### PR TITLE
ci(publish): gate the publish list per-PR and skip on exact version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -115,6 +115,30 @@ jobs:
       - name: Audit dependencies for known vulnerabilities
         run: cargo audit
 
+  # The publish ORDER check, run per-PR. `publish.yml` runs it too, but that
+  # workflow only triggers on push to `main` — so before this job existed, a
+  # crate missing from the publish list, or one listed before its dependency,
+  # was discovered mid-publish, on main, after earlier crates had already gone
+  # to crates.io. A published version cannot be deleted, only yanked, so the
+  # failure is not recoverable by re-running. Every check here is pure
+  # `cargo metadata` plus list arithmetic — no registry access, no secrets, a
+  # couple of seconds — so there is no reason for it to wait for release day.
+  #
+  # This is distinct from `publish-dry-run` below, which validates each crate's
+  # MANIFEST (declared versions on path deps, include paths, feature refs). That
+  # says nothing about whether the publish list is complete or correctly ordered.
+  publish-order:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Validate the crates.io publish list is complete and correctly ordered
+        run: ./scripts/publish-crates.sh --check
+
   publish-dry-run:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,130 +62,101 @@ jobs:
         run: |
           set -euo pipefail
 
-          # All workspace crates share a single version (lockstep).
-          # Check the root crate to decide if publishing is needed.
+          # All workspace crates share a single version (lockstep), so the root
+          # crate's version is the target version for every crate. Whether there
+          # is anything to publish is decided per crate in the loop below, not
+          # here: a crate added to the workspace after the current version was
+          # released is absent from crates.io even though the root crate is
+          # already at that version, so an early exit keyed on `fgumi` alone
+          # would silently skip it forever.
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r \
             '.packages[] | select(.name == "fgumi") | .version')
 
-          PUBLISHED_VERSION=$(curl -sSf \
-            -H "User-Agent: fgumi-ci (https://github.com/fulcrumgenomics/fgumi)" \
-            "https://crates.io/api/v1/crates/fgumi" | jq -r \
-            '.crate.max_version // "0.0.0"')
-
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Target version for all workspace crates: v$VERSION"
 
-          if [ "$VERSION" = "$PUBLISHED_VERSION" ]; then
-            echo "All crates already at v$VERSION -- nothing to publish"
-            echo "published=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+          # The publish list and its completeness/ordering checks live in
+          # scripts/publish-crates.sh so CI can run them on every PR (see the
+          # `publish-order` job in check.yml). Re-run here too: this is the last
+          # point before an irreversible upload.
+          ./scripts/publish-crates.sh --check
+          mapfile -t CRATES < <(./scripts/publish-crates.sh --list)
 
-          echo "Publishing all workspace crates (v$VERSION)..."
-
-          # Workspace crates in topological (dependency) order.
-          # Leaf crates first, root crate last.  Update this list when
-          # adding new workspace crates or changing inter-crate dependencies.
-          CRATES=(
-            fgumi-dna
-            fgumi-bgzf
-            fgumi-simd-fastq
-            fgumi-tag
-            fgumi-raw-bam
-            fgumi-bam-io
-            fgumi-umi
-            fgumi-sam
-            fgumi-metrics
-            fgumi-sort
-            fgumi-consensus
-            fgumi
-          )
-
-          # Verify every publishable workspace crate is in the publish list.
-          # Crates marked `publish = false` (serialized as `publish: []` by
-          # cargo metadata) are excluded -- e.g. internal xtask tooling.
-          WORKSPACE_CRATES=$(cargo metadata --no-deps --format-version 1 \
-            | jq -r '.packages[] | select(.publish != []) | .name' | sort)
-          LISTED_CRATES=$(printf '%s\n' "${CRATES[@]}" | sort)
-          MISSING=$(comm -23 <(echo "$WORKSPACE_CRATES") <(echo "$LISTED_CRATES"))
-          if [ -n "$MISSING" ]; then
-            echo "ERROR: workspace crates missing from CRATES publish list:"
-            echo "$MISSING"
-            echo "Add them to the CRATES array in the correct dependency order."
+          # `mapfile` reads a process substitution, and bash does not propagate
+          # its exit status -- a failing `--list` leaves CRATES empty, `set -e`
+          # sees nothing wrong, the loop below never runs, and the step reports
+          # "nothing to publish" and SUCCEEDS while the release step still tags
+          # the version. An empty list is never legitimate here, so fail loudly.
+          if [ "${#CRATES[@]}" -eq 0 ]; then
+            echo "ERROR: publish-crates.sh --list produced no crates."
+            echo "Refusing to continue: an empty publish list would silently"
+            echo "release nothing while reporting success."
             exit 1
           fi
 
