### PR TITLE
feat(pipeline): port the read-side source steps (R1b)

### DIFF
--- a/src/lib/fastq_parse.rs
+++ b/src/lib/fastq_parse.rs
@@ -171,6 +171,15 @@ impl MemoryEstimate for FastqRecord {
     }
 }
 
+/// The typed-step pipeline byte-bounds its queues on this. Delegates to
+/// [`MemoryEstimate::estimate_heap_size`] so the queue budget and the memory
+/// estimate are a single source of truth.
+impl crate::pipeline::core::item::HeapSize for FastqRecord {
+    fn heap_size(&self) -> usize {
+        MemoryEstimate::estimate_heap_size(self)
+    }
+}
+
 /// Result of parsing a FASTQ record.
 #[derive(Debug)]
 enum FastqParseResult {

--- a/src/lib/grouper.rs
+++ b/src/lib/grouper.rs
@@ -690,6 +690,15 @@ impl MemoryEstimate for FastqTemplate {
     }
 }
 
+/// The typed-step pipeline byte-bounds its queues on this. Delegates to
+/// [`MemoryEstimate::estimate_heap_size`] so the queue budget and the memory
+/// estimate are a single source of truth.
+impl crate::pipeline::core::item::HeapSize for FastqTemplate {
+    fn heap_size(&self) -> usize {
+        MemoryEstimate::estimate_heap_size(self)
+    }
+}
+
 /// Groups FASTQ records from multiple synchronized input streams into templates.
 ///
 /// This grouper expects decompressed bytes from multiple FASTQ files,

--- a/src/lib/pipeline/steps/mod.rs
+++ b/src/lib/pipeline/steps/mod.rs
@@ -6,12 +6,13 @@
 //! - `boundaries/` — record-boundary discovery
 //! - `parse/`      — record parsing
 //! - `sink/`       — write-side step implementations
+//! - `source/`     — read-side step implementations (BAM/SAM/FASTQ)
 //! - `sort/`       — sort-chain step re-exports
 //! - `tuning.rs`   — per-chain byte/queue budgets
 //! - `types.rs`    — flowing data types (`HeapSize` + `Ordered`)
 //!
-//! `source/`, `group/`, `correct/`, and the closure-driven mid-steps arrive in
-//! follow-up ports.
+//! `group/`, `correct/`, and the closure-driven mid-steps arrive in follow-up
+//! ports.
 
 pub mod bgzf;
 pub mod boundaries;
@@ -20,6 +21,7 @@ mod chain_tests;
 pub mod parse;
 pub mod sink;
 pub mod sort;
+pub mod source;
 pub mod tuning;
 pub mod types;
 

