### PR TITLE
chore(deps): declare shared third-party deps in [workspace.dependencies]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/fulcrumgenomics/fgumi"
 license = "MIT"
 
 [workspace.dependencies]
+# Internal crates. Versions are bumped in lockstep by release-plz.
 fgumi-bam-io = { version = "0.4.0", path = "crates/fgumi-bam-io" }
 fgumi-bgzf = { version = "0.4.0", path = "crates/fgumi-bgzf" }
 fgumi-consensus = { version = "0.4.0", path = "crates/fgumi-consensus", default-features = false }
@@ -21,7 +22,49 @@ fgumi-simd-fastq = { version = "0.4.0", path = "crates/fgumi-simd-fastq" }
 fgumi-sort = { version = "0.4.0", path = "crates/fgumi-sort" }
 fgumi-tag = { version = "0.4.0", path = "crates/fgumi-tag" }
 fgumi-umi = { version = "0.4.0", path = "crates/fgumi-umi" }
+
+# Third-party crates shared by two or more members. Declared once here so a member can
+# never drift onto a different version: two versions of a crate whose types cross crate
+# boundaries (e.g. noodles' `Header`/`RecordBuf`) do not unify and fail to compile.
+ahash = "0.8"
+anyhow = "1.0.102"
+approx = "0.5.1"
+bgzf = "0.4.0"
+bstr = "1.12.1"
 bytemuck = { version = "1.14", features = ["derive"] }
+bytes = "1"
+bytesize = "2.3"
+clap = { version = "4", features = ["derive"] }
+crc32fast = "1.4"
+criterion = { version = "0.8", features = ["html_reports"] }
+crossbeam-channel = "0.5"
+crossbeam-queue = "0.3"
+crossbeam-utils = "0.8.21"
+fgoxide = "0.6.0"
+fs4 = { version = "1.1", default-features = false, features = ["sync"] }
+libdeflater = "1.22"
+libmimalloc-sys = { version = "0.1.44", features = ["extended"] }
+log = "0"
+mach2 = "0.6"
+memchr = "2"
+nix = { version = "0.31", default-features = false, features = ["fs"] }
+# The noodles stack is held one minor behind (noodles 0.111 / noodles-bgzf 0.47 / noodles-csi
+# 0.56). noodles-bgzf 0.48 deprecates `MultithreadedReader::with_worker_count` and
+# `multithreaded_writer::Builder::set_worker_count` into no-ops that defer to rayon's *global*
+# thread pool, so `--threads` would silently stop bounding BGZF decompression/compression
+# parallelism — and fgumi already runs work inside its own scoped rayon pools. Upgrading needs a
+# dedicated, benchmarked migration PR.
+noodles = "0.111.0"
+noodles-bgzf = { version = "0.47.0", features = ["libdeflate"] }
+noodles-csi = "0.56.0"
+parking_lot = "0.12"
+proptest = "1.10"
+rand = "0.10"
+rayon = "1.10"
+rstest = "0.26"
+serde = { version = "1.0.228", features = ["derive"] }
+tempfile = "3.3.0"
+thiserror = "2"
 wide = "1.5"
 
 [package]
@@ -40,45 +83,42 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-clap = { version = "4", features = ["derive", "string"] }
-log = "0"
-thiserror = "2"
-# held at 0.111 workspace-wide; see crates/fgumi-bam-io/Cargo.toml for why. Every member must
-# move in lockstep — a split leaves two `noodles-sam` versions whose `Header`/`RecordBuf` types
-# do not unify, which fails to compile.
-noodles = { version = "0.111.0", features = ["bam", "fasta", "sam", "bgzf", "core", "vcf"] }
-noodles-bgzf = { version = "0.47.0", features = ["libdeflate"] }
+clap = { workspace = true, features = ["string"] }
+log = { workspace = true }
+thiserror = { workspace = true }
+noodles = { workspace = true, features = ["bam", "fasta", "sam", "bgzf", "core", "vcf"] }
+noodles-bgzf = { workspace = true }
 mimalloc = { version = "0.1.52", default-features = false }
