### PR TITLE
test(consensus): pin record_consensus_pair to two emitted reads

### DIFF
--- a/crates/fgumi-consensus/src/caller.rs
+++ b/crates/fgumi-consensus/src/caller.rs
@@ -816,6 +816,20 @@ mod tests {
         assert_eq!(stats.consensus_reads, 1);
     }
 
+    /// `consensus_reads` counts emitted reads, not templates, so recording a pair must
+    /// add two — the whole reason callers that emit both ends use this instead of two
+    /// `record_consensus()` calls. Without this, the counter could be reverted to a
+    /// per-template increment and only an end-to-end record count would notice.
+    #[test]
+    fn test_record_consensus_pair_counts_two_reads() {
+        let mut stats = ConsensusCallingStats::new();
+        stats.record_consensus_pair();
+        assert_eq!(stats.consensus_reads, 2, "a consensus pair is two emitted reads");
+
+        stats.record_consensus();
+        assert_eq!(stats.consensus_reads, 3, "a fragment consensus is one more read");
+    }
+
     #[test]
     fn test_all_rejection_reason_codes() {
         assert_eq!(RejectionReason::FragmentRead.code(), 'F');


### PR DESCRIPTION
`ConsensusCallingStats::consensus_reads` counts emitted *reads*, not templates. That is why callers emitting both ends of a pair go through `record_consensus_pair` rather than calling `record_consensus` twice — the distinction #681 introduced after duplex was found reporting one per template.

The invariant was pinned only end-to-end, by the per-command tests that compare the reported count against the records actually written. Nothing covered the accessor itself, so reverting it to a per-template increment would surface as a metrics discrepancy in duplex and simplex output rather than as a failure in the crate that owns the counter.

Mutation-checked: changing `+= 2` to `+= 1` fails the new test.

Test-only; no production code is touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that consensus pair and fragment recordings correctly increment the consensus read count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->