### PR TITLE
perf(compare): make `compare bams` faster than the sort it validates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ docs/src/metrics/
 
 # Heap profiling output produced when binaries are built with the dhat-heap feature
 dhat-heap.json
+
+# Scratch space for local benchmark corpora, profiles, and campaign notes.
+# Never committed: the compare-bams benchmark corpus alone is ~20 GB of BAMs.
+/ephemeral/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,124 @@ listed in this section.
 
 ## Benchmarking Notes
 
+### Profiling fgumi: what works, in order
+
+Reach for these in order. The first two answer most questions and need no new
+code; only drop to sampling when you genuinely need per-function attribution.
+
+**1. `tricorder` — core utilization, memory, and I/O.** The fastest way to learn
+whether a command is CPU-bound, I/O-bound, or leaving cores idle:
+
+```sh
+tricorder --interval 0.25 --summary --out agg.tsv --trace trace.tsv -- fgumi <cmd> ...
+# tricorder: wall=23.68s cpu=23.22s mean_load=98% max_rss=20.3MiB io_in=4.5MiB
+```
+
+`mean_load` is the number to read first: **98% means one core busy**, so on a
+12-core box the command is single-threaded regardless of what `--threads` was
+passed. `--trace` gives cores-over-time, which distinguishes "parallel
+throughout" from "parallel phase followed by a serial tail". Note that `io_in`
+collapses to near zero once the input is in page cache — a low `io_in` means the
+run was CPU-bound *on that invocation*, not that the tool does little I/O.
+
+**2. In-tree phase timers — the primary attribution tool.** `fgumi sort` already
+carries `SortPhaseTimer` (`crates/fgumi-sort/src/external.rs`): per-phase `f64`
+accumulators, a `time()` helper wrapping each span, and a `log_summary()` that
+emits `=== Sort Phase Timing ===` at `info!` (read+decompress / in-memory sort /
+spill write / consolidation / k-way merge / write output, each with a percentage).
+Prior campaigns got full baseline phase attribution from this with **zero new
+code** — just `RUST_LOG=info`.
+
+Mirror that pattern when optimizing any other command: the phases you would name
+in a design doc are exactly the phases worth timing, it works identically on
+macOS and Linux, and it cannot be defeated by inlining or missing symbols the way
+a sampling profiler can. Prefer adding a phase timer over fighting a profiler.
+
+**3. `perf record` / `perf stat` on Linux (EC2)** when per-function or
+per-instruction attribution is genuinely required. This is the reliable path for
+function-level work; see the EC2 host recipe in the user-level CLAUDE.md.
+
+#### macOS sampling: pitfalls that produce confidently wrong profiles
+
+`samply` works on macOS but has three traps with this codebase. All three
+silently yield a plausible-looking, wrong profile:
+
+- **The release binary has no symbols.** `[profile.release]` builds get
+  `-C strip=debuginfo`, so everything symbolicates to raw addresses. Use the
+  existing `[profile.profiling]` (inherits release, `debug = "line-tables-only"`),
+  or `CARGO_PROFILE_PROFILING_DEBUG=2` for full DWARF.
+- **Blocked threads are counted as CPU.** samply samples every thread on a timer,
+  including ones parked on a channel or condvar. Counting raw samples credited an
+  idle BGZF worker pool the same CPU as the working thread and made an 18 s run
+  look like 285 s across 21 threads. Weight samples by `threadCPUDelta`
+  (microseconds of real CPU between samples) instead of counting them.
+- **`atos` mis-resolves addresses from other images.** Feeding every sampled
+  address to `atos -o target/profiling/fgumi` resolves `libsystem_kernel` /
+  `libsystem_pthread` / `libsystem_malloc` addresses against the fgumi image,
+  landing on whatever symbol happens to sit at that offset. This is where
+  nonsense like "38% of CPU in `clap_builder::error::Error::print`" on a
+  *successful* run comes from. Map each frame to its library first (Gecko
+  `funcTable.resource` → `resourceTable` → `libs`) and only symbolicate frames
+  belonging to the fgumi image. Under fat LTO, local symbols are gone, so even
+  in-image resolution can land on a neighbouring function — treat any
+  suspiciously hot dependency symbol as misattribution until corroborated.
+
+Corroborate a sampling result against `tricorder` or a phase timer before acting
+on it. In the `compare bams` work, the sampling profile and `tricorder` agreed
+that BGZF decode dominates (~61% self time; `mean_load=98%`), which is what made
+the conclusion trustworthy — not the profile alone.
+
+### `fgumi compare bams` baseline (recorded 2026-08-01, issue #686)
+
+M2 Max (12 core), 20.1M records/file, ~2 GB BAMs, page-cached, `--threads 8`:
+
+| mode | wall | cpu | mean_load | cores busy | peak OS threads | max_rss |
+| --- | --- | --- | --- | --- | --- | --- |
+| `--command sort` (coordinate) | 23.7s | 23.2s | 98% | 0.98 / 12 | **1** | 20.3 MiB |
+| `--command group` | 24.7s | 24.3s | 98% | 0.98 / 12 | **1** | 21.2 MiB |
+| `--command simplex` (content) | 18.3s | 45.1s | 246% | 2.46 / 12 | 21 | 82.5 MiB |
+
+`sort` and `group` ignored `--threads` entirely: the tricorder `--trace`
+`n_threads` column stayed at **1** for the whole run, so the flag created no
+threads at all. `OpenedInput::open` took no thread count, so both inputs were
+decoded on the single main thread.
+
+#### After round 1 (concurrent per-input readers)
+
+`OpenedInput::open_pair` now gives each input its own read-ahead thread and a
+share of the `--threads` BGZF budget. Same host and corpus, interleaved arms with
+the page cache warmed identically before every run (minimum of 3 reps; the
+outliers are all slower, i.e. contention):
+
+| mode | baseline | round 1 | speedup |
+| --- | --- | --- | --- |
+| `--command sort` | 23.44s | 8.93s | 2.6x |
+| `--command group` | 24.36s | 9.92s | 2.5x |
+
+`mean_load` rises 98% → 370% and peak threads 1 → 13.
+
+**The win is from overlap, not from `--threads`.** Thread scaling is flat —
+`-t 1` 8.64s, `-t 2` 8.47s, `-t 4` 8.97s, `-t 8` 8.89s — because the single
+comparison thread is now the critical path. At `-t 1`: wall 8.67s, cpu 24.65s
+(2.84 cores); if the compare thread is saturated it accounts for 8.67s and the
+two readers share the remaining 15.98s, i.e. ~8.0s each. Per-file decode (~8.0s)
+and comparison (~8.7s) are balanced, with comparison the marginally longer leg,
+so adding BGZF workers cannot help until the comparison thread does less work.
+
+For reference, `fgumi sort` over the same data at `--threads 8` is 8.82s, so
+`compare --command sort` went from 2.7x slower than the sort it validates to
+roughly par (8.93s vs 8.82s) — close but not yet strictly faster, which is what
+issue #686 asks for. Closing it requires cutting comparison-thread work
+(`content_key_exact`'s per-record allocation in `RunCanceller::observe`), after
+which the already-wired BGZF parallelism should begin to matter. Sampling attributes ~55%
+of that single thread to `libdeflate_deflate_decompress_ex` and ~6% to
+`fgumi_bgzf::reader::verify_decompression` (the per-block CRC32), i.e. ~61% to
+BGZF decode. `content` reaches only 2.46 cores and additionally traverses each
+input **twice**: `bams.rs` runs `verify_records_in_order` over both paths before
+`positional_compare` reopens and streams them again — four full traversals for a
+comparison needing two. `sort_verify` already avoids this via its `OrderChecked`
+adapter, which folds the order check into the comparison read.
+
 ### samtools sort orders
 `samtools sort` supports `--template-coordinate` for template-coordinate sorting. When benchmarking sort orders:
 - Coordinate: `samtools sort -@ 4 -m 50M input.bam -o output.bam`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,56 +332,49 @@ on it. In the `compare bams` work, the sampling profile and `tricorder` agreed
 that BGZF decode dominates (~61% self time; `mean_load=98%`), which is what made
 the conclusion trustworthy — not the profile alone.
 
-### `fgumi compare bams` baseline (recorded 2026-08-01, issue #686)
+### `fgumi compare bams` performance (issue #686, 2026-08-01)
 
-M2 Max (12 core), 20.1M records/file, ~2 GB BAMs, page-cached, `--threads 8`:
+Baseline on M2 Max (12 core), 20.1M records/file, ~2 GB BAMs, page-cached,
+`--threads 8`:
 
-| mode | wall | cpu | mean_load | cores busy | peak OS threads | max_rss |
-| --- | --- | --- | --- | --- | --- | --- |
-| `--command sort` (coordinate) | 23.7s | 23.2s | 98% | 0.98 / 12 | **1** | 20.3 MiB |
-| `--command group` | 24.7s | 24.3s | 98% | 0.98 / 12 | **1** | 21.2 MiB |
-| `--command simplex` (content) | 18.3s | 45.1s | 246% | 2.46 / 12 | 21 | 82.5 MiB |
+| mode | wall | cpu | mean_load | cores busy | peak OS threads |
+| --- | --- | --- | --- | --- | --- |
+| `--command sort` (coordinate) | 23.7s | 23.2s | 98% | 0.98 / 12 | **1** |
+| `--command group` | 24.7s | 24.3s | 98% | 0.98 / 12 | **1** |
+| `--command simplex` (content) | 18.3s | 45.1s | 246% | 2.46 / 12 | 21 |
 
-`sort` and `group` ignored `--threads` entirely: the tricorder `--trace`
+`sort` and `group` ignored `--threads` entirely — the tricorder `--trace`
 `n_threads` column stayed at **1** for the whole run, so the flag created no
-threads at all. `OpenedInput::open` took no thread count, so both inputs were
-decoded on the single main thread.
+threads at all. Sampling put ~55% of that single thread in
+`libdeflate_deflate_decompress_ex` and ~6% in
+`fgumi_bgzf::reader::verify_decompression` (the per-block CRC32): ~61% in BGZF
+decode, serialized. `content` reached only 2.46 cores and additionally traversed
+each input **twice**, because `verify_records_in_order` ran over both paths before
+`positional_compare` reopened and streamed them again.
 
-#### After round 1 (concurrent per-input readers)
+After the work on #686:
 
-`OpenedInput::open_pair` now gives each input its own read-ahead thread and a
-share of the `--threads` BGZF budget. Same host and corpus, interleaved arms with
-the page cache warmed identically before every run (minimum of 3 reps; the
-outliers are all slower, i.e. contention):
-
-| mode | baseline | round 1 | speedup |
+| mode | before | after | note |
 | --- | --- | --- | --- |
-| `--command sort` | 23.44s | 8.93s | 2.6x |
-| `--command group` | 24.36s | 9.92s | 2.5x |
+| `--command sort` `-t 8` | 23.44s | **4.14s** | 5.7x; scales `-t 1` 8.92s → `-t 4` 5.58s → `-t 8` 4.14s |
+| `--command group` `-t 8` | 24.36s | ~10s | reader concurrency only; its engine was not otherwise changed |
+| `--command simplex` (content) | 47.1 CPU-s | **27.4 CPU-s** | -42% CPU |
 
-`mean_load` rises 98% → 370% and peak threads 1 → 13.
+`compare --command sort` is now 2.0x *faster* than the `fgumi sort` it validates
+(4.14s vs 8.20s), having started 2.7x slower.
 
-**The win is from overlap, not from `--threads`.** Thread scaling is flat —
-`-t 1` 8.64s, `-t 2` 8.47s, `-t 4` 8.97s, `-t 8` 8.89s — because the single
-comparison thread is now the critical path. At `-t 1`: wall 8.67s, cpu 24.65s
-(2.84 cores); if the compare thread is saturated it accounts for 8.67s and the
-two readers share the remaining 15.98s, i.e. ~8.0s each. Per-file decode (~8.0s)
-and comparison (~8.7s) are balanced, with comparison the marginally longer leg,
-so adding BGZF workers cannot help until the comparison thread does less work.
+Two findings worth keeping:
 
-For reference, `fgumi sort` over the same data at `--threads 8` is 8.82s, so
-`compare --command sort` went from 2.7x slower than the sort it validates to
-roughly par (8.93s vs 8.82s) — close but not yet strictly faster, which is what
-issue #686 asks for. Closing it requires cutting comparison-thread work
-(`content_key_exact`'s per-record allocation in `RunCanceller::observe`), after
-which the already-wired BGZF parallelism should begin to matter. Sampling attributes ~55%
-of that single thread to `libdeflate_deflate_decompress_ex` and ~6% to
-`fgumi_bgzf::reader::verify_decompression` (the per-block CRC32), i.e. ~61% to
-BGZF decode. `content` reaches only 2.46 cores and additionally traverses each
-input **twice**: `bams.rs` runs `verify_records_in_order` over both paths before
-`positional_compare` reopens and streams them again — four full traversals for a
-comparison needing two. `sort_verify` already avoids this via its `OrderChecked`
-adapter, which folds the order check into the comparison read.
+- **Report content-mode results in CPU-seconds, not wall.** This host's wall time
+  is unreliable under interactive load — identical `-t 8` runs measured 3.56s and
+  16.56s — while total CPU stayed within 24–27s across the same sweep. Total CPU is
+  the metric the content conclusions rest on.
+- **Parallel BGZF decode costs ~40% more total CPU** than single-threaded decode
+  for the same work (19.3 CPU-s at `-t 1` vs ~27 CPU-s at `-t 4`+), spent in
+  `crossbeam_channel::recv` and thread parking. It buys wall-clock on an idle host
+  and costs throughput on a busy one. Raising the read-ahead batch from 256 to 4096
+  records did **not** reduce it (26.5 vs 27.0 CPU-s) but tripled peak RSS, so that
+  time is the consumer waiting on decode, not per-handoff overhead.
 
 ### samtools sort orders
 `samtools sort` supports `--template-coordinate` for template-coordinate sorting. When benchmarking sort orders:

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -67,6 +67,9 @@ pub(crate) mod zspill_stream;
 /// `memory-debug` feature is enabled.
 #[cfg(feature = "memory-debug")]
 pub use memory_probe::print_mi_stats;
+/// Background read-ahead record reader, re-exported for `fgumi compare bams`,
+/// which reads two inputs concurrently and needs each decode off the main thread.
+pub use read_ahead::RawReadAheadReader;
 
 /// Buffer size for `BufReader` during merge phase.
 const MERGE_BUFFER_SIZE: usize = 64 * 1024;

--- a/crates/fgumi-sort/src/read_ahead.rs
+++ b/crates/fgumi-sort/src/read_ahead.rs
@@ -40,8 +40,7 @@ const CHANNEL_BUFFER_SIZE: usize = 16;
 
 /// Background reader that reads raw BAM bytes ahead while main thread processes.
 ///
-/// This is similar to [`ReadAheadReader`] but yields [`RawRecord`] (raw bytes)
-/// instead of `noodles::bam::Record`. This enables:
+/// Yields [`RawRecord`] (raw bytes) instead of `noodles::bam::Record`. This enables:
 /// - Zero-copy field extraction using fixed byte offsets
 /// - Direct writes to output without re-encoding
 /// - No dependency on noodles' internal Record representation
@@ -61,6 +60,15 @@ pub struct RawReadAheadReader {
     /// The background thread stores its error here before sending the EOF sentinel,
     /// so callers can retrieve it via `take_error()` after iteration.
     error_slot: std::sync::Arc<std::sync::Mutex<Option<std::io::Error>>>,
+    /// Set once the reader thread's EOF sentinel has been received.
+    ///
+    /// Distinguishes the two ways `recv()` stops yielding records. The reader
+    /// thread sends the sentinel on every exit path it controls — clean EOF and
+    /// read error alike — so a sender dropped *without* one means the thread died
+    /// (a panic), leaving the stream truncated at an arbitrary record. Without
+    /// this flag both collapse to `None`, and a caller that trusts `take_error()`
+    /// reads a partial input as the whole thing.
+    saw_eof: bool,
 }
 
 impl RawReadAheadReader {
@@ -108,6 +116,7 @@ impl RawReadAheadReader {
             current_batch: Vec::new(),
             batch_index: 0,
             error_slot,
+            saw_eof: false,
         }
     }
 
@@ -172,9 +181,30 @@ impl RawReadAheadReader {
         self.error_slot.lock().ok()?.take()
     }
 
+    /// Park an error reporting that the reader thread stopped without reaching EOF.
+    ///
+    /// A real read error is stored by the reader thread itself before it sends the
+    /// sentinel, so an occupied slot always describes the underlying failure more
+    /// precisely than this does and is left alone.
+    fn park_reader_died_error(&self) {
+        if let Ok(mut slot) = self.error_slot.lock()
+            && slot.is_none()
+        {
+            *slot = Some(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "read-ahead reader thread stopped before the end of the input; \
+                 the records read so far are only part of it",
+            ));
+        }
+    }
+
     /// Get the next raw record from the read-ahead buffer.
     ///
     /// Returns `Some(record)` if a record is available, `None` on EOF or error.
+    ///
+    /// A `None` from a stream that never delivered its EOF sentinel parks an error
+    /// for [`take_error`](Self::take_error), so a caller cannot mistake a dead
+    /// reader thread for the end of the input.
     #[inline]
     #[must_use]
     pub fn next_record(&mut self) -> Option<RawRecord> {
@@ -193,7 +223,20 @@ impl RawReadAheadReader {
                 self.batch_index = 1; // We'll return index 0
                 Some(std::mem::take(&mut self.current_batch[0]))
             }
-            Ok(_) | Err(_) => None, // Empty batch = EOF, or channel closed
+            // Empty batch: the reader thread's EOF sentinel, sent on both its clean
+            // and its failing exit path.
+            Ok(_) => {
+                self.saw_eof = true;
+                None
+            }
+            // Channel closed. After the sentinel that is just a second poll of an
+            // exhausted stream; before it, the reader thread died mid-input.
+            Err(_) => {
+                if !self.saw_eof {
+                    self.park_reader_died_error();
+                }
+                None
+            }
         }
     }
 }