-libmimalloc-sys = { version = "0.1.44", features = ["extended"] }
+libmimalloc-sys = { workspace = true }
 env_logger = "0.11.8"
 enum_dispatch = "0.3.13"
-anyhow = "1.0.102"
+anyhow = { workspace = true }
 read-structure = "0.2.0" # held at 0.2 because 0.3 is a breaking API + behavior change (zero-length-read handling) that needs a dedicated migration PR
-bstr = "1.12.1"
-bytes = "1"
-fgoxide = "0.6.0"
-tempfile = "3.3.0"
+bstr = { workspace = true }
+bytes = { workspace = true }
+fgoxide = { workspace = true }
+tempfile = { workspace = true }
 lru = "0.18.0"
-crc32fast = "1.4"
-crossbeam-channel = "0.5"
-crossbeam-queue = "0.3"
-crossbeam-utils = "0.8.21"
-parking_lot = "0.12"
-libdeflater = "1.22"
-serde = { version = "1.0.228", features = ["derive"] }
+crc32fast = { workspace = true }
+crossbeam-channel = { workspace = true }
+crossbeam-queue = { workspace = true }
+crossbeam-utils = { workspace = true }
+parking_lot = { workspace = true }
+libdeflater = { workspace = true }
+serde = { workspace = true }
 itertools = "0.14.0"
 indexmap = "2"
-rand = "0.10"
+rand = { workspace = true }
 csv = "1.1"
-memchr = "2"
+memchr = { workspace = true }
 statrs = "0.18"
-bytesize = "2.3"
+bytesize = { workspace = true }
 sysinfo = { version = "0.38", default-features = false, features = ["system"] } # unconditionally used by validate_against_system_memory; held at 0.38 because sysinfo >=0.39 requires rustc 1.95 > our MSRV (rust-toolchain.toml pins 1.93)
-fs4 = { version = "1.1", default-features = false, features = ["sync"] } # cross-platform filesystem free-space queries
+fs4 = { workspace = true } # cross-platform filesystem free-space queries
 num_cpus = "1.16"
-rayon = "1.10"
-approx = "0.5.1"
-ahash = "0.8"
+rayon = { workspace = true }
+approx = { workspace = true }
+ahash = { workspace = true }
 bytemuck = { workspace = true }
 rand_distr = "0.6"
 # `zlib-rs` selects flate2's fast Rust-zlib DEFLATE backend for gzipped FASTQ
@@ -101,10 +141,10 @@ fgumi-bam-io = { workspace = true }
 fgumi-sort = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mach2 = "0.6"
+mach2 = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-nix = { version = "0.31", default-features = false, features = ["fs"] }
+nix = { workspace = true }
 
 [features]
 default = ["simplex", "duplex", "codec"]
@@ -127,12 +167,11 @@ profile-adjacency = []
 stress-tests = []
 
 [dev-dependencies]
-rstest = "0"
-proptest = "1.10"
-criterion = { version = "0.8", features = ["html_reports"] }
+rstest = { workspace = true }
+proptest = { workspace = true }
+criterion = { workspace = true }
 fgumi-raw-bam = { workspace = true, features = ["test-utils", "noodles"] }
-# held at 0.111 workspace-wide; see crates/fgumi-bam-io/Cargo.toml for why
-noodles = { version = "0.111.0", features = ["bam", "sam"] }
+noodles = { workspace = true, features = ["bam", "sam"] }
 
 [[bench]]
 name = "core_functions"

--- a/crates/fgumi-bam-io/Cargo.toml
+++ b/crates/fgumi-bam-io/Cargo.toml
@@ -15,27 +15,21 @@ pedantic = { level = "deny", priority = -1 }
 
 [dependencies]
 fgumi-raw-bam = { workspace = true, features = ["noodles"] }
