### PR TITLE
refactor(fastq): consolidate read-name suffix stripping and assert cross-parser parity

### DIFF
--- a/crates/fgumi-simd-fastq/src/lib.rs
+++ b/crates/fgumi-simd-fastq/src/lib.rs
@@ -33,5 +33,7 @@ mod reader;
 
 pub use bitmask::FastqBitmask;
 pub use lexer::lex_block_full;
-pub use parser::{FastqParseError, FastqRecord, find_record_offsets, parse_records};
+pub use parser::{
+    FastqParseError, FastqRecord, find_record_offsets, parse_records, try_parse_single_record,
+};
 pub use reader::SimdFastqReader;

--- a/crates/fgumi-simd-fastq/src/parser.rs
+++ b/crates/fgumi-simd-fastq/src/parser.rs
@@ -209,7 +209,7 @@ fn strip_trailing_cr(field: &[u8]) -> &[u8] {
 /// # Errors
 ///
 /// Returns a [`FastqParseError`] describing the first structural violation.
-pub(crate) fn try_parse_single_record(record: &[u8]) -> Result<FastqRecord<'_>, FastqParseError> {
+pub fn try_parse_single_record(record: &[u8]) -> Result<FastqRecord<'_>, FastqParseError> {
     if record.is_empty() || record[0] != b'@' {
         return Err(FastqParseError::MissingAtPrefix);
     }

--- a/src/lib/commands/extract.rs
+++ b/src/lib/commands/extract.rs
@@ -21,6 +21,7 @@ use crate::commands::common::{
 use crate::fastq::FastqSegment;
 use crate::fastq::FastqSet;
 use crate::fastq::ReadSetIterator;
+use crate::fastq_parse::strip_read_suffix;
 use crate::grouper::FastqTemplate;
 use crate::logging::OperationTimer;
 use crate::sam::SamTag;
@@ -735,9 +736,9 @@ impl Extract {
     /// <https://support.illumina.com/help/BaseSpace_OLH_009008/Content/Source/Informatics/BS/FileFormat_FASTQ-files_swBS.htm>.
     ///
     /// An old-style Casava (<1.8) `/1` / `/2` read-number suffix is stripped from
-    /// the returned name (see [`strip_read_number_suffix`]) so both mates of a pair
-    /// share an identical QNAME, matching fgbio's `FastqSource`. Stripping happens
-    /// before UMI extraction so a read-number digit never leaks into the UMI.
+    /// the returned name (see [`strip_read_suffix`](crate::fastq_parse::strip_read_suffix))
+    /// so both mates of a pair share an identical QNAME, matching fgbio's `FastqSource`.
+    /// Stripping happens before UMI extraction so a read-number digit never leaks into the UMI.
     ///
     /// Some demultiplexers fold additional information (e.g. the sample index) into
     /// the colon-separated portion of the read name, producing names with 9+ fields
@@ -762,15 +763,13 @@ impl Extract {
         // Remove @ prefix if present
         let name_bytes = if header.starts_with(b"@") { &header[1..] } else { header };
 
-        // Split on space to get just the name part
-        let name_part = name_bytes.find_byte(b' ').map_or(name_bytes, |pos| &name_bytes[..pos]);
-
-        // Strip an old-style Casava (<1.8) `/1` / `/2` read-number suffix so both
-        // mates of a pair share an identical QNAME (required by the SAM spec).
-        // Matches fgbio's `FastqSource`: only `/` followed by a single digit is
-        // removed. Done before UMI extraction so the digit never leaks into the
-        // UMI's trailing `:` field.
-        let name_part = strip_read_number_suffix(name_part);
+        // Strip a trailing space comment and an old-style Casava (<1.8) `/1` / `/2`
+        // read-number suffix so both mates of a pair share an identical QNAME (required by
+        // the SAM spec). Matches fgbio's `FastqSource`: only `/` followed by a single digit
+        // is removed. Done before UMI extraction so a read-number digit never leaks into the
+        // UMI's trailing `:` field. This is the shared helper the paired-FASTQ sync
+        // validation also uses, keeping the written QNAME and validation in lock-step.
+        let name_part = strip_read_suffix(name_bytes);
 
         if !extract_umis {
             return Ok((name_part.to_vec(), None));
@@ -881,14 +880,14 @@ impl Extract {
         };
 
         // Strip space comments and /1, /2 suffixes for comparison
-        let first_name_part = strip_read_suffix_extract(first_name);
+        let first_name_part = strip_read_suffix(first_name);
 
         // Check that all other read sets have the same name
         for (i, read_set) in read_sets.iter().enumerate().skip(1) {
             let header = &read_set.header;
             let name = if header.starts_with(b"@") { &header[1..] } else { header.as_slice() };
 
-            let name_part = strip_read_suffix_extract(name);
+            let name_part = strip_read_suffix(name);
 
             if name_part != first_name_part {
                 bail!(
@@ -1171,9 +1170,9 @@ impl Extract {
 
                 // Validate read names match (synchronized mode defers this from Group step)
                 if template.records.len() >= 2 {
-                    let base_name = strip_read_suffix_extract(template.records[0].name());
+                    let base_name = strip_read_suffix(template.records[0].name());
                     for (i, record) in template.records.iter().enumerate().skip(1) {
-                        let other_base = strip_read_suffix_extract(record.name());
+                        let other_base = strip_read_suffix(record.name());
                         if base_name != other_base {
                             return Err(std::io::Error::new(
                                 std::io::ErrorKind::InvalidData,
@@ -1487,51 +1486,6 @@ impl Command for Extract {
         timer.log_completion(records_written);
         Ok(())
     }
-}
-
-/// Strip an old-style Casava (<1.8) `/<digit>` read-number suffix from a read name.
-///
-/// This is applied to the QNAME written to the unmapped BAM, mirroring fgbio's
-/// `FastqSource` header parsing: only a trailing `/` followed by a single digit is
-/// removed (e.g. `read/1` -> `read`). Stripping is intentionally conservative — `.`, `_`,
-/// and `:` are never treated as read-number separators because they can appear in
-/// legitimate read names (e.g. `sample_1`), so stripping them from the written QNAME could
-/// corrupt data. [`strip_read_suffix_extract`] applies this same suffix logic (after also
-/// stripping a trailing space comment) when validating that read names match across
-/// synchronized FASTQs, keeping validation and the written QNAME in lock-step.
-///
-/// Returns a slice of `name` without the suffix, or `name` unchanged if it has no
-/// `/<digit>` suffix.
-fn strip_read_number_suffix(name: &[u8]) -> &[u8] {
-    if name.len() >= 2 {
-        let last = name[name.len() - 1];
-        let sep = name[name.len() - 2];
-        if sep == b'/' && last.is_ascii_digit() {
-            return &name[..name.len() - 2];
-        }
-    }
-    name
-}
-
-/// Strip a trailing space comment and an old-style `/<digit>` read-number suffix from a
-/// read name, for validating that reads match across synchronized FASTQs.
-///
-/// This mirrors the QNAME write path (see [`strip_read_number_suffix`]) so that any pair
-/// of names accepted by validation is guaranteed to be written with an identical BAM
-/// QNAME. Only `/` followed by a single digit is treated as a read-number suffix; `.`,
-/// `_`, and `:` separators are preserved because they can appear in legitimate read names
-/// (e.g. `sample_1`), matching fgbio's `FastqSource`. Narrowing this to `/` alone keeps
-/// validation and the written QNAME in lock-step: a `read_1`/`read_2` pair is now
-/// correctly reported as out of sync rather than passing validation and being written
-/// with two different QNAMEs.
-///
-/// Returns a slice of `name` without the comment or read-number suffix.
-fn strip_read_suffix_extract(name: &[u8]) -> &[u8] {
-    // First strip any space-separated comment suffix (e.g., "read/1 extra" -> "read/1").
-    let name = name.iter().position(|&b| b == b' ').map_or(name, |pos| &name[..pos]);
-
-    // Then strip the same conservative `/<digit>` read-number suffix as the write path.
-    strip_read_number_suffix(name)
 }
 
 /// Returns true if `b` is a valid SAM UMI character (`ACGTN-`), matching fgbio's
@@ -2645,49 +2599,6 @@ mod tests {
         assert_eq!(umi, Some(b"ACGT".to_vec()));
     }
 
-    #[rstest]
-    // Strips a trailing `/<digit>` read-number suffix, matching the write path.
-    #[case::slash_one(b"read/1".as_slice(), b"read".as_slice())]
-    #[case::slash_two(b"read/2".as_slice(), b"read".as_slice())]
-    #[case::slash_any_digit(b"read/3".as_slice(), b"read".as_slice())]
-    // Strips a trailing space comment (before the read-number suffix).
-    #[case::space_comment(b"read 1:N:0:ACGT".as_slice(), b"read".as_slice())]
-    #[case::space_comment_then_slash(b"read/1 1:N:0:ACGT".as_slice(), b"read".as_slice())]
-    // Preserves `.`/`_`/`:` separators — they are not read-number delimiters and can
-    // appear in legitimate names, so validation must keep them (in lock-step with the
-    // write path, which also preserves them).
-    #[case::underscore(b"sample_1".as_slice(), b"sample_1".as_slice())]
-    #[case::dot(b"foo.2".as_slice(), b"foo.2".as_slice())]
-    #[case::colon(b"bar:1".as_slice(), b"bar:1".as_slice())]
-    // Preserves a multi-digit or non-digit `/` suffix.
-    #[case::slash_multi_digit(b"read/12".as_slice(), b"read/12".as_slice())]
-    #[case::slash_non_digit(b"read/x".as_slice(), b"read/x".as_slice())]
-    fn test_strip_read_suffix_extract(#[case] name: &[u8], #[case] expected: &[u8]) {
-        assert_eq!(strip_read_suffix_extract(name), expected);
-    }
-
-    proptest::proptest! {
-        /// Validation and the written QNAME must agree on the read-number suffix so that
-        /// any pair accepted by validation is written with an identical QNAME.
-        /// `strip_read_suffix_extract` first strips a trailing space comment, then delegates
-        /// to `strip_read_number_suffix`, so for any input *without* a space the two helpers
-        /// must return the identical slice. Generating arbitrary byte strings (not just
-        /// UTF-8) exercises trailing slashes, embedded digits, `.`/`_`/`:` separators, empty
-        /// names, and multi-byte edge cases that a fixed table misses.
-        #[test]
-        fn test_strip_read_suffix_extract_matches_write_path(
-            name in proptest::collection::vec(0u8..=255, 0..20),
-        ) {
-            // The invariant only holds for space-free inputs: the space-comment strip is the
-            // one step the write path performs separately before this helper is reached.
-            proptest::prop_assume!(!name.contains(&b' '));
-            proptest::prop_assert_eq!(
-                strip_read_suffix_extract(&name),
-                strip_read_number_suffix(&name),
-            );
-        }
-    }
-
     #[test]
     #[should_panic(expected = "Read names do not match")]
     fn test_extract_fails_on_underscore_read_number_suffix() {
@@ -2743,7 +2654,7 @@ mod tests {
         // as required by the SAM spec. Guards the wiring from
         // `extract_read_name_and_umi` through to the written BAM QNAME in both the
         // single-threaded (`make_raw_records`) and threaded
-        // (`make_raw_records_static` + `strip_read_suffix_extract`) record-building
+        // (`make_raw_records_static` + `strip_read_suffix`) record-building
         // paths.
         let tmp = TempDir::new().expect("failed to create temp dir");
         let r1 = create_fastq(&tmp, "r1.fq", &[("SRR001.1/1", "AAAAAAAAAA", "==========")]);

--- a/src/lib/fastq_parse.rs
+++ b/src/lib/fastq_parse.rs
@@ -489,6 +489,92 @@ mod tests {
         assert_eq!(leftover, b"@read2\nTG");
     }
 
+    // ------------------------------------------------------------------------
+    // Cross-parser behavioral parity.
+    //
+    // fgumi has two independent single-record FASTQ validators:
+    //
+    //   - `FastqRecord::from_slice` (this module) — used by `parse_fastq_records` and,
+    //     transitively, by the `unified_pipeline` FASTQ parser, whose
+    //     `parse_single_fastq_record` delegates to `from_slice`.
+    //   - `fgumi_simd_fastq::try_parse_single_record` — the fallible core behind the SIMD
+    //     `parse_records` scan and the streaming `SimdFastqReader`.
+    //
+    // Both take a single framed record slice and must agree: either both accept it and
+    // return the identical name/sequence/quality, or both reject it as malformed. The
+    // helpers below normalize each result to `Option<(name, seq, qual)>` so a single
+    // shared case table (and the fuzz test that follows it) can drive both parsers and
+    // assert they never diverge as either implementation evolves.
+    // ------------------------------------------------------------------------
+
+    /// Normalize `FastqRecord::from_slice` to `Some((name, seq, qual))` / `None`.
+    fn from_slice_outcome(input: &[u8]) -> Option<(Vec<u8>, Vec<u8>, Vec<u8>)> {
+        FastqRecord::from_slice(input)
+            .ok()
+            .map(|r| (r.name().to_vec(), r.sequence().to_vec(), r.quality().to_vec()))
+    }
+
+    /// Normalize `fgumi_simd_fastq::try_parse_single_record` to `Some((name, seq, qual))` / `None`.
+    fn simd_outcome(input: &[u8]) -> Option<(Vec<u8>, Vec<u8>, Vec<u8>)> {
+        fgumi_simd_fastq::try_parse_single_record(input)
+            .ok()
+            .map(|r| (r.name.to_vec(), r.sequence.to_vec(), r.quality.to_vec()))
+    }
+
+    /// One shared case table run through both validators. Each case's `expected` is
+    /// `Some((name, seq, qual))` for a well-formed record or `None` for a record both
+    /// parsers must reject. Cases marked below consolidate scenarios that previously lived
+    /// in only one parser's own test suite.
+    #[rstest]
+    // Well-formed: trailing newline, no trailing newline (fastq_parse-only before),
+    // single-base read (SIMD-only before), empty seq+qual, empty name, and a name that
+    // itself contains a space and a `/1` (validators must preserve the raw name verbatim —
+    // read-name canonicalization is a separate concern, see `strip_read_suffix`).
+    #[case::simple(b"@r\nACGT\n+\nIIII\n", Some((b"r".as_slice(), b"ACGT".as_slice(), b"IIII".as_slice())))]
+    #[case::no_trailing_newline(b"@r\nACGT\n+\nIIII", Some((b"r".as_slice(), b"ACGT".as_slice(), b"IIII".as_slice())))]
+    #[case::single_base(b"@r\nA\n+\nI\n", Some((b"r".as_slice(), b"A".as_slice(), b"I".as_slice())))]
+    #[case::empty_seq_and_qual(b"@r\n\n+\n\n", Some((b"r".as_slice(), b"".as_slice(), b"".as_slice())))]
+    #[case::empty_name(b"@\nACGT\n+\nIIII\n", Some((b"".as_slice(), b"ACGT".as_slice(), b"IIII".as_slice())))]
+    #[case::name_with_space_and_slash(b"@a b/1\nACGT\n+\nIIII", Some((b"a b/1".as_slice(), b"ACGT".as_slice(), b"IIII".as_slice())))]
+    // Malformed: both validators must reject.
+    #[case::empty(b"", None)]
+    #[case::missing_at(b"r\nACGT\n+\nIIII\n", None)]
+    #[case::missing_plus(b"@r\nACGT\nx\nIIII\n", None)]
+    #[case::length_mismatch(b"@r\nACGT\n+\nII\n", None)]
+    // Length mismatch at EOF with no trailing newline (fastq_parse-only before).
+    #[case::length_mismatch_no_trailing_newline(b"@r\nACGT\n+\nIII", None)]
+    // Third newline is the final byte: no quality line at all (the underflow guard case;
+    // SIMD-only before, and previously a debug-build panic in `from_slice`).
+    #[case::missing_quality_line(b"@r\nAC\n+\n", None)]
+    #[case::too_few_lines(b"@r\nACGT\n", None)]
+    fn test_record_validator_parity(
+        #[case] input: &[u8],
+        #[case] expected: Option<(&[u8], &[u8], &[u8])>,
+    ) {
+        let from_slice = from_slice_outcome(input);
+        let simd = simd_outcome(input);
+
+        // The two independent validators must agree with each other ...
+        assert_eq!(from_slice, simd, "from_slice and SIMD disagree on {input:?}");
+        // ... and with the expected outcome.
+        let expected = expected.map(|(n, s, q)| (n.to_vec(), s.to_vec(), q.to_vec()));
+        assert_eq!(from_slice, expected, "unexpected parse result for {input:?}");
+    }
+
+    proptest::proptest! {
+        /// The two validators must agree on *every* input, not just the curated table:
+        /// for any byte slice, `from_slice` and the SIMD parser must both accept it
+        /// (returning identical name/sequence/quality) or both reject it, and neither may
+        /// panic. Fuzzing arbitrary bytes exercises adversarial framing — records ending
+        /// right after the `+` line, embedded/duplicated newlines, empty lines — that a
+        /// fixed table cannot enumerate. This generalizes the SIMD crate's own
+        /// `try_parse_single_record` never-panics fuzz test to a two-parser agreement check.
+        #[test]
+        fn test_record_validator_parity_fuzz(input in proptest::collection::vec(0u8..=255, 0..64)) {
+            proptest::prop_assert_eq!(from_slice_outcome(&input), simd_outcome(&input));
+        }
+    }
+
     #[rstest]
     // A trailing '/' + single digit is stripped (any digit, fgbio parity).
     #[case::slash_one(b"read/1", b"read")]


### PR DESCRIPTION
## Summary

Follow-on to #512. Two related pieces of cleanup around FASTQ read-name and record handling:

1. **Consolidate the extract command's read-name suffix stripping onto the shared helper.** `extract.rs` carried two private helpers — `strip_read_number_suffix` (QNAME write path) and `strip_read_suffix_extract` (paired-FASTQ sync validation) — that both implemented the same rule the shared `fastq_parse::strip_read_suffix` now provides (strip a trailing space comment, then a trailing `/` + single ASCII digit; preserve `.`/`_`/`:` separators and multi-digit runs, matching fgbio `FastqSource`). All five call sites now use `strip_read_suffix`, and the two duplicated helpers are deleted. This is the follow-up #512 explicitly deferred.

2. **Pin the two independent FASTQ record validators to identical behavior, and fix a divergence found while doing so.** fgumi has two independent single-record validators: `fastq_parse::FastqRecord::from_slice` (used by `parse_fastq_records` and, transitively, by the `unified_pipeline` parser, whose `parse_single_fastq_record` delegates to it) and the SIMD crate's `try_parse_single_record` (behind `parse_records` and `SimdFastqReader`). Nothing tied them to the same behavior, and they had diverged on one input.

## The divergence (fixed)

A record whose third newline is its final byte — no quality line at all, e.g. `@r\nAC\n+\n` — was handled inconsistently:

- SIMD `try_parse_single_record`: returns a clean `FastqParseError::TooFewLines`.
- `FastqRecord::from_slice`: computed `qual_end - qual_start` unguarded, where `qual_start > qual_end`. That underflows — a **debug-build panic**, and a **misleading length-mismatch error** in release.

`from_slice` documents `# Errors` for malformed input (a panic violates that contract). This PR adds a guard that rejects the record as malformed, matching the SIMD parser. In production, framing never hands `from_slice` such a slice (complete records always have four newlines), so this is a latent-robustness fix, not a data-path behavior change.

## Cross-parser parity test

Adds a shared behavioral-parity test in `fastq_parse`: one `#[rstest]` case table plus a proptest run identical inputs through **both** validators and assert they agree — either both accept with identical name/sequence/quality, or both reject. The table folds in scenarios that previously lived in only one parser's own suite:

- SIMD-only before: single-base read; no-quality-line reject.
- fastq_parse-only before: no-trailing-newline accept; length-mismatch-at-EOF reject.

The proptest generalizes the SIMD crate's own `try_parse_single_record` never-panics fuzz property into a two-parser **agreement** check over arbitrary bytes.

To let the parity test call the SIMD validator directly (the apples-to-apples comparison with `from_slice`, without stream-framing confounds), `try_parse_single_record` is promoted from `pub(crate)` to `pub` and re-exported from the crate root.

## Notes

- No production behavior change for standard FASTQs; the consolidation is a pure de-duplication (an existing proptest already asserted the two extract helpers agreed), and the `from_slice` guard only affects a malformed slice that framing never produces.
- `unified_pipeline`'s record validator is covered transitively — it delegates to `from_slice`.

## Reading order

1. `src/lib/commands/extract.rs` — the consolidation (piece 1).
2. `src/lib/fastq_parse.rs` — the `from_slice` guard + the shared parity table/proptest (piece 2).
3. `crates/fgumi-simd-fastq/src/{parser.rs,lib.rs}` — expose `try_parse_single_record`.

## Testing

- `cargo nextest run --workspace --features compare,simulate,profile-adjacency` — 4288 passed, 0 failed.
- `cargo ci-fmt`, `cargo ci-lint` (`-D warnings -W clippy::pedantic`), `cargo ci-tag-literals` — clean.