-          EXTRA=$(comm -13 <(echo "$WORKSPACE_CRATES") <(echo "$LISTED_CRATES"))
-          if [ -n "$EXTRA" ]; then
-            echo "ERROR: CRATES publish list contains entries not in workspace:"
-            echo "$EXTRA"
-            echo "Remove or rename stale entries before publishing."
-            exit 1
-          fi
-
-          # Verify the CRATES list is in valid topological order: every
-          # workspace dependency of a crate must appear EARLIER in the list.
-          # `cargo publish` resolves each crate's dependencies against the
-          # crates.io index, so a dependency published later does not yet
-          # exist when its dependent is published.  Catching this here -- as a
-          # pure list check, before any upload -- prevents a mid-publish
-          # failure that would leave a partially released version on crates.io
-          # (published versions cannot be deleted, only yanked).
-          META=$(cargo metadata --no-deps --format-version 1)
-          WS_JSON=$(echo "$META" | jq '[.packages[] | select(.publish != []) | .name]')
-          index_of() {
-            local target="$1" i
-            for i in "${!CRATES[@]}"; do
-              if [ "${CRATES[$i]}" = "$target" ]; then echo "$i"; return; fi
-            done
-            echo "-1"
-          }
-          ORDER_ERRORS=""
-          for i in "${!CRATES[@]}"; do
-            crate="${CRATES[$i]}"
-            # Dev-dependencies with no version requirement (path-only, `req == "*"`)
-            # are stripped from the manifest cargo uploads, so they impose no
-            # ordering constraint.  This is what makes the root crate's self
-            # dev-dependency -- `fgumi = { path = ".", features = ["test-utils"] }`,
-            # the only way to enable `test-utils` for the integration test targets
-            # -- publishable: without this filter it reads as "fgumi depends on
-            # fgumi", which no ordering can satisfy.  Dev-dependencies that do
-            # carry a version (e.g. `fgumi-raw-bam = { workspace = true, ... }`)
-            # survive packaging and must still be published first.
-            DEPS=$(echo "$META" | jq -r --arg c "$crate" --argjson ws "$WS_JSON" '
-              .packages[] | select(.name == $c) | .dependencies[]
-              | select(.kind != "dev" or .req != "*") | .name
-              | select(. as $d | $ws | index($d))' | sort -u)
-            for dep in $DEPS; do
-              j=$(index_of "$dep")
-              if [ "$j" -ge "$i" ]; then
-                ORDER_ERRORS="${ORDER_ERRORS}  ${crate} depends on ${dep}, which must be listed earlier\n"
-              fi
-            done
-          done
-          if [ -n "$ORDER_ERRORS" ]; then
-            echo "ERROR: CRATES publish list is not in valid dependency order:"
-            printf "%b" "$ORDER_ERRORS"
-            echo "Reorder the CRATES array so every dependency precedes its dependents."
-            exit 1
-          fi
-
+          # Ask whether THIS EXACT version exists, not whether it is the crate's
+          # highest. Comparing against `max_version` only skips correctly when
+          # the target is the newest release; if a crate's max_version is HIGHER
+          # than the target — re-running an older tag, or a crate that drifted
+          # out of lockstep — the skip does not fire, `cargo publish` fails with
+          # "already uploaded", and because this loop runs under `set -e` every
+          # crate after it is never published. That is the partial-release this
+          # workflow exists to avoid, and a published version cannot be deleted,
+          # only yanked. A 404 (never-published crate, e.g. one added since the
+          # last release) correctly means "publish it".
+          PUBLISHED_ANY=false
           for crate in "${CRATES[@]}"; do
-            CRATE_MAX_VERSION=$(curl -sS \
+            # Retry the probe: it is an idempotent read, and both failure modes
+            # it guards are usually transient. They fail differently, and
+            # neither used to be survivable: a transport error (DNS, TLS, reset,
+            # timeout) exits curl non-zero and killed the step outright under
+            # `set -e`, while a 429/5xx exits curl ZERO and fell to the `*)` arm
+            # below, which hard-fails on an ambiguous status. Either one landing
+            # after earlier crates uploaded produces exactly the partial release
+            # this loop exists to prevent, so let a blip retry instead. curl
+            # retries 429/500/502/503/504 natively; `--retry-all-errors` extends
+            # that to the transport errors. 200 and 404 are successful transfers
+            # to curl and are never retried, so the skip and publish paths pay
+            # no added latency. Timeouts bound a hung connection.
+            CURL_RC=0
+            STATUS=$(curl -sS -o /dev/null -w '%{http_code}' \
+              --connect-timeout 10 --max-time 30 \
+              --retry 5 --retry-delay 2 --retry-all-errors \
               -H "User-Agent: fgumi-ci (https://github.com/fulcrumgenomics/fgumi)" \
-              "https://crates.io/api/v1/crates/${crate}" | jq -r \
-              '.crate.max_version // "0.0.0"')
+              "https://crates.io/api/v1/crates/${crate}/${VERSION}") || CURL_RC=$?
 
-            if [ "$CRATE_MAX_VERSION" = "$VERSION" ]; then
-              echo "$crate v$VERSION already exists on crates.io -- skipping"
-              continue
+            if [ "$CURL_RC" -ne 0 ]; then
+              echo "ERROR: querying crates.io for $crate v$VERSION failed after"
+              echo "retries (curl exit $CURL_RC). Refusing to publish without a"
+              echo "definitive answer: publishing blind could double-publish, and"
+              echo "a published version cannot be deleted, only yanked."
+              exit 1
             fi
+
+            case "$STATUS" in
+              200)
+                echo "$crate v$VERSION already exists on crates.io -- skipping"
+                continue
+                ;;
+              404) ;;  # not published at this version -- publish it below
+              *)
+                echo "ERROR: unexpected HTTP $STATUS querying crates.io for $crate v$VERSION."
+                echo "Refusing to publish on an ambiguous answer: treating it as"
+                echo "not-published could double-publish, and as published could"
+                echo "silently skip a crate."
+                exit 1
+                ;;
+            esac
 
             echo "Publishing $crate v$VERSION..."
             cargo publish -p "$crate"
             echo "✓ Published $crate v$VERSION"
