### PR TITLE
ci: run the whole workspace in cargo ci-test

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
-ci-test = "nextest run --features compare,simulate,profile-adjacency --locked --no-tests=pass"
+ci-test = "nextest run --workspace --features compare,simulate,profile-adjacency --locked --no-tests=pass"
 ci-fmt = "fmt --all -- --check"
 ci-lint = "clippy --workspace --all-targets --features compare,simulate,profile-adjacency -- -D warnings -W clippy::pedantic"
 ci-tag-literals = "run --package xtask -- check-tag-literals"


### PR DESCRIPTION
On this branch `ci-test` selected only the root `fgumi` package, so `cargo ci-test` ran **2,349** tests where the workspace has **5,434**. Every member crate — `fgumi-sort`, `fgumi-consensus`, `fgumi-pipeline-core`, `fgumi-raw-bam`, and the rest — was skipped. `fgumi-pipeline-core` alone contributes 283 tests and lists as **zero** without the flag.

```
before: ci-test = "nextest run             --features compare,simulate,profile-adjacency --locked --no-tests=pass"
after:  ci-test = "nextest run --workspace --features compare,simulate,profile-adjacency --locked --no-tests=pass"
```

The failure mode is a green pre-push run that never touched the crate being changed. That is not hypothetical — it happened on #544, whose only code change is in `crates/fgumi-pipeline-core`: the local run reported 2,349 passing tests, none of them from that crate. `ci-lint` already passes `--workspace`, so lint covered exactly the crates tests did not, which is what kept the gap quiet.

This is drift, not a deliberate divergence. `main` gained the flag in #569 ("ci: run the whole workspace in tests"), whose stated purpose was this bug; that change never reached `feat-runall`. Advancing `feat-runall` onto `main` would fix it eventually, but that is a much larger call — restoring the one word here makes the local loop trustworthy in the meantime.

## Verification

- `cargo ci-test` on this branch: **5,434 tests run, 5,434 passed**, 8 skipped. No new failures surface from the newly-included crates.
- Re-ran the previously-skipped crates directly: `fgumi-pipeline-core` **283/283 passed**.

One note for reviewers: under a saturated full-workspace run, nextest intermittently reports a `LEAK` on an arbitrary `fgumi-sort` test (it landed on `ref_sort::tests::queryname_arena_sort_breaks_exact_ties_by_offset` in one run and `reader::tests::test_skip_header_twice_errors` in another, and did not appear at all in a third). Every test passes; this is the leak-detection grace period being exceeded under CPU contention, not a defect in any particular test. Flagging it because it becomes visible for the first time with this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI test execution to run across the entire workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->