### PR TITLE
fix(simulate): join writer threads on every exit path

### DIFF
--- a/src/lib/commands/simulate/common.rs
+++ b/src/lib/commands/simulate/common.rs
@@ -5,7 +5,7 @@ use crate::commands::common::{
     resolve_memory_budget,
 };
 use crate::commands::sort::{TMP_DIRS_ENV, resolve_tmp_dirs};
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use bytesize::ByteSize;
 use clap::Args;
 use crossbeam_channel::{Receiver, Sender, bounded};
@@ -21,6 +21,7 @@ use rand::{Rng, RngExt};
 use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
+use std::thread::JoinHandle;
 
 /// Build the `@HD` header map carrying the `SO`/`GO`/`SS` sort-order tags for `order`.
 ///
@@ -862,6 +863,37 @@ fn is_conversion_target(
             MethylationMode::Disabled => false,
         }
     }
+}
+
+/// Join the writer thread, then decide which of the two failures to report.
+///
+/// Every `simulate` subcommand that streams records to a writer thread ends the
+/// same way: the generation pass returns a channel `SendError` or `Ok(())`, and
+/// the writer thread returns the counts it accumulated. Joining is unconditional
+/// because the writer owns the output file — returning while it is still running
+/// leaves the file being written behind the error.
+///
+/// A send failure is a *symptom*: the channel only closes because the writer
+/// already died, so the writer's error is the cause and is reported in preference
+/// to it. The send failure is reported only when the writer itself succeeded,
+/// which means the receiver was dropped for some other reason.
+///
+/// # Errors
+///
+/// Returns an error if the writer thread panicked, if the writer thread returned
+/// an error, or — only when the writer succeeded — if generation failed to send.
+pub fn join_writer_result<T, E: std::fmt::Display>(
+    writer_handle: JoinHandle<Result<T>>,
+    generation_result: std::result::Result<(), E>,
+) -> Result<T> {
+    let writer_result = writer_handle.join().map_err(|_| anyhow!("Writer thread panicked"))?;
+
+    if let Err(e) = generation_result {
+        writer_result?;
+        return Err(anyhow!("Failed to send record to writer: {e}"));
+    }
+
+    writer_result
 }
 
 #[cfg(test)]

--- a/src/lib/commands/simulate/consensus_reads.rs
+++ b/src/lib/commands/simulate/consensus_reads.rs
@@ -2,7 +2,9 @@
 
 use crate::commands::command::Command;
 use crate::commands::common::{CompressionOptions, parse_bool};
-use crate::commands::simulate::common::{MethylationArgs, ReferenceGenome, StrandBiasArgs};
+use crate::commands::simulate::common::{
+    MethylationArgs, ReferenceGenome, StrandBiasArgs, join_writer_result,
+};
 use crate::commands::simulate::region_to_bin;
 use crate::dna::reverse_complement;
 use crate::sam::SamTag;
