### PR TITLE
fix: recompute the BAM bin field after raw POS/CIGAR mutations (clip, zipper)

### DIFF
--- a/crates/fgumi-raw-bam/src/bin.rs
+++ b/crates/fgumi-raw-bam/src/bin.rs
@@ -1,0 +1,187 @@
+//! BAM bin field (`reg2bin`) computation.
+//!
+//! The BAM binary record carries a 16-bit `bin` field (bytes 10–11) that indexes
+//! the alignment into the UCSC binning scheme (SAM spec §5.3). The bin is a pure
+//! function of the alignment's reference span — its 0-based start (`POS`) and the
+//! reference length consumed by its CIGAR — so any operation that moves `POS` or
+//! rewrites the CIGAR (clipping, mate relocation, unmapping) invalidates it and
+//! must recompute it.
+//!
+//! The noodles BAM *encoder* recomputes the bin from `POS`+CIGAR whenever a
+//! `RecordBuf` is serialized, and htsjdk does the same on write — but fgumi's
+//! raw-byte pipelines mutate the encoded record in place and emit the bytes
+//! verbatim, so there is no encode step to refresh the field. These helpers are
+//! the raw-byte equivalent: call [`set_bin_from_raw_bam`] (or the
+//! `RawRecord::recompute_bin` convenience wrapper) after any in-place `POS`/CIGAR
+//! change so the emitted record carries a correct bin.
+
+use crate::cigar::reference_length_from_raw_bam;
+use crate::fields::pos;
+
+/// The BAM "unmapped bin" — `reg2bin(-1, 0)` per SAM spec §4.2.1. Records with no
+/// alignment position (`POS < 0`) use this value.
+pub const UNMAPPED_BIN: u16 = 4680;
+
+/// Compute the BAM bin for a reference region using the SAM spec §5.3 `reg2bin`
+/// reference implementation.
+///
+/// `beg` is the 0-based leftmost aligned position; `end` is the 0-based position
+/// one past the rightmost aligned base (i.e. a half-open `[beg, end)` interval,
+/// which equals `POS + reference_length`). Callers with an unmapped region should
+/// use [`UNMAPPED_BIN`] directly rather than passing negative coordinates here.
+///
+/// The layer constants `((1 << k) - 1) / 7` are written verbatim from the SAM
+/// specification's reference C code; clippy's `eq_op` lint flags the smallest
+/// layer (`((1 << 3) - 1) / 7`) as a tautology, but the form is kept to stay
+/// textually identical to the spec.
+#[allow(clippy::eq_op, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+#[must_use]
+pub fn reg2bin(beg: i32, end: i32) -> u16 {
+    // `end` arrives half-open; the spec reference code works with the 0-based
+    // position of the last aligned base, so decrement once up front.
+    let end = end - 1;
+    let bin = if beg >> 14 == end >> 14 {
+        ((1 << 15) - 1) / 7 + (beg >> 14)
+    } else if beg >> 17 == end >> 17 {
+        ((1 << 12) - 1) / 7 + (beg >> 17)
+    } else if beg >> 20 == end >> 20 {
+        ((1 << 9) - 1) / 7 + (beg >> 20)
+    } else if beg >> 23 == end >> 23 {
+        ((1 << 6) - 1) / 7 + (beg >> 23)
+    } else if beg >> 26 == end >> 26 {
+        ((1 << 3) - 1) / 7 + (beg >> 26)
+    } else {
+        0
+    };
+    // Truncate overflowing bin IDs, matching noodles/htsjdk behaviour.
+    bin as u16
+}
+
+/// Compute the BAM bin for a raw BAM record from its `POS` and CIGAR reference
+/// span. Returns [`UNMAPPED_BIN`] when the record has no alignment position
+/// (`POS < 0`), matching htsjdk `SAMRecord.computeIndexingBin` (which keys off
+/// the alignment start, not the unmapped flag — a flag-unmapped but *placed*
+/// read still gets its position's bin).
+#[must_use]
+pub fn bin_from_raw_bam(bam: &[u8]) -> u16 {
+    let start = pos(bam);
+    if start < 0 {
+        return UNMAPPED_BIN;
+    }
+    // A placed read with a CIGAR that consumes no reference (e.g. all soft-clip)
+    // still occupies a single reference position; clamp to 1 so its bin reflects
+    // its start rather than degenerating (matches htsjdk `alignmentEnd = start`).
+    let ref_len = reference_length_from_raw_bam(bam).max(1);
+    reg2bin(start, start + ref_len)
+}
+
+/// Recompute and write the BAM bin field (bytes 10–11, little-endian) of a raw
+/// BAM record in place, from its current `POS` and CIGAR. Call after any in-place
+/// mutation of `POS` or the CIGAR.
+pub fn set_bin_from_raw_bam(bam: &mut [u8]) {
+    let value = bin_from_raw_bam(bam);
+    bam[10..12].copy_from_slice(&value.to_le_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SamBuilder;
+    use crate::testutil::encode_op;
+    use rstest::rstest;
+
+    // CIGAR op codes (BAM encoding): M=0, S=4.
+    const M: u32 = 0;
+    const S: u32 = 4;
+
+    // Authoritative `reg2bin` vectors ported verbatim from htsjdk
+    // `GenomicIndexUtilTest.testRegionToBinDataProvider` (regionToBin uses the
+    // identical `[beg, end)` 0-based convention). Exercises every binning level:
+    // level 5 (16 kb), level 4 (128 kb), level 3 (1 Mb), level 2 (8 Mb),
+    // level 1 (64 Mb), and level 0 (whole-window bin 0). Note htsjdk's `1<<26+1`
+    // is `1<<27` under Java/Rust shift-vs-`+` precedence.
+    #[rstest]
+    #[case::empty_at_zero(0, 0, 0)]
+    #[case::base_at_pos1(1, 1, 4681)]
+    #[case::first_16kb_window(0, 1 << 14, 4681)]
+    #[case::spans_into_second_16kb(0, (1 << 14) + 1, 585)]
+    #[case::empty_at_16kb_boundary(1 << 14, 1 << 14, 585)]
+    #[case::base_past_16kb((1 << 14) + 1, (1 << 14) + 1, 4682)]
+    #[case::range_within_first_128kb(1 << 14, 1 << 17, 585)]
+    #[case::spans_into_second_128kb(1 << 14, (1 << 17) + 1, 73)]
+    #[case::empty_at_128kb_boundary(1 << 17, 1 << 17, 73)]
+    #[case::base_past_128kb((1 << 17) + 1, (1 << 17) + 1, 4689)]
+    #[case::range_within_first_1mb(1 << 17, 1 << 20, 73)]
+    #[case::spans_into_second_1mb(1 << 17, (1 << 20) + 1, 9)]
+    #[case::empty_at_1mb_boundary(1 << 20, 1 << 20, 9)]
+    #[case::base_past_1mb((1 << 20) + 1, (1 << 20) + 1, 4745)]
+    #[case::range_within_first_8mb(1 << 20, 1 << 23, 9)]
+    #[case::spans_into_second_8mb(1 << 20, (1 << 23) + 1, 1)]
+    #[case::empty_at_8mb_boundary(1 << 23, 1 << 23, 1)]
+    #[case::base_past_8mb((1 << 23) + 1, (1 << 23) + 1, 5193)]
+    #[case::range_within_first_64mb(1 << 23, 1 << 26, 1)]
+    #[case::spans_into_second_64mb(1 << 23, (1 << 26) + 1, 0)]
+    #[case::empty_at_64mb_boundary(1 << 26, 1 << 26, 0)]
+    #[case::base_past_64mb((1 << 26) + 1, (1 << 26) + 1, 8777)]
+    #[case::range_within_first_512mb(1 << 26, 1 << 27, 2)]
+    fn reg2bin_matches_htsjdk(#[case] beg: i32, #[case] end: i32, #[case] expected: u16) {
+        assert_eq!(reg2bin(beg, end), expected);
+    }
+
+    /// Build a minimal mapped record at `pos` with a single-op CIGAR, then read
+    /// its stored bin bytes back after recompute.
+    fn build_and_recompute(ref_id: i32, pos: i32, op: u32, op_len: usize) -> u16 {
+        let mut b = SamBuilder::new();
+        let mut rec = b
+            .ref_id(ref_id)
+            .pos(pos)
+            .read_name(b"r")
+            .cigar_ops(&[encode_op(op, op_len)])
+            .sequence(&vec![b'A'; op_len])
+            .qualities(&vec![30u8; op_len])
+            .build();
+        set_bin_from_raw_bam(rec.as_mut_vec());
+        rec.bin()
+    }
+
+    #[test]
+    fn set_bin_from_raw_bam_writes_position_bin_for_mapped_read() {
+        // 84M at pos 16416 -> [16416, 16500) -> level-5 bin 4682.
+        assert_eq!(build_and_recompute(0, 16416, M, 84), 4682);
+    }
+
+    #[test]
+    fn set_bin_from_raw_bam_writes_level4_bin_when_straddling_boundary() {
+        // 200M at pos 16300 -> [16300, 16500) straddles the 16 kb boundary -> 585.
+        assert_eq!(build_and_recompute(0, 16300, M, 200), 585);
+    }
+
+    #[test]
+    fn set_bin_from_raw_bam_uses_unmapped_bin_when_pos_negative() {
+        // pos = -1 -> UNMAPPED_BIN regardless of CIGAR bytes present.
+        assert_eq!(build_and_recompute(-1, -1, S, 100), UNMAPPED_BIN);
+    }
+
+    #[test]
+    fn set_bin_from_raw_bam_clamps_zero_reference_span_placed_read() {
+        // A placed read (pos >= 0) whose CIGAR consumes no reference (all soft-clip)
+        // still gets its start position's bin via the `ref_len.max(1)` clamp:
+        // 100S at pos 16416 -> reg2bin(16416, 16417) -> 4682, not the unmapped bin.
+        assert_eq!(build_and_recompute(0, 16416, S, 100), 4682);
+    }
+
+    #[test]
+    fn bin_from_raw_bam_ignores_flag_uses_alignment_start() {
+        // A placed read (pos >= 0) gets its position bin from bin_from_raw_bam.
+        let mut b = SamBuilder::new();
+        let rec = b
+            .ref_id(0)
+            .pos(16416)
+            .read_name(b"r")
+            .cigar_ops(&[encode_op(M, 84)])
+            .sequence(&[b'A'; 84])
+            .qualities(&[30u8; 84])
+            .build();
+        assert_eq!(bin_from_raw_bam(rec.as_ref()), 4682);
+    }
+}

--- a/crates/fgumi-raw-bam/src/builder.rs
+++ b/crates/fgumi-raw-bam/src/builder.rs
@@ -1,3 +1,6 @@
+// Unmapped BAM bin (SAM spec §4.2.1: `reg2bin(-1, 0)` = 4680), shared with the
+// bin module so both encoders agree on the constant.
+use crate::bin::UNMAPPED_BIN;
 use crate::raw_bam_record::RawRecord;
 use crate::sequence::pack_sequence_into;
 use crate::tags::{
@@ -44,9 +47,6 @@ pub struct UnmappedSamBuilder {
     buf: Vec<u8>,
     sealed: bool,
 }
-
-/// Unmapped BAM bin (SAM spec §4.2.1: `reg2bin(-1, 0)` = 4680).
-const UNMAPPED_BIN: u16 = 4680;
 
 impl UnmappedSamBuilder {
     /// Create a new builder with default capacity (512 bytes).

--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(unsafe_code)]
 
+pub mod bin;
 pub mod builder;
 pub mod cigar;
 pub mod fields;
@@ -56,6 +57,9 @@ pub use fields::{
     tag_value_size,
     template_length,
 };
+
+// -- bin (reg2bin) --
+pub use bin::{UNMAPPED_BIN, bin_from_raw_bam, reg2bin, set_bin_from_raw_bam};
 
 // -- builder --
 pub use builder::{SamBuilder, UnmappedSamBuilder};

--- a/crates/fgumi-raw-bam/src/raw_bam_record.rs
+++ b/crates/fgumi-raw-bam/src/raw_bam_record.rs
@@ -609,6 +609,17 @@ impl RawRecord {
         RawRecordMut::new(&mut self.0).set_bin(v);
     }
 
+    /// Recompute the BAM bin field from this record's current `POS` and CIGAR.
+    ///
+    /// Call after any in-place mutation of `POS` or the CIGAR (clipping, mate
+    /// relocation, unmapping) so the emitted record carries a correct bin — the
+    /// raw pipeline writes record bytes verbatim, with no encode step to refresh
+    /// it. Unmapped records (`POS < 0`) get [`crate::bin::UNMAPPED_BIN`].
+    #[inline]
+    pub fn recompute_bin(&mut self) {
+        crate::bin::set_bin_from_raw_bam(&mut self.0);
+    }
+
     /// Set the mate reference sequence ID.
     #[inline]
     pub fn set_mate_ref_id(&mut self, v: i32) {
@@ -928,6 +939,31 @@ mod tests {
             ed.update_int(SamTag::NM, 8);
         }
         assert_eq!(rec.tags().find_int(SamTag::NM), Some(8));
+    }
+
+    #[test]
+    fn test_recompute_bin_tracks_pos_and_cigar_mutations() {
+        use crate::bin::UNMAPPED_BIN;
+        use crate::testutil::*;
+
+        // 200M at pos 16300 straddles the 16 kb boundary -> level-4 bin 585.
+        let bytes = make_bam_bytes(0, 16300, 0, b"r", &[encode_op(0, 200)], 200, -1, -1, &[]);
+        let mut rec = RawRecord::from(bytes);
+        assert_eq!(rec.bin(), 0, "make_bam_bytes leaves the bin field zeroed");
+        rec.recompute_bin();
+        assert_eq!(rec.bin(), 585);
+
+        // Shift start across the boundary (set_pos + shorter CIGAR): 84M at 16416 -> 4682.
+        rec.set_pos(16416);
+        rec.set_cigar_ops(&[encode_op(0, 84)]);
+        rec.recompute_bin();
+        assert_eq!(rec.bin(), 4682);
+
+        // Unmapping the record (pos = -1, empty CIGAR) -> UNMAPPED_BIN.
+        rec.set_pos(-1);
+        rec.set_cigar_ops(&[]);
+        rec.recompute_bin();
+        assert_eq!(rec.bin(), UNMAPPED_BIN);
     }
 
     #[test]

--- a/crates/fgumi-sam/src/clipper.rs
+++ b/crates/fgumi-sam/src/clipper.rs
@@ -1598,6 +1598,8 @@ impl RawRecordClipper {
         record.set_mapq(0);
         record.set_template_length(0);
         record.set_cigar_ops(&[]);
+        // Now unmapped (POS = -1): the bin must become the SAM unmapped bin (4680).
+        record.recompute_bin();
     }
 
     /// Clips a specified number of bases from the start (left side) of the alignment.
@@ -1774,6 +1776,10 @@ impl RawRecordClipper {
             }
         }
 
+        // POS and/or the CIGAR changed above; refresh the BAM bin so the verbatim
+        // raw write emits a correct index bin (the encoder step that would normally
+        // recompute it is bypassed by the raw pipeline).
+        record.recompute_bin();
         read_bases_clipped
     }
 
