### PR TITLE
fix(consensus)!: require mapped reads for consensus unless --allow-unmapped

### DIFF
--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -1088,16 +1088,50 @@ impl VanillaUmiConsensusCaller {
         if self.options.max_reads.is_some() { fgbio_read_name_rank(name) } else { 0 }
     }
 
+    /// Drops unmapped reads when the set also contains at least one mapped read.
+    ///
+    /// An unmapped read has no cigar, and an empty cigar is a prefix of every cigar, so
+    /// `select_most_common_alignment_group` would match it against whichever alignment group it
+    /// was tested against first rather than letting it form a group of its own. It would then
+    /// contribute bases and depth to the consensus with no alignment supporting it.
+    ///
+    /// A wholly unmapped set is returned untouched, so molecules from
+    /// `fgumi group --allow-unmapped` (e.g. ribosome display) still produce consensus reads.
+    ///
+    /// Returns the retained reads and the original indices of any dropped unmapped reads.
+    fn drop_unmapped_if_any_mapped(
+        &mut self,
+        source_reads: Vec<SourceRead>,
+    ) -> (Vec<SourceRead>, HashSet<usize>) {
+        let is_unmapped = |sr: &SourceRead| sr.flags & flags::UNMAPPED != 0;
+
+        if !source_reads.iter().any(is_unmapped) || source_reads.iter().all(is_unmapped) {
+            return (source_reads, HashSet::new());
+        }
+
+        let (retained, dropped): (Vec<SourceRead>, Vec<SourceRead>) =
+            source_reads.into_iter().partition(|sr| !is_unmapped(sr));
+
+        self.stats.record_rejection(RejectionReason::Unmapped, dropped.len());
+        (retained, dropped.into_iter().map(|sr| sr.original_idx).collect())
+    }
+
     /// Filters `SourceReads` to only include those with the most common alignment pattern.
     /// This matches fgbio's filterToMostCommonAlignment behavior.
