### PR TITLE
test(umi): pin id assignment in assign_with_invalid_fallback

### DIFF
--- a/crates/fgumi-umi/src/assigner.rs
+++ b/crates/fgumi-umi/src/assigner.rs
@@ -3808,4 +3808,101 @@ mod tests {
             );
         }
     }
+
+    /// `assign_with_invalid_fallback` must mint an id only for UMIs `resolve`
+    /// rejects, share one id between repeats of the same rejected UMI (case-folded),
+    /// and leave resolved UMIs untouched — whatever the interleaving. The cases put
+    /// rejected UMIs before, between and after resolved ones, and repeat a rejected
+    /// UMI across a run of resolved ones, because that is where an eager mint (or a
+    /// map built at the wrong time) shifts ids.
+    ///
+    /// **This asserts fgumi's intentional divergence from fgbio for invalid UMIs,
+    /// not fgbio identity.** fgbio's `GroupReadsByUmi` discards every SAM record
+    /// whose UMI contains an `N` *before* assignment (fgbio
+    /// `GroupReadsByUmi.scala`, `filteredNsInUmi` / `discarded_ns_in_umi`), so a
+    /// rejected UMI has no fgbio molecule id to be identical to. fgumi's `group`
+    /// and `dedup` commands filter the same reads upstream
+    /// (`src/lib/commands/group.rs`, `UmiValidation::ContainsN`), matching fgbio
+    /// there; `assign_with_invalid_fallback` is the defensive backstop for a
+    /// non-`BitEnc`-encodable UMI that reaches the assigner anyway. Its behavior —
+    /// one `Single` molecule per distinct case-folded invalid string, never joined
+    /// to a valid molecule — is a deliberate fgumi choice (it also keeps the
+    /// sequential and parallel assigners in lockstep, see the `parallel_assigner`
+    /// parity harness), so this test pins that documented divergence rather than an
+    /// fgbio baseline. The fgbio-identical path — valid ACGT UMIs handled by
+    /// `resolve` — is covered by the per-strategy grouping tests
+    /// (`test_simple_error_assigner_groups_by_mismatches`,
+    /// `test_identity_assigner_groups_exact_matches`, the `test_adjacency_*` tests)
+    /// and the sequential-vs-parallel parity harness in `parallel_assigner`.
+    #[rstest]
+    #[case::all_resolved(&["AAAA", "CCCC"], &[] as &[&str], &[0, 1])]
+    #[case::all_rejected(&["AAAN", "CCCN"], &["AAAN", "CCCN"], &[100, 101])]
+    #[case::rejected_first(&["AAAN", "CCCC"], &["AAAN"], &[100, 0])]
+    #[case::rejected_last(&["AAAA", "CCCN"], &["CCCN"], &[0, 100])]
+    #[case::rejected_between_resolved(&["AAAA", "CCCN", "GGGG"], &["CCCN"], &[0, 100, 1])]
+    #[case::repeat_rejected_after_resolved(
+        &["AAAN", "CCCC", "GGGG", "AAAN"], &["AAAN"], &[100, 0, 1, 100]
+    )]
+    #[case::repeat_rejected_case_folded(&["aaan", "AAAN"], &["aaan", "AAAN"], &[100, 100])]
+    // A repeat must not consume an id. If it did, the *next* distinct rejected UMI
+    // would be minted 102 instead of 101 — the only interleaving in which a wasted
+    // mint is observable, since a discarded id never appears in the output itself.
+    #[case::repeat_rejected_then_new_rejected(
+        &["AAAN", "AAAN", "CCCN"], &["AAAN", "CCCN"], &[100, 100, 101]
+    )]
+    fn test_assign_with_invalid_fallback_id_assignment(
+        #[case] raw_umis: &[&str],
+        #[case] rejected: &[&str],
+        #[case] expected_ids: &[u64],
+    ) {
+        // `resolve` stands in for a real assigner: it rejects the listed UMIs and
+        // hands every other one a distinct id in first-seen order, so a spurious
+        // mint or a reordered mint is visible in the output vector.
+        let mut resolved_ids: AHashMap<String, MoleculeId> = AHashMap::new();
+        let mut next_resolved = 0u64;
+        let resolve = |_: usize, umi: &str| {
+            if rejected.iter().any(|r| r.eq_ignore_ascii_case(umi)) {
+                return None;
+            }
+            Some(*resolved_ids.entry(umi.to_uppercase()).or_insert_with(|| {
+                let id = MoleculeId::Single(next_resolved);
+                next_resolved += 1;
+                id
+            }))
+        };
+
+        // Count how many times `mint` fired. `assign_with_invalid_fallback` must mint
+        // exactly once per DISTINCT (case-folded) rejected UMI — never per rejected
+        // occurrence — so a repeated rejection sharing its predecessor's id, and a
+        // successful resolution after the final rejection, both leave the count
+        // untouched. Tracked via a Cell so the counter is observable after the
+        // `mint` closure is dropped at the end of the call.
+        let mints = std::cell::Cell::new(0u64);
+        let mint = || {
+            let id = MoleculeId::Single(100 + mints.get());
+            mints.set(mints.get() + 1);
+            id
+        };
+
+        let umis: Vec<Umi> = raw_umis.iter().map(|u| (*u).to_string()).collect();
+        let expected: Vec<MoleculeId> =
+            expected_ids.iter().copied().map(MoleculeId::Single).collect();
+
+        assert_eq!(assign_with_invalid_fallback(&umis, resolve, mint), expected);
+
+        // Derive the expected mint count from the inputs, not from a literal: the
+        // number of distinct case-folded rejected UMIs actually present in `raw_umis`.
+        let expected_mints = raw_umis
+            .iter()
+            .filter(|u| rejected.iter().any(|r| r.eq_ignore_ascii_case(u)))
+            .map(|u| u.to_uppercase())
+            .collect::<std::collections::HashSet<_>>()
+            .len() as u64;
+        assert_eq!(
+            mints.get(),
+            expected_mints,
+            "mint fired {} times; expected one per distinct rejected UMI ({expected_mints})",
+            mints.get(),
+        );
+    }
 }


