### PR TITLE
fix(sort): honour --compression-level when the sort fits in memory

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1773,6 +1773,23 @@ impl RawExternalSorter {
         self.merge_threads.unwrap_or(self.threads).max(1)
     }
 
+    /// Transition the worker pool from ingest (Phase 1) to output (Phase 2).
+    ///
+    /// Every sort path calls this exactly once, immediately after ingest
+    /// completes, to hand the pool over to Phase 2 and lift the active-worker cap
+    /// to `merge_threads`. Centralized here so the invariant cannot drift between
+    /// sort orders: it is precisely the transition whose omission left the
+    /// in-memory output writing at the wrong compression level.
+    ///
+    /// Workers idled by the Phase-1 cap re-check within `MAX_BACKOFF_US`, so no
+    /// explicit wake is needed; capped workers always drained their held items, so
+    /// raising the cap can never be required for correctness, only for width. The
+    /// phase half is what routes output blocks to `output_compressor` — see
+    /// [`SortWorkerPool::begin_phase2`].
+    fn enter_output_phase(&self, pool: &SortWorkerPool) {
+        pool.begin_phase2(self.phase2_threads());
+    }
+
     /// Configured maximum number of temporary spill files kept before the
     /// oldest runs are consolidated into one (`0` means unlimited). Exposed so
     /// callers can assert how their `max_temp_files` setting resolved.
@@ -2520,12 +2537,8 @@ impl RawExternalSorter {
         )?;
         probe.phase1_end(buffer.memory_usage() as u64);
 
