### PR TITLE
feat(sort)!: size the temp-file limit to the process fd budget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,6 +889,7 @@ dependencies = [
  "proptest",
  "rayon",
  "rstest",
+ "rustix",
  "tempfile",
  "zstd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,18 @@ noodles-csi = "0.56.0"
 parking_lot = "0.12"
 proptest = "1.10"
 rand = "0.10"
+# Chosen over the two syscall wrappers already in `fgumi-sort` on purpose:
+# `libc::getrlimit` is `unsafe` and the crate root is `#![deny(unsafe_code)]`,
+# and `nix` is scoped to `cfg(target_os = "linux")` there (its uses are
+# Linux-only APIs), so reaching for it would add a crate to macOS builds.
+# `rustix` is already compiled on every platform via `fs4` and `tempfile`, so it
+# costs nothing new. Declared here so the one member that calls it directly
+# cannot drift onto a different major version than those crates pull in. `std`
+# is named explicitly rather than inherited: it is on today only because `fs4`
+# and `tempfile` enable rustix's defaults, and a transitive change that stopped
+# doing so would break our build for reasons invisible in this file — the same
+# feature-unification trap documented on `flate2` above.
+rustix = { version = "1.1", default-features = false, features = ["std"] }
 rayon = "1.10"
 rstest = "0.26"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/fgumi-sort/Cargo.toml
+++ b/crates/fgumi-sort/Cargo.toml
@@ -39,6 +39,8 @@ zstd = "0.13"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+# `process` adds `getrlimit`, used by `fd_limit`. See the workspace entry.
+rustix = { workspace = true, features = ["process"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mach2 = { workspace = true }

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -2312,10 +2312,28 @@ impl RawExternalSorter {
     /// Returns the message rather than logging it so the threshold and the
     /// wording are assertable without a log capture; `merge_bams` emits it.
     fn fd_budget_warning(num_inputs: usize) -> Option<String> {
-        if crate::fd_limit::fits_fd_budget(num_inputs) {
+        // One reading of the budget answers both questions in the helper.
+        // Reading it per question would let the warning name a budget other
+        // than the one that tripped it.
+        Self::fd_budget_warning_from_nofile(crate::fd_limit::soft_nofile(), num_inputs)
+    }
+
+    /// [`Self::fd_budget_warning`] against a supplied budget rather than the
+    /// process's own.
+    ///
+    /// Split out for the reason `fd_limit::temp_file_limit_from_soft_nofile`
+    /// is: the arithmetic is then testable without the host's real
+    /// `RLIMIT_NOFILE` deciding the answer. Reading it inside made both tests
+    /// host-dependent — the silent case needs a soft limit of at least
+    /// `8 + FD_RESERVE`, so it failed under a `ulimit -n` below 40, and the
+    /// warning case only reached the branch because `usize::MAX` saturates the
+    /// comparison on a 64-bit target. The CLI's own `fd_budget_warning` already
+    /// takes the budget as a parameter; this makes the engine's match.
+    fn fd_budget_warning_from_nofile(soft: Option<u64>, num_inputs: usize) -> Option<String> {
+        if crate::fd_limit::fits_nofile_budget(soft, num_inputs) {
             return None;
         }
-        let budget = crate::fd_limit::soft_nofile().map_or_else(
+        let budget = soft.map_or_else(
             || "unknown".to_string(),
             |soft| soft.saturating_sub(crate::fd_limit::FD_RESERVE).to_string(),
         );
@@ -4708,26 +4726,65 @@ mod tests {
     }
 
     /// An ordinary merge width must not warn — every `fgumi merge` opens a
-    /// handful of inputs, so a warning there would be noise on every run.
-    #[test]
-    fn test_fd_budget_warning_is_silent_for_an_ordinary_merge() {
-        assert_eq!(RawExternalSorter::fd_budget_warning(8), None);
+    /// handful of inputs, so a warning there would be noise on every run —
+    /// while a merge past the budget must carry the two things that make the
+    /// warning actionable: how many inputs are being opened, and the
+    /// `ulimit -n` lever.
+    ///
+    /// The budget is supplied rather than read from the host, so every branch
+    /// is exercised on every target. Reading it made both assertions depend on
+    /// the machine: the silent case needs a soft limit of at least
+    /// `8 + FD_RESERVE` and failed under a `ulimit -n` below 40, and the
+    /// warning case reached its branch only because `usize::MAX` saturates the
+    /// comparison on a 64-bit target.
+    #[rstest]
+    #[case::ordinary_merge_fits(Some(1024), 8, None)]
+    // Exactly at the budget: 64 - FD_RESERVE is 32, and 32 inputs still fit.
+    #[case::exactly_at_the_budget(Some(64), 32, None)]
+    #[case::one_past_the_budget(Some(64), 33, Some(32))]
+    // A budget below the reserve saturates to zero, so any merge overruns it.
+    #[case::budget_below_the_reserve(Some(8), 1, Some(0))]
+    // Nothing to exceed where the limit cannot be read; silent by design.
+    #[case::unreadable_budget_never_warns(None, usize::MAX, None)]
+    fn test_fd_budget_warning_names_the_width_and_the_lever(
+        #[case] soft: Option<u64>,
+        #[case] num_inputs: usize,
+        #[case] expected_budget: Option<u64>,
+    ) {
+        let warning = RawExternalSorter::fd_budget_warning_from_nofile(soft, num_inputs);
+        match expected_budget {
+            None => assert_eq!(warning, None, "a merge within the budget must not warn"),
+            Some(budget) => {
+                let warning = warning.expect("a merge past the budget must warn");
+                assert!(
+                    warning.contains(&num_inputs.to_string()),
+                    "input count missing: {warning}"
+                );
+                assert!(
+                    warning.contains(&format!("budget of about {budget}")),
+                    "warning must name the budget it tripped: {warning}"
+                );
+                assert!(warning.contains("ulimit -n"), "remedy missing: {warning}");
+            }
+        }
     }
 
-    /// A merge wider than any descriptor budget must warn, and the warning has
-    /// to carry the two things that make it actionable: how many inputs are
-    /// being opened, and the `ulimit -n` lever. `usize::MAX` reaches the branch
-    /// regardless of this host's actual limit.
+    /// The production wrapper must be exactly the helper applied to the host's
+    /// own budget — the seam exists to make the arithmetic testable, not to let
+    /// the two paths answer differently.
     ///
-    /// Unix-only: where the descriptor budget cannot be read there is no budget
-    /// to exceed, and `fd_budget_warning` is silent by design.
+    /// Host-independent despite reading the real limit, because both sides read
+    /// the same one: whatever this machine reports, the answers must agree.
     #[test]
-    #[cfg(unix)]
-    fn test_fd_budget_warning_names_the_width_and_the_lever() {
-        let warning = RawExternalSorter::fd_budget_warning(usize::MAX)
-            .expect("a merge of usize::MAX inputs cannot fit any budget");
-        assert!(warning.contains(&usize::MAX.to_string()), "input count missing: {warning}");
-        assert!(warning.contains("ulimit -n"), "remedy missing: {warning}");
+    fn test_fd_budget_warning_reads_the_process_budget() {
+        let soft = crate::fd_limit::soft_nofile();
+        for num_inputs in [1_usize, 8, 1024, usize::MAX] {
+            assert_eq!(
+                RawExternalSorter::fd_budget_warning(num_inputs),
+                RawExternalSorter::fd_budget_warning_from_nofile(soft, num_inputs),
+                "wrapper and helper disagree at {num_inputs} inputs"
+            );
+        }
     }
 
     // ========================================================================

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -222,8 +222,11 @@ impl SortPhaseTimer {
     /// counts ([`RawExternalSorter::phase1_threads`] /
     /// [`RawExternalSorter::phase2_threads`]), not the configured `threads`
     /// they default from — the summary reports what the phases ran with.
+    ///
+    /// `max_temp_files` is reported so a run that consolidated says which limit
+    /// it consolidated against.
     #[allow(clippy::cast_precision_loss)]
-    fn log_summary(&self, sort_threads: usize, merge_threads: usize) {
+    fn log_summary(&self, sort_threads: usize, merge_threads: usize, max_temp_files: usize) {
         let overall = self.overall_start.map_or(0.0, |s| s.elapsed().as_secs_f64());
         // Guard against division by zero when sort completes in negligible time.
         let overall_nonzero = if overall > 0.0 { overall } else { f64::EPSILON };
@@ -246,7 +249,14 @@ impl SortPhaseTimer {
             let cons_secs = self.consolidate_secs;
             let cons_pct = 100.0 * cons_secs / overall_nonzero;
             let cons_count = self.consolidate_count;
-            info!("  Consolidation:     {cons_secs:.1}s ({cons_pct:.0}%) [{cons_count} merges]");
+            // Report the limit that triggered it: consolidation rewrites data
+            // that is already sorted, so a run that consolidated wants to know
+            // what it was up against. Reporting the number and not what to do
+            // about it keeps the recommendation with the caller that chose the
+            // limit -- the engine cannot know whether it was requested.
+            info!(
+                "  Consolidation:     {cons_secs:.1}s ({cons_pct:.0}%) [{cons_count} merges, limit {max_temp_files}]"
+            );
         }
         if self.merge_secs > 0.0 {
             let merge_secs = self.merge_secs;
@@ -584,9 +594,10 @@ impl LibraryLookup {
 /// Larger buffer reduces I/O latency impact during merge.
 const MERGE_PREFETCH_SIZE: usize = 1024;
 
-/// Maximum number of temp files before consolidation (like samtools).
-/// When this limit is reached, oldest files are merged to reduce file count.
-const DEFAULT_MAX_TEMP_FILES: usize = 64;
+// A bare `RawExternalSorter` keeps the fixed, portable `FALLBACK_MAX_TEMP_FILES`
+// as its consolidation limit. Sizing that limit to the process's soft
+// `RLIMIT_NOFILE` is a policy decision left to the caller, which opts in through
+// [`crate::fd_limit`] — `fgumi sort` does, `fgumi merge` and `fgumi simulate` do not.
 
 /// Working estimate of the raw BAM bytes per template-coordinate record (excluding the
 /// inline header and the `TemplateRecordRef<K>` index entry).  Used by the capacity
@@ -1768,7 +1779,7 @@ impl RawExternalSorter {
             spill_codec: crate::codec::SpillCodec::default(),
             write_index: false,
             pg_info: None,
-            max_temp_files: DEFAULT_MAX_TEMP_FILES,
+            max_temp_files: crate::fd_limit::FALLBACK_MAX_TEMP_FILES,
             cell_tag: None,
             initial_capacity: None,
             async_reader: false,
@@ -1932,7 +1943,10 @@ impl RawExternalSorter {
     ///
     /// When the number of temp files exceeds this limit, the oldest files
     /// are merged together to reduce the count. Set to 0 for unlimited.
-    /// Default is 64 (matching samtools).
+    ///
+    /// The default is a fixed, portable value. To size it to the host's
+    /// descriptor budget instead — which is what `fgumi sort` does — pass
+    /// [`resolve_temp_file_limit`](crate::resolve_temp_file_limit).
     #[must_use]
     pub fn max_temp_files(mut self, max: usize) -> Self {
         self.max_temp_files = max;
@@ -2677,7 +2691,7 @@ impl RawExternalSorter {
         if let Ok(pool) = Arc::try_unwrap(pool) {
             pool.shutdown();
         }
-        timer.log_summary(self.phase1_threads(), self.phase2_threads());
+        timer.log_summary(self.phase1_threads(), self.phase2_threads(), self.max_temp_files);
         debug!("Sort complete: {} records processed", stats.total_records);
 
         Ok(stats)
@@ -2868,7 +2882,7 @@ impl RawExternalSorter {
         if let Ok(pool) = Arc::try_unwrap(pool) {
             pool.shutdown();
         }
-        timer.log_summary(self.phase1_threads(), self.phase2_threads());
+        timer.log_summary(self.phase1_threads(), self.phase2_threads(), self.max_temp_files);
         debug!("Sort complete: {} records processed", stats.total_records);
 
         Ok(stats)
@@ -3138,7 +3152,7 @@ impl RawExternalSorter {
         if let Ok(pool) = Arc::try_unwrap(pool) {
             pool.shutdown();
         }
-        timer.log_summary(self.phase1_threads(), self.phase2_threads());
+        timer.log_summary(self.phase1_threads(), self.phase2_threads(), self.max_temp_files);
         debug!("Sort complete: {} records processed", stats.total_records);
 
         Ok(stats)
@@ -3463,7 +3477,7 @@ impl RawExternalSorter {
         if let Ok(pool) = Arc::try_unwrap(pool) {
             pool.shutdown();
         }
-        timer.log_summary(self.phase1_threads(), self.phase2_threads());
+        timer.log_summary(self.phase1_threads(), self.phase2_threads(), self.max_temp_files);
         debug!("Sort complete: {} records processed", stats.total_records);
 
         Ok(stats)
@@ -4583,7 +4597,10 @@ mod tests {
         assert_eq!(sorter.temp_compression, 1);
         assert!(!sorter.write_index);
         assert!(sorter.pg_info.is_none());
-        assert_eq!(sorter.max_temp_files, DEFAULT_MAX_TEMP_FILES);
+        // Fixed, not derived: a bare sorter must behave the same on every host.
+        // Deriving from `ulimit -n` is a decision the command line makes, not
+        // one the engine imposes on every embedder.
+        assert_eq!(sorter.max_temp_files, crate::fd_limit::FALLBACK_MAX_TEMP_FILES);
     }
 
     #[test]
@@ -6392,8 +6409,9 @@ mod tests {
         timer.time_write_output(|| Ok(())).expect("write ok");
         assert!(timer.write_output_secs >= 0.0);
 
-        // log_summary must not panic (output goes to log sink)
-        timer.log_summary(4, 4);
+        // log_summary must not panic (output goes to log sink). `consolidate_count`
+        // is 1 here, so the consolidation branch is exercised too.
+        timer.log_summary(4, 4, 64);
     }
 
     // ========================================================================

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -42,7 +42,7 @@ use fgumi_bam_io::ProgressTracker;
 use fgumi_bam_io::create_raw_bam_reader;
 use fgumi_bam_io::{is_stdin_path, is_stdout_path};
 use fgumi_raw_bam::SamTag;
-use log::{debug, info};
+use log::{debug, info, warn};
 use noodles::sam::Header;
 use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
 use noodles_bgzf::io::{
@@ -2294,6 +2294,38 @@ impl RawExternalSorter {
         }
     }
 
+    /// Warn when a merge is about to ask for more descriptors than the process
+    /// has.
+    ///
+    /// A merge opens every input at once, so its descriptor cost is the input
+    /// count — user-controlled, and not bounded by `max_temp_files`, which the
+    /// merge path never consults. Without this the failure surfaces as a bare
+    /// "Too many open files" naming one path, which reads like a problem with
+    /// that file rather than with the size of the merge.
+    ///
+    /// Warns rather than refuses: the reserve is deliberately conservative, so a
+    /// merge slightly over the estimate may still succeed, and refusing it would
+    /// turn a working command into a broken one. The subsequent open fails
+    /// immediately anyway — every reader is opened before any merging starts —
+    /// so nothing long-running is wasted either way.
+    ///
+    /// Returns the message rather than logging it so the threshold and the
+    /// wording are assertable without a log capture; `merge_bams` emits it.
+    fn fd_budget_warning(num_inputs: usize) -> Option<String> {
+        if crate::fd_limit::fits_fd_budget(num_inputs) {
+            return None;
+        }
+        let budget = crate::fd_limit::soft_nofile().map_or_else(
+            || "unknown".to_string(),
+            |soft| soft.saturating_sub(crate::fd_limit::FD_RESERVE).to_string(),
+        );
+        Some(format!(
+            "Merging {num_inputs} inputs opens {num_inputs} files at once, which exceeds this \
+             process's open file budget of about {budget}. Raise it with `ulimit -n`, or merge in \
+             stages, if this fails with \"Too many open files\"."
+        ))
+    }
+
     /// Merge multiple pre-sorted BAM files into a single sorted BAM.
     ///
     /// Each input BAM must already be sorted in the order specified by
@@ -2310,6 +2342,9 @@ impl RawExternalSorter {
         };
 
         debug!("Starting k-way merge of {} BAM files", inputs.len());
+        if let Some(warning) = Self::fd_budget_warning(inputs.len()) {
+            warn!("{warning}");
+        }
 
         let mut readers = Self::open_bam_prefetch_readers(inputs)?;
         let output_header = self.create_output_header(header);
@@ -4670,6 +4705,29 @@ mod tests {
     fn test_raw_sorter_max_temp_files() {
         let sorter = RawExternalSorter::new(SortOrder::Coordinate).max_temp_files(0);
         assert_eq!(sorter.max_temp_files, 0);
+    }
+
+    /// An ordinary merge width must not warn — every `fgumi merge` opens a
+    /// handful of inputs, so a warning there would be noise on every run.
+    #[test]
+    fn test_fd_budget_warning_is_silent_for_an_ordinary_merge() {
+        assert_eq!(RawExternalSorter::fd_budget_warning(8), None);
+    }
+
+    /// A merge wider than any descriptor budget must warn, and the warning has
+    /// to carry the two things that make it actionable: how many inputs are
+    /// being opened, and the `ulimit -n` lever. `usize::MAX` reaches the branch
+    /// regardless of this host's actual limit.
+    ///
+    /// Unix-only: where the descriptor budget cannot be read there is no budget
+    /// to exceed, and `fd_budget_warning` is silent by design.
+    #[test]
+    #[cfg(unix)]
+    fn test_fd_budget_warning_names_the_width_and_the_lever() {
+        let warning = RawExternalSorter::fd_budget_warning(usize::MAX)
+            .expect("a merge of usize::MAX inputs cannot fit any budget");
+        assert!(warning.contains(&usize::MAX.to_string()), "input count missing: {warning}");
+        assert!(warning.contains("ulimit -n"), "remedy missing: {warning}");
     }
 
     // ========================================================================

--- a/crates/fgumi-sort/src/fd_limit.rs
+++ b/crates/fgumi-sort/src/fd_limit.rs
@@ -37,7 +37,7 @@ pub const FALLBACK_MAX_TEMP_FILES: usize = 64;
 /// shares one input reader, spill files are written one at a time, and the
 /// temp-directory allocator holds paths rather than descriptors. 32 leaves
 /// substantial headroom over the observed peak.
-const FD_RESERVE: u64 = 32;
+pub(crate) const FD_RESERVE: u64 = 32;
 
 /// Smallest limit worth consolidating at.
 ///
@@ -199,5 +199,13 @@ mod tests {
     #[cfg(unix)]
     fn test_fits_fd_budget_rejects_an_oversized_explicit_limit() {
         assert!(!fits_fd_budget(usize::MAX));
+    }
+
+    /// `fits_fd_budget` is also the merge path's check, where the count is an
+    /// input-file count rather than a spill-file limit. A handful of inputs must
+    /// always pass, or every ordinary `fgumi merge` would warn.
+    #[test]
+    fn test_fits_fd_budget_accepts_an_ordinary_merge_width() {
+        assert!(fits_fd_budget(8));
     }
 }

--- a/crates/fgumi-sort/src/fd_limit.rs
+++ b/crates/fgumi-sort/src/fd_limit.rs
@@ -1,0 +1,203 @@
+//! Derivation of a spill-file consolidation limit from the process's file
+//! descriptor budget.
+//!
+//! The external sort consolidates spilled runs once their on-disk count reaches
+//! a limit, merging the oldest half into one. That limit exists to bound the
+//! number of descriptors held open at once: the final k-way merge opens *every*
+//! remaining spill file simultaneously, and consolidation itself opens half the
+//! limit. Consolidation is otherwise pure overhead — it rewrites data that is
+//! already sorted — so the limit should be as high as the process's descriptor
+//! budget genuinely allows, and no higher.
+//!
+//! This module is a **helper a caller opts into**, not a policy the engine
+//! applies. [`RawExternalSorter`](crate::RawExternalSorter) keeps a fixed,
+//! portable default so that an embedder who never thinks about the knob gets
+//! the same behaviour on every host; deciding to derive the limit from the
+//! environment instead belongs to whoever owns the command line. `fgumi sort`
+//! makes that decision, so its default is derived and every other sorter
+//! construction site is unaffected.
+//!
+//! Nothing here *raises* the descriptor limit. A process may raise its own soft
+//! limit to the hard limit without privileges, but `fgumi-sort` is a library and
+//! mutating a process-global resource limit is a side effect its host did not
+//! ask for.
+
+/// Limit used when the process descriptor limit cannot be read, or on a
+/// non-Unix target. Also the fixed default of a bare
+/// [`RawExternalSorter`](crate::RawExternalSorter).
+///
+/// Matches samtools' implementation, which is where fgumi's original hardcoded
+/// default came from.
+pub const FALLBACK_MAX_TEMP_FILES: usize = 64;
+
+/// Descriptors reserved for everything the sort holds open besides spill files.
+///
+/// At peak that is stdio (3), the input BAM, the output BAM and the optional
+/// index writer — roughly 7. Nothing scales with `--threads`: the worker pool
+/// shares one input reader, spill files are written one at a time, and the
+/// temp-directory allocator holds paths rather than descriptors. 32 leaves
+/// substantial headroom over the observed peak.
+const FD_RESERVE: u64 = 32;
+
+/// Smallest limit worth consolidating at.
+///
+/// Not the smallest value the consolidation path *accepts* (that is 2) but the
+/// smallest at which it still amortizes. At a limit of 2 every spill takes the
+/// run count to 2 and immediately merges both, rewriting the entire accumulated
+/// output once per spill — quadratic in the number of runs. A host whose
+/// descriptor budget cannot cover this floor cannot usefully sort a spilling
+/// BAM, and is better served by a loud `EMFILE` than by a silent hundredfold
+/// slowdown.
+const MIN_TEMP_FILES: usize = 16;
+
+// The floor must stay clear of the degenerate regime described above; a limit of
+// 2 or 3 merges on essentially every spill.
+const _: () = assert!(MIN_TEMP_FILES > 3, "floor must not sit in the quadratic regime");
+
+/// Ceiling on the derived limit.
+///
+/// Above this the limit stops binding on any realistic input: the largest
+/// workload measured spilled 88 runs at 1.33 billion records, and reaching the
+/// ceiling needs either a multi-terabyte input or a pathologically small
+/// `--max-memory`. Capping keeps a host with an unusually generous `ulimit -n`
+/// inside a merge width that has actually been tested, and bounds the per-file
+/// read-ahead buffers the merge allocates (a few MB each, none of which is
+/// charged against `--max-memory`).
+const MAX_DERIVED_TEMP_FILES: usize = 256;
+
+const _: () = assert!(MIN_TEMP_FILES <= MAX_DERIVED_TEMP_FILES);
+
+/// The process's soft `RLIMIT_NOFILE`, or `None` on a non-Unix target.
+///
+/// Exposed so a caller that derives its own limit can report which budget the
+/// number came from.
+#[must_use]
+pub fn soft_nofile() -> Option<u64> {
+    #[cfg(unix)]
+    {
+        // `getrlimit` is infallible for a valid resource. A `None` current value
+        // means no soft limit is enforced, which we treat as an enormous one and
+        // let the ceiling clamp.
+        let limit = rustix::process::getrlimit(rustix::process::Resource::Nofile);
+        Some(limit.current.unwrap_or(u64::MAX))
+    }
+    #[cfg(not(unix))]
+    {
+        None
+    }
+}
+
+/// Clamp a soft `RLIMIT_NOFILE` value to a usable consolidation limit.
+///
+/// Split from [`resolve_temp_file_limit`] so the arithmetic is testable without
+/// touching the process's real limits. Saturating throughout: a soft limit below
+/// the reserve yields the floor rather than underflowing, and `RLIM_INFINITY`
+/// (`u64::MAX`) yields the ceiling rather than overflowing.
+fn temp_file_limit_from_soft_nofile(soft: u64) -> usize {
+    let budget = usize::try_from(soft.saturating_sub(FD_RESERVE)).unwrap_or(usize::MAX);
+    budget.clamp(MIN_TEMP_FILES, MAX_DERIVED_TEMP_FILES)
+}
+
+/// A consolidation limit derived from the process's descriptor budget.
+///
+/// Falls back to [`FALLBACK_MAX_TEMP_FILES`] on a non-Unix target.
+///
+/// This is deliberately silent — see [`fits_fd_budget`] for the check a caller
+/// should warn on.
+///
+/// # Concurrency
+///
+/// The whole descriptor budget is assumed to be available to one sort. A host
+/// running several sorts concurrently in one process should divide the budget
+/// itself rather than calling this once per sort.
+#[must_use]
+pub fn resolve_temp_file_limit() -> usize {
+    soft_nofile().map_or(FALLBACK_MAX_TEMP_FILES, temp_file_limit_from_soft_nofile)
+}
+
+/// Whether `limit` spill files fit within the process's descriptor budget.
+///
+/// Deliberately independent of where `limit` came from: an explicitly requested
+/// limit can overrun the budget just as a derived one can, and in practice it is
+/// more likely to — [`resolve_temp_file_limit`] clamps to the budget, while a
+/// hardcoded value cannot. A caller that only checked derived limits would
+/// therefore skip the case most likely to fail.
+///
+/// Always true on a target where the limit cannot be read.
+#[must_use]
+pub fn fits_fd_budget(limit: usize) -> bool {
+    let Some(soft) = soft_nofile() else { return true };
+    u64::try_from(limit).is_ok_and(|limit| limit <= soft.saturating_sub(FD_RESERVE))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    /// The clamp is the whole contract: saturate at both ends, and never return
+    /// a value outside `[MIN_TEMP_FILES, MAX_DERIVED_TEMP_FILES]`.
+    #[rstest]
+    // A budget smaller than the reserve saturates to zero, then clamps up.
+    #[case::zero(0, MIN_TEMP_FILES)]
+    #[case::exactly_reserve(FD_RESERVE, MIN_TEMP_FILES)]
+    // Lower-clamp boundary: the first soft limit that clears the floor on its
+    // own merit, and the first that exceeds it.
+    #[case::at_floor(FD_RESERVE + MIN_TEMP_FILES as u64, MIN_TEMP_FILES)]
+    #[case::just_above_floor(FD_RESERVE + MIN_TEMP_FILES as u64 + 1, MIN_TEMP_FILES + 1)]
+    // A soft limit below the legacy hardcoded 64: the derived limit goes *down*,
+    // which is the safety half of deriving it at all.
+    #[case::below_legacy_default(64, 32)]
+    // The historical macOS default.
+    #[case::macos_default(256, 224)]
+    // A typical Linux container, clamped by the ceiling.
+    #[case::linux_container(1024, MAX_DERIVED_TEMP_FILES)]
+    // `RLIM_INFINITY` clamps rather than overflowing.
+    #[case::rlim_infinity(u64::MAX, MAX_DERIVED_TEMP_FILES)]
+    fn test_temp_file_limit_from_soft_nofile(#[case] soft: u64, #[case] expected: usize) {
+        assert_eq!(temp_file_limit_from_soft_nofile(soft), expected);
+    }
+
+    /// Whatever this host's `ulimit -n` happens to be, the resolved limit must
+    /// land in a range the consolidation path can act on.
+    ///
+    /// The expected range depends on whether the budget is readable at all, so
+    /// it is picked up front rather than folded into one disjunction: an
+    /// `||` whose right side never runs on a Unix host would leave the fallback
+    /// arm silently unasserted.
+    #[test]
+    fn test_resolve_temp_file_limit_is_in_range() {
+        let limit = resolve_temp_file_limit();
+        let expected = if soft_nofile().is_some() {
+            MIN_TEMP_FILES..=MAX_DERIVED_TEMP_FILES
+        } else {
+            FALLBACK_MAX_TEMP_FILES..=FALLBACK_MAX_TEMP_FILES
+        };
+        assert!(expected.contains(&limit), "resolved limit {limit} out of range {expected:?}");
+    }
+
+    /// A derived limit fits its own budget by construction, *except* when the
+    /// budget was too small to reach the floor — which is exactly the case the
+    /// caller must warn about.
+    ///
+    /// Unix-only: there is no budget to derive from, or fit inside, elsewhere.
+    #[test]
+    #[cfg(unix)]
+    fn test_resolved_limit_fits_unless_budget_is_below_the_floor() {
+        let soft = soft_nofile().expect("a Unix host always reports a soft limit");
+        let expected = soft.saturating_sub(FD_RESERVE) >= MIN_TEMP_FILES as u64;
+        assert_eq!(fits_fd_budget(temp_file_limit_from_soft_nofile(soft)), expected);
+    }
+
+    /// An explicit limit is checked against the budget on the same terms as a
+    /// derived one. This is the case that matters in practice: callers that pin
+    /// a large limit are the ones who can overrun the budget.
+    ///
+    /// Unix-only: with no readable budget nothing can overrun it, and
+    /// [`fits_fd_budget`] admits everything by design.
+    #[test]
+    #[cfg(unix)]
+    fn test_fits_fd_budget_rejects_an_oversized_explicit_limit() {
+        assert!(!fits_fd_budget(usize::MAX));
+    }
+}

--- a/crates/fgumi-sort/src/fd_limit.rs
+++ b/crates/fgumi-sort/src/fd_limit.rs
@@ -56,14 +56,34 @@ const _: () = assert!(MIN_TEMP_FILES > 3, "floor must not sit in the quadratic r
 
 /// Ceiling on the derived limit.
 ///
-/// Above this the limit stops binding on any realistic input: the largest
-/// workload measured spilled 88 runs at 1.33 billion records, and reaching the
-/// ceiling needs either a multi-terabyte input or a pathologically small
-/// `--max-memory`. Capping keeps a host with an unusually generous `ulimit -n`
-/// inside a merge width that has actually been tested, and bounds the per-file
-/// read-ahead buffers the merge allocates (a few MB each, none of which is
-/// charged against `--max-memory`).
-const MAX_DERIVED_TEMP_FILES: usize = 256;
+/// Set from a measured sweep of `--max-temp-files` against spilled-run counts of
+/// 86 / 173 / 346 / 692 on a 780M-record WGS BAM (8 threads, coordinate order),
+/// obtained by shrinking the total memory budget from 4 GiB to 512 MiB:
+///
+/// | spilled runs | consolidating (limit 64) | never consolidating | speedup |
+/// | --- | --- | --- | --- |
+/// | 86 | 789.8s | 596.4s | 1.32x |
+/// | 173 | 1540.8s | 607.1s | 2.54x |
+/// | 346 | 3026.1s | 619.7s | 4.88x |
+///
+/// Consolidation cost grows steeply because the number of passes is about
+/// `(runs - limit) / (limit / 2)` and each pass rewrites the whole accumulated
+/// output: at 346 runs it consumed 2440s of a 3026s sort, 80% of wall clock.
+/// A ceiling of 256 would cap the derived limit below the run count in the two
+/// deepest cells and re-impose exactly that cost, so it is set above the
+/// measured range rather than at it.
+///
+/// The competing cost is that each spill file open at the final merge carries
+/// per-file read-ahead not charged against `--max-memory`. Measured, that is far
+/// smaller than a naive per-file estimate suggests, because peak RSS is normally
+/// set by the phase-1 sort buffer and the merge's buffers land after that memory
+/// is released: widening 346 runs from consolidating to not cost +104 MB. It
+/// only bites at the smallest budgets, where phase 1 is too small to dominate --
+/// at 692 runs on a 512 MiB total budget, a 1024-wide merge reached 2309 MB
+/// against 1257 MB for a 256-wide one. Sizing phase-2 read-ahead as a total
+/// budget divided across files, rather than a per-file constant, would remove
+/// that and is the reason this is a ceiling rather than no cap at all.
+const MAX_DERIVED_TEMP_FILES: usize = 1024;
 
 const _: () = assert!(MIN_TEMP_FILES <= MAX_DERIVED_TEMP_FILES);
 
@@ -89,20 +109,38 @@ pub fn soft_nofile() -> Option<u64> {
 
 /// Clamp a soft `RLIMIT_NOFILE` value to a usable consolidation limit.
 ///
-/// Split from [`resolve_temp_file_limit`] so the arithmetic is testable without
-/// touching the process's real limits. Saturating throughout: a soft limit below
-/// the reserve yields the floor rather than underflowing, and `RLIM_INFINITY`
-/// (`u64::MAX`) yields the ceiling rather than overflowing.
+/// Split from [`temp_file_limit_from_nofile`] so the arithmetic is testable
+/// without touching the process's real limits. Saturating throughout: a soft
+/// limit below the reserve yields the floor rather than underflowing, and
+/// `RLIM_INFINITY` (`u64::MAX`) yields the ceiling rather than overflowing.
 fn temp_file_limit_from_soft_nofile(soft: u64) -> usize {
     let budget = usize::try_from(soft.saturating_sub(FD_RESERVE)).unwrap_or(usize::MAX);
     budget.clamp(MIN_TEMP_FILES, MAX_DERIVED_TEMP_FILES)
+}
+
+/// A consolidation limit derived from an already-taken [`soft_nofile`] reading.
+///
+/// Takes the snapshot rather than reading the limit itself, because a caller
+/// generally needs more than one answer about the same budget — the limit to
+/// hand the sorter, the budget to name in a log line, and whether the limit
+/// fits. Reading `RLIMIT_NOFILE` once per question lets those answers disagree
+/// if the limit changes in between, so the caller reads it once and derives
+/// all three from that one value.
+#[must_use]
+pub fn temp_file_limit_from_nofile(soft: Option<u64>) -> usize {
+    soft.map_or(FALLBACK_MAX_TEMP_FILES, temp_file_limit_from_soft_nofile)
 }
 
 /// A consolidation limit derived from the process's descriptor budget.
 ///
 /// Falls back to [`FALLBACK_MAX_TEMP_FILES`] on a non-Unix target.
 ///
-/// This is deliberately silent — see [`fits_fd_budget`] for the check a caller
+/// The convenience form, for a caller that wants only the number. A caller that
+/// also reports or checks the budget should take one [`soft_nofile`] reading and
+/// use [`temp_file_limit_from_nofile`] and [`fits_nofile_budget`] instead, so
+/// all three answers describe the same budget.
+///
+/// This is deliberately silent — see [`fits_nofile_budget`] for the check a caller
 /// should warn on.
 ///
 /// # Concurrency
@@ -112,21 +150,27 @@ fn temp_file_limit_from_soft_nofile(soft: u64) -> usize {
 /// itself rather than calling this once per sort.
 #[must_use]
 pub fn resolve_temp_file_limit() -> usize {
-    soft_nofile().map_or(FALLBACK_MAX_TEMP_FILES, temp_file_limit_from_soft_nofile)
+    temp_file_limit_from_nofile(soft_nofile())
 }
 
-/// Whether `limit` spill files fit within the process's descriptor budget.
+/// Whether `limit` open files fit within the descriptor budget `soft` describes.
 ///
 /// Deliberately independent of where `limit` came from: an explicitly requested
 /// limit can overrun the budget just as a derived one can, and in practice it is
-/// more likely to — [`resolve_temp_file_limit`] clamps to the budget, while a
-/// hardcoded value cannot. A caller that only checked derived limits would
+/// more likely to — [`temp_file_limit_from_nofile`] clamps to the budget, while
+/// a hardcoded value cannot. A caller that only checked derived limits would
 /// therefore skip the case most likely to fail.
 ///
-/// Always true on a target where the limit cannot be read.
+/// Takes a [`soft_nofile`] snapshot for the reason given on
+/// [`temp_file_limit_from_nofile`]: the limit being judged here was derived
+/// from a budget, and judging it against a second, independently-read budget is
+/// how the two come to disagree.
+///
+/// Always true when `soft` is `None`, i.e. on a target where the limit cannot
+/// be read.
 #[must_use]
-pub fn fits_fd_budget(limit: usize) -> bool {
-    let Some(soft) = soft_nofile() else { return true };
+pub fn fits_nofile_budget(soft: Option<u64>, limit: usize) -> bool {
+    let Some(soft) = soft else { return true };
     u64::try_from(limit).is_ok_and(|limit| limit <= soft.saturating_sub(FD_RESERVE))
 }
 
@@ -150,8 +194,11 @@ mod tests {
     #[case::below_legacy_default(64, 32)]
     // The historical macOS default.
     #[case::macos_default(256, 224)]
-    // A typical Linux container, clamped by the ceiling.
-    #[case::linux_container(1024, MAX_DERIVED_TEMP_FILES)]
+    // A typical Linux container: below the ceiling, so it passes through.
+    #[case::linux_container(1024, 992)]
+    // The limit actually observed on the AWS Batch hosts these run on, which is
+    // well above the ceiling and therefore clamps.
+    #[case::batch_host(65_536, MAX_DERIVED_TEMP_FILES)]
     // `RLIM_INFINITY` clamps rather than overflowing.
     #[case::rlim_infinity(u64::MAX, MAX_DERIVED_TEMP_FILES)]
     fn test_temp_file_limit_from_soft_nofile(#[case] soft: u64, #[case] expected: usize) {
@@ -186,26 +233,38 @@ mod tests {
     fn test_resolved_limit_fits_unless_budget_is_below_the_floor() {
         let soft = soft_nofile().expect("a Unix host always reports a soft limit");
         let expected = soft.saturating_sub(FD_RESERVE) >= MIN_TEMP_FILES as u64;
-        assert_eq!(fits_fd_budget(temp_file_limit_from_soft_nofile(soft)), expected);
+        assert_eq!(
+            fits_nofile_budget(Some(soft), temp_file_limit_from_soft_nofile(soft)),
+            expected
+        );
     }
 
     /// An explicit limit is checked against the budget on the same terms as a
     /// derived one. This is the case that matters in practice: callers that pin
     /// a large limit are the ones who can overrun the budget.
-    ///
-    /// Unix-only: with no readable budget nothing can overrun it, and
-    /// [`fits_fd_budget`] admits everything by design.
     #[test]
-    #[cfg(unix)]
-    fn test_fits_fd_budget_rejects_an_oversized_explicit_limit() {
-        assert!(!fits_fd_budget(usize::MAX));
+    fn test_fits_nofile_budget_rejects_an_oversized_explicit_limit() {
+        assert!(!fits_nofile_budget(Some(1024), usize::MAX));
     }
 
-    /// `fits_fd_budget` is also the merge path's check, where the count is an
-    /// input-file count rather than a spill-file limit. A handful of inputs must
-    /// always pass, or every ordinary `fgumi merge` would warn.
+    /// `fits_nofile_budget` is also the merge path's check, where the count is
+    /// an input-file count rather than a spill-file limit. A handful of inputs
+    /// must always pass, or every ordinary `fgumi merge` would warn.
     #[test]
-    fn test_fits_fd_budget_accepts_an_ordinary_merge_width() {
-        assert!(fits_fd_budget(8));
+    fn test_fits_nofile_budget_accepts_an_ordinary_merge_width() {
+        assert!(fits_nofile_budget(Some(1024), 8));
+    }
+
+    /// An unreadable budget admits everything, so a non-Unix host never warns.
+    #[test]
+    fn test_fits_nofile_budget_admits_everything_without_a_budget() {
+        assert!(fits_nofile_budget(None, usize::MAX));
+    }
+
+    /// An unreadable budget yields the portable fallback rather than a derived
+    /// number, which is the whole non-Unix contract.
+    #[test]
+    fn test_temp_file_limit_from_nofile_falls_back_without_a_budget() {
+        assert_eq!(temp_file_limit_from_nofile(None), FALLBACK_MAX_TEMP_FILES);
     }
 }

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -167,7 +167,10 @@ pub use external::{
     KeyTypesSpec, LibraryLookup, RawExternalSorter, cb_hasher, extract_template_key_inline,
     format_thread_counts,
 };
-pub use fd_limit::{FALLBACK_MAX_TEMP_FILES, fits_fd_budget, resolve_temp_file_limit, soft_nofile};
+pub use fd_limit::{
+    FALLBACK_MAX_TEMP_FILES, fits_nofile_budget, resolve_temp_file_limit, soft_nofile,
+    temp_file_limit_from_nofile,
+};
 pub use inline::{
     PackedCoordinateKey, RecordRef, TemplateKey, extract_coordinate_key_inline,
     radix_sort_record_refs, radix_sort_record_refs_with_max,

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -44,6 +44,7 @@ use tempfile::TempDir;
 pub(crate) mod bgzf_io;
 pub mod codec;
 pub(crate) mod external;
+pub(crate) mod fd_limit;
 pub(crate) mod inline;
 pub(crate) mod keys;
 pub(crate) mod loser_tree;
@@ -166,6 +167,7 @@ pub use external::{
     KeyTypesSpec, LibraryLookup, RawExternalSorter, cb_hasher, extract_template_key_inline,
     format_thread_counts,
 };
+pub use fd_limit::{FALLBACK_MAX_TEMP_FILES, fits_fd_budget, resolve_temp_file_limit, soft_nofile};
 pub use inline::{
     PackedCoordinateKey, RecordRef, TemplateKey, extract_coordinate_key_inline,
     radix_sort_record_refs, radix_sort_record_refs_with_max,

--- a/docs/src/guide/performance-tuning.md
+++ b/docs/src/guide/performance-tuning.md
@@ -363,10 +363,16 @@ Requested memory 16GB exceeds 90% of system memory (14.4GB)
 - `--max-memory` controls how much RAM is used for sort buffers; increase for large files to
   reduce the number of intermediate merge passes
 - `--max-temp-files` sets how many spilled runs may accumulate before the oldest are
-  consolidated into a single run (default 64, matching samtools). Consolidation is a
-  single-threaded merge pass, so on very large inputs raising this limit avoids repeated
-  consolidation passes at the cost of more open file descriptors during the final merge; the
-  output is unchanged. Must be at least 2
+  consolidated into a single run. The final k-way merge opens every remaining run at once, so
+  this limit is what bounds the sort's open file descriptors — and consolidation rewrites data
+  that is already sorted, making it pure overhead whenever the descriptor budget could have
+  carried the runs. When unset, `fgumi sort` sizes the limit to the process's soft open-file
+  limit (`ulimit -n`), less a reserve for the input, output and index handles, and capped at a
+  tested maximum. On a host with a low `ulimit -n`, raising it lets the sort avoid consolidation
+  entirely; a sort that consolidated reports the limit it hit in its phase-timing summary. Pass
+  an explicit value to override the sizing — if that value exceeds the open-file budget, the sort
+  says so at startup rather than failing partway through with "Too many open files". Must be at
+  least 2; the output is unchanged either way
 - For template-coordinate sort with single-cell data, the `CB` tag is included automatically
 - `--async-reader` is supported and can improve Phase 1 (input reading) throughput when disk
   latency is high or the OS page cache readahead is small

--- a/docs/src/guide/performance-tuning.md
+++ b/docs/src/guide/performance-tuning.md
@@ -366,13 +366,13 @@ Requested memory 16GB exceeds 90% of system memory (14.4GB)
   consolidated into a single run. The final k-way merge opens every remaining run at once, so
   this limit is what bounds the sort's open file descriptors — and consolidation rewrites data
   that is already sorted, making it pure overhead whenever the descriptor budget could have
-  carried the runs. When unset, `fgumi sort` sizes the limit to the process's soft open-file
-  limit (`ulimit -n`), less a reserve for the input, output and index handles, and capped at a
-  tested maximum. On a host with a low `ulimit -n`, raising it lets the sort avoid consolidation
+  carried the runs. The default, `auto`, sizes the limit to the process's soft open-file limit
+  (`ulimit -n`), less a reserve for the input, output and index handles, and capped at a tested
+  maximum. On a host with a low `ulimit -n`, raising it lets the sort avoid consolidation
   entirely; a sort that consolidated reports the limit it hit in its phase-timing summary. Pass
-  an explicit value to override the sizing — if that value exceeds the open-file budget, the sort
-  says so at startup rather than failing partway through with "Too many open files". Must be at
-  least 2; the output is unchanged either way
+  an explicit value (`--max-temp-files 64`) to pin it instead — if that value exceeds the
+  open-file budget, the sort says so at startup rather than failing partway through with "Too
+  many open files". Must be at least 2; the output is unchanged either way
 - For template-coordinate sort with single-cell data, the `CB` tag is included automatically
 - `--async-reader` is supported and can improve Phase 1 (input reading) throughput when disk
   latency is high or the OS page cache readahead is small

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -1022,6 +1022,22 @@ pub enum MemoryReserve {
     Fixed(usize),
 }
 
+/// How many spilled runs may accumulate before the oldest are consolidated.
+///
+/// Mirrors [`MemoryLimit`]: both are host-derived resource budgets, so both are
+/// spelled with an explicit `auto` rather than inferred from the flag's absence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaxTempFiles {
+    /// Size the limit to the process's open-file budget (`ulimit -n`).
+    Auto,
+    /// Use a fixed limit.
+    Fixed(usize),
+}
+
+/// The smallest temp-file limit a merge can act on: it needs at least two
+/// inputs to merge.
+pub(crate) const MIN_MAX_TEMP_FILES: usize = 2;
+
 /// The minimum per-thread memory budget (256 MiB).
 pub(crate) const MIN_MEMORY_PER_THREAD: usize = 256 * 1024 * 1024;
 
@@ -1046,6 +1062,25 @@ pub(crate) fn parse_memory(s: &str) -> Result<MemoryLimit, String> {
         return Ok(MemoryLimit::Auto);
     }
     Ok(MemoryLimit::Fixed(parse_memory_bytes(s, "Memory size")?))
+}
+
+/// Parse a max-temp-files string (e.g. "64", "auto").
+///
+/// Rejects values below [`MIN_MAX_TEMP_FILES`] at parse time rather than
+/// clamping them, so a caller who asks for something the merge cannot do is told
+/// so instead of silently getting a different limit.
+pub(crate) fn parse_max_temp_files(s: &str) -> Result<MaxTempFiles, String> {
+    let s = s.trim();
+    if s.eq_ignore_ascii_case("auto") {
+        return Ok(MaxTempFiles::Auto);
+    }
+    let limit: usize = s
+        .parse()
+        .map_err(|_| format!("invalid value '{s}': expected `auto` or a positive integer"))?;
+    if limit < MIN_MAX_TEMP_FILES {
+        return Err(format!("invalid value '{s}': must be at least {MIN_MAX_TEMP_FILES}"));
+    }
+    Ok(MaxTempFiles::Fixed(limit))
 }
 
 /// Parse a memory-reserve string (e.g. "10G", "auto").

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -36,8 +36,8 @@ use std::path::PathBuf;
 
 use crate::commands::command::Command;
 use crate::commands::common::{
-    CompressionOptions, MemoryLimit, MemoryReserve, parse_memory, parse_memory_reserve,
-    resolve_memory_budget,
+    CompressionOptions, MaxTempFiles, MemoryLimit, MemoryReserve, parse_max_temp_files,
+    parse_memory, parse_memory_reserve, resolve_memory_budget,
 };
 
 /// Sort order for BAM files.
@@ -154,10 +154,10 @@ PERFORMANCE:
   - Configurable temp file compression (--temp-compression)
   - Default 768M per-thread memory limit (samtools-compatible); pass
     `--max-memory auto` to detect system memory (opt-in)
-  - Spilled runs are consolidated once they reach `--max-temp-files`,
-    which defaults to a value derived from the process's open-file limit
-    (`ulimit -n`); consolidation rewrites already-sorted data, so raising
-    that limit avoids it on very large inputs
+  - Spilled runs are consolidated once they reach `--max-temp-files`
+    (default "auto": sized to the process's open-file limit, `ulimit -n`);
+    consolidation rewrites already-sorted data, so raising that limit
+    avoids it on very large inputs
 
 EXAMPLES:
 
@@ -365,12 +365,13 @@ pub struct Sort {
     /// open. Must be at least 2; to effectively disable consolidation, pass a
     /// value larger than the number of runs you expect to spill.
     ///
-    /// When unset, the limit is sized to the process's soft open-file limit
+    /// "auto" (default) sizes the limit to the process's soft open-file limit
     /// (`ulimit -n`), less a reserve for the input, output and index handles,
-    /// and capped at a tested maximum. Pass an explicit value to override that;
-    /// a value larger than the open-file budget is reported at startup.
-    #[arg(long = "max-temp-files", value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(2..))]
-    pub max_temp_files: Option<usize>,
+    /// and capped at a tested maximum. Explicit values like "64", "256" pin it;
+    /// a pinned value larger than the open-file budget is reported at startup.
+    /// Must be at least 2.
+    #[arg(long = "max-temp-files", default_value = "auto", value_parser = parse_max_temp_files)]
+    pub max_temp_files: MaxTempFiles,
 
     /// Write BAM index (.bai) alongside output.
     ///
@@ -585,7 +586,10 @@ impl Sort {
     /// resolved here and passed down. Resolving in one place keeps the number
     /// that gets logged identical to the number the engine is handed.
     fn resolved_max_temp_files(&self) -> usize {
-        self.max_temp_files.unwrap_or_else(fgumi_sort::resolve_temp_file_limit)
+        match self.max_temp_files {
+            MaxTempFiles::Auto => fgumi_sort::resolve_temp_file_limit(),
+            MaxTempFiles::Fixed(limit) => limit,
+        }
     }
 
     /// Parse the cell tag for template-coordinate sort/verify, returning `None`
@@ -593,7 +597,52 @@ impl Sort {
     fn parse_cell_tag(&self) -> Result<Option<SamTag>> {
         parse_cell_tag(self.order)
     }
+}
 
+/// The line naming the spill-file limit in force, for the run configuration log.
+///
+/// Returns the string rather than logging it so the wording — in particular
+/// whether the number was asked for, derived from a budget this line then names,
+/// or fell back to the portable default — is assertable without a log capture.
+fn max_temp_files_log_line(
+    setting: MaxTempFiles,
+    resolved: usize,
+    soft_nofile: Option<u64>,
+) -> String {
+    match (setting, soft_nofile) {
+        (MaxTempFiles::Fixed(_), _) => format!("Max temp files: {resolved}"),
+        (MaxTempFiles::Auto, Some(soft)) => {
+            format!("Max temp files: {resolved} (derived from RLIMIT_NOFILE soft limit {soft})")
+        }
+        (MaxTempFiles::Auto, None) => format!("Max temp files: {resolved} (default)"),
+    }
+}
+
+/// The warning for a spill-file limit that overruns the process's descriptor
+/// budget, or `None` when `resolved` fits.
+///
+/// Checked for explicit limits too, not just derived ones. A derived limit is
+/// clamped to the budget and can only fall short of it when the budget is below
+/// the floor; an explicit limit can overrun it outright, which makes it the case
+/// more likely to fail — so the advice names `--max-temp-files` only when the
+/// user actually set it, and otherwise points at `ulimit -n`, the only lever
+/// left.
+fn fd_budget_warning(setting: MaxTempFiles, resolved: usize) -> Option<String> {
+    if fgumi_sort::fits_fd_budget(resolved) {
+        return None;
+    }
+    let advice = if matches!(setting, MaxTempFiles::Fixed(_)) {
+        "lower --max-temp-files or raise the open file limit with `ulimit -n`"
+    } else {
+        "raise the open file limit with `ulimit -n`"
+    };
+    Some(format!(
+        "A spill-file limit of {resolved} exceeds this process's open file budget; \
+         {advice} if the sort fails with \"Too many open files\"."
+    ))
+}
+
+impl Sort {
     /// Execute sort mode: read, sort, and write output.
     fn execute_sort(&self, command_line: &str) -> Result<()> {
         let output = self.output.as_ref().expect("output required for sort mode");
@@ -667,27 +716,12 @@ impl Sort {
         );
         info!("Temp compression level: {}", self.temp_compression);
         let max_temp_files = self.resolved_max_temp_files();
-        match (self.max_temp_files, fgumi_sort::soft_nofile()) {
-            (Some(_), _) => info!("Max temp files: {max_temp_files}"),
-            (None, Some(soft)) => info!(
-                "Max temp files: {max_temp_files} (derived from RLIMIT_NOFILE soft limit {soft})"
-            ),
-            (None, None) => info!("Max temp files: {max_temp_files} (default)"),
-        }
-        // Checked for explicit limits too, not just derived ones. A derived
-        // limit is clamped to the budget and can only fall short of it when the
-        // budget is below the floor; an explicit limit can overrun it outright,
-        // which makes it the case more likely to fail.
-        if !fgumi_sort::fits_fd_budget(max_temp_files) {
-            let advice = if self.max_temp_files.is_some() {
-                "lower --max-temp-files or raise the open file limit with `ulimit -n`"
-            } else {
-                "raise the open file limit with `ulimit -n`"
-            };
-            warn!(
-                "A spill-file limit of {max_temp_files} exceeds this process's open file budget; \
-                 {advice} if the sort fails with \"Too many open files\"."
-            );
+        info!(
+            "{}",
+            max_temp_files_log_line(self.max_temp_files, max_temp_files, fgumi_sort::soft_nofile())
+        );
+        if let Some(warning) = fd_budget_warning(self.max_temp_files, max_temp_files) {
+            warn!("{warning}");
         }
         if self.write_index {
             info!("Write index: enabled");
@@ -1226,18 +1260,112 @@ mod tests {
         );
     }
 
-    /// `--max-temp-files` parses onto the struct and defaults to `None` (the
-    /// builder then applies the engine default).
+    /// `--max-temp-files` parses onto the struct and defaults to `auto`, which
+    /// is also spellable explicitly -- the point of the literal is that the
+    /// host-derived behaviour has a name rather than being the absence of a flag.
     #[rstest]
-    #[case::unset(&[], None)]
-    #[case::minimum(&["--max-temp-files", "2"], Some(2))]
-    #[case::explicit(&["--max-temp-files", "256"], Some(256))]
-    #[case::large(&["--max-temp-files", "100000"], Some(100_000))]
-    fn test_parse_max_temp_files(#[case] extra: &[&str], #[case] expected: Option<usize>) {
+    #[case::unset(&[], MaxTempFiles::Auto)]
+    #[case::auto(&["--max-temp-files", "auto"], MaxTempFiles::Auto)]
+    #[case::auto_mixed_case(&["--max-temp-files", "AUTO"], MaxTempFiles::Auto)]
+    #[case::minimum(&["--max-temp-files", "2"], MaxTempFiles::Fixed(2))]
+    #[case::explicit(&["--max-temp-files", "256"], MaxTempFiles::Fixed(256))]
+    #[case::large(&["--max-temp-files", "100000"], MaxTempFiles::Fixed(100_000))]
+    fn test_parse_max_temp_files(#[case] extra: &[&str], #[case] expected: MaxTempFiles) {
         let base = ["sort", "-i", "in.bam", "-o", "out.bam", "--order", "coordinate"];
         let args: Vec<&str> = base.iter().copied().chain(extra.iter().copied()).collect();
         let sort = Sort::try_parse_from(args).expect("parse should succeed");
         assert_eq!(sort.max_temp_files, expected);
+    }
+
+    /// The config log must say where the number came from, because the same
+    /// value means different things depending on its provenance: an explicit
+    /// limit is what the user asked for, a derived one is a function of a budget
+    /// the line then names, and the fallback is neither.
+    #[rstest]
+    #[case::fixed_omits_provenance(
+        MaxTempFiles::Fixed(256),
+        256,
+        Some(1024),
+        "Max temp files: 256"
+    )]
+    #[case::fixed_ignores_the_soft_limit(
+        MaxTempFiles::Fixed(256),
+        256,
+        None,
+        "Max temp files: 256"
+    )]
+    #[case::auto_names_the_budget_it_came_from(
+        MaxTempFiles::Auto,
+        992,
+        Some(1024),
+        "Max temp files: 992 (derived from RLIMIT_NOFILE soft limit 1024)"
+    )]
+    #[case::auto_without_a_readable_budget_is_the_default(
+        MaxTempFiles::Auto,
+        64,
+        None,
+        "Max temp files: 64 (default)"
+    )]
+    fn test_max_temp_files_log_line(
+        #[case] setting: MaxTempFiles,
+        #[case] resolved: usize,
+        #[case] soft_nofile: Option<u64>,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(max_temp_files_log_line(setting, resolved, soft_nofile), expected);
+    }
+
+    /// A limit that fits the descriptor budget must not warn, and one that
+    /// cannot must name the lever the user actually has: `--max-temp-files` only
+    /// when they set it, and `ulimit -n` either way.
+    ///
+    /// `usize::MAX` stands in for "cannot fit any budget" so the warning branch
+    /// is reached regardless of this host's `ulimit -n`; a merge-width limit of
+    /// 8 is below any budget that can run a sort at all, so it never warns.
+    ///
+    /// Unix-only: where the descriptor budget cannot be read there is no budget
+    /// to exceed, and `fd_budget_warning` is silent by design.
+    #[cfg(unix)]
+    #[rstest]
+    #[case::fits_when_explicit(MaxTempFiles::Fixed(8), 8, None)]
+    #[case::fits_when_derived(MaxTempFiles::Auto, 8, None)]
+    #[case::explicit_overrun_points_at_the_flag(
+        MaxTempFiles::Fixed(usize::MAX),
+        usize::MAX,
+        Some("lower --max-temp-files or raise the open file limit with `ulimit -n`")
+    )]
+    #[case::derived_overrun_points_only_at_ulimit(
+        MaxTempFiles::Auto,
+        usize::MAX,
+        Some("raise the open file limit with `ulimit -n`")
+    )]
+    fn test_fd_budget_warning(
+        #[case] setting: MaxTempFiles,
+        #[case] resolved: usize,
+        #[case] expected_advice: Option<&str>,
+    ) {
+        let warning = fd_budget_warning(setting, resolved);
+        match expected_advice {
+            None => assert_eq!(warning, None, "a limit within the budget must not warn"),
+            Some(advice) => {
+                let warning = warning.expect("an oversized limit must warn");
+                assert!(warning.contains(advice), "advice missing from: {warning}");
+                assert!(
+                    warning.contains(&format!("limit of {resolved}")),
+                    "warning must name the limit: {warning}"
+                );
+            }
+        }
+    }
+
+    /// The derived-overrun advice must not mention `--max-temp-files`: the user
+    /// never set it, so telling them to lower it is advice they cannot act on.
+    #[test]
+    #[cfg(unix)]
+    fn test_derived_overrun_advice_omits_the_flag_the_user_did_not_set() {
+        let warning = fd_budget_warning(MaxTempFiles::Auto, usize::MAX)
+            .expect("an oversized limit must warn");
+        assert!(!warning.contains("lower --max-temp-files"), "unexpected advice: {warning}");
     }
 
     /// Invalid values are rejected at parse time rather than silently clamped or
@@ -1271,16 +1399,19 @@ mod tests {
     /// against the engine's own default, which is deliberately a different
     /// (fixed) value now that the derivation lives in the command.
     #[rstest]
-    #[case::set(Some(256))]
-    #[case::unset(None)]
-    fn test_build_sorter_wires_max_temp_files(#[case] max_temp_files: Option<usize>) {
+    #[case::set(MaxTempFiles::Fixed(256), Some(256))]
+    #[case::auto(MaxTempFiles::Auto, None)]
+    fn test_build_sorter_wires_max_temp_files(
+        #[case] max_temp_files: MaxTempFiles,
+        #[case] expected: Option<usize>,
+    ) {
         let mut sort = make_sort(SortOrderArg::Coordinate);
         sort.max_temp_files = max_temp_files;
 
         let sorter = sort.build_sorter(512 * 1024 * 1024, "fgumi sort (test)");
         assert_eq!(
             sorter.temp_file_limit(),
-            max_temp_files.unwrap_or_else(fgumi_sort::resolve_temp_file_limit)
+            expected.unwrap_or_else(fgumi_sort::resolve_temp_file_limit)
         );
     }
 
@@ -1328,7 +1459,7 @@ mod tests {
 
         // 1 KiB memory forces spilling; `build_sorter` is the exact option ->
         // builder path `execute` uses, so this exercises the real wiring.
-        let run = |max_temp_files: Option<usize>, out: PathBuf| {
+        let run = |max_temp_files: MaxTempFiles, out: PathBuf| {
             let mut sort = make_sort(SortOrderArg::Coordinate);
             sort.input = input.clone();
             sort.output = Some(out.clone());
@@ -1349,8 +1480,9 @@ mod tests {
         };
 
         let (default_stats, default_records) =
-            run(Some(usize::MAX), dir.path().join("default.bam"));
-        let (limited_stats, limited_records) = run(Some(2), dir.path().join("limited.bam"));
+            run(MaxTempFiles::Fixed(usize::MAX), dir.path().join("default.bam"));
+        let (limited_stats, limited_records) =
+            run(MaxTempFiles::Fixed(2), dir.path().join("limited.bam"));
 
         // Precondition: the tiny budget really did spill multiple runs, so the
         // `Some(2)` run exercised consolidation rather than a trivial in-memory
@@ -1433,7 +1565,7 @@ mod tests {
             compression: CompressionOptions::default(),
             temp_compression: 1,
             temp_codec: fgumi_sort::SpillCodec::default(),
-            max_temp_files: None,
+            max_temp_files: MaxTempFiles::Auto,
             write_index: false,
             async_reader: false,
         }

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -31,7 +31,7 @@ use fgumi_sort::{
     KeyTypesSpec, QuerynameComparator, RawExternalSorter, SortOrder, verify_sort_order,
 };
 
-use log::{debug, info};
+use log::{debug, info, warn};
 use std::path::PathBuf;
 
 use crate::commands::command::Command;
@@ -154,9 +154,10 @@ PERFORMANCE:
   - Configurable temp file compression (--temp-compression)
   - Default 768M per-thread memory limit (samtools-compatible); pass
     `--max-memory auto` to detect system memory (opt-in)
-  - Spilled runs are consolidated once they reach `--max-temp-files`
-    (default 64, matching samtools); raise it to avoid repeated
-    consolidation passes on very large inputs
+  - Spilled runs are consolidated once they reach `--max-temp-files`,
+    which defaults to a value derived from the process's open-file limit
+    (`ulimit -n`); consolidation rewrites already-sorted data, so raising
+    that limit avoids it on very large inputs
 
 EXAMPLES:
 
@@ -353,14 +354,21 @@ pub struct Sort {
     ///
     /// Large inputs spill many sorted runs to disk. When the number of runs
     /// reaches this limit, the oldest are merged together in a single pass so
-    /// the final k-way merge opens fewer files at once. Raising it avoids
-    /// repeated consolidation passes on very large inputs (at the cost of more
-    /// open file descriptors during the final merge); lowering it keeps fewer
-    /// files open. Must be at least 2; to effectively disable consolidation,
-    /// pass a value larger than the number of runs you expect to spill.
+    /// the final k-way merge opens fewer files at once. That merge is the only
+    /// reason the limit exists: it opens every remaining run at once, so the
+    /// limit bounds how many file descriptors the sort needs.
     ///
-    /// When unset, a built-in default is used (see this command's help
-    /// overview for the default value).
+    /// Consolidation rewrites data that is already sorted, so it is pure
+    /// overhead whenever the descriptor budget could have carried the runs.
+    /// Raising this avoids it on very large inputs (at the cost of more open
+    /// file descriptors during the final merge); lowering it keeps fewer files
+    /// open. Must be at least 2; to effectively disable consolidation, pass a
+    /// value larger than the number of runs you expect to spill.
+    ///
+    /// When unset, the limit is sized to the process's soft open-file limit
+    /// (`ulimit -n`), less a reserve for the input, output and index handles,
+    /// and capped at a tested maximum. Pass an explicit value to override that;
+    /// a value larger than the open-file budget is reported at startup.
     #[arg(long = "max-temp-files", value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(2..))]
     pub max_temp_files: Option<usize>,
 
@@ -566,11 +574,18 @@ impl Sort {
         if let Some(n) = self.merge_threads {
             sorter = sorter.merge_threads(n);
         }
-        // Optional; falls back to the engine default when unset.
-        if let Some(n) = self.max_temp_files {
-            sorter = sorter.max_temp_files(n);
-        }
+        sorter = sorter.max_temp_files(self.resolved_max_temp_files());
         sorter
+    }
+
+    /// The spill-file consolidation limit this command will use.
+    ///
+    /// The engine's own default is a fixed, portable value; sizing it to the
+    /// host's descriptor budget is a decision the command line makes, so it is
+    /// resolved here and passed down. Resolving in one place keeps the number
+    /// that gets logged identical to the number the engine is handed.
+    fn resolved_max_temp_files(&self) -> usize {
+        self.max_temp_files.unwrap_or_else(fgumi_sort::resolve_temp_file_limit)
     }
 
     /// Parse the cell tag for template-coordinate sort/verify, returning `None`
@@ -651,6 +666,29 @@ impl Sort {
             fgumi_sort::format_thread_counts(sorter.phase1_threads(), sorter.phase2_threads())
         );
         info!("Temp compression level: {}", self.temp_compression);
+        let max_temp_files = self.resolved_max_temp_files();
+        match (self.max_temp_files, fgumi_sort::soft_nofile()) {
+            (Some(_), _) => info!("Max temp files: {max_temp_files}"),
+            (None, Some(soft)) => info!(
+                "Max temp files: {max_temp_files} (derived from RLIMIT_NOFILE soft limit {soft})"
+            ),
+            (None, None) => info!("Max temp files: {max_temp_files} (default)"),
+        }
+        // Checked for explicit limits too, not just derived ones. A derived
+        // limit is clamped to the budget and can only fall short of it when the
+        // budget is below the floor; an explicit limit can overrun it outright,
+        // which makes it the case more likely to fail.
+        if !fgumi_sort::fits_fd_budget(max_temp_files) {
+            let advice = if self.max_temp_files.is_some() {
+                "lower --max-temp-files or raise the open file limit with `ulimit -n`"
+            } else {
+                "raise the open file limit with `ulimit -n`"
+            };
+            warn!(
+                "A spill-file limit of {max_temp_files} exceeds this process's open file budget; \
+                 {advice} if the sort fails with \"Too many open files\"."
+            );
+        }
         if self.write_index {
             info!("Write index: enabled");
         }
@@ -1226,20 +1264,24 @@ mod tests {
         assert!(Sort::try_parse_from(args).is_err(), "--max-temp-files {value} must be rejected");
     }
 
-    /// The flag reaches the sorter: `Some(n)` sets the limit; `None` leaves the
-    /// engine default (read from a fresh sorter rather than hardcoded, so this
-    /// test does not pin fgumi's default number).
+    /// The flag reaches the sorter: `Some(n)` sets the limit; `None` resolves it
+    /// from the host's descriptor budget. Compared against
+    /// `resolve_temp_file_limit` rather than a hardcoded number so the test does
+    /// not pin a value that depends on the machine it runs on — and *not*
+    /// against the engine's own default, which is deliberately a different
+    /// (fixed) value now that the derivation lives in the command.
     #[rstest]
     #[case::set(Some(256))]
     #[case::unset(None)]
     fn test_build_sorter_wires_max_temp_files(#[case] max_temp_files: Option<usize>) {
-        let engine_default =
-            RawExternalSorter::new(SortOrderArg::Coordinate.into()).temp_file_limit();
         let mut sort = make_sort(SortOrderArg::Coordinate);
         sort.max_temp_files = max_temp_files;
 
         let sorter = sort.build_sorter(512 * 1024 * 1024, "fgumi sort (test)");
-        assert_eq!(sorter.temp_file_limit(), max_temp_files.unwrap_or(engine_default));
+        assert_eq!(
+            sorter.temp_file_limit(),
+            max_temp_files.unwrap_or_else(fgumi_sort::resolve_temp_file_limit)
+        );
     }
 
     /// The accessor test above only proves the flag reaches the builder. This
@@ -1247,11 +1289,17 @@ mod tests {
     /// never changes *what* is written: with a 1 KiB memory budget (no floor in
     /// `Fixed` mode) and enough records to spill many runs, `Some(2)` forces the
     /// consolidation merge to fire repeatedly (oldest runs are merged once their
-    /// count reaches the limit), while the default engine limit (64) never
+    /// count reaches the limit), while a limit far above the spill count never
     /// consolidates and merges every run in the final k-way pass. Both paths
     /// must emit the same records in the same order — this guards the
     /// consolidation path against a stable-order or record-loss regression the
     /// accessor test cannot catch.
+    ///
+    /// The control arm pins an explicit large limit rather than passing `None`.
+    /// The engine default is derived from the host's `ulimit -n`, so a `None`
+    /// control arm could itself consolidate on a low-limit machine, quietly
+    /// turning this into a consolidation-vs-consolidation comparison that still
+    /// passes while no longer testing what it claims.
     ///
     /// We compare decoded records rather than the raw BGZF bytes on purpose:
     /// the two write paths flush BGZF blocks at different points, so the
@@ -1300,7 +1348,8 @@ mod tests {
             (stats, records)
         };
 
-        let (default_stats, default_records) = run(None, dir.path().join("default.bam"));
+        let (default_stats, default_records) =
+            run(Some(usize::MAX), dir.path().join("default.bam"));
         let (limited_stats, limited_records) = run(Some(2), dir.path().join("limited.bam"));
 
         // Precondition: the tiny budget really did spill multiple runs, so the

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -557,7 +557,12 @@ impl Sort {
     /// its own. That matters most for `--sort-threads` / `--merge-threads`:
     /// they only affect scheduling, so an end-to-end run cannot distinguish a
     /// correctly wired flag from one that was parsed and then dropped.
-    fn build_sorter(&self, effective_memory: usize, command_line: &str) -> RawExternalSorter {
+    fn build_sorter(
+        &self,
+        effective_memory: usize,
+        command_line: &str,
+        soft_nofile: Option<u64>,
+    ) -> RawExternalSorter {
         let mut sorter = RawExternalSorter::new(self.order.into())
             .memory_limit(effective_memory)
             .threads(self.threads)
@@ -575,7 +580,7 @@ impl Sort {
         if let Some(n) = self.merge_threads {
             sorter = sorter.merge_threads(n);
         }
-        sorter = sorter.max_temp_files(self.resolved_max_temp_files());
+        sorter = sorter.max_temp_files(self.resolved_max_temp_files(soft_nofile));
         sorter
     }
 
@@ -585,9 +590,9 @@ impl Sort {
     /// host's descriptor budget is a decision the command line makes, so it is
     /// resolved here and passed down. Resolving in one place keeps the number
     /// that gets logged identical to the number the engine is handed.
-    fn resolved_max_temp_files(&self) -> usize {
+    fn resolved_max_temp_files(&self, soft_nofile: Option<u64>) -> usize {
         match self.max_temp_files {
-            MaxTempFiles::Auto => fgumi_sort::resolve_temp_file_limit(),
+            MaxTempFiles::Auto => fgumi_sort::temp_file_limit_from_nofile(soft_nofile),
             MaxTempFiles::Fixed(limit) => limit,
         }
     }
@@ -627,8 +632,12 @@ fn max_temp_files_log_line(
 /// more likely to fail — so the advice names `--max-temp-files` only when the
 /// user actually set it, and otherwise points at `ulimit -n`, the only lever
 /// left.
-fn fd_budget_warning(setting: MaxTempFiles, resolved: usize) -> Option<String> {
-    if fgumi_sort::fits_fd_budget(resolved) {
+fn fd_budget_warning(
+    setting: MaxTempFiles,
+    resolved: usize,
+    soft_nofile: Option<u64>,
+) -> Option<String> {
+    if fgumi_sort::fits_nofile_budget(soft_nofile, resolved) {
         return None;
     }
     let advice = if matches!(setting, MaxTempFiles::Fixed(_)) {
@@ -677,9 +686,15 @@ impl Sort {
 
         let cell_tag = self.parse_cell_tag()?;
 
+        // One reading of the descriptor budget serves the whole run: the limit
+        // handed to the sorter, the budget named in the log line, and the check
+        // the warning makes all derive from this value, so they cannot describe
+        // different limits if `RLIMIT_NOFILE` changes mid-run.
+        let soft_nofile = fgumi_sort::soft_nofile();
+
         // Built before the config log so the log can report the sorter's own
         // effective per-phase thread counts.
-        let mut sorter = self.build_sorter(effective_memory, command_line);
+        let mut sorter = self.build_sorter(effective_memory, command_line, soft_nofile);
 
         debug!("Starting Sort");
         info!("Input: {}", self.input.display());
@@ -715,12 +730,12 @@ impl Sort {
             fgumi_sort::format_thread_counts(sorter.phase1_threads(), sorter.phase2_threads())
         );
         info!("Temp compression level: {}", self.temp_compression);
-        let max_temp_files = self.resolved_max_temp_files();
-        info!(
-            "{}",
-            max_temp_files_log_line(self.max_temp_files, max_temp_files, fgumi_sort::soft_nofile())
-        );
-        if let Some(warning) = fd_budget_warning(self.max_temp_files, max_temp_files) {
+        // Read off the sorter, like the thread counts above: it is the number
+        // the engine will actually consolidate at, so it cannot drift from what
+        // this line reports.
+        let max_temp_files = sorter.temp_file_limit();
+        info!("{}", max_temp_files_log_line(self.max_temp_files, max_temp_files, soft_nofile));
+        if let Some(warning) = fd_budget_warning(self.max_temp_files, max_temp_files, soft_nofile) {
             warn!("{warning}");
         }
         if self.write_index {
@@ -1104,7 +1119,8 @@ mod tests {
         sort.sort_threads = sort_threads;
         sort.merge_threads = merge_threads;
 
-        let sorter = sort.build_sorter(512 * 1024 * 1024, "fgumi sort (test)");
+        let sorter =
+            sort.build_sorter(512 * 1024 * 1024, "fgumi sort (test)", fgumi_sort::soft_nofile());
         assert_eq!(sorter.phase1_threads(), expected_phase1);
         assert_eq!(sorter.phase2_threads(), expected_phase2);
     }
@@ -1163,7 +1179,8 @@ mod tests {
         sort.threads = threads;
         sort.sort_threads = sort_threads;
 
-        let sorter = sort.build_sorter(512 * 1024 * 1024, "fgumi sort (test)");
+        let sorter =
+            sort.build_sorter(512 * 1024 * 1024, "fgumi sort (test)", fgumi_sort::soft_nofile());
         assert_eq!(sorter.phase1_threads(), expected_phase1, "engine sort-phase fallback drifted");
         assert_eq!(sort.memory_budget_threads(), threads.max(expected_phase1));
     }
@@ -1319,32 +1336,33 @@ mod tests {
     /// cannot must name the lever the user actually has: `--max-temp-files` only
     /// when they set it, and `ulimit -n` either way.
     ///
-    /// `usize::MAX` stands in for "cannot fit any budget" so the warning branch
-    /// is reached regardless of this host's `ulimit -n`; a merge-width limit of
-    /// 8 is below any budget that can run a sort at all, so it never warns.
-    ///
-    /// Unix-only: where the descriptor budget cannot be read there is no budget
-    /// to exceed, and `fd_budget_warning` is silent by design.
-    #[cfg(unix)]
+    /// The budget is supplied rather than read from the host, so every branch
+    /// is exercised on every target: a 1024-descriptor budget admits a
+    /// merge-width limit of 8 and rejects `usize::MAX`, and a `None` budget
+    /// (the non-Unix case) admits everything by design.
     #[rstest]
-    #[case::fits_when_explicit(MaxTempFiles::Fixed(8), 8, None)]
-    #[case::fits_when_derived(MaxTempFiles::Auto, 8, None)]
+    #[case::fits_when_explicit(MaxTempFiles::Fixed(8), 8, Some(1024), None)]
+    #[case::fits_when_derived(MaxTempFiles::Auto, 8, Some(1024), None)]
     #[case::explicit_overrun_points_at_the_flag(
         MaxTempFiles::Fixed(usize::MAX),
         usize::MAX,
+        Some(1024),
         Some("lower --max-temp-files or raise the open file limit with `ulimit -n`")
     )]
     #[case::derived_overrun_points_only_at_ulimit(
         MaxTempFiles::Auto,
         usize::MAX,
+        Some(1024),
         Some("raise the open file limit with `ulimit -n`")
     )]
+    #[case::unreadable_budget_never_warns(MaxTempFiles::Fixed(usize::MAX), usize::MAX, None, None)]
     fn test_fd_budget_warning(
         #[case] setting: MaxTempFiles,
         #[case] resolved: usize,
+        #[case] soft_nofile: Option<u64>,
         #[case] expected_advice: Option<&str>,
     ) {
-        let warning = fd_budget_warning(setting, resolved);
+        let warning = fd_budget_warning(setting, resolved, soft_nofile);
         match expected_advice {
             None => assert_eq!(warning, None, "a limit within the budget must not warn"),
             Some(advice) => {
@@ -1361,9 +1379,8 @@ mod tests {
     /// The derived-overrun advice must not mention `--max-temp-files`: the user
     /// never set it, so telling them to lower it is advice they cannot act on.
     #[test]
-    #[cfg(unix)]
     fn test_derived_overrun_advice_omits_the_flag_the_user_did_not_set() {
-        let warning = fd_budget_warning(MaxTempFiles::Auto, usize::MAX)
+        let warning = fd_budget_warning(MaxTempFiles::Auto, usize::MAX, Some(1024))
             .expect("an oversized limit must warn");
         assert!(!warning.contains("lower --max-temp-files"), "unexpected advice: {warning}");
     }
@@ -1392,27 +1409,30 @@ mod tests {
         assert!(Sort::try_parse_from(args).is_err(), "--max-temp-files {value} must be rejected");
     }
 
-    /// The flag reaches the sorter: `Some(n)` sets the limit; `None` resolves it
-    /// from the host's descriptor budget. Compared against
-    /// `resolve_temp_file_limit` rather than a hardcoded number so the test does
-    /// not pin a value that depends on the machine it runs on — and *not*
-    /// against the engine's own default, which is deliberately a different
-    /// (fixed) value now that the derivation lives in the command.
+    /// The flag reaches the sorter: an explicit limit passes through untouched;
+    /// `auto` derives one from the descriptor budget it is handed. The budget is
+    /// supplied rather than read from the host, so the expected derived value is
+    /// a fixed number instead of one that depends on the machine the test runs
+    /// on — and it is deliberately *not* the engine's own default, which stays a
+    /// fixed portable value now that the derivation lives in the command.
     #[rstest]
-    #[case::set(MaxTempFiles::Fixed(256), Some(256))]
-    #[case::auto(MaxTempFiles::Auto, None)]
+    #[case::set(MaxTempFiles::Fixed(256), Some(1024), 256)]
+    #[case::auto_derives_from_the_budget(MaxTempFiles::Auto, Some(1024), 992)]
+    #[case::auto_without_a_budget_falls_back(
+        MaxTempFiles::Auto,
+        None,
+        fgumi_sort::FALLBACK_MAX_TEMP_FILES
+    )]
     fn test_build_sorter_wires_max_temp_files(
         #[case] max_temp_files: MaxTempFiles,
-        #[case] expected: Option<usize>,
+        #[case] soft_nofile: Option<u64>,
+        #[case] expected: usize,
     ) {
         let mut sort = make_sort(SortOrderArg::Coordinate);
         sort.max_temp_files = max_temp_files;
 
-        let sorter = sort.build_sorter(512 * 1024 * 1024, "fgumi sort (test)");
-        assert_eq!(
-            sorter.temp_file_limit(),
-            expected.unwrap_or_else(fgumi_sort::resolve_temp_file_limit)
-        );
+        let sorter = sort.build_sorter(512 * 1024 * 1024, "fgumi sort (test)", soft_nofile);
+        assert_eq!(sorter.temp_file_limit(), expected);
     }
 
     /// The accessor test above only proves the flag reaches the builder. This
@@ -1466,7 +1486,7 @@ mod tests {
             sort.threads = 1;
             sort.max_temp_files = max_temp_files;
 
-            let sorter = sort.build_sorter(1024, "fgumi sort (test)");
+            let sorter = sort.build_sorter(1024, "fgumi sort (test)", fgumi_sort::soft_nofile());
             let stats = sorter.sort(&input, &out).expect("sort should succeed");
 
             let mut reader =


### PR DESCRIPTION
`fgumi sort` consolidates spilled runs once their on-disk count reaches `--max-temp-files`, merging the oldest half into one. That limit exists for exactly one reason: the final k-way merge opens *every* remaining spill file at once (`SortWorkerPool::set_phase2_files`), so the limit bounds how many file descriptors the sort needs. Consolidation is otherwise pure overhead — it rewrites data that is already sorted.

The default was a hardcoded `64`, chosen to match samtools. It bears no relationship to the descriptor budget the process actually has, and fgumi never consulted that budget: there was no `RLIMIT_NOFILE` handling anywhere in the tree. The result is that fgumi consolidates on inputs where it has ample descriptors to spare.

## What it costs

Measured against `mako sort`, which is the same sort engine and differs only in that it overrides `max_temp_files` to 256. Eight threads, compression level 1:

| input | order | spills | fgumi consolidation | fgumi wall | mako wall | gain |
| --- | --- | --- | --- | --- | --- | --- |
| GIAB HG002 60x, 1.33B records, default 768M/thread | coordinate | 84 | 958.5s (1 merge) | 2529.2s | 1535.5s | **39.3%** |
| same | template-coordinate | 88 | 571.6s (1 merge) | 2190.8s | 1562.7s | **28.7%** |
| 1kg-wgs-HG00096, 780M records, `--max-memory 512M` | coordinate | 86 | 197.7s (1 merge) | 791.2s | 588.9s | **25.6%** |
| same | template-coordinate | 89 | 210.3s (1 merge) | 855.9s | 648.5s | **24.2%** |

The accounting closes: 2529.2 − 958.5 = 1570.7s against mako's 1535.5s, a 35s residual on a 2500s run. Consolidation is essentially the entire difference, and the two outputs compare IDENTICAL in every cell — so this is overhead removed, not work skipped.

At 84 spill files a merge needs ~84 descriptors. Every host these ran on affords that trivially. fgumi spent 958 seconds avoiding a cost it did not have.

## What this changes

New `fd_limit` module sizes a limit from the process's soft `RLIMIT_NOFILE`:

```
clamp(soft_nofile - 32, 16, 1024)
```

falling back to `64` on a non-Unix target.

`--max-temp-files` gained an explicit **`auto`** value, which is the default. Previously the host-derived behaviour was reachable only by *omitting* the flag, which left this command with two conventions for one idea: `--max-memory` takes a literal `auto` and shows `[default: 768M]`, while `--max-temp-files` showed no default at all and gave no way to request the sizing. It now uses the same `{Auto, Fixed}` shape. `--max-temp-files 64` still pins the old behaviour exactly.

**The sizing is done by the command, not the engine.** Deriving a default from the host environment is a policy decision, so `RawExternalSorter` keeps its fixed, portable default and `fgumi sort` resolves the limit once and passes a number down. That means `fgumi merge` and `fgumi simulate`, which also build sorters, are unaffected rather than silently inheriting a host-dependent default — and an embedder who never thinks about the knob still gets identical behaviour on every host. Resolving in one place also keeps the number in the `Max temp files:` log line identical to the one the engine is handed, rather than the two being computed by separate paths that agree only by construction.

**The reserve is a subtraction, not a fraction.** `RLIMIT_NOFILE` is per-process, so other processes on the machine do not consume this process's budget and there is nothing to leave room for on their behalf. What does consume it is descriptors fgumi holds: stdio, the input BAM, the output BAM, the optional index writer — about 7 at peak, and nothing that scales with `--threads`. 32 covers that with headroom. A percentage would be sized against the wrong thing: on a 1024-soft container, 90% is 921 and `1024 − 32` is 992; on a host with a 1,048,576 soft limit they differ by more than 100,000 descriptors that nobody has a use for.

**The floor is 16, not 2.** Two is the smallest value the consolidation path accepts, but at that limit every spill takes the run count to the limit and immediately merges, rewriting the entire accumulated output once per spill — quadratic in run count. A host whose budget cannot cover the floor gets a warning naming `ulimit -n`, and then the loud `EMFILE` it already gets today, rather than a silent hundredfold slowdown.

**The ceiling is 1024.** It started at 256, on the reasoning that the largest workload then measured spilled 88 runs, so anything above ~100 looked unreachable and the merge-buffer cost of a wide merge looked like the binding constraint. A sweep of `--max-temp-files` against spilled-run counts of 86 / 173 / 346 / 692 — obtained by shrinking a 780M-record WGS sort's total budget from 4 GiB to 512 MiB — contradicts both halves of that:

| spilled runs | consolidating (limit 64) | never consolidating | speedup |
| --- | --- | --- | --- |
| 86 | 789.8s | 596.4s | 1.32x |
| 173 | 1540.8s | 607.1s | 2.54x |
| 346 | 3026.1s | 619.7s | 4.88x |

At 346 runs consolidation consumed 2440s of a 3026s sort, 80% of wall clock. A ceiling of 256 caps the derived limit *below* the run count in the two deepest cells and re-imposes exactly that cost, so it has to sit above the measured range rather than inside it.

The competing cost — per-file read-ahead the merge allocates (a 2 MB `BufReader` plus `PHASE2_RAW_CAP`/`PHASE2_DECOMP_CAP` blocks each, none of it charged against `--max-memory`) — is real but far smaller than a per-file estimate suggests. Peak RSS is normally set by the phase-1 sort buffer and the merge's buffers land after that memory is released, so widening 346 runs from consolidating to not cost +104 MB, not the ~1.5 GB a 4.5 MB/file estimate predicts. It bites only where phase 1 is too small to dominate: at 692 runs on a 512 MiB total budget a 1024-wide merge reached 2309 MB against 1257 MB for a 256-wide one. That residual is why this stays a ceiling rather than no cap at all; sizing phase-2 read-ahead as a total budget divided across files would remove it, and is the natural follow-up.

**The budget check applies to explicit limits too.** A sized limit is clamped to the budget and can only fall short of it when the budget is below the floor; a pinned value can overrun it outright, which makes the explicit case the one *more* likely to fail. Checking only sized limits would skip it — and would leave the check dead for exactly the callers who pin the knob because they sort big things.

**It reads the limit; it never raises it.** A process may raise its own soft limit to the hard limit without privileges, but `fgumi-sort` is a library that other programs embed, and mutating a process-global resource limit is a side effect its host did not ask for. macOS would additionally reject `RLIM_INFINITY` and need clamping to `kern.maxfilesperproc`.

## Dependency

`rustix`, for `getrlimit`. Chosen over the two syscall wrappers already in `fgumi-sort`: `libc::getrlimit` is `unsafe` and the crate root is `#![deny(unsafe_code)]`, and `nix` is scoped to `cfg(target_os = "linux")` there (both its uses are Linux-only APIs), so reaching for it would add a crate to macOS builds. `rustix` is already compiled on every platform via `fs4` and `tempfile`, so enabling its `process` feature adds no crate — `Cargo.lock` grows by one line.

## Tests

- `fd_limit::tests` — table-driven over the clamp, including saturation at both ends (`0`, at the reserve, `u64::MAX` for `RLIM_INFINITY`), both lower-clamp boundaries, a soft limit *below* the old 64 to prove the sized value can go down as well as up, the historical macOS default, and a typical container limit. Plus compile-time assertions that the floor stays out of the quadratic regime.
- `fits_fd_budget` is covered for both the sized case and an oversized explicit limit.
- `test_build_sorter_wires_max_temp_files` compares against `resolve_temp_file_limit()` rather than a hardcoded number, so it does not pin a value that depends on the machine it runs on.
- `test_max_temp_files_consolidation_is_record_identical` — its control arm now pins an explicit large limit instead of passing `None`. With a sized default, a `None` control arm on a low-`ulimit` host could itself consolidate, quietly turning the test into a consolidation-vs-consolidation comparison that still passes while no longer testing what it claims.

## `fgumi merge`

A merge opens every input at once, so its descriptor cost is the input count — user-controlled, and not bounded by `--max-temp-files`, which the merge path never consults. Sizing the sort's limit would otherwise have covered the path where merge width is *internally* controlled and left the caller-controlled one untouched, so `merge_bams` now checks the input count against the same budget.

It warns rather than refuses. The reserve is deliberately conservative, so a merge slightly over the estimate may still succeed and erroring would break a working command; and nothing long-running is wasted by letting it proceed, since every reader is opened before any merging starts.

## Reading order

Four commits, each independently reviewable:

1. `feat(sort): size the temp-file limit to the process fd budget` — the `fd_limit` module and the sizing.
2. `feat(sort)!: accept auto for --max-temp-files` — the CLI surface, and the only breaking change.
3. `feat(merge): warn when a merge exceeds the process fd budget` — extends the check to the other k-way merge.
4. `perf(sort): raise the derived temp-file ceiling to 1024` — re-sites the ceiling on the measured sweep above.

## Notes for reviewers

- **`Sort::max_temp_files` changes type**, from `Option<usize>` to `MaxTempFiles { Auto, Fixed(usize) }` — hence the `!` on that commit. fg-labs/mako flattens this struct and does `.or(Some(256))`, so it will not compile against this until updated; tracked at fg-labs/mako#23. That override should be deleted rather than ported: on a stock macOS host (`ulimit -n` 256) it asks for 256 against a 224 budget, which this PR now warns about.
- **The `sort-production-lowmem` and `sort-xl` benchmark cells need a companion change.** Neither arm passes `--max-temp-files`, so once fgumi sizes to the host budget (224 on a stock macOS host, 992 on a 1024-soft container) neither consolidates at their 84–89 spills, and those cells stop measuring consolidation at all. The `Consolidation:` line is only emitted when a merge fired, so this shows up as a missing line rather than a failure. Pinning `--max-temp-files 64` on the fgumi arm restores the comparison.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: output changes: none; record-identical consolidation tests pin sort behavior. `unsafe` changes: none; the `CLAUDE.md` allowlist is unchanged. Memory, queue, thread, and backpressure policy changes: none.

Fix: resolve `--max-temp-files auto` from `RLIMIT_NOFILE`, validate fixed limits, and warn when merge inputs exceed the descriptor budget.

- Add `MaxTempFiles::{Auto, Fixed}`.
- Add Unix `rustix` support with a non-Unix fallback.
- Update `Sort::max_temp_files` and affected callers.
- Preserve explicit numeric limits and reject values below 2 or above the descriptor budget.
- Update documentation, logging, and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
