### PR TITLE
feat(pipeline): add the typed-step pipeline tree with its foundational steps (R1a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,8 @@ dependencies = [
  "fgumi-consensus",
  "fgumi-dna",
  "fgumi-metrics",
+ "fgumi-pipeline-core",
+ "fgumi-pipeline-io",
  "fgumi-raw-bam",
  "fgumi-sam",
  "fgumi-simd-fastq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,8 @@ fgumi-umi = { workspace = true }
 fgumi-consensus = { workspace = true }
 fgumi-bam-io = { workspace = true }
 fgumi-sort = { workspace = true }
+fgumi-pipeline-core = { workspace = true }
+fgumi-pipeline-io = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mach2 = { workspace = true }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -142,6 +142,7 @@ pub mod logging;
 pub mod metrics;
 pub mod mi_group;
 pub mod per_thread_accumulator;
+pub mod pipeline;
 pub use fgumi_consensus::phred;
 pub mod read_info;
 pub mod read_structure;

--- a/src/lib/pipeline/mod.rs
+++ b/src/lib/pipeline/mod.rs
@@ -1,0 +1,27 @@
+//! The typed-step pipeline framework for `--threads N` mode.
+//!
+//! A pipeline is a chain of [`core::step::Step`]s, each declaring a
+//! [`core::step::StepKind`] (`Serial` / `Parallel` / `Exclusive`); the engine
+//! runs all `N` worker threads through a round-robin dispatch loop with
+//! `Affinity`-based pinning for I/O sources/sinks. This keeps `--threads N` a
+//! strict thread cap with no separate I/O thread pools.
+//!
+//! # Module structure
+//!
+//! - [`core`]: typed-step execution engine (worker loop, queues, drain
+//!   protocol, reorder buffers).
+//! - [`steps`]: the concrete `Step` implementations (decompress, boundaries,
+//!   parse, serialize, compress, write, …).
+//!
+//! A `chains` module (declarative chain construction — `build_for`,
+//! `ChainBuilder`, per-command step factories) lands in a follow-up; until it
+//! does, nothing in `src/lib/commands` routes through this tree and every
+//! command still runs on `unified_pipeline`.
+
+/// The typed-step execution engine, extracted into the `fgumi-pipeline-core`
+/// crate so its lightweight dependency graph (no `noodles`-bam / sort /
+/// consensus) compiles fast in isolation. Re-exported here so every
+/// `crate::pipeline::core::…` path resolves — which is what lets the ported
+/// step sources compile unmodified.
+pub use fgumi_pipeline_core as core;
+pub mod steps;

--- a/src/lib/pipeline/steps/bgzf/compress.rs
+++ b/src/lib/pipeline/steps/bgzf/compress.rs
@@ -1,0 +1,313 @@
+//! `BgzfCompress` mid-step. `Parallel + ByItemOrdinal`. Compresses each
+//! `DecompressedBlock` into one logical `BgzfBlock` whose `bytes` field
+//! contains the concatenation of however many physical 64-KiB BGZF blocks
+//! `libdeflater` produces internally.
+//!
+//! ## 1:1 input-to-output mapping (Phase 3 design)
+//!
+//! Each `try_run` consumes exactly one input and emits exactly one output
+//! with `batch_serial = input.batch_serial`. This preserves the
+//! consecutive-ordinal invariant required by the downstream
+//! `ReorderStage` without any sub-serial encoding.
+//!
+//! Internally, `InlineBgzfCompressor` may produce multiple physical BGZF
+//! blocks when the input exceeds `BGZF_MAX_BLOCK_SIZE = 64 KiB`. We
+//! concatenate those physical blocks into a single `BgzfBlock`'s bytes —
+//! a valid BGZF stream is just a concatenation of independent blocks, so
+//! the downstream writer can emit them verbatim.
+
+use std::io;
+
+use fgumi_bgzf::InlineBgzfCompressor;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::{BgzfBlock, DecompressedBlock};
+
+/// Per-worker BGZF compressed-output scratch capacity. The compressed
+/// output of `BgzfCompress` is the concatenation of physical 64 KiB BGZF
+/// blocks; a single batch typically produces 1-4 such blocks. Sized to
+/// the typical case so the same mimalloc size class is hit every call.
+/// Matches legacy `bam.rs:1561` `SERIALIZATION_BUFFER_CAPACITY` × 4.
+const COMPRESS_SCRATCH_CAPACITY: usize = 256 * 1024;
+
+/// `Parallel + ByItemOrdinal` BGZF compressor.
+pub struct BgzfCompress {
+    /// Per-worker compressor (each worker holds its own clone).
+    compressor: InlineBgzfCompressor,
+    compression_level: u32,
+    /// Per-worker output scratch buffer; `mem::replace`d on each emit so
+    /// the freshly-allocated replacement is always the same size class.
+    /// See `BgzfDecompress::output_scratch` for rationale.
+    output_scratch: Vec<u8>,
+    held: HeldSlot<Unpushed<BgzfBlock>>,
+    output_byte_limit: u64,
+}
+
+impl BgzfCompress {
+    #[must_use]
+    pub fn new(compression_level: u32, output_byte_limit: u64) -> Self {
+        Self {
+            compressor: InlineBgzfCompressor::new(compression_level),
+            compression_level,
+            output_scratch: Vec::with_capacity(COMPRESS_SCRATCH_CAPACITY),
+            held: HeldSlot::new(),
+            output_byte_limit,
+        }
+    }
+}
+
+impl Clone for BgzfCompress {
+    fn clone(&self) -> Self {
+        Self {
+            compressor: InlineBgzfCompressor::new(self.compression_level),
+            compression_level: self.compression_level,
+            output_scratch: Vec::with_capacity(COMPRESS_SCRATCH_CAPACITY),
+            held: HeldSlot::new(),
+            output_byte_limit: self.output_byte_limit,
+        }
+    }
+}
+
+impl BgzfCompress {
+    /// Drain the compressor's physical BGZF blocks and assemble the single
+    /// output `BgzfBlock` byte buffer.
+    ///
+    /// INVARIANT: each block's `serial` is `InlineBgzfCompressor`'s monotonic
+    /// per-worker counter; it has no relation to the pipeline-wide
+    /// `batch_serial`. We deliberately drop it (read only `child.data`) and
+    /// inherit the parent's `batch_serial` for the emitted `BgzfBlock`. Future
+    /// code must NOT propagate `child.serial` into the framework's ordinal stream.
+    ///
+    /// The output is the concatenation of the physical block bytes (a valid BGZF
+    /// stream is just independent blocks back to back). When there is exactly one
+    /// physical block — the common case, since a batch usually fits in one 64 KiB
+    /// block — its buffer is moved out directly (no scratch allocation and no
+    /// concatenating memcpy); this is byte-identical to concatenating a single
+    /// block. For the multi-block case the bytes are concatenated into the
+    /// per-worker scratch (then `mem::replace`d out so the replacement stays in a
+    /// fixed mimalloc size class), and each drained child buffer is handed back to
+    /// the compressor's pool so the next compression reuses it.
+    fn assemble_output_bytes(&mut self) -> Vec<u8> {
+        let mut children = self.compressor.take_blocks();
+        match children.len() {
+            // No physical blocks — reachable from the all-clean rejects path,
+            // where an empty `DecompressedBlock` produces no BGZF output. Return
+            // an empty `Vec` rather than `mem::replace`-ing out the scratch:
+            // after a prior multi-block batch the scratch retains a
+            // `COMPRESS_SCRATCH_CAPACITY` allocation, and handing that out as an
+            // "empty" output would inflate queue memory/backpressure on the
+            // ordinal-preserving fast path.
+            0 => Vec::new(),
+            1 => children.pop().expect("len == 1").data,
+            _ => {
+                for child in children {
+                    self.output_scratch.extend_from_slice(&child.data);
+                    self.compressor.recycle_buffer(child.data);
+                }
+                std::mem::replace(
+                    &mut self.output_scratch,
+                    Vec::with_capacity(COMPRESS_SCRATCH_CAPACITY),
+                )
+            }
+        }
+    }
+}
+
+impl Step for BgzfCompress {
+    type Input = DecompressedBlock;
+    type Outputs = OrderedBytesSingle<BgzfBlock>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "BgzfCompress",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(parent) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let DecompressedBlock { batch_serial, bytes } = parent;
+        let uncompressed_size = u32::try_from(bytes.len()).unwrap_or(u32::MAX);
+
+        // Compress and harvest physical BGZF blocks.
+        self.compressor.write_all(&bytes)?;
+        self.compressor.flush()?;
+        let bytes = self.assemble_output_bytes();
+
+        let out = BgzfBlock { batch_serial, bytes, uncompressed_size };
+        match ctx.outputs.push(out) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_advertises_parallel_byordinal() {
+        let s = BgzfCompress::new(1, 1024);
+        let p = s.profile();
+        assert_eq!(p.name, "BgzfCompress");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    #[test]
+    fn clone_constructs_fresh_compressor() {
+        let s = BgzfCompress::new(1, 1024);
+        let _cloned = s.clone();
+    }
+
+    #[test]
+    fn small_input_produces_single_concatenated_output() {
+        let mut s = BgzfCompress::new(1, 1024);
+        s.compressor.write_all(b"hello bgzf").unwrap();
+        s.compressor.flush().unwrap();
+        let blocks = s.compressor.take_blocks();
+        assert!(!blocks.is_empty(), "expected at least one BGZF block");
+        // Each block is a valid BGZF block (starts with gzip magic 0x1f 0x8b).
+        for b in &blocks {
+            assert_eq!(&b.data[..2], &[0x1f, 0x8b], "BGZF magic");
+        }
+    }
+
+    /// Reference assembly: the straightforward concatenation the move/recycle
+    /// fast path must reproduce byte-for-byte.
+    fn reference_concat(level: u32, input: &[u8]) -> Vec<u8> {
+        let mut c = InlineBgzfCompressor::new(level);
+        c.write_all(input).unwrap();
+        c.flush().unwrap();
+        let mut out = Vec::new();
+        for block in c.take_blocks() {
+            out.extend_from_slice(&block.data);
+        }
+        out
+    }
+
+    /// Drive `assemble_output_bytes` on a fresh step over `input`.
+    fn assemble(level: u32, input: &[u8]) -> Vec<u8> {
+        let mut s = BgzfCompress::new(level, 1024);
+        s.compressor.write_all(input).unwrap();
+        s.compressor.flush().unwrap();
+        s.assemble_output_bytes()
+    }
+
+    #[test]
+    fn single_block_fast_path_is_byte_identical() {
+        // Small input → one physical block → move fast path.
+        let input = b"the quick brown fox jumps over the lazy dog";
+        let mut s = BgzfCompress::new(1, 1024);
+        s.compressor.write_all(input).unwrap();
+        s.compressor.flush().unwrap();
+        assert_eq!(s.compressor.take_blocks().len(), 1, "input should fit one block");
+
+        let assembled = assemble(1, input);
+        assert_eq!(assembled, reference_concat(1, input));
+        assert_eq!(&assembled[..2], &[0x1f, 0x8b], "valid BGZF magic");
+    }
+
+    #[test]
+    fn multi_block_concat_path_is_byte_identical() {
+        // Input larger than one 64 KiB block forces the multi-block concat +
+        // recycle path; output must still match the plain concatenation.
+        let mut input = Vec::with_capacity(200 * 1024);
+        for i in 0..(200 * 1024u32) {
+            input.push((i % 251) as u8);
+        }
+        let mut s = BgzfCompress::new(1, 1024);
+        s.compressor.write_all(&input).unwrap();
+        s.compressor.flush().unwrap();
+        assert!(s.compressor.take_blocks().len() > 1, "input should span >1 block");
+
+        let assembled = assemble(1, &input);
+        assert_eq!(assembled, reference_concat(1, &input));
+    }
+
+    #[test]
+    fn recycle_buffer_repopulates_pool_for_reuse() {
+        // After the multi-block path recycles buffers, a subsequent compression
+        // reuses them, and output remains byte-identical to a fresh compressor.
+        let big: Vec<u8> = (0..(200 * 1024u32)).map(|i| (i % 251) as u8).collect();
+        let mut s = BgzfCompress::new(1, 1024);
+
+        s.compressor.write_all(&big).unwrap();
+        s.compressor.flush().unwrap();
+        let first = s.assemble_output_bytes();
+        assert_eq!(first, reference_concat(1, &big));
+
+        // Second block through the same (now pool-primed) compressor.
+        s.compressor.write_all(&big).unwrap();
+        s.compressor.flush().unwrap();
+        let second = s.assemble_output_bytes();
+        assert_eq!(second, reference_concat(1, &big), "recycled buffers must not corrupt output");
+    }
+
+    #[test]
+    fn empty_batch_returns_unallocated_vec() {
+        // An all-clean rejects batch produces no physical BGZF blocks. The
+        // assembled output must be a truly empty `Vec`, not the per-worker
+        // scratch — otherwise an "empty" output carries a retained
+        // `COMPRESS_SCRATCH_CAPACITY` allocation and inflates queue memory.
+        let mut s = BgzfCompress::new(1, 1024);
+
+        // Fresh compressor, nothing written → no blocks.
+        let fresh = s.assemble_output_bytes();
+        assert!(fresh.is_empty());
+        assert_eq!(fresh.capacity(), 0, "empty output must not carry a scratch allocation");
+
+        // After a real multi-block batch (which routes through the scratch and
+        // replaces it with a `COMPRESS_SCRATCH_CAPACITY` Vec), a following empty
+        // batch must still return an unallocated Vec.
+        let big: Vec<u8> = (0..(200 * 1024u32)).map(|i| (i % 251) as u8).collect();
+        s.compressor.write_all(&big).unwrap();
+        s.compressor.flush().unwrap();
+        let multi = s.assemble_output_bytes();
+        assert!(!multi.is_empty(), "multi-block batch should produce output");
+
+        let after = s.assemble_output_bytes(); // no new input → empty batch
+        assert!(after.is_empty());
+        assert_eq!(
+            after.capacity(),
+            0,
+            "empty batch after a multi-block batch must not retain scratch"
+        );
+    }
+}

--- a/src/lib/pipeline/steps/bgzf/decompress.rs
+++ b/src/lib/pipeline/steps/bgzf/decompress.rs
@@ -1,0 +1,159 @@
+//! `BgzfDecompress` mid-step. `Parallel + ByItemOrdinal`. Decompresses
+//! incoming `BgzfBlock`s into `DecompressedBlock`s using `libdeflater`'s
+//! decompressor (one per worker via `Clone`).
+
+use std::io;
+
+use fgumi_bgzf::reader::decompress_block_slice_into;
+use libdeflater::Decompressor;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::{BgzfBlock, DecompressedBlock};
+
+/// Per-worker decompression scratch capacity. Sized to the upper end
+/// of typical BGZF block decompressed sizes (256 KiB ≈ 4 blocks × 64 KiB).
+/// Mirrors legacy `pipeline/bam.rs:1560` `DECOMPRESSION_BUFFER_CAPACITY`.
+///
+/// Why a fixed size: when each `try_run` calls `Vec::with_capacity(N)` with
+/// a *variable* `N` (= `block.uncompressed_size`), every allocation hits a
+/// different mimalloc size class and defeats the thread-local cache. A
+/// fixed capacity always pulls from the same size class so the freed
+/// buffer that just left for downstream gets reused on the next call.
+const DECOMPRESS_SCRATCH_CAPACITY: usize = 256 * 1024;
+
+/// `Parallel + ByItemOrdinal` decompressor. Each worker holds its own
+/// `libdeflater::Decompressor` (`Clone` constructs a fresh one) and a
+/// fixed-capacity output scratch buffer that's emitted via `mem::replace`
+/// to avoid variable-size allocations on the hot path.
+pub struct BgzfDecompress {
+    decompressor: Decompressor,
+    /// Per-worker output scratch. `try_run` decompresses into this
+    /// buffer, then swaps it out with a fresh fixed-capacity Vec via
+    /// `mem::replace`. Keeps allocations on a single mimalloc size
+    /// class so the thread-local cache can recycle them. Mirrors legacy
+    /// `WorkerState::decompression_buffer`.
+    output_scratch: Vec<u8>,
+    held: HeldSlot<Unpushed<DecompressedBlock>>,
+    output_byte_limit: u64,
+}
+
+impl BgzfDecompress {
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self {
+            decompressor: Decompressor::new(),
+            output_scratch: Vec::with_capacity(DECOMPRESS_SCRATCH_CAPACITY),
+            held: HeldSlot::new(),
+            output_byte_limit,
+        }
+    }
+}
+
+impl Clone for BgzfDecompress {
+    fn clone(&self) -> Self {
+        Self {
+            decompressor: Decompressor::new(),
+            output_scratch: Vec::with_capacity(DECOMPRESS_SCRATCH_CAPACITY),
+            held: HeldSlot::new(),
+            output_byte_limit: self.output_byte_limit,
+        }
+    }
+}
+
+impl Step for BgzfDecompress {
+    type Input = BgzfBlock;
+    type Outputs = OrderedBytesSingle<DecompressedBlock>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "BgzfDecompress",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    // `Contention` (not `NoProgress`) keeps the worker
+                    // alive for retry — `NoProgress` would let the
+                    // framework mark this worker `Skip` if input is also
+                    // drained, silently dropping the held item.
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(block) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+
+        // Decompress into the per-worker scratch buffer. After the
+        // decompressor fills it, `mem::replace` swaps it out (the filled
+        // buffer goes into the emitted block; a fresh fixed-capacity
+        // buffer takes its place). Single mimalloc size class keeps the
+        // thread-local cache hot.
+        decompress_block_slice_into(
+            &block.bytes,
+            &mut self.decompressor,
+            &mut self.output_scratch,
+        )?;
+        let bytes = std::mem::replace(
+            &mut self.output_scratch,
+            Vec::with_capacity(DECOMPRESS_SCRATCH_CAPACITY),
+        );
+
+        let decompressed = DecompressedBlock { batch_serial: block.batch_serial, bytes };
+
+        match ctx.outputs.push(decompressed) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_advertises_parallel_byordinal() {
+        let s = BgzfDecompress::new(1024);
+        let p = s.profile();
+        assert_eq!(p.name, "BgzfDecompress");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    #[test]
+    fn clone_constructs_fresh_decompressor() {
+        let s = BgzfDecompress::new(1024);
+        let _cloned = s.clone();
+    }
+}

--- a/src/lib/pipeline/steps/bgzf/mod.rs
+++ b/src/lib/pipeline/steps/bgzf/mod.rs
@@ -1,0 +1,4 @@
+//! BGZF compress/decompress steps.
+
+pub mod compress;
+pub mod decompress;

--- a/src/lib/pipeline/steps/boundaries/bam.rs
+++ b/src/lib/pipeline/steps/boundaries/bam.rs
@@ -1,0 +1,177 @@
+//! `FindBamBoundaries` mid-step. `Serial + ByItemOrdinal`. Strips the BAM
+//! header (on first input) and finds record boundaries within decompressed
+//! BGZF block data, emitting `DecompressedBlock`s whose bytes contain only
+//! complete records (4-byte `block_size` prefix + record body, repeated).
+//!
+//! Wraps [`super::state::BoundaryState`] — the boundary-finding state
+//! machine handles header skipping, cross-block record carryover, and
+//! validation. Reusing it ensures the new framework's boundary semantics
+//! match the legacy pipeline's exactly.
+
+use std::io;
+
+use super::state::BoundaryState;
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::DecompressedBlock;
+
+/// Max inputs processed per `try_run` invocation. Amortizes the Serial
+/// mutex acquisition; matches legacy `bam.rs:2050+` (`MAX_BATCHES_PER_LOCK`).
+const MAX_BATCHES_PER_LOCK: usize = 8;
+
+/// `Serial + ByItemOrdinal` boundary finder. Holds `BoundaryState` (which
+/// owns the cross-block carryover buffer + header-skip flag).
+pub struct FindBamBoundaries {
+    state: BoundaryState,
+    /// Pending output batch when we found boundaries but the push was
+    /// rejected. Held across retries until pushed.
+    held: HeldSlot<Unpushed<DecompressedBlock>>,
+    /// Self-managed output ordinal. Incremented only when a new
+    /// `DecompressedBlock` is emitted. Using the input's `batch_serial`
+    /// directly would skip ordinals when the boundary state absorbs an
+    /// input without producing output (header bytes, mid-record carryover);
+    /// the downstream `ReorderStage` requires consecutive `0, 1, 2, …`.
+    next_output_serial: u64,
+    /// Set once the final-flush path has called the (non-idempotent)
+    /// `state.finish()`; guards against a second call across the multi-pass
+    /// completion drain.
+    finalized: bool,
+    output_byte_limit: u64,
+}
+
+impl FindBamBoundaries {
+    /// Construct expecting the first input batch to begin with the BAM
+    /// header (matches `BAM_MAGIC`). The header bytes are skipped on the
+    /// first call; subsequent calls just find record boundaries.
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self {
+            state: BoundaryState::new(),
+            held: HeldSlot::new(),
+            next_output_serial: 0,
+            finalized: false,
+            output_byte_limit,
+        }
+    }
+
+    /// Construct expecting the input stream to be already past the BAM
+    /// header. Useful for runall-spliced sub-pipelines.
+    #[must_use]
+    pub fn new_no_header(output_byte_limit: u64) -> Self {
+        Self {
+            state: BoundaryState::new_no_header(),
+            held: HeldSlot::new(),
+            next_output_serial: 0,
+            finalized: false,
+            output_byte_limit,
+        }
+    }
+}
+
+impl Step for FindBamBoundaries {
+    type Input = DecompressedBlock;
+    type Outputs = OrderedBytesSingle<DecompressedBlock>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "FindBamBoundaries",
+            kind: StepKind::Serial,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        // Process up to `MAX_BATCHES_PER_LOCK` inputs per `try_run` to
+        // amortize the Serial mutex acquisition. Each iteration pops one
+        // input, runs find_boundaries, and pushes at most one output —
+        // header-only or carryover-only inputs are fully absorbed and produce
+        // no output (the loop `continue`s, and `did_work` still records the
+        // consumed input as Progress). We stop early on push rejection (held
+        // the unpushed; subsequent iterations would contend on backpressure)
+        // or on input exhaustion.
+        let mut did_work = false;
+        for _ in 0..MAX_BATCHES_PER_LOCK {
+            let Some(block) = ctx.input.pop() else { break };
+            did_work = true;
+
+            let boundary_batch = self.state.find_boundaries(&block.bytes)?;
+            if boundary_batch.buffer.is_empty() {
+                // Input fully absorbed (header/leftover); try next input.
+                continue;
+            }
+
+            let serial = self.next_output_serial;
+            self.next_output_serial += 1;
+            let out = DecompressedBlock { batch_serial: serial, bytes: boundary_batch.buffer };
+            match ctx.outputs.push(out) {
+                Ok(()) => {}
+                Err(unpushed) => {
+                    self.held.put(unpushed);
+                    // Hold off on more inputs — the held item must clear
+                    // before we accept new work.
+                    return Ok(StepOutcome::Progress);
+                }
+            }
+        }
+
+        if did_work {
+            return Ok(StepOutcome::Progress);
+        }
+
+        // No input this call. If upstream is drained, flush the boundary
+        // state's final partial-record buffer once (guarded by `finalized` —
+        // `state.finish()` is not idempotent), emit it, and report `Finished`
+        // once nothing remains. `held` is empty here (step 1 returned
+        // `Contention` otherwise); a bounced final push is parked in `held`
+        // for the held-drain at the top of the next pass.
+        if ctx.input.is_drained() {
+            if !self.finalized {
+                self.finalized = true;
+                if let Some(boundary_batch) = self.state.finish()?
+                    && !boundary_batch.buffer.is_empty()
+                {
+                    let serial = self.next_output_serial;
+                    self.next_output_serial += 1;
+                    let out =
+                        DecompressedBlock { batch_serial: serial, bytes: boundary_batch.buffer };
+                    if let Err(unpushed) = ctx.outputs.push(out) {
+                        self.held.put(unpushed);
+                    }
+                    return Ok(StepOutcome::Progress);
+                }
+            }
+            return Ok(StepOutcome::Finished);
+        }
+        Ok(StepOutcome::NoProgress)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_advertises_serial_byordinal() {
+        let s = FindBamBoundaries::new(1024);
+        let p = s.profile();
+        assert_eq!(p.name, "FindBamBoundaries");
+        assert_eq!(p.kind, StepKind::Serial);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+}

--- a/src/lib/pipeline/steps/boundaries/mod.rs
+++ b/src/lib/pipeline/steps/boundaries/mod.rs
@@ -1,0 +1,4 @@
+//! Per-format boundary-finding steps.
+
+pub mod bam;
+pub mod state;

--- a/src/lib/pipeline/steps/boundaries/state.rs
+++ b/src/lib/pipeline/steps/boundaries/state.rs
@@ -1,0 +1,876 @@
+//! `BoundaryState` / `BoundaryBatch`: the BAM record-boundary state machine.
+//!
+//! Scans decompressed BGZF block data for BAM record boundaries (header skip,
+//! cross-block record carryover, EOF validation) without decoding records.
+//! Driven by the `FindBamBoundaries` step (`super::bam`).
+//!
+//! Relocated from the legacy `bam.rs` (deleted in the issue #330 migration);
+//! the boundary-finding logic is reused verbatim so the new framework's
+//! boundary semantics match the legacy pipeline's exactly.
+
+use std::io;
+
+/// Upper bound on bytes the scanner will carry forward waiting for one record
+/// (or the BAM header) to complete.
+///
+/// This is a **corruption backstop, not a biological limit**. The scanner is a
+/// push scanner: it is handed decompressed blocks and cannot ask for "the rest
+/// of this record" the way a pull reader (htslib's `bam_read1`) can, so a
+/// corrupt length field makes every block look like "not enough data yet" and
+/// the carry grows for the rest of the stream. That still terminates —
+/// [`BoundaryState::finish`] reports the shortfall at EOF — but only after
+/// buffering the remaining input, so a large corrupt file exhausts memory
+/// before it can print the diagnostic it was about to print.
+///
+/// The value sits in the gap between what BAM permits and what BAM files
+/// contain. `block_size` is a `u32`, so the format allows a ~4 GiB record, while
+/// the largest records seen in practice — ONT ultra-long reads carrying
+/// methylation tags — run a few MB. 256 MiB is roughly 25-50x above that and
+/// still bounds memory hard.
+///
+/// It is deliberately NOT tied to the pipeline's queue budget: byte-bounded
+/// queues always admit at least one item regardless of size, so a legitimate
+/// multi-MB record flows through a 4 MiB per-step budget, and bounding the carry
+/// there would reject valid BAMs.
+const MAX_CARRY_BYTES: usize = 256 * 1024 * 1024;
+
+/// Output of `FindBoundaries` step: buffer + record offsets for parallel decoding.
+///
+/// This struct enables parallel BAM record decoding by pre-computing where
+/// each record starts in the decompressed data. The actual parsing/decoding
+/// can then be parallelized across multiple threads.
+#[derive(Debug, Clone)]
+pub struct BoundaryBatch {
+    /// The decompressed bytes (with leftover prepended, suffix removed).
+    pub buffer: Vec<u8>,
+    /// Byte offsets where each record starts (offsets into buffer).
+    /// Length = `num_records` + 1 (last entry is `buffer.len()` for easy slicing).
+    pub offsets: Vec<usize>,
+}
+
+/// State for the `FindBoundaries` step (sequential).
+///
+/// This state maintains leftover bytes from incomplete records that span
+/// across BGZF block boundaries. The boundary finding is very fast (~0.1μs
+/// per block) since it only reads 4-byte integers without decoding records.
+///
+/// Uses a reusable work buffer to minimize allocations on the hot path.
+pub struct BoundaryState {
+    /// Leftover bytes from previous block (incomplete record at end).
+    leftover: Vec<u8>,
+    /// Reusable working buffer to avoid per-call allocations.
+    work_buffer: Vec<u8>,
+    /// Whether the BAM header has been skipped.
+    header_skipped: bool,
+    /// Length of the previous call's `offsets` Vec, used to pre-size the next
+    /// one. Adjacent BGZF blocks hold near-identical record counts, so this
+    /// collapses the per-block push-regrowth (~8 reallocations) to ~1. The
+    /// returned `offsets` Vec is moved into `BoundaryBatch`, so it cannot be a
+    /// reused buffer; pre-sizing is the cheap, correctness-neutral alternative.
+    prev_offsets_len: usize,
+}
+
+impl BoundaryState {
+    /// Create a new boundary state.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            leftover: Vec::new(),
+            work_buffer: Vec::new(),
+            header_skipped: false,
+            prev_offsets_len: 0,
+        }
+    }
+
+    /// Create a new boundary state that doesn't skip the header.
+    /// Use this when the input stream is already positioned past the header.
+    #[must_use]
+    pub fn new_no_header() -> Self {
+        Self {
+            leftover: Vec::new(),
+            work_buffer: Vec::new(),
+            header_skipped: true,
+            prev_offsets_len: 0,
+        }
+    }
+
+    /// Parse BAM header and return the number of bytes consumed.
+    ///
+    /// `Ok(None)` means more data is needed. `Err` means the header's own length
+    /// fields are corrupt — their sum overflows `usize`, so no amount of further
+    /// data could satisfy them.
+    ///
+    /// # Errors
+    ///
+    /// Returns `InvalidData` when `l_text` or a reference's `l_name` overflows
+    /// the running offset. Unreachable on 64-bit targets (both are `u32` widened
+    /// to `usize`); present because a length field taken from the stream must be
+    /// folded in with checked arithmetic rather than trusted to fit.
+    fn parse_header_size(data: &[u8]) -> io::Result<Option<usize>> {
+        // BAM header structure:
+        // - magic: 4 bytes ("BAM\1")
+        // - l_text: 4 bytes (header text length)
+        // - text: l_text bytes
+        // - n_ref: 4 bytes (number of references)
+        // - for each reference:
+        //   - l_name: 4 bytes
+        //   - name: l_name bytes
+        //   - l_ref: 4 bytes
+
+        if data.len() < 8 {
+            return Ok(None);
+        }
+
+        // Check magic
+        if &data[0..4] != fgumi_raw_bam::BAM_MAGIC {
+            // Not a valid BAM file, but let's not error here
+            // Just return 0 so records start immediately
+            return Ok(Some(0));
+        }
+
+        let l_text = u32::from_le_bytes([data[4], data[5], data[6], data[7]]) as usize;
+        let Some(mut offset) = 8usize.checked_add(l_text) else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "FindBamBoundaries: BAM header l_text={l_text} overflows the header offset"
+                ),
+            ));
+        };
+
+        if data.len() < offset + 4 {
+            return Ok(None);
+        }
+
+        let n_ref = u32::from_le_bytes([
+            data[offset],
+            data[offset + 1],
+            data[offset + 2],
+            data[offset + 3],
+        ]) as usize;
+        offset += 4;
+
+        // Parse each reference
+        for _ in 0..n_ref {
+            if data.len() < offset + 4 {
+                return Ok(None);
+            }
+            let l_name = u32::from_le_bytes([
+                data[offset],
+                data[offset + 1],
+                data[offset + 2],
+                data[offset + 3],
+            ]) as usize;
+            // l_name + name + l_ref, folded in with checked arithmetic for the
+            // same reason as `l_text` above.
+            let Some(next) = offset.checked_add(8).and_then(|o| o.checked_add(l_name)) else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "FindBamBoundaries: BAM header l_name={l_name} overflows \
+                         the header offset at {offset}"
+                    ),
+                ));
+            };
+            offset = next;
+
+            if data.len() < offset {
+                return Ok(None);
+            }
+        }
+
+        Ok(Some(offset))
+    }
+
+    /// Find record boundaries in decompressed data.
+    ///
+    /// This is FAST (~0.1μs per block) because it only scans 4-byte integers
+    /// to find where records start - no actual record decoding is performed.
+    ///
+    /// # Arguments
+    ///
+    /// * `decompressed` - Decompressed bytes from one or more BGZF blocks
+    ///
+    /// # Returns
+    ///
+    /// A `BoundaryBatch` containing the complete records and their offsets.
+    /// Any incomplete record at the end is saved as leftover for the next call.
+    ///
+    /// # Errors
+    ///
+    /// Returns `InvalidData` if the bytes carried forward waiting for the header
+    /// or for one record to complete exceed this module's `MAX_CARRY_BYTES`
+    /// corruption backstop. A well-formed stream always completes a record
+    /// within a bounded carry, so exceeding it means a length field is corrupt.
+    ///
+    /// # Record-level validation
+    ///
+    /// This function does NOT validate individual record `block_size` values
+    /// against a malformed (but self-consistent) BAM stream. The per-record
+    /// cross-check below (offset delta vs. the stored prefix) is a
+    /// `debug_assertions`-only regression tripwire for this scanner's own
+    /// arithmetic — it re-reads the same `block_size` bytes the scan already
+    /// trusted, so it can only catch an internal bookkeeping bug, never input
+    /// corruption. Authoritative release-build validation of record structure
+    /// (out-of-bounds record end, trailing partial record) is performed
+    /// downstream by `parse_records` / `parse_record_ranges` on the same bytes,
+    /// which hard-error in all build modes. The `offsets` vector this returns
+    /// is not consumed in release builds (`FindBamBoundaries` forwards only
+    /// `buffer`), so promoting the cross-check to release would re-validate a
+    /// tautology at a per-record cost for no correctness benefit.
+    pub fn find_boundaries(&mut self, decompressed: &[u8]) -> io::Result<BoundaryBatch> {
+        // Step 1: Combine leftover with new data into reusable work_buffer
+        // This avoids allocating a new Vec on every call
+        self.work_buffer.clear();
+        if !self.leftover.is_empty() {
+            self.work_buffer.append(&mut self.leftover);
+        }
+        self.work_buffer.extend_from_slice(decompressed);
+
+        // Step 2: Skip header if not already done
+        let mut cursor = 0usize;
+        if !self.header_skipped {
+            if let Some(header_size) = Self::parse_header_size(&self.work_buffer)? {
+                cursor = header_size;
+                self.header_skipped = true;
+            } else {
+                // Not enough data to parse header yet. Bound the carry: a corrupt
+                // `l_text` / `l_name` makes this branch unreachable-to-satisfy, so
+                // without the check every remaining block accumulates here.
+                if self.work_buffer.len() > MAX_CARRY_BYTES {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "FindBamBoundaries: BAM header still unresolved after {} byte(s) \
+                             (limit {MAX_CARRY_BYTES}); the header length fields are corrupt",
+                            self.work_buffer.len(),
+                        ),
+                    ));
+                }
+                // Save as leftover and return an empty batch.
+                std::mem::swap(&mut self.leftover, &mut self.work_buffer);
+                return Ok(BoundaryBatch { buffer: Vec::new(), offsets: vec![0] });
+            }
+        }
+
+        // Step 3: Scan for record boundaries (FAST - just read integers)
+        let start_cursor = cursor;
+        // Pre-size from the previous block's record count so the per-record
+        // pushes below don't trigger repeated Vec regrowth (adjacent blocks
+        // hold near-identical record counts). First offset is 0 (relative to
+        // the start of records).
+        let mut offsets = Vec::with_capacity(self.prev_offsets_len.max(1));
+        offsets.push(0usize);
+
+        while cursor + 4 <= self.work_buffer.len() {
+            let block_size = u32::from_le_bytes([
+                self.work_buffer[cursor],
+                self.work_buffer[cursor + 1],
+                self.work_buffer[cursor + 2],
+                self.work_buffer[cursor + 3],
+            ]) as usize;
+
+            // Checked: `block_size` comes from the stream. Unreachable on
+            // 64-bit, but the framing rule is checked-before-use.
+            let Some(record_end) = cursor.checked_add(4).and_then(|c| c.checked_add(block_size))
+            else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "FindBamBoundaries: record end overflows \
+                         (cursor={cursor}, block_size={block_size})"
+                    ),
+                ));
+            };
+            if record_end > self.work_buffer.len() {
+                break; // Incomplete record - becomes leftover
+            }
+
+            cursor = record_end;
+            // Offset is relative to start of records (after header)
+            offsets.push(cursor - start_cursor);
+        }
+
+        // Remember this block's offset count to pre-size the next call.
+        self.prev_offsets_len = offsets.len();
+
+        // Step 4: Save leftover for next block (reuse allocation)
+        // Split work_buffer: [0..start_cursor | start_cursor..cursor | cursor..]
+        //                     header (discard) | records (output)    | leftover
+        // Bound the carry before retaining it: a corrupt `block_size` keeps the
+        // scan breaking at the same record forever, so without this the leftover
+        // grows to the size of the remaining input. `finish` would still catch
+        // the shortfall at EOF, but only after the memory was already spent.
+        let carry_len = self.work_buffer.len() - cursor;
+        if carry_len > MAX_CARRY_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "FindBamBoundaries: incomplete BAM record has carried {carry_len} byte(s) \
+                     (limit {MAX_CARRY_BYTES}); its block_size prefix is corrupt",
+                ),
+            ));
+        }
+        self.leftover.clear();
+        self.leftover.extend_from_slice(&self.work_buffer[cursor..]);
+
+        // Extract the records buffer - this allocation is unavoidable as we return ownership
+        let buffer = self.work_buffer[start_cursor..cursor].to_vec();
+
+        // Debug-only regression tripwire (NOT input validation): cross-check
+        // each record's stored block_size prefix against the offset delta this
+        // scan just computed. Both derive from the same bytes with no
+        // intervening mutation, so this only catches an internal arithmetic /
+        // indexing bug in the scan above — a corrupt-but-self-consistent
+        // block_size passes trivially. Authoritative release validation lives
+        // in parse_records / parse_record_ranges downstream (see the
+        // `find_boundaries` doc comment).
+        #[cfg(debug_assertions)]
+        for i in 0..offsets.len().saturating_sub(1) {
+            let start = offsets[i];
+            let end = offsets[i + 1];
+            if end > start + 4 {
+                let stored = u32::from_le_bytes([
+                    buffer[start],
+                    buffer[start + 1],
+                    buffer[start + 2],
+                    buffer[start + 3],
+                ]) as usize;
+                let expected = end - start - 4;
+                debug_assert_eq!(
+                    stored, expected,
+                    "find_boundaries: block_size mismatch at record {i}: stored={stored}, expected={expected}"
+                );
+            }
+        }
+
+        Ok(BoundaryBatch { buffer, offsets })
+    }
+
+    /// Call at EOF to get any remaining leftover.
+    ///
+    /// This validates that any remaining bytes form complete records.
+    /// If there are incomplete bytes at EOF, an error is returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if there are incomplete BAM records at EOF.
+    pub fn finish(&mut self) -> io::Result<Option<BoundaryBatch>> {
+        if self.leftover.is_empty() {
+            return Ok(None);
+        }
+
+        // Try to parse remaining leftover
+        let mut offsets = vec![0usize];
+        let mut cursor = 0usize;
+
+        while cursor + 4 <= self.leftover.len() {
+            let block_size = u32::from_le_bytes([
+                self.leftover[cursor],
+                self.leftover[cursor + 1],
+                self.leftover[cursor + 2],
+                self.leftover[cursor + 3],
+            ]) as usize;
+
+            // Checked for the same reason as the scan loop above.
+            let Some(record_end) = cursor.checked_add(4).and_then(|c| c.checked_add(block_size))
+            else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "FindBamBoundaries: record end overflows at EOF \
+                         (cursor={cursor}, block_size={block_size})"
+                    ),
+                ));
+            };
+            if record_end > self.leftover.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    format!(
+                        "Incomplete BAM record at EOF: need {} bytes, have {}",
+                        record_end - cursor,
+                        self.leftover.len() - cursor
+                    ),
+                ));
+            }
+
+            cursor = record_end;
+            offsets.push(cursor);
+        }
+
+        // The loop only advances `cursor` by whole records. If it stops with
+        // bytes still unconsumed (`cursor < leftover.len()`), those 1-3 trailing
+        // bytes are too short to even hold a 4-byte block-size prefix — i.e. a
+        // truncated BAM record. Surface it as an error rather than dropping the
+        // bytes and masking corruption.
+        if cursor < self.leftover.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!(
+                    "Incomplete BAM record at EOF: {} trailing byte(s) cannot form a complete record",
+                    self.leftover.len() - cursor
+                ),
+            ));
+        }
+
+        Ok(Some(BoundaryBatch { buffer: std::mem::take(&mut self.leftover), offsets }))
+    }
+}
+
+impl Default for BoundaryState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    /// Frame `payload` as one BAM record: `block_size: u32 LE` + body. The
+    /// scanner never inspects the body, so an opaque payload is sufficient —
+    /// and keeps each case's record lengths readable in the table.
+    fn record(payload: &[u8]) -> Vec<u8> {
+        let mut framed = Vec::with_capacity(4 + payload.len());
+        framed.extend_from_slice(
+            &u32::try_from(payload.len()).expect("payload fits u32").to_le_bytes(),
+        );
+        framed.extend_from_slice(payload);
+        framed
+    }
+
+    /// A well-formed binary BAM header: magic, `l_text` + text, `n_ref`, then
+    /// `(l_name, name\0, l_ref)` per reference. This is exactly the prefix
+    /// `parse_header_size` walks, so building it honestly is what makes the
+    /// header-skip assertions meaningful.
+    fn bam_header(text: &str, refs: &[(&str, u32)]) -> Vec<u8> {
+        let mut header = Vec::new();
+        header.extend_from_slice(fgumi_raw_bam::BAM_MAGIC);
+        header.extend_from_slice(&u32::try_from(text.len()).expect("text fits u32").to_le_bytes());
+        header.extend_from_slice(text.as_bytes());
+        header.extend_from_slice(&u32::try_from(refs.len()).expect("n_ref fits u32").to_le_bytes());
+        for (name, ref_len) in refs {
+            let mut name_bytes = name.as_bytes().to_vec();
+            name_bytes.push(0); // names are NUL-terminated, and l_name counts the NUL
+            header.extend_from_slice(
+                &u32::try_from(name_bytes.len()).expect("l_name fits u32").to_le_bytes(),
+            );
+            header.extend_from_slice(&name_bytes);
+            header.extend_from_slice(&ref_len.to_le_bytes());
+        }
+        header
+    }
+
+    /// Concatenate framed records, as one decompressed block would hold them.
+    fn records(payloads: &[&[u8]]) -> Vec<u8> {
+        payloads.iter().flat_map(|p| record(p)).collect()
+    }
+
+    // ========================================================================
+    // Header skipping
+    // ========================================================================
+
+    /// The header must be consumed and excluded from the emitted buffer, with
+    /// only record bytes surviving. Parameterized over header shapes because
+    /// `parse_header_size`'s arithmetic differs per section: text length and
+    /// per-reference `(l_name, name, l_ref)` walking are separate loops, and a
+    /// bug in either would pass the other's case.
+    #[rstest]
+    #[case::no_text_no_refs("", &[])]
+    #[case::text_only("@HD\tVN:1.6\n", &[])]
+    #[case::one_ref("@HD\tVN:1.6\n", &[("chr1", 1000)])]
+    #[case::several_refs("@HD\tVN:1.6\n", &[("chr1", 1000), ("chr2", 2000), ("chrM", 16569)])]
+    #[case::empty_text_with_refs("", &[("chr1", 248_956_422)])]
+    fn find_boundaries_skips_the_header_and_emits_only_record_bytes(
+        #[case] text: &str,
+        #[case] refs: &[(&str, u32)],
+    ) {
+        let payloads: [&[u8]; 2] = [&[1u8; 8], &[2u8; 16]];
+        let mut block = bam_header(text, refs);
+        block.extend_from_slice(&records(&payloads));
+
+        let mut state = BoundaryState::new();
+        let batch = state.find_boundaries(&block).expect("well-formed block scans");
+
+        assert_eq!(
+            batch.buffer,
+            records(&payloads),
+            "header bytes must not reach the output buffer"
+        );
+        assert_eq!(batch.offsets, vec![0, 12, 32], "offsets are relative to the first record");
+    }
+
+    /// A `BoundaryState::new_no_header()` treats byte 0 as the first record —
+    /// this is the runall-spliced sub-pipeline case, where an upstream stage
+    /// already consumed the header.
+    #[test]
+    fn new_no_header_treats_the_first_byte_as_a_record_boundary() {
+        let payloads: [&[u8]; 2] = [&[7u8; 4], &[9u8; 4]];
+        let block = records(&payloads);
+
+        let mut state = BoundaryState::new_no_header();
+        let batch = state.find_boundaries(&block).expect("record-aligned block scans");
+
+        assert_eq!(batch.buffer, block, "every byte is a record byte when the header is skipped");
+        assert_eq!(batch.offsets, vec![0, 8, 16]);
+    }
+
+    /// `Default` must agree with `new()` — i.e. it expects a header. Asserted
+    /// behaviorally (the header is consumed) rather than by comparing private
+    /// fields, so the test survives a field-level refactor.
+    #[test]
+    fn default_expects_a_header_like_new() {
+        let payloads: [&[u8]; 1] = [&[1u8; 8]];
+        let mut block = bam_header("", &[]);
+        block.extend_from_slice(&records(&payloads));
+
+        let batch = BoundaryState::default().find_boundaries(&block).expect("scans");
+        assert_eq!(batch.buffer, records(&payloads));
+    }
+
+    /// A header split across blocks must be buffered, not mis-parsed: the first
+    /// call cannot determine the header size, so it emits an empty batch and
+    /// carries every byte forward. Parameterized over cut points that land in
+    /// each distinct section of `parse_header_size`'s walk, since each has its
+    /// own "need more data" early return.
+    #[rstest]
+    #[case::mid_magic(2)]
+    #[case::after_magic_before_l_text(4)]
+    #[case::mid_text(10)]
+    #[case::before_n_ref(15)]
+    #[case::mid_ref_name(24)]
+    fn a_header_split_across_blocks_is_buffered_until_complete(#[case] cut: usize) {
+        let payloads: [&[u8]; 1] = [&[3u8; 8]];
+        let header = bam_header("@HD\tVN:1.6\n", &[("chr1", 1000)]);
+        assert!(
+            cut < header.len(),
+            "cut must fall inside the header for this case to mean anything"
+        );
+        let mut full = header.clone();
+        full.extend_from_slice(&records(&payloads));
+
+        let mut state = BoundaryState::new();
+        let first = state.find_boundaries(&full[..cut]).expect("partial header is not an error");
+        assert!(first.buffer.is_empty(), "no records can be emitted before the header is parsed");
+        assert_eq!(first.offsets, vec![0]);
+
+        let second = state.find_boundaries(&full[cut..]).expect("rest of the header completes it");
+        assert_eq!(second.buffer, records(&payloads), "records resume once the header is consumed");
+        assert_eq!(second.offsets, vec![0, 12]);
+    }
+
+    /// Data that does not start with `BAM\1` is treated as record bytes from
+    /// offset 0 rather than erroring — the documented "not a valid BAM file,
+    /// but let's not error here" behavior. Worth pinning because it is
+    /// surprising: a caller who feeds the wrong stream gets garbage records,
+    /// not a diagnostic.
+    #[test]
+    fn a_non_bam_magic_prefix_is_scanned_as_records_from_offset_zero() {
+        let payloads: [&[u8]; 1] = [&[5u8; 8]];
+        let block = records(&payloads);
+        assert_ne!(&block[0..4], fgumi_raw_bam::BAM_MAGIC, "fixture must not look like a header");
+
+        let mut state = BoundaryState::new();
+        let batch = state.find_boundaries(&block).expect("scans");
+
+        assert_eq!(batch.buffer, block);
+        assert_eq!(batch.offsets, vec![0, 12]);
+    }
+
+    /// Fewer than 8 bytes cannot even hold magic + `l_text`, so the scanner
+    /// must ask for more data instead of reading past the end.
+    #[test]
+    fn fewer_than_eight_bytes_cannot_resolve_the_header() {
+        let mut state = BoundaryState::new();
+        let batch = state.find_boundaries(b"BAM\x01").expect("short input is not an error");
+        assert!(batch.buffer.is_empty());
+        assert_eq!(batch.offsets, vec![0]);
+    }
+
+    // ========================================================================
+    // Record scanning and cross-block carryover
+    // ========================================================================
+
+    /// The core carryover contract: a record straddling two blocks is held back
+    /// on the first call and emitted whole on the second, never split. The
+    /// concatenated output across both calls must equal the input records
+    /// exactly — that is the invariant downstream parsing depends on.
+    #[rstest]
+    #[case::split_mid_body(18)]
+    #[case::split_on_a_record_start(12)]
+    #[case::split_mid_length_prefix(14)]
+    #[case::split_one_byte_in(1)]
+    fn a_record_spanning_two_blocks_is_emitted_whole(#[case] cut: usize) {
+        let payloads: [&[u8]; 3] = [&[1u8; 8], &[2u8; 8], &[3u8; 8]];
+        let all = records(&payloads);
+        assert!(cut < all.len());
+
+        let mut state = BoundaryState::new_no_header();
+        let first = state.find_boundaries(&all[..cut]).expect("first half scans");
+        let second = state.find_boundaries(&all[cut..]).expect("second half scans");
+
+        let mut seen = first.buffer.clone();
+        seen.extend_from_slice(&second.buffer);
+        assert_eq!(seen, all, "no byte may be dropped or duplicated across the split");
+        assert!(state.finish().expect("nothing left over").is_none());
+    }
+
+    /// Offsets must always start at 0, end at `buffer.len()`, and step by each
+    /// record's framed size — this is the contract that lets a consumer slice
+    /// records with `offsets.windows(2)`.
+    #[test]
+    fn offsets_bracket_every_record_in_the_emitted_buffer() {
+        let payloads: [&[u8]; 3] = [&[1u8; 4], &[2u8; 20], &[3u8; 0]];
+        let block = records(&payloads);
+
+        let mut state = BoundaryState::new_no_header();
+        let batch = state.find_boundaries(&block).expect("scans");
+
+        assert_eq!(batch.offsets, vec![0, 8, 32, 36]);
+        assert_eq!(*batch.offsets.last().expect("non-empty"), batch.buffer.len());
+        for (i, window) in batch.offsets.windows(2).enumerate() {
+            let body = &batch.buffer[window[0] + 4..window[1]];
+            assert_eq!(body, payloads[i], "record {i} must round-trip through its offsets");
+        }
+    }
+
+    /// An empty block is a legal no-op: nothing to scan, nothing carried.
+    #[test]
+    fn an_empty_block_yields_an_empty_batch() {
+        let mut state = BoundaryState::new_no_header();
+        let batch = state.find_boundaries(&[]).expect("empty input is not an error");
+        assert!(batch.buffer.is_empty());
+        assert_eq!(batch.offsets, vec![0]);
+    }
+
+    /// Feeding many blocks in sequence must give the same records as feeding
+    /// one concatenated block. This is what exercises the `prev_offsets_len`
+    /// pre-sizing path across calls, and it is the property that actually
+    /// matters: block framing must not be observable in the output.
+    #[test]
+    fn streaming_many_blocks_matches_scanning_one_concatenated_block() {
+        let payloads: Vec<Vec<u8>> = (0..32u8).map(|i| vec![i; usize::from(i) + 1]).collect();
+        let refs: Vec<&[u8]> = payloads.iter().map(Vec::as_slice).collect();
+        let all = records(&refs);
+
+        let one_shot = {
+            let mut state = BoundaryState::new_no_header();
+            let batch = state.find_boundaries(&all).expect("scans");
+            assert!(state.finish().expect("nothing left over").is_none());
+            batch.buffer
+        };
+
+        let streamed = {
+            let mut state = BoundaryState::new_no_header();
+            let mut out = Vec::new();
+            for chunk in all.chunks(7) {
+                out.extend_from_slice(&state.find_boundaries(chunk).expect("scans").buffer);
+            }
+            assert!(state.finish().expect("nothing left over").is_none());
+            out
+        };
+
+        assert_eq!(streamed, one_shot, "block framing must not be observable downstream");
+        assert_eq!(one_shot, all);
+    }
+
+    // ========================================================================
+    // finish(): EOF validation
+    // ========================================================================
+
+    /// With no carryover there is nothing to flush.
+    #[test]
+    fn finish_returns_none_when_no_bytes_were_carried_over() {
+        let mut state = BoundaryState::new_no_header();
+        state.find_boundaries(&records(&[&[1u8; 8]])).expect("scans");
+        assert!(state.finish().expect("no leftover").is_none());
+    }
+
+    /// `finish` flushes carried-over bytes when they happen to form whole
+    /// records. That is narrower than it sounds, and the narrowness is the
+    /// point: `find_boundaries` consumes *every* complete record it can see, so
+    /// after a successful scan the carryover is by construction an INCOMPLETE
+    /// record — making `None` or an error the normal outcomes at EOF.
+    ///
+    /// The one reachable path to a flushed batch is a stream that ended before
+    /// the header could even be resolved (< 8 bytes, so `parse_header_size`
+    /// never ran) whose bytes nonetheless frame cleanly. Pinning it keeps the
+    /// flush path honest and documents why it is nearly dead code.
+    #[test]
+    fn finish_flushes_carried_over_bytes_that_form_whole_records() {
+        // Seven bytes: too short for magic + `l_text`, so the whole block is
+        // carried over unparsed — but a clean `block_size = 3` + 3-byte body.
+        let block = record(&[7u8; 3]);
+        assert_eq!(block.len(), 7);
+
+        let mut state = BoundaryState::new();
+        let batch = state.find_boundaries(&block).expect("short input is not an error");
+        assert!(batch.buffer.is_empty(), "the header was never resolved, so nothing is emitted");
+
+        let flushed =
+            state.finish().expect("carryover frames cleanly").expect("a batch is flushed");
+        assert_eq!(flushed.buffer, block);
+        assert_eq!(flushed.offsets, vec![0, 7]);
+    }
+
+    /// After a successful scan the carryover is always a partial record, so the
+    /// normal EOF outcome is `None` — the complete records were already emitted
+    /// by `find_boundaries` itself.
+    #[test]
+    fn finish_returns_none_after_a_scan_that_consumed_every_record() {
+        let payloads: [&[u8]; 2] = [&[1u8; 8], &[2u8; 8]];
+        let all = records(&payloads);
+
+        let mut state = BoundaryState::new_no_header();
+        let batch = state.find_boundaries(&all[..12]).expect("scans");
+        assert_eq!(batch.buffer, record(&[1u8; 8]), "the first record is emitted immediately");
+
+        assert!(
+            state.finish().expect("no carryover").is_none(),
+            "a scan that ended on a record boundary leaves nothing to flush"
+        );
+    }
+
+    /// A truncated record at EOF is corruption and must surface as
+    /// `UnexpectedEof` rather than silently dropping bytes. Two distinct
+    /// truncations reach two different error sites: a declared `block_size`
+    /// that outruns the buffer, and trailing bytes too short to even hold the
+    /// 4-byte length prefix.
+    #[rstest]
+    #[case::body_shorter_than_declared_block_size(&[0x20, 0, 0, 0, 1, 2, 3])]
+    #[case::three_trailing_bytes(&[1, 2, 3])]
+    #[case::one_trailing_byte(&[9])]
+    fn finish_rejects_an_incomplete_record_at_eof(#[case] tail: &[u8]) {
+        let mut block = record(&[1u8; 8]);
+        block.extend_from_slice(tail);
+
+        let mut state = BoundaryState::new_no_header();
+        let batch = state.find_boundaries(&block).expect("the complete record scans");
+        assert_eq!(batch.buffer, record(&[1u8; 8]));
+
+        let err = state.finish().expect_err("a truncated tail must not be dropped");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    /// `finish` takes the leftover, so a second call reports nothing remaining
+    /// rather than re-emitting the same bytes. `FindBamBoundaries` guards this
+    /// with its own `finalized` flag, but the state machine must not depend on
+    /// that guard for correctness of the buffer it returns.
+    #[test]
+    fn finish_does_not_re_emit_the_same_leftover_twice() {
+        // Same short-input setup as the flush test above — the only shape that
+        // leaves whole records parked in carryover.
+        let block = record(&[7u8; 3]);
+        let mut state = BoundaryState::new();
+        state.find_boundaries(&block).expect("short input buffers");
+
+        assert!(state.finish().expect("first flush").is_some());
+        assert!(state.finish().expect("second flush").is_none(), "leftover must be consumed once");
+    }
+
+    // ========================================================================
+    // Bounded carryover on corrupt framing
+    // ========================================================================
+
+    /// A corrupt `block_size` must be rejected once the carry passes
+    /// [`MAX_CARRY_BYTES`], rather than buffering the rest of the stream.
+    ///
+    /// Without the bound this terminates *correctly* — `finish` catches the
+    /// shortfall at EOF — but only after carrying every remaining byte, so peak
+    /// memory tracks input size and a large corrupt file OOMs before it can
+    /// print the diagnostic it was about to print.
+    #[test]
+    fn a_corrupt_block_size_is_rejected_once_the_carry_passes_the_bound() {
+        let mut state = BoundaryState::new_no_header();
+        // Declare a body far larger than any real record, and never supply it.
+        let mut first =
+            u32::try_from(MAX_CARRY_BYTES * 4).expect("fits u32").to_le_bytes().to_vec();
+        first.extend_from_slice(&[7u8; 64]);
+        state.find_boundaries(&first).expect("first block just starts the carry");
+
+        // Feed blocks until the bound trips. It must trip well before the
+        // declared size is reached.
+        let block = vec![9u8; 1024 * 1024];
+        let mut fed = first.len();
+        let err = loop {
+            match state.find_boundaries(&block) {
+                Ok(_) => {
+                    fed += block.len();
+                    assert!(
+                        fed <= MAX_CARRY_BYTES + block.len(),
+                        "carry ran past the bound without erroring ({fed} bytes fed)",
+                    );
+                }
+                Err(e) => break e,
+            }
+        };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// A header whose declared `l_text` never resolves must be bounded the same
+    /// way — it is the other path that carries the whole stream forward.
+    #[test]
+    fn a_header_that_never_resolves_is_rejected_once_the_carry_passes_the_bound() {
+        let mut header = fgumi_raw_bam::BAM_MAGIC.to_vec();
+        header.extend_from_slice(&u32::MAX.to_le_bytes()); // absurd l_text
+        let mut state = BoundaryState::new();
+        state.find_boundaries(&header).expect("first block just starts the carry");
+
+        let block = vec![0u8; 1024 * 1024];
+        let mut fed = header.len();
+        let err = loop {
+            match state.find_boundaries(&block) {
+                Ok(_) => {
+                    fed += block.len();
+                    assert!(
+                        fed <= MAX_CARRY_BYTES + block.len(),
+                        "header carry ran past the bound without erroring ({fed} bytes fed)",
+                    );
+                }
+                Err(e) => break e,
+            }
+        };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// The bound must not reject legitimately large records. An ONT ultra-long
+    /// read with methylation tags can reach a few MB, and such a record spans
+    /// many BGZF blocks — so it is carried across dozens of calls before it
+    /// completes. That is exactly the shape the bound must let through, which is
+    /// why it sits far above any real record rather than at the queue budget.
+    #[test]
+    fn a_multi_megabyte_record_spanning_many_blocks_is_still_accepted() {
+        const BODY: usize = 8 * 1024 * 1024; // ~8 MB — above any real BAM record
+        // Compile-time: if the bound is ever lowered under this fixture, the
+        // test must fail to build rather than silently stop proving anything.
+        const { assert!(BODY < MAX_CARRY_BYTES) };
+
+        let mut stream = u32::try_from(BODY).expect("fits u32").to_le_bytes().to_vec();
+        stream.extend_from_slice(&vec![3u8; BODY]);
+
+        let mut state = BoundaryState::new_no_header();
+        let mut emitted = Vec::new();
+        for chunk in stream.chunks(64 * 1024) {
+            emitted.extend_from_slice(
+                &state.find_boundaries(chunk).expect("a large but legal record must scan").buffer,
+            );
+        }
+        assert!(state.finish().expect("nothing left over").is_none());
+        assert_eq!(emitted, stream, "the whole record must survive the carry intact");
+    }
+
+    /// A header that never completes before EOF leaves the partial header in
+    /// `leftover`; `finish` then reports it as corruption rather than emitting
+    /// header bytes as if they were records.
+    #[test]
+    fn finish_reports_a_header_that_never_completed_as_corruption() {
+        let header = bam_header("@HD\tVN:1.6\n", &[("chr1", 1000)]);
+        let mut state = BoundaryState::new();
+        let batch = state.find_boundaries(&header[..12]).expect("partial header buffers");
+        assert!(batch.buffer.is_empty());
+
+        let err = state.finish().expect_err("a partial header is not a valid record stream");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+}

--- a/src/lib/pipeline/steps/chain_tests.rs
+++ b/src/lib/pipeline/steps/chain_tests.rs
@@ -1,0 +1,624 @@
+//! Cross-step integration tests for the step subset in this port.
+//!
+//! Every step in `steps/` is a `try_run` state machine whose interesting
+//! behavior — held-item retry, drain detection, `Finished` reporting — only
+//! occurs when the framework drives it. Unit tests over a step's helpers
+//! therefore leave the step body itself unexercised, so these tests assemble
+//! real chains and run them through [`Pipeline::run`]:
+//!
+//! ```text
+//! ReplaySource → BgzfDecompress → FindBamBoundaries → DecodeRecords    → sink
+//! ReplaySource → BgzfDecompress → FindBamBoundaries → ParseBamRecords  → sink
+//! ReplaySource → BgzfDecompress → FindBamBoundaries → BgzfCompress     → sink
+//! ```
+//!
+//! `ReplaySource` is a test-local source because the real `source/` steps
+//! are not part of this port; the block bytes it replays are built by the same
+//! BGZF compressor the production writer uses, so the decode path sees exactly
+//! what it would in production.
+//!
+//! Each chain runs at 1 and 4 threads. That is not redundancy: at 1 thread the
+//! `Parallel` steps have a single clone and drain trivially, while at 4 the
+//! last-worker barrier (only the final clone may close a shared output) is
+//! actually exercised. A drain bug that wedges the pipeline shows up as a
+//! hang in the 4-thread case only.
+//!
+//! The full production chain (through `GroupBam`, serialization, and the file
+//! sink) is covered by the integration tests that arrive with the remaining
+//! step subtrees.
+
+use std::collections::VecDeque;
+use std::io;
+use std::sync::{Arc, Mutex};
+
+use fgumi_bam_io::GroupKeyConfig;
+use fgumi_raw_bam::{RawRecord, SamBuilder};
+use rstest::rstest;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::builder::{Pipeline, PipelineConfig};
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::item::{HeapSize, Ordered};
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::bgzf::compress::BgzfCompress;
+use crate::pipeline::steps::bgzf::decompress::BgzfDecompress;
+use crate::pipeline::steps::boundaries::bam::FindBamBoundaries;
+use crate::pipeline::steps::parse::bam::ParseBamRecords;
+use crate::pipeline::steps::parse::decode::{DecodeFromRecords, DecodeRecords};
+use crate::pipeline::steps::types::{BgzfBlock, DecodedRecordBatch, RecordBatch};
+
+/// Per-edge byte budget. Deliberately small relative to the multi-record
+/// fixtures so the byte-bounded edges bind mid-run rather than swallowing the
+/// whole stream in one go. `the_edge_budget_binds_on_the_multi_record_fixtures`
+/// pins that this constant actually has teeth — a future edit that raised it
+/// past the fixture volume would silently turn every chain below into an
+/// unbounded-queue test.
+const EDGE_LIMIT_BYTES: u64 = 16 * 1024;
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+/// A minimal binary BAM header: magic, empty text, and `n_ref` references.
+/// This is the prefix `FindBamBoundaries` must consume and discard.
+fn minimal_binary_bam_header(n_ref: u32) -> Vec<u8> {
+    let mut header = Vec::new();
+    header.extend_from_slice(fgumi_raw_bam::BAM_MAGIC);
+    header.extend_from_slice(&0u32.to_le_bytes()); // l_text = 0
+    header.extend_from_slice(&n_ref.to_le_bytes());
+    for _ in 0..n_ref {
+        header.extend_from_slice(&2u32.to_le_bytes()); // l_name = 2 ("r" + NUL)
+        header.extend_from_slice(b"r\0");
+        header.extend_from_slice(&1_000_000u32.to_le_bytes()); // l_ref
+    }
+    header
+}
+
+/// `n` mapped, paired records with distinct read names and positions — enough
+/// field variety that a group key computed from them is not trivially constant.
+fn test_records(n: usize) -> Vec<RawRecord> {
+    (0..n)
+        .map(|i| {
+            let mut b = SamBuilder::new();
+            b.read_name(format!("read{i}").as_bytes())
+                .flags(fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::FIRST_SEGMENT)
+                .ref_id(0)
+                .pos(i32::try_from(100 + i * 10).expect("pos fits i32"))
+                .cigar_ops(&[4u32 << 4]) // 4M
+                .sequence(b"ACGT")
+                .qualities(&[30u8; 4]);
+            b.build()
+        })
+        .collect()
+}
+
+/// Serialize a header + records into a BAM byte stream, then cut it into BGZF
+/// blocks of at most `payload_bytes` uncompressed bytes each.
+///
+/// Cutting at a fixed byte size (rather than on record boundaries) is the
+/// point: records land straddling block edges, which is exactly the carryover
+/// case `FindBamBoundaries` exists to handle.
+fn bgzf_blocks_for(records: &[RawRecord], payload_bytes: usize) -> Vec<BgzfBlock> {
+    let mut stream = minimal_binary_bam_header(1);
+    for record in records {
+        let bytes = record.as_ref();
+        let block_size = u32::try_from(bytes.len()).expect("record fits u32");
+        stream.extend_from_slice(&block_size.to_le_bytes());
+        stream.extend_from_slice(bytes);
+    }
+    stream
+        .chunks(payload_bytes)
+        .enumerate()
+        .map(|(i, payload)| {
+            let mut compressor = fgumi_bgzf::InlineBgzfCompressor::new(1);
+            compressor.write_all(payload).expect("compress payload");
+            compressor.flush().expect("flush compressor");
+            let mut blocks = compressor.take_blocks();
+            assert_eq!(blocks.len(), 1, "payload must fit one BGZF block");
+            BgzfBlock {
+                batch_serial: i as u64,
+                bytes: blocks.remove(0).data,
+                uncompressed_size: u32::try_from(payload.len()).expect("payload fits u32"),
+            }
+        })
+        .collect()
+}
+
+// ============================================================================
+// Test-local source and sink steps
+// ============================================================================
+
+/// Replays pre-built items into the chain. `Exclusive` because it owns mutable
+/// cursor state and must not be cloned per worker.
+///
+/// Holds a rejected item and retries it on a later tick rather than dropping
+/// it — dropping would punch a hole in the ordinal sequence, which the
+/// downstream `ByItemOrdinal` reorder stages would then wait on forever.
+struct ReplaySource<T: Send + HeapSize + Ordered + 'static> {
+    items: VecDeque<T>,
+    held: HeldSlot<Unpushed<T>>,
+}
+
+impl<T: Send + HeapSize + Ordered + 'static> ReplaySource<T> {
+    fn new(items: Vec<T>) -> Self {
+        Self { items: items.into(), held: HeldSlot::new() }
+    }
+}
+
+impl<T: Send + HeapSize + Ordered + 'static> Step for ReplaySource<T> {
+    type Input = ();
+    type Outputs = OrderedBytesSingle<T>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ReplaySource",
+            kind: StepKind::Exclusive,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: EDGE_LIMIT_BYTES }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        let Some(item) = self.items.pop_front() else {
+            return Ok(StepOutcome::Finished);
+        };
+        if let Err(unpushed) = ctx.outputs.push(item) {
+            self.held.put(unpushed);
+        }
+        Ok(StepOutcome::Progress)
+    }
+}
+
+/// Terminal sink that accumulates every item it receives, in arrival order.
+/// `Exclusive` so arrival order is the chain's output order with no
+/// sink-side interleaving to reason about.
+struct CollectSink<T: Send + 'static> {
+    collected: Arc<Mutex<Vec<T>>>,
+}
+
+impl<T> Step for CollectSink<T>
+where
+    T: Send + HeapSize + 'static,
+{
+    type Input = T;
+    type Outputs = ();
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "CollectSink",
+            kind: StepKind::Exclusive,
+            sticky: false,
+            output_queues: vec![],
+            branch_ordering: vec![],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        match ctx.input.pop() {
+            Some(item) => {
+                self.collected.lock().expect("sink mutex not poisoned").push(item);
+                Ok(StepOutcome::Progress)
+            }
+            None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+            None => Ok(StepOutcome::NoProgress),
+        }
+    }
+}
+
+// ============================================================================
+// Chains
+// ============================================================================
+
+/// `ReplaySource → BgzfDecompress → FindBamBoundaries → DecodeRecords`.
+///
+/// Every record in the input must arrive downstream exactly once, in order,
+/// with its bytes intact — across BGZF block boundaries, byte backpressure,
+/// and (at 4 threads) parallel decompress/decode workers.
+#[rstest]
+fn decode_chain_round_trips_every_record_in_order(
+    #[values(1, 4)] threads: usize,
+    #[values(1, 64, 500)] n_records: usize,
+) {
+    let records = test_records(n_records);
+    let blocks = bgzf_blocks_for(&records, 4096);
+    let collected: Arc<Mutex<Vec<DecodedRecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(blocks))
+        .chain(BgzfDecompress::new(EDGE_LIMIT_BYTES))
+        .chain(FindBamBoundaries::new(EDGE_LIMIT_BYTES))
+        .chain(DecodeRecords::new(GroupKeyConfig::default(), EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let batches = collected.lock().expect("mutex not poisoned");
+    let seen: Vec<&[u8]> = batches
+        .iter()
+        .flat_map(|batch| batch.records().iter().map(fgumi_bam_io::DecodedRecord::raw_bytes))
+        .collect();
+    let expected: Vec<&[u8]> = records.iter().map(AsRef::as_ref).collect();
+    assert_eq!(seen, expected, "records must survive the chain intact and in order");
+}
+
+/// Same chain but terminating in `ParseBamRecords`, the zero-alloc sibling of
+/// `DecodeRecords` that emits shared-buffer `RecordBatch`es instead of owned
+/// `DecodedRecord`s. It must yield the same records in the same order.
+#[rstest]
+fn parse_chain_round_trips_every_record_in_order(
+    #[values(1, 4)] threads: usize,
+    #[values(1, 64, 500)] n_records: usize,
+) {
+    let records = test_records(n_records);
+    let blocks = bgzf_blocks_for(&records, 4096);
+    let collected: Arc<Mutex<Vec<RecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(blocks))
+        .chain(BgzfDecompress::new(EDGE_LIMIT_BYTES))
+        .chain(FindBamBoundaries::new(EDGE_LIMIT_BYTES))
+        .chain(ParseBamRecords::new(EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let batches = collected.lock().expect("mutex not poisoned");
+    let seen: Vec<Vec<u8>> =
+        batches.iter().flat_map(|batch| batch.iter_record_bytes().map(<[u8]>::to_vec)).collect();
+    let expected: Vec<Vec<u8>> = records.iter().map(|r| r.as_ref().to_vec()).collect();
+    assert_eq!(seen, expected, "records must survive the parse chain intact and in order");
+}
+
+/// `… → FindBamBoundaries → BgzfCompress` re-compresses the record stream.
+/// Decompressing the sink's output must reproduce the record bytes exactly —
+/// proving the compress step preserves both content and batch ordering.
+#[rstest]
+fn compress_chain_output_decompresses_back_to_the_record_stream(#[values(1, 4)] threads: usize) {
+    let records = test_records(200);
+    let blocks = bgzf_blocks_for(&records, 4096);
+    let collected: Arc<Mutex<Vec<BgzfBlock>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(blocks))
+        .chain(BgzfDecompress::new(EDGE_LIMIT_BYTES))
+        .chain(FindBamBoundaries::new(EDGE_LIMIT_BYTES))
+        .chain(BgzfCompress::new(1, EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    // Concatenate the emitted BGZF blocks and inflate the whole stream.
+    let compressed: Vec<u8> = collected
+        .lock()
+        .expect("mutex not poisoned")
+        .iter()
+        .flat_map(|b| b.bytes.clone())
+        .collect();
+    // Read in bounded batches: `read_raw_blocks` pre-allocates `max_blocks`,
+    // so it must be given a sane cap rather than "everything".
+    let mut cursor = io::Cursor::new(compressed);
+    let mut decompressor = libdeflater::Decompressor::new();
+    let mut inflated = Vec::new();
+    loop {
+        let raw_blocks = fgumi_bgzf::reader::read_raw_blocks(&mut cursor, 64)
+            .expect("output is a valid BGZF stream");
+        if raw_blocks.is_empty() {
+            break;
+        }
+        for block in &raw_blocks {
+            inflated.extend_from_slice(
+                &fgumi_bgzf::reader::decompress_block(block, &mut decompressor)
+                    .expect("each emitted block inflates"),
+            );
+        }
+    }
+
+    // The compressed stream is the header-stripped record stream: framed
+    // `block_size` + body per record, in input order.
+    let mut expected = Vec::new();
+    for record in &records {
+        let bytes = record.as_ref();
+        expected.extend_from_slice(&u32::try_from(bytes.len()).expect("fits u32").to_le_bytes());
+        expected.extend_from_slice(bytes);
+    }
+    assert_eq!(inflated, expected, "compress must preserve the record stream byte-for-byte");
+}
+
+/// An input with a header but no records must still complete cleanly and
+/// produce nothing — the empty-BAM case, where every step sees drain before it
+/// ever sees an item.
+#[rstest]
+fn a_header_only_input_completes_with_no_records(#[values(1, 4)] threads: usize) {
+    let blocks = bgzf_blocks_for(&[], 4096);
+    let collected: Arc<Mutex<Vec<DecodedRecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(blocks))
+        .chain(BgzfDecompress::new(EDGE_LIMIT_BYTES))
+        .chain(FindBamBoundaries::new(EDGE_LIMIT_BYTES))
+        .chain(DecodeRecords::new(GroupKeyConfig::default(), EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let batches = collected.lock().expect("mutex not poisoned");
+    let total: usize = batches.iter().map(|b| b.records().len()).sum();
+    assert_eq!(total, 0, "a header-only BAM yields no records");
+}
+
+/// A single BGZF block holding the entire stream exercises the path where
+/// `FindBamBoundaries` never carries anything over — the whole header and every
+/// record arrive together in one input.
+#[rstest]
+fn a_single_block_input_needs_no_carryover(#[values(1, 4)] threads: usize) {
+    let records = test_records(50);
+    // One block big enough for the whole stream.
+    let blocks = bgzf_blocks_for(&records, 64 * 1024);
+    assert_eq!(blocks.len(), 1, "fixture must fit in a single BGZF block");
+
+    let collected: Arc<Mutex<Vec<DecodedRecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(blocks))
+        .chain(BgzfDecompress::new(EDGE_LIMIT_BYTES))
+        .chain(FindBamBoundaries::new(EDGE_LIMIT_BYTES))
+        .chain(DecodeRecords::new(GroupKeyConfig::default(), EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let batches = collected.lock().expect("mutex not poisoned");
+    let total: usize = batches.iter().map(|b| b.records().len()).sum();
+    assert_eq!(total, records.len());
+}
+
+/// `FindBamBoundaries::new_no_header` is the runall-spliced entry point: the
+/// stream is already past the header, so byte 0 is a record boundary. Feeding
+/// it a header-stripped stream must yield every record.
+#[rstest]
+fn the_no_header_boundary_variant_consumes_a_header_stripped_stream(
+    #[values(1, 4)] threads: usize,
+) {
+    let records = test_records(64);
+    // Build blocks over the record stream ONLY — no BAM header prefix.
+    let mut stream = Vec::new();
+    for record in &records {
+        let bytes = record.as_ref();
+        stream.extend_from_slice(&u32::try_from(bytes.len()).expect("fits u32").to_le_bytes());
+        stream.extend_from_slice(bytes);
+    }
+    let blocks: Vec<BgzfBlock> = stream
+        .chunks(1024)
+        .enumerate()
+        .map(|(i, payload)| {
+            let mut compressor = fgumi_bgzf::InlineBgzfCompressor::new(1);
+            compressor.write_all(payload).expect("compress");
+            compressor.flush().expect("flush");
+            let mut blocks = compressor.take_blocks();
+            assert_eq!(blocks.len(), 1);
+            BgzfBlock {
+                batch_serial: i as u64,
+                bytes: blocks.remove(0).data,
+                uncompressed_size: u32::try_from(payload.len()).expect("fits u32"),
+            }
+        })
+        .collect();
+
+    let collected: Arc<Mutex<Vec<DecodedRecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(blocks))
+        .chain(BgzfDecompress::new(EDGE_LIMIT_BYTES))
+        .chain(FindBamBoundaries::new_no_header(EDGE_LIMIT_BYTES))
+        .chain(DecodeRecords::new(GroupKeyConfig::default(), EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let batches = collected.lock().expect("mutex not poisoned");
+    let seen: Vec<&[u8]> = batches
+        .iter()
+        .flat_map(|batch| batch.records().iter().map(fgumi_bam_io::DecodedRecord::raw_bytes))
+        .collect();
+    let expected: Vec<&[u8]> = records.iter().map(AsRef::as_ref).collect();
+    assert_eq!(seen, expected, "no-header mode must treat byte 0 as a record boundary");
+}
+
+/// `… → ParseBamRecords → DecodeFromRecords` is the runall fusion shape: parse
+/// once into shared-buffer batches, then re-attach group keys downstream
+/// instead of re-serializing. It must yield the same records, in the same
+/// order, as the fused `DecodeRecords` chain above.
+#[rstest]
+fn decode_from_records_chain_matches_the_fused_decode_chain(#[values(1, 4)] threads: usize) {
+    let records = test_records(120);
+
+    let collect_via = |use_split: bool| -> Vec<Vec<u8>> {
+        let blocks = bgzf_blocks_for(&records, 4096);
+        let collected: Arc<Mutex<Vec<DecodedRecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_handle = Arc::clone(&collected);
+        let builder = Pipeline::builder();
+        let head = builder
+            .chain(ReplaySource::new(blocks))
+            .chain(BgzfDecompress::new(EDGE_LIMIT_BYTES))
+            .chain(FindBamBoundaries::new(EDGE_LIMIT_BYTES));
+        if use_split {
+            head.chain(ParseBamRecords::new(EDGE_LIMIT_BYTES))
+                .chain(DecodeFromRecords::new(GroupKeyConfig::default(), EDGE_LIMIT_BYTES))
+                .chain(CollectSink { collected: sink_handle })
+                .into_sink_marker();
+        } else {
+            head.chain(DecodeRecords::new(GroupKeyConfig::default(), EDGE_LIMIT_BYTES))
+                .chain(CollectSink { collected: sink_handle })
+                .into_sink_marker();
+        }
+        let pipeline = builder.build().expect("chain builds");
+        pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+        let batches = collected.lock().expect("mutex not poisoned");
+        batches
+            .iter()
+            .flat_map(|batch| batch.records().iter().map(|r| r.raw_bytes().to_vec()))
+            .collect()
+    };
+
+    let expected: Vec<Vec<u8>> = records.iter().map(|r| r.as_ref().to_vec()).collect();
+    assert_eq!(collect_via(false), expected, "fused decode chain must round-trip records");
+    assert_eq!(collect_via(true), expected, "split parse+decode chain must agree with it");
+}
+
+/// `ReplaySource → ParseSamChunk` covers the SAM ingest path, whose records
+/// converge on the same `DecodedRecordBatch` the BAM chain produces. Driving it
+/// through the framework (rather than calling `parse_sam_chunk_into_decoded`
+/// directly) is what exercises the step's drain and held-item handling.
+#[rstest]
+fn sam_chain_decodes_every_line_in_order(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::parse::sam::ParseSamChunk;
+    use crate::pipeline::steps::types::SamChunk;
+
+    const HEADER_TEXT: &str = "@HD\tVN:1.6\tSO:unsorted\n@SQ\tSN:chr1\tLN:100000\n";
+    let header = {
+        let mut reader = noodles::sam::io::Reader::new(HEADER_TEXT.as_bytes());
+        Arc::new(reader.read_header().expect("header parses"))
+    };
+
+    // One chunk per record keeps the ordinal stream long enough that the
+    // byte-bounded edge rejects pushes and the retry path is taken.
+    let n_records = 200usize;
+    let chunks: Vec<SamChunk> = (0..n_records)
+        .map(|i| {
+            let line = format!("read{i}\t0\tchr1\t{}\t60\t4M\t*\t0\t0\tACGT\tIIII\n", 100 + i);
+            let bytes = line.into_bytes();
+            let line_offsets = vec![0u32, u32::try_from(bytes.len()).expect("fits u32")];
+            SamChunk { batch_serial: i as u64, bytes, line_offsets }
+        })
+        .collect();
+
+    let key_config =
+        GroupKeyConfig::new_raw_no_cell(fgumi_bam_io::LibraryIndex::from_header(&header));
+    let collected: Arc<Mutex<Vec<DecodedRecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(chunks))
+        .chain(ParseSamChunk::new(Arc::clone(&header), key_config, EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let batches = collected.lock().expect("mutex not poisoned");
+    let names: Vec<Vec<u8>> = batches
+        .iter()
+        .flat_map(DecodedRecordBatch::records)
+        .map(|record| {
+            let body = record.raw_bytes();
+            let l_read_name = body[8] as usize;
+            body[32..32 + l_read_name - 1].to_vec()
+        })
+        .collect();
+    let expected: Vec<Vec<u8>> = (0..n_records).map(|i| format!("read{i}").into_bytes()).collect();
+    assert_eq!(names, expected, "SAM lines must decode in order, one record per line");
+}
+
+/// A stream that ends mid-record must fail the run, not silently drop the
+/// truncated tail. `FindBamBoundaries` carries the partial record forward, and
+/// at drain its EOF validation rejects it — so the error surfaces through
+/// `Pipeline::run` rather than showing up as quietly missing records.
+#[rstest]
+fn a_truncated_record_stream_fails_the_run(#[values(1, 4)] threads: usize) {
+    let records = test_records(32);
+    let mut stream = minimal_binary_bam_header(1);
+    for record in &records {
+        let bytes = record.as_ref();
+        stream.extend_from_slice(&u32::try_from(bytes.len()).expect("fits u32").to_le_bytes());
+        stream.extend_from_slice(bytes);
+    }
+    // Chop the final record in half — a `block_size` prefix promising bytes
+    // that never arrive.
+    stream.truncate(stream.len() - 20);
+
+    let blocks: Vec<BgzfBlock> = stream
+        .chunks(1024)
+        .enumerate()
+        .map(|(i, payload)| {
+            let mut compressor = fgumi_bgzf::InlineBgzfCompressor::new(1);
+            compressor.write_all(payload).expect("compress");
+            compressor.flush().expect("flush");
+            let mut blocks = compressor.take_blocks();
+            assert_eq!(blocks.len(), 1);
+            BgzfBlock {
+                batch_serial: i as u64,
+                bytes: blocks.remove(0).data,
+                uncompressed_size: u32::try_from(payload.len()).expect("fits u32"),
+            }
+        })
+        .collect();
+
+    let collected: Arc<Mutex<Vec<DecodedRecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(blocks))
+        .chain(BgzfDecompress::new(EDGE_LIMIT_BYTES))
+        .chain(FindBamBoundaries::new(EDGE_LIMIT_BYTES))
+        .chain(DecodeRecords::new(GroupKeyConfig::default(), EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: Arc::clone(&collected) })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+
+    let err = pipeline
+        .run(PipelineConfig { threads, ..Default::default() })
+        .expect_err("a truncated record stream must fail the run");
+    match err {
+        crate::pipeline::core::signal::PipelineError::Io { step, source } => {
+            assert_eq!(step, "FindBamBoundaries", "the boundary scanner owns EOF validation");
+            assert_eq!(source.kind(), io::ErrorKind::UnexpectedEof);
+        }
+        other => panic!("expected an I/O failure from the boundary step, got {other:?}"),
+    }
+}
+
+/// `EDGE_LIMIT_BYTES` must be small enough that the multi-record fixtures
+/// exceed it, or the byte-bounded edges never reject a push and every chain
+/// above silently degrades into an unbounded-queue test that proves nothing
+/// about backpressure or the steps' held-item retry paths.
+#[test]
+fn the_edge_budget_binds_on_the_multi_record_fixtures() {
+    let decompressed_bytes: usize = bgzf_blocks_for(&test_records(500), 4096)
+        .iter()
+        .map(|b| b.uncompressed_size as usize)
+        .sum();
+    assert!(
+        u64::try_from(decompressed_bytes).expect("fixture volume fits u64") > EDGE_LIMIT_BYTES,
+        "fixture volume ({decompressed_bytes} B) must exceed the per-edge budget \
+         ({EDGE_LIMIT_BYTES} B), else the byte-bounded edges never bind",
+    );
+}

--- a/src/lib/pipeline/steps/mod.rs
+++ b/src/lib/pipeline/steps/mod.rs
@@ -1,0 +1,30 @@
+//! Typed `Step` library.
+//!
+//! Layout:
+//!
+//! - `bgzf/`       — BGZF compress/decompress
+//! - `boundaries/` — record-boundary discovery
+//! - `parse/`      — record parsing
+//! - `sink/`       — write-side step implementations
+//! - `sort/`       — sort-chain step re-exports
+//! - `tuning.rs`   — per-chain byte/queue budgets
+//! - `types.rs`    — flowing data types (`HeapSize` + `Ordered`)
+//!
+//! `source/`, `group/`, `correct/`, and the closure-driven mid-steps arrive in
+//! follow-up ports.
+
+pub mod bgzf;
+pub mod boundaries;
+#[cfg(test)]
+mod chain_tests;
+pub mod parse;
+pub mod sink;
+pub mod sort;
+pub mod tuning;
+pub mod types;
+
+pub use tuning::BamPipelineTuning;
+pub use types::{
+    BamTemplateBatch, BgzfBlock, DecodedRecordBatch, DecompressedBlock, RecordBatch,
+    RecordBatchBuilder,
+};

--- a/src/lib/pipeline/steps/parse/bam.rs
+++ b/src/lib/pipeline/steps/parse/bam.rs
@@ -1,0 +1,439 @@
+//! `ParseBamRecords` mid-step. `Parallel + ByItemOrdinal`. Walks the
+//! record-aligned bytes from `FindBamBoundaries` and produces a
+//! `RecordBatch` that shares the input block's bytes (zero per-record
+//! allocation — the block's `Vec<u8>` is moved into the
+//! `RecordBatch`'s backing buffer, plus one `Vec<(u32, u32)>` of
+//! `(start, end)` ranges).
+
+use std::io;
+use std::sync::Arc;
+
+use fgumi_bam_io::ProgressTracker;
+use fgumi_raw_bam::RawRecord;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::{DecompressedBlock, RecordBatch};
+
+/// `Parallel + ByItemOrdinal` parser. Walks record-aligned bytes (one
+/// record = `block_size: u32 LE` + body) and emits a `RecordBatch`.
+///
+/// The bytes coming in MUST be record-aligned (post-`FindBamBoundaries`).
+/// If they aren't, parsing returns an error.
+pub struct ParseBamRecords {
+    held: HeldSlot<Unpushed<RecordBatch>>,
+    output_byte_limit: u64,
+    /// Records parsed across all Parallel workers (shared `Arc`), logged every
+    /// 1M under `RUST_LOG=info`. Compared against `SortBuffer`'s ingest rate,
+    /// this splits the read-supply (decode chain) cost from `SortBuffer.push`.
+    parse_progress: Arc<ProgressTracker>,
+}
+
+impl ParseBamRecords {
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self {
+            held: HeldSlot::new(),
+            output_byte_limit,
+            parse_progress: Arc::new(
+                ProgressTracker::new("Parse records").with_interval(1_000_000),
+            ),
+        }
+    }
+}
+
+impl Clone for ParseBamRecords {
+    fn clone(&self) -> Self {
+        // Share the parse counter across workers so the count is global.
+        Self {
+            held: HeldSlot::new(),
+            output_byte_limit: self.output_byte_limit,
+            parse_progress: Arc::clone(&self.parse_progress),
+        }
+    }
+}
+
+impl Step for ParseBamRecords {
+    type Input = DecompressedBlock;
+    type Outputs = OrderedBytesSingle<RecordBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ParseBamRecords",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    // Return `Contention` (not `NoProgress`) so the framework
+                    // doesn't observe drain on this worker while we still
+                    // have a held item to push — observing drain here
+                    // would mark the worker `Skip` and silently drop the
+                    // held item.
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(block) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let DecompressedBlock { batch_serial, bytes } = block;
+
+        // Zero per-record allocation: parse only the body byte ranges,
+        // then hand the block's `Vec<u8>` to the `RecordBatch` as the
+        // shared backing buffer. The ranges Vec is the only new
+        // allocation per batch (plus the move of `bytes` into the
+        // batch).
+        let ranges = parse_record_ranges(&bytes)?;
+        self.parse_progress.log_if_needed(ranges.len() as u64);
+        let batch = RecordBatch::from_parsed(batch_serial, bytes, ranges);
+
+        match ctx.outputs.push(batch) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+/// Smallest number of bytes a single framed BAM record can occupy: the 4-byte
+/// little-endian `block_size` prefix plus the 32-byte fixed-field header
+/// ([`fgumi_raw_bam::MIN_BAM_RECORD_LEN`]). Dividing a buffer length by this
+/// yields an upper bound on the records it can contain, which is what the two
+/// parsers below use to pre-size their output.
+const MIN_FRAMED_RECORD_LEN: usize = 4 + fgumi_raw_bam::MIN_BAM_RECORD_LEN;
+
+/// Walk record-aligned bytes and produce `(body_start, body_end)` ranges
+/// per record. Each record is preceded by a 4-byte little-endian
+/// `block_size` prefix; the body is `block_size` bytes that follow.
+/// Range values are byte offsets into the caller's buffer.
+///
+/// Used by [`ParseBamRecords`]'s zero-alloc path: the input block's
+/// `Vec<u8>` is moved into the output `RecordBatch` as a shared backing
+/// buffer, with these ranges identifying each record's body.
+///
+/// # Errors
+///
+/// Returns `Err` if a record runs past the buffer end or if there are
+/// trailing partial-record bytes.
+pub(crate) fn parse_record_ranges(bytes: &[u8]) -> io::Result<Vec<(u32, u32)>> {
+    // Pre-size from the smallest record a well-formed stream can hold (a 4-byte
+    // `block_size` prefix plus the 32-byte fixed header), so
+    // `len / MIN_FRAMED_RECORD_LEN` is an upper bound on the record count and
+    // the per-record pushes below never regrow.
+    //
+    // That bound over-reserves several times over for real records (60-200
+    // bytes), and this Vec is RETAINED: `RecordBatch::from_parsed` stores it
+    // verbatim and `RecordBatch::heap_size` bills `ranges.capacity()` against
+    // the pipeline's byte budget. Leaving the slack in place would inflate every
+    // batch's claim (~16% for a 64 KiB block of 150-byte records) and cut how
+    // many batches fit in flight. So the slack is released once at the end —
+    // see the `shrink_to_fit` below.
+    let mut ranges = Vec::with_capacity(bytes.len() / MIN_FRAMED_RECORD_LEN + 1);
+    let mut cursor = 0usize;
+    while cursor + 4 <= bytes.len() {
+        let block_size = u32::from_le_bytes([
+            bytes[cursor],
+            bytes[cursor + 1],
+            bytes[cursor + 2],
+            bytes[cursor + 3],
+        ]) as usize;
+        let body_start = cursor + 4;
+        // `block_size` is read straight out of the stream, so fold it in with
+        // checked arithmetic before it is compared against the buffer or used to
+        // slice. Unreachable on 64-bit (a `u32` widened to `usize` cannot
+        // overflow this sum), but the framing rule is that every length-derived
+        // range is checked before use, not that it happens to fit today.
+        let Some(record_end) = body_start.checked_add(block_size) else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "parse_record_ranges: record end overflows \
+                     (cursor={cursor}, block_size={block_size})"
+                ),
+            ));
+        };
+        if record_end > bytes.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "parse_record_ranges: record extends past buffer end \
+                     (cursor={cursor}, block_size={block_size}, buffer_len={})",
+                    bytes.len()
+                ),
+            ));
+        }
+        let start = u32::try_from(body_start).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("parse_record_ranges: body_start {body_start} exceeds u32::MAX"),
+            )
+        })?;
+        let end = u32::try_from(record_end).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("parse_record_ranges: body_end {record_end} exceeds u32::MAX"),
+            )
+        })?;
+        ranges.push((start, end));
+        cursor = record_end;
+    }
+    if cursor != bytes.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "parse_record_ranges: trailing partial record \
+                 (cursor={cursor}, buffer_len={})",
+                bytes.len()
+            ),
+        ));
+    }
+    // Return the table at exactly its populated size. This costs one copy of
+    // `len * 8` bytes, against the ~9 regrow-and-copy rounds the pre-size above
+    // avoided — and it keeps the batch's `heap_size` honest, so byte-bounded
+    // admission bills only memory that is actually needed.
+    ranges.shrink_to_fit();
+    Ok(ranges)
+}
+
+/// Walk record-aligned bytes and produce `Vec<RawRecord>` (one heap
+/// allocation per record, via `to_vec()`).
+///
+/// Used by:
+/// - the `SerializeBamRecords` round-trip and test paths;
+/// - the production [`DecodeRecords`](super::decode::DecodeRecords) step, whose
+///   downstream `DecodedRecord::from_raw_bytes` takes an **owned** `RawRecord`
+///   (it stores the bytes, unlike `ParseBamRecords` which only emits ranges into
+///   the shared block) — so the production decode path does allocate one `Vec`
+///   per record here. This is inherent to the owned-per-record `DecodedRecord`
+///   representation; sharing the block buffer across a batch's records (e.g.
+///   `Arc<[u8]>` + per-record range) is a `DecodedRecord` representation change
+///   deferred behind a benchmark.
+///
+/// The other production parser, the `ParseBamRecords` step, instead uses
+/// [`parse_record_ranges`] for its zero-alloc path.
+///
+/// # Errors
+///
+/// Returns `Err` if a record runs past the buffer end, or if the buffer ends
+/// with a trailing partial record (the final `block_size` does not consume the
+/// remaining bytes exactly). It does NOT enforce a per-record minimum body
+/// size, so a `block_size` below the BAM fixed-field minimum is accepted here
+/// and rejected (if at all) by later decode of the record body.
+pub(crate) fn parse_records(bytes: &[u8]) -> io::Result<Vec<RawRecord>> {
+    // Same upper-bound pre-size as `parse_record_ranges` — this sibling walks
+    // the identical framing and pushes once per record, so it has the identical
+    // regrowth cost.
+    //
+    // Deliberately NOT shrunk to fit, unlike that sibling. This `Vec` is
+    // consumed immediately by the caller (`DecodeRecords` maps it into
+    // `Vec<DecodedRecord>` and drops it), so its capacity never reaches a queued
+    // item and is never billed against the pipeline's byte budget. Paying a copy
+    // to shrink a Vec that is about to be dropped would be pure cost.
+    let mut records = Vec::with_capacity(bytes.len() / MIN_FRAMED_RECORD_LEN + 1);
+    let mut cursor = 0;
+    while cursor + 4 <= bytes.len() {
+        let block_size = u32::from_le_bytes([
+            bytes[cursor],
+            bytes[cursor + 1],
+            bytes[cursor + 2],
+            bytes[cursor + 3],
+        ]) as usize;
+        // Checked for the same reason as `parse_record_ranges` above.
+        let Some(record_end) = cursor.checked_add(4).and_then(|s| s.checked_add(block_size)) else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "parse_records: record end overflows \
+                     (cursor={cursor}, block_size={block_size})"
+                ),
+            ));
+        };
+        if record_end > bytes.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "parse_records: record extends past buffer end \
+                     (cursor={cursor}, block_size={block_size}, buffer_len={})",
+                    bytes.len()
+                ),
+            ));
+        }
+        let record: RawRecord = bytes[cursor + 4..record_end].to_vec().into();
+        records.push(record);
+        cursor = record_end;
+    }
+    if cursor != bytes.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "parse_records: trailing partial record \
+                 (cursor={cursor}, buffer_len={})",
+                bytes.len()
+            ),
+        ));
+    }
+    Ok(records)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[test]
+    fn profile_advertises_parallel_byordinal() {
+        let s = ParseBamRecords::new(1024);
+        let p = s.profile();
+        assert_eq!(p.name, "ParseBamRecords");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    /// Frame `payload` as one record: `block_size: u32 LE` + body.
+    fn framed(payload: &[u8]) -> Vec<u8> {
+        let mut out = u32::try_from(payload.len()).expect("fits u32").to_le_bytes().to_vec();
+        out.extend_from_slice(payload);
+        out
+    }
+
+    /// `parse_record_ranges` is the zero-alloc sibling of `parse_records`: it
+    /// must identify the same record bodies, expressed as offsets into the
+    /// caller's buffer rather than as copies.
+    #[test]
+    fn parse_record_ranges_brackets_each_record_body() {
+        let payloads: [&[u8]; 3] = [&[1u8; 8], &[2u8; 0], &[3u8; 20]];
+        let bytes: Vec<u8> = payloads.iter().flat_map(|p| framed(p)).collect();
+
+        let ranges = parse_record_ranges(&bytes).expect("record-aligned bytes parse");
+
+        assert_eq!(ranges, vec![(4, 12), (16, 16), (20, 40)]);
+        for (i, (start, end)) in ranges.iter().enumerate() {
+            assert_eq!(
+                &bytes[*start as usize..*end as usize],
+                payloads[i],
+                "range {i} must bracket exactly that record's body",
+            );
+        }
+    }
+
+    /// The returned table is retained inside `RecordBatch`, whose `heap_size`
+    /// bills `ranges.capacity()` against the pipeline's byte budget. So the
+    /// upper-bound pre-size must not survive into the returned Vec: excess
+    /// reserved slots would inflate every batch's claim and cut how many fit in
+    /// flight, for memory no record needs.
+    #[test]
+    fn parse_record_ranges_returns_a_table_with_no_excess_capacity() {
+        // Records well above the 36-byte minimum, so the pre-size over-reserves
+        // by several times and the slack is real rather than incidental.
+        let payloads: Vec<Vec<u8>> = (0..40).map(|_| vec![0u8; 160]).collect();
+        let refs: Vec<&[u8]> = payloads.iter().map(Vec::as_slice).collect();
+        let bytes: Vec<u8> = refs.iter().flat_map(|p| framed(p)).collect();
+
+        // Sanity: the pre-size really would over-reserve here.
+        let upper_bound = bytes.len() / MIN_FRAMED_RECORD_LEN + 1;
+        assert!(
+            upper_bound > payloads.len(),
+            "fixture must over-reserve for this test to mean anything \
+             ({upper_bound} <= {})",
+            payloads.len(),
+        );
+
+        let ranges = parse_record_ranges(&bytes).expect("parses");
+        assert_eq!(ranges.len(), payloads.len());
+        assert_eq!(
+            ranges.capacity(),
+            ranges.len(),
+            "the retained ranges table must carry no reserved slack — it is \
+             billed by RecordBatch::heap_size against the byte budget",
+        );
+    }
+
+    /// Empty input holds no records — a legal batch, not an error.
+    #[test]
+    fn parse_record_ranges_accepts_an_empty_buffer() {
+        assert!(parse_record_ranges(&[]).expect("empty is legal").is_empty());
+        assert!(parse_records(&[]).expect("empty is legal").is_empty());
+    }
+
+    /// Both parsers must reject malformed input rather than silently truncating
+    /// it — a record whose declared `block_size` runs past the buffer, and a
+    /// trailing fragment too short to frame. Silently dropping either would turn
+    /// stream corruption into missing records.
+    #[rstest]
+    #[case::block_size_overruns_the_buffer(&[0x40, 0, 0, 0, 1, 2, 3])]
+    #[case::trailing_bytes_cannot_frame_a_record(&[1, 2, 3])]
+    #[case::single_trailing_byte(&[9])]
+    fn both_parsers_reject_a_malformed_tail(#[case] tail: &[u8]) {
+        let mut bytes = framed(&[1u8; 8]);
+        bytes.extend_from_slice(tail);
+
+        let ranges_err = parse_record_ranges(&bytes).expect_err("must reject a malformed tail");
+        assert_eq!(ranges_err.kind(), io::ErrorKind::InvalidData);
+
+        let records_err = parse_records(&bytes).expect_err("must reject a malformed tail");
+        assert_eq!(records_err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// The two parsers must agree on where records are: same count, and the
+    /// bytes `parse_records` copies must equal the slices `parse_record_ranges`
+    /// points at. They feed different steps over the same stream, so a
+    /// disagreement would mean the two decode paths see different records.
+    #[test]
+    fn the_two_parsers_agree_on_record_boundaries() {
+        let payloads: Vec<Vec<u8>> = (0..16u8).map(|i| vec![i; usize::from(i) + 1]).collect();
+        let bytes: Vec<u8> = payloads.iter().flat_map(|p| framed(p)).collect();
+
+        let ranges = parse_record_ranges(&bytes).expect("parses");
+        let records = parse_records(&bytes).expect("parses");
+
+        assert_eq!(ranges.len(), records.len());
+        for (range, record) in ranges.iter().zip(&records) {
+            assert_eq!(&bytes[range.0 as usize..range.1 as usize], record.as_ref());
+        }
+    }
+
+    #[test]
+    fn parse_records_decodes_block_size_prefix() {
+        // Build two synthetic "records": [block_size=8, 8 bytes of payload], twice.
+        let mut bytes = Vec::new();
+        for &p in &[1u8, 2u8] {
+            let payload = vec![p; 8];
+            bytes.extend_from_slice(&u32::try_from(payload.len()).unwrap().to_le_bytes());
+            bytes.extend_from_slice(&payload);
+        }
+        let records = parse_records(&bytes).unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].len(), 8);
+        assert_eq!(records[1].len(), 8);
+        assert_eq!(records[0].as_ref(), &[1u8; 8]);
+        assert_eq!(records[1].as_ref(), &[2u8; 8]);
+    }
+}

