### PR TITLE
perf(sort): restore the unstable queryname sort via a totally ordered key

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -58,6 +58,31 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
+/// Maximum number of records held in one in-memory chunk.
+///
+/// Each key carries its ingest position within the chunk (see
+/// [`RawSortKey::set_position`](crate::keys::RawSortKey::set_position)) so that
+/// the key is a *total* order and the chunk sort can be unstable. That position
+/// is a `u32`, so a chunk that grew past `u32::MAX` records would have to stamp
+/// two records with the same position — exact name/flag ties would stop being
+/// totally ordered and the unstable sort could reorder them, breaking output
+/// identity with `samtools sort -n`.
+///
+/// A chunk spills on `memory_limit` long before this in any real run (holding
+/// this many records needs hundreds of GB). This is the backstop that makes the
+/// `usize` -> `u32` narrowing at the stamp site provably lossless rather than
+/// merely unlikely to overflow.
+const MAX_CHUNK_RECORDS: usize = u32::MAX as usize;
+
+/// Whether the current chunk must be spilled before accepting another record.
+///
+/// Spilling is normally driven by `memory_limit`; `MAX_CHUNK_RECORDS` is the
+/// second, independent trigger that keeps ingest positions unique within a
+/// chunk (see [`MAX_CHUNK_RECORDS`]).
+fn should_spill_chunk(memory_used: usize, memory_limit: usize, chunk_records: usize) -> bool {
+    memory_used >= memory_limit || chunk_records >= MAX_CHUNK_RECORDS
+}
+
 // ============================================================================
 // Per-Phase Timing for Sort Pipeline
 // ============================================================================