+            PUBLISHED_ANY=true
           done
 
-          echo "published=true" >> "$GITHUB_OUTPUT"
+          if [ "$PUBLISHED_ANY" = "false" ]; then
+            echo "All crates already at v$VERSION -- nothing to publish"
+          fi
 
       - name: Create GitHub release
         if: steps.publish.outputs.version != ''

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Single source of truth for the crates.io publish order, plus the checks that
+# keep it honest.
+#
+# This lives in a script rather than inline in `publish.yml` for one reason: the
+# checks are only useful *before* a release. Inline, they ran exclusively in the
+# publish job, which triggers on push to `main` — so a mis-ordered or incomplete
+# list was discovered mid-publish, on main, after some crates had already gone
+# out. `cargo publish` cannot be undone; a version can only be yanked. Every
+# check here is a pure metadata/list check needing no registry access, so CI can
+# run it on every PR and fail the PR instead of the release.
+#
+# Usage:
+#   publish-crates.sh --list    print the crates in publish order, one per line
+#   publish-crates.sh --check   validate the list against the workspace; exit 1 on error
+set -euo pipefail
+
+# Workspace crates in topological (dependency) order: leaf crates first, root
+# crate last. Update when adding a workspace crate or changing inter-crate
+# dependencies — `--check` fails the build if you forget.
+CRATES=(
+  fgumi-dna
+  fgumi-bgzf
+  fgumi-simd-fastq
+  fgumi-tag
+  fgumi-raw-bam
+  fgumi-bam-io
+  fgumi-umi
+  fgumi-sam
+  fgumi-metrics
+  fgumi-sort
+  fgumi-consensus
+  fgumi
+)
+
+list_crates() {
+  printf '%s\n' "${CRATES[@]}"
+}
+
+check_crates() {
+  local meta ws_json workspace_crates listed_crates missing extra order_errors
+  meta=$(cargo metadata --no-deps --format-version 1)
+
+  # Crates marked `publish = false` (serialized as `publish: []`) are excluded —
+  # e.g. internal xtask tooling.
+  workspace_crates=$(echo "$meta" | jq -r '.packages[] | select(.publish != []) | .name' | sort)
+  listed_crates=$(printf '%s\n' "${CRATES[@]}" | sort)
+
+  missing=$(comm -23 <(echo "$workspace_crates") <(echo "$listed_crates"))
+  if [ -n "$missing" ]; then
+    echo "ERROR: workspace crates missing from the publish list:"
+    echo "$missing"
+    echo "Add them to CRATES in ${BASH_SOURCE[0]} in the correct dependency order."
+    return 1
+  fi
+
+  extra=$(comm -13 <(echo "$workspace_crates") <(echo "$listed_crates"))
+  if [ -n "$extra" ]; then
+    echo "ERROR: the publish list contains entries not in the workspace:"
+    echo "$extra"
+    echo "Remove or rename stale entries before publishing."
+    return 1
+  fi
+
+  # Every workspace dependency of a crate must appear EARLIER in the list.
+  # `cargo publish` resolves each crate's dependencies against the crates.io
+  # index, so a dependency published later does not yet exist when its dependent
+  # is published — which fails mid-loop and leaves a partial release.
+  ws_json=$(echo "$meta" | jq '[.packages[] | select(.publish != []) | .name]')
+  index_of() {
+    local target="$1" i
+    for i in "${!CRATES[@]}"; do
+      if [ "${CRATES[$i]}" = "$target" ]; then echo "$i"; return; fi
+    done
+    echo "-1"
+  }
+  order_errors=""
+  for i in "${!CRATES[@]}"; do
+    local crate deps j
+    crate="${CRATES[$i]}"
+    # Dev-dependencies with no version requirement (path-only, `req == "*"`) are
+    # stripped from the manifest cargo uploads, so they impose no ordering
+    # constraint. This is what makes the root crate's self dev-dependency —
+    # `fgumi = { path = ".", features = ["test-utils"] }`, the only way to enable
+    # `test-utils` for the integration test targets — publishable: without this
+    # filter it reads as "fgumi depends on fgumi", which no ordering satisfies.
+    # Dev-dependencies that DO carry a version survive packaging and must still
+    # be published first.
+    deps=$(echo "$meta" | jq -r --arg c "$crate" --argjson ws "$ws_json" '
+      .packages[] | select(.name == $c) | .dependencies[]
+      | select(.kind != "dev" or .req != "*") | .name
+      | select(. as $d | $ws | index($d))' | sort -u)
+    for dep in $deps; do
+      j=$(index_of "$dep")
+      if [ "$j" -ge "$i" ]; then
+        order_errors="${order_errors}  ${crate} depends on ${dep}, which must be listed earlier\n"
+      fi
+    done
+  done
+  if [ -n "$order_errors" ]; then
+    echo "ERROR: the publish list is not in valid dependency order:"
+    printf "%b" "$order_errors"
+    echo "Reorder CRATES so every dependency precedes its dependents."
+    return 1
+  fi
+
+  echo "publish list OK: ${#CRATES[@]} crates, complete and in dependency order"
+}
+
+usage() {
+  echo "usage: $(basename "$0") --list|--check"
+}
+
+case "${1:-}" in
+  --list) list_crates ;;
+  --check) check_crates ;;
+  -h | --help) usage ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Two failure modes in the release path. Both surface only during an irreversible operation: `cargo publish` cannot be undone — a version can be yanked but never deleted — and the loop runs under `set -e`, so anything that fails mid-way leaves some crates released at the new version and the rest not.

