### PR TITLE
feat(group): accept --index-threshold always|never, reject unsatisfiable requests

### DIFF
--- a/crates/fgumi-umi/src/assigner.rs
+++ b/crates/fgumi-umi/src/assigner.rs
@@ -205,11 +205,14 @@
 //!
 //! - **Use Edit** if: You have moderate error rates and transitive clustering is
 //!   acceptable for your application. At one mismatch (`--edits 1`), once a
-//!   position reaches `--index-threshold` distinct UMIs -- floored at
-//!   [`EDIT_INDEX_THRESHOLD`], edit's own measured crossover -- candidate
-//!   neighbours come from an N-gram index rather than from the incremental
-//!   set-merge, so large position groups no longer cost quadratic time. Other
-//!   edit distances always use the set-merge.
+//!   position reaches `--index-threshold` distinct UMIs -- a numeric threshold
+//!   being floored at [`EDIT_INDEX_THRESHOLD`], edit's own measured crossover --
+//!   candidate neighbours come from an N-gram index rather than from the
+//!   incremental set-merge, so large position groups no longer cost quadratic
+//!   time. Every other `--edits` value always uses the set-merge, whatever the
+//!   threshold: the crossover was measured at one mismatch, and past it the
+//!   index's partitions get too short to be selective while single linkage
+//!   collapses the group, which makes the scan cheaper rather than dearer.
 //!
 //! - **Use Adjacency** if: You have high sequencing depth (10-100x+ per molecule),
 //!   need conservative error correction, or are doing variant calling where
@@ -229,10 +232,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use crate::MoleculeId;
 use fgumi_dna::BitEnc;
 
-/// Default minimum number of unique UMIs to use N-gram/BK-tree index for candidate search.
-/// Below this threshold, linear scan is used. Based on benchmarks: index provides ~10%
-/// speedup even at 100 UMIs/position with negligible construction overhead.
-pub const DEFAULT_INDEX_THRESHOLD: usize = 100;
+use crate::index_threshold::{DEFAULT_INDEX_THRESHOLD, IndexThreshold};
 
 /// Minimum distinct UMIs before the `Edit` strategy builds its N-gram index.
 ///
