### PR TITLE
feat(pipeline): port the grouping and closure-driven mid-steps (R1c)

### DIFF
--- a/crates/fgumi-pipeline-core/src/builder.rs
+++ b/crates/fgumi-pipeline-core/src/builder.rs
@@ -523,6 +523,46 @@ where
     }
 }
 
+impl<'b, A, B, C> Chain<'b, super::outputs::OrderedBytesTuple3<A, B, C>>
+where
+    A: Send + super::item::HeapSize + super::item::Ordered + 'static,
+    B: Send + super::item::HeapSize + super::item::Ordered + 'static,
+    C: Send + super::item::HeapSize + super::item::Ordered + 'static,
+{
+    /// Convert a 3-output ordered + byte-bounded chain into per-branch
+    /// sub-chains, the 3-way counterpart of the
+    /// [`OrderedBytesTuple2`](super::outputs::OrderedBytesTuple2) impl above.
+    ///
+    /// Without this, a step whose `Outputs` is `OrderedBytesTuple3` cannot be
+    /// wired through the typed builder at all: `append_step` exposes only
+    /// branch 0, and branch wiring is not otherwise public — so the step type
+    /// checks, builds, and is simply unreachable.
+    #[must_use = "all chain branches must be wired to a sink"]
+    pub fn into_multi(self) -> MultiChain3Ordered<'b, A, B, C> {
+        MultiChain3Ordered {
+            b0: Chain {
+                builder: self.builder,
+                producer: self.producer,
+                branch: BranchIdx(0),
+                _phantom: PhantomData,
+            },
+            b1: Chain {
+                builder: self.builder,
+                producer: self.producer,
+                branch: BranchIdx(1),
+                _phantom: PhantomData,
+            },
+            b2: Chain {
+                builder: self.builder,
+                producer: self.producer,
+                branch: BranchIdx(2),
+                _phantom: PhantomData,
+            },
+            _phantom: PhantomData,
+        }
+    }
+}
+
 impl<'b, A, B, C> Chain<'b, (A, B, C)>
 where
     A: Send + HeapSize + 'static,
@@ -775,6 +815,23 @@ where
     pub b0: Chain<'b, Single<A>>,
     pub b1: Chain<'b, Single<B>>,
     pub b2: Chain<'b, Single<C>>,
+    pub(crate) _phantom: PhantomData<&'b PipelineBuilder>,
+}
+
+/// Per-branch sub-chains of an ordered + byte-bounded 3-way fan-out. The
+/// 3-way counterpart of [`MultiChain2Ordered`]; each branch is exposed as
+/// `Chain<OrderedBytesSingle<X>>` so downstream chained steps see the
+/// byte-aware ordered shape.
+#[must_use = "all chain branches must be wired to a sink"]
+pub struct MultiChain3Ordered<'b, A, B, C>
+where
+    A: Send + super::item::HeapSize + super::item::Ordered + 'static,
+    B: Send + super::item::HeapSize + super::item::Ordered + 'static,
+    C: Send + super::item::HeapSize + super::item::Ordered + 'static,
+{
+    pub b0: Chain<'b, super::outputs::OrderedBytesSingle<A>>,
+    pub b1: Chain<'b, super::outputs::OrderedBytesSingle<B>>,
+    pub b2: Chain<'b, super::outputs::OrderedBytesSingle<C>>,
     pub(crate) _phantom: PhantomData<&'b PipelineBuilder>,
 }
 
@@ -2555,6 +2612,61 @@ mod tests {
         assert!(matches!(
             builder.build(),
             Err(BuildError::UnwiredOutput { step: "OrderedSource", branch: "1" })
+        ));
+    }
+
+    #[derive(Clone)]
+    struct OrderedSource3;
+    impl Step for OrderedSource3 {
+        type Input = ();
+        type Outputs = crate::outputs::OrderedBytesTuple3<Ord32, Ord32, Ord32>;
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "OrderedSource3",
+                kind: StepKind::Parallel,
+                sticky: false,
+                output_queues: vec![QueueSpec::ByteBounded { limit_bytes: 1024 }; 3],
+                branch_ordering: vec![BranchOrdering::ByItemOrdinal; 3],
+            }
+        }
+        fn try_run(&mut self, _ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            Ok(StepOutcome::Finished)
+        }
+        fn new_worker_copy(&self) -> Self {
+            self.clone()
+        }
+    }
+
+    /// The 3-way counterpart of `into_multi_ordered_bytes_2_exposes_one_chain_per_branch`:
+    /// all three ordered + byte-bounded branches are exposed as
+    /// `Chain<OrderedBytesSingle<_>>` and separately wireable.
+    #[test]
+    fn into_multi_ordered_bytes_3_exposes_one_chain_per_branch() {
+        let builder = PipelineBuilder::new();
+        let multi = builder.chain(OrderedSource3).into_multi();
+        let _: &Chain<'_, crate::outputs::OrderedBytesSingle<Ord32>> = &multi.b0;
+        multi.b0.chain(OrderedSink).into_sink_marker();
+        multi.b1.chain(OrderedSink).into_sink_marker();
+        multi.b2.chain(OrderedSink).into_sink_marker();
+
+        let pipeline = builder.build().expect("all three ordered branches wired");
+        assert_eq!(pipeline.graph.n_steps(), 4, "source + 3 sinks");
+    }
+
+    /// The 3-way counterpart of `into_multi_ordered_bytes_2_reports_the_branch_left_unwired`:
+    /// the dropped branch is reported BY INDEX, proving `b2` is a distinct edge
+    /// rather than an alias of `b0`/`b1`.
+    #[test]
+    fn into_multi_ordered_bytes_3_reports_the_branch_left_unwired() {
+        let builder = PipelineBuilder::new();
+        let multi = builder.chain(OrderedSource3).into_multi();
+        multi.b0.chain(OrderedSink).into_sink_marker();
+        multi.b1.chain(OrderedSink).into_sink_marker();
+        drop(multi.b2);
+
+        assert!(matches!(
+            builder.build(),
+            Err(BuildError::UnwiredOutput { step: "OrderedSource3", branch: "2" })
         ));
     }
 

--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -121,10 +121,11 @@ pub use tags::{
     TagValue, TemplateAuxTags, append_i32_array_tag, append_signed_int_tag, array_tag_element_u16,
     array_tag_to_vec_u16, extract_aux_string_tags, extract_template_aux_tags, find_array_tag,
     find_float_tag, find_int_tag, find_mc_tag_in_record, find_string_tag,
-    find_string_tag_in_record, find_string_tag_position, find_tag_type, find_uint8_tag,
-    normalize_int_tag_to_smallest_signed, read_tc_template_coordinate, remove_tag,
-    reverse_array_tag_in_place, reverse_complement_string_tag_in_place,
-    reverse_string_tag_in_place, update_int_tag, update_string_tag,
+    find_string_tag_in_record, find_string_tag_position, find_tag_type,
+    find_two_string_tags_in_record, find_uint8_tag, normalize_int_tag_to_smallest_signed,
+    read_tc_template_coordinate, remove_tag, reverse_array_tag_in_place,
+    reverse_complement_string_tag_in_place, reverse_string_tag_in_place, update_int_tag,
+    update_string_tag,
 };
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -95,6 +95,73 @@ pub fn find_string_tag_in_record(bam: &[u8], tag: impl AsTagBytes) -> Option<&[u
     find_string_tag(aux, tag)
 }
 
+/// Find two string (Z-type) tags in a complete BAM record in a **single** aux-data
+/// walk, returning each value's bytes (without the NUL terminator) or `None` if that
+/// tag is absent or not Z-type.
+///
+/// Equivalent to calling [`find_string_tag_in_record`] twice, but it walks the aux
+/// block only once — relevant on hot paths that need both an MI tag and a cell-barcode
+/// tag per record. The returned slices borrow the record's aux data.
+#[inline]
+#[must_use]
+pub fn find_two_string_tags_in_record(
+    bam: &[u8],
+    first: impl AsTagBytes,
+    second: impl AsTagBytes,
+) -> (Option<&[u8]>, Option<&[u8]>) {
+    let first = u16::from_le_bytes(*first.as_tag_bytes());
+    let second = u16::from_le_bytes(*second.as_tag_bytes());
+    let aux = aux_data_slice(bam);
+
+    let mut first_done = false;
+    let mut second_done = false;
+    let mut first_val: Option<&[u8]> = None;
+    let mut second_val: Option<&[u8]> = None;
+    let mut p = 0;
+    while p + 3 <= aux.len() {
+        let entry_u16 = u16::from_le_bytes([aux[p], aux[p + 1]]);
+        let val_type = aux[p + 2];
+
+        // Each tag resolves on its FIRST matching entry, exactly as
+        // `find_string_tag_in_record` does (it returns the first tag match and
+        // yields a value only if that match is a NUL-terminated `Z` entry). A
+        // non-`Z` (or unterminated) first match resolves the tag to `None`; we
+        // must NOT skip it and pick up a later `Z` duplicate, or the two-tag
+        // walk would disagree with two single-tag lookups on malformed aux.
+        let matches_first = entry_u16 == first && !first_done;
+        let matches_second = entry_u16 == second && !second_done;
+        if matches_first || matches_second {
+            let value = if val_type == b'Z' {
+                let start = p + 3;
+                aux[start..].iter().position(|&b| b == 0).map(|len| &aux[start..start + len])
+            } else {
+                None
+            };
+            // Independent (not `else`) so a single entry resolves both slots
+            // when `first == second`, preserving the "call twice" contract.
+            if matches_first {
+                first_done = true;
+                first_val = value;
+            }
+            if matches_second {
+                second_done = true;
+                second_val = value;
+            }
+        }
+
+        // Stop once both tags have been resolved (each to a value or `None`).
+        if first_done && second_done {
+            break;
+        }
+
+        match tag_value_size(val_type, &aux[p + 3..]) {
+            Some(size) => p += 3 + size,
+            None => break,
+        }
+    }
+    (first_val, second_val)
+}
+
 /// Find the byte range `[start, end)` of an entire tag entry (tag+type+value) in aux data.
 ///
 /// Returns offsets relative to the start of `aux_data`.
@@ -4313,5 +4380,135 @@ mod tests {
         // And still accept &[u8; 2] for backward compat.
         let v2 = find_string_tag(&aux, b"RX");
         assert_eq!(v2, Some(b"ACGT".as_ref()));
+    }
+
+    #[test]
+    fn test_find_two_string_tags_both_present_either_order() {
+        // MI before CB.
+        let aux = b"MIZ7\x00CBZACGT\x00";
+        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
+        let (mi, cb) = find_two_string_tags_in_record(&rec, SamTag::MI, SamTag::CB);
+        assert_eq!(mi, Some(b"7".as_ref()));
+        assert_eq!(cb, Some(b"ACGT".as_ref()));
+
+        // CB before MI: result is independent of aux ordering and of arg order.
+        let aux = b"CBZACGT\x00MIZ7\x00";
+        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
+        let (mi, cb) = find_two_string_tags_in_record(&rec, SamTag::MI, SamTag::CB);
+        assert_eq!(mi, Some(b"7".as_ref()));
+        assert_eq!(cb, Some(b"ACGT".as_ref()));
+    }
+
+    #[test]
+    fn test_find_two_string_tags_agrees_with_single_lookups() {
+        // Interleave a non-Z tag to make the walk non-trivial.
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"NMC");
+        aux.push(3);
+        aux.extend_from_slice(b"MIZ42\x00");
+        aux.extend_from_slice(b"CBZTGCA\x00");
+        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, &aux);
+        let (mi, cb) = find_two_string_tags_in_record(&rec, SamTag::MI, SamTag::CB);
+        assert_eq!(mi, find_string_tag_in_record(&rec, SamTag::MI));
+        assert_eq!(cb, find_string_tag_in_record(&rec, SamTag::CB));
+    }
+
+    #[test]
+    fn test_find_two_string_tags_first_match_wins_on_malformed_dup() {
+        // A non-Z MI entry precedes a Z MI duplicate. `find_string_tag_in_record`
+        // resolves the FIRST MI match (non-Z → None) and never reaches the later
+        // Z duplicate; the two-tag walk must match that rather than skipping the
+        // non-Z entry and returning the later Z value.
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"MIC"); // MI, type 'C' (uint8) ...
+        aux.push(9); //                ... 1-byte value (non-Z → MI resolves None)
+        aux.extend_from_slice(b"MIZ77\x00"); // later Z duplicate — must be ignored
+        aux.extend_from_slice(b"CBZACGT\x00");
+        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, &aux);
+
+        let (mi, cb) = find_two_string_tags_in_record(&rec, SamTag::MI, SamTag::CB);
+        assert_eq!(mi, None, "first (non-Z) MI match resolves the tag to None");
+        assert_eq!(cb, Some(b"ACGT".as_ref()));
+        // Must agree with two independent single-tag lookups.
+        assert_eq!(mi, find_string_tag_in_record(&rec, SamTag::MI));
+        assert_eq!(cb, find_string_tag_in_record(&rec, SamTag::CB));
+    }
+
+    /// A `Z` entry with no terminating NUL, in the two shapes that behave
+    /// differently.
+    ///
+    /// The doc contract says a first match that is non-`Z` *or unterminated*
+    /// resolves the tag to `None`. Only the non-`Z` half was pinned, and the
+    /// unterminated half is subtler than it reads: the value scan looks for the
+    /// next NUL anywhere in the remaining aux block, not just within the entry.
+    /// So "unterminated" resolves to `None` only when there is no NUL left at
+    /// all — if a later entry supplies one, the value runs *through* that entry
+    /// and swallows it.
+    ///
+    /// Both shapes are pinned because they fail differently: the first stops the
+    /// walk via `tag_value_size` returning `None`, the second consumes the
+    /// remaining bytes as one oversized value. Either way the two-tag walk must
+    /// agree with two independent single-tag lookups, which is the contract that
+    /// makes `find_two_string_tags_in_record` a safe substitution for calling
+    /// `find_string_tag_in_record` twice.
+    #[rstest]
+    // No NUL anywhere after the tag: the value scan finds nothing, so MI is
+    // `None`, and the walk stops rather than advancing past a sizeless entry.
+    #[case::no_nul_anywhere(b"MIZ77".as_ref(), None, None)]
+    // A later entry supplies the NUL, so MI's value runs through `CBZACGT` and
+    // consumes it — CB is never seen as an entry of its own.
+    #[case::nul_supplied_by_a_later_entry(
+        b"MIZ77CBZACGT\x00".as_ref(),
+        Some(b"77CBZACGT".as_ref()),
+        None
+    )]
+    fn test_find_two_string_tags_unterminated_z_first_match(
+        #[case] aux: &[u8],
+        #[case] expected_mi: Option<&[u8]>,
+        #[case] expected_cb: Option<&[u8]>,
+    ) {
+        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
+
+        let (mi, cb) = find_two_string_tags_in_record(&rec, SamTag::MI, SamTag::CB);
+        assert_eq!(mi, expected_mi);
+        assert_eq!(cb, expected_cb);
+        // The parity contract: identical to two independent single-tag lookups.
+        assert_eq!(
+            mi,
+            find_string_tag_in_record(&rec, SamTag::MI),
+            "MI must match a single lookup"
+        );
+        assert_eq!(
+            cb,
+            find_string_tag_in_record(&rec, SamTag::CB),
+            "CB must match a single lookup"
+        );
+    }
+
+    #[test]
+    fn test_find_two_string_tags_same_tag_fills_both() {
+        // When the same tag is requested for both first and second, a single
+        // matching aux entry must populate both outputs (not just one).
+        let aux = b"MIZ7\x00CBZACGT\x00";
+        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
+        let (a, b) = find_two_string_tags_in_record(&rec, SamTag::MI, SamTag::MI);
+        assert_eq!(a, Some(b"7".as_ref()));
+        assert_eq!(b, Some(b"7".as_ref()));
+        // Both outputs must agree with an independent single-tag lookup, proving
+        // the same-tag case behaves like two separate `find_string_tag_in_record`
+        // calls (the contract the `mi_group.rs` production path relies on).
+        let mi = find_string_tag_in_record(&rec, SamTag::MI);
+        assert_eq!(a, mi, "first output must match an independent MI lookup");
+        assert_eq!(b, mi, "second output must match an independent MI lookup");
+
+        // Same-tag MISS path: when the (identical) requested tag is absent, both
+        // outputs must be None — the zero-match branch of the same-tag case,
+        // matching two independent single-tag lookups that each miss.
+        let rec_without_mi = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, b"CBZACGT\x00");
+        let (a_missing, b_missing) =
+            find_two_string_tags_in_record(&rec_without_mi, SamTag::MI, SamTag::MI);
+        assert_eq!(a_missing, None);
+        assert_eq!(b_missing, None);
+        assert_eq!(a_missing, find_string_tag_in_record(&rec_without_mi, SamTag::MI));
     }
 }

--- a/src/lib/mi_group.rs
+++ b/src/lib/mi_group.rs
@@ -107,6 +107,111 @@ type MiTransformFn = Box<dyn Fn(&[u8]) -> String + Send + Sync>;
 /// Type alias for raw-byte record filter function.
 type RecordFilterFn = Box<dyn Fn(&[u8]) -> bool + Send + Sync>;
 
+/// Borrowed MI tag transformation, shared by `MiGrouper` and `MiGroupIterator`
+/// (whose stored transforms differ only in `Send + Sync` bounds).
+pub(crate) type MiTransform<'a> = Option<&'a dyn Fn(&[u8]) -> String>;
+
+/// The grouping key for a run of consecutive records, stored as the raw
+/// comparison bytes so that boundary detection stays allocation-free on the
+/// common (no-transform) path: a record is compared against the current
+/// group by byte-equality of its tag value(s) rather than by building an
+/// owned `String` per record. The display label handed to `MiGroup` / the
+/// iterator output is materialized from these bytes only once per group.
+pub(crate) struct MiKey {
+    /// MI tag bytes, already transformed if a transform is configured.
+    mi: Vec<u8>,
+    /// Cell tag bytes, present (`Some`) only when cell-barcode grouping is
+    /// enabled. `Some(empty)` when the tag is configured but absent on the
+    /// record, mirroring the legacy `"MI\t"` composite key.
+    cell: Option<Vec<u8>>,
+}
+
+impl MiKey {
+    /// Locate the MI (and, when cell grouping is enabled, the cell) tag value(s)
+    /// for a record. When a cell tag is configured both are found in a **single**
+    /// aux-data walk; otherwise only the MI tag is looked up. Returns `None` when
+    /// the record has no MI tag (the record is then skipped). The boolean tracks
+    /// whether cell grouping is enabled so callers can distinguish a configured
+    /// cell tag that is absent on the record (`Some(b"")`) from no cell tag at all.
+    #[inline]
+    fn locate_values(
+        bam: &[u8],
+        tag: [u8; 2],
+        cell_tag: Option<[u8; 2]>,
+    ) -> Option<(&[u8], Option<&[u8]>)> {
+        match cell_tag {
+            Some(ct) => {
+                // Single aux-block walk for both the MI and the cell tag.
+                let (mi, cell) = fgumi_raw_bam::find_two_string_tags_in_record(bam, tag, ct);
+                Some((mi?, Some(cell.unwrap_or(b""))))
+            }
+            None => Some((fgumi_raw_bam::find_string_tag_in_record(bam, tag)?, None)),
+        }
+    }
+
+    /// Extract the grouping key from raw BAM bytes, allocating the owned key
+    /// bytes. Used when a new group begins. Returns `None` when the record has
+    /// no MI tag (the record is then skipped).
+    pub(crate) fn from_record(
+        bam: &[u8],
+        tag: [u8; 2],
+        cell_tag: Option<[u8; 2]>,
+        transform: MiTransform,
+    ) -> Option<Self> {
+        let (value, cell_value) = Self::locate_values(bam, tag, cell_tag)?;
+        let mi = match transform {
+            Some(transform) => transform(value).into_bytes(),
+            None => value.to_vec(),
+        };
+        let cell = cell_value.map(<[u8]>::to_vec);
+        Some(Self { mi, cell })
+    }
+
+    /// Test whether `bam` belongs to the same MI group as this key. Returns
+    /// `None` when the record has no MI tag (the record is then skipped).
+    /// Allocation-free on the no-transform path: the record's tag bytes are
+    /// compared against the stored key directly instead of building an owned key.
+    pub(crate) fn matches_record(
+        &self,
+        bam: &[u8],
+        tag: [u8; 2],
+        cell_tag: Option<[u8; 2]>,
+        transform: MiTransform,
+    ) -> Option<bool> {
+        let (value, cell_value) = Self::locate_values(bam, tag, cell_tag)?;
+        let mi_eq = match transform {
+            Some(transform) => transform(value).as_bytes() == self.mi.as_slice(),
+            None => value == self.mi.as_slice(),
+        };
+        let cell_eq = match (cell_value, &self.cell) {
+            (Some(have), Some(want)) => have == want.as_slice(),
+            // `cell_tag` is fixed for a grouper's lifetime, so the stored key's
+            // cell presence always matches the configuration; the mixed arms are
+            // unreachable.
+            (None, None) => true,
+            (Some(_), None) | (None, Some(_)) => {
+                debug_assert!(
+                    false,
+                    "cell-tag presence is fixed for the grouper's lifetime, so the stored key's \
+                     cell presence always matches the record's; this mixed arm is unreachable"
+                );
+                false
+            }
+        };
+        Some(mi_eq && cell_eq)
+    }
+
+    /// Build the display label. With a cell tag this is `"MI\tCELL"`,
+    /// matching the legacy composite key; otherwise it is just the MI value.
+    pub(crate) fn label(&self) -> String {
+        let mi = String::from_utf8_lossy(&self.mi);
+        match &self.cell {
+            Some(cell) => format!("{mi}\t{}", String::from_utf8_lossy(cell)),
+            None => mi.into_owned(),
+        }
+    }
+}
+
 /// A Grouper that groups raw-byte BAM records by MI tag.
 ///
 /// Records arrive as raw BAM bytes (see [`DecodedRecord::from_raw_bytes`]). MI tags are

--- a/src/lib/pipeline/steps/chain_tests.rs
+++ b/src/lib/pipeline/steps/chain_tests.rs
@@ -10,6 +10,9 @@
 //! ReplaySource → BgzfDecompress → FindBamBoundaries → DecodeRecords    → sink
 //! ReplaySource → BgzfDecompress → FindBamBoundaries → ParseBamRecords  → sink
 //! ReplaySource → BgzfDecompress → FindBamBoundaries → BgzfCompress     → sink
+//! ReplaySource → TemplatesToRecordBatch                                → sink
+//! ReplaySource → GroupByMi                                             → sink
+//! ReplaySource → Process2Ordered                          → sink A + sink B
 //! ```
 //!
 //! `ReplaySource` is a test-local source because the real `source/` steps
@@ -29,12 +32,14 @@
 
 use std::collections::VecDeque;
 use std::io;
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex};
 
 use fgumi_bam_io::GroupKeyConfig;
 use fgumi_raw_bam::{RawRecord, SamBuilder};
 use rstest::rstest;
 
+use crate::grouper::ProcessedPositionGroup;
 use crate::pipeline::core::Unpushed;
 use crate::pipeline::core::builder::{Pipeline, PipelineConfig};
 use crate::pipeline::core::held::HeldSlot;
@@ -46,9 +51,11 @@ use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProf
 use crate::pipeline::steps::bgzf::compress::BgzfCompress;
 use crate::pipeline::steps::bgzf::decompress::BgzfDecompress;
 use crate::pipeline::steps::boundaries::bam::FindBamBoundaries;
+use crate::pipeline::steps::group::position::BatchedProcessedPositionGroups;
 use crate::pipeline::steps::parse::bam::ParseBamRecords;
 use crate::pipeline::steps::parse::decode::{DecodeFromRecords, DecodeRecords};
 use crate::pipeline::steps::types::{BgzfBlock, DecodedRecordBatch, RecordBatch};
+use crate::template::Template;
 
 /// Per-edge byte budget. Deliberately small relative to the multi-record
 /// fixtures so the byte-bounded edges bind mid-run rather than swallowing the
@@ -125,6 +132,85 @@ fn bgzf_blocks_for(records: &[RawRecord], payload_bytes: usize) -> Vec<BgzfBlock
             }
         })
         .collect()
+}
+
+/// A four-record template for one queryname: primary R1 and R2 plus an R1
+/// supplementary and an R2 secondary.
+///
+/// The split alignments are the point — a flatten written against
+/// [`Template::r1`]/[`Template::r2`] would silently drop them, and every record
+/// here carries a distinct position, sequence, and length so any dropped,
+/// duplicated, or reordered record changes the emitted byte stream.
+fn split_alignment_template(qname: &[u8]) -> Template {
+    use fgumi_raw_bam::flags::{FIRST_SEGMENT, LAST_SEGMENT, PAIRED, SECONDARY, SUPPLEMENTARY};
+
+    let record = |flags: u16, pos: i32, seq: &[u8], quals: &[u8]| {
+        let mut b = SamBuilder::new();
+        b.read_name(qname)
+            .flags(flags)
+            .ref_id(0)
+            .pos(pos)
+            // (length << 4) | op, where op 0 is `M`.
+            .cigar_ops(&[u32::try_from(seq.len()).expect("seq length fits u32") << 4])
+            .sequence(seq)
+            .qualities(quals);
+        b.build()
+    };
+
+    Template::from_records(vec![
+        record(PAIRED | FIRST_SEGMENT, 100, b"ACGT", &[30u8; 4]),
+        record(PAIRED | LAST_SEGMENT, 200, b"TTGCA", &[31u8; 5]),
+        record(PAIRED | FIRST_SEGMENT | SUPPLEMENTARY, 300, b"GGGCCC", &[32u8; 6]),
+        record(PAIRED | LAST_SEGMENT | SECONDARY, 400, b"TATATATA", &[33u8; 8]),
+    ])
+    .expect("split-alignment template")
+}
+
+/// A minimal record carrying `MI:Z:<mi>` — the only field `GroupByMi` reads.
+fn mi_record(mi: &str) -> RawRecord {
+    let mut b = SamBuilder::new();
+    b.read_name(b"read")
+        .flags(0)
+        .sequence(b"ACGT")
+        .qualities(&[30u8; 4])
+        .add_string_tag(*crate::sam::SamTag::MI, mi.as_bytes());
+    b.build()
+}
+
+/// A minimal record with no `MI` tag at all — dropped by `GroupByMi` and
+/// counted against `skipped_no_mi`.
+fn record_without_mi() -> RawRecord {
+    let mut b = SamBuilder::new();
+    b.read_name(b"read").flags(0).sequence(b"ACGT").qualities(&[30u8; 4]);
+    b.build()
+}
+
+/// A minimal record carrying `MI:i:<value>` — an integer where a string is
+/// required, so it groups nothing and is counted against
+/// `skipped_non_string_mi`.
+fn record_with_integer_mi(value: i32) -> RawRecord {
+    let mut b = SamBuilder::new();
+    b.read_name(b"read")
+        .flags(0)
+        .sequence(b"ACGT")
+        .qualities(&[30u8; 4])
+        .add_int_tag(*crate::sam::SamTag::MI, value);
+    b.build()
+}
+
+/// Wrap raw records in a [`DecodedRecordBatch`]. The [`GroupKey`] is left at
+/// its default because `GroupByMi` re-reads the MI tag from the record bytes
+/// and never consults the pre-computed key.
+fn decoded_batch(batch_serial: u64, records: Vec<RawRecord>) -> DecodedRecordBatch {
+    DecodedRecordBatch::new(
+        batch_serial,
+        records
+            .into_iter()
+            .map(|raw| {
+                fgumi_bam_io::DecodedRecord::from_raw_bytes(raw, fgumi_bam_io::GroupKey::default())
+            })
+            .collect(),
+    )
 }
 
 // ============================================================================
