### PR TITLE
perf(sort): say why the merge stalled, and trace every stage a spill block passes through

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1284,6 +1284,9 @@ pub(crate) struct MainThreadChunkConsumer<K: RawSortKey + 'static> {
     chunk_read_error: std::sync::Arc<std::sync::atomic::AtomicBool>,
     /// Set by `do_shutdown` when a worker thread panicked unexpectedly.
     worker_panicked: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Where and for how long the merge loop blocked. Only this thread touches
+    /// it -- see [`crate::merge_stalls::ConsumerStallTracker`].
+    stalls: crate::merge_stalls::ConsumerStallTracker,
     _phantom: std::marker::PhantomData<K>,
 }
 
@@ -1297,14 +1300,61 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
         worker_panicked: std::sync::Arc<std::sync::atomic::AtomicBool>,
     ) -> Self {
         let parser_state = (0..files.len()).map(|_| SourceParserState::new()).collect();
+        let stalls = crate::merge_stalls::ConsumerStallTracker::new(files.len());
         Self {
             files,
             parser_state,
             decompression_error,
             chunk_read_error,
             worker_panicked,
+            stalls,
             _phantom: std::marker::PhantomData,
         }
+    }
+
+    /// Where and for how long the merge loop blocked waiting for blocks.
+    pub(crate) fn stall_report(&self) -> crate::merge_stalls::ConsumerStallReport {
+        self.stalls.snapshot()
+    }
+
+    /// Observe every file's buffering state, for attributing one park.
+    ///
+    /// `try_lock` throughout: this runs while the merge is stalled and must not
+    /// add to the stall it is measuring, nor perturb the very contention it is
+    /// trying to detect. A file whose locks are both held is reported as
+    /// `contended` rather than guessed at. The two locks are taken and released
+    /// one at a time, so this introduces no lock ordering of its own.
+    fn census(&self, waited_on: usize) -> crate::merge_stalls::ParkCensus {
+        use crate::worker_pool::PHASE2_DECOMP_CAP;
+
+        let mut census = crate::merge_stalls::ParkCensus::default();
+        for (idx, file) in self.files.iter().enumerate() {
+            let Ok(raw_len) = file.raw_blocks.try_lock().map(|g| g.len()) else {
+                census.contended += 1;
+                continue;
+            };
+            let Ok(decomp_len) = file.decompressed.try_lock().map(|g| g.len()) else {
+                census.contended += 1;
+                continue;
+            };
+            let in_flight = file.decomp_in_flight.load(std::sync::atomic::Ordering::Relaxed);
+            let at_eof = file.reader_eof.load(std::sync::atomic::Ordering::Relaxed);
+            let empty = raw_len == 0 && decomp_len == 0 && in_flight == 0;
+
+            if decomp_len >= PHASE2_DECOMP_CAP {
+                census.capped += 1;
+            } else if empty && at_eof {
+                census.drained += 1;
+            } else if empty {
+                census.starved += 1;
+                if idx == waited_on {
+                    census.waited_on_starved = true;
+                }
+            } else {
+                census.working += 1;
+            }
+        }
+        census
     }
 
     /// Get the next record from a specific source.
@@ -1353,12 +1403,18 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
     /// `Ok(false)` if the source has produced all its data, or an error if a
     /// worker reported a fatal failure.
     fn advance_to_next_block(&mut self, source_id: usize) -> Result<bool> {
-        let file = &self.files[source_id];
+        self.stalls.note_block_pull();
+        let mut parked_yet = false;
+        // The file is re-borrowed per iteration rather than held: the stall
+        // tracker below needs `&mut self`, and a long-lived `&self.files[..]`
+        // would keep `self` immutably borrowed across the whole loop.
         loop {
             // Try to pop the next-in-order decompressed block.
             {
-                let mut guard =
-                    file.decompressed.lock().expect("phase2 decompressed mutex poisoned");
+                let mut guard = self.files[source_id]
+                    .decompressed
+                    .lock()
+                    .expect("phase2 decompressed mutex poisoned");
                 if let Some(data) = guard.try_pop_next() {
                     drop(guard);
                     let st = &mut self.parser_state[source_id];
@@ -1386,7 +1442,7 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
             }
 
             // Source produced everything it ever will?
-            if file.is_drained() {
+            if self.files[source_id].is_drained() {
                 return Ok(false);
             }
 
@@ -1394,7 +1450,26 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
             // decompressed block, after setting reader.eof, and after error
             // flags. The loop re-checks all conditions on wake-up so spurious
             // wake-ups are harmless.
+            //
+            // This is where the merge loop actually blocks, and it is timed
+            // exactly rather than sampled: parks happen once per ~64 KB block
+            // instead of once per ~100-byte record, so an `Instant` pair here is
+            // three orders of magnitude cheaper than one per record -- and it
+            // separates *waiting* from the record copy that the sampled "fetch
+            // next record" figure folds in with it.
+            if self.stalls.should_census() {
+                let census = self.census(source_id);
+                self.stalls.record_census(census);
+            }
+            let park_start = Instant::now();
             std::thread::park();
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "a single park cannot approach 2^64 nanoseconds"
+            )]
+            let parked_ns = park_start.elapsed().as_nanos() as u64;
+            self.stalls.record_park(source_id, parked_ns, !parked_yet);
+            parked_yet = true;
         }
     }
 
@@ -3652,9 +3727,11 @@ impl RawExternalSorter {
             ),
             MergeVerdict::IoBound => info!(
                 "  Verdict: workers idle ({util_pct:.0}% of capacity) while the consumer spent \
-                 {fetch_pct:.0}% of its loop waiting for data -- this suggests the merge is \
-                 I/O-bound. More threads are unlikely to help; faster storage, or spilling \
-                 fewer bytes, would."
+                 {fetch_pct:.0}% of its loop waiting for data -- neither side is the constraint. \
+                 More threads are unlikely to help. Storage is one candidate; the pipeline's own \
+                 coordination -- per-file read-ahead depth, lock contention, how late idle \
+                 workers notice new work -- is another, and the Merge Stalls block below is what \
+                 separates them."
             ),
             MergeVerdict::Mixed => info!(
                 "  Verdict: worker pool {util_pct:.0}% utilized, consumer {fetch_pct:.0}% \
@@ -3688,6 +3765,7 @@ impl RawExternalSorter {
         sampling: (u64, u64),
         active_workers: usize,
         pool: &Arc<SortWorkerPool>,
+        stalls: Option<crate::merge_stalls::ConsumerStallReport>,
     ) {
         let (write_secs, read_secs, tree_secs) = consumer;
         let (samples_taken, records_merged) = sampling;
@@ -3719,6 +3797,21 @@ impl RawExternalSorter {
             info!(
                 "    NOTE: rows sum to {consumer_est:.1}s > loop wall {loop_total:.1}s, so the \
                  sample is biased; treat consumer rows as indicative only"
+            );
+        }
+        // Parking is a subset of "fetch next record", so exact park time cannot
+        // legitimately exceed the sampled estimate of it. When it does, the
+        // sample missed stalls: parks are rare per record and expensive when
+        // they happen, and a 1-in-1021 record sample of a heavy-tailed event has
+        // enough variance to land far off in either direction. The exact figure
+        // in the stall block below supersedes this row whenever they disagree.
+        if let Some(s) = stalls
+            && s.park_secs > est_read * 1.05
+        {
+            info!(
+                "    NOTE: exact park time is {:.1}s, above the sampled fetch estimate of \
+                 {est_read:.1}s -- the sample under-caught stalls; prefer the Merge Stalls block",
+                s.park_secs
             );
         }
 
@@ -3761,7 +3854,135 @@ impl RawExternalSorter {
                 if loop_total > 0.0 { est_read / loop_total } else { 0.0 },
             );
         }
+        Self::log_merge_stalls(loop_total, stalls, pool);
         info!("==============================");
+    }
+
+    /// Log why the merge stalled, as opposed to where its time went.
+    ///
+    /// The three blocks answer one question each, and only together: the
+    /// consumer's exact park time and the state of the other files when it
+    /// parked; why worker file-scans came back empty; and how much of the
+    /// workers' idle time was spent asleep *through* work becoming available.
+    /// See [`crate::merge_stalls`].
+    #[allow(clippy::cast_precision_loss)]
+    fn log_merge_stalls(
+        loop_total: f64,
+        stalls: Option<crate::merge_stalls::ConsumerStallReport>,
+        pool: &Arc<SortWorkerPool>,
+    ) {
+        use crate::merge_stalls::{Phase2Skip, ScanVerdict};
+
+        let scans = pool.phase2_scan_report();
+        let wake = pool.wake_latency_report();
+        let stalls = stalls.filter(|s| !s.is_empty());
+        if stalls.is_none() && scans.is_empty() && wake.is_empty() {
+            return;
+        }
+
+        info!("=== Merge Stalls ===");
+
+        if let Some(s) = stalls {
+            Self::log_consumer_stalls(loop_total, s);
+        }
+
+        if !scans.is_empty() {
+            let reasons = Phase2Skip::ALL
+                .iter()
+                .map(|&r| format!("{}={}", r.label(), scans.skips[r as usize]))
+                .collect::<Vec<_>>()
+                .join(" ");
+            info!("  Worker scans finding no work: {} ({reasons})", scans.scans);
+            info!(
+                "    Of those: {:.0}% backpressured, {:.0}% waiting on a peer's read, {:.0}% \
+                 contended",
+                100.0 * scans.verdict_share(ScanVerdict::Backpressured),
+                100.0 * scans.verdict_share(ScanVerdict::IoWait),
+                100.0 * scans.verdict_share(ScanVerdict::Contended)
+            );
+        }
+
+        if !wake.is_empty() {
+            info!(
+                "  Worker discovery lag: ~{:.1}s of {:.1}s deep-sleep worker-seconds; {} sleeps \
+                 ended in a find, {:.0}% of them after >=320us",
+                wake.estimated_discovery_lag_secs(),
+                wake.deep_sleep_idle_secs(),
+                wake.productive_sleep_count(),
+                100.0 * wake.deep_sleep_wake_share()
+            );
+            info!(
+                "    (nothing unparks a worker, so this bounds how late work is noticed; it \
+                 delays the merge only when every worker is asleep at once)"
+            );
+        }
+    }
+
+    /// Log where the merge loop blocked and what the other files were doing.
+    ///
+    /// Exact, not sampled -- see [`crate::merge_stalls`]. When this disagrees
+    /// with the sampled "fetch next record" row above, this is the one to
+    /// believe.
+    #[allow(clippy::cast_precision_loss)]
+    fn log_consumer_stalls(loop_total: f64, s: crate::merge_stalls::ConsumerStallReport) {
+        use crate::merge_stalls::{StallShape, classify_stall};
+
+        let park_fraction = if loop_total > 0.0 { s.park_secs / loop_total } else { 0.0 };
+        info!(
+            "  Consumer parked: {:.1}s ({:.0}% of loop wall, exact) over {} parks",
+            s.park_secs,
+            100.0 * park_fraction,
+            s.parks
+        );
+        info!(
+            "    Block pulls that had to wait: {}/{} ({:.0}%), {:.1} parks each (1.0 = no wasted \
+             wake-ups)",
+            s.stalled_pulls,
+            s.block_pulls,
+            100.0 * s.stall_rate(),
+            s.parks_per_stall()
+        );
+        info!(
+            "    Worst source: #{} at {:.1}s ({:.0}% of park time; {} sources parked on)",
+            s.top_source,
+            s.top_source_park_secs,
+            100.0 * s.top_source_share(),
+            s.sources_parked_on
+        );
+        if s.censuses > 0 {
+            info!(
+                "    At a park ({} sampled): {:.0}% of live files at cap, {:.0}% starved, {:.0}% \
+                 unreadable; the awaited file was starved {:.0}% of the time",
+                s.censuses,
+                100.0 * s.capped_share,
+                100.0 * s.starved_share,
+                100.0 * s.contended_share,
+                100.0 * s.waited_on_starved_share
+            );
+        }
+        match classify_stall(
+            park_fraction,
+            s.capped_share,
+            s.starved_share,
+            s.contended_share,
+            s.waited_on_starved_share,
+        ) {
+            StallShape::NotStalled => info!("    Shape: the consumer is not waiting on blocks"),
+            StallShape::HeadOfLine => info!(
+                "    Shape: head-of-line -- the consumer waits on a starved file while the rest \
+                 sit at their cap. Read-ahead is spread evenly across files but demand is not, so \
+                 a uniformly larger cap would buffer more of what is not needed next"
+            ),
+            StallShape::PoolStarved => info!(
+                "    Shape: the pool cannot keep up -- most files are empty, so the constraint is \
+                 upstream of the per-file caps"
+            ),
+            StallShape::Contended => info!(
+                "    Shape: lock contention -- a large share of file state could not be read \
+                 without blocking, so the shares above understate what was available"
+            ),
+            StallShape::Mixed => info!("    Shape: no single candidate dominates"),
+        }
     }
 
     /// Generic merge for keyed chunks using `O(1)` key comparisons.
@@ -3907,6 +4128,12 @@ impl RawExternalSorter {
         // active, so the number cannot depend on what teardown does to the cap.
         let active_workers = pool.active_workers();
 
+        // Harvest the consumer's stall report before finalizing: `finish_output`
+        // releases the merge sources and with them the consumer, and the report
+        // describes the loop that has just ended rather than the output drain
+        // that follows.
+        let stalls = guard.consumer_ref().map(MainThreadChunkConsumer::stall_report);
+
         // Finalize before logging. `finish` drains the output queue, and every
         // block still in it is compressed by the same workers this breakdown
         // reports -- so a snapshot taken first omits the tail of
@@ -3921,6 +4148,7 @@ impl RawExternalSorter {
             (samples_taken, records_merged),
             active_workers,
             pool,
+            stalls,
         );
 
         merge_progress.log_final();
@@ -3982,6 +4210,7 @@ impl RawExternalSorter {
             .with_interval(1_000_000)
             .with_total(total_records);
 
+        let loop_start = Instant::now();
         while tree.winner_is_active() {
             let winner = tree.winner();
             let src_idx = source_map[winner];
@@ -3995,6 +4224,17 @@ impl RawExternalSorter {
                 tree.remove_winner();
             }
         }
+
+        // This path has no sampled sub-phase breakdown -- adding the per-record
+        // sampling here would duplicate the merge loop rather than share it --
+        // but the stall counters need no sampling at all, so an indexed sort is
+        // not left with nothing. `--write-index` is the default for a
+        // coordinate sort, so that gap covers most production merges.
+        Self::log_merge_stalls(
+            loop_start.elapsed().as_secs_f64(),
+            guard.consumer_ref().map(MainThreadChunkConsumer::stall_report),
+            pool,
+        );
 
         let index = guard.finish_output(|| writer.finish_index())?;
         merge_progress.log_final();

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1325,6 +1325,7 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
     /// `contended` rather than guessed at. The two locks are taken and released
     /// one at a time, so this introduces no lock ordering of its own.
     fn census(&self, waited_on: usize) -> crate::merge_stalls::ParkCensus {
+        use crate::merge_stalls::AwaitedState;
         use crate::worker_pool::PHASE2_DECOMP_CAP;
 
         let mut census = crate::merge_stalls::ParkCensus::default();
@@ -1341,15 +1342,32 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
             let at_eof = file.reader_eof.load(std::sync::atomic::Ordering::Relaxed);
             let empty = raw_len == 0 && decomp_len == 0 && in_flight == 0;
 
+            if idx == waited_on {
+                // The caller has just failed `try_pop_next` on this file, so a
+                // non-empty reorder buffer is proof it holds serials other than
+                // the one wanted -- a gap, not merely "some data". That is what
+                // makes these five states a decision rather than an inference.
+                census.awaited = Some(if decomp_len > 0 {
+                    if in_flight > 0 {
+                        AwaitedState::ReorderGapFilling
+                    } else {
+                        AwaitedState::ReorderGapStalled
+                    }
+                } else if in_flight > 0 {
+                    AwaitedState::Decompressing
+                } else if raw_len > 0 {
+                    AwaitedState::RawQueued
+                } else {
+                    AwaitedState::Starved
+                });
+            }
+
             if decomp_len >= PHASE2_DECOMP_CAP {
                 census.capped += 1;
             } else if empty && at_eof {
                 census.drained += 1;
             } else if empty {
                 census.starved += 1;
-                if idx == waited_on {
-                    census.waited_on_starved = true;
-                }
             } else {
                 census.working += 1;
             }
@@ -3951,31 +3969,46 @@ impl RawExternalSorter {
         );
         if s.censuses > 0 {
             info!(
-                "    At a park ({} sampled): {:.0}% of live files at cap, {:.0}% starved, {:.0}% \
-                 unreadable; the awaited file was starved {:.0}% of the time",
+                "    Other files at a park ({} parks sampled): {:.0}% at cap, {:.0}% starved, \
+                 {:.0}% unreadable",
                 s.censuses,
                 100.0 * s.capped_share,
                 100.0 * s.starved_share,
-                100.0 * s.contended_share,
-                100.0 * s.waited_on_starved_share
+                100.0 * s.contended_share
+            );
+            info!(
+                "    The awaited file: {:.0}% gap-filling, {:.0}% gap-stalled, {:.0}% \
+                 decompressing, {:.0}% raw-queued, {:.0}% starved",
+                100.0 * s.awaited.reorder_gap_filling,
+                100.0 * s.awaited.reorder_gap_stalled,
+                100.0 * s.awaited.decompressing,
+                100.0 * s.awaited.raw_queued,
+                100.0 * s.awaited.starved
+            );
+            info!(
+                "      -> block not read yet {:.0}%, exists but unclaimed {:.0}%, being produced \
+                 {:.0}%",
+                100.0 * s.awaited.starved,
+                100.0 * s.awaited.unclaimed(),
+                100.0 * s.awaited.in_progress()
             );
         }
-        match classify_stall(
-            park_fraction,
-            s.capped_share,
-            s.starved_share,
-            s.contended_share,
-            s.waited_on_starved_share,
-        ) {
+        match classify_stall(park_fraction, s.contended_share, s.awaited) {
             StallShape::NotStalled => info!("    Shape: the consumer is not waiting on blocks"),
             StallShape::HeadOfLine => info!(
-                "    Shape: head-of-line -- the consumer waits on a starved file while the rest \
-                 sit at their cap. Read-ahead is spread evenly across files but demand is not, so \
-                 a uniformly larger cap would buffer more of what is not needed next"
+                "    Shape: head-of-line -- the awaited file has nothing anywhere in its \
+                 pipeline, so the block has not been read from disk yet. The constraint is \
+                 upstream of the pool: storage, or read concurrency"
             ),
-            StallShape::PoolStarved => info!(
-                "    Shape: the pool cannot keep up -- most files are empty, so the constraint is \
-                 upstream of the per-file caps"
+            StallShape::WorkUnclaimed => info!(
+                "    Shape: work unclaimed -- the block the consumer needs already exists and no \
+                 worker is on it. Capacity is not the problem; scheduling and wake latency are. \
+                 Compare the discovery-lag line below"
+            ),
+            StallShape::DecompressLatency => info!(
+                "    Shape: decompression latency -- a worker is already producing the needed \
+                 block, so the consumer is paying the per-block cost serially. Only running \
+                 further ahead (a deeper PHASE2_DECOMP_CAP) or faster decompression removes it"
             ),
             StallShape::Contended => info!(
                 "    Shape: lock contention -- a large share of file state could not be read \

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1287,7 +1287,57 @@ pub(crate) struct MainThreadChunkConsumer<K: RawSortKey + 'static> {
     /// Where and for how long the merge loop blocked. Only this thread touches
     /// it -- see [`crate::merge_stalls::ConsumerStallTracker`].
     stalls: crate::merge_stalls::ConsumerStallTracker,
+    /// Shared pool state, for the epoch clock and the trace counters that
+    /// record both halves of a producer/consumer handoff.
+    shared: Arc<crate::worker_pool::SharedPipelineState>,
+    /// Source the previous block came from, and how many consecutive blocks
+    /// have now come from it. Says whether the merge dwells on one run at a
+    /// time -- in which case lookahead on that run would pay -- or hops.
+    current_run: Option<(usize, u64)>,
     _phantom: std::marker::PhantomData<K>,
+}
+
+/// Whether the merge block-lifecycle block has nothing to print.
+///
+/// Every report that block prints must appear here. A report missing from the
+/// gate is dropped whenever it is the only one populated -- which is exactly
+/// when it is the whole story. `scans` is the case that bit: the fruitless-scan
+/// cost is the figure the `WorkUnclaimed` verdict tells the reader to compare
+/// against, so a scans-only run lost the number its own verdict pointed at.
+///
+/// Pure so the coverage is testable without capturing log output, following
+/// [`classify_scan`](crate::merge_stalls::classify_scan).
+fn block_lifecycle_is_silent(
+    life: &crate::merge_trace::BlockLifecycleReport,
+    refill: &crate::merge_trace::RefillReport,
+    consumer: &crate::merge_trace::ConsumerTraceReport,
+    scans: &crate::merge_trace::HistogramReport,
+) -> bool {
+    life.is_empty() && refill.is_empty() && consumer.is_empty() && scans.is_empty()
+}
+
+/// Whether the merge stall block has nothing to print.
+///
+/// Deliberately separate from [`block_lifecycle_is_silent`], and never a gate on
+/// it: these three reports are populated by the pipeline *stalling*, the
+/// lifecycle reports by it *working*. A merge that flowed cleanly leaves this
+/// gate silent and the lifecycle gate loud, so letting this one decide whether
+/// the lifecycle block prints would drop the whole trace on exactly the runs
+/// that produced a complete one.
+///
+/// Pure so the coverage is testable without capturing log output, following
+/// [`classify_scan`](crate::merge_stalls::classify_scan). The emptiness check on
+/// `stalls` is deliberately kept here even though the caller already drops an
+/// empty report: the caller drops it for its own reason -- an empty report must
+/// not reach the block that prints it -- and a gate that answers "is there
+/// anything to print" only when someone else has pre-filtered its input is a
+/// gate whose test proves nothing.
+fn merge_stalls_are_silent(
+    stalls: Option<&crate::merge_stalls::ConsumerStallReport>,
+    scans: &crate::merge_stalls::Phase2ScanReport,
+    wake: &crate::merge_stalls::WakeLatencyReport,
+) -> bool {
+    stalls.is_none_or(|s| s.is_empty()) && scans.is_empty() && wake.is_empty()
 }
 
 impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
@@ -1298,6 +1348,7 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
         decompression_error: std::sync::Arc<std::sync::atomic::AtomicBool>,
         chunk_read_error: std::sync::Arc<std::sync::atomic::AtomicBool>,
         worker_panicked: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        shared: Arc<crate::worker_pool::SharedPipelineState>,
     ) -> Self {
         let parser_state = (0..files.len()).map(|_| SourceParserState::new()).collect();
         let stalls = crate::merge_stalls::ConsumerStallTracker::new(files.len());
@@ -1308,8 +1359,44 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
             chunk_read_error,
             worker_panicked,
             stalls,
+            shared,
+            current_run: None,
             _phantom: std::marker::PhantomData,
         }
+    }
+
+    /// Note that the merge is taking a block from `source_id`, closing the
+    /// previous source's run if it switched.
+    fn note_source_run(&mut self, source_id: usize) {
+        match self.current_run {
+            Some((prev, blocks)) if prev == source_id => {
+                self.current_run = Some((prev, blocks + 1));
+            }
+            Some((_, blocks)) => {
+                self.shared.consumer_trace.record_source_run(blocks);
+                self.current_run = Some((source_id, 1));
+            }
+            None => self.current_run = Some((source_id, 1)),
+        }
+    }
+
+    /// Flush the run in progress, so the last one is not lost at end of merge.
+    pub(crate) fn finish_source_run(&mut self) {
+        if let Some((_, blocks)) = self.current_run.take() {
+            self.shared.consumer_trace.record_source_run(blocks);
+        }
+    }
+
+    /// Start the stall accounting from now, discarding what came before.
+    ///
+    /// Called once the loser tree is seeded, so the stall figures cover the same
+    /// interval as `loop_total` -- see
+    /// [`ConsumerStallTracker::restart`](crate::merge_stalls::ConsumerStallTracker::restart).
+    pub(crate) fn restart_stalls(&mut self) {
+        self.stalls.restart();
+        // The seeding pulls opened a run that belongs to the same discarded
+        // interval; drop it rather than let it extend the merge's first run.
+        self.current_run = None;
     }
 
     /// Where and for how long the merge loop blocked waiting for blocks.
@@ -1347,19 +1434,7 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
                 // non-empty reorder buffer is proof it holds serials other than
                 // the one wanted -- a gap, not merely "some data". That is what
                 // makes these five states a decision rather than an inference.
-                census.awaited = Some(if decomp_len > 0 {
-                    if in_flight > 0 {
-                        AwaitedState::ReorderGapFilling
-                    } else {
-                        AwaitedState::ReorderGapStalled
-                    }
-                } else if in_flight > 0 {
-                    AwaitedState::Decompressing
-                } else if raw_len > 0 {
-                    AwaitedState::RawQueued
-                } else {
-                    AwaitedState::Starved
-                });
+                census.awaited = Some(AwaitedState::classify(decomp_len, in_flight, raw_len));
             }
 
             if decomp_len >= PHASE2_DECOMP_CAP {
@@ -1428,18 +1503,68 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
         // would keep `self` immutably borrowed across the whole loop.
         loop {
             // Try to pop the next-in-order decompressed block.
+            //
+            // Whether a block was actually taken is carried out of the block
+            // scope rather than returned from inside it, because crediting the
+            // source's run needs `&mut self` and the borrow of `self.files`
+            // taken below is still live in there.
+            let mut popped = false;
             {
-                let mut guard = self.files[source_id]
-                    .decompressed
-                    .lock()
-                    .expect("phase2 decompressed mutex poisoned");
-                if let Some(data) = guard.try_pop_next() {
+                let file = &self.files[source_id];
+                let mut guard =
+                    file.decompressed.lock().expect("phase2 decompressed mutex poisoned");
+                if let Some(block) = guard.try_pop_next() {
+                    let remaining = guard.len();
+                    file.decomp_len.store(remaining, std::sync::atomic::Ordering::Relaxed);
+                    // This pop may have drained the file, which opens a refill
+                    // cycle. Opening it here, at the instant the buffer hits
+                    // zero rather than when the consumer next comes back for a
+                    // block, measures the pipeline's response time rather than
+                    // the consumer's round trip.
+                    //
+                    // Opened while this mutex is still held, because a worker
+                    // closes the cycle under the same mutex and the two must not
+                    // interleave: otherwise an insert could observe a cycle,
+                    // have this pop close it and open the next, and then record
+                    // its latency against the new cycle and clear it -- losing
+                    // that cycle's real measurement and booking a zero for it.
+                    //
+                    // Only a drain pays for the extra work in the critical
+                    // section, so the cost falls once per refill cycle rather
+                    // than once per block, and the clock read and the histogram
+                    // record both stay outside the lock on the common path.
+                    let emptied_cause = if remaining == 0 {
+                        let cause = crate::merge_trace::EmptyCause::classify(
+                            file.raw_len.load(std::sync::atomic::Ordering::Relaxed),
+                            file.decomp_in_flight.load(std::sync::atomic::Ordering::Relaxed),
+                        );
+                        file.mark_emptied(self.shared.now_nanos(), cause);
+                        Some(cause)
+                    } else {
+                        None
+                    };
                     drop(guard);
+                    if let Some(cause) = emptied_cause {
+                        self.shared.refill.record_empty(cause);
+                    }
+                    let now = self.shared.now_nanos();
+                    self.shared
+                        .block_lifecycle
+                        .reorder_dwell
+                        .record(now.saturating_sub(block.inserted_nanos));
                     let st = &mut self.parser_state[source_id];
-                    st.current_buf = data;
+                    st.current_buf = block.data;
                     st.current_pos = 0;
-                    return Ok(true);
+                    popped = true;
                 }
+            }
+            if popped {
+                // Only a block that was actually consumed extends the source's
+                // run. Crediting the call instead adds one phantom block to
+                // every completed run, because a source at EOF is pulled from
+                // once more and comes back empty.
+                self.note_source_run(source_id);
+                return Ok(true);
             }
 
             // No block ready. Check error flags first — they take precedence
@@ -1479,14 +1604,18 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
                 let census = self.census(source_id);
                 self.stalls.record_census(census);
             }
+            // Classify the awaited file on *every* park, not just the censused
+            // ones: the depths are plain atomics, so unlike the pool-wide
+            // census this costs three relaxed loads rather than 86 `try_lock`s.
+            // Park durations are heavy-tailed, so the per-state distribution is
+            // exactly the thing a sampled version would get wrong.
+            let (raw_len, decomp_len, in_flight) = self.files[source_id].depths();
+            let state = crate::merge_stalls::AwaitedState::classify(decomp_len, in_flight, raw_len);
             let park_start = Instant::now();
             std::thread::park();
-            #[allow(
-                clippy::cast_possible_truncation,
-                reason = "a single park cannot approach 2^64 nanoseconds"
-            )]
-            let parked_ns = park_start.elapsed().as_nanos() as u64;
+            let parked_ns = crate::merge_trace::elapsed_nanos(park_start);
             self.stalls.record_park(source_id, parked_ns, !parked_yet);
+            self.shared.consumer_trace.record_park(state, parked_ns, in_flight);
             parked_yet = true;
         }
     }
@@ -3710,6 +3839,7 @@ impl RawExternalSorter {
                 pool.decompress_error_flag(),
                 pool.chunk_read_error_flag(),
                 pool.worker_panicked_flag(),
+                pool.shared_state(),
             )
         });
         pool.set_phase(crate::worker_pool::phase::PHASE2);