@@ -1923,6 +1929,9 @@ impl RawRecordClipper {
             }
         }
 
+        // End-clipping leaves POS unchanged but shrinks the aligned span, which can
+        // move the read into a finer bin; refresh it for the verbatim raw write.
+        record.recompute_bin();
         read_bases_clipped
     }
 
@@ -5776,6 +5785,56 @@ mod crosscheck_tests {
         let raw_qual = raw.quality_scores().to_vec();
         let buf_qual: Vec<u8> = buf.quality_scores().as_ref().to_vec();
         assert_eq!(raw_qual, buf_qual, "{context}: quality mismatch");
+    }
+
+    // =========================================================================
+    // BAM bin field is recomputed after raw clip mutations (fgbio parity)
+    //
+    // The raw pipeline emits record bytes verbatim, so a clip that moves POS or
+    // rewrites the CIGAR must refresh the bin (bytes 10-11) itself. A read placed
+    // at 16300 with 200M straddles the 16 kb bin boundary (level-4 bin 585);
+    // clipping that changes its span moves it into a level-5 (16 kb) bin.
+    // =========================================================================
+
+    /// Build a raw mapped read at `pos` (0-based) with `cigar`, encoded through
+    /// noodles so the starting bin is correct.
+    fn raw_mapped(pos: i32, cigar: &str, seq_len: usize) -> RawRecord {
+        let start_1based = usize::try_from(pos + 1).expect("1-based start must be non-negative");
+        let buf = RecordBuilder::mapped_read()
+            .sequence(&"A".repeat(seq_len))
+            .cigar(cigar)
+            .alignment_start(start_1based)
+            .build();
+        to_raw(&buf)
+    }
+
+    #[test]
+    fn raw_clip_start_of_alignment_recomputes_bin_after_pos_shift() {
+        let mut raw = raw_mapped(16300, "200M", 200);
+        assert_eq!(raw.bin(), fgumi_raw_bam::reg2bin(16300, 16500), "precondition: bin 585");
+        // Soft-clip 116 from the start: pos -> 16416, CIGAR 116S84M, span [16416, 16500).
+        RawRecordClipper::new(ClippingMode::Soft).clip_start_of_alignment(&mut raw, 116);
+        assert_eq!(raw.pos(), 16416, "precondition: pos shifted");
+        assert_eq!(raw.bin(), fgumi_raw_bam::reg2bin(16416, 16416 + 84));
+    }
+
+    #[test]
+    fn raw_clip_end_of_alignment_recomputes_bin_after_span_shrinks() {
+        let mut raw = raw_mapped(16300, "200M", 200);
+        // Soft-clip 116 from the end: pos stays 16300, span shrinks to [16300, 16384),
+        // which no longer straddles the 16 kb boundary -> level-5 bin.
+        RawRecordClipper::new(ClippingMode::Soft).clip_end_of_alignment(&mut raw, 116);
+        assert_eq!(raw.pos(), 16300, "precondition: end-clip leaves pos unchanged");
+        assert_eq!(raw.bin(), fgumi_raw_bam::reg2bin(16300, 16300 + 84));
+    }
+
+    #[test]
+    fn raw_clip_that_unmaps_read_sets_unmapped_bin() {
+        let mut raw = raw_mapped(16300, "200M", 200);
+        // Clipping every clippable base unmaps the read (fgbio SamRecordClipper).
+        RawRecordClipper::new(ClippingMode::Soft).clip_start_of_alignment(&mut raw, 200);
+        assert!(raw.flags() & fgumi_raw_bam::flags::UNMAPPED != 0, "precondition: unmapped");
+        assert_eq!(raw.bin(), fgumi_raw_bam::UNMAPPED_BIN);
     }
 
     // =========================================================================