@@ -921,6 +964,76 @@ mod tests {
         assert_eq!(borrowed.len(), num, "read-ahead should yield exactly {num} records");
         assert_eq!(borrowed, owned, "borrowed and owned read-ahead iteration must agree");
         assert!(borrowed_source.take_error().is_none(), "clean EOF must not report an error");
+    }
+
+    /// A sender dropped without the EOF sentinel is a dead reader thread, not the
+    /// end of the input, and must not read as a clean EOF.
+    ///
+    /// The reader thread sends the sentinel on both exit paths it controls, so the
+    /// only way the channel closes without one is a panic — after which the batches
+    /// already sent are an arbitrary prefix of the input. `take_error()` returning
+    /// `None` there would let `CheckedRecords` report clean EOF, and a comparison
+    /// would call two inputs identical having read only part of one.
+    ///
+    /// The channel is driven directly rather than through a panicking reader: the
+    /// state under test is the receiver's, and a real panic would only add noise to
+    /// the test output.
+    #[test]
+    fn test_read_ahead_reports_a_reader_thread_that_died_before_eof() {
+        let (tx, rx) = bounded::<Vec<RawRecord>>(4);
+        tx.send(vec![raw_record_from(&[1u8; 8])]).expect("send one batch");
+        drop(tx); // The thread died here: no EOF sentinel follows.
+
+        let mut reader = RawReadAheadReader {
+            receiver: Some(rx),
+            handle: None,
+            current_batch: Vec::new(),
+            batch_index: 0,
+            error_slot: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            saw_eof: false,
+        };
+
+        let seen: Vec<RawRecord> = std::iter::from_fn(|| reader.next()).collect();
+
+        assert_eq!(seen.len(), 1, "the batch already sent must still be yielded");
+        let err = reader.take_error().expect("a disconnect before EOF must park an error");
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::UnexpectedEof,
+            "a truncated stream is an unexpected EOF, got: {err}"
+        );
+    }
+
+    /// The sentinel ends the stream cleanly, and polling an already-ended stream
+    /// again must not manufacture the error above.
+    ///
+    /// Iterators are polled past their end routinely — `Iterator::count` and
+    /// `for` both do — and the channel is closed by then, so the disconnect arm
+    /// has to tell "closed after the sentinel" from "closed instead of it".
+    #[test]
+    fn test_read_ahead_polled_past_the_eof_sentinel_reports_no_error() {
+        let (tx, rx) = bounded::<Vec<RawRecord>>(4);
+        tx.send(vec![raw_record_from(&[1u8; 8])]).expect("send one batch");
+        tx.send(Vec::new()).expect("send the EOF sentinel");
+        drop(tx);
+
+        let mut reader = RawReadAheadReader {
+            receiver: Some(rx),
+            handle: None,
+            current_batch: Vec::new(),
+            batch_index: 0,
+            error_slot: std::sync::Arc::new(std::sync::Mutex::new(None)),
+            saw_eof: false,
+        };
+
+        let seen: Vec<RawRecord> = std::iter::from_fn(|| reader.next()).collect();
+        assert_eq!(seen.len(), 1, "one record precedes the sentinel");
+        assert!(reader.next().is_none(), "an ended stream keeps returning None");
+
+        assert!(
+            reader.take_error().is_none(),
+            "a stream that delivered its sentinel ended cleanly, however often it is polled"
+        );
     }
 
     #[test]

--- a/crates/fgumi-sort/src/verify.rs
+++ b/crates/fgumi-sort/src/verify.rs
@@ -5,9 +5,8 @@
 //! the location of the first violation (if any).
 
 use anyhow::Result;
-use std::io::Read;
 
-use crate::reader::RawBamRecordReader;
+use fgumi_raw_bam::RawRecord;
 
 /// Summary of a sort-order verification pass: `(total_records, violations, first_violation)`.
 ///
@@ -15,27 +14,37 @@ use crate::reader::RawBamRecordReader;
 /// observed and `None` otherwise.
 pub type VerifySummary = (u64, u64, Option<(u64, String)>);
 
-/// Iterates the records read by `raw_reader` and verifies that consecutive
+/// Iterates the records read by `records` and verifies that consecutive
 /// extracted keys do not violate the sort invariant.
 ///
 /// `extract_key` produces a sort key from each record's raw bytes. `is_violation`
 /// returns `true` when the *current* key violates ordering relative to the
 /// *previous* key (typically `|cur, prev| cur < prev`).
 ///
+/// Takes any stream of `io::Result<RawRecord>` rather than a concrete
+/// [`RawBamRecordReader`](crate::reader::RawBamRecordReader) so callers can supply
+/// a multithreaded or read-ahead record source. The `Result` item type is
+/// deliberate: a read failure must stay distinguishable from end-of-stream, since
+/// treating a truncated stream as a clean EOF would report a corrupt file as
+/// correctly sorted.
+///
 /// # Errors
 ///
 /// Returns any I/O error from the underlying record stream.
