### PR TITLE
fix(sort): honour --compression-level for the tail of a spilling sort

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1643,15 +1643,20 @@ pub struct RawExternalSorter {
 }
 
 /// RAII guard that ensures Phase 2 teardown runs on every exit path between
-/// `pool.set_phase(PHASE2)` and the explicit `deactivate()` in the merge loop.
-/// Without this, any `?` early-return would leave the pool stuck in PHASE2 with
-/// `phase2_files` still published. `deactivate()` drops the consumer (releasing
-/// the Arc snapshot of the per-file vector), resets the phase to `LEGACY`, and
-/// clears the pool's published file vector — in that order.
+/// `pool.set_phase(PHASE2)` and the end of the merge. Without this, any `?`
+/// early-return would leave the pool stuck in PHASE2 with `phase2_files` still
+/// published.
+///
+/// Merges finish by handing the guard to
+/// [`finish_output`](Self::finish_output), which owns the whole teardown order —
+/// the merge is done with its *sources* well before it is done with the *pool*,
+/// and getting that order wrong is silent. `Drop` still deactivates, so a merge
+/// that fails before it gets that far tears down completely.
 struct Phase2Guard<'a, K: RawSortKey + 'static> {
     pool: &'a Arc<SortWorkerPool>,
     consumer: Option<MainThreadChunkConsumer<K>>,
     active: bool,
+    sources_released: bool,
 }
 
 impl<K: RawSortKey + 'static> Phase2Guard<'_, K> {
@@ -1663,11 +1668,57 @@ impl<K: RawSortKey + 'static> Phase2Guard<'_, K> {
         self.consumer.as_ref()
     }
 
+    /// Release the drained merge sources, finalize the output, then leave Phase 2.
+    ///
+    /// **The output must be finalized inside Phase 2.** Phase 2 is what puts
+    /// [`SortStep::CompressOutput`](crate::worker_pool::SortStep::CompressOutput)
+    /// on a worker's priority list, and that step is what selects
+    /// `output_compressor`. In `LEGACY` the only compress step workers schedule
+    /// is `CompressSpill`, so every output block still queued — plus the
+    /// writer's final flush — would be compressed at `temp_compression`, and the
+    /// tail of the BAM would silently ignore the caller's `output_compression`.
+    /// This method exists so that ordering cannot be got wrong at a call site:
+    /// `finish` runs between the source release and the return to `LEGACY`.
+    ///
+    /// Releasing the sources first is what keeps a slow `finish` from holding
+    /// the merge's file descriptors and per-file reorder buffers (a 2 MiB
+    /// `BufReader` per spill file) alive while it drains.
+    ///
+    /// The underlying coupling — "which compressor a block gets" being a
+    /// function of the pool's *global phase* rather than of the block's own
+    /// origin — is what makes this ordering load-bearing at all. Tagging each
+    /// `CompressJob` with its target at submit time would retire this contract
+    /// (and the mirror-image one on `set_phase`); that is a separate change.
+    ///
+    /// Takes `self` by value: finalizing the output is the guard's terminal
+    /// operation, so a second call — which would run `finish` with the pool
+    /// already back in `LEGACY`, silently compressing the output at
+    /// `temp_compression` and reporting success — is a compile error rather than
+    /// a runtime check. The remaining `Drop` at the end of this method is a
+    /// no-op, since `deactivate` has already cleared `active`.
+    fn finish_output<T>(mut self, finish: impl FnOnce() -> Result<T>) -> Result<T> {
+        self.release_sources();
+        let finished = finish();
+        self.deactivate();
+        finished
+    }
+
+    /// Drop the consumer (releasing the Arc snapshot of the per-file vector) and
+    /// unpublish the spill files, while leaving the pool in Phase 2.
+    fn release_sources(&mut self) {
+        if self.active && !self.sources_released {
+            drop(self.consumer.take());
+            self.pool.clear_phase2_files();
+            self.sources_released = true;
+        }
+    }
+
+    /// Leave Phase 2 entirely: release the sources if that has not happened yet,
+    /// then return the pool to `LEGACY`.
     fn deactivate(&mut self) {
         if self.active {
-            drop(self.consumer.take());
+            self.release_sources();
             self.pool.set_phase(crate::worker_pool::phase::LEGACY);
-            self.pool.clear_phase2_files();
             self.active = false;
         }
     }
@@ -3429,8 +3480,9 @@ impl RawExternalSorter {
     /// Shared by both the plain ([`merge_chunks_generic`]) and indexed
     /// ([`merge_chunks_with_index`]) merges so the Phase-2 lifecycle is
     /// single-sourced and the two paths cannot drift. Returns the sources plus
-    /// an RAII [`Phase2Guard`] (borrowing `pool`) that resets Phase 2 on drop or
-    /// explicit `deactivate()`. Phase 2 is armed whether or not there are disk
+    /// an RAII [`Phase2Guard`] (borrowing `pool`); callers finish through
+    /// [`Phase2Guard::finish_output`], and `Drop` resets Phase 2 on any path
+    /// that does not get that far. Phase 2 is armed whether or not there are disk
     /// chunks: it is what makes workers reach for `output_compressor`
     /// (`SortStep::CompressOutput`) rather than the Phase 1 spill compressor, so
     /// leaving an all-in-memory merge in Phase 1 would silently write the output
@@ -3472,7 +3524,7 @@ impl RawExternalSorter {
             )
         });
         pool.set_phase(crate::worker_pool::phase::PHASE2);
