### PR TITLE
fix(duplex): count consensus reads, not templates, in --threads mode

### DIFF
--- a/crates/fgumi-consensus/src/caller.rs
+++ b/crates/fgumi-consensus/src/caller.rs
@@ -252,7 +252,10 @@ pub trait ConsensusCaller: Send + Sync {
 pub struct ConsensusCallingStats {
     /// Total number of input reads processed
     pub total_reads: usize,
-    /// Number of consensus reads generated
+    /// Number of consensus *reads* generated — not templates. A caller that emits both ends
+    /// of a pair contributes two (see [`ConsensusCallingStats::record_consensus_pair`]); a
+    /// fragment contributes one. The count is meant to equal the records written to the
+    /// output BAM.
     pub consensus_reads: usize,
     /// Number of reads filtered/rejected
     pub filtered_reads: usize,
@@ -281,6 +284,14 @@ impl ConsensusCallingStats {
     /// Records that a consensus read was created
     pub fn record_consensus(&mut self) {
         self.consensus_reads += 1;
+    }
+
+    /// Records that a consensus read pair (R1 and R2) was created.
+    ///
+    /// `consensus_reads` counts emitted *reads*, not templates, so a caller that
+    /// emits both ends of a pair must record two.
+    pub fn record_consensus_pair(&mut self) {
+        self.consensus_reads += 2;
     }
 
     /// Records that input reads were processed

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -2129,7 +2129,7 @@ impl DuplexConsensusCaller {
                             cell_tag,
                             cell_barcode.as_deref(),
                         )?;
-                        stats.record_consensus();
+                        stats.record_consensus_pair();
                         return Ok((output, stats, Vec::new()));
                     }
                     stats.record_rejection(
@@ -2183,7 +2183,7 @@ impl DuplexConsensusCaller {
                             cell_tag,
                             cell_barcode.as_deref(),
                         )?;
-                        stats.record_consensus();
+                        stats.record_consensus_pair();
                         return Ok((output, stats, Vec::new()));
                     }
                 }
@@ -2237,7 +2237,7 @@ impl DuplexConsensusCaller {
                             cell_tag,
                             cell_barcode.as_deref(),
                         )?;
-                        stats.record_consensus();
+                        stats.record_consensus_pair();
                         return Ok((output, stats, Vec::new()));
                     }
                 }

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -1183,8 +1183,7 @@ impl VanillaUmiConsensusCaller {
 
         match (r1_ok, r2_ok) {
             (true, true) => {
-                self.stats.record_consensus();
-                self.stats.record_consensus();
+                self.stats.record_consensus_pair();
                 output.extend(&r1r2_output);
             }
             (true, false) => {

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -544,10 +544,10 @@ impl Command for Duplex {
             log_overlapping_stats(&merged_overlapping_stats);
         }
 
-        // Convert stats to metrics and log
-        let mut metrics = merged_stats.to_metrics();
-        // Use local count since we tracked it during streaming
-        metrics.consensus_reads = consensus_count as u64;
+        // Convert stats to metrics and log. `consensus_reads` comes from the caller's own
+        // accounting rather than the locally tracked write count so both this path and
+        // `execute_threads_mode` report the same number for the same input.
+        let metrics = merged_stats.to_metrics();
         log_consensus_summary(&metrics);
 
         // Write statistics file if requested. Emit the same fgbio seeded key-value format as

--- a/tests/integration/test_duplex_command.rs
+++ b/tests/integration/test_duplex_command.rs
@@ -13,6 +13,7 @@ use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use rstest::rstest;
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use tempfile::TempDir;
@@ -382,6 +383,110 @@ fn test_duplex_command_with_stats() {
             "single-threaded duplex stats must emit the seeded KV row {key}:\n{stats}"
         );
     }
+}
+
+/// The reported `consensus_reads_emitted` must equal the number of consensus records
+/// actually written, in both the single-threaded and pipeline (`--threads N`) paths.
+///
+/// The duplex caller emits R1 and R2 per molecule, so a metric that counts templates
+/// rather than reads reports half the records in the output BAM.
+#[rstest]
+#[case::single_threaded(None)]
+#[case::threaded(Some("2"))]
+fn test_duplex_stats_consensus_reads_matches_records_written(#[case] threads: Option<&str>) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let stats_path = temp_dir.path().join("stats.txt");
+
+    let molecule_ids: Vec<String> = (1..=3).map(|i: i32| i.to_string()).collect();
+    let molecules = (1..=3)
+        .map(|i| create_duplex_molecule(&i.to_string(), "ACGTACGT", 30, 100 + i * 1000, 3))
+        .collect();
+    create_duplex_bam(&input_bam, molecules);
+
+    let mut args = vec![
+        "duplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--stats",
+        stats_path.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ];
+    if let Some(threads) = threads {
+        args.extend_from_slice(&["--threads", threads]);
+    }
+    Duplex::try_parse_from(args)
+        .expect("failed to parse duplex args")
+        .execute("fgumi duplex")
+        .expect("Duplex command failed");
+
+    // Independent oracle: every input molecule must yield exactly one consensus R1 and one
+    // consensus R2, so the output holds 2 records per molecule and each molecule's identity
+    // survives. A bare `records_written > 0` would accept a dropped mate, a dropped molecule,
+    // or a duplicated record whenever `consensus_reads_emitted` is wrong in the same way.
+    let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    let _header = reader.read_header().unwrap();
+    let mut records_written = 0_usize;
+    // Per molecule: (R1 count, R2 count), keyed by the molecule ID trailing the consensus
+    // read name (`<read-group-prefix>:<base MI>`).
+    let mut ends_by_molecule: HashMap<String, (usize, usize)> = HashMap::new();
+    for result in reader.records() {
+        let record = result.expect("failed to read consensus record");
+        records_written += 1;
+        let name = String::from_utf8(
+            record.name().expect("consensus record must have a read name").to_vec(),
+        )
+        .expect("consensus read name must be UTF-8");
+        let (_prefix, molecule) = name
+            .rsplit_once(':')
+            .unwrap_or_else(|| panic!("consensus read name '{name}' must be '<prefix>:<MI>'"));
+        let flags = record.flags();
+        assert!(flags.is_segmented(), "consensus record '{name}' must be paired");
+        let ends = ends_by_molecule.entry(molecule.to_string()).or_default();
+        if flags.is_first_segment() {
+            ends.0 += 1;
+        } else if flags.is_last_segment() {
+            ends.1 += 1;
+        } else {
+            panic!("consensus record '{name}' is neither R1 nor R2");
+        }
+    }
+
+    assert_eq!(
+        records_written,
+        2 * molecule_ids.len(),
+        "each of the {} input molecules must emit exactly one consensus R1 and one R2",
+        molecule_ids.len()
+    );
+    for mi in &molecule_ids {
+        assert_eq!(
+            ends_by_molecule.get(mi.as_str()).copied(),
+            Some((1, 1)),
+            "molecule {mi} must emit exactly one consensus R1 and one consensus R2, \
+             got {:?}",
+            ends_by_molecule.get(mi.as_str())
+        );
+    }
+
+    let stats = fs::read_to_string(&stats_path).expect("read stats");
+    let emitted: usize = stats
+        .lines()
+        .find_map(|line| line.strip_prefix("consensus_reads_emitted\t"))
+        .and_then(|rest| rest.split('\t').next())
+        .expect("stats must contain a consensus_reads_emitted row")
+        .parse()
+        .expect("consensus_reads_emitted must be an integer");
+
+    assert_eq!(
+        emitted, records_written,
+        "consensus_reads_emitted must count consensus reads written to the output BAM"
+    );
 }
 
 /// Verifies that the duplex consensus output BAM advertises an *unmapped consensus*


### PR DESCRIPTION
Closes #680.

`fgumi duplex --threads N` reported exactly half the consensus reads it wrote — in the log line and in the `--stats` file — while `-t 1` reported the correct number for the same input and the same (byte-identical) output BAM.

`ConsensusCallingStats::consensus_reads` counts emitted *reads*: the vanilla caller records twice for an R1/R2 pair and once for a fragment. The duplex caller instead recorded a single consensus per emitted *template* at all three of its emit sites (both-strands, AB-only, BA-only). `execute_single_threaded` masked that by overwriting `metrics.consensus_reads` with its own locally tracked write count just before logging; `execute_threads_mode` consumes the accumulated stats as-is, so the under-count surfaced only under `--threads`.

The fix corrects the accounting at its source rather than patching the reporting: `record_consensus_pair` is added alongside `record_consensus`, the duplex emit sites use it, and the single-threaded overwrite is dropped so both paths derive the metric from the same accounting.

## Verification

On a 20,000-molecule simulated duplex BAM (81,368 raw reads), before:

```console
$ fgumi duplex ... --threads 4 --stats stats-t4.txt
[INFO] Consensus reads: 10,716
$ samtools view -c out-t4.bam
21432
```

After, both `-t 1` and `-t 4` report `21,432`, matching the records in the output BAM and fgbio 4.1.0's `consensus_reads_emitted` on the same input.

New test: an rstest case table over `--threads` unset/`2` asserting the reported `consensus_reads_emitted` equals the number of records actually written. It fails on `main` for the threaded case (`3` vs `6`) and passes for both cases here.

`cargo ci-test` (6,892 tests), `cargo ci-fmt`, and `cargo ci-lint` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected consensus statistics for paired duplex and single-strand outputs.
  * Fixed single-threaded duplex metrics to report the accurate number of consensus reads emitted.

* **Tests**
  * Added coverage verifying consensus records in output files match reported statistics across threaded and single-threaded execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->