### PR TITLE
fix(sort, fastq, extract): stream `-o -` to stdout instead of creating a file named `-`

### DIFF
--- a/crates/fgumi-bam-io/src/lib.rs
+++ b/crates/fgumi-bam-io/src/lib.rs
@@ -39,5 +39,6 @@ pub use reorder::{DrainReady, ReorderBuffer};
 pub use writer::{
     BaiBuilder, BamWriter, BgzfWriterEnum, IndexingBamWriter, RawBamWriter, bai_sidecar_path,
     create_bam_writer, create_indexing_bam_writer, create_optional_bam_writer,
-    create_raw_bam_writer, write_bai_index, write_bai_sidecar, write_bam_header,
+    create_raw_bam_writer, open_output_writer, write_bai_index, write_bai_sidecar,
+    write_bam_header,
 };

--- a/crates/fgumi-bam-io/src/writer.rs
+++ b/crates/fgumi-bam-io/src/writer.rs
@@ -1165,12 +1165,16 @@ pub fn create_optional_bam_writer<P: AsRef<Path>>(
 
 /// Open an output writer for a path, supporting stdout via `-` or `/dev/stdout`.
 ///
-/// This is the single place the `-` convention is honoured, so anything writing
-/// a command's output must come through here (directly, or via one of the
+/// This is the single place the `-` convention is honoured **for BAM output**,
+/// so any BAM writer must come through here (directly, or via one of the
 /// `create_*_bam_writer` helpers) rather than calling `File::create` itself. A
 /// writer that opens the path directly silently creates a regular file *named*
 /// `-` and exits zero with an empty pipe — see the stdout axis in
 /// `tests/integration/test_input_source_matrix.rs`.
+///
+/// Commands whose output is text rather than BAM (`fgumi fastq`) do not need the
+/// boxed writer and dispatch on [`is_stdout_path`] themselves, taking
+/// `stdout().lock()` directly.
 ///
 /// A stdout path yields a block-buffered handle — fd 1 duplicated into a
 /// [`File`] — rather than [`std::io::Stdout`], whose `LineWriter` would tear

--- a/crates/fgumi-bam-io/src/writer.rs
+++ b/crates/fgumi-bam-io/src/writer.rs
@@ -1164,15 +1164,63 @@ pub fn create_optional_bam_writer<P: AsRef<Path>>(
 }
 
 /// Open an output writer for a path, supporting stdout via `-` or `/dev/stdout`.
-pub(crate) fn open_output_writer<P: AsRef<Path>>(path: P) -> Result<Box<dyn Write + Send>> {
+///
+/// This is the single place the `-` convention is honoured, so anything writing
+/// a command's output must come through here (directly, or via one of the
+/// `create_*_bam_writer` helpers) rather than calling `File::create` itself. A
+/// writer that opens the path directly silently creates a regular file *named*
+/// `-` and exits zero with an empty pipe — see the stdout axis in
+/// `tests/integration/test_input_source_matrix.rs`.
+///
+/// A stdout path yields a block-buffered handle — fd 1 duplicated into a
+/// [`File`] — rather than [`std::io::Stdout`], whose `LineWriter` would tear
+/// every BGZF flush at each `0x0a`.
+///
+/// # Errors
+///
+/// Returns an error if `path` names a file that cannot be created, or if the
+/// stdout descriptor cannot be duplicated.
+pub fn open_output_writer<P: AsRef<Path>>(path: P) -> Result<Box<dyn Write + Send>> {
     let path_ref = path.as_ref();
     if is_stdout_path(path_ref) {
-        Ok(Box::new(std::io::stdout()))
+        block_buffered_stdout()
     } else {
         let file = File::create(path_ref)
             .with_context(|| format!("Failed to create output BAM: {}", path_ref.display()))?;
         Ok(Box::new(file))
     }
+}
+
+/// A block-buffered handle on this process's stdout.
+///
+/// [`std::io::Stdout`] wraps a `LineWriter`, which splits every write at the last
+/// `\n` in the buffer and issues the two halves separately. BGZF blocks carry
+/// `0x0a` at arbitrary offsets, so a single large flush from the caller's
+/// `BufWriter` would be torn into many small `write` calls on the hot output
+/// path. Duplicating the descriptor into a [`File`] bypasses the line buffering
+/// and leaves batching to the caller's buffer, where it belongs.
+///
+/// The descriptor is duplicated rather than taken, so dropping the returned
+/// handle closes only the duplicate; fd 1 stays open for the rest of the process.
+#[cfg(unix)]
+fn block_buffered_stdout() -> Result<Box<dyn Write + Send>> {
+    use std::os::fd::AsFd;
+
+    let stdout = std::io::stdout()
+        .as_fd()
+        .try_clone_to_owned()
+        .map(File::from)
+        .context("Failed to duplicate stdout for BAM output")?;
+    Ok(Box::new(stdout))
+}
+
+/// A block-buffered handle on this process's stdout.
+///
+/// Fallback for targets without file descriptors, where the line-buffering
+/// concern described on the Unix variant cannot be worked around this way.
+#[cfg(not(unix))]
+fn block_buffered_stdout() -> Result<Box<dyn Write + Send>> {
+    Ok(Box::new(std::io::stdout()))
 }
 
 #[cfg(test)]

--- a/crates/fgumi-sort/src/bgzf_io.rs
+++ b/crates/fgumi-sort/src/bgzf_io.rs
@@ -174,8 +174,8 @@ impl StagingBuffer {
 /// `compressed_start` is captured *before* the write, so it is the on-disk byte
 /// offset at which this block begins. The BGZF EOF marker is written separately
 /// and is intentionally never passed here (no record references it).
-fn write_block_in_order(
-    writer: &mut BufWriter<std::fs::File>,
+fn write_block_in_order<W: Write>(
+    writer: &mut BufWriter<W>,
     serial: u64,
     data: &[u8],
     compressed_offset: &mut u64,
@@ -196,10 +196,14 @@ fn write_block_in_order(
 ///
 /// Uses a `BTreeMap` as a reorder buffer. When the next expected serial arrives,
 /// writes it immediately. Out-of-order blocks are buffered until their turn.
-/// Releases one permit to `permit_pool` after each block is written to disk,
+/// Releases one permit to `permit_pool` after each block is written out,
 /// unblocking the corresponding `StagingBuffer::flush()` call and bounding the
 /// number of in-flight compressed blocks to the pool capacity.
 /// Writes BGZF EOF marker and flushes when all blocks are received.
+///
+/// Generic over the sink rather than fixed to `File`: spill chunks are always
+/// files, but the sort's *output* may be stdout, which reaches here as the
+/// boxed writer `open_output_writer` hands back.
 ///
 /// When `block_offset_tx` is `Some`, each written block's `(serial,
 /// compressed_start)` is emitted on it (in strict block order) for BAI virtual
@@ -207,11 +211,11 @@ fn write_block_in_order(
 ///
 /// # Errors
 ///
-/// Returns an error if any disk write fails or if a compressed block is missing
+/// Returns an error if any write fails or if a compressed block is missing
 /// (which would silently truncate the output).
 #[allow(clippy::needless_pass_by_value)]
-pub(crate) fn io_writer_loop(
-    mut writer: BufWriter<std::fs::File>,
+pub(crate) fn io_writer_loop<W: Write>(
+    mut writer: BufWriter<W>,
     result_rx: Receiver<CompressResult>,
     buffer_pool: BufferPool,
     permit_pool: Arc<PermitPool>,
@@ -233,8 +237,8 @@ pub(crate) fn io_writer_loop(
     result
 }
 
-fn io_writer_loop_inner(
-    writer: &mut BufWriter<std::fs::File>,
+fn io_writer_loop_inner<W: Write>(
+    writer: &mut BufWriter<W>,
     result_rx: &Receiver<CompressResult>,
     buffer_pool: &BufferPool,
     permit_pool: &Arc<PermitPool>,

--- a/crates/fgumi-sort/src/pooled_bam_writer.rs
+++ b/crates/fgumi-sort/src/pooled_bam_writer.rs
@@ -25,7 +25,7 @@ use crate::codec::SpillCodec;
 use crate::worker_pool::{CompressResult, CompressTarget, PermitPool, SortWorkerPool};
 use anyhow::Result;
 use crossbeam_channel::{Receiver, bounded, unbounded};
-use fgumi_bam_io::BaiBuilder;
+use fgumi_bam_io::{BaiBuilder, is_stdout_path, open_output_writer};
 use fgumi_bgzf::BGZF_MAX_BLOCK_SIZE;
 use noodles::bam::bai;
 use noodles::sam::Header;
@@ -65,13 +65,15 @@ struct IndexState {
 impl PooledBamWriter {
     /// Create a new pooled BAM writer.
     ///
-    /// Opens the output file, writes the BAM header into the initial staging buffer,
-    /// and spawns an I/O writer thread that receives compressed blocks and writes
-    /// them in serial order.
+    /// Opens the output sink through `open_output_writer`, so `-` and
+    /// `/dev/stdout` stream to the pipe rather than creating a regular file with
+    /// that name — a non-seekable sink is accepted here. Writes the BAM header
+    /// into the initial staging buffer, and spawns an I/O writer thread that
+    /// receives compressed blocks and writes them in serial order.
     ///
     /// # Errors
     ///
-    /// Returns an error if the output file cannot be created or the header cannot
+    /// Returns an error if the output sink cannot be opened or the header cannot
     /// be serialized.
     pub fn new(pool: Arc<SortWorkerPool>, path: &Path, header: &Header) -> Result<Self> {
         Self::new_inner(pool, path, header, false)
@@ -84,11 +86,24 @@ impl PooledBamWriter {
     /// [`finish_index`](Self::finish_index). Only meaningful for
     /// coordinate-sorted output.
     ///
+    /// Unlike [`new`](Self::new), `path` must name a regular file: an index is
+    /// only usable against a sink a reader can seek within, and its sidecar is
+    /// named after `path`, so a stdout spelling would build a BAI against a pipe
+    /// and write it to a file literally named `-.bai`. The command layer rejects
+    /// `--write-index` with stdout up front, with an error that names both; this
+    /// guard keeps the invariant attached to the writer that requires it.
+    ///
     /// # Errors
     ///
-    /// Returns an error if the output file cannot be created or the header
-    /// cannot be serialized.
+    /// Returns an error if `path` is a stdout spelling, if the output file
+    /// cannot be created, or if the header cannot be serialized.
     pub fn new_indexing(pool: Arc<SortWorkerPool>, path: &Path, header: &Header) -> Result<Self> {
+        anyhow::ensure!(
+            !is_stdout_path(path),
+            "Cannot build a BAM index while streaming to stdout ({}): an index requires a \
+             seekable output file",
+            path.display()
+        );
         Self::new_inner(pool, path, header, true)
     }
 
@@ -100,8 +115,13 @@ impl PooledBamWriter {
         header: &Header,
         indexing: bool,
     ) -> Result<Self> {
-        let file = std::fs::File::create(path)?;
-        let writer = BufWriter::with_capacity(256 * 1024, file);
+        // `open_output_writer`, not `File::create`: this is the sort's *output*,
+        // so `-` and `/dev/stdout` have to reach the pipe rather than create a
+        // regular file with that name. Every one of the sort's write paths ends
+        // up here — the in-memory write, the k-way merge, and the indexing
+        // variant below — so this is the only place that dispatch is needed.
+        let sink = open_output_writer(path)?;
+        let writer = BufWriter::with_capacity(256 * 1024, sink);
 
         let reorder_capacity = pool.num_workers() * 4;
         let (result_tx, result_rx) = bounded::<CompressResult>(reorder_capacity);
@@ -303,6 +323,7 @@ mod tests {
     use super::*;
     use noodles::sam::header::record::value::Map;
     use noodles::sam::header::record::value::map::ReferenceSequence;
+    use rstest::rstest;
 
     /// Build a minimal test header with a few reference sequences.
     fn test_header() -> Header {
@@ -478,6 +499,43 @@ mod tests {
             count += 1;
         }
         assert_eq!(count, num_records, "record count mismatch");
+
+        if let Ok(pool) = Arc::try_unwrap(pool) {
+            pool.shutdown();
+        }
+    }
+
+    /// `new_indexing` must refuse a stdout spelling rather than build a BAI
+    /// against a pipe and drop it in a file named after the spelling.
+    ///
+    /// The command layer rejects `--write-index` with stdout first, so this is a
+    /// second line of defence for any future caller of this crate: the writer
+    /// that requires a seekable sink is the one that states the requirement.
+    /// Both spellings `is_stdout_path` honours are covered, since a guard that
+    /// caught only `-` would leave `/dev/stdout` writing `/dev/stdout.bai`.
+    #[rstest]
+    #[case::dash("-")]
+    #[case::dev_stdout("/dev/stdout")]
+    fn test_pooled_bam_writer_indexing_rejects_stdout(#[case] spelling: &str) {
+        let header = test_header();
+        let pool = Arc::new(SortWorkerPool::new(2, 1, 6, crate::codec::SpillCodec::Bgzf));
+
+        // Matched rather than `expect_err`: the writer is deliberately not
+        // `Debug`, so unwrapping the error out of the `Result` does not compile.
+        let message =
+            match PooledBamWriter::new_indexing(Arc::clone(&pool), Path::new(spelling), &header) {
+                Ok(_) => panic!("indexing must not accept the stdout spelling `{spelling}`"),
+                Err(error) => error.to_string(),
+            };
+        assert!(
+            message.contains("index") && message.contains(spelling),
+            "the error must name both the index and the offending path, got: {message}"
+        );
+
+        // That the *plain* writer still accepts these spellings is asserted by
+        // `declared_stdout_support_holds` in the integration matrix, not here:
+        // constructing one in-process would write BAM bytes to the test runner's
+        // own stdout.
 
         if let Ok(pool) = Arc::try_unwrap(pool) {
             pool.shutdown();

--- a/docs/src/guide/best-practices.md
+++ b/docs/src/guide/best-practices.md
@@ -402,7 +402,7 @@ For production use where filtering parameters are established, combine steps for
 **Stage 1: Group and call consensus in a single pipe:**
 
 ```bash
-fgumi group --input aligned.bam --strategy adjacency --threads 4 --compression-level 1 \
+fgumi group --input aligned.bam --strategy adjacency --threads 4 --compression-level 1 --output - \
   | fgumi simplex --input /dev/stdin --min-reads 1 --output-per-base-tags true \
     --output consensus.bam --threads 4 --compression-level 1
 ```
@@ -413,7 +413,7 @@ fgumi group --input aligned.bam --strategy adjacency --threads 4 --compression-l
 fgumi fastq --input consensus.bam \
   | bwa mem -t 16 -p -K 150000000 -Y ref.fa - \
   | fgumi zipper --unmapped consensus.bam --reference ref.fa \
-  | fgumi filter --input /dev/stdin --ref ref.fa --min-reads 3 \
+  | fgumi filter --input /dev/stdin --ref ref.fa --min-reads 3 --output - \
   | fgumi sort --input /dev/stdin --output filtered.bam --order coordinate --threads 4
 ```
 

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -29,7 +29,7 @@ use fgumi_bam_io::{
 use super::common::{
     AllowUnmappedOptions, BamIoOptions, CompressionOptions, ConsensusCallingOptions,
     QueueMemoryOptions, ReadGroupOptions, RejectsOptions, SchedulerOptions, StatsOptions,
-    ThreadingOptions, build_pipeline_config, serialize_raw_bam_records,
+    ThreadingOptions, build_pipeline_config, reject_colliding_outputs, serialize_raw_bam_records,
 };
 use crate::consensus::codec_caller::{
     CodecConsensusCaller, CodecConsensusError, CodecConsensusOptions, CodecConsensusStats,
@@ -303,6 +303,7 @@ impl Command for Codec {
         // Validate the input exists (stdin paths are exempt — the reader
         // streams them in a single pass).
         self.io.validate()?;
+        reject_colliding_outputs(&self.io.output, self.rejects_opts.rejects.as_ref(), "--rejects")?;
 
         let timer = OperationTimer::new("Calling CODEC consensus");
 

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -3,7 +3,7 @@
 //! This module provides shared argument structures that can be composed into
 //! command structs using `#[command(flatten)]`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 #[cfg(feature = "simplex")]
 use std::sync::Arc;
 
@@ -15,6 +15,7 @@ use crate::validation::validate_input_exists;
 use bytesize::ByteSize;
 use clap::Args;
 #[cfg(feature = "simplex")]
+use fgumi_bam_io::is_stdout_path;
 use fgumi_consensus::methylation::RefBaseProvider;
 use fgumi_umi::IndexThreshold;
 #[cfg(feature = "simplex")]
@@ -460,6 +461,138 @@ impl RejectsOptions {
     pub fn is_enabled(&self) -> bool {
         self.rejects.is_some()
     }
+}
+
+/// Refuse a secondary output that resolves to the same destination as `--output`.
+///
+/// A command's primary and secondary writers are both opened up front and
+/// written from the same loop, so pointing them at one destination does not make
+/// them take turns — it interleaves two BAMs. How that fails depends on the
+/// destination, and both ways are silent:
+///
+/// - **stdout.** `-` and `/dev/stdout` both resolve to fd 1, where the two
+///   writers share one file description. Every byte lands, but the stream
+///   carries two headers and two EOF blocks and no reader can parse it.
+/// - **A regular file.** Two `File::create` calls give two file *descriptions*
+///   with independent offsets, both starting at zero, so the streams overwrite
+///   each other byte for byte — the worse of the two, since bytes are destroyed
+///   rather than merely reordered. `fgumi correct -o same.bam --rejects same.bam`
+///   exited zero having logged "kept 400 and rejected 0", after which
+///   `samtools view` reported `Invalid BGZF header at offset 392`. The secondary
+///   writer is created eagerly and emits its header at offset 0 whether or not
+///   anything is ever written to it, so this needs no rejected reads to happen.
+///
+/// Both exit zero today, so the combination is rejected before any writer is
+/// opened — `File::create` truncates, and a guard that fired later would already
+/// have clobbered the primary output.
+///
+/// File identity is approximated deliberately. Paths are compared as
+/// `(canonicalized parent, file name)`, which catches `out.bam` against
+/// `./out.bam` or `sub/../out.bam` but not two symlinks onto one target, two
+/// hard links, or one name in two cases on a case-insensitive filesystem. A true
+/// `dev`+`ino` comparison needs both files to exist, and by the time they do both
+/// `File::create` calls have already truncated; closing that gap means moving the
+/// check into the writer layer. See #715, which also covers `--stats`/`--metrics`
+/// sharing a path with `--output`.
+///
+/// The null device is the one exempt destination: it discards every byte, so two
+/// writers on it cannot corrupt each other and `-o /dev/null --rejects /dev/null`
+/// is a legitimate compute-only run. Nothing else is exempt for merely not being
+/// a regular file — a FIFO or `/dev/fd/N` is a *shared* byte stream, where the
+/// two writers append through one file description and interleave two headers,
+/// two block sequences, and two EOF markers into a stream no reader can parse.
+/// That is the same failure as `-o - --rejects -`, so it is rejected the same way.
+///
+/// `secondary_flag` names the offending option in the error, since a command may
+/// have more than one secondary output.
+///
+/// # Errors
+///
+/// Returns an error if `output` and `secondary` both name stdout, or both resolve
+/// to the same destination and that destination is not the null device.
+pub fn reject_colliding_outputs(
+    output: &Path,
+    secondary: Option<&PathBuf>,
+    secondary_flag: &str,
+) -> anyhow::Result<()> {
+    let Some(secondary) = secondary else { return Ok(()) };
+
+    if is_stdout_path(output) || is_stdout_path(secondary) {
+        anyhow::ensure!(
+            !(is_stdout_path(output) && is_stdout_path(secondary)),
+            "--output and {secondary_flag} cannot both write to stdout: the two BAM streams \
+             would interleave into one unreadable stream; give {secondary_flag} a path"
+        );
+        return Ok(());
+    }
+
+    if is_null_device(output) && is_null_device(secondary) {
+        return Ok(());
+    }
+
+    if resolve_output_identity(output) == resolve_output_identity(secondary) {
+        anyhow::bail!(
+            "--output and {secondary_flag} both write to {}: the two BAM streams would \
+             interleave on a shared stream, or overwrite each other byte for byte on a \
+             regular file, and either way nothing can read the result; give \
+             {secondary_flag} a different path",
+            secondary.display()
+        );
+    }
+    Ok(())
+}
+
+/// Whether `path` is the null device, the one destination two writers can share.
+///
+/// Identity comes from `stat`, not from spelling: a path is the null device when
+/// it resolves to the same `(device, inode)` as `/dev/null`, which also accepts
+/// `/dev/./null` and a symlink onto it. A path that does not exist, or that
+/// cannot be stat'd, is not the null device — the usual case for an output — so
+/// the collision check below still runs rather than being skipped on a failed
+/// `stat`.
+///
+/// Off Unix there is no null device to compare against, so nothing is exempt.
+#[cfg(unix)]
+fn is_null_device(path: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    let (Ok(candidate), Ok(null)) = (std::fs::metadata(path), std::fs::metadata(NULL_DEVICE_PATH))
+    else {
+        return false;
+    };
+    candidate.dev() == null.dev() && candidate.ino() == null.ino()
+}
+
+#[cfg(not(unix))]
+fn is_null_device(_path: &Path) -> bool {
+    false
+}
+
+/// The discard sink two output writers are allowed to share.
+#[cfg(unix)]
+const NULL_DEVICE_PATH: &str = "/dev/null";
+
+/// A path reduced to the identity that can be established before the file exists.
+///
+/// [`std::fs::canonicalize`] resolves `.`, `..`, and symlinks, but only for a
+/// path that already exists — which an output usually does not. Canonicalizing
+/// the *parent* and keeping the file name verbatim resolves as much as can be
+/// resolved up front.
+///
+/// Two fallbacks keep this from inventing failures. `Path::parent` is `Some("")`
+/// for a bare file name, which `canonicalize` rejects with `ENOENT`; the intent
+/// there is the current directory. And a parent that cannot be canonicalized at
+/// all falls back to the path as written rather than raising, because a run whose
+/// output directory does not exist should get the writer's message about that,
+/// not a collision error from a guard that only meant to compare two names.
+fn resolve_output_identity(path: &Path) -> (PathBuf, Option<&std::ffi::OsStr>) {
+    let parent = match path.parent() {
+        Some(parent) if parent.as_os_str().is_empty() => Path::new("."),
+        Some(parent) => parent,
+        None => return (path.to_path_buf(), None),
+    };
+    let resolved = std::fs::canonicalize(parent).unwrap_or_else(|_| parent.to_path_buf());
+    (resolved, path.file_name())
 }
 
 /// Options for writing statistics to a file.
@@ -1301,6 +1434,160 @@ pub fn validate_index_threshold(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `reject_colliding_outputs` compares destinations, not the strings naming
+    /// them: `out.bam` and `./out.bam` are one file under two names, and two
+    /// writers on one file overwrite each other byte for byte.
+    ///
+    /// Each case names its two paths relative to a scratch directory the test
+    /// creates. `sub` exists and `missing` does not, which puts both sides of the
+    /// canonicalization fallback under test — the fallback must still catch the
+    /// spelling users actually type, and must not turn a run whose output
+    /// directory is absent into a collision error, since that run's real problem
+    /// is the missing directory and the writer reports it better.
+    #[rstest]
+    #[case::identical("out.bam", "out.bam", true)]
+    #[case::dot_prefixed("out.bam", "./out.bam", true)]
+    #[case::through_an_existing_parent("out.bam", "sub/../out.bam", true)]
+    #[case::distinct_names("out.bam", "rejects.bam", false)]
+    #[case::identical_under_a_missing_parent("missing/out.bam", "missing/out.bam", true)]
+    #[case::distinct_under_a_missing_parent("missing/out.bam", "missing/rejects.bam", false)]
+    fn reject_colliding_outputs_compares_resolved_files(
+        #[case] output: &str,
+        #[case] secondary: &str,
+        #[case] collides: bool,
+    ) {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::create_dir_all(dir.path().join("sub")).expect("create subdirectory");
+        let output = dir.path().join(output);
+        let secondary = dir.path().join(secondary);
+
+        let result = reject_colliding_outputs(&output, Some(&secondary), "--rejects");
+
+        assert_eq!(
+            result.is_err(),
+            collides,
+            "`-o {}` against `--rejects {}`: got {result:?}",
+            output.display(),
+            secondary.display()
+        );
+        if let Err(error) = result {
+            let message = error.to_string();
+            assert!(
+                message.contains("--rejects") && message.contains("out.bam"),
+                "the error must name the colliding option and the path, got: {message}"
+            );
+        }
+    }
+
+    /// Stdout collides with itself under either spelling, and the null device is
+    /// the one destination two writers may share.
+    ///
+    /// `-` and `/dev/stdout` are the same fd, so the two must be caught in any
+    /// combination — comparing the paths as written would let the mixed pairs
+    /// through. `/dev/null` is the opposite case: it discards both streams, so
+    /// `-o /dev/null --rejects /dev/null` is a legitimate compute-only run that a
+    /// name-based check would wrongly reject.
+    #[rstest]
+    #[case::both_dash("-", "-", true)]
+    #[case::both_dev_stdout("/dev/stdout", "/dev/stdout", true)]
+    #[case::dash_then_dev_stdout("-", "/dev/stdout", true)]
+    #[case::dev_stdout_then_dash("/dev/stdout", "-", true)]
+    #[case::stdout_then_a_file("-", "rejects.bam", false)]
+    #[case::a_file_then_stdout("out.bam", "-", false)]
+    #[case::both_dev_null("/dev/null", "/dev/null", false)]
+    #[case::dev_null_then_a_file("/dev/null", "rejects.bam", false)]
+    fn reject_colliding_outputs_handles_stdout_and_the_null_device(
+        #[case] output: &str,
+        #[case] secondary: &str,
+        #[case] collides: bool,
+    ) {
+        let secondary = PathBuf::from(secondary);
+
+        let result = reject_colliding_outputs(Path::new(output), Some(&secondary), "--rejects");
+
+        assert_eq!(
+            result.is_err(),
+            collides,
+            "`-o {output}` against `--rejects {}`: got {result:?}",
+            secondary.display()
+        );
+        if let Err(error) = result {
+            let message = error.to_string();
+            assert!(
+                message.contains("--rejects") && message.contains("stdout"),
+                "the error must name the colliding option and the stream, got: {message}"
+            );
+        }
+    }
+
+    /// A command that was given no secondary output has nothing to collide with.
+    ///
+    /// The commands call this guard unconditionally, so the `None` path is the
+    /// one taken by nearly every real run — including `-o -`, which is the whole
+    /// point of the surrounding change and must not be caught by its own guard.
+    #[rstest]
+    #[case::stdout("-")]
+    #[case::dev_stdout("/dev/stdout")]
+    #[case::a_file("out.bam")]
+    fn reject_colliding_outputs_allows_an_absent_secondary(#[case] output: &str) {
+        let result = reject_colliding_outputs(Path::new(output), None, "--rejects");
+        assert!(result.is_ok(), "`-o {output}` with no --rejects must be allowed: {result:?}");
+    }
+
+    /// A FIFO named by both outputs is a collision, not an exemption.
+    ///
+    /// The guard used to exempt every destination that merely was not a regular
+    /// file, which let `-o pipe --rejects pipe` through. Both writers then append
+    /// through one file description, so the FIFO carries two headers, two block
+    /// sequences, and two EOF markers — the same unreadable stream that
+    /// `-o - --rejects -` produces, and which that pair is already rejected for.
+    /// Two *distinct* FIFOs are two streams and stay legal.
+    #[cfg(unix)]
+    #[rstest]
+    #[case::one_fifo_named_twice("primary", "primary", true)]
+    #[case::two_distinct_fifos("primary", "secondary", false)]
+    fn reject_colliding_outputs_rejects_a_shared_fifo(
+        #[case] output: &str,
+        #[case] secondary: &str,
+        #[case] collides: bool,
+    ) {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let output = dir.path().join(output);
+        let secondary = dir.path().join(secondary);
+        make_fifo(&output);
+        if secondary != output {
+            make_fifo(&secondary);
+        }
+
+        let result = reject_colliding_outputs(&output, Some(&secondary), "--rejects");
+
+        assert_eq!(
+            result.is_err(),
+            collides,
+            "`-o {}` against `--rejects {}`: got {result:?}",
+            output.display(),
+            secondary.display()
+        );
+        if let Err(error) = result {
+            let message = error.to_string();
+            assert!(
+                message.contains("interleave"),
+                "two writers on one stream interleave rather than overwrite, got: {message}"
+            );
+        }
+    }
+
+    /// Create a FIFO at `path`.
+    ///
+    /// The standard library has no `mkfifo(3)` binding, and the crate's `nix`
+    /// dependency is gated to Linux, so the coreutils front end stands in — it is
+    /// present wherever this test compiles.
+    #[cfg(unix)]
+    fn make_fifo(path: &Path) {
+        let status = std::process::Command::new("mkfifo").arg(path).status().expect("run mkfifo");
+        assert!(status.success(), "mkfifo {} failed: {status}", path.display());
+    }
 
     /// `index_threshold_log_message` reports the threshold that is actually in effect,
     /// which is not always the raw `--index-threshold` value. `Edit` floors a numeric

--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -90,7 +90,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, RejectsOptions, SchedulerOptions,
-    ThreadingOptions, build_pipeline_config, parse_bool, serialize_raw_bam_records,
+    ThreadingOptions, build_pipeline_config, parse_bool, reject_colliding_outputs,
+    serialize_raw_bam_records,
 };
 
 /// Which SAM tag `correct` operates on.
@@ -466,6 +467,7 @@ impl Command for CorrectUmis {
     /// ```
     fn execute(&self, command_line: &str) -> Result<()> {
         self.validate()?;
+        reject_colliding_outputs(&self.io.output, self.rejects_opts.rejects.as_ref(), "--rejects")?;
 
         let timer = OperationTimer::new("Correcting UMIs");
 

--- a/src/lib/commands/downsample.rs
+++ b/src/lib/commands/downsample.rs
@@ -23,7 +23,9 @@ use std::io::Write;
 use std::path::PathBuf;
 
 use crate::commands::command::Command;
-use crate::commands::common::{BamIoOptions, CompressionOptions, parse_bool};
+use crate::commands::common::{
+    BamIoOptions, CompressionOptions, parse_bool, reject_colliding_outputs,
+};
 
 /// Downsample a BAM file by UMI family using streaming.
 ///
@@ -130,6 +132,7 @@ impl Command for Downsample {
         // is exempt from the file-existence check, matching every other streaming
         // command; the BAM reader already handles stdin.
         self.io.validate()?;
+        reject_colliding_outputs(&self.io.output, self.rejects.as_ref(), "--rejects")?;
 
         // Validate fraction
         Self::validate_fraction(self.fraction)?;

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -25,7 +25,8 @@ use super::common::{
     AllowUnmappedOptions, BamIoOptions, CompressionOptions, ConsensusCallingOptions,
     OverlappingConsensusOptions, QueueMemoryOptions, ReadGroupOptions, RejectsOptions,
     SchedulerOptions, StatsOptions, ThreadingOptions, build_pipeline_config,
-    consensus_pregroup_keep_flags, consensus_pregroup_keep_raw, serialize_raw_bam_records,
+    consensus_pregroup_keep_flags, consensus_pregroup_keep_raw, reject_colliding_outputs,
+    serialize_raw_bam_records,
 };
 use crate::commands::consensus_runner::{
     ConsensusStatsOps, create_unmapped_consensus_header, log_overlapping_stats,
@@ -297,6 +298,7 @@ impl Command for Duplex {
         // Validate the input exists (stdin paths are exempt — the reader
         // streams them in a single pass).
         self.io.validate()?;
+        reject_colliding_outputs(&self.io.output, self.rejects_opts.rejects.as_ref(), "--rejects")?;
 
         // Validate consensus arguments (e.g. error rates must be > 0).
         self.validate()?;

--- a/src/lib/commands/extract.rs
+++ b/src/lib/commands/extract.rs
@@ -34,7 +34,7 @@ use anyhow::{Context, Result, bail, ensure};
 use bstr::{BString, ByteSlice};
 use clap::Parser;
 use fgumi_bam_io::ProgressTracker;
-use fgumi_bam_io::{RawBamWriter, create_raw_bam_writer};
+use fgumi_bam_io::{RawBamWriter, create_raw_bam_writer, open_output_writer};
 use fgumi_dna::dna::reverse_complement;
 use fgumi_raw_bam::UnmappedSamBuilder;
 use fgumi_raw_bam::fields::flags;
@@ -64,6 +64,11 @@ use std::str::FromStr;
 
 const BUFFER_SIZE: usize = 1024 * 1024;
 const QUALITY_DETECTION_SAMPLE_SIZE: usize = 400;
+
+/// Output buffer for the parallel (`--threads N`) pipeline, which writes whole
+/// compressed BGZF blocks. Sized well above `BGZF_MAX_BLOCK_SIZE` so a block
+/// lands in the buffer instead of passing straight through it.
+const PIPELINE_OUTPUT_BUF_CAPACITY: usize = 256 * 1024;
 
 /// Prefix marking a read-name UMI segment that must be reverse-complemented,
 /// matching fgbio `Umis.RevcompPrefix` (`Umis.scala:33`).
@@ -1628,8 +1633,18 @@ impl Command for Extract {
             // Unified 7-step pipeline mode (--threads N was specified)
             // Uses work-stealing for better CPU utilization with strict thread cap
             // The 7-step pipeline handles its own BGZF compression internally
+            // `open_output_writer`, not `File::create`: the single-threaded
+            // branch below reaches stdout through `create_raw_bam_writer`, and
+            // which of the two runs is a function of `--threads`, which has
+            // nothing to do with where the output goes.
+            // 256 KiB, not the 8 KiB default: the pipeline hands this writer
+            // whole compressed BGZF blocks, which run up to 64 KiB and so would
+            // bypass the default buffer entirely, one `write` syscall apiece.
             let output: Box<dyn std::io::Write + Send> =
-                Box::new(std::io::BufWriter::new(File::create(&self.output)?));
+                Box::new(std::io::BufWriter::with_capacity(
+                    PIPELINE_OUTPUT_BUF_CAPACITY,
+                    open_output_writer(&self.output)?,
+                ));
 
             self.process_with_pipeline(&header, output, encoding, &read_structures, stdin_reader)?
         } else {

--- a/src/lib/commands/fastq.rs
+++ b/src/lib/commands/fastq.rs
@@ -94,8 +94,10 @@ pub struct Fastq {
     #[arg(short = 'i', long = "input")]
     pub input: PathBuf,
 
-    /// Output FASTQ file. If omitted, the FASTQ stream is written to stdout
-    /// (the default, intended for piping straight to an aligner).
+    /// Output FASTQ file, or `-` / `/dev/stdout` for stdout. If omitted, the
+    /// FASTQ stream is written to stdout (the default, intended for piping
+    /// straight to an aligner). A `.gz`/`.bgz` path is BGZF-compressed; stdout
+    /// is always plain text.
     #[arg(short = 'o', long = "output")]
     pub output: Option<PathBuf>,
 

--- a/src/lib/commands/fastq.rs
+++ b/src/lib/commands/fastq.rs
@@ -9,7 +9,7 @@ use crate::sam::SamTag;
 use crate::validation::validate_input_exists;
 use anyhow::Result;
 use clap::Parser;
-use fgumi_bam_io::{create_raw_bam_reader, is_stdin_path};
+use fgumi_bam_io::{create_raw_bam_reader, is_stdin_path, is_stdout_path};
 use fgumi_raw_bam::{
     RawRecord, aux_data_slice, extract_sequence_into, find_string_tag, quality_scores_slice,
     read_name as raw_read_name,
@@ -302,6 +302,13 @@ fn reject_output_clobbering_input(input: &Path, output: Option<&PathBuf>) -> Res
         return Ok(());
     }
 
+    // Likewise stdout: `-` names a stream, not a file, so it cannot clobber the
+    // input — and a stray `-` file left in the working directory must not make
+    // this guard canonicalise something that is not the destination.
+    if is_stdout_path(output) {
+        return Ok(());
+    }
+
     let same_path = output == input
         || (output.exists() && std::fs::canonicalize(output)? == std::fs::canonicalize(input)?);
     if same_path {
@@ -319,9 +326,12 @@ impl Command for Fastq {
         validate_input_exists(&self.input, "Input BAM")?;
         reject_output_clobbering_input(&self.input, self.output.as_ref())?;
 
-        // Use 64MB buffer for efficient pipe throughput.
-        const BUF_CAPACITY: usize = 64 * 1024 * 1024;
         match &self.output {
+            // `-` and `/dev/stdout` name the stream that omitting `--output`
+            // already writes. Spelling it out is what makes this command follow
+            // the same `-` convention as the rest of the CLI; before, `-o -`
+            // created a regular file called `-`.
+            Some(path) if is_stdout_path(path) => self.write_to_stdout(),
             // A `.gz`/`.bgz` output path must actually be compressed. Writing plain
             // text under a `.gz` name produces a file every downstream tool rejects.
             // BGZF is gzip-compatible, so `zcat`/`gzip -d` read it, and it stays
@@ -336,16 +346,40 @@ impl Command for Fastq {
             }
             Some(path) => {
                 let file = std::fs::File::create(path)?;
-                let mut writer = BufWriter::with_capacity(BUF_CAPACITY, file);
-                self.run_with_writer(&mut writer)
+                let mut writer = BufWriter::with_capacity(FASTQ_BUF_CAPACITY, file);
+                self.run_with_writer(&mut writer)?;
+                // `BufWriter`'s `Drop` flushes but discards the error, so a failed
+                // final write — a full disk here — would leave a truncated FASTQ
+                // behind an exit code of zero. Flush explicitly to report it, as
+                // the `.gz` arm's `finish` already does.
+                writer.flush()?;
+                Ok(())
             }
-            // stdout stays uncompressed: this stream is meant to be piped into an
-            // aligner, which wants plain FASTQ.
-            None => {
-                let mut writer = BufWriter::with_capacity(BUF_CAPACITY, stdout().lock());
-                self.run_with_writer(&mut writer)
-            }
+            None => self.write_to_stdout(),
         }
+    }
+}
+
+/// Output buffer size — 64MB, for efficient pipe throughput.
+const FASTQ_BUF_CAPACITY: usize = 64 * 1024 * 1024;
+
+impl Fastq {
+    /// Writes uncompressed FASTQ to stdout.
+    ///
+    /// Uncompressed regardless of how stdout was asked for: this stream is meant
+    /// to be piped into an aligner, which wants plain FASTQ.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a record cannot be written, or if the final flush
+    /// fails — `EPIPE` when the aligner on the other end exits early. Dropping
+    /// the [`BufWriter`] would swallow that flush error and report success on a
+    /// truncated stream.
+    fn write_to_stdout(&self) -> Result<()> {
+        let mut writer = BufWriter::with_capacity(FASTQ_BUF_CAPACITY, stdout().lock());
+        self.run_with_writer(&mut writer)?;
+        writer.flush()?;
+        Ok(())
     }
 }
 

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -48,7 +48,7 @@ use std::time::Instant;
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
-    build_pipeline_config, parse_bool, serialize_raw_bam_records,
+    build_pipeline_config, parse_bool, reject_colliding_outputs, serialize_raw_bam_records,
 };
 
 /// Filters and masks consensus reads based on various quality metrics.
@@ -292,6 +292,7 @@ impl Command for Filter {
         // Validate the input exists (stdin paths are exempt — the reader
         // streams them in a single pass).
         self.io.validate()?;
+        reject_colliding_outputs(&self.io.output, self.rejects.as_ref(), "--rejects")?;
 
         if let Some(ref reference) = self.reference {
             validate_file_exists(reference, "Reference FASTA")?;

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -52,7 +52,8 @@ use crate::commands::common::{
     AllowUnmappedOptions, BamIoOptions, CompressionOptions, ConsensusCallingOptions,
     OverlappingConsensusOptions, QueueMemoryOptions, ReadGroupOptions, RejectsOptions,
     SchedulerOptions, StatsOptions, ThreadingOptions, build_pipeline_config,
-    consensus_pregroup_keep_flags, consensus_pregroup_keep_raw, serialize_raw_bam_records,
+    consensus_pregroup_keep_flags, consensus_pregroup_keep_raw, reject_colliding_outputs,
+    serialize_raw_bam_records,
 };
 use crate::commands::consensus_runner::{
     ConsensusStatsOps, create_unmapped_consensus_header, log_overlapping_stats,
@@ -246,6 +247,7 @@ impl Command for Simplex {
 
         // Validate inputs
         self.io.validate()?;
+        reject_colliding_outputs(&self.io.output, self.rejects_opts.rejects.as_ref(), "--rejects")?;
 
         self.validate_read_bounds()?;
 

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -26,6 +26,7 @@ use crate::validation::validate_input_exists;
 use anyhow::{Result, bail};
 use bytesize::ByteSize;
 use clap::Parser;
+use fgumi_bam_io::is_stdout_path;
 use fgumi_sort::{
     KeyTypesSpec, QuerynameComparator, RawExternalSorter, SortOrder, verify_sort_order,
 };
@@ -450,6 +451,15 @@ impl Command for Sort {
         }
         if self.verify && self.write_index {
             bail!("--write-index cannot be used with --verify");
+        }
+        // A BAI is written to a sidecar path beside a seekable file, and a pipe
+        // is neither. Rejected up front rather than at the writer, so the run
+        // fails before streaming a BAM it could never index.
+        if self.write_index && self.output.as_deref().is_some_and(is_stdout_path) {
+            bail!(
+                "--write-index cannot be used with output to stdout: an index requires a \
+                 seekable file, so give --output a path"
+            );
         }
 
         // Validate inputs. Exempt stdin paths (`-` / `/dev/stdin`): the sort

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -366,7 +366,11 @@ pub struct Sort {
 
     /// Write BAM index (.bai) alongside output.
     ///
-    /// Only valid for coordinate sort. The index file will be written to
+    /// Only valid for coordinate sort, and not with output to stdout (`-` /
+    /// `/dev/stdout`): an index needs a seekable file and a sidecar path, so
+    /// that combination is rejected rather than silently skipped.
+    ///
+    /// The index file will be written to
     /// `<output>.bai`. Output BGZF compression stays multi-threaded (scales
     /// with `--threads`); the BAI virtual offsets are recovered from each BGZF
     /// block as it finalizes, so indexing does not serialize compression.

--- a/tests/integration/helpers/assertions.rs
+++ b/tests/integration/helpers/assertions.rs
@@ -53,6 +53,30 @@ pub fn int_tag(record: &noodles::bam::Record, tag: SamTag) -> i64 {
     }
 }
 
+/// Asserts that an in-memory BGZF stream ends with the standard 28-byte EOF block.
+///
+/// The byte-slice counterpart to [`assert_has_bgzf_eof`], for output captured
+/// from a pipe rather than written to a file. `label` names the run in the
+/// failure, since callers check several spellings of the same output.
+///
+/// # Panics
+///
+/// Panics if `bytes` is too small or is missing the BGZF EOF block.
+pub fn assert_bytes_have_bgzf_eof(bytes: &[u8], label: &str) {
+    let eof_len = BGZF_EOF.len();
+    assert!(
+        bytes.len() >= eof_len,
+        "{label}: too small to contain BGZF EOF ({} bytes)",
+        bytes.len()
+    );
+    assert_eq!(
+        &bytes[bytes.len() - eof_len..],
+        &BGZF_EOF,
+        "{label}: missing the BGZF EOF block — the stream reads as truncated \
+         (`samtools quickcheck` fails) even though its records parse"
+    );
+}
+
 /// Asserts that a file ends with the standard 28-byte BGZF EOF marker block.
 ///
 /// # Panics
@@ -60,13 +84,7 @@ pub fn int_tag(record: &noodles::bam::Record, tag: SamTag) -> i64 {
 /// Panics if the file cannot be read, is too small, or is missing the BGZF EOF block.
 pub fn assert_has_bgzf_eof(path: &std::path::Path) {
     let data = std::fs::read(path).expect("Failed to read file for EOF check");
-    assert!(data.len() >= 28, "File too small to contain BGZF EOF: {}", path.display());
-    assert_eq!(
-        &data[data.len() - 28..],
-        &BGZF_EOF,
-        "File missing BGZF EOF block: {}",
-        path.display()
-    );
+    assert_bytes_have_bgzf_eof(&data, &path.display().to_string());
 }
 
 /// Asserts that a rejects BAM's `@HD` sort-order fields (`SO`, `GO`, `SS`)

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -51,4 +51,5 @@ mod test_sort_correctness;
 mod test_sort_thread_logging;
 mod test_sort_write_index;
 mod test_streaming_input;
+mod test_streaming_output;
 mod test_zipper_command;

--- a/tests/integration/test_input_source_matrix.rs
+++ b/tests/integration/test_input_source_matrix.rs
@@ -1,27 +1,35 @@
-//! Every command declares — and is held to — its input-source contract.
+//! Every command declares — and is held to — its I/O contract.
 //!
-//! Two properties are easy to get wrong per-command and impossible to eyeball
+//! Three properties are easy to get wrong per-command and impossible to eyeball
 //! across the whole CLI:
 //!
 //! 1. **Uncompressed SAM** must be accepted anywhere BAM is, because input
 //!    format is a property of the data, not of the command.
 //! 2. **stdin** (`-i -`) must be accepted by anything that streams, so commands
 //!    compose in a pipeline.
+//! 3. **stdout** (`-o -`) must be written by anything that streams, for the same
+//!    reason — a pipeline needs both ends.
 //!
-//! Both were previously true of some commands and not others, and nothing
-//! failed when a new command picked the wrong reader. The table below is the
-//! contract: every command the binary advertises must appear in it with an
+//! All three were previously true of some commands and not others, and nothing
+//! failed when a new command picked the wrong reader or writer. The table below
+//! is the contract: every command the binary advertises must appear in it with an
 //! explicit stance, and [`every_command_declares_an_input_contract`] fails when
 //! one does not — so adding a command forces a decision rather than inheriting
-//! whichever default its reader happened to have.
+//! whichever default its reader or writer happened to have.
 //!
-//! Checking either property means running a command two ways and comparing what
-//! it wrote, which is only evidence if what it writes depends on what it read. A
+//! The stdout axis was added after `sort`, `fastq`, and `extract --threads N`
+//! were found to create a regular file *named* `-` instead of streaming: they
+//! reached for `File::create` directly rather than the stdout-aware writer the
+//! other commands share. Every one of them exited zero while doing it, which is
+//! why the check compares what arrived on the pipe rather than trusting a status.
+//!
+//! Checking any of these means running a command two ways and comparing what it
+//! wrote, which is only evidence if what it writes depends on what it read. A
 //! command handed input it cannot form a molecule from exits zero and writes a
-//! header-only file, so both comparisons pass however badly the reader behaved.
-//! That is why the table carries a third axis, `output_depends_on_input`, and
+//! header-only file, so the comparisons pass however badly the reader behaved.
+//! That is why the table carries a fourth axis, `output_depends_on_input`, and
 //! why [`every_command_output_depends_on_its_input`] drains each fixture and
-//! demands the output change: it is the assertion that keeps the other two
+//! demands the output change: it is the assertion that keeps the other three
 //! honest.
 
 use std::path::{Path, PathBuf};
@@ -46,7 +54,7 @@ enum Support {
 
 use Support::{NotApplicable, Required};
 
-/// One command's declared input-source contract.
+/// One command's declared I/O contract.
 struct InputContract {
     /// Subcommand name as it appears in `fgumi --help`.
     command: &'static str,
@@ -54,13 +62,19 @@ struct InputContract {
     sam: Support,
     /// Whether `-i -` must work.
     stdin: Support,
+    /// Whether `-o -` must stream to stdout rather than write a file named `-`.
+    ///
+    /// `NotApplicable` here is for commands whose `-o` is not a single stream:
+    /// the metrics commands and `review` take a *prefix* and write several files
+    /// from it, which no pipe can carry.
+    stdout: Support,
     /// Whether emptying the input must change the output.
     ///
-    /// This is what keeps the other two axes honest. A command handed input it
+    /// This is what keeps the other three axes honest. A command handed input it
     /// cannot form a molecule from exits zero and writes a header-only file, so
-    /// its SAM and stdin runs match the oracle no matter how badly the reader
-    /// behaved. Declaring `Required` here puts that failure mode under test —
-    /// see [`every_command_output_depends_on_its_input`].
+    /// its SAM, stdin and stdout runs match the oracle no matter how badly the
+    /// reader behaved. Declaring `Required` here puts that failure mode under
+    /// test — see [`every_command_output_depends_on_its_input`].
     output_depends_on_input: Support,
 }
 
@@ -74,24 +88,28 @@ const CONTRACTS: &[InputContract] = &[
         sam: NotApplicable("reads FASTQ, not alignment records"),
         // Only with a single input: one stdin cannot supply two FASTQs.
         stdin: Required,
+        stdout: Required,
         output_depends_on_input: Required,
     },
     InputContract {
         command: "correct",
         sam: Required,
         stdin: Required,
+        stdout: Required,
         output_depends_on_input: Required,
     },
     InputContract {
         command: "fastq",
         sam: Required,
         stdin: Required,
+        stdout: Required,
         output_depends_on_input: Required,
     },
     InputContract {
         command: "zipper",
         sam: Required,
         stdin: Required,
+        stdout: Required,
         output_depends_on_input: NotApplicable(
             "emits one output template per uBAM template, and the uBAM arrives on `-u`; an \
              empty `-i` yields the same templates, unmapped",
@@ -101,24 +119,28 @@ const CONTRACTS: &[InputContract] = &[
         command: "sort",
         sam: Required,
         stdin: Required,
+        stdout: Required,
         output_depends_on_input: Required,
     },
     InputContract {
         command: "merge",
         sam: Required,
         stdin: NotApplicable("merges N pre-sorted inputs named in a list file"),
+        stdout: Required,
         output_depends_on_input: Required,
     },
     InputContract {
         command: "group",
         sam: Required,
         stdin: Required,
+        stdout: Required,
         output_depends_on_input: Required,
     },
     InputContract {
         command: "dedup",
         sam: Required,
         stdin: Required,
+        stdout: Required,
         output_depends_on_input: Required,
     },
     #[cfg(feature = "simplex")]
@@ -126,6 +148,7 @@ const CONTRACTS: &[InputContract] = &[
         command: "simplex",
         sam: Required,
         stdin: Required,
+        stdout: Required,
         output_depends_on_input: Required,
     },
     #[cfg(feature = "duplex")]
@@ -133,6 +156,7 @@ const CONTRACTS: &[InputContract] = &[
         command: "duplex",
         sam: Required,
         stdin: Required,
+        stdout: Required,
         output_depends_on_input: Required,
     },
     #[cfg(feature = "codec")]
@@ -140,18 +164,21 @@ const CONTRACTS: &[InputContract] = &[
         command: "codec",
         sam: Required,
         stdin: Required,
+        stdout: Required,
         output_depends_on_input: Required,
     },
     InputContract {
         command: "filter",
         sam: Required,
         stdin: Required,
+        stdout: Required,
         output_depends_on_input: Required,
     },
     InputContract {
         command: "clip",
         sam: Required,
         stdin: Required,
+        stdout: Required,
         output_depends_on_input: Required,
     },
     #[cfg(feature = "duplex")]
@@ -159,6 +186,7 @@ const CONTRACTS: &[InputContract] = &[
         command: "duplex-metrics",
         sam: Required,
         stdin: Required,
+        stdout: NotApplicable("`-o` names a prefix for several metrics files, not one stream"),
         output_depends_on_input: Required,
     },
     #[cfg(feature = "simplex")]
@@ -166,18 +194,21 @@ const CONTRACTS: &[InputContract] = &[
         command: "simplex-metrics",
         sam: Required,
         stdin: Required,
+        stdout: NotApplicable("`-o` names a prefix for several metrics files, not one stream"),
         output_depends_on_input: Required,
     },
     InputContract {
         command: "review",
         sam: NotApplicable("requires BAI indexes and does random access, which needs BGZF"),
         stdin: NotApplicable("does random access against a BAI index"),
+        stdout: NotApplicable("`-o` names a prefix for a directory of BAMs and their indexes"),
         output_depends_on_input: NotApplicable("declares no axis this harness invokes"),
     },
     InputContract {
         command: "downsample",
         sam: Required,
         stdin: Required,
+        stdout: Required,
         output_depends_on_input: Required,
     },
     #[cfg(feature = "compare")]
@@ -185,6 +216,7 @@ const CONTRACTS: &[InputContract] = &[
         command: "compare",
         sam: Required,
         stdin: NotApplicable("compares two named files against each other"),
+        stdout: NotApplicable("writes its report to stdout already and takes no `--output`"),
         output_depends_on_input: Required,
     },
     #[cfg(feature = "simulate")]
@@ -192,6 +224,7 @@ const CONTRACTS: &[InputContract] = &[
         command: "simulate",
         sam: NotApplicable("generates data rather than reading it"),
         stdin: NotApplicable("generates data rather than reading it"),
+        stdout: NotApplicable("takes several named outputs, not one stream"),
         output_depends_on_input: NotApplicable("generates data rather than reading it"),
     },
 ];
@@ -239,7 +272,8 @@ fn advertised_commands() -> Vec<String> {
 /// The contract table must cover exactly the commands the binary advertises.
 ///
 /// This is the test that makes the rest of the file exhaustive: a new command
-/// fails here until someone states whether it takes SAM and stdin.
+/// fails here until someone states its position on every axis [`IoContract`]
+/// carries — SAM, stdin, stdout, and whether its output depends on its input.
 #[test]
 fn every_command_declares_an_input_contract() {
     let advertised: Vec<String> = advertised_commands()
@@ -253,15 +287,16 @@ fn every_command_declares_an_input_contract() {
         advertised.iter().filter(|name| !declared.contains(&name.as_str())).collect();
     assert!(
         undeclared.is_empty(),
-        "these commands are advertised by `fgumi --help` but declare no input contract in \
-         CONTRACTS: {undeclared:?}. Add an entry stating whether each accepts SAM and stdin."
+        "these commands are advertised by `fgumi --help` but declare no I/O contract in \
+         CONTRACTS: {undeclared:?}. Add an entry stating each command's stance on all four \
+         axes: sam, stdin, stdout, and output_depends_on_input."
     );
 
     let stale: Vec<&&str> =
         declared.iter().filter(|name| !advertised.contains(&(**name).to_string())).collect();
     assert!(
         stale.is_empty(),
-        "these commands declare an input contract but are no longer advertised by \
+        "these commands declare an I/O contract but are no longer advertised by \
          `fgumi --help`: {stale:?}. Remove their CONTRACTS entries."
     );
 }
@@ -522,11 +557,57 @@ fn run_command(
     pipe: Option<&Path>,
     run_tag: &str,
 ) -> std::process::Output {
+    run_command_writing(command, input, dir, fixture, pipe, run_tag, OutputSpec::NamedPath)
+}
+
+/// Where a run is told to put its output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OutputSpec {
+    /// `{output}` is a path inside the run directory — the normal case.
+    NamedPath,
+    /// `{output}` is the carried stdout spelling, so the run is expected to
+    /// stream to stdout.
+    ///
+    /// The spelling travels in the variant because `open_output_writer` honours
+    /// two of them, `-` and `/dev/stdout`, and a writer that special-cased only
+    /// `-` would pass a matrix that never asked for the other one.
+    ///
+    /// The child runs in a scratch working directory (see [`stray_file_dir`]), so
+    /// a command that mistakenly treats `-` as a filename creates its file there
+    /// rather than in the crate root: the repository stays clean and the stray
+    /// file is somewhere the test can look for it by name. That directory is
+    /// deliberately *not* the digested run directory, because a build with the
+    /// heap profiler enabled also drops a `dhat-heap.json` in the working
+    /// directory, which would otherwise read as an output difference.
+    Stdout(&'static str),
+}
+
+/// The working directory a [`OutputSpec::Stdout`] run is given.
+///
+/// Anything the command leaves here it created by writing to a path it should
+/// have streamed instead — see [`declared_stdout_support_holds`].
+fn stray_file_dir(dir: &Path, run_tag: &str) -> PathBuf {
+    dir.join(format!("{run_tag}-cwd"))
+}
+
+/// [`run_command`], with control over what `{output}` is substituted with.
+fn run_command_writing(
+    command: &str,
+    input: &str,
+    dir: &Path,
+    fixture: &Fixture,
+    pipe: Option<&Path>,
+    run_tag: &str,
+    output_spec: OutputSpec,
+) -> std::process::Output {
     let args = invocation(command).expect("command has an invocation");
 
     let run_dir = dir.join(run_tag);
     std::fs::create_dir_all(&run_dir).expect("create per-run output dir");
-    let output = run_dir.join(format!("{command}.out"));
+    let output = match output_spec {
+        OutputSpec::NamedPath => run_dir.join(format!("{command}.out")),
+        OutputSpec::Stdout(spelling) => PathBuf::from(spelling),
+    };
     let reference = create_test_reference(dir);
     let umis = dir.join("umis.txt");
     std::fs::write(&umis, "ACGTACGT\nTTTTGGGG\n").expect("write UMI list");
@@ -545,6 +626,11 @@ fn run_command(
 
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_fgumi"));
     cmd.args(&substituted);
+    if matches!(output_spec, OutputSpec::Stdout(_)) {
+        let cwd = stray_file_dir(dir, run_tag);
+        std::fs::create_dir_all(&cwd).expect("create the stdout run's working dir");
+        cmd.current_dir(&cwd);
+    }
     if let Some(path) = pipe {
         cmd.stdin(Stdio::from(std::fs::File::open(path).expect("open input to pipe")));
     }
@@ -704,6 +790,8 @@ fn scrub_run_identity(text: &str) -> String {
         .replace("empty.list", "<LIST>")
         .replace(STDIN_SAM_RUN, "<RUN>")
         .replace(STDIN_RUN, "<RUN>")
+        .replace(STDOUT_DEV_RUN, "<RUN>")
+        .replace(STDOUT_RUN, "<RUN>")
         .replace(SAM_RUN, "<RUN>")
         .replace(BAM_RUN, "<RUN>")
         .replace(EMPTY_RUN, "<RUN>")
@@ -714,7 +802,16 @@ const BAM_RUN: &str = "bam-run";
 const SAM_RUN: &str = "sam-run";
 const STDIN_RUN: &str = "stdin-run";
 const STDIN_SAM_RUN: &str = "stdin-sam-run";
+const STDOUT_RUN: &str = "stdout-run";
+const STDOUT_DEV_RUN: &str = "stdout-dev-run";
 const EMPTY_RUN: &str = "empty-run";
+
+/// Every spelling of stdout `open_output_writer` honours, paired with the
+/// per-run output subdirectory that spelling's run is given.
+///
+/// Kept in lockstep with `is_stdout_path`: a spelling the writer accepts but
+/// this table omits is a spelling no command in the matrix is ever asked for.
+const STDOUT_SPELLINGS: [(&str, &str); 2] = [("-", STDOUT_RUN), ("/dev/stdout", STDOUT_DEV_RUN)];
 
 /// Describes the first way two runs' outputs differ, or `None` if they match.
 ///
@@ -894,6 +991,88 @@ fn declared_stdin_support_holds() {
             }
 
             compare_to_oracle(command, dir, &oracle_run, &piped, STDIN_RUN, "stdin")
+        },
+    );
+}
+
+/// Every command declaring `stdout: Required` must write **every** stdout
+/// spelling in [`STDOUT_SPELLINGS`] to stdout, and put the same bytes there as
+/// it would have put in a named file.
+///
+/// The failure this exists to catch is silent: a writer that reaches for
+/// `File::create` instead of the stdout-aware one creates a regular file *named*
+/// `-` in the working directory, writes the output into it, and exits zero. The
+/// pipe is simply empty, so a status check — or anything that only looks at the
+/// declared output path — sees a clean run. Two things are therefore asserted:
+/// that no file named after the spelling was created, and that what arrived on
+/// the pipe matches the named-path oracle byte for byte. See
+/// [`compare_to_oracle`].
+///
+/// Both spellings run for every command rather than only `-`, because they part
+/// company inside `is_stdout_path`: `/dev/stdout` reaching `File::create` still
+/// lands on the pipe on Linux and macOS, so the stray-file check alone cannot
+/// catch it — only the byte-for-byte comparison can.
+#[test]
+fn declared_stdout_support_holds() {
+    for_each_command_requiring(
+        |c| c.stdout,
+        |command, fixture, dir| {
+            let oracle_run = run_named_path_oracle(command, fixture, dir, "a stdout spelling")?;
+            let named_input = fixture.input_for(command, false).display().to_string();
+
+            // Both spellings, every command: the two differ only inside
+            // `is_stdout_path`, so a writer that special-cased `-` alone would
+            // pass a matrix that only ever asked for `-`.
+            for (spelling, run_tag) in STDOUT_SPELLINGS {
+                let label = format!("`-o {spelling}`");
+                let streamed = run_command_writing(
+                    command,
+                    &named_input,
+                    dir,
+                    fixture,
+                    None,
+                    run_tag,
+                    OutputSpec::Stdout(spelling),
+                );
+                if !streamed.status.success() {
+                    return Err(format!(
+                        "{command}: declares stdout support but rejected {label}: {}",
+                        String::from_utf8_lossy(&streamed.stderr)
+                    ));
+                }
+
+                // Checked before the digests, because this is the actual bug and
+                // deserves to say so rather than surfacing as an empty output.
+                // Only a relative spelling can land in the run's working
+                // directory; `/dev/stdout` names a path outside it either way.
+                let run_dir = dir.join(run_tag);
+                if Path::new(spelling).is_relative()
+                    && stray_file_dir(dir, run_tag).join(spelling).is_file()
+                {
+                    return Err(format!(
+                        "{command}: {label} created a regular file named `{spelling}` instead of \
+                         writing to stdout — its writer needs to go through `open_output_writer`"
+                    ));
+                }
+
+                // The oracle wrote `<command>.out`; this run wrote the same bytes
+                // to the pipe. Materializing them under that name is what lets the
+                // two runs digest under the same key, so the existing file-by-file
+                // comparison applies unchanged. Skipped when the pipe is empty, so
+                // that case reads as a missing file rather than an empty one.
+                if !streamed.stdout.is_empty() {
+                    std::fs::write(run_dir.join(format!("{command}.out")), &streamed.stdout)
+                        .expect("materialize the stdout run's stream");
+                }
+                let materialized = std::process::Output {
+                    status: streamed.status,
+                    stdout: Vec::new(),
+                    stderr: streamed.stderr.clone(),
+                };
+
+                compare_to_oracle(command, dir, &oracle_run, &materialized, run_tag, &label)?;
+            }
+            Ok(())
         },
     );
 }

--- a/tests/integration/test_input_source_matrix.rs
+++ b/tests/integration/test_input_source_matrix.rs
@@ -13,7 +13,7 @@
 //! All three were previously true of some commands and not others, and nothing
 //! failed when a new command picked the wrong reader or writer. The table below
 //! is the contract: every command the binary advertises must appear in it with an
-//! explicit stance, and [`every_command_declares_an_input_contract`] fails when
+//! explicit stance, and [`every_command_declares_an_io_contract`] fails when
 //! one does not — so adding a command forces a decision rather than inheriting
 //! whichever default its reader or writer happened to have.
 //!
@@ -55,7 +55,7 @@ enum Support {
 use Support::{NotApplicable, Required};
 
 /// One command's declared I/O contract.
-struct InputContract {
+struct IoContract {
     /// Subcommand name as it appears in `fgumi --help`.
     command: &'static str,
     /// Whether `-i in.sam` must work.
@@ -82,8 +82,8 @@ struct InputContract {
 ///
 /// A `NotApplicable` reason is a claim about the command's design, not a
 /// to-do — if the reason stops being true, the entry should change.
-const CONTRACTS: &[InputContract] = &[
-    InputContract {
+const CONTRACTS: &[IoContract] = &[
+    IoContract {
         command: "extract",
         sam: NotApplicable("reads FASTQ, not alignment records"),
         // Only with a single input: one stdin cannot supply two FASTQs.
@@ -91,21 +91,21 @@ const CONTRACTS: &[InputContract] = &[
         stdout: Required,
         output_depends_on_input: Required,
     },
-    InputContract {
+    IoContract {
         command: "correct",
         sam: Required,
         stdin: Required,
         stdout: Required,
         output_depends_on_input: Required,
     },
-    InputContract {
+    IoContract {
         command: "fastq",
         sam: Required,
         stdin: Required,
         stdout: Required,
         output_depends_on_input: Required,
     },
-    InputContract {
+    IoContract {
         command: "zipper",
         sam: Required,
         stdin: Required,
@@ -115,28 +115,28 @@ const CONTRACTS: &[InputContract] = &[
              empty `-i` yields the same templates, unmapped",
         ),
     },
-    InputContract {
+    IoContract {
         command: "sort",
         sam: Required,
         stdin: Required,
         stdout: Required,
         output_depends_on_input: Required,
     },
-    InputContract {
+    IoContract {
         command: "merge",
         sam: Required,
         stdin: NotApplicable("merges N pre-sorted inputs named in a list file"),
         stdout: Required,
         output_depends_on_input: Required,
     },
-    InputContract {
+    IoContract {
         command: "group",
         sam: Required,
         stdin: Required,
         stdout: Required,
         output_depends_on_input: Required,
     },
-    InputContract {
+    IoContract {
         command: "dedup",
         sam: Required,
         stdin: Required,
@@ -144,7 +144,7 @@ const CONTRACTS: &[InputContract] = &[
         output_depends_on_input: Required,
     },
     #[cfg(feature = "simplex")]
-    InputContract {
+    IoContract {
         command: "simplex",
         sam: Required,
         stdin: Required,
@@ -152,7 +152,7 @@ const CONTRACTS: &[InputContract] = &[
         output_depends_on_input: Required,
     },
     #[cfg(feature = "duplex")]
-    InputContract {
+    IoContract {
         command: "duplex",
         sam: Required,
         stdin: Required,
@@ -160,21 +160,21 @@ const CONTRACTS: &[InputContract] = &[
         output_depends_on_input: Required,
     },
     #[cfg(feature = "codec")]
-    InputContract {
+    IoContract {
         command: "codec",
         sam: Required,
         stdin: Required,
         stdout: Required,
         output_depends_on_input: Required,
     },
-    InputContract {
+    IoContract {
         command: "filter",
         sam: Required,
         stdin: Required,
         stdout: Required,
         output_depends_on_input: Required,
     },
-    InputContract {
+    IoContract {
         command: "clip",
         sam: Required,
         stdin: Required,
@@ -182,7 +182,7 @@ const CONTRACTS: &[InputContract] = &[
         output_depends_on_input: Required,
     },
     #[cfg(feature = "duplex")]
-    InputContract {
+    IoContract {
         command: "duplex-metrics",
         sam: Required,
         stdin: Required,
@@ -190,21 +190,21 @@ const CONTRACTS: &[InputContract] = &[
         output_depends_on_input: Required,
     },
     #[cfg(feature = "simplex")]
-    InputContract {
+    IoContract {
         command: "simplex-metrics",
         sam: Required,
         stdin: Required,
         stdout: NotApplicable("`-o` names a prefix for several metrics files, not one stream"),
         output_depends_on_input: Required,
     },
-    InputContract {
+    IoContract {
         command: "review",
         sam: NotApplicable("requires BAI indexes and does random access, which needs BGZF"),
         stdin: NotApplicable("does random access against a BAI index"),
         stdout: NotApplicable("`-o` names a prefix for a directory of BAMs and their indexes"),
         output_depends_on_input: NotApplicable("declares no axis this harness invokes"),
     },
-    InputContract {
+    IoContract {
         command: "downsample",
         sam: Required,
         stdin: Required,
@@ -212,7 +212,7 @@ const CONTRACTS: &[InputContract] = &[
         output_depends_on_input: Required,
     },
     #[cfg(feature = "compare")]
-    InputContract {
+    IoContract {
         command: "compare",
         sam: Required,
         stdin: NotApplicable("compares two named files against each other"),
@@ -220,7 +220,7 @@ const CONTRACTS: &[InputContract] = &[
         output_depends_on_input: Required,
     },
     #[cfg(feature = "simulate")]
-    InputContract {
+    IoContract {
         command: "simulate",
         sam: NotApplicable("generates data rather than reading it"),
         stdin: NotApplicable("generates data rather than reading it"),
@@ -275,7 +275,7 @@ fn advertised_commands() -> Vec<String> {
 /// fails here until someone states its position on every axis [`IoContract`]
 /// carries — SAM, stdin, stdout, and whether its output depends on its input.
 #[test]
-fn every_command_declares_an_input_contract() {
+fn every_command_declares_an_io_contract() {
     let advertised: Vec<String> = advertised_commands()
         .into_iter()
         .filter(|name| !NOT_A_COMMAND.contains(&name.as_str()))
@@ -646,7 +646,7 @@ fn run_command_writing(
 /// and the coverage cannot drift apart. (Feature-gated commands compile out of
 /// `CONTRACTS` along with themselves, so they are simply absent here.)
 fn for_each_command_requiring(
-    axis: impl Fn(&InputContract) -> Support,
+    axis: impl Fn(&IoContract) -> Support,
     check: impl Fn(&str, &Fixture, &Path) -> Result<(), String>,
 ) {
     let mut failures = Vec::new();

--- a/tests/integration/test_streaming_output.rs
+++ b/tests/integration/test_streaming_output.rs
@@ -26,7 +26,10 @@ use std::process::{Command, Output};
 use rstest::rstest;
 use tempfile::TempDir;
 
-use crate::helpers::bam_generator::{create_minimal_header, create_umi_family, write_bam};
+use crate::helpers::assertions::assert_bytes_have_bgzf_eof;
+use crate::helpers::bam_generator::{
+    create_minimal_header, create_test_reference, create_umi_family, write_bam,
+};
 use crate::helpers::read_bam_output;
 
 /// Runs `fgumi` with `args` from inside `cwd`, and returns the completed output.
@@ -60,6 +63,20 @@ fn assert_streamed(run: &Output, cwd: &Path, label: &str) -> Vec<u8> {
     );
     assert!(!run.stdout.is_empty(), "{label}: wrote nothing to stdout");
     run.stdout.clone()
+}
+
+/// [`assert_streamed`], plus the BGZF EOF block every BAM stream must end with.
+///
+/// Parsing the records back is not enough to catch a missing EOF block: noodles
+/// reads a truncated-looking stream happily, while `samtools quickcheck` rejects
+/// it. That is not hypothetical here — issue #125 was commands emitting BAMs
+/// without it, which is why `assert_has_bgzf_eof` and `test_bgzf_eof.rs` exist.
+/// Swapping the sink is exactly the kind of change that could drop the marker,
+/// and `sort`, `extract`, and `fastq` are absent from that file's coverage.
+fn assert_streamed_bam(run: &Output, cwd: &Path, label: &str) -> Vec<u8> {
+    let stdout = assert_streamed(run, cwd, label);
+    assert_bytes_have_bgzf_eof(&stdout, label);
+    stdout
 }
 
 /// Writes `stdout` to a file so it can be read back with the shared BAM helper,
@@ -107,20 +124,26 @@ fn sort_streams_to_stdout(
     write_test_bam(&input, families);
 
     let expected = dir.path().join("expected.bam");
-    let file_args = [
-        "sort",
-        "-i",
-        input.to_str().unwrap(),
-        "-o",
-        expected.to_str().unwrap(),
-        "--order",
-        "coordinate",
-        "-m",
-        max_memory,
-        "--threads",
-        threads,
-    ];
-    let file_run = run_in(dir.path(), &file_args);
+    // Built from the output spelling rather than patched by index: `args[4] = …`
+    // silently rewrites a different flag the moment this list is reordered.
+    let args = |output: &str| {
+        [
+            "sort",
+            "-i",
+            input.to_str().unwrap(),
+            "-o",
+            output,
+            "--order",
+            "coordinate",
+            "-m",
+            max_memory,
+            "--threads",
+            threads,
+        ]
+        .map(ToString::to_string)
+    };
+
+    let file_run = run_in(dir.path(), &args(expected.to_str().unwrap()));
     assert!(
         file_run.status.success(),
         "the file baseline failed, so the stdout comparison would prove nothing: {}",
@@ -132,11 +155,9 @@ fn sort_streams_to_stdout(
         let cwd = dir.path().join(format!("cwd{spelling}").replace('/', "_"));
         std::fs::create_dir_all(&cwd).expect("create run dir");
 
-        let mut args = file_args;
-        args[4] = spelling;
-        let run = run_in(&cwd, &args);
+        let run = run_in(&cwd, &args(spelling));
         let label = format!("sort -o {spelling} (m={max_memory}, threads={threads})");
-        let stdout = assert_streamed(&run, &cwd, &label);
+        let stdout = assert_streamed_bam(&run, &cwd, &label);
 
         let streamed = bam_from_stdout(dir.path(), "streamed.bam", &stdout);
         assert_eq!(
@@ -214,12 +235,149 @@ fn sort_rejects_write_index_with_stdout(#[case] spelling: &str) {
 
     assert!(!run.status.success(), "`--write-index -o {spelling}` must be rejected, not attempted");
     let stderr = String::from_utf8_lossy(&run.stderr);
+    // Both halves matter: `execute` has a second `--write-index` rejection (the
+    // `--verify` one), so naming the flag alone would let this pass on an error
+    // that has nothing to do with stdout.
     assert!(
-        stderr.contains("--write-index"),
-        "the error must name the flag that cannot be satisfied, got: {stderr}"
+        stderr.contains("--write-index") && stderr.contains("stdout"),
+        "the error must name both the flag and the stdout conflict, got: {stderr}"
     );
+    // The stray-`-` check below cannot see a `/dev/stdout` run that opened its
+    // writer before failing, since that one reaches fd 1 without creating a file.
+    // An empty pipe is what distinguishes rejected-up-front from wrote-then-failed.
+    assert!(run.stdout.is_empty(), "the rejected run wrote {} bytes to stdout", run.stdout.len());
     assert!(!dir.path().join("-").exists(), "the rejected run still created a file named `-`");
     assert!(!dir.path().join("-.bai").exists(), "the rejected run still created a `-.bai`");
+}
+
+/// Builds the argv for a command whose `--output` and `--rejects` both point
+/// where the caller asks, writing whatever fixtures that command needs into
+/// `dir`.
+///
+/// The collision guard runs immediately after input validation and before any
+/// record is read, which is why one throwaway BAM serves every command
+/// regardless of the tags each would otherwise require. The reference and UMI
+/// list are supplied because the two commands that take them reject a missing
+/// file before the guard under test would ever run.
+fn colliding_output_args(dir: &Path, command: &[&str], output: &str, rejects: &str) -> Vec<String> {
+    let input = dir.join("input.bam");
+    write_test_bam(&input, 4);
+
+    let mut args: Vec<String> = command.iter().map(|a| (*a).to_string()).collect();
+    args.extend(
+        ["-i", input.to_str().unwrap(), "-o", output, "--rejects", rejects]
+            .map(ToString::to_string),
+    );
+    if command[0] == "correct" {
+        let umis = dir.join("umis.txt");
+        std::fs::write(&umis, "ACGTACGT\n").expect("write UMI list");
+        args.extend(["-U".to_string(), umis.display().to_string()]);
+    }
+    if command[0] == "filter" {
+        let reference = create_test_reference(dir);
+        args.extend(["-r".to_string(), reference.display().to_string()]);
+    }
+    args
+}
+
+/// A secondary output cannot share stdout with the primary one.
+///
+/// Every command here honours `-` for both `--output` and `--rejects`, so asking
+/// for both opens two BAM writers on fd 1 and interleaves them — two headers,
+/// two EOF blocks, one stream that no reader can parse — while exiting zero.
+/// That is the same silent-success shape `-o -` had before this change, one flag
+/// over, so it is rejected before either writer is opened.
+///
+/// The two spellings vary independently. What collides is the stream, not the
+/// string, so `-o - --rejects /dev/stdout` interleaves exactly as badly as the
+/// matching pair — a guard that compared the two paths for equality would pass a
+/// test that only ever passed it identical ones.
+#[rstest]
+#[case::simplex(&["simplex", "--min-reads", "1"])]
+#[case::duplex(&["duplex", "--min-reads", "1"])]
+#[case::codec(&["codec", "--min-reads", "1", "--min-duplex-length", "1"])]
+#[case::correct(&["correct", "-d", "1"])]
+#[case::filter(&["filter", "--min-reads", "1"])]
+#[case::downsample(&["downsample", "-f", "1.0"])]
+fn rejects_output_and_rejects_both_on_stdout(
+    #[case] command: &[&str],
+    #[values("-", "/dev/stdout")] output: &str,
+    #[values("-", "/dev/stdout")] rejects: &str,
+) {
+    let dir = TempDir::new().expect("create temp dir");
+    let args = colliding_output_args(dir.path(), command, output, rejects);
+
+    let run = run_in(dir.path(), &args);
+    let label = format!("{} -o {output} --rejects {rejects}", command[0]);
+
+    assert!(
+        !run.status.success(),
+        "{label}: must be rejected, not written as two interleaved streams"
+    );
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    assert!(
+        stderr.contains("--rejects") && stderr.contains("stdout"),
+        "{label}: the error must name the colliding option and the stream, got: {stderr}"
+    );
+    assert!(run.stdout.is_empty(), "{label}: nothing may reach stdout once rejected");
+    // Mirrors `sort_rejects_write_index_with_stdout`: an empty pipe and a
+    // non-zero status are also what a guard that fires *after* a writer was
+    // opened would produce, and that guard would have left a file named `-`
+    // behind. Only this assertion distinguishes the two.
+    assert!(!dir.path().join("-").exists(), "{label}: the rejected run still created a file `-`");
+}
+
+/// A secondary output cannot share a regular file with the primary one either.
+///
+/// Two `File::create` calls on one path do not take turns. They produce two file
+/// *descriptions* with independent offsets, both starting at zero, so the two
+/// BAMs overwrite each other byte for byte. Before this guard,
+/// `fgumi correct -o same.bam --rejects same.bam` exited zero having logged
+/// "kept 400 and rejected 0", and `samtools view` then reported
+/// `Invalid BGZF header at offset 392`.
+///
+/// This is the worse half of the pair the guard covers: on stdout the two
+/// writers share one file description, so every byte survives in an unparseable
+/// order, whereas here bytes are destroyed. Note too that the rejects writer is
+/// created eagerly and emits its header at offset 0 whether or not a single read
+/// is rejected — the corruption needs no rejects to occur, which is why the
+/// fixture's reads all pass.
+///
+/// The three spellings are one file under three names, which is why the guard
+/// resolves the parent directory instead of comparing the paths as written. Each
+/// run happens in `dir`, so all three are relative to it; `sub` exists so that
+/// `sub/../out.bam` has a parent that can be canonicalized.
+#[rstest]
+#[case::simplex(&["simplex", "--min-reads", "1"])]
+#[case::duplex(&["duplex", "--min-reads", "1"])]
+#[case::codec(&["codec", "--min-reads", "1", "--min-duplex-length", "1"])]
+#[case::correct(&["correct", "-d", "1"])]
+#[case::filter(&["filter", "--min-reads", "1"])]
+#[case::downsample(&["downsample", "-f", "1.0"])]
+fn rejects_output_and_rejects_on_the_same_file(
+    #[case] command: &[&str],
+    #[values("out.bam", "./out.bam", "sub/../out.bam")] rejects: &str,
+) {
+    let dir = TempDir::new().expect("create temp dir");
+    std::fs::create_dir_all(dir.path().join("sub")).expect("create subdirectory");
+    let args = colliding_output_args(dir.path(), command, "out.bam", rejects);
+
+    let run = run_in(dir.path(), &args);
+    let label = format!("{} -o out.bam --rejects {rejects}", command[0]);
+
+    assert!(!run.status.success(), "{label}: must be rejected, not written as two mangled streams");
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    assert!(
+        stderr.contains("--rejects") && stderr.contains("out.bam"),
+        "{label}: the error must name the colliding option and the path, got: {stderr}"
+    );
+    // The guard has to fire before either writer opens: `File::create` truncates,
+    // so a run that reached the writers and *then* failed would still have left a
+    // clobbered `out.bam` behind. Only the file's absence proves it fired first.
+    assert!(
+        !dir.path().join("out.bam").exists(),
+        "{label}: the rejected run still created the output file"
+    );
 }
 
 /// `extract` reaches stdout whether or not `--threads` makes it parallel.
@@ -235,10 +393,21 @@ fn sort_rejects_write_index_with_stdout(#[case] spelling: &str) {
 /// `Threads(1)`, which takes the parallel path with a single worker. Passing `1`
 /// would therefore have run the pipeline writer twice and never covered the raw
 /// one.
+///
+/// Both spellings run against both writers as contract coverage, not as a
+/// discriminating check. `File::create("/dev/stdout")` reaches fd 1 on its own on
+/// Unix, so a writer that special-cased only `-` still streams correctly here —
+/// confirmed by mutating the threaded path to do exactly that, which left all
+/// four cases passing. What the `/dev/stdout` cases pin is that both advertised
+/// spellings keep working through both writers; `-` is the spelling that has no
+/// meaning to `File::create` and so is the one the dispatch exists for.
 #[rstest]
 #[case::flag_omitted(None)]
 #[case::parallel(Some("4"))]
-fn extract_streams_to_stdout(#[case] threads: Option<&str>) {
+fn extract_streams_to_stdout(
+    #[case] threads: Option<&str>,
+    #[values("-", "/dev/stdout")] output: &str,
+) {
     let dir = TempDir::new().expect("create temp dir");
     let input = dir.path().join("input.fq");
     let fastq = (0..8).fold(String::new(), |mut text, i| {
@@ -279,10 +448,10 @@ fn extract_streams_to_stdout(#[case] threads: Option<&str>) {
 
     let cwd = dir.path().join("cwd");
     std::fs::create_dir_all(&cwd).expect("create run dir");
-    let dash_args = args("-");
-    let run = run_in(&cwd, &dash_args);
-    let label = format!("extract -o - (threads={})", threads.unwrap_or("<omitted>"));
-    let stdout = assert_streamed(&run, &cwd, &label);
+    let stdout_args = args(output);
+    let run = run_in(&cwd, &stdout_args);
+    let label = format!("extract -o {output} (threads={})", threads.unwrap_or("<omitted>"));
+    let stdout = assert_streamed_bam(&run, &cwd, &label);
 
     let streamed = bam_from_stdout(dir.path(), "streamed.bam", &stdout);
     assert_eq!(

--- a/tests/integration/test_streaming_output.rs
+++ b/tests/integration/test_streaming_output.rs
@@ -1,0 +1,336 @@
+//! Integration tests for streaming *output* support (`-o -`, `-o /dev/stdout`).
+//!
+//! [`test_input_source_matrix`](crate::test_input_source_matrix) holds every
+//! command to the stdout axis once, through whatever code path its default
+//! arguments select. That is the breadth; this file is the depth, for the two
+//! commands whose writer is chosen by something other than `--output`:
+//!
+//! - `sort` picks a different writer per phase — an in-memory write when
+//!   everything fits under `--max-memory`, a k-way merge when it does not — and
+//!   `--write-index` selects a third that needs a seekable file and so cannot be
+//!   satisfied by a pipe at all.
+//! - `extract` writes through the unified pipeline when `--threads` makes it
+//!   parallel and through a plain raw-BAM writer when it does not. Only one of
+//!   those two used to reach stdout, which made the bug depend on a flag that has
+//!   nothing to do with where the output goes.
+//!
+//! The failure mode throughout is silent: a writer that opens `-` as a filename
+//! creates a regular file called `-`, writes the output into it, and exits zero
+//! with an empty pipe. So every test here runs the command in its own working
+//! directory and asserts nothing was left behind there, rather than trusting the
+//! exit status.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+use rstest::rstest;
+use tempfile::TempDir;
+
+use crate::helpers::bam_generator::{create_minimal_header, create_umi_family, write_bam};
+use crate::helpers::read_bam_output;
+
+/// Runs `fgumi` with `args` from inside `cwd`, and returns the completed output.
+///
+/// The working directory matters: it is where a command that mistakes `-` for a
+/// filename creates its file, and giving each run a fresh one is what lets
+/// [`assert_streamed`] tell "streamed to the pipe" from "wrote a file called
+/// `-`" without depending on the state of the crate root.
+fn run_in<S: AsRef<std::ffi::OsStr>>(cwd: &Path, args: &[S]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("failed to run fgumi")
+}
+
+/// Asserts a run succeeded, streamed something, and left no file behind.
+///
+/// Returns the streamed bytes, so a caller can go on to check they are the same
+/// output the command writes to a file. `label` names the case in any failure,
+/// since every caller runs the same assertions over several spellings.
+fn assert_streamed(run: &Output, cwd: &Path, label: &str) -> Vec<u8> {
+    assert!(
+        run.status.success(),
+        "{label}: fgumi failed: {}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert!(
+        !cwd.join("-").exists(),
+        "{label}: created a regular file named `-` instead of writing to stdout"
+    );
+    assert!(!run.stdout.is_empty(), "{label}: wrote nothing to stdout");
+    run.stdout.clone()
+}
+
+/// Writes `stdout` to a file so it can be read back with the shared BAM helper,
+/// which normalizes the `@PG` `CL` line the two runs legitimately differ on.
+fn bam_from_stdout(dir: &Path, name: &str, stdout: &[u8]) -> std::path::PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, stdout).expect("write captured stdout");
+    path
+}
+
+/// A BAM of `families` UMI families, three reads each, at staggered positions.
+///
+/// Sized by caller: the sort tests need one input that fits in memory and one
+/// that cannot, and the only difference between those two runs should be the
+/// number of records.
+fn write_test_bam(path: &Path, families: usize) {
+    let header = create_minimal_header("chr1", 100_000);
+    let records: Vec<_> = (0..families)
+        .flat_map(|i| create_umi_family("ACGTACGT", 3, &format!("fam_{i:06}"), "ACGTACGTAC", 35))
+        .collect();
+    write_bam(path, &header, &records);
+}
+
+/// `sort` reaches stdout through every one of its write paths.
+///
+/// The phase that writes the output depends on whether the records fit under
+/// `--max-memory`: under it, a single in-memory write; over it, a k-way merge of
+/// spilled chunks. Those are two different writers, and only exercising the
+/// small case would leave the merge path — the one every large sort takes —
+/// untested. `--threads 2` additionally moves the write onto the pool.
+///
+/// Each case asserts the streamed bytes are the same BAM the file run produced,
+/// so a path that streams *something* but drops or reorders records still fails.
+#[rstest]
+#[case::in_memory(64, "768M", "1")]
+#[case::spill_and_merge(20_000, "1M", "1")]
+#[case::spill_and_merge_threaded(20_000, "1M", "2")]
+fn sort_streams_to_stdout(
+    #[case] families: usize,
+    #[case] max_memory: &str,
+    #[case] threads: &str,
+) {
+    let dir = TempDir::new().expect("create temp dir");
+    let input = dir.path().join("input.bam");
+    write_test_bam(&input, families);
+
+    let expected = dir.path().join("expected.bam");
+    let file_args = [
+        "sort",
+        "-i",
+        input.to_str().unwrap(),
+        "-o",
+        expected.to_str().unwrap(),
+        "--order",
+        "coordinate",
+        "-m",
+        max_memory,
+        "--threads",
+        threads,
+    ];
+    let file_run = run_in(dir.path(), &file_args);
+    assert!(
+        file_run.status.success(),
+        "the file baseline failed, so the stdout comparison would prove nothing: {}",
+        String::from_utf8_lossy(&file_run.stderr)
+    );
+
+    // A fresh working directory per streamed run, so a stray `-` is attributable.
+    for spelling in ["-", "/dev/stdout"] {
+        let cwd = dir.path().join(format!("cwd{spelling}").replace('/', "_"));
+        std::fs::create_dir_all(&cwd).expect("create run dir");
+
+        let mut args = file_args;
+        args[4] = spelling;
+        let run = run_in(&cwd, &args);
+        let label = format!("sort -o {spelling} (m={max_memory}, threads={threads})");
+        let stdout = assert_streamed(&run, &cwd, &label);
+
+        let streamed = bam_from_stdout(dir.path(), "streamed.bam", &stdout);
+        assert_eq!(
+            read_bam_output(&streamed),
+            read_bam_output(&expected),
+            "{label}: streamed a different BAM than the same sort wrote to a file"
+        );
+    }
+}
+
+/// A merge that spilled really did spill.
+///
+/// [`sort_streams_to_stdout`]'s `spill_and_merge` cases are only meaningful if
+/// the record count and memory limit actually push the sort past an in-memory
+/// write. That is a property of the fixture, not of the code under test, so it
+/// is asserted separately rather than assumed: if a future change to the buffer
+/// sizing makes 20k records fit in 1M, this fails and says so instead of quietly
+/// turning two of the three cases above into duplicates of the first.
+#[test]
+fn the_spilling_fixture_spills() {
+    let dir = TempDir::new().expect("create temp dir");
+    let input = dir.path().join("input.bam");
+    write_test_bam(&input, 20_000);
+
+    let run = run_in(
+        dir.path(),
+        &[
+            "sort",
+            "-i",
+            input.to_str().unwrap(),
+            "-o",
+            dir.path().join("out.bam").to_str().unwrap(),
+            "--order",
+            "coordinate",
+            "-m",
+            "1M",
+        ],
+    );
+    let log = String::from_utf8_lossy(&run.stderr);
+    assert!(
+        log.contains("Temporary chunks:"),
+        "20k records under `-m 1M` no longer spill, so the merge path is not being covered:\n{log}"
+    );
+}
+
+/// `--write-index` and stdout are mutually exclusive, and saying so beats
+/// half-doing it.
+///
+/// A BAI has to be written to a sidecar path next to a seekable file, which a
+/// pipe has neither of. The rejection is the same one `create_indexing_bam_writer`
+/// already makes; the point of asserting it here is that it must happen *before*
+/// anything is written, rather than the sort streaming a BAM and then failing to
+/// index it — or, worse, falling back to opening `-` as a file.
+#[rstest]
+#[case::dash("-")]
+#[case::dev_stdout("/dev/stdout")]
+fn sort_rejects_write_index_with_stdout(#[case] spelling: &str) {
+    let dir = TempDir::new().expect("create temp dir");
+    let input = dir.path().join("input.bam");
+    write_test_bam(&input, 8);
+
+    let run = run_in(
+        dir.path(),
+        &[
+            "sort",
+            "-i",
+            input.to_str().unwrap(),
+            "-o",
+            spelling,
+            "--order",
+            "coordinate",
+            "--write-index",
+        ],
+    );
+
+    assert!(!run.status.success(), "`--write-index -o {spelling}` must be rejected, not attempted");
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    assert!(
+        stderr.contains("--write-index"),
+        "the error must name the flag that cannot be satisfied, got: {stderr}"
+    );
+    assert!(!dir.path().join("-").exists(), "the rejected run still created a file named `-`");
+    assert!(!dir.path().join("-.bai").exists(), "the rejected run still created a `-.bai`");
+}
+
+/// `extract` reaches stdout whether or not `--threads` makes it parallel.
+///
+/// The two cases select different writers — a plain raw-BAM writer when the flag
+/// is absent, the unified pipeline when it is present — so `-o -` streamed for a
+/// bare `fgumi extract` and silently wrote a file named `-` once `--threads` was
+/// given. A user has no reason to expect where their output lands to depend on
+/// how many threads they asked for.
+///
+/// The first case omits `--threads` rather than passing `1`: threading mode is
+/// `SingleThreaded` only when the flag is absent, and `--threads 1` is
+/// `Threads(1)`, which takes the parallel path with a single worker. Passing `1`
+/// would therefore have run the pipeline writer twice and never covered the raw
+/// one.
+#[rstest]
+#[case::flag_omitted(None)]
+#[case::parallel(Some("4"))]
+fn extract_streams_to_stdout(#[case] threads: Option<&str>) {
+    let dir = TempDir::new().expect("create temp dir");
+    let input = dir.path().join("input.fq");
+    let fastq = (0..8).fold(String::new(), |mut text, i| {
+        use std::fmt::Write as _;
+        writeln!(text, "@read_{i}\nACGTACGTACGTACGTAC\n+\nIIIIIIIIIIIIIIIIII")
+            .expect("writing to a String cannot fail");
+        text
+    });
+    std::fs::write(&input, fastq).expect("write FASTQ");
+
+    let expected = dir.path().join("expected.bam");
+    let args = |output: &str| {
+        let mut args = vec![
+            "extract".to_string(),
+            "-i".to_string(),
+            input.to_str().unwrap().to_string(),
+            "-o".to_string(),
+            output.to_string(),
+            "-r".to_string(),
+            "8M+T".to_string(),
+            "--sample".to_string(),
+            "S1".to_string(),
+            "--library".to_string(),
+            "L1".to_string(),
+        ];
+        if let Some(threads) = threads {
+            args.extend(["--threads".to_string(), threads.to_string()]);
+        }
+        args
+    };
+    let file_args = args(expected.to_str().unwrap());
+    let file_run = run_in(dir.path(), &file_args);
+    assert!(
+        file_run.status.success(),
+        "the file baseline failed, so the stdout comparison would prove nothing: {}",
+        String::from_utf8_lossy(&file_run.stderr)
+    );
+
+    let cwd = dir.path().join("cwd");
+    std::fs::create_dir_all(&cwd).expect("create run dir");
+    let dash_args = args("-");
+    let run = run_in(&cwd, &dash_args);
+    let label = format!("extract -o - (threads={})", threads.unwrap_or("<omitted>"));
+    let stdout = assert_streamed(&run, &cwd, &label);
+
+    let streamed = bam_from_stdout(dir.path(), "streamed.bam", &stdout);
+    assert_eq!(
+        read_bam_output(&streamed),
+        read_bam_output(&expected),
+        "{label}: streamed a different BAM than it wrote to a file"
+    );
+}
+
+/// `fastq` accepts `-o -` for the stdout it already supports by omission.
+///
+/// Omitting `--output` entirely has always written plain FASTQ to stdout, so the
+/// stream itself is not new — but `-o -` wrote a file named `-`, which makes the
+/// command the odd one out among a CLI where `-` means stdout everywhere else.
+/// Both spellings must produce exactly what the file run produced.
+#[rstest]
+#[case::dash(Some("-"))]
+#[case::dev_stdout(Some("/dev/stdout"))]
+#[case::omitted(None)]
+fn fastq_streams_to_stdout(#[case] output: Option<&str>) {
+    let dir = TempDir::new().expect("create temp dir");
+    let input = dir.path().join("input.bam");
+    write_test_bam(&input, 4);
+
+    let expected = dir.path().join("expected.fq");
+    let file_run = run_in(
+        dir.path(),
+        &["fastq", "-i", input.to_str().unwrap(), "-o", expected.to_str().unwrap()],
+    );
+    assert!(
+        file_run.status.success(),
+        "the file baseline failed, so the stdout comparison would prove nothing: {}",
+        String::from_utf8_lossy(&file_run.stderr)
+    );
+
+    let cwd = dir.path().join("cwd");
+    std::fs::create_dir_all(&cwd).expect("create run dir");
+    let mut args = vec!["fastq", "-i", input.to_str().unwrap()];
+    if let Some(spelling) = output {
+        args.extend(["-o", spelling]);
+    }
+    let run = run_in(&cwd, &args);
+    let label = format!("fastq -o {}", output.unwrap_or("<omitted>"));
+    let stdout = assert_streamed(&run, &cwd, &label);
+
+    assert_eq!(
+        stdout,
+        std::fs::read(&expected).expect("read the file baseline"),
+        "{label}: streamed different FASTQ than the same command wrote to a file"
+    );
+}


### PR DESCRIPTION
Fixes #688.

## The bug

`fgumi sort -o -` created a regular file called `-` in the working directory, wrote the BAM into it, and exited zero — so the pipe was empty and a stray `-` file was left behind. `fgumi fastq -o -` did the same. `fgumi extract -o -` did it too, but only when `--threads` selected the parallel pipeline, so where the output landed depended on a flag that has nothing to do with where the output goes.

```console
$ fgumi sort -i in.sam -o - --order coordinate > out.bam
$ ls -la
-rw-r--r--  333  -          # the BAM landed here
-rw-r--r--    0  out.bam    # stdout got nothing
```

Every other BAM-writing command was already correct.

## The fix

`fgumi-bam-io` already had the dispatch — `is_stdout_path` recognizes `-` and `/dev/stdout`, and `open_output_writer` returns stdout for either. The commands that work reach it through `create_bam_writer` / `create_raw_bam_writer`; the three broken ones called `File::create` directly. They now go through `open_output_writer`, which is promoted from `pub(crate)` to `pub` and documented as the place the convention is honoured for BAM output. (`fastq` emits text, so it dispatches on `is_stdout_path` itself and takes `stdout().lock()` — no boxed writer needed.)

For `sort` that meant threading the choice through `PooledBamWriter`, which all three of its write paths funnel into (in-memory, k-way merge, and the indexing variant), so `io_writer_loop` is now generic over its sink instead of fixed to `File`. Spill chunks stay monomorphized on `File`, so the hot path is untouched.

`sort --write-index` combined with stdout is now rejected up front instead of attempted. A BAI needs a seekable file and a sidecar path, and a pipe has neither; `create_indexing_bam_writer` already refused it, and the check just moves earlier so the run fails before streaming a BAM it could never index.

## A second bug, found while reviewing this one

Making `-o -` a supported, contract-tested spelling exposed an adjacent hazard. `-` is honoured by *every* BAM writer, including secondary outputs, so a command given both `--output -` and `--rejects -` opened two writers on fd 1 and interleaved two BAMs — two headers, two EOF blocks, one stream — then exited zero:

```console
$ fgumi simplex -i g.bam -o - --rejects - --min-reads 1 > both.bam
$ # 678 bytes, 4 BGZF members, 2 EOF markers
$ echo $?
0
```

Nothing downstream can read that and nothing reported it — the same silent-success shape this PR exists to remove, one flag over. Pre-existing (`create_optional_bam_writer` has always resolved `-`), but this PR is what turns it from an undocumented accident into something users will reach for.

`reject_colliding_stdout_outputs` now bails when both paths name stdout, wired in immediately after input validation in all six commands that take a secondary BAM output: `simplex`, `duplex`, `codec`, `correct`, `filter`, `downsample`. Two identical *file* paths are deliberately left alone — that is last-writer-wins on disk, a different failure with a different fix.

## Why nothing caught the original

`tests/integration/test_input_source_matrix.rs` is the contract test for this class of bug — a table with an entry per advertised subcommand, enforced so a new command cannot be added without declaring a stance. But all three of its axes were input-side (`sam`, `stdin`, and the `output_depends_on_input` anti-vacuity guard). Nothing in `tests/`, `scripts/`, or `docs/` passed `-` as an *output* path, and no test read a BAM back from a child's stdout. `zipper` is the sharpest illustration: it *defaults* `--output` to `-`, its stdin default is explicitly covered, and its stdout default never was.

So the matrix grows a fourth axis, `stdout`. Every command declares `Required` or `NotApplicable` with a reason (the metrics commands and `review` take an output *prefix*, which no pipe can carry). The check runs the command with `-o -` in a scratch working directory, fails if a file named `-` appears there, and compares what arrived on the pipe against the same named-path oracle the other axes use — so a command that streams *something* but drops or reorders records still fails. The type and its test are renamed `IoContract` / `every_command_declares_an_io_contract` to match what they now cover.

`tests/integration/test_streaming_output.rs` is new, and covers what the matrix cannot reach with a command's default arguments:

- `sort` through each write path — in-memory, spill+merge, and spill+merge threaded — in both spellings (`-` and `/dev/stdout`), asserting the streamed bytes are the same BAM the file run produced. A companion test asserts the spilling fixture really does spill, so those cases cannot silently decay into duplicates of the in-memory one.
- `sort --write-index` rejection, asserting the error names *both* the flag and the stdout conflict — naming only the flag would also match the unrelated `--write-index cannot be used with --verify` error from the same function — and that no `-` or `-.bai` is left behind.
- The `--output`/`--rejects` collision, one case per affected command. The guard runs before any record is read, so one throwaway BAM drives all six regardless of the tags each would otherwise need.
- `extract` with `--threads` and with the flag omitted. The omission is deliberate: threading mode is `SingleThreaded` only when the flag is absent — `--threads 1` is `Threads(1)` and takes the parallel path — so passing `1` would have exercised the pipeline writer twice and never the raw one.
- `fastq` across `-o -`, `-o /dev/stdout`, and omitting `--output`.

Every streamed BAM is also checked for the trailing BGZF EOF block, via a new byte-slice `assert_bytes_have_bgzf_eof` beside the existing path-based helper. Records parsing back is not sufficient: noodles reads a stream missing the marker, `samtools quickcheck` rejects it, and issue #125 was commands emitting exactly that. `test_bgzf_eof.rs` covers group, dedup, simplex, duplex, codec, filter, clip, and correct — but not sort, extract, or fastq, the three commands this PR reroutes to a new sink. The marker is emitted today, so this pins an invariant rather than fixing a break.

## Verification

- Full suite: 6910 passed, 0 failed (`cargo ci-test`). `cargo ci-lint`, `cargo ci-fmt`, and `cargo ci-doc` clean.
- Each new test was confirmed to fail before its fix and pass after — the matrix axis named exactly `sort` and `fastq`, the targeted tests added `extract --threads`, and the collision test was written against the reproducer above.
- No throughput cost to routing the sort's output through `Stdout`: a 2M-record sort writing 116 MB measured 0.58–0.63 s to a file and 0.58–0.61 s to a pipe over three reps. The two outputs are record-identical (2,000,000 records, same `samtools view` body md5); they differ only in the `@PG` `CL` line, which correctly records the different `-o` argument.

## Also here

The two high-throughput pipelines in `docs/src/guide/best-practices.md` pipe `fgumi group` into `fgumi simplex` and `fgumi filter` into `fgumi sort` without giving either producer an `--output`. Both require one, so those examples fail with a clap usage error as written. Fixed in a separate commit by adding `--output -`, which is what the surrounding prose intends — and which now behaves.

## Reading order

1. `5254aaf3` — the original fix and the contract axis. Start at `crates/fgumi-sort/src/pooled_bam_writer.rs` and `tests/integration/test_input_source_matrix.rs`.
2. `8980d267` — the docs example fix.
3. `2b5b2e97` — the `--output`/`--rejects` collision guard.
4. `ea14bae1` — self-review fixes: BGZF EOF assertions, the tightened rejection assertions, the `IoContract` rename, and help-text corrections. Its regression test for (3) lives here rather than in that commit, since it shares a file with the EOF changes.

## Not in scope

No command's `--output` help text mentions that `-` means stdout, but neither does any `--input` help mention stdin, so documenting the convention is a consistent change across the whole CLI rather than something to bolt onto the commands touched here. `fastq`'s `--output` and `sort`'s `--write-index` are updated because this PR changed what they accept; the general sweep is worth a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: Output changes affect destination and streaming only, pinned by existing file output and integration comparisons; `unsafe` changes are none and the `CLAUDE.md` allowlist is unchanged; buffering adds 256 KiB for threaded `extract` and 64 MiB for `fastq`, with no queue, thread, or backpressure policy change.

## Summary

- Fixed `sort`, threaded `extract`, and `fastq` output for `-` and `/dev/stdout`.
- Added buffered stdout writers and BGZF EOF validation.
- Rejected `sort --write-index` for non-seekable stdout.
- Prevented primary and rejects outputs from targeting the same stdout or regular file.
- Expanded I/O contract and streaming tests.
- Updated pipeline examples to pass `--output -`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->