### PR TITLE
perf(review): stream consensus-read extraction via multi-interval query

### DIFF
--- a/crates/fgumi-raw-bam/src/cigar.rs
+++ b/crates/fgumi-raw-bam/src/cigar.rs
@@ -150,18 +150,50 @@ pub fn reference_length_from_cigar(cigar_ops: &[u32]) -> i32 {
 }
 
 /// Compute reference length directly from raw CIGAR bytes (zero allocation).
+///
+/// Returns `0` for a record with no CIGAR **and** for a malformed record whose
+/// declared read-name/CIGAR region extends past the buffer. Callers that must
+/// distinguish those two cases (e.g. to fail closed on corrupt input) should use
+/// [`reference_length_from_raw_bam_checked`] instead.
 #[inline]
 #[must_use]
 pub fn reference_length_from_raw_bam(bam: &[u8]) -> i32 {
-    let n_cigar_op = n_cigar_op(bam) as usize;
-    if n_cigar_op == 0 {
-        return 0;
+    reference_length_from_raw_bam_checked(bam).unwrap_or(0)
+}
+
+/// Like [`reference_length_from_raw_bam`], but validates the record's read-name
+/// and CIGAR bounds against the buffer and distinguishes a legitimately
+/// zero-length span from a truncated/malformed record.
+///
+/// Returns:
+/// - `Some(len)` for a well-formed record — `Some(0)` when it genuinely has no
+///   CIGAR (`n_cigar_op == 0`), otherwise the reference-consuming span.
+/// - `None` when the record is malformed: shorter than the 32-byte fixed core, or
+///   its declared read-name/CIGAR region extends past the buffer (validated with
+///   checked arithmetic so a corrupt `l_read_name`/`n_cigar_op` cannot overflow the
+///   offset math and wrap back into bounds). Callers must reject such records
+///   rather than treat them as a zero-length (point) alignment at their start.
+#[inline]
+#[must_use]
+pub fn reference_length_from_raw_bam_checked(bam: &[u8]) -> Option<i32> {
+    use crate::fields::MIN_BAM_RECORD_LEN;
+
+    // The 32-byte fixed core must be present to read `l_read_name`/`n_cigar_op`.
+    if bam.len() < MIN_BAM_RECORD_LEN {
+        return None;
     }
+    let n_cigar_op = n_cigar_op(bam) as usize;
     let l_read_name = l_read_name(bam) as usize;
-    let cigar_start = 32 + l_read_name;
-    let cigar_end = cigar_start + n_cigar_op * 4;
+    let cigar_start = MIN_BAM_RECORD_LEN.checked_add(l_read_name)?;
+    let cigar_end = cigar_start.checked_add(n_cigar_op.checked_mul(4)?)?;
     if cigar_end > bam.len() {
-        return 0;
+        return None;
+    }
+    // Validate the read-name/CIGAR bounds *before* short-circuiting on a zero-op
+    // CIGAR, so a core-only record declaring an oversized `l_read_name` fails closed
+    // rather than being accepted as a valid zero-length (point) alignment.
+    if n_cigar_op == 0 {
+        return Some(0);
     }
 
     let mut ref_len = 0i32;
@@ -169,10 +201,13 @@ pub fn reference_length_from_raw_bam(bam: &[u8]) -> i32 {
         let op = cigar_op_at(bam, cigar_start + i * 4);
         let op_type = op & 0xF;
         if consumes_ref(op_type) {
-            ref_len += (op >> 4).cast_signed();
+            // Fail closed on a malformed-but-in-bounds CIGAR whose ref-consuming
+            // lengths overflow `i32`: return `None` rather than a wrapped (negative)
+            // span that downstream span math would trust as non-negative.
+            ref_len = ref_len.checked_add((op >> 4).cast_signed())?;
         }
     }
-    ref_len
+    Some(ref_len)
 }
 
 /// Compute the query-consuming length of CIGAR operations (the "read length").
@@ -1484,6 +1519,62 @@ mod tests {
     fn test_reference_length_from_raw_bam_truncated_cigar() {
         let mut rec = make_bam_bytes(0, 100, 0, b"rea", &[(10 << 4)], 10, -1, -1, &[]);
         rec[12..14].copy_from_slice(&100u16.to_le_bytes());
+        assert_eq!(reference_length_from_raw_bam(&rec), 0);
+    }
+
+    #[test]
+    fn test_reference_length_from_raw_bam_checked_no_cigar_is_valid_zero() {
+        // A record that genuinely has no CIGAR is well-formed with a zero span.
+        let rec = make_bam_bytes(0, 100, 0, b"rea", &[], 0, -1, -1, &[]);
+        assert_eq!(reference_length_from_raw_bam_checked(&rec), Some(0));
+    }
+
+    #[test]
+    fn test_reference_length_from_raw_bam_checked_simple() {
+        let cigar = &[(50 << 4)]; // 50M
+        let rec = make_bam_bytes(0, 100, 0, b"rea", cigar, 50, -1, -1, &[]);
+        assert_eq!(reference_length_from_raw_bam_checked(&rec), Some(50));
+    }
+
+    #[test]
+    fn test_reference_length_from_raw_bam_checked_truncated_cigar_is_none() {
+        // n_cigar_op declares 100 ops but the buffer holds only one: malformed,
+        // must report `None` rather than the `0` the infallible variant returns.
+        let mut rec = make_bam_bytes(0, 100, 0, b"rea", &[(10 << 4)], 10, -1, -1, &[]);
+        rec[12..14].copy_from_slice(&100u16.to_le_bytes());
+        assert_eq!(reference_length_from_raw_bam_checked(&rec), None);
+        // The infallible variant still collapses the malformed record to `0`.
+        assert_eq!(reference_length_from_raw_bam(&rec), 0);
+    }
+
+    #[test]
+    fn test_reference_length_from_raw_bam_checked_too_short_is_none() {
+        // Shorter than the 32-byte fixed core: cannot be a valid record.
+        let rec = make_bam_bytes(0, 100, 0, b"rea", &[(10 << 4)], 10, -1, -1, &[]);
+        assert_eq!(reference_length_from_raw_bam_checked(&rec[..20]), None);
+    }
+
+    #[test]
+    fn test_reference_length_from_raw_bam_checked_zero_cigar_oversized_read_name_is_none() {
+        // Core-only record with no CIGAR but l_read_name corrupted to 255: the
+        // declared read name overruns the buffer, so it must fail closed rather than
+        // be accepted as a zero-length point alignment.
+        let mut rec = make_bam_bytes(0, 100, 0, b"rea", &[], 0, -1, -1, &[]);
+        rec[8] = 255; // l_read_name (byte 8) -> 255, far past the 36-byte buffer
+        assert_eq!(reference_length_from_raw_bam_checked(&rec), None);
+        assert_eq!(reference_length_from_raw_bam(&rec), 0);
+    }
+
+    #[test]
+    fn test_reference_length_from_raw_bam_checked_overflow_is_none() {
+        // Nine ref-consuming M ops of length 2^28-1 each sum to ~2.4B, past
+        // i32::MAX (~2.1B). The CIGAR is in-bounds but malformed: the accumulator
+        // must fail closed (None) rather than wrap negative (or panic in debug).
+        let big_m = 0x0FFF_FFFF_u32 << 4; // length = 2^28-1, op = M (0, consumes ref)
+        let cigar = vec![big_m; 9];
+        let rec = make_bam_bytes(0, 100, 0, b"rea", &cigar, 0, -1, -1, &[]);
+        assert_eq!(reference_length_from_raw_bam_checked(&rec), None);
+        // The infallible wrapper collapses the overflow to 0 like any other malform.
         assert_eq!(reference_length_from_raw_bam(&rec), 0);
     }
 

--- a/crates/fgumi-raw-bam/src/indexed_reader.rs
+++ b/crates/fgumi-raw-bam/src/indexed_reader.rs
@@ -180,6 +180,81 @@ impl<R: Read + Seek> IndexedRawBamReader<R> {
 
         Ok(RawQueryIter { reader: csi_query, ref_id, interval, record: RawRecord::new() })
     }
+
+    /// Return an iterator over [`RawRecord`]s overlapping **any** of `regions`,
+    /// in a single coordinate-ordered pass, with each record yielded exactly
+    /// once.
+    ///
+    /// This is the multi-interval analog of [`query`](Self::query) and mirrors
+    /// htsjdk's `SamReader.query(QueryInterval[])` (and therefore fgbio's
+    /// `SamSource.query(loci)`): the BAI chunks for every region are gathered
+    /// and [`merge_chunks`](noodles::csi::binning_index::merge_chunks)-ed into a
+    /// minimal, sorted, non-overlapping set, then scanned once. Because the
+    /// merged chunks are disjoint and read in virtual-position order (which, for
+    /// a coordinate-sorted BAM, is genomic-coordinate order), a record
+    /// overlapping several regions is visited a **single** time and records are
+    /// emitted in coordinate order. The caller therefore needs no external
+    /// buffering, sort, or de-duplication.
+    ///
+    /// `regions` may overlap, be unsorted, and span multiple reference
+    /// sequences; the output ordering and single-visit guarantee hold
+    /// regardless.
+    ///
+    /// # Arguments
+    ///
+    /// * `header` — SAM header obtained from [`read_header`](Self::read_header);
+    ///   resolves each region name to a reference-sequence ID.
+    /// * `regions` — genomic regions to query.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a region name is not found in the header or if the
+    /// index cannot be queried.
+    pub fn query_intervals<'a>(
+        &'a mut self,
+        header: &'a sam::Header,
+        regions: &[noodles::core::Region],
+    ) -> anyhow::Result<RawMultiQueryIter<'a, R>> {
+        use noodles::csi::binning_index::index::reference_sequence::bin::Chunk;
+        use std::collections::BTreeMap;
+
+        // Resolve every region to a reference ID + interval, grouping the
+        // intervals per reference.
+        let mut intervals_by_ref: BTreeMap<usize, Vec<Interval>> = BTreeMap::new();
+        for region in regions {
+            let ref_id =
+                header.reference_sequences().get_index_of(region.name()).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "region reference sequence {:?} not found in BAM header",
+                        region.name()
+                    )
+                })?;
+            intervals_by_ref.entry(ref_id).or_default().push(region.interval());
+        }
+
+        // Optimize each reference's intervals into a sorted, non-overlapping set
+        // (htsjdk `QueryInterval.optimizeIntervals`), then gather the BAI chunks
+        // for every optimized interval. Optimizing first shrinks both the index
+        // queries and the per-record overlap filter below.
+        let mut chunks: Vec<Chunk> = Vec::new();
+        for (ref_id, intervals) in &mut intervals_by_ref {
+            *intervals = merge_intervals(std::mem::take(intervals));
+            for interval in intervals.iter() {
+                chunks.extend(self.index.query(*ref_id, *interval).context("querying BAI index")?);
+            }
+        }
+
+        // Merge into a minimal, sorted, non-overlapping chunk set so the scan
+        // reads each covered BGZF region exactly once. Overlapping chunks from
+        // adjacent regions collapse here, which is what makes a read spanning
+        // several regions surface only once (htsjdk `optimizeIntervals` analog).
+        let merged = noodles::csi::binning_index::merge_chunks(&chunks);
+
+        let bgzf_reader = self.inner.get_mut();
+        let csi_query = noodles::csi::io::Query::new(bgzf_reader, merged);
+
+        Ok(RawMultiQueryIter { reader: csi_query, intervals_by_ref, record: RawRecord::new() })
+    }
 }
 
 // ─── iterator ───────────────────────────────────────────────────────────────
