### PR TITLE
feat(correct): add -t/--target {umi,barcode} to correct RX or BC

### DIFF
--- a/crates/fgumi-tag/src/tag.rs
+++ b/crates/fgumi-tag/src/tag.rs
@@ -94,6 +94,13 @@ impl SamTag {
     pub const QT: SamTag = SamTag::new(b'Q', b'T');
     /// Original UMI bases, before error correction (SAM spec).
     pub const OX: SamTag = SamTag::new(b'O', b'X');
+    /// Original barcode bases, before error correction.
+    ///
+    /// fgumi-local tag (not SAM-spec): the SAM spec has no "original barcode"
+    /// tag and reserves tags containing lowercase letters for local use, so
+    /// this deliberately uses lowercase `ob` to signal a local convention
+    /// rather than masquerade as a standard tag.
+    pub const OB: SamTag = SamTag::new(b'o', b'b');
     /// Original UMI base quality scores, before error correction (SAM spec).
     pub const BZ: SamTag = SamTag::new(b'B', b'Z');
     /// Read group (SAM spec).
@@ -590,5 +597,12 @@ mod tests {
                 "REVERSE tag {t} missing from PER_BASE_CONSENSUS_TAGS",
             );
         }
+    }
+
+    #[test]
+    fn ob_tag_is_lowercase_and_valid() {
+        // fgumi-local "original barcode" tag: SAM reserves lowercase tags for local use.
+        assert_eq!(SamTag::OB.to_string(), "ob");
+        assert!(SamTag::is_valid_tag_bytes(b'o', b'b'));
     }
 }

--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -11,11 +11,18 @@
 //! Rejects land in batch-input order rather than mutex-acquisition order, and the
 //! rejects BAM inherits the input header. The pattern matches `commands::filter`.
 //!
+//! By default (`--target umi`) the tool reads and writes the `RX` UMI tag and
+//! stores the pre-correction value in `OX`. With `--target barcode` it instead
+//! reads and writes the `BC` sample/library-barcode tag and stores the
+//! pre-correction value in the fgumi-local `ob` tag. Only these two SAM-spec
+//! standard tags are selectable — there is no free-form tag override (see
+//! fgumi #239).
+//!
 //! # Example
 //!
 //! ```no_run
 //! use std::path::PathBuf;
-//! use fgumi_lib::commands::correct::CorrectUmis;
+//! use fgumi_lib::commands::correct::{CorrectUmis, Target};
 //! use fgumi_lib::commands::command::Command;
 //! use fgumi_lib::commands::common::{
 //!     BamIoOptions, CompressionOptions, QueueMemoryOptions, RejectsOptions,
@@ -30,6 +37,7 @@
 //!     },
 //!     rejects_opts: RejectsOptions { rejects: Some(PathBuf::from("rejects.bam")) },
 //!     metrics: Some(PathBuf::from("metrics.txt")),
+//!     target: Target::Umi,
 //!     max_mismatches: 2,
 //!     min_distance_diff: 2,
 //!     umis: vec!["AAAAAA".to_string(), "CCCCCC".to_string()],
@@ -85,6 +93,41 @@ use crate::commands::common::{
     ThreadingOptions, build_pipeline_config, parse_bool, serialize_raw_bam_records,
 };
 
+/// Which SAM tag `correct` operates on.
+///
+/// Bounded on purpose: unlike fgbio's free-form `-t/--umi-tag`, only the two
+/// SAM-spec standard tags below are selectable, so a pipeline cannot be pointed
+/// at an arbitrary tag (the misconfiguration class removed in fgumi #239).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum, Default)]
+pub enum Target {
+    /// Correct the raw UMI tag `RX`; stash the pre-correction value in `OX`.
+    #[default]
+    Umi,
+    /// Correct the sample/library barcode tag `BC`; stash the pre-correction
+    /// value in the fgumi-local `ob` tag.
+    Barcode,
+}
+
+impl Target {
+    /// Tag the observed sequence is read from and the corrected sequence
+    /// written to.
+    pub const fn sequence_tag(self) -> SamTag {
+        match self {
+            Target::Umi => SamTag::RX,
+            Target::Barcode => SamTag::BC,
+        }
+    }
+
+    /// Tag the pre-correction original sequence is stashed in when original
+    /// storage is enabled.
+    pub const fn original_tag(self) -> SamTag {
+        match self {
+            Target::Umi => SamTag::OX,
+            Target::Barcode => SamTag::OB,
+        }
+    }
+}
+
 /// Result of matching an observed UMI to an expected UMI.
 ///
 /// Contains information about whether the match was acceptable and the details