-# The noodles stack is held one minor behind (noodles 0.111 / noodles-bgzf 0.47 / noodles-csi
-# 0.56) across the whole workspace. noodles-bgzf 0.48 deprecates
-# `MultithreadedReader::with_worker_count` and `multithreaded_writer::Builder::set_worker_count`
-# into no-ops that defer to rayon's *global* thread pool, so `--threads` would silently stop
-# bounding BGZF decompression/compression parallelism — and fgumi already runs work inside its
-# own scoped rayon pools. Upgrading needs a dedicated, benchmarked migration PR.
-noodles = { version = "0.111.0", features = ["bam", "fasta", "sam", "bgzf", "core", "vcf"] }
-noodles-bgzf = { version = "0.47.0", features = ["libdeflate"] }
-noodles-csi = "0.56.0"
-bgzf = "0.4.0"
-anyhow = "1.0.102"
-bstr = "1.12.1"
-bytes = "1"
-crossbeam-channel = "0.5"
-log = "0"
+noodles = { workspace = true, features = ["bam", "fasta", "sam", "bgzf", "core", "vcf"] }
+noodles-bgzf = { workspace = true }
+noodles-csi = { workspace = true }
+bgzf = { workspace = true }
+anyhow = { workspace = true }
+bstr = { workspace = true }
+bytes = { workspace = true }
+crossbeam-channel = { workspace = true }
+log = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-nix = { version = "0.31", default-features = false, features = ["fs"] }
+nix = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3"
-rstest = "0"
-proptest = "1.10"
-criterion = { version = "0.8", features = ["html_reports"] }
+tempfile = { workspace = true }
+rstest = { workspace = true }
+proptest = { workspace = true }
+criterion = { workspace = true }

--- a/crates/fgumi-bgzf/Cargo.toml
+++ b/crates/fgumi-bgzf/Cargo.toml
@@ -8,12 +8,12 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-libdeflater = "1.22"
-crc32fast = "1.4"
-bgzf = "0.4.0"
+libdeflater = { workspace = true }
+crc32fast = { workspace = true }
+bgzf = { workspace = true }
 
 [dev-dependencies]
-criterion = { version = "0.8", features = ["html_reports"] }
+criterion = { workspace = true }
 
 [[bench]]
 name = "stored_block_decode"

--- a/crates/fgumi-consensus/Cargo.toml
+++ b/crates/fgumi-consensus/Cargo.toml
@@ -8,16 +8,15 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-ahash = "0.8"
-anyhow = "1.0"
-approx = "0.5"
-bstr = "1.12.1"
-log = "0"
-# held at 0.111 workspace-wide; see crates/fgumi-bam-io/Cargo.toml for why
-noodles = { version = "0.111.0", features = ["bam", "sam", "core"] }
-rand = "0.10"
-thiserror = "2"
-wide = "1.5"
+ahash = { workspace = true }
+anyhow = { workspace = true }
+approx = { workspace = true }
+bstr = { workspace = true }
+log = { workspace = true }
+noodles = { workspace = true, features = ["bam", "sam", "core"] }
+rand = { workspace = true }
+thiserror = { workspace = true }
+wide = { workspace = true }
 fgumi-dna = { workspace = true }
 fgumi-sam = { workspace = true }
 fgumi-metrics = { workspace = true }
@@ -28,9 +27,9 @@ fgumi-raw-bam = { workspace = true, features = ["test-utils"] }
 # Read fgbio-oracle fixture BAMs back into RawRecords in the saturation-oracle
 # tests. fgumi-bam-io does NOT depend on fgumi-consensus, so this is cycle-free.
 fgumi-bam-io = { workspace = true }
-tempfile = "3.3.0"
-rstest = "0.26"
-proptest = "1.10"
+tempfile = { workspace = true }
+rstest = { workspace = true }
+proptest = { workspace = true }
 
 [features]
 default = ["simplex", "duplex", "codec"]