@@ -3894,46 +4024,150 @@ impl RawExternalSorter {
         let scans = pool.phase2_scan_report();
         let wake = pool.wake_latency_report();
         let stalls = stalls.filter(|s| !s.is_empty());
-        if stalls.is_none() && scans.is_empty() && wake.is_empty() {
+        if !merge_stalls_are_silent(stalls.as_ref(), &scans, &wake) {
+            info!("=== Merge Stalls ===");
+
+            if let Some(s) = stalls {
+                Self::log_consumer_stalls(loop_total, s);
+            }
+
+            if !scans.is_empty() {
+                let reasons = Phase2Skip::ALL
+                    .iter()
+                    .map(|&r| format!("{}={}", r.label(), scans.skips[r as usize]))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                info!("  Worker scans finding no work: {} ({reasons})", scans.scans);
+                info!(
+                    "    Of those: {:.0}% backpressured, {:.0}% waiting on a peer's read, {:.0}% \
+                     contended",
+                    100.0 * scans.verdict_share(ScanVerdict::Backpressured),
+                    100.0 * scans.verdict_share(ScanVerdict::IoWait),
+                    100.0 * scans.verdict_share(ScanVerdict::Contended)
+                );
+            }
+
+            if !wake.is_empty() {
+                info!(
+                    "  Worker discovery lag: ~{:.1}s of {:.1}s deep-sleep worker-seconds; {} \
+                     sleeps ended in a find, {:.0}% of them after >=320us",
+                    wake.estimated_discovery_lag_secs(),
+                    wake.deep_sleep_idle_secs(),
+                    wake.productive_sleep_count(),
+                    100.0 * wake.deep_sleep_wake_share()
+                );
+                info!(
+                    "    (nothing unparks a worker, so this bounds how late work is noticed; it \
+                     delays the merge only when every worker is asleep at once)"
+                );
+            }
+
+            // Close this block before delegating: `log_block_lifecycle` opens and
+            // closes its own, so without a terminator here the lifecycle block
+            // reads as nested inside the stall block rather than following it.
+            info!("====================");
+        }
+
+        // Outside the gate above, not inside it. The lifecycle reports record the
+        // pipeline working and these three record it stalling, so a merge that
+        // never stalled is precisely the run with a complete lifecycle trace and
+        // nothing to say above. `log_block_lifecycle` carries its own gate.
+        Self::log_block_lifecycle(pool);
+    }
+
+    /// Log every stage of a spill block's journey, and the refill cycle.
+    ///
+    /// When the stall block above printed, it said the consumer waits for a
+    /// block that is being produced; this says how long each step of producing
+    /// it takes, and -- through the refill numbers -- how much of the wait is the
+    /// pipeline working versus the pipeline not having started. When it stayed
+    /// silent, these figures are the whole report, which is why they are not
+    /// gated on it. See [`crate::merge_trace`].
+    #[allow(clippy::cast_precision_loss)]
+    fn log_block_lifecycle(pool: &Arc<SortWorkerPool>) {
+        use crate::merge_stalls::AwaitedState;
+        use crate::merge_trace::EmptyCause;
+
+        let life = pool.block_lifecycle_report();
+        let refill = pool.refill_report();
+        let consumer = pool.consumer_trace_report();
+        let scans = pool.fruitless_scan_report();
+        if block_lifecycle_is_silent(&life, &refill, &consumer, &scans) {
             return;
         }
 
-        info!("=== Merge Stalls ===");
+        info!("=== Merge Block Lifecycle ===");
+        info!("  disk read   -> {}", life.read_batch.summary());
+        info!("  raw dwell   -> {}   (queued, waiting for a worker)", life.raw_dwell.summary());
+        info!("  decompress  -> {}", life.decompress.summary());
+        info!(
+            "  reorder     -> {}   (decompressed, waiting for the consumer)",
+            life.reorder_dwell.summary()
+        );
+        if life.reorder_is_pass_through() {
+            info!(
+                "    NOTE: blocks are consumed almost as fast as they are inserted, so the \
+                 reorder buffer is a pass-through and PHASE2_DECOMP_CAP is not the binding \
+                 constraint -- however full the other files look"
+            );
+        }
 
-        if let Some(s) = stalls {
-            Self::log_consumer_stalls(loop_total, s);
+        if !refill.is_empty() {
+            info!("  Refill cycle ({} times a file's buffer ran dry)", refill.empties());
+            info!(
+                "    At the moment it emptied: {:.0}% had raw blocks unclaimed, {:.0}% already \
+                 decompressing, {:.0}% nothing at all",
+                100.0 * refill.cause_share(EmptyCause::RawReady),
+                100.0 * refill.cause_share(EmptyCause::Decompressing),
+                100.0 * refill.cause_share(EmptyCause::Dry)
+            );
+            info!("    empty -> claimed  {}", refill.claim_lag.summary());
+            info!("    empty -> inserted {}", refill.insert_lag.summary());
+            if !refill.read_lag.summary().is_empty() && !refill.read_lag.is_empty() {
+                info!("    empty -> read     {}", refill.read_lag.summary());
+            }
+            info!(
+                "    -> {:.0}% of refill latency is spent waiting for a worker to START, {:.0}% \
+                 doing the work",
+                100.0 * refill.claim_share(),
+                100.0 * (1.0 - refill.claim_share())
+            );
+        }
+
+        if !consumer.is_empty() {
+            info!("  Park duration by what the awaited file was doing");
+            for state in AwaitedState::ALL {
+                let hist = consumer.park_by_state[state as usize];
+                if !hist.is_empty() {
+                    info!("    {:<14} {}", state.label(), hist.summary());
+                }
+            }
+            let parks = consumer.parks();
+            if parks > 0 {
+                info!(
+                    "    Workers on the awaited file at a park: none {:.0}%, exactly one {:.0}%",
+                    100.0 * consumer.idle_file_parks() as f64 / parks as f64,
+                    100.0 * consumer.single_worker_parks() as f64 / parks as f64
+                );
+            }
+            if !consumer.source_run_length.is_empty() {
+                info!(
+                    "  Consecutive blocks per source: {}",
+                    consumer.source_run_length.summary_blocks()
+                );
+                if consumer.source_run_length.percentile_micros(0.90) <= 1 {
+                    info!(
+                        "    -> the merge switches source almost every block, so there is no hot \
+                         file to prioritise; demand is spread across all runs at once"
+                    );
+                }
+            }
         }
 
         if !scans.is_empty() {
-            let reasons = Phase2Skip::ALL
-                .iter()
-                .map(|&r| format!("{}={}", r.label(), scans.skips[r as usize]))
-                .collect::<Vec<_>>()
-                .join(" ");
-            info!("  Worker scans finding no work: {} ({reasons})", scans.scans);
-            info!(
-                "    Of those: {:.0}% backpressured, {:.0}% waiting on a peer's read, {:.0}% \
-                 contended",
-                100.0 * scans.verdict_share(ScanVerdict::Backpressured),
-                100.0 * scans.verdict_share(ScanVerdict::IoWait),
-                100.0 * scans.verdict_share(ScanVerdict::Contended)
-            );
+            info!("  Fruitless worker scan cost: {}", scans.summary());
         }
-
-        if !wake.is_empty() {
-            info!(
-                "  Worker discovery lag: ~{:.1}s of {:.1}s deep-sleep worker-seconds; {} sleeps \
-                 ended in a find, {:.0}% of them after >=320us",
-                wake.estimated_discovery_lag_secs(),
-                wake.deep_sleep_idle_secs(),
-                wake.productive_sleep_count(),
-                100.0 * wake.deep_sleep_wake_share()
-            );
-            info!(
-                "    (nothing unparks a worker, so this bounds how late work is noticed; it \
-                 delays the merge only when every worker is asleep at once)"
-            );
-        }
+        info!("=============================");
     }
 
     /// Log where the merge loop blocked and what the other files were doing.
@@ -4099,6 +4333,15 @@ impl RawExternalSorter {
         // lets this run unconditionally instead of behind a flag nobody
         // remembers to set.
         let mut sample_countdown: u64 = 0;
+        // Seeding the loser tree pulled one block per source, and those pulls
+        // are the likeliest of the whole merge to park -- every file is cold.
+        // They precede this clock, so they must precede the stall counters too,
+        // or `park_fraction` covers a longer interval than the wall time it is
+        // divided by and `classify_stall` reads a merge that never stalled as
+        // one that did.
+        if let Some(consumer) = guard.consumer_mut() {
+            consumer.restart_stalls();
+        }
         let loop_start = Instant::now();
 
         while tree.winner_is_active() {
@@ -4165,7 +4408,14 @@ impl RawExternalSorter {
         // releases the merge sources and with them the consumer, and the report
         // describes the loop that has just ended rather than the output drain
         // that follows.
-        let stalls = guard.consumer_ref().map(MainThreadChunkConsumer::stall_report);
+        let stalls = {
+            // Close the run in progress first, or the last (and often longest)
+            // stretch on one source is dropped from the histogram.
+            if let Some(consumer) = guard.consumer_mut() {
+                consumer.finish_source_run();
+            }
+            guard.consumer_ref().map(MainThreadChunkConsumer::stall_report)
+        };
 
         // Finalize before logging. `finish` drains the output queue, and every
         // block still in it is compressed by the same workers this breakdown
@@ -4243,6 +4493,15 @@ impl RawExternalSorter {
             .with_interval(1_000_000)
             .with_total(total_records);
 
+        // Seeding the loser tree pulled one block per source, and those pulls
+        // are the likeliest of the whole merge to park -- every file is cold.
+        // They precede this clock, so they must precede the stall counters too,
+        // or `park_fraction` covers a longer interval than the wall time it is
+        // divided by and `classify_stall` reads a merge that never stalled as
+        // one that did.
+        if let Some(consumer) = guard.consumer_mut() {
+            consumer.restart_stalls();
+        }
         let loop_start = Instant::now();
         while tree.winner_is_active() {
             let winner = tree.winner();
@@ -4265,7 +4524,14 @@ impl RawExternalSorter {
         // coordinate sort, so that gap covers most production merges.
         Self::log_merge_stalls(
             loop_start.elapsed().as_secs_f64(),
-            guard.consumer_ref().map(MainThreadChunkConsumer::stall_report),
+            {
+                // Close the run in progress first, or the last (and often
+                // longest) stretch on one source is dropped from the histogram.
+                if let Some(consumer) = guard.consumer_mut() {
+                    consumer.finish_source_run();
+                }
+                guard.consumer_ref().map(MainThreadChunkConsumer::stall_report)
+            },
             pool,
         );
 
@@ -4791,6 +5057,170 @@ mod tests {
     use noodles::sam::header::record::value::Map;
     use noodles::sam::header::record::value::map::ReadGroup;
     use rstest::rstest;
+
+    // ========================================================================
+    // Merge diagnostics reporting
+    // ========================================================================
+
+    /// The block-lifecycle gate must name every report the block prints.
+    ///
+    /// Each case populates exactly one report and asserts the block still
+    /// speaks. A report left out of the gate passes every case but its own,
+    /// which is what makes one case per report the point rather than a
+    /// formality -- `scans` was the one that had been omitted.
+    #[rstest]
+    #[case::nothing_recorded_stays_silent("none", true)]
+    #[case::block_lifecycle_alone_speaks("life", false)]
+    #[case::refill_cycle_alone_speaks("refill", false)]
+    #[case::consumer_trace_alone_speaks("consumer", false)]
+    #[case::fruitless_scans_alone_speak("scans", false)]
+    fn block_lifecycle_gate_covers_every_report(#[case] populate: &str, #[case] silent: bool) {
+        use crate::merge_trace::{
+            BlockLifecycleStats, ConsumerTraceStats, DurationHistogram, EmptyCause, RefillStats,
+        };
+
+        let life = {
+            let stats = BlockLifecycleStats::default();
+            if populate == "life" {
+                stats.raw_dwell.record(1_000);
+            }
+            let mut report = stats.snapshot();
+            // `is_empty` keys off the working stages, which the pool fills in.
+            if populate == "life" {
+                report.decompress = {
+                    let h = DurationHistogram::default();
+                    h.record(1_000);
+                    h.snapshot()
+                };
+            }
+            report
+        };
+        let refill = {
+            let stats = RefillStats::default();
+            if populate == "refill" {
+                stats.record_empty(EmptyCause::Dry);
+            }
+            stats.snapshot()
+        };
+        let consumer = {
+            let stats = ConsumerTraceStats::default();
+            if populate == "consumer" {
+                stats.record_source_run(4);
+            }
+            stats.snapshot()
+        };
+        let scans = {
+            let hist = DurationHistogram::default();
+            if populate == "scans" {
+                hist.record(1_000);
+            }
+            hist.snapshot()
+        };
+
+        assert_eq!(
+            block_lifecycle_is_silent(&life, &refill, &consumer, &scans),
+            silent,
+            "gate disagreed with the only populated report ({populate})"
+        );
+    }
+
+    /// The stall gate must name every report the stall block prints.
+    ///
+    /// Same shape, and same reason, as
+    /// [`block_lifecycle_gate_covers_every_report`]: one case per report, each
+    /// populating only that report, so a report dropped from the gate fails its
+    /// own case rather than passing on a neighbour's.
+    #[rstest]
+    #[case::nothing_recorded_stays_silent("none", true)]
+    #[case::consumer_stalls_alone_speak("stalls", false)]
+    #[case::fruitless_scans_alone_speak("scans", false)]
+    #[case::wake_latency_alone_speaks("wake", false)]
+    fn merge_stall_gate_covers_every_report(#[case] populate: &str, #[case] silent: bool) {
+        use crate::merge_stalls::{
+            ConsumerStallTracker, Phase2ScanStats, Phase2ScanTally, Phase2Skip, WakeLatencyStats,
+        };
+
+        let stalls = {
+            let mut tracker = ConsumerStallTracker::new(1);
+            if populate == "stalls" {
+                tracker.note_block_pull();
+            }
+            tracker.snapshot()
+        };
+        let scans = {
+            let stats = Phase2ScanStats::default();
+            if populate == "scans" {
+                let mut tally = Phase2ScanTally::default();
+                tally.note(Phase2Skip::RawFull);
+                stats.record_fruitless_scan(tally);
+            }
+            stats.snapshot()
+        };
+        let wake = {
+            let stats = WakeLatencyStats::default();
+            if populate == "wake" {
+                stats.record_sleep(320, 1_000);
+            }
+            stats.snapshot()
+        };
+
+        // Mirrors the caller, which drops an all-zero stall report before the
+        // gate sees it -- the tracker always exists, so `Some(empty)` is the
+        // shape a merge with no stalls actually produces.
+        let stalls = Some(stalls).filter(|s| !s.is_empty());
+        assert_eq!(
+            merge_stalls_are_silent(stalls.as_ref(), &scans, &wake),
+            silent,
+            "gate disagreed with the only populated report ({populate})"
+        );
+    }
+
+    /// The stall gate must not decide whether the lifecycle block prints.
+    ///
+    /// The two are populated by opposite conditions: a merge that flowed without
+    /// ever stalling records a full lifecycle trace and nothing at all in the
+    /// three stall reports. Gating the lifecycle block on the stall gate --
+    /// which `log_merge_stalls` did by early-returning -- drops the entire trace
+    /// on exactly those runs.
+    #[test]
+    fn silent_stall_gate_does_not_silence_the_lifecycle_gate() {
+        use crate::merge_stalls::{ConsumerStallTracker, Phase2ScanStats, WakeLatencyStats};
+        use crate::merge_trace::{
+            BlockLifecycleStats, ConsumerTraceStats, DurationHistogram, RefillStats,
+        };
+
+        // A merge that never stalled: no block pull waited, no scan came back
+        // empty, no worker slept.
+        let stalls = ConsumerStallTracker::new(1).snapshot();
+        let scans = Phase2ScanStats::default().snapshot();
+        let wake = WakeLatencyStats::default().snapshot();
+        assert!(
+            merge_stalls_are_silent(Some(&stalls), &scans, &wake),
+            "a merge with no stalls should leave the stall block silent"
+        );
+
+        // The same merge still moved every block through the pipeline.
+        let life = {
+            let stats = BlockLifecycleStats::default();
+            stats.raw_dwell.record(1_000);
+            let mut report = stats.snapshot();
+            report.decompress = {
+                let h = DurationHistogram::default();
+                h.record(1_000);
+                h.snapshot()
+            };
+            report
+        };
+        assert!(
+            !block_lifecycle_is_silent(
+                &life,
+                &RefillStats::default().snapshot(),
+                &ConsumerTraceStats::default().snapshot(),
+                &DurationHistogram::default().snapshot(),
+            ),
+            "the lifecycle block has a full trace to print and must not be gated on the stalls"
+        );
+    }
 
     // ========================================================================
     // Chunk spill triggers

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -4002,7 +4002,7 @@ impl RawExternalSorter {
                 if loop_total > 0.0 { est_read / loop_total } else { 0.0 },
             );
         }
-        Self::log_merge_stalls(loop_total, stalls, pool);
+        Self::log_merge_stalls(loop_total, merge_total, active_workers, stalls, pool);
         info!("==============================");
     }
 
@@ -4013,13 +4013,32 @@ impl RawExternalSorter {
     /// parked; why worker file-scans came back empty; and how much of the
     /// workers' idle time was spent asleep *through* work becoming available.
     /// See [`crate::merge_stalls`].
+    ///
+    /// `merge_total` and `active_workers` are the utilization denominators and
+    /// must be the same pair [`Self::log_merge_sub_phases`] divides by, because
+    /// `SATURATED_UTILIZATION` is shared between `classify_merge` and
+    /// `classify_stall` so the two verdicts agree about whether the pool was
+    /// busy. `loop_total` stays the denominator for the consumer's park
+    /// fraction, which is a fraction of the merge loop alone.
     #[allow(clippy::cast_precision_loss)]
     fn log_merge_stalls(
         loop_total: f64,
+        merge_total: f64,
+        active_workers: usize,
         stalls: Option<crate::merge_stalls::ConsumerStallReport>,
         pool: &Arc<SortWorkerPool>,
     ) {
         use crate::merge_stalls::{Phase2Skip, ScanVerdict};
+
+        // Utilization gates the stall shape: "no worker on it" means a
+        // scheduling defect on an idle pool and plain saturation on a busy one.
+        // The active cap, not the pool width -- a Phase 2 narrower than Phase 1
+        // otherwise charges the merge for workers that were never allowed to
+        // help, and reports a saturated pool as idle.
+        let utilization = pool
+            .merge_phase_breakdown()
+            .worker_utilization(merge_total, active_workers)
+            .unwrap_or(0.0);
 
         let scans = pool.phase2_scan_report();
         let wake = pool.wake_latency_report();
@@ -4028,7 +4047,7 @@ impl RawExternalSorter {
             info!("=== Merge Stalls ===");
 
             if let Some(s) = stalls {
-                Self::log_consumer_stalls(loop_total, s);
+                Self::log_consumer_stalls(loop_total, utilization, s);
             }
 
             if !scans.is_empty() {
@@ -4096,13 +4115,26 @@ impl RawExternalSorter {
             return;
         }
 
+        // Two audiences, one measurement. The distributions are what an
+        // investigation needs and are far too much for someone who just sorted a
+        // BAM, so the per-stage histograms go to debug while the numbers that
+        // change a decision stay at info. Collection is unconditional either
+        // way -- gating collection is what made the original question
+        // unanswerable from logs we had already collected.
         info!("=== Merge Block Lifecycle ===");
-        info!("  disk read   -> {}", life.read_batch.summary());
-        info!("  raw dwell   -> {}   (queued, waiting for a worker)", life.raw_dwell.summary());
-        info!("  decompress  -> {}", life.decompress.summary());
-        info!(
+        debug!("  disk read   -> {}", life.read_batch.summary());
+        debug!("  raw dwell   -> {}   (queued, waiting for a worker)", life.raw_dwell.summary());
+        debug!("  decompress  -> {}", life.decompress.summary());
+        debug!(
             "  reorder     -> {}   (decompressed, waiting for the consumer)",
             life.reorder_dwell.summary()
+        );
+        info!(
+            "  Per block: {:.0}us in the raw FIFO unclaimed, {:.0}us decompressing, {:.0}us \
+             buffered before use (p50)",
+            life.raw_dwell.percentile_micros(0.50),
+            life.decompress.percentile_micros(0.50),
+            life.reorder_dwell.percentile_micros(0.50)
         );
         if life.reorder_is_pass_through() {
             info!(
@@ -4121,10 +4153,10 @@ impl RawExternalSorter {
                 100.0 * refill.cause_share(EmptyCause::Decompressing),
                 100.0 * refill.cause_share(EmptyCause::Dry)
             );
-            info!("    empty -> claimed  {}", refill.claim_lag.summary());
-            info!("    empty -> inserted {}", refill.insert_lag.summary());
-            if !refill.read_lag.summary().is_empty() && !refill.read_lag.is_empty() {
-                info!("    empty -> read     {}", refill.read_lag.summary());
+            debug!("    empty -> claimed  {}", refill.claim_lag.summary());
+            debug!("    empty -> inserted {}", refill.insert_lag.summary());
+            if !refill.read_lag.is_empty() {
+                debug!("    empty -> read     {}", refill.read_lag.summary());
             }
             info!(
                 "    -> {:.0}% of refill latency is spent waiting for a worker to START, {:.0}% \
@@ -4135,15 +4167,19 @@ impl RawExternalSorter {
         }
 
         if !consumer.is_empty() {
-            info!("  Park duration by what the awaited file was doing");
-            for state in AwaitedState::ALL {
-                let hist = consumer.park_by_state[state as usize];
-                if !hist.is_empty() {
-                    info!("    {:<14} {}", state.label(), hist.summary());
-                }
-            }
+            // A merge that never stalled still has source runs to report, so the
+            // park block has to stand on its own count rather than on the report
+            // being non-empty -- otherwise it prints a header with nothing under
+            // it and divides by zero to fill the line below.
             let parks = consumer.parks();
             if parks > 0 {
+                debug!("  Park duration by what the awaited file was doing");
+                for state in AwaitedState::ALL {
+                    let hist = consumer.park_by_state[state as usize];
+                    if !hist.is_empty() {
+                        debug!("    {:<14} {}", state.label(), hist.summary());
+                    }
+                }
                 info!(
                     "    Workers on the awaited file at a park: none {:.0}%, exactly one {:.0}%",
                     100.0 * consumer.idle_file_parks() as f64 / parks as f64,
@@ -4165,7 +4201,7 @@ impl RawExternalSorter {
         }
 
         if !scans.is_empty() {
-            info!("  Fruitless worker scan cost: {}", scans.summary());
+            debug!("  Fruitless worker scan cost: {}", scans.summary());
         }
         info!("=============================");
     }
@@ -4176,7 +4212,11 @@ impl RawExternalSorter {
     /// with the sampled "fetch next record" row above, this is the one to
     /// believe.
     #[allow(clippy::cast_precision_loss)]
-    fn log_consumer_stalls(loop_total: f64, s: crate::merge_stalls::ConsumerStallReport) {
+    fn log_consumer_stalls(
+        loop_total: f64,
+        utilization: f64,
+        s: crate::merge_stalls::ConsumerStallReport,
+    ) {
         use crate::merge_stalls::{StallShape, classify_stall};
 
         let park_fraction = if loop_total > 0.0 { s.park_secs / loop_total } else { 0.0 };
@@ -4227,8 +4267,13 @@ impl RawExternalSorter {
                 100.0 * s.awaited.in_progress()
             );
         }
-        match classify_stall(park_fraction, s.contended_share, s.awaited) {
+        match classify_stall(park_fraction, utilization, s.contended_share, s.awaited) {
             StallShape::NotStalled => info!("    Shape: the consumer is not waiting on blocks"),
+            StallShape::PoolSaturated => info!(
+                "    Shape: pool saturated -- the consumer waits because every worker is busy, \
+                 which is what a healthy CPU-bound merge looks like. Fewer bytes to compress or \
+                 more threads would help; nothing here is misscheduled"
+            ),
             StallShape::HeadOfLine => info!(
                 "    Shape: head-of-line -- the awaited file has nothing anywhere in its \
                  pipeline, so the block has not been read from disk yet. The constraint is \
@@ -4241,8 +4286,9 @@ impl RawExternalSorter {
             ),
             StallShape::DecompressLatency => info!(
                 "    Shape: decompression latency -- a worker is already producing the needed \
-                 block, so the consumer is paying the per-block cost serially. Only running \
-                 further ahead (a deeper PHASE2_DECOMP_CAP) or faster decompression removes it"
+                 block, so the consumer is paying the per-block cost serially. Check the reorder \
+                 dwell below before reaching for a deeper cap: if blocks are consumed as fast as \
+                 they are inserted, the buffer is not what the pipeline is running into"
             ),
             StallShape::Contended => info!(
                 "    Shape: lock contention -- a large share of file state could not be read \
@@ -4522,20 +4568,40 @@ impl RawExternalSorter {
         // but the stall counters need no sampling at all, so an indexed sort is
         // not left with nothing. `--write-index` is the default for a
         // coordinate sort, so that gap covers most production merges.
+        //
+        // The active cap is read while Phase 2 is still active, so teardown
+        // cannot change it, and the consumer's report is harvested before
+        // `finish_output` releases the merge sources and with them the
+        // consumer. Both describe the loop that has just ended.
+        let loop_total = loop_start.elapsed().as_secs_f64();
+        let active_workers = pool.active_workers();
+        let stalls = {
+            // Close the run in progress first, or the last (and often longest)
+            // stretch on one source is dropped from the histogram.
+            if let Some(consumer) = guard.consumer_mut() {
+                consumer.finish_source_run();
+            }
+            guard.consumer_ref().map(MainThreadChunkConsumer::stall_report)
+        };
+
+        // Finalize before logging, for the reason the generic path does: `finish`
+        // drains the output queue, and every block still in it is compressed by
+        // the same workers `log_merge_stalls` divides into `merge_total`. Logging
+        // first omits that tail of `output_compress` while still charging the
+        // window it was queued in, understating utilization -- and utilization is
+        // the input `classify_stall` uses to tell a saturated pool from a
+        // scheduling defect, so the bias flips a verdict rather than shading a
+        // number. `loop_total` stays the consumer's park-fraction denominator,
+        // which is a fraction of the merge loop alone.
+        let index = guard.finish_output(|| writer.finish_index())?;
         Self::log_merge_stalls(
+            loop_total,
             loop_start.elapsed().as_secs_f64(),
-            {
-                // Close the run in progress first, or the last (and often
-                // longest) stretch on one source is dropped from the histogram.
-                if let Some(consumer) = guard.consumer_mut() {
-                    consumer.finish_source_run();
-                }
-                guard.consumer_ref().map(MainThreadChunkConsumer::stall_report)
-            },
+            active_workers,
+            stalls,
             pool,
         );
 
-        let index = guard.finish_output(|| writer.finish_index())?;
         merge_progress.log_final();
         Ok(index)
     }

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -51,6 +51,7 @@ pub(crate) mod loser_tree;
 pub(crate) mod memory_probe;
 pub(crate) mod merge_phases;
 pub(crate) mod merge_stalls;
+pub(crate) mod merge_trace;
 pub(crate) mod pipeline;
 pub(crate) mod pooled_bam_writer;
 pub(crate) mod pooled_chunk_writer;

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -50,6 +50,7 @@ pub(crate) mod keys;
 pub(crate) mod loser_tree;
 pub(crate) mod memory_probe;
 pub(crate) mod merge_phases;
+pub(crate) mod merge_stalls;
 pub(crate) mod pipeline;
 pub(crate) mod pooled_bam_writer;
 pub(crate) mod pooled_chunk_writer;

--- a/crates/fgumi-sort/src/merge_phases.rs
+++ b/crates/fgumi-sort/src/merge_phases.rs
@@ -32,14 +32,19 @@
 //! would mean an `Instant::now()` pair per record rather than per block, which
 //! on a billion-record sort is real overhead for a number we already have.
 
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Instant;
+use crate::merge_trace::{DurationHistogram, HistogramReport};
 
 /// Nanosecond/operation counter pair for one merge component.
+///
+/// Backed by a [`DurationHistogram`], which already keeps an exact count and
+/// sum. Sharing the storage rather than incrementing a second set of atomics
+/// keeps the totals in this report and the distributions in
+/// [`crate::merge_trace`] describing literally the same observations — two
+/// parallel counters over one event are a divergence waiting to happen, and the
+/// divergence would be silent.
 #[derive(Debug, Default)]
 pub(crate) struct ComponentCounter {
-    nanos: AtomicU64,
-    ops: AtomicU64,
+    hist: DurationHistogram,
 }
 
 impl ComponentCounter {
@@ -49,23 +54,17 @@ impl ComponentCounter {
     /// relationship to the data they describe, and the merge hot path should not
     /// pay for fences to maintain them.
     pub(crate) fn time<R>(&self, f: impl FnOnce() -> R) -> R {
-        let start = Instant::now();
-        let result = f();
-        #[allow(clippy::cast_possible_truncation)]
-        let elapsed = start.elapsed().as_nanos() as u64;
-        self.nanos.fetch_add(elapsed, Ordering::Relaxed);
-        self.ops.fetch_add(1, Ordering::Relaxed);
-        result
+        self.hist.time(f)
     }
 
-    #[allow(
-        clippy::cast_precision_loss,
-        reason = "nanosecond totals stay far below 2^52; a sort would need ~52 days of busy time to lose a nanosecond of precision here"
-    )]
+    /// The distribution behind the totals, for [`crate::merge_trace`].
+    pub(crate) fn histogram(&self) -> HistogramReport {
+        self.hist.snapshot()
+    }
+
     fn snapshot(&self) -> (f64, u64) {
-        let nanos = self.nanos.load(Ordering::Relaxed);
-        let ops = self.ops.load(Ordering::Relaxed);
-        (nanos as f64 / 1e9, ops)
+        let report = self.hist.snapshot();
+        (report.total_secs(), report.count)
     }
 }
 
@@ -192,7 +191,7 @@ mod tests {
     use rstest::rstest;
     use std::sync::Arc;
     use std::thread;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     #[test]
     fn test_counter_accumulates_time_and_ops() {

--- a/crates/fgumi-sort/src/merge_stalls.rs
+++ b/crates/fgumi-sort/src/merge_stalls.rs
@@ -517,6 +517,57 @@ const DEEP_SLEEP_FIRST_BUCKET: usize = 5;
 // Consumer side: where the merge loop blocks
 // ============================================================================
 
+/// What the file the consumer is actually waiting on was doing.
+///
+/// The pool-wide shares below say what the *other* files were doing, which
+/// turned out to answer a question nobody was asking: on a measured 780M-record
+/// merge, 98% of files sat at their cap while the awaited file was starved only
+/// 3% of the time. Knowing the rest of the pool is full says nothing about why
+/// the one file that matters has not produced its next block.
+///
+/// These five states are mutually exclusive and, crucially, are observed at a
+/// point where the consumer has *just* failed `try_pop_next`. So a non-empty
+/// reorder buffer is proof the buffer holds the wrong serials, not a guess.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AwaitedState {
+    /// The buffer holds blocks, but not the next serial, and a decompression is
+    /// underway — the gap-filler is being produced right now.
+    ReorderGapFilling,
+    /// The buffer holds blocks, but not the next serial, and nothing is being
+    /// decompressed for this file. The work exists and no worker has claimed
+    /// it.
+    ReorderGapStalled,
+    /// Nothing buffered, but a decompression for this file is in flight.
+    Decompressing,
+    /// Nothing buffered and nothing in flight, but raw blocks are queued —
+    /// read from disk and waiting for a worker to pick them up.
+    RawQueued,
+    /// Nothing anywhere and the reader is not at EOF: waiting on disk.
+    Starved,
+}
+
+impl AwaitedState {
+    /// Number of variants, for fixed-size counter arrays.
+    pub(crate) const COUNT: usize = 5;
+}
+
+// Keeps `COUNT` and `ALL` honest: the match is exhaustive, so a sixth variant
+// fails to compile here instead of indexing past the end of `park_by_state`
+// inside [`ConsumerTraceStats::record_park`](crate::merge_trace::ConsumerTraceStats)
+// -- on a worker-facing path, where it surfaces only as a panic.
+const _: () = {
+    const fn assert_count(state: AwaitedState) -> usize {
+        match state {
+            AwaitedState::ReorderGapFilling => 0,
+            AwaitedState::ReorderGapStalled => 1,
+            AwaitedState::Decompressing => 2,
+            AwaitedState::RawQueued => 3,
+            AwaitedState::Starved => AwaitedState::COUNT - 1,
+        }
+    }
+    assert!(assert_count(AwaitedState::Starved) == 4);
+};
+
 /// The other files' states at the moment the consumer parked.
 ///
 /// Built by the caller, which owns the locks; keeping the observation out of
@@ -533,9 +584,8 @@ pub(crate) struct ParkCensus {
     pub(crate) drained: u32,
     /// Files whose state could not be read without blocking.
     pub(crate) contended: u32,
-    /// Whether the file the consumer is waiting on is itself starved — nothing
-    /// buffered, nothing in flight, reader not at EOF.
-    pub(crate) waited_on_starved: bool,
+    /// What the awaited file itself was doing, when it could be read.
+    pub(crate) awaited: Option<AwaitedState>,
 }
 
 impl ParkCensus {
@@ -571,7 +621,8 @@ pub(crate) struct ConsumerStallTracker {
     census_starved: u64,
     census_contended: u64,
     census_live: u64,
-    census_waited_on_starved: u64,
+    /// Awaited-file states observed, indexed by [`AwaitedState`] as `usize`.
+    census_awaited: [u64; AwaitedState::COUNT],
     /// Countdown to the next census.
     census_countdown: u64,
 }
@@ -602,7 +653,7 @@ impl ConsumerStallTracker {
             census_starved: 0,
             census_contended: 0,
             census_live: 0,
-            census_waited_on_starved: 0,
+            census_awaited: [0; AwaitedState::COUNT],
             census_countdown: 0,
         }
     }
@@ -652,7 +703,9 @@ impl ConsumerStallTracker {
         self.census_starved += u64::from(census.starved);
         self.census_contended += u64::from(census.contended);
         self.census_live += u64::from(census.live());
-        self.census_waited_on_starved += u64::from(census.waited_on_starved);
+        if let Some(state) = census.awaited {
+            self.census_awaited[state as usize] += 1;
+        }
     }
 
     #[allow(
@@ -676,11 +729,7 @@ impl ConsumerStallTracker {
             capped_share: share(self.census_capped),
             starved_share: share(self.census_starved),
             contended_share: share(self.census_contended),
-            waited_on_starved_share: if self.censuses > 0 {
-                self.census_waited_on_starved as f64 / self.censuses as f64
-            } else {
-                0.0
-            },
+            awaited: AwaitedShares::from_counts(self.census_awaited),
             censuses: self.censuses,
             top_source: top.0,
             top_source_park_secs: top.1 as f64 / 1e9,
@@ -714,8 +763,10 @@ pub struct ConsumerStallReport {
     /// Share of live-file observations whose state could not be read at a park,
     /// pooled the same way as [`Self::capped_share`].
     pub contended_share: f64,
-    /// Share of parks where the awaited file was itself starved.
-    pub waited_on_starved_share: f64,
+    /// What the awaited file was doing, as shares of the censuses that could
+    /// read it -- which is at most [`Self::censuses`], not necessarily all of
+    /// them. See [`AwaitedShares`].
+    pub awaited: AwaitedShares,
     /// Censuses taken.
     pub censuses: u64,
     /// Source the consumer parked on longest.
@@ -771,21 +822,88 @@ impl ConsumerStallReport {
     }
 }
 
+/// What the awaited file was doing, as shares of the censuses that could read
+/// it.
+///
+/// A census that found the awaited file unreadable is excluded from the
+/// denominator, so these sum to 1 whenever any observation was made -- and the
+/// count they are shares of can be below [`ConsumerStallReport::censuses`].
+/// Multiplying a share by `censuses` therefore does not recover a count.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct AwaitedShares {
+    /// Buffer holds the wrong serials; the gap-filler is being decompressed.
+    pub reorder_gap_filling: f64,
+    /// Buffer holds the wrong serials and nothing is being decompressed.
+    pub reorder_gap_stalled: f64,
+    /// Nothing buffered; a decompression is in flight.
+    pub decompressing: f64,
+    /// Raw blocks queued with no worker on them.
+    pub raw_queued: f64,
+    /// Nothing anywhere, reader not at EOF.
+    pub starved: f64,
+}
+
+impl AwaitedShares {
+    /// Shares of `counts.iter().sum()` -- the censuses that read the awaited
+    /// file, which is what `counts` tallies. Censuses that could not read it
+    /// were never tallied here and so are not in the denominator.
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "census counts stay far below 2^52 on any real sort"
+    )]
+    fn from_counts(counts: [u64; AwaitedState::COUNT]) -> Self {
+        let total: u64 = counts.iter().sum();
+        if total == 0 {
+            return Self::default();
+        }
+        let share = |state: AwaitedState| counts[state as usize] as f64 / total as f64;
+        Self {
+            reorder_gap_filling: share(AwaitedState::ReorderGapFilling),
+            reorder_gap_stalled: share(AwaitedState::ReorderGapStalled),
+            decompressing: share(AwaitedState::Decompressing),
+            raw_queued: share(AwaitedState::RawQueued),
+            starved: share(AwaitedState::Starved),
+        }
+    }
+
+    /// Share where the block the consumer needs exists but no worker is on it.
+    ///
+    /// Actionable: the pipeline has the data and is not applying capacity to
+    /// it, which is a scheduling or discovery problem.
+    #[must_use]
+    pub fn unclaimed(self) -> f64 {
+        self.reorder_gap_stalled + self.raw_queued
+    }
+
+    /// Share where a worker is already producing the needed block.
+    ///
+    /// Not actionable by scheduling: the wait is the per-block decompression
+    /// cost, and only running further ahead or decompressing faster removes it.
+    #[must_use]
+    pub fn in_progress(self) -> f64 {
+        self.reorder_gap_filling + self.decompressing
+    }
+}
+
 /// The shape of a consumer stall — which of the candidate causes it fits.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StallShape {
     /// The consumer barely parked; whatever it spends its loop on, it is not
     /// waiting for blocks.
     NotStalled,
-    /// The consumer waits on a starved file while most others sit at their cap.
-    /// Read-ahead is allocated evenly across files while demand is not, so the
-    /// pool buffers work nobody needs yet and starves the one run that is next.
-    /// A uniformly bigger cap does not fix this; steering workers toward the
-    /// file the loser tree needs does.
+    /// The consumer waits on a file with nothing anywhere in its pipeline —
+    /// the block has not even been read from disk. The constraint is upstream
+    /// of the pool: disk, or read concurrency.
     HeadOfLine,
-    /// Most files are starved too, so the pool as a whole cannot keep the
-    /// consumer fed — the constraint is upstream of the caps.
-    PoolStarved,
+    /// The block the consumer needs already exists, in raw or partially
+    /// reordered form, and no worker is applying capacity to it. A scheduling
+    /// and discovery problem, not a capacity one: workers are idle, or looking
+    /// at the wrong file, or asleep.
+    WorkUnclaimed,
+    /// A worker is already producing the block the consumer needs. The wait is
+    /// the per-block decompression cost itself, so only running further ahead
+    /// (a deeper cap) or decompressing faster removes it.
+    DecompressLatency,
     /// Enough of the pipeline's state was lock-contended that contention is the
     /// first thing to fix; the other shares are unreliable until it is.
     Contended,
@@ -795,12 +913,8 @@ pub enum StallShape {
 
 /// Park share of the merge loop below which the consumer is not stalling.
 const NOT_STALLED_PARK_FRACTION: f64 = 0.05;
-/// Share of live files that must be at cap for head-of-line blocking.
-const HEAD_OF_LINE_CAPPED_SHARE: f64 = 0.50;
-/// Share of parks whose awaited file must be starved for head-of-line blocking.
-const HEAD_OF_LINE_WAITED_SHARE: f64 = 0.50;
-/// Share of live files that must be starved to blame the pool as a whole.
-const POOL_STARVED_SHARE: f64 = 0.50;
+/// Share of the awaited-file census one explanation must reach to be reported.
+const AWAITED_DOMINANT_SHARE: f64 = 0.50;
 /// Share of live files that must be unreadable to blame contention.
 const CONTENDED_FILE_SHARE: f64 = 0.25;
 
@@ -808,33 +922,36 @@ const CONTENDED_FILE_SHARE: f64 = 0.25;
 ///
 /// `park_fraction` is exact park time over merge loop wall clock, which makes
 /// the `NotStalled` gate trustworthy in a way the sampled fetch fraction is not.
-/// The remaining inputs come from the sampled park census.
+/// `awaited` comes from the sampled park census.
 ///
-/// The discriminating input is `waited_on_starved_share`. A high `capped_share`
-/// alone is ambiguous — it is exactly what a healthy, consumer-limited merge
-/// looks like. It only indicts the caps when the consumer is *simultaneously*
-/// blocked on a file that has nothing, which is what makes the buffering
-/// misallocated rather than merely full.
+/// # Why this classifies on the awaited file, not on the pool
 ///
-/// Thresholds are provisional; see the module doc.
+/// It used to key off "most files at cap while the awaited file is starved",
+/// on the theory that read-ahead was being misallocated across files. Measured
+/// on a 780M-record merge, 98% of files were at cap and the awaited file was
+/// starved 3% of the time — the pool-wide share was near-constant across arms
+/// that stalled 8x differently, so it discriminated nothing. What the consumer
+/// is waiting *for* does.
+///
+/// The useful split is whether the needed block exists yet, and if it does,
+/// whether anyone is working on it. Those three cases have three different
+/// fixes, and no pool-wide statistic distinguishes them.
 #[must_use]
 pub fn classify_stall(
     park_fraction: f64,
-    capped_share: f64,
-    starved_share: f64,
     contended_share: f64,
-    waited_on_starved_share: f64,
+    awaited: AwaitedShares,
 ) -> StallShape {
     if park_fraction < NOT_STALLED_PARK_FRACTION {
         StallShape::NotStalled
     } else if contended_share >= CONTENDED_FILE_SHARE {
         StallShape::Contended
-    } else if capped_share >= HEAD_OF_LINE_CAPPED_SHARE
-        && waited_on_starved_share >= HEAD_OF_LINE_WAITED_SHARE
-    {
+    } else if awaited.starved >= AWAITED_DOMINANT_SHARE {
         StallShape::HeadOfLine
-    } else if starved_share >= POOL_STARVED_SHARE {
-        StallShape::PoolStarved
+    } else if awaited.unclaimed() >= AWAITED_DOMINANT_SHARE {
+        StallShape::WorkUnclaimed
+    } else if awaited.in_progress() >= AWAITED_DOMINANT_SHARE {
+        StallShape::DecompressLatency
     } else {
         StallShape::Mixed
     }
@@ -1095,14 +1212,44 @@ mod tests {
             working: 1,
             drained: 90,
             contended: 2,
-            waited_on_starved: true,
+            awaited: Some(AwaitedState::Starved),
         });
         let report = tracker.snapshot();
         // 10 live files out of 100 observed: the 90 drained ones do not dilute.
         assert!((report.capped_share - 0.6).abs() < 1e-9);
         assert!((report.starved_share - 0.1).abs() < 1e-9);
         assert!((report.contended_share - 0.2).abs() < 1e-9);
-        assert!((report.waited_on_starved_share - 1.0).abs() < 1e-9);
+        assert!((report.awaited.starved - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_awaited_states_are_grouped_by_what_can_be_done_about_them() {
+        let mut tracker = ConsumerStallTracker::new(4);
+        for state in [
+            AwaitedState::ReorderGapStalled,
+            AwaitedState::RawQueued,
+            AwaitedState::ReorderGapFilling,
+            AwaitedState::Decompressing,
+        ] {
+            tracker.record_census(ParkCensus { awaited: Some(state), ..ParkCensus::default() });
+        }
+        let awaited = tracker.snapshot().awaited;
+        // Half the waits are on work nobody has claimed (fixable by scheduling)
+        // and half on work already underway (fixable only by getting ahead).
+        assert!((awaited.unclaimed() - 0.5).abs() < 1e-9);
+        assert!((awaited.in_progress() - 0.5).abs() < 1e-9);
+    }
+
+    /// A census that could not read the awaited file must not be counted as an
+    /// observation of it, or an unreadable file silently reads as a state.
+    #[test]
+    fn test_unreadable_awaited_file_is_not_counted() {
+        let mut tracker = ConsumerStallTracker::new(4);
+        tracker.record_census(ParkCensus { contended: 4, awaited: None, ..ParkCensus::default() });
+        let report = tracker.snapshot();
+        assert_eq!(report.censuses, 1);
+        assert!((report.awaited.starved - 0.0).abs() < f64::EPSILON);
+        assert!((report.awaited.unclaimed() - 0.0).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -1113,41 +1260,54 @@ mod tests {
         assert!((report.top_source_share() - 0.0).abs() < f64::EPSILON);
     }
 
+    /// Build shares in declaration order: filling, stalled, decompressing,
+    /// raw-queued, starved.
+    fn awaited_shares(s: [f64; AwaitedState::COUNT]) -> AwaitedShares {
+        AwaitedShares {
+            reorder_gap_filling: s[0],
+            reorder_gap_stalled: s[1],
+            decompressing: s[2],
+            raw_queued: s[3],
+            starved: s[4],
+        }
+    }
+
     #[rstest]
-    // The hypothesis under test: the consumer is blocked on an empty file while
-    // the pool has buffered every other file to its cap. Misallocated
-    // read-ahead, not insufficient read-ahead.
-    #[case::head_of_line_blocking(0.60, 0.85, 0.05, 0.02, 0.90, StallShape::HeadOfLine)]
-    // Same high capped share, but the consumer is never waiting on a starved
-    // file — this is just a consumer-limited merge, and the caps are innocent.
-    #[case::consumer_limited_but_not_misallocated(0.60, 0.85, 0.05, 0.02, 0.10, StallShape::Mixed)]
-    // Nothing buffered anywhere: the constraint is upstream of the caps, so
-    // raising them cannot help.
-    #[case::pool_cannot_keep_up(0.60, 0.05, 0.80, 0.02, 0.90, StallShape::PoolStarved)]
+    // The block has not been read from disk at all: nothing the pool does with
+    // its buffers or its scheduler can help.
+    #[case::block_not_read_yet(0.60, 0.02, [0.05, 0.05, 0.10, 0.10, 0.70], StallShape::HeadOfLine)]
+    // The block exists -- as raw bytes, or as a gap with nothing being
+    // decompressed -- and no worker has claimed it. Scheduling, not capacity.
+    #[case::work_sitting_unclaimed(0.60, 0.02, [0.10, 0.40, 0.10, 0.35, 0.05], StallShape::WorkUnclaimed)]
+    // A worker is already on it, so the wait is the decompression itself.
+    #[case::already_being_produced(0.60, 0.02, [0.45, 0.05, 0.40, 0.05, 0.05], StallShape::DecompressLatency)]
     // Contention is checked first: while a quarter of the census is unreadable,
     // the other shares are estimates of an unobserved population.
-    #[case::contention_masks_the_other_shares(0.60, 0.85, 0.05, 0.30, 0.90, StallShape::Contended)]
+    #[case::contention_masks_the_other_shares(0.60, 0.30, [0.45, 0.05, 0.40, 0.05, 0.05], StallShape::Contended)]
     // Measured on the storedout arm, where the consumer waits far less; the
     // gate has to be on exact park time, not the sampled fetch fraction.
-    #[case::consumer_not_waiting(0.01, 0.90, 0.05, 0.30, 0.90, StallShape::NotStalled)]
-    #[case::nothing_dominates(0.60, 0.30, 0.30, 0.10, 0.30, StallShape::Mixed)]
+    #[case::consumer_not_waiting(0.01, 0.30, [0.45, 0.05, 0.40, 0.05, 0.05], StallShape::NotStalled)]
+    // Unclaimed and in-progress each fall short of dominance; reporting either
+    // would be a guess.
+    #[case::nothing_dominates(0.60, 0.02, [0.25, 0.25, 0.20, 0.20, 0.10], StallShape::Mixed)]
     fn test_classify_stall(
         #[case] park_fraction: f64,
-        #[case] capped_share: f64,
-        #[case] starved_share: f64,
         #[case] contended_share: f64,
-        #[case] waited_on_starved_share: f64,
+        #[case] awaited: [f64; AwaitedState::COUNT],
         #[case] expected: StallShape,
     ) {
         assert_eq!(
-            classify_stall(
-                park_fraction,
-                capped_share,
-                starved_share,
-                contended_share,
-                waited_on_starved_share
-            ),
+            classify_stall(park_fraction, contended_share, awaited_shares(awaited)),
             expected
         );
+    }
+
+    /// The three groups partition the census, so a stall always has an answer
+    /// even when no single state dominates.
+    #[test]
+    fn test_awaited_groups_partition_the_census() {
+        let shares = awaited_shares([0.2, 0.3, 0.15, 0.25, 0.1]);
+        let total = shares.starved + shares.unclaimed() + shares.in_progress();
+        assert!((total - 1.0).abs() < 1e-9);
     }
 }

--- a/crates/fgumi-sort/src/merge_stalls.rs
+++ b/crates/fgumi-sort/src/merge_stalls.rs
@@ -1,0 +1,1153 @@
+//! Why the merge stalled — the counters that separate the candidate causes.
+//!
+//! [`crate::merge_phases`] answers *where the merge's time went*: how much
+//! thread-busy time each component consumed, and what fraction of worker
+//! capacity that used. On a spill-heavy whole-genome sort it reports a merge in
+//! which the worker pool is ~55% utilized while the consumer spends ~79% of its
+//! loop fetching records. Both halves are waiting, and neither number says what
+//! for.
+//!
+//! It cannot say, because every candidate cause produces the same reading. A
+//! worker that finds nothing to do sleeps and adds to one idle total, whether it
+//! found nothing because
+//!
+//! - every file's reorder buffer was at [`PHASE2_DECOMP_CAP`] (the consumer is
+//!   behind, and the pool is correctly throttled),
+//! - every file's raw FIFO was at [`PHASE2_RAW_CAP`] (decompression is behind
+//!   the read side, so read-ahead depth is the binding constraint),
+//! - every file with data left already had a peer worker inside a disk read
+//!   (waiting on I/O, which wants read concurrency rather than deeper buffers),
+//!   or
+//! - its `try_lock` calls lost races against other workers (contention).
+//!
+//! [`PHASE2_DECOMP_CAP`]: crate::worker_pool::PHASE2_DECOMP_CAP
+//! [`PHASE2_RAW_CAP`]: crate::worker_pool::PHASE2_RAW_CAP
+//!
+//! The file-scan loop already distinguishes all four and then discards the
+//! distinction. This module keeps it, plus two things nothing currently measures
+//! at all:
+//!
+//! - **Where the consumer actually blocks.** `advance_to_next_block` parks the
+//!   main thread waiting for one specific file's next block. Parks happen once
+//!   per ~64 KB block rather than once per ~100-byte record, so unlike the
+//!   sampled per-record timers they can be measured exactly and for free, and
+//!   they isolate *waiting* from the record copy that the sampled "fetch next
+//!   record" figure folds in with it. Censusing the other files at that moment
+//!   is what separates head-of-line blocking (this file starved, the rest at
+//!   cap) from a uniformly starved pool.
+//! - **How late workers discover work.** Nothing ever unparks a pool worker: the
+//!   wake path runs one way, workers to main thread. A worker that has backed
+//!   off to [`MAX_BACKOFF_US`](crate::worker_pool::MAX_BACKOFF_US) therefore
+//!   finds newly-available work up to a millisecond after it appears, and that
+//!   delay is indistinguishable from I/O latency in every counter that exists
+//!   today.
+//!
+//! # Cost
+//!
+//! Nothing here runs on a hot path. Skip reasons are tallied in a worker's stack
+//! frame and flushed only on the scan that found no work — the path that is
+//! about to sleep anyway. Park timing is per block. The park census is the one
+//! genuinely non-trivial cost (a `try_lock` per file) and is sampled.
+//!
+//! # Calibration status
+//!
+//! [`classify_merge`](crate::merge_phases::classify_merge)'s thresholds were
+//! fitted to measured runs. [`classify_stall`]'s were not — they encode the
+//! hypotheses this instrumentation exists to test, and the first instrumented
+//! run should either confirm or replace them. The test cases are named for the
+//! hypothesis each one pins so that is not forgotten.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+// ============================================================================
+// Worker side: why a file-scan found no work
+// ============================================================================
+
+/// Why a worker skipped one spill file during a Phase 2 scan.
+///
+/// # There is deliberately no "starved" variant
+///
+/// A file with an empty FIFO and a reader that is neither at EOF nor held by
+/// another worker is not skipped — the scan *reads* it, and the scan is
+/// therefore productive. Starvation cannot appear as a skip reason; the closest
+/// thing is [`ReadInProgress`](Self::ReadInProgress), which says a peer is
+/// already fetching. Starvation shows up on the consumer side instead, as a park
+/// while the pool is busy, which is why both halves of this module are needed to
+/// answer the question.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Phase2Skip {
+    /// The reader is at EOF and the raw FIFO is empty — nothing left for a
+    /// worker to take, though blocks may still be in flight or waiting for the
+    /// consumer to collect them.
+    Drained,
+    /// The reorder buffer is at `PHASE2_DECOMP_CAP` and the head raw block is
+    /// not the gap-filler the consumer is stuck on. Backpressure working as
+    /// intended: the consumer is behind, not the pool.
+    DecompCapped,
+    /// The raw FIFO is at `PHASE2_RAW_CAP`, so no more disk read-ahead is
+    /// admitted. Blocks are arriving faster than they are being decompressed.
+    RawFull,
+    /// Another worker holds this file's reader lock, i.e. a disk read for it is
+    /// already underway. Not a defect — but a scan dominated by it means
+    /// workers are queued behind in-flight reads, and more read concurrency,
+    /// not deeper buffers, is what would help.
+    ReadInProgress,
+    /// A `try_lock` on the raw FIFO or the reorder buffer lost a race. Work may
+    /// well have been available; this worker could not see it.
+    LockContended,
+}
+
+impl Phase2Skip {
+    /// Number of variants, for fixed-size counter arrays.
+    pub(crate) const COUNT: usize = 5;
+
+    /// Every variant, in declaration order, for iteration and display.
+    pub(crate) const ALL: [Self; Self::COUNT] = [
+        Self::Drained,
+        Self::DecompCapped,
+        Self::RawFull,
+        Self::ReadInProgress,
+        Self::LockContended,
+    ];
+
+    /// Short label for log output.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Drained => "drained",
+            Self::DecompCapped => "decomp-capped",
+            Self::RawFull => "raw-full",
+            Self::ReadInProgress => "read-in-progress",
+            Self::LockContended => "lock-contended",
+        }
+    }
+}
+
+/// Why the decompress half of a file scan declined to take a block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PopSkip {
+    /// The raw FIFO's `try_lock` lost a race.
+    RawLockContended,
+    /// The raw FIFO is empty; there is nothing decompressible buffered.
+    RawEmpty,
+    /// The reorder buffer's `try_lock` lost a race.
+    DecompLockContended,
+    /// The reorder buffer is at cap and the head block is not the gap-filler.
+    DecompCapped,
+}
+
+/// Why the read half of a file scan declined to fetch more blocks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReadSkip {
+    /// Another worker holds the reader lock.
+    ReaderBusy,
+    /// The reader has reached EOF.
+    ReaderEof,
+    /// The raw FIFO's `try_lock` lost a race, so its depth is unknown.
+    RawLockContended,
+    /// The raw FIFO is at `PHASE2_RAW_CAP`.
+    RawFull,
+}
+
+/// Reduce a file's two half-scan outcomes to the one reason worth counting.
+///
+/// Both halves decline independently and often for related reasons (a file at
+/// its decompress cap will usually also have a full raw FIFO), so the pair has
+/// to be collapsed rather than counted twice. Backpressure wins over everything
+/// else because it is the only outcome that says the pipeline is *working* —
+/// this file has data and the pool is deliberately not taking it.
+#[must_use]
+pub(crate) fn combine_skip(pop: PopSkip, read: ReadSkip) -> Phase2Skip {
+    match (pop, read) {
+        (PopSkip::DecompCapped, _) => Phase2Skip::DecompCapped,
+        (PopSkip::RawLockContended | PopSkip::DecompLockContended, _)
+        | (_, ReadSkip::RawLockContended) => Phase2Skip::LockContended,
+        (_, ReadSkip::ReaderBusy) => Phase2Skip::ReadInProgress,
+        (_, ReadSkip::RawFull) => Phase2Skip::RawFull,
+        (PopSkip::RawEmpty, ReadSkip::ReaderEof) => Phase2Skip::Drained,
+    }
+}
+
+/// Skip reasons accumulated over one worker's scan of every spill file.
+///
+/// Lives in the worker's stack frame during the scan and is discarded if the
+/// scan finds work, so a productive scan pays five increments of a local array
+/// and nothing else.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Phase2ScanTally {
+    counts: [u32; Phase2Skip::COUNT],
+}
+
+impl Phase2ScanTally {
+    /// Note that one file was skipped for `reason`.
+    #[inline]
+    pub(crate) fn note(&mut self, reason: Phase2Skip) {
+        self.counts[reason as usize] += 1;
+    }
+
+    /// How many files were skipped for `reason`.
+    #[must_use]
+    pub(crate) fn count(&self, reason: Phase2Skip) -> u32 {
+        self.counts[reason as usize]
+    }
+
+    /// Files skipped for any reason.
+    #[must_use]
+    pub(crate) fn total(&self) -> u32 {
+        self.counts.iter().sum()
+    }
+
+    /// Files that could still have yielded work — everything except the ones
+    /// that are legitimately finished.
+    ///
+    /// The denominator for every share below. A scan of 86 files where 80 are
+    /// drained and 6 are contended is a *contended* scan, not a 7%-contended
+    /// one; dividing by the live files rather than all of them is what makes the
+    /// verdict hold up as the merge nears completion and file after file drops
+    /// out.
+    #[must_use]
+    pub(crate) fn live(&self) -> u32 {
+        self.total() - self.count(Phase2Skip::Drained)
+    }
+}
+
+/// What a fruitless file scan says about the pipeline's state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ScanVerdict {
+    /// Every file is finished; the merge is winding down.
+    Drained,
+    /// The live files are buffered to their caps. Workers are ahead of the
+    /// consumer and idling *because they are throttled*, which means raising
+    /// the caps buys buffering, not throughput.
+    Backpressured,
+    /// Lock contention hid a material share of the live files from this worker.
+    Contended,
+    /// The live files already have reads underway. Workers are queued behind
+    /// in-flight disk I/O, so read concurrency — not buffer depth — is the
+    /// constraint.
+    IoWait,
+    /// No single explanation dominates.
+    Mixed,
+}
+
+impl ScanVerdict {
+    /// Number of variants, so the counter arrays indexed by `self as usize`
+    /// cannot fall behind the enum. Sizing them with a literal instead lets a
+    /// new variant compile and then index out of bounds inside
+    /// [`Phase2ScanStats::record_fruitless_scan`] -- on a worker thread, where
+    /// it surfaces only as a panicked sort worker.
+    pub(crate) const COUNT: usize = 5;
+}
+
+// Keeps `COUNT` honest: the match is exhaustive, so a sixth variant fails to
+// compile here instead of indexing past the end of the counter arrays at run
+// time.
+const _: () = {
+    const fn assert_count(verdict: ScanVerdict) -> usize {
+        match verdict {
+            ScanVerdict::Drained => 0,
+            ScanVerdict::Backpressured => 1,
+            ScanVerdict::Contended => 2,
+            ScanVerdict::IoWait => 3,
+            ScanVerdict::Mixed => ScanVerdict::COUNT - 1,
+        }
+    }
+    assert!(assert_count(ScanVerdict::Mixed) == 4);
+};
+
+/// Share of live files above which one skip reason explains the scan.
+const DOMINANT_SHARE: f64 = 0.60;
+/// Share of live files that must be lock-contended to call the scan contended.
+///
+/// Lower than [`DOMINANT_SHARE`] on purpose: contention is a defect rather than
+/// a régime, and a quarter of the pool's view being blocked by `try_lock` misses
+/// is already worth reporting even when another reason is more common.
+const CONTENDED_SHARE: f64 = 0.25;
+
+/// Classify one fruitless scan.
+///
+/// Pure so the thresholds are unit-testable without a pipeline, following
+/// [`classify_merge`](crate::merge_phases::classify_merge).
+#[must_use]
+#[allow(
+    clippy::cast_precision_loss,
+    reason = "file counts are bounded by the open-file limit; f64 represents them exactly"
+)]
+pub(crate) fn classify_scan(tally: Phase2ScanTally) -> ScanVerdict {
+    let live = tally.live();
+    if live == 0 {
+        return ScanVerdict::Drained;
+    }
+    let share = |reason: Phase2Skip| f64::from(tally.count(reason)) / f64::from(live);
+
+    if share(Phase2Skip::LockContended) >= CONTENDED_SHARE {
+        ScanVerdict::Contended
+    } else if share(Phase2Skip::DecompCapped) + share(Phase2Skip::RawFull) >= DOMINANT_SHARE {
+        ScanVerdict::Backpressured
+    } else if share(Phase2Skip::ReadInProgress) >= DOMINANT_SHARE {
+        ScanVerdict::IoWait
+    } else {
+        ScanVerdict::Mixed
+    }
+}
+
+/// Pool-wide totals for fruitless Phase 2 scans.
+///
+/// Written by every worker, so atomic; `Relaxed` throughout because these are
+/// diagnostics with no ordering relationship to the data they describe.
+#[derive(Debug, Default)]
+pub(crate) struct Phase2ScanStats {
+    /// Fruitless scans, by [`ScanVerdict`].
+    verdicts: [AtomicU64; ScanVerdict::COUNT],
+    /// Files skipped, by [`Phase2Skip`], summed over fruitless scans.
+    skips: [AtomicU64; Phase2Skip::COUNT],
+    /// Number of fruitless scans.
+    scans: AtomicU64,
+}
+
+impl Phase2ScanStats {
+    /// Record one scan that found no work.
+    pub(crate) fn record_fruitless_scan(&self, tally: Phase2ScanTally) {
+        self.scans.fetch_add(1, Ordering::Relaxed);
+        for reason in Phase2Skip::ALL {
+            let n = u64::from(tally.count(reason));
+            if n > 0 {
+                self.skips[reason as usize].fetch_add(n, Ordering::Relaxed);
+            }
+        }
+        let verdict = classify_scan(tally);
+        self.verdicts[verdict as usize].fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn snapshot(&self) -> Phase2ScanReport {
+        Phase2ScanReport {
+            scans: self.scans.load(Ordering::Relaxed),
+            verdicts: std::array::from_fn(|i| self.verdicts[i].load(Ordering::Relaxed)),
+            skips: std::array::from_fn(|i| self.skips[i].load(Ordering::Relaxed)),
+        }
+    }
+}
+
+/// Read-only view of [`Phase2ScanStats`], for logging.
+#[derive(Debug, Clone, Copy)]
+pub struct Phase2ScanReport {
+    /// Number of scans that found no work.
+    pub scans: u64,
+    /// Fruitless scans by verdict, indexed by [`ScanVerdict`] as `usize`.
+    pub verdicts: [u64; ScanVerdict::COUNT],
+    /// Files skipped by reason, indexed by [`Phase2Skip`] as `usize`.
+    pub skips: [u64; Phase2Skip::COUNT],
+}
+
+impl Phase2ScanReport {
+    /// Whether any fruitless scan was recorded, so a sort that never merged
+    /// stays silent.
+    #[must_use]
+    pub fn is_empty(self) -> bool {
+        self.scans == 0
+    }
+
+    /// Share of fruitless scans that reached `verdict`, in `[0, 1]`.
+    #[must_use]
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "scan counts stay far below 2^52 on any real sort"
+    )]
+    pub(crate) fn verdict_share(self, verdict: ScanVerdict) -> f64 {
+        if self.scans == 0 {
+            return 0.0;
+        }
+        self.verdicts[verdict as usize] as f64 / self.scans as f64
+    }
+}
+
+// ============================================================================
+// Worker side: how late work is discovered
+// ============================================================================
+
+/// Backoff levels a worker can sleep at, in microseconds.
+///
+/// The worker loop doubles its backoff from `MIN_BACKOFF_US` and clamps at
+/// `MAX_BACKOFF_US`, so these are exactly the reachable values.
+/// `test_bucket_table_matches_the_worker_loop_backoff` pins that correspondence
+/// — if the loop's constants or its doubling change, this table has to follow or
+/// the histogram silently mislabels itself.
+pub(crate) const WAKE_BUCKET_US: [u64; 8] = [10, 20, 40, 80, 160, 320, 640, 1000];
+
+/// Bucket index for a sleep of `backoff_us`.
+#[must_use]
+pub(crate) fn wake_bucket(backoff_us: u64) -> usize {
+    let last = WAKE_BUCKET_US.len() - 1;
+    WAKE_BUCKET_US.iter().position(|&us| backoff_us <= us).unwrap_or(last)
+}
+
+/// How long workers sleep, and how much of that sleep precedes finding work.
+///
+/// The second half is the point. Idle time alone cannot distinguish a worker
+/// that slept because there was nothing to do from one that slept *through* work
+/// becoming available, and only the latter is a cost the pipeline pays. A
+/// successful step recorded against a 1 ms bucket says the work was found no
+/// sooner than a millisecond after the worker last looked.
+#[derive(Debug, Default)]
+pub(crate) struct WakeLatencyStats {
+    /// Nanoseconds slept, by backoff level.
+    idle_nanos: [AtomicU64; WAKE_BUCKET_US.len()],
+    /// Sleeps, by backoff level.
+    sleeps: [AtomicU64; WAKE_BUCKET_US.len()],
+    /// Sleeps that were immediately followed by a successful step.
+    productive_sleeps: [AtomicU64; WAKE_BUCKET_US.len()],
+}
+
+impl WakeLatencyStats {
+    /// Record a sleep of `idle_nanos` at backoff level `backoff_us`.
+    pub(crate) fn record_sleep(&self, backoff_us: u64, idle_nanos: u64) {
+        let b = wake_bucket(backoff_us);
+        self.idle_nanos[b].fetch_add(idle_nanos, Ordering::Relaxed);
+        self.sleeps[b].fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record that the sleep at `backoff_us` was followed by finding work.
+    pub(crate) fn record_productive_sleep(&self, backoff_us: u64) {
+        self.productive_sleeps[wake_bucket(backoff_us)].fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn snapshot(&self) -> WakeLatencyReport {
+        WakeLatencyReport {
+            idle_nanos: std::array::from_fn(|i| self.idle_nanos[i].load(Ordering::Relaxed)),
+            sleeps: std::array::from_fn(|i| self.sleeps[i].load(Ordering::Relaxed)),
+            productive_sleeps: std::array::from_fn(|i| {
+                self.productive_sleeps[i].load(Ordering::Relaxed)
+            }),
+        }
+    }
+}
+
+/// Read-only view of [`WakeLatencyStats`], for logging.
+#[derive(Debug, Clone, Copy)]
+pub struct WakeLatencyReport {
+    /// Nanoseconds slept, by backoff level.
+    pub idle_nanos: [u64; WAKE_BUCKET_US.len()],
+    /// Sleeps, by backoff level.
+    pub sleeps: [u64; WAKE_BUCKET_US.len()],
+    /// Sleeps immediately followed by a successful step, by backoff level.
+    pub productive_sleeps: [u64; WAKE_BUCKET_US.len()],
+}
+
+impl WakeLatencyReport {
+    /// Whether any sleep was recorded.
+    #[must_use]
+    pub fn is_empty(self) -> bool {
+        self.sleeps.iter().all(|&n| n == 0)
+    }
+
+    /// Sleeps that were immediately followed by finding work.
+    ///
+    /// The denominator behind [`Self::deep_sleep_wake_share`]. Reported
+    /// alongside it because that share is meaningless at small counts, and a
+    /// pool that idles rarely produces very small counts.
+    #[must_use]
+    pub fn productive_sleep_count(self) -> u64 {
+        self.productive_sleeps.iter().sum()
+    }
+
+    /// Estimated worker-seconds lost to discovering work late.
+    ///
+    /// A sleep followed by a successful step means the work was there when the
+    /// worker woke and may have arrived at any point during the sleep, so half
+    /// the sleep is the expected lag under a uniform arrival assumption.
+    ///
+    /// **This is per-worker discovery lag, not pipeline delay.** It only holds
+    /// the merge up when every worker is asleep at once; with eight workers
+    /// jittered against each other it usually does not. Read it as a ceiling on
+    /// the cost, and compare it against the consumer's park total — if it is a
+    /// rounding error next to that, scheduling latency is not the problem and
+    /// the question is settled cheaply.
+    #[must_use]
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "sleep counts stay far below 2^52 on any real sort"
+    )]
+    pub fn estimated_discovery_lag_secs(self) -> f64 {
+        self.productive_sleeps
+            .iter()
+            .zip(WAKE_BUCKET_US)
+            .map(|(&n, us)| n as f64 * (us as f64 / 2.0) / 1e6)
+            .sum()
+    }
+
+    /// Worker-seconds slept at the deepest backoff levels.
+    ///
+    /// The pool of idle time that discovery lag is drawn from. If this is small,
+    /// [`Self::estimated_discovery_lag_secs`] cannot be large no matter how the
+    /// productive sleeps fall, which makes it a quick sanity check on the
+    /// estimate rather than a second measurement of it.
+    #[must_use]
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "nanosecond totals stay far below 2^52; a sort would need ~52 days of idle time to lose a nanosecond here"
+    )]
+    pub fn deep_sleep_idle_secs(self) -> f64 {
+        self.idle_nanos[DEEP_SLEEP_FIRST_BUCKET..].iter().sum::<u64>() as f64 / 1e9
+    }
+
+    /// Share of productive sleeps that happened at the deepest backoff levels,
+    /// in `[0, 1]`.
+    ///
+    /// High means workers are routinely finding work immediately after their
+    /// longest sleep, which is the signature of a pool that is discovering work
+    /// late rather than lacking it.
+    #[must_use]
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "sleep counts stay far below 2^52 on any real sort"
+    )]
+    pub fn deep_sleep_wake_share(self) -> f64 {
+        let total: u64 = self.productive_sleeps.iter().sum();
+        if total == 0 {
+            return 0.0;
+        }
+        let deep: u64 = self.productive_sleeps[DEEP_SLEEP_FIRST_BUCKET..].iter().sum();
+        deep as f64 / total as f64
+    }
+}
+
+/// First bucket counted as a "deep" sleep (>= 320 µs).
+const DEEP_SLEEP_FIRST_BUCKET: usize = 5;
+
+// ============================================================================
+// Consumer side: where the merge loop blocks
+// ============================================================================
+
+/// The other files' states at the moment the consumer parked.
+///
+/// Built by the caller, which owns the locks; keeping the observation out of
+/// this module leaves the accounting pure and testable.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ParkCensus {
+    /// Files whose reorder buffer is at `PHASE2_DECOMP_CAP`.
+    pub(crate) capped: u32,
+    /// Files with nothing buffered, nothing in flight, and a reader not at EOF.
+    pub(crate) starved: u32,
+    /// Files holding data but not yet at cap.
+    pub(crate) working: u32,
+    /// Files that have produced everything they ever will.
+    pub(crate) drained: u32,
+    /// Files whose state could not be read without blocking.
+    pub(crate) contended: u32,
+    /// Whether the file the consumer is waiting on is itself starved — nothing
+    /// buffered, nothing in flight, reader not at EOF.
+    pub(crate) waited_on_starved: bool,
+}
+
+impl ParkCensus {
+    /// Files that are not finished.
+    #[must_use]
+    fn live(self) -> u32 {
+        self.capped + self.starved + self.working + self.contended
+    }
+}
+
+/// Consumer-side stall accounting.
+///
+/// Owned by the merge loop's `MainThreadChunkConsumer` and touched only by the
+/// main thread, so no atomics: the consumer is single-threaded by construction
+/// and paying for interlocked adds on its own counters would be pure waste.
+#[derive(Debug)]
+pub(crate) struct ConsumerStallTracker {
+    /// Nanoseconds parked, per source.
+    park_nanos_by_source: Vec<u64>,
+    /// Parks, per source.
+    parks_by_source: Vec<u64>,
+    /// Calls to `advance_to_next_block`, i.e. attempts to pull a block.
+    block_pulls: u64,
+    /// Pulls that had to park at least once.
+    stalled_pulls: u64,
+    /// Total parks (a single pull may park more than once).
+    parks: u64,
+    /// Total nanoseconds parked.
+    park_nanos: u64,
+    /// Censuses taken, and the totals they observed.
+    censuses: u64,
+    census_capped: u64,
+    census_starved: u64,
+    census_contended: u64,
+    census_live: u64,
+    census_waited_on_starved: u64,
+    /// Countdown to the next census.
+    census_countdown: u64,
+}
+
+/// Parks between censuses.
+///
+/// A census `try_lock`s every spill file, so it is the one part of this module
+/// with a cost worth bounding. Sampling it is safe in a way that sampling the
+/// park *timing* would not be: the shares it estimates are stable properties of
+/// the pipeline's régime, whereas park durations are heavy-tailed and a sampled
+/// mean of them would be badly biased. Prime, for the same aliasing reason as
+/// the merge loop's 1021.
+const CENSUS_INTERVAL: u64 = 61;
+
+impl ConsumerStallTracker {
+    /// Create a tracker for `num_sources` spill files.
+    #[must_use]
+    pub(crate) fn new(num_sources: usize) -> Self {
+        Self {
+            park_nanos_by_source: vec![0; num_sources],
+            parks_by_source: vec![0; num_sources],
+            block_pulls: 0,
+            stalled_pulls: 0,
+            parks: 0,
+            park_nanos: 0,
+            censuses: 0,
+            census_capped: 0,
+            census_starved: 0,
+            census_contended: 0,
+            census_live: 0,
+            census_waited_on_starved: 0,
+            census_countdown: 0,
+        }
+    }
+
+    /// Note an attempt to pull the next block for a source.
+    #[inline]
+    pub(crate) fn note_block_pull(&mut self) {
+        self.block_pulls += 1;
+    }
+
+    /// Whether the caller should census the files before this park.
+    ///
+    /// Consumes one step of the countdown, so call it exactly once per park.
+    pub(crate) fn should_census(&mut self) -> bool {
+        if self.census_countdown == 0 {
+            self.census_countdown = CENSUS_INTERVAL - 1;
+            true
+        } else {
+            self.census_countdown -= 1;
+            false
+        }
+    }
+
+    /// Record one park of `nanos` waiting on `source_id`.
+    ///
+    /// `first_park_of_pull` distinguishes a pull that stalled from the repeated
+    /// parks of a single stalled pull, so `stall_rate` measures how often a
+    /// block was not ready rather than how many spurious wake-ups it took.
+    pub(crate) fn record_park(&mut self, source_id: usize, nanos: u64, first_park_of_pull: bool) {
+        self.parks += 1;
+        self.park_nanos += nanos;
+        if first_park_of_pull {
+            self.stalled_pulls += 1;
+        }
+        if let Some(slot) = self.park_nanos_by_source.get_mut(source_id) {
+            *slot += nanos;
+        }
+        if let Some(slot) = self.parks_by_source.get_mut(source_id) {
+            *slot += 1;
+        }
+    }
+
+    /// Record a census taken at a park.
+    pub(crate) fn record_census(&mut self, census: ParkCensus) {
+        self.censuses += 1;
+        self.census_capped += u64::from(census.capped);
+        self.census_starved += u64::from(census.starved);
+        self.census_contended += u64::from(census.contended);
+        self.census_live += u64::from(census.live());
+        self.census_waited_on_starved += u64::from(census.waited_on_starved);
+    }
+
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "park counts and nanosecond totals stay far below 2^52"
+    )]
+    pub(crate) fn snapshot(&self) -> ConsumerStallReport {
+        let live = self.census_live as f64;
+        let share = |n: u64| if live > 0.0 { n as f64 / live } else { 0.0 };
+        let top = self
+            .park_nanos_by_source
+            .iter()
+            .enumerate()
+            .max_by_key(|&(_, &nanos)| nanos)
+            .map_or((0, 0), |(idx, &nanos)| (idx, nanos));
+        ConsumerStallReport {
+            block_pulls: self.block_pulls,
+            stalled_pulls: self.stalled_pulls,
+            parks: self.parks,
+            park_secs: self.park_nanos as f64 / 1e9,
+            capped_share: share(self.census_capped),
+            starved_share: share(self.census_starved),
+            contended_share: share(self.census_contended),
+            waited_on_starved_share: if self.censuses > 0 {
+                self.census_waited_on_starved as f64 / self.censuses as f64
+            } else {
+                0.0
+            },
+            censuses: self.censuses,
+            top_source: top.0,
+            top_source_park_secs: top.1 as f64 / 1e9,
+            sources_parked_on: self.parks_by_source.iter().filter(|&&n| n > 0).count(),
+        }
+    }
+}
+
+/// Read-only view of [`ConsumerStallTracker`], for logging.
+#[derive(Debug, Clone, Copy)]
+pub struct ConsumerStallReport {
+    /// Attempts to pull a decompressed block.
+    pub block_pulls: u64,
+    /// Pulls where the block was not ready and the consumer had to park.
+    pub stalled_pulls: u64,
+    /// Total parks, including repeated parks within one pull.
+    pub parks: u64,
+    /// Total seconds the consumer spent parked. Exact, not sampled.
+    pub park_secs: f64,
+    /// Share of live-file observations sitting at `PHASE2_DECOMP_CAP` at a
+    /// park.
+    ///
+    /// Pooled across censuses -- summed over the numerator and over `live`,
+    /// not averaged per park -- so a census taken while more files were still
+    /// live weighs proportionally more. Live count falls as sources retire,
+    /// which is exactly when the shares are least interesting.
+    pub capped_share: f64,
+    /// Share of live-file observations with nothing buffered at a park, pooled
+    /// the same way as [`Self::capped_share`].
+    pub starved_share: f64,
+    /// Share of live-file observations whose state could not be read at a park,
+    /// pooled the same way as [`Self::capped_share`].
+    pub contended_share: f64,
+    /// Share of parks where the awaited file was itself starved.
+    pub waited_on_starved_share: f64,
+    /// Censuses taken.
+    pub censuses: u64,
+    /// Source the consumer parked on longest.
+    pub top_source: usize,
+    /// Seconds parked on that source.
+    pub top_source_park_secs: f64,
+    /// Distinct sources the consumer ever parked on.
+    pub sources_parked_on: usize,
+}
+
+impl ConsumerStallReport {
+    /// Whether the consumer ever pulled a block.
+    #[must_use]
+    pub fn is_empty(self) -> bool {
+        self.block_pulls == 0
+    }
+
+    /// Share of block pulls that had to wait, in `[0, 1]`.
+    #[must_use]
+    #[allow(clippy::cast_precision_loss, reason = "pull counts stay far below 2^52")]
+    pub fn stall_rate(self) -> f64 {
+        if self.block_pulls == 0 {
+            return 0.0;
+        }
+        self.stalled_pulls as f64 / self.block_pulls as f64
+    }
+
+    /// Parks per pull that had to wait.
+    ///
+    /// Ideally 1. Higher means the consumer is being woken and re-parked
+    /// repeatedly within a single stall: every worker unparks the main thread on
+    /// every block it publishes, for *any* file, but the consumer can only
+    /// proceed when the one file it is waiting on advances. Each of those wakes
+    /// costs a syscall and a re-lock of that file's reorder buffer, and buys
+    /// nothing. A large ratio is its own coordination problem, distinct from the
+    /// stall it is measured inside.
+    #[must_use]
+    #[allow(clippy::cast_precision_loss, reason = "park counts stay far below 2^52")]
+    pub fn parks_per_stall(self) -> f64 {
+        if self.stalled_pulls == 0 {
+            return 0.0;
+        }
+        self.parks as f64 / self.stalled_pulls as f64
+    }
+
+    /// Share of total park time spent on the single worst source, in `[0, 1]`.
+    ///
+    /// Near `1 / num_sources` means the wait is spread evenly; much higher means
+    /// one run is holding the merge up.
+    #[must_use]
+    pub fn top_source_share(self) -> f64 {
+        if self.park_secs <= 0.0 { 0.0 } else { self.top_source_park_secs / self.park_secs }
+    }
+}
+
+/// The shape of a consumer stall — which of the candidate causes it fits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StallShape {
+    /// The consumer barely parked; whatever it spends its loop on, it is not
+    /// waiting for blocks.
+    NotStalled,
+    /// The consumer waits on a starved file while most others sit at their cap.
+    /// Read-ahead is allocated evenly across files while demand is not, so the
+    /// pool buffers work nobody needs yet and starves the one run that is next.
+    /// A uniformly bigger cap does not fix this; steering workers toward the
+    /// file the loser tree needs does.
+    HeadOfLine,
+    /// Most files are starved too, so the pool as a whole cannot keep the
+    /// consumer fed — the constraint is upstream of the caps.
+    PoolStarved,
+    /// Enough of the pipeline's state was lock-contended that contention is the
+    /// first thing to fix; the other shares are unreliable until it is.
+    Contended,
+    /// No candidate fits cleanly.
+    Mixed,
+}
+
+/// Park share of the merge loop below which the consumer is not stalling.
+const NOT_STALLED_PARK_FRACTION: f64 = 0.05;
+/// Share of live files that must be at cap for head-of-line blocking.
+const HEAD_OF_LINE_CAPPED_SHARE: f64 = 0.50;
+/// Share of parks whose awaited file must be starved for head-of-line blocking.
+const HEAD_OF_LINE_WAITED_SHARE: f64 = 0.50;
+/// Share of live files that must be starved to blame the pool as a whole.
+const POOL_STARVED_SHARE: f64 = 0.50;
+/// Share of live files that must be unreadable to blame contention.
+const CONTENDED_FILE_SHARE: f64 = 0.25;
+
+/// Classify a consumer stall against the candidate causes.
+///
+/// `park_fraction` is exact park time over merge loop wall clock, which makes
+/// the `NotStalled` gate trustworthy in a way the sampled fetch fraction is not.
+/// The remaining inputs come from the sampled park census.
+///
+/// The discriminating input is `waited_on_starved_share`. A high `capped_share`
+/// alone is ambiguous — it is exactly what a healthy, consumer-limited merge
+/// looks like. It only indicts the caps when the consumer is *simultaneously*
+/// blocked on a file that has nothing, which is what makes the buffering
+/// misallocated rather than merely full.
+///
+/// Thresholds are provisional; see the module doc.
+#[must_use]
+pub fn classify_stall(
+    park_fraction: f64,
+    capped_share: f64,
+    starved_share: f64,
+    contended_share: f64,
+    waited_on_starved_share: f64,
+) -> StallShape {
+    if park_fraction < NOT_STALLED_PARK_FRACTION {
+        StallShape::NotStalled
+    } else if contended_share >= CONTENDED_FILE_SHARE {
+        StallShape::Contended
+    } else if capped_share >= HEAD_OF_LINE_CAPPED_SHARE
+        && waited_on_starved_share >= HEAD_OF_LINE_WAITED_SHARE
+    {
+        StallShape::HeadOfLine
+    } else if starved_share >= POOL_STARVED_SHARE {
+        StallShape::PoolStarved
+    } else {
+        StallShape::Mixed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    // ---- Phase2ScanTally / classify_scan -----------------------------------
+
+    #[test]
+    fn test_tally_counts_by_reason() {
+        let mut tally = Phase2ScanTally::default();
+        tally.note(Phase2Skip::ReadInProgress);
+        tally.note(Phase2Skip::ReadInProgress);
+        tally.note(Phase2Skip::Drained);
+        assert_eq!(tally.count(Phase2Skip::ReadInProgress), 2);
+        assert_eq!(tally.count(Phase2Skip::Drained), 1);
+        assert_eq!(tally.count(Phase2Skip::RawFull), 0);
+        assert_eq!(tally.total(), 3);
+    }
+
+    #[rstest]
+    // Backpressure is the one outcome that says the pipeline is working, so it
+    // wins over the read half's (correlated) complaint.
+    #[case(PopSkip::DecompCapped, ReadSkip::RawFull, Phase2Skip::DecompCapped)]
+    #[case(PopSkip::DecompCapped, ReadSkip::ReaderBusy, Phase2Skip::DecompCapped)]
+    // A lost try_lock on either side means this worker's view is unreliable,
+    // which matters more than what the other half happened to see.
+    #[case(PopSkip::RawLockContended, ReadSkip::RawFull, Phase2Skip::LockContended)]
+    #[case(PopSkip::DecompLockContended, ReadSkip::ReaderEof, Phase2Skip::LockContended)]
+    #[case(PopSkip::RawEmpty, ReadSkip::RawLockContended, Phase2Skip::LockContended)]
+    // Nothing buffered and a peer already fetching: waiting on disk, not on
+    // buffer depth.
+    #[case(PopSkip::RawEmpty, ReadSkip::ReaderBusy, Phase2Skip::ReadInProgress)]
+    #[case(PopSkip::RawEmpty, ReadSkip::RawFull, Phase2Skip::RawFull)]
+    #[case(PopSkip::RawEmpty, ReadSkip::ReaderEof, Phase2Skip::Drained)]
+    fn test_combine_skip(
+        #[case] pop: PopSkip,
+        #[case] read: ReadSkip,
+        #[case] expected: Phase2Skip,
+    ) {
+        assert_eq!(combine_skip(pop, read), expected);
+    }
+
+    /// Drained files are excluded from the denominator, so a scan late in the
+    /// merge is judged on the files that could still have produced work.
+    #[test]
+    fn test_live_excludes_drained_files() {
+        let mut tally = Phase2ScanTally::default();
+        for _ in 0..80 {
+            tally.note(Phase2Skip::Drained);
+        }
+        for _ in 0..6 {
+            tally.note(Phase2Skip::LockContended);
+        }
+        assert_eq!(tally.total(), 86);
+        assert_eq!(tally.live(), 6);
+        assert_eq!(classify_scan(tally), ScanVerdict::Contended);
+    }
+
+    fn scan_of(pairs: &[(Phase2Skip, u32)]) -> Phase2ScanTally {
+        let mut tally = Phase2ScanTally::default();
+        for &(reason, n) in pairs {
+            for _ in 0..n {
+                tally.note(reason);
+            }
+        }
+        tally
+    }
+
+    #[rstest]
+    // The whole point of the counter: workers idle because every live file is
+    // buffered to its cap. Raising the caps buys buffering, not throughput.
+    #[case::all_files_at_cap(&[(Phase2Skip::DecompCapped, 86)], ScanVerdict::Backpressured)]
+    // Read-side and decompress-side caps are the same régime for this purpose,
+    // so they are summed rather than competing.
+    #[case::caps_split_across_both_stages(
+        &[(Phase2Skip::DecompCapped, 45), (Phase2Skip::RawFull, 41)],
+        ScanVerdict::Backpressured
+    )]
+    // Workers queued behind reads their peers are already performing: the pool
+    // is waiting on disk, and deeper buffers cannot help.
+    #[case::everyone_waiting_on_a_peer_read(
+        &[(Phase2Skip::ReadInProgress, 86)],
+        ScanVerdict::IoWait
+    )]
+    // Contention is judged at a lower bar than the others — a quarter of the
+    // pool's view being invisible is a defect even when something else is more
+    // common.
+    #[case::quarter_contended_beats_a_larger_io_share(
+        &[(Phase2Skip::LockContended, 22), (Phase2Skip::ReadInProgress, 64)],
+        ScanVerdict::Contended
+    )]
+    // 40/86 buffered and 46/86 waiting on a peer read: neither reaches the
+    // dominance bar, and reporting either would be a guess.
+    #[case::no_reason_dominates(
+        &[
+            (Phase2Skip::DecompCapped, 20),
+            (Phase2Skip::RawFull, 20),
+            (Phase2Skip::ReadInProgress, 46),
+        ],
+        ScanVerdict::Mixed
+    )]
+    #[case::merge_winding_down(&[(Phase2Skip::Drained, 86)], ScanVerdict::Drained)]
+    #[case::nothing_observed(&[], ScanVerdict::Drained)]
+    fn test_classify_scan(#[case] pairs: &[(Phase2Skip, u32)], #[case] expected: ScanVerdict) {
+        assert_eq!(classify_scan(scan_of(pairs)), expected);
+    }
+
+    #[test]
+    fn test_scan_stats_accumulate_across_scans() {
+        let stats = Phase2ScanStats::default();
+        stats.record_fruitless_scan(scan_of(&[(Phase2Skip::DecompCapped, 8)]));
+        stats.record_fruitless_scan(scan_of(&[(Phase2Skip::DecompCapped, 8)]));
+        stats.record_fruitless_scan(scan_of(&[(Phase2Skip::ReadInProgress, 8)]));
+        let report = stats.snapshot();
+        assert_eq!(report.scans, 3);
+        assert_eq!(report.skips[Phase2Skip::DecompCapped as usize], 16);
+        assert_eq!(report.skips[Phase2Skip::ReadInProgress as usize], 8);
+        assert!((report.verdict_share(ScanVerdict::Backpressured) - 2.0 / 3.0).abs() < 1e-9);
+        assert!((report.verdict_share(ScanVerdict::IoWait) - 1.0 / 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_empty_scan_report_is_reported_as_empty() {
+        assert!(Phase2ScanStats::default().snapshot().is_empty());
+    }
+
+    // ---- Wake latency ------------------------------------------------------
+
+    /// The bucket table must be exactly the backoff levels the worker loop can
+    /// reach, or the histogram mislabels every row. Pinned against the loop's
+    /// own constants so a change there fails here rather than silently.
+    #[test]
+    fn test_bucket_table_matches_the_worker_loop_backoff() {
+        use crate::worker_pool::{MAX_BACKOFF_US, MIN_BACKOFF_US};
+        let mut reachable = Vec::new();
+        let mut us = MIN_BACKOFF_US;
+        loop {
+            reachable.push(us);
+            if us == MAX_BACKOFF_US {
+                break;
+            }
+            us = (us * 2).min(MAX_BACKOFF_US);
+        }
+        assert_eq!(reachable, WAKE_BUCKET_US.to_vec());
+    }
+
+    #[rstest]
+    #[case(10, 0)]
+    #[case(20, 1)]
+    #[case(320, 5)]
+    #[case(640, 6)]
+    #[case(1000, 7)]
+    // Jitter can push an actual sleep past its nominal level; it must not fall
+    // off the end of the table.
+    #[case(4000, 7)]
+    fn test_wake_bucket(#[case] backoff_us: u64, #[case] expected: usize) {
+        assert_eq!(wake_bucket(backoff_us), expected);
+    }
+
+    #[test]
+    fn test_discovery_lag_is_half_the_sleep_that_found_work() {
+        let stats = WakeLatencyStats::default();
+        // 1000 sleeps at 1 ms that each found work: 1000 x 0.5 ms = 0.5 s.
+        for _ in 0..1000 {
+            stats.record_sleep(1000, 1_000_000);
+            stats.record_productive_sleep(1000);
+        }
+        // Sleeps that found nothing cost the pipeline nothing and must not count.
+        for _ in 0..1000 {
+            stats.record_sleep(1000, 1_000_000);
+        }
+        let report = stats.snapshot();
+        assert!((report.estimated_discovery_lag_secs() - 0.5).abs() < 1e-9);
+        assert_eq!(report.sleeps[7], 2000);
+    }
+
+    #[test]
+    fn test_deep_sleep_wake_share() {
+        let stats = WakeLatencyStats::default();
+        for _ in 0..3 {
+            stats.record_productive_sleep(1000);
+        }
+        stats.record_productive_sleep(10);
+        assert!((stats.snapshot().deep_sleep_wake_share() - 0.75).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_empty_wake_report_is_reported_as_empty() {
+        let report = WakeLatencyStats::default().snapshot();
+        assert!(report.is_empty());
+        assert!((report.estimated_discovery_lag_secs() - 0.0).abs() < f64::EPSILON);
+        assert!((report.deep_sleep_wake_share() - 0.0).abs() < f64::EPSILON);
+    }
+
+    // ---- Consumer stalls ---------------------------------------------------
+
+    #[test]
+    fn test_stall_rate_counts_pulls_not_parks() {
+        let mut tracker = ConsumerStallTracker::new(4);
+        for _ in 0..10 {
+            tracker.note_block_pull();
+        }
+        // One pull that stalled and was woken spuriously twice before its block
+        // arrived is one stalled pull, not three.
+        tracker.record_park(0, 1_000_000, true);
+        tracker.record_park(0, 1_000_000, false);
+        tracker.record_park(0, 1_000_000, false);
+        let report = tracker.snapshot();
+        assert_eq!(report.parks, 3);
+        assert_eq!(report.stalled_pulls, 1);
+        assert!((report.stall_rate() - 0.1).abs() < 1e-9);
+        assert!((report.park_secs - 0.003).abs() < 1e-9);
+        // Two of the three parks bought nothing, which is the whole point of
+        // keeping the two counts apart.
+        assert!((report.parks_per_stall() - 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_park_time_is_attributed_per_source() {
+        let mut tracker = ConsumerStallTracker::new(3);
+        tracker.note_block_pull();
+        tracker.record_park(0, 1_000_000, true);
+        tracker.note_block_pull();
+        tracker.record_park(2, 9_000_000, true);
+        let report = tracker.snapshot();
+        assert_eq!(report.top_source, 2);
+        assert_eq!(report.sources_parked_on, 2);
+        assert!((report.top_source_share() - 0.9).abs() < 1e-9);
+    }
+
+    /// Census interval is a countdown, so the first park censuses and the next
+    /// `CENSUS_INTERVAL - 1` do not.
+    #[test]
+    fn test_census_sampling_interval() {
+        let mut tracker = ConsumerStallTracker::new(1);
+        assert!(tracker.should_census(), "the first park must be censused");
+        for _ in 0..CENSUS_INTERVAL - 1 {
+            assert!(!tracker.should_census());
+        }
+        assert!(tracker.should_census(), "and again exactly CENSUS_INTERVAL parks later");
+
+        let mut tracker = ConsumerStallTracker::new(1);
+        let censused = (0..CENSUS_INTERVAL * 2).filter(|_| tracker.should_census()).count();
+        assert_eq!(censused, 2);
+    }
+
+    #[test]
+    fn test_census_shares_use_live_files() {
+        let mut tracker = ConsumerStallTracker::new(10);
+        tracker.record_census(ParkCensus {
+            capped: 6,
+            starved: 1,
+            working: 1,
+            drained: 90,
+            contended: 2,
+            waited_on_starved: true,
+        });
+        let report = tracker.snapshot();
+        // 10 live files out of 100 observed: the 90 drained ones do not dilute.
+        assert!((report.capped_share - 0.6).abs() < 1e-9);
+        assert!((report.starved_share - 0.1).abs() < 1e-9);
+        assert!((report.contended_share - 0.2).abs() < 1e-9);
+        assert!((report.waited_on_starved_share - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_empty_consumer_report_is_reported_as_empty() {
+        let report = ConsumerStallTracker::new(4).snapshot();
+        assert!(report.is_empty());
+        assert!((report.stall_rate() - 0.0).abs() < f64::EPSILON);
+        assert!((report.top_source_share() - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[rstest]
+    // The hypothesis under test: the consumer is blocked on an empty file while
+    // the pool has buffered every other file to its cap. Misallocated
+    // read-ahead, not insufficient read-ahead.
+    #[case::head_of_line_blocking(0.60, 0.85, 0.05, 0.02, 0.90, StallShape::HeadOfLine)]
+    // Same high capped share, but the consumer is never waiting on a starved
+    // file — this is just a consumer-limited merge, and the caps are innocent.
+    #[case::consumer_limited_but_not_misallocated(0.60, 0.85, 0.05, 0.02, 0.10, StallShape::Mixed)]
+    // Nothing buffered anywhere: the constraint is upstream of the caps, so
+    // raising them cannot help.
+    #[case::pool_cannot_keep_up(0.60, 0.05, 0.80, 0.02, 0.90, StallShape::PoolStarved)]
+    // Contention is checked first: while a quarter of the census is unreadable,
+    // the other shares are estimates of an unobserved population.
+    #[case::contention_masks_the_other_shares(0.60, 0.85, 0.05, 0.30, 0.90, StallShape::Contended)]
+    // Measured on the storedout arm, where the consumer waits far less; the
+    // gate has to be on exact park time, not the sampled fetch fraction.
+    #[case::consumer_not_waiting(0.01, 0.90, 0.05, 0.30, 0.90, StallShape::NotStalled)]
+    #[case::nothing_dominates(0.60, 0.30, 0.30, 0.10, 0.30, StallShape::Mixed)]
+    fn test_classify_stall(
+        #[case] park_fraction: f64,
+        #[case] capped_share: f64,
+        #[case] starved_share: f64,
+        #[case] contended_share: f64,
+        #[case] waited_on_starved_share: f64,
+        #[case] expected: StallShape,
+    ) {
+        assert_eq!(
+            classify_stall(
+                park_fraction,
+                capped_share,
+                starved_share,
+                contended_share,
+                waited_on_starved_share
+            ),
+            expected
+        );
+    }
+}

--- a/crates/fgumi-sort/src/merge_stalls.rs
+++ b/crates/fgumi-sort/src/merge_stalls.rs
@@ -421,6 +421,30 @@ impl WakeLatencyStats {
     }
 }
 
+impl WakeLatencyReport {
+    /// This report minus `baseline`, i.e. what accumulated between them.
+    ///
+    /// The pool exists for the whole sort, so these counters include Phase 1's
+    /// sleeps. Reporting the running total against merge wall clock overstates
+    /// the merge's share -- on a measured run, 1815s of "deep-sleep
+    /// worker-seconds" against a merge that only had 8 x 305s = 2442
+    /// worker-seconds of capacity in the first place. Subtracting a snapshot
+    /// taken at the phase boundary is what makes the figure comparable to the
+    /// numbers printed beside it.
+    #[must_use]
+    pub fn since(self, baseline: Self) -> Self {
+        Self {
+            idle_nanos: std::array::from_fn(|i| {
+                self.idle_nanos[i].saturating_sub(baseline.idle_nanos[i])
+            }),
+            sleeps: std::array::from_fn(|i| self.sleeps[i].saturating_sub(baseline.sleeps[i])),
+            productive_sleeps: std::array::from_fn(|i| {
+                self.productive_sleeps[i].saturating_sub(baseline.productive_sleeps[i])
+            }),
+        }
+    }
+}
+
 /// Read-only view of [`WakeLatencyStats`], for logging.
 #[derive(Debug, Clone, Copy)]
 pub struct WakeLatencyReport {
@@ -549,6 +573,45 @@ pub(crate) enum AwaitedState {
 impl AwaitedState {
     /// Number of variants, for fixed-size counter arrays.
     pub(crate) const COUNT: usize = 5;
+
+    /// Every variant, in declaration order.
+    pub(crate) const ALL: [Self; Self::COUNT] = [
+        Self::ReorderGapFilling,
+        Self::ReorderGapStalled,
+        Self::Decompressing,
+        Self::RawQueued,
+        Self::Starved,
+    ];
+
+    /// Short label for log output.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::ReorderGapFilling => "gap-filling",
+            Self::ReorderGapStalled => "gap-stalled",
+            Self::Decompressing => "decompressing",
+            Self::RawQueued => "raw-queued",
+            Self::Starved => "starved",
+        }
+    }
+
+    /// Classify from a file's depths, observed at a point where the consumer
+    /// has just failed to pop the serial it wants.
+    ///
+    /// That precondition is what makes a non-empty reorder buffer mean "holds
+    /// the wrong serials" rather than merely "holds something", so this must
+    /// only be called from the park path.
+    #[must_use]
+    pub(crate) fn classify(decomp_len: usize, in_flight: usize, raw_len: usize) -> Self {
+        if decomp_len > 0 {
+            if in_flight > 0 { Self::ReorderGapFilling } else { Self::ReorderGapStalled }
+        } else if in_flight > 0 {
+            Self::Decompressing
+        } else if raw_len > 0 {
+            Self::RawQueued
+        } else {
+            Self::Starved
+        }
+    }
 }
 
 // Keeps `COUNT` and `ALL` honest: the match is exhaustive, so a sixth variant
@@ -656,6 +719,48 @@ impl ConsumerStallTracker {
             census_awaited: [0; AwaitedState::COUNT],
             census_countdown: 0,
         }
+    }
+
+    /// Restart the counters, discarding everything observed so far.
+    ///
+    /// The tracker is built with the consumer, which happens before the merge
+    /// pulls one block per source to seed the loser tree. Those pulls are the
+    /// likeliest of any to park -- every file is cold at merge start -- and they
+    /// fall outside `loop_total`, which starts once the tree is built. Left in,
+    /// they put `park_fraction` and `classify_stall` on a longer interval than
+    /// the wall clock they are divided by, and on a short merge the K seeding
+    /// parks can be most of what the verdict sees.
+    ///
+    /// Keeps the per-source vectors allocated; only their contents reset.
+    pub(crate) fn restart(&mut self) {
+        let Self {
+            park_nanos_by_source,
+            parks_by_source,
+            block_pulls,
+            stalled_pulls,
+            parks,
+            park_nanos,
+            censuses,
+            census_capped,
+            census_starved,
+            census_contended,
+            census_live,
+            census_awaited,
+            census_countdown,
+        } = self;
+        park_nanos_by_source.fill(0);
+        parks_by_source.fill(0);
+        *block_pulls = 0;
+        *stalled_pulls = 0;
+        *parks = 0;
+        *park_nanos = 0;
+        *censuses = 0;
+        *census_capped = 0;
+        *census_starved = 0;
+        *census_contended = 0;
+        *census_live = 0;
+        census_awaited.fill(0);
+        *census_countdown = 0;
     }
 
     /// Note an attempt to pull the next block for a source.
@@ -1143,6 +1248,37 @@ mod tests {
         assert!((stats.snapshot().deep_sleep_wake_share() - 0.75).abs() < 1e-9);
     }
 
+    /// Phase 1's sleeps must not be charged to the merge.
+    #[test]
+    fn test_wake_report_subtracts_a_phase_boundary_baseline() {
+        let stats = WakeLatencyStats::default();
+        for _ in 0..100 {
+            stats.record_sleep(1000, 1_000_000);
+            stats.record_productive_sleep(1000);
+        }
+        let at_merge_start = stats.snapshot();
+        for _ in 0..10 {
+            stats.record_sleep(1000, 1_000_000);
+            stats.record_productive_sleep(1000);
+        }
+        let merge_only = stats.snapshot().since(at_merge_start);
+        assert_eq!(merge_only.sleeps[7], 10, "only the merge's sleeps may be counted");
+        assert!((merge_only.estimated_discovery_lag_secs() - 0.005).abs() < 1e-9);
+        // The running total is still 110; `since` must not mutate the source.
+        assert_eq!(stats.snapshot().sleeps[7], 110);
+    }
+
+    /// A counter that somehow went backwards must clamp rather than wrap into a
+    /// nonsensical multi-century total.
+    #[test]
+    fn test_wake_report_since_saturates() {
+        let stats = WakeLatencyStats::default();
+        stats.record_sleep(1000, 1_000_000);
+        let later = stats.snapshot();
+        let empty = WakeLatencyStats::default().snapshot();
+        assert_eq!(empty.since(later).sleeps[7], 0);
+    }
+
     #[test]
     fn test_empty_wake_report_is_reported_as_empty() {
         let report = WakeLatencyStats::default().snapshot();
@@ -1250,6 +1386,47 @@ mod tests {
         assert_eq!(report.censuses, 1);
         assert!((report.awaited.starved - 0.0).abs() < f64::EPSILON);
         assert!((report.awaited.unclaimed() - 0.0).abs() < f64::EPSILON);
+    }
+
+    /// Seeding the loser tree happens before the merge clock starts, so the
+    /// stalls it incurs must not survive into the merge's report -- they would
+    /// be divided by a wall time that never contained them. Those seeding pulls
+    /// are also the likeliest to park, since every file is cold at merge start,
+    /// so leaving them in biases the verdict in exactly one direction.
+    #[test]
+    fn test_restart_drops_everything_observed_before_the_merge_clock() {
+        let mut tracker = ConsumerStallTracker::new(3);
+        // One seeding pull per source, each parking on a cold file.
+        for source in 0..3 {
+            tracker.note_block_pull();
+            tracker.record_park(source, 5_000_000, true);
+        }
+        tracker.record_census(ParkCensus {
+            starved: 3,
+            awaited: Some(AwaitedState::Starved),
+            ..ParkCensus::default()
+        });
+        assert!(!tracker.snapshot().is_empty(), "the seeding stalls were recorded");
+
+        tracker.restart();
+
+        let report = tracker.snapshot();
+        assert!(report.is_empty(), "the merge starts from nothing");
+        assert_eq!(report.parks, 0);
+        assert_eq!(report.block_pulls, 0);
+        assert_eq!(report.stalled_pulls, 0);
+        assert_eq!(report.censuses, 0);
+        assert!((report.park_secs - 0.0).abs() < f64::EPSILON);
+        assert!((report.top_source_share() - 0.0).abs() < f64::EPSILON);
+
+        // And it still counts normally afterwards -- a reset that also broke
+        // collection would pass every assertion above.
+        tracker.note_block_pull();
+        tracker.record_park(1, 2_000_000, true);
+        let report = tracker.snapshot();
+        assert_eq!(report.parks, 1);
+        assert_eq!(report.block_pulls, 1);
+        assert!((report.park_secs - 0.002).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/fgumi-sort/src/merge_stalls.rs
+++ b/crates/fgumi-sort/src/merge_stalls.rs
@@ -51,11 +51,18 @@
 //!
 //! # Calibration status
 //!
-//! [`classify_merge`](crate::merge_phases::classify_merge)'s thresholds were
-//! fitted to measured runs. [`classify_stall`]'s were not — they encode the
-//! hypotheses this instrumentation exists to test, and the first instrumented
-//! run should either confirm or replace them. The test cases are named for the
-//! hypothesis each one pins so that is not forgotten.
+//! Both [`classify_merge`](crate::merge_phases::classify_merge)'s thresholds and
+//! [`classify_stall`]'s are fitted to measured runs, and the `measured_*` test
+//! cases pin them to the specific merges that produced them — so moving a
+//! threshold means confronting the evidence rather than editing a number.
+//!
+//! Those runs cover two regimes that behave very differently: a merge of
+//! *disjoint* spill runs (which arises when the input is already sorted in the
+//! requested order, and which idles half the pool) and a merge of *interleaved*
+//! runs (which saturates it). A classifier calibrated on only one of them
+//! misreads the other — notably, "the awaited block exists and no worker is on
+//! it" describes a scheduling defect in the first regime and simple saturation
+//! in the second, which is why `classify_stall` takes worker utilization.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -84,9 +91,20 @@ pub(crate) enum Phase2Skip {
     /// not the gap-filler the consumer is stuck on. Backpressure working as
     /// intended: the consumer is behind, not the pool.
     DecompCapped,
-    /// The raw FIFO is at `PHASE2_RAW_CAP`, so no more disk read-ahead is
-    /// admitted. Blocks are arriving faster than they are being decompressed.
+    /// The raw FIFO is at `PHASE2_RAW_CAP` while the reorder buffer still has
+    /// room, so decompression — not the consumer — is what this file is waiting
+    /// on.
+    ///
+    /// Reported only when the decompress half is *not* capped; when both are
+    /// full the reason is [`FullyBuffered`](Self::FullyBuffered), because a full
+    /// raw FIFO is the downstream consequence of workers having stopped
+    /// decompressing. A zero count here therefore does **not** mean
+    /// `PHASE2_RAW_CAP` was never reached — only that it was never the root
+    /// reason. Misreading that cost real time once already.
     RawFull,
+    /// Both caps are full: the consumer is behind, and the read-ahead behind it
+    /// has backed up to its own limit. The file is as buffered as it can be.
+    FullyBuffered,
     /// Another worker holds this file's reader lock, i.e. a disk read for it is
     /// already underway. Not a defect — but a scan dominated by it means
     /// workers are queued behind in-flight reads, and more read concurrency,
@@ -99,13 +117,14 @@ pub(crate) enum Phase2Skip {
 
 impl Phase2Skip {
     /// Number of variants, for fixed-size counter arrays.
-    pub(crate) const COUNT: usize = 5;
+    pub(crate) const COUNT: usize = 6;
 
     /// Every variant, in declaration order, for iteration and display.
     pub(crate) const ALL: [Self; Self::COUNT] = [
         Self::Drained,
         Self::DecompCapped,
         Self::RawFull,
+        Self::FullyBuffered,
         Self::ReadInProgress,
         Self::LockContended,
     ];
@@ -116,11 +135,29 @@ impl Phase2Skip {
             Self::Drained => "drained",
             Self::DecompCapped => "decomp-capped",
             Self::RawFull => "raw-full",
+            Self::FullyBuffered => "fully-buffered",
             Self::ReadInProgress => "read-in-progress",
             Self::LockContended => "lock-contended",
         }
     }
 }
+
+// Keeps `COUNT` honest: the match is exhaustive, so a seventh variant fails to
+// compile here instead of indexing past the end of the counter arrays at run
+// time.
+const _: () = {
+    const fn assert_count(skip: Phase2Skip) -> usize {
+        match skip {
+            Phase2Skip::Drained => 0,
+            Phase2Skip::DecompCapped => 1,
+            Phase2Skip::RawFull => 2,
+            Phase2Skip::FullyBuffered => 3,
+            Phase2Skip::ReadInProgress => 4,
+            Phase2Skip::LockContended => Phase2Skip::COUNT - 1,
+        }
+    }
+    assert!(assert_count(Phase2Skip::LockContended) == 5);
+};
 
 /// Why the decompress half of a file scan declined to take a block.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -150,17 +187,22 @@ pub(crate) enum ReadSkip {
 
 /// Reduce a file's two half-scan outcomes to the one reason worth counting.
 ///
-/// Both halves decline independently and often for related reasons (a file at
-/// its decompress cap will usually also have a full raw FIFO), so the pair has
-/// to be collapsed rather than counted twice. Backpressure wins over everything
-/// else because it is the only outcome that says the pipeline is *working* —
-/// this file has data and the pool is deliberately not taking it.
+/// Both halves decline independently and often for causally related reasons: a
+/// file at its decompress cap has workers refusing to pull raw blocks, so its
+/// raw FIFO fills to its own cap shortly after. Counting both would double-count
+/// one condition, and reporting the downstream one would name the symptom.
+///
+/// So the reasons are ordered by causal depth, not severity. `DecompCapped`
+/// means the consumer is behind; `FullyBuffered` is the same thing after the
+/// read-ahead behind it has also backed up. Only when the decompress side has
+/// room does `RawFull` mean what it says — that decompression is the laggard.
 #[must_use]
 pub(crate) fn combine_skip(pop: PopSkip, read: ReadSkip) -> Phase2Skip {
     match (pop, read) {
-        (PopSkip::DecompCapped, _) => Phase2Skip::DecompCapped,
         (PopSkip::RawLockContended | PopSkip::DecompLockContended, _)
         | (_, ReadSkip::RawLockContended) => Phase2Skip::LockContended,
+        (PopSkip::DecompCapped, ReadSkip::RawFull) => Phase2Skip::FullyBuffered,
+        (PopSkip::DecompCapped, _) => Phase2Skip::DecompCapped,
         (_, ReadSkip::ReaderBusy) => Phase2Skip::ReadInProgress,
         (_, ReadSkip::RawFull) => Phase2Skip::RawFull,
         (PopSkip::RawEmpty, ReadSkip::ReaderEof) => Phase2Skip::Drained,
@@ -281,7 +323,11 @@ pub(crate) fn classify_scan(tally: Phase2ScanTally) -> ScanVerdict {
 
     if share(Phase2Skip::LockContended) >= CONTENDED_SHARE {
         ScanVerdict::Contended
-    } else if share(Phase2Skip::DecompCapped) + share(Phase2Skip::RawFull) >= DOMINANT_SHARE {
+    } else if share(Phase2Skip::DecompCapped)
+        + share(Phase2Skip::FullyBuffered)
+        + share(Phase2Skip::RawFull)
+        >= DOMINANT_SHARE
+    {
         ScanVerdict::Backpressured
     } else if share(Phase2Skip::ReadInProgress) >= DOMINANT_SHARE {
         ScanVerdict::IoWait
@@ -996,18 +1042,30 @@ pub enum StallShape {
     /// The consumer barely parked; whatever it spends its loop on, it is not
     /// waiting for blocks.
     NotStalled,
+    /// The pool is saturated. The consumer waits because every worker is busy,
+    /// which is the expected shape of a healthy CPU-bound merge rather than a
+    /// defect. Checked before the awaited-file states, because those cannot
+    /// tell "nobody picked this up" from "nobody was free to pick it up" — on
+    /// two measured 780M-record merges at 98% utilization the awaited file read
+    /// as 79% unclaimed, which would otherwise be reported as a scheduling bug.
+    PoolSaturated,
     /// The consumer waits on a file with nothing anywhere in its pipeline —
     /// the block has not even been read from disk. The constraint is upstream
     /// of the pool: disk, or read concurrency.
     HeadOfLine,
     /// The block the consumer needs already exists, in raw or partially
-    /// reordered form, and no worker is applying capacity to it. A scheduling
-    /// and discovery problem, not a capacity one: workers are idle, or looking
-    /// at the wrong file, or asleep.
+    /// reordered form, and no worker is applying capacity to it *while capacity
+    /// is available*. A scheduling and discovery problem, not a capacity one:
+    /// workers are idle, or looking at the wrong file, or asleep.
     WorkUnclaimed,
-    /// A worker is already producing the block the consumer needs. The wait is
-    /// the per-block decompression cost itself, so only running further ahead
-    /// (a deeper cap) or decompressing faster removes it.
+    /// A worker is already producing the block the consumer needs, so the wait
+    /// is the per-block decompression cost paid serially.
+    ///
+    /// Deliberately does not prescribe a deeper cap. Whether running further
+    /// ahead is even possible depends on the reorder dwell measured alongside
+    /// this: if blocks are consumed as fast as they are inserted, the buffer is
+    /// a pass-through and its cap is not what the pipeline is running into. See
+    /// [`crate::merge_trace::BlockLifecycleReport::reorder_is_pass_through`].
     DecompressLatency,
     /// Enough of the pipeline's state was lock-contended that contention is the
     /// first thing to fix; the other shares are unreliable until it is.
@@ -1018,6 +1076,12 @@ pub enum StallShape {
 
 /// Park share of the merge loop below which the consumer is not stalling.
 const NOT_STALLED_PARK_FRACTION: f64 = 0.05;
+/// Worker utilization at or above which a stall is simply saturation.
+///
+/// Shared with [`crate::merge_phases::classify_merge`]'s `CpuBound` threshold on
+/// purpose: the two classifiers must not disagree about whether the pool is
+/// busy.
+const SATURATED_UTILIZATION: f64 = 0.85;
 /// Share of the awaited-file census one explanation must reach to be reported.
 const AWAITED_DOMINANT_SHARE: f64 = 0.50;
 /// Share of live files that must be unreadable to blame contention.
@@ -1041,9 +1105,16 @@ const CONTENDED_FILE_SHARE: f64 = 0.25;
 /// The useful split is whether the needed block exists yet, and if it does,
 /// whether anyone is working on it. Those three cases have three different
 /// fixes, and no pool-wide statistic distinguishes them.
+///
+/// `utilization` is the one pool-wide figure that is still required, and it
+/// gates everything else. "The block exists and no worker is on it" describes
+/// both a scheduling defect and a fully-busy pool, and only utilization tells
+/// them apart. Two measured merges at 98% utilization show 79% of waits on
+/// unclaimed work; calling that a scheduling bug would be wrong.
 #[must_use]
 pub fn classify_stall(
     park_fraction: f64,
+    utilization: f64,
     contended_share: f64,
     awaited: AwaitedShares,
 ) -> StallShape {
@@ -1051,6 +1122,8 @@ pub fn classify_stall(
         StallShape::NotStalled
     } else if contended_share >= CONTENDED_FILE_SHARE {
         StallShape::Contended
+    } else if utilization >= SATURATED_UTILIZATION {
+        StallShape::PoolSaturated
     } else if awaited.starved >= AWAITED_DOMINANT_SHARE {
         StallShape::HeadOfLine
     } else if awaited.unclaimed() >= AWAITED_DOMINANT_SHARE {
@@ -1082,10 +1155,14 @@ mod tests {
     }
 
     #[rstest]
+    // Both caps full is its own state: the consumer is behind AND the read-ahead
+    // behind it has backed up. Reporting this as plain `RawFull` would name the
+    // symptom; reporting it as `DecompCapped` would lose that the FIFO filled.
+    #[case(PopSkip::DecompCapped, ReadSkip::RawFull, Phase2Skip::FullyBuffered)]
     // Backpressure is the one outcome that says the pipeline is working, so it
-    // wins over the read half's (correlated) complaint.
-    #[case(PopSkip::DecompCapped, ReadSkip::RawFull, Phase2Skip::DecompCapped)]
+    // wins over the read half's other (correlated) complaints.
     #[case(PopSkip::DecompCapped, ReadSkip::ReaderBusy, Phase2Skip::DecompCapped)]
+    #[case(PopSkip::DecompCapped, ReadSkip::ReaderEof, Phase2Skip::DecompCapped)]
     // A lost try_lock on either side means this worker's view is unreliable,
     // which matters more than what the other half happened to see.
     #[case(PopSkip::RawLockContended, ReadSkip::RawFull, Phase2Skip::LockContended)]
@@ -1138,6 +1215,13 @@ mod tests {
     // so they are summed rather than competing.
     #[case::caps_split_across_both_stages(
         &[(Phase2Skip::DecompCapped, 45), (Phase2Skip::RawFull, 41)],
+        ScanVerdict::Backpressured
+    )]
+    // `FullyBuffered` is both caps at once, so it is summed with them rather
+    // than falling through to `Mixed` — a guess, about a state the code can
+    // name exactly.
+    #[case::every_file_fully_buffered(
+        &[(Phase2Skip::FullyBuffered, 86)],
         ScanVerdict::Backpressured
     )]
     // Workers queued behind reads their peers are already performing: the pool
@@ -1450,32 +1534,92 @@ mod tests {
     }
 
     #[rstest]
+    // Measured: the degenerate coord->coord cell (run f080bff). Half the pool
+    // idle, the awaited block already being produced.
+    #[case::measured_disjoint_runs(0.79, 0.55, 0.00, [0.11, 0.02, 0.73, 0.11, 0.03], StallShape::DecompressLatency)]
+    // Measured: the same records from interleaved runs, on a saturated pool.
+    // The awaited file reads as 79% unclaimed, which is NOT a scheduling defect
+    // -- there was simply no free worker. Utilization is the only input that
+    // separates this from `WorkUnclaimed`, which is why it is an argument.
+    #[case::measured_interleaved_saturated(0.34, 0.98, 0.00, [0.00, 0.00, 0.08, 0.79, 0.13], StallShape::PoolSaturated)]
+    #[case::measured_queryname_saturated(0.25, 0.98, 0.00, [0.00, 0.00, 0.07, 0.78, 0.15], StallShape::PoolSaturated)]
+    // Same awaited shares as the two above but with capacity to spare: now the
+    // unclaimed work really is a scheduling problem.
+    #[case::unclaimed_with_idle_capacity(0.60, 0.40, 0.02, [0.10, 0.40, 0.10, 0.35, 0.05], StallShape::WorkUnclaimed)]
     // The block has not been read from disk at all: nothing the pool does with
     // its buffers or its scheduler can help.
-    #[case::block_not_read_yet(0.60, 0.02, [0.05, 0.05, 0.10, 0.10, 0.70], StallShape::HeadOfLine)]
-    // The block exists -- as raw bytes, or as a gap with nothing being
-    // decompressed -- and no worker has claimed it. Scheduling, not capacity.
-    #[case::work_sitting_unclaimed(0.60, 0.02, [0.10, 0.40, 0.10, 0.35, 0.05], StallShape::WorkUnclaimed)]
-    // A worker is already on it, so the wait is the decompression itself.
-    #[case::already_being_produced(0.60, 0.02, [0.45, 0.05, 0.40, 0.05, 0.05], StallShape::DecompressLatency)]
-    // Contention is checked first: while a quarter of the census is unreadable,
-    // the other shares are estimates of an unobserved population.
-    #[case::contention_masks_the_other_shares(0.60, 0.30, [0.45, 0.05, 0.40, 0.05, 0.05], StallShape::Contended)]
-    // Measured on the storedout arm, where the consumer waits far less; the
-    // gate has to be on exact park time, not the sampled fetch fraction.
-    #[case::consumer_not_waiting(0.01, 0.30, [0.45, 0.05, 0.40, 0.05, 0.05], StallShape::NotStalled)]
-    // Unclaimed and in-progress each fall short of dominance; reporting either
-    // would be a guess.
-    #[case::nothing_dominates(0.60, 0.02, [0.25, 0.25, 0.20, 0.20, 0.10], StallShape::Mixed)]
+    #[case::block_not_read_yet(0.60, 0.40, 0.02, [0.05, 0.05, 0.10, 0.10, 0.70], StallShape::HeadOfLine)]
+    // Contention is checked before utilization: while a quarter of the census is
+    // unreadable, every other share is an estimate of an unobserved population.
+    #[case::contention_masks_the_other_shares(0.60, 0.98, 0.30, [0.45, 0.05, 0.40, 0.05, 0.05], StallShape::Contended)]
+    // Exact park time gates the whole thing, not the sampled fetch fraction.
+    #[case::consumer_not_waiting(0.01, 0.30, 0.30, [0.45, 0.05, 0.40, 0.05, 0.05], StallShape::NotStalled)]
+    #[case::nothing_dominates(0.60, 0.40, 0.02, [0.25, 0.25, 0.20, 0.20, 0.10], StallShape::Mixed)]
     fn test_classify_stall(
         #[case] park_fraction: f64,
+        #[case] utilization: f64,
         #[case] contended_share: f64,
         #[case] awaited: [f64; AwaitedState::COUNT],
         #[case] expected: StallShape,
     ) {
         assert_eq!(
-            classify_stall(park_fraction, contended_share, awaited_shares(awaited)),
+            classify_stall(park_fraction, utilization, contended_share, awaited_shares(awaited)),
             expected
+        );
+    }
+
+    /// The saturation threshold must agree with `classify_merge`'s, or the two
+    /// verdicts in one log can contradict each other.
+    #[test]
+    fn test_saturation_threshold_agrees_with_classify_merge() {
+        use crate::merge_phases::{MergeVerdict, classify_merge};
+        assert_eq!(classify_merge(SATURATED_UTILIZATION, 0.9), MergeVerdict::CpuBound);
+        assert_eq!(
+            classify_stall(
+                0.9,
+                SATURATED_UTILIZATION,
+                0.0,
+                awaited_shares([0.0, 0.0, 0.0, 1.0, 0.0])
+            ),
+            StallShape::PoolSaturated
+        );
+    }
+
+    /// Agreeing on the threshold is only half the contract -- both verdicts have
+    /// to be computed from the *same* utilization figure, which means both
+    /// loggers must divide worker busy time by the same pair.
+    ///
+    /// Dividing by the pool width instead of the Phase 2 active cap is not a
+    /// rounding difference: on a run whose Phase 1 is wider than its Phase 2 it
+    /// moves the number across `SATURATED_UTILIZATION`, so one log reports a
+    /// saturated pool while the other blames scheduling for the same stall.
+    #[test]
+    fn test_pool_width_denominator_contradicts_the_active_cap_verdict() {
+        use crate::merge_phases::{MergePhaseBreakdown, MergeVerdict, classify_merge};
+
+        // A pool 8 threads wide, capped to 3 for Phase 2, whose workers were
+        // busy 26s across a 10s merge -- 2.6x the wall clock, so the three
+        // threads allowed to help were saturated.
+        let breakdown = MergePhaseBreakdown {
+            read: (6.0, 100),
+            decompress: (20.0, 100),
+            output_compress: (0.0, 1),
+            spill_compress: (0.0, 0),
+        };
+        let (merge_wall, active_workers, pool_width) = (10.0, 3, 8);
+        let awaited = awaited_shares([0.0, 0.0, 0.08, 0.79, 0.13]);
+
+        let by_cap = breakdown.worker_utilization(merge_wall, active_workers).unwrap();
+        assert!(by_cap >= SATURATED_UTILIZATION, "26s over 3 x 10s is saturated, got {by_cap}");
+        assert_eq!(classify_merge(by_cap, 0.1), MergeVerdict::CpuBound);
+        assert_eq!(classify_stall(0.9, by_cap, 0.0, awaited), StallShape::PoolSaturated);
+
+        let by_width = breakdown.worker_utilization(merge_wall, pool_width).unwrap();
+        assert!(by_width < SATURATED_UTILIZATION, "the wrong denominator understates it");
+        assert_ne!(
+            classify_stall(0.9, by_width, 0.0, awaited),
+            StallShape::PoolSaturated,
+            "the pool width turns the same saturated merge into a scheduling defect"
         );
     }
 

--- a/crates/fgumi-sort/src/merge_trace.rs
+++ b/crates/fgumi-sort/src/merge_trace.rs
@@ -1,0 +1,866 @@
+//! End-to-end timing for every stage a spill block passes through.
+//!
+//! [`crate::merge_stalls`] narrowed the merge's stall to one state: the awaited
+//! file's reorder buffer is empty and a decompression is in flight, 73% of the
+//! time on a measured 780M-record merge. That says *where* the consumer is
+//! blocked. It does not say why the buffer was allowed to drain in the first
+//! place, which is the actual defect — the pool has 45% of its capacity idle
+//! and 85 other files buffered to their caps while the one file being consumed
+//! runs dry.
+//!
+//! Answering that needs the block's whole journey, not a snapshot at the end of
+//! it:
+//!
+//! ```text
+//!   disk ──read──▶ raw FIFO ──claim──▶ decompress ──insert──▶ reorder ──pop──▶ consumer
+//!         (A)        (B)        (C)        (D)         (E)      (F)      (G)
+//! ```
+//!
+//! - **A** `read_batch` — how long a disk read of `PHASE2_READ_BATCH` blocks takes.
+//! - **B** `raw_dwell` — how long compressed bytes sat in the FIFO before a
+//!   worker claimed them. Pure scheduling latency: the data was there and the
+//!   pool did not pick it up.
+//! - **D** `decompress` — the per-block cost itself, the irreducible part.
+//! - **F** `reorder_dwell` — how long a decompressed block waited to be
+//!   consumed. Near zero means the lookahead buffer is not actually buffering:
+//!   blocks are being consumed as fast as they appear, so the cap is not what
+//!   is limiting anything.
+//!
+//! And the refill cycle, which is the hungry-file question stated directly.
+//! When the consumer drains a file's reorder buffer to nothing, the clock
+//! starts:
+//!
+//! - `claim_lag` — until some worker claims a raw block for that file
+//! - `insert_lag` — until a block actually lands back in the buffer
+//! - `read_lag` — for the subset where the raw FIFO was empty too, until a read
+//!   completes
+//!
+//! Splitting the empties by what the file had available at the moment it
+//! drained (`raw ready` / `already decompressing` / `nothing`) says which of
+//! those three is on the critical path, and `claim_lag` versus `insert_lag`
+//! splits the remainder into "nobody picked it up" versus "picking it up is
+//! slow".
+//!
+//! # Everything here is a distribution, not a mean
+//!
+//! Merge stalls are heavy-tailed: a mean park of 83 µs is consistent with
+//! almost every park costing 83 µs, and equally consistent with 90% costing 10
+//! µs and 1% costing 7 ms. Those two have different causes and different fixes.
+//! Every timing below is therefore a log2 histogram, and the reports quote
+//! percentiles beside the mean.
+//!
+//! # Cost
+//!
+//! One `Instant::now()` pair per *block*, not per record. Blocks are ~64 KB and
+//! records ~100 bytes, so this is roughly 1/600th the rate of anything on the
+//! record path, and the measured merge does about 5M blocks against 780M
+//! records. The per-file depth counters are plain relaxed atomics maintained
+//! next to the mutexes that already guard the collections.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use crate::merge_stalls::AwaitedState;
+
+// ============================================================================
+// Histogram
+// ============================================================================
+
+/// Number of log2 buckets. Bucket 0 is sub-microsecond; bucket `k` covers
+/// `[2^(k-1), 2^k)` µs, so the top bucket opens at ~4.2 s.
+pub(crate) const HIST_BUCKETS: usize = 24;
+
+/// Bucket index for a duration in nanoseconds.
+#[must_use]
+pub(crate) fn bucket_of_nanos(nanos: u64) -> usize {
+    let micros = nanos / 1_000;
+    if micros == 0 {
+        return 0;
+    }
+    (micros.ilog2() as usize + 1).min(HIST_BUCKETS - 1)
+}
+
+/// Inclusive lower bound of `bucket`, in microseconds.
+#[must_use]
+pub(crate) fn bucket_floor_micros(bucket: usize) -> u64 {
+    if bucket == 0 { 0 } else { 1u64 << (bucket - 1) }
+}
+
+/// A lock-free log2 histogram of durations, plus an exact sum and count.
+///
+/// The sum is kept exactly rather than estimated from buckets so the mean stays
+/// trustworthy; the buckets exist for the shape, which the mean cannot show.
+#[derive(Debug, Default)]
+pub(crate) struct DurationHistogram {
+    buckets: [AtomicU64; HIST_BUCKETS],
+    count: AtomicU64,
+    total_nanos: AtomicU64,
+}
+
+impl DurationHistogram {
+    /// Record one observation.
+    pub(crate) fn record(&self, nanos: u64) {
+        self.buckets[bucket_of_nanos(nanos)].fetch_add(1, Ordering::Relaxed);
+        self.count.fetch_add(1, Ordering::Relaxed);
+        self.total_nanos.fetch_add(nanos, Ordering::Relaxed);
+    }
+
+    /// Time `f`, recording how long it took, and return its value.
+    pub(crate) fn time<R>(&self, f: impl FnOnce() -> R) -> R {
+        let start = Instant::now();
+        let result = f();
+        self.record(elapsed_nanos(start));
+        result
+    }
+
+    pub(crate) fn snapshot(&self) -> HistogramReport {
+        HistogramReport {
+            buckets: std::array::from_fn(|i| self.buckets[i].load(Ordering::Relaxed)),
+            count: self.count.load(Ordering::Relaxed),
+            total_nanos: self.total_nanos.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Read-only view of a [`DurationHistogram`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct HistogramReport {
+    /// Observations per log2 bucket.
+    pub buckets: [u64; HIST_BUCKETS],
+    /// Total observations.
+    pub count: u64,
+    /// Exact sum of all observations, in nanoseconds.
+    pub total_nanos: u64,
+}
+
+impl HistogramReport {
+    /// Whether anything was recorded.
+    #[must_use]
+    pub fn is_empty(self) -> bool {
+        self.count == 0
+    }
+
+    /// Exact total, in seconds.
+    #[must_use]
+    #[allow(clippy::cast_precision_loss, reason = "nanosecond totals stay far below 2^52")]
+    pub fn total_secs(self) -> f64 {
+        self.total_nanos as f64 / 1e9
+    }
+
+    /// Exact mean, in microseconds.
+    #[must_use]
+    #[allow(clippy::cast_precision_loss, reason = "nanosecond totals stay far below 2^52")]
+    pub fn mean_micros(self) -> f64 {
+        if self.count == 0 {
+            return 0.0;
+        }
+        self.total_nanos as f64 / self.count as f64 / 1_000.0
+    }
+
+    /// Approximate percentile, in microseconds.
+    ///
+    /// Returns the lower bound of the bucket the percentile falls in, so it
+    /// understates by up to a factor of two. That is the right trade for a
+    /// distribution spanning microseconds to seconds: the question these answer
+    /// is "which order of magnitude", and an exact quantile would cost either
+    /// reservoir sampling or a far larger table.
+    #[must_use]
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "`fraction` is a caller-supplied percentile in [0, 1] and `count` is an observation count, so the product is non-negative and bounded by `count`"
+    )]
+    pub fn percentile_micros(self, fraction: f64) -> u64 {
+        if self.count == 0 {
+            return 0;
+        }
+        // Walk against the bucket total rather than `count`. `snapshot` reads
+        // the buckets and the counter as separate relaxed loads while workers
+        // are still recording, so `count` can be ahead of the buckets by the
+        // observations that landed in between. Targeting the larger number
+        // means no bucket ever reaches it, the loop falls through, and every
+        // percentile reports the top bucket -- a p50 of 8us printing as ~4.2s.
+        let observed: u64 = self.buckets.iter().sum();
+        if observed == 0 {
+            return 0;
+        }
+        let target = (observed as f64 * fraction.clamp(0.0, 1.0)).ceil() as u64;
+        let mut cumulative = 0u64;
+        for (idx, &n) in self.buckets.iter().enumerate() {
+            cumulative += n;
+            if cumulative >= target {
+                return bucket_floor_micros(idx);
+            }
+        }
+        bucket_floor_micros(HIST_BUCKETS - 1)
+    }
+
+    /// `count`, total, mean and the p50/p90/p99 tail for a histogram whose
+    /// observations are *counts*, not durations.
+    ///
+    /// [`ConsumerTraceStats::record_source_run`] borrows this histogram's log2
+    /// bucketing for run lengths, scaling one block to [`BLOCKS_TO_NANOS`]. That
+    /// puts blocks in the microsecond lane, so `mean_micros` and
+    /// `percentile_micros` already read as blocks -- but [`Self::summary`] would
+    /// label them `us`, and would render `total` through `total_secs()`, which is
+    /// neither blocks nor seconds. This labels every field as what it is.
+    #[must_use]
+    pub fn summary_blocks(self) -> String {
+        format!(
+            "n={} total={} blocks mean={:.1} p50={} p90={} p99={}",
+            self.count,
+            self.total_nanos / BLOCKS_TO_NANOS,
+            self.mean_micros(),
+            self.percentile_micros(0.50),
+            self.percentile_micros(0.90),
+            self.percentile_micros(0.99),
+        )
+    }
+
+    /// `count`, mean and the p50/p90/p99 tail, formatted for one log line.
+    ///
+    /// Durations only. For a histogram of counts use [`Self::summary_blocks`].
+    #[must_use]
+    pub fn summary(self) -> String {
+        format!(
+            "n={} total={:.1}s mean={:.1}us p50={}us p90={}us p99={}us",
+            self.count,
+            self.total_secs(),
+            self.mean_micros(),
+            self.percentile_micros(0.50),
+            self.percentile_micros(0.90),
+            self.percentile_micros(0.99),
+        )
+    }
+}
+
+/// Nanoseconds since `start`, saturating rather than wrapping.
+#[must_use]
+pub(crate) fn elapsed_nanos(start: Instant) -> u64 {
+    u64::try_from(start.elapsed().as_nanos()).unwrap_or(u64::MAX)
+}
+
+// ============================================================================
+// Block lifecycle
+// ============================================================================
+
+/// The two *dwell* stages of a spill block's journey: time it spent queued
+/// rather than time it spent being worked on.
+///
+/// The working stages — the disk read and the decompression — are already timed
+/// by [`MergePhaseCounters`](crate::merge_phases::MergePhaseCounters), which the
+/// workers record into on the production path. Duplicating them here would give
+/// two sources for one number, so this struct owns only what nothing else
+/// measures.
+#[derive(Debug, Default)]
+pub(crate) struct BlockLifecycleStats {
+    /// Compressed bytes sitting in the raw FIFO, unclaimed.
+    pub(crate) raw_dwell: DurationHistogram,
+    /// Decompressed block sitting in the reorder buffer, waiting to be consumed.
+    pub(crate) reorder_dwell: DurationHistogram,
+}
+
+impl BlockLifecycleStats {
+    /// Snapshot the dwell stages, leaving the working stages at their default.
+    ///
+    /// `read_batch` and `decompress` come from
+    /// [`MergePhaseCounters`](crate::merge_phases::MergePhaseCounters), which this
+    /// struct cannot see. [`SortWorkerPool::block_lifecycle_report`] is the only
+    /// caller that holds both halves, and it fills them in.
+    ///
+    /// [`SortWorkerPool::block_lifecycle_report`]: crate::worker_pool::SortWorkerPool
+    pub(crate) fn snapshot(&self) -> BlockLifecycleReport {
+        BlockLifecycleReport {
+            raw_dwell: self.raw_dwell.snapshot(),
+            reorder_dwell: self.reorder_dwell.snapshot(),
+            ..BlockLifecycleReport::default()
+        }
+    }
+}
+
+/// One spill block's full journey: the dwell stages from
+/// [`BlockLifecycleStats`] plus the working stages from
+/// [`MergePhaseCounters`](crate::merge_phases::MergePhaseCounters).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BlockLifecycleReport {
+    /// Disk reads.
+    pub read_batch: HistogramReport,
+    /// Raw FIFO dwell.
+    pub raw_dwell: HistogramReport,
+    /// Decompression.
+    pub decompress: HistogramReport,
+    /// Reorder buffer dwell.
+    pub reorder_dwell: HistogramReport,
+}
+
+impl BlockLifecycleReport {
+    /// Whether any block completed a stage.
+    #[must_use]
+    pub fn is_empty(self) -> bool {
+        self.decompress.is_empty() && self.read_batch.is_empty()
+    }
+
+    /// Whether the reorder buffer is doing any real buffering.
+    ///
+    /// A block that is consumed almost the instant it is inserted was never
+    /// lookahead — it was a block the consumer was already waiting for. When
+    /// this is true, raising the per-file cap cannot help, because the cap is
+    /// not what the pipeline is running into.
+    #[must_use]
+    pub fn reorder_is_pass_through(self) -> bool {
+        !self.reorder_dwell.is_empty()
+            && self.reorder_dwell.percentile_micros(0.90) <= PASS_THROUGH_MICROS
+    }
+}
+
+/// p90 reorder dwell at or below which the buffer is a pass-through.
+///
+/// One decompression costs ~50 µs on the measured workload, so a block that
+/// waits less than that to be consumed did not spend meaningful time buffered.
+const PASS_THROUGH_MICROS: u64 = 50;
+
+// ============================================================================
+// Refill latency
+// ============================================================================
+
+/// What a file had available at the moment its reorder buffer drained to zero.
+///
+/// This is the fork in the road for the hungry-file question, and each branch
+/// has a different fix: `RawReady` means the bytes were there and nothing
+/// picked them up (scheduling); `Decompressing` means the pipeline was already
+/// working and just is not ahead (lookahead depth); `Dry` means nothing had
+/// been read yet (read concurrency).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EmptyCause {
+    /// Raw blocks were queued and unclaimed.
+    RawReady,
+    /// A decompression was already in flight.
+    Decompressing,
+    /// Neither: the file had nothing anywhere.
+    Dry,
+}
+
+impl EmptyCause {
+    /// Number of variants, so the cause arrays indexed by `self as usize`
+    /// cannot fall behind the enum. Sizing them with a literal instead lets a
+    /// new variant compile and then index out of bounds inside
+    /// [`RefillStats::record_empty`] -- on the consumer thread, where it kills
+    /// the merge.
+    pub(crate) const COUNT: usize = 3;
+
+    /// Round-trip through a `u8`, so a file can carry the cause of its current
+    /// empty in an atomic. Any value outside the enum decodes to [`Self::Dry`],
+    /// which is unreachable in practice -- the only writer is
+    /// [`Self::as_u8`].
+    #[must_use]
+    pub(crate) const fn as_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Inverse of [`Self::as_u8`].
+    #[must_use]
+    pub(crate) const fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::RawReady,
+            1 => Self::Decompressing,
+            _ => Self::Dry,
+        }
+    }
+
+    /// Classify from a file's depths at the moment it emptied.
+    #[must_use]
+    pub(crate) fn classify(raw_len: usize, in_flight: usize) -> Self {
+        if in_flight > 0 {
+            Self::Decompressing
+        } else if raw_len > 0 {
+            Self::RawReady
+        } else {
+            Self::Dry
+        }
+    }
+}
+
+// Keeps `COUNT` and `from_u8` honest: the match is exhaustive, so a fourth
+// variant fails to compile here instead of indexing past the end of the cause
+// arrays at run time, or being folded silently into `Dry` by `from_u8`'s
+// catch-all.
+const _: () = {
+    const fn assert_count(cause: EmptyCause) -> usize {
+        match cause {
+            EmptyCause::RawReady => 0,
+            EmptyCause::Decompressing => 1,
+            EmptyCause::Dry => EmptyCause::COUNT - 1,
+        }
+    }
+    assert!(assert_count(EmptyCause::Dry) == 2);
+};
+
+/// How long it takes to put a block back into a file that has run dry.
+#[derive(Debug, Default)]
+pub(crate) struct RefillStats {
+    /// Buffer emptied to a worker claiming a raw block for that file.
+    pub(crate) claim_lag: DurationHistogram,
+    /// Buffer emptied to a block landing back in it.
+    pub(crate) insert_lag: DurationHistogram,
+    /// Buffer emptied to a disk read completing, for files that were also dry.
+    pub(crate) read_lag: DurationHistogram,
+    /// Empties by [`EmptyCause`].
+    causes: [AtomicU64; EmptyCause::COUNT],
+}
+
+impl RefillStats {
+    /// Record that a file's reorder buffer drained to nothing.
+    pub(crate) fn record_empty(&self, cause: EmptyCause) {
+        self.causes[cause as usize].fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn snapshot(&self) -> RefillReport {
+        RefillReport {
+            claim_lag: self.claim_lag.snapshot(),
+            insert_lag: self.insert_lag.snapshot(),
+            read_lag: self.read_lag.snapshot(),
+            causes: std::array::from_fn(|i| self.causes[i].load(Ordering::Relaxed)),
+        }
+    }
+}
+
+/// Read-only view of [`RefillStats`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RefillReport {
+    /// Emptied to claimed.
+    pub claim_lag: HistogramReport,
+    /// Emptied to inserted.
+    pub insert_lag: HistogramReport,
+    /// Emptied to read completed, where the file was dry.
+    pub read_lag: HistogramReport,
+    /// Empties by [`EmptyCause`] as `usize`.
+    pub causes: [u64; EmptyCause::COUNT],
+}
+
+impl RefillReport {
+    /// Whether any file ever ran dry.
+    #[must_use]
+    pub fn is_empty(self) -> bool {
+        self.causes.iter().all(|&n| n == 0)
+    }
+
+    /// Total empties observed.
+    #[must_use]
+    pub fn empties(self) -> u64 {
+        self.causes.iter().sum()
+    }
+
+    /// Share of empties that hit `cause`, in `[0, 1]`.
+    #[must_use]
+    #[allow(clippy::cast_precision_loss, reason = "empty counts stay far below 2^52")]
+    pub fn cause_share(self, cause: EmptyCause) -> f64 {
+        let total = self.empties();
+        if total == 0 {
+            return 0.0;
+        }
+        self.causes[cause as usize] as f64 / total as f64
+    }
+
+    /// Share of refill latency spent waiting for a worker to claim the work,
+    /// as opposed to doing it, in `[0, 1]`.
+    ///
+    /// The single most actionable number here. High means the pipeline is
+    /// mostly waiting to *start*, so the fix is scheduling — wake a worker
+    /// sooner, or apply more of them. Low means the pipeline starts promptly
+    /// and the wait is the work itself, so the fix is to be further ahead when
+    /// the buffer drains.
+    ///
+    /// The two histograms have slightly different populations — a file at end
+    /// of input can empty and never be claimed again — so this is a ratio of
+    /// totals rather than a paired per-cycle mean. At the scale it is read at
+    /// (thousands of cycles, a handful unmatched) that does not change the
+    /// reading, but it is why the counts printed beside them differ.
+    #[must_use]
+    pub fn claim_share(self) -> f64 {
+        let insert = self.insert_lag.total_secs();
+        if insert <= 0.0 {
+            return 0.0;
+        }
+        (self.claim_lag.total_secs() / insert).min(1.0)
+    }
+}
+
+// ============================================================================
+// Consumer trace
+// ============================================================================
+
+/// Largest concurrent-decompression count tracked exactly; higher is clamped.
+pub(crate) const MAX_TRACKED_IN_FLIGHT: usize = 8;
+
+/// Nanoseconds one block is scaled to when a count reuses the duration
+/// histogram's log2 bucketing.
+///
+/// 1 µs per block, so the bucketing sees blocks where it expects microseconds
+/// and [`HistogramReport::summary_blocks`] divides back out. Shared by the
+/// recorder and the formatter so the scale cannot drift between them.
+pub(crate) const BLOCKS_TO_NANOS: u64 = 1_000;
+
+/// What the consumer's own access pattern looks like, and what it costs.
+#[derive(Debug)]
+pub(crate) struct ConsumerTraceStats {
+    /// Park duration, split by what the awaited file was doing.
+    park_by_state: [DurationHistogram; AwaitedState::COUNT],
+    /// Consecutive block pulls from one source before the merge switches.
+    pub(crate) source_run_length: DurationHistogram,
+    /// Concurrent decompressions on the awaited file at a park, clamped.
+    in_flight_at_park: [AtomicU64; MAX_TRACKED_IN_FLIGHT + 1],
+}
+
+impl Default for ConsumerTraceStats {
+    fn default() -> Self {
+        Self {
+            park_by_state: std::array::from_fn(|_| DurationHistogram::default()),
+            source_run_length: DurationHistogram::default(),
+            in_flight_at_park: std::array::from_fn(|_| AtomicU64::new(0)),
+        }
+    }
+}
+
+impl ConsumerTraceStats {
+    /// Record a park of `nanos` that began with the awaited file in `state`,
+    /// with `in_flight` decompressions running on it.
+    pub(crate) fn record_park(&self, state: AwaitedState, nanos: u64, in_flight: usize) {
+        self.park_by_state[state as usize].record(nanos);
+        self.in_flight_at_park[in_flight.min(MAX_TRACKED_IN_FLIGHT)]
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record that the merge drew `blocks` consecutive blocks from one source.
+    ///
+    /// This is the test for whether the merge has a *hot file* worth steering
+    /// workers toward. A run length of 1 means it does not: the loser tree
+    /// interleaves records from every run at once, so by the time one source's
+    /// block is exhausted the merge has already pulled from many others.
+    /// Demand is spread evenly and continuously across all K files, and any fix
+    /// framed as "prefetch the file the consumer needs next" is answering a
+    /// question the workload does not pose.
+    ///
+    /// Reuses the duration histogram's bucketing for a count: run lengths are as
+    /// heavy-tailed as the timings and want the same log2 treatment. One block
+    /// is scaled to [`BLOCKS_TO_NANOS`] so it lands in the microsecond lane the
+    /// bucketing is built around.
+    ///
+    /// Read the result back with [`HistogramReport::summary_blocks`], never
+    /// [`HistogramReport::summary`] -- the latter labels these as durations.
+    pub(crate) fn record_source_run(&self, blocks: u64) {
+        self.source_run_length.record(blocks.saturating_mul(BLOCKS_TO_NANOS));
+    }
+
+    pub(crate) fn snapshot(&self) -> ConsumerTraceReport {
+        ConsumerTraceReport {
+            park_by_state: std::array::from_fn(|i| self.park_by_state[i].snapshot()),
+            source_run_length: self.source_run_length.snapshot(),
+            in_flight_at_park: std::array::from_fn(|i| {
+                self.in_flight_at_park[i].load(Ordering::Relaxed)
+            }),
+        }
+    }
+}
+
+/// Read-only view of [`ConsumerTraceStats`].
+#[derive(Debug, Clone, Copy)]
+pub struct ConsumerTraceReport {
+    /// Park durations by [`AwaitedState`] as `usize`.
+    pub park_by_state: [HistogramReport; AwaitedState::COUNT],
+    /// Consecutive blocks drawn from one source (values are blocks, not µs).
+    pub source_run_length: HistogramReport,
+    /// Parks by concurrent decompressions on the awaited file, clamped at
+    /// [`MAX_TRACKED_IN_FLIGHT`].
+    pub in_flight_at_park: [u64; MAX_TRACKED_IN_FLIGHT + 1],
+}
+
+impl ConsumerTraceReport {
+    /// Whether the consumer recorded nothing at all.
+    ///
+    /// Parks are not the only observation here: a merge that never stalls still
+    /// records a source run on every block it pulls, and that distribution is
+    /// what says whether there is a hot file worth steering workers toward. So
+    /// both halves must be empty, or the healthy merge loses the one diagnostic
+    /// it had.
+    #[must_use]
+    pub fn is_empty(self) -> bool {
+        self.park_by_state.iter().all(|h| h.is_empty()) && self.source_run_length.is_empty()
+    }
+
+    /// Parks where exactly one worker was decompressing the awaited file.
+    ///
+    /// The diagnostic for a demand-blind scheduler: if the consumer is starved
+    /// and only one of N workers is working on the file it needs, the pool is
+    /// not applying its capacity where the merge is actually blocked.
+    #[must_use]
+    pub fn single_worker_parks(self) -> u64 {
+        self.in_flight_at_park[1]
+    }
+
+    /// Parks with no decompression running on the awaited file at all.
+    #[must_use]
+    pub fn idle_file_parks(self) -> u64 {
+        self.in_flight_at_park[0]
+    }
+
+    /// Total parks counted in the in-flight histogram.
+    #[must_use]
+    pub fn parks(self) -> u64 {
+        self.in_flight_at_park.iter().sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(0, 0)]
+    #[case(999, 0)]
+    #[case(1_000, 1)]
+    #[case(1_999, 1)]
+    #[case(2_000, 2)]
+    #[case(50_000, 6)]
+    // 1 ms == 1000 us, which lands in [512, 1024) -- bucket 10, not 11.
+    #[case(1_000_000, 10)]
+    #[case(1_048_576_000, 21)]
+    fn test_bucket_of_nanos(#[case] nanos: u64, #[case] expected: usize) {
+        assert_eq!(bucket_of_nanos(nanos), expected);
+    }
+
+    /// Anything longer than the top bucket's floor lands in the top bucket
+    /// rather than indexing off the end.
+    #[test]
+    fn test_bucket_saturates() {
+        assert_eq!(bucket_of_nanos(u64::MAX), HIST_BUCKETS - 1);
+        assert_eq!(bucket_of_nanos(3_600 * 1_000_000_000), HIST_BUCKETS - 1);
+    }
+
+    #[rstest]
+    #[case(0, 0)]
+    #[case(1, 1)]
+    #[case(6, 32)]
+    #[case(11, 1024)]
+    fn test_bucket_floor(#[case] bucket: usize, #[case] expected: u64) {
+        assert_eq!(bucket_floor_micros(bucket), expected);
+    }
+
+    #[test]
+    fn test_histogram_keeps_an_exact_mean_and_a_bucketed_tail() {
+        let hist = DurationHistogram::default();
+        for _ in 0..99 {
+            hist.record(10_000); // 10 us
+        }
+        hist.record(10_000_000); // one 10 ms outlier
+        let report = hist.snapshot();
+        assert_eq!(report.count, 100);
+        // The mean is exact, so the outlier moves it: (99*10 + 10000)/100 us.
+        assert!((report.mean_micros() - 109.9).abs() < 0.01, "{}", report.mean_micros());
+        // ...while the median is untouched by it, which is the point.
+        assert_eq!(report.percentile_micros(0.50), 8);
+        assert_eq!(report.percentile_micros(0.99), 8);
+        assert_eq!(report.percentile_micros(1.00), 8192);
+    }
+
+    /// A mean alone cannot tell these two apart, and they have different
+    /// causes: one is uniformly slow, the other is fast with a bad tail.
+    #[test]
+    fn test_percentiles_separate_distributions_with_equal_means() {
+        let uniform = DurationHistogram::default();
+        for _ in 0..100 {
+            uniform.record(100_000); // every observation 100 us
+        }
+        let tailed = DurationHistogram::default();
+        for _ in 0..99 {
+            tailed.record(1_000); // 1 us
+        }
+        tailed.record(9_901_000); // one 9.9 ms outlier
+        let (u, t) = (uniform.snapshot(), tailed.snapshot());
+        assert!((u.mean_micros() - t.mean_micros()).abs() < 1.0, "means should match");
+        assert!(t.percentile_micros(0.50) < u.percentile_micros(0.50) / 10);
+    }
+
+    /// `snapshot` reads the buckets and the counter as separate relaxed loads,
+    /// so a report taken while workers are still recording can carry a `count`
+    /// larger than the buckets sum to. The percentiles must still describe the
+    /// observations actually present, not fall through to the top bucket --
+    /// which would print a p50 of 8us as ~4.2s in the merge trace.
+    #[test]
+    fn test_percentiles_ignore_a_count_that_ran_ahead_of_the_buckets() {
+        let hist = DurationHistogram::default();
+        for _ in 0..100 {
+            hist.record(10_000); // 10 us
+        }
+        let mut skewed = hist.snapshot();
+        // Stand in for observations counted after the buckets were read.
+        skewed.count += 50;
+
+        assert_eq!(skewed.percentile_micros(0.50), 8, "p50 must stay in the populated bucket");
+        assert_eq!(skewed.percentile_micros(0.99), 8);
+        assert_eq!(skewed.percentile_micros(1.00), 8);
+    }
+
+    /// A report whose buckets are all empty has nothing to take a percentile
+    /// of, whatever `count` claims.
+    #[test]
+    fn test_percentiles_are_zero_when_only_the_count_is_populated() {
+        let mut report = DurationHistogram::default().snapshot();
+        report.count = 7;
+        assert_eq!(report.percentile_micros(0.50), 0);
+    }
+
+    #[test]
+    fn test_empty_histogram_reports_zeroes() {
+        let report = DurationHistogram::default().snapshot();
+        assert!(report.is_empty());
+        assert!((report.mean_micros() - 0.0).abs() < f64::EPSILON);
+        assert_eq!(report.percentile_micros(0.99), 0);
+    }
+
+    #[rstest]
+    // A decompression already running means the pipeline is working but is not
+    // ahead -- a lookahead-depth problem, not a scheduling one.
+    #[case(0, 1, EmptyCause::Decompressing)]
+    #[case(4, 2, EmptyCause::Decompressing)]
+    // Bytes on hand and nobody on them: scheduling.
+    #[case(4, 0, EmptyCause::RawReady)]
+    // Nothing anywhere: the read side is behind.
+    #[case(0, 0, EmptyCause::Dry)]
+    fn test_empty_cause(
+        #[case] raw_len: usize,
+        #[case] in_flight: usize,
+        #[case] expected: EmptyCause,
+    ) {
+        assert_eq!(EmptyCause::classify(raw_len, in_flight), expected);
+    }
+
+    #[test]
+    fn test_claim_share_splits_waiting_to_start_from_doing_the_work() {
+        let stats = RefillStats::default();
+        // 8 ms of refill latency, 6 ms of it spent before any worker started.
+        stats.claim_lag.record(6_000_000);
+        stats.insert_lag.record(8_000_000);
+        stats.record_empty(EmptyCause::RawReady);
+        let report = stats.snapshot();
+        assert!((report.claim_share() - 0.75).abs() < 1e-9);
+        assert!((report.cause_share(EmptyCause::RawReady) - 1.0).abs() < 1e-9);
+        assert_eq!(report.empties(), 1);
+    }
+
+    /// Clock skew between two histograms must not produce a share above 1.
+    #[test]
+    fn test_claim_share_is_clamped() {
+        let stats = RefillStats::default();
+        stats.claim_lag.record(9_000_000);
+        stats.insert_lag.record(8_000_000);
+        assert!((stats.snapshot().claim_share() - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_empty_refill_report() {
+        let report = RefillStats::default().snapshot();
+        assert!(report.is_empty());
+        assert!((report.claim_share() - 0.0).abs() < f64::EPSILON);
+        assert!((report.cause_share(EmptyCause::Dry) - 0.0).abs() < f64::EPSILON);
+    }
+
+    /// A reorder buffer whose blocks are consumed the moment they arrive is not
+    /// buffering, so its cap is not the constraint -- the check that stops a
+    /// cap sweep being run for the wrong reason.
+    #[test]
+    fn test_pass_through_reorder_buffer_is_detected() {
+        let stats = BlockLifecycleStats::default();
+        for _ in 0..100 {
+            stats.reorder_dwell.record(2_000); // 2 us: consumed immediately
+        }
+        assert!(stats.snapshot().reorder_is_pass_through());
+
+        let buffered = BlockLifecycleStats::default();
+        for _ in 0..100 {
+            buffered.reorder_dwell.record(5_000_000); // 5 ms: genuinely queued
+        }
+        assert!(!buffered.snapshot().reorder_is_pass_through());
+    }
+
+    #[test]
+    fn test_empty_lifecycle_report_is_not_pass_through() {
+        let report = BlockLifecycleStats::default().snapshot();
+        assert!(report.is_empty());
+        assert!(!report.reorder_is_pass_through(), "no data must not read as a finding");
+    }
+
+    #[test]
+    fn test_consumer_trace_counts_parks_by_concurrency() {
+        let stats = ConsumerTraceStats::default();
+        stats.record_park(AwaitedState::Decompressing, 80_000, 1);
+        stats.record_park(AwaitedState::Decompressing, 90_000, 1);
+        stats.record_park(AwaitedState::RawQueued, 40_000, 0);
+        // Clamped: 12 concurrent decompressions is reported as the max bucket.
+        stats.record_park(AwaitedState::Decompressing, 10_000, 12);
+        let report = stats.snapshot();
+        assert_eq!(report.parks(), 4);
+        assert_eq!(report.single_worker_parks(), 2);
+        assert_eq!(report.idle_file_parks(), 1);
+        assert_eq!(report.in_flight_at_park[MAX_TRACKED_IN_FLIGHT], 1);
+        assert_eq!(report.park_by_state[AwaitedState::Decompressing as usize].count, 3);
+    }
+
+    #[test]
+    fn test_source_run_length_is_recorded_in_blocks() {
+        let stats = ConsumerTraceStats::default();
+        stats.record_source_run(1);
+        stats.record_source_run(64);
+        let report = stats.snapshot();
+        assert_eq!(report.source_run_length.count, 2);
+        // Bucketed as if microseconds, so the "us" figures read as blocks.
+        assert_eq!(report.source_run_length.percentile_micros(1.0), 64);
+    }
+
+    /// Run lengths are counts riding in a duration histogram, so the *formatter*
+    /// is what keeps them honest. `summary` would call the total seconds and the
+    /// rest microseconds; `summary_blocks` must report the block count itself.
+    #[test]
+    fn test_source_run_summary_reports_blocks_not_durations() {
+        let stats = ConsumerTraceStats::default();
+        for _ in 0..3 {
+            stats.record_source_run(4);
+        }
+        stats.record_source_run(64);
+        let report = stats.snapshot().source_run_length;
+
+        // 3x4 + 64 = 76 blocks over 4 runs, mean 19.
+        assert_eq!(
+            report.summary_blocks(),
+            "n=4 total=76 blocks mean=19.0 p50=4 p90=64 p99=64",
+            "the run-length line must read as blocks"
+        );
+        // What the duration formatter would have printed instead: a 76-block
+        // total rendered as 0.0s, and every figure labelled `us`.
+        assert!(
+            report.summary().contains("total=0.0s"),
+            "guard the reason summary_blocks exists: {}",
+            report.summary()
+        );
+    }
+
+    #[test]
+    fn test_empty_consumer_trace() {
+        assert!(ConsumerTraceStats::default().snapshot().is_empty());
+    }
+
+    /// A merge that never stalls still has a run-length distribution, and it is
+    /// the one that answers whether there is a hot file to steer workers
+    /// toward. Gating the whole consumer block on parks would drop it in
+    /// exactly the healthy case it is cheapest to read.
+    #[test]
+    fn test_source_runs_alone_make_the_consumer_trace_non_empty() {
+        let stats = ConsumerTraceStats::default();
+        stats.record_source_run(4);
+        assert!(
+            !stats.snapshot().is_empty(),
+            "a merge with source runs but no parks must still report them"
+        );
+    }
+}

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -38,6 +38,9 @@
 //!   growth when producers outpace consumers.
 
 use crate::codec::{SpillCodec, ZSPILL_MAGIC};
+use crate::merge_stalls::{
+    Phase2ScanReport, Phase2ScanTally, PopSkip, ReadSkip, WakeLatencyReport, combine_skip,
+};
 use crossbeam_channel::{Receiver, Sender, bounded};
 use crossbeam_queue::ArrayQueue;
 use fgumi_bgzf::reader::read_raw_blocks;
@@ -717,6 +720,14 @@ pub(crate) struct SharedPipelineState {
     /// [`crate::merge_phases`] -- these overlap and do not partition wall time.
     pub(crate) merge_phases: crate::merge_phases::MergePhaseCounters,
 
+    /// Why Phase 2 file scans found no work. Complements the idle totals in
+    /// [`SortPipelineStats`], which say how long workers idled but not what for.
+    pub(crate) phase2_scans: crate::merge_stalls::Phase2ScanStats,
+
+    /// How deep workers were sleeping when they found work, which bounds how
+    /// much of their idle time is discovery latency rather than absent work.
+    pub(crate) wake_latency: crate::merge_stalls::WakeLatencyStats,
+
     /// Current phase: 0=shutdown, 1=Phase1, 2=Phase2, 255=Legacy.
     pub(crate) phase: AtomicU8,
 
@@ -817,6 +828,8 @@ impl SharedPipelineState {
 
         Self {
             merge_phases: crate::merge_phases::MergePhaseCounters::default(),
+            phase2_scans: crate::merge_stalls::Phase2ScanStats::default(),
+            wake_latency: crate::merge_stalls::WakeLatencyStats::default(),
             phase: AtomicU8::new(phase::LEGACY),
             active_worker_limit: AtomicUsize::new(num_workers),
 
@@ -902,6 +915,13 @@ struct SortWorkerState {
     /// Monotonic counter incremented on each idle sleep; mixed with `worker_id` to
     /// produce per-worker jitter so all workers don't wake simultaneously.
     idle_iter: u64,
+    /// Backoff level of the sleep this worker just took, if the previous loop
+    /// iteration slept. Taken (and cleared) by the next iteration that finds
+    /// work, which is what makes that sleep "productive" — see
+    /// [`crate::merge_stalls::WakeLatencyStats`]. Distinguishing this from
+    /// `backoff_us` matters because `backoff_us` also holds `MIN_BACKOFF_US`
+    /// after a successful step, which is not a sleep at all.
+    last_sleep_us: Option<u64>,
 }
 
 impl SortWorkerState {
@@ -980,9 +1000,14 @@ fn get_sort_priorities(bp: &SortBackpressureState) -> &'static [SortStep] {
 // ============================================================================
 
 /// Minimum backoff duration in microseconds.
-const MIN_BACKOFF_US: u64 = 10;
+pub(crate) const MIN_BACKOFF_US: u64 = 10;
 /// Maximum backoff duration in microseconds (1ms).
-const MAX_BACKOFF_US: u64 = 1000;
+///
+/// Nothing unparks a pool worker — the wake path runs one way, workers to main
+/// thread — so this is also the worst-case delay between work becoming
+/// available and an idle worker noticing it. [`crate::merge_stalls`] measures
+/// how often that delay is actually paid.
+pub(crate) const MAX_BACKOFF_US: u64 = 1000;
 
 /// Sleep for the given backoff duration with ±25% jitter.
 ///
@@ -1152,6 +1177,7 @@ impl SortWorkerPool {
                         held_decompressed_input: None,
                         backoff_us: MIN_BACKOFF_US,
                         idle_iter: 0,
+                        last_sleep_us: None,
                     };
 
                     // Publish a panic as soon as the worker unwinds, not at
@@ -1220,6 +1246,9 @@ impl SortWorkerPool {
                     worker.idle_iter = worker.idle_iter.wrapping_add(1);
                     worker.backoff_us = (worker.backoff_us * 2).min(MAX_BACKOFF_US);
                 }
+                // A capped worker is idle by policy, not because work was slow
+                // to appear, so its sleep must not count as discovery latency.
+                worker.last_sleep_us = None;
                 continue;
             }
 
@@ -1229,6 +1258,8 @@ impl SortWorkerPool {
                 sleep_with_jitter(worker.backoff_us, worker.worker_id, worker.idle_iter);
                 worker.idle_iter = worker.idle_iter.wrapping_add(1);
                 worker.backoff_us = (worker.backoff_us * 2).min(MAX_BACKOFF_US);
+                // Waiting for the next phase, not for work — see above.
+                worker.last_sleep_us = None;
                 continue;
             }
 
@@ -1293,13 +1324,26 @@ impl SortWorkerPool {
 
             // 7. Backoff with jitter (ported from unified pipeline)
             if did_work {
+                // The sleep that preceded this step was slept *through* work
+                // becoming available: nothing unparks a worker, so the work may
+                // have arrived at any point during it. That is the part of idle
+                // time the pipeline actually pays for, and it is invisible in
+                // the idle total, which counts the productive and unproductive
+                // sleeps alike.
+                if let Some(slept_us) = worker.last_sleep_us.take() {
+                    shared.wake_latency.record_productive_sleep(slept_us);
+                }
                 worker.backoff_us = MIN_BACKOFF_US;
             } else {
+                let slept_us = worker.backoff_us;
                 let idle_start = Instant::now();
-                sleep_with_jitter(worker.backoff_us, worker.worker_id, worker.idle_iter);
+                sleep_with_jitter(slept_us, worker.worker_id, worker.idle_iter);
                 worker.idle_iter = worker.idle_iter.wrapping_add(1);
                 worker.backoff_us = (worker.backoff_us * 2).min(MAX_BACKOFF_US);
-                pstats.record_idle(worker.worker_id, Self::nanos_u64(idle_start.elapsed()));
+                let idle_ns = Self::nanos_u64(idle_start.elapsed());
+                pstats.record_idle(worker.worker_id, idle_ns);
+                shared.wake_latency.record_sleep(slept_us, idle_ns);
+                worker.last_sleep_us = Some(slept_us);
             }
         }
     }
@@ -1661,6 +1705,12 @@ impl SortWorkerPool {
             return StepResult::InputEmpty;
         }
 
+        // Why each file was passed over. Lives on the stack and is thrown away
+        // the moment the scan finds work, so a productive scan pays a handful of
+        // increments; only the fall-through at the bottom — the path that is
+        // about to sleep anyway — publishes it. See [`crate::merge_stalls`].
+        let mut tally = Phase2ScanTally::default();
+
         for offset in 0..n {
             let i = (worker.phase2_file_cursor + offset) % n;
             let file = &files[i];
@@ -1671,100 +1721,45 @@ impl SortWorkerPool {
             // outstanding even after the raw FIFO becomes empty. We MUST
             // decrement after inserting into the reorder buffer (or on the
             // error path) to keep the counter balanced.
-            let popped = Self::try_pop_raw_for_decompress(file);
-            if let Some((serial, raw_bytes)) = popped {
-                let data = match file.codec {
-                    SpillCodec::Bgzf => {
-                        let raw_block = RawBgzfBlock { data: raw_bytes };
-                        match shared
-                            .merge_phases
-                            .decompress
-                            .time(|| decompress_block(&raw_block, &mut worker.decompressor))
-                        {
-                            Ok(d) => d,
-                            Err(e) => {
-                                log::error!(
-                                    "BGZF decompression error (chunk source {i} serial {serial}): {e}"
-                                );
-                                shared.decompression_error.store(true, Ordering::Release);
-                                file.decomp_in_flight.fetch_sub(1, Ordering::AcqRel);
-                                shared.main_thread_handle.unpark();
-                                worker.phase2_file_cursor = (i + 1) % n;
-                                return StepResult::Success;
-                            }
-                        }
-                    }
-                    SpillCodec::Zstd => {
-                        // Allocate the scratch buffer lazily so BGZF-only sorts
-                        // don't pay 256 KiB × num_workers of dead memory.
-                        if worker.zstd_decompress_buf.len() < ZSTD_FRAME_DECOMP_CAP {
-                            worker.zstd_decompress_buf.resize(ZSTD_FRAME_DECOMP_CAP, 0);
-                        }
-                        match shared.merge_phases.decompress.time(|| {
-                            worker
-                                .zstd_decompressor
-                                .decompress_to_buffer(&raw_bytes, &mut worker.zstd_decompress_buf)
-                        }) {
-                            Ok(n) => {
-                                // Copy the `n` decompressed bytes (≤ one
-                                // staging-buffer's worth, typically ~65 KB)
-                                // into a fresh Vec for the consumer. The
-                                // scratch buffer keeps its 256 KiB capacity
-                                // so the next frame on this worker reuses it
-                                // without reallocating.
-                                worker.zstd_decompress_buf[..n].to_vec()
-                            }
-                            Err(e) => {
-                                log::error!(
-                                    "zstd decompression error (chunk source {i} serial {serial}): {e}"
-                                );
-                                shared.decompression_error.store(true, Ordering::Release);
-                                file.decomp_in_flight.fetch_sub(1, Ordering::AcqRel);
-                                shared.main_thread_handle.unpark();
-                                worker.phase2_file_cursor = (i + 1) % n;
-                                return StepResult::Success;
-                            }
-                        }
-                    }
-                };
-                let now_poppable = {
-                    let mut dec_guard =
-                        file.decompressed.lock().expect("phase2 decompressed mutex poisoned");
-                    dec_guard.insert(serial, data);
-                    dec_guard.can_pop()
-                };
-                // Decrement AFTER the insert is published. The unpark below
-                // wakes the consumer in case it has been parked waiting on
-                // this specific file (now_poppable=true) or is in the
-                // is_drained path waiting for in_flight to reach zero.
-                file.decomp_in_flight.fetch_sub(1, Ordering::AcqRel);
-                if now_poppable || file.is_drained() {
-                    // Wake the consumer either because new data is available
-                    // or because the last in-flight decompression for this
-                    // file just completed and the file is now fully drained.
-                    shared.main_thread_handle.unpark();
+            // Diverges on success -- `decompress_and_publish` always returns --
+            // so the binding is why the decompress half declined.
+            let pop_skip = match Self::try_pop_raw_for_decompress(file) {
+                Err(skip) => skip,
+                Ok((serial, raw_bytes)) => {
+                    worker.phase2_file_cursor = (i + 1) % n;
+                    return Self::decompress_and_publish(
+                        shared, worker, file, i, serial, raw_bytes,
+                    );
                 }
-                worker.phase2_file_cursor = (i + 1) % n;
-                return StepResult::Success;
-            }
+            };
 
             // -- Try reading raw blocks from disk ----------------------------
             // Skip if disk reader is contended OR already at EOF.
             let Ok(mut reader_guard) = file.reader.try_lock() else {
-                continue; // another worker is reading this file
+                // Another worker is inside a disk read for this file. That is
+                // I/O in flight, not lock contention, and conflating the two
+                // would blame the mutex for the disk.
+                tally.note(combine_skip(pop_skip, ReadSkip::ReaderBusy));
+                continue;
             };
             if reader_guard.eof {
+                tally.note(combine_skip(pop_skip, ReadSkip::ReaderEof));
                 continue;
             }
 
             // Bound disk read-ahead per file: don't keep pulling if the raw
             // FIFO is already full. Use try_lock so a momentarily contended
             // raw FIFO doesn't block the reader.
-            let raw_full = match file.raw_blocks.try_lock() {
-                Ok(g) => g.len() >= PHASE2_RAW_CAP,
-                Err(_) => true,
+            let read_skip = match file.raw_blocks.try_lock() {
+                Ok(g) if g.len() >= PHASE2_RAW_CAP => Some(ReadSkip::RawFull),
+                Ok(_) => None,
+                // Treated as full, as it always has been -- but recorded as
+                // contention, because a FIFO whose depth we could not read is
+                // not evidence that read-ahead depth is the constraint.
+                Err(_) => Some(ReadSkip::RawLockContended),
             };
-            if raw_full {
+            if let Some(read_skip) = read_skip {
+                tally.note(combine_skip(pop_skip, read_skip));
                 continue;
             }
 
@@ -1817,46 +1812,147 @@ impl SortWorkerPool {
             return StepResult::Success;
         }
 
+        // Every file declined. This worker is about to sleep, so publishing the
+        // reasons here costs nothing it was not already about to spend, and it
+        // turns an entry in the idle total into an explanation of that entry.
+        shared.phase2_scans.record_fruitless_scan(tally);
         StepResult::InputEmpty
+    }
+
+    /// Decompress one raw block and publish it into its file's reorder buffer.
+    ///
+    /// Split out of [`Self::try_phase2_file_work`] so the scan loop reads as the
+    /// scan it is. Always returns [`StepResult::Success`]: a decompression
+    /// failure is still work done — it sets the error flag and wakes the
+    /// consumer, which must surface the failure rather than spin.
+    ///
+    /// The caller must have advanced `worker.phase2_file_cursor` already, and
+    /// must have obtained `entry` from [`Self::try_pop_raw_for_decompress`],
+    /// which reserved the matching `decomp_in_flight` slot this function is
+    /// responsible for releasing.
+    fn decompress_and_publish(
+        shared: &SharedPipelineState,
+        worker: &mut SortWorkerState,
+        file: &Phase2FileState,
+        source_idx: usize,
+        serial: u64,
+        raw_bytes: Vec<u8>,
+    ) -> StepResult {
+        let data = match file.codec {
+            SpillCodec::Bgzf => {
+                let raw_block = RawBgzfBlock { data: raw_bytes };
+                match shared
+                    .merge_phases
+                    .decompress
+                    .time(|| decompress_block(&raw_block, &mut worker.decompressor))
+                {
+                    Ok(d) => d,
+                    Err(e) => {
+                        log::error!(
+                            "BGZF decompression error (chunk source {source_idx} serial {serial}): {e}"
+                        );
+                        shared.decompression_error.store(true, Ordering::Release);
+                        file.decomp_in_flight.fetch_sub(1, Ordering::AcqRel);
+                        shared.main_thread_handle.unpark();
+                        return StepResult::Success;
+                    }
+                }
+            }
+            SpillCodec::Zstd => {
+                // Allocate the scratch buffer lazily so BGZF-only sorts don't
+                // pay 256 KiB × num_workers of dead memory.
+                if worker.zstd_decompress_buf.len() < ZSTD_FRAME_DECOMP_CAP {
+                    worker.zstd_decompress_buf.resize(ZSTD_FRAME_DECOMP_CAP, 0);
+                }
+                match shared.merge_phases.decompress.time(|| {
+                    worker
+                        .zstd_decompressor
+                        .decompress_to_buffer(&raw_bytes, &mut worker.zstd_decompress_buf)
+                }) {
+                    // Copy the `n` decompressed bytes (≤ one staging-buffer's
+                    // worth, typically ~65 KB) into a fresh Vec for the
+                    // consumer. The scratch buffer keeps its 256 KiB capacity so
+                    // the next frame on this worker reuses it without
+                    // reallocating.
+                    Ok(n) => worker.zstd_decompress_buf[..n].to_vec(),
+                    Err(e) => {
+                        log::error!(
+                            "zstd decompression error (chunk source {source_idx} serial {serial}): {e}"
+                        );
+                        shared.decompression_error.store(true, Ordering::Release);
+                        file.decomp_in_flight.fetch_sub(1, Ordering::AcqRel);
+                        shared.main_thread_handle.unpark();
+                        return StepResult::Success;
+                    }
+                }
+            }
+        };
+
+        let now_poppable = {
+            let mut dec_guard =
+                file.decompressed.lock().expect("phase2 decompressed mutex poisoned");
+            dec_guard.insert(serial, data);
+            dec_guard.can_pop()
+        };
+        // Decrement AFTER the insert is published. The unpark below wakes the
+        // consumer in case it has been parked waiting on this specific file
+        // (now_poppable=true) or is in the is_drained path waiting for
+        // in_flight to reach zero.
+        file.decomp_in_flight.fetch_sub(1, Ordering::AcqRel);
+        if now_poppable || file.is_drained() {
+            // Wake the consumer either because new data is available or because
+            // the last in-flight decompression for this file just completed and
+            // the file is now fully drained.
+            shared.main_thread_handle.unpark();
+        }
+        StepResult::Success
     }
 
     /// Try to pop a raw block from `file` for decompression, applying
     /// deadlock-free admission control against the file's reorder buffer.
     ///
-    /// Returns `Some((serial, raw_block))` if a block was popped, `None` otherwise.
-    /// `None` is returned when:
-    /// - either lock is contended (`try_lock` failed),
-    /// - the raw FIFO is empty,
-    /// - or the reorder buffer is at cap and the head raw block isn't a gap-filler.
+    /// Returns `Ok(RawEntry)` if a block was popped, and otherwise
+    /// the [`PopSkip`] saying why not: either lock was contended (`try_lock`
+    /// failed), the raw FIFO was empty, or the reorder buffer was at cap and the
+    /// head raw block was not a gap-filler. The caller records that reason —
+    /// "the pool declined this file" and "the pool had nothing to take" look
+    /// identical in an idle total and mean opposite things.
     ///
     /// On success, `decomp_in_flight` is incremented so the consumer's
     /// `is_drained()` check correctly reflects the in-progress decompression.
     /// The caller is responsible for the matching decrement after inserting
     /// (or on the decompression-error path).
-    fn try_pop_raw_for_decompress(file: &Phase2FileState) -> Option<(u64, Vec<u8>)> {
-        let mut raw_guard = file.raw_blocks.try_lock().ok()?;
-        let head_serial = raw_guard.front().map(|(s, _)| *s)?;
+    fn try_pop_raw_for_decompress(
+        file: &Phase2FileState,
+    ) -> std::result::Result<(u64, Vec<u8>), PopSkip> {
+        let Ok(mut raw_guard) = file.raw_blocks.try_lock() else {
+            return Err(PopSkip::RawLockContended);
+        };
+        let Some(head_serial) = raw_guard.front().map(|(s, _)| *s) else {
+            return Err(PopSkip::RawEmpty);
+        };
 
         // Cheap admission check using the per-file reorder buffer.
         // Two cases admit: (1) under cap (normal), (2) reorder buffer is stuck
         // and this serial is the gap-filler. Otherwise: backpressure.
         let admit = {
-            let dec_guard = file.decompressed.try_lock().ok()?;
+            let Ok(dec_guard) = file.decompressed.try_lock() else {
+                return Err(PopSkip::DecompLockContended);
+            };
             dec_guard.len() < PHASE2_DECOMP_CAP
                 || (!dec_guard.can_pop() && head_serial == dec_guard.next_seq())
         };
         if !admit {
-            return None;
+            return Err(PopSkip::DecompCapped);
         }
 
         // Reserve the in-flight slot under the raw_blocks lock so the consumer
         // can never observe (raw_empty && in_flight==0 && decompressed_empty)
         // while a worker is still in the middle of decompressing this block.
-        let popped = raw_guard.pop_front();
-        if popped.is_some() {
-            file.decomp_in_flight.fetch_add(1, Ordering::AcqRel);
-        }
-        popped
+        // The FIFO was non-empty above and is still held, so this cannot fail.
+        let popped = raw_guard.pop_front().expect("raw FIFO emptied under its own lock");
+        file.decomp_in_flight.fetch_add(1, Ordering::AcqRel);
+        Ok(popped)
     }
 
     // ========================================================================
@@ -1977,6 +2073,16 @@ impl SortWorkerPool {
     /// [`crate::merge_phases`].
     pub(crate) fn merge_phase_breakdown(&self) -> crate::merge_phases::MergePhaseBreakdown {
         self.shared.merge_phases.snapshot()
+    }
+
+    /// Why Phase 2 file scans found no work -- see [`crate::merge_stalls`].
+    pub(crate) fn phase2_scan_report(&self) -> Phase2ScanReport {
+        self.shared.phase2_scans.snapshot()
+    }
+
+    /// How deep workers were sleeping when they found work.
+    pub(crate) fn wake_latency_report(&self) -> WakeLatencyReport {
+        self.shared.wake_latency.snapshot()
     }
 
     /// Codec used to compress Phase 1 spill chunks.
@@ -3088,7 +3194,7 @@ mod tests {
         let file = empty_phase2_file();
         file.raw_blocks.lock().expect("raw lock").push_back((0, dummy_raw_block(0)));
         let popped = SortWorkerPool::try_pop_raw_for_decompress(&file);
-        assert!(popped.is_some(), "under cap with empty reorder buffer should admit");
+        assert!(popped.is_ok(), "under cap with empty reorder buffer should admit");
         assert_eq!(file.decomp_in_flight.load(Ordering::Acquire), 1);
         assert!(file.raw_blocks.lock().expect("raw lock").is_empty());
     }
@@ -3114,7 +3220,11 @@ mod tests {
             .expect("raw lock")
             .push_back((PHASE2_DECOMP_CAP as u64, dummy_raw_block(1)));
         let popped = SortWorkerPool::try_pop_raw_for_decompress(&file);
-        assert!(popped.is_none(), "at cap and poppable should reject (apply backpressure)");
+        assert_eq!(
+            popped.expect_err("at cap and poppable should reject (apply backpressure)"),
+            PopSkip::DecompCapped,
+            "rejecting at cap must be reported as backpressure, not as an empty file"
+        );
         assert_eq!(file.decomp_in_flight.load(Ordering::Acquire), 0);
         assert_eq!(file.raw_blocks.lock().expect("raw lock").len(), 1);
     }
@@ -3136,7 +3246,7 @@ mod tests {
         // even though we're at cap, otherwise the consumer deadlocks.
         file.raw_blocks.lock().expect("raw lock").push_back((0, dummy_raw_block(0)));
         let popped = SortWorkerPool::try_pop_raw_for_decompress(&file);
-        assert!(popped.is_some(), "at cap and stuck should admit gap-filler at next_seq");
+        assert!(popped.is_ok(), "at cap and stuck should admit gap-filler at next_seq");
         assert_eq!(file.decomp_in_flight.load(Ordering::Acquire), 1);
     }
 
@@ -3157,16 +3267,24 @@ mod tests {
             .expect("raw lock")
             .push_back((PHASE2_DECOMP_CAP as u64 + 1, dummy_raw_block(2)));
         let popped = SortWorkerPool::try_pop_raw_for_decompress(&file);
-        assert!(popped.is_none(), "at cap, stuck, but head != next_seq should reject");
+        assert_eq!(
+            popped.expect_err("at cap, stuck, but head != next_seq should reject"),
+            PopSkip::DecompCapped
+        );
         assert_eq!(file.decomp_in_flight.load(Ordering::Acquire), 0);
     }
 
     #[test]
-    fn test_admission_empty_raw_returns_none() {
+    fn test_admission_empty_raw_reports_raw_empty() {
         let file = empty_phase2_file();
-        // Empty raw FIFO — try_pop must return None without touching in_flight.
+        // Empty raw FIFO — try_pop must report RawEmpty without touching
+        // in_flight.
         let popped = SortWorkerPool::try_pop_raw_for_decompress(&file);
-        assert!(popped.is_none());
+        assert_eq!(
+            popped.expect_err("an empty FIFO has nothing to admit"),
+            PopSkip::RawEmpty,
+            "an empty FIFO must not be conflated with a file the pool declined"
+        );
         assert_eq!(file.decomp_in_flight.load(Ordering::Acquire), 0);
     }
 

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -565,6 +565,33 @@ pub(crate) const PHASE2_DECOMP_CAP: usize = 8;
 /// Number of raw blocks to read from disk per `ReadRawBlocks` call.
 pub(crate) const PHASE2_READ_BATCH: usize = 4;
 
+/// One compressed block in a file's raw FIFO, with when it got there.
+///
+/// The timestamp is what turns "the pool did not decompress this yet" into a
+/// measurement: `enqueued_nanos` to the moment a worker claims it is pure
+/// scheduling latency, work that was available and unclaimed.
+pub(crate) struct RawEntry {
+    /// Position in the file's block sequence.
+    pub(crate) serial: u64,
+    /// Raw block bytes: a whole BGZF block, or a whole zstd frame.
+    pub(crate) bytes: Vec<u8>,
+    /// When this entry was pushed, in pool-epoch nanoseconds.
+    pub(crate) enqueued_nanos: u64,
+}
+
+/// A decompressed block in a file's reorder buffer, with when it was published.
+///
+/// `inserted_nanos` to the moment the consumer takes it is how long the block
+/// spent as genuine lookahead. Near-zero across the run means the reorder
+/// buffer is a pass-through and its cap is not the constraint, however full the
+/// other files look.
+pub(crate) struct TimedBlock {
+    /// Decompressed payload.
+    pub(crate) data: Vec<u8>,
+    /// When this block was inserted, in pool-epoch nanoseconds.
+    pub(crate) inserted_nanos: u64,
+}
+
 /// Reader state for a single spill file. Locked when reading from disk.
 pub(crate) struct Phase2Reader {
     pub(crate) inner: BufReader<std::fs::File>,
@@ -591,15 +618,53 @@ pub(crate) struct Phase2FileState {
     /// Raw compressed blocks read from disk, in serial order. For BGZF, each
     /// entry is the raw block bytes (header + deflate + footer). For zstd,
     /// each entry is one complete zstd frame's bytes.
-    pub(crate) raw_blocks: Mutex<VecDeque<(u64, Vec<u8>)>>,
+    pub(crate) raw_blocks: Mutex<VecDeque<RawEntry>>,
     /// Decompressed blocks reordered by serial. Main thread pops the next-in-order
     /// block here when its parser exhausts the current buffer.
-    pub(crate) decompressed: Mutex<ReorderBuffer<Vec<u8>>>,
+    pub(crate) decompressed: Mutex<ReorderBuffer<TimedBlock>>,
     /// Number of raw blocks currently being decompressed (popped from
     /// `raw_blocks` but not yet inserted into `decompressed`). Used by
     /// `is_drained` to avoid a race where the consumer exits while a worker
     /// is mid-decompress.
     pub(crate) decomp_in_flight: AtomicUsize,
+
+    /// Lock-free mirror of `raw_blocks.len()`, maintained under that mutex.
+    ///
+    /// Reading a depth should not require taking the lock that a worker might
+    /// be holding to *change* it: the park path needs both depths on every
+    /// park, and acquiring two mutexes per park would both cost more than the
+    /// measurement is worth and perturb the contention it is trying to measure.
+    pub(crate) raw_len: AtomicUsize,
+    /// Lock-free mirror of `decompressed.len()`, maintained under that mutex.
+    pub(crate) decomp_len: AtomicUsize,
+    /// Pool-epoch nanoseconds at which the reorder buffer last drained to
+    /// nothing, or `0` if it currently holds something.
+    ///
+    /// The start of a refill cycle: the interval from here to the next claim,
+    /// and to the next insert, is what says whether a hungry file waits to be
+    /// noticed or waits to be served.
+    pub(crate) emptied_at_nanos: AtomicU64,
+    /// The [`EmptyCause`](crate::merge_trace::EmptyCause) of the current empty,
+    /// as a `u8`.
+    ///
+    /// Stored on the file rather than only tallied, because `read_lag` is
+    /// defined over the `Dry` empties alone: on a `RawReady` or
+    /// `Decompressing` empty there was already something in the pipeline, so
+    /// the next disk read was never what the consumer was waiting for, and
+    /// folding those cycles in makes a scheduling delay look like a storage
+    /// one. Meaningless while `emptied_at_nanos` is `0`.
+    pub(crate) emptied_cause: AtomicU8,
+    /// Whether some worker has already claimed a block since the buffer last
+    /// emptied, so `claim_lag` records the *first* response, not every one.
+    pub(crate) claimed_since_empty: AtomicBool,
+    /// Whether a disk read has already completed for this file since the buffer
+    /// last emptied, so `read_lag` records the *first* one.
+    ///
+    /// A dry cycle stays open until something reaches the reorder buffer, and a
+    /// second worker can read another batch before that happens. Without this
+    /// the cycle books two samples, the second inflated by the first read's own
+    /// duration, and `read_lag`'s count outruns the dry-cycle count.
+    pub(crate) read_since_empty: AtomicBool,
 }
 
 impl Phase2FileState {
@@ -611,7 +676,123 @@ impl Phase2FileState {
             raw_blocks: Mutex::new(VecDeque::with_capacity(PHASE2_RAW_CAP)),
             decompressed: Mutex::new(ReorderBuffer::new()),
             decomp_in_flight: AtomicUsize::new(0),
+            raw_len: AtomicUsize::new(0),
+            decomp_len: AtomicUsize::new(0),
+            emptied_at_nanos: AtomicU64::new(0),
+            emptied_cause: AtomicU8::new(crate::merge_trace::EmptyCause::Dry.as_u8()),
+            claimed_since_empty: AtomicBool::new(false),
+            read_since_empty: AtomicBool::new(false),
         }
+    }
+
+    /// The file's depths without taking either mutex: `(raw, decompressed,
+    /// in-flight)`.
+    ///
+    /// A momentarily inconsistent triple is fine here and a lock is not: these
+    /// feed diagnostics sampled at a park, never a correctness decision.
+    pub(crate) fn depths(&self) -> (usize, usize, usize) {
+        (
+            self.raw_len.load(Ordering::Relaxed),
+            self.decomp_len.load(Ordering::Relaxed),
+            self.decomp_in_flight.load(Ordering::Relaxed),
+        )
+    }
+
+    /// Note that the reorder buffer just drained to nothing at `now`, for
+    /// `cause`.
+    ///
+    /// Opens a refill cycle. Called by the consumer, which is the only thing
+    /// that removes from the buffer. The cause is stored as well as tallied so
+    /// `read_lag` can be restricted to the empties it is defined over -- see
+    /// [`Self::emptied_while_dry`].
+    ///
+    /// **Must be called while holding the file's `decompressed` mutex.** That is
+    /// what makes opening a cycle mutually exclusive with
+    /// [`Self::mark_refilled`] closing one, so an insert cannot clear a cycle it
+    /// never observed. `now` is the pool epoch, which is monotonic, so a cycle's
+    /// open timestamp also serves as its identity for the two samples that
+    /// cannot take this mutex -- `claim_lag` and `read_lag`.
+    pub(crate) fn mark_emptied(&self, now: u64, cause: crate::merge_trace::EmptyCause) {
+        self.emptied_cause.store(cause.as_u8(), Ordering::Relaxed);
+        self.emptied_at_nanos.store(now, Ordering::Relaxed);
+        self.claimed_since_empty.store(false, Ordering::Relaxed);
+        self.read_since_empty.store(false, Ordering::Relaxed);
+    }
+
+    /// Whether the current refill cycle opened with the file holding nothing
+    /// anywhere -- no queued raw block, no decompression in flight.
+    ///
+    /// Only these cycles belong in `read_lag`: on the others a block was
+    /// already in the pipeline when the buffer drained, so the next disk read
+    /// completing was not what the consumer waited on.
+    pub(crate) fn emptied_while_dry(&self) -> bool {
+        matches!(
+            crate::merge_trace::EmptyCause::from_u8(self.emptied_cause.load(Ordering::Relaxed)),
+            crate::merge_trace::EmptyCause::Dry
+        )
+    }
+
+    /// Pool-epoch nanoseconds at which this file's buffer emptied, if it is
+    /// still empty.
+    pub(crate) fn emptied_at(&self) -> Option<u64> {
+        match self.emptied_at_nanos.load(Ordering::Relaxed) {
+            0 => None,
+            t => Some(t),
+        }
+    }
+
+    /// The open refill cycle, if an event observed at `event_nanos` could
+    /// belong to it.
+    ///
+    /// A cycle that opened *after* the event is not the cycle the event
+    /// answered, so timing the event against it would report a latency that
+    /// ran backwards -- which `saturating_sub` would then quietly render as a
+    /// zero rather than as the nonsense it is.
+    ///
+    /// The pairing for the two samples taken without the `decompressed` mutex;
+    /// close the window with [`Self::cycle_still_open`] once the sample is in
+    /// hand.
+    pub(crate) fn cycle_open_at(&self, event_nanos: u64) -> Option<u64> {
+        self.emptied_at().filter(|&emptied| emptied <= event_nanos)
+    }
+
+    /// Whether `cycle` is still the cycle this file has open.
+    ///
+    /// Re-read after taking a sample: a cycle that closed while the sample was
+    /// being taken cannot receive it. Cycle identity is the open timestamp,
+    /// which the pool epoch makes monotonic, so a reopened cycle never reuses
+    /// a value and this cannot be fooled by a close/reopen pair.
+    pub(crate) fn cycle_still_open(&self, cycle: u64) -> bool {
+        self.emptied_at() == Some(cycle)
+    }
+
+    /// Claim the "first response since the buffer emptied" flag.
+    ///
+    /// Returns `true` for exactly one caller per refill cycle, so several
+    /// workers piling onto the same hungry file record one claim latency
+    /// between them rather than one each.
+    pub(crate) fn take_first_claim_since_empty(&self) -> bool {
+        !self.claimed_since_empty.swap(true, Ordering::Relaxed)
+    }
+
+    /// Claim the "first disk read since the buffer emptied" flag.
+    ///
+    /// The read-side mirror of [`Self::take_first_claim_since_empty`]: returns
+    /// `true` for exactly one caller per refill cycle, so a cycle long enough
+    /// for two read batches books one sample rather than two.
+    pub(crate) fn take_first_read_since_empty(&self) -> bool {
+        !self.read_since_empty.swap(true, Ordering::Relaxed)
+    }
+
+    /// Close the refill cycle: the buffer holds something again.
+    ///
+    /// **Must be called while holding the file's `decompressed` mutex**, and
+    /// only after observing an open cycle under that same hold -- see
+    /// [`Self::mark_emptied`]. Closing on an unsynchronized read would let this
+    /// clear a cycle opened after that read, which both discards a measurement
+    /// and books the wrong one.
+    pub(crate) fn mark_refilled(&self) {
+        self.emptied_at_nanos.store(0, Ordering::Relaxed);
     }
 
     /// Mark the disk reader as having reached EOF. Updates both the
@@ -632,7 +813,7 @@ impl Phase2FileState {
             self.raw_blocks.lock().expect("phase2 raw_blocks mutex poisoned").len() as u64;
         let decomp_guard = self.decompressed.lock().expect("phase2 decompressed mutex poisoned");
         let decomp_len = decomp_guard.len() as u64;
-        let decomp_bytes: u64 = decomp_guard.iter().map(|buf| buf.len() as u64).sum();
+        let decomp_bytes: u64 = decomp_guard.iter().map(|b| b.data.len() as u64).sum();
         drop(decomp_guard);
         let active = !self.reader_eof.load(Ordering::Relaxed);
         (raw_len + decomp_len, decomp_bytes, active)
@@ -727,6 +908,26 @@ pub(crate) struct SharedPipelineState {
     /// How deep workers were sleeping when they found work, which bounds how
     /// much of their idle time is discovery latency rather than absent work.
     pub(crate) wake_latency: crate::merge_stalls::WakeLatencyStats,
+
+    /// Start of the pool's monotonic clock. Every `*_nanos` field elsewhere is
+    /// an offset from here, so timestamps fit in a `u64` atomic instead of
+    /// needing a lock around an `Instant`.
+    pub(crate) epoch: Instant,
+    /// Per-stage dwell times for spill blocks -- see [`crate::merge_trace`].
+    pub(crate) block_lifecycle: crate::merge_trace::BlockLifecycleStats,
+    /// How long a file that ran dry takes to be refilled, and by which stage.
+    pub(crate) refill: crate::merge_trace::RefillStats,
+    /// What the merge consumer's access pattern looks like and what it costs.
+    pub(crate) consumer_trace: crate::merge_trace::ConsumerTraceStats,
+    /// How long a worker's *fruitless* scan of every spill file takes -- the
+    /// scans that found no work, which are the ones on the path by which a
+    /// hungry file gets noticed. A scan that finds work returns early and is
+    /// not timed.
+    pub(crate) fruitless_scan: crate::merge_trace::DurationHistogram,
+
+    /// `wake_latency` as it stood when the pool entered Phase 2, so the merge's
+    /// share can be reported without Phase 1's sleeps folded in.
+    pub(crate) wake_latency_at_merge_start: std::sync::OnceLock<WakeLatencyReport>,
 
     /// Current phase: 0=shutdown, 1=Phase1, 2=Phase2, 255=Legacy.
     pub(crate) phase: AtomicU8,
@@ -830,6 +1031,12 @@ impl SharedPipelineState {
             merge_phases: crate::merge_phases::MergePhaseCounters::default(),
             phase2_scans: crate::merge_stalls::Phase2ScanStats::default(),
             wake_latency: crate::merge_stalls::WakeLatencyStats::default(),
+            wake_latency_at_merge_start: std::sync::OnceLock::new(),
+            epoch: Instant::now(),
+            block_lifecycle: crate::merge_trace::BlockLifecycleStats::default(),
+            refill: crate::merge_trace::RefillStats::default(),
+            consumer_trace: crate::merge_trace::ConsumerTraceStats::default(),
+            fruitless_scan: crate::merge_trace::DurationHistogram::default(),
             phase: AtomicU8::new(phase::LEGACY),
             active_worker_limit: AtomicUsize::new(num_workers),
 
@@ -855,6 +1062,11 @@ impl SharedPipelineState {
             num_workers,
             main_thread_handle,
         }
+    }
+
+    /// Nanoseconds since the pool's epoch, the unit every `*_nanos` field uses.
+    pub(crate) fn now_nanos(&self) -> u64 {
+        crate::merge_trace::elapsed_nanos(self.epoch)
     }
 
     /// Snapshot the current Phase 2 file vector. Cheap (just clones the `Arc`).
@@ -915,13 +1127,10 @@ struct SortWorkerState {
     /// Monotonic counter incremented on each idle sleep; mixed with `worker_id` to
     /// produce per-worker jitter so all workers don't wake simultaneously.
     idle_iter: u64,
-    /// Backoff level of the sleep this worker just took, if the previous loop
-    /// iteration slept. Taken (and cleared) by the next iteration that finds
-    /// work, which is what makes that sleep "productive" — see
-    /// [`crate::merge_stalls::WakeLatencyStats`]. Distinguishing this from
-    /// `backoff_us` matters because `backoff_us` also holds `MIN_BACKOFF_US`
-    /// after a successful step, which is not a sleep at all.
-    last_sleep_us: Option<u64>,
+    /// The sleep the previous loop iteration took, if it slept. Taken (and
+    /// cleared) by the next iteration that finds work, which is what makes that
+    /// sleep "productive" — see [`crate::merge_stalls::WakeLatencyStats`].
+    last_sleep: Option<PendingSleep>,
 }
 
 impl SortWorkerState {
@@ -930,6 +1139,38 @@ impl SortWorkerState {
     fn has_any_held_items(&self) -> bool {
         !self.held_raw_input_blocks.is_empty() || self.held_decompressed_input.is_some()
     }
+}
+
+/// A sleep whose cost is not yet known, and the phase it ran in.
+///
+/// The backoff level is kept separately from `backoff_us` because that field
+/// also holds `MIN_BACKOFF_US` after a successful step, which is not a sleep at
+/// all. The phase travels with it because the sleep and the step that redeems it
+/// are separate loop iterations and the phase can change in between — see
+/// [`productive_sleep_micros`].
+#[derive(Debug, Clone, Copy)]
+struct PendingSleep {
+    /// Pipeline phase the sleep ran in (see [`phase`]).
+    phase: u8,
+    /// Backoff level the sleep was taken at, in microseconds.
+    backoff_us: u64,
+}
+
+/// The sleep to charge as productive, for a step that succeeded in `current_phase`.
+///
+/// `None` when nothing was pending, or when the sleep ran in a different phase.
+/// [`crate::merge_stalls::WakeLatencyStats`] runs for the pool's whole life and
+/// the merge's share is taken by subtracting a snapshot pinned at the Phase 1 ->
+/// Phase 2 boundary, so a Phase 1 sleep recorded after that snapshot lands inside
+/// the merge's window and reports discovery lag for a merge that had not started
+/// when the worker went to sleep. Nor can it be credited to Phase 1, whose
+/// snapshot is already taken. A sleep that straddles the boundary is therefore
+/// dropped rather than misattributed to whichever side happens to be reporting.
+///
+/// Pure so the rule is testable without running the pool through a phase
+/// transition, following [`classify_scan`](crate::merge_stalls::classify_scan).
+fn productive_sleep_micros(pending: Option<PendingSleep>, current_phase: u8) -> Option<u64> {
+    pending.filter(|sleep| sleep.phase == current_phase).map(|sleep| sleep.backoff_us)
 }
 
 // ============================================================================
@@ -1177,7 +1418,7 @@ impl SortWorkerPool {
                         held_decompressed_input: None,
                         backoff_us: MIN_BACKOFF_US,
                         idle_iter: 0,
-                        last_sleep_us: None,
+                        last_sleep: None,
                     };
 
                     // Publish a panic as soon as the worker unwinds, not at
@@ -1248,7 +1489,7 @@ impl SortWorkerPool {
                 }
                 // A capped worker is idle by policy, not because work was slow
                 // to appear, so its sleep must not count as discovery latency.
-                worker.last_sleep_us = None;
+                worker.last_sleep = None;
                 continue;
             }
 
@@ -1259,7 +1500,7 @@ impl SortWorkerPool {
                 worker.idle_iter = worker.idle_iter.wrapping_add(1);
                 worker.backoff_us = (worker.backoff_us * 2).min(MAX_BACKOFF_US);
                 // Waiting for the next phase, not for work — see above.
-                worker.last_sleep_us = None;
+                worker.last_sleep = None;
                 continue;
             }
 
@@ -1330,7 +1571,12 @@ impl SortWorkerPool {
                 // time the pipeline actually pays for, and it is invisible in
                 // the idle total, which counts the productive and unproductive
                 // sleeps alike.
-                if let Some(slept_us) = worker.last_sleep_us.take() {
+                //
+                // `take` unconditionally: a sleep from another phase is dropped,
+                // not carried forward to the next step in this one.
+                if let Some(slept_us) =
+                    productive_sleep_micros(worker.last_sleep.take(), current_phase)
+                {
                     shared.wake_latency.record_productive_sleep(slept_us);
                 }
                 worker.backoff_us = MIN_BACKOFF_US;
@@ -1343,7 +1589,8 @@ impl SortWorkerPool {
                 let idle_ns = Self::nanos_u64(idle_start.elapsed());
                 pstats.record_idle(worker.worker_id, idle_ns);
                 shared.wake_latency.record_sleep(slept_us, idle_ns);
-                worker.last_sleep_us = Some(slept_us);
+                worker.last_sleep =
+                    Some(PendingSleep { phase: current_phase, backoff_us: slept_us });
             }
         }
     }
@@ -1710,6 +1957,7 @@ impl SortWorkerPool {
         // increments; only the fall-through at the bottom — the path that is
         // about to sleep anyway — publishes it. See [`crate::merge_stalls`].
         let mut tally = Phase2ScanTally::default();
+        let scan_start = shared.now_nanos();
 
         for offset in 0..n {
             let i = (worker.phase2_file_cursor + offset) % n;
@@ -1725,11 +1973,10 @@ impl SortWorkerPool {
             // so the binding is why the decompress half declined.
             let pop_skip = match Self::try_pop_raw_for_decompress(file) {
                 Err(skip) => skip,
-                Ok((serial, raw_bytes)) => {
+                Ok(entry) => {
                     worker.phase2_file_cursor = (i + 1) % n;
-                    return Self::decompress_and_publish(
-                        shared, worker, file, i, serial, raw_bytes,
-                    );
+                    Self::note_claim(shared, file, &entry);
+                    return Self::decompress_and_publish(shared, worker, file, i, entry);
                 }
             };
 
@@ -1799,14 +2046,46 @@ impl SortWorkerPool {
             // consumer's gap-filler admission rule cannot recover from that
             // and would deadlock. Lock order `reader → raw_blocks` is the only
             // nested-lock path in this function.
+            let enqueued_nanos = shared.now_nanos();
             let mut raw_guard = file.raw_blocks.lock().expect("phase2 raw_blocks mutex poisoned");
             let start_serial = reader_guard.next_serial;
             reader_guard.next_serial += raw_bytes.len() as u64;
-            for (idx, b) in raw_bytes.into_iter().enumerate() {
-                raw_guard.push_back((start_serial + idx as u64, b));
+            for (idx, bytes) in raw_bytes.into_iter().enumerate() {
+                raw_guard.push_back(RawEntry {
+                    serial: start_serial + idx as u64,
+                    bytes,
+                    enqueued_nanos,
+                });
             }
+            file.raw_len.store(raw_guard.len(), Ordering::Relaxed);
             drop(raw_guard);
             drop(reader_guard);
+
+            // If this file was dry when its buffer emptied, the read is what
+            // the consumer has actually been waiting for -- the pool could not
+            // have decompressed anything sooner. Separating that from the
+            // claim/insert lags is what keeps a storage problem from reading as
+            // a scheduling one.
+            //
+            // Bound to its cycle the same way `claim_lag` is: a cycle that
+            // opened after this read completed is not the one the read served,
+            // and one that closed while the sample was being taken is not
+            // either. `emptied_while_dry` reads the cause of whichever cycle is
+            // open, so it has to be read inside the same guarded window.
+            //
+            // Taken once per cycle, as `claim_lag` is: the cycle stays open
+            // until a block reaches the reorder buffer, so a peer can read a
+            // second batch first and would otherwise book a second sample --
+            // one that includes this read's own duration. The take sits before
+            // the final re-read so a rollover drops the sample rather than
+            // booking it against the wrong start.
+            if let Some(emptied) = file.cycle_open_at(enqueued_nanos)
+                && file.emptied_while_dry()
+                && file.take_first_read_since_empty()
+                && file.cycle_still_open(emptied)
+            {
+                shared.refill.read_lag.record(enqueued_nanos.saturating_sub(emptied));
+            }
 
             worker.phase2_file_cursor = (i + 1) % n;
             return StepResult::Success;
@@ -1816,7 +2095,37 @@ impl SortWorkerPool {
         // reasons here costs nothing it was not already about to spend, and it
         // turns an entry in the idle total into an explanation of that entry.
         shared.phase2_scans.record_fruitless_scan(tally);
+        // A scan touches every spill file, so at 86 files and ~2M fruitless
+        // scans this is not obviously negligible -- and it sits directly on the
+        // path by which a hungry file gets noticed. Measure it rather than
+        // assume.
+        shared.fruitless_scan.record(shared.now_nanos().saturating_sub(scan_start));
         StepResult::InputEmpty
+    }
+
+    /// Record that a worker claimed `entry`, closing the scheduling half of a
+    /// refill cycle if this is the first claim since the file ran dry.
+    fn note_claim(shared: &SharedPipelineState, file: &Phase2FileState, entry: &RawEntry) {
+        let now = shared.now_nanos();
+        shared.block_lifecycle.raw_dwell.record(now.saturating_sub(entry.enqueued_nanos));
+        // Unlike `insert_lag`, this path holds no mutex that the consumer must
+        // take to open a cycle, so the cycle is bound to the sample by its own
+        // timestamp instead. `emptied <= now` rejects a cycle that opened after
+        // the claim -- it cannot be the one this claim answered -- and the
+        // re-read rejects one that closed during the claim. Both are cheap
+        // enough to sit on the per-block claim path: a comparison, and a load
+        // that only runs once a cycle is actually open.
+        //
+        // What survives is a claim that arrives while the cycle rolls over,
+        // which loses a sample rather than timing one against the wrong start.
+        // A histogram missing an observation still reads correctly; one holding
+        // a zero it never measured does not.
+        if let Some(emptied) = file.cycle_open_at(now)
+            && file.take_first_claim_since_empty()
+            && file.cycle_still_open(emptied)
+        {
+            shared.refill.claim_lag.record(now.saturating_sub(emptied));
+        }
     }
 
     /// Decompress one raw block and publish it into its file's reorder buffer.
@@ -1835,9 +2144,9 @@ impl SortWorkerPool {
         worker: &mut SortWorkerState,
         file: &Phase2FileState,
         source_idx: usize,
-        serial: u64,
-        raw_bytes: Vec<u8>,
+        entry: RawEntry,
     ) -> StepResult {
+        let RawEntry { serial, bytes: raw_bytes, .. } = entry;
         let data = match file.codec {
             SpillCodec::Bgzf => {
                 let raw_block = RawBgzfBlock { data: raw_bytes };
@@ -1888,12 +2197,34 @@ impl SortWorkerPool {
             }
         };
 
-        let now_poppable = {
+        let inserted_nanos = shared.now_nanos();
+        // Close the refill cycle this insert may have ended, under the same
+        // mutex the consumer opens one with. Reading `emptied_at` outside it
+        // would let the consumer drain and re-empty in between, so this insert
+        // would time itself against a cycle it did not end and then clear that
+        // cycle -- the next insert, the one that really ended it, would find
+        // nothing open and the cycle would go unmeasured.
+        //
+        // Only the sample is taken here; the histogram record happens outside,
+        // and the load costs one relaxed read on a path that already holds the
+        // lock to insert.
+        let (now_poppable, insert_lag) = {
             let mut dec_guard =
                 file.decompressed.lock().expect("phase2 decompressed mutex poisoned");
-            dec_guard.insert(serial, data);
-            dec_guard.can_pop()
+            dec_guard.insert(serial, TimedBlock { data, inserted_nanos });
+            file.decomp_len.store(dec_guard.len(), Ordering::Relaxed);
+            let insert_lag = file.emptied_at().map(|emptied| {
+                file.mark_refilled();
+                inserted_nanos.saturating_sub(emptied)
+            });
+            (dec_guard.can_pop(), insert_lag)
         };
+        // Recorded before the wake below so the latency excludes however long
+        // the consumer then takes to notice -- that delay is the consumer's,
+        // and it is measured separately as park time.
+        if let Some(lag) = insert_lag {
+            shared.refill.insert_lag.record(lag);
+        }
         // Decrement AFTER the insert is published. The unpark below wakes the
         // consumer in case it has been parked waiting on this specific file
         // (now_poppable=true) or is in the is_drained path waiting for
@@ -1924,11 +2255,11 @@ impl SortWorkerPool {
     /// (or on the decompression-error path).
     fn try_pop_raw_for_decompress(
         file: &Phase2FileState,
-    ) -> std::result::Result<(u64, Vec<u8>), PopSkip> {
+    ) -> std::result::Result<RawEntry, PopSkip> {
         let Ok(mut raw_guard) = file.raw_blocks.try_lock() else {
             return Err(PopSkip::RawLockContended);
         };
-        let Some(head_serial) = raw_guard.front().map(|(s, _)| *s) else {
+        let Some(head_serial) = raw_guard.front().map(|e| e.serial) else {
             return Err(PopSkip::RawEmpty);
         };
 
@@ -1951,6 +2282,7 @@ impl SortWorkerPool {
         // while a worker is still in the middle of decompressing this block.
         // The FIFO was non-empty above and is still held, so this cannot fail.
         let popped = raw_guard.pop_front().expect("raw FIFO emptied under its own lock");
+        file.raw_len.store(raw_guard.len(), Ordering::Relaxed);
         file.decomp_in_flight.fetch_add(1, Ordering::AcqRel);
         Ok(popped)
     }
@@ -2075,14 +2407,64 @@ impl SortWorkerPool {
         self.shared.merge_phases.snapshot()
     }
 
+    /// The pool's shared state, for the merge consumer's own instrumentation.
+    ///
+    /// The consumer runs on the main thread and is not a pool worker, but it is
+    /// one end of the same pipeline: it needs the shared clock so its
+    /// timestamps are comparable with the workers', and the trace counters so
+    /// both halves of a handoff are recorded against one another rather than
+    /// separately.
+    pub(crate) fn shared_state(&self) -> Arc<SharedPipelineState> {
+        Arc::clone(&self.shared)
+    }
+
+    /// A spill block's full journey through the merge -- see
+    /// [`crate::merge_trace`].
+    ///
+    /// The two working stages come from the merge phase counters the workers
+    /// already record into, and the two dwell stages from `block_lifecycle`.
+    /// This is the one place that holds both, which is why it is the only place
+    /// a complete report can be assembled.
+    pub(crate) fn block_lifecycle_report(&self) -> crate::merge_trace::BlockLifecycleReport {
+        let phases = &self.shared.merge_phases;
+        crate::merge_trace::BlockLifecycleReport {
+            read_batch: phases.read.histogram(),
+            decompress: phases.decompress.histogram(),
+            ..self.shared.block_lifecycle.snapshot()
+        }
+    }
+
+    /// How long files that ran dry took to be refilled.
+    pub(crate) fn refill_report(&self) -> crate::merge_trace::RefillReport {
+        self.shared.refill.snapshot()
+    }
+
+    /// The merge consumer's access pattern and what it cost.
+    pub(crate) fn consumer_trace_report(&self) -> crate::merge_trace::ConsumerTraceReport {
+        self.shared.consumer_trace.snapshot()
+    }
+
+    /// How long a worker's fruitless scan of every spill file takes.
+    pub(crate) fn fruitless_scan_report(&self) -> crate::merge_trace::HistogramReport {
+        self.shared.fruitless_scan.snapshot()
+    }
+
     /// Why Phase 2 file scans found no work -- see [`crate::merge_stalls`].
     pub(crate) fn phase2_scan_report(&self) -> Phase2ScanReport {
         self.shared.phase2_scans.snapshot()
     }
 
-    /// How deep workers were sleeping when they found work.
+    /// How deep workers were sleeping when they found work, during the merge.
+    ///
+    /// Scoped to Phase 2 by subtracting the snapshot taken at the phase
+    /// boundary; falls back to the running total only when the pool never
+    /// entered Phase 2, in which case there is no merge to misattribute to.
     pub(crate) fn wake_latency_report(&self) -> WakeLatencyReport {
-        self.shared.wake_latency.snapshot()
+        let now = self.shared.wake_latency.snapshot();
+        match self.shared.wake_latency_at_merge_start.get() {
+            Some(&baseline) => now.since(baseline),
+            None => now,
+        }
     }
 
     /// Codec used to compress Phase 1 spill chunks.
@@ -2142,6 +2524,15 @@ impl SortWorkerPool {
 
     /// Set the current pipeline phase.
     pub fn set_phase(&self, new_phase: u8) {
+        // Pin the wake-latency counters as they stand entering the merge. They
+        // run for the pool's whole life, so without a baseline to subtract, a
+        // merge-scoped report would include every Phase 1 sleep -- see
+        // `WakeLatencyReport::since`. `OnceLock` so a workflow that re-enters
+        // PHASE2 keeps the first boundary rather than silently rebasing.
+        if new_phase == phase::PHASE2 {
+            let _ =
+                self.shared.wake_latency_at_merge_start.set(self.shared.wake_latency.snapshot());
+        }
         self.shared.phase.store(new_phase, Ordering::Release);
     }
 
@@ -2887,6 +3278,37 @@ mod tests {
         pool.shutdown();
     }
 
+    /// A sleep that straddles the Phase 1 -> Phase 2 boundary belongs to
+    /// neither report.
+    ///
+    /// `wake_latency` runs for the pool's whole life and the merge's share is
+    /// taken by subtracting a snapshot pinned at the boundary, so a Phase 1
+    /// sleep recorded after that snapshot lands inside the merge's window —
+    /// booking discovery lag against a merge that had not started when the
+    /// worker went to sleep. The sleep cannot be credited to Phase 1 either,
+    /// since its snapshot is already taken, so it is dropped.
+    #[rstest]
+    #[case::same_phase_sleep_is_charged(
+        Some(PendingSleep { phase: phase::PHASE2, backoff_us: 80 }), phase::PHASE2, Some(80)
+    )]
+    #[case::phase1_sleep_is_not_charged_to_phase2(
+        Some(PendingSleep { phase: phase::PHASE1, backoff_us: 80 }), phase::PHASE2, None
+    )]
+    #[case::phase2_sleep_is_not_charged_to_phase1(
+        Some(PendingSleep { phase: phase::PHASE2, backoff_us: 80 }), phase::PHASE1, None
+    )]
+    #[case::a_phase1_sleep_within_phase1_is_charged(
+        Some(PendingSleep { phase: phase::PHASE1, backoff_us: 40 }), phase::PHASE1, Some(40)
+    )]
+    #[case::no_pending_sleep(None, phase::PHASE2, None)]
+    fn productive_sleep_is_scoped_to_the_phase_it_ran_in(
+        #[case] pending: Option<PendingSleep>,
+        #[case] current_phase: u8,
+        #[case] expected: Option<u64>,
+    ) {
+        assert_eq!(productive_sleep_micros(pending, current_phase), expected);
+    }
+
     #[test]
     fn active_worker_limit_caps_then_reactivates() {
         // Reactivation must be observable on the SAME pool: a fresh pool can never
@@ -3184,19 +3606,62 @@ mod tests {
         Phase2FileState::new(reader, SpillCodec::Bgzf)
     }
 
-    /// Build a tiny placeholder raw block whose contents we never decode.
-    fn dummy_raw_block(byte: u8) -> Vec<u8> {
-        vec![byte; 8]
+    /// Build a tiny placeholder raw entry whose contents we never decode.
+    fn raw_entry(serial: u64, byte: u8) -> RawEntry {
+        RawEntry { serial, bytes: vec![byte; 8], enqueued_nanos: 0 }
+    }
+
+    /// A placeholder decompressed block; the insert timestamp is irrelevant to
+    /// admission control, which is what these tests exercise.
+    fn timed_block(len: usize) -> TimedBlock {
+        TimedBlock { data: vec![0u8; len], inserted_nanos: 0 }
     }
 
     #[test]
     fn test_admission_under_cap_admits() {
         let file = empty_phase2_file();
-        file.raw_blocks.lock().expect("raw lock").push_back((0, dummy_raw_block(0)));
+        file.raw_blocks.lock().expect("raw lock").push_back(raw_entry(0, 0));
         let popped = SortWorkerPool::try_pop_raw_for_decompress(&file);
         assert!(popped.is_ok(), "under cap with empty reorder buffer should admit");
         assert_eq!(file.decomp_in_flight.load(Ordering::Acquire), 1);
         assert!(file.raw_blocks.lock().expect("raw lock").is_empty());
+    }
+
+    /// Seed the FIFO through the deque *and* the mirror, the way the read path
+    /// leaves them, then pop and assert both moved together.
+    ///
+    /// Seeding matters: the other admission tests push straight into the deque
+    /// and leave `raw_len` at zero, so asserting the mirror is zero after a pop
+    /// would pass even with the store deleted. Starting from a non-zero mirror is
+    /// what gives the assertion teeth.
+    ///
+    /// The mirror is what `EmptyCause::classify` and the consumer's park census
+    /// read instead of taking the lock, so a dropped store does not corrupt data
+    /// -- it silently reclassifies every `Dry` empty as `RawReady`, sending the
+    /// next investigation after a scheduling bug that is not there.
+    #[rstest]
+    #[case::pop_leaves_the_fifo_empty(1)]
+    #[case::pop_leaves_the_rest_behind(3)]
+    fn test_raw_len_mirror_tracks_the_deque_across_a_pop(#[case] seeded: usize) {
+        let file = empty_phase2_file();
+        {
+            let mut raw = file.raw_blocks.lock().expect("raw lock");
+            for serial in 0..seeded as u64 {
+                raw.push_back(raw_entry(serial, 0));
+            }
+            file.raw_len.store(raw.len(), Ordering::Relaxed);
+        }
+        assert_eq!(file.depths().0, seeded, "the mirror starts where the read path leaves it");
+
+        SortWorkerPool::try_pop_raw_for_decompress(&file).expect("under cap should admit");
+
+        let deque_len = file.raw_blocks.lock().expect("raw lock").len();
+        assert_eq!(deque_len, seeded - 1, "exactly one entry leaves the FIFO");
+        assert_eq!(
+            file.depths().0,
+            deque_len,
+            "the lock-free raw_len mirror must track the deque; EmptyCause::classify reads it"
+        );
     }
 
     #[test]
@@ -3207,7 +3672,7 @@ mod tests {
         {
             let mut dec = file.decompressed.lock().expect("dec lock");
             for s in 0..PHASE2_DECOMP_CAP as u64 {
-                dec.insert(s, vec![0u8; 4]);
+                dec.insert(s, timed_block(4));
             }
             assert_eq!(dec.len(), PHASE2_DECOMP_CAP);
             assert!(dec.can_pop());
@@ -3215,14 +3680,11 @@ mod tests {
         // Head raw is the next serial after the buffer's contents — not the
         // gap-filler, so admission should reject (consumer is supposed to
         // drain the buffer first).
-        file.raw_blocks
-            .lock()
-            .expect("raw lock")
-            .push_back((PHASE2_DECOMP_CAP as u64, dummy_raw_block(1)));
+        file.raw_blocks.lock().expect("raw lock").push_back(raw_entry(PHASE2_DECOMP_CAP as u64, 1));
         let popped = SortWorkerPool::try_pop_raw_for_decompress(&file);
         assert_eq!(
-            popped.expect_err("at cap and poppable should reject (apply backpressure)"),
-            PopSkip::DecompCapped,
+            popped.err(),
+            Some(PopSkip::DecompCapped),
             "rejecting at cap must be reported as backpressure, not as an empty file"
         );
         assert_eq!(file.decomp_in_flight.load(Ordering::Acquire), 0);
@@ -3237,14 +3699,14 @@ mod tests {
         {
             let mut dec = file.decompressed.lock().expect("dec lock");
             for s in 1..=PHASE2_DECOMP_CAP as u64 {
-                dec.insert(s, vec![0u8; 4]);
+                dec.insert(s, timed_block(4));
             }
             assert_eq!(dec.len(), PHASE2_DECOMP_CAP);
             assert!(!dec.can_pop(), "buffer should be stuck waiting for serial 0");
         }
         // The head raw is serial 0 — the gap-filler. Admission must take it
         // even though we're at cap, otherwise the consumer deadlocks.
-        file.raw_blocks.lock().expect("raw lock").push_back((0, dummy_raw_block(0)));
+        file.raw_blocks.lock().expect("raw lock").push_back(raw_entry(0, 0));
         let popped = SortWorkerPool::try_pop_raw_for_decompress(&file);
         assert!(popped.is_ok(), "at cap and stuck should admit gap-filler at next_seq");
         assert_eq!(file.decomp_in_flight.load(Ordering::Acquire), 1);
@@ -3259,19 +3721,144 @@ mod tests {
         {
             let mut dec = file.decompressed.lock().expect("dec lock");
             for s in 1..=PHASE2_DECOMP_CAP as u64 {
-                dec.insert(s, vec![0u8; 4]);
+                dec.insert(s, timed_block(4));
             }
         }
         file.raw_blocks
             .lock()
             .expect("raw lock")
-            .push_back((PHASE2_DECOMP_CAP as u64 + 1, dummy_raw_block(2)));
+            .push_back(raw_entry(PHASE2_DECOMP_CAP as u64 + 1, 2));
         let popped = SortWorkerPool::try_pop_raw_for_decompress(&file);
-        assert_eq!(
-            popped.expect_err("at cap, stuck, but head != next_seq should reject"),
-            PopSkip::DecompCapped
-        );
+        assert_eq!(popped.err(), Some(PopSkip::DecompCapped));
         assert_eq!(file.decomp_in_flight.load(Ordering::Acquire), 0);
+    }
+
+    /// `read_lag` is defined over the empties where the file held nothing
+    /// anywhere, so the cause must be readable back off the file. Recording it
+    /// for a `RawReady` or `Decompressing` empty would time a read that was
+    /// never on the critical path and make a scheduling delay read as a storage
+    /// one.
+    #[rstest]
+    #[case::nothing_anywhere(0, 0, true)]
+    #[case::raw_block_already_queued(1, 0, false)]
+    #[case::decompression_already_in_flight(0, 1, false)]
+    #[case::both(1, 1, false)]
+    fn test_emptied_while_dry_tracks_the_cause_the_cycle_opened_with(
+        #[case] raw_len: usize,
+        #[case] in_flight: usize,
+        #[case] expected_dry: bool,
+    ) {
+        let file = empty_phase2_file();
+        file.mark_emptied(42, crate::merge_trace::EmptyCause::classify(raw_len, in_flight));
+        assert_eq!(file.emptied_at(), Some(42));
+        assert_eq!(file.emptied_while_dry(), expected_dry);
+    }
+
+    /// `claim_lag` is one sample per refill cycle, not one per worker that
+    /// piles onto the same hungry file. Only the flag's take-once behaviour
+    /// enforces that; a plain load here would inflate `claim_lag`'s count and
+    /// shift `claim_share`, the most actionable number in the trace report.
+    #[test]
+    fn test_first_claim_since_empty_fires_once_per_refill_cycle() {
+        let file = empty_phase2_file();
+        file.mark_emptied(10, crate::merge_trace::EmptyCause::Dry);
+        assert!(file.take_first_claim_since_empty(), "the first responder records");
+        assert!(!file.take_first_claim_since_empty(), "a peer on the same cycle does not");
+
+        file.mark_refilled();
+        assert_eq!(file.emptied_at(), None, "the cycle is closed");
+
+        file.mark_emptied(20, crate::merge_trace::EmptyCause::RawReady);
+        assert!(file.take_first_claim_since_empty(), "a new cycle re-arms the flag");
+        assert!(!file.take_first_claim_since_empty(), "and only re-arms it once");
+    }
+
+    /// `read_lag` is one sample per refill cycle for the same reason
+    /// `claim_lag` is. A dry cycle stays open until something lands in the
+    /// reorder buffer, and nothing stops a second worker reading another batch
+    /// before that happens -- the raw FIFO can sit below its cap with every
+    /// peer busy elsewhere. Without the take-once, that second read books a
+    /// second sample against the same `emptied`, strictly larger than the
+    /// first, inflating `read_lag`'s count past the dry-cycle count and
+    /// skewing the histogram that separates a storage constraint from a
+    /// scheduling one.
+    #[test]
+    fn test_first_read_since_empty_fires_once_per_refill_cycle() {
+        let file = empty_phase2_file();
+        file.mark_emptied(10, crate::merge_trace::EmptyCause::Dry);
+        assert!(file.take_first_read_since_empty(), "the read that served the cycle records");
+        assert!(!file.take_first_read_since_empty(), "a second batch on the same cycle does not");
+
+        file.mark_refilled();
+        file.mark_emptied(20, crate::merge_trace::EmptyCause::Dry);
+        assert!(file.take_first_read_since_empty(), "a new cycle re-arms the flag");
+        assert!(!file.take_first_read_since_empty(), "and only re-arms it once");
+    }
+
+    /// The read and claim flags measure different halves of the same cycle --
+    /// waiting to be served versus waiting to be noticed -- so one must not
+    /// consume the other's sample. Sharing a single flag would silence
+    /// whichever half happened to run second.
+    #[test]
+    fn test_the_read_and_claim_flags_are_independent() {
+        let file = empty_phase2_file();
+        file.mark_emptied(10, crate::merge_trace::EmptyCause::Dry);
+        assert!(file.take_first_read_since_empty(), "the read records");
+        assert!(file.take_first_claim_since_empty(), "and the claim still records");
+    }
+
+    /// A sample may only be timed against the cycle it actually answered.
+    ///
+    /// `claim_lag` and `read_lag` are taken without the `decompressed` mutex
+    /// that makes a cycle's open and close mutually exclusive, so the cycle is
+    /// bound to the sample by its open timestamp instead. Both halves matter:
+    /// the `<=` rejects a cycle that opened after the event, and the re-read
+    /// rejects one that closed while the sample was being taken.
+    #[rstest]
+    // The event happened after the cycle opened, so it is a sample of it.
+    #[case::event_after_the_cycle_opened(100, 150, Some(100))]
+    // Same instant still counts -- a claim can land on the drain that caused it.
+    #[case::event_at_the_instant_it_opened(100, 100, Some(100))]
+    // A cycle that opened after the event cannot be the one the event answered;
+    // timing against it would run backwards and saturate to a fictitious zero.
+    #[case::cycle_opened_after_the_event(100, 50, None)]
+    fn test_a_sample_binds_only_to_a_cycle_that_preceded_it(
+        #[case] opened_at: u64,
+        #[case] event_nanos: u64,
+        #[case] expected: Option<u64>,
+    ) {
+        let file = empty_phase2_file();
+        file.mark_emptied(opened_at, crate::merge_trace::EmptyCause::Dry);
+        assert_eq!(file.cycle_open_at(event_nanos), expected);
+    }
+
+    #[test]
+    fn test_no_sample_binds_when_no_cycle_is_open() {
+        let file = empty_phase2_file();
+        assert_eq!(file.cycle_open_at(u64::MAX), None, "a file that never drained has no cycle");
+    }
+
+    /// The re-read is what catches the interleaving the mutex cannot: a cycle
+    /// that closes -- or closes and reopens -- while a sample is in flight.
+    /// Identity is the open timestamp and the pool epoch is monotonic, so a
+    /// reopened cycle never presents the old one's value.
+    #[test]
+    fn test_a_cycle_that_rolled_over_mid_sample_rejects_the_sample() {
+        let file = empty_phase2_file();
+        file.mark_emptied(10, crate::merge_trace::EmptyCause::Dry);
+        let observed = file.cycle_open_at(15).expect("the cycle is open");
+
+        assert!(file.cycle_still_open(observed), "unchanged, so the sample stands");
+
+        file.mark_refilled();
+        assert!(!file.cycle_still_open(observed), "closed, so the sample is dropped");
+
+        file.mark_emptied(20, crate::merge_trace::EmptyCause::Dry);
+        assert!(
+            !file.cycle_still_open(observed),
+            "reopened as a different cycle -- the sample belongs to neither"
+        );
+        assert_eq!(file.cycle_open_at(25), Some(20), "and the new cycle is the one now open");
     }
 
     #[test]
@@ -3281,8 +3868,8 @@ mod tests {
         // in_flight.
         let popped = SortWorkerPool::try_pop_raw_for_decompress(&file);
         assert_eq!(
-            popped.expect_err("an empty FIFO has nothing to admit"),
-            PopSkip::RawEmpty,
+            popped.err(),
+            Some(PopSkip::RawEmpty),
             "an empty FIFO must not be conflated with a file the pool declined"
         );
         assert_eq!(file.decomp_in_flight.load(Ordering::Acquire), 0);
@@ -3308,7 +3895,7 @@ mod tests {
     fn test_is_drained_blocks_on_pending_raw() {
         let file = empty_phase2_file();
         file.mark_reader_eof(&mut file.reader.lock().expect("reader lock"));
-        file.raw_blocks.lock().expect("raw lock").push_back((0, dummy_raw_block(0)));
+        file.raw_blocks.lock().expect("raw lock").push_back(raw_entry(0, 0));
         assert!(!file.is_drained(), "raw blocks pending must keep is_drained=false");
     }
 
@@ -3316,7 +3903,7 @@ mod tests {
     fn test_is_drained_blocks_on_pending_decompressed() {
         let file = empty_phase2_file();
         file.mark_reader_eof(&mut file.reader.lock().expect("reader lock"));
-        file.decompressed.lock().expect("dec lock").insert(0, vec![1, 2, 3]);
+        file.decompressed.lock().expect("dec lock").insert(0, timed_block(3));
         assert!(!file.is_drained(), "decompressed blocks pending must keep is_drained=false");
     }
 


### PR DESCRIPTION
#706 has landed, and this branch is rebased onto `main` — its four commits are now this PR's whole diff.

#706 reports *where* the merge's time goes. On a spill-heavy whole-genome sort it says the worker pool is 55% utilized while the consumer is blocked 79% of its loop. Both halves are waiting and neither number says what for, because every candidate cause produces the same reading: a worker that finds nothing to do sleeps and adds to one idle total, whether it found nothing because the reorder buffers were capped, the raw FIFOs were full, a peer already held the reader, or a `try_lock` lost a race. The file-scan loop distinguishes all four and then discards the distinction.

This PR keeps it, in three layers.

**Why a worker idled.** A per-scan tally of skip reasons, published only on the scan that found no work — the path that is about to sleep anyway, so a productive scan pays a handful of increments to a local array. Note there is deliberately no "starved" reason: a file with an empty FIFO and a free reader is not skipped, it is *read*, so starvation cannot appear on the worker side at all. It appears on the consumer side, which is why both halves are needed.

**Where the consumer blocked, exactly.** `advance_to_next_block` parks the main thread waiting on one specific file. Parks happen once per ~64 KB block rather than once per ~100-byte record, so they can be timed exactly and for free — and they isolate *waiting* from the record copy that the sampled "fetch next record" figure folds in with it. Classifying the awaited file at each park is what answers the question; the pool-wide census, it turns out, cannot. Two arms of one experiment show 98% vs 97% of files at cap and identical decompression work, yet stall on 58% vs 7% of block pulls.

**Why that state arose.** The full block lifecycle — disk read, raw FIFO dwell, decompress, reorder dwell — plus the refill cycle keyed on the instant a buffer drains: how long until a worker claims the work, how long until a block lands, and for dry files how long until a read completes. Splitting the empties by what the file had on hand separates three different fixes (bytes unclaimed → scheduling, already decompressing → lookahead depth, nothing at all → read concurrency).

Everything is a log2 histogram with percentiles beside the mean. Merge stalls are heavy-tailed: a mean park of 83 µs is equally consistent with every park costing 83 µs and with 1% costing 7 ms, and those have different causes.

## What it found

Enough to retire four hypotheses and one benchmark. On `1kg-wgs-HG00096` at 8 threads, 86 spilled runs:

- The stall is refill latency. 271.4s of the 305s merge is per-block refill, and 175.0s of that is spent before any worker claims the work.
- The reorder buffer is a pass-through for the file being read (p90 dwell 16 µs), so `PHASE2_DECOMP_CAP` is not the binding constraint. Two planned cap sweeps were dropped as a result.
- Head-of-line blocking, lock contention and storage are all refuted.
- The merge drew ~29,540 consecutive blocks from one source — which turned out to be because the benchmark input is *already* `SO:coordinate`, making the spill runs disjoint and the merge a near-sequential drain. Re-sorting the same records from interleaved runs gives a 183s merge at 98% utilization with 1% of pulls stalling. The pathology was in the benchmark, not the engine.

## Cost

Zero, measured. Baseline wall clock 553.60s / 553.16s / 553.14s across the three instrumented builds against 552.0s uninstrumented — a 0.3% spread, same 86 spills every time. Per-file depth counters are relaxed atomics maintained under mutexes that were already being taken.

## Reporting

Collection is unconditional; verbosity is not. The per-stage histograms go to debug, and the figures that change a decision stay at info. Gating *collection* is what made the original question unanswerable from logs we had already collected — that is the lesson from #706's own gating, and it is not repeated here.

## Notes for review

- `ComponentCounter` is now backed by the same histogram type, so #706's totals and this PR's distributions describe literally the same observations rather than two sets of atomics that can drift apart silently.
- `classify_stall` takes worker utilization because the awaited-file states cannot distinguish "nobody picked this up" from "nobody was free to pick it up". Its saturation threshold is shared with `classify_merge`'s so the two verdicts in one log cannot contradict each other.
- Both classifiers' thresholds are pinned by `measured_*` test cases naming the runs that produced them, so moving one means confronting the evidence.
- `combine_skip` orders reasons by causal depth rather than severity, and `Phase2Skip::RawFull` documents why a zero count does not mean the cap was never reached. An earlier revision of this work drew exactly that wrong conclusion from `raw-full=0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: command output changes: diagnostic metrics and logs only, pinned by debug/info logging levels; `unsafe`: none, so no `CLAUDE.md` allowlist update applies; memory bounds, queue capacities, and thread/backpressure policy: none. Fix: none required.

- Adds end-to-end merge-stall instrumentation.
- Tracks worker skip reasons, wake latency, consumer wait states, block lifecycle timing, refill cycles, queue dwell, and reorder-buffer dwell.
- Adds lock-free histograms with totals, means, percentiles, cause shares, and stall-shape classification.
- Adds diagnostics for regular and indexed merges.
- Preserves unconditional metric collection while limiting detailed reports to debug and decision summaries to info.
- Adds unit tests for histogram behavior, lifecycle detection, refill classification, stall thresholds, attribution, and entry admission/drain behavior.
- Refactors `ComponentCounter` to use shared `DurationHistogram` reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
