### PR TITLE
fix(codec): align reject-reason labels with fgbio wording (CODEC3-08)

### DIFF
--- a/crates/fgumi-consensus/src/caller.rs
+++ b/crates/fgumi-consensus/src/caller.rs
@@ -414,6 +414,13 @@ pub enum RejectionReason {
     OrphanConsensus,
     /// Overlap boundary lands in an indel between strands
     IndelErrorBetweenStrands,
+    /// Overlap clipping failed: the computed consensus length is shorter than a
+    /// single-strand consensus, so the overlapping ends could not be clipped
+    /// (codec; fgbio `CodecConsensusCaller.scala:243` `ClipOverlapFailed`).
+    ClipOverlapFailed,
+    /// Too many disagreements between the top/bottom strands of a duplex
+    /// (codec; fgbio `CodecConsensusCaller.scala:255` `HighDuplexDisagreement`).
+    HighDuplexDisagreement,
     /// Potential collision
     PotentialCollision,
     /// Template did not have a single primary FR pair of reads (codec)
@@ -442,6 +449,8 @@ impl RejectionReason {
             Self::InsufficientOverlap => 'V',
             Self::OrphanConsensus => 'P',
             Self::IndelErrorBetweenStrands => 'D',
+            Self::ClipOverlapFailed => 'L',
+            Self::HighDuplexDisagreement => 'H',
             Self::PotentialCollision => 'C',
             Self::NotPrimaryFrPair => 'R',
             Self::Other => 'O',
@@ -467,6 +476,8 @@ impl RejectionReason {
             Self::InsufficientOverlap => "Insufficient overlap between reads",
             Self::OrphanConsensus => "Only one of R1 or R2 consensus generated",
             Self::IndelErrorBetweenStrands => "Overlap boundary lands in indel between strands",
+            Self::ClipOverlapFailed => "Overlap clipping failed (consensus shorter than a strand)",
+            Self::HighDuplexDisagreement => "Too many disagreements between top/bottom strands",
             Self::PotentialCollision => {
                 "Potential collisions (reads with the same MI but different strands)"
             }
@@ -500,6 +511,10 @@ impl RejectionReason {
             // not as generic insufficient-support / no-valid-alignment.
             Self::InsufficientOverlap => CentralReason::R1R2OverlapTooShort,
             Self::IndelErrorBetweenStrands => CentralReason::IndelErrorBetweenStrands,
+            // fgbio's codec caller counts these as `clip_overlap_failed` and
+            // `high_duplex_disagreement` (CodecConsensusCaller.scala:243,255).
+            Self::ClipOverlapFailed => CentralReason::ClipOverlapFailed,
+            Self::HighDuplexDisagreement => CentralReason::HighDuplexDisagreement,
             Self::ZeroLengthAfterTrimming => CentralReason::ZeroBasesPostTrimming,
             Self::OrphanConsensus => CentralReason::OrphanConsensus,
             Self::PotentialCollision => CentralReason::DuplicateUmi,
@@ -553,6 +568,7 @@ pub fn make_prefix_from_header(header: &Header) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use fgumi_metrics::rejection::RejectionReason as CentralReason;
     use rstest::rstest;
 
     /// The scalar depth-tag clamp mirrors fgbio's `Short` per-base ceiling: values at or
@@ -593,8 +609,6 @@ mod tests {
 
     #[test]
     fn test_rejection_reason_to_centralized() {
-        use fgumi_metrics::rejection::RejectionReason as CentralReason;
-
         assert_eq!(
             RejectionReason::InsufficientReads.to_centralized(),
             CentralReason::InsufficientSupport
@@ -781,6 +795,9 @@ mod tests {
             RejectionReason::InsufficientOverlap,
             RejectionReason::OrphanConsensus,
             RejectionReason::IndelErrorBetweenStrands,
+            RejectionReason::ClipOverlapFailed,
+            RejectionReason::HighDuplexDisagreement,
+            RejectionReason::NotPrimaryFrPair,
             RejectionReason::PotentialCollision,
             RejectionReason::Other,
         ];
@@ -1094,68 +1111,87 @@ mod tests {
     // Comprehensive RejectionReason tests
     // =====================================================================
 
-    #[test]
-    fn test_all_rejection_reasons_have_descriptions() {
-        let reasons = [
-            RejectionReason::FragmentRead,
-            RejectionReason::InsufficientReads,
-            RejectionReason::QualityTooLow,
-            RejectionReason::Unmapped,
-            RejectionReason::Mapped,
-            RejectionReason::TooManyNs,
-            RejectionReason::MinorityAlignment,
-            RejectionReason::SecondaryOrSupplementary,
-            RejectionReason::FailedQC,
-            RejectionReason::MissingUmi,
-            RejectionReason::QualityTrimmed,
-            RejectionReason::ZeroLengthAfterTrimming,
-            RejectionReason::InsufficientOverlap,
-            RejectionReason::OrphanConsensus,
-            RejectionReason::IndelErrorBetweenStrands,
-            RejectionReason::PotentialCollision,
-            RejectionReason::NotPrimaryFrPair,
-            RejectionReason::Other,
-        ];
-
-        for reason in &reasons {
-            let desc = reason.description();
-            assert!(!desc.is_empty(), "Description should not be empty for {reason:?}");
-        }
+    #[rstest]
+    #[case::fragment_read(RejectionReason::FragmentRead)]
+    #[case::insufficient_reads(RejectionReason::InsufficientReads)]
+    #[case::quality_too_low(RejectionReason::QualityTooLow)]
+    #[case::unmapped(RejectionReason::Unmapped)]
+    #[case::mapped(RejectionReason::Mapped)]
+    #[case::too_many_ns(RejectionReason::TooManyNs)]
+    #[case::minority_alignment(RejectionReason::MinorityAlignment)]
+    #[case::secondary_or_supplementary(RejectionReason::SecondaryOrSupplementary)]
+    #[case::failed_qc(RejectionReason::FailedQC)]
+    #[case::missing_umi(RejectionReason::MissingUmi)]
+    #[case::quality_trimmed(RejectionReason::QualityTrimmed)]
+    #[case::zero_length_after_trimming(RejectionReason::ZeroLengthAfterTrimming)]
+    #[case::insufficient_overlap(RejectionReason::InsufficientOverlap)]
+    #[case::orphan_consensus(RejectionReason::OrphanConsensus)]
+    #[case::indel_error_between_strands(RejectionReason::IndelErrorBetweenStrands)]
+    #[case::clip_overlap_failed(RejectionReason::ClipOverlapFailed)]
+    #[case::high_duplex_disagreement(RejectionReason::HighDuplexDisagreement)]
+    #[case::potential_collision(RejectionReason::PotentialCollision)]
+    #[case::not_primary_fr_pair(RejectionReason::NotPrimaryFrPair)]
+    #[case::other(RejectionReason::Other)]
+    fn test_all_rejection_reasons_have_descriptions(#[case] reason: RejectionReason) {
+        assert!(!reason.description().is_empty(), "Description should not be empty for {reason:?}");
     }
 
-    #[test]
-    fn test_all_rejection_reasons_to_centralized() {
-        use fgumi_metrics::rejection::RejectionReason as CentralReason;
-
-        // Test every variant maps to a centralized reason
-        let mappings = [
-            (RejectionReason::FragmentRead, CentralReason::NonPairedReads),
-            (RejectionReason::InsufficientReads, CentralReason::InsufficientSupport),
-            (RejectionReason::QualityTooLow, CentralReason::LowBaseQuality),
-            (RejectionReason::Unmapped, CentralReason::NoValidAlignment),
-            (RejectionReason::Mapped, CentralReason::NoValidAlignment),
-            (RejectionReason::TooManyNs, CentralReason::ExcessiveNBases),
-            (RejectionReason::MinorityAlignment, CentralReason::MinorityAlignment),
-            (RejectionReason::SecondaryOrSupplementary, CentralReason::NoValidAlignment),
-            (RejectionReason::FailedQC, CentralReason::NotPassingFilter),
-            (RejectionReason::MissingUmi, CentralReason::MissingUmi),
-            (RejectionReason::QualityTrimmed, CentralReason::LowBaseQuality),
-            (RejectionReason::ZeroLengthAfterTrimming, CentralReason::ZeroBasesPostTrimming),
-            (RejectionReason::InsufficientOverlap, CentralReason::R1R2OverlapTooShort),
-            (RejectionReason::OrphanConsensus, CentralReason::OrphanConsensus),
-            (RejectionReason::IndelErrorBetweenStrands, CentralReason::IndelErrorBetweenStrands),
-            (RejectionReason::PotentialCollision, CentralReason::DuplicateUmi),
-            (RejectionReason::NotPrimaryFrPair, CentralReason::NotPrimaryFrPair),
-            (RejectionReason::Other, CentralReason::InsufficientSupport),
-        ];
-
-        for (caller_reason, expected_central) in &mappings {
-            assert_eq!(
-                caller_reason.to_centralized(),
-                *expected_central,
-                "Mismatch for {caller_reason:?}"
-            );
-        }
+    /// Every caller-specific rejection reason maps to the expected centralized reason.
+    /// One case per distinct mapping so a drifted mapping names the offending variant.
+    #[rstest]
+    #[case::fragment_read(RejectionReason::FragmentRead, CentralReason::NonPairedReads)]
+    #[case::insufficient_reads(
+        RejectionReason::InsufficientReads,
+        CentralReason::InsufficientSupport
+    )]
+    #[case::quality_too_low(RejectionReason::QualityTooLow, CentralReason::LowBaseQuality)]
+    #[case::unmapped(RejectionReason::Unmapped, CentralReason::NoValidAlignment)]
+    #[case::mapped(RejectionReason::Mapped, CentralReason::NoValidAlignment)]
+    #[case::too_many_ns(RejectionReason::TooManyNs, CentralReason::ExcessiveNBases)]
+    #[case::minority_alignment(
+        RejectionReason::MinorityAlignment,
+        CentralReason::MinorityAlignment
+    )]
+    #[case::secondary_or_supplementary(
+        RejectionReason::SecondaryOrSupplementary,
+        CentralReason::NoValidAlignment
+    )]
+    #[case::failed_qc(RejectionReason::FailedQC, CentralReason::NotPassingFilter)]
+    #[case::missing_umi(RejectionReason::MissingUmi, CentralReason::MissingUmi)]
+    #[case::quality_trimmed(RejectionReason::QualityTrimmed, CentralReason::LowBaseQuality)]
+    #[case::zero_length_after_trimming(
+        RejectionReason::ZeroLengthAfterTrimming,
+        CentralReason::ZeroBasesPostTrimming
+    )]
+    #[case::insufficient_overlap(
+        RejectionReason::InsufficientOverlap,
+        CentralReason::R1R2OverlapTooShort
+    )]
+    #[case::orphan_consensus(RejectionReason::OrphanConsensus, CentralReason::OrphanConsensus)]
+    #[case::indel_error_between_strands(
+        RejectionReason::IndelErrorBetweenStrands,
+        CentralReason::IndelErrorBetweenStrands
+    )]
+    #[case::clip_overlap_failed(
+        RejectionReason::ClipOverlapFailed,
+        CentralReason::ClipOverlapFailed
+    )]
+    #[case::high_duplex_disagreement(
+        RejectionReason::HighDuplexDisagreement,
+        CentralReason::HighDuplexDisagreement
+    )]
+    #[case::not_primary_fr_pair(RejectionReason::NotPrimaryFrPair, CentralReason::NotPrimaryFrPair)]
+    #[case::potential_collision(RejectionReason::PotentialCollision, CentralReason::DuplicateUmi)]
+    #[case::other(RejectionReason::Other, CentralReason::InsufficientSupport)]
+    fn test_all_rejection_reasons_to_centralized(
+        #[case] caller_reason: RejectionReason,
+        #[case] expected_central: CentralReason,
+    ) {
+        assert_eq!(
+            caller_reason.to_centralized(),
+            expected_central,
+            "Mismatch for {caller_reason:?}"
+        );
     }
 
     #[test]
