### PR TITLE
docs(extract): fix private intra-doc link breaking the docs build on main

### DIFF
--- a/src/lib/commands/extract.rs
+++ b/src/lib/commands/extract.rs
@@ -15,7 +15,7 @@
 //! quality encodings. Detection pools the heads of all input FASTQs (EXT3-01), matching fgbio
 //! `FastqToBam`. When no encoding matches the observed qualities, fgumi fails like fgbio's
 //! `case Nil => fail(...)` (EXT3-03) but improves on its static message by reporting the
-//! observed quality range in the error (see [`QualityEncoding::from_stats`]).
+//! observed quality range in the error (see `QualityEncoding::from_stats`).
 
 use crate::commands::command::Command;
 use crate::commands::common::{


### PR DESCRIPTION
## Summary

The `docs` job in `Check and Test` has been failing on `main` since #587 ("docs(extract): document EXT3-03 encoding-failure parity with fgbio").

That change added a module-level doc for `extract` that links to `QualityEncoding::from_stats`, which is a **private** item. The docs job builds with `RUSTDOCFLAGS="-D warnings"`, promoting `rustdoc::private_intra_doc_links` to a hard error:

```
error: public documentation for `extract` links to private item `QualityEncoding::from_stats`
  --> src/lib/commands/extract.rs:18:48
   = note: `-D rustdoc::private-intra-doc-links` implied by `-D warnings`
error: could not document `fgumi`
```

## Fix

Drop the intra-doc link brackets and keep the code-formatted reference (`` `QualityEncoding::from_stats` ``). This preserves the reference's intent without generating a link to a private item.

## Verification

Reproduced the CI docs build locally and confirmed it now passes:

```
RUSTDOCFLAGS="-D warnings" cargo ci-doc
# Finished; Generated target/doc/fgumi_lib/index.html and 13 other files
```