--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -943,6 +943,8 @@ fn set_mate_info_raw(r1: &mut RawRecord, r2: &mut RawRecord) {
             set_mate_flags_raw(rec, mate_neg, true);
             clear_mate_mq_mc_raw(rec);
             rec.set_template_length(0);
+            // Now unmapped (POS = -1): bin must be the SAM unmapped bin (4680).
+            rec.recompute_bin();
         }
     } else {
         // Exactly one is unmapped: relocate it to the mapped mate's coordinate.
@@ -960,6 +962,9 @@ fn set_mate_info_raw(r1: &mut RawRecord, r2: &mut RawRecord) {
         set_mate_flags_raw(unmapped, mapped_snap.neg, false);
         set_mate_mq_mc_raw(unmapped, mapped_snap.mapq, &mapped_snap.cigar);
         unmapped.set_template_length(0);
+        // POS moved from unmapped (-1) to the mate's coordinate; refresh the bin so
+        // the placed read carries its position's bin (htsjdk recomputes on write).
+        unmapped.recompute_bin();
 
         // The mapped read points its mate fields at the (now co-located) unmapped read.
         // Its mate-reverse flag reflects the unmapped read's *actual* strand (htsjdk
@@ -3264,6 +3269,45 @@ mod tests {
             assert!(!has_tag(rec, *SamTag::MQ) && !has_tag(rec, *SamTag::MC), "MQ/MC removed");
             assert_eq!(rec.template_length(), 0, "TLEN 0");
         }
+    }
+
+    /// A read that clipping left unmapped is relocated to its mapped mate's
+    /// coordinate by `set_mate_info_raw` (htsjdk `SamPairUtil.setMateInfo`). fgbio
+    /// emits the placed position's bin for such a read (htsjdk recomputes the
+    /// indexing bin on write); the raw pipeline must do so explicitly.
+    #[test]
+    fn set_mate_info_raw_recomputes_bin_for_relocated_unmapped_read() {
+        use fgumi_raw_bam::flags as raw_flags;
+        let mut mapped = fgumi_raw_bam::SamBuilder::new()
+            .read_name(b"t")
+            .sequence(b"ACGTACGTACGTACGTACGT")
+            .qualities(&[30; 20])
+            .cigar_ops(&[20u32 << 4])
+            .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT)
+            .ref_id(0)
+            .pos(99)
+            .mapq(40)
+            .build();
+        let mut unmapped = fgumi_raw_bam::SamBuilder::new()
+            .read_name(b"t")
+            .sequence(b"ACGTACGTACGTACGTACGT")
+            .qualities(&[30; 20])
+            .cigar_ops(&[])
+            .flags(raw_flags::PAIRED | raw_flags::LAST_SEGMENT | raw_flags::UNMAPPED)
+            .ref_id(-1)
+            .pos(-1)
+            .mapq(0)
+            .build();
+        assert_eq!(unmapped.bin(), fgumi_raw_bam::UNMAPPED_BIN, "precondition: unmapped bin");
+
+        set_mate_info_raw(&mut mapped, &mut unmapped);
+
+        assert_eq!(unmapped.pos(), 99, "precondition: relocated to mate coord");
+        assert_eq!(
+            unmapped.bin(),
+            fgumi_raw_bam::reg2bin(99, 100),
+            "relocated unmapped read must carry its placed position's bin, not the stale 4680"
+        );
     }
 
     /// htsjdk's one-mapped branch sets the mapped read's mate-reverse flag from the

