### PR TITLE
test(simd-fastq): compare long-record bytes, not just their length

### DIFF
--- a/crates/fgumi-simd-fastq/src/parser.rs
+++ b/crates/fgumi-simd-fastq/src/parser.rs
@@ -444,16 +444,20 @@ mod tests {
 
     #[test]
     fn test_long_sequence_spanning_multiple_blocks() {
-        // 200-base sequence spans 4 blocks
-        let seq = "A".repeat(200);
-        let qual = "I".repeat(200);
+        // 200-base sequence spans 4 blocks. The bases and qualities vary with position so
+        // the assertions below pin the bytes the parser hands back, not just how many:
+        // stitching the wrong block boundary preserves the length but not the content.
+        let seq: String = (0..200).map(|i| ['A', 'C', 'G', 'T'][i % 4]).collect();
+        let qual: String =
+            (0..200).map(|i| char::from(b'!' + u8::try_from(i % 60).unwrap())).collect();
         let data = format!("@r1\n{seq}\n+\n{qual}\n");
         let offsets = find_record_offsets(data.as_bytes());
         assert_eq!(offsets, vec![0, data.len()]);
 
         let records: Vec<_> = parse_records(data.as_bytes()).collect();
         assert_eq!(records.len(), 1);
-        assert_eq!(records[0].sequence.len(), 200);
+        assert_eq!(records[0].sequence, seq.as_bytes(), "sequence mismatch across blocks");
+        assert_eq!(records[0].quality, qual.as_bytes(), "quality mismatch across blocks");
     }
 
     #[test]

--- a/crates/fgumi-simd-fastq/src/reader.rs
+++ b/crates/fgumi-simd-fastq/src/reader.rs
@@ -393,8 +393,14 @@ mod tests {
 
     #[test]
     fn test_reader_long_records() {
-        let seq = "A".repeat(500);
-        let qual = "I".repeat(500);
+        // A record four times the reader's capacity, so it can only be produced by
+        // refilling the buffer mid-record. The bases and qualities vary with position
+        // rather than repeating one byte: a misplaced boundary that dropped, duplicated,
+        // or reordered a chunk would still yield 500 bytes, so only comparing the exact
+        // bytes back can catch it.
+        let seq: String = (0..500).map(|i| ['A', 'C', 'G', 'T'][i % 4]).collect();
+        let qual: String =
+            (0..500).map(|i| char::from(b'!' + u8::try_from(i % 60).unwrap())).collect();
         let data = format!("@longread\n{seq}\n+\n{qual}\n");
         let mut reader = SimdFastqReader::with_capacity(Cursor::new(data.as_bytes()), 256);
 
@@ -403,8 +409,8 @@ mod tests {
             .expect("reader should yield a record")
             .expect("record should parse successfully");
         assert_eq!(rec.name, b"longread");
-        assert_eq!(rec.sequence.len(), 500);
-        assert_eq!(rec.quality.len(), 500);
+        assert_eq!(rec.sequence, seq.as_bytes(), "sequence mismatch across buffer refills");
+        assert_eq!(rec.quality, qual.as_bytes(), "quality mismatch across buffer refills");
 
         assert!(reader.next().is_none());
     }


### PR DESCRIPTION
Two long-record tests in `fgumi-simd-fastq` assert only that the parsed fields have the expected length, so neither can fail on the class of defect it exists to catch.

`reader.rs::test_reader_long_records` feeds a 500-byte record through a reader with a 256-byte capacity — the point being that the record can only be produced by refilling the buffer mid-record — and then checks `rec.sequence.len() == 500` and `rec.quality.len() == 500`. A refill that dropped, duplicated, or reordered a chunk still yields 500 bytes.

`parser.rs::test_long_sequence_spanning_multiple_blocks` has the same shape one level down: a 200-base sequence spanning four 64-byte lexer blocks, asserting `sequence.len() == 200` and never looking at the quality line at all.

Both built their input from `"A".repeat(n)` / `"I".repeat(n)`, so even a byte-for-byte comparison would have been weak — every position holds the same value. Both now generate position-varying bases and qualities and compare the bytes the parser returns against the bytes that went in, which is what makes a misplaced boundary observable.

Test-only; no production code is touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened validation for long sequencing records by checking exact sequence and quality content.
  * Improved detection of missing, duplicated, or reordered data when processing records across buffer refills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->