### PR TITLE
feat(bam-io): add the shared grouping and library-lookup domain types (R0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,6 +744,7 @@ dependencies = [
 name = "fgumi-bam-io"
 version = "0.5.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "bgzf",
  "bstr 1.13.0",

--- a/crates/fgumi-bam-io/Cargo.toml
+++ b/crates/fgumi-bam-io/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["bioinformatics", "bam", "sequencing", "ngs"]
 pedantic = { level = "deny", priority = -1 }
 
 [dependencies]
+ahash = { workspace = true }
 fgumi-raw-bam = { workspace = true, features = ["noodles"] }
 fgumi-bgzf = { workspace = true }
 noodles = { workspace = true, features = ["bam", "fasta", "sam", "bgzf", "core", "vcf"] }

--- a/crates/fgumi-bam-io/src/grouping.rs
+++ b/crates/fgumi-bam-io/src/grouping.rs
@@ -1,0 +1,1012 @@
+//! Shared grouping and decoded-record domain types.
+//!
+//! Used by both the group command path (`grouper`, `mi_group`,
+//! `commands::{group,dedup}` in the main crate) and the typed-step pipeline
+//! (`pipeline::steps::group`, `steps::parse::decode`).
+//!
+//! These are BAM-record domain types — pre-computed grouping keys, the
+//! decoded-record representation, the batching-weight and grouper traits.
+//! They live here in `fgumi-bam-io`, next to [`crate::MemoryEstimate`] and
+//! the [`fgumi_raw_bam`] raw-record helpers they operate on, rather than in
+//! the pipeline crate that merely consumes them.
+
+use std::io;
+use std::sync::Arc;
+
+use noodles::sam::alignment::record::data::field::Tag;
+
+use crate::library::LibraryIndex;
+use fgumi_raw_bam::{RawRecord, RawRecordView};
+
+pub use crate::mem_estimate::MemoryEstimate;
+
+// ============================================================================
+// GroupKey - Pre-computed grouping key for fast comparison in Group step
+// ============================================================================
+
+/// Pre-computed grouping key for fast comparison in Group step.
+///
+/// All fields are integers/hashes for O(1) comparison. This is computed during
+/// the parallel Decode step so the serial Group step only does integer comparisons.
+///
+/// For paired-end reads, positions are normalized so the lower position comes first.
+/// For single-end reads, the mate fields use `UNKNOWN_*` sentinel values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct GroupKey {
+    // Position info (normalized: lower position first)
+    /// Reference sequence index for position 1 (lower).
+    pub ref_id1: i32,
+    /// Unclipped 5' position for position 1.
+    pub pos1: i32,
+    /// Strand for position 1 (0=forward, 1=reverse).
+    pub strand1: u8,
+    /// Reference sequence index for position 2 (higher or mate).
+    pub ref_id2: i32,
+    /// Unclipped 5' position for position 2.
+    pub pos2: i32,
+    /// Strand for position 2.
+    pub strand2: u8,
+
+    // Grouping metadata
+    /// Library index (pre-computed from RG tag via header lookup).
+    pub library_idx: u16,
+    /// Hash of cell barcode (0 if none).
+    pub cell_hash: u64,
+
+    // For name-based grouping within position groups
+    /// Hash of QNAME for fast name comparison.
+    pub name_hash: u64,
+}
+
+impl GroupKey {
+    /// Sentinel value for unknown reference ID (unpaired reads).
+    pub const UNKNOWN_REF: i32 = i32::MAX;
+    /// Sentinel value for unknown position (unpaired reads).
+    pub const UNKNOWN_POS: i32 = i32::MAX;
+    /// Sentinel value for unknown strand (unpaired reads).
+    pub const UNKNOWN_STRAND: u8 = u8::MAX;
+
+    /// Create a `GroupKey` for a paired-end read with mate info.
+    ///
+    /// Positions are automatically normalized so the lower position comes first.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn paired(
+        ref_id: i32,
+        pos: i32,
+        strand: u8,
+        mate_ref_id: i32,
+        mate_pos: i32,
+        mate_strand: u8,
+        library_idx: u16,
+        cell_hash: u64,
+        name_hash: u64,
+    ) -> Self {
+        // Normalize: put lower position first (matching ReadInfo behavior)
+        let (ref_id1, pos1, strand1, ref_id2, pos2, strand2) =
+            if (ref_id, pos, strand) <= (mate_ref_id, mate_pos, mate_strand) {
+                (ref_id, pos, strand, mate_ref_id, mate_pos, mate_strand)
+            } else {
+                (mate_ref_id, mate_pos, mate_strand, ref_id, pos, strand)
+            };
+
+        Self { ref_id1, pos1, strand1, ref_id2, pos2, strand2, library_idx, cell_hash, name_hash }
+    }
+
+    /// Create a `GroupKey` for a single-end/unpaired read.
+    #[must_use]
+    pub fn single(
+        ref_id: i32,
+        pos: i32,
+        strand: u8,
+        library_idx: u16,
+        cell_hash: u64,
+        name_hash: u64,
+    ) -> Self {
+        Self {
+            ref_id1: ref_id,
+            pos1: pos,
+            strand1: strand,
+            ref_id2: Self::UNKNOWN_REF,
+            pos2: Self::UNKNOWN_POS,
+            strand2: Self::UNKNOWN_STRAND,
+            library_idx,
+            cell_hash,
+            name_hash,
+        }
+    }
+
+    /// Returns the position-only key for grouping by genomic position.
+    ///
+    /// This is used by `RecordPositionGrouper` to determine if records belong to
+    /// the same position group (ignoring name).
+    #[must_use]
+    pub fn position_key(&self) -> (i32, i32, u8, i32, i32, u8, u16, u64) {
+        (
+            self.ref_id1,
+            self.pos1,
+            self.strand1,
+            self.ref_id2,
+            self.pos2,
+            self.strand2,
+            self.library_idx,
+            self.cell_hash,
+        )
+    }
+}
+
+impl PartialOrd for GroupKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for GroupKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.position_key()
+            .cmp(&other.position_key())
+            .then_with(|| self.name_hash.cmp(&other.name_hash))
+    }
+}
+
+impl Default for GroupKey {
+    fn default() -> Self {
+        Self {
+            ref_id1: Self::UNKNOWN_REF,
+            pos1: Self::UNKNOWN_POS,
+            strand1: Self::UNKNOWN_STRAND,
+            ref_id2: Self::UNKNOWN_REF,
+            pos2: Self::UNKNOWN_POS,
+            strand2: Self::UNKNOWN_STRAND,
+            library_idx: 0,
+            cell_hash: 0,
+            name_hash: 0,
+        }
+    }
+}
+
+// ============================================================================
+// DecodedRecord - Record with pre-computed grouping key
+// ============================================================================
+
+/// A decoded BAM record with its pre-computed grouping key.
+///
+/// This is the output of the Decode step and input to the Group step.
+/// The key is computed during the parallel Decode step so that the
+/// serial Group step only needs to do fast integer comparisons.
+///
+/// # Cached-UMI invariant
+///
+/// `umi_value_offset` / `umi_value_len` cache the position of the UMI value
+/// *within* `data`. The invariant is: **the cache is only valid while `data` is
+/// unmodified.** Any mutation of `data` that could shift or overwrite the UMI
+/// value bytes invalidates the cache. To enforce this cheaply, the sole
+/// mutable-bytes accessor ([`Self::raw_bytes_mut`]) resets the cache to
+/// [`Self::UMI_OFFSET_UNCACHED`] on hand-out, so a `cached_umi()` read after a
+/// mutation falls back to a re-scan instead of slicing stale bytes.
+#[derive(Debug)]
+pub struct DecodedRecord {
+    /// Pre-computed grouping key.
+    pub key: GroupKey,
+    /// Raw BAM record bytes.
+    data: RawRecord,
+    /// Cached record-relative offset of the UMI tag's value bytes (i.e. the
+    /// first byte after the 2-byte tag header and the 1-byte type byte). The
+    /// slice `data[umi_value_offset..umi_value_offset + umi_value_len]` yields
+    /// the UMI bytes without the trailing NUL.
+    ///
+    /// Set to [`Self::UMI_OFFSET_UNCACHED`] when no UMI position was cached
+    /// during decode (UMI tag missing, not Z-typed, or caching disabled).
+    umi_value_offset: u32,
+    /// Cached UMI value length in bytes, paired with `umi_value_offset`.
+    umi_value_len: u16,
+}
+
+impl DecodedRecord {
+    /// Sentinel value for `umi_value_offset` indicating no cached UMI position.
+    /// Chosen as `u32::MAX` so it can never collide with a real BAM record
+    /// offset (BAM records are bounded well under 4 GiB).
+    pub const UMI_OFFSET_UNCACHED: u32 = u32::MAX;
+
+    /// Create a decoded record from raw bytes, skipping noodles decode.
+    ///
+    /// Accepts anything that converts `Into<RawRecord>` (e.g. a bare `Vec<u8>` or
+    /// an already-constructed `RawRecord`).
+    #[must_use]
+    pub fn from_raw_bytes(raw: impl Into<RawRecord>, key: GroupKey) -> Self {
+        Self {
+            key,
+            data: raw.into(),
+            umi_value_offset: Self::UMI_OFFSET_UNCACHED,
+            umi_value_len: 0,
+        }
+    }
+
+    /// Attach a cached UMI value position to this decoded record.
+    ///
+    /// `umi_value_offset` is the record-relative offset of the first UMI value
+    /// byte (after the tag header), and `umi_value_len` is the value length
+    /// (excluding any trailing NUL).
+    pub fn set_cached_umi(&mut self, umi_value_offset: u32, umi_value_len: u16) {
+        self.umi_value_offset = umi_value_offset;
+        self.umi_value_len = umi_value_len;
+    }
+
+    /// Returns the cached UMI bytes (without trailing NUL) if a position was
+    /// recorded during decode and still falls within the raw record bytes.
+    /// Returns `None` if no cache is set or the cached position is out of range.
+    #[must_use]
+    pub fn cached_umi(&self) -> Option<&[u8]> {
+        if self.umi_value_offset == Self::UMI_OFFSET_UNCACHED {
+            return None;
+        }
+        let start = self.umi_value_offset as usize;
+        let end = start.checked_add(self.umi_value_len as usize)?;
+        let value = self.data.as_ref().get(start..end)?;
+        // The cache only ever holds a Z-typed UMI value (NUL-free by the BAM
+        // spec; the trailing NUL is excluded by `set_cached_umi`). If a mutation
+        // shifted the record bytes such that this offset now lands on a different
+        // region, the slice would typically contain an interior NUL — a cheap,
+        // zero-release-cost canary for a stale cache that survived bounds checks.
+        debug_assert!(
+            !value.contains(&0),
+            "stale cached UMI: offset {start} sliced bytes containing an interior NUL \
+             (the record was likely mutated without invalidating the UMI cache)"
+        );
+        Some(value)
+    }
+
+    /// Returns the cached UMI offset ([`Self::UMI_OFFSET_UNCACHED`] when absent)
+    /// and length.
+    #[must_use]
+    pub fn cached_umi_position(&self) -> (u32, u16) {
+        (self.umi_value_offset, self.umi_value_len)
+    }
+
+    /// Returns the cached UMI `(offset, len)` position, or `None` when no
+    /// position was recorded during decode (the [`Self::UMI_OFFSET_UNCACHED`]
+    /// sentinel). Keeps the sentinel check at the owning layer so callers can
+    /// branch on a plain `Option` instead of comparing against the sentinel.
+    #[must_use]
+    pub fn cached_umi_position_opt(&self) -> Option<(u32, u16)> {
+        if self.umi_value_offset == Self::UMI_OFFSET_UNCACHED {
+            None
+        } else {
+            Some((self.umi_value_offset, self.umi_value_len))
+        }
+    }
+
+    /// Returns a reference to the raw bytes.
+    #[must_use]
+    pub fn raw_bytes(&self) -> &[u8] {
+        self.data.as_ref()
+    }
+
+    /// Immutable access to the underlying [`RawRecord`], for read-only
+    /// consumers (e.g. the FASTQ-encode step) that need the typed accessors
+    /// (`flags()`, sequence, qualities, tags) rather than the raw byte slice.
+    #[must_use]
+    pub fn record(&self) -> &RawRecord {
+        &self.data
+    }
+
+    /// Mutable access to the underlying [`RawRecord`]. Used by mid-chain
+    /// `Parallel` Process steps that need to mutate record bytes (e.g.,
+    /// MQ bumping, tag rewriting) without rebuilding the `DecodedRecord`
+    /// or invalidating its pre-computed `GroupKey`. Caller must not
+    /// change the record's identity (qname, library bytes, cell barcode)
+    /// — those feed `key`, which we don't recompute here.
+    ///
+    /// Handing out mutable bytes resets the cached UMI position to
+    /// [`Self::UMI_OFFSET_UNCACHED`] (see the type-level cached-UMI invariant):
+    /// a length-changing edit before the UMI tag could shift the value while
+    /// leaving the old offset in-bounds, so a later `cached_umi()` would slice
+    /// stale-but-valid bytes. Clearing forces a re-scan instead. This is a
+    /// single field store and the cache is only repopulated by the decode step.
+    pub fn raw_bytes_mut(&mut self) -> &mut RawRecord {
+        self.umi_value_offset = Self::UMI_OFFSET_UNCACHED;
+        self.umi_value_len = 0;
+        &mut self.data
+    }
+
+    /// Takes the [`RawRecord`] out.
+    #[must_use]
+    pub fn into_raw_bytes(self) -> RawRecord {
+        self.data
+    }
+}
+
+impl MemoryEstimate for DecodedRecord {
+    fn estimate_heap_size(&self) -> usize {
+        // RawRecord::capacity() returns the inner Vec<u8> capacity.
+        self.data.capacity()
+    }
+}
+// Vec<DecodedRecord>, Vec<RecordBuf>, Vec<u8>, RecordBuf, () — all provided
+// by the blanket/foreign impls in fgumi_bam_io::mem_estimate.
+
+// ============================================================================
+// GroupKeyConfig - Configuration for computing `GroupKey` during Decode
+// ============================================================================
+
+/// Configuration for computing `GroupKey` during the Decode step.
+///
+/// When this is provided to the pipeline, the Decode step will compute
+/// full `GroupKey` values for each record. This moves expensive computations
+/// (CIGAR parsing, tag extraction) from the serial Group step to the parallel
+/// Decode step.
+#[derive(Debug, Clone)]
+pub struct GroupKeyConfig {
+    /// Library index for fast RG → library lookup.
+    pub library_index: Arc<LibraryIndex>,
+    /// Tag used for cell barcode extraction. None skips cell extraction.
+    pub cell_tag: Option<Tag>,
+    /// When `true`, the Decode step computes only the read-name hash and
+    /// leaves the rest of the [`GroupKey`] at its default. Use for stages
+    /// that group by queryname (e.g. `correct`) and read only
+    /// [`GroupKey::name_hash`] — it skips the CIGAR 5′-position walk and the
+    /// aux-tag (RG/CB/MC) extraction pass entirely. See [`name_hash_key`].
+    pub name_hash_only: bool,
+    /// UMI tag (raw 2-byte form) whose value position should be cached on each
+    /// [`DecodedRecord`] during decode. `None` disables caching — downstream
+    /// code must fall back to scanning aux data. This is orthogonal to
+    /// `name_hash_only`: the UMI cache scan is gated solely on `umi_tag` being
+    /// set (in practice only the Group stage sets it).
+    pub umi_tag: Option<[u8; 2]>,
+}
+
+impl GroupKeyConfig {
+    /// Create a new `GroupKeyConfig` that computes the full position/cell key.
+    #[must_use]
+    pub fn new(library_index: LibraryIndex, cell_tag: Tag) -> Self {
+        Self {
+            library_index: Arc::new(library_index),
+            cell_tag: Some(cell_tag),
+            name_hash_only: false,
+            umi_tag: None,
+        }
+    }
+
+    /// Create a `GroupKeyConfig` without cell barcode extraction.
+    #[must_use]
+    pub fn new_raw_no_cell(library_index: LibraryIndex) -> Self {
+        Self {
+            library_index: Arc::new(library_index),
+            cell_tag: None,
+            name_hash_only: false,
+            umi_tag: None,
+        }
+    }
+
+    /// Create a `GroupKeyConfig` that computes only the read-name hash.
+    ///
+    /// For queryname-grouping stages (e.g. `correct`) whose grouper reads only
+    /// [`GroupKey::name_hash`]; skips the CIGAR position walk and the aux-tag
+    /// extraction pass. `library_index` is retained (unused for the key) so
+    /// the config shape is uniform across the pipeline.
+    #[must_use]
+    pub fn name_hash_only(library_index: LibraryIndex) -> Self {
+        Self {
+            library_index: Arc::new(library_index),
+            cell_tag: None,
+            name_hash_only: true,
+            umi_tag: None,
+        }
+    }
+
+    /// Enable UMI position caching for the given raw 2-byte UMI tag (e.g. `*b"RX"`).
+    ///
+    /// The Decode step will record the UMI value's record-relative position on
+    /// each [`DecodedRecord`] so downstream UMI lookups can slice it directly
+    /// via [`DecodedRecord::cached_umi`] without re-scanning aux data.
+    #[must_use]
+    pub fn with_umi_tag(mut self, umi_tag: [u8; 2]) -> Self {
+        self.umi_tag = Some(umi_tag);
+        self
+    }
+}
+
+impl Default for GroupKeyConfig {
+    fn default() -> Self {
+        Self {
+            library_index: Arc::new(LibraryIndex::default()),
+            cell_tag: Some(Tag::from([b'C', b'B'])), // Default cell barcode tag (CB)
+            name_hash_only: false,
+            umi_tag: None,
+        }
+    }
+}
+
+/// Hash a record's read name, mapping an empty name to `hash_name(None)` so the
+/// raw path matches the noodles path (which sees `None` for an empty name).
+///
+/// Shared by [`name_hash_key`] and [`compute_group_key_from_raw`]: both must
+/// produce the same hash for the same record, and a second copy of this block
+/// could drift out of parity silently.
+fn raw_name_hash(raw: &[u8]) -> u64 {
+    let name = fgumi_raw_bam::read_name(raw);
+    if name.is_empty() {
+        LibraryIndex::hash_name(None)
+    } else {
+        LibraryIndex::hash_name(Some(name))
+    }
+}
+
+/// Compute a [`GroupKey`] containing only the read-name hash, leaving all
+/// position/strand/library/cell fields at their default.
+///
+/// Reproduces exactly the `name_hash` that [`compute_group_key_from_raw`]
+/// computes (empty name → `hash_name(None)`), so a queryname grouper sees an
+/// identical hash. Skips the CIGAR 5′-position walk and the RG/CB/MC aux-tag
+/// extraction pass.
+///
+/// # Panics
+///
+/// Panics if `raw` is not a validated BAM record payload (same contract as
+/// [`compute_group_key_from_raw`]).
+#[must_use]
+pub fn name_hash_key(raw: &[u8]) -> GroupKey {
+    GroupKey { name_hash: raw_name_hash(raw), ..GroupKey::default() }
+}
+
+/// Compute a `GroupKey` directly from raw BAM bytes, matching `compute_group_key()` exactly.
+///
+/// Uses 1-based coordinate helpers to produce identical keys to the noodles path.
+///
+/// # Panics
+///
+/// Panics if `raw` is not a validated BAM record payload (as produced by the BAM
+/// reader / raw-record pipeline). Callers must not pass arbitrary external bytes;
+/// raw-field accessors will panic on malformed or truncated input.
+#[must_use]
+pub fn compute_group_key_from_raw(
+    raw: &[u8],
+    library_index: &LibraryIndex,
+    cell_tag: Option<noodles::sam::alignment::record::data::field::Tag>,
+) -> GroupKey {
+    // Extract name hash (match noodles path: empty name → None → hash 0)
+    let name_hash = raw_name_hash(raw);
+
+    // Check secondary/supplementary
+    let flg = RawRecordView::new(raw).flags();
+    let is_secondary = (flg & fgumi_raw_bam::flags::SECONDARY) != 0;
+    let is_supplementary = (flg & fgumi_raw_bam::flags::SUPPLEMENTARY) != 0;
+    if is_secondary || is_supplementary {
+        // A secondary/supplementary read cannot compute its own template
+        // coordinate (it lacks its own primary's position). When `fgumi zipper`
+        // has stamped the exact coordinate into `tc`, key on it so the read
+        // groups into the same position group as its primary — instead of an
+        // UNKNOWN position that relies on the read sorting adjacent to its
+        // primary. Library/cell are extracted the same way as primaries so the
+        // position key matches (they share their template's RG/CB).
+        let aux_data = fgumi_raw_bam::aux_data_slice(raw);
+        if let Some([tid1, pos1, neg1, tid2, pos2, neg2]) =
+            fgumi_raw_bam::read_tc_template_coordinate(aux_data)
+        {
+            let cell_tag_bytes = cell_tag.map_or([0u8; 2], |t| [t.as_ref()[0], t.as_ref()[1]]);
+            let aux_tags = fgumi_raw_bam::extract_aux_string_tags(aux_data, cell_tag_bytes, None);
+            let library_idx =
+                aux_tags.rg.map_or(0, |rg| library_index.get(LibraryIndex::hash_rg(rg)));
+            let cell_hash = aux_tags.cell.map_or(0, |cb| LibraryIndex::hash_cell_barcode(Some(cb)));
+            return GroupKey::paired(
+                tid1,
+                pos1,
+                u8::from(neg1 != 0),
+                tid2,
+                pos2,
+                u8::from(neg2 != 0),
+                library_idx,
+                cell_hash,
+                name_hash,
+            );
+        }
+        return GroupKey { name_hash, ..GroupKey::default() };
+    }
+
+    // Own position (1-based, matching noodles) — zero-allocation CIGAR iteration
+    let reverse = (flg & fgumi_raw_bam::flags::REVERSE) != 0;
+    let own_pos = fgumi_raw_bam::unclipped_5prime_from_raw_bam(raw);
+
+    let own_ref_id = fgumi_raw_bam::ref_id(raw);
+    let strand = u8::from(reverse);
+
+    // Single-pass aux tag extraction (RG, cell barcode, MC)
+    let aux_data = fgumi_raw_bam::aux_data_slice(raw);
+    let cell_tag_bytes = cell_tag.map_or([0u8; 2], |t| [t.as_ref()[0], t.as_ref()[1]]);
+    let aux_tags = fgumi_raw_bam::extract_aux_string_tags(aux_data, cell_tag_bytes, None);
+
+    let library_idx = if let Some(rg) = aux_tags.rg {
+        let rg_hash = LibraryIndex::hash_rg(rg);
+        library_index.get(rg_hash)
+    } else {
+        0
+    };
+
+    let cell_hash =
+        if let Some(cb) = aux_tags.cell { LibraryIndex::hash_cell_barcode(Some(cb)) } else { 0 };
+
+    // Check if paired
+    let is_paired = (flg & fgumi_raw_bam::flags::PAIRED) != 0;
+    if !is_paired {
+        return GroupKey::single(own_ref_id, own_pos, strand, library_idx, cell_hash, name_hash);
+    }
+
+    // Mate info — guard against MATE_UNMAPPED (matching noodles path)
+    let mate_unmapped = (flg & fgumi_raw_bam::flags::MATE_UNMAPPED) != 0;
+    let mate_reverse = (flg & fgumi_raw_bam::flags::MATE_REVERSE) != 0;
+    let mate_strand = u8::from(mate_reverse);
+    let raw_mate_ref_id = fgumi_raw_bam::mate_ref_id(raw);
+    let raw_mate_pos = fgumi_raw_bam::mate_pos(raw);
+
+    // Get mate unclipped 5' position via MC tag (skip if mate is unmapped)
+    let mate_pos_result = if mate_unmapped {
+        None
+    } else {
+        aux_tags
+            .mc
+            .map(|mc| fgumi_raw_bam::mate_unclipped_5prime_1based(raw_mate_pos, mate_reverse, mc))
+    };
+
+    match mate_pos_result {
+        Some(mp) => GroupKey::paired(
+            own_ref_id,
+            own_pos,
+            strand,
+            raw_mate_ref_id,
+            mp,
+            mate_strand,
+            library_idx,
+            cell_hash,
+            name_hash,
+        ),
+        None => {
+            // No MC tag — fall back to single-end behavior
+            GroupKey::single(own_ref_id, own_pos, strand, library_idx, cell_hash, name_hash)
+        }
+    }
+}
+
+/// Groups a stream of in-order [`DecodedRecord`]s into completed groups.
+///
+/// Implementors maintain partial groups across `add_records` calls and emit
+/// completed ones; `finish` flushes any trailing partial group at EOF. Used
+/// by the pipeline's Group step and the standalone grouping commands.
+pub trait Grouper: Send {
+    /// The type of group produced by this grouper.
+    type Group: Send;
+
+    /// Add decoded records to the grouper.
+    ///
+    /// Records are guaranteed to be in order (from template-coordinate sorted BAM).
+    /// The grouper maintains partial groups waiting for more records.
+    ///
+    /// Each `DecodedRecord` contains the record plus a pre-computed `GroupKey`
+    /// for fast comparison (position, name hash, library, etc.).
+    ///
+    /// Returns completed groups (may be empty if more records are needed).
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if grouping logic encounters invalid data.
+    fn add_records(&mut self, records: Vec<DecodedRecord>) -> io::Result<Vec<Self::Group>>;
+
+    /// Signal that no more input will arrive (EOF).
+    ///
+    /// Returns any remaining partial group.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if finalizing the grouper fails.
+    fn finish(&mut self) -> io::Result<Option<Self::Group>>;
+
+    /// Returns true if the grouper has a partial group.
+    fn has_pending(&self) -> bool;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fgumi_raw_bam::SamBuilder;
+    use fgumi_raw_bam::SamTag;
+    use fgumi_raw_bam::flags;
+
+    // ========================================================================
+    // compute_group_key_from_raw — primary (fully-populated) path
+    // ========================================================================
+
+    /// Read group `RG1` resolves to library `libA`; `RG2` to `libB`.
+    fn library_index_with_two_groups() -> LibraryIndex {
+        use noodles::sam::header::record::value::Map;
+        use noodles::sam::header::record::value::map::ReadGroup;
+        use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
+
+        let mut header = noodles::sam::Header::builder();
+        for (id, library) in [("RG1", "libA"), ("RG2", "libB")] {
+            let rg = Map::<ReadGroup>::builder()
+                .insert(rg_tag::LIBRARY, String::from(library))
+                .build()
+                .expect("read group builds");
+            header = header.add_read_group(bstr::BString::from(id), rg);
+        }
+        LibraryIndex::from_header(&header.build())
+    }
+
+    /// Build one mapped mate of a pair carrying `RG`, `CB` and `MC`.
+    fn paired_record_with_tags(
+        pos: i32,
+        mate_pos: i32,
+        reverse: bool,
+        mate_reverse: bool,
+    ) -> fgumi_raw_bam::RawRecord {
+        let mut flag = flags::PAIRED;
+        if reverse {
+            flag |= flags::REVERSE;
+        }
+        if mate_reverse {
+            flag |= flags::MATE_REVERSE;
+        }
+        let mut b = SamBuilder::new();
+        b.ref_id(0)
+            .pos(pos)
+            .flags(flag)
+            .mate_ref_id(0)
+            .mate_pos(mate_pos)
+            .read_name(b"pair_full")
+            .cigar_ops(&[cigar_m(50)])
+            .sequence(b"ACGT")
+            .qualities(&[30, 30, 30, 30])
+            .add_string_tag(SamTag::RG, b"RG1")
+            .add_string_tag(SamTag::CB, b"ACGTACGTA")
+            .add_string_tag(SamTag::MC, b"50M");
+        b.build()
+    }
+
+    /// The fully-populated branch: paired, mate mapped, `MC` present, `RG`
+    /// resolving through a non-default `LibraryIndex`, and a cell barcode read via
+    /// `cell_tag`. Every other test in this module lands on a fallback (secondary,
+    /// supplementary, or paired-without-`MC`) with `LibraryIndex::default()` and
+    /// `cell_tag: None`, so `library_idx`, `cell_hash` and the mate slot are
+    /// otherwise never exercised — and all three participate in key equality.
+    #[test]
+    fn paired_with_mc_populates_mate_library_and_cell_fields() {
+        let lib = library_index_with_two_groups();
+        let cb = noodles::sam::alignment::record::data::field::Tag::CELL_BARCODE_ID;
+
+        let rec = paired_record_with_tags(1000, 1200, false, true);
+        let key = compute_group_key_from_raw(rec.as_ref(), &lib, Some(cb));
+
+        // Mate slot is populated, not left at the single-end sentinels.
+        assert_ne!(key.ref_id2, GroupKey::UNKNOWN_REF, "MC must populate the mate slot");
+        assert_ne!(key.strand2, GroupKey::UNKNOWN_STRAND);
+
+        // Pin the mate coordinate: it must be the MC-derived unclipped 5' position,
+        // not the raw `mate_pos`. `!= UNKNOWN_POS` alone would accept a wrong
+        // CIGAR walk.
+        let expected_mate_pos = fgumi_raw_bam::mate_unclipped_5prime_1based(
+            fgumi_raw_bam::mate_pos(rec.as_ref()),
+            true,
+            "50M",
+        );
+        assert_eq!(key.pos2, expected_mate_pos, "mate slot must hold the MC-derived position");
+
+        // RG resolved through the index — not the unknown bucket.
+        assert_eq!(key.library_idx, lib.get(LibraryIndex::hash_rg(b"RG1")));
+        assert_ne!(key.library_idx, 0, "RG1 must resolve to a real library");
+
+        // Cell barcode hashed because `cell_tag` named CB.
+        assert_eq!(key.cell_hash, LibraryIndex::hash_cell_barcode(Some(b"ACGTACGTA")));
+        assert_ne!(key.cell_hash, 0);
+
+        assert_eq!(key.name_hash, LibraryIndex::hash_name(Some(b"pair_full")));
+
+        // Own slot holds this record's own unclipped 5' position.
+        assert_eq!(key.pos1, fgumi_raw_bam::unclipped_5prime_from_raw_bam(rec.as_ref()));
+        assert_eq!(key.ref_id1, fgumi_raw_bam::ref_id(rec.as_ref()));
+    }
+
+    /// Both mates of the same template must normalize to one key — this is what
+    /// makes them group together. The mate sees own/mate swapped and the strands
+    /// exchanged.
+    #[test]
+    fn paired_with_mc_normalizes_both_mates_to_the_same_key() {
+        let lib = library_index_with_two_groups();
+        let cb = noodles::sam::alignment::record::data::field::Tag::CELL_BARCODE_ID;
+
+        let forward = paired_record_with_tags(1000, 1200, false, true);
+        let reverse = paired_record_with_tags(1200, 1000, true, false);
+
+        let key_forward = compute_group_key_from_raw(forward.as_ref(), &lib, Some(cb));
+        let key_reverse = compute_group_key_from_raw(reverse.as_ref(), &lib, Some(cb));
+
+        assert_eq!(key_forward, key_reverse, "both mates of a template must share one key");
+    }
+
+    /// A secondary/supplementary read cannot derive its own template coordinate,
+    /// so `fgumi zipper` stamps the primary's into the `tc` aux array. Keying on
+    /// it puts the read in the SAME position group as its primary; without it the
+    /// read falls back to a name-only key and relies on sorting adjacency.
+    #[test]
+    fn secondary_with_tc_tag_keys_on_the_stamped_template_coordinate() {
+        let lib = library_index_with_two_groups();
+
+        let mut b = SamBuilder::new();
+        b.ref_id(0)
+            .pos(5000)
+            .flags(flags::PAIRED | flags::SECONDARY)
+            .read_name(b"sec_with_tc")
+            .cigar_ops(&[cigar_m(50)])
+            .sequence(b"ACGT")
+            .qualities(&[30, 30, 30, 30])
+            .add_string_tag(SamTag::RG, b"RG1")
+            // tc = [tid1, pos1, neg1, tid2, pos2, neg2] — the primary's coordinate.
+            .add_array_i32(SamTag::TC, &[0, 1001, 0, 0, 1249, 1]);
+        let rec = b.build();
+
+        let key = compute_group_key_from_raw(rec.as_ref(), &lib, None);
+
+        // Both slots come from `tc`, NOT from this record's own pos (5000).
+        assert_eq!((key.ref_id1, key.pos1, key.strand1), (0, 1001, 0));
+        assert_eq!((key.ref_id2, key.pos2, key.strand2), (0, 1249, 1));
+        assert_ne!(key.pos1, 5001, "the record's own position must not be used");
+
+        // Library still resolves, so the key matches its primary's.
+        assert_eq!(key.library_idx, lib.get(LibraryIndex::hash_rg(b"RG1")));
+        assert_eq!(key.name_hash, LibraryIndex::hash_name(Some(b"sec_with_tc")));
+    }
+
+    /// Without a `tc` tag the secondary path still falls back to the name-only
+    /// key — including for a mapped record with an EMPTY cigar, where
+    /// `unclipped_5prime_from_raw_bam` returns `i32::MAX`. The fallback must not
+    /// leak that sentinel into a position slot.
+    #[test]
+    fn secondary_without_tc_falls_back_to_name_only_even_with_an_empty_cigar() {
+        let lib = library_index_with_two_groups();
+
+        let mut b = SamBuilder::new();
+        b.ref_id(0)
+            .pos(5000)
+            .flags(flags::SUPPLEMENTARY)
+            .read_name(b"sup_no_tc")
+            .cigar_ops(&[])
+            .sequence(b"ACGT")
+            .qualities(&[30, 30, 30, 30]);
+        let rec = b.build();
+
+        let key = compute_group_key_from_raw(rec.as_ref(), &lib, None);
+
+        assert_eq!(key, GroupKey { name_hash: key.name_hash, ..GroupKey::default() });
+        assert_eq!(key.name_hash, LibraryIndex::hash_name(Some(b"sup_no_tc")));
+        assert_eq!(key.pos1, GroupKey::default().pos1, "no i32::MAX sentinel may leak in");
+    }
+
+    /// `library_idx` is part of key equality: the same position read under a
+    /// different read group must NOT group with it.
+    #[test]
+    fn differing_library_splits_the_key() {
+        let lib = library_index_with_two_groups();
+
+        let mut b = SamBuilder::new();
+        b.ref_id(0)
+            .pos(1000)
+            .flags(flags::PAIRED)
+            .mate_ref_id(0)
+            .mate_pos(1200)
+            .read_name(b"pair_full")
+            .cigar_ops(&[cigar_m(50)])
+            .sequence(b"ACGT")
+            .qualities(&[30, 30, 30, 30])
+            .add_string_tag(SamTag::RG, b"RG2")
+            .add_string_tag(SamTag::MC, b"50M");
+        let other_library = b.build();
+
+        let key_a = compute_group_key_from_raw(
+            paired_record_with_tags(1000, 1200, false, true).as_ref(),
+            &lib,
+            None,
+        );
+        let key_b = compute_group_key_from_raw(other_library.as_ref(), &lib, None);
+
+        assert_ne!(key_a.library_idx, key_b.library_idx);
+        assert_ne!(key_a, key_b, "a different library must not group with the first");
+    }
+
+    /// CIGAR op `(len << 4) | op_code`; op 0 = `M`.
+    fn cigar_m(len: u32) -> u32 {
+        len << 4
+    }
+
+    // ========================================================================
+    // GroupKey::paired normalization
+    // ========================================================================
+
+    #[test]
+    fn paired_normalizes_swapped_own_and_mate_to_equal_keys() {
+        // Two reads of the same template: one sees (own=A, mate=B), the other
+        // sees (own=B, mate=A). After normalization both must yield the same
+        // GroupKey, so they group together.
+        let a = GroupKey::paired(0, 100, 0, 0, 200, 1, 7, 99, 42);
+        let b = GroupKey::paired(0, 200, 1, 0, 100, 0, 7, 99, 42);
+        assert_eq!(a, b, "swapped own/mate positions must normalize to equal keys");
+
+        // The lower (ref_id, pos, strand) tuple is placed in slot 1.
+        assert_eq!((a.ref_id1, a.pos1, a.strand1), (0, 100, 0));
+        assert_eq!((a.ref_id2, a.pos2, a.strand2), (0, 200, 1));
+    }
+
+    #[test]
+    fn paired_keys_order_by_normalized_position_then_name() {
+        // Position 1 < position 2 orders the keys; equal positions fall back to
+        // name_hash ordering.
+        let lower = GroupKey::paired(0, 100, 0, 0, 200, 0, 0, 0, 1);
+        let higher = GroupKey::paired(0, 150, 0, 0, 200, 0, 0, 0, 1);
+        assert!(lower < higher, "lower position-1 must sort first");
+
+        let same_pos_low_name = GroupKey::paired(0, 100, 0, 0, 200, 0, 0, 0, 1);
+        let same_pos_high_name = GroupKey::paired(0, 100, 0, 0, 200, 0, 0, 0, 2);
+        assert!(same_pos_low_name < same_pos_high_name, "equal positions must order by name_hash",);
+    }
+
+    // ========================================================================
+    // compute_group_key_from_raw: secondary / supplementary fallback
+    // ========================================================================
+
+    #[test]
+    fn secondary_and_supplementary_records_yield_name_hash_only_key() {
+        let lib = LibraryIndex::default();
+        let expected_name_hash = LibraryIndex::hash_name(Some(b"rec1"));
+
+        for flag in [flags::SECONDARY, flags::SUPPLEMENTARY] {
+            // Give the record a real mapped position so we can prove the
+            // position fields are *not* derived for secondary/supplementary.
+            let mut b = SamBuilder::new();
+            b.ref_id(0)
+                .pos(500)
+                .flags(flag)
+                .read_name(b"rec1")
+                .cigar_ops(&[cigar_m(50)])
+                .sequence(b"ACGT")
+                .qualities(&[30, 30, 30, 30]);
+            let rec = b.build();
+
+            let key = compute_group_key_from_raw(rec.as_ref(), &lib, None);
+
+            // Only the name hash is set; every position field stays at default.
+            assert_eq!(key, GroupKey { name_hash: expected_name_hash, ..GroupKey::default() });
+            assert_eq!(key.ref_id1, GroupKey::UNKNOWN_REF);
+            assert_eq!(key.pos1, GroupKey::UNKNOWN_POS);
+            assert_eq!(key.strand1, GroupKey::UNKNOWN_STRAND);
+        }
+    }
+
+    // ========================================================================
+    // compute_group_key_from_raw: paired record missing MC falls back to single
+    // ========================================================================
+
+    #[test]
+    fn paired_without_mc_tag_falls_back_to_single_semantics() {
+        let lib = LibraryIndex::default();
+
+        // Paired + mate mapped, but no MC tag: cannot compute the mate's
+        // unclipped 5' position, so the key must use single-end semantics
+        // (mate fields left at the UNKNOWN sentinels).
+        let mut b = SamBuilder::new();
+        b.ref_id(0)
+            .pos(1000)
+            .flags(flags::PAIRED)
+            .mate_ref_id(0)
+            .mate_pos(1200)
+            .read_name(b"pair_no_mc")
+            .cigar_ops(&[cigar_m(50)])
+            .sequence(b"ACGT")
+            .qualities(&[30, 30, 30, 30]);
+        let rec = b.build();
+
+        let key = compute_group_key_from_raw(rec.as_ref(), &lib, None);
+
+        // Mate fields fall back to the single-end sentinels.
+        assert_eq!(key.ref_id2, GroupKey::UNKNOWN_REF);
+        assert_eq!(key.pos2, GroupKey::UNKNOWN_POS);
+        assert_eq!(key.strand2, GroupKey::UNKNOWN_STRAND);
+
+        // The own position is still populated; the key matches the single-end
+        // key built from the same fields.
+        let expected = GroupKey::single(
+            key.ref_id1,
+            key.pos1,
+            key.strand1,
+            key.library_idx,
+            key.cell_hash,
+            LibraryIndex::hash_name(Some(b"pair_no_mc")),
+        );
+        assert_eq!(key, expected);
+    }
+
+    // ========================================================================
+    // name_hash_key parity with compute_group_key_from_raw
+    // ========================================================================
+
+    #[test]
+    fn name_hash_key_matches_compute_group_key_name_hash() {
+        let lib = LibraryIndex::default();
+
+        // A representative spread of records: mapped single-end, secondary,
+        // paired-without-MC, and an empty-named record (exercises the
+        // hash_name(None) branch shared by both functions).
+        let mut single = SamBuilder::new();
+        single
+            .ref_id(0)
+            .pos(10)
+            .read_name(b"alpha")
+            .cigar_ops(&[cigar_m(8)])
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8]);
+
+        let mut secondary = SamBuilder::new();
+        secondary.ref_id(0).pos(20).flags(flags::SECONDARY).read_name(b"beta");
+
+        let mut paired = SamBuilder::new();
+        paired
+            .ref_id(0)
+            .pos(30)
+            .flags(flags::PAIRED)
+            .mate_ref_id(0)
+            .mate_pos(60)
+            .read_name(b"gamma");
+
+        let mut empty_name = SamBuilder::new();
+        empty_name.ref_id(0).pos(40).read_name(b"");
+
+        for mut builder in [single, secondary, paired, empty_name] {
+            let rec = builder.build();
+            let raw = rec.as_ref();
+            assert_eq!(
+                name_hash_key(raw).name_hash,
+                compute_group_key_from_raw(raw, &lib, None).name_hash,
+                "name_hash parity mismatch",
+            );
+        }
+    }
+
+    // ========================================================================
+    // DecodedRecord cached-UMI invalidation (S6-002)
+    // ========================================================================
+
+    /// Build a `DecodedRecord` carrying an RX UMI tag with its value position
+    /// cached, exactly as the Decode step's `cache_umi_position` would.
+    fn decoded_with_cached_umi(umi: &[u8]) -> DecodedRecord {
+        use fgumi_raw_bam::SamTag;
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1").sequence(b"ACGT").qualities(&[30; 4]);
+        b.add_string_tag(SamTag::RX, umi);
+        let rec = b.build();
+        let bytes = rec.as_ref();
+        let aux_offset =
+            fgumi_raw_bam::aux_data_offset_from_record(bytes).expect("aux offset present");
+        let aux = &bytes[aux_offset..];
+        let (off_in_aux, len) =
+            fgumi_raw_bam::find_string_tag_position(aux, *SamTag::RX).expect("RX tag present");
+        let offset = u32::try_from(aux_offset).expect("aux offset fits u32") + off_in_aux;
+        let mut d = DecodedRecord::from_raw_bytes(rec, GroupKey::default());
+        d.set_cached_umi(offset, len);
+        d
+    }
+
+    #[test]
+    fn cached_umi_returns_value_then_raw_bytes_mut_invalidates() {
+        // The cache resolves to the UMI value up front; handing out mutable bytes
+        // must reset the cache to the sentinel so a later read re-scans rather
+        // than slicing stale-but-in-range bytes (see the cached-UMI invariant).
+        let mut decoded = decoded_with_cached_umi(b"ACGTACGT");
+        assert_eq!(decoded.cached_umi(), Some(b"ACGTACGT".as_ref()), "cache populated up front");
+        assert_ne!(decoded.cached_umi_position().0, DecodedRecord::UMI_OFFSET_UNCACHED);
+
+        let _ = decoded.raw_bytes_mut();
+
+        assert_eq!(
+            decoded.cached_umi_position().0,
+            DecodedRecord::UMI_OFFSET_UNCACHED,
+            "raw_bytes_mut resets the cache to the uncached sentinel",
+        );
+        assert!(decoded.cached_umi().is_none(), "cached_umi returns None after mutation");
+    }
+}

