### PR TITLE
ci: compile-gate all features + nightly stress-tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -24,6 +24,10 @@ ci-doc = "doc --no-deps --workspace --features compare,simulate,profile-adjacenc
 # the run to the integration test binary, where every #[ignore] is samtools-gated. A new
 # #[ignore]-d integration test must therefore also be samtools-only.
 ci-test-samtools = "nextest run --workspace --features compare,simulate,profile-adjacency --locked --run-ignored ignored-only -E binary_id(fgumi::integration)"
+# Run the concurrency stress tests (behind the `stress-tests` feature). Timing-
+# sensitive, so run on a nightly schedule (see .github/workflows/stress.yml) rather
+# than per-PR, where a flake would block unrelated changes.
+ci-test-stress = "nextest run --workspace --features compare,simulate,profile-adjacency,stress-tests --locked"
 # Run tests with test-utils feature enabled (allows binary tests to use library test utilities)
 t = "test --features test-utils"
 # Generate and serve documentation locally (runs xtask then mdbook serve)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -260,3 +260,26 @@ jobs:
         run: samtools --version
       - name: Run samtools-gated sort-correctness tests
         run: cargo ci-test-samtools
+
+  all-features-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Set up compilation cache (sccache)
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - name: cargo check --workspace --all-features --all-targets
+        # The regular jobs only build a fixed feature set (default +
+        # compare,simulate,profile-adjacency), and no-default-features-check builds
+        # the all-off end. That leaves several declared features never compiled in
+        # CI -- notably `memory-debug` (dozens of instrumentation sites), `dhat-heap`,
+        # and `stress-tests` -- free to bit-rot. Enabling every feature at once
+        # compiles all of them (and any future feature automatically), across
+        # lib + tests + benches, so a feature that stops compiling fails at PR time.
+        # `--locked` keeps the job on the committed Cargo.lock (matching the ci-*
+        # aliases) so a drifting lockfile fails here instead of silently re-resolving.
+        run: cargo check --workspace --all-features --all-targets --locked

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -1,0 +1,55 @@
+name: Nightly Stress Tests
+
+# The concurrency stress tests (`test_pipeline_concurrency::stress_tests`, behind the
+# `stress-tests` feature) exercise the BAM pipeline under adversarial thread counts,
+# tiny queues, injected failures, and deadlock detection. They are timing-sensitive,
+# so they run on a schedule (and on demand) rather than per-PR, where an occasional
+# flake would block unrelated changes. The `all-features-check` job in check.yml only
+# *compiles* the suite (via `--all-features`); no other CI job runs it, so without this
+# workflow the tests never execute.
+on:
+  schedule:
+    - cron: "0 7 * * *" # daily at 07:00 UTC
+  workflow_dispatch: {}
+
+# Read-only by default: this workflow only builds and runs tests, so it needs no
+# write access to repo contents, issues, or the token's other scopes.
+permissions:
+  contents: read
+
+# The suite is timing-sensitive, so two overlapping runs (e.g. a manual dispatch during
+# the nightly one) would contend for the same runner capacity and produce spurious
+# failures. Serialize them, and let an in-flight run finish rather than cancelling it --
+# a partial stress run reports nothing useful.
+concurrency:
+  group: nightly-stress-tests
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+
+jobs:
+  stress-tests:
+    runs-on: ubuntu-latest
+    # The suite exercises deadlock detection and timing-sensitive concurrency, so a
+    # regression could otherwise hang until the runner's 6h hard limit. This bound is
+    # well above the normal runtime (build + ~6s of tests) but fails fast on a hang.
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Set up compilation cache (sccache)
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      - name: Install nextest
+        uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
+        with:
+          tool: nextest
+      - name: Concurrency stress tests
+        run: cargo ci-test-stress


### PR DESCRIPTION
Closes two "feature declared but never exercised in CI" gaps (task-list T3 + T4).

## T3 — compile-gate every feature (`all-features-check` job)
CI only built a fixed feature set (default + `compare,simulate,profile-adjacency`); `no-default-features-check` built the all-off end. Between them, several declared features were **never compiled** — `memory-debug` (dozens of instrumentation sites), `dhat-heap`, `stress-tests` — free to bit-rot.

New `all-features-check` job runs `cargo check --workspace --all-features --all-targets` — every feature at once, lib + tests + benches, so any feature that stops compiling fails at PR time (and future features are covered automatically). Verified green locally. *(I first tried `cargo hack --each-feature`, but this workspace's integration tests are `#[cfg(feature)]`-gated to the default set, so per-feature-in-isolation checks are noisy; `--all-features` is the clean, future-proof gate here.)*

## T4 — run the concurrency stress suite nightly (`stress.yml`)
`test_pipeline_concurrency::stress_tests` (behind `stress-tests`) exercises the BAM pipeline under adversarial thread counts, tiny queues, injected failures, and deadlock detection. No CI job enabled the feature, so it never ran.

New scheduled `stress.yml` (nightly + `workflow_dispatch`) runs it via a `ci-test-stress` alias. Scheduled rather than per-PR because the tests are timing-sensitive and a flake shouldn't block unrelated PRs (they pass in ~6s locally — trivially promotable to per-PR later if they prove stable).

## Note
Both edit CI config; like the other in-flight CI PRs (#573/#574/#575/#577) each appends its own job/workflow, so merge conflicts are trivial (append-only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **CI Improvements**
  - Added an `all-features-check` job to run `cargo check` across the full workspace with all features enabled for all targets, using the committed lockfile.
  - Introduced a “Nightly Stress Tests” workflow scheduled daily (and runnable manually) to execute timing/concurrency-sensitive stress tests.
  - Added a dedicated Cargo alias for running the stress-test suite with the required feature set and locked dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->