### PR TITLE
perf(sort): stop the k-way merge idling when the input is already sorted

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -3999,6 +3999,17 @@ impl RawExternalSorter {
                 "  Workers ({workers_n} active threads; busy time, overlaps the above and itself)"
             );
             info!("    Spill disk read:   {read_s:.1}s ({:.0}%) [{read_n} batches]", pct(read_s));
+            // Blocks-per-batch, split by allowance. A deep share near zero means
+            // the frontier gate is not firing, which reads identically to "the
+            // deeper read-ahead did not help" unless it is reported separately.
+            let (deep_b, deep_blk, shal_b, shal_blk) = pool.read_batch_split();
+            let per = |blk: u64, b: u64| if b == 0 { 0.0 } else { blk as f64 / b as f64 };
+            info!(
+                "      frontier {deep_b} batches / {deep_blk} blocks ({:.1} per batch), \
+                 other {shal_b} batches / {shal_blk} blocks ({:.1} per batch)",
+                per(deep_blk, deep_b),
+                per(shal_blk, shal_b)
+            );
             info!("    Spill decompress:  {dec_s:.1}s ({:.0}%) [{dec_n} blocks]", pct(dec_s));
             info!("    Output compress:   {comp_s:.1}s ({:.0}%) [{comp_n} blocks]", pct(comp_s));
             info!("    Total worker busy: {busy:.1}s  (NOT comparable to loop wall clock)");

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1544,6 +1544,15 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
                         None
                     };
                     drop(guard);
+                    if emptied_cause.is_some() {
+                        // This file needs a worker now. Waking one here is the
+                        // difference between the pool learning that within a
+                        // microsecond and learning it whenever some worker's
+                        // backoff happens to expire. After the drop, so the
+                        // woken worker does not immediately block on the mutex
+                        // this thread would still be holding.
+                        self.shared.wake_one_worker();
+                    }
                     if let Some(cause) = emptied_cause {
                         self.shared.refill.record_empty(cause);
                     }
@@ -1586,6 +1595,9 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
 
             // Source produced everything it ever will?
             if self.files[source_id].is_drained() {
+                // Move the drain frontier past it, so workers scanning for the
+                // next hungry file start at one that still has records.
+                self.shared.advance_phase2_frontier(&self.files);
                 return Ok(false);
             }
 