--- a/crates/fgumi-bam-io/src/lib.rs
+++ b/crates/fgumi-bam-io/src/lib.rs
@@ -12,7 +12,9 @@
 #![deny(unsafe_code)]
 
 pub mod format;
+pub mod grouping;
 pub mod header;
+pub mod library;
 pub mod mem_estimate;
 pub mod os_hints;
 pub mod paths;
@@ -26,6 +28,10 @@ pub mod writer;
 pub(crate) mod vendored;
 
 pub use format::{FORMAT_PREFIX_LEN, InputFormat, classify_input};
+pub use grouping::{
+    DecodedRecord, GroupKey, GroupKeyConfig, Grouper, compute_group_key_from_raw, name_hash_key,
+};
+pub use library::{LibraryIndex, LibraryLookup, build_library_lookup};
 pub use mem_estimate::MemoryEstimate;
 pub use paths::{is_stdin_path, is_stdout_path};
 pub use progress::ProgressTracker;

--- a/crates/fgumi-bam-io/src/library.rs
+++ b/crates/fgumi-bam-io/src/library.rs
@@ -1,0 +1,295 @@
+//! Library lookup tables built from SAM `@RG` headers.
+//!
+//! [`LibraryLookup`] maps read-group IDs to library-name strings;
+//! [`LibraryIndex`] is the hash-based hot-path variant returning numeric
+//! library indices (used by `grouping::compute_group_key_from_raw`).
+//!
+//! Relocated here from the main crate's `read_info` module so the grouping
+//! domain types (which depend on `LibraryIndex`) can live in this crate
+//! alongside [`fgumi_raw_bam::RawRecord`]-adjacent helpers and `MemoryEstimate`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use bstr::ByteSlice;
+use noodles::sam::header::Header;
+use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
+
+/// A lookup table mapping read group IDs to library names.
+///
+/// This is built from the SAM header's `@RG` lines and used to resolve the library
+/// name (`LB` field) from a record's `RG` tag. This matches fgbio's behavior where
+/// grouping uses the library name, not the read group ID.
+///
+/// Uses `Arc<str>` for library names to avoid cloning strings for every read.
+///
+/// # Note: `LibraryLookup` vs `LibraryIndex`
+///
+/// Both `LibraryLookup` and [`LibraryIndex`] exist for different use cases:
+/// - `LibraryLookup`: String-based lookup returning library names. Used where
+///   the actual library-name string is needed (e.g. the main crate's
+///   `ReadInfo::from`).
+/// - [`LibraryIndex`]: Hash-based lookup returning numeric indices. Used by
+///   [`compute_group_key_from_raw`](crate::compute_group_key_from_raw) in the
+///   hot path where only equality comparison matters, avoiding string
+///   allocations.
+pub type LibraryLookup = Arc<HashMap<String, Arc<str>>>;
+
+/// Shared "unknown" library string to avoid repeated allocations.
+static UNKNOWN_LIBRARY: std::sync::LazyLock<Arc<str>> =
+    std::sync::LazyLock::new(|| Arc::from("unknown"));
+
+/// Returns the shared "unknown" library name (`Arc<str>` of `"unknown"`),
+/// used as the fallback when a read group has no `LB` field.
+#[must_use]
+pub fn unknown_library() -> Arc<str> {
+    Arc::clone(&UNKNOWN_LIBRARY)
+}
+
+/// Builds a library lookup table from a SAM header.
+///
+/// Iterates through all `@RG` lines in the header and creates a mapping from
+/// read group ID to library name. If a read group has no `LB` field, it maps
+/// to "unknown" (matching fgbio's behavior).
+///
+/// # Arguments
+///
+/// * `header` - The SAM header containing `@RG` lines
+///
+/// # Returns
+///
+/// An `Arc<HashMap>` mapping read group IDs to library names
+#[must_use]
+pub fn build_library_lookup(header: &Header) -> LibraryLookup {
+    let mut lookup = HashMap::new();
+
+    for (id, rg) in header.read_groups() {
+        // Get the LB field from the read group's other_fields
+        let library: Arc<str> = rg
+            .other_fields()
+            .get(&rg_tag::LIBRARY)
+            .map_or_else(|| Arc::clone(&UNKNOWN_LIBRARY), |s| Arc::from(s.to_string()));
+        lookup.insert(id.to_string(), library);
+    }
+
+    Arc::new(lookup)
+}
+
+// ============================================================================
+// LibraryIndex - Fast RG to library index mapping for GroupKey computation
+// ============================================================================
+
+/// Fast lookup from `RG` tag value to library index.
+///
+/// This provides `O(1)` library lookup during Decode using string hashing,
+/// replacing the `O(n)` string comparison in the original `LibraryLookup`.
+#[derive(Debug, Clone)]
+pub struct LibraryIndex {
+    /// Map from `RG` string hash to library index.
+    lookup: ahash::AHashMap<u64, u16>,
+    /// Library names for each index (for output/debugging).
+    names: Vec<Arc<str>>,
+    /// Unknown library index (always 0).
+    unknown_idx: u16,
+}
+
+impl LibraryIndex {
+    /// Build a library index from a SAM header.
+    ///
+    /// Each unique library name gets a sequential index starting from 0.
+    /// Index 0 is reserved for "unknown" library.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the header contains more than 65,535 distinct libraries.
+    #[must_use]
+    pub fn from_header(header: &Header) -> Self {
+        let mut lookup = ahash::AHashMap::new();
+        let mut names = vec![Arc::clone(&UNKNOWN_LIBRARY)]; // Index 0 = unknown
+        let mut library_to_idx: ahash::AHashMap<Arc<str>, u16> = ahash::AHashMap::new();
+        library_to_idx.insert(Arc::clone(&UNKNOWN_LIBRARY), 0);
+
+        for (id, rg) in header.read_groups() {
+            // Get library name from LB field
+            let library: Arc<str> = rg
+                .other_fields()
+                .get(&rg_tag::LIBRARY)
+                .map_or_else(|| Arc::clone(&UNKNOWN_LIBRARY), |s| Arc::from(s.to_string()));
+
+            // Get or create library index
+            let lib_idx = *library_to_idx.entry(library.clone()).or_insert_with(|| {
+                let idx: u16 =
+                    names.len().try_into().expect("too many distinct libraries for u16 index");
+                names.push(library);
+                idx
+            });
+
+            // Hash the RG string and map to library index
+            let rg_hash = Self::hash_rg(id.as_bytes());
+            lookup.insert(rg_hash, lib_idx);
+        }
+
+        Self { lookup, names, unknown_idx: 0 }
+    }
+
+    /// Get the library index for a read group hash.
+    ///
+    /// Returns 0 (unknown) if the `RG` hash is not found.
+    #[must_use]
+    pub fn get(&self, rg_hash: u64) -> u16 {
+        *self.lookup.get(&rg_hash).unwrap_or(&self.unknown_idx)
+    }
+
+    /// Get the library name for an index.
+    #[must_use]
+    pub fn library_name(&self, idx: u16) -> &Arc<str> {
+        self.names.get(idx as usize).unwrap_or(&self.names[0])
+    }
+
+    /// Hash a byte slice using `AHash`. Returns 0 for `None`.
+    ///
+    /// This is the single hashing implementation used by all `hash_*` methods.
+    #[must_use]
+    pub fn hash_bytes(bytes: Option<&[u8]>) -> u64 {
+        use ahash::AHasher;
+        use std::hash::{Hash, Hasher};
+        match bytes {
+            Some(b) => {
+                let mut hasher = AHasher::default();
+                b.hash(&mut hasher);
+                hasher.finish()
+            }
+            None => 0,
+        }
+    }
+
+    /// Hash an `RG` tag value for lookup.
+    #[must_use]
+    pub fn hash_rg(rg_bytes: &[u8]) -> u64 {
+        Self::hash_bytes(Some(rg_bytes))
+    }
+
+    /// Hash a cell barcode for `GroupKey`.
+    #[must_use]
+    pub fn hash_cell_barcode(cell_bytes: Option<&[u8]>) -> u64 {
+        Self::hash_bytes(cell_bytes)
+    }
+
+    /// Hash a read name for `GroupKey`.
+    #[must_use]
+    pub fn hash_name(name_bytes: Option<&[u8]>) -> u64 {
+        Self::hash_bytes(name_bytes)
+    }
+}
+
+impl Default for LibraryIndex {
+    fn default() -> Self {
+        Self {
+            lookup: ahash::AHashMap::new(),
+            names: vec![Arc::clone(&UNKNOWN_LIBRARY)],
+            unknown_idx: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noodles::sam::header::record::value::Map;
+    use noodles::sam::header::record::value::map::ReadGroup;
+    use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
+
+    /// Header with three read groups: two sharing a library, one with no `LB`.
+    fn header_with_read_groups() -> Header {
+        let mut header = Header::builder();
+        // RG1 and RG3 deliberately share a library so the dedup path is exercised.
+        for (id, library) in [("RG1", "libA"), ("RG2", "libB"), ("RG3", "libA")] {
+            let rg = Map::<ReadGroup>::builder()
+                .insert(rg_tag::LIBRARY, String::from(library))
+                .build()
+                .expect("read group builds");
+            header = header.add_read_group(bstr::BString::from(id), rg);
+        }
+        // A fourth group with no LB at all, which must fall back to "unknown".
+        header = header.add_read_group(
+            bstr::BString::from("RG4"),
+            Map::<ReadGroup>::builder().build().expect("read group builds"),
+        );
+        header.build()
+    }
+
+    /// `library_idx` is the field `GroupKey` equality depends on, so read groups
+    /// sharing a library MUST collapse to one index and distinct libraries MUST
+    /// NOT — the first would merge unrelated UMI groups, the second would split
+    /// one group in half.
+    #[test]
+    fn from_header_assigns_one_index_per_distinct_library() {
+        let index = LibraryIndex::from_header(&header_with_read_groups());
+
+        let idx1 = index.get(LibraryIndex::hash_rg(b"RG1"));
+        let idx2 = index.get(LibraryIndex::hash_rg(b"RG2"));
+        let idx3 = index.get(LibraryIndex::hash_rg(b"RG3"));
+
+        assert_eq!(idx1, idx3, "read groups sharing a library share an index");
+        assert_ne!(idx1, idx2, "distinct libraries get distinct indices");
+        assert_ne!(idx1, 0, "a resolved library is never the unknown index");
+        assert_ne!(idx2, 0, "a resolved library is never the unknown index");
+
+        assert_eq!(index.library_name(idx1).as_ref(), "libA");
+        assert_eq!(index.library_name(idx2).as_ref(), "libB");
+    }
+
+    /// A read group with no `LB` maps to the shared "unknown" library at index 0,
+    /// which is also the miss value — so an absent `LB` and an absent read group
+    /// group together rather than each forming a singleton.
+    #[test]
+    fn from_header_maps_missing_library_and_unknown_read_group_to_index_zero() {
+        let index = LibraryIndex::from_header(&header_with_read_groups());
+
+        assert_eq!(index.get(LibraryIndex::hash_rg(b"RG4")), 0, "no LB field → unknown");
+        assert_eq!(index.get(LibraryIndex::hash_rg(b"ABSENT")), 0, "unseen RG → unknown");
+        assert_eq!(index.library_name(0).as_ref(), "unknown");
+    }
+
+    /// Out-of-range indices fall back to "unknown" rather than panicking.
+    #[test]
+    fn library_name_saturates_to_unknown_for_an_out_of_range_index() {
+        let index = LibraryIndex::from_header(&header_with_read_groups());
+        assert_eq!(index.library_name(u16::MAX).as_ref(), "unknown");
+    }
+
+    /// The string-keyed lookup carries the same LB resolution as the hashed one,
+    /// including the "unknown" fallback.
+    #[test]
+    fn build_library_lookup_maps_each_read_group_to_its_library() {
+        let lookup = build_library_lookup(&header_with_read_groups());
+
+        assert_eq!(lookup.len(), 4);
+        assert_eq!(lookup.get("RG1").expect("RG1 present").as_ref(), "libA");
+        assert_eq!(lookup.get("RG2").expect("RG2 present").as_ref(), "libB");
+        assert_eq!(lookup.get("RG3").expect("RG3 present").as_ref(), "libA");
+        assert_eq!(lookup.get("RG4").expect("RG4 present").as_ref(), "unknown");
+    }
+
+    /// An empty header yields an index that resolves everything to unknown.
+    #[test]
+    fn from_header_with_no_read_groups_resolves_everything_to_unknown() {
+        let index = LibraryIndex::from_header(&Header::default());
+        assert_eq!(index.get(LibraryIndex::hash_rg(b"RG1")), 0);
+        assert!(build_library_lookup(&Header::default()).is_empty());
+    }
+
+    /// `hash_bytes(None)` is the documented zero sentinel, and the typed wrappers
+    /// agree with it — `GroupKey`'s `cell_hash`/`name_hash` rely on that.
+    #[test]
+    fn hash_helpers_agree_and_treat_none_as_zero() {
+        assert_eq!(LibraryIndex::hash_bytes(None), 0);
+        assert_eq!(LibraryIndex::hash_cell_barcode(None), 0);
+        assert_eq!(LibraryIndex::hash_name(None), 0);
+        assert_eq!(
+            LibraryIndex::hash_name(Some(b"read1")),
+            LibraryIndex::hash_bytes(Some(b"read1"))
+        );
+        assert_ne!(LibraryIndex::hash_name(Some(b"read1")), 0);
+    }
+}


### PR DESCRIPTION
Prerequisite for porting `src/lib/pipeline/steps/`. Additive: nothing calls the new modules yet.

## Why

The typed-step tree imports `fgumi_bam_io::{DecodedRecord, GroupKey, GroupKeyConfig, Grouper, compute_group_key_from_raw, name_hash_key}`. On this branch those types live in `src/lib/unified_pipeline/{base,bam}.rs`, and `name_hash_key` does not exist at all — so the new pipeline tree would have to import from the tree it is meant to replace, which inverts the dependency and breaks when `unified_pipeline` is eventually deleted.

This moves them next to the raw-record helpers they operate on, matching where `feat-runall` put them. `feat-runall`'s own `pipeline/mod.rs` states the intent: *"Shared grouping/decoded-record domain types … live in the `fgumi-bam-io` crate, next to the raw-record helpers they operate on."*

## What

- `crates/fgumi-bam-io/src/grouping.rs` (779 lines) — `DecodedRecord`, `GroupKey`, `GroupKeyConfig`, `Grouper`, `compute_group_key_from_raw`, `name_hash_key`
- `crates/fgumi-bam-io/src/library.rs` (193 lines) — `LibraryLookup`, `LibraryIndex`, `build_library_lookup`, which the group key depends on
- module declarations + re-exports in `lib.rs`
- `ahash` added to the crate's dependencies, via `workspace = true` (this branch's convention; `feat-runall` pins `"0.8"` directly). It was already a workspace dependency, used by `fgumi-consensus`, `fgumi-pipeline-core`, `fgumi-sort`, `fgumi-umi`.

Both files are self-contained: their only imports are `noodles::sam` and each other.

## Duplication

`unified_pipeline` keeps its own copies of the equivalent types. That duplicate is intentional and temporary — it retires when `unified_pipeline` is deleted, after the commands migrate. Nothing is changed in `unified_pipeline` here, so no existing behaviour moves.

## Verification

Full local gate on this branch:

- `cargo ci-fmt`, `cargo ci-lint`, `cargo ci-tag-literals` — clean
- `RUSTDOCFLAGS="-D warnings" cargo ci-doc` — clean
- `./scripts/publish-crates.sh --check` — clean
- `cargo ci-test` — **8192 passed**, 30 skipped (up 6 from 8186; the ported files bring their own tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: command output changes — none; unsafe changes — none, and the CLAUDE.md allowlist is unchanged; memory bounds, queue capacity, and thread/backpressure policy changes — none.

- Added shared grouping and library-lookup domain types to `fgumi-bam-io`.
- Added `GroupKey`, `DecodedRecord`, `GroupKeyConfig`, `Grouper`, and raw-record grouping helpers.
- Added `LibraryLookup`, `LibraryIndex`, and SAM-header library mapping.
- Re-exported the new APIs from the crate root.
- Added the workspace `ahash` dependency.
- Existing `unified_pipeline` types remain temporarily. No command uses the new modules yet.
- Formatting, linting, documentation, crate checks, and tests passed: 8,192 passed and 30 skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->