### PR TITLE
build(msrv)!: honest MSRV in lockstep with the toolchain + let-chain adoption

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -152,3 +152,26 @@ jobs:
         # (lib + tests + benches) with no default features to surface
         # regressions at PR time.
         run: cargo check --workspace --no-default-features --all-targets
+
+  msrv-lockstep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: rust-version matches the pinned toolchain
+        # We support exactly the Rust we develop and test on: `rust-version`
+        # (the published MSRV) is kept identical to the `channel` in
+        # rust-toolchain.toml. This fails if the two drift, so neither can be
+        # bumped without the other. Because every other job builds on the
+        # rust-toolchain.toml channel, keeping them equal means all of CI
+        # already verifies the MSRV builds -- no separate MSRV build job needed.
+        run: |
+          set -euo pipefail
+          msrv=$(grep -m1 -E '^rust-version' Cargo.toml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          chan=$(grep -m1 -E '^channel' rust-toolchain.toml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          echo "Cargo.toml rust-version = $msrv"
+          echo "rust-toolchain.toml channel = $chan"
+          if [ "$msrv" != "$chan" ]; then
+            echo "::error::MSRV ($msrv) and pinned toolchain ($chan) have drifted; keep them in lockstep." >&2
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,14 @@ Types: `feat`, `fix`, `build`, `chore`, `ci`, `config`, `docs`, `example`, `perf
 
 ## Rust Version
 
-Minimum: 1.87.0 (uses edition 2024)
+Minimum supported and pinned build version: 1.93.0 (edition 2024).
+
+fgumi supports exactly the Rust it is developed and tested on: `rust-version`
+in `Cargo.toml` (the published MSRV) is kept identical to the `channel` in
+`rust-toolchain.toml`, and CI's `msrv-lockstep` job fails if they drift. When
+raising the toolchain, bump `rust-version` in the same change and adopt any
+idioms the newer compiler unlocks (e.g. let-chains) rather than suppressing the
+clippy lints that flag them.
 
 ## Allocator
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 version = "0.4.0"
 edition = "2024"
-rust-version = "1.87.0"
+rust-version = "1.93.0"
 repository = "https://github.com/fulcrumgenomics/fgumi"
 license = "MIT"
 

--- a/crates/fgumi-bam-io/src/prefetch_reader.rs
+++ b/crates/fgumi-bam-io/src/prefetch_reader.rs
@@ -377,10 +377,10 @@ impl Drop for PrefetchReader {
         // guarantee no leak.
         self.rx = None;
         self.current = None;
-        if let Some(handle) = self.handle.take() {
-            if handle.join().is_err() {
-                log::debug!("fgumi-prefetch producer thread panicked during shutdown");
-            }
+        if let Some(handle) = self.handle.take()
+            && handle.join().is_err()
+        {
+            log::debug!("fgumi-prefetch producer thread panicked during shutdown");
         }
     }
 }

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -681,24 +681,24 @@ impl CodecConsensusCaller {
         }
 
         // Downsample if needed
-        if let Some(max_reads) = self.options.max_reads_per_strand {
-            if r1_infos.len() > max_reads {
-                let mut indices: Vec<usize> = (0..r1_infos.len()).collect();
-                indices.shuffle(&mut self.rng);
-                indices.truncate(max_reads);
-                indices.sort_unstable();
+        if let Some(max_reads) = self.options.max_reads_per_strand
+            && r1_infos.len() > max_reads
+        {
+            let mut indices: Vec<usize> = (0..r1_infos.len()).collect();
+            indices.shuffle(&mut self.rng);
+            indices.truncate(max_reads);
+            indices.sort_unstable();
 
-                let new_r1: Vec<_> = indices
-                    .iter()
-                    .map(|&i| std::mem::replace(&mut r1_infos[i], Self::dummy_info()))
-                    .collect();
-                let new_r2: Vec<_> = indices
-                    .iter()
-                    .map(|&i| std::mem::replace(&mut r2_infos[i], Self::dummy_info()))
-                    .collect();
-                r1_infos = new_r1;
-                r2_infos = new_r2;
-            }
+            let new_r1: Vec<_> = indices
+                .iter()
+                .map(|&i| std::mem::replace(&mut r1_infos[i], Self::dummy_info()))
+                .collect();
+            let new_r2: Vec<_> = indices
+                .iter()
+                .map(|&i| std::mem::replace(&mut r2_infos[i], Self::dummy_info()))
+                .collect();
+            r1_infos = new_r1;
+            r2_infos = new_r2;
         }
 
         // Phase 3: Filter to most common alignment on ClippedRecordInfo
@@ -1395,11 +1395,11 @@ impl CodecConsensusCaller {
         if let Some(cell_tag) = &self.options.cell_tag {
             let cell_tag_bytes: [u8; 2] = [cell_tag.as_ref()[0], cell_tag.as_ref()[1]];
             for raw in source_raws {
-                if let Some(cell_bc) = RawRecordView::new(raw).tags().find_string(cell_tag_bytes) {
-                    if !cell_bc.is_empty() {
-                        self.bam_builder.append_string_tag(cell_tag_bytes, cell_bc);
-                        break;
-                    }
+                if let Some(cell_bc) = RawRecordView::new(raw).tags().find_string(cell_tag_bytes)
+                    && !cell_bc.is_empty()
+                {
+                    self.bam_builder.append_string_tag(cell_tag_bytes, cell_bc);
+                    break;
                 }
             }
         }

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -1149,20 +1149,18 @@ impl DuplexConsensusCaller {
         builder.append_int_tag(SamTag::BM, ba_depth_min);
 
         // 7. Per-base BA tags if requested and BA strand exists
-        if produce_per_base_tags {
-            if let Some(ba) = ba_opt {
-                builder.append_string_tag(SamTag::BC_BASES, &ba.bases);
+        if produce_per_base_tags && let Some(ba) = ba_opt {
+            builder.append_string_tag(SamTag::BC_BASES, &ba.bases);
 
-                let ba_depths_i16: Vec<i16> =
-                    ba.depths.iter().map(|&d| i16::try_from(d).unwrap_or(i16::MAX)).collect();
-                builder.append_i16_array_tag(SamTag::BD_BASES, &ba_depths_i16);
+            let ba_depths_i16: Vec<i16> =
+                ba.depths.iter().map(|&d| i16::try_from(d).unwrap_or(i16::MAX)).collect();
+            builder.append_i16_array_tag(SamTag::BD_BASES, &ba_depths_i16);
 
-                let ba_errors_i16: Vec<i16> =
-                    ba.errors.iter().map(|&e| i16::try_from(e).unwrap_or(i16::MAX)).collect();
-                builder.append_i16_array_tag(SamTag::BE_BASES, &ba_errors_i16);
+            let ba_errors_i16: Vec<i16> =
+                ba.errors.iter().map(|&e| i16::try_from(e).unwrap_or(i16::MAX)).collect();
+            builder.append_i16_array_tag(SamTag::BE_BASES, &ba_errors_i16);
 
-                builder.append_phred33_string_tag(SamTag::BQ, &ba.quals);
-            }
+            builder.append_phred33_string_tag(SamTag::BQ, &ba.quals);
         }
 
         // 8. Duplex consensus tags (cD, cM, cE)
@@ -1248,21 +1246,21 @@ impl DuplexConsensusCaller {
                 builder.append_i16_array_tag(t_tag, &t_counts);
             }
 
-            if let Some(ba) = &consensus.ba_consensus {
-                if let Some(ba_annot) = &ba.methylation {
-                    if let Some(bm) = crate::methylation::build_mm_tag_no_ml(
-                        &ba.bases,
-                        ba_annot,
-                        false,
-                        methylation_mode,
-                    ) {
-                        builder.append_string_tag(SamTag::BM_BASES, bm.as_bytes());
-                    }
-                    let bu = ba_annot.unconverted_counts();
-                    let bt = ba_annot.converted_counts();
-                    builder.append_i16_array_tag(SamTag::BU, &bu);
-                    builder.append_i16_array_tag(SamTag::BT, &bt);
+            if let Some(ba) = &consensus.ba_consensus
+                && let Some(ba_annot) = &ba.methylation
+            {
+                if let Some(bm) = crate::methylation::build_mm_tag_no_ml(
+                    &ba.bases,
+                    ba_annot,
+                    false,
+                    methylation_mode,
+                ) {
+                    builder.append_string_tag(SamTag::BM_BASES, bm.as_bytes());
                 }
+                let bu = ba_annot.unconverted_counts();
+                let bt = ba_annot.converted_counts();
+                builder.append_i16_array_tag(SamTag::BU, &bu);
+                builder.append_i16_array_tag(SamTag::BT, &bt);
             }
 
             // Combined duplex methylation tags (MM/ML/cu/ct)

--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -521,10 +521,10 @@ pub fn filter_read(aux_data: &[u8], thresholds: &FilterThresholds) -> Result<Fil
     }
 
     // Check maximum error rate (cE tag — Float)
-    if let Some(error_rate) = error_rate {
-        if f64::from(error_rate) > thresholds.max_read_error_rate {
-            return Ok(FilterResult::ExcessiveErrorRate);
-        }
+    if let Some(error_rate) = error_rate
+        && f64::from(error_rate) > thresholds.max_read_error_rate
+    {
+        return Ok(FilterResult::ExcessiveErrorRate);
     }
 
     Ok(FilterResult::Pass)

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -758,11 +758,11 @@ impl VanillaUmiConsensusCaller {
 
     /// Downsamples reads if there are more than `max_reads`
     fn downsample_reads(&mut self, mut reads: Vec<RawRecord>) -> Vec<RawRecord> {
-        if let Some(max_reads) = self.options.max_reads {
-            if reads.len() > max_reads {
-                reads.shuffle(&mut self.rng);
-                reads.truncate(max_reads);
-            }
+        if let Some(max_reads) = self.options.max_reads
+            && reads.len() > max_reads
+        {
+            reads.shuffle(&mut self.rng);
+            reads.truncate(max_reads);
         }
         reads
     }
@@ -1423,12 +1423,12 @@ impl VanillaUmiConsensusCaller {
         self.bam_builder.append_string_tag(SamTag::MI, umi.as_bytes());
 
         // Cell barcode tag (if configured and present in original reads)
-        if let Some(cell_tag) = self.options.cell_tag {
-            if let Some(first_raw) = original_raws.first() {
-                let tag_bytes = [cell_tag.as_ref()[0], cell_tag.as_ref()[1]];
-                if let Some(value) = RawRecordView::new(first_raw).tags().find_string(tag_bytes) {
-                    self.bam_builder.append_string_tag(tag_bytes, value);
-                }
+        if let Some(cell_tag) = self.options.cell_tag
+            && let Some(first_raw) = original_raws.first()
+        {
+            let tag_bytes = [cell_tag.as_ref()[0], cell_tag.as_ref()[1]];
+            if let Some(value) = RawRecordView::new(first_raw).tags().find_string(tag_bytes) {
+                self.bam_builder.append_string_tag(tag_bytes, value);
             }
         }
 
@@ -2705,11 +2705,11 @@ mod tests {
                 };
 
                 // Merge with previous if same kind
-                if let Some((prev_kind, prev_len)) = ops.last_mut() {
-                    if *prev_kind == kind {
-                        *prev_len += len;
-                        continue;
-                    }
+                if let Some((prev_kind, prev_len)) = ops.last_mut()
+                    && *prev_kind == kind
+                {
+                    *prev_len += len;
+                    continue;
                 }
                 ops.push((kind, len));
             }

--- a/crates/fgumi-raw-bam/src/noodles_compat.rs
+++ b/crates/fgumi-raw-bam/src/noodles_compat.rs
@@ -41,11 +41,11 @@ pub fn simplify_cigar_from_raw(
         };
 
         // Coalesce adjacent operations of the same type
-        if let Some((last_kind, last_len)) = simplified.last_mut() {
-            if *last_kind == new_kind {
-                *last_len += op_len;
-                continue;
-            }
+        if let Some((last_kind, last_len)) = simplified.last_mut()
+            && *last_kind == new_kind
+        {
+            *last_len += op_len;
+            continue;
         }
 
         simplified.push((new_kind, op_len));

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -769,27 +769,27 @@ pub fn remove_tag(record: &mut Vec<u8>, tag: impl AsTagBytes) {
 pub fn update_string_tag(record: &mut Vec<u8>, tag: impl AsTagBytes, new_value: &[u8]) {
     let tag = tag.as_tag_bytes();
     let aux_start = aux_data_offset_from_record(record).unwrap_or(record.len());
-    if aux_start < record.len() {
-        if let Some((start, end)) = find_tag_bounds(&record[aux_start..], tag) {
-            let abs_start = aux_start + start;
-            let abs_end = aux_start + end;
-            let old_value_len = end - start - 4; // subtract tag(2) + type(1) + NUL(1)
-            if old_value_len == new_value.len() {
-                // Same length: overwrite value bytes in-place (no memmove)
-                let value_start = abs_start + 3; // skip tag(2) + type(1)
-                record[value_start..value_start + new_value.len()].copy_from_slice(new_value);
-            } else {
-                // Different length: splice replacement
-                let mut replacement = Vec::with_capacity(3 + new_value.len() + 1);
-                replacement.push(tag[0]);
-                replacement.push(tag[1]);
-                replacement.push(b'Z');
-                replacement.extend_from_slice(new_value);
-                replacement.push(0);
-                record.splice(abs_start..abs_end, replacement);
-            }
-            return;
+    if aux_start < record.len()
+        && let Some((start, end)) = find_tag_bounds(&record[aux_start..], tag)
+    {
+        let abs_start = aux_start + start;
+        let abs_end = aux_start + end;
+        let old_value_len = end - start - 4; // subtract tag(2) + type(1) + NUL(1)
+        if old_value_len == new_value.len() {
+            // Same length: overwrite value bytes in-place (no memmove)
+            let value_start = abs_start + 3; // skip tag(2) + type(1)
+            record[value_start..value_start + new_value.len()].copy_from_slice(new_value);
+        } else {
+            // Different length: splice replacement
+            let mut replacement = Vec::with_capacity(3 + new_value.len() + 1);
+            replacement.push(tag[0]);
+            replacement.push(tag[1]);
+            replacement.push(b'Z');
+            replacement.extend_from_slice(new_value);
+            replacement.push(0);
+            record.splice(abs_start..abs_end, replacement);
         }
+        return;
     }
     // Tag not found — append
     append_string_tag(record, tag, new_value);
@@ -804,21 +804,21 @@ pub fn update_string_tag(record: &mut Vec<u8>, tag: impl AsTagBytes, new_value: 
 pub fn update_int_tag(record: &mut Vec<u8>, tag: impl AsTagBytes, value: i32) {
     let tag = tag.as_tag_bytes();
     let aux_start = aux_data_offset_from_record(record).unwrap_or(record.len());
-    if aux_start < record.len() {
-        if let Some((start, end)) = find_tag_bounds(&record[aux_start..], tag) {
-            let abs_start = aux_start + start;
-            let abs_end = aux_start + end;
-            let val_type = record[abs_start + 2];
-            // If 4-byte integer type, overwrite in-place
-            if matches!(val_type, b'i' | b'I') && (abs_end - abs_start) == 7 {
-                record[abs_start + 3..abs_start + 7].copy_from_slice(&value.to_le_bytes());
-                return;
-            }
-            // Different size — remove and re-append
-            record.drain(abs_start..abs_end);
-            append_int_tag(record, tag, value);
+    if aux_start < record.len()
+        && let Some((start, end)) = find_tag_bounds(&record[aux_start..], tag)
+    {
+        let abs_start = aux_start + start;
+        let abs_end = aux_start + end;
+        let val_type = record[abs_start + 2];
+        // If 4-byte integer type, overwrite in-place
+        if matches!(val_type, b'i' | b'I') && (abs_end - abs_start) == 7 {
+            record[abs_start + 3..abs_start + 7].copy_from_slice(&value.to_le_bytes());
             return;
         }
+        // Different size — remove and re-append
+        record.drain(abs_start..abs_end);
+        append_int_tag(record, tag, value);
+        return;
     }
     // Tag not found — append
     append_int_tag(record, tag, value);

--- a/crates/fgumi-sam/src/clipper.rs
+++ b/crates/fgumi-sam/src/clipper.rs
@@ -397,12 +397,11 @@ impl SamRecordClipper {
         *record.cigar_mut() = CigarBuf::from(final_ops);
 
         // Update alignment start position
-        if ref_bases_clipped > 0 {
-            if let Some(start_pos) = record.alignment_start() {
-                if let Some(new_start) = Position::new(usize::from(start_pos) + ref_bases_clipped) {
-                    *record.alignment_start_mut() = Some(new_start);
-                }
-            }
+        if ref_bases_clipped > 0
+            && let Some(start_pos) = record.alignment_start()
+            && let Some(new_start) = Position::new(usize::from(start_pos) + ref_bases_clipped)
+        {
+            *record.alignment_start_mut() = Some(new_start);
         }
 
         // Handle sequence and quality updates based on mode
@@ -2585,11 +2584,11 @@ pub mod cigar_utils {
             };
 
             // Coalesce adjacent operations of the same type
-            if let Some((last_kind, last_len)) = simplified.last_mut() {
-                if *last_kind == new_kind {
-                    *last_len += len;
-                    continue;
-                }
+            if let Some((last_kind, last_len)) = simplified.last_mut()
+                && *last_kind == new_kind
+            {
+                *last_len += len;
+                continue;
             }
 
             simplified.push((new_kind, len));

--- a/crates/fgumi-sort/src/verify.rs
+++ b/crates/fgumi-sort/src/verify.rs
@@ -41,15 +41,15 @@ pub fn verify_sort_order<K>(
         let bam: &[u8] = &record_bytes;
         let key = extract_key(bam);
 
-        if let Some(ref prev) = prev_key {
-            if is_violation(&key, prev) {
-                violations += 1;
-                if first_violation.is_none() {
-                    let name =
-                        String::from_utf8_lossy(fgumi_raw_bam::RawRecordView::new(bam).read_name())
-                            .to_string();
-                    first_violation = Some((total_records, name));
-                }
+        if let Some(ref prev) = prev_key
+            && is_violation(&key, prev)
+        {
+            violations += 1;
+            if first_violation.is_none() {
+                let name =
+                    String::from_utf8_lossy(fgumi_raw_bam::RawRecordView::new(bam).read_name())
+                        .to_string();
+                first_violation = Some((total_records, name));
             }
         }
         prev_key = Some(key);

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -458,10 +458,10 @@ impl PermitPool {
 
     /// Release a permit back to the pool after a block has been written to disk.
     pub(crate) fn release(&self) {
-        if let Ok(guard) = self.tx.lock() {
-            if let Some(tx) = guard.as_ref() {
-                let _ = tx.try_send(());
-            }
+        if let Ok(guard) = self.tx.lock()
+            && let Some(tx) = guard.as_ref()
+        {
+            let _ = tx.try_send(());
         }
     }
 
@@ -1081,20 +1081,15 @@ impl SortWorkerPool {
             let owned_step = Self::exclusive_step_for(worker.worker_id, shared, current_phase);
 
             // 5. Try owned exclusive step first (prevents starvation)
-            if !did_work {
-                if let Some(step) = owned_step {
-                    if Self::is_step_eligible(step, shared, worker, current_phase) {
-                        let t0 = Instant::now();
-                        let result = Self::execute_step(shared, worker, step);
-                        if result == StepResult::Success {
-                            pstats.record_step(
-                                worker.worker_id,
-                                step,
-                                Self::nanos_u64(t0.elapsed()),
-                            );
-                            did_work = true;
-                        }
-                    }
+            if !did_work
+                && let Some(step) = owned_step
+                && Self::is_step_eligible(step, shared, worker, current_phase)
+            {
+                let t0 = Instant::now();
+                let result = Self::execute_step(shared, worker, step);
+                if result == StepResult::Success {
+                    pstats.record_step(worker.worker_id, step, Self::nanos_u64(t0.elapsed()));
+                    did_work = true;
                 }
             }
 

--- a/crates/xtask/src/generate_metrics.rs
+++ b/crates/xtask/src/generate_metrics.rs
@@ -81,14 +81,14 @@ fn parse_metric_structs(source: &str) -> Result<Vec<ParsedMetric>> {
         .items
         .iter()
         .filter_map(|item| {
-            if let syn::Item::Impl(impl_item) = item {
-                if let Some((_, trait_path, _)) = &impl_item.trait_ {
-                    let trait_name = trait_path.segments.last().map(|s| s.ident.to_string())?;
-                    if trait_name == "Metric" {
-                        if let syn::Type::Path(type_path) = impl_item.self_ty.as_ref() {
-                            return type_path.path.segments.last().map(|s| s.ident.to_string());
-                        }
-                    }
+            if let syn::Item::Impl(impl_item) = item
+                && let Some((_, trait_path, _)) = &impl_item.trait_
+            {
+                let trait_name = trait_path.segments.last().map(|s| s.ident.to_string())?;
+                if trait_name == "Metric"
+                    && let syn::Type::Path(type_path) = impl_item.self_ty.as_ref()
+                {
+                    return type_path.path.segments.last().map(|s| s.ident.to_string());
                 }
             }
             None
@@ -118,14 +118,12 @@ fn extract_doc_comments(attrs: &[syn::Attribute]) -> String {
     let lines: Vec<String> = attrs
         .iter()
         .filter_map(|attr| {
-            if attr.path().is_ident("doc") {
-                if let syn::Meta::NameValue(nv) = &attr.meta {
-                    if let syn::Expr::Lit(lit) = &nv.value {
-                        if let syn::Lit::Str(s) = &lit.lit {
-                            return Some(s.value());
-                        }
-                    }
-                }
+            if attr.path().is_ident("doc")
+                && let syn::Meta::NameValue(nv) = &attr.meta
+                && let syn::Expr::Lit(lit) = &nv.value
+                && let syn::Lit::Str(s) = &lit.lit
+            {
+                return Some(s.value());
             }
             None
         })

--- a/crates/xtask/src/generate_tools.rs
+++ b/crates/xtask/src/generate_tools.rs
@@ -120,12 +120,12 @@ fn collect_commands() -> Vec<CommandInfo> {
 /// Format: `\x1b[38;5;NNNm[CATEGORY]\x1b[0m \x1b[36mDescription\x1b[0m`
 fn parse_about(about: &str) -> (String, String) {
     let stripped = strip_ansi(about);
-    if stripped.starts_with('[') {
-        if let Some(end_bracket) = stripped.find(']') {
-            let category = stripped[1..end_bracket].to_string();
-            let description = stripped[end_bracket + 1..].trim().to_string();
-            return (category, description);
-        }
+    if stripped.starts_with('[')
+        && let Some(end_bracket) = stripped.find(']')
+    {
+        let category = stripped[1..end_bracket].to_string();
+        let description = stripped[end_bracket + 1..].trim().to_string();
+        return (category, description);
     }
     ("Uncategorized".to_string(), stripped)
 }

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -2,7 +2,7 @@
 
 ## Getting Started
 
-If you already have the Rust toolchain installed, make sure you have at least version `1.87.0` (e.g., with `rustup show` or `rustc --version`).
+If you already have the Rust toolchain installed, make sure you have at least version `1.93.0` (e.g., with `rustup show` or `rustc --version`).
 If not, you can run `rustup update` to install the latest version.
 
 If you do not have the Rust toolchain installed, the best way to install it is with [`rustup`](https://rustup.rs/) using the following command (which assumes that you have [`curl`](https://everything.curl.dev/get) installed):

--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -217,14 +217,14 @@ impl Command for Clip {
 
         // --metrics is not produced in --threads mode; fail fast rather than
         // silently dropping a user-requested output file.
-        if self.threading.threads.is_some() {
-            if let Some(path) = &self.metrics {
-                anyhow::bail!(
-                    "--metrics {} cannot be used with --threads: detailed clipping metrics \
+        if self.threading.threads.is_some()
+            && let Some(path) = &self.metrics
+        {
+            anyhow::bail!(
+                "--metrics {} cannot be used with --threads: detailed clipping metrics \
                      are only produced by the single-threaded path",
-                    path.display()
-                );
-            }
+                path.display()
+            );
         }
 
         // ========================================================================
@@ -373,14 +373,14 @@ impl Clip {
         info!("Templates with mate extension clipping: {total_clipped_mate_extension}");
 
         // Write metrics if requested
-        if let Some(metrics_path) = &self.metrics {
-            if let Some(mut metrics) = metrics_collection {
-                info!("Writing metrics to {}", metrics_path.display());
-                metrics.finalize();
-                let all_metrics = metrics.all_metrics().map(Clone::clone);
-                write_metrics_tsv(metrics_path, &all_metrics, "clipping")?;
-                info!("Metrics written successfully");
-            }
+        if let Some(metrics_path) = &self.metrics
+            && let Some(mut metrics) = metrics_collection
+        {
+            info!("Writing metrics to {}", metrics_path.display());
+            metrics.finalize();
+            let all_metrics = metrics.all_metrics().map(Clone::clone);
+            write_metrics_tsv(metrics_path, &all_metrics, "clipping")?;
+            info!("Metrics written successfully");
         }
 
         // Flush and finish the writer

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -533,10 +533,10 @@ impl Codec {
         if self.min_reads == 0 {
             bail!("min-reads must be >= 1");
         }
-        if let Some(max) = self.max_reads {
-            if max < self.min_reads {
-                bail!("max-reads ({}) must be >= min-reads ({})", max, self.min_reads);
-            }
+        if let Some(max) = self.max_reads
+            && max < self.min_reads
+        {
+            bail!("max-reads ({}) must be >= min-reads ({})", max, self.min_reads);
         }
 
         // Validate duplex length

--- a/src/lib/commands/compare/bams.rs
+++ b/src/lib/commands/compare/bams.rs
@@ -1290,10 +1290,10 @@ impl CompareBams {
 
             // Collect diff details (limited by max_diffs)
             for r in results {
-                if let Some(detail) = r.diff_detail {
-                    if stats.diff_details.len() < self.max_diffs {
-                        stats.diff_details.push(detail);
-                    }
+                if let Some(detail) = r.diff_detail
+                    && stats.diff_details.len() < self.max_diffs
+                {
+                    stats.diff_details.push(detail);
                 }
             }
 
@@ -1511,10 +1511,10 @@ impl CompareBams {
             stats.tag_order_diffs += tag_ord as u64;
 
             for r in results {
-                if let Some(detail) = r.diff_detail {
-                    if stats.diff_details.len() < self.max_diffs {
-                        stats.diff_details.push(detail);
-                    }
+                if let Some(detail) = r.diff_detail
+                    && stats.diff_details.len() < self.max_diffs
+                {
+                    stats.diff_details.push(detail);
                 }
             }
 
@@ -1764,20 +1764,20 @@ impl CompareBams {
 
                 if !r.name_match {
                     stats.order_mismatches += 1;
-                    if let Some(detail) = r.diff_detail {
-                        if diff_details.len() < self.max_diffs {
-                            diff_details.push(detail);
-                        }
+                    if let Some(detail) = r.diff_detail
+                        && diff_details.len() < self.max_diffs
+                    {
+                        diff_details.push(detail);
                     }
                     continue;
                 }
 
                 if !r.flag_match {
                     stats.flag_mismatches += 1;
-                    if let Some(detail) = r.diff_detail {
-                        if diff_details.len() < self.max_diffs {
-                            diff_details.push(detail);
-                        }
+                    if let Some(detail) = r.diff_detail
+                        && diff_details.len() < self.max_diffs
+                    {
+                        diff_details.push(detail);
                     }
                     continue;
                 }

--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -476,10 +476,10 @@ impl CorrectUmis {
         // Validate the input exists (stdin paths are exempt — the reader
         // streams them in a single pass).
         self.io.validate()?;
-        if let Some(min) = self.min_corrected {
-            if !(0.0..=1.0).contains(&min) {
-                bail!("--min-corrected must be between 0 and 1.");
-            }
+        if let Some(min) = self.min_corrected
+            && !(0.0..=1.0).contains(&min)
+        {
+            bail!("--min-corrected must be between 0 and 1.");
         }
         Ok(())
     }
@@ -725,14 +725,14 @@ impl CorrectUmis {
         let first_umi_bytes = fgumi_raw_bam::find_string_tag(first_aux, umi_tag);
 
         // If tag exists but is not a Z-type string, return an error
-        if first_umi_bytes.is_none() {
-            if let Some(tag_type) = fgumi_raw_bam::find_tag_type(first_aux, umi_tag) {
-                anyhow::bail!(
-                    "UMI tag {:?} exists but has non-string type '{}', expected 'Z'",
-                    std::str::from_utf8(&umi_tag).unwrap_or("??"),
-                    tag_type as char,
-                );
-            }
+        if first_umi_bytes.is_none()
+            && let Some(tag_type) = fgumi_raw_bam::find_tag_type(first_aux, umi_tag)
+        {
+            anyhow::bail!(
+                "UMI tag {:?} exists but has non-string type '{}', expected 'Z'",
+                std::str::from_utf8(&umi_tag).unwrap_or("??"),
+                tag_type as char,
+            );
         }
 
         for raw in &raw_records[1..] {
@@ -741,14 +741,14 @@ impl CorrectUmis {
 
             // Mirror the first-record check: reject any record whose UMI tag
             // exists with a non-string type instead of treating it as missing.
-            if current_umi_bytes.is_none() {
-                if let Some(tag_type) = fgumi_raw_bam::find_tag_type(aux, umi_tag) {
-                    anyhow::bail!(
-                        "UMI tag {:?} exists but has non-string type '{}', expected 'Z'",
-                        std::str::from_utf8(&umi_tag).unwrap_or("??"),
-                        tag_type as char,
-                    );
-                }
+            if current_umi_bytes.is_none()
+                && let Some(tag_type) = fgumi_raw_bam::find_tag_type(aux, umi_tag)
+            {
+                anyhow::bail!(
+                    "UMI tag {:?} exists but has non-string type '{}', expected 'Z'",
+                    std::str::from_utf8(&umi_tag).unwrap_or("??"),
+                    tag_type as char,
+                );
             }
 
             match (first_umi_bytes, current_umi_bytes) {
@@ -1278,11 +1278,9 @@ impl CorrectUmis {
                         // metric bucket (CorrectUmis.scala:199-202).
                         missing_umis += num_records;
 
-                        if track_rejects {
-                            if let Some(rw) = reject_writer.as_mut() {
-                                for raw in raw_records.drain(..) {
-                                    write_raw(rw, &raw)?;
-                                }
+                        if track_rejects && let Some(rw) = reject_writer.as_mut() {
+                            for raw in raw_records.drain(..) {
+                                write_raw(rw, &raw)?;
                             }
                         }
                     }
@@ -1329,11 +1327,9 @@ impl CorrectUmis {
                                 RejectionReason::None => {}
                             }
 
-                            if track_rejects {
-                                if let Some(rw) = reject_writer.as_mut() {
-                                    for raw in raw_records.drain(..) {
-                                        write_raw(rw, &raw)?;
-                                    }
+                            if track_rejects && let Some(rw) = reject_writer.as_mut() {
+                                for raw in raw_records.drain(..) {
+                                    write_raw(rw, &raw)?;
                                 }
                             }
                         }

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -410,14 +410,12 @@ fn filter_template(
             }
         }
 
-        if check_mq {
-            if let Some(mq) = found_mq {
-                // Compare as signed so a negative MQ (e.g., MQ:c:-1) fails the filter
-                // rather than wrapping to 255 via `as u8`.
-                if mq < i64::from(config.min_mapq) {
-                    metrics.discarded_poor_alignment += 1;
-                    return false;
-                }
+        if check_mq && let Some(mq) = found_mq {
+            // Compare as signed so a negative MQ (e.g., MQ:c:-1) fails the filter
+            // rather than wrapping to 255 via `as u8`.
+            if mq < i64::from(config.min_mapq) {
+                metrics.discarded_poor_alignment += 1;
+                return false;
             }
         }
 
@@ -433,11 +431,11 @@ fn filter_template(
                     return false;
                 }
                 UmiValidation::Valid(base_count) => {
-                    if let Some(min_len) = config.min_umi_length {
-                        if base_count < min_len {
-                            metrics.discarded_umi_too_short += 1;
-                            return false;
-                        }
+                    if let Some(min_len) = config.min_umi_length
+                        && base_count < min_len
+                    {
+                        metrics.discarded_umi_too_short += 1;
+                        return false;
                     }
                 }
             }

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -485,10 +485,10 @@ impl Command for Duplex {
 
             // Apply overlapping consensus if enabled (modifies raw bytes in-place)
             // Skip if group doesn't have both strands - no duplex possible anyway
-            if let Some(ref mut oc) = overlapping_caller {
-                if has_both_strands_raw(&records) {
-                    apply_overlapping_consensus(&mut records, oc)?;
-                }
+            if let Some(ref mut oc) = overlapping_caller
+                && has_both_strands_raw(&records)
+            {
+                apply_overlapping_consensus(&mut records, oc)?;
             }
 
             // Call consensus directly — records are already RawRecord values.
@@ -712,16 +712,14 @@ impl Duplex {
                 // Skip if group doesn't have both strands — no duplex possible anyway.
                 // Propagate errors to match single-threaded behavior; silent drops here
                 // would turn real failures into output gaps in --threads mode only.
-                if let Some(ref mut oc) = overlapping_caller {
-                    if has_both_strands_raw(&group_reads) {
-                        oc.reset_stats();
-                        apply_overlapping_consensus(&mut group_reads, oc).map_err(|e| {
-                            io::Error::other(format!(
-                                "Overlapping consensus error for MI {mi}: {e}"
-                            ))
-                        })?;
-                        batch_overlapping.merge(oc.stats());
-                    }
+                if let Some(ref mut oc) = overlapping_caller
+                    && has_both_strands_raw(&group_reads)
+                {
+                    oc.reset_stats();
+                    apply_overlapping_consensus(&mut group_reads, oc).map_err(|e| {
+                        io::Error::other(format!("Overlapping consensus error for MI {mi}: {e}"))
+                    })?;
+                    batch_overlapping.merge(oc.stats());
                 }
 
                 // Call duplex consensus directly — records are already RawRecord values.

--- a/src/lib/commands/extract.rs
+++ b/src/lib/commands/extract.rs
@@ -738,18 +738,14 @@ impl Extract {
         // before the UMI.
         let parts: Vec<&[u8]> = name_part.split(|&b| b == b':').collect();
 
-        if parts.len() >= 8 {
-            if let Some(last) = parts.last() {
-                if !last.is_empty() {
-                    let umi = Self::normalize_read_name_umi(last).with_context(|| {
-                        format!(
-                            "extracting UMI from read name '{}'",
-                            String::from_utf8_lossy(name_part)
-                        )
-                    })?;
-                    return Ok((name_part.to_vec(), Some(umi)));
-                }
-            }
+        if parts.len() >= 8
+            && let Some(last) = parts.last()
+            && !last.is_empty()
+        {
+            let umi = Self::normalize_read_name_umi(last).with_context(|| {
+                format!("extracting UMI from read name '{}'", String::from_utf8_lossy(name_part))
+            })?;
+            return Ok((name_part.to_vec(), Some(umi)));
         }
 
         Ok((name_part.to_vec(), None))

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -913,20 +913,19 @@ impl Filter {
         };
 
         // Conversion fraction filter (EM-Seq/TAPs read-level)
-        if pass {
-            if let Some(min_frac) = min_conversion_fraction {
-                if !check_conversion_fraction_raw_with_ref_bases_and_tags(
-                    record,
-                    min_frac,
-                    ref_base_map.as_deref(),
-                    methylation_tags
-                        .as_ref()
-                        .expect("methylation_tags set when conversion fraction enabled"),
-                    methylation_mode,
-                ) {
-                    pass = false;
-                }
-            }
+        if pass
+            && let Some(min_frac) = min_conversion_fraction
+            && !check_conversion_fraction_raw_with_ref_bases_and_tags(
+                record,
+                min_frac,
+                ref_base_map.as_deref(),
+                methylation_tags
+                    .as_ref()
+                    .expect("methylation_tags set when conversion fraction enabled"),
+                methylation_mode,
+            )
+        {
+            pass = false;
         }
 
         Ok((masked_count as u64, pass))
@@ -947,10 +946,10 @@ impl Filter {
         min_mean_qual: Option<f64>,
         max_no_call_frac: f64,
     ) -> bool {
-        if let Some(min_qual) = min_mean_qual {
-            if mean_qual < min_qual {
-                return false;
-            }
+        if let Some(min_qual) = min_mean_qual
+            && mean_qual < min_qual
+        {
+            return false;
         }
         let no_calls = count_no_calls(bam);
         let seq_len = fgumi_raw_bam::l_seq(bam) as usize;

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -233,13 +233,12 @@ fn filter_template_raw(
         // Check mate MAPQ. Compare in i64 so a malformed `MQ:i:-1` (or any
         // negative value from a signed integer aux type) reads as below the
         // threshold instead of wrapping into a large positive u8.
-        if check_mq {
-            if let Some(mq) = found_mq {
-                if mq < i64::from(config.min_mapq) {
-                    metrics.discarded_poor_alignment += num_primary_reads;
-                    return false;
-                }
-            }
+        if check_mq
+            && let Some(mq) = found_mq
+            && mq < i64::from(config.min_mapq)
+        {
+            metrics.discarded_poor_alignment += num_primary_reads;
+            return false;
         }
 
         // Skip UMI validation in no-umi mode
@@ -255,11 +254,11 @@ fn filter_template_raw(
                     return false;
                 }
                 UmiValidation::Valid(base_count) => {
-                    if let Some(min_len) = config.min_umi_length {
-                        if base_count < min_len {
-                            metrics.discarded_umi_too_short += num_primary_reads;
-                            return false;
-                        }
+                    if let Some(min_len) = config.min_umi_length
+                        && base_count < min_len
+                    {
+                        metrics.discarded_umi_too_short += num_primary_reads;
+                        return false;
                     }
                 }
             }
@@ -1214,11 +1213,10 @@ impl Command for GroupReadsByUmi {
 
                 if filtered_templates.is_empty() {
                     #[cfg(feature = "memory-debug")]
-                    if debug_memory_flag {
-                        if let Some(stats) = stats_for_tracking.as_ref() {
+                    if debug_memory_flag
+                        && let Some(stats) = stats_for_tracking.as_ref() {
                             stats.track_position_group_memory(initial_group_size, false);
                         }
-                    }
                     return Ok(ProcessedPositionGroup {
                         templates: Vec::new(),
                         family_sizes: AHashMap::new(),
@@ -1258,12 +1256,11 @@ impl Command for GroupReadsByUmi {
                 ) {
                     log::warn!("UMI assignment failed, returning empty group: {e}");
                     #[cfg(feature = "memory-debug")]
-                    if debug_memory_flag {
-                        if let Some(stats) = stats_for_tracking.as_ref() {
+                    if debug_memory_flag
+                        && let Some(stats) = stats_for_tracking.as_ref() {
                             stats.track_position_group_memory(initial_group_size, false);
                             stats.track_template_memory(_template_memory_size, false);
                         }
-                    }
                     return Ok(ProcessedPositionGroup {
                         templates: Vec::new(),
                         family_sizes: AHashMap::new(),
@@ -1322,11 +1319,10 @@ impl Command for GroupReadsByUmi {
 
                 // Track memory deallocation when processing completes (if debug mode)
                 #[cfg(feature = "memory-debug")]
-                if debug_memory_flag {
-                    if let Some(stats) = stats_for_tracking.as_ref() {
+                if debug_memory_flag
+                    && let Some(stats) = stats_for_tracking.as_ref() {
                         stats.track_position_group_memory(initial_group_size, false);
                     }
-                }
 
                 Ok(ProcessedPositionGroup {
                     templates,
@@ -1344,12 +1340,11 @@ impl Command for GroupReadsByUmi {
                 #[cfg(feature = "memory-debug")]
                 if short_circuit_serialize {
                     let count = processed.input_record_count;
-                    if debug_memory_flag {
-                        if let Some(stats) = stats_for_serialize.as_ref() {
+                    if debug_memory_flag
+                        && let Some(stats) = stats_for_serialize.as_ref() {
                             let tmpl_size = estimate_templates_heap_size(&processed.templates);
                             stats.track_template_memory(tmpl_size, false);
                         }
-                    }
                     drop(processed);
                     return Ok(count);
                 }
@@ -1365,12 +1360,11 @@ impl Command for GroupReadsByUmi {
 
                 // Track template memory deallocation (templates are consumed here)
                 #[cfg(feature = "memory-debug")]
-                if debug_memory_flag {
-                    if let Some(stats) = stats_for_serialize.as_ref() {
+                if debug_memory_flag
+                    && let Some(stats) = stats_for_serialize.as_ref() {
                         let tmpl_size = estimate_templates_heap_size(&processed.templates);
                         stats.track_template_memory(tmpl_size, false);
                     }
-                }
 
                 // Serialize primary reads directly from templates — no
                 // intermediate `Vec<RecordBuf>`. Templates already carry

--- a/src/lib/commands/merge.rs
+++ b/src/lib/commands/merge.rs
@@ -117,14 +117,14 @@ impl Command for Merge {
         // Check output doesn't alias any input
         if let Ok(output_canon) = std::fs::canonicalize(&self.output) {
             for path in &input_paths {
-                if let Ok(input_canon) = std::fs::canonicalize(path) {
-                    if output_canon == input_canon {
-                        bail!(
-                            "Output file '{}' is the same as input file '{}'",
-                            self.output.display(),
-                            path.display()
-                        );
-                    }
+                if let Ok(input_canon) = std::fs::canonicalize(path)
+                    && output_canon == input_canon
+                {
+                    bail!(
+                        "Output file '{}' is the same as input file '{}'",
+                        self.output.display(),
+                        path.display()
+                    );
                 }
             }
         }
@@ -240,22 +240,22 @@ fn order_flag_value(order: SortOrderArg) -> &'static str {
 /// Returns an error if the header declares an order that conflicts with `order`.
 fn check_input_declared_order(header: &Header, order: SortOrderArg, source: &str) -> Result<()> {
     let expected = expected_declared_order(order);
-    if let Some(declared) = classify_declared_order(header) {
-        if declared != expected {
-            // `{source}` names the input for identification only; the remediation
-            // command uses a `<input>` placeholder (matching the streaming-verify
-            // error) so a path with shell metacharacters can't turn the
-            // copy-pasteable hint into something unexpected.
-            bail!(
-                "Input '{source}' is sorted by {declared} but merge was asked for --order \
+    if let Some(declared) = classify_declared_order(header)
+        && declared != expected
+    {
+        // `{source}` names the input for identification only; the remediation
+        // command uses a `<input>` placeholder (matching the streaming-verify
+        // error) so a path with shell metacharacters can't turn the
+        // copy-pasteable hint into something unexpected.
+        bail!(
+            "Input '{source}' is sorted by {declared} but merge was asked for --order \
                  {requested}. Every input must already be sorted in the merge order, or the \
                  k-way merge silently corrupts the output.\n\nEither merge in the inputs' \
                  existing order:\n  fgumi merge --order {declared} ...\nor sort the inputs to \
                  {requested} first:\n  fgumi sort -i <input> -o sorted.bam --order {requested}",
-                declared = declared.as_str(),
-                requested = order_flag_value(order),
-            );
-        }
+            declared = declared.as_str(),
+            requested = order_flag_value(order),
+        );
     }
     Ok(())
 }

--- a/src/lib/commands/review.rs
+++ b/src/lib/commands/review.rs
@@ -469,15 +469,15 @@ impl Review {
             // absent or `<= maf`. `!(maf <= self.maf)` reproduces that: it drops
             // both `maf > self.maf` and a NaN MAF (e.g. AD summing to zero, where
             // fgbio computes `1 - 0/0 = NaN` and `NaN <= maf` is false).
-            if let Some(ref sname) = sample_name {
-                if let Some(maf) = Self::calculate_maf(&record, &header, sname) {
-                    // Keep only when `maf <= threshold`; a MAF above the threshold
-                    // *and* a NaN MAF (partial comparison is false) both fall through
-                    // to `continue`, matching fgbio's `forall(_ <= maf)`.
-                    let within_threshold = maf <= self.maf;
-                    if !within_threshold {
-                        continue;
-                    }
+            if let Some(ref sname) = sample_name
+                && let Some(maf) = Self::calculate_maf(&record, &header, sname)
+            {
+                // Keep only when `maf <= threshold`; a MAF above the threshold
+                // *and* a NaN MAF (partial comparison is false) both fall through
+                // to `continue`, matching fgbio's `forall(_ <= maf)`.
+                let within_threshold = maf <= self.maf;
+                if !within_threshold {
+                    continue;
                 }
             }
 
@@ -700,28 +700,26 @@ impl Review {
         // Read the typed sample value directly — a `format!("{value:?}")` Debug parse
         // never matches noodles' `Float(..)` / `Array(Float(..))` rendering, so it
         // silently fails and disables MAF filtering entirely.
-        if let Some(af_idx) = keys.as_ref().iter().position(|k| k == "AF") {
-            if let Some(Some(value)) = sample.values().get(af_idx) {
-                if let Some(af) = Self::value_as_f64(value) {
-                    return Some(af);
-                }
-            }
+        if let Some(af_idx) = keys.as_ref().iter().position(|k| k == "AF")
+            && let Some(Some(value)) = sample.values().get(af_idx)
+            && let Some(af) = Self::value_as_f64(value)
+        {
+            return Some(af);
         }
 
         // Fall back to AD (allele depth), matching fgbio's `gt.getAD` → `1 - ad(0)/ad.sum`.
-        if let Some(ad_idx) = keys.as_ref().iter().position(|k| k == "AD") {
-            if let Some(Some(Value::Array(Array::Integer(depths)))) = sample.values().get(ad_idx) {
-                if !depths.is_empty() {
-                    // fgbio: `1 - ad(0) / ad.sum.toDouble`. When AD sums to zero this
-                    // is `1 - 0/0 = NaN`; the caller's `!(maf <= threshold)` check
-                    // then excludes the variant, matching fgbio's `forall(_ <= maf)`.
-                    // Missing (`.`) AD entries are treated as 0 (htsjdk's AD is a
-                    // dense int array).
-                    let total: i32 = depths.iter().map(|d| d.unwrap_or(0)).sum();
-                    let ref_depth = depths[0].unwrap_or(0);
-                    return Some(1.0 - (f64::from(ref_depth) / f64::from(total)));
-                }
-            }
+        if let Some(ad_idx) = keys.as_ref().iter().position(|k| k == "AD")
+            && let Some(Some(Value::Array(Array::Integer(depths)))) = sample.values().get(ad_idx)
+            && !depths.is_empty()
+        {
+            // fgbio: `1 - ad(0) / ad.sum.toDouble`. When AD sums to zero this
+            // is `1 - 0/0 = NaN`; the caller's `!(maf <= threshold)` check
+            // then excludes the variant, matching fgbio's `forall(_ <= maf)`.
+            // Missing (`.`) AD entries are treated as 0 (htsjdk's AD is a
+            // dense int array).
+            let total: i32 = depths.iter().map(|d| d.unwrap_or(0)).sum();
+            let ref_depth = depths[0].unwrap_or(0);
+            return Some(1.0 - (f64::from(ref_depth) / f64::from(total)));
         }
 
         None

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -243,10 +243,10 @@ impl Command for Simplex {
         // Validate inputs
         self.io.validate()?;
 
-        if let Some(max) = self.max_reads {
-            if max < self.min_reads {
-                bail!("--max-reads ({}) must be >= --min-reads ({})", max, self.min_reads);
-            }
+        if let Some(max) = self.max_reads
+            && max < self.min_reads
+        {
+            bail!("--max-reads ({}) must be >= --min-reads ({})", max, self.min_reads);
         }
 
         info!("Starting Simplex");

--- a/src/lib/mi_group.rs
+++ b/src/lib/mi_group.rs
@@ -251,11 +251,11 @@ impl MiGrouper {
 
     /// Flush current MI group to pending.
     fn flush_current_group(&mut self) {
-        if let Some(mi) = self.current_mi.take() {
-            if !self.current_records.is_empty() {
-                let records = std::mem::take(&mut self.current_records);
-                self.pending_groups.push_back(MiGroup::new(mi, records));
-            }
+        if let Some(mi) = self.current_mi.take()
+            && !self.current_records.is_empty()
+        {
+            let records = std::mem::take(&mut self.current_records);
+            self.pending_groups.push_back(MiGroup::new(mi, records));
         }
     }
 

--- a/src/lib/template.rs
+++ b/src/lib/template.rs
@@ -496,17 +496,17 @@ impl Template {
 
             // Set mate score tags (ms) in all cases
             let rr = &mut self.records;
-            if let Some(as_value) = r2_as {
-                if let Ok(v) = i32::try_from(as_value) {
-                    fgumi_raw_bam::remove_tag(rr[r1_i].as_mut_vec(), SamTag::MS);
-                    fgumi_raw_bam::append_signed_int_tag(rr[r1_i].as_mut_vec(), SamTag::MS, v);
-                }
+            if let Some(as_value) = r2_as
+                && let Ok(v) = i32::try_from(as_value)
+            {
+                fgumi_raw_bam::remove_tag(rr[r1_i].as_mut_vec(), SamTag::MS);
+                fgumi_raw_bam::append_signed_int_tag(rr[r1_i].as_mut_vec(), SamTag::MS, v);
             }
-            if let Some(as_value) = r1_as {
-                if let Ok(v) = i32::try_from(as_value) {
-                    fgumi_raw_bam::remove_tag(rr[r2_i].as_mut_vec(), SamTag::MS);
-                    fgumi_raw_bam::append_signed_int_tag(rr[r2_i].as_mut_vec(), SamTag::MS, v);
-                }
+            if let Some(as_value) = r1_as
+                && let Ok(v) = i32::try_from(as_value)
+            {
+                fgumi_raw_bam::remove_tag(rr[r2_i].as_mut_vec(), SamTag::MS);
+                fgumi_raw_bam::append_signed_int_tag(rr[r2_i].as_mut_vec(), SamTag::MS, v);
             }
         }
 
@@ -545,11 +545,11 @@ impl Template {
                         fgumi_raw_bam::remove_tag(rec.as_mut_vec(), SamTag::MC);
                     }
 
-                    if let Some(as_value) = r2_as {
-                        if let Ok(v) = i32::try_from(as_value) {
-                            fgumi_raw_bam::remove_tag(rec.as_mut_vec(), SamTag::MS);
-                            fgumi_raw_bam::append_signed_int_tag(rec.as_mut_vec(), SamTag::MS, v);
-                        }
+                    if let Some(as_value) = r2_as
+                        && let Ok(v) = i32::try_from(as_value)
+                    {
+                        fgumi_raw_bam::remove_tag(rec.as_mut_vec(), SamTag::MS);
+                        fgumi_raw_bam::append_signed_int_tag(rec.as_mut_vec(), SamTag::MS, v);
                     }
                 }
             }
@@ -590,11 +590,11 @@ impl Template {
                         fgumi_raw_bam::remove_tag(rec.as_mut_vec(), SamTag::MC);
                     }
 
-                    if let Some(as_value) = r1_as {
-                        if let Ok(v) = i32::try_from(as_value) {
-                            fgumi_raw_bam::remove_tag(rec.as_mut_vec(), SamTag::MS);
-                            fgumi_raw_bam::append_signed_int_tag(rec.as_mut_vec(), SamTag::MS, v);
-                        }
+                    if let Some(as_value) = r1_as
+                        && let Ok(v) = i32::try_from(as_value)
+                    {
+                        fgumi_raw_bam::remove_tag(rec.as_mut_vec(), SamTag::MS);
+                        fgumi_raw_bam::append_signed_int_tag(rec.as_mut_vec(), SamTag::MS, v);
                     }
                 }
             }

--- a/src/lib/umi/parallel_assigner.rs
+++ b/src/lib/umi/parallel_assigner.rs
@@ -210,10 +210,10 @@ pub fn discover_edges_parallel_k1(
         .flat_map(|(i, (enc, _))| {
             let mut edges = Vec::new();
             for neighbor in generate_neighbors(enc) {
-                if let Some(&j) = umi_to_idx.get(&neighbor) {
-                    if i < j {
-                        edges.push((i, j));
-                    }
+                if let Some(&j) = umi_to_idx.get(&neighbor)
+                    && i < j
+                {
+                    edges.push((i, j));
                 }
             }
             edges
@@ -248,12 +248,12 @@ pub fn discover_edges_parallel_k(
             let mut edges = Vec::new();
             let neighbors = generate_neighbors_k(enc, max_mismatches);
             for neighbor in neighbors {
-                if let Some(&j) = umi_to_idx.get(&neighbor) {
-                    if i < j {
-                        // Verify actual distance (neighbors may include closer matches)
-                        if enc.hamming_distance(&neighbor) <= max_mismatches {
-                            edges.push((i, j));
-                        }
+                if let Some(&j) = umi_to_idx.get(&neighbor)
+                    && i < j
+                {
+                    // Verify actual distance (neighbors may include closer matches)
+                    if enc.hamming_distance(&neighbor) <= max_mismatches {
+                        edges.push((i, j));
                     }
                 }
             }
@@ -2323,11 +2323,11 @@ mod tests {
                     if let Some(pos) = mutate {
                         // Map a base index 0..8 to a string index, skipping the dash at 4.
                         let idx = if pos < 4 { pos } else { pos + 1 };
-                        if let Some(cur) = chars.get(idx).copied() {
-                            if cur != '-' {
-                                let ci = BASES.iter().position(|&c| c == cur).unwrap_or(0);
-                                chars[idx] = BASES[(ci + 1) % 4];
-                            }
+                        if let Some(cur) = chars.get(idx).copied()
+                            && cur != '-'
+                        {
+                            let ci = BASES.iter().position(|&c| c == cur).unwrap_or(0);
+                            chars[idx] = BASES[(ci + 1) % 4];
                         }
                     }
                     chars.into_iter().collect()

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -2115,10 +2115,8 @@ fn try_step_find_boundaries<G: Send, P: Send + MemoryEstimate>(
 
         // Release memory from atomic tracker when popping from reorder buffer
         let Some((batch, heap_size)) = batch_with_size else {
-            if !did_work {
-                if let Some(stats) = state.stats() {
-                    stats.record_queue_empty(2);
-                }
+            if !did_work && let Some(stats) = state.stats() {
+                stats.record_queue_empty(2);
             }
             break; // No more data available
         };
@@ -2489,10 +2487,8 @@ fn try_step_group<G: Send + BatchWeight + MemoryEstimate + 'static, P: Send + Me
 
         // Release memory from atomic tracker when popping from reorder buffer
         let Some((records, heap_size)) = records else {
-            if !did_work {
-                if let Some(stats) = state.stats() {
-                    stats.record_queue_empty(3);
-                }
+            if !did_work && let Some(stats) = state.stats() {
+                stats.record_queue_empty(3);
             }
             break; // No more data available
         };
@@ -2925,11 +2921,11 @@ fn try_step_serialize<G: Send + 'static, P: Send + MemoryEstimate + 'static>(
     let mut total_record_count: u64 = 0;
     for item in batch {
         // Secondary serialize (borrows item) — must run before primary consumes it
-        if let Some(ref secondary_fn) = fns.secondary_serialize_fn {
-            if let Err(e) = (secondary_fn)(&item, &mut worker.core.secondary_serialization_buffer) {
-                state.set_error(e);
-                return false;
-            }
+        if let Some(ref secondary_fn) = fns.secondary_serialize_fn
+            && let Err(e) = (secondary_fn)(&item, &mut worker.core.secondary_serialization_buffer)
+        {
+            state.set_error(e);
+            return false;
         }
         // Primary serialize (consumes item)
         match (fns.serialize_fn)(item, &mut worker.core.serialization_buffer) {
@@ -3044,17 +3040,16 @@ fn try_step_write<G: Send + 'static, P: Send + MemoryEstimate + 'static>(
             }
 
             // Write secondary data (e.g., rejects) in the same serial order
-            if let Some(ref secondary_data) = batch.secondary_data {
-                if !secondary_data.is_empty() {
-                    if let Some(ref secondary_mutex) = state.output.secondary_output {
-                        let mut sw_guard = secondary_mutex.lock();
-                        if let Some(ref mut sw) = *sw_guard {
-                            if let Err(e) = sw.write_raw_bytes(secondary_data) {
-                                state.set_error(e);
-                                return (false, false);
-                            }
-                        }
-                    }
+            if let Some(ref secondary_data) = batch.secondary_data
+                && !secondary_data.is_empty()
+                && let Some(ref secondary_mutex) = state.output.secondary_output
+            {
+                let mut sw_guard = secondary_mutex.lock();
+                if let Some(ref mut sw) = *sw_guard
+                    && let Err(e) = sw.write_raw_bytes(secondary_data)
+                {
+                    state.set_error(e);
+                    return (false, false);
                 }
             }
 
@@ -3082,10 +3077,11 @@ fn try_step_write<G: Send + 'static, P: Send + MemoryEstimate + 'static>(
 
     // Record queue empty only if both Q7 queue AND reorder buffer are empty
     // (not when items are waiting out-of-order in the reorder buffer)
-    if !wrote_any && q7_truly_empty {
-        if let Some(stats) = state.stats() {
-            stats.record_queue_empty(7);
-        }
+    if !wrote_any
+        && q7_truly_empty
+        && let Some(stats) = state.stats()
+    {
+        stats.record_queue_empty(7);
     }
 
     (wrote_any, false) // Success or no work, no contention (we held lock)
@@ -3400,10 +3396,10 @@ where
                 compressor.write_blocks_to(output.as_mut())?;
 
                 // Write secondary data
-                if !buffers.secondary.is_empty() {
-                    if let Some(ref mut sw) = secondary_writer {
-                        sw.write_raw_bytes(&buffers.secondary)?;
-                    }
+                if !buffers.secondary.is_empty()
+                    && let Some(ref mut sw) = secondary_writer
+                {
+                    sw.write_raw_bytes(&buffers.secondary)?;
                 }
 
                 progress.log_if_needed(record_count);
@@ -3412,41 +3408,41 @@ where
     }
 
     // Handle any remaining bytes from boundary finding
-    if let Some(final_batch) = boundary_state.finish()? {
-        if final_batch.offsets.len() > 1 {
-            let decoded = decode_records(&final_batch, &group_key_config)?;
-            let groups = grouper.add_records(decoded)?;
+    if let Some(final_batch) = boundary_state.finish()?
+        && final_batch.offsets.len() > 1
+    {
+        let decoded = decode_records(&final_batch, &group_key_config)?;
+        let groups = grouper.add_records(decoded)?;
 
-            for group in groups {
-                let processed = (fns.process_fn)(group)?;
+        for group in groups {
+            let processed = (fns.process_fn)(group)?;
 
-                // Run MI Assign first so secondary_serialize sees the same
-                // post-assign state as the parallel path (matches Step 7 above).
-                let processed = run_mi_assign_single_threaded(
-                    fns.mi_assign_fn.as_deref(),
-                    &mut next_serial,
-                    processed,
-                )?;
+            // Run MI Assign first so secondary_serialize sees the same
+            // post-assign state as the parallel path (matches Step 7 above).
+            let processed = run_mi_assign_single_threaded(
+                fns.mi_assign_fn.as_deref(),
+                &mut next_serial,
+                processed,
+            )?;
 
-                buffers.secondary.clear();
-                if let Some(ref secondary_fn) = fns.secondary_serialize_fn {
-                    (secondary_fn)(&processed, &mut buffers.secondary)?;
-                }
-
-                buffers.serialized.clear();
-                let record_count = (fns.serialize_fn)(processed, &mut buffers.serialized)?;
-                compressor.write_all(&buffers.serialized)?;
-                compressor.maybe_compress()?;
-                compressor.write_blocks_to(output.as_mut())?;
-
-                if !buffers.secondary.is_empty() {
-                    if let Some(ref mut sw) = secondary_writer {
-                        sw.write_raw_bytes(&buffers.secondary)?;
-                    }
-                }
-
-                progress.log_if_needed(record_count);
+            buffers.secondary.clear();
+            if let Some(ref secondary_fn) = fns.secondary_serialize_fn {
+                (secondary_fn)(&processed, &mut buffers.secondary)?;
             }
+
+            buffers.serialized.clear();
+            let record_count = (fns.serialize_fn)(processed, &mut buffers.serialized)?;
+            compressor.write_all(&buffers.serialized)?;
+            compressor.maybe_compress()?;
+            compressor.write_blocks_to(output.as_mut())?;
+
+            if !buffers.secondary.is_empty()
+                && let Some(ref mut sw) = secondary_writer
+            {
+                sw.write_raw_bytes(&buffers.secondary)?;
+            }
+
+            progress.log_if_needed(record_count);
         }
     }
 
@@ -3481,10 +3477,10 @@ where
         compressor.write_blocks_to(output.as_mut())?;
 
         // Write secondary data
-        if !buffers.secondary.is_empty() {
-            if let Some(ref mut sw) = secondary_writer {
-                sw.write_raw_bytes(&buffers.secondary)?;
-            }
+        if !buffers.secondary.is_empty()
+            && let Some(ref mut sw) = secondary_writer
+        {
+            sw.write_raw_bytes(&buffers.secondary)?;
         }
 
         progress.log_if_needed(record_count);
@@ -3759,15 +3755,15 @@ where
     // Finalize secondary output writer (if present)
     if let Some(ref secondary_mutex) = state.output.secondary_output {
         let mut guard = secondary_mutex.lock();
-        if let Some(writer) = guard.take() {
-            if let Err(e) = writer.finish().map_err(|e| {
+        if let Some(writer) = guard.take()
+            && let Err(e) = writer.finish().map_err(|e| {
                 io::Error::new(e.kind(), format!("Failed to finalize secondary output: {e}"))
-            }) {
-                if result.is_err() {
-                    log::error!("Secondary output finalization also failed: {e}");
-                } else {
-                    return Err(e);
-                }
+            })
+        {
+            if result.is_err() {
+                log::error!("Secondary output finalization also failed: {e}");
+            } else {
+                return Err(e);
             }
         }
     }

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -3138,11 +3138,11 @@ impl PipelineStats {
         }
 
         // Record per-thread stats if thread_id provided
-        if let Some(tid) = thread_id {
-            if tid < MAX_THREADS {
-                let step_idx = step as usize;
-                self.per_thread_step_counts[tid][step_idx].fetch_add(1, Ordering::Relaxed);
-            }
+        if let Some(tid) = thread_id
+            && tid < MAX_THREADS
+        {
+            let step_idx = step as usize;
+            self.per_thread_step_counts[tid][step_idx].fetch_add(1, Ordering::Relaxed);
         }
     }
 
@@ -4438,14 +4438,12 @@ pub fn generic_worker_loop<C: StepContext>(ctx: &C, worker: &mut C::Worker) {
                 let success = if collect_stats {
                     let start = Instant::now();
                     let success = ctx.execute_read_step(worker);
-                    if success {
-                        if let Some(stats) = ctx.stats() {
-                            stats.record_step_for_thread(
-                                PipelineStep::Read,
-                                start.elapsed().as_nanos() as u64,
-                                Some(worker.core().scheduler.thread_id()),
-                            );
-                        }
+                    if success && let Some(stats) = ctx.stats() {
+                        stats.record_step_for_thread(
+                            PipelineStep::Read,
+                            start.elapsed().as_nanos() as u64,
+                            Some(worker.core().scheduler.thread_id()),
+                        );
                     }
                     success
                 } else {
@@ -4475,34 +4473,35 @@ pub fn generic_worker_loop<C: StepContext>(ctx: &C, worker: &mut C::Worker) {
         // BAM optimization: try owned exclusive step first (before priority loop)
         // This prevents starvation: since only this thread can do the step, prioritize it
         let owned_step = ctx.exclusive_step_owned(worker);
-        if let Some(step) = owned_step {
-            if step != PipelineStep::Read && !ctx.has_error() {
-                // Record attempt
+        if let Some(step) = owned_step
+            && step != PipelineStep::Read
+            && !ctx.has_error()
+        {
+            // Record attempt
+            if let Some(stats) = ctx.stats() {
+                stats.record_step_attempt(worker.core().scheduler.thread_id(), step);
+            }
+
+            let (success, elapsed_ns, was_contention) = if collect_stats {
+                let start = Instant::now();
+                let (success, was_contention) = ctx.execute_step(worker, step);
+                (success, start.elapsed().as_nanos() as u64, was_contention)
+            } else {
+                let (success, was_contention) = ctx.execute_step(worker, step);
+                (success, 0, was_contention)
+            };
+
+            worker.core_mut().scheduler.record_outcome(step, success, was_contention);
+
+            if success {
                 if let Some(stats) = ctx.stats() {
-                    stats.record_step_attempt(worker.core().scheduler.thread_id(), step);
+                    stats.record_step_for_thread(
+                        step,
+                        elapsed_ns,
+                        Some(worker.core().scheduler.thread_id()),
+                    );
                 }
-
-                let (success, elapsed_ns, was_contention) = if collect_stats {
-                    let start = Instant::now();
-                    let (success, was_contention) = ctx.execute_step(worker, step);
-                    (success, start.elapsed().as_nanos() as u64, was_contention)
-                } else {
-                    let (success, was_contention) = ctx.execute_step(worker, step);
-                    (success, 0, was_contention)
-                };
-
-                worker.core_mut().scheduler.record_outcome(step, success, was_contention);
-
-                if success {
-                    if let Some(stats) = ctx.stats() {
-                        stats.record_step_for_thread(
-                            step,
-                            elapsed_ns,
-                            Some(worker.core().scheduler.thread_id()),
-                        );
-                    }
-                    did_work = true;
-                }
+                did_work = true;
             }
         }
 

--- a/src/lib/unified_pipeline/fastq.rs
+++ b/src/lib/unified_pipeline/fastq.rs
@@ -3465,10 +3465,11 @@ fn fastq_try_step_write<R: BufRead + Send + 'static, P: Send + MemoryEstimate + 
         q7_truly_empty = reorder.is_empty();
     }
 
-    if !wrote_any && q7_truly_empty {
-        if let Some(stats) = state.stats() {
-            stats.record_queue_empty(7);
-        }
+    if !wrote_any
+        && q7_truly_empty
+        && let Some(stats) = state.stats()
+    {
+        stats.record_queue_empty(7);
     }
 
     wrote_any

--- a/src/lib/unified_pipeline/scheduler/optimized_chase.rs
+++ b/src/lib/unified_pipeline/scheduler/optimized_chase.rs
@@ -134,10 +134,10 @@ impl OptimizedChaseScheduler {
         }
 
         // 2. For exclusive specialists, always include their specialty second
-        if let Some(specialty) = self.exclusive_specialty {
-            if specialty != self.current_step {
-                priorities.push(specialty);
-            }
+        if let Some(specialty) = self.exclusive_specialty
+            && specialty != self.current_step
+        {
+            priorities.push(specialty);
         }
 
         // 3. Bottleneck boost: Compress and Serialize always in top priorities

--- a/src/lib/validation.rs
+++ b/src/lib/validation.rs
@@ -98,13 +98,13 @@ pub fn validate_min_max<T: Ord + Display>(
     min_name: &str,
     max_name: &str,
 ) -> Result<()> {
-    if let Some(max) = max_val {
-        if max < min_val {
-            return Err(FgumiError::InvalidParameter {
-                parameter: max_name.to_string(),
-                reason: format!("{max_name} ({max}) must be >= {min_name} ({min_val})"),
-            });
-        }
+    if let Some(max) = max_val
+        && max < min_val
+    {
+        return Err(FgumiError::InvalidParameter {
+            parameter: max_name.to_string(),
+            reason: format!("{max_name} ({max}) must be >= {min_name} ({min_val})"),
+        });
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,10 +211,10 @@ fn main() -> Result<()> {
     let result = args.subcommand.execute(&command_line);
 
     #[cfg(feature = "compare")]
-    if let Err(ref e) = result {
-        if e.downcast_ref::<CompareMismatch>().is_some() {
-            std::process::exit(1);
-        }
+    if let Err(ref e) = result
+        && e.downcast_ref::<CompareMismatch>().is_some()
+    {
+        std::process::exit(1);
     }
 
     result


### PR DESCRIPTION
## Why

`rust-version = "1.87.0"` was a false, unverified promise. The dependency floor already requires more (`noodles`/`wide` → 1.89, `sysinfo` → 1.88), and CI builds on the `rust-toolchain.toml` pin (1.93.0). An MSRV that nothing tests and that consumers can't rely on is worse than none — the same "contract with no gate rots" failure as the doctest/doc-link gaps.

The principled fix is one enforced source of truth: **fgumi supports exactly the Rust it develops and tests on.**

## What

**1. `rust-version` → 1.93.0**, matching the `rust-toolchain.toml` channel (`build(msrv)!` commit).

**2. Adopt let-chains (85 sites).** Honestly declaring MSRV ≥ 1.88 means clippy correctly suggests collapsing `if cond { if let PAT = expr { … } }` into `if cond && let PAT = expr { … }` (stabilized 1.88). Rather than suppress the lint to hide the MSRV, the code adopts the idiom the MSRV unlocks — applied mechanically via `cargo clippy --fix`, so the code, the toolchain, and the lints all agree. Rewrites are behavior-preserving (nested-if and `&& let` short-circuit identically).

**3. `msrv-lockstep` CI job** (`ci:` commit) that fails if the two versions drift. Because every other job builds on the rust-toolchain.toml channel, keeping them equal means **all of CI already verifies the MSRV compiles** — no separate MSRV build job needed.

## Marked `!` (semver-relevant)

Raising the published MSRV is a breaking change for the crates.io libraries — hence the `!`. It reflects reality (the crates already didn't build below ~1.89); this makes the manifest honest.

## Verification

- `cargo ci-lint` (`-D warnings -W clippy::pedantic`) at 1.93 → clean (was 85 `collapsible_if` before the migration).
- `cargo ci-test` → **4756 passed, 0 failed** (behavior preserved).
- `cargo ci-fmt` → clean.
- Lockstep check dry-run: `rust-version=1.93.0 == channel=1.93.0` → OK.

## Notes

- The bump and the let-chain migration are one commit on purpose: let-chains don't compile below 1.88, so they can't be split.
- Independent of #574 (docs) and #572/#573; some files overlap on non-adjacent lines and should merge cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - Raised the minimum supported Rust version to 1.93.0.
  - Updated developer setup guidance to reflect the new toolchain requirement.

- **Build Reliability**
  - Added automated checks to ensure the declared minimum Rust version matches the pinned build toolchain, preventing version drift.

- **Maintenance**
  - Streamlined internal processing and validation logic without changing command behavior or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->