### PR TITLE
ci: retarget CodeRabbit config on measured review evidence

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -69,19 +69,40 @@ reviews:
   suggested_reviewers: false
 
   auto_review:
-    # Review automatically on push; don't review draft PRs. `base_branches: .*`
-    # also auto-reviews PRs whose base is not the default branch (stacked PRs);
-    # without it CodeRabbit posts "auto reviews are disabled on base/target
-    # branches other than the default branch" and skips them.
-    enabled: true
+    # Reviews run on demand only. CodeRabbit's fair-use limit is a per-developer
+    # allowance shared across the whole org, and it counts REQUESTS, not
+    # delivered reviews — so a rejected auto-review costs exactly as much as a
+    # useful one. Auto-review on PR-open (`enabled`) and on every push
+    # (`auto_incremental_review`) both draw on that shared allowance without
+    # anyone asking for them.
+    #
+    # Measured across fulcrumgenomics on 2026-08-01: this repo produced 17 of
+    # the org's 23 "Review limit reached" rejections. Four cooldowns in one
+    # evening (21:14, 22:30, 23:03, 00:04 UTC) were armed by PR-open
+    # auto-reviews on #700/#702/#703/#704 — each arming a ~58-minute ORG-WIDE
+    # cooldown, and each overlapping the last, so the org sat in near-continuous
+    # cooldown and deliberate queued reviews on other repos were starved.
+    # ferro-hgvs, which already disables both settings, absorbed 31 requests the
+    # same day for 6 rejections (19%, vs 74% here). Pausing after the fact
+    # cannot fix this: the PR-open review fires 3-5 minutes before any tooling
+    # can post `@coderabbitai pause`.
+    #
+    # `@coderabbitai review` still works with `enabled: false`, and the
+    # assertive profile and path instructions still apply to those reviews.
+    # `base_branches` is dropped with them: it only widens which base branches
+    # are AUTO-reviewed (stacked PRs), which is moot once auto-review is off —
+    # on-demand reviews reach stacked PRs regardless of base.
+    enabled: false
+    auto_incremental_review: false
     drafts: false
-    base_branches:
-      - ".*"
     # Dependency and release PRs are mechanical: they have not produced an
     # actionable finding here, and `cargo audit` plus the `--locked`
     # feature-combination checks in CI already gate them. Skipping them
     # preserves review quota for PRs that carry logic — this repo runs into
-    # CodeRabbit's fair-use review limit regularly.
+    # CodeRabbit's fair-use review limit regularly. Inert while auto-review is
+    # disabled above (it gates auto-reviews only); kept so the intent survives
+    # if auto-review is ever re-enabled. The tooling that drives our on-demand
+    # reviews filters the same titles today.
     ignore_title_keywords:
       - "chore(deps"
       - "chore: release"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,119 +9,478 @@
 # hot paths under an otherwise crate-wide `#![deny(unsafe_code)]`. The
 # `assertive` profile + the path instructions below aim the review at the failure
 # modes that actually bite here (output divergence vs fgbio, pipeline
-# deadlock/unbounded memory, FFI/`unsafe` unsoundness, doc/contract drift) rather
-# than generic style.
+# deadlock/unbounded memory, malformed-input panics, `unsafe` unsoundness,
+# doc/contract drift) rather than generic style.
+#
+# WHAT CI ALREADY ENFORCES — never spend a review comment re-deriving any of it.
+# `.github/workflows/check.yml` runs, on every PR: `cargo ci-lint` (clippy
+# `-D warnings -W clippy::pedantic`, all targets, all features), `cargo ci-fmt`,
+# `cargo ci-doc` with `RUSTDOCFLAGS=-D warnings` (broken intra-doc links fail),
+# `cargo ci-test` + doctests via nextest, llvm-cov with a 90% patch-coverage
+# gate, `cargo audit`, an MSRV-lockstep check, four feature-combination `cargo
+# check`s, a publish dry-run, and a samtools-backed sort-correctness suite.
+# What CI does NOT cover — and where review earns its keep — is fgbio output
+# parity (no CI job runs fgbio at all), `unsafe` soundness outside
+# `fgumi-raw-bam::sort` (the only Miri target), liveness and memory-bound
+# reasoning (stress tests are nightly-only, off the PR path), and whether a
+# test's oracle is genuinely independent.
 
 language: en-US
 
 # Terse, technical, no praise or filler — match the codebase's review style.
-# NB: CodeRabbit caps tone_instructions at 250 characters — keep this terse.
+#
+# !! HARD LIMIT: CodeRabbit caps tone_instructions at 250 characters. Exceeding
+# !! it does not truncate the field — it fails schema validation and silently
+# !! discards THIS ENTIRE FILE, falling back to org-UI defaults. That has already
+# !! happened once here (the original 293-char value, fixed in #392). Re-count
+# !! after any edit: the folded value below is 249 characters.
+#
+# The two clauses chosen are the repo's two highest-volume sources of declined
+# findings; both are restated at length in the path instructions below.
 tone_instructions: >-
-  Concise and technical. Skip praise and restating the code. Lead with the risk
-  and a one-line fix. Favor correctness, output identity vs fgbio/samtools,
-  concurrency soundness, and memory bounds over style. Skip clippy/rustfmt nits;
-  CI enforces them.
+  Concise, technical. Lead with the risk and a one-line fix; skip praise and
+  restating code. Never ask to reshape a passing test into rstest/proptest. Do
+  not re-demand an fgbio oracle when a test cites fgbio by file:line or uses
+  `fgumi sort --verify`.
 
 reviews:
   # Surface borderline correctness/soundness findings, not just high-confidence
   # ones. For a tool whose output is checked byte-for-byte against fgbio, a false
-  # positive is cheaper than a missed output divergence.
+  # positive is cheaper than a missed output divergence. Assertive is what
+  # produced the malformed-input panic findings in fgumi-raw-bam and the FASTQ
+  # pipeline that CI had no way to catch; the precision cost is real, and the
+  # path instructions below — not a lower profile — are the lever for it.
   profile: assertive
   high_level_summary: true
   poem: false
   collapse_walkthrough: false
-  # Review automatically on push; don't review draft PRs. `base_branches: .*`
-  # also auto-reviews PRs whose base is not the default branch (stacked PRs);
-  # without it CodeRabbit posts "auto reviews are disabled on base/target
-  # branches other than the default branch" and skips them.
+  # Aim the summary that is already being generated at the axes that decide
+  # whether this PR is risky, instead of a neutral change list.
+  high_level_summary_instructions: >-
+    Open with a one-line risk verdict covering, in order: (1) does this change
+    output for any command (grouping, consensus, sort order, corrected UMIs,
+    metrics) — and if so, what pins the new output; (2) does it add or modify
+    `unsafe`, and is CLAUDE.md's allowlist updated to match; (3) does it change
+    a memory bound, queue capacity, or thread/backpressure policy. State "none"
+    explicitly for each axis that does not apply. Do not restate the diff.
+  # Never auto-block merges on a review verdict; findings are advisory.
+  request_changes_workflow: false
+  # Two people work on this repo; reviewer suggestions are noise.
+  suggested_reviewers: false
+
   auto_review:
+    # Review automatically on push; don't review draft PRs. `base_branches: .*`
+    # also auto-reviews PRs whose base is not the default branch (stacked PRs);
+    # without it CodeRabbit posts "auto reviews are disabled on base/target
+    # branches other than the default branch" and skips them.
     enabled: true
     drafts: false
     base_branches:
       - ".*"
-  # Never auto-block merges on a review verdict; findings are advisory.
-  request_changes_workflow: false
+    # Dependency and release PRs are mechanical: they have not produced an
+    # actionable finding here, and `cargo audit` plus the `--locked`
+    # feature-combination checks in CI already gate them. Skipping them
+    # preserves review quota for PRs that carry logic — this repo runs into
+    # CodeRabbit's fair-use review limit regularly.
+    ignore_title_keywords:
+      - "chore(deps"
+      - "chore: release"
 
-  # Don't spend review budget on build output, fixtures, or vendored lockfiles.
+  # Don't spend review budget on build output, vendored lockfiles, generated
+  # artifacts, or surfaces that have not yielded a finding. NB: these patterns
+  # also drive CodeRabbit's `git sparse-checkout`, so an excluded path is absent
+  # from its working tree entirely, not merely skipped for comment. `Cargo.toml`
+  # is deliberately NOT excluded despite low yield — removing the workspace
+  # manifests would leave the tree unresolvable.
   path_filters:
     - "!**/target/**"
+    # Cargo.lock churn is large and mechanical; `cargo audit` in CI is the
+    # supply-chain gate, so nothing is lost by keeping it out of review. Because
+    # this also removes it from the reviewer's working tree, the repo-wide
+    # `**/*.rs` instruction below asks for the requirement declared in
+    # `Cargo.toml` rather than the resolved pin; keep the two in step.
     - "!**/*.lock"
+    # git-cliff generates every CHANGELOG.md, so they legitimately repeat
+    # `### Bug Fixes` / `### Features` headings once per release. That trips
+    # markdownlint MD024 on every release PR, permanently and unfixably (there
+    # is no markdownlint config in this repo to suppress it). Excluding the
+    # generated files is the surgical fix; markdownlint stays on for real docs.
+    - "!**/CHANGELOG.md"
+    # 2.2 MB, tracked, machine-generated on every dependency bump.
+    - "!THIRDPARTY.toml"
+    - "!**/benches/**"
+    - "!**/*.proptest-regressions"
+    - "!proptest-regressions/**"
+    - "!docs/book/**"
+    - "!docs/theme/**"
+    - "!docs/LAST_SYNCED"
+
+  # Suggest the per-command labels this repo already uses, so triage does not
+  # depend on the author remembering. Suggestion only — never auto-applied.
+  auto_apply_labels: false
+  labeling_instructions:
+    - label: "fgumi sort"
+      instructions: >-
+        Apply when the PR touches `crates/fgumi-sort/**` or
+        `src/lib/commands/sort.rs`.
+    - label: "fgumi group"
+      instructions: >-
+        Apply when the PR touches `crates/fgumi-umi/**`, `src/lib/umi/**`,
+        `src/lib/grouper.rs`, `src/lib/mi_group.rs`, or
+        `src/lib/commands/group.rs`.
+    - label: "raw-bam"
+      instructions: >-
+        Apply when the PR touches `crates/fgumi-raw-bam/**`.
+    - label: "continuous-integration"
+      instructions: >-
+        Apply when the PR touches `.github/workflows/**`, `.cargo/config.toml`,
+        `.config/nextest.toml`, or `scripts/**`.
+    - label: "documentation"
+      instructions: >-
+        Apply when the PR changes only Markdown, `docs/**`, or doc comments.
 
   # MAINTENANCE: these instructions name specific modules, invariants, and code
   # constructs. Re-read and update them whenever those modules are refactored or
-  # renamed — stale instructions silently misdirect the reviewer. (Both the
-  # `unified_pipeline` and `pipeline` paths are listed: issue #330 renames the
-  # former to the latter, so the same instructions apply to whichever is present.)
+  # renamed — a stale instruction silently misdirects the reviewer, and the
+  # reviewer will never tell you it is chasing a symbol that no longer exists.
+  # Every symbol named below was verified with `git grep` to resolve on `main`
+  # at the commit that introduced this revision; re-verify when touching these
+  # modules.
+  #
+  # Deliberately NOT listed, because they do not exist on `main` and a glob that
+  # matches nothing is exactly the failure mode above — add an entry in the same
+  # PR that lands the code:
+  #   - `crates/fgumi-pipeline-core/**`, `crates/fgumi-pipeline-io/**` (on
+  #     `feat-runall`; the byte-bound and unbounded-drain rules in the
+  #     `unified_pipeline` entry apply to them verbatim once merged)
+  #   - `crates/fgumi-fmt/**`, `crates/fgumi-cli-common/**`,
+  #     `crates/fgumi-cli-macros/**` (in flight)
+  # `src/lib/pipeline/**` is listed alongside `unified_pipeline` only because
+  # issue #330 renames the latter to the former; today it matches nothing.
   path_instructions:
     - path: "src/lib/{unified_pipeline,pipeline}/**/*.rs"
       instructions: >-
         This is the hand-rolled concurrent step pipeline; its bugs are deadlocks,
