### PR TITLE
perf(sam): borrow reference bases in regenerate_alignment_tags

### DIFF
--- a/crates/fgumi-sam/src/alignment_tags.rs
+++ b/crates/fgumi-sam/src/alignment_tags.rs
@@ -105,10 +105,12 @@ pub fn regenerate_alignment_tags(
         return Ok(true);
     }
 
-    // Fetch entire reference span in one call
+    // Fetch entire reference span in one call. `fetch_borrowed` lets an in-memory
+    // provider hand back a slice instead of allocating a fresh `Vec` per record;
+    // this runs once per record for every `fgumi clip` / `fgumi filter` invocation.
     let ref_end = Position::new(usize::from(ref_start) + ref_span - 1)
         .context("Invalid reference end position")?;
-    let all_ref_bases = reference.fetch(ref_name, ref_start, ref_end)?;
+    let all_ref_bases = reference.fetch_borrowed(ref_name, ref_start, ref_end)?;
 
     // Calculate edit distance and mismatch quality
     let mut nm = 0; // Edit distance
@@ -306,10 +308,12 @@ pub fn regenerate_alignment_tags_raw(
         return Ok(true);
     }
 
-    // Fetch entire reference span in one call
+    // Fetch entire reference span in one call. `fetch_borrowed` lets an in-memory
+    // provider hand back a slice instead of allocating a fresh `Vec` per record;
+    // this runs once per record for every `fgumi clip` / `fgumi filter` invocation.
     let ref_end = Position::new(usize::from(ref_start) + ref_span - 1)
         .context("Invalid reference end position")?;
-    let all_ref_bases = reference.fetch(ref_name, ref_start, ref_end)?;
+    let all_ref_bases = reference.fetch_borrowed(ref_name, ref_start, ref_end)?;
 
     // Get seq/qual offsets and validate bounds
     let seq_off = fgumi_raw_bam::seq_offset(record);

--- a/crates/fgumi-sam/src/lib.rs
+++ b/crates/fgumi-sam/src/lib.rs
@@ -62,6 +62,25 @@ pub trait ReferenceProvider {
         start: noodles::core::Position,
         end: noodles::core::Position,
     ) -> anyhow::Result<Vec<u8>>;
+
+    /// Borrowed-slice variant of [`Self::fetch`] — same lookup semantics, but an
+    /// implementation backed by an in-memory sequence can return a borrow instead
+    /// of allocating.
+    ///
+    /// Prefer this in per-record hot loops. The default implementation delegates to
+    /// [`Self::fetch`] and yields [`std::borrow::Cow::Owned`], so existing
+    /// implementors keep working unchanged.
+    ///
+    /// # Errors
+    /// Returns an error if the chromosome is not found or the region is out of bounds.
+    fn fetch_borrowed(
+        &self,
+        chrom: &str,
+        start: noodles::core::Position,
+        end: noodles::core::Position,
+    ) -> anyhow::Result<std::borrow::Cow<'_, [u8]>> {
+        Ok(std::borrow::Cow::Owned(self.fetch(chrom, start, end)?))
+    }
 }
 
 impl<T: std::ops::Deref> ReferenceProvider for T
@@ -75,6 +94,15 @@ where
         end: noodles::core::Position,
     ) -> anyhow::Result<Vec<u8>> {
         self.deref().fetch(chrom, start, end)
+    }
+
+    fn fetch_borrowed(
+        &self,
+        chrom: &str,
+        start: noodles::core::Position,
+        end: noodles::core::Position,
+    ) -> anyhow::Result<std::borrow::Cow<'_, [u8]>> {
+        self.deref().fetch_borrowed(chrom, start, end)
     }
 }
 

--- a/src/lib/reference.rs
+++ b/src/lib/reference.rs
@@ -376,6 +376,17 @@ impl fgumi_sam::ReferenceProvider for ReferenceReader {
     ) -> anyhow::Result<Vec<u8>> {
         self.fetch(chrom, start, end)
     }
+
+    /// Returns a borrow into the in-memory sequence, avoiding the per-call `Vec`
+    /// allocation `fetch` performs.
+    fn fetch_borrowed(
+        &self,
+        chrom: &str,
+        start: noodles::core::Position,
+        end: noodles::core::Position,
+    ) -> anyhow::Result<std::borrow::Cow<'_, [u8]>> {
+        Ok(std::borrow::Cow::Borrowed(self.fetch_slice(chrom, start, end)?))
+    }
 }
 
 #[cfg(feature = "simplex")]
