### PR TITLE
feat(sort): add SortMergeSlot, the phase-2 merge handoff slot

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -55,6 +55,38 @@ jobs:
       - name: Clippy check
         run: cargo ci-lint
 
+  # `merge_slots.rs` swaps `std::sync` for `loom::sync` under `--cfg loom`, and
+  # `tests/loom_merge_slots.rs` is `#![cfg(loom)]`. Neither is built by any other
+  # job, so without this one a broken model — or a `cfg(loom)` build that stopped
+  # compiling — is invisible: the test target compiles to an empty binary under a
+  # normal build and reports success. That silence is the whole reason this job
+  # exists.
+  #
+  # Per-PR rather than on a schedule, unlike `miri.yml` and `stress.yml`. Those
+  # two are scheduled because they are non-deterministic in ways unrelated to a
+  # given change (a nightly-toolchain regression; timing sensitivity). Loom
+  # explores a bounded state space deterministically — four of the five models
+  # under a preemption bound, see the test's "Preemption-bounded exploration"
+  # note — so the same input yields the same verdict with no flake, which is
+  # what lets it gate a PR, and a gate is what stops it rotting.
+  loom:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Set up compilation cache (sccache)
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+      # Release: the models explore enough interleavings that a debug build takes
+      # several times as long for the same verdict.
+      - name: Loom model check (SortMergeSlot)
+        run: cargo test -p fgumi-sort --test loom_merge_slots --release
+        env:
+          RUSTFLAGS: --cfg loom
+
   coverage:
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,7 @@ dependencies = [
  "libdeflater",
  "libmimalloc-sys",
  "log",
+ "loom",
  "mach2",
  "nix",
  "noodles",
@@ -1049,6 +1050,21 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
 ]
 
 [[package]]
@@ -1420,6 +1436,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,6 +1462,15 @@ name = "mach2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata 0.4.16",
+]
 
 [[package]]
 name = "matrixmultiply"
@@ -1631,6 +1669,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -2228,6 +2275,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scoped_threadpool"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,6 +2384,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2550,6 +2612,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2611,6 +2682,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata 0.4.16",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "trybuild"
 version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2648,6 +2768,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/crates/fgumi-sort/Cargo.toml
+++ b/crates/fgumi-sort/Cargo.toml
@@ -13,6 +13,12 @@ keywords = ["bioinformatics", "bam", "sort", "sequencing", "ngs"]
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }
 
+[lints.rust]
+# `loom` is a config flag set only for the model-checking test target
+# (`tests/loom_merge_slots.rs`, run via `RUSTFLAGS="--cfg loom"`). Declare it so
+# the unexpected-cfg lint stays quiet under the normal `-D warnings` build.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
+
 [dependencies]
 fgumi-raw-bam = { workspace = true, features = ["noodles"] }
 fgumi-bgzf = { workspace = true }
@@ -58,3 +64,12 @@ rstest = { workspace = true }
 proptest = { workspace = true }
 criterion = { workspace = true }
 tempfile = { workspace = true }
+
+# loom is only compiled under `--cfg loom`. It is a *regular* (not dev)
+# dependency so `merge_slots.rs` itself can swap `std::sync` -> `loom::sync`
+# under `#[cfg(loom)]` and have its REAL atomics/locks model-checked by
+# `tests/loom_merge_slots.rs` (which drives the real `SortMergeSlot`). The test
+# is `#![cfg(loom)]` (empty under a normal build).
+# Run with:  RUSTFLAGS="--cfg loom" cargo test -p fgumi-sort --test loom_merge_slots --release
+[target.'cfg(loom)'.dependencies]
+loom = "0.7"

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -48,6 +48,7 @@ pub(crate) mod inline;
 pub(crate) mod keys;
 pub(crate) mod loser_tree;
 pub(crate) mod memory_probe;
+pub(crate) mod merge_slots;
 pub(crate) mod pipeline;
 pub(crate) mod pooled_bam_writer;
 pub(crate) mod pooled_chunk_writer;
@@ -170,6 +171,7 @@ pub use keys::{
     QuerynameComparator, RawCoordinateKey, RawQuerynameKey, RawQuerynameLexKey, RawSortKey,
     SortContext, SortOrder, natural_compare, natural_compare_nul, normalize_natural_key,
 };