--- a/src/lib/pipeline/steps/parse/decode.rs
+++ b/src/lib/pipeline/steps/parse/decode.rs
@@ -1,0 +1,602 @@
+//! `DecodeRecords` mid-step. `Parallel + ByItemOrdinal`. Takes a
+//! `DecompressedBlock` (record-aligned bytes from `FindBamBoundaries`),
+//! parses the records, and computes a `GroupKey` for each in a single
+//! pass — emits a `DecodedRecordBatch`.
+//!
+//! Mirrors the legacy pipeline's combined "Decode" step
+//! (`pipeline/bam.rs:329-403`, `try_step_decode`): parse +
+//! key extraction in one pass, parallelizable, so the downstream
+//! Serial `GroupBam` step only does fast hash-and-name comparisons
+//! under its mutex.
+//!
+//! ## Why parse + decode in one step (was two)
+//!
+//! An earlier shape split parse and decode into two `Parallel` steps
+//! (`ParseBamRecords` → `DecodeRecords`) under the assumption that
+//! some non-grouping callers would want the parse without the key
+//! extraction. In practice every grouping command (`clip`, `group`,
+//! `dedup`, `simplex`, `duplex`, `correct`, `filter`) does want the
+//! keys, so the split forced one extra `Sequenced<T>`-wrap +
+//! `ReorderStage` + queue traversal per batch with no payoff. Profiling
+//! at scale (twist-umi 16 M records, threads=8) showed ~16M extra
+//! atomic ops + ordinal allocations from the redundant edge —
+//! collapsing them halves the per-record framework dispatch on the
+//! upstream half of the chain.
+//!
+//! `ParseBamRecords` is still available as a standalone step for callers
+//! who genuinely don't need group keys (e.g., `roundtrip` no-op chains,
+//! integration tests that only mutate raw bytes).
+
+use std::io;
+use std::sync::Arc;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::parse::bam::parse_records;
+use crate::pipeline::steps::types::{DecodedRecordBatch, DecompressedBlock, RecordBatch};
+use fgumi_bam_io::{DecodedRecord, GroupKeyConfig, compute_group_key_from_raw, name_hash_key};
+
+/// Fail closed on a raw BAM record body too short for the unchecked field
+/// accessors used during group-key extraction.
+///
+/// The parse steps that feed this one ([`parse_records`] and the
+/// `RecordBatch` walked by [`DecodeFromRecords`]) accept any record whose
+/// `block_size` prefix is internally consistent — they do **not** enforce a
+/// per-record minimum body size (see `parse_records`' contract). Both
+/// [`name_hash_key`] and [`compute_group_key_from_raw`] then call
+/// `fgumi_raw_bam::read_name`, which reads `raw[8]` (`l_read_name`, including
+/// the trailing NUL) and slices `raw[32..32 + l_read_name - 1]` with **no**
+/// bounds check; the full-key path additionally reads the 32-byte fixed header
+/// (`flags`, `ref_id`, mate fields, …). A truncated or malformed record would
+/// therefore panic on out-of-bounds indexing. We reject it here with
+/// `InvalidData` before any key is computed so the pipeline surfaces a clean
+/// error instead of unwinding a worker thread.
+///
+/// ## Minimum-length reasoning
+///
+/// - `raw.len() >= MIN_BAM_RECORD_LEN` (32) covers every fixed-offset field,
+///   including the `raw[8]` read of `l_read_name` itself.
+/// - A `>= MIN_BAM_RECORD_LEN` check alone is **not** sufficient: with
+///   `l_read_name` as large as 255 the name slice
+///   `raw[32..32 + l_read_name - 1]` ends well past a 32-byte record. So when
+///   `l_read_name > 1` we additionally require
+///   `raw.len() >= 32 + l_read_name - 1` (the exclusive end of that slice).
+///   When `l_read_name <= 1`, `read_name` returns `&[]` without slicing, so the
+///   32-byte header is enough.
+fn validate_record_for_decode(raw: &[u8]) -> io::Result<()> {
+    if raw.len() < fgumi_raw_bam::MIN_BAM_RECORD_LEN {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "validate_record_for_decode: BAM record too short for group-key extraction \
+                 ({} byte(s) < {}-byte fixed header)",
+                raw.len(),
+                fgumi_raw_bam::MIN_BAM_RECORD_LEN,
+            ),
+        ));
+    }
+    // `raw[8]` is in bounds because `raw.len() >= MIN_BAM_RECORD_LEN` (>= 9).
+    // `read_name` only slices the name region when `l_read_name > 1`; that
+    // slice's exclusive end index is `32 + l_read_name - 1`, which must not run
+    // past the record end.
+    let l_read_name = raw[8] as usize;
+    if l_read_name > 1 {
+        // Derive from the same constant as the length guard above: both encode
+        // the identical layout fact (the fixed-field header is 32 bytes, and the
+        // read name starts immediately after it). A literal here would let the
+        // guard and the bound it protects drift apart if that constant moved.
+        let name_end = fgumi_raw_bam::MIN_BAM_RECORD_LEN + l_read_name - 1;
+        if name_end > raw.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "validate_record_for_decode: BAM record read-name region runs past record end \
+                     (l_read_name={l_read_name} needs {name_end} byte(s), record is {} byte(s))",
+                    raw.len(),
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Cache the UMI tag's value position on a `DecodedRecord` during decode.
+///
+/// Looks up `umi_tag` in the record's aux data and, when present and Z-typed,
+/// stores the record-relative offset of its value bytes (excluding the trailing
+/// NUL) via [`DecodedRecord::set_cached_umi`]. The UMI-assignment step can then
+/// slice the value through [`DecodedRecord::cached_umi`] instead of re-scanning
+/// aux data once per template. When the tag is absent or not Z-typed the cache
+/// is left in the `UMI_OFFSET_UNCACHED` state and downstream code falls back to
+/// scanning aux data. Issue #334.
+pub(crate) fn cache_umi_position(decoded: &mut DecodedRecord, umi_tag: [u8; 2]) {
+    let raw = decoded.raw_bytes();
+    let Some(aux_offset) = fgumi_raw_bam::aux_data_offset_from_record(raw) else {
+        return;
+    };
+    let aux = &raw[aux_offset..];
+    let Some((value_off_in_aux, value_len)) = fgumi_raw_bam::find_string_tag_position(aux, umi_tag)
+    else {
+        return;
+    };
+    let Ok(aux_offset_u32) = u32::try_from(aux_offset) else {
+        return;
+    };
+    let Some(value_offset) = aux_offset_u32.checked_add(value_off_in_aux) else {
+        return;
+    };
+    decoded.set_cached_umi(value_offset, value_len);
+}
+
+/// `Parallel + ByItemOrdinal` parse + decode. `DecompressedBlock →
+/// DecodedRecordBatch`.
+pub struct DecodeRecords {
+    /// Shared across all worker clones — `GroupKeyConfig` holds an
+    /// `Arc<LibraryIndex>` internally, so cloning the config is cheap.
+    key_config: GroupKeyConfig,
+    held: HeldSlot<Unpushed<DecodedRecordBatch>>,
+    output_byte_limit: u64,
+}
+
+impl DecodeRecords {
+    #[must_use]
+    pub fn new(key_config: GroupKeyConfig, output_byte_limit: u64) -> Self {
+        Self { key_config, held: HeldSlot::new(), output_byte_limit }
+    }
+}
+
+impl Clone for DecodeRecords {
+    fn clone(&self) -> Self {
+        Self {
+            key_config: self.key_config.clone(),
+            held: HeldSlot::new(),
+            output_byte_limit: self.output_byte_limit,
+        }
+    }
+}
+
+impl Step for DecodeRecords {
+    type Input = DecompressedBlock;
+    type Outputs = OrderedBytesSingle<DecodedRecordBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "DecodeRecords",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(block) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let DecompressedBlock { batch_serial, bytes } = block;
+
+        // Single pass: parse the record-aligned bytes, then compute the
+        // group key per record. Both halves are parallelizable per record
+        // and don't share state, so the framework's `Parallel` kind covers
+        // the whole pass.
+        let records = parse_records(&bytes)?;
+        let library_index: &Arc<_> = &self.key_config.library_index;
+        let cell_tag = self.key_config.cell_tag;
+        let name_hash_only = self.key_config.name_hash_only;
+        let umi_tag = self.key_config.umi_tag;
+        let decoded: Vec<DecodedRecord> = records
+            .into_iter()
+            .map(|raw| -> io::Result<DecodedRecord> {
+                // Fail closed before the unchecked raw-field accessors run: a
+                // truncated/malformed body would otherwise panic in
+                // `read_name` (see `validate_record_for_decode`).
+                validate_record_for_decode(raw.as_ref())?;
+                // Queryname-grouping stages (e.g. correct) read only
+                // `key.name_hash`; skip the CIGAR position walk + aux-tag pass.
+                let key = if name_hash_only {
+                    name_hash_key(raw.as_ref())
+                } else {
+                    compute_group_key_from_raw(raw.as_ref(), library_index, cell_tag)
+                };
+                let mut decoded = DecodedRecord::from_raw_bytes(raw, key);
+                // Cache the UMI value position so the Group step's assignment
+                // pass can slice it without re-scanning aux data (#334).
+                if let Some(umi_tag) = umi_tag {
+                    cache_umi_position(&mut decoded, umi_tag);
+                }
+                Ok(decoded)
+            })
+            .collect::<io::Result<Vec<_>>>()?;
+
+        let out = DecodedRecordBatch::new(batch_serial, decoded);
+        match ctx.outputs.push(out) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+/// `Parallel + ByItemOrdinal` group-key extractor. `RecordBatch →
+/// DecodedRecordBatch`. Sibling of [`DecodeRecords`] that skips the
+/// parse phase — useful when an earlier step (e.g. the `Sort` typed
+/// step's output) already produced `RecordBatch`es and we need to
+/// re-attach group keys without re-serializing through framed bytes.
+///
+/// Used by the runall fusion path:
+///   `... → ParseBamRecords → Sort → DecodeFromRecords → GroupByPosition`
+/// instead of the (no-sort) shorter
+///   `... → DecodeRecords → GroupByPosition`.
+pub struct DecodeFromRecords {
+    key_config: GroupKeyConfig,
+    held: HeldSlot<Unpushed<DecodedRecordBatch>>,
+    output_byte_limit: u64,
+}
+
+impl DecodeFromRecords {
+    #[must_use]
+    pub fn new(key_config: GroupKeyConfig, output_byte_limit: u64) -> Self {
+        Self { key_config, held: HeldSlot::new(), output_byte_limit }
+    }
+}
+
+impl Clone for DecodeFromRecords {
+    fn clone(&self) -> Self {
+        Self {
+            key_config: self.key_config.clone(),
+            held: HeldSlot::new(),
+            output_byte_limit: self.output_byte_limit,
+        }
+    }
+}
+
+impl Step for DecodeFromRecords {
+    type Input = RecordBatch;
+    type Outputs = OrderedBytesSingle<DecodedRecordBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "DecodeFromRecords",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(batch) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let batch_serial = batch.batch_serial();
+
+        let library_index: &Arc<_> = &self.key_config.library_index;
+        let cell_tag = self.key_config.cell_tag;
+        let name_hash_only = self.key_config.name_hash_only;
+        let umi_tag = self.key_config.umi_tag;
+        // `DecodedRecord` owns its bytes (via `RawRecord`), so we materialize
+        // a heap-allocated copy here. The `RecordBatch`'s shared backing
+        // buffer is dropped once this batch is consumed.
+        let decoded: Vec<DecodedRecord> = batch
+            .iter_record_bytes()
+            .map(|bytes| -> io::Result<DecodedRecord> {
+                // Fail closed before the unchecked raw-field accessors run: a
+                // truncated/malformed body would otherwise panic in
+                // `read_name` (see `validate_record_for_decode`).
+                validate_record_for_decode(bytes)?;
+                // Mirror `DecodeRecords::try_run`: queryname-grouping stages
+                // (e.g. correct) read only `key.name_hash`, so skip the CIGAR
+                // position walk + aux-tag pass when `name_hash_only` is set.
+                let key = if name_hash_only {
+                    name_hash_key(bytes)
+                } else {
+                    compute_group_key_from_raw(bytes, library_index, cell_tag)
+                };
+                let mut decoded = DecodedRecord::from_raw_bytes(
+                    fgumi_raw_bam::RawRecord::from(bytes.to_vec()),
+                    key,
+                );
+                // Cache the UMI value position so the Group step's assignment
+                // pass can slice it without re-scanning aux data (#334).
+                if let Some(umi_tag) = umi_tag {
+                    cache_umi_position(&mut decoded, umi_tag);
+                }
+                Ok(decoded)
+            })
+            .collect::<io::Result<Vec<_>>>()?;
+
+        let out = DecodedRecordBatch::new(batch_serial, decoded);
+        match ctx.outputs.push(out) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_advertises_parallel_byordinal() {
+        let s = DecodeRecords::new(GroupKeyConfig::default(), 1024);
+        let p = s.profile();
+        assert_eq!(p.name, "DecodeRecords");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    #[test]
+    fn from_records_profile_advertises_parallel_byordinal() {
+        let s = DecodeFromRecords::new(GroupKeyConfig::default(), 1024);
+        let p = s.profile();
+        assert_eq!(p.name, "DecodeFromRecords");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    /// The `name_hash_only` decode path (used by queryname-grouping stages
+    /// like `correct`) must produce the *same* `name_hash` the full
+    /// `compute_group_key_from_raw` would, with every other `GroupKey` field
+    /// left at its default. This is what makes the optimization output-safe:
+    /// `GroupByQueryname` reads only `key.name_hash`.
+    #[test]
+    fn name_hash_only_key_matches_full_key_name_hash_and_zeros_rest() {
+        use fgumi_bam_io::{GroupKey, LibraryIndex};
+        use fgumi_raw_bam::SamBuilder;
+        use fgumi_raw_bam::flags::{PAIRED, SECONDARY, UNMAPPED};
+        use noodles::sam::alignment::record::data::field::Tag;
+
+        let lib = LibraryIndex::default();
+        let cb = Tag::from([b'C', b'B']);
+
+        let make = |name: &[u8], flags: u16, mapped: bool| -> fgumi_raw_bam::RawRecord {
+            let mut b = SamBuilder::new();
+            b.read_name(name).flags(flags).sequence(b"ACGT").qualities(b"IIII");
+            if mapped {
+                b.ref_id(0).pos(100).cigar_ops(&[4u32 << 4]); // 4M
+            }
+            b.build()
+        };
+
+        let records = [
+            make(b"q-mapped-paired", PAIRED, true),
+            make(b"q-unmapped", UNMAPPED, false),
+            make(b"q-secondary", SECONDARY, true),
+            make(b"q", 0, true), // short name
+        ];
+
+        for raw in &records {
+            let full = compute_group_key_from_raw(raw.as_ref(), &lib, Some(cb));
+            let name_only = name_hash_key(raw.as_ref());
+            assert_eq!(
+                name_only.name_hash, full.name_hash,
+                "name_hash_only must reproduce the full key's name_hash"
+            );
+            assert_eq!(
+                name_only,
+                GroupKey { name_hash: full.name_hash, ..GroupKey::default() },
+                "name_hash_only must leave all non-name fields at default"
+            );
+        }
+    }
+
+    // ========================================================================
+    // Fail-closed validation of undersized / malformed records
+    // ========================================================================
+
+    /// A record body shorter than the 32-byte BAM fixed header must be rejected
+    /// with `InvalidData` rather than panicking in the unchecked field
+    /// accessors. Mirrors the 8-byte records built by
+    /// `parse_records_decodes_block_size_prefix` in `bam.rs` — exactly the
+    /// shape `parse_records` accepts but the key extractors cannot decode.
+    #[test]
+    fn validate_record_for_decode_rejects_record_shorter_than_fixed_header() {
+        let too_short = [0u8; 8];
+        let err = validate_record_for_decode(&too_short).expect_err("must fail closed");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// A record long enough for the fixed header but whose declared
+    /// `l_read_name` runs past the record end must also be rejected. This is
+    /// the case a bare `len >= MIN_BAM_RECORD_LEN` check would miss: without
+    /// the read-name bound, `read_name` would slice `raw[32..32 + 50 - 1]` on a
+    /// 32-byte record and panic.
+    #[test]
+    fn validate_record_for_decode_rejects_truncated_read_name() {
+        let mut rec = [0u8; fgumi_raw_bam::MIN_BAM_RECORD_LEN];
+        rec[8] = 50; // l_read_name claims 49 name bytes + NUL, none of which exist
+        let err = validate_record_for_decode(&rec).expect_err("must fail closed");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// The boundary cases that must be accepted: a 32-byte record with an empty
+    /// name (`l_read_name <= 1`, where `read_name` never slices) and a real
+    /// well-formed record built by `SamBuilder`. Proves the guard does not
+    /// reject valid input.
+    #[test]
+    fn validate_record_for_decode_accepts_minimal_and_valid_records() {
+        use fgumi_raw_bam::SamBuilder;
+
+        // 32-byte record, l_read_name = 1 (just the NUL): read_name short-circuits.
+        let mut minimal = [0u8; fgumi_raw_bam::MIN_BAM_RECORD_LEN];
+        minimal[8] = 1;
+        validate_record_for_decode(&minimal).expect("minimal empty-name record is valid");
+
+        // A real record exercising read_name's slice path.
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1").sequence(b"ACGT").qualities(&[30u8; 4]);
+        let raw = b.build();
+        validate_record_for_decode(raw.as_ref()).expect("well-formed record is valid");
+    }
+
+    /// End-to-end fail-closed proof: the same undersized record fed through the
+    /// `DecodeRecords` map logic (the production `name_hash_only` and full-key
+    /// branches) yields an `io::Error`, not a panic. Reproduces the map +
+    /// `collect::<io::Result<Vec<_>>>()` shape used by `try_run`.
+    #[test]
+    fn decode_map_fails_closed_on_undersized_record_for_both_key_branches() {
+        use fgumi_bam_io::{GroupKey, LibraryIndex};
+        use noodles::sam::alignment::record::data::field::Tag;
+
+        let lib = LibraryIndex::default();
+        let cell_tag = Some(Tag::from([b'C', b'B']));
+        // Below the fixed-header minimum — would panic in `read_name` if it
+        // reached the key extractors.
+        let undersized: &[u8] = &[0u8; 8];
+
+        for name_hash_only in [true, false] {
+            let result: io::Result<Vec<GroupKey>> = [undersized]
+                .into_iter()
+                .map(|raw| -> io::Result<GroupKey> {
+                    validate_record_for_decode(raw)?;
+                    let key = if name_hash_only {
+                        name_hash_key(raw)
+                    } else {
+                        compute_group_key_from_raw(raw, &lib, cell_tag)
+                    };
+                    Ok(key)
+                })
+                .collect();
+            let err = result.expect_err("undersized record must fail closed");
+            assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        }
+    }
+
+    // ========================================================================
+    // UMI position caching during Decode (issue #334)
+    // ========================================================================
+
+    #[test]
+    fn cache_umi_position_records_value_offset_matching_fallback() {
+        use crate::sam::SamTag;
+        use fgumi_bam_io::GroupKey;
+        use fgumi_raw_bam::{SamBuilder, flags};
+
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGT")
+            .qualities(&[30u8; 4])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+        b.add_string_tag(SamTag::RX, b"ACGTACGT");
+        let raw = b.build();
+
+        let mut decoded = DecodedRecord::from_raw_bytes(raw, GroupKey::default());
+        cache_umi_position(&mut decoded, *SamTag::RX);
+
+        // The cached slice must equal the canonical find_string_tag answer.
+        let aux = fgumi_raw_bam::aux_data_slice(decoded.raw_bytes());
+        let expected = fgumi_raw_bam::find_string_tag(aux, *SamTag::RX).expect("RX present");
+        assert_eq!(decoded.cached_umi(), Some(expected));
+        assert_eq!(decoded.cached_umi().unwrap(), b"ACGTACGT");
+    }
+
+    #[test]
+    fn cache_umi_position_leaves_cache_unset_when_tag_missing() {
+        use crate::sam::SamTag;
+        use fgumi_bam_io::GroupKey;
+        use fgumi_raw_bam::{SamBuilder, flags};
+
+        // Record with no RX tag — caching must be a no-op.
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGT")
+            .qualities(&[30u8; 4])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+        let raw = b.build();
+
+        let mut decoded = DecodedRecord::from_raw_bytes(raw, GroupKey::default());
+        cache_umi_position(&mut decoded, *SamTag::RX);
+
+        assert!(decoded.cached_umi().is_none());
+        assert_eq!(decoded.cached_umi_position().0, DecodedRecord::UMI_OFFSET_UNCACHED);
+    }
+
+    /// A tag present but not `Z`-typed must leave the cache unset rather than
+    /// caching a bogus offset/length into non-string bytes. `cache_umi_position`
+    /// relies on `find_string_tag_position` to reject the wrong type, and this
+    /// is a different rejection path from the tag being absent entirely — the
+    /// scan finds `RX`, then has to decline it on type.
+    #[test]
+    fn cache_umi_position_leaves_cache_unset_when_tag_is_not_z_typed() {
+        use crate::sam::SamTag;
+        use fgumi_bam_io::GroupKey;
+        use fgumi_raw_bam::{SamBuilder, flags};
+
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGT")
+            .qualities(&[30u8; 4])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+        // RX as an integer, not a Z string.
+        b.add_int_tag(SamTag::RX, 42);
+        let raw = b.build();
+
+        // Sanity: the tag really is present, so this exercises the type
+        // rejection and not the absent-tag path covered above.
+        let aux = fgumi_raw_bam::aux_data_slice(raw.as_ref());
+        assert!(
+            fgumi_raw_bam::find_string_tag(aux, *SamTag::RX).is_none(),
+            "an int-typed RX must not resolve as a string tag",
+        );
+
+        let mut decoded = DecodedRecord::from_raw_bytes(raw, GroupKey::default());
+        cache_umi_position(&mut decoded, *SamTag::RX);
+
+        assert!(decoded.cached_umi().is_none());
+        assert_eq!(decoded.cached_umi_position().0, DecodedRecord::UMI_OFFSET_UNCACHED);
+    }
+}

--- a/src/lib/pipeline/steps/parse/mod.rs
+++ b/src/lib/pipeline/steps/parse/mod.rs
@@ -1,0 +1,5 @@
+//! Per-format record-parsing steps.
+
+pub mod bam;
+pub mod decode;
+pub mod sam;

--- a/src/lib/pipeline/steps/parse/sam.rs
+++ b/src/lib/pipeline/steps/parse/sam.rs
@@ -1,0 +1,543 @@
+//! `ParseSamChunk` mid-step. `Parallel + ByItemOrdinal`. Consumes a
+//! `SamChunk` from the SAM source, parses each line via noodles' SAM
+//! reader, re-encodes the record into its BAM body bytes via
+//! `bam::io::Writer`, computes a `GroupKey`, and emits a
+//! `DecodedRecordBatch` — the same output type `DecodeRecords`
+//! produces for the BAM chain.
+//!
+//! Each chunk is independent (the upstream Read step splits at line
+//! boundaries, so records never cross chunks). Workers process
+//! different chunks concurrently — this is the parallel-parse phase
+//! that lets the SAM ingest path keep up with the multi-MB/s aligner
+//! output stream.
+
+use std::io;
+use std::sync::Arc;
+
+use noodles::bam;
+use noodles::sam;
+use noodles::sam::alignment::io::Write as _;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::{DecodedRecordBatch, SamChunk};
+use fgumi_bam_io::{DecodedRecord, GroupKeyConfig, compute_group_key_from_raw, name_hash_key};
+
+/// Parse every line in `chunk` and produce a `DecodedRecordBatch` carrying
+/// the chunk's batch serial. SAM lines are encoded into BAM record body
+/// bytes via `bam::io::Writer` (which writes `u32 LE block_size` +
+/// record body to its inner buffer); the 4-byte length prefix is
+/// stripped so the resulting `DecodedRecord` matches the shape produced
+/// by the BAM-side `DecodeRecords`.
+///
+/// # Errors
+///
+/// Returns I/O errors from SAM line parsing or BAM encoding.
+pub fn parse_sam_chunk_into_decoded(
+    chunk: SamChunk,
+    header: &sam::Header,
+    key_config: &GroupKeyConfig,
+) -> io::Result<DecodedRecordBatch> {
+    let SamChunk { batch_serial, bytes, line_offsets } = chunk;
+    let n_records = line_offsets.len().saturating_sub(1);
+    let mut decoded: Vec<DecodedRecord> = Vec::with_capacity(n_records);
+
+    let library_index = &key_config.library_index;
+    let cell_tag = key_config.cell_tag;
+    let name_hash_only = key_config.name_hash_only;
+
+    let mut sam_record = sam::Record::default();
+    let mut encoder = bam::io::Writer::from(Vec::<u8>::with_capacity(4096));
+
+    // Walk lines explicitly so we can skip empty ones (e.g. a trailing
+    // `\n\n` in the input shows up as a length-1 empty offset slot;
+    // feeding `\n` to noodles' `sam::io::Reader` errors with
+    // "unexpected EOL"). Each non-empty line is read with a fresh
+    // single-line reader so we don't have to coordinate state across
+    // skipped lines.
+    for i in 0..n_records {
+        let start = line_offsets[i] as usize;
+        let end = line_offsets[i + 1] as usize;
+        // Validate the range BEFORE any length arithmetic. `line_offsets` is
+        // caller-supplied (this function is `pub`), so a reversed or
+        // out-of-bounds pair must surface as `InvalidData` rather than panic on
+        // the slice below and unwind a pipeline worker. A `saturating_sub`
+        // length check does not cover this: `start = 100, end = 105` over a
+        // 12-byte buffer has span 5, sails past any length test, and then
+        // indexes out of bounds.
+        let Some(line) = bytes.get(start..end) else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "parse_sam_chunk_into_decoded: line {i} has an invalid offset range \
+                     ({start}..{end}) for a {}-byte chunk",
+                    bytes.len(),
+                ),
+            ));
+        };
+        // Length 1 means just the `\n`; length 0 would be an
+        // ill-formed offset (defensive — shouldn't happen with the
+        // current splitter, but skipping is the right behavior either way).
+        if line.len() <= 1 {
+            continue;
+        }
+        let mut sam_reader = sam::io::Reader::new(line);
+        let n = sam_reader.read_record(&mut sam_record)?;
+        if n == 0 {
+            continue;
+        }
+        encoder.get_mut().clear();
+        encoder.write_alignment_record(header, &sam_record)?;
+        // Copy the encoded body into a *right-sized* buffer, stripping the
+        // 4-byte little-endian `block_size` prefix `bam::io::Writer` prepends.
+        // The encoder's scratch buffer is retained and reused (it is cleared at
+        // the top of the next iteration), so it grows once to the largest record
+        // and never reallocates; only this right-sized `to_vec()` allocates per
+        // record.
+        //
+        // A record must NOT inherit the encoder's scratch capacity. A previous
+        // `mem::replace(encoder.get_mut(), Vec::with_capacity(cap.max(4096)))`
+        // handed every `DecodedRecord` a >=4 KiB buffer to hold a ~60-byte body
+        // — a ~20x per-record over-allocation. Because records are held in
+        // flight through the pipeline, that blew `zipper` (and any SAM-input
+        // pipeline) to tens of GiB on large inputs, while the BAM-input path
+        // stayed bounded (its records are right-sized). The single memcpy per
+        // record here is far cheaper than that blowup and matches the BAM path's
+        // right-sized records.
+        let body_bytes = encoder.get_ref()[4..].to_vec();
+        // Match the BAM decode path (`DecodeFromRecords`): under
+        // `name_hash_only` the key is the name hash alone, so SAM- and
+        // BAM-ingested records group identically.
+        let key = if name_hash_only {
+            name_hash_key(&body_bytes)
+        } else {
+            compute_group_key_from_raw(&body_bytes, library_index, cell_tag)
+        };
+        let mut record = DecodedRecord::from_raw_bytes(body_bytes, key);
+        // Parity with the BAM decode paths (`DecodeRecords` /
+        // `DecodeFromRecords`): cache the UMI value position so the Group step's
+        // assignment pass can slice it without re-scanning aux data (issue #334).
+        // Both paths converge on `DecodedRecordBatch`, so without this a
+        // SAM-ingested record would cost an extra aux scan per template that an
+        // otherwise identical BAM-ingested record does not.
+        if let Some(umi_tag) = key_config.umi_tag {
+            super::decode::cache_umi_position(&mut record, umi_tag);
+        }
+        decoded.push(record);
+    }
+
+    Ok(DecodedRecordBatch::new(batch_serial, decoded))
+}
+
+/// `Parallel + ByItemOrdinal` SAM parser. `SamChunk → DecodedRecordBatch`.
+/// Sibling of `parse::decode::DecodeRecords` for the SAM ingest path —
+/// converging at `DecodedRecordBatch` so every downstream step
+/// (`GroupBam`/`GroupByPosition`/`process_ordered`/…) is reused
+/// unchanged.
+pub struct ParseSamChunk {
+    /// Reference header. Shared across all worker clones — encoding
+    /// needs it for reference-sequence ID resolution. `Arc` so cloning
+    /// the step is cheap.
+    header: Arc<sam::Header>,
+    /// Group-key config (library index + cell tag). Shared via the
+    /// `Arc<LibraryIndex>` inside `GroupKeyConfig`.
+    key_config: GroupKeyConfig,
+    held: HeldSlot<Unpushed<DecodedRecordBatch>>,
+    output_byte_limit: u64,
+}
+
+impl ParseSamChunk {
+    #[must_use]
+    pub fn new(
+        header: Arc<sam::Header>,
+        key_config: GroupKeyConfig,
+        output_byte_limit: u64,
+    ) -> Self {
+        Self { header, key_config, held: HeldSlot::new(), output_byte_limit }
+    }
+}
+
+impl Clone for ParseSamChunk {
+    fn clone(&self) -> Self {
+        Self {
+            header: Arc::clone(&self.header),
+            key_config: self.key_config.clone(),
+            held: HeldSlot::new(),
+            output_byte_limit: self.output_byte_limit,
+        }
+    }
+}
+
+impl Step for ParseSamChunk {
+    type Input = SamChunk;
+    type Outputs = OrderedBytesSingle<DecodedRecordBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ParseSamChunk",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(chunk) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+
+        let batch = parse_sam_chunk_into_decoded(chunk, &self.header, &self.key_config)?;
+
+        match ctx.outputs.push(batch) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::steps::types::SamChunk;
+    use fgumi_bam_io::GroupKeyConfig;
+    use noodles::sam;
+    use rstest::rstest;
+
+    const SAM_TEXT: &str = "\
+@HD\tVN:1.6\tSO:unsorted\n\
+@SQ\tSN:chr1\tLN:1000\n\
+read1\t0\tchr1\t10\t60\t5M\t*\t0\t0\tACGTA\tIIIII\n\
+read2\t16\tchr1\t20\t60\t5M\t*\t0\t0\tTGCAT\t!!!!!\n";
+
+    fn parse_header(text: &str) -> sam::Header {
+        let mut reader = sam::io::Reader::new(text.as_bytes());
+        reader.read_header().expect("header parses")
+    }
+
+    fn key_config_for(header: &sam::Header) -> GroupKeyConfig {
+        let library_index = fgumi_bam_io::LibraryIndex::from_header(header);
+        GroupKeyConfig::new_raw_no_cell(library_index)
+    }
+
+    /// Build a `SamChunk` from the two record lines in `SAM_TEXT` (skipping
+    /// the header lines). This is what `ReadSamChunks` would emit downstream
+    /// of header consumption.
+    fn sam_chunk_from_records(serial: u64) -> SamChunk {
+        let records = "\
+read1\t0\tchr1\t10\t60\t5M\t*\t0\t0\tACGTA\tIIIII\n\
+read2\t16\tchr1\t20\t60\t5M\t*\t0\t0\tTGCAT\t!!!!!\n";
+        let bytes = records.as_bytes().to_vec();
+        // Two lines: offsets at [0, end_of_line_0, end_of_line_1].
+        let mut line_offsets = vec![0u32];
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'\n' {
+                line_offsets.push(u32::try_from(i + 1).unwrap());
+            }
+        }
+        SamChunk { batch_serial: serial, bytes, line_offsets }
+    }
+
+    #[test]
+    fn parse_sam_chunk_emits_one_decoded_record_per_input_line() {
+        let header = parse_header(SAM_TEXT);
+        let key_config = key_config_for(&header);
+        let chunk = sam_chunk_from_records(7);
+
+        let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
+        assert_eq!(batch.batch_serial(), 7, "serial propagated from input chunk");
+        assert_eq!(batch.records().len(), 2);
+    }
+
+    #[test]
+    fn parse_sam_chunk_records_are_right_sized_not_encoder_buffer() {
+        // Regression: each SAM record must own a *right-sized* buffer, not the
+        // shared >=4 KiB encoder scratch buffer. Handing every record the
+        // encoder's `Vec::with_capacity(>=4096)` (via `mem::replace`) made a
+        // ~60-byte record carry a 4 KiB allocation — a ~20x per-record blowup
+        // that drove pipeline-mode `zipper` to tens of GiB on large inputs
+        // (fast-path/BAM-input stayed bounded because those records are
+        // right-sized). The BAM decode path is the reference: its records'
+        // capacity tracks their length.
+        use fgumi_bam_io::MemoryEstimate;
+        let header = parse_header(SAM_TEXT);
+        let key_config = key_config_for(&header);
+        let chunk = sam_chunk_from_records(0);
+
+        let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
+        for rec in batch.records() {
+            let len = rec.raw_bytes().len();
+            let cap = rec.estimate_heap_size(); // RawRecord::capacity()
+            assert!(
+                cap <= len * 2 + 64,
+                "SAM-parsed record over-allocated: len={len} cap={cap} — each record \
+                 must own a right-sized buffer, not the shared >=4096 B encoder scratch",
+            );
+        }
+    }
+
+    #[test]
+    fn parse_sam_chunk_emits_records_with_correct_read_names() {
+        // Round-trip test: SAM text → BAM body bytes → decode names. Proves
+        // the encode step preserves identity (per SAM spec, BAM record body
+        // layout: refID/pos/l_read_name/.../read_name@offset 32).
+        let header = parse_header(SAM_TEXT);
+        let key_config = key_config_for(&header);
+        let chunk = sam_chunk_from_records(0);
+
+        let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
+
+        let mut names: Vec<Vec<u8>> = Vec::new();
+        for rec in batch.records() {
+            let body = rec.raw_bytes();
+            // BAM record body layout: bytes 0..32 are fixed fields;
+            // byte 8 is l_read_name (including NUL); read_name starts at
+            // byte 32 and is `l_read_name - 1` bytes (excluding NUL).
+            let l_read_name = body[8] as usize;
+            names.push(body[32..32 + l_read_name - 1].to_vec());
+        }
+        assert_eq!(names, vec![b"read1".to_vec(), b"read2".to_vec()]);
+    }
+
+    #[test]
+    fn parse_sam_chunk_skips_empty_lines() {
+        // A SAM file ending in `record\n\n` produces offsets that include an
+        // empty line slot. The parser must skip such empty offsets — feeding
+        // an empty line to noodles' SAM reader raises "unexpected EOL".
+        let header = parse_header(SAM_TEXT);
+        let key_config = key_config_for(&header);
+        // Construct a chunk with a real record followed by an empty line.
+        let records = b"read1\t0\tchr1\t10\t60\t5M\t*\t0\t0\tACGTA\tIIIII\n\n";
+        let bytes = records.to_vec();
+        let mut line_offsets = vec![0u32];
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'\n' {
+                line_offsets.push(u32::try_from(i + 1).unwrap());
+            }
+        }
+        // Three offsets => two "lines", second is empty (the `\n` after `\n`).
+        assert_eq!(line_offsets.len(), 3);
+        let chunk = SamChunk { batch_serial: 0, bytes, line_offsets };
+
+        let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
+        assert_eq!(batch.records().len(), 1, "empty line should be skipped, not parsed");
+    }
+
+    #[test]
+    fn parse_sam_chunk_with_empty_record_count_returns_empty_batch() {
+        let header = parse_header(SAM_TEXT);
+        let key_config = key_config_for(&header);
+        let chunk = SamChunk { batch_serial: 11, bytes: Vec::new(), line_offsets: Vec::new() };
+
+        let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
+        assert_eq!(batch.batch_serial(), 11);
+        assert!(batch.records().is_empty());
+    }
+
+    /// Full-field parity: BAM-encode a record via noodles + `DecodeRecords`
+    /// produces the same `DecodedRecord.raw_bytes()` as SAM-encode of the
+    /// equivalent text via `ParseSamChunk`. This is the strongest correctness
+    /// assertion for the SAM parse path — every BAM record field (flags,
+    /// refID, pos, MAPQ, CIGAR, sequence, quality, mate info, tags) must
+    /// round-trip identically.
+    #[test]
+    fn parse_sam_chunk_record_bytes_match_bam_decode_path() {
+        use fgumi_bam_io::DecodedRecord as _DecodedRecord;
+        use noodles::bam;
+        use noodles::sam::alignment::io::Write as _;
+
+        // Header with one ref + a read group.
+        let header_text = "\
+@HD\tVN:1.6\tSO:coordinate\n\
+@SQ\tSN:chr1\tLN:1000\n\
+@RG\tID:rg1\tSM:sample\n";
+        let header = parse_header(header_text);
+        let key_config = key_config_for(&header);
+
+        // Record with the full menagerie of fields: mapped, paired with mate,
+        // MAPQ 60, multi-op CIGAR (M/I/D/S/H), full sequence + qualities,
+        // and several optional tag types (Z string, i int, B array, A char).
+        // `RX` is a UMI tag the group-key extractor reads (relevant via
+        // GroupKeyConfig).
+        let sam_line = "rec1\t99\tchr1\t100\t60\t3M1I2M1D2S1H\t=\t200\t300\tACGTGCAC\tIIIIIIII\tRX:Z:ACGT\tNM:i:2\tBQ:Z:GGGGGGGG\tBI:B:S,10,20,30\n";
+
+        // ── BAM path: parse to noodles record, encode body bytes via the
+        // same encoder DecodeRecords would consume after BgzfDecompress +
+        // FindBamBoundaries.
+        let bam_body = {
+            let mut reader = noodles::sam::io::Reader::new(sam_line.as_bytes());
+            let mut rec = noodles::sam::Record::default();
+            reader.read_record(&mut rec).expect("sam parse");
+            let mut buf = bam::io::Writer::from(Vec::<u8>::new());
+            buf.write_alignment_record(&header, &rec).expect("encode");
+            // Strip the 4-byte block_size prefix.
+            buf.get_ref()[4..].to_vec()
+        };
+        let bam_decoded = _DecodedRecord::from_raw_bytes(
+            bam_body.clone(),
+            fgumi_bam_io::compute_group_key_from_raw(
+                &bam_body,
+                &key_config.library_index,
+                key_config.cell_tag,
+            ),
+        );
+
+        // ── SAM path: same line through ParseSamChunk.
+        let bytes = sam_line.as_bytes().to_vec();
+        let mut line_offsets = vec![0u32];
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'\n' {
+                line_offsets.push(u32::try_from(i + 1).unwrap());
+            }
+        }
+        let chunk = SamChunk { batch_serial: 0, bytes, line_offsets };
+        let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
+        assert_eq!(batch.records().len(), 1);
+        let sam_decoded = &batch.records()[0];
+
+        // Byte-identical raw record bytes (the SAM and BAM encoder paths
+        // both go through `bam::io::Writer::write_alignment_record`).
+        assert_eq!(
+            sam_decoded.raw_bytes(),
+            bam_decoded.raw_bytes(),
+            "SAM and BAM paths must produce byte-identical DecodedRecord.raw_bytes()",
+        );
+    }
+
+    /// Under `name_hash_only`, the SAM parse path must key records by the read
+    /// name hash alone — identical to the BAM `DecodeFromRecords` path — so
+    /// SAM- and BAM-ingested reads group together. Regression for the SAM path
+    /// previously ignoring `name_hash_only` and always computing the full
+    /// position/library key.
+    #[test]
+    fn parse_sam_chunk_honors_name_hash_only() {
+        let header = parse_header(SAM_TEXT);
+        let library_index = fgumi_bam_io::LibraryIndex::from_header(&header);
+        let key_config = GroupKeyConfig::name_hash_only(library_index);
+
+        let chunk = sam_chunk_from_records(0);
+        let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
+        assert_eq!(batch.records().len(), 2);
+
+        for rec in batch.records() {
+            let raw = rec.raw_bytes();
+            assert_eq!(
+                rec.key,
+                fgumi_bam_io::name_hash_key(raw),
+                "name_hash_only SAM key must be the name-hash key, not the full group key",
+            );
+            // The fixture reads are mapped (chr1:10 / chr1:20), so the full
+            // position/library key differs from the name-hash key — confirming
+            // the branch actually changed paths.
+            assert_ne!(
+                rec.key,
+                fgumi_bam_io::compute_group_key_from_raw(
+                    raw,
+                    &key_config.library_index,
+                    key_config.cell_tag,
+                ),
+                "name_hash_only key must differ from the full position/library key for a mapped read",
+            );
+        }
+    }
+
+    /// `line_offsets` is caller-supplied data, and `parse_sam_chunk_into_decoded`
+    /// is `pub`. A malformed table must produce `InvalidData`, never an
+    /// out-of-bounds slice panic that would unwind a pipeline worker.
+    ///
+    /// The `saturating_sub(start) <= 1` skip does not cover this: for
+    /// `start=100, end=105` over a 12-byte buffer the span is 5, so the old code
+    /// proceeded straight to `&bytes[100..105]` and panicked.
+    #[rstest]
+    #[case::start_and_end_past_the_buffer(100, 105)]
+    #[case::end_past_the_buffer(0, 999)]
+    #[case::reversed_range_with_a_wide_span(9, 2)]
+    fn parse_sam_chunk_rejects_a_malformed_line_offset_table(#[case] start: u32, #[case] end: u32) {
+        let header = parse_header(SAM_TEXT);
+        let key_config = key_config_for(&header);
+        let chunk = SamChunk {
+            batch_serial: 0,
+            bytes: b"read1\t0\t*\n".to_vec(),
+            line_offsets: vec![start, end],
+        };
+
+        let err = parse_sam_chunk_into_decoded(chunk, &header, &key_config)
+            .expect_err("a malformed offset table must be rejected, not sliced");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// The SAM path must cache the UMI value position exactly as the BAM paths
+    /// (`DecodeRecords` / `DecodeFromRecords`) do. Both converge on
+    /// `DecodedRecordBatch` for the same downstream Group step, so a SAM record
+    /// without the cache forces that step to re-scan aux data once per template
+    /// while a BAM record does not.
+    #[test]
+    fn parse_sam_chunk_caches_the_umi_position_like_the_bam_paths() {
+        use crate::sam::SamTag;
+
+        let header = parse_header(SAM_TEXT);
+        let library_index = fgumi_bam_io::LibraryIndex::from_header(&header);
+        let key_config = GroupKeyConfig::new_raw_no_cell(library_index).with_umi_tag(*SamTag::RX);
+
+        let line = "read1\t0\tchr1\t10\t60\t5M\t*\t0\t0\tACGTA\tIIIII\tRX:Z:ACGTACGT\n";
+        let bytes = line.as_bytes().to_vec();
+        let line_offsets = vec![0u32, u32::try_from(bytes.len()).expect("fits u32")];
+        let chunk = SamChunk { batch_serial: 0, bytes, line_offsets };
+
+        let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
+        assert_eq!(batch.records().len(), 1);
+        assert_eq!(
+            batch.records()[0].cached_umi(),
+            Some(&b"ACGTACGT"[..]),
+            "SAM-ingested records must carry the same UMI cache as BAM-ingested ones",
+        );
+    }
+
+    #[test]
+    fn parse_sam_chunk_step_profile_is_parallel_byordinal() {
+        let header = std::sync::Arc::new(parse_header(SAM_TEXT));
+        let key_config = key_config_for(&header);
+        let step = ParseSamChunk::new(header, key_config, 1024 * 1024);
+        let profile = step.profile();
+        assert_eq!(profile.name, "ParseSamChunk");
+        assert_eq!(profile.kind, crate::pipeline::core::step::StepKind::Parallel);
+        assert!(!profile.sticky);
+        assert_eq!(
+            profile.branch_ordering,
+            vec![crate::pipeline::core::reorder::BranchOrdering::ByItemOrdinal]
+        );
+        assert!(matches!(
+            profile.output_queues[0],
+            crate::pipeline::core::queues::QueueSpec::ByteBounded { .. }
+        ));
+    }
+}