-        let guard = Phase2Guard { pool, consumer, active: true };
+        let guard = Phase2Guard { pool, consumer, active: true, sources_released: false };
 
         Ok((sources, guard))
     }
@@ -3515,9 +3567,9 @@ impl RawExternalSorter {
 
         if initial_keys.is_empty() {
             debug!("Merge complete: 0 records merged");
-            guard.deactivate();
-            let writer = PooledBamWriter::new(Arc::clone(pool), output, &output_header)?;
-            writer.finish()?;
+            guard.finish_output(|| {
+                PooledBamWriter::new(Arc::clone(pool), output, &output_header)?.finish()
+            })?;
             return Ok(0);
         }
 
@@ -3588,11 +3640,6 @@ impl RawExternalSorter {
             }
         }
 
-        // Return to legacy mode before finishing writer (workers still need to compress).
-        // The guard's deactivate() drops the consumer, resets phase, and clears the
-        // pool's published file vector in the correct order.
-        guard.deactivate();
-
         if debug_timing {
             let loop_total = loop_start.elapsed().as_secs_f64();
             #[allow(clippy::cast_precision_loss)]
@@ -3606,7 +3653,7 @@ impl RawExternalSorter {
             );
         }
 
-        writer.finish()?;
+        guard.finish_output(|| writer.finish())?;
         merge_progress.log_final();
         log_snapshot("phase2.end", 0);
 
@@ -3651,9 +3698,10 @@ impl RawExternalSorter {
         }
 
         if initial_keys.is_empty() {
-            guard.deactivate();
-            let writer = PooledBamWriter::new_indexing(Arc::clone(pool), output, &output_header)?;
-            let index = writer.finish_index()?;
+            let index = guard.finish_output(|| {
+                PooledBamWriter::new_indexing(Arc::clone(pool), output, &output_header)?
+                    .finish_index()
+            })?;
             debug!("Merge complete: 0 records merged");
             return Ok(index);
         }
@@ -3679,13 +3727,7 @@ impl RawExternalSorter {
             }
         }
 
-        // Return the pool to legacy mode before finishing the writer — the
-        // workers still compress the trailing output blocks during
-        // finish_index() (CompressOutput is eligible whenever the queue is
-        // non-empty). Same ordering as merge_chunks_generic.
-        guard.deactivate();
-
-        let index = writer.finish_index()?;
+        let index = guard.finish_output(|| writer.finish_index())?;
         merge_progress.log_final();
         Ok(index)
     }
