### PR TITLE
perf: remove three per-block and per-read allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -726,6 +726,7 @@ dependencies = [
  "crc32fast",
  "criterion",
  "libdeflater",
+ "rstest",
 ]
 
 [[package]]

--- a/crates/fgumi-bam-io/src/vendored/bgzf_multithreaded.rs
+++ b/crates/fgumi-bam-io/src/vendored/bgzf_multithreaded.rs
@@ -482,7 +482,15 @@ fn compress_block(
         buffer[buffer.len() - 5],
     ]);
 
-    Ok((buffer.clone(), crc32, input.len()))
+    // Hand the compressed frame off instead of copying it: `buffer.clone()` was a
+    // full memcpy of up to ~64 KiB on every output block, kept only so the
+    // scratch buffer stayed warm for the next call. Swapping in a fresh buffer
+    // pre-sized to what this frame needed keeps it warm without the copy.
+    //
+    // `mem::take` would be wrong here: it leaves a zero-capacity Vec behind, so
+    // the next frame reallocates from scratch and the optimization regresses.
+    let frame = std::mem::replace(buffer, Vec::with_capacity(buffer.len()));
+    Ok((frame, crc32, input.len()))
 }
 
 fn spawn_writer<W>(

--- a/crates/fgumi-bgzf/Cargo.toml
+++ b/crates/fgumi-bgzf/Cargo.toml
@@ -14,6 +14,7 @@ bgzf = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+rstest = { workspace = true }
 
 [[bench]]
 name = "stored_block_decode"

--- a/crates/fgumi-bgzf/src/reader.rs
+++ b/crates/fgumi-bgzf/src/reader.rs
@@ -143,20 +143,35 @@ impl RawBgzfBlock {
 
 /// Read a single raw BGZF block from the input.
 ///
-/// Returns `Ok(Some(block))` if a block was read, `Ok(None)` at EOF,
-/// or an error if reading failed or the data is invalid.
+/// Returns `Ok(Some(block))` if a block was read, or `Ok(None)` at a clean EOF
+/// -- meaning the stream ended *before* the first header byte. Input that ends
+/// part-way through a block, header included, is truncated rather than finished
+/// and reports `UnexpectedEof`.
 ///
 /// # Errors
 ///
-/// Returns an error if the block header is invalid or reading fails.
+/// Returns an error if the block header is invalid, the block is truncated, or
+/// reading fails.
 fn read_raw_block<R: Read + ?Sized>(reader: &mut R) -> io::Result<Option<RawBgzfBlock>> {
-    // Read the 18-byte header
+    // Read the 18-byte header. Only a stream that ends *before* the first header
+    // byte is a clean EOF; a header that starts and then runs out is truncated
+    // input and must surface as `UnexpectedEof`, the same contract the block-body
+    // length check below enforces. Reading the header with a single `read_exact`
+    // would collapse both cases into `Ok(None)` and silently drop a partial block.
+    // Splitting the header read costs nothing on the paths that matter: every
+    // production caller wraps its input in a `BufReader`, so the one-byte probe is
+    // a buffer memcpy rather than a second syscall.
     let mut header = [0u8; BGZF_HEADER_SIZE];
-    match reader.read_exact(&mut header) {
-        Ok(()) => {}
-        Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => return Ok(None),
-        Err(e) => return Err(e),
+    loop {
+        match reader.read(&mut header[..1]) {
+            Ok(0) => return Ok(None),
+            Ok(_) => break,
+            // `read` (unlike `read_exact`) surfaces `Interrupted` to the caller.
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
     }
+    reader.read_exact(&mut header[1..])?;
 
     // Validate gzip magic bytes
     if header[0] != 0x1f || header[1] != 0x8b {
@@ -206,12 +221,24 @@ fn read_raw_block<R: Read + ?Sized>(reader: &mut R) -> io::Result<Option<RawBgzf
         ));
     }
 
-    // Allocate buffer and copy header
-    let mut data = vec![0u8; block_size];
-    data[..BGZF_HEADER_SIZE].copy_from_slice(&header);
+    // Reserve exactly what the block needs and fill it, rather than
+    // `vec![0u8; block_size]`, which memsets up to 64 KiB that is immediately
+    // overwritten.
+    let mut data = Vec::with_capacity(block_size);
+    data.extend_from_slice(&header);
 
-    // Read remaining block data
-    reader.read_exact(&mut data[BGZF_HEADER_SIZE..])?;
+    // Read remaining block data. `read_to_end` on a bounded `take` avoids
+    // pre-zeroing, but unlike `read_exact` it returns `Ok` on early EOF, so the
+    // length must be checked explicitly -- without this a truncated BAM would
+    // silently short-read instead of erroring.
+    let remaining = block_size - BGZF_HEADER_SIZE;
+    reader.take(remaining as u64).read_to_end(&mut data)?;
+    if data.len() != block_size {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            format!("truncated BGZF block: expected {block_size} bytes, got {}", data.len()),
+        ));
+    }
 
     Ok(Some(RawBgzfBlock { data }))
 }