-pub fn verify_sort_order<R: Read, K>(
-    raw_reader: RawBamRecordReader<R>,
+pub fn verify_sort_order<I, K>(
+    records: I,
     extract_key: impl Fn(&[u8]) -> K,
     is_violation: impl Fn(&K, &K) -> bool,
-) -> Result<VerifySummary> {
+) -> Result<VerifySummary>
+where
+    I: IntoIterator<Item = std::io::Result<RawRecord>>,
+{
     let mut total_records: u64 = 0;
     let mut violations: u64 = 0;
     let mut first_violation: Option<(u64, String)> = None;
     let mut prev_key: Option<K> = None;
 
-    for result in raw_reader {
+    for result in records {
         let record_bytes = result?;
         total_records += 1;
         let bam: &[u8] = &record_bytes;

--- a/src/lib/commands/compare/bams.rs
+++ b/src/lib/commands/compare/bams.rs
@@ -689,17 +689,19 @@ impl Command for CompareBams {
         // (`Grouping` routes through the streaming molecule-join engine, which matches
         // molecules by MI-invariant canonical id — the lexicographically smallest read name
         // in each molecule — rather than by position, so it is order-INDEPENDENT ACROSS
-        // molecules and never needs `verify_records_in_order`'s stream-level check. That is
+        // molecules and never needs the stream-level order check. That is
         // not the same as "no validation needed", though: `molecule_runs` (see
         // `super::molecule`) enforces its own precondition — that each molecule's own
         // records are consecutive, i.e. same-MI-consecutive/grouped input — and returns an
         // `Err` if a base MI's run is found non-contiguous, rather than silently trusting it).
-        if let Some(order) = declared_order
-            && matches!(mode, CompareMode::Content)
-        {
-            super::engines::sort_verify::verify_records_in_order(&self.bam1, order)?;
-            super::engines::sort_verify::verify_records_in_order(&self.bam2, order)?;
-        }
+        // The check itself is folded into `positional_compare`'s own record pass
+        // (see its `verify_order` parameter) rather than run here as two dedicated
+        // traversals. Verifying up front cost a full read of each input *before*
+        // the comparison read them again — four traversals for a job needing two —
+        // and bought nothing: the comparison already drains both inputs to
+        // completion, so it sees every record the standalone pass would have, and
+        // reports the identical diagnostic.
+        let verify_order = declared_order.filter(|_| matches!(mode, CompareMode::Content));
 
         // In `--quiet` mode only the exit code communicates the result, so suppress this
         // command's own informational stderr logging and timer (matching `compare metrics`).
@@ -755,7 +757,7 @@ impl Command for CompareBams {
             CompareMode::Content => {
                 drop(input1);
                 drop(input2);
-                self.execute_content(predicate)?
+                self.execute_content(predicate, verify_order)?
             }
             CompareMode::Grouping => self.execute_grouping(input1, input2)?,
         };
@@ -804,7 +806,14 @@ impl CompareBams {
     /// [`PositionalOutcome`](super::engines::positional::PositionalOutcome) — this
     /// report now shows record counts, a content-diff count, and (if pairing
     /// desynced) the first `RecordKey` mismatch index instead.
-    fn execute_content(&self, predicate: ContentPredicate) -> Result<u64> {
+    /// `verify_order` carries the sort order the records must actually honor, or
+    /// `None` for genuinely orderless input. It is checked inside the comparison's
+    /// own pass rather than by re-reading both inputs first (see `execute`).
+    fn execute_content(
+        &self,
+        predicate: ContentPredicate,
+        verify_order: Option<fgumi_sort::SortOrder>,
+    ) -> Result<u64> {
         if !self.quiet {
             info!(
                 "Starting content comparison with {} threads, batch size {}",
@@ -819,6 +828,7 @@ impl CompareBams {
             self.batch_size,
             self.max_diffs,
             predicate,
+            verify_order,
         )?;
 
         let is_equal = outcome.is_match();

--- a/src/lib/commands/compare/bams.rs
+++ b/src/lib/commands/compare/bams.rs
@@ -20,8 +20,8 @@ use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 use crossbeam_channel::{Receiver, bounded};
 use fgumi_bam_io::{RawBamReaderAuto, create_raw_bam_reader};
+use fgumi_raw_bam::RawRecord;
 use fgumi_raw_bam::fields as raw_fields;
-use fgumi_raw_bam::{RawRecord, find_int_tag, find_string_tag};
 use log::info;
 use noodles::sam::Header;
 use std::path::PathBuf;
@@ -516,10 +516,18 @@ impl std::fmt::Display for MiKey {
 /// yields `None`, matching the "missing MI" treatment used by the caller.
 pub(crate) fn get_mi_tag_raw(raw: &RawRecord) -> Option<MiKey> {
     let aux = raw_fields::aux_data_slice(raw.as_ref());
-    if let Some(v) = find_int_tag(aux, SamTag::MI) {
-        return Some(MiKey::Int(v));
-    }
-    let bytes = find_string_tag(aux, SamTag::MI)?;
+    // One scan of the aux data, not two. Probing `find_int_tag` and then falling
+    // back to `find_string_tag` walked every tag twice for the `MI:Z:` form that
+    // `fgumi group` actually writes, and `MI` is appended late so each walk covers
+    // nearly the whole tag block. This is per record on the grouping engine's
+    // critical path.
+    let bytes = match fgumi_raw_bam::RawTagsView::new(aux).get(SamTag::MI)? {
+        fgumi_raw_bam::TagValue::Int(v) => return Some(MiKey::Int(v)),
+        fgumi_raw_bam::TagValue::String(bytes) => bytes,
+        // Any other aux type is not a molecule id; treated as absent, exactly as
+        // the previous int-then-string probe did.
+        _ => return None,
+    };
     let s = std::str::from_utf8(bytes).ok()?;
     if let Some((base_str, strand_str)) = s.rsplit_once('/') {
         let base = base_str.parse::<i64>().ok()?;

--- a/src/lib/commands/compare/bams.rs
+++ b/src/lib/commands/compare/bams.rs
@@ -633,8 +633,13 @@ impl Command for CompareBams {
         // reopening the paths, so `--command sort` and `--command group` accept an
         // input that can only be opened once (a FIFO, a process substitution). See
         // `engines::OpenedInput`.
-        let input1 = OpenedInput::open(&self.bam1)?;
-        let input2 = OpenedInput::open(&self.bam2)?;
+        // `--threads` reaches both inputs' BGZF decoders, and each input reads
+        // ahead on its own thread, so the two decodes overlap each other and the
+        // comparison. Previously both were decoded inline on this thread and the
+        // flag did nothing for `sort`/`grouping` (issue #686). `content` mode has
+        // always passed `threads` per input this way (`start_raw_batch_reader`),
+        // so the two paths now agree on what the flag means.
+        let (input1, input2) = OpenedInput::open_pair(&self.bam1, &self.bam2, self.threads)?;
         let declared_order = require_compatible_headers(&input1.header, &input2.header)
             .context("input BAM headers are incompatible")?;
 

--- a/src/lib/commands/compare/bams.rs
+++ b/src/lib/commands/compare/bams.rs
@@ -750,10 +750,11 @@ impl Command for CompareBams {
         };
 
         let total_records = match mode {
-            // Content mode makes two passes over each input — the order verification
-            // already done above and then the record comparison itself — so it cannot
-            // stream a one-shot input and reopens by path. Releasing the streams here
-            // keeps it from holding a pipe open for a read it will never make.
+            // Content mode reopens both inputs by path for its batched, double-
+            // buffered readers, so the streams opened here for the header check are
+            // released rather than held open for a read that will never come. (The
+            // order verification that once made this a genuine two-pass mode is now
+            // folded into the comparison pass itself.)
             CompareMode::Content => {
                 drop(input1);
                 drop(input2);

--- a/src/lib/commands/compare/bams.rs
+++ b/src/lib/commands/compare/bams.rs
@@ -709,7 +709,11 @@ impl Command for CompareBams {
         // and bought nothing: the comparison already drains both inputs to
         // completion, so it sees every record the standalone pass would have, and
         // reports the identical diagnostic.
-        let verify_order = declared_order.filter(|_| matches!(mode, CompareMode::Content));
+        // `declared_order` is `None` for genuinely orderless input (extract/fastq/
+        // zipper output), in which case there is nothing to verify. No mode filter
+        // is applied here: this value is consumed only by the `Content` arm below,
+        // so a filter on the mode could never remove anything at the point of use.
+        let verify_order = declared_order;
 
         // In `--quiet` mode only the exit code communicates the result, so suppress this
         // command's own informational stderr logging and timer (matching `compare metrics`).
@@ -1249,6 +1253,24 @@ mod tests {
     #[test]
     fn get_mi_tag_raw_rejects_unknown_strand_suffix() {
         let rec = raw_record_with_aux(&aux_mi_string(b"5/C"));
+        assert_eq!(get_mi_tag_raw(&rec), None);
+    }
+
+    /// An `MI` tag of any other aux type is not a molecule id and is treated as
+    /// absent — the same answer the previous int-then-string probe gave, now that a
+    /// single scan returns whatever type is actually there. Reading such a value as
+    /// a molecule id would silently join unrelated reads into one molecule.
+    #[rstest]
+    #[case::float(b'f', (1.5f32).to_le_bytes().to_vec())]
+    #[case::char(b'A', vec![b'x'])]
+    #[case::int_array(b'B', vec![b'i', 1, 0, 0, 0, 7, 0, 0, 0])]
+    fn get_mi_tag_raw_treats_a_non_id_aux_type_as_absent(
+        #[case] type_code: u8,
+        #[case] payload: Vec<u8>,
+    ) {
+        let mut aux = vec![b'M', b'I', type_code];
+        aux.extend_from_slice(&payload);
+        let rec = raw_record_with_aux(&aux);
         assert_eq!(get_mi_tag_raw(&rec), None);
     }
 

--- a/src/lib/commands/compare/engines/mod.rs
+++ b/src/lib/commands/compare/engines/mod.rs
@@ -21,8 +21,70 @@ pub mod sort_verify;
 
 use std::path::{Path, PathBuf};
 
-use fgumi_sort::OwnedRawBamRecordReader;
+use fgumi_raw_bam::RawRecord;
+use fgumi_sort::RawReadAheadReader;
 use noodles::sam::Header;
+
+/// A record stream that reports read failures as `Err`, not as end-of-stream.
+///
+/// [`RawReadAheadReader`] decodes on a background thread and therefore cannot
+/// return an `io::Error` from `Iterator::next`: it ends iteration and parks the
+/// error in a slot for the consumer to collect via
+/// [`RawReadAheadReader::take_error`] *after* the loop. That convention is a
+/// hazard in a comparison oracle. A truncated or CRC-corrupt BAM would read as a
+/// **shorter** file rather than an error — reported as a record-count `DIFFER`,
+/// or, when both inputs are equally corrupt, as a false `IDENTICAL`. Both are
+/// silently wrong answers from the tool whose entire job is deciding whether two
+/// files agree.
+///
+/// Rather than requiring every engine loop to remember a trailing `take_error()`
+/// check, this adapter converts the error back into a final `Err` item at the
+/// point the stream ends. Engines keep using ordinary `rec?` propagation and are
+/// correct by construction; forgetting the check is not an available mistake.
+///
+/// A reader thread that dies mid-input parks an error of its own, so the same
+/// `take_error()` call also catches a stream that stopped without ever reaching
+/// its end — the failure `positional_compare` names "reader disconnected before
+/// EOF". Every way this stream can end short of the input is therefore an `Err`
+/// here, never a `None`.
+pub(crate) struct CheckedRecords {
+    inner: RawReadAheadReader,
+    /// Which input this stream reads, so a failure names the offending file.
+    ///
+    /// The background reader reports a truncated stream as a bare
+    /// `failed to fill whole buffer`, which in a two-input comparison does not say
+    /// *which* input failed. Carrying the path lets the error identify it, matching
+    /// the diagnostics the inline reader used to produce.
+    label: String,
+    /// Set once the inner iterator is exhausted, so a collected error is yielded
+    /// exactly once and the stream stays fused afterwards.
+    finished: bool,
+}
+
+impl CheckedRecords {
+    fn new(inner: RawReadAheadReader, label: String) -> Self {
+        Self { inner, label, finished: false }
+    }
+}
+
+impl Iterator for CheckedRecords {
+    type Item = std::io::Result<RawRecord>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.finished {
+            return None;
+        }
+        if let Some(record) = self.inner.next() {
+            return Some(Ok(record));
+        }
+        self.finished = true;
+        // End of stream: a parked error means the stream did not end cleanly, so
+        // surface it instead of reporting EOF, naming the input it came from.
+        self.inner.take_error().map(|e| {
+            Err(std::io::Error::new(e.kind(), format!("reading records from {}: {e}", self.label)))
+        })
+    }
+}
 
 /// One input, opened exactly once: its header and its records from the same stream.
 ///
@@ -37,35 +99,100 @@ use noodles::sam::Header;
 /// `path` is carried only to name the input in diagnostics; nothing reopens it.
 pub(crate) struct OpenedInput {
     /// Records, positioned just past the header.
-    pub(crate) reader: OwnedRawBamRecordReader,
+    pub(crate) reader: CheckedRecords,
     /// The header parsed off the front of `reader`'s stream.
     pub(crate) header: Header,
     /// What to call this input in messages.
     pub(crate) path: PathBuf,
 }
 
+/// Split a `--threads` budget between the two inputs a comparison reads.
+///
+/// `--threads` is one budget for the command, so giving the full count to *each*
+/// of two inputs would request twice the parallelism asked for: on a 12-core host
+/// `--threads 8` would spawn 16 BGZF workers plus two read-ahead threads and the
+/// main thread, paying context switches for no extra decode throughput.
+///
+/// `zipper` splits asymmetrically — 1 thread for its unmapped input, the full
+/// count for its mapped input — because its two inputs differ in cost. A
+/// comparison must fully decode both inputs and they are the same size, so an even
+/// split is the right shape here.
+///
+/// The per-input read-ahead thread is deliberately *not* charged against this
+/// budget: it overlaps I/O rather than decompressing, and `content` mode has
+/// always spawned one reader thread per input regardless of `--threads` (see
+/// `start_raw_batch_reader`).
+fn decompression_threads_per_input(threads: usize) -> usize {
+    (threads / 2).max(1)
+}
+
 impl OpenedInput {
-    /// Open `path` once, taking its header and its records from one stream.
+    /// Open `path` once with single-threaded BGZF decode.
     ///
-    /// [`fgumi_sort::open_raw_bam_record_reader_with_header`] parses the header
-    /// through a tee and replays the bytes it consumed, which is what lets one
-    /// stream serve both halves. Uncompressed SAM is sniffed and normalized there
-    /// too, so callers only ever see BAM records.
-    ///
-    /// This is the only opener the compare engines use — a second, private copy in
-    /// each engine is how the two came to disagree about how many opens an input
-    /// takes.
+    /// For callers that have no thread budget to spend. Records still arrive via a
+    /// read-ahead thread, so the decode overlaps the consumer's work.
     ///
     /// # Errors
     ///
     /// Returns an error if the input cannot be opened, is neither BAM nor SAM, or
     /// its header cannot be parsed.
     pub(crate) fn open(path: &Path) -> anyhow::Result<Self> {
+        Self::open_one(path, 1)
+    }
+
+    /// Open both inputs of a comparison, splitting `threads` between them.
+    ///
+    /// The single entry point for the two-input engines, so the budget split lives
+    /// in one place instead of being re-derived (or forgotten) per call site.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if either input cannot be opened, is neither BAM nor SAM,
+    /// or its header cannot be parsed.
+    pub(crate) fn open_pair(
+        bam1: &Path,
+        bam2: &Path,
+        threads: usize,
+    ) -> anyhow::Result<(Self, Self)> {
+        let per_input = decompression_threads_per_input(threads);
+        Ok((Self::open_one(bam1, per_input)?, Self::open_one(bam2, per_input)?))
+    }
+
+    /// Open `path` once with `decompression_threads` BGZF workers, reading ahead on
+    /// a background thread.
+    ///
+    /// `decompression_threads > 1` gives the multithreaded BGZF decoder `content`
+    /// mode has always used, and the read-ahead thread overlaps this input's decode
+    /// with the other input's and with the comparison itself. Before this, the
+    /// `sort` and `grouping` engines decoded both inputs inline on the single main
+    /// thread — `--threads` created no threads at all (issue #686), leaving BGZF
+    /// inflate plus its per-block CRC32 (~61% of the run) serialized on one core.
+    ///
+    /// Takes an already-divided per-input count, not the user's `--threads`; use
+    /// [`Self::open_pair`] for the two-input case so the split happens once.
+    ///
+    /// Still exactly one open per input, so a FIFO, a process substitution, or
+    /// stdin all still work: [`fgumi_bam_io::create_raw_bam_reader`] parses the
+    /// header off the front of the same stream it then yields records from, which
+    /// is the property this type exists to preserve (see the type docs).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the input cannot be opened, is neither BAM nor SAM, or
+    /// its header cannot be parsed.
+    fn open_one(path: &Path, decompression_threads: usize) -> anyhow::Result<Self> {
         use anyhow::Context as _;
 
-        let (reader, header) = fgumi_sort::open_raw_bam_record_reader_with_header(path)
+        let (reader, header) = fgumi_bam_io::create_raw_bam_reader(path, decompression_threads)
             .with_context(|| format!("opening raw BAM reader for {}", path.display()))?;
-        Ok(Self { reader, header, path: path.to_path_buf() })
+        Ok(Self {
+            reader: CheckedRecords::new(
+                RawReadAheadReader::new(reader),
+                path.display().to_string(),
+            ),
+            header,
+            path: path.to_path_buf(),
+        })
     }
 }
 
@@ -78,5 +205,110 @@ impl OpenedInput {
 pub(crate) fn push_diff(details: &mut Vec<String>, max_diffs: usize, msg: impl FnOnce() -> String) {
     if details.len() < max_diffs {
         details.push(msg());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    /// Write a small valid BAM so a test can then damage its bytes.
+    fn write_temp_bam(records: &[RawRecord]) -> tempfile::NamedTempFile {
+        use noodles::sam::alignment::io::Write as _;
+        let tmp = tempfile::NamedTempFile::new().expect("create temp BAM");
+        let header = Header::default();
+        let mut writer =
+            noodles::bam::io::Writer::new(std::fs::File::create(tmp.path()).expect("create BAM"));
+        writer.write_header(&header).expect("write header");
+        for record in records {
+            let buf = fgumi_raw_bam::raw_record_to_record_buf(record, &header)
+                .expect("raw_record_to_record_buf");
+            writer.write_alignment_record(&header, &buf).expect("write record");
+        }
+        writer.try_finish().expect("finish BAM");
+        tmp
+    }
+
+    /// A damaged input must surface as an `Err` from the record stream, never as a
+    /// clean end-of-stream.
+    ///
+    /// This is the invariant that makes the read-ahead reader safe to use in a
+    /// comparison oracle. [`RawReadAheadReader`] decodes on a background thread and
+    /// signals failure by ending iteration and parking the error for
+    /// `take_error()`, so a consumer that only watches for `None` sees a damaged
+    /// file as a *shorter* file. In `compare bams` that silently becomes a
+    /// record-count `DIFFER` — or a false `IDENTICAL` when both inputs are damaged
+    /// the same way — which is a wrong answer from the tool whose only job is
+    /// deciding whether two files agree. [`CheckedRecords`] converts the parked
+    /// error back into a final `Err`; this test is what keeps that true.
+    ///
+    /// Both damage modes are covered because they fail in different layers:
+    /// truncation starves the block reader mid-record, while flipped payload bytes
+    /// pass length checks and fail the per-block CRC32.
+    #[rstest]
+    #[case::truncated_mid_block(true)]
+    #[case::corrupt_payload_crc(false)]
+    fn damaged_input_yields_err_not_clean_eof(#[case] truncate: bool) {
+        let records: Vec<RawRecord> = (0..2000)
+            .map(|i| {
+                fgumi_raw_bam::SamBuilder::new()
+                    .read_name(format!("read{i:06}").as_bytes())
+                    .flags(fgumi_raw_bam::flags::FIRST_SEGMENT)
+                    .build()
+            })
+            .collect();
+        let tmp = write_temp_bam(&records);
+        let bytes = std::fs::read(tmp.path()).expect("read temp BAM");
+
+        let damaged = if truncate {
+            // Cut mid-BGZF-block: no EOF marker and an incomplete final block.
+            bytes[..bytes.len() * 3 / 5].to_vec()
+        } else {
+            // Flip bytes deep inside a compressed block: still parses as a block,
+            // cannot match its recorded CRC32.
+            let mut v = bytes.clone();
+            let off = v.len() / 2;
+            for b in &mut v[off..off + 64] {
+                *b ^= 0xFF;
+            }
+            v
+        };
+        let dmg = tempfile::NamedTempFile::new().expect("create damaged BAM");
+        std::fs::write(dmg.path(), &damaged).expect("write damaged BAM");
+
+        // Opening may already fail (the damage can land in the header region);
+        // that is an acceptable hard failure. What must never happen is a
+        // successful open whose stream then ends cleanly, hiding the damage.
+        let Ok(opened) = OpenedInput::open(dmg.path()) else {
+            return;
+        };
+        let mut saw_err = false;
+        for item in opened.reader {
+            if item.is_err() {
+                saw_err = true;
+                break;
+            }
+        }
+        assert!(
+            saw_err,
+            "damaged input must report an error, not a clean EOF (truncate={truncate}): a \
+             silently-short stream turns a corrupt file into a record-count DIFFER, or a false \
+             IDENTICAL when both sides are damaged alike"
+        );
+    }
+
+    /// `--threads` is one budget for the command, so two symmetric inputs split it
+    /// rather than each taking the full count (which would double the requested
+    /// parallelism). Always at least one worker per input.
+    #[rstest]
+    #[case::single(1, 1)]
+    #[case::two(2, 1)]
+    #[case::four(4, 2)]
+    #[case::eight(8, 4)]
+    #[case::odd_rounds_down(7, 3)]
+    #[case::zero_still_yields_one(0, 1)]
+    fn threads_are_split_between_the_two_inputs(#[case] threads: usize, #[case] expected: usize) {
+        assert_eq!(decompression_threads_per_input(threads), expected);
     }
 }

--- a/src/lib/commands/compare/engines/mod.rs
+++ b/src/lib/commands/compare/engines/mod.rs
@@ -122,7 +122,7 @@ pub(crate) struct OpenedInput {
 /// budget: it overlaps I/O rather than decompressing, and `content` mode has
 /// always spawned one reader thread per input regardless of `--threads` (see
 /// `start_raw_batch_reader`).
-fn decompression_threads_per_input(threads: usize) -> usize {
+pub(crate) fn decompression_threads_per_input(threads: usize) -> usize {
     (threads / 2).max(1)
 }
 

--- a/src/lib/commands/compare/engines/mod.rs
+++ b/src/lib/commands/compare/engines/mod.rs
@@ -246,30 +246,47 @@ mod tests {
     /// Both damage modes are covered because they fail in different layers:
     /// truncation starves the block reader mid-record, while flipped payload bytes
     /// pass length checks and fail the per-block CRC32.
+    ///
+    /// Both thread counts are covered because they propagate the failure by
+    /// different routes. At one thread the decoder runs inline on the read-ahead
+    /// thread; above one it runs on a `MultithreadedReader` worker pool, so the
+    /// error has to travel worker -> read-ahead error slot -> `CheckedRecords`.
+    /// Testing only the single-threaded path would leave the route this type
+    /// exists to protect — the one `open_pair` actually uses — unexercised.
     #[rstest]
     #[case::truncated_mid_block(true)]
     #[case::corrupt_payload_crc(false)]
-    fn damaged_input_yields_err_not_clean_eof(#[case] truncate: bool) {
-        let records: Vec<RawRecord> = (0..2000)
+    fn damaged_input_yields_err_not_clean_eof(
+        #[case] truncate: bool,
+        #[values(1, 4)] threads: usize,
+    ) {
+        // Enough records, each carrying a sequence, to span many BGZF blocks. The
+        // damage is then placed at 90% of the file, so it lands deep in the record
+        // region: damaging a small file instead puts it in the block holding the
+        // header, and the open fails before a single record is read — which would
+        // leave this test passing without ever reaching the type it is testing.
+        let records: Vec<RawRecord> = (0..20_000)
             .map(|i| {
                 fgumi_raw_bam::SamBuilder::new()
                     .read_name(format!("read{i:06}").as_bytes())
+                    .sequence(&[b'A'; 100])
+                    .qualities(&[30; 100])
                     .flags(fgumi_raw_bam::flags::FIRST_SEGMENT)
                     .build()
             })
             .collect();
         let tmp = write_temp_bam(&records);
         let bytes = std::fs::read(tmp.path()).expect("read temp BAM");
+        let offset = bytes.len() * 9 / 10;
 
         let damaged = if truncate {
             // Cut mid-BGZF-block: no EOF marker and an incomplete final block.
-            bytes[..bytes.len() * 3 / 5].to_vec()
+            bytes[..offset].to_vec()
         } else {
             // Flip bytes deep inside a compressed block: still parses as a block,
             // cannot match its recorded CRC32.
             let mut v = bytes.clone();
-            let off = v.len() / 2;
-            for b in &mut v[off..off + 64] {
+            for b in &mut v[offset..offset + 64] {
                 *b ^= 0xFF;
             }
             v
@@ -277,24 +294,31 @@ mod tests {
         let dmg = tempfile::NamedTempFile::new().expect("create damaged BAM");
         std::fs::write(dmg.path(), &damaged).expect("write damaged BAM");
 
-        // Opening may already fail (the damage can land in the header region);
-        // that is an acceptable hard failure. What must never happen is a
-        // successful open whose stream then ends cleanly, hiding the damage.
-        let Ok(opened) = OpenedInput::open(dmg.path()) else {
-            return;
-        };
+        // The open must succeed for this test to mean anything: the contract under
+        // test is what the *record stream* does with damage, so an open that fails
+        // first would leave it unexercised.
+        let (opened, _) = OpenedInput::open_pair(dmg.path(), dmg.path(), threads)
+            .expect("damage past the header must not prevent opening the input");
         let mut saw_err = false;
+        let mut error_message = String::new();
         for item in opened.reader {
-            if item.is_err() {
+            if let Err(e) = item {
                 saw_err = true;
+                error_message = e.to_string();
                 break;
             }
         }
         assert!(
             saw_err,
-            "damaged input must report an error, not a clean EOF (truncate={truncate}): a \
-             silently-short stream turns a corrupt file into a record-count DIFFER, or a false \
-             IDENTICAL when both sides are damaged alike"
+            "damaged input must report an error, not a clean EOF (truncate={truncate}, \
+             threads={threads}): a silently-short stream turns a corrupt file into a \
+             record-count DIFFER, or a false IDENTICAL when both sides are damaged alike"
+        );
+        assert!(
+            error_message.contains(&dmg.path().display().to_string()),
+            "the error must name the input that failed, since a two-input comparison \
+             cannot tell from `failed to fill whole buffer` alone which side broke: \
+             {error_message}"
         );
     }
 

--- a/src/lib/commands/compare/engines/positional.rs
+++ b/src/lib/commands/compare/engines/positional.rs
@@ -32,6 +32,7 @@ use fgumi_sort::SortOrder;
 use super::super::bams::{RawBatchMessage, start_raw_batch_reader};
 use super::super::record_key::record_keys_match;
 use super::content::{ContentPredicate, content_diffs};
+use super::decompression_threads_per_input;
 use super::header::{compare_headers, fold_header_diffs};
 use super::sort_verify::OrderCheck;
 
@@ -108,8 +109,13 @@ pub fn positional_compare(
 ) -> Result<PositionalOutcome> {
     let mut outcome = PositionalOutcome::default();
 
-    let (rx1, header1) = start_raw_batch_reader(bam1.to_path_buf(), threads, batch_size)?;
-    let (rx2, header2) = start_raw_batch_reader(bam2.to_path_buf(), threads, batch_size)?;
+    // Split the decompression budget across the two inputs rather than giving each
+    // the full count: `--threads 8` previously started 8 BGZF workers per reader,
+    // 16 in total, oversubscribing a smaller host for no extra decode throughput.
+    // The sort and grouping engines already share this convention.
+    let per_input = decompression_threads_per_input(threads);
+    let (rx1, header1) = start_raw_batch_reader(bam1.to_path_buf(), per_input, batch_size)?;
+    let (rx2, header2) = start_raw_batch_reader(bam2.to_path_buf(), per_input, batch_size)?;
 
     // Sort-order verification rides along with this pass rather than costing a
     // dedicated traversal of each input beforehand. Every record this function
@@ -248,6 +254,17 @@ pub fn positional_compare(
         if outcome.key_mismatch_at.is_none() {
             for (offset, (a, b)) in cmp_batch1.iter().zip(cmp_batch2.iter()).enumerate() {
                 let index = current_index + offset as u64;
+
+                // Byte-identical records need neither check. A `RecordKey` is a pure
+                // function of the record's bytes, so identical bytes give identical
+                // keys; and `content_diffs` opens with this very comparison, since
+                // byte equality implies content equality under every predicate. This
+                // is the common case — two files that agree — and skipping straight
+                // past it avoids extracting flags and walking both read names only to
+                // conclude they are the same.
+                if a.as_ref() == b.as_ref() {
+                    continue;
+                }
 
                 if !record_keys_match(a, b) {
                     outcome.key_mismatch_at = Some(index);

--- a/src/lib/commands/compare/engines/positional.rs
+++ b/src/lib/commands/compare/engines/positional.rs
@@ -27,10 +27,13 @@ use anyhow::{Result, bail};
 
 use fgumi_raw_bam::RawRecord;
 
+use fgumi_sort::SortOrder;
+
 use super::super::bams::{RawBatchMessage, start_raw_batch_reader};
 use super::super::record_key::record_keys_match;
 use super::content::{ContentPredicate, content_diffs};
 use super::header::{compare_headers, fold_header_diffs};
+use super::sort_verify::OrderCheck;
 
 /// Outcome of a [`positional_compare`] run.
 #[derive(Debug, Default, Clone)]
@@ -101,11 +104,19 @@ pub fn positional_compare(
     batch_size: usize,
     max_diffs: usize,
     pred: ContentPredicate,
+    verify_order: Option<SortOrder>,
 ) -> Result<PositionalOutcome> {
     let mut outcome = PositionalOutcome::default();
 
     let (rx1, header1) = start_raw_batch_reader(bam1.to_path_buf(), threads, batch_size)?;
     let (rx2, header2) = start_raw_batch_reader(bam2.to_path_buf(), threads, batch_size)?;
+
+    // Sort-order verification rides along with this pass rather than costing a
+    // dedicated traversal of each input beforehand. Every record this function
+    // pulls — including the ones drained after pairing stops — is fed through its
+    // file's checker, so the totals match a standalone pass exactly.
+    let mut order1 = verify_order.map(|order| OrderCheck::new(&header1, order));
+    let mut order2 = verify_order.map(|order| OrderCheck::new(&header2, order));
 
     fold_header_diffs(
         compare_headers(&header1, &header2),
@@ -125,17 +136,24 @@ pub fn positional_compare(
             match rx1.recv() {
                 Ok(RawBatchMessage::Batch(batch)) => {
                     outcome.bam1_count += batch.len() as u64;
+                    if let Some(check) = order1.as_mut() {
+                        for record in &batch {
+                            check.observe(record.as_ref());
+                        }
+                    }
                     pending_batch1 = Some(batch);
                 }
                 Ok(RawBatchMessage::Eof) => bam1_eof = true,
-                Ok(RawBatchMessage::Error(e)) => bail!("Error reading BAM1: {e}"),
+                Ok(RawBatchMessage::Error(e)) => {
+                    bail!("reading records from {}: {e}", bam1.display())
+                }
                 // A clean end-of-stream is always signalled by an explicit `Eof`
                 // message (see `start_raw_batch_reader`); a bare channel
                 // disconnect therefore means the reader thread died (e.g.
                 // panicked) or the stream was truncated without an `Eof`. Treat
                 // it as fatal rather than silently accepting a short read as a
                 // clean comparison.
-                Err(_) => bail!("BAM1 reader disconnected before EOF"),
+                Err(_) => bail!("{}: reader disconnected before EOF", bam1.display()),
             }
         }
 
@@ -143,13 +161,20 @@ pub fn positional_compare(
             match rx2.recv() {
                 Ok(RawBatchMessage::Batch(batch)) => {
                     outcome.bam2_count += batch.len() as u64;
+                    if let Some(check) = order2.as_mut() {
+                        for record in &batch {
+                            check.observe(record.as_ref());
+                        }
+                    }
                     pending_batch2 = Some(batch);
                 }
                 Ok(RawBatchMessage::Eof) => bam2_eof = true,
-                Ok(RawBatchMessage::Error(e)) => bail!("Error reading BAM2: {e}"),
+                Ok(RawBatchMessage::Error(e)) => {
+                    bail!("reading records from {}: {e}", bam2.display())
+                }
                 // See the BAM1 branch above: a disconnect without a prior `Eof`
                 // is a dead/truncated reader, not a clean end-of-stream.
-                Err(_) => bail!("BAM2 reader disconnected before EOF"),
+                Err(_) => bail!("{}: reader disconnected before EOF", bam2.display()),
             }
         }
 
@@ -172,10 +197,17 @@ pub fn positional_compare(
                         match rx1.recv() {
                             Ok(RawBatchMessage::Batch(batch)) => {
                                 outcome.bam1_count += batch.len() as u64;
+                                if let Some(check) = order1.as_mut() {
+                                    for record in &batch {
+                                        check.observe(record.as_ref());
+                                    }
+                                }
                             }
-                            Ok(RawBatchMessage::Error(e)) => bail!("Error reading BAM1: {e}"),
+                            Ok(RawBatchMessage::Error(e)) => {
+                                bail!("reading records from {}: {e}", bam1.display())
+                            }
                             Ok(RawBatchMessage::Eof) => break,
-                            Err(_) => bail!("BAM1 reader disconnected before EOF"),
+                            Err(_) => bail!("{}: reader disconnected before EOF", bam1.display()),
                         }
                     }
                 }
@@ -184,10 +216,17 @@ pub fn positional_compare(
                         match rx2.recv() {
                             Ok(RawBatchMessage::Batch(batch)) => {
                                 outcome.bam2_count += batch.len() as u64;
+                                if let Some(check) = order2.as_mut() {
+                                    for record in &batch {
+                                        check.observe(record.as_ref());
+                                    }
+                                }
                             }
-                            Ok(RawBatchMessage::Error(e)) => bail!("Error reading BAM2: {e}"),
+                            Ok(RawBatchMessage::Error(e)) => {
+                                bail!("reading records from {}: {e}", bam2.display())
+                            }
                             Ok(RawBatchMessage::Eof) => break,
-                            Err(_) => bail!("BAM2 reader disconnected before EOF"),
+                            Err(_) => bail!("{}: reader disconnected before EOF", bam2.display()),
                         }
                     }
                 }
@@ -240,6 +279,16 @@ pub fn positional_compare(
         if !remainder2.is_empty() {
             pending_batch2 = Some(remainder2.to_vec());
         }
+    }
+
+    // Both inputs have been read end to end, so the violation totals here equal
+    // what a dedicated pass over each file would report. bam1 is evaluated first
+    // to preserve which file is named when both are mis-sorted.
+    if let Some(check) = order1 {
+        check.into_result(bam1)?;
+    }
+    if let Some(check) = order2 {
+        check.into_result(bam2)?;
     }
 
     Ok(outcome)

--- a/src/lib/commands/compare/engines/positional.rs
+++ b/src/lib/commands/compare/engines/positional.rs
@@ -94,6 +94,14 @@ impl PositionalOutcome {
 /// (see `start_raw_batch_reader`); `max_diffs` caps the number of entries
 /// collected in `PositionalOutcome::diff_details`.
 ///
+/// `verify_order` names the sort order the records must actually honor, or `None`
+/// for genuinely orderless input. It is deliberately a required parameter rather
+/// than a defaulted one: this comparison pairs records purely by position, so an
+/// unverified order silently corrupts the pairing rather than surfacing as a diff.
+/// A convenience overload defaulting it to `None` would let a caller opt out of
+/// that check by omission, which is the failure this parameter exists to prevent —
+/// so callers state their intent explicitly, `None` included.
+///
 /// # Errors
 ///
 /// Returns an error if either BAM file cannot be opened, or if a read error

--- a/src/lib/commands/compare/engines/sort_verify.rs
+++ b/src/lib/commands/compare/engines/sort_verify.rs
@@ -427,6 +427,31 @@ where
         if from1.is_none() && from2.is_none() {
             break;
         }
+        // Byte-identical pair: cancel it here without building either record's
+        // canonical content key.
+        //
+        // Sound because the run comparison decides on the symmetric difference of
+        // the two sides' record multisets, and removing one element from each side
+        // *with the same key* leaves that symmetric difference unchanged — whatever
+        // else is pending. Byte equality implies content-key equality, and strictly
+        // so: `content_key_exact` excludes `bin`, width-normalizes integer tags, and
+        // sorts the tag multiset, so any two byte-identical records necessarily
+        // share a key. The converse does not hold, which is why this is only a fast
+        // path: content-equal records that differ in tag order, integer tag width,
+        // or `bin` fall through to the key path below and still cancel there.
+        //
+        // Worth the special case because it is the overwhelmingly common one — two
+        // files that agree, record for record — and `content_key_exact` is the
+        // dominant remaining cost on the critical path (~32%: a `Vec` per aux tag,
+        // a sort, a concatenation, and an `AHashMap` hash + insert, per record).
+        // Here a `memcmp` replaces all of it.
+        if let (Some(a), Some(b)) = (&from1, &from2)
+            && a.as_ref() == b.as_ref()
+        {
+            count1 += 1;
+            count2 += 1;
+            continue;
+        }
         if let Some(rec) = from1 {
             canceller.observe_bam1(rec.as_ref())?;
             count1 += 1;

--- a/src/lib/commands/compare/engines/sort_verify.rs
+++ b/src/lib/commands/compare/engines/sort_verify.rs
@@ -47,15 +47,15 @@ use anyhow::{Context, Result, anyhow, bail};
 
 use fgumi_raw_bam::{RawRecord, RawRecordView};
 use fgumi_sort::{
-    LibraryLookup, OwnedRawBamRecordReader, QuerynameComparator, RawQuerynameKey,
-    RawQuerynameLexKey, RawSortKey, SortContext, SortOrder, TemplateKey, cb_hasher,
-    extract_coordinate_key_inline, extract_template_key_inline, verify_sort_order,
+    LibraryLookup, QuerynameComparator, RawQuerynameKey, RawQuerynameLexKey, RawSortKey,
+    SortContext, SortOrder, TemplateKey, cb_hasher, extract_coordinate_key_inline,
+    extract_template_key_inline, verify_sort_order,
 };
 use noodles::sam::Header;
 
 use ahash::AHashMap;
 
-use super::OpenedInput;
+use super::{CheckedRecords, OpenedInput};
 use crate::sam::SamTag;
 
 use super::super::raw_compare::content_key_exact;
@@ -288,7 +288,7 @@ where
     ExtractKey: Fn(&[u8]) -> K,
     IsViolation: Fn(&K, &K) -> bool,
 {
-    reader: OwnedRawBamRecordReader,
+    reader: CheckedRecords,
     extract_key: &'a ExtractKey,
     tracker: OrderTracker<'a, K, IsViolation>,
 }
@@ -300,7 +300,7 @@ where
     IsViolation: Fn(&K, &K) -> bool,
 {
     fn new(
-        reader: OwnedRawBamRecordReader,
+        reader: CheckedRecords,
         extract_key: &'a ExtractKey,
         is_violation: &'a IsViolation,
     ) -> Self {
@@ -736,9 +736,9 @@ where
 {
     /// Record reader over the first input, already past its header. Carried rather
     /// than the path so the input is opened exactly once — see [`OpenedInput`].
-    reader1: OwnedRawBamRecordReader,
+    reader1: CheckedRecords,
     /// Record reader over the second input, already past its header.
-    reader2: OwnedRawBamRecordReader,
+    reader2: CheckedRecords,
     extract_key: ExtractKey,
     is_violation: IsViolation,
     same_core: SameCore,

--- a/src/lib/commands/compare/engines/sort_verify.rs
+++ b/src/lib/commands/compare/engines/sort_verify.rs
@@ -43,13 +43,13 @@
 use std::cmp::Ordering;
 use std::path::Path;
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Result, anyhow, bail};
 
 use fgumi_raw_bam::{RawRecord, RawRecordView};
 use fgumi_sort::{
     LibraryLookup, QuerynameComparator, RawQuerynameKey, RawQuerynameLexKey, RawSortKey,
     SortContext, SortOrder, TemplateKey, cb_hasher, extract_coordinate_key_inline,
-    extract_template_key_inline, verify_sort_order,
+    extract_template_key_inline,
 };
 use noodles::sam::Header;
 
@@ -874,8 +874,8 @@ pub(crate) fn sort_verify_compare_opened(
     let header_diffs = compare_headers(&header1, &header2);
 
     // IMPORTANT: The per-SortOrder extractor/comparator selection below must stay
-    // consistent with the matching arms in verify_records_in_order. Future changes
-    // to how an arm selects its key extractor or comparator must be applied to both sites.
+    // consistent with the matching arms in `OrderCheck::new`. Future changes to how an
+    // arm selects its key extractor or comparator must be applied to both sites.
     let mut outcome = match order {
         SortOrder::Coordinate => {
             let nref = header1.reference_sequences().len() as u32;
@@ -945,88 +945,122 @@ pub(crate) fn sort_verify_compare_opened(
     Ok(outcome)
 }
 
-/// Verify every record in `path` is non-decreasing under `order`'s comparator. Err names the
-/// first violating pair. Used as a universal precondition for order-dependent comparisons
-/// (`CompareBams::execute`'s content-mode gate: an `@HD`-declared order must not be trusted
-/// blindly — see `CompareMode::Content`'s doc comment).
+/// A per-file sort-order check folded into a comparison's own record pass, instead
+/// of costing a dedicated traversal of the file.
 ///
-/// This is a separate, fail-fast entry point from `sort_verify_compare`'s own per-file
-/// violation *counting* (`run_full_verify`'s [`OrderChecked`]/[`OrderTracker`] fold, part of
-/// the fuller `--command sort` report that also needs to keep going to compare run multisets
-/// even after finding violations). Both call sites route through the same underlying
-/// comparator machinery — the per-`SortOrder` key extractors
-/// (`extract_coordinate_key_inline`, `RawQuerynameKey`/`RawQuerynameLexKey::extract`,
-/// `extract_template_key_inline`) and their key comparisons (`<`, `TemplateKey::core_cmp`) —
-/// so no comparator logic is reimplemented here, only the per-order dispatch. This entry
-/// point calls [`verify_sort_order`] directly; the compare engine inlines that same
-/// per-record fold ([`OrderTracker::observe`]) so it can verify order within its single
-/// streaming pass.
+/// `content` mode used to answer this question by opening each input and reading it
+/// end to end *before* `positional_compare` streamed both files again — four full
+/// BAM traversals for a comparison that needs two. This type lets the comparison
+/// pass feed the records it is already decoding through the identical check.
 ///
-/// # Errors
+/// The violation *count* is why this accumulates rather than failing on the first
+/// bad record: the diagnostic reports how many records violated the order, which is
+/// only known once the whole file has been seen. `positional_compare` already
+/// drains both inputs to completion for its record counts, so the totals match a
+/// dedicated pass exactly, and evaluating bam1's result before bam2's preserves
+/// which file a mis-sorted pair names.
+/// Extracts a record's sort key and reports whether it regressed against the
+/// previous record, owning the previous key internally.
 ///
-/// Returns an error if `path` cannot be opened/read, or if any record violates `order`
-/// (naming the first violating record's 1-based position and read name).
-pub(crate) fn verify_records_in_order(path: &Path, order: SortOrder) -> Result<()> {
-    // One open, header and records from the same stream — see `OpenedInput::open`.
-    // The `path` field goes unused here: this entry point takes a single input and
-    // already has it, so there is nothing to disambiguate in its diagnostics.
-    let OpenedInput { reader, header, path: _ } = OpenedInput::open(path)
-        .with_context(|| format!("opening {} to verify sort order", path.display()))?;
+/// Boxed rather than generic so a comparison loop can hold one checker per input
+/// without the loop itself becoming generic over the four sort-key types.
+type OrderStep = Box<dyn FnMut(&[u8]) -> bool + Send>;
 
-    // IMPORTANT: The per-SortOrder extractor/comparator selection below must stay
-    // consistent with the matching arms in sort_verify_compare. Future changes
-    // to how an arm selects its key extractor or comparator must be applied to both sites.
-    let (_, violations, first_violation) = match order {
-        SortOrder::Coordinate => {
-            let nref = header.reference_sequences().len() as u32;
-            verify_sort_order(
-                reader,
-                |bam: &[u8]| extract_coordinate_key_inline(bam, nref),
-                |key: &u64, prev: &u64| key < prev,
-            )?
-        }
-        SortOrder::Queryname(QuerynameComparator::Lexicographic) => {
-            let ctx = SortContext::from_header(&header);
-            verify_sort_order(
-                reader,
-                move |bam: &[u8]| RawQuerynameLexKey::extract(bam, &ctx),
-                |key: &RawQuerynameLexKey, prev: &RawQuerynameLexKey| key < prev,
-            )?
-        }
-        SortOrder::Queryname(QuerynameComparator::Natural) => {
-            let ctx = SortContext::from_header(&header);
-            verify_sort_order(
-                reader,
-                move |bam: &[u8]| RawQuerynameKey::extract(bam, &ctx),
-                |key: &RawQuerynameKey, prev: &RawQuerynameKey| key < prev,
-            )?
-        }
-        SortOrder::TemplateCoordinate => {
-            let lib_lookup = LibraryLookup::from_header(&header);
-            let hasher = cb_hasher();
-            // Matches `fgumi sort`'s own `--verify` (crate::commands::sort::parse_cell_tag):
-            // template-coordinate always hashes the CB tag into the sort key when present.
-            let cell_tag = Some(SamTag::CB);
-            verify_sort_order(
-                reader,
-                move |bam: &[u8]| extract_template_key_inline(bam, &lib_lookup, cell_tag, &hasher),
-                |key: &TemplateKey, prev: &TemplateKey| key.core_cmp(prev) == Ordering::Less,
-            )?
-        }
-    };
+pub(crate) struct OrderCheck {
+    order: SortOrder,
+    step: OrderStep,
+    total: u64,
+    violations: u64,
+    first_violation: Option<(u64, String)>,
+}
 
-    if violations > 0 {
-        let (record_num, name) = first_violation
-            .expect("verify_sort_order must report a first_violation when violations > 0");
-        bail!(
-            "{}: {violations} record(s) violate the declared {order:?} sort order (first at \
-             record {record_num}, read name '{name}'); records must actually be in {order:?} \
-             order, not merely declare it, for order-dependent comparison",
-            path.display()
-        );
+impl OrderCheck {
+    /// Build a checker for `order`, taking whatever context that order's key
+    /// extractor needs (reference count, read-group library lookup) from `header`.
+    ///
+    /// IMPORTANT: the per-`SortOrder` extractor/comparator selection here must stay
+    /// consistent with the matching arms in `sort_verify_compare`.
+    pub(crate) fn new(header: &Header, order: SortOrder) -> Self {
+        let step: OrderStep = match order {
+            SortOrder::Coordinate => {
+                let nref = header.reference_sequences().len() as u32;
+                let mut prev: Option<u64> = None;
+                Box::new(move |bam: &[u8]| {
+                    let key = extract_coordinate_key_inline(bam, nref);
+                    let violated = prev.is_some_and(|p| key < p);
+                    prev = Some(key);
+                    violated
+                })
+            }
+            SortOrder::Queryname(QuerynameComparator::Lexicographic) => {
+                let ctx = SortContext::from_header(header);
+                let mut prev: Option<RawQuerynameLexKey> = None;
+                Box::new(move |bam: &[u8]| {
+                    let key = RawQuerynameLexKey::extract(bam, &ctx);
+                    let violated = prev.as_ref().is_some_and(|p| key < *p);
+                    prev = Some(key);
+                    violated
+                })
+            }
+            SortOrder::Queryname(QuerynameComparator::Natural) => {
+                let ctx = SortContext::from_header(header);
+                let mut prev: Option<RawQuerynameKey> = None;
+                Box::new(move |bam: &[u8]| {
+                    let key = RawQuerynameKey::extract(bam, &ctx);
+                    let violated = prev.as_ref().is_some_and(|p| key < *p);
+                    prev = Some(key);
+                    violated
+                })
+            }
+            SortOrder::TemplateCoordinate => {
+                let lib_lookup = LibraryLookup::from_header(header);
+                let hasher = cb_hasher();
+                let cell_tag = Some(SamTag::CB);
+                let mut prev: Option<TemplateKey> = None;
+                Box::new(move |bam: &[u8]| {
+                    let key = extract_template_key_inline(bam, &lib_lookup, cell_tag, &hasher);
+                    let violated = prev.as_ref().is_some_and(|p| key.core_cmp(p) == Ordering::Less);
+                    prev = Some(key);
+                    violated
+                })
+            }
+        };
+        Self { order, step, total: 0, violations: 0, first_violation: None }
     }
 
-    Ok(())
+    /// Observe one record, in file order.
+    pub(crate) fn observe(&mut self, bam: &[u8]) {
+        self.total += 1;
+        if (self.step)(bam) {
+            self.violations += 1;
+            if self.first_violation.is_none() {
+                let name = String::from_utf8_lossy(RawRecordView::new(bam).read_name()).to_string();
+                self.first_violation = Some((self.total, name));
+            }
+        }
+    }
+
+    /// Fail if any record violated the declared order.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error naming the violation count and the first violating record's
+    /// 1-based position and read name.
+    pub(crate) fn into_result(self, path: &Path) -> Result<()> {
+        if self.violations > 0 {
+            let (record_num, name) = self
+                .first_violation
+                .expect("a nonzero violation count must carry a first violation");
+            let (order, violations) = (self.order, self.violations);
+            bail!(
+                "{}: {violations} record(s) violate the declared {order:?} sort order (first at \
+                 record {record_num}, read name '{name}'); records must actually be in {order:?} \
+                 order, not merely declare it, for order-dependent comparison",
+                path.display()
+            );
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/lib/commands/compare/engines/sort_verify.rs
+++ b/src/lib/commands/compare/engines/sort_verify.rs
@@ -390,9 +390,12 @@ struct RunPairOutcome {
 }
 
 /// Compare the two files' records for the run identified by `key`, consuming both sides in
-/// lockstep and cancelling each record against its counterpart as it arrives (see
-/// [`RunCanceller`]). Never materializes the run, so an unmapped tail spanning the whole
-/// file costs memory proportional only to how far the two orderings diverge.
+/// lockstep. A pair that is byte-identical is cancelled here directly and never reaches
+/// [`RunCanceller`] — the common case, and the reason no content key is built for it.
+/// Everything else (pairs that differ, and records arriving out of step) goes to the
+/// canceller, which matches them by canonical content key as they arrive. Never
+/// materializes the run, so an unmapped tail spanning the whole file costs memory
+/// proportional only to how far the two orderings diverge.
 ///
 /// Cancellation is confined to one run, but note *why* that is not what keeps it sound: a
 /// record's run membership is a function of its content ([`content_key_exact`] covers the
@@ -529,7 +532,9 @@ impl RunResidual {
 /// Streaming multiset comparison of one equal-core-key run, in memory proportional to how
 /// far the two files' orderings diverge rather than to the run's length.
 ///
-/// Each arriving record is reduced to its canonical content key ([`content_key_exact`],
+/// Each record that reaches the canceller is reduced to its canonical content key
+/// (byte-identical pairs are cancelled by [`compare_run`] before this point — see its
+/// docs) ([`content_key_exact`],
 /// whose byte-equality is *exactly* `Exact` content-equality) and cancelled against the
 /// opposite side's pending set if a counterpart is waiting; otherwise it joins its own
 /// side's pending set. Two files listing a run's records in the same order therefore never
@@ -1443,5 +1448,120 @@ mod tests {
                 sorted_left == sorted_right
             );
         }
+    }
+
+    /// A header carrying a single reference sequence, so `ref_id = 0` records are
+    /// writable and `extract_coordinate_key_inline` sees a nonzero reference count.
+    fn single_reference_header(so: &str) -> Header {
+        use noodles::sam::header::record::value::map::ReferenceSequence;
+
+        let mut hd = Map::<HeaderRecord>::default();
+        hd.other_fields_mut().insert(hd_tag::SORT_ORDER, BString::from(so));
+        Header::builder()
+            .set_header(hd)
+            .add_reference_sequence(
+                BString::from("chr1"),
+                Map::<ReferenceSequence>::new(
+                    std::num::NonZeroUsize::new(100_000).expect("nonzero length"),
+                ),
+            )
+            .build()
+    }
+
+    /// [`OrderCheck`] must apply the comparator its [`SortOrder`] names, not merely
+    /// *a* comparator. The two queryname variants differ in nothing else, so picking
+    /// the wrong one silently accepts a file that violates the order it declares —
+    /// and content mode then pairs records positionally on that false assurance.
+    ///
+    /// Each queryname case is chosen so the *other* queryname comparator would
+    /// disagree with it: `r1 < r10 < r2` holds lexicographically and not naturally,
+    /// `r1 < r2 < r10` naturally and not lexicographically. A case table that only
+    /// listed sequences both comparators accept would pass with the arms swapped.
+    ///
+    /// Every order carries a rejecting case for the same reason. Equal keys never
+    /// violate under any comparator, so an accept-only entry — which is all
+    /// `TemplateCoordinate` had — passes whichever extractor its arm is wired to,
+    /// and that arm's extractor is the most involved of the four. An unpaired
+    /// mapped read keys on `(tid, unclipped_pos, ...)`, so descending positions
+    /// give it something to reject.
+    #[rstest]
+    #[case::coordinate_ascending(SortOrder::Coordinate, &[("a", 100), ("b", 200)], 0)]
+    #[case::coordinate_backwards(SortOrder::Coordinate, &[("a", 200), ("b", 100)], 1)]
+    #[case::coordinate_counts_every_violation(
+        SortOrder::Coordinate,
+        &[("a", 200), ("b", 100), ("c", 400), ("d", 300)],
+        2
+    )]
+    #[case::lexicographic_accepts_lexicographic_order(
+        SortOrder::Queryname(QuerynameComparator::Lexicographic),
+        &[("r1", 100), ("r10", 100), ("r2", 100)],
+        0
+    )]
+    #[case::lexicographic_rejects_natural_order(
+        SortOrder::Queryname(QuerynameComparator::Lexicographic),
+        &[("r2", 100), ("r10", 100)],
+        1
+    )]
+    #[case::natural_accepts_natural_order(
+        SortOrder::Queryname(QuerynameComparator::Natural),
+        &[("r1", 100), ("r2", 100), ("r10", 100)],
+        0
+    )]
+    #[case::natural_rejects_lexicographic_order(
+        SortOrder::Queryname(QuerynameComparator::Natural),
+        &[("r10", 100), ("r2", 100)],
+        1
+    )]
+    #[case::template_coordinate_accepts_equal_keys(
+        SortOrder::TemplateCoordinate,
+        &[("a", 100), ("b", 100)],
+        0
+    )]
+    #[case::template_coordinate_rejects_descending_positions(
+        SortOrder::TemplateCoordinate,
+        &[("a", 200), ("b", 100)],
+        1
+    )]
+    fn order_check_applies_the_comparator_its_sort_order_names(
+        #[case] order: SortOrder,
+        #[case] records: &[(&str, i32)],
+        #[case] expected_violations: u64,
+    ) {
+        let header = single_reference_header("coordinate");
+        let mut check = OrderCheck::new(&header, order);
+        for (name, pos) in records {
+            check.observe(mapped(name.as_bytes(), *pos).as_ref());
+        }
+
+        let result = check.into_result(Path::new("input.bam"));
+        if expected_violations == 0 {
+            result.unwrap_or_else(|e| panic!("{order:?} must accept {records:?}: {e}"));
+        } else {
+            let err = result.expect_err(&format!("{order:?} must reject {records:?}"));
+            let msg = err.to_string();
+            assert!(
+                msg.contains(&format!("{expected_violations} record(s) violate")),
+                "must report every violation, not stop at the first: {msg}"
+            );
+            assert!(msg.contains("input.bam"), "must name the offending input: {msg}");
+        }
+    }
+
+    /// The first violation names the record that broke the order, not merely the
+    /// count — the report is what tells a user *where* to look.
+    #[test]
+    fn order_check_names_the_first_violating_record() {
+        let header = single_reference_header("coordinate");
+        let mut check = OrderCheck::new(&header, SortOrder::Coordinate);
+        for (name, pos) in [("first", 100), ("second", 300), ("backwards", 200), ("last", 150)] {
+            check.observe(mapped(name.as_bytes(), pos).as_ref());
+        }
+
+        let msg = check
+            .into_result(Path::new("input.bam"))
+            .expect_err("a backwards record must be rejected")
+            .to_string();
+        assert!(msg.contains("record 3"), "must give the 1-based record position: {msg}");
+        assert!(msg.contains("backwards"), "must name the first violating read: {msg}");
     }
 }

--- a/src/lib/commands/compare/molecule.rs
+++ b/src/lib/commands/compare/molecule.rs
@@ -7,8 +7,6 @@
 
 use anyhow::{Result, anyhow};
 use fgumi_raw_bam::RawRecord;
-use fgumi_sort::RawBamRecordReader;
-use std::io::Read;
 
 use super::bams::get_mi_tag_raw;
 
@@ -33,8 +31,8 @@ impl MoleculeRun {
 
 /// Stream `reader` into per-molecule runs, cutting a run when the base MI (see
 /// [`super::bams::MiKey::base`]) changes. Assumes same-molecule reads are consecutive
-/// (guaranteed by grouped output; see the design doc) and *enforces* two grouping invariants
-/// in O(1) memory, yielding an `Err` on the first record that violates either:
+/// (guaranteed by grouped output; see the design doc) and *enforces* three grouping invariants
+/// in O(1) memory, yielding an `Err` on the first record that violates any of them:
 ///
 /// 1. **Every record is MI-tagged.** `fgumi group`/`fgbio GroupReadsByUmi` tag every emitted
 ///    read with an MI, so a record with a missing or unparseable MI base (`base == None`)
@@ -62,10 +60,15 @@ impl MoleculeRun {
 ///    A deliberately high per-run record ceiling ([`MAX_MOLECULE_RUN_RECORDS`]) turns that
 ///    pathological O(file) accumulation into a clear error instead of an eventual OOM; a
 ///    well-formed grouped input has bounded UMI families and never approaches it.
-pub(crate) fn molecule_runs<R: Read>(
-    reader: RawBamRecordReader<R>,
-) -> impl Iterator<Item = Result<MoleculeRun>> {
-    molecule_runs_capped(reader, MAX_MOLECULE_RUN_RECORDS)
+///
+/// Any `Err` — a violated invariant or an upstream read failure — is terminal: the iterator
+/// fuses and drops the partially accumulated run, so a caller that keeps polling sees `None`
+/// rather than that partial molecule handed back as a complete one.
+pub(crate) fn molecule_runs<I>(records: I) -> impl Iterator<Item = Result<MoleculeRun>>
+where
+    I: Iterator<Item = std::io::Result<RawRecord>>,
+{
+    molecule_runs_capped(records, MAX_MOLECULE_RUN_RECORDS)
 }
 
 /// Deliberately high last-resort ceiling on the number of records buffered for a *single*
@@ -78,19 +81,31 @@ pub(crate) const MAX_MOLECULE_RUN_RECORDS: usize = 100_000_000;
 /// [`molecule_runs`] with an explicit per-run record ceiling, so tests can exercise the
 /// over-cap error path without materializing 100M records. Production always calls through the
 /// public wrapper with [`MAX_MOLECULE_RUN_RECORDS`].
-pub(crate) fn molecule_runs_capped<R: Read>(
-    mut reader: RawBamRecordReader<R>,
+pub(crate) fn molecule_runs_capped<I>(
+    mut records: I,
     max_run_records: usize,
-) -> impl Iterator<Item = Result<MoleculeRun>> {
+) -> impl Iterator<Item = Result<MoleculeRun>>
+where
+    I: Iterator<Item = std::io::Result<RawRecord>>,
+{
     let mut pending: Vec<RawRecord> = Vec::new();
     let mut pending_base: Option<i64> = None;
     // The largest base MI of any run started so far — O(1), not an O(molecules) set (see
     // invariant 2 in the doc comment).
     let mut last_base: Option<i64> = None;
+    // Set once any arm below yields an `Err`. Every error here is terminal, and
+    // `std::iter::from_fn` is not fused: without this, a caller that polls again after an
+    // error would fall through to the end-of-stream arm and receive the records still in
+    // `pending` as a *complete* run — a partial molecule reported as whole, which is the
+    // silent truncation these errors exist to prevent.
+    let mut failed = false;
     std::iter::from_fn(move || {
-        loop {
-            match reader.next_record() {
-                Ok(Some(rec)) => {
+        if failed {
+            return None;
+        }
+        let item = loop {
+            match records.next() {
+                Some(Ok(rec)) => {
                     // Invariant 1: every record in a non-empty grouped input carries a
                     // parseable MI. `get_mi_tag_raw` returns `None` for both a missing tag and
                     // an unparseable one; reject the first such record (stricter than a
@@ -98,7 +113,7 @@ pub(crate) fn molecule_runs_capped<R: Read>(
                     let base = match get_mi_tag_raw(&rec).map(|mi| mi.base()) {
                         Some(b) => b,
                         None => {
-                            return Some(Err(anyhow!(
+                            break Some(Err(anyhow!(
                                 "input is not grouped: encountered a record with no (or an \
                                  unparseable) MI tag; grouping comparison requires every record \
                                  in a non-empty input to be MI-tagged (grouped output tags every \
@@ -112,7 +127,7 @@ pub(crate) fn molecule_runs_capped<R: Read>(
                         // rather than buffering O(file-size) records for a degenerate one-MI
                         // input.
                         if pending.len() >= max_run_records {
-                            return Some(Err(anyhow!(
+                            break Some(Err(anyhow!(
                                 "input is not grouped: a single molecule (MI base {base}) exceeds \
                                  {max_run_records} buffered records before yielding; a well-formed \
                                  grouped input has bounded UMI families, so this indicates \
@@ -129,7 +144,7 @@ pub(crate) fn molecule_runs_capped<R: Read>(
                     if let Some(m) = last_base
                         && base <= m
                     {
-                        return Some(Err(anyhow!(
+                        break Some(Err(anyhow!(
                             "input is not grouped: MI base {base} is not greater than a \
                              previously seen base {m}; grouping comparison requires \
                              same-MI-consecutive (grouped) input with monotonically \
@@ -144,18 +159,29 @@ pub(crate) fn molecule_runs_capped<R: Read>(
                         let done = std::mem::take(&mut pending);
                         pending_base = Some(base);
                         pending.push(rec);
-                        return Some(Ok(MoleculeRun::from_members(done)));
+                        break Some(Ok(MoleculeRun::from_members(done)));
                     }
                 }
-                Ok(None) => {
+                None => {
                     if pending.is_empty() {
-                        return None;
+                        break None;
                     }
-                    return Some(Ok(MoleculeRun::from_members(std::mem::take(&mut pending))));
+                    break Some(Ok(MoleculeRun::from_members(std::mem::take(&mut pending))));
                 }
-                Err(e) => return Some(Err(e.into())),
+                // A read failure must never be mistaken for end-of-stream: a
+                // corrupt input has to surface as an error, not as a file that
+                // simply held fewer molecules.
+                Some(Err(e)) => break Some(Err(e.into())),
             }
+        };
+        if matches!(item, Some(Err(_))) {
+            failed = true;
+            // Release the partial run rather than merely emptying it: the per-run cap fires
+            // only once `pending` is already enormous, and the iterator can outlive the error.
+            pending = Vec::new();
+            pending_base = None;
         }
+        item
     })
 }
 
@@ -206,7 +232,7 @@ mod tests {
         }
 
         let file = std::fs::File::open(tmp.path()).expect("open temp BAM");
-        let mut reader = RawBamRecordReader::new(file).expect("open raw reader");
+        let mut reader = fgumi_sort::RawBamRecordReader::new(file).expect("open raw reader");
         reader.skip_header().expect("skip header");
 
         molecule_runs_capped(reader, max_run_records).collect::<Result<Vec<_>>>()

--- a/src/lib/commands/compare/molecule.rs
+++ b/src/lib/commands/compare/molecule.rs
@@ -347,4 +347,78 @@ mod tests {
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0].members.len(), 2);
     }
+
+    /// A read failure must propagate as an error, never be mistaken for end-of-stream.
+    /// The record source hands back `io::Result`, so treating an `Err` like `None`
+    /// would silently turn a corrupt input into a file that simply held fewer
+    /// molecules — a wrong answer from a comparison oracle rather than a failure.
+    ///
+    /// The records already buffered when the failure arrives must not be emitted as a
+    /// complete run either: they are a partial molecule, and reporting them as whole
+    /// would be the same silent truncation one layer down.
+    #[test]
+    fn a_read_failure_propagates_instead_of_ending_the_stream() {
+        let records = vec![
+            Ok(rec(b"r_a", "1")),
+            Err(std::io::Error::other("simulated decompression failure")),
+        ];
+
+        let err = molecule_runs(records.into_iter())
+            .collect::<Result<Vec<_>>>()
+            .expect_err("a read failure must surface as an error, not a short file");
+        assert!(
+            err.to_string().contains("simulated decompression failure"),
+            "the underlying I/O failure must reach the caller: {err}"
+        );
+    }
+
+    /// Every error arm is terminal, and none may leave the partially accumulated molecule
+    /// behind. `std::iter::from_fn` is not fused, so a caller that polls past an error would
+    /// otherwise reach the end-of-stream arm and receive `pending` as a *complete*
+    /// [`MoleculeRun`] — a partial molecule reported as whole, which is exactly the silent
+    /// truncation these errors exist to prevent. `collect::<Result<Vec<_>>>` stops at the
+    /// first `Err`, so this is latent rather than live today; the cases below pin it at the
+    /// iterator rather than relying on every future caller to stop polling.
+    ///
+    /// One case per error arm — read failure, MI-less record, non-monotonic base, and the
+    /// per-run cap — because each breaks from a different point in the loop. Each case pins a
+    /// fragment unique to its arm, so a case cannot pass by tripping a *different* error than
+    /// the one it names.
+    #[rstest]
+    #[case::read_failure(
+        vec![Ok(rec(b"r_a", "1")), Err(std::io::Error::other("simulated decompression failure"))],
+        MAX_MOLECULE_RUN_RECORDS,
+        "simulated decompression failure"
+    )]
+    #[case::mi_less_record(
+        vec![Ok(rec(b"r_a", "1")), Ok(mi_less())],
+        MAX_MOLECULE_RUN_RECORDS,
+        "MI-tagged"
+    )]
+    #[case::non_monotonic_base(
+        vec![Ok(rec(b"r_a", "5")), Ok(rec(b"r_b", "1"))],
+        MAX_MOLECULE_RUN_RECORDS,
+        "not greater than"
+    )]
+    #[case::over_run_cap(vec![Ok(rec(b"r_a", "1")), Ok(rec(b"r_b", "1"))], 1, "single molecule")]
+    fn an_error_is_terminal_and_discards_the_partial_run(
+        #[case] records: Vec<std::io::Result<RawRecord>>,
+        #[case] max_run_records: usize,
+        #[case] expected_fragment: &str,
+    ) {
+        let mut runs = molecule_runs_capped(records.into_iter(), max_run_records);
+
+        let err = runs
+            .next()
+            .expect("the error must be yielded, not swallowed")
+            .expect_err("the first item must be the error, not a run");
+        assert!(
+            err.to_string().contains(expected_fragment),
+            "expected the {expected_fragment:?} arm to fire, got: {err}"
+        );
+        assert!(
+            runs.next().is_none(),
+            "polling past an error must not emit the buffered partial molecule as a run"
+        );
+    }
 }

--- a/tests/integration/test_compare_bams.rs
+++ b/tests/integration/test_compare_bams.rs
@@ -880,7 +880,7 @@ fn test_positional_compare_zero_batch_size_errors() {
     write_bam(&bam1, &header, &records);
     write_bam(&bam2, &header, &records);
 
-    let err = positional_compare(&bam1, &bam2, 1, 0, 100, ContentPredicate::Exact)
+    let err = positional_compare(&bam1, &bam2, 1, 0, 100, ContentPredicate::Exact, None)
         .expect_err("batch_size 0 must error at the engine boundary, not hang");
     assert!(
         err.to_string().contains("batch size must be at least 1"),
@@ -902,7 +902,7 @@ fn test_positional_compare_identical_bams_match() {
     write_bam(&bam1, &header, &records);
     write_bam(&bam2, &header, &records);
 
-    let outcome = positional_compare(&bam1, &bam2, 1, 64, 100, ContentPredicate::Exact)
+    let outcome = positional_compare(&bam1, &bam2, 1, 64, 100, ContentPredicate::Exact, None)
         .expect("positional_compare should succeed");
 
     assert_eq!(outcome.bam1_count, 2);
@@ -935,7 +935,7 @@ fn test_positional_compare_seq_difference_is_one_content_diff() {
     write_bam(&bam1, &header, &records1);
     write_bam(&bam2, &header, &records2);
 
-    let outcome = positional_compare(&bam1, &bam2, 1, 64, 100, ContentPredicate::Exact)
+    let outcome = positional_compare(&bam1, &bam2, 1, 64, 100, ContentPredicate::Exact, None)
         .expect("positional_compare should succeed");
 
     assert_eq!(outcome.bam1_count, 1);
@@ -965,7 +965,7 @@ fn test_positional_compare_swapped_records_is_key_mismatch() {
     write_bam(&bam1, &header, &records1);
     write_bam(&bam2, &header, &records2);
 
-    let outcome = positional_compare(&bam1, &bam2, 1, 64, 100, ContentPredicate::Exact)
+    let outcome = positional_compare(&bam1, &bam2, 1, 64, 100, ContentPredicate::Exact, None)
         .expect("positional_compare should succeed");
 
     assert_eq!(outcome.bam1_count, 2);
@@ -994,7 +994,7 @@ fn test_positional_compare_extra_trailing_record_is_presence_differ() {
     write_bam(&bam1, &header, &records1);
     write_bam(&bam2, &header, &records2);
 
-    let outcome = positional_compare(&bam1, &bam2, 1, 64, 100, ContentPredicate::Exact)
+    let outcome = positional_compare(&bam1, &bam2, 1, 64, 100, ContentPredicate::Exact, None)
         .expect("positional_compare should succeed");
 
     assert_eq!(outcome.bam1_count, 2);
@@ -1022,7 +1022,7 @@ fn test_positional_compare_header_sq_length_mismatch_is_a_diff() {
     write_bam(&bam1, &header1, &records);
     write_bam(&bam2, &header2, &records);
 
-    let outcome = positional_compare(&bam1, &bam2, 1, 64, 100, ContentPredicate::Exact)
+    let outcome = positional_compare(&bam1, &bam2, 1, 64, 100, ContentPredicate::Exact, None)
         .expect("positional_compare should succeed");
 
     assert!(outcome.header_mismatch, "a @SQ length mismatch must be flagged: {outcome:?}");

--- a/tests/integration/test_compare_bams.rs
+++ b/tests/integration/test_compare_bams.rs
@@ -2297,14 +2297,21 @@ fn write_identical_orderless_pair(dir: &Path) -> (PathBuf, PathBuf) {
 }
 
 /// A BAM that DECLARES coordinate order but whose records are out of coordinate order must be
-/// rejected up-front (don't trust the @HD tag), independent of record content.
+/// rejected (don't trust the @HD tag), independent of record content.
+///
+/// Asserts the specific diagnostic rather than merely that the word "order" appears: the
+/// message must name the declared order that was violated and the offending input, so that a
+/// change to the order check cannot degrade the report while still "containing order".
 #[test]
 fn content_mode_rejects_records_not_in_declared_coordinate_order() {
     let tmp = TempDir::new().unwrap();
     let bad = write_bam_declaring_coordinate_but_unsorted(tmp.path()); // pos 500 then pos 100
     let good = write_sorted_coordinate_bam(tmp.path());
     let err = run_compare_content_expect_err(&good, &bad);
-    assert!(err.to_lowercase().contains("order"), "got: {err}");
+    assert!(err.contains("violate the declared"), "got: {err}");
+    assert!(err.contains("Coordinate"), "must name the declared order violated: {err}");
+    let bad_name = bad.file_name().unwrap().to_str().unwrap();
+    assert!(err.contains(bad_name), "must name the offending input {bad_name}: {err}");
 }
 
 /// An orderless (extract-style `SO:unsorted GO:query`, no SS) pair has no verifiable order:
@@ -3039,5 +3046,188 @@ fn test_compare_bams_cli_reads_a_non_reopenable_input(#[case] preset: &str) {
         stdout.contains(expected_result_line),
         "the same data over a FIFO must compare equal to itself: --command {preset} must print \
          {expected_result_line:?}, got:\n{stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Content mode: sort-order verification
+//
+// Content mode pairs records purely by position, so an `@HD`-declared order the
+// records do not actually honor would silently corrupt that pairing rather than
+// surfacing as an honest diff. The check runs inside the comparison's own record
+// pass (`OrderCheck`, folded into `positional_compare`) rather than as a separate
+// traversal of each input, and these tests pin the contract that fold has to
+// preserve: that a mis-sorted input is rejected, that the reported violation
+// *count* reflects the whole file rather than stopping at the first bad record,
+// and that bam1 is reported before bam2 when both are mis-sorted.
+// ---------------------------------------------------------------------------
+
+/// Writes a coordinate-declaring BAM whose records appear at `positions` in the
+/// given order — so a caller can declare `SO:coordinate` while emitting records
+/// that violate it.
+fn write_coordinate_declared_bam(path: &Path, positions: &[i32]) {
+    let header = create_coordinate_sorted_header("chr1", 100_000);
+    let records: Vec<RawRecord> = positions
+        .iter()
+        .enumerate()
+        .map(|(i, pos)| mapped_record(format!("read{i:04}").as_bytes(), *pos))
+        .collect();
+    write_bam(path, &header, &records);
+}
+
+/// The reported violation count covers the whole file, not just the first bad
+/// record. This is why the check accumulates instead of failing fast, and it is
+/// the property a "simplify to fail-fast" refactor would silently break.
+#[test]
+fn content_mode_reports_every_sort_order_violation_not_just_the_first() {
+    let tmp = TempDir::new().unwrap();
+    let sorted = tmp.path().join("sorted.bam");
+    let mis_sorted = tmp.path().join("mis_sorted.bam");
+
+    write_coordinate_declared_bam(&sorted, &[100, 200, 300, 400, 500, 600]);
+    // Two independent backwards steps: 150 after 200, and 350 after 400.
+    write_coordinate_declared_bam(&mis_sorted, &[100, 200, 150, 400, 350, 600]);
+
+    let (code, _stdout, stderr) = run_compare(&sorted, &mis_sorted, "content", &[]);
+    assert_eq!(code, Some(1), "a mis-sorted input must fail: {stderr}");
+    assert!(
+        stderr.contains("2 record(s) violate"),
+        "violation count must cover the whole file, not stop at the first: {stderr}"
+    );
+}
+
+/// When both inputs are mis-sorted, bam1 is reported. Pins the evaluation order,
+/// which is what keeps the diagnostic stable now that both files are checked in
+/// one pass rather than one-then-the-other.
+#[test]
+fn content_mode_reports_bam1_when_both_inputs_are_mis_sorted() {
+    let tmp = TempDir::new().unwrap();
+    let first = tmp.path().join("first.bam");
+    let second = tmp.path().join("second.bam");
+
+    write_coordinate_declared_bam(&first, &[100, 200, 150, 400]);
+    write_coordinate_declared_bam(&second, &[100, 200, 150, 400]);
+
+    let (code, _stdout, stderr) = run_compare(&first, &second, "content", &[]);
+    assert_eq!(code, Some(1), "mis-sorted inputs must fail: {stderr}");
+    assert!(
+        stderr.contains("first.bam") && !stderr.contains("second.bam"),
+        "bam1 must be the input reported when both are mis-sorted: {stderr}"
+    );
+}
+
+/// A correctly-sorted pair that declares its order must still compare normally —
+/// the order check must not reject well-formed input, at any thread count. The
+/// thread parameter covers the split decompression budget as well as the check.
+#[rstest]
+fn content_mode_accepts_input_that_honors_its_declared_sort_order(#[values(1, 4)] threads: usize) {
+    let tmp = TempDir::new().unwrap();
+    let a = tmp.path().join("a.bam");
+    let b = tmp.path().join("b.bam");
+
+    write_coordinate_declared_bam(&a, &[100, 200, 300, 400]);
+    write_coordinate_declared_bam(&b, &[100, 200, 300, 400]);
+
+    assert!(
+        run_compare_in_process(&a, &b, "content", &["-t", &threads.to_string()]),
+        "correctly sorted identical BAMs must match at --threads {threads}"
+    );
+}
+
+/// Once pairing stops because one input ran out, `positional_compare` keeps draining
+/// the longer side — and must keep checking its order while doing so. The drained
+/// records are the ones no counterpart ever forced it to look at, so an order check
+/// that stopped at the last paired record would report a violation count covering
+/// only part of the file, and miss a file whose *only* mis-sorted records are in its
+/// unpaired tail. The batch size is 1 so the tail genuinely arrives as extra batches
+/// through the drain loop rather than inside the last paired batch.
+///
+/// Both directions are covered because the two sides drain through separate loops.
+#[rstest]
+#[case::bam1_is_longer(true)]
+#[case::bam2_is_longer(false)]
+fn positional_compare_checks_sort_order_in_the_unpaired_tail(#[case] bam1_is_longer: bool) {
+    let tmp = TempDir::new().unwrap();
+    let short = tmp.path().join("short.bam");
+    let long = tmp.path().join("long.bam");
+
+    write_coordinate_declared_bam(&short, &[100, 200]);
+    // The tail (everything past record 2) steps backwards at 300 -> 250.
+    write_coordinate_declared_bam(&long, &[100, 200, 300, 250, 400]);
+
+    let (bam1, bam2) = if bam1_is_longer { (&long, &short) } else { (&short, &long) };
+    let err = positional_compare(
+        bam1,
+        bam2,
+        1,
+        1,
+        100,
+        ContentPredicate::Exact,
+        Some(fgumi_sort::SortOrder::Coordinate),
+    )
+    .expect_err("a violation in the unpaired tail must still be reported");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("1 record(s) violate"),
+        "the drained tail must be order-checked too: {msg}"
+    );
+    assert!(msg.contains("long.bam"), "must name the mis-sorted input: {msg}");
+}
+
+/// Truncating a BAM mid-BGZF-block makes its reader fail partway through. That must
+/// surface as an error naming the offending input, never as a short file: a
+/// silently-short read turns a corrupt input into a record-count DIFFER, or a false
+/// IDENTICAL when both sides are damaged alike, from the tool whose only job is
+/// deciding whether two files agree.
+///
+/// Both positions are covered because each input is received through its own branch,
+/// and both the paired phase and the drain phase are covered because they receive
+/// through separate loops. Which phase sees the failure is set by how many records
+/// the intact side holds, since the damaged side fails partway through 20,000:
+/// one record makes the intact side reach EOF first, so the failure arrives while
+/// the damaged side is being drained; 20,000 keeps both sides live, so it arrives
+/// while they are still being paired. A small intact count would put every case in
+/// the drain loop and leave the pairing loop untested.
+#[rstest]
+#[case::damaged_bam1_while_pairing(true, 20_000)]
+#[case::damaged_bam2_while_pairing(false, 20_000)]
+#[case::damaged_bam1_while_draining(true, 1)]
+#[case::damaged_bam2_while_draining(false, 1)]
+fn positional_compare_reports_a_damaged_input_rather_than_a_short_one(
+    #[case] damage_bam1: bool,
+    #[case] intact_records: i32,
+) {
+    let tmp = TempDir::new().unwrap();
+    let intact = tmp.path().join("intact.bam");
+    let damaged = tmp.path().join("damaged.bam");
+
+    let positions: Vec<i32> = (0..intact_records).map(|i| 100 + i).collect();
+    write_coordinate_declared_bam(&intact, &positions);
+
+    // Enough records to span several BGZF blocks, so the cut lands well past the
+    // header and the reader delivers batches before it fails.
+    let long_positions: Vec<i32> = (0..20_000).map(|i| 100 + i).collect();
+    let whole = tmp.path().join("whole.bam");
+    write_coordinate_declared_bam(&whole, &long_positions);
+    let bytes = fs::read(&whole).expect("read whole BAM");
+    fs::write(&damaged, &bytes[..bytes.len() * 3 / 5]).expect("write truncated BAM");
+
+    let (bam1, bam2) = if damage_bam1 { (&damaged, &intact) } else { (&intact, &damaged) };
+    let err = positional_compare(
+        bam1,
+        bam2,
+        1,
+        1,
+        100,
+        ContentPredicate::Exact,
+        Some(fgumi_sort::SortOrder::Coordinate),
+    )
+    .expect_err("a truncated input must error, not read as a shorter file");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("damaged.bam"),
+        "the error must name the input that failed to read: {msg}"
     );
 }

--- a/tests/integration/test_compare_mutation.rs
+++ b/tests/integration/test_compare_mutation.rs
@@ -173,7 +173,7 @@ fn positional_baseline_identical_records_match() {
     let bam2 = tmp.path().join("b.bam");
     write_bam(&bam1, &header, &records);
     write_bam(&bam2, &header, &records);
-    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, ContentPredicate::Exact)
+    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, ContentPredicate::Exact, None)
         .expect("positional_compare should succeed");
     assert!(outcome.is_match(), "unmutated baseline must MATCH: {outcome:?}");
 }
@@ -203,7 +203,7 @@ fn positional_exact_core_field_mutation_differs(
     write_bam(&bam1, &header, &[rec_a]);
     write_bam(&bam2, &header, &[rec_b]);
 
-    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, ContentPredicate::Exact)
+    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, ContentPredicate::Exact, None)
         .expect("positional_compare should succeed");
     assert_eq!(
         outcome.key_mismatch_at, None,
@@ -237,7 +237,7 @@ fn positional_exact_qname_change_is_caught_as_key_mismatch() {
     write_bam(&bam1, &header, &[rec_a]);
     write_bam(&bam2, &header, &[rec_b]);
 
-    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, ContentPredicate::Exact)
+    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, ContentPredicate::Exact, None)
         .expect("positional_compare should succeed");
     assert_eq!(
         outcome.key_mismatch_at,
@@ -393,7 +393,7 @@ fn positional_exact_duplicated_record_differs() {
     write_bam(&bam1, &header, &records1);
     write_bam(&bam2, &header, &records2);
 
-    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, ContentPredicate::Exact)
+    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, ContentPredicate::Exact, None)
         .expect("positional_compare should succeed");
     assert_eq!(outcome.bam1_count, 2);
     assert_eq!(outcome.bam2_count, 3);
@@ -419,7 +419,7 @@ fn positional_exact_swap_of_distinct_key_records_differs() {
     write_bam(&bam1, &header, &records1);
     write_bam(&bam2, &header, &records2);
 
-    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, ContentPredicate::Exact)
+    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, ContentPredicate::Exact, None)
         .expect("positional_compare should succeed");
     assert_eq!(
         outcome.key_mismatch_at,
@@ -455,7 +455,7 @@ fn positional_exact_minus_mi_tolerates_mi_only_value_change() {
     write_bam(&bam1, &header, &[record_with_mi_and_nm(5, 1)]);
     write_bam(&bam2, &header, &[record_with_mi_and_nm(99, 1)]);
 
-    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, ContentPredicate::ExactMinusMi)
+    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, ContentPredicate::ExactMinusMi, None)
         .expect("positional_compare should succeed");
     assert_eq!(outcome.content_diffs, 0, "{outcome:?}");
     assert!(
@@ -473,7 +473,7 @@ fn positional_exact_minus_mi_still_flags_non_mi_tag_change() {
     write_bam(&bam1, &header, &[record_with_mi_and_nm(5, 1)]);
     write_bam(&bam2, &header, &[record_with_mi_and_nm(5, 2)]);
 
-    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, ContentPredicate::ExactMinusMi)
+    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, ContentPredicate::ExactMinusMi, None)
         .expect("positional_compare should succeed");
     assert_eq!(outcome.content_diffs, 1, "{outcome:?}");
     assert!(
@@ -530,7 +530,7 @@ fn positional_consensus_cd_compared_exactly(
     write_bam(&bam1, &header, &[consensus_record_cd(cd_a)]);
     write_bam(&bam2, &header, &[consensus_record_cd(cd_b)]);
 
-    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, pred)
+    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, pred, None)
         .expect("positional_compare should succeed");
     assert_eq!(outcome.is_match(), expect_match, "cD {cd_a} vs {cd_b} under {pred:?}: {outcome:?}");
 }
@@ -560,7 +560,7 @@ fn positional_consensus_single_quality_tag_difference_is_flagged(
     write_bam(&bam1, &header, &[a]);
     write_bam(&bam2, &header, &[b]);
 
-    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, ContentPredicate::Exact)
+    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, ContentPredicate::Exact, None)
         .expect("positional_compare should succeed");
     assert!(
         !outcome.is_match(),
@@ -599,7 +599,7 @@ fn positional_consensus_duplex_depth_compared_exactly(
     write_bam(&bam1, &header, &[consensus_record_with_tag(tag, value_a)]);
     write_bam(&bam2, &header, &[consensus_record_with_tag(tag, value_b)]);
 
-    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, pred)
+    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, pred, None)
         .expect("positional_compare should succeed");
     assert!(
         !outcome.is_match(),
@@ -637,7 +637,7 @@ fn positional_per_base_consensus_tag_mutation_always_differs(
     write_bam(&bam1, &header, &[per_base_consensus_record(tag, &[10, 10, 10, 10])]);
     write_bam(&bam2, &header, &[per_base_consensus_record(tag, &[10, 10, 9, 10])]);
 
-    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, pred)
+    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, pred, None)
         .expect("positional_compare should succeed");
     assert!(
         !outcome.is_match(),
@@ -1128,7 +1128,7 @@ fn verify_core_field_mutation_differs(mutate: fn(&mut SamBuilder)) -> bool {
     let bam2 = tmp.path().join("b.bam");
     write_bam(&bam1, &header, &[core_record_variant(|_| {})]);
     write_bam(&bam2, &header, &[core_record_variant(mutate)]);
-    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, ContentPredicate::Exact)
+    let outcome = positional_compare(&bam1, &bam2, 1, 64, 10, ContentPredicate::Exact, None)
         .expect("positional_compare should succeed");
     outcome.key_mismatch_at.is_none() && outcome.content_diffs == 1 && !outcome.is_match()
 }
@@ -1146,7 +1146,7 @@ fn positional_differs(
     let bam2 = tmp.path().join("b.bam");
     write_bam(&bam1, header, recs_a);
     write_bam(&bam2, header, recs_b);
-    !positional_compare(&bam1, &bam2, 1, 64, 10, pred)
+    !positional_compare(&bam1, &bam2, 1, 64, 10, pred, None)
         .expect("positional_compare should succeed")
         .is_match()
 }


### PR DESCRIPTION
Closes #686.

`fgumi compare bams --command sort` ran ~3x slower than the `fgumi sort` it validates, and `--threads` did nothing. Profiling found why, and four changes fix it; a fifth removes a redundant traversal in `content` mode.

## Result

20.1M records/file, ~2 GB BAMs, M2 Max (12 core), page cache warmed identically before every run, minimum of 3 reps:

| | before | after |
| --- | --- | --- |
| `--command sort` `-t 8` | 23.44s | **4.14s** |
| `--command sort` scaling | flat | 8.92s (`-t 1`) → 5.58s (`-t 4`) → 4.14s (`-t 8`) |
| `--command group` `-t 8` | 24.36s | ~10s |
| `--command simplex` (content) | 47.1 CPU-s | **27.4 CPU-s** |

Both of #686's acceptance criteria hold: comparison is now **2.0x faster** than the sort it validates (4.14s vs 8.20s), having started 2.7x slower, and throughput scales measurably with `--threads`.

Content-mode results are quoted in CPU-seconds deliberately — see [Measurement](#measurement).

## What was wrong

`tricorder --trace` showed `sort` and `group` running the entire comparison in **exactly one OS thread** — `n_threads` never left 1, so `--threads` created nothing at all. Sampling put ~61% of that single thread in BGZF decode (~55% `libdeflate` inflate, ~6% the per-block CRC32) while eleven cores idled. `content` reached only 2.46 cores and additionally traversed each input **twice**, because `verify_records_in_order` ran over both paths before `positional_compare` reopened and streamed them again — four traversals for a job needing two.

## The changes

Suggested reading order is commit order; each commit is independently revertable.

1. **`f7fbf95` Read both inputs concurrently.** `OpenedInput::open_pair` gives each input a share of the `--threads` BGZF budget and its own read-ahead thread, so the two decodes overlap each other and the comparison. The budget is *split* rather than handed to each input in full: they are symmetric and both must be fully decoded, so giving each the whole count would request double the parallelism asked for. (`zipper` splits asymmetrically because its two inputs differ in cost; a comparison's do not.)

2. **`352cfa1` Cancel byte-identical records without building content keys.** `RunCanceller` built a canonical content key per record — a `Vec` per aux tag, a sort, a concatenation, a hash and a map insert. Comparing the raw bytes first skips all of it for pairs that agree.

3. **`13d8907` Verify sort order during the content pass.** Folds the order check into the comparison's own record pass via `OrderCheck`, removing the two dedicated traversals.

4. **`388ff00` Skip key and content checks for byte-identical pairs (content mode).** `record_keys_match` ran on every pair before `content_diffs`, whose first act is the same byte comparison. Also splits content mode's decompression budget, which was still starting 8 BGZF workers *per* reader at `-t 8`.

5. **`f0126b3` Read the MI tag in one aux scan.** `get_mi_tag_raw` probed `find_int_tag` then `find_string_tag`, each walking the aux block from the start; `fgumi group` writes `MI:Z:`, so the integer probe always missed and its scan was wasted.

### Why the byte-equality fast paths are sound

Both rest on the same argument, and neither replaces the general path. A `RecordKey` is a pure function of a record's bytes, and `content_key_exact` excludes `bin`, width-normalizes integer tags and sorts the tag multiset — so byte equality *strictly implies* key and content equality. The converse fails, which is exactly why these are fast paths: records that are content-equal but differ in tag order, integer width or `bin` fall through and still match. For the run comparison there is a second step: removing one record from each side *with the same key* leaves the multiset symmetric difference unchanged whatever else is pending, so the fast path needs no precondition on canceller state.

## Correctness

The reader change carried a real trap. `RawReadAheadReader` is `Iterator<Item = RawRecord>` — no `Result` — and signals a read failure by *ending iteration* and parking the error for a later `take_error()`. Adopted directly, a truncated or CRC-corrupt BAM would have read as a **shorter** file: a record-count `DIFFER`, or a false `IDENTICAL` when both inputs are damaged alike. Rather than requiring every engine loop to remember a trailing check, `CheckedRecords` restores the `Result` contract at the boundary, so the engines' existing `rec?` propagation is correct by construction and forgetting the check is not an available mistake.

Every change was gated against a **121-comparison differential corpus** — matched, missing, extra, edited, tag-reordered, intra-run reordered, mis-sorted, truncated, header-conflicting and byte-corrupt inputs, in both directions and at three thread counts — requiring byte-identical verdicts, exit codes and RESULT lines against a binary built from `main`. The corpus is generated (`fgumi simulate`), not committed. Two cases carry particular weight: `tag-reorder` and `swap-adjacent` are content-equal but *not* byte-equal, so they prove the fast paths did not swallow the general checks.

Error text changed only for damaged inputs, where the messages now name the failing file and diagnose it more precisely (`block data checksum mismatch` rather than a generic open failure).

New tests: sort-order violations are pinned by count, by which file is named, and by acceptance of correctly-ordered input at more than one thread count; the damaged-input regression test is parameterized over thread count as well as damage mode, covering the worker-pool error route that `open_pair` actually uses. An existing test asserting only that an error `contains("order")` was strengthened to assert the actual contract.

## Measurement

Content-mode numbers are CPU-seconds, not wall. This host's wall time proved unreliable under interactive load — identical `-t 8` runs measured 3.56s and 16.56s — while total CPU stayed within 24–27s across the same sweep. Where wall is quoted, arms were interleaved with the page cache warmed identically before every run and the minimum of 3 reps taken; the outliers are all slower, i.e. contention.

All numbers are from this workstation. #686's criteria were written against a 780M-record `c7g.4xlarge`, and that run has not been done — the effects here (5.7x) are far outside the noise, but the issue's own scale has not been reproduced.

## Notes for reviewers

- **`fgumi-sort` gains one export and one signature generalization.** `RawReadAheadReader` is re-exported, and `verify_sort_order` now takes any `Iterator<Item = io::Result<RawRecord>>` rather than a concrete reader. The `Result` item type is deliberate: it keeps a read failure distinguishable from end-of-stream.
- **`positional_compare` gained a required parameter**, so this is a breaking change for out-of-tree callers of that feature-gated API. A defaulting overload was considered and rejected: it would let a caller opt out of order verification by omission.
- **`verify_records_in_order` is removed** — `OrderCheck` subsumes it and it had no callers left. `fgumi sort --verify` continues to use `fgumi_sort::verify_sort_order`.
- **Grouping mode keeps its ~10s** beyond the reader win; its engine (`molecule_join`) was otherwise untouched, and its remaining hot spots are `find_tag_position` and `get_mi_tag_raw`.

## Not done, deliberately

Migrating the readers to the sort engine's pooled architecture was investigated and rejected for now. `PooledInputStream::next_block` blocks on `std::thread::park()` and pool workers `unpark()` the thread captured at construction — correct for the sort pipeline's single stream and single consumer. Two pools feeding one comparison thread would let stream A's workers wake the consumer while it waits on stream B, producing a cross-stream unpark storm: a CPU-burning busy-wait, the opposite of the intent. Fixing it properly needs per-stream condvars or a per-stream consumer thread, and the latter reintroduces the channel it would be removing.

Raising the read-ahead batch from 256 to 4096 records was also measured and reverted: CPU was unchanged (26.5 vs 27.0 CPU-s) while peak RSS tripled. That null result is informative — the time in `crossbeam_channel::recv` is the comparison thread *waiting on decode*, not per-handoff overhead, so the remaining lever is decode throughput rather than handoff granularity.

`CLAUDE.md` records the profiling ladder this work established (`tricorder` first, then in-tree phase timers, then `perf` on Linux) along with three macOS sampling traps that produced confidently wrong profiles here — including "38% of CPU in `clap_builder::error::Error::print`" on a *successful* run, from symbolicating another image's addresses against the fgumi binary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: comparison verdicts, exit codes, `RESULT` lines, `--max-diffs`, and diagnostics remain pinned; `unsafe` changes are none and the `CLAUDE.md` allowlist is unchanged; thread allocation and read-ahead behavior change, with no reported memory-bound or queue-capacity change.

- `fgumi compare bams` reads both BAM inputs concurrently.
- `--threads` applies to sort and grouping comparisons through split decompression budgets.
- Sort-order checks run during comparison instead of a separate traversal.
- Byte-identical records use fast paths.
- MI tags use one auxiliary-tag scan.
- `CheckedRecords` preserves deferred read errors and identifies the affected input.
- Tests cover ordering diagnostics, damaged BAMs, thread counts, and differential comparison behavior.
- Benchmarking guidance and performance data were added to `CLAUDE.md`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->