### PR TITLE
perf(consensus): memoize the unanimous fast-path bound per pre-UMI rate

### DIFF
--- a/crates/fgumi-consensus/src/base_builder.rs
+++ b/crates/fgumi-consensus/src/base_builder.rs
@@ -193,6 +193,7 @@ use crate::phred::{
 };
 use approx::abs_diff_eq;
 use std::cmp::Ordering;
+use std::sync::OnceLock;
 use wide::f64x4;
 
 /// The four DNA bases in the order used throughout consensus calling
@@ -249,8 +250,9 @@ pub struct ConsensusBaseBuilder {
     /// Smallest winner-minus-loser log-likelihood gap at which the unanimous fast
     /// path is provably exact for this `ln_error_pre_umi`.
     ///
-    /// Derived once in [`Self::new`] by [`min_exact_unanimous_gap`]; see there for
-    /// why a single constant cannot serve every pre-UMI error rate.
+    /// Derived once per pre-UMI error rate by [`cached_min_exact_unanimous_gap`];
+    /// see [`min_exact_unanimous_gap`] for why a single constant cannot serve every
+    /// pre-UMI error rate.
     min_unanimous_gap: f64,
 }
 
@@ -318,6 +320,29 @@ fn min_exact_unanimous_gap(ln_error_pre_umi: LogProbability) -> f64 {
     wide_enough
 }
 
+/// Memoized [`min_exact_unanimous_gap`], one slot per possible pre-UMI Phred.
+///
+/// The bisection above costs ~200 iterations of the full quality chain — several
+/// thousand `exp`/`log1p` evaluations — which is far too expensive to repeat per
+/// builder: `consensus_umis` constructs a fresh `SimpleConsensusCaller`, and hence a
+/// fresh `ConsensusBaseBuilder`, for every UMI family. Since `PhredScore` is a `u8`,
+/// 256 slots cover the input domain exactly, so every `u8` is memoized without
+/// clamping. `--error-rate-pre-umi` accepts any `u8` (nothing validates the range),
+/// and the cache intentionally supports all 256 of them.
+static UNANIMOUS_GAP_CACHE: [OnceLock<f64>; 256] = [const { OnceLock::new() }; 256];
+
+/// Returns the memoized minimum exact unanimous gap for a pre-UMI error rate.
+///
+/// The gap is a pure function of `error_rate_pre_umi`: it depends only on
+/// `phred_to_ln_error_prob` of that one `u8`, so memoizing on the `u8` returns the
+/// bit-identical `f64` the direct computation would have produced. The rate is taken
+/// as a Phred score rather than as an already-converted `LogProbability` so that the
+/// cache key and the value's provenance cannot drift apart.
+fn cached_min_exact_unanimous_gap(error_rate_pre_umi: PhredScore) -> f64 {
+    *UNANIMOUS_GAP_CACHE[error_rate_pre_umi as usize]
+        .get_or_init(|| min_exact_unanimous_gap(phred_to_ln_error_prob(error_rate_pre_umi)))
+}
+
 impl ConsensusBaseBuilder {
     /// Creates a new consensus base builder
     ///
@@ -352,7 +377,7 @@ impl ConsensusBaseBuilder {
             adjusted_correct_table,
             adjusted_error_per_alt,
             ln_error_pre_umi,
-            min_unanimous_gap: min_exact_unanimous_gap(ln_error_pre_umi),
+            min_unanimous_gap: cached_min_exact_unanimous_gap(error_rate_pre_umi),
         }
     }
 
@@ -1054,5 +1079,48 @@ mod tests {
                 pair[1]
             );
         }
