### PR TITLE
refactor(io): one BGZF header predicate, one open per compare input, and plain-gzip input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,6 +708,7 @@ dependencies = [
  "bytes",
  "criterion",
  "crossbeam-channel",
+ "fgumi-bgzf",
  "fgumi-raw-bam",
  "log",
  "nix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,6 +710,7 @@ dependencies = [
  "crossbeam-channel",
  "fgumi-bgzf",
  "fgumi-raw-bam",
+ "flate2",
  "log",
  "nix",
  "noodles",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,15 @@ repository = "https://github.com/fulcrumgenomics/fgumi"
 license = "MIT"
 
 [workspace.dependencies]
+# `zlib-rs` selects flate2's fast Rust-zlib DEFLATE backend. It must be requested
+# explicitly: the backend is otherwise chosen by Cargo feature unification, and a
+# transitive change can silently drop it back to the ~2x slower `miniz_oxide`
+# default — which regressed extract throughput ~1.6x at high thread counts. Pinned
+# here rather than per-crate so `fgumi` (gzipped FASTQ in `extract`) and
+# `fgumi-bam-io` (gzipped SAM/BAM at the input boundary) cannot end up on
+# different backends.
+flate2 = { version = "1.1", features = ["zlib-rs"] }
+
 # Internal crates. Versions are bumped in lockstep by release-plz.
 fgumi-bam-io = { version = "0.4.0", path = "crates/fgumi-bam-io" }
 fgumi-bgzf = { version = "0.4.0", path = "crates/fgumi-bgzf" }
@@ -121,13 +130,7 @@ approx = { workspace = true }
 ahash = { workspace = true }
 bytemuck = { workspace = true }
 rand_distr = "0.6"
-# `zlib-rs` selects flate2's fast Rust-zlib DEFLATE backend for gzipped FASTQ
-# decompression (used by `fgumi extract`). It must be requested explicitly: the
-# backend is otherwise chosen by Cargo feature unification, and a transitive
-# change can silently drop it back to the ~2x slower `miniz_oxide` default —
-# which regressed extract throughput ~1.6x at high thread counts. Keep this
-# feature pinned so the producer-thread decompressor stays on zlib-rs.
-flate2 = { version = "1.1", features = ["zlib-rs"] }
+flate2 = { workspace = true }
 dhat = { version = "0.3", optional = true }
 fgumi-raw-bam = { workspace = true, features = ["noodles"] }
 fgumi-dna = { workspace = true }

--- a/crates/fgumi-bam-io/Cargo.toml
+++ b/crates/fgumi-bam-io/Cargo.toml
@@ -15,6 +15,7 @@ pedantic = { level = "deny", priority = -1 }
 
 [dependencies]
 fgumi-raw-bam = { workspace = true, features = ["noodles"] }
+fgumi-bgzf = { workspace = true }
 noodles = { workspace = true, features = ["bam", "fasta", "sam", "bgzf", "core", "vcf"] }
 noodles-bgzf = { workspace = true }
 noodles-csi = { workspace = true }

--- a/crates/fgumi-bam-io/Cargo.toml
+++ b/crates/fgumi-bam-io/Cargo.toml
@@ -20,6 +20,7 @@ noodles = { workspace = true, features = ["bam", "fasta", "sam", "bgzf", "core",
 noodles-bgzf = { workspace = true }
 noodles-csi = { workspace = true }
 bgzf = { workspace = true }
+flate2 = { workspace = true }
 anyhow = { workspace = true }
 bstr = { workspace = true }
 bytes = { workspace = true }

--- a/crates/fgumi-bam-io/src/format.rs
+++ b/crates/fgumi-bam-io/src/format.rs
@@ -15,25 +15,11 @@ const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
 
 /// Bytes needed to tell BGZF from plain gzip.
 ///
-/// BGZF is gzip with a mandatory `BC` extra subfield, which lives at bytes
-/// 12-13 behind the `XLEN` at 10-11. Anything shorter can only answer "gzip or
-/// not", which is how a plain-gzipped file gets mistaken for BAM.
-pub const FORMAT_PREFIX_LEN: usize = 18;
-
-/// The deflate compression method, the only one BGZF uses.
-const DEFLATE: u8 = 0x08;
-
-/// `FEXTRA`, and nothing else: BGZF sets exactly this one gzip flag.
-const FEXTRA_ONLY: u8 = 0x04;
-
-/// `XLEN`: the extra field is exactly the 6-byte `BC` subfield, no more.
-const BGZF_XLEN: [u8; 2] = [0x06, 0x00];
-
-/// The `BC` subfield identifier, which is what makes a gzip member BGZF.
-const BC_SUBFIELD_ID: [u8; 2] = [b'B', b'C'];
-
-/// `SLEN` for `BC`: two bytes, holding the total block size minus one.
-const BC_SUBFIELD_LEN: [u8; 2] = [0x02, 0x00];
+/// A whole BGZF block header, because that is what the shared predicate reads:
+/// BGZF is gzip with a mandatory `BC` extra subfield behind the `XLEN` at 10-11.
+/// Anything shorter can only answer "gzip or not", which is how a plain-gzipped
+/// file gets mistaken for BAM.
+pub const FORMAT_PREFIX_LEN: usize = fgumi_bgzf::BGZF_HEADER_SIZE;
 
 /// What an input's leading bytes say it is.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,32 +49,21 @@ pub enum InputFormat {
 ///
 /// Detection is by content, never by file extension.
 ///
-/// # The BGZF check is at fixed offsets, deliberately
+/// # The BGZF verdict comes from the decoder's own predicate
 ///
-/// RFC 1952 permits several extra subfields per gzip member in any order, so
-/// `BC` need not be first and a spec-literal check would have to walk the
-/// `FEXTRA` area looking for it. This does not, and must not: the verdict's job
-/// is to predict what the *decoder* will accept, and every decoder downstream of
-/// it is keyed to these same fixed offsets.
+/// The `Bgzf` arm delegates to [`fgumi_bgzf::is_bgzf_header`], which is the same
+/// check [`fgumi_bgzf::reader`] applies to every block it frames. That shared
+/// definition is the point: the verdict's job is to predict what the decoder will
+/// accept, so answering it with a *second*, hand-rolled copy of the layout is how
+/// the two came to disagree in the first place. See [`fgumi_bgzf::header`] for
+/// why the layout is matched at fixed offsets rather than walked, and why the
+/// predicate is the intersection of what fgumi's decoders accept rather than what
+/// RFC 1952 permits.
 ///
-/// * `fgumi_bgzf`'s `read_raw_block` (behind `read_raw_blocks`) — the sort
-///   worker pool, the BAM writers, `fastq` — checks `BC` at bytes 12-13 and
-///   takes `BSIZE` from bytes 16-17 to *frame* the block. The layout is
-///   load-bearing for where one block ends and the next begins, not merely for
-///   validation, and the deflate payload is taken as `[18 .. len - 8]`.
-/// * `noodles_bgzf`'s `is_valid_header` additionally requires `FLG` to be
-///   `FEXTRA` alone and `XLEN` to be exactly 6.
-/// * htslib's `check_header` (`bgzf.c`) requires the same `XLEN == 6`, `BC` at
-///   12-13, and `SLEN == 2`; it differs from noodles only in tolerating other
-///   `FLG` bits alongside `FEXTRA`.
-///
-/// bgzip, samtools, htsjdk and noodles all *write* exactly this layout, so no
-/// BGZF a user can produce with them is missed.
-///
-/// Answering `Bgzf` for a member that misses this layout would therefore hand it
-/// to a decoder that rejects it — `invalid BGZF header` from noodles, or
-/// `Invalid BGZF subfield ID` from `fgumi_bgzf` — which is the misleading
-/// diagnosis this classifier exists to prevent. Answering `Gzip` names it as
+/// Answering `Bgzf` for a member that misses this layout would hand it to a
+/// decoder that rejects it — `invalid BGZF header` from noodles, or a named field
+/// rejection from `fgumi_bgzf` — which is the misleading diagnosis this
+/// classifier exists to prevent. Answering `Gzip` names it as
 /// gzip-that-is-not-BGZF and points at `bgzip`, which is the actual remedy — the
 /// member has to be recompressed before fgumi can read it either way. For FASTQ,
 /// where [`InputFormat::Gzip`] is a supported input rather than an error, the
@@ -103,19 +78,8 @@ pub fn classify_input(prefix: &[u8]) -> InputFormat {
         return InputFormat::Text;
     }
 
-    // gzip. BGZF is gzip whose sole extra subfield is `BC`, at a fixed offset —
-    // see this function's doc comment for why the offsets are not walked.
-    if prefix.len() >= FORMAT_PREFIX_LEN
-        && prefix[2] == DEFLATE
-        && prefix[3] == FEXTRA_ONLY
-        && prefix[10..12] == BGZF_XLEN
-        && prefix[12..14] == BC_SUBFIELD_ID
-        && prefix[14..16] == BC_SUBFIELD_LEN
-    {
-        InputFormat::Bgzf
-    } else {
-        InputFormat::Gzip
-    }
+    // gzip. Whether it is BGZF is the block reader's question, so it answers it.
+    if fgumi_bgzf::is_bgzf_header(prefix) { InputFormat::Bgzf } else { InputFormat::Gzip }
 }
 
 #[cfg(test)]
@@ -143,42 +107,14 @@ mod tests {
     #[case::gzip_magic_but_truncated(&[0x1f, 0x8b, 0x08, 0x04], InputFormat::Gzip)]
     // A short *text* prefix is still unambiguously text.
     #[case::short_text(b"@H", InputFormat::Text)]
-    // FEXTRA set but the subfield is not `BC` — some other gzip extension.
+    // The per-field near misses — a foreign subfield, `BC` with a trailing
+    // subfield, FEXTRA plus FNAME, a wrong SLEN, a non-deflate method — are the
+    // shared predicate's contract and are pinned in `fgumi_bgzf::header`'s own
+    // table. Duplicating them here would be a second copy of exactly the thing
+    // this delegation removed. What belongs here is the dispatch: that a gzip
+    // member which is not a BGZF block reads as `Gzip` rather than `Bgzf`.
     #[case::gzip_with_non_bc_extra(
         &[0x1f, 0x8b, 0x08, 0x04, 0, 0, 0, 0, 0, 0xff, 0x06, 0x00, b'X', b'Y', 0x02, 0x00, 0x1b, 0x00],
-        InputFormat::Gzip
-    )]
-    // `BC` first but XLEN 10, so a second subfield trails it. RFC 1952 allows
-    // this; `noodles_bgzf` and htslib both reject it (XLEN must be exactly 6),
-    // so calling it BGZF would promise a decode that cannot happen — see
-    // `classify_input`'s doc comment.
-    #[case::bc_first_with_trailing_subfield(
-        &[0x1f, 0x8b, 0x08, 0x04, 0, 0, 0, 0, 0, 0xff, 0x0a, 0x00, b'B', b'C', 0x02, 0x00, 0x1b, 0x00],
-        InputFormat::Gzip
-    )]
-    // A foreign subfield ahead of `BC`: same reasoning, and here the fixed
-    // offsets cannot see `BC` at all within the 18-byte window.
-    #[case::foreign_subfield_before_bc(
-        &[0x1f, 0x8b, 0x08, 0x04, 0, 0, 0, 0, 0, 0xff, 0x0a, 0x00, b'X', b'Y', 0x02, 0x00, 0x00, 0x00],
-        InputFormat::Gzip
-    )]
-    // FEXTRA plus FNAME. The extra field precedes FNAME in a gzip member, so
-    // `XLEN` and `BC` are still where they belong and htslib would take this
-    // (`header[3] & 4`); `noodles_bgzf` requires FLG to be FEXTRA alone and
-    // rejects it, and this verdict tracks our decoder rather than the spec.
-    #[case::fextra_with_fname(
-        &[0x1f, 0x8b, 0x08, 0x0c, 0, 0, 0, 0, 0, 0xff, 0x06, 0x00, b'B', b'C', 0x02, 0x00, 0x1b, 0x00],
-        InputFormat::Gzip
-    )]
-    // `BC` at the right offset but SLEN != 2, so the block size it carries is
-    // not the two bytes every decoder reads.
-    #[case::bc_with_wrong_slen(
-        &[0x1f, 0x8b, 0x08, 0x04, 0, 0, 0, 0, 0, 0xff, 0x06, 0x00, b'B', b'C', 0x04, 0x00, 0x1b, 0x00],
-        InputFormat::Gzip
-    )]
-    // Compression method other than deflate: gzip's framing, nothing fgumi reads.
-    #[case::non_deflate_method(
-        &[0x1f, 0x8b, 0x00, 0x04, 0, 0, 0, 0, 0, 0xff, 0x06, 0x00, b'B', b'C', 0x02, 0x00, 0x1b, 0x00],
         InputFormat::Gzip
     )]
     fn classifies(#[case] prefix: &[u8], #[case] expected: InputFormat) {

--- a/crates/fgumi-bam-io/src/format.rs
+++ b/crates/fgumi-bam-io/src/format.rs
@@ -31,9 +31,13 @@ pub enum InputFormat {
     /// Plain gzip — one deflate stream, so not seekable or block-addressable —
     /// and also the rare gzip member that carries a `BC` subfield but does not
     /// match the fixed BGZF layout every fgumi decoder requires (see
-    /// [`classify_input`]). Either way fgumi's readers cannot consume it even
-    /// though it decompresses, and the remedy is the same: recompress with
-    /// `bgzip`.
+    /// [`classify_input`]).
+    ///
+    /// This is a supported alignment input, not an error: the normalization
+    /// boundary decompresses the member and re-frames what comes out, so the rest
+    /// of the pipeline still sees only BGZF. What it costs is block-parallel
+    /// decode — one deflate stream cannot be split across threads — so `bgzip` is
+    /// a performance recommendation here rather than a requirement.
     Gzip,
     /// Uncompressed text; for alignment inputs, SAM.
     Text,
@@ -64,11 +68,14 @@ pub enum InputFormat {
 /// decoder that rejects it — `invalid BGZF header` from noodles, or a named field
 /// rejection from `fgumi_bgzf` — which is the misleading diagnosis this
 /// classifier exists to prevent. Answering `Gzip` names it as
-/// gzip-that-is-not-BGZF and points at `bgzip`, which is the actual remedy — the
-/// member has to be recompressed before fgumi can read it either way. For FASTQ,
-/// where [`InputFormat::Gzip`] is a supported input rather than an error, the
-/// verdict costs only block-parallel decode: `extract` reads it with
-/// `MultiGzDecoder`, and BGZF is valid gzip.
+/// gzip-that-is-not-BGZF, which routes it to a spec-complete gzip decoder rather
+/// than to a BGZF block reader that would reject it.
+///
+/// `Gzip` is a supported verdict on every input path, not an error. `extract`
+/// reads FASTQ with `MultiGzDecoder`, and alignment inputs go through
+/// `normalize_to_bgzf`, which decompresses the member and re-frames the result.
+/// In both cases the only cost is block-parallel decode — one deflate stream
+/// cannot be split across threads — so `bgzip` buys throughput, not readability.
 #[must_use]
 pub fn classify_input(prefix: &[u8]) -> InputFormat {
     if prefix.is_empty() {

--- a/crates/fgumi-bam-io/src/sam_input.rs
+++ b/crates/fgumi-bam-io/src/sam_input.rs
@@ -1,4 +1,4 @@
-//! Transparent support for uncompressed SAM input.
+//! Transparent support for uncompressed SAM and plain-gzip input.
 //!
 //! Every fgumi reader factory is a BGZF reader: the single-threaded fast
 //! paths hand out raw BAM record bytes, and the multi-threaded pipelines hand
@@ -17,8 +17,16 @@
 //!
 //! Detection is by content, never by file extension (see [`crate::format`]), so
 //! a misnamed `reads.bam` holding SAM text and a `reads.sam` holding BGZF both
-//! read correctly. gzip that is *not* BGZF is named as such rather than handed
-//! to the block decoder, which would fail as though the file were corrupt.
+//! read correctly.
+//!
+//! Plain gzip lands here for the same reason: it is decompressed once at the
+//! boundary and re-classified, so a `gzip`-compressed SAM or BAM reads like any
+//! other input while the rest of the pipeline still sees only BGZF. That also
+//! covers a gzip member whose BGZF framing fgumi's own decoders cannot read (see
+//! [`fgumi_bgzf::header`]) — a spec-complete gzip reader handles the framing they
+//! reject, and whatever comes out is re-framed. What it costs is block-parallel
+//! decode: gzip is one deflate stream, so `--threads` stops helping on the read
+//! side, which is warned about per input rather than left as a silent cliff.
 
 use anyhow::{Context, Result, bail};
 use noodles::sam;
@@ -31,6 +39,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::format::{FORMAT_PREFIX_LEN, InputFormat, classify_input};
 use crate::reader::ChainedReader;
+use flate2::read::MultiGzDecoder;
 
 /// Read buffer wrapped around SAM text input. SAM is line-oriented and much
 /// larger than the equivalent BAM, so it is read in big gulps.
@@ -280,6 +289,123 @@ impl<R: Read> Read for SamToBamStream<R> {
     }
 }
 
+/// BAM's magic bytes, which begin the unframed byte stream inside a BAM file.
+const BAM_MAGIC: &[u8; 4] = b"BAM\x01";
+
+/// How much of an unframed BAM stream to pull per `produce` call.
+///
+/// This is a read granularity, not a block size: BGZF blocking is the writer's
+/// job, and it stages up to its own `MAX_BUF_SIZE` (~64 KiB — one block's ISIZE
+/// less the gzip and deflate overheads) before emitting anything. So chunks and
+/// blocks deliberately do not line up — at 32 KiB the first chunk emits no block
+/// at all and the second one is split across the boundary. Sizing this to match a
+/// block would buy nothing, since the writer would still choose its own cut
+/// points; what it does buy is amortizing the read over a useful span while
+/// keeping one reusable scratch buffer small.
+const REFRAME_CHUNK_SIZE: usize = 32 * 1024;
+
+/// Wraps a raw, unframed BAM byte stream in BGZF framing.
+///
+/// BAM is BGZF-framed by definition, but a BAM that has been through a
+/// spec-complete gzip decompressor comes out as the naked byte stream — that is
+/// what `gzip -dc reads.bam` produces, and what a BGZF member whose framing fgumi
+/// cannot read decompresses to. The bytes are a perfectly good BAM; only the
+/// framing is missing, and every consumer downstream reads BGZF.
+///
+/// So this re-frames rather than parses: the bytes are copied into a BGZF writer
+/// and served back out, with no record decoding anywhere. [`CompressionLevel::NONE`]
+/// for the same reason [`SamToBamStream`] uses it — the blocks are decoded again
+/// microseconds later in the same process.
+struct BgzfFramer<R> {
+    /// The unframed BAM byte stream.
+    inner: R,
+    /// Encoder writing BGZF blocks into `sink`.
+    writer: noodles_bgzf::io::Writer<SharedBuffer>,
+    /// Where the encoder's bytes land.
+    sink: SharedBuffer,
+    /// Framed bytes not yet handed to the caller.
+    staged: Vec<u8>,
+    /// How much of `staged` has been handed over.
+    offset: usize,
+    /// Whether `inner` has been read to the end and the writer finished.
+    done: bool,
+    /// Scratch for one chunk of `inner`, reused across `produce` calls.
+    ///
+    /// Held as a field rather than a local so a stream of `n` chunks does not
+    /// allocate and zero-fill `n` separate `REFRAME_CHUNK_SIZE` buffers — the
+    /// same reason [`SamToBamStream`] keeps its scratch buffers as fields.
+    chunk: Vec<u8>,
+}
+
+impl<R: Read> BgzfFramer<R> {
+    /// Wrap `inner`, which must be a raw BAM byte stream.
+    fn new(inner: R) -> Self {
+        let sink = SharedBuffer::default();
+        let writer = noodles_bgzf::io::writer::Builder::default()
+            .set_compression_level(CompressionLevel::NONE)
+            .build_from_writer(sink.clone());
+        Self {
+            inner,
+            writer,
+            sink,
+            staged: Vec::new(),
+            offset: 0,
+            done: false,
+            chunk: vec![0u8; REFRAME_CHUNK_SIZE],
+        }
+    }
+
+    /// Frame the next chunk, or finish the stream at end of input.
+    fn produce(&mut self) -> io::Result<()> {
+        let filled = crate::reader::read_prefix(&mut self.inner, &mut self.chunk)?;
+        if filled == 0 {
+            // `try_finish` writes the BGZF EOF block, which consumers require.
+            self.writer.try_finish()?;
+            self.done = true;
+        } else {
+            self.writer.write_all(&self.chunk[..filled])?;
+        }
+
+        // Same drop-guard as `SamToBamStream::stage_encoded`, for the same reason:
+        // `read` only calls `produce` with the staging buffer drained, and the
+        // `clear` below would silently discard anything still unread if that ever
+        // stopped holding.
+        debug_assert!(
+            self.offset >= self.staged.len(),
+            "produce() ran with {} unread staged bytes; clearing here would drop them",
+            self.staged.len() - self.offset
+        );
+        self.staged.clear();
+        self.offset = 0;
+        self.sink.swap_into(&mut self.staged);
+        Ok(())
+    }
+}
+
+impl<R: Read> Read for BgzfFramer<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // Same guard, same reason, same point in the chain as
+        // `SamToBamStream::read`: without it a zero-length request satisfies the
+        // refill condition below and drives a whole chunk through the BGZF encoder
+        // to produce nothing. Nothing is lost either way (`offset` does not
+        // advance), but the work is wasted.
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        while self.offset >= self.staged.len() {
+            if self.done {
+                return Ok(0);
+            }
+            self.produce()?;
+        }
+
+        let n = (&self.staged[self.offset..]).read(buf)?;
+        self.offset += n;
+        Ok(n)
+    }
+}
+
 /// Consume up to [`FORMAT_PREFIX_LEN`] bytes from `reader`.
 ///
 /// Returns fewer bytes only at end of input. The bytes are returned rather
@@ -291,7 +417,11 @@ fn read_format_prefix<R: Read>(reader: &mut R) -> io::Result<Vec<u8>> {
     Ok(prefix[..filled].to_vec())
 }
 
-/// Normalize `reader` to a BGZF byte stream, transcoding it if it is SAM text.
+/// Normalize `reader` to a BGZF byte stream, whatever it arrived as.
+///
+/// BGZF passes through; SAM text is transcoded; plain gzip is decompressed once
+/// and then handled as whichever of those it turns out to wrap, including an
+/// unframed BAM byte stream, which is re-framed rather than parsed.
 ///
 /// `path` is used only to describe the input in errors.
 ///
@@ -300,8 +430,9 @@ fn read_format_prefix<R: Read>(reader: &mut R) -> io::Result<Vec<u8>> {
 ///
 /// # Errors
 ///
-/// Returns an error if the input is empty, is gzip but not BGZF, or is text
-/// whose SAM header cannot be parsed (or is absent).
+/// Returns an error if the input is empty, decompresses to an empty gzip member,
+/// is gzip-compressed more than once, or is text whose SAM header cannot be
+/// parsed (or is absent).
 pub fn normalize_to_bgzf(
     mut reader: Box<dyn Read + Send>,
     path: &Path,
@@ -309,48 +440,71 @@ pub fn normalize_to_bgzf(
     let magic = read_format_prefix(&mut reader)
         .with_context(|| format!("Failed to read from: {}", path.display()))?;
 
-    match classify_input(&magic) {
+    // What reaches the SAM transcode below: the leading bytes already consumed,
+    // and the stream they came off. For a gzip member that is the *decompressed*
+    // stream, which is why this is a pair rather than the original reader.
+    let (prefix, stream): (Vec<u8>, Box<dyn Read + Send>) = match classify_input(&magic) {
         InputFormat::Empty => {
             bail!("Input is empty: {} (expected BAM or SAM records)", path.display())
         }
         InputFormat::Bgzf => return Ok(Box::new(ChainedReader::new(magic, reader))),
-        // Distinguished from BGZF so the error names the real problem. Left
-        // undetected, a plain-gzipped file reaches the BGZF decoder and fails
-        // with "Failed to read header", which reads as a corrupt BAM.
-        //
-        // FUTURE: support plain-gzip SAM rather than rejecting it. Now that the
-        // transcode exists this is a small arm — decode with
-        // `flate2::read::MultiGzDecoder` and hand the result to
-        // `SamToBamStream`, landing on the same normalized stream. Two things to
-        // settle first:
-        //
-        //   1. It costs block-parallel decode. gzip is one deflate stream, so
-        //      `--threads` would silently stop helping on the read side; that
-        //      wants a one-time `log::warn!` rather than a silent cliff.
-        //   2. Gzipped *SAM* is a legitimate text file and worth accepting;
-        //      gzipped *BAM* is a malformed artifact that samtools cannot read
-        //      either, so accepting it would just move the failure downstream.
-        //      The arm should therefore transcode as SAM and still reject if the
-        //      decompressed bytes turn out to be BGZF/BAM.
-        //
-        // `extract` already accepts plain-gzip FASTQ, so the asymmetry users see
-        // today is real; it is defensible only while it stays explained.
-        // Phrased as "not readable as BGZF" rather than "not BGZF": the verdict also
-        // covers a gzip member carrying a `BC` subfield in a layout fgumi's decoder
-        // rejects, which is BGZF by the letter of RFC 1952 (see
-        // `classify_input`). The remedy is the same for both, so the message does not
-        // split them.
-        InputFormat::Gzip => bail!(
-            "Input is gzip-compressed but not readable as BGZF: {} — fgumi reads BGZF (bgzip) \
-             so it can decompress blocks in parallel. Recompress with `bgzip`, or pipe it in: \
-             `gzip -dc {} | fgumi ... -i -`",
-            path.display(),
-            path.display()
-        ),
-        InputFormat::Text => {}
-    }
+        // Plain gzip: decompress at the boundary and classify what comes out, so
+        // the rest of the pipeline still sees only BGZF. `MultiGzDecoder` handles
+        // concatenated members and, unlike fgumi's own block reader, the whole of
+        // RFC 1952 -- extra subfields, FNAME and all -- which is what makes this
+        // arm the right home for a gzip member fgumi's BGZF decoder cannot frame.
+        InputFormat::Gzip => {
+            // gzip is a single deflate stream, so `--threads` stops helping on the
+            // read side. Warned per input rather than left as a silent cliff.
+            log::warn!(
+                "Input is gzip-compressed rather than BGZF: {} — decompressing it \
+                 single-threaded, so --threads will not speed up reading. Recompress \
+                 with `bgzip` for block-parallel decode.",
+                path.display()
+            );
 
-    let sam = SamToBamStream::new(ChainedReader::new(magic, reader))
+            let mut decoded: Box<dyn Read + Send> =
+                Box::new(MultiGzDecoder::new(ChainedReader::new(magic, reader)));
+            let inner = read_format_prefix(&mut decoded).with_context(|| {
+                format!("Failed to read gzip-decompressed input: {}", path.display())
+            })?;
+
+            match classify_input(&inner) {
+                // A BGZF stream inside a gzip wrapper — `gzip -c reads.bam`, where
+                // the outer member decompresses to the BAM's own BGZF blocks. Those
+                // are already framed, so they go straight down the normal path.
+                InputFormat::Bgzf => {
+                    return Ok(Box::new(ChainedReader::new(inner, decoded)));
+                }
+                // A BAM that lost its framing on the way through a gzip
+                // decompressor: the bytes are BAM, so re-frame rather than try to
+                // parse them as SAM text, which would fail with a message about a
+                // missing `@` header line for a file that is not text at all.
+                //
+                // This is also where a BGZF member fgumi's own decoder cannot frame
+                // ends up — `MultiGzDecoder` reads the whole of RFC 1952, so what
+                // comes out of it is the naked BAM byte stream, not BGZF.
+                InputFormat::Text if inner.starts_with(BAM_MAGIC) => {
+                    return Ok(Box::new(BgzfFramer::new(ChainedReader::new(inner, decoded))));
+                }
+                InputFormat::Text => (inner, decoded),
+                InputFormat::Empty => bail!(
+                    "Input is an empty gzip member: {} (expected BAM or SAM records)",
+                    path.display()
+                ),
+                // Two gzip layers. Unwrapping repeatedly would let a crafted input
+                // cost unbounded work for one open, so say what it is instead.
+                InputFormat::Gzip => bail!(
+                    "Input is gzip-compressed twice over: {} — decompress it once \
+                     (`gzip -dc`) before handing it to fgumi",
+                    path.display()
+                ),
+            }
+        }
+        InputFormat::Text => (magic, reader),
+    };
+
+    let sam = SamToBamStream::new(ChainedReader::new(prefix, stream))
         .with_context(|| format!("Failed to read SAM input: {}", path.display()))?;
 
     // A SAM header parse consumes only lines beginning with `@`, so arbitrary
@@ -612,6 +766,66 @@ mod tests {
 
         assert!(header.reference_sequences().is_empty(), "no @SQ expected");
         assert_eq!(records.len(), 1, "the unmapped record must survive");
+        Ok(())
+    }
+
+    /// `BgzfFramer` must reproduce its input byte-for-byte across many chunks.
+    ///
+    /// The integration coverage only ever feeds it a handful of short records —
+    /// well under one `REFRAME_CHUNK_SIZE`, let alone the writer's ~64 KiB staging
+    /// buffer — so the framer emits a single block plus EOF and the repeated
+    /// `produce`/`offset` bookkeeping is never exercised. This drives several
+    /// hundred KiB through it, which is many chunks and many blocks, and reads the
+    /// result back in deliberately awkward slice sizes so a partially-consumed
+    /// `staged` buffer is crossed on almost every call.
+    #[test]
+    fn frames_a_multi_block_stream_without_altering_the_bytes() -> Result<()> {
+        // Not compressible to nothing and not uniform, so a dropped or duplicated
+        // chunk changes the bytes rather than hiding in a run of identical ones.
+        let payload: Vec<u8> = (0..300_usize * 1024)
+            .map(|i| u8::try_from((i * 31 + i / 251) % 251).unwrap())
+            .collect();
+        assert!(
+            payload.len() > 4 * REFRAME_CHUNK_SIZE,
+            "the payload must span several chunks for this test to mean anything"
+        );
+
+        let mut framer = BgzfFramer::new(io::Cursor::new(payload.clone()));
+
+        // Awkward, varying read sizes: 7 bytes, then 60_000, then 1, repeating.
+        let mut framed_bytes = Vec::new();
+        let mut sizes = [7_usize, 60_000, 1].into_iter().cycle();
+        loop {
+            let mut buf = vec![0u8; sizes.next().unwrap()];
+            let n = framer.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            framed_bytes.extend_from_slice(&buf[..n]);
+        }
+
+        // A zero-length request must not consume anything or end the stream early.
+        assert_eq!(framer.read(&mut [])?, 0, "empty read must be a no-op");
+
+        // Pin the premise rather than assuming it: if the framer ever emitted one
+        // giant block, the multi-block bookkeeping would still be untested and this
+        // test's name would be a lie.
+        let mut blocks = 0;
+        let mut offset = 0;
+        while let Some(len) = fgumi_bgzf::block_size(&framed_bytes[offset..]) {
+            blocks += 1;
+            offset += len;
+            if offset >= framed_bytes.len() {
+                break;
+            }
+        }
+        assert!(blocks > 4, "expected several BGZF blocks, got {blocks}");
+
+        let mut decoded = Vec::new();
+        noodles_bgzf::io::Reader::new(io::Cursor::new(framed_bytes.clone()))
+            .read_to_end(&mut decoded)?;
+        assert_eq!(decoded.len(), payload.len(), "framing changed the byte count");
+        assert!(decoded == payload, "framing altered the bytes");
         Ok(())
     }
 }

--- a/crates/fgumi-bgzf/src/header.rs
+++ b/crates/fgumi-bgzf/src/header.rs
@@ -1,0 +1,316 @@
+//! The one BGZF block-header layout every fgumi reader agrees on.
+//!
+//! A BGZF block is a gzip member whose extra field carries a `BC` subfield
+//! holding the block's total size. Reading one means answering two questions —
+//! "is this a BGZF block?" and "where does it end?" — and both were previously
+//! answered by hand at four separate sites, which is how they came to disagree:
+//! the input sniff accepted headers the block reader would reject, and the block
+//! reader accepted headers `noodles_bgzf` would reject. This module is the single
+//! answer to both.
+//!
+//! # Why the layout is fixed rather than walked
+//!
+//! RFC 1952 lets a gzip member carry several extra subfields in any order, so a
+//! spec-literal reader would walk the extra field looking for `BC`. fgumi does
+//! not, because the layout below is not merely *validated* here — it is what
+//! [`block_size`] uses to find the end of the block, and what every consumer
+//! assumes when it takes the deflate payload as `[18 .. len - 8]`.
+//!
+//! The predicate is therefore the **intersection** of what fgumi's decoders
+//! accept, not the union and not the spec: a `true` from [`is_bgzf_header`] has
+//! to be a promise that every downstream path can keep. `noodles_bgzf`'s
+//! `is_valid_header` is the strictest of them and is not ours to change, so it
+//! sets the bar — `FLG` must be `FEXTRA` alone and `XLEN` exactly 6. htslib's
+//! `check_header` agrees on `XLEN`, `BC` and `SLEN`, differing only in tolerating
+//! other `FLG` bits; a file that exercises that difference is readable by
+//! samtools and not by fgumi, which this predicate reports honestly rather than
+//! promising a decode that would fail later.
+//!
+//! Nothing is lost in practice: bgzip, samtools, htsjdk and noodles all *write*
+//! exactly this layout, and so does fgumi — [`crate::BGZF_EOF`] is literally
+//! these bytes.
+
+use std::fmt;
+
+/// Size of a BGZF block header.
+pub const BGZF_HEADER_SIZE: usize = 18;
+
+/// gzip magic (ID1, ID2), which every BGZF block starts with.
+const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
+
+/// The deflate compression method, the only one BGZF uses.
+const DEFLATE: u8 = 0x08;
+
+/// `FEXTRA`, and nothing else: BGZF sets exactly this one gzip flag.
+const FEXTRA_ONLY: u8 = 0x04;
+
+/// `XLEN`: the extra field is exactly the 6-byte `BC` subfield, no more.
+const BGZF_XLEN: [u8; 2] = [0x06, 0x00];
+
+/// The `BC` subfield identifier, which is what makes a gzip member BGZF.
+const BC_SUBFIELD_ID: [u8; 2] = [b'B', b'C'];
+
+/// `SLEN` for `BC`: two bytes, holding the total block size minus one.
+const BC_SUBFIELD_LEN: [u8; 2] = [0x02, 0x00];
+
+/// Offset of the `BSIZE` value within the header.
+const BSIZE_OFFSET: usize = 16;
+
+/// Why a candidate header is not a BGZF block header fgumi can decode.
+///
+/// Carried rather than rendered so the streaming block reader can name the exact
+/// field that failed — "invalid BGZF header" over a truncated file and over a
+/// plain-gzip file send a reader looking in different places.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HeaderRejection {
+    /// Fewer than [`BGZF_HEADER_SIZE`] bytes were available.
+    TooShort {
+        /// How many bytes there were.
+        len: usize,
+    },
+    /// Not a gzip member at all.
+    Magic {
+        /// The first two bytes.
+        got: [u8; 2],
+    },
+    /// gzip, but not deflate-compressed.
+    CompressionMethod {
+        /// The `CM` byte.
+        got: u8,
+    },
+    /// `FLG` is not `FEXTRA` alone; see the module docs for why this is exact.
+    Flags {
+        /// The `FLG` byte.
+        got: u8,
+    },
+    /// `XLEN` is not 6, so the extra field is not just the `BC` subfield.
+    ExtraFieldLength {
+        /// The `XLEN` value.
+        got: u16,
+    },
+    /// The extra subfield is not `BC`.
+    SubfieldId {
+        /// The two subfield identifier bytes.
+        got: [u8; 2],
+    },
+    /// `BC`'s `SLEN` is not 2, so it does not hold a `BSIZE`.
+    SubfieldLength {
+        /// The `SLEN` value.
+        got: u16,
+    },
+}
+
+impl fmt::Display for HeaderRejection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::TooShort { len } => {
+                write!(f, "truncated BGZF header: expected {BGZF_HEADER_SIZE} bytes, got {len}")
+            }
+            Self::Magic { got } => write!(
+                f,
+                "Invalid BGZF magic: expected 0x1f 0x8b, got 0x{:02x} 0x{:02x}",
+                got[0], got[1]
+            ),
+            Self::CompressionMethod { got } => {
+                write!(f, "Invalid compression method: expected 0x08, got 0x{got:02x}")
+            }
+            Self::Flags { got } => {
+                write!(f, "Invalid BGZF flags: expected FEXTRA (0x04) alone, got 0x{got:02x}")
+            }
+            Self::ExtraFieldLength { got } => {
+                write!(f, "Invalid BGZF extra-field length: expected 6, got {got}")
+            }
+            Self::SubfieldId { got } => write!(
+                f,
+                "Invalid BGZF subfield ID: expected 'BC', got '{}{}'",
+                got[0] as char, got[1] as char
+            ),
+            Self::SubfieldLength { got } => {
+                write!(f, "Invalid BGZF subfield length: expected 2, got {got}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for HeaderRejection {}
+
+/// Check `prefix` against the BGZF block-header layout, naming the field that
+/// fails.
+///
+/// `prefix` may be longer than a header; only the first [`BGZF_HEADER_SIZE`]
+/// bytes are read.
+///
+/// # Errors
+///
+/// Returns the first [`HeaderRejection`] that applies, in field order, so the
+/// message names the earliest thing that is wrong rather than an arbitrary one.
+pub fn validate(prefix: &[u8]) -> Result<(), HeaderRejection> {
+    if prefix.len() < BGZF_HEADER_SIZE {
+        return Err(HeaderRejection::TooShort { len: prefix.len() });
+    }
+    if prefix[..2] != GZIP_MAGIC {
+        return Err(HeaderRejection::Magic { got: [prefix[0], prefix[1]] });
+    }
+    if prefix[2] != DEFLATE {
+        return Err(HeaderRejection::CompressionMethod { got: prefix[2] });
+    }
+    if prefix[3] != FEXTRA_ONLY {
+        return Err(HeaderRejection::Flags { got: prefix[3] });
+    }
+    if prefix[10..12] != BGZF_XLEN {
+        return Err(HeaderRejection::ExtraFieldLength {
+            got: u16::from_le_bytes([prefix[10], prefix[11]]),
+        });
+    }
+    if prefix[12..14] != BC_SUBFIELD_ID {
+        return Err(HeaderRejection::SubfieldId { got: [prefix[12], prefix[13]] });
+    }
+    if prefix[14..16] != BC_SUBFIELD_LEN {
+        return Err(HeaderRejection::SubfieldLength {
+            got: u16::from_le_bytes([prefix[14], prefix[15]]),
+        });
+    }
+    Ok(())
+}
+
+/// Whether `prefix` starts with a BGZF block header fgumi can decode.
+///
+/// The boolean form of [`validate`], for callers that only need the verdict —
+/// the input classifier, which reports a format rather than a parse failure.
+#[must_use]
+pub fn is_bgzf_header(prefix: &[u8]) -> bool {
+    validate(prefix).is_ok()
+}
+
+/// Total size of the block starting at the front of `block`, from its `BSIZE`.
+///
+/// `BSIZE` is stored as total size minus one. Returns `None` when `block` is too
+/// short to hold a header; the value is *not* validated against
+/// [`validate`], because the framing loops that call this per block run over a
+/// stream whose header was already checked, and re-checking every block's fields
+/// to compute an offset would cost a branch per block for no new information.
+#[must_use]
+pub fn block_size(block: &[u8]) -> Option<usize> {
+    if block.len() < BGZF_HEADER_SIZE {
+        return None;
+    }
+    let bsize = u16::from_le_bytes([block[BSIZE_OFFSET], block[BSIZE_OFFSET + 1]]);
+    Some(usize::from(bsize) + 1)
+}
+
+/// The smallest `BSIZE` that can describe a real block: a header and a footer,
+/// with an empty deflate payload between them.
+pub const MIN_BLOCK_SIZE: usize = BGZF_HEADER_SIZE + crate::reader::BGZF_FOOTER_SIZE;
+
+/// [`block_size`], rejecting a `BSIZE` too small to describe a block at all.
+///
+/// This is the form callers that *use* the size arithmetically want.
+/// [`block_size`] reports `BSIZE` as stored, and a malformed or corrupt block can
+/// store a value below [`MIN_BLOCK_SIZE`] — at which point `offset + size - 4`
+/// underflows and the following index is wildly out of bounds. Every caller has to
+/// enforce that floor, and each one enforcing its own copy is how the check came
+/// to be missing from one of them: two framing loops in the FASTQ pipeline took
+/// the raw value and panicked on input bytes alone.
+///
+/// Returns `None` when `block` is too short to hold a header *or* when the stored
+/// `BSIZE` is below the floor; callers that need to tell those apart can check the
+/// slice length first, which their loop guard has usually already done.
+#[must_use]
+pub fn block_size_checked(block: &[u8]) -> Option<usize> {
+    block_size(block).filter(|size| *size >= MIN_BLOCK_SIZE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    /// A valid 18-byte BGZF header: gzip magic, deflate, FEXTRA, then the
+    /// mandatory `BC` subfield carrying `BSIZE`.
+    const BGZF: [u8; 18] = [
+        0x1f, 0x8b, 0x08, 0x04, 0, 0, 0, 0, 0, 0xff, 0x06, 0x00, b'B', b'C', 0x02, 0x00, 0x1b, 0x00,
+    ];
+
+    /// Returns `BGZF` with one byte replaced, for building near-miss headers.
+    fn bgzf_with(index: usize, value: u8) -> [u8; 18] {
+        let mut header = BGZF;
+        header[index] = value;
+        header
+    }
+
+    #[rstest]
+    #[case::valid(&BGZF, None)]
+    #[case::not_gzip(b"@HD\tVN:1.6\tSO:queryname\n", Some(HeaderRejection::Magic { got: [b'@', b'H'] }))]
+    #[case::truncated(&BGZF[..17], Some(HeaderRejection::TooShort { len: 17 }))]
+    #[case::not_deflate(&bgzf_with(2, 0x00), Some(HeaderRejection::CompressionMethod { got: 0 }))]
+    // No FEXTRA at all: plain gzip.
+    #[case::plain_gzip(&bgzf_with(3, 0x00), Some(HeaderRejection::Flags { got: 0 }))]
+    // FEXTRA plus FNAME. The extra field precedes FNAME in a gzip member, so
+    // `XLEN` and `BC` are still where they belong and htslib would take this;
+    // `noodles_bgzf` requires FEXTRA alone, so fgumi cannot promise a decode.
+    #[case::fextra_with_fname(&bgzf_with(3, 0x0c), Some(HeaderRejection::Flags { got: 0x0c }))]
+    // `BC` first but a second subfield trailing it. RFC 1952 permits this; no
+    // decoder in the pipeline reads it.
+    #[case::trailing_subfield(&bgzf_with(10, 0x0a), Some(HeaderRejection::ExtraFieldLength { got: 10 }))]
+    #[case::foreign_subfield(&bgzf_with(12, b'X'), Some(HeaderRejection::SubfieldId { got: [b'X', b'C'] }))]
+    #[case::wrong_subfield_len(&bgzf_with(14, 0x04), Some(HeaderRejection::SubfieldLength { got: 4 }))]
+    fn validates(#[case] prefix: &[u8], #[case] expected: Option<HeaderRejection>) {
+        assert_eq!(validate(prefix).err(), expected);
+        assert_eq!(is_bgzf_header(prefix), expected.is_none());
+    }
+
+    /// Every rejection renders a message naming both the field that failed and the
+    /// value it saw.
+    ///
+    /// One case per variant rather than a spot check: the whole point of carrying
+    /// the rejection is that the message names the *specific* field, so a variant
+    /// whose `Display` arm was never rendered is one whose message could be wrong
+    /// -- or, in `SubfieldId`'s case, could render bytes that are not printable
+    /// characters -- without any test noticing.
+    #[rstest]
+    #[case::too_short(HeaderRejection::TooShort { len: 17 }, "truncated", "17")]
+    #[case::magic(HeaderRejection::Magic { got: [b'@', b'H'] }, "magic", "0x40")]
+    #[case::compression_method(
+        HeaderRejection::CompressionMethod { got: 0x00 },
+        "compression method",
+        "0x00"
+    )]
+    #[case::flags(HeaderRejection::Flags { got: 0x0c }, "FEXTRA", "0x0c")]
+    #[case::extra_field_length(
+        HeaderRejection::ExtraFieldLength { got: 10 },
+        "extra-field length",
+        "10"
+    )]
+    #[case::subfield_id(HeaderRejection::SubfieldId { got: [b'X', b'C'] }, "subfield ID", "XC")]
+    #[case::subfield_length(HeaderRejection::SubfieldLength { got: 4 }, "subfield length", "4")]
+    fn rejections_render(
+        #[case] rejection: HeaderRejection,
+        #[case] names_field: &str,
+        #[case] names_value: &str,
+    ) {
+        let rendered = rejection.to_string();
+        assert!(
+            rendered.contains(names_field),
+            "message must name the failing field {names_field:?}, got: {rendered}"
+        );
+        assert!(
+            rendered.contains(names_value),
+            "message must name the observed value {names_value:?}, got: {rendered}"
+        );
+    }
+
+    #[rstest]
+    // BSIZE is total size minus one: 0x1b == 27 means a 28-byte block.
+    #[case::eof_block(&BGZF, Some(28))]
+    #[case::too_short(&BGZF[..10], None)]
+    fn reads_block_size(#[case] block: &[u8], #[case] expected: Option<usize>) {
+        assert_eq!(block_size(block), expected);
+    }
+
+    /// The EOF marker the crate writes must satisfy the predicate it reads with.
+    #[test]
+    fn eof_marker_is_a_valid_header() {
+        assert_eq!(validate(&crate::BGZF_EOF), Ok(()));
+        assert_eq!(block_size(&crate::BGZF_EOF), Some(crate::BGZF_EOF.len()));
+    }
+}

--- a/crates/fgumi-bgzf/src/lib.rs
+++ b/crates/fgumi-bgzf/src/lib.rs
@@ -3,15 +3,21 @@
 //! BGZF (Blocked GZIP Format) reading and writing utilities.
 //!
 //! This crate provides low-level BGZF block I/O:
+//! - [`header`] - The block-header layout every fgumi reader agrees on
 //! - [`reader`] - Raw block reading and decompression using libdeflater
 //! - [`writer`] - Inline BGZF compression using the `bgzf` crate
 
+pub mod header;
 pub mod reader;
 pub mod writer;
 
 // Re-export commonly used types
+pub use header::{
+    BGZF_HEADER_SIZE, HeaderRejection, MIN_BLOCK_SIZE, block_size, block_size_checked,
+    is_bgzf_header,
+};
 pub use reader::{
-    BGZF_EOF, BGZF_FOOTER_SIZE, BGZF_HEADER_SIZE, RawBgzfBlock, decompress_block,
-    decompress_block_into, decompress_block_slice_into, read_raw_blocks,
+    BGZF_EOF, BGZF_FOOTER_SIZE, RawBgzfBlock, decompress_block, decompress_block_into,
+    decompress_block_slice_into, read_raw_blocks,
 };
 pub use writer::{BGZF_MAX_BLOCK_SIZE, CompressedBlock, InlineBgzfCompressor};

--- a/crates/fgumi-bgzf/src/reader.rs
+++ b/crates/fgumi-bgzf/src/reader.rs
@@ -39,7 +39,10 @@ use std::io::{self, Read};
 // ============================================================================
 
 /// Size of the BGZF block header.
-pub const BGZF_HEADER_SIZE: usize = 18;
+///
+/// Re-exported from [`crate::header`], which owns the layout this reader frames
+/// blocks with, so the constant and the field offsets cannot drift apart.
+pub use crate::header::BGZF_HEADER_SIZE;
 
 /// Size of the BGZF block footer (CRC32 + ISIZE).
 pub const BGZF_FOOTER_SIZE: usize = 8;
@@ -173,53 +176,34 @@ fn read_raw_block<R: Read + ?Sized>(reader: &mut R) -> io::Result<Option<RawBgzf
     }
     reader.read_exact(&mut header[1..])?;
 
-    // Validate gzip magic bytes
-    if header[0] != 0x1f || header[1] != 0x8b {
+    // One predicate for every reader, so a header this accepts is one the input
+    // classifier and `noodles_bgzf` accept too. This is stricter than the checks
+    // that used to live here, which took `FLG & FEXTRA` and never looked at XLEN
+    // or SLEN at all. A `BC`-first header with a trailing subfield (XLEN 10) was
+    // framed happily — `BSIZE` is still at 16-17 in that layout — and the four
+    // extra bytes then rode into the payload, which every consumer takes as
+    // `[18 .. len - 8]`. The failure surfaced downstream as `BGZF stored block
+    // size mismatch: LEN=89, payload=16`, a message about stored-block internals
+    // that says nothing about the header being the problem.
+    // The rejection is carried, not stringified: `HeaderRejection` is an
+    // `std::error::Error`, so passing it whole keeps it reachable through
+    // `source()` / `downcast_ref` for a caller that wants the failing field
+    // programmatically. `io::Error`'s `Display` delegates to it, so the rendered
+    // message is unchanged.
+    crate::header::validate(&header)
+        .map_err(|rejection| io::Error::new(io::ErrorKind::InvalidData, rejection))?;
+
+    // BSIZE is the total block size minus one, and must be big enough to describe
+    // a header plus a footer — see `block_size_checked`, which is the one
+    // definition of that floor.
+    let Some(block_size) = crate::header::block_size_checked(&header) else {
+        let stored = crate::header::block_size(&header)
+            .expect("a validated header is long enough to carry BSIZE");
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
-            format!(
-                "Invalid BGZF magic: expected 0x1f 0x8b, got 0x{:02x} 0x{:02x}",
-                header[0], header[1]
-            ),
+            format!("BGZF block too small: {stored} bytes"),
         ));
-    }
-
-    // Validate compression method (deflate)
-    if header[2] != 0x08 {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("Invalid compression method: expected 0x08, got 0x{:02x}", header[2]),
-        ));
-    }
-
-    // Validate FEXTRA flag
-    if header[3] & 0x04 == 0 {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "BGZF block missing FEXTRA flag"));
-    }
-
-    // Validate BC subfield identifier
-    if header[12] != b'B' || header[13] != b'C' {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!(
-                "Invalid BGZF subfield ID: expected 'BC', got '{}{}'",
-                header[12] as char, header[13] as char
-            ),
-        ));
-    }
-
-    // Get block size from BSIZE field (bytes 16-17, little-endian)
-    // BSIZE = total_block_size - 1
-    // BSIZE is u16, so block_size fits in usize on all platforms
-    let bsize = usize::from(u16::from_le_bytes([header[16], header[17]]));
-    let block_size = bsize + 1;
-
-    if block_size < BGZF_HEADER_SIZE + BGZF_FOOTER_SIZE {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("BGZF block too small: {block_size} bytes"),
-        ));
-    }
+    };
 
     // Reserve exactly what the block needs and fill it, rather than
     // `vec![0u8; block_size]`, which memsets up to 64 KiB that is immediately
