### PR TITLE
docs(sort): keep the binary name out of per-argument help

### DIFF
--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -180,6 +180,9 @@ EXAMPLES:
   # Reserve extra memory for bwa mem running in a pipeline
   fgumi sort -i input.bam -o sorted.bam --memory-reserve 12GiB --threads 4
 
+  # Cede cores to the aligner during ingest, but keep the merge wide
+  bwa mem -t 32 ref.fa r1.fq r2.fq | fgumi sort -i - -o sorted.bam -@ 8 --sort-threads 4
+
   # Allow more spilled runs before consolidating (fewer consolidation passes)
   fgumi sort -i input.bam -o sorted.bam --order coordinate --max-temp-files 512
 
@@ -216,7 +219,7 @@ pub struct Sort {
     /// Queryname sort supports sub-sort specifiers:
     ///   `queryname`                  Lexicographic byte ordering (default, fast)
     ///   `queryname::lexicographic`   Explicit lexicographic ordering (alias: `queryname::lex`)
-    ///   `queryname::lexicographical` Alias; fgumi emits `queryname:lexicographical` in `@HD` SS
+    ///   `queryname::lexicographical` Alias; written as `queryname:lexicographical` in `@HD` SS
     ///   `queryname::natural`         Natural numeric ordering (samtools-compatible)
     #[arg(long = "order", default_value = "template-coordinate", value_parser = SortOrderArg::parse)]
     pub order: SortOrderArg,
@@ -291,9 +294,10 @@ pub struct Sort {
     /// Number of threads for the sort phase (accumulate, sort, spill).
     ///
     /// Defaults to `--threads`. Lower this to cede cores to an upstream
-    /// producer while keeping the merge wide -- e.g. in
-    /// `bwa mem -t 32 ... | fgumi sort -@ 8 --sort-threads 4`, ingest competes
-    /// with the aligner but the merge does not.
+    /// producer while keeping the merge wide -- with `-@ 8 --sort-threads 4`,
+    /// ingest contends with the producer over only 4 threads, while the merge
+    /// still uses 8 because it cannot start until the input is exhausted, by
+    /// which point the producer has finished writing.
     ///
     /// This only changes scheduling; the output is byte-identical.
     #[arg(long = "sort-threads")]
@@ -703,8 +707,69 @@ mod tests {
     // Memory-budget helpers moved to `commands::common`; import the `pub(crate)`
     // items these tests exercise that are not re-exported through `super::*`.
     use crate::commands::common::{MIN_MEMORY_PER_THREAD, detect_total_memory, resolve_reserve};
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
     use rstest::rstest;
+
+    // ========================================================================
+    // Help-text tests
+    // ========================================================================
+
+    /// Returns true if `help` names the `fgumi` binary as a standalone token.
+    ///
+    /// Splits on every character that cannot appear inside a Rust identifier, so
+    /// a bare `fgumi`, a trailing `fgumi`, and punctuated forms (`` `fgumi` ``,
+    /// `fgumi.`, `fgumi-sort`) all match, while `fgumi` embedded in a longer word
+    /// (`fgumidocs`) and identifier-shaped mentions (`fgumi_sort`) do not.
+    fn names_the_binary(help: &str) -> bool {
+        help.split(|c: char| !c.is_ascii_alphanumeric() && c != '_').any(|token| token == "fgumi")
+    }
+
+    #[rstest]
+    #[case::bare_invocation("run fgumi sort to order records", true)]
+    #[case::trailing_token("this flag mirrors fgumi", true)]
+    #[case::followed_by_period("see fgumi.", true)]
+    #[case::backticked("see `fgumi` for details", true)]
+    #[case::hyphenated("see fgumi-sort", true)]
+    #[case::embedded_in_word("see the fgumidocs site", false)]
+    #[case::suffix_of_word("see myfgumi", false)]
+    #[case::rust_identifier("handled by fgumi_sort::run", false)]
+    #[case::no_mention("Sort records by template coordinate", false)]
+    fn test_names_the_binary(#[case] help: &str, #[case] expected: bool) {
+        assert_eq!(names_the_binary(help), expected, "help was: {help}");
+    }
+
+    /// `Sort` is `#[command(flatten)]`-ed into other binaries, so its
+    /// per-argument help renders under a program name that is not `fgumi` — a
+    /// concrete `fgumi ...` invocation there tells those users to run a command
+    /// they do not have. Per-argument help must therefore describe the flag
+    /// without naming the binary.
+    ///
+    /// The command-level `long_about` is deliberately exempt, and is not walked
+    /// here: a wrapper replaces it wholesale, so its EXAMPLES block is the right
+    /// home for worked `fgumi sort` invocations.
+    #[test]
+    fn test_arg_help_does_not_name_the_binary() {
+        let command = Sort::command();
+
+        // Guard against a vacuous pass: an empty (or trivially short) arg walk
+        // would satisfy the loop below without checking anything.
+        let arg_count = command.get_arguments().count();
+        assert!(arg_count > 10, "expected Sort to expose its flags, walked only {arg_count}");
+
+        for arg in command.get_arguments() {
+            let help = format!(
+                "{} {}",
+                arg.get_help().map(ToString::to_string).unwrap_or_default(),
+                arg.get_long_help().map(ToString::to_string).unwrap_or_default(),
+            );
+            assert!(
+                !names_the_binary(&help),
+                "help for `--{}` names the `fgumi` binary; describe the flag instead and put \
+                 worked invocations in the command-level EXAMPLES block. Help was: {help}",
+                arg.get_id()
+            );
+        }
+    }
 
     // ========================================================================
     // Temp-dir resolution tests


### PR DESCRIPTION
`Sort` is designed to be pulled into other binaries with `#[command(flatten)]`, which means its **per-argument** help renders under a program name that is not `fgumi`. So a concrete `fgumi ...` invocation in per-argument help tells those users to run a command they do not have.

`--sort-threads` (added in #608) was doing exactly that:

```
Defaults to `--threads`. Lower this to cede cores to an upstream producer while keeping
the merge wide -- e.g. in `bwa mem -t 32 ... | fgumi sort -@ 8 --sort-threads 4`, ingest
competes with the aligner but the merge does not.
```

It was also the only per-argument doc in `Sort` carrying a concrete invocation — every other one already lives in the command-level EXAMPLES block. So this is a consistency fix rather than a special case.

## What changed

**The pipeline example moves to EXAMPLES**, alongside the other twelve invocations:

```
  # Cede cores to the aligner during ingest, but keep the merge wide
  bwa mem -t 32 ref.fa r1.fq r2.fq | fgumi sort -i - -o sorted.bam -@ 8 --sort-threads 4
```

**The flag help now describes the flag**, and states the mechanism the old text left implicit (`the merge does not`):

```
Defaults to `--threads`. Lower this to cede cores to an upstream producer while keeping
the merge wide -- with `-@ 8 --sort-threads 4`, ingest contends with the producer over
only 4 threads, while the merge still uses 8 because it cannot start until the input is
exhausted, by which point the producer has finished writing.
```

That rationale is checked against the engine, not assumed: `RawExternalSorter::enter_output_phase` is called "exactly once, immediately after ingest completes," so it holds on every sort path, not just the spilling one.

**`--order` had a milder version of the same thing** — `` `queryname::lexicographical` Alias; fgumi emits `queryname:lexicographical` in @HD SS `` — now written passively (`Alias; written as ...`). Same information, and it stays true of any binary embedding the engine.

## Regression guard

`test_arg_help_does_not_name_the_binary` walks every argument's short and long help and rejects the binary name, so this cannot creep back in. It asserts a non-trivial arg count first, so an empty walk cannot pass vacuously.

I confirmed the test has teeth by temporarily reintroducing `fgumi sort` into the `--sort-threads` help: it fails and names the offending flag.

```
help for `--sort_threads` names the `fgumi` binary; describe the flag instead and put
worked invocations in the command-level EXAMPLES block. Help was: ...
```

## What is deliberately left alone

The command-level `long_about` still contains many `fgumi sort` invocations, and the test does not walk it. A wrapper replaces `long_about` wholesale, so it never reaches a downstream `--help` — which makes it the correct home for worked invocations. The exemption is documented on the test so the asymmetry reads as a decision rather than an oversight.

## Verification

```
cargo ci-fmt      # clean
cargo ci-lint     # clean (workspace, all-targets, -D warnings -W clippy::pedantic)
cargo ci-test     # 6881 tests run: 6881 passed, 27 skipped
cargo ci-doctest  # clean
```

Docs-only change to user-facing help text plus one new test; no behavior change. `grep -rn sort-threads docs/` is empty, so there is no mdbook copy of this text to keep in sync.

## Motivation

Surfaced while bumping the downstream [`mako`](https://github.com/fg-labs/mako) sorter (a thin `Sort`-flattening wrapper) to fgumi 0.5.0: `mako --help` began advertising a `fgumi sort` invocation. Before this change its `--help` contained one such invocation; after, none — every remaining mention is in `long_about`, which `mako` replaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed `sort` command help text with clearer examples and improved wording for `--order` and `--sort-threads` options.

* **Tests**
  * Added a new test to verify that per-argument help output does not include the command name, ensuring cleaner and more consistent help text presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->