### PR TITLE
perf(sort): pool-integrate and optimize the coordinate --write-index merge

### DIFF
--- a/crates/fgumi-bam-io/src/lib.rs
+++ b/crates/fgumi-bam-io/src/lib.rs
@@ -33,7 +33,7 @@ pub use reader::{
 };
 pub use reorder::{DrainReady, ReorderBuffer};
 pub use writer::{
-    BamWriter, BgzfWriterEnum, IndexingBamWriter, RawBamWriter, bai_sidecar_path,
+    BaiBuilder, BamWriter, BgzfWriterEnum, IndexingBamWriter, RawBamWriter, bai_sidecar_path,
     create_bam_writer, create_indexing_bam_writer, create_optional_bam_writer,
     create_raw_bam_writer, write_bai_index, write_bai_sidecar, write_bam_header,
 };

--- a/crates/fgumi-bam-io/src/writer.rs
+++ b/crates/fgumi-bam-io/src/writer.rs
@@ -16,8 +16,9 @@ use noodles_bgzf::io::Writer as BgzfWriter;
 use noodles_csi::binning_index::Indexer;
 use noodles_csi::binning_index::index::reference_sequence::bin::Chunk;
 use noodles_csi::binning_index::index::reference_sequence::index::LinearIndex;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::fs::File;
+use std::hash::{BuildHasher, BuildHasherDefault, Hasher};
 use std::io::{self, Write};
 use std::num::NonZero;
 use std::path::{Path, PathBuf};
@@ -27,6 +28,41 @@ use crate::vendored::{BlockInfoRx, MultithreadedWriter, MultithreadedWriterBuild
 
 /// Maximum uncompressed BGZF block size (64KB - 256 bytes for overhead).
 const MAX_BLOCK_SIZE: usize = 65280;
+
+/// Fast, non-cryptographic hasher for the dense sequential `u64` block numbers
+/// used as `block_positions` keys.
+///
+/// Multiplicative (Fibonacci) hashing spreads sequential keys across the full
+/// 64-bit space, so hashbrown gets entropy in both the bucket index and the
+/// control byte (top 7 bits) — unlike an identity hash, whose high bits stay
+/// zero for small keys. It costs a single multiply and avoids the DoS-resistant
+/// mixing of a general-purpose hasher, which this internal map does not need.
+#[derive(Default)]
+struct BlockHasher(u64);
+
+impl Hasher for BlockHasher {
+    #[inline]
+    fn write_u64(&mut self, n: u64) {
+        // 2^64 / golden ratio; odd, so the multiply is a bijection over u64.
+        self.0 = (self.0 ^ n).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        // `u64` keys hash via `write_u64`; this path is unused but required by
+        // the trait. Fold bytes in (FNV-style) so any stray key still hashes.
+        for &b in bytes {
+            self.0 = (self.0 ^ u64::from(b)).wrapping_mul(0x0100_0000_01B3);
+        }
+    }
+}
+
+/// `block_number -> compressed start offset`, hashed with [`BlockHasher`].
+type BlockPositions = HashMap<u64, u64, BuildHasherDefault<BlockHasher>>;
 
 /// Resolve the end virtual position for a BAM record that begins in
 /// `start_block` at offset `start_block_start` in the compressed stream.
@@ -38,8 +74,8 @@ const MAX_BLOCK_SIZE: usize = 65280;
 /// overflow fits in a single block. Returns `None` if any required subsequent
 /// block hasn't been completed yet (caller should defer the entry).
 #[allow(clippy::cast_possible_truncation)]
-fn compute_end_vpos(
-    block_positions: &HashMap<u64, u64>,
+fn compute_end_vpos<S: BuildHasher>(
+    block_positions: &HashMap<u64, u64, S>,
     start_block: u64,
     start_block_start: u64,
     end_offset: usize,
@@ -310,6 +346,169 @@ struct CachedIndexEntry {
     alignment_context: Option<(usize, Position, Position, bool)>,
 }
 
+/// Extract alignment context from raw BAM bytes.
+///
+/// Returns `Some((ref_id, start, end, is_mapped))` for mapped reads, or `None`
+/// for unmapped reads (the indexer still counts them via a `None` context).
+#[inline]
+#[allow(clippy::cast_sign_loss, clippy::cast_possible_wrap)]
+pub(crate) fn extract_alignment_context(bam: &[u8]) -> Option<(usize, Position, Position, bool)> {
+    let v = fgumi_raw_bam::RawRecordView::new(bam);
+    let tid = v.ref_id();
+    let pos = v.pos();
+    let flags = v.flags();
+
+    let is_unmapped = (flags & fgumi_raw_bam::flags::UNMAPPED) != 0;
+
+    // Unmapped reads: return None (indexer handles them specially).
+    if tid < 0 || is_unmapped {
+        return None;
+    }
+
+    // Calculate alignment end from CIGAR using byte-safe access
+    // (doesn't require 4-byte alignment like get_cigar_ops).
+    let ref_len = fgumi_raw_bam::reference_length_from_raw_bam(bam);
+
+    // BAM positions are 0-based, Position is 1-based.
+    let start = Position::try_from((pos + 1) as usize).ok()?;
+    let end = Position::try_from((pos + ref_len) as usize).ok()?;
+
+    Some((tid as usize, start, end, true))
+}
+
+/// Incrementally builds a BAI index from per-record positions plus per-block
+/// compressed offsets, independent of the concrete BGZF writer.
+///
+/// A writer feeds each written record's `(block_number, offset_in_block,
+/// record_len)` via [`BaiBuilder::record`], and each finalized block's
+/// `(block_number, compressed_start)` via [`BaiBuilder::note_block`].
+/// [`BaiBuilder::resolve`] converts every record whose block position is now
+/// known into an indexed chunk (records spanning multiple blocks are deferred
+/// until their terminal block is known). [`BaiBuilder::build`] produces the
+/// final [`bai::Index`] once all records are resolved.
+///
+/// This is the shared core behind both [`IndexingBamWriter`] (over the vendored
+/// multi-threaded writer) and the sort engine's pool-integrated indexing writer,
+/// so the virtual-offset accounting lives in exactly one place.
+pub struct BaiBuilder {
+    indexer: Indexer<LinearIndex>,
+    /// Records awaiting block-position resolution, in write order (which is
+    /// non-decreasing block order) — resolved strictly from the front.
+    entry_cache: VecDeque<CachedIndexEntry>,
+    /// `block_number` -> compressed start offset in the file.
+    block_positions: BlockPositions,
+}
+
+impl Default for BaiBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BaiBuilder {
+    /// Create an empty builder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            indexer: Indexer::default(),
+            entry_cache: VecDeque::new(),
+            block_positions: BlockPositions::default(),
+        }
+    }
+
+    /// Record a written BAM record's position for later index resolution.
+    ///
+    /// `block_number`/`offset_in_block` locate the record's first byte in the
+    /// uncompressed stream; `record_len` includes the 4-byte length prefix.
+    /// The alignment context is extracted from `record_bytes` eagerly.
+    pub fn record(
+        &mut self,
+        block_number: u64,
+        offset_in_block: usize,
+        record_len: usize,
+        record_bytes: &[u8],
+    ) {
+        let alignment_context = extract_alignment_context(record_bytes);
+        self.entry_cache.push_back(CachedIndexEntry {
+            block_number,
+            offset_in_block,
+            record_len,
+            alignment_context,
+        });
+    }
+
+    /// Note the compressed start offset of a finalized block.
+    pub fn note_block(&mut self, block_number: u64, compressed_start: u64) {
+        self.block_positions.insert(block_number, compressed_start);
+    }
+
+    /// Resolve pending records whose block positions are now known.
+    ///
+    /// Records are cached in write order (non-decreasing block number) and
+    /// blocks are noted in increasing order, so resolution proceeds strictly
+    /// from the front — which is also the order the indexer must receive records
+    /// in. It stops at the first record whose start (or, for a record spanning
+    /// multiple blocks, terminal) block has not yet been noted, leaving it and
+    /// everything after it cached. This is `O(records resolved)` per call, not
+    /// `O(cache length)`, so per-record resolution stays amortized `O(1)`.
+    ///
+    /// # Errors
+    /// Returns an error if the indexer rejects a record.
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn resolve(&mut self) -> io::Result<()> {
+        while let Some(entry) = self.entry_cache.front() {
+            // Copy out the fields so the front() borrow ends before pop_front().
+            let block_number = entry.block_number;
+            let offset_in_block = entry.offset_in_block;
+            let record_len = entry.record_len;
+            let alignment_context = entry.alignment_context;
+
+            let Some(&block_start) = self.block_positions.get(&block_number) else {
+                break;
+            };
+
+            // End position may fall in this block or a later one (long reads /
+            // large aux payloads can span more than one BGZF block). If the
+            // terminal block isn't noted yet, wait for it.
+            let end_offset = offset_in_block + record_len;
+            let Some(end_vpos) =
+                compute_end_vpos(&self.block_positions, block_number, block_start, end_offset)
+            else {
+                break;
+            };
+
+            let start_vpos = VirtualPosition::try_from((block_start, offset_in_block as u16))
+                .unwrap_or(VirtualPosition::MIN);
+            let chunk = Chunk::new(start_vpos, end_vpos);
+            self.indexer.add_record(alignment_context, chunk).map_err(io::Error::other)?;
+            self.entry_cache.pop_front();
+        }
+
+        Ok(())
+    }
+
+    /// Number of records still awaiting block-position resolution.
+    #[must_use]
+    pub fn pending(&self) -> usize {
+        self.entry_cache.len()
+    }
+
+    /// Build the final BAI index.
+    ///
+    /// # Errors
+    /// Returns an error if any record remains unresolved (its block position was
+    /// never noted), which would indicate a lost or miscounted block.
+    pub fn build(self, num_refs: usize) -> io::Result<bai::Index> {
+        if !self.entry_cache.is_empty() {
+            return Err(io::Error::other(format!(
+                "Unflushed index entries remain: {} entries",
+                self.entry_cache.len()
+            )));
+        }
+        Ok(self.indexer.build(num_refs))
+    }
+}
+
 /// BAM writer that builds an index incrementally during write.
 ///
 /// This writer generates a BAI (BAM index) file alongside the BAM output by tracking
@@ -332,11 +531,8 @@ struct CachedIndexEntry {
 pub struct IndexingBamWriter {
     inner: MultithreadedWriter<File>,
     block_info_rx: BlockInfoRx,
-    indexer: Indexer<LinearIndex>,
+    bai: BaiBuilder,
     num_refs: usize,
-    // Block-aware caching (htslib-style)
-    entry_cache: Vec<CachedIndexEntry>,
-    block_positions: HashMap<u64, u64>,
     current_block_number: u64,
     current_block_offset: usize,
 }
@@ -353,10 +549,8 @@ impl IndexingBamWriter {
             current_block_offset: inner.buffer_offset(),
             inner,
             block_info_rx,
-            indexer: Indexer::default(),
+            bai: BaiBuilder::new(),
             num_refs,
-            entry_cache: Vec::new(),
-            block_positions: HashMap::new(),
         }
     }
 
@@ -407,101 +601,19 @@ impl IndexingBamWriter {
             self.current_block_offset = self.inner.buffer_offset();
         }
 
-        // Cache entry for later resolution
-        let alignment_context = Self::extract_alignment_context(record_bytes);
-        self.entry_cache.push(CachedIndexEntry {
-            block_number,
-            offset_in_block,
-            record_len,
-            alignment_context,
-        });
-
-        // Process any completed blocks
+        // Cache the record's position, then resolve any completed blocks.
+        self.bai.record(block_number, offset_in_block, record_len, record_bytes);
         self.flush_completed_blocks()?;
 
         Ok(())
     }
 
