### PR TITLE
fix(consensus): collapse codec masking if into a let-chain

### DIFF
--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -1312,13 +1312,13 @@ impl CodecConsensusCaller {
         let len = consensus.quals.len();
 
         // 1. Outer bases: assign the outer quality to the first/last `outer_bases_length` bases.
-        if self.options.outer_bases_length > 0 {
-            if let Some(outer_qual) = self.options.outer_bases_qual {
-                let last_idx = len.saturating_sub(1);
-                for i in 0..min(self.options.outer_bases_length, len) {
-                    consensus.quals[i] = outer_qual;
-                    consensus.quals[last_idx - i] = outer_qual;
-                }
+        if self.options.outer_bases_length > 0
+            && let Some(outer_qual) = self.options.outer_bases_qual
+        {
+            let last_idx = len.saturating_sub(1);
+            for i in 0..min(self.options.outer_bases_length, len) {
+                consensus.quals[i] = outer_qual;
+                consensus.quals[last_idx - i] = outer_qual;
             }
         }
 


### PR DESCRIPTION
## Summary

Main's `lint` job is currently failing — commit `0ae197c0` (#575, the MSRV/let-chain adoption) bumped the toolchain to Rust 1.93, whose clippy now fires `collapsible_if` on a pre-existing nested `if` in `mask_consensus_quals_query_based` (`crates/fgumi-consensus/src/codec_caller.rs:1315`). #575 didn't clean it up, so main and every PR rebased onto it fail `cargo ci-lint`.

This collapses the nested `if outer_bases_length > 0 { if let Some(outer_qual) = outer_bases_qual }` into a single let-chain — the idiom the newer toolchain unlocks — matching the project policy in CLAUDE.md to *adopt new idioms rather than suppress the clippy lints that flag them*. Behavior is unchanged.

## Verification

- `cargo ci-lint` (workspace, `-D warnings -W clippy::pedantic`) passes clean.
- No functional change; the masking logic is byte-for-byte equivalent.