### PR TITLE
perf(compare): verify sort order in a single streaming pass

### DIFF
--- a/src/lib/commands/compare/engines/sort_verify.rs
+++ b/src/lib/commands/compare/engines/sort_verify.rs
@@ -16,15 +16,25 @@
 //! 1. Detects the shared sort order from both inputs' `@HD` `SO`/`GO`/`SS` header tags
 //!    (see [`detect_sort_order`]) and errors if the two inputs disagree or declare an
 //!    order this engine cannot verify.
-//! 2. Verifies each file independently is non-decreasing under that order's key, via
-//!    [`fgumi_sort::verify_sort_order`] — this catches a genuine mis-sort in either file.
-//! 3. Walks both files in file order, grouping each into maximal runs of records that
-//!    share the same *core* sort key (the key without the name/hash tie-break lane — see
+//! 2. Reads each file exactly **once**, in file order, layering an [`OrderChecked`] stream
+//!    adapter over that single keyed-record read. The adapter watches every key flow past
+//!    and folds monotonicity into a per-file [`OrderTracker`] (violation count + first
+//!    violation) as a side effect — this catches a genuine mis-sort in either file, and is
+//!    the exact fold [`fgumi_sort::verify_sort_order`] performs in its own standalone pass.
+//! 3. Over that same single pass, groups each file into maximal runs of records that share
+//!    the same *core* sort key (the key without the name/hash tie-break lane — see
 //!    [`fgumi_sort::TemplateKey::core_cmp`] for template-coordinate; coordinate has no
 //!    tie-break lane beyond `(tid, pos, reverse)` in the first place), and asserts the
 //!    multiset of full records is equal between the two files' corresponding runs. This
 //!    tolerates intra-run reordering while still catching a missing/extra record or any
 //!    content difference.
+//!
+//! Reading each file once (rather than an order pass per file *plus* a reopened comparison
+//! pass — four full BAM traversals) roughly halves the BAM I/O + BGZF decode this
+//! benchmarking command spends on WGS-scale inputs. Because the comparison — including its
+//! desync "drain" path — pulls records *through* the [`OrderChecked`] adapter, each file's
+//! order is verified **completely**, even past a desync point, so the per-file violation
+//! counts are identical to the old two-pass computation for every input.
 //!
 //! Both checks run independently and are `AND`ed together in
 //! [`SortVerifyOutcome::is_match`]: an order violation in either file, or any run
@@ -37,11 +47,11 @@ use std::path::Path;
 use anyhow::{Context, Result, anyhow, bail};
 
 use fgumi_bam_io::create_raw_bam_reader;
-use fgumi_raw_bam::RawRecord;
+use fgumi_raw_bam::{RawRecord, RawRecordView};
 use fgumi_sort::{
     LibraryLookup, QuerynameComparator, RawBamRecordReader, RawQuerynameKey, RawQuerynameLexKey,
-    RawSortKey, SortContext, SortOrder, TemplateKey, VerifySummary, cb_hasher,
-    extract_coordinate_key_inline, extract_template_key_inline, verify_sort_order,
+    RawSortKey, SortContext, SortOrder, TemplateKey, cb_hasher, extract_coordinate_key_inline,
+    extract_template_key_inline, verify_sort_order,
 };
 use noodles::sam::Header;
 