@@ -219,6 +294,74 @@ impl<R: Read + Seek> Iterator for RawQueryIter<'_, R> {
     }
 }
 
+// ─── multi-interval iterator ─────────────────────────────────────────────────
+
+/// Iterator over raw BAM records overlapping any of several queried regions.
+///
+/// Created by [`IndexedRawBamReader::query_intervals`]. Scans the merged BAI
+/// chunk set for all queried regions in a single virtual-position-ordered pass,
+/// yielding each overlapping record exactly once and in coordinate order. Reuses
+/// a single [`RawRecord`] buffer internally; each `next()` clones the yielded
+/// bytes into a new owned [`RawRecord`].
+pub struct RawMultiQueryIter<'r, R> {
+    reader: noodles::csi::io::Query<'r, bgzf::io::Reader<R>>,
+    /// Queried intervals grouped by reference-sequence ID. A record is yielded
+    /// only when it overlaps one of the intervals for its own reference ID; the
+    /// chunk scan can surface records outside every queried region (chunk
+    /// granularity) or on a reference with no queried region, which are skipped.
+    intervals_by_ref: std::collections::BTreeMap<usize, Vec<Interval>>,
+    record: RawRecord,
+}
+
+impl<R: Read + Seek> Iterator for RawMultiQueryIter<'_, R> {
+    type Item = anyhow::Result<RawRecord>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match read_raw_record(&mut self.reader, &mut self.record) {
+                Ok(0) => return None, // EOF / all chunks consumed
+                Ok(_) => {
+                    // Validate the record's structure *before* touching any
+                    // fixed-offset field: `record_span_1based` fails closed on a
+                    // record shorter than the 32-byte core, so a corrupt BGZF block
+                    // declaring a tiny nonzero size cannot reach the `ref_id`/`pos`
+                    // slice reads below and panic. Returns `Ok(None)` for unmapped
+                    // records (no reference span, cannot overlap).
+                    let (rec_start, rec_end) = match record_span_1based(&self.record) {
+                        Ok(Some(span)) => span,
+                        Ok(None) => continue, // no reference span (unmapped) cannot overlap
+                        Err(e) => return Some(Err(e)), // malformed record: fail closed
+                    };
+
+                    // The fixed core is now known to be present, so reading `ref_id`
+                    // can no longer index past the buffer. Keep the record only if it
+                    // overlaps one of the intervals queried on that reference.
+                    let record_ref_id = crate::fields::ref_id(&self.record);
+                    let Ok(ref_id) = usize::try_from(record_ref_id) else {
+                        continue; // unmapped / negative ref id cannot overlap a region
+                    };
+                    let Some(intervals) = self.intervals_by_ref.get(&ref_id) else {
+                        continue; // record on a reference with no queried region
+                    };
+
+                    // `intervals` is sorted by start and non-overlapping (`merge_intervals`),
+                    // so its ends are strictly increasing. Binary-search for the first
+                    // interval that could reach the record (its end `>= rec_start`); the
+                    // record overlaps iff that interval's start is `<= rec_end`. This scans
+                    // O(log intervals) rather than every queried interval per record.
+                    let idx = intervals.partition_point(|iv| interval_end(iv) < rec_start);
+                    let overlaps =
+                        intervals.get(idx).is_some_and(|iv| interval_start(iv) <= rec_end);
+                    if overlaps {
+                        return Some(Ok(self.record.clone()));
+                    }
+                }
+                Err(e) => return Some(Err(e.into())),
+            }
+        }
+    }
+}
+
 // ─── unmapped iterator ──────────────────────────────────────────────────────
 
 /// Iterator over unmapped raw BAM records.