@@ -631,6 +615,33 @@ mod tests {
         let mut bytes = Vec::new();
         compressor.write_blocks_to(&mut bytes).expect("emit block bytes");
         bytes
+    }
+
+    /// A `BC`-first header with a trailing extra subfield must be rejected at the
+    /// header, not carried into the payload.
+    ///
+    /// RFC 1952 permits the second subfield, and `BSIZE` is still at bytes 16-17,
+    /// so the block used to *frame* correctly — the four extra bytes then rode
+    /// into the deflate payload, which this reader takes as `[18 .. len - 8]`,
+    /// and the run died downstream on `BGZF stored block size mismatch`, a
+    /// message about stored-block internals that named nothing about the header.
+    #[test]
+    fn test_read_raw_block_rejects_a_trailing_extra_subfield() {
+        let full = single_block_bytes(b"the quick brown fox");
+        let mut block = full[..10].to_vec(); // magic, CM, FLG, MTIME, XFL, OS
+        block.extend_from_slice(&10u16.to_le_bytes()); // XLEN = 10, was 6
+        block.extend_from_slice(&full[12..18]); // BC, SLEN, BSIZE — still first
+        block.extend_from_slice(b"XY"); // a foreign subfield behind `BC`
+        block.extend_from_slice(&0u16.to_le_bytes()); // ...of zero length
+        block.extend_from_slice(&full[18..]); // payload and footer
+
+        let err = read_raw_block(&mut Cursor::new(block))
+            .expect_err("a header whose extra field is not exactly `BC` must be rejected");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData, "unexpected kind: {err}");
+        assert!(
+            err.to_string().contains("extra-field length"),
+            "the error must name the offending field, got: {err}"
+        );
     }
 
     /// `read_raw_block` reserves capacity and fills with `read_to_end` rather