@@ -61,8 +71,8 @@ pub struct SortVerifyOutcome {
     pub bam1_count: u64,
     /// Total number of records read from `bam2`.
     pub bam2_count: u64,
-    /// Number of sort-order violations found in `bam1` alone
-    /// (via [`fgumi_sort::verify_sort_order`]).
+    /// Number of sort-order violations found in `bam1` alone (accumulated by the per-file
+    /// order tracker, the inline fold of [`fgumi_sort::verify_sort_order`]).
     pub bam1_violations: u64,
     /// The first violation in `bam1`, if any: `(record_number, read_name)`.
     pub bam1_first_violation: Option<(u64, String)>,
@@ -223,33 +233,134 @@ fn open_raw_reader(path: &Path) -> Result<RawBamRecordReader<File>> {
 /// currently being assembled (the lookahead needed to detect a run boundary).
 type Keyed<K> = (K, RawRecord);
 
-/// Read one record and its key from `reader`, or `None` at EOF.
-fn read_keyed<K>(
-    reader: &mut RawBamRecordReader<File>,
-    extract_key: &impl Fn(&[u8]) -> K,
-) -> Result<Option<Keyed<K>>> {
-    match reader.next() {
-        Some(rec) => {
-            let rec = rec?;
-            let key = extract_key(rec.as_ref());
-            Ok(Some((key, rec)))
+/// The per-file monotonic sort-order accumulator, mirroring the fold in
+/// [`fgumi_sort::verify_sort_order`].
+///
+/// An [`OrderChecked`] adapter feeds every record's key through [`OrderTracker::observe`]
+/// exactly once, in file order, so the accumulated violation count and first violation are
+/// **complete** — even when the two compared streams desynchronize and the tail of one file
+/// is drained rather than compared. `is_violation` is borrowed (both files' trackers share
+/// one closure); the extracted key is cloned into `prev_key` to keep the yielded
+/// `(key, record)` intact for the run comparison downstream.
+struct OrderTracker<'a, K, IsViolation>
+where
+    IsViolation: Fn(&K, &K) -> bool,
+{
+    is_violation: &'a IsViolation,
+    prev_key: Option<K>,
+    total: u64,
+    violations: u64,
+    first_violation: Option<(u64, String)>,
+}
+
+impl<'a, K, IsViolation> OrderTracker<'a, K, IsViolation>
+where
+    K: Clone,
+    IsViolation: Fn(&K, &K) -> bool,
+{
+    fn new(is_violation: &'a IsViolation) -> Self {
+        Self { is_violation, prev_key: None, total: 0, violations: 0, first_violation: None }
+    }
+
+    /// Observe one record in file order: bump the running total and, if its key violates
+    /// the sort invariant relative to the previous key, bump the violation count and (once)
+    /// capture the first violation's `(record_number, read_name)`. This is exactly the
+    /// per-record body of [`fgumi_sort::verify_sort_order`], including the 1-based record
+    /// numbering and the `from_utf8_lossy` read-name extraction.
+    fn observe(&mut self, key: &K, record_bytes: &[u8]) {
+        self.total += 1;
+        if let Some(prev) = &self.prev_key
+            && (self.is_violation)(key, prev)
+        {
+            self.violations += 1;
+            if self.first_violation.is_none() {
+                let name = String::from_utf8_lossy(RawRecordView::new(record_bytes).read_name())
+                    .to_string();
+                self.first_violation = Some((self.total, name));
+            }
         }
-        None => Ok(None),
+        self.prev_key = Some(key.clone());
     }
 }
 
-/// Pull the next maximal run of records sharing the same core sort key from `reader`,
+/// A keyed-record stream that order-checks every record it yields, as a side effect.
+///
+/// Wraps the single keyed-record read the run comparison already consumes, threading each
+/// record's key through an [`OrderTracker`] before handing the `(key, record)` downstream
+/// unchanged. Because the comparison — including its desync [`OrderChecked::drain`] path —
+/// pulls records *through* this adapter, each file's order is verified completely even past
+/// a desync (the semantic invariant the old end-to-end `verify_sort_order` pass guaranteed),
+/// while the file is read only once.
+struct OrderChecked<'a, K, ExtractKey, IsViolation>
+where
+    ExtractKey: Fn(&[u8]) -> K,
+    IsViolation: Fn(&K, &K) -> bool,
+{
+    reader: RawBamRecordReader<File>,
+    extract_key: &'a ExtractKey,
+    tracker: OrderTracker<'a, K, IsViolation>,
+}
+
+impl<'a, K, ExtractKey, IsViolation> OrderChecked<'a, K, ExtractKey, IsViolation>
+where
+    K: Clone,
+    ExtractKey: Fn(&[u8]) -> K,
+    IsViolation: Fn(&K, &K) -> bool,
+{
+    fn new(
+        reader: RawBamRecordReader<File>,
+        extract_key: &'a ExtractKey,
+        is_violation: &'a IsViolation,
+    ) -> Self {
+        Self { reader, extract_key, tracker: OrderTracker::new(is_violation) }
+    }
+
+    /// Read the next record, extract and order-check its key, and yield `(key, record)`;
+    /// `None` at EOF.
+    fn next_keyed(&mut self) -> Result<Option<Keyed<K>>> {
+        match self.reader.next() {
+            Some(rec) => {
+                let rec = rec?;
+                let key = (self.extract_key)(rec.as_ref());
+                self.tracker.observe(&key, rec.as_ref());
+                Ok(Some((key, rec)))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Drain the pending lookahead plus every remaining record *through* the order tracker.
+    /// Used once the two streams have desynchronized so both the per-file violation counts
+    /// and the tracker's record total (the authoritative count in [`SortVerifyOutcome`])
+    /// still reflect each file end to end.
+    ///
+    /// The lookahead record was already read — and so already order-checked and counted —
+    /// when [`Self::next_keyed`] produced it, so it is simply dropped here; only the
+    /// still-unread tail is pulled through the tracker.
+    fn drain(&mut self, next: &mut Option<Keyed<K>>) -> Result<()> {
+        *next = None;
+        while self.next_keyed()?.is_some() {}
+        Ok(())
+    }
+}
+
+/// Pull the next maximal run of records sharing the same core sort key from `stream`,
 /// using `next` as one-record lookahead state (carried across calls). Returns `None`
-/// once the stream (and lookahead) are exhausted.
-fn pull_run<K>(
-    reader: &mut RawBamRecordReader<File>,
+/// once the stream (and lookahead) are exhausted. Every record read here flows through
+/// `stream`'s order tracker exactly once.
+fn pull_run<K, ExtractKey, IsViolation>(
+    stream: &mut OrderChecked<'_, K, ExtractKey, IsViolation>,
     next: &mut Option<Keyed<K>>,
-    extract_key: &impl Fn(&[u8]) -> K,
     same_core: &impl Fn(&K, &K) -> bool,
-) -> Result<Option<(K, Vec<RawRecord>)>> {
+) -> Result<Option<(K, Vec<RawRecord>)>>
+where
+    K: Clone,
+    ExtractKey: Fn(&[u8]) -> K,
+    IsViolation: Fn(&K, &K) -> bool,
+{
     let Some((key, rec)) = next.take() else { return Ok(None) };
     let mut run = vec![rec];
-    while let Some((k, r)) = read_keyed(reader, extract_key)? {
+    while let Some((k, r)) = stream.next_keyed()? {
         if same_core(&k, &key) {
             run.push(r);
         } else {
@@ -258,20 +369,6 @@ fn pull_run<K>(
         }
     }
     Ok(Some((key, run)))
-}
-
-/// Drain the remainder of `reader` (plus any pending lookahead), returning the number of
-/// records consumed. Used once the two streams have desynchronized, so the final record
-/// counts in [`SortVerifyOutcome`] still reflect the true totals.
-fn drain_remaining<K>(
-    reader: &mut RawBamRecordReader<File>,
-    next: &mut Option<Keyed<K>>,
-) -> Result<u64> {
-    let mut count = u64::from(next.take().is_some());
-    while reader.next().transpose()?.is_some() {
-        count += 1;
-    }
-    Ok(count)
 }
 
 /// Returns `true` iff `a` and `b` contain the same multiset of records under
@@ -314,40 +411,41 @@ fn multiset_equal(a: &[RawRecord], b: &[RawRecord]) -> bool {
 /// violation counts are merged in by [`run_full_verify`]).
 #[derive(Debug, Default)]
 struct RunCompareOutcome {
-    bam1_count: u64,
-    bam2_count: u64,
     run_mismatches: u64,
     presence_mismatch: bool,
     diff_details: Vec<String>,
 }
 
-/// Walk `reader1`/`reader2` in file order, grouping each into maximal equal-core-key runs
+/// Walk `stream1`/`stream2` in file order, grouping each into maximal equal-core-key runs
 /// and asserting the record multiset matches within each pair of corresponding runs (see
 /// the module docs). Never resyncs: once a run boundary or stream-length mismatch is
-/// found, no further runs are compared, though both readers are drained for accurate
-/// counts.
-fn run_compare<K>(
-    mut reader1: RawBamRecordReader<File>,
-    mut reader2: RawBamRecordReader<File>,
-    extract_key: &impl Fn(&[u8]) -> K,
+/// found, no further runs are compared, though both streams are drained *through their
+/// order trackers* for accurate counts and complete per-file order verification.
+fn run_compare<K, ExtractKey, IsViolation>(
+    stream1: &mut OrderChecked<'_, K, ExtractKey, IsViolation>,
+    stream2: &mut OrderChecked<'_, K, ExtractKey, IsViolation>,
     same_core: &impl Fn(&K, &K) -> bool,
     max_diffs: usize,
-) -> Result<RunCompareOutcome> {
+) -> Result<RunCompareOutcome>
+where
+    K: Clone,
+    ExtractKey: Fn(&[u8]) -> K,
+    IsViolation: Fn(&K, &K) -> bool,
+{
     let mut out = RunCompareOutcome::default();
 
-    let mut next1 = read_keyed(&mut reader1, extract_key)?;
-    let mut next2 = read_keyed(&mut reader2, extract_key)?;
+    let mut next1 = stream1.next_keyed()?;
+    let mut next2 = stream2.next_keyed()?;
 
     let mut run_index = 0u64;
 
     loop {
-        let run1 = pull_run(&mut reader1, &mut next1, extract_key, same_core)?;
-        let run2 = pull_run(&mut reader2, &mut next2, extract_key, same_core)?;
+        let run1 = pull_run(stream1, &mut next1, same_core)?;
+        let run2 = pull_run(stream2, &mut next2, same_core)?;
 
         match (run1, run2) {
             (None, None) => break,
             (Some((_, recs1)), None) => {
-                out.bam1_count += recs1.len() as u64;
                 out.presence_mismatch = true;
                 if out.diff_details.len() < max_diffs {
                     out.diff_details.push(format!(
@@ -356,11 +454,10 @@ fn run_compare<K>(
                         recs1.len()
                     ));
                 }
-                out.bam1_count += drain_remaining(&mut reader1, &mut next1)?;
+                stream1.drain(&mut next1)?;
                 break;
             }
             (None, Some((_, recs2))) => {
-                out.bam2_count += recs2.len() as u64;
                 out.presence_mismatch = true;
                 if out.diff_details.len() < max_diffs {
                     out.diff_details.push(format!(
@@ -369,13 +466,10 @@ fn run_compare<K>(
                         recs2.len()
                     ));
                 }
-                out.bam2_count += drain_remaining(&mut reader2, &mut next2)?;
+                stream2.drain(&mut next2)?;
                 break;
             }
             (Some((k1, recs1)), Some((k2, recs2))) => {
-                out.bam1_count += recs1.len() as u64;
-                out.bam2_count += recs2.len() as u64;
-
                 if !same_core(&k1, &k2) {
                     out.presence_mismatch = true;
                     if out.diff_details.len() < max_diffs {
@@ -384,8 +478,8 @@ fn run_compare<K>(
                              bam2 groups do not align (no resync)"
                         ));
                     }
-                    out.bam1_count += drain_remaining(&mut reader1, &mut next1)?;
-                    out.bam2_count += drain_remaining(&mut reader2, &mut next2)?;
+                    stream1.drain(&mut next1)?;
+                    stream2.drain(&mut next2)?;
                     break;
                 }
 
@@ -429,38 +523,39 @@ where
     order: SortOrder,
 }
 
-/// Run both verification passes (per-file monotonic order, then run-grouped multiset
-/// equality) for a single key type `K` and assemble the combined [`SortVerifyOutcome`].
+/// Verify both files in a single synchronized streaming pass for a single key type `K` and
+/// assemble the combined [`SortVerifyOutcome`].
+///
+/// Each file is read exactly once through an [`OrderChecked`] adapter that folds the
+/// per-file monotonic-order check ([`OrderTracker`]) into the same read the run-grouped
+/// multiset comparison consumes. The per-file violation counts and first violations are
+/// read out of the two adapters' trackers after the comparison, and are complete even when
+/// the streams desynchronize because [`run_compare`] drains the tail *through* the trackers
+/// (see [`OrderChecked::drain`]).
 fn run_full_verify<K, ExtractKey, IsViolation, SameCore>(
     ctx: VerifyContext<'_, K, ExtractKey, IsViolation, SameCore>,
 ) -> Result<SortVerifyOutcome>
 where
+    K: Clone,
     ExtractKey: Fn(&[u8]) -> K,
     IsViolation: Fn(&K, &K) -> bool,
     SameCore: Fn(&K, &K) -> bool,
 {
     let VerifyContext { bam1, bam2, extract_key, is_violation, same_core, max_diffs, order } = ctx;
 
-    let verify_one = |path: &Path| -> Result<VerifySummary> {
-        let reader = open_raw_reader(path)?;
-        verify_sort_order(reader, &extract_key, &is_violation)
-    };
+    let mut stream1 = OrderChecked::new(open_raw_reader(bam1)?, &extract_key, &is_violation);
+    let mut stream2 = OrderChecked::new(open_raw_reader(bam2)?, &extract_key, &is_violation);
 
-    let (_, bam1_violations, bam1_first_violation) = verify_one(bam1)?;
-    let (_, bam2_violations, bam2_first_violation) = verify_one(bam2)?;
-
-    let reader1 = open_raw_reader(bam1)?;
-    let reader2 = open_raw_reader(bam2)?;
-    let runs = run_compare(reader1, reader2, &extract_key, &same_core, max_diffs)?;
+    let runs = run_compare(&mut stream1, &mut stream2, &same_core, max_diffs)?;
 
     Ok(SortVerifyOutcome {
         sort_order: order,
-        bam1_count: runs.bam1_count,
-        bam2_count: runs.bam2_count,
-        bam1_violations,
-        bam1_first_violation,
-        bam2_violations,
-        bam2_first_violation,
+        bam1_count: stream1.tracker.total,
+        bam2_count: stream2.tracker.total,
+        bam1_violations: stream1.tracker.violations,
+        bam1_first_violation: stream1.tracker.first_violation,
+        bam2_violations: stream2.tracker.violations,
+        bam2_first_violation: stream2.tracker.first_violation,
         run_mismatches: runs.run_mismatches,
         presence_mismatch: runs.presence_mismatch,
         header_mismatch: false,
@@ -585,13 +680,16 @@ pub fn sort_verify_compare(
 /// blindly — see `CompareMode::Content`'s doc comment).
 ///
 /// This is a separate, fail-fast entry point from `sort_verify_compare`'s own per-file
-/// violation *counting* (`run_full_verify`'s `verify_one`, part of the fuller `--command
-/// sort` report that also needs to keep going to compare run multisets even after finding
-/// violations). Both call sites route through the same underlying comparator machinery —
-/// the per-`SortOrder` key extractors (`extract_coordinate_key_inline`, `RawQuerynameKey`/
-/// `RawQuerynameLexKey::extract`, `extract_template_key_inline`), their key comparisons
-/// (`<`, `TemplateKey::core_cmp`), and [`verify_sort_order`] itself — so no comparator logic
-/// is reimplemented here, only the per-order dispatch.
+/// violation *counting* (`run_full_verify`'s [`OrderChecked`]/[`OrderTracker`] fold, part of
+/// the fuller `--command sort` report that also needs to keep going to compare run multisets
+/// even after finding violations). Both call sites route through the same underlying
+/// comparator machinery — the per-`SortOrder` key extractors
+/// (`extract_coordinate_key_inline`, `RawQuerynameKey`/`RawQuerynameLexKey::extract`,
+/// `extract_template_key_inline`) and their key comparisons (`<`, `TemplateKey::core_cmp`) —
+/// so no comparator logic is reimplemented here, only the per-order dispatch. This entry
+/// point calls [`verify_sort_order`] directly; the compare engine inlines that same
+/// per-record fold ([`OrderTracker::observe`]) so it can verify order within its single
+/// streaming pass.
 ///
 /// # Errors
 ///

--- a/tests/integration/test_compare_bams.rs
+++ b/tests/integration/test_compare_bams.rs
@@ -13,6 +13,7 @@ use fgumi_lib::sam::SamTag;
 use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use noodles::sam::Header;
 use rstest::rstest;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
@@ -1825,6 +1826,58 @@ fn test_sort_verify_content_diff_differs(#[case] header: Header) {
     assert!(!outcome.is_match(), "a content difference must DIFFER: {outcome:?}");
 }
 
+/// The run *multiset* comparison itself: an equal-key run of size 2 that lines up on both
+/// sides (same key, same length — so neither the run-boundary/desync path nor a run-length
+/// difference can catch it), where one record's content differs. Only comparing the two runs'
+/// record multisets detects this. The expectations are hand-computed rather than derived from
+/// the engine: exactly one of the two runs differs, so `run_mismatches == 1`; the runs stay
+/// aligned so there is no desync; and every record on both sides is read.
+#[test]
+fn test_sort_verify_content_diff_within_aligned_multi_record_run_differs() {
+    let tmp = TempDir::new().unwrap();
+    let header = create_coordinate_sorted_header("chr1", 10000);
+
+    // The tied run at pos 100: readA is identical on both sides, readB's sequence differs by
+    // its last base in bam2 while keeping the same name and coordinate (so it stays in the
+    // same run and both files remain correctly coordinate-sorted).
+    let read_a = fragment_record(b"readA", 0, 100, false);
+    let read_b = fragment_record(b"readB", 0, 100, false);
+    let read_b_mutated = {
+        let mut b = SamBuilder::new();
+        b.read_name(b"readB")
+            .sequence(b"ACGTACGA") // last base differs from `fragment_record`'s ACGTACGT
+            .qualities(&[30; 8])
+            .ref_id(0)
+            .pos(99) // same 1-based pos 100 as `read_b`
+            .mapq(60);
+        b.build()
+    };
+    // A second, fully identical run at pos 200 — it must not be counted as a mismatch.
+    let read_c = fragment_record(b"readC", 0, 200, false);
+
+    let bam1 = tmp.path().join("a.bam");
+    let bam2 = tmp.path().join("b.bam");
+    write_bam(&bam1, &header, &[read_a.clone(), read_b, read_c.clone()]);
+    write_bam(&bam2, &header, &[read_a, read_b_mutated, read_c]);
+
+    let outcome =
+        sort_verify_compare(&bam1, &bam2, 100).expect("sort_verify_compare should succeed");
+
+    assert_eq!(outcome.bam1_violations, 0, "bam1 is itself correctly sorted: {outcome:?}");
+    assert_eq!(outcome.bam2_violations, 0, "bam2 is itself correctly sorted: {outcome:?}");
+    assert!(!outcome.presence_mismatch, "the runs line up on both sides: {outcome:?}");
+    assert_eq!(outcome.bam1_count, 3, "{outcome:?}");
+    assert_eq!(outcome.bam2_count, 3, "{outcome:?}");
+    assert_eq!(
+        outcome.run_mismatches, 1,
+        "exactly the pos-100 run's multiset differs; the pos-200 run matches: {outcome:?}"
+    );
+    assert!(
+        !outcome.is_match(),
+        "a content difference inside an aligned tied run must DIFFER: {outcome:?}"
+    );
+}
+
 /// R2 header-comparison gap, wired into the sort-verify engine: two files that agree on
 /// sort order (so `detect_sort_order` succeeds and never bails) and on every record's
 /// content can still DIFFER if their `@SQ` reference dictionaries disagree — a field
@@ -1852,6 +1905,60 @@ fn test_sort_verify_header_sq_length_mismatch_differs() {
     assert!(
         !outcome.is_match(),
         "a @SQ divergence must DIFFER even with matching sort order/content: {outcome:?}"
+    );
+}
+
+/// Appends an additional `@SQ` entry to `header`, yielding a reference dictionary one
+/// longer than the input's.
+fn header_with_extra_reference(mut header: Header, ref_name: &str, ref_len: usize) -> Header {
+    use bstr::BString;
+    use noodles::sam::header::record::value::{Map, map::ReferenceSequence};
+    use std::num::NonZeroUsize;
+
+    header.reference_sequences_mut().insert(
+        BString::from(ref_name),
+        Map::<ReferenceSequence>::new(
+            NonZeroUsize::new(ref_len).expect("reference length must be non-zero"),
+        ),
+    );
+    header
+}
+
+/// Companion to the `@SQ` *length* mismatch above, covering the other way a reference
+/// dictionary can diverge: a differing `@SQ` *count* (`nref`). bam2 declares a second
+/// reference that bam1 does not, while every record still lives on `chr1` and both files
+/// remain correctly coordinate-sorted — so neither the per-file order check nor the run
+/// comparison can see it, and only the header comparison catches the divergence.
+#[test]
+fn test_sort_verify_header_sq_count_mismatch_differs() {
+    let tmp = TempDir::new().unwrap();
+    let header1 = create_coordinate_sorted_header("chr1", 10000);
+    let header2 =
+        header_with_extra_reference(create_coordinate_sorted_header("chr1", 10000), "chr2", 20000);
+
+    // Pin the divergence the test is about: same first @SQ, different reference counts.
+    assert_eq!(header1.reference_sequences().len(), 1, "bam1 declares one @SQ");
+    assert_eq!(header2.reference_sequences().len(), 2, "bam2 declares two @SQ");
+
+    let records = vec![fragment_record(b"read1", 0, 100, false)];
+
+    let bam1 = tmp.path().join("a.bam");
+    let bam2 = tmp.path().join("b.bam");
+    write_bam(&bam1, &header1, &records);
+    write_bam(&bam2, &header2, &records);
+
+    let outcome =
+        sort_verify_compare(&bam1, &bam2, 100).expect("sort_verify_compare should succeed");
+
+    assert_eq!(outcome.bam1_violations, 0, "bam1 is itself correctly sorted: {outcome:?}");
+    assert_eq!(outcome.bam2_violations, 0, "bam2 is itself correctly sorted: {outcome:?}");
+    assert_eq!(outcome.bam1_count, 1, "{outcome:?}");
+    assert_eq!(outcome.bam2_count, 1, "{outcome:?}");
+    assert_eq!(outcome.run_mismatches, 0, "record content itself is identical");
+    assert!(outcome.header_mismatch, "a @SQ count mismatch must be flagged: {outcome:?}");
+    assert!(
+        !outcome.is_match(),
+        "an nref divergence must DIFFER even with matching sort order/content: {outcome:?}"
     );
 }
 
@@ -2506,4 +2613,141 @@ fn molecule_join_does_not_spill_to_disk() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
+}
+
+// ============================================================================
+// Single-pass sort-verify: complete per-file order verification past a desync
+// ============================================================================
+//
+// The single-streaming-pass engine reads each file once, folding the per-file monotonic
+// sort-order check into the same read the run-grouped comparison consumes (via an
+// order-checking stream adapter). The invariant most at risk under that fold: once the two
+// files' runs desynchronize (a run-boundary mismatch or one file exhausting first), the
+// comparison stops but each file's *tail* must still be pulled through its order tracker, so
+// the per-file violation count and first violation stay complete — identical to the old
+// end-to-end `verify_sort_order` pass. These tests pin that behavior for a violation that
+// lands in the tail, *past* the desync point (discovered by the drain path, not by the
+// comparison).
+
+/// Independently recompute the coordinate-order verification of `path` via the reference
+/// `fgumi_sort::verify_sort_order` two-pass primitive (the exact fold the single-pass engine
+/// folds inline), returning `(violations, first_violation)`. Used to lock the equivalence.
+fn reference_coordinate_violations(path: &Path, nref: u32) -> (u64, Option<(u64, String)>) {
+    let mut reader = fgumi_sort::RawBamRecordReader::new(fs::File::open(path).expect("open bam"))
+        .expect("reader");
+    reader.skip_header().expect("skip header");
+    let (_total, violations, first) = fgumi_sort::verify_sort_order(
+        reader,
+        |bam: &[u8]| fgumi_sort::extract_coordinate_key_inline(bam, nref),
+        |key: &u64, prev: &u64| key < prev,
+    )
+    .expect("verify_sort_order");
+    (violations, first)
+}
+
+/// A desynced coordinate-sorted pair where *each* file additionally hides a monotonic-order
+/// violation deep in its tail — after the run boundaries stop lining up. The comparison
+/// desyncs at the second run (bam1's pos-200 group vs bam2's pos-300 group don't align) and
+/// never resyncs, so the violating tail records (`readD` @ pos 50 in bam1, `readZ` @ pos 10
+/// in bam2) are only ever seen by the drain path. Both must still be counted, with the
+/// correct 1-based record number and read name, matching the reference two-pass computation.
+#[test]
+fn test_sort_verify_counts_order_violation_in_tail_past_desync() {
+    let tmp = TempDir::new().unwrap();
+    let header = create_coordinate_sorted_header("chr1", 10000);
+
+    // bam1: readA/readB/readC are non-decreasing; readD @ pos 50 violates (50 < 210) and
+    // sits past the run boundary the comparison desyncs on.
+    let records1 = vec![
+        fragment_record(b"readA", 0, 100, false),
+        fragment_record(b"readB", 0, 200, false),
+        fragment_record(b"readC", 0, 210, false),
+        fragment_record(b"readD", 0, 50, false),
+    ];
+    // bam2: readX/readY are non-decreasing after the shared readA; readZ @ pos 10 violates
+    // (10 < 310), likewise in the drained tail.
+    let records2 = vec![
+        fragment_record(b"readA", 0, 100, false),
+        fragment_record(b"readX", 0, 300, false),
+        fragment_record(b"readY", 0, 310, false),
+        fragment_record(b"readZ", 0, 10, false),
+    ];
+
+    let bam1 = tmp.path().join("a.bam");
+    let bam2 = tmp.path().join("b.bam");
+    write_bam(&bam1, &header, &records1);
+    write_bam(&bam2, &header, &records2);
+
+    let outcome =
+        sort_verify_compare(&bam1, &bam2, 100).expect("sort_verify_compare should succeed");
+
+    // The streams desynchronized (run boundaries do not align), and no resync happened.
+    assert!(outcome.presence_mismatch, "the pair must desync on the mismatched run: {outcome:?}");
+
+    // Every record in each file was still read: counts are complete.
+    assert_eq!(outcome.bam1_count, 4, "bam1 fully drained past the desync: {outcome:?}");
+    assert_eq!(outcome.bam2_count, 4, "bam2 fully drained past the desync: {outcome:?}");
+
+    // The tail-past-desync order violation in each file is fully counted, with the correct
+    // 1-based record number and read name.
+    assert_eq!(outcome.bam1_violations, 1, "bam1's tail violation must be counted: {outcome:?}");
+    assert_eq!(outcome.bam1_first_violation, Some((4, "readD".to_string())));
+    assert_eq!(outcome.bam2_violations, 1, "bam2's tail violation must be counted: {outcome:?}");
+    assert_eq!(outcome.bam2_first_violation, Some((4, "readZ".to_string())));
+
+    // And it matches the reference two-pass computation exactly.
+    let nref = u32::try_from(header.reference_sequences().len()).expect("nref fits in u32");
+    assert_eq!(reference_coordinate_violations(&bam1, nref), (1, Some((4, "readD".to_string()))));
+    assert_eq!(reference_coordinate_violations(&bam2, nref), (1, Some((4, "readZ".to_string()))));
+
+    assert!(!outcome.is_match(), "a desynced pair with mis-sorted tails must DIFFER: {outcome:?}");
+}
+
+proptest::proptest! {
+    #![proptest_config(proptest::prelude::ProptestConfig::with_cases(64))]
+
+    /// Parity/equivalence property: over randomized coordinate-keyed inputs — including
+    /// pairs that desynchronize — the single-pass engine's per-file `(violations,
+    /// first_violation)` must equal the reference `fgumi_sort::verify_sort_order` two-pass
+    /// computation run independently over each file. This locks the single-pass fold to the
+    /// primitive it replaced, for both correctly-sorted and mis-sorted inputs.
+    #[test]
+    fn prop_sort_verify_per_file_violations_match_reference(
+        positions1 in proptest::collection::vec(1i32..500, 1..12),
+        positions2 in proptest::collection::vec(1i32..500, 1..12),
+    ) {
+        let tmp = TempDir::new().unwrap();
+        let header = create_coordinate_sorted_header("chr1", 10000);
+        let nref = u32::try_from(header.reference_sequences().len()).expect("nref fits in u32");
+
+        let to_records = |positions: &[i32]| -> Vec<RawRecord> {
+            positions
+                .iter()
+                .enumerate()
+                .map(|(i, &pos)| fragment_record(format!("r{i}").as_bytes(), 0, pos, false))
+                .collect()
+        };
+        let records1 = to_records(&positions1);
+        let records2 = to_records(&positions2);
+
+        let bam1 = tmp.path().join("a.bam");
+        let bam2 = tmp.path().join("b.bam");
+        write_bam(&bam1, &header, &records1);
+        write_bam(&bam2, &header, &records2);
+
+        let outcome =
+            sort_verify_compare(&bam1, &bam2, 100).expect("sort_verify_compare should succeed");
+
+        let (ref1_violations, ref1_first) = reference_coordinate_violations(&bam1, nref);
+        let (ref2_violations, ref2_first) = reference_coordinate_violations(&bam2, nref);
+
+        proptest::prop_assert_eq!(outcome.bam1_violations, ref1_violations);
+        proptest::prop_assert_eq!(outcome.bam1_first_violation, ref1_first);
+        proptest::prop_assert_eq!(outcome.bam2_violations, ref2_violations);
+        proptest::prop_assert_eq!(outcome.bam2_first_violation, ref2_first);
+
+        // Record counts must also be complete regardless of any desync.
+        proptest::prop_assert_eq!(outcome.bam1_count, records1.len() as u64);
+        proptest::prop_assert_eq!(outcome.bam2_count, records2.len() as u64);
+    }
 }


### PR DESCRIPTION
## Summary

The sort-verify engine backing `fgumi compare bams --command sort` read each input BAM **twice**: two per-file monotonic sort-order passes (`fgumi_sort::verify_sort_order`) plus a reopened run-grouped multiset-comparison pass — **four full BAM traversals where two suffice**. `--command sort` runs on WGS-scale BAMs where BAM I/O + BGZF decode is the documented bottleneck, so this was roughly 2x the necessary decode work.

This refactor reads each file **exactly once** (4 → 2 traversals total), preserving byte-for-byte identical outputs.

## Design: an order-checking stream adapter

A sorted-BAM comparison is a synchronized merge of two ordered keyed streams. Both the per-file properties (monotonic order, count, first violation) and the cross-file properties (run-grouped multiset, presence) are folds over one pass.

An `OrderChecked` stream adapter layers over the single keyed-record read the run comparison already consumes:

- `OrderTracker` is the inline fold of `fgumi_sort::verify_sort_order` — it watches each key flow past and accumulates `(violations, first_violation)` (with the same 1-based record numbering and `from_utf8_lossy` read-name extraction).
- `OrderChecked::next_keyed` reads a record, extracts its key, feeds it through the tracker as a **side effect**, and yields `(key, record)` downstream unchanged.
- `pull_run` / `run_compare` are unchanged in comparison logic; they just pull records through the adapter instead of a bare reader.

The two concerns (order-checking vs. run comparison) stay decoupled and independently testable while sharing one read.

## The invariant preserved: complete per-file counts past a desync

Previously, `verify_one` walked each file end to end, so `bam1_violations` / `bam2_violations` and the `*_first_violation` fields were **complete** per-file counts regardless of whether the two streams desynced. The refactor keeps this: `run_compare`'s desync **drain** path pulls the tail *through* the same `OrderChecked` adapter (`OrderChecked::drain`), so a mis-sort in the drained tail — past the point where the comparison stopped — is still counted. This is not a partial-count shortcut; the per-file violation output is identical to the old two-pass computation for every input.

## Tests

- All existing sort-verify unit + integration tests remain green (`sort_verify` / `--command sort` / `test_sort_verify`).
- **New**: `test_sort_verify_counts_order_violation_in_tail_past_desync` — a desynced pair where *each* file hides a monotonic-order violation deep in its tail (only ever seen by the drain path); asserts complete violation counts, correct record number + read name, complete record totals, and cross-checks against the reference `verify_sort_order`.
- **New**: `prop_sort_verify_per_file_violations_match_reference` — property test asserting the single-pass per-file `(violations, first_violation)` equals the reference `fgumi_sort::verify_sort_order` two-pass computation over randomized coordinate-keyed inputs (including desyncing pairs).

`cargo build --offline --features compare`, `cargo nextest run --features compare` (2065 passed), `cargo ci-fmt`, and `cargo ci-lint` all pass.

## Notes

`fgumi_sort::verify_sort_order` / `VerifySummary` are retained (still used by `fgumi sort --verify`); this change just stops calling them from the compare engine.

Stacked on #530 (base branch `nh/compare-hardening`). Should be rebased onto `main` after #530 merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved BAM sort-order verification to validate and drain remaining records correctly after run-boundary desynchronization.
  - Ensures complete per-file record counts and precise sort-order violation reporting (including the first offending record index and read name), with consistent results against the trusted reference.

- **Tests**
  - Added regression coverage for run-boundary desync with violations only in post-desync tails.
  - Added checks for mismatches inside equal-key runs and for header `@SQ` dictionary count mismatches.
  - Strengthened single-pass equivalence with property-based validation against the reference.

- **Documentation**
  - Updated verification documentation/comments to reflect single-pass violation accumulation and post-desync draining behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->