### PR TITLE
fix(group): do not count a failed UMI-assignment group as accepted

### DIFF
--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -1257,6 +1257,12 @@ impl Command for GroupReadsByUmi {
                     no_umi,
                 ) {
                     log::warn!("UMI assignment failed, returning empty group: {e}");
+                    // The caller merges these metrics, so zero the accepted count
+                    // to match the zero records this group contributes. Otherwise
+                    // the grouping metrics report more accepted templates than the
+                    // output BAM holds.
+                    let mut filter_metrics = filter_metrics;
+                    filter_metrics.accepted_templates = 0;
                     #[cfg(feature = "memory-debug")]
                     if debug_memory_flag
                         && let Some(stats) = stats_for_tracking.as_ref() {
@@ -1641,7 +1647,9 @@ impl GroupReadsByUmi {
             .filter(|t| filter_template_raw(t, filter_config, &mut filter_metrics))
             .collect();
 
-        // Merge filter metrics
+        // Merge filter metrics. Remember this group's contribution so it can be
+        // rolled back if UMI assignment fails below and the group emits nothing.
+        let accepted_before_assignment = filter_metrics.accepted_templates;
         total_filter_metrics.merge(&filter_metrics);
 
         if filtered_templates.is_empty() {
@@ -1669,8 +1677,14 @@ impl GroupReadsByUmi {
             filter_config.min_umi_length,
             filter_config.no_umi,
         ) {
-            // Log error but continue processing
+            // Log error but continue processing. The group's filter metrics were
+            // already merged above, so roll back its accepted count: no records
+            // are emitted for this group, and leaving the count in place would
+            // make the `--metrics` grouping file and the run summary claim more
+            // accepted templates than the output BAM actually contains.
             log::warn!("Failed to assign UMI groups: {e}");
+            total_filter_metrics.accepted_templates =
+                total_filter_metrics.accepted_templates.saturating_sub(accepted_before_assignment);
             return Ok(());
         }
 
@@ -2041,6 +2055,15 @@ mod tests {
 
     /// Creates a `GroupReadsByUmi` with common test defaults.
     /// Tests override specific fields as needed via struct update syntax.
+    /// Pull a single named column out of the one-row grouping metrics TSV.
+    fn parse_grouping_metric(text: &str, column: &str) -> Option<u64> {
+        let mut lines = text.lines().filter(|l| !l.trim().is_empty());
+        let header = lines.next()?;
+        let idx = header.split('\t').position(|c| c == column)?;
+        let row = lines.next()?;
+        row.split('\t').nth(idx)?.trim().parse().ok()
+    }
+
     fn test_group_cmd(strategy: Strategy, edits: u32) -> GroupReadsByUmi {
         GroupReadsByUmi {
             io: BamIoOptions {
@@ -2452,6 +2475,79 @@ mod tests {
     // ========================================================================
     // Integration Tests
     // ========================================================================
+
+    /// When UMI assignment fails for a position group, `group` warns, emits zero
+    /// records for that group, and continues. The grouping metrics must not
+    /// still count that group's templates as accepted -- the `--metrics` file
+    /// and the run summary would then claim more accepted templates than the
+    /// output BAM actually contains.
+    ///
+    /// The trigger is a real one: `--strategy paired` requires the RX tag to
+    /// carry two `-`-delimited segments, and a single-segment UMI passes every
+    /// filter before failing in the assigner.
+    ///
+    /// Both execution paths are covered. `--allow-unmapped` forces the threaded
+    /// path (see `should_use_parallel`), which returns an empty group from a
+    /// different early return than the single-threaded path uses.
+    #[rstest]
+    #[case::single_threaded(false)]
+    #[case::threaded(true)]
+    fn test_umi_assignment_failure_does_not_overcount_accepted(
+        #[case] force_parallel_path: bool,
+    ) -> Result<()> {
+        // Single-segment UMIs: accepted by every filter, rejected by the paired
+        // assigner because it needs `<a>-<b>`.
+        let mut records = Vec::new();
+        for i in 0..4 {
+            let (r1, r2) = build_test_pair(&format!("p{i:02}"), 0, 100, 300, 60, 60, "AAAAAAAA");
+            records.push(r1);
+            records.push(r2);
+        }
+
+        let input = create_test_bam(records)?;
+        let paths = TestPaths::new()?;
+
+        let cmd = GroupReadsByUmi {
+            io: BamIoOptions {
+                input: input.path().to_path_buf(),
+                output: paths.output.clone(),
+                async_reader: false,
+            },
+            grouping_metrics: Some(paths.grouping_metrics.clone()),
+            allow_unmapped: force_parallel_path,
+            threading: if force_parallel_path {
+                ThreadingOptions { threads: Some(4) }
+            } else {
+                ThreadingOptions::none()
+            },
+            ..test_group_cmd(Strategy::Paired, 1)
+        };
+
+        cmd.execute("test")?;
+
+        // Assignment failed, so no records are emitted for the group.
+        let output_records = read_bam_records(&paths.output)?;
+        assert!(
+            output_records.is_empty(),
+            "expected no records when UMI assignment fails, got {}",
+            output_records.len(),
+        );
+
+        // The metrics must agree with the BAM rather than with the pre-failure
+        // filter tally.
+        let metrics_text = std::fs::read_to_string(&paths.grouping_metrics)?;
+        // Serialized column name for `UmiGroupingMetrics::accepted_records`.
+        let accepted = parse_grouping_metric(&metrics_text, "accepted_sam_records")
+            .unwrap_or_else(|| panic!("no accepted_sam_records column in:\n{metrics_text}"));
+        assert_eq!(
+            accepted,
+            output_records.len() as u64,
+            "accepted_sam_records ({accepted}) must match the {} records actually written; \
+             metrics:\n{metrics_text}",
+            output_records.len(),
+        );
+        Ok(())
+    }
 
     #[test]
     fn test_groups_reads_correctly_basic() -> Result<()> {


### PR DESCRIPTION
When `assign_umi_groups_impl` errors for a position group, `group` warns, emits zero records for that group, and continues. But both execution paths had already tallied that group's templates as accepted, so the grouping metrics file and the run summary reported more accepted templates than the output BAM actually contained.

Both paths are affected, and they fail differently:

- **Single-threaded** merges the group's filter metrics *before* assignment runs, and the error arm returned without rolling that back.
- **Threaded** returns an empty `ProcessedPositionGroup` with `filter_metrics` intact, so the caller merges the same over-count.

The single-threaded path now subtracts the contribution it recorded; the threaded early return zeroes the accepted count to match the zero records it emits.

## Reachability

The trigger is data-driven rather than hypothetical: `--strategy paired` requires the RX tag to carry two `-`-delimited segments, and a single-segment UMI passes every filter — non-PF, mapping quality, Ns, minimum length — before failing in the assigner.

## Testing

End-to-end on both paths, asserting the reported accepted count against **the number of records actually written**, not against a literal. `--allow-unmapped` forces the threaded path via `should_use_parallel`, whose empty-group early return is a different code path from the single-threaded one.

Verified non-vacuous by reverting each fix in turn: both then report 8 accepted against 0 records written.

`cargo ci-test` (5536 tests), `cargo ci-fmt`, `cargo ci-lint`, `RUSTDOCFLAGS="-D warnings" cargo ci-doc` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected grouping metrics so accepted-record counts remain accurate when UMI assignment fails.
  * Ensured failed assignments do not report records that were not written to the output BAM.
  * Applied the fix consistently to both threaded and single-threaded processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->