### PR TITLE
docs: fix stale doctest crate paths in consensus/umi and gate doctests in CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,6 +3,8 @@ ci-test = "nextest run --workspace --features compare,simulate,profile-adjacency
 ci-fmt = "fmt --all -- --check"
 ci-lint = "clippy --workspace --all-targets --features compare,simulate,profile-adjacency -- -D warnings -W clippy::pedantic"
 ci-tag-literals = "run --package xtask -- check-tag-literals"
+# Run documentation tests (nextest does not run doctests, so ci-test skips them)
+ci-doctest = "test --doc --workspace --features compare,simulate,profile-adjacency --locked"
 # Run tests with test-utils feature enabled (allows binary tests to use library test utilities)
 t = "test --features test-utils"
 # Generate and serve documentation locally (runs xtask then mdbook serve)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,7 +28,9 @@ jobs:
           tool: nextest
       - name: Unit tests
         run: cargo ci-test
-  
+      - name: Doctests
+        run: cargo ci-doctest
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/crates/fgumi-consensus/src/base_builder.rs
+++ b/crates/fgumi-consensus/src/base_builder.rs
@@ -106,7 +106,7 @@
 //! Consensus callers typically use `ConsensusBaseBuilder` as follows:
 //!
 //! ```rust,ignore
-//! use fgumi_lib::consensus::base_builder::ConsensusBaseBuilder;
+//! use fgumi_consensus::base_builder::ConsensusBaseBuilder;
 //!
 //! // Create builder with error rates
 //! let mut builder = ConsensusBaseBuilder::new(
@@ -182,7 +182,7 @@
 //!
 //! ## See Also
 //!
-//! - `vanilla_consensus_caller`: Uses this builder to call consensus across entire reads
+//! - `vanilla_caller`: Uses this builder to call consensus across entire reads
 //! - `duplex_caller`: Uses this builder for single-strand consensus before duplex combination
 //! - `phred`: Utility functions for Phred score and probability conversions
 

--- a/crates/fgumi-consensus/src/caller.rs
+++ b/crates/fgumi-consensus/src/caller.rs
@@ -87,7 +87,7 @@
 //! To implement a custom consensus caller, implement the `ConsensusCaller` trait:
 //!
 //! ```rust,ignore
-//! use fgumi_lib::consensus::caller::{ConsensusCaller, ConsensusCallingStats, ConsensusOutput};
+//! use fgumi_consensus::caller::{ConsensusCaller, ConsensusCallingStats, ConsensusOutput};
 //! use fgumi_raw_bam::RawRecord;
 //! use anyhow::Result;
 //!
@@ -120,8 +120,8 @@
 //! ### Basic Consensus Calling
 //!
 //! ```rust,ignore
-//! use fgumi_lib::consensus::vanilla_consensus_caller::VanillaUmiConsensusCaller;
-//! use fgumi_lib::consensus::caller::ConsensusCaller;
+//! use fgumi_consensus::vanilla_caller::VanillaUmiConsensusCaller;
+//! use fgumi_consensus::caller::ConsensusCaller;
 //! use fgumi_raw_bam::RawRecord;
 //!
 //! // Create consensus caller
@@ -156,7 +156,7 @@
 //!
 //! ## See Also
 //!
-//! - `vanilla_consensus_caller`: Standard single-strand consensus implementation
+//! - `vanilla_caller`: Standard single-strand consensus implementation
 //! - `duplex_caller`: Two-stage consensus for duplex sequencing
 //! - `base_builder`: Core likelihood-based consensus base calling logic
 

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -41,7 +41,7 @@
 //! ## Usage Example
 //!
 //! ```rust,ignore
-//! use fgumi_lib::consensus::codec_caller::{CodecConsensusCaller, CodecConsensusOptions};
+//! use fgumi_consensus::codec_caller::{CodecConsensusCaller, CodecConsensusOptions};
 //!
 //! let options = CodecConsensusOptions {
 //!     min_reads_per_strand: 1,

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -126,8 +126,8 @@
 //! ## Usage Example
 //!
 //! ```rust,ignore
-//! use fgumi_lib::consensus::duplex_caller::DuplexConsensusCaller;
-//! use fgumi_lib::consensus::caller::ConsensusCaller;
+//! use fgumi_consensus::duplex_caller::DuplexConsensusCaller;
+//! use fgumi_consensus::caller::ConsensusCaller;
 //!
 //! // Create duplex consensus caller
 //! let mut caller = DuplexConsensusCaller::new(
@@ -182,7 +182,7 @@
 //!
 //! ## See Also
 //!