--- a/src/lib/commands/simulate/mod.rs
+++ b/src/lib/commands/simulate/mod.rs
@@ -66,36 +66,44 @@ impl SimulateCommand {
 /// commands when constructing mapped BAM records via `fgumi_raw_bam::SamBuilder`,
 /// which does not compute the bin field automatically.
 ///
-/// The bin layer constants `((1 << k) - 1) / 7` are written verbatim from the SAM
-/// specification reference C code; clippy's `eq_op` lint flags the smallest layer
-/// (`((1 << 3) - 1) / 7 == 7 / 7 == 1`) as a tautology, but we keep the form to
-/// stay textually identical to the spec.
-#[allow(clippy::eq_op, clippy::cast_possible_truncation)]
+/// Delegates to the canonical [`fgumi_raw_bam::reg2bin`] so the simulate encoder
+/// and the raw clip/zipper pipelines share one implementation of the binning
+/// scheme. `reg2bin` takes a 0-based half-open `[beg, end)` interval, so the
+/// 1-based inclusive `start`/`end` map to `start - 1` and `end` respectively.
 #[must_use]
 pub fn region_to_bin(start_1based: Option<u32>, end_1based: Option<u32>) -> u16 {
-    /// SAM spec §4.2.1: `reg2bin(-1, 0)` = 4680.
-    const UNMAPPED_BIN: u16 = 4680;
-
     let (Some(start_1), Some(end_1)) = (start_1based, end_1based) else {
-        return UNMAPPED_BIN;
+        return fgumi_raw_bam::UNMAPPED_BIN;
     };
-    let start = (start_1.saturating_sub(1)) as usize;
-    let end = (end_1.saturating_sub(1)) as usize;
+    let beg = i32::try_from(start_1.saturating_sub(1)).unwrap_or(i32::MAX);
+    // `reg2bin` takes an exclusive end; clamp to 1 so a degenerate `end_1 == 0`
+    // maps to the same bin the pre-delegation code produced (which saturated the
+    // 0-based inclusive end to 0, i.e. an exclusive end of 1).
+    let end = i32::try_from(end_1.max(1)).unwrap_or(i32::MAX);
+    fgumi_raw_bam::reg2bin(beg, end)
+}
 
-    let bin = if start >> 14 == end >> 14 {
-        ((1 << 15) - 1) / 7 + (start >> 14)
-    } else if start >> 17 == end >> 17 {
-        ((1 << 12) - 1) / 7 + (start >> 17)
-    } else if start >> 20 == end >> 20 {
-        ((1 << 9) - 1) / 7 + (start >> 20)
-    } else if start >> 23 == end >> 23 {
-        ((1 << 6) - 1) / 7 + (start >> 23)
-    } else if start >> 26 == end >> 26 {
-        ((1 << 3) - 1) / 7 + (start >> 26)
-    } else {
-        0
-    };
+#[cfg(test)]
+mod tests {
+    use super::region_to_bin;
+    use rstest::rstest;
 
-    // Truncate overflowing bin IDs (matches noodles behaviour).
-    bin as u16
+    #[rstest]
+    // 1-based inclusive coordinates -> BAM bin (SAM spec §5.3 reg2bin).
+    #[case::single_base(Some(1), Some(1), 4681)]
+    #[case::within_first_16kb(Some(101), Some(300), 4681)]
+    #[case::second_16kb_window(Some(16417), Some(16500), 4682)]
+    #[case::straddles_16kb_boundary(Some(16301), Some(16500), 585)]
+    #[case::unmapped_start(None, Some(100), 4680)]
+    #[case::unmapped_end(Some(100), None, 4680)]
+    #[case::unmapped_both(None, None, 4680)]
+    // Degenerate 1-based end of 0 clamps to the first bin, matching pre-refactor behavior.
+    #[case::degenerate_zero_end(Some(1), Some(0), 4681)]
+    fn region_to_bin_matches_sam_spec(
+        #[case] start_1based: Option<u32>,
+        #[case] end_1based: Option<u32>,
+        #[case] expected: u16,
+    ) {
+        assert_eq!(region_to_bin(start_1based, end_1based), expected);
+    }
 }

--- a/src/lib/template.rs
+++ b/src/lib/template.rs
@@ -688,6 +688,8 @@ impl Template {
         fgumi_raw_bam::remove_tag(rr[r1_i].as_mut_vec(), SamTag::MQ);
         fgumi_raw_bam::remove_tag(rr[r1_i].as_mut_vec(), SamTag::MC);
         fgumi_raw_bam::set_template_length(&mut rr[r1_i], 0);
+        // Now unmapped (POS = -1): bin must be the SAM unmapped bin (4680).
+        fgumi_raw_bam::set_bin_from_raw_bam(&mut rr[r1_i]);
 
         // R2: set to unmapped coordinates
         fgumi_raw_bam::set_ref_id(&mut rr[r2_i], -1);
@@ -698,6 +700,8 @@ impl Template {
         fgumi_raw_bam::remove_tag(rr[r2_i].as_mut_vec(), SamTag::MQ);
         fgumi_raw_bam::remove_tag(rr[r2_i].as_mut_vec(), SamTag::MC);
         fgumi_raw_bam::set_template_length(&mut rr[r2_i], 0);
+        // Now unmapped (POS = -1): bin must be the SAM unmapped bin (4680).
+        fgumi_raw_bam::set_bin_from_raw_bam(&mut rr[r2_i]);
     }
 
     /// Raw-byte: one mapped, one unmapped. Places unmapped at mapped coords.
@@ -747,6 +751,9 @@ impl Template {
             fgumi_raw_bam::remove_tag(rr[unmapped_i].as_mut_vec(), SamTag::MC);
         }
         fgumi_raw_bam::set_template_length(&mut rr[unmapped_i], 0);
+        // POS moved from unmapped (-1) to the mate's coordinate; refresh the bin so
+        // the placed read carries its position's bin (htsjdk recomputes on write).
+        fgumi_raw_bam::set_bin_from_raw_bam(&mut rr[unmapped_i]);
     }
 }
 
