### PR TITLE
docs(codec): document the CODEC model and its quality-masking options

### DIFF
--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -166,7 +166,40 @@ struct CollectedCodecMetrics {
 #[command(
     name = "codec",
     about = "\x1b[38;5;180m[CONSENSUS]\x1b[0m      \x1b[36mCall CODEC consensus reads from grouped BAM\x1b[0m",
-    long_about = None
+    long_about = r#"
+Calls consensus reads from CODEC (Concatenating Original Duplex for Error Correction) data. CODEC
+libraries place both strands of a source duplex molecule into a single read pair, so unlike `duplex`
+-- which combines two separately sequenced single-strand consensus reads -- the two strands arrive
+already paired: R1 carries one strand and R2 carries the other.
+
+Consequently each input read pair yields at most one consensus fragment, and the duplex evidence
+comes from comparing R1 against R2 rather than from grouping reads across the file. Prior to running
+this tool, reads must have been grouped with `group`.
+
+The consensus reads produced are unaligned fragments, so they should be aligned afterwards.
+
+Quality masking
+---------------
+
+Several options reduce base qualities in regions where the duplex evidence is weaker, rather than
+discarding the bases outright:
+
+  --single-strand-qual         caps quality in regions covered by only one strand, where there is
+                               no duplex confirmation
+  --outer-bases-qual /         caps quality for the first and last --outer-bases-length bases (5 by
+  --outer-bases-length         default) of the fragment, which are the most error-prone
+
+Duplex agreement filters
+------------------------
+
+  --min-duplex-length          minimum overlap, in bases, between the two strands for a fragment to
+                               be emitted (default 1)
+  --max-duplex-disagreement-rate  maximum fraction of overlapping positions where the strands may
+                               disagree (default 1.0, i.e. no limit)
+  --max-duplex-disagreements   maximum absolute count of such disagreements
+
+Note that `--methylation-mode` is not supported for CODEC data.
+"#
 )]
 pub struct Codec {
     /// Input/output BAM options


### PR DESCRIPTION
`fgumi codec --help` had `long_about = None`, so it showed only the one-line about. Nothing explained CODEC's defining property — that both strands of a source duplex molecule arrive in a *single read pair*, R1 carrying one strand and R2 the other, so duplex evidence comes from comparing the two reads rather than from grouping reads across the file the way `duplex` does. That is the thing a user needs in order to know when this command applies.

Nor was anything documented about `--single-strand-qual`, `--outer-bases-qual` / `--outer-bases-length`, `--min-duplex-length`, or the two `--max-duplex-disagreement*` flags — several of which mask quality rather than discard bases, which is not guessable from the flag name. The same hole appeared in the generated Tool Reference.

The new text also notes that `--methylation-mode` is unsupported for CODEC. I verified that rather than taking it on faith: the flag is absent from the command entirely.

## What this PR no longer does

An earlier revision also added an error hint to `codec`, `simplex` and `duplex` telling users to pass `--threads` when the input is uncompressed SAM. **That hint was wrong**, and it has been dropped along with the three tests that asserted it.

Checked against the built binary on `main`: `--threads` does not select a SAM-capable reader. Both paths fail identically, because `create_bam_reader_for_pipeline_with_opts` reads its header through `noodles_bgzf::io::Reader` exactly as `create_raw_bam_reader_with_opts` does, and there is no SAM text path anywhere in `fgumi-bam-io`:

```
$ fgumi simplex -i in.sam -o out.bam --min-reads 1
Error: Failed to read header from: in.sam
Caused by:  invalid BGZF header

$ fgumi simplex -i in.sam -o out.bam --min-reads 1 --threads 4
Error: Failed to read header from: in.sam
Caused by:  invalid BGZF header
```

The wording came from upstream, where `ReadSamChunks`/`ParseSamChunk` genuinely exist — that capability did not survive the port to `main`, so the hint would have sent users to a flag that reproduces the identical error. That is strictly worse than the bare error, which at least already names the file and says `invalid BGZF header`.

The real fix is #642: every command that accepts BAM must accept SAM. That is implemented in a separate PR rather than papered over with a message here.

Removing the hint also restores three helper functions' doc comments, which the deleted tests had been inserted in front of (so e.g. `/// Helper to create a Codec with specified input/output paths` had ended up documenting a test).

`cargo check --all-targets` passes; the change is now confined to `codec.rs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the `fgumi codec` command help text with detailed guidance on CODEC data assumptions.
  * Added documentation for quality masking and duplex agreement filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->