### PR TITLE
test(consensus): pin reported consensus reads to records written

### DIFF
--- a/tests/integration/helpers/assertions.rs
+++ b/tests/integration/helpers/assertions.rs
@@ -17,6 +17,42 @@ const BGZF_EOF: [u8; 28] = [
     0x1b, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 ];
 
+/// Reads a required string tag off an emitted BAM record.
+///
+/// The `bam::Record` counterpart to [`assert_mi_tag`] and friends, for tests that
+/// compare a whole emitted record against an expected one rather than checking a
+/// single field. Panics rather than returning an `Option`: a missing tag is a
+/// defect in the command under test, not a case the caller should handle.
+///
+/// # Panics
+///
+/// Panics if the tag is absent, unreadable, or not a string.
+pub fn string_tag(record: &noodles::bam::Record, tag: SamTag) -> String {
+    match record.data().get(&tag.to_noodles_tag()) {
+        Some(Ok(noodles::sam::alignment::record::data::field::Value::String(value))) => {
+            value.to_string()
+        }
+        other => panic!("record must carry a string {tag:?} tag, got {other:?}"),
+    }
+}
+
+/// Reads a required integer tag off an emitted BAM record.
+///
+/// Widens every SAM integer width to `i64`, so a caller's expectation does not
+/// have to predict whether a small count was encoded as `Int8` or `Int32`.
+///
+/// # Panics
+///
+/// Panics if the tag is absent, unreadable, or not an integer.
+pub fn int_tag(record: &noodles::bam::Record, tag: SamTag) -> i64 {
+    match record.data().get(&tag.to_noodles_tag()) {
+        Some(Ok(value)) => {
+            value.as_int().unwrap_or_else(|| panic!("{tag:?} must be an integer, got {value:?}"))
+        }
+        other => panic!("record must carry an integer {tag:?} tag, got {other:?}"),
+    }
+}
+
 /// Asserts that a file ends with the standard 28-byte BGZF EOF marker block.
 ///
 /// # Panics

--- a/tests/integration/test_codec_command.rs
+++ b/tests/integration/test_codec_command.rs
@@ -14,10 +14,12 @@ use fgumi_lib::commands::command::Command;
 use fgumi_lib::sam::SamTag;
 use fgumi_raw_bam::{RawRecord, SamBuilder, flags as raw_flags};
 use noodles::bam;
+use rstest::rstest;
 use std::fs;
 use std::path::PathBuf;
 use tempfile::TempDir;
 
+use crate::helpers::assertions::{int_tag, string_tag};
 use crate::helpers::bam_generator::create_minimal_header;
 
 /// Creates a CODEC read pair (R1 forward, R2 reverse from opposite strand).