-        // Ingest is done: everything from here is Phase 2 (merge/write), so
-        // lift the active-worker cap to `merge_threads`. Workers idled by the
-        // Phase-1 cap re-check within MAX_BACKOFF_US, so no explicit wake is
-        // needed; capped workers always drained their held items, so raising
-        // the cap can never be required for correctness, only for width.
-        pool.set_active_workers(self.phase2_threads());
+        // Ingest is done: everything from here is Phase 2 (merge/write).
+        self.enter_output_phase(&pool);
 
         if chunk_files.is_empty() {
             // All records fit in memory - no merge needed
@@ -2705,12 +2718,8 @@ impl RawExternalSorter {
 
         let output_header = self.create_output_header(header);
 
-        // Ingest is done: everything from here is Phase 2 (merge/write), so
-        // lift the active-worker cap to `merge_threads`. Workers idled by the
-        // Phase-1 cap re-check within MAX_BACKOFF_US, so no explicit wake is
-        // needed; capped workers always drained their held items, so raising
-        // the cap can never be required for correctness, only for width.
-        pool.set_active_workers(self.phase2_threads());
+        // Ingest is done: everything from here is Phase 2 (merge/write).
+        self.enter_output_phase(&pool);
 
         if chunk_files.is_empty() {
             // All records fit in memory - no merge needed
@@ -2949,12 +2958,8 @@ impl RawExternalSorter {
         )?;
         probe.phase1_end(memory_used as u64);
 
-        // Ingest is done: everything from here is Phase 2 (merge/write), so
-        // lift the active-worker cap to `merge_threads`. Workers idled by the
-        // Phase-1 cap re-check within MAX_BACKOFF_US, so no explicit wake is
-        // needed; capped workers always drained their held items, so raising
-        // the cap can never be required for correctness, only for width.
-        pool.set_active_workers(self.phase2_threads());
+        // Ingest is done: everything from here is Phase 2 (merge/write).
+        self.enter_output_phase(&pool);
 
         if chunk_files.is_empty() {
             // All records fit in memory
@@ -3322,12 +3327,8 @@ impl RawExternalSorter {
         )?;
         probe.phase1_end(buffer.memory_usage() as u64);
 
-        // Ingest is done: everything from here is Phase 2 (merge/write), so
-        // lift the active-worker cap to `merge_threads`. Workers idled by the
-        // Phase-1 cap re-check within MAX_BACKOFF_US, so no explicit wake is
-        // needed; capped workers always drained their held items, so raising
-        // the cap can never be required for correctness, only for width.
-        pool.set_active_workers(self.phase2_threads());
+        // Ingest is done: everything from here is Phase 2 (merge/write).
+        self.enter_output_phase(&pool);
 
         if chunk_files.is_empty() {
             // All records fit in memory
@@ -3429,8 +3430,16 @@ impl RawExternalSorter {
     /// ([`merge_chunks_with_index`]) merges so the Phase-2 lifecycle is
     /// single-sourced and the two paths cannot drift. Returns the sources plus
     /// an RAII [`Phase2Guard`] (borrowing `pool`) that resets Phase 2 on drop or
-    /// explicit `deactivate()`. When there are no disk chunks the guard is
-    /// inactive and carries no consumer.
+    /// explicit `deactivate()`. Phase 2 is armed whether or not there are disk
+    /// chunks: it is what makes workers reach for `output_compressor`
+    /// (`SortStep::CompressOutput`) rather than the Phase 1 spill compressor, so
+    /// leaving an all-in-memory merge in Phase 1 would silently write the output
+    /// BAM at `temp_compression` and discard the caller's `output_compression`.
+    /// With no spill files `try_phase2_file_work` sees an empty file vector and
+    /// returns immediately, so the only Phase 2 work available is output
+    /// compression. The consumer is created only for disk sources — it drains the
+    /// pool's per-file reorder buffers, and there is nothing to drain when
+    /// everything is already in memory.
     fn setup_phase2_merge<'a, K: RawSortKey + Default + 'static>(
         chunk_files: &[PathBuf],
         memory_chunks: MemorySources<K>,
@@ -3448,23 +3457,22 @@ impl RawExternalSorter {
         let sources = Self::build_chunk_sources::<K>(chunk_files, memory_chunks, pool)?;
         debug!("Merging from {} sources...", sources.len());
 
-        // Create the pool consumer for PoolDisk sources and activate Phase 2.
-        // The consumer holds an Arc snapshot of the pool's per-file Phase 2
-        // state — workers populate per-file reorder buffers, the consumer pops
-        // from them.
-        let guard = if num_disk > 0 {
-            let files = pool.phase2_files();
-            let consumer = MainThreadChunkConsumer::new(
-                files,
+        // Activate Phase 2 for the whole merge, spill files or not, so the output
+        // BAM is compressed at `output_compression` rather than `temp_compression`.
+        // The consumer is created only for disk sources: it holds an Arc snapshot of
+        // the pool's per-file Phase 2 state — workers populate per-file reorder
+        // buffers, the consumer pops from them. There is nothing to consume when
+        // everything is already in memory.
+        let consumer = (num_disk > 0).then(|| {
+            MainThreadChunkConsumer::new(
+                pool.phase2_files(),
                 pool.decompress_error_flag(),
                 pool.chunk_read_error_flag(),
                 pool.worker_panicked_flag(),
-            );
-            pool.set_phase(crate::worker_pool::phase::PHASE2);
-            Phase2Guard { pool, consumer: Some(consumer), active: true }
-        } else {
-            Phase2Guard { pool, consumer: None, active: false }
-        };
+            )
+        });
+        pool.set_phase(crate::worker_pool::phase::PHASE2);
+        let guard = Phase2Guard { pool, consumer, active: true };
 
         Ok((sources, guard))
     }

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -1960,6 +1960,25 @@ impl SortWorkerPool {
         self.shared.active_worker_limit.store(n, Ordering::Release);
     }
 
+    /// Hand the pool over to Phase 2 once ingest is done, widening it to
+    /// `active_workers`.
+    ///
+    /// Both halves belong to the same transition and must happen together.
+    /// Widening alone was not enough: the phase is what makes workers schedule
+    /// [`SortStep::CompressOutput`], and that step is what selects
+    /// `output_compressor` over the Phase 1 spill compressor. A sort that stayed in
+    /// Phase 1 through its output write therefore compressed the output BAM at
+    /// `temp_compression`, silently discarding the caller's `output_compression`.
+    ///
+    /// Call this once ingest has finished — after that point every remaining byte
+    /// the pool touches is merge input or output. Callers must not leave spill
+    /// compression outstanding: Phase 1 spill jobs still queued when the phase flips
+    /// would be picked up by `CompressOutput` and written at the output level.
+    pub fn begin_phase2(&self, active_workers: usize) {
+        self.set_active_workers(active_workers);
+        self.set_phase(phase::PHASE2);
+    }
+
     /// Set the input file for Phase 1 reading.
     ///
     /// Must be called before `set_phase(PHASE1)`.

--- a/crates/fgumi-sort/tests/integration/main.rs
+++ b/crates/fgumi-sort/tests/integration/main.rs
@@ -5,5 +5,6 @@
 //! fixtures, so they live under `tests/integration/` per the project
 //! convention.
 
+mod test_output_compression;
 mod test_read_ahead;
 mod test_verify;

--- a/crates/fgumi-sort/tests/integration/test_output_compression.rs
+++ b/crates/fgumi-sort/tests/integration/test_output_compression.rs
@@ -1,0 +1,260 @@
+//! Integration test: `output_compression` must reach the BAM the sorter writes,
+//! on both the spilling and the fully-in-memory merge paths.
+//!
+//! Output BGZF blocks are compressed by the worker pool, and which compressor a
+//! worker reaches for is chosen by the pool's phase. Phase 2 used to be entered
+//! only when there were spill files to merge, so an in-memory sort left the pool
+//! in Phase 1 — where the only compress step is the *spill* one, using
+//! `temp_compression`. The user's `--compression-level` was silently replaced by
+//! the temp level.
+
+use fgumi_raw_bam::RawRecord;
+use fgumi_sam::SamBuilder;
+use fgumi_sort::{
+    LibraryLookup, QuerynameComparator, RawBamRecordReader, RawExternalSorter, RawQuerynameKey,
+    RawQuerynameLexKey, RawSortKey, SortContext, SortOrder, SpillCodec, cb_hasher,
+    extract_coordinate_key_inline, extract_template_key_inline, verify_sort_order,
+};
+use rstest::rstest;
+
+/// Number of pairs to sort. Large enough that the output spans many BGZF blocks,
+/// so the compression level has a clearly measurable effect on file size.
+const N_PAIRS: usize = 5_000;
+
+/// Stride used to emit the pairs in a scrambled but deterministic order. Coprime
+/// with [`N_PAIRS`] (5000 = 2^3·5^4, 2001 = 3·23·29), so `i * STRIDE % N_PAIRS`
+/// walks every index exactly once.
+const EMIT_STRIDE: usize = 2001;
+
+/// Builds a BAM whose records compress well, so level 0 and level 9 differ a lot.
+///
+/// Pairs are emitted in scrambled index order so the input is *not* already in
+/// any of the sort orders under test. The sorter therefore has to do real work,
+/// and the order check in [`sort_at_level`] cannot pass just by echoing the
+/// input.
+fn build_input(path: &std::path::Path) {
+    let mut builder = SamBuilder::new();
+    for i in 0..N_PAIRS {
+        let pair = i * EMIT_STRIDE % N_PAIRS;
+        let _ = builder
+            .add_pair()
+            .name(&format!("read{pair:06}"))
+            .start1(pair * 20 + 1)
+            .start2(pair * 20 + 101)
+            .build();
+    }
+    builder.write_bam(path).expect("write_bam");
+}
+
+/// Decodes every record from a BAM into an owned, in-order `Vec<RawRecord>`,
+/// re-reading through `RawBamRecordReader` rather than the writer that produced
+/// the file.
+fn decode_records(path: &std::path::Path) -> Vec<RawRecord> {
+    let file = std::fs::File::open(path).expect("open bam");
+    let mut reader = RawBamRecordReader::new(file).expect("bam reader");
+    reader.skip_header().expect("skip header");
+    let mut records = Vec::new();
+    while let Some(record) = reader.next_record().expect("read record") {
+        records.push(record);
+    }
+    records
+}
+
+/// Canonicalises a decoded record stream into a comparable multiset: the record
+/// payloads, ordered by their bytes so file order does not matter.
+fn record_multiset(records: &[RawRecord]) -> Vec<Vec<u8>> {
+    let mut payloads: Vec<Vec<u8>> = records.iter().map(|record| record.to_vec()).collect();
+    payloads.sort_unstable();
+    payloads
+}
+
+/// Counts sort-order violations in `path` under `sort_order`.
+///
+/// This runs the exported verifier (`verify_sort_order` plus the public key
+/// extractors) over the finished file — the same check `fgumi sort --verify`
+/// performs, and a different code path from the sort engine that produced it.
+fn count_sort_violations(sort_order: SortOrder, path: &std::path::Path) -> u64 {
+    let (_, header) = fgumi_bam_io::create_bam_reader(path, 1).expect("open bam for header");
+    let new_reader = || {
+        let file = std::fs::File::open(path).expect("open bam");
+        let mut reader = RawBamRecordReader::new(file).expect("bam reader");
+        reader.skip_header().expect("skip header");
+        reader
+    };
+
+    let (_, violations, _) = match sort_order {
+        SortOrder::Coordinate => {
+            let n_ref = u32::try_from(header.reference_sequences().len())
+                .expect("reference sequence count fits in u32");
+            verify_sort_order(
+                new_reader(),
+                |bam| extract_coordinate_key_inline(bam, n_ref),
+                |key, prev| key < prev,
+            )
+        }
+        SortOrder::Queryname(QuerynameComparator::Natural) => {
+            let ctx = SortContext::from_header(&header);
+            verify_sort_order(
+                new_reader(),
+                |bam| RawQuerynameKey::extract(bam, &ctx),
+                |key, prev| key < prev,
+            )
+        }
+        SortOrder::Queryname(QuerynameComparator::Lexicographic) => {
+            let ctx = SortContext::from_header(&header);
+            verify_sort_order(
+                new_reader(),
+                |bam| RawQuerynameLexKey::extract(bam, &ctx),
+                |key, prev| key < prev,
+            )
+        }
+        SortOrder::TemplateCoordinate => {
+            let lib_lookup = LibraryLookup::from_header(&header);
+            let hasher = cb_hasher();
+            verify_sort_order(
+                new_reader(),
+                |bam| extract_template_key_inline(bam, &lib_lookup, None, &hasher),
+                |key, prev| key < prev,
+            )
+        }
+    }
+    .expect("verify sort order");
+    violations
+}
+
+/// Sorts `input` in `sort_order` at the given output compression level and
+/// returns `(output_size_bytes, chunks_written, decoded_records)`.
+///
+/// `expected` is the independent baseline the output is checked against — the
+/// multiset of the *input* records, decoded straight from the input BAM without
+/// going through the sorter. Combined with the sort-order verification below,
+/// it pins the output exactly: a correct sort emits every input record, no
+/// others, in non-decreasing key order. Neither check involves the other
+/// compression run, so they cannot both drift the same way.
+fn sort_at_level(
+    sort_order: SortOrder,
+    input: &std::path::Path,
+    output: &std::path::Path,
+    memory_limit: usize,
+    output_compression: u32,
+    expected: &[Vec<u8>],
+) -> (u64, usize, Vec<RawRecord>) {
+    let stats = RawExternalSorter::new(sort_order)
+        .threads(2)
+        .memory_limit(memory_limit)
+        .spill_codec(SpillCodec::Bgzf)
+        // Held constant across levels, and deliberately different from both
+        // output levels under test: if the output is compressed at the temp
+        // level, both runs produce the same size.
+        .temp_compression(1)
+        .output_compression(output_compression)
+        .sort(input, output)
+        .expect("sort should succeed");
+
+    assert_eq!(
+        stats.output_records,
+        (N_PAIRS * 2) as u64,
+        "all records must survive the sort at level {output_compression}"
+    );
+    let records = decode_records(output);
+    // Independent of the sorter's own `output_records` bookkeeping: count the
+    // records that actually decode out of the written BAM.
+    assert_eq!(
+        records.len(),
+        N_PAIRS * 2,
+        "decoded record count must match the input at level {output_compression}"
+    );
+    // Content: exactly the input records, byte for byte, with nothing dropped,
+    // duplicated or corrupted by the output compressor.
+    assert!(
+        record_multiset(&records) == expected,
+        "level {output_compression} output is not the input record set ({sort_order:?})"
+    );
+    // Order: the output really is sorted, so the content check above cannot be
+    // satisfied by an arbitrary permutation.
+    assert_eq!(
+        count_sort_violations(sort_order, output),
+        0,
+        "level {output_compression} output is not in {sort_order:?} order"
+    );
+    let size = std::fs::metadata(output).expect("output metadata").len();
+    (size, stats.chunks_written, records)
+}
+
+/// `output_compression` must change the size of the written BAM.
+///
+/// Both merge paths are covered: a memory limit large enough to hold everything
+/// (no spill, `chunks_written == 0`) and one small enough to force spill files.
+/// Only the in-memory case was broken — it never entered Phase 2, so the pool
+/// compressed output blocks with the Phase 1 spill compressor.
+///
+/// Every sort order that routes its in-memory output through `PooledBamWriter`
+/// is exercised, because the `begin_phase2` transition is duplicated per order
+/// and a regression could reintroduce the bug in just one of them. That is:
+/// `Coordinate` (`sort_coordinate_optimized`), `Queryname`
+/// (`sort_queryname_keyed`), and `TemplateCoordinate`
+/// (`sort_template_coordinate_impl`). The `--write-index` coordinate path
+/// (`sort_coordinate_with_index`) is deliberately excluded: its in-memory
+/// branch bypasses the pool and writes at `output_compression` directly, so it
+/// is not at risk here.
+///
+/// The payload is checked against an oracle built independently of both
+/// compression runs — the input record multiset, plus `verify_sort_order` over
+/// the finished file — so a routing change that silently mangled records could
+/// not pass by mangling them the same way at both levels. See
+/// [`sort_at_level`].
+#[rstest]
+fn test_output_compression_level_reaches_the_output_bam(
+    #[values(
+        SortOrder::Coordinate,
+        SortOrder::Queryname(QuerynameComparator::Natural),
+        SortOrder::TemplateCoordinate
+    )]
+    sort_order: SortOrder,
+    #[values((256 * 1024 * 1024, false), (1024 * 1024, true))] memory: (usize, bool),
+) {
+    let (memory_limit, expect_spill) = memory;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let input = dir.path().join("input.bam");
+    build_input(&input);
+
+    // The baseline both outputs are checked against: the input records, decoded
+    // from the input BAM before any sort runs.
+    let expected = record_multiset(&decode_records(&input));
+
+    let uncompressed = dir.path().join("level0.bam");
+    let (size_level_0, chunks_0, records_level_0) =
+        sort_at_level(sort_order, &input, &uncompressed, memory_limit, 0, &expected);
+
+    let compressed = dir.path().join("level9.bam");
+    let (size_level_9, chunks_9, records_level_9) =
+        sort_at_level(sort_order, &input, &compressed, memory_limit, 9, &expected);
+
+    assert_eq!(
+        chunks_0 > 0,
+        expect_spill,
+        "expected spill={expect_spill}, got chunks_written={chunks_0} at level 0 ({sort_order:?})"
+    );
+    assert_eq!(
+        chunks_9 > 0,
+        expect_spill,
+        "expected spill={expect_spill}, got chunks_written={chunks_9} at level 9 ({sort_order:?})"
+    );
+
+    // Both runs were already checked against the independent baseline above;
+    // this additionally pins tie ordering, which "same records, sorted" leaves
+    // free: the two runs differ only in the output compressor, so the compressor
+    // must not perturb the emitted sequence at all.
+    assert_eq!(
+        records_level_0, records_level_9,
+        "level 0 and level 9 output must decode to identical records in order ({sort_order:?}, \
+         spill={expect_spill})"
+    );
+
+    assert!(
+        size_level_9 < size_level_0,
+        "output_compression was ignored for {sort_order:?}: level 9 wrote {size_level_9} bytes and \
+         level 0 wrote {size_level_0} bytes (spill={expect_spill}). Equal sizes mean the output was \
+         compressed at temp_compression instead."
+    );
+}


### PR DESCRIPTION
## The bug

Output BGZF blocks are compressed by the worker pool, and which of a worker's two compressors gets used is decided by the pool's phase — `SortStep::CompressOutput` (Phase 2) selects `output_compressor`, `SortStep::CompressSpill` (Phase 1) selects the `temp_compression` one:

```rust
phase::PHASE1 => &[SortStep::DecompressInput, SortStep::ReadInputBlocks, SortStep::CompressSpill],
phase::PHASE2 => &[SortStep::CompressOutput, SortStep::Phase2FileWork],
```

Nothing moved the pool into Phase 2 when there was nothing to merge. The `chunk_files.is_empty()` fast paths in `sort_coordinate`, `sort_queryname` and `sort_template_coordinate` write straight through `PooledBamWriter` with the pool still in Phase 1, so every output block was compressed at `temp_compression` (default 1) and `--compression-level` was silently discarded.

Measured on a real 830 MB BAM, sorted entirely in memory:

```
fgumi sort -i schmitt-abl1.aligned.bam --order coordinate --max-memory 8G --threads 8
  before:  -c 1 -> 648,124,250 bytes    -c 9 -> 648,124,250 bytes     (byte-identical)
  after:   -c 1 -> 648,124,251 bytes    -c 9 -> 551,596,268 bytes     (-15%)
```

Record content is unchanged — 13,846,696 records both ways, `samtools view` output compares identical. Only the BGZF level differs.

Spilling sorts were always correct: they enter Phase 2 to read their chunks and pick up the right compressor on the way. That is why this went unnoticed — it only bites when the input fits in `--max-memory`, which for a default 768 MB/thread × 8 threads is a good fraction of routine use.

The indexing fast path (`create_indexing_bam_writer`) was never affected; it takes `self.output_compression` directly and does not go through the pool.

## The fix

All four sort functions already marked the transition:

```rust
// Ingest is done: everything from here is Phase 2 (merge/write), so
// lift the active-worker cap to `merge_threads`. ...
pool.set_active_workers(self.phase2_threads());
```

The comment was right; the code just never told the pool its phase had changed. Since widening the pool *without* the phase change is precisely the broken state, both halves are folded into `SortWorkerPool::begin_phase2(active_workers)` and called at those four sites.

`merge_chunks_generic` also stops making Phase 2 conditional on having disk chunks. The `MainThreadChunkConsumer` is still built only for `PoolDisk` sources — there is nothing to consume when everything is in memory — but the `Phase2Guard` is always armed, so teardown back to `LEGACY` is uniform across both paths instead of only running when spill files existed.

Entering Phase 2 with no spill files is cheap: `try_phase2_file_work` sees an empty file vector and returns `InputEmpty` on the first line, so output compression is the only Phase 2 work available.

## Tests

`crates/fgumi-sort/tests/integration/test_output_compression.rs` sorts the same 5,000-pair input at `output_compression` 0 and 9 with `temp_compression` pinned to 1, and asserts the level-9 output is smaller. Two `#[case]`s cover both merge paths, asserting `chunks_written` to prove which one ran.

Before the fix the in-memory case fails and the spilled case passes:

```
output_compression was ignored: level 9 wrote 94600 bytes and level 0 wrote 94600 bytes
(spill=false). Equal sizes mean the output was compressed at temp_compression instead.
```

Full suite green: 5696 passed, plus `ci-fmt` and `ci-lint`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the configured BGZF `output_compression` level is applied consistently to the final BAM, including both in-memory and spill-based merge/write paths.
  * Improved the Phase 1 → Phase 2 transition so output blocks are routed through the correct output compression flow, preventing cases where temp/spill compression could be used instead.

* **Tests**
  * Added a new integration test covering `output_compression` levels (0 vs 9), validating record preservation, sort order, spill behavior expectations, and that level 9 produces a smaller BAM.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->