@@ -122,7 +165,7 @@ pub struct UmiMatch {
 /// # Example
 ///
 /// ```no_run
-/// # use fgumi_lib::commands::correct::CorrectUmis;
+/// # use fgumi_lib::commands::correct::{CorrectUmis, Target};
 /// # use fgumi_lib::commands::command::Command;
 /// # use fgumi_lib::commands::common::{
 /// #     BamIoOptions, CompressionOptions, QueueMemoryOptions, RejectsOptions,
@@ -137,6 +180,7 @@ pub struct UmiMatch {
 ///     },
 ///     rejects_opts: RejectsOptions { rejects: Some(PathBuf::from("rejects.bam")) },
 ///     metrics: Some(PathBuf::from("metrics.txt")),
+///     target: Target::Umi,
 ///     max_mismatches: 2,
 ///     min_distance_diff: 2,
 ///     umis: vec!["AAAAAA".to_string(), "CCCCCC".to_string()],
@@ -163,14 +207,16 @@ pub struct UmiMatch {
     long_about = r#"
 Corrects UMIs stored in BAM files when a set of fixed UMIs is in use.
 
-If the set of UMIs used in an experiment is known and is a _subset_ of the possible randomers
-of the same length, it is possible to error-correct UMIs prior to grouping reads by UMI. This
-tool takes an input BAM with UMIs in the `RX` tag and set of known UMIs (either on
-the command line or in a file) and produces:
+If the set of sequences used in an experiment is known and is a _subset_ of the possible randomers
+of the same length, it is possible to error-correct them prior to grouping reads. By default
+(`--target umi`), the tool corrects the `RX` UMI tag and stores the original in `OX`. With
+`--target barcode`, it corrects the `BC` barcode tag and stores the original in the fgumi-local
+`ob` tag. The tool accepts a set of known sequences (either on the command line or in a file)
+and produces:
 
-1. A new BAM with corrected UMIs written to the `RX` tag
-2. Optionally a set of metrics about the representation of each UMI in the set
-3. Optionally a second BAM file of reads whose UMIs could not be corrected within the specific parameters
+1. A new BAM with corrected sequences written back to the same tag they were read from (`RX` for `umi`, `BC` for `barcode`)
+2. Optionally a set of metrics about the representation of each sequence in the set
+3. Optionally a second BAM file of reads whose sequences could not be corrected within the specific parameters
 
 All of the fixed UMIs must be of the same length, and all UMIs in the BAM file must also have
 the same length. Multiple UMIs that are concatenated with hyphens (e.g. `AACCAGT-AGGTAGA`) are
@@ -199,11 +245,12 @@ If there are multiple UMIs per template, leading to hyphenated UMI tags, the val
 UMIs should be single, non-hyphenated UMIs (e.g. if a record has `RX:Z:ACGT-GGCA`, you would use
 `--umis ACGT GGCA`).
 
-## Original UMI Storage
+## Original Sequence Storage
 
-Records which have their UMIs corrected (i.e. the UMI is not identical to one of the expected
-UMIs but is close enough to be corrected) will by default have their original UMI stored in the
-`OX` tag. This can be disabled with the `--dont-store-original-umis` option.
+Records which have their sequences corrected (i.e. the sequence is not identical to one of the
+expected sequences but is close enough to be corrected) will by default have their original
+sequence stored in a backup tag: `OX` for `--target umi` or the fgumi-local `ob` tag for
+`--target barcode`. This can be disabled with the `--dont-store-original` option.
 "#
 )]
 pub struct CorrectUmis {
@@ -218,6 +265,11 @@ pub struct CorrectUmis {
     /// Optional output path for metrics TSV file.
     #[arg(short = 'M', long)]
     pub metrics: Option<PathBuf>,
+
+    /// Which SAM tag to correct: `umi` (RX; original stashed in OX) or
+    /// `barcode` (BC; original stashed in the fgumi-local `ob` tag).
+    #[arg(short = 't', long, value_enum, default_value_t = Target::Umi)]
+    pub target: Target,
 
     /// Maximum number of mismatches allowed.
     #[arg(long, default_value = "2")]
@@ -235,8 +287,17 @@ pub struct CorrectUmis {
     #[arg(short = 'U', long)]
     pub umi_files: Vec<PathBuf>,
 
-    /// Don't store original UMIs in a separate tag.
-    #[arg(long, default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    /// Don't store the pre-correction original sequence in a separate tag
+    /// (OX for umi, ob for barcode).
+    #[arg(
+        long = "dont-store-original",
+        alias = "dont-store-original-umis",
+        default_value = "false",
+        num_args = 0..=1,
+        default_missing_value = "true",
+        action = clap::ArgAction::Set,
+        value_parser = parse_bool
+    )]
     pub dont_store_original_umis: bool,
 
     /// Size of the LRU cache for UMI matching.
@@ -373,7 +434,7 @@ impl Command for CorrectUmis {
     /// # Example
     ///
     /// ```no_run
-    /// # use fgumi_lib::commands::correct::CorrectUmis;
+    /// # use fgumi_lib::commands::correct::{CorrectUmis, Target};
     /// # use fgumi_lib::commands::common::{
     /// #     BamIoOptions, CompressionOptions, QueueMemoryOptions, RejectsOptions,
     /// #     SchedulerOptions, ThreadingOptions,
@@ -385,6 +446,7 @@ impl Command for CorrectUmis {
     /// #   io: BamIoOptions { input: PathBuf::new(), output: PathBuf::new(), async_reader: false },
     /// #   rejects_opts: RejectsOptions::default(),
     /// #   metrics: None,
+    /// #   target: Target::Umi,
     /// #   max_mismatches: 2,
     /// #   min_distance_diff: 2,
     /// #   umis: vec![],
@@ -775,12 +837,13 @@ impl CorrectUmis {
         record: &mut RawRecord,
         correction: &TemplateCorrection,
         umi_tag: [u8; 2],
+        original_tag: [u8; 2],
         dont_store_original_umis: bool,
     ) {
         use fgumi_raw_bam;
 
         if correction.needs_correction {
-            // Write corrected UMI first (in-place update avoids scanning past OX)
+            // Write corrected UMI first (in-place update avoids scanning past the original tag)
             if let Some(ref corrected) = correction.corrected_umi {
                 fgumi_raw_bam::update_string_tag(
                     record.as_mut_vec(),
@@ -790,11 +853,11 @@ impl CorrectUmis {
             }
 
             // Store original UMI if there were actual mismatches
-            // Use update_string_tag to avoid duplicate OX tags
+            // Use update_string_tag to avoid duplicate original-tag writes
             if !dont_store_original_umis && correction.has_mismatches {
                 fgumi_raw_bam::update_string_tag(
                     record.as_mut_vec(),
-                    SamTag::OX,
+                    original_tag,
                     correction.original_umi.as_bytes(),
                 );
             }
@@ -885,7 +948,8 @@ impl CorrectUmis {
         const BATCH_SIZE: usize = 1000; // Templates per batch
         let max_mismatches = self.max_mismatches;
         let min_distance_diff = self.min_distance_diff;
-        let umi_tag = Tag::from(SamTag::RX);
+        let umi_tag = Tag::from(self.target.sequence_tag());
+        let original_tag_sam = self.target.original_tag();
         let revcomp = self.revcomp;
         let cache_size = self.cache_size;
         let dont_store_original_umis = self.dont_store_original_umis;
@@ -935,6 +999,8 @@ impl CorrectUmis {
                 // Count ALL input records for progress tracking (not just kept/rejected)
                 let mut total_input_records = 0u64;
                 let umi_tag_bytes: [u8; 2] = [umi_tag.as_ref()[0], umi_tag.as_ref()[1]];
+                let original_tag_bytes: [u8; 2] =
+                    [original_tag_sam.as_ref()[0], original_tag_sam.as_ref()[1]];
 
                 for template in batch {
                     // Count input records BEFORE processing
@@ -994,6 +1060,7 @@ impl CorrectUmis {
                                             &mut raw,
                                             &correction,
                                             umi_tag_bytes,
+                                            original_tag_bytes,
                                             dont_store_original_umis,
                                         );
                                         kept_raw_records.push(raw);
@@ -1224,7 +1291,8 @@ impl CorrectUmis {
         let mut mismatched = 0u64;
         let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
 
-        let umi_tag_bytes: [u8; 2] = SamTag::RX.into();
+        let umi_tag_bytes: [u8; 2] = self.target.sequence_tag().into();
+        let original_tag_bytes: [u8; 2] = self.target.original_tag().into();
         let max_mismatches = self.max_mismatches;
         let min_distance_diff = self.min_distance_diff;
         let revcomp = self.revcomp;
@@ -1315,6 +1383,7 @@ impl CorrectUmis {
                                     &mut raw,
                                     &correction,
                                     umi_tag_bytes,
+                                    original_tag_bytes,
                                     dont_store_original_umis,
                                 );
                                 write_raw(&mut writer, &raw)?;
@@ -1660,6 +1729,36 @@ mod tests {
     }
 
     #[test]
+    fn parses_default_target_as_umi() {
+        let cmd = CorrectUmis::try_parse_from([
+            "correct", "-i", "in.bam", "-o", "out.bam", "-u", "ACGT", "-d", "2",
+        ])
+        .expect("parses with defaults");
+        assert_eq!(cmd.target, Target::Umi);
+    }
+
+    #[test]
+    fn parses_barcode_target_and_alias_flag() {
+        let cmd = CorrectUmis::try_parse_from([
+            "correct",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "-u",
+            "ACGT",
+            "-d",
+            "2",
+            "--target",
+            "barcode",
+            "--dont-store-original-umis",
+        ])
+        .expect("parses barcode target and the hidden alias");
+        assert_eq!(cmd.target, Target::Barcode);
+        assert!(cmd.dont_store_original_umis);
+    }
+
+    #[test]
     fn test_find_best_match_perfect() {
         let umi_set = get_encoded_umi_set();
 
@@ -1876,6 +1975,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: None,
+            target: Target::Umi,
             max_mismatches: 2,
             min_distance_diff: 2,
             umis: vec!["AAAAAA".to_string(), "CCCCCC".to_string()],
@@ -1918,6 +2018,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions { rejects: None },
             metrics: None,
+            target: Target::Umi,
             max_mismatches: 2,
             min_distance_diff: 2,
             umis: vec!["AAAAAA".to_string(), "CCCCCC".to_string()],
@@ -1960,6 +2061,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
+            target: Target::Umi,
             max_mismatches: 2,
             min_distance_diff: 2,
             umis: vec!["AAAAAA".to_string(), "CCC".to_string()],
@@ -1992,6 +2094,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions { rejects: Some(rejects.clone()) },
             metrics: None,
+            target: Target::Umi,
             max_mismatches: 2,
             min_distance_diff: 2,
             umis: vec!["AAAAAA".to_string(), "CCCCCC".to_string()],
@@ -2042,6 +2145,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions { rejects: Some(rejects.clone()) },
             metrics: Some(metrics.clone()),
+            target: Target::Umi,
             max_mismatches: 3,
             min_distance_diff: 2,
             umis: vec![
@@ -2108,6 +2212,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions { rejects: Some(rejects.clone()) },
             metrics: None,
+            target: Target::Umi,
             max_mismatches: 3,
             min_distance_diff: 2,
             umis: vec![
@@ -2168,6 +2273,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions::default(),
             metrics: Some(metrics1.clone()),
+            target: Target::Umi,
             max_mismatches: 3,
             min_distance_diff: 2,
             umis: vec![
@@ -2197,6 +2303,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions::default(),
             metrics: Some(metrics2.clone()),
+            target: Target::Umi,
             max_mismatches: 3,
             min_distance_diff: 2,
             umis: vec![],
@@ -2242,6 +2349,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
+            target: Target::Umi,
             max_mismatches: 2,
             min_distance_diff: 2,
             umis: vec!["AAAAAA".to_string(), "TTTTTT".to_string(), "CCCCCC".to_string()],
@@ -2285,6 +2393,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
+            target: Target::Umi,
             max_mismatches: 2,
             min_distance_diff: 2,
             umis: vec!["AAAAAA".to_string(), "TTTTTT".to_string(), "CCCCCC".to_string()],
@@ -2329,6 +2438,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
+            target: Target::Umi,
             max_mismatches: 2,
             min_distance_diff: 2,
             umis: vec!["AAAAAA".to_string(), "TTTTTT".to_string(), "CCCCCC".to_string()],
@@ -2386,6 +2496,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: None,
+            target: Target::Umi,
             max_mismatches: 0, // Exact match only
             min_distance_diff: 1,
             umis: vec!["AAAAAA".to_string(), "CCCCCC".to_string()],
@@ -2434,6 +2545,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: Some(paths.metrics.clone()),
+            target: Target::Umi,
             max_mismatches: 2,
             min_distance_diff: 2,
             umis: vec![
@@ -2493,6 +2605,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: None,
+            target: Target::Umi,
             max_mismatches: 2,
             min_distance_diff: 2,
             umis: vec!["AAAAAA".to_string()], // Only one UMI
@@ -2538,6 +2651,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: None,
+            target: Target::Umi,
             max_mismatches: 2,
             min_distance_diff: 2,
             umis: vec!["AAAAAA".to_string()],
@@ -2582,6 +2696,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: None,
+            target: Target::Umi,
             max_mismatches: 1,
             min_distance_diff: 5, // Large distance for long UMIs
             umis: vec!["AAAAAAAAAAAAAAAAAAAA".to_string(), "CCCCCCCCCCCCCCCCCCCC".to_string()],
@@ -2625,6 +2740,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
+            target: Target::Umi,
             max_mismatches: 1,
             min_distance_diff: 2,
             umis: vec!["AAAAAA".to_string()],
@@ -2662,6 +2778,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
+            target: Target::Umi,
             max_mismatches: 1,
             min_distance_diff: 2,
             umis: vec!["AAAAAA".to_string()],
@@ -2703,6 +2820,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
+            target: Target::Umi,
             max_mismatches: 0, // Exact match
             min_distance_diff: 1,
             umis: vec!["AAAAAA".to_string()],
@@ -2755,6 +2873,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
+            target: Target::Umi,
             max_mismatches: 2,
             min_distance_diff: 2,
             umis: vec![
@@ -2817,6 +2936,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
+            target: Target::Umi,
             max_mismatches: 2,
             min_distance_diff: 2,
             umis: vec![
@@ -2979,6 +3099,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions::default(),
             metrics: Some(paths.metrics.clone()),
+            target: Target::Umi,
             max_mismatches: 1, // Strict matching
             min_distance_diff: 2,
             umis: vec!["AAAAAA".to_string(), "CCCCCC".to_string()],
@@ -3041,6 +3162,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions::default(),
             metrics: Some(paths.metrics.clone()),
+            target: Target::Umi,
             max_mismatches: 3,
             min_distance_diff: 2,
             umis: vec![
@@ -3102,6 +3224,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions::default(),
             metrics: Some(paths.metrics.clone()),
+            target: Target::Umi,
             max_mismatches: 2,
             min_distance_diff: 2,
             umis: vec!["AAAAAA".to_string(), "CCCCCC".to_string()],
@@ -3145,6 +3268,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions::default(),
             metrics: Some(paths.metrics.clone()),
+            target: Target::Umi,
             max_mismatches: 4,
             min_distance_diff: 0,
             umis: vec!["AAAAAAAAA".to_string(), "TTTTTTTTT".to_string()],
@@ -3183,6 +3307,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions::default(),
             metrics: Some(paths.metrics.clone()),
+            target: Target::Umi,
             max_mismatches: 1,
             min_distance_diff: 2,
             umis: vec![
@@ -3272,6 +3397,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions::default(),
             metrics: Some(paths.metrics.clone()),
+            target: Target::Umi,
             max_mismatches: 1,
             min_distance_diff: 2,
             umis: vec!["AAAAAA".to_string(), "CCCCCC".to_string()],
@@ -3344,6 +3470,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions::default(),
             metrics: None,
+            target: Target::Umi,
             max_mismatches: 2,
             min_distance_diff: 2,
             umis: FIXED_UMIS.iter().map(|s| (*s).to_string()).collect(),
@@ -3594,7 +3721,13 @@ mod tests {
             rejection_reason: RejectionReason::None,
         };
 
-        CorrectUmis::apply_correction_to_raw(&mut raw, &correction, *SamTag::RX, false);
+        CorrectUmis::apply_correction_to_raw(
+            &mut raw,
+            &correction,
+            *SamTag::RX,
+            *SamTag::OX,
+            false,
+        );
 
         // Verify corrected UMI
         let umi = fgumi_raw_bam::find_string_tag_in_record(&raw, SamTag::RX);
@@ -3626,7 +3759,13 @@ mod tests {
             rejection_reason: RejectionReason::None,
         };
 
-        CorrectUmis::apply_correction_to_raw(&mut raw, &correction, *SamTag::RX, false);
+        CorrectUmis::apply_correction_to_raw(
+            &mut raw,
+            &correction,
+            *SamTag::RX,
+            *SamTag::OX,
+            false,
+        );
 
         // Record should be unchanged
         assert_eq!(raw.len(), orig_len);
@@ -3714,6 +3853,7 @@ mod tests {
             },
             rejects_opts: RejectsOptions { rejects: Some(paths.rejects.clone()) },
             metrics: Some(paths.metrics.clone()),
+            target: Target::Umi,
             max_mismatches: 2,
             min_distance_diff: 2,
             umis: FIXED_UMIS.iter().map(|s| (*s).to_string()).collect(),
@@ -3835,7 +3975,7 @@ mod tests {
             rejection_reason: RejectionReason::None,
         };
 
-        CorrectUmis::apply_correction_to_raw(&mut raw, &correction, *SamTag::RX, true);
+        CorrectUmis::apply_correction_to_raw(&mut raw, &correction, *SamTag::RX, *SamTag::OX, true);
 
         // Corrected UMI should be present
         let umi = fgumi_raw_bam::find_string_tag_in_record(&raw, SamTag::RX);
@@ -3899,5 +4039,22 @@ mod tests {
             "estimate should account for kept-record capacities, rejects inner capacities, \
              and both outer-vec overheads",
         );
+    }
+
+    #[rstest]
+    #[case::umi(Target::Umi, SamTag::RX, SamTag::OX)]
+    #[case::barcode(Target::Barcode, SamTag::BC, SamTag::OB)]
+    fn target_maps_to_expected_tags(
+        #[case] target: Target,
+        #[case] expected_sequence: SamTag,
+        #[case] expected_original: SamTag,
+    ) {
+        assert_eq!(target.sequence_tag(), expected_sequence);
+        assert_eq!(target.original_tag(), expected_original);
+    }
+
+    #[test]
+    fn target_default_is_umi() {
+        assert_eq!(Target::default(), Target::Umi);
     }
 }

--- a/tests/integration/helpers/bam_generator.rs
+++ b/tests/integration/helpers/bam_generator.rs
@@ -58,6 +58,36 @@ pub fn create_umi_family(
         .collect()
 }
 
+/// Like [`create_umi_family`] but tags each read with an arbitrary `SamTag`
+/// (e.g. `SamTag::RX` for UMI mode or `SamTag::BC` for barcode mode).
+pub fn create_family_with_tag(
+    tag: SamTag,
+    umi: &str,
+    depth: usize,
+    base_name: &str,
+    sequence: &str,
+    quality: u8,
+) -> Vec<RawRecord> {
+    let seq = sequence.as_bytes();
+    let cigar_op = u32::try_from(seq.len()).expect("seq.len() fits u32") << 4;
+    (0..depth)
+        .map(|i| {
+            let name = format!("{base_name}_{i}");
+            let mut b = SamBuilder::new();
+            b.read_name(name.as_bytes())
+                .ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .flags(0)
+                .cigar_ops(&[cigar_op])
+                .sequence(seq)
+                .qualities(&vec![quality; seq.len()])
+                .add_string_tag(tag, umi.as_bytes());
+            b.build()
+        })
+        .collect()
+}
+
 /// Creates a paired-end UMI family.
 ///
 /// All reads are mapped to reference sequence 0. R1 is mapped at position 100,

--- a/tests/integration/test_correct_command.rs
+++ b/tests/integration/test_correct_command.rs
@@ -7,15 +7,22 @@
 
 use clap::Parser;
 use fgumi_lib::commands::command::Command;
-use fgumi_lib::commands::correct::CorrectUmis;
+use fgumi_lib::commands::correct::{CorrectUmis, Target};
+use fgumi_lib::sam::SamTag;
 use fgumi_raw_bam::RawRecord;
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
+use noodles::sam::alignment::record::data::field::Tag;
+use noodles::sam::alignment::record_buf::data::field::Value;
+use rstest::rstest;
+use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 use tempfile::TempDir;
 
-use crate::helpers::bam_generator::{create_minimal_header, create_umi_family, to_record_buf};
+use crate::helpers::bam_generator::{
+    create_family_with_tag, create_minimal_header, create_umi_family, to_record_buf,
+};
 
 /// Write a BAM with UMI-tagged reads.
 fn create_umi_bam(path: &PathBuf, families: Vec<Vec<RawRecord>>) {
@@ -37,6 +44,59 @@ fn create_umi_bam(path: &PathBuf, families: Vec<Vec<RawRecord>>) {
 /// Write a UMI whitelist file.
 fn create_whitelist(path: &PathBuf, umis: &[&str]) {
     fs::write(path, umis.join("\n")).expect("Failed to write whitelist");
+}
+
+/// Read the output BAM into an independent per-record oracle: a map from read
+/// name to that record's values for `tags` (aligned to `tags`, `None` when a
+/// tag is absent). Enables order-independent, per-record identity assertions
+/// (`{QNAME -> (RX, BC, OX, ob)}`) instead of aggregate counts. Panics on a
+/// duplicate read name so the oracle stays unambiguous.
+fn records_by_name(path: &PathBuf, tags: &[SamTag]) -> BTreeMap<String, Vec<Option<String>>> {
+    let noodles_tags: Vec<Tag> = tags.iter().map(|t| t.to_noodles_tag()).collect();
+    let mut reader = bam::io::Reader::new(fs::File::open(path).expect("open bam"));
+    let header = reader.read_header().expect("read header");
+    let mut out: BTreeMap<String, Vec<Option<String>>> = BTreeMap::new();
+    for result in reader.record_bufs(&header) {
+        let record = result.expect("read record");
+        let name = record
+            .name()
+            .map(|n| String::from_utf8_lossy(n.as_ref()).into_owned())
+            .expect("record missing read name");
+        let values = noodles_tags
+            .iter()
+            .zip(tags)
+            .map(|(noodles_tag, tag)| {
+                record.data().get(noodles_tag).map(|value| match value {
+                    Value::String(s) => s.to_string(),
+                    other => panic!("{tag} tag is not a string: {other:?}"),
+                })
+            })
+            .collect();
+        assert!(out.insert(name.clone(), values).is_none(), "duplicate read name {name}");
+    }
+    out
+}
+
+/// Build the expected per-record oracle for `records_by_name(.., &[seq_tag,
+/// original_tag])` over a fixture of `exact_{0..exact}` reads (correct as-is,
+/// no original stored) and `corr_{0..corrected}` reads (one-mismatch, corrected
+/// with the original stored). `store_original` reflects whether the run kept
+/// the original value (`false` under `--dont-store-original`).
+fn expected_target_records(
+    exact: usize,
+    corrected: usize,
+    store_original: bool,
+) -> BTreeMap<String, Vec<Option<String>>> {
+    let seq = Some("ACGTACGT".to_string());
+    let original = store_original.then(|| "ACGTACGA".to_string());
+    let mut expected: BTreeMap<String, Vec<Option<String>>> = BTreeMap::new();
+    for i in 0..exact {
+        expected.insert(format!("exact_{i}"), vec![seq.clone(), None]);
+    }
+    for i in 0..corrected {
+        expected.insert(format!("corr_{i}"), vec![seq.clone(), original.clone()]);
+    }
+    expected
 }
 
 /// Test basic UMI correction.
@@ -245,4 +305,202 @@ fn test_correct_command_rejects_streaming_threaded_integrity() {
     let observed_names: std::collections::HashSet<String> =
         observed_order.iter().cloned().collect();
     assert_eq!(observed_names, expected_names, "unexpected reject-name set");
+}
+
+/// Corrected value lands in the target's sequence tag (`RX` for UMI, `BC` for
+/// barcode) and the pre-correction original lands in the target's original
+/// tag (`OX` for UMI, `ob` for barcode); exact-match reads carry no original.
+///
+/// Asserts per-record identity (`{QNAME -> (seq_tag, original_tag)}`) against
+/// an independently constructed expected map, so a broken tag mapping — or one
+/// that drops/duplicates records — fails rather than passing an aggregate
+/// count. `seq_tag`/`original_tag` come from the case table (literal tags),
+/// not from `Target::sequence_tag()`, so the oracle does not derive its
+/// expectations from the code under test. Both the single-thread (`None`) and
+/// multi-threaded (`Some(2)`) pipeline paths are covered per target.
+#[rstest]
+#[case::umi_serial(Target::Umi, SamTag::RX, SamTag::OX, None)]
+#[case::umi_threaded(Target::Umi, SamTag::RX, SamTag::OX, Some(2))]
+#[case::barcode_serial(Target::Barcode, SamTag::BC, SamTag::OB, None)]
+#[case::barcode_threaded(Target::Barcode, SamTag::BC, SamTag::OB, Some(2))]
+fn correct_writes_corrected_value_and_original_by_target(
+    #[case] target: Target,
+    #[case] seq_tag: SamTag,
+    #[case] original_tag: SamTag,
+    #[case] threads: Option<usize>,
+) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let whitelist = temp_dir.path().join("whitelist.txt");
+
+    // 3 exact-match + 2 one-mismatch (correctable) reads on the target tag.
+    let exact = create_family_with_tag(seq_tag, "ACGTACGT", 3, "exact", "AAAAGGGG", 30);
+    let corrected = create_family_with_tag(seq_tag, "ACGTACGA", 2, "corr", "AAAAGGGG", 30);
+    create_umi_bam(&input_bam, vec![exact, corrected]);
+    create_whitelist(&whitelist, &["ACGTACGT"]);
+
+    let target_str = match target {
+        Target::Umi => "umi",
+        Target::Barcode => "barcode",
+    };
+    let mut args = vec![
+        "correct".to_string(),
+        "-i".to_string(),
+        input_bam.to_str().unwrap().to_string(),
+        "-o".to_string(),
+        output_bam.to_str().unwrap().to_string(),
+        "-U".to_string(),
+        whitelist.to_str().unwrap().to_string(),
+        "--max-mismatches".to_string(),
+        "1".to_string(),
+        "--min-distance".to_string(),
+        "1".to_string(),
+        "--target".to_string(),
+        target_str.to_string(),
+    ];
+    if let Some(n) = threads {
+        args.push("--threads".to_string());
+        args.push(n.to_string());
+    }
+    let cmd = CorrectUmis::try_parse_from(args).expect("parse");
+    cmd.execute("test").expect("correct runs");
+
+    // Independent per-record oracle: each named record must carry exactly the
+    // expected sequence-tag and original-tag values.
+    let actual = records_by_name(&output_bam, &[seq_tag, original_tag]);
+    let expected = expected_target_records(3, 2, true);
+    assert_eq!(actual, expected);
+}
+
+/// `--dont-store-original` suppresses the original-tag write for both targets,
+/// on both pipeline paths. The corrected reads are still kept and carry the
+/// corrected value in the sequence tag — asserted via the per-record oracle so
+/// the suppression check cannot pass vacuously on an empty (all-rejected)
+/// output. `seq_tag`/`original_tag` are literal case-table tags, decoupled from
+/// `Target::sequence_tag()`.
+#[rstest]
+#[case::umi_serial(Target::Umi, SamTag::RX, SamTag::OX, None)]
+#[case::umi_threaded(Target::Umi, SamTag::RX, SamTag::OX, Some(2))]
+#[case::barcode_serial(Target::Barcode, SamTag::BC, SamTag::OB, None)]
+#[case::barcode_threaded(Target::Barcode, SamTag::BC, SamTag::OB, Some(2))]
+fn correct_dont_store_original_suppresses_original_by_target(
+    #[case] target: Target,
+    #[case] seq_tag: SamTag,
+    #[case] original_tag: SamTag,
+    #[case] threads: Option<usize>,
+) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let whitelist = temp_dir.path().join("whitelist.txt");
+
+    // 3 exact-match + 2 one-mismatch (correctable) reads on the target tag, so
+    // the oracle can confirm kept records exist (guarding a vacuous pass).
+    let exact = create_family_with_tag(seq_tag, "ACGTACGT", 3, "exact", "AAAAGGGG", 30);
+    let corrected = create_family_with_tag(seq_tag, "ACGTACGA", 2, "corr", "AAAAGGGG", 30);
+    create_umi_bam(&input_bam, vec![exact, corrected]);
+    create_whitelist(&whitelist, &["ACGTACGT"]);
+
+    let target_str = match target {
+        Target::Umi => "umi",
+        Target::Barcode => "barcode",
+    };
+    let mut args = vec![
+        "correct".to_string(),
+        "-i".to_string(),
+        input_bam.to_str().unwrap().to_string(),
+        "-o".to_string(),
+        output_bam.to_str().unwrap().to_string(),
+        "-U".to_string(),
+        whitelist.to_str().unwrap().to_string(),
+        "--max-mismatches".to_string(),
+        "1".to_string(),
+        "--min-distance".to_string(),
+        "1".to_string(),
+        "--target".to_string(),
+        target_str.to_string(),
+        "--dont-store-original".to_string(),
+    ];
+    if let Some(n) = threads {
+        args.push("--threads".to_string());
+        args.push(n.to_string());
+    }
+    let cmd = CorrectUmis::try_parse_from(args).expect("parse");
+    cmd.execute("test").expect("correct runs");
+
+    // Corrected reads are still present and corrected, but NO original was
+    // stored (store_original = false) — even for the corrected reads.
+    let actual = records_by_name(&output_bam, &[seq_tag, original_tag]);
+    let expected = expected_target_records(3, 2, false);
+    assert_eq!(actual, expected);
+}
+
+/// Records carrying BOTH an `RX` (UMI) tag and a `BC` (barcode) tag, when run
+/// through `--target barcode`, should have only `BC`/`ob` touched: `BC` is
+/// corrected as expected, while `RX` is left byte-for-byte as the input wrote
+/// it and no `OX` tag is written. This guards against a correction pass
+/// bleeding across the two tag pairs when both are present on a record.
+#[test]
+fn correct_barcode_leaves_umi_tags_untouched() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let whitelist = temp_dir.path().join("whitelist.txt");
+
+    // Build families via the RX helper, then add a second BC tag to every
+    // record so each carries both tags: an untouched, unmatched-to-any-fixed
+    // UMI on RX and a barcode on BC that we want corrected.
+    let build_dual_tag_family = |bc: &str, depth: usize, base_name: &str| -> Vec<RawRecord> {
+        create_family_with_tag(SamTag::RX, "TTTTTTTT", depth, base_name, "AAAAGGGG", 30)
+            .into_iter()
+            .map(|mut record| {
+                fgumi_raw_bam::update_string_tag(record.as_mut_vec(), SamTag::BC, bc.as_bytes());
+                record
+            })
+            .collect()
+    };
+
+    let exact = build_dual_tag_family("ACGTACGT", 3, "exact");
+    let corrected = build_dual_tag_family("ACGTACGA", 2, "corr");
+    create_umi_bam(&input_bam, vec![exact, corrected]);
+    create_whitelist(&whitelist, &["ACGTACGT"]);
+
+    let cmd = CorrectUmis::try_parse_from([
+        "correct",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-o",
+        output_bam.to_str().unwrap(),
+        "-U",
+        whitelist.to_str().unwrap(),
+        "--max-mismatches",
+        "1",
+        "--min-distance",
+        "1",
+        "--target",
+        "barcode",
+    ])
+    .expect("parse");
+    cmd.execute("test").expect("correct runs");
+
+    // Per-record identity over both tag pairs (`RX`, `BC`, `OX`, `ob`): `BC` is
+    // corrected to the fixed barcode with the original stashed in `ob` for the
+    // corrected reads only, while the UMI pair is left exactly as the input
+    // wrote it — `RX` still the uncorrected "TTTTTTTT" and no `OX` on any
+    // record. Asserting full per-record identity (not aggregates) catches any
+    // cross-contamination between the two tag pairs.
+    let actual = records_by_name(&output_bam, &[SamTag::RX, SamTag::BC, SamTag::OX, SamTag::OB]);
+    let rx = || Some("TTTTTTTT".to_string());
+    let bc = || Some("ACGTACGT".to_string());
+    let mut expected: BTreeMap<String, Vec<Option<String>>> = BTreeMap::new();
+    for i in 0..3 {
+        // exact-match barcode reads: BC unchanged in value, no `ob`.
+        expected.insert(format!("exact_{i}"), vec![rx(), bc(), None, None]);
+    }
+    for i in 0..2 {
+        // corrected barcode reads: BC corrected, original barcode in `ob`.
+        expected.insert(format!("corr_{i}"), vec![rx(), bc(), None, Some("ACGTACGA".to_string())]);
+    }
+    assert_eq!(actual, expected);
 }


### PR DESCRIPTION
## Summary

Adds a bounded `-t/--target {umi,barcode}` option to `fgumi correct` so it can error-correct the `BC` sample/library-barcode tag as well as the `RX` UMI tag. The default (`umi`) reproduces today's behavior exactly.

- `--target umi` (default) — reads/writes `RX`, stashes the pre-correction value in `OX`. Unchanged behavior.
- `--target barcode` — reads/writes `BC`, stashes the pre-correction value in the fgumi-local `ob` tag.

## Motivation

`correct`'s model — error-correct observed sequences against a fixed set of known sequences — fits sample/library barcodes at least as well as UMIs, since barcodes come from a known whitelist (sample sheet / index kit). fgbio's `CorrectUmis` already supports this through its free-form `-t/--umi-tag`, so `CorrectUmis -t BC` works today.

fgumi deliberately removed that free-form override in #239 to prevent the misconfiguration bug class it describes (a non-standard tag threaded through a pipeline with one step misconfigured, yielding silently-wrong results). This PR restores the *capability* without reopening that hole: `--target` is a bounded enum over two SAM-spec standard tags (`RX` / `BC`), not an arbitrary tag string. There is no way to point `correct` at a non-standard tag.

## The `ob` tag

There is no SAM-spec "original barcode" tag (the spec has `QT` for barcode *quality*, but no analogue of `OX`). fgbio sidesteps this by writing the original barcode into `OX` — literally the "original UMI bases" tag — which this PR treats as a semantic mismatch to avoid. Instead the pre-correction barcode goes to a new fgumi-local tag `ob`. The lowercase spelling is intentional: the SAM spec reserves tags containing lowercase letters for local/end-user use and promises never to standardize them, so `ob` honestly signals a local convention rather than masquerading as a standard tag.

## Changes

- New `SamTag::OB` (`ob`) constant in `fgumi-tag`.
- New `Target { Umi, Barcode }` enum with `sequence_tag()` / `original_tag()` returning the `(RX, OX)` / `(BC, ob)` pairs; threaded through `correct`'s existing tag-agnostic plumbing (both the threaded and single-thread pipeline paths).
- `correct` gains `-t/--target <umi|barcode>` (default `umi`).
- The store-original flag is renamed to the mode-neutral `--dont-store-original`, with `--dont-store-original-umis` kept as a hidden alias for backward compatibility.
- `--help` text and module docs updated to describe both modes.

Correcting both `RX` and `BC` is two invocations, which keeps per-pass metrics and rejects unambiguous.

## Testing

- Unit: `Target` tag-pair mapping and the `ob`/`OB` constant.
- Integration (`#[rstest]` case tables over both modes): corrected value lands in the right tag, original in the right tag (`OX` / `ob`), and `--dont-store-original` (and its alias) suppresses the original write.
- A threaded-path barcode case (`--threads 2`) and a cross-contamination guard confirming a `barcode` run leaves `RX`/`OX` untouched.
- All test data is built programmatically with `SamBuilder`; no committed fixtures.

Backward compatibility: default `--target umi` is byte-for-byte identical to prior behavior, and the existing `correct` test suite passes unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added barcode correction support alongside UMI correction.
  * Added a target option to choose whether to correct UMI or barcode (default: UMI).
  * Corrected values are now written to the selected tag, with optional preservation of the original value.
  * Added a new local barcode “original barcode” tag used for storing the pre-correction value when enabled.

* **Bug Fixes**
  * Improved correctness of tag updates for both targets across single-threaded and multi-threaded processing.
  * Ensured correct behavior when records contain both UMI and barcode tags, including proper suppression of original-tag writes when no correction occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->