@@ -248,7 +391,104 @@ impl<R: Read> Iterator for UnmappedIter<'_, R> {
     }
 }
 
+// ─── interval optimization ───────────────────────────────────────────────────
+
+/// Inclusive 1-based start of `interval` as a plain `usize` (unbounded → 1).
+fn interval_start(interval: &Interval) -> usize {
+    interval.start().map_or(1, usize::from)
+}
+
+/// Inclusive 1-based end of `interval` as a plain `usize` (unbounded → `usize::MAX`).
+fn interval_end(interval: &Interval) -> usize {
+    interval.end().map_or(usize::MAX, usize::from)
+}
+
+/// Build an [`Interval`] from 1-based `start`/`end` positions.
+///
+/// `end == usize::MAX` is the sentinel [`interval_end`] returns for an unbounded
+/// end (whole-contig `chr1` / right-open `chr1:100-` queries). It is preserved as
+/// a right-open [`Interval`] rather than round-tripped through `Position`, which
+/// would pin a finite end and stop those queries from covering the tail of a
+/// reference.
+fn make_interval(start: usize, end: usize) -> Interval {
+    use noodles::core::Position;
+    let start = Position::try_from(start.max(1)).expect("start >= 1 is a valid Position");
+    if end == usize::MAX {
+        return Interval::from(start..);
+    }
+    let end = Position::try_from(end.max(1)).expect("end >= 1 is a valid Position");
+    Interval::from(start..=end)
+}
+
+/// Sort and merge a reference's intervals into a minimal, non-overlapping set,
+/// mirroring htsjdk's `QueryInterval.optimizeIntervals`.
+///
+/// Two intervals merge when they overlap **or abut** — i.e. the next interval's
+/// start is `<= end + 1` of the running interval (1-based inclusive coordinates),
+/// so `[1520,1521]` and `[1522,1525]` collapse to `[1520,1525]` while
+/// `[1520,1521]` and `[1523,1525]` (a gap at 1522) stay separate. Optimizing
+/// keeps the per-record overlap filter small and matches the disjoint-interval
+/// precondition htsjdk's multi-interval query assumes.
+fn merge_intervals(mut intervals: Vec<Interval>) -> Vec<Interval> {
+    intervals.sort_by_key(|iv| (interval_start(iv), interval_end(iv)));
+
+    let mut merged: Vec<Interval> = Vec::with_capacity(intervals.len());
+    for interval in intervals {
+        let (start, end) = (interval_start(&interval), interval_end(&interval));
+        if let Some(last) = merged.last_mut() {
+            let last_end = interval_end(last);
+            if start <= last_end.saturating_add(1) {
+                // Overlapping or abutting: extend the running interval if needed.
+                if end > last_end {
+                    *last = make_interval(interval_start(last), end);
+                }
+                continue;
+            }
+        }
+        merged.push(make_interval(start, end));
+    }
+    merged
+}
+
 // ─── overlap test ───────────────────────────────────────────────────────────
