### PR TITLE
fix: reject degenerate CLI values instead of silently misbehaving

### DIFF
--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -544,9 +544,34 @@ impl Codec {
             bail!("min-duplex-length must be >= 1");
         }
 
-        // Validate disagreement rate
+        // Validate disagreement rate. The non-finite check must come first: `NaN`
+        // compares `false` against both bounds, so a bare range test admits it, and
+        // every downstream `rate > threshold` comparison is then false — silently
+        // disabling duplex-disagreement rejection so molecules that should be
+        // rejected are emitted as consensus reads.
+        if !self.max_duplex_disagreement_rate.is_finite() {
+            bail!(
+                "max-duplex-disagreement-rate must be a finite number, got {}",
+                self.max_duplex_disagreement_rate
+            );
+        }
         if self.max_duplex_disagreement_rate < 0.0 || self.max_duplex_disagreement_rate > 1.0 {
             bail!("max-duplex-disagreement-rate must be between 0.0 and 1.0");
+        }
+
+        // Validate the fixed quality overrides. These are written straight into the
+        // consensus record's QUAL array, so a value above the maximum Phred score
+        // would emit BAM quality bytes outside the legal SAM `!`..`~` range.
+        let max_phred = ConsensusCallingOptions::MAX_PHRED;
+        for (name, value) in [
+            ("single-strand-qual", self.single_strand_qual),
+            ("outer-bases-qual", self.outer_bases_qual),
+        ] {
+            if let Some(qual) = value
+                && qual > max_phred
+            {
+                bail!("{name} ({qual}) exceeds maximum Phred score ({max_phred})");
+            }
         }
 
         Ok(())
