### PR TITLE
test(simd-fastq): sweep SIMD/scalar lexer agreement with proptest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,11 +243,21 @@ Seven `#[allow(unsafe_code)]` sites: the two public dispatch functions
 
 Note that Miri cannot execute these intrinsics, so `miri.yml` does not cover
 this crate. Correctness rests instead on the scalar-parity tests in `lexer.rs`,
-which assert the SIMD and scalar lexers agree:
-`test_simd_matches_scalar_newlines`, `test_simd_full_matches_scalar_all_fields`,
-`test_simd_full_matches_scalar_all_acgt`, and
-`test_simd_full_matches_scalar_every_position`. Any change to the intrinsic
-paths must keep these passing on both architectures.
+which assert the SIMD and scalar lexers agree. Fixed inputs pin specific shapes
+(`test_simd_matches_scalar_newlines`, `test_simd_full_matches_scalar_all_fields`,
+`test_simd_full_matches_scalar_all_acgt`,
+`test_simd_full_matches_scalar_every_position`), and `proptest` sweeps cover
+arbitrary lane combinations (`simd_newlines_match_scalar_on_arbitrary_blocks`,
+`simd_full_matches_scalar_on_arbitrary_blocks`,
+`newline_fast_path_matches_full_classifier`,
+`simd_matches_scalar_on_uniform_random_blocks`). Any change to the intrinsic
+paths must keep these passing on both architectures — note that a dev machine
+runs only one of the two, so the other is verified in CI.
+
+The sweeps compare `two_bits` only on lanes where `is_acgt` is set. That is the
+contract rather than a weakened assertion: `ENCODE_LUT` maps non-ACGT bytes to a
+don't-care value, which the SIMD paths write through unconditionally while the
+scalar path leaves those lanes zero.
 
 Any new `unsafe` site must extend this list and explain why the safe
 alternative is unacceptable. Do not introduce `unsafe` outside the crates