@@ -4706,6 +4748,231 @@ mod tests {
         assert!(names.is_empty());
         assert!(sorted.exists(), "empty-input sort must still produce an output file");
         assert_eq!(count_bam_records(&sorted), 0, "output must contain only the header");
+    }
+
+    // ========================================================================
+    // Phase 2 teardown: Phase2Guard::finish_output
+    // ========================================================================
+
+    /// Everything an empty-source merge needs: a sorter, its pool (already
+    /// handed over to Phase 2), the output header, and a temp dir holding one
+    /// spill chunk that decodes to zero records plus the output path.
+    ///
+    /// `_dir` is returned only to keep the temp dir alive for the caller's
+    /// lifetime; dropping it deletes both paths.
+    struct EmptyMergeFixture {
+        sorter: RawExternalSorter,
+        pool: Arc<SortWorkerPool>,
+        header: Header,
+        chunk: PathBuf,
+        output: PathBuf,
+        _dir: tempfile::TempDir,
+    }
+
+    /// Builds an [`EmptyMergeFixture`].
+    ///
+    /// A real Phase 1 checks its spill trigger only after pushing a record, so
+    /// it never writes an empty chunk and the "every source is empty" merge
+    /// branch is unreachable from `sort()`. Handing the merge a chunk that holds
+    /// nothing but a BGZF EOF block is the way to drive that branch directly,
+    /// and it is the shape `consolidate_chunks` emits for a zero-record run.
+    ///
+    /// No compression setting is configured, because none affects these tests:
+    /// the read side derives the chunk's codec from its magic bytes
+    /// (`SortWorkerPool::set_phase2_files`) rather than from `spill_codec`, and
+    /// the assertions are on the pipeline phase and the record count, not on
+    /// output size. `threads` is set because it sizes the pool.
+    fn empty_merge_fixture() -> EmptyMergeFixture {
+        use crate::keys::RawCoordinateKey;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let chunk = dir.path().join("empty.chunk");
+        GenericKeyedChunkWriter::<RawCoordinateKey>::create(
+            &chunk, /* compression_level */ 1, /* num_threads */ 1,
+        )
+        .expect("create empty chunk")
+        .finish()
+        .expect("finish empty chunk");
+
+        let sorter = RawExternalSorter::new(SortOrder::Coordinate).threads(2);
+        let pool = sorter.create_worker_pool().expect("worker pool");
+        sorter.enter_output_phase(&pool);
+
+        EmptyMergeFixture {
+            sorter,
+            pool,
+            header: default_merge_header(),
+            output: dir.path().join("output.bam"),
+            chunk,
+            _dir: dir,
+        }
+    }
+
+    /// The output must be finalized while the pool is still in Phase 2.
+    ///
+    /// This is the invariant [`Phase2Guard::finish_output`] exists to enforce,
+    /// and the one the bug violated: the trailing output blocks are compressed
+    /// while the writer is being finished, and `CompressOutput` — the step that
+    /// selects `output_compressor` — is only on a worker's priority list in
+    /// Phase 2. Finalizing in `LEGACY` sends those blocks through the spill
+    /// compressor at `temp_compression`.
+    ///
+    /// So the assertion is made from *inside* the finalize closure, where the
+    /// real writer's `finish()` would run — not merely before and after it.
+    #[test]
+    fn test_phase2_guard_finishes_output_while_still_in_phase2() {
+        use crate::keys::RawCoordinateKey;
+        use crate::worker_pool::phase;
+
+        let fixture = empty_merge_fixture();
+        let pool = &fixture.pool;
+        let (_sources, guard) = RawExternalSorter::setup_phase2_merge::<RawCoordinateKey>(
+            std::slice::from_ref(&fixture.chunk),
+            MemorySources::Shared(Vec::new()),
+            pool,
+        )
+        .expect("setup phase 2");
+
+        assert_eq!(pool.current_phase(), phase::PHASE2, "setup must arm Phase 2");
+        assert_eq!(pool.phase2_files().len(), 1, "the disk source must be published");
+
+        let observed = guard
+            .finish_output(|| Ok((pool.current_phase(), pool.phase2_files().len())))
+            .expect("finish_output must propagate the closure's Ok");
+
+        assert_eq!(
+            observed,
+            (phase::PHASE2, 0),
+            "the output must be finalized in Phase 2 (so its blocks are compressed at \
+             output_compression) with the drained spill files already unpublished"
+        );
+        // `finish_output` consumed the guard, so its `Drop` has already run — a
+        // second deactivate must not have disturbed the phase it just set.
+        assert_eq!(
+            pool.current_phase(),
+            phase::LEGACY,
+            "finish_output must return the pool to LEGACY once the output is done"
+        );
+    }
+
+    /// A failing finalizer still hands the pool back in `LEGACY` with the spill
+    /// files unpublished, and the error still reaches the caller unwrapped.
+    ///
+    /// A writer that fails mid-`finish` is the one exit the merge cannot retry,
+    /// so the pool it leaves behind is what the rest of the sort — and the
+    /// pool's own shutdown — has to cope with. Because
+    /// [`Phase2Guard::finish_output`] consumes the guard, the reset here is
+    /// guaranteed twice over (explicitly, then by `Drop` as the method returns);
+    /// this pins the resulting contract rather than either mechanism.
+    #[test]
+    fn test_phase2_guard_finish_output_resets_phase_on_error() {
+        use crate::keys::RawCoordinateKey;
+        use crate::worker_pool::phase;
+
+        let fixture = empty_merge_fixture();
+        let pool = &fixture.pool;
+        let (_sources, guard) = RawExternalSorter::setup_phase2_merge::<RawCoordinateKey>(
+            std::slice::from_ref(&fixture.chunk),
+            MemorySources::Shared(Vec::new()),
+            pool,
+        )
+        .expect("setup phase 2");
+
+        let failed =
+            guard.finish_output(|| -> Result<()> { Err(anyhow::anyhow!("writer blew up")) });
+
+        assert!(failed.is_err(), "finish_output must propagate the finalizer's error");
+        assert_eq!(
+            failed.unwrap_err().to_string(),
+            "writer blew up",
+            "the finalizer's own error must reach the caller, not a wrapped one"
+        );
+        assert_eq!(
+            pool.current_phase(),
+            phase::LEGACY,
+            "a failed finalize must still return the pool to LEGACY"
+        );
+        assert!(
+            pool.phase2_files().is_empty(),
+            "a failed finalize must still unpublish the spill files"
+        );
+    }
+
+    /// A merge whose every source is empty writes a header-only BAM and still
+    /// hands the pool back in `LEGACY`.
+    ///
+    /// This early-return branch finalizes its writer through the same
+    /// [`Phase2Guard::finish_output`] as the main loop, so it has the same way
+    /// to go wrong.
+    #[test]
+    fn test_merge_chunks_generic_with_only_empty_sources() {
+        use crate::keys::RawCoordinateKey;
+        use crate::worker_pool::phase;
+
+        let fixture = empty_merge_fixture();
+        let merged = fixture
+            .sorter
+            .merge_chunks_generic::<RawCoordinateKey>(
+                std::slice::from_ref(&fixture.chunk),
+                MemorySources::Shared(Vec::new()),
+                &fixture.header,
+                &fixture.output,
+                0,
+                &fixture.pool,
+            )
+            .expect("empty merge should succeed");
+
+        assert_eq!(merged, 0, "an all-empty merge must report zero records merged");
+        assert_eq!(
+            count_bam_records(&fixture.output),
+            0,
+            "output must hold the header and nothing else"
+        );
+        assert_eq!(
+            fixture.pool.current_phase(),
+            phase::LEGACY,
+            "the merge must hand the pool back in LEGACY"
+        );
+        assert!(fixture.pool.phase2_files().is_empty(), "the merge must unpublish the spill files");
+    }
+
+    /// The indexed counterpart of
+    /// [`test_merge_chunks_generic_with_only_empty_sources`]: the BAI still has
+    /// to be built and cover every reference, even with no records to index.
+    #[test]
+    fn test_merge_chunks_with_index_with_only_empty_sources() {
+        use crate::keys::RawCoordinateKey;
+        use crate::worker_pool::phase;
+
+        let fixture = empty_merge_fixture();
+        let index = fixture
+            .sorter
+            .merge_chunks_with_index::<RawCoordinateKey>(
+                std::slice::from_ref(&fixture.chunk),
+                MemorySources::Shared(Vec::new()),
+                &fixture.header,
+                &fixture.output,
+                0,
+                &fixture.pool,
+            )
+            .expect("empty indexed merge should succeed");
+
+        assert_eq!(
+            count_bam_records(&fixture.output),
+            0,
+            "output must hold the header and nothing else"
+        );
+        assert_eq!(
+            index.reference_sequences().len(),
+            fixture.header.reference_sequences().len(),
+            "the index must cover every reference sequence even with no records"
+        );
+        assert_eq!(
+            fixture.pool.current_phase(),
+            phase::LEGACY,
+            "the indexed merge must hand the pool back in LEGACY"
+        );
+        assert!(fixture.pool.phase2_files().is_empty(), "the merge must unpublish the spill files");
     }
 
     // ========================================================================

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -1950,6 +1950,19 @@ impl SortWorkerPool {
         self.shared.phase.store(new_phase, Ordering::Release);
     }
 
