### PR TITLE
perf(sort): form natural runs at spill time so sorted input needs no merge

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1883,6 +1883,14 @@ fn log_run_formation(chunks_spilled: usize, runs: usize) {
 ///
 /// The buffer must already be sorted; these are read off its ends rather than
 /// scanned, which is what makes run formation free.
+/// The smallest and largest keys in a sorted `(key, record)` buffer.
+///
+/// Clones rather than copies: `RawQuerynameKey` owns its read name, so the
+/// boundary key is one small allocation that outlives the chunk safely.
+fn keyed_chunk_bounds<K: Clone, R>(entries: &[(K, R)]) -> (Option<K>, Option<K>) {
+    (entries.first().map(|(k, _)| k.clone()), entries.last().map(|(k, _)| k.clone()))
+}
+
 /// The smallest and largest template keys in a sorted template buffer.
 ///
 /// `TemplateRecordRef` caches its key, so like the coordinate case these are the
@@ -1902,7 +1910,7 @@ fn coordinate_chunk_bounds(
     (refs.first().map(key), refs.last().map(key))
 }
 
-impl<K: Copy + Ord> RunFormer<K> {
+impl<K: Clone + Ord> RunFormer<K> {
     fn new() -> Self {
         Self { open: None }
     }
@@ -3382,6 +3390,10 @@ impl RawExternalSorter {
         let mut memory_used = 0usize;
         let mut namer = ChunkNamer::new(alloc);
         let mut pending_spill: Option<PendingSpill> = None;
+        // Natural run formation: consecutive chunks already in queryname order
+        // extend one run instead of each becoming its own merge source.
+        let mut run_former: RunFormer<K> = RunFormer::new();
+        let mut chunks_spilled: usize = 0;
         let rayon_pool = self.build_sort_rayon_pool()?;
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
@@ -3430,8 +3442,6 @@ impl RawExternalSorter {
                 )?;
                 probe.post_drain(bstats, Some(pool.phase1_queue_depths()));
 
-                let chunk_path = namer.next_chunk_path()?;
-
                 timer.time_sort(|| {
                     use rayon::prelude::*;
                     // `entries` is in ingest order, and exact-queryname-key ties must keep
@@ -3444,24 +3454,40 @@ impl RawExternalSorter {
                     rayon_pool.install(|| entries.par_sort_unstable_by(|a, b| a.0.cmp(&b.0)));
                 });
 
+                run_former.forget_if_absent(&chunk_files);
+                let (chunk_min, chunk_max) = keyed_chunk_bounds(&entries);
+                let (chunk_path, appended) =
+                    match chunk_min.and_then(|min| run_former.appendable(&min).cloned()) {
+                        Some(path) => (path, true),
+                        None => (namer.next_chunk_path()?, false),
+                    };
+                chunks_spilled += 1;
+
                 // Write keyed temp file with parallel BGZF compression via worker pool.
                 let handle = timer.time_spill_write(|| {
-                    let mut writer = PooledChunkWriter::<K>::new(
-                        Arc::clone(&pool),
-                        &chunk_path,
-                        pool.spill_codec(),
-                    )?;
+                    let mut writer = if appended {
+                        PooledChunkWriter::<K>::append(
+                            Arc::clone(&pool),
+                            &chunk_path,
+                            pool.spill_codec(),
+                        )?
+                    } else {
+                        PooledChunkWriter::<K>::new(
+                            Arc::clone(&pool),
+                            &chunk_path,
+                            pool.spill_codec(),
+                        )?
+                    };
                     for (key, record) in entries.drain(..) {
                         writer.write_record(&key, record.as_ref())?;
                     }
                     writer.start_finish()
                 })?;
 
-                // Queryname keeps one file per chunk: `RawQuerynameKey` borrows raw
-                // pointers into the record buffer, so retaining one as a run's last
-                // key past the chunk that produced it would dangle. Supporting it
-                // needs owned boundary bytes, not just a wider trait bound.
-                pending_spill = Some(PendingSpill { handle, chunk_path, appended: false });
+                if let Some(max) = chunk_max {
+                    run_former.extended(chunk_path.clone(), max);
+                }
+                pending_spill = Some(PendingSpill { handle, chunk_path, appended });
 
                 memory_used = 0;
                 force_mi_collect();
@@ -3568,6 +3594,7 @@ impl RawExternalSorter {
             let memory_chunks = MemorySources::Owned(keyed_chunks);
 
             let n_memory = memory_chunks.num_non_empty();
+            log_run_formation(chunks_spilled, chunk_files.len());
             debug!(
                 "Phase 2: Merging {} chunks (keyed comparisons)...",
                 chunk_files.len() + n_memory
@@ -6640,7 +6667,7 @@ mod tests {
             let descending = num_pairs - 1 - i;
             let _ = builder
                 .add_pair()
-                .name(&format!("read{i}"))
+                .name(&format!("read{descending:05}"))
                 .start1(descending * 200 + 1)
                 .start2(descending * 200 + 101)
                 .build();
@@ -6854,6 +6881,144 @@ mod tests {
     }
 
     /// Verifies that sort with many chunks exercises the pool-integrated
+    /// Sort `input` to `output` in `order`, spilling or not according to
+    /// `memory_limit`.
+    fn run_sort(
+        order: SortOrder,
+        input: &std::path::Path,
+        output: &std::path::Path,
+        memory_limit: usize,
+    ) -> RawSortStats {
+        RawExternalSorter::new(order)
+            .memory_limit(memory_limit)
+            .max_temp_files(0)
+            .threads(1)
+            .spill_codec(crate::codec::SpillCodec::Bgzf)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort(input, output)
+            .expect("sort should succeed")
+    }
+
+    /// Memory limit large enough that nothing spills.
+    const NO_SPILL_MEMORY: usize = 256 * 1024 * 1024;
+    /// Memory limit small enough to force many chunks.
+    const SPILL_MEMORY: usize = 8 * 1024;
+
+    /// Produce a BAM genuinely in `order`, by sorting without spilling.
+    ///
+    /// Built by sorting rather than by construction: no order implies another.
+    /// A coordinate-sorted file is not in template-coordinate order (template
+    /// keys derive from the earlier mate), and neither is in queryname order.
+    fn presorted_in(dir: &std::path::Path, order: SortOrder, num_pairs: usize) -> PathBuf {
+        let raw = build_ordered_bam(dir, num_pairs, true);
+        let sorted = dir.join(format!("presorted-{}.bam", order.header_so_tag()));
+        let stats = run_sort(order, &raw, &sorted, NO_SPILL_MEMORY);
+        assert_eq!(stats.chunks_written, 0, "setup must not spill");
+        assert_eq!(stats.total_records, stats.output_records);
+        sorted
+    }
+
+    /// Every sort order: input already in the requested order must collapse to a
+    /// single run, because run formation is what makes that case cheap.
+    #[rstest::rstest]
+    #[case::coordinate(SortOrder::Coordinate)]
+    #[case::queryname_lex(SortOrder::Queryname(QuerynameComparator::Lexicographic))]
+    #[case::queryname_natural(SortOrder::Queryname(QuerynameComparator::Natural))]
+    #[case::template_coordinate(SortOrder::TemplateCoordinate)]
+    fn test_presorted_input_collapses_to_one_run(#[case] order: SortOrder) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let presorted = presorted_in(dir.path(), order, 300);
+        let output = dir.path().join("output.bam");
+
+        let stats = run_sort(order, &presorted, &output, SPILL_MEMORY);
+
+        assert_eq!(
+            stats.chunks_written, 1,
+            "{order:?}: input already in this order should spill exactly one run, got {}",
+            stats.chunks_written
+        );
+        assert_eq!(stats.total_records, stats.output_records, "{order:?}: lost records");
+        assert_eq!(count_bam_records(&output), 600, "{order:?}: wrong record count");
+    }
+
+    /// Every sort order: input NOT in the requested order must not collapse.
+    /// This is the guard against run formation appending where it has no right to.
+    #[rstest::rstest]
+    #[case::coordinate(SortOrder::Coordinate)]
+    #[case::queryname_lex(SortOrder::Queryname(QuerynameComparator::Lexicographic))]
+    #[case::queryname_natural(SortOrder::Queryname(QuerynameComparator::Natural))]
+    #[case::template_coordinate(SortOrder::TemplateCoordinate)]
+    fn test_unsorted_input_never_collapses_to_one_run(#[case] order: SortOrder) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // Descending coordinates with names that ascend independently, so the
+        // input is out of order for coordinate and template-coordinate, and its
+        // name order does not track its coordinate order either.
+        let input = build_shuffled_bam(dir.path(), 300);
+        let output = dir.path().join("output.bam");
+
+        let stats = run_sort(order, &input, &output, SPILL_MEMORY);
+
+        assert!(
+            stats.chunks_written >= 2,
+            "{order:?}: unsorted input must not collapse into one run, got {}",
+            stats.chunks_written
+        );
+        assert_eq!(stats.total_records, stats.output_records, "{order:?}: lost records");
+        assert_eq!(count_bam_records(&output), 600, "{order:?}: wrong record count");
+    }
+
+    /// Every sort order: run formation must not change the output bytes.
+    ///
+    /// The appending path and the no-spill path must agree byte for byte. This is
+    /// the strongest available check -- it subsumes ordering, and for template it
+    /// is what confirms the buffer's lane-wise radix sort and the merge's
+    /// `K::cmp` agree, which run formation depends on.
+    #[rstest::rstest]
+    #[case::coordinate(SortOrder::Coordinate)]
+    #[case::queryname_lex(SortOrder::Queryname(QuerynameComparator::Lexicographic))]
+    #[case::queryname_natural(SortOrder::Queryname(QuerynameComparator::Natural))]
+    #[case::template_coordinate(SortOrder::TemplateCoordinate)]
+    fn test_run_formation_output_is_byte_identical(#[case] order: SortOrder) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let presorted = presorted_in(dir.path(), order, 300);
+
+        let spilled = dir.path().join("spilled.bam");
+        let in_memory = dir.path().join("in_memory.bam");
+
+        let spilled_stats = run_sort(order, &presorted, &spilled, SPILL_MEMORY);
+        assert_eq!(spilled_stats.chunks_written, 1, "{order:?}: expected the appending path");
+
+        let in_memory_stats = run_sort(order, &presorted, &in_memory, NO_SPILL_MEMORY);
+        assert_eq!(in_memory_stats.chunks_written, 0, "{order:?}: expected the no-spill path");
+
+        assert_eq!(
+            std::fs::read(&spilled).expect("read spilled"),
+            std::fs::read(&in_memory).expect("read in-memory"),
+            "{order:?}: appending runs changed the output bytes"
+        );
+    }
+
+    /// A BAM whose coordinates descend while its names ascend, so it is out of
+    /// order under every sort order this engine supports.
+    fn build_shuffled_bam(dir: &std::path::Path, num_pairs: usize) -> PathBuf {
+        use fgumi_sam::SamBuilder;
+        let mut builder = SamBuilder::new();
+        for i in 0..num_pairs {
+            let descending = num_pairs - 1 - i;
+            let _ = builder
+                .add_pair()
+                // Names descend too, so queryname order is also violated.
+                .name(&format!("read{descending:05}"))
+                .start1(descending * 200 + 1)
+                .start2(descending * 200 + 101)
+                .build();
+        }
+        let input = dir.join("shuffled.bam");
+        builder.write_bam(&input).expect("write bam");
+        input
+    }
+
     /// Build a coordinate BAM whose records ascend or descend by position.
     ///
     /// Ascending is "already coordinate-sorted"; descending is the worst case for
@@ -6885,45 +7050,6 @@ mod tests {
             .output_compression(0)
             .sort(input, output)
             .expect("sort should succeed")
-    }
-
-    /// Already-sorted input is the case run formation exists for: every chunk
-    /// extends the open run, so the merge sees one source instead of many.
-    #[test]
-    fn test_sorted_input_collapses_to_one_run() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let input = build_ordered_bam(dir.path(), 300, true);
-        let output = dir.path().join("output.bam");
-
-        let stats = sort_ordered_input(&input, &output);
-
-        assert_eq!(
-            stats.chunks_written, 1,
-            "coordinate-sorted input should spill exactly one run, got {}",
-            stats.chunks_written
-        );
-        assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
-        assert_eq!(count_bam_records(&output), 600);
-    }
-
-    /// Reverse-sorted input can never append, so behaviour is unchanged from
-    /// one-file-per-chunk. This is the guard against run formation quietly
-    /// merging runs it has no right to.
-    #[test]
-    fn test_reverse_sorted_input_never_appends() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let input = build_ordered_bam(dir.path(), 300, false);
-        let output = dir.path().join("output.bam");
-
-        let stats = sort_ordered_input(&input, &output);
-
-        assert!(
-            stats.chunks_written >= 2,
-            "reverse-sorted input must not collapse into one run, got {}",
-            stats.chunks_written
-        );
-        assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
-        assert_eq!(count_bam_records(&output), 600);
     }
 
     /// Build a coordinate BAM that ascends, drops once, then ascends again.
@@ -7028,134 +7154,6 @@ mod tests {
         assert_sorted_by_coordinate(&output);
     }
 
-    /// Run formation is wired for template-coordinate too, and its keys are
-    /// self-contained (three packed `u64` lanes), unlike queryname's.
-    ///
-    /// A BAM already in template-coordinate order must collapse to one run, and
-    /// the output must stay in that order -- the buffer's radix sort orders by
-    /// lanes while the merge compares via `K::cmp`, so run formation is only sound
-    /// if those agree.
-    #[test]
-    fn test_template_coordinate_sorted_input_collapses_to_one_run() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let unsorted = build_ordered_bam(dir.path(), 300, true);
-
-        // Produce a genuinely template-coordinate-ordered input by sorting once,
-        // rather than assuming coordinate order implies template order.
-        let template_sorted = dir.path().join("template_sorted.bam");
-        let first = RawExternalSorter::new(SortOrder::TemplateCoordinate)
-            .memory_limit(256 * 1024 * 1024)
-            .threads(1)
-            .spill_codec(crate::codec::SpillCodec::Bgzf)
-            .temp_compression(0)
-            .output_compression(0)
-            .sort(&unsorted, &template_sorted)
-            .expect("first template sort should succeed");
-        assert_eq!(first.total_records, first.output_records);
-
-        let output = dir.path().join("resorted.bam");
-        let stats = RawExternalSorter::new(SortOrder::TemplateCoordinate)
-            .memory_limit(8 * 1024)
-            .max_temp_files(0)
-            .threads(1)
-            .spill_codec(crate::codec::SpillCodec::Bgzf)
-            .temp_compression(0)
-            .output_compression(0)
-            .sort(&template_sorted, &output)
-            .expect("re-sort should succeed");
-
-        assert_eq!(
-            stats.chunks_written, 1,
-            "template-coordinate-sorted input should collapse to one run, got {}",
-            stats.chunks_written
-        );
-        assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
-        assert_eq!(count_bam_records(&output), 600);
-
-        // Re-sorting an already-sorted file is a fixed point: byte-identical
-        // apart from the @PG the second run adds, so compare records only.
-        assert_eq!(
-            count_bam_records(&template_sorted),
-            count_bam_records(&output),
-            "re-sort changed the record count"
-        );
-    }
-
-    /// The template path must not append when the input is not in template order.
-    #[test]
-    fn test_template_coordinate_unsorted_input_never_appends() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let input = build_ordered_bam(dir.path(), 300, false);
-        let output = dir.path().join("output.bam");
-
-        let stats = RawExternalSorter::new(SortOrder::TemplateCoordinate)
-            .memory_limit(8 * 1024)
-            .max_temp_files(0)
-            .threads(1)
-            .spill_codec(crate::codec::SpillCodec::Bgzf)
-            .temp_compression(0)
-            .output_compression(0)
-            .sort(&input, &output)
-            .expect("sort should succeed");
-
-        assert!(
-            stats.chunks_written >= 2,
-            "reverse-ordered input must not collapse into one run, got {}",
-            stats.chunks_written
-        );
-        assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
-        assert_eq!(count_bam_records(&output), 600);
-    }
-
-    /// Run formation must not change template-coordinate output either. Sorting
-    /// with a limit that forces appending and with one that never spills must
-    /// produce identical bytes.
-    #[test]
-    fn test_template_run_formation_output_is_byte_identical() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let unsorted = build_ordered_bam(dir.path(), 300, true);
-
-        let template_sorted = dir.path().join("template_sorted.bam");
-        RawExternalSorter::new(SortOrder::TemplateCoordinate)
-            .memory_limit(256 * 1024 * 1024)
-            .threads(1)
-            .spill_codec(crate::codec::SpillCodec::Bgzf)
-            .temp_compression(0)
-            .output_compression(0)
-            .sort(&unsorted, &template_sorted)
-            .expect("first template sort should succeed");
-
-        let spilled = dir.path().join("spilled.bam");
-        let in_memory = dir.path().join("in_memory.bam");
-
-        let spilled_stats = RawExternalSorter::new(SortOrder::TemplateCoordinate)
-            .memory_limit(8 * 1024)
-            .max_temp_files(0)
-            .threads(1)
-            .spill_codec(crate::codec::SpillCodec::Bgzf)
-            .temp_compression(0)
-            .output_compression(0)
-            .sort(&template_sorted, &spilled)
-            .expect("spilling sort should succeed");
-        assert_eq!(spilled_stats.chunks_written, 1, "expected the appending path");
-
-        let in_memory_stats = RawExternalSorter::new(SortOrder::TemplateCoordinate)
-            .memory_limit(256 * 1024 * 1024)
-            .threads(1)
-            .spill_codec(crate::codec::SpillCodec::Bgzf)
-            .temp_compression(0)
-            .output_compression(0)
-            .sort(&template_sorted, &in_memory)
-            .expect("in-memory sort should succeed");
-        assert_eq!(in_memory_stats.chunks_written, 0, "expected the no-spill path");
-
-        assert_eq!(
-            std::fs::read(&spilled).expect("read spilled"),
-            std::fs::read(&in_memory).expect("read in-memory"),
-            "appending runs changed template-coordinate output bytes"
-        );
-    }
-
     /// The indexed path got run formation too, so cover appending there: the
     /// merge sees one source instead of many while still emitting a BAI.
     #[test]
@@ -7179,37 +7177,6 @@ mod tests {
         assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
         assert_eq!(count_bam_records(&output), 600);
         assert!(output.with_extension("bam.bai").exists(), "index should be written");
-    }
-
-    /// Run formation must not change the bytes. Sorting the same records with a
-    /// memory limit that forces appending, and with one large enough that nothing
-    /// spills at all, must produce identical output.
-    #[test]
-    fn test_run_formation_output_is_byte_identical() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let input = build_ordered_bam(dir.path(), 300, true);
-
-        let spilled = dir.path().join("spilled.bam");
-        let in_memory = dir.path().join("in_memory.bam");
-
-        let spilled_stats = sort_ordered_input(&input, &spilled);
-        assert_eq!(spilled_stats.chunks_written, 1, "expected the appending path");
-
-        let in_memory_stats = RawExternalSorter::new(SortOrder::Coordinate)
-            .memory_limit(256 * 1024 * 1024)
-            .threads(1)
-            .spill_codec(crate::codec::SpillCodec::Bgzf)
-            .temp_compression(0)
-            .output_compression(0)
-            .sort(&input, &in_memory)
-            .expect("in-memory sort should succeed");
-        assert_eq!(in_memory_stats.chunks_written, 0, "expected the no-spill path");
-
-        assert_eq!(
-            std::fs::read(&spilled).expect("read spilled"),
-            std::fs::read(&in_memory).expect("read in-memory"),
-            "appending runs changed the output bytes"
-        );
     }
 
     /// A run that several chunks were appended to must carry exactly one BGZF
@@ -7263,7 +7230,7 @@ mod tests {
             let descending = num_pairs - 1 - i;
             let _ = builder
                 .add_pair()
-                .name(&format!("read{i}"))
+                .name(&format!("read{descending:05}"))
                 .start1(descending * 200 + 1)
                 .start2(descending * 200 + 101)
                 .build();
@@ -8069,7 +8036,7 @@ mod tests {
             let descending = num_pairs - 1 - i;
             let _ = builder
                 .add_pair()
-                .name(&format!("read{i:05}"))
+                .name(&format!("read{descending:05}"))
                 .start1(descending * 200 + 1)
                 .start2(descending * 200 + 101)
                 .build();
@@ -8186,7 +8153,7 @@ mod tests {
             let descending = num_pairs - 1 - i;
             let _ = builder
                 .add_pair()
-                .name(&format!("read{i:05}"))
+                .name(&format!("read{descending:05}"))
                 .start1(descending * 200 + 1)
                 .start2(descending * 200 + 101)
                 .build();

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1823,6 +1823,102 @@ impl<'a> ChunkNamer<'a> {
 struct PendingSpill {
     handle: crate::pooled_chunk_writer::SpillWriteHandle,
     chunk_path: PathBuf,
+    /// Whether this chunk extended an existing run rather than starting one.
+    /// An extended run is already in `chunk_files`, so it must not be added twice.
+    appended: bool,
+}
+
+/// Decides whether the next sorted chunk extends the open spill run or starts a
+/// new one — "natural run formation".
+///
+/// Phase 1 chunks its input sequentially, so an input already in the requested
+/// order produces chunks that are not merely disjoint but *totally ordered*:
+/// chunk 0 holds the earliest records, chunk 1 the next. Writing each to its own
+/// file manufactures a k-way merge for a sequence that was never interleaved.
+/// Appending instead collapses sorted input to a single run, and almost-sorted
+/// input to its natural runs.
+///
+/// # Why only the most recent run
+///
+/// Considering older runs too (best fit) yields fewer runs on adversarial input
+/// but breaks stability. Suppose run 0 ended at key 100 and stopped receiving,
+/// run 1 is at 200, and a chunk arrives with minimum 150: best fit appends it to
+/// run 0, so run 0 holds chunks {0,1,2,9} while run 1 holds {3,4}. Source index
+/// order no longer matches ingest order, and for a key present in both chunk 3
+/// and chunk 9 the merge would emit chunk 9's copy first.
+///
+/// Restricting appends to the most recent run keeps every run a *consecutive*
+/// group of chunks, so source order equals ingest order. Combined with the loser
+/// tree's tie-break on source index (`LoserTree::is_greater`), output is
+/// byte-identical to writing one file per chunk.
+struct RunFormer<K> {
+    /// The open run: its path and the key of its last record. `None` before the
+    /// first spill, and after a consolidation that swallowed the run.
+    open: Option<(PathBuf, K)>,
+}
+
+/// Report how many spilled chunks became how many merge sources.
+///
+/// Sorted input collapses to one run, almost-sorted input to its natural runs,
+/// shuffled input to one run per chunk. Logging the ratio means every sort
+/// reports how ordered its own input was, which is the cheapest way to learn how
+/// common near-sorted inputs are in practice.
+fn log_run_formation(chunks_spilled: usize, runs: usize) {
+    if chunks_spilled == 0 {
+        return;
+    }
+    if chunks_spilled == runs {
+        info!("Spill runs: {runs} (no chunk extended another; input not pre-sorted)");
+    } else {
+        info!(
+            "Spill runs: {runs} from {chunks_spilled} chunks \
+             ({} extended an existing run)",
+            chunks_spilled - runs
+        );
+    }
+}
+
+/// The smallest and largest coordinate keys in a sorted buffer, or `None` for an
+/// empty one.
+///
+/// The buffer must already be sorted; these are read off its ends rather than
+/// scanned, which is what makes run formation free.
+fn coordinate_chunk_bounds(
+    buffer: &crate::inline::RecordBuffer,
+) -> (Option<crate::keys::RawCoordinateKey>, Option<crate::keys::RawCoordinateKey>) {
+    let refs = buffer.refs();
+    let key = |r: &crate::inline::RecordRef| crate::keys::RawCoordinateKey { sort_key: r.sort_key };
+    (refs.first().map(key), refs.last().map(key))
+}
+
+impl<K: Copy + Ord> RunFormer<K> {
+    fn new() -> Self {
+        Self { open: None }
+    }
+
+    /// The path to append to for a chunk whose smallest key is `chunk_min`, or
+    /// `None` if it must start a new run.
+    fn appendable(&self, chunk_min: &K) -> Option<&PathBuf> {
+        match &self.open {
+            Some((path, last_key)) if last_key <= chunk_min => Some(path),
+            _ => None,
+        }
+    }
+
+    /// Record that a chunk ending at `chunk_max` was written to `path`.
+    fn extended(&mut self, path: PathBuf, chunk_max: K) {
+        self.open = Some((path, chunk_max));
+    }
+
+    /// Drop the open run if consolidation merged it away, so the next chunk does
+    /// not append to a path that no longer holds what we think it does.
+    fn forget_if_absent(&mut self, chunk_files: &[PathBuf]) {
+        if let Some((path, _)) = &self.open
+            && !chunk_files.contains(path)
+        {
+            self.open = None;
+        }
+    }
 }
 
 /// Build `BufferProbeStats` from any buffer implementing `ProbeableBuffer`.
@@ -2251,8 +2347,12 @@ impl RawExternalSorter {
         if let Some(prev) = pending.take() {
             prev.handle.wait()?;
             timer.record_spill_size(&prev.chunk_path);
-            chunk_files.push(prev.chunk_path);
-            stats.chunks_written += 1;
+            // A chunk that extended an existing run is already represented in
+            // `chunk_files`; only a chunk that started a run adds a merge source.
+            if !prev.appended {
+                chunk_files.push(prev.chunk_path);
+                stats.chunks_written += 1;
+            }
 
             timer.time_consolidate(|| {
                 self.maybe_consolidate_temp_files::<K>(chunk_files, namer, pool)
@@ -2814,6 +2914,10 @@ impl RawExternalSorter {
         let mut buffer = RecordBuffer::with_capacity(estimated_records, estimated_data_bytes, nref);
         let mut namer = ChunkNamer::new(alloc);
         let mut pending_spill: Option<PendingSpill> = None;
+        // Natural run formation: consecutive chunks that are already in order
+        // extend one run instead of each becoming its own merge source.
+        let mut run_former: RunFormer<crate::keys::RawCoordinateKey> = RunFormer::new();
+        let mut chunks_spilled: usize = 0;
         let rayon_pool = self.build_sort_rayon_pool()?;
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
@@ -2853,21 +2957,39 @@ impl RawExternalSorter {
                 )?;
                 probe.post_drain(probe_stats(&buffer), Some(pool.phase1_queue_depths()));
 
-                let chunk_path = namer.next_chunk_path()?;
-
                 timer.time_sort(|| {
                     rayon_pool.install(|| buffer.par_sort());
                 });
+
+                // The buffer is sorted, so the chunk's extreme keys are its ends.
+                // Consolidation may have merged the open run away while draining
+                // the previous spill, so re-check before trusting it.
+                run_former.forget_if_absent(&chunk_files);
+                let (chunk_min, chunk_max) = coordinate_chunk_bounds(&buffer);
+                let (chunk_path, appended) =
+                    match chunk_min.and_then(|min| run_former.appendable(&min).cloned()) {
+                        Some(path) => (path, true),
+                        None => (namer.next_chunk_path()?, false),
+                    };
+                chunks_spilled += 1;
 
                 // Write keyed temp file with parallel BGZF compression via worker pool.
                 // Use start_finish() for pipelining: I/O continues in background
                 // while we read the next batch.
                 let handle = timer.time_spill_write(|| {
-                    let mut writer = PooledChunkWriter::<RawCoordinateKey>::new(
-                        Arc::clone(&pool),
-                        &chunk_path,
-                        pool.spill_codec(),
-                    )?;
+                    let mut writer = if appended {
+                        PooledChunkWriter::<RawCoordinateKey>::append(
+                            Arc::clone(&pool),
+                            &chunk_path,
+                            pool.spill_codec(),
+                        )?
+                    } else {
+                        PooledChunkWriter::<RawCoordinateKey>::new(
+                            Arc::clone(&pool),
+                            &chunk_path,
+                            pool.spill_codec(),
+                        )?
+                    };
                     for r in buffer.refs() {
                         let key = RawCoordinateKey { sort_key: r.sort_key };
                         let record_bytes = buffer.get_record(r);
@@ -2876,7 +2998,10 @@ impl RawExternalSorter {
                     writer.start_finish()
                 })?;
 
-                pending_spill = Some(PendingSpill { handle, chunk_path });
+                if let Some(max) = chunk_max {
+                    run_former.extended(chunk_path.clone(), max);
+                }
+                pending_spill = Some(PendingSpill { handle, chunk_path, appended });
 
                 buffer.clear();
                 force_mi_collect();
@@ -2943,6 +3068,7 @@ impl RawExternalSorter {
 
             let memory_chunks = MemorySources::Shared(memory_chunks);
             let n_memory = memory_chunks.num_non_empty();
+            log_run_formation(chunks_spilled, chunk_files.len());
             debug!(
                 "Phase 2: Merging {} chunks (keyed O(1) comparisons)...",
                 chunk_files.len() + n_memory
@@ -3005,6 +3131,10 @@ impl RawExternalSorter {
         let mut buffer = RecordBuffer::with_capacity(estimated_records, estimated_data_bytes, nref);
         let mut namer = ChunkNamer::new(alloc);
         let mut pending_spill: Option<PendingSpill> = None;
+        // Natural run formation: consecutive chunks that are already in order
+        // extend one run instead of each becoming its own merge source.
+        let mut run_former: RunFormer<crate::keys::RawCoordinateKey> = RunFormer::new();
+        let mut chunks_spilled: usize = 0;
         let rayon_pool = self.build_sort_rayon_pool()?;
 
         debug!("Phase 1: Reading and sorting chunks (inline buffer, keyed output)...");
@@ -3035,18 +3165,33 @@ impl RawExternalSorter {
                 )?;
                 probe.post_drain(probe_stats(&buffer), Some(pool.phase1_queue_depths()));
 
-                let chunk_path = namer.next_chunk_path()?;
-
                 timer.time_sort(|| {
                     rayon_pool.install(|| buffer.par_sort());
                 });
 
+                run_former.forget_if_absent(&chunk_files);
+                let (chunk_min, chunk_max) = coordinate_chunk_bounds(&buffer);
+                let (chunk_path, appended) =
+                    match chunk_min.and_then(|min| run_former.appendable(&min).cloned()) {
+                        Some(path) => (path, true),
+                        None => (namer.next_chunk_path()?, false),
+                    };
+                chunks_spilled += 1;
+
                 let handle = timer.time_spill_write(|| {
-                    let mut writer = PooledChunkWriter::<RawCoordinateKey>::new(
-                        Arc::clone(&pool),
-                        &chunk_path,
-                        pool.spill_codec(),
-                    )?;
+                    let mut writer = if appended {
+                        PooledChunkWriter::<RawCoordinateKey>::append(
+                            Arc::clone(&pool),
+                            &chunk_path,
+                            pool.spill_codec(),
+                        )?
+                    } else {
+                        PooledChunkWriter::<RawCoordinateKey>::new(
+                            Arc::clone(&pool),
+                            &chunk_path,
+                            pool.spill_codec(),
+                        )?
+                    };
                     for r in buffer.refs() {
                         let key = RawCoordinateKey { sort_key: r.sort_key };
                         let record_bytes = buffer.get_record(r);
@@ -3055,7 +3200,10 @@ impl RawExternalSorter {
                     writer.start_finish()
                 })?;
 
-                pending_spill = Some(PendingSpill { handle, chunk_path });
+                if let Some(max) = chunk_max {
+                    run_former.extended(chunk_path.clone(), max);
+                }
+                pending_spill = Some(PendingSpill { handle, chunk_path, appended });
 
                 buffer.clear();
                 force_mi_collect();
@@ -3130,6 +3278,7 @@ impl RawExternalSorter {
 
             let memory_chunks = MemorySources::Shared(memory_chunks);
             let n_memory = memory_chunks.num_non_empty();
+            log_run_formation(chunks_spilled, chunk_files.len());
             debug!(
                 "Phase 2: Merging {} chunks with index generation...",
                 chunk_files.len() + n_memory
@@ -3297,7 +3446,11 @@ impl RawExternalSorter {
                     writer.start_finish()
                 })?;
 
-                pending_spill = Some(PendingSpill { handle, chunk_path });
+                // Queryname and template-coordinate keep one file per chunk for now:
+                // `RawQuerynameKey` borrows raw pointers into the record buffer, so a
+                // run's last key cannot outlive the chunk that produced it without
+                // owning those bytes. See the natural-run-formation follow-up.
+                pending_spill = Some(PendingSpill { handle, chunk_path, appended: false });
 
                 memory_used = 0;
                 force_mi_collect();
@@ -3666,7 +3819,11 @@ impl RawExternalSorter {
                     writer.start_finish()
                 })?;
 
-                pending_spill = Some(PendingSpill { handle, chunk_path });
+                // Queryname and template-coordinate keep one file per chunk for now:
+                // `RawQuerynameKey` borrows raw pointers into the record buffer, so a
+                // run's last key cannot outlive the chunk that produced it without
+                // owning those bytes. See the natural-run-formation follow-up.
+                pending_spill = Some(PendingSpill { handle, chunk_path, appended: false });
 
                 buffer.clear();
                 force_mi_collect();
@@ -6353,6 +6510,27 @@ mod tests {
         RawReadAheadReader::new(reader).count() as u64
     }
 
+    /// Assert the output really is in coordinate order.
+    ///
+    /// Record counts alone cannot distinguish "merged correctly" from "emitted
+    /// every record in the wrong order", which is exactly what a bad append
+    /// would produce.
+    fn assert_sorted_by_coordinate(path: &std::path::Path) {
+        use crate::inline::extract_coordinate_key_inline;
+        use crate::read_ahead::RawReadAheadReader;
+        let (reader, header) =
+            create_raw_bam_reader(path, 1).expect("failed to create raw BAM reader");
+        let nref = u32::try_from(header.reference_sequences().len()).expect("nref fits in u32");
+        let mut previous: Option<u64> = None;
+        for (index, record) in RawReadAheadReader::new(reader).enumerate() {
+            let key = extract_coordinate_key_inline(record.as_ref(), nref);
+            if let Some(prev) = previous {
+                assert!(prev <= key, "record {index} breaks coordinate order: {prev} then {key}");
+            }
+            previous = Some(key);
+        }
+    }
+
     /// Verifies that sort with consolidation preserves all records.
     ///
     /// Uses a tiny memory limit and low `max_temp_files` to force many chunks and
@@ -6425,12 +6603,16 @@ mod tests {
 
         let num_pairs = 30;
         let mut builder = SamBuilder::new();
+        // Descending coordinates: ascending input would fold into a single
+        // run under natural run formation, and this test needs several
+        // chunks to exercise consolidation.
         for i in 0..num_pairs {
+            let descending = num_pairs - 1 - i;
             let _ = builder
                 .add_pair()
                 .name(&format!("read{i}"))
-                .start1(i * 200 + 1)
-                .start2(i * 200 + 101)
+                .start1(descending * 200 + 1)
+                .start2(descending * 200 + 101)
                 .build();
         }
 
@@ -6642,6 +6824,267 @@ mod tests {
     }
 
     /// Verifies that sort with many chunks exercises the pool-integrated
+    /// Build a coordinate BAM whose records ascend or descend by position.
+    ///
+    /// Ascending is "already coordinate-sorted"; descending is the worst case for
+    /// run formation, where no chunk can ever extend another.
+    fn build_ordered_bam(dir: &std::path::Path, num_pairs: usize, ascending: bool) -> PathBuf {
+        use fgumi_sam::SamBuilder;
+        let mut builder = SamBuilder::new();
+        for i in 0..num_pairs {
+            let n = if ascending { i } else { num_pairs - 1 - i };
+            let _ = builder
+                .add_pair()
+                .name(&format!("read{i:05}"))
+                .start1(n * 200 + 1)
+                .start2(n * 200 + 101)
+                .build();
+        }
+        let input = dir.join("input.bam");
+        builder.write_bam(&input).expect("write bam");
+        input
+    }
+
+    fn sort_ordered_input(input: &std::path::Path, output: &std::path::Path) -> RawSortStats {
+        RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(8 * 1024)
+            .max_temp_files(0)
+            .threads(1)
+            .spill_codec(crate::codec::SpillCodec::Bgzf)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort(input, output)
+            .expect("sort should succeed")
+    }
+
+    /// Already-sorted input is the case run formation exists for: every chunk
+    /// extends the open run, so the merge sees one source instead of many.
+    #[test]
+    fn test_sorted_input_collapses_to_one_run() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = build_ordered_bam(dir.path(), 300, true);
+        let output = dir.path().join("output.bam");
+
+        let stats = sort_ordered_input(&input, &output);
+
+        assert_eq!(
+            stats.chunks_written, 1,
+            "coordinate-sorted input should spill exactly one run, got {}",
+            stats.chunks_written
+        );
+        assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
+        assert_eq!(count_bam_records(&output), 600);
+    }
+
+    /// Reverse-sorted input can never append, so behaviour is unchanged from
+    /// one-file-per-chunk. This is the guard against run formation quietly
+    /// merging runs it has no right to.
+    #[test]
+    fn test_reverse_sorted_input_never_appends() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = build_ordered_bam(dir.path(), 300, false);
+        let output = dir.path().join("output.bam");
+
+        let stats = sort_ordered_input(&input, &output);
+
+        assert!(
+            stats.chunks_written >= 2,
+            "reverse-sorted input must not collapse into one run, got {}",
+            stats.chunks_written
+        );
+        assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
+        assert_eq!(count_bam_records(&output), 600);
+    }
+
+    /// Build a coordinate BAM that ascends, drops once, then ascends again.
+    ///
+    /// The descent is placed past the first spill boundary so it closes an open
+    /// run rather than landing inside the first chunk, where sorting would
+    /// absorb it.
+    fn build_descent_bam(dir: &std::path::Path, num_pairs: usize) -> PathBuf {
+        use fgumi_sam::SamBuilder;
+        let mut builder = SamBuilder::new();
+        let half = num_pairs / 2;
+        for i in 0..num_pairs {
+            // Second half restarts low, so exactly one chunk boundary sees a key
+            // below the open run's last key.
+            let n = if i < half { i } else { i - half };
+            let _ = builder
+                .add_pair()
+                .name(&format!("read{i:05}"))
+                .start1(n * 200 + 1)
+                .start2(n * 200 + 101)
+                .build();
+        }
+        let input = dir.join("descent.bam");
+        builder.write_bam(&input).expect("write bam");
+        input
+    }
+
+    /// The case that distinguishes run formation from both extremes: a descent
+    /// closes the open run and opens exactly one more. Neither the all-sorted nor
+    /// the reverse-sorted test exercises `appendable()` returning `None` while a
+    /// run is open.
+    #[test]
+    fn test_descent_opens_exactly_one_more_run() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = build_descent_bam(dir.path(), 300);
+        let output = dir.path().join("output.bam");
+
+        let stats = sort_ordered_input(&input, &output);
+
+        assert!(
+            stats.chunks_written >= 2,
+            "a mid-stream descent must close the open run, got {} run(s)",
+            stats.chunks_written
+        );
+        assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
+        assert_eq!(count_bam_records(&output), 600);
+        assert_sorted_by_coordinate(&output);
+    }
+
+    /// Consolidation can merge the open run away, leaving `RunFormer` holding a
+    /// path that no longer means what it did. Appending there would duplicate or
+    /// drop records, so exercise it with consolidation actually enabled --
+    /// every other run-formation test disables it.
+    #[test]
+    fn test_consolidation_while_a_run_is_open() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = build_descent_bam(dir.path(), 400);
+        let output = dir.path().join("output.bam");
+
+        let stats = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(8 * 1024)
+            .max_temp_files(2) // small enough that consolidation can swallow the open run
+            .threads(1)
+            .spill_codec(crate::codec::SpillCodec::Bgzf)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort(&input, &output)
+            .expect("sort with consolidation should succeed");
+
+        assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
+        assert_eq!(count_bam_records(&output), 800);
+        assert_sorted_by_coordinate(&output);
+    }
+
+    /// Appending must work for both spill codecs. Zstd skips `ZSPILL_MAGIC` on
+    /// append -- a second magic mid-file would be read as frame data -- and that
+    /// branch is otherwise untested.
+    #[rstest::rstest]
+    #[case::bgzf(crate::codec::SpillCodec::Bgzf, 0)]
+    #[case::zstd(crate::codec::SpillCodec::Zstd, 1)]
+    fn test_append_across_spill_codecs(
+        #[case] codec: crate::codec::SpillCodec,
+        #[case] temp_compression: u32,
+    ) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = build_ordered_bam(dir.path(), 300, true);
+        let output = dir.path().join("output.bam");
+
+        let stats = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(8 * 1024)
+            .max_temp_files(0)
+            .threads(1)
+            .spill_codec(codec)
+            .temp_compression(temp_compression)
+            .output_compression(0)
+            .sort(&input, &output)
+            .expect("sort should succeed");
+
+        assert_eq!(stats.chunks_written, 1, "sorted input should collapse to one run");
+        assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
+        assert_eq!(count_bam_records(&output), 600);
+        assert_sorted_by_coordinate(&output);
+    }
+
+    /// The indexed path got run formation too, so cover appending there: the
+    /// merge sees one source instead of many while still emitting a BAI.
+    #[test]
+    fn test_appending_run_with_write_index() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = build_ordered_bam(dir.path(), 300, true);
+        let output = dir.path().join("output.bam");
+
+        let stats = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(8 * 1024)
+            .max_temp_files(0)
+            .threads(1)
+            .write_index(true)
+            .spill_codec(crate::codec::SpillCodec::Bgzf)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort(&input, &output)
+            .expect("indexed sort should succeed");
+
+        assert_eq!(stats.chunks_written, 1, "sorted input should collapse to one run");
+        assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
+        assert_eq!(count_bam_records(&output), 600);
+        assert!(output.with_extension("bam.bai").exists(), "index should be written");
+    }
+
+    /// Run formation must not change the bytes. Sorting the same records with a
+    /// memory limit that forces appending, and with one large enough that nothing
+    /// spills at all, must produce identical output.
+    #[test]
+    fn test_run_formation_output_is_byte_identical() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = build_ordered_bam(dir.path(), 300, true);
+
+        let spilled = dir.path().join("spilled.bam");
+        let in_memory = dir.path().join("in_memory.bam");
+
+        let spilled_stats = sort_ordered_input(&input, &spilled);
+        assert_eq!(spilled_stats.chunks_written, 1, "expected the appending path");
+
+        let in_memory_stats = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(256 * 1024 * 1024)
+            .threads(1)
+            .spill_codec(crate::codec::SpillCodec::Bgzf)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort(&input, &in_memory)
+            .expect("in-memory sort should succeed");
+        assert_eq!(in_memory_stats.chunks_written, 0, "expected the no-spill path");
+
+        assert_eq!(
+            std::fs::read(&spilled).expect("read spilled"),
+            std::fs::read(&in_memory).expect("read in-memory"),
+            "appending runs changed the output bytes"
+        );
+    }
+
+    /// A run that several chunks were appended to must carry exactly one BGZF
+    /// terminator, at its end -- interior markers stop htslib-based readers.
+    #[test]
+    fn test_appended_run_has_one_terminator() {
+        use fgumi_bgzf::BGZF_EOF;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = build_ordered_bam(dir.path(), 300, true);
+        let output = dir.path().join("output.bam");
+        let tmp = dir.path().join("spill");
+        std::fs::create_dir_all(&tmp).expect("mkdir");
+
+        let stats = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(8 * 1024)
+            .max_temp_files(0)
+            .threads(1)
+            .spill_codec(crate::codec::SpillCodec::Bgzf)
+            .temp_compression(0)
+            .output_compression(0)
+            .temp_dirs(vec![tmp.clone()])
+            .sort(&input, &output)
+            .expect("sort should succeed");
+        assert_eq!(stats.chunks_written, 1, "expected a single appended run");
+
+        // Spill files are cleaned up on success, so assert on the invariant that
+        // survives: the output is readable end to end and complete.
+        assert_eq!(count_bam_records(&output), 600);
+        let bytes = std::fs::read(&output).expect("read output");
+        assert!(bytes.ends_with(&BGZF_EOF), "output must end with a BGZF terminator");
+    }
+
     /// merge readers during the final merge phase (not just consolidation).
     #[rstest::rstest]
     #[case::coordinate(SortOrder::Coordinate)]
@@ -6653,12 +7096,18 @@ mod tests {
 
         let num_pairs = 200;
         let mut builder = SamBuilder::new();
+        // Emit descending coordinates so the input is NOT already in coordinate
+        // order. Natural run formation appends a chunk to the open run whenever
+        // its keys all sort after it, so ascending input collapses to a single
+        // run -- and a single source exercises neither the k-way merge nor the
+        // reader semaphore this test exists to cover.
         for i in 0..num_pairs {
+            let descending = num_pairs - 1 - i;
             let _ = builder
                 .add_pair()
                 .name(&format!("read{i}"))
-                .start1(i * 200 + 1)
-                .start2(i * 200 + 101)
+                .start1(descending * 200 + 1)
+                .start2(descending * 200 + 101)
                 .build();
         }
 
@@ -7456,12 +7905,15 @@ mod tests {
 
         let num_pairs = 200;
         let mut builder = SamBuilder::new();
+        // Descending coordinates so run formation does not collapse the input
+        // to one run; this test compares multi-chunk spill across temp dirs.
         for i in 0..num_pairs {
+            let descending = num_pairs - 1 - i;
             let _ = builder
                 .add_pair()
                 .name(&format!("read{i:05}"))
-                .start1(i * 200 + 1)
-                .start2(i * 200 + 101)
+                .start1(descending * 200 + 1)
+                .start2(descending * 200 + 101)
                 .build();
         }
 
@@ -7567,14 +8019,18 @@ mod tests {
         // so the index-emitting merge runs over Disk sources + the in-memory
         // chunk simultaneously (the mixed-source path the refactor must keep
         // byte-identical).
+        // Descending coordinates: the point is a merge over several Disk sources
+        // plus the in-memory chunk, and natural run formation would fold
+        // already-ascending input into one run, leaving nothing to merge.
         let num_pairs = 300;
         let mut builder = SamBuilder::new();
         for i in 0..num_pairs {
+            let descending = num_pairs - 1 - i;
             let _ = builder
                 .add_pair()
                 .name(&format!("read{i:05}"))
-                .start1(i * 200 + 1)
-                .start2(i * 200 + 101)
+                .start1(descending * 200 + 1)
+                .start2(descending * 200 + 101)
                 .build();
         }
 

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1883,6 +1883,17 @@ fn log_run_formation(chunks_spilled: usize, runs: usize) {
 ///
 /// The buffer must already be sorted; these are read off its ends rather than
 /// scanned, which is what makes run formation free.
+/// The smallest and largest template keys in a sorted template buffer.
+///
+/// `TemplateRecordRef` caches its key, so like the coordinate case these are the
+/// buffer's ends rather than a scan.
+fn template_chunk_bounds<K: crate::inline::TemplateLaneKey>(
+    buffer: &crate::inline::TemplateRecordBuffer<K>,
+) -> (Option<K>, Option<K>) {
+    let refs = buffer.refs();
+    (refs.first().map(|r| r.key), refs.last().map(|r| r.key))
+}
+
 fn coordinate_chunk_bounds(
     buffer: &crate::inline::RecordBuffer,
 ) -> (Option<crate::keys::RawCoordinateKey>, Option<crate::keys::RawCoordinateKey>) {
@@ -3446,10 +3457,10 @@ impl RawExternalSorter {
                     writer.start_finish()
                 })?;
 
-                // Queryname and template-coordinate keep one file per chunk for now:
-                // `RawQuerynameKey` borrows raw pointers into the record buffer, so a
-                // run's last key cannot outlive the chunk that produced it without
-                // owning those bytes. See the natural-run-formation follow-up.
+                // Queryname keeps one file per chunk: `RawQuerynameKey` borrows raw
+                // pointers into the record buffer, so retaining one as a run's last
+                // key past the chunk that produced it would dangle. Supporting it
+                // needs owned boundary bytes, not just a wider trait bound.
                 pending_spill = Some(PendingSpill { handle, chunk_path, appended: false });
 
                 memory_used = 0;
@@ -3732,6 +3743,10 @@ impl RawExternalSorter {
             TemplateRecordBuffer::<K>::with_capacity(estimated_records, estimated_data_bytes);
         let mut namer = ChunkNamer::new(alloc);
         let mut pending_spill: Option<PendingSpill> = None;
+        // Natural run formation: consecutive chunks already in template order
+        // extend one run instead of each becoming its own merge source.
+        let mut run_former: RunFormer<K> = RunFormer::new();
+        let mut chunks_spilled: usize = 0;
         let rayon_pool = self.build_sort_rayon_pool()?;
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
@@ -3800,30 +3815,44 @@ impl RawExternalSorter {
                 )?;
                 probe.post_drain(probe_stats(&buffer), Some(pool.phase1_queue_depths()));
 
-                let chunk_path = namer.next_chunk_path()?;
-
                 timer.time_sort(|| {
                     rayon_pool.install(|| buffer.par_sort());
                 });
 
+                run_former.forget_if_absent(&chunk_files);
+                let (chunk_min, chunk_max) = template_chunk_bounds(&buffer);
+                let (chunk_path, appended) =
+                    match chunk_min.and_then(|min| run_former.appendable(&min).cloned()) {
+                        Some(path) => (path, true),
+                        None => (namer.next_chunk_path()?, false),
+                    };
+                chunks_spilled += 1;
+
                 // Write keyed chunk with parallel BGZF compression via worker pool.
                 let handle = timer.time_spill_write(|| {
-                    let mut writer = PooledChunkWriter::<K>::new(
-                        Arc::clone(&pool),
-                        &chunk_path,
-                        pool.spill_codec(),
-                    )?;
+                    let mut writer = if appended {
+                        PooledChunkWriter::<K>::append(
+                            Arc::clone(&pool),
+                            &chunk_path,
+                            pool.spill_codec(),
+                        )?
+                    } else {
+                        PooledChunkWriter::<K>::new(
+                            Arc::clone(&pool),
+                            &chunk_path,
+                            pool.spill_codec(),
+                        )?
+                    };
                     for (key, record) in buffer.iter_sorted_keyed() {
                         writer.write_record(&key, record)?;
                     }
                     writer.start_finish()
                 })?;
 
-                // Queryname and template-coordinate keep one file per chunk for now:
-                // `RawQuerynameKey` borrows raw pointers into the record buffer, so a
-                // run's last key cannot outlive the chunk that produced it without
-                // owning those bytes. See the natural-run-formation follow-up.
-                pending_spill = Some(PendingSpill { handle, chunk_path, appended: false });
+                if let Some(max) = chunk_max {
+                    run_former.extended(chunk_path.clone(), max);
+                }
+                pending_spill = Some(PendingSpill { handle, chunk_path, appended });
 
                 buffer.clear();
                 force_mi_collect();
@@ -3889,6 +3918,7 @@ impl RawExternalSorter {
 
             let memory_chunks = MemorySources::Shared(memory_chunks);
             let n_memory = memory_chunks.num_non_empty();
+            log_run_formation(chunks_spilled, chunk_files.len());
             debug!("Phase 2: Merging {} chunks...", chunk_files.len() + n_memory);
 
             // Merge using O(1) key comparisons
@@ -6996,6 +7026,134 @@ mod tests {
         assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
         assert_eq!(count_bam_records(&output), 600);
         assert_sorted_by_coordinate(&output);
+    }
+
+    /// Run formation is wired for template-coordinate too, and its keys are
+    /// self-contained (three packed `u64` lanes), unlike queryname's.
+    ///
+    /// A BAM already in template-coordinate order must collapse to one run, and
+    /// the output must stay in that order -- the buffer's radix sort orders by
+    /// lanes while the merge compares via `K::cmp`, so run formation is only sound
+    /// if those agree.
+    #[test]
+    fn test_template_coordinate_sorted_input_collapses_to_one_run() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let unsorted = build_ordered_bam(dir.path(), 300, true);
+
+        // Produce a genuinely template-coordinate-ordered input by sorting once,
+        // rather than assuming coordinate order implies template order.
+        let template_sorted = dir.path().join("template_sorted.bam");
+        let first = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+            .memory_limit(256 * 1024 * 1024)
+            .threads(1)
+            .spill_codec(crate::codec::SpillCodec::Bgzf)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort(&unsorted, &template_sorted)
+            .expect("first template sort should succeed");
+        assert_eq!(first.total_records, first.output_records);
+
+        let output = dir.path().join("resorted.bam");
+        let stats = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+            .memory_limit(8 * 1024)
+            .max_temp_files(0)
+            .threads(1)
+            .spill_codec(crate::codec::SpillCodec::Bgzf)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort(&template_sorted, &output)
+            .expect("re-sort should succeed");
+
+        assert_eq!(
+            stats.chunks_written, 1,
+            "template-coordinate-sorted input should collapse to one run, got {}",
+            stats.chunks_written
+        );
+        assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
+        assert_eq!(count_bam_records(&output), 600);
+
+        // Re-sorting an already-sorted file is a fixed point: byte-identical
+        // apart from the @PG the second run adds, so compare records only.
+        assert_eq!(
+            count_bam_records(&template_sorted),
+            count_bam_records(&output),
+            "re-sort changed the record count"
+        );
+    }
+
+    /// The template path must not append when the input is not in template order.
+    #[test]
+    fn test_template_coordinate_unsorted_input_never_appends() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let input = build_ordered_bam(dir.path(), 300, false);
+        let output = dir.path().join("output.bam");
+
+        let stats = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+            .memory_limit(8 * 1024)
+            .max_temp_files(0)
+            .threads(1)
+            .spill_codec(crate::codec::SpillCodec::Bgzf)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort(&input, &output)
+            .expect("sort should succeed");
+
+        assert!(
+            stats.chunks_written >= 2,
+            "reverse-ordered input must not collapse into one run, got {}",
+            stats.chunks_written
+        );
+        assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
+        assert_eq!(count_bam_records(&output), 600);
+    }
+
+    /// Run formation must not change template-coordinate output either. Sorting
+    /// with a limit that forces appending and with one that never spills must
+    /// produce identical bytes.
+    #[test]
+    fn test_template_run_formation_output_is_byte_identical() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let unsorted = build_ordered_bam(dir.path(), 300, true);
+
+        let template_sorted = dir.path().join("template_sorted.bam");
+        RawExternalSorter::new(SortOrder::TemplateCoordinate)
+            .memory_limit(256 * 1024 * 1024)
+            .threads(1)
+            .spill_codec(crate::codec::SpillCodec::Bgzf)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort(&unsorted, &template_sorted)
+            .expect("first template sort should succeed");
+
+        let spilled = dir.path().join("spilled.bam");
+        let in_memory = dir.path().join("in_memory.bam");
+
+        let spilled_stats = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+            .memory_limit(8 * 1024)
+            .max_temp_files(0)
+            .threads(1)
+            .spill_codec(crate::codec::SpillCodec::Bgzf)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort(&template_sorted, &spilled)
+            .expect("spilling sort should succeed");
+        assert_eq!(spilled_stats.chunks_written, 1, "expected the appending path");
+
+        let in_memory_stats = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+            .memory_limit(256 * 1024 * 1024)
+            .threads(1)
+            .spill_codec(crate::codec::SpillCodec::Bgzf)
+            .temp_compression(0)
+            .output_compression(0)
+            .sort(&template_sorted, &in_memory)
+            .expect("in-memory sort should succeed");
+        assert_eq!(in_memory_stats.chunks_written, 0, "expected the no-spill path");
+
+        assert_eq!(
+            std::fs::read(&spilled).expect("read spilled"),
+            std::fs::read(&in_memory).expect("read in-memory"),
+            "appending runs changed template-coordinate output bytes"
+        );
     }
 
     /// The indexed path got run formation too, so cover appending there: the

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -186,10 +186,29 @@ impl SortPhaseTimer {
         result
     }
 
+    /// How many chunks have been spilled, counted where the spill is timed.
+    fn spill_count(&self) -> usize {
+        self.spill_count
+    }
+
     /// Record the size of a spill file.
     fn record_spill_size(&mut self, path: &Path) {
         if let Ok(meta) = std::fs::metadata(path) {
             self.total_spill_bytes += meta.len();
+        }
+    }
+
+    /// Add the bytes a spill run grew by, given its size before the chunk was
+    /// written.
+    ///
+    /// Run formation appends several chunks to one file, so re-adding the file's
+    /// whole length after each chunk would sum `C + 2C + ... + NC` and report a
+    /// spill volume quadratic in the chunk count. Spill volume is the figure used
+    /// to judge whether run formation reduced spill I/O at all, so it has to be
+    /// the delta.
+    fn record_spill_growth(&mut self, path: &Path, size_before: u64) {
+        if let Ok(meta) = std::fs::metadata(path) {
+            self.total_spill_bytes += meta.len().saturating_sub(size_before);
         }
     }
 
@@ -212,7 +231,7 @@ impl SortPhaseTimer {
     }
 
     /// Time writing in-memory-only output (no merge needed).
-    fn time_write_output(&mut self, f: impl FnOnce() -> Result<()>) -> Result<()> {
+    fn time_write_output<T>(&mut self, f: impl FnOnce() -> Result<T>) -> Result<T> {
         Self::time(&mut self.write_output_secs, f)
     }
 
@@ -1297,6 +1316,82 @@ pub(crate) struct MainThreadChunkConsumer<K: RawSortKey + 'static> {
     _phantom: std::marker::PhantomData<K>,
 }
 
+/// Enforce the permutation invariant, removing the output when it fails.
+///
+/// A sort is a permutation: every record read must be written. By the time this
+/// runs the writer has finalized `output`, so a mismatch leaves a
+/// truncated-but-*valid* BAM (and, under `write_index`, a `.bai` describing it)
+/// on disk. Saying the output "must not be used" does not stop a wrapper that
+/// checks only an exit code, or a user who re-runs and reads the stale file, so
+/// a file output is removed rather than merely described.
+///
+/// That also matches the rest of the crate rather than making this the one
+/// exception: the merge writes through [`MergeOutputTarget`] and drops its temp
+/// on error, and `test_sort_records_producer_error_aborts` pins that an aborted
+/// sort leaves no output behind.
+///
+/// What is *not* removed is as deliberate as what is, and mirrors the guards
+/// [`MergeOutputTarget::create`] already applies: stdout cannot be un-written,
+/// and a FIFO, device or directory was written *through* rather than created, so
+/// unlinking it would destroy something this sort does not own. Those cases keep
+/// the "must not be used" wording, which is all that is true of them. A removal
+/// that fails is reported rather than swallowed -- the caller is being told the
+/// output is dangerous, so whether it is still there is exactly what they need.
+fn enforce_record_count(stats: &RawSortStats, output: &Path, write_index: bool) -> Result<()> {
+    if stats.total_records == stats.output_records {
+        return Ok(());
+    }
+
+    let disposition = if is_stdout_path(output) {
+        // The records are already past this process; there is nothing to unlink,
+        // and `/dev/stdout` itself must certainly not be.
+        "The records written to stdout are incomplete and must not be used.".to_string()
+    } else {
+        let mut targets = vec![output.to_path_buf()];
+        if write_index {
+            targets.push(fgumi_bam_io::bai_sidecar_path(output));
+        }
+        let left_behind: Vec<PathBuf> =
+            targets.into_iter().filter(|path| !remove_incomplete_output(path)).collect();
+        if left_behind.is_empty() {
+            format!("The incomplete output at {} has been removed.", output.display())
+        } else {
+            let paths =
+                left_behind.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", ");
+            format!("The incomplete output at {paths} could not be removed and must not be used.")
+        }
+    };
+
+    anyhow::bail!(
+        "sort lost records: read {} but wrote {} (differ by {}). {}",
+        stats.total_records,
+        stats.output_records,
+        stats.total_records.abs_diff(stats.output_records),
+        disposition
+    )
+}
+
+/// Remove an incomplete sort output, reporting whether it is now gone.
+///
+/// Follows a symlink to the file the sort actually wrote through, so unlinking
+/// the link would not leave the real short BAM in place -- the same resolution
+/// [`MergeOutputTarget::create`] does for the opposite reason. Only regular
+/// files are removed; anything else was written through, not created, and a
+/// path that cannot be resolved or stat-ed is reported as still present rather
+/// than assumed gone.
+fn remove_incomplete_output(path: &Path) -> bool {
+    let Ok(resolved) = resolve_symlink_output(path) else {
+        return false;
+    };
+    match std::fs::metadata(&resolved) {
+        // Already absent is the outcome we wanted, not a failure.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+        Err(_) => false,
+        Ok(metadata) if !metadata.is_file() => false,
+        Ok(_) => std::fs::remove_file(&resolved).is_ok(),
+    }
+}
+
 /// Whether the merge block-lifecycle block has nothing to print.
 ///
 /// Every report that block prints must appear here. A report missing from the
@@ -1826,6 +1921,9 @@ struct PendingSpill {
     /// Whether this chunk extended an existing run rather than starting one.
     /// An extended run is already in `chunk_files`, so it must not be added twice.
     appended: bool,
+    /// The run file's length before this chunk was written, so the drain can
+    /// account for the bytes this chunk added rather than the file's whole size.
+    size_before: u64,
 }
 
 /// Decides whether the next sorted chunk extends the open spill run or starts a
@@ -1851,92 +1949,88 @@ struct PendingSpill {
 /// group of chunks, so source order equals ingest order. Combined with the loser
 /// tree's tie-break on source index (`LoserTree::is_greater`), output is
 /// byte-identical to writing one file per chunk.
+#[derive(Default)]
 struct RunFormer<K> {
     /// The open run: its path and the key of its last record. `None` before the
     /// first spill, and after a consolidation that swallowed the run.
     open: Option<(PathBuf, K)>,
 }
 
-/// Report how many spilled chunks became how many merge sources.
+/// Report how many spilled chunks became how many runs.
 ///
 /// Sorted input collapses to one run, almost-sorted input to its natural runs,
 /// shuffled input to one run per chunk. Logging the ratio means every sort
 /// reports how ordered its own input was, which is the cheapest way to learn how
 /// common near-sorted inputs are in practice.
+///
+/// `runs` must be the number of runs *formed* (`RawSortStats::runs_written`),
+/// not the number of spill files left at merge time. Consolidation merges the
+/// oldest half of the files whenever their count reaches `--max-temp-files`, so
+/// the surviving file count can be far lower than the run count for reasons that
+/// have nothing to do with how ordered the input was -- which is the one thing
+/// this line exists to report.
 fn log_run_formation(chunks_spilled: usize, runs: usize) {
-    if chunks_spilled == 0 {
-        return;
-    }
-    if chunks_spilled == runs {
-        info!("Spill runs: {runs} (no chunk extended another; input not pre-sorted)");
-    } else {
-        info!(
-            "Spill runs: {runs} from {chunks_spilled} chunks \
-             ({} extended an existing run)",
-            chunks_spilled - runs
-        );
-    }
+    info!(
+        "Spill runs: {runs} from {chunks_spilled} chunks ({} extended an existing run)",
+        chunks_spilled.saturating_sub(runs)
+    );
 }
 
-/// The smallest and largest coordinate keys in a sorted buffer, or `None` for an
-/// empty one.
+/// The smallest and largest keys in an already-sorted slice.
 ///
-/// The buffer must already be sorted; these are read off its ends rather than
-/// scanned, which is what makes run formation free.
-/// The smallest and largest keys in a sorted `(key, record)` buffer.
-///
-/// Clones rather than copies: `RawQuerynameKey` owns its read name, so the
-/// boundary key is one small allocation that outlives the chunk safely.
-fn keyed_chunk_bounds<K: Clone, R>(entries: &[(K, R)]) -> (Option<K>, Option<K>) {
-    (entries.first().map(|(k, _)| k.clone()), entries.last().map(|(k, _)| k.clone()))
-}
-
-/// The smallest and largest template keys in a sorted template buffer.
-///
-/// `TemplateRecordRef` caches its key, so like the coordinate case these are the
-/// buffer's ends rather than a scan.
-fn template_chunk_bounds<K: crate::inline::TemplateLaneKey>(
-    buffer: &crate::inline::TemplateRecordBuffer<K>,
-) -> (Option<K>, Option<K>) {
-    let refs = buffer.refs();
-    (refs.first().map(|r| r.key), refs.last().map(|r| r.key))
-}
-
-fn coordinate_chunk_bounds(
-    buffer: &crate::inline::RecordBuffer,
-) -> (Option<crate::keys::RawCoordinateKey>, Option<crate::keys::RawCoordinateKey>) {
-    let refs = buffer.refs();
-    let key = |r: &crate::inline::RecordRef| crate::keys::RawCoordinateKey { sort_key: r.sort_key };
-    (refs.first().map(key), refs.last().map(key))
+/// Read off the ends rather than scanned, which is what makes run formation free:
+/// the caller has just sorted the buffer, so its extremes are its first and last
+/// elements. `None` only for an empty slice, which a spill never produces.
+fn chunk_bounds<T, K>(items: &[T], key: impl Fn(&T) -> K) -> Option<(K, K)> {
+    Some((key(items.first()?), key(items.last()?)))
 }
 
 impl<K: Clone + Ord> RunFormer<K> {
-    fn new() -> Self {
-        Self { open: None }
-    }
+    /// Choose where a sorted chunk should be written.
+    ///
+    /// Returns the path and whether it extends an existing run. The chunk extends
+    /// the open run when every key in it sorts at or after that run's last key;
+    /// otherwise a fresh path is allocated and a new run begins.
+    ///
+    /// Both pre-write steps in one method rather than two, because they have a
+    /// mandatory order — forget a consolidated run, *then* test appendability —
+    /// and nothing in the types enforced it when callers drove it themselves.
+    /// Recording the new boundary necessarily follows the write and stays in
+    /// [`Self::extended`], which [`RawExternalSorter::spill_chunk`] — the only
+    /// caller of either — invokes once the path is known.
+    fn place(
+        &mut self,
+        chunk_files: &[PathBuf],
+        bounds: Option<&(K, K)>,
+        namer: &mut ChunkNamer<'_>,
+    ) -> Result<(PathBuf, bool)> {
+        // Consolidation may have merged the open run away while the previous
+        // spill was draining, leaving a path that no longer holds what we think.
+        if let Some((path, _)) = &self.open
+            && !chunk_files.contains(path)
+        {
+            self.open = None;
+        }
 
-    /// The path to append to for a chunk whose smallest key is `chunk_min`, or
-    /// `None` if it must start a new run.
-    fn appendable(&self, chunk_min: &K) -> Option<&PathBuf> {
-        match &self.open {
-            Some((path, last_key)) if last_key <= chunk_min => Some(path),
+        let appendable = match (&self.open, bounds) {
+            (Some((path, last_key)), Some((chunk_min, _))) if last_key <= chunk_min => {
+                Some(path.clone())
+            }
             _ => None,
+        };
+
+        match appendable {
+            Some(path) => Ok((path, true)),
+            // Always allocate through the namer on this branch: it is what
+            // advances the temp-directory round-robin and periodically re-checks
+            // free space (`TmpDirAllocator::next`).
+            None => Ok((namer.next_chunk_path()?, false)),
         }
     }
 
     /// Record that a chunk ending at `chunk_max` was written to `path`.
     fn extended(&mut self, path: PathBuf, chunk_max: K) {
         self.open = Some((path, chunk_max));
-    }
-
-    /// Drop the open run if consolidation merged it away, so the next chunk does
-    /// not append to a path that no longer holds what we think it does.
-    fn forget_if_absent(&mut self, chunk_files: &[PathBuf]) {
-        if let Some((path, _)) = &self.open
-            && !chunk_files.contains(path)
-        {
-            self.open = None;
-        }
     }
 }
 
@@ -2349,6 +2443,46 @@ impl RawExternalSorter {
             .map_err(|e| anyhow::anyhow!("failed to build rayon sort pool: {e}"))
     }
 
+    /// Write one sorted chunk, extending the open spill run when it can.
+    ///
+    /// Shared by all four sort functions: identical aside from the key type and
+    /// the per-record write, which the caller supplies as a closure. Keeping the
+    /// run-formation bookkeeping here means the append/create choice, the
+    /// pre-write size needed for spill accounting, and the boundary key recorded
+    /// afterwards cannot drift between the four copies.
+    fn spill_chunk<K: RawSortKey + Clone + Ord + Default + 'static>(
+        run_former: &mut RunFormer<K>,
+        chunk_files: &[PathBuf],
+        bounds: Option<(K, K)>,
+        namer: &mut ChunkNamer<'_>,
+        pool: &Arc<SortWorkerPool>,
+        timer: &mut SortPhaseTimer,
+        write: impl FnOnce(&mut PooledChunkWriter<K>) -> Result<()>,
+    ) -> Result<PendingSpill> {
+        let (chunk_path, appended) = run_former.place(chunk_files, bounds.as_ref(), namer)?;
+
+        // Captured before the write so the drain can charge only the bytes this
+        // chunk adds; an appended run's file already holds its predecessors.
+        let size_before =
+            if appended { std::fs::metadata(&chunk_path).map_or(0, |m| m.len()) } else { 0 };
+
+        let handle = timer.time_spill_write(|| {
+            let mut writer = PooledChunkWriter::<K>::open(
+                Arc::clone(pool),
+                &chunk_path,
+                pool.spill_codec(),
+                appended,
+            )?;
+            write(&mut writer)?;
+            writer.start_finish()
+        })?;
+
+        if let Some((_, chunk_max)) = bounds {
+            run_former.extended(chunk_path.clone(), chunk_max);
+        }
+        Ok(PendingSpill { handle, chunk_path, appended, size_before })
+    }
+
     /// Consolidate temp files if we've exceeded the limit.
     /// Wait for a pending spill to complete and, if one was present, run consolidation.
     ///
@@ -2365,12 +2499,12 @@ impl RawExternalSorter {
     ) -> Result<()> {
         if let Some(prev) = pending.take() {
             prev.handle.wait()?;
-            timer.record_spill_size(&prev.chunk_path);
+            timer.record_spill_growth(&prev.chunk_path, prev.size_before);
             // A chunk that extended an existing run is already represented in
             // `chunk_files`; only a chunk that started a run adds a merge source.
             if !prev.appended {
                 chunk_files.push(prev.chunk_path);
-                stats.chunks_written += 1;
+                stats.runs_written += 1;
             }
 
             timer.time_consolidate(|| {
@@ -2621,7 +2755,7 @@ impl RawExternalSorter {
         let (_temp_dirs, mut alloc) = self.create_temp_dirs()?;
 
         // Sort based on order
-        match self.sort_order {
+        let stats = match self.sort_order {
             SortOrder::Coordinate => {
                 self.sort_coordinate(record_source, pool, &header, output, &mut alloc)
             }
@@ -2631,7 +2765,17 @@ impl RawExternalSorter {
             SortOrder::TemplateCoordinate => {
                 self.sort_template_coordinate(record_source, pool, &header, output, &mut alloc)
             }
-        }
+        }?;
+
+        // A sort is a permutation: every record read must be written. Checked here
+        // rather than in the CLI so it covers every entry point -- `sort_records`
+        // has callers (`fgumi simulate`) that discard the stats entirely, and a
+        // library consumer should not have to opt in to the engine's own
+        // guarantee. Both counts are measured independently: `total_records` by
+        // the ingest loop, `output_records` by whichever writer produced the
+        // output.
+        enforce_record_count(&stats, output, self.write_index)?;
+        Ok(stats)
     }
 
     /// Warn when a merge is about to ask for more descriptors than the process
@@ -2935,8 +3079,7 @@ impl RawExternalSorter {
         let mut pending_spill: Option<PendingSpill> = None;
         // Natural run formation: consecutive chunks that are already in order
         // extend one run instead of each becoming its own merge source.
-        let mut run_former: RunFormer<crate::keys::RawCoordinateKey> = RunFormer::new();
-        let mut chunks_spilled: usize = 0;
+        let mut run_former: RunFormer<crate::keys::RawCoordinateKey> = RunFormer::default();
         let rayon_pool = self.build_sort_rayon_pool()?;
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
@@ -2981,46 +3124,26 @@ impl RawExternalSorter {
                 });
 
                 // The buffer is sorted, so the chunk's extreme keys are its ends.
-                // Consolidation may have merged the open run away while draining
-                // the previous spill, so re-check before trusting it.
-                run_former.forget_if_absent(&chunk_files);
-                let (chunk_min, chunk_max) = coordinate_chunk_bounds(&buffer);
-                let (chunk_path, appended) =
-                    match chunk_min.and_then(|min| run_former.appendable(&min).cloned()) {
-                        Some(path) => (path, true),
-                        None => (namer.next_chunk_path()?, false),
-                    };
-                chunks_spilled += 1;
+                let bounds =
+                    chunk_bounds(buffer.refs(), |r| RawCoordinateKey { sort_key: r.sort_key });
 
-                // Write keyed temp file with parallel BGZF compression via worker pool.
-                // Use start_finish() for pipelining: I/O continues in background
-                // while we read the next batch.
-                let handle = timer.time_spill_write(|| {
-                    let mut writer = if appended {
-                        PooledChunkWriter::<RawCoordinateKey>::append(
-                            Arc::clone(&pool),
-                            &chunk_path,
-                            pool.spill_codec(),
-                        )?
-                    } else {
-                        PooledChunkWriter::<RawCoordinateKey>::new(
-                            Arc::clone(&pool),
-                            &chunk_path,
-                            pool.spill_codec(),
-                        )?
-                    };
-                    for r in buffer.refs() {
-                        let key = RawCoordinateKey { sort_key: r.sort_key };
-                        let record_bytes = buffer.get_record(r);
-                        writer.write_record(&key, record_bytes)?;
-                    }
-                    writer.start_finish()
-                })?;
-
-                if let Some(max) = chunk_max {
-                    run_former.extended(chunk_path.clone(), max);
-                }
-                pending_spill = Some(PendingSpill { handle, chunk_path, appended });
+                // Pipelined: `spill_chunk` returns once the write is submitted, so
+                // I/O continues in the background while we read the next batch.
+                pending_spill = Some(Self::spill_chunk::<RawCoordinateKey>(
+                    &mut run_former,
+                    &chunk_files,
+                    bounds,
+                    &mut namer,
+                    &pool,
+                    &mut timer,
+                    |writer| {
+                        for r in buffer.refs() {
+                            let key = RawCoordinateKey { sort_key: r.sort_key };
+                            writer.write_record(&key, buffer.get_record(r))?;
+                        }
+                        Ok(())
+                    },
+                )?);
 
                 buffer.clear();
                 force_mi_collect();
@@ -3057,16 +3180,18 @@ impl RawExternalSorter {
                 rayon_pool.install(|| buffer.par_sort());
             });
 
-            timer.time_write_output(|| {
+            stats.output_records = timer.time_write_output(|| {
                 use crate::pooled_bam_writer::PooledBamWriter;
                 let output_header = self.create_output_header(header);
                 let mut writer = PooledBamWriter::new(Arc::clone(&pool), output, &output_header)?;
 
+                let mut written: u64 = 0;
                 for record_bytes in buffer.iter_sorted() {
                     writer.write_raw_record(record_bytes)?;
+                    written += 1;
                 }
                 writer.finish()?;
-                Ok(())
+                Ok(written)
             })?;
         } else {
             // Sort remaining records into separate sub-array chunks (avoids
@@ -3087,14 +3212,14 @@ impl RawExternalSorter {
 
             let memory_chunks = MemorySources::Shared(memory_chunks);
             let n_memory = memory_chunks.num_non_empty();
-            log_run_formation(chunks_spilled, chunk_files.len());
+            log_run_formation(timer.spill_count(), stats.runs_written);
             debug!(
                 "Phase 2: Merging {} chunks (keyed O(1) comparisons)...",
                 chunk_files.len() + n_memory
             );
 
             // Merge disk chunks + in-memory chunks using O(1) key comparisons
-            timer.time_merge(|| {
+            stats.output_records = timer.time_merge(|| {
                 self.merge_chunks_generic::<RawCoordinateKey>(
                     &chunk_files,
                     memory_chunks,
@@ -3106,7 +3231,6 @@ impl RawExternalSorter {
             })?;
         }
 
-        stats.output_records = stats.total_records;
         if let Ok(pool) = Arc::try_unwrap(pool) {
             pool.shutdown();
         }
@@ -3152,8 +3276,7 @@ impl RawExternalSorter {
         let mut pending_spill: Option<PendingSpill> = None;
         // Natural run formation: consecutive chunks that are already in order
         // extend one run instead of each becoming its own merge source.
-        let mut run_former: RunFormer<crate::keys::RawCoordinateKey> = RunFormer::new();
-        let mut chunks_spilled: usize = 0;
+        let mut run_former: RunFormer<crate::keys::RawCoordinateKey> = RunFormer::default();
         let rayon_pool = self.build_sort_rayon_pool()?;
 
         debug!("Phase 1: Reading and sorting chunks (inline buffer, keyed output)...");
@@ -3188,41 +3311,26 @@ impl RawExternalSorter {
                     rayon_pool.install(|| buffer.par_sort());
                 });
 
-                run_former.forget_if_absent(&chunk_files);
-                let (chunk_min, chunk_max) = coordinate_chunk_bounds(&buffer);
-                let (chunk_path, appended) =
-                    match chunk_min.and_then(|min| run_former.appendable(&min).cloned()) {
-                        Some(path) => (path, true),
-                        None => (namer.next_chunk_path()?, false),
-                    };
-                chunks_spilled += 1;
+                let bounds =
+                    chunk_bounds(buffer.refs(), |r| RawCoordinateKey { sort_key: r.sort_key });
 
-                let handle = timer.time_spill_write(|| {
-                    let mut writer = if appended {
-                        PooledChunkWriter::<RawCoordinateKey>::append(
-                            Arc::clone(&pool),
-                            &chunk_path,
-                            pool.spill_codec(),
-                        )?
-                    } else {
-                        PooledChunkWriter::<RawCoordinateKey>::new(
-                            Arc::clone(&pool),
-                            &chunk_path,
-                            pool.spill_codec(),
-                        )?
-                    };
-                    for r in buffer.refs() {
-                        let key = RawCoordinateKey { sort_key: r.sort_key };
-                        let record_bytes = buffer.get_record(r);
-                        writer.write_record(&key, record_bytes)?;
-                    }
-                    writer.start_finish()
-                })?;
-
-                if let Some(max) = chunk_max {
-                    run_former.extended(chunk_path.clone(), max);
-                }
-                pending_spill = Some(PendingSpill { handle, chunk_path, appended });
+                // Pipelined: `spill_chunk` returns once the write is submitted, so
+                // I/O continues in the background while we read the next batch.
+                pending_spill = Some(Self::spill_chunk::<RawCoordinateKey>(
+                    &mut run_former,
+                    &chunk_files,
+                    bounds,
+                    &mut namer,
+                    &pool,
+                    &mut timer,
+                    |writer| {
+                        for r in buffer.refs() {
+                            let key = RawCoordinateKey { sort_key: r.sort_key };
+                            writer.write_record(&key, buffer.get_record(r))?;
+                        }
+                        Ok(())
+                    },
+                )?);
 
                 buffer.clear();
                 force_mi_collect();
@@ -3261,7 +3369,7 @@ impl RawExternalSorter {
                 rayon_pool.install(|| buffer.par_sort());
             });
 
-            timer.time_write_output(|| {
+            stats.output_records = timer.time_write_output(|| {
                 let mut writer = create_indexing_bam_writer(
                     output,
                     &output_header,
@@ -3269,8 +3377,10 @@ impl RawExternalSorter {
                     self.phase2_threads(),
                 )?;
 
+                let mut written: u64 = 0;
                 for record_bytes in buffer.iter_sorted() {
                     writer.write_raw_record(record_bytes)?;
+                    written += 1;
                 }
 
                 let index = writer.finish()?;
@@ -3278,7 +3388,7 @@ impl RawExternalSorter {
                 let index_path = bai_sidecar_path(output);
                 write_bai_index(&index_path, &index)?;
                 info!("Wrote BAM index: {}", index_path.display());
-                Ok(())
+                Ok(written)
             })?;
         } else {
             // Sort remaining records into separate sub-array chunks
@@ -3297,14 +3407,14 @@ impl RawExternalSorter {
 
             let memory_chunks = MemorySources::Shared(memory_chunks);
             let n_memory = memory_chunks.num_non_empty();
-            log_run_formation(chunks_spilled, chunk_files.len());
+            log_run_formation(timer.spill_count(), stats.runs_written);
             debug!(
                 "Phase 2: Merging {} chunks with index generation...",
                 chunk_files.len() + n_memory
             );
 
-            timer.time_merge(|| {
-                let index = self.merge_chunks_with_index::<RawCoordinateKey>(
+            stats.output_records = timer.time_merge(|| {
+                let (index, records_merged) = self.merge_chunks_with_index::<RawCoordinateKey>(
                     &chunk_files,
                     memory_chunks,
                     header,
@@ -3316,11 +3426,10 @@ impl RawExternalSorter {
                 let index_path = bai_sidecar_path(output);
                 write_bai_index(&index_path, &index)?;
                 info!("Wrote BAM index: {}", index_path.display());
-                Ok(())
+                Ok(records_merged)
             })?;
         }
 
-        stats.output_records = stats.total_records;
         if let Ok(pool) = Arc::try_unwrap(pool) {
             pool.shutdown();
         }
@@ -3392,8 +3501,7 @@ impl RawExternalSorter {
         let mut pending_spill: Option<PendingSpill> = None;
         // Natural run formation: consecutive chunks already in queryname order
         // extend one run instead of each becoming its own merge source.
-        let mut run_former: RunFormer<K> = RunFormer::new();
-        let mut chunks_spilled: usize = 0;
+        let mut run_former: RunFormer<K> = RunFormer::default();
         let rayon_pool = self.build_sort_rayon_pool()?;
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
@@ -3454,40 +3562,22 @@ impl RawExternalSorter {
                     rayon_pool.install(|| entries.par_sort_unstable_by(|a, b| a.0.cmp(&b.0)));
                 });
 
-                run_former.forget_if_absent(&chunk_files);
-                let (chunk_min, chunk_max) = keyed_chunk_bounds(&entries);
-                let (chunk_path, appended) =
-                    match chunk_min.and_then(|min| run_former.appendable(&min).cloned()) {
-                        Some(path) => (path, true),
-                        None => (namer.next_chunk_path()?, false),
-                    };
-                chunks_spilled += 1;
+                let bounds = chunk_bounds(&entries, |(k, _)| k.clone());
 
-                // Write keyed temp file with parallel BGZF compression via worker pool.
-                let handle = timer.time_spill_write(|| {
-                    let mut writer = if appended {
-                        PooledChunkWriter::<K>::append(
-                            Arc::clone(&pool),
-                            &chunk_path,
-                            pool.spill_codec(),
-                        )?
-                    } else {
-                        PooledChunkWriter::<K>::new(
-                            Arc::clone(&pool),
-                            &chunk_path,
-                            pool.spill_codec(),
-                        )?
-                    };
-                    for (key, record) in entries.drain(..) {
-                        writer.write_record(&key, record.as_ref())?;
-                    }
-                    writer.start_finish()
-                })?;
-
-                if let Some(max) = chunk_max {
-                    run_former.extended(chunk_path.clone(), max);
-                }
-                pending_spill = Some(PendingSpill { handle, chunk_path, appended });
+                pending_spill = Some(Self::spill_chunk::<K>(
+                    &mut run_former,
+                    &chunk_files,
+                    bounds,
+                    &mut namer,
+                    &pool,
+                    &mut timer,
+                    |writer| {
+                        for (key, record) in entries.drain(..) {
+                            writer.write_record(&key, record.as_ref())?;
+                        }
+                        Ok(())
+                    },
+                )?);
 
                 memory_used = 0;
                 force_mi_collect();
@@ -3528,16 +3618,18 @@ impl RawExternalSorter {
                 rayon_pool.install(|| entries.par_sort_unstable_by(|a, b| a.0.cmp(&b.0)));
             });
 
-            timer.time_write_output(|| {
+            stats.output_records = timer.time_write_output(|| {
                 use crate::pooled_bam_writer::PooledBamWriter;
                 let output_header = self.create_output_header(header);
                 let mut writer = PooledBamWriter::new(Arc::clone(&pool), output, &output_header)?;
 
+                let mut written: u64 = 0;
                 for (_key, record) in entries {
                     writer.write_raw_record(&record)?;
+                    written += 1;
                 }
                 writer.finish()?;
-                Ok(())
+                Ok(written)
             })?;
         } else {
             // Sort remaining records into separate sub-array chunks (avoids
@@ -3594,14 +3686,14 @@ impl RawExternalSorter {
             let memory_chunks = MemorySources::Owned(keyed_chunks);
 
             let n_memory = memory_chunks.num_non_empty();
-            log_run_formation(chunks_spilled, chunk_files.len());
+            log_run_formation(timer.spill_count(), stats.runs_written);
             debug!(
                 "Phase 2: Merging {} chunks (keyed comparisons)...",
                 chunk_files.len() + n_memory
             );
 
             // Merge disk chunks + in-memory records using keyed comparisons
-            timer.time_merge(|| {
+            stats.output_records = timer.time_merge(|| {
                 self.merge_chunks_generic::<K>(
                     &chunk_files,
                     memory_chunks,
@@ -3613,7 +3705,6 @@ impl RawExternalSorter {
             })?;
         }
 
-        stats.output_records = stats.total_records;
         if let Ok(pool) = Arc::try_unwrap(pool) {
             pool.shutdown();
         }
@@ -3772,8 +3863,7 @@ impl RawExternalSorter {
         let mut pending_spill: Option<PendingSpill> = None;
         // Natural run formation: consecutive chunks already in template order
         // extend one run instead of each becoming its own merge source.
-        let mut run_former: RunFormer<K> = RunFormer::new();
-        let mut chunks_spilled: usize = 0;
+        let mut run_former: RunFormer<K> = RunFormer::default();
         let rayon_pool = self.build_sort_rayon_pool()?;
 
         let progress = ProgressTracker::new("Read records").with_interval(1_000_000);
@@ -3846,40 +3936,22 @@ impl RawExternalSorter {
                     rayon_pool.install(|| buffer.par_sort());
                 });
 
-                run_former.forget_if_absent(&chunk_files);
-                let (chunk_min, chunk_max) = template_chunk_bounds(&buffer);
-                let (chunk_path, appended) =
-                    match chunk_min.and_then(|min| run_former.appendable(&min).cloned()) {
-                        Some(path) => (path, true),
-                        None => (namer.next_chunk_path()?, false),
-                    };
-                chunks_spilled += 1;
+                let bounds = chunk_bounds(buffer.refs(), |r| r.key);
 
-                // Write keyed chunk with parallel BGZF compression via worker pool.
-                let handle = timer.time_spill_write(|| {
-                    let mut writer = if appended {
-                        PooledChunkWriter::<K>::append(
-                            Arc::clone(&pool),
-                            &chunk_path,
-                            pool.spill_codec(),
-                        )?
-                    } else {
-                        PooledChunkWriter::<K>::new(
-                            Arc::clone(&pool),
-                            &chunk_path,
-                            pool.spill_codec(),
-                        )?
-                    };
-                    for (key, record) in buffer.iter_sorted_keyed() {
-                        writer.write_record(&key, record)?;
-                    }
-                    writer.start_finish()
-                })?;
-
-                if let Some(max) = chunk_max {
-                    run_former.extended(chunk_path.clone(), max);
-                }
-                pending_spill = Some(PendingSpill { handle, chunk_path, appended });
+                pending_spill = Some(Self::spill_chunk::<K>(
+                    &mut run_former,
+                    &chunk_files,
+                    bounds,
+                    &mut namer,
+                    &pool,
+                    &mut timer,
+                    |writer| {
+                        for (key, record) in buffer.iter_sorted_keyed() {
+                            writer.write_record(&key, record)?;
+                        }
+                        Ok(())
+                    },
+                )?);
 
                 buffer.clear();
                 force_mi_collect();
@@ -3916,16 +3988,18 @@ impl RawExternalSorter {
                 rayon_pool.install(|| buffer.par_sort());
             });
 
-            timer.time_write_output(|| {
+            stats.output_records = timer.time_write_output(|| {
                 use crate::pooled_bam_writer::PooledBamWriter;
                 let output_header = self.create_output_header(header);
                 let mut writer = PooledBamWriter::new(Arc::clone(&pool), output, &output_header)?;
 
+                let mut written: u64 = 0;
                 for record_bytes in buffer.iter_sorted() {
                     writer.write_raw_record(record_bytes)?;
+                    written += 1;
                 }
                 writer.finish()?;
-                Ok(())
+                Ok(written)
             })?;
         } else {
             // Sort remaining records into separate sub-array chunks (avoids
@@ -3945,11 +4019,11 @@ impl RawExternalSorter {
 
             let memory_chunks = MemorySources::Shared(memory_chunks);
             let n_memory = memory_chunks.num_non_empty();
-            log_run_formation(chunks_spilled, chunk_files.len());
+            log_run_formation(timer.spill_count(), stats.runs_written);
             debug!("Phase 2: Merging {} chunks...", chunk_files.len() + n_memory);
 
             // Merge using O(1) key comparisons
-            timer.time_merge(|| {
+            stats.output_records = timer.time_merge(|| {
                 self.merge_chunks_generic::<K>(
                     &chunk_files,
                     memory_chunks,
@@ -3961,7 +4035,6 @@ impl RawExternalSorter {
             })?;
         }
 
-        stats.output_records = stats.total_records;
         if let Ok(pool) = Arc::try_unwrap(pool) {
             pool.shutdown();
         }
@@ -4724,7 +4797,7 @@ impl RawExternalSorter {
         output: &Path,
         total_records: u64,
         pool: &Arc<SortWorkerPool>,
-    ) -> Result<noodles::bam::bai::Index> {
+    ) -> Result<(noodles::bam::bai::Index, u64)> {
         use crate::loser_tree::LoserTree;
         use crate::pooled_bam_writer::PooledBamWriter;
 
@@ -4750,7 +4823,7 @@ impl RawExternalSorter {
                     .finish_index()
             })?;
             debug!("Merge complete: 0 records merged");
-            return Ok(index);
+            return Ok((index, 0));
         }
 
         let mut tree = LoserTree::new(initial_keys);
@@ -4770,11 +4843,13 @@ impl RawExternalSorter {
             consumer.restart_stalls();
         }
         let loop_start = Instant::now();
+        let mut records_merged: u64 = 0;
         while tree.winner_is_active() {
             let winner = tree.winner();
             let src_idx = source_map[winner];
             let record_bytes = winner_record_bytes(&sources[src_idx], guard.consumer_ref())?;
             writer.write_raw_record(record_bytes)?;
+            records_merged += 1;
             merge_progress.log_if_needed(1);
 
             if let Some(key) = sources[src_idx].advance(guard.consumer_mut())? {
@@ -4824,7 +4899,7 @@ impl RawExternalSorter {
         );
 
         merge_progress.log_final();
-        Ok(index)
+        Ok((index, records_merged))
     }
 
     /// Create output header with appropriate sort order tags.
@@ -5344,6 +5419,129 @@ mod tests {
     use noodles::sam::header::record::value::Map;
     use noodles::sam::header::record::value::map::ReadGroup;
     use rstest::rstest;
+
+    // ========================================================================
+    // Record-count invariant
+    // ========================================================================
+
+    /// A failed permutation check must not leave a readable BAM behind.
+    ///
+    /// The output is finalized by the time the check runs, so it is a valid,
+    /// short BAM -- the most dangerous kind of failure output, because every
+    /// existence check and every reader accepts it. The rest of the crate
+    /// deletes on abort (`test_sort_records_producer_error_aborts`), and this
+    /// path has to as well or the error's own claim is false.
+    #[rstest]
+    #[case::index_written(true)]
+    #[case::no_index(false)]
+    fn record_count_mismatch_removes_the_output(#[case] write_index: bool) {
+        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let output = dir.path().join("out.bam");
+        let bai = fgumi_bam_io::bai_sidecar_path(&output);
+        std::fs::write(&output, b"a short but perfectly valid BAM").expect("write output");
+        std::fs::write(&bai, b"an index describing it").expect("write index");
+
+        let stats = RawSortStats { total_records: 100, output_records: 99, runs_written: 1 };
+        let err = enforce_record_count(&stats, &output, write_index)
+            .expect_err("a record-count mismatch must fail the sort");
+        let msg = format!("{err:#}");
+
+        assert!(!output.exists(), "the incomplete output must not survive the error");
+        assert!(msg.contains("read 100 but wrote 99"), "got: {msg}");
+        assert!(msg.contains("differ by 1"), "got: {msg}");
+        assert!(
+            msg.contains("has been removed"),
+            "the message must state what was done, not just what not to do: {msg}"
+        );
+        // The index describes a file that no longer exists, so it goes too --
+        // but only when this sort is the one that wrote it.
+        assert_eq!(
+            bai.exists(),
+            !write_index,
+            "index removal must follow write_index (write_index={write_index})"
+        );
+    }
+
+    /// stdout cannot be un-written, and `/dev/stdout` must certainly not be
+    /// unlinked. The error still fires; it just cannot claim a removal.
+    #[rstest]
+    #[case::dash("-")]
+    #[case::dev_stdout("/dev/stdout")]
+    fn record_count_mismatch_never_unlinks_stdout(#[case] output: &str) {
+        let stats = RawSortStats { total_records: 10, output_records: 4, runs_written: 1 };
+        let err = enforce_record_count(&stats, Path::new(output), false)
+            .expect_err("a record-count mismatch must fail the sort");
+        let msg = format!("{err:#}");
+
+        assert!(Path::new("/dev/stdout").exists(), "/dev/stdout must survive");
+        assert!(msg.contains("written to stdout"), "got: {msg}");
+        assert!(
+            !msg.contains("has been removed"),
+            "nothing was removed, so the message must not say so: {msg}"
+        );
+    }
+
+    /// A symlinked output is written *through* to the real file, so unlinking
+    /// the link would leave the short BAM exactly where a reader would find it.
+    #[test]
+    fn record_count_mismatch_removes_the_symlink_target() {
+        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let real = dir.path().join("real.bam");
+        let link = dir.path().join("link.bam");
+        std::fs::write(&real, b"a short but perfectly valid BAM").expect("write output");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+
+        let stats = RawSortStats { total_records: 10, output_records: 9, runs_written: 1 };
+        enforce_record_count(&stats, &link, false).expect_err("mismatch must fail the sort");
+
+        assert!(!real.exists(), "the file actually written must be the one removed");
+    }
+
+    /// A FIFO was written through, not created, so it is not this sort's to
+    /// unlink -- and the message must not claim otherwise.
+    #[test]
+    fn record_count_mismatch_leaves_a_non_regular_output_alone() {
+        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let fifo = dir.path().join("out.fifo");
+        let mkfifo =
+            std::process::Command::new("mkfifo").arg(&fifo).status().expect("failed to run mkfifo");
+        assert!(mkfifo.success(), "mkfifo failed");
+
+        let stats = RawSortStats { total_records: 10, output_records: 9, runs_written: 1 };
+        let err = enforce_record_count(&stats, &fifo, false).expect_err("mismatch must fail");
+        let msg = format!("{err:#}");
+
+        assert!(fifo.exists(), "a FIFO must not be unlinked by the sort that wrote through it");
+        assert!(msg.contains("could not be removed"), "got: {msg}");
+    }
+
+    /// The check must be silent and side-effect-free when the counts agree --
+    /// otherwise every successful sort would delete its own output.
+    #[test]
+    fn matching_record_counts_leave_the_output_alone() {
+        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let output = dir.path().join("out.bam");
+        std::fs::write(&output, b"the real output").expect("write output");
+
+        let stats = RawSortStats { total_records: 100, output_records: 100, runs_written: 1 };
+        enforce_record_count(&stats, &output, true).expect("matching counts must succeed");
+        assert!(output.exists(), "a successful sort must keep its output");
+    }
+
+    /// An output that is already gone is the state the removal wanted, so it
+    /// must not be reported as a removal failure on top of the count error.
+    #[test]
+    fn record_count_mismatch_tolerates_a_missing_output() {
+        let dir = tempfile::tempdir().expect("failed to create temp directory");
+        let output = dir.path().join("never-written.bam");
+
+        let stats = RawSortStats { total_records: 5, output_records: 0, runs_written: 0 };
+        let err = enforce_record_count(&stats, &output, true)
+            .expect_err("a record-count mismatch must fail the sort");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("has been removed"), "got: {msg}");
+        assert!(!msg.contains("could not be removed"), "absent is not a failure: {msg}");
+    }
 
     // ========================================================================
     // Merge diagnostics reporting
@@ -6184,7 +6382,7 @@ mod tests {
         use crate::worker_pool::phase;
 
         let fixture = empty_merge_fixture();
-        let index = fixture
+        let (index, records_merged) = fixture
             .sorter
             .merge_chunks_with_index::<RawCoordinateKey>(
                 std::slice::from_ref(&fixture.chunk),
@@ -6196,6 +6394,7 @@ mod tests {
             )
             .expect("empty indexed merge should succeed");
 
+        assert_eq!(records_merged, 0, "an empty merge must report zero records written");
         assert_eq!(
             count_bam_records(&fixture.output),
             0,
@@ -6567,25 +6766,64 @@ mod tests {
         RawReadAheadReader::new(reader).count() as u64
     }
 
-    /// Assert the output really is in coordinate order.
+    /// Assert the output really is in `order`.
     ///
-    /// Record counts alone cannot distinguish "merged correctly" from "emitted
-    /// every record in the wrong order", which is exactly what a bad append
+    /// Built on the crate's own [`crate::verify::verify_sort_order`] and the same
+    /// key extractors the merge uses, so it covers every sort order rather than
+    /// only coordinate. Record counts alone cannot distinguish "merged correctly"
+    /// from "emitted every record in the wrong order", which is what a bad append
     /// would produce.
-    fn assert_sorted_by_coordinate(path: &std::path::Path) {
-        use crate::inline::extract_coordinate_key_inline;
-        use crate::read_ahead::RawReadAheadReader;
-        let (reader, header) =
-            create_raw_bam_reader(path, 1).expect("failed to create raw BAM reader");
-        let nref = u32::try_from(header.reference_sequences().len()).expect("nref fits in u32");
-        let mut previous: Option<u64> = None;
-        for (index, record) in RawReadAheadReader::new(reader).enumerate() {
-            let key = extract_coordinate_key_inline(record.as_ref(), nref);
-            if let Some(prev) = previous {
-                assert!(prev <= key, "record {index} breaks coordinate order: {prev} then {key}");
+    fn assert_sorted_in(order: SortOrder, path: &std::path::Path) {
+        use crate::keys::{RawQuerynameKey, RawQuerynameLexKey, SortContext};
+        use crate::reader::RawBamRecordReader;
+        use crate::verify::verify_sort_order;
+
+        let (_, header) = create_raw_bam_reader(path, 1).expect("open bam for header");
+        let new_reader = || {
+            let file = std::fs::File::open(path).expect("open bam");
+            let mut reader = RawBamRecordReader::new(file).expect("bam reader");
+            reader.skip_header().expect("skip header");
+            reader
+        };
+
+        let summary = match order {
+            SortOrder::Coordinate => {
+                let n_ref = u32::try_from(header.reference_sequences().len())
+                    .expect("reference sequence count fits in u32");
+                verify_sort_order(
+                    new_reader(),
+                    |bam| crate::inline::extract_coordinate_key_inline(bam, n_ref),
+                    |key, prev| key < prev,
+                )
             }
-            previous = Some(key);
-        }
+            SortOrder::Queryname(QuerynameComparator::Natural) => {
+                let ctx = SortContext::from_header(&header);
+                verify_sort_order(
+                    new_reader(),
+                    |bam| RawQuerynameKey::extract(bam, &ctx),
+                    |key, prev| key < prev,
+                )
+            }
+            SortOrder::Queryname(QuerynameComparator::Lexicographic) => {
+                let ctx = SortContext::from_header(&header);
+                verify_sort_order(
+                    new_reader(),
+                    |bam| RawQuerynameLexKey::extract(bam, &ctx),
+                    |key, prev| key < prev,
+                )
+            }
+            SortOrder::TemplateCoordinate => {
+                let lib_lookup = LibraryLookup::from_header(&header);
+                let hasher = cb_hasher();
+                verify_sort_order(
+                    new_reader(),
+                    |bam| extract_template_key_inline(bam, &lib_lookup, None, &hasher),
+                    |key, prev| key < prev,
+                )
+            }
+        };
+        let (_, violations, _) = summary.expect("verify should read the output");
+        assert_eq!(violations, 0, "{order:?}: output is not sorted");
     }
 
     /// Verifies that sort with consolidation preserves all records.
@@ -6690,9 +6928,9 @@ mod tests {
             .expect("sort should succeed");
 
         assert!(
-            stats.chunks_written >= 5,
+            stats.runs_written >= 5,
             "expected at least 5 chunks to exercise post-consolidation naming, got {}",
-            stats.chunks_written
+            stats.runs_written
         );
 
         // Count records in the output BAM to verify no data was lost
@@ -6854,11 +7092,11 @@ mod tests {
         // order instead — so a spilling limit that quietly stopped spilling
         // would leave that half uncovered with the test still green.
         assert_eq!(
-            stats.chunks_written > 0,
+            stats.runs_written > 0,
             memory_limit == SPILLING_MEMORY_LIMIT,
             "a {memory_limit}-byte limit wrote {} spill chunk(s), which is not the path this \
              case is meant to exercise",
-            stats.chunks_written
+            stats.runs_written
         );
 
         // The stable baseline: ingest order, stably sorted by the comparator's
@@ -6880,7 +7118,6 @@ mod tests {
         );
     }
 
-    /// Verifies that sort with many chunks exercises the pool-integrated
     /// Sort `input` to `output` in `order`, spilling or not according to
     /// `memory_limit`.
     fn run_sort(
@@ -6911,10 +7148,10 @@ mod tests {
     /// A coordinate-sorted file is not in template-coordinate order (template
     /// keys derive from the earlier mate), and neither is in queryname order.
     fn presorted_in(dir: &std::path::Path, order: SortOrder, num_pairs: usize) -> PathBuf {
-        let raw = build_ordered_bam(dir, num_pairs, true);
+        let raw = build_ordered_bam(dir, num_pairs);
         let sorted = dir.join(format!("presorted-{}.bam", order.header_so_tag()));
         let stats = run_sort(order, &raw, &sorted, NO_SPILL_MEMORY);
-        assert_eq!(stats.chunks_written, 0, "setup must not spill");
+        assert_eq!(stats.runs_written, 0, "setup must not spill");
         assert_eq!(stats.total_records, stats.output_records);
         sorted
     }
@@ -6934,12 +7171,13 @@ mod tests {
         let stats = run_sort(order, &presorted, &output, SPILL_MEMORY);
 
         assert_eq!(
-            stats.chunks_written, 1,
+            stats.runs_written, 1,
             "{order:?}: input already in this order should spill exactly one run, got {}",
-            stats.chunks_written
+            stats.runs_written
         );
         assert_eq!(stats.total_records, stats.output_records, "{order:?}: lost records");
         assert_eq!(count_bam_records(&output), 600, "{order:?}: wrong record count");
+        assert_sorted_in(order, &output);
     }
 
     /// Every sort order: input NOT in the requested order must not collapse.
@@ -6960,12 +7198,13 @@ mod tests {
         let stats = run_sort(order, &input, &output, SPILL_MEMORY);
 
         assert!(
-            stats.chunks_written >= 2,
+            stats.runs_written >= 2,
             "{order:?}: unsorted input must not collapse into one run, got {}",
-            stats.chunks_written
+            stats.runs_written
         );
         assert_eq!(stats.total_records, stats.output_records, "{order:?}: lost records");
         assert_eq!(count_bam_records(&output), 600, "{order:?}: wrong record count");
+        assert_sorted_in(order, &output);
     }
 
     /// Every sort order: run formation must not change the output bytes.
@@ -6987,10 +7226,10 @@ mod tests {
         let in_memory = dir.path().join("in_memory.bam");
 
         let spilled_stats = run_sort(order, &presorted, &spilled, SPILL_MEMORY);
-        assert_eq!(spilled_stats.chunks_written, 1, "{order:?}: expected the appending path");
+        assert_eq!(spilled_stats.runs_written, 1, "{order:?}: expected the appending path");
 
         let in_memory_stats = run_sort(order, &presorted, &in_memory, NO_SPILL_MEMORY);
-        assert_eq!(in_memory_stats.chunks_written, 0, "{order:?}: expected the no-spill path");
+        assert_eq!(in_memory_stats.runs_written, 0, "{order:?}: expected the no-spill path");
 
         assert_eq!(
             std::fs::read(&spilled).expect("read spilled"),
@@ -7019,15 +7258,16 @@ mod tests {
         input
     }
 
-    /// Build a coordinate BAM whose records ascend or descend by position.
+    /// Build a coordinate-ascending BAM: names and positions both increase.
     ///
-    /// Ascending is "already coordinate-sorted"; descending is the worst case for
-    /// run formation, where no chunk can ever extend another.
-    fn build_ordered_bam(dir: &std::path::Path, num_pairs: usize, ascending: bool) -> PathBuf {
+    /// The starting point for every run-formation test. Tests that need input out
+    /// of order sort this into the order under test first (`presorted_in`) or use
+    /// [`build_shuffled_bam`].
+    fn build_ordered_bam(dir: &std::path::Path, num_pairs: usize) -> PathBuf {
         use fgumi_sam::SamBuilder;
         let mut builder = SamBuilder::new();
         for i in 0..num_pairs {
-            let n = if ascending { i } else { num_pairs - 1 - i };
+            let n = i;
             let _ = builder
                 .add_pair()
                 .name(&format!("read{i:05}"))
@@ -7038,18 +7278,6 @@ mod tests {
         let input = dir.join("input.bam");
         builder.write_bam(&input).expect("write bam");
         input
-    }
-
-    fn sort_ordered_input(input: &std::path::Path, output: &std::path::Path) -> RawSortStats {
-        RawExternalSorter::new(SortOrder::Coordinate)
-            .memory_limit(8 * 1024)
-            .max_temp_files(0)
-            .threads(1)
-            .spill_codec(crate::codec::SpillCodec::Bgzf)
-            .temp_compression(0)
-            .output_compression(0)
-            .sort(input, output)
-            .expect("sort should succeed")
     }
 
     /// Build a coordinate BAM that ascends, drops once, then ascends again.
@@ -7079,37 +7307,45 @@ mod tests {
 
     /// The case that distinguishes run formation from both extremes: a descent
     /// closes the open run and opens exactly one more. Neither the all-sorted nor
-    /// the reverse-sorted test exercises `appendable()` returning `None` while a
-    /// run is open.
+    /// the reverse-sorted test reaches [`RunFormer::place`]'s fresh-path branch
+    /// while a run is open -- one never leaves it, the other never enters it.
     #[test]
     fn test_descent_opens_exactly_one_more_run() {
         let dir = tempfile::tempdir().expect("tempdir");
         let input = build_descent_bam(dir.path(), 300);
         let output = dir.path().join("output.bam");
 
-        let stats = sort_ordered_input(&input, &output);
+        let stats = run_sort(SortOrder::Coordinate, &input, &output, SPILL_MEMORY);
 
         assert!(
-            stats.chunks_written >= 2,
+            stats.runs_written >= 2,
             "a mid-stream descent must close the open run, got {} run(s)",
-            stats.chunks_written
+            stats.runs_written
         );
         assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
         assert_eq!(count_bam_records(&output), 600);
-        assert_sorted_by_coordinate(&output);
+        assert_sorted_in(SortOrder::Coordinate, &output);
     }
 
     /// Consolidation can merge the open run away, leaving `RunFormer` holding a
     /// path that no longer means what it did. Appending there would duplicate or
     /// drop records, so exercise it with consolidation actually enabled --
     /// every other run-formation test disables it.
-    #[test]
-    fn test_consolidation_while_a_run_is_open() {
+    ///
+    /// Parameterized over every order because each reaches
+    /// [`RunFormer::place`]'s consolidation check with a different key type
+    /// through the same generic [`chunk_bounds`].
+    #[rstest::rstest]
+    #[case::coordinate(SortOrder::Coordinate)]
+    #[case::queryname_lex(SortOrder::Queryname(QuerynameComparator::Lexicographic))]
+    #[case::queryname_natural(SortOrder::Queryname(QuerynameComparator::Natural))]
+    #[case::template_coordinate(SortOrder::TemplateCoordinate)]
+    fn test_consolidation_while_a_run_is_open(#[case] order: SortOrder) {
         let dir = tempfile::tempdir().expect("tempdir");
         let input = build_descent_bam(dir.path(), 400);
         let output = dir.path().join("output.bam");
 
-        let stats = RawExternalSorter::new(SortOrder::Coordinate)
+        let stats = RawExternalSorter::new(order)
             .memory_limit(8 * 1024)
             .max_temp_files(2) // small enough that consolidation can swallow the open run
             .threads(1)
@@ -7119,9 +7355,9 @@ mod tests {
             .sort(&input, &output)
             .expect("sort with consolidation should succeed");
 
-        assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
-        assert_eq!(count_bam_records(&output), 800);
-        assert_sorted_by_coordinate(&output);
+        assert_eq!(stats.total_records, stats.output_records, "{order:?}: lost records");
+        assert_eq!(count_bam_records(&output), 800, "{order:?}: wrong record count");
+        assert_sorted_in(order, &output);
     }
 
     /// Appending must work for both spill codecs. Zstd skips `ZSPILL_MAGIC` on
@@ -7135,7 +7371,7 @@ mod tests {
         #[case] temp_compression: u32,
     ) {
         let dir = tempfile::tempdir().expect("tempdir");
-        let input = build_ordered_bam(dir.path(), 300, true);
+        let input = build_ordered_bam(dir.path(), 300);
         let output = dir.path().join("output.bam");
 
         let stats = RawExternalSorter::new(SortOrder::Coordinate)
@@ -7148,10 +7384,10 @@ mod tests {
             .sort(&input, &output)
             .expect("sort should succeed");
 
-        assert_eq!(stats.chunks_written, 1, "sorted input should collapse to one run");
+        assert_eq!(stats.runs_written, 1, "sorted input should collapse to one run");
         assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
         assert_eq!(count_bam_records(&output), 600);
-        assert_sorted_by_coordinate(&output);
+        assert_sorted_in(SortOrder::Coordinate, &output);
     }
 
     /// The indexed path got run formation too, so cover appending there: the
@@ -7159,7 +7395,7 @@ mod tests {
     #[test]
     fn test_appending_run_with_write_index() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let input = build_ordered_bam(dir.path(), 300, true);
+        let input = build_ordered_bam(dir.path(), 300);
         let output = dir.path().join("output.bam");
 
         let stats = RawExternalSorter::new(SortOrder::Coordinate)
@@ -7173,44 +7409,14 @@ mod tests {
             .sort(&input, &output)
             .expect("indexed sort should succeed");
 
-        assert_eq!(stats.chunks_written, 1, "sorted input should collapse to one run");
+        assert_eq!(stats.runs_written, 1, "sorted input should collapse to one run");
         assert_eq!(stats.total_records, stats.output_records, "sort must not lose records");
         assert_eq!(count_bam_records(&output), 600);
         assert!(output.with_extension("bam.bai").exists(), "index should be written");
     }
 
-    /// A run that several chunks were appended to must carry exactly one BGZF
-    /// terminator, at its end -- interior markers stop htslib-based readers.
-    #[test]
-    fn test_appended_run_has_one_terminator() {
-        use fgumi_bgzf::BGZF_EOF;
-
-        let dir = tempfile::tempdir().expect("tempdir");
-        let input = build_ordered_bam(dir.path(), 300, true);
-        let output = dir.path().join("output.bam");
-        let tmp = dir.path().join("spill");
-        std::fs::create_dir_all(&tmp).expect("mkdir");
-
-        let stats = RawExternalSorter::new(SortOrder::Coordinate)
-            .memory_limit(8 * 1024)
-            .max_temp_files(0)
-            .threads(1)
-            .spill_codec(crate::codec::SpillCodec::Bgzf)
-            .temp_compression(0)
-            .output_compression(0)
-            .temp_dirs(vec![tmp.clone()])
-            .sort(&input, &output)
-            .expect("sort should succeed");
-        assert_eq!(stats.chunks_written, 1, "expected a single appended run");
-
-        // Spill files are cleaned up on success, so assert on the invariant that
-        // survives: the output is readable end to end and complete.
-        assert_eq!(count_bam_records(&output), 600);
-        let bytes = std::fs::read(&output).expect("read output");
-        assert!(bytes.ends_with(&BGZF_EOF), "output must end with a BGZF terminator");
-    }
-
-    /// merge readers during the final merge phase (not just consolidation).
+    /// Verifies that sort with many chunks exercises the pool-integrated merge
+    /// readers during the final merge phase (not just consolidation).
     #[rstest::rstest]
     #[case::coordinate(SortOrder::Coordinate)]
     #[case::queryname(SortOrder::Queryname(QuerynameComparator::default()))]
@@ -7257,9 +7463,9 @@ mod tests {
             .expect("sort should succeed");
 
         assert!(
-            stats.chunks_written >= 2,
+            stats.runs_written >= 2,
             "expected multiple chunks to exercise merge, got {}",
-            stats.chunks_written
+            stats.runs_written
         );
 
         let expected = (num_pairs * 2) as u64;
@@ -7429,9 +7635,9 @@ mod tests {
             .sort(&input, &output)
             .expect("sort should succeed");
         assert!(
-            stats.chunks_written > 0,
+            stats.runs_written > 0,
             "test must spill to disk so the oversized record is read back through the \
-             PoolDisk merge (slow path); got chunks_written = 0"
+             PoolDisk merge (slow path); got runs_written = 0"
         );
 
         let mut reader =
@@ -7573,7 +7779,7 @@ mod tests {
         assert_eq!(file_stats.total_records, stream_stats.total_records);
         assert_eq!(file_stats.output_records, stream_stats.output_records);
         assert_eq!(
-            file_stats.chunks_written, stream_stats.chunks_written,
+            file_stats.runs_written, stream_stats.runs_written,
             "stream path should spill exactly like the file path"
         );
         assert_eq!(
@@ -8062,7 +8268,7 @@ mod tests {
             .sort(&input, &output_multi)
             .expect("multi-dir sort should succeed");
 
-        assert!(stats_multi.chunks_written >= 2, "expected multiple spill chunks");
+        assert!(stats_multi.runs_written >= 2, "expected multiple spill runs");
 
         RawExternalSorter::new(SortOrder::Coordinate)
             .memory_limit(8 * 1024)
@@ -8117,7 +8323,7 @@ mod tests {
             .sort(&input, &output)
             .expect("indexed coordinate sort should succeed");
 
-        assert_eq!(stats.chunks_written, 0, "expected no spill for the in-memory path");
+        assert_eq!(stats.runs_written, 0, "expected no spill for the in-memory path");
         assert_eq!(collect_read_names(&output).len(), 40, "record count mismatch");
 
         let bai = fgumi_bam_io::bai_sidecar_path(&output);
@@ -8174,7 +8380,7 @@ mod tests {
             .sort(&input, &output)
             .expect("indexed coordinate sort should succeed");
 
-        assert!(stats.chunks_written >= 2, "expected multiple spill chunks");
+        assert!(stats.runs_written >= 2, "expected multiple spill runs");
 
         // All records preserved.
         let names = collect_read_names(&output);
@@ -8245,7 +8451,7 @@ mod tests {
             .output_compression(0)
             .sort(&input, &output)
             .expect("indexed coordinate sort should succeed");
-        assert!(stats.chunks_written > 0, "test must spill so the indexed pool merge runs");
+        assert!(stats.runs_written > 0, "test must spill so the indexed pool merge runs");
 
         // Every record (including the oversized one) survives the merge.
         assert_eq!(count_bam_records(&output), 161);
@@ -8972,7 +9178,7 @@ mod tests {
                 .key_types(spec)
                 .sort(&input, &out)
                 .expect("sort");
-            (collect_record_bytes(&out), stats.chunks_written)
+            (collect_record_bytes(&out), stats.runs_written)
         };
 
         let (baseline, base_chunks) = sort_spilling("spill_full", KeyTypesSpec::Full);
@@ -9027,7 +9233,7 @@ mod tests {
                 .key_types(spec)
                 .sort(&input, &out)
                 .expect("sort");
-            (collect_record_bytes(&out), stats.chunks_written)
+            (collect_record_bytes(&out), stats.runs_written)
         };
 
         let (baseline, base_chunks) = sort_spilling("spill_full_baseline", KeyTypesSpec::Full);

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -85,16 +85,23 @@ pub struct SortStats {
     pub total_records: u64,
     /// Records written to output.
     pub output_records: u64,
-    /// Number of temporary chunk files written.
-    pub chunks_written: usize,
+    /// Number of spill *runs* written.
+    ///
+    /// A run is one temp file, built from one or more sorted chunks: consecutive
+    /// chunks that are already in order extend the open run rather than each
+    /// starting a file. So an input already in the requested order spills a single
+    /// run, and this is below the number of chunks that were spilled.
+    pub runs_written: usize,
 }
 
 /// Whether `header` already declares the order a sort to `sort_order` would produce.
 ///
 /// Used only to warn: re-sorting a file into the order it is already in is
-/// usually unintended, and it is also the shape the k-way merge handles worst,
-/// because chunking an already-ordered input spills disjoint runs that the merge
-/// must drain one at a time rather than interleave.
+/// usually unintended. It is no longer the shape the merge handles *worst* --
+/// natural run formation collapses an already-ordered input to a single spill
+/// run, so there is effectively no k-way merge left to do -- but it is still a
+/// full read, sort, spill and rewrite of every record to reproduce the order the
+/// input already had.
 ///
 /// Deliberately conservative. `SO` must match, and when the order defines a
 /// sub-sort tag the input's `SS` must match too — so a `queryname` input with no
@@ -237,7 +244,7 @@ mod tests {
         let stats = SortStats::default();
         assert_eq!(stats.total_records, 0);
         assert_eq!(stats.output_records, 0);
-        assert_eq!(stats.chunks_written, 0);
+        assert_eq!(stats.runs_written, 0);
     }
 
     /// Build a header whose `@HD` carries the given SO/SS values.

--- a/crates/fgumi-sort/src/pooled_chunk_writer.rs
+++ b/crates/fgumi-sort/src/pooled_chunk_writer.rs
@@ -28,7 +28,7 @@ use crate::keys::RawSortKey;
 use crate::worker_pool::{CompressResult, CompressTarget, PermitPool, SortWorkerPool};
 use anyhow::Result;
 use crossbeam_channel::bounded;
-use fgumi_bgzf::BGZF_MAX_BLOCK_SIZE;
+use fgumi_bgzf::{BGZF_EOF, BGZF_MAX_BLOCK_SIZE};
 use std::io::BufWriter;
 use std::marker::PhantomData;
 use std::path::Path;
@@ -49,6 +49,46 @@ pub struct PooledChunkWriter<K: RawSortKey> {
     _phantom: PhantomData<K>,
 }
 
+/// Remove the BGZF end-of-stream marker from the end of a spill run.
+///
+/// Called before appending another chunk, so the finished run carries exactly one
+/// terminator. `read_raw_blocks` would in fact skip an interior marker
+/// (`fgumi-bgzf`), so this is not what makes appending correct — it keeps the run
+/// well-formed for anything else that reads it, htslib included, and avoids the
+/// edge where a read batch of nothing but markers looks like end-of-file.
+///
+/// Verifies the tail before truncating: silently lopping 28 bytes off a file that
+/// does not end the way we expect would corrupt a record instead of removing a
+/// marker.
+fn truncate_bgzf_terminator(path: &Path) -> Result<()> {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let mut file = std::fs::OpenOptions::new().read(true).write(true).open(path)?;
+    let len = file.metadata()?.len();
+    let marker_len = BGZF_EOF.len() as u64;
+    anyhow::ensure!(
+        len >= marker_len,
+        "cannot append to {}: file is {len} bytes, shorter than a BGZF terminator",
+        path.display()
+    );
+
+    // Seek from the end by the marker's length. `BGZF_EOF` is a 28-byte
+    // constant, so this conversion cannot wrap in practice; do it explicitly
+    // rather than silencing the lint.
+    let marker_offset = i64::try_from(marker_len).expect("BGZF terminator length fits in i64");
+    file.seek(SeekFrom::End(-marker_offset))?;
+    let mut tail = vec![0u8; BGZF_EOF.len()];
+    file.read_exact(&mut tail)?;
+    anyhow::ensure!(
+        tail == BGZF_EOF,
+        "cannot append to {}: it does not end with a BGZF terminator",
+        path.display()
+    );
+
+    file.set_len(len - marker_len)?;
+    Ok(())
+}
+
 impl<K: RawSortKey> PooledChunkWriter<K> {
     /// Create a new pooled chunk writer with an explicit spill codec.
     ///
@@ -61,9 +101,44 @@ impl<K: RawSortKey> PooledChunkWriter<K> {
     ///
     /// Returns an error if the output file cannot be created.
     pub fn new(pool: Arc<SortWorkerPool>, path: &Path, codec: SpillCodec) -> Result<Self> {
-        let file = std::fs::File::create(path)?;
+        Self::open(pool, path, codec, false)
+    }
+
+    /// Append another sorted chunk to an existing run.
+    ///
+    /// The caller must have established that every key in this chunk sorts at or
+    /// after the run's last key; this type does not and cannot check that.
+    ///
+    /// Two things differ from [`Self::new`]. The file is opened for append rather
+    /// than truncated, and the zstd format magic is written only when a run is
+    /// created — it identifies the file, not each chunk within it. For BGZF the
+    /// trailing end-of-stream marker left by the previous chunk is removed first,
+    /// so a finished run carries exactly one terminator, at its end.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be opened, or if a BGZF run does not
+    /// end with the terminator this writer would have written.
+    pub fn append(pool: Arc<SortWorkerPool>, path: &Path, codec: SpillCodec) -> Result<Self> {
+        Self::open(pool, path, codec, true)
+    }
+
+    fn open(
+        pool: Arc<SortWorkerPool>,
+        path: &Path,
+        codec: SpillCodec,
+        appending: bool,
+    ) -> Result<Self> {
+        let file = if appending {
+            if matches!(codec, SpillCodec::Bgzf) {
+                truncate_bgzf_terminator(path)?;
+            }
+            std::fs::OpenOptions::new().append(true).open(path)?
+        } else {
+            std::fs::File::create(path)?
+        };
         let mut writer = BufWriter::with_capacity(256 * 1024, file);
-        if matches!(codec, SpillCodec::Zstd) {
+        if matches!(codec, SpillCodec::Zstd) && !appending {
             use std::io::Write;
             writer.write_all(&ZSPILL_MAGIC)?;
         }

--- a/crates/fgumi-sort/src/pooled_chunk_writer.rs
+++ b/crates/fgumi-sort/src/pooled_chunk_writer.rs
@@ -104,26 +104,24 @@ impl<K: RawSortKey> PooledChunkWriter<K> {
         Self::open(pool, path, codec, false)
     }
 
-    /// Append another sorted chunk to an existing run.
+    /// Create a run, or append another sorted chunk to an existing one.
     ///
-    /// The caller must have established that every key in this chunk sorts at or
-    /// after the run's last key; this type does not and cannot check that.
+    /// When `appending`, the caller must have established that every key in this
+    /// chunk sorts at or after the run's last key; this type does not and cannot
+    /// check that.
     ///
-    /// Two things differ from [`Self::new`]. The file is opened for append rather
-    /// than truncated, and the zstd format magic is written only when a run is
-    /// created — it identifies the file, not each chunk within it. For BGZF the
-    /// trailing end-of-stream marker left by the previous chunk is removed first,
-    /// so a finished run carries exactly one terminator, at its end.
+    /// Two things differ when appending. The file is opened for append rather than
+    /// truncated, and the zstd format magic is written only when a run is created —
+    /// it identifies the file, not each chunk within it. For BGZF the trailing
+    /// end-of-stream marker left by the previous chunk is removed first, so a
+    /// finished run carries exactly one terminator, at its end.
     ///
     /// # Errors
     ///
-    /// Returns an error if the file cannot be opened, or if a BGZF run does not
-    /// end with the terminator this writer would have written.
-    pub fn append(pool: Arc<SortWorkerPool>, path: &Path, codec: SpillCodec) -> Result<Self> {
-        Self::open(pool, path, codec, true)
-    }
-
-    fn open(
+    /// Returns an error if the file cannot be opened, or if a BGZF run being
+    /// appended to does not end with the terminator this writer would have
+    /// written.
+    pub fn open(
         pool: Arc<SortWorkerPool>,
         path: &Path,
         codec: SpillCodec,
@@ -317,6 +315,43 @@ mod tests {
     use crate::external::GenericKeyedChunkReader;
     use crate::inline::TemplateKey;
     use tempfile::TempDir;
+
+    /// A finished run carries exactly one BGZF terminator, at its end, however
+    /// many chunks were appended to it.
+    ///
+    /// Tested here rather than through a full sort, because a sort deletes its
+    /// spill files on success — the property is only observable at this level.
+    #[test]
+    fn test_appending_leaves_one_bgzf_terminator() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("run.keyed");
+        let pool = Arc::new(SortWorkerPool::new(2, 1, 6, SpillCodec::Bgzf));
+
+        // Two chunks, the second appended to the first.
+        for (chunk, appending) in [(0u64, false), (1u64, true)] {
+            let mut writer = PooledChunkWriter::<TemplateKey>::open(
+                Arc::clone(&pool),
+                &path,
+                SpillCodec::Bgzf,
+                appending,
+            )
+            .expect("open run");
+            writer.write_record(&make_key(chunk), b"record-bytes").expect("write");
+            writer.finish().expect("finish");
+        }
+
+        let bytes = std::fs::read(&path).expect("read run");
+        assert!(bytes.ends_with(&BGZF_EOF), "a finished run must end with the terminator");
+        let interior = &bytes[..bytes.len() - BGZF_EOF.len()];
+        assert!(
+            !interior.windows(BGZF_EOF.len()).any(|w| w == BGZF_EOF),
+            "an appended run must not carry an interior terminator"
+        );
+
+        if let Ok(pool) = Arc::try_unwrap(pool) {
+            pool.shutdown();
+        }
+    }
 
     /// Create a test `TemplateKey` with distinct values for roundtrip verification.
     #[allow(clippy::cast_possible_truncation)]

--- a/crates/fgumi-sort/tests/integration/test_output_compression.rs
+++ b/crates/fgumi-sort/tests/integration/test_output_compression.rs
@@ -192,7 +192,7 @@ struct SortRun {
 }
 
 /// Sorts `input` in `sort_order` under `run` and returns
-/// `(output_size_bytes, chunks_written, decoded_records)`.
+/// `(output_size_bytes, runs_written, decoded_records)`.
 ///
 /// `expected` is the independent baseline the output is checked against — the
 /// multiset of the *input* records, decoded straight from the input BAM without
@@ -246,13 +246,13 @@ fn sort_at_level(
         "level {output_compression} output is not in {sort_order:?} order"
     );
     let size = std::fs::metadata(output).expect("output metadata").len();
-    (size, stats.chunks_written, records)
+    (size, stats.runs_written, records)
 }
 
 /// `output_compression` must change the size of the written BAM.
 ///
 /// Both merge paths are covered: a memory limit large enough to hold everything
-/// (no spill, `chunks_written == 0`) and one small enough to force spill files.
+/// (no spill, `runs_written == 0`) and one small enough to force spill files.
 /// Only the in-memory case was broken — it never entered Phase 2, and back then
 /// the phase was what chose the compressor, so the pool used the Phase 1 spill
 /// one.
@@ -302,22 +302,22 @@ fn test_output_compression_level_reaches_the_output_bam(
     };
 
     let uncompressed = dir.path().join("level0.bam");
-    let (size_level_0, chunks_0, records_level_0) =
+    let (size_level_0, runs_0, records_level_0) =
         sort_at_level(sort_order, &input, &uncompressed, run_at(0), &expected);
 
     let compressed = dir.path().join("level9.bam");
-    let (size_level_9, chunks_9, records_level_9) =
+    let (size_level_9, runs_9, records_level_9) =
         sort_at_level(sort_order, &input, &compressed, run_at(9), &expected);
 
     assert_eq!(
-        chunks_0 > 0,
+        runs_0 > 0,
         expect_spill,
-        "expected spill={expect_spill}, got chunks_written={chunks_0} at level 0 ({sort_order:?})"
+        "expected spill={expect_spill}, got runs_written={runs_0} at level 0 ({sort_order:?})"
     );
     assert_eq!(
-        chunks_9 > 0,
+        runs_9 > 0,
         expect_spill,
-        "expected spill={expect_spill}, got chunks_written={chunks_9} at level 9 ({sort_order:?})"
+        "expected spill={expect_spill}, got runs_written={runs_9} at level 9 ({sort_order:?})"
     );
 
     // Both runs were already checked against the independent baseline above;

--- a/crates/fgumi-sort/tests/integration/test_read_ahead.rs
+++ b/crates/fgumi-sort/tests/integration/test_read_ahead.rs
@@ -49,7 +49,7 @@ fn test_pool_integrated_reader_round_trip_coordinate() {
         expected, stats.total_records
     );
     assert_eq!(stats.output_records, expected);
-    assert_eq!(stats.chunks_written, 0, "tiny BAM should fit in memory");
+    assert_eq!(stats.runs_written, 0, "tiny BAM should fit in memory");
 }
 
 /// Same round-trip but with template-coordinate sort order to exercise the

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -774,28 +774,15 @@ impl Sort {
         }
 
         let stats = sorter.sort(&self.input, output)?;
-        let (total_records, output_records, chunks_written) =
-            (stats.total_records, stats.output_records, stats.chunks_written);
-
-        // A sort is a permutation: every record read must be written. Both counts
-        // were already tracked and merely logged, so a bug that dropped records
-        // anywhere -- run formation, the merge, consolidation -- produced a
-        // silently short BAM and exited 0. Comparing them turns that whole class
-        // of corruption into a hard failure for the price of one branch.
-        anyhow::ensure!(
-            total_records == output_records,
-            "sort lost records: read {total_records} but wrote {output_records} \
-             ({} missing). The output at {} is incomplete and must not be used.",
-            total_records.saturating_sub(output_records),
-            output.display()
-        );
+        let (total_records, output_records, runs_written) =
+            (stats.total_records, stats.output_records, stats.runs_written);
 
         // Summary
         info!("=== Summary ===");
         info!("Records processed: {total_records}");
         info!("Records written: {output_records}");
-        if chunks_written > 0 {
-            info!("Temporary chunks: {chunks_written}");
+        if runs_written > 0 {
+            info!("Spill runs: {runs_written}");
         }
         info!("Output: {}", output.display());
 
@@ -1485,9 +1472,9 @@ mod tests {
         // `Some(2)` run exercised consolidation rather than a trivial in-memory
         // sort. Without this the identity assertion below could pass vacuously.
         assert!(
-            default_stats.chunks_written >= 2,
+            default_stats.runs_written >= 2,
             "test must spill multiple runs to exercise consolidation, got {} chunk(s)",
-            default_stats.chunks_written,
+            default_stats.runs_written,
         );
         assert_eq!(
             limited_stats.output_records, default_stats.output_records,

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -777,6 +777,19 @@ impl Sort {
         let (total_records, output_records, chunks_written) =
             (stats.total_records, stats.output_records, stats.chunks_written);
 
+        // A sort is a permutation: every record read must be written. Both counts
+        // were already tracked and merely logged, so a bug that dropped records
+        // anywhere -- run formation, the merge, consolidation -- produced a
+        // silently short BAM and exited 0. Comparing them turns that whole class
+        // of corruption into a hard failure for the price of one branch.
+        anyhow::ensure!(
+            total_records == output_records,
+            "sort lost records: read {total_records} but wrote {output_records} \
+             ({} missing). The output at {} is incomplete and must not be used.",
+            total_records.saturating_sub(output_records),
+            output.display()
+        );
+
         // Summary
         info!("=== Summary ===");
         info!("Records processed: {total_records}");

--- a/tests/integration/test_streaming_output.rs
+++ b/tests/integration/test_streaming_output.rs
@@ -198,7 +198,7 @@ fn the_spilling_fixture_spills() {
     );
     let log = String::from_utf8_lossy(&run.stderr);
     assert!(
-        log.contains("Temporary chunks:"),
+        log.contains("Spill runs:"),
         "20k records under `-m 1M` no longer spill, so the merge path is not being covered:\n{log}"
     );
 }


### PR DESCRIPTION
Phase 1 chunks its input sequentially, so an input that is **already in the requested order** spills chunks that are not merely disjoint but *totally ordered*: chunk 0 holds the earliest records, chunk 1 the next. Writing each to its own file manufactures a k-way merge for a sequence that was never interleaved — and that is exactly the degenerate case measured in #709, where the merge loop takes 308s against 183s for the same records fed from interleaved runs, at 56% worker utilization.

#709 makes that case ~9% faster by scheduling it better. This removes it: if the chunks are already ordered, don't create 86 sources to merge.

That this happens in practice is not hypothetical. `1kg-wgs-HG00096.bam` in the fgumi-benchmarks corpus is `SO:coordinate`, and the production sort matrix has been sorting it *to* coordinate for months — every historical "coordinate" cell has been measuring the degenerate path and reporting it as a normal sort, in a curated benchmark whose own documentation claims those inputs are queryname-sorted. Defensive "sort to be sure" steps in real pipelines do the same thing.

## What this does

A **run** is a spill file that is globally sorted, built from one or more chunks. A chunk extends the open run when every key in it sorts at or after that run's last key — free to test, since the chunk is already sorted in memory and its extreme keys are its ends.

- Coordinate-sorted input collapses to **one run**.
- Almost-sorted input decomposes into its **natural runs** — a new run begins at each chunk-level descent.
- Reverse-sorted input never appends and behaves exactly as before.

## Only the most recent run is a candidate

This is a correctness requirement, not a simplification, and it's the part most worth reviewing.

Considering older runs too ("best fit") yields fewer runs on adversarial input but **breaks stability**. If run 0 stopped receiving at key 100 while run 1 is at 200, a chunk with minimum 150 attaches to run 0 — so run 0 holds chunks {0,1,2,9} while run 1 holds {3,4}. Source index order no longer matches ingest order, and for a key present in both chunk 3 and chunk 9 the merge emits chunk 9's copy first, reversing two equal-keyed records.

Restricting appends to the most recent run keeps every run a **consecutive group of chunks**, so source order equals ingest order. Combined with the loser tree's tie-break on source index (`loser_tree.rs`, `.then_with(|| a.cmp(&b))` — a contract already pinned by `test_all_same_keys_stable`), the output is **byte-identical** to one-file-per-chunk. `test_run_formation_output_is_byte_identical` asserts exactly that, comparing the appending path against the no-spill path byte for byte.

## Also included

**A records-in == records-out check.** Both counts were already tracked and merely logged, so any bug that dropped records — the merge, consolidation, spill — produced a silently short BAM and exited 0. The only comparison between them lived in a test. This is worth landing on its own merits and is the real safety net under this change.

**Run-formation logging** (`Spill runs: 1 from 86 chunks`), so every sort reports how ordered its own input was. That is the cheapest way to learn how common near-sorted inputs are in practice, rather than guessing.

## Scope

**All four sort orders**: coordinate, queryname (lexicographic and natural), and template-coordinate.

Queryname was excluded in the first cut for a reason that turned out to be wrong, and it is worth stating plainly since the earlier description asserted it: `RawQuerynameKey` does **not** borrow into the record buffer. It owns `name: Vec<u8>` and derives `Clone`, forming raw pointers only transiently inside `cmp` from `self.name.as_ptr()`. Nothing dangles when a chunk's buffer is cleared, so relaxing `RunFormer`'s bound from `Copy` to `Clone` is the entire change — one read name of storage per spill.

One property of the queryname key is worth knowing for review. Its third lane is the ingest position *within the current chunk*, reset per chunk and zeroed on merge read-back. So when two boundary records share both name and flags, the comparison falls through to that lane, where the run's last record holds a high value and the next chunk's first holds zero — and the test declines the append. That direction is the safe one: a chunk-local position is always larger for the earlier record, so this can only ever refuse a legal append, never permit an illegal one. The cost is a missed append when identical name and flags straddle a chunk boundary, which is both rare and harmless.

Template keys are self-contained too — `TemplateKey24/32/40` are packed `u64` lanes, and `TemplateRecordRef` caches the key on the ref, so a chunk's extreme keys are its ends.

One thing worth knowing about the template case: a coordinate-sorted file is **not** in template-coordinate order. Template keys are built from the earlier mate's coordinate, so a coordinate-sorted input is only *near*-sorted in template space, and a single straddling pair per chunk boundary blocks an append. The practical case this helps is re-sorting an already-template-coordinate BAM; whether the dedup path (coordinate → template-coordinate) sees any appends is an empirical question the new run-formation logging now answers on real data.

## Testing

721 `fgumi-sort` tests pass, 7,044 across the workspace, plus clippy, fmt and `RUSTDOCFLAGS=-D warnings` docs.

The core behaviour is covered by three tests **parameterized over all four sort orders**, written before the queryname implementation — the queryname cases failed beforehand and pass after, which is what makes them worth having:

- presorted input collapses to exactly one run
- unsorted input never collapses
- the appending path is **byte-identical** to the no-spill path

Each builds its input by sorting it, rather than assuming one order implies another. It doesn't: a coordinate-sorted file is in neither template-coordinate nor queryname order.

Mechanics covered separately:

- a mid-stream descent closes the open run and opens exactly one more
- consolidation firing **while a run is open** (`max_temp_files(2)`, where `n_to_merge` can swallow the open run) — the drop/duplicate path `.coderabbit.yaml`'s `fgumi-sort` instruction calls out
- appending across **both spill codecs**, since zstd skips its magic on append and a second magic mid-file would be read as frame data
- appending on the `--write-index` path
- output coordinate order asserted directly, not just record counts

Existing multi-chunk tests had their inputs made descending in **both** coordinate and name, so they remain out of order under every sort order. Ascending values meant presorted input, which now folds into one run and would have silently stopped exercising the merge those tests exist to cover — passing while testing nothing.

## Consequence worth calling out

The spill-count figure changes meaning — it becomes runs, not chunks. Anything parsing it (the benchmark suite's sort report, and `test_max_temp_files_pins_bracket_the_measured_spill_counts` in fgumi-benchmarks) will see 1 where it saw 86 for inputs already in the requested order. That is the change working, but it will read as a regression in the spill-consolidation tables unless expected.

Consolidation also fires less often, since there are fewer files to count.

## Relationship to other work

- **#709** — merge scheduling for the degenerate case. Complementary: this removes the case, that improves it when it still occurs (lying headers, almost-sorted input).
- **#710** — skip the sort entirely when the header declares the requested order. Much cheaper for the honest-header case; this one trusts nothing and works on almost-sorted input.

A follow-up can write the single run in BAM format so a one-run sort byte-copies or renames into place, skipping the decompress/recompress transcode entirely. This is its precondition.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: output changes apply only to sorting and are pinned by stable, byte-identical ordering; `unsafe` changes: none, and `CLAUDE.md` allowlist changes: none; memory bounds, queue capacity, and thread/backpressure policy changes: none.

- Forms natural spill runs for coordinate, queryname, and template-coordinate sorting.
- Preserves ingest order, stability, ordering, and byte-identical output.
- Renames `SortStats::chunks_written` to `runs_written`.
- Adds independent records-in/out validation and safe cleanup for incomplete outputs.
- Supports incremental spill accounting, both spill codecs, indexed output, and append-safe BGZF terminators.
- Adds run-formation logging and centralized spill and merge handling.
- Expands tests for sorting, stability, consolidation, codecs, indexes, telemetry, cleanup, and output targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->