### PR TITLE
refactor(consensus): share one consensus read-name implementation

### DIFF
--- a/crates/fgumi-consensus/src/caller.rs
+++ b/crates/fgumi-consensus/src/caller.rs
@@ -523,6 +523,26 @@ impl RejectionReason {
     }
 }
 
+/// Writes the consensus read name `"<read_name_prefix>:<umi>"` into `buf`, replacing whatever
+/// it held before.
+///
+/// Every consensus caller (vanilla, duplex, CODEC) names its output reads this way, once per
+/// emitted record. Sharing one implementation keeps the three callers from drifting, and
+/// writing into a caller-owned buffer instead of building a fresh `String` with `format!`
+/// keeps the name off the allocator on a path that runs once per output record.
+///
+/// # Arguments
+/// * `buf` - Reusable buffer that receives the read name
+/// * `read_name_prefix` - Prefix shared by every consensus read (see [`make_prefix_from_header`])
+/// * `umi` - Molecule identifier that distinguishes this consensus read
+pub fn write_consensus_read_name(buf: &mut Vec<u8>, read_name_prefix: &str, umi: &str) {
+    buf.clear();
+    buf.reserve(read_name_prefix.len() + 1 + umi.len());
+    buf.extend_from_slice(read_name_prefix.as_bytes());
+    buf.push(b':');
+    buf.extend_from_slice(umi.as_bytes());
+}
+
 /// Creates a read name prefix from the SAM header read groups.
 ///
 /// This matches fgbio's `makePrefixFromSamHeader` behavior:

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -75,7 +75,7 @@
 use crate::caller::{
     ConsensusCaller, ConsensusCallingStats, ConsensusOutput,
     RejectionReason as CallerRejectionReason, clamp_combined_error_to_fgbio_short,
-    clamp_per_base_to_fgbio_short,
+    clamp_per_base_to_fgbio_short, write_consensus_read_name,
 };
 use crate::phred::{MIN_PHRED, NO_CALL_BASE, NO_CALL_BASE_LOWER, PhredScore};
 use crate::simple_umi::consensus_umis;