+pub use merge_slots::{PHASE2_DECOMP_CAP, SortMergeReader, SortMergeSlot};
 pub use reader::{
     OwnedRawBamRecordReader, RawBamRecordReader, open_raw_bam_record_reader,
     open_raw_bam_record_reader_with_header,

--- a/crates/fgumi-sort/src/merge_slots.rs
+++ b/crates/fgumi-sort/src/merge_slots.rs
@@ -1,0 +1,923 @@
+//! Per-spill-file shared state for the unified-pipeline merge phase.
+//!
+//! `SortMergeSlot` is the per-spill-file shared state shuttled between
+//! `SortSpillDecompress` (producer side: reads raw BGZF blocks from
+//! disk, decompresses inline, pushes to the slot's bounded queue) and
+//! `SortMerge` (consumer side: pops decompressed blocks from the
+//! queue, parses records, drives the k-way merge) via
+//! `Arc<SortMergeSlot>` clones.
+//!
+//! # Per-slot bounded queue design (v4 — see commit `9c39dea` / PR #389 and
+//! `docs/design/sort-phase2-unification-deferral.md`)
+//!
+//! Each slot carries a bounded queue of decompressed BGZF blocks
+//! (`PHASE2_DECOMP_CAP` entries). Backpressure lives here — the
+//! producer is **non-blocking**: pushes only when the queue has
+//! space; otherwise skips this slot and tries the next. The consumer
+//! is also **non-blocking**: when the queue is empty but the slot is
+//! not yet `queue_eof` it reports `WouldBlock` (see
+//! `external.rs::slot_try_load_block`) and the cooperative `SortMerge`
+//! step yields, so the framework re-dispatches it after the producer
+//! has refilled the slot. No condvar, no parked thread.
+//!
+//! ## Why "queue has space OR consumer has a block OR slot EOF" is
+//! the full state space
+//!
+//! For any slot at any wall-clock time, one of the following is true:
+//!
+//! 1. `decompressed.len() < PHASE2_DECOMP_CAP` — producer can push.
+//! 2. `decompressed.len() > 0` — consumer can pop.
+//! 3. `queue_eof == true` — slot is done; consumer returns EOF.
+//!
+//! The "consumer would block" path is reachable only when
+//! `decompressed.len() == 0 && !queue_eof`, in which case the
+//! producer will eventually flip the state to either (1) (push more
+//! blocks) or (3) (set `queue_eof` on the read returning fewer
+//! bytes than asked), and the next consumer dispatch observes it. No
+//! "transient cap with all-workers-Skip" window.
+//!
+//! ## Atomic ordering (`decomp_error` / `queue_eof`)
+//!
+//! Producers' BOTH success and error paths MUST hold the
+//! `decompressed` mutex while storing `queue_eof` (and the error
+//! path additionally stores `decomp_error`). The consumer always
+//! acquires the same mutex at the top of its poll loop. The
+//! mutex's release-acquire chain establishes happens-before for
+//! BOTH atomics simultaneously — regardless of which the consumer
+//! loads first. Without this discipline, a stale `decomp_error`
+//! load can race a fresh `queue_eof` load and produce silent
+//! truncation.
+//!
+//! ## What used to live here, and why it's gone (v4 vs v3.1)
+//!
+//! Pre-v4 the slot also carried a `raw_blocks: Mutex<VecDeque>`
+//! queue and a `decomp_in_flight: AtomicUsize` counter. Pre-v4
+//! workers split work into a separate "read raw" step and a "claim
+//! and decompress" step, with cap+gap-filler admission. That
+//! design deadlocked at production scale because the framework's
+//! drain protocol could Skip workers during a transient "all slots
+//! at cap simultaneously" window. v4 collapses read-and-decompress
+//! into one inline operation per worker per slot per `try_run`,
+//! which for that **inline path** eliminates the `raw_blocks` queue,
+//! the in-flight counter, the reorder buffer (a plain FIFO suffices,
+//! because one worker reads per slot at a time via the reader lock,
+//! so blocks decompress strictly in read order), and the gap-filler
+//! escape.
+//!
+//! The reorder buffer and in-flight counter are **back** on this
+//! struct — [`SortMergeSlot::reorder`] and [`SortMergeSlot::in_flight`] —
+//! for the later **block-parallel** path, where several workers
+//! decompress one file's blocks concurrently and results complete out
+//! of order. The `bp_*` methods drive that path. Read the paragraph
+//! above as "the inline path does not need them", not as "this module
+//! does not have them": the state space argument above likewise covers
+//! the inline path, while the block-parallel path additionally requires
+//! `in_flight == 0` and a drained `reorder` before `queue_eof` finalizes.
+//!
+//! ## Status in this tree, and the OTHER Phase-2 implementation
+//!
+//! **`SortMergeSlot` currently has no callers.** It is landing ahead of
+//! the engine that drives it, as one slice of a phased port; the
+//! producer/consumer steps named above (`SortSpillDecompress`,
+//! `SortMerge`) and `external.rs::slot_try_load_block` arrive with the
+//! `worker_pool.rs` / `external.rs` rewrite in a later phase. Until then
+//! the crate's live Phase-2 is `worker_pool::Phase2FileState`, driven
+//! through `RawExternalSorter::sort` — the opposite of the end state.
+//!
+//! `worker_pool::Phase2FileState` keeps its own reorder buffer and
+//! in-flight counter because its single-reader/**multi-decompressor**
+//! topology needs them, and it retains the gap-filler this module
+//! dropped. Once the rewrite lands, this module becomes the production
+//! Phase-2 for both standalone `fgumi sort` and the fused `runall`
+//! sort, and `Phase2FileState` is retained as the
+//! `RawExternalSorter::sort` library path and the `#[cfg(test)]`
+//! parity oracle. (History: commit `9d6d7e9` / PR #395 and
+//! `docs/design/sort-phase2-unification-deferral.md`.)
+
+use std::collections::VecDeque;
+use std::fs::File;
+use std::io::BufReader;
+
+// Concurrency primitives are sourced from `loom` under `--cfg loom` so the
+// model-checking test (`tests/loom_merge_slots.rs`) exercises the REAL
+// `SortMergeSlot` atomics/mutexes — every interleaving and memory reordering of
+// the block-parallel EOF/in-flight/finalize protocol — instead of a hand-copied
+// re-implementation. Under a normal build these are the `std` types verbatim.
+#[cfg(loom)]
+use loom::sync::Mutex;
+#[cfg(loom)]
+use loom::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+#[cfg(not(loom))]
+use std::sync::Mutex;
+#[cfg(not(loom))]
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use fgumi_bam_io::reorder::ReorderBuffer;
+
+use crate::codec::SpillCodec;
+
+/// Per-slot decompressed-block queue cap. Bounds in-flight
+/// decompressed memory: `num_slots × PHASE2_DECOMP_CAP ×` per-entry size,
+/// where each entry is a decompressed BGZF block or zstd frame ranging from
+/// ~64 KB (BGZF) up to 256 KB (zstd worst case).
+///
+/// Raised from 8 to 32 (increment 1a) to give the work-stealing decompressor
+/// more runway ahead of the `Detached` merge, which was input-starved
+/// (`MergeDiag stalls`) at the spill-heavy operating point. The `worker_pool.rs`
+/// copy (the `cfg(test)`/library oracle path) is intentionally left at 8 — these
+/// two are no longer equal.
+///
+/// Hard cap — there is no admission escape. Producers skip a slot
+/// when its queue is at this cap, returning to it on a later
+/// `try_run` after the consumer has drained. It stays a per-slot, independent
+/// bound (deadlock-safety is unchanged — see the module header).
+///
+/// # Not the bound in force today
+///
+/// `worker_pool.rs` declares a *different* constant of the same name
+/// (`pub(crate) const PHASE2_DECOMP_CAP: usize = 8`) for its own Phase-2, and
+/// that is the one governing this crate's live merge path until the engine
+/// rewrite lands — this module has no callers yet. So `fgumi_sort::PHASE2_DECOMP_CAP`
+/// resolves to 32 while the merge that actually runs is bounded at 8. The two
+/// are deliberately unequal (see this constant's history above); the confusable
+/// part is only which is in force, and that flips when the rewrite lands.
+pub const PHASE2_DECOMP_CAP: usize = 32;
+
+/// Disk reader state for a single spill file. Mutex'd separately
+/// from `decompressed` so the producer can hold the reader during
+/// disk I/O without blocking the consumer's pop.
+pub struct SortMergeReader {
+    /// Buffered file handle.
+    pub inner: BufReader<File>,
+    /// Next per-slot sequence number to assign to a raw block read from this
+    /// file. Used ONLY by the block-parallel `SortSpillDecompress` path: each
+    /// raw block read under the reader lock is stamped with a monotonically
+    /// increasing sequence number so the out-of-order decompression results can
+    /// be reassembled in read order by the slot's [`SortMergeSlot::reorder`]
+    /// buffer. Because every read is serialized under the reader lock, the
+    /// sequence numbers are dense and assigned in strict read order. Unused by
+    /// the inline (file-granularity) path, which never reorders.
+    pub next_seq: u64,
+}
+
+/// Per-spill-file shared state.
+///
+/// Constructed by `SortAndSpill` (one per closed spill file via
+/// `slots_for_chunk_files`), embedded in
+/// `SortPhase1Event::SpillReady` as `Arc<SortMergeSlot>`, forwarded
+/// verbatim by `SortSpillDecompress`, and finally installed in
+/// `SortMerge`'s slot table. Drops when the last `Arc` is released
+/// — typically after `SortMerge`'s merge driver is exhausted.
+pub struct SortMergeSlot {
+    /// Stable identifier — the index this slot occupies in the
+    /// merge driver's source list. `SortMerge` orders sources by
+    /// `file_id` so the `LoserTree` tie-break for equal sort keys
+    /// is deterministic and matches the legacy chunk-files order.
+    pub file_id: u32,
+    /// Spill codec of this chunk's file, detected from the file magic when the
+    /// slot is opened (`slots_for_chunk_files`). The `SortSpillDecompress` step
+    /// reads it to decompress BGZF blocks or zstd frames; `reader` is already
+    /// positioned past any codec file-magic.
+    pub codec: SpillCodec,
+    /// Disk reader. Held only while reading raw bytes from disk.
+    /// One worker at a time per slot via `try_lock`.
+    pub reader: Mutex<SortMergeReader>,
+    /// Bounded queue of decompressed blocks (each a BGZF block or a zstd
+    /// frame, per this slot's `codec`), FIFO. Pushed by the producer
+    /// (`SortSpillDecompress`) after read + inline decompress; popped by the
+    /// consumer (`SortMerge` via `slot_try_load_block`). Bounded at
+    /// `PHASE2_DECOMP_CAP`; producer skips when at cap.
+    pub decompressed: Mutex<VecDeque<Vec<u8>>>,
+    /// Set true once the producer detects EOF on the disk reader
+    /// AND has pushed any final batch of decompressed blocks to
+    /// `decompressed`. After this transition, the slot will never
+    /// receive another push. Consumer surfaces this as a clean EOF
+    /// when its poll finds `decompressed.is_empty() && queue_eof`.
+    ///
+    /// **Atomic ordering:** producer must hold the `decompressed`
+    /// mutex while storing this. Consumer reads it under the same
+    /// mutex. Mutex release-acquire creates happens-before.
+    pub queue_eof: AtomicBool,
+    /// Set true if BGZF decompression of a raw block fails. Consumer
+    /// surfaces this as `Err` rather than the silent `Ok(false)` that
+    /// an empty queue + `queue_eof` would look like.
+    ///
+    /// **Atomic ordering:** identical to `queue_eof`. Producer
+    /// stores while holding `decompressed`; consumer reads under
+    /// the same lock.
+    pub decomp_error: AtomicBool,
+
+    // ── Block-parallel decompression state (file_granularity == false) ───────
+    //
+    // These three fields are inert in the inline (file-granularity) path. In
+    // the block-parallel path multiple workers decompress one file's blocks
+    // concurrently: the READ is serialized under `reader` (sequence-tagged via
+    // `SortMergeReader::next_seq`), but the decompression happens outside the
+    // lock, so results complete out of order and are reassembled here.
+    /// Number of raw blocks that have been READ (under the reader lock) but not
+    /// yet inserted into `reorder`. Incremented under the reader lock when a
+    /// batch is read; decremented after the worker inserts that batch into
+    /// `reorder`. The slot may declare EOF only once this reaches zero — a
+    /// worker that observes reader-EOF must not truncate the merge while another
+    /// worker still holds an in-flight (read-but-undelivered) block.
+    pub in_flight: AtomicUsize,
+    /// Set true once a read returns fewer raw blocks than requested, i.e. the
+    /// disk reader reached a clean EOF. Distinct from `queue_eof`: `reader_eof`
+    /// means "no more blocks will be read", whereas `queue_eof` means "every
+    /// block has been read, decompressed, reassembled, and delivered to the
+    /// FIFO". `queue_eof` is set only when `reader_eof && in_flight == 0 &&
+    /// reorder.is_empty()`. Stored under the reader lock (Release), read in the
+    /// finalize path (Acquire); being an atomic it does not participate in lock
+    /// ordering.
+    pub reader_eof: AtomicBool,
+    /// Per-slot reorder buffer that reassembles out-of-order decompression
+    /// results back into read (sequence) order before they are drained into the
+    /// FIFO. Lock order: acquire `reorder` BEFORE `decompressed` (never the
+    /// reverse); the reader lock, when held, is outermost. The consumer never
+    /// touches this — it only pops the in-order FIFO.
+    pub reorder: Mutex<ReorderBuffer<Vec<u8>>>,
+}
+
+impl SortMergeSlot {
+    /// Construct an empty slot for `file_id` backed by `reader` (positioned
+    /// past any codec file-magic) with the detected `codec`.
+    #[must_use]
+    pub fn new(file_id: u32, reader: BufReader<File>, codec: SpillCodec) -> Self {
+        Self {
+            file_id,
+            codec,
+            reader: Mutex::new(SortMergeReader { inner: reader, next_seq: 0 }),
+            decompressed: Mutex::new(VecDeque::with_capacity(PHASE2_DECOMP_CAP)),
+            queue_eof: AtomicBool::new(false),
+            decomp_error: AtomicBool::new(false),
+            in_flight: AtomicUsize::new(0),
+            reader_eof: AtomicBool::new(false),
+            reorder: Mutex::new(ReorderBuffer::new()),
+        }
+    }
+
+    /// Returns `true` when this slot has cleanly delivered all of its
+    /// output: `queue_eof` is set, the decompressed queue is empty, and
+    /// no decompression error was recorded.
+    ///
+    /// A slot whose `decomp_error` flag is set is **never** reported as
+    /// drained — an errored slot must surface as an error to its
+    /// consumer, not be mistaken for clean EOF. Callers using
+    /// `is_drained()` as a completion predicate must check
+    /// [`Self::has_error`] (or the source-level error flags) to
+    /// distinguish "still producing" from "failed".
+    ///
+    /// `decomp_error` is read while holding the `decompressed` mutex, honoring
+    /// the file's read-under-lock discipline. `queue_eof` is read *before* the
+    /// lock, on the fast path, and that is safe for the reverse reason: a
+    /// producer only stores `queue_eof` while holding this mutex, so observing
+    /// it `true` means the storing critical section has already released, and
+    /// the lock taken immediately below then establishes happens-before for
+    /// `decomp_error`. Observing it `false` unlocked can only be stale in the
+    /// direction that returns `false` early, which is the answer a
+    /// not-yet-finalized slot warrants anyway.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `decompressed` mutex is poisoned.
+    #[must_use]
+    pub fn is_drained(&self) -> bool {
+        // Fast path: not yet at EOF — no need to take the lock.
+        if !self.queue_eof.load(Ordering::Acquire) {
+            return false;
+        }
+        let guard = self.decompressed.lock().expect("SortMergeSlot decompressed mutex poisoned");
+        // Read `decomp_error` under the same lock the producer held when
+        // storing it. An errored slot is not a clean drain.
+        if self.decomp_error.load(Ordering::Acquire) {
+            return false;
+        }
+        guard.is_empty()
+    }
+
+    /// Returns `true` if this slot recorded a decompression error.
+    ///
+    /// Read under the `decompressed` mutex to honor the file's
+    /// read-under-lock discipline. Use alongside [`Self::is_drained`] to
+    /// distinguish a clean EOF (`is_drained() == true`) from a failed
+    /// slot (`has_error() == true`), since `is_drained()` returns
+    /// `false` in both the "still producing" and "errored" cases.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `decompressed` mutex is poisoned.
+    #[must_use]
+    pub fn has_error(&self) -> bool {
+        let _guard = self.decompressed.lock().expect("SortMergeSlot decompressed mutex poisoned");
+        self.decomp_error.load(Ordering::Acquire)
+    }
+
+    /// Gather probe statistics for this slot: `(pending_blocks,
+    /// pending_bytes, active)`.
+    ///
+    /// `pending_blocks` is the count of decompressed blocks waiting
+    /// for the consumer. `pending_bytes` is the sum of their byte
+    /// lengths. `active` is `!queue_eof` (the slot is still being
+    /// fed by the producer).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `decompressed` mutex is poisoned.
+    #[must_use]
+    pub fn probe_stats(&self) -> (u64, u64, bool) {
+        let dec = self.decompressed.lock().expect("SortMergeSlot decompressed mutex poisoned");
+        #[allow(clippy::cast_possible_truncation)]
+        let pending_blocks = dec.len() as u64;
+        let pending_bytes: u64 = dec.iter().map(|buf| buf.len() as u64).sum();
+        drop(dec);
+        // `Acquire` for uniformity with every other `queue_eof` reader, even
+        // though this is a best-effort diagnostics probe.
+        let active = !self.queue_eof.load(Ordering::Acquire);
+        (pending_blocks, pending_bytes, active)
+    }
+
+    /// Current number of decompressed blocks resident in the FIFO. Locks
+    /// `decompressed` for an O(1) `len()` read — used by the decompressor's
+    /// emptiest-first refill order (most-starved slot first). Cheaper than
+    /// [`Self::probe_stats`], which also sums per-block byte lengths.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `decompressed` mutex is poisoned.
+    #[must_use]
+    pub fn fifo_len(&self) -> usize {
+        self.decompressed.lock().expect("SortMergeSlot decompressed mutex poisoned").len()
+    }
+
+    // ── Block-parallel decompression helpers (file_granularity == false) ─────
+
+    /// Block-parallel admission control: may a worker read another batch of raw
+    /// blocks (whose first block would be tagged `next_seq`) into this slot's
+    /// reorder window?
+    ///
+    /// Combines [`ReorderBuffer::would_accept`] (the deadlock-free predicate the
+    /// pipeline uses elsewhere) with a hard `heap_bytes < window_budget`
+    /// backstop. The backstop is what actually bounds memory: `would_accept`
+    /// alone returns `true` (accept-all) while the buffer is *stuck* (the front
+    /// sequence not yet decompressed), which would let a slow straggler balloon
+    /// the window. The backstop is deadlock-safe **in this topology** because
+    /// reads are serialized and densely sequenced, so the front gap is ALWAYS an
+    /// already-read in-flight block (some worker is decompressing it) — never an
+    /// unread block that a new read would be required to fetch. Refusing new
+    /// reads therefore cannot wedge progress.
+    ///
+    /// `window_budget == 0` means unlimited.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `reorder` mutex is poisoned.
+    #[must_use]
+    pub fn bp_reorder_admits(&self, next_seq: u64, window_budget: u64) -> bool {
+        let rb = self.reorder.lock().expect("reorder mutex poisoned");
+        if !rb.would_accept(next_seq, window_budget) {
+            return false;
+        }
+        window_budget == 0 || rb.heap_bytes() < window_budget
+    }
+
+    /// Reserve `count` in-flight blocks just read under the reader lock.
+    ///
+    /// **Ordering requirement:** the caller MUST call this BEFORE
+    /// [`Self::bp_set_reader_eof`] for the EOF-carrying batch. Both stores are
+    /// `Release`; the lock-free finalizer in `drain_locked_and_finalize`
+    /// reads `reader_eof` (Acquire) then `in_flight` (Acquire) WITHOUT the
+    /// reader lock, so only this publish order guarantees that observing
+    /// `reader_eof == true` also makes this batch's `in_flight` increment
+    /// visible — otherwise the finalizer can declare a clean EOF that truncates
+    /// the EOF read's own still-in-flight block (loom-verified; see
+    /// `tests/loom_merge_slots.rs`).
+    pub(crate) fn bp_add_in_flight(&self, count: usize) {
+        self.in_flight.fetch_add(count, Ordering::Release);
+    }
+
+    /// Mark the disk reader as having reached a clean EOF (called under the
+    /// reader lock when a read returns fewer blocks than requested).
+    ///
+    /// **Ordering requirement:** call this AFTER [`Self::bp_add_in_flight`] has
+    /// reserved the current batch — see that method's note. Publishing
+    /// `reader_eof` before the in-flight reservation reopens a truncation race.
+    pub(crate) fn bp_set_reader_eof(&self) {
+        self.reader_eof.store(true, Ordering::Release);
+    }
+
+    /// Publish the accounting for a batch of `count` raw blocks just read under
+    /// the reader lock, in the one order that is correct: reserve the in-flight
+    /// blocks FIRST, then (on a short read) set `reader_eof`.
+    ///
+    /// This is the single source of truth for the publish order — both the
+    /// production worker (`SortSpillDecompress::try_fill_block_parallel_slot`)
+    /// and the loom model (`tests/loom_merge_slots.rs`) call it, so the ordering
+    /// is model-checked against the real code and the two cannot drift.
+    ///
+    /// **Why this order (loom-verified).** The lock-free finalizer in
+    /// `drain_locked_and_finalize` reads `reader_eof` (Acquire) then
+    /// `in_flight` (Acquire) WITHOUT the reader lock, so the reader lock does not
+    /// order this batch's accounting against it. Both stores are `Release`; a
+    /// finalizer that observes `reader_eof == true` therefore also observes this
+    /// (possibly EOF-carrying) batch's `in_flight` increment, and so cannot
+    /// finalize `queue_eof` while the batch is still in flight. Setting
+    /// `reader_eof` first would let a finalizer see `reader_eof == true` with
+    /// `in_flight == 0` after earlier blocks drained, finalizing a clean EOF that
+    /// silently truncates this batch's own block. Swapping the two lines makes
+    /// `tests/loom_merge_slots.rs` fail (as it did before the fix in `ac0a2ad`).
+    pub fn bp_commit_read(&self, count: usize, hit_eof: bool) {
+        self.bp_add_in_flight(count);
+        if hit_eof {
+            self.bp_set_reader_eof();
+        }
+    }
+
+    /// Number of additional decompressed blocks the FIFO can accept before it
+    /// hits [`PHASE2_DECOMP_CAP`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `decompressed` mutex is poisoned.
+    #[must_use]
+    pub fn bp_fifo_room(&self) -> usize {
+        let dec = self.decompressed.lock().expect("decompressed mutex poisoned");
+        PHASE2_DECOMP_CAP.saturating_sub(dec.len())
+    }
+
+    /// Tracked reorder-window heap bytes (for tests / diagnostics).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `reorder` mutex is poisoned.
+    #[must_use]
+    pub fn bp_reorder_heap_bytes(&self) -> u64 {
+        self.reorder.lock().expect("reorder mutex poisoned").heap_bytes()
+    }
+
+    /// Insert a freshly-decompressed batch `[start_seq, start_seq + count)` into
+    /// the reorder buffer, release the in-flight reservation, drain any now-ready
+    /// (in-order) blocks into the FIFO (bounded by [`PHASE2_DECOMP_CAP`]), and
+    /// finalize `queue_eof` if the slot is fully delivered.
+    ///
+    /// `count` is the reservation being released and **must** equal
+    /// `blocks.len()`. The one exception is the empty final read
+    /// (`count == 0`, `blocks` empty), which still calls through here so the
+    /// EOF can be finalized once the last in-flight block drains. Returns
+    /// `true` if it made progress (drained at least one block or finalized
+    /// EOF).
+    ///
+    /// Delivering fewer blocks than reserved is **silent truncation**, not a
+    /// tolerated shape: the short batch releases the reservation for sequence
+    /// numbers that were never inserted, so `in_flight` reaches zero and
+    /// `reorder` reports empty with those sequences simply absent. The slot
+    /// then finalizes a *clean* `queue_eof` — `is_drained()` true,
+    /// `has_error()` false — and the consumer treats a truncated spill file as
+    /// a complete one. Releasing *more* than was reserved is worse still: the
+    /// `fetch_sub` below wraps `in_flight` to `usize::MAX`, after which the
+    /// finalize predicate's `in_flight == 0` can never hold and the slot wedges
+    /// — the merge consumer polls `WouldBlock` forever rather than failing.
+    ///
+    /// Both are caller contract violations with no in-band signal, so they are
+    /// asserted here. A caller that decompresses fewer blocks than it reserved
+    /// must store `true` into [`SortMergeSlot::decomp_error`] while holding the
+    /// `decompressed` mutex — see the module header's ordering rules — rather
+    /// than short-batching this call.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `blocks.len() != count`, or if `count` exceeds the outstanding
+    /// in-flight reservation. Both checks are **always on**, release included:
+    /// the failure they catch is silent record loss or a wedged merge, neither
+    /// of which has an in-band signal, and release is the configuration that
+    /// ships. The cost is two compares per *batch* — not per record — on a path
+    /// that decompresses up to [`PHASE2_DECOMP_CAP`] blocks per call. Both run
+    /// before any lock is taken, so a violation cannot poison the `reorder` or
+    /// `decompressed` mutex.
+    ///
+    /// Also panics if the `reorder` or `decompressed` mutex is already poisoned.
+    pub fn bp_insert_drain_finalize(
+        &self,
+        start_seq: u64,
+        blocks: Vec<Vec<u8>>,
+        count: usize,
+    ) -> bool {
+        assert_eq!(
+            blocks.len(),
+            count,
+            "bp_insert_drain_finalize would release a reservation of {count} while delivering \
+             {} blocks; a short batch finalizes a clean EOF over the missing sequences",
+            blocks.len()
+        );
+        // Load once: the message must report the value that actually failed the
+        // check, not a re-read that another worker may have moved in between.
+        let in_flight = self.in_flight.load(Ordering::Acquire);
+        assert!(
+            in_flight >= count,
+            "bp_insert_drain_finalize would release {count} in-flight blocks with only \
+             {in_flight} reserved; the fetch_sub below would wrap and wedge the slot",
+        );
+        let mut rb = self.reorder.lock().expect("reorder mutex poisoned");
+        for (i, block) in blocks.into_iter().enumerate() {
+            let size = block.len();
+            // `start_seq + i` cannot exceed the number of blocks read from one
+            // spill file, which is far below u64::MAX.
+            rb.insert_with_size(start_seq + i as u64, block, size);
+        }
+        // The reservation now lives in `reorder`, so release it. AcqRel so the
+        // finalize load below sees a consistent count.
+        self.in_flight.fetch_sub(count, Ordering::AcqRel);
+        self.drain_locked_and_finalize(&mut rb)
+    }
+
+    /// Drain-only block-parallel pass: move any in-order ready blocks from the
+    /// reorder buffer into the FIFO (used when the FIFO had no room earlier, or
+    /// post-reader-EOF to flush stragglers other workers inserted) and finalize
+    /// `queue_eof`. Returns `true` if it made progress.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `reorder` or `decompressed` mutex is poisoned.
+    pub fn bp_drain_and_finalize(&self) -> bool {
+        let mut rb = self.reorder.lock().expect("reorder mutex poisoned");
+        self.drain_locked_and_finalize(&mut rb)
+    }
+
+    /// Shared drain + finalize, called with the `reorder` lock held. Acquires
+    /// `decompressed` (lock order: reorder → decompressed) so `queue_eof` is
+    /// stored under the same mutex the consumer reads it under.
+    fn drain_locked_and_finalize(&self, rb: &mut ReorderBuffer<Vec<u8>>) -> bool {
+        let mut dec = self.decompressed.lock().expect("decompressed mutex poisoned");
+        let mut room = PHASE2_DECOMP_CAP.saturating_sub(dec.len());
+        let mut drained = 0usize;
+        while room > 0 {
+            let Some(block) = rb.try_pop_next() else { break };
+            dec.push_back(block);
+            room -= 1;
+            drained += 1;
+        }
+        // Finalize EOF: reader is exhausted, every read block has been inserted
+        // (in_flight == 0), and the reorder buffer is fully drained. Stored
+        // under `decompressed` so the consumer's release-acquire chain sees it.
+        let mut finalized = false;
+        if !self.queue_eof.load(Ordering::Acquire)
+            && self.reader_eof.load(Ordering::Acquire)
+            && self.in_flight.load(Ordering::Acquire) == 0
+            && rb.is_empty()
+        {
+            self.queue_eof.store(true, Ordering::Release);
+            finalized = true;
+        }
+        drained > 0 || finalized
+    }
+}
+
+// These exercise `SortMergeSlot` outside `loom::model`, which is illegal once
+// the primitives are loom's, so they compile only in a normal (non-loom) build.
+// The `--cfg loom` invocation runs `tests/loom_merge_slots.rs` exclusively.
+#[cfg(all(test, not(loom)))]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    fn empty_reader() -> BufReader<File> {
+        BufReader::new(tempfile::tempfile().expect("create tempfile"))
+    }
+
+    #[test]
+    fn new_slot_starts_empty_and_not_drained() {
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
+        assert_eq!(slot.file_id, 0);
+        assert!(!slot.is_drained(), "fresh slot not drained until queue_eof");
+        let (pending_blocks, pending_bytes, active) = slot.probe_stats();
+        assert_eq!(pending_blocks, 0);
+        assert_eq!(pending_bytes, 0);
+        assert!(active, "active until queue_eof flips");
+    }
+
+    #[test]
+    fn drained_when_queue_eof_and_empty() {
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
+
+        // Push a decompressed block; not drained even if queue_eof.
+        slot.decompressed.lock().unwrap().push_back(vec![0xAB, 0xCD]);
+        slot.queue_eof.store(true, Ordering::Release);
+        assert!(!slot.is_drained(), "not drained while decompressed non-empty");
+
+        // Consume the block.
+        let popped = slot.decompressed.lock().unwrap().pop_front();
+        assert_eq!(popped, Some(vec![0xAB, 0xCD]));
+        assert!(slot.is_drained(), "drained once queue empty AND queue_eof");
+    }
+
+    #[test]
+    fn fifo_len_reports_block_count() {
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
+        assert_eq!(slot.fifo_len(), 0);
+        slot.decompressed.lock().unwrap().push_back(vec![0u8; 10]);
+        slot.decompressed.lock().unwrap().push_back(vec![0u8; 20]);
+        assert_eq!(slot.fifo_len(), 2, "counts blocks, not bytes");
+    }
+
+    #[test]
+    fn probe_stats_counts_decompressed_only() {
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
+        slot.decompressed.lock().unwrap().push_back(vec![0u8; 1024]);
+        slot.decompressed.lock().unwrap().push_back(vec![0u8; 512]);
+
+        let (pending_blocks, pending_bytes, active) = slot.probe_stats();
+        assert_eq!(pending_blocks, 2);
+        assert_eq!(pending_bytes, 1024 + 512);
+        assert!(active, "not yet queue_eof");
+    }
+
+    /// Blocks reach the FIFO in READ order even when decompression completes
+    /// out of order — the reorder buffer's entire purpose. Hand-pushing into
+    /// `decompressed` and popping it back would assert that `VecDeque` is a
+    /// queue, which is true of `VecDeque` and says nothing about the slot.
+    #[test]
+    fn fifo_order() {
+        let slot = SortMergeSlot::new(7, empty_reader(), SpillCodec::Bgzf);
+        slot.bp_commit_read(4, true);
+
+        // The later half of the file finishes decompressing first. Nothing may
+        // drain past the gap at seq 0, however ready seqs 2 and 3 are.
+        slot.bp_insert_drain_finalize(2, vec![vec![2], vec![3]], 2);
+        assert_eq!(slot.fifo_len(), 0, "nothing drains while seq 0 is missing");
+
+        // The front of the file lands; now the whole run drains, in read order.
+        slot.bp_insert_drain_finalize(0, vec![vec![0], vec![1]], 2);
+        let popped: Vec<u8> = slot.decompressed.lock().unwrap().drain(..).map(|b| b[0]).collect();
+        assert_eq!(popped, vec![0, 1, 2, 3], "read order, not completion order");
+        assert!(slot.queue_eof.load(Ordering::Acquire), "all 4 delivered ⇒ EOF finalizes");
+    }
+
+    /// `has_error` must report the flag through its own lock-and-load, not
+    /// merely echo the atomic. Asserting on `decomp_error` directly would test
+    /// `AtomicBool` rather than anything belonging to `SortMergeSlot`.
+    #[test]
+    fn has_error_reports_the_decomp_error_flag() {
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
+        assert!(!slot.has_error(), "a fresh slot has no error");
+        slot.decomp_error.store(true, Ordering::Release);
+        assert!(slot.has_error(), "has_error must observe a stored decomp_error");
+    }
+
+    #[test]
+    fn errored_slot_is_not_drained() {
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
+
+        // Mark EOF with an empty queue but a decompression error set: this
+        // must NOT be reported as a clean drain, otherwise a caller using
+        // is_drained() as a completion predicate would treat the failure as
+        // successful EOF and silently truncate the merge.
+        slot.queue_eof.store(true, Ordering::Release);
+        slot.decomp_error.store(true, Ordering::Release);
+        assert!(!slot.is_drained(), "errored slot must not be reported as drained");
+        assert!(slot.has_error(), "has_error must surface the recorded decomp error");
+    }
+
+    #[test]
+    fn clean_eof_reports_no_error() {
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
+        slot.queue_eof.store(true, Ordering::Release);
+        assert!(slot.is_drained(), "clean empty + queue_eof is drained");
+        assert!(!slot.has_error(), "clean drain has no error");
+    }
+
+    // ── Block-parallel helper tests ─────────────────────────────────────────
+
+    /// A single in-order batch drains straight into the FIFO and (because the
+    /// reader is at EOF with no other in-flight blocks) finalizes `queue_eof`.
+    #[test]
+    fn bp_single_batch_drains_and_finalizes() {
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
+        slot.bp_add_in_flight(2);
+        slot.bp_set_reader_eof();
+        let progressed = slot.bp_insert_drain_finalize(0, vec![vec![1u8], vec![2u8]], 2);
+        assert!(progressed);
+        assert!(slot.queue_eof.load(Ordering::Acquire), "reader_eof + drained ⇒ queue_eof");
+        let mut dec = slot.decompressed.lock().unwrap();
+        assert_eq!(dec.pop_front(), Some(vec![1u8]));
+        assert_eq!(dec.pop_front(), Some(vec![2u8]));
+    }
+
+    /// EOF-with-stragglers: a worker reads the FINAL (short) batch and hits
+    /// reader-EOF while another worker still holds an earlier in-flight batch.
+    /// The EOF-observing worker must NOT finalize `queue_eof` (which would
+    /// truncate the merge); only after the straggler is delivered, in order,
+    /// does the slot finalize. No block is dropped or reordered.
+    #[test]
+    fn bp_eof_with_straggler_does_not_truncate() {
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
+
+        // Worker A reserved seqs 0,1; worker B reserved seqs 2,3 on the final
+        // (short) read and set reader_eof.
+        slot.bp_add_in_flight(2); // A: seq 0,1
+        slot.bp_add_in_flight(2); // B: seq 2,3 (final batch)
+        slot.bp_set_reader_eof();
+
+        // Worker B finishes decompressing FIRST and delivers seqs 2,3. Gap at
+        // 0,1 ⇒ nothing drains, and in_flight (A's 2) is non-zero ⇒ no EOF.
+        let b_progress = slot.bp_insert_drain_finalize(2, vec![vec![2u8], vec![3u8]], 2);
+        assert!(!b_progress, "straggler ahead-of-gap insert drains nothing and can't finalize");
+        assert!(!slot.queue_eof.load(Ordering::Acquire), "must NOT declare EOF with A in flight");
+        assert!(slot.decompressed.lock().unwrap().is_empty(), "nothing delivered yet");
+
+        // Worker A finishes and delivers seqs 0,1 ⇒ all four drain in order and
+        // EOF finalizes.
+        let a_progress = slot.bp_insert_drain_finalize(0, vec![vec![0u8], vec![1u8]], 2);
+        assert!(a_progress);
+        assert!(slot.queue_eof.load(Ordering::Acquire), "EOF finalizes once straggler delivered");
+
+        let mut dec = slot.decompressed.lock().unwrap();
+        let order: Vec<u8> = std::iter::from_fn(|| dec.pop_front()).map(|b| b[0]).collect();
+        assert_eq!(order, vec![0, 1, 2, 3], "blocks delivered in read order, none truncated");
+    }
+
+    /// The reorder window stays bounded when the front sequence straggles: a
+    /// worker keeps decompressing ahead-of-gap blocks, but `bp_reorder_admits`
+    /// refuses new reads once `heap_bytes` reaches the window budget, so the
+    /// buffer never balloons past `budget + one batch`.
+    #[test]
+    fn bp_reorder_window_is_bounded_under_straggler() {
+        const BLOCK: usize = 1024;
+        const BUDGET: u64 = 4 * BLOCK as u64; // 4 blocks
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
+
+        // Stamp each block with its sequence number. Asserting only a count at
+        // the end would pass for a drain that dropped one block and duplicated
+        // another, or that delivered the window out of order.
+        let block_for = |seq: u64| {
+            let mut block = vec![0u8; BLOCK];
+            block[0] = u8::try_from(seq).expect("the window budget keeps seqs far below 256");
+            block
+        };
+
+        // Seq 0 is the straggler — it is reserved but never decompressed/inserted,
+        // so the buffer can never pop and keeps a permanent front gap.
+        slot.bp_add_in_flight(1); // seq 0 in flight forever (the straggler)
+
+        // Workers race ahead delivering seqs 1,2,3,… as long as admission allows.
+        let mut next = 1u64;
+        let mut admitted = 0;
+        while slot.bp_reorder_admits(next, BUDGET) {
+            slot.bp_add_in_flight(1);
+            slot.bp_insert_drain_finalize(next, vec![block_for(next)], 1);
+            // Front gap at seq 0 ⇒ nothing drains.
+            assert!(
+                slot.decompressed.lock().unwrap().is_empty(),
+                "no block may reach the FIFO while the seq-0 gap is open",
+            );
+            assert!(
+                slot.bp_reorder_heap_bytes() <= BUDGET,
+                "reorder window must stay within budget, got {} > {BUDGET}",
+                slot.bp_reorder_heap_bytes(),
+            );
+            next += 1;
+            admitted += 1;
+            assert!(admitted < 1000, "admission must eventually backpressure, not loop forever");
+        }
+        assert!(admitted > 0, "should admit at least some ahead-of-gap blocks");
+        assert!(
+            slot.bp_reorder_heap_bytes() >= BUDGET.saturating_sub(BLOCK as u64),
+            "should have filled the window before backpressuring",
+        );
+
+        // Now the part that makes the EOF check mean something. Until here
+        // `reader_eof` was never set, so asserting `!queue_eof` inside the loop
+        // was vacuous — the finalize predicate could not fire for want of
+        // `reader_eof`, whatever the straggler did. Set it, and the predicate
+        // becomes falsifiable: the only thing still holding EOF back is seq 0,
+        // which is in flight and absent from `reorder`.
+        slot.bp_set_reader_eof();
+        assert!(!slot.bp_drain_and_finalize(), "nothing can drain past the seq-0 gap");
+        assert!(
+            !slot.queue_eof.load(Ordering::Acquire),
+            "must not finalize EOF while the straggler at seq 0 is still in flight",
+        );
+
+        // Deliver the straggler; now the whole window drains in order and EOF
+        // finalizes, confirming the blocks held behind the gap were retained
+        // rather than dropped.
+        slot.bp_insert_drain_finalize(0, vec![block_for(0)], 1);
+        assert!(
+            slot.queue_eof.load(Ordering::Acquire),
+            "EOF must finalize once the straggler lands and the window drains",
+        );
+        let delivered: Vec<u8> =
+            slot.decompressed.lock().unwrap().drain(..).map(|block| block[0]).collect();
+        let expected: Vec<u8> = (0..=u8::try_from(admitted)
+            .expect("admitted is bounded by the window budget"))
+            .collect();
+        assert_eq!(
+            delivered, expected,
+            "the straggler and every admitted block must reach the FIFO exactly once, in read \
+             order — not merely in the right quantity",
+        );
+    }
+
+    /// The drain stops at [`PHASE2_DECOMP_CAP`], so a slot can sit at
+    /// reader-EOF with `in_flight == 0` and *still* owe blocks that did not fit
+    /// in the FIFO. Finalizing `queue_eof` there would strand them: the
+    /// consumer stops at `is_drained()`, and the blocks left in `reorder` are
+    /// never popped. Completion instead depends on the driver calling
+    /// [`SortMergeSlot::bp_drain_and_finalize`] again once the consumer has made
+    /// room — the one drain path whose correctness lives outside this module.
+    ///
+    /// Two boundaries: a FIFO exactly at cap (`room == 0`, the loop never runs)
+    /// and one block short of it (`room` hits zero *inside* the loop, after a
+    /// partial delivery). Both must defer the finalize.
+    #[rstest]
+    #[case::fifo_exactly_at_cap(PHASE2_DECOMP_CAP, 0, false)]
+    #[case::fifo_one_short_of_cap(PHASE2_DECOMP_CAP - 1, 1, true)]
+    fn bp_full_fifo_defers_finalize_until_the_consumer_makes_room(
+        #[case] prefill: usize,
+        #[case] drained_now: usize,
+        #[case] progressed_now: bool,
+    ) {
+        const DEFERRED: [u8; 2] = [0xAA, 0xBB];
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
+
+        // Occupy the FIFO so the incoming batch cannot fully land. The prefill
+        // bytes stay below 0xAA, so they never alias the delivered blocks.
+        // A constant byte, distinct from DEFERRED: the prefill is only there to
+        // occupy room, and keying it to `i` would make the test panic the day
+        // PHASE2_DECOMP_CAP is tuned above 256.
+        {
+            let mut dec = slot.decompressed.lock().unwrap();
+            for _ in 0..prefill {
+                dec.push_back(vec![0u8]);
+            }
+        }
+
+        // The final read: two blocks, reader at EOF, nothing else in flight.
+        // Every finalize precondition except `reorder.is_empty()` now holds.
+        slot.bp_commit_read(2, true);
+        let progressed =
+            slot.bp_insert_drain_finalize(0, DEFERRED.iter().map(|&b| vec![b]).collect(), 2);
+
+        assert_eq!(progressed, progressed_now, "progress is reported iff a block actually drained");
+        assert_eq!(slot.fifo_len(), prefill + drained_now, "the FIFO fills only to the cap");
+        assert!(
+            !slot.queue_eof.load(Ordering::Acquire),
+            "{} block(s) are still owed from `reorder`; finalizing EOF here strands them",
+            DEFERRED.len() - drained_now,
+        );
+        assert!(!slot.is_drained(), "a slot that still owes blocks is not drained");
+        assert_eq!(slot.bp_fifo_room(), 0, "the drain ran until the FIFO had no room left");
+
+        // The consumer pops; the driver's follow-up drain must deliver the
+        // remainder in read order and only then finalize.
+        {
+            let mut dec = slot.decompressed.lock().unwrap();
+            for _ in 0..DEFERRED.len() {
+                dec.pop_front();
+            }
+        }
+        assert!(slot.bp_drain_and_finalize(), "room freed ⇒ the deferred blocks drain");
+        assert!(
+            slot.queue_eof.load(Ordering::Acquire),
+            "EOF finalizes once `reorder` empties and nothing is in flight",
+        );
+
+        let delivered: Vec<Vec<u8>> = slot.decompressed.lock().unwrap().drain(..).collect();
+        assert_eq!(
+            delivered.len(),
+            prefill,
+            "prefill + {} delivered, less the {} the consumer popped: a dropped or duplicated \
+             block moves this count",
+            DEFERRED.len(),
+            DEFERRED.len(),
+        );
+        assert_eq!(
+            delivered[delivered.len() - DEFERRED.len()..],
+            DEFERRED.map(|b| vec![b]),
+            "the deferred blocks arrive behind the prefill, in read order",
+        );
+    }
+
+    /// The two caller-contract violations the assertions exist to catch: a
+    /// short batch (silent truncation) and an over-release (wraps `in_flight`
+    /// and wedges the slot). The assertions are always on, so these tests run
+    /// in release too — which is the configuration whose behaviour they pin.
+    #[test]
+    #[should_panic(expected = "while delivering")]
+    fn bp_short_batch_is_rejected() {
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
+        slot.bp_commit_read(2, true);
+        // Deliver 1 of the 2 reserved blocks: without the assertion this
+        // finalizes a clean queue_eof over the missing seq 1.
+        slot.bp_insert_drain_finalize(0, vec![vec![0xAAu8; 8]], 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "would wrap")]
+    fn bp_over_release_is_rejected() {
+        let slot = SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf);
+        slot.bp_commit_read(1, true);
+        // Release 2 with only 1 reserved: the fetch_sub would wrap in_flight
+        // to usize::MAX and the slot could never finalize.
+        slot.bp_insert_drain_finalize(0, vec![vec![1u8; 8], vec![2u8; 8]], 2);
+    }
+}

