### PR TITLE
fix(sort): emit spec sub-sort spelling `lexicographical` in @HD SS (SORT3-10)

### DIFF
--- a/crates/fgumi-sort/src/keys.rs
+++ b/crates/fgumi-sort/src/keys.rs
@@ -209,7 +209,12 @@ impl SortOrder {
     pub fn header_ss_tag(&self) -> Option<&'static str> {
         match self {
             Self::Coordinate => None,
-            Self::Queryname(QuerynameComparator::Lexicographic) => Some("queryname:lexicographic"),
+            // The `@HD SS` sub-sort spelling for lexicographic queryname is the SAM-spec /
+            // samtools-ecosystem `lexicographical` (SORT3-10), not fgumi's CLI vocabulary
+            // `lexicographic` (this type's `Display`). The `<sort-order>:` prefix is retained.
+            Self::Queryname(QuerynameComparator::Lexicographic) => {
+                Some("queryname:lexicographical")
+            }
             Self::Queryname(QuerynameComparator::Natural) => Some("queryname:natural"),
             Self::TemplateCoordinate => Some("unsorted:template-coordinate"),
         }
@@ -1501,7 +1506,9 @@ mod tests {
         assert_eq!(SortOrder::Coordinate.header_ss_tag(), None);
         assert_eq!(
             SortOrder::Queryname(QuerynameComparator::Lexicographic).header_ss_tag(),
-            Some("queryname:lexicographic")
+            // The SAM-spec / samtools sub-sort spelling is "lexicographical" (SORT3-10);
+            // fgumi previously emitted the non-standard "lexicographic". Prefix retained.
+            Some("queryname:lexicographical")
         );
         assert_eq!(
             SortOrder::Queryname(QuerynameComparator::Natural).header_ss_tag(),

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -46,6 +46,9 @@ use crate::commands::common::{
 /// - `queryname` — lexicographic ordering (default, fast)
 /// - `queryname::lexicographic` — explicit lexicographic ordering
 /// - `queryname::natural` — natural numeric ordering (samtools-compatible)
+///
+/// The `@HD SS` sub-sort for lexicographic queryname is emitted with the
+/// SAM-spec spelling `lexicographical` (accepted back as `queryname::lexicographical`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SortOrderArg {
     /// Coordinate sort (tid → pos → strand)
@@ -64,7 +67,9 @@ impl SortOrderArg {
     /// Valid values:
     /// - `coordinate`
     /// - `queryname` (default: lexicographic)
+    /// - `queryname::lex`
     /// - `queryname::lexicographic`
+    /// - `queryname::lexicographical` (alias; fgumi emits `queryname:lexicographical` in `@HD` SS)
     /// - `queryname::natural`
     /// - `template-coordinate`
     ///
@@ -75,7 +80,10 @@ impl SortOrderArg {
     pub fn parse(s: &str) -> Result<Self, String> {
         match s {
             "coordinate" => Ok(Self::Coordinate),
-            "queryname" | "queryname::lex" | "queryname::lexicographic" => Ok(Self::Queryname),
+            "queryname"
+            | "queryname::lex"
+            | "queryname::lexicographic"
+            | "queryname::lexicographical" => Ok(Self::Queryname),
             "queryname::natural" => Ok(Self::QuerynameNatural),
             "template-coordinate" => Ok(Self::TemplateCoordinate),
             other => {
@@ -83,12 +91,14 @@ impl SortOrderArg {
                     let sub =
                         other.strip_prefix("queryname::").expect("guarded by starts_with check");
                     Err(format!(
-                        "unknown queryname sub-sort '{sub}', expected 'lex', 'lexicographic', or 'natural'"
+                        "unknown queryname sub-sort '{sub}', expected 'lex', 'lexicographic', \
+                         'lexicographical', or 'natural'"
                     ))
                 } else {
                     Err(format!(
                         "unknown sort order '{other}', expected 'coordinate', 'queryname', \
-                         'queryname::lex', 'queryname::lexicographic', 'queryname::natural', \
+                         'queryname::lex', 'queryname::lexicographic', \
+                         'queryname::lexicographical', 'queryname::natural', \
                          or 'template-coordinate'"
                     ))
                 }
@@ -129,6 +139,7 @@ SORT ORDERS:
   queryname                Lexicographic read name sort (fast, default sub-sort).
   queryname::lex           Short alias for lexicographic ordering (same as above).
   queryname::lexicographic Explicit lexicographic ordering (same as above).
+  queryname::lexicographical Alias for the above; fgumi emits `queryname:lexicographical` in @HD SS.
   queryname::natural       Natural numeric ordering (samtools-compatible).
                           Use for `fgumi zipper`, template-level operations.
 
@@ -200,6 +211,7 @@ pub struct Sort {
     /// Queryname sort supports sub-sort specifiers:
     ///   `queryname`                  Lexicographic byte ordering (default, fast)
     ///   `queryname::lexicographic`   Explicit lexicographic ordering (alias: `queryname::lex`)
+    ///   `queryname::lexicographical` Alias; fgumi emits `queryname:lexicographical` in `@HD` SS
     ///   `queryname::natural`         Natural numeric ordering (samtools-compatible)
     #[arg(long = "order", default_value = "template-coordinate", value_parser = SortOrderArg::parse)]
     pub order: SortOrderArg,
@@ -976,6 +988,9 @@ mod tests {
     #[case("coordinate", Ok(SortOrderArg::Coordinate))]
     #[case("queryname", Ok(SortOrderArg::Queryname))]
     #[case("queryname::lexicographic", Ok(SortOrderArg::Queryname))]
+    // SORT3-10: the spec-spelling alias is accepted so a user can pass back the
+    // `@HD SS:queryname:lexicographical` value fgumi now emits.
+    #[case("queryname::lexicographical", Ok(SortOrderArg::Queryname))]
     #[case("queryname::lex", Ok(SortOrderArg::Queryname))]
     #[case("queryname::natural", Ok(SortOrderArg::QuerynameNatural))]
     #[case("template-coordinate", Ok(SortOrderArg::TemplateCoordinate))]
@@ -1004,7 +1019,9 @@ mod tests {
     fn test_queryname_lex_header_has_subsort() {
         let order = SortOrder::from(SortOrderArg::Queryname);
         assert_eq!(order.header_so_tag(), "queryname");
-        assert_eq!(order.header_ss_tag(), Some("queryname:lexicographic"));
+        // SORT3-10: the emitted SS sub-sort value uses the spec spelling "lexicographical"
+        // (with the `<sort-order>:` prefix retained).
+        assert_eq!(order.header_ss_tag(), Some("queryname:lexicographical"));
     }
 
     #[test]


### PR DESCRIPTION
## What / why

The `@HD SS` sub-sort value for a lexicographic queryname sort was written as `lexicographic`, which is **not** the SAM-spec / samtools-ecosystem spelling. htsjdk/Picard emit — and SS parsers recognize — `lexicographical`. fgumi's value was non-standard.

The `SS` tag is **write-only**: fgumi determines sort order from `SO`/`GO` and the CLI `--order`, and never parses an incoming `SS`. So this is a pure spelling correction with **no functional round-trip effect** (verified: `header_ss_tag()`'s only caller is the header writer in `lib.rs`; nothing reads the value back).

- `header_ss_tag()` now returns `lexicographical`.
- To avoid a UX papercut — a user seeing `SS:queryname:lexicographical` in output and passing it back — `--order queryname::lexicographical` is now accepted as an alias for `queryname::lexicographic` (help + error text updated). The CLI vocabulary and the type's `Display` keep the shorter `lexicographic`.

## Verification (§0)

- Real repro: `fgumi sort --order queryname` now emits `@HD ... SS:lexicographical`; `--order queryname::lexicographical` is accepted.
- RED-first: the `header_ss_tag()` test flipped to expect `lexicographical` failed against the old value, passes after.
- `cargo ci-fmt && ci-lint && ci-test` green (root 2268); **also ran the `fgumi-sort` crate explicitly** (451 pass) since `ci-test` covers only the root package.
- Both reviewers: 0 findings.

## Composes with SORT3-01

On current main the tag is emitted **without** the `<SO>:` prefix (`SS:lexicographical`). The prefix is a separate fix (SORT3-01, R2-HDR-01 — #514/#531, in `lib.rs`, no file overlap with this change in `keys.rs`). After both merge, the header reads the fully-conformant `SS:queryname:lexicographical`.

Main-based.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `queryname::lexicographical` sort-order alias.
  * Updated command-line help and validation messages to recognize the new alias.

* **Bug Fixes**
  * Corrected emitted SAM `@HD SS` sub-sort spelling to use the SAM-standard `queryname:lexicographical` (while keeping the `queryname:` prefix).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->