### PR TITLE
test(sort): fix flaky active_worker_limit_caps_then_reactivates

### DIFF
--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -2231,6 +2231,7 @@ fn dispatch_reserved_blocks(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     /// Build `n` distinguishable placeholder blocks.
     fn dummy_blocks(n: usize) -> Vec<RawBgzfBlock> {
@@ -2523,7 +2524,12 @@ mod tests {
 
         // Run one batch on `pool` (moved in, returned out so the next batch can
         // reuse it) and report the cumulative per-worker CompressSpill counts.
-        let run_batch = |pool: SortWorkerPool, num_jobs: usize| -> (SortWorkerPool, Vec<u64>) {
+        // `cumulative_jobs` is the total submitted across all batches so far —
+        // the counters are cumulative, so it is what they must settle at.
+        let run_batch = |pool: SortWorkerPool,
+                         num_jobs: usize,
+                         cumulative_jobs: u64|
+         -> (SortWorkerPool, Vec<u64>) {
             let (result_tx, result_rx) = pool.compress_result_channel();
             let submit_tx = result_tx.clone();
             let submit_handle = std::thread::spawn(move || {
@@ -2545,9 +2551,34 @@ mod tests {
             }
             assert_eq!(received, num_jobs);
             let pool = submit_handle.join().expect("submit thread should not panic");
-            let counts: Vec<u64> = (0..6)
-                .map(|t| pool.pipeline_stats.per_thread_step_counts[t][cs].load(Ordering::Relaxed))
-                .collect();
+
+            // A worker sends the job's result — and drops the job, closing its
+            // sender — inside `execute_step`, and only records the step counter
+            // after `execute_step` returns. So draining the result channel does
+            // NOT imply the counters are up to date: the last worker can still
+            // be between the send and the increment. Wait for the counters to
+            // settle instead of reading a value that is still in flight.
+            let read_counts = || -> Vec<u64> {
+                (0..6)
+                    .map(|t| {
+                        pool.pipeline_stats.per_thread_step_counts[t][cs].load(Ordering::Relaxed)
+                    })
+                    .collect()
+            };
+            let deadline = Instant::now() + Duration::from_secs(30);
+            let counts = loop {
+                let counts = read_counts();
+                if counts.iter().sum::<u64>() >= cumulative_jobs {
+                    break counts;
+                }
+                assert!(
+                    Instant::now() < deadline,
+                    "timed out waiting for step counters to reach {cumulative_jobs}; \
+                     per-worker counts {counts:?}"
+                );
+                std::thread::sleep(Duration::from_micros(50));
+            };
+
             (pool, counts)
         };
 
@@ -2555,7 +2586,7 @@ mod tests {
 
         // Batch 1: capped at 2 — only workers 0..2 may run.
         pool.set_active_workers(2);
-        let (pool, after_capped) = run_batch(pool, 300);
+        let (pool, after_capped) = run_batch(pool, 300, 300);
         assert!(
             after_capped.iter().filter(|&&c| c > 0).count() <= 2,
             "cap=2 must bound active workers; per-worker counts {after_capped:?}"
@@ -2568,7 +2599,7 @@ mod tests {
 
         // Batch 2: raise the cap on the SAME pool and run again.
         pool.set_active_workers(6);
-        let (pool, after_full) = run_batch(pool, 300);
+        let (pool, after_full) = run_batch(pool, 300, 600);
         // Workers >= the old cap did nothing in batch 1, so any cumulative work
         // they now show was processed solely in batch 2 — i.e. reactivation worked.
         let reactivated_work: u64 = after_full[2..].iter().sum();


### PR DESCRIPTION
`active_worker_limit_caps_then_reactivates` (added in #614) is flaky and is failing CI on unrelated PRs — it turned up on #616, whose diff is a `long_about` string in `codec.rs` and cannot reach `fgumi-sort`:

```
assertion `left == right` failed: all jobs across both batches accounted for;
per-worker counts [231, 129, 57, 17, 134, 31]
  left: 599
 right: 600
```

## Root cause

The test drains the compress result channel, joins the submit thread, and then reads `per_thread_step_counts`. Draining that channel does not mean the counters are up to date.

A worker sends the job's result — and drops the job, which closes that job's sender — inside `handle_compress_job`, i.e. inside `execute_step`. The counter is incremented afterwards, by `record_step`, once `execute_step` has returned:

```rust
let result = Self::execute_step(shared, worker, step);   // sends result, drops job's sender
if result == StepResult::Success {
    pstats.record_step(worker.worker_id, step, ...);     // counter incremented here
    did_work = true;
}
```

So `result_rx.recv()` returns `Err` — the loop the test uses to know the batch is done — as soon as the last job's sender is dropped, which is strictly before that job's counter increment. The main thread can then read the counters while a worker is still in the gap, and the sum comes up short by one per worker caught mid-gap. The counts in the CI failure sum to exactly 599.

## Evidence

Not inferred from reading alone. Inserting a 200µs sleep at precisely that gap — between `execute_step` returning `Success` and `record_step` — makes the test fail on **every** run:

```
left: 298
right: 300
```

With this change in place and that sleep still inserted, the test passes. The sleep was then removed.

(The window is narrow enough that the test passed 180/180 unmodified runs locally, including 120 under 8-way CPU contention, which is why widening the window was necessary to demonstrate it rather than fish for a failure.)

## Fix

Wait for the counters to settle instead of reading a value that is still in flight: after draining the results, poll until the summed counters reach the cumulative job total, with a 30s deadline that fails with the observed per-worker counts if they never do.

The counters are stats-only, and in production they are read after `shutdown()` has joined the workers — so this is a test synchronization defect, not a pool bug. Reordering `record_step` before the send to suit the test would change production behaviour (and the recorded duration would then exclude the send) for no benefit, so the fix stays in the test.

`cargo nextest run -p fgumi-sort`: 559 passed. `cargo ci-fmt`, `cargo ci-lint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of worker pool tests by allowing time for compression activity counters to reach their expected cumulative values.
  * Added timeout-based waiting to reduce flaky test results during asynchronous processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->