### PR TITLE
ci(miri): gate PRs that touch the Miri-scoped crate

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -12,10 +12,44 @@ name: Miri (undefined-behavior check)
 # so covering its radix-sort unsafe needs `#[cfg(not(miri))]` guards first
 # (tracked as a follow-up).
 #
-# Runs on a schedule (and on demand) rather than per-PR: Miri needs the nightly
-# toolchain (which can regress independently of this repo) and is much slower than
-# a normal test run, so a nightly-Miri hiccup should not block unrelated changes.
+# Two triggers, two jobs to do.
+#
+# **Per-PR, path-filtered — the gate.** A PR that touches `fgumi-raw-bam` gets
+# Miri before it merges, because the only thing Miri can tell you is which change
+# introduced the UB, and a nightly-only run answers that with "somewhere in
+# yesterday's merges." The filter is what keeps the original objection to per-PR
+# runs (a nightly-Miri regression should not block unrelated work) true: a PR that
+# does not touch the covered crate never starts this workflow, so it cannot be
+# blocked by it. The PRs it can block are exactly the ones that can introduce UB
+# here. Cost is not the constraint at this scope — the scoped `sort` tests run in
+# seconds, against a `test` job that takes minutes.
+#
+# Deliberately no `push:` on `main`: a `pull_request` run already tests the
+# simulated merge commit, so a merged PR was covered by construction, and the cron
+# below re-checks `main` daily anyway. Adding it would double every Miri run to buy
+# a few hours of latency on drift the cron already finds.
+#
+# **Daily cron — the canary.** Keeps covering two things a PR run cannot: a
+# nightly-Miri or toolchain regression against *unchanged* code, and `main` itself
+# between merges. It is also where scope can widen (the `fgumi-sort` FFI exclusion
+# above) without putting that cost on every PR. A failing cron files a tracking
+# issue; see the `report-failure` job, which is gated to the scheduled trigger so
+# a PR failure stays in that PR's checks.
 on:
+  pull_request:
+    # Server-side filtering, with one documented limit: GitHub evaluates `paths`
+    # against only the first 3,000 files of a diff, so a PR larger than that which
+    # touches the covered crate could fail to start this workflow. Accepted rather
+    # than worked around. The alternative -- trigger on every PR and re-derive the
+    # changed paths in a gating job -- puts a job on every PR in the repository to
+    # cover a diff shape (3,000+ files, including `crates/fgumi-raw-bam`) that
+    # would be a vendored-dependency dump, not a change to the comparator this
+    # gate protects. Revisit if that ever stops being true.
+    paths:
+      # The covered crate, and this workflow itself — editing the scope or the
+      # guards below should re-run them.
+      - "crates/fgumi-raw-bam/**"
+      - ".github/workflows/miri.yml"
   schedule:
     - cron: "0 8 * * *" # daily at 08:00 UTC
   workflow_dispatch: {}
@@ -26,8 +60,10 @@ on:
 permissions:
   contents: read
 
-# A manual dispatch overlapping (or a delayed) scheduled run adds no signal, so
-# keep only the newest run of this workflow alive.
+# Only the newest run per ref stays alive. `github.ref` is `refs/pull/N/merge` for
+# a PR, so a force-push to a PR cancels its own in-flight run without touching
+# anyone else's; a manual dispatch overlapping (or a delayed) scheduled run on the
+# same ref likewise adds no signal.
 concurrency:
   group: miri-${{ github.ref }}
   cancel-in-progress: true
@@ -44,8 +80,9 @@ jobs:
   miri:
     runs-on: ubuntu-latest
     # The scoped `sort` tests take seconds locally; anything near this cap means
-    # the interpreter (or a nightly regression) is hung, and on a daily cron that
-    # should fail fast rather than idle at GitHub's 6-hour default.
+    # the interpreter (or a nightly regression) is hung. Fail fast rather than idle
+    # at GitHub's 6-hour default — on a daily cron nobody is watching, and on a PR
+    # nobody wants to.
     timeout-minutes: 20
     steps:
       - name: Checkout code


