### PR TITLE
docs+ci: fix broken intra-doc links and gate rustdoc in CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,6 +5,9 @@ ci-lint = "clippy --workspace --all-targets --features compare,simulate,profile-
 ci-tag-literals = "run --package xtask -- check-tag-literals"
 # Run documentation tests (nextest does not run doctests, so ci-test skips them)
 ci-doctest = "test --doc --workspace --features compare,simulate,profile-adjacency --locked"
+# Build the docs and fail on any rustdoc warning (e.g. broken intra-doc links).
+# RUSTDOCFLAGS="-D warnings" is set by the caller (CI job / pre-push).
+ci-doc = "doc --no-deps --workspace --features compare,simulate,profile-adjacency --locked"
 # Run tests with test-utils feature enabled (allows binary tests to use library test utilities)
 t = "test --features test-utils"
 # Generate and serve documentation locally (runs xtask then mdbook serve)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,12 @@ on:
       - main
   pull_request:
 
+# Every job here only checks out the repo and runs read-only build/test/lint
+# steps (the coverage upload authenticates with CODECOV_TOKEN, not the workflow
+# token), so drop the inherited GITHUB_TOKEN down to read-only for all of them.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -18,6 +24,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Set up compilation cache (sccache)
@@ -36,6 +44,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
@@ -52,6 +62,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Set up compilation cache (sccache)
@@ -78,6 +90,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
@@ -92,6 +106,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install cargo-audit
         uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
         with:
@@ -104,6 +120,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Set up compilation cache (sccache)
@@ -136,6 +154,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Set up compilation cache (sccache)
@@ -160,6 +180,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: rust-version matches the pinned toolchain
         # We support exactly the Rust we develop and test on: `rust-version`
         # (the published MSRV) is kept identical to the `channel` in
@@ -177,3 +199,23 @@ jobs:
             echo "::error::MSRV ($msrv) and pinned toolchain ($chan) have drifted; keep them in lockstep." >&2
             exit 1
           fi