@@ -2665,8 +2690,14 @@ impl RawExternalSorter {
             stats.total_records += 1;
             progress.log_if_needed(1);
 
-            // Extract key from raw bytes
-            let key = K::extract(record.as_ref(), &ctx);
+            // Extract key from raw bytes. Stamp the ingest position within this
+            // chunk so the key is totally ordered: read name + flags alone is not
+            // (secondary alignments of one read collide), and without a tiebreak
+            // the chunk sort would have to be stable to preserve ingest order.
+            let mut key = K::extract(record.as_ref(), &ctx);
+            key.set_position(
+                u32::try_from(entries.len()).expect("chunk length is capped at MAX_CHUNK_RECORDS"),
+            );
 
             // Estimate memory: record bytes + key overhead
             let record_size = record.as_ref().len() + 50; // approximate key size
@@ -2680,7 +2711,7 @@ impl RawExternalSorter {
             }
 
             // Check if we need to spill to disk
-            if memory_used >= self.memory_limit {
+            if should_spill_chunk(memory_used, self.memory_limit, entries.len()) {
                 timer.end_read_span();
                 let bstats = BufferProbeStats::simple(memory_used as u64, entries.len() as u64);
                 let depths = Some(pool.phase1_queue_depths());
@@ -2701,12 +2732,14 @@ impl RawExternalSorter {
 
                 timer.time_sort(|| {
                     use rayon::prelude::*;
-                    // Stable sort: `entries` is in ingest order, so a stable sort keeps
-                    // exact-queryname-key ties in input order — matching `samtools sort -n`,
-                    // fgbio, and the arena/runall path. The loser-tree merge already breaks
-                    // cross-chunk ties by chunk (ingest) order, so this per-chunk stability
-                    // makes the whole queryname sort stable.
-                    rayon_pool.install(|| entries.par_sort_by(|a, b| a.0.cmp(&b.0)));
+                    // `entries` is in ingest order, and exact-queryname-key ties must keep
+                    // that order — matching `samtools sort -n`, fgbio, and the arena/runall
+                    // path. The key carries its ingest position (see
+                    // `RawSortKey::set_position`), so it is a total order and an unstable
+                    // sort reproduces ingest order for ties without paying for a stable
+                    // sort. The loser-tree merge breaks cross-chunk ties by chunk (ingest)
+                    // order, so the whole queryname sort stays deterministic.
+                    rayon_pool.install(|| entries.par_sort_unstable_by(|a, b| a.0.cmp(&b.0)));
                 });
 
                 // Write keyed temp file with parallel BGZF compression via worker pool.
@@ -2754,9 +2787,10 @@ impl RawExternalSorter {
 
             timer.time_sort(|| {
                 use rayon::prelude::*;
-                // Stable sort to preserve ingest order for exact-key ties (see the
-                // per-chunk sort above for the full rationale).
-                rayon_pool.install(|| entries.par_sort_by(|a, b| a.0.cmp(&b.0)));
+                // Unstable sort over a totally ordered key: position is part of the key,
+                // so ingest order is preserved for exact-key ties (see the per-chunk sort
+                // above for the full rationale).
+                rayon_pool.install(|| entries.par_sort_unstable_by(|a, b| a.0.cmp(&b.0)));
             });
 
             timer.time_write_output(|| {
@@ -2787,10 +2821,11 @@ impl RawExternalSorter {
                     let chunk_size = entries.len().div_ceil(self.threads.max(1));
                     rayon_pool.install(|| {
                         entries.par_chunks_mut(chunk_size).for_each(|chunk| {
-                            // Stable sort per chunk: chunks are contiguous ingest-ordered
-                            // slices, so stability preserves ingest order for ties within a
-                            // chunk; the loser-tree merge preserves it across chunks.
-                            chunk.sort_by(|a, b| a.0.cmp(&b.0));
+                            // Unstable sort per chunk: the key's ingest position totally
+                            // orders records within a chunk, so ties keep ingest order
+                            // without stability; the loser-tree merge preserves it across
+                            // chunks.
+                            chunk.sort_unstable_by(|a, b| a.0.cmp(&b.0));
                         });
                     });
                     // Carve sub-chunks aligned with par_chunks_mut boundaries.
@@ -2815,8 +2850,9 @@ impl RawExternalSorter {
                 })
             } else {
                 timer.time_sort(|| {
-                    // Stable sort to preserve ingest order for exact-key ties.
-                    entries.sort_by(|a, b| a.0.cmp(&b.0));
+                    // Unstable sort: the key's ingest position preserves ingest order
+                    // for exact-key ties.
+                    entries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
                 });
                 vec![entries]
             };
@@ -3994,6 +4030,49 @@ mod tests {
     use rstest::rstest;
 
     // ========================================================================
+    // Chunk spill triggers
+    // ========================================================================
+
+    /// The unstable chunk sort is only correct because each key carries a unique
+    /// ingest position, and that position is a `u32`. `MAX_CHUNK_RECORDS` is
+    /// what keeps the stamp site's `usize` -> `u32` narrowing lossless, so it
+    /// must never exceed what a `u32` can hold.
+    ///
+    /// The stamp happens *before* the push, so the largest position a chunk can
+    /// produce is `MAX_CHUNK_RECORDS - 1`.
+    #[test]
+    fn test_max_chunk_records_keeps_ingest_positions_in_u32() {
+        let largest_position = MAX_CHUNK_RECORDS - 1;
+
+        assert!(
+            u32::try_from(largest_position).is_ok(),
+            "a full chunk would stamp position {largest_position}, which must fit in u32",
+        );
+    }
+
+    /// Memory pressure and the record cap are independent spill triggers: either
+    /// one alone must force the spill.
+    #[rstest]
+    #[case::empty(0, 1_000, 0, false)]
+    #[case::under_both(999, 1_000, 10, false)]
+    #[case::at_memory_limit(1_000, 1_000, 10, true)]
+    #[case::over_memory_limit(1_001, 1_000, 10, true)]
+    #[case::one_under_record_cap(0, usize::MAX, MAX_CHUNK_RECORDS - 1, false)]
+    #[case::at_record_cap(0, usize::MAX, MAX_CHUNK_RECORDS, true)]
+    // `MAX_CHUNK_RECORDS` is `u32::MAX`, which on a 32-bit target is `usize::MAX`
+    // — `+ 1` would not be representable there. Saturating leaves the case at the
+    // cap on such a target, which is still a spill.
+    #[case::over_record_cap(0, usize::MAX, MAX_CHUNK_RECORDS.saturating_add(1), true)]
+    fn test_should_spill_chunk(
+        #[case] memory_used: usize,
+        #[case] memory_limit: usize,
+        #[case] chunk_records: usize,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(should_spill_chunk(memory_used, memory_limit, chunk_records), expected);
+    }
+
+    // ========================================================================
     // process_umask concurrency
     // ========================================================================
 
@@ -4998,6 +5077,107 @@ mod tests {
             }
             last_pos_by_name.insert(name, pos);
         }
+    }
+
+    /// A `memory_limit` the whole fixture fits under, so the sort stays in memory.
+    const IN_MEMORY_MEMORY_LIMIT: usize = 64 * 1024 * 1024;
+
+    /// A `memory_limit` the fixture exceeds several times over, forcing spills.
+    const SPILLING_MEMORY_LIMIT: usize = 4096;
+
+    /// Sorter-level output identity for both queryname comparators.
+    ///
+    /// `test_sort_queryname_preserves_exact_tie_input_order` pins the tie rule
+    /// for the default comparator; this pins the *entire* emitted record
+    /// sequence, for the natural comparator as well, against the sequence a
+    /// stable sort of the input produces. Names are chosen so the two
+    /// comparators disagree ("read2" < "read10" naturally, "read10" < "read2"
+    /// lexicographically), and each name repeats at strictly increasing
+    /// positions so exact-key ties are present in every run.
+    ///
+    /// The `threads` x `memory_limit` product covers the single-threaded and
+    /// `par_chunks_mut` in-memory paths plus the spill path, where keys are
+    /// serialized without the ingest position and rebuilt at merge time with
+    /// position 0 — so identity there rests on the merge breaking cross-chunk
+    /// ties by source (ingest) order. The body asserts which path each limit
+    /// took, so the spill case cannot quietly become a third in-memory run if
+    /// the per-record memory estimate or the fixture size changes.
+    #[rstest::rstest]
+    #[case::lexicographic(
+        QuerynameComparator::Lexicographic,
+        ["read1", "read10", "read2", "read20", "read3"]
+    )]
+    #[case::natural(
+        QuerynameComparator::Natural,
+        ["read1", "read2", "read3", "read10", "read20"]
+    )]
+    fn test_sort_queryname_output_identity_matches_stable_baseline(
+        #[case] comparator: QuerynameComparator,
+        #[case] expected_name_order: [&str; 5],
+        #[values(1, 4)] threads: usize,
+        #[values(IN_MEMORY_MEMORY_LIMIT, SPILLING_MEMORY_LIMIT)] memory_limit: usize,
+    ) {
+        use fgumi_sam::SamBuilder;
+
+        const COPIES: usize = 16;
+        const NAMES: [&str; 5] = ["read1", "read2", "read3", "read10", "read20"];
+
+        // Ingest order: every name once per copy, each at the next position, so a
+        // record's position is also its ingest rank. `start` is 1-based while the
+        // BAM record — and so `collect_names_and_positions` — stores it 0-based.
+        let mut builder = SamBuilder::new();
+        let mut ingested: Vec<(String, i32)> = Vec::new();
+        let mut pos = 0usize;
+        for _copy in 0..COPIES {
+            for name in NAMES {
+                let _ = builder.add_frag().name(name).start(pos + 1).build();
+                ingested.push((name.to_string(), i32::try_from(pos).expect("position fits i32")));
+                pos += 1;
+            }
+        }
+
+        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let input = dir.path().join("input.bam");
+        let output = dir.path().join("output.bam");
+        builder.write_bam(&input).expect("failed to write BAM");
+
+        let stats = RawExternalSorter::new(SortOrder::Queryname(comparator))
+            .threads(threads)
+            .memory_limit(memory_limit)
+            .output_compression(0)
+            .sort(&input, &output)
+            .expect("sort should succeed");
+
+        // Pin which path each limit took. Identity through the spill path is the
+        // interesting half of this test — that is where the ingest position is
+        // dropped on serialization and the merge has to break ties by source
+        // order instead — so a spilling limit that quietly stopped spilling
+        // would leave that half uncovered with the test still green.
+        assert_eq!(
+            stats.chunks_written > 0,
+            memory_limit == SPILLING_MEMORY_LIMIT,
+            "a {memory_limit}-byte limit wrote {} spill chunk(s), which is not the path this \
+             case is meant to exercise",
+            stats.chunks_written
+        );
+
+        // The stable baseline: ingest order, stably sorted by the comparator's
+        // name order. `sort_by_key` is stable, so records sharing a name keep
+        // their ingest order — exactly what the sorter must reproduce.
+        let mut expected = ingested;
+        expected.sort_by_key(|(name, _)| {
+            expected_name_order
+                .iter()
+                .position(|expected_name| expected_name == name)
+                .expect("every ingested name appears in the expected order")
+        });
+
+        assert_eq!(
+            collect_names_and_positions(&output),
+            expected,
+            "{comparator} sort with {threads} thread(s) and a {memory_limit}-byte limit did not \
+             reproduce the stable baseline sequence"
+        );
     }
 
     /// Verifies that sort with many chunks exercises the pool-integrated

--- a/crates/fgumi-sort/src/keys.rs
+++ b/crates/fgumi-sort/src/keys.rs
@@ -64,12 +64,34 @@ pub trait RawSortKey: Ord + Clone + Send + Sync + Sized {
     /// parsing overhead by reading only the fields needed for comparison.
     fn extract(bam: &[u8], ctx: &SortContext) -> Self;
 
+    /// Record this key's ingest position within the current in-memory chunk.
+    ///
+    /// Keys whose natural fields already form a total order leave this as the
+    /// default no-op. Queryname keys override it: read name plus flags is *not*
+    /// a total order (secondary alignments of one read collide), so without a
+    /// tiebreak the chunk sort has to be stable to keep ingest order, which
+    /// costs 2.3x on the in-memory sort phase (13.4s -> 31.1s over 219M records)
+    /// and 17% end-to-end. Carrying the position makes the key totally ordered,
+    /// so an unstable sort yields the same output.
+    ///
+    /// Only meaningful for the in-memory chunk sort. Keys reconstructed during
+    /// merge via [`RawSortKey::extract_from_record`] carry position 0 — see the
+    /// note there.
+    fn set_position(&mut self, _pos: u32) {}
+
     /// Extract a sort key from raw BAM record bytes without a `SortContext`.
     ///
     /// Only valid when `EMBEDDED_IN_RECORD` is `true`. Used during merge to
     /// reconstruct the key from the record itself, avoiding separate key storage.
     ///
     /// Default implementation panics — only override for embedded key types.
+    ///
+    /// Any position set by [`RawSortKey::set_position`] is NOT recovered here:
+    /// the position is not stored in the record, so keys rebuilt during merge
+    /// compare as position 0. That is sound because the merge only ever compares
+    /// the *heads of different sources* — records within one source are already
+    /// emitted in file order, and ties across sources are broken by source index
+    /// in the loser tree. Do not rely on position after spill.
     #[must_use]
     fn extract_from_record(_bam: &[u8]) -> Self {
         unimplemented!("extract_from_record only valid when EMBEDDED_IN_RECORD is true")
@@ -527,6 +549,10 @@ pub struct RawQuerynameKey {
     name: Vec<u8>,
     /// Flags for segment ordering (R1 before R2).
     flags: u16,
+    /// Ingest position within the current in-memory chunk; see
+    /// [`RawSortKey::set_position`]. Lands in existing padding on 64-bit targets,
+    /// so the key does not grow there. Zero after a merge-time rebuild.
+    pos: u32,
 }
 
 impl PartialEq for RawQuerynameKey {
@@ -546,7 +572,7 @@ impl RawQuerynameKey {
         if name.last() != Some(&0) {
             name.push(0);
         }
-        Self { name, flags }
+        Self { name, flags, pos: 0 }
     }
 
     /// Returns the read name bytes (including the null terminator).
@@ -563,10 +589,12 @@ impl RawQuerynameKey {
         let flags = queryname_flag_order(u16::from_le_bytes([bam[14], bam[15]]));
         match raw_name_with_nul(bam) {
             // BAM stores the name NUL-terminated, so copy those bytes directly
-            // instead of stripping the NUL and re-appending it.
-            Some(name) => Self { name: name.to_vec(), flags },
+            // instead of stripping the NUL and re-appending it. `pos` is filled in
+            // later by `set_position`; a merge-time rebuild leaves it 0.
+            Some(name) => Self { name: name.to_vec(), flags, pos: 0 },
             // Truncated or non-terminated record: fall back to the stripped-name
-            // path (`new` re-adds the terminator), preserving the prior bytes.
+            // path (`new` re-adds the terminator and sets `pos: 0`), preserving
+            // the prior bytes.
             None => Self::new(extract_raw_name_and_flags(bam).0.to_vec(), flags),
         }
     }
@@ -579,6 +607,7 @@ impl Ord for RawQuerynameKey {
         // SAFETY: `name` is always null-terminated (see `extract_queryname_key` and `new`).
         unsafe { natural_compare_nul(self.name.as_ptr(), other.name.as_ptr()) }
             .then_with(|| self.flags.cmp(&other.flags))
+            .then_with(|| self.pos.cmp(&other.pos))
     }
 }
 
@@ -596,6 +625,11 @@ impl RawSortKey for RawQuerynameKey {
     #[inline]
     fn extract(bam: &[u8], _ctx: &SortContext) -> Self {
         Self::extract_queryname_key(bam)
+    }
+
+    #[inline]
+    fn set_position(&mut self, pos: u32) {
+        self.pos = pos;
     }
 
     #[inline]
@@ -631,13 +665,17 @@ pub struct RawQuerynameLexKey {
     name: Vec<u8>,
     /// Flags for segment ordering (R1 before R2).
     flags: u16,
+    /// Ingest position within the current in-memory chunk; see
+    /// [`RawSortKey::set_position`]. Lands in existing padding on 64-bit targets,
+    /// so the key does not grow there. Zero after a merge-time rebuild.
+    pos: u32,
 }
 
 impl RawQuerynameLexKey {
     /// Create a new lexicographic queryname key.
     #[must_use]
     pub fn new(name: Vec<u8>, flags: u16) -> Self {
-        Self { name, flags }
+        Self { name, flags, pos: 0 }
     }
 
     /// Returns the read name bytes.
@@ -651,14 +689,17 @@ impl RawQuerynameLexKey {
     #[must_use]
     fn extract_queryname_key(bam: &[u8]) -> Self {
         let (raw_name, flags) = extract_raw_name_and_flags(bam);
-        Self { name: raw_name.to_vec(), flags }
+        Self { name: raw_name.to_vec(), flags, pos: 0 }
     }
 }
 
 impl Ord for RawQuerynameLexKey {
     #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
-        self.name.cmp(&other.name).then_with(|| self.flags.cmp(&other.flags))
+        self.name
+            .cmp(&other.name)
+            .then_with(|| self.flags.cmp(&other.flags))
+            .then_with(|| self.pos.cmp(&other.pos))
     }
 }
 
@@ -679,6 +720,11 @@ impl RawSortKey for RawQuerynameLexKey {
     }
 
     #[inline]
+    fn set_position(&mut self, pos: u32) {
+        self.pos = pos;
+    }
+
+    #[inline]
     fn extract_from_record(bam: &[u8]) -> Self {
         Self::extract_queryname_key(bam)
     }
@@ -691,7 +737,7 @@ impl RawSortKey for RawQuerynameLexKey {
     #[inline]
     fn read_from<R: Read>(reader: &mut R) -> std::io::Result<Self> {
         let (name, flags) = read_queryname_key(reader)?;
-        Ok(Self { name, flags })
+        Ok(Self { name, flags, pos: 0 })
     }
 }
 
@@ -702,6 +748,73 @@ impl RawSortKey for RawQuerynameLexKey {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The ingest position must land in the key's existing tail padding.
+    ///
+    /// On a 64-bit target `Vec<u8>` (24 bytes, align 8) plus a `u16` leaves 6 bytes of
+    /// padding, so the `u32` is free. If this ever fails the tiebreak has started
+    /// costing memory per record, and the trade against a stable sort needs
+    /// re-evaluating: the whole point is that a total order is cheaper than
+    /// stable-sorting.
+    ///
+    /// The assertion is scoped to 64-bit because the padding is. A 32-bit `Vec<u8>` is
+    /// 12 bytes, which leaves only 2 bytes after the `u16`, so the key grows from 16 to
+    /// 20 bytes there. That is a cost question, not a correctness one — the total order
+    /// the unstable sort depends on holds on every target — and fgumi's sort is a
+    /// 64-bit workload, so the zero-growth claim is made for 64-bit only.
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn position_fits_in_existing_key_padding() {
+        assert_eq!(std::mem::size_of::<RawQuerynameLexKey>(), 32);
+        assert_eq!(std::mem::size_of::<RawQuerynameKey>(), 32);
+    }
+
+    /// Name and flags alone are not a total order; position makes them one.
+    ///
+    /// This is the invariant the unstable chunk sort depends on. Several secondary
+    /// alignments of one read share a name and flag class, and if their keys compare
+    /// equal an unstable sort may emit them in any order.
+    #[test]
+    fn position_totally_orders_otherwise_equal_lex_keys() {
+        let mut first = RawQuerynameLexKey::new(b"read1".to_vec(), 99);
+        let mut second = RawQuerynameLexKey::new(b"read1".to_vec(), 99);
+        assert_eq!(first, second, "name+flags alone must collide");
+
+        first.set_position(0);
+        second.set_position(1);
+        assert_ne!(first, second);
+        assert!(first < second, "earlier ingest position must sort first");
+    }
+
+    /// Same invariant for the natural-order comparator.
+    #[test]
+    fn position_totally_orders_otherwise_equal_natural_keys() {
+        let mut first = RawQuerynameKey::new(b"read1".to_vec(), 99);
+        let mut second = RawQuerynameKey::new(b"read1".to_vec(), 99);
+        assert_eq!(first.cmp(&second), Ordering::Equal, "name+flags alone must collide");
+
+        first.set_position(0);
+        second.set_position(1);
+        assert_eq!(first.cmp(&second), Ordering::Less);
+    }
+
+    /// Position must not outrank the fields it breaks ties for.
+    #[test]
+    fn position_only_applies_after_name_and_flags() {
+        let mut later_name = RawQuerynameLexKey::new(b"read2".to_vec(), 0);
+        later_name.set_position(0);
+        let mut earlier_name = RawQuerynameLexKey::new(b"read1".to_vec(), 0);
+        earlier_name.set_position(u32::MAX);
+        assert!(earlier_name < later_name, "name must dominate position");
+    }
+
+    /// Keys default to position 0, so a merge-time rebuild is well defined.
+    #[test]
+    fn extracted_keys_default_to_position_zero() {
+        let a = RawQuerynameLexKey::new(b"read1".to_vec(), 0);
+        let b = RawQuerynameLexKey::new(b"read1".to_vec(), 0);
+        assert_eq!(a, b);
+    }
 
     // ========================================================================
     // queryname_flag_order tests


### PR DESCRIPTION
## Why

#540 made `sort --order queryname[::natural]` deterministic for exact-key ties by switching the four in-chunk sorts from `*sort_unstable_by` to their stable equivalents. That fixed a real bug: several secondary alignments of one read share a name and flag class, and an unstable sort could emit them in any order, disagreeing with `samtools sort -n`, fgbio, and fgumi's own arena/runall path.

It is also expensive. Rust's stable sort allocates an N/2-element scratch buffer and does extra moves, and the `(K, RawRecord)` element is heavy. On 219M records the in-memory sort phase went **13.4s → 31.1s (2.3x)** and end-to-end wall went **150s → 175s (1.17x)**.

## The idea

Determinism does not require a *stable sort*, only a *total order*. Read name plus flags is not one. Adding the record's ingest position within its chunk makes it one — after which an unstable sort produces exactly the output a stable sort would.

The two halves compose into a global order without a global counter:

- a `u32` position orders records **within** a chunk;
- the loser-tree merge already breaks **cross-chunk** ties by source index (`loser_tree.rs`), and sources are built in chunk (ingest) order.

The position is carried in the key behind a new `RawSortKey::set_position` whose default is a no-op, so coordinate and template-coordinate — radix sorted, where stability is free and a wider key would only add passes — are untouched.

## Cost: zero

`Vec<u8>` plus a `u16` leaves 6 bytes of tail padding, so the `u32` lands in it and both key types stay **32 bytes**. There is a test asserting this, because the entire argument is that a total order is cheaper than stable sorting — if the key ever grows, the trade needs revisiting.

## Numbers

c7g.4xlarge, `1kg-wes-HG00100.bam` (14.3 GB / 219M records), 11 spills, `--threads 8`, 3 reps, median:

| build | sort phase | wall |
|---|---|---|
| pre-#540 (unstable) | 13.4s | 150s |
| main (#540, stable) | 31.1s | 175s |
| **this change** | **14.0s** | **152s** |

The sort phase returns to within 4% of pre-#540 (the residual is the extra position comparison); wall drops 13%. Rep spread was ≤0.5s.

**Coordinate is the control** and does not move — sort phase 2.6s vs 2.3s, wall 166s vs 168s — confirming the effect is confined to the path #540 changed rather than being a general sort or I/O shift.

## Correctness

- **Output is byte-identical to the stable sort.** `compare bams --command sort` reports `IDENTICAL (sort order verified; run multisets match)` across all 219M records, through the spill path (11 spills), not just in memory.
- **#540's own regression test passes unchanged** — repeated names still emerge in ingest order across the single-threaded, `par_chunks_mut`, and spill paths. That is the point: the invariant is now preserved by the *key* rather than by the *algorithm*, so it can no longer be broken by swapping the sort primitive.
- New tests cover the invariant directly: position totally orders otherwise-equal keys (both comparators), position only applies after name and flags, and the size assertion above.
- `cargo fmt`, `clippy --all-features --all-targets -D warnings`, and the full `fgumi-sort` suite (474 tests) are clean.

## One sharp edge, documented

Keys rebuilt during merge via `extract_from_record` carry position 0, because the position is not stored in the record. So the same pair compares unequal in memory but equal at merge. That is sound — the merge only ever compares heads of *different* sources, and records within one source are already emitted in file order — but it is an asymmetry in `Ord`, so it is called out at both `set_position` and `extract_from_record`. Position must not be relied on after spill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved queryname sorting determinism by adding an ingest-position tie-breaker for exact matches.
  - Ensures consistent, correct tie handling for queryname+flag records across both in-memory and spill workflows.

- **Performance**
  - Updated chunk spilling logic to trigger on both memory pressure and a per-chunk record cap.
  - Adjusted internal sorting behavior to maintain correct tie ordering without relying on stable sort.

- **Tests**
  - Added unit and end-to-end integration coverage for the record-cap invariant, spill predicate behavior, and output identity across comparator types and settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->