### PR TITLE
fix(extract): count final FASTQ batch before publishing read_done

### DIFF
--- a/src/lib/unified_pipeline/fastq.rs
+++ b/src/lib/unified_pipeline/fastq.rs
@@ -2133,6 +2133,21 @@ fn fastq_try_step_read<R: BufRead + Send, P: Send + MemoryEstimate>(
                             }
                             continue;
                         }
+                        // Count this batch in `batches_read` BEFORE publishing
+                        // `read_done`. The pair step's completion predicate is
+                        // `read_done && chunks_paired == batches_read` (see
+                        // `fastq_try_step_find_boundaries`). If `read_done` were
+                        // stored first, another worker could observe it while this
+                        // final batch is still uncounted (`chunks_paired ==
+                        // batches_read` transiently true with the batch in flight),
+                        // set `boundaries_done`, and orphan the batch in
+                        // `q1_decompressed` — a deadlock. Incrementing first, with
+                        // the `read_done` release store ordered after it, guarantees
+                        // any thread that sees `read_done == true` also sees this
+                        // batch counted, so the predicate stays false until the
+                        // batch is actually paired. The BGZF and BAM read paths avoid
+                        // this by only setting `read_done` on a zero-batch (EOF) read.
+                        let serial = state.batches_read.fetch_add(1, Ordering::Release);
                         // Set EOF flag now if at_eof, even though we have records
                         // to push. This avoids an extra wasted read call and
                         // ensures read_done is set promptly for pipeline shutdown.
@@ -2142,7 +2157,6 @@ fn fastq_try_step_read<R: BufRead + Send, P: Send + MemoryEstimate>(
                                 state.read_done.store(true, Ordering::Release);
                             }
                         }
-                        let serial = state.batches_read.fetch_add(1, Ordering::Release);
                         let chunk =
                             PerStreamChunk { stream_idx, batch_num, data, offsets: Some(offsets) };
                         match state.q0_chunks.push((serial, chunk)) {

--- a/tests/integration/test_async_reader.rs
+++ b/tests/integration/test_async_reader.rs
@@ -313,6 +313,63 @@ fn test_extract_plain_async_reader_multithreaded() {
     assert_bam_records_equal(&baseline, &async_out);
 }
 
+/// Regression test for a pipeline deadlock on the multithreaded plain/gzip FASTQ
+/// extract path.
+///
+/// The read step (`fastq_try_step_read`, `StreamReader::Decompressed` branch)
+/// used to publish `read_done` *before* incrementing `batches_read` for the
+/// final at-EOF batch. Because the pair step completes when
+/// `read_done && chunks_paired == batches_read`, a concurrent worker could
+/// observe that predicate as satisfied while the final batch was still in
+/// flight, set `boundaries_done`, and orphan the batch in `q1_decompressed` —
+/// which trips the deadlock detector. It reproduced roughly 1 in a few hundred
+/// runs under CPU contention (never on the BGZF/BAM paths, which only set
+/// `read_done` on a zero-batch read).
+///
+/// This drives many multithreaded runs with a short `--deadlock-timeout` so any
+/// regression surfaces in seconds rather than hanging for the 10s default. The
+/// plain path exercises the same code as the gzip path. Post-fix every run
+/// completes and writes all six records.
+#[test]
+fn test_extract_multithreaded_no_deadlock_regression() {
+    let tmp = TempDir::new().unwrap();
+    let (r1_recs, r2_recs) = paired_end_records();
+    let r1 = create_plain_fastq(&tmp, "r1.fq", &r1_recs);
+    let r2 = create_plain_fastq(&tmp, "r2.fq", &r2_recs);
+
+    for i in 0..40 {
+        let output = tmp.path().join(format!("out_{i}.bam"));
+        let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+            .args([
+                "extract",
+                "--inputs",
+                r1.to_str().unwrap(),
+                r2.to_str().unwrap(),
+                "--output",
+                output.to_str().unwrap(),
+                "--read-structures",
+                "5M+T",
+                "5M+T",
+                "--sample",
+                "test_sample",
+                "--library",
+                "test_library",
+                "--compression-level",
+                "1",
+                "--threads",
+                "8",
+                "--async-reader",
+                "--deadlock-timeout",
+                "3",
+            ])
+            .status()
+            .expect("Failed to execute extract command");
+        assert!(status.success(), "extract deadlocked or failed on iteration {i}");
+        let records = read_bam_records(&output);
+        assert_eq!(records.len(), 6, "iteration {i}: expected 6 records, got {}", records.len());
+    }
+}
+
 // ============================================================================
 // BAM commands: group (file input, with and without --threads)
 // ============================================================================


### PR DESCRIPTION
## Problem

The multithreaded plain/gzip FASTQ extract pipeline can deadlock on tiny inputs. It surfaces intermittently in CI as a `test_extract_plain_async_reader_multithreaded` failure with `Error: pipeline deadlock detected with recovery disabled`. Locally it reproduces roughly 1 in a few hundred runs under CPU contention (`--threads 12`), and never on a lightly loaded machine.

The deadlock diagnostic tells the whole story — one batch orphaned in Q2 (`q1_decompressed`) while every stage reports done:

```
Queue depths: Q1=0 Q2=1 Q2b=0 Q3=0 Q4=0 Q5=0 Q6=0 Q7=0
State: read_done=true, group_done=true, draining=true
Extra: boundaries_done=true, parse_done=true, batches: read=2 paired=1 found=1 parsed=1
```

## Root cause

In `fastq_try_step_read`, the `StreamReader::Decompressed` (plain/gzip) branch publishes `read_done` *before* incrementing `batches_read` for the final at-EOF batch:

```rust
if at_eof {
    state.stream_eof[stream_idx].store(true, Release);
    if all_eof { state.read_done.store(true, Release); }   // published first
}
let serial = state.batches_read.fetch_add(1, Release);     // counted after
```

The pair step (`fastq_try_step_find_boundaries`) completes when `read_done && chunks_paired == batches_read`. Between those two stores, a concurrent worker can observe `read_done == true` with `chunks_paired == batches_read` (the final batch not yet counted, all prior chunks already paired, `pair` empty), set `boundaries_done = true`, and short-circuit. The final batch then flows into `q1_decompressed` with nobody left to pop it → deadlock.

This is specific to the `Decompressed` path — it is the only read path that sets `read_done` in the same call that pushes a data batch. The FASTQ BGZF branch and the BAM pipeline both set `read_done` only on a zero-batch (EOF) read, so they are unaffected. The gzip path shares this exact code, so `test_extract_gzip_async_reader_multithreaded` was equally susceptible.

## Fix

Increment `batches_read` before the `read_done` release store. Any thread that observes `read_done == true` (acquire) then necessarily observes the incremented `batches_read`, so the completion predicate stays false until the batch is actually paired. The change is a small reordering plus a comment documenting the invariant.

## Testing

- Reproduced pre-fix: ~1/400 deadlocks with `--threads 12` under 8-way CPU load. Post-fix: 0/800 under the same load (with `--deadlock-timeout 2`, so a real deadlock would surface in 2s).
- Verified output correctness (all 6 records written).
- Added `test_extract_multithreaded_no_deadlock_regression`: runs extract repeatedly at `--threads 8` with a short `--deadlock-timeout` so a regression surfaces quickly instead of hanging for the default timeout. It never false-fails post-fix (a 3-read job completes in milliseconds).
- `cargo fmt --check`, `cargo clippy --all-features --all-targets`, and the full `test_async_reader` + `unified_pipeline::fastq` suites pass.