### PR DESCRIPTION
Stacked on #702 — review that one first; this PR's diff against it is `.github/workflows/miri.yml` only.

## Why

Miri ran only on a daily cron, so the earliest a UB regression could surface was the next morning, attributed to a whole day of merges rather than to the change that introduced it. Bisecting UB is expensive, and naming the commit is most of Miri's value.

There was a good reason it was cron-only, recorded in the workflow header: a nightly-Miri regression should not block unrelated work. **Path filtering keeps that true** rather than trading it away — a PR that does not touch the covered crate never starts the workflow, so it cannot be blocked by it. What it can block is exactly the set of PRs able to introduce UB in the code Miri checks.

The other objection was cost, and it does not survive the current scope: the `sort` tests run in seconds under Miri, against a `test` job that takes minutes.

## What

- `pull_request` trigger filtered to `crates/fgumi-raw-bam/**` and `.github/workflows/miri.yml`.
- No `push:` on `main` — a `pull_request` run tests the simulated merge commit, so a merged PR is already covered, and the cron re-checks `main` daily. Adding it would double every Miri run to shave hours off drift the cron already catches.
- The cron stays, with a different job: a nightly/toolchain regression against *unchanged* code, and `main` between merges. It is also where scope can widen (the `fgumi-sort` FFI exclusion) without charging every PR for it.
- The failure-reporting step from #702 needed no change — it is already gated to `github.event_name == 'schedule'`, so a PR failure stays in that PR's checks instead of filing an issue.

## Verification

`actionlint` clean, and the filter checked against nine paths: `crates/fgumi-raw-bam/{src/sort.rs,Cargo.toml}` and this workflow trigger it; `fgumi-sort`, `fgumi-umi`, `src/main.rs`, `Cargo.lock`, `README.md` and `check.yml` do not.

**This PR demonstrates itself.** It touches `.github/workflows/miri.yml`, so the new filter matched and a `miri` check ran on it — the first per-PR Miri run in this repo. Measured on that run:

| job | duration |
|---|---|
| `miri` | **1m26s** |
| `test` | 3m27s |
| `coverage` | 3m43s |
| `sort-correctness` | 2m22s |

So the cost argument is settled with real numbers rather than an estimate: the whole Miri job, recompile included, is under half the `test` job and is nowhere near the critical path. Inside it, the scoped filter ran **30 tests passed, 694 filtered out** — the intended narrow scope, and not a vacuous run.

## Two things reviewers should weigh

1. **`main` is not branch-protected**, so nothing here makes the job a *required* check. If required checks are ever configured, note the standard GitHub trap: a required check skipped by a path filter leaves a PR waiting forever. That needs a "skipped is success" companion job, not a change here.

2. **Miri covers 2 of the 7 files carrying `#[allow(unsafe_code)]`** — `fgumi-sort` has five, excluded because `memory_probe.rs` calls mimalloc/mach2 FFI that Miri cannot execute. So a green Miri means less than it reads like. The higher-value follow-up is a cheap, stable-toolchain check in `check.yml` asserting the set of `allow(unsafe_code)`-bearing files matches an expected allowlist, failing on any addition or move. That would cover all 7 and catch new `unsafe` appearing in an uncovered crate, which nothing does today.

## Follow-up for the runall stack

`feat-runall` adds `fgumi-pipeline-core` and a second Miri step for its `erased` module. That crate is not on `main`, so it is deliberately absent from the filter here. Whichever branch lands that step must add `crates/fgumi-pipeline-core/**` alongside it, or the new step will only ever run on the cron.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: command output none; `unsafe` none and `CLAUDE.md` allowlist unchanged; memory, queue, and backpressure policy none.

Fix: Run Miri on relevant pull requests while retaining daily regression coverage.

- Add path-filtered `pull_request` coverage for `crates/fgumi-raw-bam/**` and `.github/workflows/miri.yml`.
- Keep scheduled failure reporting limited to cron runs.
- `actionlint` and path checks pass.
- Per-PR Miri run passed 30 tests in 1m26s.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->