--- a/src/lib/pipeline/steps/sink/mod.rs
+++ b/src/lib/pipeline/steps/sink/mod.rs
@@ -1,0 +1,4 @@
+//! Sink steps (BAM file writers, future FASTQ writers).
+
+pub mod write_bgzf;
+pub mod write_raw;

--- a/src/lib/pipeline/steps/sink/write_bgzf.rs
+++ b/src/lib/pipeline/steps/sink/write_bgzf.rs
@@ -1,0 +1,3 @@
+//! Re-export shim. The `WriteBgzfFile` sink step now lives in the
+//! `fgumi-pipeline-io` crate.
+pub use fgumi_pipeline_io::sink::write_bgzf::WriteBgzfFile;

--- a/src/lib/pipeline/steps/sink/write_raw.rs
+++ b/src/lib/pipeline/steps/sink/write_raw.rs
@@ -1,0 +1,3 @@
+//! Re-export shim. The `WriteRawFile` sink step lives in the
+//! `fgumi-pipeline-io` crate.
+pub use fgumi_pipeline_io::sink::write_raw::{RawBytesBlock, WriteRawFile};

--- a/src/lib/pipeline/steps/sort/mod.rs
+++ b/src/lib/pipeline/steps/sort/mod.rs
@@ -1,0 +1,29 @@
+//! Re-export shim. The sort typed-steps now live in the `fgumi-pipeline-io`
+//! crate (`fgumi_pipeline_io::sort`).
+pub use fgumi_pipeline_io::sort::{
+    BlockOutput, CompressSpill, MergeBatchBuilder, MergeOutput, RecordBatchOutput,
+    SORT_COORD_GROUP, SORT_IO_GROUP, SortBuffer, SortDecompressTuning, SortMerge,
+    SortSpillDecompress, SpillBlockCompress, SpillGather, SpillWrite, protocol,
+};
+
+pub mod compress_spill {
+    pub use fgumi_pipeline_io::sort::compress_spill::*;
+}
+pub mod sort_buffer {
+    pub use fgumi_pipeline_io::sort::sort_buffer::*;
+}
+pub mod merge {
+    pub use fgumi_pipeline_io::sort::merge::*;
+}
+pub mod spill_decompress {
+    pub use fgumi_pipeline_io::sort::spill_decompress::*;
+}
+pub mod spill_gather {
+    pub use fgumi_pipeline_io::sort::spill_gather::*;
+}
+pub mod spill_block_compress {
+    pub use fgumi_pipeline_io::sort::spill_block_compress::*;
+}
+pub mod spill_write {
+    pub use fgumi_pipeline_io::sort::spill_write::*;
+}