+
+/// Compute a mapped record's 1-based inclusive reference span `[start, end]`.
+///
+/// Returns:
+/// - `Ok(Some((start, end)))` for a mapped record with a valid reference span. A
+///   record with a zero-length reference span (unmapped mate placed at a position,
+///   or no CIGAR) is treated as covering its single start position, so its span
+///   equals `intersects_region`'s single-position fallback.
+/// - `Ok(None)` when the record has no reference position (unmapped, or a negative
+///   `pos`) and therefore cannot overlap any queried interval.
+/// - `Err(..)` when the record is malformed — shorter than the fixed core or its
+///   declared CIGAR extends past the record buffer. Rather than silently treating a
+///   truncated record as a point alignment at its start, the span cannot be trusted,
+///   so callers fail closed and propagate the error.
+fn record_span_1based(record: &RawRecord) -> anyhow::Result<Option<(usize, usize)>> {
+    use crate::cigar::reference_length_from_raw_bam_checked;
+    use crate::fields::pos;
+
+    let bytes: &[u8] = record;
+    // Validate the record's structure (fixed core + read-name + CIGAR all within
+    // bounds) before trusting any field; this also guarantees `pos` is in bounds.
+    let ref_len_raw = reference_length_from_raw_bam_checked(bytes).context(
+        "malformed BAM record: truncated, or declared CIGAR/read-name length \
+             exceeds record buffer",
+    )?;
+
+    let p = pos(bytes);
+    if p < 0 {
+        return Ok(None); // unmapped / no position cannot overlap a region
+    }
+    #[allow(clippy::cast_sign_loss)] // guarded by `p >= 0` check above
+    let start_1based = p as usize + 1;
+
+    #[allow(clippy::cast_sign_loss)] // reference_length_from_raw_bam_checked returns non-negative
+    let ref_len = ref_len_raw as usize;
+    let end_1based = if ref_len == 0 { start_1based } else { start_1based + ref_len - 1 };
+    Ok(Some((start_1based, end_1based)))
+}
 
 /// Returns `true` if `record` overlaps `(ref_id, interval)`.
 ///
