### PR TITLE
refactor(extract): guard FASTQ boundaries completion on empty input queue

### DIFF
--- a/src/lib/unified_pipeline/fastq.rs
+++ b/src/lib/unified_pipeline/fastq.rs
@@ -2950,7 +2950,17 @@ fn fastq_try_step_find_boundaries<R: BufRead + Send, P: Send + MemoryEstimate>(
     }
 
     // Completion: all chunks paired and all batches emitted.
-    if all_arrived && pair.is_empty() {
+    //
+    // The `q1_decompressed.is_empty()` guard is defense-in-depth: the drain loop
+    // above already empties `q1_decompressed` under `pair_state`, and the
+    // `read_done && chunks_paired == batches_read` counter relation in `all_arrived`
+    // is what guarantees no chunk is still upstream (in Q1, held, or Q2). But the
+    // sibling `parse_done` check also requires its input queue (`q2_5_boundaries`)
+    // to be empty, and matching that here means a future counter-accounting change
+    // can never let this stage declare itself done while a chunk sits in its input
+    // queue — which would orphan that chunk and deadlock the pipeline. The check is
+    // effectively free (the queue is already empty whenever `all_arrived` holds).
+    if all_arrived && pair.is_empty() && state.q1_decompressed.is_empty() {
         state.boundaries_done.store(true, Ordering::Release);
     }
 


### PR DESCRIPTION
Defense-in-depth follow-up to #598 (the FASTQ extract deadlock fix). Independent of that PR — mergeable in either order.

## What

`fastq_try_step_find_boundaries` declares the boundary stage done on `all_arrived && pair.is_empty()`, relying entirely on the `read_done && chunks_paired == batches_read` counter relation to prove no chunk is still upstream. Its sibling `parse_done` check additionally requires its own input queue (`q2_5_boundaries`) to be empty. This adds the analogous `q1_decompressed.is_empty()` guard to the boundary check.

## Why

If a future change to the read/pair counter accounting were to let `all_arrived` go true transiently while a chunk still sat in `q1_decompressed`, the stage would set `boundaries_done`, orphan that chunk, and deadlock — exactly the failure mode #598 fixed at its root. Requiring the input queue to be empty makes that class of orphan impossible by construction, matching the pattern already used for `parse_done`.

## Not a standalone fix

This is hardening, not a live-bug fix. The drain loop already empties `q1_decompressed` under the pair-state lock, so the queue is empty whenever `all_arrived` holds and the guard has no observable effect today. (It also would not have caught the #598 bug on its own: at the point that bug's predicate was transiently satisfied, the orphaned chunk was still mid-push into Q1, not yet in `q1_decompressed`.) The actual deadlock is closed by the read-step ordering fix in #598.

## Testing

No behavior change. `cargo fmt --check`, `cargo clippy --all-features --all-targets`, and the full `unified_pipeline::fastq` + `test_async_reader` suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pipeline completion handling to ensure all decompressed data is processed before boundary detection finishes.
  - Prevented potential stalled processing caused by remaining queued work being overlooked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->