### PR TITLE
docs: correct four statements that are false of the current behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Enable with: `cargo build --release --features <feature>`
 |---------|-------------|------------------|
 | `extract` | Extract UMIs from FASTQ files | `fgbio ExtractUmisFromBam` |
 | `correct` | Correct UMIs based on sequence similarity | `fgbio CorrectUmis` |
-| `zipper` | Restore original FASTQ from unaligned BAM | `fgbio ZipperBams`, `picard MergeBamAlignment` |
+| `zipper` | Merge alignments back onto the unmapped BAM, restoring its tags | `fgbio ZipperBams`, `picard MergeBamAlignment` |
 | `fastq` | Convert BAM to FASTQ format | `samtools fastq` |
 | `sort` | Sort BAM by coordinate/queryname/template | — |
 | `group` | Group reads by UMI | `fgbio GroupReadsByUmi` |

--- a/docs/src/guide/best-practices.md
+++ b/docs/src/guide/best-practices.md
@@ -37,7 +37,7 @@ fgumi group --input in.bam --output out.bam --strategy adjacency
 fgumi group --input in.bam --output out.bam --strategy adjacency --threads 8
 ```
 
-Thread allocation is automatically optimized per-command based on workload profiling.
+`--threads` sizes each command's pipeline directly; there is no automatic per-command tuning, so pick a value that suits the machine and the rest of the pipeline.
 
 ### Memory
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -57,7 +57,7 @@ cargo build --release
 | `extract` | Extract UMIs from FASTQ files |
 | `correct` | Correct UMIs based on sequence similarity |
 | `fastq` | Convert BAM to FASTQ format |
-| `zipper` | Restore original FASTQ from unaligned BAM |
+| `zipper` | Merge alignments back onto the unmapped BAM, restoring its tags |
 | `sort` | Sort BAM by coordinate/queryname/template |
 | `group` | Group reads by UMI |
 | `dedup` | Mark/remove UMI-aware duplicates |

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -669,10 +669,9 @@ different cells are never grouped together, even if they share a UMI sequence an
 The cell barcode is read from the standard `CB` tag. No correction or
 error-handling is performed on cell barcodes; they must be corrected upstream.
 
-Multi-threaded operation is supported via --threads N, which spawns N pipeline threads
-allocated based on the command's workload profile to optimize performance. Note this differs
-from fgbio, where --threads sizes only the pool of UMI-comparison worker threads; in fgumi
---threads sizes the whole read/assign/write pipeline.
+Multi-threaded operation is supported via --threads N, which spawns N pipeline threads.
+Note this differs from fgbio, where --threads sizes only the pool of UMI-comparison worker
+threads; in fgumi --threads sizes the whole read/assign/write pipeline.
 
 Example: --threads 8 spawns 8 pipeline threads (2 reader, 4 workers, 2 writer)
 

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -137,8 +137,9 @@ source molecule. The likelihood model is as follows:
    preparation, through preparing the library for sequencing (e.g. amplification, target selection), and finally,
    through sequencing.
 
-This tool assumes that reads with the same tag are grouped together (consecutive in the file). Also, this tool
-calls each end of a pair independently, and does not jointly call bases that overlap within a pair. Insertion or
+This tool assumes that reads with the same tag are grouped together (consecutive in the file). Bases that
+overlap within a read pair are consensus called jointly before UMI consensus calling; pass
+--consensus-call-overlapping-bases false to call each end of a pair independently, as fgbio does. Insertion or
 deletion errors in the reads are not considered in the consensus model.
 
 The consensus reads produced are unaligned, due to the difficulty and error-prone nature of inferring the consensus


### PR DESCRIPTION
Four documentation statements that are false of the current behavior. I checked each against the code rather than taking the report at face value.

**`zipper` was described as "Restore original FASTQ from unaligned BAM"** in both the README and the docs index. That is what `fastq` does. `zipper` is the `MergeBamAlignment` analogue — it merges an aligned stream back onto the unmapped BAM — as the README's *own pipeline example* a few lines below demonstrates:

```bash
fgumi fastq --input unaligned.bam \
  | bwa mem -p ref.fa - \
  | fgumi zipper --unmapped unaligned.bam \
  | fgumi sort --output sorted.bam --order template-coordinate
```

and as the "fgbio equivalent" column already said (`fgbio ZipperBams`, `picard MergeBamAlignment`).

**The best-practices guide claimed** "Thread allocation is automatically optimized per-command based on workload profiling." There is no such profiling — `--threads` sizes the pipeline directly. A user reading that would reasonably not bother tuning it.

**`group`'s long help carried the same claim** in different words ("allocated based on the command's workload profile to optimize performance"), and is trimmed to what actually happens. The genuinely useful part of that note — that fgumi's `--threads` sizes the whole read/assign/write pipeline where fgbio's sizes only the UMI-comparison pool — is kept.

**`simplex`'s long help said** the tool "does not jointly call bases that overlap within a pair". It does, by default: `--consensus-call-overlapping-bases` defaults to `true`. The text now states the default and names the flag that restores fgbio's behavior.

Docs CI (mdbook-linkcheck2 and `RUSTDOCFLAGS="-D warnings"`) passes, along with `cargo ci-test` (5534 tests), `cargo ci-fmt`, and `cargo ci-lint`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `zipper` merges alignments back onto unmapped BAM files while restoring tags.
  * Updated threading guidance to explain that thread counts are set directly for each command.
  * Clarified that `group --threads N` applies N threads across the full processing pipeline.
  * Documented default joint consensus calling for overlapping read-pair bases in `simplex`, with an option to call ends independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->