@@ -593,7 +620,98 @@ fn copy_stored_and_verify(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
     use std::io::Cursor;
+
+    /// Compress `payload` into a single BGZF block and return its raw bytes.
+    fn single_block_bytes(payload: &[u8]) -> Vec<u8> {
+        let mut compressor = crate::writer::InlineBgzfCompressor::new(1);
+        compressor.write_all(payload).expect("buffer payload");
+        compressor.flush().expect("flush to a block");
+        let mut bytes = Vec::new();
+        compressor.write_blocks_to(&mut bytes).expect("emit block bytes");
+        bytes
+    }
+
+    /// `read_raw_block` reserves capacity and fills with `read_to_end` rather
+    /// than `vec![0u8; block_size]`, avoiding a memset of up to 64 KiB that is
+    /// immediately overwritten. Unlike `read_exact`, `read_to_end` returns `Ok`
+    /// on early EOF, so the explicit length check is what keeps a truncated BAM
+    /// from silently short-reading. Without it this test would see `Ok(Some(..))`
+    /// carrying a short block.
+    #[test]
+    fn test_read_raw_block_rejects_a_truncated_block() {
+        // Build a well-formed block, then cut bytes off the end.
+        let full = single_block_bytes(b"the quick brown fox jumps over the lazy dog");
+        assert!(full.len() > BGZF_HEADER_SIZE + BGZF_FOOTER_SIZE, "need a real block");
+
+        // Full block round-trips.
+        let mut cursor = Cursor::new(full.clone());
+        let block = read_raw_block(&mut cursor).expect("full block should read").expect("a block");
+        let full_len = block.data.len();
+
+        // Dropping even one byte must be an error, not a short block.
+        let truncated = full[..full_len - 1].to_vec();
+        let mut cursor = Cursor::new(truncated);
+        let err = read_raw_block(&mut cursor)
+            .expect_err("a truncated block must error rather than short-read");
+        assert_eq!(
+            err.kind(),
+            io::ErrorKind::UnexpectedEof,
+            "expected UnexpectedEof for a truncated block, got: {err}",
+        );
+    }
+
+    /// A stream that ends before the first header byte is a clean EOF -- the
+    /// only case that may report `Ok(None)`.
+    #[test]
+    fn test_read_raw_block_reports_eof_on_an_empty_stream() {
+        let mut cursor = Cursor::new(Vec::new());
+        assert!(
+            read_raw_block(&mut cursor).expect("empty stream is a clean EOF").is_none(),
+            "an empty stream must read as EOF, not a block",
+        );
+    }
+
+    /// A header that starts and then runs out is truncated input, not EOF. Every
+    /// non-empty prefix shorter than a full header must surface `UnexpectedEof`,
+    /// the same contract the block-body length check enforces. The value list is
+    /// exhaustive over `1..BGZF_HEADER_SIZE`; the assertion below fails loudly if
+    /// the constant ever changes out from under it.
+    #[rstest]
+    fn test_read_raw_block_rejects_a_partial_header(
+        #[values(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17)] prefix_len: usize,
+    ) {
+        assert_eq!(BGZF_HEADER_SIZE, 18, "prefix_len values must cover 1..BGZF_HEADER_SIZE");
+
+        let full = single_block_bytes(b"payload behind a header that gets cut short");
+        let mut cursor = Cursor::new(full[..prefix_len].to_vec());
+        let err = read_raw_block(&mut cursor)
+            .expect_err("a partial header must error rather than read as EOF");
+        assert_eq!(
+            err.kind(),
+            io::ErrorKind::UnexpectedEof,
+            "expected UnexpectedEof for a {prefix_len}-byte header prefix, got: {err}",
+        );
+    }
+
+    /// The block bytes must be byte-identical to what the pre-optimization
+    /// `vec![0u8; n]` + `read_exact` path produced, header included.
+    #[test]
+    fn test_read_raw_block_bytes_match_a_prezeroed_read() {
+        let full = single_block_bytes(b"payload bytes for comparison");
+
+        let mut cursor = Cursor::new(full.clone());
+        let block = read_raw_block(&mut cursor).expect("read").expect("a block");
+
+        // Independent oracle: the block is a prefix of the stream of exactly
+        // its own length, so compare against the raw bytes directly.
+        assert_eq!(
+            block.data.as_slice(),
+            &full[..block.data.len()],
+            "block bytes must match the stream verbatim",
+        );
+    }
 
     #[test]
     fn test_eof_block_detection() {

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -4841,7 +4841,7 @@ mod fgbio_oracle_saturation_tests {
     // CODEC saturation shape is aD == bD == 32767 → cD = 65534 (the cap-before-sum
     // boundary; an uncapped sum would overflow/wrap). The OPEN-interval mixed-strand
     // case (aD != bD) is exercised by the duplex caller, whose /A and /B strand read
-    // sets are independent (see duplex_caller.rs fgbio_oracle_saturation_tests).
+    // sets are independent (see duplex_caller.rs fgbio_oracle_tests).
 
     /// fgumi's CODEC caller, driven on a DEEP fixture, must emit depth/error tags
     /// equal to values CAPTURED FROM A REAL fgbio RUN on the exact same input BAM.

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -1912,14 +1912,18 @@ impl DuplexConsensusCaller {
         // Split filtered results back by firstOfPair flag (matching fgbio lines 347-350)
         // X = AB-R1 + BA-R2, Y = AB-R2 + BA-R1 (combined for alignment filtering)
         // Now split them back into the four groups using sr.flags:
-        let filtered_ab_r1s: Vec<SourceRead> =
-            filtered_xs.iter().filter(|sr| sr.flags & flags::FIRST_SEGMENT != 0).cloned().collect();
-        let filtered_ba_r2s: Vec<SourceRead> =
-            filtered_xs.iter().filter(|sr| sr.flags & flags::FIRST_SEGMENT == 0).cloned().collect();
-        let filtered_ab_r2s: Vec<SourceRead> =
-            filtered_ys.iter().filter(|sr| sr.flags & flags::FIRST_SEGMENT == 0).cloned().collect();
-        let filtered_ba_r1s: Vec<SourceRead> =
-            filtered_ys.iter().filter(|sr| sr.flags & flags::FIRST_SEGMENT != 0).cloned().collect();
+        // The two halves of each split are exact complements on FIRST_SEGMENT, so
+        // `partition` produces the same groups in the same order as the four
+        // filter-and-clone passes it replaces -- without deep-copying every
+        // surviving SourceRead (bases, quals, and two cigar Vecs each).
+        //
+        // Binding order matters: `partition` yields (predicate true, predicate
+        // false), so with `FIRST_SEGMENT != 0` the R1 group always comes first.
+        // Swapping either pair silently transposes the strand groups.
+        let (filtered_ab_r1s, filtered_ba_r2s): (Vec<SourceRead>, Vec<SourceRead>) =
+            filtered_xs.into_iter().partition(|sr| sr.flags & flags::FIRST_SEGMENT != 0);
+        let (filtered_ba_r1s, filtered_ab_r2s): (Vec<SourceRead>, Vec<SourceRead>) =
+            filtered_ys.into_iter().partition(|sr| sr.flags & flags::FIRST_SEGMENT != 0);
 
         debug!(
             "MI {}: After split (filtered_AB-R1={}, filtered_AB-R2={}, filtered_BA-R1={}, filtered_BA-R2={})",
@@ -6375,14 +6379,18 @@ mod tests {
 }
 
 // ============================================================================
-// fgbio-oracle saturation tests (offline-pinned)
+// fgbio-oracle tests (offline-pinned)
 //
-// These tests drive fgumi's own duplex caller on a DEEP fixture and assert the
+// These tests drive fgumi's own duplex caller on a fixture and assert the
 // emitted depth/error tags equal values CAPTURED FROM A REAL fgbio RUN on the
 // exact same input BAM, rather than re-derived from the implementation's own
 // formula. This closes the CodeRabbit finding that the hand-authored saturation
 // tests "repeat the implementation's expected formulas, so a shared
 // misunderstanding of fgbio's cap-before-sum behavior would still pass".
+//
+// Two families live here: the DEEP saturation fixtures that pin fgbio's
+// cap-before-sum behavior, and the small strand-split fixtures that pin which
+// group each alignment-filtered read lands in.
 //
 // Equivalence: one `fgumi_sam::builder::SamBuilder` produces the fixture and
 // writes ONE BAM. That exact file is (1) what the offline fgbio run consumes and
@@ -6390,7 +6398,7 @@ mod tests {
 // `regen_*` tests to re-emit the fixture BAM for a fresh fgbio capture.
 // ============================================================================
 #[cfg(test)]
-mod fgbio_oracle_saturation_tests {
+mod fgbio_oracle_tests {
     use super::*;
     use crate::oracle_test_support::{ExpectedOracleTags, records_from_builder, regen_write};
     use fgumi_raw_bam::ParsedBamRecord;
@@ -6562,6 +6570,112 @@ mod fgbio_oracle_saturation_tests {
         expected.assert_matches(rec);
     }
 
+    /// fgumi's strand split -- the partition that puts each alignment-filtered
+    /// read back into its AB-R1 / AB-R2 / BA-R1 / BA-R2 group -- must place reads
+    /// exactly where fgbio places them. Assertions cover BOTH consensus records
+    /// because the two records are fed by DIFFERENT partitions: the R1 duplex
+    /// record's strands come from the X split (AB-R1 and BA-R2), the R2 record's
+    /// from the Y split (AB-R2 and BA-R1). A single record would leave one of the
+    /// two partitions unpinned.
+    ///
+    /// The `3`/`2` case is what makes a transposed binding visible: the strands
+    /// carry different depths, so swapping either partition's halves swaps aD/bD
+    /// on the affected record, and the AB-R1-only error moves from `aE`/`ae` to
+    /// `bE`/`be`. The `1`/`1` case pins the min-reads floor -- one pair per strand
+    /// is the smallest input this caller (`min_reads = [1]`) accepts.
+    ///
+    /// Oracle provenance is the same fgbio jar and invocation as
+    /// `duplex_saturation_matches_fgbio_oracle`; re-emit the fixtures with the
+    /// matching `#[ignore]`d `regen_duplex_strand_split_*` tests.
+    #[rstest]
+    // 3 /A pairs (one with a disagreeing R1 base) and 2 /B pairs. R1 record:
+    // aD = 3 (AB-R1), bD = 2 (BA-R2), and the injected error lands on the AB
+    // strand only (ae[0] = 1, aE = 1/24). R2 record: aD = 3 (AB-R2), bD = 2
+    // (BA-R1), no errors -- the variant was injected into R1s only.
+    #[case::asymmetric_depths_with_ab_r1_error(
+        3, 2, "ACGTACGT", Some("CCGTACGT"), 1,
+        ExpectedOracleTags {
+            cd: 5, cm: 5, ce: 0.025,
+            ad: 3, am: 3, ae: 0.041_666_7,
+            bd: 2, bm: 2, be: 0.0,
+            ad_bases: vec![3; 8], bd_bases: vec![2; 8],
+            ae_bases: vec![1, 0, 0, 0, 0, 0, 0, 0], be_bases: vec![0; 8],
+        },
+        ExpectedOracleTags {
+            cd: 5, cm: 5, ce: 0.0,
+            ad: 3, am: 3, ae: 0.0,
+            bd: 2, bm: 2, be: 0.0,
+            ad_bases: vec![3; 8], bd_bases: vec![2; 8],
+            ae_bases: vec![0; 8], be_bases: vec![0; 8],
+        },
+    )]
+    // One pair per strand: the minimum input `min_reads = [1]` accepts. Each of
+    // the four groups holds exactly one read, so every depth is 1.
+    #[case::one_pair_per_strand(
+        1, 1, "ACGTACGT", None, 0,
+        ExpectedOracleTags {
+            cd: 2, cm: 2, ce: 0.0,
+            ad: 1, am: 1, ae: 0.0,
+            bd: 1, bm: 1, be: 0.0,
+            ad_bases: vec![1; 8], bd_bases: vec![1; 8],
+            ae_bases: vec![0; 8], be_bases: vec![0; 8],
+        },
+        ExpectedOracleTags {
+            cd: 2, cm: 2, ce: 0.0,
+            ad: 1, am: 1, ae: 0.0,
+            bd: 1, bm: 1, be: 0.0,
+            ad_bases: vec![1; 8], bd_bases: vec![1; 8],
+            ae_bases: vec![0; 8], be_bases: vec![0; 8],
+        },
+    )]
+    fn duplex_strand_split_matches_fgbio_oracle(
+        #[case] n_ab: usize,
+        #[case] n_ba: usize,
+        #[case] bases: &str,
+        #[case] variant: Option<&str>,
+        #[case] variant_count: usize,
+        #[case] expected_r1: ExpectedOracleTags,
+        #[case] expected_r2: ExpectedOracleTags,
+    ) {
+        let builder =
+            build_duplex_fixture(n_ab, n_ba, bases, variant, variant_count, NON_OVERLAP_R2_START);
+        let records = records_from_builder(&builder);
+        let mut caller = duplex_caller();
+        let output = caller.consensus_reads(records).expect("duplex consensus succeeds");
+        let parsed = ParsedBamRecord::parse_all(&output.data);
+        assert_eq!(parsed.len(), 2, "duplex emits R1 and R2 consensus records");
+
+        let r1 = parsed
+            .iter()
+            .find(|r| r.flag & flags::FIRST_SEGMENT != 0)
+            .expect("R1 (first-of-pair) consensus present");
+        expected_r1.assert_matches(r1);
+        let r2 = parsed
+            .iter()
+            .find(|r| r.flag & flags::FIRST_SEGMENT == 0)
+            .expect("R2 (second-of-pair) consensus present");
+        expected_r2.assert_matches(r2);
+    }
+
+    /// The empty-strand boundary: with only /A pairs present the BA groups of both
+    /// partitions come out empty, and `min_reads = [1]` (padded to `[1, 1, 1]`)
+    /// requires at least one read on EACH strand. fgbio emits zero consensus reads
+    /// for this fixture ("Consensus reads emitted: 0" on the same jar and
+    /// invocation as the cases above), so fgumi must emit zero too rather than
+    /// falling back to a single-strand consensus.
+    #[test]
+    fn duplex_empty_ba_strand_emits_nothing_like_fgbio() {
+        let builder = build_duplex_fixture(2, 0, "ACGTACGT", None, 0, NON_OVERLAP_R2_START);
+        let records = records_from_builder(&builder);
+        let mut caller = duplex_caller();
+        let output = caller.consensus_reads(records).expect("duplex consensus succeeds");
+        assert_eq!(output.count, 0, "an empty BA strand must yield no consensus reads");
+        assert!(
+            ParsedBamRecord::parse_all(&output.data).is_empty(),
+            "no consensus records may be emitted when one strand is empty",
+        );
+    }
+
     /// Re-emit the duplex open-interval depth-saturation fixture BAM for fgbio.
     #[test]
     #[ignore = "regen: writes the fixture BAM (set FGUMI_ORACLE_BAM_OUT), then run fgbio on it"]
@@ -6581,5 +6695,33 @@ mod fgbio_oracle_saturation_tests {
             33_000,
             NON_OVERLAP_R2_START,
         ));
+    }
+
+    /// Re-emit the asymmetric-depth strand-split fixture BAM for fgbio.
+    #[test]
+    #[ignore = "regen: writes the fixture BAM (set FGUMI_ORACLE_BAM_OUT), then run fgbio on it"]
+    fn regen_duplex_strand_split_fixture() {
+        regen_write(&build_duplex_fixture(
+            3,
+            2,
+            "ACGTACGT",
+            Some("CCGTACGT"),
+            1,
+            NON_OVERLAP_R2_START,
+        ));
+    }
+
+    /// Re-emit the one-pair-per-strand strand-split fixture BAM for fgbio.
+    #[test]
+    #[ignore = "regen: writes the fixture BAM (set FGUMI_ORACLE_BAM_OUT), then run fgbio on it"]
+    fn regen_duplex_strand_split_single_read_fixture() {
+        regen_write(&build_duplex_fixture(1, 1, "ACGTACGT", None, 0, NON_OVERLAP_R2_START));
+    }
+
+    /// Re-emit the empty-BA-strand strand-split fixture BAM for fgbio.
+    #[test]
+    #[ignore = "regen: writes the fixture BAM (set FGUMI_ORACLE_BAM_OUT), then run fgbio on it"]
+    fn regen_duplex_strand_split_empty_strand_fixture() {
+        regen_write(&build_duplex_fixture(2, 0, "ACGTACGT", None, 0, NON_OVERLAP_R2_START));
     }
 }

--- a/crates/fgumi-consensus/src/lib.rs
+++ b/crates/fgumi-consensus/src/lib.rs
@@ -34,8 +34,8 @@ pub mod codec_caller;
 #[cfg(feature = "simplex")]
 pub mod methylation;
 
-/// Shared helpers for the offline-pinned fgbio-oracle saturation tests in the
-/// codec and duplex caller modules. Test-only: depends on the `fgumi-bam-io`
+/// Shared helpers for the offline-pinned fgbio-oracle tests in the codec and
+/// duplex caller modules. Test-only: depends on the `fgumi-bam-io`
 /// and `tempfile` dev-dependencies, so it is gated behind `cfg(test)`. Gated on
 /// `codec`/`duplex` too so it is not compiled (and flagged unused) when neither
 /// caller that uses it is enabled.

--- a/crates/fgumi-consensus/src/oracle_test_support.rs
+++ b/crates/fgumi-consensus/src/oracle_test_support.rs
@@ -1,8 +1,8 @@
-//! Shared test-only helpers for the offline-pinned fgbio-oracle saturation
-//! tests in [`codec_caller`](crate::codec_caller) and
+//! Shared test-only helpers for the offline-pinned fgbio-oracle tests in
+//! [`codec_caller`](crate::codec_caller) and
 //! [`duplex_caller`](crate::duplex_caller).
 //!
-//! Each oracle test drives fgumi's own caller on a DEEP fixture and asserts the
+//! Each oracle test drives fgumi's own caller on a fixture and asserts the
 //! emitted depth/error tags equal values CAPTURED FROM A REAL fgbio RUN on the
 //! exact same input BAM, rather than re-derived from the implementation's own
 //! formula. This closes the CodeRabbit finding that the hand-authored


### PR DESCRIPTION
Three independent allocation removals on hot paths, grouped because none justifies its own PR. **No measured headline numbers** — these are cheap and safe rather than significant, and I have not benchmarked them.

## BGZF multithreaded writer

Each deflater returned `buffer.clone()` — a full memcpy of up to ~64 KiB on every output block, kept only so the scratch buffer stayed warm for the next call. `mem::replace` with a fresh buffer pre-sized to the frame just produced keeps it warm without the copy.

A plain `mem::take` would *regress* this: it leaves a zero-capacity `Vec` behind, so the next frame reallocates from scratch.

## BGZF reader

`read_raw_block` allocated with `vec![0u8; block_size]` — a per-block memset of up to 64 KiB that is immediately overwritten. It now reserves exact capacity and fills via a bounded `read_to_end`.

This one has a sharp edge worth calling out. Unlike `read_exact`, **`read_to_end` returns `Ok` on early EOF**, so the explicit length check is load-bearing: without it a truncated BAM short-reads silently instead of erroring. The added test demonstrates that directly — with the check removed it returns `Ok(Some(block))` carrying a short block rather than `UnexpectedEof`.

## Duplex consensus

`process_group` deep-cloned every alignment-surviving `SourceRead` — bases, quals, and two cigar `Vec`s each — through four `iter().filter().cloned().collect()` passes. The two halves of each split are exact complements on `FIRST_SEGMENT`, so `into_iter().partition(..)` yields the same groups in the same order without copying.

Binding order is the hazard: `partition` returns (predicate true, predicate false), so swapping either pair silently transposes the strand groups. I checked that existing duplex tests catch that by deliberately transposing them — 4 tests fail, including `test_duplex_ba_only_methylation_tags_use_bottom_strand`.

`cargo ci-test` (5536 tests), `cargo ci-fmt`, `cargo ci-lint`, `RUSTDOCFLAGS="-D warnings" cargo ci-doc` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced allocations and eliminated per-block copying during compressed block handling.
  - Optimized raw BGZF block reading and improved efficiency when splitting duplex alignment results.
- **Bug Fixes**
  - More reliably distinguishes clean EOF from truncated BGZF blocks and reports truncation errors.
- **Tests**
  - Expanded oracle coverage for duplex strand splitting and added cases for truncated blocks and partial header scenarios.
- **Chores**
  - Added a dev-only testing dependency and refreshed related test documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->