### PR DESCRIPTION
`assign_with_invalid_fallback` backs four assigner paths — the sequential identity, edit and adjacency assigners all route non-encodable UMIs through it (`assigner.rs:1096`, `:1581`, `:1619`, `:1641`) — but had no direct tests. It was covered only incidentally, through whole assigner runs.

This adds a case table over the interleavings that actually discriminate: a rejected UMI first, last, and between resolved ones; a rejected UMI repeated after a run of resolved ones; and case-folded repeats.

## The one case that carries the weight

`repeat_rejected_then_new_rejected`. A repeated rejected UMI must not consume an id, and that is **only** observable when a second *distinct* rejected UMI follows — a minted-then-discarded id never appears in the output itself, so every other interleaving passes even when the mint is eager.

I found this by mutation-testing the table rather than assuming it: rewriting `or_insert_with(&mut mint)` as `or_insert(mint())` initially left the whole table green. With the added case, that mutation fails exactly one case and nothing else.

## Why tests and not the refactor

This started as a perf change — making the `AHashMap` lazy, since the fallback fires on a tiny fraction of records. That is not worth doing: `AHashMap::new()` does not allocate and costs ~5.6 ns, so on a per-position-group call the saving is unmeasurable, and threading an `Option` through four sites would cost readability for nothing. The tests are the part that has value, so they land on their own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added regression coverage for identifier assignment when some UMIs are rejected during resolution.
  - Verified resolved UMIs receive the exact identifiers produced by resolution (based on first-seen order), unaffected by interleaving with rejected entries.
  - Confirmed rejected UMIs mint a single shared identifier per distinct case-folded spelling, reused across repeats, with minting performed only once per distinct rejected form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->