### PR TITLE
feat(sort): unified arena sort engine for all four sort orders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,30 @@ of records) and a safe rewrite measurably regresses sort throughput.
   `RawQuerynameKey::new`).
 - **`crates/fgumi-sort/src/radix.rs`** — internal radix-sort helpers; see file
   comments for the `SAFETY:` invariants.
+- **`crates/fgumi-sort/src/ref_sort.rs`** — one `#[allow(unsafe_code)]` site in
+  `sort_coordinate_refs`: a pointer cast reinterpreting `&mut [RecordRef]` as
+  `&mut [CoordSortRef]` to feed the parallel `voracious_mt_sort` radix on the
+  large-input / multi-thread coordinate path. SAFETY: `CoordSortRef` is
+  `#[repr(transparent)]` over `RecordRef`, so the two have identical size,
+  alignment, and layout; the pointer cast (clippy rejects a ref-to-ref
+  `transmute`) is sound. This is approved for the same reason as the other sort
+  hot paths — it runs once per coordinate sort over millions of record refs, and
+  the parallel radix is measurably (~4×) faster than the safe single-threaded
+  fallback. Two tests cover this, and they establish *different* things — do not
+  read either as proving both:
+  - `prop_ref_sort_matches_copy_sorter` runs `sort_threads = 1`, so it proves
+    **byte parity** of the *serial* path against the copy sorter. It never
+    reaches the cast.
+  - `parallel_coordinate_sort_matches_serial_radix_at_threshold` is the one that
+    exercises the cast — 4 threads at the parallel cutoff over deliberately tied
+    keys — but it asserts **ref order**, comparing `(sort_key, offset)` against
+    the serial radix. It does not compare serialized bytes.
+
+  Byte-identity of the parallel path therefore follows by construction rather
+  than by direct assertion: the chunk is materialized from the refs in order, so
+  identical ref order yields identical output bytes. That is a sound inference,
+  but it is an inference, and a change that broke the materialization step would
+  not be caught by either test.
 - **`crates/fgumi-sort/src/segmented_buf.rs`** — two `#[allow(unsafe_code)]`
   sites backing the arena record buffer (a segmented, append-only `Vec<u8>` the
   sort engine decompresses/frames records into without per-record allocation):
@@ -335,16 +359,21 @@ storing a reference whose real lifetime the struct cannot name.
 
 The counts above are **production** sites. Tests carry their own
 `#[allow(unsafe_code)]` where they exercise an already-approved `unsafe` API
-directly — in `fgumi-sort` that is `segmented_buf.rs`, driving
-`SegmentedBuf::grow_uninit` / `slice_mut` to check reserve-then-write
-round-trips; in `fgumi-raw-bam` it is the `compare_nul` helper and the
-`proptest` agreement test in `src/sort.rs`, both already named above. They add
-no new `unsafe` *surface*: each calls a function already
-justified above, under that function's documented contract. A raw
-`grep -c 'allow(unsafe_code)'` therefore reports more sites than this document
-names, and the difference is entirely tests — when auditing, count sites outside
-`#[cfg(test)]`, and check each entry's own wording for whether it is quoting a
-production-only count.
+directly. In `fgumi-sort` those are `segmented_buf.rs` (8), `ref_sort.rs` (3),
+and `chunk_sorter.rs` (2), all of them driving `SegmentedBuf::grow_uninit` /
+`slice_mut` to check a reserve-then-write round-trip, or that a sorted chunk
+matches its oracle. In `fgumi-raw-bam` they are the `compare_nul` helper and the
+`proptest` agreement test in `src/sort.rs`, both already named above. They add no
+new `unsafe` *surface*: each calls a function already justified above, under that
+function's documented contract.
+
+A raw `grep -c 'allow(unsafe_code)'` over either crate therefore reports more
+sites than this document names, and the difference is tests plus prose. When
+auditing, count **attributes**, not matches: exclude the production sites listed
+above, and exclude occurrences inside `///` / `//!` comments that merely *name*
+the attribute (`segmented_buf.rs` has one such mention, which is why a naive
+`grep -c` there over-counts the test sites by one). Then check each entry's own
+wording for whether it is quoting a production-only count.
 
 Entries name the function rather than a line number on purpose: approximate
 line numbers go stale the moment anything above them moves, and a confidently

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,7 +946,9 @@ dependencies = [
  "proptest",
  "rayon",
  "rstest",
+ "smallvec",
  "tempfile",
+ "voracious_radix_sort",
  "zstd",
 ]
 
@@ -2786,6 +2788,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "voracious_radix_sort"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446e7ffcb6c27a71d05af7e51ef2ee5b71c48424b122a832f2439651e1914899"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "wait-timeout"

--- a/crates/fgumi-sort/Cargo.toml
+++ b/crates/fgumi-sort/Cargo.toml
@@ -41,7 +41,12 @@ bytes = { workspace = true }
 bytesize = { workspace = true }
 fs4 = { workspace = true }
 log = { workspace = true }
+# `smallvec` is crate-local, not workspace-inherited: `keys.rs` is its only user
+# in the workspace, and the root manifest reserves `[workspace.dependencies]` for
+# crates shared by two or more members.
+smallvec = { version = "1.15", features = ["const_generics"] }
 zstd = "0.13"
+voracious_radix_sort = { version = "1", features = ["voracious_multithread"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -55,6 +60,7 @@ nix = { workspace = true }
 [features]
 default = []
 memory-debug = []
+test-utils = []
 
 [dev-dependencies]
 fgumi-bam-io = { workspace = true }
@@ -73,3 +79,11 @@ tempfile = { workspace = true }
 # Run with:  RUSTFLAGS="--cfg loom" cargo test -p fgumi-sort --test loom_merge_slots --release
 [target.'cfg(loom)'.dependencies]
 loom = "0.7"
+
+[[bench]]
+name = "chunk_sorter"
+harness = false
+
+[[bench]]
+name = "queryname_keys"
+harness = false

--- a/crates/fgumi-sort/benches/chunk_sorter.rs
+++ b/crates/fgumi-sort/benches/chunk_sorter.rs
@@ -1,0 +1,76 @@
+//! Microbenchmark for the P6 `SortBuffer` chunk sorters' sort + materialize
+//! step (`take_sorted_chunk`).
+//!
+//! This isolates the cost the A/B smoke campaign flagged: `take_sorted_chunk`
+//! materialized a full owned `Vec<(K, RawRecord)>` (one heap copy + malloc per
+//! record) while the source `RecordBuffer` arena was still alive — doubling
+//! peak memory and paying a full per-record copy. The fix routes coordinate /
+//! template through the zero-copy `InMemoryChunk` (arena-move). Run before and
+//! after to confirm the materialize step gets cheaper:
+//!
+//!     cargo bench -p fgumi-sort --bench chunk_sorter
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use fgumi_raw_bam::testutil::make_bam_bytes;
+use fgumi_sort::{RawExternalSorter, SortOrder};
+use noodles::sam::Header;
+
+/// Build `n` aligned records at scattered positions on tid 0 so the sort does
+/// real reordering work; ~100 bp reads ≈ a realistic per-record size.
+fn synth_records(n: usize) -> Vec<Vec<u8>> {
+    (0..n)
+        .map(|i| {
+            let pos = (i as u64).wrapping_mul(2_654_435_761) % 5_000_000;
+            let name = format!("r{i:08}");
+            make_bam_bytes(0, pos as i32, 0, name.as_bytes(), &[], 100, -1, -1, &[])
+        })
+        .collect()
+}
+
+fn bench_materialize(c: &mut Criterion) {
+    const N: usize = 500_000;
+    let records = synth_records(N);
+
+    let mut group = c.benchmark_group("chunk_sorter_materialize");
+    group.throughput(Throughput::Elements(N as u64));
+    group.sample_size(10);
+
+    group.bench_function("coordinate_500k", |b| {
+        b.iter_batched(
+            || {
+                let mut sorter = RawExternalSorter::new(SortOrder::Coordinate)
+                    .threads(4)
+                    .into_coordinate_chunk_sorter(&Header::default())
+                    .expect("build coordinate chunk sorter");
+                for r in &records {
+                    sorter.push(r).expect("push");
+                }
+                sorter
+            },
+            |mut sorter| std::hint::black_box(sorter.take_sorted_chunk()),
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.bench_function("template_coordinate_500k", |b| {
+        b.iter_batched(
+            || {
+                let mut sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+                    .threads(4)
+                    .into_template_chunk_sorter(&Header::default())
+                    .expect("build template chunk sorter");
+                for r in &records {
+                    sorter.push(r).expect("push");
+                }
+                sorter
+            },
+            |mut sorter| std::hint::black_box(sorter.take_sorted_chunk()),
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_materialize);
+criterion_main!(benches);

--- a/crates/fgumi-sort/benches/queryname_keys.rs
+++ b/crates/fgumi-sort/benches/queryname_keys.rs
@@ -1,0 +1,197 @@
+//! Microbenchmarks isolating the queryname sort's per-record key cost, to
+//! decide two things before touching the production queryname path:
+//!
+//!   1. **Prefix key (solution C)** — does packing the first 8 name bytes into a
+//!      `u64` for a cheap first-pass compare actually help? The answer depends
+//!      entirely on the name distribution: Illumina read names share a long
+//!      common prefix (`instrument:run:flowcell:lane:` is identical for every
+//!      read in a lane) and only vary in the `tile:x:y` suffix — so a *front*
+//!      prefix key may discriminate nothing and add pure overhead. We therefore
+//!      bench with REALISTIC Illumina-style names, not random ones.
+//!
+//!   2. **Null-key ceilings** — the wall-time floor if the key were free:
+//!      - `*_ingest`: owned-name extraction (alloc + memcpy per record) vs a
+//!        cheap `u64` extraction (no alloc). The delta is the ceiling on what
+//!        solution A (borrow the name from the arena, drop the per-record Vec)
+//!        can recover on the ingest side.
+//!      - `*_sort`: full-name comparator vs a cheap `u64` comparator. The delta
+//!        is the ceiling on what a cheaper comparator (C, or radix on a packed
+//!        key) can recover on the sort side.
+//!
+//!     cargo bench -p fgumi-sort --bench queryname_keys
+
+use std::cmp::Ordering;
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use fgumi_raw_bam::testutil::make_bam_bytes;
+use fgumi_sort::{RawQuerynameKey, RawQuerynameLexKey, RawSortKey};
+
+/// Number of records per bench iteration.
+const N: usize = 1_000_000;
+
+/// Build `n` realistic Illumina-style read names: a fixed
+/// `instrument:run:flowcell:lane:` prefix shared by every read (22 bytes), then
+/// a varying `tile:x:y` suffix. This is the adversarial case for a front-prefix
+/// key — the first ~22 bytes are identical across all records.
+fn illumina_names(n: usize) -> Vec<Vec<u8>> {
+    (0..n)
+        .map(|i| {
+            // Vary tile (1101..1112), x (0..) and y (0..) like a real lane.
+            let tile = 1101 + (i % 12);
+            let x = (i.wrapping_mul(2_654_435_761)) % 30_000;
+            let y = (i.wrapping_mul(40_503)) % 30_000;
+            format!("A00123:45:HGVWXDSXY:1:{tile}:{x}:{y}").into_bytes()
+        })
+        .collect()
+}
+
+/// Pack the first 8 bytes of `name` into a big-endian `u64` so numeric ordering
+/// of the u64 matches lexicographic ordering of the first 8 bytes (short names
+/// zero-pad on the right).
+#[inline]
+fn prefix8(name: &[u8]) -> u64 {
+    let mut buf = [0u8; 8];
+    let take = name.len().min(8);
+    buf[..take].copy_from_slice(&name[..take]);
+    u64::from_be_bytes(buf)
+}
+
+/// Build BAM records carrying `names` (paired R1 flag), so key extraction walks
+/// a real record body exactly as production does.
+fn bam_records(names: &[Vec<u8>]) -> Vec<Vec<u8>> {
+    names.iter().map(|name| make_bam_bytes(0, 0, 0, name, &[], 100, -1, -1, &[])).collect()
+}
+
+fn bench_ingest(c: &mut Criterion) {
+    let names = illumina_names(N);
+    let records = bam_records(&names);
+
+    let mut group = c.benchmark_group("queryname_ingest_1M");
+    group.throughput(Throughput::Elements(N as u64));
+    group.sample_size(10);
+
+    // Owned natural key: alloc + memcpy of the name per record (current path).
+    group.bench_function("natural_owned_extract", |b| {
+        b.iter(|| {
+            let keys: Vec<RawQuerynameKey> =
+                records.iter().map(|r| RawQuerynameKey::extract_from_record(r)).collect();
+            std::hint::black_box(keys)
+        });
+    });
+
+    // Owned lex key: same alloc + memcpy.
+    group.bench_function("lex_owned_extract", |b| {
+        b.iter(|| {
+            let keys: Vec<RawQuerynameLexKey> =
+                records.iter().map(|r| RawQuerynameLexKey::extract_from_record(r)).collect();
+            std::hint::black_box(keys)
+        });
+    });
+
+    // Null key: a cheap u64 prefix, NO allocation. The delta vs the owned
+    // extracts is the ceiling on solution A (borrow, drop the per-record Vec).
+    group.bench_function("null_u64_extract", |b| {
+        b.iter(|| {
+            let keys: Vec<u64> = records
+                .iter()
+                .map(|r| {
+                    // True no-alloc floor: walk the raw name bytes directly
+                    // (`l_read_name` at byte 8, name at offset 32) with no
+                    // `RawQuerynameLexKey`/`NameBuf` allocation, then take the u64
+                    // prefix. `fields::read_name` yields the same name bytes
+                    // `RawQuerynameLexKey::name()` does, so the only delta vs
+                    // `lex_owned_extract` is the alloc + memcpy this path skips —
+                    // a valid lower bound for solution A.
+                    prefix8(fgumi_raw_bam::fields::read_name(r))
+                })
+                .collect();
+            std::hint::black_box(keys)
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_sort(c: &mut Criterion) {
+    let names = illumina_names(N);
+    let records = bam_records(&names);
+
+    // Pre-build the three key representations once, outside the timed loop.
+    let nat_keys: Vec<RawQuerynameKey> =
+        records.iter().map(|r| RawQuerynameKey::extract_from_record(r)).collect();
+    let lex_keys: Vec<RawQuerynameLexKey> =
+        records.iter().map(|r| RawQuerynameLexKey::extract_from_record(r)).collect();
+    // Prefix + full: (u64 prefix, full lex key). Prefix compared first, full
+    // name only on prefix ties.
+    let prefix_keys: Vec<(u64, RawQuerynameLexKey)> = records
+        .iter()
+        .map(|r| {
+            let k = RawQuerynameLexKey::extract_from_record(r);
+            (prefix8(k.name()), k)
+        })
+        .collect();
+    let u64_keys: Vec<u64> = prefix_keys.iter().map(|(p, _)| *p).collect();
+
+    let mut group = c.benchmark_group("queryname_sort_1M");
+    group.throughput(Throughput::Elements(N as u64));
+    group.sample_size(10);
+
+    // Full natural comparator (samtools strnum_cmp) — current path.
+    group.bench_function("natural_full_cmp", |b| {
+        b.iter_batched(
+            || nat_keys.clone(),
+            |mut keys| {
+                keys.sort_unstable();
+                std::hint::black_box(keys)
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    // Full lex comparator (Vec<u8>::cmp) — current lex path.
+    group.bench_function("lex_full_cmp", |b| {
+        b.iter_batched(
+            || lex_keys.clone(),
+            |mut keys| {
+                keys.sort_unstable();
+                std::hint::black_box(keys)
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    // Prefix-then-full: cheap u64 compare first, full name only on prefix ties.
+    // On Illumina names the shared front prefix means this almost always falls
+    // through to the full compare — the bench proves whether it helps or hurts.
+    group.bench_function("lex_prefix_then_full_cmp", |b| {
+        b.iter_batched(
+            || prefix_keys.clone(),
+            |mut keys| {
+                keys.sort_unstable_by(|a, b| match a.0.cmp(&b.0) {
+                    Ordering::Equal => a.1.cmp(&b.1),
+                    other => other,
+                });
+                std::hint::black_box(keys)
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    // Null key: sort the u64 prefix alone. The comparator ceiling — no full
+    // name ever compared.
+    group.bench_function("null_u64_cmp", |b| {
+        b.iter_batched(
+            || u64_keys.clone(),
+            |mut keys| {
+                keys.sort_unstable();
+                std::hint::black_box(keys)
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_ingest, bench_sort);
+criterion_main!(benches);

--- a/crates/fgumi-sort/examples/arena_bench.rs
+++ b/crates/fgumi-sort/examples/arena_bench.rs
@@ -1,0 +1,252 @@
+//! Arena-lifetime microbenchmark — settles N_arena (in-flight sort arenas) and
+//! the gather/compress release point, isolated from the typed-step pipeline.
+// Throwaway diagnostic bench (not production): relax pedantic lints.
+#![allow(
+    clippy::doc_markdown,
+    clippy::too_many_lines,
+    clippy::map_unwrap_or,
+    clippy::cast_possible_truncation
+)]
+//!
+//! Models the proposed Phase-1 dataflow with a **reused arena pool** (no
+//! mem-take-and-mint): a producer fills + par-sorts one `RecordBuffer` to a
+//! memory limit, hands ownership to a consumer that gathers (frames sorted
+//! records into ≤64 KiB blocks) + compresses, then returns the buffer to the
+//! pool. The pool depth is `N_arena`; the release point is `split`
+//! (return the buffer right after gather, before compress) or `fused`
+//! (return only after compress).
+//!
+//! Uses the REAL kernels: `RecordBuffer` (fill/par_sort/refs/get_record),
+//! `frame_keyed_record_into`, `SpillBlockCompressor::compress_block`.
+//!
+//! Run one config per process (clean peak RSS):
+//!   cargo run --release -p fgumi-sort --example arena_bench -- <mode> <N_arena> <chunk_mib> <n_chunks> <workers>
+//! e.g. cargo run --release -p fgumi-sort --example arena_bench -- split 1 512 6 4
+//!
+//! Output (stdout, one TSV line): mode N_arena chunk_mib n_chunks workers wall_s fill_s sort_s gather_s compress_s
+//! Peak RSS is sampled externally by the runner wrapper (this process prints its PID first).
+
+use std::sync::mpsc::sync_channel;
+use std::time::{Duration, Instant};
+
+use fgumi_sort::{
+    RawCoordinateKey, RawSortKey, RecordBuffer, SpillBlockCompressor, SpillCodec,
+    frame_keyed_record_into,
+};
+
+const BLOCK_SIZE: usize = 65280; // BGZF_MAX_BLOCK_SIZE
+const RECORD_BODY: usize = 200; // ~realistic BAM record body bytes
+
+/// Per-record framing overhead `frame_keyed_record_into` adds: a 4-byte `u32`
+/// record-length prefix, plus the serialized key ONLY when the key is not
+/// already embedded in the record. Derived from `RawCoordinateKey`'s own trait
+/// constants so it tracks the framing (and key size) instead of hardcoding `12`,
+/// which would silently mis-size blocks if the key encoding ever changed.
+const FRAME_OVERHEAD: usize = 4 // u32 record-length prefix
+    + if RawCoordinateKey::EMBEDDED_IN_RECORD {
+        0
+    } else {
+        // The coordinate key is fixed-size; a variable-length key (`None`) can't
+        // be statically bounded, but this bench only frames `RawCoordinateKey`.
+        match RawCoordinateKey::SERIALIZED_SIZE {
+            Some(n) => n,
+            None => 0,
+        }
+    };
+
+/// Synthesize one ~200-byte BAM-ish record into `out`: tid (bytes 0-3), pos
+/// (4-7), then a semi-compressible payload so zstd does realistic work. `n` is
+/// the record ordinal (varies tid/pos so keys differ).
+fn synth_record(out: &mut Vec<u8>, n: u64) {
+    out.clear();
+    let tid: i32 = (n % 25) as i32; // 25 contigs
+    let pos: i32 = ((n.wrapping_mul(2_654_435_761) >> 8) % 250_000_000) as i32;
+    out.extend_from_slice(&tid.to_le_bytes());
+    out.extend_from_slice(&pos.to_le_bytes());
+    // bytes 8..16 — remaining fixed BAM header fields (arbitrary)
+    out.extend_from_slice(&[0u8; 8]);
+    // payload: semi-compressible (a few repeating motifs keyed off n)
+    let motif = [(n & 0xFF) as u8, b'A', b'C', b'G', b'T', ((n >> 3) & 0xFF) as u8];
+    while out.len() < RECORD_BODY {
+        out.extend_from_slice(&motif);
+    }
+    out.truncate(RECORD_BODY);
+}
+
+/// Frame the sorted records of `buf` into ≤64 KiB raw blocks, cut-before-overflow.
+/// Reads `buf.refs()` (sorted) + `buf.get_record()` — the real gather access pattern.
+fn gather_range(buf: &RecordBuffer, start: usize, end: usize) -> Vec<Vec<u8>> {
+    let refs = buf.refs();
+    let mut blocks = Vec::new();
+    let mut cur = Vec::with_capacity(BLOCK_SIZE + 1024);
+    for r in &refs[start..end] {
+        let key = RawCoordinateKey { sort_key: r.sort_key };
+        let body = buf.get_record(r);
+        // would this record overflow a non-empty block? cut first.
+        if !cur.is_empty() && cur.len() + FRAME_OVERHEAD + body.len() > BLOCK_SIZE {
+            blocks.push(std::mem::replace(&mut cur, Vec::with_capacity(BLOCK_SIZE + 1024)));
+        }
+        frame_keyed_record_into(&mut cur, &key, body).expect("frame");
+    }
+    if !cur.is_empty() {
+        blocks.push(cur);
+    }
+    blocks
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    // Validate rather than fall through to a default. This writes a TSV row per
+    // run into a results table, so a typo that silently measured a different
+    // configuration than the label claims would corrupt the table rather than
+    // fail — the worst outcome for a benchmark.
+    let mode = args.get(1).map(String::as_str).unwrap_or("split").to_string();
+    assert!(
+        mode == "split" || mode == "fused",
+        "mode must be `split` or `fused`, got `{mode}` — any other string would run fused \
+         and be recorded under the name you typed",
+    );
+    let n_arena: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1);
+    // `sync_channel(0)` is a rendezvous channel and the seeding loop below sends
+    // nothing, so the producer would block on `free_rx.recv()` forever.
+    assert!(n_arena > 0, "N_arena must be at least 1 (0 deadlocks the producer)");
+    let chunk_mib: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(512);
+    let n_chunks: usize = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(6);
+    let workers: usize = args.get(5).and_then(|s| s.parse().ok()).unwrap_or(4);
+    let codec = SpillCodec::Zstd;
+    let level = 1u32;
+    let mem_limit = chunk_mib * 1024 * 1024;
+
+    eprintln!("PID {}", std::process::id());
+    eprintln!(
+        "config: mode={mode} N_arena={n_arena} chunk_mib={chunk_mib} n_chunks={n_chunks} workers={workers} codec=zstd{level}"
+    );
+
+    // Per-phase timing accumulators (nanos).
+    let fill_ns = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let sort_ns = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let gather_ns = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let compress_ns = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+
+    // Arena pool: a free-list channel seeded with N_arena empty buffers, and a
+    // work channel of filled+sorted buffers. Bounded so the producer blocks when
+    // no arena is free (this IS the N_arena bound).
+    let (free_tx, free_rx) = sync_channel::<RecordBuffer>(n_arena);
+    let (work_tx, work_rx) = sync_channel::<RecordBuffer>(n_arena);
+    // Estimate records/arena for with_capacity pre-sizing.
+    let est_records = mem_limit / (RECORD_BODY + 8 + 16);
+    for _ in 0..n_arena {
+        free_tx.send(RecordBuffer::with_capacity(est_records, mem_limit, 25)).expect("seed pool");
+    }
+
+    let wall = Instant::now();
+
+    // Producer: fill + par_sort each chunk, hand the owned buffer to the consumer.
+    let prod_fill = fill_ns.clone();
+    let prod_sort = sort_ns.clone();
+    let producer = std::thread::spawn(move || {
+        let mut scratch = Vec::with_capacity(RECORD_BODY + 8);
+        let mut ordinal: u64 = 0;
+        for _ in 0..n_chunks {
+            let mut buf = free_rx.recv().expect("acquire arena");
+            let t = Instant::now();
+            while buf.memory_usage() < mem_limit {
+                synth_record(&mut scratch, ordinal);
+                ordinal += 1;
+                buf.push_coordinate(&scratch).expect("push");
+            }
+            prod_fill
+                .fetch_add(t.elapsed().as_nanos() as u64, std::sync::atomic::Ordering::Relaxed);
+            let t = Instant::now();
+            buf.par_sort();
+            prod_sort
+                .fetch_add(t.elapsed().as_nanos() as u64, std::sync::atomic::Ordering::Relaxed);
+            work_tx.send(buf).expect("hand to consumer");
+        }
+        // drop work_tx → consumer loop ends
+    });
+
+    // Consumer: gather + compress each chunk; release the arena per `mode`.
+    let split = mode == "split";
+    while let Ok(mut buf) = work_rx.recv() {
+        let n = buf.len();
+        // contiguous index ranges, one per worker
+        let per = n.div_ceil(workers.max(1));
+        let ranges: Vec<(usize, usize)> = (0..workers)
+            .map(|w| (w * per, ((w + 1) * per).min(n)))
+            .filter(|(s, e)| s < e)
+            .collect();
+
+        if split {
+            // GATHER (parallel) → owned raw blocks; then RELEASE arena; then COMPRESS (parallel).
+            let tg = Instant::now();
+            let raw: Vec<Vec<u8>> = std::thread::scope(|sc| {
+                let bref = &buf;
+                let handles: Vec<_> = ranges
+                    .iter()
+                    .map(|&(s, e)| sc.spawn(move || gather_range(bref, s, e)))
+                    .collect();
+                handles.into_iter().flat_map(|h| h.join().expect("gather join")).collect()
+            });
+            gather_ns
+                .fetch_add(tg.elapsed().as_nanos() as u64, std::sync::atomic::Ordering::Relaxed);
+            // RELEASE the arena BEFORE compress (the whole point of "split").
+            buf.clear();
+            let _ = free_tx.send(buf);
+            // COMPRESS the owned raw blocks in parallel (arena already free).
+            let tc = Instant::now();
+            let chunks: Vec<&[Vec<u8>]> =
+                raw.chunks(raw.len().div_ceil(workers.max(1)).max(1)).collect();
+            std::thread::scope(|sc| {
+                for ch in &chunks {
+                    sc.spawn(move || {
+                        let mut comp = SpillBlockCompressor::new(codec, level).expect("compressor");
+                        for blk in *ch {
+                            let out = comp.compress_block(blk).expect("compress");
+                            std::hint::black_box(&out);
+                        }
+                    });
+                }
+            });
+            compress_ns
+                .fetch_add(tc.elapsed().as_nanos() as u64, std::sync::atomic::Ordering::Relaxed);
+        } else {
+            // FUSED: each worker gathers+compresses its range from the arena;
+            // the arena is released only after ALL workers finish.
+            let tf = Instant::now();
+            std::thread::scope(|sc| {
+                for &(s, e) in &ranges {
+                    let bref = &buf;
+                    sc.spawn(move || {
+                        let mut comp = SpillBlockCompressor::new(codec, level).expect("compressor");
+                        for blk in gather_range(bref, s, e) {
+                            let out = comp.compress_block(&blk).expect("compress");
+                            std::hint::black_box(&out);
+                        }
+                    });
+                }
+            });
+            // fused gather+compress are interleaved; attribute the whole span to compress.
+            compress_ns
+                .fetch_add(tf.elapsed().as_nanos() as u64, std::sync::atomic::Ordering::Relaxed);
+            buf.clear();
+            let _ = free_tx.send(buf);
+        }
+        let _ = n;
+    }
+    producer.join().expect("producer join");
+    let wall_s = wall.elapsed().as_secs_f64();
+
+    let g = |a: &std::sync::atomic::AtomicU64| {
+        Duration::from_nanos(a.load(std::sync::atomic::Ordering::Relaxed)).as_secs_f64()
+    };
+    // headline TSV
+    println!(
+        "{mode}\t{n_arena}\t{chunk_mib}\t{n_chunks}\t{workers}\t{:.2}\t{:.2}\t{:.2}\t{:.2}\t{:.2}",
+        wall_s,
+        g(&fill_ns),
+        g(&sort_ns),
+        g(&gather_ns),
+        g(&compress_ns)
+    );
+}

--- a/crates/fgumi-sort/src/arena_pool.rs
+++ b/crates/fgumi-sort/src/arena_pool.rs
@@ -174,6 +174,21 @@ impl PooledSegmentedBuf {
     }
 }
 
+impl Default for PooledSegmentedBuf {
+    /// An empty, NON-pooled buffer.
+    ///
+    /// This exists so `std::mem::take(&mut some_pooled_buf)` moves the WRAPPER
+    /// out. Without it, `take` deref-coerces through `DerefMut` and steals the
+    /// inner `SegmentedBuf`, leaving the wrapper holding a default-sized buffer
+    /// that it still believes belongs to the pool: the real arena is orphaned
+    /// (never returned) and a wrong-`segment_size` buffer is later pushed onto
+    /// the free list. Pooled-ness must travel with the arena, and it only does
+    /// if the whole wrapper moves.
+    fn default() -> Self {
+        Self::unpooled(SegmentedBuf::default())
+    }
+}
+
 impl DerefMut for PooledSegmentedBuf {
     /// Fill happens *through* the wrapper. Without this the caller would have to
     /// unwrap to write, which is exactly the window in which a dropped arena

--- a/crates/fgumi-sort/src/chunk_sorter.rs
+++ b/crates/fgumi-sort/src/chunk_sorter.rs
@@ -1,0 +1,1189 @@
+//! Lean in-memory buffering sorter for the P6 `SortBuffer` step.
+//!
+//! [`CoordinateChunkSorter`] is the buffer-management slice of the former
+//! `CoordinateSortStream` (the streaming sort engine retired in P7) with **all
+//! the disk and pool machinery removed**: it ingests records into a
+//! [`RecordBuffer`], and on
+//! demand par-sorts the buffer and drains it into an arena-backed sorted chunk
+//! (`InMemoryChunk<RawCoordinateKey>`, zero body copies — the arena is moved,
+//! not copied). It never writes to disk, owns no
+//! `SortWorkerPool`, no temp dirs, and no spill files — compressing and writing
+//! a chunk is the `CompressSpill` step's job (P6 Phase-1 split).
+//!
+//! The driver (`SortBuffer`) calls [`push`](CoordinateChunkSorter::push) per
+//! record; when it returns `true` (buffer at the memory limit), the driver takes
+//! a sorted chunk via [`take_sorted_chunk`](CoordinateChunkSorter::take_sorted_chunk)
+//! and emits it as a spill chunk. At end of input the driver takes one final
+//! residual chunk the same way.
+//!
+//! # Parity
+//!
+//! `take_sorted_chunk` uses the global stable [`RecordBuffer::par_sort`] plus a
+//! zero-copy arena drain — exactly the no-spill residual path in
+//! `CoordinateSortStream::into_slot_setup`. The legacy with-spill multi-thread
+//! path used `par_sort_into_chunks` to emit *k* sub-runs; emitting one
+//! globally-sorted chunk instead is record-order identical (the sub-runs are
+//! merged back by key with a lower-source-index tie-break, which for a stable
+//! global sort is the same original-insertion order), and it keeps the residual
+//! a single merge source so a `Parallel` `CompressSpill` reordering chunks can
+//! never perturb the tie-break.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+#[cfg(test)]
+use fgumi_raw_bam::RawRecord;
+use fgumi_raw_bam::SamTag;
+use rayon::ThreadPool;
+
+use crate::arena_pool::ArenaPool;
+use crate::external::{
+    KeyTypesSpec, LibraryLookup, TemplateKeyVariant, dropped_lane_error,
+    extract_template_key_inline, select_template_variant, verify_dropped_lanes,
+};
+use crate::inline::{
+    CbKey32, InMemoryChunk, RecordBuffer, TemplateKey, TemplateKey24, TemplateKey40,
+    TemplateLaneKey, TemplateRecordBuffer, TertKey32,
+};
+use crate::keys::RawCoordinateKey;
+use crate::memory_probe::force_mi_collect;
+
+/// In-memory coordinate buffering sorter that emits owned sorted chunks.
+pub struct CoordinateChunkSorter {
+    buffer: RecordBuffer,
+    /// Private rayon pool sized to `--threads`, used for `par_sort` and the
+    /// parallel chunk materialization.
+    rayon_pool: ThreadPool,
+    /// Memory-usage threshold (bytes) at which `push` signals a chunk is due.
+    memory_limit: usize,
+    total_records: u64,
+    /// Bounded pool of reusable sort arenas (lever-1 RSS fix). The buffer's
+    /// backing `SegmentedBuf` is acquired here and returns (reset-for-reuse)
+    /// when the emitted chunk's `Arc` drops, so at most `N_arena` arenas are
+    /// ever live. Capacity 1 (default) matches legacy's one-arena-at-a-time
+    /// `drain_pending_spill` model.
+    arena_pool: Arc<ArenaPool>,
+    /// `true` once an arena is installed in `buffer` and not yet drained.
+    has_arena: bool,
+}
+
+impl CoordinateChunkSorter {
+    /// Construct from a pre-sized buffer + rayon pool + arena pool. Built via
+    /// [`RawExternalSorter::into_coordinate_chunk_sorter`](crate::RawExternalSorter::into_coordinate_chunk_sorter).
+    /// `buffer` starts drained; the first [`ensure_arena`](Self::ensure_arena)
+    /// installs one from `arena_pool`.
+    pub(crate) fn new(
+        buffer: RecordBuffer,
+        rayon_pool: ThreadPool,
+        memory_limit: usize,
+        arena_pool: Arc<ArenaPool>,
+    ) -> Self {
+        Self { buffer, rayon_pool, memory_limit, total_records: 0, arena_pool, has_arena: false }
+    }
+
+    /// Ensure the buffer has a backing arena before a fill. Idempotent while
+    /// one is installed.
+    ///
+    /// `false` has **two** meanings and they call for opposite responses, so a
+    /// caller that treats every `false` as backpressure will spin:
+    ///
+    /// - **Pool exhausted** — all `N_arena` arenas are in flight. This is the
+    ///   backpressure signal: the caller (`SortBuffer`) reports `NoProgress` and
+    ///   retries once an in-flight chunk is spilled and its arena returns.
+    ///   Retrying is what makes progress.
+    /// - **Buffer non-empty** — a fill is already underway in the buffer's
+    ///   current storage. Retrying cannot change this until the buffer is
+    ///   drained, so the caller must keep filling and take a chunk, NOT
+    ///   backpressure. See the comment on the check below for why an arena is
+    ///   never swapped in mid-fill.
+    ///
+    /// Call this only at the start of a fill, where the second case cannot
+    /// arise, and the return value is unambiguous.
+    #[must_use]
+    pub fn ensure_arena(&mut self) -> bool {
+        if self.has_arena {
+            return true;
+        }
+        // Only acquire at the START of a fill (drained buffer). Never swap a
+        // partially-filled (default) buffer for a pool arena mid-fill — the
+        // arena install replaces the backing store, which would orphan the
+        // records already buffered. A caller that began filling the default
+        // (because the bounded pool was momentarily empty) finishes into it and
+        // drains it unpooled.
+        if !self.buffer.is_empty() {
+            return false;
+        }
+        if let Some(arena) = self.arena_pool.try_acquire() {
+            self.buffer.install_arena(arena);
+            self.has_arena = true;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Push one raw BAM record into the buffer.
+    ///
+    /// Returns `true` when the buffer's memory usage has reached the configured
+    /// limit and the caller should take a sorted (spill) chunk via
+    /// [`Self::take_sorted_chunk`] before pushing more. The caller must have
+    /// called [`ensure_arena`](Self::ensure_arena) (returning `true`) first.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the record cannot be parsed for its coordinate key
+    /// (e.g. truncated record).
+    pub fn push(&mut self, bam_bytes: &[u8]) -> Result<bool> {
+        // Best-effort: acquire a pool arena if one is free. A bounded, RSS-
+        // critical driver would call `ensure_arena` explicitly first and
+        // backpressure on `false`, so on that path the arena is always installed
+        // here. Callers (the `SortBuffer` RecordBatch path, unit tests) that
+        // don't pre-check simply fill the buffer's current (possibly pool,
+        // possibly default) storage — `take_sorted_chunk` returns it to the pool
+        // only when it is a pool arena, which the buffer's own wrapper records
+        // (`has_arena` gates acquisition here, not the return).
+        let _ = self.ensure_arena();
+        // Count only after the record is successfully buffered, so a truncated
+        // record (push_coordinate error) never bumps `total_records` for a
+        // record that was never stored.
+        self.buffer.push_coordinate(bam_bytes)?;
+        self.total_records += 1;
+        Ok(self.buffer.memory_usage() >= self.memory_limit)
+    }
+
+    /// Par-sort the current buffer, drain it into an arena-backed sorted chunk,
+    /// and leave the buffer drained for reuse.
+    ///
+    /// Returns an empty chunk if the buffer is empty (so the caller can skip
+    /// emitting an empty chunk).
+    ///
+    /// **Zero-copy materialisation.** The sorted buffer is drained into an
+    /// [`InMemoryChunk`] that *moves* the arena (`Arc<SegmentedBuf>`) and keeps
+    /// per-record `(key, offset, len)` references into it — no per-record byte
+    /// copy or allocation. (The pre-fix path materialised an owned
+    /// `Vec<(K, RawRecord)>`, copying + `malloc`-ing every record and doubling
+    /// peak RSS; the A/B smoke campaign flagged that regression vs the legacy
+    /// path, which already used this primitive.)
+    #[must_use]
+    pub fn take_sorted_chunk(&mut self) -> InMemoryChunk<RawCoordinateKey> {
+        if self.buffer.is_empty() {
+            return InMemoryChunk::empty();
+        }
+        {
+            let buffer = &mut self.buffer;
+            let rayon_pool = &self.rayon_pool;
+            rayon_pool.install(|| buffer.par_sort());
+        }
+        // One drain for both cases: the buffer holds a `PooledSegmentedBuf`,
+        // which already records whether it came from the pool, and the drain
+        // moves that wrapper whole. A pool arena therefore returns
+        // (reset-for-reuse) when the chunk's last `Arc` drops — the reuse and
+        // cap-1 bound on the standalone coordinate path — while a buffer that
+        // bypassed the pool simply drops. Branching on a parallel `has_arena`
+        // bool would be a second source of truth for something the data already
+        // knows. `has_arena` is still cleared so the next fill re-acquires.
+        let chunk = self.buffer.drain_into_single_chunk();
+        self.has_arena = false;
+        chunk
+    }
+
+    /// The arena pool this sorter draws from (test/diagnostic).
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn arena_pool(&self) -> &Arc<ArenaPool> {
+        &self.arena_pool
+    }
+
+    /// Total records pushed so far.
+    #[must_use]
+    pub fn total_records(&self) -> u64 {
+        self.total_records
+    }
+
+    /// `true` iff the buffer currently holds no records.
+    #[must_use]
+    pub fn buffer_is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+
+    /// Construct a minimal `CoordinateChunkSorter` for unit tests.
+    ///
+    /// Mirrors the construction in
+    /// [`RawExternalSorter::into_coordinate_chunk_sorter`](crate::RawExternalSorter::into_coordinate_chunk_sorter):
+    /// a zero-capacity `RecordBuffer` (the pool hands out the first arena on the
+    /// initial `ensure_arena`/`push`), a single-thread rayon pool, and a
+    /// capacity-1 `ArenaPool` with the standard segment size.
+    ///
+    /// # Panics
+    ///
+    /// Panics if rayon cannot build a single-thread pool (which never occurs in
+    /// practice but is the contract of `ThreadPoolBuilder::build`).
+    #[cfg(any(test, feature = "test-utils"))]
+    #[must_use]
+    pub fn for_test(memory_limit: usize, n_ref: u32) -> Self {
+        let buffer = crate::inline::RecordBuffer::with_capacity(0, 0, n_ref);
+        let rayon_pool =
+            rayon::ThreadPoolBuilder::new().num_threads(1).build().expect("rayon pool for test");
+        let arena_pool = crate::arena_pool::ArenaPool::new(1, crate::inline::SORT_SEGMENT_SIZE);
+        Self::new(buffer, rayon_pool, memory_limit, arena_pool)
+    }
+}
+
+// ============================================================================
+// TemplateChunkSorter — template-coordinate (stable radix, like coordinate)
+// ============================================================================
+
+/// The narrowed lane-key buffer the [`TemplateChunkSorter`] sorts on. The
+/// variant is chosen on the first `push` from `--key-types` (via
+/// [`select_template_variant`]) and matches the batch `RawExternalSorter::sort`
+/// dispatch one-for-one: `(cb, tertiary)` → `(false,false)`=`TemplateKey24`
+/// (3 lanes), `(true,false)`=`CbKey32`, `(false,true)`=`TertKey32` (4 lanes),
+/// `(true,true)`=`TemplateKey40` (5 lanes, the full key). The radix sort runs
+/// on the narrower key for speed; the emitted chunk re-widens to the full
+/// [`TemplateKey`] (see [`TemplateChunkSorter::take_sorted_chunk`]).
+enum TemplateBuffer {
+    K24(TemplateRecordBuffer<TemplateKey24>),
+    Cb32(TemplateRecordBuffer<CbKey32>),
+    Tert32(TemplateRecordBuffer<TertKey32>),
+    K40(TemplateRecordBuffer<TemplateKey40>),
+}
+
+/// Run `$body` against the inner `TemplateRecordBuffer<K>` of whichever variant
+/// `$self` holds, with the buffer bound to `$buf`. `$body` is monomorphized per
+/// arm, so type inference resolves `K` (e.g. `TemplateLaneKey::from_full`,
+/// `b.push`) from the matched buffer type.
+macro_rules! with_template_buffer {
+    ($self:expr, $buf:ident => $body:expr) => {
+        match $self {
+            TemplateBuffer::K24($buf) => $body,
+            TemplateBuffer::Cb32($buf) => $body,
+            TemplateBuffer::Tert32($buf) => $body,
+            TemplateBuffer::K40($buf) => $body,
+        }
+    };
+}
+
+impl TemplateBuffer {
+    /// Build the buffer for the chosen `variant`, sized from the shared
+    /// (key-width-agnostic) capacity hints. The slight per-`K` ref-size
+    /// difference is immaterial for a capacity hint — the buffer grows as
+    /// needed — so a single estimate is used across variants.
+    fn from_variant(
+        variant: TemplateKeyVariant,
+        estimated_records: usize,
+        estimated_data_bytes: usize,
+    ) -> Self {
+        match (variant.cb, variant.tertiary) {
+            (false, false) => Self::K24(TemplateRecordBuffer::with_capacity(
+                estimated_records,
+                estimated_data_bytes,
+            )),
+            (true, false) => Self::Cb32(TemplateRecordBuffer::with_capacity(
+                estimated_records,
+                estimated_data_bytes,
+            )),
+            (false, true) => Self::Tert32(TemplateRecordBuffer::with_capacity(
+                estimated_records,
+                estimated_data_bytes,
+            )),
+            (true, true) => Self::K40(TemplateRecordBuffer::with_capacity(
+                estimated_records,
+                estimated_data_bytes,
+            )),
+        }
+    }
+
+    /// Push a record under the narrowed key derived from its full key.
+    fn push_full(&mut self, bam_bytes: &[u8], full: &TemplateKey) -> Result<()> {
+        with_template_buffer!(self, b => b.push(bam_bytes, TemplateLaneKey::from_full(full)))
+    }
+
+    fn memory_usage(&self) -> usize {
+        with_template_buffer!(self, b => b.memory_usage())
+    }
+
+    fn is_empty(&self) -> bool {
+        with_template_buffer!(self, b => b.is_empty())
+    }
+
+    fn par_sort(&mut self) {
+        with_template_buffer!(self, b => b.par_sort());
+    }
+
+    // Test-only: only the owned oracle path (`take_sorted_chunk_owned`) clears
+    // the buffer explicitly; the production arena drain empties it in place.
+    #[cfg(test)]
+    fn clear(&mut self) {
+        with_template_buffer!(self, b => b.clear());
+    }
+
+    /// Materialize the (already narrow-key-sorted) buffer into an owned chunk
+    /// keyed by the **full** [`TemplateKey`], re-extracted per record. Narrow-K
+    /// order equals full-key order because every dropped lane is verified
+    /// constant, so the chunk is correctly ordered for the downstream merge.
+    /// Must be invoked inside the sorter's `rayon_pool.install`.
+    ///
+    /// Test-only: the owned materialisation is retained purely as the byte-parity
+    /// oracle for [`drain_into_full_key_chunk`](Self::drain_into_full_key_chunk),
+    /// which is the production path.
+    #[cfg(test)]
+    fn materialize_full(
+        &self,
+        lib_lookup: &LibraryLookup,
+        cell_tag: Option<SamTag>,
+        cb_hasher: &ahash::RandomState,
+    ) -> Vec<(TemplateKey, RawRecord)> {
+        use rayon::prelude::*;
+        with_template_buffer!(self, b => b
+            .refs()
+            .par_iter()
+            .map(|r| {
+                let bam_bytes = b.get_record(r);
+                let full = extract_template_key_inline(bam_bytes, lib_lookup, cell_tag, cb_hasher);
+                (full, RawRecord::from(bam_bytes.to_vec()))
+            })
+            .collect::<Vec<_>>())
+    }
+
+    /// Zero-copy analogue of `materialize_full`: drain
+    /// the (already narrow-key-sorted) buffer into an arena-backed
+    /// `InMemoryChunk<TemplateKey>` keyed by the re-extracted full key, WITHOUT
+    /// copying record bodies (the arena is moved into the chunk). Produces the
+    /// same sorted order, keys, and body bytes as `materialize_full` — the only
+    /// difference is the records reference the moved arena instead of owned
+    /// `RawRecord`s. Must be invoked inside the sorter's `rayon_pool.install`.
+    fn drain_into_full_key_chunk(
+        &mut self,
+        lib_lookup: &LibraryLookup,
+        cell_tag: Option<SamTag>,
+        cb_hasher: &ahash::RandomState,
+    ) -> InMemoryChunk<TemplateKey> {
+        with_template_buffer!(self, b => b.drain_into_full_key_chunk(|body| {
+            extract_template_key_inline(body, lib_lookup, cell_tag, cb_hasher)
+        }))
+    }
+}
+
+/// State that exists only once the first record has been seen: the chosen
+/// narrowed-key variant, the full key of the first record (the dropped-lane
+/// verify baseline), and the matching buffer. Bundling the three behind one
+/// `Option` captures their shared "set together on the first push" invariant in
+/// the type, so the hot path never unwraps.
+struct Provisioned {
+    /// Full key of the first record; later records' dropped lanes are verified
+    /// against it.
+    first_key: TemplateKey,
+    /// The chosen narrowed-key variant (`--key-types` + first record).
+    variant: TemplateKeyVariant,
+    /// The narrowed-key buffer matching `variant`.
+    buffer: TemplateBuffer,
+}
+
+/// In-memory template-coordinate buffering sorter that emits owned sorted
+/// chunks. The template analogue of [`CoordinateChunkSorter`]: a
+/// `TemplateRecordBuffer` + private rayon pool, with the library / cell-barcode
+/// / MI key-extraction state the template key needs. Uses the same global stable
+/// radix `TemplateRecordBuffer::par_sort`, so the single-residual-chunk parity
+/// argument is identical to coordinate's.
+///
+/// **Narrowed radix key (`--key-types`).** Like the batch `RawExternalSorter::sort`
+/// path, the in-memory radix sort runs on the `KeyTypesSpec`-narrowed key
+/// (`TemplateBuffer` — `TemplateKey24`/`CbKey32`/`TertKey32`/`TemplateKey40`),
+/// chosen lazily on the first `push` once the first record is available to seed
+/// `select_template_variant`. The narrower key is a **speed** optimization
+/// (fewer radix passes). The emitted chunk re-widens to the full [`TemplateKey`]
+/// in [`take_sorted_chunk`](Self::take_sorted_chunk) so the buffer-chain protocol
+/// (`CompressSpill`/`SortMerge`) stays on the full key.
+///
+/// Narrowing is order-preserving and validated: `--key-types` may only drop a
+/// lane the dropped-lane validation (`verify_dropped_lanes`) proves constant, so
+/// the narrow-key sort yields the identical order to a full-key sort. This path
+/// therefore produces byte-for-byte the same output as the batch path AND rejects
+/// the same dropped-lane violations. (The pre-P6 streaming path skipped this
+/// validation entirely; restoring it makes `--key-types` actually function in
+/// production.)
+pub struct TemplateChunkSorter {
+    /// Variant + first-key + buffer, provisioned on the first `push` (`None`
+    /// until then; an empty stream leaves it `None`).
+    state: Option<Provisioned>,
+    rayon_pool: ThreadPool,
+    memory_limit: usize,
+    /// Capacity hints for the lazily-built `TemplateBuffer` (key-width-agnostic).
+    estimated_records: usize,
+    estimated_data_bytes: usize,
+    lib_lookup: LibraryLookup,
+    cb_hasher: ahash::RandomState,
+    cell_tag: Option<SamTag>,
+    /// `--key-types` spec; selects which optional lanes may be dropped.
+    key_types: KeyTypesSpec,
+    /// Whether the header realizes >1 library ordinal (informs `Auto` selection).
+    header_library_varies: bool,
+    total_records: u64,
+}
+
+impl TemplateChunkSorter {
+    /// Built via
+    /// [`RawExternalSorter::into_template_chunk_sorter`](crate::RawExternalSorter::into_template_chunk_sorter).
+    /// The narrowed-key buffer is deferred to the first `push` (the variant is
+    /// chosen from the first record), so this takes capacity hints rather than a
+    /// pre-built buffer.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        rayon_pool: ThreadPool,
+        memory_limit: usize,
+        estimated_records: usize,
+        estimated_data_bytes: usize,
+        lib_lookup: LibraryLookup,
+        cb_hasher: ahash::RandomState,
+        cell_tag: Option<SamTag>,
+        key_types: KeyTypesSpec,
+        header_library_varies: bool,
+    ) -> Self {
+        Self {
+            state: None,
+            rayon_pool,
+            memory_limit,
+            estimated_records,
+            estimated_data_bytes,
+            lib_lookup,
+            cb_hasher,
+            cell_tag,
+            key_types,
+            header_library_varies,
+            total_records: 0,
+        }
+    }
+
+    /// Push one record (extracting the template key); returns `true` when the
+    /// buffer has reached the memory limit.
+    ///
+    /// On the first record the dropped-lane variant is provisioned from
+    /// `--key-types`; every record then has its dropped lanes verified against
+    /// the first record's, matching the batch `RawExternalSorter::sort` path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the record cannot be buffered (e.g. truncated), or if
+    /// a record carries a dropped-lane value (CB / MI / library) absent from the
+    /// input's first record.
+    pub fn push(&mut self, bam_bytes: &[u8]) -> Result<bool> {
+        let key = extract_template_key_inline(
+            bam_bytes,
+            &self.lib_lookup,
+            self.cell_tag,
+            &self.cb_hasher,
+        );
+
+        let memory_usage = if let Some(state) = self.state.as_mut() {
+            // Subsequent records: verify the lanes the chosen variant drops are
+            // constant relative to the first record, then buffer.
+            if let Some(violation) = verify_dropped_lanes(&state.first_key, &key, state.variant) {
+                let name = fgumi_raw_bam::RawRecordView::new(bam_bytes).read_name();
+                return Err(dropped_lane_error(&String::from_utf8_lossy(name), violation));
+            }
+            state.buffer.push_full(bam_bytes, &key)?;
+            state.buffer.memory_usage()
+        } else {
+            // First record: provision the variant from --key-types and build the
+            // matching narrowed-key buffer. Buffer the record BEFORE committing
+            // `self.state`, so a `push_full` error leaves the sorter unprovisioned
+            // rather than holding a first_key/variant from a never-buffered record.
+            let variant =
+                select_template_variant(Some(&key), self.key_types, self.header_library_varies);
+            let mut buffer = TemplateBuffer::from_variant(
+                variant,
+                self.estimated_records,
+                self.estimated_data_bytes,
+            );
+            buffer.push_full(bam_bytes, &key)?;
+            let memory_usage = buffer.memory_usage();
+            self.state = Some(Provisioned { first_key: key, variant, buffer });
+            memory_usage
+        };
+
+        // Count only after the record is successfully buffered (past the
+        // dropped-lane check and push_full), so an error never bumps
+        // `total_records` for a record that was never stored.
+        self.total_records += 1;
+        Ok(memory_usage >= self.memory_limit)
+    }
+
+    /// Par-sort (on the narrowed key) + drain the buffer into one **arena-backed**
+    /// `InMemoryChunk<TemplateKey>` keyed by the full [`TemplateKey`] — zero body
+    /// copies (the sort arena is moved into the chunk, the full key re-extracted
+    /// per record). Symmetric with [`CoordinateChunkSorter::take_sorted_chunk`].
+    /// Both `data` and `refs` are cleared by the drain.
+    #[must_use]
+    pub fn take_sorted_chunk(&mut self) -> InMemoryChunk<TemplateKey> {
+        let Some(state) = self.state.as_mut() else {
+            return InMemoryChunk::default();
+        };
+        if state.buffer.is_empty() {
+            return InMemoryChunk::default();
+        }
+        self.rayon_pool.install(|| state.buffer.par_sort());
+        let lib_lookup = &self.lib_lookup;
+        let cell_tag = self.cell_tag;
+        let cb_hasher = &self.cb_hasher;
+        let chunk = self
+            .rayon_pool
+            .install(|| state.buffer.drain_into_full_key_chunk(lib_lookup, cell_tag, cb_hasher));
+        force_mi_collect();
+        chunk
+    }
+
+    /// Test-only owned materialisation — the byte-parity oracle reference for
+    /// [`take_sorted_chunk`](Self::take_sorted_chunk). Par-sorts then copies each
+    /// record into an owned `Vec<(TemplateKey, RawRecord)>` via `materialize_full`
+    /// (the pre-arena behaviour), so a test can assert the arena chunk is
+    /// byte-identical to what the owned path produced.
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn take_sorted_chunk_owned(&mut self) -> Vec<(TemplateKey, RawRecord)> {
+        let Some(state) = self.state.as_mut() else {
+            return Vec::new();
+        };
+        if state.buffer.is_empty() {
+            return Vec::new();
+        }
+        self.rayon_pool.install(|| state.buffer.par_sort());
+        let buffer_ref = &state.buffer;
+        let lib_lookup = &self.lib_lookup;
+        let cell_tag = self.cell_tag;
+        let cb_hasher = &self.cb_hasher;
+        let chunk = self
+            .rayon_pool
+            .install(|| buffer_ref.materialize_full(lib_lookup, cell_tag, cb_hasher));
+        state.buffer.clear();
+        force_mi_collect();
+        chunk
+    }
+
+    /// Total records pushed so far.
+    #[must_use]
+    pub fn total_records(&self) -> u64 {
+        self.total_records
+    }
+
+    /// The narrowed-key variant chosen on the first push (`None` before any
+    /// push). Exposed for tests asserting `--key-types` narrowing selects the
+    /// expected lane width.
+    #[cfg(test)]
+    pub(crate) fn chosen_variant(&self) -> Option<TemplateKeyVariant> {
+        self.state.as_ref().map(|s| s.variant)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::RawExternalSorter;
+    use crate::inline::InMemoryChunk;
+    use crate::keys::{RawCoordinateKey, SortOrder};
+    use fgumi_raw_bam::testutil::make_bam_bytes;
+    use noodles::sam::Header;
+
+    /// Build `n` coordinate records at descending positions on tid 0, so a
+    /// correct sort must reorder them to ascending position.
+    fn descending_pos_records(n: usize) -> Vec<Vec<u8>> {
+        (0..n)
+            .map(|i| {
+                let pos = i32::try_from(n - 1 - i).expect("pos fits i32");
+                let name = format!("r{i:05}");
+                make_bam_bytes(0, pos, 0, name.as_bytes(), &[], 80, -1, -1, &[])
+            })
+            .collect()
+    }
+
+    /// Assert a chunk's keys are non-decreasing (each chunk is a sorted run).
+    fn assert_chunk_sorted(chunk: &InMemoryChunk<RawCoordinateKey>) {
+        for i in 1..chunk.len() {
+            assert!(
+                chunk.key_at(i - 1).cmp(chunk.key_at(i)).is_le(),
+                "chunk not sorted by coordinate key"
+            );
+        }
+    }
+
+    /// A generous memory limit keeps everything in one residual chunk; `push`
+    /// never signals full, and the single chunk is fully sorted.
+    #[test]
+    fn no_spill_single_sorted_residual_chunk() {
+        let records = descending_pos_records(500);
+        let mut sorter = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(256 * 1024 * 1024)
+            .threads(2)
+            .into_coordinate_chunk_sorter(&Header::default())
+            .expect("build chunk sorter");
+
+        for r in &records {
+            assert!(!sorter.push(r).expect("push"), "no spill expected under a large memory limit");
+        }
+        let residual = sorter.take_sorted_chunk();
+        assert_eq!(residual.len(), records.len(), "residual must hold every record");
+        assert_chunk_sorted(&residual);
+        assert_eq!(sorter.total_records(), records.len() as u64);
+        assert!(sorter.buffer_is_empty(), "buffer cleared after take");
+    }
+
+    /// The pooled arena must complete a full cycle: acquire, fill, drain into a
+    /// chunk, and return to the free list once that chunk is dropped — then be
+    /// handed out again.
+    ///
+    /// The pool's own tests cover it in isolation, and the spill test above
+    /// holds every chunk alive, so nothing observed the arena actually coming
+    /// back. That gap hid a real defect: the drain used to re-wrap the buffer
+    /// *inside* the pooled wrapper, which deref-coerced past it, orphaned the
+    /// arena, and left a wrong-sized default behind for the pool to reclaim. At
+    /// the default `capacity == 1` that retires the only slot permanently.
+    #[test]
+    fn pooled_arena_returns_to_the_pool_when_its_chunk_drops() {
+        let records = descending_pos_records(64);
+        let mut sorter = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(8 * 1024 * 1024)
+            .threads(1)
+            .into_coordinate_chunk_sorter(&Header::default())
+            .expect("build chunk sorter");
+        let pool = Arc::clone(sorter.arena_pool());
+
+        assert!(sorter.ensure_arena(), "the pool has a free arena to install");
+        assert_eq!(pool.free_len(), 0, "it is in flight, not on the free list");
+        for r in &records {
+            sorter.push(r).expect("push");
+        }
+
+        let chunk = sorter.take_sorted_chunk();
+        assert_eq!(chunk.len(), records.len());
+        assert_chunk_sorted(&chunk);
+        assert_eq!(pool.free_len(), 0, "still held by the live chunk");
+
+        drop(chunk);
+        assert_eq!(pool.free_len(), 1, "the arena returned once its chunk dropped");
+        assert!(sorter.ensure_arena(), "and the pool can hand it out again");
+    }
+
+    /// The pool-exhausted `false`: at `capacity == 1`, a live chunk holds the
+    /// only arena, so the next `ensure_arena` must refuse. This is the cap-1
+    /// backpressure signal the RSS bound rests on — if it returned `true` here
+    /// a second arena would be minted and the bound would be gone. Only the
+    /// success path was covered.
+    #[test]
+    fn ensure_arena_is_false_while_the_only_arena_is_in_flight() {
+        let records = descending_pos_records(64);
+        let mut sorter = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(8 * 1024 * 1024)
+            .threads(1)
+            .into_coordinate_chunk_sorter(&Header::default())
+            .expect("build chunk sorter");
+
+        assert!(sorter.ensure_arena(), "the fresh pool hands out its one arena");
+        for r in &records {
+            sorter.push(r).expect("push");
+        }
+        let chunk = sorter.take_sorted_chunk();
+
+        // The chunk is alive, so the arena has not returned to the pool.
+        assert!(!sorter.ensure_arena(), "capacity 1: no arena while the chunk holds it");
+        drop(chunk);
+        assert!(sorter.ensure_arena(), "and it is available again once the chunk drops");
+    }
+
+    /// The buffer-non-empty `false`, which is a *different* condition with the
+    /// opposite correct response: retrying cannot help until the buffer drains.
+    ///
+    /// It guards a correctness property, not just an optimisation — installing
+    /// an arena mid-fill replaces the backing store out from under records
+    /// already buffered, orphaning them. `push` calls `ensure_arena`
+    /// best-effort, so after the first record into a pool-less buffer the
+    /// buffer is non-empty and the refusal must hold.
+    #[test]
+    fn ensure_arena_is_false_mid_fill_so_the_backing_store_is_never_swapped() {
+        let records = descending_pos_records(4);
+        let mut sorter = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(8 * 1024 * 1024)
+            .threads(1)
+            .into_coordinate_chunk_sorter(&Header::default())
+            .expect("build chunk sorter");
+        let pool = Arc::clone(sorter.arena_pool());
+
+        // Drain the pool first so `push`'s best-effort acquire finds nothing and
+        // the fill lands in the buffer's default storage.
+        let held = pool.try_acquire().expect("take the only arena");
+        sorter.push(&records[0]).expect("push into the default storage");
+        assert!(!sorter.ensure_arena(), "pool empty AND buffer non-empty");
+
+        // Returning the arena is not enough: the buffer is now non-empty, so the
+        // refusal must persist for the mid-fill reason alone.
+        drop(held);
+        assert_eq!(pool.free_len(), 1, "the arena is back on the free list");
+        assert!(!sorter.ensure_arena(), "an available arena must still not be installed mid-fill",);
+
+        // Draining the buffer clears the condition.
+        drop(sorter.take_sorted_chunk());
+        assert!(sorter.ensure_arena(), "and once drained the arena installs");
+    }
+
+    /// A tiny memory limit forces mid-stream spill chunks; every chunk is a
+    /// sorted run and the union covers all records exactly once.
+    #[test]
+    fn tiny_limit_emits_multiple_sorted_chunks_covering_all_records() {
+        let records = descending_pos_records(2_000);
+        let mut sorter = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(16 * 1024) // tiny → frequent spills
+            .threads(2)
+            .into_coordinate_chunk_sorter(&Header::default())
+            .expect("build chunk sorter");
+
+        let mut chunks = Vec::new();
+        for r in &records {
+            if sorter.push(r).expect("push") {
+                let chunk = sorter.take_sorted_chunk();
+                assert!(!chunk.is_empty());
+                assert_chunk_sorted(&chunk);
+                chunks.push(chunk);
+            }
+        }
+        let residual = sorter.take_sorted_chunk();
+        if !residual.is_empty() {
+            assert_chunk_sorted(&residual);
+            chunks.push(residual);
+        }
+
+        assert!(chunks.len() >= 2, "tiny limit should force at least one spill plus residual");
+        // Assert identity, not just count: a spill path that drops record A and
+        // duplicates B keeps the total unchanged, so compare the multiset of
+        // record bytes across all chunks against the input.
+        let mut seen: Vec<Vec<u8>> = chunks
+            .iter()
+            .flat_map(|c| (0..c.len()).map(move |i| c.record_bytes(i).to_vec()))
+            .collect();
+        seen.sort();
+        let mut expected: Vec<Vec<u8>> = records.clone();
+        expected.sort();
+        assert_eq!(seen, expected, "chunk union must equal the input set (no drops/dups)");
+    }
+
+    /// Equal-key stability: when every record shares one coordinate, the global
+    /// stable `par_sort` must emit them in input order. This is the
+    /// output-identity-critical tie-break the single-residual design relies on
+    /// (vs samtools sort), so pin it directly — not just sortedness.
+    #[test]
+    fn equal_keys_preserve_input_order_within_chunk() {
+        // All at tid 0, pos 0 → identical coordinate key; distinct names make
+        // each record's bytes unique so input order is observable.
+        let records: Vec<Vec<u8>> = (0..400)
+            .map(|i| {
+                let name = format!("r{i:05}");
+                make_bam_bytes(0, 0, 0, name.as_bytes(), &[], 60, -1, -1, &[])
+            })
+            .collect();
+        let mut sorter = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(256 * 1024 * 1024)
+            .threads(2)
+            .into_coordinate_chunk_sorter(&Header::default())
+            .expect("build chunk sorter");
+        for r in &records {
+            assert!(!sorter.push(r).expect("push"));
+        }
+        let chunk = sorter.take_sorted_chunk();
+        assert_eq!(chunk.len(), records.len());
+        for (i, rec) in records.iter().enumerate() {
+            assert_eq!(
+                chunk.record_bytes(i),
+                rec.as_slice(),
+                "equal-key record {i} emerged out of input order"
+            );
+        }
+    }
+
+    /// `--key-types` is honored in the buffer path: dropping the tertiary (MI)
+    /// lane and then feeding a record whose MI differs from the first record's is
+    /// rejected with the same actionable error the batch `sort()` path produces.
+    /// (Pre-P6 the streaming production path skipped this validation entirely.)
+    #[test]
+    fn template_chunk_sorter_rejects_dropped_lane_violation() {
+        use crate::external::KeyTypesSpec;
+
+        // Raw BAM aux for `MI:i:<v>` (tag bytes + 'i' type + i32 LE value).
+        fn mi_aux(v: i32) -> Vec<u8> {
+            let mut a = vec![b'M', b'I', b'i'];
+            a.extend_from_slice(&v.to_le_bytes());
+            a
+        }
+
+        let mut sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+            .memory_limit(256 * 1024 * 1024)
+            .threads(1)
+            .key_types(KeyTypesSpec::None) // drop all optional lanes incl. tertiary/MI
+            .into_template_chunk_sorter(&Header::default())
+            .expect("build template chunk sorter");
+
+        let r1 = make_bam_bytes(0, 10, 0, b"r1", &[], 40, -1, -1, &mi_aux(1));
+        let r2 = make_bam_bytes(0, 10, 0, b"r2", &[], 40, -1, -1, &mi_aux(2));
+        assert!(!sorter.push(&r1).expect("first push provisions the variant"));
+        let err =
+            sorter.push(&r2).expect_err("a differing MI under --key-types none must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("MI") && msg.contains("--key-types mi"),
+            "unexpected dropped-lane error: {msg}"
+        );
+    }
+
+    /// With a consistent input (the dropped lanes are constant), `--key-types`
+    /// validation passes and the sort proceeds — the common case.
+    #[test]
+    fn template_chunk_sorter_accepts_constant_dropped_lanes() {
+        use crate::external::KeyTypesSpec;
+        let mut sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+            .memory_limit(256 * 1024 * 1024)
+            .threads(1)
+            .key_types(KeyTypesSpec::None)
+            .into_template_chunk_sorter(&Header::default())
+            .expect("build");
+        // No optional lanes present at all → nothing to violate.
+        for i in 0..200i32 {
+            let pos = 200 - i;
+            let rec = make_bam_bytes(0, pos, 0, format!("r{i}").as_bytes(), &[], 40, -1, -1, &[]);
+            sorter.push(&rec).expect("constant (absent) dropped lanes accepted");
+        }
+        assert_eq!(sorter.take_sorted_chunk().len(), 200);
+    }
+
+    /// Plain template records (no cell barcode, no MI, single library) under
+    /// `Auto` select the narrowest 3-lane [`TemplateKey24`] variant — confirming
+    /// the radix sort runs on the narrowed key, not the full key — while still
+    /// producing a correctly ordered chunk keyed by the full [`TemplateKey`].
+    #[test]
+    fn template_chunk_sorter_selects_narrow_variant_without_cb_or_mi() {
+        use crate::external::KeyTypesSpec;
+        let mut sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+            .memory_limit(256 * 1024 * 1024)
+            .threads(2)
+            .key_types(KeyTypesSpec::Auto)
+            .into_template_chunk_sorter(&Header::default())
+            .expect("build template chunk sorter");
+        assert!(sorter.chosen_variant().is_none(), "no variant before the first push");
+
+        // Descending positions on tid 0 → a correct sort reorders to ascending.
+        for i in 0..300i32 {
+            let pos = 300 - i;
+            let rec =
+                make_bam_bytes(0, pos, 0, format!("r{i:05}").as_bytes(), &[], 40, -1, -1, &[]);
+            sorter.push(&rec).expect("plain record accepted");
+        }
+
+        let variant = sorter.chosen_variant().expect("variant provisioned on first push");
+        assert_eq!(
+            variant.lanes(),
+            3,
+            "no cb / no MI / single library must narrow to the 3-lane TemplateKey24"
+        );
+
+        let chunk = sorter.take_sorted_chunk_owned();
+        assert_eq!(chunk.len(), 300, "every record retained");
+        for w in chunk.windows(2) {
+            assert!(
+                w[0].0.cmp(&w[1].0).is_le(),
+                "narrow-key sort must yield a full-key-ordered chunk"
+            );
+        }
+    }
+
+    /// Output-identity: the narrowed-key (3-lane `TemplateKey24`) sort must emit
+    /// byte-identical record order to the full-key (5-lane `TemplateKey40`) sort,
+    /// **including equal-key ties** — template-coordinate order is
+    /// output-identity-critical, so pin identity, not just sortedness. The input
+    /// deliberately contains records sharing a full template key (same tid / pos /
+    /// name) but differing in a non-key field (mapq), so a stable sort must keep
+    /// each tie group in input order under both key widths.
+    #[test]
+    fn template_chunk_sorter_narrow_matches_full_key_order() {
+        use crate::external::KeyTypesSpec;
+
+        let mut records: Vec<Vec<u8>> = Vec::new();
+        for i in 0..120i32 {
+            let pos = (i % 8) + 1; // 8 distinct positions → coordinate-level ties
+            let name = format!("t{:03}", i % 30); // 30 names → full-key ties within a pos
+            for seq_len in [20usize, 40usize] {
+                // Same (tid, pos, name) but distinct seq length → identical
+                // template key, distinct bytes: an observable equal-key tie.
+                records.push(make_bam_bytes(0, pos, 0, name.as_bytes(), &[], seq_len, -1, -1, &[]));
+            }
+        }
+
+        let sort_with = |key_types: KeyTypesSpec| -> (usize, Vec<Vec<u8>>) {
+            let mut sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+                .memory_limit(256 * 1024 * 1024)
+                .threads(2)
+                .key_types(key_types)
+                .into_template_chunk_sorter(&Header::default())
+                .expect("build template chunk sorter");
+            for r in &records {
+                sorter.push(r).expect("push");
+            }
+            let lanes = sorter.chosen_variant().expect("variant provisioned").lanes();
+            let out = sorter
+                .take_sorted_chunk_owned()
+                .into_iter()
+                .map(|(_, rec)| rec.as_ref().to_vec())
+                .collect();
+            (lanes, out)
+        };
+
+        let (narrow_lanes, narrow) = sort_with(KeyTypesSpec::Auto);
+        let (full_lanes, full) = sort_with(KeyTypesSpec::Full);
+        assert_eq!(narrow_lanes, 3, "Auto over cb/MI-free data must narrow to TemplateKey24");
+        assert_eq!(full_lanes, 5, "Full must force the 5-lane TemplateKey40");
+        assert_eq!(narrow.len(), records.len(), "every record retained");
+        assert_eq!(
+            narrow, full,
+            "narrowed-key sort must emit byte-identical record order (incl. equal-key ties) \
+             to the full-key sort"
+        );
+    }
+
+    /// Byte-parity oracle: the arena-backed production drain
+    /// (`take_sorted_chunk`, zero body copies) must produce byte-for-byte the
+    /// same sorted (full-key, body) sequence as the owned `materialize_full`
+    /// path (`take_sorted_chunk_owned`). Same records + the same deterministic stable
+    /// radix on two identical sorters ⇒ identical output, so any divergence in
+    /// the arena offset math, full-key re-extraction, or ordering fails here.
+    /// Exercises equal-key ties (same tid/pos/name, distinct seq length) under
+    /// both the narrowed (`Auto` → `TemplateKey24`) and full (`Full` →
+    /// `TemplateKey40`) key widths.
+    #[test]
+    fn template_arena_drain_matches_owned_materialize() {
+        use crate::external::KeyTypesSpec;
+
+        let mut records: Vec<Vec<u8>> = Vec::new();
+        for i in 0..120i32 {
+            let pos = (i % 8) + 1;
+            let name = format!("t{:03}", i % 30);
+            for seq_len in [20usize, 40usize] {
+                records.push(make_bam_bytes(0, pos, 0, name.as_bytes(), &[], seq_len, -1, -1, &[]));
+            }
+        }
+
+        let build = |key_types: KeyTypesSpec| {
+            RawExternalSorter::new(SortOrder::TemplateCoordinate)
+                .memory_limit(256 * 1024 * 1024)
+                .threads(2)
+                .key_types(key_types)
+                .into_template_chunk_sorter(&Header::default())
+                .expect("build template chunk sorter")
+        };
+
+        for key_types in [KeyTypesSpec::Auto, KeyTypesSpec::Full] {
+            let mut owned_sorter = build(key_types);
+            let mut arena_sorter = build(key_types);
+            for r in &records {
+                owned_sorter.push(r).expect("push owned");
+                arena_sorter.push(r).expect("push arena");
+            }
+            let owned = owned_sorter.take_sorted_chunk_owned();
+            let arena = arena_sorter.take_sorted_chunk();
+
+            assert_eq!(arena.len(), owned.len(), "record count must match ({key_types:?})");
+            assert_eq!(owned.len(), records.len(), "every record retained ({key_types:?})");
+            for (i, (key, rec)) in owned.iter().enumerate() {
+                assert_eq!(
+                    arena.key_at(i),
+                    key,
+                    "full key at {i} must match owned path ({key_types:?})"
+                );
+                assert_eq!(
+                    arena.record_bytes(i),
+                    rec.as_ref(),
+                    "record bytes at {i} must be byte-identical to owned path ({key_types:?})"
+                );
+            }
+        }
+    }
+
+    /// A worker copy must inherit the parent's provisioned lane variant.
+    ///
+    /// `fresh()` builds the per-worker copy of the arena front. Provisioning
+    /// (variant + dropped-lane baseline) is meant to happen once per sort, but
+    /// `fresh()` used to reset it to `None`, which has three consequences once
+    /// there is more than one worker: each `Auto` worker re-selects a lane from
+    /// its own first record, so two workers in one sort can emit different key
+    /// widths; each validates dropped lanes against its own baseline, so a lane
+    /// that varies only *across* workers goes unnoticed; and a worker that
+    /// receives no records seals to `K40` regardless of what the others chose.
+    ///
+    /// The empty worker is the sharpest of the three to assert, because it
+    /// isolates the inheritance: it pushes nothing, so any variant it reports
+    /// can only have come from the parent.
+    #[test]
+    #[allow(unsafe_code)]
+    fn fresh_worker_copy_inherits_the_provisioned_variant() {
+        use crate::arena_pool::PooledSegmentedBuf;
+        use crate::external::KeyTypesSpec;
+        use crate::segmented_buf::SegmentedBuf;
+        use crate::template_arena::{TemplateArenaAccumulator, TemplateMemChunk};
+        use std::sync::Arc;
+
+        let rec = make_bam_bytes(0, 1, 0, b"t000", &[], 20, -1, -1, &[]);
+        let mut parent =
+            TemplateArenaAccumulator::from_header(&Header::default(), None, KeyTypesSpec::Auto);
+
+        let mut arena = SegmentedBuf::with_capacity(0, 1 << 20);
+        arena.reserve_full_capacity();
+        // SAFETY: the slot is fully written (copy_from_slice) before any read.
+        let off = unsafe { arena.grow_uninit(rec.len()) };
+        unsafe { arena.slice_mut(off, rec.len()) }.copy_from_slice(&rec);
+        parent.push(&rec, off as u64, u32::try_from(rec.len()).unwrap()).expect("parent push");
+
+        // Clone the worker AFTER the parent is provisioned — the order the
+        // "provision once per sort" contract requires.
+        let mut worker = parent.fresh();
+
+        let parent_chunk = parent.seal(Arc::new(PooledSegmentedBuf::unpooled(arena)), 1);
+        assert!(
+            matches!(parent_chunk, TemplateMemChunk::K24(_)),
+            "precondition: this record must make `Auto` select the narrow K24 lane",
+        );
+
+        // The worker received no records. Without inheritance it falls back to
+        // K40 and the sort emits two different key widths.
+        let worker_chunk = worker.seal(
+            Arc::new(PooledSegmentedBuf::unpooled(SegmentedBuf::with_capacity(0, 1 << 20))),
+            1,
+        );
+        assert!(
+            matches!(worker_chunk, TemplateMemChunk::K24(_)),
+            "an empty worker must seal to the parent's lane, not fall back to K40",
+        );
+        assert_eq!(worker_chunk.len(), 0, "and it is still empty");
+    }
+
+    /// Worker copies must share ONE bounded sort pool, not build one each.
+    ///
+    /// The pool exists to keep the radix + gather on exactly `sort_threads`
+    /// threads instead of the global rayon pool, so that a spill does not
+    /// oversubscribe the pipeline's own workers. `sort_threads` is only known at
+    /// the first `seal`, which is *after* `fresh()` has made the copies — so if
+    /// each copy held its own holder, N workers would build N pools and put
+    /// `N × sort_threads` threads on the box, reintroducing the very
+    /// oversubscription the pool prevents, one level up.
+    ///
+    /// Asserted by pointer identity: both copies must hand back the same pool.
+    #[test]
+    fn worker_copies_share_one_bounded_sort_pool() {
+        use crate::external::KeyTypesSpec;
+        use crate::template_arena::TemplateArenaAccumulator;
+
+        let parent =
+            TemplateArenaAccumulator::from_header(&Header::default(), None, KeyTypesSpec::Auto);
+        let mut a = parent.fresh();
+        let mut b = parent.fresh();
+
+        // Sealing an unprovisioned accumulator returns early without touching the
+        // pool, so drive the pool getter directly.
+        let pa = std::ptr::from_ref(a.sort_pool_for_test(2));
+        let pb = std::ptr::from_ref(b.sort_pool_for_test(2));
+        assert!(
+            std::ptr::eq(pa, pb),
+            "worker copies must share one pool; separate pools mean N x sort_threads threads",
+        );
+    }
+
+    /// Byte-parity: the arena-front `TemplateArenaAccumulator` must produce the
+    /// same sorted (full-key, body) sequence as the owned `TemplateChunkSorter`
+    /// — same library/CB provisioning, same `--key-types` narrowed-lane radix,
+    /// same full-key re-extraction — for a mix of tied and distinct keys, under
+    /// both the narrowed (`Auto` → `TemplateKey24`) and full (`Full` →
+    /// `TemplateKey40`) widths. This pins the arena front (Inc 3) to the legacy
+    /// path before it is wired into the pipeline.
+    #[test]
+    #[allow(unsafe_code)]
+    fn template_arena_accumulator_matches_owned_sorter() {
+        use crate::arena_pool::PooledSegmentedBuf;
+        use crate::external::KeyTypesSpec;
+        use crate::segmented_buf::SegmentedBuf;
+        use crate::template_arena::TemplateArenaAccumulator;
+        use std::sync::Arc;
+
+        let mut records: Vec<Vec<u8>> = Vec::new();
+        for i in 0..120i32 {
+            let pos = (i % 8) + 1;
+            let name = format!("t{:03}", i % 30);
+            for seq_len in [20usize, 40usize] {
+                records.push(make_bam_bytes(0, pos, 0, name.as_bytes(), &[], seq_len, -1, -1, &[]));
+            }
+        }
+
+        for key_types in [KeyTypesSpec::Auto, KeyTypesSpec::Full] {
+            // ---- Owned oracle ----
+            let mut owned = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+                .memory_limit(256 * 1024 * 1024)
+                .threads(2)
+                .key_types(key_types)
+                .into_template_chunk_sorter(&Header::default())
+                .expect("build owned template sorter");
+            for r in &records {
+                owned.push(r).expect("owned push");
+            }
+            let owned_chunk = owned.take_sorted_chunk_owned();
+
+            // ---- Arena accumulator (bodies resident in a shared arena) ----
+            let mut arena = SegmentedBuf::with_capacity(0, 1 << 20);
+            arena.reserve_full_capacity();
+            let mut acc =
+                TemplateArenaAccumulator::from_header(&Header::default(), None, key_types);
+            for r in &records {
+                // SAFETY: each slot is fully written (copy_from_slice) before any read.
+                let off = unsafe { arena.grow_uninit(r.len()) };
+                unsafe { arena.slice_mut(off, r.len()) }.copy_from_slice(r);
+                acc.push(r, off as u64, u32::try_from(r.len()).unwrap()).expect("arena push");
+            }
+            let arena_arc = Arc::new(PooledSegmentedBuf::unpooled(arena));
+            let arena_chunk = acc.seal(arena_arc, 2);
+
+            assert_eq!(arena_chunk.len(), owned_chunk.len(), "record count ({key_types:?})");
+            assert_eq!(owned_chunk.len(), records.len(), "every record retained ({key_types:?})");
+            // Byte-parity is the invariant: the arena chunk's records, in sorted
+            // order, must be byte-identical to the owned oracle's. The arena chunk
+            // now carries the chosen narrow lane key (variant-agnostic here), and
+            // narrow-lane order equals full-key order, so record order matches the
+            // owned full-key sort exactly.
+            for (i, (_key, rec)) in owned_chunk.iter().enumerate() {
+                assert_eq!(
+                    arena_chunk.record_bytes(i),
+                    rec.as_ref(),
+                    "record body at {i} must be byte-identical to owned path ({key_types:?})"
+                );
+            }
+        }
+    }
+
+    /// An empty template stream never builds a buffer and yields an empty
+    /// residual (the lazy `Option<TemplateBuffer>` stays `None`).
+    #[test]
+    fn template_chunk_sorter_empty_stream_yields_empty_residual() {
+        use crate::external::KeyTypesSpec;
+        let mut sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+            .memory_limit(256 * 1024 * 1024)
+            .threads(1)
+            .key_types(KeyTypesSpec::Auto)
+            .into_template_chunk_sorter(&Header::default())
+            .expect("build template chunk sorter");
+        assert!(sorter.take_sorted_chunk().is_empty());
+        assert_eq!(sorter.total_records(), 0);
+        assert!(sorter.chosen_variant().is_none(), "no push → no variant");
+    }
+
+    /// An empty stream yields an empty residual (the caller emits no chunk).
+    #[test]
+    fn empty_stream_yields_empty_residual() {
+        let mut sorter = RawExternalSorter::new(SortOrder::Coordinate)
+            .memory_limit(256 * 1024 * 1024)
+            .threads(1)
+            .into_coordinate_chunk_sorter(&Header::default())
+            .expect("build chunk sorter");
+        assert!(sorter.take_sorted_chunk().is_empty());
+        assert_eq!(sorter.total_records(), 0);
+    }
+}

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -32,6 +32,7 @@ use crate::keys::{QuerynameComparator, RawSortKey, SortOrder};
 use crate::memory_probe::{
     BufferProbeStats, ConsumerProbeStats, MergeProbe, SpillProbe, force_mi_collect, log_snapshot,
 };
+use crate::merge_slots::SortMergeSlot;
 use crate::pooled_chunk_writer::PooledChunkWriter;
 use crate::read_ahead::{PooledInputStream, RawReadAheadReader, RecordSource};
 use crate::tmp_dir_alloc::TmpDirAllocator;
@@ -61,7 +62,7 @@ use tempfile::TempDir;
 /// Maximum number of records held in one in-memory chunk.
 ///
 /// Each key carries its ingest position within the chunk (see
-/// [`RawSortKey::set_position`](crate::keys::RawSortKey::set_position)) so that
+/// [`RawSortKey::set_position`]) so that
 /// the key is a *total* order and the chunk sort can be unstable. That position
 /// is a `u32`, so a chunk that grew past `u32::MAX` records would have to stamp
 /// two records with the same position — exact name/flag ties would stop being
@@ -479,6 +480,7 @@ fn process_umask() -> u32 {
 ///
 /// Pre-computes ordinals by sorting library names alphabetically.
 /// Empty/unknown library sorts first (ordinal 0).
+#[derive(Clone)]
 pub struct LibraryLookup {
     /// RG ID -> library ordinal
     rg_to_ordinal: HashMap<Vec<u8>, u32>,
@@ -1038,8 +1040,11 @@ impl<K: RawSortKey + 'static> GenericKeyedChunkReader<K> {
 /// individual `RawRecord`s and produces `Owned` chunks — the
 /// per-record allocation is sunk cost, so we preserve the original
 /// zero-copy `mem::swap` merge bridge.
-pub(crate) enum MemorySources<K: RawSortKey + Default + 'static> {
+pub enum MemorySources<K: RawSortKey + Default + 'static> {
+    /// Inline-buffer (coordinate / template) residual chunks sharing an
+    /// `Arc<SegmentedBuf>` — zero per-record allocation.
     Shared(Vec<InMemoryChunk<K>>),
+    /// Queryname-style residual chunks (each record an owned `RawRecord`).
     Owned(Vec<Vec<(K, fgumi_raw_bam::RawRecord)>>),
 }
 
@@ -1753,6 +1758,141 @@ impl<K: RawSortKey + 'static> Drop for Phase2Guard<'_, K> {
 }
 
 impl RawExternalSorter {
+    /// The configured sort order. Read by the typed-step `SortAndSpill` adapter
+    /// to pick the matching `*SortStream` variant.
+    #[must_use]
+    pub fn sort_order(&self) -> SortOrder {
+        self.sort_order
+    }
+
+    /// The configured cell-barcode tag (template-coordinate CB hashing), if any.
+    /// Read when building a record-input arena strategy so it matches the
+    /// block-input template strategy exactly.
+    #[must_use]
+    pub fn cell_tag_value(&self) -> Option<SamTag> {
+        self.cell_tag
+    }
+
+    /// The configured `--key-types` narrowing spec (template-coordinate only).
+    #[must_use]
+    pub fn key_types_spec(&self) -> KeyTypesSpec {
+        self.key_types
+    }
+
+    /// The configured in-memory sort budget in bytes (per-run seal threshold).
+    #[must_use]
+    pub fn memory_limit_bytes(&self) -> usize {
+        self.memory_limit
+    }
+
+    /// The configured base thread count (`--threads`).
+    ///
+    /// NOT the Phase-1 sort width — that is `phase1_threads()`, which applies
+    /// the `--sort-threads` override. Reading this as the sort width is the
+    /// D1.1 regression, pinned by `test_raw_sorter_phase_threads_builders`.
+    #[must_use]
+    pub fn num_threads(&self) -> usize {
+        self.threads
+    }
+
+    /// Convert this configured sorter into a lean coordinate buffering sorter
+    /// for the P6 `SortBuffer` step.
+    ///
+    /// Same buffer sizing / rayon pool as the retired `into_coordinate_stream`,
+    /// but with **no** `SortWorkerPool`, temp dirs, or spill files — the
+    /// `SortBuffer` step only ingests + par-sorts + materializes chunks; the
+    /// `CompressSpill` step owns compression and disk I/O.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `self.sort_order` is not `Coordinate`, the reference
+    /// count exceeds `u32::MAX`, or the rayon sort pool cannot be built.
+    pub fn into_coordinate_chunk_sorter(
+        self,
+        header: &Header,
+    ) -> Result<crate::chunk_sorter::CoordinateChunkSorter> {
+        anyhow::ensure!(
+            matches!(self.sort_order, SortOrder::Coordinate),
+            "into_coordinate_chunk_sorter requires SortOrder::Coordinate (got {:?})",
+            self.sort_order,
+        );
+        let rayon_pool = self.build_sort_rayon_pool()?;
+        let nref = u32::try_from(header.reference_sequences().len())
+            .context("reference sequence count exceeds u32::MAX")?;
+        let init_cap = self.effective_initial_capacity();
+        // Per-record footprint estimate matches `into_coordinate_stream`.
+        let estimated_records = init_cap / 240;
+        // The record *bodies* arena comes from the `ArenaPool` on the first
+        // `ensure_arena`, so no data-byte capacity is requested here. That is not
+        // the same as allocating nothing: `with_capacity` still sizes the segment
+        // for the inline headers (`estimated_records * HEADER_SIZE`), and
+        // `install_arena` replaces and drops that buffer when the pooled arena
+        // lands. Transient header storage, in other words — not zero.
+        let buffer = RecordBuffer::with_capacity(estimated_records, 0, nref);
+        // Bounded reusable-arena pool (lever-1 RSS fix). Capacity 1 = legacy's
+        // one-arena-at-a-time footprint: the next chunk cannot fill until the
+        // prior chunk is spilled and its arena returns, bounding peak RSS to
+        // ~one arena ≈ base. (Tunable via `--sort-arenas` in a later increment.)
+        let arena_pool = crate::arena_pool::ArenaPool::new(1, crate::inline::SORT_SEGMENT_SIZE);
+        Ok(crate::chunk_sorter::CoordinateChunkSorter::new(
+            buffer,
+            rayon_pool,
+            self.memory_limit,
+            arena_pool,
+        ))
+    }
+
+    /// Convert this configured sorter into a lean template-coordinate buffering
+    /// sorter for the P6 `SortBuffer` step (the template analogue of
+    /// [`Self::into_coordinate_chunk_sorter`] — same sizing as the retired
+    /// `into_template_coordinate_stream`, minus the pool/temp-dirs).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `self.sort_order` is not `TemplateCoordinate` or the
+    /// rayon sort pool cannot be built.
+    pub fn into_template_chunk_sorter(
+        self,
+        header: &Header,
+    ) -> Result<crate::chunk_sorter::TemplateChunkSorter> {
+        anyhow::ensure!(
+            matches!(self.sort_order, SortOrder::TemplateCoordinate),
+            "into_template_chunk_sorter requires SortOrder::TemplateCoordinate (got {:?})",
+            self.sort_order,
+        );
+        let rayon_pool = self.build_sort_rayon_pool()?;
+        let lib_lookup = LibraryLookup::from_header(header);
+        let header_library_varies = lib_lookup.distinct_header_ordinals() > 1;
+        let cb_hasher = cb_hasher();
+        // Capacity hints for the lazily-built narrowed-key buffer, derived the
+        // SAME way as `sort_template_coordinate_impl` so the two move together
+        // when `EST_BAM_BYTES_PER_TEMPLATE_RECORD` changes. That sibling is
+        // pinned by `estimator_bytes_per_record_matches_ref_size`; a hardcoded
+        // number here would drift silently past it.
+        //
+        // The variant — and so the exact key width — is not known until the first
+        // record, so this uses the WIDEST ref (`TemplateKey40`, 56 B). Over-
+        // estimating bytes-per-record under-estimates the record count, which
+        // only under-sizes a capacity hint: the safe direction.
+        let ref_bytes = std::mem::size_of::<TemplateRecordRef<TemplateKey40>>();
+        let data_bytes_per_record = TEMPLATE_HEADER_SIZE + EST_BAM_BYTES_PER_TEMPLATE_RECORD;
+        let bytes_per_record = data_bytes_per_record + ref_bytes;
+        let init_cap = self.effective_initial_capacity();
+        let estimated_records = (init_cap / bytes_per_record).max(1);
+        let estimated_data_bytes = init_cap * data_bytes_per_record / bytes_per_record;
+        Ok(crate::chunk_sorter::TemplateChunkSorter::new(
+            rayon_pool,
+            self.memory_limit,
+            estimated_records,
+            estimated_data_bytes,
+            lib_lookup,
+            cb_hasher,
+            self.cell_tag,
+            self.key_types,
+            header_library_varies,
+        ))
+    }
+
     /// Create a new raw external sorter with the given sort order.
     #[must_use]
     pub fn new(sort_order: SortOrder) -> Self {
@@ -1835,6 +1975,10 @@ impl RawExternalSorter {
     }
 
     /// Effective Phase-1 worker count: `sort_threads` if set, else `threads`.
+    ///
+    /// Public so the streaming arena front (`SortBuffer::from_sorter`) sizes its
+    /// per-chunk sort with the resolved `--sort-threads` override rather than the
+    /// raw base `--threads` (`num_threads`), which silently ignores the override.
     #[must_use]
     pub fn phase1_threads(&self) -> usize {
         self.sort_threads.unwrap_or(self.threads).max(1)
@@ -3766,6 +3910,22 @@ impl RawExternalSorter {
         super::create_output_header(self.sort_order, header)
     }
 
+    /// Create the spill temp dirs + allocator for the P6 `CompressSpill` step.
+    ///
+    /// Public wrapper over `Self::create_temp_dirs`: honors `--temp-dir` /
+    /// `FGUMI_TMP_DIRS` (the configured `temp_dirs`) exactly as the legacy
+    /// streaming path does. The caller hands the [`Vec<TempDir>`] RAII handles to
+    /// `CompressSpill` (held for the step's lifetime) and the [`TmpDirAllocator`]
+    /// behind a shared mutex for per-file base-dir allocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a temp directory cannot be created or has insufficient
+    /// free space.
+    pub fn create_spill_dirs(&self) -> Result<(Vec<TempDir>, TmpDirAllocator)> {
+        self.create_temp_dirs()
+    }
+
     /// Create per-base temp directories and an allocator over their subdirs.
     ///
     /// For each user-supplied base directory, a fresh sort-run subdirectory is
@@ -4256,7 +4416,7 @@ pub fn verify_dropped_lanes(
 }
 
 /// Build the actionable error message for a dropped-lane violation.
-fn dropped_lane_error(name: &str, v: DroppedLaneViolation) -> anyhow::Error {
+pub(crate) fn dropped_lane_error(name: &str, v: DroppedLaneViolation) -> anyhow::Error {
     let field = match v {
         DroppedLaneViolation::Cb => "CB",
         DroppedLaneViolation::Mi => "MI",
@@ -4267,6 +4427,668 @@ fn dropped_lane_error(name: &str, v: DroppedLaneViolation) -> anyhow::Error {
          re-run with --key-types {}",
         v.key_types_token(),
     )
+}
+
+/// Open `path` as a single [`SortMergeSlot`] with the given `file_id`.
+///
+/// The spill codec is auto-detected from the file magic: for zstd (`ZSP1`) the
+/// 4-byte magic is consumed here, leaving the reader at the first `[len][frame]`
+/// record; for BGZF the `1f 8b` is part of the first block, so the reader is
+/// rewound to byte 0. `SortSpillDecompress` reads `slot.codec` to decompress
+/// accordingly.
+///
+/// `file_id` is the slot's stable merge-order identifier — `SortMerge` orders
+/// sources by it so the `LoserTree` tie-break for equal sort keys matches the
+/// legacy chunk-files order. The P6 `CompressSpill` step passes a chunk's
+/// **logical spill index** here so the tie-break is independent of which worker
+/// happened to write the file.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be opened, its magic cannot be read, or
+/// (for BGZF) the rewind fails.
+pub fn open_spill_slot(path: &std::path::Path, file_id: u32) -> Result<Arc<SortMergeSlot>> {
+    let mut file = std::fs::File::open(path)
+        .with_context(|| format!("failed to open spill chunk {}", path.display()))?;
+    let mut magic = [0u8; 4];
+    let filled = read_exact_or_eof(&mut file, &mut magic)
+        .with_context(|| format!("failed to read spill chunk magic {}", path.display()))?;
+    let codec = if filled {
+        crate::codec::SpillCodec::from_magic(&magic).unwrap_or(crate::codec::SpillCodec::Bgzf)
+    } else {
+        crate::codec::SpillCodec::Bgzf
+    };
+    if matches!(codec, crate::codec::SpillCodec::Bgzf) {
+        use std::io::Seek;
+        file.seek(std::io::SeekFrom::Start(0))
+            .with_context(|| format!("failed to rewind spill chunk {}", path.display()))?;
+    }
+    let reader = std::io::BufReader::new(file);
+    Ok(Arc::new(SortMergeSlot::new(file_id, reader, codec)))
+}
+
+// ============================================================================
+// CoordinateSortStream — streaming coordinate-sort handle
+// ============================================================================
+
+// ============================================================================
+// QuerynameSortStream — streaming queryname-sort handle (lex or natural)
+// ============================================================================
+
+// ============================================================================
+// TemplateCoordinateSortStream — streaming template-coordinate-sort handle
+// ============================================================================
+
+// ============================================================================
+// Streaming-sort merge path (unified pipeline `SortMerge` step)
+// ============================================================================
+//
+// Ported from the issue-#330 branch onto main's sort engine. This is the
+// slot-backed, *non-blocking* merge driver used exclusively by the typed-step
+// pipeline (`MergeDriver::from_slots`). It reads records out of
+// `SortMergeSlot` queues, which the `SortSpillDecompress` step has *already*
+// filled with decompressed `Vec<u8>` blocks — so this path is **codec-agnostic**
+// (it never touches disk or the spill codec) and carries no chunk-corruption
+// risk. The eager pool-integrated `MergeDriver::new` path from #330 is
+// intentionally NOT ported: standalone `fgumi sort` uses main's own
+// `merge_chunks_*` engine, and the pipeline only ever calls `from_slots`.
+
+/// Result of a non-blocking source read. `WouldBlock` is only ever produced by
+/// `Slot` sources whose decompressed queue is momentarily empty and not yet at
+/// EOF; the in-memory source always returns `Ready`.
+pub(crate) enum TryRead<K> {
+    /// A record was read (`Some`) or the source is at clean EOF (`None`).
+    Ready(Option<K>),
+    /// The source has no bytes available right now but is not at EOF; the
+    /// caller should yield and retry on a later dispatch.
+    WouldBlock,
+}
+
+/// Per-slot byte-stream parser state for the non-blocking merge reader.
+///
+/// As decompressed blocks are popped from a `SortMergeSlot`, their bytes are
+/// stashed in `current_buf` and consumed left-to-right by the record parser.
+/// Named distinctly from main's own `SourceParserState` (the pool-merge path)
+/// because this one additionally carries resumable cross-block framing state.
+struct SlotParserState {
+    /// Current decompressed block being consumed.
+    current_buf: Vec<u8>,
+    /// Read position within `current_buf`.
+    current_pos: usize,
+    /// Resumable framing state for [`slot_try_next_record`]. `Some` while a
+    /// record spans a block boundary and the next block was not yet available,
+    /// so the read returned `WouldBlock` mid-record; the next call resumes from
+    /// here.
+    pending: Option<PendingRecord>,
+}
+
+/// Partially-read record, retained across a `WouldBlock` so the non-blocking
+/// slot reader can resume. The wire layout is `[key:ksize][len:4][body:len]`
+/// for non-embedded keys (`ksize = K::SERIALIZED_SIZE`) and `[len:4][body:len]`
+/// for embedded keys (`ksize = 0`, key extracted from the body). We collect the
+/// key prefix (if any), then the length prefix, then the body.
+#[derive(Default)]
+struct PendingRecord {
+    /// Expected serialized key size (`0` for embedded keys).
+    key_size: usize,
+    /// Key-prefix bytes collected so far (length grows to `key_size`).
+    key_buf: Vec<u8>,
+    /// Length-prefix bytes collected so far (`0..=4`).
+    len_buf: [u8; 4],
+    /// Count of `len_buf` bytes filled.
+    len_got: usize,
+    /// Total body length, known once `len_got == 4`. The body accumulates
+    /// directly into the caller's record buffer; progress is `out.len()`.
+    body_len: Option<usize>,
+}
+
+impl SlotParserState {
+    fn new() -> Self {
+        Self { current_buf: Vec::new(), current_pos: 0, pending: None }
+    }
+
+    fn remaining(&self) -> usize {
+        self.current_buf.len() - self.current_pos
+    }
+}
+
+/// Outcome of a non-blocking attempt to pull the next decompressed block from a
+/// slot into `parser.current_buf`.
+enum BlockLoad {
+    /// A block was moved into `parser.current_buf`.
+    Loaded,
+    /// The slot is fully delivered (queue empty AND `queue_eof`).
+    Eof,
+    /// The queue is empty but the producer is still feeding this slot.
+    WouldBlock,
+}
+
+/// Pop one decompressed block (FIFO) into `parser`, surfacing a decompression
+/// error in preference to EOF, reporting clean EOF, or `WouldBlock` while the
+/// producer is still active. Never parks.
+fn slot_try_load_block(
+    slot: &Arc<crate::merge_slots::SortMergeSlot>,
+    parser: &mut SlotParserState,
+) -> Result<BlockLoad> {
+    use std::sync::atomic::Ordering;
+
+    let mut guard = slot.decompressed.lock().expect("slot.decompressed mutex poisoned");
+    if let Some(data) = guard.pop_front() {
+        drop(guard);
+        parser.current_buf = data;
+        parser.current_pos = 0;
+        return Ok(BlockLoad::Loaded);
+    }
+    // Queue empty. Both atomics are visible under the lock release-acquire
+    // chain (producer stores them while holding this same mutex). Surface
+    // error in preference to EOF.
+    if slot.decomp_error.load(Ordering::Acquire) {
+        drop(guard);
+        anyhow::bail!("spill decompression error on slot {}", slot.file_id);
+    }
+    if slot.queue_eof.load(Ordering::Acquire) {
+        return Ok(BlockLoad::Eof);
+    }
+    Ok(BlockLoad::WouldBlock)
+}
+
+/// Serialized key size on the wire for a slot source: `0` for embedded keys
+/// (key extracted from the body), else `K::SERIALIZED_SIZE`. Variable-length
+/// non-embedded keys are unsupported on the slot path (none exist in
+/// production — every slot-path key is embedded).
+fn slot_key_size<K: RawSortKey>() -> Result<usize> {
+    if K::EMBEDDED_IN_RECORD {
+        Ok(0)
+    } else {
+        K::SERIALIZED_SIZE.ok_or_else(|| {
+            anyhow::anyhow!("non-embedded slot key must have a fixed serialized size")
+        })
+    }
+}
+
+/// Parse a sort key from `bytes`: extracted from the body for embedded keys, or
+/// deserialized from the `key_size`-byte prefix for non-embedded keys.
+fn slot_parse_key<K: RawSortKey + Default + 'static>(key_bytes: &[u8], body: &[u8]) -> Result<K> {
+    if K::EMBEDDED_IN_RECORD {
+        // An embedded key is read out of the body, so an empty body cannot
+        // carry one. Every extractor indexes straight into the slice
+        // (`RawCoordinateKey` reads `ref_id` off the front), so without this an
+        // empty body panics mid-merge instead of surfacing a corrupt-slot
+        // error — and it is reachable: a corrupt length prefix of 0 makes the
+        // body loop break immediately with `out` still empty.
+        //
+        // This is a floor, not a full bounds check. The minimum body an
+        // extractor needs is key-specific (8 bytes here, 16 for the coordinate
+        // key, more for queryname), and `RawSortKey` does not expose it, so a
+        // corrupt *small but non-zero* length can still panic inside an
+        // extractor. Closing that needs a per-key minimum on the trait.
+        anyhow::ensure!(
+            !body.is_empty(),
+            "record body is empty and cannot carry an embedded sort key (corrupt slot)",
+        );
+        Ok(K::extract_from_record(body))
+    } else {
+        let mut r = key_bytes;
+        K::read_from(&mut r).map_err(|e| anyhow::anyhow!("malformed slot key: {e}"))
+    }
+}
+
+/// Non-blocking, resumable read of the next record from a slot.
+///
+/// Returns `Ready(Some(key))` with the record body in `out`, `Ready(None)` at
+/// clean source EOF, or `WouldBlock` when a needed block is not yet available
+/// (progress is saved in `parser.pending` so the next call resumes).
+///
+/// # Errors
+///
+/// Truncation (EOF mid-record), a malformed key, or a producer-side
+/// decompression error.
+fn slot_try_next_record<K: RawSortKey + Default + 'static>(
+    slot: &Arc<crate::merge_slots::SortMergeSlot>,
+    parser: &mut SlotParserState,
+    out: &mut Vec<u8>,
+) -> Result<TryRead<K>> {
+    let key_size = slot_key_size::<K>()?;
+
+    if parser.pending.is_none() {
+        // Ensure at least one byte is available, or detect clean EOF at a
+        // record boundary.
+        if parser.remaining() == 0 {
+            match slot_try_load_block(slot, parser)? {
+                BlockLoad::Loaded => {}
+                BlockLoad::Eof => return Ok(TryRead::Ready(None)),
+                BlockLoad::WouldBlock => return Ok(TryRead::WouldBlock),
+            }
+        }
+        // Fast path: the entire record lives in the current block → parse in
+        // place with a single copy of the body into `out`.
+        let header = key_size + 4;
+        if parser.remaining() >= header {
+            let p = parser.current_pos;
+            let len = u32::from_le_bytes(
+                parser.current_buf[p + key_size..p + header].try_into().expect("4-byte slice"),
+            ) as usize;
+            if parser.remaining() >= header + len {
+                out.clear();
+                out.extend_from_slice(&parser.current_buf[p + header..p + header + len]);
+                let key = slot_parse_key::<K>(&parser.current_buf[p..p + key_size], out)?;
+                parser.current_pos += header + len;
+                return Ok(TryRead::Ready(Some(key)));
+            }
+        }
+        // Slow path: record spans a block boundary (or fewer than `header`
+        // bytes remain). Begin a resumable pending record.
+        parser.pending = Some(PendingRecord { key_size, ..PendingRecord::default() });
+    }
+
+    slot_collect_pending::<K>(slot, parser, out)
+}
+
+/// Resumable continuation of [`slot_try_next_record`]'s slow path. Collects the
+/// key prefix (if any), the 4-byte length prefix, then the body across as many
+/// blocks as needed, returning `WouldBlock` (state retained in
+/// `parser.pending`) whenever the next block isn't ready yet.
+fn slot_collect_pending<K: RawSortKey + Default + 'static>(
+    slot: &Arc<crate::merge_slots::SortMergeSlot>,
+    parser: &mut SlotParserState,
+    out: &mut Vec<u8>,
+) -> Result<TryRead<K>> {
+    // Stage 0: key prefix (non-embedded keys only; `key_size == 0` is a no-op).
+    loop {
+        let (key_size, key_have) = {
+            let pending = parser.pending.as_ref().expect("pending set");
+            (pending.key_size, pending.key_buf.len())
+        };
+        let need = key_size - key_have;
+        if need == 0 {
+            break;
+        }
+        if parser.current_pos == parser.current_buf.len() {
+            match slot_try_load_block(slot, parser)? {
+                BlockLoad::Loaded => {}
+                BlockLoad::Eof => anyhow::bail!(
+                    "truncated record key in slot {} ({key_have} of {key_size} key bytes at EOF)",
+                    slot.file_id,
+                ),
+                BlockLoad::WouldBlock => return Ok(TryRead::WouldBlock),
+            }
+        }
+        let avail = parser.current_buf.len() - parser.current_pos;
+        let take = need.min(avail);
+        let src = &parser.current_buf[parser.current_pos..parser.current_pos + take];
+        parser.pending.as_mut().expect("pending set").key_buf.extend_from_slice(src);
+        parser.current_pos += take;
+    }
+
+    // Stage 1: length prefix.
+    loop {
+        let len_got = parser.pending.as_ref().expect("pending set").len_got;
+        if len_got == 4 {
+            break;
+        }
+        if parser.current_pos == parser.current_buf.len() {
+            match slot_try_load_block(slot, parser)? {
+                BlockLoad::Loaded => {}
+                BlockLoad::Eof => anyhow::bail!(
+                    "truncated record length in slot {} ({len_got} of 4 length bytes at EOF)",
+                    slot.file_id,
+                ),
+                BlockLoad::WouldBlock => return Ok(TryRead::WouldBlock),
+            }
+        }
+        let avail = parser.current_buf.len() - parser.current_pos;
+        let take = (4 - len_got).min(avail);
+        let src = &parser.current_buf[parser.current_pos..parser.current_pos + take];
+        let pending = parser.pending.as_mut().expect("pending set");
+        pending.len_buf[len_got..len_got + take].copy_from_slice(src);
+        pending.len_got += take;
+        parser.current_pos += take;
+    }
+
+    // Compute body length once and reset `out` for accumulation.
+    {
+        let pending = parser.pending.as_mut().expect("pending set");
+        if pending.body_len.is_none() {
+            let len = u32::from_le_bytes(pending.len_buf) as usize;
+            // The prefix is untrusted — it comes straight off a decompressed
+            // spill block — and the next statement hands it to `reserve`, which
+            // answers an allocation failure by aborting the process rather than
+            // returning an error. Bound it first, so a corrupt slot surfaces
+            // `Err` like the `decomp_error` and truncation arms do. The ceiling
+            // is the one a single record already cannot exceed: a record must
+            // fit within one sort segment (see `SORT_SEGMENT_SIZE`).
+            anyhow::ensure!(
+                len <= crate::inline::SORT_SEGMENT_SIZE,
+                "implausible record length {len} in slot {} (exceeds the \
+                 {}-byte segment a single record must fit in)",
+                slot.file_id,
+                crate::inline::SORT_SEGMENT_SIZE,
+            );
+            pending.body_len = Some(len);
+            out.clear();
+            out.reserve(len);
+        }
+    }
+
+    // Stage 2: body.
+    loop {
+        let body_len = parser.pending.as_ref().expect("pending set").body_len.expect("len known");
+        if out.len() >= body_len {
+            break;
+        }
+        if parser.current_pos == parser.current_buf.len() {
+            match slot_try_load_block(slot, parser)? {
+                BlockLoad::Loaded => {}
+                BlockLoad::Eof => anyhow::bail!(
+                    "truncated record body in slot {} ({} of {body_len} bytes at EOF)",
+                    slot.file_id,
+                    out.len(),
+                ),
+                BlockLoad::WouldBlock => return Ok(TryRead::WouldBlock),
+            }
+        }
+        let avail = parser.current_buf.len() - parser.current_pos;
+        let take = (body_len - out.len()).min(avail);
+        out.extend_from_slice(&parser.current_buf[parser.current_pos..parser.current_pos + take]);
+        parser.current_pos += take;
+    }
+
+    let key = {
+        let pending = parser.pending.as_ref().expect("pending set");
+        slot_parse_key::<K>(&pending.key_buf, out)?
+    };
+    parser.pending = None;
+    Ok(TryRead::Ready(Some(key)))
+}
+
+/// Merge source for the slot-backed `MergeDriver`: either a decompressing slot
+/// (read non-blocking) or an already-sorted in-memory residual chunk.
+enum SlotMergeSource<K: RawSortKey + Default + 'static> {
+    /// Pipeline-integrated source — `SortSpillDecompress` fills
+    /// `slot.decompressed` with decompressed blocks; this driver reads them
+    /// in-order via the per-source [`SlotParserState`].
+    Slot { slot: Arc<crate::merge_slots::SortMergeSlot>, parser: SlotParserState },
+    /// In-memory sorted residual records from a queryname-style sort (each
+    /// record an owned `RawRecord`). Read via a zero-copy `mem::swap` bridge.
+    Memory { records: Vec<(K, fgumi_raw_bam::RawRecord)>, idx: usize },
+    /// In-memory sorted residual from an inline-buffer (coordinate / template)
+    /// sort, sharing an `Arc<SegmentedBuf>` — zero per-record allocation. Read
+    /// copies each record's bytes into the caller's reused `buf`.
+    MemoryShared { chunk: InMemoryChunk<K>, idx: usize },
+}
+
+impl<K: RawSortKey + Default + 'static> SlotMergeSource<K> {
+    /// Non-blocking read of the next record into `buf`, returning the sort key.
+    /// `Slot` sources may return `WouldBlock`; `Memory` always returns `Ready`.
+    fn try_next_record(&mut self, buf: &mut Vec<u8>) -> Result<TryRead<K>> {
+        match self {
+            SlotMergeSource::Slot { slot, parser } => slot_try_next_record::<K>(slot, parser, buf),
+            SlotMergeSource::Memory { records, idx } => {
+                if *idx < records.len() {
+                    let (ref mut key, ref mut data) = records[*idx];
+                    // Bridge: RawRecord wraps Vec<u8>; swap via the inner vec to
+                    // avoid re-allocating. The caller's buf is a plain Vec<u8>.
+                    std::mem::swap(buf, data.as_mut_vec());
+                    let key = std::mem::take(key);
+                    *idx += 1;
+                    Ok(TryRead::Ready(Some(key)))
+                } else {
+                    Ok(TryRead::Ready(None))
+                }
+            }
+            SlotMergeSource::MemoryShared { chunk, idx } => {
+                if *idx < chunk.len() {
+                    // Bytes are borrowed from the shared `Arc<SegmentedBuf>`, so
+                    // copy them into the caller's reused `buf` (one memcpy, no
+                    // per-record allocation — the materialise-time copy is gone).
+                    buf.clear();
+                    buf.extend_from_slice(chunk.record_bytes(*idx));
+                    let key = chunk.take_key(*idx);
+                    *idx += 1;
+                    Ok(TryRead::Ready(Some(key)))
+                } else {
+                    Ok(TryRead::Ready(None))
+                }
+            }
+        }
+    }
+}
+
+/// One step of a non-blocking k-way merge.
+pub enum MergeStep<'a> {
+    /// The next merged record. The bytes borrow the driver's internal winner
+    /// buffer and are valid only until the next `try_step` call — the caller
+    /// must copy them out before stepping again. The borrow checker enforces
+    /// this, which is what makes the deferred-refill protocol sound.
+    Produced(&'a [u8]),
+    /// A source's decompressed queue is momentarily empty (and not at EOF), or
+    /// a source hasn't been primed yet. No record is available right now; the
+    /// caller should yield and retry on a later dispatch, by which point the
+    /// producer will have refilled the slot.
+    Stalled,
+    /// The merge is exhausted.
+    Done,
+}
+
+impl std::fmt::Debug for MergeStep<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Produced(bytes) => write!(f, "Produced({} bytes)", bytes.len()),
+            Self::Stalled => f.write_str("Stalled"),
+            Self::Done => f.write_str("Done"),
+        }
+    }
+}
+
+/// Object-safe view over `MergeDriver<K>` so the pipeline `SortMerge` step can
+/// hold a single concrete type regardless of sort order.
+pub trait MergeDriverDyn: Send {
+    /// Produce the next merged record **without blocking**. Any step that needs
+    /// a not-yet-ready slot block returns [`MergeStep::Stalled`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates spill-file corruption or decompression errors from the
+    /// underlying slot sources.
+    fn try_step(&mut self) -> Result<MergeStep<'_>>;
+    /// Total records emitted since the driver was constructed.
+    fn records_merged(&self) -> u64;
+}
+
+/// Internal phase of the [`MergeDriver`] non-blocking state machine.
+enum MergePhase<K> {
+    /// Lazily priming the loser tree: each source's first record is pulled one
+    /// at a time (non-blocking). `next` is the index of the next source to
+    /// prime; `keys` accumulates the primed initial keys; `rec` is the partial
+    /// record buffer for the source currently being primed (retained across a
+    /// `Stalled` so a spanning first record resumes correctly).
+    Priming { next: usize, keys: Vec<K>, rec: Vec<u8> },
+    /// Active k-way merge. `pending_refill` is set after a record is emitted
+    /// (`Produced`) and means the winner's source must be refilled before the
+    /// next winner is produced.
+    Merging { tree: crate::loser_tree::LoserTree<K>, pending_refill: bool },
+    /// Exhausted.
+    Done,
+}
+
+/// Pausable state machine for a non-blocking k-way merge over slot + in-memory
+/// sources. Constructed via [`MergeDriver::from_slots`]; driven by the pipeline
+/// `SortMerge` step via [`MergeDriverDyn::try_step`].
+pub struct MergeDriver<K: RawSortKey + Default + Send + 'static> {
+    sources: Vec<SlotMergeSource<K>>,
+    /// Per-active-source current record buffer, indexed by loser-tree leaf
+    /// (parallel to `source_map`). Grows during `Priming`.
+    records: Vec<Vec<u8>>,
+    /// Loser-tree leaf → `sources` index. Built during `Priming`.
+    source_map: Vec<usize>,
+    /// Non-blocking merge state machine.
+    phase: MergePhase<K>,
+    records_merged: u64,
+    progress: ProgressTracker,
+}
+
+impl<K: RawSortKey + Default + Send + 'static> MergeDriver<K> {
+    /// Construct a driver from `SortMergeSlot`s and already-sorted in-memory
+    /// chunks. Used by the cooperative pipeline `SortMerge` step.
+    ///
+    /// Each slot becomes a slot source read **non-blocking** by
+    /// [`MergeDriverDyn::try_step`]. Priming is **lazy**: the loser tree is
+    /// built on the first `try_step` call(s) as each source yields its first
+    /// record, so construction never blocks on a not-yet-decompressed slot.
+    /// Construction is infallible (read errors surface from `try_step`), and
+    /// the empty-input case is reported by the first `try_step` returning
+    /// [`MergeStep::Done`].
+    #[must_use]
+    pub fn from_slots(
+        slots: Vec<Arc<crate::merge_slots::SortMergeSlot>>,
+        memory: MemorySources<K>,
+        total_records: u64,
+    ) -> Self {
+        let num_slots = slots.len();
+        let num_memory = memory.num_non_empty();
+        let num_sources = num_slots + num_memory;
+
+        if num_slots > 0 {
+            info!(
+                "Pipeline-integrated merge: {num_slots} slot sources + {num_memory} memory sources"
+            );
+        }
+
+        let mut sources: Vec<SlotMergeSource<K>> = Vec::with_capacity(num_sources);
+        // Order by `file_id`, do not trust the caller's `Vec` order. `file_id`
+        // is documented on `SortMergeSlot` as the stable merge-order identity,
+        // and the `LoserTree` breaks ties between equal sort keys by leaf index
+        // — so if the leaf order came from push order instead, two records with
+        // the same key could be emitted in a different order than the legacy
+        // chunk-files path produces. That is an output-identity divergence in a
+        // tool whose sort output is checked byte-for-byte, and it would be
+        // invisible except on inputs that happen to contain ties. Sorting a
+        // handful of slots once per merge costs nothing next to that.
+        let mut slots = slots;
+        slots.sort_by_key(|s| s.file_id);
+        for slot in slots {
+            sources.push(SlotMergeSource::Slot { slot, parser: SlotParserState::new() });
+        }
+        match memory {
+            MemorySources::Owned(chunks) => {
+                for chunk in chunks {
+                    if !chunk.is_empty() {
+                        sources.push(SlotMergeSource::Memory { records: chunk, idx: 0 });
+                    }
+                }
+            }
+            MemorySources::Shared(chunks) => {
+                for chunk in chunks {
+                    if !chunk.is_empty() {
+                        sources.push(SlotMergeSource::MemoryShared { chunk, idx: 0 });
+                    }
+                }
+            }
+        }
+
+        let progress = ProgressTracker::new("Merged records")
+            .with_interval(1_000_000)
+            .with_total(total_records);
+
+        Self {
+            sources,
+            records: Vec::with_capacity(num_sources),
+            source_map: Vec::with_capacity(num_sources),
+            // Lazy priming: tree built on first try_step as sources yield.
+            phase: MergePhase::Priming {
+                next: 0,
+                keys: Vec::with_capacity(num_sources),
+                rec: Vec::new(),
+            },
+            records_merged: 0,
+            progress,
+        }
+    }
+}
+
+impl<K: RawSortKey + Default + Send + 'static> MergeDriverDyn for MergeDriver<K> {
+    fn try_step(&mut self) -> Result<MergeStep<'_>> {
+        // Move the phase out so the body works with owned `tree`/`keys`/`rec`
+        // and can borrow `self.{sources,records,source_map}` freely without
+        // aliasing the phase; the phase is written back before every return.
+        // `Done` is the placeholder; any early `?` leaves the driver `Done`,
+        // which is safe because the whole merge aborts on error.
+        loop {
+            match std::mem::replace(&mut self.phase, MergePhase::Done) {
+                MergePhase::Priming { mut next, mut keys, mut rec } => {
+                    let mut stalled = false;
+                    while next < self.sources.len() {
+                        match self.sources[next].try_next_record(&mut rec)? {
+                            TryRead::WouldBlock => {
+                                stalled = true;
+                                break;
+                            }
+                            TryRead::Ready(Some(key)) => {
+                                keys.push(key);
+                                self.records.push(std::mem::take(&mut rec));
+                                self.source_map.push(next);
+                                next += 1;
+                            }
+                            TryRead::Ready(None) => {
+                                rec.clear();
+                                next += 1;
+                            }
+                        }
+                    }
+                    if stalled {
+                        self.phase = MergePhase::Priming { next, keys, rec };
+                        return Ok(MergeStep::Stalled);
+                    }
+                    if keys.is_empty() {
+                        return Ok(MergeStep::Done);
+                    }
+                    info!("Merging from {} sources...", keys.len());
+                    let tree = crate::loser_tree::LoserTree::new(keys);
+                    self.phase = MergePhase::Merging { tree, pending_refill: false };
+                    // Loop to emit the first winner.
+                }
+                MergePhase::Merging { mut tree, pending_refill } => {
+                    // Resolve the refill deferred from the previous `Produced`
+                    // (the read that would overwrite the just-emitted winner's
+                    // buffer). On `WouldBlock`, yield with the refill still
+                    // pending.
+                    if pending_refill && tree.winner_is_active() {
+                        let winner = tree.winner();
+                        let src = self.source_map[winner];
+                        match self.sources[src].try_next_record(&mut self.records[winner])? {
+                            TryRead::WouldBlock => {
+                                self.phase = MergePhase::Merging { tree, pending_refill: true };
+                                return Ok(MergeStep::Stalled);
+                            }
+                            TryRead::Ready(Some(key)) => tree.replace_winner(key),
+                            TryRead::Ready(None) => tree.remove_winner(),
+                        }
+                    }
+                    if !tree.winner_is_active() {
+                        return Ok(MergeStep::Done);
+                    }
+                    let winner = tree.winner();
+                    self.records_merged += 1;
+                    self.progress.log_if_needed(1);
+                    // Defer this winner's refill to the next call so the
+                    // returned borrow stays valid until the caller copies it.
+                    self.phase = MergePhase::Merging { tree, pending_refill: true };
+                    return Ok(MergeStep::Produced(&self.records[winner]));
+                }
+                MergePhase::Done => return Ok(MergeStep::Done),
+            }
+        }
+    }
+
+    fn records_merged(&self) -> u64 {
+        self.records_merged
+    }
+}
+
+impl<K: RawSortKey + Default + Send + 'static> Drop for MergeDriver<K> {
+    fn drop(&mut self) {
+        self.progress.log_final();
+    }
 }
 
 #[cfg(test)]
@@ -4606,6 +5428,163 @@ mod tests {
         assert!(sorter.write_index);
         assert_eq!(sorter.pg_info, Some(("1.0".to_string(), "fgumi sort".to_string())));
         assert_eq!(sorter.max_temp_files, 128);
+    }
+
+    #[test]
+    fn test_raw_sorter_phase_threads_builders() {
+        let new = || RawExternalSorter::new(SortOrder::Coordinate).threads(8);
+        // Default: both phases fall back to threads.
+        let base = new();
+        assert_eq!((base.sort_threads, base.merge_threads), (None, None));
+        assert_eq!((base.phase1_threads(), base.phase2_threads()), (8, 8));
+        // sort_threads overrides only Phase 1.
+        let sort_only = new().sort_threads(2);
+        assert_eq!((sort_only.phase1_threads(), sort_only.phase2_threads()), (2, 8));
+        // The public `num_threads()` accessor returns the BASE count, unaffected
+        // by the Phase-1 override — so the streaming front must read
+        // `phase1_threads()`, not `num_threads()`, to honor `--sort-threads`
+        // (the D1.1 regression was reading the base here). Pin the distinction.
+        assert_eq!(sort_only.num_threads(), 8);
+        assert_eq!(sort_only.phase1_threads(), 2);
+        // merge_threads overrides only Phase 2.
+        let merge_only = new().merge_threads(3);
+        assert_eq!((merge_only.phase1_threads(), merge_only.phase2_threads()), (8, 3));
+        // Both override independently.
+        let both = new().sort_threads(2).merge_threads(16);
+        assert_eq!((both.phase1_threads(), both.phase2_threads()), (2, 16));
+        // Clamp to >= 1.
+        let zero = new().sort_threads(0).merge_threads(0);
+        assert_eq!((zero.phase1_threads(), zero.phase2_threads()), (1, 1));
+    }
+
+    /// Read every record's raw bytes from a BAM, in file order.
+    fn records_bytes(path: &Path) -> Vec<Vec<u8>> {
+        let (mut reader, _h) = create_raw_bam_reader(path, 1).expect("open bam");
+        let mut out = Vec::new();
+        let mut rec = fgumi_raw_bam::RawRecord::new();
+        while reader.read_record(&mut rec).expect("read record") != 0 {
+            out.push(rec.view().as_bytes().to_vec());
+        }
+        out
+    }
+
+    /// Splitting Phase-1 (`sort_threads`) and Phase-2 (`merge_threads`) from the
+    /// base `threads` is a pure scheduling knob: output must be byte-identical to
+    /// the unsplit sort, with spills forced. Matrixed over every order (`#[values]`)
+    /// and every thread-split variant (`#[case]`) so a failure names the exact order
+    /// and split. The cases mirror the prior inline matrix: `sort_low` (Phase-1 on
+    /// 1), `merge_low` (Phase-2 on 1), `both` (Phase-1 on 1 / Phase-2 on 2), and
+    /// `sort_high` (Phase-1 above base).
+    #[rstest::rstest]
+    #[case::sort_low(Some(1), None)]
+    #[case::merge_low(None, Some(1))]
+    #[case::both(Some(1), Some(2))]
+    #[case::sort_high(Some(8), Some(2))]
+    fn phase_thread_split_is_byte_identical(
+        #[values(
+            SortOrder::Coordinate,
+            SortOrder::Queryname(QuerynameComparator::Natural),
+            SortOrder::Queryname(QuerynameComparator::Lexicographic),
+            SortOrder::TemplateCoordinate
+        )]
+        order: SortOrder,
+        #[case] sort_t: Option<usize>,
+        #[case] merge_t: Option<usize>,
+    ) {
+        use fgumi_sam::SamBuilder;
+        let mut builder = SamBuilder::new();
+        for i in 0..2000 {
+            let _ = builder
+                .add_pair()
+                .name(&format!("read{i}"))
+                .start1(i * 50 + 1)
+                .start2(i * 50 + 101)
+                .build();
+        }
+        let dir = tempfile::tempdir().expect("temp dir");
+        let input = dir.path().join("in.bam");
+        builder.write_bam(&input).expect("write bam");
+
+        let mk = |out: &Path, sort_t: Option<usize>, merge_t: Option<usize>| {
+            let mut s = RawExternalSorter::new(order)
+                .threads(4)
+                .memory_limit(32 * 1024) // force spills
+                .spill_codec(crate::codec::SpillCodec::Bgzf)
+                .temp_compression(0)
+                .output_compression(0);
+            if let Some(j) = sort_t {
+                s = s.sort_threads(j);
+            }
+            if let Some(k) = merge_t {
+                s = s.merge_threads(k);
+            }
+            s.sort(&input, out).expect("sort");
+        };
+        // Base: both phases on the unsplit `threads(4)`.
+        let base = dir.path().join("base.bam");
+        mk(&base, None, None);
+        let golden = records_bytes(&base);
+        // The split variant must reproduce the base output exactly.
+        let out = dir.path().join("variant.bam");
+        mk(&out, sort_t, merge_t);
+        assert_eq!(
+            records_bytes(&out),
+            golden,
+            "order {order:?} split sort_t={sort_t:?} merge_t={merge_t:?}: \
+             thread split must not change output"
+        );
+    }
+
+    /// Regression guard for the residual Phase-1 sort honoring `sort_threads`
+    /// rather than the base `threads`. With `threads(1).sort_threads(4)` the
+    /// residual sort/chunk decision must take the *parallel* `phase1_threads()`
+    /// branch (previously it gated on `threads`, so it ran serially and ignored
+    /// `sort_threads`). Spills are forced so the keyed-chunk residual path
+    /// (`chunk_files` non-empty) is exercised; output must be byte-identical to
+    /// the serial `threads(1)` sort for every order.
+    #[rstest::rstest]
+    #[case::coordinate(SortOrder::Coordinate)]
+    #[case::queryname_natural(SortOrder::Queryname(QuerynameComparator::Natural))]
+    #[case::queryname_lex(SortOrder::Queryname(QuerynameComparator::Lexicographic))]
+    #[case::template_coordinate(SortOrder::TemplateCoordinate)]
+    fn residual_phase1_honors_sort_threads_with_single_base_thread(#[case] order: SortOrder) {
+        use fgumi_sam::SamBuilder;
+        let mut builder = SamBuilder::new();
+        for i in 0..2000 {
+            let _ = builder
+                .add_pair()
+                .name(&format!("read{i}"))
+                .start1(i * 50 + 1)
+                .start2(i * 50 + 101)
+                .build();
+        }
+        let dir = tempfile::tempdir().expect("temp dir");
+        let input = dir.path().join("in.bam");
+        builder.write_bam(&input).expect("write bam");
+
+        let mk = |out: &Path, sort_t: Option<usize>| {
+            let mut s = RawExternalSorter::new(order)
+                .threads(1)
+                .memory_limit(32 * 1024) // force spills -> exercise residual chunk path
+                .spill_codec(crate::codec::SpillCodec::Bgzf)
+                .temp_compression(0)
+                .output_compression(0);
+            if let Some(j) = sort_t {
+                s = s.sort_threads(j);
+            }
+            s.sort(&input, out).expect("sort");
+        };
+        let serial = dir.path().join("serial.bam");
+        mk(&serial, None); // threads(1): residual sort runs serially
+        let golden = records_bytes(&serial);
+
+        let parallel = dir.path().join("parallel.bam");
+        mk(&parallel, Some(4)); // sort_threads(4): residual sort now parallel
+        assert_eq!(
+            records_bytes(&parallel),
+            golden,
+            "order {order:?}: threads(1).sort_threads(4) must match the serial sort output"
+        );
     }
 
     #[test]
@@ -6176,6 +7155,31 @@ mod tests {
 
         assert_eq!(count, 40);
         assert_eq!(count_bam_records(&merged), 40);
+
+        // Verify template-coordinate order/identity via an independent oracle
+        // (mirrors `narrow_sort_output_passes_full_width_verify`): re-extract the
+        // template key from every merged record and assert non-decreasing core
+        // order. A count-only check would pass even if the merge reordered or
+        // duplicated records.
+        let (_, hdr) = create_raw_bam_reader(&merged, 1).expect("header");
+        let lib = LibraryLookup::from_header(&hdr);
+        let hasher = cb_hasher();
+        let file = std::fs::File::open(&merged).expect("open merged");
+        let mut raw_reader = crate::reader::RawBamRecordReader::new(file).expect("reader");
+        raw_reader.skip_header().expect("skip header");
+        let (total, violations, first) = crate::verify::verify_sort_order(
+            raw_reader,
+            |bam| extract_template_key_inline(bam, &lib, None, &hasher),
+            |cur: &TemplateKey40, prev: &TemplateKey40| {
+                cur.core_cmp(prev) == std::cmp::Ordering::Less
+            },
+        )
+        .expect("verify runs");
+        assert_eq!(total, 40, "verify must see every merged record");
+        assert_eq!(
+            violations, 0,
+            "template-coordinate order violated after merge (first={first:?}, total={total})"
+        );
     }
 
     #[test]
@@ -7807,5 +8811,762 @@ mod tests {
                 "a completely-unmapped read in a single-library input must not trigger a \
                  false dropped-lane library violation",
             );
+    }
+}
+
+#[cfg(test)]
+mod from_slots_merge_tests {
+    //! Direct unit tests for the slot-backed `MergeDriver::from_slots` merge
+    //! driver: cross-block record parsing (incl. records spanning many blocks),
+    //! non-blocking stall/resume on empty-non-EOF slots, the embedded and
+    //! non-embedded sort-key arms, and memory-chunk mixing. Ported verbatim
+    //! from the issue-#330 source branch (the slimmed `from_slots` API is
+    //! identical at this layer). These exercise the parser/state-machine paths
+    //! that the end-to-end `three_step_chain_*` tests do not isolate.
+    use super::*;
+    use std::io::{BufReader, Read, Write};
+    use std::sync::Arc as StdArc;
+
+    #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
+    struct TestKey(u64);
+
+    impl RawSortKey for TestKey {
+        const SERIALIZED_SIZE: Option<usize> = Some(8);
+        const EMBEDDED_IN_RECORD: bool = false;
+        fn extract(_bam: &[u8], _ctx: &crate::keys::SortContext) -> Self {
+            unimplemented!(
+                "TestKey is only used in MergeDriver::from_slots tests, not for ingestion"
+            )
+        }
+        fn write_to<W: Write>(&self, w: &mut W) -> std::io::Result<()> {
+            w.write_all(&self.0.to_le_bytes())
+        }
+        fn read_from<R: Read>(r: &mut R) -> std::io::Result<Self> {
+            let mut buf = [0u8; 8];
+            r.read_exact(&mut buf)?;
+            Ok(TestKey(u64::from_le_bytes(buf)))
+        }
+    }
+
+    /// Serialize a sequence of `(TestKey, record_bytes)` pairs in the spill
+    /// file's wire format: `[key(8)][len(4)][record(len)]` per entry.
+    fn serialize_records(records: &[(TestKey, Vec<u8>)]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for (key, rec) in records {
+            key.write_to(&mut out).unwrap();
+            #[allow(clippy::cast_possible_truncation)]
+            let len = rec.len() as u32;
+            out.write_all(&len.to_le_bytes()).unwrap();
+            out.write_all(rec).unwrap();
+        }
+        out
+    }
+
+    /// Build a populated `SortMergeSlot` with `file_id` whose decompressed
+    /// queue contains `records` partitioned across `n_blocks` "blocks"
+    /// (so the slot parser exercises cross-block reads). Sets `queue_eof`
+    /// so the slot reports drained once consumer empties it.
+    fn populated_slot(
+        file_id: u32,
+        records: &[(TestKey, Vec<u8>)],
+        n_blocks: usize,
+    ) -> StdArc<SortMergeSlot> {
+        assert!(n_blocks >= 1, "n_blocks must be >= 1");
+        let bytes = serialize_records(records);
+        let block_size = bytes.len().div_ceil(n_blocks);
+        let slot = StdArc::new(SortMergeSlot::new(
+            file_id,
+            BufReader::new(tempfile::tempfile().expect("tempfile")),
+            crate::codec::SpillCodec::Bgzf,
+        ));
+        {
+            let mut dec = slot.decompressed.lock().unwrap();
+            for chunk in bytes.chunks(block_size) {
+                dec.push_back(chunk.to_vec());
+            }
+            slot.queue_eof.store(true, std::sync::atomic::Ordering::Release);
+        }
+        slot
+    }
+
+    /// Drive a `MergeDriver` to exhaustion via the non-blocking `try_step`,
+    /// returning the emitted record bytes in emission order.
+    ///
+    /// Tests validate ordering by inspecting the human-readable record bytes
+    /// (e.g. `b"AAA-1"`, `b"BBB-2"`) — the keys themselves are consumed by
+    /// the parser before the record is exposed, so we have no direct access to
+    /// them at this layer. These slots are pre-populated and EOF-marked before
+    /// the merge, so `try_step` never returns `Stalled` here.
+    fn drain_merge_driver_bytes<K: RawSortKey + Default + Send + 'static>(
+        mut driver: MergeDriver<K>,
+    ) -> Vec<Vec<u8>> {
+        let mut out = Vec::new();
+        loop {
+            match driver.try_step().expect("try_step") {
+                MergeStep::Produced(bytes) => out.push(bytes.to_vec()),
+                MergeStep::Done => break,
+                MergeStep::Stalled => panic!("unexpected Stalled on pre-populated EOF slots"),
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn from_slots_merges_three_pre_populated_slots() {
+        // Three slots, each with sorted records by TestKey. The merged output
+        // should be globally sorted.
+        let file0: Vec<(TestKey, Vec<u8>)> = vec![
+            (TestKey(1), b"AAA-1".to_vec()),
+            (TestKey(4), b"AAA-4".to_vec()),
+            (TestKey(7), b"AAA-7".to_vec()),
+        ];
+        let file1: Vec<(TestKey, Vec<u8>)> = vec![
+            (TestKey(2), b"BBB-2".to_vec()),
+            (TestKey(5), b"BBB-5".to_vec()),
+            (TestKey(8), b"BBB-8".to_vec()),
+        ];
+        let file2: Vec<(TestKey, Vec<u8>)> = vec![
+            (TestKey(3), b"CCC-3".to_vec()),
+            (TestKey(6), b"CCC-6".to_vec()),
+            (TestKey(9), b"CCC-9".to_vec()),
+        ];
+
+        let slots = vec![
+            populated_slot(0, &file0, 1),
+            populated_slot(1, &file1, 1),
+            populated_slot(2, &file2, 1),
+        ];
+
+        let driver = MergeDriver::<TestKey>::from_slots(slots, MemorySources::Owned(Vec::new()), 9);
+        let emitted_bytes = drain_merge_driver_bytes(driver);
+        let expected: Vec<Vec<u8>> = vec![
+            b"AAA-1".to_vec(),
+            b"BBB-2".to_vec(),
+            b"CCC-3".to_vec(),
+            b"AAA-4".to_vec(),
+            b"BBB-5".to_vec(),
+            b"CCC-6".to_vec(),
+            b"AAA-7".to_vec(),
+            b"BBB-8".to_vec(),
+            b"CCC-9".to_vec(),
+        ];
+        assert_eq!(emitted_bytes, expected, "merged sequence not globally sorted by key");
+    }
+
+    #[test]
+    fn from_slots_handles_records_spanning_block_boundaries() {
+        // Same data, but each slot's bytes are split across 4 "decompressed
+        // blocks" so the slot parser's read_exact + advance_to_next_block
+        // path is exercised. The key+len header itself may straddle a block
+        // boundary depending on byte counts.
+        let records: Vec<(TestKey, Vec<u8>)> = (0u64..20)
+            .map(|i| (TestKey(i), format!("record-{i:02}-with-some-padding").into_bytes()))
+            .collect();
+
+        let slots = vec![populated_slot(0, &records, 4)];
+        let driver =
+            MergeDriver::<TestKey>::from_slots(slots, MemorySources::Owned(Vec::new()), 20);
+        let emitted_bytes = drain_merge_driver_bytes(driver);
+        let expected: Vec<Vec<u8>> = records.into_iter().map(|(_, b)| b).collect();
+        assert_eq!(emitted_bytes, expected, "cross-block parse corrupted record sequence");
+    }
+
+    #[test]
+    fn from_slots_empty_sources_drain_to_zero_records() {
+        let empty_slot = StdArc::new(SortMergeSlot::new(
+            0,
+            BufReader::new(tempfile::tempfile().expect("tempfile")),
+            crate::codec::SpillCodec::Bgzf,
+        ));
+        // Mark drained without inserting any blocks.
+        empty_slot.queue_eof.store(true, std::sync::atomic::Ordering::Release);
+        // Lazy priming: `from_slots` always yields a driver; the empty
+        // determination happens on the first `try_step`, which returns `Done`.
+        let driver = MergeDriver::<TestKey>::from_slots(
+            vec![empty_slot],
+            MemorySources::Owned(Vec::new()),
+            0,
+        );
+        let emitted = drain_merge_driver_bytes(driver);
+        assert!(emitted.is_empty(), "all-empty merge must emit zero records");
+    }
+
+    /// The length prefix is untrusted: it comes straight off a decompressed
+    /// spill block. The slow path used to hand it to `out.reserve(len)` with no
+    /// check, so a corrupt slot could request up to 4 GiB — and `reserve`
+    /// answers an allocation failure by aborting the process, not by returning
+    /// the truncation error the next loop iteration would have produced.
+    ///
+    /// The length here is over the bound but still allocatable, so this test
+    /// discriminates on the *error message* rather than on surviving: before
+    /// the bound existed it reserved happily and then failed as a truncated
+    /// body, which is the wrong diagnosis for a corrupt length.
+    #[test]
+    fn implausible_record_length_is_rejected_before_reserving() {
+        let bogus_len = u32::try_from(crate::inline::SORT_SEGMENT_SIZE).unwrap() + 1;
+        let mut bytes = Vec::new();
+        TestKey(1).write_to(&mut bytes).unwrap();
+        bytes.write_all(&bogus_len.to_le_bytes()).unwrap();
+        bytes.write_all(b"only-a-few-body-bytes").unwrap();
+
+        let slot = StdArc::new(SortMergeSlot::new(
+            5,
+            BufReader::new(tempfile::tempfile().expect("tempfile")),
+            crate::codec::SpillCodec::Bgzf,
+        ));
+        slot.decompressed.lock().unwrap().push_back(bytes);
+        slot.queue_eof.store(true, std::sync::atomic::Ordering::Release);
+
+        let mut driver =
+            MergeDriver::<TestKey>::from_slots(vec![slot], MemorySources::Owned(Vec::new()), 1);
+        let err = driver.try_step().expect_err("an implausible length must surface as Err");
+        assert!(
+            err.to_string().contains("implausible record length") && err.to_string().contains('5'),
+            "the error must name the bad length and the slot; got: {err}",
+        );
+    }
+
+    /// An embedded key is read out of the record body itself, so an empty body
+    /// cannot carry one. `RawCoordinateKey::extract_from_record` reads `ref_id`
+    /// off the front, which on an empty body indexes out of bounds — a panic in
+    /// the middle of a merge rather than a corrupt-slot error. A zero length is
+    /// reachable from a corrupt length prefix: the body loop sees
+    /// `out.len() >= 0` and breaks immediately with `out` still empty.
+    #[test]
+    fn embedded_key_on_an_empty_body_is_an_error_not_a_panic() {
+        let err = slot_parse_key::<crate::keys::RawCoordinateKey>(&[], &[])
+            .expect_err("an empty body cannot carry an embedded key");
+        assert!(
+            err.to_string().contains("empty and cannot carry an embedded sort key"),
+            "the error must name the empty body; got: {err}",
+        );
+    }
+
+    /// Truncation at EOF must be an error, not a stall — at **every** stage of
+    /// the framer, not just the last one.
+    ///
+    /// Every other test either completes its record or stalls on a non-EOF slot,
+    /// so the three `BlockLoad::Eof` arms in `slot_collect_pending` were
+    /// unexercised. They are siblings: swapping any one for `WouldBlock` hangs
+    /// the pipeline forever on a truncated spill while the suite stays green, so
+    /// covering only the body arm left two of the three live.
+    ///
+    /// A serialized record is `[key(8)][len(4)][body(len)]`, so keeping 4 and 10
+    /// bytes lands mid-key and mid-length; `None` means "all but the last 5",
+    /// which lands mid-body.
+    #[rstest::rstest]
+    #[case::mid_key(Some(4), "truncated record key in slot 3")]
+    #[case::mid_length(Some(10), "truncated record length in slot 3")]
+    #[case::mid_body(None, "truncated record body in slot 3")]
+    fn truncation_at_eof_is_an_error_not_a_stall_at_every_stage(
+        #[case] keep: Option<usize>,
+        #[case] expected: &str,
+    ) {
+        let serialized = serialize_records(&[(TestKey(1), b"a-body-that-is-cut-short".to_vec())]);
+        let keep = keep.unwrap_or(serialized.len() - 5);
+        assert!(keep < serialized.len(), "the case must actually truncate");
+
+        let slot = StdArc::new(SortMergeSlot::new(
+            3,
+            BufReader::new(tempfile::tempfile().expect("tempfile")),
+            crate::codec::SpillCodec::Bgzf,
+        ));
+        slot.decompressed.lock().unwrap().push_back(serialized[..keep].to_vec());
+        slot.queue_eof.store(true, std::sync::atomic::Ordering::Release);
+
+        let mut driver =
+            MergeDriver::<TestKey>::from_slots(vec![slot], MemorySources::Owned(Vec::new()), 1);
+        let err = driver.try_step().expect_err("truncation must surface as Err");
+        assert!(err.to_string().contains(expected), "expected `{expected}`, got: {err}");
+    }
+
+    /// `from_slots` sorts slots by `file_id` so equal-key ties resolve the same
+    /// way the legacy chunk-files path resolves them — the `LoserTree` breaks
+    /// ties by leaf index, so leaf order must follow `file_id` and not the
+    /// caller's `Vec` order. Nothing pinned that, so the sort could vanish in a
+    /// later cleanup and the divergence would be invisible except on inputs
+    /// that contain ties. Pass the slots reversed and require `file_id` to win.
+    #[test]
+    fn key_ties_break_by_file_id_not_by_caller_push_order() {
+        let file0 = populated_slot(0, &[(TestKey(1), b"from-file-0".to_vec())], 1);
+        let file1 = populated_slot(1, &[(TestKey(1), b"from-file-1".to_vec())], 1);
+        let driver = MergeDriver::<TestKey>::from_slots(
+            vec![file1, file0], // reversed on purpose
+            MemorySources::Owned(Vec::new()),
+            2,
+        );
+        assert_eq!(
+            drain_merge_driver_bytes(driver),
+            vec![b"from-file-0".to_vec(), b"from-file-1".to_vec()],
+            "equal-key ties must resolve by file_id, not by caller push order",
+        );
+    }
+
+    /// The core BUG #3 regression: a slot whose decompressed queue is empty
+    /// and `!queue_eof` must make `try_step` return `Stalled` (yield), NOT
+    /// block the caller. The old blocking consumer (`block_ready.wait()`)
+    /// would park here forever at a single worker. After the producer fills
+    /// the slot and marks EOF, the merge resumes and drains to completion.
+    #[test]
+    fn from_slots_try_step_stalls_on_empty_non_eof_slot_then_resumes() {
+        let slot = StdArc::new(SortMergeSlot::new(
+            0,
+            BufReader::new(tempfile::tempfile().expect("tempfile")),
+            crate::codec::SpillCodec::Bgzf,
+        ));
+        // Empty queue, NOT eof — the producer is "still feeding".
+        let mut driver = MergeDriver::<TestKey>::from_slots(
+            vec![StdArc::clone(&slot)],
+            MemorySources::Owned(Vec::new()),
+            0,
+        );
+
+        // Priming cannot read the slot's first record → Stalled, not a hang.
+        assert!(
+            matches!(driver.try_step().expect("try_step"), MergeStep::Stalled),
+            "empty non-eof slot must Stall, not block"
+        );
+        // Repeated calls keep stalling (idempotent yield).
+        assert!(matches!(driver.try_step().expect("try_step"), MergeStep::Stalled));
+
+        // Producer fills the slot and marks EOF.
+        {
+            let bytes = serialize_records(&[(TestKey(1), b"only-1".to_vec())]);
+            let mut dec = slot.decompressed.lock().unwrap();
+            dec.push_back(bytes);
+            slot.queue_eof.store(true, std::sync::atomic::Ordering::Release);
+        }
+
+        // The merge now resumes: emits the record, then is Done.
+        match driver.try_step().expect("try_step") {
+            MergeStep::Produced(bytes) => assert_eq!(bytes, b"only-1"),
+            MergeStep::Stalled => panic!("should have resumed, not Stalled"),
+            MergeStep::Done => panic!("should have produced the record, not Done"),
+        }
+        assert!(matches!(driver.try_step().expect("try_step"), MergeStep::Done));
+    }
+
+    /// `try_step` must also stall (not block) when a slot drains to empty
+    /// **mid-merge** (after priming) while still `!queue_eof`, then resume
+    /// once the producer pushes the next block and marks EOF.
+    #[test]
+    fn from_slots_try_step_stalls_mid_merge_then_resumes() {
+        let slot = StdArc::new(SortMergeSlot::new(
+            0,
+            BufReader::new(tempfile::tempfile().expect("tempfile")),
+            crate::codec::SpillCodec::Bgzf,
+        ));
+        // One record present, NOT eof (more "coming").
+        {
+            let bytes = serialize_records(&[(TestKey(1), b"rec-A".to_vec())]);
+            slot.decompressed.lock().unwrap().push_back(bytes);
+        }
+        let mut driver = MergeDriver::<TestKey>::from_slots(
+            vec![StdArc::clone(&slot)],
+            MemorySources::Owned(Vec::new()),
+            0,
+        );
+
+        // Prime + emit the first record.
+        match driver.try_step().expect("try_step") {
+            MergeStep::Produced(bytes) => assert_eq!(bytes, b"rec-A"),
+            other => panic!("expected Produced(rec-A), got {other:?}"),
+        }
+        // Deferred refill finds the slot drained + not eof → Stalled.
+        assert!(
+            matches!(driver.try_step().expect("try_step"), MergeStep::Stalled),
+            "drained mid-merge non-eof slot must Stall"
+        );
+
+        // Producer pushes the next record and marks EOF.
+        {
+            let bytes = serialize_records(&[(TestKey(2), b"rec-B".to_vec())]);
+            let mut dec = slot.decompressed.lock().unwrap();
+            dec.push_back(bytes);
+            slot.queue_eof.store(true, std::sync::atomic::Ordering::Release);
+        }
+
+        match driver.try_step().expect("try_step") {
+            MergeStep::Produced(bytes) => assert_eq!(bytes, b"rec-B"),
+            other => panic!("expected Produced(rec-B), got {other:?}"),
+        }
+        assert!(matches!(driver.try_step().expect("try_step"), MergeStep::Done));
+    }
+
+    /// Resumable-framer regression: feed a single **non-embedded** record one
+    /// byte per block, asserting `try_step` `Stalled`s (retaining
+    /// `parser.pending`) until the whole record is available, then reassembles
+    /// the exact bytes. With 1-byte blocks the framer takes the slow path and
+    /// resumes a `WouldBlock` across the key prefix, the length prefix, AND the
+    /// body — the partial-record path no other test covers byte-for-byte.
+    #[test]
+    fn from_slots_try_step_resumes_record_fed_one_byte_at_a_time() {
+        let rec_body = b"multi-stage-resumable-record-body".to_vec();
+        let serialized = serialize_records(&[(TestKey(7), rec_body.clone())]);
+        assert!(serialized.len() > 12, "must span the 8-byte key + 4-byte len header");
+
+        let slot = StdArc::new(SortMergeSlot::new(
+            0,
+            BufReader::new(tempfile::tempfile().expect("tempfile")),
+            crate::codec::SpillCodec::Bgzf,
+        ));
+        slot.decompressed.lock().unwrap().push_back(vec![serialized[0]]);
+
+        let mut driver = MergeDriver::<TestKey>::from_slots(
+            vec![StdArc::clone(&slot)],
+            MemorySources::Owned(Vec::new()),
+            1,
+        );
+
+        // Each step before the last byte consumes one byte into the pending
+        // record and stalls (queue empty, not EOF).
+        for (i, &b) in serialized.iter().enumerate().skip(1) {
+            assert!(
+                matches!(driver.try_step().expect("try_step"), MergeStep::Stalled),
+                "expected Stalled with only {i} of {} bytes available",
+                serialized.len(),
+            );
+            slot.decompressed.lock().unwrap().push_back(vec![b]);
+        }
+
+        // The step that consumes the final byte completes the record.
+        match driver.try_step().expect("try_step") {
+            MergeStep::Produced(bytes) => assert_eq!(bytes, rec_body.as_slice()),
+            other => panic!("expected Produced(reassembled), got {other:?}"),
+        }
+        // No more bytes and not yet EOF → Stalled; EOF → Done.
+        assert!(matches!(driver.try_step().expect("try_step"), MergeStep::Stalled));
+        slot.queue_eof.store(true, std::sync::atomic::Ordering::Release);
+        assert!(matches!(driver.try_step().expect("try_step"), MergeStep::Done));
+    }
+
+    /// Same resumable-framer property for an **embedded**-key record split mid
+    /// body across two blocks (the key lives in the body, so this exercises the
+    /// embedded `extract_from_record` path resuming after a `WouldBlock`).
+    #[test]
+    fn from_slots_try_step_resumes_embedded_record_split_mid_body() {
+        // Embedded record: [len:4][body], key = first 8 body bytes.
+        let record = embedded_record(123, b"-embedded-tail-bytes");
+        let serialized = serialize_embedded(std::slice::from_ref(&record));
+        // Cut mid-body: 4-byte len + 10 body bytes in the first block.
+        let split = 4 + 10;
+        assert!(split < serialized.len() && split > 4 + 8, "split mid-body, past the key");
+        let (head, tail) = serialized.split_at(split);
+
+        let slot = StdArc::new(SortMergeSlot::new(
+            0,
+            BufReader::new(tempfile::tempfile().expect("tempfile")),
+            crate::codec::SpillCodec::Bgzf,
+        ));
+        slot.decompressed.lock().unwrap().push_back(head.to_vec());
+
+        let mut driver = MergeDriver::<TestEmbeddedKey>::from_slots(
+            vec![StdArc::clone(&slot)],
+            MemorySources::Owned(Vec::new()),
+            1,
+        );
+
+        // Body incomplete in the first block → Stalled mid-record.
+        assert!(matches!(driver.try_step().expect("try_step"), MergeStep::Stalled));
+
+        // Deliver the rest + EOF; the record reassembles exactly.
+        {
+            let mut dec = slot.decompressed.lock().unwrap();
+            dec.push_back(tail.to_vec());
+            slot.queue_eof.store(true, std::sync::atomic::Ordering::Release);
+        }
+        match driver.try_step().expect("try_step") {
+            MergeStep::Produced(bytes) => assert_eq!(bytes, record.as_slice()),
+            other => panic!("expected Produced(reassembled embedded), got {other:?}"),
+        }
+        assert!(matches!(driver.try_step().expect("try_step"), MergeStep::Done));
+    }
+
+    #[test]
+    fn from_slots_merges_slots_with_memory_chunks() {
+        let slot_records: Vec<(TestKey, Vec<u8>)> = vec![
+            (TestKey(1), b"slot-1".to_vec()),
+            (TestKey(3), b"slot-3".to_vec()),
+            (TestKey(5), b"slot-5".to_vec()),
+        ];
+        let memory_records: Vec<(TestKey, fgumi_raw_bam::RawRecord)> = vec![
+            (TestKey(2), fgumi_raw_bam::RawRecord::from(b"mem-2".to_vec())),
+            (TestKey(4), fgumi_raw_bam::RawRecord::from(b"mem-4".to_vec())),
+            (TestKey(6), fgumi_raw_bam::RawRecord::from(b"mem-6".to_vec())),
+        ];
+
+        let slots = vec![populated_slot(0, &slot_records, 2)];
+        let driver = MergeDriver::<TestKey>::from_slots(
+            slots,
+            MemorySources::Owned(vec![memory_records]),
+            6,
+        );
+        let emitted_bytes = drain_merge_driver_bytes(driver);
+        let expected: Vec<Vec<u8>> = vec![
+            b"slot-1".to_vec(),
+            b"mem-2".to_vec(),
+            b"slot-3".to_vec(),
+            b"mem-4".to_vec(),
+            b"slot-5".to_vec(),
+            b"mem-6".to_vec(),
+        ];
+        assert_eq!(emitted_bytes, expected, "slot+memory merge not globally sorted");
+    }
+
+    /// The same merge through `MemorySources::Shared`, which is the arm
+    /// production actually uses: `sort_coordinate_optimized` and
+    /// `sort_template_coordinate_impl` both build `Shared`, and `Owned` is the
+    /// queryname arm only. Every other `from_slots` test drove `Owned`, so the
+    /// arm carrying two of the three sort orders had no coverage here at all.
+    ///
+    /// The two arms differ in mechanism, not just in type: `Owned` swaps the
+    /// record vec out, while `Shared` copies `chunk.record_bytes(idx)` into the
+    /// caller's buffer and takes the key by index. A defect in that copy, or in
+    /// the `idx`/`len` pairing, is invisible to the `Owned` tests.
+    #[test]
+    fn from_slots_merges_slots_with_shared_memory_chunks() {
+        let slot_records: Vec<(TestKey, Vec<u8>)> = vec![
+            (TestKey(1), b"slot-1".to_vec()),
+            (TestKey(3), b"slot-3".to_vec()),
+            (TestKey(5), b"slot-5".to_vec()),
+        ];
+        let memory_chunk = crate::inline::InMemoryChunk::from_owned_records(vec![
+            (TestKey(2), b"mem-2".to_vec()),
+            (TestKey(4), b"mem-4".to_vec()),
+            (TestKey(6), b"mem-6".to_vec()),
+        ]);
+
+        let slots = vec![populated_slot(0, &slot_records, 2)];
+        let driver =
+            MergeDriver::<TestKey>::from_slots(slots, MemorySources::Shared(vec![memory_chunk]), 6);
+        let expected: Vec<Vec<u8>> = vec![
+            b"slot-1".to_vec(),
+            b"mem-2".to_vec(),
+            b"slot-3".to_vec(),
+            b"mem-4".to_vec(),
+            b"slot-5".to_vec(),
+            b"mem-6".to_vec(),
+        ];
+        assert_eq!(
+            drain_merge_driver_bytes(driver),
+            expected,
+            "slot + shared-memory merge not globally sorted",
+        );
+    }
+
+    // (v4: `from_slots_bails_on_unfilled_gap_in_decompressed` removed.
+    //  v3.1's `decompressed: Mutex<ReorderBuffer<Vec<u8>>>` is now a
+    //  `Mutex<VecDeque<Vec<u8>>>` (FIFO). There is no concept of
+    //  "ordinals" or "gaps" — the producer pushes in order under the
+    //  reader lock, so a missing-block-in-the-middle state is no
+    //  longer representable.)
+
+    // ------------------------------------------------------------------------
+    // Coverage for the EMBEDDED_IN_RECORD = true parser arm.
+    //
+    // All three production sort keys (RawCoordinateKey, RawQuerynameKey,
+    // TemplateKey) set EMBEDDED_IN_RECORD = true, but TestKey above uses
+    // the non-embedded format. This test pins the embedded-format slot path
+    // with a synthetic embedded key (TestEmbeddedKey) whose value lives at
+    // bytes 0..8 of the record itself.
+
+    /// Embedded-key test type: serialized format is `[len(4)][record(len)]`
+    /// (no separate key prefix). The key is the first 8 LE bytes of the record.
+    #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
+    struct TestEmbeddedKey(u64);
+
+    impl RawSortKey for TestEmbeddedKey {
+        const SERIALIZED_SIZE: Option<usize> = Some(0);
+        const EMBEDDED_IN_RECORD: bool = true;
+        fn extract(_bam: &[u8], _ctx: &crate::keys::SortContext) -> Self {
+            unimplemented!("TestEmbeddedKey is only used in MergeDriver::from_slots tests")
+        }
+        fn extract_from_record(bam: &[u8]) -> Self {
+            assert!(bam.len() >= 8, "embedded-key test record must have ≥8 bytes");
+            let mut buf = [0u8; 8];
+            buf.copy_from_slice(&bam[..8]);
+            TestEmbeddedKey(u64::from_le_bytes(buf))
+        }
+        fn write_to<W: Write>(&self, _w: &mut W) -> std::io::Result<()> {
+            // No-op: embedded keys are not written separately; they live
+            // inside the record bytes.
+            Ok(())
+        }
+        fn read_from<R: Read>(_r: &mut R) -> std::io::Result<Self> {
+            unreachable!(
+                "EMBEDDED_IN_RECORD = true keys take the slot_try_next_record \
+                 embedded arm, which never calls read_from"
+            )
+        }
+    }
+
+    /// Build a record whose first 8 bytes encode the embedded sort key.
+    fn embedded_record(key: u64, tail: &[u8]) -> Vec<u8> {
+        let mut v = Vec::with_capacity(8 + tail.len());
+        v.extend_from_slice(&key.to_le_bytes());
+        v.extend_from_slice(tail);
+        v
+    }
+
+    /// Serialize records in the embedded-key spill format: `[len(4)][record(len)]`.
+    fn serialize_embedded(records: &[Vec<u8>]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for rec in records {
+            #[allow(clippy::cast_possible_truncation)]
+            let len = rec.len() as u32;
+            out.write_all(&len.to_le_bytes()).unwrap();
+            out.write_all(rec).unwrap();
+        }
+        out
+    }
+
+    fn embedded_populated_slot(
+        file_id: u32,
+        records: &[Vec<u8>],
+        n_blocks: usize,
+    ) -> StdArc<SortMergeSlot> {
+        let bytes = serialize_embedded(records);
+        let block_size = bytes.len().div_ceil(n_blocks.max(1));
+        let slot = StdArc::new(SortMergeSlot::new(
+            file_id,
+            BufReader::new(tempfile::tempfile().expect("tempfile")),
+            crate::codec::SpillCodec::Bgzf,
+        ));
+        {
+            let mut dec = slot.decompressed.lock().unwrap();
+            for chunk in bytes.chunks(block_size) {
+                dec.push_back(chunk.to_vec());
+            }
+            slot.queue_eof.store(true, std::sync::atomic::Ordering::Release);
+        }
+        slot
+    }
+
+    #[test]
+    fn from_slots_embedded_key_path_merges_correctly() {
+        // Three slots, each with sorted records by embedded key. The merged
+        // output must be globally sorted. Exercises `slot_try_next_record`'s
+        // EMBEDDED_IN_RECORD arm + the `extract_from_record` key-from-bytes
+        // path.
+        let file0 =
+            vec![embedded_record(1, b"-A"), embedded_record(4, b"-A"), embedded_record(7, b"-A")];
+        let file1 =
+            vec![embedded_record(2, b"-B"), embedded_record(5, b"-B"), embedded_record(8, b"-B")];
+        let file2 =
+            vec![embedded_record(3, b"-C"), embedded_record(6, b"-C"), embedded_record(9, b"-C")];
+        let slots = vec![
+            embedded_populated_slot(0, &file0, 1),
+            embedded_populated_slot(1, &file1, 1),
+            embedded_populated_slot(2, &file2, 1),
+        ];
+
+        let driver =
+            MergeDriver::<TestEmbeddedKey>::from_slots(slots, MemorySources::Owned(Vec::new()), 9);
+        let emitted = drain_merge_driver_bytes(driver);
+
+        // Verify keys are emitted in sorted order. Tail bytes prove the
+        // identity of each source.
+        let expected = vec![
+            embedded_record(1, b"-A"),
+            embedded_record(2, b"-B"),
+            embedded_record(3, b"-C"),
+            embedded_record(4, b"-A"),
+            embedded_record(5, b"-B"),
+            embedded_record(6, b"-C"),
+            embedded_record(7, b"-A"),
+            embedded_record(8, b"-B"),
+            embedded_record(9, b"-C"),
+        ];
+        assert_eq!(emitted, expected);
+    }
+
+    #[test]
+    fn from_slots_skips_empty_slots_mixed_with_populated() {
+        // Verify a slot whose decompressed queue is empty (and reader marked EOF)
+        // is correctly elided from the LoserTree. Without correct handling
+        // the priming step would either panic or produce a phantom source.
+        let populated = vec![
+            (TestKey(1), b"one".to_vec()),
+            (TestKey(2), b"two".to_vec()),
+            (TestKey(3), b"three".to_vec()),
+        ];
+
+        let empty_slot = StdArc::new(SortMergeSlot::new(
+            99,
+            BufReader::new(tempfile::tempfile().expect("tempfile")),
+            crate::codec::SpillCodec::Bgzf,
+        ));
+        empty_slot.queue_eof.store(true, std::sync::atomic::Ordering::Release);
+        // Insert empty-slot first, then a populated slot. The driver should
+        // skip the empty one during priming and only emit records from the
+        // populated slot.
+        let slots = vec![empty_slot, populated_slot(0, &populated, 1)];
+
+        let driver = MergeDriver::<TestKey>::from_slots(slots, MemorySources::Owned(Vec::new()), 3);
+        let emitted = drain_merge_driver_bytes(driver);
+        assert_eq!(emitted, vec![b"one".to_vec(), b"two".to_vec(), b"three".to_vec()]);
+    }
+
+    /// `slot_try_load_block` checks `decomp_error` BEFORE `queue_eof`, so a slot
+    /// whose decompression failed surfaces `Err` rather than the clean EOF that
+    /// an empty queue plus `queue_eof` looks like. Nothing exercised the error
+    /// arm: every existing test drives `queue_eof`, so swapping the two checks
+    /// would silently convert a failed spill into a short read — records
+    /// dropped, exit status zero — with the whole suite green.
+    #[test]
+    fn decomp_error_surfaces_as_an_error_not_a_clean_eof() {
+        let slot = StdArc::new(SortMergeSlot::new(
+            7,
+            BufReader::new(tempfile::tempfile().expect("tempfile")),
+            crate::codec::SpillCodec::Bgzf,
+        ));
+        // The shape a failed decompression leaves behind: queue drained, EOF
+        // set, and the error flag raised. Ordering matters — both are set, so
+        // only the check order decides the outcome.
+        slot.decomp_error.store(true, std::sync::atomic::Ordering::Release);
+        slot.queue_eof.store(true, std::sync::atomic::Ordering::Release);
+
+        let mut parser = SlotParserState::new();
+        let msg = match slot_try_load_block(&slot, &mut parser) {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("a slot with decomp_error must not report a clean EOF"),
+        };
+        // The whole phrase, not a bare `7`: a lone digit matches any number that
+        // happens to appear in the message, which is a weaker claim than "this
+        // error named the slot that failed".
+        assert!(
+            msg.contains("spill decompression error on slot 7"),
+            "the error must name the failure and the slot; got: {msg}",
+        );
+    }
+
+    #[test]
+    fn from_slots_records_merged_equals_emitted_total() {
+        // `records_merged()` (surfaced by `SortMerge` at completion) must equal
+        // the number of records actually emitted across all sources.
+        let f0: Vec<(TestKey, Vec<u8>)> =
+            (0u64..15).map(|i| (TestKey(i * 2), format!("a-{i:02}").into_bytes())).collect();
+        let f1: Vec<(TestKey, Vec<u8>)> =
+            (0u64..15).map(|i| (TestKey(i * 2 + 1), format!("b-{i:02}").into_bytes())).collect();
+        let total = (f0.len() + f1.len()) as u64;
+
+        let slots = vec![populated_slot(0, &f0, 3), populated_slot(1, &f1, 2)];
+        let mut driver =
+            MergeDriver::<TestKey>::from_slots(slots, MemorySources::Owned(Vec::new()), total);
+
+        let mut emitted = 0u64;
+        loop {
+            match driver.try_step().expect("try_step") {
+                MergeStep::Produced(_) => emitted += 1,
+                MergeStep::Done => break,
+                MergeStep::Stalled => panic!("unexpected Stalled on pre-populated EOF slots"),
+            }
+        }
+        assert_eq!(emitted, total, "should emit every input record");
+        assert_eq!(
+            driver.records_merged(),
+            total,
+            "records_merged must equal the emitted record count"
+        );
     }
 }

--- a/crates/fgumi-sort/src/inline.rs
+++ b/crates/fgumi-sort/src/inline.rs
@@ -14,6 +14,7 @@
 
 #![allow(dead_code)]
 
+use crate::arena_pool::PooledSegmentedBuf;
 use crate::keys::{RawCoordinateKey, RawSortKey, SortContext};
 use crate::radix::bytes_needed_u64;
 use crate::segmented_buf::SegmentedBuf;
@@ -44,7 +45,7 @@ use std::sync::Arc;
 /// In exchange, materialization is allocation-free and the peak
 /// memory of the sort drops by ~1× (the materialization no longer
 /// transiently doubles the buffer).
-pub(crate) struct InMemoryChunk<K> {
+pub struct InMemoryChunk<K> {
     /// Shared backing store for record bytes (the original sort
     /// buffer's `SegmentedBuf`). All sibling chunks from one
     /// `par_sort_into_chunks` call share this Arc, so the segments
@@ -55,7 +56,11 @@ pub(crate) struct InMemoryChunk<K> {
     /// merge is slightly higher, but the materialization-peak
     /// memory drops by ~1× (pre-PR transiently held both the buffer
     /// and a full copy in per-record `Vec<u8>`s).
-    data: Arc<SegmentedBuf>,
+    /// Wrapped in [`PooledSegmentedBuf`] so a chunk drained from a pooled
+    /// coordinate arena returns its storage to the
+    /// [`ArenaPool`](crate::arena_pool::ArenaPool) when the last `Arc` clone
+    /// drops. Non-pooled constructors use `PooledSegmentedBuf::unpooled`.
+    data: Arc<PooledSegmentedBuf>,
     /// `(sort_key, byte_offset_in_data, len)` per record, in sorted
     /// order. `offset` is `u64` because a single `SegmentedBuf` can
     /// exceed 4 GiB at high `--max-memory` × `--threads`; `len` is
@@ -67,39 +72,79 @@ impl<K> InMemoryChunk<K> {
     /// Construct an empty chunk backed by an empty shared buffer.
     #[must_use]
     pub(crate) fn empty() -> Self {
-        Self { data: Arc::new(SegmentedBuf::default()), records: Vec::new() }
+        Self {
+            data: Arc::new(PooledSegmentedBuf::unpooled(SegmentedBuf::default())),
+            records: Vec::new(),
+        }
     }
 
     /// Construct a chunk holding the given records, all referencing
-    /// the same shared data buffer.
+    /// the same shared (possibly pooled) data buffer.
     #[must_use]
-    pub(crate) fn from_parts(data: Arc<SegmentedBuf>, records: Vec<(K, u64, u32)>) -> Self {
+    pub(crate) fn from_parts(data: Arc<PooledSegmentedBuf>, records: Vec<(K, u64, u32)>) -> Self {
         Self { data, records }
+    }
+
+    /// Build a chunk from owned `(key, bytes)` records by packing the bytes into
+    /// a fresh `SegmentedBuf`. This **copies** every record, so it is for callers
+    /// that already hold owned records (tests, or future owned→shared bridging) —
+    /// the production sort path uses `RecordBuffer::drain_into_single_chunk`,
+    /// which moves the arena without copying.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any record's length exceeds `u32::MAX`. BAM records are always
+    /// < 4 GiB, so this cannot happen for real records.
+    #[must_use]
+    pub fn from_owned_records(records: Vec<(K, Vec<u8>)>) -> Self {
+        let mut data = SegmentedBuf::new();
+        let records = records
+            .into_iter()
+            .map(|(key, bytes)| {
+                let offset = data.extend_from_slice(&bytes) as u64;
+                let len = u32::try_from(bytes.len())
+                    .expect("InMemoryChunk record length exceeds u32 (BAM records are < 4 GiB)");
+                (key, offset, len)
+            })
+            .collect();
+        Self { data: Arc::new(PooledSegmentedBuf::unpooled(data)), records }
     }
 
     /// Number of records in the chunk.
     #[must_use]
-    pub(crate) fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.records.len()
     }
 
     /// Whether the chunk is empty.
     #[must_use]
-    pub(crate) fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.records.is_empty()
     }
 
+    /// Total record-payload bytes (the sum of record lengths; excludes keys and
+    /// index overhead). Used for byte-budget accounting at the chunk boundary.
+    #[must_use]
+    pub fn payload_bytes(&self) -> usize {
+        self.records.iter().map(|(_, _, len)| *len as usize).sum()
+    }
+
     /// Borrow the `i`th record's bytes from the shared data buffer.
+    ///
+    /// `pub` so out-of-crate consumers (e.g. the block-parallel spill serializer
+    /// in `fgumi-pipeline-io`) can iterate a chunk's records zero-copy.
     #[must_use]
     #[allow(clippy::cast_possible_truncation)] // offset/len fit in usize on all supported targets
-    pub(crate) fn record_bytes(&self, i: usize) -> &[u8] {
+    pub fn record_bytes(&self, i: usize) -> &[u8] {
         let (_, offset, len) = &self.records[i];
         self.data.slice(*offset as usize, *len as usize)
     }
 
     /// Borrow the `i`th record's sort key.
+    ///
+    /// `pub` for the same reason as [`record_bytes`](Self::record_bytes).
     #[must_use]
-    pub(crate) fn key_at(&self, i: usize) -> &K {
+    pub fn key_at(&self, i: usize) -> &K {
         &self.records[i].0
     }
 
@@ -283,7 +328,14 @@ const _: () = assert!(
 /// Sorting only reorders the index; records stay in place.
 pub struct RecordBuffer {
     /// Segmented byte storage for all records (headers + BAM data).
-    data: SegmentedBuf,
+    ///
+    /// Held as the pool wrapper, not a bare `SegmentedBuf`: an arena acquired
+    /// from the [`ArenaPool`](crate::arena_pool::ArenaPool) lives here for its
+    /// whole fill, so if this were
+    /// bare, dropping the buffer on any error path would retire that pool slot
+    /// permanently. Non-pooled buffers hold an `unpooled` wrapper and drop
+    /// normally.
+    data: PooledSegmentedBuf,
     /// Index of record references for sorting.
     refs: Vec<RecordRef>,
     /// Number of reference sequences (for unmapped handling).
@@ -294,15 +346,21 @@ pub struct RecordBuffer {
 ///
 /// Both `RecordBuffer` and `TemplateRecordBuffer` use this segment size so that
 /// a single BAM record (≤128 MiB in practice) always fits within one segment.
-const SORT_SEGMENT_SIZE: usize = 256 * 1024 * 1024;
+pub const SORT_SEGMENT_SIZE: usize = 256 * 1024 * 1024;
 
 /// Shared implementation for `par_sort_into_chunks` on both buffer types.
 ///
 /// Sorts refs in place (parallel radix sort, partitioned by `chunk_size`),
-/// then drains `self.data` into a single `Arc<SegmentedBuf>` shared
+/// then drains `self.data` into a single `Arc<PooledSegmentedBuf>` shared
 /// across all produced chunks. Each chunk's `records` Vec is built from
 /// its refs' `(key, offset + header_size, len)` triples — no per-record
 /// allocation or memcpy.
+///
+/// The drain goes through each buffer's own `take_data_arc`, never through
+/// `mem::take` here: the two buffer types store `data` at different types
+/// (`PooledSegmentedBuf` vs bare `SegmentedBuf`), so a `take` written in the
+/// macro would deref-coerce past `RecordBuffer`'s pool wrapper and orphan a
+/// pooled arena. See `RecordBuffer::take_data_arc`.
 ///
 /// `$header_size` is the byte distance from each ref's `offset` field
 /// to the start of its actual record bytes inside `data`
@@ -318,7 +376,7 @@ macro_rules! par_sort_into_chunks_impl {
 
         if $threads <= 1 || n < RADIX_THRESHOLD * 2 || n <= 10_000 {
             $sort_fn(&mut $self.refs);
-            let data = Arc::new(std::mem::take(&mut $self.data));
+            let data = $self.take_data_arc();
             let records: Vec<_> =
                 $self.refs.iter().map(|r| ($key_fn(r), r.offset + header_size, r.len)).collect();
             // Clear refs to leave the buffer in a consistent drained
@@ -336,7 +394,7 @@ macro_rules! par_sort_into_chunks_impl {
             $sort_fn(chunk);
         });
 
-        let data = Arc::new(std::mem::take(&mut $self.data));
+        let data = $self.take_data_arc();
 
         let chunks: Vec<_> = $self
             .refs
@@ -364,10 +422,10 @@ impl RecordBuffer {
     #[must_use]
     pub fn with_capacity(estimated_records: usize, estimated_bytes: usize, nref: u32) -> Self {
         Self {
-            data: SegmentedBuf::with_capacity(
+            data: PooledSegmentedBuf::unpooled(SegmentedBuf::with_capacity(
                 estimated_bytes + estimated_records * HEADER_SIZE,
                 SORT_SEGMENT_SIZE,
-            ),
+            )),
             refs: Vec::with_capacity(estimated_records),
             nref,
         }
@@ -484,7 +542,7 @@ impl RecordBuffer {
     /// index-panic against the empty `SegmentedBuf`.
     #[must_use]
     pub(crate) fn drain_into_single_chunk(&mut self) -> InMemoryChunk<RawCoordinateKey> {
-        let data = Arc::new(std::mem::take(&mut self.data));
+        let data = self.take_data_arc();
         let records: Vec<_> = self
             .refs
             .iter()
@@ -495,6 +553,36 @@ impl RecordBuffer {
             .collect();
         self.refs.clear();
         InMemoryChunk::from_parts(data, records)
+    }
+
+    /// Take the backing arena out of the buffer as the shared store for the
+    /// chunks drained from it, leaving an empty placeholder behind.
+    ///
+    /// Moves the **wrapper**, not the inner `SegmentedBuf`, so whether this
+    /// arena is pool-managed travels with it: a pooled arena returns to its
+    /// [`ArenaPool`](crate::arena_pool::ArenaPool) when the chunk's last `Arc`
+    /// drops, an unpooled one just drops. Re-wrapping the inner buffer instead
+    /// would deref-coerce past the wrapper, orphan the arena, and leave a
+    /// wrong-sized default behind for the pool to reclaim — at the default
+    /// `capacity == 1` that retires the only slot permanently.
+    ///
+    /// Every drain on this type goes through here so that reasoning lives in
+    /// one place rather than being re-derived at each call site.
+    fn take_data_arc(&mut self) -> Arc<PooledSegmentedBuf> {
+        Arc::new(std::mem::take(&mut self.data))
+    }
+
+    /// Install a (pool-acquired) arena as this buffer's backing store, replacing
+    /// the empty placeholder left by `drain_into_single_chunk`. Requires the
+    /// buffer to be drained (no refs).
+    pub(crate) fn install_arena(&mut self, arena: PooledSegmentedBuf) {
+        // Unconditional (not `debug_assert!`): replacing `self.data` while stale
+        // `refs` still index the old arena is a silent data-corruption path for a
+        // bit-identical sort engine. This is a state-transition guard, not a
+        // hot-path bounds check — the `is_empty()` cost is negligible next to
+        // record processing.
+        assert!(self.refs.is_empty(), "install_arena over a non-drained buffer");
+        self.data = arena;
     }
 
     /// Get record bytes by reference.
@@ -821,7 +909,7 @@ impl RawSortKey for TemplateKey {
 
     /// # Panics
     ///
-    /// Always panics. `TemplateKey` extraction requires a [`LibraryLookup`](crate::external::LibraryLookup)
+    /// Always panics. `TemplateKey` extraction requires a [`LibraryLookup`](crate::LibraryLookup)
     /// context not available through the `RawSortKey` trait interface. All
     /// callers must use `extract_template_key_inline()` instead.
     fn extract(_bam: &[u8], _ctx: &SortContext) -> Self {
@@ -1568,21 +1656,74 @@ impl<K: TemplateLaneKey> TemplateRecordBuffer<K> {
         )
     }
 
+    /// Take the backing buffer out as the shared store for the chunks drained
+    /// from it, leaving an empty placeholder behind.
+    ///
+    /// Mirrors [`RecordBuffer::take_data_arc`] so both buffer types drain the
+    /// same way through `par_sort_into_chunks_impl!`. This buffer is never
+    /// pool-managed — `data` is a bare `SegmentedBuf`, not a wrapper — so the
+    /// shared handle is `unpooled` and simply drops with its last `Arc`.
+    fn take_data_arc(&mut self) -> Arc<PooledSegmentedBuf> {
+        Arc::new(PooledSegmentedBuf::unpooled(std::mem::take(&mut self.data)))
+    }
+
     /// Drain the (already-sorted) buffer into a single in-memory chunk
     /// whose records share an `Arc<SegmentedBuf>` backing store.
     ///
-    /// See [`RecordBuffer::drain_into_single_chunk`] for usage and
+    /// See `RecordBuffer::drain_into_single_chunk` for usage and
     /// lifetime notes — both `data` and `refs` are cleared after this
     /// call. `iter_sorted_keyed()` would yield zero records and
     /// `get_record()` called with a stale `TemplateRecordRef` would
     /// index-panic against the empty `SegmentedBuf`.
     #[must_use]
     pub(crate) fn drain_into_single_chunk(&mut self) -> InMemoryChunk<K> {
-        let data = Arc::new(std::mem::take(&mut self.data));
+        let data = self.take_data_arc();
         let records: Vec<_> = self
             .refs
             .iter()
             .map(|r| (r.key, r.offset + TEMPLATE_HEADER_SIZE as u64, r.len))
+            .collect();
+        self.refs.clear();
+        InMemoryChunk::from_parts(data, records)
+    }
+
+    /// Drain the (already-sorted) buffer into a single in-memory chunk keyed by
+    /// the **full** [`TemplateKey`] (re-extracted per record via `extract`),
+    /// whose records share an `Arc<SegmentedBuf>` backing store — NO record
+    /// bytes are copied (the arena is moved, not the bodies).
+    ///
+    /// This is the zero-copy analogue of the owned materialisation the legacy
+    /// `TemplateChunkSorter` performs: the narrow lane key `K` drove the sort,
+    /// and the full key is re-widened here for the downstream merge (whose
+    /// `MergeDriver<TemplateKey>` orders on the full key), but the record bodies
+    /// stay resident in the moved arena instead of being copied into owned
+    /// `RawRecord`s. `extract` receives each record's body bytes (the inline
+    /// header already skipped, exactly what [`get_record`](Self::get_record)
+    /// returns) and returns its full `TemplateKey`; it MUST be the same
+    /// extraction the owned path uses, so the produced chunk is byte-for-byte
+    /// identical to the owned `Vec<(TemplateKey, RawRecord)>` (same sorted order,
+    /// same keys, same bodies).
+    ///
+    /// Runs the per-record extraction in parallel (like the owned path's
+    /// `par_iter`), so call it inside the sorter's `rayon_pool.install`. Both
+    /// `data` and `refs` are cleared after this call (the arena is moved into the
+    /// returned chunk); see [`drain_into_single_chunk`](Self::drain_into_single_chunk).
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)] // body_off/len fit usize on all supported targets (BAM < 4 GiB, arena < address space)
+    pub(crate) fn drain_into_full_key_chunk(
+        &mut self,
+        extract: impl Fn(&[u8]) -> TemplateKey + Sync,
+    ) -> InMemoryChunk<TemplateKey> {
+        use rayon::prelude::*;
+        let data = self.take_data_arc();
+        let records: Vec<(TemplateKey, u64, u32)> = self
+            .refs
+            .par_iter()
+            .map(|r| {
+                let body_off = r.offset + TEMPLATE_HEADER_SIZE as u64;
+                let body = data.slice(body_off as usize, r.len as usize);
+                (extract(body), body_off, r.len)
+            })
             .collect();
         self.refs.clear();
         InMemoryChunk::from_parts(data, records)
@@ -2610,6 +2751,49 @@ mod tests {
         }
     }
 
+    /// Parallel/serial parity at the arena dispatch cutoff. The arena front
+    /// (`template_chunk_from_arena_refs`) routes to `parallel_radix_sort_template_refs`
+    /// only when `refs.len() >= PARALLEL_SORT_THRESHOLD`; the arena-vs-owned parity
+    /// test runs far below that, so the parallel branch is never compared against a
+    /// reference there. Mirror `parallel_coordinate_sort_matches_serial_radix_at_threshold`:
+    /// build a threshold-sized input with deliberate key ties and pin the parallel
+    /// radix's ordering against the single-threaded stable radix. Since the
+    /// arena-vs-owned test already proves `radix_sort_template_refs` matches the
+    /// owned sorter, parallel-matches-serial here pins parallel-matches-owned at
+    /// threshold by transitivity.
+    #[test]
+    fn parallel_template_radix_matches_serial_at_threshold() {
+        let n = crate::ref_sort::PARALLEL_SORT_THRESHOLD; // crosses the arena cutoff
+        // Vary the library-name hash (a full-key radix lane) over a small modulus
+        // → ~260 ties per value across the input, so a stability or lane-ordering
+        // bug in the parallel path would reorder equal-key records relative to the
+        // serial radix. `offset` ascends with input order to witness stability.
+        let refs: Vec<TemplateRecordRef<TemplateKey>> = (0..n)
+            .map(|i| {
+                let hash = (i as u64).wrapping_mul(2_654_435_761) % 1009;
+                let key =
+                    TemplateKey::new(0, 100, false, 0, 200, false, 0, 0, (1, true), hash, false);
+                TemplateRecordRef { key, offset: i as u64, len: 10, padding: 0 }
+            })
+            .collect();
+
+        let mut parallel = refs.clone();
+        let mut serial = refs;
+        parallel_radix_sort_template_refs(&mut parallel); // n > 10_000 → real parallel path
+        radix_sort_template_refs(&mut serial); // single-threaded stable reference
+
+        assert_eq!(parallel.len(), serial.len());
+        for (i, (p, s)) in parallel.iter().zip(&serial).enumerate() {
+            assert!(
+                p.key == s.key && p.offset == s.offset,
+                "parallel template radix diverged from serial radix at index {i} \
+                 (parallel offset {}, serial offset {})",
+                p.offset,
+                s.offset,
+            );
+        }
+    }
+
     #[test]
     fn test_template_record_buffer_sort_stability() {
         // Test that TemplateRecordBuffer::sort() is stable
@@ -3307,7 +3491,7 @@ mod tests {
     fn test_in_memory_chunk_from_parts_reads_records() {
         let (buf, offsets) =
             build_segmented_buf_with_records(&[b"first", b"second-record", b"third"]);
-        let data = Arc::new(buf);
+        let data = Arc::new(PooledSegmentedBuf::unpooled(buf));
         let records = vec![
             (10u32, offsets[0].0, offsets[0].1),
             (20u32, offsets[1].0, offsets[1].1),
@@ -3329,7 +3513,7 @@ mod tests {
     fn test_in_memory_chunk_take_key_replaces_with_default() {
         let (buf, offsets) = build_segmented_buf_with_records(&[b"payload"]);
         let chunk = InMemoryChunk::<u32>::from_parts(
-            Arc::new(buf),
+            Arc::new(PooledSegmentedBuf::unpooled(buf)),
             vec![(42u32, offsets[0].0, offsets[0].1)],
         );
         let mut chunk = chunk;
@@ -3347,7 +3531,7 @@ mod tests {
         // Arc<SegmentedBuf>, so the data isn't duplicated and is freed
         // only when the last chunk drops.
         let (buf, offsets) = build_segmented_buf_with_records(&[b"alpha", b"beta", b"gamma"]);
-        let data = Arc::new(buf);
+        let data = Arc::new(PooledSegmentedBuf::unpooled(buf));
         let chunk_a = InMemoryChunk::<u32>::from_parts(
             Arc::clone(&data),
             vec![(1, offsets[0].0, offsets[0].1)],
@@ -3448,6 +3632,44 @@ mod tests {
         // Strong count = number of chunks (after the macro's local `data`
         // binding has been dropped).
         assert_eq!(Arc::strong_count(&chunks[0].data), chunks.len());
+    }
+
+    /// `par_sort_into_chunks` must move the pool WRAPPER out of the buffer, the
+    /// same way `drain_into_single_chunk` does. Re-wrapping the *inner*
+    /// `SegmentedBuf` deref-coerces past the wrapper: the real arena is orphaned
+    /// (the chunks drop it instead of returning it) while the buffer keeps a
+    /// wrong-sized default that still believes it is pooled. At the default
+    /// `capacity == 1` that retires the only slot, and since the documented
+    /// response to `try_acquire() == None` is to backpressure until an arena
+    /// returns, the caller hangs rather than errors.
+    ///
+    /// `buffer` is deliberately still alive at the assert: the arena must come
+    /// back from the dropped chunks, not from the drained buffer's leftover
+    /// wrapper. Both exits of `par_sort_into_chunks_impl!` are covered — the
+    /// single-chunk early return and the multi-chunk path.
+    #[rstest::rstest]
+    #[case::single_chunk_exit(1_000)]
+    #[case::multi_chunk_exit(10_500)]
+    fn par_sort_into_chunks_returns_the_pooled_arena_when_its_chunks_drop(#[case] n: usize) {
+        let arena_pool = crate::arena_pool::ArenaPool::new(1, SORT_SEGMENT_SIZE);
+        let mut buffer = RecordBuffer::with_capacity(n, n * 64, 4);
+        buffer.install_arena(arena_pool.try_acquire().expect("the fresh pool hands out its arena"));
+
+        for i in 0..n {
+            // Descending position so the sort is non-trivial. `#[allow]` on the
+            // test fn would not reach the per-case fns `rstest` generates, so
+            // the cast is done with `try_from` rather than suppressed.
+            let pos = i32::try_from(n - i).expect("test record count fits i32");
+            buffer.push_coordinate(&make_coordinate_bam_record(0, pos)).expect("push_coordinate");
+        }
+
+        let rayon_pool =
+            rayon::ThreadPoolBuilder::new().num_threads(4).build().expect("rayon pool build");
+        let chunks = rayon_pool.install(|| buffer.par_sort_into_chunks(4));
+        assert_eq!(arena_pool.free_len(), 0, "the arena is in flight while the chunks hold it");
+
+        drop(chunks);
+        assert_eq!(arena_pool.free_len(), 1, "dropping the chunks returns the arena to the pool");
     }
 
     mod template_key32 {

--- a/crates/fgumi-sort/src/keys.rs
+++ b/crates/fgumi-sort/src/keys.rs
@@ -9,7 +9,7 @@
 //! - [`RawCoordinateKey`]: Fixed-size genomic coordinate key (tid, pos, strand)
 //! - [`RawQuerynameKey`]: Read name with natural numeric ordering
 //! - [`RawQuerynameLexKey`]: Read name with lexicographic ordering
-//! - [`TemplateKey`](crate::inline::TemplateKey): Template-level position for UMI grouping
+//! - [`TemplateKey`](crate::TemplateKey): Template-level position for UMI grouping
 //!
 //! # Generic Sorting Abstraction
 //!
@@ -23,10 +23,53 @@
 //! - samtools' `bam1_tag` union (C)
 
 use noodles::sam::Header;
+use smallvec::SmallVec;
 use std::cmp::Ordering;
 
 use fgumi_raw_bam::RawRecordView;
 use std::io::{Read, Write};
+
+/// Inline-capacity buffer for queryname key name bytes. An inline `SmallVec`
+/// keeps the name **contiguous inside the sort ref array** instead of a
+/// per-record heap allocation. During the comparison sort this eliminates the
+/// pointer-chase to scattered heap that dominates on memory-latency-bound cores
+/// (e.g. Graviton), where the queryname sort regressed vs the owned-`Vec` key.
+/// Names longer than the inline capacity spill to the heap transparently.
+///
+/// # Why 44
+///
+/// 44 is the smallest capacity that keeps **every** read name we have measured
+/// inline, and it is free relative to 40: `SmallVec` rounds both to a 56-byte
+/// buffer, so 40 and 44 produce an identical 64-byte `RawQuerynameKey`. 40 would
+/// leave ~16% of native Illumina names spilling for no saving.
+///
+/// Read names in practice fall into two regimes, and the choice was measured on
+/// both rather than on one:
+///
+/// - **Native Illumina** (`A00132:53:HFHJKDSXX:1:1646:26467:33332`) — 37-41
+///   bytes with the NUL. This is raw instrument output. At capacity 24 *every*
+///   name spills.
+/// - **SRA-normalized / synthetic** (`SRR36097899.1`, `mol000000_read0001`) —
+///   13-22 bytes. These fit at 24 already, so a larger inline buffer is pure
+///   cost for them.
+///
+/// End-to-end `fgumi sort --order queryname` (15-16M records, `-m 512m -t 8`,
+/// 4-6 reps, CV ≈ 3%), capacity 44 against capacity 24:
+///
+/// | input | CPU | peak RSS |
+/// | --- | --- | --- |
+/// | native Illumina | −9.5% | −4.4% |
+/// | SRA-normalized | −0.6% (neutral) | +3.9% |
+///
+/// The long-name win is not a memory-for-speed trade, which is the intuition
+/// this measurement overturned: a million individually heap-allocated names cost
+/// *more* resident memory than a million 16-byte-larger inline keys, so 44 is
+/// both faster and smaller there. Isolated key-level cost on native names is
+/// 2.4x faster to extract and 1.95x faster to sort. The price is ~4% peak RSS on
+/// short-name inputs, where CPU is unchanged.
+pub(crate) const NAME_INLINE_CAP: usize = 44;
+
+type NameBuf = SmallVec<[u8; NAME_INLINE_CAP]>;
 
 // ============================================================================
 // Generic Sorting Abstraction (Trait-based, inspired by fgbio/samtools)
@@ -519,13 +562,18 @@ fn write_queryname_key<W: Write>(name: &[u8], flags: u16, writer: &mut W) -> std
 }
 
 /// Deserialize a queryname key from `[name_len: u16][name: bytes][flags: u16]`.
+///
+/// Reads the name straight into an inline [`NameBuf`] so the spill-merge read
+/// path allocates no per-record heap for short names — the merge-side analogue
+/// of the SSO key change on the ingest path.
 #[inline]
-fn read_queryname_key<R: Read>(reader: &mut R) -> std::io::Result<(Vec<u8>, u16)> {
+fn read_queryname_key<R: Read>(reader: &mut R) -> std::io::Result<(NameBuf, u16)> {
     let mut len_buf = [0u8; 2];
     reader.read_exact(&mut len_buf)?;
     let name_len = u16::from_le_bytes(len_buf) as usize;
 
-    let mut name = vec![0u8; name_len];
+    let mut name: NameBuf = SmallVec::new();
+    name.resize(name_len, 0);
     reader.read_exact(&mut name)?;
 
     let mut flags_buf = [0u8; 2];
@@ -543,16 +591,31 @@ fn read_queryname_key<R: Read>(reader: &mut R) -> std::io::Result<(Vec<u8>, u16)
 /// Unlike fixed-size keys, serialization size depends on name length.
 ///
 /// Serialization format: `[name_len: u16][name: bytes][flags: u16]`
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct RawQuerynameKey {
-    /// Read name bytes, null-terminated for `natural_compare_nul`.
-    name: Vec<u8>,
+    /// Read name bytes, null-terminated for `natural_compare_nul`. Inline for
+    /// short names (see [`NameBuf`]) so the comparison sort stays cache-local.
+    name: NameBuf,
     /// Flags for segment ordering (R1 before R2).
     flags: u16,
     /// Ingest position within the current in-memory chunk; see
     /// [`RawSortKey::set_position`]. Lands in existing padding on 64-bit targets,
     /// so the key does not grow there. Zero after a merge-time rebuild.
     pos: u32,
+}
+
+impl Default for RawQuerynameKey {
+    /// A default key must still satisfy the null-terminated invariant that
+    /// `cmp`'s `natural_compare_nul` relies on — a derived `Default` would leave
+    /// `name` empty (no terminator), so a default-constructed key would feed a
+    /// non-terminated pointer into the comparator (out-of-bounds read). This is
+    /// required because generic merge code bounds `K: RawSortKey + Default`
+    /// (e.g. `MergeDriver<K>`, `MemorySources<K>`). The default is the empty
+    /// name `"\0"` — it orders before any non-empty name and terminates
+    /// immediately.
+    fn default() -> Self {
+        Self { name: SmallVec::from_slice(&[0]), flags: 0, pos: 0 }
+    }
 }
 
 impl PartialEq for RawQuerynameKey {
@@ -572,7 +635,7 @@ impl RawQuerynameKey {
         if name.last() != Some(&0) {
             name.push(0);
         }
-        Self { name, flags, pos: 0 }
+        Self { name: SmallVec::from_vec(name), flags, pos: 0 }
     }
 
     /// Returns the read name bytes (including the null terminator).
@@ -589,12 +652,13 @@ impl RawQuerynameKey {
         let flags = queryname_flag_order(u16::from_le_bytes([bam[14], bam[15]]));
         match raw_name_with_nul(bam) {
             // BAM stores the name NUL-terminated, so copy those bytes directly
-            // instead of stripping the NUL and re-appending it. `pos` is filled in
-            // later by `set_position`; a merge-time rebuild leaves it 0.
-            Some(name) => Self { name: name.to_vec(), flags, pos: 0 },
+            // (inline when short) instead of stripping the NUL and re-appending
+            // it. `pos` is filled in later by `set_position`; a merge-time
+            // rebuild leaves it 0.
+            Some(name) => Self { name: SmallVec::from_slice(name), flags, pos: 0 },
             // Truncated or non-terminated record: fall back to the stripped-name
             // path (`new` re-adds the terminator and sets `pos: 0`), preserving
-            // the prior bytes.
+            // the prior bytes exactly.
             None => Self::new(extract_raw_name_and_flags(bam).0.to_vec(), flags),
         }
     }
@@ -604,7 +668,11 @@ impl Ord for RawQuerynameKey {
     #[inline]
     #[allow(unsafe_code)]
     fn cmp(&self, other: &Self) -> Ordering {
-        // SAFETY: `name` is always null-terminated (see `extract_queryname_key` and `new`).
+        // SAFETY: `name` is always null-terminated by every constructor
+        // (`extract_queryname_key`, `new`, `read_from`, and the hand-written
+        // `Default`, which exists precisely to uphold this invariant -- a
+        // derived one would leave `name` empty and this walk would run off the
+        // end).
         unsafe { natural_compare_nul(self.name.as_ptr(), other.name.as_ptr()) }
             .then_with(|| self.flags.cmp(&other.flags))
             .then_with(|| self.pos.cmp(&other.pos))
@@ -644,8 +712,18 @@ impl RawSortKey for RawQuerynameKey {
 
     #[inline]
     fn read_from<R: Read>(reader: &mut R) -> std::io::Result<Self> {
-        let (name, flags) = read_queryname_key(reader)?;
-        Ok(Self::new(name, flags))
+        // A well-formed frame (written by `write_to`) already carries the
+        // trailing NUL that `cmp`'s `natural_compare_nul` unsafe relies on, so
+        // the common path constructs directly rather than via `new`. But
+        // `read_from` is a public entry point that could be handed a truncated
+        // or malformed frame; re-append the terminator if it is missing so the
+        // NUL-termination invariant holds unconditionally and the comparator can
+        // never walk off the end.
+        let (mut name, flags) = read_queryname_key(reader)?;
+        if name.last() != Some(&0) {
+            name.push(0);
+        }
+        Ok(Self { name, flags, pos: 0 })
     }
 }
 
@@ -661,8 +739,9 @@ impl RawSortKey for RawQuerynameKey {
 /// Serialization format: `[name_len: u16][name: bytes][flags: u16]`
 #[derive(Clone, Eq, PartialEq, Debug, Default)]
 pub struct RawQuerynameLexKey {
-    /// Read name bytes.
-    name: Vec<u8>,
+    /// Read name bytes. Inline for short names (see [`NameBuf`]) so the
+    /// comparison sort stays cache-local.
+    name: NameBuf,
     /// Flags for segment ordering (R1 before R2).
     flags: u16,
     /// Ingest position within the current in-memory chunk; see
@@ -675,7 +754,7 @@ impl RawQuerynameLexKey {
     /// Create a new lexicographic queryname key.
     #[must_use]
     pub fn new(name: Vec<u8>, flags: u16) -> Self {
-        Self { name, flags, pos: 0 }
+        Self { name: SmallVec::from_vec(name), flags, pos: 0 }
     }
 
     /// Returns the read name bytes.
@@ -689,7 +768,7 @@ impl RawQuerynameLexKey {
     #[must_use]
     fn extract_queryname_key(bam: &[u8]) -> Self {
         let (raw_name, flags) = extract_raw_name_and_flags(bam);
-        Self { name: raw_name.to_vec(), flags, pos: 0 }
+        Self { name: SmallVec::from_slice(raw_name), flags, pos: 0 }
     }
 }
 
@@ -751,22 +830,31 @@ mod tests {
 
     /// The ingest position must land in the key's existing tail padding.
     ///
-    /// On a 64-bit target `Vec<u8>` (24 bytes, align 8) plus a `u16` leaves 6 bytes of
-    /// padding, so the `u32` is free. If this ever fails the tiebreak has started
-    /// costing memory per record, and the trade against a stable sort needs
+    /// On a 64-bit target [`NameBuf`] measures 56 bytes (align 8); adding the `u16`
+    /// flags reaches 58, which rounds up to 64 and leaves 6 bytes of padding. The
+    /// `u32` position therefore costs nothing. If this ever fails the tiebreak has
+    /// started costing memory per record, and the trade against a stable sort needs
     /// re-evaluating: the whole point is that a total order is cheaper than
     /// stable-sorting.
     ///
-    /// The assertion is scoped to 64-bit because the padding is. A 32-bit `Vec<u8>` is
-    /// 12 bytes, which leaves only 2 bytes after the `u16`, so the key grows from 16 to
-    /// 20 bytes there. That is a cost question, not a correctness one — the total order
-    /// the unstable sort depends on holds on every target — and fgumi's sort is a
-    /// 64-bit workload, so the zero-growth claim is made for 64-bit only.
+    /// The size moved from 32 to 48 when the name became an inline `SmallVec` rather
+    /// than a `Vec<u8>`, and from 48 to 64 when that buffer grew from 24 to 44 bytes
+    /// so native Illumina names stop spilling (see [`NameBuf`]). Both steps are the
+    /// SSO buffer being paid for, not the position, which was free before either
+    /// change and is free after both.
+    ///
+    /// The assertion is scoped to 64-bit because the padding is. That is a cost
+    /// question, not a correctness one — the total order the unstable sort depends on
+    /// holds on every target — and fgumi's sort is a 64-bit workload, so the
+    /// zero-growth claim is made for 64-bit only.
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn position_fits_in_existing_key_padding() {
-        assert_eq!(std::mem::size_of::<RawQuerynameLexKey>(), 32);
-        assert_eq!(std::mem::size_of::<RawQuerynameKey>(), 32);
+        assert_eq!(std::mem::size_of::<RawQuerynameLexKey>(), 64);
+        assert_eq!(std::mem::size_of::<RawQuerynameKey>(), 64);
+        // The claim is that `pos` is free, so pin the padding it lives in rather
+        // than only the total: name + flags alone already round up to 64.
+        assert_eq!(std::mem::size_of::<NameBuf>() + std::mem::size_of::<u16>(), 58);
     }
 
     /// Name and flags alone are not a total order; position makes them one.
@@ -814,6 +902,21 @@ mod tests {
         let a = RawQuerynameLexKey::new(b"read1".to_vec(), 0);
         let b = RawQuerynameLexKey::new(b"read1".to_vec(), 0);
         assert_eq!(a, b);
+    }
+
+    /// `RawQuerynameKey::default()` must produce a null-terminated `name` so the
+    /// `unsafe` `natural_compare_nul` in `cmp` never walks off the end of an
+    /// unterminated buffer (a derived `Default` would leave `name` empty). The
+    /// default orders before any non-empty name.
+    #[test]
+    fn default_queryname_key_is_null_terminated() {
+        let def = RawQuerynameKey::default();
+        assert_eq!(def.name(), &[0u8], "default name must be a single NUL terminator");
+        // cmp against a real key must not read out of bounds and must order the
+        // empty default first.
+        let real = RawQuerynameKey::new(b"read1".to_vec(), 0);
+        assert_eq!(def.cmp(&real), Ordering::Less);
+        assert_eq!(def.cmp(&RawQuerynameKey::default()), Ordering::Equal);
     }
 
     // ========================================================================
@@ -1836,5 +1939,114 @@ mod tests {
             Some(&0),
             "extracted name must be NUL-terminated for natural_compare_nul"
         );
+    }
+
+    // NameBuf heap-fallback (SSO spill) tests
+    //
+    // `NameBuf` inlines names up to `NAME_INLINE_CAP` bytes and spills longer ones to the
+    // heap. Read names in real data are almost always short, so the common
+    // unit tests above only exercise the inline path. These tests explicitly
+    // drive names past the inline capacity for BOTH key kinds (lexicographic
+    // and natural) across every surface that touches a `NameBuf`: `new`,
+    // `extract_from_record`, the `write_to`/`read_from` serialization
+    // roundtrip, and ordering — so the heap-backed path can never silently
+    // regress.
+    // ========================================================================
+
+    /// A read name comfortably longer than `NameBuf`'s inline capacity, so the
+    /// backing `SmallVec` is forced onto the heap. The trailing `9` / `10` lets a
+    /// paired name below expose the lex-vs-natural ordering split.
+    ///
+    /// The prefix alone must exceed `NAME_INLINE_CAP`, so every name derived from
+    /// it spills regardless of suffix — `heap_name_prefix_actually_spills` pins
+    /// that. Raising the capacity without lengthening this would silently turn
+    /// the whole heap-fallback block below into a second set of inline tests.
+    const HEAP_NAME_PREFIX: &[u8] = b"A00123:45:HGVWXDSXY:1:1101:12345:67890:24680:13579:";
+
+    /// The heap-fallback block below is only meaningful while its names spill.
+    #[test]
+    fn heap_name_prefix_actually_spills() {
+        assert!(
+            HEAP_NAME_PREFIX.len() > NAME_INLINE_CAP,
+            "HEAP_NAME_PREFIX is {} bytes but NameBuf inlines {NAME_INLINE_CAP}; the \
+             heap-fallback tests would run on the inline path",
+            HEAP_NAME_PREFIX.len(),
+        );
+    }
+
+    #[test]
+    fn test_natural_key_heap_name_serialization_roundtrip() {
+        let name = [HEAP_NAME_PREFIX, b"67890"].concat();
+        assert!(name.len() > NAME_INLINE_CAP, "test name must exceed NameBuf inline capacity");
+
+        let key = RawQuerynameKey::new(name.clone(), 42);
+        // `new` appends the NUL terminator that `natural_compare_nul` relies on.
+        assert_eq!(key.name(), [name.as_slice(), b"\0"].concat().as_slice());
+
+        let mut buf = Vec::new();
+        key.write_to(&mut buf).expect("write_to should succeed");
+        let mut cursor = std::io::Cursor::new(&buf);
+        let restored = RawQuerynameKey::read_from(&mut cursor).expect("read_from should succeed");
+
+        assert_eq!(key, restored);
+        assert_eq!(restored.name(), key.name(), "heap name (incl. NUL) must survive roundtrip");
+    }
+
+    #[test]
+    fn test_lex_key_heap_name_serialization_roundtrip() {
+        let name = [HEAP_NAME_PREFIX, b"67890"].concat();
+        assert!(name.len() > NAME_INLINE_CAP, "test name must exceed NameBuf inline capacity");
+
+        let key = RawQuerynameLexKey::new(name.clone(), 42);
+        assert_eq!(key.name(), name.as_slice());
+
+        let mut buf = Vec::new();
+        key.write_to(&mut buf).expect("write_to should succeed");
+        let mut cursor = std::io::Cursor::new(&buf);
+        let restored =
+            RawQuerynameLexKey::read_from(&mut cursor).expect("read_from should succeed");
+
+        assert_eq!(key, restored);
+        assert_eq!(restored.name(), key.name(), "heap name must survive roundtrip");
+    }
+
+    #[test]
+    fn test_queryname_keys_extract_from_record_heap_name() {
+        use fgumi_raw_bam::testutil::make_bam_bytes;
+
+        let name = [HEAP_NAME_PREFIX, b"67890"].concat();
+        assert!(name.len() > NAME_INLINE_CAP, "test name must exceed NameBuf inline capacity");
+        let bam = make_bam_bytes(0, 0, 0, &name, &[], 100, -1, -1, &[]);
+
+        // Lexicographic: the extracted name is the raw name, no NUL.
+        let lex = RawQuerynameLexKey::extract_from_record(&bam);
+        assert_eq!(lex.name(), name.as_slice());
+
+        // Natural: the extracted name is NUL-terminated for `natural_compare_nul`.
+        let nat = RawQuerynameKey::extract_from_record(&bam);
+        assert_eq!(nat.name(), [name.as_slice(), b"\0"].concat().as_slice());
+    }
+
+    #[test]
+    fn test_heap_name_lex_vs_natural_ordering_difference() {
+        // Both names spill to the heap; they differ only in the numeric suffix
+        // `9` vs `10`, so the two comparators disagree exactly as they do for
+        // short names — proving the split is preserved on the heap-backed path.
+        let name_9 = [HEAP_NAME_PREFIX, b"9"].concat();
+        let name_10 = [HEAP_NAME_PREFIX, b"10"].concat();
+        assert!(
+            name_9.len() > NAME_INLINE_CAP && name_10.len() > NAME_INLINE_CAP,
+            "names must exceed inline capacity",
+        );
+
+        // Lexicographic: '1' < '9', so `...:10` sorts before `...:9`.
+        let lex_9 = RawQuerynameLexKey::new(name_9.clone(), 0);
+        let lex_10 = RawQuerynameLexKey::new(name_10.clone(), 0);
+        assert!(lex_10 < lex_9, "lexicographic: '...:10' should be < '...:9'");
+
+        // Natural: 9 < 10 numerically, so `...:9` sorts before `...:10`.
+        let nat_9 = RawQuerynameKey::new(name_9, 0);
+        let nat_10 = RawQuerynameKey::new(name_10, 0);
+        assert!(nat_9 < nat_10, "natural: '...:9' should be < '...:10'");
     }
 }

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -40,10 +40,12 @@ use noodles::sam::header::record::value::map::header::tag as header_tag;
 use tempfile::TempDir;
 
 // Sub-modules are crate-private except where a consumer needs to name the type
-// itself rather than just receive it (`arena_pool`, `segmented_buf`, `codec`).
+// itself rather than just receive it (`arena_pool`, `segmented_buf`, `codec`,
+// `ref_sort`, `template_arena`).
 // Everything else is re-exported at the crate root below.
 pub mod arena_pool;
 pub(crate) mod bgzf_io;
+pub(crate) mod chunk_sorter;
 pub mod codec;
 pub(crate) mod external;
 pub(crate) mod inline;
@@ -57,7 +59,17 @@ pub(crate) mod pooled_chunk_writer;
 pub(crate) mod radix;
 pub(crate) mod read_ahead;
 pub(crate) mod reader;
+pub mod ref_sort;
 pub mod segmented_buf;
+pub mod template_arena;
+// Block-granular spill compression kernel for the block-parallel spill steps
+// (`SpillGather`/`SpillCompress`/`SpillWrite`). Surfaced via the re-exports
+// below.
+pub(crate) mod spill_block;
+pub(crate) mod spill_block_reader;
+// Synchronous inline spill compress for the P6 `CompressSpill` step (retires the
+// `SortWorkerPool` compress path). Surfaced via `write_sorted_chunk` below.
+pub(crate) mod sync_spill_writer;
 pub(crate) mod tmp_dir_alloc;
 pub(crate) mod verify;
 pub(crate) mod worker_pool;
@@ -165,14 +177,17 @@ fn create_temp_dir(base: Option<&Path>) -> Result<TempDir> {
 }
 
 pub use arena_pool::{ArenaPool, PooledSegmentedBuf};
+pub use chunk_sorter::{CoordinateChunkSorter, TemplateChunkSorter};
 pub use codec::SpillCodec;
+pub use external::MemorySources;
 pub use external::{
-    KeyTypesSpec, LibraryLookup, RawExternalSorter, cb_hasher, extract_template_key_inline,
-    format_thread_counts,
+    KeyTypesSpec, LibraryLookup, MergeDriver, MergeDriverDyn, MergeStep, RawExternalSorter,
+    cb_hasher, extract_template_key_inline, format_thread_counts, open_spill_slot,
 };
 pub use inline::{
-    PackedCoordinateKey, RecordRef, TemplateKey, extract_coordinate_key_inline,
-    radix_sort_record_refs, radix_sort_record_refs_with_max,
+    CbKey32, InMemoryChunk, PackedCoordinateKey, RecordBuffer, RecordRef, SORT_SEGMENT_SIZE,
+    TemplateKey, TemplateKey24, TertKey32, extract_coordinate_key_inline, radix_sort_record_refs,
+    radix_sort_record_refs_with_max,
 };
 pub use keys::{
     QuerynameComparator, RawCoordinateKey, RawQuerynameKey, RawQuerynameLexKey, RawSortKey,
@@ -183,7 +198,17 @@ pub use reader::{
     OwnedRawBamRecordReader, RawBamRecordReader, open_raw_bam_record_reader,
     open_raw_bam_record_reader_with_header,
 };
+pub use ref_sort::{
+    coordinate_chunk_from_arena_refs, coordinate_chunk_from_refs, queryname_chunk_from_arena_refs,
+};
 pub use segmented_buf::SegmentedBuf;
+pub use spill_block::{SpillBlockCompressor, frame_keyed_record_into, spill_magic, spill_trailer};
+pub use spill_block_reader::SpillBlockDecompressor;
+pub use sync_spill_writer::{write_sorted_chunk, write_sorted_chunk_inmem};
+pub use template_arena::{
+    TemplateArenaAccumulator, TemplateMemChunk, template_chunk_from_arena_refs,
+};
+pub use tmp_dir_alloc::TmpDirAllocator;
 pub use verify::{VerifySummary, verify_sort_order};
 
 #[cfg(test)]

--- a/crates/fgumi-sort/src/merge_slots.rs
+++ b/crates/fgumi-sort/src/merge_slots.rs
@@ -76,13 +76,22 @@
 //!
 //! ## Status in this tree, and the OTHER Phase-2 implementation
 //!
-//! **`SortMergeSlot` currently has no callers.** It is landing ahead of
-//! the engine that drives it, as one slice of a phased port; the
-//! producer/consumer steps named above (`SortSpillDecompress`,
-//! `SortMerge`) and `external.rs::slot_try_load_block` arrive with the
-//! `worker_pool.rs` / `external.rs` rewrite in a later phase. Until then
-//! the crate's live Phase-2 is `worker_pool::Phase2FileState`, driven
-//! through `RawExternalSorter::sort` — the opposite of the end state.
+//! **`SortMergeSlot` has in-crate callers but no production caller.** The
+//! arena engine gave it two: `external.rs::open_spill_slot`, which opens a
+//! spill file as a slot, and `MergeDriver::from_slots`, which merges a set
+//! of them. Both are reachable only from tests in this tree — their
+//! production consumer is the typed-step `SortSpillDecompress` /
+//! `SortMerge` pair, which arrives with `fgumi-pipeline-io` in a later
+//! phase. Until then the crate's live Phase-2 is
+//! `worker_pool::Phase2FileState`, driven through `RawExternalSorter::sort`
+//! — which is what `fgumi sort` and `fgumi merge` actually call.
+//!
+//! That "no production driver yet" fact is now stated in four places — twice
+//! here, once on `worker_pool::Phase2FileState`, and once in
+//! `docs/design/sort-phase2-unification-deferral.md`, which is **canonical**.
+//! All four have to change together when the pipeline steps land, so start
+//! from the design doc. (This PR already had to correct that doc for a stale
+//! method name, which is the failure mode.)
 //!
 //! `worker_pool::Phase2FileState` keeps its own reorder buffer and
 //! in-flight counter because its single-reader/**multi-decompressor**
@@ -136,11 +145,16 @@ use crate::codec::SpillCodec;
 ///
 /// `worker_pool.rs` declares a *different* constant of the same name
 /// (`pub(crate) const PHASE2_DECOMP_CAP: usize = 8`) for its own Phase-2, and
-/// that is the one governing this crate's live merge path until the engine
-/// rewrite lands — this module has no callers yet. So `fgumi_sort::PHASE2_DECOMP_CAP`
-/// resolves to 32 while the merge that actually runs is bounded at 8. The two
-/// are deliberately unequal (see this constant's history above); the confusable
-/// part is only which is in force, and that flips when the rewrite lands.
+/// that is the one governing this crate's live merge path: `fgumi sort` and
+/// `fgumi merge` run through `RawExternalSorter`, i.e. the pool. This module's
+/// callers (`open_spill_slot`, `MergeDriver::from_slots`) are reachable only
+/// from tests until the typed-step `SortMerge` consumer lands. So
+/// `fgumi_sort::PHASE2_DECOMP_CAP` resolves to 32 while the merge that actually
+/// runs is bounded at 8. The two are deliberately unequal (see this constant's
+/// history above); the confusable part is only which is in force, and that
+/// flips when the pipeline steps land — see
+/// `docs/design/sort-phase2-unification-deferral.md`, the canonical statement
+/// of when that happens.
 pub const PHASE2_DECOMP_CAP: usize = 32;
 
 /// Disk reader state for a single spill file. Mutex'd separately

--- a/crates/fgumi-sort/src/ref_sort.rs
+++ b/crates/fgumi-sort/src/ref_sort.rs
@@ -1,0 +1,415 @@
+//! Build a sorted coordinate [`InMemoryChunk`] from record bodies already resident
+//! in a shared arena, WITHOUT copying record bytes — the core of the parallel-inflate
+//! ingest. The chunk's `(offset, len)` point at record bodies in the supplied arena;
+//! the existing Phase-2 merge consumes it unchanged.
+
+use std::cmp::Ordering;
+use std::sync::Arc;
+
+use voracious_radix_sort::{RadixSort, Radixable};
+
+use crate::arena_pool::PooledSegmentedBuf;
+use crate::inline::{
+    InMemoryChunk, RecordRef, extract_coordinate_key_inline, radix_sort_record_refs,
+};
+use crate::keys::{RawCoordinateKey, RawSortKey};
+
+/// Arrays smaller than this sort faster single-threaded (the parallel radix's
+/// partition + thread-coordination overhead exceeds its benefit on small inputs;
+/// microbench-tuned). Shared with the template arena builder
+/// (`template_arena::template_chunk_from_arena_refs`) so both order-specific
+/// radix fronts fall back to the serial path at the same input size.
+pub(crate) const PARALLEL_SORT_THRESHOLD: usize = 256 * 1024;
+
+/// `repr(transparent)` view of a [`RecordRef`] that orders by the
+/// `(sort_key, offset)` **composite** rather than by `sort_key` alone.  This lets
+/// `voracious`'s (unstable) parallel radix produce a STABLE-equivalent coordinate
+/// order: within one chunk every record has a distinct `offset` that increases in
+/// input order, so `(sort_key, offset)` is a total order whose ties resolve to
+/// input order — byte-identical to the stable single-threaded radix.  Wrapping
+/// (instead of changing `RecordRef`'s own `PartialEq`) keeps `RecordRef`'s
+/// existing key-only equality untouched for the rest of the engine.
+#[repr(transparent)]
+#[derive(Copy, Clone)]
+struct CoordSortRef(RecordRef);
+
+/// `sort_coordinate_refs` reinterprets `*mut [RecordRef]` as `*mut [CoordSortRef]`.
+/// A fat pointer carries an element count, not a byte length, so the cast is
+/// sound only while the two types share size and alignment — a stride mismatch
+/// would walk the slice off its end. `repr(transparent)` guarantees that today;
+/// this pins it, so adding a field or dropping the attribute is a compile error
+/// rather than silent unsoundness. Worth the two lines because this crate is not
+/// covered by the Miri job (`miri.yml` runs only `-p fgumi-raw-bam sort`).
+const _: () = {
+    assert!(size_of::<CoordSortRef>() == size_of::<RecordRef>());
+    assert!(align_of::<CoordSortRef>() == align_of::<RecordRef>());
+};
+
+impl CoordSortRef {
+    #[inline]
+    fn composite(self) -> u128 {
+        (u128::from(self.0.sort_key) << 64) | u128::from(self.0.offset)
+    }
+}
+
+impl PartialOrd for CoordSortRef {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.composite().cmp(&other.composite()))
+    }
+}
+
+impl PartialEq for CoordSortRef {
+    fn eq(&self, other: &Self) -> bool {
+        self.composite() == other.composite()
+    }
+}
+
+impl Radixable<u128> for CoordSortRef {
+    type Key = u128;
+    #[inline]
+    fn key(&self) -> u128 {
+        self.composite()
+    }
+}
+
+/// Sort coordinate `RecordRef`s in place, stably by `sort_key`.
+///
+/// For large inputs with `sort_threads > 1`, uses `voracious`'s parallel radix
+/// over the `(sort_key, offset)` composite (see [`CoordSortRef`]) — measured ~4×
+/// faster than the single-threaded radix at realistic coordinate-key widths.  For
+/// small inputs or a single thread it falls back to the single-threaded stable LSD
+/// radix (the parallel path's overhead does not pay off there).  Both produce
+/// byte-identical output (verified by the ref-sort oracle tests) — but only
+/// under the precondition below.
+///
+/// # Precondition: `offset` ascends with input order
+///
+/// The two branches break equal-key ties differently. The serial radix is
+/// *stable*, so ties keep input order. The parallel radix sorts the
+/// `(sort_key, offset)` composite, so ties order by `offset`. They agree only
+/// while `offset` ascends with input order — which holds for every caller today,
+/// because refs are built by appending each record to an arena in input order.
+///
+/// A caller that broke it (refs assembled from a reordered source, or from two
+/// arenas) would get a different record order depending on `sort_threads` and
+/// input size, and only above `PARALLEL_SORT_THRESHOLD` — an output-identity
+/// divergence invisible to any test whose refs happen to be built in order,
+/// which includes `parallel_coordinate_sort_matches_serial_radix_at_threshold`
+/// (it constructs `offset: i`). Hence the debug assertion rather than a comment.
+fn sort_coordinate_refs(refs: &mut [RecordRef], sort_threads: usize) {
+    if sort_threads > 1 && refs.len() >= PARALLEL_SORT_THRESHOLD {
+        debug_assert!(
+            refs.windows(2).all(|w| w[0].offset <= w[1].offset),
+            "parallel coordinate sort requires `offset` to ascend with input order: it breaks \
+             equal-key ties by `offset`, while the serial radix breaks them by input order, so \
+             the two diverge on ties when this does not hold",
+        );
+        // SAFETY: `CoordSortRef` is `#[repr(transparent)]` over `RecordRef`, so the
+        // two have identical size, alignment, and layout; reinterpreting the slice
+        // (via a pointer cast — clippy rejects a ref-to-ref `transmute`) is sound.
+        // This is the only `unsafe` in this module's production path.
+        #[allow(unsafe_code)]
+        let view: &mut [CoordSortRef] =
+            unsafe { &mut *(std::ptr::from_mut::<[RecordRef]>(refs) as *mut [CoordSortRef]) };
+        view.voracious_mt_sort(sort_threads);
+    } else {
+        radix_sort_record_refs(refs);
+    }
+}
+
+/// Build a sorted coordinate chunk from record bodies already resident in `arena`.
+///
+/// `bodies[i] = (body_offset, body_len)` locate each record's BAM body (the 4-byte
+/// `block_size` prefix already excluded) within `arena`. The coordinate key is
+/// extracted from each body exactly as `RecordBuffer::push_coordinate` does, the
+/// refs are radix-sorted, and the same `arena` is wrapped into the returned chunk
+/// (no record bytes are copied). The chunk's `(offset, len)` therefore point at the
+/// bodies in `arena`, byte-identical to what the copy-based sorter materializes.
+#[must_use]
+#[allow(clippy::cast_possible_truncation)] // offset/len fit in usize on all supported targets (BAM is < 4 GiB; arenas < address space)
+pub fn coordinate_chunk_from_arena_refs(
+    arena: Arc<PooledSegmentedBuf>,
+    bodies: &[(u64, u32)],
+    n_ref: u32,
+    sort_threads: usize,
+) -> InMemoryChunk<RawCoordinateKey> {
+    let mut refs: Vec<RecordRef> = Vec::with_capacity(bodies.len());
+    for &(offset, len) in bodies {
+        let body = arena.slice(offset as usize, len as usize);
+        let sort_key = extract_coordinate_key_inline(body, n_ref);
+        refs.push(RecordRef::new(sort_key, offset, len));
+    }
+    coordinate_chunk_from_refs(arena, refs, sort_threads)
+}
+
+/// Build a sorted coordinate chunk from already-extracted `RecordRef`s (each
+/// carries its coordinate `sort_key` and the `(offset, len)` of its body in
+/// `arena`).  Radix-sorts the refs and wraps `arena` into the returned chunk —
+/// NO walk of the arena and NO record-byte copies.
+///
+/// This is the fused entry point: the caller (`FindBoundariesAndSort`) extracts
+/// the key during its single boundary scan and hands the refs here, so the arena
+/// is walked exactly once for the whole run (the previous two-step
+/// [`coordinate_chunk_from_arena_refs`] re-walked it to re-derive each key).
+#[must_use]
+pub fn coordinate_chunk_from_refs(
+    arena: Arc<PooledSegmentedBuf>,
+    mut refs: Vec<RecordRef>,
+    sort_threads: usize,
+) -> InMemoryChunk<RawCoordinateKey> {
+    sort_coordinate_refs(&mut refs, sort_threads);
+    let records: Vec<(RawCoordinateKey, u64, u32)> =
+        refs.iter().map(|r| (RawCoordinateKey { sort_key: r.sort_key }, r.offset, r.len)).collect();
+    InMemoryChunk::from_parts(arena, records)
+}
+
+/// Build a sorted queryname chunk from already-extracted `(key, offset, len)`
+/// refs pointing into `arena`. Unlike the coordinate/template builders, the
+/// queryname key is a variable-length read name (not radix-able), so this sorts
+/// by the key comparator with `par_sort_unstable_by` — matching the legacy
+/// queryname path's unstable comparator sort. No record bytes are copied: the
+/// returned chunk references its bodies in `arena`.
+///
+/// **Threading contract (differs from the coordinate/template radix builders on
+/// purpose).** Those take an explicit `sort_threads` and gate the parallel radix
+/// on both `sort_threads > 1` and `PARALLEL_SORT_THRESHOLD`. This builder takes
+/// no `sort_threads`: the caller (`QuerynameStrategy::seal`, in `fgumi-pipeline-io`)
+/// runs it inside a rayon pool already sized to `sort_threads`, so parallelism is
+/// bounded there,
+/// and `rayon::par_sort_unstable_by` has its own internal sequential cutoff for
+/// small slices — so a tiny run does not pay a partition/coordination cost even
+/// without an explicit size threshold here.
+#[must_use]
+pub fn queryname_chunk_from_arena_refs<K: RawSortKey>(
+    arena: Arc<PooledSegmentedBuf>,
+    mut records: Vec<(K, u64, u32)>,
+) -> InMemoryChunk<K> {
+    use rayon::prelude::*;
+    // `par_sort_unstable_by` gives no order guarantee for records whose keys
+    // compare equal (exact name+flag-class ties). samtools resolves those
+    // remaining ties by input order; the arena assigns offsets in ingest order,
+    // so break exact ties by ascending offset to preserve that (and keep output
+    // byte-identical run to run).
+    records.par_sort_unstable_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    InMemoryChunk::from_parts(arena, records)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The parallel `voracious_mt_sort` coordinate path only fires at
+    /// `sort_threads > 1 && refs.len() >= PARALLEL_SORT_THRESHOLD`; the oracle
+    /// tests use small, single-thread inputs and never reach it. Build a
+    /// threshold-sized input with deliberate key ties and pin the parallel path's
+    /// ordering against the single-threaded stable radix (`radix_sort_record_refs`,
+    /// which the oracle already proves matches the copy sorter). Both order by
+    /// `sort_key`, breaking ties by input order (== ascending `offset` here), so
+    /// they must agree on `(sort_key, offset)` for every record — a divergence
+    /// would mean the parallel composite mis-sorts or loses stability.
+    #[test]
+    fn parallel_coordinate_sort_matches_serial_radix_at_threshold() {
+        let n = PARALLEL_SORT_THRESHOLD; // exactly at the parallel cutoff
+        // Keys in a small range → ~260 ties per key across the input, so a
+        // stability bug in the parallel path would reorder equal-key records.
+        let refs: Vec<RecordRef> = (0..n)
+            .map(|i| {
+                let i = i as u64;
+                RecordRef::new(i.wrapping_mul(2_654_435_761) % 997, i, 1)
+            })
+            .collect();
+        let mut parallel = refs.clone();
+        let mut serial = refs;
+        sort_coordinate_refs(&mut parallel, 4); // threads > 1 + len >= threshold → parallel path
+        radix_sort_record_refs(&mut serial); // single-threaded stable reference
+        assert_eq!(parallel.len(), serial.len());
+        for (p, s) in parallel.iter().zip(&serial) {
+            assert_eq!(
+                (p.sort_key, p.offset),
+                (s.sort_key, s.offset),
+                "parallel voracious path diverged from the serial radix"
+            );
+        }
+    }
+    use crate::arena_pool::PooledSegmentedBuf;
+    use crate::chunk_sorter::CoordinateChunkSorter;
+    use crate::segmented_buf::SegmentedBuf;
+    use std::sync::Arc;
+
+    // Build a minimal valid BAM record body (no block_size prefix) with the given
+    // refId/pos and a one-character read name `name`. The read name is NOT part of
+    // the coordinate sort key (which reads only refId/pos/flags at bytes 0-15), so
+    // two records with the same (refId,pos) but different `name` are a coordinate
+    // TIE whose relative order is observable in the output bytes — that is what lets
+    // these tests actually witness a stable-vs-unstable sort difference. Returns the
+    // body bytes.
+    fn coord_body(ref_id: i32, pos: i32, name: u8) -> Vec<u8> {
+        // Minimal BAM record body: refID(4) pos(4) l_read_name(1) mapq(1) bin(2)
+        // n_cigar_op(2) flag(2) l_seq(4) next_refID(4) next_pos(4) tlen(4) + read_name.
+        let mut b = Vec::new();
+        b.extend_from_slice(&ref_id.to_le_bytes());
+        b.extend_from_slice(&pos.to_le_bytes());
+        b.push(2); // l_read_name (incl NUL): "<name>\0"
+        b.push(0); // mapq
+        b.extend_from_slice(&0u16.to_le_bytes()); // bin
+        b.extend_from_slice(&0u16.to_le_bytes()); // n_cigar_op
+        b.extend_from_slice(&0u16.to_le_bytes()); // flag (forward)
+        b.extend_from_slice(&0u32.to_le_bytes()); // l_seq
+        b.extend_from_slice(&(-1i32).to_le_bytes()); // next_refID
+        b.extend_from_slice(&(-1i32).to_le_bytes()); // next_pos
+        b.extend_from_slice(&0i32.to_le_bytes()); // tlen
+        b.push(name); // read_name char (distinguishes tied records)
+        b.push(0); // read_name NUL terminator
+        b
+    }
+
+    #[allow(unsafe_code)]
+    #[test]
+    fn ref_sort_matches_copy_based_sorter_byte_for_byte() {
+        // Records deliberately out of coordinate order.
+        let n_ref = 4u32;
+        // Distinct read-name bytes make every record byte-unique, so a stability
+        // divergence (reordering the (0,50) tie at indices 1 and 3) would change the
+        // output byte sequence and fail the assertion below.
+        let recs = vec![
+            coord_body(2, 100, b'a'),
+            coord_body(0, 50, b'b'),
+            coord_body(2, 10, b'c'),
+            coord_body(0, 50, b'd'), // coordinate tie with index 1 → stable sort must keep b before d
+            coord_body(1, 999, b'e'),
+        ];
+
+        // ---- Path A: the existing copy-based sorter (the ORACLE) ----
+        let mut oracle = CoordinateChunkSorter::for_test(usize::MAX, n_ref); // see note below
+        for r in &recs {
+            let _ = oracle.push(r).unwrap();
+        }
+        let oracle_chunk = oracle.take_sorted_chunk();
+        let oracle_bytes: Vec<Vec<u8>> =
+            (0..oracle_chunk.len()).map(|i| oracle_chunk.record_bytes(i).to_vec()).collect();
+
+        // ---- Path B: the ref-sort over an arena holding verbatim [block_size][body] ----
+        let mut arena = SegmentedBuf::with_capacity(0, 1 << 20);
+        arena.reserve_full_capacity();
+        let mut bodies = Vec::new();
+        for r in &recs {
+            // store verbatim record: 4-byte block_size (= body len) then body.
+            let block_size = u32::try_from(r.len()).unwrap();
+            // SAFETY: each slot fully written before any read.
+            let prefix_off = unsafe { arena.grow_uninit(4) };
+            unsafe { arena.slice_mut(prefix_off, 4) }.copy_from_slice(&block_size.to_le_bytes());
+            let body_off = unsafe { arena.grow_uninit(r.len()) };
+            unsafe { arena.slice_mut(body_off, r.len()) }.copy_from_slice(r);
+            bodies.push((body_off as u64, block_size)); // ref points at the BODY, len = block_size
+        }
+        let arena_arc = Arc::new(PooledSegmentedBuf::unpooled(arena));
+        let ref_chunk = coordinate_chunk_from_arena_refs(arena_arc, &bodies, n_ref, 1);
+        let ref_bytes: Vec<Vec<u8>> =
+            (0..ref_chunk.len()).map(|i| ref_chunk.record_bytes(i).to_vec()).collect();
+
+        assert_eq!(
+            ref_bytes, oracle_bytes,
+            "ref-sort output must be byte-identical to the copy-based sorter"
+        );
+    }
+
+    use proptest::prelude::*;
+
+    proptest! {
+        // For any multiset of (refId, pos) records — including ties and unmapped —
+        // the ref-sort produces the same sorted body sequence as the copy sorter.
+        #[test]
+        #[allow(unsafe_code)]
+        fn prop_ref_sort_matches_copy_sorter(
+            // `-1` tids exercise the unmapped → `nref` sentinel (`u64::MAX`)
+            // ordering path, which `0..5` alone never reaches despite the header.
+            coords in prop::collection::vec((-1i32..5, 0i32..2000), 0..60),
+        ) {
+            let n_ref = 5u32;
+            // A unique read-name per record (by input index) makes every record
+            // byte-distinct, so any reordering of equal-key (tied) records would
+            // change the output and fail the assertion — witnessing stability.
+            let recs: Vec<Vec<u8>> = coords
+                .iter()
+                .enumerate()
+                .map(|(i, &(t, p))| coord_body(t, p, u8::try_from(i).unwrap()))
+                .collect();
+
+            let mut oracle = CoordinateChunkSorter::for_test(usize::MAX, n_ref);
+            for r in &recs { let _ = oracle.push(r).unwrap(); }
+            let oracle_chunk = oracle.take_sorted_chunk();
+            let oracle_bytes: Vec<Vec<u8>> =
+                (0..oracle_chunk.len()).map(|i| oracle_chunk.record_bytes(i).to_vec()).collect();
+
+            let mut arena = SegmentedBuf::with_capacity(0, 1 << 20);
+            arena.reserve_full_capacity();
+            let mut bodies = Vec::new();
+            for r in &recs {
+                let bs = u32::try_from(r.len()).unwrap();
+                // SAFETY: each slot is fully written (via `slice_mut`) before any
+                // read — the 4-byte prefix and the body are copied in immediately
+                // after each `grow_uninit`, satisfying the write-before-read contract.
+                let po = unsafe { arena.grow_uninit(4) };
+                unsafe { arena.slice_mut(po, 4) }.copy_from_slice(&bs.to_le_bytes());
+                // SAFETY: as above — the body slot is fully written before any read.
+                let bo = unsafe { arena.grow_uninit(r.len()) };
+                unsafe { arena.slice_mut(bo, r.len()) }.copy_from_slice(r);
+                bodies.push((bo as u64, bs));
+            }
+            let arena_arc = Arc::new(PooledSegmentedBuf::unpooled(arena));
+            let ref_chunk = coordinate_chunk_from_arena_refs(arena_arc, &bodies, n_ref, 1);
+            let ref_bytes: Vec<Vec<u8>> =
+                (0..ref_chunk.len()).map(|i| ref_chunk.record_bytes(i).to_vec()).collect();
+
+            prop_assert_eq!(ref_bytes, oracle_bytes);
+        }
+    }
+
+    /// Exact queryname ties (identical name + flag class) must emerge in ingest
+    /// order — samtools' final tie-break — which the arena encodes as ascending
+    /// offset. `par_sort_unstable_by` on the key alone gives no such guarantee,
+    /// so feed equal-key refs in scrambled order and assert the sort restores
+    /// ascending-offset (== ingest) order.
+    #[test]
+    #[allow(unsafe_code)]
+    fn queryname_arena_sort_breaks_exact_ties_by_offset() {
+        use crate::keys::RawQuerynameKey;
+
+        let n = 2_000usize;
+        let key = RawQuerynameKey::new(b"dup/name".to_vec(), 0); // one shared key → all ties
+
+        // Each body encodes its ingest index; offsets ascend with the index, so a
+        // correct sort must decode 0,1,2,… in order.
+        let mut arena = SegmentedBuf::with_capacity(0, 1 << 20);
+        arena.reserve_full_capacity();
+        let mut by_index: Vec<(u64, u32)> = Vec::with_capacity(n);
+        for i in 0..n {
+            let body = (i as u64).to_le_bytes();
+            // SAFETY: each slot is fully written (copy_from_slice) before any read.
+            let off = unsafe { arena.grow_uninit(body.len()) };
+            unsafe { arena.slice_mut(off, body.len()) }.copy_from_slice(&body);
+            by_index.push((off as u64, u32::try_from(body.len()).unwrap()));
+        }
+
+        // Feed refs in a scrambled order (odds then evens) so an unstable sort with
+        // no offset tie-break would not reliably yield ascending offsets.
+        let mut refs: Vec<(RawQuerynameKey, u64, u32)> = Vec::with_capacity(n);
+        for i in (0..n).filter(|i| i % 2 == 1).chain((0..n).filter(|i| i % 2 == 0)) {
+            let (off, len) = by_index[i];
+            refs.push((key.clone(), off, len));
+        }
+
+        let arena_arc = Arc::new(PooledSegmentedBuf::unpooled(arena));
+        let chunk = queryname_chunk_from_arena_refs(arena_arc, refs);
+        assert_eq!(chunk.len(), n);
+
+        let mut prev: Option<u64> = None;
+        for i in 0..chunk.len() {
+            let v = u64::from_le_bytes(chunk.record_bytes(i).try_into().unwrap());
+            if let Some(p) = prev {
+                assert!(v > p, "exact-tie records not in ascending ingest order: {p} then {v}");
+            }
+            prev = Some(v);
+        }
+    }
+}

--- a/crates/fgumi-sort/src/spill_block.rs
+++ b/crates/fgumi-sort/src/spill_block.rs
@@ -1,0 +1,429 @@
+//! Block-granular spill compression kernel shared by the Phase-1 spill steps
+//! (`SpillGather` → `SpillCompress` → `SpillWrite`).
+//!
+//! The legacy [`SyncSpillWriter`](crate::sync_spill_writer) streams a whole
+//! sorted chunk through one stateful compressor on a single worker. To compress
+//! a spill across the framework pool instead, the chunk is cut into raw blocks by
+//! the (Serial) serialize step, each block is compressed **independently** by a
+//! (Parallel) compress worker, and the writer concatenates the results per file.
+//! This module holds the three pieces that keep that byte-compatible with the
+//! existing spill readers:
+//!
+//! - [`frame_keyed_record_into`] — append one `[key?][u32 LE len][record]` record
+//!   to a raw block buffer (the identical on-disk record layout
+//!   `SyncSpillWriter::write_record` produces).
+//! - [`SpillBlockCompressor`] — a per-worker, codec-fixed compressor whose
+//!   [`compress_block`](SpillBlockCompressor::compress_block) turns one raw block
+//!   into a self-contained, independently-decodable unit: framed BGZF block(s)
+//!   for bgzf, or a `[u32 LE len][zstd frame]` for zstd.
+//! - [`spill_magic`] / [`spill_trailer`] — the per-codec file prologue/epilogue
+//!   the writer brackets the compressed blocks with.
+//!
+//! Because a BGZF/zstd spill stream is just independent blocks concatenated and
+//! the readers stream across boundaries, **any** blocking of the same raw
+//! `[key?][len][record]…` byte stream reads back to the identical records (see
+//! the round-trip + re-blocking-independence tests below and the format notes in
+//! [`sync_spill_writer`](crate::sync_spill_writer)). Block boundaries are
+//! therefore the serialize step's free choice, and compression is a pure function
+//! of each block — so the result is byte-for-byte independent of how many workers
+//! compress concurrently. The one bound on that freedom is
+//! [`MAX_SPILL_BLOCK_LEN`].
+
+use std::io;
+
+use fgumi_bgzf::BGZF_EOF;
+use fgumi_bgzf::writer::InlineBgzfCompressor;
+use zstd::bulk::Compressor as ZstdCompressor;
+
+/// Largest raw block [`SpillBlockCompressor::compress_block`] will accept, and
+/// the ceiling the reader sizes its decompression scratch to.
+///
+/// This is one contract with two enforcement points, which is why it lives here
+/// (the writer side) and is imported by `spill_block_reader`, rather than being
+/// declared next to the buffer it bounds. The reader has to cap *something*: the
+/// decompressed size it reads out of a zstd frame header is attacker- (or
+/// corruption-) controlled, so an uncapped allocation would take the process
+/// out. Once the reader caps, the writer must reject the same size, or a block
+/// above the cap writes successfully and is unreadable — a spill file this
+/// process produced and cannot consume.
+///
+/// 64 MiB is far above any single BAM record in practice (long reads are ~1 MiB
+/// at the extreme), so it bounds corruption without bounding real data.
+pub(crate) const MAX_SPILL_BLOCK_LEN: usize = 64 * 1024 * 1024;
+
+use crate::codec::{SpillCodec, ZSPILL_MAGIC};
+use crate::keys::RawSortKey;
+
+/// Append one keyed record to `block` in the spill record framing:
+/// `[key bytes if !K::EMBEDDED_IN_RECORD][u32 LE record-len][record body]`.
+///
+/// This is the exact layout `SyncSpillWriter::write_record` writes; the
+/// serialize step accumulates records into a raw block with this helper, and the
+/// merge / Phase-2 readers parse it back unchanged.
+///
+/// # Errors
+///
+/// Returns an error if the record is longer than `u32::MAX` (cannot fit the
+/// length prefix) or key serialization fails.
+pub fn frame_keyed_record_into<K: RawSortKey>(
+    block: &mut Vec<u8>,
+    key: &K,
+    record: &[u8],
+) -> io::Result<()> {
+    // Validate the length BEFORE writing the key, so an oversized record fails
+    // loud without leaving partial (key) bytes in the block.
+    let record_len = u32::try_from(record.len()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("BAM record too large ({} bytes) for a u32 length prefix", record.len()),
+        )
+    })?;
+    if !K::EMBEDDED_IN_RECORD {
+        // `Vec<u8>: Write`, so the key serializes straight into the block buffer.
+        key.write_to(block)?;
+    }
+    block.extend_from_slice(&record_len.to_le_bytes());
+    block.extend_from_slice(record);
+    Ok(())
+}
+
+/// Per-worker, codec-fixed block compressor. Constructed once per compress
+/// worker (like `BgzfCompress`'s `InlineBgzfCompressor`) and reused across the
+/// blocks that worker handles.
+pub enum SpillBlockCompressor {
+    /// bgzf: each block becomes one or more framed BGZF blocks (header + deflate
+    /// + footer). No EOF marker — that is the file trailer (see [`spill_trailer`]).
+    Bgzf(InlineBgzfCompressor),
+    /// zstd: each block becomes one `[u32 LE frame-len][zstd frame]` unit.
+    Zstd(ZstdCompressor<'static>),
+}
+
+impl SpillBlockCompressor {
+    /// Build a compressor for `codec` at `compression` (bgzf level — `0` writes
+    /// framed *stored* blocks; or zstd level, which must be ≥ 1).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the zstd compressor cannot be initialized.
+    pub fn new(codec: SpillCodec, compression: u32) -> io::Result<Self> {
+        match codec {
+            SpillCodec::Bgzf => Ok(Self::Bgzf(InlineBgzfCompressor::new(compression))),
+            SpillCodec::Zstd => {
+                #[allow(clippy::cast_possible_wrap)]
+                let compressor = ZstdCompressor::new(compression as i32).map_err(|e| {
+                    io::Error::other(format!("zstd compressor init (level {compression}): {e}"))
+                })?;
+                Ok(Self::Zstd(compressor))
+            }
+        }
+    }
+
+    /// Compress one raw block into a self-contained, independently-decodable
+    /// unit. Concatenating these units (bracketed by [`spill_magic`] /
+    /// [`spill_trailer`]) reproduces the same decompressed stream as the
+    /// streaming `SyncSpillWriter`, regardless of where the block boundaries fall.
+    ///
+    /// An empty block yields an empty `Vec` (no empty BGZF block / zstd frame is
+    /// emitted), matching the streaming writer's "no empty frames" invariant.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if compression fails, if a zstd frame exceeds `u32::MAX`,
+    /// or if `raw` exceeds `MAX_SPILL_BLOCK_LEN` — see that constant for why
+    /// the write side is where that has to fail.
+    pub fn compress_block(&mut self, raw: &[u8]) -> io::Result<Vec<u8>> {
+        if raw.is_empty() {
+            return Ok(Vec::new());
+        }
+        // Fail here rather than let the reader fail later. The block boundary is
+        // the serialize step's free choice (see the module doc), so nothing in
+        // the type system stops it picking one the reader cannot decompress —
+        // and a spill file that writes successfully and cannot be read back is
+        // the worst shape this failure can take. Same reason the length check in
+        // `frame_keyed_record_into` runs before any bytes are written.
+        if raw.len() > MAX_SPILL_BLOCK_LEN {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "spill block of {} bytes exceeds the {MAX_SPILL_BLOCK_LEN}-byte limit the \
+                     reader can decompress",
+                    raw.len(),
+                ),
+            ));
+        }
+        match self {
+            Self::Bgzf(compressor) => {
+                compressor.write_all(raw)?;
+                // Flush forces a block boundary at the end of this raw block, so
+                // the unit is independently decodable.
+                compressor.flush()?;
+                let mut out = Vec::new();
+                for block in compressor.take_blocks() {
+                    out.extend_from_slice(&block.data);
+                }
+                Ok(out)
+            }
+            Self::Zstd(compressor) => {
+                let frame = compressor
+                    .compress(raw)
+                    .map_err(|e| io::Error::other(format!("zstd compress: {e}")))?;
+                let frame_len = u32::try_from(frame.len()).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "zstd frame larger than 4 GiB cannot fit a u32 length prefix",
+                    )
+                })?;
+                let mut out = Vec::with_capacity(4 + frame.len());
+                out.extend_from_slice(&frame_len.to_le_bytes());
+                out.extend_from_slice(&frame);
+                Ok(out)
+            }
+        }
+    }
+}
+
+/// File prologue for `codec`: `ZSPILL_MAGIC` for zstd, empty for bgzf (a BGZF
+/// stream needs no prologue — each block self-identifies via the gzip magic).
+#[must_use]
+pub fn spill_magic(codec: SpillCodec) -> &'static [u8] {
+    match codec {
+        SpillCodec::Bgzf => &[],
+        SpillCodec::Zstd => &ZSPILL_MAGIC,
+    }
+}
+
+/// File epilogue for `codec`: the `BGZF_EOF` empty-block terminator for bgzf,
+/// empty for zstd (the zstd spill format has no trailing marker).
+#[must_use]
+pub fn spill_trailer(codec: SpillCodec) -> &'static [u8] {
+    match codec {
+        SpillCodec::Bgzf => &BGZF_EOF,
+        SpillCodec::Zstd => &[],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::external::GenericKeyedChunkReader;
+    use crate::inline::TemplateKey;
+    use std::fs::File;
+    use std::io::{BufWriter, Write as _};
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn make_key(i: u64) -> TemplateKey {
+        TemplateKey::new(
+            i as i32,
+            i as i32,
+            false,
+            i32::MAX,
+            i32::MAX,
+            false,
+            0,
+            0,
+            (0, false),
+            i,
+            false,
+        )
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn sample_records(n: u64) -> Vec<(TemplateKey, Vec<u8>)> {
+        (0..n).map(|i| (make_key(i), vec![(i % 256) as u8; 200 + (i as usize % 50)])).collect()
+    }
+
+    /// The writer must reject exactly what the reader cannot decompress.
+    ///
+    /// These two limits are one contract with two enforcement points, and the
+    /// failure mode when they disagree is asymmetric: a writer that accepts more
+    /// than the reader accepts produces a spill file this process wrote and
+    /// cannot read back. Rejecting at write time turns that into a loud error
+    /// on the block that caused it.
+    ///
+    /// Both cases allocate a buffer of the size under test, so the at-limit case
+    /// really does build and compress 64 MiB. That is deliberate — it is the
+    /// only way to show the limit is inclusive rather than off by one — and it
+    /// is affordable because the buffer is zeroed, which zstd collapses almost
+    /// instantly. The over-limit case is the cheap one: `compress_block` checks
+    /// the length before touching the compressor, so it short-circuits.
+    #[rstest::rstest]
+    #[case::at_the_limit(MAX_SPILL_BLOCK_LEN, true)]
+    #[case::one_over_the_limit(MAX_SPILL_BLOCK_LEN + 1, false)]
+    fn compress_block_accepts_exactly_what_the_reader_can_decompress(
+        #[case] len: usize,
+        #[case] accepted: bool,
+    ) {
+        // `compress_block` checks the length before touching the compressor, so
+        // a zeroed buffer of the boundary size exercises the branch without
+        // needing meaningful content.
+        let raw = vec![0u8; len];
+        let mut compressor = SpillBlockCompressor::new(SpillCodec::Zstd, 1).expect("compressor");
+        let result = compressor.compress_block(&raw);
+        assert_eq!(
+            result.is_ok(),
+            accepted,
+            "a {len}-byte block should {} at the {MAX_SPILL_BLOCK_LEN}-byte limit",
+            if accepted { "be accepted" } else { "be rejected" },
+        );
+        if !accepted {
+            let err = result.unwrap_err();
+            assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+            assert!(
+                err.to_string().contains("exceeds the"),
+                "the error must name the limit; got: {err}",
+            );
+        }
+    }
+
+    /// A zero-length body must frame as `[key][0u32]` and read back as an empty
+    /// record, on BOTH key branches.
+    ///
+    /// The failure this guards is not an error but a silent desync: the length
+    /// prefix is what the reader advances by, so a framer or reader that
+    /// mishandles a zero length leaves the stream misaligned and every
+    /// *subsequent* record decodes as garbage. The neighbouring record proves
+    /// alignment survived — asserting only that the empty record round-trips
+    /// would miss exactly that.
+    #[rstest::rstest]
+    #[case::non_embedded_key(false)]
+    #[case::embedded_key(true)]
+    fn zero_length_record_body_frames_and_keeps_the_stream_aligned(#[case] embedded: bool) {
+        let mut block = Vec::new();
+        if embedded {
+            let key = crate::keys::RawCoordinateKey { sort_key: 7 };
+            frame_keyed_record_into(&mut block, &key, &[]).unwrap();
+            // `[u32 LE 0]` and nothing else — no key prefix, no body.
+            assert_eq!(block, 0u32.to_le_bytes().to_vec(), "embedded zero-length framing");
+            frame_keyed_record_into(&mut block, &key, &[0xAB, 0xCD]).unwrap();
+            let mut expected = 0u32.to_le_bytes().to_vec();
+            expected.extend_from_slice(&2u32.to_le_bytes());
+            expected.extend_from_slice(&[0xAB, 0xCD]);
+            assert_eq!(block, expected, "the next record must start right after the empty one");
+        } else {
+            let key = make_key(3);
+            frame_keyed_record_into(&mut block, &key, &[]).unwrap();
+            let mut key_bytes = Vec::new();
+            key.write_to(&mut key_bytes).unwrap();
+            let mut expected = key_bytes.clone();
+            expected.extend_from_slice(&0u32.to_le_bytes());
+            assert_eq!(block, expected, "non-embedded zero-length framing");
+            frame_keyed_record_into(&mut block, &key, &[0xAB, 0xCD]).unwrap();
+            expected.extend_from_slice(&key_bytes);
+            expected.extend_from_slice(&2u32.to_le_bytes());
+            expected.extend_from_slice(&[0xAB, 0xCD]);
+            assert_eq!(block, expected, "the next record must start right after the empty one");
+        }
+    }
+
+    /// An embedded key (`RawCoordinateKey`, `EMBEDDED_IN_RECORD == true`) writes
+    /// no key prefix — the framed block is exactly `[u32 LE len][record]`. Locks
+    /// the embedded layout at the kernel boundary (the streaming-writer tests use
+    /// the non-embedded `TemplateKey`, which exercises the key-prefix branch).
+    #[test]
+    fn frame_omits_key_prefix_for_embedded_keys() {
+        let mut block = Vec::new();
+        let key = crate::keys::RawCoordinateKey { sort_key: 0x0102_0304_0506_0708 };
+        frame_keyed_record_into(&mut block, &key, &[0xAB, 0xCD]).unwrap();
+        // Just the u32 LE length (2) + the 2 record bytes — no key prefix.
+        assert_eq!(block, [2, 0, 0, 0, 0xAB, 0xCD]);
+    }
+
+    /// Write a spill file via the block kernel: frame records into raw blocks
+    /// (cutting a new block every `records_per_block` records, to force many
+    /// independent compressed units), compress each block, and bracket with the
+    /// codec magic/trailer.
+    fn write_via_kernel(
+        path: &Path,
+        codec: SpillCodec,
+        compression: u32,
+        records: &[(TemplateKey, Vec<u8>)],
+        records_per_block: usize,
+    ) {
+        let mut comp = SpillBlockCompressor::new(codec, compression).unwrap();
+        let mut out = BufWriter::with_capacity(256 * 1024, File::create(path).unwrap());
+        out.write_all(spill_magic(codec)).unwrap();
+        let mut block = Vec::new();
+        let mut in_block = 0usize;
+        let flush =
+            |block: &mut Vec<u8>, comp: &mut SpillBlockCompressor, out: &mut BufWriter<File>| {
+                out.write_all(&comp.compress_block(block).unwrap()).unwrap();
+                block.clear();
+            };
+        for (k, r) in records {
+            frame_keyed_record_into(&mut block, k, r).unwrap();
+            in_block += 1;
+            if in_block >= records_per_block {
+                flush(&mut block, &mut comp, &mut out);
+                in_block = 0;
+            }
+        }
+        flush(&mut block, &mut comp, &mut out);
+        out.write_all(spill_trailer(codec)).unwrap();
+        out.flush().unwrap();
+    }
+
+    fn read_back(path: &Path) -> Vec<(TemplateKey, Vec<u8>)> {
+        let mut reader =
+            GenericKeyedChunkReader::<TemplateKey>::open(path, None).expect("open reader");
+        let mut buf = Vec::new();
+        let mut out = Vec::new();
+        while let Some(key) = reader.next_record(&mut buf).expect("read record") {
+            out.push((key, buf.clone()));
+        }
+        out
+    }
+
+    /// Kernel-built files read back to the original records for every codec/level
+    /// — including a small block size that forces many independent compressed
+    /// units, proving block-independent compression is reader-compatible.
+    #[test]
+    fn kernel_blocks_read_back_records() {
+        let dir = TempDir::new().unwrap();
+        let records = sample_records(400);
+        for (codec, level, name) in
+            [(SpillCodec::Zstd, 3, "z3"), (SpillCodec::Bgzf, 1, "b1"), (SpillCodec::Bgzf, 0, "b0")]
+        {
+            let path = dir.path().join(format!("kernel_{name}.keyed"));
+            write_via_kernel(&path, codec, level, &records, 7);
+            assert_eq!(read_back(&path), records, "kernel round-trip mismatch for {name}");
+        }
+    }
+
+    /// Kernel output matches the streaming `write_sorted_chunk` oracle, read back
+    /// through the production reader — locks block-granular ≡ streaming.
+    #[test]
+    fn kernel_matches_streaming_oracle_read_back() {
+        let dir = TempDir::new().unwrap();
+        let records = sample_records(500);
+        let keyed: Vec<(TemplateKey, fgumi_raw_bam::RawRecord)> =
+            records.iter().map(|(k, r)| (*k, fgumi_raw_bam::RawRecord::from(r.clone()))).collect();
+        for (codec, level) in [(SpillCodec::Zstd, 3), (SpillCodec::Bgzf, 1)] {
+            let kernel_path = dir.path().join("kernel.keyed");
+            let oracle_path = dir.path().join("oracle.keyed");
+            write_via_kernel(&kernel_path, codec, level, &records, 11);
+            crate::write_sorted_chunk(&oracle_path, codec, level, &keyed).unwrap();
+            assert_eq!(
+                read_back(&kernel_path),
+                read_back(&oracle_path),
+                "kernel vs streaming-oracle read-back differ ({codec:?})"
+            );
+        }
+    }
+
+    /// Different block boundaries produce files that read back identically — the
+    /// invariant that lets the (Serial) serialize step choose boundaries freely.
+    #[test]
+    fn reblocking_is_boundary_independent() {
+        let dir = TempDir::new().unwrap();
+        let records = sample_records(300);
+        for codec in [SpillCodec::Zstd, SpillCodec::Bgzf] {
+            let a = dir.path().join("a.keyed");
+            let b = dir.path().join("b.keyed");
+            write_via_kernel(&a, codec, 1, &records, 3);
+            write_via_kernel(&b, codec, 1, &records, 64);
+            assert_eq!(read_back(&a), read_back(&b), "re-blocking changed readback ({codec:?})");
+        }
+    }
+}

--- a/crates/fgumi-sort/src/spill_block_reader.rs
+++ b/crates/fgumi-sort/src/spill_block_reader.rs
@@ -1,0 +1,605 @@
+//! Codec-aware streaming block decompressor for the typed-step
+//! `SortSpillDecompress` pipeline step.
+//!
+//! A spill chunk is either a BGZF block-stream (self-framed `1f 8b` blocks) or
+//! a zstd "ZSP1" stream (`[u32 LE frame-len][zstd frame]` records after the
+//! 4-byte file magic). Both standalone `fgumi sort` (via the worker pool) and
+//! the fused streaming sort write spill chunks with whichever
+//! [`SpillCodec`] the sorter is configured for; this
+//! decompressor lets the streaming `SortSpillDecompress` step read either.
+//!
+//! Each decompressed BGZF block (or zstd frame) is returned as one `Vec<u8>`.
+//! The block/frame boundaries are immaterial: the downstream `MergeDriver`
+//! parses `[len][record]` records out of a slot's decompressed-block queue and
+//! reassembles records that span block boundaries, so any chunking of the
+//! decompressed byte stream is correct.
+
+use std::io::{self, Read};
+
+use libdeflater::Decompressor as BgzfDecompressor;
+use zstd::bulk::Decompressor as ZstdDecompressor;
+
+use crate::codec::SpillCodec;
+use crate::worker_pool::read_length_prefix;
+
+/// Output staging-buffer capacity for a single decompressed block/frame. Mirrors
+/// the worker pool's `ZSTD_FRAME_DECOMP_CAP` / `BgzfDecompress` scratch sizing so
+/// the mimalloc size-class reuse pattern matches.
+const SCRATCH_CAP: usize = 256 * 1024;
+
+/// Ceiling for sizing the scratch buffer up from [`SCRATCH_CAP`].
+///
+/// A single BAM record can legitimately exceed `SCRATCH_CAP` (long reads), so
+/// the reader sizes up to fit rather than refusing — but not without limit: the
+/// size comes from the frame header, which a corrupt frame can claim to be
+/// anything, so an unbounded allocation on garbage would take the process out.
+///
+/// This is deliberately the *same* constant the writer enforces, imported rather
+/// than redeclared: if the reader capped lower than the writer accepted, a block
+/// in between would write successfully and be unreadable.
+use crate::spill_block::MAX_SPILL_BLOCK_LEN as MAX_SCRATCH_CAP;
+
+/// Per-worker codec-aware decompressor. Holds a libdeflate decompressor (BGZF)
+/// and a zstd decompressor plus reusable scratch buffers; one instance per
+/// `SortSpillDecompress` worker copy.
+pub struct SpillBlockDecompressor {
+    bgzf: BgzfDecompressor,
+    zstd: ZstdDecompressor<'static>,
+    /// Reused output buffer for the BGZF path (`mem::replace`d into the result).
+    bgzf_scratch: Vec<u8>,
+    /// Reused output buffer for the zstd path (decompressed-into, then copied).
+    zstd_buf: Vec<u8>,
+    /// Reused input buffer for the zstd path (one compressed frame at a time).
+    zstd_frame: Vec<u8>,
+}
+
+impl SpillBlockDecompressor {
+    /// Construct a fresh decompressor.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the zstd decompressor cannot be created (allocation failure).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            bgzf: BgzfDecompressor::new(),
+            zstd: ZstdDecompressor::new().expect("zstd decompressor init"),
+            bgzf_scratch: Vec::with_capacity(SCRATCH_CAP),
+            zstd_buf: Vec::new(),
+            zstd_frame: Vec::new(),
+        }
+    }
+
+    /// Read and decompress up to `max` blocks from `reader` using `codec`,
+    /// returning the decompressed block bytes. A result with fewer than `max`
+    /// entries (including an empty `Vec`) signals that the reader reached a
+    /// clean EOF.
+    ///
+    /// The reader must be positioned at a block boundary — for zstd, at the
+    /// start of a `[len][frame]` record (i.e. the `ZSP1` file magic already
+    /// consumed); for BGZF, at the start of a block. `slots_for_chunk_files`
+    /// detects the codec from the file magic and positions the reader
+    /// accordingly when opening each slot.
+    ///
+    /// # Errors
+    ///
+    /// Propagates I/O errors, BGZF/zstd decompression failures, and truncation
+    /// (a partial length prefix or frame body at EOF).
+    pub fn read_blocks<R: Read + ?Sized>(
+        &mut self,
+        reader: &mut R,
+        codec: SpillCodec,
+        max: usize,
+    ) -> io::Result<Vec<Vec<u8>>> {
+        match codec {
+            SpillCodec::Bgzf => self.read_bgzf_blocks(reader, max),
+            SpillCodec::Zstd => self.read_zstd_frames(reader, max),
+        }
+    }
+
+    fn read_bgzf_blocks<R: Read + ?Sized>(
+        &mut self,
+        reader: &mut R,
+        max: usize,
+    ) -> io::Result<Vec<Vec<u8>>> {
+        let raw_blocks = fgumi_bgzf::reader::read_raw_blocks(reader, max)?;
+        let mut out = Vec::with_capacity(raw_blocks.len());
+        for raw in raw_blocks {
+            fgumi_bgzf::reader::decompress_block_slice_into(
+                &raw.data,
+                &mut self.bgzf,
+                &mut self.bgzf_scratch,
+            )?;
+            // mem::replace the filled scratch out and re-allocate a fresh one,
+            // so the consumer owns the bytes and the next decompress reuses a
+            // same-size-class allocation (matches `BgzfDecompress`).
+            out.push(std::mem::replace(&mut self.bgzf_scratch, Vec::with_capacity(SCRATCH_CAP)));
+        }
+        Ok(out)
+    }
+
+    /// Decompress one zstd frame into the reusable scratch buffer, sizing it up
+    /// first if the output would not fit, and return the decompressed length.
+    ///
+    /// Both read paths funnel through here so the sizing policy cannot drift
+    /// between them — they previously each held their own copy of the
+    /// resize-then-decompress sequence, and only one of the two would have been
+    /// fixed by a change to either.
+    ///
+    /// The size comes from the frame header rather than from retrying on a
+    /// too-small-destination error. `decompress_to_buffer` surfaces zstd's
+    /// `get_error_name` text through `io::Error`, and that wording is not an
+    /// API contract — matching on it means a zstd bump could silently turn
+    /// "size up and succeed" into a hard failure on a spill file this very
+    /// process wrote. Reading the header also allocates exactly once instead of
+    /// doubling into place.
+    fn decompress_zstd_frame(&mut self, frame: &[u8]) -> io::Result<usize> {
+        // Both spill writers compress each block in a single
+        // `Compressor::compress` call, which records the content size in the
+        // frame header, so a missing size means the frame did not come from us.
+        let content_size = zstd::zstd_safe::get_frame_content_size(frame)
+            .map_err(|e| io::Error::other(format!("zstd spill frame header: {e}")))?
+            .ok_or_else(|| {
+                io::Error::other("zstd spill frame carries no content size (not written by fgumi)")
+            })?;
+        let needed = usize::try_from(content_size).map_err(|_| {
+            io::Error::other(format!("zstd spill frame content size {content_size} exceeds usize"))
+        })?;
+        if needed > MAX_SCRATCH_CAP {
+            return Err(io::Error::other(format!(
+                "zstd spill frame decompresses to {needed} bytes, over the \
+                 {MAX_SCRATCH_CAP}-byte scratch ceiling (or the frame is corrupt)"
+            )));
+        }
+        // Reuse by CAPACITY, not by length. `decompress_to_buffer` sets the
+        // vector's length to the decompressed byte count, so after any frame
+        // `len` is the size of that frame's output, not the buffer size — a
+        // `resize(want, 0)` guarded on `len` would therefore zero-fill the
+        // difference on essentially every frame, immediately before zstd
+        // overwrites it. `clear` + `reserve` keeps the allocation and zeroes
+        // nothing; `reserve` is a no-op once capacity is high enough, so the
+        // buffer still never shrinks.
+        let want = needed.max(SCRATCH_CAP);
+        self.zstd_buf.clear();
+        self.zstd_buf.reserve(want);
+        self.zstd
+            .decompress_to_buffer(frame, &mut self.zstd_buf)
+            .map_err(|e| io::Error::other(format!("zstd spill frame decompress: {e}")))
+    }
+
+    fn read_zstd_frames<R: Read + ?Sized>(
+        &mut self,
+        reader: &mut R,
+        max: usize,
+    ) -> io::Result<Vec<Vec<u8>>> {
+        let mut out = Vec::with_capacity(max);
+        for _ in 0..max {
+            // `read_length_prefix` returns `Ok(None)` only at a clean frame
+            // boundary EOF; a 1–3 byte partial prefix surfaces as an error.
+            let Some(frame_len) = read_length_prefix(reader)? else {
+                break;
+            };
+            // Read into spare capacity rather than `resize(frame_len, 0)` +
+            // `read_exact`: the resize zero-fills the whole frame on every
+            // iteration only to overwrite it immediately. `read_to_end` appends,
+            // so the reuse is by capacity and nothing is zeroed. It also stops
+            // short instead of erroring, so the short read is checked here to
+            // keep `read_exact`'s `UnexpectedEof` semantics.
+            self.zstd_frame.clear();
+            self.zstd_frame.reserve(frame_len);
+            Read::take(&mut *reader, frame_len as u64).read_to_end(&mut self.zstd_frame)?;
+            if self.zstd_frame.len() != frame_len {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    format!(
+                        "truncated zstd spill frame: expected {frame_len} bytes, got {}",
+                        self.zstd_frame.len(),
+                    ),
+                ));
+            }
+            // Move the frame out so `decompress_zstd_frame` can take `&mut self`,
+            // then put it back to keep its allocation across frames. An error
+            // here abandons the whole read, so not restoring it on that path
+            // costs nothing.
+            let frame = std::mem::take(&mut self.zstd_frame);
+            let n = self.decompress_zstd_frame(&frame)?;
+            self.zstd_frame = frame;
+            out.push(self.zstd_buf[..n].to_vec());
+        }
+        Ok(out)
+    }
+
+    /// Read up to `max` *raw* (still-compressed) blocks from `reader` using
+    /// `codec`, returning the compressed payloads **without** decompressing them.
+    ///
+    /// This is the read half of the block-parallel `SortSpillDecompress` path:
+    /// the caller acquires the per-slot reader lock, calls `read_raw` to pull a
+    /// batch of compressed blocks (which it sequence-tags), releases the lock,
+    /// and then decompresses each block via [`Self::decompress_one`] *outside*
+    /// the lock so multiple workers decompress one file's blocks concurrently.
+    /// The read and the decompression of a given block still happen within a
+    /// single `try_run` of a single worker — only the lock is released between
+    /// them — which preserves the read-and-decompress-together invariant that
+    /// the FIFO inline path also upholds.
+    ///
+    /// For BGZF each returned `Vec<u8>` is one complete raw block (header +
+    /// compressed data + footer), exactly what [`Self::decompress_one`] expects;
+    /// EOF-marker blocks are skipped. For zstd each is one raw frame body (the
+    /// `[u32 LE len]` prefix is consumed here). A result shorter than `max`
+    /// (including empty) signals a clean EOF, matching [`Self::read_blocks`].
+    ///
+    /// # Errors
+    ///
+    /// Propagates I/O errors and truncation (a partial BGZF block, or a partial
+    /// zstd length prefix / frame body at EOF).
+    pub fn read_raw<R: Read + ?Sized>(
+        &mut self,
+        reader: &mut R,
+        codec: SpillCodec,
+        max: usize,
+    ) -> io::Result<Vec<Vec<u8>>> {
+        match codec {
+            SpillCodec::Bgzf => {
+                let raw_blocks = fgumi_bgzf::reader::read_raw_blocks(reader, max)?;
+                Ok(raw_blocks.into_iter().map(|b| b.data).collect())
+            }
+            SpillCodec::Zstd => {
+                let mut out = Vec::with_capacity(max);
+                for _ in 0..max {
+                    let Some(frame_len) = read_length_prefix(reader)? else {
+                        break;
+                    };
+                    // Same zero-fill removal as `read_zstd_frames`: `vec![0u8; n]`
+                    // zeroes the frame immediately before the read overwrites it.
+                    // The *reuse* half of that fix does not transfer — `read_raw`
+                    // hands each frame out as an owned `Vec` — but the zero-fill
+                    // half does. `read_to_end` stops short instead of erroring, so
+                    // the short read is checked to keep `read_exact`'s
+                    // `UnexpectedEof` semantics.
+                    let mut frame = Vec::with_capacity(frame_len);
+                    Read::take(&mut *reader, frame_len as u64).read_to_end(&mut frame)?;
+                    if frame.len() != frame_len {
+                        return Err(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            format!(
+                                "truncated zstd spill frame: expected {frame_len} bytes, got {}",
+                                frame.len(),
+                            ),
+                        ));
+                    }
+                    out.push(frame);
+                }
+                Ok(out)
+            }
+        }
+    }
+
+    /// Decompress a single raw block/frame previously read by [`Self::read_raw`].
+    ///
+    /// `raw` is one BGZF raw block (header + compressed data + footer) or one
+    /// zstd frame body, per `codec`. Returns the decompressed bytes. Uses the
+    /// worker's reusable scratch buffers, so this is cheap to call in a loop over
+    /// a freshly-read batch.
+    ///
+    /// # Errors
+    ///
+    /// Propagates BGZF/zstd decompression failures (bad CRC, size mismatch, or a
+    /// malformed frame).
+    pub fn decompress_one(&mut self, codec: SpillCodec, raw: &[u8]) -> io::Result<Vec<u8>> {
+        match codec {
+            SpillCodec::Bgzf => {
+                fgumi_bgzf::reader::decompress_block_slice_into(
+                    raw,
+                    &mut self.bgzf,
+                    &mut self.bgzf_scratch,
+                )?;
+                Ok(std::mem::replace(&mut self.bgzf_scratch, Vec::with_capacity(SCRATCH_CAP)))
+            }
+            SpillCodec::Zstd => {
+                let n = self.decompress_zstd_frame(raw)?;
+                Ok(self.zstd_buf[..n].to_vec())
+            }
+        }
+    }
+}
+
+impl Default for SpillBlockDecompressor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pooled_chunk_writer::PooledChunkWriter;
+    use crate::worker_pool::SortWorkerPool;
+    use std::io::Cursor;
+    use std::sync::Arc;
+
+    /// A length prefix that promises more bytes than follow must surface
+    /// `UnexpectedEof` from BOTH zstd read paths.
+    ///
+    /// `read_zstd_frames` and `read_raw` each read the frame body via
+    /// `Read::take(..).read_to_end(..)`, which — unlike the `read_exact` it
+    /// replaced — *stops short* instead of erroring. The explicit length check is
+    /// what restores the loud failure, and it exists in two places, so this is a
+    /// guard-set-parity case: drop the check in either path and a truncated spill
+    /// gets silently decompressed as a short frame with every test still green.
+    #[rstest::rstest]
+    #[case::read_zstd_frames(false)]
+    #[case::read_raw(true)]
+    fn a_truncated_zstd_frame_is_unexpected_eof(#[case] via_read_raw: bool) {
+        // `[u32 LE 64]` promising 64 body bytes, followed by only 8.
+        let mut bytes = 64u32.to_le_bytes().to_vec();
+        bytes.extend_from_slice(&[0xEE; 8]);
+
+        let mut d = SpillBlockDecompressor::new();
+        let mut cursor = Cursor::new(bytes);
+        let err = if via_read_raw {
+            d.read_raw(&mut cursor, SpillCodec::Zstd, 4).expect_err("truncated frame must error")
+        } else {
+            d.read_zstd_frames(&mut cursor, 4).expect_err("truncated frame must error")
+        };
+        assert_eq!(
+            err.kind(),
+            io::ErrorKind::UnexpectedEof,
+            "a short frame must be UnexpectedEof, not a silent short read; got: {err}",
+        );
+        assert!(
+            err.to_string().contains("truncated zstd spill frame"),
+            "the error must name the truncation; got: {err}",
+        );
+    }
+
+    /// A zstd frame with no recorded content size must be rejected, not
+    /// decompressed into an unsized buffer.
+    ///
+    /// The reader sizes its scratch from the frame header, so a frame that omits
+    /// the content size has nothing to size from. Both spill writers compress
+    /// each block in one `bulk::compress` call, which always records it — so a
+    /// size-less frame did not come from fgumi, and guessing at its size is the
+    /// wrong response. `stream::encode_all` produces exactly that shape (verified
+    /// against zstd 0.13: bulk records the size, the streaming APIs do not), so
+    /// this is a real frame rather than a hand-forged header.
+    #[test]
+    fn a_zstd_frame_without_a_content_size_is_rejected() {
+        let payload = vec![9u8; 5000];
+        let sizeless = zstd::stream::encode_all(&payload[..], 1).expect("stream-compress");
+        assert!(
+            zstd::zstd_safe::get_frame_content_size(&sizeless).expect("readable header").is_none(),
+            "precondition: the streaming API must omit the content size",
+        );
+
+        let mut d = SpillBlockDecompressor::new();
+        let err = d
+            .decompress_one(SpillCodec::Zstd, &sizeless)
+            .expect_err("a size-less frame must be rejected");
+        assert!(
+            err.to_string().contains("carries no content size"),
+            "the error must say the size is missing; got: {err}",
+        );
+    }
+
+    /// A single zstd block larger than `SCRATCH_CAP` must survive the round
+    /// trip. Before the reader sized its scratch to the frame, such a block
+    /// wrote successfully and then failed on read — a spill file that could be
+    /// produced but not consumed. Refusing the write was never the answer: a
+    /// long-read BAM record alone can exceed 256 KiB.
+    ///
+    /// `compress_block` does now bound what it accepts, but at
+    /// `MAX_SPILL_BLOCK_LEN` (64 MiB), which is the reader's ceiling too — the
+    /// two agree by construction. This block is 768 KiB, above `SCRATCH_CAP`
+    /// and far below that bound, so it exercises scratch growth specifically
+    /// and not the writer's limit (which
+    /// `compress_block_accepts_exactly_what_the_reader_can_decompress` covers).
+    #[test]
+    fn oversized_zstd_block_round_trips_through_the_reader() {
+        let raw: Vec<u8> = (0..(SCRATCH_CAP * 3)).map(|i| u8::try_from(i % 251).unwrap()).collect();
+        assert!(raw.len() > SCRATCH_CAP, "precondition: larger than the fixed scratch");
+
+        let mut compressor =
+            crate::spill_block::SpillBlockCompressor::new(SpillCodec::Zstd, 3).expect("compressor");
+        let framed = compressor.compress_block(&raw).expect("compress accepts an oversized block");
+        // `compress_block` prefixes the zstd frame with a u32 length; the
+        // block-level entry point takes the bare frame.
+        let frame = &framed[4..];
+
+        let mut decompressor = SpillBlockDecompressor::new();
+        let out = decompressor
+            .decompress_one(SpillCodec::Zstd, frame)
+            .expect("reader must grow its scratch rather than fail");
+        assert_eq!(out, raw, "oversized block round-trips byte-for-byte");
+
+        // The grown buffer is reused, so a normal-sized block still works after.
+        let small = vec![7u8; 1024];
+        let small_framed = compressor.compress_block(&small).expect("compress");
+        let small_frame = &small_framed[4..];
+        let small_out =
+            decompressor.decompress_one(SpillCodec::Zstd, small_frame).expect("decompress");
+        assert_eq!(small_out, small, "a later small block is unaffected by the growth");
+    }
+
+    /// A spill chunk written with codec X, read back through
+    /// `SpillBlockDecompressor`, must yield the exact `[len][record]` byte
+    /// stream that was written — for BOTH codecs. This is the round-trip the
+    /// streaming merge depends on.
+    fn roundtrip(codec: SpillCodec) {
+        use crate::keys::{RawCoordinateKey, RawSortKey};
+        // Build framed records whose total size (~440 KB) far exceeds the
+        // writer's ~64 KB block cap, so the chunk is written as MANY blocks /
+        // frames. That is what actually exercises the per-block decompress and
+        // the downstream record reassembly across block boundaries — the whole
+        // reason `read_blocks` returns per-block `Vec<u8>`s. Each record is
+        // stamped with its index at both ends so a misaligned reassembly is
+        // caught, not just a stream of zeros.
+        let records: Vec<Vec<u8>> = (0usize..80)
+            .map(|i| {
+                let size = 3000 + (i % 13) * 500; // 3000..9000 bytes
+                let mut r = vec![0u8; size];
+                let stamp = u8::try_from(i % 251).expect("i % 251 fits u8");
+                r[0] = stamp;
+                let last = r.len() - 1;
+                r[last] = stamp;
+                r
+            })
+            .collect();
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("chunk.spill");
+        let pool = Arc::new(SortWorkerPool::new(1, 1, 6, codec));
+        {
+            let mut w = PooledChunkWriter::<RawCoordinateKey>::new(Arc::clone(&pool), &path, codec)
+                .expect("writer");
+            for rec in &records {
+                let key = RawCoordinateKey::extract_from_record(rec);
+                w.write_record(&key, rec).expect("write");
+            }
+            w.start_finish().expect("start_finish").wait().expect("finish");
+        }
+
+        // Re-open + position past the codec magic exactly like
+        // slots_for_chunk_files does.
+        let mut file = std::fs::File::open(&path).expect("open");
+        let mut magic = [0u8; 4];
+        let filled = crate::external::read_exact_or_eof(&mut file, &mut magic).expect("magic");
+        let detected = if filled {
+            SpillCodec::from_magic(&magic).unwrap_or(SpillCodec::Bgzf)
+        } else {
+            SpillCodec::Bgzf
+        };
+        assert_eq!(detected, codec, "codec must be detected from the file magic");
+        if matches!(detected, SpillCodec::Bgzf) {
+            use std::io::Seek;
+            file.seek(std::io::SeekFrom::Start(0)).expect("seek");
+        }
+
+        let mut reader = std::io::BufReader::new(file);
+        let mut dec = SpillBlockDecompressor::new();
+        let mut all = Vec::new();
+        loop {
+            let blocks = dec.read_blocks(&mut reader, detected, 4).expect("read_blocks");
+            let got = blocks.len();
+            for b in blocks {
+                all.extend_from_slice(&b);
+            }
+            if got < 4 {
+                break;
+            }
+        }
+
+        // The decompressed stream is `[u32 LE len][record]` per record, in order.
+        let mut cursor = Cursor::new(&all);
+        let mut read_back: Vec<Vec<u8>> = Vec::new();
+        let mut len_buf = [0u8; 4];
+        while Read::read(&mut cursor, &mut len_buf).map(|n| n == 4).unwrap_or(false) {
+            let len = u32::from_le_bytes(len_buf) as usize;
+            let mut rec = vec![0u8; len];
+            cursor.read_exact(&mut rec).expect("record body");
+            read_back.push(rec);
+        }
+        assert_eq!(read_back, records, "round-trip mismatch for {codec:?}");
+    }
+
+    #[test]
+    fn roundtrip_bgzf() {
+        roundtrip(SpillCodec::Bgzf);
+    }
+
+    #[test]
+    fn roundtrip_zstd() {
+        roundtrip(SpillCodec::Zstd);
+    }
+
+    /// The split `read_raw` + `decompress_one` path (used by the block-parallel
+    /// `SortSpillDecompress`) must yield the exact same per-block bytes as the
+    /// inline `read_blocks` path. We read the same chunk twice and compare.
+    fn read_raw_matches_read_blocks(codec: SpillCodec) {
+        use crate::keys::{RawCoordinateKey, RawSortKey};
+
+        let records: Vec<Vec<u8>> = (0usize..80)
+            .map(|i| {
+                let size = 3000 + (i % 13) * 500;
+                let mut r = vec![0u8; size];
+                let stamp = u8::try_from(i % 251).expect("i % 251 fits u8");
+                r[0] = stamp;
+                let last = r.len() - 1;
+                r[last] = stamp;
+                r
+            })
+            .collect();
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("chunk.spill");
+        let pool = Arc::new(SortWorkerPool::new(1, 1, 6, codec));
+        {
+            let mut w = PooledChunkWriter::<RawCoordinateKey>::new(Arc::clone(&pool), &path, codec)
+                .expect("writer");
+            for rec in &records {
+                let key = RawCoordinateKey::extract_from_record(rec);
+                w.write_record(&key, rec).expect("write");
+            }
+            w.start_finish().expect("start_finish").wait().expect("finish");
+        }
+
+        // Helper: open the chunk positioned past any codec magic.
+        let open = || {
+            let mut file = std::fs::File::open(&path).expect("open");
+            let mut magic = [0u8; 4];
+            let filled = crate::external::read_exact_or_eof(&mut file, &mut magic).expect("magic");
+            let detected = if filled {
+                SpillCodec::from_magic(&magic).unwrap_or(SpillCodec::Bgzf)
+            } else {
+                SpillCodec::Bgzf
+            };
+            if matches!(detected, SpillCodec::Bgzf) {
+                use std::io::Seek;
+                file.seek(std::io::SeekFrom::Start(0)).expect("seek");
+            }
+            (std::io::BufReader::new(file), detected)
+        };
+
+        // Path A: inline read_blocks.
+        let (mut reader_a, detected) = open();
+        let mut dec_a = SpillBlockDecompressor::new();
+        let mut blocks_a: Vec<Vec<u8>> = Vec::new();
+        loop {
+            let blocks = dec_a.read_blocks(&mut reader_a, detected, 4).expect("read_blocks");
+            let got = blocks.len();
+            blocks_a.extend(blocks);
+            if got < 4 {
+                break;
+            }
+        }
+
+        // Path B: read_raw + decompress_one.
+        let (mut reader_b, _) = open();
+        let mut dec_b = SpillBlockDecompressor::new();
+        let mut blocks_b: Vec<Vec<u8>> = Vec::new();
+        loop {
+            let raws = dec_b.read_raw(&mut reader_b, detected, 4).expect("read_raw");
+            let got = raws.len();
+            for raw in &raws {
+                blocks_b.push(dec_b.decompress_one(detected, raw).expect("decompress_one"));
+            }
+            if got < 4 {
+                break;
+            }
+        }
+
+        assert_eq!(
+            blocks_a, blocks_b,
+            "split read_raw path must match inline read_blocks ({codec:?})"
+        );
+    }
+
+    #[test]
+    fn read_raw_matches_read_blocks_bgzf() {
+        read_raw_matches_read_blocks(SpillCodec::Bgzf);
+    }
+
+    #[test]
+    fn read_raw_matches_read_blocks_zstd() {
+        read_raw_matches_read_blocks(SpillCodec::Zstd);
+    }
+}

--- a/crates/fgumi-sort/src/sync_spill_writer.rs
+++ b/crates/fgumi-sort/src/sync_spill_writer.rs
@@ -1,0 +1,684 @@
+//! Synchronous keyed-chunk spill writer (inline compression, no worker pool).
+//!
+//! The P6 Phase-1 decomposition runs the spill **compress** as a `Parallel`
+//! `CompressSpill` step on the framework work-stealing pool, replacing the async
+//! [`PooledChunkWriter`] → `SortWorkerPool` path so the sort no longer needs a
+//! second, private thread pool. Each `CompressSpill` `try_run` already executes
+//! on a framework worker, so the per-chunk write compresses **inline** on that
+//! thread.
+//!
+//! The on-disk format is byte-compatible with [`PooledChunkWriter`], so
+//! `SortSpillDecompress` (the Phase-2 streaming reader) and
+//! `GenericKeyedChunkReader` (the merge reader) read these files unchanged:
+//!
+//! - **bgzf** (any `compression`, including `0`): framed BGZF blocks (header +
+//!   deflate + footer) via [`InlineBgzfCompressor`] then a trailing `BGZF_EOF`,
+//!   exactly like `PooledChunkWriter`'s bgzf path. Level 0 still produces *framed*
+//!   (stored) BGZF blocks — NOT raw bytes — because the bgzf reader requires the
+//!   `0x1f 0x8b` block magic; an unframed raw spill would fail the reader's
+//!   magic check.
+//! - **zstd** (the production default): [`ZSPILL_MAGIC`] then
+//!   `[u32 LE frame-len][zstd frame]` per ≤`BGZF_MAX_BLOCK_SIZE` raw block, with
+//!   no trailing marker — mirroring `PooledChunkWriter`'s zstd path and the
+//!   `ZspillStreamReader` format.
+//!
+//! In both cases block/frame *boundaries* may differ from the pooled writer, but
+//! the decompressed byte stream (and therefore every record read back) is
+//! identical, because the reader streams across boundaries.
+//!
+//! [`PooledChunkWriter`]: crate::pooled_chunk_writer::PooledChunkWriter
+
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::marker::PhantomData;
+use std::path::Path;
+
+use anyhow::Result;
+use fgumi_bgzf::writer::InlineBgzfCompressor;
+use fgumi_bgzf::{BGZF_EOF, BGZF_MAX_BLOCK_SIZE};
+use fgumi_raw_bam::RawRecord;
+use zstd::bulk::Compressor as ZstdCompressor;
+
+use crate::codec::{SpillCodec, ZSPILL_MAGIC};
+use crate::keys::RawSortKey;
+
+/// Compress and write a fully-sorted in-memory chunk to `path` as a keyed spill
+/// file, inline on the calling thread (no `SortWorkerPool`).
+///
+/// This is the single-chunk entry point the P6 `CompressSpill` step calls per
+/// sorted chunk: it creates a `SyncSpillWriter` for `codec`/`compression`,
+/// writes every `(key, record)` pair in `records` order, and closes the file.
+/// The on-disk format is byte-compatible with `PooledChunkWriter`, so
+/// [`open_spill_slot`](crate::open_spill_slot) → `SortSpillDecompress` / the
+/// merge reader consume it unchanged.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be created, the zstd compressor cannot be
+/// initialized, or any record write/flush fails.
+pub fn write_sorted_chunk<K: RawSortKey>(
+    path: &Path,
+    codec: SpillCodec,
+    compression: u32,
+    records: &[(K, RawRecord)],
+) -> Result<()> {
+    let mut writer = SyncSpillWriter::<K>::create(path, codec, compression)?;
+    for (key, record) in records {
+        writer.write_record(key, record.as_ref())?;
+    }
+    writer.finish()
+}
+
+/// Write an already-sorted [`InMemoryChunk`](crate::InMemoryChunk) to a spill
+/// file — the zero-copy analogue of [`write_sorted_chunk`]. The chunk's records
+/// share an `Arc<SegmentedBuf>` backing store, so this iterates by index and
+/// writes each record's bytes directly (no owned `RawRecord`s), avoiding the
+/// per-record copy the buffer chain previously paid to materialise
+/// `Vec<(K, RawRecord)>`.
+///
+/// # Errors
+///
+/// Propagates I/O / compression errors from the underlying writer.
+pub fn write_sorted_chunk_inmem<K: RawSortKey>(
+    path: &Path,
+    codec: SpillCodec,
+    compression: u32,
+    chunk: &crate::InMemoryChunk<K>,
+) -> Result<()> {
+    let mut writer = SyncSpillWriter::<K>::create(path, codec, compression)?;
+    for i in 0..chunk.len() {
+        writer.write_record(chunk.key_at(i), chunk.record_bytes(i))?;
+    }
+    writer.finish()
+}
+
+/// Synchronous keyed-chunk spill writer that compresses inline on the calling
+/// (framework-worker) thread — no `SortWorkerPool`.
+pub(crate) enum SyncSpillWriter<K: RawSortKey> {
+    /// bgzf: framed BGZF blocks (any level, including a stored level-0 block) +
+    /// trailing `BGZF_EOF`.
+    Bgzf(BgzfSpillWriter<K>),
+    /// zstd: inline-compressed `[u32 len][frame]` blocks after `ZSPILL_MAGIC`.
+    Zstd(ZstdSpillWriter<K>),
+}
+
+impl<K: RawSortKey> SyncSpillWriter<K> {
+    /// Create a writer for `path` using `codec` at `compression` level.
+    ///
+    /// For zstd, `compression` is the zstd level (must be ≥ 1 — level 0 is
+    /// rejected up front by `SortOptions::validate`, since zstd has no
+    /// uncompressed mode). For bgzf, `compression == 0` writes *framed* stored
+    /// (uncompressed) BGZF blocks and `> 0` writes deflate-compressed BGZF blocks
+    /// at that level — in both cases valid, reader-consumable BGZF.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the output file cannot be created or the zstd
+    /// compressor cannot be initialized.
+    pub(crate) fn create(path: &Path, codec: SpillCodec, compression: u32) -> Result<Self> {
+        match codec {
+            SpillCodec::Bgzf => Ok(Self::Bgzf(BgzfSpillWriter::create(path, compression)?)),
+            SpillCodec::Zstd => Ok(Self::Zstd(ZstdSpillWriter::create(path, compression)?)),
+        }
+    }
+
+    /// Write one keyed record in the spill frame format.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if key serialization or the underlying write fails.
+    pub(crate) fn write_record(&mut self, key: &K, record: &[u8]) -> Result<()> {
+        match self {
+            Self::Bgzf(w) => w.write_record(key, record),
+            Self::Zstd(w) => w.write_record(key, record),
+        }
+    }
+
+    /// Flush and close the chunk file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a final flush/compress fails.
+    pub(crate) fn finish(self) -> Result<()> {
+        match self {
+            Self::Bgzf(w) => w.finish(),
+            Self::Zstd(w) => w.finish(),
+        }
+    }
+}
+
+/// Inline BGZF spill writer: framed BGZF blocks (via [`InlineBgzfCompressor`])
+/// followed by a trailing `BGZF_EOF`, matching `PooledChunkWriter`'s bgzf output.
+/// Records are framed `[key.write_to() if !EMBEDDED][u32 LE record-len][record]`
+/// into the compressor's byte stream, identical to the zstd arm.
+pub(crate) struct BgzfSpillWriter<K: RawSortKey> {
+    writer: BufWriter<File>,
+    compressor: InlineBgzfCompressor,
+    /// Reused staging buffer for serialized keys (non-embedded keys only).
+    ///
+    /// Kept on the writer rather than allocated per record: this is the
+    /// queryname and template-coordinate spill path, so a per-record `Vec`
+    /// costs one malloc/free for every record in the sort.
+    key_scratch: Vec<u8>,
+    _marker: PhantomData<K>,
+}
+
+impl<K: RawSortKey> BgzfSpillWriter<K> {
+    fn create(path: &Path, level: u32) -> Result<Self> {
+        let file = File::create(path)?;
+        let writer = BufWriter::with_capacity(256 * 1024, file);
+        Ok(Self {
+            writer,
+            compressor: InlineBgzfCompressor::new(level),
+            key_scratch: Vec::new(),
+            _marker: PhantomData,
+        })
+    }
+
+    /// Drain any completed (full-block) compressed output to disk, bounding the
+    /// compressor's retained-block memory during a large chunk write.
+    fn drain_blocks(&mut self) -> Result<()> {
+        for block in self.compressor.take_blocks() {
+            self.writer.write_all(&block.data)?;
+        }
+        Ok(())
+    }
+
+    fn write_record(&mut self, key: &K, record: &[u8]) -> Result<()> {
+        // Validate the record length BEFORE any compressor write, so an oversized
+        // record fails loud without leaving partial (key) bytes in the stream.
+        let record_len = u32::try_from(record.len())
+            .map_err(|_| anyhow::anyhow!("BAM record too large ({} bytes)", record.len()))?;
+        if !K::EMBEDDED_IN_RECORD {
+            // `compressor` and `key_scratch` are disjoint fields, so the scratch
+            // can be filled and written without moving it out of `self`.
+            self.key_scratch.clear();
+            key.write_to(&mut self.key_scratch)?;
+            self.compressor.write_all(&self.key_scratch)?;
+        }
+        self.compressor.write_all(&record_len.to_le_bytes())?;
+        // Drain between block-sized chunks so retained compressed-block memory
+        // stays bounded even for a very large (long-read) record, rather than
+        // scaling with the record size.
+        for chunk in record.chunks(BGZF_MAX_BLOCK_SIZE) {
+            self.compressor.write_all(chunk)?;
+            self.drain_blocks()?;
+        }
+        // Catch the key/length bytes when `record` is empty (the loop is a no-op).
+        self.drain_blocks()
+    }
+
+    fn finish(mut self) -> Result<()> {
+        self.compressor.flush()?;
+        self.drain_blocks()?;
+        // BGZF stream terminator (the empty-block EOF marker), as the pooled
+        // writer and noodles bgzf writer both emit.
+        self.writer.write_all(&BGZF_EOF)?;
+        self.writer.flush()?;
+        Ok(())
+    }
+}
+
+/// Inline zstd spill writer: `ZSPILL_MAGIC` then length-prefixed zstd frames,
+/// one frame per ≤`BGZF_MAX_BLOCK_SIZE` raw block.
+pub(crate) struct ZstdSpillWriter<K: RawSortKey> {
+    writer: BufWriter<File>,
+    compressor: ZstdCompressor<'static>,
+    /// Raw (uncompressed) staging block; flushed as a zstd frame at
+    /// `BGZF_MAX_BLOCK_SIZE`.
+    block: Vec<u8>,
+    /// Reused staging buffer for serialized keys — see
+    /// [`BgzfSpillWriter::key_scratch`].
+    key_scratch: Vec<u8>,
+    _marker: PhantomData<K>,
+}
+
+impl<K: RawSortKey> ZstdSpillWriter<K> {
+    fn create(path: &Path, level: u32) -> Result<Self> {
+        let file = File::create(path)?;
+        let mut writer = BufWriter::with_capacity(256 * 1024, file);
+        writer.write_all(&ZSPILL_MAGIC)?;
+        #[allow(clippy::cast_possible_wrap)]
+        let compressor = ZstdCompressor::new(level as i32)
+            .map_err(|e| anyhow::anyhow!("zstd compressor init (level {level}): {e}"))?;
+        Ok(Self {
+            writer,
+            compressor,
+            block: Vec::with_capacity(BGZF_MAX_BLOCK_SIZE + 1024),
+            key_scratch: Vec::new(),
+            _marker: PhantomData,
+        })
+    }
+
+    /// Compress the staged block as one zstd frame and write `[u32 len][frame]`.
+    /// No-op when the block is empty (no empty frames in the stream).
+    fn flush_block(&mut self) -> Result<()> {
+        if self.block.is_empty() {
+            return Ok(());
+        }
+        let frame = self
+            .compressor
+            .compress(&self.block)
+            .map_err(|e| anyhow::anyhow!("zstd compress: {e}"))?;
+        let frame_len = u32::try_from(frame.len())
+            .map_err(|_| anyhow::anyhow!("zstd frame larger than 4 GiB cannot fit a u32 prefix"))?;
+        self.writer.write_all(&frame_len.to_le_bytes())?;
+        self.writer.write_all(&frame)?;
+        self.block.clear();
+        Ok(())
+    }
+
+    /// Append `data` to the staging block, flushing a frame whenever the block
+    /// fills. A record (or key) larger than one block therefore spans frames —
+    /// safe because the reader streams across frame boundaries.
+    fn append(&mut self, mut data: &[u8]) -> Result<()> {
+        while !data.is_empty() {
+            let space = BGZF_MAX_BLOCK_SIZE.saturating_sub(self.block.len());
+            let n = data.len().min(space);
+            self.block.extend_from_slice(&data[..n]);
+            data = &data[n..];
+            if self.block.len() >= BGZF_MAX_BLOCK_SIZE {
+                self.flush_block()?;
+            }
+        }
+        Ok(())
+    }
+
+    fn write_record(&mut self, key: &K, record: &[u8]) -> Result<()> {
+        // Validate the record length BEFORE any append, so an oversized record
+        // fails loud without leaving partial (key) bytes in the staging block.
+        let record_len = u32::try_from(record.len())
+            .map_err(|_| anyhow::anyhow!("BAM record too large ({} bytes)", record.len()))?;
+        if !K::EMBEDDED_IN_RECORD {
+            // `append` takes `&mut self`, so unlike the bgzf arm the scratch
+            // cannot stay borrowed from `self` across the call — move it out and
+            // put it back, which reuses the allocation across records all the
+            // same. An error here abandons the whole spill, so not restoring the
+            // buffer on that path costs nothing.
+            let mut key_bytes = std::mem::take(&mut self.key_scratch);
+            key_bytes.clear();
+            key.write_to(&mut key_bytes)?;
+            self.append(&key_bytes)?;
+            self.key_scratch = key_bytes;
+        }
+        self.append(&record_len.to_le_bytes())?;
+        self.append(record)?;
+        Ok(())
+    }
+
+    fn finish(mut self) -> Result<()> {
+        self.flush_block()?;
+        self.writer.flush()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::external::GenericKeyedChunkReader;
+    use crate::inline::TemplateKey;
+    use crate::pooled_chunk_writer::PooledChunkWriter;
+    use crate::worker_pool::SortWorkerPool;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn make_key(i: u64) -> TemplateKey {
+        TemplateKey::new(
+            i as i32,
+            i as i32,
+            false,
+            i32::MAX,
+            i32::MAX,
+            false,
+            0,
+            0,
+            (0, false),
+            i,
+            false,
+        )
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn sample_records(n: u64) -> Vec<(TemplateKey, Vec<u8>)> {
+        (0..n).map(|i| (make_key(i), vec![(i % 256) as u8; 200 + (i as usize % 50)])).collect()
+    }
+
+    fn read_back(path: &Path) -> Vec<(TemplateKey, Vec<u8>)> {
+        let mut reader =
+            GenericKeyedChunkReader::<TemplateKey>::open(path, None).expect("open reader");
+        let mut buf = Vec::new();
+        let mut out = Vec::new();
+        while let Some(key) = reader.next_record(&mut buf).expect("read record") {
+            out.push((key, buf.clone()));
+        }
+        out
+    }
+
+    /// A minimal BAM fixed-block body with the coordinate fields set: `ref_id` at
+    /// 0..4, `pos` at 4..8, `flag` at 14..16 — the three
+    /// `RawCoordinateKey::extract_from_record` reads. 32 bytes is the fixed block,
+    /// plus a tail byte to make each record distinguishable.
+    fn coordinate_body(tid: i32, pos: i32, tail: u8) -> Vec<u8> {
+        let mut b = vec![0u8; 32];
+        b[0..4].copy_from_slice(&tid.to_le_bytes());
+        b[4..8].copy_from_slice(&pos.to_le_bytes());
+        b[14..16].copy_from_slice(&0u16.to_le_bytes()); // flags: mapped, forward
+        b.push(tail);
+        b
+    }
+
+    fn read_back_coordinate(path: &Path) -> Vec<Vec<u8>> {
+        let mut reader = GenericKeyedChunkReader::<crate::keys::RawCoordinateKey>::open(path, None)
+            .expect("open reader");
+        let mut buf = Vec::new();
+        let mut out = Vec::new();
+        while reader.next_record(&mut buf).expect("read record").is_some() {
+            out.push(buf.clone());
+        }
+        out
+    }
+
+    /// The embedded-key writer path, on both codecs.
+    ///
+    /// Every other writer test uses `TemplateKey`, whose `EMBEDDED_IN_RECORD` is
+    /// `false` — so they all take the `if !K::EMBEDDED_IN_RECORD` branch and write
+    /// a key prefix. The *skip* side of that branch, which the coordinate and
+    /// queryname sorts use, was never exercised at this layer: those records carry
+    /// their key inside the body and the spill frame is `[u32 len][record]` with no
+    /// prefix at all. A writer that emitted a prefix anyway would desync the
+    /// reader, and no existing test would notice.
+    #[rstest::rstest]
+    #[case::zstd(SpillCodec::Zstd)]
+    #[case::bgzf(SpillCodec::Bgzf)]
+    fn sync_writers_round_trip_embedded_keys(#[case] codec: SpillCodec) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("embedded.keyed");
+        // Ascending positions so the spill is a sorted run, as production writes.
+        let bodies: Vec<Vec<u8>> =
+            (0..16i32).map(|i| coordinate_body(0, i * 10, u8::try_from(i).unwrap())).collect();
+
+        let mut w =
+            SyncSpillWriter::<crate::keys::RawCoordinateKey>::create(&path, codec, 1).unwrap();
+        for b in &bodies {
+            let key = crate::keys::RawCoordinateKey::extract_from_record(b);
+            w.write_record(&key, b).unwrap();
+        }
+        w.finish().unwrap();
+
+        assert_eq!(
+            read_back_coordinate(&path),
+            bodies,
+            "embedded-key records must round-trip with no key prefix ({codec:?})",
+        );
+    }
+
+    /// The sync zstd writer round-trips every record back through the same reader
+    /// the production merge/Phase-2 path uses, and the file carries `ZSPILL_MAGIC`.
+    #[test]
+    fn sync_zstd_round_trips() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("sync_zstd.keyed");
+        let records = sample_records(300);
+
+        let mut w = SyncSpillWriter::<TemplateKey>::create(&path, SpillCodec::Zstd, 3).unwrap();
+        for (k, r) in &records {
+            w.write_record(k, r).unwrap();
+        }
+        w.finish().unwrap();
+
+        let bytes = std::fs::read(&path).unwrap();
+        assert_eq!(&bytes[..ZSPILL_MAGIC.len()], &ZSPILL_MAGIC[..], "missing ZSPILL_MAGIC");
+        assert_eq!(read_back(&path), records, "sync zstd round-trip mismatch");
+    }
+
+    /// Cross-check: the sync zstd writer and the pooled (async) zstd writer
+    /// produce files that read back to the *same* records — proving the formats
+    /// are interchangeable for `SortSpillDecompress` / the merge reader.
+    #[test]
+    fn sync_zstd_matches_pooled_zstd_read_back() {
+        let dir = TempDir::new().unwrap();
+        let records = sample_records(500);
+
+        let sync_path = dir.path().join("sync.keyed");
+        let mut w =
+            SyncSpillWriter::<TemplateKey>::create(&sync_path, SpillCodec::Zstd, 3).unwrap();
+        for (k, r) in &records {
+            w.write_record(k, r).unwrap();
+        }
+        w.finish().unwrap();
+
+        let pooled_path = dir.path().join("pooled.keyed");
+        let pool = Arc::new(SortWorkerPool::new(2, 3, 6, SpillCodec::Zstd));
+        {
+            let mut pw = PooledChunkWriter::<TemplateKey>::new(
+                Arc::clone(&pool),
+                &pooled_path,
+                SpillCodec::Zstd,
+            )
+            .unwrap();
+            for (k, r) in &records {
+                pw.write_record(k, r).unwrap();
+            }
+            pw.finish().unwrap();
+        }
+        if let Ok(p) = Arc::try_unwrap(pool) {
+            p.shutdown();
+        }
+
+        assert_eq!(
+            read_back(&sync_path),
+            read_back(&pooled_path),
+            "sync vs pooled read-back differ"
+        );
+    }
+
+    /// A zero-length record body must round-trip through the writer, on BOTH
+    /// codecs, without desynchronising the records around it.
+    ///
+    /// This is the sibling of the kernel-level
+    /// `zero_length_record_body_frames_and_keeps_the_stream_aligned`: that one
+    /// pins `frame_keyed_record_into`, this one pins the streaming writers.
+    ///
+    /// The empty body is the degenerate shape of both arms' inner loops —
+    /// `record.chunks(BGZF_MAX_BLOCK_SIZE)` and the zstd `append` both iterate
+    /// zero times — so the record reaches the stream as `[key][0u32]` and
+    /// nothing else, entirely via the surrounding flush paths. The empty record
+    /// sits between two non-empty ones so a misframed zero length surfaces as
+    /// its neighbours decoding wrong, rather than as one silently-absent record.
+    ///
+    /// Note on scope: the trailing `drain_blocks()` in the bgzf arm is NOT what
+    /// makes this pass. Removing it keeps every test green, because `finish()`
+    /// flushes the compressor before draining — that call bounds retained
+    /// block memory between records, which is what its own comment claims, and
+    /// is not load-bearing for correctness.
+    #[rstest::rstest]
+    #[case::zstd(SpillCodec::Zstd)]
+    #[case::bgzf(SpillCodec::Bgzf)]
+    fn sync_writers_round_trip_a_zero_length_record_body(#[case] codec: SpillCodec) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("empty-body.keyed");
+        let records: Vec<(TemplateKey, Vec<u8>)> = vec![
+            (make_key(1), vec![0xAA; 64]),
+            (make_key(2), Vec::new()),
+            (make_key(3), vec![0xBB; 96]),
+        ];
+
+        let mut w = SyncSpillWriter::<TemplateKey>::create(&path, codec, 1).unwrap();
+        for (k, r) in &records {
+            w.write_record(k, r).unwrap();
+        }
+        w.finish().unwrap();
+
+        assert_eq!(
+            read_back(&path),
+            records,
+            "a zero-length body must round-trip and keep its neighbours aligned ({codec:?})",
+        );
+    }
+
+    /// Records larger than one block must span blocks and still round-trip —
+    /// on BOTH codecs.
+    ///
+    /// The two arms interleave differently and neither can vouch for the other:
+    /// zstd fills a staging block and flushes a frame when it is full, while
+    /// bgzf pushes `record.chunks(BGZF_MAX_BLOCK_SIZE)` into the compressor and
+    /// drains completed blocks between chunks. That chunk/drain interleaving is
+    /// exactly where a boundary defect would live, and it was untested — the
+    /// case ran zstd only.
+    #[rstest::rstest]
+    #[case::zstd(SpillCodec::Zstd)]
+    #[case::bgzf(SpillCodec::Bgzf)]
+    fn sync_writers_span_blocks_for_large_records(#[case] codec: SpillCodec) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("large.keyed");
+        // Two records each ~3x the block size — forces multi-block spanning.
+        // The `+ 17` keeps the tail from landing on a block boundary.
+        let big = vec![0xABu8; BGZF_MAX_BLOCK_SIZE * 3 + 17];
+        let records = vec![(make_key(1), big.clone()), (make_key(2), big)];
+
+        let mut w = SyncSpillWriter::<TemplateKey>::create(&path, codec, 1).unwrap();
+        for (k, r) in &records {
+            w.write_record(k, r).unwrap();
+        }
+        w.finish().unwrap();
+
+        assert_eq!(
+            read_back(&path),
+            records,
+            "large-record block spanning round-trip mismatch for {codec:?}",
+        );
+    }
+
+    /// Uncompressed bgzf (level 0) must write *framed* (stored) BGZF blocks —
+    /// starting with the `0x1f 0x8b` gzip magic — NOT raw bytes, or the bgzf
+    /// reader's magic check rejects the spill. Regression for the
+    /// `--temp-compression 0 --temp-codec bgzf` path. Also cross-checks that the
+    /// records read back match the pooled writer at level 0.
+    #[test]
+    fn sync_bgzf_level0_is_framed_and_matches_pooled() {
+        let dir = TempDir::new().unwrap();
+        let records = sample_records(300);
+
+        let sync_path = dir.path().join("sync_l0.keyed");
+        let mut w =
+            SyncSpillWriter::<TemplateKey>::create(&sync_path, SpillCodec::Bgzf, 0).unwrap();
+        for (k, r) in &records {
+            w.write_record(k, r).unwrap();
+        }
+        w.finish().unwrap();
+
+        let bytes = std::fs::read(&sync_path).unwrap();
+        assert_eq!(
+            &bytes[..2],
+            &[0x1f, 0x8b],
+            "level-0 bgzf spill must be framed BGZF (gzip magic), not raw"
+        );
+        assert_eq!(read_back(&sync_path), records, "level-0 bgzf round-trip mismatch");
+
+        // Cross-check vs the pooled writer at level 0 (its pool is built with
+        // temp_compression = 0).
+        let pooled_path = dir.path().join("pooled_l0.keyed");
+        let pool = Arc::new(SortWorkerPool::new(2, 0, 6, SpillCodec::Bgzf));
+        {
+            let mut pw = PooledChunkWriter::<TemplateKey>::new(
+                Arc::clone(&pool),
+                &pooled_path,
+                SpillCodec::Bgzf,
+            )
+            .unwrap();
+            for (k, r) in &records {
+                pw.write_record(k, r).unwrap();
+            }
+            pw.finish().unwrap();
+        }
+        if let Ok(p) = Arc::try_unwrap(pool) {
+            p.shutdown();
+        }
+        assert_eq!(
+            read_back(&sync_path),
+            read_back(&pooled_path),
+            "level-0 bgzf: sync vs pooled read-back differ"
+        );
+    }
+
+    /// `write_sorted_chunk_inmem` must produce a byte-identical spill file to
+    /// `write_sorted_chunk` for the same records.
+    ///
+    /// It is a separate public entry point that walks the chunk by index
+    /// (`key_at(i)` / `record_bytes(i)`) instead of iterating owned pairs, and
+    /// nothing covered it. An off-by-one or a key/record mismatch in that
+    /// indexing still yields a spill file that parses cleanly, so the merge
+    /// would emit wrong records rather than fail — the parity assertion is what
+    /// makes that visible.
+    #[test]
+    fn write_sorted_chunk_inmem_matches_write_sorted_chunk() {
+        let dir = TempDir::new().unwrap();
+        let records = sample_records(400);
+
+        let keyed: Vec<(TemplateKey, RawRecord)> =
+            records.iter().map(|(k, r)| (*k, RawRecord::from(r.clone()))).collect();
+        let owned: Vec<(TemplateKey, Vec<u8>)> =
+            records.iter().map(|(k, r)| (*k, r.clone())).collect();
+        let chunk = crate::InMemoryChunk::from_owned_records(owned);
+
+        let from_pairs = dir.path().join("pairs.keyed");
+        let from_chunk = dir.path().join("chunk.keyed");
+        crate::write_sorted_chunk(&from_pairs, SpillCodec::Zstd, 3, &keyed).unwrap();
+        crate::write_sorted_chunk_inmem(&from_chunk, SpillCodec::Zstd, 3, &chunk).unwrap();
+
+        assert_eq!(read_back(&from_chunk), records, "in-mem writer round-trip mismatch");
+        assert_eq!(
+            std::fs::read(&from_chunk).unwrap(),
+            std::fs::read(&from_pairs).unwrap(),
+            "the two writers must produce byte-identical spill files",
+        );
+    }
+
+    /// `write_sorted_chunk` (the per-chunk entry the `CompressSpill` step calls)
+    /// round-trips every record through the merge reader, and `open_spill_slot`
+    /// opens the result with the requested `file_id` and the detected codec.
+    #[test]
+    fn write_sorted_chunk_round_trips_and_open_spill_slot_sets_file_id() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("chunk_0007.keyed");
+        let records = sample_records(400);
+        // `write_sorted_chunk` takes `(K, RawRecord)`; `read_back` yields
+        // `(K, Vec<u8>)`. Build the keyed form once and compare read-back vs the
+        // original `Vec<u8>` payloads.
+        let keyed: Vec<(TemplateKey, RawRecord)> =
+            records.iter().map(|(k, r)| (*k, RawRecord::from(r.clone()))).collect();
+
+        crate::write_sorted_chunk(&path, SpillCodec::Zstd, 3, &keyed).unwrap();
+        assert_eq!(read_back(&path), records, "write_sorted_chunk round-trip mismatch");
+
+        let slot = crate::open_spill_slot(&path, 7).expect("open spill slot");
+        assert_eq!(slot.file_id, 7, "open_spill_slot must honor the requested file_id");
+        assert_eq!(slot.codec, SpillCodec::Zstd, "codec must be detected from the file magic");
+
+        // The bgzf arm: codec detection must fall back to Bgzf (no ZSPILL magic).
+        let bgzf_path = dir.path().join("chunk_0008.keyed");
+        crate::write_sorted_chunk(&bgzf_path, SpillCodec::Bgzf, 1, &keyed).unwrap();
+        let bgzf_slot = crate::open_spill_slot(&bgzf_path, 8).expect("open bgzf spill slot");
+        assert_eq!(bgzf_slot.file_id, 8);
+        assert_eq!(bgzf_slot.codec, SpillCodec::Bgzf);
+    }
+
+    /// The bgzf arm frames records itself and drives `InlineBgzfCompressor`
+    /// directly; confirm the unified type round-trips there too.
+    #[test]
+    fn sync_bgzf_round_trips() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("sync_bgzf.keyed");
+        let records = sample_records(200);
+
+        let mut w = SyncSpillWriter::<TemplateKey>::create(&path, SpillCodec::Bgzf, 1).unwrap();
+        for (k, r) in &records {
+            w.write_record(k, r).unwrap();
+        }
+        w.finish().unwrap();
+
+        assert_eq!(read_back(&path), records, "sync bgzf round-trip mismatch");
+    }
+}

--- a/crates/fgumi-sort/src/template_arena.rs
+++ b/crates/fgumi-sort/src/template_arena.rs
@@ -1,0 +1,455 @@
+//! Template-coordinate arena-front sort: build a sorted
+//! [`InMemoryChunk<TemplateKey>`] from record bodies already resident in a shared
+//! arena, WITHOUT copying record bytes — the template analogue of the coordinate
+//! [`coordinate_chunk_from_refs`](crate::ref_sort::coordinate_chunk_from_refs).
+//!
+//! [`TemplateArenaAccumulator`] encapsulates everything the template key needs
+//! that the arena-front pipeline step (`FindBoundariesAndSort` in
+//! `fgumi-pipeline-io`) does not have: the [`LibraryLookup`], cell-barcode tag +
+//! hasher, the `--key-types` narrowed-lane selection, and the per-record
+//! dropped-lane verification. The pipeline step calls [`push`](TemplateArenaAccumulator::push)
+//! per record (arena offset + len) and [`seal`](TemplateArenaAccumulator::seal)
+//! per run, exactly mirroring the owned [`TemplateChunkSorter`](crate::TemplateChunkSorter)
+//! so the output is byte-for-byte identical — only the record bodies stay in the
+//! shared arena instead of being copied into owned `RawRecord`s.
+
+use std::io;
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Result;
+use noodles::sam::Header;
+
+use crate::arena_pool::PooledSegmentedBuf;
+use crate::external::{
+    KeyTypesSpec, LibraryLookup, TemplateKeyVariant, cb_hasher, dropped_lane_error,
+    extract_template_key_inline, select_template_variant, verify_dropped_lanes,
+};
+use crate::inline::{
+    CbKey32, InMemoryChunk, TemplateKey, TemplateKey24, TemplateKey40, TemplateLaneKey,
+    TemplateRecordRef, TertKey32, parallel_radix_sort_template_refs, radix_sort_template_refs,
+};
+use crate::ref_sort::PARALLEL_SORT_THRESHOLD;
+use crate::{SpillCodec, frame_keyed_record_into, write_sorted_chunk_inmem};
+use fgumi_raw_bam::{RawRecordView, SamTag};
+
+/// Variant-carrying erased template residual chunk: one arm per `--key-types`
+/// narrowed lane. Lets `MemoryChunkErased::TemplateCoordinate` hold whichever
+/// lane variant the sort chose, so template-coordinate rides its natural narrow
+/// key end-to-end through merge and spill — exactly like every other sort order
+/// rides its own `K` — instead of being pinned to the full 40-byte
+/// [`TemplateKey`]. Narrow-lane order equals full-key order (every dropped lane
+/// is verified constant on the ingest path), so merging and spilling the narrow
+/// key is byte-identical to the full key. The [`K40`](Self::K40) arm is the full
+/// key (all lanes), used by the legacy owned path and the full variant.
+pub enum TemplateMemChunk {
+    /// 24-byte core-only lane (neither cb nor tertiary optional word present).
+    K24(InMemoryChunk<TemplateKey24>),
+    /// 32-byte lane whose optional word carries `cb_hash`.
+    Cb32(InMemoryChunk<CbKey32>),
+    /// 32-byte lane whose optional word carries the tertiary (library<<48 | mi).
+    Tert32(InMemoryChunk<TertKey32>),
+    /// Full 40-byte key (all lanes) — the legacy owned path and full variant.
+    K40(InMemoryChunk<TemplateKey>),
+}
+
+/// Run `$body` against the inner `InMemoryChunk<K>` of whichever variant
+/// `$self` holds, with the chunk bound to `$chunk`. `$body` is monomorphized per
+/// arm, so type inference resolves `K` (e.g. `c.key_at`) from the matched chunk
+/// type. Mirrors `chunk_sorter::with_template_buffer!`.
+///
+/// Every per-variant dispatch on this enum goes through here: writing the
+/// four-arm match out by hand in each method makes a fifth lane variant a
+/// six-site edit, and a copy-paste that dispatches the wrong arm still compiles.
+macro_rules! with_template_chunk {
+    ($self:expr, $chunk:ident => $body:expr) => {
+        match $self {
+            TemplateMemChunk::K24($chunk) => $body,
+            TemplateMemChunk::Cb32($chunk) => $body,
+            TemplateMemChunk::Tert32($chunk) => $body,
+            TemplateMemChunk::K40($chunk) => $body,
+        }
+    };
+}
+
+impl TemplateMemChunk {
+    /// Number of records in the chunk.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        with_template_chunk!(self, c => c.len())
+    }
+
+    /// `true` iff the chunk holds zero records.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Total record-payload bytes (sum of record lengths; excludes keys and
+    /// index overhead). Used for byte-budget accounting at the chunk boundary.
+    #[must_use]
+    pub fn payload_bytes(&self) -> usize {
+        with_template_chunk!(self, c => c.payload_bytes())
+    }
+
+    /// Borrow the `i`th record's raw BAM body bytes, in this chunk's sorted order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `i >= self.len()`.
+    #[must_use]
+    pub fn record_bytes(&self, i: usize) -> &[u8] {
+        with_template_chunk!(self, c => c.record_bytes(i))
+    }
+
+    /// Frame the `i`th record into `out` in the spill layout
+    /// `[key][u32 LE len][record]`, using this chunk's narrow-lane key.
+    ///
+    /// Encapsulates the per-variant key dispatch so the pipeline-io spill
+    /// serializer stays variant-agnostic.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if writing to `out` fails.
+    pub fn frame_record_into(&self, i: usize, out: &mut Vec<u8>) -> io::Result<()> {
+        with_template_chunk!(self, c => frame_keyed_record_into(out, c.key_at(i), c.record_bytes(i)))
+    }
+
+    /// Write the whole chunk to a spill file at `path` via
+    /// [`write_sorted_chunk_inmem`], keyed by this chunk's narrow lane.
+    ///
+    /// Encapsulates the per-variant key dispatch so the pipeline-io compress
+    /// step stays variant-agnostic.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the spill write fails.
+    pub fn write_spill(&self, path: &Path, codec: SpillCodec, compression: u32) -> Result<()> {
+        with_template_chunk!(self, c => write_sorted_chunk_inmem(path, codec, compression, c))
+    }
+}
+
+/// Build a sorted template chunk from narrow-lane refs pointing into `arena`.
+///
+/// Featherweight seal (the template analogue of the coordinate
+/// [`coordinate_chunk_from_refs`](crate::ref_sort::coordinate_chunk_from_refs)):
+/// sorts `refs` on their cached narrow lane key (stable radix — parallel for
+/// large multi-threaded runs, matching the owned path's `par_sort`) and copies
+/// that narrow key straight into the returned [`InMemoryChunk<K>`]. NO full-key
+/// re-extraction, NO arena body access — the key is already resident in each
+/// ref (computed once at `push`). No record bytes are copied: the records
+/// reference their bodies in `arena` at `(offset, len)`. Narrow-lane order
+/// equals full-key order (every dropped lane is verified constant on the ingest
+/// path), so the chunk is correctly ordered for the downstream `MergeDriver<K>`,
+/// and spilling/merging the narrow key is byte-identical to the full key.
+///
+/// The parallel-vs-serial decision mirrors the coordinate front
+/// ([`sort_coordinate_refs`](crate::ref_sort)): it uses the parallel radix only
+/// when `sort_threads > 1` AND the run exceeds the shared
+/// `PARALLEL_SORT_THRESHOLD`, so a small run does not pay the parallel radix's
+/// partition/coordination overhead. Both paths produce byte-identical output
+/// (the parallel template radix is stability-tested against the serial one).
+#[must_use]
+pub fn template_chunk_from_arena_refs<K: TemplateLaneKey>(
+    arena: Arc<PooledSegmentedBuf>,
+    mut refs: Vec<TemplateRecordRef<K>>,
+    sort_threads: usize,
+) -> InMemoryChunk<K> {
+    if sort_threads > 1 && refs.len() >= PARALLEL_SORT_THRESHOLD {
+        parallel_radix_sort_template_refs(&mut refs);
+    } else {
+        radix_sort_template_refs(&mut refs);
+    }
+    let records: Vec<(K, u64, u32)> = refs.into_iter().map(|r| (r.key, r.offset, r.len)).collect();
+    InMemoryChunk::from_parts(arena, records)
+}
+
+/// Narrow-lane ref accumulator, one arm per `--key-types` variant (mirrors the
+/// owned `TemplateBuffer`'s variant set). Each holds `TemplateRecordRef<K>`s
+/// pointing at record bodies in the shared inflate arena — no owned byte storage.
+enum ArenaRefs {
+    K24(Vec<TemplateRecordRef<TemplateKey24>>),
+    Cb32(Vec<TemplateRecordRef<CbKey32>>),
+    Tert32(Vec<TemplateRecordRef<TertKey32>>),
+    K40(Vec<TemplateRecordRef<TemplateKey40>>),
+}
+
+/// [`with_template_chunk!`]'s analogue for [`ArenaRefs`]: run `$body` against
+/// the inner `Vec<TemplateRecordRef<K>>` of whichever variant `$self` holds.
+macro_rules! with_arena_refs {
+    ($self:expr, $refs:ident => $body:expr) => {
+        match $self {
+            ArenaRefs::K24($refs) => $body,
+            ArenaRefs::Cb32($refs) => $body,
+            ArenaRefs::Tert32($refs) => $body,
+            ArenaRefs::K40($refs) => $body,
+        }
+    };
+}
+
+impl ArenaRefs {
+    fn for_variant(v: TemplateKeyVariant) -> Self {
+        match (v.cb, v.tertiary) {
+            (false, false) => Self::K24(Vec::new()),
+            (true, false) => Self::Cb32(Vec::new()),
+            (false, true) => Self::Tert32(Vec::new()),
+            (true, true) => Self::K40(Vec::new()),
+        }
+    }
+
+    #[inline]
+    fn push(&mut self, full: &TemplateKey, offset: u64, len: u32) {
+        // The `key` field type resolves `K` per arm, so `from_full` narrows to the
+        // matching lane width (identical to the owned `TemplateRecordBuffer::push`).
+        with_arena_refs!(self, v => v.push(TemplateRecordRef {
+            key: TemplateLaneKey::from_full(full),
+            offset,
+            len,
+            padding: 0,
+        }));
+    }
+
+    fn reserve(&mut self, n: usize) {
+        with_arena_refs!(self, v => v.reserve(n));
+    }
+}
+
+/// State that exists only once the first record has been seen: the chosen
+/// narrowed-key variant, the first record's full key (the dropped-lane verify
+/// baseline), and the accumulated refs. Set together on the first push and
+/// persisted across runs (spills) — matching the owned `TemplateChunkSorter`,
+/// whose variant/baseline are chosen once and never re-selected.
+struct AccState {
+    first_key: TemplateKey,
+    variant: TemplateKeyVariant,
+    refs: ArenaRefs,
+}
+
+/// Arena-front template-coordinate accumulator: the template analogue of the
+/// owned [`TemplateChunkSorter`](crate::TemplateChunkSorter), accumulating
+/// arena-pointing refs instead of copying records. Produces byte-identical
+/// output (same provisioning, same dropped-lane rejection, same sorted order).
+pub struct TemplateArenaAccumulator {
+    lib_lookup: LibraryLookup,
+    cell_tag: Option<SamTag>,
+    cb_hasher: ahash::RandomState,
+    key_types: KeyTypesSpec,
+    header_library_varies: bool,
+    /// Variant + baseline + refs; `None` until the first record provisions it.
+    state: Option<AccState>,
+    /// Reserve hint received before the first record (variant unknown), applied
+    /// when the ref buffer is provisioned.
+    pending_reserve: usize,
+    /// Bounded rayon pool (sized to `sort_threads`) that [`seal`](Self::seal)
+    /// installs the per-run radix + full-key gather into, so they run on exactly
+    /// `sort_threads` threads instead of the GLOBAL rayon pool. Without this the
+    /// parallel radix and `par_iter` gather fan out over every core and
+    /// oversubscribe the pipeline's own worker pool during a spill (the pipeline
+    /// runs the sort on one worker while the others inflate/compress). Mirrors
+    /// the owned `TemplateChunkSorter`'s `rayon_pool.install(...)`.
+    ///
+    /// **Shared across worker copies, and it has to be.** `sort_threads` is only
+    /// known at the first [`seal`](Self::seal), which happens *after*
+    /// [`fresh`](Self::fresh) has already produced the copies — so a plain
+    /// `Option<ThreadPool>`, or even an `Option<Arc<ThreadPool>>`, gives every
+    /// worker its own pool and puts `workers × sort_threads` threads on the box.
+    /// That is precisely the oversubscription this field exists to prevent, just
+    /// reintroduced one level up. `Arc<OnceLock<_>>` lets the copies be made
+    /// first and the single pool be built once, by whichever worker seals first.
+    sort_pool: Arc<std::sync::OnceLock<rayon::ThreadPool>>,
+}
+
+impl TemplateArenaAccumulator {
+    /// Build an accumulator from the BAM `header`, the sort's cell-barcode tag,
+    /// and the `--key-types` spec, deriving the library lookup and CB hasher
+    /// exactly as
+    /// [`RawExternalSorter::into_template_chunk_sorter`](crate::RawExternalSorter::into_template_chunk_sorter).
+    #[must_use]
+    pub fn from_header(header: &Header, cell_tag: Option<SamTag>, key_types: KeyTypesSpec) -> Self {
+        let lib_lookup = LibraryLookup::from_header(header);
+        let header_library_varies = lib_lookup.distinct_header_ordinals() > 1;
+        Self {
+            lib_lookup,
+            cell_tag,
+            cb_hasher: cb_hasher(),
+            key_types,
+            header_library_varies,
+            state: None,
+            pending_reserve: 0,
+            sort_pool: Arc::new(std::sync::OnceLock::new()),
+        }
+    }
+
+    /// Reserve capacity for approximately `est_records` refs for the current run.
+    pub fn reserve(&mut self, est_records: usize) {
+        if let Some(state) = self.state.as_mut() {
+            state.refs.reserve(est_records);
+        } else {
+            self.pending_reserve = self.pending_reserve.max(est_records);
+        }
+    }
+
+    /// Extract the template key from `body` (the record's BAM body, `block_size`
+    /// prefix excluded, at arena offset `body_off`, length `len`), provision the
+    /// narrowed-lane variant on the first record, verify the dropped lanes on
+    /// every subsequent record, and accumulate a ref into the arena.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a record carries a dropped-lane value (CB / MI /
+    /// library) absent from the first record — the same rejection the owned
+    /// `TemplateChunkSorter::push` performs.
+    pub fn push(&mut self, body: &[u8], body_off: u64, len: u32) -> Result<()> {
+        let key =
+            extract_template_key_inline(body, &self.lib_lookup, self.cell_tag, &self.cb_hasher);
+        if let Some(state) = self.state.as_mut() {
+            if let Some(violation) = verify_dropped_lanes(&state.first_key, &key, state.variant) {
+                let name = RawRecordView::new(body).read_name();
+                return Err(dropped_lane_error(&String::from_utf8_lossy(name), violation));
+            }
+            state.refs.push(&key, body_off, len);
+        } else {
+            let variant =
+                select_template_variant(Some(&key), self.key_types, self.header_library_varies);
+            let mut refs = ArenaRefs::for_variant(variant);
+            if self.pending_reserve > 0 {
+                refs.reserve(self.pending_reserve);
+            }
+            refs.push(&key, body_off, len);
+            self.state = Some(AccState { first_key: key, variant, refs });
+        }
+        Ok(())
+    }
+
+    /// Sort the refs accumulated for the current run and drain them into an
+    /// arena-backed [`TemplateMemChunk`] (zero body copies). The chosen variant +
+    /// baseline are RETAINED for subsequent runs (spills), matching the owned
+    /// sorter. Empty if nothing was pushed.
+    ///
+    /// Featherweight seal: each arm emits the variant-matching narrow
+    /// [`TemplateMemChunk`] lane using the key already resident in the ref — no
+    /// per-record re-extraction and no body access — so the downstream
+    /// merge/spill ride the narrow key lane chosen for this run.
+    ///
+    /// # `sort_threads` is per-sort, not per-call
+    ///
+    /// The signature takes it per call, which reads as though each call sizes its
+    /// own execution. It does not: the value builds the shared bounded pool on
+    /// the FIRST seal across the whole worker fan-out, and every later call —
+    /// this accumulator's next run, or another worker copy — runs on that pool at
+    /// its original width, silently ignoring a different value. Pass the same
+    /// number every time; see `sort_pool`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the bounded sort rayon pool cannot be built (an infrastructure
+    /// failure, e.g. the OS refuses the `sort_threads` worker threads).
+    #[must_use]
+    pub fn seal(
+        &mut self,
+        arena: Arc<PooledSegmentedBuf>,
+        sort_threads: usize,
+    ) -> TemplateMemChunk {
+        // Drain this run's refs, leaving a fresh empty accumulator of the SAME
+        // variant so the next run re-uses the once-chosen variant + baseline.
+        // (Scoped so the `self.state` borrow ends before we touch `sort_pool`.)
+        let refs = {
+            let Some(state) = self.state.as_mut() else {
+                return TemplateMemChunk::K40(InMemoryChunk::default());
+            };
+            std::mem::replace(&mut state.refs, ArenaRefs::for_variant(state.variant))
+        };
+        let pool = self.bounded_sort_pool(sort_threads);
+        // Featherweight seal: each arm produces the variant-matching narrow chunk
+        // (the key is already in the ref — no re-extraction, no body access), and
+        // tags it with the chosen variant so the downstream merge/spill ride the
+        // narrow lane. The variant is global, so every run's chunk shares one arm.
+        pool.install(move || match refs {
+            ArenaRefs::K24(r) => {
+                TemplateMemChunk::K24(template_chunk_from_arena_refs(arena, r, sort_threads))
+            }
+            ArenaRefs::Cb32(r) => {
+                TemplateMemChunk::Cb32(template_chunk_from_arena_refs(arena, r, sort_threads))
+            }
+            ArenaRefs::Tert32(r) => {
+                TemplateMemChunk::Tert32(template_chunk_from_arena_refs(arena, r, sort_threads))
+            }
+            ArenaRefs::K40(r) => {
+                TemplateMemChunk::K40(template_chunk_from_arena_refs(arena, r, sort_threads))
+            }
+        })
+    }
+
+    /// The shared bounded pool, built on first use at `sort_threads` threads.
+    ///
+    /// Running the radix + gather inside `pool.install` bounds BOTH to
+    /// `sort_threads` (via the pool's `current_num_threads`), so they do not
+    /// oversubscribe the pipeline's worker pool on a spill. Built once for the
+    /// whole fan-out — see the `sort_pool` field.
+    ///
+    /// **First call wins.** `get_or_init` builds the pool once, so a later call
+    /// with a different `sort_threads` silently gets the existing pool at the
+    /// original width. That is deliberate — one pool for the fan-out is the whole
+    /// point — but it means `sort_threads` is a property of the *sort*, not of an
+    /// individual call.
+    fn bounded_sort_pool(&self, sort_threads: usize) -> &rayon::ThreadPool {
+        self.sort_pool.get_or_init(|| {
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(sort_threads.max(1))
+                .thread_name(|i| format!("tmpl-sort-{i}"))
+                .build()
+                .expect("build bounded template-sort rayon pool")
+        })
+    }
+
+    /// The shared bounded pool, for tests that assert copies share one (the
+    /// sharing is otherwise unobservable — `seal` returns early before touching
+    /// the pool when the accumulator was never provisioned).
+    #[cfg(test)]
+    pub fn sort_pool_for_test(&mut self, sort_threads: usize) -> &rayon::ThreadPool {
+        self.bounded_sort_pool(sort_threads)
+    }
+
+    /// A worker copy: same configuration and provisioning, empty refs.
+    ///
+    /// **Provisioning is per-sort, not per-worker, and this carries it across.**
+    /// The chosen lane variant and the dropped-lane baseline (`first_key`) are
+    /// selected once from the first record and must then be identical for every
+    /// worker in the sort. Resetting them here instead would let each `Auto`
+    /// worker select a lane from *its own* first record, so one sort could emit
+    /// chunks of two different key widths; would give each worker a different
+    /// baseline, so a lane constant within every worker but varying across them
+    /// would pass `verify_dropped_lanes`; and would seal a worker that received
+    /// no records as [`TemplateMemChunk::K40`] no matter what the others chose.
+    ///
+    /// The refs are NOT carried — each worker accumulates its own — so a copy
+    /// starts empty but already knows which lane it is filling.
+    ///
+    /// # Preconditions
+    ///
+    /// Call this only **after** the parent has been provisioned (i.e. after its
+    /// first [`push`](Self::push)). Cloning a worker from an unprovisioned
+    /// parent yields `state: None`, and that worker will provision itself
+    /// independently — the exact divergence above. There is no production
+    /// caller yet; the pipeline step that fans workers out arrives with
+    /// `fgumi-pipeline-io`, and it owns honouring this.
+    #[must_use]
+    pub fn fresh(&self) -> Self {
+        Self {
+            lib_lookup: self.lib_lookup.clone(),
+            cell_tag: self.cell_tag,
+            cb_hasher: self.cb_hasher.clone(),
+            key_types: self.key_types,
+            header_library_varies: self.header_library_varies,
+            // Carry variant + baseline, not refs: same lane, own accumulation.
+            state: self.state.as_ref().map(|s| AccState {
+                first_key: s.first_key,
+                variant: s.variant,
+                refs: ArenaRefs::for_variant(s.variant),
+            }),
+            pending_reserve: 0,
+            // Share the holder, not a new one: see the field's doc.
+            sort_pool: Arc::clone(&self.sort_pool),
+        }
+    }
+}

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -575,6 +575,34 @@ pub(crate) struct Phase2Reader {
 /// file. The locks here are deliberately fine-grained so different workers can
 /// be reading, decompressing, and the main thread can be popping records all
 /// concurrently as long as they touch different sub-states.
+///
+/// # Two Phase-2 merge implementations (production vs. the retained oracle)
+///
+/// **In this tree THIS pool path is the production sort.** `fgumi sort` and
+/// `fgumi merge` both construct a `RawExternalSorter`, so every real sort runs
+/// through here. The source branch's note said the opposite — that the buffer
+/// chain over `merge_slots.rs` had taken over and this path was reduced to a
+/// library entry point and parity oracle — but that end state needs the
+/// typed-step `SortMerge` consumer, which lands with `fgumi-pipeline-io` in a
+/// later phase. Read the paragraph below as describing why the two Phase-2
+/// implementations differ, not as a claim about which one runs.
+///
+/// The two implementations differ deliberately, and that difference is
+/// load-bearing for the oracle. This path keeps the `raw_blocks` FIFO,
+/// `decomp_in_flight`, the reorder buffer, and the gap-filler because its merge
+/// consumer is a parked OS thread (`external.rs::advance_to_next_block`, immune
+/// to the v4 framework-Skip deadlock) and its single-*reader* /
+/// multi-*decompressor* topology means completion order ≠ pop order. The
+/// slimmer `merge_slots.rs` needs only the *inline* subset of that machinery:
+/// its `decompressed` queue is a plain `VecDeque` with no gap-filler, because
+/// its inline consumer reads AND decompresses in one op so blocks decompress
+/// strictly in read order. It still declares `in_flight`, `reader_eof`, and
+/// `reorder` — inert on that inline path, live on its block-parallel one — so
+/// the difference is the gap-filler and the FIFO discipline, not the fields.
+/// Do NOT delete the gap-filler or the reorder buffer
+/// here to "match" `merge_slots` — it would reintroduce a real deadlock and/or
+/// out-of-order merge output. (History: commits `9d6d7e9` / `9c39dea`, PRs
+/// #389 / #395, `docs/design/sort-phase2-unification-deferral.md`.)
 pub(crate) struct Phase2FileState {
     /// Disk reader. Held only while popping bytes from disk.
     pub(crate) reader: Mutex<Phase2Reader>,

--- a/crates/fgumi-sort/src/zspill_stream.rs
+++ b/crates/fgumi-sort/src/zspill_stream.rs
@@ -8,7 +8,7 @@
 //!
 //! This module presents a [`Read`]-compatible view over the decompressed
 //! content of such a file, so the legacy
-//! [`GenericKeyedChunkReader`](crate::external::GenericKeyedChunkReader) record
+//! `GenericKeyedChunkReader` record
 //! parser can consume zstd-compressed spills without further changes. The
 //! worker-pool reader takes the faster, per-frame parallel-decompress path;
 //! this stream reader is the fallback used by the consolidation merge and the

--- a/docs/design/sort-phase2-unification-deferral.md
+++ b/docs/design/sort-phase2-unification-deferral.md
@@ -12,17 +12,22 @@ design:
   (`advance_to_next_block`). Keeps `--write-index`, `--verify`, zstd spill.
 - **Streaming / runall** (`crates/fgumi-sort/src/merge_slots.rs`,
   `external.rs::MergeDriver`) — drives the fused in-pipeline `runall` sort. A
-  cooperative `try_run` state machine that yields (`Stalled`/`WouldBlock`)
+  cooperative `MergeDriverDyn::try_step` state machine that yields
+  (`Stalled`/`WouldBlock`)
   instead of blocking, so it composes with the typed-step pipeline framework.
 
-> **Which of these exists in this tree.** Only the pool driver runs here. The
-> streaming driver is arriving in phases: `merge_slots.rs::SortMergeSlot` is its
-> first piece and has **no callers**, and `external.rs::MergeDriver` does not
-> exist on this branch at all. So read the streaming bullet — and every claim
-> below about the cooperative consumer, including the deadlock analysis — as
-> describing the end state this landing builds toward, not code you can run
-> today. In particular, none of it is a statement about `SortMergeSlot`, which
-> is a passive handoff slot and not a driver.
+> **Which of these runs in this tree.** Only the pool driver. Both halves of the
+> streaming driver now exist — `merge_slots.rs::SortMergeSlot` and
+> `external.rs::MergeDriver`, the latter arriving with the arena engine — but
+> nothing in production drives them: `MergeDriver::from_slots` and
+> `open_spill_slot` are reachable only from tests until the typed-step
+> `SortMerge` consumer lands with `fgumi-pipeline-io`. `fgumi sort` and
+> `fgumi merge` both go through `RawExternalSorter`, i.e. the pool path.
+>
+> So read the streaming bullet — and every claim below about the cooperative
+> consumer, including the deadlock analysis — as describing the end state this
+> landing builds toward. The analysis is about that consumer, not about
+> `SortMergeSlot`, which is a passive handoff slot rather than a driver.
 
 Unifying these onto a single driver is a deliberate **future** refactor with its
 own design + bench gate + deadlock re-analysis. It is intentionally NOT done in
@@ -71,7 +76,7 @@ consumer, and no one has shown the pool path deadlock-free in general.
 3. `--verify` ported (today a separate read-and-check path, designed to stay
    legacy).
 4. A consumer for the file-to-file case that is not exposed to the v4 drain
-   deadlock — the streaming consumer is the cooperative `try_run` model that hit
+   deadlock — the streaming consumer is the cooperative `try_step` model that hit
    it in production. "Not exposed to *this* deadlock" is the bar; general
    deadlock freedom is not something either driver has been shown to have.
 


### PR DESCRIPTION
> **Stacked on #719.** Base is `nh/runall-06-arena-leaf`; review that one first. GitHub will retarget this to `main-runall` when #719 merges.

The engine itself — the last and largest slice of P3. Six modules plus the `external.rs`, `worker_pool.rs`, `inline.rs`, and `keys.rs` rewrites that carry them. Everything landed so far (`SortMergeSlot` + its loom model in #718, the arena pool and block-offset planner in #719) came out of the same upstream commit and was split off ahead of this one; this is its remainder.

`chunk_sorter.rs`, `ref_sort.rs`, `template_arena.rs`, `spill_block.rs`, `spill_block_reader.rs`, `sync_spill_writer.rs`. These could not land separately: the first three form a dependency cycle among themselves and all reach into the rewritten `external.rs`, the last three need `external.rs` **and** `worker_pool.rs`, and `external.rs` in turn depends on the new modules.

## This is a three-way merge, not a port

The source commit predates **30 commits** of `fgumi-sort` work on main — 18 on `external.rs` alone. Wholesale copying would have silently reverted them. The places where both sides moved:

**`keys.rs` — two independent improvements to one struct.** Upstream gave the key an inline `SmallVec` name buffer; main independently added a `pos: u32` ingest position to make name+flags a *total* order (#621, which is what lets the chunk sort be unstable). Both are kept — the key is now `NameBuf` + flags + pos. Taking either side alone drops an optimization or reintroduces nondeterminism.

`position_fits_in_existing_key_padding` asserted 32 bytes, reasoning that a `Vec<u8>` is 24. Measured: `NameBuf` is 40 and the key is 48. The test's *claim* — that `pos` is free — still holds, because name+flags alone already round up to 48. So the expectation and its derivation were corrected and the padding is now pinned directly, rather than the assertion being weakened to fit.

**`keys.rs::header_ss_tag` is byte-identical to main's** (H1), so the `@HD SS` spelling fixes (#514, #567) survive. Verified by diffing the function against the base, not by inspection.

**`inline.rs`** set `RecordBuffer::max_sort_key`, a field main removed when it began deriving the radix bound inside the first counting pass (#622). Both sides had optimized the same thing; main's needs no stored field, so the reset is dropped.

**`lib.rs` re-exports are a union.** The engine's export list drops `format_thread_counts` (main-only, from #691 — and it lives in the very `external.rs` being rewritten), `SortMergeReader`, and the `reader.rs` entry points including `open_raw_bam_record_reader_with_header`. The root crate imports those. Establishing this by *building* rather than trusting a grep list is what the tracker asks for, and it is what caught them.

**`worker_pool.rs::set_main_thread` is dropped rather than ported.** It re-targets the unpark handle for the streaming path, requires an `ArcSwap` field type from an upstream change main never took, and has no callers anywhere — its own doc says its production caller was retired. Porting it would mean adding a dependency to support dead code for a path that does not exist here.

**`smallvec` is crate-local, not workspace-inherited** — `keys.rs` is its only user, and the root manifest reserves `[workspace.dependencies]` for crates shared by two or more members.

## Doc claims that were true when written and are not now

- `merge_slots.rs` said `SortMergeSlot` has **no callers**. It has two now — `open_spill_slot` and `MergeDriver::from_slots` — both reachable only from tests.
- `worker_pool.rs` carried the source branch's claim that the pool path *"no longer drives any production sort"*. In this tree it is the only thing that does: `fgumi sort` and `fgumi merge` both construct a `RawExternalSorter`. The end state it describes needs the typed-step `SortMerge` consumer, which lands with `fgumi-pipeline-io`.
- `docs/design/sort-phase2-unification-deferral.md` said `external.rs::MergeDriver` does not exist on this branch. It does now.

## Unsafe surface (D2)

CLAUDE.md gains the `ref_sort.rs` and `segmented_buf.rs` allowlist entries, plus a note reconciling the counts: a raw grep finds **22** `#[allow(unsafe_code)]` sites against the **7 production** sites the allowlist names, and the difference is entirely tests exercising already-approved APIs. Anyone auditing by grep would otherwise conclude the allowlist is 15 entries short.

Separately, CLAUDE.md's `inline.rs` entry describes three unsafe regions that are no longer there (they moved to `radix.rs`). That staleness predates this PR — it is already true on the base — so it is flagged rather than fixed here.

## Verification

`ci-fmt`, `ci-lint`, `ci-doc`, `ci-tag-literals` clean · **7,903 tests pass** · 5/5 loom models pass · `--no-default-features` and `--all-features` both build.

Worth noting: the source branch **does not build its own workspace** at this commit — its `fgumi-pipeline-io` imports four `*SortStream` symbols the engine removed, and the consumer updates its commit message points to were never merged. This is the first tree in which the arena engine compiles against its consumers.

## Next

This is the gate. Once it is reviewed, the P3 benchmark (main vs `main-runall`, both arms, sort only) is what decides whether the engine is kept.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: sort output changes, pinned by stable sorting, ingest order, and offset tie-breaking; grouping, consensus, corrected UMIs, and metrics: none; unsafe: yes, with the approved `ref_sort.rs` cast documented in `CLAUDE.md`; memory bounds, arena reuse, decompression scratch limits, and thread/backpressure policies change.

Fix: use unified arena-backed sort, spill, and merge paths with documented limits and updated unsafe guidance.

- Added coordinate and template arena sorters with stable parallel sorting, zero-copy draining, arena reuse, narrowing validation, and spill support.
- Added BGZF/Zstd spill framing, compression, decompression, synchronous writing, and streaming merge APIs.
- Exposed sort modules, chunk builders, merge drivers, spill codecs, and temporary-directory utilities.
- Changed queryname keys to inline `SmallVec` storage with heap fallback and explicit null termination.
- Added diagnostics, benchmarks, lifecycle and ordering tests, codec round trips, and documentation for production and test-only merge paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->