--- a/src/lib/pipeline/steps/source/chain_tests.rs
+++ b/src/lib/pipeline/steps/source/chain_tests.rs
@@ -1,0 +1,578 @@
+//! End-to-end tests for the read-side source chains.
+//!
+//! The source steps are `try_run` state machines wrapped around real readers,
+//! so their interesting behavior — round-robin stream rotation, chunk
+//! alignment to whole 4-line records, per-stream ordinal assignment, drain
+//! reporting, and held-item retry under backpressure — only happens when the
+//! framework drives them against an actual stream. These tests assemble the
+//! two production FASTQ topologies and the SAM topology and run them through
+//! `Pipeline::run`:
+//!
+//! ```text
+//! ReadFastqInputs (all streams)  → ParseFastqChunks → ZipFastqRecords → sink
+//! ReadFastqInputs (one per stream) ×2 → PairRawFastq → ParseAndZipFastq → sink
+//! ReadSamChunks → sink
+//! ```
+//!
+//! The two FASTQ chains are not redundant: the first is the N>=3 fallback
+//! (a single `Affinity::Reader` worker rotating across every stream), the
+//! second is the paired-end path (one reader per stream on disjoint workers,
+//! joined two-way). They assign ordinals by different rules, so a bug in
+//! either is invisible to the other. Both must recover the same templates in
+//! the same order from the same input.
+//!
+//! `pair_fastq` and `zip_fastq` carry their own targeted pipeline tests for
+//! backpressure and stream skew; these cover the plain read-through path those
+//! tests stub out with synthetic sources.
+
+use std::io::{self, BufRead};
+use std::sync::{Arc, Mutex};
+
+use rstest::rstest;
+
+use crate::pipeline::core::builder::{Pipeline, PipelineBuilder, PipelineConfig};
+use crate::pipeline::core::item::{HeapSize, Ordered};
+use crate::pipeline::core::step::{Affinity, Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::source::pair_fastq::PairRawFastq;
+use crate::pipeline::steps::source::parse_fastq::ParseFastqChunks;
+use crate::pipeline::steps::source::parse_zip_fastq::ParseAndZipFastq;
+use crate::pipeline::steps::source::read_fastq::{FastqOrdinalSequence, ReadFastqInputs};
+use crate::pipeline::steps::source::read_sam_chunks::ReadSamChunks;
+use crate::pipeline::steps::source::zip_fastq::{FastqTemplateBatch, ZipFastqRecords};
+use crate::pipeline::steps::types::SamChunk;
+
+/// Per-edge byte budget, deliberately small relative to the fixtures so the
+/// byte-bounded edges reject pushes mid-run and the sources' held-item retry
+/// paths run. `the_edge_budget_binds_on_the_fixture` pins that it has teeth.
+const EDGE_LIMIT_BYTES: u64 = 512;
+
+/// FASTQ records per emitted chunk. Small enough that the fixtures below span
+/// many chunks, so stream rotation and cross-chunk ordinal assignment are
+/// actually exercised rather than fitting in a single chunk.
+const BATCH_RECORD_COUNT: usize = 8;
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+/// `n` FASTQ records for stream `stream_idx`, named `read{i}` so both streams
+/// of a pair agree on the name (which is what `ZipFastqRecords` /
+/// `ParseAndZipFastq` join on) while their sequences differ.
+fn fastq_text(n: usize, stream_idx: usize) -> String {
+    use std::fmt::Write as _;
+    // One distinct base per stream, so a template that mixes streams (or drops
+    // one) is visible in the assertion rather than hidden behind identical
+    // sequences. Cycles past four streams, which no fixture here reaches.
+    let base = ['A', 'C', 'G', 'T'][stream_idx % 4];
+    let mut out = String::new();
+    for i in 0..n {
+        writeln!(out, "@read{i}\n{base}{base}{base}{base}\n+\nIIII").expect("write to String");
+    }
+    out
+}
+
+fn boxed_reader(text: String) -> Box<dyn BufRead + Send> {
+    Box::new(io::Cursor::new(text.into_bytes()))
+}
+
+/// SAM record lines (no header) for the `ReadSamChunks` fixture.
+fn sam_record_lines(n: usize) -> String {
+    let mut out = String::new();
+    for i in 0..n {
+        use std::fmt::Write as _;
+        let pos = 100 + i;
+        writeln!(out, "read{i}\t0\tchr1\t{pos}\t60\t4M\t*\t0\t0\tACGT\tIIII")
+            .expect("write to String");
+    }
+    out
+}
+
+// ============================================================================
+// Collecting sink
+// ============================================================================
+
+/// Terminal sink accumulating every item in arrival order. `Exclusive`, so
+/// arrival order is the chain's output order with no sink-side interleaving.
+struct CollectSink<T: Send + 'static> {
+    collected: Arc<Mutex<Vec<T>>>,
+}
+
+impl<T: Send + HeapSize + 'static> Step for CollectSink<T> {
+    type Input = T;
+    type Outputs = ();
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "CollectSink",
+            kind: StepKind::Exclusive,
+            sticky: false,
+            output_queues: vec![],
+            branch_ordering: vec![],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        match ctx.input.pop() {
+            Some(item) => {
+                self.collected.lock().expect("sink mutex not poisoned").push(item);
+                Ok(StepOutcome::Progress)
+            }
+            None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+            None => Ok(StepOutcome::NoProgress),
+        }
+    }
+}
+
+/// Flatten collected template batches into `(name, [seq per stream])`, in
+/// batch-serial order. Both FASTQ chains must produce the identical result,
+/// which is what makes them comparable.
+fn templates_in_order(batches: &[FastqTemplateBatch]) -> Vec<(Vec<u8>, Vec<Vec<u8>>)> {
+    // Assert arrival order rather than sorting into it. The chain declares
+    // `ByItemOrdinal` and terminates in an `Exclusive` sink, so batches must
+    // ALREADY arrive in ordinal order — that is the property the reorder stage
+    // exists to provide. Sorting here would silently repair a reorder
+    // regression and leave the comparison below still passing.
+    for pair in batches.windows(2) {
+        assert!(
+            pair[0].ordinal() < pair[1].ordinal(),
+            "batches arrived out of order: ordinal {} before {}",
+            pair[0].ordinal(),
+            pair[1].ordinal(),
+        );
+    }
+    batches
+        .iter()
+        .flat_map(|batch| {
+            batch.templates.iter().map(|t| {
+                (t.name.clone(), t.records.iter().map(|r| r.sequence().to_vec()).collect())
+            })
+        })
+        .collect()
+}
+
+/// The templates the fixtures must yield: `read0..read{n-1}`, each pairing an
+/// all-`A` R1 sequence with an all-`C` R2 sequence.
+fn expected_templates(n: usize, n_streams: usize) -> Vec<(Vec<u8>, Vec<Vec<u8>>)> {
+    (0..n)
+        .map(|i| {
+            let seqs = (0..n_streams)
+                .map(|s| {
+                    let base = [b'A', b'C', b'G', b'T'][s % 4];
+                    vec![base; 4]
+                })
+                .collect();
+            (format!("read{i}").into_bytes(), seqs)
+        })
+        .collect()
+}
+
+// ============================================================================
+// Chains
+// ============================================================================
+
+/// The N-stream fallback topology: one `Affinity::Reader` source rotating across
+/// every stream, then parallel parse, then the serial zip join.
+///
+/// Swept over `n_streams` including **3**, which is the case this topology
+/// exists for — `PairRawFastq` handles exactly two, so anything above that
+/// routes here. A 2-stream-only test would leave the rotation across a third
+/// stream, and its drain, entirely unexercised.
+#[rstest]
+fn round_robin_fastq_chain_recovers_every_template_in_order(
+    #[values(1, 4)] threads: usize,
+    #[values(1, 8, 100)] n_records: usize,
+    #[values(2, 3)] n_streams: usize,
+) {
+    let collected: Arc<Mutex<Vec<FastqTemplateBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+
+    let readers: Vec<Box<dyn BufRead + Send>> =
+        (0..n_streams).map(|s| boxed_reader(fastq_text(n_records, s))).collect();
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReadFastqInputs::new(readers, BATCH_RECORD_COUNT, EDGE_LIMIT_BYTES))
+        .chain(ParseFastqChunks::new(EDGE_LIMIT_BYTES))
+        .chain(ZipFastqRecords::new(n_streams, EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let batches = collected.lock().expect("mutex not poisoned");
+    let templates = templates_in_order(&batches);
+    assert_eq!(templates, expected_templates(n_records, n_streams));
+    // Every template must carry exactly one record per stream — a dropped or
+    // duplicated stream would otherwise be invisible if the sequences matched.
+    assert!(
+        templates.iter().all(|(_, seqs)| seqs.len() == n_streams),
+        "every template must hold one record per stream",
+    );
+}
+
+/// Mismatched FASTQ inputs must **fail**, not hang.
+///
+/// This is the regression test for the ordinal-density bug. The reader used to
+/// derive ordinals as `chunk_serial * n_streams_total + stream_idx`, giving each
+/// stream its own residue class. That is unique but only dense when every
+/// stream yields the same number of chunks — so a short R2 left a permanently
+/// unfilled ordinal, `BranchOrdering::ByItemOrdinal` stalled waiting for it, and
+/// the run hung.
+///
+/// The damage was not just the stall: it *masked the correct diagnostic*.
+/// `ZipFastqRecords` already detects this input and reports "FASTQ sources out
+/// of sync", but the stalled reorder stage meant those chunks never reached it.
+/// So the assertion here is the error, not merely "does not hang" — the fix is
+/// what lets the existing check fire.
+///
+/// Stream 0 must outlive stream 1 by at least two read cycles, since the gap
+/// only strands a later ordinal if one is minted *after* it.
+#[rstest]
+fn mismatched_stream_lengths_error_rather_than_hanging(#[values(1, 4)] threads: usize) {
+    let collected: Arc<Mutex<Vec<FastqTemplateBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+
+    // BATCH_RECORD_COUNT records per chunk per cycle: stream 0 runs for several
+    // cycles after stream 1 is exhausted.
+    let long_records = BATCH_RECORD_COUNT * 4;
+    let short_records = BATCH_RECORD_COUNT;
+    let readers: Vec<Box<dyn BufRead + Send>> =
+        vec![boxed_reader(fastq_text(long_records, 0)), boxed_reader(fastq_text(short_records, 1))];
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReadFastqInputs::new(readers, BATCH_RECORD_COUNT, EDGE_LIMIT_BYTES))
+        .chain(ParseFastqChunks::new(EDGE_LIMIT_BYTES))
+        .chain(ZipFastqRecords::new(2, EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+
+    let err = pipeline
+        .run(PipelineConfig { threads, ..Default::default() })
+        .expect_err("mismatched FASTQ stream lengths must fail the run");
+    let message = format!("{err}");
+    assert!(
+        message.contains("out of sync"),
+        "expected the zipper's out-of-sync diagnostic, got: {message}",
+    );
+}
+
+/// The paired-end topology: one reader per stream pinned to a distinct worker,
+/// joined two-way by `PairRawFastq`, then parsed and zipped in one step.
+///
+/// Needs >= 3 threads: R1 and R2 hold disjoint single-worker affinities and a
+/// third worker drives the join and sink.
+#[rstest]
+fn per_stream_paired_fastq_chain_recovers_every_template_in_order(
+    #[values(3, 5)] threads: usize,
+    #[values(1, 8, 100)] n_records: usize,
+) {
+    let collected: Arc<Mutex<Vec<FastqTemplateBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+
+    // One sequence, cloned into both readers — that shared counter is what
+    // keeps the combined ordinal stream gap-free.
+    let ordinals = FastqOrdinalSequence::new();
+    let r1 = ReadFastqInputs::new_single(
+        boxed_reader(fastq_text(n_records, 0)),
+        /* global_stream_idx */ 0,
+        ordinals.clone(),
+        Affinity::Worker(0),
+        BATCH_RECORD_COUNT,
+        EDGE_LIMIT_BYTES,
+    );
+    let r2 = ReadFastqInputs::new_single(
+        boxed_reader(fastq_text(n_records, 1)),
+        1,
+        ordinals,
+        Affinity::Worker(1),
+        BATCH_RECORD_COUNT,
+        EDGE_LIMIT_BYTES,
+    );
+
+    let builder = PipelineBuilder::new();
+    let r1_tail = builder.append_source(r1);
+    let r2_tail = builder.append_source(r2);
+    let paired = builder.append_step2(PairRawFastq::new(EDGE_LIMIT_BYTES), r1_tail, r2_tail);
+    let zipped = builder.append_step(ParseAndZipFastq::new(EDGE_LIMIT_BYTES), paired);
+    builder.append_step(CollectSink { collected: sink_handle }, zipped);
+
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let batches = collected.lock().expect("mutex not poisoned");
+    assert_eq!(templates_in_order(&batches), expected_templates(n_records, 2));
+}
+
+/// Both FASTQ topologies draw ordinals from one shared `FastqOrdinalSequence`;
+/// they differ only in *who mints* — the round-robin reader is the single
+/// instance minting for every stream, while the per-stream readers each hold a
+/// clone of the same sequence. Reading the same input through both must
+/// therefore recover byte-identical templates in the same order; a wiring
+/// mistake that gave one topology its own counter is invisible to that
+/// topology's own test, because a per-instance sequence still looks dense from
+/// inside a single reader.
+#[test]
+fn both_fastq_topologies_agree_on_the_same_input() {
+    const N: usize = 64;
+
+    let round_robin = {
+        let collected: Arc<Mutex<Vec<FastqTemplateBatch>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_handle = Arc::clone(&collected);
+        let builder = Pipeline::builder();
+        builder
+            .chain(ReadFastqInputs::new(
+                vec![boxed_reader(fastq_text(N, 0)), boxed_reader(fastq_text(N, 1))],
+                BATCH_RECORD_COUNT,
+                EDGE_LIMIT_BYTES,
+            ))
+            .chain(ParseFastqChunks::new(EDGE_LIMIT_BYTES))
+            .chain(ZipFastqRecords::new(2, EDGE_LIMIT_BYTES))
+            .chain(CollectSink { collected: sink_handle })
+            .into_sink_marker();
+        builder
+            .build()
+            .expect("builds")
+            .run(PipelineConfig { threads: 4, ..Default::default() })
+            .expect("runs");
+        let batches = collected.lock().expect("mutex not poisoned");
+        templates_in_order(&batches)
+    };
+
+    let per_stream = {
+        let collected: Arc<Mutex<Vec<FastqTemplateBatch>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_handle = Arc::clone(&collected);
+        let builder = PipelineBuilder::new();
+        let ordinals = FastqOrdinalSequence::new();
+        let a = builder.append_source(ReadFastqInputs::new_single(
+            boxed_reader(fastq_text(N, 0)),
+            0,
+            ordinals.clone(),
+            Affinity::Worker(0),
+            BATCH_RECORD_COUNT,
+            EDGE_LIMIT_BYTES,
+        ));
+        let b = builder.append_source(ReadFastqInputs::new_single(
+            boxed_reader(fastq_text(N, 1)),
+            1,
+            ordinals,
+            Affinity::Worker(1),
+            BATCH_RECORD_COUNT,
+            EDGE_LIMIT_BYTES,
+        ));
+        let paired = builder.append_step2(PairRawFastq::new(EDGE_LIMIT_BYTES), a, b);
+        let zipped = builder.append_step(ParseAndZipFastq::new(EDGE_LIMIT_BYTES), paired);
+        builder.append_step(CollectSink { collected: sink_handle }, zipped);
+        builder
+            .build()
+            .expect("builds")
+            .run(PipelineConfig { threads: 4, ..Default::default() })
+            .expect("runs");
+        let batches = collected.lock().expect("mutex not poisoned");
+        templates_in_order(&batches)
+    };
+
+    assert_eq!(round_robin, expected_templates(N, 2));
+    assert_eq!(
+        round_robin, per_stream,
+        "the round-robin and per-stream reader topologies must agree on identical input",
+    );
+}
+
+/// An empty FASTQ stream must drain cleanly and produce nothing — every step
+/// sees drain before it ever sees an item.
+#[rstest]
+fn an_empty_fastq_stream_completes_with_no_templates(#[values(1, 4)] threads: usize) {
+    let collected: Arc<Mutex<Vec<FastqTemplateBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReadFastqInputs::new(
+            vec![boxed_reader(String::new()), boxed_reader(String::new())],
+            BATCH_RECORD_COUNT,
+            EDGE_LIMIT_BYTES,
+        ))
+        .chain(ParseFastqChunks::new(EDGE_LIMIT_BYTES))
+        .chain(ZipFastqRecords::new(2, EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let batches = collected.lock().expect("mutex not poisoned");
+    let total: usize = batches.iter().map(|b| b.templates.len()).sum();
+    assert_eq!(total, 0);
+}
+
+/// `ReadSamChunks` must emit every record line exactly once, split on line
+/// boundaries, with a sentinel-form offset table per chunk. A tiny target chunk
+/// size forces many chunks so the split path runs repeatedly rather than
+/// emitting everything in one go.
+#[rstest]
+fn sam_chunk_source_emits_every_line_split_on_record_boundaries(
+    #[values(1, 4)] threads: usize,
+    #[values(1, 200)] n_records: usize,
+) {
+    let text = sam_record_lines(n_records);
+    let collected: Arc<Mutex<Vec<SamChunk>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReadSamChunks::new(
+            boxed_reader(text.clone()),
+            /* target_chunk_bytes */ 256,
+            EDGE_LIMIT_BYTES,
+        ))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let chunks = collected.lock().expect("mutex not poisoned").drain(..).collect::<Vec<_>>();
+    // Same reasoning as `templates_in_order`: assert the arrival order the
+    // chain promises instead of sorting into it, so an out-of-order emission
+    // fails here rather than being repaired before the byte comparison.
+    for pair in chunks.windows(2) {
+        assert!(
+            pair[0].ordinal() < pair[1].ordinal(),
+            "chunks arrived out of order: ordinal {} before {}",
+            pair[0].ordinal(),
+            pair[1].ordinal(),
+        );
+    }
+
+    // Every chunk's offset table must be sentinel-form and describe complete
+    // lines; concatenating them must reproduce the input exactly.
+    let mut lines: Vec<String> = Vec::new();
+    let mut rebuilt = Vec::new();
+    for chunk in &chunks {
+        rebuilt.extend_from_slice(&chunk.bytes);
+        assert_eq!(
+            *chunk.line_offsets.last().expect("sentinel-form table is never empty") as usize,
+            chunk.bytes.len(),
+            "the final offset must be the sentinel end-of-chunk",
+        );
+        for w in chunk.line_offsets.windows(2) {
+            let line = &chunk.bytes[w[0] as usize..w[1] as usize];
+            assert_eq!(line.last(), Some(&b'\n'), "every emitted line must be complete");
+            lines.push(String::from_utf8(line.to_vec()).expect("utf8"));
+        }
+    }
+    assert_eq!(rebuilt, text.as_bytes(), "chunks must reproduce the input byte-for-byte");
+    assert_eq!(lines.len(), n_records, "one line per input record, no duplicates or drops");
+    assert_eq!(lines.concat(), text);
+}
+
+/// An empty SAM body drains cleanly with no chunks carrying records.
+#[test]
+fn an_empty_sam_stream_completes_with_no_records() {
+    let collected: Arc<Mutex<Vec<SamChunk>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReadSamChunks::new(boxed_reader(String::new()), 256, EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    builder
+        .build()
+        .expect("chain builds")
+        .run(PipelineConfig { threads: 1, ..Default::default() })
+        .expect("chain runs");
+
+    let chunks = collected.lock().expect("mutex not poisoned");
+    let total: usize = chunks.iter().map(SamChunk::record_count).sum();
+    assert_eq!(total, 0);
+}
+
+/// `EDGE_LIMIT_BYTES` must be small enough that the multi-record fixtures
+/// exceed it, or the byte-bounded edges never reject a push and every chain
+/// above silently degrades into an unbounded-queue test.
+///
+/// This is a **necessary condition, not a proof of backpressure**: a fast
+/// -draining downstream can keep occupancy under the limit even when the whole
+/// fixture is far larger than one edge. The sibling test below closes the other
+/// half — that an edge at this budget really does reject these chunk sizes.
+#[test]
+fn the_edge_budget_binds_on_the_fixtures() {
+    let limit = usize::try_from(EDGE_LIMIT_BYTES).expect("budget fits usize");
+
+    // One FASTQ stream must not fit in a single edge, so the reader is forced
+    // to hold a rejected chunk and retry rather than emitting everything in one
+    // pass. One chunk must still fit, or the edge would wedge instead.
+    let stream_bytes = fastq_text(100, 0).len();
+    let chunk_bytes = fastq_text(BATCH_RECORD_COUNT, 0).len();
+    assert!(
+        stream_bytes > limit,
+        "one FASTQ stream ({stream_bytes} B) must exceed the per-edge budget \
+         ({limit} B), else the byte-bounded edges never bind and these chains \
+         prove nothing about backpressure",
+    );
+    assert!(
+        chunk_bytes < limit,
+        "a single chunk ({chunk_bytes} B) must still fit the budget ({limit} B), \
+         else the edge admits nothing and the pipeline wedges",
+    );
+
+    // Same for the SAM fixture.
+    let sam_bytes = sam_record_lines(200).len();
+    assert!(sam_bytes > limit, "SAM fixture ({sam_bytes} B) must exceed the budget ({limit} B)");
+}
+
+/// A byte-bounded edge at exactly `EDGE_LIMIT_BYTES`, fed the chunk sizes the
+/// FASTQ chains put on it, must reject before the fixture is exhausted — so the
+/// held-item retry path in `ReadFastqInputs` is genuinely reachable at this
+/// budget, not merely reachable in principle.
+///
+/// What this still does not assert is that a rejection occurred *during the
+/// chain runs above*. Observing that needs the per-edge reject counter, which
+/// `fgumi-pipeline-core` records (`EdgeMetrics::record_reject`) but keeps
+/// `pub(crate)`, so it is unreachable from here without widening that crate's
+/// API — out of scope for this PR. The chains cover the retry path indirectly:
+/// every record arrives, in order, across an edge this test shows must reject,
+/// which could not happen if held items were dropped or never retried. That is
+/// an inference from the end state, not a direct assertion, and it is recorded
+/// here so the gap is visible rather than assumed closed.
+#[test]
+fn the_byte_bounded_edge_rejects_at_the_test_budget() {
+    use crate::pipeline::core::queues::{ByteBoundedQueue, ItemQueue};
+    use crate::pipeline::steps::source::read_fastq::FastqRawChunk;
+
+    let queue = ByteBoundedQueue::<FastqRawChunk>::new(EDGE_LIMIT_BYTES);
+    let chunk_data = fastq_text(BATCH_RECORD_COUNT, 0).into_bytes();
+    let chunk_bytes = chunk_data.len();
+
+    // Push identical chunks until one is refused. The fixture spans many such
+    // chunks, so a queue that never rejects would loop past the whole stream.
+    let max_pushes = fastq_text(100, 0).len() / chunk_bytes + 1;
+    let mut accepted = 0usize;
+    let mut rejected = false;
+    for ordinal in 0..max_pushes {
+        let chunk = FastqRawChunk {
+            ordinal: ordinal as u64,
+            stream_idx: 0,
+            chunk_serial: ordinal as u64,
+            data: chunk_data.clone(),
+        };
+        if queue.try_push(chunk).is_err() {
+            rejected = true;
+            break;
+        }
+        accepted += 1;
+    }
+
+    assert!(
+        rejected,
+        "a {EDGE_LIMIT_BYTES}-byte edge admitted all {max_pushes} chunks of {chunk_bytes} B \
+         without rejecting; the byte budget is not binding and the chains above prove \
+         nothing about the held-item retry path",
+    );
+    assert!(
+        accepted >= 1,
+        "the edge must admit at least one chunk before rejecting, else the chains wedge \
+         instead of exercising backpressure",
+    );
+}

--- a/src/lib/pipeline/steps/source/mod.rs
+++ b/src/lib/pipeline/steps/source/mod.rs
@@ -1,0 +1,703 @@
+//! BAM, SAM, and FASTQ source steps.
+//!
+//! - `read_bam` / `read_sam_chunks` — open a BAM/SAM input and emit blocks
+//!   or line-aligned chunks.
+//! - `read_fastq` — read raw FASTQ bytes, cut on whole-record boundaries.
+//! - `parse_fastq` / `parse_zip_fastq` — parse those bytes into records.
+//! - `pair_fastq` / `zip_fastq` — join per-stream chunks into templates.
+
+#[cfg(test)]
+mod chain_tests;
+pub mod pair_fastq;
+pub mod parse_fastq;
+pub mod parse_zip_fastq;
+pub mod read_bam;
+pub mod read_fastq;
+pub mod read_sam_chunks;
+pub mod zip_fastq;
+
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, Read};
+use std::path::Path;
+
+/// Wrap a `File::open` failure with the path while **preserving the original
+/// [`io::ErrorKind`]**.
+///
+/// `io::Error::other` would flatten every kind to [`io::ErrorKind::Other`], so a
+/// missing input would stop reporting as [`io::ErrorKind::NotFound`] and callers
+/// (and users) would lose the distinction between "no such file" and
+/// "permission denied".
+fn open_error(path: &std::path::Path, source: &io::Error) -> io::Error {
+    io::Error::new(source.kind(), format!("open {}: {source}", path.display()))
+}
+
+/// The BAM-opener counterpart to [`open_error`], preserving the underlying
+/// [`io::ErrorKind`] across an `anyhow::Error`.
+///
+/// `create_bam_reader_for_pipeline_with_opts` returns `anyhow::Error`, so
+/// `io::Error::other` on it would flatten `NotFound` to `Other` — exactly the
+/// loss `open_error` exists to prevent on the plain `File::open` paths, just one
+/// error type further away.
+///
+/// The `io::Error` is usually **not** the top of the chain: the opener adds
+/// `.with_context(..)`, so a top-level `downcast` would miss it. Walking
+/// `chain()` finds the first I/O error wherever it sits, and a non-I/O failure
+/// (a malformed header, say) still falls back to `Other`, which is accurate for
+/// it.
+fn open_bam_error(path: &std::path::Path, source: &anyhow::Error) -> io::Error {
+    let message = format!("open BAM {}: {source}", path.display());
+    match source.chain().find_map(|e| e.downcast_ref::<io::Error>()) {
+        Some(io_err) => io::Error::new(io_err.kind(), message),
+        None => io::Error::other(message),
+    }
+}
+
+/// Parse a whole-record-aligned FASTQ chunk into records, returning them with
+/// the summed `HeapSize` of the parsed records.
+///
+/// `data` must contain a whole number of 4-line FASTQ records, each terminated
+/// by `\n` (as produced by `read_fastq_raw_bytes_from_bufread`). Record
+/// boundaries are located with the SIMD lexer (`find_record_offsets`) — a single
+/// vectorized pass over the chunk rather than a per-byte scalar scan.
+///
+/// `step_name` appears in the truncation error so the two callers
+/// (`ParseFastqChunks` and `ParseAndZipFastq`) stay distinguishable in logs.
+///
+/// # Errors
+///
+/// Returns `InvalidData` when the chunk ends mid-record, i.e. the reader's
+/// whole-record alignment guarantee was violated upstream.
+pub(crate) fn parse_fastq_chunk(
+    data: &[u8],
+    step_name: &str,
+) -> io::Result<(Vec<crate::fastq_parse::FastqRecord>, usize)> {
+    use crate::pipeline::core::item::HeapSize as _;
+
+    // `find_record_offsets` returns `[0, end_1, .., end_n]` where `end_n` is one
+    // byte past the final *complete* record; trailing incomplete bytes are
+    // excluded. The reader guarantees whole-record-aligned chunks, so the last
+    // offset must equal `data.len()` — anything else is a truncated record.
+    let offsets = fgumi_simd_fastq::find_record_offsets(data);
+    let last = offsets.last().copied().unwrap_or(0);
+    if last != data.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "{step_name}: truncated FASTQ record ({} trailing bytes after the last \
+                 complete record)",
+                data.len() - last
+            ),
+        ));
+    }
+
+    let num_records = offsets.len().saturating_sub(1);
+    let mut records = Vec::with_capacity(num_records);
+    let mut total_bytes = 0usize;
+    for window in offsets.windows(2) {
+        let record = crate::fastq_parse::FastqRecord::from_slice(&data[window[0]..window[1]])?;
+        total_bytes += record.heap_size();
+        records.push(record);
+    }
+    Ok((records, total_bytes))
+}
+
+use fgumi_bam_io::{ChainedReader, InputFormat, TeeReader};
+use flate2::read::MultiGzDecoder;
+use noodles::bgzf::io::Reader as BgzfReader;
+use noodles::sam;
+
+/// Opaque, opened input source ready to feed into the typed-step pipeline.
+///
+/// The two variants encode the BAM vs. SAM choice. The BAM variant carries
+/// a `Box<dyn Read + Send>` whose first bytes are the BAM header (file
+/// seeked to byte 0 for on-disk inputs, or a `TeeReader`/`ChainedReader`
+/// replay for stdin) and the parsed header. The SAM variant carries the
+/// SAM reader already positioned past its header — record reads go
+/// straight into [`read_sam_chunks::ReadSamChunks`].
+///
+/// Each command's new-pipeline path opens its input via [`InputSource::open`]
+/// once, threads the [`sam::Header`] into upstream validation /
+/// `@PG`-mutation, then `match`es on the variant to build the appropriate
+/// chain preamble (3-step BAM vs. 2-step SAM).
+pub enum InputSource {
+    /// BAM input (BGZF-compressed). `reader` is positioned at byte 0 of
+    /// the BAM stream — the `read_bam::ReadBgzfBlocks` source emits the
+    /// header bytes as part of the first block(s); `FindBamBoundaries::new`
+    /// strips them downstream.
+    Bam { reader: Box<dyn Read + Send>, header: sam::Header },
+    /// SAM (text) input. `reader` has consumed the `@`-prefixed header
+    /// lines; subsequent `read_record` calls yield the first record.
+    /// Pair with `FindBamBoundaries::new_no_header` (the SAM source
+    /// emits record bodies directly, no header bytes to strip).
+    Sam { reader: sam::io::Reader<Box<dyn BufRead + Send>>, header: sam::Header },
+}
+
+impl InputSource {
+    /// Open `path` and detect the input shape.
+    ///
+    /// Detection: `is_stdin_path` chooses stdin vs file; then the file
+    /// extension (`.sam`/`.bam`/none) selects the reader, and anything without
+    /// one is classified by content through [`fgumi_bam_io::classify_input`].
+    ///
+    /// Content classification never reduces to a magic-byte test. A leading
+    /// `\x1f` says "gzip", not "BGZF", and plain gzip is a supported input on
+    /// every other fgumi path — so treating it as BAM would hand a single
+    /// deflate stream to a block reader that rejects it. Reopenable inputs get
+    /// this for free from `create_bam_reader_for_pipeline_with_opts`, which
+    /// normalizes; pipes are classified (and decompressed if needed) in
+    /// `open_stream_by_content`.
+    ///
+    /// # Errors
+    ///
+    /// Returns I/O errors from file open, stdin read, or header parse.
+    pub fn open<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        Self::open_with_opts(path, fgumi_bam_io::PipelineReaderOpts::default())
+    }
+
+    /// [`InputSource::open`] with a [`fgumi_bam_io::PipelineReaderOpts`].
+    ///
+    /// # Errors
+    ///
+    /// Returns I/O errors from file open, stdin read, or header parse.
+    pub fn open_with_opts<P: AsRef<Path>>(
+        path: P,
+        opts: fgumi_bam_io::PipelineReaderOpts,
+    ) -> io::Result<Self> {
+        let path = path.as_ref();
+        let is_stdin = fgumi_bam_io::is_stdin_path(path);
+
+        // Suffix hint: explicit `.sam` → SAM; `.bam` → BAM. Anything else is
+        // decided by content — including `.gz`, whose extension says only that
+        // it is compressed, not by what.
+        let extension = path.extension();
+        let suffix_says_sam = extension.is_some_and(|e| e.eq_ignore_ascii_case("sam"));
+        let suffix_is_bam = extension.is_some_and(|e| e.eq_ignore_ascii_case("bam"));
+
+        if is_stdin {
+            // The path is just `-`, so there is no suffix to consult and the
+            // content decides. `PipelineReaderOpts` is not threaded through here:
+            // there is no path to reopen, so there is no async-reader wiring.
+            let _ = opts;
+            open_stream_by_content(Box::new(io::stdin()))
+        } else if suffix_says_sam {
+            let file = File::open(path).map_err(|e| open_error(path, &e))?;
+            let buf: Box<dyn BufRead + Send> =
+                Box::new(BufReader::with_capacity(2 * 1024 * 1024, file));
+            open_sam_from_boxed_buf(buf)
+        } else if suffix_is_bam {
+            // BAM file: parse header via the existing helper, which
+            // handles the seek-to-0 + opt.async_reader wiring.
+            let (reader, header) =
+                fgumi_bam_io::create_bam_reader_for_pipeline_with_opts(path, opts)
+                    .map_err(|e| open_bam_error(path, &e))?;
+            Ok(InputSource::Bam { reader, header })
+        } else {
+            // No suffix hint: the content decides.
+            let file = File::open(path).map_err(|e| open_error(path, &e))?;
+            // Whether re-opening `path` can replay the bytes classification
+            // consumes. Only a regular file can: for a FIFO or a `/dev/fd/N`
+            // handed over by process substitution, reading those bytes drains
+            // them out of the pipe for good, and a second open yields the *rest*
+            // of the stream, not the start of it — silently losing the header.
+            //
+            // An `fstat` on an already-open descriptor essentially cannot fail, but
+            // `unwrap_or(false)` picks the safe direction if it somehow does: the
+            // in-stream path always yields correct bytes and merely forgoes the
+            // async-reader wiring, whereas a wrong "regular" answer corrupts input.
+            if !file.metadata().map(|m| m.is_file()).unwrap_or(false) {
+                // Non-regular: classify in-stream. Same trade-off the stdin branch
+                // makes — no async-reader wiring, because there is no reopenable path.
+                let _ = opts;
+                return open_stream_by_content(Box::new(file));
+            }
+
+            // Regular file: classify here, then choose between keeping the text
+            // in the SAM reader and handing the path to the normalizing helper.
+            let mut file = file;
+            let (prefix, format) = take_format_prefix(&mut file)?;
+            match format {
+                // SAM text stays SAM: `ReadSamChunks` parses it directly, and
+                // routing it through the helper would transcode it to BGZF and
+                // throw that away.
+                InputFormat::Text => {
+                    open_sam_from_boxed_buf(buffered(ChainedReader::new(prefix, file)))
+                }
+                // Compressed: re-open through the helper, which seeks to byte 0,
+                // preserves the async-reader wiring, and normalizes — so a plain
+                // gzip member is decompressed there rather than handed to a block
+                // reader that would reject it. The bytes consumed above are simply
+                // re-read; a regular file can always be replayed.
+                InputFormat::Bgzf | InputFormat::Gzip => {
+                    drop(file);
+                    let (reader, header) =
+                        fgumi_bam_io::create_bam_reader_for_pipeline_with_opts(path, opts)
+                            .map_err(|e| open_bam_error(path, &e))?;
+                    Ok(InputSource::Bam { reader, header })
+                }
+                InputFormat::Empty => Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    format!("input is empty: {} (expected BAM or SAM records)", path.display()),
+                )),
+            }
+        }
+    }
+
+    /// Borrow the parsed header. Common for both variants.
+    #[must_use]
+    pub fn header(&self) -> &sam::Header {
+        match self {
+            InputSource::Bam { header, .. } | InputSource::Sam { header, .. } => header,
+        }
+    }
+}
+
+/// Consume up to [`fgumi_bam_io::FORMAT_PREFIX_LEN`] bytes and classify them.
+///
+/// The bytes are returned rather than pushed back so the caller can replay them
+/// through a [`ChainedReader`]: these inputs are pipes, which cannot be rewound
+/// or reopened. Short reads are looped over, because one `read` on a pipe may
+/// return fewer bytes than are available and a short prefix classifies as
+/// [`fgumi_bam_io::InputFormat::Gzip`] regardless of what the stream really is
+/// — BGZF cannot be recognized from fewer than a full header.
+fn take_format_prefix<R: Read + ?Sized>(reader: &mut R) -> io::Result<(Vec<u8>, InputFormat)> {
+    let mut prefix = vec![0u8; fgumi_bam_io::FORMAT_PREFIX_LEN];
+    let mut filled = 0;
+    while filled < prefix.len() {
+        match reader.read(&mut prefix[filled..]) {
+            Ok(0) => break,
+            Ok(n) => filled += n,
+            // A signal can interrupt a `read` on a stream that is still
+            // perfectly readable. `read_exact` retries this kind rather than
+            // propagating it, and a hand-rolled fill loop has to do the same —
+            // otherwise a signal during startup fails the open outright.
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+    prefix.truncate(filled);
+    let format = fgumi_bam_io::classify_input(&prefix);
+    Ok((prefix, format))
+}
+
+/// Open a stream that cannot be reopened — stdin, a FIFO, a `/dev/fd/N` from
+/// process substitution — by classifying its content.
+///
+/// Regular files do not come through here: they go to
+/// `create_bam_reader_for_pipeline_with_opts`, which normalizes via
+/// `normalize_to_bgzf` and so already decompresses plain gzip and transcodes
+/// SAM. A pipe has no such second pass, so the classification and the gzip
+/// decompression have to happen here.
+///
+/// Classification is by content through the shared
+/// [`fgumi_bam_io::classify_input`], never by a hand-rolled magic-byte test: a
+/// bare `\x1f` check cannot tell BGZF from plain gzip, and answering "BGZF" for
+/// a plain-gzip member hands it to a block reader that rejects it — the
+/// misleading diagnosis that classifier exists to prevent.
+fn open_stream_by_content(reader: Box<dyn Read + Send>) -> io::Result<InputSource> {
+    let mut reader = reader;
+    let (prefix, format) = take_format_prefix(&mut reader)?;
+    match format {
+        InputFormat::Empty => Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "input stream is empty (expected BAM or SAM records)",
+        )),
+        InputFormat::Bgzf => {
+            open_bam_from_stdin_boxed_buf(buffered(ChainedReader::new(prefix, reader)))
+        }
+        InputFormat::Text => open_sam_from_boxed_buf(buffered(ChainedReader::new(prefix, reader))),
+        // Plain gzip: one deflate stream, so no block-parallel decode. Decompress
+        // at this boundary and classify what comes out, exactly as
+        // `normalize_to_bgzf` does for reopenable inputs.
+        InputFormat::Gzip => {
+            log::warn!(
+                "input stream is gzip-compressed rather than BGZF — decompressing it \
+                 single-threaded, so --threads will not speed up reading. Recompress \
+                 with `bgzip` for block-parallel decode."
+            );
+            let mut decoded: Box<dyn Read + Send> =
+                Box::new(MultiGzDecoder::new(ChainedReader::new(prefix, reader)));
+            let (inner_prefix, inner_format) = take_format_prefix(&mut *decoded)?;
+            match inner_format {
+                InputFormat::Bgzf => open_bam_from_stdin_boxed_buf(buffered(ChainedReader::new(
+                    inner_prefix,
+                    decoded,
+                ))),
+                InputFormat::Text => {
+                    open_sam_from_boxed_buf(buffered(ChainedReader::new(inner_prefix, decoded)))
+                }
+                InputFormat::Gzip => Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "input stream is gzip-compressed more than once; decompress it before \
+                     piping it in",
+                )),
+                InputFormat::Empty => Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "input stream decompresses to an empty gzip member",
+                )),
+            }
+        }
+    }
+}
+
+/// Box a reader as the buffered stream both openers take.
+fn buffered<R: Read + Send + 'static>(reader: R) -> Box<dyn BufRead + Send> {
+    Box::new(BufReader::with_capacity(2 * 1024 * 1024, reader))
+}
+
+/// Wrap an already-buffered stdin-shape BAM reader into a BAM
+/// `InputSource`. The BGZF reader's header-probe goes through a
+/// `TeeReader` so we can replay the consumed header bytes ahead of the
+/// remaining stdin stream via `ChainedReader`. File inputs take the
+/// re-open-at-byte-0 path via `create_bam_reader_for_pipeline_with_opts`
+/// and never reach this function.
+fn open_bam_from_stdin_boxed_buf(buf: Box<dyn BufRead + Send>) -> io::Result<InputSource> {
+    let tee = TeeReader::new(buf);
+    let bgzf = BgzfReader::new(tee);
+    let mut bam_reader = noodles::bam::io::Reader::from(bgzf);
+    let header = bam_reader
+        .read_header()
+        // Preserve the source kind: a truncated header arrives as
+        // `UnexpectedEof`, and flattening it to `Other` loses the one signal a
+        // caller can branch on. Same policy as `open_error`/`open_bam_error`.
+        .map_err(|e| io::Error::new(e.kind(), format!("read BAM header from stdin: {e}")))?;
+    let bgzf = bam_reader.into_inner();
+    let tee = bgzf.into_inner();
+    let (buffered, remaining) = tee.into_parts();
+    let chained: Box<dyn Read + Send> = Box::new(ChainedReader::new(buffered, remaining));
+    Ok(InputSource::Bam { reader: chained, header })
+}
+
+/// Wrap an already-buffered SAM-shape reader (file or stdin) into a SAM
+/// `InputSource`. Parses the header up front so subsequent record reads
+/// start at the first record line.
+fn open_sam_from_boxed_buf(buf: Box<dyn BufRead + Send>) -> io::Result<InputSource> {
+    let mut sam_reader = sam::io::Reader::new(buf);
+    let header = sam_reader.read_header().map_err(|e| {
+        // See the BAM header read above: keep the source `ErrorKind`.
+        io::Error::new(e.kind(), format!("read SAM header: {e}"))
+    })?;
+    Ok(InputSource::Sam { reader: sam_reader, header })
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+    use std::io::Write;
+
+    const SAM_TEXT: &str = "\
+@HD\tVN:1.6\tSO:unsorted\n\
+@SQ\tSN:chr1\tLN:1000\n\
+read1\t0\tchr1\t10\t60\t5M\t*\t0\t0\tACGTA\tIIIII\n";
+
+    #[test]
+    fn opens_bam_file_by_extension() {
+        let path = tempfile::NamedTempFile::with_suffix(".bam").unwrap().into_temp_path();
+        let header = noodles::sam::Header::default();
+        let writer = fgumi_bam_io::create_raw_bam_writer(&path, &header, 1, 1).unwrap();
+        writer.finish().unwrap();
+
+        let source = InputSource::open(&path).unwrap();
+        assert!(matches!(source, InputSource::Bam { .. }));
+    }
+
+    #[test]
+    fn opens_sam_file_by_extension() {
+        let path = tempfile::NamedTempFile::with_suffix(".sam").unwrap().into_temp_path();
+        std::fs::File::create(&path).unwrap().write_all(SAM_TEXT.as_bytes()).unwrap();
+
+        let source = InputSource::open(&path).unwrap();
+        let InputSource::Sam { header, .. } = source else {
+            panic!("expected SAM source");
+        };
+        assert_eq!(header.reference_sequences().len(), 1);
+    }
+
+    #[test]
+    fn falls_back_to_magic_byte_when_extension_missing() {
+        // SAM content, no `.sam` suffix.
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        std::fs::File::create(&path).unwrap().write_all(SAM_TEXT.as_bytes()).unwrap();
+
+        let source = InputSource::open(&path).unwrap();
+        assert!(matches!(source, InputSource::Sam { .. }));
+    }
+
+    /// Write a minimal single-reference BAM and return its path.
+    fn write_bam(suffix: &str) -> tempfile::TempPath {
+        let path = tempfile::NamedTempFile::with_suffix(suffix).unwrap().into_temp_path();
+        let header = noodles::sam::Header::builder()
+            .add_reference_sequence(
+                bstr::BString::from("chr1"),
+                noodles::sam::header::record::value::Map::<
+                    noodles::sam::header::record::value::map::ReferenceSequence,
+                >::new(std::num::NonZeroUsize::new(1000).unwrap()),
+            )
+            .build();
+        let writer = fgumi_bam_io::create_raw_bam_writer(&path, &header, 1, 1).unwrap();
+        writer.finish().unwrap();
+        path
+    }
+
+    /// The magic-byte fallback must resolve BGZF content to BAM, not just
+    /// resolve text content to SAM. Without this the suffix-less BAM branch —
+    /// which re-opens through the async-reader-aware helper — is never taken.
+    #[test]
+    fn falls_back_to_magic_byte_for_bam_without_extension() {
+        let path = write_bam("");
+        let source = InputSource::open(&path).unwrap();
+        assert!(matches!(source, InputSource::Bam { .. }));
+        assert_eq!(source.header().reference_sequences().len(), 1);
+    }
+
+    /// Serve `bytes` over a FIFO at a suffix-less path and open it.
+    ///
+    /// The FIFO is what makes the input non-reopenable, which is the branch
+    /// under test: a regular file would be handed to the normalizing helper
+    /// instead. Opening a FIFO for writing blocks until a reader opens it, so
+    /// the writer runs concurrently with the open.
+    #[cfg(unix)]
+    fn open_via_fifo(bytes: Vec<u8>, dir: &tempfile::TempDir) -> io::Result<InputSource> {
+        let fifo = dir.path().join("stream"); // deliberately no extension
+        let status = std::process::Command::new("mkfifo").arg(&fifo).status().expect("mkfifo runs");
+        assert!(status.success(), "mkfifo failed for {}", fifo.display());
+
+        let writer_path = fifo.clone();
+        let writer = std::thread::spawn(move || {
+            let mut f = std::fs::File::create(&writer_path).expect("open fifo for write");
+            let _ = f.write_all(&bytes); // the reader may reject before draining
+        });
+
+        let opened = InputSource::open(&fifo);
+        let _ = writer.join();
+        opened
+    }
+
+    /// Plain-gzip SAM over a pipe must be decompressed and read as SAM.
+    ///
+    /// A bare `\x1f` check calls this BGZF and hands it to the BAM block reader,
+    /// which fails with a header error on a stream that is perfectly readable —
+    /// the misleading diagnosis `classify_input` exists to prevent. Plain gzip is
+    /// a supported verdict on every other fgumi input path, so it must be one
+    /// here too.
+    #[cfg(unix)]
+    #[test]
+    fn suffix_less_plain_gzip_sam_over_a_pipe_is_read_as_sam() {
+        use flate2::write::GzEncoder;
+
+        let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        encoder.write_all(SAM_TEXT.as_bytes()).expect("gzip the SAM text");
+        let gzipped = encoder.finish().expect("finish gzip member");
+        assert_eq!(gzipped[0], 0x1f, "the fixture must start with the gzip magic byte");
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = open_via_fifo(gzipped, &dir).expect("gzipped SAM opens");
+
+        let InputSource::Sam { header, .. } = source else {
+            panic!("expected a SAM source; plain gzip must not be routed to the BAM reader");
+        };
+        assert_eq!(header.reference_sequences().len(), 1);
+    }
+
+    /// The error arms of `open_stream_by_content` and of the suffix-less regular
+    /// -file branch, which the happy-path tests above never reach.
+    ///
+    /// Each is a named diagnosis rather than a downstream parse failure, so the
+    /// message is what is asserted — a caller piping the wrong thing in should be
+    /// told what is wrong with it, not handed "invalid BGZF header".
+    #[cfg(unix)]
+    #[test]
+    fn an_empty_stream_is_named_as_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let Err(err) = open_via_fifo(Vec::new(), &dir) else {
+            panic!("an empty stream must be an error");
+        };
+
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        assert!(err.to_string().contains("empty"), "got: {err}");
+    }
+
+    /// gzip wrapped around gzip: the inner classification sees gzip again, which
+    /// no fgumi reader decodes. Named explicitly rather than left to fail as a
+    /// corrupt BAM header.
+    #[cfg(unix)]
+    #[test]
+    fn a_doubly_gzipped_stream_is_rejected_by_name() {
+        use flate2::write::GzEncoder;
+
+        let gzip_once = |bytes: &[u8]| {
+            let mut e = GzEncoder::new(Vec::new(), flate2::Compression::fast());
+            e.write_all(bytes).expect("gzip");
+            e.finish().expect("finish gzip member")
+        };
+        let doubled = gzip_once(&gzip_once(SAM_TEXT.as_bytes()));
+
+        let dir = tempfile::tempdir().unwrap();
+        let Err(err) = open_via_fifo(doubled, &dir) else {
+            panic!("a doubly-gzipped stream must be an error");
+        };
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("more than once"), "got: {err}");
+    }
+
+    /// A well-formed gzip member carrying nothing: the outer classification
+    /// succeeds and the *inner* one is `Empty`, a different branch from the
+    /// empty-stream case above.
+    #[cfg(unix)]
+    #[test]
+    fn a_gzip_member_that_decompresses_to_nothing_is_named() {
+        use flate2::write::GzEncoder;
+
+        let encoder = GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        let empty_member = encoder.finish().expect("finish an empty gzip member");
+        assert_eq!(empty_member[0], 0x1f, "still a well-formed gzip member");
+
+        let dir = tempfile::tempdir().unwrap();
+        let Err(err) = open_via_fifo(empty_member, &dir) else {
+            panic!("an empty gzip member must be an error");
+        };
+
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        assert!(err.to_string().contains("empty gzip member"), "got: {err}");
+    }
+
+    /// The regular-file branch has its own `Empty` arm, reached without any pipe.
+    #[test]
+    fn an_empty_suffix_less_file_is_named_as_empty() {
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        let Err(err) = InputSource::open(&path) else {
+            panic!("an empty file must be an error");
+        };
+
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        assert!(err.to_string().contains("input is empty"), "got: {err}");
+    }
+
+    /// The same path must still resolve gzipped *BAM* to BAM: the verdict comes
+    /// from what the member decompresses to, not from the outer wrapper.
+    #[cfg(unix)]
+    #[test]
+    fn suffix_less_plain_gzip_bam_over_a_pipe_is_read_as_bam() {
+        use flate2::write::GzEncoder;
+
+        let bam_bytes = std::fs::read(write_bam("")).unwrap();
+        let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        encoder.write_all(&bam_bytes).expect("gzip the BAM bytes");
+        let gzipped = encoder.finish().expect("finish gzip member");
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = open_via_fifo(gzipped, &dir).expect("gzipped BAM opens");
+
+        assert!(matches!(source, InputSource::Bam { .. }));
+        assert_eq!(source.header().reference_sequences().len(), 1);
+    }
+
+    /// A suffix-less BGZF input that is **not** a regular file must be read
+    /// through the buffer that already holds the peeked bytes. Re-opening the
+    /// path — which is what a regular file gets, to keep the async-reader
+    /// wiring — would hand back the stream *minus* the bytes `fill_buf` already
+    /// drained out of the pipe, so the BAM header would be gone. This is the
+    /// `<(...)` process-substitution and named-pipe case.
+    ///
+    /// A regression here manifests as a hang rather than an assertion failure:
+    /// the re-open blocks forever waiting for a second writer that never comes.
+    #[cfg(unix)]
+    #[test]
+    fn suffix_less_bam_from_a_fifo_keeps_the_peeked_bytes() {
+        let bam_bytes = std::fs::read(write_bam("")).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let fifo = dir.path().join("stream"); // deliberately no extension
+        let status = std::process::Command::new("mkfifo").arg(&fifo).status().expect("mkfifo runs");
+        assert!(status.success(), "mkfifo failed for {}", fifo.display());
+
+        // Opening a FIFO for writing blocks until a reader opens it, so the
+        // writer has to run concurrently with the `open` below. The payload is
+        // far under the pipe buffer, so the writer never blocks on a full pipe.
+        let writer_path = fifo.clone();
+        let writer = std::thread::spawn(move || {
+            let mut f = std::fs::File::create(&writer_path).expect("open fifo for write");
+            f.write_all(&bam_bytes).expect("write bam to fifo");
+        });
+
+        let source = InputSource::open(&fifo).expect("fifo opens as BAM");
+        assert!(matches!(source, InputSource::Bam { .. }));
+        assert_eq!(source.header().reference_sequences().len(), 1);
+
+        writer.join().expect("writer thread joins");
+    }
+
+    /// `header()` is the variant-agnostic accessor commands use before they
+    /// branch on the input shape, so it must resolve for both variants.
+    #[test]
+    fn header_accessor_resolves_for_both_variants() {
+        let sam_path = tempfile::NamedTempFile::with_suffix(".sam").unwrap().into_temp_path();
+        std::fs::File::create(&sam_path).unwrap().write_all(SAM_TEXT.as_bytes()).unwrap();
+        let sam = InputSource::open(&sam_path).unwrap();
+        assert!(matches!(sam, InputSource::Sam { .. }));
+        assert_eq!(sam.header().reference_sequences().len(), 1);
+
+        let bam = InputSource::open(write_bam(".bam")).unwrap();
+        assert!(matches!(bam, InputSource::Bam { .. }));
+        assert_eq!(bam.header().reference_sequences().len(), 1);
+    }
+
+    /// The stdin BAM path cannot re-open by path, so it tees the header-probe
+    /// bytes and replays them ahead of the remaining stream. Driving the helper
+    /// directly over an in-memory BAM covers that replay without needing a real
+    /// stdin: the parsed header must come back, and the returned reader must
+    /// still begin at byte 0 of the BAM stream (magic included) so the
+    /// downstream boundary step can strip the header itself.
+    #[test]
+    fn stdin_bam_path_replays_the_consumed_header_bytes() {
+        let bytes = std::fs::read(write_bam(".bam")).unwrap();
+        let buf: Box<dyn BufRead + Send> = Box::new(BufReader::new(io::Cursor::new(bytes.clone())));
+
+        let source = open_bam_from_stdin_boxed_buf(buf).unwrap();
+        let InputSource::Bam { mut reader, header } = source else {
+            panic!("expected BAM source");
+        };
+        assert_eq!(header.reference_sequences().len(), 1);
+
+        // The replayed stream must be byte-identical to the original file: the
+        // header probe consumed bytes that `ChainedReader` has to hand back.
+        let mut replayed = Vec::new();
+        reader.read_to_end(&mut replayed).unwrap();
+        assert_eq!(replayed, bytes, "the teed header bytes must be replayed intact");
+    }
+
+    /// A `.sam`-suffixed file whose header does not parse must surface an error
+    /// rather than yielding a source with an empty header.
+    #[test]
+    fn a_malformed_sam_header_is_an_error() {
+        let path = tempfile::NamedTempFile::with_suffix(".sam").unwrap().into_temp_path();
+        std::fs::File::create(&path).unwrap().write_all(b"@HD\tthis is not a valid tag\n").unwrap();
+        assert!(InputSource::open(&path).is_err());
+    }
+
+    /// Opening a path that does not exist must be an error, not a panic — and
+    /// must keep the original [`io::ErrorKind`] and name the path.
+    ///
+    /// `open_error` exists precisely so `io::Error::other` does not flatten
+    /// `NotFound` into `Other`, which would cost callers the distinction between
+    /// "no such file" and "permission denied". Asserting only `is_err()` would
+    /// let a regression back to `io::Error::other` pass unnoticed, so both
+    /// properties are pinned here. One case per branch that can fail to open: the
+    /// `.sam` and suffix-less branches go through `open_error`, and the `.bam`
+    /// branch through `open_bam_error`, which has to recover the kind from an
+    /// `anyhow::Error` chain rather than from an `io::Error` directly.
+    #[rstest]
+    #[case::sam_suffix("/nonexistent/fgumi-test-input.sam")]
+    #[case::bam_suffix("/nonexistent/fgumi-test-input.bam")]
+    #[case::suffix_less_path("/nonexistent/fgumi-test-input")]
+    fn a_missing_file_reports_not_found_with_its_path(#[case] path: &str) {
+        let Err(err) = InputSource::open(path) else {
+            panic!("opening {path} must be an error");
+        };
+
+        assert_eq!(err.kind(), io::ErrorKind::NotFound, "kind must survive the wrap: {err}");
+        assert!(err.to_string().contains(path), "the message must name the path; got: {err}");
+    }
+}

