### PR TITLE
fix: use configured error rates for the consensus UMI

### DIFF
--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -80,7 +80,7 @@ use crate::caller::{
     write_consensus_read_name,
 };
 use crate::phred::{MIN_PHRED, NO_CALL_BASE, NO_CALL_BASE_LOWER, PhredScore};
-use crate::simple_umi::consensus_umis;
+use crate::simple_umi::{UmiErrorRates, consensus_umis};
 use crate::vanilla_caller::{
     VanillaConsensusRead, VanillaUmiConsensusCaller, VanillaUmiConsensusOptions,
 };
@@ -1440,6 +1440,41 @@ impl CodecConsensusCaller {
         }
     }
 
+    /// Calls the consensus UMI (RX) across every record in the MI group.
+    ///
+    /// All records are used — not just the ones that passed filtering for sequence consensus —
+    /// to match fgbio, which includes reads excluded from sequence consensus (unmapped, non-FR,
+    /// etc.) when building the UMI consensus. Their UMI bases help resolve N's at ambiguous
+    /// positions. The consensus is called with the *configured* error rates so that
+    /// `--error-rate-pre-umi` / `--error-rate-post-umi` apply to the UMI as well as the bases.
+    ///
+    /// Returns `None` when no record carries an RX tag, or the consensus came back empty.
+    fn consensus_umi(&self, all_records: &[RawRecord]) -> Option<String> {
+        let umis: Vec<String> = all_records
+            .iter()
+            .filter_map(|raw| {
+                RawRecordView::new(raw)
+                    .tags()
+                    .find_string(SamTag::RX)
+                    .and_then(|b| String::from_utf8(b.to_vec()).ok())
+            })
+            .collect();
+
+        if umis.is_empty() {
+            return None;
+        }
+
+        let consensus_umi = consensus_umis(
+            &umis,
+            UmiErrorRates {
+                pre_umi: self.options.error_rate_pre_umi,
+                post_umi: self.options.error_rate_post_umi,
+            },
+        );
+
+        (!consensus_umi.is_empty()).then_some(consensus_umi)
+    }
+
     /// Builds the output record from the consensus and writes raw bytes into `output`.
     ///
     /// # Errors
@@ -1589,25 +1624,9 @@ impl CodecConsensusCaller {
             }
         }
 