@@ -259,14 +499,18 @@ fn intersects_region(
     ref_id: usize,
     interval: Interval,
 ) -> anyhow::Result<bool> {
-    use crate::cigar::reference_length_from_raw_bam;
+    use crate::cigar::reference_length_from_raw_bam_checked;
     use crate::fields::{pos, ref_id as raw_ref_id};
     use noodles::core::Position;
 
     let bytes: &[u8] = record;
-    if bytes.len() < 8 {
-        return Ok(false);
-    }
+    // Validate the record's structure (fixed core + read-name + CIGAR all within
+    // bounds) before trusting any field; a truncated/malformed record fails closed
+    // instead of being mistaken for a point alignment at its start.
+    let ref_len_raw = reference_length_from_raw_bam_checked(bytes).context(
+        "malformed BAM record: truncated, or declared CIGAR/read-name length \
+             exceeds record buffer",
+    )?;
 
     // Reference-sequence ID check.
     let record_ref_id = raw_ref_id(bytes);
@@ -286,8 +530,7 @@ fn intersects_region(
     let start_1based = p as usize + 1;
 
     // Alignment end: start_1based + ref_length - 1
-    let ref_len_raw = reference_length_from_raw_bam(bytes);
-    #[allow(clippy::cast_sign_loss)] // reference_length_from_raw_bam returns non-negative
+    #[allow(clippy::cast_sign_loss)] // reference_length_from_raw_bam_checked returns non-negative
     let ref_len = ref_len_raw as usize;
     if ref_len == 0 {
         // Unmapped or no CIGAR; treat as single-position
@@ -314,6 +557,7 @@ mod tests {
     use crate::testutil::*;
     use noodles::bam::{self, bai};
     use noodles::sam::alignment::io::Write as _;
+    use rstest::rstest;
     use std::io::Cursor;
 
     // ── helpers ──────────────────────────────────────────────────────────────
@@ -421,6 +665,52 @@ mod tests {
 
     // ── tests ─────────────────────────────────────────────────────────────────
 
+    /// A well-formed mapped record yields its 1-based inclusive reference span.
+    #[test]
+    fn record_span_1based_accepts_well_formed_record() {
+        // pos=100 (0-based) -> 101 (1-based), 10M -> [101, 110].
+        let bytes = make_bam_bytes(0, 100, 0, b"rea", &[(10 << 4)], 10, -1, -1, &[]);
+        let record = RawRecord::from(bytes);
+        assert_eq!(record_span_1based(&record).expect("span"), Some((101, 110)));
+    }
+
+    /// A record whose declared CIGAR overruns its buffer must fail closed rather
+    /// than be mistaken for a point alignment at its start position.
+    #[test]
+    fn record_span_1based_rejects_truncated_cigar() {
+        // Well-formed 10M record, then corrupt n_cigar_op to claim 100 ops.
+        let mut bytes = make_bam_bytes(0, 100, 0, b"rea", &[(10 << 4)], 10, -1, -1, &[]);
+        bytes[12..14].copy_from_slice(&100u16.to_le_bytes());
+        let record = RawRecord::from(bytes);
+        assert!(record_span_1based(&record).is_err());
+    }
+
+    /// A record shorter than the 32-byte fixed core must fail closed rather than
+    /// let a fixed-offset field read index past the buffer and panic. This is the
+    /// guard `RawMultiQueryIter::next` runs *before* reading `ref_id`, so a corrupt
+    /// BGZF block declaring a tiny nonzero size fails closed instead of crashing
+    /// the scan (a bare `fields::ref_id` would slice `bam[0..4]` and panic here).
+    #[test]
+    fn record_span_1based_rejects_sub_core_length_record() {
+        // Three bytes: shorter than the fixed core, and shorter than the 4 bytes a
+        // bare `ref_id` read would index.
+        let record = RawRecord::from(vec![0u8; 3]);
+        assert!(record_span_1based(&record).is_err());
+    }
+
+    /// The single-interval overlap test shares the same malformed-CIGAR guard and
+    /// also fails closed on a truncated record.
+    #[test]
+    fn intersects_region_rejects_truncated_cigar() {
+        use noodles::core::Position;
+        let mut bytes = make_bam_bytes(0, 100, 0, b"rea", &[(10 << 4)], 10, -1, -1, &[]);
+        bytes[12..14].copy_from_slice(&100u16.to_le_bytes());
+        let record = RawRecord::from(bytes);
+        let interval =
+            Interval::from(Position::try_from(1).unwrap()..=Position::try_from(1000).unwrap());
+        assert!(intersects_region(&record, 0, interval).is_err());
+    }
+
     /// Query a region; verify the right records are returned.
     #[test]
     fn query_returns_overlapping_records() {
@@ -444,6 +734,195 @@ mod tests {
         let raw = results[0].as_ref().expect("record ok");
         // Verify position (0-based pos = 49 → 1-based start = 50).
         assert_eq!(raw.pos(), 49);
+    }
+
+    /// Ported from htsjdk `QueryIntervalTest.testOptimizeIntervals`: overlapping
+    /// and abutting intervals merge; a one-base gap keeps them separate; unsorted
+    /// input is sorted. Compared as `(start, end)` pairs so the assertion is
+    /// independent of `Interval`'s own equality. Each case names the scenario so a
+    /// failure reports the exact interval set and expected merged output.
+    #[rstest]
+    #[case::overlapping(vec![(1520, 1521), (1521, 1525)], vec![(1520, 1525)])]
+    #[case::abutting_zero_gap(vec![(1520, 1521), (1522, 1525)], vec![(1520, 1525)])]
+    #[case::one_base_gap_kept_separate(
+        vec![(1520, 1521), (1523, 1525)],
+        vec![(1520, 1521), (1523, 1525)]
+    )]
+    #[case::unsorted_overlapping(vec![(20, 30), (10, 20)], vec![(10, 30)])]
+    fn merge_intervals_matches_htsjdk_optimize_intervals(
+        #[case] input: Vec<(usize, usize)>,
+        #[case] expected: Vec<(usize, usize)>,
+    ) {
+        use noodles::core::Position;
+        let iv = |s: usize, e: usize| {
+            Interval::from(Position::try_from(s).unwrap()..=Position::try_from(e).unwrap())
+        };
+        let pairs = |ivs: Vec<Interval>| -> Vec<(usize, usize)> {
+            ivs.iter().map(|i| (interval_start(i), interval_end(i))).collect()
+        };
+
+        let intervals: Vec<Interval> = input.iter().map(|&(s, e)| iv(s, e)).collect();
+        assert_eq!(pairs(merge_intervals(intervals)), expected);
+    }
+
+    /// Ported from htsjdk `BAMFileIndexTest.testMultiIntervalQuery`: a
+    /// multi-interval query returns exactly the union of the per-interval
+    /// queries, with each record yielded once and in coordinate order. Records
+    /// are keyed by `(ref_id, pos)`, which is unique here by construction.
+    #[test]
+    fn query_intervals_equals_union_of_single_queries() {
+        use noodles::core::Region;
+        use std::collections::BTreeSet;
+
+        let header = make_header(&[("chr1", 1000), ("chr2", 1000)]);
+        // SPAN starts before every region and covers them all — a naive
+        // per-region loop would surface it once per region; the merged scan must
+        // surface it exactly once.
+        let records = [
+            mapped_record(0, 5, 300),  // chr1:5-304 (spans every chr1 region)
+            mapped_record(0, 50, 10),  // chr1:50-59
+            mapped_record(0, 100, 10), // chr1:100-109 (inside two overlapping regions)
+            mapped_record(0, 150, 10), // chr1:150-159
+            mapped_record(0, 400, 10), // chr1:400-409 (not queried)
+            mapped_record(1, 30, 10),  // chr2:30-39
+        ];
+        let (bam, index) = build_and_index(&header, &records);
+
+        let regions: Vec<Region> = ["chr1:45-105", "chr1:100-160", "chr2:25-35"]
+            .iter()
+            .map(|s| s.parse().expect("region"))
+            .collect();
+
+        let mut reader = IndexedRawBamReader::new(Cursor::new(bam), index);
+        let hdr = reader.read_header().expect("header");
+
+        // Union of the per-interval single-region queries.
+        let mut union: BTreeSet<(i32, i32)> = BTreeSet::new();
+        for region in &regions {
+            for result in reader.query(&hdr, region).expect("query") {
+                let rec = result.expect("record ok");
+                union.insert((rec.ref_id(), rec.pos()));
+            }
+        }
+
+        // Multi-interval query over the same reader.
+        let multi: Vec<_> = reader
+            .query_intervals(&hdr, &regions)
+            .expect("query_intervals")
+            .map(|r| r.expect("record ok"))
+            .collect();
+        let multi_keys: Vec<(i32, i32)> = multi.iter().map(|r| (r.ref_id(), r.pos())).collect();
+
+        // Each record appears exactly once.
+        let multi_set: BTreeSet<(i32, i32)> = multi_keys.iter().copied().collect();
+        assert_eq!(
+            multi_set.len(),
+            multi_keys.len(),
+            "multi-interval query yielded a record more than once: {multi_keys:?}"
+        );
+        // Same set as the union of the single-interval queries.
+        assert_eq!(multi_set, union, "multi-interval set differs from single-query union");
+        // Emitted in coordinate order.
+        let mut sorted = multi_keys.clone();
+        sorted.sort_unstable();
+        assert_eq!(multi_keys, sorted, "records not in coordinate order: {multi_keys:?}");
+    }
+
+    /// `make_interval` must keep an unbounded end (`usize::MAX` sentinel) open
+    /// rather than pinning it to a finite `Position`, while a bounded end still
+    /// round-trips inclusively.
+    #[test]
+    fn make_interval_preserves_unbounded_end() {
+        let unbounded = make_interval(100, usize::MAX);
+        assert_eq!(interval_start(&unbounded), 100);
+        assert!(unbounded.end().is_none(), "unbounded end must not be pinned to a finite Position");
+        assert_eq!(interval_end(&unbounded), usize::MAX);
+
+        let bounded = make_interval(100, 200);
+        assert_eq!((interval_start(&bounded), interval_end(&bounded)), (100, 200));
+        assert_eq!(bounded.end().map(usize::from), Some(200));
+    }
+
+    /// A whole-contig (`chr1`) query carries an unbounded interval; every record on
+    /// the contig — including ones deep in its tail — must be returned, proving the
+    /// unbounded end is not pinned to a finite position.
+    #[test]
+    fn query_intervals_whole_contig_covers_tail() {
+        use noodles::core::Region;
+        use std::collections::BTreeSet;
+
+        let header = make_header(&[("chr1", 100_000)]);
+        let records = [
+            mapped_record(0, 10, 10),     // chr1:10-19
+            mapped_record(0, 100, 10),    // chr1:100-109
+            mapped_record(0, 50_000, 10), // chr1:50000-50009 (deep in the tail)
+        ];
+        let (bam, index) = build_and_index(&header, &records);
+        let mut reader = IndexedRawBamReader::new(Cursor::new(bam), index);
+        let hdr = reader.read_header().expect("header");
+
+        let regions: Vec<Region> = vec!["chr1".parse().expect("region")];
+        let got: BTreeSet<i32> = reader
+            .query_intervals(&hdr, &regions)
+            .expect("query_intervals")
+            .map(|r| r.expect("record ok").pos())
+            .collect();
+        // 0-based positions of all three records (10,100,50000 → -1).
+        let expected: BTreeSet<i32> = [9, 99, 49_999].into_iter().collect();
+        assert_eq!(got, expected, "whole-contig query must cover the entire reference");
+    }
+
+    /// Overlap boundaries for the merged-interval binary search: a record whose
+    /// span touches an interval at either edge overlaps, while one that falls in
+    /// the gap between two intervals — or entirely before/after them — does not.
+    /// Guards the `partition_point` bounds (`end >= rec_start` / `start <= rec_end`)
+    /// against off-by-one regressions.
+    #[test]
+    fn query_intervals_overlap_boundaries() {
+        use noodles::core::Region;
+        use std::collections::BTreeSet;
+
+        let header = make_header(&[("chr1", 1000)]);
+        // Two point regions at chr1:100 and chr1:200 → merged intervals
+        // [(100,100), (200,200)]. Records chosen to sit on each boundary and in
+        // the gaps; only those whose 1-based span includes 100 or 200 overlap.
+        let records = [
+            mapped_record(0, 50, 10),  // [50,59]    before first  → excluded
+            mapped_record(0, 91, 10),  // [91,100]   ends at 100    → included
+            mapped_record(0, 100, 1),  // [100,100]  exact point    → included
+            mapped_record(0, 101, 10), // [101,110]  gap            → excluded
+            mapped_record(0, 196, 5),  // [196,200]  ends at 200    → included
+            mapped_record(0, 200, 5),  // [200,204]  starts at 200  → included
+            mapped_record(0, 205, 5),  // [205,209]  after last     → excluded
+        ];
+        let (bam, index) = build_and_index(&header, &records);
+
+        let regions: Vec<Region> =
+            ["chr1:100-100", "chr1:200-200"].iter().map(|s| s.parse().expect("region")).collect();
+
+        let mut reader = IndexedRawBamReader::new(Cursor::new(bam), index);
+        let hdr = reader.read_header().expect("header");
+
+        let got: BTreeSet<i32> = reader
+            .query_intervals(&hdr, &regions)
+            .expect("query_intervals")
+            .map(|r| r.expect("record ok").pos())
+            .collect();
+
+        // 0-based positions of the four overlapping records (91,100,196,200 → -1).
+        let expected: BTreeSet<i32> = [90, 99, 195, 199].into_iter().collect();
+        assert_eq!(got, expected, "boundary overlap set mismatch");
+    }
+
+    /// `query_intervals` with no regions yields nothing.
+    #[test]
+    fn query_intervals_no_regions_is_empty() {
+        let header = make_header(&[("chr1", 1000)]);
+        let (bam, index) = build_and_index(&header, &[mapped_record(0, 10, 10)]);
+        let mut reader = IndexedRawBamReader::new(Cursor::new(bam), index);
+        let hdr = reader.read_header().expect("header");
+        let count = reader.query_intervals(&hdr, &[]).expect("query_intervals").count();
+        assert_eq!(count, 0, "no regions must yield no records");
     }
 
     /// Query a region with no overlapping records — iterator must be empty.

--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -81,6 +81,7 @@ pub use cigar::{
     read_pos_at_ref_pos_raw,
     reference_length_from_cigar,
     reference_length_from_raw_bam,
+    reference_length_from_raw_bam_checked,
     unclipped_5prime_from_raw_bam,
     unclipped_5prime_raw,
 };

--- a/src/lib/commands/review.rs
+++ b/src/lib/commands/review.rs
@@ -775,6 +775,7 @@ impl Review {
         command_line: &str,
     ) -> Result<HashSet<String>> {
         use noodles::bam;
+        use std::collections::HashMap;
 
         let index = Self::read_bam_index(&self.consensus_bam)?;
         let mut reader = IndexedRawBamReader::from_path(&self.consensus_bam, index)?;
@@ -790,60 +791,78 @@ impl Review {
 
         let mut mi_set = HashSet::new();
 
-        // Buffer the matching consensus reads, deduplicating those seen across the
-        // per-variant region queries, then emit them in coordinate order. A consensus
-        // read that is non-reference at two or more variant loci is returned by each of
-        // those loci's queries, but fgbio's single `consensusIn.query(variants)` emits
-        // every matching read exactly once and in coordinate order. Key on read identity
-        // (name, flags, ref id, position) so each physical record is buffered once.
-        let mut written_records: HashSet<(Vec<u8>, u16, i32, i32)> = HashSet::new();
-        let mut records: Vec<RawRecord> = Vec::new();
+        // Issue a single multi-interval query, one point region per variant. Mirroring
+        // fgbio's single `consensusIn.query(variants)`, `query_intervals` merges the
+        // regions' BAI chunks and scans them once, so every overlapping consensus read
+        // is visited exactly once and in coordinate order. We can therefore filter and
+        // stream straight to the writer — no buffering, de-duplication, or final sort is
+        // required, and the emitted `.consensus.bam` (indexed in `execute` via
+        // `bam::fs::index`) is coordinate-sorted by construction.
+        let regions = variants
+            .iter()
+            .map(|variant| -> Result<noodles::core::Region> {
+                let pos = noodles::core::Position::try_from(variant.pos as usize)?;
+                Ok(noodles::core::Region::new(variant.chrom.as_str(), pos..=pos))
+            })
+            .collect::<Result<Vec<_>>>()?;
 
-        // Query each variant region
+        // Group variants by reference ID so each read is only tested against variants on
+        // its own contig — `has_non_reference_base` matches on position, not contig.
+        let ref_id_by_name: HashMap<String, i32> = header
+            .reference_sequences()
+            .keys()
+            .enumerate()
+            .map(|(idx, name)| (String::from_utf8_lossy(name).into_owned(), idx as i32))
+            .collect();
+        let mut variants_by_ref_id: HashMap<i32, Vec<&Variant>> = HashMap::new();
         for variant in variants {
-            let start = noodles::core::Position::try_from(variant.pos as usize)?;
-            let region = noodles::core::Region::new(variant.chrom.as_str(), start..=start);
-
-            for result in reader.query(&header, &region)? {
-                let record = result?;
-
-                // Check if this read has a non-reference base at the variant position
-                if self.has_non_reference_base(&record, variant)? {
-                    let identity = (
-                        record.read_name().to_vec(),
-                        record.flags(),
-                        record.ref_id(),
-                        record.pos(),
-                    );
-                    if !written_records.insert(identity) {
-                        continue; // Already extracted at another variant locus.
-                    }
-
-                    // fgbio records `toMi(rec)` in its source set for every
-                    // non-reference consensus read, erroring if the MI tag is
-                    // absent (ReviewConsensusVariantsTest.scala:166).
-                    let mi_base = to_mi(&record)?;
-                    mi_set.insert(mi_base);
-
-                    records.push(record);
-                }
+            if let Some(&ref_id) = ref_id_by_name.get(&variant.chrom) {
+                variants_by_ref_id.entry(ref_id).or_default().push(variant);
             }
         }
+        // Sort each reference's variants by position so a read only has to test the
+        // variants inside its aligned span, found by binary search below, rather than
+        // every variant on the contig.
+        for ref_variants in variants_by_ref_id.values_mut() {
+            ref_variants.sort_by_key(|variant| variant.pos);
+        }
 
-        // Emit in coordinate order so the indexed `.consensus.bam` (indexed in `execute`
-        // via `bam::fs::index`) is valid. The per-variant queries visit variants in
-        // coordinate order, but a read that is non-reference only at a later variant can
-        // still start before a read emitted at an earlier variant, so query order is not
-        // necessarily coordinate-sorted. A stable sort by (reference id, position) — with
-        // unmapped reads (ref id -1) placed last, matching BAM coordinate order —
-        // reproduces fgbio's `query(variants)` ordering.
-        records.sort_by_key(|record| {
-            let ref_id = record.ref_id();
-            let ref_key = if ref_id < 0 { i64::MAX } else { i64::from(ref_id) };
-            (ref_key, record.pos())
-        });
-        for record in &records {
-            write_raw_record(writer.get_mut(), record)?;
+        for result in reader.query_intervals(&header, &regions)? {
+            let record = result?;
+
+            let Some(overlapping) = variants_by_ref_id.get(&record.ref_id()) else {
+                continue; // read on a reference with no reviewed variant
+            };
+
+            // Only variants within the read's aligned span can be non-reference in it
+            // (`has_non_reference_base` returns false outside `[start, end]`). Restrict
+            // the scan to that position range via binary search on the sorted variants.
+            let (Some(start), Some(end)) =
+                (record.alignment_start_1based(), record.alignment_end_1based())
+            else {
+                continue; // unmapped / no aligned span cannot be non-reference at a variant
+            };
+            #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+            let (start, end) = (start as i32, end as i32);
+            let lo = overlapping.partition_point(|variant| variant.pos < start);
+            let hi = overlapping.partition_point(|variant| variant.pos <= end);
+
+            // fgbio's `nonReferenceAtAnyVariant`: keep the read if it is non-reference at
+            // any variant it overlaps. The single ordered scan already guarantees each
+            // read is seen once and in coordinate order, so we write it in place.
+            let mut non_reference = false;
+            for &variant in &overlapping[lo..hi] {
+                if self.has_non_reference_base(&record, variant)? {
+                    non_reference = true;
+                    break;
+                }
+            }
+            if non_reference {
+                // fgbio records `toMi(rec)` for every non-reference consensus read,
+                // erroring if the MI tag is absent (ReviewConsensusVariantsTest.scala:166).
+                mi_set.insert(to_mi(&record)?);
+                write_raw_record(writer.get_mut(), &record)?;
+            }
         }
 
         Ok(mi_set)


### PR DESCRIPTION
Stacked on #522.

## Why

#522 fixed `ReviewConsensusVariants` cross-locus de-duplication and coordinate-ordered output by buffering every matching consensus read in a `Vec<RawRecord>` and sorting before writing. CodeRabbit flagged (correctly) that the buffer grows with the total number of non-reference matches across all reviewed loci — a real footprint on high-depth panels.

fgbio never buffers. `SamSource.query(variants)` issues a single optimized multi-interval htsjdk query (`QueryInterval.optimizeIntervals` + one coordinate-ordered pass over the merged BAI chunks), so each overlapping read is visited exactly once, in coordinate order, and streamed straight to the writer. The buffer/sort/dedup in #522 only exist because fgumi's reader offered *single-region* `query` and *full-scan*, but no multi-interval query — so #522 reconstructed the missing primitive's effect after the fact.

This PR adds the primitive itself instead of working around its absence.

## What

- **New `IndexedRawBamReader::query_intervals`** — the multi-interval analog of `query`. It optimizes each reference's intervals (sort + merge overlapping/abutting, matching htsjdk `optimizeIntervals`), gathers their BAI chunks, `merge_chunks`-es them into a minimal non-overlapping set, and scans that set once. A read spanning several regions surfaces **once** (chunk-level merge), and records emerge in **coordinate order** (virtual-position-ordered scan of a coordinate-sorted BAM). This is htsjdk's `optimizeIntervals` + single-pass query, lifted into fgumi as a reusable primitive.
- **`extract_consensus_reads` rewired** to issue one `query_intervals` over a point region per variant, group variants by reference id (so `has_non_reference_base` only ever sees same-contig variants — closing a latent cross-contig hazard), and write each non-reference read in place. The `records` buffer, `written_records` dedup set, and final sort are **gone**. Peak memory is now O(1) in matched reads, like fgbio, while staying index-efficient — no full-scan regression for sparse panels.

## Tests

Ports htsjdk's known-good tests for the new primitive:
- `QueryIntervalTest.testOptimizeIntervals` → `merge_intervals_matches_htsjdk_optimize_intervals` (overlapping merge, abutting merge, one-base-gap kept separate, unsorted input sorted).
- `BAMFileIndexTest.testMultiIntervalQuery` → `query_intervals_equals_union_of_single_queries` (multi-interval result equals the union of the per-interval queries, each record once, in coordinate order — with a spanning read that a naive per-region loop would double-emit).

The existing REV3-05 (written-once) and REV3-05b (coordinate-sorted) parity tests continue to pin the fgbio-parity of the streamed output. Full suite: 4743 passed.

## Reading order

1. `crates/fgumi-raw-bam/src/indexed_reader.rs` — `query_intervals` + `merge_intervals` + `RawMultiQueryIter`, then the two ported tests.
2. `src/lib/commands/review.rs` — `extract_consensus_reads` rewire.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-region querying via a new `query_intervals` API, backed by a single-pass iterator that merges intervals and yields matching records once each in coordinate order.
* **Improvements**
  * Consensus-read extraction now uses the new multi-region interval scan for simpler, faster processing.
  * Added a checked helper for computing reference-consuming span from raw BAM CIGAR data, and re-exported it for external use.
* **Bug Fixes**
  * More robust handling of malformed/truncated records to prevent incorrect overlap/span results.
* **Tests**
  * Expanded coverage for interval merging, multi-region equivalence (including empty inputs), and malformed/truncated CIGAR scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->