@@ -342,6 +342,9 @@ pub struct CodecConsensusCaller {
     /// Reusable builder for raw-byte BAM record output
     bam_builder: UnmappedSamBuilder,
 
+    /// Reusable buffer holding the read name of the consensus record being built
+    read_name_buf: Vec<u8>,
+
     /// Whether to store rejected reads (raw bytes) for output
     track_rejects: bool,
 
@@ -407,6 +410,7 @@ impl CodecConsensusCaller {
             consensus_counter: 0,
             ss_caller,
             bam_builder: UnmappedSamBuilder::new(),
+            read_name_buf: Vec::new(),
             track_rejects: false,
             rejected_reads: Vec::new(),
         }
@@ -1340,6 +1344,23 @@ impl CodecConsensusCaller {
         consensus
     }
 
+    /// Writes the read name of the next consensus record into the reusable buffer.
+    ///
+    /// Records carrying a UMI are named `"<prefix>:<umi>"`, matching the vanilla and duplex
+    /// callers; records without one fall back to a running counter so every emitted name is
+    /// still unique.
+    fn write_read_name(&mut self, umi: Option<&str>) {
+        self.consensus_counter += 1;
+        if let Some(umi_str) = umi {
+            write_consensus_read_name(&mut self.read_name_buf, &self.read_name_prefix, umi_str);
+        } else {
+            use std::io::Write as _;
+            self.read_name_buf.clear();
+            write!(&mut self.read_name_buf, "{}:{}", self.read_name_prefix, self.consensus_counter)
+                .expect("writing to a Vec<u8> cannot fail");
+        }
+    }
+
     /// Builds the output record from the consensus and writes raw bytes into `output`.
     ///
     /// # Errors
@@ -1361,12 +1382,7 @@ impl CodecConsensusCaller {
         all_records: &[RawRecord],
     ) -> Result<()> {
         // Generate read name - use ':' delimiter to match fgbio format
-        self.consensus_counter += 1;
-        let read_name = if let Some(umi_str) = umi {
-            format!("{}:{}", self.read_name_prefix, umi_str)
-        } else {
-            format!("{}:{}", self.read_name_prefix, self.consensus_counter)
-        };
+        self.write_read_name(umi);
 
         // Codec always outputs unmapped fragments
         let flag = flags::UNMAPPED;
@@ -1375,7 +1391,7 @@ impl CodecConsensusCaller {
         // not a bug: return an error rather than panicking partway through
         // writing the output.
         self.bam_builder.try_build_record(
-            read_name.as_bytes(),
+            &self.read_name_buf,
             flag,
             &consensus.bases,
             &consensus.quals,

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -204,7 +204,7 @@ use noodles::sam::alignment::record_buf::RecordBuf;
 use crate::caller::ConsensusOutput;
 use crate::caller::{
     ConsensusCaller, ConsensusCallingStats, RejectionReason, clamp_combined_error_to_fgbio_short,
-    clamp_per_base_to_fgbio_short,
+    clamp_per_base_to_fgbio_short, write_consensus_read_name,
 };
 use crate::phred::MAX_PHRED;
 use crate::phred::{MIN_PHRED, PhredScore};
@@ -1029,6 +1029,7 @@ impl DuplexConsensusCaller {
     ///
     /// # Arguments
     /// * `builder` - Reusable builder for raw BAM record construction
+    /// * `read_name_buf` - Reusable buffer holding the record's read name
     /// * `output` - `ConsensusOutput` to append the record into
     /// * `consensus` - The duplex consensus read to convert
     /// * `read_type` - Whether this is R1 or R2
@@ -1056,6 +1057,7 @@ impl DuplexConsensusCaller {
     )]
     pub(crate) fn duplex_read_into(
         builder: &mut UnmappedSamBuilder,
+        read_name_buf: &mut Vec<u8>,
         output: &mut ConsensusOutput,
         consensus: &DuplexConsensusRead,
         read_type: ReadType,
@@ -1085,10 +1087,10 @@ impl DuplexConsensusCaller {
         }
 
         // Build the record (name, flags, bases, quals)
-        let read_name = format!("{read_name_prefix}:{umi}");
+        write_consensus_read_name(read_name_buf, read_name_prefix, umi);
         // The UMI is input-derived, so an over-long name is bad data rather than
         // a bug; propagate instead of panicking mid-write.
-        builder.try_build_record(read_name.as_bytes(), flag, &consensus.bases, &consensus.quals)?;
+        builder.try_build_record(read_name_buf, flag, &consensus.bases, &consensus.quals)?;
 
         // 1. MI tag (string)
         builder.append_string_tag(SamTag::MI, umi.as_bytes());
@@ -1765,6 +1767,7 @@ impl DuplexConsensusCaller {
     ) -> Result<(ConsensusOutput, ConsensusCallingStats, Vec<Vec<u8>>)> {
         let mut stats = ConsensusCallingStats::new();
         let mut builder = UnmappedSamBuilder::new();
+        let mut read_name_buf = Vec::new();
         let mut output = ConsensusOutput::default();
         let methylation_mode = ss_caller.options.methylation_mode;
 
@@ -2081,6 +2084,7 @@ impl DuplexConsensusCaller {
                         // Write DuplexConsensusReads as raw bytes
                         Self::duplex_read_into(
                             &mut builder,
+                            &mut read_name_buf,
                             &mut output,
                             &dr1,
                             ReadType::R1,
@@ -2097,6 +2101,7 @@ impl DuplexConsensusCaller {
                         )?;
                         Self::duplex_read_into(
                             &mut builder,
+                            &mut read_name_buf,
                             &mut output,
                             &dr2,
                             ReadType::R2,
@@ -2133,6 +2138,7 @@ impl DuplexConsensusCaller {
                         let empty: &[&RawRecord] = &[];
                         Self::duplex_read_into(
                             &mut builder,
+                            &mut read_name_buf,
                             &mut output,
                             &dr1,
                             ReadType::R1,
@@ -2149,6 +2155,7 @@ impl DuplexConsensusCaller {
                         )?;
                         Self::duplex_read_into(
                             &mut builder,
+                            &mut read_name_buf,
                             &mut output,
                             &dr2,
                             ReadType::R2,
@@ -2185,6 +2192,7 @@ impl DuplexConsensusCaller {
                         let empty: &[&RawRecord] = &[];
                         Self::duplex_read_into(
                             &mut builder,
+                            &mut read_name_buf,
                             &mut output,
                             &dr1,
                             ReadType::R1,
@@ -2201,6 +2209,7 @@ impl DuplexConsensusCaller {
                         )?;
                         Self::duplex_read_into(
                             &mut builder,
+                            &mut read_name_buf,
                             &mut output,
                             &dr2,
                             ReadType::R2,
@@ -4379,9 +4388,12 @@ mod tests {
         };
 
         let mut builder = UnmappedSamBuilder::new();
+
+        let mut read_name_buf = Vec::new();
         let mut output = ConsensusOutput::default();
         DuplexConsensusCaller::duplex_read_into(
             &mut builder,
+            &mut read_name_buf,
             &mut output,
             &duplex,
             ReadType::Fragment,
@@ -4780,9 +4792,12 @@ mod tests {
         let cell_barcode = "ACGTACGT-1";
 
         let mut builder = UnmappedSamBuilder::new();
+
+        let mut read_name_buf = Vec::new();
         let mut output = ConsensusOutput::default();
         DuplexConsensusCaller::duplex_read_into(
             &mut builder,
+            &mut read_name_buf,
             &mut output,
             &duplex,
             ReadType::Fragment,
@@ -4831,9 +4846,12 @@ mod tests {
         };
 
         let mut builder = UnmappedSamBuilder::new();
+
+        let mut read_name_buf = Vec::new();
         let mut output = ConsensusOutput::default();
         DuplexConsensusCaller::duplex_read_into(
             &mut builder,
+            &mut read_name_buf,
             &mut output,
             &duplex,
             ReadType::Fragment,
@@ -4962,9 +4980,12 @@ mod tests {
         };
 
         let mut builder = UnmappedSamBuilder::new();
+
+        let mut read_name_buf = Vec::new();
         let mut output = ConsensusOutput::default();
         DuplexConsensusCaller::duplex_read_into(
             &mut builder,
+            &mut read_name_buf,
             &mut output,
             &duplex,
             ReadType::R1,
@@ -5035,9 +5056,12 @@ mod tests {
         };
 
         let mut builder = UnmappedSamBuilder::new();
+
+        let mut read_name_buf = Vec::new();
         let mut output = ConsensusOutput::default();
         DuplexConsensusCaller::duplex_read_into(
             &mut builder,
+            &mut read_name_buf,
             &mut output,
             &duplex,
             ReadType::R1,
@@ -5105,9 +5129,12 @@ mod tests {
         };
 
         let mut builder = UnmappedSamBuilder::new();
+
+        let mut read_name_buf = Vec::new();
         let mut output = ConsensusOutput::default();
         DuplexConsensusCaller::duplex_read_into(
             &mut builder,
+            &mut read_name_buf,
             &mut output,
             &duplex,
             ReadType::R1,
@@ -5213,9 +5240,12 @@ mod tests {
         };
 
         let mut builder = UnmappedSamBuilder::new();
+
+        let mut read_name_buf = Vec::new();
         let mut output = ConsensusOutput::default();
         DuplexConsensusCaller::duplex_read_into(
             &mut builder,
+            &mut read_name_buf,
             &mut output,
             &duplex,
             ReadType::R1,
@@ -5274,9 +5304,11 @@ mod tests {
         // Helper to build and parse a single record
         let build_and_parse = |read_type: ReadType| -> ParsedBamRecord {
             let mut builder = UnmappedSamBuilder::new();
+            let mut read_name_buf = Vec::new();
             let mut output = ConsensusOutput::default();
             DuplexConsensusCaller::duplex_read_into(
                 &mut builder,
+                &mut read_name_buf,
                 &mut output,
                 &duplex,
                 read_type,
@@ -6106,9 +6138,12 @@ mod tests {
         let duplex = duplex_result.expect("Should produce duplex consensus");
 
         let mut builder = UnmappedSamBuilder::new();
+
+        let mut read_name_buf = Vec::new();
         let mut output = ConsensusOutput::default();
         DuplexConsensusCaller::duplex_read_into(
             &mut builder,
+            &mut read_name_buf,
             &mut output,
             &duplex,
             ReadType::Fragment,

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -5,7 +5,10 @@
 //! sequence using a likelihood-based model.
 
 use crate::base_builder::ConsensusBaseBuilder;
-use crate::caller::{ConsensusCaller, ConsensusCallingStats, ConsensusOutput, RejectionReason};
+use crate::caller::{
+    ConsensusCaller, ConsensusCallingStats, ConsensusOutput, RejectionReason,
+    write_consensus_read_name,
+};
 use crate::phred::{
     MIN_PHRED, NO_CALL_BASE, NO_CALL_BASE_LOWER, PhredScore, ln_error_prob_two_trials,
     ln_prob_to_phred, phred_to_ln_error_prob,
@@ -386,6 +389,9 @@ pub struct VanillaUmiConsensusCaller {
 
     /// Reference sequence names indexed by `ref_id` (for mapping `ref_id` → contig name).
     ref_names: Option<std::sync::Arc<Vec<String>>>,
+
+    /// Reusable buffer holding the read name of the consensus record being built.
+    read_name_buf: Vec<u8>,
 }
 
 #[expect(
@@ -450,6 +456,7 @@ impl VanillaUmiConsensusCaller {
             bam_builder: UnmappedSamBuilder::new(),
             reference: None,
             ref_names: None,
+            read_name_buf: Vec::new(),
         }
     }
 
@@ -1454,7 +1461,7 @@ impl VanillaUmiConsensusCaller {
         errors: &[u16],
         methylation: Option<&crate::methylation::MethylationAnnotation>,
     ) -> Result<()> {
-        let read_name = format!("{}:{}", self.read_name_prefix, umi);
+        write_consensus_read_name(&mut self.read_name_buf, &self.read_name_prefix, umi);
 
         let mut flag = flags::UNMAPPED;
         match read_type {
@@ -1469,7 +1476,7 @@ impl VanillaUmiConsensusCaller {
 
         // The UMI is input-derived, so an over-long name is bad data rather than
         // a bug; propagate instead of panicking mid-write.
-        self.bam_builder.try_build_record(read_name.as_bytes(), flag, bases, quals)?;
+        self.bam_builder.try_build_record(&self.read_name_buf, flag, bases, quals)?;
 
         // RG tag
         self.bam_builder.append_string_tag(SamTag::RG, self.read_group_id.as_bytes());


### PR DESCRIPTION
## Summary

This is a **hygiene / deduplication** change. It is explicitly **not** a performance PR — see "On performance" below.

The vanilla, duplex and CODEC consensus callers each constructed their output read name with their own copy of `format!("{}:{}", read_name_prefix, umi)`. The naming convention — the `:` delimiter that matches fgbio — therefore lived in three separate places and had to be kept in sync by hand.

This PR adds a single shared implementation, `caller::write_consensus_read_name(buf, read_name_prefix, umi)`, and has all three callers use it. The name is written into a caller-owned `Vec<u8>` that is reused across records rather than allocating a fresh `String` per emitted record.

CODEC has a second naming path: records without a UMI fall back to `"<prefix>:<counter>"`. That branch now writes into the same buffer via `write!`, and both branches moved into a small private `CodecConsensusCaller::write_read_name` helper so `build_output_record_into` stays under the line limit and the two naming rules sit next to each other.

Duplex's `duplex_read_into` is an associated function that already receives a reusable `UnmappedSamBuilder`; it now receives a companion `&mut Vec<u8>` for the read name, declared alongside the builder in `call_group` so both have the same per-group lifetime.

## On performance

Removing a per-record `String` allocation is a real (small) win, but the honest ceiling here is **0.44% (simplex) / 0.68% (duplex)** `fmt` inclusive time — comfortably below run-to-run variance. **No speedup is claimed and none should be inferred.** The value of this change is that the three callers now share one implementation instead of three copies of the same string format.

## Correctness

Output is byte-identical across simplex, duplex and CODEC — this change alters how the name bytes are produced, not what they are.

All 588 `fgumi-consensus` tests pass. `cargo fmt --check` and `cargo clippy --all-targets` (with `-D warnings -W clippy::pedantic`) are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved consensus record generation by reusing memory when constructing read names.
  * Reduced temporary allocations during consensus processing, which may improve throughput and resource efficiency for large datasets.

* **Consistency**
  * Standardized consensus read names using the `<read-name-prefix>:<UMI>` format across supported consensus workflows.

* **Bug Fixes**
  * Preserved validation for read names that exceed supported length limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->