@@ -207,6 +293,54 @@ where
     }
 
     fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        match ctx.input.pop() {
+            Some(item) => {
+                self.collected.lock().expect("sink mutex not poisoned").push(item);
+                Ok(StepOutcome::Progress)
+            }
+            None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+            None => Ok(StepOutcome::NoProgress),
+        }
+    }
+}
+
+/// Like [`CollectSink`], but ignores its input for the first `remaining_stalls`
+/// calls.
+///
+/// Stalling the terminal step is what lets an upstream byte-bounded output
+/// queue actually fill up. With a sink that drains on every tick the queue
+/// returns to zero bytes between pushes, so `cur >= limit` never holds at push
+/// time and the producer's held-slot retry path is never taken — at one thread
+/// it is structurally unreachable, and at four it depends on scheduling. That
+/// makes a "this exercises backpressure" claim untrue exactly when the test
+/// looks like it passes.
+struct StallingCollectSink<T: Send + 'static> {
+    collected: Arc<Mutex<Vec<T>>>,
+    remaining_stalls: usize,
+}
+
+impl<T> Step for StallingCollectSink<T>
+where
+    T: Send + HeapSize + 'static,
+{
+    type Input = T;
+    type Outputs = ();
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "StallingCollectSink",
+            kind: StepKind::Exclusive,
+            sticky: false,
+            output_queues: vec![],
+            branch_ordering: vec![],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if self.remaining_stalls > 0 {
+            self.remaining_stalls -= 1;
+            return Ok(StepOutcome::NoProgress);
+        }
         match ctx.input.pop() {
             Some(item) => {
                 self.collected.lock().expect("sink mutex not poisoned").push(item);
@@ -604,6 +738,1450 @@ fn a_truncated_record_stream_fails_the_run(#[values(1, 4)] threads: usize) {
         }
         other => panic!("expected an I/O failure from the boundary step, got {other:?}"),
     }
+}
+
+/// `ReplaySource → TemplatesToRecordBatch` is the AAM-fusion adapter: it turns
+/// the queryname-template view back into the flat-record view the sort ingest
+/// consumes. Driving it through `Pipeline::run` (rather than re-running its
+/// flattening loop in a unit test) is what exercises `try_run` itself — the
+/// held-slot retry, the drain path, and the last-clone `Finished` gate that a
+/// `Parallel` step only reaches under the framework.
+///
+/// Every record of every template must arrive downstream exactly once,
+/// byte-for-byte, in template order, in a batch carrying the input batch's
+/// serial — *including* the secondary and supplementary alignments.
+#[rstest]
+fn templates_to_records_flattens_every_record_including_split_alignments(
+    #[values(1, 4)] threads: usize,
+) {
+    use crate::pipeline::steps::templates_to_records::TemplatesToRecordBatch;
+    use crate::pipeline::steps::types::BamTemplateBatch;
+
+    const N_BATCHES: u64 = 200;
+    const TEMPLATES_PER_BATCH: usize = 2;
+    const RECORDS_PER_TEMPLATE: usize = 4;
+
+    // Record each template's records in `records` order — the order the step is
+    // contracted to emit. Reading that off the template rather than hard-coding
+    // r1/r2/supplementary/secondary keeps this a test of the flattening step,
+    // not of `Template::from_records`' internal layout.
+    let mut expected: Vec<Vec<u8>> = Vec::new();
+    let mut batches: Vec<BamTemplateBatch> = Vec::new();
+    for serial in 0..N_BATCHES {
+        let templates: Vec<Template> = (0..TEMPLATES_PER_BATCH)
+            .map(|t| split_alignment_template(format!("q{serial}_{t}").as_bytes()))
+            .collect();
+        for template in &templates {
+            expected.extend(template.records.iter().map(|r| r.as_ref().to_vec()));
+        }
+        batches.push(BamTemplateBatch::new(serial, templates));
+    }
+
+    // Same guard as `the_edge_budget_binds_on_the_multi_record_fixtures`: unless
+    // the fixture volume exceeds the per-edge budget the output queue never
+    // rejects a push, and the step's held-slot retry path — the whole reason for
+    // running this through the framework — goes unexercised.
+    let fixture_bytes: usize = batches.iter().map(BamTemplateBatch::total_bytes).sum();
+    assert!(
+        u64::try_from(fixture_bytes).expect("fixture volume fits u64") > EDGE_LIMIT_BYTES,
+        "fixture volume ({fixture_bytes} B) must exceed the per-edge budget \
+         ({EDGE_LIMIT_BYTES} B), else the held-slot retry path never runs",
+    );
+
+    let collected: Arc<Mutex<Vec<RecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(batches))
+        .chain(TemplatesToRecordBatch::new(EDGE_LIMIT_BYTES))
+        .chain(StallingCollectSink {
+            collected: sink_handle,
+            remaining_stalls: PROCESS_SINK_STALLS,
+        })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let emitted = collected.lock().expect("mutex not poisoned");
+
+    // One output batch per input batch, each carrying its input's serial, in
+    // ordinal order — the contract `BranchOrdering::ByItemOrdinal` consumers
+    // downstream depend on.
+    let serials: Vec<u64> = emitted.iter().map(RecordBatch::batch_serial).collect();
+    assert_eq!(
+        serials,
+        (0..N_BATCHES).collect::<Vec<u64>>(),
+        "each input batch must yield one output batch carrying its serial, in order",
+    );
+
+    // Batch boundaries are preserved 1:1 — the step neither splits an input
+    // batch across outputs nor coalesces several into one. Reported as the first
+    // offending batch rather than an `assert_eq!` over the whole vector, which
+    // would dump 200 elements to name a single bad one.
+    let expected_per_batch = TEMPLATES_PER_BATCH * RECORDS_PER_TEMPLATE;
+    if let Some((i, n)) =
+        emitted.iter().map(RecordBatch::len).enumerate().find(|&(_, n)| n != expected_per_batch)
+    {
+        panic!(
+            "output batch {i} holds {n} records, expected {expected_per_batch} — \
+             every output batch must hold exactly its input batch's records",
+        );
+    }
+
+    let seen: Vec<Vec<u8>> =
+        emitted.iter().flat_map(|batch| batch.iter_record_bytes().map(<[u8]>::to_vec)).collect();
+    assert_eq!(
+        seen.len(),
+        expected.len(),
+        "every record — primary, supplementary, and secondary — must be emitted exactly once",
+    );
+    // Likewise pinpointed: a whole-vector compare of ~1,600 records would print
+    // the entire fixture to report one differing byte.
+    if let Some((i, (got, want))) =
+        seen.iter().zip(&expected).enumerate().find(|(_, (got, want))| got != want)
+    {
+        panic!("record {i} was altered in flight: got {got:02x?}, expected {want:02x?}");
+    }
+}
+
+/// `ReplaySource → GroupByMi` drives the MI grouper through the framework.
+///
+/// Its unit tests all call `process_record` / `flush_current_group` directly,
+/// which leaves `try_run` — where the ordinals are minted, the held slot is
+/// retried, and drain is sequenced — entirely unexercised. Each of those fails
+/// by *silently truncating* output rather than erroring, so nothing downstream
+/// would notice:
+///
+/// * **Ordinal contiguity.** `GroupByMi` mints its own batch serials, and the
+///   `ByItemOrdinal` reorder stage releases only in contiguous order — a
+///   skipped or reused serial stalls it forever.
+/// * **Held-slot retry.** `output_byte_limit` is deliberately smaller than one
+///   emitted batch, and the sink stalls long enough for the queue to fill, so
+///   pushes bounce and `emit_batch` parks the batch in `held`. The retry must
+///   not mint a second ordinal for it. Both halves are needed: with a sink that
+///   drains every tick the queue empties between pushes and this path is never
+///   taken at all (verified by injecting a double-ordinal bug, which a
+///   non-stalling sink failed to catch at one thread).
+/// * **Drain sequencing.** The molecule count is not a multiple of the target
+///   batch count, so the run-in-progress must be flushed and emitted as a final
+///   partial batch *before* `Finished`.
+#[rstest]
+fn group_by_mi_emits_contiguous_batches_ending_in_a_partial(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::group::mi::{BatchedMiGroups, GroupByMi};
+
+    const N_MOLECULES: usize = 337;
+    const RECORDS_PER_MOLECULE: usize = 3;
+    const TARGET_BATCH_COUNT: usize = 10;
+    // Deliberately coprime with `RECORDS_PER_MOLECULE` so molecule runs straddle
+    // input-batch boundaries — the run-length state must survive across calls.
+    const RECORDS_PER_INPUT_BATCH: usize = 7;
+    // Smaller than one emitted batch, so the second push always bounces.
+    const OUTPUT_BYTE_LIMIT: u64 = 1024;
+    // Long enough for the grouper to emit and then bounce against a full queue,
+    // but no longer: each stall costs the driver a back-off interval, so a
+    // larger count buys nothing and adds seconds to the multi-threaded case.
+    // Calibrated by injecting the double-ordinal bug and finding the smallest
+    // count the single-threaded case still catches it at (16), then leaving a
+    // margin for scheduling variance. At 8 the bug slips through.
+    const SINK_STALLS: usize = 24;
+
+    assert_ne!(
+        N_MOLECULES % TARGET_BATCH_COUNT,
+        0,
+        "the fixture must leave a partial final batch, else the drain arm is untested",
+    );
+
+    let records: Vec<RawRecord> = (0..N_MOLECULES)
+        .flat_map(|m| (0..RECORDS_PER_MOLECULE).map(move |_| mi_record(&format!("mol{m}"))))
+        .collect();
+    let batches: Vec<DecodedRecordBatch> = records
+        .chunks(RECORDS_PER_INPUT_BATCH)
+        .enumerate()
+        .map(|(i, chunk)| decoded_batch(i as u64, chunk.to_vec()))
+        .collect();
+
+    let collected: Arc<Mutex<Vec<BatchedMiGroups>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(batches))
+        .chain(GroupByMi::with_target_batch_count(
+            *crate::sam::SamTag::MI,
+            OUTPUT_BYTE_LIMIT,
+            TARGET_BATCH_COUNT,
+        ))
+        .chain(StallingCollectSink { collected: sink_handle, remaining_stalls: SINK_STALLS })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let emitted = collected.lock().expect("mutex not poisoned");
+
+    // Several batches, or the contiguity claim below is vacuous.
+    assert!(
+        emitted.len() > 1,
+        "fixture must span several output batches, got {}; the ordinal contiguity and \
+         held-slot paths only run when more than one batch is emitted",
+        emitted.len(),
+    );
+
+    // The load-bearing assertion: serials are dense and start at zero. A held
+    // batch that minted a second ordinal on retry, or a dropped emit, shows up
+    // here as a gap or a duplicate.
+    let serials: Vec<u64> = emitted.iter().map(|b| b.batch_serial).collect();
+    assert_eq!(
+        serials,
+        (0..emitted.len() as u64).collect::<Vec<u64>>(),
+        "emitted batch serials must be contiguous from zero",
+    );
+
+    // No batch is emitted empty — an empty emit would burn an ordinal for
+    // nothing, which the drain arm's `!accumulator.is_empty()` guard prevents.
+    assert!(emitted.iter().all(|b| !b.groups.is_empty()), "no batch may be emitted empty");
+
+    // Every molecule arrives exactly once, in order, with all its records.
+    let groups: Vec<(String, usize)> =
+        emitted.iter().flat_map(|b| &b.groups).map(|g| (g.mi.clone(), g.records.len())).collect();
+    let expected: Vec<(String, usize)> =
+        (0..N_MOLECULES).map(|m| (format!("mol{m}"), RECORDS_PER_MOLECULE)).collect();
+    assert_eq!(
+        groups.len(),
+        expected.len(),
+        "every molecule must be emitted exactly once — a truncated tail means the drain \
+         arm dropped the final partial batch",
+    );
+    if let Some((i, (got, want))) =
+        groups.iter().zip(&expected).enumerate().find(|(_, (got, want))| got != want)
+    {
+        panic!("group {i} differs: got {got:?}, expected {want:?}");
+    }
+
+    // The batch cap: no emitted batch may exceed the target, even though one
+    // `add_records` call can complete more groups than that. Without this, a
+    // regression that let the accumulator grow past the cap before emitting
+    // would keep serials dense, keep every molecule present, and still leave a
+    // short final batch — passing every other assertion here.
+    if let Some((i, n)) =
+        emitted.iter().map(|b| b.groups.len()).enumerate().find(|&(_, n)| n > TARGET_BATCH_COUNT)
+    {
+        panic!("batch {i} holds {n} groups, above the {TARGET_BATCH_COUNT} cap");
+    }
+
+    // The last batch is the partial one the drain arm flushed.
+    let last = emitted.last().expect("at least one batch");
+    assert!(
+        last.groups.len() < TARGET_BATCH_COUNT,
+        "the final batch must be the short one emitted at drain, got {} groups",
+        last.groups.len(),
+    );
+}
+
+/// Records with no usable MI tag must be dropped without disturbing the
+/// grouping of the records around them, and the chain must still reach the
+/// drain arm — which is where the skipped-record warnings are reported.
+///
+/// The counters themselves are unit-tested; what only the framework reaches is
+/// `try_run`'s drain arm calling `report_skipped_records` and *still* returning
+/// `Finished`. A regression that returned early there would hang the chain
+/// rather than truncate it.
+#[rstest]
+fn group_by_mi_drops_untagged_records_and_still_completes(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::group::mi::{BatchedMiGroups, GroupByMi};
+
+    // Untagged and integer-MI records are interleaved *inside* a molecule run,
+    // so a regression that reset the run on a skip would split "mol0" in two.
+    let records = [
+        record_without_mi(),
+        mi_record("mol0"),
+        record_with_integer_mi(1),
+        mi_record("mol0"),
+        record_without_mi(),
+        mi_record("mol1"),
+        record_with_integer_mi(2),
+    ];
+    let batches: Vec<DecodedRecordBatch> = records
+        .chunks(2)
+        .enumerate()
+        .map(|(i, chunk)| decoded_batch(i as u64, chunk.to_vec()))
+        .collect();
+
+    let collected: Arc<Mutex<Vec<BatchedMiGroups>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(batches))
+        .chain(GroupByMi::new(*crate::sam::SamTag::MI, EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let emitted = collected.lock().expect("mutex not poisoned");
+    let groups: Vec<(String, usize)> =
+        emitted.iter().flat_map(|b| &b.groups).map(|g| (g.mi.clone(), g.records.len())).collect();
+    assert_eq!(
+        groups,
+        vec![("mol0".to_string(), 2), ("mol1".to_string(), 1)],
+        "untagged and wrong-typed records must be dropped without splitting the runs \
+         they sit inside",
+    );
+}
+
+/// A trivial ordered item: `ordinal` is its place in a branch's sequence,
+/// `value` identifies which input produced it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Numbered {
+    ordinal: u64,
+    value: u64,
+}
+
+/// A deliberately non-zero weight. `HeapSize`'s default returns 0, and a
+/// zero-weight item can never fill a `ByteBounded` queue — `current_bytes`
+/// stays at 0, every push is admitted, and the held-slot retry arms of every
+/// byte-bounded step below become unreachable. Giving the item a weight is what
+/// lets a small `limit_bytes` actually bind.
+impl HeapSize for Numbered {
+    fn heap_size(&self) -> usize {
+        128
+    }
+}
+
+impl Ordered for Numbered {
+    fn ordinal(&self) -> u64 {
+        self.ordinal
+    }
+}
+
+/// Returning `None` for a branch of a [`Process2Ordered`] must not stall the
+/// chain **when that branch mints its own dense, branch-local ordinals**.
+///
+/// This is the safe half of the contract documented on `Process2Output`. The
+/// unsafe half — a branch that propagates the *input's* ordinal and then omits
+/// an item — leaves a permanent hole, and the `ByItemOrdinal` reorder stage
+/// releases only in contiguous order, so it waits for an ordinal that will
+/// never arrive. That failure mode is a **hang**, which is precisely why it is
+/// not reproduced here: a test that builds the wedged configuration on purpose
+/// can only assert "still not finished after N seconds", which is slow, and
+/// proves a timeout rather than the contract. Asserting the safe direction
+/// positively pins the same rule without ever constructing the stall.
+///
+/// Note the test is still hang-*sensitive*, just not hang-*dependent*: if a
+/// regression made sparse output wedge this chain, the run would never return
+/// and nextest would kill it at its slow-test timeout. It fails either way —
+/// it just does not need the stall to pass.
+#[rstest]
+fn sparse_ordered_fan_out_completes_when_each_branch_mints_its_own_ordinals(
+    #[values(1, 4)] threads: usize,
+) {
+    use crate::pipeline::steps::process::{Process2Output, process2_ordered};
+
+    const N_INPUTS: u64 = 300;
+    // Every third input goes to B, the rest to A — so *both* branches see
+    // `None` for a substantial share of the inputs.
+    const B_EVERY: u64 = 3;
+
+    let inputs: Vec<Numbered> = (0..N_INPUTS).map(|i| Numbered { ordinal: i, value: i }).collect();
+
+    // Branch-local ordinal counters. Shared across worker clones (the closure is
+    // `Fn` behind an `Arc`), so at four threads the *assignment* of ordinals to
+    // values races — but the sequence each branch mints stays dense, which is
+    // the property the reorder stage actually requires.
+    let next_a = Arc::new(AtomicU64::new(0));
+    let next_b = Arc::new(AtomicU64::new(0));
+    let (mint_a, mint_b) = (Arc::clone(&next_a), Arc::clone(&next_b));
+
+    let collected_a: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let collected_b: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let (sink_a, sink_b) = (Arc::clone(&collected_a), Arc::clone(&collected_b));
+
+    let builder = Pipeline::builder();
+    let multi = builder
+        .chain(ReplaySource::new(inputs))
+        .chain(process2_ordered(
+            "SparseFanOut",
+            EDGE_LIMIT_BYTES,
+            EDGE_LIMIT_BYTES,
+            move |item: Numbered| {
+                if item.value.is_multiple_of(B_EVERY) {
+                    let ordinal = mint_b.fetch_add(1, AtomicOrdering::Relaxed);
+                    Ok(Process2Output::only_b(Numbered { ordinal, value: item.value }))
+                } else {
+                    let ordinal = mint_a.fetch_add(1, AtomicOrdering::Relaxed);
+                    Ok(Process2Output::only_a(Numbered { ordinal, value: item.value }))
+                }
+            },
+        ))
+        .into_multi();
+    multi.b0.chain(CollectSink { collected: sink_a }).into_sink_marker();
+    multi.b1.chain(CollectSink { collected: sink_b }).into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let branch_a = collected_a.lock().expect("mutex not poisoned");
+    let branch_b = collected_b.lock().expect("mutex not poisoned");
+
+    // Both branches must have skipped some inputs, or "sparse" is vacuous and
+    // this degenerates into an ordinary every-item fan-out test.
+    assert!(!branch_a.is_empty() && !branch_b.is_empty(), "both branches must receive items");
+    assert_eq!(
+        branch_a.len() as u64 + branch_b.len() as u64,
+        N_INPUTS,
+        "every input must reach exactly one branch",
+    );
+
+    // The load-bearing assertion: each branch released a dense sequence from
+    // zero, in order. A hole would have stalled the reorder stage instead.
+    for (name, branch) in [("a", &*branch_a), ("b", &*branch_b)] {
+        let ordinals: Vec<u64> = branch.iter().map(|n| n.ordinal).collect();
+        assert_eq!(
+            ordinals,
+            (0..branch.len() as u64).collect::<Vec<u64>>(),
+            "branch {name} must release a dense ordinal sequence from zero",
+        );
+    }
+
+    // Nothing was routed to the wrong branch, dropped, or duplicated. Sorted
+    // because ordinal assignment races across workers at four threads.
+    let mut values_a: Vec<u64> = branch_a.iter().map(|n| n.value).collect();
+    let mut values_b: Vec<u64> = branch_b.iter().map(|n| n.value).collect();
+    values_a.sort_unstable();
+    values_b.sort_unstable();
+    assert_eq!(
+        values_a,
+        (0..N_INPUTS).filter(|v| !v.is_multiple_of(B_EVERY)).collect::<Vec<u64>>()
+    );
+    assert_eq!(values_b, (0..N_INPUTS).filter(|v| v.is_multiple_of(B_EVERY)).collect::<Vec<u64>>());
+}
+
+/// A single-end primary record with the given queryname.
+fn single_end_record(qname: &[u8]) -> RawRecord {
+    let mut b = SamBuilder::new();
+    b.read_name(qname)
+        .flags(0)
+        .ref_id(0)
+        .pos(100)
+        .cigar_ops(&[4u32 << 4])
+        .sequence(b"ACGT")
+        .qualities(&[30u8; 4]);
+    b.build()
+}
+
+/// Wrap raw records in a [`DecodedRecordBatch`], pairing each with an explicit
+/// [`GroupKey`]. Position and queryname grouping both key off the pre-computed
+/// key rather than re-parsing the record, so the key is the fixture.
+fn decoded_batch_with_keys(
+    batch_serial: u64,
+    records: Vec<(RawRecord, fgumi_bam_io::GroupKey)>,
+) -> DecodedRecordBatch {
+    DecodedRecordBatch::new(
+        batch_serial,
+        records
+            .into_iter()
+            .map(|(raw, key)| fgumi_bam_io::DecodedRecord::from_raw_bytes(raw, key))
+            .collect(),
+    )
+}
+
+/// A single-end position key at `pos` — `strand2` stays `UNKNOWN_STRAND`, so
+/// `has_mate_position()` is false and the grouper's MC-tag validation (which
+/// only applies to *paired* primaries) is not triggered.
+fn position_key_at(pos: i32) -> fgumi_bam_io::GroupKey {
+    fgumi_bam_io::GroupKey { ref_id1: 0, pos1: pos, strand1: 0, ..Default::default() }
+}
+
+/// Hash a queryname the way the decode step would, so `GroupByQueryname`'s
+/// `name_hash` fast-path pre-check is exercised rather than short-circuited by
+/// a constant hash.
+///
+/// This routes through `LibraryIndex::hash_name`, the exact hasher
+/// `compute_group_key_from_raw` uses to fill `GroupKey::name_hash` on the decode
+/// path (an empty name maps to `hash_name(None)`), so a key built here is
+/// byte-for-byte comparable to one the grouper computes rather than merely
+/// self-consistent.
+fn name_hash_of(qname: &[u8]) -> u64 {
+    let name = if qname.is_empty() { None } else { Some(qname) };
+    fgumi_bam_io::LibraryIndex::hash_name(name)
+}
+
+/// Split a `DecompressedBlock` byte stream — framed `block_size` + body per
+/// record — back into record bodies, asserting the framing is well-formed.
+///
+/// The framing is half of what `SerializeGroups` produces, so parsing it back
+/// rather than comparing opaque bytes is what makes a truncated or
+/// wrongly-sized prefix fail loudly here instead of much further downstream.
+fn unframe_records(bytes: &[u8]) -> Vec<Vec<u8>> {
+    let mut out = Vec::new();
+    let mut pos = 0usize;
+    while pos < bytes.len() {
+        assert!(pos + 4 <= bytes.len(), "truncated block_size prefix at byte {pos}");
+        let len = u32::from_le_bytes(bytes[pos..pos + 4].try_into().expect("4 bytes")) as usize;
+        pos += 4;
+        assert!(pos + len <= bytes.len(), "block_size {len} at byte {pos} runs past the stream");
+        out.push(bytes[pos..pos + len].to_vec());
+        pos += len;
+    }
+    out
+}
+
+/// One `ProcessedPositionGroup` holding `n_templates` paired templates, each
+/// tagged with the molecule id `mi` (use [`MoleculeId::None`] for the
+/// pass-through path, which must emit the record bytes unchanged).
+fn processed_group(
+    qname_prefix: &str,
+    n_templates: usize,
+    mi: fgumi_umi::MoleculeId,
+) -> ProcessedPositionGroup {
+    let templates: Vec<Template> = (0..n_templates)
+        .map(|t| {
+            let mut template = split_alignment_template(format!("{qname_prefix}_{t}").as_bytes());
+            template.mi = mi;
+            template
+        })
+        .collect();
+    let input_record_count = templates.iter().map(|t| t.records.len() as u64).sum();
+    ProcessedPositionGroup {
+        templates,
+        family_sizes: ahash::AHashMap::new(),
+        filter_metrics: crate::grouper::FilterMetrics::default(),
+        input_record_count,
+        distinct_mi_count: u64::from(mi.id().is_some()),
+    }
+}
+
+/// `ReplaySource → SerializeGroups` covers `build_serialize_processed_groups_step`,
+/// which had no test at all.
+///
+/// The step does two things in one pass — rewrite the MI tag into each record's
+/// body, and frame each body with its BAM `block_size` prefix — and both are
+/// asserted here by parsing the emitted stream back apart.
+///
+/// The MI half matters beyond line coverage: `emit_templates_raw_with_mi` is
+/// deliberately shared with the single-threaded writer in `commands::group`
+/// precisely so the two cannot drift in MI-injection semantics. Nothing was
+/// pinning that shared behavior, so a change to it would have been invisible
+/// on both paths.
+///
+/// Both branches of the emit are exercised: templates with an assigned
+/// `MoleculeId` get `MI:Z:<id>` written into their records, while templates
+/// left at `MoleculeId::None` must pass through byte-for-byte untouched.
+///
+/// Note what the fixture pins about *which* records are emitted. The templates
+/// here carry four records each — primary R1 and R2 plus a supplementary and a
+/// secondary — and the step emits **only the two primaries**, because
+/// `emit_templates_raw_with_mi` iterates `[template.r1(), template.r2()]`. That
+/// matches its doc ("primary reads") and is asserted rather than worked around:
+/// it is a real output-shaping decision, and a change that started emitting
+/// split alignments would otherwise slip through silently.
+#[rstest]
+fn serialize_processed_groups_frames_every_record_and_injects_mi(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::serialize_processed::build_serialize_processed_groups_step;
+    use crate::pipeline::steps::types::DecompressedBlock;
+    use fgumi_umi::MoleculeId;
+
+    const N_BATCHES: u64 = 40;
+    const TEMPLATES_PER_GROUP: usize = 2;
+    // Records per template that the step *emits* (the two primaries). The
+    // fixture holds four; the progress counter instead totals every *input*
+    // record, which is why it has its own constant.
+    const EMITTED_PER_TEMPLATE: usize = 2;
+    const INPUT_RECORDS_PER_TEMPLATE: usize = 4;
+    // Two groups per batch: one MI-assigned, one left unassigned, so both emit
+    // branches run for every batch.
+    const GROUPS_PER_BATCH: usize = 2;
+
+    let mut expected: Vec<(Vec<u8>, Option<String>)> = Vec::new();
+    let mut batches: Vec<BatchedProcessedPositionGroups> = Vec::new();
+    for serial in 0..N_BATCHES {
+        let assigned = processed_group(
+            &format!("mi{serial}"),
+            TEMPLATES_PER_GROUP,
+            MoleculeId::Single(serial),
+        );
+        let untouched =
+            processed_group(&format!("raw{serial}"), TEMPLATES_PER_GROUP, MoleculeId::None);
+        for group in [&assigned, &untouched] {
+            for template in &group.templates {
+                let label = template.mi.id().map(|id| id.to_string());
+                // ONLY the primary R1/R2 — see the note on the test.
+                for raw in [template.r1(), template.r2()].into_iter().flatten() {
+                    expected.push((raw.to_vec(), label.clone()));
+                }
+            }
+        }
+        batches.push(BatchedProcessedPositionGroups::new(serial, vec![assigned, untouched]));
+    }
+
+    let collected: Arc<Mutex<Vec<DecompressedBlock>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let progress = Arc::new(AtomicU64::new(0));
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(batches))
+        .chain(build_serialize_processed_groups_step(
+            EDGE_LIMIT_BYTES,
+            *crate::sam::SamTag::MI,
+            Arc::clone(&progress),
+        ))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let emitted = collected.lock().expect("mutex not poisoned");
+
+    let serials: Vec<u64> = emitted.iter().map(|b| b.batch_serial).collect();
+    assert_eq!(
+        serials,
+        (0..N_BATCHES).collect::<Vec<u64>>(),
+        "each input batch must yield one block carrying its serial, in order",
+    );
+
+    // The progress counter is bumped with each batch's *input record* count.
+    let expected_records =
+        N_BATCHES * (GROUPS_PER_BATCH * TEMPLATES_PER_GROUP * INPUT_RECORDS_PER_TEMPLATE) as u64;
+    assert_eq!(
+        progress.load(AtomicOrdering::Relaxed),
+        expected_records,
+        "the shared progress counter must total every input record",
+    );
+
+    let bodies: Vec<Vec<u8>> =
+        emitted.iter().flat_map(|block| unframe_records(&block.bytes)).collect();
+    assert_eq!(
+        bodies.len(),
+        expected.len(),
+        "every primary record must be framed and emitted exactly once",
+    );
+    // Stated as its own arithmetic so the primaries-only contract is visible
+    // rather than implied by the length of `expected`.
+    assert_eq!(
+        bodies.len() as u64,
+        N_BATCHES * (GROUPS_PER_BATCH * TEMPLATES_PER_GROUP * EMITTED_PER_TEMPLATE) as u64,
+        "the step emits primaries only — supplementary and secondary records are excluded",
+    );
+    assert!(
+        bodies.iter().all(|b| {
+            let flags = u16::from_le_bytes([b[14], b[15]]);
+            flags & (fgumi_raw_bam::flags::SECONDARY | fgumi_raw_bam::flags::SUPPLEMENTARY) == 0
+        }),
+        "no emitted record may carry the secondary or supplementary flag",
+    );
+
+    for (i, (body, (original, want_mi))) in bodies.iter().zip(&expected).enumerate() {
+        let got_mi = fgumi_raw_bam::find_string_tag_in_record(body, *crate::sam::SamTag::MI)
+            .map(|v| String::from_utf8_lossy(v).into_owned());
+        assert_eq!(got_mi.as_deref(), want_mi.as_deref(), "record {i}: MI tag");
+        if want_mi.is_none() {
+            assert_eq!(
+                body, original,
+                "record {i}: an unassigned template must pass through byte-for-byte",
+            );
+        }
+    }
+}
+
+/// `ReplaySource → GroupByPosition` drives the position grouper through the
+/// framework. Like the MI grouper, its unit tests exercise helpers directly and
+/// leave `try_run`/`emit_batch` — the ordinal minting, the batch cap, and the
+/// `finish()`-once drain path — unrun.
+///
+/// Positions arrive in runs, so a group closes only when the position changes;
+/// the last run has no successor and can only be emitted by the drain arm
+/// calling the (non-idempotent) `grouper.finish()`, guarded by `finalized`.
+#[rstest]
+fn group_by_position_emits_contiguous_batches_ending_in_a_partial(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::group::position::{BatchedRawPositionGroups, GroupByPosition};
+
+    const N_POSITIONS: usize = 205;
+    const RECORDS_PER_POSITION: usize = 3;
+    const TARGET_BATCH_COUNT: usize = 8;
+    const RECORDS_PER_INPUT_BATCH: usize = 7;
+    const OUTPUT_BYTE_LIMIT: u64 = 1024;
+    const SINK_STALLS: usize = 24;
+
+    assert_ne!(
+        N_POSITIONS % TARGET_BATCH_COUNT,
+        0,
+        "the fixture must leave a partial final batch, else the drain arm is untested",
+    );
+
+    let records: Vec<(RawRecord, fgumi_bam_io::GroupKey)> = (0..N_POSITIONS)
+        .flat_map(|p| {
+            let key = position_key_at(i32::try_from(100 + p * 10).expect("pos fits i32"));
+            (0..RECORDS_PER_POSITION)
+                .map(move |r| (single_end_record(format!("p{p}_{r}").as_bytes()), key))
+        })
+        .collect();
+    let batches: Vec<DecodedRecordBatch> = records
+        .chunks(RECORDS_PER_INPUT_BATCH)
+        .enumerate()
+        .map(|(i, chunk)| decoded_batch_with_keys(i as u64, chunk.to_vec()))
+        .collect();
+
+    let collected: Arc<Mutex<Vec<BatchedRawPositionGroups>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(batches))
+        .chain(GroupByPosition::with_target_batch_count(OUTPUT_BYTE_LIMIT, TARGET_BATCH_COUNT))
+        .chain(StallingCollectSink { collected: sink_handle, remaining_stalls: SINK_STALLS })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let emitted = collected.lock().expect("mutex not poisoned");
+    assert!(emitted.len() > 1, "fixture must span several output batches");
+
+    let serials: Vec<u64> = emitted.iter().map(|b| b.batch_serial).collect();
+    assert_eq!(
+        serials,
+        (0..emitted.len() as u64).collect::<Vec<u64>>(),
+        "emitted batch serials must be contiguous from zero",
+    );
+    assert!(emitted.iter().all(|b| !b.groups.is_empty()), "no batch may be emitted empty");
+
+    // The batch cap: no emitted batch may exceed the target, even though one
+    // `add_records` call can complete more groups than that.
+    if let Some((i, n)) =
+        emitted.iter().map(|b| b.groups.len()).enumerate().find(|&(_, n)| n > TARGET_BATCH_COUNT)
+    {
+        panic!("batch {i} holds {n} groups, above the {TARGET_BATCH_COUNT} cap");
+    }
+
+    let sizes: Vec<usize> =
+        emitted.iter().flat_map(|b| &b.groups).map(|g| g.records.len()).collect();
+    assert_eq!(
+        sizes.len(),
+        N_POSITIONS,
+        "every position must be emitted exactly once — a short count means the drain arm \
+         dropped the final run that only `finish()` can close",
+    );
+    assert!(
+        sizes.iter().all(|&n| n == RECORDS_PER_POSITION),
+        "every position group must hold all of its records",
+    );
+}
+
+/// The default grouper drops secondary/supplementary records — they decode to
+/// an `UNKNOWN_REF` position key and have no position of their own — while
+/// `GroupByPosition::with_secondary_supplementary` keeps them, which is what
+/// `fgumi dedup` needs so the duplicate flag propagates across split
+/// alignments.
+///
+/// Run as one parameterized pair so the two constructors are compared on
+/// identical input; asserting only the inclusive case would not show that the
+/// default actually excludes.
+#[rstest]
+#[case::default_grouper_drops_them(false, 1)]
+#[case::with_secondary_supplementary_keeps_them(true, 2)]
+fn group_by_position_secondary_supplementary_policy(
+    #[case] include_secondary_supplementary: bool,
+    #[case] expected_groups: usize,
+) {
+    use crate::pipeline::steps::group::position::{BatchedRawPositionGroups, GroupByPosition};
+    use fgumi_bam_io::GroupKey;
+
+    // One positioned run, then a record carrying the UNKNOWN_REF key that a
+    // secondary/supplementary alignment decodes to.
+    let positioned = position_key_at(100);
+    let unknown = GroupKey::default(); // ref_id1 == UNKNOWN_REF
+    let records = vec![
+        (single_end_record(b"a"), positioned),
+        (single_end_record(b"b"), positioned),
+        (single_end_record(b"supp"), unknown),
+    ];
+
+    let collected: Arc<Mutex<Vec<BatchedRawPositionGroups>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let step = if include_secondary_supplementary {
+        GroupByPosition::with_secondary_supplementary(EDGE_LIMIT_BYTES)
+    } else {
+        GroupByPosition::new(EDGE_LIMIT_BYTES)
+    };
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(vec![decoded_batch_with_keys(0, records)]))
+        .chain(step)
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads: 1, ..Default::default() }).expect("chain runs");
+
+    let emitted = collected.lock().expect("mutex not poisoned");
+    let groups: Vec<usize> =
+        emitted.iter().flat_map(|b| &b.groups).map(|g| g.records.len()).collect();
+    assert_eq!(groups.len(), expected_groups, "position groups emitted: {groups:?}");
+    assert_eq!(groups[0], 2, "the positioned run always groups its two records");
+}
+
+/// `ReplaySource → GroupByQueryname` drives the queryname grouper through the
+/// framework, covering the same `try_run`/`emit_batch` surface: ordinal
+/// minting, the held-slot retry, and the drain arm that closes the final
+/// run-in-progress before reporting `Finished`.
+#[rstest]
+fn group_by_queryname_emits_contiguous_batches_ending_in_a_partial(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::group::queryname::GroupByQueryname;
+    use crate::pipeline::steps::types::BamTemplateBatch;
+    use fgumi_raw_bam::flags::{FIRST_SEGMENT, LAST_SEGMENT, PAIRED};
+
+    const N_TEMPLATES: usize = 203;
+    const TARGET_BATCH_COUNT: usize = 8;
+    const RECORDS_PER_INPUT_BATCH: usize = 5;
+    const OUTPUT_BYTE_LIMIT: u64 = 1024;
+    const SINK_STALLS: usize = 24;
+
+    assert_ne!(
+        N_TEMPLATES % TARGET_BATCH_COUNT,
+        0,
+        "the fixture must leave a partial final batch, else the drain arm is untested",
+    );
+
+    let paired = |qname: &[u8], flags: u16| {
+        let mut b = SamBuilder::new();
+        b.read_name(qname)
+            .flags(flags)
+            .ref_id(0)
+            .pos(100)
+            .cigar_ops(&[4u32 << 4])
+            .sequence(b"ACGT")
+            .qualities(&[30u8; 4]);
+        b.build()
+    };
+
+    let mut records: Vec<(RawRecord, fgumi_bam_io::GroupKey)> = Vec::new();
+    for t in 0..N_TEMPLATES {
+        let qname = format!("q{t:05}");
+        let key = fgumi_bam_io::GroupKey {
+            name_hash: name_hash_of(qname.as_bytes()),
+            ..Default::default()
+        };
+        records.push((paired(qname.as_bytes(), PAIRED | FIRST_SEGMENT), key));
+        records.push((paired(qname.as_bytes(), PAIRED | LAST_SEGMENT), key));
+    }
+    let batches: Vec<DecodedRecordBatch> = records
+        .chunks(RECORDS_PER_INPUT_BATCH)
+        .enumerate()
+        .map(|(i, chunk)| decoded_batch_with_keys(i as u64, chunk.to_vec()))
+        .collect();
+
+    let collected: Arc<Mutex<Vec<BamTemplateBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(batches))
+        .chain(GroupByQueryname::with_target_batch_count(OUTPUT_BYTE_LIMIT, TARGET_BATCH_COUNT))
+        .chain(StallingCollectSink { collected: sink_handle, remaining_stalls: SINK_STALLS })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let emitted = collected.lock().expect("mutex not poisoned");
+    assert!(emitted.len() > 1, "fixture must span several output batches");
+
+    let serials: Vec<u64> = emitted.iter().map(BamTemplateBatch::batch_serial).collect();
+    assert_eq!(
+        serials,
+        (0..emitted.len() as u64).collect::<Vec<u64>>(),
+        "emitted batch serials must be contiguous from zero",
+    );
+
+    // The batch cap: no emitted batch may exceed the target. Without this, a
+    // regression that let the accumulator grow past the cap before emitting
+    // would keep serials dense, keep every template present, and still leave a
+    // short final batch — passing every other assertion here.
+    if let Some((i, n)) = emitted
+        .iter()
+        .map(|b| b.templates().len())
+        .enumerate()
+        .find(|&(_, n)| n > TARGET_BATCH_COUNT)
+    {
+        panic!("batch {i} holds {n} templates, above the {TARGET_BATCH_COUNT} cap");
+    }
+
+    // Every queryname becomes exactly one template, in input order, holding
+    // both of its records.
+    let names: Vec<String> = emitted
+        .iter()
+        .flat_map(BamTemplateBatch::templates)
+        .map(|t| String::from_utf8_lossy(&t.name).into_owned())
+        .collect();
+    let expected: Vec<String> = (0..N_TEMPLATES).map(|t| format!("q{t:05}")).collect();
+    assert_eq!(
+        names.len(),
+        expected.len(),
+        "every queryname must yield one template — a short count means the drain arm \
+         dropped the run in progress",
+    );
+    if let Some((i, (got, want))) =
+        names.iter().zip(&expected).enumerate().find(|(_, (got, want))| got != want)
+    {
+        panic!("template {i} differs: got {got:?}, expected {want:?}");
+    }
+    assert!(
+        emitted.iter().flat_map(BamTemplateBatch::templates).all(|t| t.records.len() == 2),
+        "each template must hold both of its records",
+    );
+}
+
+/// Inputs for the closure-driven mid-step chains below.
+fn numbered_inputs(n: u64) -> Vec<Numbered> {
+    (0..n).map(|i| Numbered { ordinal: i, value: i }).collect()
+}
+
+/// Collect a sink's values, sorted — for the unordered (`BranchOrdering::None`)
+/// variants, where arrival order races across workers.
+fn sorted_values(sink: &Arc<Mutex<Vec<Numbered>>>) -> Vec<u64> {
+    let mut v: Vec<u64> =
+        sink.lock().expect("mutex not poisoned").iter().map(|n| n.value).collect();
+    v.sort_unstable();
+    v
+}
+
+const PROCESS_INPUTS: u64 = 200;
+
+/// Small enough that a handful of `Numbered` items exceed it, so the ordered
+/// mid-step chains below actually bounce a push and take their held-slot path.
+const PROCESS_EDGE_BYTES: u64 = 256;
+
+/// Ditto for the count-bounded variants.
+const PROCESS_EDGE_SLOTS: usize = 2;
+
+/// Ticks the terminal sink ignores before it starts draining, so the queue
+/// upstream of it fills. See [`StallingCollectSink`].
+const PROCESS_SINK_STALLS: usize = 64;
+
+/// The closure-driven mid-steps in `process.rs` are all the same state machine
+/// around a different output arity, and every one of their `try_run` bodies —
+/// held-slot retry, drain detection, `Finished` on the last clone — was
+/// reachable only through the framework. The unit tests in that module cover
+/// the `Process*Output` constructors and profiles, not the steps.
+///
+/// These chains exercise one variant each. They are deliberately small and
+/// uniform: the value being pinned is that each variant passes every input
+/// through exactly once and terminates, which is what a drain or held-slot
+/// regression breaks.
+#[rstest]
+fn process_chain_passes_every_item_through(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::process::process;
+
+    let collected: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(numbered_inputs(PROCESS_INPUTS)))
+        // `Process` is count-bounded and unordered; the doubling makes a
+        // pass-through implementation distinguishable from a real one.
+        .chain(process("Double", PROCESS_EDGE_SLOTS, |item: Numbered| {
+            Ok(Numbered { ordinal: item.ordinal, value: item.value * 2 })
+        }))
+        .chain(StallingCollectSink {
+            collected: sink_handle,
+            remaining_stalls: PROCESS_SINK_STALLS,
+        })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    assert_eq!(
+        sorted_values(&collected),
+        (0..PROCESS_INPUTS).map(|v| v * 2).collect::<Vec<u64>>(),
+        "every input must be transformed and emitted exactly once",
+    );
+}
+
+/// `ProcessOrdered` is the byte-bounded, `ByItemOrdinal` sibling of `Process`,
+/// so its output must arrive in input order rather than merely intact.
+#[rstest]
+fn process_ordered_chain_preserves_input_order(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::process::process_ordered;
+
+    let collected: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(numbered_inputs(PROCESS_INPUTS)))
+        .chain(process_ordered("DoubleOrdered", PROCESS_EDGE_BYTES, |item: Numbered| {
+            Ok(Numbered { ordinal: item.ordinal, value: item.value * 2 })
+        }))
+        .chain(StallingCollectSink {
+            collected: sink_handle,
+            remaining_stalls: PROCESS_SINK_STALLS,
+        })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let values: Vec<u64> =
+        collected.lock().expect("mutex not poisoned").iter().map(|n| n.value).collect();
+    assert_eq!(
+        values,
+        (0..PROCESS_INPUTS).map(|v| v * 2).collect::<Vec<u64>>(),
+        "an ordered branch must release in input order, not merely intact",
+    );
+}
+
+/// `ProcessWithWorkerState` lazily initializes one state value per worker and
+/// reuses it across items. The state here counts the items that worker handled,
+/// so the per-worker totals must sum to the input count however the framework
+/// distributes work.
+#[rstest]
+fn process_with_worker_state_chain_reuses_state_per_worker(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::process::process_with_worker_state;
+
+    let collected: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let inits = Arc::new(AtomicU64::new(0));
+    let init_counter = Arc::clone(&inits);
+    let handled = Arc::new(AtomicU64::new(0));
+    let handled_counter = Arc::clone(&handled);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(numbered_inputs(PROCESS_INPUTS)))
+        .chain(process_with_worker_state(
+            "CountPerWorker",
+            PROCESS_EDGE_BYTES,
+            move || {
+                init_counter.fetch_add(1, AtomicOrdering::Relaxed);
+                0u64 // per-worker item counter
+            },
+            move |seen: &mut u64, item: Numbered| {
+                *seen += 1;
+                handled_counter.fetch_add(1, AtomicOrdering::Relaxed);
+                Ok(Numbered { ordinal: item.ordinal, value: item.value })
+            },
+        ))
+        .chain(StallingCollectSink {
+            collected: sink_handle,
+            remaining_stalls: PROCESS_SINK_STALLS,
+        })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let values: Vec<u64> =
+        collected.lock().expect("mutex not poisoned").iter().map(|n| n.value).collect();
+    assert_eq!(values, (0..PROCESS_INPUTS).collect::<Vec<u64>>(), "ordered output, in order");
+    // State is created lazily per worker, so at most one per worker — never one
+    // per item, which is the regression this construction exists to avoid.
+    let inits = inits.load(AtomicOrdering::Relaxed);
+    assert!(
+        inits >= 1 && inits <= threads as u64,
+        "expected between 1 and {threads} state initializations, got {inits}",
+    );
+    // The per-worker counters must sum to the input count however the framework
+    // distributes work — the claim the doc comment makes, now pinned. Summing
+    // through the shared accumulator is what distinguishes "each item handled by
+    // some worker" from a drain regression that silently drops items.
+    assert_eq!(
+        handled.load(AtomicOrdering::Relaxed),
+        PROCESS_INPUTS,
+        "per-worker counters must total the input count",
+    );
+}
+
+/// `MiAssign` threads a single running counter through the closure so emitted
+/// molecule ids are globally consecutive. It is `Serial`, so the counter needs
+/// no synchronization — and the assertion is that the ids come out dense and
+/// in order regardless of thread count.
+#[rstest]
+fn mi_assign_chain_hands_out_consecutive_ids(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::process::mi_assign;
+
+    const IDS_PER_ITEM: u64 = 2;
+
+    let collected: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(numbered_inputs(PROCESS_INPUTS)))
+        .chain(mi_assign("AssignIds", PROCESS_EDGE_BYTES, |next_mi: &mut u64, item: Numbered| {
+            let base = *next_mi;
+            *next_mi += IDS_PER_ITEM;
+            Ok(Numbered { ordinal: item.ordinal, value: base })
+        }))
+        .chain(StallingCollectSink {
+            collected: sink_handle,
+            remaining_stalls: PROCESS_SINK_STALLS,
+        })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let values: Vec<u64> =
+        collected.lock().expect("mutex not poisoned").iter().map(|n| n.value).collect();
+    assert_eq!(
+        values,
+        (0..PROCESS_INPUTS).map(|i| i * IDS_PER_ITEM).collect::<Vec<u64>>(),
+        "each item must reserve its own block of ids, consecutively and in order",
+    );
+}
+
+/// `Process2` fans out to two *unordered* branches, each with its own held
+/// slot. Splitting on parity sends every input to exactly one branch, so a
+/// dropped held item shows up as a missing value on one side.
+#[rstest]
+fn process2_chain_splits_across_both_branches(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::process::{Process2Output, process2};
+
+    let collected_a: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let collected_b: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let (sink_a, sink_b) = (Arc::clone(&collected_a), Arc::clone(&collected_b));
+
+    let builder = Pipeline::builder();
+    let multi = builder
+        .chain(ReplaySource::new(numbered_inputs(PROCESS_INPUTS)))
+        .chain(process2("SplitParity", PROCESS_EDGE_SLOTS, PROCESS_EDGE_SLOTS, |item: Numbered| {
+            Ok(if item.value.is_multiple_of(2) {
+                Process2Output::only_a(item)
+            } else {
+                Process2Output::only_b(item)
+            })
+        }))
+        .into_multi();
+    multi
+        .b0
+        .chain(StallingCollectSink { collected: sink_a, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    multi
+        .b1
+        .chain(StallingCollectSink { collected: sink_b, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    assert_eq!(
+        sorted_values(&collected_a),
+        (0..PROCESS_INPUTS).filter(|v| v.is_multiple_of(2)).collect::<Vec<u64>>(),
+    );
+    assert_eq!(
+        sorted_values(&collected_b),
+        (0..PROCESS_INPUTS).filter(|v| !v.is_multiple_of(2)).collect::<Vec<u64>>(),
+    );
+}
+
+/// `Process2WithWorkerState` is the kept/rejects shape with per-worker scratch
+/// — `correct`'s cache lives here. Both branches are ordered, and both receive
+/// every item, so each must release a dense sequence.
+#[rstest]
+fn process2_with_worker_state_chain_feeds_both_ordered_branches(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::process::{Process2Output, process2_with_worker_state};
+
+    let collected_a: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let collected_b: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let (sink_a, sink_b) = (Arc::clone(&collected_a), Arc::clone(&collected_b));
+
+    let builder = Pipeline::builder();
+    let multi = builder
+        .chain(ReplaySource::new(numbered_inputs(PROCESS_INPUTS)))
+        .chain(process2_with_worker_state(
+            "KeptAndRejects",
+            PROCESS_EDGE_BYTES,
+            PROCESS_EDGE_BYTES,
+            || 0u64,
+            |seen: &mut u64, item: Numbered| {
+                *seen += 1;
+                Ok(Process2Output::both(
+                    Numbered { ordinal: item.ordinal, value: item.value },
+                    Numbered { ordinal: item.ordinal, value: item.value * 10 },
+                ))
+            },
+        ))
+        .into_multi();
+    multi
+        .b0
+        .chain(StallingCollectSink { collected: sink_a, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    multi
+        .b1
+        .chain(StallingCollectSink { collected: sink_b, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let values_a: Vec<u64> =
+        collected_a.lock().expect("mutex not poisoned").iter().map(|n| n.value).collect();
+    let values_b: Vec<u64> =
+        collected_b.lock().expect("mutex not poisoned").iter().map(|n| n.value).collect();
+    assert_eq!(values_a, (0..PROCESS_INPUTS).collect::<Vec<u64>>(), "branch a, in order");
+    assert_eq!(
+        values_b,
+        (0..PROCESS_INPUTS).map(|v| v * 10).collect::<Vec<u64>>(),
+        "branch b, in order",
+    );
+}
+
+/// `Process3WithWorkerState` widens the same shape to three ordered branches —
+/// the FASTQ-encode fan-out (R1 / R2 / other).
+///
+/// This step had no test because it had no way to be *wired*: `OrderedBytesTuple3`
+/// carried queue and handle support but no `Chain::into_multi`, unlike its
+/// 2-branch sibling, and `append_step` exposes only branch 0. The step
+/// type-checked and built and was simply unreachable. `into_multi` for the
+/// 3-branch ordered shape is added alongside this test.
+#[rstest]
+fn process3_with_worker_state_chain_feeds_all_three_branches(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::process::{Process3Output, process3_with_worker_state};
+
+    let sinks: [Arc<Mutex<Vec<Numbered>>>; 3] =
+        std::array::from_fn(|_| Arc::new(Mutex::new(Vec::new())));
+    let [sink_a, sink_b, sink_c]: [Arc<Mutex<Vec<Numbered>>>; 3] =
+        std::array::from_fn(|i| Arc::clone(&sinks[i]));
+
+    let builder = Pipeline::builder();
+    let multi = builder
+        .chain(ReplaySource::new(numbered_inputs(PROCESS_INPUTS)))
+        .chain(process3_with_worker_state(
+            "FanOut3",
+            PROCESS_EDGE_BYTES,
+            PROCESS_EDGE_BYTES,
+            PROCESS_EDGE_BYTES,
+            || 0u64,
+            |seen: &mut u64, item: Numbered| {
+                *seen += 1;
+                Ok(Process3Output::both3(
+                    Numbered { ordinal: item.ordinal, value: item.value },
+                    Numbered { ordinal: item.ordinal, value: item.value * 10 },
+                    Numbered { ordinal: item.ordinal, value: item.value * 100 },
+                ))
+            },
+        ))
+        .into_multi();
+    multi
+        .b0
+        .chain(StallingCollectSink { collected: sink_a, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    multi
+        .b1
+        .chain(StallingCollectSink { collected: sink_b, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    multi
+        .b2
+        .chain(StallingCollectSink { collected: sink_c, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    for (branch, multiplier) in [(0usize, 1u64), (1, 10), (2, 100)] {
+        let values: Vec<u64> =
+            sinks[branch].lock().expect("mutex not poisoned").iter().map(|n| n.value).collect();
+        assert_eq!(
+            values,
+            (0..PROCESS_INPUTS).map(|v| v * multiplier).collect::<Vec<u64>>(),
+            "branch {branch} must release every item, in order",
+        );
+    }
+}
+
+/// `GroupBam` must emit the grouper's batches as formed, never merged.
+///
+/// [`TemplateGrouper::add_records`] already caps each returned batch at
+/// `template_batch_size` and keeps the remainder pending, so the only way to
+/// exceed the cap is for the step to `extend` those batches together — which is
+/// what it used to do, turning the configured size from a bound into a mere
+/// trigger (measured at 624x for a 40k-record input).
+///
+/// `RECORDS_PER_INPUT_BATCH` is deliberately several times `TARGET_BATCH_COUNT`
+/// so one `add_records` call completes several whole batches. That is the case
+/// the merge destroyed and the only one that distinguishes the two behaviors:
+/// feed it fewer templates per input than the target and both the fixed and the
+/// broken step emit one batch per input, and the test proves nothing.
+///
+/// This drives the step through `Pipeline::run` rather than calling the grouper
+/// directly, because the property belongs to `GroupBam`, not to
+/// `TemplateGrouper` — a grouper-level assertion passes even if the step
+/// reintroduces the merge.
+#[rstest]
+fn group_bam_emits_grouper_batches_without_merging_them(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::group::bam::GroupBam;
+    use crate::pipeline::steps::types::BamTemplateBatch;
+
+    const N_TEMPLATES: usize = 205;
+    const TARGET_BATCH_COUNT: usize = 8;
+    const RECORDS_PER_INPUT_BATCH: usize = 40;
+    const OUTPUT_BYTE_LIMIT: u64 = 1024;
+    const SINK_STALLS: usize = 24;
+
+    const _: () = assert!(
+        RECORDS_PER_INPUT_BATCH > TARGET_BATCH_COUNT,
+        "one input batch must complete more than one output batch or the merge is invisible",
+    );
+    assert_ne!(
+        N_TEMPLATES % TARGET_BATCH_COUNT,
+        0,
+        "the fixture must leave a partial final batch, else the drain arm is untested",
+    );
+
+    // One single-end record per queryname, so templates and records are 1:1 and
+    // a short count is unambiguous.
+    let records: Vec<(RawRecord, fgumi_bam_io::GroupKey)> = (0..N_TEMPLATES)
+        .map(|t| {
+            let qname = format!("t{t:04}");
+            let key = fgumi_bam_io::GroupKey {
+                name_hash: name_hash_of(qname.as_bytes()),
+                ..Default::default()
+            };
+            (single_end_record(qname.as_bytes()), key)
+        })
+        .collect();
+    let batches: Vec<DecodedRecordBatch> = records
+        .chunks(RECORDS_PER_INPUT_BATCH)
+        .enumerate()
+        .map(|(i, chunk)| decoded_batch_with_keys(i as u64, chunk.to_vec()))
+        .collect();
+
+    let collected: Arc<Mutex<Vec<BamTemplateBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(batches))
+        .chain(GroupBam::new(TARGET_BATCH_COUNT, OUTPUT_BYTE_LIMIT))
+        .chain(StallingCollectSink { collected: sink_handle, remaining_stalls: SINK_STALLS })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let emitted = collected.lock().expect("mutex not poisoned");
+    assert!(emitted.len() > 1, "fixture must span several output batches");
+
+    let serials: Vec<u64> = emitted.iter().map(Ordered::ordinal).collect();
+    assert_eq!(
+        serials,
+        (0..emitted.len() as u64).collect::<Vec<u64>>(),
+        "emitted batch serials must be contiguous from zero",
+    );
+    assert!(emitted.iter().all(|b| !b.templates().is_empty()), "no batch may be emitted empty");
+
+    // The cap, and the whole point of the test: with the merge in place the
+    // first batch of each input would hold `RECORDS_PER_INPUT_BATCH` templates.
+    if let Some((i, n)) = emitted
+        .iter()
+        .map(|b| b.templates().len())
+        .enumerate()
+        .find(|&(_, n)| n > TARGET_BATCH_COUNT)
+    {
+        panic!("batch {i} holds {n} templates, above the {TARGET_BATCH_COUNT} cap");
+    }
+
+    // Nothing was dropped on the way — a short count would mean the `Finished`
+    // gate closed the output while batches were still queued.
+    let total: usize = emitted.iter().map(|b| b.templates().len()).sum();
+    assert_eq!(
+        total, N_TEMPLATES,
+        "every template must be emitted exactly once; a short count means queued batches \
+         were lost when the step reported Finished",
+    );
+}
+
+/// A `None` on one of `Process3WithWorkerState`'s ordered branches must not
+/// stall the run, provided that branch mints its own dense ordinals.
+///
+/// The sibling test above feeds all three branches on every input, so it never
+/// exercises a gap. That matters because the step's named caller is the paired
+/// FASTQ encode fan-out (R1 / R2 / **other**), and the "other" branch is `None`
+/// for most inputs — the sparse case is the *normal* case in production, not an
+/// edge case. All three branches declare [`BranchOrdering::ByItemOrdinal`],
+/// whose `ReorderStage` releases only contiguously, so a branch that skipped an
+/// input while propagating the *input's* ordinal would leave a permanent hole
+/// and wait for it forever.
+///
+/// This pins the safe half of the rule documented on `Process2Output`: the
+/// sparse branch here numbers what it emits, so a skip simply means the next
+/// emitted item takes the next ordinal and the sequence stays dense. The
+/// failure it guards against is a hang, not a wrong answer, which is why the
+/// run completing at all is half the assertion.
+#[rstest]
+fn process3_tolerates_a_none_branch_that_mints_its_own_ordinals(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::process::{Process3Output, process3_with_worker_state};
+
+    // Only every fourth input reaches the third branch.
+    const C_EVERY: u64 = 4;
+
+    let sinks: [Arc<Mutex<Vec<Numbered>>>; 3] =
+        std::array::from_fn(|_| Arc::new(Mutex::new(Vec::new())));
+    let [sink_a, sink_b, sink_c]: [Arc<Mutex<Vec<Numbered>>>; 3] =
+        std::array::from_fn(|i| Arc::clone(&sinks[i]));
+
+    // Branch-local counter for the sparse branch. Shared across worker clones,
+    // so at four threads which *value* gets which ordinal races — but the
+    // sequence stays dense, which is the property the reorder stage requires.
+    let next_c = Arc::new(AtomicU64::new(0));
+    let mint_c = Arc::clone(&next_c);
+
+    let builder = Pipeline::builder();
+    let multi = builder
+        .chain(ReplaySource::new(numbered_inputs(PROCESS_INPUTS)))
+        .chain(process3_with_worker_state(
+            "SparseFanOut3",
+            PROCESS_EDGE_BYTES,
+            PROCESS_EDGE_BYTES,
+            PROCESS_EDGE_BYTES,
+            || 0u64,
+            move |seen: &mut u64, item: Numbered| {
+                *seen += 1;
+                // a and b take every input and propagate its ordinal, which
+                // stays dense because nothing is skipped on those branches.
+                let a = Numbered { ordinal: item.ordinal, value: item.value };
+                let b = Numbered { ordinal: item.ordinal, value: item.value * 10 };
+                let c = item.value.is_multiple_of(C_EVERY).then(|| Numbered {
+                    ordinal: mint_c.fetch_add(1, AtomicOrdering::Relaxed),
+                    value: item.value * 100,
+                });
+                Ok(Process3Output { a: Some(a), b: Some(b), c })
+            },
+        ))
+        .into_multi();
+    multi
+        .b0
+        .chain(StallingCollectSink { collected: sink_a, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    multi
+        .b1
+        .chain(StallingCollectSink { collected: sink_b, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    multi
+        .b2
+        .chain(StallingCollectSink { collected: sink_c, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    // The dense branches are unaffected by the third one's gaps.
+    for (branch, multiplier) in [(0usize, 1u64), (1, 10)] {
+        let values: Vec<u64> =
+            sinks[branch].lock().expect("mutex not poisoned").iter().map(|n| n.value).collect();
+        assert_eq!(
+            values,
+            (0..PROCESS_INPUTS).map(|v| v * multiplier).collect::<Vec<u64>>(),
+            "dense branch {branch} must release every item, in order",
+        );
+    }
+
+    let branch_c = sinks[2].lock().expect("mutex not poisoned");
+    let expected_c: Vec<u64> =
+        (0..PROCESS_INPUTS).filter(|v| v.is_multiple_of(C_EVERY)).map(|v| v * 100).collect();
+
+    // Sparse, or the test degenerates into the all-branches case above.
+    assert!(
+        (branch_c.len() as u64) < PROCESS_INPUTS,
+        "the third branch must skip inputs or this proves nothing about gaps",
+    );
+    assert_eq!(branch_c.len(), expected_c.len(), "every routed item reached the sparse branch");
+
+    // The load-bearing assertion: the sparse branch released a dense sequence
+    // from zero. A hole would have stalled its reorder stage instead of
+    // producing short output.
+    let ordinals: Vec<u64> = branch_c.iter().map(|n| n.ordinal).collect();
+    assert_eq!(
+        ordinals,
+        (0..branch_c.len() as u64).collect::<Vec<u64>>(),
+        "the sparse branch must release a dense ordinal sequence from zero",
+    );
+
+    // Nothing was routed wrongly, dropped, or duplicated. Sorted because
+    // ordinal assignment races across workers at four threads.
+    let mut values_c: Vec<u64> = branch_c.iter().map(|n| n.value).collect();
+    values_c.sort_unstable();
+    assert_eq!(values_c, expected_c);
 }
 
 /// `EDGE_LIMIT_BYTES` must be small enough that the multi-record fixtures

--- a/src/lib/pipeline/steps/group/bam.rs
+++ b/src/lib/pipeline/steps/group/bam.rs
@@ -1,0 +1,218 @@
+//! `GroupBam` mid-step. `Serial + ByItemOrdinal`. Wraps the legacy
+//! [`crate::grouper::TemplateGrouper`]: incoming `DecodedRecordBatch`es
+//! (records + pre-computed `GroupKey` from the parallel `DecodeRecords`
+//! step) are batched by QNAME into `Template`s and emitted as
+//! `BamTemplateBatch`es.
+//!
+//! Templates can span batch boundaries (a template may have records in
+//! consecutive `DecodedRecordBatch`es). The `Serial` mutex is held briefly
+//! per call and the per-record `GroupKey` work happens upstream in
+//! parallel — matches legacy's "Decode (parallel) → Group (serial)"
+//! split (`pipeline/bam.rs:329-403, 2269-2571`).
+//!
+//! Once the input is drained, `try_run` calls the grouper's `finish()` once
+//! (guarded by `finalized`) to flush any final partial template, emits whatever
+//! batches remain queued, and only then reports `Finished`.
+//!
+//! ## One emitted batch per formed batch
+//!
+//! [`TemplateGrouper::add_records`] already returns *correctly sized* batches —
+//! its `collect_batches` peels off exactly `batch_size` templates at a time and
+//! leaves the remainder pending — so this step must not flatten them back
+//! together. An earlier version did, `extend`ing every returned batch into one
+//! output, which turned `template_batch_size` from a bound into a mere trigger:
+//! the emitted batch was sized by however many templates one input batch
+//! happened to complete, measured at 624x the configured size for a 40k-record
+//! input. That also let a single item blow the output queue's byte budget wide
+//! open, since [`crate::pipeline::core::queues::ByteBoundedQueue`] admits any
+//! item once it is under budget (a strict `cur + size <= limit` would deadlock
+//! producers whose items legitimately exceed the limit).
+//!
+//! Batches the output queue has no room for are parked in `pending_batches` and
+//! re-offered on later calls, which is why `Finished` is gated on that queue
+//! being empty as well as on the input being drained.
+
+use std::collections::VecDeque;
+use std::io;
+
+use crate::grouper::TemplateGrouper;
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::{BamTemplateBatch, DecodedRecordBatch};
+use crate::template::Template;
+use fgumi_bam_io::Grouper;
+
+/// Max inputs processed per `try_run` invocation. Amortizes the `Serial`
+/// mutex acquisition; matches legacy `bam.rs:2497+` (`MAX_BATCHES_PER_LOCK`).
+const MAX_BATCHES_PER_LOCK: usize = 8;
+
+/// `Serial + ByItemOrdinal` template grouper. Holds a [`TemplateGrouper`]
+/// and consumes pre-decoded records from upstream `DecodeRecords`.
+pub struct GroupBam {
+    grouper: TemplateGrouper,
+    /// Self-managed output ordinal. Incremented only when a new
+    /// `BamTemplateBatch` is emitted. Templates may span several input
+    /// batches (a partial template with no `Grouper`-emitted output);
+    /// using the input's `batch_serial` would skip ordinals and deadlock
+    /// the downstream `ReorderStage`.
+    next_output_serial: u64,
+    /// Batches the grouper has already formed but the output queue has not yet
+    /// accepted, in emission order.
+    ///
+    /// Distinct from `held`, which parks the single batch whose push was
+    /// *rejected*: one `add_records` call can complete many batches, and only
+    /// one of them can be in flight at a time, so the rest queue here rather
+    /// than being merged into an oversized batch.
+    pending_batches: VecDeque<Vec<Template>>,
+    /// Pending output (when push is rejected).
+    held: HeldSlot<Unpushed<BamTemplateBatch>>,
+    /// Set once the final-flush path has called the (non-idempotent)
+    /// `grouper.finish()`; guards against a second call across the
+    /// multi-pass completion drain.
+    finalized: bool,
+    output_byte_limit: u64,
+    name: &'static str,
+}
+
+impl GroupBam {
+    /// Construct a `GroupBam` step.
+    ///
+    /// * `template_batch_size` — number of templates per emitted batch
+    ///   (passed through to `TemplateGrouper::new`).
+    /// * `output_byte_limit` — byte budget for the output queue.
+    #[must_use]
+    pub fn new(template_batch_size: usize, output_byte_limit: u64) -> Self {
+        Self {
+            grouper: TemplateGrouper::new(template_batch_size),
+            next_output_serial: 0,
+            pending_batches: VecDeque::new(),
+            held: HeldSlot::new(),
+            finalized: false,
+            output_byte_limit,
+            name: "GroupBam",
+        }
+    }
+}
+
+impl Step for GroupBam {
+    type Input = DecodedRecordBatch;
+    type Outputs = OrderedBytesSingle<BamTemplateBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Serial,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        // Flush batches formed by an earlier call before forming any more, so
+        // `pending_batches` drains rather than growing. If the output is still
+        // refusing, stop here — taking more input would only deepen the queue.
+        if self.emit_pending(ctx) {
+            return Ok(StepOutcome::Progress);
+        }
+
+        // Process up to `MAX_BATCHES_PER_LOCK` inputs per `try_run` to
+        // amortize the Serial mutex acquisition.
+        let mut did_work = false;
+        for _ in 0..MAX_BATCHES_PER_LOCK {
+            let Some(batch) = ctx.input.pop() else { break };
+            did_work = true;
+            let records = batch.into_records();
+
+            // Feed pre-decoded records into the wrapped grouper. The grouper
+            // returns zero or more completed `TemplateBatch`es (= `Vec<Template>`),
+            // each already capped at `template_batch_size`. Queue them as-is —
+            // merging them here would undo that cap.
+            self.pending_batches.extend(self.grouper.add_records(records)?);
+        }
+
+        if did_work {
+            self.emit_pending(ctx);
+            return Ok(StepOutcome::Progress);
+        }
+
+        // No input this call. If upstream is drained, flush the inner
+        // grouper's final partial template once (guarded by `finalized` —
+        // `grouper.finish()` is not idempotent), then drain whatever is still
+        // queued. `held` is empty here (step 1 returned `Contention`
+        // otherwise); a bounced push is parked in `held` for the held-drain at
+        // the top of the next pass.
+        if ctx.input.is_drained() {
+            if !self.finalized {
+                self.finalized = true;
+                if let Some(final_batch) = self.grouper.finish()?
+                    && !final_batch.is_empty()
+                {
+                    self.pending_batches.push_back(final_batch);
+                }
+            }
+            // `Finished` must wait for the queue to empty: reporting it while a
+            // batch is still queued closes the output with records unsent,
+            // which surfaces as short output far from here rather than as an
+            // error at the point of loss.
+            if !self.pending_batches.is_empty() {
+                self.emit_pending(ctx);
+                return Ok(StepOutcome::Progress);
+            }
+            return Ok(StepOutcome::Finished);
+        }
+        Ok(StepOutcome::NoProgress)
+    }
+}
+
+impl GroupBam {
+    /// Push queued batches until the output rejects one or the queue empties.
+    ///
+    /// Returns `true` if a push was rejected — the batch is parked in `held`
+    /// and the caller should yield rather than take on more work. Ordinals are
+    /// consumed in emission order, including for the rejected batch, because
+    /// `held` retries that same batch with the ordinal it was assigned; the
+    /// `ByItemOrdinal` reorder stage downstream releases only contiguously, so
+    /// a skipped or reused ordinal would stall it.
+    fn emit_pending(&mut self, ctx: &mut StepCtx<'_, Self>) -> bool {
+        while let Some(templates) = self.pending_batches.pop_front() {
+            let serial = self.next_output_serial;
+            self.next_output_serial += 1;
+            let out = BamTemplateBatch::new(serial, templates);
+            if let Err(unpushed) = ctx.outputs.push(out) {
+                self.held.put(unpushed);
+                return true;
+            }
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_advertises_serial_byordinal() {
+        let s = GroupBam::new(64, 1024);
+        let p = s.profile();
+        assert_eq!(p.name, "GroupBam");
+        assert_eq!(p.kind, StepKind::Serial);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+}

--- a/src/lib/pipeline/steps/group/mi.rs
+++ b/src/lib/pipeline/steps/group/mi.rs
@@ -1,0 +1,814 @@
+//! `GroupByMi` step for the new typed-step pipeline framework.
+//!
+//! Mirrors the legacy pipeline's MI-tag grouping (`fgumi simplex`,
+//! `fgumi duplex`): consumes `DecodedRecordBatch` items in input order,
+//! accumulates records by MI tag value via run-length grouping (assumes
+//! input is already sorted by MI, which is the contract upstream of
+//! consensus calling), and emits **batches** of completed `MiGroup`s as
+//! a single `BatchedMiGroups` per output ordinal.
+//!
+//! Design follows `GroupByPosition`: `Serial` + `ByItemOrdinal`, batched
+//! output to amortize downstream `Serial` mutex cost, held-slot retry
+//! pattern for backpressure.
+
+use std::io;
+
+use crate::mi_group::{MiGroup, MiKey, MiTransform};
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::item::{HeapSize, Ordered};
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::DecodedRecordBatch;
+use fgumi_bam_io::MemoryEstimate;
+
+/// Max input batches consumed per `try_run` invocation. Amortizes the
+/// Serial mutex acquisition; mirrors `GroupByPosition::MAX_BATCHES_PER_LOCK`.
+const MAX_BATCHES_PER_LOCK: usize = 8;
+
+/// Default target batch count. Mirrors legacy's per-batch group count
+/// for simplex (50 groups per `MiGroupBatch`).
+pub const DEFAULT_TARGET_BATCH_COUNT: usize = 50;
+
+/// Records retained for one MI key between long-run warnings.
+///
+/// `current_records` holds the whole run in progress and is not emitted until
+/// the key changes or input drains, so its size is set by the largest MI family
+/// in the input rather than by any configured limit: `MAX_BATCHES_PER_LOCK`
+/// bounds input consumed *per call*, `target_batch_count` counts *completed*
+/// groups, and the output queue's byte budget bounds what has been *pushed* —
+/// which this has not been. Legacy `MiGrouper` (`crate::mi_group`) retains the
+/// same way, so this is the ported behavior rather than a regression, but a
+/// pathological family can still exhaust memory with no diagnostic at all.
+///
+/// This does not bound anything; it makes the growth *visible* before the run
+/// dies, which is the cheap half of the fix and costs one comparison per record.
+///
+/// 100k is ~100x beyond any legitimate family — even deep amplicon data keeps a
+/// single UMI at a single position in the thousands — so it should never fire on
+/// real input, while still leaving roughly a 10x margin before the retained
+/// records amount to serious memory (100k records is tens of MB; 1M is hundreds).
+const LONG_RUN_WARN_INTERVAL: usize = 100_000;
+
+/// A batch of `MiGroup`s carrying its monotonic ordinal.
+#[derive(Debug)]
+pub struct BatchedMiGroups {
+    pub batch_serial: u64,
+    pub groups: Vec<MiGroup>,
+}
+
+impl BatchedMiGroups {
+    #[must_use]
+    pub fn new(batch_serial: u64, groups: Vec<MiGroup>) -> Self {
+        Self { batch_serial, groups }
+    }
+}
+
+impl HeapSize for BatchedMiGroups {
+    fn heap_size(&self) -> usize {
+        self.groups.iter().map(MemoryEstimate::estimate_heap_size).sum::<usize>()
+            + self.groups.capacity() * std::mem::size_of::<MiGroup>()
+    }
+}
+
+impl Ordered for BatchedMiGroups {
+    fn ordinal(&self) -> u64 {
+        self.batch_serial
+    }
+}
+
+/// Type alias for the optional MI-tag transform closure (mirrors
+/// `MiGrouper`'s `mi_transform`). When set, the closure is invoked
+/// with the raw MI tag bytes and produces a transformed key — used
+/// e.g. by `duplex` to strip `/A` and `/B` suffixes so both strands
+/// of a paired molecule group together.
+type MiTransformFn = Box<dyn Fn(&[u8]) -> String + Send + Sync>;
+
+/// Type alias for the optional record-filter closure (mirrors
+/// `MiGrouper`'s `record_filter`). When set, records that fail the
+/// filter are skipped without contributing to any MI group.
+type RecordFilterFn = Box<dyn Fn(&[u8]) -> bool + Send + Sync>;
+
+/// `Serial + ByItemOrdinal` MI-tag grouper. Records arriving in input
+/// order are partitioned into runs of consecutive same-MI records;
+/// each run becomes one [`MiGroup`]. Completed groups accumulate
+/// until the target batch size is reached, then emit as one
+/// [`BatchedMiGroups`].
+///
+/// State is held behind the framework's per-step mutex (the runtime
+/// stores a `Serial` step inside `Arc<Mutex<...>>` and acquires
+/// per-`try_run`). Held-slot retry pattern matches `GroupByPosition`:
+/// when an emit is rejected by downstream backpressure, the partial
+/// state stays buffered until the held slot drains.
+pub struct GroupByMi {
+    /// MI tag bytes to look up in each record's auxiliary data.
+    tag: [u8; 2],
+    /// Optional cell barcode tag. When set, the group key becomes
+    /// `MI\tCELL`, so reads from different cells with the same MI
+    /// tag are placed in separate groups (mirrors `MiGrouper`).
+    cell_tag: Option<[u8; 2]>,
+    /// Optional record filter (skip records that don't match).
+    record_filter: Option<RecordFilterFn>,
+    /// Optional MI-tag transformation. When set, the raw MI bytes are
+    /// piped through this closure before being used as the group key
+    /// (and stored on the emitted `MiGroup`). When unset, the raw MI
+    /// bytes are used as a UTF-8 lossy string.
+    mi_transform: Option<MiTransformFn>,
+    /// Run-length state: the grouping key currently being accumulated, stored as
+    /// raw comparison bytes so run-boundary detection stays allocation-free on
+    /// the common (no-transform) path. The owned display label is materialized
+    /// only once per group (at the group boundary) via [`MiKey::label`].
+    current_key: Option<MiKey>,
+    /// Run-length state: records accumulated for `current_key`.
+    current_records: Vec<fgumi_raw_bam::RawRecord>,
+    /// `current_records.len()` at which the next long-run warning fires, bumped
+    /// by [`LONG_RUN_WARN_INTERVAL`] each time and reset at every run boundary.
+    ///
+    /// A running threshold rather than `len % INTERVAL == 0`: this is checked
+    /// once per retained record, and a runtime modulo is an integer division on
+    /// that path, where this is a single predictable compare.
+    next_long_run_warn_at: usize,
+    /// Self-managed monotonic ordinal — each emitted *batch* gets the
+    /// next value. Required for `BranchOrdering::ByItemOrdinal`'s
+    /// `ReorderStage` to see contiguous serials.
+    next_ordinal: u64,
+    /// Accumulator: completed groups waiting to be packaged into a batch.
+    accumulator: Vec<MiGroup>,
+    /// Held output slot when downstream rejected the most recent push.
+    held: HeldSlot<Unpushed<BatchedMiGroups>>,
+    target_batch_count: usize,
+    output_byte_limit: u64,
+    /// Records dropped because they carry no MI tag at all. Expected in small
+    /// numbers (e.g. unmapped mates upstream filters missed); reported at
+    /// end-of-stream so a silent whole-input drop cannot go unnoticed.
+    skipped_no_mi: u64,
+    /// Records dropped because MI is present but **not** a `Z` (string) tag.
+    /// Almost always a malformed input rather than a legitimate skip: `fgumi
+    /// group` and fgbio both write MI as a string (it can carry a `/A`,`/B`
+    /// strand suffix), so an `MI:i:` integer silently matches nothing.
+    skipped_non_string_mi: u64,
+    name: &'static str,
+}
+
+impl GroupByMi {
+    /// Construct a `GroupByMi` step grouping by the given 2-byte tag
+    /// (typically `"MI"`).
+    #[must_use]
+    pub fn new(tag: [u8; 2], output_byte_limit: u64) -> Self {
+        Self::with_target_batch_count(tag, output_byte_limit, DEFAULT_TARGET_BATCH_COUNT)
+    }
+
+    /// Construct with a custom target batch count.
+    #[must_use]
+    pub fn with_target_batch_count(
+        tag: [u8; 2],
+        output_byte_limit: u64,
+        target_batch_count: usize,
+    ) -> Self {
+        Self {
+            tag,
+            cell_tag: None,
+            record_filter: None,
+            mi_transform: None,
+            current_key: None,
+            current_records: Vec::new(),
+            next_long_run_warn_at: LONG_RUN_WARN_INTERVAL,
+            next_ordinal: 0,
+            accumulator: Vec::with_capacity(target_batch_count),
+            held: HeldSlot::new(),
+            target_batch_count: target_batch_count.max(1),
+            output_byte_limit,
+            skipped_no_mi: 0,
+            skipped_non_string_mi: 0,
+            name: "GroupByMi",
+        }
+    }
+
+    /// Set an optional cell-barcode tag for composite grouping.
+    #[must_use]
+    pub fn with_cell_tag(mut self, cell_tag: Option<[u8; 2]>) -> Self {
+        self.cell_tag = cell_tag;
+        self
+    }
+
+    /// Install an optional record filter. Records that fail are dropped
+    /// before they contribute to any MI group. Mirrors
+    /// `MiGrouper::with_filter_and_transform`'s filter closure.
+    #[must_use]
+    pub fn with_record_filter<F>(mut self, filter: F) -> Self
+    where
+        F: Fn(&[u8]) -> bool + Send + Sync + 'static,
+    {
+        self.record_filter = Some(Box::new(filter));
+        self
+    }
+
+    /// Install an optional MI-tag transform closure. The raw MI tag
+    /// bytes are piped through this closure to produce the per-record
+    /// group key. Used by `duplex` to strip `/A`/`/B` suffixes so both
+    /// strands of a paired molecule end up in the same MI group.
+    #[must_use]
+    pub fn with_mi_transform<F>(mut self, transform: F) -> Self
+    where
+        F: Fn(&[u8]) -> String + Send + Sync + 'static,
+    {
+        self.mi_transform = Some(Box::new(transform));
+        self
+    }
+
+    /// Borrow the installed MI-transform closure (if any) as the
+    /// `Option<&dyn Fn>` shape [`MiKey`] expects.
+    #[inline]
+    fn transform(&self) -> MiTransform<'_> {
+        self.mi_transform.as_ref().map(|t| t.as_ref() as &dyn Fn(&[u8]) -> String)
+    }
+
+    /// Run the optional filter against a record's bytes; returns `true`
+    /// to keep, `false` to discard.
+    #[inline]
+    fn passes_filter(&self, bam: &[u8]) -> bool {
+        match &self.record_filter {
+            Some(filter) => filter(bam),
+            None => true,
+        }
+    }
+
+    /// Accumulate one raw record into the current MI run, opening a new run (and
+    /// flushing the previous one) at a group boundary. Run-boundary detection is
+    /// an allocation-free byte comparison against the stored key on the common
+    /// (no-transform) path; the owned key is built only when a new run begins.
+    /// Records that fail the optional filter, or that carry no MI tag, are
+    /// dropped (matching `MiGrouper`).
+    fn process_record(&mut self, raw: fgumi_raw_bam::RawRecord) {
+        // Optional filter (mirrors `MiGrouper::should_keep`).
+        if !self.passes_filter(raw.as_ref()) {
+            return;
+        }
+        let same_group = match &self.current_key {
+            Some(key) => {
+                // `None` means no usable MI tag on this record: count why, and skip.
+                let Some(matches) =
+                    key.matches_record(raw.as_ref(), self.tag, self.cell_tag, self.transform())
+                else {
+                    self.count_skipped_record(raw.as_ref());
+                    return;
+                };
+                matches
+            }
+            None => false,
+        };
+        if same_group {
+            self.current_records.push(raw);
+            self.warn_if_run_is_long();
+        } else {
+            // New run (or first record). Build the owned key once at the
+            // boundary; `from_record` returns `None` (skip) without an MI tag.
+            let Some(key) =
+                MiKey::from_record(raw.as_ref(), self.tag, self.cell_tag, self.transform())
+            else {
+                self.count_skipped_record(raw.as_ref());
+                return;
+            };
+            self.flush_current_group();
+            self.current_key = Some(key);
+            self.current_records.push(raw);
+            // A new run starts the ladder over, so a file with many large-but-
+            // legal families warns once per family that crosses the threshold
+            // rather than once and then never again.
+            self.next_long_run_warn_at = LONG_RUN_WARN_INTERVAL;
+        }
+    }
+
+    /// Warn every [`LONG_RUN_WARN_INTERVAL`] records retained for one MI key.
+    ///
+    /// Warning at each multiple rather than once keeps the signal proportional
+    /// to the problem: a run that keeps growing keeps saying so, and because the
+    /// gap between messages is a fixed number of records, the log cannot outpace
+    /// the growth it is reporting.
+    #[inline]
+    fn warn_if_run_is_long(&mut self) {
+        if self.current_records.len() < self.next_long_run_warn_at {
+            return;
+        }
+        let label = self.current_key.as_ref().map_or_else(|| "<none>".to_string(), MiKey::label);
+        log::warn!(
+            "MI group '{label}' has reached {} records held in memory, which is far beyond a \
+             typical family; this step holds a whole MI run before emitting it, so memory will \
+             keep growing until the MI tag changes. Check that the input is grouped and sorted \
+             by MI and that the MI tag is not constant across records.",
+            self.current_records.len(),
+        );
+        self.next_long_run_warn_at =
+            self.current_records.len().saturating_add(LONG_RUN_WARN_INTERVAL);
+    }
+
+    /// Classify a record that produced no usable MI key, so end-of-stream can tell
+    /// "no MI tag" apart from "MI present but the wrong type".
+    ///
+    /// Only runs on the skip path, so it costs nothing for records that group
+    /// normally.
+    #[inline]
+    fn count_skipped_record(&mut self, bam: &[u8]) {
+        let aux = fgumi_raw_bam::aux_data_slice(bam);
+        match fgumi_raw_bam::find_tag_type(aux, self.tag) {
+            // Present but not `Z`: the caller almost certainly meant this record
+            // to group, so it is tracked separately and warned about loudly.
+            Some(kind) if kind != b'Z' => self.skipped_non_string_mi += 1,
+            _ => self.skipped_no_mi += 1,
+        }
+    }
+
+    /// Report records dropped for want of a usable MI tag, once, at end-of-stream.
+    ///
+    /// A wrong-typed MI is warned about unconditionally: it means the input was
+    /// written with e.g. `MI:i:1` instead of `MI:Z:1`, which groups nothing and
+    /// otherwise surfaces only as an inexplicably empty output.
+    fn report_skipped_records(&self) {
+        if self.skipped_non_string_mi > 0 {
+            log::warn!(
+                "{}: dropped {} record(s) whose {} tag is present but not a string (Z) tag. \
+                 fgumi and fgbio write {} as a string because it may carry a /A or /B strand \
+                 suffix; an integer tag such as `MI:i:1` matches no group. Re-run `fgumi group` \
+                 on this input, or rewrite the tag as `MI:Z:`.",
+                self.name,
+                self.skipped_non_string_mi,
+                String::from_utf8_lossy(&self.tag),
+                String::from_utf8_lossy(&self.tag),
+            );
+        }
+        if self.skipped_no_mi > 0 {
+            log::warn!(
+                "{}: dropped {} record(s) carrying no {} tag.",
+                self.name,
+                self.skipped_no_mi,
+                String::from_utf8_lossy(&self.tag),
+            );
+        }
+    }
+
+    /// Flush the run-in-progress into the accumulator (if non-empty). The owned
+    /// display label is materialized here — once per group — from the stored key
+    /// bytes, rather than per record.
+    fn flush_current_group(&mut self) {
+        if let Some(key) = self.current_key.take()
+            && !self.current_records.is_empty()
+        {
+            let records = std::mem::take(&mut self.current_records);
+            self.accumulator.push(MiGroup::new(key.label(), records));
+        }
+    }
+
+    /// Take at most `target_batch_count` groups off the accumulator, leaving
+    /// any excess for the next batch.
+    ///
+    /// The last of the three grouping steps to get this cap; `GroupByPosition`
+    /// and `GroupByQueryname` have the identical method for the identical
+    /// reason. `process_record` appends per record and the `>=` checks run once
+    /// per input batch, so one `DecodedRecordBatch` that closes many MI runs
+    /// leaves the accumulator well past the target — handing it over wholesale
+    /// would size the emitted batch by the input rather than by
+    /// `target_batch_count`, defeating the threshold that exists to bound it.
+    /// The `>=` re-entry in `try_run` and the drained path both loop back here
+    /// until the accumulator falls below the target, so the excess is emitted
+    /// rather than delayed.
+    fn drain_one_batch(&mut self) -> Vec<MiGroup> {
+        let take = self.accumulator.len().min(self.target_batch_count);
+        self.accumulator.drain(..take).collect()
+    }
+
+    /// Package at most `target_batch_count` accumulated groups into a
+    /// `BatchedMiGroups` and emit. On rejection, hold; the next `try_run` will
+    /// retry via the held slot. Always returns `Progress` because we either
+    /// emitted or queued a batch for retry. Leftovers above the cap stay in the
+    /// accumulator, which is also what makes a rejected push safe.
+    fn emit_batch(&mut self, ctx: &mut StepCtx<'_, Self>) -> StepOutcome {
+        let serial = self.next_ordinal;
+        self.next_ordinal += 1;
+        let groups = self.drain_one_batch();
+        let out = BatchedMiGroups::new(serial, groups);
+        if let Err(unpushed) = ctx.outputs.push(out) {
+            self.held.put(unpushed);
+        }
+        StepOutcome::Progress
+    }
+}
+
+impl Step for GroupByMi {
+    type Input = DecodedRecordBatch;
+    type Outputs = OrderedBytesSingle<BatchedMiGroups>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Serial,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // 1. Drain held slot first.
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        // 2. If the accumulator is full enough, emit a batch first;
+        // hold off on more input until it lands.
+        if self.accumulator.len() >= self.target_batch_count {
+            return Ok(self.emit_batch(ctx));
+        }
+
+        // 3. Process up to `MAX_BATCHES_PER_LOCK` input batches per
+        // call to amortize the Serial mutex acquisition.
+        let mut did_work = false;
+        for _ in 0..MAX_BATCHES_PER_LOCK {
+            let Some(batch) = ctx.input.pop() else { break };
+            did_work = true;
+            let records = batch.into_records();
+            for decoded in records {
+                self.process_record(decoded.into_raw_bytes());
+            }
+            if self.accumulator.len() >= self.target_batch_count {
+                break;
+            }
+        }
+
+        if self.accumulator.len() >= self.target_batch_count {
+            return Ok(self.emit_batch(ctx));
+        }
+        if did_work {
+            return Ok(StepOutcome::Progress);
+        }
+
+        // 4. No input this call. If upstream is drained, close the
+        // in-progress MI run, emit the final partial batch, and report
+        // `Finished` once nothing remains. `held` is empty here (step 1
+        // returned `Contention` otherwise); a bounced `emit_batch` push is
+        // parked in `held` for step 1 to retry next pass.
+        if ctx.input.is_drained() {
+            self.flush_current_group();
+            if !self.accumulator.is_empty() {
+                return Ok(self.emit_batch(ctx));
+            }
+            self.report_skipped_records();
+            return Ok(StepOutcome::Finished);
+        }
+        Ok(StepOutcome::NoProgress)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fgumi_raw_bam::RawRecord;
+    use rstest::rstest;
+
+    /// Build a minimal unmapped raw BAM record carrying a single Z-type tag.
+    #[allow(clippy::cast_possible_truncation)]
+    fn raw_with_tag(tag: &str, value: &str) -> RawRecord {
+        raw_with_tags(&[(tag, value)])
+    }
+
+    /// An emitted batch must never exceed `target_batch_count`.
+    ///
+    /// `process_record` appends per record while the `>=` checks run once per
+    /// input batch, so a single `DecodedRecordBatch` that closes many MI runs
+    /// leaves the accumulator well past the target. Taking it wholesale would
+    /// size the emitted batch by the input rather than by the configured
+    /// threshold. Pins that the excess is preserved rather than dropped, and
+    /// that repeated draining converges — which is what makes the `>=` re-entry
+    /// in `try_run` and the drained-path loop terminate.
+    ///
+    /// The third of three: `GroupByPosition` and `GroupByQueryname` carry the
+    /// same test for the same guard.
+    #[test]
+    fn draining_caps_each_batch_and_preserves_the_excess() {
+        use crate::sam::SamTag;
+        const TARGET: usize = 64;
+        let mut step = GroupByMi::with_target_batch_count(*SamTag::MI, 1 << 20, TARGET);
+
+        // 150 completed groups, as one input batch closing many runs would leave.
+        step.accumulator = (0..150).map(|i| MiGroup::new(format!("mi{i}"), Vec::new())).collect();
+
+        let first = step.drain_one_batch();
+        assert_eq!(first.len(), TARGET, "a batch must never exceed the target");
+        assert_eq!(step.accumulator.len(), 86, "the excess stays queued, not dropped");
+
+        let second = step.drain_one_batch();
+        assert_eq!(second.len(), TARGET);
+        assert_eq!(step.accumulator.len(), 22);
+
+        // The tail comes out as a short final batch and the accumulator empties.
+        let third = step.drain_one_batch();
+        assert_eq!(third.len(), 22, "the remainder is emitted as a short batch");
+        assert!(step.accumulator.is_empty());
+        assert!(step.drain_one_batch().is_empty(), "draining an empty accumulator is a no-op");
+    }
+
+    /// The long-run warning re-arms at a fixed record interval and starts over
+    /// at each run boundary.
+    ///
+    /// Drives the threshold from a small seeded value rather than pushing
+    /// `LONG_RUN_WARN_INTERVAL` real records, so the arithmetic is pinned
+    /// without a 100k-record test. What matters is that the next threshold is
+    /// derived from the length *reached* (not the previous threshold), so the
+    /// ladder cannot fall behind a run that grows by more than one record
+    /// between checks, and that a new MI key resets it — otherwise a file of
+    /// many large families would warn once and then stay silent.
+    #[test]
+    fn the_long_run_warning_re_arms_and_resets_at_a_run_boundary() {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20);
+        assert_eq!(
+            step.next_long_run_warn_at, LONG_RUN_WARN_INTERVAL,
+            "a fresh step is armed at the interval",
+        );
+
+        // Open a run, then seed the threshold low enough to trip on the next
+        // record rather than materializing 100k of them.
+        step.process_record(raw_with_tag("MI", "fam"));
+        step.next_long_run_warn_at = 2;
+        step.process_record(raw_with_tag("MI", "fam"));
+        assert_eq!(step.current_records.len(), 2, "both records are retained in one run");
+        assert_eq!(
+            step.next_long_run_warn_at,
+            2 + LONG_RUN_WARN_INTERVAL,
+            "the next warning is a full interval past the length just reached",
+        );
+
+        // A different MI value starts a new run, which re-arms from scratch.
+        step.process_record(raw_with_tag("MI", "other"));
+        assert_eq!(
+            step.next_long_run_warn_at, LONG_RUN_WARN_INTERVAL,
+            "a run boundary resets the ladder so each family warns on its own merits",
+        );
+    }
+
+    /// Build a minimal unmapped raw BAM record carrying a single `i`-type
+    /// (signed 32-bit integer) tag, e.g. the malformed `MI:i:1` that groups
+    /// nothing because MI is defined as a string tag.
+    #[allow(clippy::cast_possible_truncation)]
+    fn raw_with_int_tag(tag: &str, value: i32) -> RawRecord {
+        let t = tag.as_bytes();
+        let mut aux: Vec<u8> = vec![t[0], t[1], b'i'];
+        aux.extend_from_slice(&value.to_le_bytes());
+        raw_with_aux(&aux)
+    }
+
+    /// Build a minimal unmapped raw BAM record carrying the given Z-type tags
+    /// in the supplied aux-block order.
+    #[allow(clippy::cast_possible_truncation)]
+    fn raw_with_tags(tags: &[(&str, &str)]) -> RawRecord {
+        let mut aux: Vec<u8> = Vec::new();
+        for (tag, value) in tags {
+            let t = tag.as_bytes();
+            aux.extend_from_slice(&[t[0], t[1], b'Z']);
+            aux.extend_from_slice(value.as_bytes());
+            aux.push(0);
+        }
+        raw_with_aux(&aux)
+    }
+
+    /// Wrap a pre-encoded aux block in a minimal unmapped raw BAM record.
+    #[allow(clippy::cast_possible_truncation)]
+    fn raw_with_aux(aux: &[u8]) -> RawRecord {
+        let name = b"read";
+        let l_read_name: u8 = (name.len() + 1) as u8;
+        let seq_len: u32 = 4;
+        let seq_bytes = seq_len.div_ceil(2) as usize;
+
+        let total = 32 + l_read_name as usize + seq_bytes + seq_len as usize + aux.len();
+        let mut buf = vec![0u8; total];
+        buf[0..4].copy_from_slice(&(-1i32).to_le_bytes());
+        buf[4..8].copy_from_slice(&(-1i32).to_le_bytes());
+        buf[8] = l_read_name;
+        buf[12..14].copy_from_slice(&0u16.to_le_bytes());
+        buf[16..20].copy_from_slice(&seq_len.to_le_bytes());
+        buf[20..24].copy_from_slice(&(-1i32).to_le_bytes());
+        buf[24..28].copy_from_slice(&(-1i32).to_le_bytes());
+        let name_start = 32;
+        buf[name_start..name_start + name.len()].copy_from_slice(name);
+        buf[name_start + name.len()] = 0;
+        let aux_start = 32 + l_read_name as usize + seq_bytes + seq_len as usize;
+        buf[aux_start..aux_start + aux.len()].copy_from_slice(aux);
+        RawRecord::from(buf)
+    }
+
+    /// Build a minimal unmapped raw BAM record carrying no aux tags.
+    #[allow(clippy::cast_possible_truncation)]
+    fn raw_without_tag() -> RawRecord {
+        raw_with_tags(&[])
+    }
+
+    /// Drive a sequence of records through [`GroupByMi::process_record`], close
+    /// the final run, and return `(label, record_count)` per completed group.
+    fn run_grouping(step: &mut GroupByMi, records: Vec<RawRecord>) -> Vec<(String, usize)> {
+        for raw in records {
+            step.process_record(raw);
+        }
+        step.flush_current_group();
+        step.accumulator.iter().map(|g| (g.mi.clone(), g.records.len())).collect()
+    }
+
+    /// Two MI values that are distinct raw bytes but render to the same
+    /// replacement character must stay in separate groups.
+    ///
+    /// This is the regression test for the `MiKey` change: the previous shape
+    /// ran `String::from_utf8_lossy` *before* comparing, so `\x80` and `\x81`
+    /// both became U+FFFD and the three records below collapsed into one group
+    /// of 3 — silently merging two distinct molecules. `MiKey` compares the raw
+    /// tag bytes and only converts lossily to build the display label.
+    ///
+    /// The labels are asserted to be *identical* on purpose. `MiGroup.mi` is a
+    /// diagnostic string, not an identity: nothing rekeys groups by it or writes
+    /// it back into a BAM, and treating it as unique is exactly the mistake the
+    /// old code made. The record counts are what carry the grouping claim.
+    #[test]
+    fn distinct_invalid_utf8_mi_values_stay_in_separate_groups() {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20);
+        let records = vec![
+            raw_with_aux(b"MIZ\x80\x00"),
+            raw_with_aux(b"MIZ\x80\x00"),
+            raw_with_aux(b"MIZ\x81\x00"),
+        ];
+
+        let groups = run_grouping(&mut step, records);
+
+        assert_eq!(groups.len(), 2, "distinct raw MI bytes must not merge: {groups:?}");
+        assert_eq!(groups[0].1, 2, "the two \\x80 records group together");
+        assert_eq!(groups[1].1, 1, "the \\x81 record is its own group");
+        assert_eq!(
+            groups[0].0, groups[1].0,
+            "both labels render to the same replacement character — the label is \
+             diagnostic, and the separation above is what proves the keys differ",
+        );
+    }
+
+    #[test]
+    fn single_mi_run_forms_one_group() {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20);
+        let records: Vec<RawRecord> = (0..1000).map(|_| raw_with_tag("MI", "7")).collect();
+        let groups = run_grouping(&mut step, records);
+        assert_eq!(groups, vec![("7".to_string(), 1000)]);
+    }
+
+    #[test]
+    fn distinct_mi_values_split_runs_and_label_once() {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20);
+        let records = vec![
+            raw_with_tag("MI", "1"),
+            raw_with_tag("MI", "1"),
+            raw_with_tag("MI", "2"),
+            raw_with_tag("MI", "1"), // non-adjacent: a fresh run, not merged
+        ];
+        let groups = run_grouping(&mut step, records);
+        assert_eq!(groups, vec![("1".to_string(), 2), ("2".to_string(), 1), ("1".to_string(), 1)]);
+    }
+
+    #[test]
+    fn records_without_mi_are_skipped() {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20);
+        let records = vec![
+            raw_without_tag(), // skipped, no current run yet
+            raw_with_tag("MI", "5"),
+            raw_without_tag(), // skipped, current run preserved
+            raw_with_tag("MI", "5"),
+        ];
+        let groups = run_grouping(&mut step, records);
+        assert_eq!(groups, vec![("5".to_string(), 2)]);
+    }
+
+    /// A dropped record must be *counted*, and a wrong-typed MI counted apart from
+    /// an absent one, so end-of-stream can warn instead of emitting a silently
+    /// empty output.
+    ///
+    /// The `MI:i:` case is the one that bites: fgumi and fgbio write MI as a `Z`
+    /// string (it may carry a `/A`,`/B` suffix), so an integer MI matches no group
+    /// and the whole input vanishes with no diagnostic.
+    #[rstest]
+    #[case::integer_mi_is_wrong_type(vec![raw_with_int_tag("MI", 1), raw_with_int_tag("MI", 1)], 0, 2)]
+    #[case::absent_mi(vec![raw_without_tag(), raw_without_tag()], 2, 0)]
+    #[case::mixed(vec![raw_without_tag(), raw_with_int_tag("MI", 3)], 1, 1)]
+    #[case::valid_string_mi_counts_nothing(vec![raw_with_tag("MI", "1"), raw_with_tag("MI", "1")], 0, 0)]
+    fn skipped_records_are_counted_by_reason(
+        #[case] records: Vec<RawRecord>,
+        #[case] expected_no_mi: u64,
+        #[case] expected_non_string_mi: u64,
+    ) {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20);
+        run_grouping(&mut step, records);
+
+        assert_eq!(step.skipped_no_mi, expected_no_mi, "records with no MI tag");
+        assert_eq!(
+            step.skipped_non_string_mi, expected_non_string_mi,
+            "records whose MI is present but not a Z tag",
+        );
+    }
+
+    /// An all-integer-MI input must produce zero groups — the regression that made
+    /// four simplex parity tests compare one empty BAM against another.
+    #[test]
+    fn integer_mi_groups_nothing() {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20);
+        let records = (0..8).map(|_| raw_with_int_tag("MI", 1)).collect();
+        assert!(run_grouping(&mut step, records).is_empty());
+    }
+
+    #[test]
+    fn cell_tag_composite_key_splits_and_labels() {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20).with_cell_tag(Some(*SamTag::CB));
+        // Same MI, different CB → distinct groups; aux order varies to exercise
+        // the single-pass dual-tag lookup regardless of tag ordering.
+        let records = vec![
+            raw_with_tags(&[("MI", "1"), ("CB", "ACGT")]),
+            raw_with_tags(&[("CB", "ACGT"), ("MI", "1")]),
+            raw_with_tags(&[("MI", "1"), ("CB", "TGCA")]),
+            raw_with_tags(&[("MI", "1"), ("CB", "TGCA")]),
+        ];
+        let groups = run_grouping(&mut step, records);
+        assert_eq!(groups, vec![("1\tACGT".to_string(), 2), ("1\tTGCA".to_string(), 2)]);
+    }
+
+    #[test]
+    fn missing_cell_tag_uses_empty_suffix() {
+        use crate::sam::SamTag;
+        // With a cell tag configured, a record that lacks `CB` keys on an empty
+        // cell suffix (`MI\t`), distinct from a record that carries `CB`. Guards
+        // against a future aux-lookup change silently merging or splitting MI
+        // groups when the configured cell tag is absent.
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20).with_cell_tag(Some(*SamTag::CB));
+        let records = vec![
+            raw_with_tag("MI", "1"),                       // no CB → "1\t"
+            raw_with_tag("MI", "1"),                       // no CB → "1\t"
+            raw_with_tags(&[("MI", "1"), ("CB", "ACGT")]), // → "1\tACGT"
+        ];
+        let groups = run_grouping(&mut step, records);
+        assert_eq!(groups, vec![("1\t".to_string(), 2), ("1\tACGT".to_string(), 1)]);
+    }
+
+    #[test]
+    fn mi_transform_groups_strands_together() {
+        use crate::sam::SamTag;
+        // Strip a trailing "/A" or "/B" so both strands of a molecule group.
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20).with_mi_transform(|mi: &[u8]| {
+            let s = String::from_utf8_lossy(mi);
+            s.split('/').next().unwrap_or("").to_string()
+        });
+        let records =
+            vec![raw_with_tag("MI", "1/A"), raw_with_tag("MI", "1/B"), raw_with_tag("MI", "2/A")];
+        let groups = run_grouping(&mut step, records);
+        // Label is the transformed key, materialized once per group.
+        assert_eq!(groups, vec![("1".to_string(), 2), ("2".to_string(), 1)]);
+    }
+
+    #[test]
+    fn record_filter_drops_records() {
+        use crate::sam::SamTag;
+        // Filter out any record whose MI tag value is "skip".
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20).with_record_filter(|bam: &[u8]| {
+            fgumi_raw_bam::find_string_tag_in_record(bam, *SamTag::MI) != Some(b"skip")
+        });
+        let records = vec![
+            raw_with_tag("MI", "1"),
+            raw_with_tag("MI", "skip"), // dropped, run "1" preserved
+            raw_with_tag("MI", "1"),
+        ];
+        let groups = run_grouping(&mut step, records);
+        assert_eq!(groups, vec![("1".to_string(), 2)]);
+    }
+
+    #[test]
+    fn profile_advertises_serial_byordinal() {
+        use crate::sam::SamTag;
+        let s = GroupByMi::new(*SamTag::MI, 1024);
+        let p = s.profile();
+        assert_eq!(p.name, "GroupByMi");
+        assert_eq!(p.kind, StepKind::Serial);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    #[test]
+    fn batched_mi_groups_carries_ordinal() {
+        let groups = vec![MiGroup::new("0".to_string(), Vec::new())];
+        let wrapped = BatchedMiGroups::new(7, groups);
+        assert_eq!(wrapped.ordinal(), 7);
+        assert_eq!(wrapped.groups.len(), 1);
+    }
+}

--- a/src/lib/pipeline/steps/group/mod.rs
+++ b/src/lib/pipeline/steps/group/mod.rs
@@ -1,0 +1,6 @@
+//! Per-format grouping steps.
+
+pub mod bam;
+pub mod mi;
+pub mod position;
+pub mod queryname;

--- a/src/lib/pipeline/steps/group/position.rs
+++ b/src/lib/pipeline/steps/group/position.rs
@@ -1,0 +1,398 @@
+//! `GroupByPosition` step for the new typed-step pipeline framework.
+//!
+//! Mirrors the legacy pipeline's position-based grouping (`fgumi group`):
+//! consumes `DecodedRecordBatch` items in template-coordinate order,
+//! accumulates records by position via `RecordPositionGrouper`, and
+//! emits **batches** of completed `RawPositionGroup`s as a single
+//! `BatchedRawPositionGroups` per output ordinal.
+//!
+//! ## Why batched (not one-group-per-item)
+//!
+//! Legacy's chain operates on `Vec<P>` at every `Serial` step
+//! (`mi_assign`, `serialize`, ...) so each `Serial` step pays one mutex
+//! acquisition per *batch*, not per *group*. The new pipeline's
+//! initial implementation emitted one group per item; profile diff at
+//! 53M records showed `mi_assign`-style per-group serial bottlenecks
+//! collapsed CPU from 4 cores to ~1 effective core mid-run.
+//!
+//! Batching here matches legacy's data-flow shape: the `Group` step
+//! aggregates many small completions into one batch, every downstream
+//! `Serial` step amortizes its lock cost over the whole batch, and the
+//! `Parallel` `Process` / `Serialize` steps each get one fat unit of work
+//! per dispatch.
+//!
+//! ## Ordinal allocation
+//!
+//! Each emitted *batch* gets a fresh `batch_serial: u64` from a per-step
+//! monotonic counter. Ordinals form a contiguous `0, 1, 2, …` sequence
+//! so the downstream `ReorderStage` can release batches in
+//! input-record order — required for the `Serial` `MiAssign` step to
+//! produce deterministic MI numbering across runs (matches legacy
+//! `docs/design/deterministic-mi-numbering.md`).
+//!
+//! ## Batch sizing
+//!
+//! One threshold: `target_batch_count`, defaulting to 64 groups. Mirrors
+//! legacy's `template_batch_size: 500` adjusted for position-group granularity
+//! (one position group ≈ 5–10 templates on typical workloads). It is a hard cap
+//! on the emitted batch, not just a trigger — `emit_batch` drains at most that
+//! many groups, because `add_records` can complete more in one call than the
+//! target and the accumulator is only checked after extending.
+//!
+//! Byte-based sizing is deliberately *not* a second threshold here. An earlier
+//! revision of this doc described a `target_batch_bytes` derived from the
+//! producer's `output_byte_limit`, but no such field was ever implemented — the
+//! transport budget is enforced by the byte-bounded output queue itself, which
+//! rejects a push that would exceed it and parks the batch in `held`. Adding a
+//! second in-step threshold would duplicate that accounting rather than
+//! reinforce it.
+
+use std::io;
+
+use crate::grouper::{ProcessedPositionGroup, RawPositionGroup, RecordPositionGrouper};
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::item::{HeapSize, Ordered};
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::DecodedRecordBatch;
+use fgumi_bam_io::Grouper;
+use fgumi_bam_io::MemoryEstimate;
+
+/// Max input batches consumed per `try_run` invocation. Amortizes the
+/// `Serial` mutex acquisition; mirrors `GroupBam`'s `MAX_BATCHES_PER_LOCK`.
+const MAX_BATCHES_PER_LOCK: usize = 8;
+
+/// Default target batch count. Mirrors legacy's `template_batch_size: 500`
+/// adjusted for position-group granularity. Position grouping aggregates
+/// many records into one group; legacy's 500 templates per batch maps
+/// to roughly 50–100 position groups, but small caps reduce tail
+/// latency on busy loci. 64 is a balance: fewer mutex acquisitions
+/// downstream, but small enough that one busy-locus group dominating a
+/// batch isn't catastrophic.
+pub const DEFAULT_TARGET_BATCH_COUNT: usize = 64;
+
+/// A batch of `RawPositionGroup`s carrying its monotonic ordinal.
+/// Replaces the per-group `OrderedRawPositionGroup` emitted by earlier
+/// versions of `GroupByPosition`. Downstream `Process` / `MiAssign` /
+/// `Serialize` steps operate on the whole batch per dispatch, amortizing
+/// per-item costs the way legacy does on `Vec<P>`.
+#[derive(Debug)]
+pub struct BatchedRawPositionGroups {
+    pub batch_serial: u64,
+    pub groups: Vec<RawPositionGroup>,
+}
+
+impl BatchedRawPositionGroups {
+    #[must_use]
+    pub fn new(batch_serial: u64, groups: Vec<RawPositionGroup>) -> Self {
+        Self { batch_serial, groups }
+    }
+}
+
+impl HeapSize for BatchedRawPositionGroups {
+    fn heap_size(&self) -> usize {
+        self.groups.iter().map(MemoryEstimate::estimate_heap_size).sum::<usize>()
+            + self.groups.capacity() * std::mem::size_of::<RawPositionGroup>()
+    }
+}
+
+impl Ordered for BatchedRawPositionGroups {
+    fn ordinal(&self) -> u64 {
+        self.batch_serial
+    }
+}
+
+/// A batch of `ProcessedPositionGroup`s carrying its monotonic ordinal.
+/// Same shape as `BatchedRawPositionGroups`; the `process_step`
+/// transforms one into the other one-batch-at-a-time.
+#[derive(Debug)]
+pub struct BatchedProcessedPositionGroups {
+    pub batch_serial: u64,
+    pub groups: Vec<ProcessedPositionGroup>,
+}
+
+impl BatchedProcessedPositionGroups {
+    #[must_use]
+    pub fn new(batch_serial: u64, groups: Vec<ProcessedPositionGroup>) -> Self {
+        Self { batch_serial, groups }
+    }
+}
+
+impl HeapSize for BatchedProcessedPositionGroups {
+    fn heap_size(&self) -> usize {
+        self.groups.iter().map(MemoryEstimate::estimate_heap_size).sum::<usize>()
+            + self.groups.capacity() * std::mem::size_of::<ProcessedPositionGroup>()
+    }
+}
+
+impl Ordered for BatchedProcessedPositionGroups {
+    fn ordinal(&self) -> u64 {
+        self.batch_serial
+    }
+}
+
+/// `Serial + ByItemOrdinal` position grouper. Wraps a
+/// `RecordPositionGrouper` and emits batches of completed
+/// `RawPositionGroup`s.
+///
+/// State is held behind the framework's per-step mutex (the runtime
+/// stores a `Serial` step inside `Arc<Mutex<...>>` and acquires
+/// per-`try_run`); the inner `RecordPositionGrouper` mutates freely
+/// while the lock is held. Held-slot retry pattern matches `GroupBam`:
+/// when an emit is rejected by downstream backpressure, the partial
+/// state stays buffered until the held slot drains.
+pub struct GroupByPosition {
+    grouper: RecordPositionGrouper,
+    /// Self-managed monotonic ordinal — each emitted *batch* gets the
+    /// next value. Required for `BranchOrdering::ByItemOrdinal`'s
+    /// `ReorderStage` to see contiguous serials.
+    next_ordinal: u64,
+    /// Accumulator: completed groups produced by `add_records` waiting
+    /// to be packaged into a batch and pushed downstream. Drained when
+    /// it reaches `target_batch_count`, on the input-drained completion
+    /// path in `try_run`, or via the held-slot path when a prior push was
+    /// rejected.
+    accumulator: Vec<RawPositionGroup>,
+    /// Held output slot when downstream rejected the most recent push.
+    held: HeldSlot<Unpushed<BatchedRawPositionGroups>>,
+    /// Set once the final-flush path has called the (non-idempotent)
+    /// `grouper.finish()`; guards against a second call across the
+    /// multi-pass completion drain.
+    finalized: bool,
+    target_batch_count: usize,
+    output_byte_limit: u64,
+    name: &'static str,
+}
+
+impl GroupByPosition {
+    /// Construct a `GroupByPosition` step. `output_byte_limit` controls
+    /// the byte-bounded queue capacity for emitted batches; sized via
+    /// `BamPipelineTuning::per_step_byte_limit` in production.
+    /// Uses `DEFAULT_TARGET_BATCH_COUNT` for the per-batch group count.
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self::with_target_batch_count(output_byte_limit, DEFAULT_TARGET_BATCH_COUNT)
+    }
+
+    /// Construct with a custom target batch count.
+    #[must_use]
+    pub fn with_target_batch_count(output_byte_limit: u64, target_batch_count: usize) -> Self {
+        Self::with_grouper(RecordPositionGrouper::new(), output_byte_limit, target_batch_count)
+    }
+
+    /// Construct with `RecordPositionGrouper::with_secondary_supplementary()`
+    /// — used by `fgumi dedup`, which must place secondary/supplementary
+    /// records into the same position group as their adjacent primary so
+    /// the duplicate flag propagates uniformly across split alignments.
+    /// The standard `new` constructor uses the default grouper, which
+    /// excludes secondary/supplementary records by position (matching
+    /// `fgumi group` semantics).
+    #[must_use]
+    pub fn with_secondary_supplementary(output_byte_limit: u64) -> Self {
+        Self::with_grouper(
+            RecordPositionGrouper::with_secondary_supplementary(),
+            output_byte_limit,
+            DEFAULT_TARGET_BATCH_COUNT,
+        )
+    }
+
+    fn with_grouper(
+        grouper: RecordPositionGrouper,
+        output_byte_limit: u64,
+        target_batch_count: usize,
+    ) -> Self {
+        Self {
+            grouper,
+            next_ordinal: 0,
+            accumulator: Vec::with_capacity(target_batch_count),
+            held: HeldSlot::new(),
+            finalized: false,
+            target_batch_count: target_batch_count.max(1),
+            output_byte_limit,
+            name: "GroupByPosition",
+        }
+    }
+}
+
+impl Step for GroupByPosition {
+    type Input = DecodedRecordBatch;
+    type Outputs = OrderedBytesSingle<BatchedRawPositionGroups>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Serial,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // 1. Drain held slot first.
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        // 2. If the accumulator is full enough, emit a batch. Don't
+        // pull more input until the batch lands — keeps `accumulator`
+        // bounded to ~`target_batch_count` groups.
+        if self.accumulator.len() >= self.target_batch_count {
+            return Ok(self.emit_batch(ctx));
+        }
+
+        // 3. Process up to `MAX_BATCHES_PER_LOCK` input batches per
+        // call to amortize the Serial mutex acquisition. Stop early
+        // once the accumulator hits the target so memory stays
+        // bounded.
+        let mut did_work = false;
+        for _ in 0..MAX_BATCHES_PER_LOCK {
+            let Some(batch) = ctx.input.pop() else { break };
+            did_work = true;
+            let records = batch.into_records();
+            let groups = self.grouper.add_records(records)?;
+            self.accumulator.extend(groups);
+            if self.accumulator.len() >= self.target_batch_count {
+                break;
+            }
+        }
+
+        // 4. If we filled the accumulator, emit. Otherwise return
+        // Progress (we did work) or NoProgress (input was empty).
+        if self.accumulator.len() >= self.target_batch_count {
+            return Ok(self.emit_batch(ctx));
+        }
+        if did_work {
+            return Ok(StepOutcome::Progress);
+        }
+
+        // 5. No input this call. If upstream is drained, flush the inner
+        // grouper's final partial group once (guarded by `finalized` —
+        // `grouper.finish()` is not idempotent), emit any leftover groups as
+        // a final batch, and report `Finished` once nothing remains. `held` is
+        // empty here (step 1 returned `Contention` otherwise); `emit_batch`
+        // parks a bounced final push in `held` for step 1 to retry next pass.
+        if ctx.input.is_drained() {
+            if !self.finalized {
+                self.finalized = true;
+                if let Some(final_group) = self.grouper.finish()? {
+                    self.accumulator.push(final_group);
+                }
+            }
+            if !self.accumulator.is_empty() {
+                return Ok(self.emit_batch(ctx));
+            }
+            return Ok(StepOutcome::Finished);
+        }
+        Ok(StepOutcome::NoProgress)
+    }
+}
+
+impl GroupByPosition {
+    /// Take at most `target_batch_count` groups off the accumulator, leaving
+    /// any excess for the next batch.
+    ///
+    /// Split out from `emit_batch` so the cap is testable without standing up a
+    /// pipeline: `emit_batch` needs a `StepCtx`, and the property worth pinning
+    /// — that one oversized `add_records` result becomes several bounded batches
+    /// rather than one unbounded one — is entirely in this decision.
+    fn drain_one_batch(&mut self) -> Vec<RawPositionGroup> {
+        let take = self.accumulator.len().min(self.target_batch_count);
+        self.accumulator.drain(..take).collect()
+    }
+
+    /// Package at most `target_batch_count` accumulated groups into one batch.
+    ///
+    /// The cap is why this drains rather than taking the whole accumulator: a
+    /// single `add_records` call can complete more groups than the target — the
+    /// count is only checked *after* extending — so handing the accumulator over
+    /// wholesale would emit a batch of unbounded size, defeating the very
+    /// threshold that exists to bound it. Anything above the cap stays in the
+    /// accumulator, and the `>=` checks in `try_run` re-enter here until it
+    /// falls below the target.
+    ///
+    /// Leftovers are also what makes a rejected push safe: the bounced batch
+    /// parks in `held` while the groups that did not fit in it remain queued.
+    fn emit_batch(&mut self, ctx: &mut StepCtx<'_, Self>) -> StepOutcome {
+        let serial = self.next_ordinal;
+        self.next_ordinal += 1;
+        let groups = self.drain_one_batch();
+        let out = BatchedRawPositionGroups::new(serial, groups);
+        if let Err(unpushed) = ctx.outputs.push(out) {
+            self.held.put(unpushed);
+        }
+        StepOutcome::Progress
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_advertises_serial_byordinal() {
+        let s = GroupByPosition::new(1024);
+        let p = s.profile();
+        assert_eq!(p.name, "GroupByPosition");
+        assert_eq!(p.kind, StepKind::Serial);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    /// One `add_records` call can complete more groups than `target_batch_count`
+    /// — the count is only checked after extending the accumulator — so the cap
+    /// has to be applied when the batch is packaged, not when it is triggered.
+    ///
+    /// Without it, a burst of completions is emitted as a single unbounded
+    /// batch, which is exactly the memory bound `target_batch_count` exists to
+    /// provide. Pins that the excess is preserved rather than dropped, and that
+    /// repeated draining converges.
+    #[test]
+    fn draining_caps_each_batch_and_preserves_the_excess() {
+        const TARGET: usize = 64;
+        let mut step = GroupByPosition::with_target_batch_count(1 << 20, TARGET);
+
+        // 150 completed groups, as one oversized `add_records` result would leave.
+        step.accumulator = (0..150)
+            .map(|_| RawPositionGroup {
+                group_key: fgumi_bam_io::GroupKey::default(),
+                records: Vec::new(),
+            })
+            .collect();
+
+        let first = step.drain_one_batch();
+        assert_eq!(first.len(), TARGET, "a batch must never exceed the target");
+        assert_eq!(step.accumulator.len(), 86, "the excess stays queued, not dropped");
+
+        let second = step.drain_one_batch();
+        assert_eq!(second.len(), TARGET);
+        assert_eq!(step.accumulator.len(), 22);
+
+        // The tail comes out as a short final batch and the accumulator empties,
+        // so the repeated `>=` checks in `try_run` terminate.
+        let third = step.drain_one_batch();
+        assert_eq!(third.len(), 22, "the remainder is emitted as a short batch");
+        assert!(step.accumulator.is_empty());
+        assert!(step.drain_one_batch().is_empty(), "draining an empty accumulator is a no-op");
+    }
+
+    #[test]
+    fn batched_raw_groups_carries_ordinal() {
+        let groups = vec![RawPositionGroup {
+            group_key: fgumi_bam_io::GroupKey::default(),
+            records: Vec::new(),
+        }];
+        let wrapped = BatchedRawPositionGroups::new(42, groups);
+        assert_eq!(wrapped.ordinal(), 42);
+        assert_eq!(wrapped.groups.len(), 1);
+    }
+}

--- a/src/lib/pipeline/steps/group/queryname.rs
+++ b/src/lib/pipeline/steps/group/queryname.rs
@@ -1,0 +1,361 @@
+//! `GroupByQueryname` step for the new typed-step pipeline framework.
+//!
+//! Mirrors the legacy pipeline's queryname grouping (`fgumi filter
+//! --filter-by-template=true`, `fgumi sort --order queryname`):
+//! consumes `DecodedRecordBatch` items, run-length groups consecutive
+//! same-name records into `Template`s, and emits **batches** of
+//! completed templates as one `BamTemplateBatch` per output ordinal.
+//!
+//! Design follows `GroupByMi` and `GroupByPosition`: `Serial` +
+//! `ByItemOrdinal`, batched output to amortize downstream `Serial`
+//! mutex cost, held-slot retry pattern for backpressure.
+
+use std::io;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::{BamTemplateBatch, DecodedRecordBatch};
+use crate::template::Template;
+
+/// Max input batches consumed per `try_run` invocation. Amortizes the
+/// Serial mutex acquisition; mirrors `GroupByMi::MAX_BATCHES_PER_LOCK`.
+const MAX_BATCHES_PER_LOCK: usize = 8;
+
+/// Default target batch count. Mirrors legacy's
+/// `TemplateGrouper::new(1000)` (the production batch size in
+/// `Filter::execute_threads_mode_template`).
+pub const DEFAULT_TARGET_BATCH_COUNT: usize = 1000;
+
+/// `Serial + ByItemOrdinal` queryname grouper. Records arriving in
+/// queryname-grouped (or queryname-sorted) order are partitioned into
+/// runs of consecutive same-name records; each run becomes one
+/// [`Template`]. Completed templates accumulate until the target batch
+/// size is reached, then emit as one [`BamTemplateBatch`].
+///
+/// State is held behind the framework's per-step mutex (the runtime
+/// stores a `Serial` step inside `Arc<Mutex<...>>` and acquires
+/// per-`try_run`). Held-slot retry pattern matches `GroupByMi`:
+/// when an emit is rejected by downstream backpressure, the partial
+/// state stays buffered until the held slot drains.
+pub struct GroupByQueryname {
+    /// Run-length state: queryname currently being accumulated, kept in a
+    /// reusable buffer so each template boundary refills (`clear` +
+    /// `extend_from_slice`) rather than re-allocating a fresh `Vec`. Only
+    /// meaningful while a run is active (`current_name_hash.is_some()`).
+    current_name: Vec<u8>,
+    /// Run-length state: cached `name_hash` for fast pre-check. `Some` iff a
+    /// run is currently active; doubles as the run-active flag so the
+    /// `current_name` allocation survives across template boundaries.
+    current_name_hash: Option<u64>,
+    /// Run-length state: records accumulated for `current_name`.
+    current_records: Vec<fgumi_raw_bam::RawRecord>,
+    /// Self-managed monotonic ordinal — each emitted *batch* gets the
+    /// next value.
+    next_ordinal: u64,
+    /// Accumulator: completed templates waiting to be packaged.
+    accumulator: Vec<Template>,
+    /// Held output slot when downstream rejected the most recent push.
+    held: HeldSlot<Unpushed<BamTemplateBatch>>,
+    target_batch_count: usize,
+    output_byte_limit: u64,
+    name: &'static str,
+}
+
+impl GroupByQueryname {
+    /// Construct a `GroupByQueryname` step.
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self::with_target_batch_count(output_byte_limit, DEFAULT_TARGET_BATCH_COUNT)
+    }
+
+    /// Construct with a custom target batch count.
+    #[must_use]
+    pub fn with_target_batch_count(output_byte_limit: u64, target_batch_count: usize) -> Self {
+        Self {
+            current_name: Vec::new(),
+            current_name_hash: None,
+            current_records: Vec::new(),
+            next_ordinal: 0,
+            accumulator: Vec::with_capacity(target_batch_count),
+            held: HeldSlot::new(),
+            target_batch_count: target_batch_count.max(1),
+            output_byte_limit,
+            name: "GroupByQueryname",
+        }
+    }
+
+    /// Flush the run-in-progress into the accumulator (if non-empty). The
+    /// `current_name` buffer is retained (only the run-active flag is cleared)
+    /// so its allocation is reused by the next template boundary.
+    fn flush_current_template(&mut self) -> io::Result<()> {
+        if !self.current_records.is_empty() {
+            let records = std::mem::take(&mut self.current_records);
+            let template = Template::from_records(records)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            self.accumulator.push(template);
+            self.current_name_hash = None;
+        }
+        Ok(())
+    }
+
+    /// Accumulate one raw record into the current template run, opening a new
+    /// run (and flushing the previous one) at a queryname boundary. The cached
+    /// `name_hash` pre-check short-circuits most inequality before the byte
+    /// compare; the `current_name` buffer is reused across boundaries.
+    fn process_record(&mut self, raw: fgumi_raw_bam::RawRecord, name_hash: u64) -> io::Result<()> {
+        let read_name = fgumi_raw_bam::read_name(raw.as_ref());
+        // A run is active iff `current_name_hash` is `Some`.
+        let same_template = match self.current_name_hash {
+            Some(h) => h == name_hash && self.current_name == read_name,
+            None => false,
+        };
+        if same_template {
+            self.current_records.push(raw);
+        } else {
+            self.flush_current_template()?;
+            // Reuse the buffer: clear + refill rather than allocate.
+            self.current_name.clear();
+            self.current_name.extend_from_slice(read_name);
+            self.current_name_hash = Some(name_hash);
+            self.current_records.push(raw);
+        }
+        Ok(())
+    }
+
+    /// Take at most `target_batch_count` templates off the accumulator, leaving
+    /// any excess for the next batch.
+    ///
+    /// Mirrors `GroupByPosition::drain_one_batch`, and for the same reason: one
+    /// pass over an input batch can complete more templates than the target —
+    /// the count is only checked *after* extending — so handing the accumulator
+    /// over wholesale would emit a batch of unbounded size, defeating the very
+    /// threshold that exists to bound it. The `>=` checks in `try_run` re-enter
+    /// here until the accumulator falls below the target, and the drained path
+    /// does the same until it empties.
+    fn drain_one_batch(&mut self) -> Vec<Template> {
+        let take = self.accumulator.len().min(self.target_batch_count);
+        self.accumulator.drain(..take).collect()
+    }
+
+    /// Package at most `target_batch_count` accumulated templates into one
+    /// batch and emit. On rejection, hold; the next `try_run` will retry via the
+    /// held slot. Leftovers above the cap stay in the accumulator, which is also
+    /// what makes a rejected push safe.
+    fn emit_batch(&mut self, ctx: &mut StepCtx<'_, Self>) -> StepOutcome {
+        let serial = self.next_ordinal;
+        self.next_ordinal += 1;
+        let templates = self.drain_one_batch();
+        let out = BamTemplateBatch::new(serial, templates);
+        if let Err(unpushed) = ctx.outputs.push(out) {
+            self.held.put(unpushed);
+        }
+        StepOutcome::Progress
+    }
+}
+
+impl Step for GroupByQueryname {
+    type Input = DecodedRecordBatch;
+    type Outputs = OrderedBytesSingle<BamTemplateBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Serial,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // 1. Drain held slot first.
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        // 2. If the accumulator is full enough, emit a batch first.
+        if self.accumulator.len() >= self.target_batch_count {
+            return Ok(self.emit_batch(ctx));
+        }
+
+        // 3. Process up to `MAX_BATCHES_PER_LOCK` input batches per call.
+        let mut did_work = false;
+        for _ in 0..MAX_BATCHES_PER_LOCK {
+            let Some(batch) = ctx.input.pop() else { break };
+            did_work = true;
+            let records = batch.into_records();
+            for decoded in records {
+                let name_hash = decoded.key.name_hash;
+                let raw = decoded.into_raw_bytes();
+                self.process_record(raw, name_hash)?;
+            }
+            if self.accumulator.len() >= self.target_batch_count {
+                break;
+            }
+        }
+
+        if self.accumulator.len() >= self.target_batch_count {
+            return Ok(self.emit_batch(ctx));
+        }
+        if did_work {
+            return Ok(StepOutcome::Progress);
+        }
+
+        // 4. No input this call. If upstream is drained, close the
+        // run-in-progress, emit the final partial batch, and report
+        // `Finished` once nothing remains. `held` is empty here (step 1
+        // returned `Contention` otherwise); `emit_batch` parks a bounced
+        // final push in `held` for step 1 to retry next pass.
+        if ctx.input.is_drained() {
+            self.flush_current_template()?;
+            if !self.accumulator.is_empty() {
+                return Ok(self.emit_batch(ctx));
+            }
+            return Ok(StepOutcome::Finished);
+        }
+        Ok(StepOutcome::NoProgress)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::core::item::Ordered;
+    use fgumi_bam_io::library::LibraryIndex;
+    use fgumi_raw_bam::{RawRecord, SamBuilder as RawSamBuilder};
+
+    use fgumi_raw_bam::flags;
+
+    /// Build a minimal mapped raw record with the given read name and flags.
+    fn raw_named(name: &[u8], flag: u16) -> RawRecord {
+        let mut b = RawSamBuilder::new();
+        b.read_name(name).sequence(b"ACGT").qualities(&[30; 4]).flags(flag);
+        b.build()
+    }
+
+    /// An emitted batch must never exceed `target_batch_count`.
+    ///
+    /// One pass over an input batch can complete far more templates than the
+    /// target, so taking the whole accumulator would emit a single unbounded
+    /// batch — exactly the memory bound `target_batch_count` exists to provide.
+    /// Pins that the excess is preserved rather than dropped, and that repeated
+    /// draining converges, which is what makes the `>=` re-entry in `try_run`
+    /// and the drained-path loop terminate.
+    ///
+    /// Mirrors `GroupByPosition`'s `draining_caps_each_batch_and_preserves_the_excess`.
+    #[test]
+    fn draining_caps_each_batch_and_preserves_the_excess() {
+        const TARGET: usize = 64;
+        let mut step = GroupByQueryname::with_target_batch_count(1 << 20, TARGET);
+
+        // 150 completed templates, as one oversized grouping pass would leave.
+        step.accumulator = (0..150).map(|i| Template::new(format!("q{i}").into_bytes())).collect();
+
+        let first = step.drain_one_batch();
+        assert_eq!(first.len(), TARGET, "a batch must never exceed the target");
+        assert_eq!(step.accumulator.len(), 86, "the excess stays queued, not dropped");
+
+        let second = step.drain_one_batch();
+        assert_eq!(second.len(), TARGET);
+        assert_eq!(step.accumulator.len(), 22);
+
+        // The tail comes out as a short final batch and the accumulator empties.
+        let third = step.drain_one_batch();
+        assert_eq!(third.len(), 22, "the remainder is emitted as a short batch");
+        assert!(step.accumulator.is_empty());
+        assert!(step.drain_one_batch().is_empty(), "draining an empty accumulator is a no-op");
+    }
+
+    /// Drive each `(name, flag)` record through [`GroupByQueryname::process_record`],
+    /// close the final run, and return `(name, record_count)` per template in order.
+    fn run_grouping(
+        step: &mut GroupByQueryname,
+        records: &[(&[u8], u16)],
+    ) -> Vec<(Vec<u8>, usize)> {
+        for (name, flag) in records {
+            let raw = raw_named(name, *flag);
+            let name_hash = LibraryIndex::hash_name(Some(name));
+            step.process_record(raw, name_hash).expect("process_record");
+        }
+        step.flush_current_template().expect("flush");
+        step.accumulator.iter().map(|t| (t.name.clone(), t.records().len())).collect()
+    }
+
+    const R1: u16 = flags::PAIRED | flags::FIRST_SEGMENT;
+    const R2: u16 = flags::PAIRED | flags::LAST_SEGMENT;
+
+    #[test]
+    fn consecutive_same_name_forms_one_template() {
+        let mut step = GroupByQueryname::new(1 << 20);
+        let records: Vec<(&[u8], u16)> = vec![(b"read1", R1), (b"read1", R2)];
+        let groups = run_grouping(&mut step, &records);
+        assert_eq!(groups, vec![(b"read1".to_vec(), 2)]);
+    }
+
+    #[test]
+    fn distinct_and_nonadjacent_names_split_runs() {
+        let mut step = GroupByQueryname::new(1 << 20);
+        // read1 appears again non-adjacently → a fresh template, not merged.
+        let records: Vec<(&[u8], u16)> =
+            vec![(b"read1", R1), (b"read1", R2), (b"read2", R1), (b"read1", R1)];
+        let groups = run_grouping(&mut step, &records);
+        assert_eq!(
+            groups,
+            vec![(b"read1".to_vec(), 2), (b"read2".to_vec(), 1), (b"read1".to_vec(), 1)]
+        );
+    }
+
+    #[test]
+    fn buffer_reuse_across_boundaries_preserves_grouping() {
+        // Short-then-long-then-short name transitions exercise the reused
+        // `current_name` buffer (clear + refill); grouping must stay exact.
+        let mut step = GroupByQueryname::new(1 << 20);
+        let records: Vec<(&[u8], u16)> = vec![
+            (b"a", R1),
+            (b"a", R2),
+            (b"longer_name", R1),
+            (b"b", R1),
+            (b"b", R2),
+            (b"another_longer_name", R1),
+            (b"c", R1),
+        ];
+        let groups = run_grouping(&mut step, &records);
+        assert_eq!(
+            groups,
+            vec![
+                (b"a".to_vec(), 2),
+                (b"longer_name".to_vec(), 1),
+                (b"b".to_vec(), 2),
+                (b"another_longer_name".to_vec(), 1),
+                (b"c".to_vec(), 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn profile_advertises_serial_byordinal() {
+        let s = GroupByQueryname::new(1024);
+        let p = s.profile();
+        assert_eq!(p.name, "GroupByQueryname");
+        assert_eq!(p.kind, StepKind::Serial);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    #[test]
+    fn batched_templates_carries_ordinal() {
+        let templates = vec![];
+        let wrapped = BamTemplateBatch::new(11, templates);
+        assert_eq!(wrapped.ordinal(), 11);
+    }
+}

--- a/src/lib/pipeline/steps/mod.rs
+++ b/src/lib/pipeline/steps/mod.rs
@@ -2,26 +2,45 @@
 //!
 //! Layout:
 //!
-//! - `bgzf/`       — BGZF compress/decompress
-//! - `boundaries/` — record-boundary discovery
-//! - `parse/`      — record parsing
-//! - `sink/`       — write-side step implementations
-//! - `source/`     — read-side step implementations (BAM/SAM/FASTQ)
-//! - `sort/`       — sort-chain step re-exports
-//! - `tuning.rs`   — per-chain byte/queue budgets
-//! - `types.rs`    — flowing data types (`HeapSize` + `Ordered`)
+//! - `bgzf/`                    — BGZF compress/decompress
+//! - `boundaries/`              — record-boundary discovery
+//! - `group/`                   — template grouping (BAM, position, queryname, MI)
+//! - `parse/`                   — record parsing
+//! - `process.rs`               — closure-driven mid-steps (`Process`,
+//!   `ProcessWithWorkerState`, `MiAssign`)
+//! - `serialize.rs`             — record serialization
+//! - `serialize_processed.rs`   — serialization for processed-template batches
+//! - `sink/`                    — write-side step implementations
+//! - `sort/`                    — sort-chain step re-exports
+//! - `source/`                  — read-side step implementations (BAM/SAM/FASTQ)
+//! - `templates_to_records.rs`  — flatten templates back into records
+//! - `tuning.rs`                — per-chain byte/queue budgets
+//! - `types.rs`                 — flowing data types (`HeapSize` + `Ordered`)
 //!
-//! `group/`, `correct/`, and the closure-driven mid-steps arrive in follow-up
-//! ports.
+//! `correct/`, `extract.rs`, and `align_and_merge` arrive in follow-up ports:
+//! the first two additionally require the command-layer options refactor
+//! (`CorrectOptions` / `ExtractOptions`), which lands with the command rewiring.
+//!
+//! This module deliberately holds only what the chain builder actually
+//! constructs. Two steps that exist upstream are *not* ported here:
+//! `coalesce.rs` (a `CoalesceBytes` byte-batching step with no caller anywhere,
+//! upstream included) and `roundtrip.rs` (a whole-chain convenience whose only
+//! consumer is the `compare bam-roundtrip` command, so it travels with the
+//! command rewiring rather than with the steps).
 
 pub mod bgzf;
 pub mod boundaries;
 #[cfg(test)]
 mod chain_tests;
+pub mod group;
 pub mod parse;
+pub mod process;
+pub mod serialize;
+pub mod serialize_processed;
 pub mod sink;
 pub mod sort;
 pub mod source;
+pub mod templates_to_records;
 pub mod tuning;
 pub mod types;
 
@@ -30,3 +49,6 @@ pub use types::{
     BamTemplateBatch, BgzfBlock, DecodedRecordBatch, DecompressedBlock, RecordBatch,
     RecordBatchBuilder,
 };
+
+#[cfg(test)]
+mod tests;

--- a/src/lib/pipeline/steps/process.rs
+++ b/src/lib/pipeline/steps/process.rs
@@ -1,0 +1,1747 @@
+//! Closure-driven mid-steps: `Process`, `ProcessOrdered`,
+//! `ProcessWithWorkerState`, `MiAssign`.
+//!
+//! The four are colocated per Phase 0 design line 371:
+//! `process.rs # process(fn), process_with_worker_state(init, fn), mi_assign(fn)`.
+//!
+//! In addition to the single-output `Process*` family, this module also
+//! provides the 2-output fan-out variants `Process2`, `Process2Ordered`, and
+//! `Process2WithWorkerState` for the kept/rejects shape (e.g. `correct`'s
+//! `CorrectOutputs`).
+
+use std::io;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::item::{HeapSize, Ordered};
+use crate::pipeline::core::outputs::{OrderedBytesSingle, Single};
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Process<I, T, F> — Parallel, FIFO output (Single<T>).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Closure-driven `Parallel` mid-step with `Single<T>` output (FIFO by
+/// arrival). Use [`ProcessOrdered`] when consumers need order preserved.
+pub struct Process<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    f: Arc<F>,
+    held: HeldSlot<Unpushed<T>>,
+    name: &'static str,
+    capacity: usize,
+    _phantom: PhantomData<fn() -> I>,
+}
+
+impl<I, T, F> Process<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    pub fn new(name: &'static str, capacity: usize, f: F) -> Self {
+        Self { f: Arc::new(f), held: HeldSlot::new(), name, capacity, _phantom: PhantomData }
+    }
+}
+
+impl<I, T, F> Clone for Process<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            f: Arc::clone(&self.f),
+            held: HeldSlot::new(),
+            name: self.name,
+            capacity: self.capacity,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, T, F> Step for Process<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    type Input = I;
+    type Outputs = Single<T>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::CountBounded { capacity: self.capacity }],
+            branch_ordering: vec![BranchOrdering::None],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        let Some(item) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let out = (self.f)(item)?;
+        match ctx.outputs.push(out) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+/// Convenience constructor for [`Process`].
+pub fn process<I, T, F>(name: &'static str, capacity: usize, f: F) -> Process<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    Process::new(name, capacity, f)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ProcessOrdered<I, T, F> — Parallel, ByItemOrdinal output
+// (OrderedBytesSingle<T>). The canonical BAM-step shape.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Closure-driven `Parallel` mid-step with `OrderedBytesSingle<T>` output.
+/// Closure must produce `T: HeapSize + Ordered`; the framework's reorder
+/// stage uses `T::ordinal()` to preserve global ordering.
+///
+/// Phase 3's BAM steps that don't fit into a more specific type
+/// (`GroupBam`, `MiAssign`) compose via `ProcessOrdered` with a closure
+/// that copies the input batch's serial onto the output.
+pub struct ProcessOrdered<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    f: Arc<F>,
+    held: HeldSlot<Unpushed<T>>,
+    name: &'static str,
+    limit_bytes: u64,
+    _phantom: PhantomData<fn() -> I>,
+}
+
+impl<I, T, F> ProcessOrdered<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    pub fn new(name: &'static str, limit_bytes: u64, f: F) -> Self {
+        Self { f: Arc::new(f), held: HeldSlot::new(), name, limit_bytes, _phantom: PhantomData }
+    }
+}
+
+impl<I, T, F> Clone for ProcessOrdered<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            f: Arc::clone(&self.f),
+            held: HeldSlot::new(),
+            name: self.name,
+            limit_bytes: self.limit_bytes,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, T, F> Step for ProcessOrdered<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    type Input = I;
+    type Outputs = OrderedBytesSingle<T>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.limit_bytes }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        let Some(item) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let out = (self.f)(item)?;
+        match ctx.outputs.push(out) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+/// Convenience constructor for [`ProcessOrdered`].
+pub fn process_ordered<I, T, F>(
+    name: &'static str,
+    limit_bytes: u64,
+    f: F,
+) -> ProcessOrdered<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    ProcessOrdered::new(name, limit_bytes, f)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ProcessWithWorkerState<I, T, F, S, FInit> — Parallel + lazy per-worker
+// state. Used by consensus callers (simplex/duplex/codec) where each
+// worker reuses one caller across all batches.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `Parallel` + lazy per-worker state. The framework's `Clone` resets
+/// `state` to `None`; first `try_run` initializes via `init()`, subsequent
+/// calls reuse the stored `S` via `&mut`. Each worker owns its clone
+/// exclusively (`Parallel` kind), so no synchronization is needed.
+///
+/// **Implementation note** (deviates from Phase 0 design line 136 which
+/// proposed `OnceLock<S>`): `OnceLock` doesn't expose `&mut S`, but
+/// consensus callers need mutable access to internal scratch buffers.
+/// `Option<S>` + `get_or_insert_with` provides equivalent lazy-init
+/// semantics with the required `&mut` access. Race-free because `Parallel`
+/// workers each own their clone.
+pub struct ProcessWithWorkerState<I, T, F, S, FInit>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(&mut S, I) -> io::Result<T> + Send + Sync + 'static,
+    S: Send + HeapSize + 'static,
+    FInit: Fn() -> S + Send + Sync + 'static,
+{
+    f: Arc<F>,
+    init: Arc<FInit>,
+    /// Lazy per-worker state. `Clone` resets to `None`.
+    state: Option<S>,
+    held: HeldSlot<Unpushed<T>>,
+    name: &'static str,
+    limit_bytes: u64,
+    _phantom: PhantomData<fn() -> I>,
+}
+
+impl<I, T, F, S, FInit> ProcessWithWorkerState<I, T, F, S, FInit>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(&mut S, I) -> io::Result<T> + Send + Sync + 'static,
+    S: Send + HeapSize + 'static,
+    FInit: Fn() -> S + Send + Sync + 'static,
+{
+    pub fn new(name: &'static str, limit_bytes: u64, init: FInit, f: F) -> Self {
+        Self {
+            f: Arc::new(f),
+            init: Arc::new(init),
+            state: None,
+            held: HeldSlot::new(),
+            name,
+            limit_bytes,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, T, F, S, FInit> Clone for ProcessWithWorkerState<I, T, F, S, FInit>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(&mut S, I) -> io::Result<T> + Send + Sync + 'static,
+    S: Send + HeapSize + 'static,
+    FInit: Fn() -> S + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            f: Arc::clone(&self.f),
+            init: Arc::clone(&self.init),
+            state: None, // <-- per-worker fresh; lazy on first try_run
+            held: HeldSlot::new(),
+            name: self.name,
+            limit_bytes: self.limit_bytes,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, T, F, S, FInit> Step for ProcessWithWorkerState<I, T, F, S, FInit>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(&mut S, I) -> io::Result<T> + Send + Sync + 'static,
+    S: Send + HeapSize + 'static,
+    FInit: Fn() -> S + Send + Sync + 'static,
+{
+    type Input = I;
+    type Outputs = OrderedBytesSingle<T>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.limit_bytes }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        let Some(item) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let state = self.state.get_or_insert_with(|| (self.init)());
+        let out = (self.f)(state, item)?;
+        match ctx.outputs.push(out) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+/// Convenience constructor for [`ProcessWithWorkerState`].
+pub fn process_with_worker_state<I, T, F, S, FInit>(
+    name: &'static str,
+    limit_bytes: u64,
+    init: FInit,
+    f: F,
+) -> ProcessWithWorkerState<I, T, F, S, FInit>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(&mut S, I) -> io::Result<T> + Send + Sync + 'static,
+    S: Send + HeapSize + 'static,
+    FInit: Fn() -> S + Send + Sync + 'static,
+{
+    ProcessWithWorkerState::new(name, limit_bytes, init, f)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Process2WithWorkerState<I, A, B, S, Init, F> — Parallel + lazy per-worker
+// state + 2-output fan-out. Mirror of `ProcessWithWorkerState` widened to two
+// ordered + byte-bounded output branches. Used by `CorrectStep` (kept +
+// rejects) where each worker reuses one `LruCache` across all batches without
+// `thread_local!` debt at every 2-output worker-state call site.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `Parallel` + lazy per-worker state + 2-output fan-out. `Clone` resets
+/// `state` to `None`; first `try_run` initializes via `init()`; subsequent
+/// calls reuse the stored `S` via `&mut`. Each worker owns its clone
+/// exclusively (`Parallel` kind), so no synchronization is needed.
+///
+/// **Implementation note** (deviates from Phase 0 design line 136 which
+/// proposed `OnceLock<S>`): `OnceLock` doesn't expose `&mut S`, but
+/// consensus callers need mutable access to internal scratch buffers.
+/// `Option<S>` + `get_or_insert_with` provides equivalent lazy-init
+/// semantics with the required `&mut` access. Race-free because `Parallel`
+/// workers each own their clone. This applies to this variant for the same
+/// reasons as the 1-output sibling [`ProcessWithWorkerState`].
+pub struct Process2WithWorkerState<I, A, B, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    f: Arc<F>,
+    init: Arc<Init>,
+    state: Option<S>,
+    held_a: HeldSlot<Unpushed<A>>,
+    held_b: HeldSlot<Unpushed<B>>,
+    name: &'static str,
+    limit_bytes_a: u64,
+    limit_bytes_b: u64,
+    _phantom: PhantomData<fn() -> I>,
+}
+
+impl<I, A, B, S, Init, F> Process2WithWorkerState<I, A, B, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    pub fn new(
+        name: &'static str,
+        limit_bytes_a: u64,
+        limit_bytes_b: u64,
+        init: Init,
+        f: F,
+    ) -> Self {
+        Self {
+            f: Arc::new(f),
+            init: Arc::new(init),
+            state: None,
+            held_a: HeldSlot::new(),
+            held_b: HeldSlot::new(),
+            name,
+            limit_bytes_a,
+            limit_bytes_b,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, A, B, S, Init, F> Clone for Process2WithWorkerState<I, A, B, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            f: Arc::clone(&self.f),
+            init: Arc::clone(&self.init),
+            state: None, // per-worker fresh; lazy on first try_run
+            held_a: HeldSlot::new(),
+            held_b: HeldSlot::new(),
+            name: self.name,
+            limit_bytes_a: self.limit_bytes_a,
+            limit_bytes_b: self.limit_bytes_b,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, A, B, S, Init, F> Step for Process2WithWorkerState<I, A, B, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    type Input = I;
+    type Outputs = crate::pipeline::core::outputs::OrderedBytesTuple2<A, B>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![
+                QueueSpec::ByteBounded { limit_bytes: self.limit_bytes_a },
+                QueueSpec::ByteBounded { limit_bytes: self.limit_bytes_b },
+            ],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal, BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        let view = ctx.outputs.view();
+
+        if let Some(unpushed) = self.held_a.take() {
+            match view.a.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held_a.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        if let Some(unpushed) = self.held_b.take() {
+            match view.b.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held_b.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(item) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let state = self.state.get_or_insert_with(|| (self.init)());
+        let Process2Output { a, b } = (self.f)(state, item)?;
+
+        if let Some(av) = a
+            && let Err(unpushed) = view.a.push(av)
+        {
+            self.held_a.put(unpushed);
+        }
+        if let Some(bv) = b
+            && let Err(unpushed) = view.b.push(bv)
+        {
+            self.held_b.put(unpushed);
+        }
+        Ok(StepOutcome::Progress)
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+/// Convenience constructor for [`Process2WithWorkerState`].
+pub fn process2_with_worker_state<I, A, B, S, Init, F>(
+    name: &'static str,
+    limit_bytes_a: u64,
+    limit_bytes_b: u64,
+    init: Init,
+    f: F,
+) -> Process2WithWorkerState<I, A, B, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    Process2WithWorkerState::new(name, limit_bytes_a, limit_bytes_b, init, f)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Process3WithWorkerState<I, A, B, C, S, Init, F> — Parallel + lazy per-worker
+// state + 3-output fan-out. Mirror of `Process2WithWorkerState` widened to
+// three ordered + byte-bounded output branches. Used by the paired FASTQ
+// encode (R1 / R2 / other), where each worker reuses one scratch buffer set
+// across all batches. Each branch carries its own `HeldSlot` for independent
+// backpressure, exactly as the 2-output sibling.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Output of a [`Process3WithWorkerState`] closure: one optional value per
+/// output branch.
+///
+/// The rule for returning `None` on an ordered branch is the same one stated at
+/// length on [`Process2Output`], because both types feed the same `ReorderStage`
+/// contract: `None` is safe when the branch mints its own **dense, branch-local**
+/// ordinals, and unsafe when the branch propagates the *input's* ordinal, where
+/// the skip leaves a permanent hole that stalls the run. See [`Process2Output`]
+/// for why that stalls rather than merely dropping an item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Process3Output<A, B, C> {
+    pub a: Option<A>,
+    pub b: Option<B>,
+    pub c: Option<C>,
+}
+
+impl<A, B, C> Process3Output<A, B, C> {
+    #[must_use]
+    pub fn both3(a: A, b: B, c: C) -> Self {
+        Self { a: Some(a), b: Some(b), c: Some(c) }
+    }
+}
+
+/// `Parallel` + lazy per-worker state + 3-output fan-out. `Clone` resets
+/// `state` to `None`; first `try_run` initializes via `init()`; subsequent
+/// calls reuse the stored `S` via `&mut`. Each worker owns its clone
+/// exclusively (`Parallel` kind), so no synchronization is needed. Mirror of
+/// [`Process2WithWorkerState`] with a third branch.
+pub struct Process3WithWorkerState<I, A, B, C, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    C: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process3Output<A, B, C>> + Send + Sync + 'static,
+{
+    f: Arc<F>,
+    init: Arc<Init>,
+    state: Option<S>,
+    held_a: HeldSlot<Unpushed<A>>,
+    held_b: HeldSlot<Unpushed<B>>,
+    held_c: HeldSlot<Unpushed<C>>,
+    name: &'static str,
+    limit_bytes_a: u64,
+    limit_bytes_b: u64,
+    limit_bytes_c: u64,
+    _phantom: PhantomData<fn() -> I>,
+}
+
+impl<I, A, B, C, S, Init, F> Process3WithWorkerState<I, A, B, C, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    C: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process3Output<A, B, C>> + Send + Sync + 'static,
+{
+    pub fn new(
+        name: &'static str,
+        limit_bytes_a: u64,
+        limit_bytes_b: u64,
+        limit_bytes_c: u64,
+        init: Init,
+        f: F,
+    ) -> Self {
+        Self {
+            f: Arc::new(f),
+            init: Arc::new(init),
+            state: None,
+            held_a: HeldSlot::new(),
+            held_b: HeldSlot::new(),
+            held_c: HeldSlot::new(),
+            name,
+            limit_bytes_a,
+            limit_bytes_b,
+            limit_bytes_c,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, A, B, C, S, Init, F> Clone for Process3WithWorkerState<I, A, B, C, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    C: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process3Output<A, B, C>> + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            f: Arc::clone(&self.f),
+            init: Arc::clone(&self.init),
+            state: None, // per-worker fresh; lazy on first try_run
+            held_a: HeldSlot::new(),
+            held_b: HeldSlot::new(),
+            held_c: HeldSlot::new(),
+            name: self.name,
+            limit_bytes_a: self.limit_bytes_a,
+            limit_bytes_b: self.limit_bytes_b,
+            limit_bytes_c: self.limit_bytes_c,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, A, B, C, S, Init, F> Step for Process3WithWorkerState<I, A, B, C, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    C: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process3Output<A, B, C>> + Send + Sync + 'static,
+{
+    type Input = I;
+    type Outputs = crate::pipeline::core::outputs::OrderedBytesTuple3<A, B, C>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![
+                QueueSpec::ByteBounded { limit_bytes: self.limit_bytes_a },
+                QueueSpec::ByteBounded { limit_bytes: self.limit_bytes_b },
+                QueueSpec::ByteBounded { limit_bytes: self.limit_bytes_c },
+            ],
+            branch_ordering: vec![
+                BranchOrdering::ByItemOrdinal,
+                BranchOrdering::ByItemOrdinal,
+                BranchOrdering::ByItemOrdinal,
+            ],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        let view = ctx.outputs.view();
+
+        if let Some(unpushed) = self.held_a.take() {
+            match view.a.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held_a.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        if let Some(unpushed) = self.held_b.take() {
+            match view.b.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held_b.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        if let Some(unpushed) = self.held_c.take() {
+            match view.c.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held_c.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(item) = ctx.input.pop() else {
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let state = self.state.get_or_insert_with(|| (self.init)());
+        let Process3Output { a, b, c } = (self.f)(state, item)?;
+
+        if let Some(av) = a
+            && let Err(unpushed) = view.a.push(av)
+        {
+            self.held_a.put(unpushed);
+        }
+        if let Some(bv) = b
+            && let Err(unpushed) = view.b.push(bv)
+        {
+            self.held_b.put(unpushed);
+        }
+        if let Some(cv) = c
+            && let Err(unpushed) = view.c.push(cv)
+        {
+            self.held_c.put(unpushed);
+        }
+        Ok(StepOutcome::Progress)
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+/// Convenience constructor for [`Process3WithWorkerState`].
+#[allow(clippy::too_many_arguments)]
+pub fn process3_with_worker_state<I, A, B, C, S, Init, F>(
+    name: &'static str,
+    limit_bytes_a: u64,
+    limit_bytes_b: u64,
+    limit_bytes_c: u64,
+    init: Init,
+    f: F,
+) -> Process3WithWorkerState<I, A, B, C, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    C: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process3Output<A, B, C>> + Send + Sync + 'static,
+{
+    Process3WithWorkerState::new(name, limit_bytes_a, limit_bytes_b, limit_bytes_c, init, f)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MiAssign<I, F> — Serial + monotonic MI counter. Used for deterministic
+// MoleculeId numbering across input batches.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `Serial` closure-driven step that maintains a monotonic MI counter.
+/// Used by `group` / `dedup` for deterministic `MoleculeId` numbering.
+/// The closure receives `(&mut next_mi, input)` and returns the transformed
+/// output (with MI tags applied to records).
+pub struct MiAssign<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(&mut u64, I) -> io::Result<T> + Send + Sync + 'static,
+{
+    f: Arc<F>,
+    next_mi: u64,
+    held: HeldSlot<Unpushed<T>>,
+    name: &'static str,
+    limit_bytes: u64,
+    _phantom: PhantomData<fn() -> I>,
+}
+
+impl<I, T, F> MiAssign<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(&mut u64, I) -> io::Result<T> + Send + Sync + 'static,
+{
+    pub fn new(name: &'static str, limit_bytes: u64, f: F) -> Self {
+        Self {
+            f: Arc::new(f),
+            next_mi: 0,
+            held: HeldSlot::new(),
+            name,
+            limit_bytes,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, T, F> Step for MiAssign<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(&mut u64, I) -> io::Result<T> + Send + Sync + 'static,
+{
+    type Input = I;
+    type Outputs = OrderedBytesSingle<T>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Serial,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.limit_bytes }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        let Some(item) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            //
+            // Unlike the `Parallel` steps above, this one is `Serial`: the
+            // driver keeps a single mutex-protected instance shared by every
+            // eligible worker and never calls `new_worker_copy`, so there are
+            // no sibling clones to wait for and no `StepDrainCounter` to
+            // coordinate. Whichever worker holds the lock when the input
+            // drains reports `Finished` once, and the shared `DrainGate`
+            // latches that so the others never re-run the step.
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let out = (self.f)(&mut self.next_mi, item)?;
+        match ctx.outputs.push(out) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+}
+
+/// Convenience constructor for [`MiAssign`].
+pub fn mi_assign<I, T, F>(name: &'static str, limit_bytes: u64, f: F) -> MiAssign<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(&mut u64, I) -> io::Result<T> + Send + Sync + 'static,
+{
+    MiAssign::new(name, limit_bytes, f)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Process2<I, A, B, F> — Parallel, fan-out to two unordered output branches.
+// Used by `correct`/`filter`-style commands that emit a primary output plus
+// a rejects/secondary output. Both branches are `BranchOrdering::None` (FIFO
+// by arrival) so workers can race to push without ordinal coordination.
+//
+// Backpressure: each branch carries its own `HeldSlot`. If branch A pushes
+// fail, the rejected item is parked in `held_a` and the next `try_run`
+// drains it before popping new input. Branch B is independent. This means
+// a stuck consumer on one side won't drop items — but it also means a
+// permanently slow consumer will eventually block the step. The dispatch that
+// first parks an item still returns `Progress` (with the produced item(s)
+// buffered — up to one per branch, since a single dispatch can fill both
+// `held_a` and `held_b`); `Contention` is reported only on a *subsequent*
+// dispatch, by the held-drain preamble, when a still-held item cannot be
+// pushed. Each branch holds at most one item (one input is popped per call).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Output of a [`Process2`] closure: one optional value per output branch.
+/// Either branch may be `None` to indicate "no item produced for this
+/// branch this call" (filter / sparse fan-out).
+///
+/// # Returning `None` on an ordered branch
+///
+/// `None` is safe only when that branch mints its own **dense, branch-local**
+/// ordinals — i.e. the closure numbers what it emits, so skipping an input
+/// simply means the next emitted item takes the next ordinal.
+///
+/// It is **not** safe when the branch propagates the *input's* ordinal. Omitting
+/// an item then leaves a permanent hole in the sequence, and a branch wired with
+/// [`BranchOrdering::ByItemOrdinal`] has a `ReorderStage` that releases items
+/// only in contiguous order — so it waits forever for an ordinal no one will
+/// ever emit. That is a stall, not a dropped item: the run hangs rather than
+/// producing short output, which is why it is worth stating here rather than
+/// leaving to be discovered.
+///
+/// The same caveat applies to [`Process2Ordered`] and
+/// [`Process2WithWorkerState`], which share this output type.
+///
+/// [`BranchOrdering::ByItemOrdinal`]: crate::pipeline::core::reorder::BranchOrdering
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Process2Output<A, B> {
+    pub a: Option<A>,
+    pub b: Option<B>,
+}
+
+impl<A, B> Process2Output<A, B> {
+    #[must_use]
+    pub fn both(a: A, b: B) -> Self {
+        Self { a: Some(a), b: Some(b) }
+    }
+
+    #[must_use]
+    pub fn only_a(a: A) -> Self {
+        Self { a: Some(a), b: None }
+    }
+
+    #[must_use]
+    pub fn only_b(b: B) -> Self {
+        Self { a: None, b: Some(b) }
+    }
+
+    #[must_use]
+    pub fn none() -> Self {
+        Self { a: None, b: None }
+    }
+}
+
+/// Closure-driven `Parallel` mid-step that fans out to two unordered output
+/// branches `(A, B)`. The closure returns a [`Process2Output`] describing
+/// what to push to each branch.
+///
+/// Both output branches use `BranchOrdering::None`. If the consumer of either
+/// branch needs ordering, prefer composing single-output ordered steps
+/// instead — `Process2` is for the sparse-output / rejects-path shape.
+pub struct Process2<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + 'static,
+    B: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    f: Arc<F>,
+    held_a: HeldSlot<Unpushed<A>>,
+    held_b: HeldSlot<Unpushed<B>>,
+    name: &'static str,
+    capacity_a: usize,
+    capacity_b: usize,
+    _phantom: PhantomData<fn() -> I>,
+}
+
+impl<I, A, B, F> Process2<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + 'static,
+    B: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    pub fn new(name: &'static str, capacity_a: usize, capacity_b: usize, f: F) -> Self {
+        Self {
+            f: Arc::new(f),
+            held_a: HeldSlot::new(),
+            held_b: HeldSlot::new(),
+            name,
+            capacity_a,
+            capacity_b,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, A, B, F> Clone for Process2<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + 'static,
+    B: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            f: Arc::clone(&self.f),
+            held_a: HeldSlot::new(),
+            held_b: HeldSlot::new(),
+            name: self.name,
+            capacity_a: self.capacity_a,
+            capacity_b: self.capacity_b,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, A, B, F> Step for Process2<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + 'static,
+    B: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    type Input = I;
+    type Outputs = (A, B);
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![
+                QueueSpec::CountBounded { capacity: self.capacity_a },
+                QueueSpec::CountBounded { capacity: self.capacity_b },
+            ],
+            branch_ordering: vec![BranchOrdering::None, BranchOrdering::None],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        let view = ctx.outputs.view();
+
+        // Drain held items first. A branch that's still rejecting blocks
+        // forward progress on this worker until the consumer drains.
+        if let Some(unpushed) = self.held_a.take() {
+            match view.a.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held_a.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        if let Some(unpushed) = self.held_b.take() {
+            match view.b.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held_b.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(item) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let Process2Output { a, b } = (self.f)(item)?;
+
+        // Push each side. If either is rejected, hold and continue —
+        // we still made progress (consumed input + produced what we could).
+        if let Some(av) = a
+            && let Err(unpushed) = view.a.push(av)
+        {
+            self.held_a.put(unpushed);
+        }
+        if let Some(bv) = b
+            && let Err(unpushed) = view.b.push(bv)
+        {
+            self.held_b.put(unpushed);
+        }
+        Ok(StepOutcome::Progress)
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+/// Convenience constructor for [`Process2`].
+pub fn process2<I, A, B, F>(
+    name: &'static str,
+    capacity_a: usize,
+    capacity_b: usize,
+    f: F,
+) -> Process2<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + 'static,
+    B: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    Process2::new(name, capacity_a, capacity_b, f)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Process2Ordered<I, A, B, F> — Parallel, fan-out to two ordered + byte-bounded
+// branches. Both branches use `BranchOrdering::ByItemOrdinal` so each output
+// stream is reorderable into input order downstream. Use this when both
+// outputs need to be BAM-sortable (e.g., `filter` emitting kept and rejected
+// records that each feed an ordered `BgzfCompress` + `WriteBgzfFile` chain).
+//
+// Backpressure semantics mirror `Process2`: per-branch `HeldSlot` parks the
+// rejected item and the next `try_run` retries before popping new input.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Closure-driven `Parallel` mid-step that fans out to two ordered output
+/// branches `(A, B)`, both `BranchOrdering::ByItemOrdinal`. The closure
+/// returns a [`Process2Output`] describing what to push to each branch.
+///
+/// Both `A` and `B` must implement [`Ordered`] + [`HeapSize`]: each
+/// branch's reorder stage uses `item.ordinal()` to release in input
+/// order and the byte-bounded queue uses `heap_size()` for admission
+/// control.
+pub struct Process2Ordered<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    f: Arc<F>,
+    held_a: HeldSlot<Unpushed<A>>,
+    held_b: HeldSlot<Unpushed<B>>,
+    name: &'static str,
+    limit_bytes_a: u64,
+    limit_bytes_b: u64,
+    _phantom: PhantomData<fn() -> I>,
+}
+
+impl<I, A, B, F> Process2Ordered<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    pub fn new(name: &'static str, limit_bytes_a: u64, limit_bytes_b: u64, f: F) -> Self {
+        Self {
+            f: Arc::new(f),
+            held_a: HeldSlot::new(),
+            held_b: HeldSlot::new(),
+            name,
+            limit_bytes_a,
+            limit_bytes_b,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, A, B, F> Clone for Process2Ordered<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            f: Arc::clone(&self.f),
+            held_a: HeldSlot::new(),
+            held_b: HeldSlot::new(),
+            name: self.name,
+            limit_bytes_a: self.limit_bytes_a,
+            limit_bytes_b: self.limit_bytes_b,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, A, B, F> Step for Process2Ordered<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    type Input = I;
+    type Outputs = crate::pipeline::core::outputs::OrderedBytesTuple2<A, B>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![
+                QueueSpec::ByteBounded { limit_bytes: self.limit_bytes_a },
+                QueueSpec::ByteBounded { limit_bytes: self.limit_bytes_b },
+            ],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal, BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        let view = ctx.outputs.view();
+
+        if let Some(unpushed) = self.held_a.take() {
+            match view.a.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held_a.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        if let Some(unpushed) = self.held_b.take() {
+            match view.b.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held_b.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(item) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let Process2Output { a, b } = (self.f)(item)?;
+
+        if let Some(av) = a
+            && let Err(unpushed) = view.a.push(av)
+        {
+            self.held_a.put(unpushed);
+        }
+        if let Some(bv) = b
+            && let Err(unpushed) = view.b.push(bv)
+        {
+            self.held_b.put(unpushed);
+        }
+        Ok(StepOutcome::Progress)
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+/// Convenience constructor for [`Process2Ordered`].
+pub fn process2_ordered<I, A, B, F>(
+    name: &'static str,
+    limit_bytes_a: u64,
+    limit_bytes_b: u64,
+    f: F,
+) -> Process2Ordered<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    Process2Ordered::new(name, limit_bytes_a, limit_bytes_b, f)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::core::{PipelineBuilder, PipelineConfig};
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicU32, Ordering as AtomicOrd};
+
+    /// Source emitting `remaining` items via a shared atomic counter; safe for
+    /// single- and multi-worker `Parallel` execution. (Relocated here with the
+    /// `process2` pipeline-run tests below: the `fgumi-pipeline-core` crate that
+    /// owns the builder can't depend on this `pipeline::steps` layer, so these
+    /// end-to-end `process2` tests live next to `process2` itself.)
+    #[derive(Clone)]
+    struct SharedCountingSource {
+        remaining: Arc<AtomicU32>,
+    }
+    impl Step for SharedCountingSource {
+        type Input = ();
+        type Outputs = Single<u32>;
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "SharedSource",
+                kind: StepKind::Parallel,
+                sticky: false,
+                output_queues: vec![QueueSpec::Unbounded],
+                branch_ordering: vec![BranchOrdering::None],
+            }
+        }
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> std::io::Result<StepOutcome> {
+            let n = self.remaining.load(AtomicOrd::Acquire);
+            if n == 0 {
+                return Ok(StepOutcome::Finished);
+            }
+            if self
+                .remaining
+                .compare_exchange(n, n - 1, AtomicOrd::AcqRel, AtomicOrd::Acquire)
+                .is_ok()
+            {
+                ctx.outputs.push(n).map_err(|_| {
+                    std::io::Error::other("Unbounded queue rejected push (impossible)")
+                })?;
+                Ok(StepOutcome::Progress)
+            } else {
+                Ok(StepOutcome::NoProgress)
+            }
+        }
+        fn new_worker_copy(&self) -> Self {
+            self.clone()
+        }
+    }
+
+    /// Sink that pops and collects the values it receives. Collecting the
+    /// actual values (rather than only a count) lets the fan-out tests assert
+    /// the exact multiset routed to each branch: a bug that drops, duplicates,
+    /// swaps, or misroutes values while preserving the per-branch count would
+    /// slip past a count-only assertion.
+    #[derive(Clone)]
+    struct ParallelCollectingSink {
+        received: Arc<Mutex<Vec<u32>>>,
+    }
+    impl Step for ParallelCollectingSink {
+        type Input = u32;
+        type Outputs = ();
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "ParallelSink",
+                kind: StepKind::Parallel,
+                sticky: false,
+                output_queues: vec![],
+                branch_ordering: vec![],
+            }
+        }
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> std::io::Result<StepOutcome> {
+            match ctx.input.pop() {
+                Some(v) => {
+                    self.received.lock().expect("sink mutex poisoned").push(v);
+                    Ok(StepOutcome::Progress)
+                }
+                None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+                None => Ok(StepOutcome::NoProgress),
+            }
+        }
+        fn new_worker_copy(&self) -> Self {
+            self.clone()
+        }
+    }
+
+    /// Sorted copy of a collecting sink's values, for multiset assertions
+    /// (workers pop concurrently, so arrival order is non-deterministic).
+    fn sorted_received(received: &Arc<Mutex<Vec<u32>>>) -> Vec<u32> {
+        let mut values = received.lock().expect("sink mutex poisoned").clone();
+        values.sort_unstable();
+        values
+    }
+
+    #[test]
+    fn pipeline_run_process2_fans_out_to_two_sinks() {
+        let remaining = Arc::new(AtomicU32::new(20));
+        let evens_received = Arc::new(Mutex::new(Vec::new()));
+        let odds_received = Arc::new(Mutex::new(Vec::new()));
+
+        // Process2 routes even items to branch A, odd items to branch B.
+        let split = process2::<u32, u32, u32, _>("EvenOddSplit", 32, 32, |x: u32| {
+            if x.is_multiple_of(2) {
+                Ok(Process2Output::only_a(x))
+            } else {
+                Ok(Process2Output::only_b(x))
+            }
+        });
+
+        let builder = PipelineBuilder::new();
+        let after_split =
+            builder.chain(SharedCountingSource { remaining: Arc::clone(&remaining) }).chain(split);
+        let multi = after_split.into_multi();
+        multi
+            .b0
+            .chain(ParallelCollectingSink { received: Arc::clone(&evens_received) })
+            .into_sink_marker();
+        multi
+            .b1
+            .chain(ParallelCollectingSink { received: Arc::clone(&odds_received) })
+            .into_sink_marker();
+
+        let pipeline = builder.build().unwrap();
+        let result = pipeline.run(PipelineConfig { threads: 4, ..Default::default() });
+        assert!(result.is_ok(), "run failed: {:?}", result.err());
+
+        // Source emits values [20, 19, ..., 1]. Assert the exact multiset each
+        // branch received, not just the count: evens = {2, 4, ..., 20}, odds =
+        // {1, 3, ..., 19}.
+        let expected_evens: Vec<u32> = (1..=10).map(|k| k * 2).collect();
+        let expected_odds: Vec<u32> = (0..10).map(|k| k * 2 + 1).collect();
+        assert_eq!(sorted_received(&evens_received), expected_evens, "evens values");
+        assert_eq!(sorted_received(&odds_received), expected_odds, "odds values");
+    }
+
+    #[test]
+    fn pipeline_run_process2_drops_branches_emit_none() {
+        let remaining = Arc::new(AtomicU32::new(15));
+        let kept = Arc::new(Mutex::new(Vec::new()));
+        let dropped = Arc::new(Mutex::new(Vec::new()));
+
+        // Keep multiples of 3 on branch A, route the rest to branch B, drop 1.
+        let filter = process2::<u32, u32, u32, _>("FilterStep", 16, 16, |x: u32| {
+            if x == 1 {
+                Ok(Process2Output::none())
+            } else if x.is_multiple_of(3) {
+                Ok(Process2Output::only_a(x))
+            } else {
+                Ok(Process2Output::only_b(x))
+            }
+        });
+
+        let builder = PipelineBuilder::new();
+        let after =
+            builder.chain(SharedCountingSource { remaining: Arc::clone(&remaining) }).chain(filter);
+        let multi = after.into_multi();
+        multi.b0.chain(ParallelCollectingSink { received: Arc::clone(&kept) }).into_sink_marker();
+        multi
+            .b1
+            .chain(ParallelCollectingSink { received: Arc::clone(&dropped) })
+            .into_sink_marker();
+
+        let pipeline = builder.build().unwrap();
+        let result = pipeline.run(PipelineConfig { threads: 4, ..Default::default() });
+        assert!(result.is_ok(), "run failed: {:?}", result.err());
+
+        // [15..1]: multiples of 3 kept = {3, 6, 9, 12, 15}; value 1 dropped; the
+        // other 9 on branch B. Assert the exact multiset per branch, not just
+        // the count, so a misroute that preserves counts can't slip through.
+        assert_eq!(sorted_received(&kept), vec![3, 6, 9, 12, 15], "kept values");
+        assert_eq!(
+            sorted_received(&dropped),
+            vec![2, 4, 5, 7, 8, 10, 11, 13, 14],
+            "other-branch values"
+        );
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct Item {
+        ord: u64,
+        v: u32,
+    }
+    impl HeapSize for Item {
+        fn heap_size(&self) -> usize {
+            std::mem::size_of::<Self>()
+        }
+    }
+    impl Ordered for Item {
+        fn ordinal(&self) -> u64 {
+            self.ord
+        }
+    }
+
+    #[test]
+    fn process_profile_is_parallel_fifo() {
+        let s: Process<u32, u32, _> = process("test", 4, |x: u32| Ok(x + 1));
+        let p = s.profile();
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::None]);
+    }
+
+    #[test]
+    fn process_ordered_profile_is_parallel_byitem() {
+        let s: ProcessOrdered<Item, Item, _> =
+            process_ordered("test", 1024, |x: Item| Ok(Item { ord: x.ord, v: x.v + 1 }));
+        let p = s.profile();
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    #[test]
+    fn process_with_worker_state_clone_resets_state() {
+        let s = process_with_worker_state::<Item, Item, _, u64, _>(
+            "stateful",
+            1024,
+            || 0u64, // init
+            |state, item| {
+                *state += 1;
+                Ok(Item { ord: item.ord, v: u32::try_from(*state).unwrap_or(0) })
+            },
+        );
+        let cloned = s.clone();
+        assert!(s.state.is_none());
+        assert!(cloned.state.is_none());
+    }
+
+    #[test]
+    fn process2_profile_is_parallel_two_unordered_branches() {
+        let s: Process2<u32, u32, String, _> =
+            process2("test2", 4, 4, |x: u32| Ok(Process2Output::both(x + 1, x.to_string())));
+        let p = s.profile();
+        assert_eq!(p.name, "test2");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert!(!p.sticky);
+        assert_eq!(p.output_queues.len(), 2);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::None, BranchOrdering::None]);
+    }
+
+    #[test]
+    fn process2_output_constructors() {
+        let both: Process2Output<u32, &str> = Process2Output::both(1, "a");
+        assert_eq!(both.a, Some(1));
+        assert_eq!(both.b, Some("a"));
+
+        let only_a: Process2Output<u32, &str> = Process2Output::only_a(2);
+        assert_eq!(only_a.a, Some(2));
+        assert_eq!(only_a.b, None);
+
+        let only_b: Process2Output<u32, &str> = Process2Output::only_b("b");
+        assert_eq!(only_b.a, None);
+        assert_eq!(only_b.b, Some("b"));
+
+        let none: Process2Output<u32, &str> = Process2Output::none();
+        assert_eq!(none.a, None);
+        assert_eq!(none.b, None);
+    }
+
+    #[test]
+    fn process2_with_worker_state_clone_resets_state() {
+        #[derive(Default)]
+        struct WS {
+            counter: u32,
+        }
+        impl HeapSize for WS {
+            fn heap_size(&self) -> usize {
+                0
+            }
+        }
+
+        let step = process2_with_worker_state::<Item, Item, Item, WS, _, _>(
+            "stateful2",
+            1024,
+            1024,
+            WS::default,
+            |state, item| {
+                state.counter += 1;
+                Ok(Process2Output::both(
+                    Item { ord: item.ord, v: state.counter },
+                    Item { ord: item.ord, v: state.counter },
+                ))
+            },
+        );
+        let cloned = step.clone();
+        assert!(step.state.is_none());
+        assert!(cloned.state.is_none());
+    }
+
+    #[test]
+    fn process2_with_worker_state_profile_is_parallel_byitem_two_branches() {
+        #[derive(Default)]
+        struct WS;
+        impl HeapSize for WS {
+            fn heap_size(&self) -> usize {
+                0
+            }
+        }
+
+        let step = process2_with_worker_state::<Item, Item, Item, WS, _, _>(
+            "stateful2-profile",
+            512,
+            1024,
+            WS::default,
+            |_state, item| Ok(Process2Output::both(item, Item { ord: 0, v: 0 })),
+        );
+        let profile = step.profile();
+        assert_eq!(profile.kind, StepKind::Parallel);
+        assert_eq!(profile.output_queues.len(), 2);
+        assert_eq!(
+            profile.output_queues,
+            vec![
+                QueueSpec::ByteBounded { limit_bytes: 512 },
+                QueueSpec::ByteBounded { limit_bytes: 1024 },
+            ]
+        );
+        assert_eq!(
+            profile.branch_ordering,
+            vec![BranchOrdering::ByItemOrdinal, BranchOrdering::ByItemOrdinal]
+        );
+    }
+
+    #[test]
+    fn process3_with_worker_state_clone_resets_state() {
+        #[derive(Default)]
+        struct WS {
+            counter: u32,
+        }
+        impl HeapSize for WS {
+            fn heap_size(&self) -> usize {
+                0
+            }
+        }
+
+        let step = process3_with_worker_state::<Item, Item, Item, Item, WS, _, _>(
+            "stateful3",
+            1024,
+            1024,
+            1024,
+            WS::default,
+            |state, item| {
+                state.counter += 1;
+                Ok(Process3Output::both3(
+                    Item { ord: item.ord, v: state.counter },
+                    Item { ord: item.ord, v: state.counter },
+                    Item { ord: item.ord, v: state.counter },
+                ))
+            },
+        );
+        let cloned = step.clone();
+        assert!(step.state.is_none());
+        assert!(cloned.state.is_none());
+    }
+
+    #[test]
+    fn process3_with_worker_state_profile_is_parallel_byitem_three_branches() {
+        #[derive(Default)]
+        struct WS;
+        impl HeapSize for WS {
+            fn heap_size(&self) -> usize {
+                0
+            }
+        }
+
+        let step = process3_with_worker_state::<Item, Item, Item, Item, WS, _, _>(
+            "stateful3-profile",
+            256,
+            512,
+            1024,
+            WS::default,
+            |_state, item| {
+                Ok(Process3Output::both3(item, Item { ord: 0, v: 0 }, Item { ord: 0, v: 0 }))
+            },
+        );
+        let profile = step.profile();
+        assert_eq!(profile.kind, StepKind::Parallel);
+        assert_eq!(profile.output_queues.len(), 3);
+        assert_eq!(
+            profile.output_queues,
+            vec![
+                QueueSpec::ByteBounded { limit_bytes: 256 },
+                QueueSpec::ByteBounded { limit_bytes: 512 },
+                QueueSpec::ByteBounded { limit_bytes: 1024 },
+            ]
+        );
+        assert_eq!(
+            profile.branch_ordering,
+            vec![
+                BranchOrdering::ByItemOrdinal,
+                BranchOrdering::ByItemOrdinal,
+                BranchOrdering::ByItemOrdinal,
+            ]
+        );
+    }
+
+    #[test]
+    fn mi_assign_profile_is_serial() {
+        let s: MiAssign<Item, Item, _> = mi_assign("mi", 1024, |next_mi, item: Item| {
+            let mi = *next_mi;
+            *next_mi += 1;
+            Ok(Item { ord: item.ord, v: u32::try_from(mi).unwrap_or(0) })
+        });
+        let p = s.profile();
+        assert_eq!(p.kind, StepKind::Serial);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+}

--- a/src/lib/pipeline/steps/serialize.rs
+++ b/src/lib/pipeline/steps/serialize.rs
@@ -1,0 +1,263 @@
+//! `SerializeBamRecords`: `Parallel + ByItemOrdinal` step that frames
+//! `RawRecord`s as on-disk BAM record framing (4-byte little-endian
+//! `block_size` prefix + record body) into a single
+//! `DecompressedBlock`, ready for `BgzfCompress`. Input is
+//! `BamTemplateBatch` (templates of records). Inverse of
+//! `ParseBamRecords + GroupBam`. Used by the group/consensus chains.
+//!
+//! Output `batch_serial` mirrors the input's.
+
+use std::io;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::{BamTemplateBatch, DecompressedBlock};
+
+/// Per-worker serialization scratch capacity. Sized to the typical
+/// 500-template batch (~ 256 B/record × ~2 records/template + framing).
+/// Mirrors legacy `bam.rs:1561` `SERIALIZATION_BUFFER_CAPACITY` (64 KiB)
+/// scaled up to match the new framework's larger batch sizes.
+const SERIALIZE_SCRATCH_CAPACITY: usize = 1024 * 1024;
+
+/// Append one BAM-framed record (4-byte little-endian `block_size` + body)
+/// into `scratch`. This is the canonical on-disk BAM record framing used by
+/// the output path; the terminal standalone-sort path inlines the identical
+/// layout in `SortMerge`'s `BlockBuilder` (`fgumi-pipeline-io`), which must
+/// stay byte-for-byte in sync with this helper.
+///
+/// # Errors
+///
+/// Returns `io::ErrorKind::InvalidData` if `body.len()` exceeds `u32::MAX` —
+/// unreachable in practice (BAM body size is u32-bounded and
+/// `tuning.per_step_byte_limit` is 4 MiB by default).
+fn frame_record_into(scratch: &mut Vec<u8>, body: &[u8]) -> io::Result<()> {
+    let block_size = u32::try_from(body.len()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("record exceeds u32 BAM block_size: {}", body.len()),
+        )
+    })?;
+    scratch.extend_from_slice(&block_size.to_le_bytes());
+    scratch.extend_from_slice(body);
+    Ok(())
+}
+
+/// `Parallel + ByItemOrdinal` serializer. Templates → record-aligned bytes.
+pub struct SerializeBamRecords {
+    held: HeldSlot<Unpushed<DecompressedBlock>>,
+    output_byte_limit: u64,
+    /// Per-worker output scratch — see `BgzfDecompress::output_scratch`
+    /// for the `mem::replace` + fixed-size-class rationale.
+    output_scratch: Vec<u8>,
+}
+
+impl SerializeBamRecords {
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self {
+            held: HeldSlot::new(),
+            output_byte_limit,
+            output_scratch: Vec::with_capacity(SERIALIZE_SCRATCH_CAPACITY),
+        }
+    }
+}
+
+impl Clone for SerializeBamRecords {
+    fn clone(&self) -> Self {
+        Self {
+            held: HeldSlot::new(),
+            output_byte_limit: self.output_byte_limit,
+            output_scratch: Vec::with_capacity(SERIALIZE_SCRATCH_CAPACITY),
+        }
+    }
+}
+
+impl Step for SerializeBamRecords {
+    type Input = BamTemplateBatch;
+    type Outputs = OrderedBytesSingle<DecompressedBlock>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "SerializeBamRecords",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(batch) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+
+        // Serialize into the per-worker scratch buffer; `mem::replace` it
+        // out at the end. Same-size-class recycling via mimalloc's
+        // thread-local cache is the goal — see `BgzfDecompress` for the
+        // rationale. Per-record framing shared with `SerializeRecordBatch`
+        // via [`frame_record_into`].
+        for template in batch.templates() {
+            for record in &template.records {
+                frame_record_into(&mut self.output_scratch, record.as_ref())?;
+            }
+        }
+        let bytes = std::mem::replace(
+            &mut self.output_scratch,
+            Vec::with_capacity(SERIALIZE_SCRATCH_CAPACITY),
+        );
+
+        let out = DecompressedBlock { batch_serial: batch.batch_serial(), bytes };
+        match ctx.outputs.push(out) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::steps::parse::bam::parse_records;
+    use crate::template::Template;
+    use fgumi_raw_bam::RawRecord;
+    use rstest::rstest;
+
+    #[test]
+    fn profile_advertises_parallel_byordinal() {
+        let s = SerializeBamRecords::new(1024);
+        let p = s.profile();
+        assert_eq!(p.name, "SerializeBamRecords");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    /// Cross-crate parity: `frame_record_into` (this `Serialize` step) and
+    /// `fgumi-pipeline-io`'s `BlockBuilder` (the standalone-sort terminal path)
+    /// are separate, independently-maintained encoders of the same on-disk
+    /// `[u32 LE block_size][body]` BAM record framing. They MUST stay
+    /// byte-for-byte in sync; the cases below pin that so a future edit to either
+    /// can't silently diverge (the failure mode a written comment alone can't
+    /// catch). This helper asserts the parity for one `body`.
+    fn assert_framing_parity(body: &[u8]) {
+        use fgumi_pipeline_io::sort::merge::{BlockBuilder, MergeBatchBuilder};
+
+        let mut via_serialize = Vec::new();
+        frame_record_into(&mut via_serialize, body).expect("frame_record_into");
+
+        let mut builder = BlockBuilder::with_capacity(0, body.len() + 4, 1);
+        builder.push_record_bytes(body).expect("push_record_bytes");
+        let via_block_builder = builder.build().bytes;
+
+        assert_eq!(
+            via_serialize,
+            via_block_builder,
+            "framing diverged for a {}-byte body",
+            body.len()
+        );
+    }
+
+    #[rstest]
+    #[case::empty(&[])]
+    #[case::one_byte(b"x")]
+    #[case::short(b"a slightly longer record body")]
+    #[case::two_sixty(&[0u8; 260])]
+    fn framing_matches_pipeline_io_block_builder(#[case] body: &[u8]) {
+        assert_framing_parity(body);
+    }
+
+    /// Same parity check for a large (5000-byte) body — kept separate from the
+    /// `#[rstest]` cases above since a literal that size is awkward as a `#[case]`.
+    #[test]
+    fn framing_matches_pipeline_io_block_builder_large_body() {
+        assert_framing_parity(&vec![0xABu8; 5000]);
+    }
+
+    /// Build a minimal `RawRecord` whose bytes match what `parse_records`
+    /// would emit (a body of `len` arbitrary bytes; serialization
+    /// prepends the 4-byte `block_size`).
+    fn raw_of_len(len: usize, fill: u8) -> RawRecord {
+        vec![fill; len].into()
+    }
+
+    #[test]
+    fn serialize_then_parse_roundtrip() {
+        // Two templates, one record each. After serializing we expect
+        // [block_size=8, 8 bytes][block_size=12, 12 bytes].
+        let r1 = raw_of_len(8, 0xAA);
+        let r2 = raw_of_len(12, 0xBB);
+        let mut t1 = Template::new(b"q1".to_vec());
+        t1.records.push(r1.clone());
+        let mut t2 = Template::new(b"q2".to_vec());
+        t2.records.push(r2.clone());
+        let input = BamTemplateBatch::new(7, vec![t1, t2]);
+
+        // Drive the serializer manually (mirrors the closure path; the
+        // step trait integration is exercised by `tests.rs` via `run`).
+        let record_count: usize = input.templates().iter().map(|t| t.records.len()).sum();
+        let mut bytes = Vec::with_capacity(input.total_bytes() + 4 * record_count);
+        for template in input.templates() {
+            for record in &template.records {
+                // Frame through the production encoder rather than re-deriving
+                // the layout here: a local copy would keep this test green
+                // through a regression in `frame_record_into`, leaving it a
+                // round-trip against itself. The exact byte layout is pinned
+                // separately by `frame_record_into_writes_le_prefix_then_body`.
+                frame_record_into(&mut bytes, record.as_ref()).expect("frame_record_into");
+            }
+        }
+        let parsed = parse_records(&bytes).expect("parse");
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].as_ref(), r1.as_ref());
+        assert_eq!(parsed[1].as_ref(), r2.as_ref());
+    }
+
+    /// `frame_record_into` writes `[u32 LE block_size][body]` and is the
+    /// canonical layout the terminal-sort `BlockBuilder` must reproduce
+    /// byte-for-byte; verify the exact prefix + body layout here.
+    #[test]
+    fn frame_record_into_writes_le_prefix_then_body() {
+        let mut scratch = Vec::new();
+        frame_record_into(&mut scratch, &[0xAA; 8]).unwrap();
+        frame_record_into(&mut scratch, &[0xBB; 12]).unwrap();
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&8u32.to_le_bytes());
+        expected.extend_from_slice(&[0xAA; 8]);
+        expected.extend_from_slice(&12u32.to_le_bytes());
+        expected.extend_from_slice(&[0xBB; 12]);
+        assert_eq!(scratch, expected);
+        // Round-trips through the BAM record parser.
+        let parsed = parse_records(&scratch).expect("parse");
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].as_ref(), &[0xAA; 8]);
+        assert_eq!(parsed[1].as_ref(), &[0xBB; 12]);
+    }
+}

--- a/src/lib/pipeline/steps/serialize_processed.rs
+++ b/src/lib/pipeline/steps/serialize_processed.rs
@@ -1,0 +1,196 @@
+//! `build_serialize_processed_groups_step`: shared builder for the
+//! `BatchedProcessedPositionGroups → DecompressedBlock` serialize step.
+//!
+//! Standalone `fgumi group` and the runall `--stop-after group` fused
+//! chain (`execute_group_pipeline` in `commands::runall`) both end on
+//! the same shape: take an MI-id-assigned batch of position groups,
+//! rewrite the MI tag bytes into each record's body, frame each body
+//! with the BAM `block_size` prefix, and concatenate into a single
+//! `DecompressedBlock` ready for `BgzfCompress`.
+//!
+//! Doing MI-tag-injection + framing in ONE closure pass (rather than
+//! the three-step `BatchedProcessedPositionGroups → BatchedMiGroups →
+//! RecordBatch → DecompressedBlock` consensus-tap detour) eliminates
+//! two cross-step queue handoffs and two intermediate batch allocations
+//! per BAM block. Measured ~11–15 % wall-time recovery on `--stop-after
+//! group` benchmarks vs. the consensus-tap detour the runall path was
+//! using before this builder existed.
+//!
+//! `emit_templates_raw_with_mi` lives in this module because both this
+//! step AND the standalone single-threaded writer in `commands::group`
+//! call it — keeping it pub(crate) at the step-library layer means
+//! both callers can't drift in MI-injection semantics.
+
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use log::info;
+
+use crate::pipeline::steps::group::position::BatchedProcessedPositionGroups;
+use crate::pipeline::steps::process::{ProcessWithWorkerState, process_with_worker_state};
+use crate::pipeline::steps::types::DecompressedBlock;
+use crate::template::Template;
+
+/// Per-worker scratch state for the serialize step. `scratch` is the
+/// record-aligned tag-update buffer; `mi_buf` is the formatted MI
+/// string. Both are reused across batches for the same reason the
+/// legacy `try_step_serialize` reused
+/// `worker.core.{serialization_buffer, secondary_serialization_buffer}`.
+///
+/// Must be `pub` because [`build_serialize_processed_groups_step`]'s
+/// return type names it via `ProcessWithWorkerState<…, SerializeState, …>` —
+/// callers that bind the returned step to a `let` can't see a private
+/// type in the public signature.
+pub struct SerializeState {
+    scratch: Vec<u8>,
+    mi_buf: String,
+}
+
+impl crate::pipeline::core::item::HeapSize for SerializeState {}
+
+/// Construct the `SerializeGroups` step: consumes
+/// [`BatchedProcessedPositionGroups`], emits [`DecompressedBlock`].
+///
+/// The per-batch closure:
+///   * walks every `ProcessedPositionGroup.templates`,
+///   * calls `emit_templates_raw_with_mi` which writes the MI tag
+///     bytes into the per-record `scratch` and appends framed bytes
+///     into the batch's output `Vec<u8>`,
+///   * updates `progress_counter` with the input record count and
+///     logs a "Processed N records" line every million records.
+///
+/// The output `Vec<u8>` is sized at `total_records * 800` so a typical
+/// BAM record (~256 B body + ~4 B framing + tag-update headroom) hits
+/// zero `realloc`s mid-batch. Smaller starts (e.g. 64 KiB + grow)
+/// landed in the medium → large mimalloc size class boundary and
+/// regressed on CODEC 8M benches.
+///
+/// `assign_tag_bytes` is the 2-byte tag the MI string is written under
+/// (`MI` by default; user-overridable via `--assign-tag`).
+///
+/// `progress_counter` is shared across all worker copies — bump
+/// atomically with the batch's input record count.
+pub fn build_serialize_processed_groups_step(
+    per_step_byte_limit: u64,
+    assign_tag_bytes: [u8; 2],
+    progress_counter: Arc<AtomicU64>,
+) -> ProcessWithWorkerState<
+    BatchedProcessedPositionGroups,
+    DecompressedBlock,
+    impl Fn(&mut SerializeState, BatchedProcessedPositionGroups) -> io::Result<DecompressedBlock>
+    + Send
+    + Sync
+    + 'static,
+    SerializeState,
+    impl Fn() -> SerializeState + Send + Sync + 'static,
+> {
+    process_with_worker_state::<
+        BatchedProcessedPositionGroups,
+        DecompressedBlock,
+        _,
+        SerializeState,
+        _,
+    >(
+        "SerializeGroups",
+        per_step_byte_limit,
+        || SerializeState { scratch: Vec::with_capacity(512), mi_buf: String::with_capacity(16) },
+        move |state: &mut SerializeState,
+              item: BatchedProcessedPositionGroups|
+              -> io::Result<DecompressedBlock> {
+            let BatchedProcessedPositionGroups { batch_serial, groups } = item;
+            // Size by record count, not template count: a paired-end template
+            // holds ~2 records, so `templates.len()` under-sized the buffer ~2×
+            // and forced reallocs. `input_record_count` is the per-group record
+            // tally; summed once here for both the capacity hint and the
+            // progress counter below.
+            let total_input_records: u64 =
+                groups.iter().fold(0u64, |acc, g| acc.saturating_add(g.input_record_count));
+            // The `saturating_mul`/`unwrap_or(usize::MAX)` is purely overflow-
+            // defensive and unreachable for realistic record counts (a count
+            // approaching `usize::MAX / 800` is impossible for any BAM). It is a
+            // theoretical guard only: if it ever did saturate to `usize::MAX`,
+            // the `with_capacity(usize::MAX)` would itself abort — so the guard
+            // protects against the multiply wrapping, not against a real
+            // allocation of that size.
+            let mut output = Vec::with_capacity(
+                usize::try_from(total_input_records.saturating_mul(800)).unwrap_or(usize::MAX),
+            );
+            for processed in &groups {
+                emit_templates_raw_with_mi(
+                    &processed.templates,
+                    0, // already mi_assign'd upstream — base offset is 0
+                    assign_tag_bytes,
+                    &mut state.scratch,
+                    &mut state.mi_buf,
+                    |bytes| {
+                        output.extend_from_slice(bytes);
+                        Ok(())
+                    },
+                )?;
+            }
+
+            let prev = progress_counter.fetch_add(total_input_records, Ordering::Relaxed);
+            if (prev + total_input_records) / 1_000_000 > prev / 1_000_000 {
+                info!("Processed {} records", prev + total_input_records);
+            }
+
+            Ok(DecompressedBlock { batch_serial, bytes: output })
+        },
+    )
+}
+
+/// Emit raw-byte primary reads for a batch of templates with MI tags injected.
+///
+/// For each template, if `has_mi` then the raw bytes are copied into `scratch`,
+/// the MI tag is updated in place, and the result is emitted via `emit`; otherwise
+/// the raw bytes are emitted unchanged. Each emitted record is prefixed with a
+/// 4-byte little-endian `block_size`. `mi_buf` and `scratch` are reused across
+/// templates to amortize allocations.
+///
+/// Shared by the threaded-pipeline `SerializeGroups` step (this module's
+/// [`build_serialize_processed_groups_step`]) and the single-threaded writer
+/// in [`crate::commands::group`] so they can't drift in MI-injection
+/// semantics.
+pub(crate) fn emit_templates_raw_with_mi(
+    templates: &[Template],
+    base_mi: u64,
+    assign_tag_bytes: [u8; 2],
+    scratch: &mut Vec<u8>,
+    mi_buf: &mut String,
+    mut emit: impl FnMut(&[u8]) -> io::Result<()>,
+) -> io::Result<()> {
+    for template in templates {
+        let mi = template.mi;
+        let has_mi = mi.is_assigned();
+        if has_mi {
+            // write_with_offset clears the buffer before writing.
+            mi.write_with_offset(base_mi, mi_buf);
+        }
+        for raw in [template.r1(), template.r2()].into_iter().flatten() {
+            if has_mi {
+                scratch.clear();
+                scratch.extend_from_slice(raw);
+                fgumi_raw_bam::update_string_tag(scratch, assign_tag_bytes, mi_buf.as_bytes());
+                let block_size = u32::try_from(scratch.len()).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("BAM record too large ({} bytes)", scratch.len()),
+                    )
+                })?;
+                emit(&block_size.to_le_bytes())?;
+                emit(scratch)?;
+            } else {
+                let block_size = u32::try_from(raw.len()).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("BAM record too large ({} bytes)", raw.len()),
+                    )
+                })?;
+                emit(&block_size.to_le_bytes())?;
+                emit(raw)?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/lib/pipeline/steps/templates_to_records.rs
+++ b/src/lib/pipeline/steps/templates_to_records.rs
@@ -1,0 +1,196 @@
+//! `TemplatesToRecordBatch` adapter step.
+//!
+//! Bridges the queryname-template view (`BamTemplateBatch`,
+//! emitted by `AlignAndMergeStep` and `ZipperMergeStep`) to the
+//! flat-record view (`RecordBatch`, consumed by the sort ingest
+//! (`SortBuffer`), `DecodeRecords`, etc.). Flattens each `Template`'s records into
+//! a single `RecordBatch` carrying the input batch's serial
+//! ordinal, so `BranchOrdering::ByItemOrdinal` consumers downstream
+//! see a monotonic sequence.
+//!
+//! `Parallel + ByItemOrdinal` — the conversion is per-batch
+//! stateless, so the framework can clone this step across workers.
+//! Used to fuse AAM-fed runall pipelines (eliminating the
+//! tempfile bridge between AAM and the downstream sort).
+
+use std::io;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::{BamTemplateBatch, RecordBatch, RecordBatchBuilder};
+
+/// `Parallel + ByItemOrdinal` adapter step.
+///
+/// Each `try_run` pops one [`BamTemplateBatch`], appends every
+/// record from every contained template into a
+/// [`RecordBatchBuilder`], and emits the resulting [`RecordBatch`]
+/// downstream. Backpressure is handled via a [`HeldSlot`]
+/// preserving the input batch's serial ordinal.
+pub struct TemplatesToRecordBatch {
+    held: HeldSlot<Unpushed<RecordBatch>>,
+    output_byte_limit: u64,
+}
+
+impl TemplatesToRecordBatch {
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self { held: HeldSlot::new(), output_byte_limit }
+    }
+}
+
+impl Clone for TemplatesToRecordBatch {
+    fn clone(&self) -> Self {
+        Self { held: HeldSlot::new(), output_byte_limit: self.output_byte_limit }
+    }
+}
+
+impl Step for TemplatesToRecordBatch {
+    type Input = BamTemplateBatch;
+    type Outputs = OrderedBytesSingle<RecordBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "TemplatesToRecordBatch",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    // `Contention` (not `NoProgress`) — see
+                    // `BgzfDecompress` for the rationale. Returning
+                    // `NoProgress` from a Parallel step on a held
+                    // slot risks the framework marking this worker
+                    // `Skip` if the upstream input is also drained,
+                    // silently dropping the held item.
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(batch) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+
+        let serial = batch.batch_serial();
+        // Pre-size the backing buffer from the exact sum of record
+        // body bytes. `batch.total_bytes()` over-estimates because
+        // `Template::heap_size` includes the queryname bytes, but
+        // those don't appear in the `RecordBatch.backing` (only the
+        // body bytes do). Computing the tight number once is cheap
+        // and keeps the builder's allocation in a single mimalloc
+        // size class.
+        let bytes_cap: usize = batch
+            .templates()
+            .iter()
+            .flat_map(|t| t.records.iter().map(fgumi_raw_bam::RawRecord::len))
+            .sum();
+        let records_cap: usize = batch.templates().iter().map(|t| t.records.len()).sum();
+        let mut builder = RecordBatchBuilder::with_capacity(serial, bytes_cap, records_cap);
+        let (_, templates) = batch.into_parts();
+        for template in templates {
+            for record in template.records {
+                builder.push_record_bytes(record.as_ref());
+            }
+        }
+        let rb = builder.build();
+
+        match ctx.outputs.push(rb) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::template::Template;
+    use fgumi_raw_bam::SamBuilder;
+
+    fn make_record(qname: &[u8], flags: u16) -> fgumi_raw_bam::RawRecord {
+        let mut b = SamBuilder::new();
+        b.read_name(qname).flags(flags).sequence(b"ACGT").qualities(b"IIII");
+        b.build()
+    }
+
+    /// Build a paired-end template: one R1 primary + one R2 primary
+    /// (the minimum that satisfies `Template::from_records`).
+    fn make_paired_template(qname: &[u8]) -> Template {
+        use fgumi_raw_bam::flags::{FIRST_SEGMENT, LAST_SEGMENT, PAIRED};
+        let r1 = make_record(qname, PAIRED | FIRST_SEGMENT);
+        let r2 = make_record(qname, PAIRED | LAST_SEGMENT);
+        Template::from_records(vec![r1, r2]).expect("paired template")
+    }
+
+    #[test]
+    fn profile_advertises_parallel_byordinal() {
+        let s = TemplatesToRecordBatch::new(1024);
+        let p = s.profile();
+        assert_eq!(p.name, "TemplatesToRecordBatch");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    #[test]
+    fn clone_resets_held_slot() {
+        let mut s = TemplatesToRecordBatch::new(1024);
+        // We can't easily put a real Unpushed into held without a
+        // live framework, so just assert the clone has a fresh slot
+        // (no panic in HeldSlot::new(), which would fire if we
+        // accidentally cloned a held item).
+        let _ = s.held.take(); // empty
+        let cloned = s.clone();
+        assert!(!cloned.held.is_held());
+    }
+
+    /// Verify the flattening logic: 2 paired templates → 4 records,
+    /// preserving the input batch's serial ordinal.
+    #[test]
+    fn flatten_preserves_record_count_and_serial() {
+        let batch = BamTemplateBatch::new(
+            42,
+            vec![make_paired_template(b"q1"), make_paired_template(b"q2")],
+        );
+        let total_bytes = batch.total_bytes();
+        let serial = batch.batch_serial();
+        let records_cap: usize = batch.templates().iter().map(|t| t.records.len()).sum();
+        let mut builder = RecordBatchBuilder::with_capacity(serial, total_bytes, records_cap);
+        let (_, templates) = batch.into_parts();
+        for template in templates {
+            for record in template.records {
+                builder.push_record_bytes(record.as_ref());
+            }
+        }
+        let rb = builder.build();
+        assert_eq!(rb.batch_serial(), 42);
+        assert_eq!(rb.len(), 4, "4 records flattened from 2 paired templates");
+    }
+}

--- a/src/lib/pipeline/steps/tests.rs
+++ b/src/lib/pipeline/steps/tests.rs
@@ -1,0 +1,338 @@
+//! Phase 3 cross-step integration tests. The block-level chain:
+//!
+//! ```text
+//! ReadBgzfBlocks → BgzfDecompress → FindBamBoundaries → DecodeRecords
+//!     → GroupBam → SerializeBamRecords → BgzfCompress → WriteBgzfFile
+//! ```
+//!
+//! Drives the chain via `Pipeline::run` against a synthetic BAM, then
+//! reads back the output to verify record-count invariance and
+//! ordering. Threads-{1, 4} variants exercise the framework's drain
+//! protocol under both `Serial`-only and `Parallel` + `Serial` mixes.
+
+use crate::pipeline::core::builder::{Pipeline, PipelineConfig};
+use crate::pipeline::steps::bgzf::compress::BgzfCompress;
+use crate::pipeline::steps::bgzf::decompress::BgzfDecompress;
+use crate::pipeline::steps::boundaries::bam::FindBamBoundaries;
+use crate::pipeline::steps::group::bam::GroupBam;
+use crate::pipeline::steps::parse::decode::DecodeRecords;
+use crate::pipeline::steps::serialize::SerializeBamRecords;
+use crate::pipeline::steps::sink::write_bgzf::WriteBgzfFile;
+use crate::pipeline::steps::source::read_bam::{DEFAULT_BLOCKS_PER_BATCH, read_bam};
+use fgumi_bam_io::GroupKeyConfig;
+
+/// Build an in-memory BAM file with `n_records` synthetic records using
+/// fgumi-bam-io's writer. Returns the path (a `tempfile::TempPath`) so
+/// the file is cleaned up when dropped.
+fn build_test_bam(n_records: usize) -> tempfile::TempPath {
+    use fgumi_raw_bam::testutil::make_bam_bytes;
+    use noodles::sam::Header;
+
+    let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    let header = Header::default();
+    let mut writer = fgumi_bam_io::create_raw_bam_writer(&path, &header, 1, 1).unwrap();
+    for i in 0..n_records {
+        let name_str = format!("read_{i}");
+        let record_bytes = make_bam_bytes(
+            -1,  // tid (unmapped)
+            -1,  // pos
+            0x4, // flag (unmapped)
+            name_str.as_bytes(),
+            &[], // cigar_ops
+            0,   // seq_len
+            -1,  // mate_tid
+            -1,  // mate_pos
+            &[], // aux_data
+        );
+        writer.write_raw_record(&record_bytes).unwrap();
+    }
+    writer.finish().unwrap();
+    path
+}
+
+/// Read back a BAM file and return the count of records.
+fn count_records(path: &std::path::Path) -> usize {
+    use fgumi_bam_io::PipelineReaderOpts;
+    use fgumi_raw_bam::RawRecord;
+
+    let (mut reader, _hdr) =
+        fgumi_bam_io::create_raw_bam_reader_with_opts(path, 1, PipelineReaderOpts::default())
+            .unwrap();
+    let mut record = RawRecord::default();
+    let mut n = 0;
+    loop {
+        match reader.read_record(&mut record).unwrap() {
+            0 => break,
+            _ => n += 1,
+        }
+    }
+    n
+}
+
+/// Read every record's bytes into a `Vec<Vec<u8>>` in input order. Used
+/// for byte-level + ordering equivalence checks.
+fn collect_record_bytes(path: &std::path::Path) -> Vec<Vec<u8>> {
+    use fgumi_bam_io::PipelineReaderOpts;
+    use fgumi_raw_bam::RawRecord;
+
+    let (mut reader, _hdr) =
+        fgumi_bam_io::create_raw_bam_reader_with_opts(path, 1, PipelineReaderOpts::default())
+            .unwrap();
+    let mut record = RawRecord::default();
+    let mut all = Vec::new();
+    while reader.read_record(&mut record).unwrap() > 0 {
+        all.push(record.as_ref().to_vec());
+    }
+    all
+}
+
+/// Assert input and output have byte-identical records in input order.
+/// Catches reorderings, dropped records, and per-record mutations that a
+/// pure count check would miss.
+fn assert_records_round_trip_in_order(input: &std::path::Path, output: &std::path::Path) {
+    let in_recs = collect_record_bytes(input);
+    let out_recs = collect_record_bytes(output);
+    assert_eq!(
+        in_recs.len(),
+        out_recs.len(),
+        "record count mismatch: input={}, output={}",
+        in_recs.len(),
+        out_recs.len()
+    );
+    for (i, (a, b)) in in_recs.iter().zip(out_recs.iter()).enumerate() {
+        assert_eq!(a, b, "record {i}: input bytes != output bytes");
+    }
+}
+
+/// Wire the full block-level chain and return the built pipeline.
+///
+/// Shared by [`run_full_chain`] and the DAG-rendering test so there is exactly
+/// one description of the chain. Kept separate from running it because the two
+/// callers want different things from the same pipeline — one runs it, the other
+/// only renders `dag()` — and a second copy of the wiring would let the DAG
+/// assertion list drift from the chain it claims to describe.
+fn build_full_chain(input: &std::path::Path, output: &std::path::Path) -> Pipeline {
+    let opts = fgumi_bam_io::PipelineReaderOpts::default();
+    let (read_step, header) =
+        read_bam(input, opts, DEFAULT_BLOCKS_PER_BATCH, 4 * 1024 * 1024).unwrap();
+    let bytes_4mb: u64 = 4 * 1024 * 1024;
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(read_step)
+        .chain(BgzfDecompress::new(bytes_4mb))
+        .chain(FindBamBoundaries::new(bytes_4mb))
+        // DecodeRecords now does parse + group-key extraction in one pass
+        // (matches legacy bam.rs Decode step); the previous Parse → Decode
+        // split was unused outside tests.
+        .chain(DecodeRecords::new(GroupKeyConfig::default(), bytes_4mb))
+        .chain(GroupBam::new(64, bytes_4mb))
+        .chain(SerializeBamRecords::new(bytes_4mb))
+        .chain(BgzfCompress::new(1, bytes_4mb))
+        .chain(WriteBgzfFile::new(output, &header, 1).unwrap())
+        .into_sink_marker();
+    builder.build().unwrap()
+}
+
+/// Wire the full block-level chain end-to-end and run it.
+fn run_full_chain(input: &std::path::Path, output: &std::path::Path, threads: usize) {
+    build_full_chain(input, output).run(PipelineConfig { threads, ..Default::default() }).unwrap();
+}
+
+#[test]
+fn full_chain_threads_1() {
+    // The comment on `full_chain_threads_2` claims the chain works at
+    // `threads >= 1`, but every case in this file ran with 2 or 4 — so the
+    // claim was untested. One worker is the interesting case: the
+    // `Affinity::Reader` source and `Affinity::Writer` sink land on the *same*
+    // worker, so a drain or termination path that only makes progress when
+    // another worker can run the other end would deadlock here and nowhere
+    // else. Asserts the full ordered round-trip, not just completion.
+    let input = build_test_bam(50);
+    let output = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    run_full_chain(&input, &output, 1);
+    assert_records_round_trip_in_order(&input, &output);
+}
+
+#[test]
+fn full_chain_threads_2() {
+    // Source/sink are Serial+Affinity (Reader/Writer): worker 0 reads,
+    // worker 1 writes, all workers can do interior Parallel/Serial steps.
+    // The chain works at threads >= 1; this test exercises a small case.
+    let input = build_test_bam(50);
+    let output = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    run_full_chain(&input, &output, 2);
+    let bytes = std::fs::read(&output).unwrap();
+    assert!(bytes.len() >= 28, "output BAM must contain at least the BGZF EOF: {}", bytes.len());
+    assert_eq!(&bytes[0..2], &[0x1f, 0x8b], "BGZF/gzip magic");
+    assert_records_round_trip_in_order(&input, &output);
+}
+
+#[test]
+fn full_chain_threads_4() {
+    // Source/sink are Serial+Affinity (Reader on T0, Writer on TN-1);
+    // Boundaries/Group are Serial (any worker eligible). Decode/parse/
+    // serialize/compress are Parallel. With threads=4 every worker
+    // rotates through whatever has work.
+    let input = build_test_bam(200);
+    let output = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    run_full_chain(&input, &output, 4);
+    let bytes = std::fs::read(&output).unwrap();
+    assert!(bytes.len() >= 28);
+    assert_eq!(&bytes[0..2], &[0x1f, 0x8b]);
+    assert_records_round_trip_in_order(&input, &output);
+}
+
+#[test]
+fn full_chain_many_records_spans_many_bgzf_blocks() {
+    // 50_000 unmapped records → tens of BGZF blocks. Exercises the
+    // boundary state's cross-block carryover and the reorder stages
+    // under realistic block counts.
+    let input = build_test_bam(50_000);
+    let output = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    run_full_chain(&input, &output, 4);
+    assert_records_round_trip_in_order(&input, &output);
+}
+
+#[test]
+#[ignore = "big — run with --ignored or in CI"]
+fn full_chain_500k_records() {
+    let input = build_test_bam(500_000);
+    let output = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    run_full_chain(&input, &output, 4);
+    assert_eq!(count_records(&output), 500_000);
+}
+
+/// Build a BAM with mapped paired-end records (more realistic record
+/// sizes — sequence + cigar + tags). 100bp reads, 4bp cigar, RG tag.
+fn build_paired_test_bam(n_pairs: usize) -> tempfile::TempPath {
+    use fgumi_raw_bam::testutil::make_bam_bytes;
+    use noodles::sam::Header;
+
+    let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    let header = Header::default();
+    let mut writer = fgumi_bam_io::create_raw_bam_writer(&path, &header, 1, 1).unwrap();
+    // Flags: PAIRED | UNMAPPED | MATE_UNMAPPED + (FIRST_SEGMENT | LAST_SEGMENT).
+    let r1_flags: u16 = 1 | 4 | 8 | 64;
+    let r2_flags: u16 = 1 | 4 | 8 | 128;
+    for i in 0..n_pairs {
+        let name_str = format!("read_{i:08}");
+        let r1 = make_bam_bytes(-1, -1, r1_flags, name_str.as_bytes(), &[], 100, -1, -1, &[]);
+        writer.write_raw_record(&r1).unwrap();
+        let r2 = make_bam_bytes(-1, -1, r2_flags, name_str.as_bytes(), &[], 100, -1, -1, &[]);
+        writer.write_raw_record(&r2).unwrap();
+    }
+    writer.finish().unwrap();
+    path
+}
+
+#[test]
+fn full_chain_paired_records() {
+    // 10K pairs = 20K records, paired by name (GroupBam should produce
+    // one Template per pair).
+    let input = build_paired_test_bam(10_000);
+    let output = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    run_full_chain(&input, &output, 4);
+    assert_records_round_trip_in_order(&input, &output);
+}
+
+#[test]
+fn full_chain_empty_bam() {
+    // Header-only input; the chain should still produce a valid BAM with
+    // a header + EOF and zero records.
+    let input = build_test_bam(0);
+    let output = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    run_full_chain(&input, &output, 2);
+    let bytes = std::fs::read(&output).unwrap();
+    assert!(bytes.len() >= 28);
+    assert_eq!(count_records(&output), 0);
+}
+
+#[test]
+fn full_chain_with_process_mutates_mq() {
+    // Plan Task 12 Step 4: insert a `Process` mid-step that bumps every
+    // record's MAPQ to a known value, run the chain end-to-end, and
+    // verify the output reflects the change. This is the regression test
+    // for the closure-driven `ProcessOrdered` family + the held-slot /
+    // drain contract under a non-trivial Parallel transform.
+    use crate::pipeline::steps::process::process_ordered;
+    use crate::pipeline::steps::types::DecodedRecordBatch;
+
+    let input = build_test_bam(2_000);
+    let output = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+
+    let opts = fgumi_bam_io::PipelineReaderOpts::default();
+    let (read_step, header) =
+        read_bam(&input, opts, DEFAULT_BLOCKS_PER_BATCH, 4 * 1024 * 1024).unwrap();
+    let bytes_4mb: u64 = 4 * 1024 * 1024;
+
+    let bump_mq = process_ordered::<DecodedRecordBatch, DecodedRecordBatch, _>(
+        "BumpMq",
+        bytes_4mb,
+        |batch: DecodedRecordBatch| {
+            // BAM record body byte 9 is `mapq` (raw layout: refID(4) +
+            // pos(4) + l_read_name(1) + mapq(1) + ...). Mutating mapq
+            // doesn't change the record's identity (qname / library /
+            // cell barcode), so the pre-computed GroupKey stays valid.
+            // Take ownership, edit in place, and rebuild via `new` so the
+            // cached `total_bytes` is recomputed for the edited records.
+            let serial = batch.batch_serial();
+            let mut records = batch.into_records();
+            for record in &mut records {
+                let buf = record.raw_bytes_mut().as_mut_vec();
+                if buf.len() > 9 {
+                    buf[9] = 42;
+                }
+            }
+            Ok(DecodedRecordBatch::new(serial, records))
+        },
+    );
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(read_step)
+        .chain(BgzfDecompress::new(bytes_4mb))
+        .chain(FindBamBoundaries::new(bytes_4mb))
+        .chain(DecodeRecords::new(GroupKeyConfig::default(), bytes_4mb))
+        .chain(bump_mq)
+        .chain(GroupBam::new(64, bytes_4mb))
+        .chain(SerializeBamRecords::new(bytes_4mb))
+        .chain(BgzfCompress::new(1, bytes_4mb))
+        .chain(WriteBgzfFile::new(&output, &header, 1).unwrap())
+        .into_sink_marker();
+    let pipeline = builder.build().unwrap();
+    pipeline.run(PipelineConfig { threads: 4, ..Default::default() }).unwrap();
+
+    // Every output record's mapq byte must be 42.
+    let recs = collect_record_bytes(&output);
+    assert_eq!(recs.len(), 2_000);
+    for (i, r) in recs.iter().enumerate() {
+        assert!(r.len() > 9, "record {i} too short");
+        assert_eq!(r[9], 42, "record {i} mapq not mutated by Process step");
+    }
+}
+
+#[test]
+fn pipeline_dag_renders_for_full_chain() {
+    let input = build_test_bam(0);
+    let output = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+
+    // The same helper `run_full_chain` uses, so the names asserted below cannot
+    // drift from the chain that actually runs.
+    let pipeline = build_full_chain(&input, &output);
+
+    let dag = pipeline.dag();
+    for name in [
+        "ReadBgzfBlocks",
+        "BgzfDecompress",
+        "FindBamBoundaries",
+        "DecodeRecords",
+        "GroupBam",
+        "SerializeBamRecords",
+        "BgzfCompress",
+        "WriteBgzfFile",
+    ] {
+        assert!(dag.contains(name), "DAG missing {name}: {dag}");
+    }
+    assert!(dag.contains("(sink)"), "DAG missing sink marker: {dag}");
+}


### PR DESCRIPTION
Third PR in the stack that ports the typed-step pipeline onto `main-runall`:

```
main-runall
 └─ #736  port the read-side source steps (R1b)
     └─ #741  collapse the duplicated grouping domain types (R0b)
         └─ #### this PR (R1c)
```

Review the parent PRs first; the diff shown here is only correct once they merge in order.

## What this adds

The steps that sit between the read side and the write side:

- `steps/group/` — `GroupBam`, `GroupByPosition`, `GroupByQueryname`, `GroupByMi`
- `steps/process.rs` — `Process`, `ProcessOrdered`, `ProcessWithWorkerState`, and the 2-/3-input variants
- `steps/serialize.rs`, `steps/serialize_processed.rs`, `steps/templates_to_records.rs`
- `steps/tests.rs` — full-chain tests over the newly wired steps

This depends on #741 rather than merely following it: `GroupBam` hands a `DecodedRecord` to a `TemplateGrouper`, which is where the two duplicate definitions of that type stop being interchangeable.

## Scope

Limited to the steps the chain builder actually constructs, which was checked against `chains/builder.rs` rather than assumed. Two upstream files are therefore left out:

- `coalesce.rs` — a `CoalesceBytes` byte-batching step with no caller anywhere, including upstream.
- `roundtrip.rs` — a whole-chain convenience whose only consumer is the `compare bam-roundtrip` command, so it travels with the command rewiring rather than with the steps.

`steps/mod.rs` records both reasons so the omission is not mistaken for an oversight.

## Supporting changes

- `fgumi-raw-bam` gains `find_two_string_tags_in_record`, a single pass that locates two string tags at once, plus its tests. `GroupByMi` needs both `RX` and `MI` per record.
- `mi_group.rs` gains `MiKey`/`MiTransform`. **This fixes a real defect**: the previous shape ran `String::from_utf8_lossy` *before* comparing, so two distinct MI tags that are both invalid UTF-8 collapsed to U+FFFD and grouped together. `MiKey` compares the raw tag bytes and only converts lossily to build the display label.

The nested `if` blocks in the ported files are written as let-chains, which this toolchain's `clippy::collapsible_if` requires; upstream predates it.

## Verification

`ci-fmt`, `ci-lint`, `ci-tag-literals`, `ci-doc` (with `RUSTDOCFLAGS="-D warnings"`), and `publish-crates.sh --check` all pass. `cargo ci-test`: **8470 passed**, up from 8414 on #736.

Still unreachable from any command — the chain builder that constructs these steps arrives later, and it additionally needs the command-options refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: Command output changes: none; new steps remain unreachable from commands. `unsafe`: none; CLAUDE.md allowlist changes: none. Memory, queue, and thread/backpressure policy: changed through byte-limited batching, held-output retries, and worker-state processing.

Fix: Integrate the new steps into the chain builder and command options in a later change.

## Changes

- Added typed grouping, processing, serialization, and template-to-record steps.
- Added raw two-tag BAM lookup support and raw-byte MI comparison.
- Added ordered three-output chain support.
- Added unit, integration, serialization, ordering, backpressure, and full-chain tests.
- Documented intentionally excluded `coalesce.rs` and `roundtrip.rs` steps.

## Validation

- Formatting, linting, tag-literal, documentation, crate-publish, and test checks pass.
- 8,508 tests pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->