### PR TITLE
ci: gate sort correctness against samtools

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,6 +8,22 @@ ci-doctest = "test --doc --workspace --features compare,simulate,profile-adjacen
 # Build the docs and fail on any rustdoc warning (e.g. broken intra-doc links).
 # RUSTDOCFLAGS="-D warnings" is set by the caller (CI job / pre-push).
 ci-doc = "doc --no-deps --workspace --features compare,simulate,profile-adjacency --locked"
+# Run only the #[ignore]-d integration tests (the sort-correctness suites in
+# tests/integration/{test_sort_correctness,test_async_reader,test_sort_write_index}.rs).
+# They require the `samtools` binary on PATH — samtools builds the BAM fixtures,
+# counts records, and queries the fgumi-written .bai index; sort ordering itself is
+# checked by `fgumi sort --verify` (fgumi's own canonical order checker), not by
+# diffing against `samtools sort` — this gates internal sort-correctness, not
+# samtools output parity. The `sort-correctness` CI job installs samtools and runs
+# this, so these tests are actually gated instead of being permanently skipped.
+# NOTE: `--run-ignored ignored-only` alone would run EVERY #[ignore]-d test in the
+# workspace, which is more than the samtools-gated ones: fgumi-consensus also has
+# #[ignore]-d `regen_*` fixture writers (codec_caller.rs, duplex_caller.rs) that are
+# maintainer tools, not correctness gates -- they build large fixtures and persist a
+# temp BAM that nothing cleans up. The `binary_id(fgumi::integration)` filterset scopes
+# the run to the integration test binary, where every #[ignore] is samtools-gated. A new
+# #[ignore]-d integration test must therefore also be samtools-only.
+ci-test-samtools = "nextest run --workspace --features compare,simulate,profile-adjacency --locked --run-ignored ignored-only -E binary_id(fgumi::integration)"
 # Run tests with test-utils feature enabled (allows binary tests to use library test utilities)
 t = "test --features test-utils"
 # Generate and serve documentation locally (runs xtask then mdbook serve)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -219,3 +219,44 @@ jobs:
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - name: Build documentation
         run: cargo ci-doc
+
+  sort-correctness:
+    runs-on: ubuntu-latest
+    # This job only reads the repository -- it builds and runs tests, and never
+    # writes back to GitHub. Drop the default GITHUB_TOKEN scopes to read-only so
+    # the token exposed to test code cannot mutate the repo.
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Set up compilation cache (sccache)
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - name: Install nextest
+        uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
+        with:
+          tool: nextest
+      - name: Install samtools
+        # The sort-correctness suites (tests/integration/test_sort_correctness.rs,
+        # test_async_reader.rs, test_sort_write_index.rs) need the `samtools` binary to
+        # build BAM fixtures, count records, and query the fgumi-written .bai index.
+        # Sort ordering itself is verified by `fgumi sort --verify` (fgumi's own order
+        # checker), not by diffing against `samtools sort` — this job gates internal
+        # sort-correctness, not samtools output parity. These tests are `#[ignore]`d
+        # because they need samtools; without this job they never run in CI, so
+        # sort-correctness was ungated. samtools is taken from the runner's apt repo —
+        # the tests never parse samtools' record order, so they do not depend on a
+        # specific samtools patch version.
+        run: sudo apt-get update && sudo apt-get install -y samtools
+      - name: Verify samtools is on PATH
+        # The samtools-gated suites early-return when `samtools_available()`
+        # (which shells out to `samtools --version`) is false, so a missing binary
+        # would let this job pass without running any of them. Fail loudly instead:
+        # this asserts the exact predicate the tests gate on.
+        run: samtools --version
+      - name: Run samtools-gated sort-correctness tests
+        run: cargo ci-test-samtools


### PR DESCRIPTION
## Why

`fgumi sort`'s core contract is that it matches `samtools sort` — and there's a suite that verifies exactly that: `test_sort_correctness` (coordinate / queryname-lex / queryname-natural / template-coordinate, in-memory **and** with disk spills), `test_async_reader`, and `test_sort_write_index`. **All 18 are `#[ignore]`d** because they shell out to `samtools`, which is never installed in CI. So fgumi's headline feature has been running on an ungated contract — a sort regression (like the recent simulate template-coordinate bug) could ship green.

This is the "contract with no gate" pattern: reference-parity tests that exist but never run.

## What

- New **`sort-parity`** CI job: installs samtools (apt) and runs the ignored suite via a new `ci-test-samtools` alias (`nextest run --run-ignored ignored-only`).
- Stacked on #576, whose hermetic rewrite removed samtools from the *simulate* sort tests — so `ignored-only` now selects **exactly** these 18 sort-vs-samtools tests (verified: 18 run, 18 pass, ~1s locally).

samtools comes from the runner's apt repo; the tests are tie-insensitive, so they don't depend on a specific samtools patch version (a hard version pin is a possible follow-up if ever needed).

## Base

Targets `nh/test-simulate-sort-hermetic` (#576) and should merge after it — it relies on #576 having un-ignored the simulate sort tests, so `ignored-only` is exactly the samtools set.

First of a task-list series closing "contract with no gate" gaps (T1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a dedicated CI test command that runs the workspace suite while executing only the previously ignored, samtools-gated tests.
  * Introduced a CI job that installs `samtools`, verifies it’s available, and runs the samtools-dependent sort-correctness integration checks for reliable automated test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->