+    /// The current pipeline phase (see [`phase`]), the read counterpart to
+    /// [`set_phase`](Self::set_phase).
+    ///
+    /// The phase selects which compress step workers schedule — and therefore
+    /// which compressor the output blocks go through — so it is the observable
+    /// the Phase 2 teardown tests assert on. Workers read the phase constantly,
+    /// but no caller *outside* the pool needs it, so this accessor exists for
+    /// those tests.
+    #[cfg(test)]
+    pub(crate) fn current_phase(&self) -> u8 {
+        self.shared.phase.load(Ordering::Acquire)
+    }
+
     /// Cap the number of workers active in the current phase to `n` (clamped to
     /// `[1, num_workers]`). Workers with `worker_id >= n` idle until the limit is
     /// raised. Used to run Phase 1 on fewer threads than Phase 2; raising the

--- a/crates/fgumi-sort/tests/integration/test_output_compression.rs
+++ b/crates/fgumi-sort/tests/integration/test_output_compression.rs
@@ -7,14 +7,26 @@
 //! in Phase 1 — where the only compress step is the *spill* one, using
 //! `temp_compression`. The user's `--compression-level` was silently replaced by
 //! the temp level.
+//!
+//! The spilling merge had the mirror-image defect at the other end: it returned
+//! the pool to `LEGACY` *before* finishing the writer, so the output blocks
+//! still queued at teardown — plus the writer's final flush — went through the
+//! spill compressor and the tail of the BAM came out at `temp_compression`.
+//! Both defects are the same coupling seen from opposite sides: which
+//! compressor a block gets is decided by the pool's phase when a worker pops
+//! it, not by where the block came from.
+//!
+//! Hence the two tests below: the first asserts `output_compression` reaches
+//! the file, the second that `temp_compression` never does.
 
