### PR TITLE
fix(pipeline): don't declare a stage done while its items are still in flight

### DIFF
--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -2031,6 +2031,46 @@ fn try_step_decompress<G: Send, P: Send + MemoryEstimate>(
     }
 }
 
+/// Whether `FindBoundaries` has consumed all its input and pushed all its output,
+/// and so may set `boundary_done`.
+///
+/// Two things must hold, and the second is easy to miss.
+///
+/// **All input consumed.** `batches_boundary_processed == next_read_serial` implies
+/// `Decompress` also finished, since no more can be processed than was
+/// decompressed, so this also rules out data still sitting in `q2_decompressed`.
+///
+/// **No output still outstanding.** `batches_boundary_processed` is incremented
+/// when a batch is popped from `q2_reorder` — *before* its boundaries are pushed —
+/// so a batch whose push failed is already counted as processed while it waits in
+/// some worker's `held_boundaries`, in no queue and invisible to the other workers.
+/// Setting `boundary_done` there lets `Group` finish on
+/// `batches_grouped == batches_boundary_found`, which excludes that batch, and latch
+/// its one-way `finished` flag; the batch is then pushed and decoded, and reaches an
+/// already-finalized grouper.
+///
+/// `next_boundary_serial == batches_boundary_found` is what rules that out. A serial
+/// is minted only immediately before a push is attempted, and
+/// `batches_boundary_found` is incremented only when a push succeeds (including the
+/// retry of a held batch, which reuses its serial rather than minting a new one), so
+/// the two are equal exactly when nothing is outstanding. Note this cannot be done
+/// with `batches_boundary_processed`: a batch with no records is counted as processed
+/// but mints no serial and is never pushed, so `found == processed` is not an
+/// invariant even when nothing is held.
+///
+/// `batches_boundary_found` is loaded before `next_boundary_serial` so the comparison
+/// errs toward "not complete": a batch outstanding at the first load forces
+/// `next_boundary_serial` above the value read, and it only ever grows.
+fn boundary_finding_is_complete<G: Send, P: Send + MemoryEstimate>(
+    state: &BamPipelineState<G, P>,
+) -> bool {
+    state.read_done.load(Ordering::Acquire)
+        && state.batches_boundary_processed.load(Ordering::Acquire)
+            == state.next_read_serial.load(Ordering::Acquire)
+        && state.batches_boundary_found.load(Ordering::Acquire)
+            == state.next_boundary_serial.load(Ordering::Acquire)
+}
+
 /// Try to execute Step 3: Find record boundaries in decompressed data.
 ///
 /// SYNC WITH: fastq.rs `fastq_try_step_find_boundaries()`
@@ -2066,7 +2106,8 @@ fn try_step_find_boundaries<G: Send, P: Send + MemoryEstimate>(
                 did_work = true;
             }
             Err((serial, held)) => {
-                // Still can't push - put it back and signal backpressure
+                // Still can't push - put it back and signal backpressure. The serial
+                // it already holds keeps it visible to `boundary_finding_is_complete`.
                 worker.held_boundaries = Some((serial, held));
                 return (false, false); // Backpressure, not contention
             }
@@ -2150,7 +2191,10 @@ fn try_step_find_boundaries<G: Send, P: Send + MemoryEstimate>(
                             state.deadlock_state.record_q2b_push();
                         }
                         Err((serial, boundary_batch)) => {
-                            // Output full - hold the result and stop processing
+                            // Output full - hold the result and stop processing. The
+                            // serial is already minted and `batches_boundary_found` is
+                            // not, which is what keeps this batch visible to
+                            // `boundary_finding_is_complete` while it waits.
                             worker.held_boundaries = Some((serial, boundary_batch));
                             return (true, false); // Did work (processed data), will retry push later
                         }
@@ -2169,20 +2213,10 @@ fn try_step_find_boundaries<G: Send, P: Send + MemoryEstimate>(
         return (true, false); // Success, no contention (we held the lock)
     }
 