--- a/crates/fgumi-dna/Cargo.toml
+++ b/crates/fgumi-dna/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 [dependencies]
 
 [dev-dependencies]
-rstest = "0"
+rstest = { workspace = true }
 
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }

--- a/crates/fgumi-metrics/Cargo.toml
+++ b/crates/fgumi-metrics/Cargo.toml
@@ -8,19 +8,18 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-anyhow = "1.0"
-fgoxide = "0.6.0"
-tempfile = "3.3.0"
-# held at 0.111 workspace-wide; see crates/fgumi-bam-io/Cargo.toml for why
-noodles = { version = "0.111.0", features = ["sam"], optional = true }
+serde = { workspace = true }
+anyhow = { workspace = true }
+fgoxide = { workspace = true }
+tempfile = { workspace = true }
+noodles = { workspace = true, features = ["sam"], optional = true }
 fgumi-raw-bam = { workspace = true, optional = true }
 
 [dev-dependencies]
-tempfile = "3.3.0"
+tempfile = { workspace = true }
 fgumi-sam = { workspace = true }
-rstest = "0.26"
-proptest = "1.10"
+rstest = { workspace = true }
+proptest = { workspace = true }
 strum = { version = "0.28", features = ["derive"] }
 
 [features]

--- a/crates/fgumi-raw-bam/Cargo.toml
+++ b/crates/fgumi-raw-bam/Cargo.toml
@@ -8,9 +8,8 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-# held at 0.111 workspace-wide; see crates/fgumi-bam-io/Cargo.toml for why
-noodles = { version = "0.111.0", features = ["bam", "bgzf", "core", "csi", "sam"], optional = true }
-anyhow = { version = "1.0.102", optional = true }
+noodles = { workspace = true, features = ["bam", "bgzf", "core", "csi", "sam"], optional = true }
+anyhow = { workspace = true, optional = true }
 bytemuck = { workspace = true }
 fgumi-dna = { workspace = true }
 fgumi-tag = { workspace = true }
@@ -22,7 +21,7 @@ noodles = ["dep:noodles", "dep:anyhow"]
 test-utils = []
 
 [dev-dependencies]
-bstr = "1.12.1"
-proptest = "1.10"
-rstest = "0"
-tempfile = "3"
+bstr = { workspace = true }
+proptest = { workspace = true }
+rstest = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/fgumi-sam/Cargo.toml
+++ b/crates/fgumi-sam/Cargo.toml
@@ -8,20 +8,19 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-# held at 0.111 workspace-wide; see crates/fgumi-bam-io/Cargo.toml for why
-noodles = { version = "0.111.0", features = ["bam", "sam", "core"] }
+noodles = { workspace = true, features = ["bam", "sam", "core"] }
 fgumi-raw-bam = { workspace = true, features = ["noodles"] }
 fgumi-tag = { workspace = true }
-bstr = "1.12.1"
-clap = { version = "4", features = ["derive"] }
-log = "0"
-anyhow = "1.0"
+bstr = { workspace = true }
+clap = { workspace = true }
+log = { workspace = true }
+anyhow = { workspace = true }
 fgumi-dna = { workspace = true }
-tempfile = "3.3.0"
+tempfile = { workspace = true }
 
 [dev-dependencies]
 fgumi-raw-bam = { workspace = true, features = ["test-utils"] }
-rstest = "0.26"
+rstest = { workspace = true }
 
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }

--- a/crates/fgumi-simd-fastq/Cargo.toml
+++ b/crates/fgumi-simd-fastq/Cargo.toml
@@ -10,10 +10,10 @@ license.workspace = true
 [dependencies]
 
 [dev-dependencies]
-rstest = "0"
-proptest = "1.10"
-criterion = { version = "0.8", features = ["html_reports"] }
-memchr = "2"
+rstest = { workspace = true }
+proptest = { workspace = true }
+criterion = { workspace = true }
+memchr = { workspace = true }
 seq_io = "0.3.4"
 
 [[bench]]