-        // RX tag (UmiBases) - extract from ALL records in the MI group and build consensus.
-        // This must use all_records (not just filtered source_raws) to match fgbio, which
-        // includes reads excluded from sequence consensus (unmapped, non-FR, etc.) when
-        // building the UMI consensus. Their UMI bases help resolve N's at ambiguous positions.
-        let umis: Vec<String> = all_records
-            .iter()
-            .filter_map(|raw| {
-                RawRecordView::new(raw)
-                    .tags()
-                    .find_string(SamTag::RX)
-                    .and_then(|b| String::from_utf8(b.to_vec()).ok())
-            })
-            .collect();
-
-        if !umis.is_empty() {
-            let consensus_umi = consensus_umis(&umis);
-            if !consensus_umi.is_empty() {
-                self.bam_builder.append_string_tag(SamTag::RX, consensus_umi.as_bytes());
-            }
+        // RX tag (UmiBases)
+        if let Some(consensus_umi) = self.consensus_umi(all_records) {
+            self.bam_builder.append_string_tag(SamTag::RX, consensus_umi.as_bytes());
         }
 
         // Write the completed record with block_size prefix
@@ -2513,6 +2532,60 @@ mod tests {
         // Check RX tag is preserved (UmiBases consensus)
         let rx = consensus.get_string_tag(SamTag::RX).expect("RX tag not found in consensus");
         assert_eq!(&rx[..], b"ACC-TGA", "RX tag should be preserved");
+    }
+
+    /// Regression for fulcrumgenomics/fgbio#1163: the CODEC consensus UMI (RX) must be called
+    /// with the *configured* pre-/post-UMI error rates, not hardcoded defaults.
+    ///
+    /// Two pairs carry UMI `A` and one carries `C`, so the group sees four `A`s and two `C`s.
+    /// A negligible post-UMI error rate calls the majority base `A`; at Q1 (~79% error) an
+    /// observed base is *less* likely than each unobserved one, so the two unobserved bases
+    /// tie and the position is a no-call.
+    #[rstest]
+    #[case::negligible_post_umi_error(93, b"A")]
+    #[case::extreme_post_umi_error(1, b"N")]
+    fn test_codec_consensus_umi_uses_configured_error_rates(
+        #[case] error_rate_post_umi: u8,
+        #[case] expected_rx: &[u8; 1],
+    ) {
+        let options = CodecConsensusOptions {
+            min_reads_per_strand: 1,
+            min_duplex_length: 1,
+            error_rate_pre_umi: 93, // no pre-UMI adjustment
+            error_rate_post_umi,
+            ..Default::default()
+        };
+        let mut caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
+
+        let mut reads = Vec::new();
+        for (name, umi) in [("read1", "A"), ("read2", "A"), ("read3", "C")] {
+            reads.extend(create_fr_pair(
+                name,
+                1,
+                11,
+                30,
+                35,
+                &[(Kind::Match, 30)],
+                &[(Kind::Match, 30)],
+                "hi",
+                Some(umi),
+                false, // R1 forward
+                true,  // R2 reverse
+            ));
+        }
+
+        let output = caller
+            .consensus_reads_from_sam_records(reads)
+            .expect("consensus_reads_from_sam_records should succeed");
+
+        assert_eq!(output.count, 1, "Should produce one consensus read");
+        let records = ParsedBamRecord::parse_all(&output.data);
+
+        assert_eq!(
+            records[0].get_string_tag(SamTag::RX).as_deref(),
+            Some(&expected_rx[..]),
+            "CODEC RX should reflect the configured post-UMI error rate"
+        );
     }
 
     /// Port of fgbio test: "make a consensus where R1 has a deletion outside of the overlap region"

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -207,7 +207,7 @@ use crate::caller::{
 };
 use crate::phred::MAX_PHRED;
 use crate::phred::{MIN_PHRED, PhredScore};
-use crate::simple_umi::consensus_umis;
+use crate::simple_umi::{UmiErrorRates, consensus_umis};
 use crate::vanilla_caller::{
     VanillaConsensusRead, VanillaUmiConsensusCaller, VanillaUmiConsensusOptions,
 };
@@ -1137,6 +1137,7 @@ impl DuplexConsensusCaller {
         methylation_mode: crate::MethylationMode,
         cell_tag: Option<Tag>,
         cell_barcode: Option<&str>,
+        umi_error_rates: UmiErrorRates,
     ) -> Result<()> {
         // Build flags
         let mut flag = flags::UNMAPPED;
@@ -1312,7 +1313,7 @@ impl DuplexConsensusCaller {
         }
 
         if !all_umis.is_empty() {
-            let consensus_umi = consensus_umis(&all_umis);
+            let consensus_umi = consensus_umis(&all_umis, umi_error_rates);
             builder.append_string_tag(SamTag::RX, consensus_umi.as_bytes());
         }
 
@@ -1803,7 +1804,7 @@ impl DuplexConsensusCaller {
 
         // Call consensus on all UMI sequences and update RX tag
         if !all_umis.is_empty() {
-            let consensus_umi = consensus_umis(&all_umis);
+            let consensus_umi = consensus_umis(&all_umis, ss_caller.umi_error_rates());
             duplex.data_mut().insert(rx_tag, Value::from(consensus_umi));
         }
 
@@ -1839,6 +1840,9 @@ impl DuplexConsensusCaller {
         let mut read_name_buf = Vec::new();
         let mut output = ConsensusOutput::default();
         let methylation_mode = ss_caller.options.methylation_mode;
+        // The consensus UMI (RX) must be called under the same error model as the consensus
+        // bases; the single-strand caller carries the configured rates.
+        let umi_error_rates = ss_caller.umi_error_rates();
 
         // Helper: move raw input records into the reject payload if rejects are being
         // tracked. Each rejection site moves `a_records`/`b_records` into the reject
@@ -2167,6 +2171,7 @@ impl DuplexConsensusCaller {
                             methylation_mode,
                             cell_tag,
                             cell_barcode.as_deref(),
+                            umi_error_rates,
                         )?;
                         Self::duplex_read_into(
                             &mut builder,
@@ -2184,6 +2189,7 @@ impl DuplexConsensusCaller {
                             methylation_mode,
                             cell_tag,
                             cell_barcode.as_deref(),
+                            umi_error_rates,
                         )?;
                         stats.record_consensus_pair();
                         return Ok((output, stats, Vec::new()));
@@ -2245,6 +2251,7 @@ impl DuplexConsensusCaller {
                             methylation_mode,
                             cell_tag,
                             cell_barcode.as_deref(),
+                            umi_error_rates,
                         )?;
                         Self::duplex_read_into(
                             &mut builder,
@@ -2262,6 +2269,7 @@ impl DuplexConsensusCaller {
                             methylation_mode,
                             cell_tag,
                             cell_barcode.as_deref(),
+                            umi_error_rates,
                         )?;
                         stats.record_consensus_pair();
                         return Ok((output, stats, Vec::new()));
@@ -2319,6 +2327,7 @@ impl DuplexConsensusCaller {
                             methylation_mode,
                             cell_tag,
                             cell_barcode.as_deref(),
+                            umi_error_rates,
                         )?;
                         Self::duplex_read_into(
                             &mut builder,
@@ -2336,6 +2345,7 @@ impl DuplexConsensusCaller {
                             methylation_mode,
                             cell_tag,
                             cell_barcode.as_deref(),
+                            umi_error_rates,
                         )?;
                         stats.record_consensus_pair();
                         return Ok((output, stats, Vec::new()));
@@ -3956,6 +3966,63 @@ mod tests {
         Ok(())
     }
 
+    /// Regression for fulcrumgenomics/fgbio#1163: the duplex consensus UMI (RX) must be called
+    /// with the *configured* pre-/post-UMI error rates, not hardcoded defaults.
+    ///
+    /// Two AB pairs carry UMI `A` and one BA pair carries `C`, so each duplex read sees UMIs
+    /// `A`, `A`, `C`. A negligible post-UMI error rate calls the majority base `A`; at Q1
+    /// (~79% error) an observed base is *less* likely than each unobserved one, so the two
+    /// unobserved bases tie and the position is a no-call.
+    #[rstest]
+    #[case::negligible_post_umi_error(93, b"A")]
+    #[case::extreme_post_umi_error(1, b"N")]
+    fn test_duplex_consensus_umi_uses_configured_error_rates(
+        #[case] error_rate_post_umi: u8,
+        #[case] expected_rx: &[u8; 1],
+    ) -> Result<()> {
+        let mut caller = DuplexConsensusCaller::new(
+            "consensus".to_string(),
+            "RG1".to_string(),
+            vec![1],
+            10,
+            false,
+            false,
+            None,
+            None,
+            false,
+            93, // error_rate_pre_umi: no pre-UMI adjustment
+            error_rate_post_umi,
+        )?;
+
+        let cigar_10m = &[encode_op(0, 10)];
+        let quals = &[20u8; 10];
+        let mut b = SamBuilder::new();
+        let rx_a: &[(SamTag, &[u8])] = &[(SamTag::RX, b"A")];
+        let rx_c: &[(SamTag, &[u8])] = &[(SamTag::RX, b"C")];
+
+        let reads = vec![
+            ab_r1(&mut b, b"q1", b"AAAAAAAAAA", quals, cigar_10m, b"foo/A", rx_a),
+            ab_r2(&mut b, b"q1", b"CCCCCCCCCC", quals, cigar_10m, b"foo/A", rx_a),
+            ab_r1(&mut b, b"q2", b"AAAAAAAAAA", quals, cigar_10m, b"foo/A", rx_a),
+            ab_r2(&mut b, b"q2", b"CCCCCCCCCC", quals, cigar_10m, b"foo/A", rx_a),
+            ba_r1(&mut b, b"q3", b"CCCCCCCCCC", quals, cigar_10m, b"foo/B", rx_c),
+            ba_r2(&mut b, b"q3", b"AAAAAAAAAA", quals, cigar_10m, b"foo/B", rx_c),
+        ];
+
+        let result = caller.consensus_reads(reads)?;
+        assert_eq!(result.count, 2, "Should produce 2 duplex consensus reads");
+
+        for rec in &ParsedBamRecord::parse_all(&result.data) {
+            assert_eq!(
+                rec.get_string_tag(SamTag::RX).as_deref(),
+                Some(&expected_rx[..]),
+                "Duplex RX should reflect the configured post-UMI error rate"
+            );
+        }
+
+        Ok(())
+    }
+
     /// Port of fgbio test: "handle absent UMI (left)"
     /// Tests the reverse case where left UMI is absent in A family
     #[test]
@@ -4659,6 +4726,7 @@ mod tests {
             crate::MethylationMode::Disabled,
             None,
             None,
+            UmiErrorRates::default(),
         )
         .expect("write_duplex_consensus_record should succeed");
 
@@ -5063,6 +5131,7 @@ mod tests {
             crate::MethylationMode::Disabled,
             Some(cell_tag),
             Some(cell_barcode),
+            UmiErrorRates::default(),
         )
         .expect("write_duplex_consensus_record should succeed");
 
@@ -5117,6 +5186,7 @@ mod tests {
             crate::MethylationMode::Disabled,
             None,
             None,
+            UmiErrorRates::default(),
         )
         .expect("write_duplex_consensus_record should succeed");
 
@@ -5251,6 +5321,7 @@ mod tests {
             crate::MethylationMode::Disabled,
             None,
             None,
+            UmiErrorRates::default(),
         )
         .expect("write_duplex_consensus_record should succeed");
 
@@ -5327,6 +5398,7 @@ mod tests {
             crate::MethylationMode::Disabled,
             None,
             None,
+            UmiErrorRates::default(),
         )
         .expect("duplex_read_into should succeed");
 
@@ -5400,6 +5472,7 @@ mod tests {
             crate::MethylationMode::Disabled,
             None,
             None,
+            UmiErrorRates::default(),
         )
         .expect("duplex_read_into should succeed");
 
@@ -5511,6 +5584,7 @@ mod tests {
             crate::MethylationMode::Disabled,
             None,
             None,
+            UmiErrorRates::default(),
         )
         .expect("write_duplex_consensus_record should succeed");
 
@@ -5574,6 +5648,7 @@ mod tests {
                 crate::MethylationMode::Disabled,
                 None,
                 None,
+                UmiErrorRates::default(),
             )
             .expect("write_duplex_consensus_record should succeed");
             let records = ParsedBamRecord::parse_all(&output.data);
@@ -6409,6 +6484,7 @@ mod tests {
             crate::MethylationMode::EmSeq,
             None,
             None,
+            UmiErrorRates::default(),
         )
         .unwrap();
 

--- a/crates/fgumi-consensus/src/simple_umi.rs
+++ b/crates/fgumi-consensus/src/simple_umi.rs
@@ -18,6 +18,24 @@ const DEFAULT_ERROR_RATE_POST: u8 = 90;
 /// Default quality score for observations (Q20)
 const DEFAULT_Q_ERROR: u8 = 20;
 
+/// The Phred-scaled error rates a consensus caller was configured with.
+///
+/// Both rates are plain `u8`s, so passing them as separate arguments makes them trivially
+/// swappable at a call site; bundling them keeps `pre` and `post` attached to their names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UmiErrorRates {
+    /// Phred-scaled error rate prior to UMI labeling
+    pub pre_umi: u8,
+    /// Phred-scaled error rate after UMI labeling
+    pub post_umi: u8,
+}
+
+impl Default for UmiErrorRates {
+    fn default() -> Self {
+        Self { pre_umi: DEFAULT_ERROR_RATE_PRE, post_umi: DEFAULT_ERROR_RATE_POST }
+    }
+}
+
 /// Simple consensus caller for UMI sequences.
 ///
 /// Uses position-by-position likelihood-based consensus calling, matching
@@ -143,10 +161,19 @@ pub struct SimpleUmiConsensusCaller {
 }
 
 impl SimpleUmiConsensusCaller {
-    /// Creates a new simple UMI consensus caller
+    /// Creates a new simple UMI consensus caller using the given error rates.
+    ///
+    /// Callers should pass the rates configured on the command line so that the consensus UMI
+    /// derived here is called the same way as the one written to a consensus BAM.
     #[must_use]
-    pub fn new() -> Self {
-        Self { caller: SimpleConsensusCaller::default() }
+    pub fn new(error_rates: UmiErrorRates) -> Self {
+        Self {
+            caller: SimpleConsensusCaller::new(
+                error_rates.pre_umi,
+                error_rates.post_umi,
+                DEFAULT_Q_ERROR,
+            ),
+        }
     }
 
     /// Calls consensus on a list of UMIs, returning the consensus UMI and whether errors were corrected.
@@ -218,7 +245,7 @@ impl SimpleUmiConsensusCaller {
 
 impl Default for SimpleUmiConsensusCaller {
     fn default() -> Self {
-        Self::new()
+        Self::new(UmiErrorRates::default())
     }
 }
 
@@ -227,20 +254,26 @@ impl Default for SimpleUmiConsensusCaller {
 /// This is the single shared function for UMI consensus calling across all
 /// consensus callers (Vanilla, Duplex, CODEC), matching fgbio's behavior.
 ///
+/// The caller's configured error rates must be passed in so that the consensus UMI is called
+/// under the same error model as the consensus bases themselves; using the defaults here would
+/// silently ignore `--error-rate-pre-umi` / `--error-rate-post-umi`.
+///
 /// # Arguments
 /// * `umis` - Slice of UMI strings observed in a family
+/// * `error_rates` - The caller's configured pre-/post-UMI error rates
 ///
 /// # Returns
 /// The consensus UMI string, or empty string if input is empty
 #[must_use]
-pub fn consensus_umis(umis: &[String]) -> String {
+pub fn consensus_umis(umis: &[String], error_rates: UmiErrorRates) -> String {
     if umis.is_empty() {
         return String::new();
     }
     if umis.len() == 1 {
         return umis[0].clone();
     }
-    let mut caller = SimpleConsensusCaller::default();
+    let mut caller =
+        SimpleConsensusCaller::new(error_rates.pre_umi, error_rates.post_umi, DEFAULT_Q_ERROR);
     caller.call_consensus(umis)
 }
 

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -13,7 +13,7 @@ use crate::phred::{
     MIN_PHRED, NO_CALL_BASE, NO_CALL_BASE_LOWER, PhredScore, ln_error_prob_two_trials,
     ln_prob_to_phred, phred_to_ln_error_prob,
 };
-use crate::simple_umi::consensus_umis;
+use crate::simple_umi::{UmiErrorRates, consensus_umis};
 use anyhow::{Context, Result, anyhow, bail};
 use fgumi_dna::dna::reverse_complement;
 use fgumi_raw_bam::hash::fgbio_read_name_rank;
@@ -406,6 +406,15 @@ pub struct VanillaUmiConsensusCaller {
     reason = "consensus calling uses numeric casts for quality/position math"
 )]
 impl VanillaUmiConsensusCaller {
+    /// Returns the configured pre-/post-UMI error rates, for calling the consensus UMI (RX).
+    #[must_use]
+    pub fn umi_error_rates(&self) -> UmiErrorRates {
+        UmiErrorRates {
+            pre_umi: self.options.error_rate_pre_umi,
+            post_umi: self.options.error_rate_post_umi,
+        }
+    }
+
     /// Creates a new vanilla consensus caller
     ///
     /// # Arguments
@@ -1622,7 +1631,7 @@ impl VanillaUmiConsensusCaller {
             .collect();
 
         if !umis.is_empty() {
-            let consensus_umi = consensus_umis(&umis);
+            let consensus_umi = consensus_umis(&umis, self.umi_error_rates());
             self.bam_builder.append_string_tag(SamTag::RX, consensus_umi.as_bytes());
         }
 
@@ -1732,6 +1741,7 @@ pub(crate) enum ReadType {
 )]
 mod tests {
     use super::*;
+    use crate::phred::MAX_PHRED;
     use fgumi_raw_bam::{
         ParsedBamRecord, SamBuilder, encode_op, num_bases_extending_past_mate_raw,
     };
@@ -4830,6 +4840,65 @@ mod tests {
             consensus_rx,
             Some(b"TNT".to_vec()),
             "Consensus RX should be TNT (from filtered reads TTT and TAT)"
+        );
+    }
+
+    /// Port of fgbio test (fulcrumgenomics/fgbio#1163): the consensus UMI (RX) must be called
+    /// with the *configured* pre-/post-UMI error rates, not hardcoded defaults.
+    ///
+    /// With UMIs `A`, `A`, `C` a negligible post-UMI error rate calls the majority base `A`.
+    /// A post-UMI error rate of Q1 (~79% error) makes an observed base *less* likely than each
+    /// unobserved one, so the two unobserved bases (G, T) tie for the maximum likelihood and the
+    /// position is a no-call. The two cases therefore differ only if the configured rate is used.
+    #[rstest]
+    #[case::negligible_post_umi_error(MAX_PHRED, b"A")]
+    #[case::extreme_post_umi_error(1, b"N")]
+    fn test_consensus_umi_uses_configured_error_rates(
+        #[case] error_rate_post_umi: PhredScore,
+        #[case] expected_rx: &[u8; 1],
+    ) {
+        let len = 10;
+        let bases = vec![b'A'; len];
+        let quals = vec![30u8; len];
+
+        let reads: Vec<_> = [(b"READ0", &b"A"[..]), (b"READ1", &b"A"[..]), (b"READ2", &b"C"[..])]
+            .iter()
+            .map(|(name, umi)| {
+                let mut b = SamBuilder::new();
+                b.read_name(*name)
+                    .ref_id(0)
+                    .pos(0)
+                    .sequence(&bases)
+                    .qualities(&quals)
+                    .cigar_ops(&[encode_op(0, len)])
+                    .add_string_tag(SamTag::MI, b"AAA")
+                    .add_string_tag(SamTag::RX, umi);
+                b.build()
+            })
+            .collect();
+
+        let options = VanillaUmiConsensusOptions {
+            min_reads: 1,
+            min_input_base_quality: 2,
+            min_consensus_base_quality: 0,
+            error_rate_pre_umi: MAX_PHRED,
+            error_rate_post_umi,
+            ..VanillaUmiConsensusOptions::default()
+        };
+
+        let mut caller =
+            VanillaUmiConsensusCaller::new("c".to_string(), "AAA".to_string(), options);
+
+        let output =
+            consensus_reads_from_raw(&mut caller, reads).expect("consensus should succeed");
+
+        assert_eq!(output.count, 1, "Should produce 1 consensus");
+        let records = ParsedBamRecord::parse_all(&output.data);
+
+        assert_eq!(
+            records[0].get_string_tag(SamTag::RX),
+            Some(expected_rx.to_vec()),
+            "Consensus RX should reflect the configured post-UMI error rate"
         );
     }
 

--- a/crates/xtask/src/check_tag_literals.rs
+++ b/crates/xtask/src/check_tag_literals.rs
@@ -17,7 +17,7 @@
 //! * **Payload allowlist** — specific 2-byte sequences that are known-good across the
 //!   rest of the codebase because they are not SAM aux-tag identifiers:
 //!   - SAM header sub-fields (`SO`, `GO`, `SS`) accepted by the noodles header API.
-//!   - Read-name fixtures (`q1`, `q2`, `r0`–`r4`, `rd`).
+//!   - Read-name fixtures (`q1`–`q3`, `r0`–`r4`, `rd`).
 //!   - 2-bp DNA sequence fragments (`AA`, `AC`, `AT`, …) used in sequence tests.
 //!   - Opaque test-fixture tag names (`XA`–`XY`, `x0`–`x9`, `ZZ`, `Zz`, …) used to
 //!     exercise SAM/BAM parsers without carrying semantic meaning.
@@ -65,7 +65,7 @@ const DIR_ALLOWLIST: &[&str] = &[
 const PAYLOAD_ALLOWLIST: &[&[u8; 2]] = &[
     // ---- SAM header sub-fields (noodles `other_fields` map key convention) ----
     b"SO", b"GO", b"SS", // ---- Read-name fixtures ----
-    b"q1", b"q2", b"r0", b"r1", b"r2", b"r3", b"r4", b"rd",
+    b"q1", b"q2", b"q3", b"r0", b"r1", b"r2", b"r3", b"r4", b"rd",
     // ---- 2-bp DNA sequence fragments used in sequence/UMI tests ----
     b"AA", b"AC", b"AG", b"AT", b"CA", b"CC", b"CG", b"GA", b"GC", b"GT", b"NN", b"TA", b"TC",
     b"TT",

--- a/src/lib/commands/duplex_metrics.rs
+++ b/src/lib/commands/duplex_metrics.rs
@@ -8,11 +8,12 @@
 
 use crate::logging::OperationTimer;
 use crate::metrics::duplex::{DuplexMetricsCollector, DuplexYieldMetric, FamilySizeMetric};
-use crate::simple_umi_consensus::SimpleUmiConsensusCaller;
+use crate::simple_umi_consensus::{SimpleUmiConsensusCaller, UmiErrorRates};
 use crate::umi::extract_mi_base;
 use crate::validation::validate_input_exists;
 use anyhow::Result;
 use clap::Parser;
+use fgumi_consensus::phred::MAX_PHRED;
 use log::info;
 use statrs::distribution::{Binomial, DiscreteCDF};
 use std::path::PathBuf;
@@ -104,6 +105,14 @@ pub struct DuplexMetrics {
     #[arg(long = "duplex-umi-counts", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub duplex_umi_counts: bool,
 
+    /// Phred-scaled error rate prior to UMI integration, used when calling the consensus UMI
+    #[arg(short = '1', long = "error-rate-pre-umi", default_value = "45")]
+    pub error_rate_pre_umi: u8,
+
+    /// Phred-scaled error rate post UMI integration, used when calling the consensus UMI
+    #[arg(short = '2', long = "error-rate-post-umi", default_value = "40")]
+    pub error_rate_post_umi: u8,
+
     /// Optional intervals file to restrict analysis (BED or Picard interval list format)
     #[arg(short = 'l', long = "intervals")]
     pub intervals: Option<PathBuf>,
@@ -143,6 +152,21 @@ impl Command for DuplexMetrics {
             );
         }
 
+        // The consensus UMI is called with these rates, so apply the same bounds the consensus
+        // commands do: a Phred score of 0 is not a meaningful prior, and MAX_PHRED is the top of
+        // the lookup tables.
+        for (name, value) in [
+            ("error-rate-pre-umi", self.error_rate_pre_umi),
+            ("error-rate-post-umi", self.error_rate_post_umi),
+        ] {
+            if value == 0 {
+                anyhow::bail!("--{name} must be > 0");
+            }
+            if value > MAX_PHRED {
+                anyhow::bail!("--{name} ({value}) exceeds maximum Phred score ({MAX_PHRED})");
+            }
+        }
+
         // Load intervals if provided
         let intervals = if let Some(intervals_path) = &self.intervals {
             info!("  Loading intervals from: {}", intervals_path.display());
@@ -165,7 +189,10 @@ impl Command for DuplexMetrics {
             })
             .collect();
 
-        let mut umi_consensus_caller = SimpleUmiConsensusCaller::default();
+        let mut umi_consensus_caller = SimpleUmiConsensusCaller::new(UmiErrorRates {
+            pre_umi: self.error_rate_pre_umi,
+            post_umi: self.error_rate_post_umi,
+        });
 
         info!("Processing templates in single pass at {} sampling fractions...", fractions.len());
 
@@ -801,6 +828,8 @@ mod tests {
             min_ab_reads: 0,
             min_ba_reads: 0,
             duplex_umi_counts: false,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -836,6 +865,8 @@ mod tests {
             min_ab_reads: 1,
             min_ba_reads: 1,
             duplex_umi_counts: false,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -915,6 +946,8 @@ mod tests {
             min_ab_reads: 1,
             min_ba_reads: 0,
             duplex_umi_counts: false,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -961,6 +994,8 @@ mod tests {
             min_ab_reads: 1,
             min_ba_reads: 0,
             duplex_umi_counts: false,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -999,6 +1034,8 @@ mod tests {
             min_ab_reads: 1,
             min_ba_reads: 0,
             duplex_umi_counts: false,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -1040,6 +1077,8 @@ mod tests {
             min_ab_reads: 1,
             min_ba_reads: 1,
             duplex_umi_counts: false,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -1101,6 +1140,8 @@ mod tests {
             min_ab_reads: 1,
             min_ba_reads: 1,
             duplex_umi_counts: true,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -1139,6 +1180,108 @@ mod tests {
         Ok(())
     }
 
+    /// Regression for fulcrumgenomics/fgbio#1163: the consensus UMI this tool derives for its
+    /// metrics must be called with the *configured* pre-/post-UMI error rates, matching how the
+    /// consensus BAM's `RX` tag is called, rather than hardcoded defaults.
+    ///
+    /// The family below observes each UMI position five-to-one. A normal post-UMI error rate
+    /// calls the majority base, so metrics are keyed on `AAA`/`TTT`. At Q1 (~79% error) an
+    /// observed base is *less* likely than each of the three unobserved ones, so every position
+    /// no-calls — even the unanimous ones — and both UMIs collapse to a single `NNN` key.
+    #[rstest]
+    #[case::normal_post_umi_error(40, &["AAA", "TTT"])]
+    #[case::extreme_post_umi_error(1, &["NNN"])]
+    fn test_umi_consensus_uses_configured_error_rates(
+        #[case] error_rate_post_umi: u8,
+        #[case] expected_umis: &[&str],
+    ) -> Result<()> {
+        let mut records = Vec::new();
+
+        // A strand: AAA-TTT (2 exact + 1 with 1 error: CAA-TTT)
+        for i in 1..=3 {
+            let umi = if i == 3 { "CAA-TTT" } else { "AAA-TTT" };
+            let (r1, r2) = build_test_pair(&format!("a{i}"), 0, 100, 200, umi, "1/A", true, false);
+            records.push(r1);
+            records.push(r2);
+        }
+
+        // B strand: TTT-AAA (2 exact + 1 with 1 error: CTT-AAA)
+        for i in 1..=3 {
+            let umi = if i == 3 { "CTT-AAA" } else { "TTT-AAA" };
+            let (r1, r2) = build_test_pair(&format!("b{i}"), 0, 200, 100, umi, "1/B", false, true);
+            records.push(r1);
+            records.push(r2);
+        }
+
+        let input = create_test_bam(records)?;
+        let output_dir = TempDir::new()?;
+        let output = output_dir.path().join("output");
+
+        let cmd = DuplexMetrics {
+            input: input.path().to_path_buf(),
+            output: output.clone(),
+            min_ab_reads: 1,
+            min_ba_reads: 1,
+            duplex_umi_counts: false,
+            error_rate_pre_umi: 93, // no pre-UMI adjustment
+            error_rate_post_umi,
+            intervals: None,
+            description: None,
+        };
+
+        cmd.execute("test")?;
+
+        let umi_path = format!("{}.umi_counts.txt", output.display());
+        let umi_metrics: Vec<UmiMetric> = DelimFile::default().read_tsv(&umi_path)?;
+
+        let mut umis: Vec<&str> = umi_metrics.iter().map(|m| m.umi.as_str()).collect();
+        umis.sort_unstable();
+
+        assert_eq!(
+            umis, expected_umis,
+            "consensus UMIs should reflect the configured post-UMI error rate"
+        );
+
+        Ok(())
+    }
+
+    /// A Phred-scaled error rate of 0 means "always wrong", which is not a meaningful prior;
+    /// fgbio rejects it, and anything above `MAX_PHRED` is out of range for the lookup tables.
+    #[rstest]
+    #[case::pre_umi_zero(0, 40, "error-rate-pre-umi")]
+    #[case::post_umi_zero(45, 0, "error-rate-post-umi")]
+    #[case::pre_umi_too_high(94, 40, "error-rate-pre-umi")]
+    #[case::post_umi_too_high(45, 94, "error-rate-post-umi")]
+    fn test_invalid_error_rates_are_rejected(
+        #[case] error_rate_pre_umi: u8,
+        #[case] error_rate_post_umi: u8,
+        #[case] expected_message: &str,
+    ) -> Result<()> {
+        let (r1, r2) = build_test_pair("a1", 0, 100, 200, "AAA-TTT", "1/A", true, false);
+        let input = create_test_bam(vec![r1, r2])?;
+        let output_dir = TempDir::new()?;
+
+        let cmd = DuplexMetrics {
+            input: input.path().to_path_buf(),
+            output: output_dir.path().join("output"),
+            min_ab_reads: 1,
+            min_ba_reads: 1,
+            duplex_umi_counts: false,
+            error_rate_pre_umi,
+            error_rate_post_umi,
+            intervals: None,
+            description: None,
+        };
+
+        let err = cmd.execute("test").expect_err("invalid error rate should be rejected");
+        assert!(
+            err.to_string().contains(expected_message),
+            "error should name the offending option, got: {err}"
+        );
+
+        Ok(())
+    }
+
     /// DXM-03: a malformed duplex UMI whose `RX` is not exactly two `-`-delimited
     /// segments (e.g. no dash) must be rejected with a clear error, matching fgbio
     /// (`split("-", -1)` + `case Array(u1, u2)` throws a `MatchError`) and fgumi's own
@@ -1162,6 +1305,8 @@ mod tests {
             min_ab_reads: 1,
             min_ba_reads: 1,
             duplex_umi_counts: false,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -1206,6 +1351,8 @@ mod tests {
             min_ab_reads: 1,
             min_ba_reads: 1,
             duplex_umi_counts: true,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -1267,6 +1414,8 @@ mod tests {
             min_ab_reads: 1,
             min_ba_reads: 1,
             duplex_umi_counts: false,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -1371,6 +1520,8 @@ mod tests {
             min_ab_reads: 1,
             min_ba_reads: 1,
             duplex_umi_counts: false,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -1497,6 +1648,8 @@ mod tests {
             min_ab_reads: 1,
             min_ba_reads: 1,
             duplex_umi_counts: false,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -1590,6 +1743,8 @@ mod tests {
                 min_ab_reads: 1,
                 min_ba_reads: 1,
                 duplex_umi_counts: false,
+                error_rate_pre_umi: 45,
+                error_rate_post_umi: 40,
                 intervals: None,
                 description: None,
             };
@@ -1617,6 +1772,8 @@ mod tests {
                 min_ab_reads: 2,
                 min_ba_reads: 1,
                 duplex_umi_counts: false,
+                error_rate_pre_umi: 45,
+                error_rate_post_umi: 40,
                 intervals: None,
                 description: None,
             };
@@ -1644,6 +1801,8 @@ mod tests {
                 min_ab_reads: 2,
                 min_ba_reads: 2,
                 duplex_umi_counts: false,
+                error_rate_pre_umi: 45,
+                error_rate_post_umi: 40,
                 intervals: None,
                 description: None,
             };
@@ -1768,6 +1927,8 @@ mod tests {
             min_ab_reads: 1,
             min_ba_reads: 1,
             duplex_umi_counts: false,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: Some(intervals_path),
             description: None,
         };
@@ -1827,6 +1988,8 @@ mod tests {
             min_ab_reads: 1,
             min_ba_reads: 1,
             duplex_umi_counts: false,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -2063,6 +2226,8 @@ mod tests {
             min_ab_reads: 1,
             min_ba_reads: 1,
             duplex_umi_counts: false,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -2098,6 +2263,8 @@ mod tests {
             min_ab_reads: 1,
             min_ba_reads: 1,
             duplex_umi_counts: false,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -2117,6 +2284,8 @@ mod tests {
             min_ab_reads: 3,
             min_ba_reads: 2,
             duplex_umi_counts: true,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: Some(PathBuf::from("intervals.bed")),
             description: Some("Test Sample".to_string()),
         };
@@ -2135,6 +2304,8 @@ mod tests {
             min_ab_reads: 1,
             min_ba_reads: 2, // Invalid: BA > AB
             duplex_umi_counts: false,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -2368,6 +2539,8 @@ mod tests {
             min_ab_reads: 1,
             min_ba_reads: 1,
             duplex_umi_counts: false,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: Some(intervals_path),
             description: None,
         };
@@ -2454,6 +2627,8 @@ mod tests {
             min_ab_reads: 1,
             min_ba_reads: 1,
             duplex_umi_counts: false,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };

--- a/src/lib/commands/simplex_metrics.rs
+++ b/src/lib/commands/simplex_metrics.rs
@@ -9,10 +9,11 @@
 
 use crate::logging::OperationTimer;
 use crate::metrics::simplex::{SimplexMetricsCollector, SimplexYieldMetric};
-use crate::simple_umi_consensus::SimpleUmiConsensusCaller;
+use crate::simple_umi_consensus::{SimpleUmiConsensusCaller, UmiErrorRates};
 use crate::validation::validate_input_exists;
 use anyhow::Result;
 use clap::Parser;
+use fgumi_consensus::phred::MAX_PHRED;
 use log::info;
 use std::path::PathBuf;
 
@@ -77,6 +78,14 @@ pub struct SimplexMetrics {
     #[arg(long = "min-reads", default_value = "1")]
     pub min_reads: usize,
 
+    /// Phred-scaled error rate prior to UMI integration, used when calling the consensus UMI
+    #[arg(short = '1', long = "error-rate-pre-umi", default_value = "45")]
+    pub error_rate_pre_umi: u8,
+
+    /// Phred-scaled error rate post UMI integration, used when calling the consensus UMI
+    #[arg(short = '2', long = "error-rate-post-umi", default_value = "40")]
+    pub error_rate_post_umi: u8,
+
     /// Optional intervals file to restrict analysis. Both BED and Picard interval-list formats are
     /// auto-detected (an fgumi superset; fgbio's duplex analog accepts only the Picard interval list).
     #[arg(short = 'l', long = "intervals")]
@@ -107,6 +116,21 @@ impl Command for SimplexMetrics {
             anyhow::bail!("--min-reads must be >= 1 (got {})", self.min_reads);
         }
 
+        // The consensus UMI is called with these rates, so apply the same bounds the consensus
+        // commands do: a Phred score of 0 is not a meaningful prior, and MAX_PHRED is the top of
+        // the lookup tables.
+        for (name, value) in [
+            ("error-rate-pre-umi", self.error_rate_pre_umi),
+            ("error-rate-post-umi", self.error_rate_post_umi),
+        ] {
+            if value == 0 {
+                anyhow::bail!("--{name} must be > 0");
+            }
+            if value > MAX_PHRED {
+                anyhow::bail!("--{name} ({value}) exceeds maximum Phred score ({MAX_PHRED})");
+            }
+        }
+
         // Load intervals if provided
         let intervals = if let Some(intervals_path) = &self.intervals {
             info!("  Loading intervals from: {}", intervals_path.display());
@@ -123,7 +147,10 @@ impl Command for SimplexMetrics {
         let mut collectors: Vec<SimplexMetricsCollector> =
             fractions.iter().map(|_| SimplexMetricsCollector::new()).collect();
 
-        let mut umi_consensus_caller = SimpleUmiConsensusCaller::default();
+        let mut umi_consensus_caller = SimpleUmiConsensusCaller::new(UmiErrorRates {
+            pre_umi: self.error_rate_pre_umi,
+            post_umi: self.error_rate_post_umi,
+        });
 
         info!("Processing templates in single pass at {} sampling fractions...", fractions.len());
 
@@ -536,6 +563,8 @@ mod tests {
             input: input.path().to_path_buf(),
             output: output_dir.path().join("output"),
             min_reads: 0,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -567,6 +596,8 @@ mod tests {
             input: input.path().to_path_buf(),
             output,
             min_reads: 1,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -660,6 +691,8 @@ mod tests {
             input: input.path().to_path_buf(),
             output: output.clone(),
             min_reads: 1,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -728,6 +761,8 @@ mod tests {
             input: input.path().to_path_buf(),
             output: output.clone(),
             min_reads: 1,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -756,6 +791,94 @@ mod tests {
         Ok(())
     }
 
+    /// Regression for fulcrumgenomics/fgbio#1163: the consensus UMI this tool derives for its
+    /// metrics must be called with the *configured* pre-/post-UMI error rates rather than
+    /// hardcoded defaults, matching `duplex-metrics` and the consensus commands.
+    ///
+    /// The family below observes each UMI position two-to-one. A normal post-UMI error rate calls
+    /// the majority base, so metrics are keyed on `AAA`/`TTT`. At Q1 (~79% error) an observed base
+    /// is *less* likely than each of the three unobserved ones, so every position no-calls — even
+    /// the unanimous ones — and both UMIs collapse to a single `NNN` key.
+    #[rstest]
+    #[case::normal_post_umi_error(40, &["AAA", "TTT"])]
+    #[case::extreme_post_umi_error(1, &["NNN"])]
+    fn test_umi_consensus_uses_configured_error_rates(
+        #[case] error_rate_post_umi: u8,
+        #[case] expected_umis: &[&str],
+    ) -> Result<()> {
+        let mut records = Vec::new();
+
+        // One family whose UMIs disagree two-to-one at the first position of each half.
+        for (i, umi) in ["AAA-TTT", "AAA-TTT", "CAA-CTT"].iter().enumerate() {
+            let (r1, r2) = build_test_pair(&format!("q{i}"), 0, 100, 200, umi, "1/A");
+            records.push(r1);
+            records.push(r2);
+        }
+
+        let input = create_test_bam(records)?;
+        let output_dir = TempDir::new()?;
+        let output = output_dir.path().join("output");
+
+        let cmd = SimplexMetrics {
+            input: input.path().to_path_buf(),
+            output: output.clone(),
+            min_reads: 1,
+            error_rate_pre_umi: 93, // no pre-UMI adjustment
+            error_rate_post_umi,
+            intervals: None,
+            description: None,
+        };
+        cmd.execute("test")?;
+
+        let umi_path = format!("{}.umi_counts.txt", output.display());
+        let umi_metrics: Vec<UmiMetric> = DelimFile::default().read_tsv(&umi_path)?;
+
+        let mut umis: Vec<&str> = umi_metrics.iter().map(|m| m.umi.as_str()).collect();
+        umis.sort_unstable();
+
+        assert_eq!(
+            umis, expected_umis,
+            "consensus UMIs should reflect the configured post-UMI error rate"
+        );
+
+        Ok(())
+    }
+
+    /// A Phred-scaled error rate of 0 means "always wrong", which is not a meaningful prior;
+    /// fgbio rejects it, and anything above `MAX_PHRED` is out of range for the lookup tables.
+    #[rstest]
+    #[case::pre_umi_zero(0, 40, "error-rate-pre-umi")]
+    #[case::post_umi_zero(45, 0, "error-rate-post-umi")]
+    #[case::pre_umi_too_high(94, 40, "error-rate-pre-umi")]
+    #[case::post_umi_too_high(45, 94, "error-rate-post-umi")]
+    fn test_invalid_error_rates_are_rejected(
+        #[case] error_rate_pre_umi: u8,
+        #[case] error_rate_post_umi: u8,
+        #[case] expected_message: &str,
+    ) -> Result<()> {
+        let (r1, r2) = build_test_pair("q1", 0, 100, 200, "AAA-TTT", "1/A");
+        let input = create_test_bam(vec![r1, r2])?;
+        let output_dir = TempDir::new()?;
+
+        let cmd = SimplexMetrics {
+            input: input.path().to_path_buf(),
+            output: output_dir.path().join("output"),
+            min_reads: 1,
+            error_rate_pre_umi,
+            error_rate_post_umi,
+            intervals: None,
+            description: None,
+        };
+
+        let err = cmd.execute("test").expect_err("invalid error rate should be rejected");
+        assert!(
+            err.to_string().contains(expected_message),
+            "error should name the offending option, got: {err}"
+        );
+
+        Ok(())
+    }
+
     #[test]
     fn test_downsampling_generates_multiple_fractions() -> Result<()> {
         let mut records = Vec::new();
@@ -776,6 +899,8 @@ mod tests {
             input: input.path().to_path_buf(),
             output: output.clone(),
             min_reads: 1,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };
@@ -800,6 +925,8 @@ mod tests {
             input: PathBuf::from("test.bam"),
             output: PathBuf::from("output"),
             min_reads: 1,
+            error_rate_pre_umi: 45,
+            error_rate_post_umi: 40,
             intervals: None,
             description: None,
         };


### PR DESCRIPTION
> [!IMPORTANT]
> **Do not merge until [fulcrumgenomics/fgbio#1163](https://github.com/fulcrumgenomics/fgbio/pull/1163) merges.** This is a port of that PR, so it should track whatever that review lands on — if the upstream approach changes (option names, defaults, whether the metrics tools get the options at all), this PR changes with it. Held as a draft until then.

## Summary

Port of [fulcrumgenomics/fgbio#1163](https://github.com/fulcrumgenomics/fgbio/pull/1163) — fgumi had the same bug.

The consensus UMI written to the `RX` tag was called with `SimpleConsensusCaller`'s hardcoded 90/90 error rates rather than the configured `--error-rate-pre-umi` / `--error-rate-post-umi`, so neither option had any effect on the `RX` tag emitted by `simplex`, `duplex`, or `codec`. The per-base consensus itself was always correct — `ConsensusBaseBuilder::new(options.error_rate_pre_umi, options.error_rate_post_umi)` threads them properly; only the UMI consensus was disconnected.

Following the same PR, `duplex-metrics` and `simplex-metrics` gain `-1/--error-rate-pre-umi` and `-2/--error-rate-post-umi` (matching the flags, defaults, and validation of the consensus commands) so the consensus UMI they key their counts on is calculated the same way as the one written to a consensus BAM. `simplex-metrics` has no fgbio counterpart but had the identical hardcoded default, so it gets the same treatment for consistency.

## Behavior change

The metrics tools' UMI consensus moves from 90/90 to the 45/40 defaults. The bases called are unchanged in practice — at `qError=20` the per-observation quality dominates the likelihood at both settings — but it is a real change to the effective prior and worth noting.

## Reading order

1. `crates/fgumi-consensus/src/simple_umi.rs` — `consensus_umis()` takes a `UmiErrorRates` pair instead of using the defaults. The rates travel bundled rather than as two loose `u8` arguments, which would be trivially swappable at the four call sites.
2. `vanilla_caller.rs`, `duplex_caller.rs`, `codec_caller.rs` — the call sites. The duplex caller reuses the rates its single-strand caller was built with; the CODEC `RX` block moves into a `consensus_umi()` helper to keep `build_output_record_into()` under the line limit.
3. `src/lib/commands/{duplex,simplex}_metrics.rs` — the new options.

Both commits compile and test standalone, so the branch is bisectable.

## Testing

Six new `#[rstest]` case tables, each written and watched failing before the corresponding fix:

| Path | Normal rate | Post-UMI Q1 |
| --- | --- | --- |
| vanilla / duplex / CODEC `RX` | `A` | `N` |
| `duplex-metrics`, `simplex-metrics` `umi_counts` | `AAA`, `TTT` | `NNN` |

The mechanism, mirroring fgbio's regression test: at Q1 (~79% error) an observed base becomes *less* likely than each of the three unobserved ones, so the unobserved bases tie for the maximum likelihood and the position no-calls. With a multi-base UMI that collapses every position, not just the disagreeing one — hence the single `NNN` key in the metrics cases.

Plus a 4-case validation table per metrics tool covering `0` and `94` for each rate.

`cargo ci-test` (5723 passed / 0 failed), `cargo ci-fmt`, and `cargo ci-lint` all clean.

One unrelated adjustment: the `check-tag-literals` xtask flagged the new `b"q3"` read-name fixture as a bare SAM-tag byte literal, so it is allowlisted next to the existing `q1`/`q2`.

