### PR TITLE
ci: report scheduled-workflow failures as a tracking issue

### DIFF
--- a/.github/actions/report-cron-failure/action.yml
+++ b/.github/actions/report-cron-failure/action.yml
@@ -1,0 +1,87 @@
+name: Report cron failure
+description: >-
+  Open (or update) a tracking issue when a scheduled workflow fails, so a red
+  cron is visible in the repository rather than only in per-user email.
+
+# A scheduled workflow that fails notifies nobody except the person who last
+# touched its file, by email, which is easy to filter and invisible to everyone
+# else. `miri.yml` failed on every run for two weeks before anyone noticed. This
+# action turns that silence into an issue in the repository.
+#
+# One issue per workflow, reused: a failure that persists for weeks comments on
+# the existing issue rather than filing a new one each night. Filing duplicates
+# would be just as easy to tune out as filing nothing.
+
+inputs:
+  token:
+    description: "Token with `issues: write` on this repository."
+    required: true
+  label:
+    description: Label applied to the tracking issue.
+    required: false
+    default: ci-failure
+
+runs:
+  using: composite
+  steps:
+    - name: Open or update the tracking issue
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        LABEL: ${{ inputs.label }}
+        REPO: ${{ github.repository }}
+        WORKFLOW: ${{ github.workflow }}
+        REF_NAME: ${{ github.ref_name }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        set -euo pipefail
+
+        title="Scheduled workflow failing: ${WORKFLOW}"
+
+        # Created on demand so the action is self-contained: a repository that
+        # has never had a cron failure needs no out-of-band setup for the first
+        # one to be reportable. Idempotent -- a second create is a no-op.
+        gh label create "$LABEL" --repo "$REPO" \
+          --description "A scheduled workflow is failing" --color d73a4a \
+          >/dev/null 2>&1 || true
+
+        # Match on the exact title rather than `--search`, whose full-text
+        # matching would also hit issues that merely mention the workflow.
+        #
+        # `--limit` because `gh issue list` returns only the first 30 otherwise.
+        # The label is shared by every workflow's tracking issue and by anything
+        # a human labels, so the one being looked for can be paged out -- and a
+        # miss files a duplicate, which is exactly what the dedupe exists to
+        # prevent. 100 is far above any plausible count of open `ci-failure`
+        # issues while still being a single request.
+        existing=$(
+          gh issue list --repo "$REPO" --label "$LABEL" --state open --limit 100 \
+            --json number,title \
+            | jq -r --arg t "$title" '[.[] | select(.title == $t)] | .[0].number // empty'
+        )
+
+        if [ -n "$existing" ]; then
+          # "not green" rather than "failed": the callers also report a run
+          # cancelled by its `timeout-minutes`, which is a hang, not a failure.
+          gh issue comment "$existing" --repo "$REPO" \
+            --body "Still not green on \`${REF_NAME}\` — [run](${RUN_URL})."
+          echo "Commented on existing issue #${existing}."
+        else
+          # Heredoc so the body reads as the Markdown it becomes. It must stay
+          # flush left: `<<EOF` does not strip indentation, and leading spaces
+          # would render as a code block.
+          body=$(cat <<EOF
+        The scheduled workflow \`${WORKFLOW}\` did not succeed on \`${REF_NAME}\`
+        -- it failed, or was cancelled after exceeding its timeout.
+
+        Failing run: ${RUN_URL}
+
+        This issue was opened automatically. Subsequent failures of this workflow
+        comment here rather than filing new issues, so the comment count is how long
+        it has been broken. Close it once the workflow is green again — the next
+        failure opens a fresh one.
+        EOF
+          )
+          gh issue create --repo "$REPO" --label "$LABEL" --title "$title" --body "$body"
+          echo "Opened a new tracking issue."
+        fi

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -20,7 +20,9 @@ on:
     - cron: "0 8 * * *" # daily at 08:00 UTC
   workflow_dispatch: {}
 
-# The job only reads the repository and runs tests; it never writes back.
+# The job reads the repository and runs tests; it never writes back to contents.
+# `issues: write` is granted to the `report-failure` job alone, which is the only
+# thing here that writes anything.
 permissions:
   contents: read
 
@@ -79,3 +81,50 @@ jobs:
           # `.proptest-regressions` file the lookup resolves to.
           MIRIFLAGS: -Zmiri-disable-isolation
         run: cargo +nightly miri test -p fgumi-raw-bam sort
+
+  # Nothing watches a cron's result, so a failure has to announce itself. See the
+  # action for why it reuses one issue per workflow.
+  #
+  # A separate job rather than a final step in `miri`, because the two failures
+  # most worth reporting are the ones a step could not report on. A step there
+  # `uses: ./...`, which only resolves once the repository is on disk, so a failed
+  # checkout takes the reporting down with it; and `timeout-minutes` *cancels* the
+  # job, which skips `if: failure()` steps entirely -- so the hang that bound
+  # exists to catch would go unreported. A separate job checks out for itself and
+  # reads the outcome from `needs`, which survives both.
+  report-failure:
+    needs: miri
+    # `always()`, or this job is skipped along with its cancelled dependency --
+    # which would give back the timeout blind spot the job exists to close.
+    #
+    # `cancelled` as well as `failure` because GitHub documents a `timeout-minutes`
+    # overrun as cancelling the job, and does not state which of the two it then
+    # reports; matching both makes a hang reportable either way. The cost is that
+    # a deliberately cancelled scheduled run also files -- but a human cancelling
+    # a nightly cron was watching it, and the dedupe folds that into one issue
+    # they can close. A hang has nobody watching, which is the whole problem.
+    #
+    # Scheduled runs only: a `workflow_dispatch` failure is already in front of
+    # whoever dispatched it, and -- once a workflow also runs on `pull_request` --
+    # a PR failure is visible in that PR's checks. Filing an issue for either is
+    # noise; the silent trigger is the one that needs it.
+    if: >-
+      always()
+      && (needs.miri.result == 'failure' || needs.miri.result == 'cancelled')
+      && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    # The only write access in this workflow, scoped to the one job that writes.
+    permissions:
+      contents: read
+      issues: write
+    # A checkout and three `gh` calls; minutes here mean stuck, not busy.
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Report failure
+        uses: ./.github/actions/report-cron-failure
+        with:
+          token: ${{ github.token }}

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -12,8 +12,9 @@ on:
     - cron: "0 7 * * *" # daily at 07:00 UTC
   workflow_dispatch: {}
 
-# Read-only by default: this workflow only builds and runs tests, so it needs no
-# write access to repo contents, issues, or the token's other scopes.
+# This workflow only builds and runs tests, so it needs no write access to repo
+# contents. `issues: write` is granted to the `report-failure` job alone, which is
+# the only thing here that writes anything.
 permissions:
   contents: read
 
@@ -53,3 +54,49 @@ jobs:
           tool: nextest
       - name: Concurrency stress tests
         run: cargo ci-test-stress
+
+  # Nothing watches a cron's result, so a failure has to announce itself. See the
+  # action for why it reuses one issue per workflow.
+  #
+  # A separate job rather than a final step in `stress-tests`, because the two
+  # failures most worth reporting are the ones a step could not report on. A step
+  # there `uses: ./...`, which only resolves once the repository is on disk, so a
+  # failed checkout takes the reporting down with it; and `timeout-minutes`
+  # *cancels* the job, which skips `if: failure()` steps entirely -- so the
+  # deadlock that bound exists to catch would go unreported. A separate job checks
+  # out for itself and reads the outcome from `needs`, which survives both.
+  report-failure:
+    needs: stress-tests
+    # `always()`, or this job is skipped along with its cancelled dependency --
+    # which would give back the timeout blind spot the job exists to close.
+    #
+    # `cancelled` as well as `failure` because GitHub documents a `timeout-minutes`
+    # overrun as cancelling the job, and does not state which of the two it then
+    # reports; matching both makes a hang reportable either way. That matters more
+    # here than in `miri.yml`: this suite exercises deadlock detection, so a hang
+    # is its characteristic failure rather than an unlikely one.
+    #
+    # Scheduled runs only: a `workflow_dispatch` failure is already in front of
+    # whoever dispatched it, and -- once a workflow also runs on `pull_request` --
+    # a PR failure is visible in that PR's checks. Filing an issue for either is
+    # noise; the silent trigger is the one that needs it.
+    if: >-
+      always()
+      && (needs.stress-tests.result == 'failure' || needs.stress-tests.result == 'cancelled')
+      && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    # The only write access in this workflow, scoped to the one job that writes.
+    permissions:
+      contents: read
+      issues: write
+    # A checkout and three `gh` calls; minutes here mean stuck, not busy.
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Report failure
+        uses: ./.github/actions/report-cron-failure
+        with:
+          token: ${{ github.token }}


### PR DESCRIPTION
## Summary

A failing cron notifies nobody. GitHub emails only the person who last touched the workflow file — private, easy to filter, invisible to the rest of the team. `miri.yml` failed on **every one of its 13 runs** over two weeks and that surfaced nowhere. It was found by chance, by manually dispatching the workflow for an unrelated reason.

This adds a composite action that opens a tracking issue when a scheduled workflow fails, wired into both crons as an `if: failure()` step.

## The dedupe is the point

A naive "file an issue on failure" would have produced fourteen issues for the outage above, which is just as easy to tune out as producing none — the same silence reached by a different route.

So: one open issue per workflow, reused. The first failure files it; every subsequent failure comments on it. The comment count then reads as *how long this has been broken*. Closing the issue once the workflow is green means the next failure opens a fresh one.

Matching is on the exact issue title (`Scheduled workflow failing: <name>`) rather than `gh`'s full-text `--search`, which would also match issues that merely mention the workflow — and would let the two crons adopt each other's issue.

## Scope

Both cron workflows, not just the broken one. `stress.yml` has the identical blind spot; it has simply been green every day so far, so its blind spot is untested rather than absent.

## Permissions

Both workflows gain `issues: write`, used only by the reporting step. Neither writes to repository contents, and `persist-credentials: false` on checkout is unchanged — the step authenticates `gh` through `github.token` in the environment, not through git credentials.

The `ci-failure` label is created on demand inside the action (idempotent, failure tolerated), so this needs no out-of-band setup and no manual step before the first failure can be reported.

No third-party action is introduced — `gh` and `jq` are both preinstalled on GitHub-hosted runners, so there is nothing new to pin by commit hash.

## Verification

The failure path is the one that never runs in normal operation, which is exactly how the original bug survived, so I tested it directly rather than by inspection. I extracted the action's script and ran it against a stubbed `gh` across three cases:

| Case | Expected | Result |
|---|---|---|
| No open issue with the label | file a new issue | 1 create, 0 comments |
| Open issue with this workflow's exact title | comment, don't duplicate | 1 comment on that issue, 0 creates |
| Open issue with the *other* workflow's title | file its own issue | 1 create |

Also confirmed the issue body renders flush-left — indented heredoc content would have turned the whole body into a Markdown code block.

## What this does not solve

`miri.yml` failed on its very first run, so there was never a green baseline to regress from. Notification would have caught it on day one, which is enough here. But nothing automatable enforces "confirm a new gate actually passes before trusting it" — that stays a review-time habit.

## Related

- #701 fixes the underlying `miri.yml` failure. The two PRs touch different regions of that file and should not conflict.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: command output changes: yes, issue reporting is pinned by exact workflow-title matching; `unsafe`: none, CLAUDE.md allowlist: unchanged; memory, queue, and thread/backpressure policy: none.

Fix: The composite action reports scheduled `miri.yml` and `stress.yml` failures through one open tracking issue per workflow. It creates the `ci-failure` label when needed, comments on an existing exact-title issue, or creates a new issue after closure. Both workflows now grant `issues: write`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->