### PR TITLE
test(codec): read stats as fgbio KV metrics in pre-group-filter test

### DIFF
--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -886,15 +886,30 @@ mod tests {
         cmd.outer_bases_length = 0;
         cmd.execute("test")?;
 
-        let metrics: Vec<ConsensusMetrics> = DelimFile::default().read_tsv(&stats_path)?;
-        let metrics = metrics.first().expect("stats file should contain one metrics row");
+        // Codec emits fgbio's vertical key-value metrics format, so read the rows
+        // back as `ConsensusKvMetric` and look up the two counts by key: the
+        // supplementary read must be filtered before grouping, so exactly the two
+        // primaries are considered (`raw_reads_considered`) and the single FR
+        // molecule is emitted (`consensus_reads_emitted`).
+        let kv_metrics: Vec<ConsensusKvMetric> = DelimFile::default().read_tsv(&stats_path)?;
+        let value_for = |key: &str| -> u64 {
+            kv_metrics
+                .iter()
+                .find(|m| m.key == key)
+                .unwrap_or_else(|| panic!("stats file should contain a `{key}` row"))
+                .value
+                .parse()
+                .unwrap_or_else(|_| panic!("`{key}` value should be an integer"))
+        };
         assert_eq!(
-            metrics.total_input_reads, 2,
+            value_for("raw_reads_considered"),
+            2,
             "the supplementary alignment must be dropped before grouping (allow_unmapped={allow_unmapped}): \
              only the two primary reads reach the codec caller"
         );
         assert_eq!(
-            metrics.consensus_reads, 1,
+            value_for("consensus_reads_emitted"),
+            1,
             "the valid mapped FR pair is consensus-called (allow_unmapped={allow_unmapped})"
         );
 
@@ -951,7 +966,7 @@ mod tests {
     }
 
     // Integration tests
-    use crate::metrics::consensus::ConsensusMetrics;
+    use crate::metrics::consensus::ConsensusKvMetric;
     use fgumi_raw_bam::{
         SamBuilder as RawSamBuilder, flags, raw_record_to_record_buf, testutil::encode_op,
     };


### PR DESCRIPTION
`test_codec_allow_unmapped_gates_pregroup_filter` parsed the codec stats file as a wide `ConsensusMetrics` TSV, but `codec` emits fgbio's vertical key-value format (`ConsensusKvMetric`). The header mismatch made `read_tsv` fail with `Error parsing delimited data file header` in all four cases (fast-path/threaded × default/allow-unmapped), failing `test` and `coverage` on `main`.

This was a semantic merge conflict, not a code regression: #513 switched codec stats to the KV format, then #509 (merged after) added this test against the old wide layout. Both merged cleanly as text, so the break only surfaced on the merged `main` tip — which is why the release PR (#454) and branches rebased on it (#519, #527) all inherit the same four failing cases.

The fix reads the rows back as `ConsensusKvMetric` and looks up the counts by key (`raw_reads_considered`, `consensus_reads_emitted`), mirroring the sibling `simplex` tests. The assertions' intent is unchanged: the supplementary alignment is filtered before grouping (2 raw reads considered) and the single FR molecule is emitted (1 consensus read).

Verified locally: all four cases pass; full `codec` module green; `fmt` and `clippy --all-targets -D warnings` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated CODEC integration test coverage to validate the current `--stats` tab-separated output format.
  * Added checks for raw reads considered and consensus reads emitted statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->