### PR TITLE
fix(extract): error on an over-long read name instead of panicking

### DIFF
--- a/crates/fgumi-consensus/src/caller.rs
+++ b/crates/fgumi-consensus/src/caller.rs
@@ -543,6 +543,43 @@ pub fn write_consensus_read_name(buf: &mut Vec<u8>, read_name_prefix: &str, umi:
     buf.extend_from_slice(umi.as_bytes());
 }
 
+/// Context for a consensus read name that BAM cannot represent.
+///
+/// The builder's own `ReadNameTooLong` reports the length and the limit but not *which*
+/// consensus group hit it. The UMI is input-derived, so on a large batch job a single
+/// malformed molecule identifier otherwise aborts the run with no way to find it. `name` is
+/// the fully-built consensus read name (see [`write_consensus_read_name`]), so it identifies
+/// the group by both prefix and UMI. A long name is truncated to a bounded head AND tail so
+/// it stays readable, and so the identifying bytes survive at *either* end: the read-group
+/// prefix leads and the UMI trails (see [`write_consensus_read_name`]). Showing only the head
+/// would drop the UMI — the very identifier this context exists to surface — for two groups
+/// that share a prefix. The tail is bounded too, so a name that is over-long *because* of an
+/// input-derived UMI cannot produce a multi-kilobyte line.
+///
+/// Shared by all three callers (vanilla, duplex, CODEC) for the same reason the name-writing
+/// itself is: three copies of this drift.
+#[must_use]
+pub fn consensus_read_name_too_long_context(name: &[u8]) -> String {
+    format!("could not write the consensus record for read {}", render_bounded_read_name(name))
+}
+
+/// Render a read name for a diagnostic, bounded at both ends.
+///
+/// A name within the budget is shown whole; a longer one becomes `head...tail` with the
+/// `(name shown truncated)` marker, retaining the leading `HEAD` and trailing `TAIL` bytes so
+/// distinguishing content at either end survives. `HEAD + TAIL` equals the whole-name budget,
+/// so a name at the budget is shown in full and the boundary is exact.
+fn render_bounded_read_name(name: &[u8]) -> String {
+    const HEAD: usize = 44;
+    const TAIL: usize = 20;
+    if name.len() <= HEAD + TAIL {
+        return format!("'{}'", String::from_utf8_lossy(name));
+    }
+    let head = String::from_utf8_lossy(&name[..HEAD]);
+    let tail = String::from_utf8_lossy(&name[name.len() - TAIL..]);
+    format!("'{head}...{tail}' (name shown truncated)")
+}
+
 /// Creates a read name prefix from the SAM header read groups.
 ///
 /// This matches fgbio's `makePrefixFromSamHeader` behavior:
@@ -603,6 +640,114 @@ mod tests {
     #[case::u16_max(65_535, 32_767)]
     fn test_clamp_per_base_to_fgbio_short(#[case] input: u16, #[case] expected: i32) {
         assert_eq!(clamp_per_base_to_fgbio_short(input), expected);
+    }
+
+    /// A name with a recognizable leading and trailing token, padded to `total` bytes, so a
+    /// truncated rendering can be checked for retaining *both* ends.
+    fn tagged_name(total: usize) -> Vec<u8> {
+        const LEAD: &[u8] = b"LEADmarker"; // 10 bytes — stands in for the read-group prefix
+        const TAIL: &[u8] = b"tailUMI0"; //   8 bytes — stands in for the UMI at the tail
+        assert!(total >= LEAD.len() + TAIL.len());
+        let mut v = Vec::with_capacity(total);
+        v.extend_from_slice(LEAD);
+        v.resize(total - TAIL.len(), b'x');
+        v.extend_from_slice(TAIL);
+        v
+    }
+
+    /// The context must name the offending consensus read, and stay readable when the name is
+    /// long — which, for a `ReadNameTooLong` failure, it always is (255+ bytes by definition).
+    /// A truncated name must retain its head (read-group prefix) AND tail (UMI), so two groups
+    /// that differ only in their UMI stay distinguishable.
+    #[rstest]
+    // Within budget: shown whole (both tokens present verbatim), no marker.
+    #[case::short(b"LEADmarker:AAA-tailUMI0".to_vec(), false)]
+    // Exactly at the 64-byte whole-name budget: still shown whole.
+    #[case::at_budget(tagged_name(64), false)]
+    // One past the budget: truncated to head+tail; both tokens must survive.
+    #[case::one_past_budget(tagged_name(65), true)]
+    // A real `ReadNameTooLong` name: truncated, both ends retained.
+    #[case::over_bam_limit(tagged_name(255), true)]
+    fn test_consensus_read_name_too_long_context(
+        #[case] name: Vec<u8>,
+        #[case] expect_truncated: bool,
+    ) {
+        let message = consensus_read_name_too_long_context(&name);
+
+        assert!(
+            message.starts_with("could not write the consensus record for read '"),
+            "unexpected message: {message}"
+        );
+        // The head (read-group prefix) and tail (UMI) tokens survive at both ends regardless
+        // of truncation — this is what keeps two same-prefix, different-UMI groups distinct.
+        assert!(message.contains("LEADmarker"), "{message} should retain the head token");
+        assert!(message.contains("tailUMI0"), "{message} should retain the tail token");
+        assert_eq!(
+            message.contains("(name shown truncated)"),
+            expect_truncated,
+            "a {}-byte name should{} be marked truncated: {message}",
+            name.len(),
+            if expect_truncated { "" } else { " not" }
+        );
+        if expect_truncated {
+            assert!(
+                message.contains("..."),
+                "a truncated name must show the ... elision: {message}"
+            );
+        } else {
+            // A within-budget name is shown in full, byte for byte.
+            let whole = String::from_utf8_lossy(&name);
+            assert!(
+                message.contains(whole.as_ref()),
+                "a within-budget name must be shown whole: {message}"
+            );
+        }
+    }
+
+    /// Two names sharing a prefix but differing only in their trailing UMI must produce
+    /// *different* diagnostics even once truncated — the whole reason the tail is retained.
+    #[test]
+    fn test_consensus_read_name_too_long_context_distinguishes_by_umi() {
+        let mut a = vec![b'p'; 250];
+        let mut b = a.clone();
+        a.extend_from_slice(b":UMI-AAAA");
+        b.extend_from_slice(b":UMI-CCCC");
+        let (msg_a, msg_b) =
+            (consensus_read_name_too_long_context(&a), consensus_read_name_too_long_context(&b));
+        assert_ne!(
+            msg_a, msg_b,
+            "different UMIs must give different diagnostics: {msg_a} vs {msg_b}"
+        );
+        assert!(msg_a.contains("UMI-AAAA") && msg_b.contains("UMI-CCCC"), "each UMI must survive");
+    }
+
+    /// The message must not grow with the name: a `ReadNameTooLong` name is unbounded, and a
+    /// multi-kilobyte error line is unreadable.
+    #[test]
+    fn test_consensus_read_name_too_long_context_length_is_bounded() {
+        let long = consensus_read_name_too_long_context(&vec![b'N'; 255]);
+        let much_longer = consensus_read_name_too_long_context(&vec![b'N'; 100_000]);
+
+        assert_eq!(long, much_longer, "the message must not grow with the name");
+        assert!(long.len() < 160, "message must stay readable, got {} bytes", long.len());
+
+        // All-invalid-UTF-8 at a realistic over-long length: lossy replacement expands each bad
+        // byte to the 3-byte U+FFFD, so the bound must hold against that worst case too.
+        let invalid = consensus_read_name_too_long_context(&vec![0xffu8; 4096]);
+        assert!(invalid.contains("(name shown truncated)"), "must be truncated: {invalid}");
+        assert!(
+            invalid.len() < 300,
+            "invalid-UTF-8 message must stay bounded, got {} bytes",
+            invalid.len()
+        );
+    }
+
+    /// Non-UTF-8 bytes in a name must not panic the error path — the context is built while
+    /// already reporting a failure, so it has to be total.
+    #[test]
+    fn test_consensus_read_name_too_long_context_tolerates_invalid_utf8() {
+        let message = consensus_read_name_too_long_context(&[0xff, 0xfe, b'x']);
+        assert!(message.contains('x'), "unexpected message: {message}");
     }
 
     #[test]

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -75,7 +75,7 @@
 use crate::caller::{
     ConsensusCaller, ConsensusCallingStats, ConsensusOutput,
     RejectionReason as CallerRejectionReason, clamp_combined_error_to_fgbio_short,
-    clamp_per_base_to_fgbio_short, write_consensus_read_name,
+    clamp_per_base_to_fgbio_short, consensus_read_name_too_long_context, write_consensus_read_name,
 };
 use crate::phred::{MIN_PHRED, NO_CALL_BASE, NO_CALL_BASE_LOWER, PhredScore};
 use crate::simple_umi::consensus_umis;
@@ -83,7 +83,7 @@ use crate::vanilla_caller::{
     VanillaConsensusRead, VanillaUmiConsensusCaller, VanillaUmiConsensusOptions,
 };
 use crate::{IndexedSourceRead, SourceRead, select_most_common_alignment_group};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use fgumi_dna::dna::reverse_complement;
 use fgumi_raw_bam::{
     self as bam_fields, RawRecord, RawRecordView, SamTag, UnmappedSamBuilder, flags,
@@ -1387,15 +1387,12 @@ impl CodecConsensusCaller {
         // Codec always outputs unmapped fragments
         let flag = flags::UNMAPPED;
 
-        // The UMI comes from the input BAM, so an over-long name is bad data,
-        // not a bug: return an error rather than panicking partway through
-        // writing the output.
-        self.bam_builder.try_build_record(
-            &self.read_name_buf,
-            flag,
-            &consensus.bases,
-            &consensus.quals,
-        )?;
+        // The UMI comes from the input BAM, so an over-long name is bad data, not a bug:
+        // return an error rather than panicking partway through writing the output, naming
+        // the offending read so the failing molecule is findable in a batch run.
+        self.bam_builder
+            .try_build_record(&self.read_name_buf, flag, &consensus.bases, &consensus.quals)
+            .with_context(|| consensus_read_name_too_long_context(&self.read_name_buf))?;
 
         // RG tag
         self.bam_builder.append_string_tag(SamTag::RG, self.read_group_id.as_bytes());

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -188,9 +188,7 @@
 
 #[cfg(test)]
 use ahash::AHashMap;
-#[cfg(test)]
-use anyhow::Context;
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 #[cfg(test)]
 use bstr::BString;
 #[cfg(test)]
@@ -204,7 +202,7 @@ use noodles::sam::alignment::record_buf::RecordBuf;
 use crate::caller::ConsensusOutput;
 use crate::caller::{
     ConsensusCaller, ConsensusCallingStats, RejectionReason, clamp_combined_error_to_fgbio_short,
-    clamp_per_base_to_fgbio_short, write_consensus_read_name,
+    clamp_per_base_to_fgbio_short, consensus_read_name_too_long_context, write_consensus_read_name,
 };
 use crate::phred::MAX_PHRED;
 use crate::phred::{MIN_PHRED, PhredScore};
@@ -1089,8 +1087,11 @@ impl DuplexConsensusCaller {
         // Build the record (name, flags, bases, quals)
         write_consensus_read_name(read_name_buf, read_name_prefix, umi);
         // The UMI is input-derived, so an over-long name is bad data rather than
-        // a bug; propagate instead of panicking mid-write.
-        builder.try_build_record(read_name_buf, flag, &consensus.bases, &consensus.quals)?;
+        // a bug; propagate instead of panicking mid-write, naming the offending read so the
+        // failing molecule is findable in a batch run.
+        builder
+            .try_build_record(read_name_buf, flag, &consensus.bases, &consensus.quals)
+            .with_context(|| consensus_read_name_too_long_context(read_name_buf))?;
 
         // 1. MI tag (string)
         builder.append_string_tag(SamTag::MI, umi.as_bytes());

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -7,14 +7,14 @@
 use crate::base_builder::ConsensusBaseBuilder;
 use crate::caller::{
     ConsensusCaller, ConsensusCallingStats, ConsensusOutput, RejectionReason,
-    write_consensus_read_name,
+    consensus_read_name_too_long_context, write_consensus_read_name,
 };
 use crate::phred::{
     MIN_PHRED, NO_CALL_BASE, NO_CALL_BASE_LOWER, PhredScore, ln_error_prob_two_trials,
     ln_prob_to_phred, phred_to_ln_error_prob,
 };
 use crate::simple_umi::consensus_umis;
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use fgumi_dna::dna::reverse_complement;
 use fgumi_raw_bam::{RawRecord, RawRecordView, UnmappedSamBuilder, flags};
 use fgumi_sam::SamTag;
@@ -1475,8 +1475,11 @@ impl VanillaUmiConsensusCaller {
         }
 
         // The UMI is input-derived, so an over-long name is bad data rather than
-        // a bug; propagate instead of panicking mid-write.
-        self.bam_builder.try_build_record(&self.read_name_buf, flag, bases, quals)?;
+        // a bug; propagate instead of panicking mid-write, naming the offending read so the
+        // failing molecule is findable in a batch run.
+        self.bam_builder
+            .try_build_record(&self.read_name_buf, flag, bases, quals)
+            .with_context(|| consensus_read_name_too_long_context(&self.read_name_buf))?;
 
         // RG tag
         self.bam_builder.append_string_tag(SamTag::RG, self.read_group_id.as_bytes());

--- a/src/lib/commands/extract.rs
+++ b/src/lib/commands/extract.rs
@@ -920,6 +920,56 @@ impl Extract {
         Ok(())
     }
 
+    /// Context for a read name that BAM cannot represent.
+    ///
+    /// The builder's own error reports the length and the limit but not which
+    /// read hit it, which is what the user needs to find the offending FASTQ
+    /// record. `name` is the final name as written, so it already includes the
+    /// `+<UMI>` suffix when `--annotate-read-names` is set. Long names are
+    /// truncated so the message stays readable.
+    fn read_name_too_long_context(name: &[u8]) -> String {
+        // Bounded head AND tail: the name is the FASTQ header plus an optional `+<UMI>` suffix
+        // (`--annotate-read-names`), so head-only truncation would drop a UMI that lands past
+        // the budget. Retaining both ends keeps two otherwise-similar reads distinguishable,
+        // and bounding the tail keeps the line readable for an over-long input-derived name.
+        const HEAD: usize = 44;
+        const TAIL: usize = 20;
+        let shown = if name.len() <= HEAD + TAIL {
+            format!("'{}'", String::from_utf8_lossy(name))
+        } else {
+            let head = String::from_utf8_lossy(&name[..HEAD]);
+            let tail = String::from_utf8_lossy(&name[name.len() - TAIL..]);
+            format!("'{head}...{tail}' (name shown truncated)")
+        };
+        format!("could not write the record for read {shown}")
+    }
+
+    /// Builds one raw BAM record for a template segment, substituting a single `N` @ Q2 when
+    /// the segment has no sequence.
+    ///
+    /// The name comes from the input FASTQ header (plus the UMI when `--annotate-read-names`
+    /// is set), so an over-long name is bad input rather than a bug: fail cleanly via
+    /// `try_build_record` instead of panicking partway through writing the output BAM, and
+    /// attach [`Self::read_name_too_long_context`] so the message names the offending read.
+    ///
+    /// Shared by the single-threaded (`make_raw_records`) and threaded
+    /// (`make_raw_records_static`) paths, which are otherwise easy to let drift apart.
+    fn build_template_record(
+        builder: &mut UnmappedSamBuilder,
+        name: &[u8],
+        flag: u16,
+        seq: &[u8],
+        quals: &[u8],
+        encoding: QualityEncoding,
+    ) -> Result<()> {
+        if seq.is_empty() {
+            builder.try_build_record(name, flag, b"N", &[2u8])
+        } else {
+            builder.try_build_record(name, flag, seq, &encoding.to_standard_numeric(quals))
+        }
+        .with_context(|| Self::read_name_too_long_context(name))
+    }
+
     /// Write raw BAM records from a read set directly to a writer.
     ///
     /// Uses `UnmappedSamBuilder` to construct records as raw bytes,
@@ -1011,13 +1061,14 @@ impl Extract {
             };
             let final_read_name: &[u8] = annotated_name.as_deref().unwrap_or(&read_name_bytes);
 
-            // Build the record - if empty seq, substitute with single N @ Q2
-            if template.seq.is_empty() {
-                builder.build_record(final_read_name, flag, b"N", &[2u8]);
-            } else {
-                let numeric_quals = encoding.to_standard_numeric(&template.quals);
-                builder.build_record(final_read_name, flag, &template.seq, &numeric_quals);
-            }
+            Self::build_template_record(
+                builder,
+                final_read_name,
+                flag,
+                &template.seq,
+                &template.quals,
+                encoding,
+            )?;
 
             // Append tags
             // Read group
@@ -1222,9 +1273,13 @@ impl Extract {
                 let combined = FastqSet::combine_readsets(fastq_sets);
 
                 // Build raw BAM records
+                // Render the whole `anyhow` chain (`{:#}`), not just the
+                // outermost context: the pipeline carries `io::Error`, so
+                // `to_string()` here would drop the underlying cause and leave
+                // the user with a context line and no reason for it.
                 let result = make_raw_records_static(&combined, encoding, &extract_config)
                     .map_err(|e| {
-                        std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())
+                        std::io::Error::new(std::io::ErrorKind::InvalidData, format!("{e:#}"))
                     })?;
 
                 // Debug: Check if we produce fewer records than template has
@@ -1349,13 +1404,14 @@ fn make_raw_records_static(
         };
         let final_read_name: &[u8] = annotated_name.as_deref().unwrap_or(&read_name_bytes);
 
-        // Build the record - if empty seq, substitute with single N @ Q2
-        if template.seq.is_empty() {
-            builder.build_record(final_read_name, flag, b"N", &[2u8]);
-        } else {
-            let numeric_quals = encoding.to_standard_numeric(&template.quals);
-            builder.build_record(final_read_name, flag, &template.seq, &numeric_quals);
-        }
+        Extract::build_template_record(
+            &mut builder,
+            final_read_name,
+            flag,
+            &template.seq,
+            &template.quals,
+            encoding,
+        )?;
 
         // Append tags
         // Read group
@@ -2716,6 +2772,90 @@ mod tests {
         // Both mates share the suffix-free QNAME.
         assert_eq!(recs[0].name().map(|n| n.as_bytes()), Some(b"SRR001.1".as_slice()));
         assert_eq!(recs[1].name().map(|n| n.as_bytes()), Some(b"SRR001.1".as_slice()));
+    }
+
+    /// A BAM read name is length-prefixed by a single byte that counts the
+    /// trailing NUL, so names of 255 bytes or more cannot be represented. The
+    /// name here comes straight from the input FASTQ header, so an over-long
+    /// one is bad input: `extract` must fail cleanly rather than abort with a
+    /// Rust panic partway through writing the output BAM and leave a truncated
+    /// file behind.
+    ///
+    /// Both record-building paths are covered: `make_raw_records`
+    /// (single-threaded) and `make_raw_records_static` (threaded).
+    #[rstest]
+    #[case::at_limit(254, true)]
+    #[case::one_over(255, false)]
+    #[case::far_over(4096, false)]
+    fn test_extract_rejects_over_long_read_name(
+        #[case] name_len: usize,
+        #[case] expect_ok: bool,
+        #[values(ThreadingOptions::none(), ThreadingOptions::new(2))] threading: ThreadingOptions,
+    ) {
+        let tmp = TempDir::new().expect("failed to create temp dir");
+        let read_name = "N".repeat(name_len);
+        let r1 = create_fastq(&tmp, "r1.fq", &[(&read_name, "AAAAAAAAAA", "==========")]);
+        let output = tmp.path().join("output.bam");
+
+        let extract = Extract {
+            inputs: vec![r1],
+            output: output.clone(),
+            read_structures: vec![],
+            store_umi_quals: false,
+            store_cell_quals: false,
+            store_sample_barcode_qualities: false,
+            extract_umis_from_read_names: false,
+            annotate_read_names: false,
+            single_tag: None,
+            clipping_attribute: None,
+            read_group_id: "A".to_string(),
+            sample: "s".to_string(),
+            library: "l".to_string(),
+            barcode: None,
+            platform: "illumina".to_string(),
+            platform_unit: None,
+            platform_model: None,
+            sequencing_center: None,
+            predicted_insert_size: None,
+            description: None,
+            comment: vec![],
+            run_date: None,
+            threading,
+            compression: CompressionOptions { compression_level: 1 },
+            scheduler_opts: SchedulerOptions::default(),
+            queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
+        };
+
+        // Before the fix this panicked in the builder instead of returning Err.
+        let result = extract.execute("test");
+
+        assert_eq!(result.is_ok(), expect_ok, "name of {name_len} bytes: expected ok={expect_ok}");
+        match result {
+            Ok(()) => {
+                let recs = read_bam_records(&output);
+                assert_eq!(recs.len(), 1);
+                assert_eq!(
+                    recs[0].name().map(|n| n.as_bytes()),
+                    Some(read_name.as_bytes()),
+                    "an accepted name must round-trip unchanged"
+                );
+            }
+            Err(e) => {
+                let msg = format!("{e:#}");
+                assert!(msg.contains("read name too long"), "unexpected error: {msg}");
+                assert!(
+                    msg.contains("could not write the record for read 'NNN"),
+                    "the error should name the offending read: {msg}"
+                );
+                // A rejected name is always over-long (255+ bytes), so it is truncated for the
+                // diagnostic — the marker must say so rather than silently showing a partial name.
+                assert!(
+                    msg.contains("(name shown truncated)"),
+                    "an over-long name must be marked truncated: {msg}"
+                );
+            }
+        }
     }
 
     /// EXT-03: fgbio `Umis.extractUmisFromReadName` upper-cases the extracted UMI


### PR DESCRIPTION
Stacked on #611 — it adds `UnmappedSamBuilder::try_build_record`, which this PR uses. Base will need retargeting to `main` once #611 merges. Review the second commit only.

## The problem

BAM stores the read name length in a single byte that includes the trailing NUL, so a name of 255 bytes or more cannot be represented. `extract` builds its record name from the input FASTQ header — plus `+<UMI>` when `--annotate-read-names` is set — so the length is entirely data-controlled. Both record-building paths called the asserting `build_record`, so a long FASTQ read name aborted the command with a Rust panic partway through writing the output BAM, leaving a truncated file rather than failing cleanly.

This is the same failure mode #611 fixed for the consensus callers. `extract` was the one remaining caller feeding the builder input-derived names; it was found during the sibling audit on that PR and deliberately left out of it to keep that change scoped to `fix(consensus)`.

Before, on a 300-byte read name:

```
thread ... panicked at crates/fgumi-raw-bam/src/builder.rs:172:9:
read name too long (300 bytes, max 254)
```

After:

```
Error: could not write the record for read 'NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN...' (name shown truncated)

Caused by:
    read name too long (300 bytes, max 254); BAM stores the name length in one byte including its NUL terminator
```

## The change

Routes `make_raw_records` (single-threaded) and `make_raw_records_static` (threaded) through `try_build_record`. Both enclosing functions already returned `Result`, so the error propagates without restructuring.

The builder’s error reports the length and the limit but not *which* read hit it, which is what you need to find the offending FASTQ record. `read_name_too_long_context` adds the name, truncated to 64 bytes so the message stays readable. It reports the final name as written, so it already includes the `+<UMI>` suffix when annotation is on.

One extra fix was required to make that message actually reach the user. The threaded path converted the `anyhow` error into the pipeline’s `io::Error` with `e.to_string()`, which keeps only the outermost context and drops everything below it — you would have seen the read name with no reason attached. It now renders the full chain with `{:#}`. That repairs the report for every error out of `make_raw_records_static`, not just this one.

The neighbouring `.map_err(std::io::Error::other)` a few lines up is left alone: it preserves the error object rather than stringifying it, so it is not lossy in the same way.

## Testing

`test_extract_rejects_over_long_read_name` is an end-to-end test through `execute` — an `#[rstest]` case table over the exact boundary, run against **both** record-building paths via `#[values]`:

| name length | expected |
|---|---|
| 254 | accepted, round-trips unchanged |
| 255 | rejected |
| 4096 | rejected |

Reverting the production change makes all four rejection cases fail with a panic in the builder, which is the reported failure mode — verified, not assumed.

Full suite: `cargo ci-test` 5549 passed / 22 skipped; `cargo ci-fmt`, `cargo ci-lint`, `cargo ci-doctest`, and `RUSTDOCFLAGS="-D warnings" cargo ci-doc` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of FASTQ and consensus records with read names exceeding BAM’s length limit.
  * These inputs now return clear, actionable errors instead of producing unhelpful failures or panics.
  * Error messages identify the affected read and include relevant UMI information when applicable.
  * Very long or invalid read names are safely truncated in diagnostics while preserving useful identifying details.
  * Error details are now retained consistently across single-threaded and threaded extraction modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->