### PR TITLE
feat(group): accept --index-threshold always|never, reject unsatisfiable requests

### DIFF
--- a/crates/fgumi-umi/src/assigner.rs
+++ b/crates/fgumi-umi/src/assigner.rs
@@ -224,10 +224,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use crate::MoleculeId;
 use fgumi_dna::BitEnc;
 
-/// Default minimum number of unique UMIs to use N-gram/BK-tree index for candidate search.
-/// Below this threshold, linear scan is used. Based on benchmarks: index provides ~10%
-/// speedup even at 100 UMIs/position with negligible construction overhead.
-pub const DEFAULT_INDEX_THRESHOLD: usize = 100;
+use crate::index_threshold::{DEFAULT_INDEX_THRESHOLD, IndexThreshold};
 
 /// A node in the BK-tree.
 ///
@@ -545,6 +542,26 @@ pub enum Strategy {
 }
 
 impl Strategy {
+    /// Whether this strategy consults the UMI index at all, at `edits`.
+    ///
+    /// `Identity` and `Edit` have no index code path. `Adjacency` indexes only at
+    /// `edits == 1` — `build_adjacency_graph_bitenc` gates on it, and the BK-tree branch
+    /// that would serve larger distances is reachable only from the generic
+    /// `build_adjacency_graph` the paired strategy uses. `Paired` therefore indexes at
+    /// every edit distance.
+    ///
+    /// Callers use this to reject an [`IndexThreshold`] that
+    /// [demands indexing](IndexThreshold::demands_indexing) under a configuration that
+    /// cannot deliver it.
+    #[must_use]
+    pub fn can_use_index(&self, edits: u32) -> bool {
+        match self {
+            Strategy::Identity | Strategy::Edit => false,
+            Strategy::Adjacency => edits == 1,
+            Strategy::Paired => true,
+        }
+    }
+
     /// Create a new UMI assigner for this strategy
     ///
     /// # Arguments
@@ -560,7 +577,7 @@ impl Strategy {
     /// Panics if `edits` is non-zero when using the Identity strategy.
     #[must_use]
     pub fn new_assigner(&self, edits: u32) -> Box<dyn UmiAssigner> {
-        self.new_assigner_full(edits, 1, DEFAULT_INDEX_THRESHOLD)
+        self.new_assigner_full(edits, 1, IndexThreshold::default())
     }
 
     /// Create a new UMI assigner with thread count specified
@@ -575,7 +592,7 @@ impl Strategy {
     /// A boxed trait object implementing the `UmiAssigner` trait
     #[must_use]
     pub fn new_assigner_with_threads(&self, edits: u32, threads: usize) -> Box<dyn UmiAssigner> {
-        self.new_assigner_full(edits, threads, DEFAULT_INDEX_THRESHOLD)
+        self.new_assigner_full(edits, threads, IndexThreshold::default())
     }
 
     /// Create a new UMI assigner with all parameters specified
@@ -596,12 +613,13 @@ impl Strategy {
     ///
     /// Panics if `edits` is non-zero with the `Identity` strategy.
     #[must_use]
-    pub fn new_assigner_full(
+    pub fn new_assigner_full<T: Into<IndexThreshold>>(
         &self,
         edits: u32,
         threads: usize,
-        index_threshold: usize,
+        index_threshold: T,
     ) -> Box<dyn UmiAssigner> {
+        let index_threshold = index_threshold.into();
         match self {
             Strategy::Identity => {
                 assert_eq!(edits, 0, "Edits should be zero when using the identity UMI assigner");
@@ -1176,7 +1194,7 @@ struct Node {
 pub struct AdjacencyUmiAssigner {
     max_mismatches: u32,
     threads: usize,
-    index_threshold: usize,
+    index_threshold: IndexThreshold,
     counter: AtomicU64,
 }
 
@@ -1194,8 +1212,17 @@ impl AdjacencyUmiAssigner {
     ///
     /// A new `AdjacencyUmiAssigner` instance
     #[must_use]
-    pub fn new(max_mismatches: u32, threads: usize, index_threshold: usize) -> Self {
-        Self { max_mismatches, threads, index_threshold, counter: AtomicU64::new(0) }
+    pub fn new<T: Into<IndexThreshold>>(
+        max_mismatches: u32,
+        threads: usize,
+        index_threshold: T,
+    ) -> Self {
+        Self {
+            max_mismatches,
+            threads,
+            index_threshold: index_threshold.into(),
+            counter: AtomicU64::new(0),
+        }
     }
 
     /// Whether a position group of `num_umis` distinct UMIs is *eligible* to be
@@ -1216,7 +1243,7 @@ impl AdjacencyUmiAssigner {
     /// and edit-distance conditions permit indexing", not "an index was built".
     #[must_use]
     pub fn uses_index(&self, num_umis: usize) -> bool {
-        num_umis >= self.index_threshold && self.max_mismatches == 1
+        self.index_threshold.admits(num_umis) && self.max_mismatches == 1
     }
 
     /// Generate the next unique molecule ID
@@ -1461,7 +1488,7 @@ impl AdjacencyUmiAssigner {
         // Unlike `build_adjacency_graph_bitenc`, this path indexes at every edit
         // distance: N-gram for k=1 (most efficient), BK-tree for k>1. Only the
         // `index_threshold` minimum applies -- see `PairedUmiAssigner::uses_index`.
-        let (ngram_index, bktree) = if nodes.len() >= self.index_threshold {
+        let (ngram_index, bktree) = if self.index_threshold.admits(nodes.len()) {
             let umis: Vec<(usize, &str)> =
                 umi_counts.iter().enumerate().map(|(i, (umi, _, _))| (i, umi.as_str())).collect();
 
@@ -1793,7 +1820,11 @@ impl PairedUmiAssigner {
     ///
     /// A new `PairedUmiAssigner` instance
     #[must_use]
-    pub fn new_with_threads(max_mismatches: u32, threads: usize, index_threshold: usize) -> Self {
+    pub fn new_with_threads<T: Into<IndexThreshold>>(
+        max_mismatches: u32,
+        threads: usize,
+        index_threshold: T,
+    ) -> Self {
         let prefix_len = max_mismatches as usize + 1;
         Self {
             adjacency: AdjacencyUmiAssigner::new(max_mismatches, threads, index_threshold),
@@ -1816,7 +1847,7 @@ impl PairedUmiAssigner {
     /// then falls back to the linear scan.
     #[must_use]
     pub fn uses_index(&self, num_umis: usize) -> bool {
-        num_umis >= self.adjacency.index_threshold
+        self.adjacency.index_threshold.admits(num_umis)
     }
 
     /// Get the prefix for lower-ordered reads in a pair
@@ -3859,23 +3890,36 @@ mod tests {
     // ========================================================================
 
     /// Pins what `--index-threshold` actually does, so the CLI help can be checked
-    /// against it. The gate is `num_umis >= index_threshold`, so `0` means the index
-    /// is ALWAYS built -- it does not disable the index. Disabling it requires a
-    /// threshold larger than any position group, e.g. `usize::MAX`.
+    /// against it. A bare integer is a MINIMUM group size, not a switch, so `0` turns
+    /// the index fully on. `never` is the only way to turn it off.
     #[rstest]
-    #[case::zero_always_indexes(0, 1, true)]
-    #[case::zero_indexes_empty_group(0, 0, true)]
-    #[case::below_threshold_scans(100, 99, false)]
-    #[case::at_threshold_indexes(100, 100, true)]
-    #[case::above_threshold_indexes(100, 101, true)]
-    #[case::usize_max_never_indexes(usize::MAX, 1_000_000, false)]
+    #[case::zero_always_indexes(IndexThreshold::MinUmis(0), 1, true)]
+    #[case::zero_indexes_empty_group(IndexThreshold::MinUmis(0), 0, true)]
+    #[case::below_threshold_scans(IndexThreshold::MinUmis(100), 99, false)]
+    #[case::at_threshold_indexes(IndexThreshold::MinUmis(100), 100, true)]
+    #[case::above_threshold_indexes(IndexThreshold::MinUmis(100), 101, true)]
+    #[case::always_indexes_singleton(IndexThreshold::Always, 1, true)]
+    #[case::never_skips_huge_group(IndexThreshold::Never, 1_000_000, false)]
     fn test_adjacency_index_threshold_is_a_minimum_not_a_switch(
-        #[case] index_threshold: usize,
+        #[case] index_threshold: IndexThreshold,
         #[case] num_umis: usize,
         #[case] expected: bool,
     ) {
         let assigner = AdjacencyUmiAssigner::new(1, 1, index_threshold);
         assert_eq!(assigner.uses_index(num_umis), expected);
+    }
+
+    /// `never` wins over every other consideration, including an edit distance that
+    /// would otherwise index (paired) -- there is no combination that resurrects it.
+    #[rstest]
+    #[case::adjacency_edits_one(1)]
+    #[case::adjacency_edits_two(2)]
+    fn test_never_suppresses_the_index_at_every_edit_distance(#[case] max_mismatches: u32) {
+        let adjacency = AdjacencyUmiAssigner::new(max_mismatches, 1, IndexThreshold::Never);
+        assert!(!adjacency.uses_index(1_000_000));
+
+        let paired = PairedUmiAssigner::new_with_threads(max_mismatches, 1, IndexThreshold::Never);
+        assert!(!paired.uses_index(1_000_000));
     }
 
     /// The adjacency assigner only indexes at `--edits 1`; every other value falls
@@ -3908,7 +3952,8 @@ mod tests {
         #[case] num_umis: usize,
         #[case] expected: bool,
     ) {
-        let assigner = PairedUmiAssigner::new_with_threads(max_mismatches, 1, 100);
+        let assigner =
+            PairedUmiAssigner::new_with_threads(max_mismatches, 1, IndexThreshold::MinUmis(100));
         assert_eq!(assigner.uses_index(num_umis), expected);
     }
 }

--- a/crates/fgumi-umi/src/index_threshold.rs
+++ b/crates/fgumi-umi/src/index_threshold.rs
@@ -1,0 +1,178 @@
+//! When the UMI-matching index is used instead of a linear scan.
+
+use std::fmt;
+use std::str::FromStr;
+
+/// Default minimum number of unique UMIs to use N-gram/BK-tree index for candidate search.
+/// Below this threshold, linear scan is used. Based on benchmarks: index provides ~10%
+/// speedup even at 100 UMIs/position with negligible construction overhead.
+pub const DEFAULT_INDEX_THRESHOLD: usize = 100;
+
+/// Value of `--index-threshold`: when to match UMIs through the N-gram/BK-tree index
+/// rather than by comparing every pair.
+///
+/// The index is a pure optimization — it narrows the candidate set, it does not change
+/// which UMIs group together — so every variant yields the same grouping and differs only
+/// in how much work reaching it takes.
+///
+/// [`MinUmis`](Self::MinUmis) is a *minimum group size*, not a switch, and that has caught
+/// people out: `MinUmis(0)` admits every group, so a plain `0` turns the index fully **on**
+/// — the opposite of what the CLI help claimed for a long time. [`Always`](Self::Always) and
+/// [`Never`](Self::Never) let that intent be stated in a word rather than encoded in a
+/// number no one can read back. `Never` is not otherwise reachable: suppressing the index
+/// through `MinUmis` alone would take a value larger than any position group.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexThreshold {
+    /// Index every position group, whatever its size.
+    Always,
+    /// Never index; always compare all UMI pairs.
+    Never,
+    /// Index a position group once it holds at least this many distinct UMIs.
+    MinUmis(usize),
+}
+
+impl IndexThreshold {
+    /// Whether a position group of `num_umis` distinct UMIs is matched through the index.
+    #[must_use]
+    pub fn admits(self, num_umis: usize) -> bool {
+        match self {
+            Self::Always => true,
+            Self::Never => false,
+            Self::MinUmis(min) => num_umis >= min,
+        }
+    }
+
+    /// Whether this value *asserts* that indexing must happen, rather than merely tuning
+    /// when it starts.
+    ///
+    /// Only the `always` keyword asserts. A number — including `0`, which admits every
+    /// group exactly as `Always` does — is a tuning knob allowed to end up inert, which is
+    /// what lets the default `100` coexist with strategies that never index. Callers use
+    /// this to reject a request they cannot honour instead of silently ignoring it.
+    #[must_use]
+    pub fn demands_indexing(self) -> bool {
+        matches!(self, Self::Always)
+    }
+}
+
+impl Default for IndexThreshold {
+    fn default() -> Self {
+        Self::MinUmis(DEFAULT_INDEX_THRESHOLD)
+    }
+}
+
+impl From<usize> for IndexThreshold {
+    fn from(min_umis: usize) -> Self {
+        Self::MinUmis(min_umis)
+    }
+}
+
+impl FromStr for IndexThreshold {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        if s.eq_ignore_ascii_case("always") {
+            Ok(Self::Always)
+        } else if s.eq_ignore_ascii_case("never") {
+            Ok(Self::Never)
+        } else {
+            s.parse::<usize>().map(Self::MinUmis).map_err(|e| {
+                format!("expected 'always', 'never', or a non-negative integer, got '{s}': {e}")
+            })
+        }
+    }
+}
+
+impl fmt::Display for IndexThreshold {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Always => f.write_str("always"),
+            Self::Never => f.write_str("never"),
+            Self::MinUmis(min) => write!(f, "{min}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    /// `--index-threshold` accepts the two keywords and any non-negative integer.
+    #[rstest]
+    #[case::always("always", IndexThreshold::Always)]
+    #[case::always_mixed_case("Always", IndexThreshold::Always)]
+    #[case::never("never", IndexThreshold::Never)]
+    #[case::never_upper("NEVER", IndexThreshold::Never)]
+    #[case::zero("0", IndexThreshold::MinUmis(0))]
+    #[case::default_value("100", IndexThreshold::MinUmis(100))]
+    fn test_index_threshold_parses(#[case] input: &str, #[case] expected: IndexThreshold) {
+        assert_eq!(input.parse::<IndexThreshold>(), Ok(expected));
+    }
+
+    /// Rejected input names the accepted forms, so the error is actionable.
+    #[rstest]
+    #[case::negative("-1")]
+    #[case::word("off")]
+    #[case::empty("")]
+    #[case::float("1.5")]
+    fn test_index_threshold_rejects_invalid(#[case] input: &str) {
+        let err = input.parse::<IndexThreshold>().expect_err("must reject");
+        assert!(
+            err.contains("always") && err.contains("never"),
+            "error should name the accepted forms, got: {err}"
+        );
+    }
+
+    /// `admits` is the gate the assigners consult. `MinUmis` is a MINIMUM, so `0`
+    /// admits every group — the reading the CLI help had backwards for a long time.
+    #[rstest]
+    #[case::always_admits_empty(IndexThreshold::Always, 0, true)]
+    #[case::always_admits_huge(IndexThreshold::Always, 1_000_000, true)]
+    #[case::never_rejects_huge(IndexThreshold::Never, 1_000_000, false)]
+    #[case::zero_admits_singleton(IndexThreshold::MinUmis(0), 1, true)]
+    #[case::below_minimum(IndexThreshold::MinUmis(100), 99, false)]
+    #[case::at_minimum(IndexThreshold::MinUmis(100), 100, true)]
+    #[case::above_minimum(IndexThreshold::MinUmis(100), 101, true)]
+    fn test_index_threshold_admits(
+        #[case] threshold: IndexThreshold,
+        #[case] num_umis: usize,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(threshold.admits(num_umis), expected);
+    }
+
+    /// Only the `always` keyword asserts that indexing must happen. A number is a
+    /// tuning knob allowed to end up inert, which is what lets the default `100`
+    /// coexist with strategies that never index.
+    #[rstest]
+    #[case::always_demands(IndexThreshold::Always, true)]
+    #[case::never_does_not(IndexThreshold::Never, false)]
+    #[case::zero_does_not(IndexThreshold::MinUmis(0), false)]
+    #[case::default_does_not(IndexThreshold::MinUmis(100), false)]
+    fn test_only_always_demands_indexing(
+        #[case] threshold: IndexThreshold,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(threshold.demands_indexing(), expected);
+    }
+
+    /// Values round-trip through `Display`, so logs and help text stay parseable.
+    #[rstest]
+    #[case::always(IndexThreshold::Always, "always")]
+    #[case::never(IndexThreshold::Never, "never")]
+    #[case::min_umis(IndexThreshold::MinUmis(100), "100")]
+    fn test_index_threshold_displays_and_round_trips(
+        #[case] threshold: IndexThreshold,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(threshold.to_string(), expected);
+        assert_eq!(expected.parse::<IndexThreshold>(), Ok(threshold));
+    }
+
+    /// The default matches the documented `--index-threshold` default.
+    #[test]
+    fn test_default_is_the_documented_threshold() {
+        assert_eq!(IndexThreshold::default(), IndexThreshold::MinUmis(DEFAULT_INDEX_THRESHOLD));
+    }
+}

--- a/crates/fgumi-umi/src/lib.rs
+++ b/crates/fgumi-umi/src/lib.rs
@@ -8,12 +8,14 @@
 //! - UMI grouping and family analysis
 
 pub mod assigner;
+pub mod index_threshold;
 
 // Re-export commonly used items
 pub use assigner::{
     AdjacencyUmiAssigner, IdentityUmiAssigner, PairedUmiAssigner, SimpleErrorUmiAssigner, Strategy,
     Umi, UmiAssigner,
 };
+pub use index_threshold::{DEFAULT_INDEX_THRESHOLD, IndexThreshold};
 
 use std::collections::HashSet;
 

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -16,6 +16,7 @@ use clap::Args;
 use fgumi_bam_io::is_stdin_path;
 #[cfg(feature = "simplex")]
 use fgumi_consensus::methylation::RefBaseProvider;
+use fgumi_umi::{IndexThreshold, Strategy};
 #[cfg(feature = "simplex")]
 use log::{info, warn};
 use noodles::sam::Header;
@@ -1139,6 +1140,46 @@ pub fn build_pipeline_config(
     config.pipeline.queue_memory_limit = queue_memory_limit_bytes;
     queue_memory.log_memory_config(num_threads, queue_memory_limit_bytes);
     Ok(config)
+}
+
+/// Reject an `--index-threshold` that demands indexing under a configuration that can
+/// never index.
+///
+/// `always` is an assertion that the UMI index will be used, so a strategy/edits
+/// combination with no index code path has to be an error rather than a flag that is
+/// quietly ignored. Pass the EFFECTIVE strategy and edits, so `--no-umi` (which forces
+/// identity) is caught too.
+///
+/// A bare integer is deliberately not checked. It is a tuning knob allowed to end up
+/// inert — otherwise the default `100` could not coexist with `--strategy identity` —
+/// and that includes `0`, even though `0` admits every group exactly as `always` does.
+///
+/// # Errors
+///
+/// Returns an error naming the conflict and how to resolve it.
+pub fn validate_index_threshold(
+    index_threshold: IndexThreshold,
+    strategy: Strategy,
+    edits: u32,
+) -> anyhow::Result<()> {
+    if !index_threshold.demands_indexing() || strategy.can_use_index(edits) {
+        return Ok(());
+    }
+
+    let name = format!("{strategy:?}").to_lowercase();
+    let (context, reason) = match strategy {
+        Strategy::Adjacency => (
+            format!(" --edits {edits}"),
+            "the adjacency strategy only indexes at --edits 1".to_string(),
+        ),
+        _ => (String::new(), format!("the {name} strategy never uses the UMI index")),
+    };
+
+    anyhow::bail!(
+        "--index-threshold always cannot be honoured with --strategy {name}{context}: \
+         {reason}. Drop --index-threshold to leave indexing to the default threshold, \
+         or pass --index-threshold never to state that a linear scan is intended."
+    )
 }
 
 #[cfg(test)]

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -42,6 +42,7 @@ use anyhow::{Context, Result, bail};
 use clap::Parser;
 use fgoxide::io::DelimFile;
 use fgumi_bam_io::create_bam_reader_for_pipeline_with_opts;
+use fgumi_umi::IndexThreshold;
 
 use log::info;
 use noodles::sam::Header;
@@ -1119,13 +1120,13 @@ pub struct MarkDuplicates {
     #[command(flatten)]
     pub compression: CompressionOptions,
 
-    /// Minimum distinct UMIs at a position before the N-gram/BK-tree index is used
-    /// instead of a linear scan over all UMI pairs. This is a minimum, not a switch:
-    /// 0 indexes every position group, and disabling the index takes a value larger
-    /// than any group. Only affects Adjacency/Paired strategies, and Adjacency only
-    /// indexes at --edits 1.
+    /// When to match UMIs through the N-gram/BK-tree index instead of comparing every
+    /// pair. Either `always`, `never`, or a minimum number of distinct UMIs at a
+    /// position (so `0` behaves like `always`). The index is a pure optimization: it
+    /// never changes which reads group together. Only Adjacency and Paired index at
+    /// all, and Adjacency only at --edits 1.
     #[arg(long = "index-threshold", default_value = "100")]
-    pub index_threshold: usize,
+    pub index_threshold: IndexThreshold,
 
     /// Skip UMI-based grouping; group by template coordinate alone. Forces identity
     /// strategy and ignores any existing UMI tags. Templates are NOT split by strand of
@@ -1165,11 +1166,6 @@ impl Command for MarkDuplicates {
             (self.strategy, false)
         };
 
-        // Validate the input exists (stdin paths are exempt).
-        self.io.validate()?;
-
-        let min_mapq: u8 = self.min_map_q.unwrap_or(0);
-
         // Identity strategy requires edits=0, others use the configured value
         // Also force edits=0 in no-umi mode
         let effective_edits =
@@ -1178,6 +1174,19 @@ impl Command for MarkDuplicates {
             } else {
                 self.edits
             };
+
+        // `--index-threshold always` asserts that indexing will happen; reject it when
+        // the resolved strategy/edits can never index rather than ignoring the flag.
+        crate::commands::common::validate_index_threshold(
+            self.index_threshold,
+            effective_strategy,
+            effective_edits,
+        )?;
+
+        // Validate the input exists (stdin paths are exempt).
+        self.io.validate()?;
+
+        let min_mapq: u8 = self.min_map_q.unwrap_or(0);
 
         let timer = OperationTimer::new("Marking duplicates");
 

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -32,6 +32,7 @@ use clap::Parser;
 use fgoxide::io::DelimFile;
 use fgumi_bam_io::ProgressTracker;
 use fgumi_bam_io::{create_bam_reader_for_pipeline, create_bam_writer};
+use fgumi_umi::IndexThreshold;
 // MemoryEstimate is gated because it's only used in memory-debug blocks below
 use crate::sam::SamTag;
 #[cfg(feature = "memory-debug")]
@@ -481,7 +482,7 @@ fn should_use_parallel(
 fn create_umi_assigner(
     strategy: Strategy,
     effective_edits: u32,
-    index_threshold: usize,
+    index_threshold: IndexThreshold,
     num_threads: usize,
     use_parallel: bool,
 ) -> Box<dyn UmiAssigner> {
@@ -857,13 +858,13 @@ pub struct GroupReadsByUmi {
     #[command(flatten)]
     pub compression: CompressionOptions,
 
-    /// Minimum distinct UMIs at a position before the N-gram/BK-tree index is used
-    /// instead of a linear scan over all UMI pairs. This is a minimum, not a switch:
-    /// 0 indexes every position group, and disabling the index takes a value larger
-    /// than any group. Only affects Adjacency/Paired strategies, and Adjacency only
-    /// indexes at --edits 1.
+    /// When to match UMIs through the N-gram/BK-tree index instead of comparing every
+    /// pair. Either `always`, `never`, or a minimum number of distinct UMIs at a
+    /// position (so `0` behaves like `always`). The index is a pure optimization: it
+    /// never changes which reads group together. Only Adjacency and Paired index at
+    /// all, and Adjacency only at --edits 1.
     #[arg(long = "index-threshold", default_value = "100")]
-    pub index_threshold: usize,
+    pub index_threshold: IndexThreshold,
 
     /// Skip UMI-based grouping; group by template coordinate and strand of origin. Forces
     /// identity strategy and ignores any existing UMI tags. An F1R2 and an F2R1 template at
@@ -965,12 +966,6 @@ impl Command for GroupReadsByUmi {
             (self.strategy, false)
         };
 
-        // Validate the input exists (stdin paths are exempt).
-        self.io.validate()?;
-
-        // Set minimum mapping quality
-        let min_mapq: u8 = self.min_map_q.unwrap_or(1);
-
         // Identity strategy requires edits=0, others use the configured value
         // Also force edits=0 in no-umi mode
         let effective_edits =
@@ -979,6 +974,20 @@ impl Command for GroupReadsByUmi {
             } else {
                 self.edits
             };
+
+        // `--index-threshold always` asserts that indexing will happen; reject it when
+        // the resolved strategy/edits can never index rather than ignoring the flag.
+        crate::commands::common::validate_index_threshold(
+            self.index_threshold,
+            effective_strategy,
+            effective_edits,
+        )?;
+
+        // Validate the input exists (stdin paths are exempt).
+        self.io.validate()?;
+
+        // Set minimum mapping quality
+        let min_mapq: u8 = self.min_map_q.unwrap_or(1);
 
         // Initialize tracking infrastructure
         let timer = OperationTimer::new("Grouping reads by UMI");
@@ -1701,7 +1710,7 @@ impl GroupReadsByUmi {
         filter_config: &GroupFilterConfig,
         strategy: Strategy,
         effective_edits: u32,
-        index_threshold: usize,
+        index_threshold: IndexThreshold,
         threads: usize,
         parallel_group_min_templates: Option<&ParallelMinTemplates>,
         raw_tag: [u8; 2],
@@ -2010,7 +2019,7 @@ mod tests {
     #[case(Strategy::Adjacency)]
     #[case(Strategy::Paired)]
     fn create_umi_assigner_parallel_builds_parallel_variant(#[case] strategy: Strategy) {
-        let assigner = create_umi_assigner(strategy, 1, 0, 2, true);
+        let assigner = create_umi_assigner(strategy, 1, IndexThreshold::MinUmis(0), 2, true);
         let any = assigner.as_any();
         let is_parallel = match strategy {
             Strategy::Identity => any.is::<ParallelIdentityAssigner>(),
@@ -2033,7 +2042,7 @@ mod tests {
     #[case(Strategy::Paired)]
     fn create_umi_assigner_single_thread_builds_non_parallel_variant(#[case] strategy: Strategy) {
         // num_threads = 1 with use_parallel = true must still fall back to sequential.
-        let assigner = create_umi_assigner(strategy, 0, 0, 1, true);
+        let assigner = create_umi_assigner(strategy, 0, IndexThreshold::MinUmis(0), 1, true);
         let any = assigner.as_any();
         assert!(
             !any.is::<ParallelIdentityAssigner>()
@@ -2053,7 +2062,7 @@ mod tests {
     #[case(Strategy::Paired)]
     fn create_umi_assigner_sequential_builds_non_parallel_variant(#[case] strategy: Strategy) {
         // Identity requires zero edits; the other strategies accept zero too.
-        let assigner = create_umi_assigner(strategy, 0, 0, 2, false);
+        let assigner = create_umi_assigner(strategy, 0, IndexThreshold::MinUmis(0), 2, false);
         let any = assigner.as_any();
         assert!(
             !any.is::<ParallelIdentityAssigner>()
@@ -2141,7 +2150,7 @@ mod tests {
             min_umi_length: None,
             threading: ThreadingOptions::none(),
             compression: CompressionOptions { compression_level: 1 },
-            index_threshold: 100,
+            index_threshold: IndexThreshold::default(),
             no_umi: false,
             scheduler_opts: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
@@ -2499,7 +2508,8 @@ mod tests {
         assert_ne!(truncated[0], truncated[3], "truncated UMIs must stay distinct");
 
         // Sequential adjacency assigner, max 1 mismatch (num_threads = 1, use_parallel = false).
-        let assigner = create_umi_assigner(Strategy::Adjacency, 1, 100, 1, false);
+        let assigner =
+            create_umi_assigner(Strategy::Adjacency, 1, IndexThreshold::default(), 1, false);
         let assignments = assigner.assign(&truncated);
 
         assert_eq!(assignments.len(), 5);
@@ -3826,6 +3836,60 @@ mod tests {
             error_msg.contains("--no-umi cannot be used with --strategy paired"),
             "Error message should mention the conflict"
         );
+    }
+
+    /// `--index-threshold always` is an assertion that indexing will happen, so a
+    /// strategy/edits combination that can never index must be rejected rather than
+    /// silently ignoring the request.
+    ///
+    /// Only `always` is checked. A bare integer -- including `0`, which admits every
+    /// group just as `always` does -- is a tuning knob allowed to end up inert; that is
+    /// what lets the default `100` coexist with `--strategy identity`.
+    #[rstest]
+    #[case::identity_never_indexes(Strategy::Identity, 0, "identity")]
+    #[case::edit_never_indexes(Strategy::Edit, 1, "edit")]
+    #[case::adjacency_needs_one_edit(Strategy::Adjacency, 2, "--edits 1")]
+    fn test_index_threshold_always_rejected_when_index_unreachable(
+        #[case] strategy: Strategy,
+        #[case] edits: u32,
+        #[case] expected_in_message: &str,
+    ) {
+        let mut cmd = test_group_cmd(strategy, edits);
+        cmd.index_threshold = IndexThreshold::Always;
+
+        let err = cmd.execute("test").expect_err("must reject an unsatisfiable --index-threshold");
+        let message = err.to_string();
+        assert!(
+            message.contains("--index-threshold always") && message.contains(expected_in_message),
+            "error should say why the request cannot be honoured, got: {message}"
+        );
+    }
+
+    /// The combinations that CAN index must not be rejected, and neither must a bare
+    /// integer under a strategy that never indexes.
+    #[rstest]
+    #[case::adjacency_one_edit(Strategy::Adjacency, 1, IndexThreshold::Always)]
+    #[case::paired_two_edits(Strategy::Paired, 2, IndexThreshold::Always)]
+    #[case::identity_with_number(Strategy::Identity, 0, IndexThreshold::MinUmis(100))]
+    #[case::identity_with_zero(Strategy::Identity, 0, IndexThreshold::MinUmis(0))]
+    #[case::identity_with_never(Strategy::Identity, 0, IndexThreshold::Never)]
+    fn test_index_threshold_accepted_when_satisfiable(
+        #[case] strategy: Strategy,
+        #[case] edits: u32,
+        #[case] index_threshold: IndexThreshold,
+    ) {
+        let mut cmd = test_group_cmd(strategy, edits);
+        cmd.index_threshold = index_threshold;
+
+        // `test_group_cmd` points at /dev/null, so execution fails later on I/O. All
+        // that matters here is that it is not rejected by the index-threshold check.
+        if let Err(e) = cmd.execute("test") {
+            let message = e.to_string();
+            assert!(
+                !message.contains("--index-threshold"),
+                "must not be rejected for --index-threshold, got: {message}"
+            );
+        }
     }
 
     #[test]

--- a/tests/integration/test_dedup_command.rs
+++ b/tests/integration/test_dedup_command.rs
@@ -472,3 +472,63 @@ fn test_dedup_no_umi_large_position_group() {
     // All templates should share the same MI value (one group in identity strategy).
     assert_eq!(mi_values.len(), 1, "all records should share a single MI tag value");
 }
+
+/// `dedup` carries its own copy of `--index-threshold`, so it needs the same
+/// unsatisfiable-request check `group` has: `always` under a strategy with no index
+/// code path must be rejected, not silently ignored.
+#[test]
+fn test_dedup_rejects_index_threshold_always_when_index_unreachable() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    create_sorted_bam(&input_bam, create_duplicate_group("dup1", "ACGTACGT", 3, 100));
+
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--index-threshold",
+        "always",
+    ])
+    .expect("failed to parse dedup args");
+
+    let err = cmd.execute("fgumi dedup").expect_err("must reject an unsatisfiable request");
+    let message = err.to_string();
+    assert!(
+        message.contains("--index-threshold always")
+            && message.contains("never uses the UMI index"),
+        "error should say why the request cannot be honoured, got: {message}"
+    );
+}
+
+/// `never` is always satisfiable, so it must be accepted everywhere -- including under
+/// a strategy that would not have indexed anyway.
+#[test]
+fn test_dedup_accepts_index_threshold_never() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    create_sorted_bam(&input_bam, create_duplicate_group("dup1", "ACGTACGT", 3, 100));
+
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--index-threshold",
+        "never",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse dedup args");
+
+    cmd.execute("fgumi dedup").expect("--index-threshold never must be accepted");
+    assert!(output_bam.exists(), "Output BAM not created");
+}


### PR DESCRIPTION
**Stacked on #632** — review that first; this PR's diff is against it.

## Why

#632 corrected the `--index-threshold` help, which had claimed "Set to 0 to always use linear scan" when `0` in fact indexes *every* group. But correcting the docs **removed a documented capability rather than delivering it**: the gate is `num_umis >= index_threshold`, so there is no value that disables the index short of one larger than any position group — literally `--index-threshold 18446744073709551615`.

## What

Make the option a keyword-or-number, matching `--parallel-group-min-templates` one screen away in the same file (`Auto | Fixed(usize)`, with a hand-written `FromStr`):

```
--index-threshold always     index every position group
--index-threshold never      always scan all UMI pairs
--index-threshold <N>        index groups of N or more   (default 100)
```

- **`never` is the new capability.**
- **`always` is sugar** for `0`, which already meant this but read as its opposite — precisely the trap that produced the wrong docs. Once `always` exists, nobody needs to write or interpret a bare `0` again.

**Backward compatible:** every existing integer invocation keeps working unchanged, `0` included. No one's command line silently flips meaning — which is the decisive argument against the alternative of redefining `0` to mean "off".

**Why not `--no-index`?** Two knobs controlling one behaviour needs a precedence rule for `--no-index --index-threshold 50`. Keeping it in one option makes the contradictory state unrepresentable. (`--index-threshold -1` was also considered: it needs an `isize` widening plus `allow_negative_numbers`, and puts a third magic value into an integer whose existing magic value already caused this bug.)

## Unsatisfiable requests are now errors

`always` asserts that indexing will happen, so a configuration that can never index is rejected rather than accepted and ignored:

```
$ fgumi group --strategy identity --index-threshold always
Error: --index-threshold always cannot be honoured with --strategy identity: the identity
strategy never uses the UMI index. Drop --index-threshold to leave indexing to the default
threshold, or pass --index-threshold never to state that a linear scan is intended.

$ fgumi group --strategy adjacency --edits 2 --index-threshold always
Error: --index-threshold always cannot be honoured with --strategy adjacency --edits 2: the
adjacency strategy only indexes at --edits 1. ...
```

That second case surfaces an asymmetry the help had left implicit and #632 could only describe: **adjacency silently ignores the index at any `--edits` other than 1**, while paired indexes at all of them. `Strategy::can_use_index(edits)` now states it in code.

The check runs against the **effective** strategy and edits, so `--no-umi` (which forces identity) is caught too.

**A bare integer is deliberately not checked.** It is a tuning knob allowed to end up inert — otherwise the default `100` could not coexist with `--strategy identity`. That includes `0`, even though `0` admits every group exactly as `always` does. This asymmetry is the one judgement call in the PR; the alternative (erroring on `0` too) is defensible and I'll change it if you prefer.

## Structure

- `IndexThreshold` lives in `fgumi-umi` next to the assigners that consult it, with `FromStr`, `Display` (round-trips), `Default`, `From<usize>`, `admits()` and `demands_indexing()`.
- `dedup` carries its own copy of the option, so `validate_index_threshold` lives in `commands::common` and both commands call it.
- Assigner constructors take `T: Into<IndexThreshold>`, so all 41 existing integer call sites are untouched.

## Tests

- 33 cases on the type: parsing (both keywords, mixed case, integers), rejection messages naming the accepted forms, `admits()` across the boundary, `demands_indexing()`, and `Display` round-trip.
- The #632 assigner tables extend into it — `#[case::usize_max_never_indexes(usize::MAX, …)]` becomes `#[case::never_skips_huge_group(IndexThreshold::Never, …)]`, which is what that case was always trying to say — plus a new case proving `never` wins at every edit distance for both strategies.
- CLI: `group` rejects `always` under identity/edit/adjacency-with-edits≠1 and accepts every satisfiable combination; `dedup` gets the same two tests through `try_parse_from`, since it has its own copy of the flag.
- All three error paths verified against the built binary, including the clap parse error for a bad value.

Full suite green: 5746 passed, plus `ci-fmt`, `ci-lint`, `ci-doc` (`RUSTDOCFLAGS=-D warnings`) and `ci-doctest`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added flexible `--index-threshold` settings: minimum UMI count, `always`, or `never`.
  - Applied threshold controls to `dedup` and `group` commands.
  - Added clear command-line validation for incompatible strategy and threshold combinations.
  - Exposed the threshold configuration for broader application use.

- **Bug Fixes**
  - Prevented unsupported indexing requests from proceeding and provided actionable error messages.
  - Improved handling of indexing decisions for different UMI assignment strategies.

- **Tests**
  - Added coverage for valid, invalid, and incompatible threshold configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->