### PR TITLE
fix(consensus): error on an over-long consensus read name instead of panicking

### DIFF
--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -1341,10 +1341,11 @@ impl CodecConsensusCaller {
     }
 
     /// Builds the output record from the consensus and writes raw bytes into `output`.
-    #[expect(
-        clippy::unnecessary_wraps,
-        reason = "Result return type kept for API consistency with other callers"
-    )]
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `<prefix>:<UMI>` read name exceeds BAM's
+    /// 254-byte limit, which an over-long input-derived `umi` can cause.
     #[expect(
         clippy::too_many_arguments,
         reason = "all_records needed separately from source_raws for UMI consensus"
@@ -1370,12 +1371,15 @@ impl CodecConsensusCaller {
         // Codec always outputs unmapped fragments
         let flag = flags::UNMAPPED;
 
-        self.bam_builder.build_record(
+        // The UMI comes from the input BAM, so an over-long name is bad data,
+        // not a bug: return an error rather than panicking partway through
+        // writing the output.
+        self.bam_builder.try_build_record(
             read_name.as_bytes(),
             flag,
             &consensus.bases,
             &consensus.quals,
-        );
+        )?;
 
         // RG tag
         self.bam_builder.append_string_tag(SamTag::RG, self.read_group_id.as_bytes());

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -1041,6 +1041,11 @@ impl DuplexConsensusCaller {
     /// * `first_of_pair` - Whether this is first of pair (for RX orientation)
     /// * `cell_tag` - Optional cell barcode tag (e.g., CB)
     /// * `cell_barcode` - Optional cell barcode value to add to record
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `<prefix>:<UMI>` read name exceeds BAM's
+    /// 254-byte limit, which an over-long input-derived `umi` can cause.
     #[expect(
         clippy::too_many_arguments,
         reason = "duplex record construction requires many parameters from the calling context"
@@ -1048,10 +1053,6 @@ impl DuplexConsensusCaller {
     #[expect(
         clippy::too_many_lines,
         reason = "BAM record construction has many sequential tag-writing steps"
-    )]
-    #[expect(
-        clippy::unnecessary_wraps,
-        reason = "Result return type kept for API consistency with other consensus record builders"
     )]
     pub(crate) fn duplex_read_into(
         builder: &mut UnmappedSamBuilder,
@@ -1085,7 +1086,9 @@ impl DuplexConsensusCaller {
 
         // Build the record (name, flags, bases, quals)
         let read_name = format!("{read_name_prefix}:{umi}");
-        builder.build_record(read_name.as_bytes(), flag, &consensus.bases, &consensus.quals);
+        // The UMI is input-derived, so an over-long name is bad data rather than
+        // a bug; propagate instead of panicking mid-write.
+        builder.try_build_record(read_name.as_bytes(), flag, &consensus.bases, &consensus.quals)?;
 
         // 1. MI tag (string)
         builder.append_string_tag(SamTag::MI, umi.as_bytes());

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -1318,7 +1318,7 @@ impl VanillaUmiConsensusCaller {
             &depths,
             &errors,
             methylation.as_ref(),
-        );
+        )?;
 
         Ok((true, surviving_count, surviving_reads))
     }
@@ -1433,6 +1433,11 @@ impl VanillaUmiConsensusCaller {
     }
 
     /// Builds a consensus record as raw BAM bytes and writes it into a `ConsensusOutput`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `<prefix>:<UMI>` read name exceeds BAM's
+    /// 254-byte limit, which an over-long input-derived `umi` can cause.
     #[expect(
         clippy::too_many_arguments,
         reason = "consensus record building requires many parameters from the calling context"
@@ -1448,7 +1453,7 @@ impl VanillaUmiConsensusCaller {
         depths: &[u16],
         errors: &[u16],
         methylation: Option<&crate::methylation::MethylationAnnotation>,
-    ) {
+    ) -> Result<()> {
         let read_name = format!("{}:{}", self.read_name_prefix, umi);
 
         let mut flag = flags::UNMAPPED;
@@ -1462,7 +1467,9 @@ impl VanillaUmiConsensusCaller {
             ReadType::Fragment => {}
         }
 
-        self.bam_builder.build_record(read_name.as_bytes(), flag, bases, quals);
+        // The UMI is input-derived, so an over-long name is bad data rather than
+        // a bug; propagate instead of panicking mid-write.
+        self.bam_builder.try_build_record(read_name.as_bytes(), flag, bases, quals)?;
 
         // RG tag
         self.bam_builder.append_string_tag(SamTag::RG, self.read_group_id.as_bytes());
@@ -1545,6 +1552,7 @@ impl VanillaUmiConsensusCaller {
         // Write record with block_size prefix
         self.bam_builder.write_with_block_size(&mut output.data);
         output.count += 1;
+        Ok(())
     }
 }
 
