### PR TITLE
perf(simulate): stream records into the sort instead of an intermediate BAM

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1884,6 +1884,71 @@ impl RawExternalSorter {
     ///
     /// Returns an error if reading, sorting, or writing the BAM file fails.
     pub fn sort(&self, input: &Path, output: &Path) -> Result<RawSortStats> {
+        let pool = self.create_worker_pool()?;
+
+        // Open input BAM and create record source
+        // N+2 model: workers do ReadInputBlocks + DecompressInput,
+        // main thread reads records directly from PooledInputStream.
+        debug!(
+            "Phase 1: Pool-integrated input reading ({} workers, N+2 model)",
+            pool.num_workers()
+        );
+        let (record_source, header) = {
+            let (reader, header) =
+                create_raw_bam_reader_pool_integrated(input, &pool, self.async_reader)?;
+            (RecordSource::direct(reader), header)
+        };
+
+        self.sort_from_source(record_source, &header, output, pool)
+    }
+
+    /// Sort records produced in-process, without a BAM input file.
+    ///
+    /// This is the streaming counterpart to [`Self::sort`]: instead of reading
+    /// an input BAM, records are pulled from `records` as the sort's accumulate
+    /// phase consumes them. Producers that would otherwise write an unsorted BAM
+    /// only to hand it straight back for sorting should use this — it removes a
+    /// full compress/write/read/decompress round-trip, and removes the
+    /// intermediate file's disk footprint entirely (which for inputs that exceed
+    /// `memory_limit` would otherwise sit alongside the spill chunks).
+    ///
+    /// Spill and merge behave exactly as in [`Self::sort`]: when everything fits
+    /// within `memory_limit` nothing touches disk except the output; past that
+    /// limit, sorted chunks spill to the configured temp directories and are
+    /// k-way merged.
+    ///
+    /// `header` is the input header — the output header's sort-order tags are
+    /// derived from it the same way [`Self::sort`] derives them from the input
+    /// BAM's header, and `pg_info` (if set) is applied to it.
+    ///
+    /// An `Err` item from `records` aborts the sort and is propagated; the
+    /// output file is not written, so a producer failure can never leave a
+    /// silently truncated result behind.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the producer yields one, or if sorting, spilling, or
+    /// writing the output BAM fails.
+    pub fn sort_records<I>(
+        &self,
+        records: I,
+        header: &Header,
+        output: &Path,
+    ) -> Result<RawSortStats>
+    where
+        I: IntoIterator<Item = Result<fgumi_raw_bam::RawRecord>>,
+        I::IntoIter: Send + 'static,
+    {
+        let pool = self.create_worker_pool()?;
+        debug!("Phase 1: In-process record stream (no input BAM)");
+        self.sort_from_source(RecordSource::stream(records), header, output, pool)
+    }
+
+    /// Build the shared worker pool used by every phase of a sort run.
+    ///
+    /// Also enforces the spill-codec/compression-level invariant, so no entry
+    /// point can reach a misconfigured pool.
+    fn create_worker_pool(&self) -> Result<Arc<SortWorkerPool>> {
         // zstd has no level-0 "stored" mode; silently remapping to 1 would
         // surprise API callers who set temp_compression(0) expecting an
         // uncompressed spill (which works for BGZF). Mirror the CLI guard so
@@ -1902,31 +1967,31 @@ impl RawExternalSorter {
         debug!("Threads: {}", self.threads);
 
         // Shared worker pool for parallel BGZF compress/decompress across all phases
-        let pool = Arc::new(SortWorkerPool::new(
+        Ok(Arc::new(SortWorkerPool::new(
             self.threads.max(1),
             self.temp_compression,
             self.output_compression,
             self.spill_codec,
-        ));
+        )))
+    }
 
-        // Open input BAM and create record source
-        // N+2 model: workers do ReadInputBlocks + DecompressInput,
-        // main thread reads records directly from PooledInputStream.
-        debug!(
-            "Phase 1: Pool-integrated input reading ({} workers, N+2 model)",
-            pool.num_workers()
-        );
-        let (record_source, header) = {
-            let (reader, header) =
-                create_raw_bam_reader_pool_integrated(input, &pool, self.async_reader)?;
-            (RecordSource::direct(reader), header)
-        };
-
+    /// Run the sort over an already-constructed record source.
+    ///
+    /// Shared tail of [`Self::sort`] and [`Self::sort_records`]: applies
+    /// `pg_info` to the header, provisions temp directories, and dispatches to
+    /// the per-order implementation.
+    fn sort_from_source(
+        &self,
+        record_source: RecordSource,
+        header: &Header,
+        output: &Path,
+        pool: Arc<SortWorkerPool>,
+    ) -> Result<RawSortStats> {
         // Add @PG record if pg_info was provided
         let header = if let Some((ref version, ref command_line)) = self.pg_info {
-            fgumi_bam_io::header::add_pg_record(header, version, command_line)?
+            fgumi_bam_io::header::add_pg_record(header.clone(), version, command_line)?
         } else {
-            header
+            header.clone()
         };
 
         // _temp_dirs: RAII handles; kept alive until sort returns.
@@ -5115,6 +5180,170 @@ mod tests {
             .sort(&unsorted, &sorted)
             .expect("sort should succeed");
         (sorted, names)
+    }
+
+    // ========================================================================
+    // sort_records (in-process record stream) tests
+    // ========================================================================
+
+    /// Read a BAM into its header plus every record, for replaying through
+    /// [`RawExternalSorter::sort_records`].
+    fn read_bam_records(path: &Path) -> (Header, Vec<fgumi_raw_bam::RawRecord>) {
+        use crate::read_ahead::RawReadAheadReader;
+        let (reader, header) =
+            create_raw_bam_reader(path, 1).expect("failed to create raw BAM reader");
+        (header, RawReadAheadReader::new(reader).collect())
+    }
+
+    /// Build an unsorted BAM of `num_pairs` pairs whose coordinates deliberately
+    /// do not follow input order, so a sort has real work to do.
+    fn build_unsorted_bam(dir: &Path, num_pairs: usize) -> PathBuf {
+        let mut builder = SamBuilder::new();
+        for i in 0..num_pairs {
+            // Interleave high and low coordinates so input order != sort order.
+            let start = if i % 2 == 0 { (num_pairs - i) * 200 + 1 } else { i * 200 + 1 };
+            let _ = builder
+                .add_pair()
+                .name(&format!("read{i:04}"))
+                .start1(start)
+                .start2(start + 100)
+                .build();
+        }
+        let path = dir.join("unsorted.bam");
+        builder.write_bam(&path).expect("failed to write BAM");
+        path
+    }
+
+    /// `sort_records` must produce byte-identical output to `sort` over the same
+    /// records in the same order, for every sort order and on both the
+    /// fits-in-memory and spill-and-merge paths.
+    ///
+    /// This is the invariant callers rely on when they replace an
+    /// "write unsorted BAM, then sort it" round-trip with a direct stream:
+    /// removing the intermediate file must not change a single output byte.
+    #[rstest::rstest]
+    fn test_sort_records_matches_sort_from_file(
+        #[values(
+            SortOrder::Coordinate,
+            SortOrder::Queryname(QuerynameComparator::Lexicographic),
+            SortOrder::Queryname(QuerynameComparator::Natural),
+            SortOrder::TemplateCoordinate
+        )]
+        sort_order: SortOrder,
+        // 8 MiB fits the whole 100-pair set in memory (no spill); 16 KiB forces
+        // several spills and a k-way merge.
+        #[values(8 * 1024 * 1024, 16 * 1024)] memory_limit: usize,
+    ) {
+        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let input = build_unsorted_bam(dir.path(), 100);
+        let (header, records) = read_bam_records(&input);
+
+        let from_file = dir.path().join("from_file.bam");
+        let from_stream = dir.path().join("from_stream.bam");
+
+        let sorter = || {
+            RawExternalSorter::new(sort_order)
+                .memory_limit(memory_limit)
+                .threads(2)
+                .spill_codec(crate::codec::SpillCodec::Bgzf)
+                .temp_compression(0)
+                .output_compression(0)
+        };
+
+        let file_stats = sorter().sort(&input, &from_file).expect("file sort should succeed");
+        let stream_stats = sorter()
+            .sort_records(records.into_iter().map(Ok), &header, &from_stream)
+            .expect("stream sort should succeed");
+
+        assert_eq!(file_stats.total_records, stream_stats.total_records);
+        assert_eq!(file_stats.output_records, stream_stats.output_records);
+        assert_eq!(
+            file_stats.chunks_written, stream_stats.chunks_written,
+            "stream path should spill exactly like the file path"
+        );
+        assert_eq!(
+            std::fs::read(&from_file).expect("read file output"),
+            std::fs::read(&from_stream).expect("read stream output"),
+            "sort_records output must be byte-identical to sort()"
+        );
+    }
+
+    /// An empty stream produces a header-only BAM, matching `sort` on an empty
+    /// input rather than erroring.
+    #[test]
+    fn test_sort_records_empty_stream_writes_header_only() {
+        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let input = build_unsorted_bam(dir.path(), 1);
+        let (header, _) = read_bam_records(&input);
+        let output = dir.path().join("empty.bam");
+
+        let stats = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+            .output_compression(0)
+            .sort_records(std::iter::empty(), &header, &output)
+            .expect("empty stream should succeed");
+
+        assert_eq!(stats.total_records, 0);
+        assert_eq!(count_bam_records(&output), 0);
+    }
+
+    /// A producer error must abort the sort and propagate, leaving no output
+    /// file behind — a truncated "successful" result would be worse than a
+    /// failure, since callers would ship a silently short BAM.
+    ///
+    /// Covered on both the fits-in-memory path and after a spill, since the
+    /// error is only observed once the stream is drained.
+    #[rstest::rstest]
+    #[case::before_spill(8 * 1024 * 1024)]
+    #[case::after_spill(16 * 1024)]
+    fn test_sort_records_producer_error_aborts(#[case] memory_limit: usize) {
+        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let input = build_unsorted_bam(dir.path(), 100);
+        let (header, records) = read_bam_records(&input);
+        let output = dir.path().join("aborted.bam");
+
+        // Emit every record, then fail instead of ending cleanly.
+        let stream = records
+            .into_iter()
+            .map(Ok)
+            .chain(std::iter::once(Err(anyhow::anyhow!("producer exploded"))));
+
+        let err = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+            .memory_limit(memory_limit)
+            .threads(2)
+            .spill_codec(crate::codec::SpillCodec::Bgzf)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort_records(stream, &header, &output)
+            .expect_err("producer error should abort the sort");
+
+        assert!(
+            format!("{err:#}").contains("producer exploded"),
+            "producer error should be propagated, got: {err:#}"
+        );
+        assert!(!output.exists(), "aborted sort must not leave an output BAM behind");
+    }
+
+    /// A producer that fails before yielding anything aborts too, rather than
+    /// falling through the empty-input path and writing a header-only BAM.
+    #[test]
+    fn test_sort_records_error_on_first_record_aborts() {
+        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let input = build_unsorted_bam(dir.path(), 1);
+        let (header, _) = read_bam_records(&input);
+        let output = dir.path().join("aborted_first.bam");
+
+        let stream = std::iter::once(Err(anyhow::anyhow!("failed before first record")));
+
+        let err = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+            .output_compression(0)
+            .sort_records(stream, &header, &output)
+            .expect_err("producer error should abort the sort");
+
+        assert!(
+            format!("{err:#}").contains("failed before first record"),
+            "producer error should be propagated, got: {err:#}"
+        );
+        assert!(!output.exists(), "aborted sort must not leave an output BAM behind");
     }
 
     /// Collect all read names from a BAM file as strings.

--- a/crates/fgumi-sort/src/read_ahead.rs
+++ b/crates/fgumi-sort/src/read_ahead.rs
@@ -405,10 +405,17 @@ impl IoRead for PooledInputStream {
 // RecordSource — unified iterator for pool and non-pool paths
 // ============================================================================
 
+/// Boxed record stream handed to [`RecordSource::Stream`].
+///
+/// Each item is either a record or the producer's terminal error; the first
+/// `Err` ends the stream and is surfaced through [`RecordSource::take_error`].
+pub type BoxedRecordStream = Box<dyn Iterator<Item = anyhow::Result<RawRecord>> + Send>;
+
 /// Unified record source for Phase 1 reading.
 ///
-/// Wraps either a `RawReadAheadReader` (non-pool path, has background thread)
-/// or a direct `RawBamReader<PooledInputStream>` (pool path, no extra threads).
+/// Wraps a `RawReadAheadReader` (non-pool path, has background thread), a
+/// direct `RawBamReader<PooledInputStream>` (pool path, no extra threads), or a
+/// caller-supplied in-process stream (no BAM input file at all).
 pub enum RecordSource {
     /// Legacy path: background thread prefetches records.
     #[allow(dead_code)] // retained for potential future use / benchmarking
@@ -419,6 +426,13 @@ pub enum RecordSource {
     /// if any. Callers should call `take_error()` after the iteration loop to
     /// propagate errors rather than silently treating them as EOF.
     Direct(RawBamReader<PooledInputStream>, Option<std::io::Error>),
+    /// In-process path: records are produced by the caller (e.g. a simulator or
+    /// a pipeline stage) rather than read from a BAM file.
+    ///
+    /// The second field mirrors `Direct`'s error slot: a producer error stops
+    /// iteration and is reported by `take_error()`, so the sort aborts instead
+    /// of writing a silently truncated output.
+    Stream(BoxedRecordStream, Option<std::io::Error>),
 }
 
 impl RecordSource {
@@ -428,13 +442,23 @@ impl RecordSource {
         Self::Direct(reader, None)
     }
 
+    /// Wrap a caller-supplied fallible record iterator as the `Stream` variant.
+    #[must_use]
+    pub fn stream<I>(records: I) -> Self
+    where
+        I: IntoIterator<Item = anyhow::Result<RawRecord>>,
+        I::IntoIter: Send + 'static,
+    {
+        Self::Stream(Box::new(records.into_iter()), None)
+    }
+
     /// Take any I/O error that occurred during iteration.
     ///
     /// Returns `Some(err)` if the iterator stopped due to a read error rather than
     /// clean EOF. Call this after exhausting the iterator to detect truncated input.
     pub fn take_error(&mut self) -> Option<std::io::Error> {
         match self {
-            Self::Direct(_, err) => err.take(),
+            Self::Direct(_, err) | Self::Stream(_, err) => err.take(),
             Self::ReadAhead(r) => r.take_error(),
         }
     }
@@ -461,6 +485,21 @@ impl Iterator for RecordSource {
                     }
                 }
             }
+            Self::Stream(records, error_slot) => match records.next() {
+                Some(Ok(record)) => Some(record),
+                None => None,
+                Some(Err(e)) => {
+                    log::error!("Error producing record for sort: {e:#}");
+                    // Preserve the first error; don't overwrite with later ones.
+                    if error_slot.is_none() {
+                        // `anyhow::Error` converts into the boxed source type
+                        // `io::Error::other` takes, so the message and cause
+                        // chain survive the round-trip through `take_error()`.
+                        *error_slot = Some(std::io::Error::other(e));
+                    }
+                    None
+                }
+            },
         }
     }
 }