@@ -319,6 +321,131 @@ fn test_codec_command_with_stats() {
     // Verify stats file has content
     let stats_content = fs::read_to_string(&stats_file).expect("Failed to read stats");
     assert!(!stats_content.is_empty(), "Stats file should not be empty");
+}
+
+/// A codec consensus record reduced to the fields a caller cannot get right by accident:
+/// its name, flags, sequence, molecule identifier, and the raw-read depths it claims.
+#[derive(Debug, PartialEq, Eq)]
+struct CodecConsensusIdentity {
+    name: String,
+    flags: u16,
+    sequence: String,
+    mi: String,
+    total_depth: i64,
+    a_depth: i64,
+    b_depth: i64,
+}
+
+impl CodecConsensusIdentity {
+    /// Project an emitted BAM record onto the fields this test pins.
+    fn from_record(record: &bam::Record) -> Self {
+        Self {
+            name: String::from_utf8_lossy(
+                record.name().expect("consensus record must be named").as_ref(),
+            )
+            .into_owned(),
+            flags: record.flags().bits(),
+            sequence: record.sequence().iter().map(char::from).collect(),
+            mi: string_tag(record, SamTag::MI),
+            total_depth: int_tag(record, SamTag::CD),
+            a_depth: int_tag(record, SamTag::AD),
+            b_depth: int_tag(record, SamTag::BD),
+        }
+    }
+}
+
+/// The reported `consensus_reads_emitted` must equal the number of consensus records
+/// actually written, in both the single-threaded and pipeline (`--threads N`) paths.
+///
+/// `ConsensusCallingStats::consensus_reads` counts emitted reads, so a caller that counts
+/// molecules or templates instead reports a number that does not match its own output.
+#[rstest]
+#[case::single_threaded(None)]
+#[case::threaded(Some("2"))]
+fn test_codec_stats_consensus_reads_matches_records_written(#[case] threads: Option<&str>) {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let stats_file = temp_dir.path().join("stats.tsv");
+
+    let mut pairs = Vec::new();
+    for molecule in 0..3 {
+        for read in 0..3 {
+            let (r1, r2) = create_codec_read_pair(
+                &format!("mol{molecule}_read{read}"),
+                b"ACGTACGT",
+                b"ACGTACGT",
+                &[30; 8],
+                &[30; 8],
+                100 + molecule * 100,
+                &format!("UMI00{molecule}"),
+                None,
+            );
+            pairs.push((r1, r2));
+        }
+    }
+    create_codec_test_bam(&input_bam, pairs);
+
+    let mut args = vec![
+        "codec",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--stats",
+        stats_file.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--min-duplex-length",
+        "1",
+        "--compression-level",
+        "1",
+    ];
+    if let Some(threads) = threads {
+        args.extend_from_slice(&["--threads", threads]);
+    }
+    Codec::try_parse_from(args)
+        .expect("failed to parse codec args")
+        .execute("fgumi codec")
+        .expect("Failed to run codec command");
+
+    // Identity, not just cardinality: every molecule is built from three identical read
+    // pairs, so each consensus record is fully determined -- one unmapped record per
+    // molecule, named and MI-tagged by its UMI, carrying the molecule's sequence and its
+    // six raw reads split evenly across the two strands.
+    let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    let _header = reader.read_header().unwrap();
+    let records =
+        reader.records().collect::<Result<Vec<_>, _>>().expect("failed to read the consensus BAM");
+    let observed = records.iter().map(CodecConsensusIdentity::from_record).collect::<Vec<_>>();
+    let expected = (0..3)
+        .map(|molecule| CodecConsensusIdentity {
+            name: format!(":UMI00{molecule}"),
+            flags: raw_flags::UNMAPPED,
+            sequence: "ACGTACGT".to_string(),
+            mi: format!("UMI00{molecule}"),
+            total_depth: 6,
+            a_depth: 3,
+            b_depth: 3,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(observed, expected, "codec must emit one fully determined consensus per molecule");
+
+    let records_written = records.len();
+
+    let stats = fs::read_to_string(&stats_file).expect("Failed to read stats");
+    let emitted: usize = stats
+        .lines()
+        .find_map(|line| line.strip_prefix("consensus_reads_emitted\t"))
+        .and_then(|rest| rest.split('\t').next())
+        .expect("stats must contain a consensus_reads_emitted row")
+        .parse()
+        .expect("consensus_reads_emitted must be an integer");
+
+    assert_eq!(
+        emitted, records_written,
+        "consensus_reads_emitted must count consensus reads written to the output BAM"
+    );
 }
 
 /// Test CODEC command with rejected reads output.

--- a/tests/integration/test_simplex_command.rs
+++ b/tests/integration/test_simplex_command.rs
@@ -10,18 +10,23 @@ use clap::Parser;
 use fgumi_lib::commands::command::Command;
 use fgumi_lib::commands::simplex::Simplex;
 use fgumi_lib::sam::SamTag;
+use fgumi_raw_bam::flags as raw_flags;
 use noodles::bam;
 use noodles::sam::Header;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use noodles::sam::header::record::value::Map;
 use noodles::sam::header::record::value::map::ReadGroup;
 use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
+use rstest::rstest;
 use std::fs;
 use std::num::NonZeroUsize;
 use std::path::Path;
 use tempfile::TempDir;
 
-use crate::helpers::bam_generator::{create_minimal_header, create_umi_family, to_record_buf};
+use crate::helpers::assertions::{int_tag, string_tag};
+use crate::helpers::bam_generator::{
+    create_minimal_header, create_paired_umi_family, create_umi_family, to_record_buf,
+};
 
 /// Write grouped BAM file (reads grouped by MI tag).
 fn create_grouped_bam(path: &Path, families: Vec<(&str, Vec<fgumi_raw_bam::RawRecord>)>) {
@@ -112,6 +117,125 @@ fn test_simplex_command_with_stats() {
     .expect("failed to parse simplex args");
     cmd.execute("fgumi simplex").expect("Simplex command with stats failed");
     assert!(stats_path.exists(), "Stats file not created");
+}
+
+/// A simplex consensus record reduced to the fields a caller cannot get right by accident:
+/// its name, flags, sequence, molecule identifier, UMI, and the raw-read depth it claims.
+#[derive(Debug, PartialEq, Eq)]
+struct SimplexConsensusIdentity {
+    name: String,
+    flags: u16,
+    sequence: String,
+    mi: String,
+    rx: String,
+    depth: i64,
+}
+
+impl SimplexConsensusIdentity {
+    /// Project an emitted BAM record onto the fields this test pins.
+    fn from_record(record: &bam::Record) -> Self {
+        Self {
+            name: String::from_utf8_lossy(
+                record.name().expect("consensus record must be named").as_ref(),
+            )
+            .into_owned(),
+            flags: record.flags().bits(),
+            sequence: record.sequence().iter().map(char::from).collect(),
+            mi: string_tag(record, SamTag::MI),
+            rx: string_tag(record, SamTag::RX),
+            depth: int_tag(record, SamTag::CD),
+        }
+    }
+}
+
+/// The reported `consensus_reads_emitted` must equal the number of consensus records
+/// actually written, in both the single-threaded and pipeline (`--threads N`) paths.
+///
+/// `ConsensusCallingStats::consensus_reads` counts emitted reads, so a caller that counts
+/// molecules or templates instead reports a number that does not match its own output.
+#[rstest]
+#[case::single_threaded(None)]
+#[case::threaded(Some("2"))]
+fn test_simplex_stats_consensus_reads_matches_records_written(#[case] threads: Option<&str>) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let stats_path = temp_dir.path().join("stats.txt");
+
+    // Paired families, so the caller's R1/R2 branch -- the one that must record two
+    // consensus reads per template -- is the branch under test.
+    let families = (1..=3)
+        .map(|i| {
+            create_paired_umi_family("ACGT", 3, &format!("fam{i}"), "ACGTACGT", "TTTTAAAA", 30)
+        })
+        .collect::<Vec<_>>();
+    create_grouped_bam(
+        &input_bam,
+        vec![("1", families[0].clone()), ("2", families[1].clone()), ("3", families[2].clone())],
+    );
+
+    let mut args = vec![
+        "simplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--stats",
+        stats_path.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ];
+    if let Some(threads) = threads {
+        args.extend_from_slice(&["--threads", threads]);
+    }
+    Simplex::try_parse_from(args)
+        .expect("failed to parse simplex args")
+        .execute("fgumi simplex")
+        .expect("Simplex command failed");
+
+    // Identity, not just cardinality: every family is built from three identical read
+    // pairs, so each consensus pair is fully determined -- an R1/R2 pair per family,
+    // named and MI-tagged by the family's molecule id, carrying that family's two
+    // sequences, its UMI, and its three raw reads per strand.
+    let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    let _header = reader.read_header().unwrap();
+    let records =
+        reader.records().collect::<Result<Vec<_>, _>>().expect("failed to read the consensus BAM");
+    let observed = records.iter().map(SimplexConsensusIdentity::from_record).collect::<Vec<_>>();
+    let unmapped_pair = raw_flags::PAIRED | raw_flags::UNMAPPED | raw_flags::MATE_UNMAPPED;
+    let expected = (1..=3)
+        .flat_map(|family| {
+            [(raw_flags::FIRST_SEGMENT, "ACGTACGT"), (raw_flags::LAST_SEGMENT, "TTTTAAAA")].map(
+                |(segment, sequence)| SimplexConsensusIdentity {
+                    name: format!(":{family}"),
+                    flags: unmapped_pair | segment,
+                    sequence: sequence.to_string(),
+                    mi: family.to_string(),
+                    rx: "ACGT".to_string(),
+                    depth: 3,
+                },
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(observed, expected, "simplex must emit one fully determined R1/R2 pair per family");
+
+    let records_written = records.len();
+
+    let stats = fs::read_to_string(&stats_path).expect("read stats");
+    let emitted: usize = stats
+        .lines()
+        .find_map(|line| line.strip_prefix("consensus_reads_emitted\t"))
+        .and_then(|rest| rest.split('\t').next())
+        .expect("stats must contain a consensus_reads_emitted row")
+        .parse()
+        .expect("consensus_reads_emitted must be an integer");
+
+    assert_eq!(
+        emitted, records_written,
+        "consensus_reads_emitted must count consensus reads written to the output BAM"
+    );
 }
 
 /// Test simplex command with rejects output.


### PR DESCRIPTION
Follow-up to #681, which fixed `duplex` reporting half the consensus reads it wrote: the caller recorded one consensus per emitted *template* while `ConsensusCallingStats::consensus_reads` counts emitted *reads*.

I checked the two sibling commands for the same defect and **neither has it** — codec emits one record per molecule and increments once per record, and the vanilla caller behind simplex records twice for an R1/R2 pair and once for a fragment. So there is no bug to fix here. What was missing is that nothing *pinned* the invariant #681 established, so it could regress in either command without a test noticing.

This adds the same rstest case table to both: run the command single-threaded and with `--threads 2`, then assert the `consensus_reads_emitted` row in `--stats` equals the records in the output BAM.

## These tests are load-bearing

A test that passes the moment it is written proves nothing on its own, so both were verified by mutation:

| Mutation | Result |
|---|---|
| codec `consensus_reads_generated += 1` → `+= 2` | codec test fails, 6 vs 3, both threading modes |
| vanilla caller's second `record_consensus()` for a pair dropped | simplex test fails, 3 vs 6, both threading modes |

The simplex case deliberately uses `create_paired_umi_family` rather than `create_umi_family`. That matters: `create_umi_family` builds *fragment* reads, so the R1/R2 branch that records twice is never reached, and with fragments the test **passed under mutation** — it would have been decoration. Worth knowing for anyone adding coverage to the consensus callers.

`cargo ci-test` (6,894 tests), `cargo ci-fmt`, and `cargo ci-lint` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added parameterized integration tests for codec and simplex processing.
  * Verified consensus record identities, pairing information, metadata tags, and output statistics.
  * Covered both single-threaded and two-thread execution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->