@@ -468,10 +468,15 @@ impl NgramIndex {
         // Need at least 1 base per partition for meaningful filtering, and at
         // most 16: `extract_bits` packs 2 bits per base into a `u32`, so a wider
         // partition would silently truncate the key (and trips its own
-        // `debug_assert!` in debug builds). Only reachable at
-        // `max_mismatches == 0`, where `partition_len == umi_len`; every caller
-        // in this crate gates on `max_mismatches == 1`, so this guards the
-        // `pub` constructor rather than closing a live hole.
+        // `debug_assert!` in debug builds). Every caller in this crate gates on
+        // `max_mismatches == 1`, so `partition_len == umi_len / 2`, and the two
+        // arms differ in reachability:
+        //
+        // - `== 0` is live: a 1-base UMI splits into two 0-base pieces. The build
+        //   declines and the caller stays on its linear scan.
+        // - `> 16` is not: `BitEnc::from_bytes` rejects anything over 32 bases, so
+        //   half of an encodable UMI is always at most 16. It guards the `pub`
+        //   constructor, whose `max_mismatches == 0` gives `partition_len == umi_len`.
         if partition_len == 0 || partition_len > 16 {
             return None;
         }
@@ -596,6 +601,32 @@ pub enum Strategy {
 }
 
 impl Strategy {
+    /// Whether this strategy consults the UMI index at all, at `edits`.
+    ///
+    /// `Identity` has no index code path. `Edit` and `Adjacency` index only at
+    /// `edits == 1`; `Paired` indexes at every edit distance, N-gram for k=1 and BK-tree
+    /// for k>1.
+    ///
+    /// Both `edits == 1` gates are read from the assigner that enforces them
+    /// (`SimpleErrorUmiAssigner::indexes_at_edit_distance` and
+    /// `AdjacencyUmiAssigner::indexes_at_edit_distance`) rather than restated here, so
+    /// what this reports and what the assigner does cannot drift apart. Restating them
+    /// is how the two came to disagree once already: the N-gram index *can* serve k>1,
+    /// but neither assigner *reaches* it there.
+    ///
+    /// Callers use this to reject an [`IndexThreshold`] that
+    /// [demands indexing](IndexThreshold::demands_indexing) under a configuration that
+    /// cannot deliver it.
+    #[must_use]
+    pub fn can_use_index(&self, edits: u32) -> bool {
+        match self {
+            Strategy::Identity => false,
+            Strategy::Edit => SimpleErrorUmiAssigner::indexes_at_edit_distance(edits),
+            Strategy::Adjacency => AdjacencyUmiAssigner::indexes_at_edit_distance(edits),
+            Strategy::Paired => true,
+        }
+    }
+
     /// Create a new UMI assigner for this strategy
     ///
     /// # Arguments
@@ -611,7 +642,7 @@ impl Strategy {
     /// Panics if `edits` is non-zero when using the Identity strategy.
     #[must_use]
     pub fn new_assigner(&self, edits: u32) -> Box<dyn UmiAssigner> {
-        self.new_assigner_full(edits, 1, DEFAULT_INDEX_THRESHOLD)
+        self.new_assigner_full(edits, 1, IndexThreshold::default())
     }
 
     /// Create a new UMI assigner with thread count specified
@@ -626,7 +657,7 @@ impl Strategy {
     /// A boxed trait object implementing the `UmiAssigner` trait
     #[must_use]
     pub fn new_assigner_with_threads(&self, edits: u32, threads: usize) -> Box<dyn UmiAssigner> {
-        self.new_assigner_full(edits, threads, DEFAULT_INDEX_THRESHOLD)
+        self.new_assigner_full(edits, threads, IndexThreshold::default())
     }
 
     /// Create a new UMI assigner with all parameters specified
@@ -635,9 +666,10 @@ impl Strategy {
     ///
     /// * `edits` - Maximum number of mismatches allowed between UMIs
     /// * `threads` - Number of threads to use (only applies to Adjacency and Paired strategies)
-    /// * `index_threshold` - Minimum distinct UMIs at a position before an index is used
-    ///   instead of a linear scan; see [`AdjacencyUmiAssigner::uses_index`] and
-    ///   [`PairedUmiAssigner::uses_index`]
+    /// * `index_threshold` - When a position group is matched through an index rather
+    ///   than by comparing every pair; see [`SimpleErrorUmiAssigner::uses_index`],
+    ///   [`AdjacencyUmiAssigner::uses_index`] and [`PairedUmiAssigner::uses_index`] for
+    ///   the per-strategy gate. `Edit` floors a numeric value at [`EDIT_INDEX_THRESHOLD`].
     ///
     /// # Returns
     ///
@@ -647,12 +679,13 @@ impl Strategy {
     ///
     /// Panics if `edits` is non-zero with the `Identity` strategy.
     #[must_use]
-    pub fn new_assigner_full(
+    pub fn new_assigner_full<T: Into<IndexThreshold>>(
         &self,
         edits: u32,
         threads: usize,
-        index_threshold: usize,
+        index_threshold: T,
     ) -> Box<dyn UmiAssigner> {
+        let index_threshold = index_threshold.into();
         match self {
             Strategy::Identity => {
                 assert_eq!(edits, 0, "Edits should be zero when using the identity UMI assigner");
@@ -664,7 +697,7 @@ impl Strategy {
             // is honoured.
             Strategy::Edit => Box::new(SimpleErrorUmiAssigner::new_with_index_threshold(
                 edits,
-                index_threshold.max(EDIT_INDEX_THRESHOLD),
+                index_threshold.floored_at(EDIT_INDEX_THRESHOLD),
             )),
             Strategy::Adjacency => {
                 Box::new(AdjacencyUmiAssigner::new(edits, threads, index_threshold))
@@ -1061,7 +1094,7 @@ impl UnionFind {
 /// Uses atomic counter for ID generation, making it safe to use across threads.
 pub struct SimpleErrorUmiAssigner {
     max_mismatches: u32,
-    index_threshold: usize,
+    index_threshold: IndexThreshold,
     counter: AtomicU64,
 }
 
@@ -1088,15 +1121,57 @@ impl SimpleErrorUmiAssigner {
     /// # Arguments
     ///
     /// * `max_mismatches` - Maximum number of mismatches allowed between UMIs in the same group
-    /// * `index_threshold` - Build the N-gram index once a position group has at
-    ///   least this many distinct, encodable UMIs. Consulted only once a
-    ///   position exceeds `MERGE_DEFER_POINT` distinct UMIs and only when
-    ///   `max_mismatches == 1`, so any value at or below `MERGE_DEFER_POINT`
-    ///   behaves identically, and no value indexes at other distances.
-    ///   `usize::MAX` never indexes.
+    /// * `index_threshold` - When to build the N-gram index rather than merge UMIs
+    ///   into sets pairwise. Consulted only once a position exceeds
+    ///   `MERGE_DEFER_POINT` distinct UMIs, so every [`IndexThreshold::MinUmis`] at
+    ///   or below `MERGE_DEFER_POINT` — including `0` — behaves identically, as does
+    ///   [`IndexThreshold::Always`]. [`IndexThreshold::Never`] never indexes.
     #[must_use]
-    pub fn new_with_index_threshold(max_mismatches: u32, index_threshold: usize) -> Self {
-        Self { max_mismatches, index_threshold, counter: AtomicU64::new(0) }
+    pub fn new_with_index_threshold<T: Into<IndexThreshold>>(
+        max_mismatches: u32,
+        index_threshold: T,
+    ) -> Self {
+        Self { max_mismatches, index_threshold: index_threshold.into(), counter: AtomicU64::new(0) }
+    }
+
+    /// Whether the edit strategy consults its N-gram index at all, at `max_mismatches`.
+    ///
+    /// This is the single source of truth for edit's edit-distance gate: `assign` gates
+    /// its defer/index branch on it, [`Self::uses_index`] folds it in, and
+    /// [`Strategy::can_use_index`] reports it to the CLI. Binding all three to one
+    /// predicate is deliberate — when the gate lived only in `assign` as a bare
+    /// `max_mismatches == 1`, the docs, the startup log line and the index/scan parity
+    /// test all drifted into claiming the opposite.
+    ///
+    /// [`NgramIndex`] itself is not so limited: it partitions into `max_mismatches + 1`
+    /// pieces and its pigeonhole recall holds at any distance. The restriction is a
+    /// measured one, not a capability one — [`EDIT_INDEX_THRESHOLD`]'s crossover was
+    /// measured at one mismatch only, and above it the index loses: the pieces get too
+    /// short to be selective (4 bases at k=1 but 2 at k=2 for an 8-base UMI) while
+    /// single linkage collapses the group into one component, which makes the set-merge's
+    /// early-exiting scan *cheaper*. Widening this needs a `-e 2`/`-e 3` benchmark arm
+    /// first; `benches/umi_assigner_threshold.rs` sweeps one mismatch only.
+    #[must_use]
+    pub const fn indexes_at_edit_distance(max_mismatches: u32) -> bool {
+        max_mismatches == 1
+    }
+
+    /// Whether a position group of `num_umis` distinct UMIs is *eligible* to be matched
+    /// through the N-gram index rather than by merging UMIs into sets pairwise.
+    ///
+    /// As for [`AdjacencyUmiAssigner::uses_index`], this is the threshold *and* an
+    /// edit-distance condition: see [`Self::indexes_at_edit_distance`]. (The paired
+    /// strategy is the only one with no such condition — see
+    /// [`PairedUmiAssigner::uses_index`].)
+    ///
+    /// Eligibility is necessary but not sufficient. The index is only *reached* once a
+    /// position exceeds `MERGE_DEFER_POINT` distinct UMIs, and [`NgramIndex::new`] then
+    /// declines an empty group, a UMI containing non-ACGT bases, inconsistent UMI
+    /// lengths, or a UMI too short to split into `max_mismatches + 1` pieces — after
+    /// which the paused set-merge resumes.
+    #[must_use]
+    pub fn uses_index(&self, num_umis: usize) -> bool {
+        self.index_threshold.admits(num_umis) && Self::indexes_at_edit_distance(self.max_mismatches)
     }
 
     /// Add one UMI to the accumulated groups, merging any it bridges.
@@ -1245,7 +1320,12 @@ impl UmiAssigner for SimpleErrorUmiAssigner {
         //
         // `test_edit_matches_brute_force_across_regimes` checks all three
         // regimes against an independent oracle.
-        let can_index = self.max_mismatches == 1;
+        //
+        // The edit-distance gate is `indexes_at_edit_distance`, not a bare
+        // `max_mismatches == 1` written out here, so that `Strategy::can_use_index`
+        // (which the CLI validates `--index-threshold always` against) reports exactly
+        // what this branch does.
+        let can_index = Self::indexes_at_edit_distance(self.max_mismatches);
         let mut distinct: Vec<&Umi> = Vec::new();
         let mut seen: std::collections::HashSet<&str> =
             std::collections::HashSet::with_capacity(upper_umis.len());
@@ -1298,7 +1378,7 @@ impl UmiAssigner for SimpleErrorUmiAssigner {
             // covered at most `MERGE_DEFER_POINT` UMIs, so discarding it and
             // rebuilding every component from the index is cheap relative to the
             // position being grouped.
-            let indexed = if distinct.len() >= self.index_threshold {
+            let indexed = if self.uses_index(distinct.len()) {
                 self.components_via_index(&distinct)
             } else {
                 None
@@ -1413,7 +1493,7 @@ struct Node {
 pub struct AdjacencyUmiAssigner {
     max_mismatches: u32,
     threads: usize,
-    index_threshold: usize,
+    index_threshold: IndexThreshold,
     counter: AtomicU64,
 }
 
@@ -1424,28 +1504,39 @@ impl AdjacencyUmiAssigner {
     ///
     /// * `max_mismatches` - Maximum number of mismatches allowed for UMIs to be adjacent
     /// * `threads` - Number of threads to use for matching (default: 1)
-    /// * `index_threshold` - Minimum distinct UMIs at a position before the N-gram index
-    ///   is used instead of a linear scan; see [`AdjacencyUmiAssigner::uses_index`]
+    /// * `index_threshold` - When a position group is matched through the N-gram index
+    ///   rather than by a linear scan; see [`AdjacencyUmiAssigner::uses_index`]
     ///
     /// # Returns
     ///
     /// A new `AdjacencyUmiAssigner` instance
     #[must_use]
-    pub fn new(max_mismatches: u32, threads: usize, index_threshold: usize) -> Self {
-        Self { max_mismatches, threads, index_threshold, counter: AtomicU64::new(0) }
+    pub fn new<T: Into<IndexThreshold>>(
+        max_mismatches: u32,
+        threads: usize,
+        index_threshold: T,
+    ) -> Self {
+        Self {
+            max_mismatches,
+            threads,
+            index_threshold: index_threshold.into(),
+            counter: AtomicU64::new(0),
+        }
     }
 
     /// Whether a position group of `num_umis` distinct UMIs is *eligible* to be
     /// matched through the N-gram index rather than a linear scan over all UMI pairs.
     ///
-    /// `index_threshold` is a MINIMUM, not a switch: the index is built once a group
-    /// is at least that large, so `0` indexes every group and disabling the index
-    /// entirely takes a threshold larger than any group (e.g. `usize::MAX`).
+    /// An [`IndexThreshold::MinUmis`] is a MINIMUM, not a switch: the index is built
+    /// once a group is at least that large, so `0` indexes every group exactly as
+    /// [`IndexThreshold::Always`] does. [`IndexThreshold::Never`] is what turns the
+    /// index off.
     ///
-    /// The index is additionally limited to `max_mismatches == 1`, which is all
-    /// `NgramIndex` serves here; every other edit distance falls back to the linear
-    /// scan whatever the threshold. (The paired strategy is not so limited — see
-    /// [`PairedUmiAssigner::uses_index`].)
+    /// The index is additionally limited to `max_mismatches == 1` (see
+    /// [`Self::indexes_at_edit_distance`]); every other edit distance falls back to the
+    /// linear scan whatever the threshold. The edit strategy has the same condition
+    /// ([`SimpleErrorUmiAssigner::uses_index`]); the paired strategy is the only one
+    /// without it — see [`PairedUmiAssigner::uses_index`].
     ///
     /// Eligibility is necessary but not sufficient: [`NgramIndex::new`] declines an
     /// empty group, a UMI containing non-ACGT bases, or inconsistent UMI lengths, and
@@ -1453,7 +1544,33 @@ impl AdjacencyUmiAssigner {
     /// and edit-distance conditions permit indexing", not "an index was built".
     #[must_use]
     pub fn uses_index(&self, num_umis: usize) -> bool {
-        num_umis >= self.index_threshold && self.max_mismatches == 1
+        self.index_admits(num_umis) && Self::indexes_at_edit_distance(self.max_mismatches)
+    }
+
+    /// Whether the adjacency strategy consults its N-gram index at all, at
+    /// `max_mismatches`.
+    ///
+    /// The single source of truth for adjacency's edit-distance gate: [`Self::uses_index`]
+    /// folds it in (and `build_adjacency_graph_bitenc` gates on `uses_index`), and
+    /// [`Strategy::can_use_index`] reports it to the CLI, so what the CLI validates
+    /// `--index-threshold always` against is what this assigner actually does. The
+    /// BK-tree branch that would serve larger distances is reachable only from the
+    /// generic `build_adjacency_graph` the paired strategy uses.
+    #[must_use]
+    pub const fn indexes_at_edit_distance(max_mismatches: u32) -> bool {
+        max_mismatches == 1
+    }
+
+    /// Whether `index_threshold` alone admits a position group of `num_umis` distinct
+    /// UMIs, before any edit-distance condition.
+    ///
+    /// This is the gate [`Self::build_adjacency_graph`] runs *and* the one
+    /// [`PairedUmiAssigner::uses_index`] reports — the paired strategy drives that path
+    /// and has no edit-distance condition of its own. Both go through here rather than
+    /// spelling out `index_threshold.admits(..)` twice, so the paired `uses_index` tests
+    /// exercise the live gate instead of a parallel copy of it.
+    fn index_admits(&self, num_umis: usize) -> bool {
+        self.index_threshold.admits(num_umis)
     }
 
     /// Generate the next unique molecule ID
@@ -1697,8 +1814,9 @@ impl AdjacencyUmiAssigner {
         // Try to build index for fast candidate search (if enough UMIs).
         // Unlike `build_adjacency_graph_bitenc`, this path indexes at every edit
         // distance: N-gram for k=1 (most efficient), BK-tree for k>1. Only the
-        // `index_threshold` minimum applies -- see `PairedUmiAssigner::uses_index`.
-        let (ngram_index, bktree) = if nodes.len() >= self.index_threshold {
+        // `index_threshold` minimum applies -- see `PairedUmiAssigner::uses_index`,
+        // which reports this same `index_admits` gate.
+        let (ngram_index, bktree) = if self.index_admits(nodes.len()) {
             let umis: Vec<(usize, &str)> =
                 umi_counts.iter().enumerate().map(|(i, (umi, _, _))| (i, umi.as_str())).collect();
 
@@ -2022,15 +2140,18 @@ impl PairedUmiAssigner {
     ///
     /// * `max_mismatches` - Maximum number of mismatches allowed for UMIs to be adjacent
     /// * `threads` - Number of threads to use for matching
-    /// * `index_threshold` - Minimum distinct UMIs at a position before an index is used
-    ///   instead of a linear scan; see [`AdjacencyUmiAssigner::uses_index`] and
-    ///   [`PairedUmiAssigner::uses_index`]
+    /// * `index_threshold` - When a position group is matched through an index rather
+    ///   than by a linear scan; see [`PairedUmiAssigner::uses_index`]
     ///
     /// # Returns
     ///
     /// A new `PairedUmiAssigner` instance
     #[must_use]
-    pub fn new_with_threads(max_mismatches: u32, threads: usize, index_threshold: usize) -> Self {
+    pub fn new_with_threads<T: Into<IndexThreshold>>(
+        max_mismatches: u32,
+        threads: usize,
+        index_threshold: T,
+    ) -> Self {
         let prefix_len = max_mismatches as usize + 1;
         Self {
             adjacency: AdjacencyUmiAssigner::new(max_mismatches, threads, index_threshold),
@@ -2042,10 +2163,11 @@ impl PairedUmiAssigner {
     /// Whether a position group of `num_umis` distinct UMIs is *eligible* to be
     /// matched through an index rather than a linear scan over all UMI pairs.
     ///
-    /// As for [`AdjacencyUmiAssigner::uses_index`], `index_threshold` is a MINIMUM:
-    /// `0` indexes every group. Unlike the adjacency strategy, the paired strategy
-    /// indexes at every `--edits` value — N-gram for k=1, BK-tree for k>1 — so only
-    /// the threshold applies.
+    /// As for [`AdjacencyUmiAssigner::uses_index`], an [`IndexThreshold::MinUmis`] is a
+    /// MINIMUM: `0` indexes every group, and [`IndexThreshold::Never`] is what turns the
+    /// index off. Unlike the adjacency and edit strategies, the paired strategy indexes at
+    /// every `--edits` value — N-gram for k=1, BK-tree for k>1 — so only the threshold
+    /// applies. This reads the very gate `build_adjacency_graph` runs, not a copy of it.
     ///
     /// As there, eligibility is necessary but not sufficient: [`NgramIndex::new`] and
     /// [`BkTree::from_umis`] both decline UMIs they cannot encode (non-ACGT bases, and
@@ -2053,7 +2175,7 @@ impl PairedUmiAssigner {
     /// then falls back to the linear scan.
     #[must_use]
     pub fn uses_index(&self, num_umis: usize) -> bool {
-        num_umis >= self.adjacency.index_threshold
+        self.adjacency.index_admits(num_umis)
     }
 
     /// Get the prefix for lower-ordered reads in a pair
@@ -2915,9 +3037,11 @@ mod tests {
     /// boundary, and the two together pin the resume path in between -- the one
     /// that must reproduce work it deliberately postponed.
     ///
-    /// Both edit distances are swept because they take different paths:
-    /// `can_index` gates on `max_mismatches == 1`, so one mismatch reaches the
-    /// index while two is always the pure set-merge.
+    /// Both edit distances are swept because they take different paths: `can_index` gates
+    /// on `indexes_at_edit_distance`, so one mismatch reaches the index above the
+    /// threshold while two is always the pure set-merge. Unlike the index/scan parity
+    /// test, this one is non-vacuous either way -- the oracle is independent of both
+    /// paths.
     #[rstest]
     #[case::below_defer_point(10)]
     #[case::just_below_defer(63)]
@@ -2983,7 +3107,7 @@ mod tests {
     }
 
     /// The index must be a pure discovery optimisation: forcing it on
-    /// (`index_threshold = 0`) and off (`usize::MAX`) must produce identical
+    /// (`--index-threshold always`) and off (`never`) must produce identical
     /// molecule ids for the same input.
     ///
     /// Each case is padded past [`MERGE_DEFER_POINT`] with filler UMIs, because
@@ -2993,12 +3117,12 @@ mod tests {
     /// scan against itself; `assert!(distinct > MERGE_DEFER_POINT)` below keeps
     /// that from recurring.
     ///
-    /// Only one mismatch is swept: `can_index` gates on `max_mismatches == 1`,
-    /// so at any other edit distance the threshold is never consulted and both
-    /// sides run the identical set-merge -- the comparison would be vacuous in
-    /// exactly the way the padding above exists to prevent. The set-merge itself
-    /// is checked at two mismatches against an independent oracle by
-    /// `test_edit_matches_brute_force_across_regimes`.
+    /// Only one mismatch is swept: `can_index` gates on `indexes_at_edit_distance`, so at
+    /// any other distance the threshold is never consulted and both sides run the
+    /// identical set-merge -- the comparison would be vacuous in exactly the way the
+    /// padding above exists to prevent. The set-merge itself is checked against an
+    /// independent oracle by `test_edit_matches_brute_force_across_regimes`, and the
+    /// index's recall at other distances by `test_ngram_index_matches_brute_force`.
     #[rstest]
     #[case::pure_acgt(&["AAAAAAAA", "AAAAAAAC", "AAAAAACC", "TTTTTTTT", "TTTTTTTG"])]
     #[case::all_singletons(&["AAAAAAAA", "CCCCCCCC", "GGGGGGGG", "TTTTTTTT"])]
@@ -3008,6 +3132,7 @@ mod tests {
     // (deliberate parity with the parallel assigner); each gets its own id.
     #[case::n_containing(&["AAAAAAAA", "AAAAAAAN", "AAAAAAAC", "NNNNNNNN"])]
     fn test_edit_index_matches_scan(#[case] interesting: &[&str]) {
+        let max_mismatches = 1;
         // Filler shares the UMI length so `assert_uniform_umi_length` is happy,
         // and is far from the interesting UMIs so it forms its own components.
         let mut umis: Vec<Umi> = interesting.iter().map(|u| (*u).to_string()).collect();
@@ -3020,9 +3145,17 @@ mod tests {
             "case must exceed MERGE_DEFER_POINT or the index is never reached"
         );
 
-        let indexed = SimpleErrorUmiAssigner::new_with_index_threshold(1, 0).assign(&umis);
-        let scanned = SimpleErrorUmiAssigner::new_with_index_threshold(1, usize::MAX).assign(&umis);
-        assert_eq!(indexed, scanned, "index/scan divergence at one mismatch");
+        // `Always` and `Never` name the two sides directly, so the test cannot
+        // silently compare the scan against itself the way a pair of numbers can.
+        let indexed = SimpleErrorUmiAssigner::new_with_index_threshold(
+            max_mismatches,
+            IndexThreshold::Always,
+        )
+        .assign(&umis);
+        let scanned =
+            SimpleErrorUmiAssigner::new_with_index_threshold(max_mismatches, IndexThreshold::Never)
+                .assign(&umis);
+        assert_eq!(indexed, scanned, "index/scan divergence at {max_mismatches} mismatch(es)");
     }
 
     /// Dashed dual UMIs reach the index build and are declined by it
@@ -3032,9 +3165,9 @@ mod tests {
     /// the fallback is genuinely exercised.
     ///
     /// Checked against `brute_force_components` rather than against the
-    /// `index_threshold = usize::MAX` scan: because the index *always* declines
-    /// dashed input, both thresholds now take the same resume-merge branch, so
-    /// comparing them would assert nothing. The independent oracle is what makes
+    /// [`IndexThreshold::Never`] scan: because the index *always* declines dashed
+    /// input, both thresholds now take the same resume-merge branch, so comparing
+    /// them would assert nothing. The independent oracle is what makes
     /// this test load-bearing.
     #[test]
     fn test_edit_dashed_umis_fall_back_within_indexed_path() {
@@ -4596,6 +4729,97 @@ mod tests {
         assert!(indices.contains(&2)); // second partition matches (CCCC)
     }
 
+    /// `NgramIndex` finds *exactly* the neighbour set, at every distance and UMI length
+    /// it accepts -- no false negatives (pigeonhole) and no false positives
+    /// (`find_within` re-verifies each candidate's Hamming distance).
+    ///
+    /// The lengths deliberately include ones that `max_mismatches + 1` does not divide.
+    /// `partition_len` is a FLOOR, so the partitions leave a tail uncovered -- an 8-base
+    /// UMI at k=2 covers bases 0..6 and ignores the last two. Recall survives it because
+    /// pigeonhole needs only that the blocks be disjoint: `k` differences can dirty at
+    /// most `k` of the `k + 1` blocks, and any difference landing in the uncovered tail
+    /// simply leaves fewer to distribute.
+    ///
+    /// The edit strategy is gated to one mismatch on measured grounds (see
+    /// `SimpleErrorUmiAssigner::indexes_at_edit_distance`), so this is the coverage that
+    /// keeps that a benchmarking decision: the index is already known-correct wherever a
+    /// future sweep might want to enable it.
+    #[rstest]
+    fn test_ngram_index_matches_brute_force(
+        #[values(8, 9, 11, 12, 16)] umi_len: usize,
+        #[values(0, 1, 2, 3)] max_mismatches: u32,
+    ) {
+        let mut distinct: Vec<Umi> = {
+            let generated = umis_with_distinct(150, umi_len, 0x0FEE_D5EE);
+            let mut seen = HashSet::new();
+            generated.into_iter().filter(|umi| seen.insert(umi.clone())).collect()
+        };
+
+        // Plant neighbours at EXACTLY `max_mismatches` distance. Random UMIs alone leave
+        // the relation empty at the longer lengths (no two random 16-mers are within 3),
+        // which would make the recall half of the assertion vacuous while the test still
+        // passed -- so the planted pairs are what make it load-bearing.
+        let planted: Vec<Umi> = distinct
+            .iter()
+            .take(20)
+            .map(|umi| {
+                let mut bytes = umi.clone().into_bytes();
+                // Every one of the first `max_mismatches` bases changes, whatever it was.
+                for base in bytes.iter_mut().take(max_mismatches as usize) {
+                    *base = if *base == b'A' { b'C' } else { b'A' };
+                }
+                String::from_utf8(bytes).expect("ASCII")
+            })
+            .collect();
+        distinct.extend(planted);
+        let distinct: Vec<&str> = {
+            let mut seen = HashSet::new();
+            distinct.iter().map(String::as_str).filter(|umi| seen.insert(*umi)).collect()
+        };
+        let indexed: Vec<(usize, &str)> = distinct.iter().copied().enumerate().collect();
+
+        let index = NgramIndex::new(&indexed, max_mismatches)
+            .expect("index must build for these lengths and distances");
+
+        // Every unordered pair within `max_mismatches`, computed independently of the
+        // index by comparing bases directly.
+        let mut expected: HashSet<(usize, usize)> = HashSet::new();
+        for (i, a) in distinct.iter().enumerate() {
+            for (j, b) in distinct.iter().enumerate().skip(i + 1) {
+                let dist = a.bytes().zip(b.bytes()).filter(|(x, y)| x != y).count();
+                if dist <= max_mismatches as usize {
+                    expected.insert((i, j));
+                }
+            }
+        }
+
+        let mut found: HashSet<(usize, usize)> = HashSet::new();
+        for (i, umi) in distinct.iter().enumerate() {
+            for (j, _dist) in index.find_within(umi, max_mismatches) {
+                if i != j {
+                    found.insert((i.min(j), i.max(j)));
+                }
+            }
+        }
+
+        // At zero mismatches the only neighbours would be identical strings, which a
+        // distinct set cannot hold, so an empty relation there is correct -- the
+        // assertion is pure precision. Everywhere else the planted pairs must show up,
+        // or recall is being asserted against nothing.
+        if max_mismatches > 0 {
+            assert!(
+                !expected.is_empty(),
+                "planted neighbours vanished at len {umi_len}, {max_mismatches} mismatch(es): \
+                 the recall half of this test would be vacuous"
+            );
+        }
+
+        assert_eq!(
+            found, expected,
+            "index/brute-force disagreement at len {umi_len}, {max_mismatches} mismatch(es)"
+        );
+    }
+
     #[test]
     fn test_ngram_index_find_invalid_query() {
         let umis = vec![(0, "AAAAAAAA")];
@@ -4746,24 +4970,118 @@ mod tests {
     // --index-threshold semantics
     // ========================================================================
 
-    /// Pins what `--index-threshold` actually does, so the CLI help can be checked
-    /// against it. The gate is `num_umis >= index_threshold`, so `0` means the index
-    /// is ALWAYS built -- it does not disable the index. Disabling it requires a
-    /// threshold larger than any position group, e.g. `usize::MAX`.
+    /// `Strategy::can_use_index` is what turns `--index-threshold always` into a
+    /// command-line error, so it must name exactly the combinations that have an
+    /// index code path. Identity has none; edit's and adjacency's are gated on one
+    /// mismatch; paired's is not gated on the edit distance at all.
     #[rstest]
-    #[case::zero_always_indexes(0, 1, true)]
-    #[case::zero_indexes_empty_group(0, 0, true)]
-    #[case::below_threshold_scans(100, 99, false)]
-    #[case::at_threshold_indexes(100, 100, true)]
-    #[case::above_threshold_indexes(100, 101, true)]
-    #[case::usize_max_never_indexes(usize::MAX, 1_000_000, false)]
+    #[case::identity(crate::assigner::Strategy::Identity, 0, false)]
+    #[case::edit_zero_edits(crate::assigner::Strategy::Edit, 0, false)]
+    #[case::edit_one_edit(crate::assigner::Strategy::Edit, 1, true)]
+    #[case::edit_two_edits(crate::assigner::Strategy::Edit, 2, false)]
+    #[case::adjacency_zero_edits(crate::assigner::Strategy::Adjacency, 0, false)]
+    #[case::adjacency_one_edit(crate::assigner::Strategy::Adjacency, 1, true)]
+    #[case::adjacency_two_edits(crate::assigner::Strategy::Adjacency, 2, false)]
+    #[case::paired_one_edit(crate::assigner::Strategy::Paired, 1, true)]
+    #[case::paired_two_edits(crate::assigner::Strategy::Paired, 2, true)]
+    fn test_strategy_can_use_index(
+        #[case] strategy: crate::assigner::Strategy,
+        #[case] edits: u32,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(strategy.can_use_index(edits), expected);
+    }
+
+    /// The edit assigner indexes only at one mismatch, and no threshold overrides that:
+    /// `uses_index` is the gate `assign` consults, so `Always` on a group far past
+    /// `EDIT_INDEX_THRESHOLD` still yields `false` at every other distance.
+    ///
+    /// This is the pairing that matters, and the one whose absence let the gate and its
+    /// advertisement disagree: `Strategy::can_use_index` is what the CLI validates
+    /// `--index-threshold always` against, so it must equal what the assigner does at
+    /// every distance, not merely at the default.
+    #[rstest]
+    fn test_edit_index_is_gated_to_one_mismatch(#[values(0, 1, 2, 3, 6)] max_mismatches: u32) {
+        let expected = max_mismatches == 1;
+        let assigner = SimpleErrorUmiAssigner::new_with_index_threshold(
+            max_mismatches,
+            IndexThreshold::Always,
+        );
+
+        assert_eq!(
+            assigner.uses_index(EDIT_INDEX_THRESHOLD + 50),
+            expected,
+            "`always` must not resurrect the index at {max_mismatches} mismatch(es)"
+        );
+        assert_eq!(
+            crate::assigner::Strategy::Edit.can_use_index(max_mismatches),
+            expected,
+            "`can_use_index` must report what the assigner does at {max_mismatches} \
+             mismatch(es), or `--index-threshold always` validates against a fiction"
+        );
+    }
+
+    /// The gate is a *measured* restriction, not a capability one -- `NgramIndex` itself
+    /// serves any distance an 8-base UMI can be split into, because it partitions into
+    /// `max_mismatches + 1` pieces and `find_within` re-verifies each candidate's
+    /// Hamming distance. Pinned so that widening the gate stays a benchmarking question
+    /// (`benches/umi_assigner_threshold.rs` sweeps one mismatch only) rather than
+    /// looking like a correctness one.
+    #[rstest]
+    fn test_ngram_index_builds_at_every_edit_distance(#[values(0, 1, 2, 3)] max_mismatches: u32) {
+        let umis = umis_with_distinct(EDIT_INDEX_THRESHOLD + 50, 8, 0xED17);
+        let distinct: Vec<&Umi> = {
+            let mut seen = std::collections::HashSet::new();
+            umis.iter().filter(|umi| seen.insert(umi.as_str())).collect()
+        };
+        let indexed: Vec<(usize, &str)> =
+            distinct.iter().enumerate().map(|(i, umi)| (i, umi.as_str())).collect();
+
+        assert!(
+            NgramIndex::new(&indexed, max_mismatches).is_some(),
+            "the index must be buildable at {max_mismatches} mismatch(es), not declined"
+        );
+    }
+
+    /// `never` reaches the edit assigner too, so no group size resurrects the index --
+    /// at one mismatch, where it would otherwise have fired.
+    #[test]
+    fn test_edit_never_suppresses_the_index() {
+        let assigner = SimpleErrorUmiAssigner::new_with_index_threshold(1, IndexThreshold::Never);
+        assert!(!assigner.uses_index(1_000_000));
+    }
+
+    /// Pins what `--index-threshold` actually does, so the CLI help can be checked
+    /// against it. A bare integer is a MINIMUM group size, not a switch, so `0` turns
+    /// the index fully on. `never` is the only way to turn it off.
+    #[rstest]
+    #[case::zero_always_indexes(IndexThreshold::MinUmis(0), 1, true)]
+    #[case::zero_indexes_empty_group(IndexThreshold::MinUmis(0), 0, true)]
+    #[case::below_threshold_scans(IndexThreshold::MinUmis(100), 99, false)]
+    #[case::at_threshold_indexes(IndexThreshold::MinUmis(100), 100, true)]
+    #[case::above_threshold_indexes(IndexThreshold::MinUmis(100), 101, true)]
+    #[case::always_indexes_singleton(IndexThreshold::Always, 1, true)]
+    #[case::never_skips_huge_group(IndexThreshold::Never, 1_000_000, false)]
     fn test_adjacency_index_threshold_is_a_minimum_not_a_switch(
-        #[case] index_threshold: usize,
+        #[case] index_threshold: IndexThreshold,
         #[case] num_umis: usize,
         #[case] expected: bool,
     ) {
         let assigner = AdjacencyUmiAssigner::new(1, 1, index_threshold);
         assert_eq!(assigner.uses_index(num_umis), expected);
+    }
+
+    /// `never` wins over every other consideration, including an edit distance that
+    /// would otherwise index (paired) -- there is no combination that resurrects it.
+    #[rstest]
+    #[case::edits_one(1)]
+    #[case::edits_two(2)]
+    fn test_never_suppresses_the_index_at_every_edit_distance(#[case] max_mismatches: u32) {
+        let adjacency = AdjacencyUmiAssigner::new(max_mismatches, 1, IndexThreshold::Never);
+        assert!(!adjacency.uses_index(1_000_000));
+
+        let paired = PairedUmiAssigner::new_with_threads(max_mismatches, 1, IndexThreshold::Never);
+        assert!(!paired.uses_index(1_000_000));
     }
 
     /// The adjacency assigner only indexes at `--edits 1`; every other value falls
@@ -4796,7 +5114,8 @@ mod tests {
         #[case] num_umis: usize,
         #[case] expected: bool,
     ) {
-        let assigner = PairedUmiAssigner::new_with_threads(max_mismatches, 1, 100);
+        let assigner =
+            PairedUmiAssigner::new_with_threads(max_mismatches, 1, IndexThreshold::MinUmis(100));
         assert_eq!(assigner.uses_index(num_umis), expected);
     }
 }

--- a/crates/fgumi-umi/src/assigner.rs
+++ b/crates/fgumi-umi/src/assigner.rs
@@ -635,7 +635,9 @@ impl Strategy {
     ///
     /// * `edits` - Maximum number of mismatches allowed between UMIs
     /// * `threads` - Number of threads to use (only applies to Adjacency and Paired strategies)
-    /// * `index_threshold` - Minimum UMIs per position to use N-gram/BK-tree index
+    /// * `index_threshold` - Minimum distinct UMIs at a position before an index is used
+    ///   instead of a linear scan; see [`AdjacencyUmiAssigner::uses_index`] and
+    ///   [`PairedUmiAssigner::uses_index`]
     ///
     /// # Returns
     ///
@@ -1422,7 +1424,8 @@ impl AdjacencyUmiAssigner {
     ///
     /// * `max_mismatches` - Maximum number of mismatches allowed for UMIs to be adjacent
     /// * `threads` - Number of threads to use for matching (default: 1)
-    /// * `index_threshold` - Minimum UMIs per position to use N-gram/BK-tree index (default: 1000)
+    /// * `index_threshold` - Minimum distinct UMIs at a position before the N-gram index
+    ///   is used instead of a linear scan; see [`AdjacencyUmiAssigner::uses_index`]
     ///
     /// # Returns
     ///
@@ -1430,6 +1433,27 @@ impl AdjacencyUmiAssigner {
     #[must_use]
     pub fn new(max_mismatches: u32, threads: usize, index_threshold: usize) -> Self {
         Self { max_mismatches, threads, index_threshold, counter: AtomicU64::new(0) }
+    }
+
+    /// Whether a position group of `num_umis` distinct UMIs is *eligible* to be
+    /// matched through the N-gram index rather than a linear scan over all UMI pairs.
+    ///
+    /// `index_threshold` is a MINIMUM, not a switch: the index is built once a group
+    /// is at least that large, so `0` indexes every group and disabling the index
+    /// entirely takes a threshold larger than any group (e.g. `usize::MAX`).
+    ///
+    /// The index is additionally limited to `max_mismatches == 1`, which is all
+    /// `NgramIndex` serves here; every other edit distance falls back to the linear
+    /// scan whatever the threshold. (The paired strategy is not so limited — see
+    /// [`PairedUmiAssigner::uses_index`].)
+    ///
+    /// Eligibility is necessary but not sufficient: [`NgramIndex::new`] declines an
+    /// empty group, a UMI containing non-ACGT bases, or inconsistent UMI lengths, and
+    /// the caller then falls back to the linear scan. So `true` means "the threshold
+    /// and edit-distance conditions permit indexing", not "an index was built".
+    #[must_use]
+    pub fn uses_index(&self, num_umis: usize) -> bool {
+        num_umis >= self.index_threshold && self.max_mismatches == 1
     }
 
     /// Generate the next unique molecule ID
@@ -1514,7 +1538,7 @@ impl AdjacencyUmiAssigner {
         };
 
         // Try to build index for fast candidate search (if enough UMIs)
-        let ngram_index = if nodes.len() >= self.index_threshold && self.max_mismatches == 1 {
+        let ngram_index = if self.uses_index(nodes.len()) {
             // For BitEnc-based matching, we need to use the original strings for NgramIndex
             // since it internally converts to BitEnc
             let umis: Vec<(usize, &str)> = umi_counts
@@ -1670,8 +1694,10 @@ impl AdjacencyUmiAssigner {
             None
         };
 
-        // Try to build index for fast candidate search (if enough UMIs)
-        // Use N-gram index for k=1 (most efficient), BK-tree for k>1
+        // Try to build index for fast candidate search (if enough UMIs).
+        // Unlike `build_adjacency_graph_bitenc`, this path indexes at every edit
+        // distance: N-gram for k=1 (most efficient), BK-tree for k>1. Only the
+        // `index_threshold` minimum applies -- see `PairedUmiAssigner::uses_index`.
         let (ngram_index, bktree) = if nodes.len() >= self.index_threshold {
             let umis: Vec<(usize, &str)> =
                 umi_counts.iter().enumerate().map(|(i, (umi, _, _))| (i, umi.as_str())).collect();
@@ -1996,7 +2022,9 @@ impl PairedUmiAssigner {
     ///
     /// * `max_mismatches` - Maximum number of mismatches allowed for UMIs to be adjacent
     /// * `threads` - Number of threads to use for matching
-    /// * `index_threshold` - Minimum UMIs per position to use N-gram/BK-tree index
+    /// * `index_threshold` - Minimum distinct UMIs at a position before an index is used
+    ///   instead of a linear scan; see [`AdjacencyUmiAssigner::uses_index`] and
+    ///   [`PairedUmiAssigner::uses_index`]
     ///
     /// # Returns
     ///
@@ -2009,6 +2037,23 @@ impl PairedUmiAssigner {
             lower_prefix: "a".repeat(prefix_len),
             higher_prefix: "b".repeat(prefix_len),
         }
+    }
+
+    /// Whether a position group of `num_umis` distinct UMIs is *eligible* to be
+    /// matched through an index rather than a linear scan over all UMI pairs.
+    ///
+    /// As for [`AdjacencyUmiAssigner::uses_index`], `index_threshold` is a MINIMUM:
+    /// `0` indexes every group. Unlike the adjacency strategy, the paired strategy
+    /// indexes at every `--edits` value — N-gram for k=1, BK-tree for k>1 — so only
+    /// the threshold applies.
+    ///
+    /// As there, eligibility is necessary but not sufficient: [`NgramIndex::new`] and
+    /// [`BkTree::from_umis`] both decline UMIs they cannot encode (non-ACGT bases, and
+    /// for the N-gram index an empty group or inconsistent lengths), and the caller
+    /// then falls back to the linear scan.
+    #[must_use]
+    pub fn uses_index(&self, num_umis: usize) -> bool {
+        num_umis >= self.adjacency.index_threshold
     }
 
     /// Get the prefix for lower-ordered reads in a pair
@@ -4695,5 +4740,63 @@ mod tests {
             "mint fired {} times; expected one per distinct rejected UMI ({expected_mints})",
             mints.get(),
         );
+    }
+
+    // ========================================================================
+    // --index-threshold semantics
+    // ========================================================================
+
+    /// Pins what `--index-threshold` actually does, so the CLI help can be checked
+    /// against it. The gate is `num_umis >= index_threshold`, so `0` means the index
+    /// is ALWAYS built -- it does not disable the index. Disabling it requires a
+    /// threshold larger than any position group, e.g. `usize::MAX`.
+    #[rstest]
+    #[case::zero_always_indexes(0, 1, true)]
+    #[case::zero_indexes_empty_group(0, 0, true)]
+    #[case::below_threshold_scans(100, 99, false)]
+    #[case::at_threshold_indexes(100, 100, true)]
+    #[case::above_threshold_indexes(100, 101, true)]
+    #[case::usize_max_never_indexes(usize::MAX, 1_000_000, false)]
+    fn test_adjacency_index_threshold_is_a_minimum_not_a_switch(
+        #[case] index_threshold: usize,
+        #[case] num_umis: usize,
+        #[case] expected: bool,
+    ) {
+        let assigner = AdjacencyUmiAssigner::new(1, 1, index_threshold);
+        assert_eq!(assigner.uses_index(num_umis), expected);
+    }
+
+    /// The adjacency assigner only indexes at `--edits 1`; every other value falls
+    /// back to a linear scan over all UMI pairs regardless of `--index-threshold`.
+    /// `build_adjacency_graph_bitenc` gates on `self.max_mismatches == 1`, and the
+    /// BK-tree branch that would serve k>1 is only reachable from the generic
+    /// `build_adjacency_graph` used by the paired strategy.
+    #[rstest]
+    #[case::edits_zero(0, false)]
+    #[case::edits_one(1, true)]
+    #[case::edits_two(2, false)]
+    #[case::edits_three(3, false)]
+    fn test_adjacency_index_requires_exactly_one_edit(
+        #[case] max_mismatches: u32,
+        #[case] expected: bool,
+    ) {
+        let assigner = AdjacencyUmiAssigner::new(max_mismatches, 1, 100);
+        assert_eq!(assigner.uses_index(1_000), expected);
+    }
+
+    /// The paired strategy indexes at every `--edits` value: N-gram for k=1, BK-tree
+    /// for k>1. Only the `--index-threshold` minimum applies.
+    #[rstest]
+    #[case::edits_one_below_threshold(1, 99, false)]
+    #[case::edits_one_at_threshold(1, 100, true)]
+    #[case::edits_two_at_threshold(2, 100, true)]
+    #[case::edits_three_at_threshold(3, 100, true)]
+    fn test_paired_index_applies_at_every_edit_distance(
+        #[case] max_mismatches: u32,
+        #[case] num_umis: usize,
+        #[case] expected: bool,
+    ) {
+        let assigner = PairedUmiAssigner::new_with_threads(max_mismatches, 1, 100);
+        assert_eq!(assigner.uses_index(num_umis), expected);
     }
 }

--- a/crates/fgumi-umi/src/index_threshold.rs
+++ b/crates/fgumi-umi/src/index_threshold.rs
@@ -1,0 +1,241 @@
+//! When the UMI-matching index is used instead of a linear scan.
+
+use std::fmt;
+use std::str::FromStr;
+
+/// Default minimum number of unique UMIs to use N-gram/BK-tree index for candidate search.
+/// Below this threshold, linear scan is used. Based on benchmarks: index provides ~10%
+/// speedup even at 100 UMIs/position with negligible construction overhead.
+pub const DEFAULT_INDEX_THRESHOLD: usize = 100;
+
+/// Value of `--index-threshold`: when to match UMIs through the N-gram/BK-tree index
+/// rather than by comparing every pair.
+///
+/// The index is a pure optimization — it narrows the candidate set, it does not change
+/// which UMIs group together — so every variant yields the same grouping and differs only
+/// in how much work reaching it takes.
+///
+/// [`MinUmis`](Self::MinUmis) is a *minimum group size*, not a switch, and that has caught
+/// people out: `MinUmis(0)` admits every group, so a plain `0` turns the index fully **on**
+/// — the opposite of what the CLI help claimed for a long time. [`Always`](Self::Always) and
+/// [`Never`](Self::Never) let that intent be stated in a word rather than encoded in a
+/// number no one can read back. `Never` is not otherwise reachable: suppressing the index
+/// through `MinUmis` alone would take a value larger than any position group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexThreshold {
+    /// Index every position group, whatever its size.
+    Always,
+    /// Never index; always compare all UMI pairs.
+    Never,
+    /// Index a position group once it holds at least this many distinct UMIs.
+    MinUmis(usize),
+}
+
+impl IndexThreshold {
+    /// Whether a position group of `num_umis` distinct UMIs is matched through the index.
+    #[must_use]
+    pub fn admits(self, num_umis: usize) -> bool {
+        match self {
+            Self::Always => true,
+            Self::Never => false,
+            Self::MinUmis(min) => num_umis >= min,
+        }
+    }
+
+    /// Whether this value *asserts* that indexing must happen, rather than merely tuning
+    /// when it starts.
+    ///
+    /// Only the `always` keyword asserts. A number — including `0`, which admits every
+    /// group exactly as `Always` does — is a tuning knob allowed to end up inert, which is
+    /// what lets the default `100` coexist with strategies that never index. Callers use
+    /// this to reject a request they cannot honour instead of silently ignoring it.
+    #[must_use]
+    pub fn demands_indexing(self) -> bool {
+        matches!(self, Self::Always)
+    }
+
+    /// This value with any numeric minimum raised to at least `min_umis`.
+    ///
+    /// A strategy whose measured index crossover sits above the shared default uses this
+    /// to floor the number it was handed, so asking it for a lower one only ever buys a
+    /// slower run.
+    ///
+    /// The keywords pass through unchanged: they state an intent about *whether* to index,
+    /// not a group size to be negotiated, so `Always` still indexes every group and `Never`
+    /// still indexes none. Clamping `Always` instead would be actively wrong, not merely
+    /// conservative — [`demands_indexing`](Self::demands_indexing) makes `always` an
+    /// assertion that callers *reject* when it cannot be honoured, so a clamped `Always`
+    /// would pass validation and then silently not index every group below the floor. That
+    /// is the quietly-ignored-flag failure this type exists to remove. It would also leave
+    /// no way at all to reach the index below the floor, since numbers are floored too, and
+    /// make `always` an exact alias for the floor value.
+    ///
+    /// The cost of honouring it is small, two-sided, and very rarely paid. The index is only
+    /// *reached* once a position passes the strategy's defer point, so the floor governs one
+    /// narrow band — 65..199 distinct UMIs at a single position — and across it `Always`
+    /// measures ~1.3x slower at 80 distinct, break-even near 130, and 1.2-1.5x *faster* by
+    /// 199 on single-UMI input.
+    ///
+    /// That band is close to empty in practice. Over seven benchmark corpora (~29.8M mapped
+    /// position groups: twist-umi, agilent-hs2, idt-cfdna, SRR6109255, qiaseq-umi,
+    /// schmitt-abl1, synthetic-pipeline-xlarge) the mean position holds 1.0-2.5 distinct UMIs
+    /// and only 45 groups in total land in the band, 38 of them in the one amplicon dataset.
+    /// Every group in the corpus that passes the defer point at all carries a *dual* UMI,
+    /// whose `-` is not `BitEnc`-encodable, so the index build is declined and the set-merge
+    /// resumes regardless of this setting; the sole simplex corpus (qiaseq-umi) never exceeds
+    /// 18 distinct UMIs at a position and so never reaches the index either. High-depth
+    /// simplex input would exercise this — nothing here does.
+    ///
+    /// Whichever way it is decided, no molecule id moves: the index only filters candidates,
+    /// each of which is still distance-checked in full.
+    ///
+    /// Someone typing `always` is overriding the default deliberately; the default is what
+    /// protects the naive path.
+    #[must_use]
+    pub fn floored_at(self, min_umis: usize) -> Self {
+        match self {
+            Self::MinUmis(min) => Self::MinUmis(min.max(min_umis)),
+            keyword => keyword,
+        }
+    }
+}
+
+impl Default for IndexThreshold {
+    fn default() -> Self {
+        Self::MinUmis(DEFAULT_INDEX_THRESHOLD)
+    }
+}
+
+impl From<usize> for IndexThreshold {
+    fn from(min_umis: usize) -> Self {
+        Self::MinUmis(min_umis)
+    }
+}
+
+impl FromStr for IndexThreshold {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        if s.eq_ignore_ascii_case("always") {
+            Ok(Self::Always)
+        } else if s.eq_ignore_ascii_case("never") {
+            Ok(Self::Never)
+        } else {
+            s.parse::<usize>().map(Self::MinUmis).map_err(|e| {
+                format!("expected 'always', 'never', or a non-negative integer, got '{s}': {e}")
+            })
+        }
+    }
+}
+
+impl fmt::Display for IndexThreshold {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Always => f.write_str("always"),
+            Self::Never => f.write_str("never"),
+            Self::MinUmis(min) => write!(f, "{min}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    /// `--index-threshold` accepts the two keywords and any non-negative integer.
+    #[rstest]
+    #[case::always("always", IndexThreshold::Always)]
+    #[case::always_mixed_case("Always", IndexThreshold::Always)]
+    #[case::never("never", IndexThreshold::Never)]
+    #[case::never_upper("NEVER", IndexThreshold::Never)]
+    #[case::zero("0", IndexThreshold::MinUmis(0))]
+    #[case::default_value("100", IndexThreshold::MinUmis(100))]
+    fn test_index_threshold_parses(#[case] input: &str, #[case] expected: IndexThreshold) {
+        assert_eq!(input.parse::<IndexThreshold>(), Ok(expected));
+    }
+
+    /// Rejected input names the accepted forms, so the error is actionable.
+    #[rstest]
+    #[case::negative("-1")]
+    #[case::word("off")]
+    #[case::empty("")]
+    #[case::float("1.5")]
+    fn test_index_threshold_rejects_invalid(#[case] input: &str) {
+        let err = input.parse::<IndexThreshold>().expect_err("must reject");
+        assert!(
+            err.contains("always") && err.contains("never"),
+            "error should name the accepted forms, got: {err}"
+        );
+    }
+
+    /// `admits` is the gate the assigners consult. `MinUmis` is a MINIMUM, so `0`
+    /// admits every group — the reading the CLI help had backwards for a long time.
+    #[rstest]
+    #[case::always_admits_empty(IndexThreshold::Always, 0, true)]
+    #[case::always_admits_huge(IndexThreshold::Always, 1_000_000, true)]
+    #[case::never_rejects_huge(IndexThreshold::Never, 1_000_000, false)]
+    #[case::zero_admits_singleton(IndexThreshold::MinUmis(0), 1, true)]
+    #[case::below_minimum(IndexThreshold::MinUmis(100), 99, false)]
+    #[case::at_minimum(IndexThreshold::MinUmis(100), 100, true)]
+    #[case::above_minimum(IndexThreshold::MinUmis(100), 101, true)]
+    fn test_index_threshold_admits(
+        #[case] threshold: IndexThreshold,
+        #[case] num_umis: usize,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(threshold.admits(num_umis), expected);
+    }
+
+    /// Only the `always` keyword asserts that indexing must happen. A number is a
+    /// tuning knob allowed to end up inert, which is what lets the default `100`
+    /// coexist with strategies that never index.
+    #[rstest]
+    #[case::always_demands(IndexThreshold::Always, true)]
+    #[case::never_does_not(IndexThreshold::Never, false)]
+    #[case::zero_does_not(IndexThreshold::MinUmis(0), false)]
+    #[case::default_does_not(IndexThreshold::MinUmis(100), false)]
+    fn test_only_always_demands_indexing(
+        #[case] threshold: IndexThreshold,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(threshold.demands_indexing(), expected);
+    }
+
+    /// `floored_at` raises a numeric minimum to the strategy's own crossover and leaves
+    /// the keywords alone: `always` is an escape hatch that must not be talked down to a
+    /// crossover, and `never` has no minimum to raise.
+    #[rstest]
+    #[case::below_floor_is_raised(IndexThreshold::MinUmis(0), 200, IndexThreshold::MinUmis(200))]
+    #[case::default_is_raised(IndexThreshold::MinUmis(100), 200, IndexThreshold::MinUmis(200))]
+    #[case::at_floor_unchanged(IndexThreshold::MinUmis(200), 200, IndexThreshold::MinUmis(200))]
+    #[case::above_floor_honoured(IndexThreshold::MinUmis(500), 200, IndexThreshold::MinUmis(500))]
+    #[case::always_passes_through(IndexThreshold::Always, 200, IndexThreshold::Always)]
+    #[case::never_passes_through(IndexThreshold::Never, 200, IndexThreshold::Never)]
+    fn test_floored_at_raises_only_numeric_minimums(
+        #[case] threshold: IndexThreshold,
+        #[case] min_umis: usize,
+        #[case] expected: IndexThreshold,
+    ) {
+        assert_eq!(threshold.floored_at(min_umis), expected);
+    }
+
+    /// Values round-trip through `Display`, so logs and help text stay parseable.
+    #[rstest]
+    #[case::always(IndexThreshold::Always, "always")]
+    #[case::never(IndexThreshold::Never, "never")]
+    #[case::min_umis(IndexThreshold::MinUmis(100), "100")]
+    fn test_index_threshold_displays_and_round_trips(
+        #[case] threshold: IndexThreshold,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(threshold.to_string(), expected);
+        assert_eq!(expected.parse::<IndexThreshold>(), Ok(threshold));
+    }
+
+    /// The default matches the documented `--index-threshold` default.
+    #[test]
+    fn test_default_is_the_documented_threshold() {
+        assert_eq!(IndexThreshold::default(), IndexThreshold::MinUmis(DEFAULT_INDEX_THRESHOLD));
+    }
+}

--- a/crates/fgumi-umi/src/lib.rs
+++ b/crates/fgumi-umi/src/lib.rs
@@ -8,12 +8,14 @@
 //! - UMI grouping and family analysis
 
 pub mod assigner;
+pub mod index_threshold;
 
 // Re-export commonly used items
 pub use assigner::{
     AdjacencyUmiAssigner, EDIT_INDEX_THRESHOLD, IdentityUmiAssigner, PairedUmiAssigner,
     SimpleErrorUmiAssigner, Strategy, Umi, UmiAssigner,
 };
+pub use index_threshold::{DEFAULT_INDEX_THRESHOLD, IndexThreshold};
 
 use std::collections::HashSet;
 

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -17,6 +17,7 @@ use clap::Args;
 use fgumi_bam_io::is_stdin_path;
 #[cfg(feature = "simplex")]
 use fgumi_consensus::methylation::RefBaseProvider;
+use fgumi_umi::IndexThreshold;
 #[cfg(feature = "simplex")]
 use log::{info, warn};
 use noodles::sam::Header;
@@ -136,11 +137,13 @@ pub fn add_pg_to_builder(
 /// `group` and `dedup` both report the N-gram index threshold that is actually in
 /// effect, which is not always the raw `--index-threshold` value:
 ///
-/// - [`Strategy::Edit`] indexes only at one mismatch, and floors the flag at its own
-///   measured crossover ([`fgumi_umi::EDIT_INDEX_THRESHOLD`], higher than the shared
+/// - [`Strategy::Edit`] indexes only at one mismatch, and floors a numeric flag at its
+///   own measured crossover ([`fgumi_umi::EDIT_INDEX_THRESHOLD`], higher than the shared
 ///   default), so it reports `max(flag, EDIT_INDEX_THRESHOLD)` at one mismatch and
 ///   "not used" otherwise.
-/// - [`Strategy::Adjacency`] and [`Strategy::Paired`] use the flag verbatim.
+/// - [`Strategy::Adjacency`] also indexes only at one mismatch, so it reports "not used"
+///   at any other, and the flag verbatim at one.
+/// - [`Strategy::Paired`] uses the flag verbatim at every mismatch count.
 /// - [`Strategy::Identity`] never indexes, so it reports nothing.
 ///
 /// # Arguments
@@ -155,15 +158,18 @@ pub fn add_pg_to_builder(
 pub fn index_threshold_log_message(
     strategy: Strategy,
     effective_edits: u32,
-    index_threshold: usize,
+    index_threshold: IndexThreshold,
 ) -> Option<String> {
     match strategy {
-        Strategy::Edit if effective_edits == 1 => Some(format!(
-            "Index threshold: {} (edit)",
-            index_threshold.max(fgumi_umi::EDIT_INDEX_THRESHOLD)
-        )),
-        Strategy::Edit => {
+        Strategy::Edit if effective_edits != 1 => {
             Some("Index threshold: not used (edit indexes only at --edits 1)".to_string())
+        }
+        Strategy::Edit => Some(format!(
+            "Index threshold: {} (edit)",
+            index_threshold.floored_at(fgumi_umi::EDIT_INDEX_THRESHOLD)
+        )),
+        Strategy::Adjacency if effective_edits != 1 => {
+            Some("Index threshold: not used (adjacency indexes only at --edits 1)".to_string())
         }
         Strategy::Adjacency | Strategy::Paired => {
             Some(format!("Index threshold: {index_threshold}"))
@@ -188,7 +194,11 @@ const _: () = assert!(
 /// Shared by `group` and `dedup` so the two cannot drift apart when a threshold
 /// changes. See [`index_threshold_log_message`] for the arguments and the
 /// per-strategy behavior.
-pub fn log_index_threshold(strategy: Strategy, effective_edits: u32, index_threshold: usize) {
+pub fn log_index_threshold(
+    strategy: Strategy,
+    effective_edits: u32,
+    index_threshold: IndexThreshold,
+) {
     if let Some(message) = index_threshold_log_message(strategy, effective_edits, index_threshold) {
         log::info!("{message}");
     }
@@ -1205,44 +1215,141 @@ pub fn build_pipeline_config(
     Ok(config)
 }
 
+/// Reject an `--index-threshold` that demands indexing under a configuration that can
+/// never index.
+///
+/// `always` is an assertion that the UMI index will be used, so a strategy/edits
+/// combination with no index code path has to be an error rather than a flag that is
+/// quietly ignored. Pass the EFFECTIVE strategy and edits, so `--no-umi` (which forces
+/// identity) is caught too.
+///
+/// A bare integer is deliberately not checked. It is a tuning knob allowed to end up
+/// inert — otherwise the default `100` could not coexist with `--strategy identity` —
+/// and that includes `0`, even though `0` admits every group exactly as `always` does.
+///
+/// # Errors
+///
+/// Returns an error naming the conflict and how to resolve it.
+pub fn validate_index_threshold(
+    index_threshold: IndexThreshold,
+    strategy: Strategy,
+    edits: u32,
+) -> anyhow::Result<()> {
+    if !index_threshold.demands_indexing() || strategy.can_use_index(edits) {
+        return Ok(());
+    }
+
+    let name = format!("{strategy:?}").to_lowercase();
+    let (context, reason) = match strategy {
+        // Edit and adjacency both have an index, just not at this edit distance, so the
+        // reason has to name the distance rather than claim they never index.
+        Strategy::Edit | Strategy::Adjacency => {
+            (format!(" --edits {edits}"), format!("the {name} strategy only indexes at --edits 1"))
+        }
+        _ => (String::new(), format!("the {name} strategy never uses the UMI index")),
+    };
+
+    anyhow::bail!(
+        "--index-threshold always cannot be honoured with --strategy {name}{context}: \
+         {reason}. Drop --index-threshold to leave indexing to the default threshold, \
+         or pass --index-threshold never to state that a linear scan is intended."
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     /// `index_threshold_log_message` reports the threshold that is actually in effect,
-    /// which is not always the raw `--index-threshold` value. `Edit` floors the flag at
-    /// its own measured crossover and indexes only at one mismatch; `Adjacency`/`Paired`
-    /// use the flag verbatim; `Identity` never indexes and so reports nothing.
+    /// which is not always the raw `--index-threshold` value. `Edit` floors a numeric
+    /// flag at its own measured crossover and indexes only at one mismatch; `Adjacency`
+    /// uses the flag verbatim and also only indexes at one mismatch; `Paired` uses the
+    /// flag verbatim always; `Identity` never indexes and so reports nothing.
     #[rstest]
-    // Edit at one mismatch floors the flag at EDIT_INDEX_THRESHOLD (200).
-    #[case::edit_flag_below_floor(Strategy::Edit, 1, 100, Some("Index threshold: 200 (edit)"))]
-    // A flag above the floor wins, so the user can still raise it.
-    #[case::edit_flag_above_floor(Strategy::Edit, 1, 500, Some("Index threshold: 500 (edit)"))]
-    // Zero does not disable indexing: the gate is `distinct >= threshold`, so the
-    // floor still applies.
-    #[case::edit_flag_zero(Strategy::Edit, 1, 0, Some("Index threshold: 200 (edit)"))]
-    // Edit only indexes at one mismatch.
+    // Edit floors a numeric flag at EDIT_INDEX_THRESHOLD (200)...
+    #[case::edit_flag_below_floor(
+        Strategy::Edit,
+        1,
+        IndexThreshold::MinUmis(100),
+        Some("Index threshold: 200 (edit)")
+    )]
+    // ...a flag above the floor wins, so the user can still raise it...
+    #[case::edit_flag_above_floor(
+        Strategy::Edit,
+        1,
+        IndexThreshold::MinUmis(500),
+        Some("Index threshold: 500 (edit)")
+    )]
+    // ...and `0` does not disable indexing (the gate is `distinct >= threshold`), so
+    // the floor still applies to it.
+    #[case::edit_flag_zero(
+        Strategy::Edit,
+        1,
+        IndexThreshold::MinUmis(0),
+        Some("Index threshold: 200 (edit)")
+    )]
+    // The keywords state an intent rather than a group size, so the floor leaves them be.
+    #[case::edit_always(
+        Strategy::Edit,
+        1,
+        IndexThreshold::Always,
+        Some("Index threshold: always (edit)")
+    )]
+    #[case::edit_never(
+        Strategy::Edit,
+        1,
+        IndexThreshold::Never,
+        Some("Index threshold: never (edit)")
+    )]
+    // Edit indexes only at one mismatch, so every other distance reports "not used".
     #[case::edit_two_mismatches(
         Strategy::Edit,
         2,
-        100,
+        IndexThreshold::MinUmis(100),
         Some("Index threshold: not used (edit indexes only at --edits 1)")
     )]
     #[case::edit_zero_mismatches(
         Strategy::Edit,
         0,
-        100,
+        IndexThreshold::MinUmis(100),
         Some("Index threshold: not used (edit indexes only at --edits 1)")
     )]
-    // Adjacency and paired report the raw flag, with no floor.
-    #[case::adjacency(Strategy::Adjacency, 1, 100, Some("Index threshold: 100"))]
-    #[case::paired(Strategy::Paired, 1, 37, Some("Index threshold: 37"))]
+    // The edit-distance condition outranks the keyword: `never` at two mismatches is
+    // "not used" for the stronger reason, not "never". (`always` cannot reach here at
+    // all -- `validate_index_threshold` rejects it before anything is logged.)
+    #[case::edit_never_two_mismatches(
+        Strategy::Edit,
+        2,
+        IndexThreshold::Never,
+        Some("Index threshold: not used (edit indexes only at --edits 1)")
+    )]
+    // Adjacency reports the raw flag, with no floor, but only indexes at one mismatch.
+    #[case::adjacency(
+        Strategy::Adjacency,
+        1,
+        IndexThreshold::MinUmis(100),
+        Some("Index threshold: 100")
+    )]
+    #[case::adjacency_two_mismatches(
+        Strategy::Adjacency,
+        2,
+        IndexThreshold::MinUmis(100),
+        Some("Index threshold: not used (adjacency indexes only at --edits 1)")
+    )]
+    // Paired reports the raw flag at every mismatch count.
+    #[case::paired(Strategy::Paired, 1, IndexThreshold::MinUmis(37), Some("Index threshold: 37"))]
+    #[case::paired_two_mismatches(
+        Strategy::Paired,
+        2,
+        IndexThreshold::Never,
+        Some("Index threshold: never")
+    )]
     // Identity never indexes, so it emits no line at all.
-    #[case::identity(Strategy::Identity, 0, 100, None)]
+    #[case::identity(Strategy::Identity, 0, IndexThreshold::MinUmis(100), None)]
     fn test_index_threshold_log_message(
         #[case] strategy: Strategy,
         #[case] effective_edits: u32,
-        #[case] index_threshold: usize,
+        #[case] index_threshold: IndexThreshold,
         #[case] expected: Option<&str>,
     ) {
         assert_eq!(
@@ -1257,7 +1364,7 @@ mod tests {
     fn test_index_threshold_log_message_uses_crate_floor() {
         let floor = fgumi_umi::EDIT_INDEX_THRESHOLD;
         assert_eq!(
-            index_threshold_log_message(Strategy::Edit, 1, 0),
+            index_threshold_log_message(Strategy::Edit, 1, IndexThreshold::MinUmis(0)),
             Some(format!("Index threshold: {floor} (edit)"))
         );
     }
@@ -1269,9 +1376,11 @@ mod tests {
         #[values(Strategy::Identity, Strategy::Edit, Strategy::Adjacency, Strategy::Paired)]
         strategy: Strategy,
         #[values(0, 1, 2)] effective_edits: u32,
+        #[values(IndexThreshold::Always, IndexThreshold::Never, IndexThreshold::MinUmis(100))]
+        index_threshold: IndexThreshold,
     ) {
         enable_logging();
-        log_index_threshold(strategy, effective_edits, 100);
+        log_index_threshold(strategy, effective_edits, index_threshold);
     }
 
     /// Enable an at-Trace logger so `log::warn!`/`debug!` macros evaluate their

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -1119,12 +1119,13 @@ pub struct MarkDuplicates {
     #[command(flatten)]
     pub compression: CompressionOptions,
 
-    /// Minimum distinct UMIs at a position before an N-gram/BK-tree index is
-    /// built, instead of comparing every pair. Set high (e.g. a value larger
-    /// than any position group) to always use the linear scan.
-    /// Affects the Edit, Adjacency and Paired strategies. Edit floors this at
-    /// its own measured crossover (200 distinct UMIs), below which the index
-    /// costs more than the scan it replaces, and indexes only at --edits 1.
+    /// Minimum distinct UMIs at a position before the N-gram/BK-tree index is used
+    /// instead of a linear scan over all UMI pairs. This is a minimum, not a switch:
+    /// 0 indexes every position group, and disabling the index takes a value larger
+    /// than any group. Affects the Edit, Adjacency and Paired strategies. Edit floors
+    /// this at its own measured crossover (200 distinct UMIs), below which the index
+    /// costs more than the scan it replaces. Adjacency only indexes at --edits 1;
+    /// Edit and Paired index at every edit distance.
     #[arg(long = "index-threshold", default_value = "100")]
     pub index_threshold: usize,
 

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -42,6 +42,7 @@ use anyhow::{Context, Result, bail};
 use clap::Parser;
 use fgoxide::io::DelimFile;
 use fgumi_bam_io::create_bam_reader_for_pipeline_with_opts;
+use fgumi_umi::IndexThreshold;
 
 use log::info;
 use noodles::sam::Header;
@@ -1119,15 +1120,16 @@ pub struct MarkDuplicates {
     #[command(flatten)]
     pub compression: CompressionOptions,
 
-    /// Minimum distinct UMIs at a position before the N-gram/BK-tree index is used
-    /// instead of a linear scan over all UMI pairs. This is a minimum, not a switch:
-    /// 0 indexes every position group, and disabling the index takes a value larger
-    /// than any group. Affects the Edit, Adjacency and Paired strategies. Edit floors
-    /// this at its own measured crossover (200 distinct UMIs), below which the index
-    /// costs more than the scan it replaces. Adjacency only indexes at --edits 1;
-    /// Edit and Paired index at every edit distance.
+    /// When to match UMIs through the N-gram/BK-tree index instead of comparing every
+    /// pair. Either `always`, `never`, or a minimum number of distinct UMIs at a
+    /// position. The number is a minimum, not a switch, so `0` gates the index on for
+    /// every group exactly as `always` does; only `always` additionally errors when the
+    /// strategy can never index. The index is a pure optimization: it never changes
+    /// which reads group together. Edit and Adjacency index only at --edits 1, and Edit
+    /// floors a numeric threshold at its own measured crossover (200 distinct UMIs);
+    /// Paired indexes at every --edits value.
     #[arg(long = "index-threshold", default_value = "100")]
-    pub index_threshold: usize,
+    pub index_threshold: IndexThreshold,
 
     /// Skip UMI-based grouping; group by template coordinate alone. Forces identity
     /// strategy and ignores any existing UMI tags. Templates are NOT split by strand of
@@ -1167,11 +1169,6 @@ impl Command for MarkDuplicates {
             (self.strategy, false)
         };
 
-        // Validate the input exists (stdin paths are exempt).
-        self.io.validate()?;
-
-        let min_mapq: u8 = self.min_map_q.unwrap_or(0);
-
         // Identity strategy requires edits=0, others use the configured value
         // Also force edits=0 in no-umi mode
         let effective_edits =
@@ -1180,6 +1177,19 @@ impl Command for MarkDuplicates {
             } else {
                 self.edits
             };
+
+        // `--index-threshold always` asserts that indexing will happen; reject it when
+        // the resolved strategy/edits can never index rather than ignoring the flag.
+        crate::commands::common::validate_index_threshold(
+            self.index_threshold,
+            effective_strategy,
+            effective_edits,
+        )?;
+
+        // Validate the input exists (stdin paths are exempt).
+        self.io.validate()?;
+
+        let min_mapq: u8 = self.min_map_q.unwrap_or(0);
 
         let timer = OperationTimer::new("Marking duplicates");
 

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -857,12 +857,13 @@ pub struct GroupReadsByUmi {
     #[command(flatten)]
     pub compression: CompressionOptions,
 
-    /// Minimum distinct UMIs at a position before an N-gram/BK-tree index is
-    /// built, instead of comparing every pair. Set high (e.g. a value larger
-    /// than any position group) to always use the linear scan.
-    /// Affects the Edit, Adjacency and Paired strategies. Edit floors this at
-    /// its own measured crossover (200 distinct UMIs), below which the index
-    /// costs more than the scan it replaces, and indexes only at --edits 1.
+    /// Minimum distinct UMIs at a position before the N-gram/BK-tree index is used
+    /// instead of a linear scan over all UMI pairs. This is a minimum, not a switch:
+    /// 0 indexes every position group, and disabling the index takes a value larger
+    /// than any group. Affects the Edit, Adjacency and Paired strategies. Edit floors
+    /// this at its own measured crossover (200 distinct UMIs), below which the index
+    /// costs more than the scan it replaces. Adjacency only indexes at --edits 1;
+    /// Edit and Paired index at every edit distance.
     #[arg(long = "index-threshold", default_value = "100")]
     pub index_threshold: usize,
 

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -32,6 +32,7 @@ use clap::Parser;
 use fgoxide::io::DelimFile;
 use fgumi_bam_io::ProgressTracker;
 use fgumi_bam_io::{create_bam_reader_for_pipeline, create_bam_writer};
+use fgumi_umi::IndexThreshold;
 // MemoryEstimate is gated because it's only used in memory-debug blocks below
 use crate::sam::SamTag;
 #[cfg(feature = "memory-debug")]
@@ -481,7 +482,7 @@ fn should_use_parallel(
 fn create_umi_assigner(
     strategy: Strategy,
     effective_edits: u32,
-    index_threshold: usize,
+    index_threshold: IndexThreshold,
     num_threads: usize,
     use_parallel: bool,
 ) -> Box<dyn UmiAssigner> {
@@ -857,15 +858,19 @@ pub struct GroupReadsByUmi {
     #[command(flatten)]
     pub compression: CompressionOptions,
 
-    /// Minimum distinct UMIs at a position before the N-gram/BK-tree index is used
-    /// instead of a linear scan over all UMI pairs. This is a minimum, not a switch:
-    /// 0 indexes every position group, and disabling the index takes a value larger
-    /// than any group. Affects the Edit, Adjacency and Paired strategies. Edit floors
-    /// this at its own measured crossover (200 distinct UMIs), below which the index
-    /// costs more than the scan it replaces. Adjacency only indexes at --edits 1;
-    /// Edit and Paired index at every edit distance.
+    /// When to match UMIs through the N-gram/BK-tree index instead of comparing every
+    /// pair. Either `always`, `never`, or a minimum number of distinct UMIs at a
+    /// position. The number is a minimum, not a switch, so `0` gates the index on for
+    /// every group exactly as `always` does; only `always` additionally errors when the
+    /// strategy can never index. The index is a pure optimization: it never changes
+    /// which reads group together. Edit and Adjacency index only at --edits 1, and Edit
+    /// floors a numeric threshold at its own measured crossover (200 distinct UMIs);
+    /// Paired indexes at every --edits value. Ignored for any position group handed to a
+    /// parallel assigner, which with --threads above 1 means every group under
+    /// --allow-unmapped and any group meeting --parallel-group-min-templates: those
+    /// assigners find neighbours by enumeration and never consult the index.
     #[arg(long = "index-threshold", default_value = "100")]
-    pub index_threshold: usize,
+    pub index_threshold: IndexThreshold,
 
     /// Skip UMI-based grouping; group by template coordinate and strand of origin. Forces
     /// identity strategy and ignores any existing UMI tags. An F1R2 and an F2R1 template at
@@ -967,12 +972,6 @@ impl Command for GroupReadsByUmi {
             (self.strategy, false)
         };
 
-        // Validate the input exists (stdin paths are exempt).
-        self.io.validate()?;
-
-        // Set minimum mapping quality
-        let min_mapq: u8 = self.min_map_q.unwrap_or(1);
-
         // Identity strategy requires edits=0, others use the configured value
         // Also force edits=0 in no-umi mode
         let effective_edits =
@@ -981,6 +980,20 @@ impl Command for GroupReadsByUmi {
             } else {
                 self.edits
             };
+
+        // `--index-threshold always` asserts that indexing will happen; reject it when
+        // the resolved strategy/edits can never index rather than ignoring the flag.
+        crate::commands::common::validate_index_threshold(
+            self.index_threshold,
+            effective_strategy,
+            effective_edits,
+        )?;
+
+        // Validate the input exists (stdin paths are exempt).
+        self.io.validate()?;
+
+        // Set minimum mapping quality
+        let min_mapq: u8 = self.min_map_q.unwrap_or(1);
 
         // Initialize tracking infrastructure
         let timer = OperationTimer::new("Grouping reads by UMI");
@@ -1705,7 +1718,7 @@ impl GroupReadsByUmi {
         filter_config: &GroupFilterConfig,
         strategy: Strategy,
         effective_edits: u32,
-        index_threshold: usize,
+        index_threshold: IndexThreshold,
         threads: usize,
         parallel_group_min_templates: Option<&ParallelMinTemplates>,
         raw_tag: [u8; 2],
@@ -2014,7 +2027,7 @@ mod tests {
     #[case(Strategy::Adjacency)]
     #[case(Strategy::Paired)]
     fn create_umi_assigner_parallel_builds_parallel_variant(#[case] strategy: Strategy) {
-        let assigner = create_umi_assigner(strategy, 1, 0, 2, true);
+        let assigner = create_umi_assigner(strategy, 1, IndexThreshold::MinUmis(0), 2, true);
         let any = assigner.as_any();
         let is_parallel = match strategy {
             Strategy::Identity => any.is::<ParallelIdentityAssigner>(),
@@ -2037,7 +2050,7 @@ mod tests {
     #[case(Strategy::Paired)]
     fn create_umi_assigner_single_thread_builds_non_parallel_variant(#[case] strategy: Strategy) {
         // num_threads = 1 with use_parallel = true must still fall back to sequential.
-        let assigner = create_umi_assigner(strategy, 0, 0, 1, true);
+        let assigner = create_umi_assigner(strategy, 0, IndexThreshold::MinUmis(0), 1, true);
         let any = assigner.as_any();
         assert!(
             !any.is::<ParallelIdentityAssigner>()
@@ -2057,7 +2070,7 @@ mod tests {
     #[case(Strategy::Paired)]
     fn create_umi_assigner_sequential_builds_non_parallel_variant(#[case] strategy: Strategy) {
         // Identity requires zero edits; the other strategies accept zero too.
-        let assigner = create_umi_assigner(strategy, 0, 0, 2, false);
+        let assigner = create_umi_assigner(strategy, 0, IndexThreshold::MinUmis(0), 2, false);
         let any = assigner.as_any();
         assert!(
             !any.is::<ParallelIdentityAssigner>()
@@ -2145,7 +2158,7 @@ mod tests {
             min_umi_length: None,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
-            index_threshold: 100,
+            index_threshold: IndexThreshold::default(),
             no_umi: false,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
@@ -2503,7 +2516,8 @@ mod tests {
         assert_ne!(truncated[0], truncated[3], "truncated UMIs must stay distinct");
 
         // Sequential adjacency assigner, max 1 mismatch (num_threads = 1, use_parallel = false).
-        let assigner = create_umi_assigner(Strategy::Adjacency, 1, 100, 1, false);
+        let assigner =
+            create_umi_assigner(Strategy::Adjacency, 1, IndexThreshold::default(), 1, false);
         let assignments = assigner.assign(&truncated);
 
         assert_eq!(assignments.len(), 5);
@@ -3830,6 +3844,82 @@ mod tests {
             error_msg.contains("--no-umi cannot be used with --strategy paired"),
             "Error message should mention the conflict"
         );
+    }
+
+    /// `--index-threshold always` is an assertion that indexing will happen, so a
+    /// strategy/edits combination that can never index must be rejected rather than
+    /// silently ignoring the request.
+    ///
+    /// Only `always` is checked. A bare integer -- including `0`, which admits every
+    /// group just as `always` does -- is a tuning knob allowed to end up inert; that is
+    /// what lets the default `100` coexist with `--strategy identity`.
+    #[rstest]
+    // The expected substring names the STRATEGY as well as the distance: edit and
+    // adjacency share the "only indexes at --edits 1" wording, so asserting the distance
+    // alone would pass even if the message blamed the wrong strategy.
+    #[case::identity_never_indexes(
+        Strategy::Identity,
+        0,
+        "the identity strategy never uses the UMI index"
+    )]
+    #[case::adjacency_needs_one_edit(
+        Strategy::Adjacency,
+        2,
+        "the adjacency strategy only indexes at --edits 1"
+    )]
+    #[case::adjacency_zero_edits(
+        Strategy::Adjacency,
+        0,
+        "the adjacency strategy only indexes at --edits 1"
+    )]
+    #[case::edit_needs_one_edit(Strategy::Edit, 2, "the edit strategy only indexes at --edits 1")]
+    #[case::edit_zero_edits(Strategy::Edit, 0, "the edit strategy only indexes at --edits 1")]
+    fn test_index_threshold_always_rejected_when_index_unreachable(
+        #[case] strategy: Strategy,
+        #[case] edits: u32,
+        #[case] expected_in_message: &str,
+    ) {
+        let mut cmd = test_group_cmd(strategy, edits);
+        cmd.index_threshold = IndexThreshold::Always;
+
+        let err = cmd.execute("test").expect_err("must reject an unsatisfiable --index-threshold");
+        let message = err.to_string();
+        assert!(
+            message.contains("--index-threshold always") && message.contains(expected_in_message),
+            "error should say why the request cannot be honoured, got: {message}"
+        );
+    }
+
+    /// The combinations that CAN index must not be rejected, and neither must a bare
+    /// integer under a strategy that never indexes.
+    #[rstest]
+    #[case::adjacency_one_edit(Strategy::Adjacency, 1, IndexThreshold::Always)]
+    #[case::paired_two_edits(Strategy::Paired, 2, IndexThreshold::Always)]
+    #[case::edit_one_edit(Strategy::Edit, 1, IndexThreshold::Always)]
+    // Edit at two edits cannot index, but a bare integer there is still inert-and-legal,
+    // exactly as it is for identity.
+    #[case::edit_two_edits_with_number(Strategy::Edit, 2, IndexThreshold::MinUmis(100))]
+    #[case::edit_two_edits_with_never(Strategy::Edit, 2, IndexThreshold::Never)]
+    #[case::identity_with_number(Strategy::Identity, 0, IndexThreshold::MinUmis(100))]
+    #[case::identity_with_zero(Strategy::Identity, 0, IndexThreshold::MinUmis(0))]
+    #[case::identity_with_never(Strategy::Identity, 0, IndexThreshold::Never)]
+    fn test_index_threshold_accepted_when_satisfiable(
+        #[case] strategy: Strategy,
+        #[case] edits: u32,
+        #[case] index_threshold: IndexThreshold,
+    ) {
+        let mut cmd = test_group_cmd(strategy, edits);
+        cmd.index_threshold = index_threshold;
+
+        // `test_group_cmd` points at /dev/null, so execution fails later on I/O. All
+        // that matters here is that it is not rejected by the index-threshold check.
+        if let Err(e) = cmd.execute("test") {
+            let message = e.to_string();
+            assert!(
+                !message.contains("--index-threshold"),
+                "must not be rejected for --index-threshold, got: {message}"
+            );
+        }
     }
 
     #[test]

--- a/tests/integration/test_dedup_command.rs
+++ b/tests/integration/test_dedup_command.rs
@@ -14,6 +14,8 @@ use fgumi_lib::sam::SamTag;
 use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
+use noodles::sam::alignment::record::data::field::Tag;
+use noodles::sam::alignment::record_buf::data::field::Value;
 use std::fs;
 use std::path::Path;
 use tempfile::TempDir;
@@ -471,4 +473,151 @@ fn test_dedup_no_umi_large_position_group() {
 
     // All templates should share the same MI value (one group in identity strategy).
     assert_eq!(mi_values.len(), 1, "all records should share a single MI tag value");
+}
+
+/// `dedup` carries its own copy of `--index-threshold`, so it needs the same
+/// unsatisfiable-request check `group` has: `always` under a strategy with no index
+/// code path must be rejected, not silently ignored.
+#[test]
+fn test_dedup_rejects_index_threshold_always_when_index_unreachable() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    create_sorted_bam(&input_bam, create_duplicate_group("dup1", "ACGTACGT", 3, 100));
+
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--index-threshold",
+        "always",
+    ])
+    .expect("failed to parse dedup args");
+
+    let err = cmd.execute("fgumi dedup").expect_err("must reject an unsatisfiable request");
+    let message = err.to_string();
+    assert!(
+        message.contains("--index-threshold always")
+            && message.contains("never uses the UMI index"),
+        "error should say why the request cannot be honoured, got: {message}"
+    );
+}
+
+/// Read back (name, flags, MI) per record, in file order.
+///
+/// `never` only ever changes *how* neighbours are discovered, so this is the granularity
+/// the contract is stated at: which molecule each read landed in, and whether it was
+/// marked a duplicate.
+fn dedup_output_summary(path: &Path) -> Vec<(String, u16, Option<String>)> {
+    let mi_tag = Tag::from(SamTag::MI);
+    let mut reader = bam::io::Reader::new(fs::File::open(path).expect("failed to open output BAM"));
+    let header = reader.read_header().expect("failed to read output header");
+    reader
+        .record_bufs(&header)
+        .map(|record| {
+            let record = record.expect("failed to read output record");
+            let mi = record.data().get(&mi_tag).map(|value| match value {
+                Value::String(mi) => mi.to_string(),
+                other => panic!("MI must be a string tag, got {other:?}"),
+            });
+            let name = record.name().expect("output record must be named").to_string();
+            (name, record.flags().bits(), mi)
+        })
+        .collect()
+}
+
+/// Run dedup on `input_bam`, appending `extra_args`, and summarise the output.
+fn run_dedup(
+    input_bam: &Path,
+    output_bam: &Path,
+    extra_args: &[&str],
+) -> Vec<(String, u16, Option<String>)> {
+    let mut args = vec![
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--compression-level",
+        "1",
+    ];
+    args.extend_from_slice(extra_args);
+
+    MarkDuplicates::try_parse_from(args)
+        .expect("failed to parse dedup args")
+        .execute("fgumi dedup")
+        .expect("dedup must succeed");
+    dedup_output_summary(output_bam)
+}
+
+/// `never` is always satisfiable, so it must be accepted everywhere -- including under
+/// a strategy that would not have indexed anyway.
+///
+/// The index is a pure optimisation: it changes which UMI pairs are *compared*, never
+/// which reads group together. So the contract is output identity with the default
+/// threshold, not merely "a file appeared" -- and the absolute grouping is pinned too,
+/// since comparing the two runs alone would pass if both regressed the same way.
+#[test]
+fn test_dedup_accepts_index_threshold_never() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let never_bam = temp_dir.path().join("never.bam");
+    let default_bam = temp_dir.path().join("default.bam");
+    // Three pairs sharing one UMI at one position: one molecule, six records.
+    create_sorted_bam(&input_bam, create_duplicate_group("dup1", "ACGTACGT", 3, 100));
+
+    let never = run_dedup(&input_bam, &never_bam, &["--index-threshold", "never"]);
+    let default = run_dedup(&input_bam, &default_bam, &[]);
+
+    assert_eq!(
+        never, default,
+        "--index-threshold never must not change the output; it only suppresses the index"
+    );
+
+    // Absolute expectations, so this still fails if both runs regress together.
+    assert_eq!(never.len(), 6, "all six records must be emitted (marked, not removed)");
+
+    // All six records, pinned by name, flags and molecule. The two ends sit in
+    // different template-coordinate position groups (99 and 199), so each end gets its
+    // own molecule id -- the three copies of each end share one, which is the grouping
+    // the index would have had to get wrong to matter here.
+    let expected = vec![
+        ("dup1_0".to_string(), flags::PAIRED | flags::FIRST_SEGMENT, Some("0".to_string())),
+        (
+            "dup1_1".to_string(),
+            flags::PAIRED | flags::FIRST_SEGMENT | flags::DUPLICATE,
+            Some("0".to_string()),
+        ),
+        (
+            "dup1_2".to_string(),
+            flags::PAIRED | flags::FIRST_SEGMENT | flags::DUPLICATE,
+            Some("0".to_string()),
+        ),
+        (
+            "dup1_0".to_string(),
+            flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE,
+            Some("1".to_string()),
+        ),
+        (
+            "dup1_1".to_string(),
+            flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE | flags::DUPLICATE,
+            Some("1".to_string()),
+        ),
+        (
+            "dup1_2".to_string(),
+            flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE | flags::DUPLICATE,
+            Some("1".to_string()),
+        ),
+    ];
+    assert_eq!(never, expected, "--index-threshold never changed the grouping");
+
+    // One template is the primary; the other two pairs are marked duplicates.
+    let duplicates = never.iter().filter(|(_, flags, _)| flags & flags::DUPLICATE != 0).count();
+    assert_eq!(duplicates, 4, "two of the three pairs must be marked duplicate: {never:?}");
 }


### PR DESCRIPTION
## What this does

`--index-threshold` was a bare `usize` meaning "index once a position group holds at least this many distinct UMIs". That left no way to turn the index off: suppressing it needed a value larger than any group, i.e. literally `--index-threshold 18446744073709551615`.

This makes the option a keyword-or-number, matching `--parallel-group-min-templates` one screen away in the same file:

```
--index-threshold always     index every position group
--index-threshold never      always scan all UMI pairs
--index-threshold <N>        index groups of N or more (default 100)
```

`never` is the new capability. `always` is sugar for `0`, which already meant this but read as its opposite — the trap that produced the wrong help text in the first place. Every existing integer invocation keeps working unchanged, `0` included, so no command line silently changes meaning.

Keeping this in one option rather than adding a `--no-index` flag makes the contradictory state unrepresentable: two knobs controlling one behaviour would need a precedence rule for `--no-index --index-threshold 50`.

## `always` is an assertion, so it can fail

A configuration that can never index is now a command-line error rather than a flag that is quietly ignored:

```
$ fgumi group --strategy identity --index-threshold always
Error: --index-threshold always cannot be honoured with --strategy identity:
the identity strategy never uses the UMI index. Drop --index-threshold to leave
indexing to the default threshold, or pass --index-threshold never to state that
a linear scan is intended.

$ fgumi group --strategy adjacency --edits 2 --index-threshold always
Error: --index-threshold always cannot be honoured with --strategy adjacency
--edits 2: the adjacency strategy only indexes at --edits 1. ...
```

That second case surfaces an asymmetry the help had left implicit: `build_adjacency_graph_bitenc` gates on `max_mismatches == 1` and `SimpleErrorUmiAssigner::assign` gates its defer/index branch the same way, so the adjacency and edit strategies both silently ignore the index at any other `--edits`, while paired indexes at all of them. `Strategy::can_use_index` now states it, and the check runs against the **effective** strategy and edits so `--no-umi` (which forces identity) is caught too.

A bare integer is deliberately not checked. It is a tuning knob allowed to end up inert — otherwise the default `100` could not coexist with `--strategy identity` — and that includes `0`, even though `0` admits every group exactly as `always` does.

`dedup` carries its own copy of the option, so the validation lives in `commands::common` and both call it. Assigner constructors take `T: Into<IndexThreshold>`, leaving every existing integer call site untouched.

## Integrating with edit's own index (#645)

`Edit` grew an index of its own in #645, gated on its own measured crossover (`EDIT_INDEX_THRESHOLD`, 200) rather than the shared default. `IndexThreshold::floored_at` expresses that floor: a numeric threshold is raised to the crossover, while the keywords pass through untouched, so `always` still means every group — the escape hatch that isolates the index in a profile — and `never` still means none. Every existing numeric invocation keeps the `max(flag, 200)` behaviour it had.

What `Strategy::can_use_index` reports for `Edit` is `edits == 1`, the same as adjacency. It is tempting to say otherwise: `components_via_index` hands `max_mismatches` straight to `NgramIndex::new`, which partitions each UMI into `max_mismatches + 1` pieces and pigeonholes over them, so the index is *capable* at any distance — a new brute-force test pins that across five UMI lengths and four distances, including the lengths `max_mismatches + 1` does not divide.

But `assign` never *reaches* it elsewhere. #645 gated the defer/index branch on one mismatch deliberately, because `EDIT_INDEX_THRESHOLD`'s crossover was measured there and nowhere else, and past it the index loses: the partitions get too short to be selective (4 bases at k=1, 2 at k=2 for an 8-base UMI) while single linkage collapses the group into one component, which makes the set-merge's early-exiting scan *cheaper* rather than dearer. Widening the gate is a benchmarking question — `benches/umi_assigner_threshold.rs` sweeps one mismatch only.

So both `edits == 1` gates now read from the assigner that enforces them, `SimpleErrorUmiAssigner::indexes_at_edit_distance` and its adjacency twin, rather than being restated in `can_use_index`, in the `Index threshold:` startup line, and in the parity test's rationale. Restating them is how they came to disagree in the first place: the index's capability at k>1 was read as evidence that `assign` used it there. The parity test stays at one mismatch — at any other distance both sides run the identical set-merge, so sweeping wider would compare the scan against itself.

## The gate has a name now

Rather than only rewording the help, the first commit extracts the condition so it can be tested rather than restated:

- `AdjacencyUmiAssigner::uses_index(num_umis)` — the threshold **and** the `max_mismatches == 1` restriction; `build_adjacency_graph_bitenc` calls it.
- `PairedUmiAssigner::uses_index(num_umis)` — the threshold only, reading the same `index_admits` gate `build_adjacency_graph` runs rather than a parallel copy of it.
- `SimpleErrorUmiAssigner::uses_index(num_umis)` — the threshold only, added here alongside edit's integration.

## Tests

- `index_threshold.rs` — parsing (both keywords, mixed case, integers, rejected input naming the accepted forms), `admits`, `demands_indexing`, `floored_at`, and `Display` round-trips.
- `test_strategy_can_use_index` — the strategy/edits matrix that decides whether `always` is honourable.
- `test_edit_index_is_built_at_every_edit_distance` — pinned against a real `NgramIndex` build at 0–3 mismatches, not against the flag.
- `test_edit_index_matches_scan` — `always` vs `never` produce identical molecule ids, swept across 1–3 mismatches. Naming the two sides as keywords also removes the old failure mode where a pair of numbers could silently compare the scan against itself.
- `test_index_threshold_always_rejected_when_index_unreachable` / `..._accepted_when_satisfiable` on `group`, and the equivalent end-to-end pair on `dedup`.

Full suite green: 6709 passed, plus `ci-fmt`, `ci-lint`, and docs with `RUSTDOCFLAGS=-D warnings`.

## Not addressed here

**`--edits > 1` has no index on the adjacency path.** The BK-tree branch that would serve k>1 exists but is only reachable from the paired strategy's generic builder, so `--edits 2` inherits the O(u²) behaviour on large position groups. `--index-threshold always` now reports this as an error rather than ignoring it, which is the point — but wiring the BK-tree into the BitEnc path is a separate change and wants a benchmark first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an `IndexThreshold` configuration for `--index-threshold` (`always`, `never`, or minimum UMI-group size) with consistent indexing eligibility across strategies and edit distances.
* **Bug Fixes**
  * Invalid `--index-threshold always` combinations are now rejected with clear, strategy-specific error messages instead of being ignored.
  * Startup messaging now accurately reflects when indexing can be used (e.g., edit-indexing only at `--edits 1` where applicable).
* **Tests**
  * Expanded parsing, strategy eligibility, and command-level validation for `--index-threshold` semantics, including adjacency constraints and `Never` handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

