### PR TITLE
fix(simd-fastq): bring the SIMD lexer under the crate-wide unsafe policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,45 @@ regresses `samtools sort -n`–style throughput.
     SAFETY: the buffers are `to_vec()` + push, so the pointer is valid and
     null-terminated for the call's lifetime.
 
+### Approved SIMD intrinsics (fgumi-simd-fastq)
+
+`crates/fgumi-simd-fastq/src/lexer.rs` classifies 64-byte FASTQ blocks through
+hand-written NEON (aarch64) and AVX2 (`x86_64`) intrinsics, with a scalar
+fallback. All `unsafe` in the crate is confined to this one file. It is approved
+because the lexer runs once per 64 bytes of every FASTQ processed (billions of
+blocks on production inputs) and the scalar fallback — retained and exercised in
+tests as the reference implementation — is materially slower.
+
+Calling a `#[target_feature]` function is `unsafe` because the caller must
+guarantee the CPU supports that feature; the intrinsics themselves are then safe
+within it. Two obligations therefore apply at every site, and both are recorded
+in `// SAFETY:` comments:
+
+- **Feature availability.** `lex_block` / `lex_block_full` dispatch on the
+  architecture. On aarch64 NEON is architecturally mandatory, so the precondition
+  is unconditional. On `x86_64` every AVX2 call is guarded by
+  `is_x86_feature_detected!("avx2")` with a scalar `else` branch.
+- **Load bounds.** The only memory accesses are vector loads from
+  `block.as_ptr()`, where `block: &[u8; 64]`. NEON issues four 16-byte
+  `vld1q_u8` loads at offsets 0/16/32/48; AVX2 issues two 32-byte
+  `_mm256_loadu_si256` loads at offsets 0 and 32. Both cover exactly 64 bytes and
+  no more. Both use unaligned load forms, so no alignment beyond `u8` is
+  required.
+
+Seven `#[allow(unsafe_code)]` sites: the two public dispatch functions
+(`lex_block`, `lex_block_full`), the NEON helpers (`neon_movemask`,
+`lex_block_newlines_neon`, `lex_block_neon`), and the AVX2 implementations
+(`lex_block_newlines_avx2`, `lex_block_avx2`). The nested `neon_two_bits` /
+`avx2_two_bits` helpers are covered by the lexically-enclosing allow.
+
+Note that Miri cannot execute these intrinsics, so `miri.yml` does not cover
+this crate. Correctness rests instead on the scalar-parity tests in `lexer.rs`,
+which assert the SIMD and scalar lexers agree:
+`test_simd_matches_scalar_newlines`, `test_simd_full_matches_scalar_all_fields`,
+`test_simd_full_matches_scalar_all_acgt`, and
+`test_simd_full_matches_scalar_every_position`. Any change to the intrinsic
+paths must keep these passing on both architectures.
+
 Any new `unsafe` site must extend this list and explain why the safe
 alternative is unacceptable. Do not introduce `unsafe` outside the crates
 listed in this section.

--- a/crates/fgumi-simd-fastq/src/lexer.rs
+++ b/crates/fgumi-simd-fastq/src/lexer.rs
@@ -17,15 +17,24 @@ use crate::bitmask::FastqBitmask;
 /// This is the fast path for record boundary detection. Use [`lex_block_full`]
 /// when ACGT classification and 2-bit encoding are also needed.
 #[inline]