--- a/crates/fgumi-sort/Cargo.toml
+++ b/crates/fgumi-sort/Cargo.toml
@@ -17,35 +17,34 @@ pedantic = { level = "deny", priority = -1 }
 fgumi-raw-bam = { workspace = true, features = ["noodles"] }
 fgumi-bgzf = { workspace = true }
 fgumi-bam-io = { workspace = true }
-# held at 0.111 workspace-wide; see crates/fgumi-bam-io/Cargo.toml for why
-noodles = { version = "0.111.0", features = ["bam", "sam", "core", "csi"] }
-noodles-bgzf = { version = "0.47.0", features = ["libdeflate"] }
-libdeflater = "1.22"
-libmimalloc-sys = { version = "0.1.44", features = ["extended"] }
-rayon = "1.10"
-crossbeam-channel = "0.5"
-crossbeam-queue = "0.3"
-crossbeam-utils = "0.8.21"
-parking_lot = "0.12"
-tempfile = "3.3.0"
+noodles = { workspace = true, features = ["bam", "sam", "core", "csi"] }
+noodles-bgzf = { workspace = true }
+libdeflater = { workspace = true }
+libmimalloc-sys = { workspace = true }
+rayon = { workspace = true }
+crossbeam-channel = { workspace = true }
+crossbeam-queue = { workspace = true }
+crossbeam-utils = { workspace = true }
+parking_lot = { workspace = true }
+tempfile = { workspace = true }
 bytemuck = { workspace = true }
-ahash = "0.8"
-anyhow = "1.0.102"
-bstr = "1.12.1"
-bytes = "1"
-bytesize = "2.3"
-fs4 = { version = "1.1", default-features = false, features = ["sync"] }
-log = "0"
+ahash = { workspace = true }
+anyhow = { workspace = true }
+bstr = { workspace = true }
+bytes = { workspace = true }
+bytesize = { workspace = true }
+fs4 = { workspace = true }
+log = { workspace = true }
 zstd = "0.13"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mach2 = "0.6"
+mach2 = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-nix = { version = "0.31", default-features = false, features = ["fs"] }
+nix = { workspace = true }
 
 [features]
 default = []
@@ -55,7 +54,7 @@ memory-debug = []
 fgumi-bam-io = { workspace = true }
 fgumi-raw-bam = { workspace = true, features = ["test-utils", "noodles"] }
 fgumi-sam = { workspace = true }
-rstest = "0"
-proptest = "1.10"
-criterion = { version = "0.8", features = ["html_reports"] }
-tempfile = "3"
+rstest = { workspace = true }
+proptest = { workspace = true }
+criterion = { workspace = true }
+tempfile = { workspace = true }

--- a/crates/fgumi-tag/Cargo.toml
+++ b/crates/fgumi-tag/Cargo.toml
@@ -8,9 +8,8 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-# held at 0.111 workspace-wide; see crates/fgumi-bam-io/Cargo.toml for why
-noodles = { version = "0.111.0", features = ["sam"] }
-anyhow = "1.0"
+noodles = { workspace = true, features = ["sam"] }
+anyhow = { workspace = true }
 
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }

--- a/crates/fgumi-umi/Cargo.toml
+++ b/crates/fgumi-umi/Cargo.toml
@@ -8,15 +8,15 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-ahash = "0.8"
-anyhow = "1.0"
-clap = { version = "4", features = ["derive"], optional = true }
-rayon = "1.10"
+ahash = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true, optional = true }
+rayon = { workspace = true }
 fgumi-dna = { workspace = true }
 
 [dev-dependencies]
-rstest = "0.26"
-proptest = "1"
+rstest = { workspace = true }
+proptest = { workspace = true }
 
 [features]
 default = ["cli"]

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -15,14 +15,14 @@ compare = ["fgumi/compare"]
 simulate = ["fgumi/simulate"]
 
 [dependencies]