-use fgumi_raw_bam::RawRecord;
+use fgumi_raw_bam::{IndexedRawBamReader, RawRecord};
 use fgumi_sam::SamBuilder;
 use fgumi_sort::{
     LibraryLookup, QuerynameComparator, RawBamRecordReader, RawExternalSorter, RawQuerynameKey,
     RawQuerynameLexKey, RawSortKey, SortContext, SortOrder, SpillCodec, cb_hasher,
     extract_coordinate_key_inline, extract_template_key_inline, verify_sort_order,
 };
+use noodles::core::Region;
 use rstest::rstest;
 
 /// Number of pairs to sort. Large enough that the output spans many BGZF blocks,
@@ -25,6 +37,9 @@ const N_PAIRS: usize = 5_000;
 /// with [`N_PAIRS`] (5000 = 2^3·5^4, 2001 = 3·23·29), so `i * STRIDE % N_PAIRS`
 /// walks every index exactly once.
 const EMIT_STRIDE: usize = 2001;
+
+/// Memory limit small enough that the sort has to spill chunk files.
+const SPILL_MEMORY_LIMIT: usize = 1024 * 1024;
 
 /// Builds a BAM whose records compress well, so level 0 and level 9 differ a lot.
 ///
@@ -66,6 +81,42 @@ fn record_multiset(records: &[RawRecord]) -> Vec<Vec<u8>> {
     let mut payloads: Vec<Vec<u8>> = records.iter().map(|record| record.to_vec()).collect();
     payloads.sort_unstable();
     payloads
+}
+
+/// Reads the BAI sidecar written next to `path` and uses it to query the file,
+/// returning `(index_bytes, records_resolved)`.
+///
+/// The query covers all of `chr1` — the only reference [`build_input`] places
+/// records on — so `records_resolved` is the whole file, record for record,
+/// when the index is correct. Going through the index (rather than just loading
+/// it) is what makes this a check on the *virtual offsets*: a `.bai` whose
+/// offsets point into the wrong BGZF blocks still parses, but seeking to them
+/// yields short reads or garbage, so records go missing or the read errors out.
+/// Callers compare the returned records against a linear scan of the same file,
+/// so a query that merely returns the right *number* of records is not enough.
+///
+/// The raw index bytes are returned alongside so two runs can be compared
+/// directly: identical output blocks must produce an identical index.
+fn query_via_index(path: &std::path::Path) -> (Vec<u8>, Vec<RawRecord>) {
+    let bai_path = fgumi_bam_io::bai_sidecar_path(path);
+    // Parsed from the bytes already in hand rather than re-reading the sidecar.
+    let index_bytes = std::fs::read(&bai_path)
+        .unwrap_or_else(|e| panic!("expected a BAI sidecar at {}: {e}", bai_path.display()));
+    let index = noodles::bam::bai::io::Reader::new(&index_bytes[..])
+        .read_index()
+        .expect("BAI must be loadable");
+
+    let mut reader =
+        IndexedRawBamReader::from_path(path, index).expect("open indexed reader over sorted BAM");
+    let header = reader.read_header().expect("read header through the indexed reader");
+    let region: Region = "chr1".parse().expect("chr1 is a valid region");
+    let resolved: Vec<RawRecord> = reader
+        .query(&header, &region)
+        .expect("query chr1")
+        .map(|record| record.expect("indexed query must resolve to a readable record"))
+        .collect();
+
+    (index_bytes, resolved)
 }
 
 /// Counts sort-order violations in `path` under `sort_order`.