@@ -1297,6 +1304,48 @@ mod tests {
             "R2 ms should be 55"
         );
 
+        Ok(())
+    }
+
+    /// A read left unmapped is relocated to its mapped mate's coordinate by
+    /// `fix_mate_info` (used by `zipper`). fgbio emits the placed position's bin
+    /// (htsjdk recomputes the indexing bin on write); the raw pipeline must
+    /// recompute it rather than keep the stale unmapped bin (4680).
+    #[test]
+    fn test_fix_mate_info_recomputes_bin_for_relocated_unmapped_mate() -> Result<()> {
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(FLAG_PAIRED | FLAG_READ1)
+            .ref_id(0)
+            .pos(99)
+            .mapq(30)
+            .cigar_ops(&[fgumi_raw_bam::testutil::encode_op(0, 100)]);
+        let r1 = b.build();
+
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(&[b'A'; 100])
+            .qualities(&[30u8; 100])
+            .flags(FLAG_PAIRED | FLAG_READ2 | FLAG_UNMAPPED)
+            .ref_id(-1)
+            .pos(-1)
+            .mapq(0)
+            .cigar_ops(&[]);
+        let r2 = b.build();
+        assert_eq!(r2.bin(), fgumi_raw_bam::UNMAPPED_BIN, "precondition: unmapped bin");
+
+        let mut template = Template::from_records(vec![r1, r2])?;
+        template.fix_mate_info()?;
+
+        let r2 = &template.records()[1];
+        assert_eq!(r2.pos(), 99, "precondition: relocated to mate coord");
+        assert_eq!(
+            r2.bin(),
+            fgumi_raw_bam::reg2bin(99, 100),
+            "relocated unmapped mate must carry its placed position's bin, not the stale 4680"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

`fgumi clip` (and, in a narrower case, `fgumi zipper`) emitted a stale BAM `bin` field. The raw pipelines mutate an already-encoded BAM record in place and write the bytes verbatim, so — unlike the noodles/htsjdk encoders, which recompute the indexing bin on write — there is no serialization step to refresh `bin` (bytes 10–11) after `POS` or the CIGAR changes. Any clip that moved a read into a different bin shipped the pre-clip value, diverging from fgbio.

### Reproduction

A read placed at 16300 with `200M` straddles the 16 kb bin boundary (level-4 bin 585). A 116-base 5′ soft-clip moves it to `pos 16416`, `116S84M`, whose correct bin is 4682:

| Tool | resulting alignment | `bin` |
|------|--------------------|-------|
| fgbio ClipBam | `pos 16417`, `116S84M` | **4682** ✓ |
| fgumi clip (before) | `pos 16417`, `116S84M` | **585** ✗ (stale) |

The same class of bug affected `zipper`'s mate reconciliation: a read relocated to its mapped mate's coordinate kept the stale unmapped bin (4680) instead of its placed position's bin.

Note: fgumi's own BAI/CSI writer recomputes start/end from `POS`+CIGAR and ignores the record's `bin`, so its own index was unaffected. The stale bin hurt external consumers (htsjdk/samtools-based tools reading fgumi output) and broke byte-parity with fgbio.

## What changed

- **`fgumi-raw-bam::bin`** (new module): the canonical SAM spec §5.3 `reg2bin`, the `UNMAPPED_BIN` constant, and `bin_from_raw_bam` / `set_bin_from_raw_bam`, which compute a record's bin from its `POS` and CIGAR reference span (unmapped `POS < 0` → 4680, keying off the alignment start like htsjdk `computeIndexingBin`, not the unmapped flag). Plus a `RawRecord::recompute_bin()` wrapper.
- **`clip`**: recompute the bin at the three raw mutation primitives (`clip_start_of_alignment`, `clip_end_of_alignment`, `make_read_unmapped_raw`) so a clipped record is always self-consistent, and in `set_mate_info_raw` when a clipped-unmapped read is relocated or a pair is cleared to unmapped. `upgrade_clipping` only converts clip type (no `POS`/span move), so it correctly needs no recompute.
- **`zipper`** (`Template::fix_mate_info`): recompute after relocating an unmapped mate to its mate's coordinate and after clearing a pair to unmapped.
- **`simulate`**: `region_to_bin` now delegates to the shared `reg2bin` instead of duplicating the spec code; the private `UNMAPPED_BIN` in `builder.rs` also shares the constant.

## Testing

- Unit tests at every mutation site (clip start/end/unmap, `set_mate_info_raw` relocation, `fix_mate_info` relocation), each asserting the emitted bin equals `reg2bin` of the post-op coordinates — TDD, each written failing first.
- `reg2bin` is covered by the full authoritative vector table ported from htsjdk `GenomicIndexUtilTest.testRegionToBinDataProvider`, exercising every binning level (16 kb through the whole-window bin 0).
- End-to-end: rebuilt binary re-run on the reproductions above — every previously-stale case now matches `reg2bin` of the post-op coordinates, and **directly matches fgbio ClipBam / ZipperBams** output bins.
- Full workspace suite (5243 tests), `cargo ci-fmt`, and `cargo ci-lint` all pass.

## Reading order

1. `crates/fgumi-raw-bam/src/bin.rs` — the shared helper and its semantics.
2. `crates/fgumi-sam/src/clipper.rs` and `src/lib/commands/clip.rs` — the clip fix.
3. `src/lib/template.rs` — the zipper fix.
4. `src/lib/commands/simulate/mod.rs` — the delegation refactor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BAM bin calculation and update support based on alignment position and CIGAR span.
  * Added APIs to compute or refresh bins for raw BAM records.
  * Added automatic bin updates when clipping reads or modifying mate information.

* **Bug Fixes**
  * Prevented stale bin values after coordinate, CIGAR, or mapping-status changes.
  * Correctly handles unmapped and zero-reference-span reads.

* **Tests**
  * Added coverage for bin boundaries, clipping, unmapped reads, and coordinate mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->