### PR TITLE
fix(duplex): emit unmapped consensus header on the single-threaded path

### DIFF
--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -388,6 +388,13 @@ impl Command for Duplex {
         let methylation_ref: MethylationRef =
             load_methylation_reference(methylation_mode, &self.reference, &header)?;
 
+        // Consensus reads are unmapped and carry the single collapsed read group, so the
+        // output advertises a freshly built consensus header (no @SQ, no SS sub-sort)
+        // rather than the input header — matching fgbio and the `--threads` path below.
+        let read_group_id = &self.read_group.read_group_id;
+        let output_header =
+            create_unmapped_consensus_header(&header, read_group_id, "Read group", command_line)?;
+
         // ============================================================
         // For non-pipeline modes, create output writers here
         // ============================================================
@@ -395,7 +402,7 @@ impl Command for Duplex {
         // Create output BAM writer with multi-threaded BGZF compression
         let mut writer = create_bam_writer(
             &self.io.output,
-            &header,
+            &output_header,
             writer_threads,
             self.compression.compression_level,
         )?;

--- a/tests/integration/test_duplex_command.rs
+++ b/tests/integration/test_duplex_command.rs
@@ -12,6 +12,7 @@ use fgumi_lib::sam::SamTag;
 use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
+use rstest::rstest;
 use std::fs;
 use std::path::Path;
 use tempfile::TempDir;
@@ -99,19 +100,24 @@ fn create_duplex_read_pair(
 
 /// Create a BAM with duplex-grouped reads (MI tags with /A and /B strand suffixes).
 pub(crate) fn create_duplex_bam(path: &Path, molecules: Vec<Vec<(RawRecord, RawRecord)>>) {
-    let header = create_minimal_header("chr1", 10000);
+    create_duplex_bam_with_header(path, &create_minimal_header("chr1", 10000), molecules);
+}
+
+/// Create a BAM with duplex-grouped reads using a caller-supplied header, so tests can
+/// pin behavior that depends on header content (e.g. `@RG` collapsing).
+fn create_duplex_bam_with_header(
+    path: &Path,
+    header: &noodles::sam::Header,
+    molecules: Vec<Vec<(RawRecord, RawRecord)>>,
+) {
     let mut writer =
         bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
-    writer.write_header(&header).expect("Failed to write header");
+    writer.write_header(header).expect("Failed to write header");
 
     for pairs in molecules {
         for (r1, r2) in pairs {
-            writer
-                .write_alignment_record(&header, &to_record_buf(&r1))
-                .expect("Failed to write R1");
-            writer
-                .write_alignment_record(&header, &to_record_buf(&r2))
-                .expect("Failed to write R2");
+            writer.write_alignment_record(header, &to_record_buf(&r1)).expect("Failed to write R1");
+            writer.write_alignment_record(header, &to_record_buf(&r2)).expect("Failed to write R2");
         }
     }
     writer.try_finish().expect("Failed to finish BAM");
@@ -375,5 +381,202 @@ fn test_duplex_command_with_stats() {
             stats.contains(key),
             "single-threaded duplex stats must emit the seeded KV row {key}:\n{stats}"
         );
+    }
+}
+
+/// Verifies that the duplex consensus output BAM advertises an *unmapped consensus*
+/// header, identically in the single-threaded (`--threads` unset) and pipeline
+/// (`--threads N`) paths.
+///
+/// fgbio's `UmiConsensusCaller.outputHeader` builds a brand-new `SAMFileHeader`:
+/// no sequence dictionary, the single collapsed `@RG`, `SO:unsorted` + `GO:query`,
+/// and `SamOrder.Unsorted.applyTo` explicitly *clears* `SS`. Consensus reads are
+/// unmapped, so carrying the input's `@SQ` dictionary and its
+/// `SS:unsorted:template-coordinate` sub-sort forward is wrong twice over: the
+/// records reference no contig, and the header falsely advertises a
+/// template-coordinate order that downstream sort-order preconditions
+/// (`check_consensus_sort_order`) accept without warning.
+///
+/// `simplex` and `codec` build the consensus header in both threading paths; this
+/// test pins `duplex` to the same contract — @SQ, @HD, @RG, and the exact fgbio
+/// provenance @CO — and checks the emitted records honour it (unmapped, carrying the
+/// declared @RG).
+#[rstest]
+#[case::single_threaded(None)]
+#[case::pipeline(Some("2"))]
+fn test_duplex_command_emits_unmapped_consensus_header(#[case] threads: Option<&str>) {
+    use bstr::BString;
+    use noodles::sam::alignment::record::data::field::Tag;
+    use noodles::sam::alignment::record_buf::data::field::Value;
+    use noodles::sam::header::record::value::Map;
+    use noodles::sam::header::record::value::map::ReadGroup;
+    use noodles::sam::header::record::value::map::header::tag as header_tag;
+    use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
+
+    // Two input read groups with distinct SM/LB/PL/PU/CN/DS values. fgbio collapses each
+    // tag's distinct values into the single output @RG (comma-joined in read-group order,
+    // with PL upper-cased); the expectations below are fixed and independent of the
+    // implementation so a collapse that drops, reorders, or mangles a tag fails here.
+    let input_read_groups: &[(&str, &[(_, &str)])] = &[
+        (
+            "rgA",
+            &[
+                (rg_tag::SAMPLE, "sampleA"),
+                (rg_tag::LIBRARY, "libA"),
+                (rg_tag::PLATFORM, "illumina"),
+                (rg_tag::PLATFORM_UNIT, "unitA"),
+                (rg_tag::SEQUENCING_CENTER, "centerA"),
+                (rg_tag::DESCRIPTION, "descA"),
+            ],
+        ),
+        (
+            "rgB",
+            &[
+                (rg_tag::SAMPLE, "sampleB"),
+                (rg_tag::LIBRARY, "libB"),
+                (rg_tag::PLATFORM, "iontorrent"),
+                (rg_tag::PLATFORM_UNIT, "unitB"),
+                (rg_tag::SEQUENCING_CENTER, "centerB"),
+                (rg_tag::DESCRIPTION, "descB"),
+            ],
+        ),
+    ];
+    let expected_collapsed_rg: &[(_, &str)] = &[
+        (rg_tag::SAMPLE, "sampleA,sampleB"),
+        (rg_tag::LIBRARY, "libA,libB"),
+        (rg_tag::PLATFORM, "ILLUMINA,IONTORRENT"),
+        (rg_tag::PLATFORM_UNIT, "unitA,unitB"),
+        (rg_tag::SEQUENCING_CENTER, "centerA,centerB"),
+        (rg_tag::DESCRIPTION, "descA,descB"),
+    ];
+
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    let mut input_header = create_minimal_header("chr1", 10000);
+    for (id, tags) in input_read_groups {
+        let mut rg = Map::<ReadGroup>::builder();
+        for (tag, value) in *tags {
+            rg = rg.insert(*tag, (*value).to_string());
+        }
+        input_header
+            .read_groups_mut()
+            .insert(BString::from(*id), rg.build().expect("valid read group"));
+    }
+
+    let molecule = create_duplex_molecule("1", "ACGTACGT", 30, 100, 3);
+    create_duplex_bam_with_header(&input_bam, &input_header, vec![molecule]);
+
+    let mut args = vec![
+        "duplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--compression-level",
+        "1",
+    ];
+    if let Some(threads) = threads {
+        args.extend_from_slice(&["--threads", threads]);
+    }
+    let cmd = Duplex::try_parse_from(args).expect("failed to parse duplex args");
+    let read_group_id = cmd.read_group.read_group_id.clone();
+    cmd.execute("fgumi duplex").expect("Duplex command failed");
+
+    let mut input_reader = bam::io::Reader::new(fs::File::open(&input_bam).unwrap());
+    let input_read_group_count = input_reader.read_header().unwrap().read_groups().len();
+
+    let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    let output_header = reader.read_header().unwrap();
+
+    // Consensus reads are unmapped: the input's sequence dictionary must be dropped.
+    assert!(
+        output_header.reference_sequences().is_empty(),
+        "consensus output header must not carry @SQ lines, found {:?}",
+        output_header.reference_sequences().keys().collect::<Vec<_>>(),
+    );
+
+    let hd = output_header.header().expect("output header must have an @HD line");
+    assert_eq!(
+        hd.other_fields().get(&header_tag::SORT_ORDER).map(std::string::ToString::to_string),
+        Some("unsorted".to_string()),
+        "consensus output must be SO:unsorted",
+    );
+    assert_eq!(
+        hd.other_fields().get(&header_tag::GROUP_ORDER).map(std::string::ToString::to_string),
+        Some("query".to_string()),
+        "consensus output must be GO:query",
+    );
+    assert_eq!(
+        hd.other_fields().get(&header_tag::SUBSORT_ORDER).map(std::string::ToString::to_string),
+        None,
+        "consensus output must not advertise an SS sub-sort (fgbio clears it)",
+    );
+
+    // The records carry RG:Z:<read_group_id>, so the header must declare exactly that
+    // read group and no other, with the collapsed SM/LB/PL/PU/CN/DS attributes fgbio
+    // derives from the input read groups.
+    let read_groups = output_header.read_groups();
+    assert_eq!(read_groups.len(), 1, "consensus output must declare exactly one @RG");
+    let output_rg = read_groups
+        .get(&BString::from(read_group_id.as_str()))
+        .expect("consensus output must declare the @RG the consensus records reference");
+    for (tag, expected) in expected_collapsed_rg {
+        assert_eq!(
+            output_rg.other_fields().get(tag).map(std::string::ToString::to_string).as_deref(),
+            Some(*expected),
+            "collapsed @RG must carry the expected {tag} value",
+        );
+    }
+    // No stray attributes beyond the collapsed set fgbio produces.
+    assert_eq!(
+        output_rg.other_fields().len(),
+        expected_collapsed_rg.len(),
+        "collapsed @RG must carry exactly the collapsed SM/LB/PL/PU/CN/DS attributes, found {:?}",
+        output_rg.other_fields().keys().collect::<Vec<_>>(),
+    );
+
+    // fgbio records provenance as a single @CO naming the collapsed read group and the
+    // number of input read groups it was built from. Assert the whole comment set against
+    // an expectation derived from the input header, so a malformed comment or a wrong
+    // input-@RG count fails here rather than passing a substring check.
+    let expected_comment = format!(
+        "Read group {read_group_id} contains consensus reads generated from \
+         {input_read_group_count} input read groups."
+    );
+    assert_eq!(
+        output_header.comments().iter().map(std::string::ToString::to_string).collect::<Vec<_>>(),
+        vec![expected_comment],
+        "consensus output must carry exactly the fgbio-style @CO provenance comment",
+    );
+
+    // The header contract only holds if the records honour it: an @SQ-free header cannot
+    // describe a mapped record, and the lone @RG must be the one the records reference.
+    let records: Vec<_> = reader
+        .record_bufs(&output_header)
+        .map(|result| result.expect("failed to read consensus record"))
+        .collect();
+    assert!(!records.is_empty(), "duplex must emit at least one consensus record");
+    for record in &records {
+        assert!(
+            record.flags().is_unmapped(),
+            "consensus records must be unmapped, found flags {:?}",
+            record.flags(),
+        );
+        let rg = record
+            .data()
+            .get(&Tag::from(SamTag::RG))
+            .expect("consensus record must carry an RG tag");
+        match rg {
+            Value::String(id) => assert_eq!(
+                String::from_utf8_lossy(id),
+                read_group_id,
+                "consensus records must reference the @RG the header declares",
+            ),
+            other => panic!("RG tag must be a string, found {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

`fgumi duplex`'s single-threaded path — the **default**, taken whenever `--threads` is not passed — wrote the *input* header to the consensus output instead of building a consensus header. Every other consensus path already called `create_unmapped_consensus_header`: `duplex --threads N`, and both the single-threaded and pipeline paths of `simplex` and `codec`. This is an isolated inconsistency within fgumi, not a disagreement with fgbio about data; it dates to the initial commit rather than being a regression.

Observed on a duplex-grouped BAM, before this change:

| run | header |
| --- | --- |
| `duplex` (default) | `@HD SO:unsorted GO:query SS:unsorted:template-coordinate` + `@SQ chr1` + `@SQ chr2`, no `@RG`, no `@CO` |
| `duplex --threads 4` | `@HD SO:unsorted GO:query` + `@RG ID:A` + `@CO` |
| `simplex` / `codec` (both paths) | `@HD SO:unsorted GO:query` + `@RG ID:A` + `@CO` |

Three defects follow from the passthrough:

1. **Stale `@SQ` dictionary.** Consensus reads are unmapped and reference no contig, so the input sequence dictionary is meaningless in the output.
2. **Stale `SS:unsorted:template-coordinate` sub-sort.** The output falsely advertises a template-coordinate order over unmapped, arbitrarily-ordered records. This is the one with downstream teeth: `check_consensus_sort_order` returns `Ok` immediately for anything `is_template_coordinate_sorted`, so such a header is accepted outright instead of falling to the query-grouped warn branch. fgbio's `checkSortOrder` behaves the same way.
3. **Dangling `@RG` reference.** Records carry `RG:Z:A`, but the header declared only the input's read groups — so `RG:Z:A` referred to a read group the header never defined.

## What fgbio does

`UmiConsensusCaller.outputHeader` constructs a brand-new `SAMFileHeader` — hence an empty sequence dictionary, no `@SQ` — adds the single collapsed `@RG`, then applies `SamOrder.Unsorted` and sets `GroupOrder.query`. `SamOrder.applyTo` does `header.setAttribute("SS", subSort.map(...).orNull)`, and `Unsorted` has `subSort = None`, so **`SS` is explicitly cleared rather than merely absent**. The result is `@HD VN:1.6 SO:unsorted GO:query` + `@RG` + `@CO` — exactly what fgumi's `create_unmapped_consensus_header` already produces.

## Changes

- `src/lib/commands/duplex.rs`: build the output header with `create_unmapped_consensus_header` on the single-threaded path and hand it to the primary writer. The rejects writer keeps the input header, matching `simplex` — rejects are raw input records and their RGs must not be collapsed.
- `tests/integration/test_duplex_command.rs`: `test_duplex_command_emits_unmapped_consensus_header`, an `#[rstest]` case table over `case::single_threaded` / `case::pipeline`, asserting no `@SQ`, `SO:unsorted` + `GO:query` + absent `SS`, exactly one `@RG A`, and the `@CO` provenance comment.

## Verification

- Test written first: `case_1_single_threaded` failed with `consensus output header must not carry @SQ lines, found ["chr1"]` while `case_2_pipeline` passed, pinning the diagnosis to the single-threaded path. Both pass after the fix.
- `cargo ci-fmt && cargo ci-lint && cargo ci-test`: green, 5536 tests passed, 22 skipped.
- End-to-end on a simulated duplex-grouped BAM: both threading modes now emit the consensus header, and the record stream is **byte-identical** to the pre-fix output (matching md5 over `samtools view`, 1570 records). Header-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Duplex consensus BAM output now consistently uses the correct unmapped-consensus header in both single-threaded and multi-threaded modes, including proper read group and provenance metadata.
* **Tests**
  * Added a regression test that runs the duplex command in both execution modes and validates the unmapped-consensus BAM header contract and emitted consensus records (including RG tags).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->