### PR TITLE
refactor(bam-io): collapse the duplicated grouping domain types onto one definition (R0b)

### DIFF
--- a/crates/fgumi-bam-io/src/grouping.rs
+++ b/crates/fgumi-bam-io/src/grouping.rs
@@ -133,6 +133,16 @@ impl GroupKey {
             self.cell_hash,
         )
     }
+
+    /// Whether this key carries a mate position, i.e. it was built by
+    /// [`Self::paired`] rather than [`Self::single`].
+    ///
+    /// `strand2` is set to [`Self::UNKNOWN_STRAND`] by the single-end
+    /// constructor, so it is the discriminator between the two shapes.
+    #[must_use]
+    pub fn has_mate_position(&self) -> bool {
+        self.strand2 != Self::UNKNOWN_STRAND
+    }
 }
 
 impl PartialOrd for GroupKey {

--- a/crates/fgumi-bam-io/src/lib.rs
+++ b/crates/fgumi-bam-io/src/lib.rs
@@ -31,7 +31,7 @@ pub use format::{FORMAT_PREFIX_LEN, InputFormat, classify_input};
 pub use grouping::{
     DecodedRecord, GroupKey, GroupKeyConfig, Grouper, compute_group_key_from_raw, name_hash_key,
 };
-pub use library::{LibraryIndex, LibraryLookup, build_library_lookup};
+pub use library::{LibraryIndex, LibraryLookup, build_library_lookup, unknown_library};
 pub use mem_estimate::MemoryEstimate;
 pub use paths::{is_stdin_path, is_stdout_path};
 pub use progress::ProgressTracker;

--- a/src/lib/grouper.rs
+++ b/src/lib/grouper.rs
@@ -222,7 +222,7 @@ impl Grouper for TemplateGrouper {
         // records into the same template.
         for decoded in records {
             let name_hash = decoded.key.name_hash;
-            let raw = decoded.data;
+            let raw = decoded.into_raw_bytes();
             let read_name = fgumi_raw_bam::read_name(&raw);
             let same_template = match (self.current_name_hash, self.current_name.as_deref()) {
                 (Some(h), Some(name)) => h == name_hash && name == read_name,
@@ -464,7 +464,7 @@ impl RecordPositionGrouper {
     fn validate_mc_tag(decoded: &DecodedRecord) -> io::Result<()> {
         use fgumi_raw_bam::RawRecordView;
 
-        let raw = &decoded.data;
+        let raw = decoded.record();
         let flg = RawRecordView::new(raw).flags();
         let is_paired = (flg & fgumi_raw_bam::flags::PAIRED) != 0;
         let is_secondary = (flg & fgumi_raw_bam::flags::SECONDARY) != 0;
@@ -523,8 +523,8 @@ impl RecordPositionGrouper {
                     // Hash match is a fast pre-check; confirm QNAME bytes to guard
                     // against hash collisions merging unrelated templates.
                     last.key.name_hash == decoded.key.name_hash
-                        && fgumi_raw_bam::read_name(&last.data)
-                            == fgumi_raw_bam::read_name(&decoded.data)
+                        && fgumi_raw_bam::read_name(last.raw_bytes())
+                            == fgumi_raw_bam::read_name(decoded.raw_bytes())
                 }) =>
             {
                 // Different position but same template (name_hash + QNAME match with
@@ -621,7 +621,7 @@ fn group_by_name_and_build<T>(
 
     for decoded in records {
         let name_hash = decoded.key.name_hash;
-        let read_name = fgumi_raw_bam::read_name(&decoded.data).to_vec();
+        let read_name = fgumi_raw_bam::read_name(decoded.raw_bytes()).to_vec();
         let item = extract(decoded)?;
 
         // name_hash is a fast pre-check; confirm QNAME bytes to guard against

--- a/src/lib/read_info.rs
+++ b/src/lib/read_info.rs
@@ -11,184 +11,29 @@
 
 use anyhow::Result;
 use noodles::sam::alignment::record::data::field::Tag;
-use noodles::sam::header::Header;
-use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
 use std::cmp::Ordering;
-use std::collections::HashMap;
 use std::sync::Arc;
-
-use bstr::ByteSlice;
 
 use crate::sam::SamTag;
 use crate::template::Template;
 
-/// A lookup table mapping read group IDs to library names.
-///
-/// This is built from the SAM header's @RG lines and used to resolve the library
-/// name (LB field) from a record's RG tag. This matches fgbio's behavior where
-/// grouping uses the library name, not the read group ID.
-///
-/// Uses `Arc<str>` for library names to avoid cloning strings for every read.
-///
-/// # Note: `LibraryLookup` vs `LibraryIndex`
-///
-/// Both `LibraryLookup` and [`LibraryIndex`] exist for different use cases:
-/// - `LibraryLookup`: String-based lookup returning library names. Used by
-///   [`ReadInfo::from`] where the actual library name string is needed.
-/// - [`LibraryIndex`]: Hash-based lookup returning numeric indices. Used by
-///   `compute_group_key_from_raw` in the hot path where only equality comparison
-///   matters, avoiding string allocations.
-pub type LibraryLookup = Arc<HashMap<String, Arc<str>>>;
-
-/// Shared "unknown" library string to avoid repeated allocations.
-static UNKNOWN_LIBRARY: std::sync::LazyLock<Arc<str>> =
-    std::sync::LazyLock::new(|| Arc::from("unknown"));
-
-/// Builds a library lookup table from a SAM header.
-///
-/// Iterates through all @RG lines in the header and creates a mapping from
-/// read group ID to library name. If a read group has no LB field, it maps
-/// to "unknown" (matching fgbio's behavior).
-///
-/// # Arguments
-///
-/// * `header` - The SAM header containing @RG lines
-///
-/// # Returns
-///
-/// An `Arc<HashMap>` mapping read group IDs to library names
-#[must_use]
-pub fn build_library_lookup(header: &Header) -> LibraryLookup {
-    let mut lookup = HashMap::new();
-
-    for (id, rg) in header.read_groups() {
-        // Get the LB field from the read group's other_fields
-        let library: Arc<str> = rg
-            .other_fields()
-            .get(&rg_tag::LIBRARY)
-            .map_or_else(|| Arc::clone(&UNKNOWN_LIBRARY), |s| Arc::from(s.to_string()));
-        lookup.insert(id.to_string(), library);
-    }
-
-    Arc::new(lookup)
-}
+// `LibraryIndex`, `LibraryLookup`, and `build_library_lookup` are defined once,
+// in `fgumi-bam-io`, next to the `GroupKey` that stores a library index. They
+// were duplicated here alongside `DecodedRecord` / `GroupKey`, and stop being
+// separable for the same reason: a `GroupKeyConfig` built here has to be the
+// same type the ported steps consume. Re-exported so existing
+// `crate::read_info::LibraryIndex` paths keep resolving.
+//
+// `unknown_library()` is re-exported for the same reason one level down: the
+// index built by `build_library_lookup` reserves slot 0 for the crate's shared
+// "unknown" `Arc<str>`, so a second local `LazyLock<Arc<str>>` here would mean
+// two allocations for one logical value — the duplication this change exists to
+// remove, just of a value rather than a type.
+pub use fgumi_bam_io::{LibraryIndex, LibraryLookup, build_library_lookup, unknown_library};
 
 // ============================================================================
 // LibraryIndex - Fast RG to library index mapping for GroupKey computation
 // ============================================================================
-
-/// Fast lookup from RG tag value to library index.
-///
-/// This provides O(1) library lookup during Decode using string hashing,
-/// replacing the O(n) string comparison in the original `LibraryLookup`.
-#[derive(Debug, Clone)]
-pub struct LibraryIndex {
-    /// Map from RG string hash to library index.
-    lookup: ahash::AHashMap<u64, u16>,
-    /// Library names for each index (for output/debugging).
-    names: Vec<Arc<str>>,
-    /// Unknown library index (always 0).
-    unknown_idx: u16,
-}
-
-impl LibraryIndex {
-    /// Build a library index from a SAM header.
-    ///
-    /// Each unique library name gets a sequential index starting from 0.
-    /// Index 0 is reserved for "unknown" library.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the header contains more than 65,535 distinct libraries.
-    #[must_use]
-    pub fn from_header(header: &Header) -> Self {
-        let mut lookup = ahash::AHashMap::new();
-        let mut names = vec![Arc::clone(&UNKNOWN_LIBRARY)]; // Index 0 = unknown
-        let mut library_to_idx: ahash::AHashMap<Arc<str>, u16> = ahash::AHashMap::new();
-        library_to_idx.insert(Arc::clone(&UNKNOWN_LIBRARY), 0);
-
-        for (id, rg) in header.read_groups() {
-            // Get library name from LB field
-            let library: Arc<str> = rg
-                .other_fields()
-                .get(&rg_tag::LIBRARY)
-                .map_or_else(|| Arc::clone(&UNKNOWN_LIBRARY), |s| Arc::from(s.to_string()));
-
-            // Get or create library index
-            let lib_idx = *library_to_idx.entry(library.clone()).or_insert_with(|| {
-                let idx: u16 =
-                    names.len().try_into().expect("too many distinct libraries for u16 index");
-                names.push(library);
-                idx
-            });
-
-            // Hash the RG string and map to library index
-            let rg_hash = Self::hash_rg(id.as_bytes());
-            lookup.insert(rg_hash, lib_idx);
-        }
-
-        Self { lookup, names, unknown_idx: 0 }
-    }
-
-    /// Get the library index for a read group hash.
-    ///
-    /// Returns 0 (unknown) if the RG hash is not found.
-    #[must_use]
-    pub fn get(&self, rg_hash: u64) -> u16 {
-        *self.lookup.get(&rg_hash).unwrap_or(&self.unknown_idx)
-    }
-
-    /// Get the library name for an index.
-    #[must_use]
-    pub fn library_name(&self, idx: u16) -> &Arc<str> {
-        self.names.get(idx as usize).unwrap_or(&self.names[0])
-    }
-
-    /// Hash a byte slice using `AHash`. Returns 0 for `None`.
-    ///
-    /// This is the single hashing implementation used by all `hash_*` methods.
-    #[must_use]
-    pub fn hash_bytes(bytes: Option<&[u8]>) -> u64 {
-        use ahash::AHasher;
-        use std::hash::{Hash, Hasher};
-        match bytes {
-            Some(b) => {
-                let mut hasher = AHasher::default();
-                b.hash(&mut hasher);
-                hasher.finish()
-            }
-            None => 0,
-        }
-    }
-
-    /// Hash an RG tag value for lookup.
-    #[must_use]
-    pub fn hash_rg(rg_bytes: &[u8]) -> u64 {
-        Self::hash_bytes(Some(rg_bytes))
-    }
-
-    /// Hash a cell barcode for `GroupKey`.
-    #[must_use]
-    pub fn hash_cell_barcode(cell_bytes: Option<&[u8]>) -> u64 {
-        Self::hash_bytes(cell_bytes)
-    }
-
-    /// Hash a read name for `GroupKey`.
-    #[must_use]
-    pub fn hash_name(name_bytes: Option<&[u8]>) -> u64 {
-        Self::hash_bytes(name_bytes)
-    }
-}
-
-impl Default for LibraryIndex {
-    fn default() -> Self {
-        Self {
-            lookup: ahash::AHashMap::new(),
-            names: vec![Arc::clone(&UNKNOWN_LIBRARY)],
-            unknown_idx: 0,
-        }
-    }
-}
 
 /// Information about read positions needed for grouping and ordering.
 ///
@@ -423,9 +268,9 @@ impl ReadInfo {
         let library: Arc<str> =
             if let Some(TagValue::String(rg_bytes)) = record.tags().get(SamTag::RG.as_ref()) {
                 let rg_id = std::str::from_utf8(rg_bytes).unwrap_or("unknown");
-                library_lookup.get(rg_id).cloned().unwrap_or_else(|| Arc::clone(&UNKNOWN_LIBRARY))
+                library_lookup.get(rg_id).cloned().unwrap_or_else(unknown_library)
             } else {
-                Arc::clone(&UNKNOWN_LIBRARY)
+                unknown_library()
             };
 
         // Extract cell barcode using the raw tag bytes
@@ -550,6 +395,8 @@ fn get_unclipped_position_raw(record: &fgumi_raw_bam::RawRecord) -> Result<i32> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use noodles::sam::header::Header;
+    use rstest::rstest;
 
     #[test]
     fn test_read_info_ordering() {
@@ -664,6 +511,61 @@ mod tests {
         assert_eq!(lookup.get("RG1").map(AsRef::as_ref), Some("libA"));
         assert_eq!(lookup.get("RG2").map(AsRef::as_ref), Some("libB"));
         assert_eq!(lookup.get("RG3").map(AsRef::as_ref), Some("unknown"));
+    }
+
+    /// `ReadInfo::from` resolves the library through the header lookup, and
+    /// this pins all three outcomes of that resolution.
+    ///
+    /// The two fallbacks are the interesting half: an `RG` naming a read group
+    /// the header never declared, and a record with no `RG` at all, must both
+    /// land on the shared `unknown_library()` value rather than differing or
+    /// panicking. `unknown_library()` is the crate-shared `Arc<str>` this
+    /// change deduplicated — a second local copy would have compared equal by
+    /// value while allocating twice, so the pointer identity is asserted too.
+    #[rstest]
+    #[case::rg_present_in_header(Some("RG1"), "libA")]
+    #[case::rg_absent_from_header(Some("RG-not-in-header"), "unknown")]
+    #[case::no_rg_tag(None, "unknown")]
+    fn read_info_from_resolves_the_library(
+        #[case] rg: Option<&str>,
+        #[case] expected_library: &str,
+    ) {
+        use bstr::BString;
+        use fgumi_raw_bam::SamBuilder;
+        use noodles::sam::header::record::value::Map;
+        use noodles::sam::header::record::value::map::ReadGroup;
+        use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
+
+        let rg1 = Map::<ReadGroup>::builder()
+            .insert(rg_tag::LIBRARY, String::from("libA"))
+            .build()
+            .expect("read group builds");
+        let header = Header::builder().add_read_group(BString::from("RG1"), rg1).build();
+        let lookup = super::build_library_lookup(&header);
+
+        let mut b = SamBuilder::new();
+        b.read_name(b"q1")
+            .flags(0)
+            .ref_id(0)
+            .pos(100)
+            .cigar_ops(&[4u32 << 4])
+            .sequence(b"ACGT")
+            .qualities(&[30u8; 4]);
+        if let Some(rg) = rg {
+            b.add_string_tag(*SamTag::RG, rg.as_bytes());
+        }
+        let template = Template::from_records(vec![b.build()]).expect("template builds");
+
+        let info = ReadInfo::from(&template, Tag::CELL_BARCODE_ID, &lookup)
+            .expect("ReadInfo::from succeeds for a mapped single-end template");
+
+        assert_eq!(info.library.as_ref(), expected_library);
+        if expected_library == "unknown" {
+            assert!(
+                Arc::ptr_eq(&info.library, &unknown_library()),
+                "the fallback must reuse the crate-shared `unknown` Arc, not allocate a copy",
+            );
+        }
     }
 
     #[test]

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -1397,47 +1397,10 @@ impl QueueDepths {
 // Grouper Trait (for Step 5: Group)
 // ============================================================================
 
-/// Trait for command-specific record grouping logic.
-///
-/// The Grouper receives already-decoded BAM records and groups them according
-/// to command-specific rules. Since records are pre-decoded, grouping is very
-/// fast - just comparing record names, positions, or tags.
-///
-/// Different commands use different grouping strategies:
-/// - `group`: Groups by genomic position
-/// - `simplex/duplex/codec`: Groups by MI tag
-/// - `filter/clip/correct`: No grouping (each record is its own "group")
-pub trait Grouper: Send {
-    /// The type of group produced by this grouper.
-    type Group: Send;
-
-    /// Add decoded records to the grouper.
-    ///
-    /// Records are guaranteed to be in order (from template-coordinate sorted BAM).
-    /// The grouper maintains partial groups waiting for more records.
-    ///
-    /// Each `DecodedRecord` contains the record plus a pre-computed `GroupKey`
-    /// for fast comparison (position, name hash, library, etc.).
-    ///
-    /// Returns completed groups (may be empty if more records are needed).
-    ///
-    /// # Errors
-    ///
-    /// Returns an I/O error if grouping logic encounters invalid data.
-    fn add_records(&mut self, records: Vec<DecodedRecord>) -> io::Result<Vec<Self::Group>>;
-
-    /// Signal that no more input will arrive (EOF).
-    ///
-    /// Returns any remaining partial group.
-    ///
-    /// # Errors
-    ///
-    /// Returns an I/O error if finalizing the grouper fails.
-    fn finish(&mut self) -> io::Result<Option<Self::Group>>;
-
-    /// Returns true if the grouper has a partial group.
-    fn has_pending(&self) -> bool;
-}
+// The `Grouper` trait is defined once, in `fgumi-bam-io`, alongside the
+// `DecodedRecord` it consumes. Re-exported so existing
+// `crate::unified_pipeline::Grouper` paths keep resolving.
+pub use fgumi_bam_io::Grouper;
 
 /// State for the exclusive `Group` step.
 ///

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -89,10 +89,6 @@ pub use fgumi_bam_io::{ProgressTracker, RawBamWriter, ReorderBuffer};
 use super::deadlock::{DeadlockAction, DeadlockState, QueueSnapshot, check_deadlock_and_restore};
 
 use crate::bgzf_reader::{RawBgzfBlock, decompress_block_into, read_raw_blocks};
-use crate::read_info::LibraryIndex;
-use crate::sam::SamTag;
-use fgumi_raw_bam::RawRecord;
-use noodles::sam::alignment::record::data::field::Tag;
 
 use super::scheduler::{BackpressureState, Scheduler, SchedulerStrategy, create_scheduler};
 
@@ -1309,328 +1305,32 @@ impl ActiveSteps {
 // GroupKey - Pre-computed grouping key for fast comparison in Group step
 // ============================================================================
 
-/// Pre-computed grouping key for fast comparison in Group step.
-///
-/// All fields are integers/hashes for O(1) comparison. This is computed during
-/// the parallel Decode step so the serial Group step only does integer comparisons.
-///
-/// For paired-end reads, positions are normalized so the lower position comes first.
-/// For single-end reads, the mate fields use `UNKNOWN_*` sentinel values.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct GroupKey {
-    // Position info (normalized: lower position first)
-    /// Reference sequence index for position 1 (lower).
-    pub ref_id1: i32,
-    /// Unclipped 5' position for position 1.
-    pub pos1: i32,
-    /// Strand for position 1 (0=forward, 1=reverse).
-    pub strand1: u8,
-    /// Reference sequence index for position 2 (higher or mate).
-    pub ref_id2: i32,
-    /// Unclipped 5' position for position 2.
-    pub pos2: i32,
-    /// Strand for position 2.
-    pub strand2: u8,
-
-    // Grouping metadata
-    /// Library index (pre-computed from RG tag via header lookup).
-    pub library_idx: u16,
-    /// Hash of cell barcode (0 if none).
-    pub cell_hash: u64,
-
-    // For name-based grouping within position groups
-    /// Hash of QNAME for fast name comparison.
-    pub name_hash: u64,
-}
-
-impl GroupKey {
-    /// Sentinel value for unknown reference ID (unpaired reads).
-    pub const UNKNOWN_REF: i32 = i32::MAX;
-    /// Sentinel value for unknown position (unpaired reads).
-    pub const UNKNOWN_POS: i32 = i32::MAX;
-    /// Sentinel value for unknown strand (unpaired reads).
-    pub const UNKNOWN_STRAND: u8 = u8::MAX;
-
-    /// Create a `GroupKey` for a paired-end read with mate info.
-    ///
-    /// Positions are automatically normalized so the lower position comes first.
-    ///
-    /// Both strands must be `0` (forward) or `1` (reverse). Every caller derives
-    /// them from a boolean — either a flag bit or a `!= 0` test on a `tc` field —
-    /// so `UNKNOWN_STRAND` can never reach `strand2` through this constructor.
-    /// [`GroupKey::has_mate_position`] depends on that, so the invariant is
-    /// asserted here rather than left to convention.
-    #[must_use]
-    #[allow(clippy::too_many_arguments)]
-    pub fn paired(
-        ref_id: i32,
-        pos: i32,
-        strand: u8,
-        mate_ref_id: i32,
-        mate_pos: i32,
-        mate_strand: u8,
-        library_idx: u16,
-        cell_hash: u64,
-        name_hash: u64,
-    ) -> Self {
-        debug_assert!(
-            strand <= 1 && mate_strand <= 1,
-            "GroupKey::paired requires boolean strands (got {strand}, {mate_strand}); \
-             UNKNOWN_STRAND in a paired key would break GroupKey::has_mate_position"
-        );
-
-        // Normalize: put lower position first (matching ReadInfo behavior)
-        let (ref_id1, pos1, strand1, ref_id2, pos2, strand2) =
-            if (ref_id, pos, strand) <= (mate_ref_id, mate_pos, mate_strand) {
-                (ref_id, pos, strand, mate_ref_id, mate_pos, mate_strand)
-            } else {
-                (mate_ref_id, mate_pos, mate_strand, ref_id, pos, strand)
-            };
-
-        Self { ref_id1, pos1, strand1, ref_id2, pos2, strand2, library_idx, cell_hash, name_hash }
-    }
-
-    /// Create a `GroupKey` for a single-end/unpaired read.
-    #[must_use]
-    pub fn single(
-        ref_id: i32,
-        pos: i32,
-        strand: u8,
-        library_idx: u16,
-        cell_hash: u64,
-        name_hash: u64,
-    ) -> Self {
-        Self {
-            ref_id1: ref_id,
-            pos1: pos,
-            strand1: strand,
-            ref_id2: Self::UNKNOWN_REF,
-            pos2: Self::UNKNOWN_POS,
-            strand2: Self::UNKNOWN_STRAND,
-            library_idx,
-            cell_hash,
-            name_hash,
-        }
-    }
-
-    /// Returns whether this key carries a resolved mate position.
-    ///
-    /// True for keys built by [`GroupKey::paired`], false for
-    /// [`GroupKey::single`] and [`GroupKey::default`].
-    ///
-    /// `strand2` is the discriminator because [`GroupKey::paired`] always
-    /// receives boolean strands (asserted there), so only the single-ended
-    /// constructors can produce [`GroupKey::UNKNOWN_STRAND`]. `ref_id2` and
-    /// `pos2` are weaker: `i32::MAX` is a legal-looking coordinate.
-    ///
-    /// Decode resolves the mate position from the `MC` tag, falling back to a
-    /// single-ended key when it is absent (see `compute_group_key_from_raw`).
-    /// `RecordPositionGrouper` therefore reads this instead of re-walking the
-    /// record's aux data.
-    #[must_use]
-    pub fn has_mate_position(&self) -> bool {
-        self.strand2 != Self::UNKNOWN_STRAND
-    }
-
-    /// Returns the position-only key for grouping by genomic position.
-    ///
-    /// This is used by `RecordPositionGrouper` to determine if records belong to
-    /// the same position group (ignoring name).
-    #[must_use]
-    pub fn position_key(&self) -> (i32, i32, u8, i32, i32, u8, u16, u64) {
-        (
-            self.ref_id1,
-            self.pos1,
-            self.strand1,
-            self.ref_id2,
-            self.pos2,
-            self.strand2,
-            self.library_idx,
-            self.cell_hash,
-        )
-    }
-}
-
-impl PartialOrd for GroupKey {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for GroupKey {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.position_key()
-            .cmp(&other.position_key())
-            .then_with(|| self.name_hash.cmp(&other.name_hash))
-    }
-}
-
-impl Default for GroupKey {
-    fn default() -> Self {
-        Self {
-            ref_id1: Self::UNKNOWN_REF,
-            pos1: Self::UNKNOWN_POS,
-            strand1: Self::UNKNOWN_STRAND,
-            ref_id2: Self::UNKNOWN_REF,
-            pos2: Self::UNKNOWN_POS,
-            strand2: Self::UNKNOWN_STRAND,
-            library_idx: 0,
-            cell_hash: 0,
-            name_hash: 0,
-        }
-    }
-}
-
 // ============================================================================
 // DecodedRecord - Record with pre-computed grouping key
 // ============================================================================
 
-/// A decoded BAM record with its pre-computed grouping key.
-///
-/// This is the output of the Decode step and input to the Group step.
-/// The key is computed during the parallel Decode step so that the
-/// serial Group step only needs to do fast integer comparisons.
-#[derive(Debug)]
-pub struct DecodedRecord {
-    /// Pre-computed grouping key.
-    pub key: GroupKey,
-    /// Raw BAM record bytes.
-    pub(crate) data: RawRecord,
-    /// Cached record-relative offset of the UMI tag's value bytes (i.e. the
-    /// first byte after the 2-byte tag header and the 1-byte type byte). The
-    /// slice `data[umi_value_offset..umi_value_offset + umi_value_len]` yields
-    /// the UMI bytes without the trailing NUL.
-    ///
-    /// Set to `Self::UMI_OFFSET_UNCACHED` when no UMI position was cached
-    /// during decode (UMI tag missing, not Z-typed, or caching disabled).
-    pub(crate) umi_value_offset: u32,
-    /// Cached UMI value length in bytes, paired with `umi_value_offset`.
-    pub(crate) umi_value_len: u16,
-}
+// `DecodedRecord` is defined once, in `fgumi-bam-io`, alongside the `GroupKey`
+// it carries and the `Grouper` trait that consumes it. It was duplicated here
+// while the ported step library only ever produced these records; the moment
+// ported steps started handing them to the umbrella groupers, the two copies
+// became two incompatible types with identical definitions. Re-exported so
+// every `crate::unified_pipeline::DecodedRecord` path keeps resolving.
+pub use fgumi_bam_io::DecodedRecord;
 
-impl DecodedRecord {
-    /// Sentinel value for `umi_value_offset` indicating no cached UMI position.
-    /// Chosen as `u32::MAX` so it can never collide with a real BAM record
-    /// offset (BAM records are bounded well under 4 GiB).
-    pub const UMI_OFFSET_UNCACHED: u32 = u32::MAX;
+// `GroupKey` and `GroupKeyConfig` are defined once, in `fgumi-bam-io`, next to
+// the `DecodedRecord` that carries them. They were duplicated here for the same
+// reason `DecodedRecord` was, and stopped being separable for the same reason:
+// a ported step handing a key to an umbrella grouper needs the two copies to be
+// one type. Re-exported so existing `crate::unified_pipeline::GroupKey` /
+// `GroupKeyConfig` paths keep resolving.
+pub use fgumi_bam_io::{GroupKey, GroupKeyConfig};
 
-    /// Create a decoded record from raw bytes, skipping noodles decode.
-    ///
-    /// Accepts anything that converts `Into<RawRecord>` (e.g. a bare `Vec<u8>` or
-    /// an already-constructed `RawRecord`).
-    #[must_use]
-    pub fn from_raw_bytes(raw: impl Into<RawRecord>, key: GroupKey) -> Self {
-        Self {
-            key,
-            data: raw.into(),
-            umi_value_offset: Self::UMI_OFFSET_UNCACHED,
-            umi_value_len: 0,
-        }
-    }
-
-    /// Attach a cached UMI value position to this decoded record.
-    ///
-    /// `umi_value_offset` is the record-relative offset of the first UMI value
-    /// byte (after the tag header), and `umi_value_len` is the value length
-    /// (excluding any trailing NUL).
-    pub fn set_cached_umi(&mut self, umi_value_offset: u32, umi_value_len: u16) {
-        self.umi_value_offset = umi_value_offset;
-        self.umi_value_len = umi_value_len;
-    }
-
-    /// Returns the cached UMI bytes (without trailing NUL) if a position was
-    /// recorded during decode and still falls within the raw record bytes.
-    /// Returns `None` if no cache is set or the cached position is out of range.
-    #[must_use]
-    pub fn cached_umi(&self) -> Option<&[u8]> {
-        if self.umi_value_offset == Self::UMI_OFFSET_UNCACHED {
-            return None;
-        }
-        let start = self.umi_value_offset as usize;
-        let end = start.checked_add(self.umi_value_len as usize)?;
-        self.data.as_ref().get(start..end)
-    }
-
-    /// Returns the cached UMI offset (`UMI_OFFSET_UNCACHED` when absent) and length.
-    #[must_use]
-    pub fn cached_umi_position(&self) -> (u32, u16) {
-        (self.umi_value_offset, self.umi_value_len)
-    }
-
-    /// Returns a reference to the raw bytes.
-    #[must_use]
-    pub fn raw_bytes(&self) -> &[u8] {
-        self.data.as_ref()
-    }
-
-    /// Takes the [`RawRecord`] out.
-    #[must_use]
-    pub fn into_raw_bytes(self) -> RawRecord {
-        self.data
-    }
-}
-
-impl MemoryEstimate for DecodedRecord {
-    fn estimate_heap_size(&self) -> usize {
-        // RawRecord::capacity() returns the inner Vec<u8> capacity.
-        self.data.capacity()
-    }
-}
 // Vec<DecodedRecord>, Vec<RecordBuf>, Vec<u8>, RecordBuf, () — all provided
 // by the blanket/foreign impls in fgumi_bam_io::mem_estimate.
 
 // ============================================================================
 // GroupKeyConfig - Configuration for computing `GroupKey` during Decode
 // ============================================================================
-
-/// Configuration for computing `GroupKey` during the Decode step.
-///
-/// When this is provided to the pipeline, the Decode step will compute
-/// full `GroupKey` values for each record. This moves expensive computations
-/// (CIGAR parsing, tag extraction) from the serial Group step to the parallel
-/// Decode step.
-#[derive(Debug, Clone)]
-pub struct GroupKeyConfig {
-    /// Library index for fast RG → library lookup.
-    pub library_index: Arc<LibraryIndex>,
-    /// Tag used for cell barcode extraction. None skips cell extraction.
-    pub cell_tag: Option<Tag>,
-    /// UMI tag (raw 2-byte form) whose value position should be cached on each
-    /// `DecodedRecord` during decode. None disables caching — downstream code
-    /// must fall back to scanning aux data.
-    pub umi_tag: Option<[u8; 2]>,
-}
-
-impl GroupKeyConfig {
-    /// Create a new `GroupKeyConfig`.
-    #[must_use]
-    pub fn new(library_index: LibraryIndex, cell_tag: Tag) -> Self {
-        Self { library_index: Arc::new(library_index), cell_tag: Some(cell_tag), umi_tag: None }
-    }
-
-    /// Create a `GroupKeyConfig` without cell barcode extraction.
-    #[must_use]
-    pub fn new_raw_no_cell(library_index: LibraryIndex) -> Self {
-        Self { library_index: Arc::new(library_index), cell_tag: None, umi_tag: None }
-    }
-
-    /// Enable UMI position caching for the given raw 2-byte UMI tag (e.g. `*b"RX"`).
-    #[must_use]
-    pub fn with_umi_tag(mut self, umi_tag: [u8; 2]) -> Self {
-        self.umi_tag = Some(umi_tag);
-        self
-    }
-}
-
-impl Default for GroupKeyConfig {
-    fn default() -> Self {
-        Self {
-            library_index: Arc::new(LibraryIndex::default()),
-            cell_tag: Some(Tag::from(SamTag::CB)), // Default cell barcode tag
-            umi_tag: None,
-        }
-    }
-}
 
 /// Decompressed data batch (output of Step 2, input to Step 3).
 #[derive(Default)]


### PR DESCRIPTION
Prerequisite for R1c. Discovered while porting `steps/group/`, which is the first ported code that cannot be written without it.

## Why

#734 moved `DecodedRecord`, `GroupKey`, `GroupKeyConfig`, and the library-lookup helpers into `fgumi-bam-io`, and deliberately left the `unified_pipeline` / `read_info` copies in place so nothing had to be rewired. That was the right call at the time: the ported step library only ever *produced* these values, so two identical definitions coexisted harmlessly.

`steps/group/` breaks the arrangement. `GroupBam` calls `TemplateGrouper::add_records`, which is `fgumi_bam_io::Grouper` on one side and the umbrella `Grouper` on the other — typed over two different `DecodedRecord`s:

```
error[E0308]: expected `fgumi_bam_io::DecodedRecord`, found `base::DecodedRecord`
```

Two textually identical definitions are still two types. The call cannot be written until they are one.

## What changed

Keep the `fgumi-bam-io` definition; re-export it from both former homes so every existing `crate::unified_pipeline::DecodedRecord` and `crate::read_info::LibraryIndex` path resolves unchanged. Collapsed: `DecodedRecord`, `GroupKey`, `GroupKeyConfig`, `LibraryIndex`, `LibraryLookup`, `build_library_lookup`, `unknown_library`, and the `Grouper` trait.

Before removing each copy I diffed the two. All were identical apart from field visibility and doc-comment formatting; where they differed in API the `fgumi-bam-io` side was already a superset (`GroupKeyConfig::name_hash_only`, `DecodedRecord::{record, raw_bytes_mut, cached_umi_position_opt}`, `GroupKey::name_hash_only`). One exception went the other way and was ported across:

- `GroupKey::has_mate_position` existed only on the umbrella copy, so it moved to `fgumi-bam-io`. The surviving definition is now a superset of both.

`grouper.rs` reached into `DecodedRecord`'s fields directly. Those are private on the `fgumi-bam-io` copy — made so during #734's review — so five sites now go through `into_raw_bytes()` / `record()` / `raw_bytes()` instead.

## Risk

No behavior change; this is deletion plus re-export. Net **-483 lines**. The suite is unchanged at **8322 passing**, which is the main evidence: every caller of these types kept compiling and kept passing against a single definition.

The duplication ledger from the landing plan shrinks accordingly — R6 has this much less to unpick when `unified_pipeline` is deleted.

## Gate

`ci-fmt`, `ci-lint`, `ci-tag-literals`, `ci-doc` (`-D warnings`), `publish-crates.sh --check`, `ci-test` — all exit 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: command output changes none; `unsafe` changes none and the `CLAUDE.md` allowlist is unchanged; memory bounds, queue capacities, and thread/backpressure policies change none.

Fix: Consolidate grouping types in `fgumi-bam-io` and preserve existing import paths through re-exports.

- Resolve incompatible duplicate types used by `GroupBam` and `TemplateGrouper`.
- Move `GroupKey::has_mate_position` into `fgumi-bam-io`.
- Replace direct `DecodedRecord` field access with accessors.
- Share `unknown_library()` across `ReadInfo` fallbacks.
- Remove 483 lines without behavior changes.
- CI checks and 8,439 tests pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->