### PR TITLE
test(review): skip float-parseable garbage in AF-fallback proptest

### DIFF
--- a/src/lib/commands/review.rs
+++ b/src/lib/commands/review.rs
@@ -2864,6 +2864,11 @@ chr2\t20\t.\tC\tT\t.\tPASS\t.\tGT:AD\t0/1:99,1\n",
         ) {
             use noodles::vcf::variant::record_buf::samples::sample::Value;
             use noodles::vcf::variant::record_buf::samples::sample::value::Array;
+            // `[a-zA-Z]{1,8}` can spell the case-insensitive `inf`/`infinity`/`nan`
+            // forms that `f64::from_str` parses as genuine floats; those take the `AF`
+            // path, not the `AD` fallback this test asserts. Only truly unparseable
+            // garbage exercises the fallback, so skip any sample that parses.
+            proptest::prop_assume!(garbage.parse::<f64>().is_err());
             let af = Value::String(garbage);
             let ad = Value::Array(Array::Integer(vec![Some(ref_depth), Some(alt_depth)]));
             let got = calculate_maf_for(Some(af), Some(ad)).expect("AD fallback yields Some");


### PR DESCRIPTION
The `unparseable_af_string_falls_back_to_ad` proptest in `review.rs` drew its "unparseable" AF strings from `[a-zA-Z]{1,8}`, assuming any alphabetic string fails to parse as a float and therefore exercises the AD fallback path. But `f64::from_str` parses the case-insensitive `inf`/`infinity`/`nan` spellings as genuine floats, which take the `AF` path instead. Whenever proptest happened to draw one of those (the CI-minimized input was `garbage = "inf"`), the test failed — intermittently, depending on the random seed CI drew. This surfaced as a spurious `test` job failure on an unrelated compare PR.

The fix adds a `prop_assume!` that skips any sample which parses as `f64`, so only truly unparseable garbage reaches the fallback assertion. The excluded spellings are a tiny fraction of the `[a-zA-Z]{1,8}` space, so the reject rate is negligible.

Verified by running the test with `PROPTEST_CASES=8192` and five additional `PROPTEST_CASES=4096` runs on fresh seeds — all pass. `cargo ci-fmt` and `cargo ci-lint` are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for invalid allele-frequency values.
  * Ensured fallback behavior is reliably tested when allele-frequency parsing fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->