--- a/crates/fgumi-sort/tests/loom_merge_slots.rs
+++ b/crates/fgumi-sort/tests/loom_merge_slots.rs
@@ -1,0 +1,358 @@
+//! Loom model-check of the block-parallel Phase-2 decompress protocol
+//! (`file_granularity == false`), driving the **real** `SortMergeSlot`.
+//!
+//! # What this verifies (and what it does NOT)
+//!
+//! Under `--cfg loom`, `merge_slots.rs` swaps `std::sync` -> `loom::sync`, so
+//! the `SortMergeSlot` constructed here uses loom's atomics and mutexes. loom
+//! explores the thread interleavings and the memory reorderings the C11 model
+//! permits (preemption-bounded — see "Preemption-bounded exploration" below),
+//! running the REAL slot methods each time:
+//!
+//!   * [`SortMergeSlot::bp_commit_read`] — the publish order (reserve
+//!     `in_flight` before setting `reader_eof`) that the original silent-
+//!     truncation bug lived in. Production
+//!     (`SortSpillDecompress::try_fill_block_parallel_slot`) calls the SAME
+//!     method, so the model and the code cannot drift.
+//!   * [`SortMergeSlot::bp_insert_drain_finalize`] /
+//!     [`SortMergeSlot::bp_drain_and_finalize`] and the private
+//!     `drain_locked_and_finalize` (the finalize predicate `!queue_eof &&
+//!     reader_eof && in_flight == 0 && reorder.is_empty()`, the lock order
+//!     reorder -> decompressed, and the real `in_flight.fetch_sub(AcqRel)`).
+//!   * The slot's REAL `reader` mutex serializes reads, and its REAL `reorder`
+//!     buffer ([`fgumi_bam_io::reorder::ReorderBuffer`]) reassembles them.
+//!
+//! Only two things are *not* the production code, both sound and documented:
+//!
+//!   * **The "read" is simulated.** loom cannot model real file I/O, so a
+//!     worker computes `(start_seq, got, hit_eof)` from a test-held total under
+//!     the real `reader` lock instead of calling `read_raw`; "decompression"
+//!     yields the seq number as the payload. The slot's accounting/finalize
+//!     methods that run on the result are 100% production code.
+//!   * **Blocking `reader.lock()` instead of production's `try_lock()`.** The
+//!     property under test depends only on reads being *serialized* (so
+//!     `reader_eof` can never become visible while an unreserved block still
+//!     exists); a blocking lock preserves exactly that while collapsing the
+//!     `try_lock`-miss-retry fan-out that would otherwise explode loom's state
+//!     space (and a spin-retry is a loom anti-pattern). It is a sound
+//!     over-approximation of the serialization invariant.
+//!
+//! ## Modeling choices (documented for honesty)
+//!
+//!   * **Window/FIFO admission disabled.** `bp_reorder_admits` backpressure is a
+//!     *bounded-memory* property, separately covered by the `merge_slots` unit
+//!     test `bp_reorder_window_is_bounded_under_straggler`. Workers here always
+//!     admit, keeping the model focused on the EOF/truncation invariants.
+//!   * **Tiny sizes (2-4 blocks, 2-3 workers).** loom's state space is
+//!     super-exponential; these sizes still exercise every out-of-order
+//!     insert/finalize interleaving the per-slot protocol can hit (more blocks
+//!     add only more of the same kind, not a new kind).
+//!   * **One pass per producer.** `n_workers == reads_needed(N, batch)`, so
+//!     every block is read by exactly one producer and every producer
+//!     terminates. The *consumer* does spin: [`consume_until_drained`] breaks
+//!     only on `is_drained()`, which requires `queue_eof`. So a protocol that
+//!     never finalizes does NOT reach [`run_model`]'s assertions — the consumer
+//!     never returns from its poll loop, `consumer.join()` never completes, and
+//!     the `queue_eof` assertion below is unreachable. It surfaces instead as a
+//!     loom `max_branches` panic from the spinning consumer, which names the
+//!     harness rather than the protocol. Read that failure as "`queue_eof` was
+//!     never finalized", not as a model that needs a bigger branch budget.
+//!   * **A concurrent merge consumer** ([`consume_until_drained`]) polls the
+//!     FIFO and STOPS at `is_drained()`, mirroring `SortMerge`. This is what
+//!     makes a *premature* `queue_eof` observable as truncation (without it the
+//!     straggler is appended after the join and the bug hides — verified: the
+//!     `bp_commit_read` order swap is caught only with the consumer present).
+//!   * **Preemption-bounded exploration.** The consumer's poll loop adds a
+//!     scheduling point per iteration; combined with 2-3 producers the fully
+//!     exhaustive state space is minutes-long. Every model is therefore explored
+//!     under a preemption bound (`Some(k)`) — a recognized technique: essentially
+//!     all real concurrency bugs (including the truncation race this guards)
+//!     manifest with ≤2-3 preemptions. The bound is verified to still catch the
+//!     `bp_commit_read` order swap.
+//!
+//! Run with:
+//! ```text
+//! RUSTFLAGS="--cfg loom" cargo test -p fgumi-sort --test loom_merge_slots --release
+//! ```
+//!
+//! # Complementary coverage and its residual
+//!
+//! This model is one leg of the block-parallel hardening; the others are the
+//! `merge_slots` unit tests (bounded-memory window), the
+//! `fgumi-pipeline-io` granularity/proptest/soak-matrix tests (the real
+//! end-to-end pipeline over real spill files), and a `ThreadSanitizer` pass.
+//!
+//! **Sanitizer residual (recorded for honesty):** the `ThreadSanitizer` run
+//! exercised the real pipeline on **arm64 only**, and the C decompression codecs
+//! (`zstd` via the `zstd` crate, `libdeflate` via `libdeflater`) are
+//! **uninstrumented** — the sanitizer only sees the Rust side, so a data race
+//! *inside* a C codec would be missed. This is acceptable because the codecs are
+//! pure per-block transforms with no shared mutable state across threads (each
+//! worker decompresses its own block into its own buffer); the cross-thread
+//! protocol the sanitizer and loom actually need to clear is the Rust-side slot
+//! accounting, which is fully instrumented here.
+
+#![cfg(loom)]
+#![deny(unsafe_code)]
+// Block counts/seqs in this model are tiny (≤ a handful) and always fit a
+// usize; the casts below are between u64 model seqs and usize counts.
+#![allow(clippy::cast_possible_truncation)]
+
+use std::fs::File;
+use std::io::BufReader;
+
+use fgumi_sort::{SortMergeSlot, SpillCodec};
+use loom::sync::Arc;
+use loom::sync::atomic::Ordering;
+
+/// A throwaway reader for the slot. The block-parallel slot methods never touch
+/// `reader.inner`; the model serializes reads on the `reader` mutex and computes
+/// the read result arithmetically, so an empty file is all the struct needs.
+fn empty_reader() -> BufReader<File> {
+    BufReader::new(tempfile::tempfile().expect("create tempfile"))
+}
+
+/// One worker's body: mirrors a single `try_run` of
+/// `SortSpillDecompress::try_fill_block_parallel_slot`, but with the file read
+/// simulated (see module docs). Reads up to `block_batch` blocks under the REAL
+/// `reader` lock, publishes the accounting via the REAL
+/// [`SortMergeSlot::bp_commit_read`], "decompresses" outside the lock, then
+/// inserts/drains/finalizes via the REAL [`SortMergeSlot::bp_insert_drain_finalize`].
+/// A worker that finds the reader already at EOF falls through to the REAL
+/// Phase-B drain-only [`SortMergeSlot::bp_drain_and_finalize`].
+fn worker_one_pass(slot: &SortMergeSlot, block_batch: u64, total_blocks: u64) {
+    if slot.queue_eof.load(Ordering::Acquire) {
+        return;
+    }
+    let mut did_phase_a = false;
+    if !slot.reader_eof.load(Ordering::Acquire) {
+        // Blocking lock (sound over-approximation of production's `try_lock`;
+        // see module docs) — serializes reads on the REAL reader mutex.
+        let mut reader = slot.reader.lock().unwrap();
+        // Re-check under the lock: another worker may have hit EOF.
+        if !slot.reader_eof.load(Ordering::Acquire) {
+            let start_seq = reader.next_seq;
+            let remaining = total_blocks - start_seq;
+            let got = block_batch.min(remaining);
+            let hit_eof = got < block_batch;
+            // Stamp the read range and commit the accounting BEFORE releasing
+            // the lock, via the real publish-order method.
+            reader.next_seq += got;
+            slot.bp_commit_read(got as usize, hit_eof);
+            drop(reader);
+
+            // "Decompress" outside the reader lock: the payload is the seq as
+            // 8 little-endian bytes, so the drained FIFO can be checked for
+            // in-order, no-loss delivery.
+            let blocks: Vec<Vec<u8>> =
+                (start_seq..start_seq + got).map(|s| s.to_le_bytes().to_vec()).collect();
+            slot.bp_insert_drain_finalize(start_seq, blocks, got as usize);
+            did_phase_a = true;
+        }
+    }
+    if !did_phase_a {
+        slot.bp_drain_and_finalize();
+    }
+}
+
+/// Number of reader-lock acquisitions (= worker passes) needed to read every
+/// block and then observe the clean EOF: `ceil((N + 1) / batch)`. The `+ 1`
+/// accounts for the read that returns fewer than `batch` blocks (possibly
+/// empty), which is what sets `reader_eof`.
+fn reads_needed(total_blocks: u64, block_batch: u64) -> usize {
+    ((total_blocks + 1).div_ceil(block_batch)) as usize
+}
+
+/// Decode an 8-byte little-endian seq payload back to its sequence number.
+fn seq_of(block: &[u8]) -> u64 {
+    let mut buf = [0u8; 8];
+    buf.copy_from_slice(&block[..8]);
+    u64::from_le_bytes(buf)
+}
+
+/// The merge consumer, mirroring `SortMerge`/`slot_try_load_block`: pop every
+/// available block, then STOP the instant the slot looks cleanly drained
+/// (`is_drained()` == `queue_eof && FIFO empty && !error`). Returns the seqs it
+/// collected, in pop (delivery) order.
+///
+/// This stop condition is what makes a *premature* `queue_eof` observable: if
+/// the slot finalizes EOF while a block is still outstanding (the truncation the
+/// publish-order protocol prevents), the consumer sees an empty FIFO + EOF and
+/// quits early, so `run_model`'s completeness check fails. Without a consumer
+/// the straggler would still be appended after the join and the bug would hide.
+///
+/// `yield_now` between polls is the loom scheduling point. Every producer runs
+/// exactly one pass, so against a protocol that finalizes `queue_eof` this wait
+/// terminates. Against one that does not, it spins forever — see the module
+/// header's "One pass per producer" note for why that surfaces as a loom
+/// `max_branches` panic rather than as the assertions in [`run_model`].
+fn consume_until_drained(slot: &SortMergeSlot) -> Vec<u64> {
+    let mut collected = Vec::new();
+    loop {
+        loop {
+            let popped = slot.decompressed.lock().unwrap().pop_front();
+            match popped {
+                Some(b) => collected.push(seq_of(&b)),
+                None => break,
+            }
+        }
+        if slot.is_drained() {
+            break;
+        }
+        loom::thread::yield_now();
+    }
+    collected
+}
+
+/// Drive one worker pass per required read over `total_blocks` blocks with
+/// `block_batch` blocks per read PLUS a concurrent merge consumer, under loom,
+/// and assert the no-loss / in-order / clean-EOF invariants for every
+/// interleaving against the REAL slot state.
+fn run_model(total_blocks: u64, block_batch: u64) {
+    let slot = Arc::new(SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf));
+    let n_workers = reads_needed(total_blocks, block_batch);
+
+    let mut handles: Vec<_> = (0..n_workers)
+        .map(|_| {
+            let slot = Arc::clone(&slot);
+            loom::thread::spawn(move || worker_one_pass(&slot, block_batch, total_blocks))
+        })
+        .collect();
+    let consumer = {
+        let slot = Arc::clone(&slot);
+        loom::thread::spawn(move || consume_until_drained(&slot))
+    };
+    for h in handles.drain(..) {
+        h.join().unwrap();
+    }
+    let delivered = consumer.join().unwrap();
+
+    // Post-conditions: clean EOF reached, no error, nothing left in flight or
+    // buffered, and the consumer collected every block exactly once, in read
+    // order, BEFORE it observed the clean EOF (a premature `queue_eof` truncates
+    // `delivered`).
+    assert!(slot.queue_eof.load(Ordering::Acquire), "slot never reached queue_eof");
+    assert!(!slot.has_error(), "spurious decomp_error");
+    assert_eq!(slot.in_flight.load(Ordering::Acquire), 0, "blocks left in flight at EOF");
+    assert!(slot.reorder.lock().unwrap().is_empty(), "reorder buffer not drained at EOF");
+    assert!(slot.decompressed.lock().unwrap().is_empty(), "FIFO not fully consumed at EOF");
+
+    let expected: Vec<u64> = (0..total_blocks).collect();
+    assert_eq!(
+        delivered, expected,
+        "blocks lost, duplicated, reordered, or truncated by early EOF"
+    );
+}
+
+/// Run `f` under loom with at most `preemption_bound` preemptions. See the
+/// module-level "Preemption-bounded exploration" note for why every model is
+/// bounded rather than exhaustive.
+fn check_model<F: Fn() + Sync + Send + 'static>(preemption_bound: usize, f: F) {
+    let mut builder = loom::model::Builder::new();
+    builder.preemption_bound = Some(preemption_bound);
+    builder.check(f);
+}
+
+/// Three blocks, batch 2 ⇒ 2 producer passes: the second read is SHORT (carries
+/// seq 2 AND sets `reader_eof`) while the first read's blocks (seq 0,1) may
+/// still be in flight — the exact `bp_eof_with_straggler` shape.
+#[test]
+fn loom_three_blocks_batch2() {
+    check_model(3, || run_model(3, 2));
+}
+
+/// Two blocks, batch 2 ⇒ 2 producer passes: the second read is the EMPTY
+/// EOF-detecting read (got == 0) that sets `reader_eof` while the first read's
+/// blocks (seq 0,1) may still be in flight. Exercises the `count == 0` finalize
+/// path of `bp_insert_drain_finalize`.
+#[test]
+fn loom_two_blocks_batch2_empty_eof_read() {
+    check_model(3, || run_model(2, 2));
+}
+
+/// Four blocks, batch 3 ⇒ 2 producer passes (read seq 0,1,2; short read seq 3
+/// sets EOF). A larger in-flight batch straggling behind the EOF read.
+#[test]
+fn loom_four_blocks_batch3() {
+    check_model(3, || run_model(4, 3));
+}
+
+/// Two blocks, batch 1 ⇒ 3 producer passes (read seq 0, read seq 1, empty EOF
+/// read) plus the consumer — four concurrent threads. Covers the three-way race
+/// between two in-flight blocks and the EOF-setter. Bounded tighter (the
+/// four-thread × nested-mutex state space is the largest here).
+#[test]
+fn loom_two_blocks_batch1_three_workers_bounded() {
+    check_model(2, || run_model(2, 1));
+}
+
+// ── decomp-error-beats-clean-EOF (#399) ──────────────────────────────────────
+
+/// The consumer that observes `queue_eof` under the `decompressed` mutex
+/// (`is_drained`) must also observe `decomp_error` whenever the producer took
+/// the error path — i.e. a failed slot can never be mistaken for a clean EOF.
+///
+/// This drives the REAL slot: the producer mirrors
+/// `SortSpillDecompress::mark_slot_failed` (store `decomp_error` then
+/// `queue_eof`, both under the `decompressed` mutex), and the consumer is the
+/// real [`SortMergeSlot::is_drained`] / [`SortMergeSlot::has_error`] pair. The
+/// mutex release-acquire makes the two flags jointly visible regardless of which
+/// the consumer reads first.
+#[test]
+fn loom_decomp_error_beats_clean_eof() {
+    loom::model(|| {
+        let slot = Arc::new(SortMergeSlot::new(0, empty_reader(), SpillCodec::Bgzf));
+
+        // Producer: error path. Mirrors `mark_slot_failed` — set decomp_error
+        // THEN queue_eof, both under the `decompressed` mutex.
+        let producer = {
+            let slot = Arc::clone(&slot);
+            loom::thread::spawn(move || {
+                let _g = slot.decompressed.lock().unwrap();
+                slot.decomp_error.store(true, Ordering::Release);
+                slot.queue_eof.store(true, Ordering::Release);
+            })
+        };
+
+        // Consumer: the real `is_drained()` / `has_error()`.
+        //
+        // The assertion is `!drained`, flatly, not `!(drained && !errored)`.
+        // The producer's only path is the error path, so there is no
+        // interleaving in which a clean drain is legal: before the producer
+        // runs, `queue_eof` is unset and `is_drained()` is false; after it,
+        // `decomp_error` is set and `is_drained()` must still be false.
+        //
+        // The composite form is what the old assertion used, and it could not
+        // fail: with the `decomp_error` guard present `drained` is always
+        // false, and with it deleted `errored` is true, so `drained && !errored`
+        // is unsatisfiable either way — the test stayed green against the exact
+        // bug it names. Asserting `!drained` alone restores the discrimination;
+        // deleting the guard from `is_drained` now fails this model.
+        //
+        // `has_error()` is still called, before `is_drained()` in one variant
+        // and after in the other, so the documented order-independence of the
+        // two reads is what the model actually exercises.
+        let consumer = {
+            let slot = Arc::clone(&slot);
+            loom::thread::spawn(move || {
+                let errored = slot.has_error();
+                let drained = slot.is_drained();
+                assert!(!drained, "errored slot reported a clean drain");
+                assert!(!drained || errored, "clean EOF hid a decomp error");
+            })
+        };
+
+        let consumer_reversed = {
+            let slot = Arc::clone(&slot);
+            loom::thread::spawn(move || {
+                let drained = slot.is_drained();
+                let _errored = slot.has_error();
+                assert!(!drained, "errored slot reported a clean drain (reversed read order)");
+            })
+        };
+
+        producer.join().unwrap();
+        consumer.join().unwrap();
+        consumer_reversed.join().unwrap();
+    });
+}

