### PR TITLE
docs: mark fgumi production ready as of v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,21 @@
 
 # fgumi
 
-**⚠️ RESEARCH PREVIEW - USE AT YOUR OWN RISK**
+**Production ready as of v0.5.0 — the fgbio-parity release.**
 
-This software is currently a **research preview**. While we have extensively
-tested these tools across a wide variety of vendor-provided data, **no
-guarantees are made** regarding correctness or stability.
+fgumi's output is validated against
+[fgbio](https://github.com/fulcrumgenomics/fgbio) across a wide range of
+vendor-provided data, and we now recommend fgumi over fgbio for UMI
+processing. The two intentionally differ in a handful of places — most visibly
+`MI` tag values, and `dedup --no-umi`, which drops fgbio's strand-of-origin
+split to match Picard `MarkDuplicates`. The divergences we know of are
+catalogued in the
+[migration guide](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/src/guide/migration-from-fgbio.md).
 
-We are targeting **July 31, 2026** to recommend fgumi over
-[fgbio](https://github.com/fulcrumgenomics/fgbio) for production use.
+As with any change to a production pipeline, validate against your own data
+before switching, and please
+[open an issue](https://github.com/fulcrumgenomics/fgumi/issues) for any
+divergence that isn't documented.
 
 Fulcrum Genomics Unique Molecular Indexing (UMI) Tools - a suite of high-performance tools for working with UMI-tagged sequencing data.
 
@@ -62,6 +69,7 @@ The diagram shows the workflow from FASTQ files to filtered consensus reads:
 
 * [Documentation](https://docs.rs/fgumi)
 * [Best Practice Pipeline](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/src/guide/best-practices.md): Recommended workflow from FASTQ to consensus
+* [Migration from fgbio](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/src/guide/migration-from-fgbio.md): Tool mapping, key differences, and known divergences
 * [Performance Tuning Guide](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/src/guide/performance-tuning.md): Threading, memory, and compression optimization
 * [Snakemake Pipeline](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/FastqToConsensus-RnD.smk): Reference implementation
 * [Metrics](https://github.com/fulcrumgenomics/fgumi/blob/main/docs/src/guide/working-with-metrics.md): Output metrics documentation

--- a/docs/src/guide/migration-from-fgbio.md
+++ b/docs/src/guide/migration-from-fgbio.md
@@ -118,6 +118,34 @@ mismatch even when the molecules are identical — verify equivalence at the **g
 `fgumi compare bams --mode grouping`, which preserves the input read names, rather than at the
 consensus stage.
 
+### Deduplication Without UMIs
+
+`fgumi dedup --no-umi` groups templates by coordinate, with neither UMI nor strand-of-origin
+sub-partitioning, matching Picard `MarkDuplicates` rather than fgbio's `GroupReadsByUmi`. It is
+not coordinate-*only*: the grouping key also carries the read group's library and, for
+cell-barcoded input, the `CB` tag, so duplicates are still never called across libraries or
+across cells. `--no-umi` removes the UMI and strand-of-origin splits, nothing else.
+
+Dropping the strand-of-origin split is deliberate. A standard library prep ligates the same
+asymmetric Y-adapter to both ends of a double-stranded fragment, and read 1 is primed from the P5
+end, so a *single* input fragment yields both an F1R2 and an F2R1 read pair at the same unclipped
+5' coordinates. Strand of origin therefore distinguishes the two halves of one molecule, not two
+molecules — sub-partitioning on it while marking duplicates keeps two reads per input fragment and
+double-counts it.
+
+Validated against Picard `MarkDuplicates` 3.4.0 on a 15.8M-primary-read duplex panel: fgumi's
+marked count equals Picard's expectation exactly, with per-template flag agreement
+of 99.9%. The residual is a representative tie-break — fgumi keeps the first template in
+template-coordinate order, Picard the earliest `read1IndexInFile` — and is symmetric.
+
+`fgumi group --no-umi` **does** still split by strand of origin, because consensus calling is a
+positional pileup that requires every read 1 in a molecule to be the same physical strand from the
+same 5' start. `dedup` calls no consensus, so it needs no such split.
+
+> **Changed in v0.5.0.** Earlier versions split `dedup --no-umi` by strand of origin, so v0.5.0
+> marks more duplicates (+~2 percentage points on a moderately duplicated panel). There is no flag
+> to restore the previous behavior; use the UMI grouping path if you need strand separation.
+
 ### Group Metrics
 
 fgumi's `group` command now produces a third metrics file beyond family sizes and grouping

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -216,7 +216,7 @@ struct DedupFilterConfig {
     include_non_pf: bool,
     /// Minimum UMI length.
     min_umi_length: Option<usize>,
-    /// Skip UMI validation; group by template coordinate alone, orientation-agnostically.
+    /// Skip UMI validation; group by template coordinate, orientation-agnostically.
     no_umi: bool,
 }
 
@@ -1131,10 +1131,11 @@ pub struct MarkDuplicates {
     #[arg(long = "index-threshold", default_value = "100")]
     pub index_threshold: IndexThreshold,
 
-    /// Skip UMI-based grouping; group by template coordinate alone. Forces identity
-    /// strategy and ignores any existing UMI tags. Templates are NOT split by strand of
-    /// origin in this mode, so F1R2 and F2R1 at the same coordinates are one molecule,
-    /// matching Picard `MarkDuplicates` (see "Grouping key" in --help).
+    /// Skip UMI-based grouping; group by template coordinate. Forces identity strategy
+    /// and ignores any existing UMI tags. Templates are NOT split by strand of origin in
+    /// this mode, so F1R2 and F2R1 at the same coordinates are one molecule, matching
+    /// Picard `MarkDuplicates`. Library and cell barcode still partition the grouping key
+    /// (see "Grouping key" in --help).
     #[arg(long = "no-umi", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
     pub no_umi: bool,
 


### PR DESCRIPTION
v0.5.0 is the fgbio-parity release, so the README's research-preview banner — and the **July 31, 2026** date we were targeting to recommend fgumi over fgbio — are both out of date.

## README

Replaces the banner with a production recommendation. It still does two honest things the old banner did: it names where fgumi and fgbio intentionally differ (`MI` tag values, and `dedup --no-umi`, which follows Picard `MarkDuplicates`), and it tells users to validate against their own data before switching a production pipeline. It also asks for an issue on any divergence that *isn't* documented, which is the useful signal to collect now that people will start trusting the output.

The migration-guide link is absolute rather than repo-relative, matching every other link in the README — relative links break when crates.io renders it.

Also adds the migration guide to the Resources list. It wasn't there, which is odd on its own and worse now that the banner sends readers to it.

## Migration guide

The banner claims the `dedup --no-umi` behavior is documented in the migration guide. It wasn't — the guide covers the `MI` divergence but had nothing on dedup. Rather than drop the clause, this adds the section, since it's a breaking change in v0.5.0 that anyone upgrading needs:

- Why coordinate-only grouping is correct for duplicate marking (one fragment yields both an F1R2 and an F2R1 pair, so strand of origin separates the two halves of one molecule, not two molecules).
- The Picard `MarkDuplicates` 3.4.0 validation, and what the residual disagreement actually is (representative tie-break, symmetric).
- Why `group --no-umi` still splits by strand while `dedup --no-umi` doesn't — consensus calling is a positional pileup and needs the split; dedup calls no consensus.
- A "Changed in v0.5.0" note with the direction of the shift and the fact that there's no flag to restore the old behavior.

Facts and figures are from #649.

## Verification

`cargo docs-build` exits 0 with mdbook-linkcheck2 clean; the three `Potential incomplete link` warnings are pre-existing, in generated tool/metric pages, and untouched by this change.

## Note for reviewers

The v0.5.0 release notes now carry a user-facing preamble above the generated changelog, which makes the same production-readiness framing. Worth a skim for consistency with the wording here: https://github.com/fulcrumgenomics/fgumi/releases/tag/v0.5.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project status to production-ready as of v0.5.0.
  * Added links and guidance for migrating from fgbio.
  * Documented differences in no-UMI deduplication behavior, including coordinate-based grouping and changes introduced in v0.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->