### PR TITLE
fix(clip): upgrade clipping on all template reads, not just the primary pair

### DIFF
--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -323,6 +323,17 @@ impl Clip {
             let template = template?;
             let mut records: Vec<RawRecord> = template.into_records();
 
+            // Upgrade existing clipping on *every* read of the template first — including
+            // secondary/supplementary alignments — matching fgbio ClipBam, which runs
+            // `upgradeAllClipping` over `template.allReads` (ClipBam.scala:123) before clipping the
+            // primary pair. Doing it per-template here (rather than per-primary inside
+            // clip_pair/clip_fragment) is what lets supplementary reads' clipping be upgraded too.
+            if self.upgrade_clipping {
+                for record in &mut records {
+                    clipper.upgrade_all_clipping_raw(record)?;
+                }
+            }
+
             // Clip the primary R1/R2 (or a lone fragment) — never positional records[0]/[1] —
             // so templates with secondary/supplementary reads (len > 2) are clipped too, matching
             // fgbio ClipBam's Template.r1/r2 handling.
@@ -420,10 +431,8 @@ impl Clip {
     ) -> Result<()> {
         let prior_bases_clipped = clipped_bases_raw(record);
 
-        // Upgrade existing clipping if requested
-        if self.upgrade_clipping {
-            clipper.upgrade_all_clipping_raw(record)?;
-        }
+        // Note: clipping upgrades (`--upgrade-clipping`) are applied once per template over all
+        // reads by the caller (matching fgbio ClipBam.scala:123), not here.
 
         // Apply fixed-position clipping
         let num_five_prime = if self.read_one_five_prime > 0 {
@@ -491,11 +500,8 @@ impl Clip {
         let prior_bases_clipped_r1 = clipped_bases_raw(r1);
         let prior_bases_clipped_r2 = clipped_bases_raw(r2);
 
-        // Upgrade existing clipping if requested
-        if self.upgrade_clipping {
-            clipper.upgrade_all_clipping_raw(r1)?;
-            clipper.upgrade_all_clipping_raw(r2)?;
-        }
+        // Note: clipping upgrades (`--upgrade-clipping`) are applied once per template over all
+        // reads by the caller (matching fgbio ClipBam.scala:123), not here.
 
         // Determine read types (raw flags: bit 6 = first segment, bit 7 = last segment)
         let (is_r1_first, is_r2_last) = (r1.is_first_segment(), r2.is_last_segment());
@@ -653,6 +659,16 @@ impl Clip {
                 templates_count += 1;
                 let mut records: Vec<RawRecord> = template.into_records();
 
+                // Upgrade existing clipping on *every* read of the template first — including
+                // secondary/supplementary alignments — matching fgbio ClipBam's
+                // `template.allReads.foreach(upgradeAllClipping)` (ClipBam.scala:123) before the
+                // primary pair is clipped.
+                if upgrade_clipping {
+                    for record in &mut records {
+                        clipper.upgrade_all_clipping_raw(record).map_err(io::Error::other)?;
+                    }
+                }
+
                 // Clip the primary R1/R2 (or a lone fragment) by flags, never positional
                 // records[0]/[1], so templates with secondary/supplementary reads are clipped
                 // too (matches fgbio ClipBam's Template.r1/r2 handling).
@@ -660,11 +676,6 @@ impl Clip {
                     (Some(i1), Some(i2)) => {
                         let [r1, r2] =
                             records.get_disjoint_mut([i1, i2]).expect("distinct primary indices");
-
-                        if upgrade_clipping {
-                            clipper.upgrade_all_clipping_raw(r1).map_err(io::Error::other)?;
-                            clipper.upgrade_all_clipping_raw(r2).map_err(io::Error::other)?;
-                        }
 
                         // Determine read types (raw flags)
                         let is_r1_first = r1.is_first_segment();
@@ -714,11 +725,9 @@ impl Clip {
                         fix_supplemental_mate_info(&mut records, i1, i2);
                     }
                     (Some(i1), None) => {
-                        // Fragment - apply fixed-position clipping (R1 thresholds)
+                        // Fragment - apply fixed-position clipping (R1 thresholds). Any clipping
+                        // upgrade was already applied over all template reads above.
                         let record = &mut records[i1];
-                        if upgrade_clipping {
-                            clipper.upgrade_all_clipping_raw(record).map_err(io::Error::other)?;
-                        }
                         if read_one_five_prime > 0 {
                             clipper.clip_5_prime_end_of_alignment(record, read_one_five_prime);
                         }

--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -404,9 +404,13 @@ impl Clip {
     /// Clips a fragment (unpaired) read.
     ///
     /// Applies clipping operations to a single fragment read, including:
-    /// 1. Upgrading existing clipping if requested
-    /// 2. Applying fixed-position 5' and 3' clipping
-    /// 3. Updating metrics if a metrics collector is provided
+    /// 1. Applying fixed-position 5' and 3' clipping
+    /// 2. Updating metrics if a metrics collector is provided
+    ///
+    /// Clipping upgrades (`--upgrade-clipping`) are *not* performed here: the caller runs a
+    /// template-wide pre-pass that upgrades clipping on every read of the template (including
+    /// secondary/supplementary alignments) before this method runs, matching fgbio `ClipBam`
+    /// (`ClipBam.scala:123`).
     ///
     /// Fragment reads are treated as R1 for the purposes of fixed-position clipping.
     ///
@@ -466,11 +470,15 @@ impl Clip {
     /// Clips a pair of reads with comprehensive clipping logic.
     ///
     /// Applies multiple types of clipping to a read pair:
-    /// 1. Upgrading existing clipping if requested
-    /// 2. Fixed-position 5' and 3' clipping for each read
-    /// 3. Overlap clipping to remove duplicate coverage
-    /// 4. Mate-extension clipping to remove reads extending past mate start
-    /// 5. Updating metrics for both reads
+    /// 1. Fixed-position 5' and 3' clipping for each read
+    /// 2. Overlap clipping to remove duplicate coverage
+    /// 3. Mate-extension clipping to remove reads extending past mate start
+    /// 4. Updating metrics for both reads
+    ///
+    /// Clipping upgrades (`--upgrade-clipping`) are *not* performed here: the caller runs a
+    /// template-wide pre-pass that upgrades clipping on every read of the template (including
+    /// secondary/supplementary alignments) before this method runs, matching fgbio `ClipBam`
+    /// (`ClipBam.scala:123`).
     ///
     /// The method intelligently determines which read is R1 vs R2 based on SAM flags
     /// and applies the appropriate fixed-position clipping thresholds.

--- a/tests/integration/test_clip_command.rs
+++ b/tests/integration/test_clip_command.rs
@@ -388,6 +388,29 @@ fn cigar_ops(rec: &RecordBuf) -> Vec<(CigarKind, usize)> {
     rec.cigar().as_ref().iter().map(|op| (op.kind(), op.len())).collect()
 }
 
+/// A record's identity for exact match/count assertions:
+/// `(name, flags, 1-based pos, 1-based mate-pos, CIGAR ops, SEQ bytes, QUAL scores)`.
+///
+/// SEQ and QUAL are included so a hard-clip upgrade that rewrites the CIGAR (e.g. `10S40M`
+/// -> `10H40M`) but fails to drop the hard-clipped bases from the payload — leaving 50
+/// SEQ/QUAL bytes under a 40-base-consuming CIGAR — is rejected, not silently accepted.
+type RecordIdentity = (String, u16, usize, usize, Vec<(CigarKind, usize)>, Vec<u8>, Vec<u8>);
+
+/// Extracts the [`RecordIdentity`] tuple from a mapped, mate-mapped record.
+fn record_identity(rec: &RecordBuf) -> RecordIdentity {
+    let name =
+        rec.name().map(|n| String::from_utf8_lossy(n.as_ref()).into_owned()).unwrap_or_default();
+    (
+        name,
+        u16::from(rec.flags()),
+        usize::from(rec.alignment_start().expect("mapped record has alignment start")),
+        usize::from(rec.mate_alignment_start().expect("record has mate alignment start")),
+        cigar_ops(rec),
+        rec.sequence().as_ref().to_vec(),
+        rec.quality_scores().as_ref().to_vec(),
+    )
+}
+
 /// The record's mate-CIGAR (`MC`) tag as a string, if present.
 fn mate_cigar(rec: &RecordBuf) -> Option<String> {
     use noodles::sam::alignment::record::data::field::Tag;
@@ -423,11 +446,13 @@ fn mapped_read(name: &[u8], flags: u16, pos: i32, match_len: u32, mapq: u8) -> R
 }
 
 /// Build a mapped read with an explicit CIGAR (raw BAM `(len << 4) | op` codes) and a
-/// matching-length sequence/qualities. `read_len` must equal the CIGAR's read-consuming length.
+/// matching-length sequence/qualities. `mate_pos` sets the mate's position (PNEXT); pass the
+/// mate read's start, not the read's own. `read_len` must equal the CIGAR's read-consuming length.
 fn read_with_cigar(
     name: &[u8],
     flags: u16,
     pos: i32,
+    mate_pos: i32,
     cigar_ops: &[u32],
     read_len: usize,
     mapq: u8,
@@ -442,7 +467,7 @@ fn read_with_cigar(
         .mapq(mapq)
         .cigar_ops(cigar_ops)
         .mate_ref_id(0)
-        .mate_pos(pos);
+        .mate_pos(mate_pos);
     b.build()
 }
 
@@ -465,6 +490,7 @@ fn run_supplementary_upgrade_case(threads: Option<&str>) {
         b"t",
         flags::PAIRED | flags::FIRST_SEGMENT | flags::SUPPLEMENTARY,
         199,
+        99, // mate = primary R2 at position 99, not the supplementary's own position
         &[(10u32 << 4) | 4, 40u32 << 4], // 10S40M
         50,
         60,
@@ -493,40 +519,73 @@ fn run_supplementary_upgrade_case(threads: Option<&str>) {
     let cmd = Clip::try_parse_from(&args).expect("failed to parse clip args");
     cmd.execute("fgumi clip").expect("Clip command failed");
 
-    let recs = read_output_records(&output_bam);
+    let recs = read_output_record_bufs(&output_bam);
     assert_eq!(recs.len(), 3, "all three reads retained");
 
-    // The supplementary read's leading 10S must have been upgraded to 10H.
-    let supp_out = recs
-        .iter()
-        .find(|(_, _, f)| f & flags::SUPPLEMENTARY != 0)
-        .expect("supplementary read present in output");
-    assert_eq!(
-        supp_out.1,
-        vec![(CigarKind::HardClip, 10), (CigarKind::Match, 40)],
-        "supplementary soft clip must be upgraded to hard (fgbio ClipBam.scala:123 upgrades \
-         template.allReads); got {:?}",
-        supp_out.1
-    );
-
-    // The primaries carried no clipping, so upgrade is a no-op on them.
-    for (_, ops, f) in &recs {
-        if f & flags::SUPPLEMENTARY == 0 {
-            assert_eq!(*ops, vec![(CigarKind::Match, 50)], "primary CIGAR must be unchanged");
-        }
+    // Assert the exact identity of all three expected records — (name, flags, 1-based pos,
+    // 1-based mate_pos, CIGAR) — each present exactly once. Count-only checks would pass even
+    // with two copies of the same primary, so this pins down every record.
+    //
+    // Values are hand-derived from the fixed inputs and the post-clip mate-info fixing:
+    //   * Only `--upgrade-clipping` (Hard) is on — no fixed/overlap/extension clipping — so both
+    //     primaries stay 50M and the supplementary's leading 10S is upgraded to 10H.
+    //   * `set_mate_info_raw` sets MATE_REVERSE on primary R1 (its mate R2 is reverse) and, via
+    //     `fix_supplemental_mate_info`, on the supplementary (its mate primary R2 is reverse); it
+    //     also points every read's mate at primary position 99 (0-based) => 100 (1-based).
+    // Fixtures build reads with SEQ = all `A` and QUAL = all 30 (`read_with_cigar` /
+    // `mapped_read`), so the unchanged 50M primaries keep 50 bytes each and the hard-clipped
+    // supplementary must drop its leading 10 to 40 bytes.
+    let expected: [RecordIdentity; 3] = [
+        // Primary R1: forward, unchanged 50M; MATE_REVERSE now set (mate R2 is reverse).
+        (
+            "t".to_string(),
+            flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE,
+            100,
+            100,
+            vec![(CigarKind::Match, 50)],
+            vec![b'A'; 50],
+            vec![30; 50],
+        ),
+        // Primary R2: reverse, unchanged 50M.
+        (
+            "t".to_string(),
+            flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE,
+            100,
+            100,
+            vec![(CigarKind::Match, 50)],
+            vec![b'A'; 50],
+            vec![30; 50],
+        ),
+        // Supplementary R1: leading 10S upgraded to 10H (fgbio ClipBam.scala:123 upgrades
+        // template.allReads); MATE_REVERSE set from the primary R2 mate. The hard clip drops the
+        // leading 10 bases, so SEQ/QUAL shrink 50 -> 40.
+        (
+            "t".to_string(),
+            flags::PAIRED | flags::FIRST_SEGMENT | flags::SUPPLEMENTARY | flags::MATE_REVERSE,
+            200,
+            100,
+            vec![(CigarKind::HardClip, 10), (CigarKind::Match, 40)],
+            vec![b'A'; 40],
+            vec![30; 40],
+        ),
+    ];
+    let actual: Vec<RecordIdentity> = recs.iter().map(record_identity).collect();
+    for want in &expected {
+        let count = actual.iter().filter(|got| *got == want).count();
+        assert_eq!(
+            count, 1,
+            "expected exactly one record matching {want:?}; got {count} in {actual:?}"
+        );
     }
 }
 
-/// Single-threaded path: `--upgrade-clipping` upgrades a supplementary alignment's clipping.
-#[test]
-fn test_upgrade_clipping_upgrades_supplementary_single_threaded() {
-    run_supplementary_upgrade_case(None);
-}
-
-/// `--threads` path: `--upgrade-clipping` upgrades a supplementary alignment's clipping.
-#[test]
-fn test_upgrade_clipping_upgrades_supplementary_threads_mode() {
-    run_supplementary_upgrade_case(Some("2"));
+/// `--upgrade-clipping` upgrades a supplementary alignment's clipping on both the single-threaded
+/// (`None`) and `--threads` (`Some("2")`) code paths.
+#[rstest]
+#[case::single_threaded(None)]
+#[case::threaded(Some("2"))]
+fn test_upgrade_clipping_upgrades_supplementary(#[case] threads: Option<&str>) {
+    run_supplementary_upgrade_case(threads);
 }
 
 /// `--threads` mode routes through `execute_threads_mode`; exercise the `(Some, Some)` primary-pair

--- a/tests/integration/test_clip_command.rs
+++ b/tests/integration/test_clip_command.rs
@@ -422,6 +422,113 @@ fn mapped_read(name: &[u8], flags: u16, pos: i32, match_len: u32, mapq: u8) -> R
     b.build()
 }
 
+/// Build a mapped read with an explicit CIGAR (raw BAM `(len << 4) | op` codes) and a
+/// matching-length sequence/qualities. `read_len` must equal the CIGAR's read-consuming length.
+fn read_with_cigar(
+    name: &[u8],
+    flags: u16,
+    pos: i32,
+    cigar_ops: &[u32],
+    read_len: usize,
+    mapq: u8,
+) -> RawRecord {
+    let mut b = SamBuilder::new();
+    b.read_name(name)
+        .sequence(&vec![b'A'; read_len])
+        .qualities(&vec![30; read_len])
+        .flags(flags)
+        .ref_id(0)
+        .pos(pos)
+        .mapq(mapq)
+        .cigar_ops(cigar_ops)
+        .mate_ref_id(0)
+        .mate_pos(pos);
+    b.build()
+}
+
+/// Runs `clip --upgrade-clipping` (Hard mode) over a template whose only clipped read is a
+/// supplementary alignment (`10S40M`), and asserts the supplementary's leading soft clip is
+/// upgraded to hard. fgbio `ClipBam` upgrades `template.allReads` (`ClipBam.scala:123`), not just
+/// the primary R1/R2, so the supplementary must be upgraded too. `threads` selects the
+/// single-threaded (`None`) vs `--threads` code path — the fix must hold on both.
+fn run_supplementary_upgrade_case(threads: Option<&str>) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let ref_path = create_test_reference(temp_dir.path());
+
+    // Primary pair, both 50M (no clipping to upgrade — they must stay 50M).
+    let r1 = mapped_read(b"t", flags::PAIRED | flags::FIRST_SEGMENT, 99, 50, 60);
+    let r2 = mapped_read(b"t", flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE, 99, 50, 60);
+    // R1 supplementary with a leading soft clip: 10S40M. The only read carrying clipping.
+    let supp = read_with_cigar(
+        b"t",
+        flags::PAIRED | flags::FIRST_SEGMENT | flags::SUPPLEMENTARY,
+        199,
+        &[(10u32 << 4) | 4, 40u32 << 4], // 10S40M
+        50,
+        60,
+    );
+    create_bam_from_records(&input_bam, &[r1, r2, supp]);
+
+    let mut args = vec![
+        "clip".to_string(),
+        "--input".to_string(),
+        input_bam.to_str().unwrap().to_string(),
+        "--output".to_string(),
+        output_bam.to_str().unwrap().to_string(),
+        "--reference".to_string(),
+        ref_path.to_str().unwrap().to_string(),
+        "--clipping-mode".to_string(),
+        "hard".to_string(),
+        "--upgrade-clipping".to_string(),
+        "true".to_string(),
+        "--compression-level".to_string(),
+        "1".to_string(),
+    ];
+    if let Some(t) = threads {
+        args.push("--threads".to_string());
+        args.push(t.to_string());
+    }
+    let cmd = Clip::try_parse_from(&args).expect("failed to parse clip args");
+    cmd.execute("fgumi clip").expect("Clip command failed");
+
+    let recs = read_output_records(&output_bam);
+    assert_eq!(recs.len(), 3, "all three reads retained");
+
+    // The supplementary read's leading 10S must have been upgraded to 10H.
+    let supp_out = recs
+        .iter()
+        .find(|(_, _, f)| f & flags::SUPPLEMENTARY != 0)
+        .expect("supplementary read present in output");
+    assert_eq!(
+        supp_out.1,
+        vec![(CigarKind::HardClip, 10), (CigarKind::Match, 40)],
+        "supplementary soft clip must be upgraded to hard (fgbio ClipBam.scala:123 upgrades \
+         template.allReads); got {:?}",
+        supp_out.1
+    );
+
+    // The primaries carried no clipping, so upgrade is a no-op on them.
+    for (_, ops, f) in &recs {
+        if f & flags::SUPPLEMENTARY == 0 {
+            assert_eq!(*ops, vec![(CigarKind::Match, 50)], "primary CIGAR must be unchanged");
+        }
+    }
+}
+
+/// Single-threaded path: `--upgrade-clipping` upgrades a supplementary alignment's clipping.
+#[test]
+fn test_upgrade_clipping_upgrades_supplementary_single_threaded() {
+    run_supplementary_upgrade_case(None);
+}
+
+/// `--threads` path: `--upgrade-clipping` upgrades a supplementary alignment's clipping.
+#[test]
+fn test_upgrade_clipping_upgrades_supplementary_threads_mode() {
+    run_supplementary_upgrade_case(Some("2"));
+}
+
 /// `--threads` mode routes through `execute_threads_mode`; exercise the `(Some, Some)` primary-pair
 /// branch with fixed R1/R2 clipping, overlap clipping, mate-extension clipping and clip upgrading
 /// all enabled. R1 (fwd, 150M) and R2 (rev, 100M) fully overlap, so overlap clipping engages.


### PR DESCRIPTION
Stacked on #502 (it restructured this clip loop; rebase to `main` once #502 merges).

## Problem

`fgumi clip --upgrade-clipping` upgraded existing clipping (soft→hard, or soft-with-mask) only on the **primary** R1/R2/fragment. fgbio `ClipBam` upgrades **every** read of the template — `template.allReads.foreach(upgradeAllClipping)` (`ClipBam.scala:123`) — *before* clipping the primary pair. So a soft-clipped **secondary or supplementary** alignment stayed soft in fgumi while fgbio hard-clips it (dropping SEQ/QUAL for the clipped span in Hard mode), diverging on any chimeric template carrying clipped supplementaries.

This was a known parity gap surfaced during the #502 / #528 reviews.

## Fix

Hoist the upgrade to a single per-template pass over **all** records — in both the single-threaded and `--threads` code paths — matching fgbio’s ordering (upgrade all reads, then clip the primary pair). The now-redundant per-primary upgrades inside `clip_pair`/`clip_fragment` and the threaded inline branch are removed; those helpers now match fgbio’s `clipPair`/`clipFragment`, which do not upgrade.

The per-record clipped-base counts used for overlap/extension metrics are unaffected — upgrading soft→hard preserves the *number* of clipped bases.

## Tests (TDD)

Added `test_upgrade_clipping_upgrades_supplementary_{single_threaded,threads_mode}`: a template with a primary pair (`50M`, no clipping) plus an R1 **supplementary** `10S40M`, run with `--upgrade-clipping --clipping-mode hard`. Asserts the supplementary becomes `10H40M` and the primaries stay `50M`. Both tests fail before the fix (supplementary stays `10S40M`) and pass after; full clip suite (66 tests) green.

## fgbio parity

`ClipBam.scala:122-136`: `if (upgradeClipping) template.allReads.foreach { r => clipper.upgradeAllClipping(r) }` runs before the `(template.r1, template.r2)` match — verified against `~/work/git/fgbio-4.1.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `--upgrade-clipping` so clipping upgrades are applied consistently across all reads in a template, including supplementary alignments.
  * Ensured single-threaded and multithreaded processing produce consistent clipping results.
  * Improved error handling during clipping upgrades.

* **Tests**
  * Added coverage validating supplementary alignment clipping and consistency across processing modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->