### PR TITLE
fix(duplex): restore single-strand consensus via --min-reads 1,1,0

### DIFF
--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -323,6 +323,76 @@ pub struct DuplexConsensusCaller {
     reason = "consensus calling uses numeric casts for quality/position math and has domain-specific variable names"
 )]
 impl DuplexConsensusCaller {
+    /// The `YX` (less-covered strand) minimum implied by `min_reads`.
+    ///
+    /// fgbio pads `--min-reads` to three values by repeating the last
+    /// (`padTo(3, last)`), so the `YX` threshold is the third value when one was
+    /// given and the last value otherwise. Returns `None` only for an empty
+    /// slice, which [`Self::new`] rejects.
+    #[must_use]
+    pub fn min_yx_reads_for(min_reads: &[usize]) -> Option<usize> {
+        min_reads.get(2).or_else(|| min_reads.last()).copied()
+    }
+
+    /// Whether `min_reads` lets a molecule observed on only one strand still
+    /// yield a consensus — fgbio's `-M 1 1 0` single-strand mode, i.e. a `YX`
+    /// minimum of 0.
+    ///
+    /// Callers that need this answer before a caller exists (the CLI's
+    /// overlapping-consensus gate, and the threaded path, which decides before
+    /// the per-batch caller is built) must go through here rather than
+    /// re-deriving the padding rule, so the gate cannot drift from the
+    /// `min_yx_reads` [`Self::new`] actually applies.
+    #[must_use]
+    pub fn allows_single_strand_consensus(min_reads: &[usize]) -> bool {
+        Self::min_yx_reads_for(min_reads) == Some(0)
+    }
+
+    /// Validates `min_reads` against the rule [`Self::new`] applies: 1-3 values,
+    /// ordered high to low (`total >= XY >= YX`) once fgbio's `padTo(3, last)`
+    /// has filled the missing slots. No lower bound is imposed, matching fgbio.
+    ///
+    /// [`Self::new`] delegates here, so a caller that must reject bad input
+    /// *before* a caller exists can fail fast without re-deriving the rule. The
+    /// CLI's `--threads` path is exactly that case: it builds its per-batch
+    /// caller inside the pipeline's process closure, i.e. after the output BAM
+    /// has already been created, so an ordering violation caught only there
+    /// surfaces as a wrapped I/O error from a worker and leaves a partial file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `min_reads` is empty, has more than 3 values, or the
+    /// values are not in decreasing order (`total >= XY >= YX`).
+    pub fn validate_min_reads(min_reads: &[usize]) -> Result<()> {
+        // `min_yx_reads_for` is `None` only for an empty slice, so binding it here rather
+        // than unwrapping below keeps the emptiness check in one place.
+        let (Some(&min_total_reads), Some(&last), Some(min_yx_reads)) =
+            (min_reads.first(), min_reads.last(), Self::min_yx_reads_for(min_reads))
+        else {
+            anyhow::bail!("min_reads parameter must have at least 1 value");
+        };
+        if min_reads.len() > 3 {
+            anyhow::bail!(
+                "min_reads parameter must have 1-3 values (total, [XY, [YX]]), got {} values",
+                min_reads.len()
+            );
+        }
+
+        // fgbio's `padTo(3, last)`: the missing slots repeat the last value given.
+        let min_xy_reads = min_reads.get(1).copied().unwrap_or(last);
+
+        // Validate min_reads ordering: yx <= xy <= total (matching fgbio)
+        // For depth thresholds it's required that yx <= xy <= total
+        if min_xy_reads > min_total_reads {
+            anyhow::bail!("min-reads values must be specified high to low (total >= XY)");
+        }
+        if min_yx_reads > min_xy_reads {
+            anyhow::bail!("min-reads values must be specified high to low (XY >= YX)");
+        }
+
+        Ok(())
+    }
+
     /// Creates a new duplex consensus caller
     ///
     /// # Arguments
@@ -370,31 +440,17 @@ impl DuplexConsensusCaller {
         error_rate_pre_umi: u8,
         error_rate_post_umi: u8,
     ) -> Result<Self> {
+        // Arity and ordering both live in `validate_min_reads` so the CLI can apply the
+        // same rule before any output exists.
+        Self::validate_min_reads(&min_reads)?;
+
         // Parse min_reads vector like fgbio: padTo(3, last)
         // [total, XY, YX] where XY >= YX (larger strand, smaller strand)
-        if min_reads.is_empty() {
-            anyhow::bail!("min_reads parameter must have at least 1 value");
-        }
-        if min_reads.len() > 3 {
-            anyhow::bail!(
-                "min_reads parameter must have 1-3 values (total, [XY, [YX]]), got {} values",
-                min_reads.len()
-            );
-        }
-
-        let last = *min_reads.last().expect("expected a last item");
+        let last = *min_reads.last().expect("min_reads was validated non-empty above");
         let min_total_reads = min_reads[0];
         let min_xy_reads = min_reads.get(1).copied().unwrap_or(last);
-        let min_yx_reads = min_reads.get(2).copied().unwrap_or(last);
-
-        // Validate min_reads ordering: yx <= xy <= total (matching fgbio)
-        // For depth thresholds it's required that yx <= xy <= total
-        if min_xy_reads > min_total_reads {
-            anyhow::bail!("min-reads values must be specified high to low (total >= XY)");
-        }
-        if min_yx_reads > min_xy_reads {
-            anyhow::bail!("min-reads values must be specified high to low (XY >= YX)");
-        }
+        let min_yx_reads =
+            Self::min_yx_reads_for(&min_reads).expect("min_reads was validated non-empty above");
 
         // Create single-strand consensus caller with min_reads=1 (matching fgbio)
         // Filtering happens at duplex level based on input read counts, not at SS level
@@ -2147,7 +2203,31 @@ impl DuplexConsensusCaller {
                     let duplex_r1 = Self::duplex_consensus(Some(r1_a), None, None);
                     let duplex_r2 = Self::duplex_consensus(Some(r2_a), None, None);
 
-                    if let (Some(dr1), Some(dr2)) = (duplex_r1, duplex_r2) {
+                    // Re-check the thresholds against the post-filter depths, as the
+                    // both-strand arm does: `has_minimum_number_of_reads` above ran on the
+                    // raw pre-filter counts, and `filter_by_alignment` can drop reads after
+                    // it passed. Without this a group whose surviving depth falls below
+                    // `--min-reads` still emits a consensus. Falls through to the rejection
+                    // at the end of the function, which records `InsufficientReads`.
+                    //
+                    // fgbio applies its equivalent (`duplexHasMinimumNumberOfReads`) to
+                    // every emitted consensus, single-strand included
+                    // (`DuplexConsensusCaller.scala:221`), for exactly this reason; before
+                    // this PR `min_yx_reads == 0` was unreachable, so the gap was dormant.
+                    if let (Some(dr1), Some(dr2)) = (duplex_r1, duplex_r2)
+                        && Self::duplex_consensus_has_minimum_reads(
+                            &dr1,
+                            min_total_reads,
+                            min_xy_reads,
+                            min_yx_reads,
+                        )
+                        && Self::duplex_consensus_has_minimum_reads(
+                            &dr2,
+                            min_total_reads,
+                            min_xy_reads,
+                            min_yx_reads,
+                        )
+                    {
                         let empty: &[&RawRecord] = &[];
                         Self::duplex_read_into(
                             &mut builder,
@@ -2191,17 +2271,37 @@ impl DuplexConsensusCaller {
             (None, None, Some(ref r1_b), Some(ref r2_b)) => {
                 // Only BA strand - check if single-strand consensus is allowed.
                 //
-                // Mirrors fgbio's mapping where full-duplex output R1 combines AB-R1
-                // with BA-R2 and output R2 combines AB-R2 with BA-R1 (AB-R1 and BA-R2
-                // sequence the same physical strand, as do AB-R2 and BA-R1). When AB
-                // is absent, output R1 therefore derives from BA-R2 and output R2 from
-                // BA-R1. BA is passed in the BA slot so is_ba_only=true is preserved
-                // and methylation tags are emitted as bm/bu/bt.
+                // Each consensus read is built from the input reads of the same end, as in
+                // the AB-only arm above and as fgbio does: with one strand group present it
+                // treats that group as "AB", so output R1 comes from its R1s and output R2
+                // from its R2s. Mapping output R1 from BA-R2 instead -- to keep output R1 on
+                // the physical strand that AB-R1 would have sequenced -- would be the more
+                // strand-consistent choice, but it puts the opposite end of the molecule in
+                // R1 for `/B`-only molecules than for every other molecule class, and it
+                // does not reproduce fgbio.
+                //
+                // BA is still passed in the BA slot so is_ba_only=true is preserved and the
+                // per-strand methylation tags are emitted as bm/bu/bt: that flag records
+                // which strand *group* the bases came from, which is unaffected by the end.
                 if min_yx_reads == 0 {
-                    let duplex_r1 = Self::duplex_consensus(None, Some(r2_b), None);
-                    let duplex_r2 = Self::duplex_consensus(None, Some(r1_b), None);
+                    let duplex_r1 = Self::duplex_consensus(None, Some(r1_b), None);
+                    let duplex_r2 = Self::duplex_consensus(None, Some(r2_b), None);
 
-                    if let (Some(dr1), Some(dr2)) = (duplex_r1, duplex_r2) {
+                    // Post-filter threshold re-check, as in the AB-only arm above.
+                    if let (Some(dr1), Some(dr2)) = (duplex_r1, duplex_r2)
+                        && Self::duplex_consensus_has_minimum_reads(
+                            &dr1,
+                            min_total_reads,
+                            min_xy_reads,
+                            min_yx_reads,
+                        )
+                        && Self::duplex_consensus_has_minimum_reads(
+                            &dr2,
+                            min_total_reads,
+                            min_xy_reads,
+                            min_yx_reads,
+                        )
+                    {
                         let empty: &[&RawRecord] = &[];
                         Self::duplex_read_into(
                             &mut builder,
@@ -2211,7 +2311,7 @@ impl DuplexConsensusCaller {
                             ReadType::R1,
                             &base_mi,
                             empty,
-                            &filtered_ba_r2_raws,
+                            &filtered_ba_r1_raws,
                             produce_per_base_tags,
                             read_name_prefix,
                             read_group_id,
@@ -2228,7 +2328,7 @@ impl DuplexConsensusCaller {
                             ReadType::R2,
                             &base_mi,
                             empty,
-                            &filtered_ba_r1_raws,
+                            &filtered_ba_r2_raws,
                             produce_per_base_tags,
                             read_name_prefix,
                             read_group_id,
@@ -3231,6 +3331,63 @@ mod tests {
         assert!(strand.is_none(), "Should return None for MI without /suffix");
     }
 
+    /// The CLI gates overlapping-base consensus on
+    /// `DuplexConsensusCaller::allows_single_strand_consensus` before any caller
+    /// exists, so that helper has to agree with the `min_yx_reads` a constructed
+    /// caller actually applies. Asserting against the built caller's field is
+    /// what makes the two impossible to drift apart: a change to either padding
+    /// rule alone fails here.
+    #[rstest]
+    #[case::one_value_padded(&[1], 1)]
+    #[case::one_value_zero_padded(&[0], 0)]
+    #[case::two_values_last_repeated(&[3, 1], 1)]
+    #[case::two_values_zero_repeated(&[1, 0], 0)]
+    #[case::three_values_single_strand(&[1, 1, 0], 0)]
+    #[case::three_values_both_strands(&[2, 1, 1], 1)]
+    fn test_min_yx_reads_for_matches_the_constructed_caller(
+        #[case] min_reads: &[usize],
+        #[case] expected_min_yx_reads: usize,
+    ) {
+        assert_eq!(
+            DuplexConsensusCaller::min_yx_reads_for(min_reads),
+            Some(expected_min_yx_reads),
+            "helper padded {min_reads:?} to the wrong YX threshold"
+        );
+
+        let caller = DuplexConsensusCaller::new(
+            "consensus".to_string(),
+            "RG1".to_string(),
+            min_reads.to_vec(),
+            20,
+            false,
+            false,
+            None,
+            None,
+            false,
+            45,
+            40,
+        )
+        .expect("valid min_reads");
+        assert_eq!(
+            caller.min_yx_reads, expected_min_yx_reads,
+            "caller's YX threshold diverged from the helper for {min_reads:?}"
+        );
+        assert_eq!(
+            DuplexConsensusCaller::allows_single_strand_consensus(min_reads),
+            caller.min_yx_reads == 0,
+            "single-strand gate disagrees with the caller's YX threshold for {min_reads:?}"
+        );
+    }
+
+    /// `min_reads` is rejected as empty by `new`, so the helper's only `None`
+    /// case is unreachable in production; pin it anyway so a future caller that
+    /// skips the emptiness check gets `None` rather than a panic.
+    #[test]
+    fn test_min_yx_reads_for_is_none_when_min_reads_is_empty() {
+        assert_eq!(DuplexConsensusCaller::min_yx_reads_for(&[]), None);
+        assert!(!DuplexConsensusCaller::allows_single_strand_consensus(&[]));
+    }
+
     /// Port of fgbio test: validation exception for invalid min-reads order
     /// Tests that `min_reads` values must be in decreasing order
     #[test]
@@ -3252,6 +3409,50 @@ mod tests {
 
         // fgbio throws ValidationException for invalid min_reads order
         assert!(result.is_err(), "Should fail with invalid min_reads order [1, 2, 3]");
+    }
+
+    /// `validate_min_reads` is what the CLI calls to fail fast, and `new` is what
+    /// actually applies the thresholds, so the two verdicts must never diverge —
+    /// otherwise the `--threads` path would accept a value the workers then reject
+    /// mid-pipeline, over an output BAM that already exists.
+    #[rstest]
+    #[case::single_value(&[1], true)]
+    #[case::single_zero(&[0], true)]
+    #[case::descending(&[3, 2, 1], true)]
+    #[case::equal_values(&[2, 2, 2], true)]
+    #[case::single_strand_mode(&[1, 1, 0], true)]
+    #[case::two_value_form(&[3, 2], true)]
+    #[case::zero_in_two_value_form(&[3, 0], true)]
+    #[case::empty(&[], false)]
+    #[case::too_many_values(&[4, 3, 2, 1], false)]
+    #[case::xy_above_total(&[1, 2, 3], false)]
+    #[case::yx_above_xy(&[3, 1, 2], false)]
+    #[case::xy_above_total_in_two_value_form(&[1, 2], false)]
+    fn test_validate_min_reads_agrees_with_new(#[case] min_reads: &[usize], #[case] valid: bool) {
+        assert_eq!(
+            DuplexConsensusCaller::validate_min_reads(min_reads).is_ok(),
+            valid,
+            "validate_min_reads gave the wrong verdict for {min_reads:?}"
+        );
+
+        let caller = DuplexConsensusCaller::new(
+            "consensus".to_string(),
+            "RG1".to_string(),
+            min_reads.to_vec(),
+            20,
+            false,
+            false,
+            None,
+            None,
+            false,
+            45,
+            40,
+        );
+        assert_eq!(
+            caller.is_ok(),
+            valid,
+            "new() disagreed with validate_min_reads for {min_reads:?}"
+        );
     }
 
     /// Port of fgbio test: "count errors against the actual consensus base, before it is masked to N"
@@ -6375,11 +6576,15 @@ mod tests {
         Ok(())
     }
 
-    /// Regression test: BA-only consensus must map output R1 to BA-R2 and output
-    /// R2 to BA-R1, matching the fgbio full-duplex pairing (AB-R1 + BA-R2 → R1,
-    /// AB-R2 + BA-R1 → R2). AB-R1 and BA-R2 sequence the same physical strand, as
-    /// do AB-R2 and BA-R1, so a BA-only group should emit BA-R2 under the R1 slot
-    /// and BA-R1 under the R2 slot.
+    /// Regression test: BA-only consensus must map output R1 to BA-R1 and output R2 to
+    /// BA-R2, i.e. each output read is built from the input reads of the same end.
+    ///
+    /// The full-duplex pairing (AB-R1 + BA-R2 → R1, AB-R2 + BA-R1 → R2) holds only while
+    /// both strand groups are present. fgbio does not extend it to a lone group: it takes
+    /// the sole group as its "AB" side, so output R1 comes from that group's R1s whether
+    /// it is `/A` or `/B`. Mapping BA-R2 → R1 keeps output R1 on a single physical strand
+    /// across molecules, but places the opposite end of the molecule in R1 for `/B`-only
+    /// molecules and does not reproduce fgbio.
     #[test]
     fn test_duplex_ba_only_mate_pair_mapping() -> Result<()> {
         let mut caller = DuplexConsensusCaller::new(
@@ -6456,13 +6661,169 @@ mod tests {
             .expect("Should have a LAST_SEGMENT record");
 
         assert_eq!(
-            r1.bases, b"AAAAAAAAAA",
-            "Output R1 bases should match BA-R2 consensus (AAAAAAAAAA)"
+            r1.bases, b"CCCCCCCCCC",
+            "Output R1 bases should match BA-R1 consensus (CCCCCCCCCC)"
         );
         assert_eq!(
-            r2.bases, b"CCCCCCCCCC",
-            "Output R2 bases should match BA-R1 consensus (CCCCCCCCCC)"
+            r2.bases, b"AAAAAAAAAA",
+            "Output R2 bases should match BA-R2 consensus (AAAAAAAAAA)"
         );
+
+        Ok(())
+    }
+
+    /// Builds `count` read pairs on one strand group, all with the same CIGAR.
+    ///
+    /// `mi` picks the strand group (`foo/A` or `foo/B`); the flags follow the
+    /// expected orientations (AB-R1 +, AB-R2 -, BA-R1 -, BA-R2 +).
+    fn single_strand_pairs(
+        b: &mut SamBuilder,
+        mi: &[u8],
+        cigar: &[u32],
+        name_prefix: u8,
+        count: u8,
+    ) -> Vec<RawRecord> {
+        let is_ab = mi.ends_with(b"/A");
+        let quals = &[30u8; 10];
+        (0..count)
+            .flat_map(|i| {
+                let name = [name_prefix, b'0' + i];
+                let (r1_flags, r2_flags) = if is_ab {
+                    (
+                        flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE,
+                        flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE,
+                    )
+                } else {
+                    (
+                        flags::PAIRED | flags::FIRST_SEGMENT | flags::REVERSE,
+                        flags::PAIRED | flags::LAST_SEGMENT | flags::MATE_REVERSE,
+                    )
+                };
+                [r1_flags, r2_flags]
+                    .into_iter()
+                    .map(|flg| {
+                        b.clear();
+                        b.ref_id(0)
+                            .pos(99)
+                            .flags(flg)
+                            .mate_ref_id(0)
+                            .mate_pos(99)
+                            .read_name(&name)
+                            .cigar_ops(cigar)
+                            .sequence(b"ACGTACGTAC")
+                            .qualities(quals);
+                        b.add_string_tag(SamTag::MI, mi);
+                        b.add_string_tag(SamTag::RG, b"A");
+                        b.build()
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
+    /// Regression test: the single-strand arms must re-check `--min-reads` against
+    /// the POST-alignment-filter depths, as the both-strand arm does and as fgbio
+    /// does for every molecule.
+    ///
+    /// `has_minimum_number_of_reads` runs on the raw pre-filter counts, and
+    /// `filter_by_alignment` (fgbio's `filterToMostCommonAlignment`) can drop reads
+    /// after it passed — the exact case fgbio's own comment calls out at
+    /// `DuplexConsensusCaller.scala:224` ("Even though we had enough reads going
+    /// into consensus calling, we can lose some in the process (e.g. to CIGAR
+    /// filtering)"). fgbio applies `duplexHasMinimumNumberOfReads` to every emitted
+    /// consensus, so single-strand molecules are not exempt there.
+    ///
+    /// Here five single-strand pairs clear a `5,3,0` threshold on the raw counts,
+    /// but two carry a `5M1I4M` CIGAR that is neither a prefix of nor prefixed by
+    /// `10M`, so the most-common-alignment group keeps only three — below
+    /// `min_total_reads = 5`. Without the re-check the molecule still emitted a
+    /// consensus pair, silently violating the configured threshold. The `3,3,0`
+    /// case is the control: the same three survivors clear that threshold and must
+    /// still be emitted, with `aD` pinning that the pair really was built from the
+    /// three filtered reads rather than all five.
+    #[rstest]
+    #[case::ab_only_below_threshold_after_filtering(b"foo/A", &[5, 3, 0], false)]
+    #[case::ba_only_below_threshold_after_filtering(b"foo/B", &[5, 3, 0], false)]
+    #[case::ab_only_survivors_clear_threshold(b"foo/A", &[3, 3, 0], true)]
+    #[case::ba_only_survivors_clear_threshold(b"foo/B", &[3, 3, 0], true)]
+    fn test_single_strand_rechecks_min_reads_after_alignment_filtering(
+        #[case] mi: &[u8],
+        #[case] min_reads: &[usize],
+        #[case] expect_consensus: bool,
+    ) -> Result<()> {
+        /// Reads surviving `filter_by_alignment`: the three pairs sharing `10M`.
+        const FILTERED_DEPTH: i32 = 3;
+
+        let mut caller = DuplexConsensusCaller::new(
+            "consensus".to_string(),
+            "RG1".to_string(),
+            min_reads.to_vec(),
+            0,
+            false,
+            false,
+            None,
+            None,
+            false,
+            45,
+            40,
+        )?;
+
+        // 10M: [(M, 10)]. 5M1I4M: [(M, 5), (I, 1), (M, 4)] -- neither simplified
+        // CIGAR is a prefix of the other, so they form two alignment groups.
+        let common_cigar = &[encode_op(0, 10)];
+        let odd_cigar = &[encode_op(0, 5), encode_op(1, 1), encode_op(0, 4)];
+        let mut b = SamBuilder::new();
+        let mut reads = single_strand_pairs(&mut b, mi, common_cigar, b'c', 3);
+        reads.extend(single_strand_pairs(&mut b, mi, odd_cigar, b'o', 2));
+
+        let result = caller.consensus_reads(reads)?;
+        let records = ParsedBamRecord::parse_all(&result.data);
+
+        if !expect_consensus {
+            assert_eq!(
+                result.count, 0,
+                "min_reads {min_reads:?} exceeds the alignment-filtered depth of \
+                 {FILTERED_DEPTH}, so the molecule must be rejected"
+            );
+            assert!(records.is_empty(), "rejected molecule must emit no records");
+            return Ok(());
+        }
+
+        assert_eq!(result.count, 2, "min_reads {min_reads:?} is met by the filtered reads");
+        assert_eq!(records.len(), 2);
+
+        let r1 = records
+            .iter()
+            .find(|r| r.flag & flags::FIRST_SEGMENT != 0)
+            .expect("Should have a FIRST_SEGMENT record");
+        let r2 = records
+            .iter()
+            .find(|r| r.flag & flags::LAST_SEGMENT != 0)
+            .expect("Should have a LAST_SEGMENT record");
+
+        for (label, rec) in [("R1", r1), ("R2", r2)] {
+            assert_eq!(
+                rec.get_string_tag(SamTag::MI).as_deref(),
+                Some(b"foo".as_slice()),
+                "{label} should carry the base molecule identifier"
+            );
+            assert_eq!(
+                rec.bases.len(),
+                10,
+                "{label} should span the 10bp the surviving 10M reads cover"
+            );
+            assert_eq!(
+                rec.get_int_tag(SamTag::AD),
+                Some(FILTERED_DEPTH),
+                "{label} aD should count only the alignment-filtered reads"
+            );
+            assert_eq!(
+                rec.get_int_tag(SamTag::BD),
+                Some(0),
+                "{label} bD should be 0: the molecule was observed on one strand"
+            );
+        }
+        assert_eq!(r1.name, r2.name, "both ends should share one consensus read name");
 
         Ok(())
     }
@@ -6567,10 +6928,16 @@ mod fgbio_oracle_tests {
     }
 
     fn duplex_caller() -> DuplexConsensusCaller {
+        duplex_caller_with_min_reads(vec![1])
+    }
+
+    /// The same caller as [`duplex_caller`] with an explicit `--min-reads`, so the
+    /// single-strand fixtures can run at fgbio's `-M 1 1 0`.
+    fn duplex_caller_with_min_reads(min_reads: Vec<usize>) -> DuplexConsensusCaller {
         DuplexConsensusCaller::new(
             "duplex".to_string(),
             "A".to_string(),
-            vec![1],
+            min_reads,
             10,    // min_input_base_quality (fgbio default)
             true,  // produce_per_base_tags (fgbio CLI always emits per-base arrays)
             false, // trim
@@ -6764,6 +7131,273 @@ mod fgbio_oracle_tests {
             ParsedBamRecord::parse_all(&output.data).is_empty(),
             "no consensus records may be emitted when one strand is empty",
         );
+    }
+
+    /// SINGLE-STRAND fixture: `SINGLE_STRAND_PAIRS` read pairs all carrying the SAME
+    /// `MI` strand suffix, so one of the two strand groups is empty and fgbio's
+    /// single-strand mode (`-M 1 1 0`) is what decides whether anything is emitted.
+    ///
+    /// Unlike [`build_duplex_fixture`], R1 and R2 carry DIFFERENT stored bases
+    /// (`R1_BASES` / `R2_BASES`, neither a reverse complement of the other). That is
+    /// what makes the read-end mapping observable: with a lone strand group, fgbio
+    /// treats it as its "AB" side and builds output R1 from that group's R1s
+    /// whichever suffix it carries, so both the `/A`-only and `/B`-only fixtures must
+    /// put `R1_BASES` in output R1. A BA-only arm that instead paired output R1 with
+    /// the group's R2s (the full-duplex `AB-R1 + BA-R2` rule, which does not extend
+    /// to a lone group) would swap the two, and the pinned bases below catch it.
+    ///
+    /// One pair's R1 carries `VARIANT_R1_BASES`, disagreeing at base 0, so the
+    /// per-strand error numerator (`aE`/`ae`) is exercised rather than pinned at 0.
+    /// R2 starts at [`NON_OVERLAP_R2_START`] so FR overlapping-base masking cannot
+    /// reach the injected base (see [`build_duplex_fixture`]). Every read carries an
+    /// `RX` tag so the emitted consensus `RX` is pinned too.
+    fn build_single_strand_fixture(strand_suffix: &str) -> SamBuilder {
+        let mut b = SamBuilder::new();
+        b.set_template_coordinate_sort_order();
+        let (strand1, strand2) = if strand_suffix == "A" {
+            (Strand::Plus, Strand::Minus)
+        } else {
+            (Strand::Minus, Strand::Plus)
+        };
+        let quals = vec![40u8; R1_BASES.len()];
+        for i in 0..SINGLE_STRAND_PAIRS {
+            let r1_bases = if i == 0 { VARIANT_R1_BASES } else { R1_BASES };
+            let _ = b
+                .add_pair()
+                .name(&format!("s{i:07}"))
+                .bases1(r1_bases)
+                .bases2(R2_BASES)
+                .quals1(&quals)
+                .quals2(&quals)
+                .contig(0)
+                .start1(100)
+                .start2(NON_OVERLAP_R2_START)
+                .strand1(strand1)
+                .strand2(strand2)
+                .attr("MI", format!("mol/{strand_suffix}"))
+                .attr("RX", SOURCE_RX)
+                .build();
+        }
+        b
+    }
+
+    /// Read pairs in each single-strand fixture. Three keeps the depths small enough
+    /// to read at a glance while leaving room for one disagreeing read.
+    const SINGLE_STRAND_PAIRS: usize = 3;
+    /// R1's stored bases in the single-strand fixtures.
+    const R1_BASES: &str = "ACGTACGT";
+    /// R2's stored bases: distinct from `R1_BASES` and not its reverse complement, so
+    /// a swapped read-end mapping is visible in the emitted bases.
+    const R2_BASES: &str = "TTGGCCAA";
+    /// One pair's R1 bases, disagreeing with `R1_BASES` at base 0.
+    const VARIANT_R1_BASES: &str = "CCGTACGT";
+    /// The `RX` every source read carries, so the consensus `RX` can be pinned.
+    const SOURCE_RX: &str = "AAAA-CCCC";
+
+    /// fgumi's SINGLE-STRAND duplex output must match a real fgbio run record for
+    /// record: not only the depth/error tags, but the flags, bases, qualities, `MI`
+    /// and `RX` that identify each emitted read, and which tags are emitted at all.
+    ///
+    /// Every other oracle case in this module has both strand groups populated, and
+    /// the remaining single-strand tests in this file either derive their
+    /// expectations from the fgumi input or compare two fgumi execution modes against
+    /// each other. Neither form can catch a single-strand read-end mapping,
+    /// post-filter threshold, or masking rule that differs from fgbio in the same way
+    /// in both places -- hence this independent, offline-pinned oracle.
+    ///
+    /// Oracle provenance -- fgbio `4.1.0`, on the fixture BAM the matching
+    /// `#[ignore]`d `regen_duplex_single_strand_*` test emits (CLI defaults for
+    /// `--error-rate-pre-umi 45 --error-rate-post-umi 40 --min-input-base-quality 10`,
+    /// which is what `duplex_caller_with_min_reads` passes):
+    ///
+    /// ```text
+    /// fgbio CallDuplexConsensusReads -i <fixture>.bam -o out.bam -M 1 1 0
+    /// samtools view out.bam
+    /// ```
+    ///
+    /// Captured output, identical for the `/A`-only and `/B`-only fixtures except for
+    /// the error position noted in the case table (read names elided -- fgbio derives
+    /// the prefix from the read group, fgumi from `--read-name-prefix`):
+    ///
+    /// ```text
+    /// 77  ACGTACGT INNNNNNN aD:i:3 bD:i:0 cD:i:3 aE:f:0.0416667 bE:f:0 cE:f:0.0416667
+    ///     MI:Z:mol aM:i:3 bM:i:0 cM:i:3 RX:Z:AAAA-CCCC ac:Z:ACGTACGT
+    ///     ad:B:s,3,3,3,3,3,3,3,3 ae:B:s,1,0,0,0,0,0,0,0 aq:Z:INNNNNNN
+    /// 141 TTGGCCAA NNNNNNNN aD:i:3 bD:i:0 cD:i:3 aE:f:0 bE:f:0 cE:f:0
+    ///     MI:Z:mol aM:i:3 bM:i:0 cM:i:3 RX:Z:AAAA-CCCC ac:Z:TTGGCCAA
+    ///     ad:B:s,3,3,3,3,3,3,3,3 ae:B:s,0,0,0,0,0,0,0,0 aq:Z:NNNNNNNN
+    /// ```
+    ///
+    /// Methylation tags (`au`/`at`, `bu`/`bt`) are not pinned here: fgbio emits them
+    /// only for a bisulfite/methylation run, which this fixture is not. The `/B`-only
+    /// methylation orientation is covered by
+    /// `test_duplex_ba_only_uses_bottom_strand_methylation_tags`.
+    #[rstest]
+    // The two cases pin the same bases in the same output slots: fgbio takes whichever
+    // lone strand group is present as its "AB" side, so a `/B`-only molecule yields
+    // the same read ends in the same slots a `/A`-only one does. An arm that paired
+    // output R1 with the group's R2s (the full-duplex `AB-R1 + BA-R2` rule, which does
+    // not extend to a lone group) would swap R1 and R2 in the `/B` case alone.
+    //
+    // Only the ERROR POSITION differs, and only because of strand orientation: the
+    // disagreeing base is stored at offset 0 of the variant R1 either way, but the
+    // `/B` fixture's R1s are REVERSE, so fgbio consensus-calls them in sequencing
+    // orientation and the disagreement lands at the far end.
+    #[case::ab_only("A", 0)]
+    #[case::ba_only("B", R1_BASES.len() - 1)]
+    fn duplex_single_strand_matches_fgbio_oracle(
+        #[case] strand_suffix: &str,
+        #[case] error_index: usize,
+    ) {
+        /// fgbio's per-base no-call quality (`N` in the captured `aq`/`SEQ` strings):
+        /// with one disagreeing read out of three the consensus quality is floored.
+        const NO_CALL_QUAL: u8 = b'N' - 33;
+        /// The quality fgbio emits at the one base the three reads disagree on.
+        const DISAGREEMENT_QUAL: u8 = b'I' - 33;
+        /// Reads on the single populated strand, i.e. the pinned `aD`/`aM`/`ad`.
+        const DEPTH: i16 = 3;
+        const _: () = assert!(SINGLE_STRAND_PAIRS == DEPTH as usize);
+        /// `aE` = 1 error / (depth 3 * 8 bases).
+        const AE: f32 = 0.041_666_7;
+
+        let builder = build_single_strand_fixture(strand_suffix);
+        let records = records_from_builder(&builder);
+        let mut caller = duplex_caller_with_min_reads(vec![1, 1, 0]);
+        let output = caller.consensus_reads(records).expect("duplex consensus succeeds");
+        let parsed = ParsedBamRecord::parse_all(&output.data);
+        assert_eq!(parsed.len(), 2, "single-strand duplex emits R1 and R2 consensus records");
+
+        let r1 = parsed
+            .iter()
+            .find(|r| r.flag & flags::FIRST_SEGMENT != 0)
+            .expect("R1 (first-of-pair) consensus present");
+        let r2 = parsed
+            .iter()
+            .find(|r| r.flag & flags::FIRST_SEGMENT == 0)
+            .expect("R2 (second-of-pair) consensus present");
+
+        // Flags 77 / 141: consensus reads are unmapped and in molecule orientation, so
+        // neither REVERSE nor MATE_REVERSE is set even for the `/B`-only fixture.
+        let unmapped_pair = flags::PAIRED | flags::UNMAPPED | flags::MATE_UNMAPPED;
+        assert_eq!(r1.flag, unmapped_pair | flags::FIRST_SEGMENT, "R1 flags (fgbio-pinned)");
+        assert_eq!(r2.flag, unmapped_pair | flags::LAST_SEGMENT, "R2 flags (fgbio-pinned)");
+
+        // Bases and qualities. The lone disagreeing R1 is outvoted, so R1 reproduces
+        // the majority `R1_BASES`; only its quality at `error_index` records the
+        // disagreement.
+        let mut expected_r1_quals = vec![NO_CALL_QUAL; R1_BASES.len()];
+        expected_r1_quals[error_index] = DISAGREEMENT_QUAL;
+        assert_eq!(r1.bases, R1_BASES.as_bytes(), "R1 bases (fgbio-pinned)");
+        assert_eq!(r1.quals, expected_r1_quals, "R1 qualities (fgbio-pinned)");
+        assert_eq!(r2.bases, R2_BASES.as_bytes(), "R2 bases (fgbio-pinned)");
+        assert_eq!(
+            r2.quals,
+            vec![NO_CALL_QUAL; R2_BASES.len()],
+            "R2 qualities (fgbio-pinned): the R2s all agree"
+        );
+
+        // Per-base error array: 1 at the disagreeing base on R1, all-zero on R2.
+        let mut expected_ae_bases = vec![0i16; R1_BASES.len()];
+        expected_ae_bases[error_index] = 1;
+
+        for (label, rec, bases, ae, ae_bases) in [
+            ("R1", r1, R1_BASES, AE, expected_ae_bases),
+            ("R2", r2, R2_BASES, 0.0, vec![0i16; R2_BASES.len()]),
+        ] {
+            assert_eq!(
+                rec.get_string_tag(SamTag::MI).as_deref(),
+                Some(b"mol".as_slice()),
+                "{label} MI (fgbio-pinned): the base molecule id, `/A`-`/B` suffix stripped"
+            );
+            assert_eq!(
+                rec.get_string_tag(SamTag::RX).as_deref(),
+                Some(SOURCE_RX.as_bytes()),
+                "{label} RX (fgbio-pinned): carried over from the source reads"
+            );
+
+            // The populated strand's depths, and the same values on the combined
+            // tags -- with one strand absent, `cD`/`cM` are just `aD`/`aM`.
+            for (tag, name) in
+                [(SamTag::AD, "aD"), (SamTag::AM, "aM"), (SamTag::CD, "cD"), (SamTag::CM, "cM")]
+            {
+                assert_eq!(
+                    rec.get_int_tag(tag),
+                    Some(i32::from(DEPTH)),
+                    "{label} {name} (fgbio-pinned)"
+                );
+            }
+            // The absent strand still gets zero-valued SCALAR tags, matching fgbio.
+            for (tag, name) in [(SamTag::BD, "bD"), (SamTag::BM, "bM")] {
+                assert_eq!(rec.get_int_tag(tag), Some(0), "{label} {name} (fgbio-pinned)");
+            }
+            for (tag, name) in [(SamTag::AE, "aE"), (SamTag::CE, "cE")] {
+                let got =
+                    rec.get_float_tag(tag).unwrap_or_else(|| panic!("{label} {name} present"));
+                assert!(
+                    (got - ae).abs() < 1e-6,
+                    "{label} {name} (fgbio-pinned): expected {ae}, got {got}"
+                );
+            }
+            assert_eq!(rec.get_float_tag(SamTag::BE), Some(0.0), "{label} bE (fgbio-pinned)");
+
+            assert_eq!(
+                rec.get_i16_array_tag(SamTag::AD_BASES),
+                Some(vec![DEPTH; bases.len()]),
+                "{label} ad (fgbio-pinned)"
+            );
+            assert_eq!(
+                rec.get_i16_array_tag(SamTag::AE_BASES),
+                Some(ae_bases),
+                "{label} ae (fgbio-pinned)"
+            );
+            assert_eq!(
+                rec.get_string_tag(SamTag::AC).as_deref(),
+                Some(bases.as_bytes()),
+                "{label} ac (fgbio-pinned): the single-strand consensus bases"
+            );
+            assert_eq!(
+                rec.get_string_tag(SamTag::AQ).as_deref(),
+                Some(rec.quals.iter().map(|q| q + 33).collect::<Vec<_>>().as_slice()),
+                "{label} aq (fgbio-pinned): the single-strand consensus qualities"
+            );
+
+            // Tag SHAPE, not just tag values: with one strand absent fgbio emits NO
+            // per-base array or per-strand string for it. Emitting zero-filled `bd`/
+            // `be`/`bc`/`bq` here would be a silent divergence that value-only
+            // assertions would miss.
+            //
+            // Each accessor matches one BAM aux type, so the absence check has to use
+            // the type the tag is WRITTEN as or it passes vacuously: `bd`/`be` are
+            // `B:s` arrays (`append_i16_array_tag`), `bc`/`bq` are `Z` strings
+            // (`append_string_tag` / `append_phred33_string_tag`).
+            for (tag, name) in [(SamTag::BD_BASES, "bd"), (SamTag::BE_BASES, "be")] {
+                assert!(
+                    rec.get_i16_array_tag(tag).is_none(),
+                    "{label} must NOT carry {name} (fgbio-pinned): the BA strand is absent"
+                );
+            }
+            for (tag, name) in [(SamTag::BC_BASES, "bc"), (SamTag::BQ, "bq")] {
+                assert!(
+                    rec.get_string_tag(tag).is_none(),
+                    "{label} must NOT carry {name} (fgbio-pinned): the BA strand is absent"
+                );
+            }
+        }
+        assert_eq!(r1.name, r2.name, "both ends share one consensus read name");
+    }
+
+    /// Re-emit the `/A`-only single-strand fixture BAM for fgbio.
+    #[test]
+    #[ignore = "regen: writes the fixture BAM (set FGUMI_ORACLE_BAM_OUT), then run fgbio on it"]
+    fn regen_duplex_single_strand_ab_only_fixture() {
+        regen_write(&build_single_strand_fixture("A"));
+    }
+
+    /// Re-emit the `/B`-only single-strand fixture BAM for fgbio.
+    #[test]
+    #[ignore = "regen: writes the fixture BAM (set FGUMI_ORACLE_BAM_OUT), then run fgbio on it"]
+    fn regen_duplex_single_strand_ba_only_fixture() {
+        regen_write(&build_single_strand_fixture("B"));
     }
 
     /// Re-emit the duplex open-interval depth-saturation fixture BAM for fgbio.

--- a/docs/src/guide/duplex-consensus-calling.md
+++ b/docs/src/guide/duplex-consensus-calling.md
@@ -71,16 +71,42 @@ The final duplex R1 and R2 are produced by merging the appropriate A and B reads
 
 ### For Duplex Consensus
 
-`fgumi duplex` and `fgumi filter` accept one, two, or three `--min-reads` values. If fewer than three values are supplied, the last is repeated (e.g. `80 40` becomes `80 40 40`, `10` becomes `10 10 10`).
+`fgumi duplex` and `fgumi filter` accept one, two, or three `--min-reads` values. If fewer than three values are supplied, the last is repeated (e.g. `80,40` becomes `80,40,40`, `10` becomes `10,10,10`).
 
 The values control:
 1. **First value**: minimum total raw reads across both single-strand consensuses for the final duplex read
 2. **Second value**: minimum reads for the single-strand consensus with *more* support
 3. **Third value**: minimum reads for the single-strand consensus with *less* support
 
-If values two and three differ, the more stringent value must come first.
+The values must be given high to low: no value may exceed the one before it, so the total is at least the more-supported strand's minimum, which is in turn at least the less-supported strand's. `--min-reads 1,2` is rejected for the same reason `--min-reads 3,1,2` is.
 
-**Example:** `--min-reads 7 3 1` requires:
+**Example:** `--min-reads 7,3,1` requires:
 - At least 7 total raw reads supporting the duplex consensus
 - At least 3 raw reads for the better-supported single-strand consensus
 - At least 1 raw read for the other single-strand consensus
+
+### Single-strand molecules
+
+Any of the values may be 0. A third value of 0 means the less-supported strand is allowed to
+have no reads at all, so a molecule observed on only one strand still yields a consensus read
+pair:
+
+```console
+fgumi duplex --input grouped.bam --output consensus.bam --min-reads 1,1,0
+```
+
+Every molecule is then collapsed regardless of whether it makes duplex, which is useful when
+the duplex consensus BAM is also meant to stand in for the simplex one. Molecules that made
+duplex are still distinguishable afterward: a single-strand consensus carries `bD:i:0`,
+meaning no reads on the second strand. Filter on `aD`/`bD` (or with `fgumi filter
+--min-reads`) if you need only true duplex molecules.
+
+This matches `fgbio CallDuplexConsensusReads --min-reads 1 1 0`, which produces the same
+consensus reads. Note that fgbio does not document a value of 0 — neither
+`CallDuplexConsensusReads` nor `FilterConsensusReads` describes it — but it does implement
+it, and fgumi's output for `1,1,0` is identical to fgbio's.
+
+A *first* value of 0 is accepted too, and behaves the same as 1: the check it controls is
+`total >= min-reads` over a group that already has at least one read. Unlike `fgumi simplex`
+and `fgumi codec`, which reject 0 because there it really would make the minimum-family-size
+filter a silent no-op, `fgumi duplex` applies no lower bound — as fgbio does not.

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -189,7 +189,12 @@ pub struct Duplex {
     pub compression: CompressionOptions,
 
     /// Minimum reads for consensus calling.
-    /// Can specify 1-3 values: \[duplex\] or \[duplex, AB/BA\] or \[duplex, AB, BA\]
+    ///
+    /// Can specify 1-3 values: \[duplex\] or \[duplex, AB/BA\] or \[duplex, AB, BA\]. The values
+    /// must be given high to low — no value may exceed the one before it — so `7,3,1` is
+    /// accepted and `1,2` is rejected. Values may be 0: `1,1,0` emits a consensus for a
+    /// molecule observed on only one strand, so every molecule is collapsed whether or not it
+    /// makes duplex.
     #[arg(short = 'M', long = "min-reads", value_delimiter = ',', default_value = "1")]
     pub min_reads: Vec<usize>,
 
@@ -480,6 +485,7 @@ impl Command for Duplex {
             .with_cell_tag(Some(*SamTag::CB));
         // Single-threaded processing
         // Create overlapping consensus caller for single-threaded mode
+        let single_strand_allowed = self.allows_single_strand_consensus();
         let mut overlapping_caller = if overlapping_enabled {
             Some(OverlappingBasesConsensusCaller::new(
                 AgreementStrategy::Consensus,
@@ -492,10 +498,10 @@ impl Command for Duplex {
         for group_result in mi_group_iter {
             let (_base_mi, mut records) = group_result.context("Failed to read MI group")?;
 
-            // Apply overlapping consensus if enabled (modifies raw bytes in-place)
-            // Skip if group doesn't have both strands - no duplex possible anyway
+            // Apply overlapping consensus if enabled (modifies raw bytes in-place).
+            // Skip single-strand groups only when they cannot produce a consensus anyway.
             if let Some(ref mut oc) = overlapping_caller
-                && has_both_strands_raw(&records)
+                && (single_strand_allowed || has_both_strands_raw(&records))
             {
                 apply_overlapping_consensus(&mut records, oc)?;
             }
@@ -585,14 +591,33 @@ impl Duplex {
         if self.consensus.error_rate_post_umi == 0 {
             bail!("error-rate-post-umi must be > 0");
         }
-        // Matches simplex and codec: 0 admits empty groups, making the
-        // minimum-family-size filter a silent no-op rather than an error.
-        // `DuplexConsensusCaller::new` validates emptiness and high-to-low
-        // ordering but never a lower bound.
-        if self.min_reads.contains(&0) {
-            bail!("--min-reads must be >= 1 (a value of 0 admits empty groups)");
-        }
+        // `--min-reads` is deliberately not bounded below, matching fgbio, which validates
+        // only the ordering -- each value no larger than the one before it
+        // (`total >= XY >= YX`). A 0 in the per-strand slots is fgbio's single-strand mode
+        // (`-M 1 1 0`), where a molecule observed on only one strand still yields a
+        // consensus. A total of 0 is equivalent to 1 rather than degenerate, because the
+        // check it feeds (`min_total <= num_xy + num_yx`) is only reached for a group that
+        // already has at least one read. This is why `duplex` differs from `simplex` and
+        // `codec`, where a 0 really would make the filter a silent no-op.
+        //
+        // The ordering rule itself is `DuplexConsensusCaller`'s, applied here so that both
+        // execution paths reject a bad value before any I/O. `--threads` mode builds its
+        // caller inside the pipeline's per-batch closure, i.e. after the output BAM has
+        // been created, so relying on the constructor alone would turn an argument error
+        // into a mid-run worker failure that leaves a partial output file behind.
+        DuplexConsensusCaller::validate_min_reads(&self.min_reads)?;
         Ok(())
+    }
+
+    /// Whether a molecule seen on only one strand can still yield a consensus, i.e. whether
+    /// the per-strand minimum for the less-covered strand is 0 (fgbio's `-M 1 1 0` mode).
+    ///
+    /// Delegates to `DuplexConsensusCaller`, which owns the `padTo(3, last)` rule, so this
+    /// gate cannot drift from the `min_yx_reads` the caller actually applies. The threaded
+    /// path needs the answer before a caller exists, which is why the delegate takes the
+    /// raw `min_reads` slice rather than reading it off a constructed caller.
+    fn allows_single_strand_consensus(&self) -> bool {
+        DuplexConsensusCaller::allows_single_strand_consensus(&self.min_reads)
     }
 
     /// Execute using 7-step unified pipeline with --threads.
@@ -633,6 +658,7 @@ impl Duplex {
         let collected_metrics_for_serialize = Arc::clone(&collected_metrics);
 
         // Capture configuration for closures
+        let single_strand_allowed = self.allows_single_strand_consensus();
         let min_reads = self.min_reads.clone();
         let min_input_base_quality = self.consensus.min_input_base_quality;
         let output_per_base_tags = self.consensus.output_per_base_tags;
@@ -725,11 +751,11 @@ impl Duplex {
                 caller.clear();
 
                 // Apply overlapping consensus if enabled (modifies raw bytes in-place).
-                // Skip if group doesn't have both strands — no duplex possible anyway.
+                // Skip single-strand groups only when they cannot produce a consensus anyway.
                 // Propagate errors to match single-threaded behavior; silent drops here
                 // would turn real failures into output gaps in --threads mode only.
                 if let Some(ref mut oc) = overlapping_caller
-                    && has_both_strands_raw(&group_reads)
+                    && (single_strand_allowed || has_both_strands_raw(&group_reads))
                 {
                     oc.reset_stats();
                     apply_overlapping_consensus(&mut group_reads, oc).map_err(|e| {
@@ -1184,20 +1210,45 @@ mod tests {
         assert_eq!(duplex.validate().is_ok(), expect_ok);
     }
 
+    /// `validate()` applies exactly the rule fgbio does to `--min-reads`: no lower bound,
+    /// but the values must be ordered high to low — each no larger than the one before it,
+    /// after fgbio's `padTo(3, last)` fills the missing slots.
+    ///
+    /// The accepted cases guard against reintroducing the lower-bound rejection
+    /// `validate()` used to apply. A 0 in the per-strand slots is fgbio's single-strand
+    /// mode (`-M 1 1 0`), where a molecule seen on only one strand still yields a
+    /// consensus; a total of 0 is equivalent to 1, since a group that reaches the check
+    /// has at least one read.
+    ///
+    /// The rejected cases pin the ordering rule to `validate()` rather than to
+    /// `DuplexConsensusCaller::new` alone. `--threads` mode builds its caller inside the
+    /// pipeline's per-batch closure, after the output BAM exists, so an ordering violation
+    /// caught only by the constructor would be a mid-run failure over a partial file
+    /// instead of an argument error.
     #[rstest]
-    #[case::single_zero(vec![0], false)]
-    #[case::zero_in_tail(vec![3, 0], false)]
-    #[case::all_zero(vec![0, 0, 0], false)]
+    #[case::single_zero(vec![0], true)]
+    #[case::all_zero(vec![0, 0, 0], true)]
+    #[case::zero_two_value_form(vec![0, 0], true)]
     #[case::single_one(vec![1], true)]
     #[case::descending(vec![3, 2, 1], true)]
-    fn test_validate_rejects_zero_min_reads(
-        #[case] min_reads: Vec<usize>,
-        #[case] expect_ok: bool,
-    ) {
+    #[case::single_strand_mode(vec![1, 1, 0], true)]
+    #[case::zero_both_strand_slots(vec![1, 0, 0], true)]
+    #[case::zero_in_two_value_form(vec![3, 0], true)]
+    #[case::equal_values(vec![2, 2, 2], true)]
+    #[case::xy_above_total(vec![1, 2, 3], false)]
+    #[case::yx_above_xy(vec![3, 1, 2], false)]
+    #[case::xy_above_total_in_two_value_form(vec![1, 2], false)]
+    #[case::empty(vec![], false)]
+    #[case::too_many_values(vec![4, 3, 2, 1], false)]
+    fn test_validate_min_reads(#[case] min_reads: Vec<usize>, #[case] expect_ok: bool) {
         let mut duplex =
             create_duplex_with_paths(PathBuf::from("test.bam"), PathBuf::from("output.bam"));
-        duplex.min_reads = min_reads;
-        assert_eq!(duplex.validate().is_ok(), expect_ok);
+        duplex.min_reads = min_reads.clone();
+        assert_eq!(
+            duplex.validate().is_ok(),
+            expect_ok,
+            "validate() disagreed with the --min-reads contract for {min_reads:?}"
+        );
     }
 
     #[test]

--- a/tests/integration/test_duplex_command.rs
+++ b/tests/integration/test_duplex_command.rs
@@ -15,7 +15,7 @@ use noodles::sam::alignment::io::Write as AlignmentWrite;
 use rstest::rstest;
 use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, to_record_buf};
@@ -33,7 +33,30 @@ fn create_duplex_read_pair(
     ref_start: i32,
     is_b_strand: bool,
 ) -> (RawRecord, RawRecord) {
-    let seq = sequence.as_bytes();
+    create_duplex_read_pair_with_sequences(
+        name,
+        mi_tag,
+        sequence,
+        sequence,
+        quality,
+        ref_start,
+        is_b_strand,
+    )
+}
+
+/// As [`create_duplex_read_pair`], but with distinct (equal-length) R1 and R2 sequences so
+/// tests can tell which input read a consensus read was built from.
+fn create_duplex_read_pair_with_sequences(
+    name: &str,
+    mi_tag: &str,
+    r1_sequence: &str,
+    r2_sequence: &str,
+    quality: u8,
+    ref_start: i32,
+    is_b_strand: bool,
+) -> (RawRecord, RawRecord) {
+    assert_eq!(r1_sequence.len(), r2_sequence.len(), "R1 and R2 must be the same length");
+    let seq = r1_sequence.as_bytes();
     let read_len = seq.len();
     let cigar_op = u32::try_from(read_len).expect("read_len fits u32") << 4;
 
@@ -82,7 +105,7 @@ fn create_duplex_read_pair(
     let r2 = {
         let mut b = SamBuilder::new();
         b.read_name(name.as_bytes())
-            .sequence(seq)
+            .sequence(r2_sequence.as_bytes())
             .qualities(&vec![quality; read_len])
             .flags(r2_flags)
             .ref_id(0)
@@ -383,6 +406,501 @@ fn test_duplex_command_with_stats() {
             "single-threaded duplex stats must emit the seeded KV row {key}:\n{stats}"
         );
     }
+}
+
+/// Build a molecule observed on a single strand only: `depth` read pairs all carrying
+/// the same `/A` or `/B` MI suffix.
+fn create_single_strand_molecule(
+    mi_id: &str,
+    sequence: &str,
+    quality: u8,
+    ref_start: i32,
+    depth: usize,
+    is_b_strand: bool,
+) -> Vec<(RawRecord, RawRecord)> {
+    let strand = if is_b_strand { 'B' } else { 'A' };
+    (0..depth)
+        .map(|i| {
+            create_duplex_read_pair(
+                &format!("{strand}_{i}"),
+                &format!("{mi_id}/{strand}"),
+                sequence,
+                quality,
+                ref_start,
+                is_b_strand,
+            )
+        })
+        .collect()
+}
+
+/// A third `--min-reads` value of 0 is fgbio's single-strand mode: molecules seen on only
+/// one strand still yield a consensus. With a non-zero third value they are rejected.
+///
+/// The first two `--min-reads` values still apply in single-strand mode, and they count
+/// TEMPLATES, not read records: `has_minimum_number_of_reads` counts only the R1 of each
+/// pair, matching fgbio's `x.count(r => r.paired && r.firstOfPair)`. The threshold cases
+/// below straddle the molecule's template count to pin that — see `MOLECULE_DEPTH`.
+#[rstest]
+fn test_duplex_single_strand_mode_emits_one_strand_molecules(
+    #[values(None, Some("2"))] threads: Option<&str>,
+    #[values(true, false)] is_b_strand: bool,
+) {
+    /// Read pairs on the molecule's single strand: 3 templates, i.e. 6 read records.
+    const MOLECULE_DEPTH: usize = 3;
+
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+
+    let molecule =
+        create_single_strand_molecule("1", "ACGTACGT", 30, 100, MOLECULE_DEPTH, is_b_strand);
+    create_duplex_bam(&input_bam, vec![molecule]);
+
+    // Identity of one consensus record: `(is_r1, molecule id from the read name, bases)`. A
+    // bare record count cannot tell a correct R1/R2 pair from two empty, duplicated, or
+    // wrong-molecule records, so the assertions below work off this instead.
+    let run = |min_reads: &str, output_bam: &Path| -> Vec<(bool, String, String)> {
+        let mut args = vec![
+            "duplex",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output_bam.to_str().unwrap(),
+            "--min-reads",
+            min_reads,
+            "--compression-level",
+            "1",
+        ];
+        if let Some(threads) = threads {
+            args.extend_from_slice(&["--threads", threads]);
+        }
+        Duplex::try_parse_from(args)
+            .expect("failed to parse duplex args")
+            .execute("fgumi duplex")
+            .expect("Duplex command failed");
+        let mut reader = bam::io::Reader::new(fs::File::open(output_bam).unwrap());
+        let _header = reader.read_header().unwrap();
+        reader
+            .records()
+            .map(|result| {
+                let record = result.expect("failed to read consensus record");
+                let name = String::from_utf8(
+                    record.name().expect("consensus record must have a read name").to_vec(),
+                )
+                .expect("consensus read name must be UTF-8");
+                // Consensus reads are named `<read-group-prefix>:<base MI>`, so the molecule
+                // identity survives in the name even though the `/A`-`/B` suffix does not.
+                let (_prefix, molecule) = name.rsplit_once(':').unwrap_or_else(|| {
+                    panic!("consensus read name '{name}' must be '<prefix>:<MI>'")
+                });
+                let flags = record.flags();
+                assert!(flags.is_segmented(), "consensus record '{name}' must be paired");
+                assert!(
+                    flags.is_first_segment() != flags.is_last_segment(),
+                    "consensus record '{name}' must be exactly one of R1/R2"
+                );
+                let bases: String = record.sequence().iter().map(char::from).collect();
+                assert_eq!(
+                    record.quality_scores().as_ref().len(),
+                    bases.len(),
+                    "consensus record '{name}' must carry one quality per base"
+                );
+                (flags.is_first_segment(), molecule.to_string(), bases)
+            })
+            .collect()
+    };
+
+    // The molecule's reads are `sequence` long, and a single-strand consensus over identical
+    // Q30 reads reproduces those bases (reverse-complemented on whichever end the strand puts
+    // in reverse orientation), so neither end may come back empty or N-masked.
+    let sequence = "ACGTACGT";
+    let expected_bases = [sequence.to_string(), reverse_complement(sequence)];
+
+    // The whole contract for an emitted pair: two records, exactly one R1, both carrying the
+    // input molecule's id and reproducing its bases. Every accepting case below asserts this,
+    // so none of them can pass on a bare record count.
+    let assert_is_the_molecules_pair = |reads: &[(bool, String, String)], context: &str| {
+        assert_eq!(reads.len(), 2, "{context}: expected an R1/R2 consensus pair, got {reads:?}");
+        assert_eq!(
+            reads.iter().filter(|(is_r1, _, _)| *is_r1).count(),
+            1,
+            "{context}: the pair must be exactly one consensus R1 and one consensus R2, got \
+             {reads:?}"
+        );
+        for (_, molecule, bases) in reads {
+            assert_eq!(
+                molecule, "1",
+                "{context}: consensus must carry the input molecule's id, got {molecule}"
+            );
+            assert!(
+                expected_bases.contains(bases),
+                "{context}: consensus bases {bases:?} must reproduce the molecule's reads (one \
+                 of {expected_bases:?})"
+            );
+        }
+    };
+
+    assert_is_the_molecules_pair(
+        &run("1,1,0", &temp_dir.path().join("single-strand.bam")),
+        "a one-strand molecule with a third --min-reads value of 0",
+    );
+
+    assert!(
+        run("1", &temp_dir.path().join("both-strands.bam")).is_empty(),
+        "a one-strand molecule must still be rejected when both strands are required"
+    );
+
+    // Template-count boundary. The molecule is MOLECULE_DEPTH templates but twice that many
+    // read records, so a threshold in between separates the two readings: at exactly
+    // MOLECULE_DEPTH the molecule must still be emitted, and one above it must be rejected.
+    // An implementation counting records instead of templates would emit in both cases.
+    let at_depth = format!("{MOLECULE_DEPTH},{MOLECULE_DEPTH},0");
+    assert_is_the_molecules_pair(
+        &run(&at_depth, &temp_dir.path().join("at-template-count.bam")),
+        &format!("--min-reads {at_depth} equals the molecule's {MOLECULE_DEPTH} templates"),
+    );
+    let above_depth = format!("{},{},0", MOLECULE_DEPTH + 1, MOLECULE_DEPTH + 1);
+    assert!(
+        run(&above_depth, &temp_dir.path().join("above-template-count.bam")).is_empty(),
+        "--min-reads {above_depth} exceeds the molecule's {MOLECULE_DEPTH} templates, so no \
+         consensus may be emitted -- the {} read records must not count toward the threshold",
+        MOLECULE_DEPTH * 2
+    );
+}
+
+/// An out-of-order `--min-reads` is an argument error, not a mid-run failure.
+///
+/// Both execution paths must reject it before touching the output. That is only
+/// automatic single-threaded, where the caller is constructed up front; `--threads`
+/// mode builds its caller inside the pipeline's per-batch closure, i.e. after the
+/// output BAM has been created, so without an up-front check the same bad value
+/// would surface as a wrapped worker I/O error over a partial file.
+#[rstest]
+fn test_duplex_rejects_out_of_order_min_reads_before_writing_output(
+    #[values(None, Some("2"))] threads: Option<&str>,
+    #[values("1,2,3", "3,1,2")] min_reads: &str,
+) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    create_duplex_bam(
+        &input_bam,
+        vec![create_single_strand_molecule("1", "ACGTACGT", 30, 100, 3, false)],
+    );
+
+    let mut args = vec![
+        "duplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        min_reads,
+        "--compression-level",
+        "1",
+    ];
+    if let Some(threads) = threads {
+        args.extend_from_slice(&["--threads", threads]);
+    }
+
+    let error = Duplex::try_parse_from(args)
+        .expect("failed to parse duplex args")
+        .execute("fgumi duplex")
+        .expect_err(&format!("--min-reads {min_reads} must be rejected"));
+    let message = format!("{error:#}");
+    assert!(
+        message.contains("min-reads values must be specified high to low"),
+        "--min-reads {min_reads} must fail as an argument error, got: {message}"
+    );
+    assert!(
+        !output_bam.exists(),
+        "--min-reads {min_reads} must be rejected before the output BAM is created, but \
+         {} was left behind",
+        output_bam.display()
+    );
+}
+
+/// Reverse complement, for deriving the source-molecule orientation of a reverse-strand read.
+fn reverse_complement(sequence: &str) -> String {
+    sequence
+        .chars()
+        .rev()
+        .map(|base| match base {
+            'A' => 'T',
+            'C' => 'G',
+            'G' => 'C',
+            'T' => 'A',
+            other => other,
+        })
+        .collect()
+}
+
+/// In single-strand mode a consensus read must be built from the input read of the same
+/// end, for a `/B`-only molecule as much as for a `/A`-only one: consensus R1 from the
+/// molecule's R1s and consensus R2 from its R2s, each in source-molecule orientation.
+///
+/// This matches fgbio, which treats whichever strand group is present as the "AB" group.
+#[rstest]
+fn test_duplex_single_strand_consensus_reads_follow_input_read_ends(
+    #[values(true, false)] is_b_strand: bool,
+    #[values(None, Some("2"))] threads: Option<&str>,
+) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    // Deliberately not reverse complements of each other, so that "built from R1" and
+    // "built from R2" cannot produce the same bases.
+    let (r1_seq, r2_seq) = ("AAAACCCC", "ACACACAC");
+    let strand = if is_b_strand { 'B' } else { 'A' };
+    let molecule = (0..3)
+        .map(|i| {
+            create_duplex_read_pair_with_sequences(
+                &format!("{strand}_{i}"),
+                &format!("1/{strand}"),
+                r1_seq,
+                r2_seq,
+                30,
+                100,
+                is_b_strand,
+            )
+        })
+        .collect();
+    create_duplex_bam(&input_bam, vec![molecule]);
+
+    let mut args = vec![
+        "duplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1,1,0",
+        "--compression-level",
+        "1",
+    ];
+    if let Some(threads) = threads {
+        args.extend_from_slice(&["--threads", threads]);
+    }
+    Duplex::try_parse_from(args)
+        .expect("failed to parse duplex args")
+        .execute("fgumi duplex")
+        .expect("Duplex command failed");
+
+    // `/A` reads are R1-forward/R2-reverse and `/B` reads the reverse, so the source-molecule
+    // orientation of each end flips with the strand.
+    let (expected_r1, expected_r2) = if is_b_strand {
+        (reverse_complement(r1_seq), r2_seq.to_string())
+    } else {
+        (r1_seq.to_string(), reverse_complement(r2_seq))
+    };
+
+    let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    let _header = reader.read_header().unwrap();
+    let mut seen_r1 = None;
+    let mut seen_r2 = None;
+    for result in reader.records() {
+        let record = result.expect("Failed to read record");
+        let bases: String = record.sequence().iter().map(char::from).collect();
+        if record.flags().is_first_segment() {
+            seen_r1 = Some(bases);
+        } else {
+            seen_r2 = Some(bases);
+        }
+    }
+
+    assert_eq!(
+        seen_r1.as_deref(),
+        Some(expected_r1.as_str()),
+        "consensus R1 must be built from the molecule's R1 reads"
+    );
+    assert_eq!(
+        seen_r2.as_deref(),
+        Some(expected_r2.as_str()),
+        "consensus R2 must be built from the molecule's R2 reads"
+    );
+}
+
+/// Build a `/A` read pair whose mates align over exactly the same reference bases, so the
+/// overlapping-bases consensus has something to correct.
+fn create_fully_overlapping_pair(
+    name: &str,
+    mi_tag: &str,
+    r1_sequence: &str,
+    r2_sequence: &str,
+    quality: u8,
+    ref_start: i32,
+) -> (RawRecord, RawRecord) {
+    assert_eq!(r1_sequence.len(), r2_sequence.len(), "R1 and R2 must be the same length");
+    let read_len = r1_sequence.len();
+    let cigar_op = u32::try_from(read_len).expect("read_len fits u32") << 4;
+    let build = |sequence: &str, read_flags: u16| {
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .sequence(sequence.as_bytes())
+            .qualities(&vec![quality; read_len])
+            .flags(read_flags)
+            .ref_id(0)
+            .pos(ref_start - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar_op])
+            .mate_ref_id(0)
+            .mate_pos(ref_start - 1)
+            .template_length(0)
+            .add_string_tag(SamTag::MI, mi_tag.as_bytes());
+        b.build()
+    };
+    (
+        build(r1_sequence, flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE),
+        build(r2_sequence, flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE),
+    )
+}
+
+/// R1's stored bases in the overlap fixture below.
+const OVERLAP_R1_BASES: &str = "ACGTACGT";
+/// R2's stored bases in the overlap fixture below. BAM `SEQ` is stored in reference
+/// orientation, so these ARE R2's reference bases: they disagree with `OVERLAP_R1_BASES`
+/// at the LAST reference base (offset 7), which is the base the overlapping consensus
+/// masks. R2 is `REVERSE`, so its sequencing orientation is the reverse complement
+/// `TCGTACGT` — what the uncorrected consensus emits for R2.
+const OVERLAP_R2_BASES: &str = "ACGTACGA";
+
+/// Write the single-strand overlapping-mates fixture: one `/A` pair whose mates align over
+/// exactly the same reference bases at equal quality but disagree at one of them.
+///
+/// One BAM builder serves both the assertion test and the `#[ignore]`d regen test below,
+/// so the bytes the offline fgbio run consumes are the bytes the command under test reads.
+fn write_overlapping_single_strand_fixture(path: &Path) {
+    let molecule = vec![create_fully_overlapping_pair(
+        "ab_0",
+        "1/A",
+        OVERLAP_R1_BASES,
+        OVERLAP_R2_BASES,
+        30,
+        100,
+    )];
+    create_duplex_bam(path, vec![molecule]);
+}
+
+/// Re-emit the single-strand overlapping-mates fixture BAM for a fresh fgbio capture.
+///
+/// Mirrors `fgumi_consensus`'s `regen_write` helper — writes to `FGUMI_ORACLE_BAM_OUT` when
+/// set, otherwise to a logged temp path — which that crate keeps `pub(crate)`, so it cannot
+/// be shared with this integration test.
+#[test]
+#[ignore = "regen: writes the fixture BAM (set FGUMI_ORACLE_BAM_OUT), then run fgbio on it"]
+fn regen_duplex_single_strand_overlap_fixture() {
+    let path = std::env::var_os("FGUMI_ORACLE_BAM_OUT").map_or_else(
+        || {
+            let (_file, path) = tempfile::NamedTempFile::new()
+                .expect("temp fixture BAM")
+                .keep()
+                .expect("persist temp fixture BAM");
+            path
+        },
+        PathBuf::from,
+    );
+    write_overlapping_single_strand_fixture(&path);
+    eprintln!("wrote fixture BAM to {}", path.display());
+}
+
+/// The overlapping-bases consensus is applied to single-strand molecules too.
+///
+/// It is skipped for groups without both strands on the grounds that no duplex consensus
+/// can be built from them — which stops being true once the third `--min-reads` value is 0.
+///
+/// Both the corrected and uncorrected outputs are pinned to a real fgbio run on this exact
+/// fixture rather than to a "contains an N" predicate, so a masking rule that differs from
+/// fgbio in WHICH base it masks, or in what it leaves behind, is caught. Oracle provenance
+/// — fgbio `4.1.0`, on the BAM `regen_duplex_single_strand_overlap_fixture` emits:
+///
+/// ```text
+/// fgbio CallDuplexConsensusReads -i <fixture>.bam -o out.bam -M 1 1 0 \
+///   --consensus-call-overlapping-bases {true,false}
+/// samtools view out.bam   # SEQ of the R1 (0x40) and R2 (0x80) records
+/// ```
+#[rstest]
+fn test_duplex_single_strand_mode_applies_overlapping_consensus(
+    #[values(None, Some("2"))] threads: Option<&str>,
+) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+
+    write_overlapping_single_strand_fixture(&input_bam);
+
+    // Each consensus record as `(is_r1, bases, qualities)`. Qualities are part of the pinned
+    // identity: the overlapping consensus combines the mates' evidence where they AGREE,
+    // which raises the consensus quality, so bases alone would not catch a correction that
+    // masked the right base but mis-weighted the rest.
+    let consensus_reads = |overlapping: &str, output_bam: &Path| -> Vec<(bool, String, String)> {
+        let mut args = vec![
+            "duplex",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output_bam.to_str().unwrap(),
+            "--min-reads",
+            "1,1,0",
+            "--consensus-call-overlapping-bases",
+            overlapping,
+            "--compression-level",
+            "1",
+        ];
+        if let Some(threads) = threads {
+            args.extend_from_slice(&["--threads", threads]);
+        }
+        Duplex::try_parse_from(args)
+            .expect("failed to parse duplex args")
+            .execute("fgumi duplex")
+            .expect("Duplex command failed");
+
+        let mut reader = bam::io::Reader::new(fs::File::open(output_bam).unwrap());
+        let _header = reader.read_header().unwrap();
+        let mut reads: Vec<(bool, String, String)> = reader
+            .records()
+            .map(|result| {
+                let record = result.expect("Failed to read record");
+                let bases: String = record.sequence().iter().map(char::from).collect();
+                // Render qualities as the printable SAM characters the captured fgbio
+                // `samtools view` output shows, so expected and actual read alike.
+                let quals: String =
+                    record.quality_scores().as_ref().iter().map(|&q| char::from(q + 33)).collect();
+                (record.flags().is_first_segment(), bases, quals)
+            })
+            .collect();
+        reads.sort_by_key(|(is_r1, _, _)| !*is_r1);
+        reads
+    };
+
+    // fgbio's captured output. The mates disagree at the LAST reference base, which the
+    // overlapping consensus masks to N at qual 2 in both mates. In sequencing orientation
+    // that lands at the end of R1 (forward) and at the start of R2 (reverse), and fgbio
+    // treats the two ends differently: the leading no-call survives as an `N` with depth 0,
+    // while the trailing one is trimmed, leaving R1 one base shorter than R2. Confirmed by
+    // running the same fgbio command on a fixture that disagrees at the FIRST reference
+    // base instead, which swaps the two records' shapes exactly.
+    let corrected = consensus_reads("true", &temp_dir.path().join("corrected.bam"));
+    assert_eq!(
+        corrected,
+        vec![
+            (true, "ACGTACG".to_string(), "HHHHHHH".to_string()),
+            (false, "NCGTACGT".to_string(), "#HHHHHHH".to_string()),
+        ],
+        "corrected single-strand output must match the captured fgbio 4.1.0 run"
+    );
+
+    // Without the correction each mate is consensus-called on its own, so both keep all
+    // eight bases -- R2 reverse-complemented into sequencing orientation -- and the quality
+    // stays at what one Q30 read supports rather than the combined value above.
+    let uncorrected = consensus_reads("false", &temp_dir.path().join("uncorrected.bam"));
+    assert_eq!(
+        uncorrected,
+        vec![
+            (true, "ACGTACGT".to_string(), ">>>>>>>>".to_string()),
+            (false, "TCGTACGT".to_string(), ">>>>>>>>".to_string()),
+        ],
+        "uncorrected single-strand output must match the captured fgbio 4.1.0 run"
+    );
 }
 
 /// The reported `consensus_reads_emitted` must equal the number of consensus records


### PR DESCRIPTION
Closes #678.

`fgumi duplex --min-reads 1,1,0` — fgbio's single-strand mode, where a molecule observed on only one strand still yields a consensus — worked in 0.4.0 and errors out in 0.5.0. `DuplexConsensusCaller` has always implemented the mode; what changed is the CLI. #601 added a lower bound to `Duplex::validate()` for consistency with `simplex` and `codec`, but its blanket `contains(&0)` also rejected the per-strand slots, where a 0 is meaningful.

The bound is dropped entirely rather than narrowed, matching fgbio, which validates only that the values run from least to most stringent. `simplex` and `codec` keep their check, because there a 0 really does make the minimum-family-size filter a silent no-op — that part of #601 stands. `duplex` differs in both slots: a 0 per strand is the single-strand mode, and a total of 0 is equivalent to 1 rather than degenerate, because the check it feeds (`min_total <= num_xy + num_yx`) is only reached for a group that already has at least one read.

Restoring the flag alone was not enough to reproduce fgbio, because two code paths that are unreachable while the mode is gated were wrong.

**The overlapping-bases consensus was skipped for single-strand groups.** It is gated on the group having both strands, "no duplex possible anyway" — which stops being true once the third value is 0, so single-strand molecules with overlapping mates kept uncorrected bases. It is now gated on whether the group can actually produce a consensus.

**BA-only molecules came out with R1/R2 swapped relative to fgbio.** #298 mapped output R1 from BA-R2 and R2 from BA-R1, to keep output R1 on the physical strand that AB-R1 would have sequenced. That formula holds only while both strand groups are present; fgbio does not extend it to a lone group, taking whichever group is present as its "AB" side, so output R1 comes from that group's R1s whether it is `/A` or `/B`. Verified in the data — within a molecule, AB-R1 and BA-R1 are on opposite strands at opposite ends:

```
molecule 13395: A-R1=fwd@44192844   B-R1=rev@44193088
molecule 14413: A-R1=rev@67604810   B-R1=fwd@67604719
```

so the previous mapping put the opposite end of the molecule in R1 for `/B`-only molecules than for every other molecule class. Each consensus read is now built from the input reads of the same end. **#298's other half is preserved**: BA still goes in the BA slot, so `is_ba_only` stays true and per-strand methylation tags are still emitted as `bm`/`bu`/`bt` — that flag records which strand *group* the bases came from, which the end does not change. `test_duplex_ba_only_methylation_tags_use_bottom_strand` is untouched and passes; `test_duplex_ba_only_mate_pair_mapping` is updated to the new expectation.

## Verification

On 20,000 simulated duplex molecules (81,368 raw reads), against fgbio 4.1.0, comparing with `fgumi compare bams --command duplex`:

| `--min-reads` | records | content diffs vs fgbio |
|---|---|---|
| `1` | 21,432 | 0 |
| `1,1,0` | 40,000 | 0 |
| `1,1,0 --threads 4` | 40,000 | 0 |
| `0` | 40,000 | 0 |

Before this change, 14,014 of those 40,000 records differed from fgbio, in two ways: R1/R2 swaps on `/B`-only molecules, and missing overlap corrections on single-strand molecules whose mates overlap. Disabling the overlapping consensus on both sides isolates the first defect, and it accounts for exactly 9,048 differing records — the R1/R2 pairs of all 4,524 `/B`-only molecules, with the 4,760 `/A`-only and 10,716 two-strand molecules matching fgbio exactly. `--min-reads 1` is unchanged.

New tests, each watched failing first: `--min-reads` lower-bound cases; single-strand molecules are emitted with `1,1,0` and still rejected with `1`; consensus reads follow input read ends for `/A`-only and `/B`-only molecules; the overlapping consensus is applied to single-strand groups. All are parameterized over single-threaded and `--threads 2`.

`cargo ci-test` (6,903 tests), `cargo ci-fmt`, and `cargo ci-lint` pass.

## Note on fgbio's docs

fgbio implements this mode but does not document it — neither `CallDuplexConsensusReads` nor `FilterConsensusReads` mentions a 0 value, and `DuplexConsensusCaller.duplexConsensus`'s own scaladoc ("If either of the incoming reads are undefined, the duplex read will be undefined") contradicts its `case (Some(a), None)` arm. This PR documents the mode on the fgumi side, in the duplex consensus guide and in `--min-reads`' help text.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Duplex consensus calling supports single-strand molecules with configurations such as `--min-reads 1,1,0`.
  - Single-strand consensus reads are marked with `bD:i:0`.
  - Consensus generation is consistent in threaded and single-threaded modes.

- **Bug Fixes**
  - Corrected R1/R2 orientation and methylation handling for BA-only consensus output.
  - Improved overlapping-base handling and threshold enforcement.
  - Invalid `--min-reads` configurations are rejected before output is created.

- **Documentation**
  - Added guidance on zero-valued thresholds, filtering, and fgbio equivalence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->