### PR TITLE
docs(dedup,group): document that --no-umi still splits by strand of origin

### DIFF
--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -215,7 +215,7 @@ struct DedupFilterConfig {
     include_non_pf: bool,
     /// Minimum UMI length.
     min_umi_length: Option<usize>,
-    /// Skip UMI validation (position-only grouping).
+    /// Skip UMI validation; group by template coordinate and strand of origin alone.
     no_umi: bool,
 }
 
@@ -972,8 +972,34 @@ Pass-through templates are written verbatim: never marked, never MI-tagged, and 
 unique in the metrics.
 
 The counts of templates dropped for each reason are reported in the metrics output
-(--metrics). Deduplication of the templates that remain (representative selection, the
-0x400 flag, and --remove-duplicates) follows Picard `MarkDuplicates` semantics.
+(--metrics). For the templates that remain, representative selection (the duplicate score),
+the 0x400 flag, and --remove-duplicates follow Picard `MarkDuplicates` semantics; the
+grouping key does not — see below.
+
+# Grouping key (strand of origin)
+
+Templates are grouped by template coordinate — the unclipped 5' position of both ends —
+*and* by strand of origin, i.e. which mate defines the forward end. Two templates at the
+same coordinates whose read 1 is on opposite strands (F1R2 vs F2R1) are therefore two
+molecules, not one, and each keeps its own representative. This matches
+`fgbio GroupReadsByUmi`, whose model exists to tell the two strands of a duplex molecule
+apart for consensus calling, and it applies to every strategy except `paired`, which
+deliberately pairs the two strands back together.
+
+Picard `MarkDuplicates` is orientation-agnostic: it collapses F1R2 and F2R1 at the same
+coordinates into one duplicate set with one survivor. So `fgumi dedup` finds more molecules
+and marks *fewer* duplicates than Picard on the same input:
+
+  marked duplicates = templates - molecule groups
+
+The gap is made up entirely of fragments sequenced from both strands at the same
+coordinates, so it grows with duplication depth — roughly 2 percentage points of duplicate
+rate on a moderately duplicated capture panel, and more on deeper libraries.
+
+--no-umi turns off UMI grouping but does NOT turn off the strand split, so it is not a
+drop-in for Picard `MarkDuplicates`; there is currently no option to group
+orientation-agnostically. Use Picard `MarkDuplicates` itself if you need
+orientation-agnostic duplicate marking.
 
 # Cell Barcodes
 
@@ -1064,8 +1090,10 @@ pub struct MarkDuplicates {
     #[arg(long = "index-threshold", default_value = "100")]
     pub index_threshold: usize,
 
-    /// Skip UMI-based grouping; group by position only. Forces identity strategy
-    /// and ignores any existing UMI tags.
+    /// Skip UMI-based grouping; group by template coordinate and strand of origin. Forces
+    /// identity strategy and ignores any existing UMI tags. Because templates are still split
+    /// by strand of origin, this is not equivalent to Picard `MarkDuplicates` (see "Grouping
+    /// key" in --help).
     #[arg(long = "no-umi", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub no_umi: bool,
 

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -96,7 +96,7 @@ struct GroupFilterConfig {
     include_non_pf: bool,
     /// Minimum UMI length (None to disable).
     min_umi_length: Option<usize>,
-    /// Skip UMI validation (position-only grouping).
+    /// Skip UMI validation; group by template coordinate and strand of origin alone.
     no_umi: bool,
     /// Whether to allow fully unmapped templates (both reads unmapped).
     allow_unmapped: bool,
@@ -857,8 +857,9 @@ pub struct GroupReadsByUmi {
     #[arg(long = "index-threshold", default_value = "100")]
     pub index_threshold: usize,
 
-    /// Skip UMI-based grouping; group by position only. Forces identity strategy
-    /// and ignores any existing UMI tags.
+    /// Skip UMI-based grouping; group by template coordinate and strand of origin. Forces
+    /// identity strategy and ignores any existing UMI tags. An F1R2 and an F2R1 template at
+    /// the same coordinates therefore remain separate molecules.
     #[arg(long = "no-umi", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub no_umi: bool,
 


### PR DESCRIPTION
## Summary

`--no-umi` is documented as "Skip UMI-based grouping; **group by position only**". It does not group by position only. The identity assigner inherits the `split_templates_by_pair_orientation() -> true` trait default (`crates/fgumi-umi/src/assigner.rs`), so `assign_umi_groups` additionally partitions each position group by which mate defines the forward end. An F1R2 and an F2R1 template at the same unclipped 5' coordinates stay two molecules, and each keeps its own representative.

This is the dominant reason `fgumi dedup --no-umi` and Picard `MarkDuplicates` disagree on the duplicate flag, and the help text actively points users the wrong way for exactly the MarkDuplicates-swap case where `--no-umi` is the natural thing to reach for.

Documentation only — no behavior change. Whether the split *should* be optional is a separate design question and is deliberately not addressed here; the help text now states plainly that no such option exists.

## Evidence

`twist-umi` benchmark sample (SRR34589119), 15,826,646 primary reads, Picard 3.4.0, same input templates through both tools. Reconstructing duplicate families two ways and checking whether each tool marks exactly (family − 1) per family:

| Key | Families | Expected N−1 | fgumi marked | Picard marked |
|---|---|---|---|---|
| chr7 · coordinate only | 177,121 | 159,666 | off by −7,307 | **MATCH** |
| chr7 · coordinate + read-1 strand | 184,428 | 152,359 | **MATCH** | off by +7,307 |
| chr1 · coordinate only | 285,369 | 208,491 | off by −10,873 | **MATCH** |
| chr1 · coordinate + read-1 strand | 296,242 | 197,618 | **MATCH** | off by +10,873 |

Both tools build the identical set of coordinate families; fgumi sub-splits them by strand and marks N−1 of each. Both matches are exact, in both directions, on both chromosomes.

The per-template flag disagreement decomposes to the read against that split — `picard-dup-only − fgumi-dup-only` equals the strand-split count exactly (chr7 `7,398 − 91 = 7,307`; chr1 `11,041 − 168 = 10,873`). The small bidirectional residual is representative tie-breaking, not a count difference.

## What changed

- **`dedup` long help**: new `# Grouping key (strand of origin)` section — the key, why it exists (`fgbio GroupReadsByUmi` parity, duplex strand separation), the contrast with orientation-agnostic Picard, `marked duplicates = templates − molecule groups`, and that there is no orientation-agnostic option.
- **`dedup` long help**: the adjacent sentence claimed deduplication "follows Picard `MarkDuplicates` semantics". Scoped to representative selection / the 0x400 flag / `--remove-duplicates`, which is where it holds — the grouping key is where it doesn't. This mirrors the existing `# Filtering` section, which already documents that `dedup` is not a Picard record-count drop-in.
- **`dedup --no-umi` and `group --no-umi`**: "group by position only" → "group by template coordinate alone … still split by strand of origin".
- Both internal `*FilterConfig::no_umi` doc comments, which carried the same wording.

`docs/src/tools/*.md` is generated and gitignored, so no doc files are committed; regenerated locally via `cargo run -p xtask -- generate-docs` to confirm both the new section and the argument tables render.

## Testing

`cargo ci-fmt`, `cargo ci-lint`, `cargo ci-test` all clean — 5863 passed, 0 failed, 27 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `--no-umi` behavior for deduplication and grouping.
  * Documented that UMI tags are ignored and identity grouping is used.
  * Explained that templates remain separated by strand of origin, including at matching coordinates.
  * Clarified that this behavior is not equivalent to Picard `MarkDuplicates`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->