### PR TITLE
fix(zipper): name the tag-skipping flag after the tag it actually writes

### DIFF
--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -182,11 +182,15 @@ pub struct Zipper {
     #[arg(long = "exclude-missing-reads", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub exclude_missing_reads: bool,
 
-    /// Skip adding `pa` (primary alignment) tags to secondary/supplementary reads.
-    /// By default, zipper adds a `pa` tag containing the primary alignment's template
+    /// Skip adding `tc` (template coordinate) tags to secondary/supplementary reads.
+    /// By default, zipper adds a `tc` tag containing the primary alignment's template
     /// sort key coordinates, which enables correct template-coordinate sorting and
     /// deduplication of these reads. Use this flag if you don't need this functionality.
-    #[arg(long = "skip-pa-tags", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    ///
+    /// The former name `--skip-pa-tags` is accepted as an alias. It described a `pa`
+    /// tag that this command has never written, so grepping the output for `pa`
+    /// found nothing; the tag is and always was `tc`.
+    #[arg(long = "skip-tc-tags", alias = "skip-pa-tags", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub skip_tc_tags: bool,
 
     /// Restore unconverted bases in EM-seq consensus reads after bwameth re-alignment.
@@ -532,7 +536,7 @@ pub fn merge_raw(
         fgumi_raw_bam::normalize_int_tag_to_smallest_signed(record.as_mut_vec(), SamTag::XS);
     }
 
-    // Step 6: Add PA tags
+    // Step 6: Add tc (template coordinate) tags
     if !skip_tc_tags {
         add_template_coordinate_tags_raw(mapped);
     }
@@ -3677,9 +3681,19 @@ mod tests {
         assert_eq!(cmd.exclude_missing_reads, expected);
     }
 
+    /// The flag is named for the tag it actually controls (`tc`); the former
+    /// `--skip-pa-tags` spelling stays accepted as an alias so existing scripts
+    /// keep working. Repo precedent for that is the `--queue-memory*` aliases.
     #[rstest]
-    // --skip-pa-tags (default false)
+    // default (neither spelling passed)
     #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam"], false)]
+    // --skip-tc-tags: the name that matches the tag actually written
+    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--skip-tc-tags"], true)]
+    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--skip-tc-tags", "true"], true)]
+    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--skip-tc-tags", "false"], false)]
+    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--skip-tc-tags=true"], true)]
+    #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--skip-tc-tags=false"], false)]
+    // --skip-pa-tags: retained alias, must behave identically
     #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--skip-pa-tags"], true)]
     #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--skip-pa-tags", "true"], true)]
     #[case(&["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam", "--skip-pa-tags", "false"], false)]


### PR DESCRIPTION
The flag was `--skip-pa-tags` and its help said it skipped "`pa` (primary alignment) tags" — but the struct field is `skip_tc_tags` and the command writes `tc` (template coordinate). No `pa` tag has ever been written, so a user who grepped the output for the thing the flag named found nothing.

Renamed to `--skip-tc-tags`, with `--skip-pa-tags` **kept as an alias** rather than renamed outright, so existing scripts keep working. Repo precedent for that is the `--queue-memory*` aliases. Help text and the internal step comment now say `tc`.

One detail worth flagging: the tag bytes are lowercase **`tc`**, not `TC` — `SamTag::TC` is the Rust constant's name, not the tag's spelling (`assert_eq!(*SamTag::TC, [b't', b'c'])`). The help refers to it as `tc` accordingly, since that is what a user would actually grep for.

The existing parsing test gains cases for the new spelling alongside the retained alias, covering the bare flag, explicit `true`/`false`, and the `=` form for both — 13 cases total.

`cargo ci-test` (5539 tests), `cargo ci-fmt`, `cargo ci-lint`, `RUSTDOCFLAGS="-D warnings" cargo ci-doc` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `--skip-tc-tags` command-line option for controlling template-coordinate tags on supplementary reads.
  * Retained `--skip-pa-tags` as a backward-compatible alias.

* **Documentation**
  * Updated command help text to accurately describe template-coordinate tag behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->