### PR TITLE
ci(miri): disable Miri isolation so the raw-bam proptest can run

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -32,7 +32,10 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  # Keep the raw-pointer proptest agreement test tractable under Miri's interpreter.
+  # Keep the raw-pointer proptest agreement test tractable under Miri's
+  # interpreter. Note this only reaches proptest because the step below disables
+  # Miri's isolation: an isolated `env::vars_os()` sees none of the host
+  # environment, so every `PROPTEST_*` knob is silently ignored.
   PROPTEST_CASES: "32"
 
 jobs:
@@ -61,4 +64,18 @@ jobs:
         # cannot interpret, and the BAM encode/decode roundtrip tests are slow and
         # exercise no `unsafe` of ours. The `sort` tests (comparator + coordinate/
         # queryname raw-key tests) run clean under Miri in a few seconds.
+        env:
+          # `test_natural_compare_agrees_with_nul` is a `proptest`, and proptest
+          # resolves the path to its `.proptest-regressions` file through
+          # `std::env::current_dir()` before running a single case. `getcwd` is
+          # unsupported under Miri's default isolation, so that test aborted the
+          # whole step — this workflow had never once passed. Isolation is safe
+          # to drop here: these tests are pure comparator calls over in-memory
+          # byte buffers, so every host access it re-permits is proptest's, not
+          # theirs — that `current_dir()` lookup; the `env::vars_os()` read
+          # through which it picks up the `PROPTEST_*` knobs (here the
+          # `PROPTEST_CASES` cap set above, which isolation had been silently
+          # discarding); and reading — on failure, writing — the
+          # `.proptest-regressions` file the lookup resolves to.
+          MIRIFLAGS: -Zmiri-disable-isolation
         run: cargo +nightly miri test -p fgumi-raw-bam sort


### PR DESCRIPTION
## Summary

The Miri workflow has never passed. Every one of its 13 runs since it was added on 2026-07-21 has failed, always in the same place:

```
error: unsupported operation: `getcwd` not available when isolation is enabled
   = note: this is on thread `sort::tests::te`
  13: sort::tests::test_natural_compare_agrees_with_nul
```

It fails on a daily cron, so the red has gone unnoticed.

## Cause

`test_natural_compare_agrees_with_nul` is a `proptest`. Before running a single case, proptest resolves the path to its `.proptest-regressions` file through `std::env::current_dir()` — and `getcwd` is unsupported under Miri's default isolation. The failure is in proptest's setup, not in the code under test or in the property itself.

The other 23 tests in the step pass. This one aborts the step, so the workflow has never reported a real result on the `unsafe` it exists to check.

## Why disable isolation rather than skip the test

That test is the one most worth keeping: it is the agreement check between `natural_compare` and `natural_compare_nul`, the raw-pointer comparator this whole step exists to interpret under Miri. Skipping it, or filtering it out of the step, would leave the gate looking green while no longer covering the `*const u8` walk.

Disabling isolation for this step is safe. These tests are pure comparator calls over in-memory byte buffers — they open no files, read no clock, and reach for no host state of their own. The only isolated operation in play is the cwd lookup proptest performs on their behalf. Stacked Borrows and the rest of Miri's UB checking are unaffected; `-Zmiri-disable-isolation` relaxes only host-interaction shims.

## Second effect, also fixed

Miri's isolation blocks environment access too: an isolated `env::vars_os()` returns none of the host variables. So the workflow-level `PROPTEST_CASES: "32"` — added to keep this very test tractable under the interpreter — has been silently ignored on every run, and the test has been running proptest's default case count whenever it got that far. Disabling isolation makes that cap effective for the first time. The comment above it now records the dependency so it does not get "cleaned up" later.

This is also why the narrower fix does not work: `PROPTEST_DISABLE_FAILURE_PERSISTENCE=1` would avoid the `getcwd` call, but proptest never sees the variable under isolation. I tried it first and it changed nothing.

## Verification

Run locally on this branch, with the exact command and environment the workflow uses:

```
$ MIRIFLAGS=-Zmiri-disable-isolation PROPTEST_CASES=32 \
    cargo +nightly miri test -p fgumi-raw-bam sort
test result: ok. 30 passed; 0 failed; 0 ignored; 0 measured; 694 filtered out; finished in 15.62s
exit 0
```

Before the change, the same command without `MIRIFLAGS` exits 1 on the proptest. Both directions were confirmed, as was the environment behaviour: a probe variable produces proptest's "Ignoring unknown env-var" warning with isolation off and no warning with it on.

## Note for #697

`main-runall` adds a second Miri step for `fgumi-pipeline-core`. Because both steps share one job under `bash -e`, this failure aborts the job before that step runs — so the new step has never executed in CI either. It is verified locally only. Once this lands and `main-runall` picks it up, that step will run for real.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration testing configuration to support expanded property-based test coverage.
  * Improved raw-pointer comparator checks in the Miri test environment while preserving in-memory test behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->