@@ -817,6 +842,43 @@ mod tests {
 
     fn create_test_codec() -> Codec {
         create_codec_with_paths(PathBuf::from("input.bam"), PathBuf::from("output.bam"))
+    }
+
+    #[rstest]
+    #[case::typical(0.1, true)]
+    #[case::lower_bound(0.0, true)]
+    #[case::upper_bound(1.0, true)]
+    #[case::negative(-0.1, false)]
+    #[case::above_one(1.1, false)]
+    #[case::nan(f64::NAN, false)]
+    #[case::infinity(f64::INFINITY, false)]
+    fn test_validate_max_duplex_disagreement_rate(#[case] rate: f64, #[case] expected_ok: bool) {
+        let mut codec = create_test_codec();
+        codec.max_duplex_disagreement_rate = rate;
+        assert_eq!(
+            codec.validate().is_ok(),
+            expected_ok,
+            "unexpected validation result for rate {rate}"
+        );
+    }
+
+    #[rstest]
+    #[case::ss_qual_valid(Some(40), None, true)]
+    #[case::ss_qual_at_max(Some(93), None, true)]
+    #[case::ss_qual_too_high(Some(94), None, false)]
+    #[case::outer_qual_valid(None, Some(2), true)]
+    #[case::outer_qual_at_max(None, Some(93), true)]
+    #[case::outer_qual_too_high(None, Some(94), false)]
+    #[case::both_unset(None, None, true)]
+    fn test_validate_fixed_quality_overrides(
+        #[case] single_strand_qual: Option<u8>,
+        #[case] outer_bases_qual: Option<u8>,
+        #[case] expected_ok: bool,
+    ) {
+        let mut codec = create_test_codec();
+        codec.single_strand_qual = single_strand_qual;
+        codec.outer_bases_qual = outer_bases_qual;
+        assert_eq!(codec.validate().is_ok(), expected_ok);
     }
 
     /// The `--allow-unmapped` CLI flag defaults to `false` (fgbio parity: the

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -425,7 +425,10 @@ impl Default for ConsensusCallingOptions {
 
 impl ConsensusCallingOptions {
     /// Maximum valid Phred score (Illumina 1.8+ uses 0-41, but we allow up to 93).
-    const MAX_PHRED: u8 = 93;
+    ///
+    /// 93 is the largest score representable in the SAM `!`..`~` QUAL alphabet;
+    /// anything above it would serialize to a byte outside that range.
+    pub(crate) const MAX_PHRED: u8 = 93;
 
     /// Validates the consensus calling options.
     ///

--- a/src/lib/commands/downsample.rs
+++ b/src/lib/commands/downsample.rs
@@ -7,7 +7,6 @@
 
 use crate::logging::OperationTimer;
 use crate::sam::{SamTag, is_template_coordinate_sorted};
-use crate::validation::validate_file_exists;
 use anyhow::{Result, bail};
 use clap::Parser;
 use fgumi_bam_io::ProgressTracker;
@@ -103,18 +102,37 @@ pub struct Downsample {
     pub compression: CompressionOptions,
 }
 
+impl Downsample {
+    /// Validates that `--fraction` is a finite value in `(0.0, 1.0]`.
+    ///
+    /// The non-finite check must come first: `NaN` compares `false` against both
+    /// `<= 0.0` and `> 1.0`, so a bare range test admits it. A `NaN` fraction then
+    /// makes every `rng < fraction` sampling decision false, silently producing an
+    /// empty output BAM with exit code 0.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `fraction` is not finite or falls outside `(0.0, 1.0]`.
+    fn validate_fraction(fraction: f64) -> Result<()> {
+        if !fraction.is_finite() {
+            bail!("--fraction must be a finite number, got {fraction}");
+        }
+        if fraction <= 0.0 || fraction > 1.0 {
+            bail!("--fraction must be between 0.0 (exclusive) and 1.0 (inclusive), got {fraction}");
+        }
+        Ok(())
+    }
+}
+
 impl Command for Downsample {
     fn execute(&self, command_line: &str) -> Result<()> {
-        // Validate inputs
-        validate_file_exists(&self.io.input, "Input BAM")?;
+        // Validate inputs. Use the shared validator so stdin (`-` / `/dev/stdin`)
+        // is exempt from the file-existence check, matching every other streaming
+        // command; the BAM reader already handles stdin.
+        self.io.validate()?;
 
         // Validate fraction
-        if self.fraction <= 0.0 || self.fraction > 1.0 {
-            bail!(
-                "--fraction must be between 0.0 (exclusive) and 1.0 (inclusive), got {}",
-                self.fraction
-            );
-        }
+        Self::validate_fraction(self.fraction)?;
 
         let timer = OperationTimer::new("Downsampling reads");
 
@@ -384,6 +402,24 @@ fn get_mi_tag(record: &RawRecord) -> Result<String> {
 mod tests {
     use super::*;
     use fgumi_raw_bam::SamBuilder as RawSamBuilder;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::typical(0.5, true)]
+    #[case::lower_bound_exclusive(0.0, false)]
+    #[case::upper_bound_inclusive(1.0, true)]
+    #[case::negative(-0.1, false)]
+    #[case::above_one(1.5, false)]
+    #[case::nan(f64::NAN, false)]
+    #[case::infinity(f64::INFINITY, false)]
+    #[case::neg_infinity(f64::NEG_INFINITY, false)]
+    fn test_validate_fraction(#[case] fraction: f64, #[case] expected_ok: bool) {
+        assert_eq!(
+            Downsample::validate_fraction(fraction).is_ok(),
+            expected_ok,
+            "unexpected validation result for fraction {fraction}"
+        );
+    }
 
     /// Create a test record with a string MI tag.
     fn create_test_record(name: &str, mi: &str) -> RawRecord {
@@ -497,55 +533,6 @@ mod tests {
 
         let family = iter.next_family().expect("next_family should succeed");
         assert!(family.is_none());
-    }
-
-    #[test]
-    fn test_validate_fraction_too_low() {
-        let cmd = Downsample {
-            io: test_bam_io_options(),
-            fraction: 0.0,
-            rejects: None,
-            seed: None,
-            validate_mi_order: false,
-            histogram_kept: None,
-            histogram_rejected: None,
-            compression: CompressionOptions { compression_level: 1 },
-        };
-
-        // We can't call execute() without a real BAM file, but we can test the validation
-        assert!(cmd.fraction <= 0.0);
-    }
-
-    #[test]
-    fn test_validate_fraction_too_high() {
-        let cmd = Downsample {
-            io: test_bam_io_options(),
-            fraction: 1.5,
-            rejects: None,
-            seed: None,
-            validate_mi_order: false,
-            histogram_kept: None,
-            histogram_rejected: None,
-            compression: CompressionOptions { compression_level: 1 },
-        };
-
-        assert!(cmd.fraction > 1.0);
-    }
-
-    #[test]
-    fn test_validate_fraction_valid() {
-        let cmd = Downsample {
-            io: test_bam_io_options(),
-            fraction: 0.5,
-            rejects: None,
-            seed: None,
-            validate_mi_order: false,
-            histogram_kept: None,
-            histogram_rejected: None,
-            compression: CompressionOptions { compression_level: 1 },
-        };
-
-        assert!(cmd.fraction > 0.0 && cmd.fraction <= 1.0);
     }
 
     #[test]

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -577,6 +577,13 @@ impl Duplex {
         if self.consensus.error_rate_post_umi == 0 {
             bail!("error-rate-post-umi must be > 0");
         }
+        // Matches simplex and codec: 0 admits empty groups, making the
+        // minimum-family-size filter a silent no-op rather than an error.
+        // `DuplexConsensusCaller::new` validates emptiness and high-to-low
+        // ordering but never a lower bound.
+        if self.min_reads.contains(&0) {
+            bail!("--min-reads must be >= 1 (a value of 0 admits empty groups)");
+        }
         Ok(())
     }
 
@@ -1166,6 +1173,22 @@ mod tests {
             create_duplex_with_paths(PathBuf::from("test.bam"), PathBuf::from("output.bam"));
         duplex.consensus.error_rate_pre_umi = pre_umi;
         duplex.consensus.error_rate_post_umi = post_umi;
+        assert_eq!(duplex.validate().is_ok(), expect_ok);
+    }
+
+    #[rstest]
+    #[case::single_zero(vec![0], false)]
+    #[case::zero_in_tail(vec![3, 0], false)]
+    #[case::all_zero(vec![0, 0, 0], false)]
+    #[case::single_one(vec![1], true)]
+    #[case::descending(vec![3, 2, 1], true)]
+    fn test_validate_rejects_zero_min_reads(
+        #[case] min_reads: Vec<usize>,
+        #[case] expect_ok: bool,
+    ) {
+        let mut duplex =
+            create_duplex_with_paths(PathBuf::from("test.bam"), PathBuf::from("output.bam"));
+        duplex.min_reads = min_reads;
         assert_eq!(duplex.validate().is_ok(), expect_ok);
     }
 

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -246,11 +246,7 @@ impl Command for Simplex {
         // Validate inputs
         self.io.validate()?;
 
-        if let Some(max) = self.max_reads
-            && max < self.min_reads
-        {
-            bail!("--max-reads ({}) must be >= --min-reads ({})", max, self.min_reads);
-        }
+        self.validate_read_bounds()?;
 
         info!("Starting Simplex");
         info!("Input: {}", self.io.input.display());
@@ -510,6 +506,27 @@ impl Command for Simplex {
     }
 }
 impl Simplex {
+    /// Validates the `--min-reads` / `--max-reads` family-size bounds.
+    ///
+    /// `--min-reads 0` is rejected because it admits empty groups, silently turning
+    /// the minimum-family-size filter into a no-op (the `raw_records.len() < min_reads`
+    /// test can never fire). `codec` already enforces the same lower bound.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `min_reads` is 0, or if `max_reads` is below `min_reads`.
+    fn validate_read_bounds(&self) -> Result<()> {
+        if self.min_reads == 0 {
+            bail!("--min-reads must be >= 1 (a value of 0 admits empty groups)");
+        }
+        if let Some(max) = self.max_reads
+            && max < self.min_reads
+        {
+            bail!("--max-reads ({}) must be >= --min-reads ({})", max, self.min_reads);
+        }
+        Ok(())
+    }
+
     /// Execute using 7-step unified pipeline with --threads.
     ///
     /// This method is called when `--threads N` is specified with N > 1.
@@ -804,6 +821,28 @@ mod tests {
     /// A `Simplex` instance configured for testing
     fn create_test_simplex() -> Simplex {
         create_simplex_with_paths(PathBuf::from("test.bam"), PathBuf::from("out.bam"))
+    }
+
+    #[rstest]
+    #[case::min_reads_zero_rejected(0, None, false)]
+    #[case::min_reads_one(1, None, true)]
+    #[case::min_reads_three(3, None, true)]
+    #[case::max_below_min(3, Some(2), false)]
+    #[case::max_equals_min(3, Some(3), true)]
+    #[case::max_above_min(3, Some(9), true)]
+    fn test_validate_read_bounds(
+        #[case] min_reads: usize,
+        #[case] max_reads: Option<usize>,
+        #[case] expected_ok: bool,
+    ) {
+        let mut simplex = create_test_simplex();
+        simplex.min_reads = min_reads;
+        simplex.max_reads = max_reads;
+        assert_eq!(
+            simplex.validate_read_bounds().is_ok(),
+            expected_ok,
+            "unexpected result for min_reads={min_reads} max_reads={max_reads:?}"
+        );
     }
 
     /// Creates a Simplex command with the given input/output paths and default parameters.


### PR DESCRIPTION
Five independent validation gaps where an out-of-range or non-finite argument is accepted and then silently changes behaviour rather than erroring.

## `downsample --fraction NaN` → empty BAM, exit 0

The range test `fraction <= 0.0 || fraction > 1.0` is false for `NaN`, so `NaN` passed validation; every `rng < fraction` sampling decision is then false and the command writes an **empty output BAM with exit code 0**. Adds a leading `is_finite` guard, extracted into a testable `validate_fraction`.

## `downsample -i -` spuriously rejected

Input validation called `validate_file_exists` directly instead of `BamIoOptions::validate`, which exempts stdin. Piping into downsample failed with "file does not exist" even though the BAM reader handles stdin fine.

## `codec --max-duplex-disagreement-rate NaN` disables rejection

Same NaN hole. A `NaN` rate makes every downstream `rate > threshold` comparison false, **silently disabling duplex-disagreement rejection** so molecules that should be rejected are emitted as consensus reads.

## `codec --single-strand-qual` / `--outer-bases-qual` unbounded

Both are bare `Option<u8>` written straight into the consensus record's QUAL array, so a value above the maximum Phred score emits BAM quality bytes outside the legal SAM `!`..`~` range — corrupt output, no error. Now bounded by the existing `ConsensusCallingOptions::MAX_PHRED` (93), which already guards the four sibling quality options; widened to `pub(crate)` so there is one source of truth rather than a second literal.

## `simplex` and `duplex --min-reads 0` are silent no-ops

0 was accepted, making the minimum-family-size filter dead since `raw_records.len() < 0` can never hold. `codec` already rejects this. simplex's bounds are extracted into `validate_read_bounds`, and the same lower bound is added to `duplex` — whose caller validates emptiness (`duplex_caller.rs:376`) and high-to-low ordering (`:394`, `:397`) but never a lower bound. All three consensus commands now agree on the same flag.

## Note on removed tests

This also drops three pre-existing downsample tests that were **vacuous**: they built a command with `fraction: 0.0` and then asserted `cmd.fraction <= 0.0`, never invoking validation, so they passed regardless of whether it existed. The new rstest tables call the validators directly and cover the NaN/infinity cases.

## Testing

- `cargo ci-test`: 5564 passed, 22 skipped
- `cargo ci-fmt`, `cargo ci-lint`: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for disagreement rates, quality overrides, downsampling fractions, and read-count settings.
  - Rejects non-finite values such as `NaN` and infinity where applicable.
  - Prevents invalid quality scores and empty read groups from being accepted.
  - Added clearer error messages for invalid command-line options.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->