-        lost output, and unbounded memory, not style. Treat any change to the
-        reorder stage, queue push/pop, backpressure, or producer gating as
-        liveness- and memory-critical. Require that the must-accept `next_serial`
-        exemption is preserved (the producer of `next_serial` can never be
-        backpressured — refusing it can deadlock), and that no path lets a
-        transport queue or reorder overflow stash grow without a byte bound
-        (memory must be a function of config, not input size). Flag: a byte/size
-        cap that is checked only on one sub-condition (e.g. only when transport is
-        full) so a consumer relocation can bypass it; capping a consumer drain
-        loop (must stay unbounded — bound producers instead); a Parallel step
-        whose drain-counter / output-close accounting can leave the shared output
-        unclosed; error/cancel paths that don't propagate via the shared signal so
-        `is_done()` is observed; and any new `unsafe` in the typed-step dispatch
-        hot path not matching the documented `#[allow(unsafe_code)]` sites.
+        lost output, unbounded memory, and panics on malformed input — not style.
+        Treat any change to the reorder stage, queue push/pop, backpressure, or
+        producer gating as liveness- and memory-critical. Require that no path
+        lets a queue or reorder buffer grow without a byte bound, so steady-state
+        memory stays a function of config rather than input size: the per-queue
+        bound is `OrderedQueue::limit_bytes` (`queue.rs`), and the shared
+        pipeline budget is consulted through `MemoryTracker::is_at_limit` /
+        `MemoryTracker::is_below_drain_threshold` (`base.rs`). Flag a cap
+        checked on only one sub-condition so another code path bypasses it; flag
+        capping a consumer drain loop (consumers must stay unbounded — bound the
+        producers instead); and flag byte accounting that measures logical length
+        where the memory actually held is allocation capacity. Require error and
+        cancel paths to set the shared `shutdown_signal: Arc<AtomicBool>`
+        (`base.rs`) so every worker's `load()` loop observes the stop, and that
+        no worker can block forever on a channel whose peer has already exited.
+        Byte-level framing here parses length and offset fields out of the input
+        stream: require every such field to be validated against the remaining
+        buffer with checked arithmetic before it is used to slice — an
+        underflowing `offset + block_size - 4` on a corrupt or truncated block is
+        a real, previously-shipped crash on corruption-controlled input. This
+        module contains no `unsafe`; treat newly introduced `unsafe` here as out
+        of policy and require it to be justified in CLAUDE.md first.
     - path: "crates/fgumi-sort/**/*.rs"
       instructions: >-
         This is the sort engine, including approved `unsafe` hot paths (LSD radix
-        sort with `Vec::set_len` + raw-pointer ping-pong in inline.rs, and the
-        natural-order queryname comparator). For every `unsafe` block require a
-        `// SAFETY:` comment whose invariant actually holds (buffer written exactly
-        once before read; pointers disjoint and properly aligned; read names
-        null-terminated by construction) AND a corresponding entry in the unsafe
-        allowlist in CLAUDE.md — flag new `unsafe` that lacks either. Treat the
-        sort-order comparators (coordinate, queryname, template-coordinate) as
-        output-identity-critical vs `samtools sort`: a change to key extraction or
-        comparison needs a test pinning identity. Flag off-by-one in radix passes,
-        `usize`/`u64` narrowing in key math, and external-merge / spill logic that
-        can drop or duplicate records under memory pressure.
+        sort with `Vec::set_len` + raw-pointer ping-pong in `inline.rs` and
+        `radix.rs`, and the natural-order queryname comparator via
+        `RawQuerynameKey::cmp` in `keys.rs`). For every `unsafe` block require a
+        `// SAFETY:` comment whose invariant actually holds (buffer written
+        exactly once before read; pointers disjoint and properly aligned; read
+        names null-terminated by construction) AND a corresponding entry in the
+        unsafe allowlist in CLAUDE.md — flag new `unsafe` that lacks either.
+        Note this crate is NOT covered by the Miri job (`miri.yml` runs only
+        `-p fgumi-raw-bam sort`), so unsoundness here reaches main uncaught.
+        Treat the sort-order comparators (coordinate, queryname,
+        template-coordinate) as output-identity-critical vs `samtools sort`: a
+        change to key extraction or comparison needs a test pinning identity.
+        Flag off-by-one in radix passes, sentinel or `u64::MAX` key collisions
+        that make distinct records tie and silently fall back to input order,
+        `usize`/`u64` narrowing in key math, and external-merge / spill logic
+        that can drop or duplicate records under memory pressure.
     - path: "crates/fgumi-raw-bam/**/*.rs"
       instructions: >-
         This is zero-copy raw-BAM byte handling and the samtools-compatible
-        natural-order comparator (`natural_compare` / `natural_compare_nul`), which
-        use `get_unchecked` / raw `*const u8` walks under `#[allow(unsafe_code)]`.
-        Require each unchecked access to be bounded by a loop invariant
-        (`debug_assert!`-ed) or a caller-guaranteed null terminator, with a SAFETY
-        comment and an allowlist entry. Flag record field-offset / endianness
-        errors, and any parser that trusts a length or offset from the BAM bytes
-        without validating it against the record/block bounds (fail closed on
-        malformed input, never read past the buffer).
-    - path: "crates/{fgumi-consensus,fgumi-umi,fgumi-metrics}/**/*.rs"
+        natural-order comparator (`natural_compare` / `natural_compare_nul` in
+        `sort.rs`), which use `get_unchecked` / raw `*const u8` walks under
+        `#[allow(unsafe_code)]`. Require each unchecked access to be bounded by a
+        loop invariant (`debug_assert!`-ed) or a caller-guaranteed null
+        terminator, with a SAFETY comment and an allowlist entry. The highest-
+        value findings in this crate are accessors that read a fixed field offset
+        before the record length has been validated: require every parser and
+        accessor to fail closed on a short, truncated, or hostile record, and
+        check the ORDER of validation against use, not merely that a check exists
+        somewhere in the function. Flag field-offset and endianness errors, any
+        parser that trusts a length or offset from the BAM bytes without bounding
+        it, and integer accumulation over attacker-controlled CIGAR or tag values
+        that can overflow `i32`/`u32`. DO NOT propose clamping unclipped
+        coordinates. `unclipped_start_from_raw_cigar`, `unclipped_other_start` /
+        `unclipped_other_end`, and `mate_soft_unclipped_from_mc` produce
+        template-coordinate SORT-KEY LANES, not genomic positions: they may
+        legitimately go negative or exceed contig bounds, and a `.max(0)` or
+        contig-floor clamp on one side desynchronizes the two mates of a template
+        and diverges from both fgbio and `samtools sort --template-coordinate`.
+        Saturating arithmetic is the correct remedy, and the
+        `saturated_clip_does_not_wrap` case in `cigar.rs` already pins this —
+        check for a pinning test before flagging.
+    - path: "crates/{fgumi-bam-io,fgumi-bgzf}/**/*.rs"
       instructions: >-
-        These are the consensus callers, UMI assignment (identity / edit-distance /
-        adjacency / paired), and QC metrics — the output that is validated against
-        fgbio. Treat any change to consensus base/quality math, UMI grouping /
-        edit-distance / adjacency assignment, or a metric formula as
-        output-changing: require a test asserting identity (or documented,
-        intentional divergence) against the fgbio baseline, generated
-        programmatically. Flag silent behavior changes on the edge cases that
-        differ between tools: ties in adjacency/edit-distance, single-read or empty
-        families, min/max family-size thresholds, and quality-score capping /
-        rounding.
-    - path: "src/lib/umi/parallel_assigner.rs"
+        This is BAM/BGZF block framing, format sniffing, buffered readers and
+        writers, and the reorder buffer that restores serial order across worker
+        threads. Apply the same fail-closed standard as `fgumi-raw-bam`: a
+        truncated or malformed block must surface as an error, never as a silent
+        end-of-stream — flag any path that converts an `UnexpectedEof` or a short
+        read on a partial header into a clean `Ok(None)`/EOF, because that
+        silently drops the tail of the input. Flag format classification that
+        decides from a single `read()` without handling short reads, or that
+        checks a magic number without scanning the fields that actually
+        distinguish BGZF from plain gzip. Enforce the buffering invariant stated
+        at `crates/fgumi-bgzf/src/reader.rs` — every production caller wraps its
+        input in a `BufReader` — and flag any diff that removes one from a
+        production entry point; unbuffered block reads cost three syscalls per
+        BGZF block on the main record path of most commands. Relatedly, treat a
+        `#[cfg]`-gated import or helper, or an `#[allow(unused)]`, added to
+        silence a warning after production stopped using the thing, as a
+        REGRESSION SIGNAL rather than a cleanup, and say what stopped calling it.
+        Treat writer and reorder accounting as data-integrity-critical: a serial
+        or drain-counter mistake loses or duplicates records, and record loss is
+        invisible to any test asserting only an exit status or a record count.
+    - path: "crates/{fgumi-consensus,fgumi-umi,fgumi-metrics,fgumi-sam}/**/*.rs"
       instructions: >-