@@ -122,32 +173,45 @@ fn count_sort_violations(sort_order: SortOrder, path: &std::path::Path) -> u64 {
     violations
 }
 
-/// Sorts `input` in `sort_order` at the given output compression level and
-/// returns `(output_size_bytes, chunks_written, decoded_records)`.
+/// The knobs a single [`sort_at_level`] run varies.
+///
+/// `write_index` picks the finalization path under test: `false` routes the
+/// merge through `merge_chunks_generic` (`writer.finish()`), `true` through
+/// `merge_chunks_with_index` (`writer.finish_index()`), which additionally pins
+/// BAI virtual offsets to the block layout the tail compression produces.
+#[derive(Clone, Copy)]
+struct SortRun {
+    memory_limit: usize,
+    output_compression: u32,
+    temp_compression: u32,
+    write_index: bool,
+}
+
+/// Sorts `input` in `sort_order` under `run` and returns
+/// `(output_size_bytes, chunks_written, decoded_records)`.
 ///
 /// `expected` is the independent baseline the output is checked against — the
 /// multiset of the *input* records, decoded straight from the input BAM without
 /// going through the sorter. Combined with the sort-order verification below,
 /// it pins the output exactly: a correct sort emits every input record, no
-/// others, in non-decreasing key order. Neither check involves the other
-/// compression run, so they cannot both drift the same way.
+/// others, in non-decreasing key order. Neither check involves any other sort
+/// run, so two runs cannot drift the same way.
 fn sort_at_level(
     sort_order: SortOrder,
     input: &std::path::Path,
     output: &std::path::Path,
-    memory_limit: usize,
-    output_compression: u32,
+    run: SortRun,
     expected: &[Vec<u8>],
 ) -> (u64, usize, Vec<RawRecord>) {
+    let SortRun { memory_limit, output_compression, temp_compression, write_index } = run;
+
     let stats = RawExternalSorter::new(sort_order)
         .threads(2)
         .memory_limit(memory_limit)
         .spill_codec(SpillCodec::Bgzf)
-        // Held constant across levels, and deliberately different from both
-        // output levels under test: if the output is compressed at the temp
-        // level, both runs produce the same size.
-        .temp_compression(1)
+        .temp_compression(temp_compression)
         .output_compression(output_compression)
+        .write_index(write_index)
         .sort(input, output)
         .expect("sort should succeed");
 
@@ -211,7 +275,7 @@ fn test_output_compression_level_reaches_the_output_bam(
         SortOrder::TemplateCoordinate
     )]
     sort_order: SortOrder,
