### PR TITLE
test(consensus): pin that the per-base error count stays exact on deep pileups

### DIFF
--- a/crates/fgumi-consensus/src/base_builder.rs
+++ b/crates/fgumi-consensus/src/base_builder.rs
@@ -493,6 +493,41 @@ impl ConsensusBaseBuilder {
 mod tests {
     use super::*;
 
+    /// The per-base error count in the consensus callers is
+    /// `contributions() - observations_for_base(base)`. Both operands must stay
+    /// unsaturated `u32` counters: the callers clamp only the *stored* cD/cE
+    /// values to fgbio's `Short` ceiling, and clamping the operands instead
+    /// would collapse the difference toward zero on a deep pileup and understate
+    /// cE. This pins that on a pileup deep enough that a `u16`/`i16` counter
+    /// would have saturated.
+    #[test]
+    fn test_deep_pileup_keeps_error_count_exact_past_the_short_ceiling() {
+        let short_ceiling = u32::from(i16::MAX.unsigned_abs()); // 32_767
+        let matching = short_ceiling + 5_000;
+        let mismatching = short_ceiling + 1_000;
+
+        let mut builder = ConsensusBaseBuilder::new(45, 40);
+        for _ in 0..matching {
+            builder.add(b'A', 30);
+        }
+        for _ in 0..mismatching {
+            builder.add(b'C', 30);
+        }
+
+        let depth = builder.contributions();
+        assert_eq!(depth, matching + mismatching, "depth must not saturate");
+        assert!(depth > short_ceiling, "precondition: the pileup exceeds the Short ceiling");
+
+        let (base, _qual) = builder.call();
+        assert_eq!(base, b'A', "the majority base should win");
+
+        // The subtraction is exact because neither operand is clamped. Were both
+        // saturated at the ceiling first, this difference would collapse to 0.
+        let error_count = depth - builder.observations_for_base(base);
+        assert_eq!(error_count, mismatching, "error count must be exact, not a clamped difference");
+        assert_ne!(error_count, 0, "a saturated-operand subtraction would collapse to zero here");
+    }
+
     #[test]
     fn test_single_base_perfect() {
         let mut builder = ConsensusBaseBuilder::new(45, 40);


### PR DESCRIPTION
This was carried on the port list as a suspected **cE collapse on deep mixed pileups** — the concern being that the per-base error count subtracts two operands that are already saturated at the `Short` ceiling, so on a deep enough pileup the difference would collapse toward zero and understate `cE`.

**I investigated and it is not a bug.** No behavior change here; this is the test that pins why.

## Why it does not happen

The error count is computed as:

```rust
let error_count = depth - self.consensus_builder.observations_for_base(base);
```

Both operands are unsaturated `u32` counters — `observations` is `[u32; 4]` and `contributions()` sums it. The clamp to fgbio's `Short` ceiling is applied to the *result*, when the value is pushed into the `errors` array, which is exactly what fgbio does (it stores per-base depths and errors as `Short`). So the subtraction is exact and only the stored value is clamped.

## Why it is still worth a test

The correctness of `cE` on deep families depends entirely on those two operands staying wide, and nothing pinned that. Narrowing `observations` to a saturating `u16` — a plausible "memory optimization" — would silently collapse the difference toward zero on exactly the deepest families, where the metric matters most, with no test failing.

The test builds a pileup where both the matching and mismatching counts individually exceed the `Short` ceiling (70,534 contributions total) and asserts the error count comes back exact at 36,767, rather than the 0 a saturated-operand subtraction would produce.

Wave 1 separately verified that per-base `aD`/`bD`/`ae`/`be` clamp correctly via `clamp_per_base_to_fgbio_short` with `i64` intermediates, so this closes out the last open question in that area.

`cargo ci-test` (5535 tests), `cargo ci-fmt`, `cargo ci-lint`, `RUSTDOCFLAGS="-D warnings" cargo ci-doc` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy when processing extremely deep sequencing pileups.
  * Error counts now remain exact beyond the previous observation-count ceiling, preventing mismatches from being incorrectly reported as zero.

* **Tests**
  * Added regression coverage for deep pileups with a dominant base and mismatching observations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->