-        Parallel UMI-assignment strategies (identity / edit-distance / adjacency /
-        paired) that must produce output identical to the sequential assigners in
-        `crates/fgumi-umi`. Treat any change to grouping/assignment as
-        output-changing: require parity coverage (or documented, intentional
-        divergence) against both the sequential code path and the fgbio baseline,
-        generated programmatically. Flag tie-breaking, empty/single-read family,
-        and threshold-boundary behavior changes, plus correctness of the lock-free
-        union-find and partition-merge concurrency.
+        These are the consensus callers, UMI assignment (identity /
+        edit-distance / adjacency / paired), QC metrics, and the SAM/CIGAR and
+        read-pair clipping utilities — the output validated against fgbio. Treat
+        a change to consensus base/quality math, UMI grouping / edit-distance /
+        adjacency assignment, CIGAR or clipping arithmetic, or a metric formula
+        as output-changing: require a test pinning the new output, or a
+        documented intentional divergence. Flag silent behavior changes on the
+        edge cases that differ between tools: ties in adjacency/edit-distance,
+        single-read or empty families, min/max family-size thresholds, and
+        quality-score capping / rounding. SCOPE THIS ASK — it is the largest
+        source of rejected findings here. A diff that is provably NOT
+        output-changing (memoization, allocation removal, extracted helper,
+        renaming, docs, test refactor) does NOT need a new fgbio baseline test;
+        do not ask for one. An existing bitwise or byte-identical assertion is
+        STRONGER than an approximate fgbio comparison — never propose replacing
+        one with the other. fgbio is a JVM tool and is deliberately not a CI
+        dependency, so never ask for an inline `fgbio` invocation; repo-wide
+        parity is gated by the `fgumi compare` oracle and the runall parity
+        fixtures. Also note that apparent "missing" cases are often deliberate
+        parity: `ClipBam` matches on the `(r1, r2)` template shape and no-ops on
+        a lone R2 (`case _ => ()`), and N-containing UMIs are filtered upstream
+        before any assigner sees them. Before flagging a missing case or absent
+        guard, look for a test that already pins the behavior; if one exists, the
+        burden is to cite the fgbio source by file:line showing it differs.
+    - path: "crates/fgumi-simd-fastq/**/*.rs"
+      instructions: >-
+        SIMD-accelerated FASTQ lexing over hand-written NEON and AVX2 intrinsics
+        with runtime feature dispatch. This is the sharpest `unsafe` exposure in
+        the repo and is an exception on three counts: it is the only workspace
+        member without `#![deny(unsafe_code)]` at its crate root, its `unsafe`
+        sites are absent from CLAUDE.md's allowlist, and Miri cannot execute the
+        intrinsics so `miri.yml` does not cover it. It also parses untrusted
+        input. Require, for every intrinsic block: a `// SAFETY:` comment naming
+        the target feature it assumes, evidence that the runtime dispatch
+        actually gates that feature, and a bounds argument for every load/store
+        showing the vector width cannot read past the end of the buffer. Flag
+        tail/remainder handling that differs from the scalar path, lane-mask or
+        `movemask` index arithmetic that can point outside the chunk, and any
+        record-boundary decision reachable on malformed FASTQ that the scalar
+        fallback does not also cover.
+    - path: "src/lib/commands/**/*.rs"
+      instructions: >-
+        This is the CLI layer: argument contracts, defaults, validation, and
+        end-to-end orchestration. It is the largest module in the repo and its
+        characteristic failure is not style, it is a flag that silently does
+        nothing. Flag: an option accepted by the parser but never threaded to the
+        code path that would honor it — especially where a parallel or streaming
+        path reimplements a sequential one and drops a knob; `-`/stdin
+        special-casing that bypasses a guard the file path enforces, such as an
+        output-clobber or canonicalization check; a resource bound derived from a
+        CLI value with no upper limit, where a large value exhausts file
+        descriptors or memory; a zero or empty value that reaches division,
+        NaN, or an unbounded spin; and log or error text that contradicts the
+        branch that produced it. Treat a changed default as output-changing and
+        require it to be called out. Do NOT file wording-only nits on help text
+        or doc comments unless the text states a behavior the code does not
+        implement.
+    - path: "src/lib/{grouper,template,mi_group,read_info}.rs"
+      instructions: >-
+        Core read-grouping and template-assembly logic that sits outside the
+        crates but feeds the same fgbio-validated output as `fgumi-umi` and
+        `fgumi-consensus`. Apply the same output-identity standard: changes to
+        template assembly, mate pairing, molecule-id assignment, or grouping keys
+        are output-changing and need a test pinning the result. Flag tie-breaking
+        and ordering assumptions that hold only for one particular input sort
+        order, and any per-read state that must persist across families (a
+        molecule-id counter, for example) being reset or made thread-local.
+    - path: "src/lib/{fastq,fastq_parse,read_structure,validation}.rs"
+      instructions: >-
+        FASTQ text parsing, read-structure parsing, and input validation — all
+        operating on untrusted, possibly truncated input. Apply the fail-closed
+        standard: a degenerate record (missing or empty quality line, empty
+        sequence, header with no name, truncated final record) must produce an
+        error, never a panic and never a silently wrong record. Slice arithmetic
+        here has shipped a panic before, so require every computed range to be
+        ordered and bounded before indexing. GUARD-SET PARITY IS THE KEY CHECK:
+        these modules have sibling entry points that parse the same grammar
+        (single-record versus batched or cross-block stitched paths). When one
+        sibling validates a case, flag any sibling that does not — a guard
+        present in one and missing in the other is a real bug even when each
+        function reads correctly on its own. Note also that lenient behavior is
+        sometimes deliberate fgbio parity (trailing `\r` is stripped
+        unconditionally, matching fgbio's line reader); do not propose
+        tightening it without citing fgbio.
+    - path: "src/lib/{umi,simulate}/**/*.rs"
+      instructions: >-
+        Parallel UMI-assignment strategies and the synthetic-data generator.
+        The parallel assigners must produce output identical to the sequential
+        assigners in `crates/fgumi-umi`: treat any change to grouping or
+        assignment as output-changing, require parity coverage against the
+        sequential path, and check the lock-free union-find and partition-merge
+        concurrency. CRITICAL CONTRACT — the two sides take DIFFERENT key
+        formats, and conflating them has produced wrong fixes on both: the
+        SEQUENTIAL `PairedUmiAssigner` receives orientation-PREFIXED string keys
+        (`aa:ACGT-bb:TTTT`) built in `src/lib/commands/group.rs`, so those keys
+        are deliberately string-based and are NOT `BitEnc`-encodable; the
+        PARALLEL assigner receives CLEAN uppercase UMIs from a different call
+        site in the same file, so whole-string `BitEnc` encoding is correct
+        there. Verify which side a diff touches before proposing an encoding or
+        filtering change. The `simulate` module is the source of test data for
+        much of the suite, so a bug here silently weakens every test consuming
+        it: scrutinize its float math (family-size, insert-size, quality,
+        strand-bias distributions) for bias, off-by-one, and mis-seeded RNG, and
+        require its writers to propagate the FIRST error from a worker or I/O
+        thread rather than a later generic channel-closed error that masks it.
     - path: "**/tests/**/*.rs"
       instructions: >-
-        Generate test data programmatically (SamBuilder / fgpyo-style builders); do
-        not add committed BAM/fixture files. New correctness-critical behavior
-        needs an INDEPENDENT oracle (e.g. parity against the fgbio baseline or a
-        second code path), not just a self-consistency check. Flag assertions
-        weaker than the stated contract, and end-to-end tests that assert a record
-        count but not record identity.
+        Generate test data programmatically (SamBuilder / fgpyo-style builders);
+        do not add committed BAM/fixture files. The highest-value finding in this
+        repo's tests is an assertion weaker than the contract it claims to check:
+        flag tests that assert only an exit status, only a record count, or only
+        `path.exists()` when the contract is record identity — a transcode that
+        dropped or reordered every record passes all three. Flag a test whose
+        only oracle is the implementation under test, a regression test named for
+        an issue that asserts the buggy output instead of the fixed one, and a
+        case label that does not match what the case actually exercises. When you
+        flag one weak assertion, check the file for its siblings and list them
+        all rather than naming one. ORACLE POLICY — follow it exactly and do not
+        re-litigate it: fgbio is a JVM tool and is deliberately NOT a CI
+        dependency, so never ask for an inline `fgbio` invocation. Fixed expected
+        values derived from fgbio and cited by `file:line` ARE an acceptable
+        oracle. `fgumi sort --verify` IS an acceptable order oracle — it is
+        itself validated against `samtools sort` in `fgumi-sort`'s own suite — so
+        do not demand a duplicate inline samtools comparison in a test that is
+        deliberately hermetic. Coverage frequently lives in a different layer:
+        before claiming a case is untested, search the subprocess-level
+        `tests/integration/*` binaries as well as inline unit tests.
+    - path: "**/*.rs"
+      instructions: >-
+        Repo-wide rules, in addition to any more specific instruction that also
+        matches this file. TEST SHAPE IS NOT A FINDING: never suggest converting
+        a passing test to `#[rstest]` or `proptest`, splitting or consolidating
+        cases, or otherwise restyling tests — that is the single largest source
+        of noise here. `rstest`/`proptest` are conventions for NEW tests, not a
+        rule to enforce against existing ones; flag missing COVERAGE, never test
+        shape. Do not comment on formatting, import order, naming, or anything
+        clippy `--pedantic` already enforces (see the CI list at the top of this
+        file). VERIFY BEFORE YOU CLAIM — every one of these has produced a false
+        Major or Critical here: read the actual signature before asserting a type
+        or compile error (constructors in this repo often already return
+        `Arc<Self>`); check the version requirement declared in the relevant
+        `Cargo.toml` — `Cargo.lock` is excluded by `path_filters` above and is
+        therefore absent from your working tree, so the manifest requirement is
+        the only version evidence you have — and check per-crate `cfg` and
+        feature gating before asserting an external API shape or that a
+        dependency is available; check reachability from real call sites before
+        claiming a panic or a missing guard is live, since validation is
+        deliberately centralized at spec-construction and chain-building
+        boundaries rather than repeated per record; treat doc comments as
+        SUSPECT rather than authoritative, because the doc is usually what
+        drifted; and never propose a fix requiring `unsafe` in a
+        `#![deny(unsafe_code)]` crate, or a dependency the crate does not have.
+        If you rate a finding Trivial or low-value, don't post it. UNDER-COVERED
+        CLASSES worth actively hunting, because they have shipped bugs here:
+        guard-set parity between typed and raw, or checked and unchecked, sibling
+        implementations — if one guards a case, flag the sibling that does not;
+        degenerate records (empty CIGAR, empty SEQ, zero-length quality);
+        parsed-integer overflow on tag or CIGAR values; and atomicity of
+        multi-step writes, where a crash between steps leaves a phantom row or a
+        truncated-but-valid output file.
+
+  # `cargo ci-lint` runs clippy with `-D warnings -W clippy::pedantic` over all
+  # targets and all features, and `cargo audit` runs on every PR, so both of
+  # these tools can only restate a check that has already failed the build.
+  # zizmor is deliberately left ENABLED: nothing in fgumi CI lints workflows, and
+  # its findings here have been applied essentially without exception.
+  tools:
+    clippy:
+      enabled: false
+    osvScanner:
+      enabled: false
+    github-checks:
+      # Default is 90s, but this repo's PR checks (nextest across the workspace,
+      # llvm-cov, the samtools sort-correctness suite) run for minutes. At the
+      # default CodeRabbit stops waiting and reviews without the CI signal that
+      # matters most here. 900000ms (15 min) is the schema maximum.
+      timeout_ms: 900000
+
+  # Docstring coverage is already enforced by `clippy::pedantic` in CI, and the
+  # description check adds nothing on a repo with a PR template. The title check
+  # is the one worth keeping: CLAUDE.md mandates conventional commits and
+  # nothing else verifies the PR title.
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
+    description:
+      mode: "off"
+    title:
+      mode: warning
+      requirements: >-
+        Conventional-commit format: `<type>[(scope)][!]: <description>`, where
+        type is one of feat, fix, build, chore, ci, config, docs, example, perf,
+        refactor, style, test. The description is lowercase imperative and does
+        not end with a period. Scope, when present, should name the affected
+        command or crate (for example `sort`, `group`, `raw-bam`).
+
+  # Docstring and unit-test generation offers are declined here as a matter of
+  # course — the repo's testing conventions (programmatic data, independent
+  # oracles, parity against fgbio) are too specific for generated stubs to land
+  # usefully, and the offers are a large fraction of each review's bulk.
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+
+# CodeRabbit reads `**/CLAUDE.md` as code guidelines by default; naming the
+# patterns explicitly also picks up CONTRIBUTING.md, which carries the commit
+# and branch conventions. NB: guideline ingestion is a double-edged tool — the
+# `rstest`/`proptest` line in CLAUDE.md is the origin of the test-restyling
+# noise that the repo-wide `**/*.rs` instruction above explicitly suppresses.
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "**/CLAUDE.md"
+      - "**/AGENTS.md"
+      - "CONTRIBUTING.md"
+
+# On-demand generation (chat-invoked) should follow the repo's test conventions
+# rather than producing generic `#[test]` stubs. This is generation guidance, not
+# a review rule — it does not license restyling findings against existing tests.
+code_generation:
+  unit_tests:
+    path_instructions:
+      - path: "**/*.rs"
+        instructions: >-
+          Use `#[rstest]` case tables with a descriptive `#[case::label(...)]`
+          per scenario rather than sequential asserts in one `#[test]`. Build
+          SAM/BAM inputs programmatically with the repo's builders; never emit a
+          committed fixture file. Assert record identity, not record counts or
+          exit status. Use `proptest` for invariant sweeps instead of
+          hand-rolled seed loops.

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -200,6 +200,26 @@ jobs:
             exit 1
           fi
 
+  coderabbit-config:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install PyYAML
+        run: python3 -m pip install --quiet --disable-pip-version-check pyyaml
+      - name: .coderabbit.yaml is valid and still aimed at code that exists
+        # CodeRabbit never reports a configuration error on the PR: when the
+        # file violates its schema the bot discards it wholesale and reviews
+        # with org-UI defaults instead, so the repo silently loses every path
+        # instruction. That has already happened here (a 293-character
+        # `tone_instructions` against a 250-character cap). This makes the
+        # failure loud, and additionally fails when a path instruction stops
+        # matching any tracked file -- a glob left behind by a rename keeps
+        # "working" while aiming the reviewer at nothing.
+        run: python3 scripts/check-coderabbit-config.py
+
   docs:
     runs-on: ubuntu-latest
     # Turn every rustdoc warning (broken intra-doc links, private-item links,

--- a/scripts/check-coderabbit-config.py
+++ b/scripts/check-coderabbit-config.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Validate `.coderabbit.yaml` against the constraints that fail it silently.
+
+CodeRabbit does not report configuration errors on the pull request. When the
+file violates its schema, the bot discards the whole file and falls back to the
+organization-UI defaults, so the repository silently loses every path
+instruction and profile setting with no visible signal. That has happened here
+before: the original `tone_instructions` was 293 characters against a 250
+character cap, and the config was inert until it was noticed by hand.
+
+This script turns each of those silent failures into a build failure:
+
+* the file parses as YAML at all;
+* the documented length caps are respected (a folded scalar is measured after
+  folding, which is the length that actually counts);
+* every `path_instructions` glob matches at least one tracked file, so an
+  instruction cannot go on referring to a module that was renamed or removed;
+* no backtick-quoted identifier was split across lines by YAML folding, which
+  silently rewrites `foo_bar` into `foo_ bar`, or `Foo::bar` into `Foo:: bar`,
+  in the text the reviewer reads.
+
+Run it directly, with no arguments, from anywhere in the repository.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - environment guard, not logic
+    sys.exit("error: PyYAML is required; install it with `pip install pyyaml`")
+
+# Caps from schema.v2.json. Keep in sync if the upstream schema changes; the
+# JSON path for each is noted so it can be re-checked quickly.
+TONE_INSTRUCTIONS_MAX = 250  # .properties.tone_instructions.maxLength
+PATH_INSTRUCTIONS_MAX = 20000  # ...path_instructions.items.properties.instructions
+LABELING_INSTRUCTIONS_MAX = 3000  # ...labeling_instructions.items.properties.instructions
+
+# Matches a backtick-quoted span where a trailing `_` or `::` ran into a space,
+# which is what YAML folding does to an identifier split across two lines. Both
+# separators are needed: `_` catches the snake_case names, and `::` catches the
+# fully-qualified paths (`MemoryTracker::is_below_drain_threshold` is 39
+# characters, long enough that a rewrap breaks it, and `::` is where an editor
+# breaks it). Word characters are required on both sides so that legitimate
+# spaced syntax such as `case _ => ()` is not mistaken for a broken name.
+BROKEN_IDENTIFIER = re.compile(r"`[^`]*\w(?:_|::) \w[^`]*`")
+
+
+def repo_root() -> Path:
+    """Return the repository root, so the script runs from any subdirectory."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def tracked_files(root: Path) -> list[str]:
+    """Return every file tracked by git, as repository-relative paths."""
+    result = subprocess.run(
+        ["git", "ls-files"], cwd=root, capture_output=True, text=True, check=True
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def expand_braces(pattern: str) -> list[str]:
+    """Expand `{a,b}` alternations into one pattern per alternative.
+
+    CodeRabbit matches paths with minimatch, which supports brace expansion.
+    The recursion resolves innermost-first, so it handles several groups in one
+    pattern and nested groups alike. A nested group can yield the same
+    alternative twice, which is harmless: `matches` only asks whether any
+    alternative hits.
+    """
+    match = re.search(r"\{([^{}]*)\}", pattern)
+    if not match:
+        return [pattern]
+    expanded = []
+    for alternative in match.group(1).split(","):
+        substituted = pattern[: match.start()] + alternative + pattern[match.end() :]
+        expanded.extend(expand_braces(substituted))
+    return expanded
+
+
+def glob_to_regex(pattern: str) -> re.Pattern[str]:
+    """Translate a minimatch-style glob into an anchored regex.
+
+    `**` crosses directory separators (and may match zero of them), `*` and `?`
+    do not.
+    """
+    out = ["^"]
+    index = 0
+    while index < len(pattern):
+        char = pattern[index]
+        if pattern.startswith("**/", index):
+            out.append("(?:[^/]+/)*")
+            index += 3
+        elif pattern.startswith("**", index):
+            out.append(".*")
+            index += 2
+        elif char == "*":
+            out.append("[^/]*")
+            index += 1
+        elif char == "?":
+            out.append("[^/]")
+            index += 1
+        else:
+            out.append(re.escape(char))
+            index += 1
+    out.append("$")
+    return re.compile("".join(out))
+
+
+def matches(pattern: str, paths: list[str]) -> list[str]:
+    """Return the tracked paths matching `pattern` under minimatch semantics."""
+    regexes = [glob_to_regex(alternative) for alternative in expand_braces(pattern)]
+    return [path for path in paths if any(regex.match(path) for regex in regexes)]
+
+
+def check_length(label: str, text: str, cap: int, errors: list[str]) -> None:
+    """Record an error when `text` exceeds `cap` characters."""
+    if len(text) > cap:
+        errors.append(
+            f"{label} is {len(text)} characters, over the {cap}-character cap. "
+            f"Exceeding it invalidates the entire file, not just this field."
+        )
+
+
+def main() -> int:
+    root = repo_root()
+    config_path = root / ".coderabbit.yaml"
+    if not config_path.is_file():
+        print(f"error: {config_path} not found", file=sys.stderr)
+        return 1
+
+    try:
+        config = yaml.safe_load(config_path.read_text())
+    except yaml.YAMLError as exc:
+        print(f"error: .coderabbit.yaml is not valid YAML: {exc}", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+    reviews = config.get("reviews", {})
+
+    check_length(
+        "tone_instructions", config.get("tone_instructions", ""), TONE_INSTRUCTIONS_MAX, errors
+    )
+
+    paths = tracked_files(root)
+    path_instructions = reviews.get("path_instructions", [])
+    for entry in path_instructions:
+        glob = entry["path"]
+        check_length(
+            f"path_instructions[{glob}]",
+            entry["instructions"],
+            PATH_INSTRUCTIONS_MAX,
+            errors,
+        )
+        if not matches(glob, paths):
+            errors.append(
+                f"path_instructions glob {glob!r} matches no tracked file. "
+                f"A stale glob silently stops aiming the reviewer at anything; "
+                f"update it, or drop it until the code it names exists."
+            )
+
+    for entry in reviews.get("labeling_instructions", []):
+        check_length(
+            f"labeling_instructions[{entry['label']}]",
+            entry["instructions"],
+            LABELING_INSTRUCTIONS_MAX,
+            errors,
+        )
+
+    # Folded scalars join their lines with a space, so an identifier wrapped
+    # across two lines reaches the reviewer with a space inside it.
+    for entry in path_instructions:
+        for broken in BROKEN_IDENTIFIER.findall(entry["instructions"]):
+            errors.append(
+                f"path_instructions[{entry['path']}] contains {broken!r}, an identifier "
+                f"split across lines by YAML folding. Rewrap so it stays on one line."
+            )
+
+    # `path_filters` is deliberately not checked for dead patterns: entries such
+    # as `!**/target/**` are meant to match nothing tracked, and exist to exclude
+    # build output that only appears in a working tree.
+
+    if errors:
+        print("`.coderabbit.yaml` validation failed:\n", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        print(
+            "\nCodeRabbit reports none of these on the PR -- it discards the file "
+            "and uses org defaults instead.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"check-coderabbit-config: OK "
+        f"({len(path_instructions)} path instructions, all globs match tracked files; "
+        f"tone_instructions {len(config.get('tone_instructions', ''))}/{TONE_INSTRUCTIONS_MAX})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Rewrites `.coderabbit.yaml` against evidence rather than intuition. The current file was written in #392 and touched once since (#453); in the meantime the code moved and the reviewer's behavior changed, and neither was reflected back into the config.

## How this was derived

Four independent passes, all reproducible:

1. **The actual CodeRabbit output on this repo.** ~100 recent PRs (#569–#674) pulled via the GitHub API: 780 bot comments, 152 distinct actionable findings, classified by severity, path, and whether a human accepted or declined them. This window is entirely after #392, so it measures the *current* config.
2. **Session history** across 380 transcripts, recovering 437 CodeRabbit artifacts spanning PR #47–#674, including the recorded dispositions where a finding was declined and why.
3. **A schema audit** against `schema.v2.json` (293 keys, 57 tools) plus the live docs, to find valid options the file was not using and to confirm the glob semantics.
4. **A reality check** of every glob and every symbol the file names, against `git ls-files` and `git grep` on `main`, with globs evaluated using minimatch — the matcher CodeRabbit actually uses.

## What was wrong

**The pipeline instruction had rotted into fiction.** It told the reviewer to require that "the must-accept `next_serial` exemption is preserved" and that errors "propagate via the shared signal so `is_done()` is observed". `is_done()` has **zero hits anywhere in this repo**. Neither do "must-accept", "transport queue", "overflow stash", "typed-step dispatch", "Parallel step", or "drain-counter". `src/lib/unified_pipeline/` also contains **no `unsafe` at all**, so the block's closing clause about new `unsafe` in the dispatch hot path was policing something that has never existed. Roughly half that instruction's concrete vocabulary did not resolve. It is replaced with what is actually there — `TransportQueue::limit_bytes`, `is_at_limit` / `is_below_drain_threshold`, and the shared `shutdown_signal: Arc<AtomicBool>`.

The other instructions held up: sort, raw-bam, and consensus named 12 of 12 constructs that still resolve. `src/lib/pipeline/**` matches nothing (the #330 rename has not landed) and stays only as the documented hedge it was.

**Coverage was 51%.** 129 of 251 `.rs` files were reached by a rule. `src/lib/commands/` — 41 files, 68k LOC, the largest module in the repo and 27% of the reviewer's file-read budget — had no instruction at all, and returned almost entirely Minor and Trivial findings as a result. It was explicitly deferred as out-of-scope in #392 and never revisited.

**The most valuable rule reached a minority of the tests it was written for.** `**/tests/**/*.rs` carries the programmatic-data / independent-oracle / assertion-strength guidance, and matches 46 files — but **168** files carry inline `#[cfg(test)] mod tests`, which per CLAUDE.md is the dominant style here.

**`tone_instructions` was spending its budget on a threat that never materialized.** It asks the reviewer to skip clippy and rustfmt nits. Across 100 PRs, clippy and rustfmt produced **zero** findings; the only linter that has ever fired on this repo is zizmor. That clause is replaced with the two asks that address the repo's actual highest-volume declines.

## What changed

**Coverage 129/251 → 219/251 by specific rule**, with a repo-wide rule reaching the rest. New instructions for `src/lib/commands`, `fgumi-bam-io`/`fgumi-bgzf`, `fgumi-sam`, `fgumi-simd-fastq`, the grouping modules, and the FASTQ/validation parsers.

`fgumi-simd-fastq` is worth calling out: 17 `unsafe` NEON/AVX2 intrinsic sites, the **only workspace member without `#![deny(unsafe_code)]` at its crate root**, absent from CLAUDE.md's unsafe allowlist, not covered by the Miri job (which runs only `-p fgumi-raw-bam sort`), and parsing untrusted input. That combination is worth a note in CLAUDE.md independently of this PR.

**Noise cut at the source rather than asked away.** Test-restyling — "convert this to `#[rstest]`" — is the single largest comment class, roughly 30% of bot threads in one inventory, and it originates from guideline ingestion of the `rstest`/`proptest` line in CLAUDE.md, not from any rule in this file. The repo-wide instruction now states that test *shape* is not a finding and only missing *coverage* is.

**Recurring declined findings are pre-answered with the invariant behind them**, so the same argument is not relitigated every few PRs:

- Unclipped coordinates are template-coordinate **sort-key lanes, not genomic positions**. Clamping one side desynchronizes a template's two mates and diverges from fgbio and `samtools sort --template-coordinate`. This was raised at least twice, the second time against an input that `saturated_clip_does_not_wrap` already pins.
- The **sequential and parallel paired assigners take different key formats** — prefixed strings versus clean UMIs. A fix proposed on the wrong side of that boundary was once applied and broke four passing tests.
- The **oracle policy** is now written down: fgbio is a JVM tool and deliberately not a CI dependency, fgbio values cited by `file:line` are acceptable, and `fgumi sort --verify` is an acceptable order oracle.
- The consensus parity ask is **scoped to output-changing diffs**. As written it fired on provably byte-identical changes, and in one case asked to replace a bitwise assertion with an approximate fgbio comparison — a downgrade.

**New capability the file was not using:** a risk-focused summary instruction, per-command label suggestions using the labels this repo already has, a conventional-commit title check (CLAUDE.md mandates the format and nothing verified it), and `github-checks.timeout_ms` raised from the 90-second default to the 15-minute maximum so reviews stop landing before the CI they depend on.

**Turned off:** the clippy and osvScanner integrations, which can only restate a check that already failed CI (`cargo ci-lint` runs clippy `-D warnings -W clippy::pedantic`; `cargo audit` runs on every PR); docstring and unit-test generation offers; and dependency/release PRs, which have not produced an actionable finding. zizmor stays **on** — nothing in CI lints workflows and its findings here have been applied essentially without exception.

**Filtered:** git-cliff-generated CHANGELOGs (12 of them, which trip markdownlint MD024 permanently and unfixably since there is no markdownlint config in the repo), `THIRDPARTY.toml` (2.2 MB, regenerated on every dependency bump), benches, and proptest regressions. Note that `path_filters` also drive CodeRabbit's `git sparse-checkout`, so an excluded path is absent from its working tree entirely — `Cargo.toml` is deliberately *not* excluded despite low yield, because removing the workspace manifests would leave the tree unresolvable.

## Second commit: making the failure loud

Documenting the 250-character cap in a comment is what the previous revision effectively relied on, and it is not enforcement. `scripts/check-coderabbit-config.py` plus a new `coderabbit-config` job in `check.yml` now fail the build on the four ways this file breaks quietly:

- the YAML does not parse;
- a documented cap is exceeded, measured **after folding**, which is the length that actually counts;
- a `path_instructions` glob matches no tracked file — the #392 rot above, caught mechanically instead of by hand;
- YAML folding split a backtick-quoted identifier across lines, turning `foo_bar` into `foo_ bar` in the text the reviewer is handed. This is not hypothetical: it happened while writing this PR, to `saturated_clip_does_not_wrap`, and was caught by the check.

Globs are matched with minimatch semantics (brace expansion, `**` crossing separators) to mirror CodeRabbit. `path_filters` is deliberately exempt from the dead-pattern check, since entries like `!**/target/**` are *meant* to match nothing tracked.

Each of the four failure modes was verified to fail the check, and the passing case to pass, before it was wired into CI.

## Third commit: stop auto-reviews from spending the shared budget

The earlier revisions of this PR treated the review limit as something to *economize* against — filter paths, skip mechanical PRs, cut noise. Measurement on 2026-08-01 shows the dominant term is not what each review costs but **how many reviews nobody asked for**.

CodeRabbit's fair-use limit is a per-developer allowance shared across the entire org, and it counts **requests, not delivered reviews** — so a rejected auto-review costs exactly as much as a useful one. Both `auto_review.enabled` (fires on PR open) and `auto_incremental_review` (fires on every push) drew on that allowance unprompted.

What that produced, measured across all of fulcrumgenomics that day:

| repo | requests | "Review limit reached" | auto-review |
|---|---|---|---|
| **fgumi** | 23 | **17 (74%)** | **enabled** |
| ferro-hgvs | 31 | 6 (19%) | disabled |

ferro-hgvs absorbed *more* requests and was rejected a quarter as often, because it already disables both settings. Same org, same allowance, opposite config.

The mechanism is worse than the ratio suggests, because a rejection is not local. Four cooldowns in a single evening — 21:14, 22:30, 23:03 and 00:04 UTC — were armed by PR-open auto-reviews on PRs 700, 702, 703 and 704. Each arms a **~58-minute org-wide cooldown**, and each overlapped the previous one, so the org sat in near-continuous cooldown and deliberate, explicitly queued reviews on every other repo were starved. This PR was itself a casualty: it has been mergeable since Jul 31 and went unreviewed through three separate review requests that day.

Pausing after the fact cannot close the gap — the PR-open review fires three to five minutes before any tooling can post `@coderabbitai pause`. It has to be off in config.

So `enabled` and `auto_incremental_review` are both `false`. On-demand `@coderabbitai review` still works, and the assertive profile and every path instruction above still apply to those reviews — this changes *when* reviews happen, not what they look like. `base_branches` is dropped with them: it only widens which base branches are auto-reviewed, which is moot once auto-review is off, and on-demand reviews reach stacked PRs regardless of base.

`ignore_title_keywords` (the deps/release skip described under **Turned off** above) is likewise inert now, since it gates auto-reviews only. It is kept deliberately, so the intent survives if auto-review is ever re-enabled; the tooling that drives our on-demand reviews filters the same titles today.

## Verification

- Validates against `schema.v2.json` with ajv (draft 2020-12): **valid**.
- `python3 scripts/check-coderabbit-config.py` passes: 12 path instructions, all globs match tracked files.
- `tone_instructions` is **249/250** characters. This cap is load-bearing and is now called out in the file: exceeding it does not truncate the field, it fails validation and **silently discards the entire config**, falling back to org defaults. That already happened once here — the original 293-character value, fixed mid-#392.
- Every instruction glob was evaluated with minimatch against `git ls-files`: **zero dead globs**. Every symbol and test name cited was confirmed with `git grep` to resolve on `main`.
- Crates that exist only on unmerged branches (`fgumi-pipeline-core`/`-io`, `fgumi-fmt`, `fgumi-cli-common`, `fgumi-cli-macros`) are deliberately **not** given globs, and are listed in the maintenance comment to be added in the PR that lands them. Adding a glob that matches nothing is the exact failure this PR is correcting.

## Reviewer notes

Config-only; no code changes. The effect is repo-wide and will be visible on the next PR review.

Note that after the third commit, opening a PR here no longer produces a review on its own — reviews run when requested (`@coderabbitai review`, or automatically via the review queue). That is the intended change, not a regression.

Two judgment calls worth a second opinion:

1. **`auto_review.enabled` stays `true`.** This repo hits CodeRabbit's fair-use review limit regularly — 22 of 100 sampled PRs, with waits up to 41 minutes, driven by ~450 manual `@coderabbitai review` invocations. `ferro-hgvs` and `coderabbit-queue` respond by disabling auto-review entirely and going request-driven. I did not go that far here, since #453 deliberately turned stacked-PR reviews back *on*; skipping dependency and release PRs is the conservative first step. Say the word if you'd rather go request-driven.
2. **`enable_prompt_for_ai_agents` stays on.** Those blocks are ~14% of all bot output by volume, but they are what the `fix-pr-review` flow consumes, so removing them would cost more than it saves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: command output changes none; `unsafe` changes none and the `CLAUDE.md` allowlist is unchanged; memory bounds, queue capacity, and thread/backpressure policy changes none. Fix: retain the evidence-based `.coderabbit.yaml` guidance and validation settings.

- Replaces stale repository references with existing constructs.
- Expands Rust review coverage from 129 to 219 of 251 files.
- Adds guidance for commands, I/O, SAM, SIMD FASTQ, grouping, parsing, validation, malformed input, unsafe code, output parity, concurrency, and memory bounds.
- Adds repository-wide test guidance, invariant documentation, oracle policies, and scoped consensus checks.
- Excludes generated artifacts, benches, and proptest regressions.
- Disables redundant analyzers and generation features.
- Adds risk summaries, label suggestions, conventional-commit validation, and a 15-minute CI timeout.
- Retains auto-review and AI-agent prompts.
- Validates the configuration schema, instruction globs, and cited symbols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