-//! - `vanilla_consensus_caller`: Single-strand consensus calling used in Stage 1
+//! - `vanilla_caller`: Single-strand consensus calling used in Stage 1
 //! - `caller`: Base consensus calling infrastructure and trait definitions
 //! - `base_builder`: Likelihood-based consensus algorithm for individual bases
 

--- a/crates/fgumi-consensus/src/phred.rs
+++ b/crates/fgumi-consensus/src/phred.rs
@@ -47,7 +47,7 @@ pub type LogProbability = f64;
 ///
 /// # Examples
 /// ```
-/// use fgumi_lib::phred::phred_to_ln_error_prob;
+/// use fgumi_consensus::phred::phred_to_ln_error_prob;
 ///
 /// // Q10 corresponds to 10% error rate
 /// let ln_error = phred_to_ln_error_prob(10);
@@ -74,7 +74,7 @@ pub fn phred_to_ln_error_prob(phred: PhredScore) -> LogProbability {
 ///
 /// # Examples
 /// ```
-/// use fgumi_lib::phred::phred_to_ln_correct_prob;
+/// use fgumi_consensus::phred::phred_to_ln_correct_prob;
 ///
 /// // Q30 = 0.1% error, so 99.9% correct
 /// let ln_correct = phred_to_ln_correct_prob(30);
@@ -100,7 +100,7 @@ pub fn phred_to_ln_correct_prob(phred: PhredScore) -> LogProbability {
 ///
 /// # Examples
 /// ```
-/// use fgumi_lib::phred::ln_prob_to_phred;
+/// use fgumi_consensus::phred::ln_prob_to_phred;
 ///
 /// // 1% error (0.01) corresponds to Q20
 /// let phred = ln_prob_to_phred(0.01_f64.ln());
@@ -234,7 +234,7 @@ fn ln_a_minus_b(a: f64, b: f64) -> f64 {
 ///
 /// # Examples
 /// ```
-/// use fgumi_lib::phred::ln_error_prob_two_trials;
+/// use fgumi_consensus::phred::ln_error_prob_two_trials;
 ///
 /// // If both trials have 10% error, combined error using 4/3 formula:
 /// // f(0.1, 0.1) = 0.1 + 0.1 - 4/3*0.1*0.1 = 0.2 - 0.0133... ≈ 0.1867
@@ -277,7 +277,7 @@ pub fn ln_error_prob_two_trials(ln_p1: LogProbability, ln_p2: LogProbability) ->
 ///
 /// # Examples
 /// ```
-/// use fgumi_lib::phred::ln_sum_exp;
+/// use fgumi_consensus::phred::ln_sum_exp;
 ///
 /// // ln(0.1) + ln(0.2) should give ln(0.3)
 /// let result = ln_sum_exp(0.1_f64.ln(), 0.2_f64.ln());
@@ -309,7 +309,7 @@ pub fn ln_sum_exp(ln_a: LogProbability, ln_b: LogProbability) -> LogProbability 
 ///
 /// # Examples
 /// ```
-/// use fgumi_lib::phred::ln_sum_exp_array;
+/// use fgumi_consensus::phred::ln_sum_exp_array;
 ///
 /// // ln(0.1) + ln(0.2) + ln(0.3) should give ln(0.6)
 /// let values = vec![0.1_f64.ln(), 0.2_f64.ln(), 0.3_f64.ln()];

--- a/crates/fgumi-consensus/src/sequence.rs
+++ b/crates/fgumi-consensus/src/sequence.rs
@@ -18,7 +18,7 @@
 /// # Example
 ///
 /// ```
-/// use fgumi_lib::consensus::ConsensusSequence;
+/// use fgumi_consensus::ConsensusSequence;
 ///
 /// let mut seq = ConsensusSequence::new();
 /// seq.push(b'A', 30, 10, 0);

--- a/crates/fgumi-umi/src/assigner.rs
+++ b/crates/fgumi-umi/src/assigner.rs
@@ -123,7 +123,7 @@
 //! ### Basic Usage - Identity Strategy
 //!
 //! ```
-//! use fgumi_lib::umi::assigner::{Strategy, UmiAssigner};
+//! use fgumi_umi::assigner::{Strategy, UmiAssigner};
 //!
 //! let strategy = Strategy::Identity;
 //! let assigner = strategy.new_assigner(0); // No mismatches allowed
@@ -145,7 +145,7 @@
 //! ### Error-Tolerant Assignment - Adjacency Strategy
 //!
 //! ```
-//! use fgumi_lib::umi::assigner::{Strategy, UmiAssigner};
+//! use fgumi_umi::assigner::{Strategy, UmiAssigner};
 //!
 //! let strategy = Strategy::Adjacency;
 //! let assigner = strategy.new_assigner(1); // Allow 1 mismatch
@@ -166,7 +166,7 @@
 //! ### Paired UMI Assignment - Duplex Sequencing
 //!
 //! ```
-//! use fgumi_lib::umi::assigner::{Strategy, UmiAssigner, TOP_STRAND_DUPLEX, BOTTOM_STRAND_DUPLEX};
+//! use fgumi_umi::assigner::{Strategy, UmiAssigner, TOP_STRAND_DUPLEX, BOTTOM_STRAND_DUPLEX};
 //!
 //! let strategy = Strategy::Paired;
 //! let assigner = strategy.new_assigner(1); // Allow 1 mismatch per UMI half
@@ -633,7 +633,7 @@ impl Strategy {
 /// # Examples
 ///
 /// ```
-/// use fgumi_lib::umi::assigner::count_mismatches;
+/// use fgumi_umi::assigner::count_mismatches;
 ///
 /// assert_eq!(count_mismatches("ACGT", "ACGT"), 0);
 /// assert_eq!(count_mismatches("ACGT", "ACTT"), 1);
@@ -723,7 +723,7 @@ fn assign_with_invalid_fallback(
 /// # Examples
 ///
 /// ```
-/// use fgumi_lib::umi::assigner::matches_within_threshold;
+/// use fgumi_umi::assigner::matches_within_threshold;
 ///
 /// assert!(matches_within_threshold("ACGT", "ACGT", 1));
 /// assert!(matches_within_threshold("ACGT", "ACTT", 1));


### PR DESCRIPTION
## Problem

Several compiled doctests referenced `use fgumi_lib::...`, but the `consensus`, `phred`, and `umi` modules were long ago extracted from the monolithic `fgumi_lib` crate into standalone `fgumi-consensus` and `fgumi-umi` crates. Those crates don't depend on `fgumi_lib`, so every such doctest failed to compile with `error[E0433]: unresolved crate fgumi_lib`.

These never turned CI red because **CI runs tests via `cargo nextest`, and nextest does not compile or run doctests** (both the `test` job's `cargo ci-test` and the `coverage` job use nextest). So the doctest rot was invisible.

## Fix

**1. Repoint the stale imports to the crates' own roots** (12 compiled doctests):

| Before | After | File |
|---|---|---|
| `fgumi_lib::phred::X` | `fgumi_consensus::phred::X` | `crates/fgumi-consensus/src/phred.rs` (6) |
| `fgumi_lib::consensus::ConsensusSequence` | `fgumi_consensus::ConsensusSequence` | `crates/fgumi-consensus/src/sequence.rs` (1) |
| `fgumi_lib::umi::assigner::X` | `fgumi_umi::assigner::X` | `crates/fgumi-umi/src/assigner.rs` (5) |

Doctests *inside* the `fgumi_lib` crate (`src/lib/...`, e.g. `logging`, `validation`, `simulate`) correctly reference `fgumi_lib::` as a self-reference and are left unchanged.

**2. Gate doctests in CI so this can't rot again.** Add a `ci-doctest` cargo alias (mirroring the other `ci-*` aliases) and run it as a new "Doctests" step in the `test` job, right after the nextest run, with the same feature set as `ci-test`.

## Verification

```
cargo ci-doctest   # test --doc --workspace --features compare,simulate,profile-adjacency --locked
# 87 doctests passed, 0 failed
```

`cargo ci-fmt` clean.

## Out of scope (noted follow-up)

The remaining `fgumi_lib::...` references live in `,ignore`-fenced module-level examples (the consensus caller-trait walkthroughs in `caller.rs`, `base_builder.rs`, `codec_caller.rs`, `duplex_caller.rs`). They are not compiled, so the new CI gate does not cover them, and some reference since-renamed symbols (e.g. `vanilla_consensus_caller` -> `vanilla_caller`) that need per-example verification. Fixing/​un-ignoring those is a separate docs pass.

## Context

Surfaced while validating #572 with a full `cargo test --workspace` (which does run doctests). Independent of that PR — this touches only `fgumi-consensus`, `fgumi-umi`, and CI config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples and references to use current module paths.
  * Corrected related documentation links and naming for consensus calling examples.
* **Tests**
  * Added a dedicated documentation-test step to the continuous integration test workflow, ensuring Rust documentation examples are validated separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->