-anyhow = "1"
-clap = { version = "4", features = ["derive"] }
+anyhow = { workspace = true }
+clap = { workspace = true }
 syn = { version = "2", features = ["full", "extra-traits"] }
 quote = "1"
 fgumi = { path = "../.." }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile = { workspace = true }
 
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }


### PR DESCRIPTION
## Why

A grouped dependency bump updated `noodles` in all eight `crates/*/Cargo.toml` files but left the root manifest on the older requirement. The build then linked two `noodles-sam` versions at once, and types that cross crate boundaries — `Header`, `RecordBuf` — do not unify across two versions of the same crate, so the workspace failed to compile with several dozen mismatched-type errors, taking out the `test`, `lint`, `docs` and `no-default-features-check` jobs together.

This has now happened four weeks running: #546, #571 and #583 were all closed for it, and #588 was fixed by hand.

The root cause is that a version can be declared in two places and drift. This PR removes the second place.

## What

Every third-party crate used by **two or more** members now declares its version once in `[workspace.dependencies]`; members reference it as `{ workspace = true }` and carry only the features they add on top. 33 crates in total.

The whole held noodles stack (`noodles` / `noodles-bgzf` / `noodles-csi`) now sits together, with the rationale for the hold stated once instead of copied into eight manifests.

Deps used by exactly one member are deliberately left alone — they cannot diverge, so hoisting them would add indirection for nothing. That includes the root-only holds (`read-structure`, `sysinfo`) and singletons like `strum`, `seq_io`, `zstd`, `libc`, `syn`, `quote`.

Where members disagreed on a requirement, the most specific one wins:

| crate | was | now |
|---|---|---|
| `rstest` | `"0"` / `"0.26"` | `"0.26"` |
| `tempfile` | `"3"` / `"3.3.0"` | `"3.3.0"` |
| `anyhow` | `"1"` / `"1.0"` / `"1.0.102"` | `"1.0.102"` |
| `proptest` | `"1"` / `"1.10"` | `"1.10"` |
| `approx` | `"0.5"` / `"0.5.1"` | `"0.5.1"` |
| `serde` | `"1.0"` / `"1.0.228"` | `"1.0.228"` |

All of these already resolved to the same versions, which is why the lockfile does not move.

## This is a pure refactor

Two independent checks, both byte-identical before and after:

- `Cargo.lock` — unchanged, and not part of this diff.
- `cargo tree -e features --workspace --features compare,simulate,profile-adjacency` — unchanged, so feature unification is untouched as well (features do not appear in the lockfile, so the lock alone would not prove this).

Full local CI is green: `ci-fmt`, `ci-lint` (`-D warnings -W clippy::pedantic`), `check --workspace --no-default-features --all-targets`, `ci-doc` with `RUSTDOCFLAGS=-D warnings`, `ci-test` (5445 passed / 22 skipped), `ci-doctest`.

## What this does and does not fix

It makes the version **split** structurally impossible, which is the thing that broke CI.

It does not necessarily make dependabot start writing the root manifest again. Separately from the split, dependabot has been silently dropping *every* edit to the root `Cargo.toml` since around #546: of the 23 updates #588 advertised, four never happened (`itertools`, `read-structure`, `sysinfo`, plus root's half of `noodles`), and all four are root-declared. The job log shows it decided on those updates and finished clean with no error — it simply produced no change. The logs have no file-level granularity, so the mechanism is not visible in them.

Worst case after this PR, a bump that needs a manifest edit lands as a lockfile-only PR instead of a broken one. Best case dependabot writes the single hoisted entry correctly. Either beats a split.

Worth following up separately: since the holds on `read-structure` and `sysinfo` have only been surviving because root writes vanish, they should get real `ignore` entries in `.github/dependabot.yml` rather than relying on a comment and a bug.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized third-party dependency version management across the workspace.
  * Updated project components and development tools to use shared dependency versions.
  * Preserved existing optional dependencies and relevant feature selections where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->