@@ -321,14 +323,7 @@ impl Command for ConsensusReads {
         // Drop sender to signal writer thread that we're done
         drop(sender);
 
-        // Check generation result
-        if let Err(e) = generation_result {
-            return Err(anyhow::anyhow!("Failed to send record to writer: {e}"));
-        }
-
-        // Wait for writer thread to finish
-        let read_count =
-            writer_handle.join().map_err(|_| anyhow::anyhow!("Writer thread panicked"))??;
+        let read_count = join_writer_result(writer_handle, generation_result)?;
 
         info!("Generated {read_count} consensus read pairs");
         info!("Done");

--- a/src/lib/commands/simulate/correct_reads.rs
+++ b/src/lib/commands/simulate/correct_reads.rs
@@ -2,7 +2,7 @@
 
 use crate::commands::command::Command;
 use crate::commands::common::CompressionOptions;
-use crate::commands::simulate::common::generate_random_sequence;
+use crate::commands::simulate::common::{generate_random_sequence, join_writer_result};
 use crate::sam::SamTag;
 use crate::simulate::create_rng;
 use anyhow::{Context, Result};
@@ -291,14 +291,8 @@ impl Command for CorrectReads {
         // Drop sender to signal writer thread that we're done
         drop(sender);
 
-        // Check generation result
-        if let Err(e) = generation_result {
-            return Err(anyhow::anyhow!("Failed to send record to writer: {e}"));
-        }
-
-        // Wait for writer thread to finish
         let (read_count, exact_count, edit1_count, edit2_count, multi_count) =
-            writer_handle.join().map_err(|_| anyhow::anyhow!("Writer thread panicked"))??;
+            join_writer_result(writer_handle, generation_result)?;
 
         info!("Generated {read_count} reads:");
         info!(

--- a/src/lib/commands/simulate/fastq_reads.rs
+++ b/src/lib/commands/simulate/fastq_reads.rs
@@ -5,7 +5,7 @@ use crate::commands::common::parse_bool;
 use crate::commands::simulate::common::{
     FamilySizeArgs, InsertSizeArgs, MethylationArgs, MethylationConfig, QualityArgs,
     ReferenceGenome, SimulationCommon, apply_methylation_conversion, body_error_rng,
-    generate_random_sequence, introduce_errors_inplace,
+    generate_random_sequence, introduce_errors_inplace, join_writer_result,
 };
 use crate::simulate::{FastqWriter, create_rng};
 use anyhow::{Context, Result, bail};
@@ -359,14 +359,7 @@ impl Command for FastqReads {
         // Drop sender to signal writer thread that we're done
         drop(sender);
 
-        // Check generation result
-        if let Err(e) = generation_result {
-            return Err(anyhow::anyhow!("Failed to send record to writer: {e}"));
-        }
-
-        // Wait for writer thread to finish
-        let read_count =
-            writer_handle.join().map_err(|_| anyhow::anyhow!("Writer thread panicked"))??;
+        let read_count = join_writer_result(writer_handle, generation_result)?;
 
         info!("Generated {read_count} read pairs");
         info!("Done");

--- a/src/lib/simulate/parallel_gzip_writer.rs
+++ b/src/lib/simulate/parallel_gzip_writer.rs
@@ -95,7 +95,11 @@ pub struct ParallelGzipWriter {
     /// Next serial number to assign.
     next_serial: u64,
     /// Channel to send uncompressed blocks to compression workers.
-    compress_tx: Sender<UncompressedBlock>,
+    ///
+    /// `Option` so shutdown can close it — dropping the sender is what tells the
+    /// workers to finish — while leaving the struct intact for [`Drop`] to run
+    /// over a second time without repeating the work.
+    compress_tx: Option<Sender<UncompressedBlock>>,
     /// Handles for compression worker threads.
     compression_handles: Vec<JoinHandle<()>>,
     /// Handle for the I/O writer thread.
@@ -157,7 +161,7 @@ impl ParallelGzipWriter {
             block_buffer: Vec::with_capacity(config.block_size),
             block_size: config.block_size,
             next_serial: 0,
-            compress_tx,
+            compress_tx: Some(compress_tx),
             compression_handles,
             io_handle: Some(io_handle),
         })
@@ -222,6 +226,8 @@ impl ParallelGzipWriter {
         self.next_serial += 1;
 
         self.compress_tx
+            .as_ref()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "Writer already finished"))?
             .send(block)
             .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "Compression channel closed"))
     }