-    /// Process block completion notifications and resolve cached index entries.
-    #[allow(clippy::cast_possible_truncation)]
+    /// Drain block-position notifications and resolve any now-complete records.
     fn flush_completed_blocks(&mut self) -> io::Result<()> {
-        // Drain block info from receiver
         while let Ok(info) = self.block_info_rx.try_recv() {
-            self.block_positions.insert(info.block_number, info.compressed_start);
+            self.bai.note_block(info.block_number, info.compressed_start);
         }
-
-        // Flush cached entries for completed blocks
-        let mut i = 0;
-        while i < self.entry_cache.len() {
-            let entry = &self.entry_cache[i];
-
-            if let Some(&block_start) = self.block_positions.get(&entry.block_number) {
-                // Block is complete - calculate virtual positions
-                let start_vpos =
-                    VirtualPosition::try_from((block_start, entry.offset_in_block as u16))
-                        .unwrap_or(VirtualPosition::MIN);
-
-                // End position: same block, next block, or any block further
-                // along (long reads / large aux payloads can span more than two
-                // BGZF blocks).
-                let end_offset = entry.offset_in_block + entry.record_len;
-                let Some(end_vpos) = compute_end_vpos(
-                    &self.block_positions,
-                    entry.block_number,
-                    block_start,
-                    end_offset,
-                ) else {
-                    // A later block isn't ready yet — defer this entry.
-                    i += 1;
-                    continue;
-                };
-
-                let chunk = Chunk::new(start_vpos, end_vpos);
-                if let Some(ctx) = entry.alignment_context {
-                    self.indexer.add_record(Some(ctx), chunk).map_err(io::Error::other)?;
-                } else {
-                    // Unmapped record
-                    self.indexer.add_record(None, chunk).map_err(io::Error::other)?;
-                }
-
-                self.entry_cache.remove(i);
-            } else {
-                i += 1;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Extract alignment context from raw BAM bytes.
-    ///
-    /// Returns `Some((ref_id, start, end, is_mapped))` for mapped reads,
-    /// or `None` for unmapped reads (needed for unmapped record counting).
-    #[inline]
-    #[allow(clippy::cast_sign_loss, clippy::cast_possible_wrap)]
-    fn extract_alignment_context(bam: &[u8]) -> Option<(usize, Position, Position, bool)> {
-        // Extract fields from BAM record
-        let v = fgumi_raw_bam::RawRecordView::new(bam);
-        let tid = v.ref_id();
-        let pos = v.pos();
-        let flags = v.flags();
-
-        let is_unmapped = (flags & fgumi_raw_bam::flags::UNMAPPED) != 0;
-
-        // Unmapped reads: return None (indexer handles them specially)
-        if tid < 0 || is_unmapped {
-            return None;
-        }
-
-        // Calculate alignment end from CIGAR using byte-safe access
-        // (doesn't require 4-byte alignment like get_cigar_ops)
-        let ref_len = fgumi_raw_bam::reference_length_from_raw_bam(bam);
-
-        // BAM positions are 0-based, Position is 1-based
-        let start = Position::try_from((pos + 1) as usize).ok()?;
-        let end = Position::try_from((pos + ref_len) as usize).ok()?;
-
-        Some((tid as usize, start, end, true))
+        self.bai.resolve()
     }
 
     /// Finish writing, flush the BGZF stream, and return the index.
@@ -516,7 +628,7 @@ impl IndexingBamWriter {
         // Wait a bit for the writer thread to finish processing
         for _ in 0..100 {
             self.flush_completed_blocks()?;
-            if self.entry_cache.is_empty() {
+            if self.bai.pending() == 0 {
                 break;
             }
             std::thread::sleep(std::time::Duration::from_millis(10));
@@ -528,17 +640,9 @@ impl IndexingBamWriter {
         // Final flush of any remaining entries
         self.flush_completed_blocks()?;
 
-        // All entries should be flushed now
-        if !self.entry_cache.is_empty() {
-            return Err(io::Error::other(format!(
-                "Unflushed index entries remain: {} entries",
-                self.entry_cache.len()
-            )));
-        }
-
-        // Build the final index
-        let index = self.indexer.build(self.num_refs);
-        Ok(index)
+        // Build the final index (errors if any entry remained unresolved).
+        let num_refs = self.num_refs;
+        self.bai.build(num_refs)
     }
 }
 

--- a/crates/fgumi-bam-io/src/writer.rs
+++ b/crates/fgumi-bam-io/src/writer.rs
@@ -767,11 +767,16 @@ pub fn write_bai_sidecar<P: AsRef<Path>>(bam_path: P) -> Result<PathBuf> {
 /// Returns an error if the file cannot be created or writing the index fails.
 pub fn write_bai_index<P: AsRef<Path>>(path: P, index: &bai::Index) -> Result<()> {
     let path_ref = path.as_ref();
-    let file = File::create(path_ref)
-        .with_context(|| format!("Failed to create index file: {}", path_ref.display()))?;
-    let mut writer = bai::io::Writer::new(file);
-    writer
+    // `bai::io::Writer` serializes the index as a great many tiny fields (each
+    // bin and chunk writes 8-byte virtual offsets), so writing straight to the
+    // file issues one `write()` syscall per field. For a WGS-scale index (tens
+    // of MB) that unbuffered tail dominates the post-merge main-thread time.
+    // Serialize into memory first, then write the whole sidecar in one call.
+    let mut buf = Vec::new();
+    bai::io::Writer::new(&mut buf)
         .write_index(index)
+        .with_context(|| format!("Failed to serialize BAI index for: {}", path_ref.display()))?;
+    std::fs::write(path_ref, &buf)
         .with_context(|| format!("Failed to write index to: {}", path_ref.display()))?;
     Ok(())
 }

--- a/crates/fgumi-bam-io/src/writer.rs
+++ b/crates/fgumi-bam-io/src/writer.rs
@@ -18,7 +18,7 @@ use noodles_csi::binning_index::index::reference_sequence::bin::Chunk;
 use noodles_csi::binning_index::index::reference_sequence::index::LinearIndex;
 use std::collections::{HashMap, VecDeque};
 use std::fs::File;
-use std::hash::{BuildHasher, BuildHasherDefault, Hasher};
+use std::hash::{BuildHasherDefault, Hasher};
 use std::io::{self, Write};
 use std::num::NonZero;
 use std::path::{Path, PathBuf};
@@ -26,17 +26,31 @@ use std::path::{Path, PathBuf};
 use crate::paths::is_stdout_path;
 use crate::vendored::{BlockInfoRx, MultithreadedWriter, MultithreadedWriterBuilder};
 
-/// Maximum uncompressed BGZF block size (64KB - 256 bytes for overhead).
-const MAX_BLOCK_SIZE: usize = 65280;
+/// Maximum uncompressed BGZF block size.
+///
+/// [`compute_end_vpos`] serves two writers, so this must match the block size
+/// both of them flush at:
+///
+/// - The sort engine's pooled writer flushes at `fgumi_bgzf::BGZF_MAX_BLOCK_SIZE`,
+///   which is itself this same `bgzf::BGZF_BLOCK_SIZE` — deriving the constant
+///   here (rather than hardcoding 65280) means that path's virtual-offset math
+///   and block layout cannot silently diverge.
+/// - [`IndexingBamWriter`] flushes at the vendored `MultithreadedWriter`'s own
+///   `BGZF_BLOCK_SIZE` (`crate::vendored::bgzf_multithreaded`), a deliberately
+///   independent copy that keeps the vendored module self-contained. It is equal
+///   to this value today; keep the two in step, since nothing enforces it.
+const MAX_BLOCK_SIZE: usize = bgzf::BGZF_BLOCK_SIZE;
 
 /// Fast, non-cryptographic hasher for the dense sequential `u64` block numbers
 /// used as `block_positions` keys.
 ///
-/// Multiplicative (Fibonacci) hashing spreads sequential keys across the full
-/// 64-bit space, so hashbrown gets entropy in both the bucket index and the
-/// control byte (top 7 bits) — unlike an identity hash, whose high bits stay
-/// zero for small keys. It costs a single multiply and avoids the DoS-resistant
-/// mixing of a general-purpose hasher, which this internal map does not need.
+/// One multiplicative (Fibonacci) step spreads sequential keys across the full
+/// 64-bit space — enough entropy for both hashbrown's bucket index and its
+/// control byte — at the cost of a single multiply and no DoS-resistant mixing,
+/// which this internal, non-adversarial map does not need. A standard hasher
+/// (`ahash`, `FxHash`) would also serve, but each costs several
+/// multiply-equivalents per `u64`; this map is hot in the merge, so the single
+/// multiply is deliberate.
 #[derive(Default)]
 struct BlockHasher(u64);
 
@@ -74,8 +88,8 @@ type BlockPositions = HashMap<u64, u64, BuildHasherDefault<BlockHasher>>;
 /// overflow fits in a single block. Returns `None` if any required subsequent
 /// block hasn't been completed yet (caller should defer the entry).
 #[allow(clippy::cast_possible_truncation)]
-fn compute_end_vpos<S: BuildHasher>(
-    block_positions: &HashMap<u64, u64, S>,
+fn compute_end_vpos(
+    block_positions: &BlockPositions,
     start_block: u64,
     start_block_start: u64,
     end_offset: usize,
@@ -397,12 +411,11 @@ pub struct BaiBuilder {
     entry_cache: VecDeque<CachedIndexEntry>,
     /// `block_number` -> compressed start offset in the file.
     block_positions: BlockPositions,
-}
-
-impl Default for BaiBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
+    /// Watermark: every block number below this has been pruned from
+    /// `block_positions` once its records resolved. Keeps the map bounded by the
+    /// in-flight block window instead of growing one entry per output block for
+    /// the whole (WGS-scale) file.
+    pruned_below: u64,
 }
 
 impl BaiBuilder {
@@ -413,6 +426,7 @@ impl BaiBuilder {
             indexer: Indexer::default(),
             entry_cache: VecDeque::new(),
             block_positions: BlockPositions::default(),
+            pruned_below: 0,
         }
     }
 
@@ -484,12 +498,25 @@ impl BaiBuilder {
             self.entry_cache.pop_front();
         }
 
+        // Prune block offsets no remaining or future record can reference. Every
+        // pending entry has block_number >= the front's, and future records are
+        // recorded with even larger block numbers, so blocks below the front are
+        // dead. Advancing a watermark (block numbers are dense sequential
+        // serials) makes this O(1) amortized and bounds `block_positions` to the
+        // in-flight window.
+        if let Some(front_block) = self.entry_cache.front().map(|e| e.block_number) {
+            while self.pruned_below < front_block {
+                self.block_positions.remove(&self.pruned_below);
+                self.pruned_below += 1;
+            }
+        }
+
         Ok(())
     }
 
     /// Number of records still awaiting block-position resolution.
     #[must_use]
-    pub fn pending(&self) -> usize {
+    pub(crate) fn pending(&self) -> usize {
         self.entry_cache.len()
     }
 
@@ -506,6 +533,12 @@ impl BaiBuilder {
             )));
         }
         Ok(self.indexer.build(num_refs))
+    }
+}
+
+impl Default for BaiBuilder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -1202,7 +1235,7 @@ mod tests {
 
     /// Build a `block_positions` map mapping `[0..n)` to deterministic
     /// compressed offsets so virtual positions are easy to assert against.
-    fn make_block_positions(n: u64) -> HashMap<u64, u64> {
+    fn make_block_positions(n: u64) -> BlockPositions {
         // Use 0x10000-step starts so each block is at a distinct, recognizable
         // virtual offset.
         (0..n).map(|i| (i, i * 0x1_0000)).collect()
@@ -1256,7 +1289,7 @@ mod tests {
     #[test]
     fn test_compute_end_vpos_multi_block_lookup_uses_terminal_block() {
         // A record that spans blocks 5..7 (start block 5, ends in block 7).
-        let mut positions = HashMap::new();
+        let mut positions = BlockPositions::default();
         positions.insert(5u64, 0x5_0000u64);
         // Block 6 missing on purpose — we only need the terminal block start.
         positions.insert(7u64, 0x7_0000u64);
@@ -1277,7 +1310,7 @@ mod tests {
     #[test]
     fn test_compute_end_vpos_offset_within_starting_block() {
         // Start somewhere in the middle of block 3; record extends into block 4.
-        let mut positions = HashMap::new();
+        let mut positions = BlockPositions::default();
         positions.insert(3u64, 0x3_0000u64);
         positions.insert(4u64, 0x4_0000u64);
 

--- a/crates/fgumi-sort/src/bgzf_io.rs
+++ b/crates/fgumi-sort/src/bgzf_io.rs
@@ -16,6 +16,21 @@ use std::sync::Arc;
 /// Padding beyond `BGZF_MAX_BLOCK_SIZE` for the staging buffer capacity.
 const STAGING_PADDING: usize = 4096;
 
+/// Per-block position notification emitted by the I/O writer loop when index
+/// generation is enabled.
+///
+/// `serial` is the block's serial number (assigned by [`StagingBuffer`] at
+/// flush time, and equal to its block number since one compress job produces
+/// exactly one BGZF block). `compressed_start` is the cumulative number of
+/// compressed bytes written to the file *before* this block — i.e. its on-disk
+/// byte offset. The pooled indexing writer uses these to resolve BAI virtual
+/// offsets.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BlockOffset {
+    pub serial: u64,
+    pub compressed_start: u64,
+}
+
 /// Staging buffer that accumulates data and submits full blocks to the pool.
 pub(crate) struct StagingBuffer {
     pool: Arc<SortWorkerPool>,
@@ -57,6 +72,25 @@ impl StagingBuffer {
     #[inline]
     pub(crate) fn is_full(&self) -> bool {
         self.buf.len() >= BGZF_MAX_BLOCK_SIZE
+    }
+
+    /// Current uncompressed length of the pending (not-yet-flushed) block.
+    ///
+    /// This is the uncompressed offset at which the next appended byte will
+    /// land in the current block — used by the indexing writer to record where
+    /// a record starts.
+    #[inline]
+    pub(crate) fn buf_len(&self) -> usize {
+        self.buf.len()
+    }
+
+    /// Serial number the pending block will be assigned when flushed.
+    ///
+    /// Because one compress job produces exactly one BGZF block, this is also
+    /// the block number the indexing writer pairs with [`BlockOffset`].
+    #[inline]
+    pub(crate) fn next_serial(&self) -> u64 {
+        self.next_serial
     }
 
     /// Flush the staging buffer: swap it with a recycled buffer and submit for compression.
@@ -124,6 +158,31 @@ impl StagingBuffer {
     }
 }
 
+/// Write one output block in serial order: emit its compressed start offset
+/// (when indexing is enabled), write the bytes, advance the running compressed
+/// offset, and release one reorder permit.
+///
+/// `compressed_start` is captured *before* the write, so it is the on-disk byte
+/// offset at which this block begins. The BGZF EOF marker is written separately
+/// and is intentionally never passed here (no record references it).
+fn write_block_in_order(
+    writer: &mut BufWriter<std::fs::File>,
+    serial: u64,
+    data: &[u8],
+    compressed_offset: &mut u64,
+    block_offset_tx: Option<&Sender<BlockOffset>>,
+    permit_pool: &Arc<PermitPool>,
+) -> Result<()> {
+    if let Some(tx) = block_offset_tx {
+        // Best-effort: the indexing consumer keeps the receiver alive until finish.
+        let _ = tx.send(BlockOffset { serial, compressed_start: *compressed_offset });
+    }
+    writer.write_all(data)?;
+    *compressed_offset += data.len() as u64;
+    permit_pool.release();
+    Ok(())
+}
+
 /// I/O writer loop: receives compressed blocks and writes them in serial order.
 ///
 /// Uses a `BTreeMap` as a reorder buffer. When the next expected serial arrives,
@@ -132,6 +191,10 @@ impl StagingBuffer {
 /// unblocking the corresponding `StagingBuffer::flush()` call and bounding the
 /// number of in-flight compressed blocks to the pool capacity.
 /// Writes BGZF EOF marker and flushes when all blocks are received.
+///
+/// When `block_offset_tx` is `Some`, each written block's `(serial,
+/// compressed_start)` is emitted on it (in strict block order) for BAI virtual
+/// offset resolution; when `None`, this is a no-op with zero overhead.
 ///
 /// # Errors
 ///
@@ -144,8 +207,16 @@ pub(crate) fn io_writer_loop(
     buffer_pool: BufferPool,
     permit_pool: Arc<PermitPool>,
     codec: SpillCodec,
+    block_offset_tx: Option<Sender<BlockOffset>>,
 ) -> Result<()> {
-    let result = io_writer_loop_inner(&mut writer, &result_rx, &buffer_pool, &permit_pool, codec);
+    let result = io_writer_loop_inner(
+        &mut writer,
+        &result_rx,
+        &buffer_pool,
+        &permit_pool,
+        codec,
+        block_offset_tx.as_ref(),
+    );
     if result.is_err() {
         // Unblock any producers waiting on acquire() so they don't park forever.
         permit_pool.close();
@@ -159,21 +230,36 @@ fn io_writer_loop_inner(
     buffer_pool: &BufferPool,
     permit_pool: &Arc<PermitPool>,
     codec: SpillCodec,
+    block_offset_tx: Option<&Sender<BlockOffset>>,
 ) -> Result<()> {
     let mut next_expected: u64 = 0;
     let mut reorder_buf: BTreeMap<u64, Vec<u8>> = BTreeMap::new();
+    let mut compressed_offset: u64 = 0;
+    let tx = block_offset_tx;
 
     while let Ok(result) = result_rx.recv() {
         buffer_pool.checkin(result.recycled_buf);
 
         if result.serial == next_expected {
-            writer.write_all(&result.compressed)?;
-            permit_pool.release();
+            write_block_in_order(
+                writer,
+                next_expected,
+                &result.compressed,
+                &mut compressed_offset,
+                tx,
+                permit_pool,
+            )?;
             next_expected += 1;
 
             while let Some(data) = reorder_buf.remove(&next_expected) {
-                writer.write_all(&data)?;
-                permit_pool.release();
+                write_block_in_order(
+                    writer,
+                    next_expected,
+                    &data,
+                    &mut compressed_offset,
+                    tx,
+                    permit_pool,
+                )?;
                 next_expected += 1;
             }
         } else {
@@ -186,8 +272,14 @@ fn io_writer_loop_inner(
     while let Some((&serial, _)) = reorder_buf.first_key_value() {
         if serial == next_expected {
             let data = reorder_buf.remove(&serial).expect("key just checked");
-            writer.write_all(&data)?;
-            permit_pool.release();
+            write_block_in_order(
+                writer,
+                next_expected,
+                &data,
+                &mut compressed_offset,
+                tx,
+                permit_pool,
+            )?;
             next_expected += 1;
         } else {
             return Err(anyhow::anyhow!(
@@ -235,8 +327,9 @@ mod tests {
         let out_file = std::fs::File::create(&out_path).unwrap();
         let writer = std::io::BufWriter::new(out_file);
         let pp = Arc::clone(&permit_pool);
-        let io_handle =
-            std::thread::spawn(move || io_writer_loop(writer, result_rx, buffer_pool, pp, codec));
+        let io_handle = std::thread::spawn(move || {
+            io_writer_loop(writer, result_rx, buffer_pool, pp, codec, None)
+        });
 
         let mut staging = StagingBuffer::new(Arc::clone(&pool), result_tx, permit_pool, codec);
         staging.write_chunked(data).unwrap();
@@ -307,8 +400,9 @@ mod tests {
         let out_file = std::fs::File::create(&out_path).unwrap();
         let writer = std::io::BufWriter::new(out_file);
         let pp = Arc::clone(&permit_pool);
-        let io_handle =
-            std::thread::spawn(move || io_writer_loop(writer, result_rx, buffer_pool, pp, codec));
+        let io_handle = std::thread::spawn(move || {
+            io_writer_loop(writer, result_rx, buffer_pool, pp, codec, None)
+        });
 
         let mut staging = StagingBuffer::new(Arc::clone(&pool), result_tx, permit_pool, codec);
         staging.write_chunked(&large).unwrap();
@@ -346,8 +440,9 @@ mod tests {
         let out_file = std::fs::File::create(&out_path).unwrap();
         let writer = std::io::BufWriter::new(out_file);
         let pp = Arc::clone(&permit_pool);
-        let io_handle =
-            std::thread::spawn(move || io_writer_loop(writer, result_rx, buffer_pool, pp, codec));
+        let io_handle = std::thread::spawn(move || {
+            io_writer_loop(writer, result_rx, buffer_pool, pp, codec, None)
+        });
 
         // Submit block 1 first, then block 0 (out of order).
         // Each needs a pre-acquired permit since they bypass StagingBuffer::flush().

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1116,6 +1116,29 @@ impl<K: RawSortKey + Default + 'static> ChunkSource<K> {
     }
 }
 
+/// Bytes of `source`'s current record to hand to the merge writer.
+///
+/// For `PoolDisk` sources this borrows directly from the pooled decompressed
+/// block when the record fit in one block (the zero-copy fast path), falling
+/// back to the source's scratch buffer for a record that straddled a block
+/// boundary. All other source variants borrow from their own backing store via
+/// [`ChunkSource::current_bytes`] and ignore `consumer`.
+///
+/// `consumer` must be `Some` whenever `source` is `PoolDisk`; the merge loops
+/// uphold this (a `PoolDisk` source only exists when Phase 2 is active).
+#[inline]
+fn winner_record_bytes<'a, K: RawSortKey + Default + 'static>(
+    source: &'a ChunkSource<K>,
+    consumer: Option<&'a MainThreadChunkConsumer<K>>,
+) -> &'a [u8] {
+    match source {
+        ChunkSource::PoolDisk { source_id, scratch } => {
+            consumer.and_then(|c| c.current_record_bytes(*source_id)).unwrap_or(scratch.as_slice())
+        }
+        other => other.current_bytes(),
+    }
+}
+
 // ============================================================================
 // MainThreadChunkConsumer — pool-integrated merge reader
 // ============================================================================
@@ -1132,6 +1155,21 @@ impl<K: RawSortKey + Default + 'static> ChunkSource<K> {
 // buffer reaches `PHASE2_DECOMP_CAP`, workers stop pulling new raw blocks for
 // that file (with a deadlock-free escape hatch for the gap-filling serial).
 
+/// Where the current record's bytes live for zero-copy presentation to the
+/// merge loop.
+///
+/// The common case (`Borrowed`) is a record that lies contiguously inside the
+/// source's current decompressed block, so it can be handed to the writer as a
+/// slice with no intermediate copy. A record that straddles a block boundary is
+/// reassembled into the source's scratch buffer (`Scratch`) as before.
+#[derive(Clone, Copy)]
+enum CurRecord {
+    /// Record occupies `current_buf[start..end]` — borrow it directly.
+    Borrowed { start: usize, end: usize },
+    /// Record was reassembled into the `ChunkSource`'s scratch buffer.
+    Scratch,
+}
+
 /// Per-source byte-stream parser state owned by the main thread.
 ///
 /// As blocks are pulled from `Phase2FileState.decompressed`, the bytes are
@@ -1141,11 +1179,13 @@ struct SourceParserState {
     current_buf: Vec<u8>,
     /// Read position within `current_buf`.
     current_pos: usize,
+    /// Location of the most recently parsed record's bytes.
+    cur_record: CurRecord,
 }
 
 impl SourceParserState {
     fn new() -> Self {
-        Self { current_buf: Vec::new(), current_pos: 0 }
+        Self { current_buf: Vec::new(), current_pos: 0, cur_record: CurRecord::Scratch }
     }
 
     fn remaining(&self) -> usize {
@@ -1218,6 +1258,23 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
         self.parse_next_record(source_id, buf)
     }
 
+    /// Bytes of `source_id`'s current record when they were borrowed directly
+    /// from the decompressed block (the zero-copy fast path). Returns `None`
+    /// when the record straddled a block boundary and was reassembled into the
+    /// source's scratch buffer, in which case the caller reads it from there.
+    ///
+    /// The returned slice is valid until the next `advance` of this source
+    /// (which is what may replace `current_buf`); the merge loop always writes
+    /// the current record before advancing its source, so this holds.
+    #[inline]
+    fn current_record_bytes(&self, source_id: usize) -> Option<&[u8]> {
+        let st = &self.parser_state[source_id];
+        match st.cur_record {
+            CurRecord::Borrowed { start, end } => Some(&st.current_buf[start..end]),
+            CurRecord::Scratch => None,
+        }
+    }
+
     /// Pull the next decompressed block for `source_id` from the per-file
     /// reorder buffer, blocking the main thread (`std::thread::park`) until
     /// either a block becomes available, the source drains, or a worker error
@@ -1285,11 +1342,31 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
             }
             let len = u32::from_le_bytes(len_buf) as usize;
 
+            // Fast path: the whole record is contiguous in the current block, so
+            // borrow it in place rather than copying it into `buf` (the source's
+            // scratch). A record only straddles a block boundary right at the
+            // ~64KB block edges, so this hits for the vast majority of records
+            // and removes one full-record memcpy per record from the merge.
+            if self.parser_state[source_id].remaining() >= len {
+                let start = self.parser_state[source_id].current_pos;
+                let end = start + len;
+                {
+                    let st = &mut self.parser_state[source_id];
+                    st.current_pos = end;
+                    st.cur_record = CurRecord::Borrowed { start, end };
+                }
+                let key =
+                    K::extract_from_record(&self.parser_state[source_id].current_buf[start..end]);
+                return Ok(Some(key));
+            }
+
+            // Slow path: record spans a block boundary — reassemble into scratch.
             buf.clear();
             buf.resize(len, 0);
             if !self.read_exact_from_source(source_id, buf)? {
                 return Err(anyhow::anyhow!("truncated record in chunk source {source_id}"));
             }
+            self.parser_state[source_id].cur_record = CurRecord::Scratch;
             let key = K::extract_from_record(buf);
             Ok(Some(key))
         } else {
@@ -1307,6 +1384,9 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
             if !self.read_exact_from_source(source_id, buf)? {
                 return Err(anyhow::anyhow!("truncated record in chunk source {source_id}"));
             }
+            // Keyed records are always presented from scratch — only the
+            // EMBEDDED coordinate/template path is zero-copy for now.
+            self.parser_state[source_id].cur_record = CurRecord::Scratch;
             Ok(Some(key))
         }
     }
@@ -1548,6 +1628,10 @@ struct Phase2Guard<'a, K: RawSortKey + 'static> {
 impl<K: RawSortKey + 'static> Phase2Guard<'_, K> {
     fn consumer_mut(&mut self) -> Option<&mut MainThreadChunkConsumer<K>> {
         self.consumer.as_mut()
+    }
+
+    fn consumer_ref(&self) -> Option<&MainThreadChunkConsumer<K>> {
+        self.consumer.as_ref()
     }
 
     fn deactivate(&mut self) {
@@ -3420,12 +3504,13 @@ impl RawExternalSorter {
             let src_idx = source_map[winner];
             let sample_this = debug_timing && records_merged.is_multiple_of(merge_sample_interval);
 
+            let record_bytes = winner_record_bytes(&sources[src_idx], guard.consumer_ref());
             if sample_this {
                 let t0 = Instant::now();
-                writer.write_raw_record(sources[src_idx].current_bytes())?;
+                writer.write_raw_record(record_bytes)?;
                 merge_write_secs += t0.elapsed().as_secs_f64();
             } else {
-                writer.write_raw_record(sources[src_idx].current_bytes())?;
+                writer.write_raw_record(record_bytes)?;
             }
 
             records_merged += 1;
@@ -3576,7 +3661,8 @@ impl RawExternalSorter {
         while tree.winner_is_active() {
             let winner = tree.winner();
             let src_idx = source_map[winner];
-            writer.write_raw_record(sources[src_idx].current_bytes())?;
+            let record_bytes = winner_record_bytes(&sources[src_idx], guard.consumer_ref());
+            writer.write_raw_record(record_bytes)?;
             merge_progress.log_if_needed(1);
 
             if let Some(key) = sources[src_idx].advance(guard.consumer_mut())? {
@@ -5262,6 +5348,100 @@ mod tests {
         let expected = (num_pairs * 2) as u64;
         let observed = count_bam_records(&output);
         assert_eq!(observed, expected, "sort lost data");
+    }
+
+    /// A record larger than one BGZF block must survive a spill followed by a
+    /// pool-integrated merge.
+    ///
+    /// When records are spilled, the writer pre-flushes so a normal record
+    /// never straddles a BGZF block boundary — only an oversized record
+    /// (written via `write_chunked`) spans blocks. On merge that oversized
+    /// record is the one case that cannot be borrowed in place from a single
+    /// decompressed block, so it exercises the reassemble-into-scratch slow
+    /// path that the zero-copy fast path falls back to. This guards that
+    /// fast/slow split: the fast path handles the ~200 normal reads, the slow
+    /// path the one oversized read, and every byte must round-trip.
+    #[rstest::rstest]
+    #[case::coordinate(SortOrder::Coordinate)]
+    #[case::template_coordinate(SortOrder::TemplateCoordinate)]
+    fn test_oversized_record_survives_spill_and_pool_merge(#[case] sort_order: SortOrder) {
+        use fgumi_sam::SamBuilder;
+
+        // Well over one ~64 KB BGZF block; default refs are 200 MB so a mapped
+        // read this long is still in-bounds. The bases are position-dependent
+        // rather than a uniform run so they can serve as their own oracle: a
+        // scratch reassembly that shuffled or duplicated bytes within the
+        // record would preserve the length (and round-trip a run of `A`s) but
+        // must not survive an exact base-by-base comparison below.
+        let big_len = 70_000usize;
+        let big_seq: String = {
+            let mut state = 0x2545_f491_4f6c_dd1d_u64;
+            (0..big_len)
+                .map(|_| {
+                    state = state
+                        .wrapping_mul(6_364_136_223_846_793_005)
+                        .wrapping_add(1_442_695_040_888_963_407);
+                    ['A', 'C', 'G', 'T'][((state >> 33) & 0b11) as usize]
+                })
+                .collect()
+        };
+
+        let mut builder = SamBuilder::new();
+        for i in 0..100 {
+            let _ = builder.add_frag().name(&format!("n{i:04}")).contig(0).start(i + 1).build();
+        }
+        let _ = builder.add_frag().name("oversized").contig(0).start(50).bases(&big_seq).build();
+        for i in 0..100 {
+            let _ = builder.add_frag().name(&format!("m{i:04}")).contig(0).start(i + 1).build();
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = dir.path().join("input.bam");
+        let output = dir.path().join("output.bam");
+        builder.write_bam(&input).expect("write_bam");
+
+        // Memory limit below the oversized record forces it into its own spill
+        // chunk (so it is read back through the PoolDisk merge, not from memory);
+        // two threads give a genuine multi-source merge.
+        let stats = RawExternalSorter::new(sort_order)
+            .memory_limit(64 * 1024)
+            .threads(2)
+            .spill_codec(crate::codec::SpillCodec::Bgzf)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort(&input, &output)
+            .expect("sort should succeed");
+        assert!(
+            stats.chunks_written > 0,
+            "test must spill to disk so the oversized record is read back through the \
+             PoolDisk merge (slow path); got chunks_written = 0"
+        );
+
+        let mut reader =
+            noodles::bam::io::reader::Builder.build_from_path(&output).expect("open output");
+        let _header = reader.read_header().expect("read header");
+        let mut count = 0u64;
+        let mut oversized_bases: Option<Vec<u8>> = None;
+        for result in reader.records() {
+            let record = result.expect("read record");
+            let name: &[u8] = record.name().expect("read name").as_ref();
+            if name == b"oversized" {
+                oversized_bases = Some(record.sequence().iter().collect());
+            }
+            count += 1;
+        }
+        assert_eq!(count, 201, "spill + pool merge lost records");
+        let oversized_bases = oversized_bases.expect("oversized read must survive the merge");
+        assert_eq!(
+            oversized_bases.len(),
+            big_len,
+            "oversized read lost bases across the spill + pool merge"
+        );
+        assert_eq!(
+            oversized_bases,
+            big_seq.as_bytes(),
+            "oversized read's bases were corrupted across the spill + pool merge"
+        );
     }
 
     // ========================================================================

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -3487,8 +3487,13 @@ impl RawExternalSorter {
 
     /// Merge keyed chunks with BAM index generation.
     ///
-    /// Similar to `merge_chunks_generic` but uses `IndexingBamWriter` to build
-    /// the BAI index incrementally during the merge. Returns the generated index.
+    /// Identical input/output pipeline to `merge_chunks_generic` — the shared
+    /// worker pool decompresses the input runs (`PoolDisk` sources) and
+    /// compresses the output blocks — but the output goes through
+    /// [`PooledBamWriter::new_indexing`], which tracks each record's virtual
+    /// file offset and returns the generated BAI index. A single pool of
+    /// workers therefore serves both decompression and compression; there is no
+    /// separate writer thread pool and no serialized single-reader input.
     fn merge_chunks_with_index<K: RawSortKey + Default + 'static>(
         &self,
         chunk_files: &[PathBuf],
@@ -3499,34 +3504,46 @@ impl RawExternalSorter {
         pool: &Arc<SortWorkerPool>,
     ) -> Result<noodles::bam::bai::Index> {
         use crate::loser_tree::LoserTree;
-        use fgumi_bam_io::create_indexing_bam_writer;
+        use crate::pooled_bam_writer::PooledBamWriter;
+        use crate::worker_pool::phase;
 
-        // Thread budget: writer gets the Phase 2 (merge/write) thread count
-        // (merge is output-compression-bound), readers use semaphore concurrency
-        // of 1. Same split as merge_chunks_generic, whose PooledBamWriter inherits
-        // the same cap via the shared pool raised to `phase2_threads()`.
-        // TODO: Replace create_indexing_bam_writer with PooledIndexingBamWriter
-        let writer_threads = self.phase2_threads();
         let reader_concurrency: usize = 1;
+        let num_disk = chunk_files.len();
 
-        // The indexing path uses a non-pooled writer and has no pool consumer set up,
-        // so use GenericKeyedChunkReader (pool_decompress=false).
-        // TODO: Replace create_indexing_bam_writer with PooledIndexingBamWriter to
-        // enable pool-integrated decompression for the indexing path.
+        if num_disk > 0 {
+            debug!(
+                "Pool-integrated indexed merge: {} disk sources, {} pool workers (N+2 model)",
+                num_disk,
+                pool.num_workers()
+            );
+        }
+
         let mut sources = Self::build_chunk_sources::<K>(
             chunk_files,
             memory_chunks,
             reader_concurrency,
-            false,
+            true,
             pool,
         )?;
 
         let num_sources = sources.len();
-        debug!(
-            "Merge thread budget (indexing): {writer_threads} writer + {reader_concurrency} reader + 1 main = {} total",
-            writer_threads + reader_concurrency + 1
-        );
         debug!("Merging from {num_sources} sources (indexing)...");
+
+        // Create the pool consumer for PoolDisk sources and activate Phase 2,
+        // exactly as merge_chunks_generic does.
+        let mut guard: Phase2Guard<'_, K> = if num_disk > 0 {
+            let files = pool.phase2_files();
+            let consumer = MainThreadChunkConsumer::new(
+                files,
+                pool.decompress_error_flag(),
+                pool.chunk_read_error_flag(),
+                pool.worker_panicked_flag(),
+            );
+            pool.set_phase(phase::PHASE2);
+            Phase2Guard { pool, consumer: Some(consumer), active: true }
+        } else {
+            Phase2Guard { pool, consumer: None, active: false }
+        };
 
         let output_header = self.create_output_header(header);
 
@@ -3535,32 +3552,23 @@ impl RawExternalSorter {
         let mut source_map: Vec<usize> = Vec::with_capacity(sources.len());
 
         for (idx, source) in sources.iter_mut().enumerate() {
-            if let Some(key) = source.advance(None)? {
+            if let Some(key) = source.advance(guard.consumer_mut())? {
                 initial_keys.push(key);
                 source_map.push(idx);
             }
         }
 
         if initial_keys.is_empty() {
-            let writer = create_indexing_bam_writer(
-                output,
-                &output_header,
-                self.output_compression,
-                writer_threads,
-            )?;
-            let index = writer.finish()?;
+            guard.deactivate();
+            let writer = PooledBamWriter::new_indexing(Arc::clone(pool), output, &output_header)?;
+            let index = writer.finish_index()?;
             debug!("Merge complete: 0 records merged");
             return Ok(index);
         }
 
         let mut tree = LoserTree::new(initial_keys);
 
-        let mut writer = create_indexing_bam_writer(
-            output,
-            &output_header,
-            self.output_compression,
-            writer_threads,
-        )?;
+        let mut writer = PooledBamWriter::new_indexing(Arc::clone(pool), output, &output_header)?;
         let merge_progress = ProgressTracker::new("Merged records")
             .with_interval(1_000_000)
             .with_total(total_records);
@@ -3571,14 +3579,20 @@ impl RawExternalSorter {
             writer.write_raw_record(sources[src_idx].current_bytes())?;
             merge_progress.log_if_needed(1);
 
-            if let Some(key) = sources[src_idx].advance(None)? {
+            if let Some(key) = sources[src_idx].advance(guard.consumer_mut())? {
                 tree.replace_winner(key);
             } else {
                 tree.remove_winner();
             }
         }
 
-        let index = writer.finish()?;
+        // Return the pool to legacy mode before finishing the writer — the
+        // workers still compress the trailing output blocks during
+        // finish_index() (CompressOutput is eligible whenever the queue is
+        // non-empty). Same ordering as merge_chunks_generic.
+        guard.deactivate();
+
+        let index = writer.finish_index()?;
         merge_progress.log_final();
         Ok(index)
     }

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1021,16 +1021,10 @@ impl<K: RawSortKey + Default + 'static> MemorySources<K> {
 ///
 /// Each variant owns its "current record" state internally so the merge loop
 /// can borrow the current record's bytes via [`Self::current_bytes`] without
-/// copying. Disk-backed variants own a `scratch: Vec<u8>` holding the most
+/// copying. The `PoolDisk` variant owns a `scratch: Vec<u8>` holding the most
 /// recently read record's bytes; `Memory`/`MemoryOwned` borrow directly from
 /// their backing store, eliminating the per-record memcpy on the in-memory path.
 enum ChunkSource<K: RawSortKey + Default + 'static> {
-    /// Disk-based chunk with prefetching reader (legacy path with per-source threads).
-    Disk {
-        reader: GenericKeyedChunkReader<K>,
-        /// Bytes for the current record (filled by the most recent `advance`).
-        scratch: Vec<u8>,
-    },
     /// In-memory chunk from an inline-buffer sort (coordinate / template).
     /// All records borrow their bytes from a shared `Arc<SegmentedBuf>`;
     /// `current_bytes` borrows them directly (zero-copy).
@@ -1059,7 +1053,6 @@ impl<K: RawSortKey + Default + 'static> ChunkSource<K> {
     /// record's bytes without copying.
     fn advance(&mut self, consumer: Option<&mut MainThreadChunkConsumer<K>>) -> Result<Option<K>> {
         match self {
-            ChunkSource::Disk { reader, scratch } => reader.next_record(scratch),
             ChunkSource::PoolDisk { source_id, scratch } => {
                 let c = consumer.ok_or_else(|| {
                     anyhow::anyhow!(
@@ -1099,11 +1092,11 @@ impl<K: RawSortKey + Default + 'static> ChunkSource<K> {
     /// Caller MUST have received `Some(_)` from a prior `advance`. The merge
     /// loops uphold this: the init loop only retains a source whose first
     /// `advance` returned `Some`, and the main loop only calls this on the
-    /// active tree winner — so the `Disk`/`PoolDisk` empty-scratch case is
+    /// active tree winner — so the `PoolDisk` empty-scratch case is
     /// unreachable.
     fn current_bytes(&self) -> &[u8] {
         match self {
-            ChunkSource::Disk { scratch, .. } | ChunkSource::PoolDisk { scratch, .. } => scratch,
+            ChunkSource::PoolDisk { scratch, .. } => scratch,
             ChunkSource::Memory { chunk, idx } => {
                 debug_assert!(*idx != usize::MAX, "current_bytes called before advance");
                 chunk.record_bytes(*idx)
@@ -1126,22 +1119,27 @@ impl<K: RawSortKey + Default + 'static> ChunkSource<K> {
 ///
 /// `consumer` must be `Some` whenever `source` is `PoolDisk` (a `PoolDisk`
 /// source only exists when Phase 2 is active, which is exactly when the merge
-/// loops set the consumer); a missing consumer is a pipeline bug and panics here
-/// rather than silently writing empty/stale scratch bytes.
+/// loops set the consumer); a missing consumer is a pipeline bug and returns an
+/// error here — matching [`ChunkSource::advance`]'s handling of the same
+/// invariant — rather than silently writing empty/stale scratch bytes.
 #[inline]
 fn winner_record_bytes<'a, K: RawSortKey + Default + 'static>(
     source: &'a ChunkSource<K>,
     consumer: Option<&'a MainThreadChunkConsumer<K>>,
-) -> &'a [u8] {
+) -> Result<&'a [u8]> {
     match source {
         ChunkSource::PoolDisk { source_id, scratch } => {
-            let consumer =
-                consumer.expect("PoolDisk source requires a MainThreadChunkConsumer during merge");
+            let consumer = consumer.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "PoolDisk source (id {source_id}) requires a MainThreadChunkConsumer \
+                     during merge but none was provided — this is a bug in the sort pipeline"
+                )
+            })?;
             // `Some` on the zero-copy fast path; `None` means the record
             // straddled a block boundary and was reassembled into `scratch`.
-            consumer.current_record_bytes(*source_id).unwrap_or(scratch.as_slice())
+            Ok(consumer.current_record_bytes(*source_id).unwrap_or(scratch.as_slice()))
         }
-        other => other.current_bytes(),
+        other => Ok(other.current_bytes()),
     }
 }
 
@@ -3359,26 +3357,21 @@ impl RawExternalSorter {
 
     /// Build chunk sources from disk files and in-memory chunks.
     ///
-    /// When `pool_decompress` is true, disk sources become `PoolDisk` variants —
-    /// workers read and decompress in the background, main thread parses records.
-    /// No per-source threads are spawned.
-    ///
-    /// When `pool_decompress` is false, disk sources use `GenericKeyedChunkReader`
-    /// with its own per-source background thread — the legacy per-source-reader
-    /// path, now unused since both the plain and indexed merges are
-    /// pool-integrated.
+    /// Disk chunks become `PoolDisk` sources: the shared worker pool reads and
+    /// decompresses them in the background while the main thread parses records,
+    /// so no per-source threads are spawned. Both the plain
+    /// ([`merge_chunks_generic`]) and indexed ([`merge_chunks_with_index`])
+    /// merges go through this pool-integrated path.
     fn build_chunk_sources<K: RawSortKey + Default + 'static>(
         chunk_files: &[PathBuf],
         memory_chunks: MemorySources<K>,
-        reader_concurrency: usize,
-        pool_decompress: bool,
         pool: &Arc<SortWorkerPool>,
     ) -> Result<Vec<ChunkSource<K>>> {
         let num_disk = chunk_files.len();
         let num_memory = memory_chunks.num_non_empty();
         let mut sources: Vec<ChunkSource<K>> = Vec::with_capacity(num_disk + num_memory);
 
-        if pool_decompress && !chunk_files.is_empty() {
+        if !chunk_files.is_empty() {
             // Pool-integrated path: install per-file Phase 2 state on the
             // pool, then create one PoolDisk source per file. Workers
             // cooperatively read+decompress all files via work-stealing.
@@ -3386,15 +3379,6 @@ impl RawExternalSorter {
 
             for source_id in 0..num_disk {
                 sources.push(ChunkSource::PoolDisk { source_id, scratch: Vec::new() });
-            }
-        } else {
-            // Legacy path: per-source reader threads (used by indexing path)
-            let sem = make_reader_semaphore(reader_concurrency);
-            for path in chunk_files {
-                sources.push(ChunkSource::Disk {
-                    reader: GenericKeyedChunkReader::<K>::open(path, Some(Arc::clone(&sem)))?,
-                    scratch: Vec::new(),
-                });
             }
         }
 
@@ -3425,10 +3409,7 @@ impl RawExternalSorter {
             );
         }
 
-        // The pooled path decompresses on the workers, so reader_concurrency is
-        // irrelevant here; pass 1 (build_chunk_sources only uses it for the
-        // legacy per-source-reader path, which pool_decompress=true skips).
-        let sources = Self::build_chunk_sources::<K>(chunk_files, memory_chunks, 1, true, pool)?;
+        let sources = Self::build_chunk_sources::<K>(chunk_files, memory_chunks, pool)?;
         debug!("Merging from {} sources...", sources.len());
 
         // Create the pool consumer for PoolDisk sources and activate Phase 2.
@@ -3522,7 +3503,7 @@ impl RawExternalSorter {
             let src_idx = source_map[winner];
             let sample_this = debug_timing && records_merged.is_multiple_of(merge_sample_interval);
 
-            let record_bytes = winner_record_bytes(&sources[src_idx], guard.consumer_ref());
+            let record_bytes = winner_record_bytes(&sources[src_idx], guard.consumer_ref())?;
             if sample_this {
                 let t0 = Instant::now();
                 writer.write_raw_record(record_bytes)?;
@@ -3643,7 +3624,7 @@ impl RawExternalSorter {
         while tree.winner_is_active() {
             let winner = tree.winner();
             let src_idx = source_map[winner];
-            let record_bytes = winner_record_bytes(&sources[src_idx], guard.consumer_ref());
+            let record_bytes = winner_record_bytes(&sources[src_idx], guard.consumer_ref())?;
             writer.write_raw_record(record_bytes)?;
             merge_progress.log_if_needed(1);
 

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1124,8 +1124,10 @@ impl<K: RawSortKey + Default + 'static> ChunkSource<K> {
 /// boundary. All other source variants borrow from their own backing store via
 /// [`ChunkSource::current_bytes`] and ignore `consumer`.
 ///
-/// `consumer` must be `Some` whenever `source` is `PoolDisk`; the merge loops
-/// uphold this (a `PoolDisk` source only exists when Phase 2 is active).
+/// `consumer` must be `Some` whenever `source` is `PoolDisk` (a `PoolDisk`
+/// source only exists when Phase 2 is active, which is exactly when the merge
+/// loops set the consumer); a missing consumer is a pipeline bug and panics here
+/// rather than silently writing empty/stale scratch bytes.
 #[inline]
 fn winner_record_bytes<'a, K: RawSortKey + Default + 'static>(
     source: &'a ChunkSource<K>,
@@ -1133,7 +1135,11 @@ fn winner_record_bytes<'a, K: RawSortKey + Default + 'static>(
 ) -> &'a [u8] {
     match source {
         ChunkSource::PoolDisk { source_id, scratch } => {
-            consumer.and_then(|c| c.current_record_bytes(*source_id)).unwrap_or(scratch.as_slice())
+            let consumer =
+                consumer.expect("PoolDisk source requires a MainThreadChunkConsumer during merge");
+            // `Some` on the zero-copy fast path; `None` means the record
+            // straddled a block boundary and was reassembled into `scratch`.
+            consumer.current_record_bytes(*source_id).unwrap_or(scratch.as_slice())
         }
         other => other.current_bytes(),
     }
@@ -3358,8 +3364,9 @@ impl RawExternalSorter {
     /// No per-source threads are spawned.
     ///
     /// When `pool_decompress` is false, disk sources use `GenericKeyedChunkReader`
-    /// with its own per-source background thread. Used by the indexing path, which
-    /// does not yet support pool-integrated decompression.
+    /// with its own per-source background thread — the legacy per-source-reader
+    /// path, now unused since both the plain and indexed merges are
+    /// pool-integrated.
     fn build_chunk_sources<K: RawSortKey + Default + 'static>(
         chunk_files: &[PathBuf],
         memory_chunks: MemorySources<K>,
@@ -3396,6 +3403,55 @@ impl RawExternalSorter {
         Ok(sources)
     }
 
+    /// Build the pooled merge sources and activate Phase 2.
+    ///
+    /// Shared by both the plain ([`merge_chunks_generic`]) and indexed
+    /// ([`merge_chunks_with_index`]) merges so the Phase-2 lifecycle is
+    /// single-sourced and the two paths cannot drift. Returns the sources plus
+    /// an RAII [`Phase2Guard`] (borrowing `pool`) that resets Phase 2 on drop or
+    /// explicit `deactivate()`. When there are no disk chunks the guard is
+    /// inactive and carries no consumer.
+    fn setup_phase2_merge<'a, K: RawSortKey + Default + 'static>(
+        chunk_files: &[PathBuf],
+        memory_chunks: MemorySources<K>,
+        pool: &'a Arc<SortWorkerPool>,
+    ) -> Result<(Vec<ChunkSource<K>>, Phase2Guard<'a, K>)> {
+        let num_disk = chunk_files.len();
+        if num_disk > 0 {
+            debug!(
+                "Pool-integrated merge: {} disk sources, {} pool workers (N+2 model)",
+                num_disk,
+                pool.num_workers()
+            );
+        }
+
+        // The pooled path decompresses on the workers, so reader_concurrency is
+        // irrelevant here; pass 1 (build_chunk_sources only uses it for the
+        // legacy per-source-reader path, which pool_decompress=true skips).
+        let sources = Self::build_chunk_sources::<K>(chunk_files, memory_chunks, 1, true, pool)?;
+        debug!("Merging from {} sources...", sources.len());
+
+        // Create the pool consumer for PoolDisk sources and activate Phase 2.
+        // The consumer holds an Arc snapshot of the pool's per-file Phase 2
+        // state — workers populate per-file reorder buffers, the consumer pops
+        // from them.
+        let guard = if num_disk > 0 {
+            let files = pool.phase2_files();
+            let consumer = MainThreadChunkConsumer::new(
+                files,
+                pool.decompress_error_flag(),
+                pool.chunk_read_error_flag(),
+                pool.worker_panicked_flag(),
+            );
+            pool.set_phase(crate::worker_pool::phase::PHASE2);
+            Phase2Guard { pool, consumer: Some(consumer), active: true }
+        } else {
+            Phase2Guard { pool, consumer: None, active: false }
+        };
+
+        Ok((sources, guard))
+    }
+
     /// Generic merge for keyed chunks using `O(1)` key comparisons.
     ///
     /// This is the unified merge function that works with any `RawSortKey` type.
@@ -3413,47 +3469,9 @@ impl RawExternalSorter {
     ) -> Result<u64> {
         use crate::loser_tree::LoserTree;
         use crate::pooled_bam_writer::PooledBamWriter;
-        use crate::worker_pool::phase;
 
-        let reader_concurrency: usize = 1;
-        let num_disk = chunk_files.len();
-
-        if num_disk > 0 {
-            debug!(
-                "Pool-integrated merge: {} disk sources, {} pool workers (N+2 model)",
-                num_disk,
-                pool.num_workers()
-            );
-        }
-
-        let mut sources = Self::build_chunk_sources::<K>(
-            chunk_files,
-            memory_chunks,
-            reader_concurrency,
-            true,
-            pool,
-        )?;
-
-        let num_sources = sources.len();
-        debug!("Merging from {num_sources} sources...");
-
-        // Create pool consumer for PoolDisk sources and activate Phase 2.
-        // The consumer holds an Arc snapshot of the pool's per-file Phase 2
-        // state — workers populate per-file reorder buffers, the consumer pops
-        // from them.
-        let mut guard: Phase2Guard<'_, K> = if num_disk > 0 {
-            let files = pool.phase2_files();
-            let consumer = MainThreadChunkConsumer::new(
-                files,
-                pool.decompress_error_flag(),
-                pool.chunk_read_error_flag(),
-                pool.worker_panicked_flag(),
-            );
-            pool.set_phase(phase::PHASE2);
-            Phase2Guard { pool, consumer: Some(consumer), active: true }
-        } else {
-            Phase2Guard { pool, consumer: None, active: false }
-        };
+        let (mut sources, mut guard) =
+            Self::setup_phase2_merge::<K>(chunk_files, memory_chunks, pool)?;
 
         let output_header = self.create_output_header(header);
 
@@ -3590,45 +3608,9 @@ impl RawExternalSorter {
     ) -> Result<noodles::bam::bai::Index> {
         use crate::loser_tree::LoserTree;
         use crate::pooled_bam_writer::PooledBamWriter;
-        use crate::worker_pool::phase;
 
-        let reader_concurrency: usize = 1;
-        let num_disk = chunk_files.len();
-
-        if num_disk > 0 {
-            debug!(
-                "Pool-integrated indexed merge: {} disk sources, {} pool workers (N+2 model)",
-                num_disk,
-                pool.num_workers()
-            );
-        }
-
-        let mut sources = Self::build_chunk_sources::<K>(
-            chunk_files,
-            memory_chunks,
-            reader_concurrency,
-            true,
-            pool,
-        )?;
-
-        let num_sources = sources.len();
-        debug!("Merging from {num_sources} sources (indexing)...");
-
-        // Create the pool consumer for PoolDisk sources and activate Phase 2,
-        // exactly as merge_chunks_generic does.
-        let mut guard: Phase2Guard<'_, K> = if num_disk > 0 {
-            let files = pool.phase2_files();
-            let consumer = MainThreadChunkConsumer::new(
-                files,
-                pool.decompress_error_flag(),
-                pool.chunk_read_error_flag(),
-                pool.worker_panicked_flag(),
-            );
-            pool.set_phase(phase::PHASE2);
-            Phase2Guard { pool, consumer: Some(consumer), active: true }
-        } else {
-            Phase2Guard { pool, consumer: None, active: false }
-        };
+        let (mut sources, mut guard) =
+            Self::setup_phase2_merge::<K>(chunk_files, memory_chunks, pool)?;
 
         let output_header = self.create_output_header(header);
 
@@ -6178,6 +6160,63 @@ mod tests {
                 stale.display(),
             );
         }
+    }
+
+    /// A record spanning multiple BGZF blocks must resolve correct virtual
+    /// offsets through the pool-integrated indexed merge.
+    ///
+    /// Normal records never straddle a block boundary (the spill writer
+    /// pre-flushes), so an oversized record is the only thing that drives
+    /// `BaiBuilder`'s cross-block `compute_end_vpos` walk while
+    /// `merge_chunks_with_index` builds the index — a wrong block stride there
+    /// would fail the index build or emit a corrupt `.bai`. This is the
+    /// non-samtools counterpart to the `#[ignore]` samtools cross-check: it
+    /// forces the oversized record through a spilled indexed merge, then loads
+    /// the produced `.bai` back and checks it is well-formed.
+    #[test]
+    fn test_write_index_oversized_record_builds_loadable_bai() {
+        use fgumi_sam::SamBuilder;
+
+        let big_seq = "A".repeat(70_000); // > one ~64 KB BGZF block
+        let mut builder = SamBuilder::new();
+        for i in 0..80 {
+            let _ = builder.add_frag().name(&format!("n{i:04}")).contig(0).start(i + 1).build();
+        }
+        let _ = builder.add_frag().name("oversized").contig(0).start(40).bases(&big_seq).build();
+        for i in 0..80 {
+            let _ = builder.add_frag().name(&format!("m{i:04}")).contig(0).start(i + 1).build();
+        }
+        let expected_refs = builder.header.reference_sequences().len();
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = dir.path().join("input.bam");
+        let output = dir.path().join("output.bam");
+        builder.write_bam(&input).expect("write_bam");
+
+        let stats = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(64 * 1024) // below the oversized record → forces it into a spill chunk
+            .threads(2) // multi-source pool-integrated indexed merge
+            .write_index(true) // routes through merge_chunks_with_index
+            .spill_codec(crate::codec::SpillCodec::Bgzf)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort(&input, &output)
+            .expect("indexed coordinate sort should succeed");
+        assert!(stats.chunks_written > 0, "test must spill so the indexed pool merge runs");
+
+        // Every record (including the oversized one) survives the merge.
+        assert_eq!(count_bam_records(&output), 161);
+
+        // The .bai the indexed merge produced must load cleanly and cover every
+        // reference: a corrupt cross-block virtual offset would have failed the
+        // index build above or produced an unreadable sidecar here.
+        let bai = fgumi_bam_io::bai_sidecar_path(&output);
+        let index = noodles::bam::bai::fs::read(&bai).expect("BAI must be loadable");
+        assert_eq!(
+            index.reference_sequences().len(),
+            expected_refs,
+            "index should cover every reference sequence"
+        );
     }
 
     /// Per-phase thread counts are a scheduling knob only: whatever the split,

--- a/crates/fgumi-sort/src/pooled_bam_writer.rs
+++ b/crates/fgumi-sort/src/pooled_bam_writer.rs
@@ -20,12 +20,14 @@
 //!                                              ──────► write ordered
 //! ```
 
-use crate::bgzf_io::{StagingBuffer, io_writer_loop};
+use crate::bgzf_io::{BlockOffset, StagingBuffer, io_writer_loop};
 use crate::codec::SpillCodec;
 use crate::worker_pool::{CompressResult, PermitPool, SortWorkerPool};
 use anyhow::Result;
-use crossbeam_channel::bounded;
+use crossbeam_channel::{Receiver, bounded, unbounded};
+use fgumi_bam_io::BaiBuilder;
 use fgumi_bgzf::BGZF_MAX_BLOCK_SIZE;
+use noodles::bam::bai;
 use noodles::sam::Header;
 use std::io::BufWriter;
 use std::path::Path;
@@ -45,6 +47,19 @@ pub struct PooledBamWriter {
     /// `None` only after `start_finish()` transfers ownership to `SpillWriteHandle`.
     staging: Option<StagingBuffer>,
     io_handle: Option<JoinHandle<Result<()>>>,
+    /// Present only for writers created via [`PooledBamWriter::new_indexing`];
+    /// drives incremental BAI generation.
+    index: Option<IndexState>,
+}
+
+/// State for incremental BAI generation, held only by an indexing writer.
+struct IndexState {
+    /// Shared virtual-offset accumulator (identical logic to `IndexingBamWriter`).
+    bai: BaiBuilder,
+    /// Per-block `(serial, compressed_start)` notifications from the I/O thread.
+    block_offset_rx: Receiver<BlockOffset>,
+    /// Number of reference sequences, needed to finalize the index.
+    num_refs: usize,
 }
 
 impl PooledBamWriter {
@@ -59,6 +74,32 @@ impl PooledBamWriter {
     /// Returns an error if the output file cannot be created or the header cannot
     /// be serialized.
     pub fn new(pool: Arc<SortWorkerPool>, path: &Path, header: &Header) -> Result<Self> {
+        Self::new_inner(pool, path, header, false)
+    }
+
+    /// Create a pooled BAM writer that also builds a BAI index during the write.
+    ///
+    /// Output bytes are identical to [`new`](Self::new); additionally, each
+    /// record's virtual file offset is tracked and the index is returned by
+    /// [`finish_index`](Self::finish_index). Only meaningful for
+    /// coordinate-sorted output.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output file cannot be created or the header
+    /// cannot be serialized.
+    pub fn new_indexing(pool: Arc<SortWorkerPool>, path: &Path, header: &Header) -> Result<Self> {
+        Self::new_inner(pool, path, header, true)
+    }
+
+    /// Shared constructor for [`new`](Self::new) and
+    /// [`new_indexing`](Self::new_indexing).
+    fn new_inner(
+        pool: Arc<SortWorkerPool>,
+        path: &Path,
+        header: &Header,
+        indexing: bool,
+    ) -> Result<Self> {
         let file = std::fs::File::create(path)?;
         let writer = BufWriter::with_capacity(256 * 1024, file);
 
@@ -67,9 +108,20 @@ impl PooledBamWriter {
         let buffer_pool = pool.buffer_pool.clone();
         let permit_pool = Arc::new(PermitPool::new(reorder_capacity));
 
+        // When indexing, wire an unbounded channel so the I/O thread can emit
+        // each block's compressed start offset without ever blocking on send
+        // (the consumer drains it during writes and once more at finish).
+        let (block_offset_tx, index) = if indexing {
+            let (tx, rx) = unbounded::<BlockOffset>();
+            let num_refs = header.reference_sequences().len();
+            (Some(tx), Some(IndexState { bai: BaiBuilder::new(), block_offset_rx: rx, num_refs }))
+        } else {
+            (None, None)
+        };
+
         let pp = Arc::clone(&permit_pool);
         let io_handle = thread::spawn(move || {
-            io_writer_loop(writer, result_rx, buffer_pool, pp, SpillCodec::Bgzf)
+            io_writer_loop(writer, result_rx, buffer_pool, pp, SpillCodec::Bgzf, block_offset_tx)
         });
 
         let mut staging = StagingBuffer::new(pool, result_tx, permit_pool, SpillCodec::Bgzf);
@@ -81,7 +133,7 @@ impl PooledBamWriter {
         staging.write_chunked(&header_buf)?;
         staging.flush()?;
 
-        Ok(Self { staging: Some(staging), io_handle: Some(io_handle) })
+        Ok(Self { staging: Some(staging), io_handle: Some(io_handle), index })
     }
 
     /// Write a raw BAM record to the output.
@@ -107,6 +159,15 @@ impl PooledBamWriter {
         if staging.buf().len() + needed > BGZF_MAX_BLOCK_SIZE {
             staging.flush()?;
         }
+        // For indexing, capture the record's start position *after* any pre-flush
+        // and *before* appending. `next_serial`/`buf_len` are the writer's own
+        // block number and uncompressed offset, so the recorded position matches
+        // the block layout exactly (records never straddle a block except the
+        // oversized case below, which `compute_end_vpos` resolves by walking
+        // full-size blocks forward).
+        if let Some(index) = self.index.as_mut() {
+            index.bai.record(staging.next_serial(), staging.buf_len(), needed, record_bytes);
+        }
         // Write the 4-byte length prefix (always fits: staging is empty after the pre-flush,
         // and 4 bytes is well within BGZF_MAX_BLOCK_SIZE).
         staging.buf().extend_from_slice(&block_size.to_le_bytes());
@@ -117,6 +178,14 @@ impl PooledBamWriter {
         } else {
             staging.buf().extend_from_slice(record_bytes);
             staging.flush_if_full()?;
+        }
+        // Drain block-offset notifications and resolve completed records so the
+        // pending-entry cache stays bounded by the in-flight block count.
+        if let Some(index) = self.index.as_mut() {
+            while let Ok(bo) = index.block_offset_rx.try_recv() {
+                index.bai.note_block(bo.serial, bo.compressed_start);
+            }
+            index.bai.resolve()?;
         }
         Ok(())
     }
@@ -145,6 +214,50 @@ impl PooledBamWriter {
             drop(staging); // closes result_tx → I/O thread exits after draining
         }
         Ok(SpillWriteHandle::new(self.io_handle.take()))
+    }
+
+    /// Finish writing and return the BAI index built during the write.
+    ///
+    /// Flushes remaining data, joins the I/O thread (ensuring every block is
+    /// written and every block-offset notification emitted), resolves the
+    /// trailing records, and builds the index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called on a writer not created via
+    /// [`new_indexing`](Self::new_indexing).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if flushing, the I/O thread, or index construction
+    /// fails (the latter includes any record whose block offset was never
+    /// observed).
+    pub fn finish_index(mut self) -> Result<bai::Index> {
+        let mut index = self.index.take().expect("finish_index requires an indexing writer");
+
+        // Flush remaining staging and close the input to the I/O thread.
+        if let Some(mut staging) = self.staging.take() {
+            if !staging.buf().is_empty() {
+                staging.flush()?;
+            }
+            // Closes result_tx → I/O thread drains, writes all blocks, emits all
+            // offsets, then exits (dropping its block-offset sender).
+            drop(staging);
+        }
+
+        // Join the I/O thread so every block offset has been emitted before we
+        // drain the channel for the last time.
+        if let Some(handle) = self.io_handle.take() {
+            handle.join().map_err(|_| anyhow::anyhow!("I/O writer thread panicked"))??;
+        }
+
+        // Drain the final block offsets and resolve the remaining records.
+        while let Ok(bo) = index.block_offset_rx.try_recv() {
+            index.bai.note_block(bo.serial, bo.compressed_start);
+        }
+        index.bai.resolve()?;
+        let idx = index.bai.build(index.num_refs)?;
+        Ok(idx)
     }
 }
 
@@ -219,6 +332,103 @@ mod tests {
         rec.resize(rec.len() + seq_len, 0xFF); // qual
 
         rec
+    }
+
+    /// Create a mapped raw BAM record with a single `seq_len`M CIGAR at
+    /// `(ref_id, pos)` (0-based pos), mapq 60, flag 0.
+    #[allow(clippy::cast_possible_truncation)]
+    fn make_mapped_record(name: &[u8], ref_id: i32, pos: i32, seq_len: usize) -> Vec<u8> {
+        let name_len = name.len() + 1;
+        let seq_bytes = seq_len.div_ceil(2);
+        let mut rec = Vec::new();
+
+        rec.extend_from_slice(&ref_id.to_le_bytes());
+        rec.extend_from_slice(&pos.to_le_bytes());
+        let bin_mq_nl: u32 = (name_len as u32) | (60u32 << 8) | (4680u32 << 16); // mapq 60
+        rec.extend_from_slice(&bin_mq_nl.to_le_bytes());
+        let flag_nc: u32 = 1; // n_cigar_op = 1, flag = 0 (mapped)
+        rec.extend_from_slice(&flag_nc.to_le_bytes());
+        rec.extend_from_slice(&(seq_len as u32).to_le_bytes());
+        rec.extend_from_slice(&(-1i32).to_le_bytes()); // mate_ref_id
+        rec.extend_from_slice(&(-1i32).to_le_bytes()); // mate_pos
+        rec.extend_from_slice(&0i32.to_le_bytes()); // tlen
+        rec.extend_from_slice(name);
+        rec.push(0); // null terminator
+        let cigar_op: u32 = (seq_len as u32) << 4; // seq_len M (op code 0)
+        rec.extend_from_slice(&cigar_op.to_le_bytes());
+        rec.resize(rec.len() + seq_bytes, 0x11); // seq
+        rec.resize(rec.len() + seq_len, 0xFF); // qual
+        rec
+    }
+
+    /// The indexing writer must produce byte-identical BAM output to the plain
+    /// pooled writer (indexing is a pure side-channel) and yield a writable BAI.
+    ///
+    /// Covers a coordinate-sorted mix that spans many BGZF blocks: mapped reads
+    /// on two references, trailing unmapped reads, and an oversized record that
+    /// spans multiple blocks (exercising cross-block virtual-offset accounting).
+    #[test]
+    fn test_indexing_writer_output_matches_plain_and_writes_bai() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let header = test_header(); // chr1 (100k), chr2 (200k)
+
+        let mut records: Vec<Vec<u8>> = Vec::new();
+        for i in 0..1500 {
+            records.push(make_mapped_record(format!("c1_{i:05}").as_bytes(), 0, i * 30, 60));
+        }
+        for i in 0..1500 {
+            records.push(make_mapped_record(format!("c2_{i:05}").as_bytes(), 1, i * 30, 60));
+        }
+        for i in 0..100 {
+            records.push(make_test_record(format!("unm_{i:03}").as_bytes(), 60)); // unmapped
+        }
+        // Oversized (unmapped) record that spans multiple BGZF blocks.
+        records.push(make_test_record(b"oversized", BGZF_MAX_BLOCK_SIZE + 500));
+
+        let pool = Arc::new(SortWorkerPool::new(4, 1, 6, crate::codec::SpillCodec::Bgzf));
+
+        let plain_path = dir.path().join("plain.bam");
+        {
+            let mut w = PooledBamWriter::new(Arc::clone(&pool), &plain_path, &header)
+                .expect("plain writer");
+            for r in &records {
+                w.write_raw_record(r).expect("write");
+            }
+            w.finish().expect("finish plain");
+        }
+
+        let indexed_path = dir.path().join("indexed.bam");
+        let index = {
+            let mut w = PooledBamWriter::new_indexing(Arc::clone(&pool), &indexed_path, &header)
+                .expect("indexing writer");
+            for r in &records {
+                w.write_raw_record(r).expect("write");
+            }
+            w.finish_index().expect("finish_index")
+        };
+
+        // Indexing must not change a single output byte.
+        assert_eq!(
+            std::fs::read(&plain_path).expect("read plain"),
+            std::fs::read(&indexed_path).expect("read indexed"),
+            "indexing writer must produce byte-identical BAM output to the plain writer"
+        );
+
+        // The returned index must serialize to a sidecar that loads back cleanly
+        // and covers every reference: a non-empty file alone would not catch a
+        // corrupt virtual offset, which is the contract this writer owes.
+        let bai_path = dir.path().join("indexed.bam.bai");
+        fgumi_bam_io::write_bai_index(&bai_path, &index).expect("write bai");
+        let loaded = bai::fs::read(&bai_path).expect("BAI must be loadable");
+        assert_eq!(
+            loaded.reference_sequences().len(),
+            header.reference_sequences().len(),
+            "index should cover every reference sequence"
+        );
+
+        if let Ok(pool) = Arc::try_unwrap(pool) {
+            pool.shutdown();
+        }
     }
 
     #[test]

--- a/crates/fgumi-sort/src/pooled_bam_writer.rs
+++ b/crates/fgumi-sort/src/pooled_bam_writer.rs
@@ -199,6 +199,22 @@ impl PooledBamWriter {
         self.start_finish()?.wait()
     }
 
+    /// Flush any remaining staged data and drop the staging buffer.
+    ///
+    /// Dropping the staging buffer closes the result channel, so the I/O thread
+    /// drains its queue, writes every block (and, for an indexing writer, emits
+    /// every block offset), then exits. Shared by
+    /// [`start_finish`](Self::start_finish) and [`finish_index`](Self::finish_index).
+    fn flush_and_close_staging(&mut self) -> Result<()> {
+        if let Some(mut staging) = self.staging.take() {
+            if !staging.buf().is_empty() {
+                staging.flush()?;
+            }
+            drop(staging);
+        }
+        Ok(())
+    }
+
     /// Flush remaining data and signal the I/O thread, but don't wait for it.
     ///
     /// Returns a [`SpillWriteHandle`] that can be waited on later.
@@ -207,12 +223,7 @@ impl PooledBamWriter {
     ///
     /// Returns an error if flushing the staging buffer fails.
     pub fn start_finish(mut self) -> Result<SpillWriteHandle> {
-        if let Some(mut staging) = self.staging.take() {
-            if !staging.buf().is_empty() {
-                staging.flush()?;
-            }
-            drop(staging); // closes result_tx → I/O thread exits after draining
-        }
+        self.flush_and_close_staging()?;
         Ok(SpillWriteHandle::new(self.io_handle.take()))
     }
 
@@ -235,15 +246,10 @@ impl PooledBamWriter {
     pub fn finish_index(mut self) -> Result<bai::Index> {
         let mut index = self.index.take().expect("finish_index requires an indexing writer");
 
-        // Flush remaining staging and close the input to the I/O thread.
-        if let Some(mut staging) = self.staging.take() {
-            if !staging.buf().is_empty() {
-                staging.flush()?;
-            }
-            // Closes result_tx → I/O thread drains, writes all blocks, emits all
-            // offsets, then exits (dropping its block-offset sender).
-            drop(staging);
-        }
+        // Flush remaining staging and close the input to the I/O thread: it then
+        // drains, writes all blocks, emits all offsets, and exits (dropping its
+        // block-offset sender).
+        self.flush_and_close_staging()?;
 
         // Join the I/O thread so every block offset has been emitted before we
         // drain the channel for the last time.

--- a/crates/fgumi-sort/src/pooled_chunk_writer.rs
+++ b/crates/fgumi-sort/src/pooled_chunk_writer.rs
@@ -75,7 +75,7 @@ impl<K: RawSortKey> PooledChunkWriter<K> {
 
         let pp = Arc::clone(&permit_pool);
         let io_handle =
-            thread::spawn(move || io_writer_loop(writer, result_rx, buffer_pool, pp, codec));
+            thread::spawn(move || io_writer_loop(writer, result_rx, buffer_pool, pp, codec, None));
 
         Ok(Self {
             staging: Some(StagingBuffer::new(pool, result_tx, permit_pool, codec)),

--- a/tests/integration/test_sort_write_index.rs
+++ b/tests/integration/test_sort_write_index.rs
@@ -10,7 +10,8 @@ use clap::Parser;
 use fgumi_lib::commands::command::Command as FgumiCommand;
 use fgumi_lib::commands::sort::Sort;
 use std::ffi::OsStr;
-use std::path::Path;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
 
@@ -170,5 +171,180 @@ fn test_write_index_requires_coordinate_sort() {
     assert!(
         err_msg.contains("--write-index is only valid for coordinate sort"),
         "Expected error about coordinate sort, got: {err_msg}"
+    );
+}
+
+/// Build a larger unsorted BAM: `mapped_per_contig` mapped reads on each of
+/// chr1/chr2 at scattered positions, plus some unmapped reads. Large enough to
+/// span many BGZF blocks so cross-block virtual offsets are exercised.
+fn create_large_test_bam(dir: &Path, mapped_per_contig: usize) -> PathBuf {
+    let mut sam = String::from(
+        "@HD\tVN:1.6\tSO:unsorted\n@SQ\tSN:chr1\tLN:1000000\n@SQ\tSN:chr2\tLN:1000000\n",
+    );
+    // Interleave contigs and scatter positions (unsorted input); fgumi sorts it.
+    for i in 0..mapped_per_contig {
+        let p1 = 1 + (i * 37) % 999_000;
+        let p2 = 1 + (i * 53 + 11) % 999_000;
+        let _ = writeln!(sam, "r1_{i}\t0\tchr1\t{p1}\t60\t10M\t*\t0\t0\tACGTACGTAC\tIIIIIIIIII");
+        let _ = writeln!(sam, "r2_{i}\t0\tchr2\t{p2}\t60\t10M\t*\t0\t0\tACGTACGTAC\tIIIIIIIIII");
+    }
+    for i in 0..100 {
+        let _ = writeln!(sam, "u_{i}\t4\t*\t0\t0\t*\t*\t0\t0\tACGTACGTAC\tIIIIIIIIII");
+    }
+    // Placed-but-unmapped reads: FUNMAP (0x4) set, but with a reference + position
+    // (e.g. the unmapped mate of a mapped read). samtools position-bins these so
+    // they appear in region queries; fgumi's indexer classifies them as unmapped
+    // and does not position-bin them (pre-existing behavior, unchanged by the
+    // pooled-writer work). The test therefore compares MAPPED-only retrieval.
+    for i in 0..2000 {
+        let p1 = 1 + (i * 101) % 999_000;
+        let p2 = 1 + (i * 149 + 7) % 999_000;
+        let _ = writeln!(sam, "pu1_{i}\t4\tchr1\t{p1}\t0\t*\t*\t0\t0\tACGTACGTAC\tIIIIIIIIII");
+        let _ = writeln!(sam, "pu2_{i}\t4\tchr2\t{p2}\t0\t*\t*\t0\t0\tACGTACGTAC\tIIIIIIIIII");
+    }
+
+    let sam_path = dir.join("large_input.sam");
+    std::fs::write(&sam_path, sam).expect("write SAM");
+    let bam_path = dir.join("large_input.bam");
+    let status = Command::new("samtools")
+        .args(["view", "-b", "-o", bam_path.to_str().unwrap(), sam_path.to_str().unwrap()])
+        .status()
+        .expect("run samtools view");
+    assert!(status.success(), "samtools view failed");
+    bam_path
+}
+
+/// `samtools view -c [extra] <bam> <region>` — record count in a region via the
+/// `.bai`. `extra` carries filter flags (e.g. `-F 4` to count mapped reads only).
+fn region_count(bam: &Path, region: &str, extra: &[&str]) -> i64 {
+    let out = Command::new("samtools")
+        .arg("view")
+        .arg("-c")
+        .args(extra)
+        .args([bam.to_str().unwrap(), region])
+        .output()
+        .expect("run samtools view -c");
+    assert!(
+        out.status.success(),
+        "samtools view -c {region} failed on {}: {}",
+        bam.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().parse().expect("parse count")
+}
+
+/// Per-reference MAPPED counts (`ref\tlen\tmapped`) from idxstats. Excludes the
+/// unmapped column, which legitimately differs for placed-but-unmapped reads.
+fn idxstats_mapped(bam: &Path) -> String {
+    idxstats(bam)
+        .lines()
+        .map(|line| {
+            let mut f = line.split('\t');
+            format!(
+                "{}\t{}\t{}",
+                f.next().unwrap_or_default(),
+                f.next().unwrap_or_default(),
+                f.next().unwrap_or_default()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// `samtools idxstats <bam>` — per-reference mapped/unmapped counts from the `.bai`.
+fn idxstats(bam: &Path) -> String {
+    let out = Command::new("samtools")
+        .args(["idxstats", bam.to_str().unwrap()])
+        .output()
+        .expect("run samtools idxstats");
+    assert!(
+        out.status.success(),
+        "samtools idxstats failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// The `.bai` fgumi writes must be equivalent to one samtools builds for the
+/// *same* output bytes: identical region counts and identical idxstats.
+///
+/// This is the strong correctness check for the pooled indexing writer — it
+/// validates the recovered virtual offsets against samtools (the reference
+/// implementation) across a spill-forcing, multi-block, multi-threaded sort.
+#[test]
+#[ignore = "requires samtools"]
+fn test_sort_write_index_matches_samtools_index() {
+    if !samtools_available() {
+        eprintln!("Skipping: samtools not available");
+        return;
+    }
+
+    let temp_dir = TempDir::new().unwrap();
+    // 15k reads/contig + unmapped → many BGZF blocks; -m 64K forces many spills
+    // and a consolidation pass, so the fixed pooled indexed merge is exercised.
+    let input_bam = create_large_test_bam(temp_dir.path(), 15_000);
+    let sorted = temp_dir.path().join("sorted.bam");
+    let fgumi_bai = temp_dir.path().join("sorted.bam.bai");
+
+    let cmd = Sort::try_parse_from([
+        OsStr::new("sort"),
+        OsStr::new("-i"),
+        input_bam.as_os_str(),
+        OsStr::new("-o"),
+        sorted.as_os_str(),
+        OsStr::new("--order"),
+        OsStr::new("coordinate"),
+        OsStr::new("--write-index"),
+        OsStr::new("-m"),
+        OsStr::new("64K"),
+        OsStr::new("-@"),
+        OsStr::new("4"),
+    ])
+    .expect("parse sort args");
+    cmd.execute("fgumi sort").expect("fgumi sort --write-index failed");
+    assert!(sorted.exists() && fgumi_bai.exists(), "sorted BAM + fgumi .bai must exist");
+
+    // Reference index: let samtools index the identical output bytes.
+    let reference = temp_dir.path().join("reference.bam");
+    std::fs::copy(&sorted, &reference).expect("copy sorted bam");
+    let status = Command::new("samtools")
+        .args(["index", reference.to_str().unwrap()])
+        .status()
+        .expect("run samtools index");
+    assert!(status.success(), "samtools index failed");
+
+    // Region counts via fgumi's .bai must equal those via samtools' .bai.
+    let regions = [
+        "chr1",
+        "chr2",
+        "chr1:1-100000",
+        "chr1:500000-600000",
+        "chr2:1-1000000",
+        "chr2:250000-250500",
+        "chr1:999500-1000000",
+        "chr1:1-1000000",
+    ];
+    // MAPPED-read retrieval (`-F 4`) via fgumi's .bai must exactly match samtools'
+    // .bai over the same bytes — this validates the recovered virtual offsets.
+    // (Placed-but-unmapped reads are position-binned by samtools but not by fgumi;
+    // see create_large_test_bam. That is a pre-existing indexing choice, not a
+    // property of the pooled writer, so it is deliberately excluded here.)
+    let mut total = 0i64;
+    for r in regions {
+        let via_fgumi = region_count(&sorted, r, &["-F", "4"]);
+        let via_samtools = region_count(&reference, r, &["-F", "4"]);
+        assert_eq!(
+            via_fgumi, via_samtools,
+            "region {r}: fgumi .bai mapped count {via_fgumi} != samtools .bai {via_samtools}"
+        );
+        total += via_fgumi;
+    }
+    assert!(total > 0, "expected non-empty mapped region queries");
+
+    // Per-reference mapped counts must match exactly.
+    assert_eq!(
+        idxstats_mapped(&sorted),
+        idxstats_mapped(&reference),
+        "per-reference mapped counts via fgumi .bai must match samtools"
     );
 }


### PR DESCRIPTION
## Summary

Fixes and then optimizes the coordinate `--write-index` merge. Stacked on #643 (base `tf_expose_sort_temp_limit`), so this PR shows only the write-index changes.

Three commits:

1. **Pool-integrate the indexed merge.** `RawExternalSorter::merge_chunks_with_index` took a different, far slower path than the plain coordinate merge: it forced `reader_concurrency = 1`, `pool_decompress = false`, and a standalone `create_indexing_bam_writer`, which serialized input decompression to a single reader and bypassed the shared worker pool entirely — so the merge thread ran hot while the pool sat idle. It now mirrors `merge_chunks_generic`: `PoolDisk` sources decompressed by the worker pool, output through `PooledBamWriter::new_indexing`, with BAI virtual-offset tracking hooked into the pooled output.

2. **Borrow merge records in place (zero-copy read).** The k-way merge copied every record twice — once from the decompressed block into a per-source scratch buffer, then again into the writer's staging buffer. The first copy is now elided: when a record is contiguous in its current decompressed block (the ~100% common case, since the spill writer pre-flushes records to block boundaries) it is borrowed in place; only a record that straddles a block boundary falls back to reassembling into scratch. This is shared by the plain and indexed merges, so both get faster.

3. **Buffer the `.bai` write.** `write_bai_index` handed the output file straight to `bai::io::Writer`, which emits the index as many tiny fields — one `write()` syscall per field. It now serializes into memory and writes the sidecar in a single call.

## BAI correctness

`BaiBuilder` is extracted from `IndexingBamWriter` so the vendored-writer path and the pooled path share one virtual-offset implementation. Records are cached in write order (which is non-decreasing block order) and resolved strictly from the front of a `VecDeque`, and the `block_number -> compressed offset` map is pruned behind the front record so it stays bounded to the in-flight block window rather than growing one entry per block for the whole output.

## Validation

- Full gate green: `cargo ci-fmt`, `cargo ci-lint` (clippy pedantic), `cargo ci-test` (5746 tests).
- Output is **byte-identical** to the plain pooled writer (unit test), and the generated `.bai` **matches samtools exactly** — mapped-only region counts and per-reference `idxstats`, on a forced spill + consolidation + multithreaded input (`#[ignore]`, requires samtools).
- A new non-samtools test drives an oversized (multi-block) record through a spilled `--write-index` merge and loads the produced `.bai` back, covering `BaiBuilder`'s cross-block offset resolution.
- Real WGS (NA12813, 1.287B reads, coordinate `--write-index`, `-@ 8`): after this PR the indexed merge is ~234s and the full sort ~599s; the zero-copy read and buffered `.bai` account for ~272s → ~234s merge and ~659s → ~599s total on top of the initial pooling fix. Real-file mapped-only region counts and per-reference mapped counts match samtools exactly.

## Known limitation (pre-existing, not introduced here)

`extract_alignment_context` returns `None` for a placed-but-unmapped read — one with a valid `RNAME`/`POS` but the `FUNMAP` flag set — so such reads are not position-binned and region queries miss them. This behavior is carried verbatim from the original `IndexingBamWriter`; it is why the samtools cross-checks compare mapped-only (`-F 4`). Whether to match htslib's position-binning of these reads is worth deciding separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for generating BAI indexes while sorting BAM files (including incremental index building during output).
* **Bug Fixes**
  * Improved BAI virtual-offset resolution for boundary and edge cases.
  * More reliable handling of oversized records that span compressed blocks.
  * Reduced unnecessary data copying during pooled merges for better correctness and efficiency.
* **Tests**
  * Expanded indexed-write coverage, including oversized-record spill/boundary handling.
  * Added samtools-compatibility verification for `.bai` output (guarded/disabled by default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->