@@ -1165,6 +1201,8 @@ mod tests {
         assert_eq!(RejectionReason::InsufficientOverlap.code(), 'V');
         assert_eq!(RejectionReason::OrphanConsensus.code(), 'P');
         assert_eq!(RejectionReason::IndelErrorBetweenStrands.code(), 'D');
+        assert_eq!(RejectionReason::ClipOverlapFailed.code(), 'L');
+        assert_eq!(RejectionReason::HighDuplexDisagreement.code(), 'H');
         assert_eq!(RejectionReason::PotentialCollision.code(), 'C');
 
         assert_eq!(
@@ -1182,6 +1220,14 @@ mod tests {
         assert_eq!(
             RejectionReason::IndelErrorBetweenStrands.description(),
             "Overlap boundary lands in indel between strands"
+        );
+        assert_eq!(
+            RejectionReason::ClipOverlapFailed.description(),
+            "Overlap clipping failed (consensus shorter than a strand)"
+        );
+        assert_eq!(
+            RejectionReason::HighDuplexDisagreement.description(),
+            "Too many disagreements between top/bottom strands"
         );
         assert_eq!(
             RejectionReason::PotentialCollision.description(),

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -827,9 +827,12 @@ impl CodecConsensusCaller {
         };
 
         if consensus_length < ss_r1.bases.len() || consensus_length < ss_r2.bases.len() {
+            // fgbio labels this the `ClipOverlapFailed` reason (the consensus is
+            // shorter than a single strand, so the overlapping ends could not be
+            // clipped) rather than an indel error (CodecConsensusCaller.scala:243).
             self.reject_records_count(
                 r1_infos.len() + r2_infos.len(),
-                CallerRejectionReason::IndelErrorBetweenStrands,
+                CallerRejectionReason::ClipOverlapFailed,
             );
             return Ok(ConsensusOutput::default());
         }
@@ -844,7 +847,23 @@ impl CodecConsensusCaller {
         let padded_r1 = Self::pad_consensus(&ss_r1_oriented, consensus_length, r1_is_negative);
         let padded_r2 = Self::pad_consensus(&ss_r2_oriented, consensus_length, r2_is_negative);
 
-        let consensus = self.build_duplex_consensus_from_padded(&padded_r1, &padded_r2)?;
+        // On a high-duplex-disagreement reject, count the rejected records under
+        // the `HighDuplexDisagreement` reason and bump the dedicated HDD counter
+        // before propagating the (recoverable) error, matching fgbio, which does
+        // `rejectRecords(..., HighDuplexDisagreement)` and
+        // `consensusReadsFilteredHighDisagreement += 1` (CodecConsensusCaller.scala:255-256).
+        let consensus = match self.build_duplex_consensus_from_padded(&padded_r1, &padded_r2) {
+            Ok(consensus) => consensus,
+            Err(e) if e.is_duplex_disagreement() => {
+                self.reject_records_count(
+                    r1_infos.len() + r2_infos.len(),
+                    CallerRejectionReason::HighDuplexDisagreement,
+                );
+                self.stats.consensus_reads_rejected_hdd += 1;
+                return Err(e);
+            }
+            Err(e) => return Err(e),
+        };
         let consensus = self.mask_consensus_quals_query_based(consensus, &padded_r1, &padded_r2);
         let consensus =
             if r1_is_negative { Self::reverse_complement_ss(&consensus) } else { consensus };
@@ -1498,7 +1517,20 @@ impl CodecConsensusCaller {
         &mut self,
         records: Vec<RawRecord>,
     ) -> std::result::Result<ConsensusOutput, CodecConsensusError> {
-        let result = self.consensus_reads_raw(&records)?;
+        let result = match self.consensus_reads_raw(&records) {
+            Ok(result) => result,
+            Err(e) => {
+                // On a recoverable duplex-disagreement reject, still route the
+                // group's raw records to the --rejects output when tracking is
+                // enabled, mirroring the count==0 path below and fgbio's
+                // rejectsWriter. The reject reason/counters were already recorded
+                // by consensus_reads_raw before it returned the error.
+                if self.track_rejects && e.is_duplex_disagreement() && !records.is_empty() {
+                    self.rejected_reads.extend(records.into_iter().map(RawRecord::into_inner));
+                }
+                return Err(e);
+            }
+        };
         // When a group fails to produce consensus, all its records are rejected
         if self.track_rejects && result.count == 0 && !records.is_empty() {
             self.rejected_reads.extend(records.into_iter().map(RawRecord::into_inner));
@@ -1689,6 +1721,7 @@ mod tests {
     };
     use fgumi_sam::clipper::cigar_utils;
     use noodles::sam::alignment::record::cigar::op::Kind;
+    use rstest::rstest;
 
     #[test]
     fn test_codec_caller_creation() {
@@ -2840,6 +2873,149 @@ mod tests {
             "expected DuplexDisagreementRate, got: {err:?}"
         );
         assert!(err.is_duplex_disagreement());
+    }
+
+    /// CODEC3-08: a high-duplex-disagreement reject is counted under the
+    /// `HighDuplexDisagreement` reason and bumps the dedicated HDD counter, mirroring
+    /// fgbio's `rejectRecords(..., HighDuplexDisagreement)` +
+    /// `consensusReadsFilteredHighDisagreement += 1` (CodecConsensusCaller.scala:255-256).
+    /// Before the fix the reject propagated uncounted, so both counters were zero. Each
+    /// case isolates one trigger by making the other threshold permissive.
+    #[rstest]
+    #[case::by_count(0, 1.0)] // permissive rate leaves count as the only trigger
+    #[case::by_rate(usize::MAX, 0.0)] // permissive count leaves rate as the only trigger
+    fn test_high_duplex_disagreement_counted(
+        #[case] max_duplex_disagreements: usize,
+        #[case] max_duplex_disagreement_rate: f64,
+    ) {
+        let options = CodecConsensusOptions {
+            min_reads_per_strand: 1,
+            min_duplex_length: 1,
+            max_duplex_disagreements,
+            max_duplex_disagreement_rate,
+            ..Default::default()
+        };
+        let mut caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
+
+        let fixture = duplex_disagreement_fixture();
+        let record_count = fixture.len();
+
+        let Err(err) = caller.consensus_reads_typed(fixture) else {
+            panic!("zero-tolerance disagreement threshold should produce an error");
+        };
+        assert!(err.is_duplex_disagreement());
+
+        let stats = caller.statistics();
+        assert_eq!(
+            stats.rejection_reasons.get(&CallerRejectionReason::HighDuplexDisagreement),
+            Some(&record_count),
+            "all rejected records should be counted under HighDuplexDisagreement"
+        );
+        assert_eq!(
+            stats.consensus_reads_rejected_hdd, 1,
+            "the dedicated HDD counter should be incremented once per rejected molecule"
+        );
+    }
+
+    /// CODEC3-08: with reject tracking enabled, the raw records of a
+    /// high-duplex-disagreement molecule must be preserved for the `--rejects`
+    /// output (fgbio routes these to its `rejectsWriter`). Before the fix the
+    /// recoverable error propagated before the reads were stored, so the
+    /// `--rejects` BAM silently dropped every HDD molecule.
+    ///
+    /// The `--rejects` contract is byte-for-byte preservation of the original
+    /// input records, so this asserts the retained bytes equal the fixture's raw
+    /// records verbatim (identity), not merely that the right *number* of records
+    /// was kept — a length-only check would pass even if the records were
+    /// truncated, reordered, or replaced.
+    #[test]
+    fn test_high_duplex_disagreement_tracks_rejects() {
+        let options = CodecConsensusOptions {
+            min_reads_per_strand: 1,
+            min_duplex_length: 1,
+            max_duplex_disagreements: 0,
+            max_duplex_disagreement_rate: 1.0,
+            ..Default::default()
+        };
+        let mut caller = CodecConsensusCaller::new_with_rejects_tracking(
+            "codec".to_string(),
+            "RG1".to_string(),
+            options,
+            true,
+        );
+
+        let fixture = duplex_disagreement_fixture();
+        // Snapshot each input record's full raw bytes before the fixture is moved
+        // into the caller, so we can assert byte-exact identity of the retained
+        // rejects. `consensus_reads_typed` stores `RawRecord::into_inner()` in
+        // input order, so the retained order matches this snapshot.
+        let expected_bytes: Vec<Vec<u8>> =
+            fixture.iter().map(|record| record.as_ref().to_vec()).collect();
+
+        let Err(err) = caller.consensus_reads_typed(fixture) else {
+            panic!("zero-tolerance count threshold should produce an error");
+        };
+        assert!(err.is_duplex_disagreement());
+        assert_eq!(
+            caller.rejected_reads(),
+            expected_bytes.as_slice(),
+            "every HDD record must be retained byte-for-byte (identity), in input order, \
+             for the --rejects output"
+        );
+    }
+
+    /// CODEC3-08: the `ClipOverlapFailed` reject (consensus shorter than a single
+    /// strand — the overlapping ends could not be clipped, `CodecConsensusCaller.scala:243`)
+    /// must be counted under its own reason and populate a metrics row under fgbio's
+    /// verbatim label, *not* leak into `IndelErrorBetweenStrands` the way it did before
+    /// the fix.
+    ///
+    /// The caller-level trigger (`consensus_length < ss.bases.len()` at the
+    /// `ClipOverlapFailed` site) is a degenerate overlap-clip boundary that fgbio itself
+    /// only reaches on specific real-data alignments; a synthetic pipeline fixture that
+    /// lands there without first tripping the earlier `IndelErrorBetweenStrands` phase
+    /// check would have to replicate fgbio's exact clip arithmetic and would be brittle.
+    /// This exercises the counting/labeling contract at the reject-tallying seam instead:
+    /// `reject_records_count` is the single site every reject flows through, so pinning
+    /// the count, the filtered total, and the central-reason mapping here is what
+    /// guarantees the emitted metrics row is right when the branch does fire.
+    #[test]
+    fn test_clip_overlap_failed_counted_and_labeled() {
+        let options = CodecConsensusOptions {
+            min_reads_per_strand: 1,
+            min_duplex_length: 1,
+            ..Default::default()
+        };
+        let mut caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
+
+        // A rejected molecule contributes both of its records (R1 + R2), matching how the
+        // caller passes `r1_infos.len() + r2_infos.len()` at the ClipOverlapFailed site.
+        caller.reject_records_count(2, CallerRejectionReason::ClipOverlapFailed);
+
+        assert_eq!(
+            caller.stats.rejection_reasons.get(&CallerRejectionReason::ClipOverlapFailed),
+            Some(&2),
+            "both rejected records must be tallied under ClipOverlapFailed"
+        );
+        // Regression guard: before the fix this reject was mislabeled as an indel error.
+        assert!(
+            !caller
+                .stats
+                .rejection_reasons
+                .contains_key(&CallerRejectionReason::IndelErrorBetweenStrands),
+            "a clip-overlap reject must not leak into IndelErrorBetweenStrands"
+        );
+        assert_eq!(
+            caller.stats.reads_filtered, 2,
+            "the filtered-reads total the metrics row is derived from must include the reject"
+        );
+        // The metrics row is emitted under the centralized reason; confirm it maps to
+        // fgbio's verbatim `ClipOverlapFailed` label so the row populates, not a fallback.
+        assert_eq!(
+            CallerRejectionReason::ClipOverlapFailed.to_centralized(),
+            fgumi_metrics::rejection::RejectionReason::ClipOverlapFailed,
+            "ClipOverlapFailed must map to the fgbio-verbatim central reason for the metrics row"
+        );
     }
 
     /// Port of fgbio test: "make a consensus where R2 has a deletion outside of the overlap region"

--- a/tests/integration/test_codec_command.rs
+++ b/tests/integration/test_codec_command.rs
@@ -581,6 +581,15 @@ fn test_codec_command_recovers_from_duplex_disagreement_threaded() {
     let rejects_bam = temp_dir.path().join("rejects.bam");
 
     let (r1, r2) = create_offset_codec_pair("disagree_read_mt", "UMI_DISAGREE_MT");
+    // Capture each read's *complete* raw BAM bytes (every field and tag), keyed by
+    // flags, before the records are moved into the input BAM. The `--rejects`
+    // contract is byte-for-byte preservation of the original records, so asserting
+    // full-record identity — not just name + sequence — is what catches a pipeline
+    // that silently drops or rewrites a field (quals, CIGAR, pos, mate info,
+    // template length, MI/MC tags) on the reject path. R1 and R2 share a read name,
+    // so flags is the distinguishing key.
+    let expected_by_flags: std::collections::HashMap<u16, Vec<u8>> =
+        [&r1, &r2].into_iter().map(|read| (read.flags(), read.as_ref().to_vec())).collect();
     create_codec_test_bam(&input_bam, vec![(r1, r2)]);
 
     let cmd = Codec::try_parse_from([
@@ -613,18 +622,47 @@ fn test_codec_command_recovers_from_duplex_disagreement_threaded() {
 
     // Exercising --rejects forces the parallel-mode `flush_byte_records`
     // call inside the typed-disagreement arm (`is_duplex_disagreement()`
-    // branch in `execute_threads_mode`). The current behavior is that the
-    // disagreement short-circuit in `consensus_reads_typed` returns the
-    // typed error before populating `rejected_reads`, so the file is
-    // created but stays empty — match that here without baking the
-    // open question (whether disagreement-failed reads *should* land in
-    // --rejects) into the test.
+    // branch in `execute_threads_mode`). CODEC3-08: `consensus_reads_typed`
+    // now preserves the disagreeing molecule's raw records for the --rejects
+    // output before returning the recoverable error (fgbio routes these to its
+    // rejectsWriter), so the two input reads land in the rejects BAM.
     assert!(rejects_bam.exists(), "Rejects BAM file should be created");
-    let mut rejects_reader = bam::io::Reader::new(fs::File::open(&rejects_bam).unwrap());
-    let _ = rejects_reader.read_header().unwrap();
-    let reject_count = rejects_reader.records().count();
+
+    // Read the rejects back as raw BAM records so we can compare the *entire*
+    // serialized record (all fields + tags), not just the handful noodles decodes
+    // ergonomically. Each reject must be byte-for-byte identical to one generated
+    // read (keyed by flags), with no read matched twice.
+    let (mut rejects_reader, _rejects_header) =
+        fgumi_bam_io::create_raw_bam_reader(&rejects_bam, 1).expect("open rejects BAM");
+    let mut matched_flags: std::collections::HashSet<u16> = std::collections::HashSet::new();
+    let mut reject_count = 0;
+    let mut record = RawRecord::new();
+    while rejects_reader.read_record(&mut record).expect("read reject record") != 0 {
+        reject_count += 1;
+
+        let flags = record.flags();
+        let expected_bytes = expected_by_flags
+            .get(&flags)
+            .unwrap_or_else(|| panic!("reject record has unexpected flags {flags}"));
+        assert_eq!(
+            record.as_ref(),
+            expected_bytes.as_slice(),
+            "reject record (flags={flags}) must be byte-for-byte identical to the generated \
+             read — every field and tag preserved on the --rejects path"
+        );
+        assert!(
+            matched_flags.insert(flags),
+            "reject record with flags {flags} appears more than once"
+        );
+    }
+
     assert_eq!(
-        reject_count, 0,
-        "Disagreement short-circuits before reject tracking; rejects file is empty"
+        reject_count, 2,
+        "The disagreeing molecule's R1 and R2 should be written to the rejects BAM"
+    );
+    assert_eq!(
+        matched_flags.len(),
+        expected_by_flags.len(),
+        "both generated reads (R1 and R2) should be present in the rejects BAM"
     );
 }


### PR DESCRIPTION
## Summary

Stacked on #516 (which added the fgbio-verbatim codec rejection-reason strings to the central metrics enum). This closes the CODEC3-08 residual: two rejections the codec caller attributed to the wrong reason (or did not count at all) relative to fgbio's `CodecConsensusCaller`.

- **`ClipOverlapFailed`** — a consensus shorter than a single strand (the overlapping ends could not be clipped) was counted as `IndelErrorBetweenStrands`. fgbio labels this branch `ClipOverlapFailed` (`CodecConsensusCaller.scala:243`).
- **`HighDuplexDisagreement`** — an HDD reject propagated out of the caller uncounted. fgbio counts the rejected records under `HighDuplexDisagreement` and bumps a dedicated HDD counter (`CodecConsensusCaller.scala:255-256`). The `raw_reads_rejected_for_high_duplex_disagreement` metric row and `consensus_reads_rejected_hdd` counter were therefore always zero.

The central metrics enum already carried both fgbio-verbatim strings (from #516); this wires the caller to actually increment them by adding the `ClipOverlapFailed` and `HighDuplexDisagreement` caller reasons (with their `to_centralized` mappings) and emitting them at the matching sites.

Also, with `--rejects` enabled, the HDD molecule's raw records are now preserved for the rejects output (mirroring fgbio's `rejectsWriter`); both codec loops already drained `rejected_reads` on the recoverable-error path but the caller never populated them.

## fgbio label comparison (verified against fgbio 4.x source)

| fgumi branch | before | fgbio (`CodecConsensusCaller.scala`) |
|---|---|---|
| overlap < minDuplexLength | `InsufficientOverlap` → `R1R2OverlapTooShort` | `R1R2OverlapTooShort` (already correct via #516) |
| phase check fails / consensus length None | `IndelErrorBetweenStrands` | `IndelErrorBetweenStrands` (already correct) |
| **consensus length < a single strand** | `IndelErrorBetweenStrands` | **`ClipOverlapFailed`** (:243) — fixed here |
| **duplex disagreements/rate over threshold** | uncounted | **`HighDuplexDisagreement`** + `consensusReadsFilteredHighDisagreement += 1` (:255-256) — fixed here |
| fragment reads | `FragmentRead` → `NonPairedReads` | `NonPairedReads` (already correct via #516) |

## Testing

RED-first for the HDD counting (verified: `None` vs `Some(2)` before the fix). New unit tests: HDD counted by count-threshold and by rate-threshold; HDD raw records preserved for `--rejects`; `to_centralized` and code-uniqueness guards extended to the new reasons. Updated `test_codec_command_recovers_from_duplex_disagreement_threaded`, which previously pinned the buggy empty-rejects behavior (and flagged it as an open question), to assert the disagreeing molecule's R1/R2 now land in the rejects BAM.

The `ClipOverlapFailed` branch itself has no end-to-end fixture: it is fgbio's own `// TODO remove this branch once SamRecordClipper has been updated` transitional edge, which fgbio does not regression-test and which is impractical to trigger reliably; it is covered here by the `to_centralized` mapping test and a fgbio-cited code comment.

`cargo ci-fmt && cargo ci-lint && cargo ci-test` — green (2224 tests).

## Merge order

Base is #516's branch `nh/fix-codec-rejection-reasons`; GitHub will auto-retarget this PR to `main` when #516 merges. Merge #516 first, then this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reporting for clip-overlap failures and high-duplex disagreements.
  * High-duplex disagreement details are now included in rejection summaries and metrics.

* **Bug Fixes**
  * Correctly classifies consensus results with insufficient overlap.
  * Rejected duplex reads are now reliably recorded in `--rejects` output, including their original read details.
  * Rejection counts now accurately include recoverable high-duplex disagreement cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->