-    // No batches processed - check if we should finish
-    // Completion check: Only finish when THIS step has processed all input batches.
-    // We check batches_boundary_processed == total_read directly, which implies that
-    // Decompress has also finished (since we can't process more than was decompressed).
-    // This prevents a race where FindBoundaries sets boundary_done while data is still
-    // in q2_decompressed waiting to be processed.
-    let read_done = state.read_done.load(Ordering::Acquire);
-    let total_read = state.next_read_serial.load(Ordering::Acquire);
-    let batches_boundary_processed = state.batches_boundary_processed.load(Ordering::Acquire);
-
-    if read_done
-        && batches_boundary_processed == total_read
-        && !state.boundary_done.load(Ordering::Acquire)
-    {
+    // No batches processed - check if we should finish. The flag is tested first so
+    // the drain-down spin, which reaches here on every pass, does not re-read the
+    // counters only to be rejected by an already-set flag.
+    if !state.boundary_done.load(Ordering::Acquire) && boundary_finding_is_complete(state) {
         // All input processed - finish and emit any remaining boundaries
         match boundary_guard.finish() {
             Ok(Some(final_batch)) => {
@@ -2196,7 +2230,9 @@ fn try_step_find_boundaries<G: Send, P: Send + MemoryEstimate>(
                             state.deadlock_state.record_q2b_push();
                         }
                         Err((serial, final_batch)) => {
-                            // Hold final batch for next attempt
+                            // Hold final batch for next attempt. `boundary_done` is
+                            // deliberately not set on this path — the retry re-enters
+                            // `finish()` after Priority 1 pushes this batch.
                             worker.held_boundaries = Some((serial, final_batch));
                             return (true, false);
                         }
@@ -4617,6 +4653,53 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.non_empty_queues.iter().any(|s| s.contains("q2_decompressed")));
+    }
+
+    /// `FindBoundaries` may only set `boundary_done` once every input batch has been
+    /// consumed *and* every boundary batch it minted has actually been pushed.
+    ///
+    /// `batch_held` is the regression: a batch whose push failed is already counted in
+    /// `batches_boundary_processed` while it waits in a worker's `held_boundaries`. See
+    /// [`boundary_finding_is_complete`] for why that orphans the batch.
+    #[rstest]
+    #[case::all_pushed(true, 5, 5, true)]
+    #[case::batch_held(true, 5, 4, false)]
+    #[case::input_outstanding(true, 3, 5, false)]
+    #[case::reader_still_going(false, 5, 5, false)]
+    fn test_boundary_finding_completion_requires_no_held_batch(
+        #[case] read_done: bool,
+        #[case] batches_processed: u64,
+        #[case] batches_pushed: u64,
+        #[case] expected_complete: bool,
+    ) {
+        let state = create_test_state(0);
+        state.read_done.store(read_done, Ordering::SeqCst);
+        state.next_read_serial.store(5, Ordering::SeqCst);
+        state.batches_boundary_processed.store(batches_processed, Ordering::SeqCst);
+        // Five batches minted a serial; `batches_pushed` of them reached the queue, so
+        // a shortfall is a batch held for a retried push.
+        state.next_boundary_serial.store(5, Ordering::SeqCst);
+        state.batches_boundary_found.store(batches_pushed, Ordering::SeqCst);
+
+        assert_eq!(
+            boundary_finding_is_complete(&state),
+            expected_complete,
+            "completion must require all input consumed and every minted batch pushed"
+        );
+    }
+
+    /// An empty input completes immediately: every counter is zero, so both equalities
+    /// hold trivially. Worth pinning because the failure mode is a stage that never
+    /// declares itself done and hangs on a file with no records.
+    #[test]
+    fn test_boundary_finding_completes_on_empty_input() {
+        let state = create_test_state(0);
+        state.read_done.store(true, Ordering::SeqCst);
+
+        assert!(
+            boundary_finding_is_complete(&state),
+            "an input with no batches must complete rather than hang"
+        );
     }
 
     #[test]

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -4289,6 +4289,34 @@ pub trait HasRecycledBuffers {
 ///
 /// This trait ensures both BAM and FASTQ pipelines use the same exit logic,
 /// preventing the race condition where data in held items is lost on exit.
+///
+/// **A related rule governs per-stage done flags, and is not enforced here.** Worker
+/// exit is covered by `has_any_held_items()` above; a stage's `*_done` flag is not.
+/// Before setting it, a stage must account for *every* place an item can sit between
+/// produced and consumed, because a downstream stage may latch finished off that flag
+/// and orphan whatever it missed. There are three such places, and a completion
+/// predicate that omits any of them is a stalled pipeline:
+///
+/// 1. **its own input/output queue** — items pushed but not yet drained. Counters do
+///    not cover this: a producer that counts *after* pushing can leave the counter
+///    level with its target while the items are still queued, so the predicate must
+///    test the queue itself. Omitting this term is what stranded blocks in FASTQ
+///    `BlockMerge`.
+/// 2. **a worker-local held slot** — an item whose push failed. This one cannot be
+///    queried, since a held item is invisible to every other worker, so the counters
+///    have to be arranged such that a held item keeps the predicate false. Getting
+///    that backwards is what stranded a batch in BAM `FindBoundaries`.
+/// 3. **the stage's own intermediate state** — pending maps, surplus records,
+///    cross-block remainders (`BlockMergeState`, `Group`'s `pending_groups`).
+///
+/// For (2) specifically, a stage is exposed only when its predicate compares against
+/// a counter incremented *before* the push, so a held item is already counted as
+/// done. Existing stages avoid that in one of three ways, any of which suffices:
+/// counting *after* the push (`Decompress`, FASTQ `Parse`, FASTQ `BlockParseFast`);
+/// counting at serial-assignment time, so a held item raises the target rather than
+/// lowering it (`Read`, FASTQ gzip `FindBoundaries`, and BAM `FindBoundaries` via
+/// `next_boundary_serial`); or keeping the un-pushed item inside the shared lock so
+/// it is globally visible (`Group`). Prefer one of those to a new counter.
 pub trait WorkerStateCommon {
     /// Check if this worker is holding any items that haven't been pushed yet.
     ///

--- a/src/lib/unified_pipeline/fastq.rs
+++ b/src/lib/unified_pipeline/fastq.rs
@@ -2504,6 +2504,70 @@ fn drain_exhausted_stream<R: BufRead + Send, P: Send + MemoryEstimate>(
     DrainResult::Ok { did_work, batches_this_call }
 }
 
+/// Whether `BlockMerge` has nothing left to do and may declare the pipeline done.
+///
+/// Completion is only safe when every parsed block has been *consumed*, not
+/// merely produced, so all three holding places must be empty at once:
+///
+/// - `q2_block_parsed` — blocks pushed but not yet drained into the pending maps;
+/// - `merge` — the pending maps, surplus records and cross-block suffix bytes;
+/// - `held_parsed` — a merged batch the worker could not push downstream.
+///
+/// Checking the counters alone is *not* sufficient, and omitting the
+/// `q2_block_parsed` term strands blocks: `BlockMerge`'s drain loop can observe
+/// a momentarily empty queue, `BlockParseFast` can then push the last blocks and
+/// bring `chunks_block_parsed` level with `batches_read`, and this predicate
+/// would report completion with those blocks still queued. Nothing pops them
+/// afterwards — `BlockParseFast` returns early once `block_merge_done` is set —
+/// so the run stalls until the deadlock detector fires.
+///
+/// The queue check is sound because `BlockParseFast` pushes *before* it counts
+/// (with a `Release` increment), and deliberately does not count a block it is
+/// still holding. Observing `chunks_block_parsed == batches_read` through an
+/// `Acquire` load therefore happens-after every one of those pushes, so each
+/// pushed block is visible to this thread. Reading the queue *after* that load —
+/// `&&` sequences its operands left to right — means an empty queue can only mean
+/// the blocks were drained, never that they had not landed yet.
+///
+/// `held_parsed_is_none` is only the *calling* worker's held slot, so another
+/// worker can hold a merged batch while this one declares completion. That is
+/// benign here, unlike the equivalent in `bam.rs`'s `FindBoundaries`, which needs a
+/// globally visible count: the held batch is pushed at Priority 1 before the
+/// `block_merge_done` early-return can strand it,
+/// [`FastqPipelineState::is_complete`] separately requires the output queues to be
+/// empty, and the BGZF path skips `Group` entirely, so there is no one-way
+/// `finished` latch to trip.
+fn block_merge_is_complete<R: BufRead + Send, P: Send + MemoryEstimate>(
+    state: &FastqPipelineState<R, P>,
+    merge: &BlockMergeState,
+    held_parsed_is_none: bool,
+) -> bool {
+    state.read_done.load(Ordering::Acquire)
+        && state.chunks_block_parsed.load(Ordering::Acquire)
+            == state.batches_read.load(Ordering::Acquire)
+        // Must be observed *after* the counter load above — see the doc comment.
+        && state.q2_block_parsed.is_empty()
+        && merge.is_empty()
+        && held_parsed_is_none
+}
+
+/// Publishes `BlockMerge`'s completion flags if [`block_merge_is_complete`] holds.
+///
+/// Both of `BlockMerge`'s exits end in the same three stores, and the drift between
+/// its two completion *conditions* is what stranded blocks in the first place, so
+/// condition and action are kept together in one place rather than repeated.
+fn finish_block_merge_if_complete<R: BufRead + Send, P: Send + MemoryEstimate>(
+    state: &FastqPipelineState<R, P>,
+    merge: &BlockMergeState,
+    worker: &FastqWorkerState<P>,
+) {
+    if block_merge_is_complete(state, merge, worker.held_parsed.is_none()) {
+        state.block_merge_done.store(true, Ordering::Release);
+        state.parse_done.store(true, Ordering::Release);
+        state.group_done.store(true, Ordering::Release);
+    }
+}
+
 /// `BlockMerge` step: serial step that assembles `BlockParsed` items into
 /// `FastqTemplate`s and pushes them to the output groups queue.
 ///
@@ -2593,14 +2657,7 @@ fn fastq_try_step_block_merge<R: BufRead + Send, P: Send + MemoryEstimate>(
     }
     if drained == 0 && merge.r1_pending.is_empty() && merge.r2_pending.is_empty() {
         // Nothing to do. Check for completion.
-        let all_chunks_block_parsed = state.read_done.load(Ordering::Acquire)
-            && state.chunks_block_parsed.load(Ordering::Acquire)
-                == state.batches_read.load(Ordering::Acquire);
-        if all_chunks_block_parsed && merge.is_empty() {
-            state.block_merge_done.store(true, Ordering::Release);
-            state.parse_done.store(true, Ordering::Release);
-            state.group_done.store(true, Ordering::Release);
-        }
+        finish_block_merge_if_complete(state, &merge, worker);
         return (did_work, false);
     }
 
@@ -2811,23 +2868,7 @@ fn fastq_try_step_block_merge<R: BufRead + Send, P: Send + MemoryEstimate>(
     }
 
     // Check for completion: all chunks processed, queue drained, and merge state empty.
-    let all_chunks_block_parsed = state.read_done.load(Ordering::Acquire)
-        && state.chunks_block_parsed.load(Ordering::Acquire)
-            == state.batches_read.load(Ordering::Acquire);
-    if all_chunks_block_parsed
-        && state.q2_block_parsed.is_empty()
-        && merge.r1_pending.is_empty()
-        && merge.r2_pending.is_empty()
-        && merge.r1_surplus.is_empty()
-        && merge.r2_surplus.is_empty()
-        && merge.r1_suffix_bytes.is_empty()
-        && merge.r2_suffix_bytes.is_empty()
-        && worker.held_parsed.is_none()
-    {
-        state.block_merge_done.store(true, Ordering::Release);
-        state.parse_done.store(true, Ordering::Release);
-        state.group_done.store(true, Ordering::Release);
-    }
+    finish_block_merge_if_complete(state, &merge, worker);
 
     (did_work, false)
 }
@@ -5392,6 +5433,56 @@ mod tests {
         // Block 0 must be processed first (BTreeMap ordering by key).
         let first_key = *state.r1_pending.keys().next().unwrap();
         assert_eq!(first_key, 0, "BTreeMap must yield block 0 first");
+    }
+
+    /// `BlockMerge` may only declare completion when every parsed block has been
+    /// *consumed*, so each of the three places a block can sit must independently
+    /// veto completion.
+    ///
+    /// `blocks_still_queued` is the regression — it stalled the run until the deadlock
+    /// detector fired (`Q2b=2, merged=0, block_merge_done=true`). See
+    /// [`block_merge_is_complete`] for why a counters-only predicate strands blocks.
+    #[rstest]
+    #[case::all_drained(true, true, false, false, false, true)]
+    #[case::blocks_still_queued(true, true, true, false, false, false)]
+    #[case::counters_behind(true, false, false, false, false, false)]
+    #[case::reader_still_going(false, true, false, false, false, false)]
+    #[case::merge_state_pending(true, true, false, true, false, false)]
+    #[case::batch_held_downstream(true, true, false, false, true, false)]
+    fn test_block_merge_completion_requires_every_block_consumed(
+        #[case] read_done: bool,
+        #[case] counters_caught_up: bool,
+        #[case] blocks_queued: bool,
+        #[case] merge_pending: bool,
+        #[case] batch_held: bool,
+        #[case] expected_complete: bool,
+    ) {
+        let state = make_fastq_state();
+        let mut merge = BlockMergeState::new();
+
+        // `read_done` plus a counter level with `batches_read` is what tells
+        // BlockMerge that no further blocks will ever be produced.
+        state.read_done.store(read_done, Ordering::Release);
+        state.batches_read.store(2, Ordering::Release);
+        state.chunks_block_parsed.store(if counters_caught_up { 2 } else { 1 }, Ordering::Release);
+
+        if blocks_queued {
+            let block =
+                make_block_parsed(0, 0, vec![make_record("r1", "ACGT", "IIII")], vec![], vec![]);
+            state.q2_block_parsed.push(block).expect("queue has capacity");
+        }
+        if merge_pending {
+            merge.r1_pending.insert(
+                0,
+                make_block_parsed(0, 0, vec![make_record("r1", "ACGT", "IIII")], vec![], vec![]),
+            );
+        }
+
+        assert_eq!(
+            block_merge_is_complete(&state, &merge, !batch_held),
+            expected_complete,
+            "completion must require an empty queue, empty merge state and no held batch"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two pipeline stages could declare themselves finished while items were still in flight, stalling the run until the deadlock detector fired. Both are pre-existing on `main`.

The first surfaced as a flaky `test_extract_bgzf_async_reader_multithreaded` failure under a loaded full-suite run:

```
Queue depths: Q1=0 Q2=0 Q2b=2 Q3=0 Q4=0 Q5=0 Q6=0 Q7=0
State: read_done=true, group_done=true, draining=true
Extra: block_merge_done=true, parse_done=true, batches: read=2 block_parsed=2 merged=0
Pipeline counters: ... total_templates_pushed=0, templates_written=0
```

Two parsed blocks stranded in `q2_block_parsed` while the only stage that drains it had already finished, and nothing was ever written. Investigating it turned up the same class of bug in the BAM pipeline.

## The class

A completion predicate must account for **every** place an item can sit between produced and consumed, because a downstream stage may latch finished off that flag and orphan whatever it missed. There are three such places, and each bug here missed a different one:

| Place | Covered by | Missed in |
|---|---|---|
| the stage's input/output queue | testing the queue directly — counters don't cover it | **FASTQ `BlockMerge`** |
| a worker-local held slot | counter shape, since a held item is invisible to other workers | **BAM `FindBoundaries`** |
| the stage's own intermediate state | pending maps, surplus, remainders | — (both already covered) |

## `fix(fastq)` — `BlockMerge` declared done with blocks still queued

`BlockMerge` had two completion checks that had drifted apart:

| Term | early-return | end-of-step |
|---|---|---|
| `read_done && chunks_block_parsed == batches_read` | ✅ | ✅ |
| pending maps / surplus / suffix empty | ✅ | ✅ |
| **`q2_block_parsed.is_empty()`** | ❌ **missing** | ✅ |

The drain loop pops from a momentarily empty queue, `BlockParseFast` then pushes the final blocks and brings the counter level with `batches_read`, and the early return concludes the pipeline is done. Nothing pops them afterwards — `BlockParseFast` returns early once `block_merge_done` is set.

Both checks now go through one `block_merge_is_complete`, and both exits through one `finish_block_merge_if_complete`, so condition and action cannot drift again. The queue term is sound because `BlockParseFast` pushes *before* it counts, so observing the counter caught up through an `Acquire` load happens-after every push; reading the queue after that load distinguishes "drained" from "not yet landed".

## `fix(bam)` — `FindBoundaries` finished with a batch held for retry

`batches_boundary_processed` is incremented when a batch is popped from `q2_reorder`, *before* its boundaries are pushed. When the push fails the batch moves to `WorkerState::held_boundaries` — already counted as processed, absent from `batches_boundary_found`, and in no queue. Any worker holding the boundary lock then sees `batches_boundary_processed == next_read_serial` and sets `boundary_done` with that push outstanding. `Group` finishes on `batches_grouped == batches_boundary_found`, which excludes the held batch, and latches its one-way `finished` flag; the batch is pushed and decoded afterwards, reaching an already-finalized grouper while `q3` never drains.

This one **stalls rather than losing records** — `has_any_held_items` keeps the holding worker alive — but the grouper has already emitted its final group, so a UMI family spanning that boundary is split.

The predicate now also requires `batches_boundary_found == next_boundary_serial`. A serial is minted only immediately before a push and `found` only when one succeeds (a retried held batch reuses its serial), so the two are equal exactly when nothing is outstanding — no worker needs to see another's held slot. It cannot be built from `batches_boundary_processed`: a batch with no records is counted as processed but mints no serial and is never pushed, so `found == processed` is not an invariant even when nothing is held.

## Also

`base.rs` gains the general rule beside the existing worker-exit invariant it belongs next to — the three places, which bug came from missing which, and the three ways the other stages already avoid the held-slot half (count after the push; count at serial-assignment so a held item raises the target; or keep the un-pushed item inside the shared lock). That doc is what would have prevented both bugs; a runtime mechanism would be redundant for the six stages that are already safe for better reasons.

## Testing

Both races need a specific interleaving. Neither reproduced in 25 stress reps under full CPU saturation — **in either direction**, so the stress runs show no regression rather than validating the fixes. The regression tests therefore pin the predicates directly: reverting only the new term in each fails exactly one case (`blocks_still_queued`, `batch_held`) and no other. Empty input is pinned too, since the failure mode there is hanging on a record-less file.

`cargo ci-test` (6537 tests), `ci-fmt`, `ci-lint`, and `ci-doc` all pass.

## Follow-up (not in this PR)

`bam.rs` has two dead completion flags found during the audit: `decompress_done` is never set or read, and `decode_done` is written but never read — and its predicate already omits `held_decoded`, making it a latent third instance of this class should anyone wire it up. Both are pre-existing and untouched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pipeline completion detection to ensure queued, held, and buffered data is fully processed before marking stages complete.
  * Prevented premature completion that could leave data stranded or cause processing to stall.
  * Added handling for empty-input completion and final pending batches.

* **Documentation**
  * Clarified worker completion requirements for queued, held, and intermediate work.

* **Tests**
  * Added regression coverage for delayed consumption, held batches, active readers, and empty inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->