### PR TITLE
docs(extract): document EXT3-03 encoding-failure parity with fgbio (W9 follow-up to #550)

### DIFF
--- a/src/lib/commands/extract.rs
+++ b/src/lib/commands/extract.rs
@@ -12,7 +12,10 @@
 //! # Quality Encoding
 //!
 //! Automatically detects and handles both Phred+33 (standard) and Phred+64 (Illumina 1.3-1.7)
-//! quality encodings.
+//! quality encodings. Detection pools the heads of all input FASTQs (EXT3-01), matching fgbio
+//! `FastqToBam`. When no encoding matches the observed qualities, fgumi fails like fgbio's
+//! `case Nil => fail(...)` (EXT3-03) but improves on its static message by reporting the
+//! observed quality range in the error (see [`QualityEncoding::from_stats`]).
 
 use crate::commands::command::Command;
 use crate::commands::common::{
@@ -280,7 +283,22 @@ impl QualityEncoding {
             return Ok(QualityEncoding::Standard);
         }
 
-        // Quality scores should be printable ASCII (33-126)
+        // No-compatible-encoding failure (fgbio parity: EXT3-03).
+        //
+        // fgbio `FastqToBam` derives this failure from its encoding model: it builds
+        // the set of encodings whose ASCII range contains every observed quality char,
+        // and `case Nil => fail("Quality scores in FASTQ files do not match any known
+        // encoding.")` when that set is empty (`FastqToBam.scala:131`). Because the
+        // Standard (Phred+33) ASCII range `[33, 126]` is the union of all three fgbio
+        // encodings' ranges (Solexa `[59, 126]` and Illumina `[64, 126]` are subsets),
+        // fgbio's compatible set is empty on *exactly* the condition below: an observed
+        // char `< 33` or `> 126`. So this bail is fgbio-equivalent on the failure set.
+        //
+        // fgumi intentionally *improves* on fgbio's message here rather than copying it.
+        // fgbio emits a static string; fgumi reports the observed `[min, max]` range and
+        // the required range, which points the user straight at the offending file
+        // instead of just asserting no encoding matched. This divergence is deliberate,
+        // not a parity gap (see `detect_reports_observed_range_on_no_compatible_encoding`).
         if min_qual < 33 || max_qual > 126 {
             bail!(
                 "Invalid quality scores detected: range [{min_qual}, {max_qual}]. \
@@ -3690,28 +3708,31 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("no records provided"));
     }
 
-    #[test]
-    fn test_quality_encoding_detection_invalid_low() {
-        // Test that quality scores below 33 produce an error
-        let records = vec![vec![20u8, 30, 40, 50]]; // 20 is below valid range
-
-        let result = QualityEncoding::detect(&records);
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert!(err_msg.contains("Invalid quality scores"));
-        assert!(err_msg.contains("20"));
-    }
-
-    #[test]
-    fn test_quality_encoding_detection_invalid_high() {
-        // Test that quality scores above 126 produce an error
-        let records = vec![vec![50u8, 60, 70, 127]]; // 127 is above valid range
-
-        let result = QualityEncoding::detect(&records);
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert!(err_msg.contains("Invalid quality scores"));
-        assert!(err_msg.contains("127"));
+    /// EXT3-03 (fgbio parity + message improvement): fgbio `FastqToBam` fails with
+    /// `case Nil => fail("Quality scores in FASTQ files do not match any known encoding.")`
+    /// when no encoding's ASCII range contains every observed quality char. Because
+    /// Standard's `[33, 126]` range is the union of all three fgbio encodings (Solexa
+    /// `[59, 126]` and Illumina `[64, 126]` are subsets), fgbio's compatible set is empty
+    /// on exactly the condition fgumi bails on: a char `< 33` or `> 126`. So fgumi's
+    /// failure *set* matches fgbio. fgumi deliberately *improves* on fgbio's static
+    /// message by naming the observed `[min, max]` range; these cases assert both that
+    /// each fgbio-Nil input fails and that the improved range-reporting message survives.
+    #[rstest]
+    #[case::below_min_char(vec![vec![20u8, 30, 40, 50]], "20", "50")]
+    #[case::above_max_char(vec![vec![50u8, 60, 70, 127]], "50", "127")]
+    #[case::both_out_of_range(vec![vec![20u8], vec![127u8]], "20", "127")]
+    fn detect_reports_observed_range_on_no_compatible_encoding(
+        #[case] records: Vec<Vec<u8>>,
+        #[case] expected_min: &str,
+        #[case] expected_max: &str,
+    ) {
+        let err = QualityEncoding::detect(&records).expect_err("no compatible encoding must fail");
+        let msg = err.to_string();
+        assert!(msg.contains("Invalid quality scores"), "unexpected message: {msg}");
+        assert!(
+            msg.contains(&format!("[{expected_min}, {expected_max}]")),
+            "message must report the observed range (the fgbio-message improvement): {msg}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What / why (EXT3-03, W9 follow-up to #550)

Follow-on to #550 (EXT3-01, now merged). #550 deferred **EXT3-03** — fgbio `FastqToBam`'s `case Nil => fail(...)` hard-fail on the "no compatible encoding" branch — as a separate item. This PR closes it out.

### Finding

Tracing both sides shows fgumi's failure behavior **already matches fgbio's**, so EXT3-03 is a documentation + parity-lock change, not a behavior change.

fgbio derives the failure from its encoding model: it builds the set of encodings whose ASCII range contains every observed quality char and fails with `case Nil => fail("Quality scores in FASTQ files do not match any known encoding.")` when that set is empty (`FastqToBam.scala:131`). Because Standard's ASCII range `[33, 126]` is the **union** of all three fgbio encodings (Solexa `[59, 126]` and Illumina `[64, 126]` are subsets), fgbio's compatible set is empty on *exactly* the condition fgumi already bails on in `QualityEncoding::from_stats`: an observed quality char `< 33` or `> 126`.

I checked the empty-input, all-empty-quals, and ambiguous-range paths too — none is a case where fgumi succeeds but fgbio fails. The failure *sets* are identical.

### fgumi message is a deliberate improvement

The only real difference is the message. fgbio emits a static string; fgumi reports the observed `[min, max]` range and the required range, pointing the user straight at the offending file. This divergence is intentional and now documented as such (not a parity gap).

| | message on no-compatible-encoding |
|---|---|
| fgbio | `Quality scores in FASTQ files do not match any known encoding.` |
| fgumi | `Invalid quality scores detected: range [20, 50]. Quality scores must be in the printable ASCII range (33-126)` |

## Changes

- Document the EXT3-03 fgbio parity at the detection bail site in `QualityEncoding::from_stats`, and in the module `# Quality Encoding` header.
- Record that fgumi's dynamic, range-reporting message is a deliberate improvement over fgbio's static one.
- Consolidate the `invalid_low` / `invalid_high` tests into an `#[rstest]` case table (`detect_reports_observed_range_on_no_compatible_encoding`, cases `below_min_char` / `above_max_char` / `both_out_of_range`) that asserts both the fgbio-equivalent failure set and that the improved range-reporting message survives.

No runtime behavior change; net diff is docs + a test refactor (1 file, +45/−24).

## Verification

- Targeted encoding-detection tests green (16/16, incl. the 3 new parity cases).
- `cargo ci-fmt` and `cargo ci-lint` clean.
- Full `cargo ci-test` is green except one pre-existing, unrelated failure: the workspace-wide `xtask check_tag_literals` lint walks into stray nested agent worktrees under `main/.claude/worktrees/` (foreign branches, untracked by this repo) and flags *their* bench files. This diff contains no bare SAM-tag byte literals and does not touch that check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how quality encoding is detected across all input FASTQ files.
  * Documented improved error reporting when no compatible encoding is found, including the observed quality range.

* **Bug Fixes**
  * Error messages now report the minimum and maximum observed quality scores for invalid encodings.

* **Tests**
  * Added coverage verifying that invalid quality errors include the observed score range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->