### The publish-list checks never ran until release day

`publish.yml` triggers only on `push: branches: [main]`, and the completeness/ordering checks lived inside its publish job. So a crate missing from `CRATES`, or one listed before its dependency, was discovered **mid-publish, on main, after earlier crates had already gone to crates.io**.

Every one of those checks is pure `cargo metadata` plus list arithmetic — no registry access, no secrets, a couple of seconds. There was never a reason to defer them. They move to `scripts/publish-crates.sh`, which `publish.yml` still calls (it is the last point before upload) and which the new `publish-order` job in `check.yml` runs on every PR.

This is deliberately **separate from the existing `publish-dry-run` job**, which validates each crate's *manifest* (declared versions on path deps, `include` paths, feature references). That says nothing about whether the publish list is complete or correctly ordered — the two catch disjoint failures.

### The skip compared `max_version`, not the exact version

```bash
CRATE_MAX_VERSION=$(curl … | jq -r '.crate.max_version // "0.0.0"')
if [ "$CRATE_MAX_VERSION" = "$VERSION" ]; then … continue; fi
```

Correct only when the target *is* the newest release. If a crate's `max_version` is higher — re-running an older tag, or a crate that drifted out of lockstep — the skip does not fire, `cargo publish` fails with "already uploaded", and every crate after it is never published.