--- a/src/lib/commands/compare/bams.rs
+++ b/src/lib/commands/compare/bams.rs
@@ -30,9 +30,9 @@ use std::thread;
 use crate::commands::command::Command;
 use crate::commands::common::parse_bool;
 
+use super::engines::OpenedInput;
 use super::engines::content::ContentPredicate;
 use super::engines::header::require_compatible_headers;
-use super::engines::molecule_join::molecule_join_compare;
 use super::engines::positional::positional_compare;
 
 /// Comparison mode for BAM files
@@ -627,10 +627,16 @@ impl Command for CompareBams {
         // first — ahead of any mode/preset dispatch — means an incompatible pair always
         // hard-exits here instead of silently cascading into per-record diffs (content/
         // grouping) or a differently-worded engine-level error (`sort`).
-        let (_, h1) = create_raw_bam_reader(&self.bam1, 1)?;
-        let (_, h2) = create_raw_bam_reader(&self.bam2, 1)?;
-        let declared_order =
-            require_compatible_headers(&h1, &h2).context("input BAM headers are incompatible")?;
+        //
+        // Each input is opened *once*, for both its header and its records: the
+        // single-pass engines below take the streams this reads from rather than
+        // reopening the paths, so `--command sort` and `--command group` accept an
+        // input that can only be opened once (a FIFO, a process substitution). See
+        // `engines::OpenedInput`.
+        let input1 = OpenedInput::open(&self.bam1)?;
+        let input2 = OpenedInput::open(&self.bam2)?;
+        let declared_order = require_compatible_headers(&input1.header, &input2.header)
+            .context("input BAM headers are incompatible")?;
 
         // `sort` has no notion of `CompareMode`/`ContentPredicate` — it verifies sort
         // order and compares by sort-key run instead of pairing records positionally or
@@ -651,7 +657,7 @@ impl Command for CompareBams {
                 );
             }
             let timer = (!self.quiet).then(|| OperationTimer::new("Comparing BAMs"));
