### PR TITLE
fix(sort): write the BAI sidecar to the samtools path, not an extension-replaced one

### DIFF
--- a/crates/fgumi-bam-io/src/lib.rs
+++ b/crates/fgumi-bam-io/src/lib.rs
@@ -33,7 +33,7 @@ pub use reader::{
 };
 pub use reorder::{DrainReady, ReorderBuffer};
 pub use writer::{
-    BamWriter, BgzfWriterEnum, IndexingBamWriter, RawBamWriter, create_bam_writer,
-    create_indexing_bam_writer, create_optional_bam_writer, create_raw_bam_writer, write_bai_index,
-    write_bam_header,
+    BamWriter, BgzfWriterEnum, IndexingBamWriter, RawBamWriter, bai_sidecar_path,
+    create_bam_writer, create_indexing_bam_writer, create_optional_bam_writer,
+    create_raw_bam_writer, write_bai_index, write_bai_sidecar, write_bam_header,
 };

--- a/crates/fgumi-bam-io/src/writer.rs
+++ b/crates/fgumi-bam-io/src/writer.rs
@@ -1,7 +1,10 @@
 //! BAM writer factories and related types.
 //!
 //! This module provides writer factories for BAM output, including standard BAM writers,
-//! raw-bytes BAM writers, and an incremental-indexing BAM writer.
+//! raw-bytes BAM writers, an incremental-indexing BAM writer, and BAI sidecar
+//! helpers (`bai_sidecar_path` for the naming convention, `write_bai_index` for
+//! a prebuilt index, and `write_bai_sidecar` to index a finished BAM and write
+//! its sidecar in one call).
 
 use anyhow::{Context, Result};
 use bgzf::CompressionLevel;
@@ -17,7 +20,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{self, Write};
 use std::num::NonZero;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::paths::is_stdout_path;
 use crate::vendored::{BlockInfoRx, MultithreadedWriter, MultithreadedWriterBuilder};
@@ -598,10 +601,62 @@ pub fn create_indexing_bam_writer<P: AsRef<Path>>(
     Ok(writer)
 }
 
+/// Append `.bai` to a BAM path to form its conventional sidecar index path.
+///
+/// This appends to the **full** path, which is the samtools convention, rather
+/// than replacing the final extension:
+///
+/// - `foo.bam` → `foo.bam.bai`
+/// - `foo` (no extension) → `foo.bai`
+/// - `foo.sorted` → `foo.sorted.bai`
+///
+/// `Path::with_extension("bam.bai")` is not equivalent and must not be used
+/// here: it replaces everything after the last `.`, so it is correct only for
+/// paths ending in exactly `.bam`. For anything else it rewrites the basename
+/// itself — `foo.sorted` and `foo.other` both collapse to `foo.bam.bai`, so the
+/// index lands beside a file that does not exist and two sorts in one directory
+/// silently overwrite each other's index.
+#[must_use]
+pub fn bai_sidecar_path<P: AsRef<Path>>(bam_path: P) -> PathBuf {
+    let mut index_os = bam_path.as_ref().as_os_str().to_owned();
+    index_os.push(".bai");
+    PathBuf::from(index_os)
+}
+
+/// Build a BAI index for a finished coordinate-sorted BAM and write it to the
+/// conventional `<bam_path>.bai` sidecar, returning the path written.
+///
+/// The sidecar path comes from [`bai_sidecar_path`], so a BAM whose path does
+/// not end in `.bam` still gets a correctly named index.
+///
+/// **Invariant:** the BAM at `bam_path` must already be closed by its writer.
+/// [`noodles::bam::fs::index`] re-reads the file from disk to compute virtual
+/// offsets, so any buffered writes must have been flushed first.
+///
+/// Callers that already hold an in-memory index (for example an incrementally
+/// indexing writer) should not use this — it would re-read the whole BAM. Pair
+/// [`bai_sidecar_path`] with [`write_bai_index`] instead.
+///
+/// # Errors
+/// Returns an error if indexing the BAM or writing the BAI sidecar fails.
+pub fn write_bai_sidecar<P: AsRef<Path>>(bam_path: P) -> Result<PathBuf> {
+    let bam_path = bam_path.as_ref();
+
+    let index = noodles::bam::fs::index(bam_path)
+        .with_context(|| format!("Failed to index {}", bam_path.display()))?;
+
+    let index_path = bai_sidecar_path(bam_path);
+    write_bai_index(&index_path, &index)
+        .with_context(|| format!("Failed to write BAI to {}", index_path.display()))?;
+
+    Ok(index_path)
+}
+
 /// Write a BAI index to a file.
 ///
 /// # Arguments