It now asks whether that exact version exists (`/api/v1/crates/{crate}/{version}`): **200 skips, 404 publishes**. A crate that has never been published — one added since the last release — 404s and is correctly published, rather than being compared against a `"0.0.0"` fallback.

Any other status is a hard failure rather than a guess. Treating an ambiguous answer as not-published risks a double publish; treating it as published silently skips a crate. Neither is recoverable, so the workflow stops.

### Why this matters now

The `feat-runall` landing adds six workspace crates. Two of the three hazards the release plan tracks are about exactly this list, and the third — resumability — is what the exact-version check buys: a re-run after a partial failure now completes instead of re-failing on the first already-published crate.

### Verification

- `publish-crates.sh --list` is **byte-identical** to the array it replaces (verified by diffing against `origin/main`'s inline `CRATES`) — this is a pure refactor of the list, with no crate added or reordered.
- Both checks confirmed to actually fail: removing a crate reports it missing; moving one after its dependent reports `fgumi-raw-bam depends on fgumi-dna, which must be listed earlier`.
- `shellcheck` clean; both workflow files parse as valid YAML.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: command output changes through publish decisions, pinned by exact-version crates.io responses; `unsafe`: none, CLAUDE.md allowlist unchanged; memory, queue, and backpressure policy: none.

Fix: Move publish-list completeness and dependency-order checks into `scripts/publish-crates.sh`.

- Run `publish-order` validation on every PR.
- Retain validation before publishing.
- Publish only when the exact target version returns HTTP 404.
- Skip publishing when the exact target version returns HTTP 200.
- Fail on other registry responses.
- Preserve the existing publish order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->