--- a/src/lib/pipeline/steps/source/pair_fastq.rs
+++ b/src/lib/pipeline/steps/source/pair_fastq.rs
@@ -1,0 +1,1017 @@
+//! `PairRawFastq` step: a cheap two-input chunk-level pairing step that joins
+//! the `FastqRawChunk` streams emitted by two concurrent per-stream
+//! [`ReadFastqInputs`] readers (R1 + R2) into a single
+//! [`PairedRawFastqBatch`] stream for the downstream `Parallel`
+//! [`ParseAndZipFastq`] step.
+//!
+//! `Serial` + `Affinity::None`. This step mirrors the legacy pipeline's
+//! `FindBoundaries` stage: it does the cheap chunk-level pairing serially
+//! (matching the R1 chunk and R2 chunk at the same `chunk_serial`) and assigns
+//! a fresh, globally-unique, monotonically-increasing `ordinal` to each emitted
+//! pair. The expensive per-record FASTQ parse and template build then run in
+//! parallel in [`ParseAndZipFastq`].
+//!
+//! [`ReadFastqInputs`]: super::read_fastq::ReadFastqInputs
+//! [`ParseAndZipFastq`]: super::parse_zip_fastq::ParseAndZipFastq
+//!
+//! ## Why serial ordinal assignment is load-bearing
+//!
+//! [`ParseAndZipFastq`] is `Parallel` + `ByItemOrdinal`, so the framework
+//! reorders its output by each item's `ordinal()`. For that reorder to be
+//! correct the ordinals MUST be globally unique and dense. Assigning them here,
+//! serially, from a single `next_ordinal` counter on this step guarantees both
+//! properties. (The per-`FastqRawChunk` ordinal from the readers is NOT reused
+//! — two readers each carry their own ordinal sequence; we mint a fresh one for
+//! the paired batch.)
+//!
+//! ## Completion
+//!
+//! `try_run` opportunistically buffers whichever branch has a chunk ready and
+//! emits a pair as soon as both streams' chunks for the lowest `chunk_serial`
+//! are present. Once **both** input branches are drained, `finalize_pairs`
+//! flushes the remaining complete pairs in `chunk_serial` order (one per call)
+//! and returns `StepOutcome::Finished`, bailing with an error if either stream
+//! ran short.
+
+use std::collections::BTreeMap;
+use std::io;
+
+use super::read_fastq::FastqRawChunk;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::item::{HeapSize, Ordered};
+use crate::pipeline::core::step::Affinity;
+use crate::pipeline::core::{
+    BranchOrdering, OrderedBytesSingle, QueueSpec, Step2, StepCtx2, StepKind, StepOutcome,
+    StepProfile, Unpushed,
+};
+
+/// Backpressure cap on the total bytes buffered across the two partial-pair
+/// slots. Mirrors `ZipFastqRecords::DEFAULT_PENDING_BACKPRESSURE_BYTES`.
+const DEFAULT_PENDING_BACKPRESSURE_BYTES: usize = 256 * 1024 * 1024;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PairedRawFastqBatch — the raw bytes of one R1 chunk + one R2 chunk that share
+// a chunk_serial, plus a freshly-minted globally-unique ordinal.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A matched pair of raw (decompressed, unparsed) FASTQ byte chunks — one from
+/// stream A (R1) and one from stream B (R2) — that share a `chunk_serial`.
+///
+/// `ordinal` is minted serially by [`PairRawFastq`] and is the key the
+/// framework uses to reorder the `Parallel` [`ParseAndZipFastq`] output.
+/// `chunk_serial` is carried through for diagnostics / desync messages only.
+///
+/// [`ParseAndZipFastq`]: super::parse_zip_fastq::ParseAndZipFastq
+pub struct PairedRawFastqBatch {
+    /// Globally-unique monotonic ordinal, minted by [`PairRawFastq`].
+    pub ordinal: u64,
+    /// The shared per-stream round-robin cycle serial (for desync diagnostics).
+    pub chunk_serial: u64,
+    /// Raw bytes of the stream-A (R1) chunk, whole-record-aligned.
+    pub data_a: Vec<u8>,
+    /// Raw bytes of the stream-B (R2) chunk, whole-record-aligned.
+    pub data_b: Vec<u8>,
+}
+
+impl HeapSize for PairedRawFastqBatch {
+    fn heap_size(&self) -> usize {
+        // Allocated capacity, not logical length. `try_emit_complete` moves the
+        // two `FastqRawChunk::data` buffers in verbatim, and those were built by
+        // `read_fastq_raw_bytes_from_bufread` with `Vec::with_capacity`, so
+        // capacity exceeds length on any short chunk (the final partial batch,
+        // or reads shorter than the per-record estimate). `FastqRawChunk::heap_size`
+        // and `pending_total_bytes` both account by capacity; measuring `len()`
+        // here would make the byte-bounded output queue under-count the memory it
+        // is holding.
+        self.data_a.capacity() + self.data_b.capacity()
+    }
+}
+
+impl Ordered for PairedRawFastqBatch {
+    fn ordinal(&self) -> u64 {
+        self.ordinal
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PairRawFastq — Serial two-input pairing step
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `Serial` two-input chunk-level pairing step. Buffers the most recent
+/// unmatched chunk from each stream keyed by `chunk_serial`; once both streams
+/// have produced their chunk for the lowest pending `chunk_serial`, emits a
+/// [`PairedRawFastqBatch`] with a fresh `ordinal`.
+pub struct PairRawFastq {
+    /// Partial pairs keyed by `chunk_serial`. Each value is `(Option<a>,
+    /// Option<b>)`; a complete pair is emitted (and removed) as soon as both
+    /// slots are filled and it is the lowest pending serial.
+    pending: BTreeMap<u64, (Option<FastqRawChunk>, Option<FastqRawChunk>)>,
+    pending_total_bytes: usize,
+    pending_backpressure_bytes: usize,
+    /// Serial, monotonic ordinal assignment point for the downstream parallel
+    /// reorder. Incremented once per emitted pair.
+    next_ordinal: u64,
+    held: HeldSlot<Unpushed<PairedRawFastqBatch>>,
+    output_byte_limit: u64,
+}
+
+impl PairRawFastq {
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self {
+            pending: BTreeMap::new(),
+            pending_total_bytes: 0,
+            pending_backpressure_bytes: DEFAULT_PENDING_BACKPRESSURE_BYTES,
+            next_ordinal: 0,
+            held: HeldSlot::new(),
+            output_byte_limit,
+        }
+    }
+
+    /// Override the soft pending-backpressure limit (test-only).
+    ///
+    /// Production wires the default 256 MiB limit; tests shrink it to a few
+    /// bytes so a skewed-completion scenario can cross it with a handful of
+    /// small chunks rather than hundreds of megabytes of data.
+    #[cfg(test)]
+    fn with_backpressure_bytes(mut self, bytes: usize) -> Self {
+        self.pending_backpressure_bytes = bytes;
+        self
+    }
+
+    /// Buffer a chunk from stream A (slot 0) or stream B (slot 1).
+    ///
+    /// Each reader mints exactly one chunk per `(chunk_serial, stream)`, so a
+    /// target slot is always `None` here. The byte accounting (X5-004) depends
+    /// on that invariant: it adds `chunk.data.capacity()` to `pending_total_bytes`,
+    /// which feeds the catastrophic-desync guard and the backpressure decision.
+    /// A *hard* `assert!` enforces single-chunk-per-serial in release builds
+    /// too: overwriting an already-filled slot would silently change emitted
+    /// read identity (and drift the byte total), so a retry/replay/re-chunk
+    /// regression must fail fast rather than corrupt output.
+    fn buffer_chunk(&mut self, chunk: FastqRawChunk, is_a: bool) {
+        self.pending_total_bytes += chunk.data.capacity();
+        let entry = self.pending.entry(chunk.chunk_serial).or_insert((None, None));
+        let slot = if is_a { &mut entry.0 } else { &mut entry.1 };
+        assert!(
+            slot.is_none(),
+            "duplicate chunk for serial {} stream {}: single-chunk-per-serial invariant violated",
+            chunk.chunk_serial,
+            if is_a { "A" } else { "B" },
+        );
+        *slot = Some(chunk);
+    }
+
+    /// If the lowest pending `chunk_serial` has both stream slots filled, remove
+    /// it and produce a `PairedRawFastqBatch` with a fresh ordinal.
+    fn try_emit_complete(&mut self) -> Option<PairedRawFastqBatch> {
+        let lowest_serial = *self.pending.keys().next()?;
+        let entry = self.pending.get(&lowest_serial)?;
+        if entry.0.is_none() || entry.1.is_none() {
+            return None;
+        }
+
+        let (a, b) = self.pending.remove(&lowest_serial).unwrap();
+        let a = a.unwrap();
+        let b = b.unwrap();
+        self.pending_total_bytes =
+            self.pending_total_bytes.saturating_sub(a.data.capacity() + b.data.capacity());
+
+        let ordinal = self.next_ordinal;
+        self.next_ordinal += 1;
+        Some(PairedRawFastqBatch {
+            ordinal,
+            chunk_serial: lowest_serial,
+            data_a: a.data,
+            data_b: b.data,
+        })
+    }
+}
+
+/// Decide which input branches to pull this dispatch, given backpressure state.
+///
+/// Returns `(pull_a, pull_b)`. The pending-pair buffer must be byte-bounded, but
+/// bounding it by globally refusing to pull deadlocks: when one FASTQ stream
+/// races ahead, the buffer fills with its unmatched chunks, and the chunk needed
+/// to complete the lowest pending pair sits unpulled in the *behind* stream's
+/// queue. So under backpressure we still pull whichever stream is missing from
+/// the front (lowest pending) pair — the pull that lets the front pair emit and
+/// the buffer drain — and throttle only the stream that is already ahead.
+///
+/// - Not over the limit → pull both (normal streaming).
+/// - Over the limit, front pair missing a slot → pull only that (behind) stream.
+/// - Over the limit, front pair already complete (or no pending) → pull neither;
+///   the caller drains via `try_emit_complete` instead of accumulating more.
+fn pull_decision(
+    over_backpressure: bool,
+    front_missing_a: bool,
+    front_missing_b: bool,
+) -> (bool, bool) {
+    if !over_backpressure {
+        return (true, true);
+    }
+    (front_missing_a, front_missing_b)
+}
+
+impl Step2 for PairRawFastq {
+    type InputA = FastqRawChunk;
+    type InputB = FastqRawChunk;
+    type Outputs = OrderedBytesSingle<PairedRawFastqBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "PairRawFastq",
+            kind: StepKind::Serial,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            // FIFO (no reorder stage) is BOTH correct and required for
+            // throughput here. Each emitted `PairedRawFastqBatch` already
+            // carries a dense, globally-unique `ordinal` minted serially by
+            // this step, and the downstream `ParseAndZipFastq` is Parallel +
+            // `ByItemOrdinal`, so it re-establishes input order by that
+            // ordinal regardless of arrival order. Imposing `ByItemOrdinal`
+            // on THIS edge would insert a `ReorderStage` that releases items
+            // strictly one-at-a-time in ordinal order, serializing the
+            // Parallel consumer (its workers would contend on a single
+            // `next_serial` slot) and defeating the whole point of moving the
+            // parse + template build into a Parallel step. This mirrors the
+            // legacy `MergeFastqRawChunks` → `ParseFastqChunks` edge, which
+            // was FIFO for the same reason.
+            branch_ordering: vec![BranchOrdering::None],
+        }
+    }
+
+    fn affinity(&self) -> Affinity {
+        // Let any free worker drive the pairing; pinning it to a reader's
+        // worker would serialize read + pair on one thread.
+        Affinity::None
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx2<'_, Self>) -> io::Result<StepOutcome> {
+        // 1. Drain held output slot first.
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        // 2. Catastrophic-desync guard: one stream producing far more data
+        //    than its counterpart balloons the partial-pair buffer. With the
+        //    per-stream backpressure below this should never trip (the ahead
+        //    stream is throttled at 1x), but keep it as a safety net.
+        if self.pending_total_bytes > 2 * self.pending_backpressure_bytes {
+            return Err(io::Error::other(format!(
+                "PairRawFastq: catastrophic stream desync — pending buffer ({} bytes) \
+                 exceeds 2x backpressure limit ({} bytes). One FASTQ stream is producing \
+                 far more data than its counterpart.",
+                self.pending_total_bytes, self.pending_backpressure_bytes
+            )));
+        }
+
+        // 3. Drain available chunks and emit every pair we can in this dispatch.
+        //    Doing this in a loop (rather than one chunk per call) amortizes the
+        //    Serial mutex / dispatch overhead and keeps the downstream Parallel
+        //    `ParseAndZipFastq` workers fed.
+        //
+        //    Backpressure is PER-STREAM, not global: once the pending buffer is
+        //    over the limit we keep pulling whichever stream is missing from the
+        //    lowest pending pair (the pull that completes it and drains the
+        //    buffer) and throttle only the stream that is ahead. Globally
+        //    refusing to pull here deadlocks — the completing chunk sits unpulled
+        //    in the behind stream's full queue while the buffer never drains
+        //    (a fast aligner makes the front-end run fast enough to desync the
+        //    R1/R2 readers past the limit and trip this).
+        let mut pulled = false;
+        let mut emitted = false;
+        loop {
+            let over_backpressure = self.pending_total_bytes > self.pending_backpressure_bytes;
+            let (front_missing_a, front_missing_b) = match self.pending.values().next() {
+                Some((a, b)) => (a.is_none(), b.is_none()),
+                None => (false, false),
+            };
+            let (pull_a, pull_b) =
+                pull_decision(over_backpressure, front_missing_a, front_missing_b);
+
+            let mut pulled_this_iter = false;
+            if pull_a && let Some(chunk) = ctx.a.pop() {
+                self.buffer_chunk(chunk, /* is_a */ true);
+                pulled_this_iter = true;
+            }
+            if pull_b && let Some(chunk) = ctx.b.pop() {
+                self.buffer_chunk(chunk, /* is_a */ false);
+                pulled_this_iter = true;
+            }
+            pulled |= pulled_this_iter;
+
+            // Emit every complete pair currently at the front of the buffer.
+            while let Some(pair) = self.try_emit_complete() {
+                emitted = true;
+                if let Err(unpushed) = ctx.outputs.push(pair) {
+                    // Output queue is full: hold the rejected pair and yield so
+                    // the downstream consumer can drain it.
+                    self.held.put(unpushed);
+                    return Ok(StepOutcome::Progress);
+                }
+            }
+
+            // Stop when neither branch yielded a new chunk this iteration.
+            if !pulled_this_iter {
+                break;
+            }
+        }
+
+        if pulled || emitted {
+            return Ok(StepOutcome::Progress);
+        }
+
+        // Nothing pulled or emitted this call. When over backpressure, pulling
+        // of the surplus (ahead) stream has stopped, so if the front pending pair
+        // is missing a record from a stream that is already drained, that stream
+        // can never complete the pair AND the ahead stream can never drain —
+        // `finalize_pairs` (both-drained) is unreachable, and `pending_total_bytes`
+        // plateaus below the 2x catastrophic-desync abort so that guard never
+        // fires either. This is the unequal-record-count case (e.g. a truncated
+        // R1): fail fast instead of spinning `NoProgress` forever (a silent hang).
+        // Under normal backpressure both streams still drain and the richer
+        // `finalize_pairs` desync report handles the mismatch.
+        if self.pending_total_bytes > self.pending_backpressure_bytes
+            && let Some((&serial, (a_slot, b_slot))) = self.pending.iter().next()
+        {
+            let a_short = a_slot.is_none() && ctx.a.is_drained();
+            let b_short = b_slot.is_none() && ctx.b.is_drained();
+            if a_short || b_short {
+                // The stream whose front slot is missing is the one that ended
+                // early. Report through the shared helper so this mid-stream
+                // fail-fast names the short stream and orphaned serial exactly
+                // like the both-drained `finalize_pairs` path.
+                let short_stream = usize::from(!a_short);
+                return Err(out_of_sync_error(short_stream, serial));
+            }
+        }
+
+        // If both input branches are drained, the pairing is complete — flush
+        // remaining pairs and finish.
+        if ctx.a.is_drained() && ctx.b.is_drained() {
+            return self.finalize_pairs(ctx);
+        }
+        Ok(StepOutcome::NoProgress)
+    }
+}
+
+/// Build the canonical FASTQ out-of-sync error identifying the stream that ended
+/// early. `short_stream` is the 0-based index of the stream that ran out of
+/// records first (0 = R1/A, 1 = R2/B) and `chunk_serial` is the orphaned serial
+/// still holding only the other stream's chunk.
+///
+/// Shared by both fail paths — the both-drained [`PairRawFastq::finalize_pairs`]
+/// desync report and the over-backpressure mid-stream fail-fast — so the two
+/// surface byte-for-byte identical diagnostics regardless of which path detects
+/// the mismatch.
+fn out_of_sync_error(short_stream: usize, chunk_serial: u64) -> io::Error {
+    io::Error::other(format!(
+        "FASTQ sources out of sync: stream {short_stream} ended before chunk_serial \
+         {chunk_serial} while the other stream had more records"
+    ))
+}
+
+impl PairRawFastq {
+    /// Both input branches are drained: emit the next remaining complete pair
+    /// (in `chunk_serial` order), or report `Finished` once `pending` is empty.
+    /// Any serial holding only one stream's chunk means the two FASTQ streams
+    /// desynchronized (unequal record counts) — a fatal error. One pair per
+    /// call (re-dispatched); a bounced push is parked in `held` and retried by
+    /// `try_run`'s held-drain preamble next pass.
+    fn finalize_pairs(&mut self, ctx: &mut StepCtx2<'_, Self>) -> io::Result<StepOutcome> {
+        let Some(&lowest_serial) = self.pending.keys().next() else {
+            return Ok(StepOutcome::Finished);
+        };
+        let entry = self.pending.get(&lowest_serial).unwrap();
+        if entry.0.is_none() || entry.1.is_none() {
+            let short = usize::from(entry.0.is_some());
+            return Err(out_of_sync_error(short, lowest_serial));
+        }
+        let pair = self.try_emit_complete().expect("entry is complete");
+        if let Err(unpushed) = ctx.outputs.push(pair) {
+            self.held.put(unpushed);
+        }
+        Ok(StepOutcome::Progress)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chunk(stream_idx: usize, chunk_serial: u64, data: &[u8]) -> FastqRawChunk {
+        // The pairing reads only `chunk_serial` and `data`; ordinal/stream_idx
+        // are carried by the readers but irrelevant to the pair join. Derive a
+        // deterministic ordinal for clarity.
+        let ordinal = chunk_serial * 2 + stream_idx as u64;
+        FastqRawChunk { ordinal, stream_idx, chunk_serial, data: data.to_vec() }
+    }
+
+    #[test]
+    fn pull_decision_pulls_both_when_not_backpressured() {
+        assert_eq!(pull_decision(false, true, true), (true, true));
+        assert_eq!(pull_decision(false, false, false), (true, true));
+    }
+
+    #[test]
+    fn pull_decision_under_backpressure_pulls_only_the_behind_stream() {
+        // The deadlock fix: when over the limit and the front pair is missing
+        // B, we MUST still pull B (the behind stream) so the pair can complete
+        // and the buffer drain — never refuse the completing pull.
+        assert_eq!(pull_decision(true, false, true), (false, true), "missing B → pull B only");
+        assert_eq!(pull_decision(true, true, false), (true, false), "missing A → pull A only");
+    }
+
+    #[test]
+    fn pull_decision_under_backpressure_with_complete_front_pulls_neither() {
+        // Front pair is complete; draining (emit) is the way forward, not pulling
+        // more — so throttle both streams.
+        assert_eq!(pull_decision(true, false, false), (false, false));
+    }
+
+    #[test]
+    fn paired_batch_heap_size_and_ordinal() {
+        let batch = PairedRawFastqBatch {
+            ordinal: 9,
+            chunk_serial: 3,
+            data_a: vec![0u8; 10],
+            data_b: vec![0u8; 7],
+        };
+        assert_eq!(batch.heap_size(), 17);
+        assert_eq!(batch.ordinal(), 9);
+    }
+
+    /// `heap_size` must report the memory the batch actually holds, which for a
+    /// short chunk is the reader's over-allocated capacity rather than the byte
+    /// count. Built with explicit spare capacity so the two differ — a `vec![]`
+    /// of exact length cannot tell `len()` and `capacity()` apart.
+    #[test]
+    fn paired_batch_heap_size_counts_spare_capacity() {
+        let mut data_a = Vec::with_capacity(300);
+        data_a.extend_from_slice(&[0u8; 10]);
+        let mut data_b = Vec::with_capacity(300);
+        data_b.extend_from_slice(&[0u8; 7]);
+        let (cap_a, cap_b) = (data_a.capacity(), data_b.capacity());
+
+        let batch = PairedRawFastqBatch { ordinal: 0, chunk_serial: 0, data_a, data_b };
+
+        assert_eq!(batch.heap_size(), cap_a + cap_b);
+        assert!(
+            batch.heap_size() > 17,
+            "heap_size must exceed the 17 live bytes; got {}",
+            batch.heap_size()
+        );
+    }
+
+    #[test]
+    fn profile_advertises_serial_fifo() {
+        let step = PairRawFastq::new(1024);
+        let p = step.profile();
+        assert_eq!(p.name, "PairRawFastq");
+        assert_eq!(p.kind, StepKind::Serial);
+        assert!(!p.sticky);
+        assert_eq!(step.affinity(), Affinity::None);
+        // FIFO on this edge: the items carry a dense ordinal and the Parallel
+        // downstream reorders, so a reorder stage here would needlessly
+        // serialize the consumer.
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::None]);
+        assert!(matches!(p.output_queues[0], QueueSpec::ByteBounded { .. }));
+    }
+
+    /// X5-004: a duplicate chunk for an already-filled `(chunk_serial, stream)`
+    /// slot violates the single-chunk-per-serial invariant the byte accounting
+    /// depends on. The hard `assert!` in `buffer_chunk` must catch it in all
+    /// builds rather than letting `pending_total_bytes` silently drift.
+    #[test]
+    #[should_panic(expected = "single-chunk-per-serial invariant violated")]
+    fn buffer_chunk_rejects_duplicate_slot() {
+        let mut step = PairRawFastq::new(64 * 1024);
+        step.buffer_chunk(chunk(0, 0, b"raw_a0"), true);
+        // Second chunk for the same (serial 0, stream A) slot — must trip the guard.
+        step.buffer_chunk(chunk(0, 0, b"raw_a0_again"), true);
+    }
+
+    /// Buffering a-then-b for a serial completes the pair; out-of-order serial
+    /// arrival still emits in `chunk_serial` order with dense ordinals.
+    #[test]
+    fn pairs_in_chunk_serial_order_with_fresh_dense_ordinals() {
+        let mut step = PairRawFastq::new(64 * 1024 * 1024);
+
+        // Buffer serial 0 (A then B) and serial 1 (B then A) interleaved.
+        step.buffer_chunk(chunk(0, 0, b"raw_a0"), true);
+        assert!(step.try_emit_complete().is_none(), "serial 0 missing B");
+        step.buffer_chunk(chunk(1, 1, b"raw_b1"), false);
+        assert!(step.try_emit_complete().is_none(), "lowest serial 0 still missing B");
+        step.buffer_chunk(chunk(1, 0, b"raw_b0"), false);
+
+        // Now serial 0 is complete and is the lowest → emits first, ordinal 0.
+        let p0 = step.try_emit_complete().unwrap();
+        assert_eq!(p0.ordinal, 0);
+        assert_eq!(p0.chunk_serial, 0);
+        assert_eq!(p0.data_a, b"raw_a0");
+        assert_eq!(p0.data_b, b"raw_b0");
+
+        // serial 1 still missing A.
+        assert!(step.try_emit_complete().is_none());
+        step.buffer_chunk(chunk(0, 1, b"raw_a1"), true);
+        let p1 = step.try_emit_complete().unwrap();
+        assert_eq!(p1.ordinal, 1, "ordinals are dense and monotonic");
+        assert_eq!(p1.chunk_serial, 1);
+        assert_eq!(p1.data_a, b"raw_a1");
+        assert_eq!(p1.data_b, b"raw_b1");
+
+        assert_eq!(step.pending_total_bytes, 0);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // X3-003: drive the paired-FASTQ source through a REAL fused chain under
+    // back-pressure with skewed stream completion, on a watchdog thread.
+    //
+    // The in-module `pull_decision` tests above only check the decision
+    // predicate in isolation. This test exercises the actual `PairRawFastq`
+    // step inside a `Pipeline` with a tiny byte limit and one stream (R1)
+    // racing far ahead of the other (R2): R1 emits ALL its chunks before R2
+    // emits any. The partial-pair buffer crosses the limit while the front
+    // pair is missing R2; the deadlock fix must keep pulling R2 (the behind
+    // stream) so the front pair completes and the buffer drains. A regression
+    // that globally refuses to pull under back-pressure wedges the step, and
+    // the watchdog fires.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrd};
+
+    use crate::pipeline::core::{PipelineBuilder, PipelineConfig, Step, StepCtx};
+
+    /// Bytes per emitted raw chunk. Sized so that buffering a SINGLE unmatched
+    /// leader chunk already crosses the pairing step's soft byte limit — that
+    /// way the partial-pair buffer is over-limit with the front pair missing
+    /// its R2 slot, which is exactly the state where a "refuse all pulls under
+    /// back-pressure" regression deadlocks (it will not pull the available R2
+    /// chunk that would complete the front pair and drain the buffer).
+    const X3_CHUNK_BYTES: usize = 1024;
+    /// Number of chunk serials each stream emits.
+    const X3_N_SERIALS: u64 = 16;
+    /// Soft backpressure limit for the pairing step under test. Sized so a
+    /// single buffered unmatched chunk crosses the SOFT limit (1x) but stays
+    /// under the HARD desync limit (2x): `768 < 1024 (one chunk) < 1536`. This
+    /// puts the step in the over-soft-limit / front-pair-incomplete regime that
+    /// the deadlock fix targets, WITHOUT tripping the catastrophic-desync abort.
+    const X3_SOFT_LIMIT_BYTES: usize = 768;
+    /// Per-source output-queue byte limit. Small (a few chunks) so a
+    /// back-pressured pairing step leaves a source's output queue full and that
+    /// source cannot drain — the precondition for the deadlock to manifest (if
+    /// the streams always drained, `finalize_pairs` would flush everything even
+    /// under a refuse-to-pull regression, masking the bug).
+    const X3_SOURCE_QUEUE_BYTES: u64 = 4 * 1024;
+    /// R2 holds back until R1 has emitted this many chunks, so the front pair
+    /// (serial 0) is reliably buffered R1-first and over the limit with its R2
+    /// slot still missing. Kept minimal (just enough to order the front pair) so
+    /// it does not also stall the FIXED path, which over the limit pulls ONLY
+    /// the behind stream.
+    const X3_LAG_UNTIL: usize = 1;
+
+    /// Serial source emitting `FastqRawChunk`s for ONE stream, serials `0..N`,
+    /// at the given `stream_idx`. Mirrors the per-stream `ReadFastqInputs`
+    /// reader: one chunk per dispatch, each carrying a globally-unique ordinal.
+    ///
+    /// To force the skewed-completion regime the deadlock fix targets, the
+    /// stream is optionally gated on a shared "leader progress" counter: the
+    /// leader (R1) increments it on every emit, and the laggard (R2) refuses to
+    /// emit (`NoProgress`) until the leader has raced `lag_until` chunks ahead.
+    /// This piles the leader's unmatched chunks in `PairRawFastq`'s partial-pair
+    /// buffer past the byte limit while the front pair is still missing R2 —
+    /// exactly the state where a "refuse all pulls under back-pressure"
+    /// regression deadlocks (the completing R2 chunk is available but never
+    /// pulled).
+    struct OneStreamSource {
+        stream_idx: usize,
+        next_serial: u64,
+        n_serials: u64,
+        held: HeldSlot<Unpushed<FastqRawChunk>>,
+        output_byte_limit: u64,
+        /// Shared leader-progress counter (chunks the leader has emitted).
+        leader_progress: Arc<AtomicUsize>,
+        /// If `Some(n)`, this is the laggard: do not emit until the leader has
+        /// emitted at least `n` chunks. If `None`, this is the leader.
+        lag_until: Option<usize>,
+    }
+
+    impl OneStreamSource {
+        fn leader(
+            stream_idx: usize,
+            n_serials: u64,
+            output_byte_limit: u64,
+            leader_progress: Arc<AtomicUsize>,
+        ) -> Self {
+            Self {
+                stream_idx,
+                next_serial: 0,
+                n_serials,
+                held: HeldSlot::new(),
+                output_byte_limit,
+                leader_progress,
+                lag_until: None,
+            }
+        }
+
+        fn laggard(
+            stream_idx: usize,
+            n_serials: u64,
+            output_byte_limit: u64,
+            leader_progress: Arc<AtomicUsize>,
+            lag_until: usize,
+        ) -> Self {
+            Self {
+                stream_idx,
+                next_serial: 0,
+                n_serials,
+                held: HeldSlot::new(),
+                output_byte_limit,
+                leader_progress,
+                lag_until: Some(lag_until),
+            }
+        }
+    }
+
+    impl Step for OneStreamSource {
+        type Input = ();
+        type Outputs = OrderedBytesSingle<FastqRawChunk>;
+
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "OneStreamSource",
+                kind: StepKind::Serial,
+                sticky: false,
+                output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+                branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+            }
+        }
+
+        fn affinity(&self) -> Affinity {
+            // Distinct workers so R1 and R2 can race independently (mirrors the
+            // production per-stream reader affinities).
+            Affinity::Worker(self.stream_idx)
+        }
+
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            if let Some(unpushed) = self.held.take() {
+                match ctx.outputs.retry(unpushed) {
+                    Ok(()) => {}
+                    Err(again) => {
+                        self.held.put(again);
+                        return Ok(StepOutcome::Contention);
+                    }
+                }
+            }
+
+            if self.next_serial >= self.n_serials {
+                return Ok(StepOutcome::Finished);
+            }
+
+            // Laggard: stall until the leader has raced far enough ahead to
+            // pile its chunks past the byte limit with the front pair missing.
+            if let Some(lag_until) = self.lag_until
+                && self.leader_progress.load(AtomicOrd::Acquire) < lag_until
+            {
+                return Ok(StepOutcome::NoProgress);
+            }
+
+            let chunk_serial = self.next_serial;
+            self.next_serial += 1;
+
+            // Globally-unique ordinal across both streams (N == 2):
+            // serial*2 + stream_idx.
+            let ordinal = chunk_serial * 2 + self.stream_idx as u64;
+            let chunk = FastqRawChunk {
+                ordinal,
+                stream_idx: self.stream_idx,
+                chunk_serial,
+                data: vec![b'A'; X3_CHUNK_BYTES],
+            };
+            match ctx.outputs.push(chunk) {
+                Ok(()) => {
+                    if self.lag_until.is_none() {
+                        self.leader_progress.fetch_add(1, AtomicOrd::Release);
+                    }
+                    Ok(StepOutcome::Progress)
+                }
+                Err(unpushed) => {
+                    self.held.put(unpushed);
+                    if self.lag_until.is_none() {
+                        self.leader_progress.fetch_add(1, AtomicOrd::Release);
+                    }
+                    Ok(StepOutcome::Progress)
+                }
+            }
+        }
+    }
+
+    /// Serial sink that records each paired batch's `chunk_serial` in the order
+    /// it is popped. Declared `Serial` (not `Parallel`) so the recorded order is
+    /// exactly the emission order of the upstream `Serial` `PairRawFastq` step —
+    /// a `Parallel` sink would let multiple workers race on `pop()` and reorder
+    /// the observations, masking any ordering regression in the pairing step.
+    #[derive(Clone)]
+    struct PairSink {
+        seen_serials: Arc<Mutex<Vec<u64>>>,
+        count: Arc<AtomicUsize>,
+    }
+
+    impl Step for PairSink {
+        type Input = PairedRawFastqBatch;
+        type Outputs = ();
+
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "PairSink",
+                kind: StepKind::Serial,
+                sticky: false,
+                output_queues: vec![],
+                branch_ordering: vec![],
+            }
+        }
+
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            match ctx.input.pop() {
+                Some(batch) => {
+                    // Each emitted pair must carry equal-length R1/R2 data.
+                    assert_eq!(batch.data_a.len(), X3_CHUNK_BYTES);
+                    assert_eq!(batch.data_b.len(), X3_CHUNK_BYTES);
+                    self.seen_serials.lock().unwrap().push(batch.chunk_serial);
+                    self.count.fetch_add(1, AtomicOrd::Relaxed);
+                    Ok(StepOutcome::Progress)
+                }
+                None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+                None => Ok(StepOutcome::NoProgress),
+            }
+        }
+
+        fn new_worker_copy(&self) -> Self {
+            self.clone()
+        }
+    }
+
+    /// End-to-end: two per-stream sources (R1 races ahead, R2 lags) feed
+    /// `PairRawFastq` (tiny byte limit) which feeds a collecting sink. Driven on
+    /// a watchdog thread so the deadlock regression surfaces as a timeout. The
+    /// run must complete and emit every pair in `chunk_serial` order.
+    #[test]
+    fn pair_fastq_does_not_deadlock_under_backpressure_with_skewed_streams() {
+        use std::time::{Duration, Instant};
+
+        let seen = Arc::new(Mutex::new(Vec::<u64>::new()));
+        let count = Arc::new(AtomicUsize::new(0));
+
+        // R1 (leader) races ahead; R2 (laggard) stalls until R1 has emitted
+        // `X3_LAG_UNTIL` chunks, forcing the partial-pair buffer over the limit
+        // with the front pair missing R2.
+        let leader_progress = Arc::new(AtomicUsize::new(0));
+
+        let seen_for_thread = Arc::clone(&seen);
+        let count_for_thread = Arc::clone(&count);
+        let leader_for_thread = Arc::clone(&leader_progress);
+        let worker = std::thread::Builder::new()
+            .name("pair-fastq-x3-003".into())
+            .spawn(move || -> io::Result<()> {
+                let r1 = OneStreamSource::leader(
+                    0,
+                    X3_N_SERIALS,
+                    X3_SOURCE_QUEUE_BYTES,
+                    Arc::clone(&leader_for_thread),
+                );
+                let r2 = OneStreamSource::laggard(
+                    1,
+                    X3_N_SERIALS,
+                    X3_SOURCE_QUEUE_BYTES,
+                    leader_for_thread,
+                    X3_LAG_UNTIL,
+                );
+                let pair =
+                    PairRawFastq::new(64 * 1024).with_backpressure_bytes(X3_SOFT_LIMIT_BYTES);
+                let sink = PairSink { seen_serials: seen_for_thread, count: count_for_thread };
+
+                let builder = PipelineBuilder::new();
+                let r1_tail = builder.append_source(r1);
+                let r2_tail = builder.append_source(r2);
+                let pair_tail = builder.append_step2(pair, r1_tail, r2_tail);
+                builder.append_step(sink, pair_tail);
+
+                let pipeline = builder.build().map_err(io::Error::other)?;
+                // 3 workers: R1, R2, and a free worker for pairing/sink.
+                pipeline
+                    .run(PipelineConfig { threads: 3, ..Default::default() })
+                    .map_err(io::Error::other)
+            })
+            .expect("spawn pipeline worker");
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while !worker.is_finished() {
+            assert!(
+                Instant::now() < deadline,
+                "PairRawFastq pipeline did not finish within 30s — likely the X3-003 \
+                 refuse-to-pull-under-backpressure deadlock regression"
+            );
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        worker.join().expect("pipeline thread panicked").expect("pipeline run returned Err");
+
+        // Full output: one pair per serial, every serial present AND observed in
+        // ascending `chunk_serial` order. The Serial `PairSink` records in pop
+        // order, so we assert the observed vector directly (no sorting) — an
+        // out-of-order emission from `PairRawFastq` would now fail the test.
+        let serials = seen.lock().unwrap().clone();
+        assert_eq!(
+            serials.len(),
+            usize::try_from(X3_N_SERIALS).unwrap(),
+            "expected one emitted pair per serial, got {}",
+            serials.len()
+        );
+        let expected: Vec<u64> = (0..X3_N_SERIALS).collect();
+        assert_eq!(
+            serials, expected,
+            "every chunk_serial must be paired exactly once and emitted in order"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // S5a2-011: when the two FASTQ streams have UNEQUAL record counts, one
+    // stream's reader drains while the other still has a chunk for the lowest
+    // pending serial. `finalize_pairs` must abort with an "out of sync" error
+    // that names the stream index that ENDED EARLY (the missing one) — and it
+    // must do so symmetrically, whichever of the two streams is short. The
+    // `run_desync_harness` helper below drives both directions; the two tests
+    // assert the stream-1-short and stream-0-short cases respectively.
+    //
+    // Wiring mirrors the X3-003 harness above: two `OneStreamSource` leaders
+    // (no lag — we want clean end-of-stream desync at drain, not mid-stream
+    // backpressure), one feeding 3 serials and one feeding 2. Serial 2 buffers
+    // only the long stream's chunk; both readers then drain, `finalize_pairs`
+    // finds serial 2 holding one side present and the other missing, computes
+    // `short` from which side is absent, and reports "stream <short> ended
+    // before chunk_serial 2". The backpressure limit is kept generous so the
+    // catastrophic-desync hard-abort (2x) never fires first — the one-serial
+    // skew keeps the partial-pair buffer tiny.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// The long stream emits this many serials.
+    const DESYNC_LONG_SERIALS: u64 = 3;
+    /// The short stream emits this many serials (it ends one serial early).
+    const DESYNC_SHORT_SERIALS: u64 = 2;
+
+    /// Run the two-leader desync harness with `serials0` chunks on stream 0 and
+    /// `serials1` on stream 1, returning the pipeline run result. Whichever
+    /// stream is short drains first, leaving the lowest pending serial holding
+    /// only the long stream's chunk, so `finalize_pairs` must abort with an
+    /// "out of sync" error naming the SHORT (missing) stream index. Shared by
+    /// both desync tests so the stream-0-short and stream-1-short cases exercise
+    /// byte-for-byte the same wiring (only the lengths swap).
+    fn run_desync_harness(serials0: u64, serials1: u64) -> Result<(), String> {
+        run_desync_harness_with_backpressure(serials0, serials1, None)
+    }
+
+    fn run_desync_harness_with_backpressure(
+        serials0: u64,
+        serials1: u64,
+        backpressure_bytes: Option<usize>,
+    ) -> Result<(), String> {
+        use std::time::{Duration, Instant};
+
+        // Both sources are leaders with no lag gate; the shared counter is
+        // unused for ordering here but required by the constructor signature.
+        let unused_progress = Arc::new(AtomicUsize::new(0));
+
+        let progress_for_thread = Arc::clone(&unused_progress);
+        let worker = std::thread::Builder::new()
+            .name("pair-fastq-s5a2-011".into())
+            .spawn(move || -> Result<(), String> {
+                let stream0 = OneStreamSource::leader(
+                    0,
+                    serials0,
+                    X3_SOURCE_QUEUE_BYTES,
+                    Arc::clone(&progress_for_thread),
+                );
+                let stream1 = OneStreamSource::leader(
+                    1,
+                    serials1,
+                    X3_SOURCE_QUEUE_BYTES,
+                    progress_for_thread,
+                );
+                // Default (generous) backpressure lets the streams reach the
+                // end-of-stream `finalize_pairs` desync path; a small cap instead
+                // exercises the mid-stream fail-fast (surplus over 1x stops
+                // pulling before both branches drain).
+                let pair = match backpressure_bytes {
+                    Some(bytes) => PairRawFastq::new(64 * 1024).with_backpressure_bytes(bytes),
+                    None => PairRawFastq::new(64 * 1024),
+                };
+                let sink = PairSink {
+                    seen_serials: Arc::new(Mutex::new(Vec::new())),
+                    count: Arc::new(AtomicUsize::new(0)),
+                };
+
+                let builder = PipelineBuilder::new();
+                let tail0 = builder.append_source(stream0);
+                let tail1 = builder.append_source(stream1);
+                let pair_tail = builder.append_step2(pair, tail0, tail1);
+                builder.append_step(sink, pair_tail);
+
+                let pipeline = builder.build().map_err(|e| e.to_string())?;
+                pipeline
+                    .run(PipelineConfig { threads: 3, ..Default::default() })
+                    .map_err(|e| e.to_string())
+            })
+            .expect("spawn pipeline worker");
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while !worker.is_finished() {
+            assert!(
+                Instant::now() < deadline,
+                "PairRawFastq desync pipeline did not finish within 30s — likely a deadlock"
+            );
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        worker.join().expect("pipeline thread panicked")
+    }
+
+    #[test]
+    fn finalize_pairs_reports_desync_with_short_stream_index() {
+        // Stream 0 long (3 serials), stream 1 short (2): serial 2 buffers only
+        // stream 0's chunk, so `short = usize::from(entry.0.is_some()) = 1` and
+        // the error must name the MISSING (short) stream, index 1.
+        let result = run_desync_harness(DESYNC_LONG_SERIALS, DESYNC_SHORT_SERIALS);
+        let err = result.expect_err("unequal stream lengths must abort the pipeline run");
+        assert!(
+            err.contains("out of sync"),
+            "desync abort must report an out-of-sync error, got: {err}"
+        );
+        assert!(
+            err.contains("stream 1 ended before chunk_serial 2"),
+            "desync error must name the short stream (index 1) and the orphaned \
+             serial (2), got: {err}"
+        );
+    }
+
+    #[test]
+    fn finalize_pairs_reports_desync_when_stream_zero_is_short() {
+        // Mirror of the above with the lengths swapped: stream 0 short (2
+        // serials), stream 1 long (3). Serial 2 now buffers only stream 1's
+        // chunk, so the missing-stream index is 0 — guards the symmetric branch
+        // that a stream-1-only test would leave unexercised.
+        let result = run_desync_harness(DESYNC_SHORT_SERIALS, DESYNC_LONG_SERIALS);
+        let err = result.expect_err("unequal stream lengths must abort the pipeline run");
+        assert!(
+            err.contains("out of sync"),
+            "desync abort must report an out-of-sync error, got: {err}"
+        );
+        assert!(
+            err.contains("stream 0 ended before chunk_serial 2"),
+            "desync error must name the short stream (index 0) and the orphaned \
+             serial (2), got: {err}"
+        );
+    }
+
+    #[test]
+    fn truncated_stream_over_backpressure_fails_fast_instead_of_hanging() {
+        // Stream 0 (a) has 3 chunks (X3_CHUNK_BYTES each), stream 1 (b) has 1.
+        // With a small backpressure cap, after the first pair the surplus from
+        // stream 0 crosses 1x the cap, so per-stream backpressure STOPS pulling
+        // stream 0 — leaving its remaining chunks unpulled (so it never drains),
+        // and pending plateaus BELOW the 2x catastrophic-desync abort, which
+        // therefore never fires. The front pair is missing stream 1, which is
+        // drained. Pre-fix this spun `NoProgress` forever (the harness's 30s
+        // deadline would trip); the fix detects the unpairable record and fails
+        // fast. This also proves the run terminates (no hang).
+        let result = run_desync_harness_with_backpressure(3, 1, Some(X3_SOFT_LIMIT_BYTES));
+        let err = result.expect_err("truncated stream over backpressure must abort, not hang");
+        assert!(
+            err.contains("out of sync") && err.contains("stream 1 ended before chunk_serial 1"),
+            "backpressure fail-fast must reuse the shared out-of-sync error naming the \
+             short stream (index 1) and the orphaned serial (1), got: {err}"
+        );
+    }
+
+    #[test]
+    fn truncated_stream_zero_over_backpressure_fails_fast_instead_of_hanging() {
+        // Mirror of the above with the lengths swapped: stream 0 (a) has 1 chunk,
+        // stream 1 (b) has 3. Now the surplus is stream 1, and the front pair is
+        // missing stream 0, which is drained — so this drives the symmetric
+        // `a_slot.is_none() && ctx.a.is_drained()` branch that the stream-1-short
+        // test leaves unexercised. The abort must name the short stream (index 0).
+        let result = run_desync_harness_with_backpressure(1, 3, Some(X3_SOFT_LIMIT_BYTES));
+        let err = result.expect_err("truncated stream over backpressure must abort, not hang");
+        assert!(
+            err.contains("out of sync") && err.contains("stream 0 ended before chunk_serial 1"),
+            "backpressure fail-fast must reuse the shared out-of-sync error naming the \
+             short stream (index 0) and the orphaned serial (1), got: {err}"
+        );
+    }
+}

--- a/src/lib/pipeline/steps/source/parse_fastq.rs
+++ b/src/lib/pipeline/steps/source/parse_fastq.rs
@@ -1,0 +1,186 @@
+//! `ParseFastqChunks` mid-step. `Parallel + ByItemOrdinal`. Parses the raw,
+//! whole-record-aligned FASTQ bytes of a `FastqRawChunk` into a
+//! `FastqChunkBatch` of `FastqRecord`s.
+//!
+//! This step exists to lift the FASTQ-parse cost off the single
+//! `ReadFastqInputs` reader thread: `ReadFastqInputs` now only reads and
+//! gzip-decompresses bytes (serial, I/O-bound), and one `ParseFastqChunks`
+//! worker per pipeline thread parses the chunks concurrently. The framework
+//! reorders the parallel output by each chunk's globally-unique `ordinal`,
+//! which `ParseFastqChunks` faithfully propagates from input to output.
+
+use std::io;
+
+use crate::fastq_parse::FastqRecord;
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+
+use super::read_fastq::{FastqChunkBatch, FastqRawChunk};
+
+/// Parse a whole-record-aligned FASTQ chunk, returning the records and their
+/// summed heap size. Thin wrapper over [`super::parse_fastq_chunk`] that pins
+/// this step's name into the truncation error.
+///
+/// # Errors
+///
+/// Propagates the shared parser's `InvalidData` on a truncated chunk.
+fn parse_fastq_records(data: &[u8]) -> io::Result<(Vec<FastqRecord>, usize)> {
+    super::parse_fastq_chunk(data, "ParseFastqChunks")
+}
+
+/// `Parallel + ByItemOrdinal` FASTQ parser. Each worker is independent and
+/// stateless beyond the held slot — a `FastqRawChunk` in, a `FastqChunkBatch`
+/// out, with the globally-unique `ordinal` (and the `stream_idx` /
+/// `chunk_serial` join keys) preserved verbatim.
+pub struct ParseFastqChunks {
+    held: HeldSlot<Unpushed<FastqChunkBatch>>,
+    output_byte_limit: u64,
+}
+
+impl ParseFastqChunks {
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self { held: HeldSlot::new(), output_byte_limit }
+    }
+}
+
+impl Clone for ParseFastqChunks {
+    fn clone(&self) -> Self {
+        Self { held: HeldSlot::new(), output_byte_limit: self.output_byte_limit }
+    }
+}
+
+impl Step for ParseFastqChunks {
+    type Input = FastqRawChunk;
+    type Outputs = OrderedBytesSingle<FastqChunkBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ParseFastqChunks",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    // `Contention` (not `NoProgress`) keeps the worker alive
+                    // for retry — `NoProgress` would let the framework mark
+                    // this worker `Skip` if input is also drained, silently
+                    // dropping the held item.
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(chunk) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+
+        let (records, total_bytes) = parse_fastq_records(&chunk.data)?;
+        let batch = FastqChunkBatch::new(
+            chunk.ordinal,
+            chunk.stream_idx,
+            chunk.chunk_serial,
+            records,
+            total_bytes,
+        );
+
+        match ctx.outputs.push(batch) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::core::item::Ordered;
+
+    #[test]
+    fn profile_advertises_parallel_byordinal() {
+        let s = ParseFastqChunks::new(1024);
+        let p = s.profile();
+        assert_eq!(p.name, "ParseFastqChunks");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    #[test]
+    fn parse_fastq_records_parses_all_records() {
+        let data = b"@read1\nACGT\n+\nIIII\n@read2\nTGCA\n+\nJJJJ\n";
+        let (records, total_bytes) = parse_fastq_records(data).unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].name(), b"read1");
+        assert_eq!(records[0].sequence(), b"ACGT");
+        assert_eq!(records[1].name(), b"read2");
+        assert_eq!(records[1].sequence(), b"TGCA");
+        assert!(total_bytes > 0);
+    }
+
+    #[test]
+    fn parse_fastq_records_empty_input() {
+        let (records, total_bytes) = parse_fastq_records(b"").unwrap();
+        assert!(records.is_empty());
+        assert_eq!(total_bytes, 0);
+    }
+
+    #[test]
+    fn parse_fastq_records_truncated_errors() {
+        // Only 2 of 4 lines present.
+        let data = b"@read1\nACGT\n";
+        let err = parse_fastq_records(data).unwrap_err();
+        assert!(err.to_string().contains("truncated"), "got: {err}");
+    }
+
+    /// The core correctness gate: parsing a `FastqRawChunk` must preserve the
+    /// globally-unique `ordinal` and the `(stream_idx, chunk_serial)` join
+    /// keys verbatim on the produced `FastqChunkBatch`.
+    #[test]
+    fn parse_preserves_ordinal_stream_and_serial() {
+        let data = b"@read1\nACGT\n+\nIIII\n".to_vec();
+        let chunk = FastqRawChunk { ordinal: 17, stream_idx: 1, chunk_serial: 4, data };
+
+        let (records, total_bytes) = parse_fastq_records(&chunk.data).unwrap();
+        let batch = FastqChunkBatch::new(
+            chunk.ordinal,
+            chunk.stream_idx,
+            chunk.chunk_serial,
+            records,
+            total_bytes,
+        );
+
+        assert_eq!(batch.ordinal(), 17, "framework reorder key must be the unique ordinal");
+        assert_eq!(batch.stream_idx, 1);
+        assert_eq!(batch.chunk_serial, 4, "zip join key must be preserved");
+        assert_eq!(batch.records.len(), 1);
+        assert_eq!(batch.records[0].name(), b"read1");
+    }
+}

--- a/src/lib/pipeline/steps/source/parse_zip_fastq.rs
+++ b/src/lib/pipeline/steps/source/parse_zip_fastq.rs
@@ -1,0 +1,321 @@
+//! `ParseAndZipFastq` step: `Parallel + ByItemOrdinal`. Parses the raw,
+//! whole-record-aligned bytes of a [`PairedRawFastqBatch`] (one R1 chunk + one
+//! R2 chunk) into per-stream `FastqRecord`s and zips them record-by-record into
+//! a [`FastqTemplateBatch`].
+//!
+//! This step exists to lift BOTH the FASTQ parse and the template build off the
+//! serial source path and fan them across worker threads. It mirrors the legacy
+//! pipeline's `Decode` stage: the cheap chunk-level pairing already happened
+//! serially in [`PairRawFastq`] (which minted a globally-unique `ordinal`), and
+//! each worker here parses + zips one paired batch independently. The framework
+//! reorders the parallel output by each batch's `ordinal`, which this step
+//! propagates verbatim onto the emitted `FastqTemplateBatch`.
+//!
+//! [`PairRawFastq`]: super::pair_fastq::PairRawFastq
+//!
+//! Used only for the common paired-end (N == 2) case. The N == 1 and N >= 3
+//! paths keep the separate `ParseFastqChunks` → `ZipFastqRecords` structure.
+
+use std::io;
+
+use crate::fastq_parse::{FastqRecord, strip_read_suffix};
+use crate::grouper::FastqTemplate;
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+
+use super::pair_fastq::PairedRawFastqBatch;
+use super::zip_fastq::FastqTemplateBatch;
+
+/// Parse a whole-record-aligned FASTQ chunk into records. Thin wrapper over
+/// [`super::parse_fastq_chunk`] that pins this step's name into the truncation
+/// error and drops the byte total, which this step recomputes per template.
+///
+/// # Errors
+///
+/// Propagates the shared parser's `InvalidData` on a truncated chunk.
+fn parse_fastq_records(data: &[u8]) -> io::Result<Vec<FastqRecord>> {
+    super::parse_fastq_chunk(data, "ParseAndZipFastq").map(|(records, _)| records)
+}
+
+/// Zip the per-stream records of one paired batch into `FastqTemplate`s.
+///
+/// Record `i` from stream A and record `i` from stream B form one template; the
+/// names must match after [`strip_read_suffix`]. This mirrors the legacy
+/// `ZipFastqRecords::try_emit_complete` logic verbatim — including its error
+/// semantics — so output (and failure behavior) is byte-identical to the
+/// `ParseFastqChunks` → `ZipFastqRecords` path the N != 2 chains still use.
+///
+/// Strict, fgbio-consistent mismatch handling (see `FastqSource.zipped`): a
+/// record-count difference between the streams is an explicit "out of sync"
+/// error, and a read name that disagrees after suffix-stripping is a "read name
+/// mismatch" error. The count check is the same one `ZipFastqRecords` applies
+/// on the N>=3 path, so both paths report identically.
+fn zip_records(
+    records_a: Vec<FastqRecord>,
+    records_b: Vec<FastqRecord>,
+    chunk_serial: u64,
+) -> io::Result<Vec<FastqTemplate>> {
+    // Paired FASTQ is positionally parallel: every stream must contribute the
+    // same number of records for this chunk. Reject a mismatch explicitly
+    // rather than letting it surface as an incidental name mismatch from the
+    // back-pop below.
+    if records_a.len() != records_b.len() {
+        return Err(io::Error::other(format!(
+            "FASTQ sources out of sync at chunk_serial {chunk_serial}: \
+             stream 0 has {} records, stream 1 has {}",
+            records_a.len(),
+            records_b.len(),
+        )));
+    }
+
+    let n_records = records_a.len();
+    let mut streams: [Vec<FastqRecord>; 2] = [records_a, records_b];
+
+    // Pop from the back of each stream (avoids O(n^2) front removal) and
+    // reverse at the end to restore the original record order.
+    let mut reversed_templates = Vec::with_capacity(n_records);
+    for _ in 0..n_records {
+        let mut records = Vec::with_capacity(2);
+        let mut base_name: Option<Vec<u8>> = None;
+
+        for (stream_idx, stream) in streams.iter_mut().enumerate() {
+            // Unreachable after the equal-count check above; kept defensive.
+            let Some(record) = stream.pop() else {
+                return Err(io::Error::other(format!(
+                    "FASTQ sources out of sync: stream {stream_idx} ran short at \
+                     chunk_serial {chunk_serial}",
+                )));
+            };
+
+            let stripped = strip_read_suffix(record.name());
+            match &base_name {
+                None => base_name = Some(stripped.to_vec()),
+                Some(expected) => {
+                    if stripped != expected.as_slice() {
+                        // `InvalidData`, matching the same check in
+                        // `ZipFastqRecords::try_emit_complete`: a name mismatch is
+                        // malformed input, and the two paths must classify it the
+                        // same way or a caller matching on kind sees it only from
+                        // one of them.
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!(
+                                "FASTQ read name mismatch at chunk_serial {}: stream 0 has '{}', \
+                             stream {} has '{}'",
+                                chunk_serial,
+                                String::from_utf8_lossy(expected),
+                                stream_idx,
+                                String::from_utf8_lossy(stripped),
+                            ),
+                        ));
+                    }
+                }
+            }
+            records.push(record);
+        }
+
+        reversed_templates.push(FastqTemplate { name: base_name.unwrap(), records });
+    }
+
+    reversed_templates.reverse();
+    Ok(reversed_templates)
+}
+
+/// `Parallel + ByItemOrdinal` FASTQ parse-and-zip. Each worker is independent
+/// and stateless beyond the held slot — a `PairedRawFastqBatch` in, a
+/// `FastqTemplateBatch` out, with the globally-unique `ordinal` preserved
+/// verbatim as the output `batch_serial`.
+pub struct ParseAndZipFastq {
+    held: HeldSlot<Unpushed<FastqTemplateBatch>>,
+    output_byte_limit: u64,
+}
+
+impl ParseAndZipFastq {
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self { held: HeldSlot::new(), output_byte_limit }
+    }
+}
+
+impl Clone for ParseAndZipFastq {
+    fn clone(&self) -> Self {
+        Self { held: HeldSlot::new(), output_byte_limit: self.output_byte_limit }
+    }
+}
+
+impl Step for ParseAndZipFastq {
+    type Input = PairedRawFastqBatch;
+    type Outputs = OrderedBytesSingle<FastqTemplateBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ParseAndZipFastq",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    // `Contention` (not `NoProgress`) keeps the worker alive
+                    // for retry — `NoProgress` would let the framework mark
+                    // this worker `Skip` if input is also drained, silently
+                    // dropping the held item.
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(batch) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+
+        let records_a = parse_fastq_records(&batch.data_a)?;
+        let records_b = parse_fastq_records(&batch.data_b)?;
+        let templates = zip_records(records_a, records_b, batch.chunk_serial)?;
+        // Preserve the serially-minted ordinal so the framework reorder keeps
+        // the FASTQ records in input order.
+        let template_batch = FastqTemplateBatch::new(batch.ordinal, templates);
+
+        match ctx.outputs.push(template_batch) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::core::item::Ordered;
+
+    fn record_bytes(name: &str, seq: &str) -> Vec<u8> {
+        let qual: String = std::iter::repeat_n('I', seq.len()).collect();
+        format!("@{name}\n{seq}\n+\n{qual}\n").into_bytes()
+    }
+
+    #[test]
+    fn profile_advertises_parallel_byordinal() {
+        let s = ParseAndZipFastq::new(1024);
+        let p = s.profile();
+        assert_eq!(p.name, "ParseAndZipFastq");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    #[test]
+    fn parse_fastq_records_parses_all_records() {
+        let mut data = record_bytes("read1", "ACGT");
+        data.extend(record_bytes("read2", "TGCA"));
+        let records = parse_fastq_records(&data).unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].name(), b"read1");
+        assert_eq!(records[1].name(), b"read2");
+    }
+
+    #[test]
+    fn parse_fastq_records_truncated_errors() {
+        let data = b"@read1\nACGT\n";
+        let err = parse_fastq_records(data).unwrap_err();
+        assert!(err.to_string().contains("truncated"), "got: {err}");
+    }
+
+    /// The core zip correctness: record i from A and record i from B form one
+    /// template, the base read name (suffix-stripped) is preserved, and R1/R2
+    /// land in records[0]/records[1] in input order.
+    #[test]
+    fn zip_pairs_records_and_strips_suffixes() {
+        let mut data_a = record_bytes("read1/1", "ACGT");
+        data_a.extend(record_bytes("read2/1", "TGCA"));
+        let mut data_b = record_bytes("read1/2", "GGGG");
+        data_b.extend(record_bytes("read2/2", "CCCC"));
+
+        let recs_a = parse_fastq_records(&data_a).unwrap();
+        let recs_b = parse_fastq_records(&data_b).unwrap();
+        let templates = zip_records(recs_a, recs_b, 0).unwrap();
+
+        assert_eq!(templates.len(), 2);
+        assert_eq!(templates[0].name, b"read1");
+        assert_eq!(templates[0].records.len(), 2);
+        assert_eq!(templates[0].records[0].sequence(), b"ACGT");
+        assert_eq!(templates[0].records[1].sequence(), b"GGGG");
+        assert_eq!(templates[1].name, b"read2");
+        assert_eq!(templates[1].records[0].sequence(), b"TGCA");
+        assert_eq!(templates[1].records[1].sequence(), b"CCCC");
+    }
+
+    #[test]
+    fn zip_name_mismatch_errors() {
+        let recs_a = parse_fastq_records(&record_bytes("readA/1", "ACGT")).unwrap();
+        let recs_b = parse_fastq_records(&record_bytes("readB/2", "GGGG")).unwrap();
+        let err = zip_records(recs_a, recs_b, 0).unwrap_err();
+        assert!(err.to_string().contains("mismatch"), "expected mismatch error, got: {err}");
+    }
+
+    /// Unequal record counts are rejected by an explicit, strict count check
+    /// (fgbio-consistent) — distinct from a name mismatch. A has 2 records, B
+    /// has 1, so the streams are out of sync regardless of read names.
+    #[test]
+    fn zip_unequal_counts_errors() {
+        let mut data_a = record_bytes("read1/1", "ACGT");
+        data_a.extend(record_bytes("read2/1", "TGCA"));
+        let recs_a = parse_fastq_records(&data_a).unwrap();
+        let recs_b = parse_fastq_records(&record_bytes("read1/2", "GGGG")).unwrap();
+        let err = zip_records(recs_a, recs_b, 7).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("out of sync"), "expected count out-of-sync error, got: {msg}");
+        assert!(msg.contains("chunk_serial 7"), "should name the chunk_serial, got: {msg}");
+    }
+
+    /// A shorter than B is symmetric: the explicit count check rejects it the
+    /// same way, naming the differing counts rather than relying on back-pop
+    /// name misalignment.
+    #[test]
+    fn zip_a_shorter_than_b_errors() {
+        let recs_a = parse_fastq_records(&record_bytes("read1/1", "ACGT")).unwrap();
+        let mut data_b = record_bytes("read1/2", "GGGG");
+        data_b.extend(record_bytes("read2/2", "CCCC"));
+        let recs_b = parse_fastq_records(&data_b).unwrap();
+        let err = zip_records(recs_a, recs_b, 0).unwrap_err();
+        assert!(err.to_string().contains("out of sync"), "got: {err}");
+    }
+
+    /// The output `FastqTemplateBatch` must carry the input batch's ordinal as
+    /// its `batch_serial` so the framework reorder preserves input order.
+    #[test]
+    fn output_ordinal_is_input_ordinal() {
+        let data_a = record_bytes("r/1", "ACGT");
+        let data_b = record_bytes("r/2", "GGGG");
+        let recs_a = parse_fastq_records(&data_a).unwrap();
+        let recs_b = parse_fastq_records(&data_b).unwrap();
+        let templates = zip_records(recs_a, recs_b, 0).unwrap();
+        let batch = FastqTemplateBatch::new(42, templates);
+        assert_eq!(batch.ordinal(), 42);
+    }
+}