--- a/src/lib/pipeline/steps/tuning.rs
+++ b/src/lib/pipeline/steps/tuning.rs
@@ -1,0 +1,153 @@
+//! Per-thread auto-tuned defaults for the BAM step library, preserving the
+//! per-step batch-size and thread-count heuristics from the legacy
+//! `PipelineConfig::auto_tuned` (removed in the issue #330 migration).
+//!
+//! Centralizes the per-step batch sizes and thread-count heuristics so
+//! command builders don't have to know the magic numbers. Phase 4
+//! migrations should construct via `BamPipelineTuning::auto_tuned(threads)`
+//! and pass the resulting struct into each step's constructor.
+
+/// Per-thread auto-tuned defaults for the BAM step library.
+///
+/// Mirrors legacy `PipelineConfig::auto_tuned`: `blocks_per_read_batch`
+/// scales with thread count to reduce downstream queue-op pulse rate;
+/// `template_batch_size` defaults to 500 templates/batch (matches
+/// legacy's `target_templates_per_batch`).
+#[derive(Debug, Clone, Copy)]
+pub struct BamPipelineTuning {
+    /// Number of pipeline worker threads.
+    pub threads: usize,
+    /// BGZF blocks per `ReadBgzfBlocks` emission. Matches legacy's
+    /// `blocks_per_read_batch`: 16 (1-3 threads), 32 (4-7), 48 (8-15),
+    /// 64 (16+).
+    pub blocks_per_batch: usize,
+    /// Templates per `GroupBam` output batch. Legacy default: 500.
+    pub template_batch_size: usize,
+    /// Per-step output queue byte budget. 4 MiB per step is a reasonable
+    /// laptop-class default; large workloads should raise this via the
+    /// `--queue-memory` flag (see `PipelineConfig::queue_memory_total`).
+    pub per_step_byte_limit: u64,
+    /// BGZF compression level for output (1-12). Default: 1 for the
+    /// round-trip preset (fastest); production commands should use 6.
+    pub compression_level: u32,
+}
+
+impl BamPipelineTuning {
+    /// Auto-tuned defaults for `threads` worker threads, mirroring the legacy
+    /// `PipelineConfig::auto_tuned` (`unified_pipeline::base`). Deliberately not
+    /// an intra-doc link: that module is deleted once the commands migrate off
+    /// it, and a link would break again then.
+    #[must_use]
+    pub fn auto_tuned(threads: usize) -> Self {
+        let threads = threads.max(1);
+        let blocks_per_batch = match threads {
+            1..=3 => 16,
+            4..=7 => 32,
+            8..=15 => 48,
+            _ => 64,
+        };
+        Self {
+            threads,
+            blocks_per_batch,
+            template_batch_size: 500,
+            per_step_byte_limit: 4 * 1024 * 1024,
+            compression_level: 1,
+        }
+    }
+
+    /// Override the BGZF compression level (default 1 — fastest).
+    /// Production commands typically want 6.
+    #[must_use]
+    pub fn with_compression_level(mut self, level: u32) -> Self {
+        self.compression_level = level;
+        self
+    }
+
+    /// Override the per-step byte limit. Use this with the global memory
+    /// budget from the `--queue-memory` flag.
+    #[must_use]
+    pub fn with_per_step_byte_limit(mut self, bytes: u64) -> Self {
+        self.per_step_byte_limit = bytes;
+        self
+    }
+}
+
+impl Default for BamPipelineTuning {
+    fn default() -> Self {
+        Self::auto_tuned(4)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auto_tuned_matches_legacy_block_counts() {
+        assert_eq!(BamPipelineTuning::auto_tuned(1).blocks_per_batch, 16);
+        assert_eq!(BamPipelineTuning::auto_tuned(3).blocks_per_batch, 16);
+        assert_eq!(BamPipelineTuning::auto_tuned(4).blocks_per_batch, 32);
+        assert_eq!(BamPipelineTuning::auto_tuned(7).blocks_per_batch, 32);
+        assert_eq!(BamPipelineTuning::auto_tuned(8).blocks_per_batch, 48);
+        assert_eq!(BamPipelineTuning::auto_tuned(15).blocks_per_batch, 48);
+        assert_eq!(BamPipelineTuning::auto_tuned(16).blocks_per_batch, 64);
+        assert_eq!(BamPipelineTuning::auto_tuned(64).blocks_per_batch, 64);
+    }
+
+    #[test]
+    fn template_batch_size_matches_legacy_default() {
+        assert_eq!(BamPipelineTuning::auto_tuned(8).template_batch_size, 500);
+    }
+
+    #[test]
+    fn min_one_thread() {
+        assert_eq!(BamPipelineTuning::auto_tuned(0).threads, 1);
+    }
+
+    /// The defaults documented on the struct: 4 MiB per step and level 1 (the
+    /// round-trip preset). Commands override both, so a silent drift here would
+    /// change every chain that does not.
+    #[test]
+    fn auto_tuned_defaults_match_the_documented_budget_and_level() {
+        let tuning = BamPipelineTuning::auto_tuned(8);
+        assert_eq!(tuning.per_step_byte_limit, 4 * 1024 * 1024);
+        assert_eq!(tuning.compression_level, 1);
+    }
+
+    /// The builder-style overrides must change only their own field — a command
+    /// setting a production compression level must not also perturb the queue
+    /// budget, and vice versa.
+    #[test]
+    fn the_builder_overrides_change_only_their_own_field() {
+        let base = BamPipelineTuning::auto_tuned(8);
+
+        let leveled = base.with_compression_level(6);
+        assert_eq!(leveled.compression_level, 6);
+        assert_eq!(leveled.per_step_byte_limit, base.per_step_byte_limit);
+        assert_eq!(leveled.blocks_per_batch, base.blocks_per_batch);
+        assert_eq!(leveled.threads, base.threads);
+
+        let budgeted = base.with_per_step_byte_limit(64 * 1024);
+        assert_eq!(budgeted.per_step_byte_limit, 64 * 1024);
+        assert_eq!(budgeted.compression_level, base.compression_level);
+        assert_eq!(budgeted.blocks_per_batch, base.blocks_per_batch);
+
+        // Chaining applies both.
+        let both = base.with_compression_level(6).with_per_step_byte_limit(64 * 1024);
+        assert_eq!(both.compression_level, 6);
+        assert_eq!(both.per_step_byte_limit, 64 * 1024);
+    }
+
+    /// `Default` is documented as `auto_tuned(4)`; pin it so the default queue
+    /// budget cannot drift away from the 4-thread tuning without a test failing.
+    #[test]
+    fn default_is_the_four_thread_tuning() {
+        let default = BamPipelineTuning::default();
+        let explicit = BamPipelineTuning::auto_tuned(4);
+        assert_eq!(default.threads, explicit.threads);
+        assert_eq!(default.blocks_per_batch, explicit.blocks_per_batch);
+        assert_eq!(default.template_batch_size, explicit.template_batch_size);
+        assert_eq!(default.per_step_byte_limit, explicit.per_step_byte_limit);
+        assert_eq!(default.compression_level, explicit.compression_level);
+    }
+}

--- a/src/lib/pipeline/steps/types.rs
+++ b/src/lib/pipeline/steps/types.rs
@@ -1,0 +1,468 @@
+//! Concrete data types that flow through the BAM step library.
+//!
+//! Every flowing type carries an explicit `batch_serial: u64` field and
+//! impls both [`HeapSize`] (so byte-bounded queues can budget memory) and
+//! [`Ordered`] (so `BranchOrdering::ByItemOrdinal` reorder stages preserve
+//! global ordering across multi-step Parallel transforms).
+//!
+//! Serial propagation: every transform copies the input's `batch_serial`
+//! onto its output items. For Serial steps that span batch boundaries
+//! (`FindBamBoundaries`, `GroupBam`), the output's serial is the
+//! serial of the *last* contributing input — this preserves monotonicity
+//! since the output ordinal of batch N is always ≥ the output ordinal of
+//! batch N-1.
+//!
+//! `BamTemplateBatch` is named to disambiguate from
+//! `crate::template::TemplateBatch` (a legacy type alias for
+//! `Vec<Template>`); the new framework's batch carries metadata alongside
+//! the templates.
+
+use crate::pipeline::core::item::{HeapSize, Ordered};
+use crate::template::Template;
+use fgumi_bam_io::{DecodedRecord, MemoryEstimate};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Light flowing types (BgzfBlock, DecompressedBlock, RecordBatch,
+// RecordBatchBuilder) moved to the `fgumi-pipeline-io` crate. Re-export them so
+// `crate::pipeline::steps::types::*` paths keep resolving and there is ONE
+// canonical definition of each. The heavy types below (BamTemplateBatch,
+// DecodedRecordBatch, SamChunk) stay in the umbrella because they depend on
+// `crate::template::Template`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub use fgumi_pipeline_io::types::{BgzfBlock, DecompressedBlock, RecordBatch, RecordBatchBuilder};
+
+/// Bytes held by a `Vec`'s backing store, counted by **allocated capacity**.
+///
+/// The batch types below cache a `total_bytes` that feeds byte-bounded
+/// admission control, so it must describe the memory the queue is really
+/// holding. Summing only the elements' own heap misses the container itself: a
+/// 1,000-element `Vec<DecodedRecord>` is tens of KiB before a single record
+/// body is counted, and a `Vec` grown by repeated `push` typically carries up
+/// to 2x its logical length in reserved slots. Counting `capacity()` rather
+/// than `len()` is the same rule the per-record accounting already follows.
+///
+/// Takes the `Vec`'s `capacity()` rather than a borrow of the `Vec` itself, so
+/// the reserved-slot count is explicit at every call site and the helper cannot
+/// silently degrade to `len()` through a slice deref.
+fn container_bytes<T>(capacity: usize) -> usize {
+    capacity * std::mem::size_of::<T>()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DecodedRecordBatch — parsed records with pre-computed `GroupKey`s.
+// Output of the parallel `DecodeRecords` step; input to the serial
+// `GroupBam` step. Mirrors legacy's split where key computation runs in
+// the parallel Decode step (`pipeline/bam.rs:329-403`) so that
+// the serial Group step only does fast hash-and-name comparisons.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A batch of `DecodedRecord`s — raw record bytes paired with a
+/// pre-computed `GroupKey`. Carries `total_bytes` for O(1) `HeapSize`.
+///
+/// `total_bytes` is cached at construction (`new`) and sums each record's
+/// **allocated capacity** ([`MemoryEstimate::estimate_heap_size`]), not its
+/// logical `raw_bytes().len()`, plus the `Vec`'s own backing store (also by
+/// allocated capacity). This feeds the pipeline's byte-backpressure budget,
+/// which must track the true heap footprint: accounting by `len` under-counts
+/// an over-allocated record, and ignoring the container under-counts the
+/// reserved slots — either lets the pipeline buffer far past its budget.
+///
+/// The fields are **private** so the cached `total_bytes` can never drift out
+/// of sync with `records`: the only constructor is [`Self::new`] (which
+/// recomputes the cache), reads go through [`Self::records`] /
+/// [`Self::total_bytes`], and taking ownership of the records consumes the
+/// batch via [`Self::into_records`]. There is no way to mutate `records` in
+/// place, so byte-bounded admission control always sees the true footprint.
+#[derive(Debug)]
+pub struct DecodedRecordBatch {
+    batch_serial: u64,
+    records: Vec<DecodedRecord>,
+    total_bytes: usize,
+}
+
+impl DecodedRecordBatch {
+    #[must_use]
+    pub fn new(batch_serial: u64, records: Vec<DecodedRecord>) -> Self {
+        let total_bytes = records.iter().map(MemoryEstimate::estimate_heap_size).sum::<usize>()
+            + container_bytes::<DecodedRecord>(records.capacity());
+        Self { batch_serial, records, total_bytes }
+    }
+
+    /// The batch's ordering serial.
+    #[must_use]
+    pub fn batch_serial(&self) -> u64 {
+        self.batch_serial
+    }
+
+    /// Immutable view of the batch's decoded records.
+    #[must_use]
+    pub fn records(&self) -> &[DecodedRecord] {
+        &self.records
+    }
+
+    /// Cached heap footprint: each record's allocated capacity plus the
+    /// `Vec`'s own backing store.
+    #[must_use]
+    pub fn total_bytes(&self) -> usize {
+        self.total_bytes
+    }
+
+    /// Consume the batch and return ownership of its records. The cached
+    /// `total_bytes` is dropped with the batch, so callers move the records
+    /// out without any risk of leaving a stale byte count behind.
+    #[must_use]
+    pub fn into_records(self) -> Vec<DecodedRecord> {
+        self.records
+    }
+}
+
+impl HeapSize for DecodedRecordBatch {
+    fn heap_size(&self) -> usize {
+        self.total_bytes
+    }
+}
+
+impl Ordered for DecodedRecordBatch {
+    fn ordinal(&self) -> u64 {
+        self.batch_serial
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BamTemplateBatch — grouped templates carrying batch metadata.
+// Disambiguated from `crate::template::TemplateBatch` (= `Vec<Template>`).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A batch of templates (same-queryname record groups), with batch serial
+/// for ordering and `total_bytes` for memory accounting.
+///
+/// The fields are **private** so the cached `total_bytes` can never drift out
+/// of sync with `templates`: construct via [`Self::new`] (which recomputes the
+/// cache) or [`Self::from_parts`] (which trusts a caller that already summed
+/// `heap_size`), read through the accessors, and take ownership of the
+/// templates by consuming the batch via [`Self::into_parts`]. There is no way
+/// to mutate `templates` in place, so byte-bounded admission control always
+/// sees the true footprint.
+#[derive(Debug)]
+pub struct BamTemplateBatch {
+    batch_serial: u64,
+    templates: Vec<Template>,
+    total_bytes: usize,
+}
+
+impl BamTemplateBatch {
+    #[must_use]
+    pub fn new(batch_serial: u64, templates: Vec<Template>) -> Self {
+        let total_bytes = templates.iter().map(Template::heap_size).sum::<usize>()
+            + container_bytes::<Template>(templates.capacity());
+        Self { batch_serial, templates, total_bytes }
+    }
+
+    /// Construct from a pre-computed `total_bytes`, skipping the
+    /// per-template `heap_size` walk inside `new`. Use when the
+    /// caller already summed `heap_size` in a prior pass (e.g.,
+    /// the AAM merge loop, which folds heap accounting into the
+    /// same loop that builds the `Vec<Template>`).
+    #[must_use]
+    pub fn from_parts(batch_serial: u64, templates: Vec<Template>, total_bytes: usize) -> Self {
+        // The caller supplies the summed per-template heap; the container's
+        // reserved capacity is added here because the caller cannot know it.
+        let total_bytes = total_bytes + container_bytes::<Template>(templates.capacity());
+        Self { batch_serial, templates, total_bytes }
+    }
+
+    /// The batch's ordering serial.
+    #[must_use]
+    pub fn batch_serial(&self) -> u64 {
+        self.batch_serial
+    }
+
+    /// Immutable view of the batch's templates.
+    #[must_use]
+    pub fn templates(&self) -> &[Template] {
+        &self.templates
+    }
+
+    /// Cached heap footprint: summed `Template::heap_size` plus the `Vec`'s
+    /// own backing store.
+    #[must_use]
+    pub fn total_bytes(&self) -> usize {
+        self.total_bytes
+    }
+
+    /// Consume the batch and return its serial and templates. The cached
+    /// `total_bytes` is dropped with the batch, so callers move the templates
+    /// out (and re-wrap via [`Self::new`]) without risking a stale byte count.
+    #[must_use]
+    pub fn into_parts(self) -> (u64, Vec<Template>) {
+        (self.batch_serial, self.templates)
+    }
+}
+
+impl HeapSize for BamTemplateBatch {
+    fn heap_size(&self) -> usize {
+        self.total_bytes
+    }
+}
+
+impl Ordered for BamTemplateBatch {
+    fn ordinal(&self) -> u64 {
+        self.batch_serial
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SamChunk — a slab of SAM text bytes ending on a newline boundary, plus an
+// inline line-offset table. Emitted by `ReadSamChunks` (Serial+Reader) and
+// consumed by `ParseSamChunk` (Parallel). The parallel parser slices each
+// line via `bytes[offsets[i]..offsets[i+1]]` — no cross-chunk dependencies
+// because the Read step never splits a record across two chunks.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A chunk of SAM text plus its sentinel-form line-offset table.
+///
+/// `line_offsets` has `N+1` entries describing `N` complete records. Line
+/// `i` is `bytes[line_offsets[i] as usize..line_offsets[i+1] as usize]`
+/// and includes its trailing `\n`. The chunk always ends on a newline
+/// boundary (the Read step holds any trailing partial line as carryover).
+#[derive(Debug)]
+pub struct SamChunk {
+    pub batch_serial: u64,
+    pub bytes: Vec<u8>,
+    pub line_offsets: Vec<u32>,
+}
+
+impl SamChunk {
+    /// Number of complete records carried by this chunk.
+    #[must_use]
+    pub fn record_count(&self) -> usize {
+        self.line_offsets.len().saturating_sub(1)
+    }
+}
+
+impl HeapSize for SamChunk {
+    fn heap_size(&self) -> usize {
+        self.bytes.capacity() + container_bytes::<u32>(self.line_offsets.capacity())
+    }
+}
+
+impl Ordered for SamChunk {
+    fn ordinal(&self) -> u64 {
+        self.batch_serial
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Tests for the light types (BgzfBlock, DecompressedBlock, RecordBatch,
+    // RecordBatchBuilder) moved with those types to the `fgumi-pipeline-io`
+    // crate. Only the heavy-type tests remain below.
+
+    #[test]
+    fn template_batch_carries_serial() {
+        let batch = BamTemplateBatch::new(42, vec![]);
+        assert_eq!(batch.heap_size(), 0);
+        assert_eq!(batch.ordinal(), 42);
+    }
+
+    #[test]
+    fn decoded_record_batch_heap_size_counts_capacity_not_len() {
+        // `heap_size` feeds the pipeline's byte-backpressure budget, so it must
+        // report the records' true heap footprint (allocated capacity), not
+        // their logical length. Accounting by `len` under-counts an
+        // over-allocated record — exactly the failure mode where a SAM-parsed
+        // record with a 4 KiB buffer holding ~60 bytes fooled backpressure and
+        // let the pipeline buffer far past its memory budget.
+        use fgumi_bam_io::{GroupKey, MemoryEstimate};
+        let mut raw = Vec::with_capacity(4096);
+        raw.extend_from_slice(&[0u8; 64]); // len 64, capacity 4096
+        let rec = DecodedRecord::from_raw_bytes(raw, GroupKey::default());
+        let cap = rec.estimate_heap_size();
+        assert!(cap >= 4096, "sanity: over-allocated record capacity, got {cap}");
+        let batch = DecodedRecordBatch::new(0, vec![rec]);
+        let expected = cap + std::mem::size_of::<DecodedRecord>(); // one container slot
+        assert_eq!(
+            batch.heap_size(),
+            expected,
+            "heap_size must reflect allocated capacity ({cap}) plus the container, \
+             not logical len — else byte-backpressure under-counts real memory",
+        );
+    }
+
+    #[test]
+    fn decoded_record_batch_accessors_and_into_records_round_trip() {
+        // The fields are private; callers read via the accessors and take
+        // ownership by consuming the batch. `into_records` must hand back the
+        // exact records `new` was given, and `batch_serial` must round-trip.
+        use fgumi_bam_io::GroupKey;
+        let rec = DecodedRecord::from_raw_bytes(vec![7u8; 32], GroupKey::default());
+        let batch = DecodedRecordBatch::new(3, vec![rec]);
+        assert_eq!(batch.batch_serial(), 3);
+        assert_eq!(batch.records().len(), 1);
+        assert_eq!(batch.total_bytes(), batch.heap_size());
+        let records = batch.into_records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].raw_bytes().len(), 32);
+    }
+
+    #[test]
+    fn bam_template_batch_accessors_and_into_parts_round_trip() {
+        // Mirror of the DecodedRecordBatch contract: private fields, read via
+        // accessors, consume via `into_parts` to move the templates out and
+        // re-wrap through `new` (which recomputes the byte cache).
+        let t1 = crate::template::Template::new(b"read1".to_vec());
+        let expected_bytes = t1.heap_size() + std::mem::size_of::<crate::template::Template>();
+        let batch = BamTemplateBatch::new(9, vec![t1]);
+        assert_eq!(batch.batch_serial(), 9);
+        assert_eq!(batch.templates().len(), 1);
+        assert_eq!(batch.total_bytes(), expected_bytes);
+        let (serial, templates) = batch.into_parts();
+        assert_eq!(serial, 9);
+        // Re-wrapping the moved-out templates recomputes an identical cache.
+        let rewrapped = BamTemplateBatch::new(serial, templates);
+        assert_eq!(rewrapped.total_bytes(), expected_bytes);
+    }
+
+    #[test]
+    fn template_batch_new_total_bytes_sums_heap_sizes() {
+        // Template::new(name) → heap_size() == name.len() (no records).
+        // Two templates with distinct known names; no RawRecord builders needed.
+        let t1 = crate::template::Template::new(b"read1".to_vec()); // 5 bytes
+        let t2 = crate::template::Template::new(b"read_two".to_vec()); // 8 bytes
+        let expected =
+            t1.heap_size() + t2.heap_size() + 2 * std::mem::size_of::<crate::template::Template>(); // 13 + container
+        let batch = BamTemplateBatch::new(7, vec![t1, t2]);
+        assert_eq!(batch.total_bytes, expected);
+        assert_eq!(batch.heap_size(), expected); // HeapSize delegates to total_bytes
+        assert_eq!(batch.ordinal(), 7);
+    }
+
+    #[test]
+    fn template_batch_from_parts_trusts_caller_total_bytes() {
+        // from_parts must NOT re-walk the templates — it trusts the caller's
+        // summed `heap_size` (e.g. the AAM merge loop, which folds heap
+        // accounting into its own loop). It still adds the container term,
+        // which the caller has no way to know.
+        let batch = BamTemplateBatch::from_parts(99, vec![], 12345);
+        assert_eq!(batch.heap_size(), 12345, "an empty Vec has no container allocation");
+        assert_eq!(batch.ordinal(), 99);
+    }
+
+    // ========================================================================
+    // Container capacity in the byte budget
+    //
+    // `heap_size` feeds byte-bounded admission control, so it must report the
+    // batch's TRUE footprint. Each of these types owns a `Vec` whose backing
+    // store is real memory the queue is holding: a 1000-element
+    // `Vec<DecodedRecord>` is tens of KiB of container before a single record
+    // body is counted. Omitting it lets a full queue exceed its configured
+    // limit — the same class of under-count the per-record capacity accounting
+    // above already guards against.
+    // ========================================================================
+
+    /// Reserved-but-unused slots are allocated memory, so the batch's byte
+    /// count must grow with `capacity()`, not with `len()`.
+    #[test]
+    fn decoded_record_batch_counts_reserved_container_capacity() {
+        use fgumi_bam_io::GroupKey;
+        let record = || DecodedRecord::from_raw_bytes(vec![7u8; 32], GroupKey::default());
+
+        let tight = DecodedRecordBatch::new(0, vec![record()]);
+
+        let mut padded = Vec::with_capacity(256);
+        padded.push(record());
+        let padded = DecodedRecordBatch::new(0, padded);
+
+        assert!(
+            padded.heap_size() > tight.heap_size(),
+            "a batch holding 256 reserved slots must out-weigh a tight one \
+             ({} vs {})",
+            padded.heap_size(),
+            tight.heap_size(),
+        );
+        assert_eq!(
+            padded.heap_size() - tight.heap_size(),
+            (256 - 1) * std::mem::size_of::<DecodedRecord>(),
+            "the difference must be exactly the extra reserved slots",
+        );
+    }
+
+    /// Same contract for templates, through both constructors.
+    #[test]
+    fn template_batch_counts_reserved_container_capacity() {
+        let template = || crate::template::Template::new(b"read1".to_vec());
+
+        let mut padded = Vec::with_capacity(64);
+        padded.push(template());
+        let heap_only: usize = padded.iter().map(crate::template::Template::heap_size).sum();
+
+        let via_new = BamTemplateBatch::new(0, padded);
+        assert_eq!(
+            via_new.total_bytes(),
+            heap_only + 64 * std::mem::size_of::<crate::template::Template>(),
+            "new() must add the container's reserved capacity to the summed heap",
+        );
+
+        // `from_parts` receives the caller's summed heap and must add the same
+        // container term — otherwise the two constructors disagree on the
+        // footprint of identical batches.
+        let (_, templates) = via_new.into_parts();
+        let via_parts = BamTemplateBatch::from_parts(0, templates, heap_only);
+        assert_eq!(
+            via_parts.total_bytes(),
+            via_new_total_bytes_for_comparison(heap_only),
+            "from_parts must agree with new() on the same templates",
+        );
+    }
+
+    /// The expected `total_bytes` for the 64-slot fixture above, expressed once
+    /// so both constructors are compared against the same definition.
+    fn via_new_total_bytes_for_comparison(heap_only: usize) -> usize {
+        heap_only + 64 * std::mem::size_of::<crate::template::Template>()
+    }
+
+    /// A `SamChunk`'s `bytes` come from a reader buffer that routinely carries
+    /// spare capacity, so accounting by `len()` under-counts the slab the queue
+    /// is actually holding.
+    #[test]
+    fn sam_chunk_heap_size_counts_capacity_not_len() {
+        let mut bytes = Vec::with_capacity(8192);
+        bytes.extend_from_slice(&[0u8; 500]);
+        let mut line_offsets = Vec::with_capacity(64);
+        line_offsets.extend_from_slice(&[0u32; 10]);
+
+        let chunk = SamChunk { batch_serial: 1, bytes, line_offsets };
+        assert_eq!(
+            chunk.heap_size(),
+            8192 + 64 * std::mem::size_of::<u32>(),
+            "heap_size must report allocated capacity, not logical length",
+        );
+    }
+
+    #[test]
+    fn sam_chunk_record_count_is_offsets_minus_one() {
+        // Sentinel-form line_offsets: N+1 entries describe N records.
+        // `bytes` and `line_offsets` come from `split_complete_lines`.
+        let bytes = b"abc\nde\n".to_vec();
+        let line_offsets = vec![0u32, 4, 7];
+        let chunk = SamChunk { batch_serial: 5, bytes, line_offsets };
+        assert_eq!(chunk.record_count(), 2);
+    }
+
+    #[test]
+    fn sam_chunk_record_count_is_zero_for_empty_offsets() {
+        let chunk = SamChunk { batch_serial: 0, bytes: Vec::new(), line_offsets: Vec::new() };
+        assert_eq!(chunk.record_count(), 0);
+    }
+
+    #[test]
+    fn sam_chunk_heap_size_sums_bytes_and_offsets() {
+        let chunk =
+            SamChunk { batch_serial: 1, bytes: vec![0u8; 500], line_offsets: vec![0u32; 10] };
+        assert_eq!(chunk.heap_size(), 500 + 10 * std::mem::size_of::<u32>());
+        assert_eq!(chunk.ordinal(), 1);
+    }
+}

--- a/src/lib/template.rs
+++ b/src/lib/template.rs
@@ -108,6 +108,23 @@ impl Template {
         }
     }
 
+    /// True allocated heap footprint in bytes: summed record **capacities** plus
+    /// the `Vec<RawRecord>` container overhead plus the queryname allocation.
+    /// Used by the pipeline framework's `BamTemplateBatch` for byte-bounded queue
+    /// budgeting, so the budget tracks real RSS. Accounting by logical `len()`
+    /// under-counts over-allocated record buffers and ignores container overhead,
+    /// which lets the pipeline buffer past its `--max-memory` budget and risk an
+    /// OOM (this mirrors `DecodedRecordBatch`, which already sizes by capacity).
+    /// `MemoryEstimate::estimate_heap_size` delegates here so the two never
+    /// diverge.
+    #[must_use]
+    pub fn heap_size(&self) -> usize {
+        let name_size = self.name.capacity();
+        let records_size = self.records.iter().map(RawRecord::capacity).sum::<usize>()
+            + self.records.capacity() * std::mem::size_of::<RawRecord>();
+        name_size + records_size
+    }
+
     /// Returns the primary R1 record if present.
     #[must_use]
     pub fn r1(&self) -> Option<&RawRecord> {
@@ -1035,14 +1052,10 @@ impl<R: std::io::Read> Iterator for TemplateIterator<R> {
 
 impl MemoryEstimate for Template {
     fn estimate_heap_size(&self) -> usize {
-        // name: Vec<u8>
-        let name_size = self.name.capacity();
-
-        // records: Vec<RawRecord>
-        let records_size = self.records.iter().map(RawRecord::capacity).sum::<usize>()
-            + self.records.capacity() * std::mem::size_of::<RawRecord>();
-
-        name_size + records_size
+        // Single source of truth: the pipeline byte-budget (`Template::heap_size`)
+        // and `MemoryEstimate` must agree, so both use the capacity-based
+        // footprint computed in `heap_size`.
+        self.heap_size()
     }
 }
 
@@ -1066,6 +1079,62 @@ mod tests {
     const FLAG_MATE_REVERSE: u16 = 0x20;
     const FLAG_UNMAPPED: u16 = 0x4;
     const FLAG_MATE_UNMAPPED: u16 = 0x8;
+    #[test]
+    fn heap_size_counts_capacity_and_matches_memory_estimate() {
+        // A queryname allocation with spare capacity: the byte budget must count
+        // the allocated capacity (real RSS), not the 5-byte logical length —
+        // otherwise the pipeline under-counts and can buffer past --max-memory.
+        let mut name = Vec::with_capacity(64);
+        name.extend_from_slice(b"read1");
+        let mut template = Template::new(name);
+
+        // Hold real records in a Vec with deliberately reserved spare capacity so
+        // BOTH record terms of `heap_size` are exercised — the per-record byte
+        // buffers (`RawRecord::capacity`) and the `Vec<RawRecord>` backing store
+        // (`records.capacity() * size_of::<RawRecord>()`). The empty-records case
+        // left both at zero, so a dropped record term would have gone unnoticed.
+        let mut records: Vec<RawRecord> = Vec::with_capacity(8);
+        records.push(create_test_raw(b"read1", raw_flags::PAIRED | raw_flags::FIRST_SEGMENT));
+        records.push(create_test_raw(b"read1", raw_flags::PAIRED | raw_flags::LAST_SEGMENT));
+        template.records = records;
+
+        // heap_size (pipeline byte-budget) and estimate_heap_size (MemoryEstimate)
+        // are a single source of truth — they must never diverge.
+        assert_eq!(
+            template.heap_size(),
+            template.estimate_heap_size(),
+            "heap_size and estimate_heap_size must agree",
+        );
+
+        // Independent lower bound re-derived from the components in the test (NOT
+        // via estimate_heap_size, which delegates to heap_size and is tautological).
+        // If heap_size ever drops the record-buffer or Vec-backing term, this trips.
+        let record_bytes = template.records.iter().map(RawRecord::capacity).sum::<usize>();
+        let vec_backing = template.records.capacity() * std::mem::size_of::<RawRecord>();
+        let expected_min = template.name.capacity() + record_bytes + vec_backing;
+        assert!(
+            template.heap_size() >= expected_min,
+            "heap_size {} must cover queryname ({}) + record buffers ({record_bytes}) + \
+             Vec<RawRecord> backing ({vec_backing})",
+            template.heap_size(),
+            template.name.capacity(),
+        );
+        // The record terms must be non-trivial: real byte buffers and the reserved
+        // spare Vec slots both contribute, not just the queryname.
+        assert!(record_bytes > 0, "records must carry real byte capacity");
+        assert!(vec_backing > 0, "Vec<RawRecord> backing store must be counted");
+        assert!(
+            template.records.capacity() >= 8,
+            "reserved spare Vec capacity must be retained ({} < 8)",
+            template.records.capacity(),
+        );
+        // And the footprint reflects the allocated queryname capacity (>= 64).
+        assert!(
+            template.heap_size() >= 64,
+            "heap_size must count allocated capacity, got {}",
+            template.heap_size(),
+        );
+    }
 
     /// Create a simple test raw record with given name and flags.
     fn create_test_raw(name: &[u8], flags: u16) -> RawRecord {


### PR DESCRIPTION
**Stacked on #734** (R0). Review that first; this PR's diff is against it.

Additive: nothing in `src/lib/commands` routes through the new tree, so every command still runs on `unified_pipeline`. No behaviour changes.

## Why this is cheap

`feat-runall`'s `src/lib/pipeline/mod.rs` does `pub use fgumi_pipeline_core as core;`. Every `crate::pipeline::core::…` path inside `steps/` resolves through that shim, so the step sources compile **unmodified** — this is a near-verbatim port plus a module root, not a rewrite.

## What

- `src/lib/pipeline/mod.rs` — the `core` re-export shim + `steps`. (`chains` follows in a later PR; until it lands nothing routes here.)
- `src/lib/pipeline/steps/` — `mod`, `types`, `tuning`, and the `sink/`, `sort/`, `bgzf/`, `boundaries/`, `parse/` subtrees.
- `src/lib/template.rs` — `Template::heap_size` lifted out of the `MemoryEstimate` impl so the pipeline can budget on it, with `estimate_heap_size` delegating. Separate commit.
- Root `Cargo.toml` — depends on `fgumi-pipeline-core` and `fgumi-pipeline-io`. This edge did not previously exist: both crates had landed with no consumer.

Still to come: `source/`, `group/`, `correct/`, the closure-driven mid-steps, and `align_and_merge` (which needs `crate::aligner`, not yet ported).

## Two deliberate deltas from `feat-runall`

Both are noted in the commit message:

1. **`boundaries/bam.rs` uses a let-chain** instead of nested `if`s. The source predates the toolchain that unlocked them and `ci-lint` rejects the nested form as `collapsible_if`. Per `CLAUDE.md` we adopt the idiom rather than suppress the lint.
2. **`tuning.rs` demotes an intra-doc link to a code span.** `[`PipelineConfig::auto_tuned`]` resolves to `unified_pipeline::base` — the module this whole port exists to retire. Linking it would break again on deletion, so the reference is now prose.

## Verification

Full local gate:

- `cargo ci-fmt`, `cargo ci-lint`, `cargo ci-tag-literals` — clean
- `RUSTDOCFLAGS="-D warnings" cargo ci-doc` — clean
- `./scripts/publish-crates.sh --check` — clean
- `cargo ci-test` — **8234 passed**, 30 skipped (up 42 from #734's 8192; the ported steps bring their own tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: command output changes: none; `unsafe`: none, and `CLAUDE.md` allowlist unchanged; memory, queue, and backpressure policy: changed through `Template::heap_size` and typed-step byte limits. Fix: route the typed pipeline only after command-output parity is validated.

- Added the foundational typed-step pipeline tree under `src/lib/pipeline/`.
- Added BGZF compression and decompression, BAM boundary detection, BAM/SAM parsing, decoding, sorting, sinks, tuning, and pipeline data types.
- Added re-export shims for pipeline core and IO implementations.
- Exposed `Template::heap_size`; `MemoryEstimate::estimate_heap_size` now delegates to it.
- Existing commands continue to use `unified_pipeline`.
- Tests, formatting, linting, documentation, publishing checks, and crate checks pass: 8,234 tests passed and 30 skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->