### PR TITLE
ci: run the whole workspace in tests + fix stale fgumi-sam revcomp assertions

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
-ci-test = "nextest run --features compare,simulate,profile-adjacency --locked --no-tests=pass"
+ci-test = "nextest run --workspace --features compare,simulate,profile-adjacency --locked --no-tests=pass"
 ci-fmt = "fmt --all -- --check"
 ci-lint = "clippy --workspace --all-targets --features compare,simulate,profile-adjacency -- -D warnings -W clippy::pedantic"
 ci-tag-literals = "run --package xtask -- check-tag-literals"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           tool: nextest
       - name: Generate coverage
-        run: cargo llvm-cov nextest --features compare,simulate,profile-adjacency --no-tests=pass --lcov --output-path lcov.info
+        run: cargo llvm-cov nextest --workspace --features compare,simulate,profile-adjacency --no-tests=pass --lcov --output-path lcov.info
       - name: Upload to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:

--- a/crates/fgumi-sam/src/lib.rs
+++ b/crates/fgumi-sam/src/lib.rs
@@ -570,9 +570,11 @@ mod tests {
         let value = BufValue::from("acgt".to_string());
         let revcomp = revcomp_buf_value(&value);
 
-        // Lowercase is normalized to uppercase
+        // Case is preserved: fgumi_dna::reverse_complement uses the shared
+        // IUPAC-aware, case-preserving LUT (fgbio Sequences.complement parity,
+        // #491). "acgt" -> complement "tgca" -> reversed "acgt".
         if let BufValue::String(s) = revcomp {
-            assert_eq!(s.to_string(), "ACGT");
+            assert_eq!(s.to_string(), "acgt");
         } else {
             panic!("Expected String");
         }
@@ -583,9 +585,10 @@ mod tests {
         let value = BufValue::from("AcGt".to_string());
         let revcomp = revcomp_buf_value(&value);
 
-        // Mixed case is normalized to uppercase
+        // Case is preserved per base (#491): "AcGt" -> complement "TgCa" ->
+        // reversed "aCgT".
         if let BufValue::String(s) = revcomp {
-            assert_eq!(s.to_string(), "ACGT");
+            assert_eq!(s.to_string(), "aCgT");
         } else {
             panic!("Expected String");
         }
@@ -898,13 +901,14 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn test_revcomp_buf_value_ambiguous_bases_unchanged() {
-        // IUPAC ambiguity codes are not complemented
+    fn test_revcomp_buf_value_ambiguous_bases_complemented() {
+        // IUPAC ambiguity codes ARE complemented via the shared LUT (#491):
+        // R<->Y, K<->M, S and W are self-complementary.
         let value = BufValue::from("RYSWKM".to_string());
         let revcomp = revcomp_buf_value(&value);
         if let BufValue::String(s) = revcomp {
-            // Reversed but not complemented (our function only complements ACGTN)
-            assert_eq!(s.to_string(), "MKWSYR");
+            // complement "RYSWKM" -> "YRSWMK", reversed -> "KMWSRY".
+            assert_eq!(s.to_string(), "KMWSRY");
         } else {
             panic!("Expected String");
         }


### PR DESCRIPTION
This hotfix closes a CI coverage gap and fixes the sub-crate tests it was hiding.

## The footgun

`cargo ci-test` (the `test` CI job) was:

```
nextest run --features compare,simulate,profile-adjacency --locked --no-tests=pass
```

`compare`/`simulate`/`profile-adjacency` are features of the **root `fgumi` package**, and neither `--workspace` nor `-p` was passed, so cargo scoped the build to the root package only. The per-crate unit tests for every workspace member — `fgumi-sam`, `fgumi-dna`, `fgumi-sort`, `fgumi-umi`, `fgumi-consensus`, `fgumi-metrics`, `fgumi-raw-bam`, … — were **never compiled or run in CI**. Locally, `cargo ci-test` built only 3 suites (`fgumi`, `fgumi::integration`, `fgumi::integration_tests`); `cargo nextest run --workspace` builds them all.

The `coverage` job’s `cargo llvm-cov nextest …` had the same scoping, so coverage was measured on the root package only.

## What this hides

Three `fgumi-sam` `revcomp_buf_value` tests still asserted the pre-#491 behavior (uppercase-normalizing, ACGTN-only). When #491 made `fgumi_dna::reverse_complement` IUPAC-aware and case-preserving (shared 256-byte `COMPLEMENT` LUT, fgbio `Sequences.complement` parity), these went red — but CI never ran them, so `main` stayed green. `cargo nextest run -p fgumi-sam` fails them today.

## Changes

- **`test(sam)`**: update the three assertions to the case-preserving IUPAC behavior — `"acgt"→"acgt"`, `"AcGt"→"aCgT"`, `"RYSWKM"→"KMWSRY"` (renamed `..._unchanged` → `..._complemented`, fixed the stale comments). `revcomp_buf_value` has no production caller (the raw per-base tag path works on bytes; consensus tags are always uppercase ACGTN), so this is a test-only correction with no behavior change.
- **`ci`**: add `--workspace` to `ci-test` and to the coverage `llvm-cov` invocation. `ci-lint` already uses `--workspace --features …`, so this matches the existing pattern and confirms cargo accepts the combination.

## Validation

- `cargo ci-test` (updated) now runs the whole workspace: **4722 tests, all green** (was 2310 root-only).
- `cargo ci-fmt` and `cargo ci-lint` clean.
- Whole-workspace on unmodified `main` was 4251 tests with exactly these 3 failing; with this PR all green.