+
+  docs:
+    runs-on: ubuntu-latest
+    # Turn every rustdoc warning (broken intra-doc links, private-item links,
+    # etc.) into a hard error. This gates doc *build* and link health; doctest
+    # *execution* (running the `///` examples) is a separate concern not covered
+    # here — nextest does not run doctests either.
+    env:
+      RUSTDOCFLAGS: "-D warnings"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Set up compilation cache (sccache)
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - name: Build documentation
+        run: cargo ci-doc

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -415,7 +415,7 @@ impl CodecConsensusCaller {
     /// Creates a new CODEC consensus caller with optional rejected-reads tracking.
     ///
     /// When `track_rejects` is `true`, raw BAM bytes of rejected reads are stored
-    /// and can be retrieved via [`rejected_reads`] / [`take_rejected_reads`].
+    /// and can be retrieved via [`Self::rejected_reads`] / [`Self::take_rejected_reads`].
     #[must_use]
     pub fn new_with_rejects_tracking(
         read_name_prefix: String,

--- a/crates/fgumi-raw-bam/src/cigar.rs
+++ b/crates/fgumi-raw-bam/src/cigar.rs
@@ -1029,7 +1029,7 @@ impl CigarOp {
 
     /// True if this op type consumes query bases (M, I, S, =, X).
     ///
-    /// Uses the [`BAM_CIGAR_TYPE`] bitmask for a branchless test.
+    /// Uses the `BAM_CIGAR_TYPE` bitmask for a branchless test.
     #[inline]
     #[must_use]
     pub fn consumes_query(self) -> bool {
@@ -1038,7 +1038,7 @@ impl CigarOp {
 
     /// True if this op type consumes reference bases (M, D, N, =, X).
     ///
-    /// Uses the [`BAM_CIGAR_TYPE`] bitmask for a branchless test.
+    /// Uses the `BAM_CIGAR_TYPE` bitmask for a branchless test.
     #[inline]
     #[must_use]
     pub fn consumes_ref(self) -> bool {

--- a/crates/fgumi-raw-bam/src/indexed_reader.rs
+++ b/crates/fgumi-raw-bam/src/indexed_reader.rs
@@ -91,7 +91,7 @@ impl<R: Read + Seek> IndexedRawBamReader<R> {
 impl<R: Read> IndexedRawBamReader<R> {
     /// Read (and consume) the BAM header.
     ///
-    /// Must be called exactly once before [`query`], because the header
+    /// Must be called exactly once before [`Self::query`], because the header
     /// encodes the reference-sequence dictionary needed to resolve region
     /// names to reference-sequence IDs.
     ///
@@ -118,7 +118,7 @@ impl<R: Read + Seek> IndexedRawBamReader<R> {
     ///
     /// - Seek or read failures.
     /// - The index has no `last_first_record_start_position` AND
-    ///   [`read_header`](Self::read_header) has not been called — without
+    ///   [`Self::read_header`](Self::read_header) has not been called — without
     ///   either, the first-record position is unknown and falling back to
     ///   BGZF offset 0 would attempt to parse the BAM header as a record.
     pub fn query_unmapped(&mut self) -> anyhow::Result<UnmappedIter<'_, R>> {
@@ -150,7 +150,7 @@ impl<R: Read + Seek> IndexedRawBamReader<R> {
     ///
     /// # Arguments
     ///
-    /// * `header` — SAM header obtained from [`read_header`]; used to
+    /// * `header` — SAM header obtained from [`Self::read_header`]; used to
     ///   resolve the region name to a reference-sequence ID.
     /// * `region` — Genomic region to query (e.g. `"chr1:100-200".parse()`).
     ///

--- a/crates/fgumi-raw-bam/src/noodles_compat.rs
+++ b/crates/fgumi-raw-bam/src/noodles_compat.rs
@@ -60,13 +60,13 @@ pub fn simplify_cigar_from_raw(
 /// field before the record payload.  This constant names that prefix so it can be stripped.
 const BLOCK_SIZE_PREFIX_LEN: usize = 4;
 
-/// Encode a single `RecordBuf` to raw BAM bytes and wrap in a [`RawRecord`].
+/// Encode a single `RecordBuf` to raw BAM bytes and wrap in a [`RawRecord`](crate::RawRecord).
 ///
 /// Uses noodles' BAM writer machinery writing to an in-memory buffer to produce
 /// the record's binary representation. The 4-byte `block_size` prefix written
 /// by the BAM framing protocol is stripped so the returned `RawRecord` contains
 /// only the record payload bytes (matching the layout of records produced by
-/// [`raw_records_to_record_bufs`] and consumed by [`RawRecord`] field accessors).
+/// [`raw_records_to_record_bufs`] and consumed by [`RawRecord`](crate::RawRecord) field accessors).
 ///
 /// # Errors
 ///
@@ -118,7 +118,7 @@ pub fn raw_record_to_record_buf(
 ///
 /// Holds a reference to the SAM header and an internal scratch `Vec<u8>` so
 /// that per-call allocations for the encoded output are avoided.  The scratch
-/// buffer is reused on every call to [`encode`] and [`encode_into`].
+/// buffer is reused on every call to [`RecordBufEncoder::encode`] and [`RecordBufEncoder::encode_into`].
 ///
 /// # Examples
 ///
@@ -142,10 +142,11 @@ impl<'h> RecordBufEncoder<'h> {
         Self { header, scratch: Vec::with_capacity(512) }
     }
 
-    /// Encode `buf` into a freshly-allocated [`RawRecord`].
+    /// Encode `buf` into a freshly-allocated [`RawRecord`](crate::RawRecord).
     ///
-    /// The internal scratch buffer is reused for the encoding step, so no
-    /// allocation is needed there.  The returned [`RawRecord`] owns its bytes.
+    /// The internal scratch buffer is reused for the encoding step and may grow
+    /// when a record exceeds its current capacity. The returned
+    /// [`RawRecord`](crate::RawRecord) owns its bytes.
     ///
     /// # Errors
     ///
@@ -171,7 +172,7 @@ impl<'h> RecordBufEncoder<'h> {
         Ok(crate::RawRecord::from(self.scratch[BLOCK_SIZE_PREFIX_LEN..].to_vec()))
     }
 
-    /// Encode `buf` into the caller-supplied `out` [`RawRecord`], replacing its
+    /// Encode `buf` into the caller-supplied `out` [`RawRecord`](crate::RawRecord), replacing its
     /// contents.
     ///
     /// Reuses both the internal scratch buffer and the storage inside `out` to

--- a/crates/fgumi-raw-bam/src/raw_bam_record.rs
+++ b/crates/fgumi-raw-bam/src/raw_bam_record.rs
@@ -67,7 +67,7 @@ impl RawRecord {
 
     /// Returns the allocated capacity of the underlying byte buffer.
     ///
-    /// Useful for memory-estimation purposes (e.g., [`MemoryEstimate`] implementations).
+    /// Useful for memory-estimation purposes (e.g., `MemoryEstimate` implementations).
     #[inline]
     #[must_use]
     pub fn capacity(&self) -> usize {

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -1003,7 +1003,7 @@ pub fn normalize_int_tag_to_smallest_signed(record: &mut Vec<u8>, tag: impl AsTa
 
 /// Append an integer tag using the smallest *signed* type that fits.
 ///
-/// Unlike [`append_int_tag`] (which prefers unsigned types), this uses only
+/// Unlike `append_int_tag` (which prefers unsigned types), this uses only
 /// signed types: `i8` (type `'c'`) -> `i16` (type `'s'`) -> `i32` (type `'i'`).
 /// This matches fgbio's `to_smallest_signed_int` encoding.
 #[inline]

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1640,7 +1640,7 @@ impl RawExternalSorter {
 
     /// Set the codec used for temporary chunk files.
     ///
-    /// Defaults to [`SpillCodec::Zstd`] which is significantly faster than
+    /// Defaults to [`SpillCodec::Zstd`](crate::codec::SpillCodec::Zstd) which is significantly faster than
     /// BGZF at comparable ratios for BAM-record data.
     #[must_use]
     pub fn spill_codec(mut self, codec: crate::codec::SpillCodec) -> Self {

--- a/src/lib/commands/simulate/common.rs
+++ b/src/lib/commands/simulate/common.rs
@@ -100,7 +100,7 @@ fn parse_noise_stddev(s: &str) -> Result<f64, String> {
 }
 
 impl QualityArgs {
-    /// Convert to a [`PositionQualityModel`].
+    /// Convert to a [`PositionQualityModel`](crate::simulate::PositionQualityModel).
     pub fn to_quality_model(&self) -> crate::simulate::PositionQualityModel {
         crate::simulate::PositionQualityModel::new(
             self.warmup_bases,
@@ -113,7 +113,7 @@ impl QualityArgs {
         )
     }
 
-    /// Convert to a [`ReadPairQualityBias`].
+    /// Convert to a [`ReadPairQualityBias`](crate::simulate::ReadPairQualityBias).
     pub fn to_quality_bias(&self) -> crate::simulate::ReadPairQualityBias {
         crate::simulate::ReadPairQualityBias::new(self.r2_quality_offset)
     }
@@ -140,7 +140,7 @@ pub struct InsertSizeArgs {
 }
 
 impl InsertSizeArgs {
-    /// Convert to an [`InsertSizeModel`].
+    /// Convert to an [`InsertSizeModel`](crate::simulate::InsertSizeModel).
     pub fn to_insert_size_model(&self) -> crate::simulate::InsertSizeModel {
         crate::simulate::InsertSizeModel::new(
             self.insert_size_mean,
@@ -180,7 +180,7 @@ pub struct FamilySizeArgs {
 }
 
 impl FamilySizeArgs {
-    /// Convert to a [`FamilySizeDistribution`].
+    /// Convert to a [`FamilySizeDistribution`](crate::simulate::FamilySizeDistribution).
     pub fn to_family_size_distribution(
         &self,
     ) -> anyhow::Result<crate::simulate::FamilySizeDistribution> {
@@ -214,7 +214,7 @@ pub struct StrandBiasArgs {
 }
 
 impl StrandBiasArgs {
-    /// Convert to a [`StrandBiasModel`].
+    /// Convert to a [`StrandBiasModel`](crate::simulate::StrandBiasModel).
     pub fn to_strand_bias_model(&self) -> crate::simulate::StrandBiasModel {
         crate::simulate::StrandBiasModel::new(self.strand_alpha, self.strand_beta)
     }

--- a/src/lib/fastq_parse.rs
+++ b/src/lib/fastq_parse.rs
@@ -193,7 +193,7 @@ enum FastqParseResult {
 /// Returns parsed records and leftover bytes for incomplete records.
 ///
 /// `at_eof` marks `data` as the complete, final input rather than one chunk of a
-/// stream. It is passed through to [`parse_single_fastq_record`]: only when
+/// stream. It is passed through to `parse_single_fastq_record`: only when
 /// `true` is a final record without a terminating newline accepted; when `false`
 /// such a tail is returned as leftover so an incremental caller (e.g.
 /// `FastqGrouper::add_bytes_for_stream`) can complete it with the next chunk.

--- a/src/lib/per_thread_accumulator.rs
+++ b/src/lib/per_thread_accumulator.rs
@@ -17,7 +17,7 @@
 //! pipeline completes, callers fold the slots into the final metric output.
 //!
 //! The slot index is assigned lazily from a process-wide atomic counter
-//! ([`SLOT_COUNTER`]) and cached in thread-local storage ([`THREAD_SLOT`]).
+//! (`SLOT_COUNTER`) and cached in thread-local storage (`THREAD_SLOT`).
 //! Indices are taken modulo the instance's slot count, so reused threads
 //! across test runs, or long-lived threads that touch multiple accumulators,
 //! remain correct — at worst two threads share a slot and merge under the same
@@ -100,7 +100,7 @@ impl<A: Default + Send> PerThreadAccumulator<A> {
 }
 
 /// Returns a process-wide unique index for the calling thread, lazily
-/// assigned from [`SLOT_COUNTER`] and cached in [`THREAD_SLOT`]. Callers map
+/// assigned from `SLOT_COUNTER` and cached in `THREAD_SLOT`. Callers map
 /// the index into their own slot range with modulo.
 #[inline]
 fn global_thread_index() -> usize {

--- a/src/lib/reference.rs
+++ b/src/lib/reference.rs
@@ -277,16 +277,16 @@ impl ReferenceReader {
         Ok(self.fetch_slice(chrom, start, end)?.to_vec())
     }
 
-    /// Borrowed-slice variant of [`fetch`] that returns a reference into the
+    /// Borrowed-slice variant of [`Self::fetch`] that returns a reference into the
     /// in-memory sequence — same lookup semantics, no allocation.
     ///
-    /// Prefer this over [`fetch`] in hot loops (e.g., per-record reference
+    /// Prefer this over [`Self::fetch`] in hot loops (e.g., per-record reference
     /// access in `fgumi zipper`'s `--restore-unconverted-bases` path) where
     /// allocating a fresh `Vec<u8>` per call adds up to gigabytes of churn.
     ///
     /// # Errors
     ///
-    /// Same as [`fetch`]: returns an error if the chromosome is missing or the
+    /// Same as [`Self::fetch`]: returns an error if the chromosome is missing or the
     /// requested region exceeds the sequence length.
     pub fn fetch_slice(&self, chrom: &str, start: Position, end: Position) -> Result<&[u8]> {
         let sequence = self


### PR DESCRIPTION
## Problem

`RUSTDOCFLAGS="-D warnings" cargo doc` fails on ~15 unresolved or private-item intra-doc links spread across four crates. They accumulated silently because **nothing in CI builds the docs** — the test/coverage jobs run `cargo nextest` (which doesn't run doctests), and there was no docs job. Same root cause as the doctest gap fixed in #573, one layer up (doc *links* rather than doctest *code*).

## Changes

**1. Fix the broken intra-doc links** (`docs:` commit) — repoint or demote each:
- **fgumi-raw-bam**: `[`RawRecord`]` → `[`RawRecord`](crate::RawRecord)`; `encode`/`encode_into` → `RecordBufEncoder::`; `query`/`read_header` → `Self::`; `MemoryEstimate` (downstream trait), `append_int_tag` (`pub(crate)`), `BAM_CIGAR_TYPE` (private const) → code spans.
- **fgumi-sort**: a `[`SpillCodec::Zstd`]` occurrence in a doc comment lacking the reference-link definition → inline path.
- **fgumi-consensus**: `rejected_reads`/`take_rejected_reads` → `Self::`.
- **fgumi (main)**: `simulate` model links → `crate::simulate::…`; `[`fetch`]` → `Self::fetch`; private `SLOT_COUNTER`/`THREAD_SLOT` → code spans.

**2. Gate rustdoc in CI** (`ci:` commit) — add a `ci-doc` alias and a `docs` job that runs `cargo doc --no-deps --workspace` with `RUSTDOCFLAGS="-D warnings"`, so any rustdoc warning (broken link, private-item link) fails the build going forward.

## Verification

- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --features compare,simulate,profile-adjacency` → clean.
- `cargo ci-fmt`, `cargo ci-lint`, `cargo ci-tag-literals` → clean.

## Note

This started as a broader CI-hardening pass. The MSRV half (correcting the declared `rust-version`) is **intentionally not here**: the declared `1.87.0` is false (deps `noodles`/`wide` force ≥1.89), but bumping it to the real floor unlocks ~85 MSRV-gated `collapsible_if` (let-chain) clippy warnings across the workspace that `-D warnings` would turn into errors. That needs its own decision (adopt let-chains vs. `allow` the lint) and PR, so it's decoupled to keep this one focused and green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved API documentation clarity and consistency across the project.
  * Corrected Rustdoc links and intra-doc references for easier navigation.
  * Clarified record encoding, buffer reuse, memory estimates, and simulation-related argument mappings.
  * Refined documentation for readers, sorting, tagging, and threading APIs.

* **Quality Improvements**
  * Added a documentation validation job that treats Rustdoc warnings as errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->