### PR TITLE
perf(sort): break the k-way merge into its component costs

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -3618,15 +3618,27 @@ impl RawExternalSorter {
             let pct = |secs: f64| if busy > 0.0 { 100.0 * secs / busy } else { 0.0 };
             let (read_s, read_n) = workers.read;
             let (dec_s, dec_n) = workers.decompress;
-            let (comp_s, comp_n) = workers.compress;
-            info!(
-                "  Workers ({} threads; busy time, overlaps the above and itself)",
-                pool.num_workers()
-            );
+            let (comp_s, comp_n) = workers.output_compress;
+            let (spill_s, spill_n) = workers.spill_compress;
+            let workers_n = pool.num_workers();
+            info!("  Workers ({workers_n} threads; busy time, overlaps the above and itself)");
             info!("    Spill disk read:   {read_s:.1}s ({:.0}%) [{read_n} batches]", pct(read_s));
             info!("    Spill decompress:  {dec_s:.1}s ({:.0}%) [{dec_n} blocks]", pct(dec_s));
             info!("    Output compress:   {comp_s:.1}s ({:.0}%) [{comp_n} blocks]", pct(comp_s));
             info!("    Total worker busy: {busy:.1}s  (NOT comparable to loop wall clock)");
+            // Utilization is the thread-efficiency question: well below 100%
+            // means the pool idled, the merge was bound by something other than
+            // worker CPU, and adding compression threads cannot help.
+            if let Some(util) = workers.worker_utilization(loop_total, workers_n) {
+                info!(
+                    "    Worker utilization: {:.0}% of {workers_n} threads x {loop_total:.1}s",
+                    100.0 * util
+                );
+            }
+            // Phase 1 spill compression rides the same worker step, so it is
+            // reported for context but excluded from the merge totals above.
+            info!("  Phase 1 (not part of the merge)");
+            info!("    Spill compress:    {spill_s:.1}s [{spill_n} blocks]");
         }
         info!("==============================");
     }

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -3711,12 +3711,24 @@ impl RawExternalSorter {
         let mut merge_read_secs = 0.0f64;
         let mut merge_tree_secs = 0.0f64;
         let mut samples_taken: u64 = 0;
+        // Countdown rather than `records_merged % interval`. A non-power-of-two
+        // modulo compiles to a multiply-shift, which is a few cycles per record
+        // -- ~0.1% of a billion-record merge. A decrement and a
+        // perfectly-predicted branch is not measurable at all, which is what
+        // lets this run unconditionally instead of behind a flag nobody
+        // remembers to set.
+        let mut sample_countdown: u64 = 0;
         let loop_start = Instant::now();
 
         while tree.winner_is_active() {
             let winner = tree.winner();
             let src_idx = source_map[winner];
-            let sample_this = records_merged.is_multiple_of(merge_sample_interval);
+            let sample_this = sample_countdown == 0;
+            if sample_this {
+                sample_countdown = merge_sample_interval - 1;
+            } else {
+                sample_countdown -= 1;
+            }
 
             let record_bytes = winner_record_bytes(&sources[src_idx], guard.consumer_ref())?;
             if sample_this {

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -3558,12 +3558,44 @@ impl RawExternalSorter {
         Ok((sources, guard))
     }
 
-    /// Generic merge for keyed chunks using `O(1)` key comparisons.
+    /// Say, in one line, what limited the merge.
     ///
-    /// This is the unified merge function that works with any `RawSortKey` type.
-    /// It provides `O(1)` comparisons during merge for fixed-size keys (coordinate, template)
-    /// and `O(name_len)` for variable-size keys (queryname).
-    #[allow(clippy::too_many_lines)]
+    /// Two numbers decide it. `utilization` is the worker pool's share of its
+    /// own capacity; `fetch_fraction` is how much of the consumer's loop went
+    /// into fetching the next record, which is where it blocks waiting for a
+    /// decompressed block. The interesting case is *both* being unfavourable:
+    /// if the pool is idle **and** the consumer is waiting, then neither side is
+    /// the bottleneck and the merge is waiting on storage.
+    ///
+    /// Deliberately hedged ("suggests", "likely"). These thresholds come from a
+    /// handful of measured runs, not a model, and the cost of a confident wrong
+    /// diagnosis -- someone raising `--threads` on an I/O-bound sort -- is worse
+    /// than the cost of a vague right one. The numbers above the verdict are the
+    /// evidence; this line only points at them.
+    fn log_merge_verdict(utilization: Option<f64>, fetch_fraction: f64) {
+        use crate::merge_phases::{MergeVerdict, classify_merge};
+
+        let Some(utilization) = utilization else { return };
+        let (util_pct, fetch_pct) = (100.0 * utilization, 100.0 * fetch_fraction);
+
+        match classify_merge(utilization, fetch_fraction) {
+            MergeVerdict::CpuBound => info!(
+                "  Verdict: worker pool saturated ({util_pct:.0}%); the merge is CPU-bound, so \
+                 more threads may help"
+            ),
+            MergeVerdict::IoBound => info!(
+                "  Verdict: workers idle ({util_pct:.0}% of capacity) while the consumer spent \
+                 {fetch_pct:.0}% of its loop waiting for data -- this suggests the merge is \
+                 I/O-bound. More threads are unlikely to help; faster storage, or spilling \
+                 fewer bytes, would."
+            ),
+            MergeVerdict::Mixed => info!(
+                "  Verdict: worker pool {util_pct:.0}% utilized, consumer {fetch_pct:.0}% \
+                 waiting on data -- neither clearly saturated"
+            ),
+        }
+    }
+
     /// Log the merge's component breakdown: main-thread work and worker work.
     ///
     /// The two halves are measured differently and must be read differently.
@@ -3573,11 +3605,21 @@ impl RawExternalSorter {
     /// the consumer, and routinely exceed `loop wall` -- see
     /// [`crate::merge_phases`]. Comparing a worker figure to `loop wall` is
     /// meaningless; comparing worker figures to each other is the point.
+    ///
+    /// The two wall clocks are therefore separate arguments, and each denominator
+    /// takes the one it belongs to. `loop_total` covers the consumer loop alone,
+    /// which is what the sampled consumer rows partition. `merge_total` runs
+    /// through output finalization, which is where the queued tail of
+    /// `output_compress` is actually done, so it is what worker utilization
+    /// divides by; using `loop_total` there would charge worker busy time to a
+    /// window that ended before some of it happened.
     #[allow(clippy::cast_precision_loss)]
     fn log_merge_sub_phases(
         loop_total: f64,
+        merge_total: f64,
         consumer: (f64, f64, f64),
         sampling: (u64, u64),
+        active_workers: usize,
         pool: &Arc<SortWorkerPool>,
     ) {
         let (write_secs, read_secs, tree_secs) = consumer;
@@ -3600,6 +3642,7 @@ impl RawExternalSorter {
             "    Enqueue write:     {est_write:.1}s  (hands off to workers; excludes compression)"
         );
         info!("    Loop wall clock:   {loop_total:.1}s");
+        info!("    Merge wall clock:  {merge_total:.1}s (loop plus output finalization)");
         // These three estimates partition one thread's time, so they cannot
         // legitimately exceed it. Saying so in the log beats leaving a reader to
         // notice the arithmetic -- a biased sample is the failure mode here, and
@@ -3620,8 +3663,10 @@ impl RawExternalSorter {
             let (dec_s, dec_n) = workers.decompress;
             let (comp_s, comp_n) = workers.output_compress;
             let (spill_s, spill_n) = workers.spill_compress;
-            let workers_n = pool.num_workers();
-            info!("  Workers ({workers_n} threads; busy time, overlaps the above and itself)");
+            let workers_n = active_workers;
+            info!(
+                "  Workers ({workers_n} active threads; busy time, overlaps the above and itself)"
+            );
             info!("    Spill disk read:   {read_s:.1}s ({:.0}%) [{read_n} batches]", pct(read_s));
             info!("    Spill decompress:  {dec_s:.1}s ({:.0}%) [{dec_n} blocks]", pct(dec_s));
             info!("    Output compress:   {comp_s:.1}s ({:.0}%) [{comp_n} blocks]", pct(comp_s));
@@ -3629,9 +3674,10 @@ impl RawExternalSorter {
             // Utilization is the thread-efficiency question: well below 100%
             // means the pool idled, the merge was bound by something other than
             // worker CPU, and adding compression threads cannot help.
-            if let Some(util) = workers.worker_utilization(loop_total, workers_n) {
+            if let Some(util) = workers.worker_utilization(merge_total, workers_n) {
                 info!(
-                    "    Worker utilization: {:.0}% of {workers_n} threads x {loop_total:.1}s",
+                    "    Worker utilization: {:.0}% of {workers_n} active threads x \
+                     {merge_total:.1}s",
                     100.0 * util
                 );
             }
@@ -3639,10 +3685,24 @@ impl RawExternalSorter {
             // reported for context but excluded from the merge totals above.
             info!("  Phase 1 (not part of the merge)");
             info!("    Spill compress:    {spill_s:.1}s [{spill_n} blocks]");
+
+            // Utilization over the full merge window; the fetch fraction stays
+            // relative to the consumer loop, which is the only thing it is a
+            // fraction of.
+            Self::log_merge_verdict(
+                workers.worker_utilization(merge_total, workers_n),
+                if loop_total > 0.0 { est_read / loop_total } else { 0.0 },
+            );
         }
         info!("==============================");
     }
 
+    /// Generic merge for keyed chunks using `O(1)` key comparisons.
+    ///
+    /// This is the unified merge function that works with any `RawSortKey` type.
+    /// It provides `O(1)` comparisons during merge for fixed-size keys (coordinate, template)
+    /// and `O(name_len)` for variable-size keys (queryname).
+    #[allow(clippy::too_many_lines)]
     fn merge_chunks_generic<K: RawSortKey + Default + 'static>(
         &self,
         chunk_files: &[PathBuf],
@@ -3771,14 +3831,31 @@ impl RawExternalSorter {
             }
         }
 
+        let loop_total = loop_start.elapsed().as_secs_f64();
+        // The active limit, not the pool width: Phase 2 caps the pool to
+        // `phase2_threads`, so on a run with a wider Phase 1 the extra threads
+        // cannot take merge work and must not sit in the utilization
+        // denominator -- a saturated pool would read as idle, and the verdict
+        // would call a CPU-bound merge I/O-bound. Read while Phase 2 is still
+        // active, so the number cannot depend on what teardown does to the cap.
+        let active_workers = pool.active_workers();
+
+        // Finalize before logging. `finish` drains the output queue, and every
+        // block still in it is compressed by the same workers this breakdown
+        // reports -- so a snapshot taken first omits the tail of
+        // `output_compress` and divides the rest by a wall clock that stops
+        // before the drain.
+        guard.finish_output(|| writer.finish())?;
+
         Self::log_merge_sub_phases(
+            loop_total,
             loop_start.elapsed().as_secs_f64(),
             (merge_write_secs, merge_read_secs, merge_tree_secs),
             (samples_taken, records_merged),
+            active_workers,
             pool,
         );
 
-        guard.finish_output(|| writer.finish())?;
         merge_progress.log_final();
         log_snapshot("phase2.end", 0);
 

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -3564,6 +3564,73 @@ impl RawExternalSorter {
     /// It provides `O(1)` comparisons during merge for fixed-size keys (coordinate, template)
     /// and `O(name_len)` for variable-size keys (queryname).
     #[allow(clippy::too_many_lines)]
+    /// Log the merge's component breakdown: main-thread work and worker work.
+    ///
+    /// The two halves are measured differently and must be read differently.
+    /// Consumer figures are sampled 1-in-N and scaled, so they estimate that one
+    /// thread's wall time and do partition `loop wall`. Worker figures are exact
+    /// busy-time sums across every pool thread, so they overlap each other AND
+    /// the consumer, and routinely exceed `loop wall` -- see
+    /// [`crate::merge_phases`]. Comparing a worker figure to `loop wall` is
+    /// meaningless; comparing worker figures to each other is the point.
+    #[allow(clippy::cast_precision_loss)]
+    fn log_merge_sub_phases(
+        loop_total: f64,
+        consumer: (f64, f64, f64),
+        sampling: (u64, u64),
+        pool: &Arc<SortWorkerPool>,
+    ) {
+        let (write_secs, read_secs, tree_secs) = consumer;
+        let (samples_taken, records_merged) = sampling;
+        if records_merged == 0 {
+            return;
+        }
+        let scale =
+            if samples_taken > 0 { records_merged as f64 / samples_taken as f64 } else { 1.0 };
+        let (est_write, est_read, est_tree) =
+            (write_secs * scale, read_secs * scale, tree_secs * scale);
+
+        info!("=== Merge Sub-Phase Timing ===");
+        info!(
+            "  Consumer (main thread; {samples_taken} samples of {records_merged} records, scaled {scale:.0}x)"
+        );
+        info!("    Fetch next record: {est_read:.1}s  (includes waiting on decompressed blocks)");
+        info!("    Loser tree:        {est_tree:.1}s");
+        info!(
+            "    Enqueue write:     {est_write:.1}s  (hands off to workers; excludes compression)"
+        );
+        info!("    Loop wall clock:   {loop_total:.1}s");
+        // These three estimates partition one thread's time, so they cannot
+        // legitimately exceed it. Saying so in the log beats leaving a reader to
+        // notice the arithmetic -- a biased sample is the failure mode here, and
+        // it is silent otherwise.
+        let consumer_est = est_read + est_tree + est_write;
+        if consumer_est > loop_total * 1.05 {
+            info!(
+                "    NOTE: rows sum to {consumer_est:.1}s > loop wall {loop_total:.1}s, so the \
+                 sample is biased; treat consumer rows as indicative only"
+            );
+        }
+
+        let workers = pool.merge_phase_breakdown();
+        if !workers.is_empty() {
+            let busy = workers.total_busy_secs();
+            let pct = |secs: f64| if busy > 0.0 { 100.0 * secs / busy } else { 0.0 };
+            let (read_s, read_n) = workers.read;
+            let (dec_s, dec_n) = workers.decompress;
+            let (comp_s, comp_n) = workers.compress;
+            info!(
+                "  Workers ({} threads; busy time, overlaps the above and itself)",
+                pool.num_workers()
+            );
+            info!("    Spill disk read:   {read_s:.1}s ({:.0}%) [{read_n} batches]", pct(read_s));
+            info!("    Spill decompress:  {dec_s:.1}s ({:.0}%) [{dec_n} blocks]", pct(dec_s));
+            info!("    Output compress:   {comp_s:.1}s ({:.0}%) [{comp_n} blocks]", pct(comp_s));
+            info!("    Total worker busy: {busy:.1}s  (NOT comparable to loop wall clock)");
+        }
+        info!("==============================");
+    }
+
     fn merge_chunks_generic<K: RawSortKey + Default + 'static>(
         &self,
         chunk_files: &[PathBuf],
@@ -3614,9 +3681,20 @@ impl RawExternalSorter {
 
         let mut merge_probe = MergeProbe::new();
 
-        // Sub-phase timing: only paid when debug logging is enabled.
-        let debug_timing = log::log_enabled!(log::Level::Debug);
-        let merge_sample_interval: u64 = 1024;
+        // Sub-phase timing. Sampled 1-in-`merge_sample_interval`, so on a
+        // billion-record merge this is a few million `Instant::now()` pairs
+        // rather than two billion -- cheap enough to run unconditionally. It
+        // used to be gated on debug logging, which meant the one breakdown that
+        // explains where a merge-dominated sort spends its time was absent from
+        // every benchmark log we actually collect.
+        // Prime, and deliberately NOT 1024. Records are ~100 bytes and spill
+        // blocks ~64 KB, so a power-of-two interval aliases against block
+        // boundaries: the sampled record keeps landing on the refill that blocks
+        // waiting for the next block, and scaling those up overestimated the
+        // consumer's cost by ~2x -- enough that the sub-phases summed to more
+        // than the loop wall clock they are supposed to partition. A prime
+        // interval decorrelates the sample from any block-size-derived period.
+        let merge_sample_interval: u64 = 1021;
         let mut merge_write_secs = 0.0f64;
         let mut merge_read_secs = 0.0f64;
         let mut merge_tree_secs = 0.0f64;
@@ -3626,7 +3704,7 @@ impl RawExternalSorter {
         while tree.winner_is_active() {
             let winner = tree.winner();
             let src_idx = source_map[winner];
-            let sample_this = debug_timing && records_merged.is_multiple_of(merge_sample_interval);
+            let sample_this = records_merged.is_multiple_of(merge_sample_interval);
 
             let record_bytes = winner_record_bytes(&sources[src_idx], guard.consumer_ref())?;
             if sample_this {
@@ -3669,18 +3747,12 @@ impl RawExternalSorter {
             }
         }
 
-        if debug_timing {
-            let loop_total = loop_start.elapsed().as_secs_f64();
-            #[allow(clippy::cast_precision_loss)]
-            let scale =
-                if samples_taken > 0 { records_merged as f64 / samples_taken as f64 } else { 1.0 };
-            let est_write = merge_write_secs * scale;
-            let est_read = merge_read_secs * scale;
-            let est_tree = merge_tree_secs * scale;
-            debug!(
-                "Merge sub-phases (sampled {samples_taken}/{records_merged}, scale={scale:.1}x): write={est_write:.2}s read={est_read:.2}s tree={est_tree:.2}s total={loop_total:.2}s records={records_merged}"
-            );
-        }
+        Self::log_merge_sub_phases(
+            loop_start.elapsed().as_secs_f64(),
+            (merge_write_secs, merge_read_secs, merge_tree_secs),
+            (samples_taken, records_merged),
+            pool,
+        );
 
         guard.finish_output(|| writer.finish())?;
         merge_progress.log_final();

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -48,6 +48,7 @@ pub(crate) mod inline;
 pub(crate) mod keys;
 pub(crate) mod loser_tree;
 pub(crate) mod memory_probe;
+pub(crate) mod merge_phases;
 pub(crate) mod pipeline;
 pub(crate) mod pooled_bam_writer;
 pub(crate) mod pooled_chunk_writer;

--- a/crates/fgumi-sort/src/merge_phases.rs
+++ b/crates/fgumi-sort/src/merge_phases.rs
@@ -1,0 +1,187 @@
+//! Per-component timing for the final k-way merge.
+//!
+//! [`SortPhaseTimer`](crate::external::SortPhaseTimer) reports the merge as one
+//! bucket, and its own doc says why that is coarse: the span "includes reader
+//! decompression + writer compression". That is enough to see the merge dominate
+//! a spill-heavy sort, and not enough to say what to do about it. These counters
+//! split it.
+//!
+//! # These are busy-time sums, not a partition of merge wall time
+//!
+//! The merge is a concurrent pipeline: worker threads read spill blocks from
+//! disk, decompress them, and compress output blocks, while the main thread
+//! drains the loser tree. All four happen *at the same time* on different
+//! threads. So the four counters here overlap each other and routinely sum to
+//! more than the merge's wall clock — on an 8-thread sort they can sum to
+//! several times it.
+//!
+//! Read them as "how much thread-busy time went into each component", which is
+//! the right question for a phase that is CPU-bound, and compare them against
+//! each other rather than against wall clock. The ratio between them is the
+//! signal; their sum is not meaningful.
+//!
+//! Each counter also carries an operation count, so a component's mean cost per
+//! unit is available without assuming a block size.
+//!
+//! # Scope: worker threads only
+//!
+//! These cover the three things pool workers do during the merge. The main
+//! thread's own work -- loser-tree pops, fetching the next record, enqueueing
+//! writes -- is already measured by the sampled timers in
+//! `merge_chunks_generic`, and is reported alongside these. Duplicating it here
+//! would mean an `Instant::now()` pair per record rather than per block, which
+//! on a billion-record sort is real overhead for a number we already have.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+/// Nanosecond/operation counter pair for one merge component.
+#[derive(Debug, Default)]
+pub(crate) struct ComponentCounter {
+    nanos: AtomicU64,
+    ops: AtomicU64,
+}
+
+impl ComponentCounter {
+    /// Run `f`, adding its elapsed time and one operation to this counter.
+    ///
+    /// `Relaxed` throughout: these are diagnostic totals with no ordering
+    /// relationship to the data they describe, and the merge hot path should not
+    /// pay for fences to maintain them.
+    pub(crate) fn time<R>(&self, f: impl FnOnce() -> R) -> R {
+        let start = Instant::now();
+        let result = f();
+        #[allow(clippy::cast_possible_truncation)]
+        let elapsed = start.elapsed().as_nanos() as u64;
+        self.nanos.fetch_add(elapsed, Ordering::Relaxed);
+        self.ops.fetch_add(1, Ordering::Relaxed);
+        result
+    }
+
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "nanosecond totals stay far below 2^52; a sort would need ~52 days of busy time to lose a nanosecond of precision here"
+    )]
+    fn snapshot(&self) -> (f64, u64) {
+        let nanos = self.nanos.load(Ordering::Relaxed);
+        let ops = self.ops.load(Ordering::Relaxed);
+        (nanos as f64 / 1e9, ops)
+    }
+}
+
+/// Busy-time counters for the four components of the k-way merge.
+#[derive(Debug, Default)]
+pub(crate) struct MergePhaseCounters {
+    /// Pulling raw (still-compressed) blocks off disk into the per-file FIFO.
+    pub(crate) read: ComponentCounter,
+    /// Decompressing spill blocks (BGZF or zstd, whichever the spill used).
+    pub(crate) decompress: ComponentCounter,
+    /// Compressing output blocks (BGZF at `--compression-level`).
+    pub(crate) compress: ComponentCounter,
+}
+
+/// A read-only view of the counters, for logging.
+#[derive(Debug, Clone, Copy)]
+pub struct MergePhaseBreakdown {
+    /// Busy seconds spent reading raw spill blocks from disk, and block count.
+    pub read: (f64, u64),
+    /// Busy seconds spent decompressing spill blocks, and block count.
+    pub decompress: (f64, u64),
+    /// Busy seconds spent compressing output blocks, and block count.
+    pub compress: (f64, u64),
+}
+
+impl MergePhaseCounters {
+    pub(crate) fn snapshot(&self) -> MergePhaseBreakdown {
+        MergePhaseBreakdown {
+            read: self.read.snapshot(),
+            decompress: self.decompress.snapshot(),
+            compress: self.compress.snapshot(),
+        }
+    }
+}
+
+impl MergePhaseBreakdown {
+    /// Total busy seconds across all four components.
+    ///
+    /// Deliberately *not* comparable to merge wall clock — see the module doc.
+    /// Provided so each component can be expressed as a share of total merge
+    /// effort, which is the comparison that means something.
+    #[must_use]
+    pub fn total_busy_secs(self) -> f64 {
+        self.read.0 + self.decompress.0 + self.compress.0
+    }
+
+    /// Whether anything was recorded, so a sort that never merged stays silent.
+    #[must_use]
+    pub fn is_empty(self) -> bool {
+        self.read.1 == 0 && self.decompress.1 == 0 && self.compress.1 == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn test_counter_accumulates_time_and_ops() {
+        let counter = ComponentCounter::default();
+        for _ in 0..3 {
+            counter.time(|| thread::sleep(Duration::from_millis(5)));
+        }
+        let (secs, ops) = counter.snapshot();
+        assert_eq!(ops, 3);
+        assert!(secs >= 0.015, "expected >= 15ms accumulated, got {secs}");
+    }
+
+    #[test]
+    fn test_counter_returns_the_closure_value() {
+        let counter = ComponentCounter::default();
+        assert_eq!(counter.time(|| 42), 42);
+    }
+
+    /// The counters are written from several worker threads at once, so the
+    /// accumulation must not lose updates.
+    #[test]
+    fn test_counter_accumulates_across_threads() {
+        let counter = Arc::new(ComponentCounter::default());
+        thread::scope(|scope| {
+            for _ in 0..4 {
+                let counter = Arc::clone(&counter);
+                scope.spawn(move || {
+                    for _ in 0..25 {
+                        counter.time(|| ());
+                    }
+                });
+            }
+        });
+        assert_eq!(counter.snapshot().1, 100);
+    }
+
+    /// Busy time from concurrent threads exceeds the wall clock they ran in.
+    /// This is the property the module doc warns about, pinned so nobody
+    /// "fixes" the counters into a wall-clock partition.
+    #[test]
+    fn test_busy_time_may_exceed_wall_clock() {
+        let counters = MergePhaseCounters::default();
+        let start = Instant::now();
+        thread::scope(|scope| {
+            for _ in 0..4 {
+                scope.spawn(|| {
+                    counters.decompress.time(|| thread::sleep(Duration::from_millis(20)));
+                });
+            }
+        });
+        let wall = start.elapsed().as_secs_f64();
+        let busy = counters.snapshot().total_busy_secs();
+        assert!(busy > wall, "busy {busy} should exceed wall {wall} for concurrent work");
+    }
+
+    #[test]
+    fn test_empty_breakdown_is_reported_as_empty() {
+        assert!(MergePhaseCounters::default().snapshot().is_empty());
+    }
+}

--- a/crates/fgumi-sort/src/merge_phases.rs
+++ b/crates/fgumi-sort/src/merge_phases.rs
@@ -147,9 +147,49 @@ impl MergePhaseBreakdown {
     }
 }
 
+/// What limited the merge, inferred from worker utilization and consumer wait.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergeVerdict {
+    /// The worker pool was saturated; worker CPU is the wall.
+    CpuBound,
+    /// Workers idled *and* the consumer waited -- neither side is the
+    /// bottleneck, which points at storage.
+    IoBound,
+    /// Neither condition clearly holds.
+    Mixed,
+}
+
+/// Worker utilization at or above which the pool counts as saturated.
+const SATURATED_UTILIZATION: f64 = 0.85;
+/// Worker utilization below which the pool counts as idle.
+const IDLE_UTILIZATION: f64 = 0.60;
+/// Consumer wait fraction above which the consumer counts as starved.
+const STARVED_FETCH_FRACTION: f64 = 0.50;
+
+/// Classify what limited the merge.
+///
+/// The discriminating case is *both* sides being unfavourable: an idle pool
+/// alone could just mean a cheap merge, and a waiting consumer alone could mean
+/// slow workers. Together they mean neither side is the constraint, which
+/// leaves storage.
+///
+/// Thresholds are calibrated from a handful of measured runs, not a model, so
+/// callers should present the result as a hint and show the numbers behind it.
+#[must_use]
+pub fn classify_merge(utilization: f64, fetch_fraction: f64) -> MergeVerdict {
+    if utilization >= SATURATED_UTILIZATION {
+        MergeVerdict::CpuBound
+    } else if utilization < IDLE_UTILIZATION && fetch_fraction > STARVED_FETCH_FRACTION {
+        MergeVerdict::IoBound
+    } else {
+        MergeVerdict::Mixed
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
     use std::sync::Arc;
     use std::thread;
     use std::time::Duration;
@@ -211,5 +251,36 @@ mod tests {
     #[test]
     fn test_empty_breakdown_is_reported_as_empty() {
         assert!(MergePhaseCounters::default().snapshot().is_empty());
+    }
+
+    /// The thresholds are pinned against the runs that calibrated them, so a
+    /// future tweak has to confront the evidence rather than just move a number.
+    #[rstest]
+    // Measured on a 780M-record WGS merge (EBS): workers half idle AND the
+    // consumer waiting three quarters of its loop. Both "optimized" arms of that
+    // experiment got slower, confirming storage was the constraint.
+    #[case::measured_ebs_merge(0.52, 0.74, MergeVerdict::IoBound)]
+    // Same code on a laptop with local NVMe: the pool saturates instead.
+    #[case::measured_local_nvme(0.93, 0.03, MergeVerdict::CpuBound)]
+    // Idle pool but a consumer that is NOT waiting: the merge is simply cheap,
+    // which must not be reported as an I/O problem.
+    #[case::idle_pool_busy_consumer(0.20, 0.05, MergeVerdict::Mixed)]
+    // Waiting consumer but a busy pool: workers are the constraint, not storage.
+    #[case::busy_pool_waiting_consumer(0.80, 0.90, MergeVerdict::Mixed)]
+    #[case::at_saturation_boundary(0.85, 0.99, MergeVerdict::CpuBound)]
+    #[case::just_below_saturation(0.84, 0.10, MergeVerdict::Mixed)]
+    fn test_classify_merge(
+        #[case] utilization: f64,
+        #[case] fetch_fraction: f64,
+        #[case] expected: MergeVerdict,
+    ) {
+        assert_eq!(classify_merge(utilization, fetch_fraction), expected);
+    }
+
+    /// A saturated pool is CPU-bound regardless of consumer wait, since the
+    /// saturation test is checked first.
+    #[test]
+    fn test_saturation_takes_precedence_over_consumer_wait() {
+        assert_eq!(classify_merge(0.95, 0.95), MergeVerdict::CpuBound);
     }
 }

--- a/crates/fgumi-sort/src/merge_phases.rs
+++ b/crates/fgumi-sort/src/merge_phases.rs
@@ -76,8 +76,14 @@ pub(crate) struct MergePhaseCounters {
     pub(crate) read: ComponentCounter,
     /// Decompressing spill blocks (BGZF or zstd, whichever the spill used).
     pub(crate) decompress: ComponentCounter,
-    /// Compressing output blocks (BGZF at `--compression-level`).
-    pub(crate) compress: ComponentCounter,
+    /// Compressing OUTPUT blocks (BGZF at `--compression-level`), during the
+    /// merge.
+    pub(crate) output_compress: ComponentCounter,
+    /// Compressing SPILL blocks during Phase 1. Counted separately because the
+    /// same worker step serves both targets: lumping them together attributes
+    /// Phase 1's spill compression to the merge, which overstates the merge's
+    /// compression cost by however much was spilled.
+    pub(crate) spill_compress: ComponentCounter,
 }
 
 /// A read-only view of the counters, for logging.
@@ -88,7 +94,10 @@ pub struct MergePhaseBreakdown {
     /// Busy seconds spent decompressing spill blocks, and block count.
     pub decompress: (f64, u64),
     /// Busy seconds spent compressing output blocks, and block count.
-    pub compress: (f64, u64),
+    pub output_compress: (f64, u64),
+    /// Busy seconds spent compressing Phase 1 spill blocks, and block count.
+    /// Not part of the merge -- reported for context, excluded from merge totals.
+    pub spill_compress: (f64, u64),
 }
 
 impl MergePhaseCounters {
@@ -96,26 +105,45 @@ impl MergePhaseCounters {
         MergePhaseBreakdown {
             read: self.read.snapshot(),
             decompress: self.decompress.snapshot(),
-            compress: self.compress.snapshot(),
+            output_compress: self.output_compress.snapshot(),
+            spill_compress: self.spill_compress.snapshot(),
         }
     }
 }
 
 impl MergePhaseBreakdown {
-    /// Total busy seconds across all four components.
+    /// Total worker busy seconds attributable to the merge.
     ///
-    /// Deliberately *not* comparable to merge wall clock — see the module doc.
-    /// Provided so each component can be expressed as a share of total merge
-    /// effort, which is the comparison that means something.
+    /// Excludes `spill_compress`, which happens in Phase 1. Deliberately *not*
+    /// a partition of merge wall clock — see the module doc — but it is the
+    /// numerator of a meaningful utilization figure: divided by
+    /// `merge_wall * num_workers` it says what fraction of the available worker
+    /// capacity the merge actually used.
     #[must_use]
     pub fn total_busy_secs(self) -> f64 {
-        self.read.0 + self.decompress.0 + self.compress.0
+        self.read.0 + self.decompress.0 + self.output_compress.0
+    }
+
+    /// Fraction of available worker capacity the merge consumed, in `[0, 1]`.
+    ///
+    /// `busy / (wall * workers)`. Well below 1 means workers idled -- the merge
+    /// was bound by something other than worker CPU (the consumer thread, lock
+    /// contention, or I/O latency), and adding compression threads would not
+    /// help. Near 1 means the pool was saturated and worker CPU is the wall.
+    #[must_use]
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "thread counts are small integers; f64 represents them exactly"
+    )]
+    pub fn worker_utilization(self, merge_wall_secs: f64, num_workers: usize) -> Option<f64> {
+        let capacity = merge_wall_secs * num_workers as f64;
+        (capacity > 0.0).then(|| self.total_busy_secs() / capacity)
     }
 
     /// Whether anything was recorded, so a sort that never merged stays silent.
     #[must_use]
     pub fn is_empty(self) -> bool {
-        self.read.1 == 0 && self.decompress.1 == 0 && self.compress.1 == 0
+        self.read.1 == 0 && self.decompress.1 == 0 && self.output_compress.1 == 0
     }
 }
 

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -1883,11 +1883,19 @@ impl SortWorkerPool {
         // Destructured so the BGZF compressor and the zstd one are borrowed as
         // disjoint fields rather than through `worker` twice.
         let SortWorkerState { compressor, output_compressor, zstd_compressor, .. } = worker;
+        let target = job.target;
         let bgzf_compressor = match job.target {
             CompressTarget::Spill => compressor,
             CompressTarget::Output => output_compressor,
         };
-        shared.merge_phases.compress.time(|| {
+        // Attributed by target, not lumped: this one step compresses both Phase 1
+        // spill blocks and merge output blocks, so a single counter would charge
+        // spill compression to the merge.
+        let counter = match target {
+            CompressTarget::Spill => &shared.merge_phases.spill_compress,
+            CompressTarget::Output => &shared.merge_phases.output_compress,
+        };
+        counter.time(|| {
             Self::handle_compress_job(shared, job, bgzf_compressor, zstd_compressor);
         });
         StepResult::Success

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -49,7 +49,7 @@ use std::fmt::Write as FmtWrite;
 use std::io::{BufReader, Read};
 use std::io::{Seek, SeekFrom};
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread::{self, JoinHandle};
 use std::time::Instant;
 use zstd::bulk::{Compressor as ZstdCompressor, Decompressor as ZstdDecompressor};
@@ -713,6 +713,10 @@ pub struct SortWorkerPool {
 /// `push()`/`pop()` only). The compress result channel stays as `crossbeam_channel`
 /// because the I/O writer thread needs blocking `recv()`.
 pub(crate) struct SharedPipelineState {
+    /// Busy-time counters for the four components of the k-way merge. See
+    /// [`crate::merge_phases`] -- these overlap and do not partition wall time.
+    pub(crate) merge_phases: crate::merge_phases::MergePhaseCounters,
+
     /// Current phase: 0=shutdown, 1=Phase1, 2=Phase2, 255=Legacy.
     pub(crate) phase: AtomicU8,
 
@@ -812,6 +816,7 @@ impl SharedPipelineState {
         let compress_queue_cap = num_workers * 4;
 
         Self {
+            merge_phases: crate::merge_phases::MergePhaseCounters::default(),
             phase: AtomicU8::new(phase::LEGACY),
             active_worker_limit: AtomicUsize::new(num_workers),
 
@@ -1671,7 +1676,11 @@ impl SortWorkerPool {
                 let data = match file.codec {
                     SpillCodec::Bgzf => {
                         let raw_block = RawBgzfBlock { data: raw_bytes };
-                        match decompress_block(&raw_block, &mut worker.decompressor) {
+                        match shared
+                            .merge_phases
+                            .decompress
+                            .time(|| decompress_block(&raw_block, &mut worker.decompressor))
+                        {
                             Ok(d) => d,
                             Err(e) => {
                                 log::error!(
@@ -1691,10 +1700,11 @@ impl SortWorkerPool {
                         if worker.zstd_decompress_buf.len() < ZSTD_FRAME_DECOMP_CAP {
                             worker.zstd_decompress_buf.resize(ZSTD_FRAME_DECOMP_CAP, 0);
                         }
-                        match worker
-                            .zstd_decompressor
-                            .decompress_to_buffer(&raw_bytes, &mut worker.zstd_decompress_buf)
-                        {
+                        match shared.merge_phases.decompress.time(|| {
+                            worker
+                                .zstd_decompressor
+                                .decompress_to_buffer(&raw_bytes, &mut worker.zstd_decompress_buf)
+                        }) {
                             Ok(n) => {
                                 // Copy the `n` decompressed bytes (≤ one
                                 // staging-buffer's worth, typically ~65 KB)
@@ -1758,46 +1768,32 @@ impl SortWorkerPool {
                 continue;
             }
 
-            let raw_bytes: Vec<Vec<u8>> = match file.codec {
-                SpillCodec::Bgzf => {
-                    match read_raw_blocks(&mut reader_guard.inner, PHASE2_READ_BATCH) {
-                        Ok(blocks) => blocks.into_iter().map(|b| b.data).collect(),
-                        Err(e) => {
-                            log::error!("I/O error reading chunk file (source {i}): {e}");
-                            shared.chunk_read_error.store(true, Ordering::Release);
-                            file.mark_reader_eof(&mut reader_guard);
-                            drop(reader_guard);
-                            shared.main_thread_handle.unpark();
-                            Self::maybe_mark_all_eof(shared);
-                            worker.phase2_file_cursor = (i + 1) % n;
-                            return StepResult::Success;
-                        }
-                    }
-                }
-                SpillCodec::Zstd => {
-                    match read_raw_zstd_frames(&mut reader_guard.inner, PHASE2_READ_BATCH) {
-                        Ok(frames) => frames,
-                        Err(e) => {
-                            log::error!("I/O error reading zstd chunk file (source {i}): {e}");
-                            shared.chunk_read_error.store(true, Ordering::Release);
-                            file.mark_reader_eof(&mut reader_guard);
-                            drop(reader_guard);
-                            shared.main_thread_handle.unpark();
-                            Self::maybe_mark_all_eof(shared);
-                            worker.phase2_file_cursor = (i + 1) % n;
-                            return StepResult::Success;
-                        }
-                    }
+            // Both codecs read into the same `Vec<Vec<u8>>`, so the read is
+            // dispatched on the codec but the failure is handled once. The two
+            // arms previously carried identical error handling differing only
+            // in one word of the message, which had to be kept in step by hand.
+            let read = match file.codec {
+                SpillCodec::Bgzf => shared
+                    .merge_phases
+                    .read
+                    .time(|| read_raw_blocks(&mut reader_guard.inner, PHASE2_READ_BATCH))
+                    .map(|blocks| blocks.into_iter().map(|b| b.data).collect()),
+                SpillCodec::Zstd => shared
+                    .merge_phases
+                    .read
+                    .time(|| read_raw_zstd_frames(&mut reader_guard.inner, PHASE2_READ_BATCH)),
+            };
+            let raw_bytes: Vec<Vec<u8>> = match read {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    log::error!("I/O error reading {} chunk file (source {i}): {e}", file.codec);
+                    shared.chunk_read_error.store(true, Ordering::Release);
+                    return Self::retire_phase2_source(shared, worker, file, reader_guard, i, n);
                 }
             };
 
             if raw_bytes.is_empty() {
-                file.mark_reader_eof(&mut reader_guard);
-                drop(reader_guard);
-                shared.main_thread_handle.unpark();
-                Self::maybe_mark_all_eof(shared);
-                worker.phase2_file_cursor = (i + 1) % n;
-                return StepResult::Success;
+                return Self::retire_phase2_source(shared, worker, file, reader_guard, i, n);
             }
 
             // Acquire the raw_blocks lock BEFORE releasing the reader lock and
@@ -1891,13 +1887,47 @@ impl SortWorkerPool {
             CompressTarget::Spill => compressor,
             CompressTarget::Output => output_compressor,
         };
-        Self::handle_compress_job(shared, job, bgzf_compressor, zstd_compressor);
+        shared.merge_phases.compress.time(|| {
+            Self::handle_compress_job(shared, job, bgzf_compressor, zstd_compressor);
+        });
         StepResult::Success
     }
 
     // ========================================================================
     // Helper: EOF tracking for Phase 2
     // ========================================================================
+
+    /// Retire a phase-2 source: mark its reader EOF, wake the consumer, and
+    /// advance this worker's cursor past it.
+    ///
+    /// Shared by the two ways a source stops producing — a clean end of file
+    /// and an unreadable chunk — which differ only in whether the caller
+    /// latches `chunk_read_error` before calling. Both must retire the reader
+    /// rather than leave it live: a reader still marked readable is retried by
+    /// every worker forever, and a consumer parked on this source never wakes.
+    ///
+    /// Takes the guard by value so the reader lock is provably released before
+    /// the consumer is unparked; waking it while still holding the lock would
+    /// have it contend for a lock this thread has not dropped yet.
+    ///
+    /// Returns [`StepResult::Success`] because the *step* completed. A read
+    /// failure reaches the consumer through `chunk_read_error`, not through
+    /// this result.
+    fn retire_phase2_source(
+        shared: &SharedPipelineState,
+        worker: &mut SortWorkerState,
+        file: &Phase2FileState,
+        mut reader_guard: MutexGuard<'_, Phase2Reader>,
+        source: usize,
+        num_sources: usize,
+    ) -> StepResult {
+        file.mark_reader_eof(&mut reader_guard);
+        drop(reader_guard);
+        shared.main_thread_handle.unpark();
+        Self::maybe_mark_all_eof(shared);
+        worker.phase2_file_cursor = (source + 1) % num_sources;
+        StepResult::Success
+    }
 
     /// Check if all sources have reached EOF and set the global flag if so.
     fn maybe_mark_all_eof(shared: &SharedPipelineState) {
@@ -1916,6 +1946,14 @@ impl SortWorkerPool {
     /// Number of worker threads in the pool.
     pub fn num_workers(&self) -> usize {
         self.num_workers
+    }
+
+    /// Busy-time breakdown of worker-side merge work.
+    ///
+    /// Overlapping sums, not a partition of merge wall time -- see
+    /// [`crate::merge_phases`].
+    pub(crate) fn merge_phase_breakdown(&self) -> crate::merge_phases::MergePhaseBreakdown {
+        self.shared.merge_phases.snapshot()
     }
 
     /// Codec used to compress Phase 1 spill chunks.

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -125,7 +125,7 @@ pub(crate) fn read_length_prefix<R: std::io::Read + ?Sized>(
 const ZSTD_FRAME_DECOMP_CAP: usize = 256 * 1024;
 
 /// Hard cap on the `u32 LE` length prefix of any zstd spill frame. Frames are
-/// produced one per ~64 KiB of input by `handle_compress_job`; even
+/// produced one per ~64 KiB of input by `compress_job`; even
 /// pathological expansion can't reach this. Beyond it, we treat the value as
 /// corruption rather than allocate gigabytes.
 pub(crate) const MAX_ZSTD_FRAME_BYTES: usize = 2 * 1024 * 1024;
@@ -1895,9 +1895,11 @@ impl SortWorkerPool {
             CompressTarget::Spill => &shared.merge_phases.spill_compress,
             CompressTarget::Output => &shared.merge_phases.output_compress,
         };
-        counter.time(|| {
-            Self::handle_compress_job(shared, job, bgzf_compressor, zstd_compressor);
-        });
+        // Only the compression is timed; the handoff below can block on a full
+        // result channel, which is writer backpressure rather than CPU work.
+        let compressed =
+            counter.time(|| Self::compress_job(&job, bgzf_compressor, zstd_compressor));
+        Self::deliver_compress_result(shared, job, compressed);
         StepResult::Success
     }
 
@@ -1954,6 +1956,19 @@ impl SortWorkerPool {
     /// Number of worker threads in the pool.
     pub fn num_workers(&self) -> usize {
         self.num_workers
+    }
+
+    /// Number of workers currently eligible to run work, as last set by
+    /// [`Self::set_active_workers`].
+    ///
+    /// Not the same as [`Self::num_workers`]: the pool is sized to the wider of
+    /// the two phases and then capped per phase, so on a run whose Phase 1 is
+    /// wider than its Phase 2 the pool holds threads that cannot take Phase 2
+    /// work. Anything dividing by a thread count — utilization above all —
+    /// wants this number, or it charges the merge for workers that were never
+    /// allowed to help and reports a saturated pool as idle.
+    pub fn active_workers(&self) -> usize {
+        self.shared.active_worker_limit.load(Ordering::Acquire)
     }
 
     /// Busy-time breakdown of worker-side merge work.
@@ -2223,14 +2238,22 @@ impl SortWorkerPool {
         d.as_nanos() as u64
     }
 
-    /// Handle a compress job on a worker thread.
-    fn handle_compress_job(
-        shared: &SharedPipelineState,
-        job: CompressJob,
+    /// Compress one job's payload on a worker thread.
+    ///
+    /// Split from [`Self::deliver_compress_result`] so the merge-phase counters
+    /// can time compression alone. Delivery spins in a `try_send` retry loop
+    /// whenever the writer is behind, and timing the two together charges that
+    /// backpressure to `spill_compress` / `output_compress` — inflating worker
+    /// busy time, and with it the utilization the merge verdict reads, so an
+    /// I/O-bound merge reports as CPU-bound. That distinction is the entire
+    /// point of the breakdown, so the wait is measured nowhere rather than in
+    /// the wrong place.
+    fn compress_job(
+        job: &CompressJob,
         bgzf_compressor: &mut InlineBgzfCompressor,
         zstd_compressor: &mut ZstdCompressor<'static>,
-    ) {
-        let compressed: Vec<u8> = match job.codec {
+    ) -> Vec<u8> {
+        match job.codec {
             SpillCodec::Bgzf => {
                 bgzf_compressor
                     .write_all(&job.data)
@@ -2269,8 +2292,18 @@ impl SortWorkerPool {
                 out.extend_from_slice(&frame);
                 out
             }
-        };
+        }
+    }
 
+    /// Hand a finished compress job to the I/O writer, recycling its input
+    /// buffer.
+    ///
+    /// Deliberately untimed — see [`Self::compress_job`].
+    fn deliver_compress_result(
+        shared: &SharedPipelineState,
+        job: CompressJob,
+        compressed: Vec<u8>,
+    ) {
         let mut recycled = job.data;
         recycled.clear();
 
@@ -2618,7 +2651,7 @@ mod tests {
         pool.shutdown();
     }
 
-    /// zstd is spill-only, and `handle_compress_job` asserts that unconditionally.
+    /// zstd is spill-only, and `compress_job` asserts that unconditionally.
     ///
     /// The assert is the backstop for the one target/codec combination the
     /// per-job `CompressTarget` cannot express correctly: there is a single zstd
@@ -2628,7 +2661,7 @@ mod tests {
     /// test, a future output-zstd feature (or a mis-stamped call site) would only
     /// trip it in production.
     ///
-    /// `handle_compress_job` is called directly, on the test thread, rather than
+    /// `compress_job` is called directly, on the test thread, rather than
     /// through `submit_compress`: a panic on a pool worker unwinds only that
     /// worker — its guard publishes `worker_panicked` and the unwind stops at the
     /// thread boundary — so `#[should_panic]` would never observe it, and the
@@ -2637,14 +2670,12 @@ mod tests {
     #[test]
     #[should_panic(expected = "zstd is spill-only")]
     fn test_zstd_output_job_trips_the_spill_only_assert() {
-        let shared = SharedPipelineState::new(1, std::thread::current());
         let mut bgzf_compressor = InlineBgzfCompressor::new(0);
         let mut zstd_compressor = ZstdCompressor::new(1).expect("zstd compressor init");
         let (result_tx, _result_rx) = bounded(1);
 
-        SortWorkerPool::handle_compress_job(
-            &shared,
-            CompressJob {
+        SortWorkerPool::compress_job(
+            &CompressJob {
                 data: vec![b'A'; 64],
                 serial: 0,
                 result_tx,
@@ -2723,13 +2754,30 @@ mod tests {
     #[test]
     fn set_active_workers_clamps() {
         let pool = SortWorkerPool::new(4, 1, 6, crate::codec::SpillCodec::Bgzf);
+        // A fresh pool is fully active, so anything dividing by the active count
+        // before a cap is applied still gets the pool width.
+        assert_eq!(pool.active_workers(), 4, "a pool starts with every worker active");
         // Clamp to [1, num_workers].
         pool.set_active_workers(0);
-        assert_eq!(pool.shared.active_worker_limit.load(Ordering::Acquire), 1);
+        assert_eq!(pool.active_workers(), 1);
         pool.set_active_workers(100);
-        assert_eq!(pool.shared.active_worker_limit.load(Ordering::Acquire), 4);
+        assert_eq!(pool.active_workers(), 4);
         pool.set_active_workers(2);
-        assert_eq!(pool.shared.active_worker_limit.load(Ordering::Acquire), 2);
+        assert_eq!(pool.active_workers(), 2);
+        pool.shutdown();
+    }
+
+    /// The merge breakdown divides worker busy time by the *active* count, so a
+    /// pool sized to a wide Phase 1 and capped to a narrower Phase 2 must report
+    /// the narrower number — reporting the pool width there would understate
+    /// utilization and flip the merge verdict from CPU-bound to I/O-bound.
+    #[test]
+    fn active_workers_reports_the_phase2_cap_not_the_pool_width() {
+        let pool = SortWorkerPool::new(8, 1, 6, crate::codec::SpillCodec::Bgzf);
+        pool.set_active_workers(8);
+        pool.begin_phase2(3);
+        assert_eq!(pool.num_workers(), 8, "the pool is still eight threads wide");
+        assert_eq!(pool.active_workers(), 3, "but only three may take Phase 2 work");
         pool.shutdown();
     }
 


### PR DESCRIPTION
The k-way merge dominates a spill-heavy sort — 54% of wall clock on a 780M-record WGS BAM — and `SortPhaseTimer` reports it as a single number whose own doc concedes the span "includes reader decompression + writer compression". That is enough to know the merge is where the time goes, and not enough to know what to do about it.

This splits the merge into its components: spill disk read, spill decompression, and output compression on the worker side, alongside the main thread's loser-tree work. It runs unconditionally at `info`, so the breakdown is in every log rather than behind a flag.

## What it revealed

Run on `1kg-wgs-HG00096` (780M records, 86 spilled runs, 8 threads, c7g.4xlarge, EBS), with three arms differing only in compression:

| arm | spill volume | output | merge wall | total wall | worker util |
| --- | --- | --- | --- | --- | --- |
| baseline (zstd spill, output level 1) | 44.5 GB | 45.4 GB | 325.9s | **598.8s** | 52% |
| uncompressed spill | 315 GB | 45.4 GB | 1153.9s | 1870.4s (3.1×) | 21% |
| uncompressed output | 44.5 GB | 310 GB | 718.7s | 990.8s (1.7×) | 10% |

Baseline breakdown: output compression 952.1s (70% of worker busy time), spill decompression 251.4s (18%), spill disk read 158.0s (12%).

The finding is that **compression is load-bearing, not overhead.** It runs ~7:1 on this data, and removing it from either side makes the sort substantially slower — the worker pool idles waiting on I/O instead of finishing early, which is exactly what the utilization column shows. A breakdown that reported only "compression is 70% of merge CPU" would invite precisely the wrong optimization; pairing it with utilization is what makes it actionable.

That conclusion is also substrate-dependent, which is worth knowing before anyone reuses these numbers. The same three arms on a laptop with local NVMe and a warm page cache produce the opposite ordering — there I/O is nearly free, the pool saturates at 93% utilization, and removing output compression *does* speed the merge up. The instrument reports both honestly; the interpretation belongs to whoever reads it.

## What is measured, and how to read it

The two halves are measured differently and are labelled as such in the output:

- **Consumer rows** are sampled 1-in-1021 and scaled. They estimate one thread's wall clock and do partition `loop wall`.
- **Worker rows** are exact busy-time sums across every pool thread. They overlap each other *and* the consumer, and routinely exceed `loop wall`.

Comparing a worker row to loop wall clock is meaningless; comparing worker rows to each other is the point. `worker_utilization` — `busy / (merge_wall × workers)` — is the one figure that legitimately relates the two.

Example output:

```
=== Merge Sub-Phase Timing ===
  Consumer (main thread; 1979 samples of 2020089 records, scaled 1021x)
    Fetch next record: 0.7s  (includes waiting on decompressed blocks)
    Loser tree:        0.4s
    Enqueue write:     0.5s  (hands off to workers; excludes compression)
    Loop wall clock:   1.3s
  Workers (8 threads; busy time, overlaps the above and itself)
    Spill disk read:   158.0s (12%) [1270320 batches]
    Spill decompress:  251.4s (18%) [5080820 blocks]
    Output compress:   952.1s (70%) [5114375 blocks]
    Total worker busy: 1361.6s  (NOT comparable to loop wall clock)
    Worker utilization: 52% of 8 threads x 325.8s
  Phase 1 (not part of the merge)
    Spill compress:    612.3s [5080820 blocks]
==============================
```

## Three problems found while validating it

Each is fixed here, and each is the reason to trust the numbers above.

**Spill compression was charged to the merge.** `try_compress` serves both `CompressTarget::Spill` and `CompressTarget::Output` through one step, so a single counter attributed Phase 1's spill compression to the merge — reporting 82,549 compressed blocks on a sort whose merge writes 16,506. Split by target; the counts now cross-check, with 5,080,820 spill blocks compressed in Phase 1 against exactly 5,080,820 decompressed during the merge.

**The consumer sample aliased against block boundaries.** The interval was 1024 records; records are ~100 bytes and spill blocks ~64 KB, so the sampled record kept landing on the refill that blocks waiting for the next block. Scaling those up overstated the consumer by 2× — the sub-phases summed to more than the loop wall clock they partition. A prime interval decorrelates it and brings the overshoot to ~20%, which is the floor for timing ~100ns spans with a ~25ns clock-read pair. The reporter now checks that sum against loop wall itself and says so in the log when it does not hold, rather than leaving a reader to notice the arithmetic.

**The breakdown was gated behind `log_enabled!(Debug)`.** Benchmark logs run at `info`, so the one thing that explains a merge-dominated sort was absent from every log actually collected. It now runs unconditionally.

## Cost

The worker counters scale with blocks, not records: ~52K `Instant::now()` pairs for a 2M-read sort, against block spans of 35–150 µs — about 0.03%.

The consumer path is sampled, and the sampling test is a countdown rather than a modulo. `records_merged % 1021` would be a multiply-shift on every record (~0.1% of a billion-record merge); a decrement and a perfectly-predicted branch is not measurable. That is deliberate: it removes the argument for putting this behind a flag, and instrumentation behind a flag is absent from exactly the logs where it is needed — which is how the consumer breakdown sat unused behind `debug!` in the first place.

## Notes

- `merge_chunks_with_index` (the `--write-index` path) has its own merge loop and is not instrumented; only `merge_chunks_generic` is. Worth extending if the indexed path ever becomes the one under investigation.
- The utilization figure counts only merge-attributed worker busy time, so it is a lower bound on total worker activity — workers may be doing other steps. It answers "was the pool saturated by merge work", not "was the pool idle".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: sort output is unchanged; no `unsafe` changes and no CLAUDE.md allowlist update is needed; no memory bound, queue capacity, or thread/backpressure policy changes.

Adds unconditional merge-phase diagnostics for spill reads, decompression, output compression, and Phase 1 spill compression. Adds sampled consumer timing, exact worker busy time, worker utilization, and CPU/I/O/mixed bottleneck classification. Adds atomic counters and tests for timing accumulation and verdict thresholds. Indexed merge remains uninstrumented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->