### PR TITLE
fix(sort): report the thread counts each phase actually uses

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -92,6 +92,21 @@ fn should_spill_chunk(memory_used: usize, memory_limit: usize, chunk_records: us
     memory_used >= memory_limit || chunk_records >= MAX_CHUNK_RECORDS
 }
 
+/// Render the effective per-phase worker counts for a log line.
+///
+/// Collapses to a single number when the phases agree (the common case, where
+/// neither `--sort-threads` nor `--merge-threads` was overridden) and spells
+/// both out otherwise. Shared by the engine's end-of-run summary and the `sort`
+/// command's config dump so the two emitters cannot drift.
+#[must_use]
+pub fn format_thread_counts(sort_threads: usize, merge_threads: usize) -> String {
+    if sort_threads == merge_threads {
+        format!("{sort_threads}")
+    } else {
+        format!("sort {sort_threads}, merge {merge_threads}")
+    }
+}
+
 // ============================================================================
 // Per-Phase Timing for Sort Pipeline
 // ============================================================================
@@ -202,8 +217,13 @@ impl SortPhaseTimer {
     }
 
     /// Log the final summary.
+    ///
+    /// `sort_threads` and `merge_threads` are the *effective* per-phase worker
+    /// counts ([`RawExternalSorter::phase1_threads`] /
+    /// [`RawExternalSorter::phase2_threads`]), not the configured `threads`
+    /// they default from — the summary reports what the phases ran with.
     #[allow(clippy::cast_precision_loss)]
-    fn log_summary(&self, threads: usize) {
+    fn log_summary(&self, sort_threads: usize, merge_threads: usize) {
         let overall = self.overall_start.map_or(0.0, |s| s.elapsed().as_secs_f64());
         // Guard against division by zero when sort completes in negligible time.
         let overall_nonzero = if overall > 0.0 { overall } else { f64::EPSILON };
@@ -239,7 +259,7 @@ impl SortPhaseTimer {
             info!("  Write output:      {write_secs:.1}s ({write_pct:.0}%)");
         }
         info!("  Total wall clock:  {overall:.1}s");
-        info!("  Threads: {threads}");
+        info!("  Threads: {}", format_thread_counts(sort_threads, merge_threads));
         info!("=========================");
     }
 }