-/// * `path` - Path for the output BAI file (typically `output.bam.bai`)
+/// * `path` - Path for the output BAI file; derive it with [`bai_sidecar_path`]
+///   rather than by replacing the BAM path's extension
 /// * `index` - The BAI index to write
 ///
 /// # Errors
@@ -1146,5 +1201,44 @@ mod tests {
 
         assert!(temp.path().metadata()?.len() > 0);
         Ok(())
+    }
+
+    /// The samtools convention appends `.bai` to the whole BAM path rather than
+    /// replacing the final extension. `Path::with_extension("bam.bai")` -- what
+    /// these call sites used to do -- happens to agree only for paths ending in
+    /// exactly `.bam`; for anything else it rewrites the basename, so distinct
+    /// outputs collide on one index path.
+    #[rstest::rstest]
+    #[case::plain_bam("foo.bam", "foo.bam.bai")]
+    #[case::no_extension("foo", "foo.bai")]
+    #[case::non_bam_extension("foo.sorted", "foo.sorted.bai")]
+    #[case::dotted_stem("sample.v2.bam", "sample.v2.bam.bai")]
+    #[case::with_directory("a/b/out", "a/b/out.bai")]
+    #[case::directory_with_dots("a.d/out.bam", "a.d/out.bam.bai")]
+    fn test_bai_sidecar_path_appends_to_full_path(#[case] bam: &str, #[case] expected: &str) {
+        assert_eq!(bai_sidecar_path(bam), PathBuf::from(expected));
+    }
+
+    /// The old expression and the new helper must agree exactly on `.bam` paths
+    /// (so this change is a no-op for the common case) and must differ on the
+    /// paths that were broken -- including two distinct outputs that previously
+    /// collapsed onto the same index path and would silently clobber each other.
+    #[test]
+    fn test_bai_sidecar_path_differs_from_with_extension_only_off_dot_bam() {
+        let with_ext = |p: &str| Path::new(p).with_extension("bam.bai");
+
+        assert_eq!(bai_sidecar_path("foo.bam"), with_ext("foo.bam"), "no change for .bam paths");
+
+        for broken in ["foo", "foo.sorted", "foo.other"] {
+            assert_ne!(
+                bai_sidecar_path(broken),
+                with_ext(broken),
+                "{broken} was mis-named by the old expression and must change",
+            );
+        }
+
+        // The collision the old expression produced: distinct outputs, one index.
+        assert_eq!(with_ext("foo.sorted"), with_ext("foo.other"));
+        assert_ne!(bai_sidecar_path("foo.sorted"), bai_sidecar_path("foo.other"));
     }
 }

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -2422,7 +2422,7 @@ impl RawExternalSorter {
         alloc: &mut TmpDirAllocator,
     ) -> Result<RawSortStats> {
         use crate::keys::RawCoordinateKey;
-        use fgumi_bam_io::{create_indexing_bam_writer, write_bai_index};
+        use fgumi_bam_io::{bai_sidecar_path, create_indexing_bam_writer, write_bai_index};
 
         debug!("Indexing enabled: will write BAM index alongside output");
 
@@ -2539,7 +2539,7 @@ impl RawExternalSorter {
 
                 let index = writer.finish()?;
 
-                let index_path = output.with_extension("bam.bai");
+                let index_path = bai_sidecar_path(output);
                 write_bai_index(&index_path, &index)?;
                 info!("Wrote BAM index: {}", index_path.display());
                 Ok(())
@@ -2574,7 +2574,7 @@ impl RawExternalSorter {
                     &pool,
                 )?;
 
-                let index_path = output.with_extension("bam.bai");
+                let index_path = bai_sidecar_path(output);
                 write_bai_index(&index_path, &index)?;
                 info!("Wrote BAM index: {}", index_path.display());
                 Ok(())
@@ -5763,8 +5763,62 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_sort_coordinate_with_index_spilled_preserves_records() {
+    /// The indexed coordinate sort derives the sidecar path in two independent
+    /// places: the in-memory path (everything fits under the memory limit) and
+    /// the spilling merge path. This covers the in-memory one; the spilling
+    /// sibling below covers the other. Both must land on the samtools sidecar
+    /// path even when the output is not named `*.bam`.
+    #[rstest::rstest]
+    #[case::dot_bam_output("output.bam")]
+    #[case::non_bam_output("output.sorted")]
+    fn test_sort_coordinate_with_index_in_memory_writes_sidecar(#[case] output_name: &str) {
+        use fgumi_sam::SamBuilder;
+
+        let mut builder = SamBuilder::new();
+        for i in 0..20 {
+            let _ = builder
+                .add_pair()
+                .name(&format!("read{i:05}"))
+                .start1(i * 200 + 1)
+                .start2(i * 200 + 101)
+                .build();
+        }
+
+        let workdir = tempfile::tempdir().expect("workdir");
+        let input = workdir.path().join("input.bam");
+        let output = workdir.path().join(output_name);
+        builder.write_bam(&input).expect("write bam");
+
+        let stats = RawExternalSorter::new(SortOrder::Coordinate)
+            // Generous limit so nothing spills and the in-memory branch runs.
+            .memory_limit(64 * 1024 * 1024)
+            .threads(1)
+            .write_index(true)
+            .output_compression(0)
+            .sort(&input, &output)
+            .expect("indexed coordinate sort should succeed");
+
+        assert_eq!(stats.chunks_written, 0, "expected no spill for the in-memory path");
+        assert_eq!(collect_read_names(&output).len(), 40, "record count mismatch");
+
+        let bai = fgumi_bam_io::bai_sidecar_path(&output);
+        assert!(bai.exists(), "index should exist at the sidecar path {}", bai.display());
+
+        let stale = output.with_extension("bam.bai");
+        if stale != bai {
+            assert!(!stale.exists(), "no index at the extension-replaced path {}", stale.display());
+        }
+    }
+
+    /// `output_name` covers both the `.bam` case (where the old
+    /// `with_extension("bam.bai")` happened to be right) and a name that does
+    /// not end in `.bam` (where it silently wrote the index under a different
+    /// basename entirely).
+    #[rstest::rstest]
+    #[case::dot_bam_output("output.bam")]
+    #[case::non_bam_output("output.sorted")]
+    #[case::no_extension_output("output")]
+    fn test_sort_coordinate_with_index_spilled_preserves_records(#[case] output_name: &str) {
         use fgumi_sam::SamBuilder;
 
         // Enough pairs that an 8 KiB memory limit forces multiple spills,
@@ -5784,7 +5838,7 @@ mod tests {
 
         let workdir = tempfile::tempdir().expect("workdir");
         let input = workdir.path().join("input.bam");
-        let output = workdir.path().join("output.bam");
+        let output = workdir.path().join(output_name);
         builder.write_bam(&input).expect("write bam");
 
         let stats = RawExternalSorter::new(SortOrder::Coordinate)
@@ -5803,9 +5857,29 @@ mod tests {
         let names = collect_read_names(&output);
         assert_eq!(names.len(), num_pairs * 2, "record count mismatch");
 
-        // A .bai index was produced alongside the output.
-        let bai = output.with_extension("bam.bai");
-        assert!(bai.exists() || output.with_extension("bai").exists(), "index file should exist");
+        // The index must land at exactly the samtools sidecar path -- append
+        // `.bai` to the full output path. Asserting the exact path (rather than
+        // accepting either naming) is the point: the old
+        // `with_extension("bam.bai")` put it under a different basename for any
+        // output not ending in `.bam`, where no indexed reader would find it.
+        let bai = fgumi_bam_io::bai_sidecar_path(&output);
+        assert!(
+            bai.exists(),
+            "index should exist at the sidecar path {} for output {}",
+            bai.display(),
+            output.display(),
+        );
+
+        // And nowhere else: a stray index under the rewritten basename would
+        // mean the old expression is still in play somewhere.
+        let stale = output.with_extension("bam.bai");
+        if stale != bai {
+            assert!(
+                !stale.exists(),
+                "no index should be written to the extension-replaced path {}",
+                stale.display(),
+            );
+        }
     }
 
     // ========================================================================

--- a/src/lib/commands/review.rs
+++ b/src/lib/commands/review.rs
@@ -235,19 +235,11 @@ impl Command for Review {
         let consensus_out_path = self.output.with_extension("consensus.bam");
         let grouped_out_path = self.output.with_extension("grouped.bam");
 
-        use noodles::bam;
-        use noodles::bam::bai;
-        let consensus_index = bam::fs::index(&consensus_out_path)?;
-        let mut consensus_index_writer = bai::io::Writer::new(std::fs::File::create(
-            consensus_out_path.with_extension("bam.bai"),
-        )?);
-        consensus_index_writer.write_index(&consensus_index)?;
-
-        let grouped_index = bam::fs::index(&grouped_out_path)?;
-        let mut grouped_index_writer = bai::io::Writer::new(std::fs::File::create(
-            grouped_out_path.with_extension("bam.bai"),
-        )?);
-        grouped_index_writer.write_index(&grouped_index)?;
+        // Both paths are built with a `.bam` suffix above, so the sidecar naming
+        // is unchanged here; going through the shared helper keeps every writer
+        // on one convention rather than re-deriving it per call site.
+        fgumi_bam_io::write_bai_sidecar(&consensus_out_path)?;
+        fgumi_bam_io::write_bai_sidecar(&grouped_out_path)?;
 
         // Generate detailed review file
         info!("Generating detailed review file...");
@@ -260,12 +252,17 @@ impl Command for Review {
 }
 
 impl Review {
-    /// Load a BAM index, preferring the `<prefix>.bam.bai` sidecar and falling back
-    /// to `<prefix>.bai` for callers that used samtools' default naming.
+    /// Load a BAM index, preferring the samtools sidecar (`.bai` appended to the
+    /// full BAM path, e.g. `foo.bam` → `foo.bam.bai`) and falling back to the
+    /// extension-replaced form (`foo.bam` → `foo.bai`) that some tools emit.
+    ///
+    /// The lookup must derive the primary path the same way the writers do, or a
+    /// BAM whose name does not end in `.bam` would be indexed at one path and
+    /// searched for at another.
     fn read_bam_index(path: &Path) -> Result<noodles::bam::bai::Index> {
         use noodles::bam;
 
-        let bam_bai = path.with_extension("bam.bai");
+        let bam_bai = fgumi_bam_io::bai_sidecar_path(path);
         if bam_bai.exists() {
             return Ok(bam::bai::fs::read(&bam_bai)?);
         }
@@ -1553,7 +1550,7 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
             }
             drop(writer);
 
-            let index_path = path.with_extension("bam.bai");
+            let index_path = fgumi_bam_io::bai_sidecar_path(path);
             let index = bam::fs::index(path).expect("index bam");
             let mut index_writer =
                 bai::io::Writer::new(std::fs::File::create(&index_path).expect("create bai"));
@@ -1706,7 +1703,7 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
             use noodles::bam::bai;
 
             // Index raw BAM
-            let raw_index_path = raw_path.with_extension("bam.bai");
+            let raw_index_path = fgumi_bam_io::bai_sidecar_path(&raw_path);
             let raw_index = bam::fs::index(&raw_path).expect("failed to index BAM file");
             let mut raw_index_writer = bai::io::Writer::new(
                 std::fs::File::create(&raw_index_path).expect("failed to create file"),
@@ -1714,7 +1711,7 @@ CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
             raw_index_writer.write_index(&raw_index).expect("failed to write BAM index");
 
             // Index consensus BAM
-            let consensus_index_path = consensus_path.with_extension("bam.bai");
+            let consensus_index_path = fgumi_bam_io::bai_sidecar_path(&consensus_path);
             let con_index = bam::fs::index(&consensus_path).expect("failed to index BAM file");
             let mut con_index_writer = bai::io::Writer::new(
                 std::fs::File::create(&consensus_index_path).expect("failed to create file"),
@@ -1833,7 +1830,7 @@ chr2\t20\t.\tC\tT\t.\tPASS\t.\tGT:AD\t0/1:100,2\n";
             for path in [&consensus_path, &grouped_path] {
                 let index = bam::fs::index(path).expect("failed to index BAM");
                 let mut writer = bai::io::Writer::new(
-                    std::fs::File::create(path.with_extension("bam.bai"))
+                    std::fs::File::create(fgumi_bam_io::bai_sidecar_path(path))
                         .expect("failed to create BAM index"),
                 );
                 writer.write_index(&index).expect("failed to write BAM index");

--- a/tests/integration/test_review_command.rs
+++ b/tests/integration/test_review_command.rs
@@ -12,17 +12,37 @@ use fgumi_lib::sam::SamTag;
 use fgumi_raw_bam::{RawRecord, SamBuilder};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
+use rstest::rstest;
 use std::fs;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{
     create_coordinate_sorted_header, create_test_reference, to_record_buf,
 };
 
-/// Create a coordinate-sorted, indexed BAM file.
-fn create_indexed_bam(path: &Path, records: &[RawRecord]) {
+/// Append `.bai` to the full BAM path, spelled out here (not via the production
+/// helper under test) so the test owns an independent expectation of the samtools
+/// sidecar convention.
+fn appended_bai_path(bam_path: &Path) -> PathBuf {
+    let mut index_os = bam_path.as_os_str().to_owned();
+    index_os.push(".bai");
+    PathBuf::from(index_os)
+}
+
+/// Create a coordinate-sorted, indexed BAM file and return the path of the BAI written.
+///
+/// The index path is derived here *independently* of the production helper under
+/// test — by literally appending `.bai` to the full BAM path (see
+/// [`appended_bai_path`]) — so this fixture is a faithful oracle. If
+/// `bai_sidecar_path` / `Review::read_bam_index` regressed to the old
+/// extension-replacing convention (`Path::with_extension("bam.bai")`), the index
+/// would land at a path the command no longer looks in for any BAM not named
+/// `*.bam`, and the test would fail. Using the production helper on both sides
+/// would instead let a naming regression pass whenever writer and reader drift
+/// together.
+fn create_indexed_bam(path: &Path, records: &[RawRecord]) -> PathBuf {
     let header = create_coordinate_sorted_header("chr1", 10000);
 
     // Write BAM and drop to flush
@@ -37,12 +57,12 @@ fn create_indexed_bam(path: &Path, records: &[RawRecord]) {
         }
     }
 
-    // Create BAI index
+    let index_path = appended_bai_path(path);
     let index = bam::fs::index(path).expect("Failed to create BAM index");
-    let index_path = path.with_extension("bam.bai");
     let mut index_writer =
         noodles::bam::bai::io::Writer::new(fs::File::create(&index_path).unwrap());
-    index_writer.write_index(&index).unwrap();
+    index_writer.write_index(&index).expect("Failed to write BAM index");
+    index_path
 }
 
 /// Create a minimal VCF file with one variant.
@@ -101,12 +121,22 @@ fn test_review_missing_input_files() {
 ///
 /// Creates minimal VCF, consensus BAM, grouped BAM, and reference files.
 /// Verifies the command completes and produces output files.
-#[test]
-fn test_review_basic_execution() {
+///
+/// Parameterized over the input BAM naming so the index-lookup contract is pinned
+/// for the cases that distinguish the samtools sidecar convention from the old
+/// extension-replacing one: a plain `*.bam` (where the two agree), a non-`.bam`
+/// suffix, and an extensionless name. The command reads its indexes through
+/// `Review::read_bam_index`, so it only succeeds if it finds the BAI at the
+/// appended path this fixture wrote.
+#[rstest]
+#[case::dot_bam("consensus.bam", "grouped.bam")]
+#[case::non_bam_suffix("consensus.sorted", "grouped.sorted")]
+#[case::extensionless("consensus", "grouped")]
+fn test_review_basic_execution(#[case] consensus_name: &str, #[case] grouped_name: &str) {
     let temp_dir = TempDir::new().unwrap();
     let vcf_path = temp_dir.path().join("variants.vcf");
-    let consensus_bam = temp_dir.path().join("consensus.bam");
-    let grouped_bam = temp_dir.path().join("grouped.bam");
+    let consensus_bam = temp_dir.path().join(consensus_name);
+    let grouped_bam = temp_dir.path().join(grouped_name);
     let ref_path = create_test_reference(temp_dir.path());
     let output_prefix = temp_dir.path().join("review_out");
 
@@ -127,7 +157,7 @@ fn test_review_basic_execution() {
             .add_string_tag(SamTag::MI, b"1");
         b.build()
     }];
-    create_indexed_bam(&consensus_bam, &consensus_records);
+    let consensus_index = create_indexed_bam(&consensus_bam, &consensus_records);
 
     // Create a grouped BAM with raw reads (MI tag matches consensus)
     let grouped_records = vec![
@@ -156,7 +186,23 @@ fn test_review_basic_execution() {
             b.build()
         },
     ];
-    create_indexed_bam(&grouped_bam, &grouped_records);
+    let grouped_index = create_indexed_bam(&grouped_bam, &grouped_records);
+
+    // The fixture wrote each index at the appended sidecar path (`<bam>.bai`). Assert
+    // it is there, and that nothing was written at the extension-replaced path the old
+    // buggy convention produced — so a regression that reads from the wrong path cannot
+    // be masked by an index happening to sit there.
+    for (bam, index) in [(&consensus_bam, &consensus_index), (&grouped_bam, &grouped_index)] {
+        assert!(index.exists(), "fixture must write the BAI sidecar at {}", index.display());
+        let extension_replaced = bam.with_extension("bam.bai");
+        if extension_replaced != *index {
+            assert!(
+                !extension_replaced.exists(),
+                "no index should exist at the extension-replaced path {}",
+                extension_replaced.display(),
+            );
+        }
+    }
 
     let cmd = Review::try_parse_from([
         "review",


### PR DESCRIPTION
`Path::with_extension("bam.bai")` replaces everything after the final `.` rather than appending, so it produced the correct sidecar name only for outputs already ending in `.bam`. For anything else it rewrote the basename itself:

```
fgumi sort --write-index -o out          wrote out.bam.bai     (indexed readers look for out.bai)
fgumi sort --write-index -o out.sorted   wrote out.bam.bai     (indexed readers look for out.sorted.bai)
```

So the index was invisible to every indexed reader. Worse, distinct outputs collapse onto a single index path: sorting `out.sorted` and then `out.other` in the same directory silently overwrites the first run's index with the second's, leaving a stale index that still reads as structurally valid.

## The fix

Adds `bai_sidecar_path` to `fgumi-bam-io`, which appends `.bai` to the full path per the samtools convention, plus `write_bai_sidecar` for the index-then-write pattern the review command open-coded in several places. Callers that already hold an in-memory index — the indexing sort writer — pair `bai_sidecar_path` with the existing `write_bai_index` instead, so nothing re-reads a BAM it just finished writing.

The read side is updated in lockstep. `Review::read_bam_index` derived its primary lookup with the same broken expression, so a BAM not named `*.bam` would have been indexed at one path and searched for at another. Its extension-replaced fallback is retained, since other tools do emit indexes under that name.

## Why the existing test did not catch it

Behavior is unchanged for outputs ending in `.bam`, and the existing sort test used `output.bam`. It also asserted:

```rust
assert!(bai.exists() || output.with_extension("bai").exists(), "index file should exist");
```

That either-naming check accommodates the bug rather than pinning the contract — it passes whichever path the index lands at.

It is now an rstest table over `.bam`, non-`.bam`, and extensionless outputs that asserts the *exact* sidecar path, and additionally asserts no index appears at the extension-replaced path. A sibling test covers the non-spilling in-memory sort path, which derives the sidecar path at a second call site that the spilling test never reaches.

The `review` integration fixture now builds its index through the same helper the command reads with, so the fixture cannot drift into agreeing with a regression.

## Verification

`cargo ci-test` (5545 tests), `cargo ci-fmt`, `cargo ci-lint`, and `RUSTDOCFLAGS="-D warnings" cargo ci-doc` all pass. Patch coverage is 100% of changed lines. Each new assertion was checked for non-vacuity by reverting the corresponding call site and confirming the matching case fails while the `.bam` case keeps passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for samtools-style BAM BAI sidecar naming using the `.bai` suffix.
  - Added a helper to create and write BAM BAI sidecars and return their index paths.

- **Bug Fixes**
  - Corrected BAI sidecar path handling for BAM filenames that don’t end with `.bam`.
  - Ensured outputs use the preferred sidecar location, while still falling back to legacy locations only when needed.

- **Tests**
  - Expanded unit and integration coverage to verify the exact BAI sidecar paths written and to confirm legacy locations are not used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->