--- a/src/lib/commands/simulate/common.rs
+++ b/src/lib/commands/simulate/common.rs
@@ -1,11 +1,18 @@
 //! Shared CLI arguments and utilities for simulation commands.
 
-use crate::commands::common::MethylationModeArg;
+use crate::commands::common::{
+    MemoryLimit, MemoryReserve, MethylationModeArg, parse_bool, parse_memory, parse_memory_reserve,
+    resolve_memory_budget,
+};
+use crate::commands::sort::{TMP_DIRS_ENV, resolve_tmp_dirs};
 use anyhow::{Context, Result, bail};
+use bytesize::ByteSize;
 use clap::Args;
+use crossbeam_channel::{Receiver, Sender, bounded};
 use fgumi_consensus::MethylationMode;
 use fgumi_consensus::methylation::is_cpg_context;
-use fgumi_sort::SortOrder;
+use fgumi_raw_bam::RawRecord;
+use fgumi_sort::{RawExternalSorter, SortOrder};
 use log::info;
 use noodles::fasta;
 use noodles::sam::header::record::value::Map;
@@ -515,6 +522,197 @@ pub struct PositionDistArgs {
     /// Number of unique UMIs per position
     #[arg(long = "umis-per-position", default_value = "1")]
     pub umis_per_position: usize,
+}
+
+/// Sort-engine resource options for the simulation commands that stream their
+/// records through `fgumi-sort`.
+///
+/// These mirror the equivalent `fgumi sort` flags (same names, same defaults)
+/// so a simulation that has to spill behaves — and is tuned — exactly like a
+/// standalone sort.
+#[derive(Args, Debug, Clone)]
+pub struct SortResourceArgs {
+    /// Maximum memory for in-memory sorting of the generated records.
+    ///
+    /// Default is "768M" per thread (matching `fgumi sort` and samtools). Pass
+    /// "auto" to detect system memory and subtract --memory-reserve. When the
+    /// limit is reached, sorted chunks spill to temporary files.
+    #[arg(short = 'm', long = "max-memory", default_value = "768M", value_parser = parse_memory)]
+    pub max_memory: MemoryLimit,
+
+    /// Memory to reserve for other processes when --max-memory=auto.
+    ///
+    /// Ignored when --max-memory is set to an explicit value.
+    #[arg(long = "memory-reserve", default_value = "auto", value_parser = parse_memory_reserve)]
+    pub memory_reserve: MemoryReserve,
+
+    /// Scale the memory limit by thread count (samtools behavior).
+    ///
+    /// When enabled (default), --max-memory specifies memory per thread.
+    #[arg(long = "memory-per-thread", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    pub memory_per_thread: bool,
+
+    /// Temporary directory for sort spill files. Repeatable.
+    ///
+    /// If no flags are given and `FGUMI_TMP_DIRS` is set, its value is parsed as
+    /// a `PATH`-style list and used instead. If neither is provided, the system
+    /// default temp directory is used — note that on many modern Linux distros
+    /// `/tmp` is a RAM-backed tmpfs, so point this at real disk for large runs.
+    #[arg(short = 'T', long = "tmp-dir", action = clap::ArgAction::Append)]
+    pub tmp_dirs: Vec<PathBuf>,
+}
+
+impl SortResourceArgs {
+    /// Apply the resolved memory budget and temp directories to `sorter`.
+    ///
+    /// `threads` is the command's thread count, which scales the per-thread
+    /// memory budget exactly as it does in `fgumi sort`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the memory budget cannot be resolved (e.g. zero
+    /// threads, or an overflowing per-thread limit).
+    pub fn apply(&self, sorter: RawExternalSorter, threads: usize) -> Result<RawExternalSorter> {
+        let effective_memory = resolve_memory_budget(
+            self.max_memory,
+            self.memory_reserve,
+            threads,
+            self.memory_per_thread,
+        )?;
+        info!("Sort memory: {}", ByteSize(effective_memory as u64));
+
+        let mut sorter = sorter.memory_limit(effective_memory);
+
+        // For auto mode, cap the initial buffer pre-allocation at 768 MiB/thread
+        // so an `auto` budget on a large host doesn't allocate the whole budget
+        // upfront for what may be a tiny simulation. Mirrors `fgumi sort`.
+        if matches!(self.max_memory, MemoryLimit::Auto) {
+            let init = 768_usize
+                .checked_mul(1024 * 1024)
+                .and_then(|b| b.checked_mul(threads))
+                .ok_or_else(|| anyhow::anyhow!("initial auto buffer size overflowed"))?;
+            sorter = sorter.initial_capacity(effective_memory.min(init));
+        }
+
+        let env_value = std::env::var(TMP_DIRS_ENV).ok();
+        let tmp_dirs = resolve_tmp_dirs(&self.tmp_dirs, env_value.as_deref());
+        if !tmp_dirs.is_empty() {
+            let joined =
+                tmp_dirs.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", ");
+            info!("Sort temp directories: {joined}");
+            sorter = sorter.temp_dirs(tmp_dirs);
+        }
+
+        Ok(sorter)
+    }
+}
+
+/// Number of record *batches* in flight between the generator thread and the
+/// sort's accumulate loop.
+///
+/// With `RECORD_BATCH_SIZE` this buffers ~16k records (a few MiB). Deep enough
+/// that the generator is not stalled by short pauses in the sort (e.g. a
+/// spill), small enough that the queue itself is not a meaningful memory
+/// consumer next to the sort buffer.
+const RECORD_CHANNEL_CAPACITY: usize = 64;
+
+/// Records per batch handed across the channel.
+///
+/// Records move in batches, not one at a time: a per-record send costs more
+/// than the whole intermediate-BAM round-trip this streaming design removes
+/// (measured: ~7% slower end-to-end when unbatched). 256 matches the batch size
+/// the sort's own read-ahead reader uses.
+const RECORD_BATCH_SIZE: usize = 256;
+
+/// A batch of generated records, or the generator's terminal error.
+type RecordBatch = Result<Vec<RawRecord>>;
+
+/// Sending half of the generator → sorter record stream.
+///
+/// The simulation commands generate records on a background thread and hand
+/// them straight to [`RawExternalSorter::sort_records`], so no unsorted
+/// intermediate BAM is ever written: runs that fit in memory touch disk only
+/// for the final output, and runs that don't spill exactly like `fgumi sort`.
+pub(super) struct RecordSink {
+    sender: Sender<RecordBatch>,
+    batch: Vec<RawRecord>,
+}
+
+impl RecordSink {
+    /// Create a sink/stream pair to connect a generator thread to the sorter.
+    ///
+    /// Pass the receiver through [`into_record_stream`] to get the per-record
+    /// iterator [`RawExternalSorter::sort_records`] takes; the sink goes to the
+    /// generator.
+    ///
+    /// The generator must **own** the sink and drop it when it finishes:
+    /// dropping the sender is what signals end-of-stream. A sink kept alive
+    /// elsewhere (e.g. left in the caller's scope) leaves the sort blocked
+    /// waiting for records that will never arrive. Call [`Self::finish`] before
+    /// dropping so the last partial batch is not lost.
+    pub(super) fn new() -> (Self, Receiver<RecordBatch>) {
+        let (sender, receiver) = bounded(RECORD_CHANNEL_CAPACITY);
+        (Self { sender, batch: Vec::with_capacity(RECORD_BATCH_SIZE) }, receiver)
+    }
+
+    /// Hand one record to the sorter, sending it once a batch has accumulated.
+    ///
+    /// Returns `false` once the sorter has hung up, which only happens when the
+    /// sort itself failed. Generators must stop on `false` — continuing would
+    /// buffer forever against a receiver that is gone — and let the sort's own
+    /// error surface as the reported failure.
+    pub(super) fn send(&mut self, record: RawRecord) -> bool {
+        self.batch.push(record);
+        if self.batch.len() < RECORD_BATCH_SIZE {
+            return true;
+        }
+        self.flush()
+    }
+
+    /// Send any buffered records, ending the stream cleanly.
+    ///
+    /// Returns `false` if the sorter had already hung up, exactly as
+    /// [`Self::send`] does.
+    pub(super) fn finish(mut self) -> bool {
+        self.flush()
+    }
+
+    /// Report a generator failure to the sorter, which aborts the sort and
+    /// propagates the error instead of writing a truncated output.
+    ///
+    /// Buffered records are dropped: the stream is being abandoned, and sending
+    /// them would only delay the abort.
+    pub(super) fn fail(self, error: anyhow::Error) {
+        // If the sorter already hung up it is failing on its own error, which
+        // is the one the user should see; dropping ours is correct.
+        let _ = self.sender.send(Err(error));
+    }
+
+    /// Send the current batch if it is non-empty, leaving the buffer empty.
+    fn flush(&mut self) -> bool {
+        if self.batch.is_empty() {
+            return true;
+        }
+        let batch = std::mem::replace(&mut self.batch, Vec::with_capacity(RECORD_BATCH_SIZE));
+        self.sender.send(Ok(batch)).is_ok()
+    }
+}
+
+/// Adapt a [`RecordSink`]'s batched receiver into the per-record stream
+/// [`RawExternalSorter::sort_records`] consumes.
+///
+/// Batching is a transport detail of the generator → sorter handoff, so it is
+/// unwrapped here rather than pushed into the sort's API.
+pub(super) fn into_record_stream(
+    receiver: Receiver<RecordBatch>,
+) -> impl Iterator<Item = Result<RawRecord>> + Send + 'static {
+    receiver.into_iter().flat_map(|batch| -> Box<dyn Iterator<Item = Result<RawRecord>> + Send> {
+        // One `Box` per batch, not per record.
+        match batch {
+            Ok(records) => Box::new(records.into_iter().map(Ok)),
+            Err(e) => Box::new(std::iter::once(Err(e))),
+        }
+    })
 }
 
 /// Generate a random DNA sequence of the given length.

