### PR TITLE
docs: point Zenodo DOI badge at the concept DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![codecov](https://codecov.io/gh/fulcrumgenomics/fgumi/graph/badge.svg)](https://codecov.io/gh/fulcrumgenomics/fgumi)
 [![Bioconda](https://img.shields.io/conda/vn/bioconda/fgumi.svg?label=bioconda)](https://bioconda.github.io/recipes/fgumi/README.html)
 [![License](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/fulcrumgenomics/fgumi/blob/main/LICENSE)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18702470.svg)](https://doi.org/10.5281/zenodo.18702470)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18702466.svg)](https://doi.org/10.5281/zenodo.18702466)
 
 # fgumi
 


### PR DESCRIPTION
The DOI badge referenced `10.5281/zenodo.18702470`. That is an orphan concept series containing a single record, for the `fgumi-metrics-v0.1.0` sub-crate tag — so the badge advertised a DOI for one sub-crate's first release, and would never track any subsequent release.

This switches the badge to `10.5281/zenodo.18702466`, the repository's main concept series, which covers all 17 deposited releases and currently resolves to `v0.4.0`.

A concept DOI always resolves to the latest version, so the badge now stays current without manual bumps at each release.

Verified: `https://zenodo.org/api/records/18702466` → `10.5281/zenodo.20778691`, title `fulcrumgenomics/fgumi: v0.4.0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s DOI badge to reference the latest Zenodo record.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->