### PR TITLE
perf(group): validate mate CIGARs from the decoded key, not a second aux walk

### DIFF
--- a/src/lib/grouper.rs
+++ b/src/lib/grouper.rs
@@ -394,6 +394,14 @@ impl MemoryEstimate for RawPositionGroup {
 /// Without MC tags, R1 and R2 would get different `position_key()` values and
 /// be incorrectly split.
 ///
+/// That requirement is enforced by reading [`GroupKey::has_mate_position`] on
+/// each eligible record — **not** by re-reading the `MC` tag bytes. Anything
+/// that changes how `compute_group_key_from_raw` falls back when `MC` is absent
+/// must keep that method meaning "the mate position was resolved", or this
+/// grouper silently stops rejecting MC-less input. A caller that hand-builds
+/// [`DecodedRecord`]s with keys from some other source is likewise not
+/// validated; both in-tree producers go through `compute_group_key_from_raw`.
+///
 /// By default, secondary/supplementary reads are skipped (they have UNKNOWN
 /// position keys). Use [`with_secondary_supplementary`](Self::with_secondary_supplementary)
 /// to include them — they are coalesced by `name_hash` into the group of their
@@ -405,8 +413,6 @@ pub struct RecordPositionGrouper {
     current_group_key: Option<GroupKey>,
     /// Records at the current position.
     current_records: Vec<DecodedRecord>,
-    /// Whether MC tags have been validated on paired records.
-    mc_validated: bool,
     /// Whether to include secondary and supplementary reads in groups.
     /// When true, secondary/supplementary reads (which have UNKNOWN position keys)
     /// are kept and coalesced by `name_hash` into the group of their primary read.
@@ -424,7 +430,6 @@ impl RecordPositionGrouper {
             current_position_key: None,
             current_group_key: None,
             current_records: Vec::new(),
-            mc_validated: false,
             include_secondary_supplementary: false,
         }
     }
@@ -438,13 +443,25 @@ impl RecordPositionGrouper {
         Self { include_secondary_supplementary: true, ..Self::new() }
     }
 
-    /// Validate that a paired primary record has an MC tag.
+    /// Validate that a paired primary record has a resolved mate position.
     ///
     /// Skips validation for records that are unmapped or whose mates are unmapped,
     /// since unmapped reads have no CIGAR to report in an MC tag. Every eligible
-    /// paired primary record is checked — `mc_validated` is kept only as a
-    /// "seen at least one valid MC" marker, not a short-circuit.
-    fn validate_mc_tag(&mut self, decoded: &DecodedRecord) -> io::Result<()> {
+    /// paired primary record is checked.
+    ///
+    /// The check reads [`GroupKey::has_mate_position`] rather than re-walking the
+    /// record's aux data: the Decode step already resolved the mate position from
+    /// the `MC` tag, and falls back to a single-ended key when it could not (see
+    /// `compute_group_key_from_raw`). Re-deriving that here cost a second full
+    /// aux-TLV walk plus a UTF-8 validation, per record, on this serial step.
+    ///
+    /// This makes validation agree with the value grouping actually uses. It also
+    /// makes fgumi marginally more permissive for one malformed shape: a record
+    /// carrying `MC` **twice** with a non-`Z` copy first is accepted here, where a
+    /// byte-level `find_mc_tag_in_record` scan rejected it. Duplicate aux tags
+    /// violate SAM §1.5; see `test_mc_presence_matches_key_shape` for the pinned
+    /// case.
+    fn validate_mc_tag(decoded: &DecodedRecord) -> io::Result<()> {
         use fgumi_raw_bam::RawRecordView;
 
         let raw = &decoded.data;
@@ -455,15 +472,18 @@ impl RecordPositionGrouper {
         let is_unmapped = (flg & fgumi_raw_bam::flags::UNMAPPED) != 0;
         let is_mate_unmapped = (flg & fgumi_raw_bam::flags::MATE_UNMAPPED) != 0;
 
-        if is_paired && !is_secondary && !is_supplementary && !is_unmapped && !is_mate_unmapped {
-            if fgumi_raw_bam::find_mc_tag_in_record(raw).is_none() {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "RecordPositionGrouper requires MC tags on paired-end reads. \
-                     Run `fgumi zipper` to add MC tags before `fgumi group`.",
-                ));
-            }
-            self.mc_validated = true;
+        if is_paired
+            && !is_secondary
+            && !is_supplementary
+            && !is_unmapped
+            && !is_mate_unmapped
+            && !decoded.key.has_mate_position()
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "RecordPositionGrouper requires MC tags on paired-end reads. \
+                 Run `fgumi zipper` to add MC tags before `fgumi group`.",
+            ));
         }
 
         Ok(())
