### PR TITLE
feat(cli): accept on/off/1/0 for boolean flags via BoolishValueParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- Boolean command-line flags now additionally accept `on`, `off`, `1`, and `0`, alongside the
+  existing `true`/`false`/`yes`/`no`/`y`/`n`/`t`/`f`. All spellings remain case-insensitive, and
+  values outside that set are still rejected.
+- Boolean command-line flags now render a `true|false` placeholder in help, so `fgumi filter -h`
+  shows `--memory-per-thread [<true|false>]` rather than `--memory-per-thread
+  [<MEMORY_PER_THREAD>]`, which read as a request for a per-thread memory size.
+
 ## [0.5.0] - 2026-07-28
 
 ### Bug Fixes

--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -35,7 +35,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use super::command::Command;
 use super::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
-    build_pipeline_config, parse_bool,
+    build_pipeline_config,
 };
 
 /// Clips reads in a BAM file to remove overlaps
@@ -91,18 +91,19 @@ pub struct Clip {
     pub clipping_mode: ClippingMode,
 
     /// Clip overlapping read pairs
-    #[arg(long = "clip-overlapping-reads", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "clip-overlapping-reads", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub clip_overlapping_reads: bool,
 
     /// Clip reads that extend past their mate's start position
     #[arg(
         long = "clip-bases-past-mate",
         alias = "clip-extending-past-mate",
+        value_name = "true|false",
         default_value = "false",
         num_args = 0..=1,
         default_missing_value = "true",
         action = clap::ArgAction::Set,
-        value_parser = parse_bool,
+        value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true,
     )]
     pub clip_extending_past_mate: bool,
 