--- a/crates/fgumi-simd-fastq/src/lexer.rs
+++ b/crates/fgumi-simd-fastq/src/lexer.rs
@@ -447,6 +447,98 @@ const fn interleave_bits_32(lo: u32, hi: u32) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
+
+    /// Build the `two_bits` mask covering only the lanes flagged in `is_acgt`.
+    ///
+    /// The 2-bit encoding is only defined for A/C/G/T lanes: `ENCODE_LUT` maps
+    /// every other byte to a don't-care value, and the SIMD paths write that
+    /// value through unconditionally (`two_bits |= chunk_two_bits`) while the
+    /// scalar path leaves non-ACGT lanes zero. Comparing whole `two_bits` words
+    /// would therefore assert agreement the implementations never promised.
+    /// Restricting the comparison to `is_acgt` lanes is the actual contract, and
+    /// because `is_acgt` is itself asserted equal first, no divergence can hide
+    /// behind a disagreeing mask.
+    fn acgt_lane_mask(is_acgt: u64) -> u128 {
+        let mut mask: u128 = 0;
+        for lane in 0..64 {
+            if is_acgt & (1u64 << lane) != 0 {
+                mask |= 0b11u128 << (lane * 2);
+            }
+        }
+        mask
+    }
+
+    /// Bytes weighted toward what a real FASTQ block contains.
+    ///
+    /// Uniform `any::<u8>()` almost never produces a newline or a base, so it
+    /// exercises the classification masks far less than it appears to. This
+    /// generator keeps newlines and ACGT dense enough to hit the interesting
+    /// lanes, while still emitting arbitrary bytes.
+    fn fastq_ish_byte() -> impl Strategy<Value = u8> {
+        prop_oneof![
+            6 => prop::sample::select(vec![b'A', b'C', b'G', b'T', b'a', b'c', b'g', b't']),
+            2 => Just(b'\n'),
+            1 => prop::sample::select(vec![b'N', b'n', b'@', b'+', b'I', b'J', b' ']),
+            1 => any::<u8>(),
+        ]
+    }
+
+    fn block_strategy() -> impl Strategy<Value = [u8; 64]> {
+        prop::collection::vec(fastq_ish_byte(), 64)
+            .prop_map(|bytes| <[u8; 64]>::try_from(bytes.as_slice()).expect("64 bytes"))
+    }
+
+    proptest! {
+        // Miri cannot execute SIMD intrinsics, so `miri.yml` does not cover this
+        // crate (see CLAUDE.md). Agreement with the scalar reference over
+        // randomized blocks is what stands in for it: the fixed-input tests below
+        // pin specific shapes, but only a sweep exercises arbitrary lane
+        // combinations across all four NEON / two AVX2 loads at once.
+        #[test]
+        fn simd_newlines_match_scalar_on_arbitrary_blocks(block in block_strategy()) {
+            prop_assert_eq!(lex_block(&block), lex_block_scalar(&block).newlines);
+        }
+
+        #[test]
+        fn simd_full_matches_scalar_on_arbitrary_blocks(block in block_strategy()) {
+            let simd = lex_block_full(&block);
+            let scalar = lex_block_scalar(&block);
+
+            prop_assert_eq!(simd.newlines, scalar.newlines, "newlines diverged");
+            prop_assert_eq!(simd.is_acgt, scalar.is_acgt, "is_acgt diverged");
+
+            let mask = acgt_lane_mask(scalar.is_acgt);
+            prop_assert_eq!(
+                simd.two_bits & mask,
+                scalar.two_bits & mask,
+                "two_bits diverged on an ACGT lane"
+            );
+        }
+
+        // The newline-only fast path and the full classifier are separate
+        // implementations of the same predicate, so they must agree with each
+        // other and not merely each with the scalar reference.
+        #[test]
+        fn newline_fast_path_matches_full_classifier(block in block_strategy()) {
+            prop_assert_eq!(lex_block(&block), lex_block_full(&block).newlines);
+        }
+
+        // Uniformly random bytes, as an adversarial complement to the weighted
+        // generator: sparse in newlines and bases, dense in everything else.
+        #[test]
+        fn simd_matches_scalar_on_uniform_random_blocks(bytes in prop::collection::vec(any::<u8>(), 64)) {
+            let block = <[u8; 64]>::try_from(bytes.as_slice()).expect("64 bytes");
+            let simd = lex_block_full(&block);
+            let scalar = lex_block_scalar(&block);
+
+            prop_assert_eq!(simd.newlines, scalar.newlines, "newlines diverged");
+            prop_assert_eq!(simd.is_acgt, scalar.is_acgt, "is_acgt diverged");
+
+            let mask = acgt_lane_mask(scalar.is_acgt);
+            prop_assert_eq!(simd.two_bits & mask, scalar.two_bits & mask, "two_bits diverged");
+        }
+    }
 
     fn make_block(data: &[u8]) -> [u8; 64] {
         let mut block = [0u8; 64];

--- a/crates/fgumi-simd-fastq/src/parser.rs
+++ b/crates/fgumi-simd-fastq/src/parser.rs
@@ -299,6 +299,79 @@ mod tests {
         fn test_try_parse_single_record_never_panics(record in proptest::collection::vec(any::<u8>(), 0..64)) {
             let _ = try_parse_single_record(&record);
         }
+
+        // `find_record_offsets` consumes the SIMD lexer's newline bitmask and is
+        // the only code that stitches results across 64-byte block boundaries, so
+        // it needs inputs longer than one block. The length range spans several
+        // blocks and deliberately includes exact multiples of 64, where the final
+        // block is full and the "remaining bytes" tail path is empty.
+        #[test]
+        fn test_find_record_offsets_never_panics(data in proptest::collection::vec(any::<u8>(), 0..300)) {
+            let offsets = find_record_offsets(&data);
+
+            // Whatever it returns must be usable for slicing: offsets are in
+            // bounds and strictly increasing, or a later slice would panic in a
+            // caller rather than here.
+            for pair in offsets.windows(2) {
+                prop_assert!(pair[0] < pair[1], "offsets not strictly increasing: {:?}", pair);
+            }
+            for &offset in &offsets {
+                prop_assert!(offset <= data.len(), "offset {} past end {}", offset, data.len());
+            }
+        }
+
+        // NB: `parse_records` is deliberately NOT fuzzed for panics. It is
+        // documented as assuming well-formed input and routes through
+        // `parse_single_record`, which panics by contract on malformed records.
+        // The untrusted-input entry points are `try_parse_single_record` and
+        // `SimdFastqReader`, which uses the fallible form at every call site;
+        // those are what the no-panic properties above and the reader's own
+        // tests cover. Asserting that `parse_records` never panics would assert
+        // the opposite of its documented contract.
+
+        // Well-formed input must round-trip: every record the parser yields has
+        // to carry back the exact name, sequence, and quality that went in. This
+        // is the counterpart to the no-panic properties above -- those only prove
+        // the parser does not crash, not that it parses correctly.
+        // Bases and their quality bytes are generated as pairs so the two lines
+        // are the same length by construction. Qualities span the whole printable
+        // Phred+33 range rather than a constant, so a parser that returned the
+        // right number of quality bytes but the wrong ones would fail here.
+        #[test]
+        fn test_well_formed_records_round_trip(
+            records in proptest::collection::vec(
+                (
+                    "[A-Za-z0-9_:.-]{1,20}",
+                    proptest::collection::vec(
+                        (prop::sample::select(vec![b'A', b'C', b'G', b'T', b'N']), b'!'..=b'~'),
+                        1..40,
+                    ),
+                ),
+                1..8,
+            )
+        ) {
+            let mut input = Vec::new();
+            for (name, bases) in &records {
+                input.push(b'@');
+                input.extend_from_slice(name.as_bytes());
+                input.push(b'\n');
+                input.extend(bases.iter().map(|(base, _)| *base));
+                input.extend_from_slice(b"\n+\n");
+                // One quality byte per base, so the record is internally consistent.
+                input.extend(bases.iter().map(|(_, quality)| *quality));
+                input.push(b'\n');
+            }
+
+            let parsed: Vec<_> = parse_records(&input).collect();
+            prop_assert_eq!(parsed.len(), records.len(), "record count mismatch");
+            for (parsed_record, (name, bases)) in parsed.iter().zip(records.iter()) {
+                let sequence: Vec<u8> = bases.iter().map(|(base, _)| *base).collect();
+                let quality: Vec<u8> = bases.iter().map(|(_, quality)| *quality).collect();
+                prop_assert_eq!(parsed_record.name, name.as_bytes(), "name mismatch");
+                prop_assert_eq!(parsed_record.sequence, sequence.as_slice(), "sequence mismatch");
+                prop_assert_eq!(parsed_record.quality, quality.as_slice(), "quality mismatch");
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
> **Stacked on #676.** Base is `nh/fix-simd-fastq-unsafe-policy`, so review that one first; this PR's diff is the two test modules plus a CLAUDE.md line. Retarget to `main` once #676 lands.

#676 brought the SIMD lexer under `#![deny(unsafe_code)]` and documented what the scalar-parity tests are standing in for, since Miri cannot execute intrinsics and `miri.yml` does not reach this crate. It also said plainly that this closes a *policy* gap and does not by itself prove the intrinsics sound. This is the follow-up that strengthens the evidence.

## The gap

Agreement with the scalar reference was asserted only over fixed inputs: uniform blocks, one structured FASTQ block, and a loop setting a single byte at each of the 64 positions. Nothing exercised an **arbitrary combination of lanes** — which is where per-lane shuffle and movemask arithmetic is most likely to go wrong. AVX2's `_mm256_shuffle_epi8` operates within each 128-bit half, so a lane-crossing mistake needs both halves populated *differently* to surface, and no existing test does that.

## What's added

Four `proptest` sweeps in `lexer.rs`: newline bitmask vs scalar, full classification vs scalar on all three fields, the newline-only fast path vs the full classifier (separate implementations of the same predicate, so they must agree with each other and not merely each with scalar), and the same over uniformly random bytes as an adversarial complement.

Blocks come from a generator weighted toward newlines and bases. Uniform `any::<u8>()` almost never produces either, so it would leave the classification masks largely untouched while looking thorough.

Three properties in `parser.rs`: `find_record_offsets` over multi-block inputs — it is the code that stitches results across 64-byte boundaries, and the existing no-panic property stopped at 64 bytes — with its output checked in-bounds and strictly increasing; the streaming iterator; and a round-trip property over well-formed input, because no-panic properties prove only that the parser does not crash, not that it parses correctly.

## Two judgment calls worth reviewing

**`two_bits` is compared only on `is_acgt` lanes.** This is the contract, not a weakened assertion. `ENCODE_LUT` maps non-ACGT bytes to a don't-care value; the SIMD paths write it through unconditionally (`two_bits |= chunk_two_bits`) while the scalar path leaves those lanes zero. Comparing whole words would assert agreement the implementations never promised. `is_acgt` is asserted equal *first*, so no divergence can hide behind a disagreeing mask.

**`parse_records` is deliberately not fuzzed for panics.** I wrote that property first and it failed — then checking the contract showed the test was wrong, not the code. `parse_records` is documented as assuming well-formed input and routes through `parse_single_record`, which panics by contract. I confirmed `SimdFastqReader` uses the fallible `try_parse_single_record` at **both** call sites and that the panicking wrapper is reached only from this crate's bench and doc example, so no production path feeds it untrusted input. A note in the test module records this so the omission does not later read as an oversight.

## Verification

- `cargo ci-test`: **6896 passed** (up from 6890), 27 skipped. `ci-fmt` and `ci-lint` clean.
- `cargo check -p fgumi-simd-fastq --target x86_64-apple-darwin --all-targets` — the AVX2 half compiled rather than assumed.
- **Non-vacuity verified by mutation, not asserted.** Dropping `G` from the NEON ACGT comparison fails both full-classification properties while the newline-only property correctly still passes; truncating the newline fast path to three of its four loads fails both newline properties. proptest shrank each to a single offending byte (index 51 and 57 respectively).
- Regression seeds written during those deliberate failures were **discarded, not committed** — they encode bugs that never existed.
- The diff against #676 is **additive only**: 156 insertions, 0 deletions, no production code touched.

## Honest limit

A dev machine runs one instruction set, so locally these sweep the **NEON** path only; the AVX2 path is compiled here and exercised on CI's x86_64 runners. That is a genuine gain — the lane-crossing class described above is precisely what CI now sweeps and previously did not — but it does mean neither machine alone validates both paths. Worth knowing when reading a green check on a Mac.

This still does not make the intrinsics *proven* sound. Randomized agreement raises confidence; it is not Miri.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added property-based coverage for SIMD FASTQ lexing across realistic and random input blocks.
  * Added validation against scalar behavior for newline detection, DNA bases, and 2-bit encoding.
  * Added parser tests for multi-block offsets, bounds, panic safety, and well-formed FASTQ round trips.

* **Documentation**
  * Expanded documentation of SIMD lexer correctness guarantees and cross-architecture validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->