-            let total_records = self.execute_sort_verify()?;
+            let total_records = self.execute_sort_verify(input1, input2)?;
             if let Some(timer) = timer {
                 timer.log_completion(total_records);
             }
@@ -737,8 +743,16 @@ impl Command for CompareBams {
         };
 
         let total_records = match mode {
-            CompareMode::Content => self.execute_content(predicate)?,
-            CompareMode::Grouping => self.execute_grouping()?,
+            // Content mode makes two passes over each input — the order verification
+            // already done above and then the record comparison itself — so it cannot
+            // stream a one-shot input and reopens by path. Releasing the streams here
+            // keeps it from holding a pipe open for a read it will never make.
+            CompareMode::Content => {
+                drop(input1);
+                drop(input2);
+                self.execute_content(predicate)?
+            }
+            CompareMode::Grouping => self.execute_grouping(input1, input2)?,
         };
 
         if let Some(timer) = timer {
@@ -852,14 +866,15 @@ impl CompareBams {
     /// [`CommandPreset::Sort`]'s). Preserves the same external report contract as
     /// `execute_content`: the `RESULT: BAM files are IDENTICAL` / `RESULT: BAM files
     /// DIFFER` line and exit-1-on-mismatch behavior via [`super::CompareMismatch`].
-    fn execute_sort_verify(&self) -> Result<u64> {
+    fn execute_sort_verify(&self, input1: OpenedInput, input2: OpenedInput) -> Result<u64> {
         if !self.quiet {
             info!("Using --command sort preset: sort-key-run verification (no positional pairing)");
         }
 
-        let outcome = super::engines::sort_verify::sort_verify_compare(
-            &self.bam1,
-            &self.bam2,
+        // The streams `execute` already opened, not the paths — see `OpenedInput`.
+        let outcome = super::engines::sort_verify::sort_verify_compare_opened(
+            input1,
+            input2,
             self.max_diffs,
         )?;
 
@@ -932,7 +947,7 @@ impl CompareBams {
     /// Returns an error if either input cannot be read (see [`molecule_join_compare`]), or
     /// [`super::CompareMismatch`] if the two BAMs are found to differ (non-zero exit via the
     /// `Command` trait).
-    fn execute_grouping(&self) -> Result<u64> {
+    fn execute_grouping(&self, input1: OpenedInput, input2: OpenedInput) -> Result<u64> {
         if !self.quiet {
             info!(
                 "Starting streaming molecule-join grouping comparison (max-diffs {})",
@@ -940,7 +955,13 @@ impl CompareBams {
             );
         }
 
-        let outcome = molecule_join_compare(&self.bam1, &self.bam2, self.max_diffs)?;
+        // The streams `execute` already opened, not the paths — see `OpenedInput`.
+        let outcome = super::engines::molecule_join::molecule_join_compare_capped_opened(
+            input1,
+            input2,
+            self.max_diffs,
+            super::engines::molecule_join::MAX_PENDING_MOLECULES,
+        )?;
         let is_equivalent = outcome.is_match();
 
         if !self.quiet {

--- a/src/lib/commands/compare/engines/mod.rs
+++ b/src/lib/commands/compare/engines/mod.rs
@@ -19,6 +19,56 @@ pub(crate) mod molecule_join;
 pub mod positional;
 pub mod sort_verify;
 
+use std::path::{Path, PathBuf};
+
+use fgumi_sort::OwnedRawBamRecordReader;
+use noodles::sam::Header;
+
+/// One input, opened exactly once: its header and its records from the same stream.
+///
+/// Passed to the single-pass engines instead of a path so the caller's open is the
+/// only one. `CompareBams::execute` must read both headers before dispatching — an
+/// incompatible pair has to hard-exit ahead of any engine — and if the engine then
+/// opened the path again for its records, the command as a whole would require a
+/// re-openable input even though each half of it reads the stream once. A FIFO, a
+/// process substitution and stdin are all opened once and never again, so that
+/// second open is the difference between accepting them and not.
+///
+/// `path` is carried only to name the input in diagnostics; nothing reopens it.
+pub(crate) struct OpenedInput {
+    /// Records, positioned just past the header.
+    pub(crate) reader: OwnedRawBamRecordReader,
+    /// The header parsed off the front of `reader`'s stream.
+    pub(crate) header: Header,
+    /// What to call this input in messages.
+    pub(crate) path: PathBuf,
+}
+
+impl OpenedInput {
+    /// Open `path` once, taking its header and its records from one stream.
+    ///
+    /// [`fgumi_sort::open_raw_bam_record_reader_with_header`] parses the header
+    /// through a tee and replays the bytes it consumed, which is what lets one
+    /// stream serve both halves. Uncompressed SAM is sniffed and normalized there
+    /// too, so callers only ever see BAM records.
+    ///
+    /// This is the only opener the compare engines use — a second, private copy in
+    /// each engine is how the two came to disagree about how many opens an input
+    /// takes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the input cannot be opened, is neither BAM nor SAM, or
+    /// its header cannot be parsed.
+    pub(crate) fn open(path: &Path) -> anyhow::Result<Self> {
+        use anyhow::Context as _;
+
+        let (reader, header) = fgumi_sort::open_raw_bam_record_reader_with_header(path)
+            .with_context(|| format!("opening raw BAM reader for {}", path.display()))?;
+        Ok(Self { reader, header, path: path.to_path_buf() })
+    }
+}
+
 /// Append `msg()` to `details` unless it is already at the `max_diffs` cap — lazily, so
 /// callers only pay for building the message string when it will actually be kept.
 ///

--- a/src/lib/commands/compare/engines/molecule_join.rs
+++ b/src/lib/commands/compare/engines/molecule_join.rs
@@ -12,14 +12,14 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use ahash::AHashMap;
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use fgumi_raw_bam::RawRecord;
-use fgumi_sort::OwnedRawBamRecordReader;
 use noodles::sam::Header;
 
 use super::super::bams::{MiKey, get_mi_tag_raw};
 use super::super::molecule::{MoleculeRun, molecule_runs};
 use super::super::record_key::{RecordKey, record_key};
+use super::OpenedInput;
 use super::content::{ContentPredicate, content_diffs};
 use super::header::require_compatible_headers;
 use super::push_diff;
@@ -262,26 +262,6 @@ impl MoleculeJoinOutcome {
     }
 }
 
-/// Open `path` once, returning its parsed header and a raw-byte record reader
-/// positioned just past that header.
-///
-/// One open per input rather than two. This engine needs the header (to compare
-/// the two inputs' headers for compatibility) *and* the records, and taking them
-/// from separate opens meant the input had to be re-openable — which a FIFO, a
-/// process substitution and stdin are not.
-/// [`fgumi_sort::open_raw_bam_record_reader_with_header`] parses the header
-/// through a tee and replays the bytes it consumed, so one stream serves both.
-/// Uncompressed SAM is sniffed and normalized there too.
-///
-/// This makes the *engine* single-open, which is what its own entry points
-/// promise; the `compare bams` CLI still opens both inputs once more up front for
-/// its header-compatibility precondition — see
-/// [`open_raw_reader_with_header`](super::sort_verify) for the full note.
-fn open_raw_with_header(path: &Path) -> Result<(OwnedRawBamRecordReader, Header)> {
-    fgumi_sort::open_raw_bam_record_reader_with_header(path)
-        .with_context(|| format!("opening raw BAM reader for {}", path.display()))
-}
-
 /// Fold one matched pair (already known bam1-run/bam2-run in that order) into `matched`/
 /// `diff_details` via [`compare_molecule`]. Shared by both sides of [`molecule_join_compare`]'s
 /// hash-join loop so the "compare, then either count as matched or record diffs" step isn't
@@ -387,10 +367,34 @@ pub(crate) fn molecule_join_compare_capped(
     max_diffs: usize,
     max_pending: usize,
 ) -> Result<MoleculeJoinOutcome> {
-    // One open per input; the readers below stream the same streams these headers
-    // were parsed from — see `open_raw_with_header`.
-    let (reader1, h1) = open_raw_with_header(bam1)?;
-    let (reader2, h2) = open_raw_with_header(bam2)?;
+    // One open per input: `OpenedInput::open` mints the stream and parses its
+    // header off the front, and the capped variant below reads its records from
+    // that same stream rather than reopening the path.
+    molecule_join_compare_capped_opened(
+        OpenedInput::open(bam1)?,
+        OpenedInput::open(bam2)?,
+        max_diffs,
+        max_pending,
+    )
+}
+
+/// [`molecule_join_compare_capped`] over inputs the caller already opened.
+///
+/// See [`OpenedInput`]: `CompareBams::execute` reads both headers before it can
+/// dispatch, so taking the streams from it rather than reopening the paths is what
+/// lets `compare bams --command group` take a FIFO or a process substitution.
+///
+/// # Errors
+///
+/// As [`molecule_join_compare_capped`], minus the opens the caller already made.
+pub(crate) fn molecule_join_compare_capped_opened(
+    input1: OpenedInput,
+    input2: OpenedInput,
+    max_diffs: usize,
+    max_pending: usize,
+) -> Result<MoleculeJoinOutcome> {
+    let OpenedInput { reader: reader1, header: h1, path: _ } = input1;
+    let OpenedInput { reader: reader2, header: h2, path: _ } = input2;
     // Make this public API sound on its own, independent of the CLI's own (redundant but
     // cheap) call — see this function's doc comment.
     require_compatible_headers(&h1, &h2)?;

--- a/src/lib/commands/compare/engines/sort_verify.rs
+++ b/src/lib/commands/compare/engines/sort_verify.rs
@@ -55,6 +55,7 @@ use noodles::sam::Header;
 
 use ahash::AHashMap;
 
+use super::OpenedInput;
 use crate::sam::SamTag;
 
 use super::super::raw_compare::content_key_exact;
@@ -218,28 +219,6 @@ pub(crate) fn sort_order_from_header(header: &Header) -> Result<SortOrder> {
 /// Back-compat alias for existing internal callers.
 pub(crate) fn detect_sort_order(header: &Header) -> Result<SortOrder> {
     sort_order_from_header(header)
-}
-
-/// Open `path` once, returning its parsed header and a raw-byte record reader
-/// positioned just past that header.
-///
-/// One open per input rather than two. Every caller here needs both the header
-/// (to pick a key extractor) and the records, and taking them from separate opens
-/// meant the input had to be re-openable — which a FIFO, a process substitution
-/// and stdin are not. [`fgumi_sort::open_raw_bam_record_reader_with_header`]
-/// parses the header through a tee and replays the bytes it consumed, so one
-/// stream serves both. Uncompressed SAM is sniffed and normalized there too.
-///
-/// This makes the *engine* single-open, which is what its own entry points
-/// promise. The `compare bams` CLI is a separate question: it opens both inputs
-/// once more up front for its header-compatibility precondition, deliberately, so
-/// that an incompatible pair hard-exits before any engine runs
-/// (see [`CompareBams::execute`](super::super::bams::CompareBams)). A command line
-/// therefore still names re-openable inputs — `compare`'s declared contract, since
-/// it compares two named files against each other.
-fn open_raw_reader_with_header(path: &Path) -> Result<(OwnedRawBamRecordReader, Header)> {
-    fgumi_sort::open_raw_bam_record_reader_with_header(path)
-        .with_context(|| format!("opening raw BAM reader for {}", path.display()))
 }
 
 /// A record together with its extracted sort key, read one step ahead of the run
@@ -756,8 +735,7 @@ where
     SameCore: Fn(&K, &K) -> bool,
 {
     /// Record reader over the first input, already past its header. Carried rather
-    /// than the path so the input is opened exactly once — see
-    /// [`open_raw_reader_with_header`].
+    /// than the path so the input is opened exactly once — see [`OpenedInput`].
     reader1: OwnedRawBamRecordReader,
     /// Record reader over the second input, already past its header.
     reader2: OwnedRawBamRecordReader,
@@ -831,9 +809,29 @@ pub fn sort_verify_compare(
     max_diffs: usize,
 ) -> Result<SortVerifyOutcome> {
     // One open per input, which is what the record readers below then stream —
-    // see `open_raw_reader_with_header`.
-    let (reader1, header1) = open_raw_reader_with_header(bam1)?;
-    let (reader2, header2) = open_raw_reader_with_header(bam2)?;
+    // see `OpenedInput::open`.
+    sort_verify_compare_opened(OpenedInput::open(bam1)?, OpenedInput::open(bam2)?, max_diffs)
+}
+
+/// [`sort_verify_compare`] over inputs the caller already opened.
+///
+/// The entry point for `CompareBams::execute`, which has to read both headers to
+/// check them for compatibility before dispatching here, and would otherwise have
+/// to reopen both paths for their records — see [`OpenedInput`]. Handing the
+/// streams over instead is what lets `compare bams --command sort` take a FIFO or
+/// a process substitution.
+///
+/// # Errors
+///
+/// As [`sort_verify_compare`], minus the opens the caller already made.
+pub(crate) fn sort_verify_compare_opened(
+    input1: OpenedInput,
+    input2: OpenedInput,
+    max_diffs: usize,
+) -> Result<SortVerifyOutcome> {
+    let OpenedInput { reader: reader1, header: header1, path: bam1 } = input1;
+    let OpenedInput { reader: reader2, header: header2, path: bam2 } = input2;
+    let (bam1, bam2) = (bam1.as_path(), bam2.as_path());
 
     let order1 = detect_sort_order(&header1)
         .map_err(|e| anyhow!("detecting sort order from {}: {e}", bam1.display()))?;
@@ -944,9 +942,10 @@ pub fn sort_verify_compare(
 /// Returns an error if `path` cannot be opened/read, or if any record violates `order`
 /// (naming the first violating record's 1-based position and read name).
 pub(crate) fn verify_records_in_order(path: &Path, order: SortOrder) -> Result<()> {
-    // One open, header and records from the same stream — see
-    // `open_raw_reader_with_header`.
-    let (reader, header) = open_raw_reader_with_header(path)
+    // One open, header and records from the same stream — see `OpenedInput::open`.
+    // The `path` field goes unused here: this entry point takes a single input and
+    // already has it, so there is nothing to disambiguate in its diagnostics.
+    let OpenedInput { reader, header, path: _ } = OpenedInput::open(path)
         .with_context(|| format!("opening {} to verify sort order", path.display()))?;
 
     // IMPORTANT: The per-SortOrder extractor/comparator selection below must stay

--- a/src/lib/unified_pipeline/fastq.rs
+++ b/src/lib/unified_pipeline/fastq.rs
@@ -37,6 +37,7 @@ use crate::fastq_parse::FastqRecord;
 use crate::grouper::FastqTemplate;
 use fgumi_bam_io::ProgressTracker;
 use fgumi_bam_io::ReorderBuffer;
+use fgumi_bgzf::{block_size as bgzf_block_size, block_size_checked as bgzf_block_size_checked};
 use libdeflater::Decompressor;
 
 use super::base::{
@@ -1039,8 +1040,12 @@ fn estimate_uncompressed_size(raw_data: &[u8]) -> usize {
     let mut offset = 0;
 
     while offset + BGZF_HEADER_SIZE + BGZF_FOOTER_SIZE <= raw_data.len() {
-        let bsize = u16::from_le_bytes([raw_data[offset + 16], raw_data[offset + 17]]) as usize;
-        let block_size = bsize + 1;
+        // Shared with the block reader so both the BSIZE offset and the minimum
+        // block size have one definition. The checked form matters here: a
+        // malformed BSIZE below the floor would underflow `offset + block_size - 4`
+        // and then index far out of bounds. This is only a capacity estimate, so
+        // stop summing and let `decompress_bgzf_chunk` report the malformed block.
+        let Some(block_size) = bgzf_block_size_checked(&raw_data[offset..]) else { break };
 
         if offset + block_size > raw_data.len() {
             break;
@@ -1078,9 +1083,26 @@ fn decompress_bgzf_chunk(raw_data: &[u8], decompressor: &mut Decompressor) -> io
             break; // Incomplete block at end
         }
 
-        // Parse BSIZE from header (bytes 16-17, little-endian)
-        let bsize = u16::from_le_bytes([raw_data[offset + 16], raw_data[offset + 17]]) as usize;
-        let block_size = bsize + 1;
+        // Parse the block's total size, via the same helper the block reader
+        // frames with. The header's *fields* were validated when the stream was
+        // classified and, for a streamed input, again per block by
+        // `read_raw_blocks`; re-checking them here would cost a branch per block
+        // to learn nothing new.
+        // The loop guard above already proved there are at least `BGZF_HEADER_SIZE`
+        // bytes left, so `None` here means the stored BSIZE is below the floor, not
+        // that the slice is short. Such a block holds no deflate payload at all and
+        // `decompress_block_slice_into` would no-op on it — silently dropping data
+        // instead of reporting corruption. This is the real decode, so error.
+        let Some(block_size) = bgzf_block_size_checked(&raw_data[offset..]) else {
+            let stored = bgzf_block_size(&raw_data[offset..]).unwrap_or(0);
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "BGZF block too small: offset={offset}, block_size={stored}, minimum={}",
+                    fgumi_bgzf::MIN_BLOCK_SIZE
+                ),
+            ));
+        };
 
         // Validate block size
         if offset + block_size > raw_data.len() {
@@ -5566,6 +5588,47 @@ mod tests {
         assert!(
             bp.memory_drained,
             "memory_drained should be true after draining below low-water mark"
+        );
+    }
+
+    /// A BGZF header whose `BSIZE` is smaller than a header plus a footer must not
+    /// be trusted as a block length.
+    ///
+    /// `fgumi_bgzf::block_size` documents that it reads `BSIZE` without validating
+    /// it — the floor is the caller's job, which is why
+    /// `fgumi_bgzf::reader::read_raw_block` checks it explicitly. Both loops here
+    /// take the same unvalidated value, so a corrupt or malformed block claiming
+    /// `BSIZE = 0` (a 1-byte block) used to make `estimate_uncompressed_size`
+    /// compute `offset + 1 - 4`, which underflows `usize` and then indexes far out
+    /// of bounds — a crash driven purely by input bytes, on a streaming path.
+    ///
+    /// `estimate_uncompressed_size` only estimates a capacity and has no error
+    /// channel, so it stops summing; `decompress_bgzf_chunk` is the real decode and
+    /// must reject the block rather than silently skipping it.
+    #[test]
+    fn test_undersized_bgzf_block_size_is_rejected_not_trusted() {
+        // A structurally valid BGZF header (so `block_size` returns `Some`) whose
+        // BSIZE field says 0, i.e. a total block size of one byte.
+        let mut raw = vec![
+            0x1f, 0x8b, 0x08, 0x04, 0, 0, 0, 0, 0, 0xff, 0x06, 0x00, b'B', b'C', 0x02, 0x00,
+            /* BSIZE = 0 -> block_size = 1 */ 0x00, 0x00,
+        ];
+        // Pad past `BGZF_HEADER_SIZE + BGZF_FOOTER_SIZE` so both loops enter.
+        raw.extend_from_slice(&[0u8; 16]);
+
+        assert_eq!(
+            estimate_uncompressed_size(&raw),
+            0,
+            "an undersized BSIZE must stop the estimate, not underflow the ISIZE offset"
+        );
+
+        let mut decompressor = Decompressor::new();
+        let err = decompress_bgzf_chunk(&raw, &mut decompressor)
+            .expect_err("an undersized BSIZE must be rejected, not skipped");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("too small"),
+            "the error must name the undersized block, got: {err}"
         );
     }
 }

--- a/tests/integration/test_compare_bams.rs
+++ b/tests/integration/test_compare_bams.rs
@@ -265,7 +265,10 @@ fn test_grouping_mode_identical_bams() {
 
     let (code, stdout, _stderr) = run_compare(&bam1, &bam2, "grouping", &[]);
     assert_eq!(code, Some(0), "Expected success for identical grouped BAMs, stdout:\n{stdout}");
-    assert!(stdout.contains("EQUIVALENT"), "Expected EQUIVALENT in output, got:\n{stdout}");
+    assert!(
+        stdout.contains("RESULT: BAM groupings are EQUIVALENT"),
+        "expected 'RESULT: BAM groupings are EQUIVALENT' in output, got:\n{stdout}"
+    );
 }
 
 #[test]
@@ -368,7 +371,10 @@ fn test_content_mode_reordered_tags_equivalent() {
         Some(0),
         "Expected success for reordered tags in content mode, stdout:\n{stdout}"
     );
-    assert!(stdout.contains("IDENTICAL"), "Expected IDENTICAL in output, got:\n{stdout}");
+    assert!(
+        stdout.contains("RESULT: BAM files are IDENTICAL"),
+        "expected 'RESULT: BAM files are IDENTICAL' in output, got:\n{stdout}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -443,7 +449,10 @@ fn test_grouping_mode_ignore_order() {
 
     let (code, stdout, _stderr) = run_compare(&bam1, &bam2, "grouping", &["--ignore-order"]);
     assert_eq!(code, Some(0), "Expected success for ignore-order grouping mode, stdout:\n{stdout}");
-    assert!(stdout.contains("EQUIVALENT"), "Expected EQUIVALENT in output, got:\n{stdout}");
+    assert!(
+        stdout.contains("RESULT: BAM groupings are EQUIVALENT"),
+        "expected 'RESULT: BAM groupings are EQUIVALENT' in output, got:\n{stdout}"
+    );
 }
 
 /// Runs `CompareBams::execute()` in-process under `--mode grouping` (plus any `extra_args`,
@@ -754,7 +763,10 @@ fn test_grouping_mode_paired_strand_suffix_equivalent() {
         Some(0),
         "Expected EQUIVALENT for identical paired-strand BAMs, stdout:\n{stdout}"
     );
-    assert!(stdout.contains("EQUIVALENT"), "Expected EQUIVALENT, got:\n{stdout}");
+    assert!(
+        stdout.contains("RESULT: BAM groupings are EQUIVALENT"),
+        "expected 'RESULT: BAM groupings are EQUIVALENT' in output, got:\n{stdout}"
+    );
     // Note: unlike the retired key-join engine, this molecule-join engine has no
     // "missing MI" counter to assert against directly. Regression coverage for MI:Z:0/A
     // and 0/B being parsed as present (not missing) lives primarily in
@@ -785,7 +797,10 @@ fn test_grouping_unordered_paired_strand_suffix_equivalent() {
         Some(0),
         "Expected EQUIVALENT for ignore-order paired-strand BAMs, stdout:\n{stdout}"
     );
-    assert!(stdout.contains("EQUIVALENT"), "Expected EQUIVALENT, got:\n{stdout}");
+    assert!(
+        stdout.contains("RESULT: BAM groupings are EQUIVALENT"),
+        "expected 'RESULT: BAM groupings are EQUIVALENT' in output, got:\n{stdout}"
+    );
 }
 
 #[test]
@@ -1411,7 +1426,10 @@ fn test_command_group_content_identical_mi_renumbered_and_reordered_matches() {
         "Expected EQUIVALENT for content-identical, MI-renumbered, reordered BAMs via \
          `--command group`, stdout:\n{stdout}"
     );
-    assert!(stdout.contains("EQUIVALENT"), "Expected EQUIVALENT in output, got:\n{stdout}");
+    assert!(
+        stdout.contains("RESULT: BAM groupings are EQUIVALENT"),
+        "expected 'RESULT: BAM groupings are EQUIVALENT' in output, got:\n{stdout}"
+    );
 }
 
 /// Regression: an explicit `--mode content` overrides a preset's own predicate. Under
@@ -2002,7 +2020,10 @@ fn test_command_sort_identical_bams_match() {
         Some(0),
         "identical sorted BAMs must be IDENTICAL (exit 0) via --command sort:\n{stdout}"
     );
-    assert!(stdout.contains("IDENTICAL"), "expected IDENTICAL in output, got:\n{stdout}");
+    assert!(
+        stdout.contains("RESULT: BAM files are IDENTICAL"),
+        "expected 'RESULT: BAM files are IDENTICAL' in output, got:\n{stdout}"
+    );
 }
 
 /// End-to-end smoke test: `--command sort` reports DIFFER (and exits non-zero) when
@@ -2854,11 +2875,14 @@ fn test_sort_verify_reads_a_non_reopenable_input() {
     let bam = tmp.path().join("a.bam");
     write_bam(&bam, &header, &records);
 
-    let (fifo, feeder) = serve_over_fifo(tmp.path(), "a.fifo", &bam);
-    let oracle = bam.clone();
-    let outcome = bounded(move || sort_verify_compare(&fifo, &oracle, 100))
-        .expect("sort_verify_compare must accept an input it can only open once");
-    join_feeder(feeder);
+    // Both arguments are FIFOs: serving only the first would leave a regression that
+    // reopens just the second indistinguishable from a passing run.
+    let (fifo1, feeder1) = serve_over_fifo(tmp.path(), "a.fifo", &bam);
+    let (fifo2, feeder2) = serve_over_fifo(tmp.path(), "b.fifo", &bam);
+    let outcome = bounded(move || sort_verify_compare(&fifo1, &fifo2, 100))
+        .expect("sort_verify_compare must accept inputs it can only open once");
+    join_feeder(feeder1);
+    join_feeder(feeder2);
 
     assert!(outcome.is_match(), "the same data over a FIFO must match itself: {outcome:?}");
     assert_eq!(outcome.bam1_count, records.len() as u64, "every record must be read from the FIFO");
@@ -2879,14 +2903,141 @@ fn test_molecule_join_reads_a_non_reopenable_input() {
     let bam = tmp.path().join("a.bam");
     write_bam(&bam, &header, &records);
 
-    let (fifo, feeder) = serve_over_fifo(tmp.path(), "a.fifo", &bam);
-    let oracle = bam.clone();
-    let outcome = bounded(move || molecule_join_compare(&fifo, &oracle, 100))
-        .expect("molecule_join_compare must accept an input it can only open once");
-    join_feeder(feeder);
+    // Both arguments are FIFOs, for the reason given in
+    // [`test_sort_verify_reads_a_non_reopenable_input`].
+    let (fifo1, feeder1) = serve_over_fifo(tmp.path(), "a.fifo", &bam);
+    let (fifo2, feeder2) = serve_over_fifo(tmp.path(), "b.fifo", &bam);
+    let outcome = bounded(move || molecule_join_compare(&fifo1, &fifo2, 100))
+        .expect("molecule_join_compare must accept inputs it can only open once");
+    join_feeder(feeder1);
+    join_feeder(feeder2);
 
     assert!(outcome.is_match(), "the same data over a FIFO must match itself: {outcome:?}");
     assert_eq!(outcome.matched, 1, "the single molecule must be matched");
     assert_eq!(outcome.bam1_molecules, 1);
     assert_eq!(outcome.bam2_molecules, 1);
+}
+
+/// Waits for `child`, failing the test if it has not exited within a generous bound.
+///
+/// A second open of a FIFO **blocks** rather than erroring — there is no writer left
+/// to attach — so a command that regresses to two opens would hang this test
+/// indefinitely instead of failing it, and CI would report a timeout with no
+/// indication of which property broke. The child is killed so the run does not leak
+/// a blocked process.
+///
+/// Both pipes are drained on their own threads for the whole wait, rather than only
+/// after the child exits. `stdout` and `stderr` are both `piped()`, so a child whose
+/// combined output outgrows the OS pipe buffer (16 KiB on macOS, 64 KiB on Linux)
+/// would block in `write` before reaching `exit`, `try_wait` would never return
+/// `Some`, and the timeout would fire — blaming a second open that never happened.
+/// Today's output is far short of that, but the diagnostic must not be able to lie.
+#[cfg(unix)]
+fn wait_bounded(mut child: std::process::Child, label: &str) -> std::process::Output {
+    use std::io::Read;
+
+    let mut child_stdout = child.stdout.take().expect("stdout was piped");
+    let mut child_stderr = child.stderr.take().expect("stderr was piped");
+    let drain_stdout = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        child_stdout.read_to_end(&mut buf).expect("drain fgumi stdout");
+        buf
+    });
+    let drain_stderr = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        child_stderr.read_to_end(&mut buf).expect("drain fgumi stderr");
+        buf
+    });
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    loop {
+        match child.try_wait().expect("poll fgumi") {
+            Some(status) => {
+                return std::process::Output {
+                    status,
+                    stdout: drain_stdout.join().expect("stdout drain thread"),
+                    stderr: drain_stderr.join().expect("stderr drain thread"),
+                };
+            }
+            None if std::time::Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!(
+                    "compare bams --command {label} did not exit within 30s on a FIFO input; \
+                     the likely cause is a second open of the input, which blocks forever on a \
+                     FIFO because no writer is left to attach"
+                );
+            }
+            None => std::thread::sleep(std::time::Duration::from_millis(20)),
+        }
+    }
+}
+
+/// `compare bams` must accept inputs it can only open once, end to end.
+///
+/// The engine-level tests above pin the engines; this pins the *command*, which is
+/// where the second open used to live: `execute` read both headers for its
+/// compatibility precondition and the engine then reopened both paths for their
+/// records, so the CLI required a re-openable input even though each half read the
+/// stream once. Both single-pass presets are covered — `--command sort` and
+/// `--command group` — because they dispatch to different engines.
+///
+/// Content mode is deliberately absent: it makes two passes over each input (order
+/// verification, then the record comparison) and so cannot stream a FIFO at all.
+#[cfg(unix)]
+#[rstest]
+#[case::sort_preset("sort")]
+#[case::group_preset("group")]
+fn test_compare_bams_cli_reads_a_non_reopenable_input(#[case] preset: &str) {
+    let tmp = TempDir::new().unwrap();
+    // `create_minimal_header` advertises SO:unsorted GO:query SS:template-coordinate,
+    // which satisfies the sort-verify engine and the grouping engine alike.
+    let header = create_minimal_header("chr1", 10000);
+    let records = vec![mi_record(b"read1", 100, "1"), mi_record(b"read2", 200, "1")];
+
+    let bam = tmp.path().join("a.bam");
+    write_bam(&bam, &header, &records);
+
+    // Both arguments are FIFOs. Serving only the first would leave the second
+    // re-openable, so a regression that reopened just `bam2` — `execute` opens the two
+    // independently — would still pass.
+    let (fifo1, feeder1) = serve_over_fifo(tmp.path(), "a.fifo", &bam);
+    let (fifo2, feeder2) = serve_over_fifo(tmp.path(), "b.fifo", &bam);
+
+    let child = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args(["compare", "bams"])
+        .arg(&fifo1)
+        .arg(&fifo2)
+        .args(["--command", preset])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn fgumi");
+    let output = wait_bounded(child, preset);
+
+    // Assert before joining: a regression leaves a feeder blocked in its `open`
+    // forever, so joining first would hang rather than fail. See `serve_over_fifo`.
+    assert!(
+        output.status.success(),
+        "compare bams --command {preset} rejected FIFOs it accepts as regular files:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    join_feeder(feeder1);
+    join_feeder(feeder2);
+
+    // Each preset has its own result line — `execute_sort_verify` prints "BAM files
+    // are IDENTICAL", `execute_grouping` prints "BAM groupings are EQUIVALENT". Accepting
+    // either would let a dispatch regression that ran the wrong engine for the preset
+    // still pass, so pin the one this preset must print.
+    let expected_result_line = match preset {
+        "sort" => "RESULT: BAM files are IDENTICAL",
+        "group" => "RESULT: BAM groupings are EQUIVALENT",
+        other => panic!("unexpected preset {other}: add its RESULT line to this match"),
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(expected_result_line),
+        "the same data over a FIFO must compare equal to itself: --command {preset} must print \
+         {expected_result_line:?}, got:\n{stdout}"
+    );
 }

--- a/tests/integration/test_sam_input.rs
+++ b/tests/integration/test_sam_input.rs
@@ -536,3 +536,157 @@ fn a_stream_header_fault_names_the_mapped_input() {
         "a header fault on the mapped stream must name it, got: {stderr}"
     );
 }
+
+// ============================================================================
+// Plain gzip, accepted at the normalization boundary
+// ============================================================================
+
+/// gzip-compresses `source` into `dest`.
+fn gzip_file(source: &Path, dest: &Path) {
+    use std::io::Write as _;
+
+    let bytes = std::fs::read(source).expect("read gzip source");
+    let mut encoder = flate2::write::GzEncoder::new(
+        File::create(dest).expect("create gzip output"),
+        flate2::Compression::fast(),
+    );
+    encoder.write_all(&bytes).expect("gzip the input");
+    encoder.finish().expect("finish gzip stream");
+}
+
+/// Rewrites every BGZF block in `source` to carry a second extra subfield.
+///
+/// `BC` stays first and `BSIZE` stays correct, so the result is a spec-legal BGZF
+/// file per RFC 1952 — and one that no fgumi decoder can frame, because they all
+/// require `XLEN` to be exactly 6 (as do htslib and noodles). It is still a valid
+/// gzip member, which is the whole point: the boundary decompresses it with a
+/// spec-complete gzip reader and re-frames what comes out.
+fn add_trailing_extra_subfield(source: &Path, dest: &Path) {
+    let data = std::fs::read(source).expect("read BGZF source");
+    let mut out = Vec::with_capacity(data.len());
+    let mut offset = 0;
+
+    while offset < data.len() {
+        let bsize = u16::from_le_bytes([data[offset + 16], data[offset + 17]]) as usize;
+        let total = bsize + 1;
+        let new_total = total + 4; // the foreign subfield's four bytes
+
+        out.extend_from_slice(&data[offset..offset + 10]); // magic, CM, FLG, MTIME, XFL, OS
+        out.extend_from_slice(&10u16.to_le_bytes()); // XLEN: 6 -> 10
+        out.extend_from_slice(&data[offset + 12..offset + 16]); // BC, SLEN
+        out.extend_from_slice(&u16::try_from(new_total - 1).expect("BSIZE fits").to_le_bytes());
+        out.extend_from_slice(b"XY"); // the foreign subfield, behind `BC`
+        out.extend_from_slice(&0u16.to_le_bytes()); // ...of zero length
+        out.extend_from_slice(&data[offset + 18..offset + total]); // payload and footer
+
+        offset += total;
+    }
+
+    std::fs::write(dest, out).expect("write reframed BGZF");
+}
+
+/// gzip is accepted at the boundary, whatever it turns out to be wrapping.
+///
+/// fgumi reads BGZF so it can decompress blocks in parallel, and plain gzip gives
+/// that up — but rejecting it outright made `fgumi` the only tool in the pipeline
+/// that could not read a file `gzip` produced. It is now decompressed at the
+/// boundary and re-classified, so the rest of the pipeline still sees only BGZF.
+///
+/// Each case must produce exactly what the equivalent BAM input produces; matching
+/// exit status alone would not catch a transcode that dropped records.
+#[rstest]
+// `gzip -c reads.sam`: text inside, so it takes the SAM transcode.
+#[case::gzipped_sam(false, false)]
+// `gzip -c reads.bam`: BGZF inside, which needs no transcode at all.
+#[case::gzipped_bam(true, false)]
+// A BGZF file carrying a second extra subfield. Spec-legal, unframeable by every
+// decoder in the pipeline, and a plain gzip member — so it arrives here.
+#[case::bgzf_with_a_trailing_subfield(true, true)]
+fn gzip_input_is_accepted_and_matches_bam(#[case] from_bam: bool, #[case] reframe: bool) {
+    let dir = TempDir::new().expect("create temp dir");
+    let (bam_input, sam_input) = write_input_pair(dir.path());
+    let args = &["sort", "-i", "{input}", "-o", "{output}", "--order", "queryname"];
+
+    let gzipped = dir.path().join("input.gz");
+    if reframe {
+        add_trailing_extra_subfield(&bam_input, &gzipped);
+    } else {
+        gzip_file(if from_bam { &bam_input } else { &sam_input }, &gzipped);
+    }
+
+    let gzip_output = dir.path().join("from_gzip.bam");
+    let result = run(args, &gzipped, &gzip_output);
+    assert!(
+        result.status.success(),
+        "gzip input rejected: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    // Succeeding is not enough: the records have to survive the round trip.
+    let bam_output = dir.path().join("from_bam.bam");
+    let baseline = run(args, &bam_input, &bam_output);
+    assert!(baseline.status.success(), "BAM input failed, so the gzip result proves nothing");
+    assert_eq!(
+        read_output(&gzip_output),
+        read_output(&bam_output),
+        "gzip input produced different records than the same data as BGZF",
+    );
+}
+
+/// Two gzip layers are named rather than peeled.
+///
+/// Unwrapping until something recognisable appears would let a small crafted input
+/// cost unbounded work for one open, so the boundary decompresses exactly once and
+/// says what it found.
+#[test]
+fn doubly_gzipped_input_is_rejected() {
+    let dir = TempDir::new().expect("create temp dir");
+    let (_, sam_input) = write_input_pair(dir.path());
+
+    let once = dir.path().join("once.gz");
+    gzip_file(&sam_input, &once);
+    let twice = dir.path().join("twice.gz");
+    gzip_file(&once, &twice);
+
+    let output = dir.path().join("out.bam");
+    let result =
+        run(&["sort", "-i", "{input}", "-o", "{output}", "--order", "queryname"], &twice, &output);
+
+    assert!(!result.status.success(), "doubly-gzipped input was accepted");
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        stderr.contains("gzip-compressed twice"),
+        "the error should name the double compression, got: {stderr}"
+    );
+}
+
+/// A gzip member holding nothing is named as such, not as a SAM parse failure.
+///
+/// The empty-input check at the boundary runs on the bytes *as they arrive*, so a
+/// gzip member that decompresses to nothing slips past it and is caught on the
+/// second classification instead. Without that arm the empty result would take the
+/// SAM transcode and fail with a message about an absent `@` header line, which
+/// says nothing about the file being empty.
+#[test]
+fn empty_gzip_member_is_rejected() {
+    let dir = TempDir::new().expect("create temp dir");
+
+    let empty = dir.path().join("empty");
+    File::create(&empty).expect("create empty source");
+    let gzipped = dir.path().join("empty.gz");
+    gzip_file(&empty, &gzipped);
+
+    let output = dir.path().join("out.bam");
+    let result = run(
+        &["sort", "-i", "{input}", "-o", "{output}", "--order", "queryname"],
+        &gzipped,
+        &output,
+    );
+
+    assert!(!result.status.success(), "an empty gzip member was accepted");
+    let stderr = String::from_utf8_lossy(&result.stderr);
+    assert!(
+        stderr.contains("empty gzip member"),
+        "the error should name the empty member, got: {stderr}"
+    );
+}


### PR DESCRIPTION
Three follow-ups from the #644 review, each independent. Stacked on `nh/feat-accept-sam-input` because all three touch code that only exists there (`classify_input`, `normalize_to_bgzf`, `open_raw_bam_record_reader_with_header`); the base should be retargeted to `main` once #644 merges.

**Suggested reading order: one commit at a time, in order.** They share a theme — the input boundary — but nothing else, and each stands alone.

### 1. `refactor(bgzf)`: give the BGZF header layout one definition

"Is this a BGZF block?" and "where does it end?" were answered by hand at four sites, and they had drifted. `read_raw_block` checked magic, CM, `FLG & FEXTRA` and `BC` but never `XLEN` or `SLEN`; `classify_input` checked all six itself; `unified_pipeline::fastq` read `BSIZE` from bytes 16-17 twice more with no validation at all. The input sniff and the block reader could therefore disagree about the same file — the thing the one-classifier work set out to prevent, one layer further down.

`fgumi_bgzf::header` is now the single answer to both questions, and the predicate is the *intersection* of what fgumi's decoders accept rather than what RFC 1952 permits: a `true` has to be a promise every downstream path can keep. noodles is the strictest and is not ours to change, so it sets the bar.

This closes a real gap. A `BC`-first header with a trailing subfield (`XLEN` 10) framed happily — `BSIZE` is still at 16-17 in that layout — and the four extra bytes rode into the payload every consumer takes as `[18 .. len - 8]`, dying downstream on `BGZF stored block size mismatch: LEN=89, payload=16`, a message about stored-block internals that says nothing about the header.

### 2. `fix(compare)`: open each input once for the single-pass presets

The engines took one open per input after #644; the command around them did not. `CompareBams::execute` must read both headers before dispatching — an incompatible pair hard-exits ahead of any engine, deliberately — and the engine then reopened both paths for their records. Each half read its stream once, but the command as a whole still needed a re-openable input, so `compare bams --command sort` and `--command group` rejected a FIFO or a process substitution that `fgumi sort` reads happily.

`execute` now opens each input once as an `OpenedInput` and hands the streams to whichever engine runs. The path-taking entry points remain as wrappers, so the public API is unchanged and neither form can drift into opening twice. Content mode still opens by path and releases the streams first — it makes two passes over each input and cannot stream a one-shot input at all.

### 3. `feat(io)`: accept plain-gzip input at the normalization boundary

gzip that was not BGZF was rejected outright, making fgumi the one tool in the pipeline that could not read what `gzip` produced. It is decompressed once at the boundary and re-classified now, so the pipeline still sees only BGZF: BGZF passes through, SAM text takes the existing transcode, and a raw unframed BAM is re-framed by copying its bytes through a BGZF writer (no record parsing — only the framing is missing).

That last arm is what makes this more than a convenience. A BGZF file carrying a second gzip extra subfield is legal per RFC 1952 and unframeable by fgumi, noodles and htslib alike, but it is still a plain gzip member — so a spec-complete gzip reader handles the framing they reject and what falls out is exactly an unframed BAM. Such a file now reads correctly; the test builds one by rewriting a real BAM's block headers.

Two decisions worth flagging for review:

- **Gzipped BAM is accepted, not rejected.** The plan recorded in #644 was to reject it because samtools cannot read it either — but "samtools cannot" does not imply "we cannot", and what comes out of the decompressor is a perfectly good BAM.
- **The boundary decompresses exactly once.** Peeling layers until something recognisable appears would let a small crafted input cost unbounded work for one open, so two gzip layers are named instead.

The cost is block-parallel decode, warned about per input rather than left as a silent cliff. `flate2` moves to `[workspace.dependencies]` so the two crates that need it share one declaration — its `zlib-rs` pin exists for a documented throughput reason, and a second unpinned copy is precisely the feature-unification hazard that comment warns about.

### Verification

`cargo ci-test` 6036 passed / 0 failed, `ci-fmt` and `ci-lint` clean at each commit. Every behavioural change has a test that fails before it and passes after — including the FIFO cases, which **hang** rather than fail when the property regresses, so those bound the work and fail with a named message instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for plain gzip-compressed SAM and BAM inputs with automatic normalization into BGZF for downstream processing.
  * Improved reliability for BAM comparisons by opening inputs once (better support for streamed/FIFO inputs).

* **Bug Fixes**
  * Strengthened BGZF header validation and block-size detection to prevent misclassification of truncated/incorrect data.
  * Added clear rejection for double-compressed gzip inputs.

* **Tests**
  * Expanded integration coverage for gzip variants, stricter BGZF validation, and non-reopenable FIFO comparison inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->