--- a/docs/design/sort-phase2-unification-deferral.md
+++ b/docs/design/sort-phase2-unification-deferral.md
@@ -1,0 +1,93 @@
+# Sort Phase-2 merge: two drivers, unification deferred
+
+## Status: DEFERRED (not a feat-runall blocker)
+
+fgumi's external sort has **two** Phase-2 (merge) drivers, and they exist by
+design:
+
+- **Pool / standalone** (`crates/fgumi-sort/src/worker_pool.rs`,
+  `external.rs::merge_chunks_generic`) — drives standalone file-to-file
+  `fgumi sort`. Work-stealing pool reads + decompresses spill blocks in
+  parallel; the merge consumer is a **parked OS thread**
+  (`advance_to_next_block`). Keeps `--write-index`, `--verify`, zstd spill.
+- **Streaming / runall** (`crates/fgumi-sort/src/merge_slots.rs`,
+  `external.rs::MergeDriver`) — drives the fused in-pipeline `runall` sort. A
+  cooperative `try_run` state machine that yields (`Stalled`/`WouldBlock`)
+  instead of blocking, so it composes with the typed-step pipeline framework.
+
+> **Which of these exists in this tree.** Only the pool driver runs here. The
+> streaming driver is arriving in phases: `merge_slots.rs::SortMergeSlot` is its
+> first piece and has **no callers**, and `external.rs::MergeDriver` does not
+> exist on this branch at all. So read the streaming bullet — and every claim
+> below about the cooperative consumer, including the deadlock analysis — as
+> describing the end state this landing builds toward, not code you can run
+> today. In particular, none of it is a statement about `SortMergeSlot`, which
+> is a passive handoff slot and not a driver.
+
+Unifying these onto a single driver is a deliberate **future** refactor with its
+own design + bench gate + deadlock re-analysis. It is intentionally NOT done in
+the feat-runall line.
+
+## What is already shared (so the duplication is smaller than it looks)
+
+- `LoserTree<K>` (`loser_tree.rs`) — the actual k-way merge / tie-break
+  primitive. Both drivers use the one implementation.
+- `RawSortKey` comparators and the `keys.rs` key types.
+- `ReorderBuffer` (`fgumi-bam-io`) — also used by Phase-1 read-ahead, so it is a
+  shared utility, not pool-specific duplication.
+
+What genuinely differs is the **driver** (the outer drive loop and the
+read/decompress topology), not the merge core.
+
+## Why the streaming path dropped the pool's machinery
+
+The pre-v4 streaming slot also carried a `raw_blocks` FIFO, a `decomp_in_flight`
+counter, a reorder buffer, and a cap+gap-filler admission rule. That design
+**deadlocked at production scale**: the framework's drain protocol could Skip
+workers during a transient "all slots at cap simultaneously" window. v4 collapsed
+read-and-decompress into one inline op per worker per slot, which made a plain
+bounded FIFO correct (blocks decompress strictly in read order) and removed the
+deadlock surface.
+
+The pool path keeps all of that machinery and does not hit **that specific
+deadlock** — the v4 cooperative-drain Skip described above — because (a) its
+consumer is a parked OS thread the engine cannot Skip, and (b) it is
+single-*reader* but **multi-*decompressor*** — workers decompress in parallel,
+so completion order ≠ pop order, and the reorder buffer + in-flight counter are
+a *correctness* dependency (they re-order out-of-order completions and close the
+`is_drained` truncation race), not redundancy.
+
+That is a claim about one analyzed failure mode, not a proof of general deadlock
+freedom: avoiding the cooperative `Skip` path is a property of the parked-thread
+consumer, and no one has shown the pool path deadlock-free in general.
+
+## Prerequisites before unification is even attemptable
+
+1. The streaming path gains a true file-to-file drive (BAM source +
+   bgzf-decompress + parse → SortAndSpill → SortSpillDecompress → SortMerge →
+   serialize → WriteBgzfFile).
+2. `--write-index` (`.bai`) wired onto/alongside that chain (the pool path has
+   it via `IndexBamFinalizeHook`, PR #393; the streaming step does not).
+3. `--verify` ported (today a separate read-and-check path, designed to stay
+   legacy).
+4. A consumer for the file-to-file case that is not exposed to the v4 drain
+   deadlock — the streaming consumer is the cooperative `try_run` model that hit
+   it in production. "Not exposed to *this* deadlock" is the bar; general
+   deadlock freedom is not something either driver has been shown to have.
+
+## Explicit risk
+
+Routing standalone sort through the streaming path **re-opens the v4
+cooperative-consumer deadlock** that standalone sort is not currently exposed to
+(parked OS thread). Until all four prerequisites land, it is a net capability
+LOSS + added risk and buys no shipped feature.
+
+## Safe-to-pursue-independently sub-step (does NOT require the above)
+
+Factor the shared **per-winner merge-emit core**: both drivers already share
+`LoserTree`, so extract a `MergeSource<K>` trait (`try_next_record`) + a single
+`merge_emit(tree, sources, emit_fn)` core that the pool's blocking loop and the
+streaming state machine both call one-winner-at-a-time. Keep the
+blocking-vs-cooperative **outer** drive separate — that is the deadlock-relevant
+axis and must NOT be merged. MED risk (hot-loop perf; needs a sort bench
+matrix), but carries no deadlock surface.


### PR DESCRIPTION
First slice of P3 (the arena sort engine) in the `feat-runall` landing series, on top of #714.

### Why this is one module and not nine

P3 is the phase the tracker calls the gate: **+8,567/−5,029 across 31 files**, rewriting `external.rs` (4,307 lines changed) and `worker_pool.rs` (1,160), adding nine modules, and taking the crate's `unsafe` allow-surface from 6 sites to 21. It does not decompose the way P1 and P2 did. I checked each new module against the current tree rather than assuming:

| Module | Blocked on |
|---|---|
| `merge_slots` | **nothing** — needs only `codec` |
| `spill_block`, `sync_spill_writer` | `InMemoryChunk`, from the `inline.rs` rewrite |
| `spill_block_reader` | the `worker_pool.rs` rewrite |
| `template_arena`, `chunk_sorter` | the `external.rs` rewrite |
| `arena_pool` | `SegmentedBuf::reset_for_reuse`, which needs the new `cur` write-cursor and its `cur == total_len / segment_size` invariant — not an additive method |
| `ref_sort` | `InMemoryChunk` plus a new `voracious_radix_sort` dependency |
| `block_offsets` | compiles, but its unit tests need `SegmentedBuf::grow_uninit` / `slice_mut` from the same rewrite |

So eight of the nine have to arrive with the engine. This one doesn't, which makes it the only piece reviewable on its own instead of inside an 8,500-line diff — and it is the piece where that matters most, being lock-free concurrent code whose bugs are interleavings rather than lines.

### What it is

`SortMergeSlot` is the bounded handoff between the phase-2 merge reader and its decompression workers. The reader pushes compressed spill blocks; workers claim and decompress them; the slot carries the EOF and error signalling that tells a drained consumer whether the stream finished or failed.

It lands with no callers, like `decompress_into_slice` in #714 — its consumer is the `worker_pool.rs` rewrite in the main P3 PR.

### It arrives with its model check

`tests/loom_merge_slots.rs` drives the real `SortMergeSlot` under [loom](https://docs.rs/loom), which enumerates thread interleavings systematically rather than leaving them to timing luck (four of the five models under a preemption bound, documented in the test). Five scenarios, including a decompression error racing a clean EOF, and multi-block batches against bounded worker pools — orderings a normal test run would have to be lucky to hit.

```
RUSTFLAGS="--cfg loom" cargo test -p fgumi-sort --test loom_merge_slots --release
running 5 tests
test result: ok. 5 passed; 0 failed; ... finished in 49.69s
```

`loom` is a `cfg(loom)`-only dependency, so the normal build never sees it and the test target is empty without the flag. This is not run in CI — it takes ~50s and needs the flag — so it is a local/manual gate for changes to this file.

### Two fixes relative to the source branch

- **Dead intra-doc links.** `bp_add_in_flight` and `bp_commit_read` link `[`Self::drain_locked_and_finalize`]`, which is private, so the links render dead once `SortMergeSlot` is re-exported. `cargo doc` emits these on `feat-runall` today; they are downgraded to code spans here rather than ported forward.
- **The loom test needed the root re-export.** `pub(crate) mod merge_slots` alone left `fgumi_sort::SortMergeSlot` unresolved and the test failed to compile — five errors, four of them cascading. It passes on `feat-runall` because `lib.rs:197` re-exports the type; that re-export comes along here.

### Changes made to the ported module

Three review passes ran over this (a CodeRabbit-style review, a multi-agent gauntlet, and a port-fidelity audit against `feat-runall`). The port itself came back clean — `loom_merge_slots.rs` is byte-identical to the source branch, and `merge_slots.rs` differed only by two deliberate doc-link downgrades. What the reviews found was in the *ported code*, inherited from `feat-runall`. Everything below tightens or documents; none of it alters behaviour, so later phases that port callers of this module are unaffected.

**Two caller-contract violations that fail silently.** `bp_insert_drain_finalize` documented that `blocks.len()` need not equal `count`. It must. Delivering fewer blocks than reserved releases the reservation for sequences never inserted, so `in_flight` reaches zero, `reorder` reports empty with those sequences simply absent, and the slot finalizes a **clean** `queue_eof` — `is_drained()` true, `has_error()` false. A truncated spill file becomes indistinguishable from a complete one. Releasing *more* than reserved wraps `in_flight` to `usize::MAX`, after which the finalize predicate's `in_flight == 0` can never hold and the merge polls `WouldBlock` forever instead of failing. Both are now documented as contract violations and caught by assertions that are **always on, release included** — the failure has no in-band signal and release is what ships. Two compares per batch, not per record, both before any lock is taken so a violation cannot poison a mutex. The `#[should_panic]` tests run in release too, where they previously did not exist: `cargo test --release --lib merge_slots` reported 13 tests before and reports 15 now.

**The loom model could not fail for the bug it names.** `loom_decomp_error_beats_clean_eof` asserted `!(drained && !errored)`. With the `decomp_error` guard present `drained` is always false; with it deleted `errored` is also true — the predicate is unsatisfiable either way, and deleting the guard from `is_drained` left the test green. It now asserts `!drained` flatly: the producer's only path is the error path, so no interleaving may report a clean drain. Verified by mutation — deleting the guard now fails the model. A reversed-read-order consumer was added so the documented order-independence of the two reads is actually exercised.

**The module header described a system that isn't here.** It asserted this module is the live production Phase-2 and that `worker_pool::Phase2FileState` no longer drives a sort — the exact inverse of this tree, where this module has no callers and `Phase2FileState` is reached through `RawExternalSorter::sort`. It also stated the reorder buffer and in-flight counter were *eliminated*, while the same file declares both for the block-parallel path. Rewritten to describe the tree it ships in.

**Smaller items:** `bp_add_in_flight`/`bp_set_reader_eof` demoted to `pub(crate)` (their docs call the call order safety-critical and `bp_commit_read` exists to encapsulate it; nothing outside the module calls them on any branch); `is_drained`'s doc claimed both flags are read under the mutex when `queue_eof` is read on the unlocked fast path, so the reasoning is now stated rather than misstated; `decomp_error_flag_set_and_read` tested `AtomicBool` rather than the slot; a vacuous `!queue_eof` assertion is now a real check of the finalize predicate under a straggler; `SortMergeReader` re-exported.

`PHASE2_DECOMP_CAP` is 32 here and 8 in `worker_pool.rs`, and the crate root exports this one while the other bounds the live merge. I nearly dropped it from the re-export — `fgumi-pipeline-io/src/sort/spill_decompress.rs` imports it at P4, so that would have broken the next phase. Kept, with a doc note on which is in force.

### The loom test is now run by CI

The fidelity audit found that **no workflow on any branch** invokes `RUSTFLAGS="--cfg loom"`. Combined with `#![cfg(loom)]`, that means a broken model compiles to an empty target under normal CI and reports success — the guard could rot with no signal. `check.yml` now has a `loom` job.

Per-PR rather than scheduled, unlike `miri.yml` and `stress.yml`: those are scheduled because they are non-deterministic in ways unrelated to a given change (nightly-toolchain drift; timing sensitivity). Loom explores a bounded state space deterministically — same input, same verdict — so it can gate a PR, and a gate is what stops it rotting. This is a deliberate improvement over the source branch, not a port.

### Verification

`cargo ci-fmt`, `ci-lint`, `ci-doc` clean (0 warnings); **7569 tests pass**, 27 skipped; 5/5 loom model checks pass. `Cargo.lock` regenerated (WS-LOCK).

Mutation-verified rather than assumed: deleting the `decomp_error` guard from `is_drained` fails `loom_decomp_error_beats_clean_eof`; the short-batch and over-release contract violations each fail their `#[should_panic]` test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable, bounded Phase 2 sorting with ordered decompression and merge processing.
  * Added progress, buffering, and error-state diagnostics for sorting operations.

* **Documentation**
  * Added design documentation covering Phase 2 sorting architecture and future unification considerations.

* **Tests**
  * Added concurrency validation for ordering, end-of-file handling, buffering limits, and decompression errors.
  * Added automated CI checks to validate these scenarios across concurrent execution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Review round 2

CodeRabbit posted four findings; all four are addressed, plus a self-review pass on the resulting diff.

- **The FIFO-full drain had no test.** `drain_locked_and_finalize` stops once the FIFO reaches `PHASE2_DECOMP_CAP`, so a slot can be at reader-EOF with `in_flight == 0` and still owe blocks that did not fit — finalizing there would strand them. The cap is 32 and every test and model used at most five blocks, so nothing reached it. Now covered at both boundaries, and deleting the `reorder`-empty guard fails both cases while no other test notices.
- **"Exhaustive" was wrong.** Four of the five models run under a preemption bound; the workflow comment contradicted the test's own note. Corrected here, in the commit message, and above.
- **The design doc described a tree this is not.** It names a streaming driver whose `external.rs::MergeDriver` half does not exist on this branch at all, so its deadlock analysis could be read as applying to the uncalled `SortMergeSlot`. Scoped with a note rather than by naming `MergeDriver` as the live driver, which would have been equally untrue. Its "immune to deadlock" claim is now scoped to the one analyzed failure mode.
- **Two order assertions were counts.** `fifo_order` pushed into and popped from `decompressed` by hand — asserting that `VecDeque` is a queue, not anything about the slot — and the straggler test closed on a block count while every block was identical bytes. A drain that dropped one block and duplicated another, or ran backwards, passed both. Blocks now carry their sequence number and the assertions are on identity and order: reversing the drain fails both now and failed neither before.

### Review round 3

- **The contract guards were debug-only.** Promoted to always-on `assert`, since the conditions they catch are silent record loss and a wedged merge, and release is the configuration that ships. Both run before any lock is taken, so a violation cannot poison a mutex, and no correct caller can trip them. The second guard now loads `in_flight` once, so the value reported on failure is the one that actually failed the check.
- **The loom header's stated failure mode was impossible.** It claimed a protocol that never finalizes `queue_eof` "surfaces as the `queue_eof` assertion below, not as a hang" — but `consume_until_drained` breaks only on `is_drained()`, and `run_model` joins the consumer before its assertions, so that path spins the consumer and never reaches them. The real symptom is a loom `max_branches` panic naming the harness. Corrected, along with the same claim on `consume_until_drained` itself.