@@ -2492,6 +2504,17 @@ impl RawExternalSorter {
         output: &Path,
         pool: Arc<SortWorkerPool>,
     ) -> Result<RawSortStats> {
+        // Say so when the input claims to be in the order being requested. This
+        // is checked before @PG is added so it reflects the input as given.
+        if crate::header_declares_order(header, self.sort_order) {
+            log::warn!(
+                "Input header already declares this sort order ({}); sorting it again. \
+                 Headers are not verified, so the sort still runs -- use `--verify` to \
+                 check an input's order without rewriting it.",
+                self.sort_order_flag_value()
+            );
+        }
+
         // Add @PG record if pg_info was provided
         let header = if let Some((ref version, ref command_line)) = self.pg_info {
             fgumi_bam_io::header::add_pg_record(header.clone(), version, command_line)?
@@ -4076,8 +4099,9 @@ impl RawExternalSorter {
                     100.0 * wake.deep_sleep_wake_share()
                 );
                 info!(
-                    "    (nothing unparks a worker, so this bounds how late work is noticed; it \
-                     delays the merge only when every worker is asleep at once)"
+                    "    (the consumer unparks one worker when a reorder buffer drains, so this \
+                     bounds how late work arriving any other way is noticed; it delays the merge \
+                     only when every worker is asleep at once)"
                 );
             }
 
@@ -5204,6 +5228,7 @@ mod tests {
     fn merge_stall_gate_covers_every_report(#[case] populate: &str, #[case] silent: bool) {
         use crate::merge_stalls::{
             ConsumerStallTracker, Phase2ScanStats, Phase2ScanTally, Phase2Skip, WakeLatencyStats,
+            WakePhase,
         };
 
         let stalls = {
@@ -5225,9 +5250,9 @@ mod tests {
         let wake = {
             let stats = WakeLatencyStats::default();
             if populate == "wake" {
-                stats.record_sleep(320, 1_000);
+                stats.record_sleep(WakePhase::Merge, 320, 1_000);
             }
-            stats.snapshot()
+            stats.snapshot(WakePhase::Merge)
         };
 
         // Mirrors the caller, which drops an all-zero stall report before the
@@ -5250,7 +5275,9 @@ mod tests {
     /// on exactly those runs.
     #[test]
     fn silent_stall_gate_does_not_silence_the_lifecycle_gate() {
-        use crate::merge_stalls::{ConsumerStallTracker, Phase2ScanStats, WakeLatencyStats};
+        use crate::merge_stalls::{
+            ConsumerStallTracker, Phase2ScanStats, WakeLatencyStats, WakePhase,
+        };
         use crate::merge_trace::{
             BlockLifecycleStats, ConsumerTraceStats, DurationHistogram, RefillStats,
         };
@@ -5259,7 +5286,7 @@ mod tests {
         // empty, no worker slept.
         let stalls = ConsumerStallTracker::new(1).snapshot();
         let scans = Phase2ScanStats::default().snapshot();
-        let wake = WakeLatencyStats::default().snapshot();
+        let wake = WakeLatencyStats::default().snapshot(WakePhase::Merge);
         assert!(
             merge_stalls_are_silent(Some(&stalls), &scans, &wake),
             "a merge with no stalls should leave the stall block silent"

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -186,10 +186,29 @@ impl SortPhaseTimer {
         result
     }
 
+    /// How many chunks have been spilled, counted where the spill is timed.
+    fn spill_count(&self) -> usize {
+        self.spill_count
+    }
+
     /// Record the size of a spill file.
     fn record_spill_size(&mut self, path: &Path) {
         if let Ok(meta) = std::fs::metadata(path) {
             self.total_spill_bytes += meta.len();
+        }
+    }
+
+    /// Add the bytes a spill run grew by, given its size before the chunk was
+    /// written.
+    ///
+    /// Run formation appends several chunks to one file, so re-adding the file's
+    /// whole length after each chunk would sum `C + 2C + ... + NC` and report a
+    /// spill volume quadratic in the chunk count. Spill volume is the figure used
+    /// to judge whether run formation reduced spill I/O at all, so it has to be
+    /// the delta.
+    fn record_spill_growth(&mut self, path: &Path, size_before: u64) {
+        if let Ok(meta) = std::fs::metadata(path) {
+            self.total_spill_bytes += meta.len().saturating_sub(size_before);
         }
     }
 
@@ -212,7 +231,7 @@ impl SortPhaseTimer {
     }
 
     /// Time writing in-memory-only output (no merge needed).
-    fn time_write_output(&mut self, f: impl FnOnce() -> Result<()>) -> Result<()> {
+    fn time_write_output<T>(&mut self, f: impl FnOnce() -> Result<T>) -> Result<T> {
         Self::time(&mut self.write_output_secs, f)
     }
 
@@ -1297,6 +1316,82 @@ pub(crate) struct MainThreadChunkConsumer<K: RawSortKey + 'static> {
     _phantom: std::marker::PhantomData<K>,
 }
 
+/// Enforce the permutation invariant, removing the output when it fails.
+///
+/// A sort is a permutation: every record read must be written. By the time this
+/// runs the writer has finalized `output`, so a mismatch leaves a
+/// truncated-but-*valid* BAM (and, under `write_index`, a `.bai` describing it)
+/// on disk. Saying the output "must not be used" does not stop a wrapper that
+/// checks only an exit code, or a user who re-runs and reads the stale file, so
+/// a file output is removed rather than merely described.
+///
+/// That also matches the rest of the crate rather than making this the one
+/// exception: the merge writes through [`MergeOutputTarget`] and drops its temp
+/// on error, and `test_sort_records_producer_error_aborts` pins that an aborted
+/// sort leaves no output behind.
+///
+/// What is *not* removed is as deliberate as what is, and mirrors the guards
+/// [`MergeOutputTarget::create`] already applies: stdout cannot be un-written,
+/// and a FIFO, device or directory was written *through* rather than created, so
+/// unlinking it would destroy something this sort does not own. Those cases keep
+/// the "must not be used" wording, which is all that is true of them. A removal
+/// that fails is reported rather than swallowed -- the caller is being told the
+/// output is dangerous, so whether it is still there is exactly what they need.
+fn enforce_record_count(stats: &RawSortStats, output: &Path, write_index: bool) -> Result<()> {
+    if stats.total_records == stats.output_records {
+        return Ok(());
+    }
+
+    let disposition = if is_stdout_path(output) {
+        // The records are already past this process; there is nothing to unlink,
+        // and `/dev/stdout` itself must certainly not be.
+        "The records written to stdout are incomplete and must not be used.".to_string()
+    } else {
+        let mut targets = vec![output.to_path_buf()];
+        if write_index {
+            targets.push(fgumi_bam_io::bai_sidecar_path(output));
+        }
+        let left_behind: Vec<PathBuf> =
+            targets.into_iter().filter(|path| !remove_incomplete_output(path)).collect();
+        if left_behind.is_empty() {
+            format!("The incomplete output at {} has been removed.", output.display())
+        } else {
+            let paths =
+                left_behind.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", ");
+            format!("The incomplete output at {paths} could not be removed and must not be used.")
+        }
+    };
+
+    anyhow::bail!(
+        "sort lost records: read {} but wrote {} (differ by {}). {}",
+        stats.total_records,
+        stats.output_records,
+        stats.total_records.abs_diff(stats.output_records),
+        disposition
+    )
+}
+
+/// Remove an incomplete sort output, reporting whether it is now gone.
+///
+/// Follows a symlink to the file the sort actually wrote through, so unlinking
+/// the link would not leave the real short BAM in place -- the same resolution
+/// [`MergeOutputTarget::create`] does for the opposite reason. Only regular
+/// files are removed; anything else was written through, not created, and a
+/// path that cannot be resolved or stat-ed is reported as still present rather
+/// than assumed gone.
+fn remove_incomplete_output(path: &Path) -> bool {
+    let Ok(resolved) = resolve_symlink_output(path) else {
+        return false;
+    };
+    match std::fs::metadata(&resolved) {
+        // Already absent is the outcome we wanted, not a failure.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+        Err(_) => false,
+        Ok(metadata) if !metadata.is_file() => false,
+        Ok(_) => std::fs::remove_file(&resolved).is_ok(),
+    }
+}
+
 /// Whether the merge block-lifecycle block has nothing to print.
 ///
 /// Every report that block prints must appear here. A report missing from the
@@ -1847,6 +1942,120 @@ impl<'a> ChunkNamer<'a> {
 struct PendingSpill {
     handle: crate::pooled_chunk_writer::SpillWriteHandle,
     chunk_path: PathBuf,
+    /// Whether this chunk extended an existing run rather than starting one.
+    /// An extended run is already in `chunk_files`, so it must not be added twice.
+    appended: bool,
+    /// The run file's length before this chunk was written, so the drain can
+    /// account for the bytes this chunk added rather than the file's whole size.
+    size_before: u64,
+}
+
+/// Decides whether the next sorted chunk extends the open spill run or starts a
+/// new one — "natural run formation".
+///
+/// Phase 1 chunks its input sequentially, so an input already in the requested
+/// order produces chunks that are not merely disjoint but *totally ordered*:
+/// chunk 0 holds the earliest records, chunk 1 the next. Writing each to its own
+/// file manufactures a k-way merge for a sequence that was never interleaved.
+/// Appending instead collapses sorted input to a single run, and almost-sorted
+/// input to its natural runs.
+///
+/// # Why only the most recent run
+///
+/// Considering older runs too (best fit) yields fewer runs on adversarial input
+/// but breaks stability. Suppose run 0 ended at key 100 and stopped receiving,
+/// run 1 is at 200, and a chunk arrives with minimum 150: best fit appends it to
+/// run 0, so run 0 holds chunks {0,1,2,9} while run 1 holds {3,4}. Source index
+/// order no longer matches ingest order, and for a key present in both chunk 3
+/// and chunk 9 the merge would emit chunk 9's copy first.
+///
+/// Restricting appends to the most recent run keeps every run a *consecutive*
+/// group of chunks, so source order equals ingest order. Combined with the loser
+/// tree's tie-break on source index (`LoserTree::is_greater`), output is
+/// byte-identical to writing one file per chunk.
+#[derive(Default)]
+struct RunFormer<K> {
+    /// The open run: its path and the key of its last record. `None` before the
+    /// first spill, and after a consolidation that swallowed the run.
+    open: Option<(PathBuf, K)>,
+}
+
+/// Report how many spilled chunks became how many runs.
+///
+/// Sorted input collapses to one run, almost-sorted input to its natural runs,
+/// shuffled input to one run per chunk. Logging the ratio means every sort
+/// reports how ordered its own input was, which is the cheapest way to learn how
+/// common near-sorted inputs are in practice.
+///
+/// `runs` must be the number of runs *formed* (`RawSortStats::runs_written`),
+/// not the number of spill files left at merge time. Consolidation merges the
+/// oldest half of the files whenever their count reaches `--max-temp-files`, so
+/// the surviving file count can be far lower than the run count for reasons that
+/// have nothing to do with how ordered the input was -- which is the one thing
+/// this line exists to report.
+fn log_run_formation(chunks_spilled: usize, runs: usize) {
+    info!(
+        "Spill runs: {runs} from {chunks_spilled} chunks ({} extended an existing run)",
+        chunks_spilled.saturating_sub(runs)
+    );
+}
+
+/// The smallest and largest keys in an already-sorted slice.
+///
+/// Read off the ends rather than scanned, which is what makes run formation free:
+/// the caller has just sorted the buffer, so its extremes are its first and last
+/// elements. `None` only for an empty slice, which a spill never produces.
+fn chunk_bounds<T, K>(items: &[T], key: impl Fn(&T) -> K) -> Option<(K, K)> {
+    Some((key(items.first()?), key(items.last()?)))
+}
+
+impl<K: Clone + Ord> RunFormer<K> {
+    /// Choose where a sorted chunk should be written.
+    ///
+    /// Returns the path and whether it extends an existing run. The chunk extends
+    /// the open run when every key in it sorts at or after that run's last key;
+    /// otherwise a fresh path is allocated and a new run begins.
+    ///
+    /// Both pre-write steps in one method rather than two, because they have a
+    /// mandatory order — forget a consolidated run, *then* test appendability —
+    /// and nothing in the types enforced it when callers drove it themselves.
+    /// Recording the new boundary necessarily follows the write and stays in
+    /// [`Self::extended`], which [`RawExternalSorter::spill_chunk`] — the only
+    /// caller of either — invokes once the path is known.
+    fn place(
+        &mut self,
+        chunk_files: &[PathBuf],
+        bounds: Option<&(K, K)>,
+        namer: &mut ChunkNamer<'_>,
+    ) -> Result<(PathBuf, bool)> {
+        // Consolidation may have merged the open run away while the previous
+        // spill was draining, leaving a path that no longer holds what we think.
+        if let Some((path, _)) = &self.open
+            && !chunk_files.contains(path)
+        {
+            self.open = None;
+        }
+
+        let appendable = match (&self.open, bounds) {
+            (Some((path, last_key)), Some((chunk_min, _))) if last_key <= chunk_min => {
+                Some(path.clone())
+            }
+            _ => None,
+        };
+
+        match appendable {
+            Some(path) => Ok((path, true)),
+            // Always allocate through the namer on this branch: it is what
+            // advances the temp-directory round-robin and periodically re-checks
+            // free space (`TmpDirAllocator::next`).
+            None => Ok((namer.next_chunk_path()?, false)),
+        }
+    }
+
+    /// Record that a chunk ending at `chunk_max` was written to `path`.
+    fn extended(&mut self, path: PathBuf, chunk_max: K) {
+        self.open = Some((path, chunk_max));
+    }
 }
 
 /// Build `BufferProbeStats` from any buffer implementing `ProbeableBuffer`.
@@ -2258,6 +2467,46 @@ impl RawExternalSorter {
             .map_err(|e| anyhow::anyhow!("failed to build rayon sort pool: {e}"))
     }
 
+    /// Write one sorted chunk, extending the open spill run when it can.
+    ///
+    /// Shared by all four sort functions: identical aside from the key type and
+    /// the per-record write, which the caller supplies as a closure. Keeping the
+    /// run-formation bookkeeping here means the append/create choice, the
+    /// pre-write size needed for spill accounting, and the boundary key recorded
+    /// afterwards cannot drift between the four copies.
+    fn spill_chunk<K: RawSortKey + Clone + Ord + Default + 'static>(
+        run_former: &mut RunFormer<K>,
+        chunk_files: &[PathBuf],
+        bounds: Option<(K, K)>,
+        namer: &mut ChunkNamer<'_>,
+        pool: &Arc<SortWorkerPool>,
+        timer: &mut SortPhaseTimer,
+        write: impl FnOnce(&mut PooledChunkWriter<K>) -> Result<()>,
+    ) -> Result<PendingSpill> {
+        let (chunk_path, appended) = run_former.place(chunk_files, bounds.as_ref(), namer)?;
+
+        // Captured before the write so the drain can charge only the bytes this
+        // chunk adds; an appended run's file already holds its predecessors.
+        let size_before =
+            if appended { std::fs::metadata(&chunk_path).map_or(0, |m| m.len()) } else { 0 };
+
+        let handle = timer.time_spill_write(|| {
+            let mut writer = PooledChunkWriter::<K>::open(
+                Arc::clone(pool),
+                &chunk_path,
+                pool.spill_codec(),
+                appended,
+            )?;
+            write(&mut writer)?;
+            writer.start_finish()
+        })?;
+
+        if let Some((_, chunk_max)) = bounds {
+            run_former.extended(chunk_path.clone(), chunk_max);
+        }
+        Ok(PendingSpill { handle, chunk_path, appended, size_before })
+    }
+
     /// Consolidate temp files if we've exceeded the limit.
     /// Wait for a pending spill to complete and, if one was present, run consolidation.
     ///
@@ -2274,9 +2523,13 @@ impl RawExternalSorter {
     ) -> Result<()> {
         if let Some(prev) = pending.take() {
             prev.handle.wait()?;
-            timer.record_spill_size(&prev.chunk_path);
-            chunk_files.push(prev.chunk_path);
-            stats.chunks_written += 1;
+            timer.record_spill_growth(&prev.chunk_path, prev.size_before);
+            // A chunk that extended an existing run is already represented in
+            // `chunk_files`; only a chunk that started a run adds a merge source.
+            if !prev.appended {
+                chunk_files.push(prev.chunk_path);
+                stats.runs_written += 1;
+            }
 
             timer.time_consolidate(|| {
                 self.maybe_consolidate_temp_files::<K>(chunk_files, namer, pool)
@@ -2526,7 +2779,7 @@ impl RawExternalSorter {
         let (_temp_dirs, mut alloc) = self.create_temp_dirs()?;
 
         // Sort based on order
-        match self.sort_order {
+        let stats = match self.sort_order {
             SortOrder::Coordinate => {
                 self.sort_coordinate(record_source, pool, &header, output, &mut alloc)
             }
@@ -2536,7 +2789,17 @@ impl RawExternalSorter {
             SortOrder::TemplateCoordinate => {
                 self.sort_template_coordinate(record_source, pool, &header, output, &mut alloc)
             }
-        }
+        }?;
+
+        // A sort is a permutation: every record read must be written. Checked here
+        // rather than in the CLI so it covers every entry point -- `sort_records`
+        // has callers (`fgumi simulate`) that discard the stats entirely, and a
+        // library consumer should not have to opt in to the engine's own
+        // guarantee. Both counts are measured independently: `total_records` by
+        // the ingest loop, `output_records` by whichever writer produced the
+        // output.
+        enforce_record_count(&stats, output, self.write_index)?;
+        Ok(stats)
     }
 
     /// Warn when a merge is about to ask for more descriptors than the process
@@ -2838,6 +3101,9 @@ impl RawExternalSorter {
         let mut buffer = RecordBuffer::with_capacity(estimated_records, estimated_data_bytes, nref);
         let mut namer = ChunkNamer::new(alloc);
         let mut pending_spill: Option<PendingSpill> = None;
+        // Natural run formation: consecutive chunks that are already in order
+        // extend one run instead of each becoming its own merge source.
+        let mut run_former: RunFormer<crate::keys::RawCoordinateKey> = RunFormer::default();
         let rayon_pool = self.build_sort_rayon_pool()?;
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
@@ -2877,30 +3143,31 @@ impl RawExternalSorter {
                 )?;
                 probe.post_drain(probe_stats(&buffer), Some(pool.phase1_queue_depths()));
 
-                let chunk_path = namer.next_chunk_path()?;
-
                 timer.time_sort(|| {
                     rayon_pool.install(|| buffer.par_sort());
                 });
 
-                // Write keyed temp file with parallel BGZF compression via worker pool.
-                // Use start_finish() for pipelining: I/O continues in background
-                // while we read the next batch.
-                let handle = timer.time_spill_write(|| {
-                    let mut writer = PooledChunkWriter::<RawCoordinateKey>::new(
-                        Arc::clone(&pool),
-                        &chunk_path,
-                        pool.spill_codec(),
-                    )?;
-                    for r in buffer.refs() {
-                        let key = RawCoordinateKey { sort_key: r.sort_key };
-                        let record_bytes = buffer.get_record(r);
-                        writer.write_record(&key, record_bytes)?;
-                    }
-                    writer.start_finish()
-                })?;
+                // The buffer is sorted, so the chunk's extreme keys are its ends.
+                let bounds =
+                    chunk_bounds(buffer.refs(), |r| RawCoordinateKey { sort_key: r.sort_key });
 
-                pending_spill = Some(PendingSpill { handle, chunk_path });
+                // Pipelined: `spill_chunk` returns once the write is submitted, so
+                // I/O continues in the background while we read the next batch.
+                pending_spill = Some(Self::spill_chunk::<RawCoordinateKey>(
+                    &mut run_former,
+                    &chunk_files,
+                    bounds,
+                    &mut namer,
+                    &pool,
+                    &mut timer,
+                    |writer| {
+                        for r in buffer.refs() {
+                            let key = RawCoordinateKey { sort_key: r.sort_key };
+                            writer.write_record(&key, buffer.get_record(r))?;
+                        }
+                        Ok(())
+                    },
+                )?);
 
                 buffer.clear();
                 force_mi_collect();
@@ -2937,16 +3204,18 @@ impl RawExternalSorter {
                 rayon_pool.install(|| buffer.par_sort());
             });
 
-            timer.time_write_output(|| {
+            stats.output_records = timer.time_write_output(|| {
                 use crate::pooled_bam_writer::PooledBamWriter;
                 let output_header = self.create_output_header(header);
                 let mut writer = PooledBamWriter::new(Arc::clone(&pool), output, &output_header)?;
 
+                let mut written: u64 = 0;
                 for record_bytes in buffer.iter_sorted() {
                     writer.write_raw_record(record_bytes)?;
+                    written += 1;
                 }
                 writer.finish()?;
-                Ok(())
+                Ok(written)
             })?;
         } else {
             // Sort remaining records into separate sub-array chunks (avoids
@@ -2967,13 +3236,14 @@ impl RawExternalSorter {
 
             let memory_chunks = MemorySources::Shared(memory_chunks);
             let n_memory = memory_chunks.num_non_empty();
+            log_run_formation(timer.spill_count(), stats.runs_written);
             debug!(
                 "Phase 2: Merging {} chunks (keyed O(1) comparisons)...",
                 chunk_files.len() + n_memory
             );
 
             // Merge disk chunks + in-memory chunks using O(1) key comparisons
-            timer.time_merge(|| {
+            stats.output_records = timer.time_merge(|| {
                 self.merge_chunks_generic::<RawCoordinateKey>(
                     &chunk_files,
                     memory_chunks,
@@ -2985,7 +3255,6 @@ impl RawExternalSorter {
             })?;
         }
 
-        stats.output_records = stats.total_records;
         if let Ok(pool) = Arc::try_unwrap(pool) {
             pool.shutdown();
         }
@@ -3029,6 +3298,9 @@ impl RawExternalSorter {
         let mut buffer = RecordBuffer::with_capacity(estimated_records, estimated_data_bytes, nref);
         let mut namer = ChunkNamer::new(alloc);
         let mut pending_spill: Option<PendingSpill> = None;
+        // Natural run formation: consecutive chunks that are already in order
+        // extend one run instead of each becoming its own merge source.
+        let mut run_former: RunFormer<crate::keys::RawCoordinateKey> = RunFormer::default();
         let rayon_pool = self.build_sort_rayon_pool()?;
 
         debug!("Phase 1: Reading and sorting chunks (inline buffer, keyed output)...");
@@ -3059,27 +3331,30 @@ impl RawExternalSorter {
                 )?;
                 probe.post_drain(probe_stats(&buffer), Some(pool.phase1_queue_depths()));
 
-                let chunk_path = namer.next_chunk_path()?;
-
                 timer.time_sort(|| {
                     rayon_pool.install(|| buffer.par_sort());
                 });
 
-                let handle = timer.time_spill_write(|| {
-                    let mut writer = PooledChunkWriter::<RawCoordinateKey>::new(
-                        Arc::clone(&pool),
-                        &chunk_path,
-                        pool.spill_codec(),
-                    )?;
-                    for r in buffer.refs() {
-                        let key = RawCoordinateKey { sort_key: r.sort_key };
-                        let record_bytes = buffer.get_record(r);
-                        writer.write_record(&key, record_bytes)?;
-                    }
-                    writer.start_finish()
-                })?;
+                let bounds =
+                    chunk_bounds(buffer.refs(), |r| RawCoordinateKey { sort_key: r.sort_key });
 
-                pending_spill = Some(PendingSpill { handle, chunk_path });
+                // Pipelined: `spill_chunk` returns once the write is submitted, so
+                // I/O continues in the background while we read the next batch.
+                pending_spill = Some(Self::spill_chunk::<RawCoordinateKey>(
+                    &mut run_former,
+                    &chunk_files,
+                    bounds,
+                    &mut namer,
+                    &pool,
+                    &mut timer,
+                    |writer| {
+                        for r in buffer.refs() {
+                            let key = RawCoordinateKey { sort_key: r.sort_key };
+                            writer.write_record(&key, buffer.get_record(r))?;
+                        }
+                        Ok(())
+                    },
+                )?);
 
                 buffer.clear();
                 force_mi_collect();
@@ -3118,7 +3393,7 @@ impl RawExternalSorter {
                 rayon_pool.install(|| buffer.par_sort());
             });
 
-            timer.time_write_output(|| {
+            stats.output_records = timer.time_write_output(|| {
                 let mut writer = create_indexing_bam_writer(
                     output,
                     &output_header,
@@ -3126,8 +3401,10 @@ impl RawExternalSorter {
                     self.phase2_threads(),
                 )?;
 
+                let mut written: u64 = 0;
                 for record_bytes in buffer.iter_sorted() {
                     writer.write_raw_record(record_bytes)?;
+                    written += 1;
                 }
 
                 let index = writer.finish()?;
@@ -3135,7 +3412,7 @@ impl RawExternalSorter {
                 let index_path = bai_sidecar_path(output);
                 write_bai_index(&index_path, &index)?;
                 info!("Wrote BAM index: {}", index_path.display());
-                Ok(())
+                Ok(written)
             })?;
         } else {
             // Sort remaining records into separate sub-array chunks
@@ -3154,13 +3431,14 @@ impl RawExternalSorter {
 
             let memory_chunks = MemorySources::Shared(memory_chunks);
             let n_memory = memory_chunks.num_non_empty();
+            log_run_formation(timer.spill_count(), stats.runs_written);
             debug!(
                 "Phase 2: Merging {} chunks with index generation...",
                 chunk_files.len() + n_memory
             );
 
-            timer.time_merge(|| {
-                let index = self.merge_chunks_with_index::<RawCoordinateKey>(
+            stats.output_records = timer.time_merge(|| {
+                let (index, records_merged) = self.merge_chunks_with_index::<RawCoordinateKey>(
                     &chunk_files,
                     memory_chunks,
                     header,
@@ -3172,11 +3450,10 @@ impl RawExternalSorter {
                 let index_path = bai_sidecar_path(output);
                 write_bai_index(&index_path, &index)?;
                 info!("Wrote BAM index: {}", index_path.display());
-                Ok(())
+                Ok(records_merged)
             })?;
         }
 
-        stats.output_records = stats.total_records;
         if let Ok(pool) = Arc::try_unwrap(pool) {
             pool.shutdown();
         }
@@ -3246,6 +3523,9 @@ impl RawExternalSorter {
         let mut memory_used = 0usize;
         let mut namer = ChunkNamer::new(alloc);
         let mut pending_spill: Option<PendingSpill> = None;
+        // Natural run formation: consecutive chunks already in queryname order
+        // extend one run instead of each becoming its own merge source.
+        let mut run_former: RunFormer<K> = RunFormer::default();
         let rayon_pool = self.build_sort_rayon_pool()?;
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
@@ -3294,8 +3574,6 @@ impl RawExternalSorter {
                 )?;
                 probe.post_drain(bstats, Some(pool.phase1_queue_depths()));
 
-                let chunk_path = namer.next_chunk_path()?;
-
                 timer.time_sort(|| {
                     use rayon::prelude::*;
                     // `entries` is in ingest order, and exact-queryname-key ties must keep
@@ -3308,20 +3586,22 @@ impl RawExternalSorter {
                     rayon_pool.install(|| entries.par_sort_unstable_by(|a, b| a.0.cmp(&b.0)));
                 });
 
-                // Write keyed temp file with parallel BGZF compression via worker pool.
-                let handle = timer.time_spill_write(|| {
-                    let mut writer = PooledChunkWriter::<K>::new(
-                        Arc::clone(&pool),
-                        &chunk_path,
-                        pool.spill_codec(),
-                    )?;
-                    for (key, record) in entries.drain(..) {
-                        writer.write_record(&key, record.as_ref())?;
-                    }
-                    writer.start_finish()
-                })?;
+                let bounds = chunk_bounds(&entries, |(k, _)| k.clone());
 
-                pending_spill = Some(PendingSpill { handle, chunk_path });
+                pending_spill = Some(Self::spill_chunk::<K>(
+                    &mut run_former,
+                    &chunk_files,
+                    bounds,
+                    &mut namer,
+                    &pool,
+                    &mut timer,
+                    |writer| {
+                        for (key, record) in entries.drain(..) {
+                            writer.write_record(&key, record.as_ref())?;
+                        }
+                        Ok(())
+                    },
+                )?);
 
                 memory_used = 0;
                 force_mi_collect();
@@ -3362,16 +3642,18 @@ impl RawExternalSorter {
                 rayon_pool.install(|| entries.par_sort_unstable_by(|a, b| a.0.cmp(&b.0)));
             });
 
-            timer.time_write_output(|| {
+            stats.output_records = timer.time_write_output(|| {
                 use crate::pooled_bam_writer::PooledBamWriter;
                 let output_header = self.create_output_header(header);
                 let mut writer = PooledBamWriter::new(Arc::clone(&pool), output, &output_header)?;
 
+                let mut written: u64 = 0;
                 for (_key, record) in entries {
                     writer.write_raw_record(&record)?;
+                    written += 1;
                 }
                 writer.finish()?;
-                Ok(())
+                Ok(written)
             })?;
         } else {
             // Sort remaining records into separate sub-array chunks (avoids
@@ -3428,13 +3710,14 @@ impl RawExternalSorter {
             let memory_chunks = MemorySources::Owned(keyed_chunks);
 
             let n_memory = memory_chunks.num_non_empty();
+            log_run_formation(timer.spill_count(), stats.runs_written);
             debug!(
                 "Phase 2: Merging {} chunks (keyed comparisons)...",
                 chunk_files.len() + n_memory
             );
 
             // Merge disk chunks + in-memory records using keyed comparisons
-            timer.time_merge(|| {
+            stats.output_records = timer.time_merge(|| {
                 self.merge_chunks_generic::<K>(
                     &chunk_files,
                     memory_chunks,
@@ -3446,7 +3729,6 @@ impl RawExternalSorter {
             })?;
         }
 
-        stats.output_records = stats.total_records;
         if let Ok(pool) = Arc::try_unwrap(pool) {
             pool.shutdown();
         }
@@ -3603,6 +3885,9 @@ impl RawExternalSorter {
             TemplateRecordBuffer::<K>::with_capacity(estimated_records, estimated_data_bytes);
         let mut namer = ChunkNamer::new(alloc);
         let mut pending_spill: Option<PendingSpill> = None;
+        // Natural run formation: consecutive chunks already in template order
+        // extend one run instead of each becoming its own merge source.
+        let mut run_former: RunFormer<K> = RunFormer::default();
         let rayon_pool = self.build_sort_rayon_pool()?;
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
@@ -3671,26 +3956,26 @@ impl RawExternalSorter {
                 )?;
                 probe.post_drain(probe_stats(&buffer), Some(pool.phase1_queue_depths()));
 
-                let chunk_path = namer.next_chunk_path()?;
-
                 timer.time_sort(|| {
                     rayon_pool.install(|| buffer.par_sort());
                 });
 
-                // Write keyed chunk with parallel BGZF compression via worker pool.
-                let handle = timer.time_spill_write(|| {
-                    let mut writer = PooledChunkWriter::<K>::new(
-                        Arc::clone(&pool),
-                        &chunk_path,
-                        pool.spill_codec(),
-                    )?;
-                    for (key, record) in buffer.iter_sorted_keyed() {
-                        writer.write_record(&key, record)?;
-                    }
-                    writer.start_finish()
-                })?;
+                let bounds = chunk_bounds(buffer.refs(), |r| r.key);
 
-                pending_spill = Some(PendingSpill { handle, chunk_path });
+                pending_spill = Some(Self::spill_chunk::<K>(
+                    &mut run_former,
+                    &chunk_files,
+                    bounds,
+                    &mut namer,
+                    &pool,
+                    &mut timer,
+                    |writer| {
+                        for (key, record) in buffer.iter_sorted_keyed() {
+                            writer.write_record(&key, record)?;
+                        }
+                        Ok(())
+                    },
+                )?);
 
                 buffer.clear();
                 force_mi_collect();
@@ -3727,16 +4012,18 @@ impl RawExternalSorter {
                 rayon_pool.install(|| buffer.par_sort());
             });
 
-            timer.time_write_output(|| {
+            stats.output_records = timer.time_write_output(|| {
                 use crate::pooled_bam_writer::PooledBamWriter;
                 let output_header = self.create_output_header(header);
                 let mut writer = PooledBamWriter::new(Arc::clone(&pool), output, &output_header)?;
 
+                let mut written: u64 = 0;
                 for record_bytes in buffer.iter_sorted() {
                     writer.write_raw_record(record_bytes)?;
+                    written += 1;
                 }
                 writer.finish()?;
-                Ok(())
+                Ok(written)
             })?;
         } else {
             // Sort remaining records into separate sub-array chunks (avoids
@@ -3756,10 +4043,11 @@ impl RawExternalSorter {
 
             let memory_chunks = MemorySources::Shared(memory_chunks);
             let n_memory = memory_chunks.num_non_empty();
+            log_run_formation(timer.spill_count(), stats.runs_written);
             debug!("Phase 2: Merging {} chunks...", chunk_files.len() + n_memory);
 
             // Merge using O(1) key comparisons
-            timer.time_merge(|| {
+            stats.output_records = timer.time_merge(|| {
                 self.merge_chunks_generic::<K>(
                     &chunk_files,
                     memory_chunks,
@@ -3771,7 +4059,6 @@ impl RawExternalSorter {
             })?;
         }
 
-        stats.output_records = stats.total_records;
         if let Ok(pool) = Arc::try_unwrap(pool) {
             pool.shutdown();
         }
@@ -4538,7 +4825,7 @@ impl RawExternalSorter {
         output: &Path,
         total_records: u64,
         pool: &Arc<SortWorkerPool>,
-    ) -> Result<noodles::bam::bai::Index> {
+    ) -> Result<(noodles::bam::bai::Index, u64)> {
         use crate::loser_tree::LoserTree;
         use crate::pooled_bam_writer::PooledBamWriter;
 
@@ -4564,7 +4851,7 @@ impl RawExternalSorter {
                     .finish_index()
             })?;
             debug!("Merge complete: 0 records merged");
-            return Ok(index);
+            return Ok((index, 0));
         }
 
         let mut tree = LoserTree::new(initial_keys);
@@ -4584,11 +4871,13 @@ impl RawExternalSorter {
             consumer.restart_stalls();
         }
         let loop_start = Instant::now();
+        let mut records_merged: u64 = 0;
         while tree.winner_is_active() {
             let winner = tree.winner();
             let src_idx = source_map[winner];
             let record_bytes = winner_record_bytes(&sources[src_idx], guard.consumer_ref())?;
             writer.write_raw_record(record_bytes)?;
+            records_merged += 1;
             merge_progress.log_if_needed(1);
 
             if let Some(key) = sources[src_idx].advance(guard.consumer_mut())? {
@@ -4638,7 +4927,7 @@ impl RawExternalSorter {
         );
 
         merge_progress.log_final();
-        Ok(index)
+        Ok((index, records_merged))
     }
 
     /// Create output header with appropriate sort order tags.
@@ -5158,6 +5447,129 @@ mod tests {
     use noodles::sam::header::record::value::Map;
     use noodles::sam::header::record::value::map::ReadGroup;
     use rstest::rstest;
+
+    // ========================================================================
+    // Record-count invariant
+    // ========================================================================
+
+    /// A failed permutation check must not leave a readable BAM behind.
+    ///
+    /// The output is finalized by the time the check runs, so it is a valid,
+    /// short BAM -- the most dangerous kind of failure output, because every
+    /// existence check and every reader accepts it. The rest of the crate
+    /// deletes on abort (`test_sort_records_producer_error_aborts`), and this
+    /// path has to as well or the error's own claim is false.
+    #[rstest]
+    #[case::index_written(true)]
+    #[case::no_index(false)]
+    fn record_count_mismatch_removes_the_output(#[case] write_index: bool) {
+        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let output = dir.path().join("out.bam");
+        let bai = fgumi_bam_io::bai_sidecar_path(&output);
+        std::fs::write(&output, b"a short but perfectly valid BAM").expect("write output");
+        std::fs::write(&bai, b"an index describing it").expect("write index");
+
+        let stats = RawSortStats { total_records: 100, output_records: 99, runs_written: 1 };
+        let err = enforce_record_count(&stats, &output, write_index)
+            .expect_err("a record-count mismatch must fail the sort");
+        let msg = format!("{err:#}");
+
+        assert!(!output.exists(), "the incomplete output must not survive the error");
+        assert!(msg.contains("read 100 but wrote 99"), "got: {msg}");
+        assert!(msg.contains("differ by 1"), "got: {msg}");
+        assert!(
+            msg.contains("has been removed"),
+            "the message must state what was done, not just what not to do: {msg}"
+        );
+        // The index describes a file that no longer exists, so it goes too --
+        // but only when this sort is the one that wrote it.
+        assert_eq!(
+            bai.exists(),
+            !write_index,
+            "index removal must follow write_index (write_index={write_index})"
+        );
+    }
+
+    /// stdout cannot be un-written, and `/dev/stdout` must certainly not be
+    /// unlinked. The error still fires; it just cannot claim a removal.
+    #[rstest]
+    #[case::dash("-")]
+    #[case::dev_stdout("/dev/stdout")]
+    fn record_count_mismatch_never_unlinks_stdout(#[case] output: &str) {
+        let stats = RawSortStats { total_records: 10, output_records: 4, runs_written: 1 };
+        let err = enforce_record_count(&stats, Path::new(output), false)
+            .expect_err("a record-count mismatch must fail the sort");
+        let msg = format!("{err:#}");
+
+        assert!(Path::new("/dev/stdout").exists(), "/dev/stdout must survive");
+        assert!(msg.contains("written to stdout"), "got: {msg}");
+        assert!(
+            !msg.contains("has been removed"),
+            "nothing was removed, so the message must not say so: {msg}"
+        );
+    }
+
+    /// A symlinked output is written *through* to the real file, so unlinking
+    /// the link would leave the short BAM exactly where a reader would find it.
+    #[test]
+    fn record_count_mismatch_removes_the_symlink_target() {
+        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let real = dir.path().join("real.bam");
+        let link = dir.path().join("link.bam");
+        std::fs::write(&real, b"a short but perfectly valid BAM").expect("write output");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+
+        let stats = RawSortStats { total_records: 10, output_records: 9, runs_written: 1 };
+        enforce_record_count(&stats, &link, false).expect_err("mismatch must fail the sort");
+
+        assert!(!real.exists(), "the file actually written must be the one removed");
+    }
+
+    /// A FIFO was written through, not created, so it is not this sort's to
+    /// unlink -- and the message must not claim otherwise.
+    #[test]
+    fn record_count_mismatch_leaves_a_non_regular_output_alone() {
+        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let fifo = dir.path().join("out.fifo");
+        let mkfifo =
+            std::process::Command::new("mkfifo").arg(&fifo).status().expect("failed to run mkfifo");
+        assert!(mkfifo.success(), "mkfifo failed");
+
+        let stats = RawSortStats { total_records: 10, output_records: 9, runs_written: 1 };
+        let err = enforce_record_count(&stats, &fifo, false).expect_err("mismatch must fail");
+        let msg = format!("{err:#}");
+
+        assert!(fifo.exists(), "a FIFO must not be unlinked by the sort that wrote through it");
+        assert!(msg.contains("could not be removed"), "got: {msg}");
+    }
+
+    /// The check must be silent and side-effect-free when the counts agree --
+    /// otherwise every successful sort would delete its own output.
+    #[test]
+    fn matching_record_counts_leave_the_output_alone() {
+        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let output = dir.path().join("out.bam");
+        std::fs::write(&output, b"the real output").expect("write output");
+
+        let stats = RawSortStats { total_records: 100, output_records: 100, runs_written: 1 };
+        enforce_record_count(&stats, &output, true).expect("matching counts must succeed");
+        assert!(output.exists(), "a successful sort must keep its output");
+    }
+
+    /// An output that is already gone is the state the removal wanted, so it
+    /// must not be reported as a removal failure on top of the count error.
+    #[test]
+    fn record_count_mismatch_tolerates_a_missing_output() {
+        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let output = dir.path().join("never-written.bam");
+
+        let stats = RawSortStats { total_records: 5, output_records: 0, runs_written: 0 };
+        let err = enforce_record_count(&stats, &output, true)
+            .expect_err("a record-count mismatch must fail the sort");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("has been removed"), "got: {msg}");
+        assert!(!msg.contains("could not be removed"), "absent is not a failure: {msg}");
+    }
 
     // ========================================================================
     // Merge diagnostics reporting
@@ -6099,7 +6511,7 @@ mod tests {
         use crate::worker_pool::phase;
 
         let fixture = empty_merge_fixture();
-        let index = fixture
+        let (index, records_merged) = fixture
             .sorter
             .merge_chunks_with_index::<RawCoordinateKey>(
                 std::slice::from_ref(&fixture.chunk),
@@ -6111,6 +6523,7 @@ mod tests {
             )
             .expect("empty indexed merge should succeed");
 
+        assert_eq!(records_merged, 0, "an empty merge must report zero records written");
         assert_eq!(
             count_bam_records(&fixture.output),
             0,
@@ -6482,6 +6895,66 @@ mod tests {
         RawReadAheadReader::new(reader).count() as u64
     }
 
+    /// Assert the output really is in `order`.
+    ///
+    /// Built on the crate's own [`crate::verify::verify_sort_order`] and the same
+    /// key extractors the merge uses, so it covers every sort order rather than
+    /// only coordinate. Record counts alone cannot distinguish "merged correctly"
+    /// from "emitted every record in the wrong order", which is what a bad append
+    /// would produce.
+    fn assert_sorted_in(order: SortOrder, path: &std::path::Path) {
+        use crate::keys::{RawQuerynameKey, RawQuerynameLexKey, SortContext};
+        use crate::reader::RawBamRecordReader;
+        use crate::verify::verify_sort_order;
+
+        let (_, header) = create_raw_bam_reader(path, 1).expect("open bam for header");
+        let new_reader = || {
+            let file = std::fs::File::open(path).expect("open bam");
+            let mut reader = RawBamRecordReader::new(file).expect("bam reader");
+            reader.skip_header().expect("skip header");
+            reader
+        };
+
+        let summary = match order {
+            SortOrder::Coordinate => {
+                let n_ref = u32::try_from(header.reference_sequences().len())
+                    .expect("reference sequence count fits in u32");
+                verify_sort_order(
+                    new_reader(),
+                    |bam| crate::inline::extract_coordinate_key_inline(bam, n_ref),
+                    |key, prev| key < prev,
+                )
+            }
+            SortOrder::Queryname(QuerynameComparator::Natural) => {
+                let ctx = SortContext::from_header(&header);
+                verify_sort_order(
+                    new_reader(),
+                    |bam| RawQuerynameKey::extract(bam, &ctx),
+                    |key, prev| key < prev,
+                )
+            }
+            SortOrder::Queryname(QuerynameComparator::Lexicographic) => {
+                let ctx = SortContext::from_header(&header);
+                verify_sort_order(
+                    new_reader(),
+                    |bam| RawQuerynameLexKey::extract(bam, &ctx),
+                    |key, prev| key < prev,
+                )
+            }
+            SortOrder::TemplateCoordinate => {
+                let lib_lookup = LibraryLookup::from_header(&header);
+                let hasher = cb_hasher();
+                verify_sort_order(
+                    new_reader(),
+                    |bam| extract_template_key_inline(bam, &lib_lookup, None, &hasher),
+                    |key, prev| key < prev,
+                )
+            }
+        };
+        let (_, violations, _) = summary.expect("verify should read the output");
+        assert_eq!(violations, 0, "{order:?}: output is not sorted");
+    }
+
     /// Verifies that sort with consolidation preserves all records.
     ///
     /// Uses a tiny memory limit and low `max_temp_files` to force many chunks and
@@ -6554,12 +7027,16 @@ mod tests {
 
         let num_pairs = 30;
         let mut builder = SamBuilder::new();
+        // Descending coordinates: ascending input would fold into a single
+        // run under natural run formation, and this test needs several
+        // chunks to exercise consolidation.
         for i in 0..num_pairs {
+            let descending = num_pairs - 1 - i;
             let _ = builder
                 .add_pair()
-                .name(&format!("read{i}"))
-                .start1(i * 200 + 1)
-                .start2(i * 200 + 101)
+                .name(&format!("read{descending:05}"))
+                .start1(descending * 200 + 1)
+                .start2(descending * 200 + 101)
                 .build();
         }
 
@@ -6580,9 +7057,9 @@ mod tests {
             .expect("sort should succeed");
 
         assert!(
-            stats.chunks_written >= 5,
+            stats.runs_written >= 5,
             "expected at least 5 chunks to exercise post-consolidation naming, got {}",
-            stats.chunks_written
+            stats.runs_written
         );
 
         // Count records in the output BAM to verify no data was lost
@@ -6744,11 +7221,11 @@ mod tests {
         // order instead — so a spilling limit that quietly stopped spilling
         // would leave that half uncovered with the test still green.
         assert_eq!(
-            stats.chunks_written > 0,
+            stats.runs_written > 0,
             memory_limit == SPILLING_MEMORY_LIMIT,
-            "a {memory_limit}-byte limit wrote {} spill chunk(s), which is not the path this \
+            "a {memory_limit}-byte limit wrote {} spill run(s), which is not the path this \
              case is meant to exercise",
-            stats.chunks_written
+            stats.runs_written
         );
 
         // The stable baseline: ingest order, stably sorted by the comparator's
@@ -6770,8 +7247,305 @@ mod tests {
         );
     }
 
-    /// Verifies that sort with many chunks exercises the pool-integrated
-    /// merge readers during the final merge phase (not just consolidation).
+    /// Sort `input` to `output` in `order`, spilling or not according to
+    /// `memory_limit`.
+    fn run_sort(
+        order: SortOrder,
+        input: &std::path::Path,
+        output: &std::path::Path,
+        memory_limit: usize,
+    ) -> RawSortStats {
+        RawExternalSorter::new(order)
+            .memory_limit(memory_limit)
+            .max_temp_files(0)
+            .threads(1)
+            .spill_codec(crate::codec::SpillCodec::Bgzf)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort(input, output)
+            .expect("sort should succeed")
+    }
+
+    /// Memory limit large enough that nothing spills.
+    const NO_SPILL_MEMORY: usize = 256 * 1024 * 1024;
+    /// Memory limit small enough to force many chunks.
+    const SPILL_MEMORY: usize = 8 * 1024;
+
+    /// Produce a BAM genuinely in `order`, by sorting without spilling.
+    ///
+    /// Built by sorting rather than by construction: no order implies another.
+    /// A coordinate-sorted file is not in template-coordinate order (template
+    /// keys derive from the earlier mate), and neither is in queryname order.
+    fn presorted_in(dir: &std::path::Path, order: SortOrder, num_pairs: usize) -> PathBuf {
+        let raw = build_ordered_bam(dir, num_pairs);
+        let sorted = dir.join(format!("presorted-{}.bam", order.header_so_tag()));
+        let stats = run_sort(order, &raw, &sorted, NO_SPILL_MEMORY);
+        assert_eq!(stats.runs_written, 0, "setup must not spill");
+        assert_eq!(stats.total_records, stats.output_records);
+        sorted
+    }
+
+    /// Every sort order: input already in the requested order must collapse to a
+    /// single run, because run formation is what makes that case cheap.
+    #[rstest::rstest]
+    #[case::coordinate(SortOrder::Coordinate)]
+    #[case::queryname_lex(SortOrder::Queryname(QuerynameComparator::Lexicographic))]
+    #[case::queryname_natural(SortOrder::Queryname(QuerynameComparator::Natural))]
+    #[case::template_coordinate(SortOrder::TemplateCoordinate)]
+    fn test_presorted_input_collapses_to_one_run(#[case] order: SortOrder) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let presorted = presorted_in(dir.path(), order, 300);
+        let output = dir.path().join("output.bam");
+
+        let stats = run_sort(order, &presorted, &output, SPILL_MEMORY);
+
+        assert_eq!(
+            stats.runs_written, 1,
+            "{order:?}: input already in this order should spill exactly one run, got {}",
+            stats.runs_written
+        );
+        assert_eq!(stats.total_records, stats.output_records, "{order:?}: lost records");
+        assert_eq!(count_bam_records(&output), 600, "{order:?}: wrong record count");
+        assert_sorted_in(order, &output);
+    }
+
+    /// Every sort order: input NOT in the requested order must not collapse.
+    /// This is the guard against run formation appending where it has no right to.
+    #[rstest::rstest]
+    #[case::coordinate(SortOrder::Coordinate)]
+    #[case::queryname_lex(SortOrder::Queryname(QuerynameComparator::Lexicographic))]
+    #[case::queryname_natural(SortOrder::Queryname(QuerynameComparator::Natural))]
+    #[case::template_coordinate(SortOrder::TemplateCoordinate)]
+    fn test_unsorted_input_never_collapses_to_one_run(#[case] order: SortOrder) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Descending coordinates with names that ascend independently, so the
+        // input is out of order for coordinate and template-coordinate, and its
+        // name order does not track its coordinate order either.
+        let input = build_shuffled_bam(dir.path(), 300);
+        let output = dir.path().join("output.bam");
+
+        let stats = run_sort(order, &input, &output, SPILL_MEMORY);
+
+        assert!(
+            stats.runs_written >= 2,
+            "{order:?}: unsorted input must not collapse into one run, got {}",
+            stats.runs_written
+        );
+        assert_eq!(stats.total_records, stats.output_records, "{order:?}: lost records");
+        assert_eq!(count_bam_records(&output), 600, "{order:?}: wrong record count");
+        assert_sorted_in(order, &output);
+    }
+
+    /// Every sort order: run formation must not change the output bytes.
+    ///
+    /// The appending path and the no-spill path must agree byte for byte. This is
+    /// the strongest available check -- it subsumes ordering, and for template it
+    /// is what confirms the buffer's lane-wise radix sort and the merge's
+    /// `K::cmp` agree, which run formation depends on.
+    #[rstest::rstest]
+    #[case::coordinate(SortOrder::Coordinate)]
+    #[case::queryname_lex(SortOrder::Queryname(QuerynameComparator::Lexicographic))]
+    #[case::queryname_natural(SortOrder::Queryname(QuerynameComparator::Natural))]
+    #[case::template_coordinate(SortOrder::TemplateCoordinate)]
+    fn test_run_formation_output_is_byte_identical(#[case] order: SortOrder) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let presorted = presorted_in(dir.path(), order, 300);
+
+        let spilled = dir.path().join("spilled.bam");
+        let in_memory = dir.path().join("in_memory.bam");
+
+        let spilled_stats = run_sort(order, &presorted, &spilled, SPILL_MEMORY);
+        assert_eq!(spilled_stats.runs_written, 1, "{order:?}: expected the appending path");
+
+        let in_memory_stats = run_sort(order, &presorted, &in_memory, NO_SPILL_MEMORY);
+        assert_eq!(in_memory_stats.runs_written, 0, "{order:?}: expected the no-spill path");
+
+        assert_eq!(
+            std::fs::read(&spilled).expect("read spilled"),
+            std::fs::read(&in_memory).expect("read in-memory"),
+            "{order:?}: appending runs changed the output bytes"
+        );
+    }
+
+    /// A BAM whose coordinates descend while its names ascend, so it is out of
+    /// order under every sort order this engine supports.
+    fn build_shuffled_bam(dir: &std::path::Path, num_pairs: usize) -> PathBuf {
+        use fgumi_sam::SamBuilder;
+        let mut builder = SamBuilder::new();
+        for i in 0..num_pairs {
+            let descending = num_pairs - 1 - i;
+            let _ = builder
+                .add_pair()
+                // Names descend too, so queryname order is also violated.
+                .name(&format!("read{descending:05}"))
+                .start1(descending * 200 + 1)
+                .start2(descending * 200 + 101)
+                .build();
+        }
+        let input = dir.join("shuffled.bam");
+        builder.write_bam(&input).expect("write bam");
+        input
+    }
+
+    /// Build a coordinate-ascending BAM: names and positions both increase.
+    ///
+    /// The starting point for every run-formation test. Tests that need input out
+    /// of order sort this into the order under test first (`presorted_in`) or use
+    /// [`build_shuffled_bam`].
+    fn build_ordered_bam(dir: &std::path::Path, num_pairs: usize) -> PathBuf {
+        use fgumi_sam::SamBuilder;
+        let mut builder = SamBuilder::new();
+        for i in 0..num_pairs {
+            let n = i;
+            let _ = builder
+                .add_pair()
+                .name(&format!("read{i:05}"))
+                .start1(n * 200 + 1)
+                .start2(n * 200 + 101)
+                .build();
+        }
+        let input = dir.join("input.bam");
+        builder.write_bam(&input).expect("write bam");
+        input
+    }
+
+    /// Build a coordinate BAM that ascends, drops once, then ascends again.
+    ///
+    /// The descent is placed past the first spill boundary so it closes an open
+    /// run rather than landing inside the first chunk, where sorting would
+    /// absorb it.
+    fn build_descent_bam(dir: &std::path::Path, num_pairs: usize) -> PathBuf {
+        use fgumi_sam::SamBuilder;
+        let mut builder = SamBuilder::new();
+        let half = num_pairs / 2;
+        for i in 0..num_pairs {
+            // Second half restarts low, so exactly one chunk boundary sees a key
+            // below the open run's last key.
+            let n = if i < half { i } else { i - half };
+            let _ = builder
+                .add_pair()
+                .name(&format!("read{i:05}"))
+                .start1(n * 200 + 1)
+                .start2(n * 200 + 101)
+                .build();
+        }
+        let input = dir.join("descent.bam");
+        builder.write_bam(&input).expect("write bam");
+        input
+    }
+
+    /// The case that distinguishes run formation from both extremes: a descent
+    /// closes the open run and opens exactly one more. Neither the all-sorted nor
+    /// the reverse-sorted test reaches [`RunFormer::place`]'s fresh-path branch
+    /// while a run is open -- one never leaves it, the other never enters it.
+    #[test]
+    fn test_descent_opens_exactly_one_more_run() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = build_descent_bam(dir.path(), 300);
+        let output = dir.path().join("output.bam");
+
+        let stats = run_sort(SortOrder::Coordinate, &input, &output, SPILL_MEMORY);
+
+        assert!(
+            stats.runs_written >= 2,
+            "a mid-stream descent must close the open run, got {} run(s)",
+            stats.runs_written
+        );
+        assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
+        assert_eq!(count_bam_records(&output), 600);
+        assert_sorted_in(SortOrder::Coordinate, &output);
+    }
+
+    /// Consolidation can merge the open run away, leaving `RunFormer` holding a
+    /// path that no longer means what it did. Appending there would duplicate or
+    /// drop records, so exercise it with consolidation actually enabled --
+    /// every other run-formation test disables it.
+    ///
+    /// Parameterized over every order because each reaches
+    /// [`RunFormer::place`]'s consolidation check with a different key type
+    /// through the same generic [`chunk_bounds`].
+    #[rstest::rstest]
+    #[case::coordinate(SortOrder::Coordinate)]
+    #[case::queryname_lex(SortOrder::Queryname(QuerynameComparator::Lexicographic))]
+    #[case::queryname_natural(SortOrder::Queryname(QuerynameComparator::Natural))]
+    #[case::template_coordinate(SortOrder::TemplateCoordinate)]
+    fn test_consolidation_while_a_run_is_open(#[case] order: SortOrder) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = build_descent_bam(dir.path(), 400);
+        let output = dir.path().join("output.bam");
+
+        let stats = RawExternalSorter::new(order)
+            .memory_limit(8 * 1024)
+            .max_temp_files(2) // small enough that consolidation can swallow the open run
+            .threads(1)
+            .spill_codec(crate::codec::SpillCodec::Bgzf)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort(&input, &output)
+            .expect("sort with consolidation should succeed");
+
+        assert_eq!(stats.total_records, stats.output_records, "{order:?}: lost records");
+        assert_eq!(count_bam_records(&output), 800, "{order:?}: wrong record count");
+        assert_sorted_in(order, &output);
+    }
+
+    /// Appending must work for both spill codecs. Zstd skips `ZSPILL_MAGIC` on
+    /// append -- a second magic mid-file would be read as frame data -- and that
+    /// branch is otherwise untested.
+    #[rstest::rstest]
+    #[case::bgzf(crate::codec::SpillCodec::Bgzf, 0)]
+    #[case::zstd(crate::codec::SpillCodec::Zstd, 1)]
+    fn test_append_across_spill_codecs(
+        #[case] codec: crate::codec::SpillCodec,
+        #[case] temp_compression: u32,
+    ) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = build_ordered_bam(dir.path(), 300);
+        let output = dir.path().join("output.bam");
+
+        let stats = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(8 * 1024)
+            .max_temp_files(0)
+            .threads(1)
+            .spill_codec(codec)
+            .temp_compression(temp_compression)
+            .output_compression(0)
+            .sort(&input, &output)
+            .expect("sort should succeed");
+
+        assert_eq!(stats.runs_written, 1, "sorted input should collapse to one run");
+        assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
+        assert_eq!(count_bam_records(&output), 600);
+        assert_sorted_in(SortOrder::Coordinate, &output);
+    }
+
+    /// The indexed path got run formation too, so cover appending there: the
+    /// merge sees one source instead of many while still emitting a BAI.
+    #[test]
+    fn test_appending_run_with_write_index() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = build_ordered_bam(dir.path(), 300);
+        let output = dir.path().join("output.bam");
+
+        let stats = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(8 * 1024)
+            .max_temp_files(0)
+            .threads(1)
+            .write_index(true)
+            .spill_codec(crate::codec::SpillCodec::Bgzf)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort(&input, &output)
+            .expect("indexed sort should succeed");
+
+        assert_eq!(stats.runs_written, 1, "sorted input should collapse to one run");
+        assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
+        assert_eq!(count_bam_records(&output), 600);
+        assert!(output.with_extension("bam.bai").exists(), "index should be written");
+    }
+
+    /// Verifies that sort with many chunks exercises the pool-integrated merge
+    /// readers during the final merge phase (not just consolidation).
     #[rstest::rstest]
     #[case::coordinate(SortOrder::Coordinate)]
     #[case::queryname(SortOrder::Queryname(QuerynameComparator::default()))]
@@ -6782,12 +7556,18 @@ mod tests {
 
         let num_pairs = 200;
         let mut builder = SamBuilder::new();
+        // Emit descending coordinates so the input is NOT already in coordinate
+        // order. Natural run formation appends a chunk to the open run whenever
+        // its keys all sort after it, so ascending input collapses to a single
+        // run -- and a single source exercises neither the k-way merge nor the
+        // reader semaphore this test exists to cover.
         for i in 0..num_pairs {
+            let descending = num_pairs - 1 - i;
             let _ = builder
                 .add_pair()
-                .name(&format!("read{i}"))
-                .start1(i * 200 + 1)
-                .start2(i * 200 + 101)
+                .name(&format!("read{descending:05}"))
+                .start1(descending * 200 + 1)
+                .start2(descending * 200 + 101)
                 .build();
         }
 
@@ -6812,9 +7592,9 @@ mod tests {
             .expect("sort should succeed");
 
         assert!(
-            stats.chunks_written >= 2,
+            stats.runs_written >= 2,
             "expected multiple chunks to exercise merge, got {}",
-            stats.chunks_written
+            stats.runs_written
         );
 
         let expected = (num_pairs * 2) as u64;
@@ -6984,9 +7764,9 @@ mod tests {
             .sort(&input, &output)
             .expect("sort should succeed");
         assert!(
-            stats.chunks_written > 0,
+            stats.runs_written > 0,
             "test must spill to disk so the oversized record is read back through the \
-             PoolDisk merge (slow path); got chunks_written = 0"
+             PoolDisk merge (slow path); got runs_written = 0"
         );
 
         let mut reader =
@@ -7128,7 +7908,7 @@ mod tests {
         assert_eq!(file_stats.total_records, stream_stats.total_records);
         assert_eq!(file_stats.output_records, stream_stats.output_records);
         assert_eq!(
-            file_stats.chunks_written, stream_stats.chunks_written,
+            file_stats.runs_written, stream_stats.runs_written,
             "stream path should spill exactly like the file path"
         );
         assert_eq!(
@@ -7585,12 +8365,15 @@ mod tests {
 
         let num_pairs = 200;
         let mut builder = SamBuilder::new();
+        // Descending coordinates so run formation does not collapse the input
+        // to one run; this test compares multi-chunk spill across temp dirs.
         for i in 0..num_pairs {
+            let descending = num_pairs - 1 - i;
             let _ = builder
                 .add_pair()
-                .name(&format!("read{i:05}"))
-                .start1(i * 200 + 1)
-                .start2(i * 200 + 101)
+                .name(&format!("read{descending:05}"))
+                .start1(descending * 200 + 1)
+                .start2(descending * 200 + 101)
                 .build();
         }
 
@@ -7614,7 +8397,7 @@ mod tests {
             .sort(&input, &output_multi)
             .expect("multi-dir sort should succeed");
 
-        assert!(stats_multi.chunks_written >= 2, "expected multiple spill chunks");
+        assert!(stats_multi.runs_written >= 2, "expected multiple spill runs");
 
         RawExternalSorter::new(SortOrder::Coordinate)
             .memory_limit(8 * 1024)
@@ -7669,7 +8452,7 @@ mod tests {
             .sort(&input, &output)
             .expect("indexed coordinate sort should succeed");
 
-        assert_eq!(stats.chunks_written, 0, "expected no spill for the in-memory path");
+        assert_eq!(stats.runs_written, 0, "expected no spill for the in-memory path");
         assert_eq!(collect_read_names(&output).len(), 40, "record count mismatch");
 
         let bai = fgumi_bam_io::bai_sidecar_path(&output);
@@ -7696,14 +8479,18 @@ mod tests {
         // so the index-emitting merge runs over Disk sources + the in-memory
         // chunk simultaneously (the mixed-source path the refactor must keep
         // byte-identical).
+        // Descending coordinates: the point is a merge over several Disk sources
+        // plus the in-memory chunk, and natural run formation would fold
+        // already-ascending input into one run, leaving nothing to merge.
         let num_pairs = 300;
         let mut builder = SamBuilder::new();
         for i in 0..num_pairs {
+            let descending = num_pairs - 1 - i;
             let _ = builder
                 .add_pair()
-                .name(&format!("read{i:05}"))
-                .start1(i * 200 + 1)
-                .start2(i * 200 + 101)
+                .name(&format!("read{descending:05}"))
+                .start1(descending * 200 + 1)
+                .start2(descending * 200 + 101)
                 .build();
         }
 
@@ -7722,7 +8509,7 @@ mod tests {
             .sort(&input, &output)
             .expect("indexed coordinate sort should succeed");
 
-        assert!(stats.chunks_written >= 2, "expected multiple spill chunks");
+        assert!(stats.runs_written >= 2, "expected multiple spill runs");
 
         // All records preserved.
         let names = collect_read_names(&output);
@@ -7793,7 +8580,7 @@ mod tests {
             .output_compression(0)
             .sort(&input, &output)
             .expect("indexed coordinate sort should succeed");
-        assert!(stats.chunks_written > 0, "test must spill so the indexed pool merge runs");
+        assert!(stats.runs_written > 0, "test must spill so the indexed pool merge runs");
 
         // Every record (including the oversized one) survives the merge.
         assert_eq!(count_bam_records(&output), 161);
@@ -8520,7 +9307,7 @@ mod tests {
                 .key_types(spec)
                 .sort(&input, &out)
                 .expect("sort");
-            (collect_record_bytes(&out), stats.chunks_written)
+            (collect_record_bytes(&out), stats.runs_written)
         };
 
         let (baseline, base_chunks) = sort_spilling("spill_full", KeyTypesSpec::Full);
@@ -8575,7 +9362,7 @@ mod tests {
                 .key_types(spec)
                 .sort(&input, &out)
                 .expect("sort");
-            (collect_record_bytes(&out), stats.chunks_written)
+            (collect_record_bytes(&out), stats.runs_written)
         };
 
         let (baseline, base_chunks) = sort_spilling("spill_full_baseline", KeyTypesSpec::Full);

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -89,6 +89,31 @@ pub struct SortStats {
     pub chunks_written: usize,
 }
 
+/// Whether `header` already declares the order a sort to `sort_order` would produce.
+///
+/// Used only to warn: re-sorting a file into the order it is already in is
+/// usually unintended, and it is also the shape the k-way merge handles worst,
+/// because chunking an already-ordered input spills disjoint runs that the merge
+/// must drain one at a time rather than interleave.
+///
+/// Deliberately conservative. `SO` must match, and when the order defines a
+/// sub-sort tag the input's `SS` must match too — so a `queryname` input with no
+/// `SS` does not warn for either queryname flavor, since the header does not say
+/// which one it is. A header that lies still gets sorted; nothing here skips work.
+pub(crate) fn header_declares_order(header: &Header, sort_order: keys::SortOrder) -> bool {
+    let Some(hd) = header.header() else {
+        return false;
+    };
+    let field = |tag| hd.other_fields().get(&tag).map(ToString::to_string);
+    if field(header_tag::SORT_ORDER).as_deref() != Some(sort_order.header_so_tag()) {
+        return false;
+    }
+    match sort_order.header_ss_tag() {
+        None => true,
+        Some(expected) => field(header_tag::SUBSORT_ORDER).as_deref() == Some(expected),
+    }
+}
+
 /// Create an output header with appropriate sort order tags (SO, GO, SS).
 ///
 /// Preserves all existing header content (reference sequences, read groups, programs,
@@ -213,6 +238,98 @@ mod tests {
         assert_eq!(stats.total_records, 0);
         assert_eq!(stats.output_records, 0);
         assert_eq!(stats.chunks_written, 0);
+    }
+
+    /// Build a header whose `@HD` carries the given SO/SS values.
+    fn header_with_sort_tags(so: Option<&str>, ss: Option<&str>) -> Header {
+        let mut builder = Map::<noodles::sam::header::record::value::map::Header>::builder();
+        if let Some(so) = so {
+            builder = builder.insert(header_tag::SORT_ORDER, BString::from(so));
+        }
+        if let Some(ss) = ss {
+            builder = builder.insert(header_tag::SUBSORT_ORDER, BString::from(ss));
+        }
+        Header::builder().set_header(builder.build().expect("valid header")).build()
+    }
+
+    #[test]
+    fn test_header_declares_order_matches_coordinate() {
+        let header = header_with_sort_tags(Some("coordinate"), None);
+        assert!(header_declares_order(&header, keys::SortOrder::Coordinate));
+    }
+
+    #[test]
+    fn test_header_declares_order_rejects_a_different_order() {
+        let header = header_with_sort_tags(Some("coordinate"), None);
+        assert!(!header_declares_order(&header, keys::SortOrder::TemplateCoordinate));
+        assert!(!header_declares_order(
+            &header,
+            keys::SortOrder::Queryname(keys::QuerynameComparator::Natural)
+        ));
+    }
+
+    #[test]
+    fn test_header_declares_order_needs_no_hd_line() {
+        let header = Header::builder().build();
+        assert!(!header_declares_order(&header, keys::SortOrder::Coordinate));
+    }
+
+    /// A `queryname` header with no `SS` does not say *which* queryname order it
+    /// is in, so neither flavor may claim it. Warning here would fire on every
+    /// `samtools sort -n` output regardless of which comparator was requested.
+    #[test]
+    fn test_header_declares_order_queryname_without_subsort_is_ambiguous() {
+        let header = header_with_sort_tags(Some("queryname"), None);
+        assert!(!header_declares_order(
+            &header,
+            keys::SortOrder::Queryname(keys::QuerynameComparator::Natural)
+        ));
+        assert!(!header_declares_order(
+            &header,
+            keys::SortOrder::Queryname(keys::QuerynameComparator::Lexicographic)
+        ));
+    }
+
+    #[test]
+    fn test_header_declares_order_discriminates_queryname_flavors() {
+        let natural = header_with_sort_tags(Some("queryname"), Some("queryname:natural"));
+        assert!(header_declares_order(
+            &natural,
+            keys::SortOrder::Queryname(keys::QuerynameComparator::Natural)
+        ));
+        assert!(!header_declares_order(
+            &natural,
+            keys::SortOrder::Queryname(keys::QuerynameComparator::Lexicographic)
+        ));
+    }
+
+    /// Template-coordinate shares `SO:unsorted` with plain unsorted input, so the
+    /// sub-sort tag is the only thing that distinguishes them.
+    #[test]
+    fn test_header_declares_order_template_coordinate_requires_subsort() {
+        let bare = header_with_sort_tags(Some("unsorted"), None);
+        assert!(!header_declares_order(&bare, keys::SortOrder::TemplateCoordinate));
+
+        let tagged = header_with_sort_tags(Some("unsorted"), Some("unsorted:template-coordinate"));
+        assert!(header_declares_order(&tagged, keys::SortOrder::TemplateCoordinate));
+    }
+
+    /// The predicate must agree with what `create_output_header` writes, or fgumi
+    /// would fail to recognise its own output as already sorted.
+    #[test]
+    fn test_header_declares_order_accepts_fgumi_own_output() {
+        for order in [
+            keys::SortOrder::Coordinate,
+            keys::SortOrder::TemplateCoordinate,
+            keys::SortOrder::Queryname(keys::QuerynameComparator::Natural),
+            keys::SortOrder::Queryname(keys::QuerynameComparator::Lexicographic),
+        ] {
+            let written = create_output_header(order, &Header::builder().build());
+            assert!(
+                header_declares_order(&written, order),
+                "fgumi's own {order:?} output header should be recognised"
+            );
+        }
     }
 
     #[test]

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -85,16 +85,23 @@ pub struct SortStats {
     pub total_records: u64,
     /// Records written to output.
     pub output_records: u64,
-    /// Number of temporary chunk files written.
-    pub chunks_written: usize,
+    /// Number of spill *runs* written.
+    ///
+    /// A run is one temp file, built from one or more sorted chunks: consecutive
+    /// chunks that are already in order extend the open run rather than each
+    /// starting a file. So an input already in the requested order spills a single
+    /// run, and this is below the number of chunks that were spilled.
+    pub runs_written: usize,
 }
 
 /// Whether `header` already declares the order a sort to `sort_order` would produce.
 ///
 /// Used only to warn: re-sorting a file into the order it is already in is
-/// usually unintended, and it is also the shape the k-way merge handles worst,
-/// because chunking an already-ordered input spills disjoint runs that the merge
-/// must drain one at a time rather than interleave.
+/// usually unintended. It is no longer the shape the merge handles *worst* --
+/// natural run formation collapses an already-ordered input to a single spill
+/// run, so there is effectively no k-way merge left to do -- but it is still a
+/// full read, sort, spill and rewrite of every record to reproduce the order the
+/// input already had.
 ///
 /// Deliberately conservative. `SO` must match, and when the order defines a
 /// sub-sort tag the input's `SS` must match too — so a `queryname` input with no
@@ -237,7 +244,7 @@ mod tests {
         let stats = SortStats::default();
         assert_eq!(stats.total_records, 0);
         assert_eq!(stats.output_records, 0);
-        assert_eq!(stats.chunks_written, 0);
+        assert_eq!(stats.runs_written, 0);
     }
 
     /// Build a header whose `@HD` carries the given SO/SS values.

--- a/crates/fgumi-sort/src/merge_stalls.rs
+++ b/crates/fgumi-sort/src/merge_stalls.rs
@@ -13,8 +13,10 @@
 //!
 //! - every file's reorder buffer was at [`PHASE2_DECOMP_CAP`] (the consumer is
 //!   behind, and the pool is correctly throttled),
-//! - every file's raw FIFO was at [`PHASE2_RAW_CAP`] (decompression is behind
-//!   the read side, so read-ahead depth is the binding constraint),
+//! - every file's raw FIFO was at its read-ahead allowance -- [`PHASE2_RAW_CAP`],
+//!   or [`PHASE2_STARVING_RAW_CAP`] for the file at the drain frontier
+//!   (decompression is behind the read side, so read-ahead depth is the binding
+//!   constraint),
 //! - every file with data left already had a peer worker inside a disk read
 //!   (waiting on I/O, which wants read concurrency rather than deeper buffers),
 //!   or
@@ -22,6 +24,7 @@
 //!
 //! [`PHASE2_DECOMP_CAP`]: crate::worker_pool::PHASE2_DECOMP_CAP
 //! [`PHASE2_RAW_CAP`]: crate::worker_pool::PHASE2_RAW_CAP
+//! [`PHASE2_STARVING_RAW_CAP`]: crate::worker_pool::PHASE2_STARVING_RAW_CAP
 //!
 //! The file-scan loop already distinguishes all four and then discards the
 //! distinction. This module keeps it, plus two things nothing currently measures
@@ -35,12 +38,15 @@
 //!   record" figure folds in with it. Censusing the other files at that moment
 //!   is what separates head-of-line blocking (this file starved, the rest at
 //!   cap) from a uniformly starved pool.
-//! - **How late workers discover work.** Nothing ever unparks a pool worker: the
-//!   wake path runs one way, workers to main thread. A worker that has backed
-//!   off to [`MAX_BACKOFF_US`](crate::worker_pool::MAX_BACKOFF_US) therefore
-//!   finds newly-available work up to a millisecond after it appears, and that
-//!   delay is indistinguishable from I/O latency in every counter that exists
-//!   today.
+//! - **How late workers discover work.** One wake path runs main thread to
+//!   workers: when a file's reorder buffer drains, the consumer unparks a single
+//!   worker through
+//!   [`SharedPipelineState::wake_one_worker`](crate::worker_pool::SharedPipelineState).
+//!   Everything else a worker could pick up arrives with no wake at all, and
+//!   that is what this measures: a worker that has backed off to
+//!   [`MAX_BACKOFF_US`](crate::worker_pool::MAX_BACKOFF_US) finds unannounced
+//!   work up to a millisecond after it appears, and that delay is
+//!   indistinguishable from I/O latency in every other counter.
 //!
 //! # Cost
 //!
@@ -91,16 +97,18 @@ pub(crate) enum Phase2Skip {
     /// not the gap-filler the consumer is stuck on. Backpressure working as
     /// intended: the consumer is behind, not the pool.
     DecompCapped,
-    /// The raw FIFO is at `PHASE2_RAW_CAP` while the reorder buffer still has
-    /// room, so decompression — not the consumer — is what this file is waiting
-    /// on.
+    /// The raw FIFO is at this file's read-ahead allowance while the reorder
+    /// buffer still has room, so decompression — not the consumer — is what this
+    /// file is waiting on. The allowance is `PHASE2_RAW_CAP` for every file
+    /// except the one at the drain frontier, which is allowed
+    /// `PHASE2_STARVING_RAW_CAP`.
     ///
     /// Reported only when the decompress half is *not* capped; when both are
     /// full the reason is [`FullyBuffered`](Self::FullyBuffered), because a full
     /// raw FIFO is the downstream consequence of workers having stopped
-    /// decompressing. A zero count here therefore does **not** mean
-    /// `PHASE2_RAW_CAP` was never reached — only that it was never the root
-    /// reason. Misreading that cost real time once already.
+    /// decompressing. A zero count here therefore does **not** mean the
+    /// allowance was never reached — only that it was never the root reason.
+    /// Misreading that cost real time once already.
     RawFull,
     /// Both caps are full: the consumer is behind, and the read-ahead behind it
     /// has backed up to its own limit. The file is as buffered as it can be.
@@ -181,7 +189,7 @@ pub(crate) enum ReadSkip {
     ReaderEof,
     /// The raw FIFO's `try_lock` lost a race, so its depth is unknown.
     RawLockContended,
-    /// The raw FIFO is at `PHASE2_RAW_CAP`.
+    /// The raw FIFO is at this file's read-ahead allowance.
     RawFull,
 }
 
@@ -426,6 +434,70 @@ pub(crate) fn wake_bucket(backoff_us: u64) -> usize {
     WAKE_BUCKET_US.iter().position(|&us| backoff_us <= us).unwrap_or(last)
 }
 
+/// Which set of wake counters a wait belongs to.
+///
+/// A wait is filed under the phase the worker believed it was in when it *took*
+/// the wait — a value decided once, at the top of the worker's iteration, and
+/// carried through to the record. That is what makes the merge's share of these
+/// counters race-free: a Phase 1 wait lands in `Other` however late the worker
+/// gets around to recording it.
+///
+/// Subtracting a baseline snapshot taken at the phase boundary cannot promise
+/// that, which is why it is no longer how the merge is scoped. The boundary can
+/// fall between a worker's phase load and its record, and the wait then lands
+/// *after* the baseline while still belonging to the phase before it — charging
+/// the merge for a wait taken before it started, and leaving a productive wait in
+/// the merge window whose matching sleep was subtracted away.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WakePhase {
+    /// Every phase other than the merge, principally Phase 1's read/sort/spill.
+    Other = 0,
+    /// Phase 2: the k-way merge, the window [`WakeLatencyStats::snapshot`] is
+    /// asked for by the merge diagnostics.
+    Merge = 1,
+}
+
+impl WakePhase {
+    /// Number of variants, so the counter arrays indexed by `self as usize`
+    /// cannot fall behind the enum. Sizing them with a literal instead lets a
+    /// new variant compile and then index out of bounds inside
+    /// [`WakeLatencyStats::record_sleep`] -- on a worker thread, where it
+    /// surfaces only as a panicked sort worker.
+    pub(crate) const COUNT: usize = 2;
+}
+
+// Keeps `COUNT` honest: the match is exhaustive, so a third variant fails to
+// compile here instead of indexing past the end of the counter arrays at run
+// time.
+const _: () = {
+    const fn assert_count(phase: WakePhase) -> usize {
+        match phase {
+            WakePhase::Other => 0,
+            WakePhase::Merge => WakePhase::COUNT - 1,
+        }
+    }
+    assert!(assert_count(WakePhase::Merge) == 1);
+};
+
+/// One phase's worth of [`WakeLatencyStats`] counters.
+#[derive(Debug, Default)]
+struct WakeCounters {
+    /// Nanoseconds slept, by backoff level.
+    idle_nanos: [AtomicU64; WAKE_BUCKET_US.len()],
+    /// Sleeps, by backoff level.
+    sleeps: [AtomicU64; WAKE_BUCKET_US.len()],
+    /// Waits that were immediately followed by a successful step, bucketed by
+    /// how long they *actually* lasted.
+    productive_sleeps: [AtomicU64; WAKE_BUCKET_US.len()],
+    /// Observed nanoseconds of those waits.
+    ///
+    /// Kept alongside the count because the count alone can only be turned into
+    /// a duration via the bucket's nominal width, and since waits became
+    /// `park_timeout` an `unpark` can end one at any point. See
+    /// [`WakeLatencyStats::record_productive_sleep`].
+    productive_nanos: [AtomicU64; WAKE_BUCKET_US.len()],
+}
+
 /// How long workers sleep, and how much of that sleep precedes finding work.
 ///
 /// The second half is the point. Idle time alone cannot distinguish a worker
@@ -433,59 +505,54 @@ pub(crate) fn wake_bucket(backoff_us: u64) -> usize {
 /// becoming available, and only the latter is a cost the pipeline pays. A
 /// successful step recorded against a 1 ms bucket says the work was found no
 /// sooner than a millisecond after the worker last looked.
+///
+/// The pool exists for the whole sort, so a single running total would include
+/// Phase 1's sleeps: on a measured run, 1815s of "deep-sleep worker-seconds"
+/// against a merge that only had 8 x 305s = 2442 worker-seconds of capacity in
+/// the first place. Counters are therefore kept per [`WakePhase`], so the merge
+/// reads its own and nothing else's.
 #[derive(Debug, Default)]
 pub(crate) struct WakeLatencyStats {
-    /// Nanoseconds slept, by backoff level.
-    idle_nanos: [AtomicU64; WAKE_BUCKET_US.len()],
-    /// Sleeps, by backoff level.
-    sleeps: [AtomicU64; WAKE_BUCKET_US.len()],
-    /// Sleeps that were immediately followed by a successful step.
-    productive_sleeps: [AtomicU64; WAKE_BUCKET_US.len()],
+    /// One set of counters per [`WakePhase`], indexed by its discriminant.
+    by_phase: [WakeCounters; WakePhase::COUNT],
 }
 
 impl WakeLatencyStats {
-    /// Record a sleep of `idle_nanos` at backoff level `backoff_us`.
-    pub(crate) fn record_sleep(&self, backoff_us: u64, idle_nanos: u64) {
+    /// Record a sleep of `idle_nanos` at backoff level `backoff_us`, taken in `phase`.
+    pub(crate) fn record_sleep(&self, phase: WakePhase, backoff_us: u64, idle_nanos: u64) {
+        let counters = &self.by_phase[phase as usize];
         let b = wake_bucket(backoff_us);
-        self.idle_nanos[b].fetch_add(idle_nanos, Ordering::Relaxed);
-        self.sleeps[b].fetch_add(1, Ordering::Relaxed);
+        counters.idle_nanos[b].fetch_add(idle_nanos, Ordering::Relaxed);
+        counters.sleeps[b].fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Record that the sleep at `backoff_us` was followed by finding work.
-    pub(crate) fn record_productive_sleep(&self, backoff_us: u64) {
-        self.productive_sleeps[wake_bucket(backoff_us)].fetch_add(1, Ordering::Relaxed);
-    }
-
-    pub(crate) fn snapshot(&self) -> WakeLatencyReport {
-        WakeLatencyReport {
-            idle_nanos: std::array::from_fn(|i| self.idle_nanos[i].load(Ordering::Relaxed)),
-            sleeps: std::array::from_fn(|i| self.sleeps[i].load(Ordering::Relaxed)),
-            productive_sleeps: std::array::from_fn(|i| {
-                self.productive_sleeps[i].load(Ordering::Relaxed)
-            }),
-        }
-    }
-}
-
-impl WakeLatencyReport {
-    /// This report minus `baseline`, i.e. what accumulated between them.
+    /// Record that a wait of `observed_nanos`, taken in `phase`, was followed by
+    /// finding work.
     ///
-    /// The pool exists for the whole sort, so these counters include Phase 1's
-    /// sleeps. Reporting the running total against merge wall clock overstates
-    /// the merge's share -- on a measured run, 1815s of "deep-sleep
-    /// worker-seconds" against a merge that only had 8 x 305s = 2442
-    /// worker-seconds of capacity in the first place. Subtracting a snapshot
-    /// taken at the phase boundary is what makes the figure comparable to the
-    /// numbers printed beside it.
-    #[must_use]
-    pub fn since(self, baseline: Self) -> Self {
-        Self {
-            idle_nanos: std::array::from_fn(|i| {
-                self.idle_nanos[i].saturating_sub(baseline.idle_nanos[i])
-            }),
-            sleeps: std::array::from_fn(|i| self.sleeps[i].saturating_sub(baseline.sleeps[i])),
+    /// Bucketed by the observed duration, not by the backoff level that was
+    /// requested. Since waits became `park_timeout`,
+    /// [`SharedPipelineState::wake_one_worker`](crate::worker_pool::SharedPipelineState)
+    /// can end a 1 ms wait after a few microseconds -- and charging that to the
+    /// 1 ms bucket would report discovery lag the wake had just eliminated,
+    /// making the pool look worst exactly where this path works best.
+    pub(crate) fn record_productive_sleep(&self, phase: WakePhase, observed_nanos: u64) {
+        let counters = &self.by_phase[phase as usize];
+        let b = wake_bucket(observed_nanos / 1_000);
+        counters.productive_sleeps[b].fetch_add(1, Ordering::Relaxed);
+        counters.productive_nanos[b].fetch_add(observed_nanos, Ordering::Relaxed);
+    }
+
+    /// The counters for `phase` alone.
+    pub(crate) fn snapshot(&self, phase: WakePhase) -> WakeLatencyReport {
+        let counters = &self.by_phase[phase as usize];
+        WakeLatencyReport {
+            idle_nanos: std::array::from_fn(|i| counters.idle_nanos[i].load(Ordering::Relaxed)),
+            sleeps: std::array::from_fn(|i| counters.sleeps[i].load(Ordering::Relaxed)),
             productive_sleeps: std::array::from_fn(|i| {
-                self.productive_sleeps[i].saturating_sub(baseline.productive_sleeps[i])
+                counters.productive_sleeps[i].load(Ordering::Relaxed)
+            }),
+            productive_nanos: std::array::from_fn(|i| {
+                counters.productive_nanos[i].load(Ordering::Relaxed)
             }),
         }
     }
@@ -498,8 +565,10 @@ pub struct WakeLatencyReport {
     pub idle_nanos: [u64; WAKE_BUCKET_US.len()],
     /// Sleeps, by backoff level.
     pub sleeps: [u64; WAKE_BUCKET_US.len()],
-    /// Sleeps immediately followed by a successful step, by backoff level.
+    /// Waits immediately followed by a successful step, by observed duration.
     pub productive_sleeps: [u64; WAKE_BUCKET_US.len()],
+    /// Observed nanoseconds of those waits, by the same bucketing.
+    pub productive_nanos: [u64; WAKE_BUCKET_US.len()],
 }
 
 impl WakeLatencyReport {
@@ -521,9 +590,16 @@ impl WakeLatencyReport {
 
     /// Estimated worker-seconds lost to discovering work late.
     ///
-    /// A sleep followed by a successful step means the work was there when the
-    /// worker woke and may have arrived at any point during the sleep, so half
-    /// the sleep is the expected lag under a uniform arrival assumption.
+    /// A wait followed by a successful step means the work was there when the
+    /// worker woke and may have arrived at any point during it, so half the
+    /// wait is the expected lag under a uniform arrival assumption.
+    ///
+    /// Computed from the *observed* wait, not the requested backoff level. Since
+    /// waits became `park_timeout`, an `unpark` from
+    /// [`SharedPipelineState::wake_one_worker`](crate::worker_pool::SharedPipelineState)
+    /// can cut a 1 ms wait to microseconds; charging the nominal level would
+    /// report that truncated wait as a full millisecond of lag, i.e. attribute
+    /// to discovery latency exactly the latency the wake removed.
     ///
     /// **This is per-worker discovery lag, not pipeline delay.** It only holds
     /// the merge up when every worker is asleep at once; with eight workers
@@ -534,22 +610,22 @@ impl WakeLatencyReport {
     #[must_use]
     #[allow(
         clippy::cast_precision_loss,
-        reason = "sleep counts stay far below 2^52 on any real sort"
+        reason = "nanosecond totals stay far below 2^52 on any real sort"
     )]
     pub fn estimated_discovery_lag_secs(self) -> f64 {
-        self.productive_sleeps
-            .iter()
-            .zip(WAKE_BUCKET_US)
-            .map(|(&n, us)| n as f64 * (us as f64 / 2.0) / 1e6)
-            .sum()
+        self.productive_nanos.iter().sum::<u64>() as f64 / 2.0 / 1e9
     }
 
-    /// Worker-seconds slept at the deepest backoff levels.
+    /// Worker-seconds spent waiting at the deepest *requested* backoff levels.
     ///
-    /// The pool of idle time that discovery lag is drawn from. If this is small,
-    /// [`Self::estimated_discovery_lag_secs`] cannot be large no matter how the
-    /// productive sleeps fall, which makes it a quick sanity check on the
-    /// estimate rather than a second measurement of it.
+    /// The pool of idle time most of the discovery lag is drawn from, printed
+    /// beside it for scale: a lag that is a rounding error against this is not
+    /// worth chasing. Not a strict bound on
+    /// [`Self::estimated_discovery_lag_secs`] — that sums productive waits at
+    /// every observed duration, including ones a shallow backoff produced — and
+    /// the two are bucketed differently on purpose: this by the level requested,
+    /// so it describes the backoff policy, and the lag by the duration observed,
+    /// so an unparked wait costs what it actually cost.
     #[must_use]
     #[allow(
         clippy::cast_precision_loss,
@@ -1310,14 +1386,14 @@ mod tests {
         let stats = WakeLatencyStats::default();
         // 1000 sleeps at 1 ms that each found work: 1000 x 0.5 ms = 0.5 s.
         for _ in 0..1000 {
-            stats.record_sleep(1000, 1_000_000);
-            stats.record_productive_sleep(1000);
+            stats.record_sleep(WakePhase::Merge, 1000, 1_000_000);
+            stats.record_productive_sleep(WakePhase::Merge, 1_000_000);
         }
         // Sleeps that found nothing cost the pipeline nothing and must not count.
         for _ in 0..1000 {
-            stats.record_sleep(1000, 1_000_000);
+            stats.record_sleep(WakePhase::Merge, 1000, 1_000_000);
         }
-        let report = stats.snapshot();
+        let report = stats.snapshot(WakePhase::Merge);
         assert!((report.estimated_discovery_lag_secs() - 0.5).abs() < 1e-9);
         assert_eq!(report.sleeps[7], 2000);
     }
@@ -1326,46 +1402,102 @@ mod tests {
     fn test_deep_sleep_wake_share() {
         let stats = WakeLatencyStats::default();
         for _ in 0..3 {
-            stats.record_productive_sleep(1000);
+            stats.record_productive_sleep(WakePhase::Merge, 1_000_000);
         }
-        stats.record_productive_sleep(10);
-        assert!((stats.snapshot().deep_sleep_wake_share() - 0.75).abs() < 1e-9);
+        stats.record_productive_sleep(WakePhase::Merge, 10_000);
+        assert!((stats.snapshot(WakePhase::Merge).deep_sleep_wake_share() - 0.75).abs() < 1e-9);
+    }
+
+    /// A wait cut short by `wake_one_worker` must be charged what it cost, not
+    /// what it asked for.
+    ///
+    /// Waits are `park_timeout`, so an unpark can end a 1 ms backoff after
+    /// microseconds. Bucketing by the requested level would book each of these
+    /// as a full millisecond and report ~0.5 s of discovery lag — attributing to
+    /// late discovery precisely the latency the wake removed, so the metric
+    /// would look worst exactly where this path works best.
+    #[test]
+    fn test_discovery_lag_uses_the_observed_wait_not_the_requested_backoff() {
+        let stats = WakeLatencyStats::default();
+        // 1000 waits that asked for 1 ms but were unparked after 5 us.
+        for _ in 0..1000 {
+            stats.record_sleep(WakePhase::Merge, 1000, 5_000);
+            stats.record_productive_sleep(WakePhase::Merge, 5_000);
+        }
+        let report = stats.snapshot(WakePhase::Merge);
+
+        // 1000 x 5us / 2 = 2.5 ms, not the 500 ms the nominal level implies.
+        assert!(
+            (report.estimated_discovery_lag_secs() - 0.0025).abs() < 1e-9,
+            "got {}",
+            report.estimated_discovery_lag_secs()
+        );
+        assert_eq!(report.productive_sleep_count(), 1000);
+        assert!(
+            (report.deep_sleep_wake_share() - 0.0).abs() < f64::EPSILON,
+            "a 5us wait is not a deep sleep, whatever backoff level requested it"
+        );
     }
 
     /// Phase 1's sleeps must not be charged to the merge.
     #[test]
-    fn test_wake_report_subtracts_a_phase_boundary_baseline() {
+    fn test_the_merge_report_holds_only_the_merges_own_waits() {
         let stats = WakeLatencyStats::default();
         for _ in 0..100 {
-            stats.record_sleep(1000, 1_000_000);
-            stats.record_productive_sleep(1000);
+            stats.record_sleep(WakePhase::Other, 1000, 1_000_000);
+            stats.record_productive_sleep(WakePhase::Other, 1_000_000);
         }
-        let at_merge_start = stats.snapshot();
         for _ in 0..10 {
-            stats.record_sleep(1000, 1_000_000);
-            stats.record_productive_sleep(1000);
+            stats.record_sleep(WakePhase::Merge, 1000, 1_000_000);
+            stats.record_productive_sleep(WakePhase::Merge, 1_000_000);
         }
-        let merge_only = stats.snapshot().since(at_merge_start);
+        let merge_only = stats.snapshot(WakePhase::Merge);
         assert_eq!(merge_only.sleeps[7], 10, "only the merge's sleeps may be counted");
         assert!((merge_only.estimated_discovery_lag_secs() - 0.005).abs() < 1e-9);
-        // The running total is still 110; `since` must not mutate the source.
-        assert_eq!(stats.snapshot().sleeps[7], 110);
+        // Phase 1's counters are untouched and still readable in their own right.
+        assert_eq!(stats.snapshot(WakePhase::Other).sleeps[7], 100);
     }
 
-    /// A counter that somehow went backwards must clamp rather than wrap into a
-    /// nonsensical multi-century total.
+    /// The race that a phase-boundary baseline could not close: a worker loads
+    /// `PHASE1`, the main thread flips the pool to `PHASE2` (which is where the
+    /// baseline used to be pinned), and only *then* does the worker record the
+    /// wait it took back in Phase 1.
+    ///
+    /// Order is the whole test — every record here happens after the transition,
+    /// which is exactly when a baseline subtraction would have swept the Phase 1
+    /// wait into the merge. Filing by the phase carried from the worker's load
+    /// makes the ordering irrelevant, so this holds for any interleaving rather
+    /// than merely for the one a threaded test happened to produce.
     #[test]
-    fn test_wake_report_since_saturates() {
+    fn test_a_phase1_wait_recorded_after_the_merge_began_stays_out_of_the_merge() {
         let stats = WakeLatencyStats::default();
-        stats.record_sleep(1000, 1_000_000);
-        let later = stats.snapshot();
-        let empty = WakeLatencyStats::default().snapshot();
-        assert_eq!(empty.since(later).sleeps[7], 0);
+
+        // The merge has begun and taken one short wait of its own.
+        stats.record_sleep(WakePhase::Merge, 10, 5_000);
+        stats.record_productive_sleep(WakePhase::Merge, 5_000);
+
+        // A worker that loaded PHASE1 before the flip now records its wait.
+        stats.record_sleep(WakePhase::Other, 1000, 1_000_000);
+        stats.record_productive_sleep(WakePhase::Other, 1_000_000);
+
+        let merge = stats.snapshot(WakePhase::Merge);
+        assert_eq!(
+            merge.idle_nanos.iter().sum::<u64>(),
+            5_000,
+            "the Phase 1 wait must not appear in the merge's idle time"
+        );
+        assert_eq!(
+            merge.productive_nanos.iter().sum::<u64>(),
+            5_000,
+            "nor in the merge's productive waits, which is what discovery lag is derived from"
+        );
+        // 5us / 2, not the 0.5 s the Phase 1 wait would have implied.
+        assert!((merge.estimated_discovery_lag_secs() - 0.000_002_5).abs() < 1e-12);
     }
 
     #[test]
     fn test_empty_wake_report_is_reported_as_empty() {
-        let report = WakeLatencyStats::default().snapshot();
+        let report = WakeLatencyStats::default().snapshot(WakePhase::Merge);
         assert!(report.is_empty());
         assert!((report.estimated_discovery_lag_secs() - 0.0).abs() < f64::EPSILON);
         assert!((report.deep_sleep_wake_share() - 0.0).abs() < f64::EPSILON);

--- a/crates/fgumi-sort/src/pooled_chunk_writer.rs
+++ b/crates/fgumi-sort/src/pooled_chunk_writer.rs
@@ -28,7 +28,7 @@ use crate::keys::RawSortKey;
 use crate::worker_pool::{CompressResult, CompressTarget, PermitPool, SortWorkerPool};
 use anyhow::Result;
 use crossbeam_channel::bounded;
-use fgumi_bgzf::BGZF_MAX_BLOCK_SIZE;
+use fgumi_bgzf::{BGZF_EOF, BGZF_MAX_BLOCK_SIZE};
 use std::io::BufWriter;
 use std::marker::PhantomData;
 use std::path::Path;
@@ -49,6 +49,46 @@ pub struct PooledChunkWriter<K: RawSortKey> {
     _phantom: PhantomData<K>,
 }
 
+/// Remove the BGZF end-of-stream marker from the end of a spill run.
+///
+/// Called before appending another chunk, so the finished run carries exactly one
+/// terminator. `read_raw_blocks` would in fact skip an interior marker
+/// (`fgumi-bgzf`), so this is not what makes appending correct — it keeps the run
+/// well-formed for anything else that reads it, htslib included, and avoids the
+/// edge where a read batch of nothing but markers looks like end-of-file.
+///
+/// Verifies the tail before truncating: silently lopping 28 bytes off a file that
+/// does not end the way we expect would corrupt a record instead of removing a
+/// marker.
+fn truncate_bgzf_terminator(path: &Path) -> Result<()> {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let mut file = std::fs::OpenOptions::new().read(true).write(true).open(path)?;
+    let len = file.metadata()?.len();
+    let marker_len = BGZF_EOF.len() as u64;
+    anyhow::ensure!(
+        len >= marker_len,
+        "cannot append to {}: file is {len} bytes, shorter than a BGZF terminator",
+        path.display()
+    );
+
+    // Seek from the end by the marker's length. `BGZF_EOF` is a 28-byte
+    // constant, so this conversion cannot wrap in practice; do it explicitly
+    // rather than silencing the lint.
+    let marker_offset = i64::try_from(marker_len).expect("BGZF terminator length fits in i64");
+    file.seek(SeekFrom::End(-marker_offset))?;
+    let mut tail = vec![0u8; BGZF_EOF.len()];
+    file.read_exact(&mut tail)?;
+    anyhow::ensure!(
+        tail == BGZF_EOF,
+        "cannot append to {}: it does not end with a BGZF terminator",
+        path.display()
+    );
+
+    file.set_len(len - marker_len)?;
+    Ok(())
+}
+
 impl<K: RawSortKey> PooledChunkWriter<K> {
     /// Create a new pooled chunk writer with an explicit spill codec.
     ///
@@ -61,9 +101,42 @@ impl<K: RawSortKey> PooledChunkWriter<K> {
     ///
     /// Returns an error if the output file cannot be created.
     pub fn new(pool: Arc<SortWorkerPool>, path: &Path, codec: SpillCodec) -> Result<Self> {
-        let file = std::fs::File::create(path)?;
+        Self::open(pool, path, codec, false)
+    }
+
+    /// Create a run, or append another sorted chunk to an existing one.
+    ///
+    /// When `appending`, the caller must have established that every key in this
+    /// chunk sorts at or after the run's last key; this type does not and cannot
+    /// check that.
+    ///
+    /// Two things differ when appending. The file is opened for append rather than
+    /// truncated, and the zstd format magic is written only when a run is created —
+    /// it identifies the file, not each chunk within it. For BGZF the trailing
+    /// end-of-stream marker left by the previous chunk is removed first, so a
+    /// finished run carries exactly one terminator, at its end.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be opened, or if a BGZF run being
+    /// appended to does not end with the terminator this writer would have
+    /// written.
+    pub fn open(
+        pool: Arc<SortWorkerPool>,
+        path: &Path,
+        codec: SpillCodec,
+        appending: bool,
+    ) -> Result<Self> {
+        let file = if appending {
+            if matches!(codec, SpillCodec::Bgzf) {
+                truncate_bgzf_terminator(path)?;
+            }
+            std::fs::OpenOptions::new().append(true).open(path)?
+        } else {
+            std::fs::File::create(path)?
+        };
         let mut writer = BufWriter::with_capacity(256 * 1024, file);
-        if matches!(codec, SpillCodec::Zstd) {
+        if matches!(codec, SpillCodec::Zstd) && !appending {
             use std::io::Write;
             writer.write_all(&ZSPILL_MAGIC)?;
         }
@@ -242,6 +315,43 @@ mod tests {
     use crate::external::GenericKeyedChunkReader;
     use crate::inline::TemplateKey;
     use tempfile::TempDir;
+
+    /// A finished run carries exactly one BGZF terminator, at its end, however
+    /// many chunks were appended to it.
+    ///
+    /// Tested here rather than through a full sort, because a sort deletes its
+    /// spill files on success — the property is only observable at this level.
+    #[test]
+    fn test_appending_leaves_one_bgzf_terminator() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("run.keyed");
+        let pool = Arc::new(SortWorkerPool::new(2, 1, 6, SpillCodec::Bgzf));
+
+        // Two chunks, the second appended to the first.
+        for (chunk, appending) in [(0u64, false), (1u64, true)] {
+            let mut writer = PooledChunkWriter::<TemplateKey>::open(
+                Arc::clone(&pool),
+                &path,
+                SpillCodec::Bgzf,
+                appending,
+            )
+            .expect("open run");
+            writer.write_record(&make_key(chunk), b"record-bytes").expect("write");
+            writer.finish().expect("finish");
+        }
+
+        let bytes = std::fs::read(&path).expect("read run");
+        assert!(bytes.ends_with(&BGZF_EOF), "a finished run must end with the terminator");
+        let interior = &bytes[..bytes.len() - BGZF_EOF.len()];
+        assert!(
+            !interior.windows(BGZF_EOF.len()).any(|w| w == BGZF_EOF),
+            "an appended run must not carry an interior terminator"
+        );
+
+        if let Ok(pool) = Arc::try_unwrap(pool) {
+            pool.shutdown();
+        }
+    }
 
     /// Create a test `TemplateKey` with distinct values for roundtrip verification.
     #[allow(clippy::cast_possible_truncation)]

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -39,7 +39,8 @@
 
 use crate::codec::{SpillCodec, ZSPILL_MAGIC};
 use crate::merge_stalls::{
-    Phase2ScanReport, Phase2ScanTally, PopSkip, ReadSkip, WakeLatencyReport, combine_skip,
+    Phase2ScanReport, Phase2ScanTally, PopSkip, ReadSkip, WakeLatencyReport, WakePhase,
+    combine_skip,
 };
 use crossbeam_channel::{Receiver, Sender, bounded};
 use crossbeam_queue::ArrayQueue;
@@ -549,7 +550,11 @@ const INPUT_READ_BATCH_SIZE: usize = 16;
 
 /// Number of raw BGZF blocks to keep read-ahead per spill file.
 ///
-/// Bounds disk read-ahead memory: K files × `PHASE2_RAW_CAP` × ~64 KB.
+/// Bounds disk read-ahead memory for every file except the one at the drain
+/// frontier, which is allowed [`PHASE2_STARVING_RAW_CAP`] instead: K files ×
+/// `PHASE2_RAW_CAP` × ~64 KB, plus that single deeper file. Still a function of
+/// config rather than input size, because the deep allowance is scoped to one
+/// file at a time.
 pub(crate) const PHASE2_RAW_CAP: usize = 8;
 
 /// Number of decompressed blocks the per-file reorder buffer may hold before
@@ -696,6 +701,17 @@ impl Phase2FileState {
             self.decomp_len.load(Ordering::Relaxed),
             self.decomp_in_flight.load(Ordering::Relaxed),
         )
+    }
+
+    /// Whether the consumer would block on this file right now: its reorder
+    /// buffer is empty and nothing is on its way into it.
+    ///
+    /// Two relaxed atomic loads, no mutex — cheap enough to consult on every
+    /// worker scan. Raw blocks may still be queued; that is precisely a file
+    /// that needs a worker's attention, not one that has it.
+    pub(crate) fn is_starving(&self) -> bool {
+        self.decomp_len.load(Ordering::Relaxed) == 0
+            && self.decomp_in_flight.load(Ordering::Relaxed) == 0
     }
 
     /// Note that the reorder buffer just drained to nothing at `now`, for
@@ -925,10 +941,6 @@ pub(crate) struct SharedPipelineState {
     /// not timed.
     pub(crate) fruitless_scan: crate::merge_trace::DurationHistogram,
 
-    /// `wake_latency` as it stood when the pool entered Phase 2, so the merge's
-    /// share can be reported without Phase 1's sleeps folded in.
-    pub(crate) wake_latency_at_merge_start: std::sync::OnceLock<WakeLatencyReport>,
-
     /// Current phase: 0=shutdown, 1=Phase1, 2=Phase2, 255=Legacy.
     pub(crate) phase: AtomicU8,
 
@@ -1020,6 +1032,29 @@ pub(crate) struct SharedPipelineState {
     /// buffer (Phase 2) so the main thread wakes immediately instead of
     /// spin-yielding.
     main_thread_handle: std::thread::Thread,
+
+    /// Worker thread handles, indexed by `worker_id`, so the consumer can wake
+    /// an idle worker instead of waiting out its backoff.
+    ///
+    /// Each worker publishes its own handle once, at the top of its loop; a
+    /// slot that is still empty simply cannot be woken yet, which is harmless
+    /// because a worker that has not reached its loop is not sleeping either.
+    worker_threads: Vec<std::sync::OnceLock<std::thread::Thread>>,
+    /// Rotates the target of [`Self::wake_one_worker`] so repeated wakes spread
+    /// across the pool rather than always hitting worker 0.
+    wake_cursor: AtomicUsize,
+
+    /// Lowest merge source index that has not yet delivered all its records.
+    ///
+    /// Phase 1 chunks its input sequentially, so an input that is already in
+    /// the requested order spills coordinate-*disjoint* runs: source 0 holds
+    /// the earliest records, source 1 the next, and the merge drains them one
+    /// at a time rather than interleaving. This is the frontier of that drain,
+    /// and [`SortWorkerPool::try_phase2_file_work`] uses it to look where the
+    /// work actually is. Only ever moves forward, and only a scan *hint* — the
+    /// scan still wraps over every file, so a stale value costs nothing but a
+    /// few microseconds of walking.
+    pub(crate) phase2_lowest_active: AtomicUsize,
 }
 
 impl SharedPipelineState {
@@ -1031,7 +1066,6 @@ impl SharedPipelineState {
             merge_phases: crate::merge_phases::MergePhaseCounters::default(),
             phase2_scans: crate::merge_stalls::Phase2ScanStats::default(),
             wake_latency: crate::merge_stalls::WakeLatencyStats::default(),
-            wake_latency_at_merge_start: std::sync::OnceLock::new(),
             epoch: Instant::now(),
             block_lifecycle: crate::merge_trace::BlockLifecycleStats::default(),
             refill: crate::merge_trace::RefillStats::default(),
@@ -1061,7 +1095,76 @@ impl SharedPipelineState {
 
             num_workers,
             main_thread_handle,
+            worker_threads: (0..num_workers).map(|_| std::sync::OnceLock::new()).collect(),
+            wake_cursor: AtomicUsize::new(0),
+            phase2_lowest_active: AtomicUsize::new(0),
         }
+    }
+
+    /// Publish a worker's thread handle so it can be woken by name.
+    fn register_worker_thread(&self, worker_id: usize) {
+        if let Some(slot) = self.worker_threads.get(worker_id) {
+            let _ = slot.set(std::thread::current());
+        }
+    }
+
+    /// Wake one idle worker, rotating which one.
+    ///
+    /// The consumer calls this the instant a reorder buffer drains. Without it
+    /// the wake path runs one way — workers to main thread — so a file that
+    /// runs dry waits out an idle worker's backoff (up to [`MAX_BACKOFF_US`])
+    /// before anyone even looks at it. That wait is pure latency: the work is
+    /// available and unclaimed.
+    ///
+    /// One worker, not all: the refill it needs to start is a disk read, which
+    /// is serialized by the file's reader mutex anyway, and a woken worker
+    /// resets its own backoff to [`MIN_BACKOFF_US`] on success and so stays hot
+    /// for the blocks that follow. Waking the whole pool would spend N fruitless
+    /// scans to get the one read that matters.
+    pub(crate) fn wake_one_worker(&self) {
+        if self.worker_threads.is_empty() {
+            return;
+        }
+        let idx = Self::wake_target(
+            self.wake_cursor.fetch_add(1, Ordering::Relaxed),
+            self.active_worker_limit.load(Ordering::Acquire),
+            self.worker_threads.len(),
+        );
+        if let Some(handle) = self.worker_threads[idx].get() {
+            handle.unpark();
+        }
+    }
+
+    /// Which worker slot the next wake should target.
+    ///
+    /// Rotates over the *active* workers, not the pool width. A pool sized to a
+    /// wide Phase 1 and capped to a narrower Phase 2 leaves workers with
+    /// `worker_id >= active_worker_limit` idle by policy, and unparking one of
+    /// those buys nothing: it re-enters its idle path without ever looking at
+    /// the starving file, while the workers that could refill it stay parked
+    /// for the rest of their backoff — exactly the latency this wake exists to
+    /// remove.
+    ///
+    /// Pure so the selection is testable without standing up a pool, following
+    /// [`classify_scan`](crate::merge_stalls::classify_scan). Clamped to at
+    /// least 1 so the modulo is always defined, however the limit was set.
+    fn wake_target(cursor: usize, active_limit: usize, pool_width: usize) -> usize {
+        cursor % active_limit.clamp(1, pool_width.max(1))
+    }
+
+    /// Advance the drain frontier past every source that is now fully drained.
+    ///
+    /// Called by the merge consumer when a source reports drained. Walks rather
+    /// than jumping to `source_id + 1` so the frontier stays truthful when
+    /// sources finish out of order — otherwise a single early finisher would
+    /// park the hint past files that are still live, and the hint would point at
+    /// the one place there is guaranteed to be no work.
+    pub(crate) fn advance_phase2_frontier(&self, files: &[Phase2FileState]) {
+        let mut frontier = self.phase2_lowest_active.load(Ordering::Relaxed);
+        while frontier < files.len() && files[frontier].is_drained() {
+            frontier += 1;
+        }
+        self.phase2_lowest_active.store(frontier, Ordering::Relaxed);
     }
 
     /// Nanoseconds since the pool's epoch, the unit every `*_nanos` field uses.
@@ -1127,10 +1230,10 @@ struct SortWorkerState {
     /// Monotonic counter incremented on each idle sleep; mixed with `worker_id` to
     /// produce per-worker jitter so all workers don't wake simultaneously.
     idle_iter: u64,
-    /// The sleep the previous loop iteration took, if it slept. Taken (and
+    /// The wait the previous loop iteration took, if it waited. Taken (and
     /// cleared) by the next iteration that finds work, which is what makes that
-    /// sleep "productive" — see [`crate::merge_stalls::WakeLatencyStats`].
-    last_sleep: Option<PendingSleep>,
+    /// wait "productive" — see [`crate::merge_stalls::WakeLatencyStats`].
+    last_wait: Option<PendingWait>,
 }
 
 impl SortWorkerState {
@@ -1141,36 +1244,47 @@ impl SortWorkerState {
     }
 }
 
-/// A sleep whose cost is not yet known, and the phase it ran in.
+/// A wait whose cost is not yet known, and the phase it ran in.
 ///
-/// The backoff level is kept separately from `backoff_us` because that field
-/// also holds `MIN_BACKOFF_US` after a successful step, which is not a sleep at
-/// all. The phase travels with it because the sleep and the step that redeems it
-/// are separate loop iterations and the phase can change in between — see
-/// [`productive_sleep_micros`].
+/// The duration is the *observed* one rather than the backoff level that was
+/// requested: waits are `park_timeout`, so a wake from
+/// [`SharedPipelineState::wake_one_worker`] ends one early, and the gap between
+/// requested and actual is precisely what that wake exists to create.
+///
+/// The phase travels with it because the wait and the step that redeems it are
+/// separate loop iterations and the phase can change in between — see
+/// [`productive_wait_nanos`].
 #[derive(Debug, Clone, Copy)]
-struct PendingSleep {
-    /// Pipeline phase the sleep ran in (see [`phase`]).
+struct PendingWait {
+    /// Pipeline phase the wait ran in (see [`phase`]).
     phase: u8,
-    /// Backoff level the sleep was taken at, in microseconds.
-    backoff_us: u64,
+    /// Observed duration of the wait, in nanoseconds.
+    nanos: u64,
 }
 
-/// The sleep to charge as productive, for a step that succeeded in `current_phase`.
+/// The wait to charge as productive, for a step that succeeded in `current_phase`.
 ///
-/// `None` when nothing was pending, or when the sleep ran in a different phase.
-/// [`crate::merge_stalls::WakeLatencyStats`] runs for the pool's whole life and
-/// the merge's share is taken by subtracting a snapshot pinned at the Phase 1 ->
-/// Phase 2 boundary, so a Phase 1 sleep recorded after that snapshot lands inside
-/// the merge's window and reports discovery lag for a merge that had not started
-/// when the worker went to sleep. Nor can it be credited to Phase 1, whose
-/// snapshot is already taken. A sleep that straddles the boundary is therefore
-/// dropped rather than misattributed to whichever side happens to be reporting.
+/// `None` when nothing was pending, or when the wait ran in a different phase. A
+/// productive wait is the claim "this step waited *this* long for its work", and
+/// that claim only holds when the wait and the step it redeems belong to the same
+/// phase: a Phase 1 wait redeemed by a Phase 2 step describes neither phase's
+/// behaviour. A wait that straddles the boundary is therefore dropped rather than
+/// misattributed to whichever side happens to be reporting.
 ///
 /// Pure so the rule is testable without running the pool through a phase
-/// transition, following [`classify_scan`](crate::merge_stalls::classify_scan).
-fn productive_sleep_micros(pending: Option<PendingSleep>, current_phase: u8) -> Option<u64> {
-    pending.filter(|sleep| sleep.phase == current_phase).map(|sleep| sleep.backoff_us)
+/// transition, following [`jittered_wait_micros`].
+fn productive_wait_nanos(pending: Option<PendingWait>, current_phase: u8) -> Option<u64> {
+    pending.filter(|wait| wait.phase == current_phase).map(|wait| wait.nanos)
+}
+
+/// The wake-latency counters a wait taken in pipeline phase `phase` belongs to.
+///
+/// The merge is the only phase reported separately, so everything else shares one
+/// bucket. Workers pass the phase they read at the top of their iteration, which
+/// is what keeps a wait out of the merge's counters when `set_phase(PHASE2)` lands
+/// mid-iteration — see [`WakePhase`].
+const fn wake_phase(phase: u8) -> WakePhase {
+    if phase == phase::PHASE2 { WakePhase::Merge } else { WakePhase::Other }
 }
 
 // ============================================================================
@@ -1244,28 +1358,58 @@ fn get_sort_priorities(bp: &SortBackpressureState) -> &'static [SortStep] {
 pub(crate) const MIN_BACKOFF_US: u64 = 10;
 /// Maximum backoff duration in microseconds (1ms).
 ///
-/// Nothing unparks a pool worker — the wake path runs one way, workers to main
-/// thread — so this is also the worst-case delay between work becoming
-/// available and an idle worker noticing it. [`crate::merge_stalls`] measures
-/// how often that delay is actually paid.
+/// This bounds how late an idle worker notices work that appeared while it was
+/// backing off. [`SharedPipelineState::wake_one_worker`] cuts that wait short
+/// for the case that measurably mattered — a merge source running dry — and
+/// [`crate::merge_stalls`] measures how often the full wait is still paid.
 pub(crate) const MAX_BACKOFF_US: u64 = 1000;
 
-/// Sleep for the given backoff duration with ±25% jitter.
+/// Wait out the given backoff with ±25% jitter, or until someone unparks us.
 ///
-/// Uses `yield_now()` at minimum backoff to avoid sleep syscall overhead.
-/// `worker_id` and `iter` are mixed into the seed so concurrent workers
-/// do not produce identical sleep durations and thundering-herd on wakeup.
-fn sleep_with_jitter(backoff_us: u64, worker_id: usize, iter: u64) {
+/// Uses `yield_now()` at minimum backoff to avoid a syscall on the hot path;
+/// above that it parks with a timeout rather than sleeping, so a wake from
+/// [`SharedPipelineState::wake_one_worker`] returns immediately instead of
+/// waiting out the full duration. `worker_id` and `iter` are mixed into the seed
+/// so concurrent workers do not produce identical durations and thundering-herd
+/// on wakeup.
+///
+/// A pending unpark token makes the next `park_timeout` return at once. That is
+/// a spurious early wake, which costs one scan and is harmless — the caller
+/// loops.
+fn idle_wait_with_jitter(backoff_us: u64, worker_id: usize, iter: u64) {
     if backoff_us <= MIN_BACKOFF_US {
         std::thread::yield_now();
     } else {
-        let jitter_range = backoff_us / 4;
-        // Cheap deterministic seed — no syscall, differs per worker and iteration.
-        let jitter_seed = (worker_id as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15).wrapping_add(iter);
-        let jitter_offset = (jitter_seed % (jitter_range * 2)).saturating_sub(jitter_range);
-        let actual_us = backoff_us.saturating_add(jitter_offset).max(MIN_BACKOFF_US);
-        std::thread::sleep(std::time::Duration::from_micros(actual_us));
+        let actual_us = jittered_wait_micros(backoff_us, worker_id, iter);
+        std::thread::park_timeout(std::time::Duration::from_micros(actual_us));
     }
+}
+
+/// `backoff_us` spread over ±25%, deterministically per `(worker_id, iter)`.
+///
+/// Pure so the spread is testable without parking a thread, following
+/// [`classify_scan`](crate::merge_stalls::classify_scan).
+///
+/// The two directions are computed separately because the offset is unsigned.
+/// Subtracting the half-range from `seed % (range * 2)` in `u64` — the obvious
+/// spelling — saturates every negative offset to zero, which silently turns
+/// ±25% into 0..+25%: no worker ever wakes *earlier* than nominal, so the pool
+/// keeps exactly the synchronized wake-ups the jitter exists to break up.
+///
+/// Callers must have already excluded `backoff_us <= MIN_BACKOFF_US`, which is
+/// what keeps `jitter_range` non-zero and the modulo defined.
+fn jittered_wait_micros(backoff_us: u64, worker_id: usize, iter: u64) -> u64 {
+    debug_assert!(backoff_us > MIN_BACKOFF_US, "caller must handle the yield_now case");
+    let jitter_range = (backoff_us / 4).max(1);
+    // Cheap deterministic seed — no syscall, differs per worker and iteration.
+    let jitter_seed = (worker_id as u64).wrapping_mul(0x9e37_79b9_7f4a_7c15).wrapping_add(iter);
+    let jitter_offset = jitter_seed % (jitter_range * 2);
+    let actual_us = if jitter_offset < jitter_range {
+        backoff_us.saturating_sub(jitter_range - jitter_offset)
+    } else {
+        backoff_us.saturating_add(jitter_offset - jitter_range)
+    };
+    actual_us.max(MIN_BACKOFF_US)
 }
 
 // ============================================================================
@@ -1418,7 +1562,7 @@ impl SortWorkerPool {
                         held_decompressed_input: None,
                         backoff_us: MIN_BACKOFF_US,
                         idle_iter: 0,
-                        last_sleep: None,
+                        last_wait: None,
                     };
 
                     // Publish a panic as soon as the worker unwinds, not at
@@ -1464,6 +1608,8 @@ impl SortWorkerPool {
         worker: &mut SortWorkerState,
         pstats: &SortPipelineStats,
     ) {
+        // Publish this thread so the consumer can wake it out of a backoff.
+        shared.register_worker_thread(worker.worker_id);
         loop {
             // 1. Check shutdown
             let current_phase = shared.phase.load(Ordering::Acquire);
@@ -1483,24 +1629,24 @@ impl SortWorkerPool {
                 if Self::try_advance_all_held(shared, worker) {
                     worker.backoff_us = MIN_BACKOFF_US;
                 } else {
-                    sleep_with_jitter(worker.backoff_us, worker.worker_id, worker.idle_iter);
+                    idle_wait_with_jitter(worker.backoff_us, worker.worker_id, worker.idle_iter);
                     worker.idle_iter = worker.idle_iter.wrapping_add(1);
                     worker.backoff_us = (worker.backoff_us * 2).min(MAX_BACKOFF_US);
                 }
                 // A capped worker is idle by policy, not because work was slow
-                // to appear, so its sleep must not count as discovery latency.
-                worker.last_sleep = None;
+                // to appear, so its wait must not count as discovery latency.
+                worker.last_wait = None;
                 continue;
             }
 
             // 2. Check phase completion — wait for next phase, only exit on SHUTDOWN.
             //    Workers must survive across Phase 1 → Phase 2 transitions.
             if Self::is_phase_complete(shared, current_phase) && !worker.has_any_held_items() {
-                sleep_with_jitter(worker.backoff_us, worker.worker_id, worker.idle_iter);
+                idle_wait_with_jitter(worker.backoff_us, worker.worker_id, worker.idle_iter);
                 worker.idle_iter = worker.idle_iter.wrapping_add(1);
                 worker.backoff_us = (worker.backoff_us * 2).min(MAX_BACKOFF_US);
                 // Waiting for the next phase, not for work — see above.
-                worker.last_sleep = None;
+                worker.last_wait = None;
                 continue;
             }
 
@@ -1565,32 +1711,38 @@ impl SortWorkerPool {
 
             // 7. Backoff with jitter (ported from unified pipeline)
             if did_work {
-                // The sleep that preceded this step was slept *through* work
-                // becoming available: nothing unparks a worker, so the work may
-                // have arrived at any point during it. That is the part of idle
-                // time the pipeline actually pays for, and it is invisible in
-                // the idle total, which counts the productive and unproductive
-                // sleeps alike.
+                // The wait that preceded this step was slept *through* work
+                // becoming available, so the work may have arrived at any point
+                // during it. That is the part of idle time the pipeline actually
+                // pays for, and it is invisible in the idle total, which counts
+                // the productive and unproductive waits alike. `wake_one_worker`
+                // shortens the wait when the consumer knows work is coming; what
+                // is recorded here is what the wait actually cost.
                 //
-                // `take` unconditionally: a sleep from another phase is dropped,
+                // `take` unconditionally: a wait from another phase is dropped,
                 // not carried forward to the next step in this one.
-                if let Some(slept_us) =
-                    productive_sleep_micros(worker.last_sleep.take(), current_phase)
+                if let Some(waited_ns) =
+                    productive_wait_nanos(worker.last_wait.take(), current_phase)
                 {
-                    shared.wake_latency.record_productive_sleep(slept_us);
+                    // Filed under the phase loaded at the top of this iteration, not
+                    // under whatever the pool has flipped to by now: `set_phase` can
+                    // land between that load and this record, and a wait taken before
+                    // the merge is not the merge's to report.
+                    shared
+                        .wake_latency
+                        .record_productive_sleep(wake_phase(current_phase), waited_ns);
                 }
                 worker.backoff_us = MIN_BACKOFF_US;
             } else {
                 let slept_us = worker.backoff_us;
                 let idle_start = Instant::now();
-                sleep_with_jitter(slept_us, worker.worker_id, worker.idle_iter);
+                idle_wait_with_jitter(slept_us, worker.worker_id, worker.idle_iter);
                 worker.idle_iter = worker.idle_iter.wrapping_add(1);
                 worker.backoff_us = (worker.backoff_us * 2).min(MAX_BACKOFF_US);
                 let idle_ns = Self::nanos_u64(idle_start.elapsed());
                 pstats.record_idle(worker.worker_id, idle_ns);
-                shared.wake_latency.record_sleep(slept_us, idle_ns);
-                worker.last_sleep =
-                    Some(PendingSleep { phase: current_phase, backoff_us: slept_us });
+                shared.wake_latency.record_sleep(wake_phase(current_phase), slept_us, idle_ns);
+                worker.last_wait = Some(PendingWait { phase: current_phase, nanos: idle_ns });
             }
         }
     }
@@ -1959,8 +2111,32 @@ impl SortWorkerPool {
         let mut tally = Phase2ScanTally::default();
         let scan_start = shared.now_nanos();
 
+        // Where to start looking. Normally the worker's own round-robin cursor,
+        // which spreads N workers over the file set and is what keeps an
+        // interleaved merge — where every file is hot — saturated.
+        //
+        // But when the input was already in the requested order, the spill runs
+        // are disjoint and only one file is ever being consumed. Round-robin
+        // then spends most of a scan on files sitting at `PHASE2_DECOMP_CAP`
+        // with nothing to give, while the one file the merge is blocked on waits
+        // to be reached. So if the drain frontier is starving, start there: it
+        // is the file the consumer is either blocked on or about to be.
+        //
+        // Gated on `is_starving` rather than applied unconditionally, because a
+        // frontier that is merely *active* is the common case in an interleaved
+        // merge, and sending every worker to file 0 there would undo the spread
+        // that makes that case fast.
+        let start = {
+            let frontier = shared.phase2_lowest_active.load(Ordering::Relaxed);
+            if frontier < n && files[frontier].is_starving() {
+                frontier
+            } else {
+                worker.phase2_file_cursor
+            }
+        };
+
         for offset in 0..n {
-            let i = (worker.phase2_file_cursor + offset) % n;
+            let i = (start + offset) % n;
             let file = &files[i];
 
             // -- Try decompression first (highest-value work) ----------------
@@ -2456,15 +2632,12 @@ impl SortWorkerPool {
 
     /// How deep workers were sleeping when they found work, during the merge.
     ///
-    /// Scoped to Phase 2 by subtracting the snapshot taken at the phase
-    /// boundary; falls back to the running total only when the pool never
-    /// entered Phase 2, in which case there is no merge to misattribute to.
+    /// Scoped to Phase 2 by reading Phase 2's own counters, so a wait taken in
+    /// Phase 1 is absent whether or not the worker got around to recording it
+    /// before the merge started. A pool that never entered Phase 2 reports zeros,
+    /// which is the truth: there was no merge.
     pub(crate) fn wake_latency_report(&self) -> WakeLatencyReport {
-        let now = self.shared.wake_latency.snapshot();
-        match self.shared.wake_latency_at_merge_start.get() {
-            Some(&baseline) => now.since(baseline),
-            None => now,
-        }
+        self.shared.wake_latency.snapshot(WakePhase::Merge)
     }
 
     /// Codec used to compress Phase 1 spill chunks.
@@ -2523,16 +2696,13 @@ impl SortWorkerPool {
     }
 
     /// Set the current pipeline phase.
+    ///
+    /// Note what this deliberately does *not* do: pin a wake-latency baseline to
+    /// subtract later. Workers file each wait under the phase they read at the top
+    /// of their iteration (see [`wake_phase`]), so the merge's share is already
+    /// separated at record time and cannot depend on where this store lands
+    /// relative to a worker's in-flight iteration.
     pub fn set_phase(&self, new_phase: u8) {
-        // Pin the wake-latency counters as they stand entering the merge. They
-        // run for the pool's whole life, so without a baseline to subtract, a
-        // merge-scoped report would include every Phase 1 sleep -- see
-        // `WakeLatencyReport::since`. `OnceLock` so a workflow that re-enters
-        // PHASE2 keeps the first boundary rather than silently rebasing.
-        if new_phase == phase::PHASE2 {
-            let _ =
-                self.shared.wake_latency_at_merge_start.set(self.shared.wake_latency.snapshot());
-        }
         self.shared.phase.store(new_phase, Ordering::Release);
     }
 
@@ -2612,6 +2782,13 @@ impl SortWorkerPool {
         // Reset EOF state
         self.shared.all_chunks_eof.store(false, Ordering::Release);
         self.shared.sources_at_eof.store(0, Ordering::Release);
+        // The drain frontier indexes the file vector being replaced, so a pool
+        // that merges twice would carry the prior set's frontier into the new
+        // one: at or past the old source count it disables frontier
+        // prioritization outright, and below it points at whichever file now
+        // happens to sit at that index. `advance_phase2_frontier` only walks
+        // forward, so neither is self-correcting.
+        self.shared.phase2_lowest_active.store(0, Ordering::Release);
 
         let mut states: Vec<Phase2FileState> = Vec::with_capacity(total_sources);
         for path in files {
@@ -3278,35 +3455,99 @@ mod tests {
         pool.shutdown();
     }
 
-    /// A sleep that straddles the Phase 1 -> Phase 2 boundary belongs to
+    /// A wait that straddles the Phase 1 -> Phase 2 boundary belongs to
     /// neither report.
     ///
-    /// `wake_latency` runs for the pool's whole life and the merge's share is
-    /// taken by subtracting a snapshot pinned at the boundary, so a Phase 1
-    /// sleep recorded after that snapshot lands inside the merge's window —
-    /// booking discovery lag against a merge that had not started when the
-    /// worker went to sleep. The sleep cannot be credited to Phase 1 either,
-    /// since its snapshot is already taken, so it is dropped.
+    /// A productive wait asserts that the step it precedes waited that long for
+    /// its work, and a Phase 1 wait redeemed by a Phase 2 step describes neither
+    /// phase's behaviour: it would book discovery lag against a merge that had
+    /// not started when the worker went to sleep, and against a Phase 1 whose
+    /// step never came. So it is dropped rather than filed on either side.
+    ///
+    /// Which counters the charge then lands in is [`wake_phase`]'s job, and it
+    /// takes the same `current_phase` this does, so the two cannot disagree.
     #[rstest]
-    #[case::same_phase_sleep_is_charged(
-        Some(PendingSleep { phase: phase::PHASE2, backoff_us: 80 }), phase::PHASE2, Some(80)
+    #[case::same_phase_wait_is_charged(
+        Some(PendingWait { phase: phase::PHASE2, nanos: 5_000 }), phase::PHASE2, Some(5_000)
     )]
-    #[case::phase1_sleep_is_not_charged_to_phase2(
-        Some(PendingSleep { phase: phase::PHASE1, backoff_us: 80 }), phase::PHASE2, None
+    #[case::phase1_wait_is_not_charged_to_phase2(
+        Some(PendingWait { phase: phase::PHASE1, nanos: 5_000 }), phase::PHASE2, None
     )]
-    #[case::phase2_sleep_is_not_charged_to_phase1(
-        Some(PendingSleep { phase: phase::PHASE2, backoff_us: 80 }), phase::PHASE1, None
+    #[case::phase2_wait_is_not_charged_to_phase1(
+        Some(PendingWait { phase: phase::PHASE2, nanos: 5_000 }), phase::PHASE1, None
     )]
-    #[case::a_phase1_sleep_within_phase1_is_charged(
-        Some(PendingSleep { phase: phase::PHASE1, backoff_us: 40 }), phase::PHASE1, Some(40)
+    #[case::a_phase1_wait_within_phase1_is_charged(
+        Some(PendingWait { phase: phase::PHASE1, nanos: 7_000 }), phase::PHASE1, Some(7_000)
     )]
-    #[case::no_pending_sleep(None, phase::PHASE2, None)]
-    fn productive_sleep_is_scoped_to_the_phase_it_ran_in(
-        #[case] pending: Option<PendingSleep>,
+    #[case::no_pending_wait(None, phase::PHASE2, None)]
+    fn productive_wait_is_scoped_to_the_phase_it_ran_in(
+        #[case] pending: Option<PendingWait>,
         #[case] current_phase: u8,
         #[case] expected: Option<u64>,
     ) {
-        assert_eq!(productive_sleep_micros(pending, current_phase), expected);
+        assert_eq!(productive_wait_nanos(pending, current_phase), expected);
+    }
+
+    /// The jitter must spread waits in *both* directions.
+    ///
+    /// Its whole job is to desynchronize workers that backed off together, and a
+    /// one-sided spread cannot: if every wait is nominal-or-longer, the pool
+    /// keeps the alignment the jitter was added to break. The unsigned-subtract
+    /// spelling that produces exactly that failure is the one this pins against.
+    #[rstest]
+    fn jitter_spreads_waits_both_sides_of_the_backoff(
+        #[values(20u64, 40, 80, 160, 320, 640, 1000)] backoff_us: u64,
+    ) {
+        let range = backoff_us / 4;
+        let waits: Vec<u64> =
+            (0..512).map(|iter| jittered_wait_micros(backoff_us, 3, iter)).collect();
+
+        let min = *waits.iter().min().expect("non-empty");
+        let max = *waits.iter().max().expect("non-empty");
+        assert!(
+            min >= backoff_us.saturating_sub(range).max(MIN_BACKOFF_US),
+            "waits must stay within -25%: min {min} for backoff {backoff_us}"
+        );
+        assert!(max <= backoff_us + range, "waits must stay within +25%: max {max}");
+        assert!(
+            min < backoff_us,
+            "some wait must be SHORTER than nominal (backoff {backoff_us}, min {min}) -- \
+             a saturating unsigned subtract clamps these away and leaves 0..+25%"
+        );
+        assert!(max > backoff_us, "and some wait must be longer (max {max})");
+    }
+
+    /// The consumer wakes a worker the instant a merge source runs dry, so the
+    /// woken worker has to be one that may actually take Phase 2 work. Rotating
+    /// over the pool width instead sends most wakes to workers idled by the
+    /// Phase 2 cap, which re-park without looking at the starving file — and
+    /// the workers that could have refilled it wait out their full backoff.
+    #[rstest]
+    // A pool 8 wide capped to 3 must never select a worker above the cap, at
+    // any point in the rotation.
+    #[case::capped_pool_rotates_only_over_active_workers(0, 3, 8, 0)]
+    #[case::capped_pool_wraps_at_the_cap(2, 3, 8, 2)]
+    #[case::capped_pool_never_selects_a_capped_worker(3, 3, 8, 0)]
+    #[case::capped_pool_keeps_rotating_past_the_wrap(7, 3, 8, 1)]
+    // Uncapped, the cap equals the width and the rotation is unchanged.
+    #[case::uncapped_pool_rotates_over_the_whole_width(7, 8, 8, 7)]
+    #[case::uncapped_pool_wraps_at_the_width(8, 8, 8, 0)]
+    // A limit above the width cannot select a slot that does not exist.
+    #[case::limit_above_the_width_is_clamped(5, 99, 4, 1)]
+    // A zero limit must not divide by zero; slot 0 is always a real worker.
+    #[case::zero_limit_falls_back_to_one_worker(7, 0, 8, 0)]
+    fn wake_target_rotates_only_over_workers_that_can_take_phase2_work(
+        #[case] cursor: usize,
+        #[case] active_limit: usize,
+        #[case] pool_width: usize,
+        #[case] expected: usize,
+    ) {
+        let idx = SharedPipelineState::wake_target(cursor, active_limit, pool_width);
+        assert_eq!(idx, expected);
+        assert!(idx < pool_width, "the slot must exist in the pool");
+        if active_limit > 0 {
+            assert!(idx < active_limit, "a capped worker cannot refill the starving source");
+        }
     }
 
     #[test]
@@ -4078,5 +4319,99 @@ mod tests {
         );
         assert_eq!(phase2_file_position(&files[0]), 0);
         pool.shutdown();
+    }
+
+    /// A pool that merges twice must start the second merge's frontier at its
+    /// own first source.
+    ///
+    /// The frontier is an index into the file vector `set_phase2_files`
+    /// replaces, so carrying it across would leave the second merge pointing at
+    /// a file the number no longer describes — and `advance_phase2_frontier`
+    /// only walks forward, so nothing would ever pull it back.
+    #[test]
+    fn test_set_phase2_files_restarts_the_drain_frontier() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let spill = |name: &str| {
+            let path = dir.path().join(name);
+            let mut file = std::fs::File::create(&path).expect("create");
+            file.write_all(&[0x1f, 0x8b, 0x00, 0x00]).expect("write magic");
+            path
+        };
+
+        let pool = SortWorkerPool::new(1, 1, 6, SpillCodec::Bgzf);
+
+        // First merge: one source, drained to completion.
+        pool.set_phase2_files(std::slice::from_ref(&spill("first.spill")))
+            .expect("set_phase2_files");
+        let first = pool.phase2_files();
+        first[0].reader_eof.store(true, Ordering::Release);
+        assert!(first[0].is_drained(), "the lone source must read as fully consumed");
+        pool.shared.advance_phase2_frontier(&first);
+        assert_eq!(
+            pool.shared.phase2_lowest_active.load(Ordering::Relaxed),
+            1,
+            "a completed merge parks the frontier past its last source"
+        );
+
+        // Second merge: a fresh set, whose file 0 is live.
+        pool.set_phase2_files(&[spill("second-a.spill"), spill("second-b.spill")])
+            .expect("set_phase2_files");
+        assert_eq!(
+            pool.shared.phase2_lowest_active.load(Ordering::Relaxed),
+            0,
+            "the new source set must be prioritized from its own first file"
+        );
+
+        pool.shutdown();
+    }
+
+    /// Repeated wakes must rotate rather than always hitting worker 0:
+    /// re-waking one worker while the others sleep is the starvation the wake
+    /// path exists to avoid. Registered handles are all this thread, so the
+    /// observable contract here is the cursor advancing once per wake.
+    #[test]
+    fn test_wake_one_worker_rotates_across_the_pool() {
+        let shared = SharedPipelineState::new(4, std::thread::current());
+        for expected in 1..=8 {
+            shared.wake_one_worker();
+            assert_eq!(
+                shared.wake_cursor.load(Ordering::Relaxed),
+                expected,
+                "each wake must advance the cursor exactly once"
+            );
+        }
+    }
+
+    /// The rotation test above only proves the cursor moves; every slot it
+    /// rotates through is empty, so it passes with the `unpark` dispatch
+    /// deleted. This one registers a real worker and asserts the wake is
+    /// actually delivered, which is the behaviour the starving-source path
+    /// depends on.
+    ///
+    /// No sleep is needed to order the two threads: `unpark` on a thread that
+    /// has not parked yet leaves a token, so the next `park` returns
+    /// immediately. Failure surfaces as the `recv_timeout` below rather than as
+    /// a hang.
+    #[test]
+    fn test_wake_one_worker_unparks_a_registered_worker() {
+        let shared = Arc::new(SharedPipelineState::new(1, std::thread::current()));
+        let (registered_tx, registered_rx) = bounded::<()>(1);
+        let (woken_tx, woken_rx) = bounded::<()>(1);
+
+        let worker_shared = Arc::clone(&shared);
+        let worker = std::thread::spawn(move || {
+            worker_shared.register_worker_thread(0);
+            registered_tx.send(()).expect("main thread is still waiting");
+            std::thread::park();
+            woken_tx.send(()).expect("main thread is still waiting");
+        });
+
+        registered_rx.recv().expect("the worker must publish its handle");
+        shared.wake_one_worker();
+        woken_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("wake_one_worker must unpark the worker registered in slot 0");
+        worker.join().expect("worker thread must not panic");
     }
 }

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -575,13 +575,63 @@ pub(crate) const PHASE2_READ_BATCH: usize = 4;
 /// [`SortWorkerPool::try_phase2_file_work`].
 ///
 /// Applies to one file at a time, so the extra read-ahead memory is this many
-/// compressed blocks — a few MB — not K times that.
-pub(crate) const PHASE2_STARVING_RAW_CAP: usize = 64;
+/// compressed blocks — at ~9 KB compressed that is ~4.7 MB for the one hot
+/// file, not K times that.
+///
+/// The value is empirical. Measured on a 780M-record coordinate re-sort, merge
+/// loop: 308s at the uniform cap of 8, 288s at 64, 280s at 512. It was chosen
+/// as "deep enough to cover a 2 MB buffer refill", and that reasoning turned out
+/// to be wrong — read duty cycle moved only 47.6% -> 48.8% across the 8x from 64
+/// to 512, so covering refills is demonstrably not the mechanism. The gain is
+/// real and reproducible; what produces it is not established. Do not tune this
+/// further on the strength of that story.
+pub(crate) const PHASE2_STARVING_RAW_CAP: usize = 512;
 
 /// Blocks to read per call for that same file. Large enough that one read is a
 /// sequential run rather than a 256 KB pinprick, since only one worker may hold
 /// a given file's reader mutex and that read is therefore the whole refill rate.
 pub(crate) const PHASE2_STARVING_READ_BATCH: usize = 32;
+
+/// The file index a Phase 2 scan starts at.
+///
+/// The frontier -- the lowest source that has not delivered everything -- when
+/// it is starving, and the worker's own round-robin cursor otherwise. Gated on
+/// starving rather than applied always: a frontier that is merely *active* is
+/// the common case in an interleaved merge, and sending every worker to file 0
+/// there would undo the spread that makes that case fast.
+///
+/// `frontier` is only meaningful while it indexes a live file; past the end it
+/// names no source and the cursor stands.
+///
+/// Pure so both branches of the gate are testable without racing a live pool,
+/// following [`classify_scan`](crate::merge_stalls::classify_scan).
+fn phase2_scan_start(
+    frontier: usize,
+    num_files: usize,
+    frontier_starving: bool,
+    cursor: usize,
+) -> usize {
+    if frontier < num_files && frontier_starving { frontier } else { cursor }
+}
+
+/// The `(raw_cap, read_batch)` a file may read at.
+///
+/// The drain frontier gets the deep allowance so one read becomes a sequential
+/// run rather than a pinprick; every other file keeps the shallow one. Scoped to
+/// the frontier rather than to any starving file because at merge start *every*
+/// file is empty, and letting all K deepen at once would multiply read-ahead
+/// memory by K.
+fn phase2_read_allowance(is_frontier: bool) -> (usize, usize) {
+    // The deep allowance must actually be deeper, or scoping it to the frontier
+    // buys nothing and the two branches are the same read.
+    const _: () = assert!(PHASE2_STARVING_RAW_CAP > PHASE2_RAW_CAP);
+    const _: () = assert!(PHASE2_STARVING_READ_BATCH > PHASE2_READ_BATCH);
+    if is_frontier {
+        (PHASE2_STARVING_RAW_CAP, PHASE2_STARVING_READ_BATCH)
+    } else {
+        (PHASE2_RAW_CAP, PHASE2_READ_BATCH)
+    }
+}
 
 /// Blocks a read may fetch for a file whose raw FIFO holds `raw_len`, or `None`
 /// when the FIFO is already at its cap.
@@ -2174,8 +2224,8 @@ impl SortWorkerPool {
         // merge, and sending every worker to file 0 there would undo the spread
         // that makes that case fast.
         let frontier = shared.phase2_lowest_active.load(Ordering::Relaxed);
-        let frontier_starving = frontier < n && files[frontier].is_starving();
-        let start = if frontier_starving { frontier } else { worker.phase2_file_cursor };
+        let frontier_starving = files.get(frontier).is_some_and(Phase2FileState::is_starving);
+        let start = phase2_scan_start(frontier, n, frontier_starving, worker.phase2_file_cursor);
 
         for offset in 0..n {
             let i = (start + offset) % n;
@@ -2234,11 +2284,7 @@ impl SortWorkerPool {
             //
             // Still scoped to one file: at merge start every file is empty, and
             // letting all K deepen at once would multiply read-ahead memory by K.
-            let (raw_cap, read_batch) = if i == frontier {
-                (PHASE2_STARVING_RAW_CAP, PHASE2_STARVING_READ_BATCH)
-            } else {
-                (PHASE2_RAW_CAP, PHASE2_READ_BATCH)
-            };
+            let (raw_cap, read_batch) = phase2_read_allowance(i == frontier);
 
             // Bound disk read-ahead per file: don't keep pulling if the raw
             // FIFO is already full. Use try_lock so a momentarily contended
@@ -3546,6 +3592,75 @@ mod tests {
         assert_eq!(pool.num_workers(), 8, "the pool is still eight threads wide");
         assert_eq!(pool.active_workers(), 3, "but only three may take Phase 2 work");
         pool.shutdown();
+    }
+
+    /// The scan-start gate: a starving frontier is served before the worker's
+    /// own cursor.
+    ///
+    /// This is the whole point of the frontier scheduling. When the merge is
+    /// draining one source at a time, round-robin spends most of a scan on
+    /// files that have nothing to give while the one file the consumer is
+    /// blocked on waits to be reached. Both branches matter: the gate must fire
+    /// when the frontier is starving *and* stay out of the way when it is not,
+    /// or an interleaved merge loses the spread that makes it fast.
+    #[rstest]
+    // Starving frontier wins over the cursor, wherever the cursor happens to be.
+    #[case::starving_frontier_is_served_first(0, 8, true, 5, 0)]
+    #[case::starving_frontier_mid_pool(3, 8, true, 7, 3)]
+    // An active frontier leaves the round-robin spread alone.
+    #[case::active_frontier_defers_to_the_cursor(0, 8, false, 5, 5)]
+    #[case::active_frontier_mid_pool(3, 8, false, 0, 0)]
+    // A frontier past the end names no live source, so it cannot be started at
+    // -- this is the guard that kept the old `frontier < n` from indexing out
+    // of bounds.
+    #[case::frontier_past_the_end_defers(8, 8, true, 2, 2)]
+    #[case::frontier_far_past_the_end_defers(99, 8, true, 2, 2)]
+    // A merge with no sources has nowhere to start but the cursor.
+    #[case::no_files_defers(0, 0, true, 0, 0)]
+    fn phase2_scan_starts_at_a_starving_frontier(
+        #[case] frontier: usize,
+        #[case] num_files: usize,
+        #[case] frontier_starving: bool,
+        #[case] cursor: usize,
+        #[case] expected: usize,
+    ) {
+        assert_eq!(phase2_scan_start(frontier, num_files, frontier_starving, cursor), expected);
+    }
+
+    /// Only the drain frontier gets the deep allowance.
+    ///
+    /// At merge start every file is empty and would qualify on starvation
+    /// alone, so scoping to the frontier is what keeps read-ahead memory from
+    /// being multiplied by K.
+    #[rstest]
+    #[case::frontier_reads_deep(true, PHASE2_STARVING_RAW_CAP, PHASE2_STARVING_READ_BATCH)]
+    #[case::every_other_file_reads_shallow(false, PHASE2_RAW_CAP, PHASE2_READ_BATCH)]
+    fn phase2_read_allowance_is_scoped_to_the_frontier(
+        #[case] is_frontier: bool,
+        #[case] expected_cap: usize,
+        #[case] expected_batch: usize,
+    ) {
+        assert_eq!(phase2_read_allowance(is_frontier), (expected_cap, expected_batch));
+    }
+
+    /// `is_starving` is what arms the scan-start gate, and it means "this file
+    /// can give the consumer nothing right now" -- neither buffered nor being
+    /// produced. A file with a decompression in flight is about to deliver, so
+    /// steering the pool at it would be wasted work.
+    #[rstest]
+    #[case::nothing_buffered_or_in_flight(0, 0, true)]
+    #[case::blocks_buffered(2, 0, false)]
+    #[case::decompression_in_flight(0, 1, false)]
+    #[case::both(2, 1, false)]
+    fn a_file_is_starving_only_with_nothing_buffered_and_nothing_coming(
+        #[case] decomp_len: usize,
+        #[case] in_flight: usize,
+        #[case] expected: bool,
+    ) {
+        let file = empty_phase2_file();
+        file.decomp_len.store(decomp_len, Ordering::Relaxed);
+        file.decomp_in_flight.store(in_flight, Ordering::Relaxed);
+        assert_eq!(file.is_starving(), expected);
     }
 
     /// A read may never carry the raw FIFO past its cap.

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -570,6 +570,37 @@ pub(crate) const PHASE2_DECOMP_CAP: usize = 8;
 /// Number of raw blocks to read from disk per `ReadRawBlocks` call.
 pub(crate) const PHASE2_READ_BATCH: usize = 4;
 
+/// Read-ahead depth for the single merge source the consumer is draining while
+/// it has nothing buffered. See the read path in
+/// [`SortWorkerPool::try_phase2_file_work`].
+///
+/// Applies to one file at a time, so the extra read-ahead memory is this many
+/// compressed blocks — a few MB — not K times that.
+pub(crate) const PHASE2_STARVING_RAW_CAP: usize = 64;
+
+/// Blocks to read per call for that same file. Large enough that one read is a
+/// sequential run rather than a 256 KB pinprick, since only one worker may hold
+/// a given file's reader mutex and that read is therefore the whole refill rate.
+pub(crate) const PHASE2_STARVING_READ_BATCH: usize = 32;
+
+/// Blocks a read may fetch for a file whose raw FIFO holds `raw_len`, or `None`
+/// when the FIFO is already at its cap.
+///
+/// Admitting on "not yet full" and then reading a whole batch overshoots the
+/// cap by up to a batch: at the frontier allowance that is a FIFO admitted at
+/// 511 and left holding 543. `raw_cap` is a read-ahead *memory* bound, so it has
+/// to bound -- and the deep path, which raised the cap 64x and the batch 8x, is
+/// exactly where an unclamped overshoot is largest.
+///
+/// Pure so the bound is testable without a pool, following
+/// [`classify_scan`](crate::merge_stalls::classify_scan).
+fn admitted_read_batch(raw_len: usize, raw_cap: usize, read_batch: usize) -> Option<usize> {
+    match raw_cap.saturating_sub(raw_len) {
+        0 => None,
+        headroom => Some(read_batch.min(headroom)),
+    }
+}
+
 /// One compressed block in a file's raw FIFO, with when it got there.
 ///
 /// The timestamp is what turns "the pool did not decompress this yet" into a
@@ -1044,6 +1075,18 @@ pub(crate) struct SharedPipelineState {
     /// across the pool rather than always hitting worker 0.
     wake_cursor: AtomicUsize,
 
+    /// Read batches taken at the deep frontier allowance, and the blocks they
+    /// returned; and the same for batches taken at the uniform allowance.
+    ///
+    /// Blocks-per-batch is the number that says whether the deep path is
+    /// actually engaging. Without it, a gate that silently almost never fires
+    /// looks exactly like a change that did not help — which is precisely the
+    /// mistake this counter exists to prevent.
+    pub(crate) deep_read_batches: AtomicU64,
+    pub(crate) deep_read_blocks: AtomicU64,
+    pub(crate) shallow_read_batches: AtomicU64,
+    pub(crate) shallow_read_blocks: AtomicU64,
+
     /// Lowest merge source index that has not yet delivered all its records.
     ///
     /// Phase 1 chunks its input sequentially, so an input that is already in
@@ -1097,6 +1140,10 @@ impl SharedPipelineState {
             main_thread_handle,
             worker_threads: (0..num_workers).map(|_| std::sync::OnceLock::new()).collect(),
             wake_cursor: AtomicUsize::new(0),
+            deep_read_batches: AtomicU64::new(0),
+            deep_read_blocks: AtomicU64::new(0),
+            shallow_read_batches: AtomicU64::new(0),
+            shallow_read_blocks: AtomicU64::new(0),
             phase2_lowest_active: AtomicUsize::new(0),
         }
     }
@@ -2126,14 +2173,9 @@ impl SortWorkerPool {
         // frontier that is merely *active* is the common case in an interleaved
         // merge, and sending every worker to file 0 there would undo the spread
         // that makes that case fast.
-        let start = {
-            let frontier = shared.phase2_lowest_active.load(Ordering::Relaxed);
-            if frontier < n && files[frontier].is_starving() {
-                frontier
-            } else {
-                worker.phase2_file_cursor
-            }
-        };
+        let frontier = shared.phase2_lowest_active.load(Ordering::Relaxed);
+        let frontier_starving = frontier < n && files[frontier].is_starving();
+        let start = if frontier_starving { frontier } else { worker.phase2_file_cursor };
 
         for offset in 0..n {
             let i = (start + offset) % n;
@@ -2170,21 +2212,50 @@ impl SortWorkerPool {
                 continue;
             }
 
+            // The file the merge is draining gets a deeper allowance than the
+            // uniform per-file one.
+            //
+            // Uniform read-ahead is what makes the disjoint-run case slow. Only
+            // one worker may read a given file (its reader mutex), so at
+            // `PHASE2_READ_BATCH` = 4 blocks the hot file is refilled 4 blocks at
+            // a time by one thread, and the per-batch read latency is amortized
+            // over only those 4. Reading a larger run turns many small
+            // serialized reads into one sequential one, without needing more
+            // readers.
+            //
+            // Keyed on being the frontier alone, NOT on the file also looking
+            // starved. An earlier version required `is_starving()` here, which
+            // needs `decomp_in_flight == 0` -- but by the time a worker reaches
+            // the read path some other worker has usually already begun
+            // decompressing, so the file no longer looked starved and the deep
+            // path fired for only 6% of batches (5.6 blocks per read against the
+            // intended 32). Whether a worker happens to be mid-decompress says
+            // nothing about how far ahead the file should read.
+            //
+            // Still scoped to one file: at merge start every file is empty, and
+            // letting all K deepen at once would multiply read-ahead memory by K.
+            let (raw_cap, read_batch) = if i == frontier {
+                (PHASE2_STARVING_RAW_CAP, PHASE2_STARVING_READ_BATCH)
+            } else {
+                (PHASE2_RAW_CAP, PHASE2_READ_BATCH)
+            };
+
             // Bound disk read-ahead per file: don't keep pulling if the raw
             // FIFO is already full. Use try_lock so a momentarily contended
             // raw FIFO doesn't block the reader.
-            let read_skip = match file.raw_blocks.try_lock() {
-                Ok(g) if g.len() >= PHASE2_RAW_CAP => Some(ReadSkip::RawFull),
-                Ok(_) => None,
-                // Treated as full, as it always has been -- but recorded as
-                // contention, because a FIFO whose depth we could not read is
-                // not evidence that read-ahead depth is the constraint.
-                Err(_) => Some(ReadSkip::RawLockContended),
-            };
-            if let Some(read_skip) = read_skip {
-                tally.note(combine_skip(pop_skip, read_skip));
+            // Treated as full when contended, as it always has been -- but
+            // recorded as contention, because a FIFO whose depth we could not
+            // read is not evidence that read-ahead depth is the constraint.
+            let Ok(raw_guard) = file.raw_blocks.try_lock() else {
+                tally.note(combine_skip(pop_skip, ReadSkip::RawLockContended));
                 continue;
-            }
+            };
+            let admitted = admitted_read_batch(raw_guard.len(), raw_cap, read_batch);
+            drop(raw_guard);
+            let Some(read_batch) = admitted else {
+                tally.note(combine_skip(pop_skip, ReadSkip::RawFull));
+                continue;
+            };
 
             // Both codecs read into the same `Vec<Vec<u8>>`, so the read is
             // dispatched on the codec but the failure is handled once. The two
@@ -2194,12 +2265,12 @@ impl SortWorkerPool {
                 SpillCodec::Bgzf => shared
                     .merge_phases
                     .read
-                    .time(|| read_raw_blocks(&mut reader_guard.inner, PHASE2_READ_BATCH))
+                    .time(|| read_raw_blocks(&mut reader_guard.inner, read_batch))
                     .map(|blocks| blocks.into_iter().map(|b| b.data).collect()),
                 SpillCodec::Zstd => shared
                     .merge_phases
                     .read
-                    .time(|| read_raw_zstd_frames(&mut reader_guard.inner, PHASE2_READ_BATCH)),
+                    .time(|| read_raw_zstd_frames(&mut reader_guard.inner, read_batch)),
             };
             let raw_bytes: Vec<Vec<u8>> = match read {
                 Ok(bytes) => bytes,
@@ -2209,6 +2280,17 @@ impl SortWorkerPool {
                     return Self::retire_phase2_source(shared, worker, file, reader_guard, i, n);
                 }
             };
+
+            // Record which allowance this batch was taken at, and what it
+            // returned, so "the deep path did not help" can be told apart from
+            // "the deep path did not run".
+            let (batches, blocks) = if i == frontier {
+                (&shared.deep_read_batches, &shared.deep_read_blocks)
+            } else {
+                (&shared.shallow_read_batches, &shared.shallow_read_blocks)
+            };
+            batches.fetch_add(1, Ordering::Relaxed);
+            blocks.fetch_add(raw_bytes.len() as u64, Ordering::Relaxed);
 
             if raw_bytes.is_empty() {
                 return Self::retire_phase2_source(shared, worker, file, reader_guard, i, n);
@@ -2693,6 +2775,17 @@ impl SortWorkerPool {
     /// reorder buffers via this snapshot.
     pub(crate) fn phase2_files(&self) -> Arc<Vec<Phase2FileState>> {
         self.shared.phase2_files_snapshot()
+    }
+
+    /// Phase 2 read batches split by allowance:
+    /// `(frontier_batches, frontier_blocks, other_batches, other_blocks)`.
+    pub(crate) fn read_batch_split(&self) -> (u64, u64, u64, u64) {
+        (
+            self.shared.deep_read_batches.load(Ordering::Relaxed),
+            self.shared.deep_read_blocks.load(Ordering::Relaxed),
+            self.shared.shallow_read_batches.load(Ordering::Relaxed),
+            self.shared.shallow_read_blocks.load(Ordering::Relaxed),
+        )
     }
 
     /// Set the current pipeline phase.
@@ -3453,6 +3546,41 @@ mod tests {
         assert_eq!(pool.num_workers(), 8, "the pool is still eight threads wide");
         assert_eq!(pool.active_workers(), 3, "but only three may take Phase 2 work");
         pool.shutdown();
+    }
+
+    /// A read may never carry the raw FIFO past its cap.
+    ///
+    /// The cap is a read-ahead memory bound, and admitting on "not yet full"
+    /// and then reading a full batch breaks it by up to a batch. Every case
+    /// asserts the post-read depth against the cap rather than the returned
+    /// figure alone, because that bound is the property, not the arithmetic.
+    #[rstest]
+    // Well under the cap: the batch is what limits the read, not the headroom.
+    #[case::far_below_the_cap_reads_a_full_batch(0, 512, 32, Some(32))]
+    #[case::shallow_path_far_below_the_cap(0, 8, 4, Some(4))]
+    // One entry below the allowance -- the case that used to overshoot by 31.
+    #[case::one_below_the_frontier_cap_reads_one(511, 512, 32, Some(1))]
+    #[case::one_below_the_shallow_cap_reads_one(7, 8, 4, Some(1))]
+    // Partly full: headroom is what limits the read.
+    #[case::headroom_shorter_than_the_batch(500, 512, 32, Some(12))]
+    // At or past the cap: no read at all.
+    #[case::at_the_cap_declines(512, 512, 32, None)]
+    #[case::past_the_cap_declines(600, 512, 32, None)]
+    fn read_batch_never_overshoots_the_raw_fifo_cap(
+        #[case] raw_len: usize,
+        #[case] raw_cap: usize,
+        #[case] read_batch: usize,
+        #[case] expected: Option<usize>,
+    ) {
+        let admitted = admitted_read_batch(raw_len, raw_cap, read_batch);
+        assert_eq!(admitted, expected);
+        if let Some(n) = admitted {
+            assert!(n > 0, "an admitted read must fetch something");
+            assert!(
+                raw_len + n <= raw_cap,
+                "read of {n} on a FIFO of {raw_len} exceeds the cap of {raw_cap}"
+            );
+        }
     }
 
     /// A wait that straddles the Phase 1 -> Phase 2 boundary belongs to

--- a/crates/fgumi-sort/tests/integration/test_output_compression.rs
+++ b/crates/fgumi-sort/tests/integration/test_output_compression.rs
@@ -192,7 +192,7 @@ struct SortRun {
 }
 
 /// Sorts `input` in `sort_order` under `run` and returns
-/// `(output_size_bytes, chunks_written, decoded_records)`.
+/// `(output_size_bytes, runs_written, decoded_records)`.
 ///
 /// `expected` is the independent baseline the output is checked against — the
 /// multiset of the *input* records, decoded straight from the input BAM without
@@ -246,13 +246,13 @@ fn sort_at_level(
         "level {output_compression} output is not in {sort_order:?} order"
     );
     let size = std::fs::metadata(output).expect("output metadata").len();
-    (size, stats.chunks_written, records)
+    (size, stats.runs_written, records)
 }
 
 /// `output_compression` must change the size of the written BAM.
 ///
 /// Both merge paths are covered: a memory limit large enough to hold everything
-/// (no spill, `chunks_written == 0`) and one small enough to force spill files.
+/// (no spill, `runs_written == 0`) and one small enough to force spill files.
 /// Only the in-memory case was broken — it never entered Phase 2, and back then
 /// the phase was what chose the compressor, so the pool used the Phase 1 spill
 /// one.
@@ -302,22 +302,22 @@ fn test_output_compression_level_reaches_the_output_bam(
     };
 
     let uncompressed = dir.path().join("level0.bam");
-    let (size_level_0, chunks_0, records_level_0) =
+    let (size_level_0, runs_0, records_level_0) =
         sort_at_level(sort_order, &input, &uncompressed, run_at(0), &expected);
 
     let compressed = dir.path().join("level9.bam");
-    let (size_level_9, chunks_9, records_level_9) =
+    let (size_level_9, runs_9, records_level_9) =
         sort_at_level(sort_order, &input, &compressed, run_at(9), &expected);
 
     assert_eq!(
-        chunks_0 > 0,
+        runs_0 > 0,
         expect_spill,
-        "expected spill={expect_spill}, got chunks_written={chunks_0} at level 0 ({sort_order:?})"
+        "expected spill={expect_spill}, got runs_written={runs_0} at level 0 ({sort_order:?})"
     );
     assert_eq!(
-        chunks_9 > 0,
+        runs_9 > 0,
         expect_spill,
-        "expected spill={expect_spill}, got chunks_written={chunks_9} at level 9 ({sort_order:?})"
+        "expected spill={expect_spill}, got runs_written={runs_9} at level 9 ({sort_order:?})"
     );
 
     // Both runs were already checked against the independent baseline above;
@@ -388,10 +388,10 @@ fn test_temp_compression_does_not_reach_the_output_bam(
             temp_compression,
             write_index,
         };
-        let (size, chunks, scanned) = sort_at_level(sort_order, &input, &output, run, &expected);
+        let (size, runs, scanned) = sort_at_level(sort_order, &input, &output, run, &expected);
         assert!(
-            chunks > 0,
-            "test must exercise the spilling path, but no chunks were written \
+            runs > 0,
+            "test must exercise the spilling path, but no spill runs were written \
              ({sort_order:?}, temp_compression={temp_compression})"
         );
 

--- a/crates/fgumi-sort/tests/integration/test_read_ahead.rs
+++ b/crates/fgumi-sort/tests/integration/test_read_ahead.rs
@@ -49,7 +49,7 @@ fn test_pool_integrated_reader_round_trip_coordinate() {
         expected, stats.total_records
     );
     assert_eq!(stats.output_records, expected);
-    assert_eq!(stats.chunks_written, 0, "tiny BAM should fit in memory");
+    assert_eq!(stats.runs_written, 0, "tiny BAM should fit in memory");
 }
 
 /// Same round-trip but with template-coordinate sort order to exercise the

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -774,15 +774,15 @@ impl Sort {
         }
 
         let stats = sorter.sort(&self.input, output)?;
-        let (total_records, output_records, chunks_written) =
-            (stats.total_records, stats.output_records, stats.chunks_written);
+        let (total_records, output_records, runs_written) =
+            (stats.total_records, stats.output_records, stats.runs_written);
 
         // Summary
         info!("=== Summary ===");
         info!("Records processed: {total_records}");
         info!("Records written: {output_records}");
-        if chunks_written > 0 {
-            info!("Temporary chunks: {chunks_written}");
+        if runs_written > 0 {
+            info!("Spill runs: {runs_written}");
         }
         info!("Output: {}", output.display());
 
@@ -1472,9 +1472,9 @@ mod tests {
         // `Some(2)` run exercised consolidation rather than a trivial in-memory
         // sort. Without this the identity assertion below could pass vacuously.
         assert!(
-            default_stats.chunks_written >= 2,
-            "test must spill multiple runs to exercise consolidation, got {} chunk(s)",
-            default_stats.chunks_written,
+            default_stats.runs_written >= 2,
+            "test must spill multiple runs to exercise consolidation, got {} run(s)",
+            default_stats.runs_written,
         );
         assert_eq!(
             limited_stats.output_records, default_stats.output_records,

--- a/tests/integration/test_streaming_output.rs
+++ b/tests/integration/test_streaming_output.rs
@@ -198,7 +198,7 @@ fn the_spilling_fixture_spills() {
     );
     let log = String::from_utf8_lossy(&run.stderr);
     assert!(
-        log.contains("Temporary chunks:"),
+        log.contains("Spill runs:"),
         "20k records under `-m 1M` no longer spill, so the merge path is not being covered:\n{log}"
     );
 }


### PR DESCRIPTION
Sorting an already-`SO:coordinate` BAM *to* coordinate order is a real user action — idempotent pipeline steps, re-sorting someone else's output — and it is the case the k-way merge handles worst. Phase 1 chunks its input sequentially, so an already-ordered input spills coordinate-**disjoint** runs: source 0 holds the earliest records, source 1 the next. The merge then drains one source at a time instead of interleaving, and the case that should be fastest is the slowest one.

Measured on GIAB-scale real data (`1kg-wgs-HG00096`, 779,820,469 records, 86 spills, c7g.4xlarge, 8 threads, `--max-memory 512M --max-temp-files 1024 --temp-compression 1 --compression-level 1`, spills on xfs):

| | degenerate (coord→coord) | interleaved (qname→coord) |
| --- | --- | --- |
| merge loop | 308.4s / 308.8s | 183.3s / 184.2s |
| worker utilization | 56% | 98% |
| consumer parked | 240.0s (78%) | 59.0s (32%) |
| consecutive blocks per source | 29,540 | 1.0 |

Same records, same host, same flags, back-to-back. Rep spread on the merge loop is 0.03–0.16%, so >1% is signal.

## What this changes

**Serve the starving source first, and wake a worker when one runs dry.** Workers scanned files from their own round-robin cursor, which spreads the pool well when every file is hot but wastes most of a scan when only one is. This tracks the drain frontier and starts the scan there when that source is starving — gated on *starving* so an interleaved merge, where the frontier is merely active, keeps the spread that makes it fast. Separately, nothing ever unparked a pool worker: the wake path ran one way, workers → main thread, so a dry source waited out a backoff. Workers now park with a timeout so the consumer can wake one the instant a reorder buffer drains.

**Let the source being drained read further ahead** — 32 blocks per read instead of 4, and 512 raw blocks of read-ahead instead of 8, scoped to the frontier so the extra memory is ~4.7 MB for one file rather than K times that.

**Warn when the input header already declares the requested order.** One line, no behaviour change. Deliberately a warning and not a skip, since headers lie, and conservative about what counts as a match: `SO` must agree, and when the order defines a sub-sort tag `SS` must agree too, so a `queryname` input with no `SS` does not warn for either flavor.

Also adds a blocks-per-batch counter to the merge log, split by frontier vs other. That exists because an earlier version of the read-ahead gate silently fired for only 6% of batches and read *identically* to a change that did not help — the shape of bug this counter makes visible.

## Results

| | baseline | +priority/unpark | +read-ahead 64 | +read-ahead 512 |
| --- | --- | --- | --- | --- |
| degenerate merge loop | 308.15s | 301.35s | 288.0s | **279.9s** |
| consumer parked | 240.0s | 231.8s | 215.4s | 210.1s |
| worker utilization | 56% | 57% | 59% | 61% |
| interleaved merge loop | 183.3s | 183.3s | 183.2s | 183.2s |
| peak RSS | — | — | 4.55 GB | 4.55 GB |

**−9.2% on the degenerate merge loop, no regression on the interleaved arm, flat peak RSS.** The scoping is visible in the counter: the interleaved regime sends only 1.2% of its blocks down the deep path, because it has no single hot source.

## What is *not* claimed

The improvement is reproducible; the mechanism is not established. Four hypotheses were tested and refuted along the way, each by measurement:

- **Worker discovery lag** — waking workers earlier left it unchanged at 78.4s.
- **Read batch count** — raising it did nothing on its own.
- **Read request size** — the volume is 7.5× faster at 1 MB than 64 KB (`dd`, `O_DIRECT`), so larger reads looked like the fix; making requests 8× larger moved read throughput 342 → 340 MB/s.
- **FIFO-full backpressure** — an 8× deeper cap moved read *duty cycle* only 47.6% → 48.8%, not toward 100% as predicted.

Read busy time is pinned near 137s across every variant, cap and batch size tried. So roughly 100s of the remaining merge is unexplained by any counter currently in the code. The `PHASE2_STARVING_RAW_CAP` doc comment records this explicitly rather than leaving a plausible-but-refuted story for the next person to tune against.

A scaled reproducer (40M records, `--max-memory 26M`) reproduces the spill regime exactly — 86/87 spills — but **not** the penalty: 8.7s vs 9.3s, i.e. the degenerate arm is marginally faster when everything fits in page cache. Useful for iterating on correctness in seconds; useless for judging anything I/O-related.

Full write-up, including the device characterization and the wrong turns: `reports/2026-08-03-merge-idle-time-preliminary.md` in fgumi-benchmarks.

## Correctness

Output is unaffected by design — this changes only which file a worker looks at first, how far ahead it reads, and when it wakes. `sort --verify` PASSes both baseline arms (779,820,469 records, 0 violations), and `fgumi compare bams --command sort` between pre-fix and post-fix output on both arms is running at time of opening; I will post the verdicts here. Output file sizes already differ from pre-fix by 2 bytes on the degenerate arm, consistent with the `@PG` command line and nothing else.

703 `fgumi-sort` tests pass, including 6 new ones for the header predicate — covering the queryname-without-`SS` ambiguity, template-coordinate needing `SS` to disambiguate from plain unsorted, and round-tripping fgumi's own output headers.

## Follow-up, not in this PR

On sorted input the runs are not merely disjoint but *totally ordered*, so the merge is nearly a concatenation. The larger win is skipping it: if the input header declares the requested order, rewrite the header and copy the input's BGZF blocks — for this workload ~150s against ~567s, a ~3.8× win on the whole command, with `--force-sort` as the escape hatch. `header_declares_order` from this PR is already the predicate that branch would test. The version that survives *almost*-sorted input records each chunk's key range at spill time and streams single-covered ranges while merging only overlaps. Designing that is the next piece of work.

## Base

#706 has landed. Stacked on #708 — review that first; retarget to `main` once it lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: sort output changes are pinned by record-count invariants and independent sort verification; `unsafe` changes are none and the CLAUDE.md allowlist is unchanged; read-ahead limits and worker wake/backpressure policy changed, while peak RSS remained flat.

Fix: improve k-way merge scheduling and spill-run formation.

- Prioritize starving sources and wake workers when sources run dry.
- Add frontier-scoped read-ahead and merge batch diagnostics.
- Form natural spill runs for coordinate, template-coordinate, and queryname orders.
- Handle BGZF terminators when appending spill runs.
- Track spill runs with `SortStats::runs_written`.
- Add conservative `SO`/`SS` header-order warnings.
- Enforce record-count invariants and clean up invalid regular-file outputs.
- Improve coordinate-to-coordinate merge time from 308.15s to 279.9s on GIAB-scale data.
- Preserve interleaved-input performance and keep peak RSS flat.
- Pass more than 7,000 workspace tests, clippy, formatting, and documentation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