--- a/src/lib/commands/simulate/grouped_reads.rs
+++ b/src/lib/commands/simulate/grouped_reads.rs
@@ -1,17 +1,17 @@
 //! Generate a grouped BAM with MI tags for consensus calling.
 //!
-//! Records are generated in molecule order to an unsorted temp BAM, then rewritten
-//! into template-coordinate order by the canonical `fgumi-sort` engine — the same
-//! sort `fgumi sort`/`fgumi group` use and that is validated against
+//! Records are generated in molecule order on a background thread and streamed
+//! straight into the canonical `fgumi-sort` engine — the same sort
+//! `fgumi sort`/`fgumi group` use and that is validated against
 //! `samtools sort --template-coordinate`.
 
 use crate::commands::command::Command;
 use crate::commands::common::{CompressionOptions, parse_bool};
 use crate::commands::simulate::common::{
     FamilySizeArgs, InsertSizeArgs, MethylationArgs, MethylationConfig, PositionDistArgs,
-    QualityArgs, ReferenceArgs, ReferenceGenome, SimulationCommon, StrandBiasArgs,
-    apply_methylation_conversion, body_error_rng, build_sort_order_header_map,
-    generate_random_sequence, introduce_errors_inplace, pad_sequence,
+    QualityArgs, RecordSink, ReferenceArgs, ReferenceGenome, SimulationCommon, SortResourceArgs,
+    StrandBiasArgs, apply_methylation_conversion, body_error_rng, build_sort_order_header_map,
+    generate_random_sequence, into_record_stream, introduce_errors_inplace, pad_sequence,
 };
 use crate::commands::simulate::region_to_bin;
 use crate::dna::reverse_complement;