@@ -123,11 +124,11 @@ pub struct Clip {
     pub read_two_three_prime: usize,
 
     /// Upgrade existing clipping to the specified clipping mode
-    #[arg(short = 'H', long = "upgrade-clipping", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(short = 'H', long = "upgrade-clipping", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub upgrade_clipping: bool,
 
     /// Automatically clip extended attributes that match read length
-    #[arg(short = 'a', long = "auto-clip-attributes", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(short = 'a', long = "auto-clip-attributes", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub auto_clip_attributes: bool,
 
     /// Output file for clipping metrics (only produced by the single-threaded path; cannot be

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -629,11 +629,11 @@ pub struct ConsensusCallingOptions {
     /// Produce per-base tags (cd, ce) in addition to per-read tags. The default (true) matches
     /// fgbio, which always writes per-base tags; setting this to false drops per-base tags that
     /// fgbio emits unconditionally.
-    #[arg(short = 'B', long = "output-per-base-tags", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(short = 'B', long = "output-per-base-tags", value_name = "true|false", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub output_per_base_tags: bool,
 
     /// Quality-trim reads before consensus calling (removes low-quality bases from ends)
-    #[arg(long = "trim", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "trim", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub trim: bool,
 
     /// Minimum consensus base quality (output consensus bases below this are masked to N). The
@@ -760,7 +760,7 @@ impl Default for ReadGroupOptions {
 #[derive(Debug, Clone, Args)]
 pub struct OverlappingConsensusOptions {
     /// Consensus call overlapping bases in read pairs before UMI consensus calling
-    #[arg(long = "consensus-call-overlapping-bases", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "consensus-call-overlapping-bases", value_name = "true|false", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub consensus_call_overlapping_bases: bool,
 }
 
@@ -853,7 +853,7 @@ pub struct AllowUnmappedOptions {
     /// all secondary/supplementary alignments — are dropped before consensus
     /// calling. Enable for consensus on unmapped input (e.g. ribosome/protein
     /// display), mirroring `fgumi group --allow-unmapped`.
-    #[arg(long = "allow-unmapped", value_name = "ALLOW_UNMAPPED", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "allow-unmapped", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub enabled: bool,
 }
 
@@ -878,7 +878,7 @@ pub struct SchedulerOptions {
     ///
     /// Shows per-step timing, throughput, contention metrics, and
     /// per-thread work distribution.
-    #[arg(long = "pipeline-stats", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool, hide = true)]
+    #[arg(long = "pipeline-stats", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true, hide = true)]
     pub pipeline_stats: bool,
 
     /// Timeout in seconds for deadlock detection (default: 10, 0 = disabled).
@@ -892,7 +892,7 @@ pub struct SchedulerOptions {
     ///
     /// Uses progressive doubling: 2x -> 4x -> unbind, with restoration
     /// after 30s of sustained progress.
-    #[arg(long = "deadlock-recover", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool, hide = true)]
+    #[arg(long = "deadlock-recover", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true, hide = true)]
     pub deadlock_recover: bool,
 }
 
@@ -1200,7 +1200,7 @@ pub struct QueueMemoryOptions {
     /// When enabled (default), --max-memory is per thread, so total memory =
     /// `max_memory` × threads. Disable for a fixed total budget regardless of
     /// thread count (recommended on fixed-RAM hosts).
-    #[arg(long = "memory-per-thread", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "memory-per-thread", value_name = "true|false", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub memory_per_thread: bool,
 }
 
@@ -1346,16 +1346,6 @@ pub(crate) fn is_r1_genomically_earlier_raw(r1: &[u8], r2: &[u8]) -> bool {
         return r1_pos < r2_pos;
     }
     (RawRecordView::new(r1).flags() & fgumi_raw_bam::flags::REVERSE) == 0
-}
-
-/// Parses a boolean value from a string, accepting: true/false, yes/no, y/n, t/f
-/// (case-insensitive). Matches sopt/fgbio behavior.
-pub(crate) fn parse_bool(s: &str) -> Result<bool, String> {
-    match s.to_ascii_lowercase().as_str() {
-        "true" | "t" | "yes" | "y" => Ok(true),
-        "false" | "f" | "no" | "n" => Ok(false),
-        _ => Err(format!("Invalid boolean value '{s}'. Expected: true|false|yes|no|y|n|t|f")),
-    }
 }
 
 // Re-export from the library crate for backward compatibility.
@@ -2286,50 +2276,57 @@ mod tests {
         assert_eq!(cmd.queue_memory.max_memory, expected);
     }
 
+    /// The accepted boolean spellings, asserted through the CLI rather than a
+    /// parser function, so the test survives a change of parser.
+    ///
+    /// `on`/`off`/`1`/`0` are accepted since the switch to clap's
+    /// `BoolishValueParser`; they were rejected by the previous hand-rolled
+    /// `parse_bool`, and the cases below moved up from the rejected table.
     #[rstest]
-    #[case("true", true)]
-    #[case("false", false)]
-    #[case("yes", true)]
-    #[case("no", false)]
-    #[case("t", true)]
-    #[case("f", false)]
-    #[case("y", true)]
-    #[case("n", false)]
-    #[case("True", true)]
-    #[case("TRUE", true)]
-    #[case("False", false)]
-    #[case("FALSE", false)]
-    #[case("Yes", true)]
-    #[case("YES", true)]
-    #[case("No", false)]
-    #[case("NO", false)]
-    #[case("T", true)]
-    #[case("F", false)]
-    #[case("Y", true)]
-    #[case("N", false)]
-    #[case("tRuE", true)]
-    #[case("fAlSe", false)]
-    #[case("yEs", true)]
-    fn test_parse_bool_valid(#[case] input: &str, #[case] expected: bool) {
-        assert_eq!(parse_bool(input).expect("should parse"), expected);
+    #[case::lower_true("true", true)]
+    #[case::lower_false("false", false)]
+    #[case::yes("yes", true)]
+    #[case::no("no", false)]
+    #[case::t("t", true)]
+    #[case::f("f", false)]
+    #[case::y("y", true)]
+    #[case::n("n", false)]
+    #[case::on("on", true)]
+    #[case::off("off", false)]
+    #[case::one("1", true)]
+    #[case::zero("0", false)]
+    #[case::mixed_case_true("TrUe", true)]
+    #[case::upper_false("FALSE", false)]
+    #[case::upper_yes("YES", true)]
+    #[case::mixed_case_no("No", false)]
+    #[case::upper_on("ON", true)]
+    #[case::mixed_case_off("oFf", false)]
+    fn bool_flag_accepts_spelling(#[case] value: &str, #[case] expected: bool) {
+        let cmd = TestBoolFlags::try_parse_from(["test", "--memory-per-thread", value])
+            .expect("boolean spelling should be accepted");
+        assert_eq!(cmd.queue_memory.memory_per_thread, expected);
     }
 
+    /// Anything outside that set is still rejected -- the parser widens what is
+    /// accepted, it does not fall back to `true` for unrecognized input.
     #[rstest]
-    #[case("")]
-    #[case("tru")]
-    #[case("fals")]
-    #[case("truee")]
-    #[case("noo")]
-    #[case("yess")]
-    #[case("maybe")]
-    #[case("0")]
-    #[case("1")]
-    #[case("on")]
-    #[case("off")]
-    #[case(" true")]
-    #[case("true ")]
-    fn test_parse_bool_invalid(#[case] input: &str) {
-        assert!(parse_bool(input).is_err(), "expected error for input: {input:?}");
+    #[case::empty("")]
+    #[case::truncated_true("tru")]
+    #[case::truncated_false("fals")]
+    #[case::overlong_true("truee")]
+    #[case::overlong_no("noo")]
+    #[case::overlong_yes("yess")]
+    #[case::not_a_bool("maybe")]
+    #[case::leading_space(" true")]
+    #[case::trailing_space("true ")]
+    #[case::numeric_two("2")]
+    #[case::negative_one("-1")]
+    #[case::size_suffix("10G")]
+    fn bool_flag_rejects_spelling(#[case] value: &str) {
+        assert!(
+            TestBoolFlags::try_parse_from(["test", "--memory-per-thread", value]).is_err(),
+            "expected rejection for input: {value:?}"
+        );
     }
 
     #[rstest]
@@ -2343,6 +2340,12 @@ mod tests {
     #[case(&["test", "--trim", "NO"], false)]
     #[case(&["test", "--trim=yes"], true)]
     #[case(&["test", "--trim=no"], false)]
+    // Accepted since the switch to clap's `BoolishValueParser`; these four
+    // moved up from the rejected table below.
+    #[case(&["test", "--trim", "on"], true)]
+    #[case(&["test", "--trim", "off"], false)]
+    #[case(&["test", "--trim", "1"], true)]
+    #[case(&["test", "--trim", "0"], false)]
     fn test_extended_bool_values_in_cli(#[case] args: &[&str], #[case] expected: bool) {
         let cmd = TestBoolFlags::try_parse_from(args).expect("valid CLI args should parse");
         assert_eq!(cmd.consensus.trim, expected);
@@ -2350,10 +2353,10 @@ mod tests {
 
     #[rstest]
     #[case(&["test", "--trim", "maybe"])]
-    #[case(&["test", "--trim", "0"])]
-    #[case(&["test", "--trim", "1"])]
-    #[case(&["test", "--trim", "on"])]
-    #[case(&["test", "--trim", "off"])]
+    #[case(&["test", "--trim", "2"])]
+    #[case(&["test", "--trim", "-1"])]
+    #[case(&["test", "--trim", "tru"])]
+    #[case(&["test", "--trim", "10G"])]
     fn test_extended_bool_values_in_cli_invalid(#[case] args: &[&str]) {
         assert!(TestBoolFlags::try_parse_from(args).is_err());
     }

--- a/src/lib/commands/compare/bams.rs
+++ b/src/lib/commands/compare/bams.rs
@@ -28,7 +28,6 @@ use std::path::PathBuf;
 use std::thread;
 
 use crate::commands::command::Command;
-use crate::commands::common::parse_bool;
 
 use super::engines::OpenedInput;
 use super::engines::content::ContentPredicate;
@@ -325,7 +324,7 @@ pub struct CompareBams {
     pub max_diffs: usize,
 
     /// Quiet mode - only exit code indicates result (0=equal, 1=different)
-    #[arg(short = 'q', long = "quiet", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(short = 'q', long = "quiet", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub quiet: bool,
 
     /// Ignore record order when comparing. Only valid with `--mode grouping`
@@ -336,7 +335,7 @@ pub struct CompareBams {
     /// backward compatibility.
     /// Overrides `--command` preset if both given. Defaults to false when
     /// neither `--ignore-order` nor `--command` is set.
-    #[arg(long = "ignore-order", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "ignore-order", value_name = "true|false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub ignore_order: Option<bool>,
 
     /// Initial buffer size for --ignore-order mode (number of records)

--- a/src/lib/commands/compare/metrics.rs
+++ b/src/lib/commands/compare/metrics.rs
@@ -32,7 +32,6 @@
 //! string equality.
 
 use crate::commands::command::Command;
-use crate::commands::common::parse_bool;
 use crate::commands::compare::engines::push_diff;
 use crate::logging::OperationTimer;
 use crate::validation::validate_file_exists;
@@ -130,11 +129,11 @@ pub struct CompareMetrics {
     /// Quiet mode - the exit code is the only result signal (0=equal, 1=different):
     /// suppresses the stdout report and this command's own informational logging. Global
     /// startup logging stays under `RUST_LOG` control (like fgbio's `--log-level`).
-    #[arg(short = 'q', long = "quiet", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(short = 'q', long = "quiet", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub quiet: bool,
 
     /// Verbose mode - print success message when files match
-    #[arg(short = 'v', long = "verbose", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(short = 'v', long = "verbose", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub verbose: bool,
 }
 

--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -90,8 +90,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, RejectsOptions, SchedulerOptions,
-    ThreadingOptions, build_pipeline_config, parse_bool, reject_colliding_outputs,
-    serialize_raw_bam_records,
+    ThreadingOptions, build_pipeline_config, reject_colliding_outputs, serialize_raw_bam_records,
 };
 
 /// Which SAM tag `correct` operates on.
@@ -293,11 +292,12 @@ pub struct CorrectUmis {
     #[arg(
         long = "dont-store-original",
         alias = "dont-store-original-umis",
+        value_name = "true|false",
         default_value = "false",
         num_args = 0..=1,
         default_missing_value = "true",
         action = clap::ArgAction::Set,
-        value_parser = parse_bool
+        value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true
     )]
     pub dont_store_original_umis: bool,
 
@@ -310,7 +310,7 @@ pub struct CorrectUmis {
     pub min_corrected: Option<f64>,
 
     /// Reverse complement UMIs before matching.
-    #[arg(long, default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long, value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub revcomp: bool,
 
     /// Threading options for parallel processing.

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -53,7 +53,7 @@ use serde::{Deserialize, Serialize};
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
-    build_pipeline_config, is_r1_genomically_earlier_raw, parse_bool,
+    build_pipeline_config, is_r1_genomically_earlier_raw,
 };
 use crate::sam::TC_TAG;
 use fgumi_raw_bam;
@@ -1082,7 +1082,7 @@ pub struct MarkDuplicates {
     pub family_size_histogram: Option<PathBuf>,
 
     /// Remove duplicates instead of just marking them
-    #[arg(short = 'r', long = "remove-duplicates", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(short = 'r', long = "remove-duplicates", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub remove_duplicates: bool,
 
     /// Minimum mapping quality for a read to be included
@@ -1090,14 +1090,14 @@ pub struct MarkDuplicates {
     pub min_map_q: Option<u8>,
 
     /// Include reads flagged as not passing QC
-    #[arg(short = 'n', long = "include-non-pf-reads", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(short = 'n', long = "include-non-pf-reads", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub include_non_pf_reads: bool,
 
     /// Emit templates with no mapped read (both mates unmapped) untouched instead of
     /// discarding them. Such templates carry no alignment coordinate and no duplicate
     /// signal; passing them through preserves a complete record set (like Picard
     /// `MarkDuplicates`). Truncated/corrupt records are still dropped.
-    #[arg(long = "include-unmapped", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "include-unmapped", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub include_unmapped: bool,
 
     /// UMI grouping strategy
@@ -1136,7 +1136,7 @@ pub struct MarkDuplicates {
     /// this mode, so F1R2 and F2R1 at the same coordinates are one molecule, matching
     /// Picard `MarkDuplicates`. Library and cell barcode still partition the grouping key
     /// (see "Grouping key" in --help).
-    #[arg(long = "no-umi", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "no-umi", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub no_umi: bool,
 
     /// Scheduler and pipeline options

--- a/src/lib/commands/downsample.rs
+++ b/src/lib/commands/downsample.rs
@@ -23,9 +23,7 @@ use std::io::Write;
 use std::path::PathBuf;
 
 use crate::commands::command::Command;
-use crate::commands::common::{
-    BamIoOptions, CompressionOptions, parse_bool, reject_colliding_outputs,
-};
+use crate::commands::common::{BamIoOptions, CompressionOptions, reject_colliding_outputs};
 
 /// Downsample a BAM file by UMI family using streaming.
 ///
@@ -88,7 +86,7 @@ pub struct Downsample {
     pub seed: Option<u64>,
 
     /// Validate that MI tags appear in consecutive groups (error if seen non-consecutively)
-    #[arg(long = "validate-mi-order", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "validate-mi-order", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub validate_mi_order: bool,
 
     /// Output file for kept family size histogram

--- a/src/lib/commands/duplex_metrics.rs
+++ b/src/lib/commands/duplex_metrics.rs
@@ -6,7 +6,6 @@
 //! - Ideal duplex fraction calculation using proper binomial CDF
 //! - Optional interval filtering (BED or Picard interval list format) to restrict analysis to specific regions
 
-use crate::commands::common::parse_bool;
 use crate::logging::OperationTimer;
 use crate::metrics::duplex::{DuplexMetricsCollector, DuplexYieldMetric, FamilySizeMetric};
 use crate::simple_umi_consensus::SimpleUmiConsensusCaller;
@@ -102,7 +101,7 @@ pub struct DuplexMetrics {
     pub min_ba_reads: usize,
 
     /// Collect duplex UMI counts (memory intensive)
-    #[arg(long = "duplex-umi-counts", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "duplex-umi-counts", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub duplex_umi_counts: bool,
 
     /// Optional intervals file to restrict analysis (BED or Picard interval list format)

--- a/src/lib/commands/fastq.rs
+++ b/src/lib/commands/fastq.rs
@@ -3,7 +3,6 @@
 //! This tool reads a BAM file and outputs interleaved FASTQ to stdout for piping to aligners.
 //! Input should be queryname-sorted or template-coordinate sorted.
 
-use crate::commands::common::parse_bool;
 use crate::logging::OperationTimer;
 use crate::sam::SamTag;
 use crate::validation::validate_input_exists;
@@ -102,7 +101,7 @@ pub struct Fastq {
     pub output: Option<PathBuf>,
 
     /// Don't append /1 and /2 to read names.
-    #[arg(short = 'n', long = "no-read-suffix", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(short = 'n', long = "no-read-suffix", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub no_suffix: bool,
 
     /// Exclude reads with any of these flags present [0x900 = secondary|supplementary].
@@ -126,7 +125,7 @@ pub struct Fastq {
     ///
     /// With the default delimiters this matches `samtools fastq -U`
     /// (`readname:AAAA+CCCC`), the layout DRAGEN expects.
-    #[arg(short = 'a', short_alias = 'U', long = "annotate-read-names", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(short = 'a', short_alias = 'U', long = "annotate-read-names", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub annotate_read_names: bool,
 
     /// Tags to read the UMI from, in priority order; the first present wins.

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -48,7 +48,7 @@ use std::time::Instant;
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
-    build_pipeline_config, parse_bool, reject_colliding_outputs, serialize_raw_bam_records,
+    build_pipeline_config, reject_colliding_outputs, serialize_raw_bam_records,
 };
 
 /// Filters and masks consensus reads based on various quality metrics.
@@ -155,7 +155,7 @@ pub struct Filter {
     pub max_no_call_fraction: f64,
 
     /// Reverse per-base tags for negative strand reads
-    #[arg(short = 'R', long = "reverse-per-base-tags", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(short = 'R', long = "reverse-per-base-tags", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub reverse_per_base_tags: bool,
 
     /// Threading options for parallel processing
@@ -163,7 +163,7 @@ pub struct Filter {
     pub threading: ThreadingOptions,
 
     /// Filter templates together (all primary reads must pass)
-    #[arg(long = "filter-by-template", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "filter-by-template", value_name = "true|false", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub filter_by_template: bool,
 
     /// Optional output BAM file for rejected reads
@@ -175,7 +175,7 @@ pub struct Filter {
     pub stats: Option<PathBuf>,
 
     /// Require single-strand agreement for duplex consensus (mask bases where AB and BA disagree)
-    #[arg(short = 's', long = "require-single-strand-agreement", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(short = 's', long = "require-single-strand-agreement", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub require_single_strand_agreement: bool,
 
     /// Minimum methylation depth (cu+ct) to keep a base call (EM-Seq/TAPs).
@@ -187,7 +187,7 @@ pub struct Filter {
     /// Require strand methylation agreement at CpG sites for duplex consensus (EM-Seq/TAPs).
     /// Masks both positions of a CpG dinucleotide when top and bottom strands disagree on
     /// methylation status. Requires --ref.
-    #[arg(long = "require-strand-methylation-agreement", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "require-strand-methylation-agreement", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub require_strand_methylation_agreement: bool,
 
     #[allow(clippy::doc_markdown)]

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -4,7 +4,7 @@ use crate::assigner::{PairedUmiAssigner, Strategy, UmiAssigner};
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
-    build_pipeline_config, is_r1_genomically_earlier_raw, parse_bool,
+    build_pipeline_config, is_r1_genomically_earlier_raw,
 };
 use crate::grouper::{
     FilterMetrics, ProcessedPositionGroup, RawPositionGroup, RecordPositionGrouper,
@@ -772,7 +772,7 @@ pub struct GroupReadsByUmi {
     pub min_map_q: Option<u8>,
 
     /// Include non-PF reads
-    #[arg(short = 'n', long = "include-non-pf-reads", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(short = 'n', long = "include-non-pf-reads", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub include_non_pf_reads: bool,
 
     /// Allow fully unmapped templates (both reads unmapped). Input must be
@@ -793,7 +793,7 @@ pub struct GroupReadsByUmi {
     /// For paired UMIs (e.g., "ACGT-TGCA"), edit distance is computed on the
     /// concatenated sequence with dashes removed (30 bases for 15bp-15bp UMIs).
     /// With --edits 1, only 1 mismatch is allowed across ALL bases.
-    #[arg(long = "allow-unmapped", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "allow-unmapped", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub allow_unmapped: bool,
 
     /// Enable the parallel UMI assigner for position groups with at least this
@@ -875,7 +875,7 @@ pub struct GroupReadsByUmi {
     /// Skip UMI-based grouping; group by template coordinate and strand of origin. Forces
     /// identity strategy and ignores any existing UMI tags. An F1R2 and an F2R1 template at
     /// the same coordinates therefore remain separate molecules.
-    #[arg(long = "no-umi", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "no-umi", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub no_umi: bool,
 
     /// Scheduler and pipeline statistics options.
@@ -888,7 +888,7 @@ pub struct GroupReadsByUmi {
 
     /// Enable comprehensive memory debugging (reports every 1 second)
     #[cfg(feature = "memory-debug")]
-    #[arg(long, default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long, value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub debug_memory: bool,
 
     /// Memory report interval in seconds (default: 1, minimum: 1)

--- a/src/lib/commands/review.rs
+++ b/src/lib/commands/review.rs
@@ -4,7 +4,6 @@
 //! raw reads to facilitate manual review of variant calls. It creates filtered
 //! BAM files and a detailed TSV report.
 
-use crate::commands::common::parse_bool;
 use crate::logging::OperationTimer;
 use crate::reference::find_dict_path;
 use crate::sam::SamTag;
@@ -171,7 +170,7 @@ pub struct Review {
     pub sample: Option<String>,
 
     /// Ignore N bases in consensus reads
-    #[arg(short = 'N', long = "ignore-ns", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(short = 'N', long = "ignore-ns", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub ignore_ns: bool,
 
     /// Only output detailed information for variants at or below this MAF

--- a/src/lib/commands/simulate/common.rs
+++ b/src/lib/commands/simulate/common.rs
@@ -1,7 +1,7 @@
 //! Shared CLI arguments and utilities for simulation commands.
 
 use crate::commands::common::{
-    MemoryLimit, MemoryReserve, MethylationModeArg, parse_bool, parse_memory, parse_memory_reserve,
+    MemoryLimit, MemoryReserve, MethylationModeArg, parse_memory, parse_memory_reserve,
     resolve_memory_budget,
 };
 use crate::commands::sort::{TMP_DIRS_ENV, resolve_tmp_dirs};
@@ -550,7 +550,7 @@ pub struct SortResourceArgs {
     /// Scale the memory limit by thread count (samtools behavior).
     ///
     /// When enabled (default), --max-memory specifies memory per thread.
-    #[arg(long = "memory-per-thread", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "memory-per-thread", value_name = "true|false", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub memory_per_thread: bool,
 
     /// Temporary directory for sort spill files. Repeatable.

--- a/src/lib/commands/simulate/consensus_reads.rs
+++ b/src/lib/commands/simulate/consensus_reads.rs
@@ -1,7 +1,7 @@
 //! Generate consensus BAM with tags for filter.
 
 use crate::commands::command::Command;
-use crate::commands::common::{CompressionOptions, parse_bool};
+use crate::commands::common::CompressionOptions;
 use crate::commands::simulate::common::{
     MethylationArgs, ReferenceGenome, StrandBiasArgs, join_writer_result,
 };
@@ -96,7 +96,7 @@ pub struct ConsensusReads {
     pub error_rate_stddev: f64,
 
     /// Generate duplex consensus tags (aD, bD, aM, bM, aE, bE)
-    #[arg(long = "duplex", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "duplex", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub duplex: bool,
 
     /// Base quality for consensus reads

--- a/src/lib/commands/simulate/fastq_reads.rs
+++ b/src/lib/commands/simulate/fastq_reads.rs
@@ -1,7 +1,6 @@
 //! Generate paired-end FASTQ files with UMI sequences.
 
 use crate::commands::command::Command;
-use crate::commands::common::parse_bool;
 use crate::commands::simulate::common::{
     FamilySizeArgs, InsertSizeArgs, MethylationArgs, MethylationConfig, QualityArgs,
     ReferenceGenome, SimulationCommon, apply_methylation_conversion, body_error_rng,
@@ -59,7 +58,7 @@ pub struct FastqReads {
     pub read_structure_r2: String,
 
     /// Generate duplex-style reads (A/B strand pairs)
-    #[arg(long = "duplex", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "duplex", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub duplex: bool,
 
     /// Reference FASTA file for sampling template sequences.

--- a/src/lib/commands/simulate/grouped_reads.rs
+++ b/src/lib/commands/simulate/grouped_reads.rs
@@ -6,7 +6,7 @@
 //! `samtools sort --template-coordinate`.
 
 use crate::commands::command::Command;
-use crate::commands::common::{CompressionOptions, parse_bool};
+use crate::commands::common::CompressionOptions;
 use crate::commands::simulate::common::{
     FamilySizeArgs, InsertSizeArgs, MethylationArgs, MethylationConfig, PositionDistArgs,
     QualityArgs, RecordSink, ReferenceArgs, ReferenceGenome, SimulationCommon, SortResourceArgs,
@@ -54,7 +54,7 @@ pub struct GroupedReads {
     pub truth_output: PathBuf,
 
     /// Generate duplex-style MI tags (e.g., "1/A", "1/B")
-    #[arg(long = "duplex", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "duplex", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub duplex: bool,
 
     /// Mapping quality for aligned reads

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -36,7 +36,7 @@ use std::path::PathBuf;
 
 use crate::commands::command::Command;
 use crate::commands::common::{
-    CompressionOptions, MemoryLimit, MemoryReserve, parse_bool, parse_memory, parse_memory_reserve,
+    CompressionOptions, MemoryLimit, MemoryReserve, parse_memory, parse_memory_reserve,
     resolve_memory_budget,
 };
 
@@ -212,7 +212,7 @@ pub struct Sort {
     /// Reads records sequentially and checks that each record's sort key
     /// is >= the previous record's key. Exits 0 if sorted correctly,
     /// non-zero if any records are out of order.
-    #[arg(long = "verify", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "verify", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub verify: bool,
 
     /// Sort order.
@@ -269,7 +269,7 @@ pub struct Sort {
     /// memory = `max_memory` × the larger of --threads and --sort-threads, since
     /// the sort phase is what fills the in-memory buffer. Disable for fixed total
     /// memory.
-    #[arg(long = "memory-per-thread", value_name = "true|false", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "memory-per-thread", value_name = "true|false", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub memory_per_thread: bool,
 
     /// Temporary directory for intermediate files. Repeatable.
@@ -374,7 +374,7 @@ pub struct Sort {
     /// `<output>.bai`. Output BGZF compression stays multi-threaded (scales
     /// with `--threads`); the BAI virtual offsets are recovered from each BGZF
     /// block as it finalizes, so indexing does not serialize compression.
-    #[arg(long = "write-index", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "write-index", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub write_index: bool,
 
     /// Enable async userspace prefetch on the input BAM.
@@ -859,8 +859,9 @@ mod tests {
         }
     }
 
-    /// Whether `arg` takes an optional value, the shape every `parse_bool` flag
-    /// on `Sort` uses (`num_args = 0..=1`, so a bare `--flag` means `true`).
+    /// Whether `arg` takes an optional value, the shape every
+    /// `BoolishValueParser` flag on `Sort` uses (`num_args = 0..=1`, so a bare
+    /// `--flag` means `true`).
     fn takes_optional_value(arg: &clap::Arg) -> bool {
         arg.get_num_args().is_some_and(|range| range.min_values() == 0 && range.max_values() == 1)
     }

--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -47,7 +47,7 @@
 //! - `TagInfo`: Holds sets of tags to remove/reverse/revcomp
 //! - `merge_raw()`: Core function that transfers metadata between templates using raw bytes
 use crate::commands::command::Command;
-use crate::commands::common::{CompressionOptions, parse_bool};
+use crate::commands::common::CompressionOptions;
 use crate::logging::OperationTimer;
 use crate::reference::{ReferenceReader, find_dict_path};
 use crate::sam::{SamTag, TemplateCoordinateInfo, check_sort};
@@ -186,7 +186,7 @@ pub struct Zipper {
 
     /// Exclude reads from the unmapped BAM that are not present in the aligned BAM.
     /// Useful when reads were intentionally removed (e.g., by adapter trimming) prior to alignment.
-    #[arg(long = "exclude-missing-reads", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "exclude-missing-reads", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub exclude_missing_reads: bool,
 
     /// Skip adding `tc` (template coordinate) tags to secondary/supplementary reads.
@@ -209,7 +209,7 @@ pub struct Zipper {
     /// secondary and supplementary reads come out with no `tc`, which is what
     /// `dedup` checks on those reads, so it rejects that output too — re-zipper
     /// without the flag.
-    #[arg(long = "skip-tc-tags", alias = "skip-pa-tags", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "skip-tc-tags", alias = "skip-pa-tags", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub skip_tc_tags: bool,
 
     /// Restore unconverted bases in EM-seq consensus reads after bwameth re-alignment.
@@ -222,7 +222,7 @@ pub struct Zipper {
     ///
     /// This produces a final BAM where the sequence shows the original (unconverted) bases,
     /// while methylation state is preserved in MM/ML tags and cu/ct count tags.
-    #[arg(long = "restore-unconverted-bases", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = parse_bool)]
+    #[arg(long = "restore-unconverted-bases", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub restore_unconverted_bases: bool,
 }
 


### PR DESCRIPTION
Follow-up to the question raised in #690: *should we prefer `BoolishValueParser`?*

## What changes

`parse_bool` is replaced by clap's [`BoolishValueParser`](https://docs.rs/clap/latest/clap/builder/struct.BoolishValueParser.html) at all 44 boolean `#[arg]` sites, and the function is deleted. Each of those 44 sites also gains `value_name = "true|false"`, extending repo-wide the convention #690 established for `Sort`'s three flags.

| | accepted (case-insensitive) |
|---|---|
| before | `true` `false` `yes` `no` `y` `n` `t` `f` |
| after | those, plus `on` `off` `1` `0` |

A strict superset, verified against `clap_builder-4.6.2`: `TRUE_LITERALS` and `FALSE_LITERALS` contain all eight previous spellings. Nothing that parsed before parses differently.

Unrecognized input is still **rejected**. Worth stating explicitly because clap's own doc comment on `str_to_bool` claims "Any other value will be considered as `true`" — that comment is wrong. The function returns `None`, and `BoolishValueParser::parse_ref` maps that to a validation error. Confirmed on the binary: `--memory-per-thread 10G` errors.

## The tradeoff, stated plainly

`parse_bool` documented itself as *"Matches sopt/fgbio behavior"*, so this deliberately diverges from sopt's accepted set — that is the one real consequence, and it is the point of the change rather than a side effect. The flags now take the spellings users coming from other CLIs reach for first.

The other cost named in #690 was the error message. Ours was `Invalid boolean value '10G'. Expected: true|false|yes|no|y|n|t|f`; clap's is `invalid value '10G' for '--memory-per-thread [<true|false>]': value was not a boolean`. Less enumerative, but it names the offending flag, which ours never did.

## `hide_possible_values` and the placeholder

These two are one decision, which is why the `value_name` sweep rides here rather than in a follow-up.

`BoolishValueParser::possible_values()` yields all twelve literals but marks ten hidden, so help would print `[possible values: true, false]` — advertising two of the twelve accepted spellings, which is worse than advertising none. Each site therefore sets `hide_possible_values = true`.

That suppression makes the placeholder the only in-help signal about what the flag takes, and without `value_name` clap derives it from the field name. `--memory-per-thread [<MEMORY_PER_THREAD>]` reads as a request for a per-thread memory size and invites `--memory-per-thread 10G`. #690 fixed that for the three flags on `Sort`; the remaining 41 were left rendering the derived name, so the *same* flag rendered two different ways depending on which command you asked — `QueueMemoryOptions::memory_per_thread` is flattened into `dedup`, `group`, `filter`, `clip`, `correct`, and the consensus callers. `--allow-unmapped` was worse still: it set `value_name = "ALLOW_UNMAPPED"` explicitly.

Verified on the built binary across `sort`, `filter`, `dedup`, `group`, `clip`, `correct`, and `simplex`: every one now renders `--memory-per-thread [<true|false>]`, no `[possible values: ...]` line appears anywhere, and no upper-snake placeholder survives on a boolean flag.

## Tests

The two rstest tables that called `parse_bool` directly now drive the same cases through `TestBoolFlags::try_parse_from`, asserting the CLI contract rather than a private function, so they survive another change of parser.

`on`/`off`/`1`/`0` **moved from the rejected table to the accepted one**. That migration is the behaviour change, made explicit rather than implied — a third table, `test_extended_bool_values_in_cli_invalid`, asserted those four were rejected, and it failed on the first run of this change exactly as it should have.

`test_bool_args_name_their_accepted_values` (added by #690) still guards `Sort` only, and it identifies boolean args by the structural proxy `num_args = 0..=1` rather than by their parser. Both are addressed in a follow-up PR stacked on this one: `Arg::get_possible_values()` now surfaces `BoolishValueParser`'s literal set, so the test can identify boolean args exactly and walk every command instead of `Sort`.

`cargo ci-fmt` / `ci-lint` clean.

## Note for the runall landing series

`feat-runall` and `main-runall` are deliberately **not** changed here. `main-runall` inherits this for `src/lib/commands/` on its next rebase, but two copies of `parse_bool` survive on that side and must not become the live parser — `crates/fgumi-cli-common/src/lib.rs:526` (landed by #672) and `crates/fgumi-sort-cli/src/sort.rs` (lands at P4). Both are recorded in the landing tracker's duplication ledger so the port converts them rather than reintroducing the function.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: command output changes: none; `unsafe` changes: none, and `CLAUDE.md` allowlist updates: none; memory bounds, queue capacity, and thread/backpressure policy changes: none.

Replaced the custom `parse_bool` parser at 44 CLI boolean argument sites with clap’s `BoolishValueParser`.

Boolean arguments now accept `true`, `false`, `yes`, `no`, `y`, `n`, `t`, `f`, `on`, `off`, `1`, and `0`. Invalid values remain rejected.

Standardized boolean help output with `value_name = "true|false"` and hidden possible values.

Updated CLI parsing tests for the expanded value set and invalid input. Formatting, lint, tests, and help rendering pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->