-    #[values((256 * 1024 * 1024, false), (1024 * 1024, true))] memory: (usize, bool),
+    #[values((256 * 1024 * 1024, false), (SPILL_MEMORY_LIMIT, true))] memory: (usize, bool),
 ) {
     let (memory_limit, expect_spill) = memory;
     let dir = tempfile::tempdir().expect("tempdir");
@@ -222,13 +286,23 @@ fn test_output_compression_level_reaches_the_output_bam(
     // from the input BAM before any sort runs.
     let expected = record_multiset(&decode_records(&input));
 
+    // The temp level is held constant across both runs, and is deliberately
+    // different from both output levels under test: if the output were
+    // compressed at the temp level, both runs would produce the same size.
+    let run_at = |output_compression| SortRun {
+        memory_limit,
+        output_compression,
+        temp_compression: 1,
+        write_index: false,
+    };
+
     let uncompressed = dir.path().join("level0.bam");
     let (size_level_0, chunks_0, records_level_0) =
-        sort_at_level(sort_order, &input, &uncompressed, memory_limit, 0, &expected);
+        sort_at_level(sort_order, &input, &uncompressed, run_at(0), &expected);
 
     let compressed = dir.path().join("level9.bam");
     let (size_level_9, chunks_9, records_level_9) =
-        sort_at_level(sort_order, &input, &compressed, memory_limit, 9, &expected);
+        sort_at_level(sort_order, &input, &compressed, run_at(9), &expected);
 
     assert_eq!(
         chunks_0 > 0,
@@ -256,5 +330,109 @@ fn test_output_compression_level_reaches_the_output_bam(
         "output_compression was ignored for {sort_order:?}: level 9 wrote {size_level_9} bytes and \
          level 0 wrote {size_level_0} bytes (spill={expect_spill}). Equal sizes mean the output was \
          compressed at temp_compression instead."
+    );
+}
+
+/// `temp_compression` must not reach the output BAM.
+///
+/// The mirror image of the check above, at the other end of the sort: see this
+/// file's module header for the defect. The output must be finalized while the
+/// pool is still in Phase 2, or the trailing blocks go through the *temp*
+/// compressor — so raising `temp_compression` alone would change the output.
+///
+/// So: sort twice at `output_compression = 0`, changing only the temp level.
+/// The written BAM must be exactly the same size both times. Level 0 is used
+/// for the output because it makes any block that slipped through the temp
+/// compressor strictly smaller, and therefore visible in the total.
+///
+/// Only the spilling path is exercised — the in-memory path never builds a
+/// `Phase2Guard`, so it has no teardown to get wrong.
+///
+/// Both spilling finalizations are covered: `merge_chunks_generic`
+/// (`writer.finish()`) and, via the `coordinate_indexed` case,
+/// `merge_chunks_with_index` (`writer.finish_index()`). Each sort order is
+/// covered because each routes to the merge through its own entry point. The
+/// indexed path carries the extra risk that the tail block's compression level
+/// moves the BGZF boundaries the BAI records, so that case additionally pins the
+/// index itself — see [`query_via_index`]. `write_index` is only meaningful for
+/// `SortOrder::Coordinate`; the other orders never reach
+/// `sort_coordinate_with_index`, so pairing them with it would just re-run the
+/// unindexed case.
+#[rstest]
+#[case::coordinate(SortOrder::Coordinate, false)]
+#[case::coordinate_indexed(SortOrder::Coordinate, true)]
+#[case::queryname_natural(SortOrder::Queryname(QuerynameComparator::Natural), false)]
+#[case::template_coordinate(SortOrder::TemplateCoordinate, false)]
+fn test_temp_compression_does_not_reach_the_output_bam(
+    #[case] sort_order: SortOrder,
+    #[case] write_index: bool,
+) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let input = dir.path().join("input.bam");
+    build_input(&input);
+    let expected = record_multiset(&decode_records(&input));
+
+    // Returns the output size and, for an indexed run, the BAI bytes. The BAI is
+    // checked here rather than by the caller because this is where `scanned` —
+    // the linear-scan oracle `sort_at_level` already produced — is in hand.
+    let sort_with_temp = |tag: &str, temp_compression: u32| -> (u64, Option<Vec<u8>>) {
+        let output = dir.path().join(format!("{tag}.bam"));
+        let run = SortRun {
+            memory_limit: SPILL_MEMORY_LIMIT,
+            output_compression: 0,
+            temp_compression,
+            write_index,
+        };
+        let (size, chunks, scanned) = sort_at_level(sort_order, &input, &output, run, &expected);
+        assert!(
+            chunks > 0,
+            "test must exercise the spilling path, but no chunks were written \
+             ({sort_order:?}, temp_compression={temp_compression})"
+        );
+
+        // The index is built from the virtual positions of the blocks the pool
+        // compressed, so a tail block that slipped through the temp compressor
+        // would move every offset after it.
+        //
+        // The oracle for "resolved correctly" is `scanned`, a linear scan of the
+        // same BAM that does not consult the index at all: an indexed query over
+        // the only reference in the file must yield exactly those records, in
+        // that order. Comparing counts alone would pass on an index that pointed
+        // at the right number of wrong records.
+        let bai = write_index.then(|| {
+            let (bai, queried) = query_via_index(&output);
+            assert!(
+                queried == scanned,
+                "indexed query at temp_compression={temp_compression} resolved {} records against \
+                 {} in the file: the BAI's virtual offsets do not match the blocks in the BAM",
+                queried.len(),
+                scanned.len()
+            );
+            bai
+        });
+
+        (size, bai)
+    };
+
+    let (size_temp_0, bai_temp_0) = sort_with_temp("temp0", 0);
+    let (size_temp_9, bai_temp_9) = sort_with_temp("temp9", 9);
+
+    assert_eq!(
+        size_temp_0, size_temp_9,
+        "temp_compression leaked into the output for {sort_order:?}: the same sort wrote \
+         {size_temp_0} bytes at temp_compression=0 and {size_temp_9} bytes at \
+         temp_compression=9, but only output_compression (0 for both) may affect the output"
+    );
+
+    // Identical output blocks must produce an identical index. Compared as raw
+    // bytes rather than with `assert_eq!`, which would dump both whole indexes
+    // into the failure message.
+    assert!(
+        bai_temp_0 == bai_temp_9,
+        "temp_compression changed the BAI for {sort_order:?} ({:?} and {:?} bytes): the indexed \
+         merge compressed part of the output at the temp level, shifting the virtual offsets the \
+         index records",
+        bai_temp_0.as_ref().map(Vec::len),
+        bai_temp_9.as_ref().map(Vec::len),
     );
 }


### PR DESCRIPTION
Follow-up to #633. That PR fixed the fully-in-memory sort, which never entered Phase 2 at all and so wrote its *entire* output at `temp_compression`. This fixes the remaining leak on the **spilling** path, where only the tail of the file is affected.

## The bug

`Phase2Guard::deactivate` returned the pool to `LEGACY` *before* the output writer was finished, at all four merge sites. But `select_priorities` only offers `CompressOutput` in Phase 2 — in `LEGACY` the sole compress step is `CompressSpill`, which binds `worker.compressor` (the `temp_compression` one). Every output block still sitting in the compress queue at teardown, plus the writer's final flush, was therefore compressed at the temp level, and the tail of the BAM silently ignored `--compression-level`.

The comments at both merge sites ("workers still need to compress", "CompressOutput is eligible whenever the queue is non-empty") describe the intent correctly, and `is_available` really does gate `CompressOutput` on a non-empty queue. What they miss is that in `LEGACY` the step is never dispatched in the first place, so the eligibility check never gets consulted.

## Measured

5,000-pair coordinate sort forced to spill, writing at `--compression-level 0`:

| `temp_compression` | output size |
|---|---|
| 0 | 2,062,091 bytes |
| 9 | 2,021,843 bytes |

~40 KB (~2%) of the output came out at the temp level. The in-memory path is unaffected — it never builds a `Phase2Guard`, so there is no early teardown to get wrong, and it produces exactly the 2,062,091-byte level-0 output either way.

## The fix

Split the guard's teardown into its two halves:

- `release_sources` drops the consumer and unpublishes the spill files — which is what stops workers touching files that are about to be deleted — while leaving the pool in Phase 2, so trailing blocks still route to `output_compressor`.
- `deactivate` returns the pool to `LEGACY` after the writer is finished, and remains what `Drop` calls, so error paths are unchanged.

`try_phase2_file_work` returns immediately on an empty file vector, so output compression is the only Phase 2 work left in that window.

## Testing

New integration test `test_temp_compression_does_not_reach_the_output_bam` sorts twice at `output_compression 0`, varying only the temp level, and asserts the two outputs are the same size. It fails on all three pooled sort orders before this change:

```
temp_compression leaked into the output for Coordinate: the same sort wrote 2062091 bytes
at temp_compression=0 and 2021843 bytes at temp_compression=9, but only output_compression
(0 for both) may affect the output
```

`sort_at_level` gained a `temp_compression` parameter so both tests share it; the existing test passes `1` as before.

`cargo ci-fmt`, `cargo ci-lint` clean; `cargo ci-test` 6476 passed / 27 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed output compression so the final BAM consistently honors the selected output compression level (not temporary/spill settings), including spilling runs.
  * Improved Phase 2 merge finalization to ensure writer/index output is finalized at the correct stage, including when all sources are empty.
* **Refactor**
  * Clarified merge teardown so output finalization happens before the worker pool transitions to the earlier phase.
* **Tests**
  * Added integration coverage for BGZF compressor routing across spilling and in-memory paths, plus deterministic checks for BAI/index bytes.
  * Added unit tests validating the Phase 2 teardown contract and empty-merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->