### PR TITLE
feat(sort): add per-phase --sort-threads / --merge-threads

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1494,8 +1494,15 @@ pub struct RawExternalSorter {
     /// distributed across them in free-space-aware round-robin order via
     /// [`TmpDirAllocator`].
     temp_dirs: Vec<PathBuf>,
-    /// Number of threads for parallel operations.
+    /// Number of threads for parallel operations. Used by both phases unless
+    /// overridden by `sort_threads` / `merge_threads`.
     threads: usize,
+    /// Phase-1 (accumulate/sort/spill) worker count. `None` means "use
+    /// `threads`". Lets a caller cede cores to an upstream producer during
+    /// ingest while keeping the merge wide.
+    sort_threads: Option<usize>,
+    /// Phase-2 (merge/write) worker count. `None` means "use `threads`".
+    merge_threads: Option<usize>,
     /// Compression level for output.
     output_compression: u32,
     /// Compression level for temporary chunk files (0 = uncompressed).
@@ -1568,6 +1575,8 @@ impl RawExternalSorter {
             memory_limit: 512 * 1024 * 1024, // 512 MB default
             temp_dirs: Vec::new(),
             threads: 1,
+            sort_threads: None,
+            merge_threads: None,
             output_compression: 6,
             temp_compression: 1, // Default: fast compression
             spill_codec: crate::codec::SpillCodec::default(),
@@ -1613,6 +1622,42 @@ impl RawExternalSorter {
     pub fn threads(mut self, threads: usize) -> Self {
         self.threads = threads;
         self
+    }
+
+    /// Set the Phase-1 (accumulate/sort/spill) worker count, overriding
+    /// [`threads`](Self::threads) for that phase only.
+    ///
+    /// Phase 1 competes with whatever is feeding the sort, so a pipeline like
+    /// `bwa mem -t 32 | fgumi sort` can lower this to cede cores to the producer
+    /// during ingest while leaving the merge at full width.
+    ///
+    /// This is purely a scheduling knob: output is byte-identical regardless.
+    #[must_use]
+    pub fn sort_threads(mut self, n: usize) -> Self {
+        self.sort_threads = Some(n);
+        self
+    }
+
+    /// Set the Phase-2 (merge/write) worker count, overriding
+    /// [`threads`](Self::threads) for that phase only.
+    ///
+    /// This is purely a scheduling knob: output is byte-identical regardless.
+    #[must_use]
+    pub fn merge_threads(mut self, n: usize) -> Self {
+        self.merge_threads = Some(n);
+        self
+    }
+
+    /// Effective Phase-1 worker count: `sort_threads` if set, else `threads`.
+    #[must_use]
+    pub fn phase1_threads(&self) -> usize {
+        self.sort_threads.unwrap_or(self.threads).max(1)
+    }
+
+    /// Effective Phase-2 worker count: `merge_threads` if set, else `threads`.
+    #[must_use]
+    pub fn phase2_threads(&self) -> usize {
+        self.merge_threads.unwrap_or(self.threads).max(1)
     }
 
     /// Set the output compression level.
@@ -1744,7 +1789,7 @@ impl RawExternalSorter {
     /// idle at the moment rayon fans out.
     fn build_sort_rayon_pool(&self) -> Result<rayon::ThreadPool> {
         rayon::ThreadPoolBuilder::new()
-            .num_threads(self.threads.max(1))
+            .num_threads(self.phase1_threads())
             .thread_name(|i| format!("fgumi-sort-rayon-{i}"))
             .build()
             .map_err(|e| anyhow::anyhow!("failed to build rayon sort pool: {e}"))
@@ -1811,7 +1856,7 @@ impl RawExternalSorter {
         let merged_path = namer.next_merged_path()?;
 
         // Open readers with semaphore to cap concurrent I/O.
-        let sem = make_reader_semaphore(self.threads);
+        let sem = make_reader_semaphore(self.phase1_threads());
         let mut readers: Vec<GenericKeyedChunkReader<K>> = files_to_merge
             .iter()
             .map(|p| GenericKeyedChunkReader::<K>::open(p, Some(Arc::clone(&sem))))
@@ -1964,15 +2009,24 @@ impl RawExternalSorter {
 
         debug!("Starting raw-bytes sort with order: {:?}", self.sort_order);
         debug!("Memory limit: {} MB", self.memory_limit / (1024 * 1024));
-        debug!("Threads: {}", self.threads);
+        debug!(
+            "Threads: {} (phase 1: {}, phase 2: {})",
+            self.threads,
+            self.phase1_threads(),
+            self.phase2_threads()
+        );
 
-        // Shared worker pool for parallel BGZF compress/decompress across all phases
-        Ok(Arc::new(SortWorkerPool::new(
-            self.threads.max(1),
+        // One worker pool spans both phases, so size it to the wider of the two
+        // and cap the active count per phase via `set_active_workers`.
+        let pool = SortWorkerPool::new(
+            self.phase1_threads().max(self.phase2_threads()),
             self.temp_compression,
             self.output_compression,
             self.spill_codec,
-        )))
+        );
+        // Phase 1 runs first; the merge raises this to `phase2_threads()`.
+        pool.set_active_workers(self.phase1_threads());
+        Ok(Arc::new(pool))
     }
 
     /// Run the sort over an already-constructed record source.
@@ -2345,6 +2399,13 @@ impl RawExternalSorter {
         )?;
         probe.phase1_end(buffer.memory_usage() as u64);
 
+        // Ingest is done: everything from here is Phase 2 (merge/write), so
+        // lift the active-worker cap to `merge_threads`. Workers idled by the
+        // Phase-1 cap re-check within MAX_BACKOFF_US, so no explicit wake is
+        // needed; capped workers always drained their held items, so raising
+        // the cap can never be required for correctness, only for width.
+        pool.set_active_workers(self.phase2_threads());
+
         if chunk_files.is_empty() {
             // All records fit in memory - no merge needed
             debug!("All records fit in memory, performing in-memory sort");
@@ -2370,8 +2431,10 @@ impl RawExternalSorter {
             // chunk becomes its own in-memory merge source.
             let memory_chunks: Vec<InMemoryChunk<RawCoordinateKey>> = if buffer.is_empty() {
                 Vec::new()
-            } else if self.threads > 1 {
-                timer.time_sort(|| rayon_pool.install(|| buffer.par_sort_into_chunks(self.threads)))
+            } else if self.phase1_threads() > 1 {
+                timer.time_sort(|| {
+                    rayon_pool.install(|| buffer.par_sort_into_chunks(self.phase1_threads()))
+                })
             } else {
                 timer.time_sort(|| {
                     rayon_pool.install(|| buffer.par_sort());
@@ -2521,6 +2584,13 @@ impl RawExternalSorter {
 
         let output_header = self.create_output_header(header);
 
+        // Ingest is done: everything from here is Phase 2 (merge/write), so
+        // lift the active-worker cap to `merge_threads`. Workers idled by the
+        // Phase-1 cap re-check within MAX_BACKOFF_US, so no explicit wake is
+        // needed; capped workers always drained their held items, so raising
+        // the cap can never be required for correctness, only for width.
+        pool.set_active_workers(self.phase2_threads());
+
         if chunk_files.is_empty() {
             // All records fit in memory - no merge needed
             debug!("All records fit in memory, performing in-memory sort");
@@ -2534,7 +2604,7 @@ impl RawExternalSorter {
                     output,
                     &output_header,
                     self.output_compression,
-                    self.threads,
+                    self.phase2_threads(),
                 )?;
 
                 for record_bytes in buffer.iter_sorted() {
@@ -2552,8 +2622,10 @@ impl RawExternalSorter {
             // Sort remaining records into separate sub-array chunks
             let memory_chunks: Vec<InMemoryChunk<RawCoordinateKey>> = if buffer.is_empty() {
                 Vec::new()
-            } else if self.threads > 1 {
-                timer.time_sort(|| rayon_pool.install(|| buffer.par_sort_into_chunks(self.threads)))
+            } else if self.phase1_threads() > 1 {
+                timer.time_sort(|| {
+                    rayon_pool.install(|| buffer.par_sort_into_chunks(self.phase1_threads()))
+                })
             } else {
                 timer.time_sort(|| {
                     rayon_pool.install(|| buffer.par_sort());
@@ -2748,6 +2820,13 @@ impl RawExternalSorter {
         )?;
         probe.phase1_end(memory_used as u64);
 
+        // Ingest is done: everything from here is Phase 2 (merge/write), so
+        // lift the active-worker cap to `merge_threads`. Workers idled by the
+        // Phase-1 cap re-check within MAX_BACKOFF_US, so no explicit wake is
+        // needed; capped workers always drained their held items, so raising
+        // the cap can never be required for correctness, only for width.
+        pool.set_active_workers(self.phase2_threads());
+
         if chunk_files.is_empty() {
             // All records fit in memory
             debug!("All records fit in memory, performing in-memory sort");
@@ -2781,10 +2860,10 @@ impl RawExternalSorter {
             // `InMemoryChunk`s sharing an `Arc<SegmentedBuf>`.
             let keyed_chunks: Vec<Vec<(K, fgumi_raw_bam::RawRecord)>> = if entries.is_empty() {
                 Vec::new()
-            } else if self.threads > 1 {
+            } else if self.phase1_threads() > 1 {
                 timer.time_sort(|| {
                     use rayon::prelude::*;
-                    let chunk_size = entries.len().div_ceil(self.threads.max(1));
+                    let chunk_size = entries.len().div_ceil(self.phase1_threads());
                     rayon_pool.install(|| {
                         entries.par_chunks_mut(chunk_size).for_each(|chunk| {
                             // Stable sort per chunk: chunks are contiguous ingest-ordered
@@ -3111,6 +3190,13 @@ impl RawExternalSorter {
         )?;
         probe.phase1_end(buffer.memory_usage() as u64);
 
+        // Ingest is done: everything from here is Phase 2 (merge/write), so
+        // lift the active-worker cap to `merge_threads`. Workers idled by the
+        // Phase-1 cap re-check within MAX_BACKOFF_US, so no explicit wake is
+        // needed; capped workers always drained their held items, so raising
+        // the cap can never be required for correctness, only for width.
+        pool.set_active_workers(self.phase2_threads());
+
         if chunk_files.is_empty() {
             // All records fit in memory
             debug!("All records fit in memory, performing in-memory sort");
@@ -3135,8 +3221,10 @@ impl RawExternalSorter {
             // intermediate merge back into a single sorted buffer)
             let memory_chunks: Vec<InMemoryChunk<K>> = if buffer.is_empty() {
                 Vec::new()
-            } else if self.threads > 1 {
-                timer.time_sort(|| rayon_pool.install(|| buffer.par_sort_into_chunks(self.threads)))
+            } else if self.phase1_threads() > 1 {
+                timer.time_sort(|| {
+                    rayon_pool.install(|| buffer.par_sort_into_chunks(self.phase1_threads()))
+                })
             } else {
                 timer.time_sort(|| {
                     rayon_pool.install(|| buffer.par_sort());
@@ -3405,10 +3493,12 @@ impl RawExternalSorter {
         use crate::loser_tree::LoserTree;
         use fgumi_bam_io::create_indexing_bam_writer;
 
-        // Thread budget: writer gets all threads (merge is output-compression-bound),
-        // readers use semaphore concurrency of 1. Same split as merge_chunks_generic.
+        // Thread budget: writer gets the Phase 2 (merge/write) thread count
+        // (merge is output-compression-bound), readers use semaphore concurrency
+        // of 1. Same split as merge_chunks_generic, whose PooledBamWriter inherits
+        // the same cap via the shared pool raised to `phase2_threads()`.
         // TODO: Replace create_indexing_bam_writer with PooledIndexingBamWriter
-        let writer_threads = self.threads;
+        let writer_threads = self.phase2_threads();
         let reader_concurrency: usize = 1;
 
         // The indexing path uses a non-pooled writer and has no pool consumer set up,
@@ -5886,6 +5976,120 @@ mod tests {
                 stale.display(),
             );
         }
+    }
+
+    /// Per-phase thread counts are a scheduling knob only: whatever the split,
+    /// the sorted output must be byte-identical to a plain `--threads` run.
+    /// Also exercises the asymmetric cases in both directions, since Phase 1 and
+    /// Phase 2 size the shared pool differently (`max` of the two) and the cap
+    /// is flipped at the ingest/merge boundary -- a capped worker that failed to
+    /// drain held items would strand records and change the output.
+    ///
+    /// `write_index` is crossed in via `#[values]` so both the plain and the
+    /// `--write-index` output paths are covered for every split -- the indexed
+    /// path routes through separate writers (`sort_coordinate_with_index` and
+    /// `merge_chunks_with_index`) that must honor `merge_threads` the same way.
+    /// `memory_limit` is crossed in to hit both indexed writer sites: the small
+    /// limit spills and runs `merge_chunks_with_index`; the large limit keeps
+    /// everything in memory and runs the in-memory indexed writer. Output is
+    /// byte-identical regardless of the writer's compression-thread count, so
+    /// this guards the path against regression rather than asserting the count.
+    #[rstest::rstest]
+    #[case::narrow_sort_wide_merge(1, 4)]
+    #[case::wide_sort_narrow_merge(4, 1)]
+    #[case::both_narrow(1, 1)]
+    #[case::both_wide(3, 3)]
+    fn test_per_phase_threads_produce_identical_output(
+        #[case] sort_threads: usize,
+        #[case] merge_threads: usize,
+        #[values(false, true)] write_index: bool,
+        #[values(16 * 1024, 64 * 1024 * 1024)] memory_limit: usize,
+    ) {
+        use fgumi_sam::SamBuilder;
+
+        // Enough records that, at the small memory limit, Phase 1 spills several
+        // chunks and Phase 2 runs a real k-way merge across them; at the large
+        // limit everything fits in memory and the in-memory write path runs.
+        let num_pairs = 400;
+        let mut builder = SamBuilder::new();
+        for i in 0..num_pairs {
+            let _ = builder
+                .add_pair()
+                .name(&format!("read{i:05}"))
+                .start1((num_pairs - i) * 100 + 1)
+                .start2((num_pairs - i) * 100 + 51)
+                .build();
+        }
+
+        let workdir = tempfile::tempdir().expect("workdir");
+        let input = workdir.path().join("input.bam");
+        builder.write_bam(&input).expect("write bam");
+
+        let run = |sorter: RawExternalSorter, out: &std::path::Path| {
+            let stats = sorter.sort(&input, out).expect("sort should succeed");
+            (stats.total_records, std::fs::read(out).expect("read output"))
+        };
+
+        let baseline_out = workdir.path().join("baseline.bam");
+        let (baseline_records, baseline_bytes) = run(
+            RawExternalSorter::new(SortOrder::Coordinate)
+                .memory_limit(memory_limit)
+                .threads(2)
+                .write_index(write_index)
+                .spill_codec(crate::codec::SpillCodec::Bgzf)
+                .temp_compression(0)
+                .output_compression(0),
+            &baseline_out,
+        );
+
+        let split_out = workdir.path().join("split.bam");
+        let (split_records, split_bytes) = run(
+            RawExternalSorter::new(SortOrder::Coordinate)
+                .memory_limit(memory_limit)
+                .threads(2)
+                .sort_threads(sort_threads)
+                .merge_threads(merge_threads)
+                .write_index(write_index)
+                .spill_codec(crate::codec::SpillCodec::Bgzf)
+                .temp_compression(0)
+                .output_compression(0),
+            &split_out,
+        );
+
+        assert_eq!(
+            split_records, baseline_records,
+            "per-phase threads must not change the record count",
+        );
+        assert_eq!(
+            split_bytes, baseline_bytes,
+            "per-phase threads ({sort_threads}/{merge_threads}, write_index={write_index}) \
+             changed the output bytes; this is a scheduling knob and must be output-identical",
+        );
+    }
+
+    /// The per-phase counts fall back to `--threads` independently, so an unset
+    /// override must not silently pin a phase to 1.
+    #[rstest::rstest]
+    #[case::neither_set(None, None, 6, 6)]
+    #[case::sort_only(Some(2), None, 2, 6)]
+    #[case::merge_only(None, Some(3), 6, 3)]
+    #[case::both_set(Some(2), Some(3), 2, 3)]
+    #[case::zero_clamps_to_one(Some(0), Some(0), 1, 1)]
+    fn test_phase_thread_defaults(
+        #[case] sort_threads: Option<usize>,
+        #[case] merge_threads: Option<usize>,
+        #[case] expected_phase1: usize,
+        #[case] expected_phase2: usize,
+    ) {
+        let mut sorter = RawExternalSorter::new(SortOrder::Coordinate).threads(6);
+        if let Some(n) = sort_threads {
+            sorter = sorter.sort_threads(n);
+        }
+        if let Some(n) = merge_threads {
+            sorter = sorter.merge_threads(n);
+        }
+        assert_eq!(sorter.phase1_threads(), expected_phase1);
+        assert_eq!(sorter.phase2_threads(), expected_phase2);
     }
 
     // ========================================================================

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -656,6 +656,16 @@ pub(crate) struct SharedPipelineState {
     /// Current phase: 0=shutdown, 1=Phase1, 2=Phase2, 255=Legacy.
     pub(crate) phase: AtomicU8,
 
+    /// Number of workers permitted to be active in the current phase. Workers
+    /// with `worker_id >= active_worker_limit` idle (backoff) instead of taking
+    /// work. Lets the sort driver run Phase 1 (accumulate/sort/spill) on fewer
+    /// threads than Phase 2 (merge/write) — e.g. to cede cores to an upstream
+    /// producer in a pipeline. Defaults to `num_workers` (all active), so the
+    /// behavior is unchanged unless the driver calls `set_active_workers`.
+    /// Capped workers re-check this within `MAX_BACKOFF_US`, so raising the
+    /// limit reactivates them without an explicit wake.
+    pub(crate) active_worker_limit: AtomicUsize,
+
     // --- Phase 1 queues ---
     /// Input BAM file (Mutex because only one worker reads at a time).
     pub(crate) input_file: std::sync::Mutex<Option<Box<dyn Read + Send>>>,
@@ -743,6 +753,7 @@ impl SharedPipelineState {
 
         Self {
             phase: AtomicU8::new(phase::LEGACY),
+            active_worker_limit: AtomicUsize::new(num_workers),
 
             input_file: std::sync::Mutex::new(None),
             input_eof: AtomicBool::new(false),
@@ -1068,6 +1079,25 @@ impl SortWorkerPool {
             let current_phase = shared.phase.load(Ordering::Acquire);
             if current_phase == phase::SHUTDOWN {
                 break;
+            }
+
+            // 1b. Honor the per-phase active-worker cap: workers above the limit
+            //     take no NEW work, but must still drain any items they already
+            //     hold — held items are per-worker, so a capped worker that
+            //     froze with held work would strand that output (no other worker
+            //     can advance it). So advance held items first, then idle without
+            //     acquiring fresh work. Capped workers re-check the limit within
+            //     MAX_BACKOFF_US, so a later raise reactivates them. Default
+            //     limit == num_workers ⇒ no worker is ever capped (no-op).
+            if worker.worker_id >= shared.active_worker_limit.load(Ordering::Acquire) {
+                if Self::try_advance_all_held(shared, worker) {
+                    worker.backoff_us = MIN_BACKOFF_US;
+                } else {
+                    sleep_with_jitter(worker.backoff_us, worker.worker_id, worker.idle_iter);
+                    worker.idle_iter = worker.idle_iter.wrapping_add(1);
+                    worker.backoff_us = (worker.backoff_us * 2).min(MAX_BACKOFF_US);
+                }
+                continue;
             }
 
             // 2. Check phase completion — wait for next phase, only exit on SHUTDOWN.
@@ -1831,6 +1861,16 @@ impl SortWorkerPool {
         self.shared.phase.store(new_phase, Ordering::Release);
     }
 
+    /// Cap the number of workers active in the current phase to `n` (clamped to
+    /// `[1, num_workers]`). Workers with `worker_id >= n` idle until the limit is
+    /// raised. Used to run Phase 1 on fewer threads than Phase 2; raising the
+    /// limit reactivates idled workers within `MAX_BACKOFF_US` (no explicit wake
+    /// needed). Defaults to `num_workers` (all active) when never called.
+    pub fn set_active_workers(&self, n: usize) {
+        let n = n.clamp(1, self.num_workers);
+        self.shared.active_worker_limit.store(n, Ordering::Release);
+    }
+
     /// Set the input file for Phase 1 reading.
     ///
     /// Must be called before `set_phase(PHASE1)`.
@@ -2230,6 +2270,94 @@ mod tests {
         assert_eq!(received, num_jobs);
 
         let pool = submit_handle.join().expect("submit thread should not panic");
+        pool.shutdown();
+    }
+
+    #[test]
+    fn set_active_workers_clamps() {
+        let pool = SortWorkerPool::new(4, 1, 6, crate::codec::SpillCodec::Bgzf);
+        // Clamp to [1, num_workers].
+        pool.set_active_workers(0);
+        assert_eq!(pool.shared.active_worker_limit.load(Ordering::Acquire), 1);
+        pool.set_active_workers(100);
+        assert_eq!(pool.shared.active_worker_limit.load(Ordering::Acquire), 4);
+        pool.set_active_workers(2);
+        assert_eq!(pool.shared.active_worker_limit.load(Ordering::Acquire), 2);
+        pool.shutdown();
+    }
+
+    #[test]
+    fn active_worker_limit_caps_then_reactivates() {
+        // Reactivation must be observable on the SAME pool: a fresh pool can never
+        // prove that raising the cap re-enables workers idled by an earlier cap.
+        // With a cap of 2 over 6 workers, only workers 0..2 may run compress steps;
+        // workers >= 2 stay idle. Raising the cap to 6 and running a second batch
+        // must bring those workers online — and because per-worker counts are
+        // cumulative and they did nothing under the cap, any work they show after
+        // the second batch was done exclusively in that batch.
+        let cs = SortStep::CompressSpill as usize;
+
+        // Run one batch on `pool` (moved in, returned out so the next batch can
+        // reuse it) and report the cumulative per-worker CompressSpill counts.
+        let run_batch = |pool: SortWorkerPool, num_jobs: usize| -> (SortWorkerPool, Vec<u64>) {
+            let (result_tx, result_rx) = pool.compress_result_channel();
+            let submit_tx = result_tx.clone();
+            let submit_handle = std::thread::spawn(move || {
+                for i in 0..num_jobs {
+                    pool.submit_compress(CompressJob {
+                        data: vec![b'X'; 4096],
+                        serial: i as u64,
+                        result_tx: submit_tx.clone(),
+                        codec: SpillCodec::Bgzf,
+                    });
+                }
+                drop(submit_tx);
+                pool
+            });
+            drop(result_tx);
+            let mut received = 0;
+            while result_rx.recv().is_ok() {
+                received += 1;
+            }
+            assert_eq!(received, num_jobs);
+            let pool = submit_handle.join().expect("submit thread should not panic");
+            let counts: Vec<u64> = (0..6)
+                .map(|t| pool.pipeline_stats.per_thread_step_counts[t][cs].load(Ordering::Relaxed))
+                .collect();
+            (pool, counts)
+        };
+
+        let pool = SortWorkerPool::new(6, 1, 6, crate::codec::SpillCodec::Bgzf);
+
+        // Batch 1: capped at 2 — only workers 0..2 may run.
+        pool.set_active_workers(2);
+        let (pool, after_capped) = run_batch(pool, 300);
+        assert!(
+            after_capped.iter().filter(|&&c| c > 0).count() <= 2,
+            "cap=2 must bound active workers; per-worker counts {after_capped:?}"
+        );
+        assert!(
+            after_capped[2..].iter().all(|&c| c == 0),
+            "workers >= cap must do no work; per-worker counts {after_capped:?}"
+        );
+        assert_eq!(after_capped.iter().sum::<u64>(), 300, "all batch-1 jobs accounted for");
+
+        // Batch 2: raise the cap on the SAME pool and run again.
+        pool.set_active_workers(6);
+        let (pool, after_full) = run_batch(pool, 300);
+        // Workers >= the old cap did nothing in batch 1, so any cumulative work
+        // they now show was processed solely in batch 2 — i.e. reactivation worked.
+        let reactivated_work: u64 = after_full[2..].iter().sum();
+        assert!(
+            reactivated_work > 0,
+            "raising the cap on the same pool must reactivate workers >= old cap; \
+             after_capped {after_capped:?}, after_full {after_full:?}"
+        );
+        assert_eq!(
+            after_full.iter().sum::<u64>(),
+            600,
+            "all jobs across both batches accounted for; per-worker counts {after_full:?}"
+        );
         pool.shutdown();
     }
 

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -283,6 +283,24 @@ pub struct Sort {
     #[arg(short = '@', short_alias = 't', long = "threads", default_value = "1")]
     pub threads: usize,
 
+    /// Number of threads for the sort phase (accumulate, sort, spill).
+    ///
+    /// Defaults to `--threads`. Lower this to cede cores to an upstream
+    /// producer while keeping the merge wide -- e.g. in
+    /// `bwa mem -t 32 ... | fgumi sort -@ 8 --sort-threads 4`, ingest competes
+    /// with the aligner but the merge does not.
+    ///
+    /// This only changes scheduling; the output is byte-identical.
+    #[arg(long = "sort-threads")]
+    pub sort_threads: Option<usize>,
+
+    /// Number of threads for the merge phase (k-way merge and output write).
+    ///
+    /// Defaults to `--threads`. This only changes scheduling; the output is
+    /// byte-identical.
+    #[arg(long = "merge-threads")]
+    pub merge_threads: Option<usize>,
+
     /// Compression options for output BAM.
     #[command(flatten)]
     pub compression: CompressionOptions,
@@ -432,6 +450,33 @@ impl Command for Sort {
 }
 
 impl Sort {
+    /// Construct the sorter from this command's options.
+    ///
+    /// Extracted from `execute` so the option-to-builder wiring is testable on
+    /// its own. That matters most for `--sort-threads` / `--merge-threads`:
+    /// they only affect scheduling, so an end-to-end run cannot distinguish a
+    /// correctly wired flag from one that was parsed and then dropped.
+    fn build_sorter(&self, effective_memory: usize, command_line: &str) -> RawExternalSorter {
+        let mut sorter = RawExternalSorter::new(self.order.into())
+            .memory_limit(effective_memory)
+            .threads(self.threads)
+            .output_compression(self.compression.compression_level)
+            .temp_compression(self.temp_compression)
+            .spill_codec(self.temp_codec)
+            .write_index(self.write_index)
+            .async_reader(self.async_reader)
+            .pg_info(crate::version::VERSION.to_string(), command_line.to_string());
+
+        // Each per-phase override is optional and falls back to `--threads`.
+        if let Some(n) = self.sort_threads {
+            sorter = sorter.sort_threads(n);
+        }
+        if let Some(n) = self.merge_threads {
+            sorter = sorter.merge_threads(n);
+        }
+        sorter
+    }
+
     /// Parse the cell tag for template-coordinate sort/verify, returning `None`
     /// for other sort orders.
     fn parse_cell_tag(&self) -> Result<Option<SamTag>> {
@@ -508,15 +553,7 @@ impl Sort {
         }
 
         // Sort using raw-bytes sorter for optimal memory efficiency and speed
-        let mut sorter = RawExternalSorter::new(self.order.into())
-            .memory_limit(effective_memory)
-            .threads(self.threads)
-            .output_compression(self.compression.compression_level)
-            .temp_compression(self.temp_compression)
-            .spill_codec(self.temp_codec)
-            .write_index(self.write_index)
-            .async_reader(self.async_reader)
-            .pg_info(crate::version::VERSION.to_string(), command_line.to_string());
+        let mut sorter = self.build_sorter(effective_memory, command_line);
 
         // For auto mode, cap initial buffer pre-allocation at 768 MiB/thread
         // (matching samtools default) to avoid huge upfront allocations.
@@ -750,6 +787,97 @@ mod tests {
         assert_eq!(sort.temp_codec, expected);
     }
 
+    /// The per-phase flags must parse and reach the command struct, defaulting
+    /// to `None` (which the builder resolves to `--threads`) when not passed.
+    #[rstest]
+    #[case::neither(&[], None, None)]
+    #[case::sort_only(&["--sort-threads", "4"], Some(4), None)]
+    #[case::merge_only(&["--merge-threads", "3"], None, Some(3))]
+    #[case::both(&["--sort-threads", "2", "--merge-threads", "8"], Some(2), Some(8))]
+    fn test_parse_per_phase_threads(
+        #[case] extra: &[&str],
+        #[case] expected_sort: Option<usize>,
+        #[case] expected_merge: Option<usize>,
+    ) {
+        let base = ["sort", "-i", "in.bam", "-o", "out.bam", "--order", "coordinate"];
+        let args: Vec<&str> = base.iter().copied().chain(extra.iter().copied()).collect();
+        let sort = Sort::try_parse_from(args).expect("parse should succeed");
+        assert_eq!(sort.sort_threads, expected_sort);
+        assert_eq!(sort.merge_threads, expected_merge);
+    }
+
+    /// The flags must actually reach the sorter. This cannot be checked through
+    /// an end-to-end run: the per-phase counts only affect scheduling, so a flag
+    /// that parsed and was then silently dropped produces byte-identical output
+    /// to one that was wired correctly. Assert the resolved per-phase counts on
+    /// the built sorter instead.
+    #[rstest]
+    #[case::defaults(None, None, 2, 2)]
+    #[case::narrow_sort(Some(1), Some(4), 1, 4)]
+    #[case::narrow_merge(Some(4), Some(1), 4, 1)]
+    #[case::sort_only(Some(3), None, 3, 2)]
+    #[case::merge_only(None, Some(3), 2, 3)]
+    fn test_build_sorter_wires_per_phase_threads(
+        #[case] sort_threads: Option<usize>,
+        #[case] merge_threads: Option<usize>,
+        #[case] expected_phase1: usize,
+        #[case] expected_phase2: usize,
+    ) {
+        let mut sort = make_sort(SortOrderArg::Coordinate);
+        sort.threads = 2;
+        sort.sort_threads = sort_threads;
+        sort.merge_threads = merge_threads;
+
+        let sorter = sort.build_sorter(512 * 1024 * 1024, "fgumi sort (test)");
+        assert_eq!(sorter.phase1_threads(), expected_phase1);
+        assert_eq!(sorter.phase2_threads(), expected_phase2);
+    }
+
+    /// Separately, the knob must not change what is written. Covers the same
+    /// asymmetric splits end-to-end through `execute`.
+    #[rstest]
+    #[case::defaults(None, None)]
+    #[case::narrow_sort(Some(1), Some(4))]
+    #[case::narrow_merge(Some(4), Some(1))]
+    fn test_execute_with_per_phase_threads_is_output_identical(
+        #[case] sort_threads: Option<usize>,
+        #[case] merge_threads: Option<usize>,
+    ) {
+        use fgumi_sam::SamBuilder;
+
+        let mut builder = SamBuilder::new();
+        for i in 0..60 {
+            let _ = builder
+                .add_pair()
+                .name(&format!("read{i:04}"))
+                .start1((60 - i) * 100 + 1)
+                .start2((60 - i) * 100 + 51)
+                .build();
+        }
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = dir.path().join("in.bam");
+        builder.write_bam(&input).expect("write bam");
+
+        let run = |st: Option<usize>, mt: Option<usize>, out: PathBuf| {
+            let mut sort = make_sort(SortOrderArg::Coordinate);
+            sort.input = input.clone();
+            sort.output = Some(out.clone());
+            sort.threads = 2;
+            sort.sort_threads = st;
+            sort.merge_threads = mt;
+            sort.execute("fgumi sort (test)").expect("sort should succeed");
+            std::fs::read(&out).expect("read output")
+        };
+
+        let baseline = run(None, None, dir.path().join("baseline.bam"));
+        let actual = run(sort_threads, merge_threads, dir.path().join("actual.bam"));
+        assert_eq!(
+            actual, baseline,
+            "per-phase threads must not change output bytes (sort={sort_threads:?}, \
+             merge={merge_threads:?})",
+        );
+    }
+
     /// Helper to construct a `Sort` struct with a given order.
     fn make_sort(order: SortOrderArg) -> Sort {
         Sort {
@@ -763,6 +891,8 @@ mod tests {
             memory_per_thread: true,
             tmp_dirs: Vec::new(),
             threads: 1,
+            sort_threads: None,
+            merge_threads: None,
             compression: CompressionOptions::default(),
             temp_compression: 1,
             temp_codec: fgumi_sort::SpillCodec::default(),


### PR DESCRIPTION
`fgumi sort` had a single `-@/--threads` sizing both Phase 1 (accumulate/sort/spill) and Phase 2 (merge/write). Those phases contend with different things: Phase 1 competes with whatever feeds the sort, while Phase 2 runs after the producer is finished. A user running `bwa mem -t 32 ... | fgumi sort -@ 8` had no way to cede cores to the aligner during ingest while keeping the merge wide.

## Engine

`SortWorkerPool` gains an `active_worker_limit` and `set_active_workers`. A single pool still spans both phases — sized to the wider of the two counts — and the driver flips the active cap at the ingest/merge boundary. Workers above the cap idle rather than taking new work and re-check the limit within `MAX_BACKOFF_US`, so raising it reactivates them without an explicit wake.

The invariant that makes this safe: a capped worker still drains items it *already holds* and only declines to acquire new work. Held items are per-worker, so a worker that froze while holding work would strand that output with no other worker able to advance it.

`RawExternalSorter` gains `sort_threads`/`merge_threads` builders plus `phase1_threads()`/`phase2_threads()`, each falling back to `threads` independently. The CLI exposes `--sort-threads` / `--merge-threads` with the same defaulting.

This is purely a scheduling knob: output is byte-identical for any split.

## On testing a knob that by definition changes nothing observable

An end-to-end run *cannot* tell a correctly wired flag from one that was parsed and then silently dropped — both produce identical bytes. So the sorter construction is extracted from `execute` into `Sort::build_sorter`, and the wiring is asserted directly on the resolved per-phase counts. I verified that test is non-vacuous by unwiring the flag and confirming it fails; the output-identity test, as expected, does not.

Both properties are covered separately:

- **Wiring** — `build_sorter` resolves each override, and each falls back to `--threads` independently.
- **Output identity** — four asymmetric splits produce byte-identical output to a plain `--threads` run over a spilling multi-chunk merge, exercising both the wider-Phase-1 and wider-Phase-2 pool sizings.
- **Pool behavior** — clamping of the active count, and (on a single pool, the only way to show it) that workers idled by a cap come back online when the cap is raised.

Runall-only halves of the upstream change — `SortSpillDecompress::with_max_concurrency` and the chains builder — are deliberately not ported; they depend on crates that do not exist on `main`.

## Verification

`cargo ci-test` (5557 tests), `cargo ci-fmt`, `cargo ci-lint`, and `RUSTDOCFLAGS="-D warnings" cargo ci-doc` pass. Patch coverage 96%.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added independent thread controls for the sorter’s phase 1 (sort/accumulate/spill) and phase 2 (merge/output).
  - Introduced `--sort-threads` and `--merge-threads` for `fgumi sort`, with safe clamping.
- **Bug Fixes**
  - Ensured varying phase thread settings do not change output bytes.
- **Tests**
  - Added coverage for CLI parsing, phase override fallback/clamping, worker cap enforcement/reactivation, and output consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->