@@ -4600,6 +4608,65 @@ mod tests {
 
         // This should panic - can't pad to smaller length
         let _ = read.padded_default(7, true);
+    }
+
+    /// A consensus read name is `<prefix>:<UMI>` and the UMI comes straight from
+    /// the input BAM's MI tag, so its length is data-controlled. An over-long
+    /// UMI must surface as an error, not abort the command with a Rust panic
+    /// partway through writing the output BAM and leave a truncated file behind.
+    ///
+    /// The boundary is exact: BAM stores the name length in one byte including
+    /// the NUL, so `prefix:` plus the UMI must stay at 254 bytes or fewer.
+    #[rstest]
+    #[case::just_fits(244, true)]
+    #[case::one_too_long(245, false)]
+    #[case::absurdly_long(4096, false)]
+    fn test_over_long_umi_errors_instead_of_panicking(
+        #[case] umi_len: usize,
+        #[case] expect_ok: bool,
+    ) {
+        // "consensus:" is 10 bytes, so a 244-byte UMI lands exactly on the 254 limit.
+        let umi = vec![b'A'; umi_len];
+        let mut b1 = SamBuilder::new();
+        b1.read_name(b"read1")
+            .ref_id(0)
+            .pos(0)
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+            .sequence(b"ACGT")
+            .qualities(&[30, 30, 30, 30])
+            .cigar_ops(&[encode_op(0, 4)])
+            .add_string_tag(SamTag::MI, &umi);
+        let r1 = b1.build();
+
+        let mut b2 = SamBuilder::new();
+        b2.read_name(b"read1")
+            .ref_id(0)
+            .pos(0)
+            .flags(flags::PAIRED | flags::LAST_SEGMENT)
+            .sequence(b"ACGT")
+            .qualities(&[30, 30, 30, 30])
+            .cigar_ops(&[encode_op(0, 4)])
+            .add_string_tag(SamTag::MI, &umi);
+        let r2 = b2.build();
+
+        let options = VanillaUmiConsensusOptions {
+            min_reads: 1,
+            min_consensus_base_quality: 0,
+            ..Default::default()
+        };
+        let mut caller =
+            VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
+
+        // `consensus_reads` returns Result, so a too-long name must come back as
+        // Err. If the assertion path were still in play this would panic and the
+        // test would fail rather than report a clean error.
+        let result = caller.consensus_reads(vec![r1, r2]);
+
+        assert_eq!(result.is_ok(), expect_ok, "UMI of {umi_len} bytes: expected ok={expect_ok}",);
+        if let Err(e) = result {
+            let msg = format!("{e:#}");
+            assert!(msg.contains("read name too long"), "unexpected error for {umi_len}: {msg}");
+        }
     }
 
     /// Test that statistics are counted correctly without double-counting.

--- a/crates/fgumi-raw-bam/src/builder.rs
+++ b/crates/fgumi-raw-bam/src/builder.rs
@@ -9,6 +9,29 @@ use crate::tags::{
     append_u16_array_tag,
 };
 
+/// A read name that does not fit BAM's single-byte name-length field.
+///
+/// BAM stores `l_read_name` as a `u8` that counts the trailing NUL, so a name
+/// of 255 bytes or more cannot be represented.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReadNameTooLong {
+    /// Length of the offending name, in bytes.
+    pub len: usize,
+}
+
+impl std::fmt::Display for ReadNameTooLong {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "read name too long ({} bytes, max 254); BAM stores the name length in one byte \
+             including its NUL terminator",
+            self.len
+        )
+    }
+}
+
+impl std::error::Error for ReadNameTooLong {}
+
 // ============================================================================
 // Unmapped BAM Record Builder
 // ============================================================================
@@ -67,6 +90,50 @@ impl UnmappedSamBuilder {
         self.sealed = false;
     }
 