--- a/src/lib/pipeline/steps/source/read_bam.rs
+++ b/src/lib/pipeline/steps/source/read_bam.rs
@@ -1,0 +1,6 @@
+//! Re-export shim. The `ReadBgzfBlocks` source step and `read_bam*` helpers
+//! now live in the `fgumi-pipeline-io` crate.
+pub use fgumi_pipeline_io::source::read_bam::{
+    DEFAULT_BLOCKS_PER_BATCH, ReadBgzfBlocks, read_bam, read_bam_auto, read_bam_from_reader,
+    read_bam_stdin,
+};

--- a/src/lib/pipeline/steps/source/read_fastq.rs
+++ b/src/lib/pipeline/steps/source/read_fastq.rs
@@ -1,0 +1,756 @@
+//! `ReadFastqInputs` source step: reads (and gzip-decompresses) raw FASTQ
+//! bytes from one or more `BufRead` streams in round-robin order and emits
+//! `FastqRawChunk` items. Parsing into `FastqRecord`s is deferred to the
+//! downstream `Parallel` `ParseFastqChunks` step so the decode/parse work
+//! can fan out across worker threads rather than bottlenecking on the
+//! single reader thread.
+//!
+//! ## Per-stream vs. all-streams instantiation
+//!
+//! For the common paired-end case (R1 + R2) the gzip decompression is the
+//! bottleneck, and a single reader serializing both streams cannot keep up.
+//! The framework runs distinct `Serial` steps on distinct workers
+//! concurrently (a `Serial` step holds a per-step mutex, not a global one),
+//! so the fix is to instantiate **one reader per stream** and pair their
+//! outputs 2-way (see `PairRawFastq`). Each per-stream reader is built with
+//! [`ReadFastqInputs::new_single`], is pinned to its **own** worker
+//! (`Affinity::Worker(0)` for R1, `Affinity::Worker(1)` for R2), and draws its
+//! chunks' `ordinal` from a [`FastqOrdinalSequence`] **shared by every reader
+//! on the branch**. That sharing is required, not incidental: handing each
+//! reader its own sequence makes them all mint `0, 1, 2, …` and collide, which
+//! does not fail loudly — it silently interleaves records in the downstream
+//! reorder buffer.
+//!
+//! The distinct-worker pinning is load-bearing, not a tuning choice: a `Serial`
+//! source dispatched by more than one worker hits a `try_lock`-after-`Finished`
+//! race in the runtime's source-drain path, so concurrent per-stream readers
+//! must never use [`Affinity::None`]. See [`ReadFastqInputs::new_single`].
+//!
+//! The N≥3 fallback keeps the original single-reader, all-streams,
+//! round-robin model ([`ReadFastqInputs::new`], [`Affinity::Reader`]): a
+//! single worker-0-sticky thread drives all I/O reads, same as
+//! `ReadBgzfBlocks`.
+
+use std::collections::VecDeque;
+use std::io::{self, BufRead};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use parking_lot::Mutex;
+
+use crate::fastq_parse::FastqRecord;
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::item::{HeapSize, Ordered};
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Affinity, Step, StepCtx, StepKind, StepOutcome, StepProfile};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FastqRawChunk — one chunk of raw (decompressed, unparsed) FASTQ bytes from
+// a single stream.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The shared, monotonic ordinal sequence for FASTQ chunks.
+///
+/// Every chunk emitted by every [`ReadFastqInputs`] instance feeding one
+/// `ParseFastqChunks` branch draws its ordinal from a single counter, so the
+/// sequence is both **globally unique** and **gap-free**.
+///
+/// Density is the load-bearing half, and it is why this is a shared counter
+/// rather than a per-stream arithmetic partition. The earlier scheme assigned
+/// `chunk_serial * n_streams_total + stream_idx`, giving each stream its own
+/// residue class. That is unique, but it is only dense when every stream
+/// produces the *same number of chunks* — a property of the input data, not
+/// something a reader can enforce. Mismatched FASTQ inputs (R1 longer than R2,
+/// e.g. a truncated download) leave a permanently unfilled ordinal, and
+/// `BranchOrdering::ByItemOrdinal` releases only in contiguous order, so the
+/// reorder stage waits forever on an ordinal no reader will ever mint. The
+/// symptom is a hang, not an error — and it masks the *correct* diagnostic,
+/// because `ZipFastqRecords` already reports "FASTQ sources out of sync" once
+/// the chunks actually reach it.
+///
+/// A per-instance counter cannot replace this: under `new_single` each reader
+/// owns one stream and cannot know how many cycles the other streams will run,
+/// so it cannot know how many ordinals to mint. Density is a global property,
+/// so it needs a globally-shared counter. This mirrors `PairRawFastq`, which
+/// already mints its ordinals from one serial counter.
+///
+/// The cost is one uncontended `fetch_add` per *chunk* (hundreds of KB of
+/// FASTQ), which is far below the noise floor of decompressing that chunk.
+#[derive(Debug, Clone, Default)]
+pub struct FastqOrdinalSequence(Arc<AtomicU64>);
+
+impl FastqOrdinalSequence {
+    /// A fresh sequence starting at 0. Share one clone per reader instance
+    /// feeding the same downstream branch.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Take the next ordinal. `Relaxed` is sufficient: the value only has to be
+    /// unique and monotonic, and the reorder stage does its own ordering.
+    pub(crate) fn next(&self) -> u64 {
+        self.0.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+/// A chunk of decompressed, whole-record-aligned raw FASTQ bytes emitted by
+/// [`ReadFastqInputs`] and consumed by `ParseFastqChunks`.
+///
+/// `ordinal` is a globally-unique, monotonically-increasing counter assigned
+/// once per emitted chunk (regardless of stream). It is the key the framework
+/// uses to reorder the `Parallel` `ParseFastqChunks` output — `stream_idx` and
+/// `chunk_serial` are NOT globally unique (two streams emit chunks with the
+/// same `chunk_serial`), so they must not be used as a reorder key. The
+/// `(stream_idx, chunk_serial)` pair is preserved purely so `ZipFastqRecords`
+/// can re-join the per-stream chunks.
+pub struct FastqRawChunk {
+    /// Globally-unique monotonic ordinal, for the framework's reorder buffer.
+    pub ordinal: u64,
+    /// Index of the originating FASTQ stream (0-based).
+    pub stream_idx: usize,
+    /// Per-stream round-robin cycle serial, for the `ZipFastqRecords` join.
+    pub chunk_serial: u64,
+    /// Decompressed raw FASTQ bytes, aligned to whole records (4 lines each).
+    ///
+    /// Rebuild this chunk rather than mutating it in place: an in-place edit
+    /// that breaks whole-record (4-line) alignment desyncs downstream parsing.
+    pub data: Vec<u8>,
+}
+
+impl HeapSize for FastqRawChunk {
+    fn heap_size(&self) -> usize {
+        // Allocated capacity, not logical length: byte-bounded queues budget the
+        // memory actually held, and these buffers are read into with spare
+        // capacity. `PairFastqStreams` accounts for the same chunks and must use
+        // the same measure, or `pending_total_bytes` drifts against the queues.
+        self.data.capacity()
+    }
+}
+
+impl Ordered for FastqRawChunk {
+    fn ordinal(&self) -> u64 {
+        self.ordinal
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FastqChunkBatch — one chunk of parsed records from a single FASTQ stream.
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub struct FastqChunkBatch {
+    /// Globally-unique monotonic ordinal, propagated from the originating
+    /// [`FastqRawChunk`]. Used by the framework to reorder the output of the
+    /// `Parallel` `ParseFastqChunks` step. Distinct from `chunk_serial`,
+    /// which is only per-stream unique and is reused across streams.
+    pub ordinal: u64,
+    pub stream_idx: usize,
+    pub chunk_serial: u64,
+    pub records: Vec<FastqRecord>,
+    total_bytes: usize,
+}
+
+impl FastqChunkBatch {
+    #[must_use]
+    pub fn new(
+        ordinal: u64,
+        stream_idx: usize,
+        chunk_serial: u64,
+        records: Vec<FastqRecord>,
+        total_bytes: usize,
+    ) -> Self {
+        Self { ordinal, stream_idx, chunk_serial, records, total_bytes }
+    }
+}
+
+impl HeapSize for FastqChunkBatch {
+    fn heap_size(&self) -> usize {
+        self.total_bytes
+    }
+}
+
+impl Ordered for FastqChunkBatch {
+    fn ordinal(&self) -> u64 {
+        self.ordinal
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FASTQ reading helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Read up to `count` complete FASTQ records' worth of raw bytes from
+/// `reader` into a single `Vec<u8>`, returning the bytes plus the number of
+/// complete records read.
+///
+/// Each record is 4 lines (`@name`, sequence, `+`, quality); the bytes are
+/// always whole-record-aligned (the function never splits mid-record). A
+/// returned count of 0 with empty bytes signals EOF for the stream.
+///
+/// Decompression (when the underlying `BufRead` is a gzip decoder) happens
+/// here; FASTQ structure validation and `FastqRecord` parsing are deferred to
+/// `ParseFastqChunks`. The only structural check performed here is that each
+/// record begins with `@`, so the round-robin reader fails fast on a malformed
+/// stream rather than emitting garbage to the parse workers.
+fn read_fastq_raw_bytes_from_bufread(
+    reader: &mut dyn BufRead,
+    count: usize,
+) -> io::Result<(Vec<u8>, usize)> {
+    let mut data: Vec<u8> = Vec::with_capacity(count * 300);
+    let mut records_read = 0;
+
+    for _ in 0..count {
+        // Line 1: @name
+        let line_start = data.len();
+        let bytes_read = reader.read_until(b'\n', &mut data)?;
+        if bytes_read == 0 {
+            break;
+        }
+        if data[line_start] != b'@' {
+            // A lone newline (blank line between records) is a common
+            // hand-edit/corruption artifact; give it a clearer message than
+            // the raw "got '\n'" the generic branch would produce.
+            let message = if data[line_start] == b'\n' {
+                "Unexpected blank line in FASTQ stream (expected a record \
+                 starting with '@')"
+                    .to_string()
+            } else {
+                format!(
+                    "Expected FASTQ record to start with '@', got '{}'",
+                    data[line_start] as char
+                )
+            };
+            return Err(io::Error::new(io::ErrorKind::InvalidData, message));
+        }
+        if data.last() != Some(&b'\n') {
+            data.push(b'\n');
+        }
+
+        // Line 2: sequence
+        let bytes_read = reader.read_until(b'\n', &mut data)?;
+        if bytes_read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "Unexpected EOF reading FASTQ sequence line",
+            ));
+        }
+        if data.last() != Some(&b'\n') {
+            data.push(b'\n');
+        }
+
+        // Line 3: +
+        let bytes_read = reader.read_until(b'\n', &mut data)?;
+        if bytes_read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "Unexpected EOF reading FASTQ separator line",
+            ));
+        }
+        if data.last() != Some(&b'\n') {
+            data.push(b'\n');
+        }
+
+        // Line 4: quality
+        let bytes_read = reader.read_until(b'\n', &mut data)?;
+        if bytes_read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "Unexpected EOF reading FASTQ quality line",
+            ));
+        }
+        if data.last() != Some(&b'\n') {
+            data.push(b'\n');
+        }
+
+        records_read += 1;
+    }
+
+    Ok((data, records_read))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ReadFastqInputs — Serial+Reader source step
+// ─────────────────────────────────────────────────────────────────────────────
+
+type FastqReaders = Vec<Box<dyn BufRead + Send>>;
+
+pub struct ReadFastqInputs {
+    readers: Arc<Mutex<Option<FastqReaders>>>,
+    /// Number of streams this instance reads (the length of `readers`). For
+    /// `new_single` this is always 1; for `new` it is the total stream count.
+    n_streams: usize,
+    /// Global index of this instance's first (local) stream. The emitted
+    /// `FastqRawChunk::stream_idx` is `stream_idx_base + local_idx`, so a
+    /// per-stream reader for R2 reports `stream_idx = 1` even though its only
+    /// reader is at local index 0.
+    stream_idx_base: usize,
+    /// Shared ordinal source. Every reader feeding the same downstream branch
+    /// holds a clone, so the emitted ordinals are unique *and* gap-free even
+    /// when the streams differ in length. See [`FastqOrdinalSequence`].
+    ordinals: FastqOrdinalSequence,
+    /// Scheduling hint reported by `affinity()`. `Affinity::Worker(i)` for the
+    /// per-stream concurrent readers (each pinned to a distinct worker);
+    /// `Affinity::Reader` for the single all-streams fallback.
+    affinity: Affinity,
+    /// Whether the step advertises `sticky` in its profile. The all-streams
+    /// fallback is `sticky` (the legacy worker-0 burst-read model). The
+    /// per-stream concurrent readers are NOT sticky: a sticky reader would
+    /// monopolize its worker via the scheduler's sticky re-entry loop
+    /// (spinning on the reader while it makes Progress), starving the
+    /// `Parallel` `BgzfCompress` of that worker between read bursts and
+    /// regressing throughput at low `--threads`. Non-sticky lets the
+    /// affinity-pinned worker interleave compression work between reads.
+    sticky: bool,
+    batch_record_count: usize,
+    next_chunk_serial: u64,
+    pending: VecDeque<FastqRawChunk>,
+    held: HeldSlot<Unpushed<FastqRawChunk>>,
+    output_byte_limit: u64,
+    exhausted: Vec<bool>,
+    all_done: bool,
+}
+
+impl ReadFastqInputs {
+    /// All-streams reader: reads every stream in `readers` round-robin on a
+    /// single worker (`Affinity::Reader`). Used for the N≥3 fallback where
+    /// the per-stream concurrent model's coordination overhead is not worth
+    /// it. `stream_idx_base` is 0, so emitted chunks carry their natural
+    /// stream index. This is the only reader on its branch, so it owns a
+    /// private [`FastqOrdinalSequence`].
+    #[must_use]
+    pub fn new(
+        readers: Vec<Box<dyn BufRead + Send>>,
+        batch_record_count: usize,
+        output_byte_limit: u64,
+    ) -> Self {
+        Self::build(
+            readers,
+            0,
+            FastqOrdinalSequence::new(),
+            Affinity::Reader,
+            /* sticky */ true,
+            batch_record_count,
+            output_byte_limit,
+        )
+    }
+
+    /// Single-stream reader: reads exactly one stream so multiple instances
+    /// (e.g. one for R1, one for R2) can run concurrently on different
+    /// workers. `global_stream_idx` is this stream's index in the full
+    /// pipeline, carried on each chunk so `ZipFastqRecords` can re-join the
+    /// streams.
+    ///
+    /// `ordinals` must be the **same** [`FastqOrdinalSequence`] for every
+    /// reader feeding one downstream branch — that shared counter is what
+    /// makes the combined ordinal stream gap-free when the streams differ in
+    /// length. Handing each reader its own sequence would make them all mint
+    /// `0, 1, 2, …` and collide, which does not fail loudly: it silently
+    /// interleaves records in the reorder buffer.
+    ///
+    /// `affinity` pins this reader to a specific worker. Each per-stream
+    /// reader is given a **distinct** worker (e.g. `Affinity::Worker(0)` for
+    /// R1, `Affinity::Worker(1)` for R2) so the two gzip decoders run
+    /// concurrently AND no two workers ever contend the same source mutex.
+    /// The latter is load-bearing: a `Serial` source dispatched by more than
+    /// one worker hits a `try_lock`-after-`Finished` race in the runtime's
+    /// source-drain path, so concurrent readers must use disjoint
+    /// single-worker affinities, never `Affinity::None`.
+    ///
+    #[must_use]
+    pub fn new_single(
+        reader: Box<dyn BufRead + Send>,
+        global_stream_idx: usize,
+        ordinals: FastqOrdinalSequence,
+        affinity: Affinity,
+        batch_record_count: usize,
+        output_byte_limit: u64,
+    ) -> Self {
+        Self::build(
+            vec![reader],
+            global_stream_idx,
+            ordinals,
+            affinity,
+            /* sticky */ false,
+            batch_record_count,
+            output_byte_limit,
+        )
+    }
+
+    fn build(
+        readers: Vec<Box<dyn BufRead + Send>>,
+        stream_idx_base: usize,
+        ordinals: FastqOrdinalSequence,
+        affinity: Affinity,
+        sticky: bool,
+        batch_record_count: usize,
+        output_byte_limit: u64,
+    ) -> Self {
+        // No ordinal-collision guard is needed here any more. The previous
+        // scheme derived ordinals from `(stream_idx, n_streams_total)`, so a
+        // reader wired with an index outside the declared total silently minted
+        // another reader's ordinals, and an unconditional assert stood here to
+        // catch it. Drawing from one shared counter makes uniqueness structural
+        // instead of arithmetic, so there is nothing left to assert.
+        //
+        // Worth noting which half of the invariant that assert covered: it
+        // guarded *uniqueness* only. Nothing guarded *density*, which is the
+        // half that actually broke — and its failure mode was a silent hang
+        // rather than a panic. See [`FastqOrdinalSequence`].
+        let n_streams = readers.len();
+
+        Self {
+            readers: Arc::new(Mutex::new(Some(readers))),
+            n_streams,
+            stream_idx_base,
+            ordinals,
+            affinity,
+            sticky,
+            batch_record_count: batch_record_count.max(1),
+            next_chunk_serial: 0,
+            pending: VecDeque::new(),
+            held: HeldSlot::new(),
+            output_byte_limit,
+            exhausted: vec![false; n_streams],
+            all_done: false,
+        }
+    }
+}
+
+impl Step for ReadFastqInputs {
+    type Input = ();
+    type Outputs = OrderedBytesSingle<FastqRawChunk>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ReadFastqInputs",
+            kind: StepKind::Serial,
+            sticky: self.sticky,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn affinity(&self) -> Affinity {
+        self.affinity
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // 1. Drain held slot.
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        // 2. Drain pending batches.
+        if let Some(batch) = self.pending.pop_front() {
+            match ctx.outputs.push(batch) {
+                Ok(()) => return Ok(StepOutcome::Progress),
+                Err(unpushed) => {
+                    self.held.put(unpushed);
+                    return Ok(StepOutcome::Progress);
+                }
+            }
+        }
+
+        if self.all_done {
+            return Ok(StepOutcome::Finished);
+        }
+
+        // 3. Read one round-robin cycle: one chunk per stream at the current serial.
+        let chunk_serial = self.next_chunk_serial;
+        let mut any_read = false;
+
+        {
+            let mut guard = self.readers.lock();
+            let readers = guard.as_mut().expect("ReadFastqInputs: readers missing");
+            debug_assert_eq!(
+                readers.len(),
+                self.n_streams,
+                "reader count must match the declared stream count"
+            );
+
+            // Read one chunk from every non-exhausted stream this cycle. Each
+            // cycle reads all streams, so there is no rotation offset.
+            for (idx, reader) in readers.iter_mut().enumerate() {
+                if self.exhausted[idx] {
+                    continue;
+                }
+
+                let (data, records_read) =
+                    read_fastq_raw_bytes_from_bufread(reader.as_mut(), self.batch_record_count)?;
+
+                if records_read == 0 {
+                    self.exhausted[idx] = true;
+                    continue;
+                }
+
+                any_read = true;
+                // Global stream index (== local idx for the all-streams
+                // reader, which has stream_idx_base == 0).
+                let stream_idx = self.stream_idx_base + idx;
+                // Drawn per emitted chunk, so a stream that exhausts early
+                // leaves no hole in the sequence.
+                let ordinal = self.ordinals.next();
+                self.pending.push_back(FastqRawChunk { ordinal, stream_idx, chunk_serial, data });
+            }
+        }
+
+        // Advance to the next round-robin cycle.
+        self.next_chunk_serial += 1;
+
+        if !any_read {
+            self.all_done = true;
+            return Ok(StepOutcome::Finished);
+        }
+
+        // Emit one batch from the freshly-filled pending queue.
+        if let Some(batch) = self.pending.pop_front() {
+            match ctx.outputs.push(batch) {
+                Ok(()) => Ok(StepOutcome::Progress),
+                Err(unpushed) => {
+                    self.held.put(unpushed);
+                    Ok(StepOutcome::Progress)
+                }
+            }
+        } else {
+            Ok(StepOutcome::NoProgress)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+    use crate::pipeline::core::item::Ordered;
+
+    /// Every way `read_fastq_raw_bytes_from_bufread` can reject a malformed
+    /// record, one case per rejection. The reader exists to fail fast on
+    /// degenerate input, and without these the only covered paths were the happy
+    /// path, the count cap, and empty input — so a regression that reordered the
+    /// `read_until` / `bytes_read == 0` checks would still have passed.
+    ///
+    /// Note that the *first* line's `bytes_read == 0` is a clean `break` (end of
+    /// stream between records), not an error, so it is covered by the empty-input
+    /// test rather than here.
+    #[rstest]
+    #[case::eof_before_sequence(b"@read1\n".as_slice(), io::ErrorKind::UnexpectedEof, "sequence line")]
+    #[case::eof_before_separator(
+        b"@read1\nACGT\n".as_slice(),
+        io::ErrorKind::UnexpectedEof,
+        "separator line"
+    )]
+    #[case::eof_before_quality(
+        b"@read1\nACGT\n+\n".as_slice(),
+        io::ErrorKind::UnexpectedEof,
+        "quality line"
+    )]
+    #[case::blank_line_between_records(
+        b"\n@read1\nACGT\n+\nIIII\n".as_slice(),
+        io::ErrorKind::InvalidData,
+        "blank line"
+    )]
+    #[case::name_line_missing_at_sign(
+        b"read1\nACGT\n+\nIIII\n".as_slice(),
+        io::ErrorKind::InvalidData,
+        "start with '@'"
+    )]
+    fn read_fastq_raw_bytes_rejects_malformed_records(
+        #[case] input: &[u8],
+        #[case] expected_kind: io::ErrorKind,
+        #[case] expected_message_fragment: &str,
+    ) {
+        let mut reader = io::Cursor::new(input.to_vec());
+        let err = read_fastq_raw_bytes_from_bufread(&mut reader, 2)
+            .expect_err("malformed input must be rejected");
+
+        assert_eq!(err.kind(), expected_kind, "wrong error kind for: {err}");
+        assert!(
+            err.to_string().contains(expected_message_fragment),
+            "message {err:?} should mention {expected_message_fragment:?}",
+        );
+    }
+
+    /// A final quality line with no trailing newline is normalized rather than
+    /// rejected, so the emitted chunk stays 4-line aligned for the parser
+    /// downstream. This is the boundary case the `data.last() != Some(&b'\n')`
+    /// guards exist for, and it sits right next to the EOF rejections above.
+    #[test]
+    fn read_fastq_raw_bytes_appends_a_missing_final_newline() {
+        let mut reader = io::Cursor::new(b"@read1\nACGT\n+\nIIII".to_vec());
+
+        let (bytes, records_read) =
+            read_fastq_raw_bytes_from_bufread(&mut reader, 1).expect("record is complete");
+
+        assert_eq!(records_read, 1);
+        assert_eq!(bytes, b"@read1\nACGT\n+\nIIII\n");
+    }
+
+    #[test]
+    fn fastq_chunk_batch_heap_size_returns_total_bytes() {
+        // ordinal (7) and chunk_serial (5) are intentionally different to
+        // confirm `ordinal()` reports the unique ordinal, not chunk_serial.
+        let batch = FastqChunkBatch::new(7, 0, 5, vec![], 1234);
+        assert_eq!(batch.heap_size(), 1234);
+        assert_eq!(batch.ordinal(), 7);
+    }
+
+    #[test]
+    fn fastq_raw_chunk_heap_size_and_ordinal() {
+        let chunk =
+            FastqRawChunk { ordinal: 3, stream_idx: 1, chunk_serial: 0, data: vec![0u8; 42] };
+        assert_eq!(chunk.heap_size(), 42);
+        assert_eq!(chunk.ordinal(), 3);
+    }
+
+    /// `heap_size` must report allocation capacity, not live length: the reader
+    /// builds each chunk with `Vec::with_capacity(count * 300)`, so a short
+    /// chunk — the final partial batch, or reads under the per-record estimate —
+    /// holds materially more memory than it spans.
+    ///
+    /// The test above cannot pin that: `vec![0u8; 42]` has `capacity() == len()`,
+    /// so it passes for either measure and a regression to `len()` would stay
+    /// green while the byte-bounded queue under-counted what it holds. Mirrors
+    /// `pair_fastq::tests::paired_batch_heap_size_counts_spare_capacity`.
+    #[test]
+    fn fastq_raw_chunk_heap_size_counts_spare_capacity() {
+        let mut data = Vec::with_capacity(300);
+        data.extend_from_slice(&[0u8; 42]);
+        let capacity = data.capacity();
+
+        let chunk = FastqRawChunk { ordinal: 3, stream_idx: 1, chunk_serial: 0, data };
+
+        assert_eq!(chunk.heap_size(), capacity);
+        assert!(
+            chunk.heap_size() > 42,
+            "heap_size must exceed the 42 live bytes; got {}",
+            chunk.heap_size()
+        );
+    }
+
+    #[test]
+    fn profile_advertises_serial_reader_byordinal() {
+        let readers: Vec<Box<dyn BufRead + Send>> =
+            vec![Box::new(io::Cursor::new(Vec::<u8>::new()))];
+        let step = ReadFastqInputs::new(readers, 400, 1024 * 1024);
+        let profile = step.profile();
+        assert_eq!(profile.name, "ReadFastqInputs");
+        assert_eq!(profile.kind, StepKind::Serial);
+        assert!(profile.sticky);
+        assert_eq!(step.affinity(), Affinity::Reader);
+        assert_eq!(profile.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+        assert!(matches!(profile.output_queues[0], QueueSpec::ByteBounded { .. }));
+    }
+
+    /// The per-stream constructor keeps `global_stream_idx` purely as chunk
+    /// metadata for `ZipFastqRecords` to re-join on.
+    ///
+    /// This replaces a pair of tests that pinned an ordinal-collision guard
+    /// (`global_stream_idx` had to be `< n_streams_total`, else two readers
+    /// minted the same ordinal). Drawing ordinals from one shared sequence
+    /// makes that collision structurally impossible, so the guard and its
+    /// tests are gone rather than merely unused.
+    #[test]
+    fn new_single_records_its_global_stream_index() {
+        let reader: Box<dyn BufRead + Send> = Box::new(io::Cursor::new(Vec::<u8>::new()));
+        let step = ReadFastqInputs::new_single(
+            reader,
+            1,
+            FastqOrdinalSequence::new(),
+            Affinity::Worker(1),
+            400,
+            1024,
+        );
+        assert_eq!(step.stream_idx_base, 1);
+    }
+
+    #[test]
+    fn new_single_pins_to_requested_worker() {
+        // Per-stream readers pin to a distinct worker so the two gzip
+        // decoders run concurrently (R1 on worker 0, R2 on worker 1) without
+        // contending the same source mutex.
+        let reader: Box<dyn BufRead + Send> = Box::new(io::Cursor::new(Vec::<u8>::new()));
+        let step = ReadFastqInputs::new_single(
+            reader,
+            1,
+            FastqOrdinalSequence::new(),
+            Affinity::Worker(1),
+            400,
+            1024,
+        );
+        assert_eq!(step.affinity(), Affinity::Worker(1));
+        assert_eq!(step.stream_idx_base, 1);
+        assert_eq!(step.n_streams, 1);
+        // Per-stream readers are NOT sticky — a sticky reader would monopolize
+        // its worker and starve the parallel compressor.
+        assert!(!step.profile().sticky);
+    }
+
+    /// The shared sequence must be unique *and* gap-free across every reader
+    /// drawing from it — including when one stream exhausts long before
+    /// another, which is precisely the case the old strided formula could not
+    /// express.
+    ///
+    /// Density is the half that matters: `BranchOrdering::ByItemOrdinal`
+    /// releases only in contiguous order, so a hole stalls the reorder stage
+    /// forever rather than erroring.
+    #[test]
+    fn shared_ordinal_sequence_is_dense_across_readers() {
+        let seq = FastqOrdinalSequence::new();
+        // Two "readers" sharing one sequence, drawing at wildly different
+        // rates — stream 0 keeps going long after stream 1 stops.
+        let r1 = seq.clone();
+        let r2 = seq.clone();
+        let mut minted = Vec::new();
+        for cycle in 0..10u64 {
+            minted.push(r1.next());
+            if cycle < 3 {
+                minted.push(r2.next());
+            }
+        }
+
+        let expected: Vec<u64> = (0..minted.len() as u64).collect();
+        let mut sorted = minted.clone();
+        sorted.sort_unstable();
+        assert_eq!(
+            sorted, expected,
+            "ordinals must be unique and gap-free however unevenly the readers draw",
+        );
+    }
+
+    #[test]
+    fn read_fastq_raw_bytes_from_bufread_reads_whole_records() {
+        let data = b"@read1\nACGT\n+\nIIII\n@read2\nTGCA\n+\nJJJJ\n";
+        let mut reader = io::Cursor::new(data.to_vec());
+        let (bytes, records_read) = read_fastq_raw_bytes_from_bufread(&mut reader, 10).unwrap();
+        assert_eq!(records_read, 2);
+        // Raw bytes are returned verbatim (whole-record-aligned).
+        assert_eq!(bytes, data);
+    }
+
+    #[test]
+    fn read_fastq_raw_bytes_from_bufread_respects_count() {
+        let data = b"@read1\nACGT\n+\nIIII\n@read2\nTGCA\n+\nJJJJ\n";
+        let mut reader = io::Cursor::new(data.to_vec());
+        let (bytes, records_read) = read_fastq_raw_bytes_from_bufread(&mut reader, 1).unwrap();
+        assert_eq!(records_read, 1);
+        assert_eq!(bytes, b"@read1\nACGT\n+\nIIII\n");
+    }
+
+    #[test]
+    fn read_fastq_raw_bytes_from_bufread_empty_input() {
+        let mut reader = io::Cursor::new(Vec::<u8>::new());
+        let (bytes, records_read) = read_fastq_raw_bytes_from_bufread(&mut reader, 10).unwrap();
+        assert_eq!(records_read, 0);
+        assert!(bytes.is_empty());
+    }
+}

