### PR TITLE
fix(consensus)!: make consensus read downsampling deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ All notable changes to this project will be documented in this file.
   old selection was the bug. Runs that do not set a cap are unaffected and remain
   byte-identical. Ports [fgbio#1166](https://github.com/fulcrumgenomics/fgbio/pull/1166).
 
+### Bug Fixes
+
+- `duplex --max-reads-per-strand 0` is now rejected at startup. It previously exited 0 having
+  written an empty BAM, because a cap of zero empties every strand. `simplex` and `codec`
+  already validated their equivalents.
+
 ### Features
 
 - Boolean command-line flags now additionally accept `on`, `off`, `1`, and `0`, alongside the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** consensus downsampling now selects which reads to retain by a hash of the read
+  name rather than by shuffling a seeded random number generator. This affects `simplex
+  --max-reads`, `duplex --max-reads-per-strand`, and `codec --max-reads`.
+
+  The retained subset is now a pure function of the tag family, so it is reproducible across
+  runs, thread counts, and execution modes. Mates share a read name and therefore a rank, so
+  the two ends of a template rank together; `codec --max-reads` selects whole pairs and so
+  always keeps or drops both ends, while `simplex --max-reads` (which caps the whole family by
+  record count, fgumi#723) and `duplex --max-reads-per-strand` (which caps each end
+  independently) can retain one end of a template without the other. Previously the surviving
+  reads depended on how many families the
+  consensus caller had already processed, so `--threads N` and the no-`--threads` path could
+  produce different consensus reads from the same input — measured at 566 of 77,804 records
+  (0.73%) on one library at `--max-reads-per-strand 2`.
+
+  **Which reads are retained differs from previous releases** for any run that sets a cap.
+  There is no way to fix the reproducibility bug while preserving the old selection, since the
+  old selection was the bug. Runs that do not set a cap are unaffected and remain
+  byte-identical. Ports [fgbio#1166](https://github.com/fulcrumgenomics/fgbio/pull/1166).
+
 ### Features
 
 - Boolean command-line flags now additionally accept `on`, `off`, `1`, and `0`, alongside the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,6 @@ dependencies = [
  "log",
  "noodles",
  "proptest",
- "rand 0.10.2",
  "rstest",
  "tempfile",
  "thiserror 2.0.19",

--- a/crates/fgumi-consensus/Cargo.toml
+++ b/crates/fgumi-consensus/Cargo.toml
@@ -14,7 +14,6 @@ approx = { workspace = true }
 bstr = { workspace = true }
 log = { workspace = true }
 noodles = { workspace = true, features = ["bam", "sam", "core"] }
-rand = { workspace = true }
 thiserror = { workspace = true }
 wide = { workspace = true }
 fgumi-dna = { workspace = true }

--- a/crates/fgumi-consensus/src/caller.rs
+++ b/crates/fgumi-consensus/src/caller.rs
@@ -633,11 +633,40 @@ pub fn make_prefix_from_header(header: &Header) -> String {
     }
 }
 
+/// Selects which of `ranks` survive a cap of `max_reads`, returning their indices in
+/// ascending (input) order.
+///
+/// The lowest-ranking entries are kept, where rank is the fgbio-compatible Murmur3 hash of
+/// the read name (see [`fgumi_raw_bam::hash::fgbio_read_name_rank`]). Ranks are compared as
+/// **signed** `i32`, matching fgbio's Scala `Int` — about half of all read names rank
+/// negative, so an unsigned comparison would silently reorder them. The selection sort is
+/// **stable**, matching Scala's `sortInPlaceBy`, so tied ranks resolve to input order.
+///
+/// The returned indices are re-sorted ascending after truncation so callers emit records in
+/// input order. That second sort orders *indices*, not ranks, and is independent of the
+/// selection above.
+///
+/// Callers pass ranks already stamped on their records rather than hashing here: Rust's
+/// `sort_by_key` may evaluate its key closure more than once per element, so hashing inside
+/// it would re-hash per comparison.
+pub(crate) fn select_lowest_ranking(ranks: &[i32], max_reads: usize) -> Vec<usize> {
+    let mut indices: Vec<usize> = (0..ranks.len()).collect();
+    if ranks.len() <= max_reads {
+        return indices;
+    }
+    indices.sort_by_key(|&i| ranks[i]);
+    indices.truncate(max_reads);
+    indices.sort_unstable();
+    indices
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use fgumi_metrics::rejection::RejectionReason as CentralReason;
+    use proptest::prelude::*;
     use rstest::rstest;
+    use std::collections::HashSet;
 
     /// The scalar depth-tag clamp mirrors fgbio's `Short` per-base ceiling: values at or
     /// below 32767 pass through; anything above (up to `u16::MAX`) saturates at 32767,
@@ -1441,5 +1470,47 @@ mod tests {
         map.insert(RejectionReason::TooManyNs, 3);
         assert_eq!(map[&RejectionReason::QualityTooLow], 5);
         assert_eq!(map[&RejectionReason::TooManyNs], 3);
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// Both ends of a template share a read name and therefore a rank, so a cap that lands
+        /// inside a tied group must keep the ends that arrived *first*. This is the property the
+        /// stable sort in [`select_lowest_ranking`] exists to provide.
+        ///
+        /// A property test rather than a fixed vector, because a fixed vector only diverges under
+        /// `sort_unstable_by_key` at particular lengths and caps — pdqsort is effectively stable
+        /// on short slices — so a single case can silently lose its power when the standard
+        /// library's sort implementation changes. Random families keep the tripwire live: roughly
+        /// one in six mate-paired inputs distinguishes stable from unstable selection.
+        #[test]
+        fn select_lowest_ranking_resolves_ties_by_arrival_order(
+            template_ranks in prop::collection::vec(any::<i32>(), 2..40),
+            cap_seed in any::<usize>(),
+        ) {
+            // Each template contributes two records (R1 then R2) that share one rank.
+            let ranks: Vec<i32> = template_ranks.iter().flat_map(|&r| [r, r]).collect();
+            let cap = cap_seed % (ranks.len() - 1) + 1;
+
+            let kept = select_lowest_ranking(&ranks, cap);
+            let keep: HashSet<usize> = kept.iter().copied().collect();
+
+            prop_assert_eq!(kept.len(), cap.min(ranks.len()));
+            prop_assert!(kept.windows(2).all(|w| w[0] < w[1]), "survivors must come back in input order");
+
+            // Within one rank value the retained records must be a prefix of that value's
+            // records in arrival order: never a later record while an earlier tied one was
+            // dropped. An unstable sort violates this; nothing else about the rule does.
+            for (i, rank_i) in ranks.iter().enumerate().filter(|(i, _)| keep.contains(i)) {
+                for (j, rank_j) in ranks.iter().enumerate().take(i) {
+                    prop_assert!(
+                        rank_j != rank_i || keep.contains(&j),
+                        "kept index {} but dropped earlier index {} tied at rank {}",
+                        i, j, rank_i
+                    );
+                }
+            }
+        }
     }
 }

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -76,7 +76,8 @@ use crate::base_builder::TieRule;
 use crate::caller::{
     ConsensusCaller, ConsensusCallingStats, ConsensusOutput,
     RejectionReason as CallerRejectionReason, clamp_combined_error_to_fgbio_short,
-    clamp_per_base_to_fgbio_short, consensus_read_name_too_long_context, write_consensus_read_name,
+    clamp_per_base_to_fgbio_short, consensus_read_name_too_long_context, select_lowest_ranking,
+    write_consensus_read_name,
 };
 use crate::phred::{MIN_PHRED, NO_CALL_BASE, NO_CALL_BASE_LOWER, PhredScore};
 use crate::simple_umi::consensus_umis;
@@ -86,13 +87,11 @@ use crate::vanilla_caller::{
 use crate::{IndexedSourceRead, SourceRead, select_most_common_alignment_group};
 use anyhow::{Context, Result};
 use fgumi_dna::dna::reverse_complement;
+use fgumi_raw_bam::hash::fgbio_read_name_rank;
 use fgumi_raw_bam::{
     self as bam_fields, RawRecord, RawRecordView, SamTag, UnmappedSamBuilder, flags,
 };
 use noodles::sam::alignment::record::data::field::Tag;
-use rand::SeedableRng;
-use rand::rngs::StdRng;
-use rand::seq::SliceRandom;
 use std::cmp::{max, min};
 use std::collections::HashMap;
 use thiserror::Error;
@@ -336,9 +335,6 @@ pub struct CodecConsensusCaller {
     /// Statistics tracker
     stats: CodecConsensusStats,
 
-    /// Random number generator for downsampling
-    rng: StdRng,
-
     /// Counter for consensus read naming
     consensus_counter: u64,
 
@@ -380,8 +376,6 @@ impl CodecConsensusCaller {
         read_group_id: String,
         options: CodecConsensusOptions,
     ) -> Self {
-        let rng = StdRng::seed_from_u64(42);
-
         // Create VanillaUmiConsensusCaller for single-strand consensus building
         // Matches fgbio's ssCaller initialization in DuplexConsensusCaller:
         // - minReads = 1 (CODEC handles filtering itself)
@@ -393,9 +387,12 @@ impl CodecConsensusCaller {
             error_rate_post_umi: options.error_rate_post_umi,
             min_input_base_quality: options.min_input_base_quality,
             min_reads: 1, // CODEC handles read filtering
+            // Must stay `None`: codec applies its own `max_reads_per_strand` cap in
+            // `consensus_reads_raw`, so `to_source_read_for_codec_raw` leaves `name_hash`
+            // unstamped. Threading a cap here would make every rank tie and silently select by
+            // input order. Pinned by `codec_single_strand_caller_never_downsamples`.
             max_reads: None,
             produce_per_base_tags: true,
-            seed: None,
             trim: false,
             min_consensus_base_quality: 0, // MIN - we handle quality masking
             cell_tag: None,
@@ -414,7 +411,6 @@ impl CodecConsensusCaller {
             read_group_id,
             options,
             stats: CodecConsensusStats::default(),
-            rng,
             consensus_counter: 0,
             ss_caller,
             bam_builder: UnmappedSamBuilder::new(),
@@ -536,6 +532,10 @@ impl CodecConsensusCaller {
             ref_id: rid,
             alignment_start: astart,
             original_cigar,
+            // Left unstamped: these `SourceRead`s feed `ss_caller`, which is constructed with
+            // `max_reads: None`, so `downsample_source_reads` never reads this field. Codec caps
+            // earlier, in `consensus_reads_raw`. See the invariant note at that construction.
+            name_hash: 0,
         }
     }
 
@@ -706,14 +706,16 @@ impl CodecConsensusCaller {
             return Ok(ConsensusOutput::default());
         }
 
-        // Downsample if needed
+        // Downsample if needed, keeping the lowest-ranking read pairs. Rank is a
+        // Murmur3 hash of the read name (fgbio's rule, fulcrumgenomics/fgbio#1166), so
+        // selection is reproducible and independent of how work is divided across
+        // threads. R1 and R2 share a name and so are selected together; the shared
+        // index vector below keeps them aligned. The sort is stable so tied ranks keep
+        // input order.
         if let Some(max_reads) = self.options.max_reads_per_strand
             && r1_infos.len() > max_reads
         {
-            let mut indices: Vec<usize> = (0..r1_infos.len()).collect();
-            indices.shuffle(&mut self.rng);
-            indices.truncate(max_reads);
-            indices.sort_unstable();
+            let indices = Self::keep_indices_for_infos(records, &r1_infos, max_reads);
 
             let new_r1: Vec<_> = indices
                 .iter()
@@ -963,6 +965,43 @@ impl CodecConsensusCaller {
             adjusted_pos: 0,
             flags: 0,
         }
+    }
+
+    /// Which of `names` to keep when capping at `max_reads`, lowest-ranking first.
+    ///
+    /// The one implementation of codec's cap rule: rank each read name with
+    /// [`fgumi_raw_bam::hash::fgbio_read_name_rank`], then hand the ranks to
+    /// [`select_lowest_ranking`]. Production (`consensus_reads_raw`) and the `downsample_pairs`
+    /// test wrapper both go through here, so a test cannot pass against a ranking that
+    /// production does not use.
+    ///
+    /// Ranking here rather than stamping every `ClippedRecordInfo` at construction keeps the
+    /// hash inside the caller's own `max_reads_per_strand` guard: an uncapped run — the default
+    /// — does no hashing at all, and the rank cannot go stale or be left unstamped.
+    fn keep_indices_by_name_rank<'a>(
+        names: impl Iterator<Item = &'a [u8]>,
+        max_reads: usize,
+    ) -> Vec<usize> {
+        let ranks: Vec<i32> = names.map(fgbio_read_name_rank).collect();
+        select_lowest_ranking(&ranks, max_reads)
+    }
+
+    /// Which of `infos` to keep when capping at `max_reads`.
+    ///
+    /// The production form of [`Self::keep_indices_by_name_rank`]. A `ClippedRecordInfo` carries
+    /// no read name, only a `raw_idx` back into `records`, so resolving that index is part of the
+    /// rule and not incidental plumbing: resolving it wrongly — by position, or to a fixed record
+    /// — makes every rank tie and selection falls back to input order, which is the behaviour
+    /// this ranking replaces. Kept as a named function so that mapping is directly testable.
+    fn keep_indices_for_infos(
+        records: &[RawRecord],
+        infos: &[ClippedRecordInfo],
+        max_reads: usize,
+    ) -> Vec<usize> {
+        Self::keep_indices_by_name_rank(
+            infos.iter().map(|info| RawRecordView::new(records[info.raw_idx].as_ref()).read_name()),
+            max_reads,
+        )
     }
 
     /// Filter `ClippedRecordInfo`s to the most common alignment pattern.
@@ -1737,22 +1776,24 @@ impl CodecConsensusCaller {
         Self::compute_consensus_length_raw(&info_pos, &info_neg, overlap_end)
     }
 
-    /// Test-only wrapper: downsample pairs using `max_reads_per_strand` option.
+    /// Test-only wrapper: downsample pairs using the `max_reads_per_strand` option.
+    ///
+    /// Delegates to [`Self::keep_indices_by_name_rank`], the same function `consensus_reads_raw`
+    /// uses, so a change to the ranking or selection rule cannot pass here while breaking
+    /// production. It differs from the production path only in operating on `RawRecord`s
+    /// directly rather than on already-clipped `ClippedRecordInfo`s.
     pub fn downsample_pairs(
-        &mut self,
+        &self,
         r1s: Vec<RawRecord>,
         r2s: Vec<RawRecord>,
     ) -> (Vec<RawRecord>, Vec<RawRecord>) {
         let Some(max_reads) = self.options.max_reads_per_strand else {
             return (r1s, r2s);
         };
-        if r1s.len() <= max_reads {
-            return (r1s, r2s);
-        }
-        let mut indices: Vec<usize> = (0..r1s.len()).collect();
-        indices.shuffle(&mut self.rng);
-        indices.truncate(max_reads);
-        indices.sort_unstable();
+        let indices = Self::keep_indices_by_name_rank(
+            r1s.iter().map(|r| RawRecordView::new(r.as_ref()).read_name()),
+            max_reads,
+        );
         let new_r1: Vec<_> = indices.iter().map(|&i| r1s[i].clone()).collect();
         let new_r2: Vec<_> = indices.iter().map(|&i| r2s[i].clone()).collect();
         (new_r1, new_r2)
@@ -4403,7 +4444,7 @@ mod tests {
         use noodles::sam::alignment::record::cigar::op::Kind;
 
         let options = CodecConsensusOptions { max_reads_per_strand: Some(2), ..Default::default() };
-        let mut caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
+        let caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
 
         // Create 5 R1s and 5 R2s
         let r1s: Vec<RawRecord> = (0..5)
@@ -4446,7 +4487,7 @@ mod tests {
         use noodles::sam::alignment::record::cigar::op::Kind;
 
         let options = CodecConsensusOptions { max_reads_per_strand: None, ..Default::default() };
-        let mut caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
+        let caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
 
         let r1s: Vec<RawRecord> = (0..5)
             .map(|i| {
@@ -4482,6 +4523,174 @@ mod tests {
         // No limit, so all reads should be kept
         assert_eq!(ds_r1s.len(), 5);
         assert_eq!(ds_r2s.len(), 5);
+    }
+
+    /// Codec downsampling keeps the lowest-hashing read pairs, not a shuffled sample, so the
+    /// retained subset is reproducible and matches fgbio's rule. Drives the real
+    /// `downsample_pairs` selection (same rank/sort/truncate/restore-order logic used inline in
+    /// `consensus_reads_raw`) with real read names, rather than re-deriving the ranking in the
+    /// test — see the task report for why that's preferred over a test-only reimplementation.
+    #[test]
+    fn codec_downsampling_retains_lowest_hashing_pairs() {
+        use noodles::sam::alignment::record::cigar::op::Kind;
+
+        let options = CodecConsensusOptions { max_reads_per_strand: Some(3), ..Default::default() };
+        let caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
+
+        // Ten templates named q0..q9; signed Murmur3(42) ranks (htsjdk-derived) put
+        // q3 (-1135430185) < q2 (-974105965) < q0 (-593808727) lowest, so a cap of 3 keeps
+        // exactly {q0, q2, q3}.
+        let names: Vec<String> = (0..10).map(|i| format!("q{i}")).collect();
+        let expected: Vec<String> = vec!["q3".to_string(), "q2".to_string(), "q0".to_string()];
+
+        let r1s: Vec<RawRecord> = names
+            .iter()
+            .map(|n| {
+                create_test_paired_read(
+                    n,
+                    &[b'A'; 20],
+                    &[30; 20],
+                    true,
+                    false,
+                    true,
+                    100,
+                    &[(Kind::Match, 20)],
+                )
+            })
+            .collect();
+        let r2s: Vec<RawRecord> = names
+            .iter()
+            .map(|n| {
+                create_test_paired_read(
+                    n,
+                    &[b'A'; 20],
+                    &[30; 20],
+                    false,
+                    true,
+                    false,
+                    110,
+                    &[(Kind::Match, 20)],
+                )
+            })
+            .collect();
+
+        let (ds_r1s, ds_r2s) = caller.downsample_pairs(r1s, r2s);
+        let names_of = |recs: &[RawRecord]| -> Vec<String> {
+            let mut names: Vec<String> = recs
+                .iter()
+                .map(|r| {
+                    String::from_utf8(RawRecordView::new(r.as_ref()).read_name().to_vec())
+                        .expect("read names are ASCII")
+                })
+                .collect();
+            names.sort();
+            names
+        };
+        let mut expected_sorted = expected;
+        expected_sorted.sort();
+
+        assert_eq!(names_of(&ds_r1s), expected_sorted);
+        // Both ends must survive together: R1 and R2 share a read name and therefore a rank,
+        // so a cap retains or discards a template as a unit.
+        assert_eq!(names_of(&ds_r2s), expected_sorted, "R2 must keep the same templates as R1");
+    }
+
+    /// The cap must rank each info by *its own* record, resolved through `raw_idx`.
+    ///
+    /// `infos` are deliberately built in the reverse of file order, so the correct answer is
+    /// distinguishable from the two ways this mapping is plausibly broken. Records are named
+    /// `q0..q9`, whose htsjdk-derived ranks put `q3 < q2 < q0` lowest, so a cap of 3 keeps the
+    /// infos holding those three — positions 6, 7 and 9 under the reversal.
+    ///
+    /// Resolving by info position instead of `raw_idx` would rank `q0..q9` in order and keep
+    /// `[0, 2, 3]`; resolving every info to one fixed record would tie every rank and keep
+    /// `[0, 1, 2]`. Neither matches, so both fail here.
+    #[test]
+    fn codec_cap_ranks_each_info_by_its_own_record() {
+        let records: Vec<RawRecord> = (0..10)
+            .map(|i| {
+                create_test_paired_read(
+                    &format!("q{i}"),
+                    &[b'A'; 20],
+                    &[30; 20],
+                    true,
+                    false,
+                    true,
+                    100,
+                    &[(Kind::Match, 20)],
+                )
+            })
+            .collect();
+        let infos: Vec<ClippedRecordInfo> = (0..10)
+            .map(|i| CodecConsensusCaller::build_clipped_info(records[9 - i].as_ref(), 9 - i, 0))
+            .collect();
+
+        assert_eq!(
+            CodecConsensusCaller::keep_indices_for_infos(&records, &infos, 3),
+            vec![6, 7, 9]
+        );
+    }
+
+    /// Codec's single-strand caller must never downsample.
+    ///
+    /// Codec applies `max_reads_per_strand` itself in `consensus_reads_raw`, so
+    /// `to_source_read_for_codec_raw` leaves `SourceRead::name_hash` at 0. Those zero ranks are
+    /// only safe while unread: threading a cap into `ss_caller` would make every rank tie and
+    /// `downsample_source_reads` would silently select by input order — reinstating exactly the
+    /// order dependence the ranking removes. Holds even when the codec cap is set.
+    #[test]
+    fn codec_single_strand_caller_never_downsamples() {
+        let caller = CodecConsensusCaller::new(
+            "codec".to_string(),
+            "RG1".to_string(),
+            CodecConsensusOptions { max_reads_per_strand: Some(3), ..Default::default() },
+        );
+        assert!(
+            caller.ss_caller.options.max_reads.is_none(),
+            "codec's single-strand caller must not carry a cap while name_hash is left at 0"
+        );
+    }
+
+    /// [`select_lowest_ranking`] is the single selection primitive behind both the production
+    /// `consensus_reads_raw` cap and the `downsample_pairs` test wrapper, so these cases pin
+    /// the production rule directly.
+    #[rstest]
+    // Signed comparison: negative ranks sort below positive ones. Comparing as `u32` would
+    // instead keep [2, 7], and `wrapping_abs` would keep [7] over [-9].
+    #[case::signed_ranks_sort_below_positive(vec![7, -9, 2], 2, vec![1, 2])]
+    // An all-tied input pins only that the first `max_reads` records survive. It provably
+    // CANNOT detect a regression to `sort_unstable_by_key` — with uniform keys every ordering
+    // is a valid sorted ordering — so the case below carries that duty.
+    #[case::all_tied_keeps_the_first_max_reads(vec![5, 5, 5, 5], 2, vec![0, 1])]
+    // Stability is load-bearing: mates share a read name and therefore a rank, so a cap landing
+    // inside a tied pair must keep the end that arrived FIRST. This vector is the tripwire for a
+    // regression to `sort_unstable_by_key`; a short vector cannot serve, because pdqsort falls
+    // back to an (effectively stable) insertion sort on small slices. Eleven mate pairs with
+    // alternating-sign ranks is the smallest divergent input found: the lowest rank (-9) is held
+    // by the pair at indices 18/19, and unstable selection keeps 19 instead of 18.
+    #[case::tie_split_keeps_the_first_arriving_end(
+        vec![0, 0, -1, -1, 2, 2, -3, -3, 4, 4, -5, -5, 6, 6, -7, -7, 8, 8, -9, -9, 10, 10],
+        1,
+        vec![18]
+    )]
+    // At or below the cap nothing is dropped.
+    #[case::at_cap_keeps_everything(vec![3, 1, 2], 3, vec![0, 1, 2])]
+    #[case::below_cap_keeps_everything(vec![3, 1], 9, vec![0, 1])]
+    // htsjdk-derived q0..q9 ranks: q3 < q2 < q0 are the three lowest.
+    #[case::htsjdk_q_names(
+        vec![
+            -593_808_727, 303_033_695, -974_105_965, -1_135_430_185, 1_999_667_023,
+            1_258_614_125, 1_143_495_474, -403_640_721, 680_071_392, 98_042_550,
+        ],
+        3,
+        vec![0, 2, 3]
+    )]
+    fn test_select_lowest_ranking(
+        #[case] ranks: Vec<i32>,
+        #[case] max_reads: usize,
+        #[case] expected: Vec<usize>,
+    ) {
+        assert_eq!(select_lowest_ranking(&ranks, max_reads), expected);
     }
 
     #[test]

--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -2738,7 +2738,6 @@ mod tests {
                 min_reads: 1,
                 max_reads: None,
                 produce_per_base_tags: true,
-                seed: Some(42),
                 trim: false,
                 min_consensus_base_quality: 40,
                 cell_tag: None,

--- a/crates/fgumi-consensus/src/methylation.rs
+++ b/crates/fgumi-consensus/src/methylation.rs
@@ -933,6 +933,9 @@ pub(crate) mod tests {
             ref_id: 0,
             alignment_start: 0,
             original_cigar: vec![(Kind::Match, bases.len())],
+            // No backing record to hash a name from. Nothing in production constructs a
+            // recordless `SourceRead`, so this value is never used for real selection.
+            name_hash: 0,
         }
     }
 }

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -7,7 +7,7 @@
 use crate::base_builder::{ConsensusBaseBuilder, TieRule};
 use crate::caller::{
     ConsensusCaller, ConsensusCallingStats, ConsensusOutput, RejectionReason,
-    consensus_read_name_too_long_context, write_consensus_read_name,
+    consensus_read_name_too_long_context, select_lowest_ranking, write_consensus_read_name,
 };
 use crate::phred::{
     MIN_PHRED, NO_CALL_BASE, NO_CALL_BASE_LOWER, PhredScore, ln_error_prob_two_trials,
@@ -16,13 +16,11 @@ use crate::phred::{
 use crate::simple_umi::consensus_umis;
 use anyhow::{Context, Result, anyhow, bail};
 use fgumi_dna::dna::reverse_complement;
+use fgumi_raw_bam::hash::fgbio_read_name_rank;
 use fgumi_raw_bam::{RawRecord, RawRecordView, UnmappedSamBuilder, flags};
 use fgumi_sam::SamTag;
 use fgumi_sam::clipper::cigar_utils::{self, SimplifiedCigar};
 use noodles::sam::alignment::record::cigar::op::Kind;
-use rand::SeedableRng;
-use rand::rngs::StdRng;
-use rand::seq::SliceRandom;
 use std::collections::HashSet;
 
 /// Indexed source read for alignment filtering: (index, length, `simplified_cigar`)
@@ -146,6 +144,13 @@ pub(crate) struct SourceRead {
     pub(crate) alignment_start: i64,
     /// Original (pre-reversal) simplified CIGAR (for reverse-strand ref position mapping)
     pub(crate) original_cigar: SimplifiedCigar,
+    /// fgbio-compatible rank of the record's read name, from
+    /// [`fgumi_raw_bam::hash::fgbio_read_name_rank`].
+    ///
+    /// Computed once here rather than at each comparison during downsampling,
+    /// which would re-hash the name on every comparison. Both ends of a template
+    /// share a read name and so share this rank.
+    pub(crate) name_hash: i32,
 }
 
 /// Vanilla consensus read - matches fgbio's `VanillaConsensusRead`
@@ -306,9 +311,6 @@ pub struct VanillaUmiConsensusOptions {
     /// Whether to produce per-base tags (cd, ce)
     pub produce_per_base_tags: bool,
 
-    /// Random seed for reproducible downsampling
-    pub seed: Option<u64>,
-
     /// Whether to quality-trim reads before consensus calling
     pub trim: bool,
 
@@ -341,7 +343,6 @@ impl Default for VanillaUmiConsensusOptions {
             min_reads: 2, // Match fgbio default
             max_reads: None,
             produce_per_base_tags: true, // Match fgbio default
-            seed: Some(42),              // Hard-coded seed for reproducible downsampling
             trim: false,
             min_consensus_base_quality: 40, // Match fgbio default
             cell_tag: None,
@@ -370,9 +371,6 @@ pub struct VanillaUmiConsensusCaller {
 
     /// Consensus base builder (reused across positions)
     consensus_builder: ConsensusBaseBuilder,
-
-    /// Random number generator for downsampling (seeded or thread-local)
-    rng: StdRng,
 
     /// Rejected reads as raw bytes (if tracking is enabled).
     ///
@@ -441,13 +439,6 @@ impl VanillaUmiConsensusCaller {
             ConsensusBaseBuilder::new(options.error_rate_pre_umi, options.error_rate_post_umi)
                 .with_tie_rule(options.tie_rule);
 
-        // Create RNG - either seeded or from OS entropy
-        let rng = if let Some(seed) = options.seed {
-            StdRng::seed_from_u64(seed)
-        } else {
-            rand::make_rng()
-        };
-
         // Pre-compute single-input consensus quals lookup table (matching fgbio)
         // For each input quality, compute the output quality when only one read contributes
         let single_input_consensus_quals = Self::compute_single_input_consensus_quals(&options);
@@ -458,7 +449,6 @@ impl VanillaUmiConsensusCaller {
             options,
             stats: ConsensusCallingStats::new(),
             consensus_builder,
-            rng,
             rejected_reads: Vec::new(),
             track_rejects,
             single_input_consensus_quals,
@@ -631,6 +621,9 @@ impl VanillaUmiConsensusCaller {
             ref_id: rid,
             alignment_start: astart,
             original_cigar,
+            // This bridge is test-only and no downsampling test exercises it; stamp the
+            // real rank anyway so it stays consistent with the raw-bytes path.
+            name_hash: read.name().map_or(0, |n| fgbio_read_name_rank(n)),
         })
     }
 
@@ -671,7 +664,8 @@ impl VanillaUmiConsensusCaller {
         };
 
         // Cap the reads contributing to the single-strand CONSENSUS, matching fgbio's
-        // `consensusCall` (`VanillaUmiConsensusCaller.scala:288`: `shuffle.take(maxReads)`).
+        // `consensusCall` (`VanillaUmiConsensusCaller.scala`, `downsample(maxReads)` since
+        // fulcrumgenomics/fgbio#1166 — previously `shuffle.take(maxReads)`).
         // The duplex and codec callers reach the single-strand consensus through
         // `consensus_call`, so without this cap `--max-reads-per-strand` is silently ignored
         // on those paths (DUPLEX3-01). The vanilla path caps raw records earlier in
@@ -814,47 +808,74 @@ impl VanillaUmiConsensusCaller {
     }
 
     /// Downsamples reads if there are more than `max_reads`
-    fn downsample_reads(&mut self, mut reads: Vec<RawRecord>) -> Vec<RawRecord> {
+    fn downsample_reads(&self, mut reads: Vec<RawRecord>) -> Vec<RawRecord> {
         if let Some(max_reads) = self.options.max_reads
             && reads.len() > max_reads
         {
-            reads.shuffle(&mut self.rng);
-            reads.truncate(max_reads);
+            // Rank once per record, not inside the sort key: `sort_by_key` may evaluate its
+            // closure more than once per element, which would re-hash on every comparison.
+            let ranks: Vec<i32> = reads
+                .iter()
+                .map(|raw| fgbio_read_name_rank(RawRecordView::new(raw.as_ref()).read_name()))
+                .collect();
+            let keep_indices = select_lowest_ranking(&ranks, max_reads);
+
+            // Drop the non-survivors in place. `retain` preserves input order and moves the
+            // retained records rather than cloning them — families reaching here can be large.
+            let mut keep = vec![false; reads.len()];
+            for i in keep_indices {
+                keep[i] = true;
+            }
+            let mut idx = 0;
+            reads.retain(|_| {
+                let keeping = keep[idx];
+                idx += 1;
+                keeping
+            });
         }
         reads
     }
 
-    /// Downsamples already-filtered `SourceReads` if there are more than `max_reads`.
+    /// Downsamples already-filtered `SourceReads` to at most `max_reads`, keeping the
+    /// lowest-ranking reads.
     ///
     /// This is the `SourceRead` analogue of [`Self::downsample_reads`], applied inside
     /// [`Self::consensus_call`] so the per-strand cap reaches the duplex and codec callers
-    /// (which build consensus from pre-filtered `SourceReads` rather than raw records). It
-    /// mirrors fgbio's `consensusCall` (`shuffle.take(maxReads)`): the retained subset is
-    /// selected by shuffling with the caller's seeded RNG (default seed 42) so the selection is
-    /// deterministic and unbiased, then keeping `max_reads`. When `max_reads` is unset or the
-    /// strand is at or below the cap this simply clones the input, preserving byte-identical
-    /// output for the default configuration.
+    /// (which build consensus from pre-filtered `SourceReads` rather than raw records).
     ///
-    /// To avoid deep-cloning the entire (potentially very large) family just to discard most of
-    /// it, this shuffles an *index* vector `[0, len)` and clones only the `max_reads` retained
-    /// reads. This is bit-identical to shuffling the reads themselves and truncating:
-    /// `SliceRandom::shuffle` is Fisher-Yates, and its RNG-call sequence depends only on the
-    /// slice LENGTH, not the element type. So shuffling `[0..len]` yields the SAME permutation as
-    /// shuffling the reads, hence `idxs[0..max_reads]` selects exactly the reads (in the same
-    /// order) that `reads.shuffle().truncate(max_reads)` would keep. Selection therefore stays
-    /// deterministic-per-seed and unchanged from the prior implementation.
+    /// Rank comes from [`SourceRead::name_hash`], a Murmur3 hash of the read name, so the
+    /// retained subset is a pure function of the family: independent of how many families this
+    /// caller has already downsampled, of how work is divided across threads or execution
+    /// modes, and of the order the reads arrive in. This mirrors fgbio's
+    /// `VanillaUmiConsensusCaller.downsampleRank` (fulcrumgenomics/fgbio#1166).
     ///
-    /// The *rule* matches fgbio, but the *selection* does not byte-match it when downsampling
-    /// actually triggers: fgumi shuffles with `StdRng` (`ChaCha`) while fgbio uses Scala's
-    /// `Random.shuffle` over `java.util.Random` (an LCG), so the same seed value yields a
-    /// different permutation and therefore a different surviving subset. Downsampled consensus
-    /// bases/quals/depths are thus deterministic within fgumi but not byte-identical to fgbio on
-    /// any strand that exceeds the cap.
-    fn downsample_source_reads(&mut self, source_reads: &[SourceRead]) -> Vec<SourceRead> {
+    /// Because both ends of a template share a read name they share a rank, so a template is
+    /// retained or discarded as a unit **when both ends are downsampled from the same
+    /// surviving-template set**. That holds for a single call over one shared list, but the
+    /// duplex caller downsamples R1 and R2 independently (`duplex_caller.rs`, after each end
+    /// runs its own `create_source_read`/`filter_by_alignment`): a template whose R1 survives
+    /// upstream filtering while its R2 does not shifts the cap boundary on the surviving end, so
+    /// the two ends' retained subsets can diverge for such templates. This matches fgbio's own
+    /// structure, so it is parity-faithful rather than a shortcoming of this function.
+    ///
+    /// The sort is **stable**, matching Scala's `sortInPlaceBy`, so tied ranks keep input
+    /// order. Ranks are compared as **signed** `i32`, matching fgbio's Scala `Int`.
+    ///
+    /// To avoid deep-cloning a potentially very large family just to discard most of it, this
+    /// orders an *index* vector and clones only the retained reads. When `max_reads` is unset
+    /// or the family is at or below the cap this simply clones the input, preserving
+    /// byte-identical output for the default configuration.
+    /// Deliberately does NOT use [`crate::caller::select_lowest_ranking`], which re-sorts the
+    /// survivors back into input order. fgbio's `downsample` returns them in *rank* order, and
+    /// these reads feed per-position consensus aggregation where order is immaterial — so
+    /// matching fgbio costs nothing and keeps the two implementations comparable. The
+    /// raw-record and codec paths use the shared helper because they emit records, where input
+    /// order is observable.
+    fn downsample_source_reads(&self, source_reads: &[SourceRead]) -> Vec<SourceRead> {
         match self.options.max_reads {
             Some(max_reads) if source_reads.len() > max_reads => {
                 let mut idxs: Vec<usize> = (0..source_reads.len()).collect();
-                idxs.shuffle(&mut self.rng);
+                idxs.sort_by_key(|&i| source_reads[i].name_hash);
                 idxs.truncate(max_reads);
                 idxs.into_iter().map(|i| source_reads[i].clone()).collect()
             }
@@ -1046,7 +1067,25 @@ impl VanillaUmiConsensusCaller {
             ref_id: rid,
             alignment_start: astart,
             original_cigar,
+            name_hash: self.source_read_name_rank(view.read_name()),
         })
+    }
+
+    /// The downsampling rank for a `SourceRead`, or `0` when no cap is configured.
+    ///
+    /// [`Self::downsample_source_reads`] is the only consumer and runs only when `max_reads` is
+    /// `Some`, so the hash is dead work otherwise — and uncapped is the default configuration,
+    /// i.e. every read of an ordinary run. Gating on the consumer's own guard rather than on a
+    /// caller-supplied flag is deliberate: a placeholder returned while downsampling was live
+    /// would tie every rank, and selection would silently fall back to input order — the exact
+    /// order dependence this ranking exists to remove.
+    ///
+    /// Standalone `simplex` still pays for ranks it never reads, because it caps raw records in
+    /// `process_group` and does not route through `consensus_call`. That residue is bounded by
+    /// `--max-reads` per family rather than by the size of the input, and removing it would need
+    /// exactly the caller-supplied flag this avoids.
+    fn source_read_name_rank(&self, name: &[u8]) -> i32 {
+        if self.options.max_reads.is_some() { fgbio_read_name_rank(name) } else { 0 }
     }
 
     /// Filters `SourceReads` to only include those with the most common alignment pattern.
@@ -1699,6 +1738,31 @@ mod tests {
         b.build()
     }
 
+    /// Like [`create_test_read`], but with an explicit `ref_id`/`pos`/`sequence` so a mate pair
+    /// can differ in every per-end field except the read name (which the two ends must share to
+    /// share a downsample rank). Used by [`downsampling_keeps_mate_pairs_together`] so that test
+    /// is sensitive to end-dependence flowing through position or sequence, not only `flags`.
+    fn create_test_read_at(
+        name: &str,
+        is_first: bool,
+        ref_id: i32,
+        pos: i32,
+        seq: &[u8],
+    ) -> RawRecord {
+        let quals = vec![b'I'; seq.len()];
+        let flg = flags::PAIRED | if is_first { flags::FIRST_SEGMENT } else { flags::LAST_SEGMENT };
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .flags(flg)
+            .ref_id(ref_id)
+            .pos(pos)
+            .sequence(seq)
+            .qualities(&quals)
+            .cigar_ops(&[encode_op(0, seq.len())])
+            .add_string_tag(SamTag::MI, b"UMI123");
+        b.build()
+    }
+
     #[test]
     fn test_consensus_caller_creation() {
         let options = VanillaUmiConsensusOptions::default();
@@ -1901,89 +1965,15 @@ mod tests {
     }
 
     #[test]
-    fn test_deterministic_downsampling() {
-        // Test that downsampling with a seed produces deterministic results
-        let seed = 42u64;
-        let options = VanillaUmiConsensusOptions {
-            min_reads: 1,
-            max_reads: Some(3),
-            seed: Some(seed),
-            ..Default::default()
-        };
-
-        // Create 10 reads with different names
-        let mut reads: Vec<RawRecord> = Vec::new();
-        for i in 0..10 {
-            let name = format!("read{i}");
-            reads.push(create_test_read(&name, b"ACGT", b"####", false, false));
-        }
-
-        // Create two callers with the same seed
-        let mut caller1 = VanillaUmiConsensusCaller::new(
-            "consensus".to_string(),
-            "A".to_string(),
-            options.clone(),
-        );
-        let mut caller2 =
-            VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
-
-        // Downsample with both callers
-        let downsampled1 = caller1.downsample_reads(reads.clone());
-        let downsampled2 = caller2.downsample_reads(reads);
-
-        // Both should produce exactly 3 reads (max_reads)
-        assert_eq!(downsampled1.len(), 3);
-        assert_eq!(downsampled2.len(), 3);
-
-        // Both should select the same reads in the same order
-        for i in 0..3 {
-            assert_eq!(
-                RawRecordView::new(&downsampled1[i]).read_name(),
-                RawRecordView::new(&downsampled2[i]).read_name()
-            );
-        }
-    }
-
-    #[test]
-    fn test_nondeterministic_downsampling_without_seed() {
-        // Test that downsampling without a seed still works (even if not deterministic)
-        let options = VanillaUmiConsensusOptions {
-            min_reads: 1,
-            max_reads: Some(3),
-            seed: None,
-            ..Default::default()
-        };
-
-        // Create 10 reads
-        let mut reads: Vec<RawRecord> = Vec::new();
-        for i in 0..10 {
-            let name = format!("read{i}");
-            reads.push(create_test_read(&name, b"ACGT", b"####", false, false));
-        }
-
-        let mut caller =
-            VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
-
-        let downsampled = caller.downsample_reads(reads);
-
-        // Should produce exactly 3 reads (max_reads)
-        assert_eq!(downsampled.len(), 3);
-    }
-
-    #[test]
     fn test_consensus_call_caps_reads_per_strand() {
         // DUPLEX3-01: `consensus_call` is the single-strand consensus entry point used by the
         // duplex and codec callers (the vanilla path downsamples raw records earlier and never
         // reaches this method). fgbio caps the contributing reads inside `consensusCall`
-        // (`shuffle.take(maxReads)`), so `--max-reads-per-strand` must limit how many reads
+        // (`downsample(maxReads)`), so `--max-reads-per-strand` must limit how many reads
         // contribute here. Without the cap, every read contributes and the per-strand depth
         // exceeds the requested maximum.
-        let options = VanillaUmiConsensusOptions {
-            min_reads: 1,
-            max_reads: Some(3),
-            seed: Some(42),
-            ..Default::default()
-        };
+        let options =
+            VanillaUmiConsensusOptions { min_reads: 1, max_reads: Some(3), ..Default::default() };
         let mut caller =
             VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
 
@@ -2014,12 +2004,8 @@ mod tests {
     /// depth is capped, but the full uncapped read set survives in `source_reads`.
     #[test]
     fn consensus_call_caps_consensus_but_retains_full_source_reads() {
-        let options = VanillaUmiConsensusOptions {
-            min_reads: 1,
-            max_reads: Some(3),
-            seed: Some(42),
-            ..Default::default()
-        };
+        let options =
+            VanillaUmiConsensusOptions { min_reads: 1, max_reads: Some(3), ..Default::default() };
         let mut caller =
             VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
 
@@ -2046,47 +2032,296 @@ mod tests {
         );
     }
 
-    /// The per-strand downsampling is deterministic for a fixed seed: two `consensus_call`s over
-    /// the same reads from a caller seeded identically select the same subset and so produce a
-    /// byte-identical consensus. Reads carry a distinct base composition so *which* reads survive
-    /// the cap changes the consensus — the selection (not just the count) is what is pinned.
-    /// (Determinism only: the shuffle uses fgumi's `StdRng`, not fgbio's `java.util.Random`, so
-    /// the selection is not byte-parity with fgbio even at the same seed — see
-    /// `downsample_source_reads`.)
+    /// The retained subset must not depend on how many families the caller already
+    /// downsampled. This is the original fgbio bug (fulcrumgenomics/fgbio#1166) and,
+    /// in fgumi, the cause of `--threads N` disagreeing with the no-threads path.
     #[test]
-    fn consensus_call_downsampling_is_deterministic_for_a_fixed_seed() {
-        let make_reads = || -> Vec<SourceRead> {
-            (0..8)
-                .map(|i| {
-                    let mut sr = create_source_read_with_cigar("4M");
-                    // A third of the reads read 'C' instead of 'A', so the consensus base at each
-                    // position depends on which reads the cap keeps.
-                    if i % 3 == 0 {
-                        sr.bases = vec![b'C'; sr.bases.len()];
-                    }
-                    sr
-                })
-                .collect()
+    fn downsampling_ignores_caller_history() {
+        let options =
+            VanillaUmiConsensusOptions { min_reads: 1, max_reads: Some(3), ..Default::default() };
+        let reads = || -> Vec<SourceRead> {
+            (0..10).map(|i| create_source_read_with_rank("4M", i * 1000 - 4000)).collect()
         };
-        let call = || {
-            let options = VanillaUmiConsensusOptions {
-                min_reads: 1,
-                max_reads: Some(3),
-                seed: Some(42),
-                ..Default::default()
-            };
-            let mut caller =
-                VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
-            caller
-                .consensus_call("umi", make_reads())
-                .expect("consensus_call should succeed")
-                .expect("consensus should be produced")
+        let fresh =
+            VanillaUmiConsensusCaller::new("c".to_string(), "A".to_string(), options.clone());
+        let expected = fresh.downsample_source_reads(&reads());
+
+        let used = VanillaUmiConsensusCaller::new("c".to_string(), "A".to_string(), options);
+        let _ = used.downsample_source_reads(&reads()); // an unrelated family first
+        let actual = used.downsample_source_reads(&reads());
+
+        assert_eq!(
+            actual.iter().map(|sr| sr.name_hash).collect::<Vec<_>>(),
+            expected.iter().map(|sr| sr.name_hash).collect::<Vec<_>>(),
+            "a caller's downsampling history must not change which reads it keeps"
+        );
+    }
+
+    /// Ranks are compared as signed i32, matching fgbio's Scala `Int`. Under an unsigned
+    /// comparison the negative ranks would sort last instead of first; under any
+    /// absolute-value comparison (`.abs()`, `unsigned_abs()`, or — the form that actually
+    /// exists elsewhere in this repo, `src/lib/commands/shared_metrics.rs:151` —
+    /// `wrapping_abs()`) `-3` would sort AFTER `2` instead of before it, which the
+    /// `abs_order_diverges_from_signed` case below pins down.
+    #[rstest]
+    #[case::signed_extremes(vec![5, i32::MIN, -1, 1], 2, vec![i32::MIN, -1])]
+    #[case::abs_order_diverges_from_signed(vec![-3, 2], 1, vec![-3])]
+    fn downsampling_compares_ranks_as_signed(
+        #[case] ranks: Vec<i32>,
+        #[case] max_reads: usize,
+        #[case] expected: Vec<i32>,
+    ) {
+        let options = VanillaUmiConsensusOptions {
+            min_reads: 1,
+            max_reads: Some(max_reads),
+            ..Default::default()
         };
-        let first = call();
-        let second = call();
-        assert_eq!(first.bases, second.bases, "same seed must select the same reads → same bases");
-        assert_eq!(first.quals, second.quals, "same seed → identical quals");
-        assert_eq!(first.depths, second.depths, "same seed → identical depths");
+        let caller = VanillaUmiConsensusCaller::new("c".to_string(), "A".to_string(), options);
+        let reads: Vec<SourceRead> =
+            ranks.iter().map(|&rank| create_source_read_with_rank("4M", rank)).collect();
+        let kept: Vec<i32> =
+            caller.downsample_source_reads(&reads).iter().map(|s| s.name_hash).collect();
+        assert_eq!(kept, expected, "ranks must be compared as SIGNED i32, not by absolute value");
+    }
+
+    /// Equal ranks keep input order: fgbio sorts with Scala's stable `sortInPlaceBy`,
+    /// so ties resolve to arrival order. Guards against a later switch to
+    /// `sort_unstable_by_key`.
+    ///
+    /// An all-tied input can never distinguish stable from unstable sorting:
+    /// `sort_unstable_by_key` provably preserves input order when every key is equal, at any
+    /// length (insertion sort on tiny slices, an all-equal-partition fast path above that). So
+    /// this uses a MIXED tied/distinct key pattern (`rank = i % 3`) over `n = 30` elements —
+    /// large enough that pattern-defeating quicksort's partitioning actually reorders the tied
+    /// group of rank-0 elements (measured: at `n = 8` the two algorithms still agree; `n = 30`
+    /// is where they diverge).
+    #[test]
+    fn downsampling_is_stable_on_tied_ranks() {
+        let options =
+            VanillaUmiConsensusOptions { min_reads: 1, max_reads: Some(4), ..Default::default() };
+        let caller = VanillaUmiConsensusCaller::new("c".to_string(), "A".to_string(), options);
+        let n = 30;
+        let mut reads: Vec<SourceRead> =
+            (0..n).map(|i| create_source_read_with_rank("4M", i % 3)).collect();
+        for (i, sr) in reads.iter_mut().enumerate() {
+            sr.original_idx = i;
+        }
+        // The lowest rank (0) is tied among indices 0, 3, 6, 9, ...; a stable sort must keep
+        // the first `max_reads` of THOSE in arrival order.
+        let kept: Vec<usize> =
+            caller.downsample_source_reads(&reads).iter().map(|s| s.original_idx).collect();
+        assert_eq!(kept, vec![0, 3, 6, 9], "tied ranks must resolve to input order");
+    }
+
+    /// The subset is invariant to the order reads arrive in.
+    #[test]
+    fn downsampling_ignores_input_order() {
+        let options =
+            VanillaUmiConsensusOptions { min_reads: 1, max_reads: Some(3), ..Default::default() };
+        let reads: Vec<SourceRead> =
+            (0..10).map(|i| create_source_read_with_rank("4M", i * 977 - 5000)).collect();
+        let caller =
+            VanillaUmiConsensusCaller::new("c".to_string(), "A".to_string(), options.clone());
+        let forward: Vec<i32> =
+            caller.downsample_source_reads(&reads).iter().map(|s| s.name_hash).collect();
+
+        let mut reversed_input = reads;
+        reversed_input.reverse();
+        let caller2 = VanillaUmiConsensusCaller::new("c".to_string(), "A".to_string(), options);
+        let mut backward: Vec<i32> =
+            caller2.downsample_source_reads(&reversed_input).iter().map(|s| s.name_hash).collect();
+        backward.sort_unstable();
+        let mut forward_sorted = forward;
+        forward_sorted.sort_unstable();
+
+        assert_eq!(backward, forward_sorted, "input order must not change the retained SET");
+    }
+
+    /// Both ends of a template must be retained (or discarded) together. Rank is keyed by
+    /// read name alone (`SourceRead::name_hash`), never by end, so downsampling the R1 list
+    /// and the R2 list independently — exactly how the duplex caller reaches
+    /// `downsample_source_reads`, once per strand per end via `consensus_call` — must retain
+    /// the same set of templates. This routes R1 and R2 through the REAL production
+    /// `create_source_read` (not the `create_source_read_with_rank` test shortcut used by the
+    /// other tests here), and gives R1/R2 distinct `ref_id`, `pos`, and `sequence` (as real
+    /// mates have) so it is sensitive to end-dependence introduced anywhere in the
+    /// name-to-rank pipeline — through position or sequence, not only through `flags` — and
+    /// not only inside the sort key: in fgbio's original report, a per-end-keyed rank was
+    /// deterministic and passed every other downsampling test, yet kept R1 = {0, 3, 9} and
+    /// R2 = {2, 8, 9} — different templates on each end.
+    #[test]
+    fn downsampling_keeps_mate_pairs_together() {
+        let options =
+            VanillaUmiConsensusOptions { min_reads: 1, max_reads: Some(3), ..Default::default() };
+        let caller = VanillaUmiConsensusCaller::new("c".to_string(), "A".to_string(), options);
+
+        // 10 templates; R1 and R2 of the same template share a read name (as in a real BAM)
+        // but differ in ref_id, pos, and sequence, so only the name drives the shared rank.
+        let (r1_reads, r2_reads): (Vec<SourceRead>, Vec<SourceRead>) = (0..10)
+            .map(|i| {
+                let name = format!("read{i}");
+                let pos_r1 = i32::try_from(i * 100).expect("small test index fits in i32");
+                let pos_r2 = i32::try_from(i * 200 + 37).expect("small test index fits in i32");
+                let r1_raw = create_test_read_at(&name, true, 0, pos_r1, b"ACGTACGT");
+                let r2_raw = create_test_read_at(&name, false, 1, pos_r2, b"TTTTGGGGCCCC");
+                let sr1 = caller
+                    .create_source_read(r1_raw.as_ref(), i, 0)
+                    .expect("R1 source read should be created");
+                let sr2 = caller
+                    .create_source_read(r2_raw.as_ref(), i, 0)
+                    .expect("R2 source read should be created");
+                (sr1, sr2)
+            })
+            .unzip();
+
+        let mut r1_kept: Vec<usize> =
+            caller.downsample_source_reads(&r1_reads).iter().map(|sr| sr.original_idx).collect();
+        let mut r2_kept: Vec<usize> =
+            caller.downsample_source_reads(&r2_reads).iter().map(|sr| sr.original_idx).collect();
+        r1_kept.sort_unstable();
+        r2_kept.sort_unstable();
+
+        assert_eq!(
+            r1_kept, r2_kept,
+            "R1 and R2 of the same templates must be retained together, not independently \
+             per end"
+        );
+    }
+
+    /// The raw-record path ranks by read-name hash like the `SourceRead` path, so simplex's
+    /// group-level cap is reproducible across execution modes. Expected values are the same
+    /// htsjdk-derived oracle: signed ranks put q3 < q2 < q0 lowest, so a cap of 3 keeps
+    /// exactly those.
+    ///
+    /// (The cap here is still applied to the whole MI group rather than per end — see
+    /// fgumi#723 — but which reads it keeps is now deterministic.)
+    #[test]
+    fn downsample_reads_retains_lowest_hashing_names() {
+        let options =
+            VanillaUmiConsensusOptions { min_reads: 1, max_reads: Some(3), ..Default::default() };
+        let caller = VanillaUmiConsensusCaller::new("c".to_string(), "A".to_string(), options);
+        let reads: Vec<RawRecord> = (0..10)
+            .map(|i| create_test_read(&format!("q{i}"), b"ACGT", b"####", false, false))
+            .collect();
+
+        let mut names: Vec<String> = caller
+            .downsample_reads(reads)
+            .iter()
+            .map(|r| {
+                String::from_utf8(RawRecordView::new(r.as_ref()).read_name().to_vec())
+                    .expect("read names are ASCII")
+            })
+            .collect();
+        names.sort();
+        assert_eq!(names, vec!["q0", "q2", "q3"]);
+    }
+
+    /// Both ends of a template share a read name and therefore a rank, so they sort adjacently
+    /// and the cap keeps or drops them together — *unless* the truncation boundary falls inside
+    /// a pair. The simplex cap counts records, not templates (fgumi#723), so whether a template
+    /// splits depends on where the boundary lands in the rank-sorted list, not on the parity of
+    /// `max_reads`: a family mixing fragment and paired reads can split at an even cap and stay
+    /// whole at an odd one. The `--max-reads` help text documents this.
+    ///
+    /// Ranks for "q0".."q4" sort `q3 < q2 < q0 < q1 < q4`, so the rank-sorted record list is
+    /// `q3 q3 | q2 q2 | q0 q0 | q1 q1 | q4 q4`. A cap of 4 lands between blocks; a cap of 3
+    /// lands inside q2's block and keeps only the end that arrived first (the sort is stable).
+    ///
+    /// The expected column is the retained `(name, is_r1)` sequence in output order, which pins
+    /// membership, input-order preservation, and *which* end survives a split in one assertion.
+    #[rstest]
+    #[case::boundary_between_pairs(4, &[("q2", true), ("q2", false), ("q3", true), ("q3", false)])]
+    #[case::boundary_inside_a_pair(3, &[("q2", true), ("q3", true), ("q3", false)])]
+    fn downsample_reads_splits_a_template_only_at_the_cap_boundary(
+        #[case] max_reads: usize,
+        #[case] expected: &[(&str, bool)],
+    ) {
+        let options = VanillaUmiConsensusOptions {
+            min_reads: 1,
+            max_reads: Some(max_reads),
+            ..Default::default()
+        };
+        let caller = VanillaUmiConsensusCaller::new("c".to_string(), "A".to_string(), options);
+        let mut reads: Vec<RawRecord> = Vec::new();
+        for i in 0..5 {
+            let name = format!("q{i}");
+            reads.push(create_test_read(&name, b"ACGT", b"####", true, true));
+            reads.push(create_test_read(&name, b"ACGT", b"####", true, false));
+        }
+
+        let kept: Vec<(String, bool)> = caller
+            .downsample_reads(reads)
+            .iter()
+            .map(|r| {
+                let view = RawRecordView::new(r.as_ref());
+                let name =
+                    String::from_utf8(view.read_name().to_vec()).expect("read names are ASCII");
+                (name, view.flags() & flags::FIRST_SEGMENT != 0)
+            })
+            .collect();
+        let expected: Vec<(String, bool)> =
+            expected.iter().map(|&(n, r1)| (n.to_string(), r1)).collect();
+
+        assert_eq!(kept, expected);
+    }
+
+    /// Pins *which* reads a cap retains, with expected values derived from htsjdk's
+    /// `Murmur3(42)` rather than from fgumi. Without this, a deterministic-but-biased
+    /// rule — e.g. sorting by read name, which on Illumina names sorts by tile/x/y —
+    /// passes every other downsampling test.
+    ///
+    /// Signed ranks for "q0".."q9" put q3 < q2 < q0 below all others, so a cap of 3
+    /// keeps exactly those. fgbio#1166's own golden test asserts the same three,
+    /// derived independently.
+    ///
+    /// Goes through `create_source_read` (the production path that stamps the real rank,
+    /// not the `name_hash: 0` test shortcut) and `downsample_source_reads` (the production
+    /// selection path), rather than sorting the `SourceRead`s here and inspecting
+    /// `original_idx` directly, so the test exercises selection, not only ranking.
+    #[test]
+    fn downsampling_retains_the_lowest_hashing_names() {
+        let caller = VanillaUmiConsensusCaller::new(
+            "c".to_string(),
+            "A".to_string(),
+            VanillaUmiConsensusOptions { min_reads: 1, max_reads: Some(3), ..Default::default() },
+        );
+        let srcs: Vec<SourceRead> = (0..10)
+            .map(|i| {
+                let read = create_test_read(&format!("q{i}"), b"ACGT", b"####", false, false);
+                caller.create_source_read(read.as_ref(), i, 0).expect("source read")
+            })
+            .collect();
+
+        let mut kept: Vec<usize> =
+            caller.downsample_source_reads(&srcs).iter().map(|sr| sr.original_idx).collect();
+        kept.sort_unstable();
+        assert_eq!(kept, vec![0, 2, 3], "a cap of 3 must retain q0, q2 and q3");
+    }
+
+    /// A cap really does shape the consensus, end to end through `consensus_reads`: the same
+    /// 10-read family capped at 3 and left uncapped must report different depths, not just
+    /// the same record count. `count == 1` alone (the previous version of this test) would
+    /// pass even if the cap were ignored entirely.
+    #[test]
+    fn capped_consensus_depth_reflects_the_cap() {
+        let build = |max_reads: Option<usize>| -> i32 {
+            let mut caller = VanillaUmiConsensusCaller::new(
+                "c".to_string(),
+                "A".to_string(),
+                VanillaUmiConsensusOptions { min_reads: 1, max_reads, ..Default::default() },
+            );
+            let reads: Vec<RawRecord> = (0..10)
+                .map(|i| create_test_read(&format!("q{i}"), b"ACGT", b"####", false, false))
+                .collect();
+            let output =
+                consensus_reads_from_raw(&mut caller, reads).expect("consensus_reads_from_raw");
+            assert_eq!(output.count, 1);
+            let records = ParsedBamRecord::parse_all(&output.data);
+            records[0].get_int_tag(SamTag::CD).expect("cD present")
+        };
+
+        assert_eq!(build(Some(3)), 3, "a cap of 3 must cap consensus depth at 3");
+        assert_eq!(build(None), 10, "uncapped, the full 10-read family must contribute");
     }
 
     #[rstest]
@@ -2105,12 +2340,7 @@ mod tests {
         #[case] max_reads: Option<usize>,
         #[case] expected_max_depth: u16,
     ) {
-        let options = VanillaUmiConsensusOptions {
-            min_reads: 1,
-            max_reads,
-            seed: Some(42),
-            ..Default::default()
-        };
+        let options = VanillaUmiConsensusOptions { min_reads: 1, max_reads, ..Default::default() };
         let mut caller =
             VanillaUmiConsensusCaller::new("consensus".to_string(), "A".to_string(), options);
 
@@ -2147,7 +2377,6 @@ mod tests {
             let options = VanillaUmiConsensusOptions {
                 min_reads,
                 max_reads: Some(max_reads),
-                seed: Some(42),
                 ..Default::default()
             };
             let mut caller = VanillaUmiConsensusCaller::new(
@@ -3061,7 +3290,16 @@ mod tests {
             ref_id: -1,
             alignment_start: -1,
             original_cigar: simplified_cigar,
+            // No backing record to hash a name from. Nothing in production constructs a
+            // recordless `SourceRead`, so this value is never used for real selection.
+            name_hash: 0,
         }
+    }
+
+    /// Like [`create_source_read_with_cigar`] but with an explicit downsample rank,
+    /// so tests can pin exactly which reads a cap retains.
+    fn create_source_read_with_rank(cigar_str: &str, name_hash: i32) -> SourceRead {
+        SourceRead { name_hash, ..create_source_read_with_cigar(cigar_str) }
     }
 
     /// Helper to format simplified cigar as string (for test assertions)
@@ -3273,6 +3511,33 @@ mod tests {
             vec![2, 30, 2, 21, 2, 20, 2, 30, 2, 30],
             "Low quality bases get qual 2"
         );
+    }
+
+    /// With a cap configured, `create_source_read` stamps the fgbio rank of the record's read
+    /// name, so downsampling never re-hashes and mates (which share a name) share a rank.
+    ///
+    /// With no cap it stamps nothing: `downsample_source_reads` is the only reader and does not
+    /// run, so hashing every read of an uncapped run — the default — would be pure waste. The
+    /// uncapped case pins that gate, since a rank of `0` is only safe while unread.
+    #[rstest]
+    #[case::q0_capped("q0", Some(3), -593_808_727)]
+    #[case::read0_capped("read0", Some(3), 916_970_908)]
+    #[case::q0_uncapped("q0", None, 0)]
+    #[case::read0_uncapped("read0", None, 0)]
+    fn create_source_read_stamps_the_fgbio_rank(
+        #[case] name: &str,
+        #[case] max_reads: Option<usize>,
+        #[case] expected: i32,
+    ) {
+        let caller = VanillaUmiConsensusCaller::new(
+            "consensus".to_string(),
+            "A".to_string(),
+            VanillaUmiConsensusOptions { min_reads: 1, max_reads, ..Default::default() },
+        );
+        let read = create_test_read(name, b"ACGT", b"####", false, false);
+        let sr =
+            caller.create_source_read(read.as_ref(), 0, 0).expect("source read should be created");
+        assert_eq!(sr.name_hash, expected);
     }
 
     /// Ported from fgbio: "trim the source read when the end is low-quality so that there are no trailing no-calls"

--- a/crates/fgumi-raw-bam/src/hash.rs
+++ b/crates/fgumi-raw-bam/src/hash.rs
@@ -1,0 +1,146 @@
+//! fgbio-parity hashing of BAM read names.
+
+/// The Murmur3-32 body htsjdk applies to a Java `CharSequence`, over `len` UTF-16
+/// code units read through `at`. Indexed rather than iterator-based because the
+/// algorithm consumes code units pairwise.
+#[expect(
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    clippy::cast_possible_truncation,
+    reason = "lossless bit reinterpretations required for Java Murmur3 parity: the seed and \
+              final hash are Java `int`s reinterpreted as `u32` for the mixing arithmetic, and \
+              `len` is a read name / char count that never approaches u32::MAX"
+)]
+fn murmur3_hash_indexed(len: usize, at: impl Fn(usize) -> u16, seed: i32) -> i32 {
+    let mut h1: u32 = seed as u32;
+
+    let mut i = 1;
+    while i < len {
+        let k1 = u32::from(at(i - 1)) | (u32::from(at(i)) << 16);
+        h1 = murmur3_mix_h1(h1, murmur3_mix_k1(k1));
+        i += 2;
+    }
+
+    if len & 1 == 1 {
+        let k1 = murmur3_mix_k1(u32::from(at(len - 1)));
+        h1 ^= k1;
+    }
+
+    murmur3_fmix(h1, (2 * len) as u32) as i32
+}
+
+/// Port of htsjdk `Murmur3.hashUnencodedChars` (Apache-2.0; derived from
+/// Guava's Apache-2.0 `Murmur3_32`; original `MurmurHash3` is public domain).
+/// `chars` is the Java `CharSequence` / UTF-16 code units.
+///
+/// The returned hash is **signed**, and must be compared as such: htsjdk hashes
+/// by Java `int`, so about half of all inputs hash negative. Comparing as `u32`
+/// silently reorders every one of them.
+#[must_use]
+pub fn htsjdk_murmur3_hash_unencoded_chars(chars: &[u16], seed: i32) -> i32 {
+    murmur3_hash_indexed(chars.len(), |i| chars[i], seed)
+}
+
+/// Ranks a read name for fgbio-compatible downsampling.
+///
+/// Mirrors fgbio's `VanillaUmiConsensusCaller.downsampleRank`: the rank is
+/// `new Murmur3(42).hashUnencodedChars(readName)`, and downsampling keeps the
+/// lowest-ranking reads. Because both ends of a template share a read name they
+/// share a rank, so a cap retains or discards a template as a unit.
+///
+/// The returned rank is **signed**, and must be compared as such: fgbio ranks by
+/// Scala `Int`, so about half of all read names rank negative. Comparing as
+/// `u32` silently reorders every one of them.
+///
+/// htsjdk hashes the UTF-16 code units of a Java `String`. The SAM spec restricts
+/// read names to printable ASCII (`[!-?A-~]{1,254}`), for which widening each
+/// byte to a `u16` is exactly that code-unit sequence — so this avoids a UTF-8
+/// decode on a per-read hot path. A non-ASCII byte would be a spec violation;
+/// it still hashes deterministically, just not identically to htsjdk on the same
+/// bytes.
+#[must_use]
+pub fn fgbio_read_name_rank(name: &[u8]) -> i32 {
+    murmur3_hash_indexed(name.len(), |i| u16::from(name[i]), 42)
+}
+
+#[inline]
+fn murmur3_mix_k1(mut k1: u32) -> u32 {
+    k1 = k1.wrapping_mul(0xcc9e_2d51);
+    k1 = k1.rotate_left(15);
+    k1 = k1.wrapping_mul(0x1b87_3593);
+    k1
+}
+
+#[inline]
+fn murmur3_mix_h1(mut h1: u32, k1: u32) -> u32 {
+    h1 ^= k1;
+    h1 = h1.rotate_left(13);
+    h1.wrapping_mul(5).wrapping_add(0xe654_6b64)
+}
+
+#[inline]
+fn murmur3_fmix(mut h1: u32, length: u32) -> u32 {
+    h1 ^= length;
+    h1 ^= h1 >> 16;
+    h1 = h1.wrapping_mul(0x85eb_ca6b);
+    h1 ^= h1 >> 13;
+    h1 = h1.wrapping_mul(0xc2b2_ae35);
+    h1 ^= h1 >> 16;
+    h1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    /// Reference values captured from htsjdk's `Murmur3(42).hashUnencodedChars(s)`
+    /// by running htsjdk itself, not fgumi's port. These are the independent
+    /// oracle: if the port drifts, these fail.
+    #[rstest]
+    #[case::q0("q0", -593_808_727)]
+    #[case::q2("q2", -974_105_965)]
+    #[case::q3("q3", -1_135_430_185)]
+    #[case::q9("q9", 98_042_550)]
+    #[case::read0("read0", 916_970_908)]
+    #[case::read5("read5", -1_573_193_749)]
+    fn rank_matches_htsjdk_reference_vectors(#[case] name: &str, #[case] expected: i32) {
+        assert_eq!(fgbio_read_name_rank(name.as_bytes()), expected, "rank mismatch on {name:?}");
+    }
+
+    /// The ASCII fast path must agree with decoding to UTF-16 first, which is
+    /// what htsjdk does to a Java `String`.
+    #[rstest]
+    #[case::short("A")]
+    #[case::typical("H0164ALXX140820:2:1101:10003:23260")]
+    #[case::odd_length("abc")]
+    #[case::even_length("abcd")]
+    fn ascii_fast_path_matches_utf16_widening(#[case] name: &str) {
+        let widened: Vec<u16> = name.encode_utf16().collect();
+        assert_eq!(
+            fgbio_read_name_rank(name.as_bytes()),
+            htsjdk_murmur3_hash_unencoded_chars(&widened, 42)
+        );
+    }
+
+    /// The rank must depend on the *whole* name.
+    ///
+    /// Mates share a read name and therefore a rank, which is what lets a cap keep or drop both
+    /// ends of a template together — but that property is only useful if names that genuinely
+    /// differ rank differently. A hash that ignored the tail would collapse Illumina names
+    /// differing only in their x/y coordinates onto one rank, and a cap would then retain
+    /// whole tiles instead of a spread of the family. (Asserting a name equals *itself* would
+    /// pin none of this: it holds for any pure function, including a constant.)
+    #[rstest]
+    #[case::last_byte("H0164ALXX140820:2:1101:10003:23260", "H0164ALXX140820:2:1101:10003:23261")]
+    #[case::first_byte("A0164ALXX140820:2:1101:10003:23260", "B0164ALXX140820:2:1101:10003:23260")]
+    #[case::middle_byte("H0164ALXX140820:2:1101:10003:23260", "H0164ALXX140820:2:2101:10003:23260")]
+    #[case::length("frag:1", "frag:10")]
+    fn distinct_names_rank_distinctly(#[case] left: &str, #[case] right: &str) {
+        assert_ne!(
+            fgbio_read_name_rank(left.as_bytes()),
+            fgbio_read_name_rank(right.as_bytes()),
+            "{left:?} and {right:?} must not share a rank"
+        );
+    }
+}

--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -4,6 +4,7 @@ pub mod bin;
 pub mod builder;
 pub mod cigar;
 pub mod fields;
+pub mod hash;
 pub mod overlap;
 pub mod raw_bam_record;
 pub mod sequence;
@@ -60,6 +61,9 @@ pub use fields::{
 
 // -- bin (reg2bin) --
 pub use bin::{UNMAPPED_BIN, bin_from_raw_bam, reg2bin, set_bin_from_raw_bam};
+
+// -- hash --
+pub use hash::{fgbio_read_name_rank, htsjdk_murmur3_hash_unencoded_chars};
 
 // -- builder --
 pub use builder::{ReadNameTooLong, SamBuilder, UnmappedSamBuilder};

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -235,7 +235,15 @@ pub struct Codec {
     #[arg(short = 'M', long = "min-reads", default_value = "1")]
     pub min_reads: usize,
 
-    /// Maximum read pairs per strand, downsample if exceeded (fgbio's `--max-read-pairs`)
+    /// Maximum read pairs per strand, downsample if exceeded (fgbio's `--max-read-pairs`).
+    ///
+    /// If more than this many read pairs are present in a tag family, the family is downsampled
+    /// to exactly this many read pairs.
+    ///
+    /// Which pairs are retained is determined by a hash of the read names, so the selection is
+    /// reproducible across runs, thread counts, and execution modes. The cap selects whole pairs
+    /// — R1 and R2 are indexed by one shared selection — so both ends of a template are always
+    /// retained or discarded together.
     #[arg(long = "max-reads")]
     pub max_reads: Option<usize>,
 

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -199,7 +199,17 @@ pub struct Duplex {
     #[arg(short = 'M', long = "min-reads", value_delimiter = ',', default_value = "1")]
     pub min_reads: Vec<usize>,
 
-    /// Maximum reads per strand (downsample if exceeded)
+    /// Maximum number of reads to use when building a single-strand consensus.
+    ///
+    /// If more than this many reads are present for a strand, that strand is downsampled to
+    /// exactly this many reads. The cap is applied independently to each end of each strand.
+    ///
+    /// Which reads are retained is determined by a hash of the read names, so the selection is
+    /// reproducible across runs, thread counts, and execution modes. Mates share a read name and
+    /// therefore a rank, so both ends of a template are normally retained or discarded together;
+    /// because each end is capped independently, a template whose R1 survives upstream alignment
+    /// filtering while its R2 does not can shift the cap boundary on one end alone, and then the
+    /// two ends' retained subsets diverge. This matches fgbio's structure.
     #[arg(long = "max-reads-per-strand")]
     pub max_reads_per_strand: Option<usize>,
 

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -618,6 +618,17 @@ impl Duplex {
         // been created, so relying on the constructor alone would turn an argument error
         // into a mid-run worker failure that leaves a partial output file behind.
         DuplexConsensusCaller::validate_min_reads(&self.min_reads)?;
+
+        // `--max-reads-per-strand 0` empties every strand, so no molecule can produce a
+        // consensus. fgbio failed deep in consensus calling with a bare
+        // `IllegalArgumentException` (fixed in fulcrumgenomics/fgbio#1166); fgumi was quieter
+        // still, exiting 0 having written an empty BAM. Only a lower bound is checked here,
+        // matching fgbio: unlike `simplex` and `codec`, duplex cannot compare the cap against
+        // `--min-reads` (a vector with its own ordering rule), and a cap below it is already
+        // handled gracefully -- `consensus_call` returns no consensus rather than panicking.
+        if self.max_reads_per_strand == Some(0) {
+            bail!("--max-reads-per-strand must be >= 1");
+        }
         Ok(())
     }
 
@@ -1260,6 +1271,63 @@ mod tests {
             duplex.validate().is_ok(),
             expect_ok,
             "validate() disagreed with the --min-reads contract for {min_reads:?}"
+        );
+    }
+
+    /// A cap of zero empties every strand, so no consensus can be built from any molecule.
+    /// fgbio failed deep in consensus calling with a bare `IllegalArgumentException`
+    /// (`CallDuplexConsensusReads`, fixed in fulcrumgenomics/fgbio#1166); fgumi was quieter
+    /// still — it exited 0 having written an empty BAM. simplex and codec already reject
+    /// their equivalents, so this closes the gap.
+    ///
+    /// Only a lower bound is applied, matching fgbio, rather than simplex/codec's stronger
+    /// `max >= min_reads`: duplex's `--min-reads` is a vector of up to three values with its
+    /// own ordering rule, and a cap below it is already handled gracefully — `consensus_call`
+    /// returns no consensus rather than panicking.
+    #[rstest]
+    #[case::zero_rejected(Some(0), false)]
+    #[case::one_accepted(Some(1), true)]
+    #[case::typical_accepted(Some(50), true)]
+    #[case::unset_accepted(None, true)]
+    fn test_validate_max_reads_per_strand(
+        #[case] max_reads_per_strand: Option<usize>,
+        #[case] expect_ok: bool,
+    ) {
+        let mut duplex =
+            create_duplex_with_paths(PathBuf::from("test.bam"), PathBuf::from("output.bam"));
+        duplex.max_reads_per_strand = max_reads_per_strand;
+        assert_eq!(
+            duplex.validate().is_ok(),
+            expect_ok,
+            "validate() disagreed with the --max-reads-per-strand contract for \
+             {max_reads_per_strand:?}"
+        );
+    }
+
+    /// fgbio validates `--max-reads-per-strand >= 1` because its option is an `Option[Int]`
+    /// and so accepts negatives. fgumi's is an `Option<usize>`, so clap rejects a negative at
+    /// parse time and `validate()` never sees it — the guard above only has to cover zero.
+    ///
+    /// Uses the attached `=-1` form and asserts the error *kind*, because both of those are
+    /// what make this test about the field's type. With the space-separated form clap rejects a
+    /// bare `-1` as a flag-shaped token (`UnknownArgument`) whatever the field type is, so that
+    /// spelling passes identically for an `Option<i64>` — the very shape this docstring claims
+    /// would need a runtime guard.
+    #[test]
+    fn test_negative_max_reads_per_strand_fails_to_parse() {
+        let parsed = Duplex::try_parse_from([
+            "duplex",
+            "--input",
+            "in.bam",
+            "--output",
+            "out.bam",
+            "--max-reads-per-strand=-1",
+        ]);
+        let error = parsed.expect_err("a negative --max-reads-per-strand must fail at parse time");
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::ValueValidation,
+            "the value must be rejected by the `usize` parser, not as an unknown argument"
         );
     }
 

--- a/src/lib/commands/shared_metrics.rs
+++ b/src/lib/commands/shared_metrics.rs
@@ -143,60 +143,20 @@ fn unclipped_five_prime_position_raw(record: &RawRecord) -> Option<i32> {
 /// and convert the read name to UTF-16 code units before hashing.
 #[must_use]
 pub fn compute_hash_fraction(read_name: &str) -> f64 {
-    let chars: Vec<u16> = read_name.encode_utf16().collect();
-    let hash = htsjdk_murmur3_hash_unencoded_chars(&chars, 42);
+    // SAM restricts read names to printable ASCII, and for those the UTF-16 code units htsjdk
+    // hashes are exactly the bytes widened — so the byte entry point is identical here and
+    // avoids a per-read `Vec<u16>`. A non-ASCII name violates the spec but must still hash the
+    // way htsjdk would, so it takes the widening path.
+    let hash = if read_name.is_ascii() {
+        fgumi_raw_bam::hash::fgbio_read_name_rank(read_name.as_bytes())
+    } else {
+        let chars: Vec<u16> = read_name.encode_utf16().collect();
+        fgumi_raw_bam::hash::htsjdk_murmur3_hash_unencoded_chars(&chars, 42)
+    };
     // `wrapping_abs` mirrors Java `Math.abs` (which returns `Int.MinValue`
     // unchanged when the input is `Int.MinValue`) so the rare edge case
     // produces the same downsample decision as fgbio.
     f64::from(hash.wrapping_abs()) / f64::from(i32::MAX)
-}
-
-/// Port of htsjdk `Murmur3.hashUnencodedChars` (Apache-2.0; derived from
-/// Guava's Apache-2.0 `Murmur3_32`; original `MurmurHash3` is public domain).
-/// `chars` is the Java `CharSequence` / UTF-16 code units.
-fn htsjdk_murmur3_hash_unencoded_chars(chars: &[u16], seed: i32) -> i32 {
-    let mut h1: u32 = seed as u32;
-    let length = chars.len();
-
-    let mut i = 1;
-    while i < length {
-        let k1 = u32::from(chars[i - 1]) | (u32::from(chars[i]) << 16);
-        h1 = murmur3_mix_h1(h1, murmur3_mix_k1(k1));
-        i += 2;
-    }
-
-    if length & 1 == 1 {
-        let k1 = murmur3_mix_k1(u32::from(chars[length - 1]));
-        h1 ^= k1;
-    }
-
-    murmur3_fmix(h1, (2 * length) as u32) as i32
-}
-
-#[inline]
-fn murmur3_mix_k1(mut k1: u32) -> u32 {
-    k1 = k1.wrapping_mul(0xcc9e_2d51);
-    k1 = k1.rotate_left(15);
-    k1 = k1.wrapping_mul(0x1b87_3593);
-    k1
-}
-
-#[inline]
-fn murmur3_mix_h1(mut h1: u32, k1: u32) -> u32 {
-    h1 ^= k1;
-    h1 = h1.rotate_left(13);
-    h1.wrapping_mul(5).wrapping_add(0xe654_6b64)
-}
-
-#[inline]
-fn murmur3_fmix(mut h1: u32, length: u32) -> u32 {
-    h1 ^= length;
-    h1 ^= h1 >> 16;
-    h1 = h1.wrapping_mul(0x85eb_ca6b);
-    h1 ^= h1 >> 13;
-    h1 = h1.wrapping_mul(0xc2b2_ae35);
-    h1 ^= h1 >> 16;
-    h1
 }
 
 /// Parses an intervals file in BED or Picard interval list format.
@@ -785,7 +745,7 @@ mod tests {
     #[case("NB500947:HT3JMBGX2:1:11101:19204:10048", -1_636_484_024)]
     fn test_murmur3_matches_htsjdk_reference_vectors(#[case] name: &str, #[case] expected: i32) {
         let chars: Vec<u16> = name.encode_utf16().collect();
-        let got = htsjdk_murmur3_hash_unencoded_chars(&chars, 42);
+        let got = fgumi_raw_bam::hash::htsjdk_murmur3_hash_unencoded_chars(&chars, 42);
         assert_eq!(got, expected, "Murmur3 mismatch on {name:?}");
     }
 

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -209,10 +209,16 @@ pub struct Simplex {
     #[arg(short = 'M', long = "min-reads")]
     pub min_reads: usize,
 
-    /// Maximum reads to use per tag family (downsample if exceeded). Note: over-sized families are
-    /// downsampled with a different pseudo-random generator than fgbio's Scala `Random`, so which
-    /// reads survive (and therefore the consensus of a downsampled family) is not bit-identical to
-    /// fgbio, though it is deterministic within fgumi for a given input.
+    /// Maximum reads to use per tag family (downsample if exceeded).
+    ///
+    /// Which reads are retained is determined by a hash of the read names, so the selection is
+    /// reproducible across runs, thread counts, and execution modes.
+    ///
+    /// Note the cap applies to the whole tag family rather than to each end independently, unlike
+    /// fgbio (fgumi#723). Mates share a read name and therefore a rank, so the two ends of a
+    /// template sort together, but the cap counts records: a template straddling the cap boundary
+    /// keeps one end and drops the other, which can push that end below `--min-reads` and reject
+    /// the family.
     #[arg(long = "max-reads")]
     pub max_reads: Option<usize>,
 
@@ -368,7 +374,6 @@ impl Command for Simplex {
             min_reads: self.min_reads,
             max_reads: self.max_reads,
             produce_per_base_tags: self.consensus.output_per_base_tags,
-            seed: Some(42), // Hard-coded seed for reproducible downsampling
             trim: self.consensus.trim,
             min_consensus_base_quality: self.consensus.min_consensus_base_quality,
             cell_tag: Some(cell_tag),
@@ -584,7 +589,6 @@ impl Simplex {
             min_reads,
             max_reads,
             produce_per_base_tags: output_per_base_tags,
-            seed: Some(42),
             trim,
             min_consensus_base_quality,
             cell_tag: Some(cell_tag),

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -20,6 +20,7 @@ mod test_compare_bams;
 mod test_compare_metrics_command;
 #[cfg(feature = "compare")]
 mod test_compare_mutation;
+mod test_consensus_downsampling;
 mod test_correct_command;
 mod test_dedup_command;
 mod test_downsample_command;

--- a/tests/integration/test_consensus_downsampling.rs
+++ b/tests/integration/test_consensus_downsampling.rs
@@ -1,0 +1,476 @@
+//! Determinism regression tests for consensus downsampling.
+//!
+//! Downsampling used to select which reads to keep by shuffling with a seeded RNG held on
+//! the consensus caller. The RNG is stateful, so the surviving subset for a family depended
+//! on how many families that caller instance had already processed.
+//!
+//! fgumi never had fgbio's thread-count bug — the unified pipeline builds a fresh caller per
+//! batch at a fixed batch size, so `--threads 1` and `--threads 8` agreed. But the
+//! no-`--threads` path holds a single caller for the entire run, putting its RNG at a
+//! different position for every family, so the two execution *modes* disagreed under a cap.
+//! On a ~77k-molecule library that diverged on 566 of 77,804 duplex records (0.73%).
+//!
+//! Ranking reads by a Murmur3 hash of the read name makes the retained subset a pure
+//! function of the family, so every mode agrees. These tests pin that.
+//!
+//! Two properties of the fixtures are load-bearing, and a test that loses either would pass
+//! vacuously — including against the old shuffle:
+//!
+//! 1. **Reads within a family differ in sequence.** If every read were identical, any
+//!    selection would yield the same consensus and no divergence could be observed.
+//! 2. **The family count exceeds the pipeline's per-batch group count** (50 for simplex, 100
+//!    for duplex). The caller is constructed once per batch, so a single-batch input would
+//!    put every family at the same RNG position and hide the divergence entirely.
+//!
+//! Uncapped runs always agreed across modes; the uncapped cases guard the default
+//! configuration against a regression.
+
+use clap::Parser;
+use fgumi_lib::commands::command::Command;
+use fgumi_lib::commands::duplex::Duplex;
+use fgumi_lib::commands::simplex::Simplex;
+use fgumi_lib::sam::SamTag;
+use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
+use noodles::bam;
+use noodles::sam::Header;
+use noodles::sam::alignment::io::Write as AlignmentWrite;
+use noodles::sam::alignment::record::data::field::Value;
+use noodles::sam::alignment::record::data::field::value::Array;
+use noodles::sam::alignment::record::data::field::value::array::Values;
+use rstest::rstest;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+use crate::helpers::bam_generator::{create_minimal_header, to_record_buf};
+
+/// The fields that must match across execution modes for two runs to be identical.
+///
+/// Compared field by field rather than by `Debug`-formatting the whole record, so a failure
+/// names the field that diverged and the assertion cannot be weakened by a change to any
+/// type's `Debug` implementation. Sequence and the consensus tags are what a change in
+/// *which* reads were retained actually moves.
+#[derive(Debug, PartialEq, Eq)]
+struct RecordFingerprint {
+    name: Vec<u8>,
+    flags: u16,
+    sequence: Vec<u8>,
+    quality_scores: Vec<u8>,
+    tags: Vec<(String, String)>,
+}
+
+/// Renders an aux value canonically, by matching the value's own type rather than formatting
+/// it with `Debug`.
+///
+/// Keeps the fingerprint's promise that no type's `Debug` implementation can weaken the
+/// comparison: every variant is rendered from its actual contents, floats through their bit
+/// pattern so the comparison stays exact.
+fn render_tag_value(value: &Value<'_>) -> String {
+    match value {
+        Value::Character(c) => format!("A:{}", char::from(*c)),
+        Value::Int8(_)
+        | Value::UInt8(_)
+        | Value::Int16(_)
+        | Value::UInt16(_)
+        | Value::Int32(_)
+        | Value::UInt32(_) => {
+            format!("i:{}", value.as_int().expect("integer variant has an integer value"))
+        }
+        Value::Float(f) => format!("f:{:#010x}", f.to_bits()),
+        Value::String(s) => format!("Z:{s}"),
+        Value::Hex(s) => format!("H:{s}"),
+        Value::Array(array) => format!("B:{}", render_array(array)),
+    }
+}
+
+/// Renders an aux array as `<subtype>:<comma-separated values>`.
+fn render_array(array: &Array<'_>) -> String {
+    fn join<N: std::fmt::Display>(values: &(dyn Values<'_, N> + '_)) -> String {
+        values
+            .iter()
+            .map(|v| v.expect("read array value").to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+    match array {
+        Array::Int8(v) => format!("c:{}", join(v.as_ref())),
+        Array::UInt8(v) => format!("C:{}", join(v.as_ref())),
+        Array::Int16(v) => format!("s:{}", join(v.as_ref())),
+        Array::UInt16(v) => format!("S:{}", join(v.as_ref())),
+        Array::Int32(v) => format!("i:{}", join(v.as_ref())),
+        Array::UInt32(v) => format!("I:{}", join(v.as_ref())),
+        Array::Float(v) => {
+            let bits: Vec<String> =
+                v.iter().map(|f| format!("{:#010x}", f.expect("read value").to_bits())).collect();
+            format!("f:{}", bits.join(","))
+        }
+    }
+}
+
+/// The largest value of an integer aux tag across every record of a BAM.
+///
+/// `cD` is the number of raw reads that contributed to a consensus, so this is the absolute
+/// oracle for "the cap actually capped": no consensus may be built from more reads than the cap
+/// allows, whatever execution mode produced it.
+fn max_int_tag(path: &Path, tag: SamTag) -> Option<i64> {
+    let mut reader = bam::io::Reader::new(fs::File::open(path).expect("open output BAM"));
+    let _header = reader.read_header().expect("read header");
+    reader
+        .records()
+        .filter_map(|result| {
+            let record = result.expect("read record");
+            record.data().get(tag.as_ref()).map(|value| {
+                value.expect("read aux field").as_int().expect("depth tag is an integer")
+            })
+        })
+        .max()
+}
+
+/// Reads every record of a BAM into a comparable fingerprint, in file order.
+fn fingerprints(path: &Path) -> Vec<RecordFingerprint> {
+    let mut reader = bam::io::Reader::new(fs::File::open(path).expect("open output BAM"));
+    let _header = reader.read_header().expect("read header");
+    reader
+        .records()
+        .map(|result| {
+            let record = result.expect("read record");
+            let mut tags: Vec<(String, String)> = record
+                .data()
+                .iter()
+                .map(|field| {
+                    let (tag, value) = field.expect("read aux field");
+                    (String::from_utf8_lossy(tag.as_ref()).into_owned(), render_tag_value(&value))
+                })
+                .collect();
+            // Aux field ordering is not part of the contract; the set of values is.
+            tags.sort();
+            RecordFingerprint {
+                name: record.name().map(|n| n.to_vec()).unwrap_or_default(),
+                flags: record.flags().bits(),
+                sequence: record.sequence().iter().collect::<Vec<u8>>(),
+                quality_scores: record.quality_scores().as_ref().to_vec(),
+                tags,
+            }
+        })
+        .collect()
+}
+
+/// An 8bp sequence carrying a single `C` at `offset % 8`, the rest `A`.
+///
+/// Gives each read in a family distinct content so *which* reads survive a cap is visible in
+/// the consensus, not merely in its depth.
+fn distinguishing_sequence(offset: usize) -> String {
+    let mut bases = vec![b'A'; 8];
+    bases[offset % 8] = b'C';
+    String::from_utf8(bases).expect("ASCII bases")
+}
+
+/// Writes `records` as a BAM with a minimal single-reference header.
+fn write_bam(path: &Path, header: &Header, records: &[RawRecord]) {
+    let mut writer = bam::io::Writer::new(fs::File::create(path).expect("create BAM"));
+    writer.write_header(header).expect("write header");
+    for raw in records {
+        writer.write_alignment_record(header, &to_record_buf(raw)).expect("write record");
+    }
+    writer.try_finish().expect("finish BAM");
+}
+
+/// One `MI`-tagged FR read pair for the simplex fixture.
+fn simplex_pair(name: &str, mi: &str, sequence: &str) -> (RawRecord, RawRecord) {
+    let seq = sequence.as_bytes();
+    let read_len = seq.len();
+    let cigar_op = u32::try_from(read_len).expect("read_len fits u32") << 4;
+    let span = i32::try_from(read_len + 100).expect("template span fits i32");
+
+    let build = |first: bool| {
+        let (pos, mate_pos, rev, mate_rev) =
+            if first { (100, 200, false, true) } else { (200, 100, true, false) };
+        let segment = if first { flags::FIRST_SEGMENT } else { flags::LAST_SEGMENT };
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .sequence(seq)
+            .qualities(&vec![30u8; read_len])
+            .flags(
+                flags::PAIRED
+                    | segment
+                    | if rev { flags::REVERSE } else { 0 }
+                    | if mate_rev { flags::MATE_REVERSE } else { 0 },
+            )
+            .ref_id(0)
+            .pos(pos - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar_op])
+            .mate_ref_id(0)
+            .mate_pos(mate_pos - 1)
+            .template_length(if first { span } else { -span })
+            .add_string_tag(SamTag::MI, mi.as_bytes());
+        b.build()
+    };
+
+    (build(true), build(false))
+}
+
+/// One `MI`-tagged read pair on the `/A` (FR) or `/B` (RF) strand for the duplex fixture.
+///
+/// The orientation is the point: the duplex caller pairs an FR template with the RF template
+/// at the same coordinates, so wrong flags or mate positions silently yield two single-strand
+/// molecules instead of one duplex.
+fn duplex_pair(name: &str, mi: &str, sequence: &str, is_b_strand: bool) -> (RawRecord, RawRecord) {
+    let seq = sequence.as_bytes();
+    let read_len = seq.len();
+    let cigar_op = u32::try_from(read_len).expect("read_len fits u32") << 4;
+    let span = i32::try_from(read_len + 100).expect("template span fits i32");
+
+    let (r1_start, r2_start, r1_rev, r2_rev) =
+        if is_b_strand { (200, 100, true, false) } else { (100, 200, false, true) };
+    let tlen = if is_b_strand { -span } else { span };
+
+    let build = |first: bool| {
+        let (pos, mate_pos, rev, mate_rev) = if first {
+            (r1_start, r2_start, r1_rev, r2_rev)
+        } else {
+            (r2_start, r1_start, r2_rev, r1_rev)
+        };
+        let segment = if first { flags::FIRST_SEGMENT } else { flags::LAST_SEGMENT };
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .sequence(seq)
+            .qualities(&vec![30u8; read_len])
+            .flags(
+                flags::PAIRED
+                    | segment
+                    | if rev { flags::REVERSE } else { 0 }
+                    | if mate_rev { flags::MATE_REVERSE } else { 0 },
+            )
+            .ref_id(0)
+            .pos(pos - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar_op])
+            .mate_ref_id(0)
+            .mate_pos(mate_pos - 1)
+            .template_length(if first { tlen } else { -tlen })
+            .add_string_tag(SamTag::RX, b"AAA-TTT")
+            .add_string_tag(SamTag::MI, mi.as_bytes());
+        b.build()
+    };
+
+    (build(true), build(false))
+}
+
+/// Builds a grouped BAM of `families` MI families, each with `depth` read pairs.
+fn write_simplex_input(path: &Path, families: usize, depth: usize) {
+    let header = create_minimal_header("chr1", 10_000);
+    let mut records: Vec<RawRecord> = Vec::new();
+    for family in 0..families {
+        for read in 0..depth {
+            let (r1, r2) = simplex_pair(
+                &format!("f{family}:{read}"),
+                &format!("{family}"),
+                &distinguishing_sequence(read),
+            );
+            records.push(r1);
+            records.push(r2);
+        }
+    }
+    write_bam(path, &header, &records);
+}
+
+/// Builds a duplex-grouped BAM: `families` molecules, each with `depth_per_strand` read
+/// pairs on `/A` and on `/B`.
+fn write_duplex_input(path: &Path, families: usize, depth_per_strand: usize) {
+    let header = create_minimal_header("chr1", 10_000);
+    let mut records: Vec<RawRecord> = Vec::new();
+    for family in 0..families {
+        for (suffix, is_b_strand) in [("A", false), ("B", true)] {
+            for read in 0..depth_per_strand {
+                let (r1, r2) = duplex_pair(
+                    &format!("m{family}{suffix}:{read}"),
+                    &format!("{family}/{suffix}"),
+                    &distinguishing_sequence(read),
+                    is_b_strand,
+                );
+                records.push(r1);
+                records.push(r2);
+            }
+        }
+    }
+    write_bam(path, &header, &records);
+}
+
+/// Where a labelled run of `command` writes its output.
+fn output_path(dir: &Path, command: &str, label: &str) -> PathBuf {
+    dir.join(format!("{command}.{label}.bam"))
+}
+
+/// Asserts that a cap actually constrained the output, in two independent ways.
+///
+/// Without this, the cross-mode assertions alone are satisfied by an implementation that ignores
+/// the cap in *every* mode — dropping the option from both the sequential and the threaded
+/// construction sites leaves all three runs equal and uncapped, and equally green.
+///
+/// The depth tags are the absolute check (no consensus may be built from more raw reads than
+/// the cap allows); the comparison against the uncapped baseline is the relative one, and catches
+/// a cap that is honoured but has no effect on this fixture.
+///
+/// `depth_tags` must name the depths the cap actually bounds. For `simplex --max-reads` that is
+/// the combined `cD`; for `duplex --max-reads-per-strand` it is the per-strand `aD` and `bD` —
+/// `cD` sums both strands and legitimately reaches twice the cap.
+fn assert_cap_took_effect(
+    capped: &[RecordFingerprint],
+    uncapped: &[RecordFingerprint],
+    capped_bam: &Path,
+    cap: &str,
+    depth_tags: &[SamTag],
+) {
+    let cap: i64 = cap.parse().expect("cap is numeric");
+    for &tag in depth_tags {
+        let name = String::from_utf8_lossy(tag.as_ref()).into_owned();
+        let max_depth =
+            max_int_tag(capped_bam, tag).unwrap_or_else(|| panic!("no record carries {name}"));
+        assert!(
+            max_depth <= cap,
+            "a consensus used {max_depth} raw reads ({name}), exceeding the cap of {cap}"
+        );
+    }
+    assert_ne!(
+        capped, uncapped,
+        "capped output is identical to the uncapped run, so the cap changed nothing"
+    );
+}
+
+/// Runs `simplex` with the given cap and thread setting, returning the output fingerprints.
+fn run_simplex(
+    dir: &Path,
+    input: &Path,
+    label: &str,
+    cap: Option<&str>,
+    threads: Option<&str>,
+) -> Vec<RecordFingerprint> {
+    let output = output_path(dir, "simplex", label);
+    let mut args: Vec<String> = vec![
+        "simplex".into(),
+        "--input".into(),
+        input.to_str().expect("utf-8 path").into(),
+        "--output".into(),
+        output.to_str().expect("utf-8 path").into(),
+        "--min-reads".into(),
+        "1".into(),
+        "--compression-level".into(),
+        "1".into(),
+    ];
+    if let Some(cap) = cap {
+        args.push("--max-reads".into());
+        args.push(cap.into());
+    }
+    if let Some(threads) = threads {
+        args.push("--threads".into());
+        args.push(threads.into());
+    }
+    let cmd = Simplex::try_parse_from(&args).expect("parse simplex args");
+    cmd.execute("fgumi simplex").expect("simplex should succeed");
+    fingerprints(&output)
+}
+
+/// Runs `duplex` with the given cap and thread setting, returning the output fingerprints.
+fn run_duplex(
+    dir: &Path,
+    input: &Path,
+    label: &str,
+    cap: Option<&str>,
+    threads: Option<&str>,
+) -> Vec<RecordFingerprint> {
+    let output = output_path(dir, "duplex", label);
+    let mut args: Vec<String> = vec![
+        "duplex".into(),
+        "--input".into(),
+        input.to_str().expect("utf-8 path").into(),
+        "--output".into(),
+        output.to_str().expect("utf-8 path").into(),
+        "--min-reads".into(),
+        "1".into(),
+        "--compression-level".into(),
+        "1".into(),
+    ];
+    if let Some(cap) = cap {
+        args.push("--max-reads-per-strand".into());
+        args.push(cap.into());
+    }
+    if let Some(threads) = threads {
+        args.push("--threads".into());
+        args.push(threads.into());
+    }
+    let cmd = Duplex::try_parse_from(&args).expect("parse duplex args");
+    cmd.execute("fgumi duplex").expect("duplex should succeed");
+    fingerprints(&output)
+}
+
+/// `simplex` output must not depend on which execution mode produced it.
+///
+/// The capped case is the regression: before hash-based selection, `--threads N` and the
+/// no-`--threads` path retained different reads. The uncapped case guards the default
+/// configuration, which was always mode-independent and must stay so.
+/// The odd cap is not redundant with the even one: reads within a family arrive interleaved
+/// R1/R2 and mates share a rank, so a cap of 2 lands exactly on a tie boundary and never
+/// consults the stable sort, while a cap of 3 lands *inside* one — making arrival order, the
+/// last selection input that is not a pure function of the family, observable across modes.
+#[rstest]
+#[case::capped(Some("2"))]
+#[case::capped_odd(Some("3"))]
+#[case::uncapped(None)]
+fn simplex_output_is_identical_across_execution_modes(#[case] cap: Option<&str>) {
+    let temp = TempDir::new().expect("temp dir");
+    let input = temp.path().join("grouped.bam");
+    write_simplex_input(&input, 60, 6);
+
+    let single = run_simplex(temp.path(), &input, "t1", cap, Some("1"));
+    let many = run_simplex(temp.path(), &input, "t8", cap, Some("8"));
+    let no_threads = run_simplex(temp.path(), &input, "none", cap, None);
+
+    assert!(!single.is_empty(), "expected consensus reads to be produced");
+    assert_eq!(single, many, "--threads 1 and --threads 8 must produce identical output");
+    assert_eq!(single, no_threads, "--threads and no-threads must produce identical output");
+
+    if let Some(cap) = cap {
+        let uncapped = run_simplex(temp.path(), &input, "uncapped", None, Some("1"));
+        assert_cap_took_effect(
+            &single,
+            &uncapped,
+            &output_path(temp.path(), "simplex", "t1"),
+            cap,
+            &[SamTag::CD],
+        );
+    }
+}
+
+/// `duplex` output must not depend on which execution mode produced it.
+///
+/// This is the path where the divergence was measured on real data: 566 of 77,804 records
+/// differed between `--threads N` and the no-threads path at `--max-reads-per-strand 2`.
+#[rstest]
+#[case::capped(Some("2"))]
+#[case::capped_odd(Some("3"))]
+#[case::uncapped(None)]
+fn duplex_output_is_identical_across_execution_modes(#[case] cap: Option<&str>) {
+    let temp = TempDir::new().expect("temp dir");
+    let input = temp.path().join("duplex-grouped.bam");
+    write_duplex_input(&input, 120, 4);
+
+    let single = run_duplex(temp.path(), &input, "t1", cap, Some("1"));
+    let many = run_duplex(temp.path(), &input, "t8", cap, Some("8"));
+    let no_threads = run_duplex(temp.path(), &input, "none", cap, None);
+
+    assert!(!single.is_empty(), "expected duplex consensus reads to be produced");
+    assert_eq!(single, many, "--threads 1 and --threads 8 must produce identical output");
+    assert_eq!(single, no_threads, "--threads and no-threads must produce identical output");
+
+    if let Some(cap) = cap {
+        let uncapped = run_duplex(temp.path(), &input, "uncapped", None, Some("1"));
+        assert_cap_took_effect(
+            &single,
+            &uncapped,
+            &output_path(temp.path(), "duplex", "t1"),
+            cap,
+            &[SamTag::AD, SamTag::BD],
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Consensus downsampling selected which reads to keep by shuffling with a seeded `StdRng` held on the consensus caller:

```rust
reads.shuffle(&mut self.rng);
reads.truncate(max_reads);
```

The RNG is stateful, so which reads survive a tag family depends on how many families that caller instance has already downsampled.

fgumi does **not** have fgbio's thread-count bug. The unified pipeline builds a fresh caller per batch at a fixed batch size, so `--threads 1` and `--threads 8` already agreed — I verified this byte-for-byte. But the no-`--threads` path holds a single caller for the entire run (`simplex.rs:378`, `duplex.rs:420`), putting its RNG at a different position for every family. The two execution *modes* therefore disagreed under a cap:

- duplex `--max-reads-per-strand 2`: **566 of 77,804 consensus records differed** (0.73%) between `--threads N` and no-`--threads`
- simplex `--max-reads 2`: differed
- **with no cap, both modes were byte-identical** — the divergence is cap-specific

Two further consequences of RNG-based selection:

- **Both ends of a template were downsampled independently.** duplex calls `consensus_call` once per strand per end (`duplex_caller.rs:1992-1995`), so R1 and R2 sampled different templates. Beyond reproducibility, this silently *lost* reads: families whose split left one end empty produced no consensus pair at all.
- **Selection could not match fgbio.** fgumi shuffles with `StdRng` (ChaCha); fgbio uses `java.util.Random` (an LCG). Against fgbio 4.1.0 at `--max-reads-per-strand 2`, 487 of 77,804 duplex records (0.63%) differed in SEQ/QUAL. Depth distributions matched exactly, so selection was the only difference. This was already documented as a known limitation in `downsample_source_reads`.

## Fix

Rank reads by a Murmur3 hash of the read name and keep the lowest-ranking ones, porting fulcrumgenomics/fgbio#1166. The retained subset becomes a pure function of the family — independent of caller history, execution mode, and arrival order — and because mates share a read name they share a rank, so a template is retained or discarded as a unit.

fgumi already contained a byte-exact port of htsjdk's `Murmur3.hashUnencodedChars`, validated against reference vectors captured from htsjdk 3.1.2. It moves from the root crate down into `fgumi-raw-bam`, where the consensus callers can reach it, alongside the samtools-parity read-name comparator already living there.

Three details are load-bearing for parity, and each has a dedicated test:

- The rank is computed **once per read** and stored on `SourceRead` / `ClippedRecordInfo`, never inside a sort key closure. Rust's `sort_by_key` may evaluate its closure more than once per element, so hashing there would re-hash on every comparison — the same defect the review of fgbio#1166 flagged in its Scala (25–30× the element count at n=100k).
- Ranks compare as **signed `i32`**, matching fgbio's Scala `Int`. About half of all read names hash negative, so an unsigned comparison silently reorders them.
- The sort is **stable**, matching Scala's `sortInPlaceBy`, so tied ranks keep input order.

Selection now lives in one place, `caller::select_lowest_ranking`, shared by the raw-record and codec paths. With no RNG left on the caller there is no per-instance state for downsampling to depend on, so the `seed` option and the `rand` dependency are removed — the determinism is structural rather than incidental.

## Behaviour changes

**1. Which reads are retained differs from previous releases** for any run that sets `--max-reads`, `--max-reads-per-strand`, or codec `--max-reads`. There is no way to fix the reproducibility bug while preserving the old selection, since the old selection *was* the bug. Runs without a cap are byte-identical, verified against a pre-change binary.

**2. Both ends of a template are now retained or discarded together**, which also recovers reads the old shuffle lost. On a 77k-molecule library:

| | reads emitted | `cD` distribution |
|---|---|---|
| before | 726,854 | `1`: 726,854 |
| after | 734,536 | `1`: 734,536 |
| fgbio 4.1.0 | 734,536 | `1`: 702,047 · `2`: 32,489 |

The count now matches fgbio. The depth does not, because simplex still applies the cap to the whole tag family rather than to each end — tracked separately as #723, and deliberately not fixed here.

**3. `duplex --max-reads-per-strand 0` is now rejected** (second commit). It previously exited 0 having written an empty BAM.

## Tests

Every selection test was verified **red under a mutant that breaks the property it claims to guard**, not merely green afterward:

- the subset is independent of how many families the caller downsampled previously
- the subset is invariant to input read order
- signed comparison — mutating to `wrapping_abs` (the abs form that exists elsewhere in this repo) fails it
- stability — mutating to `sort_unstable_by_key` fails it, using mixed tied/distinct keys at n=30, since all-equal keys can never separate stable from unstable
- both ends of a template retained together — a `hash(name + end)` mutant fails exactly this test and nothing else
- a golden test pinning *which* reads are retained, derived independently from htsjdk `Murmur3(42)` by running real htsjdk. Without it, a deterministic-but-*biased* rule passes everything above — sorting by read name, which on Illumina names sorts by tile/x/y, would systematically favour one region of the flowcell.

Plus the regression test for the bug that is actually live in fgumi: capped output must be identical across `--threads 1`, `--threads 8`, and no-`--threads`, for simplex and duplex. **Verified failing at `e2ad27bf`** — both capped cases fail, both uncapped cases pass.

Full suite: 7182 passed, 30 skipped.

## Deliberately not included

**No fgbio byte-parity oracle.** fgbio#1166 is still open, so there is nothing stable to pin against; a fixture generated from released 4.1.0 would disagree by design, since it still uses the shuffle. Once that PR merges, this change also restores byte parity under a cap, and the oracle can follow. This is a known gap, not an oversight.

Also out of scope, both filed: **#723** (simplex caps the whole MI group instead of each end) and **#724** / fulcrumgenomics/fgbio#1167 (reads dropped by downsampling are counted as used in `raw_reads_used` and never reach `--rejects` — pre-existing and shared with fgbio).

## Reading order

Two commits, mirroring fgbio#1166's structure. Both build and test standalone.

1. `fix(consensus)!: make consensus read downsampling deterministic` — start at `crates/fgumi-raw-bam/src/hash.rs` (the ranking primitive), then `caller::select_lowest_ranking`, then the three call sites in `vanilla_caller.rs` and `codec_caller.rs`.
2. `fix(duplex): reject --max-reads-per-strand 0` — reviewable independently.

Closes #725


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: output changes for capped consensus runs, pinned by signed fgbio-compatible read-name hashes and stable pair selection; `unsafe` changes: none, and CLAUDE.md allowlist changes: none; memory bounds, queue capacity, and thread/backpressure policy changes: none.

- Replaced seeded random downsampling with deterministic lowest signed Murmur3 read-name ranks.
- Preserved input-order stability and retained paired ends together.
- Applied shared selection logic to raw-record, vanilla, and CODEC paths.
- Removed the obsolete RNG and `seed` option.
- Added fgbio-compatible UTF-16 Murmur3 hashing and public hash helpers.
- Added unit, property-based, and integration coverage across execution modes, ordering, ties, pairing, hash vectors, and cap boundaries.
- Rejected `--max-reads-per-strand 0`.
- Updated command documentation.
- Uncapped runs remain byte-identical. Capped runs can retain different reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->