+    /// Fallible counterpart to [`Self::build_record`] for names that come from
+    /// input data rather than from the caller.
+    ///
+    /// Consensus read names are `<prefix>:<UMI>`, and the UMI is read from the
+    /// input BAM's `MI`/`RX` tag. A long or malformed UMI is therefore
+    /// attacker- or accident-controlled, and letting it reach the length
+    /// assertion aborts the whole command with a Rust panic partway through
+    /// writing the output BAM, leaving a truncated file. Callers handling
+    /// data-derived names should use this and propagate the error instead.
+    ///
+    /// On success this writes exactly what [`Self::build_record`] would; see
+    /// that method for the record layout and argument meanings.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `name` is 255 bytes or longer; BAM stores the name
+    /// length in a single byte including its NUL terminator, so 254 is the
+    /// maximum.
+    ///
+    /// On failure the builder is reset, exactly as [`Self::build_record`]
+    /// leaves it when its own length assertion fires, so a caller that ignores
+    /// the error cannot append tags onto — and re-emit — the previous record.
+    ///
+    /// # Panics
+    ///
+    /// Only the name length is checked. This still panics, like
+    /// [`Self::build_record`], if `quals` is non-empty and
+    /// `bases.len() != quals.len()`, which is a caller bug rather than bad
+    /// input.
+    pub fn try_build_record(
+        &mut self,
+        name: &[u8],
+        flag: u16,
+        bases: &[u8],
+        quals: &[u8],
+    ) -> Result<(), ReadNameTooLong> {
+        if name.len() >= 255 {
+            self.clear();
+            return Err(ReadNameTooLong { len: name.len() });
+        }
+        self.build_record(name, flag, bases, quals);
+        Ok(())
+    }
+
     /// Write the 32-byte fixed header, read name, packed sequence, and
     /// quality scores for an unmapped record.
     ///