@@ -2205,7 +2225,7 @@ impl RawExternalSorter {
         debug!("Starting raw-bytes sort with order: {:?}", self.sort_order);
         debug!("Memory limit: {} MB", self.memory_limit / (1024 * 1024));
         debug!(
-            "Threads: {} (phase 1: {}, phase 2: {})",
+            "Threads: {} (default for both phases; phase 1: {}, phase 2: {})",
             self.threads,
             self.phase1_threads(),
             self.phase2_threads()
@@ -2657,7 +2677,7 @@ impl RawExternalSorter {
         if let Ok(pool) = Arc::try_unwrap(pool) {
             pool.shutdown();
         }
-        timer.log_summary(self.threads);
+        timer.log_summary(self.phase1_threads(), self.phase2_threads());
         debug!("Sort complete: {} records processed", stats.total_records);
 
         Ok(stats)
@@ -2848,7 +2868,7 @@ impl RawExternalSorter {
         if let Ok(pool) = Arc::try_unwrap(pool) {
             pool.shutdown();
         }
-        timer.log_summary(self.threads);
+        timer.log_summary(self.phase1_threads(), self.phase2_threads());
         debug!("Sort complete: {} records processed", stats.total_records);
 
         Ok(stats)
@@ -3118,7 +3138,7 @@ impl RawExternalSorter {
         if let Ok(pool) = Arc::try_unwrap(pool) {
             pool.shutdown();
         }
-        timer.log_summary(self.threads);
+        timer.log_summary(self.phase1_threads(), self.phase2_threads());
         debug!("Sort complete: {} records processed", stats.total_records);
 
         Ok(stats)
@@ -3443,7 +3463,7 @@ impl RawExternalSorter {
         if let Ok(pool) = Arc::try_unwrap(pool) {
             pool.shutdown();
         }
-        timer.log_summary(self.threads);
+        timer.log_summary(self.phase1_threads(), self.phase2_threads());
         debug!("Sort complete: {} records processed", stats.total_records);
 
         Ok(stats)
@@ -6373,7 +6393,7 @@ mod tests {
         assert!(timer.write_output_secs >= 0.0);
 
         // log_summary must not panic (output goes to log sink)
-        timer.log_summary(4);
+        timer.log_summary(4, 4);
     }
 
     // ========================================================================

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -161,6 +161,7 @@ fn create_temp_dir(base: Option<&Path>) -> Result<TempDir> {
 pub use codec::SpillCodec;
 pub use external::{
     KeyTypesSpec, LibraryLookup, RawExternalSorter, cb_hasher, extract_template_key_inline,
+    format_thread_counts,
 };
 pub use inline::{
     PackedCoordinateKey, RecordRef, TemplateKey, extract_coordinate_key_inline,

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -288,6 +288,10 @@ pub struct Sort {
     ///
     /// Used for parallel sorting of in-memory chunks and parallel temp-chunk
     /// (BGZF or zstd) compression.
+    ///
+    /// This is also the multiplier for `--max-memory --memory-per-thread`: the
+    /// sort runs on one global memory budget, so `--sort-threads` and
+    /// `--merge-threads` change scheduling only and never resize it.
     #[arg(short = '@', short_alias = 't', long = "threads", default_value = "1")]
     pub threads: usize,
 
@@ -299,7 +303,8 @@ pub struct Sort {
     /// still uses 8 because it cannot start until the input is exhausted, by
     /// which point the producer has finished writing.
     ///
-    /// This only changes scheduling; the output is byte-identical.
+    /// This only changes scheduling; the output is byte-identical, and the
+    /// memory budget stays sized from `--threads`.
     #[arg(long = "sort-threads")]
     pub sort_threads: Option<usize>,
 
@@ -534,6 +539,10 @@ impl Sort {
 
         let cell_tag = self.parse_cell_tag()?;
 
+        // Built before the config log so the log can report the sorter's own
+        // effective per-phase thread counts.
+        let mut sorter = self.build_sorter(effective_memory, command_line);
+
         debug!("Starting Sort");
         info!("Input: {}", self.input.display());
         info!("Output: {}", output.display());
@@ -544,8 +553,12 @@ impl Sort {
         }
         if let MemoryLimit::Fixed(per_thread) = self.max_memory {
             if self.memory_per_thread {
+                // The multiplier is `--threads`, not the per-phase counts logged
+                // below: `resolve_memory_budget` sizes one global budget for the
+                // whole run, so `--sort-threads`/`--merge-threads` do not change
+                // it. Name the flag so the two lines cannot be read as disagreeing.
                 info!(
-                    "Max memory: {} ({}/thread x {} threads)",
+                    "Max memory: {} ({}/thread x {} threads, from --threads)",
                     ByteSize(effective_memory as u64),
                     ByteSize(per_thread as u64),
                     self.threads
@@ -554,7 +567,13 @@ impl Sort {
                 info!("Max memory: {} (fixed)", ByteSize(effective_memory as u64));
             }
         }
-        info!("Threads: {}", self.threads);
+        // Read the counts off the sorter rather than off `--threads`, which is
+        // only where `--sort-threads`/`--merge-threads` default from: logging the
+        // flag alone reports 1 thread for a run that was asked for more.
+        info!(
+            "Threads: {}",
+            fgumi_sort::format_thread_counts(sorter.phase1_threads(), sorter.phase2_threads())
+        );
         info!("Temp compression level: {}", self.temp_compression);
         if self.write_index {
             info!("Write index: enabled");
@@ -569,9 +588,6 @@ impl Sort {
                 .join(", ");
             info!("Temp directories: {joined}");
         }
-
-        // Sort using raw-bytes sorter for optimal memory efficiency and speed
-        let mut sorter = self.build_sorter(effective_memory, command_line);
 
         // For auto mode, cap initial buffer pre-allocation at 768 MiB/thread
         // (matching samtools default) to avoid huge upfront allocations.

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -48,6 +48,7 @@ mod test_simplex_metrics_command;
 mod test_simplex_pipeline;
 mod test_simulate_sort;
 mod test_sort_correctness;
+mod test_sort_thread_logging;
 mod test_sort_write_index;
 mod test_streaming_input;
 mod test_zipper_command;

--- a/tests/integration/test_sort_thread_logging.rs
+++ b/tests/integration/test_sort_thread_logging.rs
@@ -1,0 +1,88 @@
+//! Integration tests for the thread counts `fgumi sort` reports.
+//!
+//! `--sort-threads` and `--merge-threads` each default to `--threads`, so the
+//! flag alone does not describe a run that set only the per-phase overrides.
+//! These tests pin the reported counts to the ones the phases actually use.
+
+use rstest::rstest;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+/// Writes a small unsorted SAM and returns its path.
+///
+/// SAM keeps the fixture readable and avoids a samtools dependency; sort accepts
+/// it directly.
+fn write_unsorted_sam(dir: &Path) -> PathBuf {
+    let mut sam = String::from("@HD\tVN:1.6\tSO:unsorted\n@SQ\tSN:chr1\tLN:10000\n");
+    for pos in [500, 100, 400, 200, 300] {
+        writeln!(sam, "q{pos}\t0\tchr1\t{pos}\t60\t10M\t*\t0\t0\tACGTACGTAC\tIIIIIIIIII")
+            .expect("write SAM record");
+    }
+    let path = dir.join("unsorted.sam");
+    std::fs::write(&path, sam).expect("write SAM fixture");
+    path
+}
+
+/// Runs `fgumi sort` at info verbosity and returns its stderr.
+///
+/// Pinned to info rather than `-v` so the engine's debug config dump — which
+/// reports the `--threads` default alongside its own phase breakdown — stays out
+/// of the captured lines.
+fn sort_and_capture_logs(extra_args: &[&str]) -> String {
+    let tmp = TempDir::new().expect("tempdir");
+    let input = write_unsorted_sam(tmp.path());
+    let output = tmp.path().join("sorted.bam");
+
+    let result = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .env("RUST_LOG", "info")
+        .args(["sort", "-i"])
+        .arg(&input)
+        .arg("-o")
+        .arg(&output)
+        .args(["--order", "coordinate"])
+        .args(extra_args)
+        .output()
+        .expect("run fgumi sort");
+
+    let stderr = String::from_utf8_lossy(&result.stderr).into_owned();
+    assert!(result.status.success(), "fgumi sort failed:\n{stderr}");
+    stderr
+}
+
+/// Every `Threads:` line the run logged, stripped of its log prefix.
+fn threads_lines(stderr: &str) -> Vec<String> {
+    stderr
+        .lines()
+        .filter_map(|line| line.split_once("Threads: "))
+        .map(|(_, counts)| counts.trim().to_string())
+        .collect()
+}
+
+/// Every `Threads:` line a run logs must name the counts its phases actually
+/// used.
+///
+/// * `per_phase_overrides_without_threads` — overrides with `--threads` left
+///   alone used to report `Threads: 1` while the phases ran 8 and 16 workers.
+/// * `sort_override_below_threads` — a phase override below `--threads` is the
+///   documented use (cede cores to an upstream producer, keep the merge wide),
+///   so both counts must still show.
+/// * `matching_phase_counts` — with no overrides the phases agree, so the report
+///   stays a single count rather than repeating it twice.
+#[rstest]
+#[case::per_phase_overrides_without_threads(
+    &["--sort-threads", "8", "--merge-threads", "16"],
+    "sort 8, merge 16"
+)]
+#[case::sort_override_below_threads(&["--threads", "6", "--sort-threads", "2"], "sort 2, merge 6")]
+#[case::matching_phase_counts(&["--threads", "4"], "4")]
+fn reported_thread_counts_match_the_phases(#[case] extra_args: &[&str], #[case] expected: &str) {
+    let stderr = sort_and_capture_logs(extra_args);
+    let reported = threads_lines(&stderr);
+
+    assert!(!reported.is_empty(), "no `Threads:` line was logged:\n{stderr}");
+    for counts in &reported {
+        assert_eq!(counts, expected, "misreported thread counts:\n{stderr}");
+    }
+}


### PR DESCRIPTION
`--sort-threads` and `--merge-threads` each default to `--threads`, but the config log and the phase-timing summary both printed `--threads` verbatim. So a run given only the per-phase overrides reported one thread while running eight sort workers and sixteen merge workers:

```
$ fgumi sort -i in.bam -o out.bam --sort-threads 8 --merge-threads 16
INFO  Threads: 1
INFO    Threads: 1
```

Now:

```
INFO  Threads: sort 8, merge 16
INFO    Threads: sort 8, merge 16
```

It collapses to a single number when both phases agree, so the common case stays terse. The command layer reads the counts off the built sorter (`phase1_threads`/`phase2_threads`) rather than re-deriving the fallback, so the log can't drift from what the engine schedules — `build_sorter` moves above the config log to allow that, and is pure construction. The engine's debug config dump now labels its `--threads` value as the default the phases fall back to.

Logging only; scheduling and output are unchanged. Three integration tests cover the overrides-without-`--threads` case, an override below `--threads`, and the collapsed single-count case; I checked all three fail before the fix (the first reporting `left: "1"`).

`ci-fmt`/`ci-lint` clean. `ci-test` is 6892 passed / 3 failed, the 3 being `test_input_source_matrix::declared_{sam,stdin}_support_*`, which fail identically on a pristine `main` — they diff R-generated `simplex_qc.pdf` byte-for-byte and R stamps `/CreationDate` into it. Same unrelated failures noted in #690.

### Follow-up: the memory budget ignores the per-phase counts

Worth a separate look, since this PR makes it visible rather than introducing it. `resolve_memory_budget` scales by `--threads` only, so the same invocation now logs:

```
INFO  Max memory: 732.4 MiB (732.4 MiB/thread x 1 threads)
INFO  Threads: sort 8, merge 16
```

That is truthful about what was computed, but a run asking for 8 sort threads gets the 1-thread budget. Under the intended usage (`-@ 32 --sort-threads 4`, lowering a phase below `--threads`) it doesn't bite, since `--threads` is set. Whether the budget should follow the phase counts is a behavior change, so I left it out here.