@@ -230,25 +236,78 @@ impl ParallelGzipWriter {
     ///
     /// # Errors
     ///
-    /// Returns an error if flushing or joining worker threads fails.
+    /// Returns an error if flushing or joining worker threads fails. Every thread
+    /// is joined regardless — see `shutdown`, which this delegates to.
     pub fn finish(mut self) -> io::Result<()> {
-        // Dispatch any remaining data
-        self.dispatch_block()?;
+        self.shutdown()
+    }
 
-        // Close the compression channel
-        drop(self.compress_tx);
+    /// Close the channel and join every thread, returning the first error.
+    ///
+    /// Joining is unconditional. It used to happen behind three `?`s — a failed
+    /// final dispatch returned before any join, and a worker that panicked
+    /// returned before the remaining workers and the I/O thread were joined — so
+    /// the error surfaced while detached threads were still compressing and still
+    /// writing to the output file. The caller would see the failure, and the file
+    /// would keep growing behind it.
+    ///
+    /// The first error a join discovers wins, so the cause is reported rather than
+    /// whatever the unwinding happened to hit last; later errors are dropped, not
+    /// hidden behind an earlier `Ok`. The final dispatch's own error ranks below
+    /// all of them because it is usually a symptom: an I/O thread that fails
+    /// closes `output_rx`, the workers break out of their loop, and the dispatch
+    /// then reports a generic "Compression channel closed" for a write that
+    /// actually failed on a full disk.
+    ///
+    /// Idempotent: the sender and the handles are taken, so the [`Drop`] that runs
+    /// after [`Self::finish`] finds nothing left to do.
+    fn shutdown(&mut self) -> io::Result<()> {
+        // Not `?`: a failed dispatch must not skip the joins below.
+        let dispatch_result = self.dispatch_block();
 
-        // Wait for compression workers (they return () so just check for panic)
-        for handle in self.compression_handles {
-            handle.join().map_err(|_| io::Error::other("Compression worker thread panicked"))?;
+        // Dropping the sender is what lets the workers see the channel close and
+        // exit, so it has to happen before the joins or they would block forever.
+        drop(self.compress_tx.take());
+
+        let mut result: io::Result<()> = Ok(());
+        for handle in self.compression_handles.drain(..) {
+            if handle.join().is_err() && result.is_ok() {
+                result = Err(io::Error::other("Compression worker thread panicked"));
+            }
         }
 
-        // Wait for I/O thread
         if let Some(handle) = self.io_handle.take() {
-            handle.join().map_err(|_| io::Error::other("I/O thread panicked"))??;
+            let io_result = match handle.join() {
+                Ok(io_result) => io_result,
+                Err(_) => Err(io::Error::other("I/O thread panicked")),
+            };
+            if let Err(e) = io_result
+                && result.is_ok()
+            {
+                result = Err(e);
+            }
         }
 
-        Ok(())
+        // Only if every thread shut down cleanly is the dispatch failure the cause.
+        result.and(dispatch_result)
+    }
+}
+
+impl Drop for ParallelGzipWriter {
+    /// Join the worker threads even when [`Self::finish`] was never reached.
+    ///
+    /// Without this, any `?` between construction and `finish` — a failed
+    /// `write_record`, or the first of two writers failing to finish — detached
+    /// threads that were still compressing and writing. The caller unwound while
+    /// its output file was still being written to, and whether those writes landed
+    /// depended on how quickly the process exited.
+    ///
+    /// Errors cannot propagate from a drop, so they are logged rather than
+    /// swallowed silently. A caller that wants them calls [`Self::finish`].
+    fn drop(&mut self) {
+        if let Err(e) = self.shutdown() {
+            log::warn!("Error shutting down the parallel gzip writer: {e}");
+        }
     }
 }
 
@@ -277,6 +336,115 @@ mod tests {
     use std::fs::File;
     use std::io::Read;
     use tempfile::NamedTempFile;
+
+    /// A sink that fails every write, to drive the I/O thread's error path.
+    struct FailingSink;
+
+    impl Write for FailingSink {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::other("sink is broken"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A failing I/O thread must surface its error from `finish`, not hang.
+    ///
+    /// The joins used to sit behind `?`, so an error on one of them returned with
+    /// the remaining threads unjoined. This drives that path: the payload is small
+    /// enough that nothing is dispatched until shutdown, so the final dispatch
+    /// succeeds and the I/O thread's failure is the first error — which is the one
+    /// the caller has to see.
+    #[test]
+    fn test_finish_reports_an_io_thread_failure() {
+        let config = ParallelGzipConfig::with_threads(2);
+        let mut writer =
+            ParallelGzipWriter::new(FailingSink, &config).expect("writer construction");
+        writer.write_all(b"ACGT").expect("buffered, not yet dispatched");
+
+        let err = writer.finish().expect_err("a failing sink must surface as an error");
+        assert!(
+            err.to_string().contains("sink is broken"),
+            "the I/O thread's own error must be reported, got: {err}"
+        );
+    }
+
+    /// The I/O thread's error must outrank the channel closure it causes.
+    ///
+    /// With enough payload to dispatch mid-write, the failing sink kills the I/O
+    /// thread first: `output_rx` closes, the compression workers break out of
+    /// their loop, and the final dispatch in `shutdown` then fails with a generic
+    /// "Compression channel closed". Seeding the shutdown result from that
+    /// dispatch let the symptom win over the sink's real error, which is the one
+    /// the caller has to see. Writes are expected to fail here for the same
+    /// reason — the assertion is on what `finish` reports.
+    #[test]
+    fn test_finish_prefers_the_io_error_over_the_closed_channel() {
+        let config = ParallelGzipConfig::with_threads(2);
+        let mut writer =
+            ParallelGzipWriter::new(FailingSink, &config).expect("writer construction");
+
+        let block = vec![b'A'; DEFAULT_BLOCK_SIZE];
+        for _ in 0..64 {
+            if writer.write_all(&block).is_err() {
+                break;
+            }
+        }
+        // Leave a partial block buffered so shutdown has something left to dispatch
+        // down the by-now-closed channel — that failed dispatch is the symptom.
+        let _ = writer.write(b"ACGT");
+
+        let err = writer.finish().expect_err("a failing sink must surface as an error");
+        assert!(
+            err.to_string().contains("sink is broken"),
+            "the I/O thread's own error must outrank the channel-closed symptom, got: {err}"
+        );
+    }
+
+    /// Dropping a writer whose sink fails must log, not panic.
+    ///
+    /// This is the path that runs when a caller is already unwinding: a write
+    /// failed, the `?` propagated, and the writer is dropped on the way out. A
+    /// panic from `Drop` during an unwind aborts the process, so the shutdown error
+    /// has to be logged and swallowed here — the caller that wants it calls
+    /// `finish`. The test passing without an abort is the assertion.
+    #[test]
+    fn test_drop_swallows_a_shutdown_error() {
+        let config = ParallelGzipConfig::with_threads(2);
+        let mut writer =
+            ParallelGzipWriter::new(FailingSink, &config).expect("writer construction");
+        writer.write_all(b"ACGT").expect("buffered, not yet dispatched");
+        drop(writer);
+    }
+
+    /// Dropping a writer without calling `finish` must still complete the output.
+    ///
+    /// Any `?` between construction and `finish` drops the writer — a failed
+    /// `write_record`, or the first of two writers failing to finish. Without a
+    /// `Drop` that joins, the compression and I/O threads were detached and went
+    /// on writing to the file while the caller unwound, so what ended up on disk
+    /// depended on how quickly the process exited. Reading the file straight after
+    /// the drop is the assertion: it can only be complete if the drop waited.
+    #[test]
+    fn test_drop_without_finish_completes_the_output() -> io::Result<()> {
+        let temp = NamedTempFile::new()?;
+        let path = temp.path().to_path_buf();
+        let payload: Vec<u8> = (0..200_000u32).map(|i| b"ACGT"[(i % 4) as usize]).collect();
+
+        {
+            let config = ParallelGzipConfig::with_threads(4);
+            let mut writer = ParallelGzipWriter::new(File::create(&path)?, &config)?;
+            writer.write_all(&payload)?;
+            // Deliberately no `finish()`: this is the path a `?` takes.
+        }
+
+        let mut decoded = Vec::new();
+        MultiGzDecoder::new(File::open(&path)?).read_to_end(&mut decoded)?;
+        assert_eq!(decoded, payload, "the dropped writer left an incomplete file");
+        Ok(())
+    }
 
     #[test]
     fn test_basic_compression() -> io::Result<()> {

--- a/tests/integration/test_e2e_regression.rs
+++ b/tests/integration/test_e2e_regression.rs
@@ -13,11 +13,14 @@ use fgumi_lib::commands::extract::Extract;
 use fgumi_lib::commands::filter::Filter;
 use fgumi_lib::commands::group::GroupReadsByUmi;
 use fgumi_lib::commands::simplex::Simplex;
+use fgumi_lib::commands::simulate::consensus_reads::ConsensusReads;
+use fgumi_lib::commands::simulate::correct_reads::CorrectReads;
 use fgumi_lib::commands::simulate::fastq_reads::FastqReads;
 use fgumi_lib::commands::simulate::grouped_reads::GroupedReads;
 use fgumi_lib::commands::sort::Sort;
 use fgumi_lib::sam::SamTag;
 use noodles::bam;
+use rstest::rstest;
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::Write;
@@ -761,4 +764,110 @@ fn assert_simplex_has_methylation_tags(bam_path: &Path) {
     assert!(with_ml > 0, "Expected at least one record with an ML tag; got {total} records");
     assert!(with_cu > 0, "Expected at least one record with a cu tag; got {total} records");
     assert!(with_ct > 0, "Expected at least one record with a ct tag; got {total} records");
+}
+
+/// A writer that dies must report *its* error, not the send failure it causes.
+///
+/// The writer thread owns the output files; the generator only learns something
+/// went wrong because its channel closed. The command used to return on that send
+/// failure without joining the writer, so it reported "Failed to send record to
+/// writer: sending on a disconnected channel" — the symptom — and discarded the
+/// writer's own error along with the unjoined handle. It also left the writer
+/// running over its output while the caller unwound.
+///
+/// A directory where R1 should go makes the writer fail at its first `File::create`,
+/// which is the cheapest way to reach that path deterministically.
+#[test]
+fn simulate_fastq_reads_reports_the_writer_error_not_the_send_failure() {
+    let dir = TempDir::new().expect("create temp dir");
+    let reference = create_test_reference(dir.path());
+
+    // R1's path is a directory, so the writer cannot create it.
+    let r1 = dir.path().join("r1.fastq.gz");
+    std::fs::create_dir(&r1).expect("create the blocking directory");
+
+    let cmd = FastqReads::try_parse_from([
+        OsStr::new("fastq-reads"),
+        OsStr::new("-1"),
+        r1.as_os_str(),
+        OsStr::new("-2"),
+        dir.path().join("r2.fastq.gz").as_os_str(),
+        OsStr::new("--truth"),
+        dir.path().join("truth.txt").as_os_str(),
+        OsStr::new("--reference"),
+        reference.as_os_str(),
+        OsStr::new("--num-molecules"),
+        OsStr::new("200"),
+    ])
+    .expect("failed to parse fastq-reads args");
+
+    let err = cmd.execute("fgumi simulate fastq-reads").expect_err("the writer cannot succeed");
+    let rendered = format!("{err:#}");
+    assert!(
+        rendered.contains("Failed to create"),
+        "the writer's own error must be reported, got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("Failed to send record to writer"),
+        "the send failure is the symptom, not the cause: {rendered}"
+    );
+}
+
+/// The BAM-writing siblings of the test above must report the writer's error too.
+///
+/// `consensus_reads`, `correct_reads` and `fastq_reads` each spawn a writer thread
+/// and each had the same early return, so fixing one and testing only that one is
+/// how the other two would quietly regress. A directory where the output BAM
+/// should go makes the writer fail at `create_raw_bam_writer`, which reaches the
+/// same path as the FASTQ case.
+#[rstest]
+#[case::consensus_reads(false)]
+#[case::correct_reads(true)]
+fn simulate_bam_commands_report_the_writer_error_not_the_send_failure(#[case] correct: bool) {
+    let dir = TempDir::new().expect("create temp dir");
+    let reference = create_test_reference(dir.path());
+
+    // The output BAM's path is a directory, so the writer cannot create it.
+    let output = dir.path().join("out.bam");
+    std::fs::create_dir(&output).expect("create the blocking directory");
+
+    let err = if correct {
+        let includelist = dir.path().join("umis.txt");
+        std::fs::write(&includelist, "ACGTACGT\nTTTTGGGG\n").expect("write include list");
+        let cmd = CorrectReads::try_parse_from([
+            OsStr::new("correct-reads"),
+            OsStr::new("-o"),
+            output.as_os_str(),
+            OsStr::new("--includelist"),
+            includelist.as_os_str(),
+            OsStr::new("--truth"),
+            dir.path().join("truth.txt").as_os_str(),
+            OsStr::new("--num-reads"),
+            OsStr::new("200"),
+        ])
+        .expect("failed to parse correct-reads args");
+        cmd.execute("fgumi simulate correct-reads").expect_err("the writer cannot succeed")
+    } else {
+        let cmd = ConsensusReads::try_parse_from([
+            OsStr::new("consensus-reads"),
+            OsStr::new("-o"),
+            output.as_os_str(),
+            OsStr::new("--reference"),
+            reference.as_os_str(),
+            OsStr::new("--num-reads"),
+            OsStr::new("200"),
+        ])
+        .expect("failed to parse consensus-reads args");
+        cmd.execute("fgumi simulate consensus-reads").expect_err("the writer cannot succeed")
+    };
+
+    let rendered = format!("{err:#}");
+    assert!(
+        rendered.contains("Failed to create output BAM"),
+        "the writer's own error must be reported, got: {rendered}"
+    );
+    assert!(
+        !rendered.contains("Failed to send record to writer"),
+        "the send failure is the symptom, not the cause: {rendered}"
+    );
 }


### PR DESCRIPTION
Started as "why does nextest intermittently flag `simulate::fastq_writer::tests::test_multi_threaded_writer` as `LEAK`". **That flag is still unexplained** — the test calls `finish()`, and it did not reproduce in three full suite runs or five isolated ones. What the investigation did turn up is a set of real detached-thread bugs, which this fixes. The flake is left open deliberately rather than declared fixed.

### `ParallelGzipWriter` joined its threads only on the happy path

`finish()` joined behind three `?`s: a failed final dispatch returned before any join, and a panicking worker returned before the remaining workers and the I/O thread were joined. The caller got its error while detached threads were still compressing and still writing the output file. Joining is now unconditional, with the first error winning so the cause is reported.

There was also **no `Drop`**, so any `?` between construction and `finish` detached the threads entirely. Not hypothetical — `simulate fastq-reads` has:

```rust
r1_writer.finish()?;
r2_writer.finish()?;
```

If R1's finish fails, `r2_writer` is dropped unfinished and its threads keep writing `r2.fastq.gz` while the process unwinds; what lands on disk depends on how fast it exits. A failing `write_record` drops both. The new `Drop` joins, which also brings this writer in line with `noodles::bgzf::MultithreadedWriter`, which has always finished in `Drop`.

### The same shape one level up, in three commands

`consensus_reads`, `correct_reads` and `fastq_reads` each did:

```rust
drop(sender);
if let Err(e) = generation_result { return Err(...); }   // handle never joined
let count = writer_handle.join()?;
```

So a generation failure returned while the writer thread was still writing its BAM or FASTQ. And it reported the wrong error: the send only fails because the receiver hung up, i.e. the writer already died — so `"Failed to send record to writer"` was the symptom while the writer's own error, the cause, was discarded along with the unjoined handle. All three now join first and prefer the writer's error. `mapped_reads` already did this correctly via `sink.fail`, and is unchanged.

Worth noting for review: the BAM **writer** itself was never at risk — `create_raw_bam_writer` builds on noodles' `MultithreadedWriter`, which joins in `Drop`. The bug in the BAM commands is at the command level, not in the writer.

### Test

Drops a writer without finishing and reads the file immediately: it can only be complete if the drop waited. Verified to fail with the `Drop` impl removed and pass with it.

`cargo ci-test` 6595 passed / 0 failed, `ci-fmt` and `ci-lint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved parallel simulation reliability by always completing writer thread work before returning results or errors.
  - Enhanced error propagation so writer failures/panics are surfaced before downstream send failures.
  - Ensured consistent read counters and messaging when generation/writing encounters issues.

- **Reliability**
  - Made compressed output finalization deterministic, preserving the first failure.
  - Ensured complete gzip output even when explicit completion isn’t called.

- **Tests**
  - Added regression coverage for writer failure/error reporting across fastq-reads and BAM-writing variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->