+    ///
+    /// Unmapped reads are dropped first whenever any mapped read is present: fgumi always
+    /// prefers to build a consensus from mapped reads. A wholly unmapped set is left intact so
+    /// that `fgumi group --allow-unmapped` workflows still produce consensus reads.
     ///
     /// Returns the filtered `SourceReads` and a set of rejected original indices.
     fn filter_source_reads_by_alignment(
         &mut self,
         source_reads: Vec<SourceRead>,
     ) -> (Vec<SourceRead>, HashSet<usize>) {
+        let (source_reads, unmapped_rejected) = self.drop_unmapped_if_any_mapped(source_reads);
+
         if source_reads.len() < 2 {
-            return (source_reads, HashSet::new());
+            return (source_reads, unmapped_rejected);
         }
 
         // Create indexed data: (source_read_index, length, simplified_cigar)
@@ -1122,7 +1156,8 @@ impl VanillaUmiConsensusCaller {
 
         // Collect rejected original indices with pre-allocated capacity
         let rejected_count = source_reads.len().saturating_sub(keep_indices.len());
-        let mut rejected_original_indices = HashSet::with_capacity(rejected_count);
+        let mut rejected_original_indices = unmapped_rejected;
+        rejected_original_indices.reserve(rejected_count);
         for (i, sr) in source_reads.iter().enumerate() {
             if !keep_mask[i] {
                 rejected_original_indices.insert(sr.original_idx);

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -446,7 +446,7 @@ impl Command for Codec {
 
         // Use the raw_reader opened above (single input open). Apply the fgbio
         // pre-group filter: always drop secondary/supplementary; --allow-unmapped
-        // relaxes only the unmapped-without-mapped-mate rule.
+        // relaxes only the mapped-record rule.
         let allow_unmapped = self.allow_unmapped.enabled;
         let raw_record_iter = std::iter::from_fn(move || {
             loop {
@@ -688,7 +688,7 @@ impl Codec {
 
         // ========== grouper_fn ==========
         // Apply the fgbio pre-group filter (always drop secondary/supplementary;
-        // --allow-unmapped relaxes only the unmapped-without-mapped-mate rule).
+        // --allow-unmapped relaxes only the mapped-record rule).
         let allow_unmapped = self.allow_unmapped.enabled;
         let grouper_fn = move |_header: &Header| {
             let grouper = MiGrouper::new("MI", batch_size)
@@ -948,7 +948,7 @@ mod tests {
 
     /// The codec pre-group filter drops secondary/supplementary alignments before
     /// grouping (fgbio parity), and `--allow-unmapped` must **not** relax that
-    /// exclusion — it only relaxes the unmapped-without-mapped-mate rule.
+    /// exclusion — it only relaxes the mapped-record rule.
     ///
     /// This is the codec counterpart to simplex's
     /// `test_allow_unmapped_gates_pregroup_filter` /
@@ -1153,6 +1153,102 @@ mod tests {
         let r2 = to_record_buf(b2.build());
 
         (r1, r2)
+    }
+
+    /// A fully-unmapped primary pair (both ends `UNMAPPED`, both mates
+    /// `MATE_UNMAPPED`) sharing `mi_value`. Used to verify that `--allow-unmapped`
+    /// admits such a pair past the pre-group filter but the codec caller still
+    /// declines to call it.
+    fn create_codec_unmapped_pair(
+        mi_value: &str,
+        read_len: usize,
+        quals: &[u8],
+    ) -> (RecordBuf, RecordBuf) {
+        let seq_forward = b"ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT";
+        let seq = &seq_forward[..read_len];
+
+        let build = |flags: u16| {
+            let mut b = RawSamBuilder::new();
+            // ref_id/pos/mate_ref_id/mate_pos of -1 are BAM's "no alignment", and
+            // an unmapped record carries no cigar.
+            b.read_name(format!("read_{mi_value}").as_bytes())
+                .flags(flags)
+                .ref_id(-1)
+                .pos(-1)
+                .mapq(0)
+                .sequence(seq)
+                .qualities(quals)
+                .mate_ref_id(-1)
+                .mate_pos(-1)
+                .template_length(0);
+            b.add_string_tag(SamTag::MI, mi_value.as_bytes());
+            b.add_string_tag(SamTag::RG, b"A");
+            to_record_buf(b.build())
+        };
+
+        let r1 =
+            build(flags::PAIRED | flags::FIRST_SEGMENT | flags::UNMAPPED | flags::MATE_UNMAPPED);
+        let r2 =
+            build(flags::PAIRED | flags::LAST_SEGMENT | flags::UNMAPPED | flags::MATE_UNMAPPED);
+        (r1, r2)
+    }
+
+    /// `--allow-unmapped` admits unmapped primary records into grouping, but the
+    /// codec caller requires a mapped primary FR pair (`is_primary_fr_pair_raw`
+    /// rejects an unmapped read or an unmapped mate), so `codec` emits no
+    /// consensus for a fully-unmapped pair however the flag is set.
+    ///
+    /// This pins the split documented on
+    /// [`consensus_pregroup_keep_flags`](crate::commands::common::consensus_pregroup_keep_flags):
+    /// the flag governs the *filter*, the caller governs whether a consensus is
+    /// produced. `raw_reads_considered` counts post-filter reads, so the two
+    /// assertions separate the two stages — with the flag on, both reads reach
+    /// the caller and are still not called; with it off, the filter drops them
+    /// before grouping.
+    #[rstest]
+    #[case::default_filters_before_grouping(false, 0)]
+    #[case::allow_unmapped_admits_then_caller_rejects(true, 2)]
+    fn test_codec_emits_no_consensus_for_unmapped_pair(
+        #[case] allow_unmapped: bool,
+        #[case] expected_reads_considered: u64,
+    ) -> Result<()> {
+        let dir = TempDir::new()?;
+        let input_path = dir.path().join("input.bam");
+        let output_path = dir.path().join("output.bam");
+        let stats_path = dir.path().join("stats.txt");
+
+        let (r1, r2) = create_codec_unmapped_pair("UMI001", 20, &[30; 20]);
+        write_codec_bam(&input_path, vec![r1, r2])?;
+
+        let mut cmd = create_codec_with_paths(input_path, output_path);
+        cmd.allow_unmapped.enabled = allow_unmapped;
+        cmd.stats_opts.stats = Some(stats_path.clone());
+        cmd.read_group.read_name_prefix = Some("codec".to_string());
+        cmd.outer_bases_length = 0;
+        cmd.execute("test")?;
+
+        let kv_metrics: Vec<ConsensusKvMetric> = DelimFile::default().read_tsv(&stats_path)?;
+        let value_for = |key: &str| -> u64 {
+            kv_metrics
+                .iter()
+                .find(|m| m.key == key)
+                .unwrap_or_else(|| panic!("stats file should contain a `{key}` row"))
+                .value
+                .parse()
+                .unwrap_or_else(|_| panic!("`{key}` value should be an integer"))
+        };
+        assert_eq!(
+            value_for("raw_reads_considered"),
+            expected_reads_considered,
+            "--allow-unmapped governs only the pre-group filter (allow_unmapped={allow_unmapped})"
+        );
+        assert_eq!(
+            value_for("consensus_reads_emitted"),
+            0,
+            "the codec caller never calls a fully-unmapped pair (allow_unmapped={allow_unmapped})"
+        );
+
+        Ok(())
     }
 
     /// A mapped supplementary alignment of R1 (`SUPPLEMENTARY` flag set) sharing

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -345,18 +345,33 @@ fn header_sort_and_group_order(header: &Header) -> (String, String, Option<Strin
 
 /// The fgbio `ConsensusCallingIterator` pre-group filter
 /// (`ConsensusCallingIterator.scala:56-58`): drop secondary/supplementary
-/// alignments and any record that is unmapped **and** lacks a mapped mate.
+/// alignments and any record that is unmapped.
 ///
 /// fgbio applies this to *every* consensus caller (simplex, duplex, codec),
 /// for both the single- and multi-threaded execution paths, before grouping
 /// reads by molecular identifier. fgumi replicates it in the consensus
 /// commands.
 ///
-/// `--allow-unmapped` relaxes **only** the unmapped-without-mapped-mate rule so
-/// fully-unmapped input can be consensus-called (mirroring
-/// `fgumi group --allow-unmapped`). Secondary/supplementary alignments are
-/// **always** dropped, matching fgbio — `--allow-unmapped` never lets
-/// non-primary alignments into grouping.
+/// An unmapped record is dropped even when its mate is mapped. It has no cigar,
+/// and an empty cigar is a prefix of every cigar, so it would match every
+/// alignment group in `select_most_common_alignment_group` rather than forming
+/// one of its own, and would contribute bases and depth to the consensus with no
+/// alignment supporting it. The *mapped* end of a half-mapped pair is still kept.
+/// See fulcrumgenomics/fgbio#1168.
+///
+/// `--allow-unmapped` relaxes **only** the mapped-record rule, admitting
+/// unmapped primary records into grouping (mirroring `fgumi group
+/// --allow-unmapped`). Whether they then produce a consensus is the *caller's*
+/// decision, and the callers differ: `VanillaUmiConsensusCaller` (simplex and
+/// duplex) calls fully-unmapped input, while `CodecConsensusCaller` requires a
+/// mapped primary FR pair and rejects anything else as
+/// `CallerRejectionReason::NotPrimaryFrPair`, so `codec` emits no consensus for
+/// an unmapped pair however the flag is set. Where unmapped input *is* called,
+/// unmapped reads never displace mapped ones: within any set being consensus
+/// called, `VanillaUmiConsensusCaller::drop_unmapped_if_any_mapped` prefers the
+/// mapped reads. Secondary/supplementary alignments are **always** dropped,
+/// matching fgbio — `--allow-unmapped` never lets non-primary alignments into
+/// grouping.
 ///
 /// Returns `true` if the record should be kept.
 #[must_use]
@@ -367,13 +382,12 @@ pub fn consensus_pregroup_keep_flags(flags: u16, allow_unmapped: bool) -> bool {
     if flags & flags::SECONDARY != 0 || flags & flags::SUPPLEMENTARY != 0 {
         return false;
     }
-    // --allow-unmapped relaxes only the mapped-or-mate-mapped eligibility check.
+    // --allow-unmapped relaxes only the mapped-record rule. Without it a primary
+    // record is kept only when it is itself mapped; a mapped mate is not an exception.
     if allow_unmapped {
         return true;
     }
-    let is_mapped = flags & flags::UNMAPPED == 0;
-    let has_mapped_mate = flags & flags::PAIRED != 0 && flags & flags::MATE_UNMAPPED == 0;
-    is_mapped || has_mapped_mate
+    flags & flags::UNMAPPED == 0
 }
 
 /// Raw-BAM-bytes wrapper around [`consensus_pregroup_keep_flags`], suitable as
@@ -848,11 +862,13 @@ pub struct CompressionOptions {
 /// (name, default, and boolean parsing) stays identical across all three.
 #[derive(Debug, Clone, Args)]
 pub struct AllowUnmappedOptions {
-    /// Process reads that are unmapped and lack a mapped mate. By default
-    /// (fgbio parity, `ConsensusCallingIterator.scala:56-58`) such reads — and
-    /// all secondary/supplementary alignments — are dropped before consensus
-    /// calling. Enable for consensus on unmapped input (e.g. ribosome/protein
-    /// display), mirroring `fgumi group --allow-unmapped`.
+    /// Process unmapped reads. By default (fgbio parity,
+    /// `ConsensusCallingIterator.scala:56-58`) an unmapped read is dropped before
+    /// consensus calling whether or not its mate is mapped, as are all
+    /// secondary/supplementary alignments. Enable for consensus on unmapped input
+    /// (e.g. ribosome/protein display), mirroring `fgumi group --allow-unmapped`.
+    /// Note that `codec` requires a mapped FR pair, so it emits no consensus for
+    /// an unmapped pair even with this flag.
     #[arg(long = "allow-unmapped", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub enabled: bool,
 }
@@ -2193,12 +2209,14 @@ mod tests {
     use rstest::rstest;
 
     /// The `ConsensusCallingIterator` pre-group filter (fgbio parity,
-    /// `ConsensusCallingIterator.scala:56-58`): secondary and supplementary alignments are
-    /// always dropped, and an unmapped read is kept only when it has a mapped mate.
+    /// `ConsensusCallingIterator.scala:56-58`): the default keeps only mapped primary
+    /// records. Secondary and supplementary alignments are always dropped, and an
+    /// unmapped read is dropped whether or not its mate is mapped — a mapped mate is
+    /// not an exception, because the unmapped end has no cigar to group on.
     ///
     /// `--allow-unmapped` (the `allow_unmapped` column) relaxes **only** the
-    /// unmapped-without-mapped-mate rule: it makes otherwise-eligible primary alignments pass
-    /// regardless of mapping, but secondary/supplementary alignments are still dropped. The
+    /// mapped-record rule: it makes primary alignments pass regardless of mapping, but
+    /// secondary/supplementary alignments are still dropped. The
     /// `*_dropped_even_with_allow_unmapped` cases pin that the flag never lets a non-primary
     /// alignment into grouping (the regression this exists to prevent).
     #[rstest]
@@ -2212,8 +2230,15 @@ mod tests {
         false,
         false
     )]
-    #[case::unmapped_paired_mate_mapped_kept(
+    // The unmapped end of a half-mapped pair is dropped along with any other unmapped record: it
+    // has no cigar to group on. The mapped end is kept, since it is mapped in its own right.
+    #[case::unmapped_paired_mate_mapped_dropped(
         fgumi_raw_bam::flags::UNMAPPED | fgumi_raw_bam::flags::PAIRED,
+        false,
+        false
+    )]
+    #[case::mapped_paired_mate_unmapped_kept(
+        fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::MATE_UNMAPPED,
         false,
         true
     )]

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -467,7 +467,7 @@ impl Command for Duplex {
 
         // Use the raw_reader opened above (single input open). Apply the fgbio
         // pre-group filter: always drop secondary/supplementary; --allow-unmapped
-        // relaxes only the unmapped-without-mapped-mate rule.
+        // relaxes only the mapped-record rule.
         let allow_unmapped = self.allow_unmapped.enabled;
         let raw_record_iter = std::iter::from_fn(move || {
             loop {
@@ -696,7 +696,7 @@ impl Duplex {
         let batch_size = 100; // MI groups per batch
 
         // Apply the fgbio pre-group filter: always drop secondary/supplementary;
-        // --allow-unmapped relaxes only the unmapped-without-mapped-mate rule.
+        // --allow-unmapped relaxes only the mapped-record rule.
         let allow_unmapped = self.allow_unmapped.enabled;
 
         // MI transform for raw bytes: strip /A and /B suffixes for duplex grouping
@@ -1483,9 +1483,9 @@ mod tests {
 
     /// The `--allow-unmapped` flag gates the fgbio pre-group filter for duplex.
     /// The same AB/BA molecule as `test_duplex_consensus_basic_ab_ba_pairing`,
-    /// but with every read unmapped (and no mapped mate): dropped by default
-    /// (fgbio parity), consensus-called with `--allow-unmapped`. Covers both
-    /// the single-threaded fast path and the multi-threaded pipeline path.
+    /// but with every read unmapped: dropped by default (fgbio parity),
+    /// consensus-called with `--allow-unmapped`. Covers both the single-threaded
+    /// fast path and the multi-threaded pipeline path.
     #[rstest]
     #[case::fast_path(ThreadingOptions::none())]
     #[case::threaded(ThreadingOptions::new(2))]

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -403,7 +403,7 @@ impl Command for Simplex {
 
         // Use the raw_reader opened above (single input open). Apply the fgbio
         // pre-group filter: always drop secondary/supplementary; --allow-unmapped
-        // relaxes only the unmapped-without-mapped-mate rule.
+        // relaxes only the mapped-record rule.
         let allow_unmapped = self.allow_unmapped.enabled;
         let raw_record_iter = std::iter::from_fn(move || {
             loop {
@@ -610,7 +610,7 @@ impl Simplex {
 
         // ========== grouper_fn ==========
         // Apply the fgbio pre-group filter (always drop secondary/supplementary;
-        // --allow-unmapped relaxes only the unmapped-without-mapped-mate rule).
+        // --allow-unmapped relaxes only the mapped-record rule).
         let allow_unmapped = self.allow_unmapped.enabled;
         let grouper_fn = move |_header: &Header| {
             let grouper = MiGrouper::new("MI", batch_size)

--- a/tests/integration/test_codec_command.rs
+++ b/tests/integration/test_codec_command.rs
@@ -896,3 +896,107 @@ fn test_codec_command_recovers_from_duplex_disagreement_threaded() {
         "both generated reads (R1 and R2) should be present in the rejects BAM"
     );
 }
+
+/// Builds a CODEC pair whose R2 is unmapped, matching the geometry of
+/// [`create_codec_read_pair`] so it lands in the same molecule.
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+fn create_half_mapped_codec_pair(
+    name: &str,
+    r1_seq: &[u8],
+    r2_seq: &[u8],
+    ref_start: usize,
+    umi: &str,
+) -> (RawRecord, RawRecord) {
+    let r1_len = r1_seq.len();
+    let r2_len = r2_seq.len();
+    let r1_cigar_op = u32::try_from(r1_len).expect("r1_len fits u32") << 4;
+    let pos = i32::try_from(ref_start).expect("ref_start fits i32") - 1;
+
+    let mut b1 = SamBuilder::new();
+    b1.read_name(name.as_bytes())
+        .sequence(r1_seq)
+        .qualities(&vec![30u8; r1_len])
+        .cigar_ops(&[r1_cigar_op])
+        .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT | raw_flags::MATE_REVERSE)
+        .ref_id(0)
+        .pos(pos)
+        .mapq(60)
+        .mate_ref_id(0)
+        .mate_pos(pos)
+        .template_length(r1_len as i32)
+        .add_string_tag(SamTag::MI, umi.as_bytes());
+
+    let mut b2 = SamBuilder::new();
+    b2.read_name(name.as_bytes())
+        .sequence(r2_seq)
+        .qualities(&vec![30u8; r2_len])
+        .flags(
+            raw_flags::PAIRED | raw_flags::LAST_SEGMENT | raw_flags::REVERSE | raw_flags::UNMAPPED,
+        )
+        .ref_id(0)
+        .pos(pos)
+        .mapq(0)
+        .mate_ref_id(0)
+        .mate_pos(pos)
+        .template_length(-(r2_len as i32))
+        .add_string_tag(SamTag::MI, umi.as_bytes());
+
+    (b1.build(), b2.build())
+}
+
+/// Neither end of a half-mapped pair may contribute to a CODEC consensus when mapped reads are
+/// present in the same molecule. fgumi always prefers mapped reads.
+#[test]
+fn test_codec_ignores_half_mapped_pair_when_mapped_reads_present() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    let mut pairs = Vec::new();
+    for i in 0..2 {
+        pairs.push(create_codec_read_pair(
+            &format!("mapped{i}"),
+            b"ACGTACGT",
+            b"ACGTACGT",
+            &[30; 8],
+            &[30; 8],
+            100,
+            "UMI001",
+            None,
+        ));
+    }
+    pairs.push(create_half_mapped_codec_pair(
+        "halfmapped",
+        b"ACGTACGT",
+        b"TTTTTTTT",
+        100,
+        "UMI001",
+    ));
+    create_codec_test_bam(&input_bam, pairs);
+
+    let cmd = Codec::try_parse_from([
+        "codec",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--min-duplex-length",
+        "1",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse codec args");
+    cmd.execute("fgumi codec").expect("Failed to run codec command");
+
+    let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    let _header = reader.read_header().unwrap();
+    let records: Vec<bam::Record> =
+        reader.records().map(|r| r.expect("failed to read record")).collect();
+    assert_eq!(records.len(), 1, "expected a single CODEC consensus read");
+
+    // Only the two fully mapped pairs contribute to each single-strand consensus.
+    assert_eq!(int_tag(&records[0], SamTag::AD), 2, "R1 strand must use only the mapped reads");
+    assert_eq!(int_tag(&records[0], SamTag::BD), 2, "R2 strand must use only the mapped reads");
+}

--- a/tests/integration/test_duplex_command.rs
+++ b/tests/integration/test_duplex_command.rs
@@ -1349,6 +1349,9 @@ fn test_duplex_ignores_unmapped_end_when_mapped_reads_present() {
     // All three AB-R1s are mapped, so all three contribute to R1's AB single-strand consensus.
     assert_eq!(depth(r1, SamTag::AD), 3, "R1 should use all three mapped AB reads");
 
-    // Only the two mapped AB-R2s may contribute to R2's AB single-strand consensus.
+    // Only the two mapped AB-R2s may contribute to R2's AB single-strand consensus. AD is the
+    // oracle here rather than the emitted bases: the record's SEQ is the *duplex* consensus of
+    // the AB and BA strands, so it does not expose the AB single-strand bases this test is about.
+    // (The simplex counterpart can assert bases because it has only one strand.)
     assert_eq!(depth(r2, SamTag::AD), 2, "R2 must use only the two mapped AB reads");
 }

--- a/tests/integration/test_duplex_command.rs
+++ b/tests/integration/test_duplex_command.rs
@@ -1203,3 +1203,152 @@ fn test_duplex_command_emits_unmapped_consensus_header(#[case] threads: Option<&
         }
     }
 }
+
+/// Builds an A-strand pair whose R2 is unmapped, matching the geometry of
+/// [`create_duplex_read_pair_with_sequences`] so it lands in the same molecule.
+///
+/// The R2 keeps its REVERSE flag so strand grouping is unaffected; only the mapping is removed.
+fn create_half_mapped_a_strand_pair(
+    name: &str,
+    mi_tag: &str,
+    r1_sequence: &str,
+    r2_sequence: &str,
+    quality: u8,
+    ref_start: i32,
+) -> (RawRecord, RawRecord) {
+    let read_len = r1_sequence.len();
+    let cigar_op = u32::try_from(read_len).expect("read_len fits u32") << 4;
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap,
+        reason = "test data with known small values"
+    )]
+    let tlen: i32 = (read_len + 100) as i32;
+
+    let r1 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .sequence(r1_sequence.as_bytes())
+            .qualities(&vec![quality; read_len])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .ref_id(0)
+            .pos(ref_start - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar_op])
+            .mate_ref_id(0)
+            .mate_pos(ref_start + 100 - 1)
+            .template_length(tlen)
+            .add_string_tag(SamTag::MI, mi_tag.as_bytes());
+        b.build()
+    };
+
+    let r2 = {
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .sequence(r2_sequence.as_bytes())
+            .qualities(&vec![quality; read_len])
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE | flags::UNMAPPED)
+            .ref_id(0)
+            .pos(ref_start + 100 - 1)
+            .mapq(0)
+            .mate_ref_id(0)
+            .mate_pos(ref_start - 1)
+            .template_length(-tlen)
+            .add_string_tag(SamTag::MI, mi_tag.as_bytes());
+        b.build()
+    };
+
+    (r1, r2)
+}
+
+/// The unmapped end of a half-mapped pair must not contribute to a single-strand consensus when
+/// mapped reads are present on that strand. fgumi always prefers mapped reads.
+#[test]
+fn test_duplex_ignores_unmapped_end_when_mapped_reads_present() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    let molecule = vec![
+        create_duplex_read_pair_with_sequences(
+            "ab1",
+            "1/A",
+            "ACGTACGTAC",
+            "GGGGGGGGGG",
+            30,
+            100,
+            false,
+        ),
+        create_duplex_read_pair_with_sequences(
+            "ab2",
+            "1/A",
+            "ACGTACGTAC",
+            "GGGGGGGGGG",
+            30,
+            100,
+            false,
+        ),
+        create_half_mapped_a_strand_pair("ab3", "1/A", "ACGTACGTAC", "TTTTTTTTTT", 30, 100),
+        create_duplex_read_pair_with_sequences(
+            "ba1",
+            "1/B",
+            "ACGTACGTAC",
+            "GGGGGGGGGG",
+            30,
+            100,
+            true,
+        ),
+        create_duplex_read_pair_with_sequences(
+            "ba2",
+            "1/B",
+            "ACGTACGTAC",
+            "GGGGGGGGGG",
+            30,
+            100,
+            true,
+        ),
+    ];
+    create_duplex_bam(&input_bam, vec![molecule]);
+
+    let cmd = Duplex::try_parse_from([
+        "duplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse duplex args");
+    cmd.execute("fgumi duplex").expect("Duplex command failed");
+
+    let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    let _header = reader.read_header().unwrap();
+    let records: Vec<bam::Record> =
+        reader.records().map(|r| r.expect("failed to read record")).collect();
+    assert_eq!(records.len(), 2, "expected one duplex consensus read pair");
+
+    let depth = |record: &bam::Record, tag: SamTag| -> i64 {
+        match record.data().get(&tag.to_noodles_tag()) {
+            Some(Ok(value)) => value.as_int().expect("depth tag must be an integer"),
+            other => panic!("record must carry an integer {tag:?} tag, got {other:?}"),
+        }
+    };
+
+    let r1 = records
+        .iter()
+        .find(|r| r.flags().bits() & flags::FIRST_SEGMENT != 0)
+        .expect("missing R1 consensus");
+    let r2 = records
+        .iter()
+        .find(|r| r.flags().bits() & flags::LAST_SEGMENT != 0)
+        .expect("missing R2 consensus");
+
+    // All three AB-R1s are mapped, so all three contribute to R1's AB single-strand consensus.
+    assert_eq!(depth(r1, SamTag::AD), 3, "R1 should use all three mapped AB reads");
+
+    // Only the two mapped AB-R2s may contribute to R2's AB single-strand consensus.
+    assert_eq!(depth(r2, SamTag::AD), 2, "R2 must use only the two mapped AB reads");
+}

--- a/tests/integration/test_simplex_command.rs
+++ b/tests/integration/test_simplex_command.rs
@@ -482,3 +482,213 @@ fn test_simplex_command_rejects_inherits_input_read_groups() {
         "expected the singleton family in rejects, got {reject_names:?}",
     );
 }
+
+/// Builds a tag family of `mapped_pairs` fully mapped pairs plus one pair whose R2 is unmapped.
+///
+/// The mapped R2s carry `r2_mapped_seq` and the unmapped R2 carries `r2_unmapped_seq`, so the
+/// emitted R2 consensus shows which reads contributed to it. All records share one position so
+/// they land in a single tag family.
+fn half_mapped_family(
+    mapped_pairs: usize,
+    r1_seq: &str,
+    r2_mapped_seq: &str,
+    r2_unmapped_seq: &str,
+) -> Vec<fgumi_raw_bam::RawRecord> {
+    use fgumi_raw_bam::{SamBuilder, flags};
+
+    let r1_cigar = u32::try_from(r1_seq.len()).expect("fits u32") << 4;
+    let r2_cigar = u32::try_from(r2_mapped_seq.len()).expect("fits u32") << 4;
+    let template_len = i32::try_from(100 + r2_mapped_seq.len()).expect("fits i32");
+    let mut records = Vec::new();
+
+    let mut push_pair = |name: &str, r2_seq: &str, r2_unmapped: bool| {
+        let mut b1 = SamBuilder::new();
+        b1.read_name(name.as_bytes())
+            .ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+            .mate_ref_id(0)
+            .mate_pos(199)
+            .template_length(template_len)
+            .cigar_ops(&[r1_cigar])
+            .sequence(r1_seq.as_bytes())
+            .qualities(&vec![30u8; r1_seq.len()])
+            .add_string_tag(SamTag::RX, b"ACGT");
+        records.push(b1.build());
+
+        let mut b2 = SamBuilder::new();
+        let r2_flags = if r2_unmapped {
+            flags::PAIRED | flags::LAST_SEGMENT | flags::UNMAPPED
+        } else {
+            flags::PAIRED | flags::LAST_SEGMENT
+        };
+        b2.read_name(name.as_bytes())
+            .ref_id(0)
+            .pos(199)
+            .mapq(if r2_unmapped { 0 } else { 60 })
+            .flags(r2_flags)
+            .mate_ref_id(0)
+            .mate_pos(99)
+            .template_length(-template_len)
+            .sequence(r2_seq.as_bytes())
+            .qualities(&vec![30u8; r2_seq.len()])
+            .add_string_tag(SamTag::RX, b"ACGT");
+        if !r2_unmapped {
+            b2.cigar_ops(&[r2_cigar]);
+        }
+        records.push(b2.build());
+    };
+
+    for i in 0..mapped_pairs {
+        push_pair(&format!("mapped_{i}"), r2_mapped_seq, false);
+    }
+    push_pair("halfmapped", r2_unmapped_seq, true);
+
+    records
+}
+
+/// The unmapped end of a half-mapped pair must not contribute to a consensus when mapped reads
+/// are present in the same family. fgumi always prefers mapped reads.
+#[test]
+fn test_simplex_ignores_unmapped_end_when_mapped_reads_present() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    let family = half_mapped_family(2, "ACGTACGTAC", "GGGGGGGGGG", "TTTTTTTTTT");
+    create_grouped_bam(&input_bam, vec![("1", family)]);
+
+    let cmd = Simplex::try_parse_from([
+        "simplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse simplex args");
+    cmd.execute("fgumi simplex").expect("Simplex command failed");
+
+    let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    let _header = reader.read_header().unwrap();
+    let records: Vec<bam::Record> =
+        reader.records().map(|r| r.expect("failed to read record")).collect();
+    assert_eq!(records.len(), 2, "expected one consensus read pair");
+
+    let r1 = records
+        .iter()
+        .find(|r| r.flags().bits() & raw_flags::FIRST_SEGMENT != 0)
+        .expect("missing R1 consensus");
+    let r2 = records
+        .iter()
+        .find(|r| r.flags().bits() & raw_flags::LAST_SEGMENT != 0)
+        .expect("missing R2 consensus");
+
+    // All three R1s are mapped, so all three contribute.
+    assert_eq!(int_tag(r1, SamTag::CD), 3, "R1 should use all three mapped reads");
+
+    // Only the two mapped R2s may contribute; the unmapped R2's bases must not reach the consensus.
+    assert_eq!(int_tag(r2, SamTag::CD), 2, "R2 must use only the two mapped reads");
+    let r2_bases: String = r2.sequence().iter().map(char::from).collect();
+    assert_eq!(r2_bases, "GGGGGGGGGG", "R2 consensus must come from the mapped reads");
+}
+
+/// Under `--allow-unmapped`, unmapped reads are admitted to grouping, but must still not displace
+/// mapped reads within a set being consensus called.
+#[test]
+fn test_simplex_prefers_mapped_reads_even_when_unmapped_are_allowed() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    let family = half_mapped_family(2, "ACGTACGTAC", "GGGGGGGGGG", "TTTTTTTTTT");
+    create_grouped_bam(&input_bam, vec![("1", family)]);
+
+    let cmd = Simplex::try_parse_from([
+        "simplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--allow-unmapped",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse simplex args");
+    cmd.execute("fgumi simplex").expect("Simplex command failed");
+
+    let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    let _header = reader.read_header().unwrap();
+    let records: Vec<bam::Record> =
+        reader.records().map(|r| r.expect("failed to read record")).collect();
+    let r2 = records
+        .iter()
+        .find(|r| r.flags().bits() & raw_flags::LAST_SEGMENT != 0)
+        .expect("missing R2 consensus");
+
+    assert_eq!(int_tag(r2, SamTag::CD), 2, "mapped reads must win even with --allow-unmapped");
+    let r2_bases: String = r2.sequence().iter().map(char::from).collect();
+    assert_eq!(r2_bases, "GGGGGGGGGG", "R2 consensus must come from the mapped reads");
+}
+
+/// `--allow-unmapped` must still produce a consensus for a wholly unmapped family; this is the
+/// capability (e.g. ribosome display) that keeps fgumi from simply requiring mapped reads.
+#[test]
+fn test_simplex_allow_unmapped_still_consenses_a_wholly_unmapped_family() {
+    use fgumi_raw_bam::{SamBuilder, flags};
+
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    let mut records = Vec::new();
+    for i in 0..3 {
+        for (segment, seq) in
+            [(flags::FIRST_SEGMENT, "ACGTACGTAC"), (flags::LAST_SEGMENT, "GGGGGGGGGG")]
+        {
+            let mut b = SamBuilder::new();
+            b.read_name(format!("unmapped_{i}").as_bytes())
+                .ref_id(-1)
+                .pos(-1)
+                .mapq(0)
+                .flags(flags::PAIRED | segment | flags::UNMAPPED | flags::MATE_UNMAPPED)
+                .mate_ref_id(-1)
+                .mate_pos(-1)
+                .sequence(seq.as_bytes())
+                .qualities(&vec![30u8; seq.len()])
+                .add_string_tag(SamTag::RX, b"ACGT");
+            records.push(b.build());
+        }
+    }
+    create_grouped_bam(&input_bam, vec![("1", records)]);
+
+    let cmd = Simplex::try_parse_from([
+        "simplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--allow-unmapped",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse simplex args");
+    cmd.execute("fgumi simplex").expect("Simplex command failed");
+
+    let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    let _header = reader.read_header().unwrap();
+    let records: Vec<bam::Record> =
+        reader.records().map(|r| r.expect("failed to read record")).collect();
+    assert_eq!(records.len(), 2, "a wholly unmapped family must still yield a consensus pair");
+    for record in &records {
+        assert_eq!(int_tag(record, SamTag::CD), 3, "all three unmapped reads should contribute");
+    }
+}


### PR DESCRIPTION
Companion to fulcrumgenomics/fgbio#1168, which fixes the same defect in the Scala implementation.

## Problem

Unmapped reads contribute bases and depth to consensus reads, with no alignment supporting them.

`fgumi group --allow-unmapped` deliberately supports wholly unmapped templates (ribosome display and similar), but its gate is on templates with **both** reads unmapped, so a *half*-mapped pair is kept regardless of that flag. The consensus pre-group filter then kept any record that was mapped **or** had a mapped mate, which admitted the unmapped end too.

That end has no cigar, and `is_cigar_prefix` returns `true` for an empty left hand side — `a.len() > b.len()` is false, `last_index = 0.saturating_sub(1)`, and the loop body never runs:

```rust
pub fn is_cigar_prefix(a: &[(Kind, usize)], b: &[(Kind, usize)]) -> bool {
    if a.len() > b.len() { return false; }
    let last_index = a.len().saturating_sub(1);
    for (i, &(op_a, len_a)) in a.iter().enumerate() { ... }
    true
}
```

So in `select_most_common_alignment_group` an empty cigar matches *every* alignment group instead of forming one of its own, and the read is retained rather than rejected. Whether it is retained at all depends on where it lands in the length-descending sort, so the outcome turns on a read-length tiebreak.

Observed for a molecule of three read pairs where one pair has an unmapped R2:

| Command | Symptom |
|---|---|
| `simplex` | `cD=3` for R2 where only two reads are eligible, and the unmapped read's bases reach the consensus |
| `duplex` | `aD=3` for the AB single-strand consensus of R2 where only two AB-R2s are mapped |
| `codec` | Unaffected — its alignment grouping is reached only for templates forming a primary FR pair |

## Fix

Two layers.

**1. `consensus_pregroup_keep_flags` now requires the record to be mapped** (`src/lib/commands/common.rs`). This is fgumi's copy of fgbio's `ConsensusCallingIterator` filter and is already shared by simplex, duplex and codec, so all three are covered by construction — and it is already parameterised by `--allow-unmapped`, so the relaxation has a home. The mapped end of a half-mapped pair is unaffected; it is mapped in its own right.

**2. Under `--allow-unmapped`, mapped reads still win.** `drop_unmapped_if_any_mapped` removes unmapped reads from any set being consensus called that also holds a mapped read, and leaves a wholly unmapped set intact. Dropped reads are attributed to `RejectionReason::Unmapped` — which existed in the enum with no production call site until now — and reach the rejects output.

So: unmapped reads are not consensus input by default; with `--allow-unmapped` they are admitted but never displace mapped reads.

## Behaviour change

**This is breaking for input containing half-mapped pairs.** A family of such pairs previously produced an R2 consensus built from unaligned reads. It now produces no consensus for that end, and therefore no read pair.

That is deliberate: it restores parity with fgbio, where the same family produces nothing at all. Gating the fallback behind `--allow-unmapped` rather than applying it unconditionally is what keeps the default in step with fgbio while preserving the wholly-unmapped capability fgbio does not have.

## Tests

Written first, watched failing, then fixed — the two commits are `test:` then `fix:` in that order, so the first is red by design. Happy to squash if you would rather not carry a red commit.

At the test commit, verified: 3 failing, 2 passing guards.

| Test | At `test:` commit | Purpose |
|---|---|---|
| `test_simplex_ignores_unmapped_end_when_mapped_reads_present` | FAIL | reproduces the defect |
| `test_duplex_ignores_unmapped_end_when_mapped_reads_present` | FAIL | reproduces the defect |
| `test_simplex_prefers_mapped_reads_even_when_unmapped_are_allowed` | FAIL | pins layer 2, under `--allow-unmapped` |
| `test_codec_ignores_half_mapped_pair_when_mapped_reads_present` | PASS | guards codec's existing FR-pair protection |
| `test_simplex_allow_unmapped_still_consenses_a_wholly_unmapped_family` | PASS | guards the `--allow-unmapped` capability against this change |

The simplex tests assert R2's *bases* as well as its depth. Depth alone can look correct while the consensus is still contaminated — that is how the `--max-reads` interaction was caught in the fgbio equivalent.

`test_consensus_pregroup_keep_flags`'s `unmapped_paired_mate_mapped` case is inverted to pin the new behaviour, and a case is added for the mapped end of a half-mapped pair, which is still kept.

After: `cargo ci-test` 7247 passed, 0 failed; `cargo ci-fmt` and `cargo ci-lint` clean.

## Not addressed here

**The root cause in `is_cigar_prefix` is untouched.** An empty cigar is still a prefix of every cigar. This PR makes that unreachable from the consensus callers by default, and harmless under `--allow-unmapped`; any future path producing an empty cigar would hit it again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: output changes for consensus grouping and consensus depth/bases, pinned by mapped-read filtering; sort order, corrected UMIs, and metrics: none. `unsafe` changes: none, and `CLAUDE.md` allowlist updates: none. Memory bounds, queue capacity, and thread/backpressure policy: none.

Fix: Require mapped records by default. With `--allow-unmapped`, retain wholly unmapped families but prefer mapped records when both types exist. Attribute removed records to `RejectionReason::Unmapped`.

Tests cover simplex, duplex, and CODEC behavior, including half-mapped pairs and mapped-read depth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->