@@ -487,8 +507,8 @@ impl RecordPositionGrouper {
             return Ok(None);
         }
 
-        // Validate MC tag on first paired primary record
-        self.validate_mc_tag(&decoded)?;
+        // Validate the mate position resolved during decode (i.e. the MC tag was usable)
+        Self::validate_mc_tag(&decoded)?;
 
         let record_pos_key = decoded.key.position_key();
 
@@ -1120,6 +1140,7 @@ mod tests {
     // ========================================================================
 
     use fgumi_raw_bam::{SamBuilder as RawSamBuilder, SamTag, flags as raw_flags};
+    use rstest::rstest;
 
     /// Helper: create a `DecodedRecord` with the given `GroupKey` and flags/tags.
     fn make_decoded(
@@ -1370,49 +1391,124 @@ mod tests {
         assert_eq!(groups[0].records.len(), 1);
     }
 
-    #[test]
-    fn test_record_position_grouper_mc_validation_skips_unmapped_mate() {
-        // Paired records with unmapped mates have no MC tag — validation should skip them.
+    /// Build the raw bytes of a paired record, optionally carrying an `MC` tag.
+    ///
+    /// `prepend_non_z_mc` puts a non-`Z` `MC` entry ahead of the real one, the
+    /// one shape where the byte-level scan and decode's aux pass disagree.
+    fn build_raw(
+        flags: u16,
+        pos: i32,
+        mc: Option<&str>,
+        name: &[u8],
+        prepend_non_z_mc: bool,
+    ) -> fgumi_raw_bam::RawRecord {
         use fgumi_raw_bam::testutil::encode_op;
-        let mut grouper = RecordPositionGrouper::new();
-        let key = GroupKey::single(0, 100, 0, 0, 0, 12345);
+
         let mut b = RawSamBuilder::new();
-        b.read_name(b"read1")
+        b.read_name(name)
             .sequence(b"ACGT")
             .qualities(&[30; 4])
-            .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT | raw_flags::MATE_UNMAPPED)
+            .flags(flags)
             .ref_id(0)
-            .pos(99)
+            .pos(pos)
+            .mate_ref_id(0)
+            .mate_pos(pos + 100)
             .cigar_ops(&[encode_op(0, 4)]);
-        let decoded = DecodedRecord::from_raw_bytes(b.build(), key);
-
-        // Should NOT error even though there's no MC tag
-        let result = grouper.add_records(vec![decoded]);
-        assert!(result.is_ok());
-        assert!(!grouper.mc_validated); // Not validated — skipped due to unmapped mate
+        if prepend_non_z_mc {
+            b.add_int_tag(SamTag::MC, 5);
+        }
+        if let Some(mc_val) = mc {
+            b.add_string_tag(SamTag::MC, mc_val.as_bytes());
+        }
+        b.build()
     }
 
-    #[test]
-    fn test_record_position_grouper_mc_validation_fails_without_mc() {
-        let mut grouper = RecordPositionGrouper::new();
-        // Paired record without MC tag
-        let key = GroupKey::paired(0, 100, 0, 0, 200, 1, 0, 0, 12345);
-        let decoded = make_decoded(key, true, true, None); // No MC tag
+    /// Build a `DecodedRecord` whose `GroupKey` is derived from its own bytes by
+    /// the real decode path, rather than hand-supplied.
+    ///
+    /// MC validation reads the key that decode produced, so a test that hands in
+    /// a key unrelated to the record's bytes proves nothing about the decode →
+    /// group contract. Every MC-validation test below builds its record this way.
+    fn decoded_via_decode(flags: u16, pos: i32, mc: Option<&str>, name: &[u8]) -> DecodedRecord {
+        use crate::read_info::LibraryIndex;
+        use crate::unified_pipeline::compute_group_key_from_raw;
 
-        let result = grouper.add_records(vec![decoded]);
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert!(err_msg.contains("MC tags"), "Error should mention MC tags: {err_msg}");
+        let raw = build_raw(flags, pos, mc, name, false);
+        let (key, _) = compute_group_key_from_raw(&raw, &LibraryIndex::default(), None, None);
+        DecodedRecord::from_raw_bytes(raw, key)
     }
 
-    #[test]
-    fn test_record_position_grouper_mc_validation_passes_with_mc() {
+    const PRIMARY_PAIRED: u16 = raw_flags::PAIRED | raw_flags::FIRST_SEGMENT;
+
+    /// The invariant Design C rests on: for every record the grouper validates,
+    /// the byte-level MC scan and the decoded key shape agree — **except** for
+    /// duplicate `MC` entries, pinned as the last case here.
+    ///
+    /// That divergence is deliberate and documented on `validate_mc_tag`.
+    /// `find_tag_position` matches the first entry with the `MC` name whatever
+    /// its type and then rejects it for not being `Z`; `extract_aux_string_tags`
+    /// skips non-`Z` entries and finds the second copy. Duplicate aux tags
+    /// violate SAM §1.5, and the relaxation only makes validation agree with the
+    /// value grouping actually uses.
+    #[rstest]
+    #[case::mc_present(PRIMARY_PAIRED, Some("4M"), false, true)]
+    #[case::mc_absent(PRIMARY_PAIRED, None, false, false)]
+    #[case::mc_present_reverse_strands(
+        PRIMARY_PAIRED | raw_flags::REVERSE | raw_flags::MATE_REVERSE,
+        Some("4M"),
+        false,
+        true
+    )]
+    #[case::duplicate_mc_non_z_first(PRIMARY_PAIRED, Some("4M"), true, false)]
+    fn test_mc_presence_matches_key_shape(
+        #[case] flags: u16,
+        #[case] mc: Option<&str>,
+        #[case] prepend_non_z_mc: bool,
+        #[case] byte_scan_finds_mc: bool,
+    ) {
+        use crate::read_info::LibraryIndex;
+        use crate::unified_pipeline::compute_group_key_from_raw;
+
+        let raw = build_raw(flags, 99, mc, b"read1", prepend_non_z_mc);
+        let (key, _) = compute_group_key_from_raw(&raw, &LibraryIndex::default(), None, None);
+
+        assert_eq!(
+            fgumi_raw_bam::find_mc_tag_in_record(&raw).is_some(),
+            byte_scan_finds_mc,
+            "byte-level MC scan disagreed with the case table"
+        );
+        assert_eq!(
+            key.has_mate_position(),
+            mc.is_some(),
+            "decode must resolve a mate position exactly when it can read an MC tag"
+        );
+    }
+
+    #[rstest]
+    // Paired primary, mate mapped, MC present → validates.
+    #[case::paired_with_mc(PRIMARY_PAIRED, Some("4M"), true)]
+    // Paired primary, mate mapped, no MC → rejected. This is the whole point.
+    #[case::paired_without_mc(PRIMARY_PAIRED, None, false)]
+    // Mate unmapped: no CIGAR exists to report, so MC absence is expected.
+    #[case::mate_unmapped(PRIMARY_PAIRED | raw_flags::MATE_UNMAPPED, None, true)]
+    // Read itself unmapped — excluded from the requirement.
+    #[case::self_unmapped(PRIMARY_PAIRED | raw_flags::UNMAPPED, None, true)]
+    // Unpaired reads have no mate to describe.
+    #[case::unpaired(0, None, true)]
+    fn test_record_position_grouper_mc_validation(
+        #[case] flags: u16,
+        #[case] mc: Option<&str>,
+        #[case] expected_ok: bool,
+    ) {
         let mut grouper = RecordPositionGrouper::new();
-        let key = GroupKey::paired(0, 100, 0, 0, 200, 1, 0, 0, 12345);
-        let decoded = make_decoded(key, true, true, Some("4M"));
+        let decoded = decoded_via_decode(flags, 99, mc, b"read1");
 
         let result = grouper.add_records(vec![decoded]);
-        assert!(result.is_ok());
+        assert_eq!(result.is_ok(), expected_ok);
+        if !expected_ok {
+            let err_msg = result.unwrap_err().to_string();
+            assert!(err_msg.contains("MC tags"), "Error should mention MC tags: {err_msg}");
+        }
     }
 
     #[test]
@@ -1420,29 +1516,35 @@ mod tests {
         // Regression: after a record with a valid MC tag, a later paired primary
         // missing MC must still fail validation (no short-circuit).
         let mut grouper = RecordPositionGrouper::new();
-        let key_ok = GroupKey::paired(0, 100, 0, 0, 200, 1, 0, 0, 11111);
-        let ok_record = make_decoded(key_ok, true, true, Some("4M"));
+        let ok_record = decoded_via_decode(PRIMARY_PAIRED, 99, Some("4M"), b"readA");
         grouper.add_records(vec![ok_record]).expect("first record with MC should validate");
-        assert!(grouper.mc_validated);
 
-        let key_bad = GroupKey::paired(0, 300, 0, 0, 400, 1, 0, 0, 22222);
-        let bad_record = make_decoded(key_bad, true, true, None);
+        let bad_record = decoded_via_decode(PRIMARY_PAIRED, 299, None, b"readB");
         let result = grouper.add_records(vec![bad_record]);
         assert!(result.is_err(), "later paired primary missing MC must fail");
         let err_msg = result.unwrap_err().to_string();
         assert!(err_msg.contains("MC tags"), "Error should mention MC tags: {err_msg}");
     }
 
-    #[test]
-    fn test_record_position_grouper_mc_validation_skips_unpaired() {
-        // Unpaired records should not trigger MC validation
-        let mut grouper = RecordPositionGrouper::new();
-        let key = GroupKey::single(0, 100, 0, 0, 0, 12345);
-        let decoded = make_decoded(key, false, false, None); // Unpaired, no MC tag
+    /// `fgumi dedup` builds this grouper with `with_secondary_supplementary()`,
+    /// which disables the `UNKNOWN_REF` early return in `process_record`. Paired
+    /// secondary/supplementary reads therefore reach validation carrying a
+    /// default-shaped key, and must not be rejected for lacking an MC tag.
+    #[rstest]
+    #[case::secondary(PRIMARY_PAIRED | raw_flags::SECONDARY)]
+    #[case::supplementary(PRIMARY_PAIRED | raw_flags::SUPPLEMENTARY)]
+    fn test_record_position_grouper_dedup_mode_allows_paired_secondary_without_mc(
+        #[case] flags: u16,
+    ) {
+        let mut grouper = RecordPositionGrouper::with_secondary_supplementary();
+        let decoded = decoded_via_decode(flags, 99, None, b"read1");
+        assert!(
+            !decoded.key.has_mate_position(),
+            "precondition: a secondary read without `tc` gets a single-ended key"
+        );
 
         let result = grouper.add_records(vec![decoded]);
-        assert!(result.is_ok());
-        assert!(!grouper.mc_validated); // Should not be validated for unpaired
+        assert!(result.is_ok(), "dedup must accept paired secondary reads without MC tags");
     }
 
     #[test]

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -552,7 +552,12 @@ pub fn compute_group_key_from_raw(
             name_hash,
         ),
         None => {
-            // No MC tag — fall back to single-end behavior
+            // No MC tag — fall back to single-end behavior.
+            //
+            // `RecordPositionGrouper::validate_mc_tag` detects a missing MC tag by
+            // testing `GroupKey::has_mate_position()` on the key produced here,
+            // instead of re-walking the aux data on its serial step. Keep this the
+            // only way an eligible paired record can receive a single-ended key.
             GroupKey::single(own_ref_id, own_pos, strand, library_idx, cell_hash, name_hash)
         }
     };

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -1354,6 +1354,12 @@ impl GroupKey {
     /// Create a `GroupKey` for a paired-end read with mate info.
     ///
     /// Positions are automatically normalized so the lower position comes first.
+    ///
+    /// Both strands must be `0` (forward) or `1` (reverse). Every caller derives
+    /// them from a boolean — either a flag bit or a `!= 0` test on a `tc` field —
+    /// so `UNKNOWN_STRAND` can never reach `strand2` through this constructor.
+    /// [`GroupKey::has_mate_position`] depends on that, so the invariant is
+    /// asserted here rather than left to convention.
     #[must_use]
     #[allow(clippy::too_many_arguments)]
     pub fn paired(
@@ -1367,6 +1373,12 @@ impl GroupKey {
         cell_hash: u64,
         name_hash: u64,
     ) -> Self {
+        debug_assert!(
+            strand <= 1 && mate_strand <= 1,
+            "GroupKey::paired requires boolean strands (got {strand}, {mate_strand}); \
+             UNKNOWN_STRAND in a paired key would break GroupKey::has_mate_position"
+        );
+
         // Normalize: put lower position first (matching ReadInfo behavior)
         let (ref_id1, pos1, strand1, ref_id2, pos2, strand2) =
             if (ref_id, pos, strand) <= (mate_ref_id, mate_pos, mate_strand) {
@@ -1399,6 +1411,25 @@ impl GroupKey {
             cell_hash,
             name_hash,
         }
+    }
+
+    /// Returns whether this key carries a resolved mate position.
+    ///
+    /// True for keys built by [`GroupKey::paired`], false for
+    /// [`GroupKey::single`] and [`GroupKey::default`].
+    ///
+    /// `strand2` is the discriminator because [`GroupKey::paired`] always
+    /// receives boolean strands (asserted there), so only the single-ended
+    /// constructors can produce [`GroupKey::UNKNOWN_STRAND`]. `ref_id2` and
+    /// `pos2` are weaker: `i32::MAX` is a legal-looking coordinate.
+    ///
+    /// Decode resolves the mate position from the `MC` tag, falling back to a
+    /// single-ended key when it is absent (see `compute_group_key_from_raw`).
+    /// `RecordPositionGrouper` therefore reads this instead of re-walking the
+    /// record's aux data.
+    #[must_use]
+    pub fn has_mate_position(&self) -> bool {
+        self.strand2 != Self::UNKNOWN_STRAND
     }
 
     /// Returns the position-only key for grouping by genomic position.
@@ -5198,6 +5229,8 @@ pub fn shared_try_step_write_new<S: WritePipelineState>(state: &S) -> StepResult
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     #[test]
@@ -5474,6 +5507,40 @@ mod tests {
         assert_eq!(key.ref_id2, 5);
         assert_eq!(key.pos2, 500);
         assert_eq!(key.strand2, 1);
+    }
+
+    /// `has_mate_position` must key on `strand2` alone.
+    ///
+    /// The byte-derived keys built by `GroupKey::single` set all three sentinels
+    /// together, so a `ref_id2`-based implementation is indistinguishable from a
+    /// `strand2`-based one on any real record. The two mixed-sentinel struct
+    /// literals below are therefore the only cases that can tell them apart, and
+    /// they exist to make the wrong implementations fail.
+    #[rstest]
+    // Real shapes, both constructors.
+    #[case::paired_forward_forward(GroupKey::paired(0, 100, 0, 0, 200, 0, 0, 0, 1), true)]
+    #[case::paired_reverse_reverse(GroupKey::paired(0, 100, 1, 0, 200, 1, 0, 0, 1), true)]
+    #[case::single_ended(GroupKey::single(0, 100, 0, 0, 0, 1), false)]
+    #[case::default_key(GroupKey::default(), false)]
+    // Mixed sentinels: resolved positions but an unknown strand2 → NOT a mate
+    // position. Kills an implementation that tests `ref_id2 != UNKNOWN_REF`.
+    #[case::resolved_positions_unknown_strand(
+        GroupKey { ref_id2: 0, pos2: 0, strand2: GroupKey::UNKNOWN_STRAND, ..GroupKey::default() },
+        false
+    )]
+    // Unknown positions but a real strand2 → IS a mate position. Kills an
+    // implementation that tests `strand2 != 0`.
+    #[case::unknown_positions_forward_strand(
+        GroupKey {
+            ref_id2: GroupKey::UNKNOWN_REF,
+            pos2: GroupKey::UNKNOWN_POS,
+            strand2: 0,
+            ..GroupKey::default()
+        },
+        true
+    )]
+    fn test_group_key_has_mate_position(#[case] key: GroupKey, #[case] expected: bool) {
+        assert_eq!(key.has_mate_position(), expected);
     }
 
     #[test]


### PR DESCRIPTION
## The redundancy

`RecordPositionGrouper::validate_mc_tag` ran `find_mc_tag_in_record` on every eligible record — a full walk of the aux TLV block plus a `str::from_utf8` — to confirm an MC tag was present. The parallel Decode step had already answered that question: `compute_group_key_from_raw` resolves the mate position from MC (`bam.rs:534-540`) and falls back to a single-ended `GroupKey` when it cannot (`:554-557`).

So the pipeline's hottest serial step was re-deriving, with a second aux walk, a fact a parallel step already had. This reads `GroupKey::has_mate_position()` instead.

It also drops `mc_validated`, which was written on every validated record and read only by tests.

## Measured

Quiet `c8g.4xlarge` (16 vCPU, gp3 3000 IOPS / 500 MB/s, `TMPDIR` on EBS), template-coordinate sorted twist-umi BAM, **7,868,052 accepted records** on every run. `fgumi group -s adjacency --threads 1`, 7 reps each, interleaved:

| | user CPU (s) | min |
|---|---|---|
| `main` | 20.18 20.26 20.35 20.26 20.32 20.32 20.24 | 20.18 |
| this PR | 19.87 19.85 19.84 19.72 19.84 19.90 19.89 | 19.72 |

Ranges do not overlap — about **2%**. A separate arm with the validation *deleted outright* (the strict ceiling) bottomed out at 19.72 s, so this captures essentially all of the available saving rather than trading one cost for another.

**Wall clock does not move**, and I want to be explicit about that because a profile of the serial step alone suggests otherwise. At 8, 12 and 16 threads the wall distributions of the two arms overlap completely. At `--threads 12` this removes ~1.0 s of user CPU — all of it from the serial Group thread — while wall moves ~0.2 s. The thread pool, not this step, is the wall-clock limiter on that hardware. This is a CPU saving; it is not a throughput win.

Output is **byte-identical**: same whole-file md5 from both arms when run with an identical output path (the path is embedded in `@PG CL:`, so it has to be held constant for the comparison to mean anything).

## One deliberate behavior relaxation

Validation now trusts the decoded key rather than re-reading the tag bytes, and the two lookups do not walk aux data the same way:

- `find_tag_position` returns the **first entry whose tag name matches, whatever its type byte**, and `find_string_tag` then rejects it for not being `Z`.
- `extract_aux_string_tags` only inspects `Z` entries and **skips past** everything else.

They therefore disagree on one malformed shape — MC present **twice** with a non-`Z` copy first:

| aux | before | after |
|---|---|---|
| `MC:A:x`, `MC:Z:100M` | error | accepted |
| `MC:i:5`, `MC:Z:50M` | error | accepted |

Duplicate aux tags violate SAM §1.5, and decode already uses the `extract_aux_string_tags` answer to build the key — so this makes validation agree with the value grouping actually uses. `test_mc_presence_matches_key_shape` pins it as a recorded decision rather than leaving it to be discovered.

## Why a key-shape check rather than a flag on `DecodedRecord`

Carrying an explicit bit was the obvious alternative. It would change the return type of `pub compute_group_key_from_raw` (a semver break), touch ~25 test call sites to be genuinely compiler-enforced, and — in the cheap variant that defaults the bit to `false` — reintroduce exactly the silent-failure mode the enforcement was meant to prevent. It also would not remove the coupling, only relocate it: the bit still has to be computed from `aux_tags.mc` at the same point the key shape is decided, and unlike the key shape it can drift out of sync with the key.

Validating inside `decode_records` was rejected outright: that path is shared with the MI-tag grouper (`mi_group.rs`), which has no MC requirement, so an unconditional check there would reject input those commands accept today.

`GroupKey::paired` gains a `debug_assert!` that both strands are boolean. That is what makes the `strand2` sentinel safe to key on, and it checks the invariant at the one site capable of violating it, in every debug and test build.

## Tests

- `test_group_key_has_mate_position` — includes two mixed-sentinel struct literals. They exist because `GroupKey::single` sets all three sentinels together, so on any byte-derived key a `ref_id2`-based implementation is indistinguishable from a `strand2`-based one; without those cases that mutation survives the whole suite.
- `test_mc_presence_matches_key_shape` — differential table over real bytes through the real decode path, including the duplicate-MC divergence.
- `test_record_position_grouper_mc_validation` — five-case eligibility table. The previous tests hand-built a `GroupKey` unrelated to the record's bytes, which cannot exercise the decode-to-group contract; these derive the key from the bytes.
- `..._dedup_mode_allows_paired_secondary_without_mc` — `fgumi dedup` builds this grouper with `with_secondary_supplementary()`, which disables the `UNKNOWN_REF` early return, so paired secondary reads reach validation carrying a default-shaped key.

Nine mutations were applied and each fails at least one test: inverting `has_mate_position`; keying it on `ref_id2`; keying it on `strand2 != 0`; dropping each of the five eligibility terms; and removing the MC check entirely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved paired-end record grouping by consistently resolving mate-position information during decoding.
  - Corrected handling of missing or duplicated mate-coordinate metadata, including fallback to single-ended grouping when appropriate.
  - Strengthened validation of paired-end strand information to prevent inconsistent grouping results.
  - Added regression coverage for paired and single-ended record shapes and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->