+    }
+
+    /// The memoized gap must equal the directly computed one for every representable
+    /// pre-UMI Phred, bit for bit. Sweeps the whole `u8` domain — including the
+    /// values above `MAX_PHRED`, which the CLI accepts unvalidated — because the cache
+    /// is indexed by the raw `u8` and must be exact across every index it can ever be given.
+    #[test]
+    fn test_cached_gap_matches_uncached_across_the_whole_u8_domain() {
+        for q in 0..=u8::MAX {
+            let cached = cached_min_exact_unanimous_gap(q);
+            let direct = min_exact_unanimous_gap(phred_to_ln_error_prob(q));
+            assert_eq!(
+                cached.to_bits(),
+                direct.to_bits(),
+                "memoized gap for Q{q} ({cached}) differs from the direct computation ({direct})"
+            );
+        }
+    }
+
+    /// The gap a builder stores must be derived from the **pre**-UMI rate, not the
+    /// post-UMI one. The asymmetric cases are what discriminate a transposed
+    /// argument; `umi_consensus_defaults` is symmetric and cannot, but is kept
+    /// because Q90/Q90 is the pair `SimpleConsensusCaller` actually uses.
+    #[rstest]
+    #[case::default_cli_rates(45, 40)]
+    #[case::pre_below_post(40, 45)]
+    #[case::umi_consensus_defaults(90, 90)]
+    #[case::max_pre_low_post(93, 2)]
+    #[case::low_pre_max_post(2, 93)]
+    fn test_builder_gap_is_keyed_on_the_pre_umi_rate(
+        #[case] error_rate_pre_umi: PhredScore,
+        #[case] error_rate_post_umi: PhredScore,
+    ) {
+        let builder = ConsensusBaseBuilder::new(error_rate_pre_umi, error_rate_post_umi);
+        let expected = min_exact_unanimous_gap(phred_to_ln_error_prob(error_rate_pre_umi));
+
+        assert_eq!(
+            builder.min_unanimous_gap.to_bits(),
+            expected.to_bits(),
+            "builder built with pre={error_rate_pre_umi}, post={error_rate_post_umi} stored gap \
+             {} but the pre-UMI rate requires {expected}",
+            builder.min_unanimous_gap
+        );
     }
 }


### PR DESCRIPTION
Stacked on #634 — please read the two together, and **land them together**. #634 alone is a large regression on every `simplex`/`duplex`/`codec` run.

## What #634 introduces

#634 correctly replaces the hardcoded `FAST_PATH_THRESHOLD = 23.0` with a bound derived from the pre-UMI error rate. That derivation bisects the full quality chain: ~200 iterations, each evaluating `ln_sum_exp_array` + `ln_normalize` + `ln_not` + `ln_error_prob_two_trials` + `ln_prob_to_phred` — on the order of a couple of thousand transcendental evaluations.

It runs in `ConsensusBaseBuilder::new`, and `consensus_umis` constructs a fresh `SimpleConsensusCaller`, and hence a fresh builder, for **every UMI family** (`simple_umi.rs:236-244` → `:46`; called from `vanilla_caller.rs:1517`, `duplex_caller.rs:1241`, `duplex_caller.rs:1732`, `codec_caller.rs:1511`). So the bisection was being paid per family.

## The change

The bound is a pure function of the pre-UMI error rate, and `PhredScore` is a `u8`, so 256 `OnceLock` slots cover the input domain exactly — no clamping, and no behaviour change for the out-of-range values the CLI already rejects. This is the same shape as the post-UMI table memoization in #626.

The cache is keyed on the Phred score rather than on an already-converted `LogProbability` so the cache key and the value provenance cannot drift apart.

## Output is unchanged

The memoized value is the same `f64` the direct computation produces. Verified two ways:

- bitwise agreement across the **whole `u8` domain** (`test_cached_gap_matches_uncached_across_the_whole_u8_domain`), and
- a `-1`/`-2` parameter sweep on real data — 15 combinations of pre ∈ {40, 50, 70, 90, 93} × post ∈ {30, 40, 90} on a grouped idt-cfdna BAM, **record bodies byte-identical** in every one. That sweep is the direct test of the cache key, since the key is exactly `-1`.

## Measured

`fgumi simplex --min-reads 1 --threads 1` over `idt-cfdna.group.adjacency.fgbio.bam`, three repetitions:

| | user CPU |
|---|---|
| #634 | 3.23 s, 3.23 s, 3.36 s |
| #634 + this | 2.10 s, 2.13 s, 2.11 s |

~35% less user CPU, with `samtools view | md5` identical on both sides.

## Note on scope

The constructor still builds `adjusted_correct_table`/`adjusted_error_per_alt` with 94 `ln_error_prob_two_trials` calls per builder — the identical "expensive pure setup keyed on a `u8`" shape. That is #626's scope, not this PR's; the two are complementary and should be read together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved consensus-building efficiency by caching the computed unanimous-gap threshold per pre-UMI Phred/error-rate input.
* **Reliability**
  * Ensured the stored unanimous-gap threshold is derived solely from the configured pre-UMI error rate.
* **Tests**
  * Added validation that cached results match direct calculations across the full Phred `u8` range and that threshold values remain correct across different pre/post combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->