@@ -394,6 +405,64 @@ impl fgumi_consensus::methylation::RefBaseProvider for ReferenceReader {
 mod tests {
     use super::*;
     use crate::sam::builder::create_default_test_fasta;
+
+    /// `fetch_borrowed` must hand back a borrow, not an owned copy — that is the
+    /// entire point of the override. A `Cow::Owned` here means the default trait
+    /// implementation is being used and the per-record allocation is still happening.
+    #[test]
+    fn test_fetch_borrowed_borrows_and_matches_fetch() -> Result<()> {
+        use fgumi_sam::ReferenceProvider;
+
+        let fasta = create_default_test_fasta()?;
+        let reader = ReferenceReader::new(fasta.path())?;
+        let (start, end) = (Position::try_from(1)?, Position::try_from(4)?);
+
+        let borrowed = ReferenceProvider::fetch_borrowed(&reader, "chr1", start, end)?;
+        assert!(
+            matches!(borrowed, std::borrow::Cow::Borrowed(_)),
+            "expected a borrowed slice; an owned value means the allocation is still happening"
+        );
+
+        // Same bytes as the allocating path.
+        let owned = ReferenceProvider::fetch(&reader, "chr1", start, end)?;
+        assert_eq!(borrowed.as_ref(), owned.as_slice());
+
+        // Errors propagate identically for a missing chromosome.
+        assert!(ReferenceProvider::fetch_borrowed(&reader, "nope", start, end).is_err());
+        Ok(())
+    }
+
+    /// The production call sites (`clip.rs`, `filter.rs`) pass `&ReferenceReader`
+    /// into a `R: ReferenceProvider` generic, so they resolve through the `T: Deref`
+    /// blanket impl rather than `ReferenceReader`'s own. If that blanket stops
+    /// forwarding `fetch_borrowed`, it silently falls back to the trait default —
+    /// which returns `Cow::Owned`, reinstating the per-record allocation with no
+    /// output change and no other test failing. This pins the forwarding.
+    #[test]
+    fn test_fetch_borrowed_forwards_through_reference() -> Result<()> {
+        use fgumi_sam::ReferenceProvider;
+
+        /// Mirrors how `regenerate_alignment_tags_raw` takes its provider.
+        fn borrows_via_generic<R: ReferenceProvider>(
+            provider: R,
+            chrom: &str,
+            start: Position,
+            end: Position,
+        ) -> Result<bool> {
+            Ok(matches!(provider.fetch_borrowed(chrom, start, end)?, std::borrow::Cow::Borrowed(_)))
+        }
+
+        let fasta = create_default_test_fasta()?;
+        let reader = ReferenceReader::new(fasta.path())?;
+        let (start, end) = (Position::try_from(1)?, Position::try_from(4)?);
+
+        assert!(
+            borrows_via_generic(&reader, "chr1", start, end)?,
+            "&ReferenceReader must still borrow; an owned value means the Deref blanket \
+             impl stopped forwarding fetch_borrowed and the allocation is back"
+        );
+        Ok(())
+    }
 
     #[test]
     fn test_fetch_subsequence() -> Result<()> {


### PR DESCRIPTION
Removes a per-record reference allocation from the `clip` and `filter` hot paths.

## The allocation

`regenerate_alignment_tags` and `regenerate_alignment_tags_raw` fetch each record's reference span via `ReferenceProvider::fetch` (`alignment_tags.rs:111`, `:312`), and on `ReferenceReader` that is literally:

```rust
pub fn fetch(&self, ...) -> Result<Vec<u8>> {
    Ok(self.fetch_slice(chrom, start, end)?.to_vec())
}
```

— a fresh allocation and copy per record, on every `fgumi clip` and `fgumi filter` run given a reference (`clip.rs:649`, `clip.rs:763`, `filter.rs:882`).

The remedy already existed and simply had not been applied here. `fetch_slice` returns a borrow, and its doc comment recommends preferring it *"in hot loops (e.g., per-record reference access in `fgumi zipper`'s `--restore-unconverted-bases` path) where allocating a fresh `Vec<u8>` per call adds up to gigabytes of churn."* That advice was taken for zipper and not for the alignment-tag path.

## The change

Adds `ReferenceProvider::fetch_borrowed`, returning `Cow<[u8]>`:

- The **default implementation** delegates to `fetch` and yields `Cow::Owned`, so every existing implementor (including test mocks) keeps working unchanged.
- The **`Deref` blanket impl** forwards it. This is load-bearing: the production call sites pass `&ReferenceReader` into an `R: ReferenceProvider` generic, so they resolve through the blanket, not through `ReferenceReader`'s own impl.
- **`ReferenceReader`** overrides it with `Cow::Borrowed` over the existing `fetch_slice`.

## Measurements

2M records from a query-grouped WES BAM against hs38, `clip --threads 4 --clip-overlapping-reads true`, hyperfine, 8 runs after 2 warmups:

| | wall | user | sys |
|---|---|---|---|
| baseline | 6.416 s ± 1.343 s | 4.722 s | 1.206 s |
| borrowed | 5.284 s ± 0.829 s | 4.270 s | 0.735 s |

That is 1.21× ± 0.32 wall. **The variance is wide on this host and the ranges overlap, so treat the wall figure as indicative rather than settled** — I would not merge this on the wall number alone. The steadier signals are ~10% less user CPU and ~40% less system time, both consistent with removing a per-record allocation. If you want a firmer number before merging, this should be re-run on a quiet c8g.

Output records are byte-identical across the two binaries (md5 of `samtools view` output; only the `@PG` version/command-line differs).

## Testing

Two unit tests. The first asserts `ReferenceReader::fetch_borrowed` actually yields `Cow::Borrowed` — an owned value there would silently mean the default implementation is in use and the allocation is still happening — and that it agrees with `fetch` and errors identically on a missing chromosome.

The second pins the `Deref` blanket forwarding through a generic helper instantiated as `R = &ReferenceReader`, the exact shape the production call sites use. Verified non-vacuous: deleting the blanket's `fetch_borrowed` forward makes it fail, and without it the fallback to `Cow::Owned` would reinstate the allocation with no output change and no other test failing.

- `cargo ci-test`: 5536 passed, 22 skipped
- `cargo ci-fmt`, `cargo ci-lint`: clean
- Local `cargo llvm-cov`: 100% of added lines covered in all three files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved reference sequence handling to reduce unnecessary memory allocations during alignment tag calculation.
  * Maintained existing NM, UQ, and MD tag results while improving efficiency for in-memory reference data.

* **Tests**
  * Added coverage confirming borrowed reference data matches allocated results and remains available through generic reference-provider access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->