@@ -87,6 +154,10 @@ impl UnmappedSamBuilder {
     /// # Panics
     ///
     /// Panics if `quals` is non-empty and `bases.len() != quals.len()`.
+    ///
+    /// Panics if `name` is 255 bytes or longer. Use [`Self::try_build_record`]
+    /// when the name is derived from input data, where an over-long name is bad
+    /// input rather than a bug.
     pub fn build_record(&mut self, name: &[u8], flag: u16, bases: &[u8], quals: &[u8]) {
         assert!(
             bases.len() == quals.len() || quals.is_empty(),
@@ -594,6 +665,74 @@ mod tests {
     use crate::tags::*;
     use crate::testutil::*;
     use fgumi_tag::SamTag;
+    use rstest::rstest;
+
+    // ── try_build_record: data-derived names must error, not panic ───────────
+
+    /// Consensus read names are `<prefix>:<UMI>` with the UMI read from the
+    /// input BAM, so an over-long name is bad input rather than a bug. It must
+    /// come back as a typed error; the asserting `build_record` would abort the
+    /// command partway through writing the output BAM.
+    #[rstest]
+    #[case::at_limit(254, true)]
+    #[case::one_over(255, false)]
+    #[case::far_over(1024, false)]
+    #[case::empty(0, true)]
+    fn test_try_build_record_rejects_over_long_names(
+        #[case] name_len: usize,
+        #[case] expect_ok: bool,
+    ) {
+        let mut builder = UnmappedSamBuilder::new();
+        let name = vec![b'N'; name_len];
+        let result = builder.try_build_record(&name, 4, b"ACGT", &[30, 30, 30, 30]);
+
+        assert_eq!(
+            result.is_ok(),
+            expect_ok,
+            "name of {name_len} bytes: expected ok={expect_ok}, got {result:?}",
+        );
+        if let Err(e) = result {
+            assert_eq!(e.len, name_len, "the error should report the offending length");
+            assert!(e.to_string().contains("read name too long"), "unhelpful error message: {e}");
+        }
+    }
+
+    /// A name accepted by `try_build_record` must produce exactly the record
+    /// `build_record` would have, so routing the fallible path through it is
+    /// not a behavior change for valid input.
+    #[test]
+    fn test_try_build_record_matches_build_record_for_valid_names() {
+        let name = b"prefix:ACGTACGT";
+
+        let mut fallible = UnmappedSamBuilder::new();
+        fallible.try_build_record(name, 4, b"ACGT", &[30, 31, 32, 33]).expect("valid name");
+        let fallible_bytes = fallible.as_bytes().to_vec();
+
+        let mut asserting = UnmappedSamBuilder::new();
+        asserting.build_record(name, 4, b"ACGT", &[30, 31, 32, 33]);
+
+        assert_eq!(fallible_bytes, asserting.as_bytes(), "record bytes must be identical");
+    }
+
+    /// The builder is reused across records, so a rejected name must not leave
+    /// the previous record sealed in the buffer: a caller that ignores the
+    /// error would otherwise append tags onto, and re-emit, the prior record.
+    #[test]
+    fn test_try_build_record_resets_builder_on_rejection() {
+        let mut builder = UnmappedSamBuilder::new();
+        builder.build_record(b"first", 4, b"ACGT", &[30, 30, 30, 30]);
+        assert!(!builder.as_bytes().is_empty(), "precondition: a record was built");
+
+        let too_long = vec![b'N'; 255];
+        builder
+            .try_build_record(&too_long, 4, b"ACGT", &[30, 30, 30, 30])
+            .expect_err("a 255-byte name must be rejected");
+
+        // Inspect the fields directly: `as_bytes` debug-asserts that the
+        // builder is sealed, which is exactly the state under test.
+        assert!(builder.buf.is_empty(), "the rejected call must clear the prior record");
+        assert!(!builder.sealed, "the rejected call must leave the builder unsealed");
+    }
 
     #[test]
     fn test_builder_basic_unmapped_record() {

--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -62,7 +62,7 @@ pub use fields::{
 pub use bin::{UNMAPPED_BIN, bin_from_raw_bam, reg2bin, set_bin_from_raw_bam};
 
 // -- builder --
-pub use builder::{SamBuilder, UnmappedSamBuilder};
+pub use builder::{ReadNameTooLong, SamBuilder, UnmappedSamBuilder};
 
 // -- cigar --
 #[cfg(feature = "noodles")]


### PR DESCRIPTION
Consensus read names are `<prefix>:<UMI>`, and the UMI is read from the input BAM's `MI`/`RX` tag — so its length is data-controlled. `UnmappedSamBuilder` asserted the BAM name limit, which meant a long or malformed UMI aborted `fgumi duplex`, `fgumi codec`, or `fgumi simplex` with a Rust panic **partway through writing the output BAM**, leaving a truncated file instead of failing cleanly.

Adds `UnmappedSamBuilder::try_build_record` and a `ReadNameTooLong` error, and routes all three consensus callers through it. `build_record` keeps the assertion for callers that supply their own names — tests, fixtures — and now documents that it panics and points at the fallible variant.

## Propagation

`build_consensus_record_into` (vanilla) becomes fallible; its caller already returns `Result`, so this propagates without restructuring.

The duplex and codec builders already returned `Result` — but only decoratively, as their own attributes recorded:

```rust
#[expect(clippy::unnecessary_wraps,
         reason = "Result return type kept for API consistency with other callers")]
```

Those expectations are now *unfulfilled*, because the functions can genuinely fail. Clippy flagged them, which is a nice independent confirmation that the `Result` became real rather than ornamental. Both are removed.

## Boundary

BAM stores `l_read_name` in a single byte including the NUL terminator, so the limit is 254. With the 10-byte `consensus:` prefix that puts the exact boundary at a 244-byte UMI accepted and 245 rejected — pinned as test cases rather than described.

Covered at the builder level (at-limit, one-over, far-over, empty, plus byte-identical output against `build_record` for valid names) and end-to-end through the caller. Reverting the fix makes the end-to-end cases panic inside the builder, which is precisely the reported failure mode.

`cargo ci-test` (5542 tests), `cargo ci-fmt`, `cargo ci-lint`, `RUSTDOCFLAGS="-D warnings" cargo ci-doc` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fallible unmapped BAM record builder API that rejects overlong read names with a dedicated `ReadNameTooLong` error.

* **Bug Fixes**
  * Record construction now fails gracefully when read names are invalid/too long, avoiding panics and preventing malformed output.
  * Consensus and duplex/codec writing paths now propagate record-construction errors instead of assuming success.

* **Tests**
  * Added tests covering rejection and error messaging for overlong UMI-derived read names, plus byte-identical output for valid boundary cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->