@@ -23,7 +23,6 @@ use crate::simulate::{
 use anyhow::{Context, Result};
 use clap::Parser;
 use fgumi_bam_io::ProgressTracker;
-use fgumi_bam_io::create_raw_bam_writer;
 use fgumi_raw_bam::{RawRecord, SamBuilder, flags as raw_flags};
 use fgumi_sort::{KeyTypesSpec, RawExternalSorter, SortOrder};
 use log::info;
@@ -32,7 +31,6 @@ use rand::{Rng, RngExt};
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
-use tempfile::NamedTempFile;
 
 /// Generate template-coordinate sorted BAM with MI tags for consensus callers.
 #[derive(Parser, Debug)]
@@ -69,13 +67,16 @@ pub struct GroupedReads {
     #[arg(long = "error-rate", default_value = "0.0")]
     pub error_rate: f64,
 
-    /// Number of writer threads
+    /// Number of threads for sorting and BAM compression
     #[arg(short = 't', long = "threads", default_value = "1")]
     pub threads: usize,
 
     /// Compression options for output BAM.
     #[command(flatten)]
     pub compression: CompressionOptions,
+
+    #[command(flatten)]
+    pub sort_resources: SortResourceArgs,
 
     #[command(flatten)]
     pub common: SimulationCommon,
@@ -215,33 +216,121 @@ impl Command for GroupedReads {
         // Use a different seed for molecule generation to avoid correlation with positions
         let mut seed_rng = create_rng(self.common.seed.map(|s| s.wrapping_add(1)));
 
-        // Generate molecules in `mol_id` order to an unsorted temp BAM, then let the
-        // canonical `fgumi-sort` engine produce the final template-coordinate order (see
-        // the sort pass after the write loop). This reuses the one sort implementation
-        // that `fgumi sort`/`fgumi group` use and that is validated against
-        // `samtools sort --template-coordinate`, instead of a bespoke key that has to
-        // re-derive the ordering (and previously mis-ordered reverse-R1 pairs). Because
-        // ordering is deferred to that external sort, generation can stream each molecule
-        // straight into the write loop below — no O(N) molecule-metadata buffer needed.
+        // Generate molecules in `mol_id` order and stream them straight into the
+        // canonical `fgumi-sort` engine, which produces the final template-coordinate
+        // order. This reuses the one sort implementation that `fgumi sort`/`fgumi group`
+        // use and that is validated against `samtools sort --template-coordinate`,
+        // instead of a bespoke key that has to re-derive the ordering (and previously
+        // mis-ordered reverse-R1 pairs). Because ordering is deferred to that sort,
+        // generation can stream each molecule as it is produced — no O(N)
+        // molecule-metadata buffer, and no unsorted intermediate BAM: runs that fit in
+        // `--max-memory` touch disk only for the final output, and larger runs spill
+        // sorted chunks exactly like `fgumi sort` would.
+        info!("Generating records and sorting into template-coordinate order...");
 
-        // Write records to an unsorted temp BAM alongside the final output; the sort
-        // pass below rewrites it into the destination in template-coordinate order.
-        let output_dir = self.output.parent().filter(|p| !p.as_os_str().is_empty());
-        let unsorted_temp = match output_dir {
-            Some(dir) => NamedTempFile::new_in(dir),
-            None => NamedTempFile::new(),
+        let sorter = self
+            .sort_resources
+            .apply(
+                RawExternalSorter::new(SortOrder::TemplateCoordinate)
+                    .threads(self.threads)
+                    .output_compression(self.compression.compression_level)
+                    // grouped-reads always writes MI tags, so include the tertiary
+                    // (library|mi) lane in the template-coordinate key rather than
+                    // relying on first-record auto-detection (equivalent to
+                    // `fgumi sort --key-types mi`).
+                    .key_types(KeyTypesSpec::Explicit { cb: false, tertiary: true }),
+                self.threads,
+            )
+            .context("Failed to configure the sort for simulated reads")?;
+
+        let (sink, records) = RecordSink::new();
+
+        // Generation runs on its own thread so it overlaps the sort's accumulate,
+        // spill, and merge work. `scope` lets it borrow the reference genome and
+        // parameters instead of cloning them. `sink` is moved into the closure so
+        // its sender is dropped when generation ends — that is what signals
+        // end-of-stream to the sort.
+        let total_pairs = std::thread::scope(|scope| -> Result<usize> {
+            let generator = scope.spawn(|| {
+                self.generate_records(
+                    sink,
+                    &params,
+                    &ref_genome,
+                    &position_table,
+                    num_positions,
+                    &mut seed_rng,
+                )
+            });
+
+            // Consumes `records`, so a sort failure drops the receiver and the
+            // generator's next `send` returns false, unblocking it.
+            sorter
+                .sort_records(into_record_stream(records), &header, &self.output)
+                .context("Failed to template-coordinate sort simulated reads")?;
+
+            generator.join().unwrap_or_else(|payload| std::panic::resume_unwind(payload))
+        })?;
+
+        info!("Generated {total_pairs} read pairs");
+        info!("Done");
+
+        Ok(())
+    }
+}
+
+impl GroupedReads {
+    /// Generate every molecule's read pairs, sending records to `sink` and
+    /// writing the truth TSV.
+    ///
+    /// Returns the number of read pairs generated. A generator failure is
+    /// reported to `sink` so the sort aborts rather than writing a truncated
+    /// BAM, and is also returned.
+    ///
+    /// Takes `sink` by value: it is consumed at the end of this call, which
+    /// closes the record stream and is how the sort learns generation is
+    /// finished.
+    fn generate_records(
+        &self,
+        mut sink: RecordSink,
+        params: &GenerationParams,
+        ref_genome: &ReferenceGenome,
+        position_table: &[(usize, usize)],
+        num_positions: usize,
+        seed_rng: &mut impl Rng,
+    ) -> Result<usize> {
+        let result = self.generate_records_inner(
+            &mut sink,
+            params,
+            ref_genome,
+            position_table,
+            num_positions,
+            seed_rng,
+        );
+        match result {
+            // Flush the final partial batch, then close the stream.
+            Ok(total_pairs) => {
+                sink.finish();
+                Ok(total_pairs)
+            }
+            // Surface the failure to the sort so it aborts instead of treating
+            // the truncated stream as a clean end of input.
+            Err(e) => {
+                sink.fail(anyhow::anyhow!("{e:#}"));
+                Err(e)
+            }
         }
-        .context("Failed to create temporary BAM for the pre-sort write pass")?;
-        let unsorted_path = unsorted_temp.path().to_path_buf();
+    }
 
-        // Set up writer with multi-threaded BGZF compression
-        let mut writer = create_raw_bam_writer(
-            &unsorted_path,
-            &header,
-            self.threads,
-            self.compression.compression_level,
-        )?;
-
+    /// Body of [`Self::generate_records`]; see it for the contract.
+    fn generate_records_inner(
+        &self,
+        sink: &mut RecordSink,
+        params: &GenerationParams,
+        ref_genome: &ReferenceGenome,
+        position_table: &[(usize, usize)],
+        num_positions: usize,
+        seed_rng: &mut impl Rng,
+    ) -> Result<usize> {
         // Create truth file
         let truth_file = File::create(&self.truth_output)
             .with_context(|| format!("Failed to create {}", self.truth_output.display()))?;
@@ -251,8 +340,6 @@ impl Command for GroupedReads {
             "read_name\ttrue_umi\tmolecule_id\tmi_tag\tchrom\tposition\tstrand"
         )?;
 
-        // Generate and write records to the unsorted temp BAM (molecule order).
-        info!("Generating and writing records...");
         let progress = ProgressTracker::new("Processed molecules").with_interval(100_000);
         let mut total_pairs = 0usize;
 
@@ -276,24 +363,28 @@ impl Command for GroupedReads {
                 seed,
                 pos_chrom_idx,
                 pos_local_pos,
-                &params,
-                &ref_genome,
+                params,
+                ref_genome,
             );
 
             for (r1, r2, read_name, umi_str, mi_tag, is_top_strand, insert_size) in pairs {
-                // Write reads in template-coordinate order (earlier 5' position first).
+                // Emit reads in template-coordinate order (earlier 5' position first).
                 // For F1R2 (top strand): R1 forward at pos, R2 reverse at pos+insert-read_len
                 //   R1's 5' = pos, R2's 5' = pos+insert-1 → R1 first (always)
                 // For R1F2 (!top strand): R1 reverse at end, R2 forward at start
                 //   R2 first if insert < 2*read_len, else R1 first
+                // This does not affect the sorted output (the sort decides that), but it
+                // keeps the stream in the same order the pre-streaming implementation
+                // wrote it, which pins tie-breaking between equal sort keys.
                 let r2_first = !is_top_strand && insert_size < 2 * params.read_length;
-                if r2_first {
-                    writer.write_raw_record(r2.as_ref())?;
-                    writer.write_raw_record(r1.as_ref())?;
-                } else {
-                    writer.write_raw_record(r1.as_ref())?;
-                    writer.write_raw_record(r2.as_ref())?;
+                let (first, second) = if r2_first { (r2, r1) } else { (r1, r2) };
+                if !sink.send(first) || !sink.send(second) {
+                    // The sorter hung up, which means it failed; its error is the
+                    // one worth reporting, so stop quietly.
+                    truth_writer.flush()?;
+                    return Ok(total_pairs);
                 }
+
                 let strand_char = if is_top_strand { '+' } else { '-' };
                 writeln!(
                     truth_writer,
@@ -312,30 +403,8 @@ impl Command for GroupedReads {
 
         progress.log_final();
         truth_writer.flush()?;
-        writer.finish()?;
 
-        info!("Generated {total_pairs} read pairs");
-
-        // Produce the final template-coordinate order with the canonical fgumi-sort
-        // engine (the same one `fgumi sort`/`fgumi group` use), reading the unsorted
-        // temp and writing the destination. This is correct for every read orientation
-        // by construction and stays consistent with the rest of fgumi.
-        info!("Sorting into template-coordinate order...");
-        RawExternalSorter::new(SortOrder::TemplateCoordinate)
-            .threads(self.threads)
-            .output_compression(self.compression.compression_level)
-            // grouped-reads always writes MI tags, so include the tertiary (library|mi)
-            // lane in the template-coordinate key rather than relying on first-record
-            // auto-detection (equivalent to `fgumi sort --key-types mi`).
-            .key_types(KeyTypesSpec::Explicit { cb: false, tertiary: true })
-            .sort(&unsorted_path, &self.output)
-            .context("Failed to template-coordinate sort simulated reads")?;
-        // `unsorted_temp` is dropped here, removing the intermediate BAM.
-        drop(unsorted_temp);
-
-        info!("Done");
-
-        Ok(())
+        Ok(total_pairs)
     }
 }
 

--- a/src/lib/commands/simulate/mapped_reads.rs
+++ b/src/lib/commands/simulate/mapped_reads.rs
@@ -1,17 +1,18 @@
 //! Generate a template-coordinate sorted BAM for `fgumi group`.
 //!
-//! Records are generated in molecule order to an unsorted temp BAM, then rewritten
-//! into template-coordinate order by the canonical `fgumi-sort` engine — the same
-//! sort `fgumi sort`/`fgumi group` use and that is validated against
+//! Records are generated in molecule order on a background thread and streamed
+//! straight into the canonical `fgumi-sort` engine — the same sort
+//! `fgumi sort`/`fgumi group` use and that is validated against
 //! `samtools sort --template-coordinate`.
 
 use crate::commands::command::Command;
 use crate::commands::common::CompressionOptions;
 use crate::commands::simulate::common::{
     FamilySizeArgs, InsertSizeArgs, MethylationArgs, MethylationConfig, PositionDistArgs,
-    QualityArgs, ReferenceArgs, ReferenceGenome, SimulationCommon, apply_methylation_conversion,
-    body_error_rng, build_sort_order_header_map, generate_random_sequence,
-    introduce_errors_inplace, pad_sequence, validate_rate,
+    QualityArgs, RecordSink, ReferenceArgs, ReferenceGenome, SimulationCommon, SortResourceArgs,
+    apply_methylation_conversion, body_error_rng, build_sort_order_header_map,
+    generate_random_sequence, into_record_stream, introduce_errors_inplace, pad_sequence,
+    validate_rate,
 };
 use crate::commands::simulate::region_to_bin;
 use crate::dna::reverse_complement;
@@ -22,7 +23,6 @@ use crate::simulate::{
 use anyhow::{Context, Result};
 use clap::Parser;
 use fgumi_bam_io::ProgressTracker;
-use fgumi_bam_io::create_raw_bam_writer;
 use fgumi_raw_bam::{RawRecord, RawRecordView, SamBuilder, flags as raw_flags};
 use fgumi_sort::{RawExternalSorter, SortOrder};
 use log::info;
@@ -31,7 +31,6 @@ use rand::{Rng, RngExt};
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
-use tempfile::NamedTempFile;
 
 /// Generate template-coordinate sorted BAM with paired alignments for `fgumi group`.
 #[derive(Parser, Debug)]
@@ -75,13 +74,16 @@ pub struct MappedReads {
     #[arg(long = "error-rate", default_value = "0.0")]
     pub error_rate: f64,
 
-    /// Number of writer threads
+    /// Number of threads for sorting and BAM compression
     #[arg(short = 't', long = "threads", default_value = "1")]
     pub threads: usize,
 
     /// Compression options for output BAM.
     #[command(flatten)]
     pub compression: CompressionOptions,
+
+    #[command(flatten)]
+    pub sort_resources: SortResourceArgs,
 
     #[command(flatten)]
     pub common: SimulationCommon,
@@ -222,41 +224,128 @@ impl Command for MappedReads {
         // mapped.
         let mut unmapped_rng = create_rng(self.common.seed.map(|s| s.wrapping_add(2)));
 
-        // Generate molecules in `mol_id` order to an unsorted temp BAM, then let the
-        // canonical `fgumi-sort` engine produce the final template-coordinate order (see
-        // the sort pass after the write loop). This reuses the one sort implementation
-        // that `fgumi sort`/`fgumi group` use and that is validated against
-        // `samtools sort --template-coordinate`, instead of a bespoke key that has to
-        // re-derive the ordering (and previously mis-ordered reverse-R1 pairs). Because
-        // ordering is deferred to that external sort, generation can stream each molecule
-        // straight into the write loop below — no O(N) molecule-metadata buffer needed.
+        // Generate molecules in `mol_id` order and stream them straight into the
+        // canonical `fgumi-sort` engine, which produces the final template-coordinate
+        // order. This reuses the one sort implementation that `fgumi sort`/`fgumi group`
+        // use and that is validated against `samtools sort --template-coordinate`,
+        // instead of a bespoke key that has to re-derive the ordering (and previously
+        // mis-ordered reverse-R1 pairs). Because ordering is deferred to that sort,
+        // generation can stream each molecule as it is produced — no O(N)
+        // molecule-metadata buffer, and no unsorted intermediate BAM: runs that fit in
+        // `--max-memory` touch disk only for the final output, and larger runs spill
+        // sorted chunks exactly like `fgumi sort` would.
+        info!("Generating records and sorting into template-coordinate order...");
 
-        // Write records to an unsorted temp BAM alongside the final output; the sort
-        // pass below rewrites it into the destination in template-coordinate order.
-        let output_dir = self.output.parent().filter(|p| !p.as_os_str().is_empty());
-        let unsorted_temp = match output_dir {
-            Some(dir) => NamedTempFile::new_in(dir),
-            None => NamedTempFile::new(),
+        let sorter = self
+            .sort_resources
+            .apply(
+                RawExternalSorter::new(SortOrder::TemplateCoordinate)
+                    .threads(self.threads)
+                    .output_compression(self.compression.compression_level),
+                self.threads,
+            )
+            .context("Failed to configure the sort for simulated reads")?;
+
+        let (sink, records) = RecordSink::new();
+
+        // Generation runs on its own thread so it overlaps the sort's accumulate,
+        // spill, and merge work. `scope` lets it borrow the reference genome and
+        // parameters instead of cloning them. `sink` is moved into the closure so
+        // its sender is dropped when generation ends — that is what signals
+        // end-of-stream to the sort.
+        let total_pairs = std::thread::scope(|scope| -> Result<usize> {
+            let generator = scope.spawn(|| {
+                self.generate_records(
+                    sink,
+                    &params,
+                    &ref_genome,
+                    &position_table,
+                    num_positions,
+                    &mut seed_rng,
+                    &mut unmapped_rng,
+                )
+            });
+
+            // Consumes `records`, so a sort failure drops the receiver and the
+            // generator's next `send` returns false, unblocking it.
+            sorter
+                .sort_records(into_record_stream(records), &header, &self.output)
+                .context("Failed to template-coordinate sort simulated reads")?;
+
+            generator.join().unwrap_or_else(|payload| std::panic::resume_unwind(payload))
+        })?;
+
+        info!("Generated {total_pairs} read pairs");
+        info!("Done");
+
+        Ok(())
+    }
+}
+
+impl MappedReads {
+    /// Generate every molecule's read pairs, sending records to `sink` and
+    /// writing the truth TSV.
+    ///
+    /// Returns the number of read pairs generated. A generator failure is
+    /// reported to `sink` so the sort aborts rather than writing a truncated
+    /// BAM, and is also returned.
+    ///
+    /// Takes `sink` by value: it is consumed at the end of this call, which
+    /// closes the record stream and is how the sort learns generation is
+    /// finished.
+    #[allow(clippy::too_many_arguments)]
+    fn generate_records(
+        &self,
+        mut sink: RecordSink,
+        params: &GenerationParams,
+        ref_genome: &ReferenceGenome,
+        position_table: &[(usize, usize)],
+        num_positions: usize,
+        seed_rng: &mut impl Rng,
+        unmapped_rng: &mut impl Rng,
+    ) -> Result<usize> {
+        let result = self.generate_records_inner(
+            &mut sink,
+            params,
+            ref_genome,
+            position_table,
+            num_positions,
+            seed_rng,
+            unmapped_rng,
+        );
+        match result {
+            // Flush the final partial batch, then close the stream.
+            Ok(total_pairs) => {
+                sink.finish();
+                Ok(total_pairs)
+            }
+            // Surface the failure to the sort so it aborts instead of treating
+            // the truncated stream as a clean end of input.
+            Err(e) => {
+                sink.fail(anyhow::anyhow!("{e:#}"));
+                Err(e)
+            }
         }
-        .context("Failed to create temporary BAM for the pre-sort write pass")?;
-        let unsorted_path = unsorted_temp.path().to_path_buf();
+    }
 
-        // Set up writer with multi-threaded BGZF compression
-        let mut writer = create_raw_bam_writer(
-            &unsorted_path,
-            &header,
-            self.threads,
-            self.compression.compression_level,
-        )?;
-
+    /// Body of [`Self::generate_records`]; see it for the contract.
+    #[allow(clippy::too_many_arguments)]
+    fn generate_records_inner(
+        &self,
+        sink: &mut RecordSink,
+        params: &GenerationParams,
+        ref_genome: &ReferenceGenome,
+        position_table: &[(usize, usize)],
+        num_positions: usize,
+        seed_rng: &mut impl Rng,
+        unmapped_rng: &mut impl Rng,
+    ) -> Result<usize> {
         // Create truth file
         let truth_file = File::create(&self.truth_output)
             .with_context(|| format!("Failed to create {}", self.truth_output.display()))?;
         let mut truth_writer = BufWriter::new(truth_file);
         writeln!(truth_writer, "read_name\ttrue_umi\tmolecule_id\tchrom\tposition\tstrand")?;
 
-        // Generate and write records to the unsorted temp BAM (molecule order).
-        info!("Generating and writing records...");
         let progress = ProgressTracker::new("Processed molecules").with_interval(100_000);
         let mut total_pairs = 0usize;
 
@@ -286,34 +375,35 @@ impl Command for MappedReads {
                 pos_chrom_idx,
                 pos_local_pos,
                 is_unmapped,
-                &params,
-                &ref_genome,
+                params,
+                ref_genome,
             );
 
             for (r1, r2, read_name, umi_str, is_top_strand) in pairs {
+                // Emit the record whose reference start is lower first. This does not
+                // affect the sorted output (the sort decides that), but it keeps the
+                // stream in the same order the pre-streaming implementation wrote it,
+                // which pins tie-breaking between records with equal sort keys.
+                // Unmapped pairs have no coordinates, so they keep R1-then-R2 order.
+                let r2_first = if is_unmapped {
+                    false
+                } else {
+                    RawRecordView::new(r1.as_ref()).pos() > RawRecordView::new(r2.as_ref()).pos()
+                };
+                let (first, second) = if r2_first { (r2, r1) } else { (r1, r2) };
+                if !sink.send(first) || !sink.send(second) {
+                    // The sorter hung up, which means it failed; its error is the
+                    // one worth reporting, so stop quietly.
+                    truth_writer.flush()?;
+                    return Ok(total_pairs);
+                }
+
                 if is_unmapped {
-                    // Unmapped pairs: emit R1 then R2 in the conventional order.
                     // Truth rows record unmapped-sentinel values for chrom/pos/strand
                     // so downstream validators can distinguish unmapped from mapped
                     // molecules.
-                    writer.write_raw_record(r1.as_ref())?;
-                    writer.write_raw_record(r2.as_ref())?;
                     writeln!(truth_writer, "{}\t{}\t{}\t*\t*\t*", read_name, umi_str, mol_id)?;
                 } else {
-                    // Template-coordinate order: write the record whose reference start
-                    // is lower first so pairs are emitted in coordinate order. R1F2
-                    // pairs have R1 (reverse read) at the higher coordinate, so emit R2
-                    // first when R1's alignment_start is strictly greater.
-                    let r1_pos = RawRecordView::new(r1.as_ref()).pos();
-                    let r2_pos = RawRecordView::new(r2.as_ref()).pos();
-                    let r2_first = r1_pos > r2_pos;
-                    if r2_first {
-                        writer.write_raw_record(r2.as_ref())?;
-                        writer.write_raw_record(r1.as_ref())?;
-                    } else {
-                        writer.write_raw_record(r1.as_ref())?;
-                        writer.write_raw_record(r2.as_ref())?;
-                    }
                     let strand_char = if is_top_strand { '+' } else { '-' };
                     writeln!(
                         truth_writer,
@@ -332,26 +422,8 @@ impl Command for MappedReads {
 
         progress.log_final();
         truth_writer.flush()?;
-        writer.finish()?;
 
-        info!("Generated {total_pairs} read pairs");
-
-        // Produce the final template-coordinate order with the canonical fgumi-sort
-        // engine (the same one `fgumi sort`/`fgumi group` use), reading the unsorted
-        // temp and writing the destination. This is correct for every read orientation
-        // by construction and stays consistent with the rest of fgumi.
-        info!("Sorting into template-coordinate order...");
-        RawExternalSorter::new(SortOrder::TemplateCoordinate)
-            .threads(self.threads)
-            .output_compression(self.compression.compression_level)
-            .sort(&unsorted_path, &self.output)
-            .context("Failed to template-coordinate sort simulated reads")?;
-        // `unsorted_temp` is dropped here, removing the intermediate BAM.
-        drop(unsorted_temp);
-
-        info!("Done");
-
-        Ok(())
+        Ok(total_pairs)
     }
 }
 

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -330,7 +330,7 @@ pub struct Sort {
 
 /// Environment variable name for the fallback temp-dir list, parsed as a
 /// `PATH`-style list when no `-T/--tmp-dir` flags are passed.
-const TMP_DIRS_ENV: &str = "FGUMI_TMP_DIRS";
+pub(crate) const TMP_DIRS_ENV: &str = "FGUMI_TMP_DIRS";
 
 /// Resolve the final list of temp directories for a sort run.
 ///

--- a/tests/integration/test_simulate_sort.rs
+++ b/tests/integration/test_simulate_sort.rs
@@ -56,11 +56,66 @@ fn fgumi(args: &[&str]) {
     assert!(status.success(), "`fgumi {}` failed: {status}", args.join(" "));
 }
 
-/// `simulate` generates in molecule order and then sorts via the canonical
+/// Run `fgumi simulate <subcommand>` into `dir`, returning the output BAM path.
+///
+/// `max_memory` is passed straight through to `--max-memory`, which bounds the
+/// streaming sort's in-memory buffer: a large value keeps the whole run in
+/// memory, a tiny one forces spill-to-disk plus a k-way merge.
+fn simulate(
+    dir: &Path,
+    subcommand: &str,
+    num_molecules: usize,
+    duplex: bool,
+    max_memory: &str,
+    name: &str,
+) -> PathBuf {
+    let reference = write_reference(dir);
+    let bam = dir.join(format!("{name}.bam"));
+    let truth = dir.join(format!("{name}.truth.tsv"));
+
+    let num_molecules = num_molecules.to_string();
+    let bam_arg = bam.to_str().unwrap().to_string();
+    let reference = reference.to_str().unwrap().to_string();
+    let truth = truth.to_str().unwrap().to_string();
+    // Keep spill files inside the test's temp dir rather than the system temp.
+    let tmp_dir = dir.to_str().unwrap().to_string();
+
+    let mut args = vec![
+        "simulate",
+        subcommand,
+        "-o",
+        &bam_arg,
+        "--truth",
+        &truth,
+        "--reference",
+        &reference,
+        "--num-molecules",
+        &num_molecules,
+        "--seed",
+        "42",
+        "--max-memory",
+        max_memory,
+        "--tmp-dir",
+        &tmp_dir,
+    ];
+    if duplex {
+        args.push("--duplex");
+    }
+    fgumi(&args);
+
+    bam
+}
+
+/// `simulate` generates in molecule order and streams into the canonical
 /// `fgumi-sort` engine, so its output must be template-coordinate sorted for every
 /// subcommand and read orientation. `fgumi sort --verify` asserts exactly that
 /// (0 sort-order violations), and it is the check that fails if the ordering
 /// regresses.
+///
+/// Each case runs twice — once with a memory budget that holds the whole run
+/// (the sort's in-memory fast path) and once with a tiny budget that forces
+/// spill-to-disk and a k-way merge — because streaming generation feeds both
+/// paths and only the second exercises the spill/merge code.
 #[rstest]
 #[case::mapped_reads("mapped-reads", 1_000, false)]
 #[case::grouped_reads_simplex("grouped-reads", 1_000, false)]
@@ -70,38 +125,51 @@ fn simulate_output_is_template_coordinate_sorted(
     #[case] subcommand: &str,
     #[case] num_molecules: usize,
     #[case] duplex: bool,
+    #[values("768M", "1M")] max_memory: &str,
 ) {
     let dir = TempDir::new().expect("create temp dir");
-    let reference = write_reference(dir.path());
-    let bam = dir.path().join("out.bam");
-    let truth = dir.path().join("truth.tsv");
-
-    let num_molecules = num_molecules.to_string();
-    let bam = bam.to_str().unwrap();
-    let reference = reference.to_str().unwrap();
-    let truth = truth.to_str().unwrap();
-
-    let mut args = vec![
-        "simulate",
-        subcommand,
-        "-o",
-        bam,
-        "--truth",
-        truth,
-        "--reference",
-        reference,
-        "--num-molecules",
-        &num_molecules,
-        "--seed",
-        "42",
-    ];
-    if duplex {
-        args.push("--duplex");
-    }
-    fgumi(&args);
+    let bam = simulate(dir.path(), subcommand, num_molecules, duplex, max_memory, "out");
 
     // The canonical verifier: the output must already be in template-coordinate
     // order. Exit code is non-zero (and this asserts) if any records are out of
     // order — which is how the previous reverse-R1 mis-ordering was caught.
-    fgumi(&["sort", "-i", bam, "--verify", "--order", "template-coordinate"]);
+    fgumi(&["sort", "-i", bam.to_str().unwrap(), "--verify", "--order", "template-coordinate"]);
+}
+
+/// Read every alignment record of a BAM, excluding the header.
+///
+/// The header cannot be part of an output comparison: its `@PG` record embeds
+/// the command line, which differs between any two runs invoked with different
+/// flags.
+fn read_records(path: &Path) -> Vec<noodles::sam::alignment::RecordBuf> {
+    let mut reader = noodles::bam::io::Reader::new(
+        std::fs::File::open(path).unwrap_or_else(|e| panic!("open {}: {e}", path.display())),
+    );
+    let header = reader.read_header().expect("read BAM header");
+    reader.record_bufs(&header).map(|r| r.expect("read BAM record")).collect()
+}
+
+/// The output must not depend on how much memory the sort was given: spilling
+/// to disk and merging has to reproduce the in-memory result exactly.
+///
+/// This is what pins the streaming design — records enter the sort in
+/// generation order regardless of budget, so tie-breaking between equal sort
+/// keys cannot drift with the spill boundaries.
+#[rstest]
+#[case::mapped_reads("mapped-reads", 2_000, false)]
+#[case::grouped_reads_duplex("grouped-reads", 2_000, true)]
+fn simulate_output_is_identical_regardless_of_spilling(
+    #[case] subcommand: &str,
+    #[case] num_molecules: usize,
+    #[case] duplex: bool,
+) {
+    let dir = TempDir::new().expect("create temp dir");
+    let in_memory = simulate(dir.path(), subcommand, num_molecules, duplex, "768M", "in_memory");
+    let spilled = simulate(dir.path(), subcommand, num_molecules, duplex, "1M", "spilled");
+
+    assert_eq!(
+        read_records(&in_memory),
+        read_records(&spilled),
+        "spilling changed the simulated output"
+    );
 }


### PR DESCRIPTION
Follow-up to #576. That PR made `simulate` delegate ordering to the canonical `fgumi-sort` engine by writing an unsorted temp BAM and handing it to `sort()`. This removes the temp BAM.

## The redundancy

`RawExternalSorter` was reachable only through `sort(input_path, output_path)`, so a producer that already has records in memory had to write a BAM just to hand it straight back. Two costs, and the second is the one that bites:

1. Every run pays a full compress → write → read → decompress round-trip, even when the records fit in memory and the sort's existing zero-temp-file fast path would otherwise touch disk only for the output.
2. Runs larger than the memory limit keep the whole intermediate on disk *alongside* the spill chunks — and it lands in the **output** directory, so `simulate` demanded ~2.1x the output size on the destination volume.

The engine never needed the file: every per-order implementation is already driven by a `RecordSource` iterator. The file-to-file signature was the only thing in the way.

## The change

**`feat(sort)`** — `RawExternalSorter::sort_records(records, header, output)` sorts an in-process record stream. It runs the same accumulate/spill/merge path as `sort`, including the in-memory fast path; both entry points now share `create_worker_pool` (which also enforces the spill-codec invariant, so neither can reach a misconfigured pool) and `sort_from_source`.

The new `RecordSource::Stream` variant carries fallible items. The first `Err` ends the stream and surfaces through `take_error`, which every sort order already checks *before* writing output — so a producer failure aborts rather than leaving a silently truncated BAM.

**`perf(simulate)`** — `mapped-reads` and `grouped-reads` generate on a scoped thread that streams into `sort_records`. Nothing is materialized before the output, and generation overlaps the sort's accumulate/spill/merge work.

Records cross the channel in batches of 256 (the batch size the sort's own read-ahead reader uses). This is load-bearing, not incidental: sending records one at a time costs **more than the intermediate BAM it replaces** — measured ~7% slower end-to-end before batching, ~7% faster after.

## Routing threads and memory

Both commands were running the sort with a hardcoded 512 MB limit, no `initial_capacity` tuning, and no way to steer spill off a tmpfs `/tmp`. They now take the same knobs as `fgumi sort`, with the same names, defaults, and semantics: `--max-memory`, `--memory-reserve`, `--memory-per-thread`, `-T/--tmp-dir` (plus `FGUMI_TMP_DIRS`). `--threads` now drives the sort's thread count and the per-thread memory scaling.

**Behavior change worth flagging:** the default is now `768M` *per thread* rather than `512M` fixed, so `-t 4` gets a 3 GB budget and spills later than before.

## Measured

1M molecules (6,003,722 records, 4 threads), versus the implementation merged in #576:

| | before | after |
|---|---|---|
| wall, spilling (512M budget) | 13.85 s | **13.18 s** |
| wall, no spill (200k mol) | 2.65 s | **2.47 s** |
| peak disk, output directory | 1234 MB | **593 MB** |
| peak disk, output + temp | 1722 MB | **1182 MB** |

Output records are byte-identical to the previous implementation for mapped-reads, grouped-reads, and grouped-reads-duplex (verified against a binary built at 829cebdc; only `@PG` differs, since the two binaries have different paths).

## Tests

`fgumi-sort` gains 12 tests pinning the invariant every caller depends on: `sort_records` output is byte-identical to `sort` over the same records for all four sort orders, on both the fits-in-memory and spill-and-merge paths; an empty stream writes a header-only BAM; and a producer error aborts with no output file left behind, whether it fails on the first record or after a spill.

The `simulate` integration table now runs every case at both a budget that holds the whole run and one that forces spill-and-merge, and asserts the spilled output matches the in-memory output record for record. That comparison is over records rather than whole files because `@PG` embeds the command line, which necessarily differs between the two runs.

## Verification

- `cargo ci-test` -> 5463 passed, 0 failed
- `cargo ci-fmt`, `cargo ci-lint` (`-D warnings -W clippy::pedantic`), `cargo ci-doctest` -> clean

## Reading order

Start with `crates/fgumi-sort/src/external.rs` (`sort` / `sort_records` / `sort_from_source`), then `read_ahead.rs` for the `Stream` variant's error contract, then `simulate/common.rs` for `RecordSink` and `SortResourceArgs`. The two command files are mechanical after that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Simulation commands now stream generated reads directly into sorting, reducing intermediate file usage.
  - Added memory, reserve, per-thread, and temporary-directory options for controlling simulation sorting resources.
  - Added an in-process record-streaming API for sorting generated records.

- **Bug Fixes**
  - Sorting now aborts cleanly when record generation fails, preventing incomplete output files.

- **Tests**
  - Added coverage confirming identical results across memory and spill-to-disk configurations.
  - Added validation for empty streams and producer errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->