+#[allow(unsafe_code)]
 pub fn lex_block(block: &[u8; 64]) -> u64 {
     #[cfg(target_arch = "aarch64")]
     {
+        // SAFETY: NEON is architecturally mandatory on aarch64, so the
+        // `target_feature(enable = "neon")` precondition holds unconditionally
+        // on this branch. `block` is a `&[u8; 64]`, satisfying the callee's
+        // requirement that it may read exactly 64 bytes from `block.as_ptr()`.
         unsafe { lex_block_newlines_neon(block) }
     }
 
     #[cfg(target_arch = "x86_64")]
     {
         if is_x86_feature_detected!("avx2") {
+            // SAFETY: guarded by the `is_x86_feature_detected!("avx2")` check
+            // immediately above, which is the callee's `target_feature`
+            // precondition. `block` is a `&[u8; 64]`, so the 64 bytes the
+            // callee reads from `block.as_ptr()` are all in bounds.
             unsafe { lex_block_newlines_avx2(block) }
         } else {
             lex_block_newlines_scalar(block)
@@ -44,15 +53,24 @@ pub fn lex_block(block: &[u8; 64]) -> u64 {
 /// (e.g., for UMI extraction in a fused pipeline).
 #[inline]
 #[must_use]
+#[allow(unsafe_code)]
 pub fn lex_block_full(block: &[u8; 64]) -> FastqBitmask {
     #[cfg(target_arch = "aarch64")]
     {
+        // SAFETY: NEON is architecturally mandatory on aarch64, so the
+        // `target_feature(enable = "neon")` precondition holds unconditionally
+        // on this branch. `block` is a `&[u8; 64]`, satisfying the callee's
+        // requirement that it may read exactly 64 bytes from `block.as_ptr()`.
         unsafe { lex_block_neon(block) }
     }
 
     #[cfg(target_arch = "x86_64")]
     {
         if is_x86_feature_detected!("avx2") {
+            // SAFETY: guarded by the `is_x86_feature_detected!("avx2")` check
+            // immediately above, which is the callee's `target_feature`
+            // precondition. `block` is a `&[u8; 64]`, so the 64 bytes the
+            // callee reads from `block.as_ptr()` are all in bounds.
             unsafe { lex_block_avx2(block) }
         } else {
             lex_block_scalar(block)
@@ -151,12 +169,16 @@ use std::arch::aarch64::uint8x16_t;
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
 #[inline]
+#[allow(unsafe_code)]
 unsafe fn neon_movemask(cmp: uint8x16_t) -> u64 {
     use std::arch::aarch64::{
         vaddv_u8, vcreate_u8, vget_high_u8, vget_low_u8, vmul_u8, vshrq_n_u8,
     };
 
-    // NEON intrinsics are safe to call inside a #[target_feature(enable = "neon")] function
+    // SAFETY: every intrinsic below is register-only -- none dereferences a
+    // pointer -- so the sole precondition is NEON availability, which the
+    // `target_feature(enable = "neon")` attribute makes the caller's obligation
+    // and which is architecturally guaranteed on aarch64.
     let shifted = vshrq_n_u8(cmp, 7);
     let weights = vcreate_u8(u64::from_le_bytes([1, 2, 4, 8, 16, 32, 64, 128]));
     let low = vget_low_u8(shifted);
@@ -173,9 +195,16 @@ unsafe fn neon_movemask(cmp: uint8x16_t) -> u64 {
 ///
 /// Requires NEON support (mandatory on aarch64).
 #[target_feature(enable = "neon")]
+#[allow(unsafe_code)]
 unsafe fn lex_block_newlines_neon(block: &[u8; 64]) -> u64 {
     use std::arch::aarch64::{vceqq_u8, vdupq_n_u8, vld1q_u8};
 
+    // SAFETY: NEON availability is the caller's obligation via `target_feature`.
+    // The only memory access is `vld1q_u8` at `block.as_ptr().add(chunk_idx * 16)`
+    // for `chunk_idx` in `0..4`, reading 16 bytes each: the last load starts at
+    // offset 48 and ends at 64, exactly the length of the `&[u8; 64]`, so every
+    // load is in bounds. `vld1q_u8` is an unaligned load, so no alignment is
+    // required beyond that of `u8`.
     unsafe {
         let newline = vdupq_n_u8(b'\n');
         let mut result: u64 = 0;
@@ -196,6 +225,7 @@ unsafe fn lex_block_newlines_neon(block: &[u8; 64]) -> u64 {
 ///
 /// Requires NEON support (mandatory on aarch64).
 #[target_feature(enable = "neon")]
+#[allow(unsafe_code)]
 unsafe fn lex_block_neon(block: &[u8; 64]) -> FastqBitmask {
     use std::arch::aarch64::{
         vandq_u8, vceqq_u8, vdupq_n_u8, vld1q_u8, vorrq_u8, vqtbl1q_u8, vshrq_n_u8,
@@ -280,11 +310,17 @@ const fn byte_as_i8(b: u8) -> i8 {
 ///
 /// Requires AVX2 support.
 #[target_feature(enable = "avx2")]
+#[allow(unsafe_code)]
 unsafe fn lex_block_newlines_avx2(block: &[u8; 64]) -> u64 {
     use std::arch::x86_64::{
         _mm256_cmpeq_epi8, _mm256_loadu_si256, _mm256_movemask_epi8, _mm256_set1_epi8,
     };
 
+    // SAFETY: AVX2 availability is the caller's obligation via `target_feature`,
+    // enforced at both call sites by `is_x86_feature_detected!("avx2")`. The two
+    // `_mm256_loadu_si256` loads read 32 bytes from offsets 0 and 32 of a
+    // `&[u8; 64]`, covering exactly the array and no more. The `loadu` form is
+    // an unaligned load, so the `__m256i` alignment requirement does not apply.
     unsafe {
         let newline = _mm256_set1_epi8(i8::from_ne_bytes([b'\n']));
         let v1 = _mm256_loadu_si256(block.as_ptr().cast());
@@ -302,6 +338,7 @@ unsafe fn lex_block_newlines_avx2(block: &[u8; 64]) -> u64 {
 ///
 /// Requires AVX2 support (checked by caller via `is_x86_feature_detected!`).
 #[target_feature(enable = "avx2")]
+#[allow(unsafe_code)]
 unsafe fn lex_block_avx2(block: &[u8; 64]) -> FastqBitmask {
     use std::arch::x86_64::{
         __m256i, _mm256_and_si256, _mm256_cmpeq_epi8, _mm256_loadu_si256, _mm256_movemask_epi8,

--- a/crates/fgumi-simd-fastq/src/lib.rs
+++ b/crates/fgumi-simd-fastq/src/lib.rs
@@ -26,6 +26,11 @@
 //! assert_eq!(records[0].sequence, b"ACGT");
 //! ```
 
+// Every `unsafe` in this crate is confined to the SIMD intrinsic paths in
+// `lexer.rs`, which carry a targeted `#[allow(unsafe_code)]` and a `// SAFETY:`
+// note; see the fgumi-simd-fastq section of CLAUDE.md for the allowlist.
+#![deny(unsafe_code)]
+
 mod bitmask;
 mod lexer;
 mod parser;


### PR DESCRIPTION
CLAUDE.md states that `#![deny(unsafe_code)]` is set at the crate root of every workspace member. It was not. `fgumi-simd-fastq` was the sole exception, so its `unsafe` sites were the only ones in the workspace that could be added or changed without tripping the lint or showing up in the allowlist.

Found while auditing `.coderabbit.yaml` (#675), which needed an accurate picture of where `unsafe` lives.

## Why this crate in particular

The exposure was the sharpest in the repo rather than the mildest:

- `lexer.rs` carries **17 `unsafe` occurrences** across hand-written NEON and AVX2 intrinsics with runtime feature dispatch.
- It parses **untrusted input** — FASTQ record boundaries straight off a byte stream.
- **Miri cannot execute intrinsics**, and `miri.yml` runs only `-p fgumi-raw-bam sort`, so nothing in CI checks this crate for unsoundness.
- It appeared **nowhere in CLAUDE.md**, so anyone auditing the unsafe surface by reading the allowlist would not have found it.
- The crate had **no `// SAFETY:` comments at all** — not one, anywhere.

## What changed

Attributes, comments, and docs only. No behavior change, no logic touched.

- `#![deny(unsafe_code)]` at the crate root, matching every sibling.
- Seven targeted `#[allow(unsafe_code)]`: the two public dispatch functions (`lex_block`, `lex_block_full`), the three NEON helpers (`neon_movemask`, `lex_block_newlines_neon`, `lex_block_neon`), and the two AVX2 implementations (`lex_block_newlines_avx2`, `lex_block_avx2`). The nested `neon_two_bits` / `avx2_two_bits` helpers are covered by the lexically-enclosing allow rather than repeating it.
- A `// SAFETY:` comment per site. Calling a `#[target_feature]` function is `unsafe` because the caller must guarantee CPU support; the intrinsics are then safe within it. So each comment discharges exactly two obligations:
  - **Feature availability** — NEON is architecturally mandatory on aarch64, so that precondition is unconditional; every AVX2 call is guarded by `is_x86_feature_detected!("avx2")` with a scalar `else` branch.
  - **Load bounds** — the only memory accesses are vector loads from `block.as_ptr()` where `block: &[u8; 64]`. NEON issues four 16-byte `vld1q_u8` loads at offsets 0/16/32/48; AVX2 issues two 32-byte `_mm256_loadu_si256` loads at 0 and 32. Both cover exactly 64 bytes and no more, and both use unaligned load forms, so no alignment beyond `u8` is required.
- A CLAUDE.md allowlist section for the crate, recording the approval rationale, the absence of Miri coverage, and the four scalar-parity tests that stand in for it.

With this change CLAUDE.md's claim is true rather than aspirational — all **14** workspace crate roots were checked individually.

## Verification

- `cargo ci-fmt`, `cargo ci-lint` (clippy `-D warnings -W clippy::pedantic`): clean.
- `cargo ci-test`: **6890 passed**, 27 skipped.
- `cargo nextest run -p fgumi-simd-fastq`: 50 passed.
- **Both architectures compiled, not assumed.** Four of the seven allow sites and one SAFETY note are on AVX2 code that is `cfg`'d out on the aarch64 dev machine, so `cargo check -p fgumi-simd-fastq --target x86_64-apple-darwin` was run to compile that half. Both pass.
- **The deny was negative-tested**: removing a single `#[allow(unsafe_code)]` fails the build with `error: usage of an unsafe block`, confirming the lint is live rather than decorative.

## Note on what this does and does not buy

This closes a *policy* gap: new `unsafe` in this crate now has to be deliberate and has to be justified in CLAUDE.md, the same as everywhere else. It does not by itself prove the existing intrinsics sound — the bounds arguments above were derived by reading the loads, and Miri still cannot check them. If we want that, the options are a fuzz target over `lex_block_full` or asserting SIMD/scalar agreement under `proptest` rather than the fixed inputs used today. Happy to file that separately if it's worth doing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for reviewing and maintaining SIMD implementations, including CPU feature checks, memory safety, and scalar-parity testing.

* **Refactor**
  * Clarified safety guarantees around architecture-specific SIMD processing.
  * Restricted unsafe code to documented SIMD paths while preserving existing behavior and public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->