### PR TITLE
ci(publish): ignore version-less dev-dependencies in the publish-order check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -142,8 +142,18 @@ jobs:
           ORDER_ERRORS=""
           for i in "${!CRATES[@]}"; do
             crate="${CRATES[$i]}"
+            # Dev-dependencies with no version requirement (path-only, `req == "*"`)
+            # are stripped from the manifest cargo uploads, so they impose no
+            # ordering constraint.  This is what makes the root crate's self
+            # dev-dependency -- `fgumi = { path = ".", features = ["test-utils"] }`,
+            # the only way to enable `test-utils` for the integration test targets
+            # -- publishable: without this filter it reads as "fgumi depends on
+            # fgumi", which no ordering can satisfy.  Dev-dependencies that do
+            # carry a version (e.g. `fgumi-raw-bam = { workspace = true, ... }`)
+            # survive packaging and must still be published first.
             DEPS=$(echo "$META" | jq -r --arg c "$crate" --argjson ws "$WS_JSON" '
-              .packages[] | select(.name == $c) | .dependencies[].name
+              .packages[] | select(.name == $c) | .dependencies[]
+              | select(.kind != "dev" or .req != "*") | .name
               | select(. as $d | $ws | index($d))' | sort -u)
             for dep in $DEPS; do
               j=$(index_of "$dep")


### PR DESCRIPTION
The v0.5.0 publish run on `main` failed: https://github.com/fulcrumgenomics/fgumi/actions/runs/30386480361/job/90366938846

```
ERROR: CRATES publish list is not in valid dependency order:
  fgumi depends on fgumi, which must be listed earlier
```

## Root cause

The publish job's topological pre-flight gate walks every entry of `cargo metadata`'s `dependencies` array, which includes dev-dependencies. #644 added a self dev-dependency to the root crate — `fgumi = { path = ".", features = ["test-utils"] }`, the only way to enable `test-utils` for the integration test targets, which link the library as an external crate — so the gate saw `fgumi` as a dependency of itself, which no ordering can satisfy. v0.4.0 published cleanly because that dev-dependency did not exist yet.

It is a false positive. Cargo strips path-only dev-dependencies (no version requirement) from the manifest it uploads, so they impose no publish-ordering constraint at all. Verified with a minimal probe crate carrying the same self dev-dependency: the packaged `Cargo.toml` comes out with an empty `[dev-dependencies]` table. `cargo publish` itself would have been fine.

## Fix

Skip dev-dependencies whose requirement is `*` (path-only, hence stripped at package time). Dev-dependencies that do carry a version — e.g. `fgumi-raw-bam = { workspace = true, features = ["test-utils", "noodles"] }` — survive packaging, so they must still be published first and are still enforced.

## Verification

- The gate now passes against the workspace as it stands on `main`.
- It is not vacuous: with `fgumi` deliberately moved to the front of `CRATES`, it still reports all ten of its workspace dependencies as out of order and exits 1.
- Dry-packaged all twelve crates (`cargo package --no-verify -p <crate>`): the four leaf crates package cleanly, and every other failure is exactly `failed to select a version for the requirement fgumi-* = "^0.5.0"` — expected, since 0.5.0 is not on the index yet — so nothing else is waiting behind the gate.

## Release state

Nothing was published and no release artifacts exist, because the gate runs before any upload: crates.io still reports `0.4.0` as `max_version` for every workspace crate, and there is no `v0.5.0` tag or GitHub release. No force push or history rewrite is needed.

Merging this to `main` re-triggers the workflow, which is idempotent — it re-checks `max_version` per crate and skips anything already published, and the release step skips an existing tag/release — so the v0.5.0 publish and release complete on that run. Note that re-running the failed job would not have helped: for `push` events GitHub reads the workflow file at the triggering SHA, so a re-run would execute the same broken script.