--- a/src/lib/pipeline/steps/source/read_sam_chunks.rs
+++ b/src/lib/pipeline/steps/source/read_sam_chunks.rs
@@ -1,0 +1,625 @@
+//! `ReadSamChunks` source step + supporting helpers.
+//!
+//! 2-step parallel-parse SAM ingest. See
+//! `docs/design/refactor/unified-chain-builder-architecture.md` (the
+//! "Source resolver (delivered in Phase 1)" diagram) for how this step
+//! fits into the per-command chain:
+//!
+//! ```text
+//! ReadSamChunks (Serial + Reader)
+//!     ↓ SamChunk { batch_serial, bytes, line_offsets }
+//! ParseSamChunk (Parallel)
+//!     ↓ DecodedRecordBatch
+//! ```
+//!
+//! The Read step does NOT parse records — it reads bytes, finds line
+//! boundaries with `memchr`, and emits a chunk plus its line-offset table.
+//! Per-line parsing happens in parallel downstream.
+
+use std::io::{self, BufRead};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use parking_lot::Mutex;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Affinity, Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::SamChunk;
+
+/// Target bytes per emitted [`SamChunk`]. Picked to match a typical L1 cache
+/// working set (256 KB) — each parallel parser worker chews through one
+/// chunk while the next one is in flight.
+pub const DEFAULT_SAM_CHUNK_BYTES: usize = 256 * 1024;
+
+/// Upper bound on the carryover buffer while still searching for the first
+/// newline. A single SAM alignment record — even a long-read record with a
+/// multi-megabase CIGAR/sequence — is realistically a few MB of text, so a
+/// 1 GiB ceiling is enormously generous. Exceeding it without ever seeing a
+/// `\n` means the input is not newline-delimited SAM (e.g. a truncated/binary
+/// stream); we surface an error rather than letting `leftover` grow until the
+/// process is OOM-killed.
+const MAX_RECORD_BYTES: usize = 1024 * 1024 * 1024;
+
+/// Mutable per-source state: the SAM byte reader, a small carryover buffer
+/// for the trailing partial line, and an EOF flag.
+///
+/// Read at the byte level — header parsing is the caller's job (typically
+/// via [`crate::pipeline::steps::source::InputSource::open`], which
+/// drives `noodles::sam::io::Reader::read_header` then hands the post-header
+/// reader's underlying buffered stream into [`ReadSamState::new`]).
+pub struct ReadSamState {
+    reader: Box<dyn BufRead + Send>,
+    /// Trailing partial line from the previous `read_next_chunk` call. The
+    /// next call prepends these bytes before scanning so records never get
+    /// split across chunks. Private (encapsulation); use `leftover_len`
+    /// and `leftover_bytes` for in-crate test assertions.
+    leftover: Vec<u8>,
+    eof: bool,
+    /// Ceiling on a single newline-free span before the input is rejected as
+    /// not newline-delimited. A field rather than a bare constant so tests can
+    /// drive the rejection path with a small cap instead of buffering a
+    /// gigabyte; production callers get [`MAX_RECORD_BYTES`] via `new`.
+    max_record_bytes: usize,
+}
+
+impl ReadSamState {
+    #[must_use]
+    pub fn new(reader: Box<dyn BufRead + Send>) -> Self {
+        Self { reader, leftover: Vec::new(), eof: false, max_record_bytes: MAX_RECORD_BYTES }
+    }
+
+    /// Construct with a custom newline-free span ceiling. Test-facing: it makes
+    /// the `InvalidData` rejection reachable without a gigabyte of input.
+    #[cfg(test)]
+    fn with_max_record_bytes(reader: Box<dyn BufRead + Send>, max_record_bytes: usize) -> Self {
+        Self { reader, leftover: Vec::new(), eof: false, max_record_bytes }
+    }
+
+    /// Read the next chunk: append fresh bytes to `leftover`, split at the
+    /// last newline, return the complete-records prefix plus its
+    /// sentinel-form offset table. The trailing partial line stays in
+    /// `self.leftover` for the next call.
+    ///
+    /// `target_bytes` is a **soft lower bound**: the loop reads at least
+    /// that many bytes AND waits for at least one newline before
+    /// splitting. This guarantees forward progress even when a single
+    /// SAM line exceeds `target_bytes` (otherwise an upper-bound loop
+    /// would stall — leftover would fill with bytes that contain no
+    /// newline and the splitter would emit empty chunks forever).
+    /// Practical implication: chunks may be larger than `target_bytes`
+    /// if a record spans several reads, but never smaller than one
+    /// complete record once data is available.
+    ///
+    /// Returns `Ok(None)` only when the reader has signalled EOF AND no
+    /// bytes remain in `leftover` — i.e. the stream is fully consumed.
+    /// If EOF is reached with leftover bytes present, a synthetic `\n`
+    /// is appended so the final partial line becomes a complete record
+    /// (SAM tools traditionally accept a missing trailing newline).
+    ///
+    /// # Panics (debug)
+    ///
+    /// Debug-asserts that `target_bytes <= u32::MAX`. Line offsets emitted
+    /// by `split_complete_lines` are stored as `u32`; the production
+    /// entry point [`ReadSamChunks::new`] also asserts this at
+    /// construction. Direct callers (e.g. unit tests) should respect
+    /// the same cap.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying reader's I/O error.
+    pub fn read_next_chunk(
+        &mut self,
+        target_bytes: usize,
+    ) -> io::Result<Option<(Vec<u8>, Vec<u32>)>> {
+        debug_assert!(
+            u32::try_from(target_bytes).is_ok(),
+            "target_bytes ({target_bytes}) exceeds u32::MAX; \
+             line offsets in the emitted chunk are stored as u32"
+        );
+        // Soft-lower-bound read loop: keep pulling from the reader until
+        // we have at least `target_bytes` AND at least one newline (so
+        // the splitter can emit a complete record). `read_until(b'\n', ...)`
+        // would force per-record I/O sync — we want larger reads to
+        // amortize syscalls, so we pull raw bytes via `fill_buf`/`consume`.
+        // Scan for the first newline incrementally. Re-running `memchr` over the
+        // whole of `leftover` on every iteration re-reads bytes already known to
+        // be newline-free, which is quadratic in the length of a newline-less
+        // span — exactly the input the ceiling below exists to reject, so the
+        // rejection path was the slowest one. `scanned` marks how far the search
+        // has already reached; everything before it is known newline-free.
+        let mut newline_at = memchr::memchr(b'\n', &self.leftover);
+        let mut scanned = if newline_at.is_some() { 0 } else { self.leftover.len() };
+
+        while !self.eof {
+            // Stop when we have enough bytes for the target AND at least
+            // one complete record sits in the buffer.
+            if self.leftover.len() >= target_bytes && newline_at.is_some() {
+                break;
+            }
+            let chunk = self.reader.fill_buf()?;
+            if chunk.is_empty() {
+                self.eof = true;
+                break;
+            }
+            let take = chunk.len();
+            self.leftover.extend_from_slice(&chunk[..take]);
+            self.reader.consume(take);
+
+            if newline_at.is_none() {
+                newline_at =
+                    memchr::memchr(b'\n', &self.leftover[scanned..]).map(|off| scanned + off);
+                if newline_at.is_none() {
+                    scanned = self.leftover.len();
+                }
+            }
+
+            // Guard against unbounded growth: if `leftover` exceeds the
+            // per-record ceiling while still containing no newline, the input
+            // is not newline-delimited SAM. Bail out instead of buffering the
+            // whole stream into memory. (Once a newline is present the loop
+            // breaks above, so this only fires on a genuinely newline-less span.)
+            if newline_at.is_none() && self.leftover.len() > self.max_record_bytes {
+                let max = self.max_record_bytes;
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "SAM record exceeds {max} bytes with no newline; \
+                         input does not appear to be newline-delimited SAM text"
+                    ),
+                ));
+            }
+        }
+
+        if self.leftover.is_empty() {
+            // Reader is fully drained and nothing was held over.
+            return Ok(None);
+        }
+
+        // At true EOF with leftover bytes: append a synthetic `\n` so the
+        // trailing partial line becomes a complete record. SAM tools
+        // traditionally accept files without a trailing newline.
+        if self.eof && !self.leftover.ends_with(b"\n") {
+            self.leftover.push(b'\n');
+        }
+
+        let (offsets, leftover_slice) = split_complete_lines(&self.leftover);
+        let split_at = self.leftover.len() - leftover_slice.len();
+        let new_leftover = self.leftover.split_off(split_at);
+        let bytes = std::mem::replace(&mut self.leftover, new_leftover);
+        Ok(Some((bytes, offsets)))
+    }
+
+    /// Test-only accessor: length of the carryover buffer holding the
+    /// trailing partial line. Mostly useful for asserting that a
+    /// mid-stream read held the right partial bytes.
+    #[cfg(test)]
+    fn leftover_len(&self) -> usize {
+        self.leftover.len()
+    }
+
+    /// Test-only accessor: bytes of the carryover buffer.
+    #[cfg(test)]
+    fn leftover_bytes(&self) -> &[u8] {
+        &self.leftover
+    }
+}
+
+/// `Serial + sticky + Affinity::Reader` SAM-chunk source. Reads SAM text
+/// bytes, splits at newline boundaries, and emits `SamChunk` items with
+/// inline line-offset tables. Per-line parsing is delegated to the
+/// downstream `Parallel` parser step.
+pub struct ReadSamChunks {
+    state: Arc<Mutex<Option<ReadSamState>>>,
+    next_serial: u64,
+    held: HeldSlot<Unpushed<SamChunk>>,
+    target_chunk_bytes: usize,
+    output_byte_limit: u64,
+    finished: Arc<AtomicBool>,
+}
+
+impl ReadSamChunks {
+    /// Build a SAM chunk source from a buffered reader positioned past the
+    /// SAM header (typically obtained via `InputSource::open`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `target_chunk_bytes` exceeds `u32::MAX` — line offsets
+    /// inside an emitted `SamChunk` are held as `u32`. In production all
+    /// callsites pass `DEFAULT_SAM_CHUNK_BYTES` (256 KB) so this is
+    /// unreachable; the assert exists to catch a configuration mistake
+    /// at construction rather than panicking deep in the read loop.
+    #[must_use]
+    pub fn new(
+        reader: Box<dyn BufRead + Send>,
+        target_chunk_bytes: usize,
+        output_byte_limit: u64,
+    ) -> Self {
+        assert!(
+            u32::try_from(target_chunk_bytes).is_ok(),
+            "target_chunk_bytes ({target_chunk_bytes}) exceeds u32::MAX; \
+             line offsets in SamChunk are stored as u32"
+        );
+        Self {
+            state: Arc::new(Mutex::new(Some(ReadSamState::new(reader)))),
+            next_serial: 0,
+            held: HeldSlot::new(),
+            target_chunk_bytes: target_chunk_bytes.max(1),
+            output_byte_limit,
+            finished: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+impl Step for ReadSamChunks {
+    type Input = ();
+    type Outputs = OrderedBytesSingle<SamChunk>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ReadSamChunks",
+            kind: StepKind::Serial,
+            sticky: true,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn affinity(&self) -> Affinity {
+        Affinity::Reader
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // 1. Drain the held slot first.
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        if self.finished.load(Ordering::Acquire) {
+            return Ok(StepOutcome::Finished);
+        }
+
+        // 3. Pull the next chunk from the reader.
+        let next = {
+            let mut guard = self.state.lock();
+            let state = guard.as_mut().expect("ReadSamChunks: state missing — was clone() called?");
+            state.read_next_chunk(self.target_chunk_bytes)?
+        };
+
+        let Some((bytes, line_offsets)) = next else {
+            self.finished.store(true, Ordering::Release);
+            return Ok(StepOutcome::Finished);
+        };
+
+        let serial = self.next_serial;
+        self.next_serial += 1;
+        let chunk = SamChunk { batch_serial: serial, bytes, line_offsets };
+        match ctx.outputs.push(chunk) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+}
+
+/// Split `data` into complete `\n`-terminated records.
+///
+/// Returns `(line_offsets, leftover)` where:
+///
+/// - `line_offsets` is the sentinel-form table — `N+1` entries describing
+///   `N` complete lines. Line `i` is `data[line_offsets[i]..line_offsets[i+1]]`.
+///   Each line's bytes include its trailing `\n`. Empty if `data` contains
+///   no complete line.
+/// - `leftover` is the trailing partial line (bytes after the last `\n`).
+///   Empty if `data` ends on a `\n` boundary. The caller carries this
+///   forward into the next read so records aren't split mid-line.
+///
+/// # Panics
+///
+/// Panics if `data.len()` exceeds `u32::MAX` (we hold offsets as `u32`
+/// because individual chunks are sized in the hundreds-of-KB range).
+#[must_use]
+pub fn split_complete_lines(data: &[u8]) -> (Vec<u32>, &[u8]) {
+    // Find the position just past the last newline. Everything up to that
+    // position is "complete lines"; the remainder is the partial-line
+    // leftover for the next read.
+    let Some(last_nl) = memchr::memrchr(b'\n', data) else {
+        return (Vec::new(), data);
+    };
+    let split = last_nl + 1; // include the trailing \n in the complete region
+    let (complete, leftover) = data.split_at(split);
+
+    // Walk newline positions to build the sentinel-form offset table.
+    let mut offsets: Vec<u32> = Vec::new();
+    offsets.push(0);
+    for nl in memchr::memchr_iter(b'\n', complete) {
+        offsets.push(u32::try_from(nl + 1).expect("chunk size fits in u32"));
+    }
+    (offsets, leftover)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufReader, Cursor};
+
+    fn reader_from(bytes: &[u8]) -> Box<dyn std::io::BufRead + Send> {
+        Box::new(BufReader::new(Cursor::new(bytes.to_vec())))
+    }
+
+    /// A `BufRead` that releases at most `piece` bytes per `fill_buf`.
+    ///
+    /// `BufReader<Cursor<_>>` hands the whole input over on the first
+    /// `fill_buf`, so every test built on `reader_from` leaves the read loop
+    /// after one iteration — with `scanned` still `0`. That makes the
+    /// incremental-scan arithmetic in `read_next_chunk` (which converts a
+    /// slice-relative newline index back to an absolute one) unreachable. This
+    /// reader forces the loop to append repeatedly and resume the search from
+    /// `scanned`.
+    struct Dribble {
+        data: Vec<u8>,
+        pos: usize,
+        piece: usize,
+    }
+
+    impl Dribble {
+        fn boxed(data: Vec<u8>, piece: usize) -> Box<dyn std::io::BufRead + Send> {
+            Box::new(Self { data, pos: 0, piece })
+        }
+    }
+
+    impl io::Read for Dribble {
+        fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+            let n = self.piece.min(out.len()).min(self.data.len() - self.pos);
+            out[..n].copy_from_slice(&self.data[self.pos..self.pos + n]);
+            self.pos += n;
+            Ok(n)
+        }
+    }
+
+    impl io::BufRead for Dribble {
+        fn fill_buf(&mut self) -> io::Result<&[u8]> {
+            let end = (self.pos + self.piece).min(self.data.len());
+            Ok(&self.data[self.pos..end])
+        }
+
+        fn consume(&mut self, amt: usize) {
+            self.pos = (self.pos + amt).min(self.data.len());
+        }
+    }
+
+    /// The newline search must resume at `scanned` and still report an
+    /// **absolute** offset. The first `\n` sits at byte 20, well past the 8-byte
+    /// piece size, so it is found on the third `fill_buf` in a slice that starts
+    /// at 16 — a sign error or a missing `scanned +` would place it at 4.
+    #[test]
+    fn read_next_chunk_resumes_the_newline_search_across_fill_buf_calls() {
+        let mut data = vec![b'A'; 20];
+        data.push(b'\n');
+        data.extend_from_slice(b"sec");
+
+        let mut state = ReadSamState::new(Dribble::boxed(data, 8));
+
+        let (bytes, offsets) =
+            state.read_next_chunk(4).expect("read succeeds").expect("a chunk is emitted");
+
+        // Three 8-byte pieces are pulled before the newline is seen, so the
+        // buffer holds 24 bytes; only the 21 through the newline are complete.
+        let mut expected = vec![b'A'; 20];
+        expected.push(b'\n');
+        assert_eq!(bytes, expected);
+        assert_eq!(offsets, vec![0, 21]);
+        assert_eq!(state.leftover_bytes(), b"sec");
+    }
+
+    /// The newline-free ceiling must also fire when bytes trickle in, since the
+    /// check runs inside the same loop the incremental scan advances.
+    #[test]
+    fn the_newline_free_cap_still_fires_on_small_pieces() {
+        const CAP: usize = 64;
+
+        let mut state =
+            ReadSamState::with_max_record_bytes(Dribble::boxed(vec![b'A'; CAP * 4], 7), CAP);
+
+        let err = state.read_next_chunk(16).expect_err("newline-free input is rejected");
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("no newline"), "got: {err}");
+    }
+
+    #[test]
+    fn split_complete_lines_empty_input_returns_empty_offsets_and_empty_leftover() {
+        let (offsets, leftover) = split_complete_lines(b"");
+        assert!(offsets.is_empty(), "expected no line offsets for empty input");
+        assert!(leftover.is_empty(), "expected no leftover for empty input");
+    }
+
+    #[test]
+    fn split_complete_lines_single_line_terminated_by_newline_no_leftover() {
+        // "abc\n" — one complete record, ends at newline. Sentinel-form
+        // offsets are [0, 4]: line 0 is bytes[0..4] = "abc\n".
+        let (offsets, leftover) = split_complete_lines(b"abc\n");
+        assert_eq!(offsets, vec![0, 4]);
+        assert!(leftover.is_empty(), "expected no leftover when input ends on \\n");
+    }
+
+    #[test]
+    fn split_complete_lines_multiple_lines_no_trailing_newline_leaves_partial_leftover() {
+        // "abc\nde\nf" — two complete lines ("abc\n", "de\n") and a partial
+        // line "f" carried over. Offsets [0, 4, 7] index into bytes[..7].
+        let input = b"abc\nde\nf";
+        let (offsets, leftover) = split_complete_lines(input);
+        assert_eq!(offsets, vec![0, 4, 7]);
+        assert_eq!(leftover, b"f");
+        // Verify the offsets actually slice out the lines.
+        assert_eq!(&input[offsets[0] as usize..offsets[1] as usize], b"abc\n");
+        assert_eq!(&input[offsets[1] as usize..offsets[2] as usize], b"de\n");
+    }
+
+    #[test]
+    fn split_complete_lines_only_partial_line_returns_empty_offsets() {
+        // "abc" — no newline at all. Nothing complete; everything is leftover.
+        let (offsets, leftover) = split_complete_lines(b"abc");
+        assert!(offsets.is_empty());
+        assert_eq!(leftover, b"abc");
+    }
+
+    #[test]
+    fn read_next_chunk_emits_complete_lines_and_holds_partial_as_leftover() {
+        // Soft-lower-bound semantics: with target=10 against a 16-byte
+        // cursor that delivers everything in one `fill_buf`, the loop
+        // reads it all (target satisfied + at least one `\n` present),
+        // splits at the last newline, and holds the trailing partial
+        // line "linX" as the carryover for the next call.
+        let mut state = ReadSamState::new(reader_from(b"line1\nline2\nlinX"));
+        let (bytes, offsets) =
+            state.read_next_chunk(10).expect("read ok").expect("at least one chunk");
+        assert_eq!(offsets, vec![0, 6, 12]);
+        assert_eq!(&bytes[0..6], b"line1\n");
+        assert_eq!(&bytes[6..12], b"line2\n");
+        assert_eq!(state.leftover_bytes(), b"linX");
+    }
+
+    #[test]
+    fn read_next_chunk_flushes_partial_line_at_eof_with_synthetic_newline() {
+        // Input without a trailing newline. A large target reads everything
+        // in one go, then EOF triggers the synthetic-`\n` flush so the
+        // final partial line becomes a complete record.
+        let mut state = ReadSamState::new(reader_from(b"only_one"));
+        let (bytes, offsets) =
+            state.read_next_chunk(1024).expect("read ok").expect("at least one chunk");
+        assert_eq!(offsets, vec![0, 9]);
+        assert_eq!(bytes, b"only_one\n");
+        assert_eq!(state.leftover_len(), 0, "EOF flush should drain leftover");
+    }
+
+    #[test]
+    fn read_next_chunk_returns_none_after_full_drain() {
+        // After EOF + flushed final record, the next call returns None.
+        let mut state = ReadSamState::new(reader_from(b"a\nb\n"));
+        let _first = state.read_next_chunk(1024).expect("read ok").expect("first chunk");
+        let second = state.read_next_chunk(1024).expect("read ok");
+        assert!(second.is_none(), "expected None on second call after drain");
+    }
+
+    #[test]
+    fn read_next_chunk_target_smaller_than_line_does_not_stall() {
+        // Regression test for the target-bytes-as-upper-bound stall: if
+        // `target_bytes` was smaller than the smallest line, the old
+        // upper-bound loop terminated with leftover holding partial
+        // bytes and no newline. Subsequent calls returned empty chunks
+        // forever (the exit condition was already satisfied).
+        //
+        // Fix treats `target_bytes` as a soft LOWER bound: read at least
+        // that many bytes AND wait for a newline before splitting.
+        //
+        // Input: two 5-byte records against a 4-byte target. First call
+        // must emit BOTH records (the Cursor delivers everything in one
+        // `fill_buf`, the second `\n` satisfies the lower bound). A
+        // follow-up call must return None — drained.
+        let mut state = ReadSamState::new(reader_from(b"hello\nworld\n"));
+        let (bytes, offsets) =
+            state.read_next_chunk(4).expect("read ok").expect("at least one chunk");
+        assert_eq!(bytes, b"hello\nworld\n", "must drain both complete records, not stall");
+        assert_eq!(offsets, vec![0, 6, 12], "two records: hello\\n at [0..6], world\\n at [6..12]");
+        assert_eq!(state.leftover_len(), 0, "leftover should be empty after draining");
+
+        // Second call: reader is drained, leftover empty → returns None.
+        let second = state.read_next_chunk(4).expect("read ok");
+        assert!(second.is_none(), "second call must return None — stream fully consumed");
+    }
+
+    #[test]
+    fn read_next_chunk_returns_none_for_empty_input() {
+        let mut state = ReadSamState::new(reader_from(b""));
+        let result = state.read_next_chunk(1024).expect("read ok");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn split_complete_lines_consecutive_newlines_yield_empty_lines() {
+        // "\n\n" — two empty records, both terminated. The parser should
+        // accept zero-length lines; SAM doesn't naturally produce them but
+        // the splitter shouldn't drop them either (drives the invariant
+        // that offsets.windows(2) cover every byte of `complete`).
+        let (offsets, leftover) = split_complete_lines(b"\n\n");
+        assert_eq!(offsets, vec![0, 1, 2]);
+        assert!(leftover.is_empty());
+    }
+
+    #[test]
+    fn read_sam_chunks_profile_advertises_serial_reader_byordinal() {
+        let step = ReadSamChunks::new(reader_from(b""), 64 * 1024, 1024 * 1024);
+        let profile = step.profile();
+        assert_eq!(profile.name, "ReadSamChunks");
+        assert_eq!(profile.kind, crate::pipeline::core::step::StepKind::Serial);
+        assert!(profile.sticky);
+        assert_eq!(step.affinity(), crate::pipeline::core::step::Affinity::Reader);
+        assert_eq!(
+            profile.branch_ordering,
+            vec![crate::pipeline::core::reorder::BranchOrdering::ByItemOrdinal]
+        );
+        assert!(matches!(
+            profile.output_queues[0],
+            crate::pipeline::core::queues::QueueSpec::ByteBounded { .. }
+        ));
+    }
+
+    /// A newline-free span past the ceiling must be rejected as `InvalidData`
+    /// rather than buffered. This is the path the cap exists for — a
+    /// non-newline-delimited input (a binary file handed to the SAM reader)
+    /// would otherwise pull the whole stream into `leftover`.
+    ///
+    /// Driven through a small cap so the rejection is reachable without
+    /// allocating the production-sized ceiling.
+    #[test]
+    fn a_newline_free_span_past_the_cap_is_rejected() {
+        const CAP: usize = 4 * 1024;
+        let input = vec![b'A'; CAP * 4]; // no newline anywhere
+        let mut state = ReadSamState::with_max_record_bytes(
+            Box::new(std::io::BufReader::new(std::io::Cursor::new(input))),
+            CAP,
+        );
+
+        let err = state
+            .read_next_chunk(1024)
+            .expect_err("a newline-free input must be rejected, not buffered");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("newline-delimited"),
+            "error should name the actual problem, got: {err}"
+        );
+    }
+
+    /// The cap must not fire on legitimate input whose records simply exceed the
+    /// soft target: a single long line under the ceiling still parses.
+    #[test]
+    fn a_long_but_terminated_line_under_the_cap_is_accepted() {
+        const CAP: usize = 4 * 1024;
+        let mut input = vec![b'A'; CAP / 2];
+        input.push(b'\n');
+        let expected = input.clone();
+        let mut state = ReadSamState::with_max_record_bytes(
+            Box::new(std::io::BufReader::new(std::io::Cursor::new(input))),
+            CAP,
+        );
+
+        let (bytes, offsets) = state
+            .read_next_chunk(64)
+            .expect("a terminated line under the cap must parse")
+            .expect("one complete record");
+        assert_eq!(bytes, expected);
+        assert_eq!(offsets, vec![0, u32::try_from(expected.len()).unwrap()]);
+    }
+}

--- a/src/lib/pipeline/steps/source/zip_fastq.rs
+++ b/src/lib/pipeline/steps/source/zip_fastq.rs
@@ -1,0 +1,1041 @@
+//! `ZipFastqRecords` step: joins per-stream `FastqChunkBatch` items into
+//! `FastqTemplateBatch` items by matching chunk serials across streams.
+//!
+//! `Serial` + `Affinity::None`. Receives round-robin chunks from
+//! `ReadFastqInputs` and buffers them in a `BTreeMap` keyed by
+//! `chunk_serial`. When all `n_streams` slots for the lowest serial are
+//! filled, the records are zipped into `FastqTemplate`s and emitted.
+
+use std::collections::BTreeMap;
+use std::io;
+
+use crate::fastq_parse::{FastqRecord, strip_read_suffix};
+use crate::grouper::FastqTemplate;
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::item::{HeapSize, Ordered};
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+
+use super::read_fastq::FastqChunkBatch;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FastqTemplateBatch
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub struct FastqTemplateBatch {
+    pub batch_serial: u64,
+    pub templates: Vec<FastqTemplate>,
+    total_bytes: usize,
+}
+
+impl FastqTemplateBatch {
+    #[must_use]
+    pub fn new(batch_serial: u64, templates: Vec<FastqTemplate>) -> Self {
+        let total_bytes: usize = templates.iter().map(HeapSize::heap_size).sum();
+        Self { batch_serial, templates, total_bytes }
+    }
+}
+
+impl HeapSize for FastqTemplateBatch {
+    fn heap_size(&self) -> usize {
+        self.total_bytes
+    }
+}
+
+impl Ordered for FastqTemplateBatch {
+    fn ordinal(&self) -> u64 {
+        self.batch_serial
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ZipFastqRecords — Serial step
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_PENDING_BACKPRESSURE_BYTES: usize = 256 * 1024 * 1024;
+
+/// Outcome of a full egress drain attempt ([`ZipFastqRecords::drain_complete`]).
+enum DrainStop {
+    /// The lowest serial is incomplete (or `pending` is empty): nothing more to
+    /// emit right now. `emitted` records whether at least one batch left.
+    Exhausted { emitted: bool },
+    /// A downstream push could not complete; the unpushed batch is now in
+    /// `self.held`. The caller must stop draining immediately (no further serial
+    /// may be emitted while the single held slot is occupied) and return
+    /// `Progress` — parking a complete serial in `held` is real forward progress,
+    /// and the held-slot retry preamble on the next dispatch flushes it before
+    /// any more work runs (see the `try_run` call site).
+    Held,
+}
+
+pub struct ZipFastqRecords {
+    n_streams: usize,
+    pending: BTreeMap<u64, Vec<Option<FastqChunkBatch>>>,
+    pending_total_bytes: usize,
+    pending_backpressure_bytes: usize,
+    held: HeldSlot<Unpushed<FastqTemplateBatch>>,
+    output_byte_limit: u64,
+    next_batch_serial: u64,
+    /// Whether the soft-limit warning has already fired for the current
+    /// over-limit episode. This step is `Serial` and the driver re-dispatches it
+    /// in a tight loop, so an unguarded warning emits one identical line per
+    /// dispatch for the whole time a legitimately-ahead stream stays over the
+    /// limit — the exact case the branch exists to admit. Cleared when the
+    /// buffer drops back under the limit, so each episode warns once.
+    over_soft_limit_warned: bool,
+}
+
+impl ZipFastqRecords {
+    /// Construct a zipper for `n_streams` FASTQ streams.
+    ///
+    /// # Preconditions
+    ///
+    /// `n_streams >= 1`. The count is wired from the FASTQ-input count, which
+    /// is always at least one, and `try_emit_complete` indexes
+    /// `stream_records[0]`, so a zero-stream configuration would panic on that
+    /// index. A `debug_assert!` makes an accidental zero-stream wiring fail
+    /// loudly in debug/test builds.
+    #[must_use]
+    pub fn new(n_streams: usize, output_byte_limit: u64) -> Self {
+        debug_assert!(n_streams >= 1, "ZipFastqRecords requires n_streams >= 1, got {n_streams}");
+        Self {
+            n_streams,
+            pending: BTreeMap::new(),
+            pending_total_bytes: 0,
+            pending_backpressure_bytes: DEFAULT_PENDING_BACKPRESSURE_BYTES,
+            held: HeldSlot::new(),
+            output_byte_limit,
+            next_batch_serial: 0,
+            over_soft_limit_warned: false,
+        }
+    }
+
+    /// Latch the over-soft-limit episode, returning `true` only on the dispatch
+    /// that *enters* it.
+    ///
+    /// The caller warns on `true`. Because this step is `Serial` and the driver
+    /// re-dispatches it in a tight loop, warning unconditionally would emit one
+    /// identical line per dispatch for as long as a legitimately-ahead stream
+    /// stays over the limit.
+    fn enter_over_soft_limit(&mut self) -> bool {
+        let first = !self.over_soft_limit_warned;
+        self.over_soft_limit_warned = true;
+        first
+    }
+
+    /// Clear the episode latch, so the next crossing warns again.
+    fn leave_over_soft_limit(&mut self) {
+        self.over_soft_limit_warned = false;
+    }
+
+    /// Override the soft pending-backpressure limit (test-only).
+    ///
+    /// Production wires the default 256 MiB limit; tests shrink it to a few KiB
+    /// so a lag-then-burst scenario can cross the soft/hard thresholds with a
+    /// handful of small records rather than hundreds of megabytes of data.
+    #[cfg(test)]
+    fn with_backpressure_bytes(mut self, bytes: usize) -> Self {
+        self.pending_backpressure_bytes = bytes;
+        self
+    }
+
+    /// Egress: emit every currently-complete consecutive lowest serial.
+    ///
+    /// Loops [`Self::try_emit_complete`] until it yields `None` (the lowest
+    /// serial is incomplete or `pending` is empty) or a downstream push fails.
+    /// On a failed push the unpushed batch is stashed in `self.held` and the
+    /// loop stops — the single held slot can hold only one item, so no further
+    /// serial may be emitted until it flushes on a later dispatch.
+    ///
+    /// Backpressure never gates this: draining is the only action that relieves
+    /// pending-byte pressure, so it must always run. Bounded: each successful
+    /// emit removes one key from `pending` (in `try_emit_complete`), so the loop
+    /// runs at most `pending.len()` times and strictly shrinks `pending`.
+    ///
+    /// Precondition: `self.held` is empty (the held-slot preamble in `try_run`
+    /// guarantees this by returning `Contention` on a failed retry).
+    fn drain_complete(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<DrainStop> {
+        debug_assert!(
+            !self.held.is_held(),
+            "drain_complete requires an empty held slot — the try_run preamble must clear it"
+        );
+        let mut emitted = false;
+        loop {
+            match self.try_emit_complete()? {
+                None => return Ok(DrainStop::Exhausted { emitted }),
+                Some(template_batch) => match ctx.outputs.push(template_batch) {
+                    Ok(()) => emitted = true,
+                    Err(unpushed) => {
+                        self.held.put(unpushed);
+                        return Ok(DrainStop::Held);
+                    }
+                },
+            }
+        }
+    }
+
+    fn try_emit_complete(&mut self) -> io::Result<Option<FastqTemplateBatch>> {
+        let Some(lowest_serial) = self.pending.keys().next().copied() else {
+            return Ok(None);
+        };
+
+        let slots = self.pending.get(&lowest_serial).unwrap();
+        let all_filled = slots.iter().all(Option::is_some);
+        if !all_filled {
+            return Ok(None);
+        }
+
+        let chunks: Vec<FastqChunkBatch> = self
+            .pending
+            .remove(&lowest_serial)
+            .unwrap()
+            .into_iter()
+            .map(|opt| opt.expect("every slot is filled — checked by `all_filled` above"))
+            .collect();
+
+        // Subtract using each batch's own `HeapSize`, which is the measure the
+        // byte-bounded queues budget and the same one the insert side adds. A
+        // hand-rolled sum over `records` would be a *second* measure of the same
+        // chunk: it happens to agree today because the records are moved through
+        // unchanged, but `FastqChunkBatch::new` takes `total_bytes` as a
+        // parameter rather than deriving it, so the two can diverge — and then
+        // `pending_total_bytes` would drift against the queue budget and the
+        // soft/hard thresholds would fire on a different measure than the queues
+        // enforce.
+        let chunk_bytes: usize = chunks.iter().map(HeapSize::heap_size).sum();
+        self.pending_total_bytes = self.pending_total_bytes.saturating_sub(chunk_bytes);
+
+        let mut stream_records: Vec<Vec<FastqRecord>> =
+            chunks.into_iter().map(|chunk| chunk.records).collect();
+
+        let n_records = stream_records[0].len();
+
+        // Paired/N-stream FASTQ is positionally parallel: every stream must
+        // contribute the same number of records for this chunk. Reject a
+        // mismatch explicitly (matches the N==2 ParseAndZipFastq path and
+        // fgbio's FastqSource.zipped "out of sync" check) rather than letting
+        // it surface as an incidental name mismatch from the back-pop below.
+        for (stream_idx, recs) in stream_records.iter().enumerate().skip(1) {
+            if recs.len() != n_records {
+                return Err(io::Error::other(format!(
+                    "FASTQ sources out of sync at chunk_serial {lowest_serial}: \
+                     stream 0 has {n_records} records, stream {stream_idx} has {}",
+                    recs.len(),
+                )));
+            }
+        }
+
+        // Zip across streams: record i from each stream forms one template.
+        // Drain from the back (via pop) to avoid O(n^2) from front removal;
+        // reverse in place afterwards.
+        let mut templates = Vec::with_capacity(n_records);
+        for _ in 0..n_records {
+            let mut records = Vec::with_capacity(self.n_streams);
+            let mut base_name: Option<Vec<u8>> = None;
+
+            for (stream_idx, stream) in stream_records.iter_mut().enumerate() {
+                // Unreachable after the equal-count check above; kept defensive.
+                let Some(record) = stream.pop() else {
+                    return Err(io::Error::other(format!(
+                        "FASTQ sources out of sync: stream {stream_idx} ran short at chunk_serial {lowest_serial}",
+                    )));
+                };
+
+                let stripped = strip_read_suffix(record.name());
+                match &base_name {
+                    None => {
+                        base_name = Some(stripped.to_vec());
+                    }
+                    Some(expected) => {
+                        if stripped != expected.as_slice() {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!(
+                                    "FASTQ read name mismatch at chunk_serial {}: stream 0 has '{}', stream {} has '{}'",
+                                    lowest_serial,
+                                    String::from_utf8_lossy(expected),
+                                    stream_idx,
+                                    String::from_utf8_lossy(stripped),
+                                ),
+                            ));
+                        }
+                    }
+                }
+                records.push(record);
+            }
+
+            templates.push(FastqTemplate { name: base_name.unwrap(), records });
+        }
+
+        // We popped from the back, so reverse to restore original order.
+        templates.reverse();
+
+        let serial = self.next_batch_serial;
+        self.next_batch_serial += 1;
+        Ok(Some(FastqTemplateBatch::new(serial, templates)))
+    }
+}
+
+impl Step for ZipFastqRecords {
+    type Input = FastqChunkBatch;
+    type Outputs = OrderedBytesSingle<FastqTemplateBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ZipFastqRecords",
+            kind: StepKind::Serial,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // ── (a) Held-slot retry preamble ────────────────────────────────────
+        // Single-occupancy: if the retry still can't push, re-hold and return
+        // Contention so control never reaches egress/ingress with a full slot.
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        // ── (b) Full egress drain — ALWAYS runs, before any backpressure gate.
+        // Draining the complete lowest serials is the ONLY action that relieves
+        // pending-byte pressure, so it must never be throttled (the previous
+        // code returned NoProgress/Err on backpressure *before* emitting, which
+        // wedged the step whenever the lowest serial was already complete but
+        // over the soft limit — see issue notes for S5a1-001).
+        match self.drain_complete(ctx)? {
+            // `Held` means a complete serial was removed from `pending` (bytes
+            // subtracted) and parked in the held slot for retry — that is real
+            // forward progress ("held one for later"), not mutex contention.
+            // Misreporting it as `Contention` on this liveness-critical
+            // backpressure path would understate progress to the driver.
+            DrainStop::Held => return Ok(StepOutcome::Progress),
+            DrainStop::Exhausted { emitted } => {
+                // If anything was emitted, report Progress now: pressure dropped
+                // and the next dispatch re-evaluates ingress against the new
+                // (lower) byte total. We deliberately do NOT also pop input this
+                // dispatch — that keeps the held-slot single-occupancy reasoning
+                // trivial and gives the driver a clean re-dispatch point.
+                if emitted {
+                    return Ok(StepOutcome::Progress);
+                }
+                // Nothing emitted ⇒ the lowest serial is incomplete (or pending
+                // is empty). Fall through to the desync check / ingress gate.
+            }
+        }
+
+        // Reaching here: `pending` is empty OR its lowest serial is incomplete,
+        // and the held slot is empty.
+
+        // ── (c) Hard desync abort — predicated on a genuinely-stuck serial ───
+        // Abort ONLY when the lowest serial is still incomplete after a full
+        // drain AND the buffer is over the hard limit. A complete lowest serial
+        // is drained in (b) before this check, so a non-empty `pending` here
+        // means the lowest serial is incomplete; if bytes are also over 2x, one
+        // stream is producing unboundedly more than its counterpart — a real
+        // desync. (The old predicate fired on bytes alone, false-aborting an
+        // in-sync but ahead stream whose lowest serial was emittable.)
+        let lowest_incomplete = !self.pending.is_empty();
+        if lowest_incomplete && self.pending_total_bytes > 2 * self.pending_backpressure_bytes {
+            let (&serial, _) = self.pending.iter().next().expect("pending non-empty");
+            return Err(io::Error::other(format!(
+                "ZipFastqRecords: catastrophic stream desync — lowest chunk_serial {serial} \
+                 is still incomplete while pending buffer ({} bytes) exceeds 2x backpressure \
+                 limit ({} bytes). One FASTQ stream is producing far more data than its \
+                 counterpart.",
+                self.pending_total_bytes, self.pending_backpressure_bytes
+            )));
+        }
+
+        // ── (c') Advisory soft limit — warn, never refuse ────────────────────
+        // Being over the soft limit does *not* throttle ingress, and cannot: the
+        // chunk that completes the lowest serial (and so lets egress drain) is
+        // itself still queued in `ctx.input`, so refusing input here would stall
+        // the very drain that relieves the pressure. That is the S5a1-001
+        // deadlock. The hard 2x abort above is therefore the sole bound on
+        // `pending`, and this arm only reports.
+        //
+        // An earlier revision also refused ingress when `pending` was empty, as a
+        // precautionary throttle. That branch could never run: `pending_total_bytes`
+        // moves only with `pending` — bytes are added on insert and the same sum
+        // is subtracted when the entry is removed — so an empty `pending` always
+        // means zero bytes, which is never over a positive limit. The assert below
+        // pins that invariant, so a future accounting change that breaks it is
+        // loud in debug builds rather than silently resurrecting dead code.
+        debug_assert!(
+            !self.pending.is_empty() || self.pending_total_bytes == 0,
+            "pending accounting desync: empty pending must imply zero bytes, got {}",
+            self.pending_total_bytes
+        );
+        if self.pending_total_bytes > self.pending_backpressure_bytes {
+            // Once per over-limit episode, not once per dispatch.
+            if self.enter_over_soft_limit() {
+                log::warn!(
+                    "ZipFastqRecords: pending buffer exceeds backpressure limit ({} > {}); lowest \
+                     serial incomplete, continuing ingress to complete it",
+                    self.pending_total_bytes,
+                    self.pending_backpressure_bytes
+                );
+            }
+        } else {
+            self.leave_over_soft_limit();
+        }
+
+        // ── (d) Ingress: pop one input chunk + insert, then drain again ──────
+        let Some(batch) = ctx.input.pop() else {
+            // No input this call. Egress already ran in (b) and emitted nothing,
+            // so the lowest serial is incomplete. If upstream is drained, this
+            // is the residual-completion / EOF path: every remaining entry must
+            // be complete (all streams ended cleanly) — a `None` slot means a
+            // stream ended early (out of sync).
+            if ctx.input.is_drained() {
+                if let Some((&serial, slots)) = self.pending.iter().next() {
+                    for (idx, slot) in slots.iter().enumerate() {
+                        if slot.is_none() {
+                            return Err(io::Error::other(format!(
+                                "FASTQ sources out of sync: stream {idx} ended before \
+                                 chunk_serial {serial} while other streams had more records",
+                            )));
+                        }
+                    }
+                    // All slots present but the full drain in (b) emitted
+                    // nothing: unreachable (a complete lowest entry always
+                    // emits). Fail loud — returning NoProgress here would hang
+                    // (input is drained, so the step is never re-fed).
+                    return Err(io::Error::other(format!(
+                        "ZipFastqRecords: chunk_serial {serial} has all streams present but \
+                         did not emit — internal invariant violated",
+                    )));
+                }
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+
+        let chunk_serial = batch.chunk_serial;
+        let stream_idx = batch.stream_idx;
+        // The batch's own `HeapSize`, matching the removal side and the measure
+        // the byte-bounded queues budget — see the note in `try_emit_complete`.
+        let batch_bytes: usize = batch.heap_size();
+
+        let n = self.n_streams;
+        let slots =
+            self.pending.entry(chunk_serial).or_insert_with(|| (0..n).map(|_| None).collect());
+        // `stream_idx` is set by the upstream splitter and is an invariant, not
+        // input — but indexing on a violated invariant would panic inside a
+        // worker. Fail closed with the step's own error path instead, keeping a
+        // `debug_assert!` so a violation is loud in development.
+        debug_assert!(stream_idx < n, "stream_idx {stream_idx} out of range for {n} streams");
+        let Some(slot) = slots.get_mut(stream_idx) else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("ZipFastqRecords: stream_idx {stream_idx} out of range for {n} streams"),
+            ));
+        };
+        *slot = Some(batch);
+        self.pending_total_bytes += batch_bytes;
+
+        // The new chunk may have completed the lowest serial. Run the full drain
+        // again so a completion is emitted immediately (one unified egress
+        // path). Held single-occupancy holds: the preamble guaranteed the slot
+        // empty and this drain only `put`s after a `take`-confirmed empty slot.
+        // Both drain outcomes are forward progress here — this dispatch consumed
+        // an input chunk, and `Held` additionally parked a freshly dequeued
+        // serial for retry — so report `Progress` either way (never `Contention`).
+        self.drain_complete(ctx)?;
+        Ok(StepOutcome::Progress)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fastq_parse::FastqRecord;
+    use crate::pipeline::core::item::Ordered;
+
+    fn make_record(name: &str, seq: &str) -> FastqRecord {
+        let qual: String = std::iter::repeat_n('I', seq.len()).collect();
+        let data = format!("@{name}\n{seq}\n+\n{qual}\n");
+        FastqRecord::from_slice(data.as_bytes()).unwrap()
+    }
+
+    fn make_chunk(
+        stream_idx: usize,
+        chunk_serial: u64,
+        records: Vec<FastqRecord>,
+    ) -> FastqChunkBatch {
+        let total_bytes: usize = records.iter().map(HeapSize::heap_size).sum();
+        // ZipFastqRecords joins by (stream_idx, chunk_serial) and does not read
+        // `ordinal`, so the per-chunk ordinal is irrelevant to the join. Derive
+        // a deterministic unique value for clarity.
+        let ordinal = chunk_serial * 8 + stream_idx as u64;
+        FastqChunkBatch::new(ordinal, stream_idx, chunk_serial, records, total_bytes)
+    }
+
+    #[test]
+    fn fastq_template_batch_heap_size_and_ordinal() {
+        let batch = FastqTemplateBatch::new(42, vec![]);
+        assert_eq!(batch.heap_size(), 0);
+        assert_eq!(batch.ordinal(), 42);
+    }
+
+    #[test]
+    fn test_zip_1_stream() {
+        let mut zip = ZipFastqRecords::new(1, 64 * 1024 * 1024);
+
+        let r1 = make_record("read1", "ACGT");
+        let r2 = make_record("read2", "TGCA");
+        let chunk = make_chunk(0, 0, vec![r1, r2]);
+
+        // Insert the chunk.
+        zip.pending.insert(0, vec![Some(chunk)]);
+
+        let batch = zip.try_emit_complete().unwrap().unwrap();
+        assert_eq!(batch.templates.len(), 2);
+        assert_eq!(batch.templates[0].name, b"read1");
+        assert_eq!(batch.templates[0].records.len(), 1);
+        assert_eq!(batch.templates[1].name, b"read2");
+        assert_eq!(batch.templates[1].records.len(), 1);
+        assert_eq!(batch.ordinal(), 0);
+    }
+
+    #[test]
+    fn test_zip_2_streams() {
+        let mut zip = ZipFastqRecords::new(2, 64 * 1024 * 1024);
+
+        let r1_s0 = make_record("read1/1", "ACGT");
+        let r2_s0 = make_record("read2/1", "TGCA");
+        let chunk_s0 = make_chunk(0, 0, vec![r1_s0, r2_s0]);
+
+        let r1_s1 = make_record("read1/2", "GGGG");
+        let r2_s1 = make_record("read2/2", "CCCC");
+        let chunk_s1 = make_chunk(1, 0, vec![r1_s1, r2_s1]);
+
+        zip.pending.insert(0, vec![Some(chunk_s0), Some(chunk_s1)]);
+
+        let batch = zip.try_emit_complete().unwrap().unwrap();
+        assert_eq!(batch.templates.len(), 2);
+        assert_eq!(batch.templates[0].name, b"read1");
+        assert_eq!(batch.templates[0].records.len(), 2);
+        assert_eq!(batch.templates[0].records[0].sequence(), b"ACGT");
+        assert_eq!(batch.templates[0].records[1].sequence(), b"GGGG");
+        assert_eq!(batch.templates[1].name, b"read2");
+        assert_eq!(batch.templates[1].records.len(), 2);
+    }
+
+    #[test]
+    fn test_zip_3_streams() {
+        let mut zip = ZipFastqRecords::new(3, 64 * 1024 * 1024);
+
+        let mk = |suffix: &str, seq: &str| make_record(&format!("read1{suffix}"), seq);
+        let chunk_s0 = make_chunk(0, 0, vec![mk("/1", "AAAA")]);
+        let chunk_s1 = make_chunk(1, 0, vec![mk("/2", "CCCC")]);
+        let chunk_s2 = make_chunk(2, 0, vec![mk("", "GGGG")]);
+
+        zip.pending.insert(0, vec![Some(chunk_s0), Some(chunk_s1), Some(chunk_s2)]);
+
+        let batch = zip.try_emit_complete().unwrap().unwrap();
+        assert_eq!(batch.templates.len(), 1);
+        assert_eq!(batch.templates[0].name, b"read1");
+        assert_eq!(batch.templates[0].records.len(), 3);
+    }
+
+    #[test]
+    fn test_zip_4_streams() {
+        let mut zip = ZipFastqRecords::new(4, 64 * 1024 * 1024);
+
+        let mk = |suffix: &str, seq: &str| make_record(&format!("readA{suffix}"), seq);
+        let chunk_s0 = make_chunk(0, 0, vec![mk("/1", "AAAA")]);
+        let chunk_s1 = make_chunk(1, 0, vec![mk("/2", "CCCC")]);
+        let chunk_s2 = make_chunk(2, 0, vec![mk("", "GGGG")]);
+        let chunk_s3 = make_chunk(3, 0, vec![mk("", "TTTT")]);
+
+        zip.pending.insert(0, vec![Some(chunk_s0), Some(chunk_s1), Some(chunk_s2), Some(chunk_s3)]);
+
+        let batch = zip.try_emit_complete().unwrap().unwrap();
+        assert_eq!(batch.templates.len(), 1);
+        assert_eq!(batch.templates[0].name, b"readA");
+        assert_eq!(batch.templates[0].records.len(), 4);
+    }
+
+    #[test]
+    fn test_zip_desync_bails() {
+        let mut zip = ZipFastqRecords::new(2, 64 * 1024 * 1024);
+
+        // Stream 0 has chunk_serial 0, stream 1 is missing.
+        let r1 = make_record("read1/1", "ACGT");
+        let chunk = make_chunk(0, 0, vec![r1]);
+        zip.pending.insert(0, vec![Some(chunk), None]);
+
+        // The drained-completion path in `try_run` walks `pending` and errors
+        // on a half-filled serial. Since we can't build a `StepCtx` here, test
+        // the pending state detection directly.
+        let slots = zip.pending.get(&0).unwrap();
+        let all_filled = slots.iter().all(Option::is_some);
+        assert!(!all_filled, "incomplete slot should be detected");
+
+        // Verify that try_emit_complete returns None for partial entries.
+        let result = zip.try_emit_complete().unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_zip_name_mismatch_errors() {
+        let mut zip = ZipFastqRecords::new(2, 64 * 1024 * 1024);
+
+        let r1_s0 = make_record("readA/1", "ACGT");
+        let r1_s1 = make_record("readB/2", "GGGG");
+        let chunk_s0 = make_chunk(0, 0, vec![r1_s0]);
+        let chunk_s1 = make_chunk(1, 0, vec![r1_s1]);
+
+        zip.pending.insert(0, vec![Some(chunk_s0), Some(chunk_s1)]);
+
+        let err = zip.try_emit_complete().unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("mismatch"), "expected name mismatch error, got: {msg}");
+    }
+
+    /// Within a complete chunk, unequal per-stream record counts are rejected
+    /// by the explicit strict count check (fgbio-consistent), not surfaced as a
+    /// name mismatch. Matches the `N==2` `ParseAndZipFastq` path.
+    #[test]
+    fn test_zip_unequal_counts_out_of_sync() {
+        let mut zip = ZipFastqRecords::new(2, 64 * 1024 * 1024);
+
+        // Same chunk_serial, both streams present, but stream 0 has 2 records
+        // and stream 1 has 1.
+        let s0 =
+            make_chunk(0, 0, vec![make_record("read1/1", "ACGT"), make_record("read2/1", "TT")]);
+        let s1 = make_chunk(1, 0, vec![make_record("read1/2", "GGGG")]);
+        zip.pending.insert(0, vec![Some(s0), Some(s1)]);
+
+        let err = zip.try_emit_complete().unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("out of sync"), "expected count out-of-sync error, got: {msg}");
+    }
+
+    #[test]
+    fn test_zip_multiple_serials_in_order() {
+        let mut zip = ZipFastqRecords::new(1, 64 * 1024 * 1024);
+
+        let chunk0 = make_chunk(0, 0, vec![make_record("read1", "AAAA")]);
+        let chunk1 = make_chunk(0, 1, vec![make_record("read2", "CCCC")]);
+
+        zip.pending.insert(0, vec![Some(chunk0)]);
+        zip.pending.insert(1, vec![Some(chunk1)]);
+
+        let batch0 = zip.try_emit_complete().unwrap().unwrap();
+        assert_eq!(batch0.ordinal(), 0);
+        assert_eq!(batch0.templates[0].name, b"read1");
+
+        let batch1 = zip.try_emit_complete().unwrap().unwrap();
+        assert_eq!(batch1.ordinal(), 1);
+        assert_eq!(batch1.templates[0].name, b"read2");
+    }
+
+    #[test]
+    fn profile_advertises_serial_byordinal() {
+        let step = ZipFastqRecords::new(2, 1024);
+        let p = step.profile();
+        assert_eq!(p.name, "ZipFastqRecords");
+        assert_eq!(p.kind, StepKind::Serial);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // S5a1-001 regression: lag-then-burst over the soft backpressure limit.
+    //
+    // The buggy code returned NoProgress/Err on backpressure *before* draining
+    // the (already-complete) lowest serial, so once `pending` crossed the soft
+    // limit with the lowest serial incomplete and input still queued, the step
+    // wedged forever (NoProgress on every re-dispatch, never popping the chunk
+    // that would complete the serial). The test below drives the REAL `try_run`
+    // through a `Pipeline` with a tiny soft limit and a lag-then-burst stream
+    // pattern; under the bug it deadlocks and the watchdog fires, under the fix
+    // it completes and emits every zipped template in order.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrd};
+
+    use crate::pipeline::core::step::Affinity;
+    use crate::pipeline::core::{PipelineBuilder, PipelineConfig};
+
+    /// `(batch_serial, template names)` recorded by the collecting sink.
+    type SeenBatches = Arc<Mutex<Vec<(u64, Vec<Vec<u8>>)>>>;
+
+    /// Bytes per FASTQ record this source emits. Sized so a small run of
+    /// records crosses the few-KiB soft limit the test sets on the zipper.
+    const TEST_RECORD_SEQ_LEN: usize = 200;
+    /// Number of chunk serials emitted per stream.
+    const TEST_N_SERIALS: u64 = 12;
+    /// Soft backpressure limit for the zipper under test. Sized so the lagging
+    /// streams (streams 0 and 1, `TEST_N_SERIALS` records each at
+    /// `TEST_RECORD_SEQ_LEN` bytes) cross the soft limit before the stream-2
+    /// burst arrives, yet stay UNDER the 2x hard-desync limit — the lag is a
+    /// legitimately-ahead in-sync stream, not a genuine desync, so the hard arm
+    /// must NOT fire. (~12 records/stream * 2 streams * ~280 B ≈ 6.7 KiB, which
+    /// is > soft (5 KiB) and < hard (10 KiB).)
+    const TEST_SOFT_LIMIT_BYTES: usize = 5 * 1024;
+
+    fn big_record(name: &str) -> FastqRecord {
+        let seq: String = std::iter::repeat_n('A', TEST_RECORD_SEQ_LEN).collect();
+        make_record(name, &seq)
+    }
+
+    /// Serial source that emits `FastqChunkBatch` items in a deliberately
+    /// skewed order: all of streams 0 and 1 (serials `0..N`) FIRST, then all of
+    /// stream 2 in a burst. The leading streams pile up incomplete lowest
+    /// serials in the zipper (stream 2's slot is missing) and push it over the
+    /// soft limit before the completing burst arrives.
+    struct LagThenBurstSource {
+        /// Emission plan: each entry is `(stream_idx, chunk_serial)`.
+        plan: Vec<(usize, u64)>,
+        next: usize,
+        ordinals: crate::pipeline::steps::source::read_fastq::FastqOrdinalSequence,
+        held: HeldSlot<Unpushed<FastqChunkBatch>>,
+        output_byte_limit: u64,
+    }
+
+    impl LagThenBurstSource {
+        fn new(n_serials: u64, n_streams_total: usize, output_byte_limit: u64) -> Self {
+            let mut plan = Vec::new();
+            // Streams 0..n-1 first (the "lag"): every serial of every leading
+            // stream before any of the final stream.
+            for stream_idx in 0..n_streams_total - 1 {
+                for serial in 0..n_serials {
+                    plan.push((stream_idx, serial));
+                }
+            }
+            // Final stream in a burst: a run of consecutive lowest serials
+            // becomes complete at once.
+            for serial in 0..n_serials {
+                plan.push((n_streams_total - 1, serial));
+            }
+            Self {
+                plan,
+                next: 0,
+                ordinals: crate::pipeline::steps::source::read_fastq::FastqOrdinalSequence::new(),
+                held: HeldSlot::new(),
+                output_byte_limit,
+            }
+        }
+
+        /// A plan in which only stream 0 ever emits, so the lowest serial can
+        /// never complete and `pending` grows without bound — a genuine desync,
+        /// as opposed to the in-sync-but-ahead lag the burst plan models.
+        fn with_only_the_first_stream(n_serials: u64, output_byte_limit: u64) -> Self {
+            let plan = (0..n_serials).map(|serial| (0usize, serial)).collect();
+            Self {
+                plan,
+                next: 0,
+                ordinals: crate::pipeline::steps::source::read_fastq::FastqOrdinalSequence::new(),
+                held: HeldSlot::new(),
+                output_byte_limit,
+            }
+        }
+
+        /// The same plan with the final stream stopped one serial short, so a
+        /// `pending` entry still has an empty slot when input drains — the
+        /// truncated-input shape the EOF-desync guard exists to diagnose.
+        fn with_final_stream_truncated(
+            n_serials: u64,
+            n_streams_total: usize,
+            output_byte_limit: u64,
+        ) -> Self {
+            let mut source = Self::new(n_serials, n_streams_total, output_byte_limit);
+            source.plan.pop().expect("plan is non-empty");
+            source
+        }
+    }
+
+    impl Step for LagThenBurstSource {
+        type Input = ();
+        type Outputs = OrderedBytesSingle<FastqChunkBatch>;
+
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "LagThenBurstSource",
+                kind: StepKind::Serial,
+                sticky: false,
+                output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+                branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+            }
+        }
+
+        fn affinity(&self) -> Affinity {
+            Affinity::Reader
+        }
+
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            if let Some(unpushed) = self.held.take() {
+                match ctx.outputs.retry(unpushed) {
+                    Ok(()) => {}
+                    Err(again) => {
+                        self.held.put(again);
+                        return Ok(StepOutcome::Contention);
+                    }
+                }
+            }
+
+            let Some(&(stream_idx, chunk_serial)) = self.plan.get(self.next) else {
+                return Ok(StepOutcome::Finished);
+            };
+            self.next += 1;
+
+            // Trailing non-digit so `strip_read_suffix` does not eat the serial
+            // (it strips a `_`/`/`/`.`/`:` + `1`/`2` pair-suffix).
+            let name = format!("read{chunk_serial}x");
+            let record = big_record(&name);
+            let total_bytes = record.heap_size();
+            // Draw from the same shared sequence production uses, so the
+            // harness cannot drift from what the reader emits. Ordinals follow
+            // emission order; the zipper keys on `chunk_serial`, so the skewed
+            // plan this source exists to produce is unaffected.
+            let ordinal = self.ordinals.next();
+            let chunk =
+                FastqChunkBatch::new(ordinal, stream_idx, chunk_serial, vec![record], total_bytes);
+
+            match ctx.outputs.push(chunk) {
+                Ok(()) => Ok(StepOutcome::Progress),
+                Err(unpushed) => {
+                    self.held.put(unpushed);
+                    Ok(StepOutcome::Progress)
+                }
+            }
+        }
+    }
+
+    /// Serial (single-consumer) sink that records, per emitted batch, its
+    /// `batch_serial` and the names of the templates it carries, so the test can
+    /// assert full drain and correct zipping/order. A `Serial` sink drains the
+    /// queue in FIFO order on one worker, so the recorded sequence is the true
+    /// emission order — letting the test assert ordering directly instead of
+    /// sorting (which would only prove set equality).
+    #[derive(Clone)]
+    struct CollectingSink {
+        seen: SeenBatches,
+        count: Arc<AtomicUsize>,
+    }
+
+    impl Step for CollectingSink {
+        type Input = FastqTemplateBatch;
+        type Outputs = ();
+
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "CollectingSink",
+                kind: StepKind::Serial,
+                sticky: false,
+                output_queues: vec![],
+                branch_ordering: vec![],
+            }
+        }
+
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            match ctx.input.pop() {
+                Some(batch) => {
+                    let names: Vec<Vec<u8>> =
+                        batch.templates.iter().map(|t| t.name.clone()).collect();
+                    self.seen.lock().unwrap().push((batch.batch_serial, names));
+                    self.count.fetch_add(1, AtomicOrd::Relaxed);
+                    Ok(StepOutcome::Progress)
+                }
+                None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+                None => Ok(StepOutcome::NoProgress),
+            }
+        }
+
+        fn new_worker_copy(&self) -> Self {
+            self.clone()
+        }
+    }
+
+    /// The soft-limit warning must fire once per over-limit *episode*, not once
+    /// per dispatch. The step is `Serial` and the driver re-dispatches it in a
+    /// tight loop, so an unlatched warning floods the log for the whole time an
+    /// ahead-but-in-sync stream sits over the limit — burying everything else.
+    #[test]
+    fn soft_limit_warning_latches_once_per_episode() {
+        let mut zip = ZipFastqRecords::new(1, 64 * 1024);
+
+        assert!(zip.enter_over_soft_limit(), "the dispatch that enters the episode must warn");
+        assert!(!zip.enter_over_soft_limit(), "a later dispatch in the same episode must not");
+        assert!(!zip.enter_over_soft_limit(), "nor any after that");
+
+        zip.leave_over_soft_limit();
+
+        assert!(zip.enter_over_soft_limit(), "a fresh episode must warn again");
+    }
+
+    /// Sized so a stream-0-only plan clears the 2x hard-desync ceiling with room
+    /// to spare: 12 serials * ~280 B/record is ~3.4 KB, well past 2 * 512 B.
+    /// Deliberately not `TEST_SOFT_LIMIT_BYTES` — that one is tuned so the
+    /// lag-then-burst case stays *under* the hard ceiling.
+    const TEST_HARD_ABORT_LIMIT_BYTES: usize = 512;
+
+    /// A genuinely desynced stream must abort, and this is the only bound on
+    /// `pending`.
+    ///
+    /// The soft limit deliberately does not refuse ingress — doing so deadlocks,
+    /// since the chunk that completes the lowest serial is itself still queued
+    /// upstream — so this 2x abort is what stops an unbounded buffer. Its
+    /// predicate is a conjunction (lowest serial still incomplete after a full
+    /// drain AND bytes past 2x), and a regression weakening either half, or
+    /// reverting to a bytes-only predicate, would leave the suite green while
+    /// removing the ceiling entirely.
+    ///
+    /// This pins the direction `zip_does_not_deadlock_on_lag_then_burst_over_soft_limit`
+    /// cannot: that test proves the abort does *not* fire for an ahead-but-in-sync
+    /// stream. Together they fix both sides of the predicate.
+    #[test]
+    fn zip_aborts_on_a_genuine_stream_desync() {
+        let n_streams = 2usize;
+        let seen = Arc::new(Mutex::new(Vec::<(u64, Vec<Vec<u8>>)>::new()));
+        let count = Arc::new(AtomicUsize::new(0));
+
+        // Only stream 0 emits, so serial 0 never completes and every chunk stays
+        // resident in `pending`.
+        let source = LagThenBurstSource::with_only_the_first_stream(TEST_N_SERIALS, 64 * 1024);
+        let zip = ZipFastqRecords::new(n_streams, 64 * 1024)
+            .with_backpressure_bytes(TEST_HARD_ABORT_LIMIT_BYTES);
+        let sink = CollectingSink { seen: Arc::clone(&seen), count: Arc::clone(&count) };
+
+        let builder = PipelineBuilder::new();
+        builder.chain(source).chain(zip).chain(sink).into_sink_marker();
+        let pipeline = builder.build().expect("chain builds");
+
+        let err = pipeline
+            .run(PipelineConfig { threads: 2, ..Default::default() })
+            .expect_err("a one-sided stream must abort rather than buffer without bound");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("catastrophic stream desync"),
+            "expected the hard 2x desync abort, got: {msg}"
+        );
+    }
+
+    /// A stream that ends before its counterparts must fail the run with a
+    /// diagnosable message rather than silently dropping the unmatched records.
+    ///
+    /// This is the guard that turns a truncated FASTQ input — one file cut short,
+    /// a partial download — into an error naming the stream and serial. It sits
+    /// on the input-drained path inside `try_run`, so it needs a real `Pipeline`
+    /// to reach: the `try_emit_complete` unit tests above cannot drive it.
+    #[test]
+    fn zip_reports_a_stream_that_ends_early() {
+        let n_streams = 2usize;
+        let seen = Arc::new(Mutex::new(Vec::<(u64, Vec<Vec<u8>>)>::new()));
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let source =
+            LagThenBurstSource::with_final_stream_truncated(TEST_N_SERIALS, n_streams, 64 * 1024);
+        let zip = ZipFastqRecords::new(n_streams, 64 * 1024);
+        let sink = CollectingSink { seen: Arc::clone(&seen), count: Arc::clone(&count) };
+
+        let builder = PipelineBuilder::new();
+        builder.chain(source).chain(zip).chain(sink).into_sink_marker();
+        let pipeline = builder.build().expect("chain builds");
+
+        let err = pipeline
+            .run(PipelineConfig { threads: 2, ..Default::default() })
+            .expect_err("a stream that ends early must fail the run");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ended before"),
+            "expected the EOF-desync diagnosis naming the stream and serial, got: {msg}"
+        );
+    }
+
+    /// Drive `ZipFastqRecords` through a real `Pipeline` under a lag-then-burst
+    /// stream pattern that crosses its (shrunk) soft backpressure limit, on a
+    /// watchdog thread so a deadlock regression surfaces as a timeout rather
+    /// than hanging the test runner.
+    ///
+    /// Pre-fix this deadlocks: the zipper crosses the soft limit while the
+    /// lowest serial is incomplete, returns `NoProgress` before draining/popping,
+    /// and never admits the completing burst → the watchdog fires. Post-fix the
+    /// advisory soft limit admits the completing chunks, egress fully drains,
+    /// and the run completes with every template zipped in order.
+    #[test]
+    fn zip_does_not_deadlock_on_lag_then_burst_over_soft_limit() {
+        use std::time::{Duration, Instant};
+
+        let n_streams = 3usize;
+        let seen = Arc::new(Mutex::new(Vec::<(u64, Vec<Vec<u8>>)>::new()));
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let seen_for_thread = Arc::clone(&seen);
+        let count_for_thread = Arc::clone(&count);
+        let worker = std::thread::Builder::new()
+            .name("zip-lag-burst".into())
+            .spawn(move || -> io::Result<()> {
+                let source = LagThenBurstSource::new(TEST_N_SERIALS, n_streams, 64 * 1024);
+                let zip = ZipFastqRecords::new(n_streams, 64 * 1024)
+                    .with_backpressure_bytes(TEST_SOFT_LIMIT_BYTES);
+                let sink = CollectingSink { seen: seen_for_thread, count: count_for_thread };
+
+                let builder = PipelineBuilder::new();
+                builder.chain(source).chain(zip).chain(sink).into_sink_marker();
+                let pipeline = builder.build().map_err(io::Error::other)?;
+                // A modest thread count keeps the Serial zipper single-driven
+                // while letting the source/sink run on other workers.
+                pipeline
+                    .run(PipelineConfig { threads: 2, ..Default::default() })
+                    .map_err(io::Error::other)
+            })
+            .expect("spawn pipeline worker");
+
+        // Generous timeout: the run completes in well under a second on a
+        // healthy system; 30 s leaves headroom for slow CI while still failing
+        // fast on the deadlock regression.
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while !worker.is_finished() {
+            assert!(
+                Instant::now() < deadline,
+                "ZipFastqRecords pipeline did not finish within 30s — likely the S5a1-001 \
+                 backpressure-starves-egress deadlock regression"
+            );
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        worker.join().expect("pipeline thread panicked").expect("pipeline run returned Err");
+
+        // Full drain: one batch per serial, exactly TEST_N_SERIALS batches.
+        let seen = seen.lock().unwrap().clone();
+        assert_eq!(
+            seen.len(),
+            usize::try_from(TEST_N_SERIALS).unwrap(),
+            "expected one emitted batch per serial (full drain), got {}",
+            seen.len()
+        );
+
+        // Correctness + order: the single-consumer sink records the true emission
+        // order, so assert `batch_serial`s are contiguous 0..N directly (no sort)
+        // — proving `ZipFastqRecords` emits in order, not merely as a set. Each
+        // batch carries the single expected zipped template `read_<serial>`.
+        for (i, (serial, names)) in seen.iter().enumerate() {
+            assert_eq!(*serial, i as u64, "batch serials must be contiguous and in order");
+            assert_eq!(names.len(), 1, "each chunk carried exactly one record");
+            assert_eq!(
+                names[0],
+                format!("read{i}x").into_bytes(),
+                "template name must match the source record for serial {i}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
**Stacked on #735** (R1a). Review that first; this PR's diff is against it.

Additive — nothing in `src/lib/commands` routes through the new tree, so every command still runs on `unified_pipeline`.

## What

- `steps/source/` (8 files, ~3,650 lines): `ReadFastqInputs` (FASTQ readers), `PairRawFastq` (serial chunk-level pairing that mints the globally-unique ordinal), `ParseAndZipFastq` (parallel parse + template zip), `read_sam_chunks`, `zip_fastq`, `parse_fastq`, plus a re-export shim for the BAM source that already lives in `fgumi-pipeline-io`.
- `HeapSize` for `FastqRecord` and `FastqTemplate` — separate commit.

## The `HeapSize` commit

The framework byte-bounds its queues on `HeapSize`. Both types implement only `MemoryEstimate`, which the framework cannot see. The new impls **delegate** to `MemoryEstimate::estimate_heap_size` rather than restating the computation, so the queue budget and the memory estimate cannot drift apart. This mirrors the treatment `Template` received in #735.

## Deltas from `feat-runall`

Both forced by this branch's stricter gate, and both noted in the commit message:

1. **Four nested `if`s in `pair_fastq.rs` become let-chains.** The source predates the toolchain that unlocked them; `ci-lint` rejects the nested form as `collapsible_if`. Per `CLAUDE.md` we adopt the idiom rather than suppress the lint.
2. **Three module-level intra-doc links gain reference-style definitions** (`ReadFastqInputs`, `ParseAndZipFastq`, `PairRawFastq`). They resolved only inside the item docs that already carried a definition; the module docs had none. `ci-doc` catches this here because this branch checks private-item links (#722) — `feat-runall` does not.

## Verification

- `cargo ci-fmt`, `cargo ci-lint`, `cargo ci-tag-literals` — clean
- `RUSTDOCFLAGS="-D warnings" cargo ci-doc` — clean
- `./scripts/publish-crates.sh --check` — clean
- `cargo ci-test` — **8303 passed**, 30 skipped (up 58 from #735's 8245; the ported steps bring their own tests)

## Remaining in R1

`group/`, `correct/`, and the closure-driven mid-steps; then `align_and_merge` + `src/lib/aligner.rs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: command output changes: none; `unsafe`: none, and `CLAUDE.md` allowlist changes: none; memory bounds and backpressure policy: changed through byte-bounded source queues and per-stream buffering. Fix: add typed read-side source steps while keeping command routing through `unified_pipeline`.

## Changes

- Added typed FASTQ source steps for reading, parsing, pairing, and zipping.
- Added SAM chunk reading and BAM source re-exports.
- Added `InputSource` for BAM/SAM detection, header access, stdin replay, and input validation.
- Added dense global FASTQ ordinals to prevent reorder hangs when streams end at different times.
- Added ordering, truncation, name, EOF, stream synchronization, and backpressure handling.
- Added `HeapSize` implementations for `FastqRecord` and `FastqTemplate`.
- Updated pipeline module documentation and exports.
- Added unit and end-to-end tests for source-chain behavior, malformed and empty input, chunk reconstruction, memory limits, and backpressure.

## Verification

Formatting, linting, tag checks, documentation, crate publishing checks, static checks, and tests pass. The suite reports 8,440 passing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->