### PR TITLE
feat(commands): project per-stage options out of the CLI structs (R1e-a)

### DIFF
--- a/crates/fgumi-umi/src/assigner.rs
+++ b/crates/fgumi-umi/src/assigner.rs
@@ -565,7 +565,7 @@ pub const BOTTOM_STRAND_DUPLEX: &str = "/B";
 ///
 /// Determines how reads are grouped based on their UMI sequences. Each strategy makes
 /// different tradeoffs between speed, error tolerance, and grouping behavior.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum Strategy {
     /// Only reads with identical UMI sequences are grouped together

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -277,6 +277,93 @@ pub struct Codec {
     pub queue_memory: QueueMemoryOptions,
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// CodecOptions — the stage's tuning knobs, projected out of the CLI struct
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Codec-stage tuning, independent of how the values were supplied.
+///
+/// See [`crate::commands::zipper::ZipperOptions`] for why this is a plain
+/// struct rather than a flattened `clap::Args`. Note that the consensus-calling
+/// knobs are held **flat** here even though [`Codec`] nests them behind
+/// `#[command(flatten)]` sub-structs: the chain builder wants one bag per stage,
+/// not a re-run of the CLI's grouping.
+#[derive(Debug, Clone)]
+pub struct CodecOptions {
+    /// Pre-UMI error rate (phred).
+    pub error_rate_pre_umi: u8,
+    /// Post-UMI error rate (phred).
+    pub error_rate_post_umi: u8,
+    /// Minimum input base quality.
+    pub min_input_base_quality: u8,
+    /// Emit per-base consensus tags.
+    pub output_per_base_tags: bool,
+    /// Trim consensus reads.
+    pub trim: bool,
+    /// Minimum consensus base quality.
+    pub min_consensus_base_quality: u8,
+    /// How to resolve a near-tie between the two most likely consensus bases.
+    pub tie_rule: fgumi_consensus::TieRule,
+    /// Minimum reads per consensus.
+    pub min_reads: usize,
+    /// Cap on reads per consensus.
+    pub max_reads: Option<usize>,
+    /// Minimum duplex overlap length.
+    pub min_duplex_length: usize,
+    /// Quality cap for single-strand positions.
+    pub single_strand_qual: Option<u8>,
+    /// Quality cap for outer bases.
+    pub outer_bases_qual: Option<u8>,
+    /// How many bases count as outer.
+    pub outer_bases_length: usize,
+    /// Maximum duplex disagreement rate.
+    pub max_duplex_disagreement_rate: f64,
+    /// Maximum duplex disagreements.
+    pub max_duplex_disagreements: Option<usize>,
+    /// Let fully-unmapped primary templates through the pre-group filter.
+    ///
+    /// Carried as the whole flattened sub-struct, like `io` / `rejects_opts` /
+    /// `read_group`, rather than as a bare `bool`.
+    pub allow_unmapped: AllowUnmappedOptions,
+    /// Input/output paths and reader mode.
+    pub io: BamIoOptions,
+    /// Optional rejects output.
+    pub rejects_opts: RejectsOptions,
+    /// Optional stats output.
+    pub stats_opts: StatsOptions,
+    /// Read-group identity for emitted reads.
+    pub read_group: ReadGroupOptions,
+}
+
+impl Codec {
+    /// Project the parsed CLI flags into [`CodecOptions`].
+    #[must_use]
+    pub fn to_codec_options(&self) -> CodecOptions {
+        CodecOptions {
+            error_rate_pre_umi: self.consensus.error_rate_pre_umi,
+            error_rate_post_umi: self.consensus.error_rate_post_umi,
+            min_input_base_quality: self.consensus.min_input_base_quality,
+            output_per_base_tags: self.consensus.output_per_base_tags,
+            trim: self.consensus.trim,
+            min_consensus_base_quality: self.consensus.min_consensus_base_quality,
+            tie_rule: self.consensus.tie_rule.into(),
+            min_reads: self.min_reads,
+            max_reads: self.max_reads,
+            min_duplex_length: self.min_duplex_length,
+            single_strand_qual: self.single_strand_qual,
+            outer_bases_qual: self.outer_bases_qual,
+            outer_bases_length: self.outer_bases_length,
+            max_duplex_disagreement_rate: self.max_duplex_disagreement_rate,
+            max_duplex_disagreements: self.max_duplex_disagreements,
+            allow_unmapped: self.allow_unmapped.clone(),
+            io: self.io.clone(),
+            rejects_opts: self.rejects_opts.clone(),
+            stats_opts: self.stats_opts.clone(),
+            read_group: self.read_group.clone(),
+        }
+    }
+}
+
 /// Decide how the single-thread codec loop should handle a typed
 /// [`CodecConsensusError`]: silently swallow recoverable duplex-disagreement
 /// rejects (so the loop continues) and surface any other variant as a fatal
@@ -844,6 +931,125 @@ impl Codec {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every tuning flag must survive the projection into [`CodecOptions`].
+    /// See the simplex counterpart for why this parses rather than constructs.
+    ///
+    /// Every value here is deliberately **non-default**, and every field of
+    /// `CodecOptions` is asserted. Both halves matter: an assertion that
+    /// compares a default against a default passes even when the projection
+    /// ignores the parsed field entirely, and a field left unasserted can be
+    /// dropped from the projection without any test noticing.
+    #[test]
+    fn to_codec_options_carries_every_tuning_flag() {
+        let cmd = Codec::try_parse_from([
+            "codec",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--error-rate-pre-umi",
+            "42",
+            "--error-rate-post-umi",
+            "37",
+            "--min-input-base-quality",
+            "16",
+            "--output-per-base-tags=false",
+            "--trim=true",
+            "--min-consensus-base-quality",
+            "23",
+            "--tie-rule",
+            "ulp-relative",
+            "--min-reads",
+            "4",
+            "--max-reads",
+            "88",
+            "--min-duplex-length",
+            "9",
+            "--single-strand-qual",
+            "12",
+            "--outer-bases-qual",
+            "15",
+            "--outer-bases-length",
+            "7",
+            "--max-duplex-disagreement-rate",
+            "0.25",
+            "--max-duplex-disagreements",
+            "6",
+            "--rejects",
+            "rej.bam",
+            "--stats",
+            "stats.txt",
+            "--read-group-id",
+            "Z",
+            "--read-name-prefix",
+            "pfx",
+            "--allow-unmapped=true",
+        ])
+        .expect("parses");
+
+        let opts = cmd.to_codec_options();
+
+        assert_eq!(opts.error_rate_pre_umi, 42);
+        assert_eq!(opts.error_rate_post_umi, 37);
+        assert_eq!(opts.min_input_base_quality, 16);
+        assert!(!opts.output_per_base_tags, "an explicit false must not be lost");
+        assert!(opts.trim);
+        assert_eq!(opts.min_consensus_base_quality, 23);
+        assert_eq!(
+            opts.tie_rule,
+            fgumi_consensus::TieRule::UlpRelative,
+            "--tie-rule must reach the projection"
+        );
+        assert_eq!(opts.min_reads, 4);
+        assert_eq!(opts.max_reads, Some(88));
+        assert_eq!(opts.min_duplex_length, 9);
+        assert_eq!(opts.single_strand_qual, Some(12));
+        assert_eq!(opts.outer_bases_qual, Some(15));
+        assert_eq!(opts.outer_bases_length, 7);
+        assert!((opts.max_duplex_disagreement_rate - 0.25).abs() < f64::EPSILON);
+        assert_eq!(opts.max_duplex_disagreements, Some(6));
+        assert!(opts.allow_unmapped.enabled, "--allow-unmapped must reach the projection");
+        // The flattened sub-structs must come across whole, not field by field.
+        assert_eq!(opts.io.input, std::path::PathBuf::from("in.bam"));
+        assert_eq!(opts.io.output, std::path::PathBuf::from("out.bam"));
+        assert_eq!(opts.rejects_opts.rejects, Some(std::path::PathBuf::from("rej.bam")));
+        assert_eq!(opts.stats_opts.stats, Some(std::path::PathBuf::from("stats.txt")));
+        assert_eq!(opts.read_group.read_group_id, "Z");
+        assert_eq!(opts.read_group.read_name_prefix, Some("pfx".to_string()));
+    }
+
+    /// The projection must carry defaults faithfully too — a field hard-coded to
+    /// the value the non-default test happens to pass would slip through it.
+    #[test]
+    fn to_codec_options_carries_defaults() {
+        let cmd =
+            Codec::try_parse_from(["codec", "-i", "in.bam", "-o", "out.bam"]).expect("parses");
+
+        let opts = cmd.to_codec_options();
+
+        assert_eq!(opts.error_rate_pre_umi, 45);
+        assert_eq!(opts.error_rate_post_umi, 40);
+        assert_eq!(opts.min_input_base_quality, 10);
+        assert!(opts.output_per_base_tags);
+        assert!(!opts.trim);
+        assert_eq!(opts.min_consensus_base_quality, 2);
+        assert_eq!(opts.tie_rule, fgumi_consensus::TieRule::FgbioCompat);
+        assert_eq!(opts.min_reads, 1);
+        assert_eq!(opts.max_reads, None);
+        assert_eq!(opts.min_duplex_length, 1);
+        assert_eq!(opts.single_strand_qual, None);
+        assert_eq!(opts.outer_bases_qual, None);
+        assert_eq!(opts.outer_bases_length, 5);
+        assert!((opts.max_duplex_disagreement_rate - 1.0).abs() < f64::EPSILON);
+        assert_eq!(opts.max_duplex_disagreements, None);
+        assert!(!opts.allow_unmapped.enabled);
+        assert_eq!(opts.rejects_opts.rejects, None);
+        assert_eq!(opts.stats_opts.stats, None);
+        assert_eq!(opts.read_group.read_group_id, "A");
+        assert_eq!(opts.read_group.read_name_prefix, None);
+    }
+
     use noodles::sam::alignment::io::Write as AlignmentWrite;
     use rstest::rstest;
     use std::path::PathBuf;

--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -330,6 +330,63 @@ pub struct CorrectUmis {
     pub queue_memory: QueueMemoryOptions,
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// CorrectOptions — the stage's tuning knobs, projected out of the CLI struct
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// CorrectUmis-stage tuning, independent of how the values were supplied.
+///
+/// See [`crate::commands::zipper::ZipperOptions`] for why this is a plain
+/// struct rather than a flattened `clap::Args`. Note that the rejects path is
+/// held **flat** here even though [`CorrectUmis`] nests it behind a
+/// `#[command(flatten)]` sub-struct: the chain builder wants one bag per stage,
+/// not a re-run of the CLI's grouping.
+#[derive(Debug, Clone)]
+pub struct CorrectOptions {
+    /// Optional metrics output.
+    pub metrics: Option<PathBuf>,
+    /// Which SAM tag is corrected: `RX`/`OX` for UMIs, `BC`/`ob` for barcodes.
+    pub target: Target,
+    /// Maximum mismatches when matching a UMI.
+    pub max_mismatches: usize,
+    /// Minimum distance to the runner-up UMI.
+    pub min_distance_diff: usize,
+    /// Expected UMI sequences.
+    pub umis: Vec<String>,
+    /// Files holding expected UMI sequences.
+    pub umi_files: Vec<PathBuf>,
+    /// Skip storing the original UMI.
+    pub dont_store_original_umis: bool,
+    /// UMI match cache size.
+    pub cache_size: usize,
+    /// Minimum corrected fraction before failing.
+    pub min_corrected: Option<f64>,
+    /// Also match the reverse complement.
+    pub revcomp: bool,
+    /// Optional rejects output path.
+    pub rejects_path: Option<PathBuf>,
+}
+
+impl CorrectUmis {
+    /// Project the parsed CLI flags into [`CorrectOptions`].
+    #[must_use]
+    pub fn to_correct_options(&self) -> CorrectOptions {
+        CorrectOptions {
+            metrics: self.metrics.clone(),
+            target: self.target,
+            max_mismatches: self.max_mismatches,
+            min_distance_diff: self.min_distance_diff,
+            umis: self.umis.clone(),
+            umi_files: self.umi_files.clone(),
+            dont_store_original_umis: self.dont_store_original_umis,
+            cache_size: self.cache_size,
+            min_corrected: self.min_corrected,
+            revcomp: self.revcomp,
+            rejects_path: self.rejects_opts.rejects.clone(),
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 enum RejectionReason {
     WrongLength,
@@ -1685,6 +1742,99 @@ pub fn find_umi_pairs_within_distance(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every tuning flag must survive the projection into [`CorrectOptions`].
+    ///
+    /// Every value here is deliberately **non-default**, and every field of
+    /// `CorrectOptions` is asserted. Both halves matter: an assertion that
+    /// compares a default against a default passes even when the projection
+    /// ignores the parsed field entirely, and a field left unasserted can be
+    /// dropped from the projection without any test noticing.
+    ///
+    /// `rejects_path` is the one field that changes shape: it is read out of the
+    /// flattened `RejectsOptions`.
+    #[test]
+    fn to_correct_options_carries_every_tuning_flag() {
+        let cmd = CorrectUmis::try_parse_from([
+            "correct",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "-u",
+            "ACGT",
+            "-u",
+            "TTTT",
+            "-U",
+            "umis.txt",
+            "--target",
+            "barcode",
+            "--max-mismatches",
+            "5",
+            "--min-distance",
+            "3",
+            "--cache-size",
+            "4096",
+            "--min-corrected",
+            "0.75",
+            "--revcomp=true",
+            "--dont-store-original=true",
+            "--rejects",
+            "rej.bam",
+            "--metrics",
+            "m.txt",
+        ])
+        .expect("parses");
+
+        let opts = cmd.to_correct_options();
+
+        assert_eq!(opts.metrics, Some(std::path::PathBuf::from("m.txt")));
+        assert_eq!(opts.target, Target::Barcode, "--target must reach the projection");
+        assert_eq!(opts.max_mismatches, 5);
+        assert_eq!(opts.min_distance_diff, 3);
+        assert_eq!(opts.umis, vec!["ACGT".to_string(), "TTTT".to_string()]);
+        assert_eq!(opts.umi_files, vec![std::path::PathBuf::from("umis.txt")]);
+        assert!(opts.dont_store_original_umis);
+        assert_eq!(opts.cache_size, 4096);
+        assert_eq!(opts.min_corrected, Some(0.75));
+        assert!(opts.revcomp);
+        assert_eq!(
+            opts.rejects_path,
+            Some(std::path::PathBuf::from("rej.bam")),
+            "rejects_path must be read from the flattened RejectsOptions",
+        );
+    }
+
+    /// The projection must carry defaults faithfully too — a field hard-coded to
+    /// the value the non-default test happens to pass would slip through it.
+    #[test]
+    fn to_correct_options_carries_defaults() {
+        let cmd = CorrectUmis::try_parse_from([
+            "correct",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "-u",
+            "ACGT",
+            "--min-distance",
+            "1",
+        ])
+        .expect("parses");
+
+        let opts = cmd.to_correct_options();
+
+        assert_eq!(opts.metrics, None);
+        assert_eq!(opts.target, Target::Umi);
+        assert_eq!(opts.max_mismatches, 2);
+        assert!(opts.umi_files.is_empty());
+        assert!(!opts.dont_store_original_umis);
+        assert_eq!(opts.cache_size, 100_000);
+        assert_eq!(opts.min_corrected, None);
+        assert!(!opts.revcomp);
+        assert_eq!(opts.rejects_path, None);
+    }
+
     use noodles::sam;
     use noodles::sam::alignment::io::Write as SamWrite;
     use noodles::sam::alignment::record_buf::RecordBuf;

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -227,6 +227,86 @@ pub struct Duplex {
     pub reference: Option<std::path::PathBuf>,
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// DuplexOptions — the stage's tuning knobs, projected out of the CLI struct
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Duplex-stage tuning, independent of how the values were supplied.
+///
+/// See [`crate::commands::zipper::ZipperOptions`] for why this is a plain
+/// struct rather than a flattened `clap::Args`. Note that the consensus-calling
+/// knobs are held **flat** here even though [`Duplex`] nests them behind
+/// `#[command(flatten)]` sub-structs: the chain builder wants one bag per stage,
+/// not a re-run of the CLI's grouping.
+#[derive(Debug, Clone)]
+pub struct DuplexOptions {
+    /// Pre-UMI error rate (phred).
+    pub error_rate_pre_umi: u8,
+    /// Post-UMI error rate (phred).
+    pub error_rate_post_umi: u8,
+    /// Minimum input base quality.
+    pub min_input_base_quality: u8,
+    /// Emit per-base consensus tags.
+    pub output_per_base_tags: bool,
+    /// Trim consensus reads.
+    pub trim: bool,
+    /// Minimum consensus base quality.
+    pub min_consensus_base_quality: u8,
+    /// How to resolve a near-tie between the two most likely consensus bases.
+    pub tie_rule: fgumi_consensus::TieRule,
+    /// Call overlapping bases jointly.
+    pub consensus_call_overlapping_bases: bool,
+    /// Minimum reads per consensus, per tier.
+    pub min_reads: Vec<usize>,
+    /// Cap on reads per strand.
+    pub max_reads_per_strand: Option<usize>,
+    /// Let fully-unmapped primary templates through the pre-group filter.
+    ///
+    /// Carried as the whole flattened sub-struct, like `io` / `rejects_opts` /
+    /// `read_group`, rather than as a bare `bool`.
+    pub allow_unmapped: AllowUnmappedOptions,
+    /// Input/output paths and reader mode.
+    pub io: BamIoOptions,
+    /// Optional rejects output.
+    pub rejects_opts: RejectsOptions,
+    /// Optional stats output.
+    pub stats_opts: StatsOptions,
+    /// Read-group identity for emitted reads.
+    pub read_group: ReadGroupOptions,
+    /// Resolved methylation calling mode (`Disabled` when the flag is unset).
+    pub methylation_mode: fgumi_consensus::MethylationMode,
+    /// Reference FASTA for methylation-aware modes.
+    pub reference: Option<std::path::PathBuf>,
+}
+
+impl Duplex {
+    /// Project the parsed CLI flags into [`DuplexOptions`].
+    #[must_use]
+    pub fn to_duplex_options(&self) -> DuplexOptions {
+        DuplexOptions {
+            error_rate_pre_umi: self.consensus.error_rate_pre_umi,
+            error_rate_post_umi: self.consensus.error_rate_post_umi,
+            min_input_base_quality: self.consensus.min_input_base_quality,
+            output_per_base_tags: self.consensus.output_per_base_tags,
+            trim: self.consensus.trim,
+            min_consensus_base_quality: self.consensus.min_consensus_base_quality,
+            tie_rule: self.consensus.tie_rule.into(),
+            consensus_call_overlapping_bases: self.overlapping.consensus_call_overlapping_bases,
+            min_reads: self.min_reads.clone(),
+            max_reads_per_strand: self.max_reads_per_strand,
+            allow_unmapped: self.allow_unmapped.clone(),
+            io: self.io.clone(),
+            rejects_opts: self.rejects_opts.clone(),
+            stats_opts: self.stats_opts.clone(),
+            read_group: self.read_group.clone(),
+            methylation_mode: crate::commands::common::resolve_methylation_mode(
+                self.methylation_mode,
+            ),
+            reference: self.reference.clone(),
+        }
+    }
+}
+
 impl Command for Duplex {
     /// Executes the duplex consensus calling pipeline.
     ///
@@ -945,6 +1025,110 @@ fn has_both_strands_raw(records: &[RawRecord]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every tuning flag must survive the projection into [`DuplexOptions`].
+    /// See the simplex counterpart for why this parses rather than constructs.
+    #[test]
+    fn to_duplex_options_carries_every_tuning_flag() {
+        let cmd = Duplex::try_parse_from([
+            "duplex",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--error-rate-pre-umi",
+            "41",
+            "--error-rate-post-umi",
+            "36",
+            "--min-input-base-quality",
+            "18",
+            "--output-per-base-tags=false",
+            "--trim=true",
+            "--min-consensus-base-quality",
+            "21",
+            "--tie-rule",
+            "ulp-relative",
+            "--consensus-call-overlapping-bases=false",
+            "--min-reads",
+            "3,2,1",
+            "--max-reads-per-strand",
+            "55",
+            "--rejects",
+            "rej.bam",
+            "--stats",
+            "stats.txt",
+            "--read-group-id",
+            "Z",
+            "--read-name-prefix",
+            "pfx",
+            "--methylation-mode",
+            "em-seq",
+            "--ref",
+            "ref.fa",
+            "--allow-unmapped=true",
+        ])
+        .expect("parses");
+
+        let opts = cmd.to_duplex_options();
+
+        assert_eq!(opts.error_rate_pre_umi, 41);
+        assert_eq!(opts.error_rate_post_umi, 36);
+        assert_eq!(opts.min_input_base_quality, 18);
+        assert!(!opts.output_per_base_tags, "an explicit false must not be lost");
+        assert!(opts.trim);
+        assert_eq!(opts.min_consensus_base_quality, 21);
+        assert_eq!(
+            opts.tie_rule,
+            fgumi_consensus::TieRule::UlpRelative,
+            "--tie-rule must reach the projection"
+        );
+        assert!(!opts.consensus_call_overlapping_bases);
+        assert_eq!(opts.min_reads, vec![3, 2, 1]);
+        assert_eq!(opts.max_reads_per_strand, Some(55));
+        assert!(opts.allow_unmapped.enabled, "--allow-unmapped must reach the projection");
+        assert_eq!(
+            opts.methylation_mode,
+            fgumi_consensus::MethylationMode::EmSeq,
+            "--methylation-mode must reach the projection",
+        );
+        assert_eq!(opts.reference, Some(std::path::PathBuf::from("ref.fa")));
+        // The flattened sub-structs must come across whole, not field by field.
+        assert_eq!(opts.io.input, std::path::PathBuf::from("in.bam"));
+        assert_eq!(opts.io.output, std::path::PathBuf::from("out.bam"));
+        assert_eq!(opts.rejects_opts.rejects, Some(std::path::PathBuf::from("rej.bam")));
+        assert_eq!(opts.stats_opts.stats, Some(std::path::PathBuf::from("stats.txt")));
+        assert_eq!(opts.read_group.read_group_id, "Z");
+        assert_eq!(opts.read_group.read_name_prefix, Some("pfx".to_string()));
+    }
+
+    /// The projection must carry defaults faithfully too — a field hard-coded to
+    /// the value the non-default test happens to pass would slip through it.
+    #[test]
+    fn to_duplex_options_carries_defaults() {
+        let cmd =
+            Duplex::try_parse_from(["duplex", "-i", "in.bam", "-o", "out.bam"]).expect("parses");
+
+        let opts = cmd.to_duplex_options();
+
+        assert_eq!(opts.error_rate_pre_umi, 45);
+        assert_eq!(opts.error_rate_post_umi, 40);
+        assert_eq!(opts.min_input_base_quality, 10);
+        assert!(opts.output_per_base_tags);
+        assert!(!opts.trim);
+        assert_eq!(opts.min_consensus_base_quality, 2);
+        assert_eq!(opts.tie_rule, fgumi_consensus::TieRule::FgbioCompat);
+        assert!(opts.consensus_call_overlapping_bases);
+        assert_eq!(opts.min_reads, vec![1]);
+        assert_eq!(opts.max_reads_per_strand, None);
+        assert!(!opts.allow_unmapped.enabled);
+        assert_eq!(opts.methylation_mode, fgumi_consensus::MethylationMode::Disabled);
+        assert_eq!(opts.reference, None);
+        assert_eq!(opts.rejects_opts.rejects, None);
+        assert_eq!(opts.stats_opts.stats, None);
+        assert_eq!(opts.read_group.read_group_id, "A");
+        assert_eq!(opts.read_group.read_name_prefix, None);
+    }
+
     use anyhow::Result;
     use fgumi_bam_io::{create_bam_reader, create_bam_writer};
     use fgumi_raw_bam::{

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -218,6 +218,80 @@ pub struct Filter {
     pub queue_memory: QueueMemoryOptions,
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// FilterOptions — the stage's tuning knobs, projected out of the CLI struct
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Filter-stage tuning, independent of how the values were supplied.
+///
+/// See [`crate::commands::zipper::ZipperOptions`] for why this is a plain
+/// struct rather than a flattened `clap::Args`: the chain builder only reads
+/// these values, so moving the fields off [`Filter`] would rewrite this module
+/// and its tests for no gain here.
+#[derive(Debug, Clone)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct FilterOptions {
+    /// Reference FASTA, required by methylation-aware filters.
+    pub reference: Option<PathBuf>,
+    /// Minimum reads supporting a consensus, per depth tier.
+    pub min_reads: Vec<usize>,
+    /// Maximum per-read error rate, per depth tier.
+    pub max_read_error_rate: Vec<f64>,
+    /// Maximum per-base error rate, per depth tier.
+    pub max_base_error_rate: Vec<f64>,
+    /// Minimum consensus base quality.
+    pub min_base_quality: Option<u8>,
+    /// Minimum mean base quality across the read.
+    pub min_mean_base_quality: Option<f64>,
+    /// Maximum fraction of no-called bases.
+    pub max_no_call_fraction: f64,
+    /// Reverse per-base tags on negative-strand reads.
+    pub reverse_per_base_tags: bool,
+    /// Filter whole templates rather than individual reads.
+    pub filter_by_template: bool,
+    /// Optional path for rejected records.
+    pub rejects: Option<PathBuf>,
+    /// Optional path for filter statistics.
+    pub stats: Option<PathBuf>,
+    /// Require both single-strand consensuses to agree.
+    pub require_single_strand_agreement: bool,
+    /// Minimum methylation depth, per tier.
+    pub min_methylation_depth: Vec<usize>,
+    /// Require both strands to agree on methylation.
+    pub require_strand_methylation_agreement: bool,
+    /// Minimum bisulfite conversion fraction.
+    pub min_conversion_fraction: Option<f64>,
+    /// Resolved methylation calling mode (`Disabled` when the flag is unset).
+    pub methylation_mode: fgumi_consensus::MethylationMode,
+}
+
+impl Filter {
+    /// Project the parsed CLI flags into [`FilterOptions`].
+    #[must_use]
+    pub fn to_filter_options(&self) -> FilterOptions {
+        FilterOptions {
+            reference: self.reference.clone(),
+            min_reads: self.min_reads.clone(),
+            max_read_error_rate: self.max_read_error_rate.clone(),
+            max_base_error_rate: self.max_base_error_rate.clone(),
+            min_base_quality: self.min_base_quality,
+            min_mean_base_quality: self.min_mean_base_quality,
+            max_no_call_fraction: self.max_no_call_fraction,
+            reverse_per_base_tags: self.reverse_per_base_tags,
+            filter_by_template: self.filter_by_template,
+            rejects: self.rejects.clone(),
+            stats: self.stats.clone(),
+            require_single_strand_agreement: self.require_single_strand_agreement,
+            min_methylation_depth: self.min_methylation_depth.clone(),
+            require_strand_methylation_agreement: self.require_strand_methylation_agreement,
+            min_conversion_fraction: self.min_conversion_fraction,
+            methylation_mode: crate::commands::common::resolve_methylation_mode(
+                self.methylation_mode,
+            ),
+        }
+    }
+}
+
 // ============================================================================
 // 7-Step Pipeline Types
 // ============================================================================
@@ -1155,6 +1229,104 @@ impl Filter {
 #[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
+
+    /// Every tuning flag must survive the projection into [`FilterOptions`].
+    ///
+    /// Driven through `try_parse_from` rather than a struct literal: a literal
+    /// would still compile if a flag were renamed or unwired, whereas parsing
+    /// pins the whole path from command line to option struct. Non-default
+    /// values throughout, so a field read from the wrong source fails rather
+    /// than coincidentally matching its default.
+    #[test]
+    fn to_filter_options_carries_every_tuning_flag() {
+        let cmd = Filter::try_parse_from([
+            "filter",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--ref",
+            "ref.fa",
+            "--min-reads",
+            "3,2,1",
+            "--max-read-error-rate",
+            "0.06,0.07",
+            "--max-base-error-rate",
+            "0.05",
+            "--min-base-quality",
+            "13",
+            "--min-mean-base-quality",
+            "22.5",
+            "--max-no-call-fraction",
+            "0.3",
+            "--reverse-per-base-tags=true",
+            "--filter-by-template=false",
+            "--rejects",
+            "rej.bam",
+            "--stats",
+            "stats.txt",
+            "--require-single-strand-agreement=true",
+            "--min-methylation-depth",
+            "4,5",
+            "--require-strand-methylation-agreement=true",
+            "--min-conversion-fraction",
+            "0.9",
+            "--methylation-mode",
+            "em-seq",
+        ])
+        .expect("parses");
+
+        let opts = cmd.to_filter_options();
+
+        assert_eq!(opts.reference, Some(std::path::PathBuf::from("ref.fa")));
+        assert_eq!(opts.min_reads, vec![3, 2, 1]);
+        assert_eq!(opts.max_base_error_rate, vec![0.05]);
+        assert_eq!(opts.min_base_quality, Some(13));
+        assert_eq!(opts.min_mean_base_quality, Some(22.5));
+        assert!((opts.max_no_call_fraction - 0.3).abs() < f64::EPSILON);
+        assert!(opts.reverse_per_base_tags);
+        assert!(!opts.filter_by_template, "an explicit false must not be lost");
+        assert_eq!(opts.rejects, Some(std::path::PathBuf::from("rej.bam")));
+        assert_eq!(opts.stats, Some(std::path::PathBuf::from("stats.txt")));
+        assert!(opts.require_single_strand_agreement);
+        assert_eq!(opts.min_methylation_depth, vec![4, 5]);
+        assert!(opts.require_strand_methylation_agreement);
+        assert_eq!(opts.min_conversion_fraction, Some(0.9));
+        assert_eq!(opts.max_read_error_rate, vec![0.06, 0.07]);
+        assert_eq!(
+            opts.methylation_mode,
+            fgumi_consensus::MethylationMode::EmSeq,
+            "--methylation-mode must reach the projection",
+        );
+    }
+
+    /// The projection must carry defaults faithfully too — a field hard-coded to
+    /// the value the non-default test happens to pass would slip through it.
+    #[test]
+    fn to_filter_options_carries_defaults() {
+        let cmd =
+            Filter::try_parse_from(["filter", "-i", "in.bam", "-o", "out.bam"]).expect("parses");
+
+        let opts = cmd.to_filter_options();
+
+        assert_eq!(opts.reference, None);
+        assert!(opts.min_reads.is_empty());
+        assert_eq!(opts.max_read_error_rate, vec![0.025]);
+        assert_eq!(opts.max_base_error_rate, vec![0.1]);
+        assert_eq!(opts.min_base_quality, None);
+        assert_eq!(opts.min_mean_base_quality, None);
+        assert!((opts.max_no_call_fraction - 0.2).abs() < f64::EPSILON);
+        assert!(!opts.reverse_per_base_tags);
+        assert!(opts.filter_by_template);
+        assert_eq!(opts.rejects, None);
+        assert_eq!(opts.stats, None);
+        assert!(!opts.require_single_strand_agreement);
+        assert!(opts.min_methylation_depth.is_empty());
+        assert!(!opts.require_strand_methylation_agreement);
+        assert_eq!(opts.min_conversion_fraction, None);
+        assert_eq!(opts.methylation_mode, fgumi_consensus::MethylationMode::Disabled);
+    }
+
     use crate::sam::SamTag;
     use fgumi_raw_bam::{RawRecord, SamBuilder as RawSamBuilder, aux_data_slice, flags};
     use noodles::sam::alignment::record_buf::RecordBuf;

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -897,6 +897,103 @@ pub struct GroupReadsByUmi {
     pub memory_report_interval: u64,
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// GroupOptions — the stage's tuning knobs, projected out of the CLI struct
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Group-stage tuning, independent of how the values were supplied.
+///
+/// See [`crate::commands::zipper::ZipperOptions`] for why this is a plain
+/// struct rather than a flattened `clap::Args`.
+///
+/// Two fields hold *resolved* values rather than raw flags, because grouping
+/// cannot be configured from the raw ones alone: `min_map_q` applies the
+/// default that [`GroupReadsByUmi`] would otherwise apply at run time, and
+/// `effective_strategy` / `effective_edits` carry the `--no-umi` and
+/// identity-implies-zero-edits rules. Both come from the same methods
+/// `execute` uses, so the command and the chain builder cannot drift apart.
+#[derive(Debug, Clone)]
+pub struct GroupOptions {
+    /// Minimum mapping quality for mapped reads, with the default applied.
+    pub min_map_q: u8,
+    /// Include non-PF reads.
+    pub include_non_pf_reads: bool,
+    /// Allow fully unmapped templates.
+    pub allow_unmapped: bool,
+    /// The strategy as requested on the command line.
+    pub strategy: Strategy,
+    /// The edit distance as requested on the command line.
+    pub edits: u32,
+    /// Minimum UMI length to accept.
+    pub min_umi_length: Option<usize>,
+    /// When to build the N-gram/BK-tree index instead of scanning linearly.
+    ///
+    /// This is [`fgumi_umi::IndexThreshold`] rather than a bare count: the
+    /// flag also accepts `always` / `never`, which a number cannot express.
+    pub index_threshold: IndexThreshold,
+    /// Skip UMI-based grouping entirely.
+    pub no_umi: bool,
+    /// Template-count floor for handing a position group to a parallel assigner.
+    pub parallel_group_min_templates: Option<ParallelMinTemplates>,
+    /// The strategy actually used, after applying `--no-umi`.
+    pub effective_strategy: Strategy,
+    /// The edit distance actually used, after applying `--no-umi` and the
+    /// identity-implies-zero rule.
+    pub effective_edits: u32,
+    /// Optional family-size histogram output.
+    pub family_size_histogram: Option<PathBuf>,
+    /// Optional grouping-metrics output.
+    pub grouping_metrics: Option<PathBuf>,
+    /// Optional output prefix for the full set of metrics files.
+    pub metrics_prefix: Option<PathBuf>,
+}
+
+impl GroupReadsByUmi {
+    /// The minimum mapping quality to apply, defaulting when the flag is absent.
+    #[must_use]
+    pub fn resolved_min_map_q(&self) -> u8 {
+        self.min_map_q.unwrap_or(1)
+    }
+
+    /// Resolve the strategy and edit distance grouping will actually use.
+    ///
+    /// `--no-umi` forces identity grouping, and identity grouping requires an
+    /// edit distance of zero; both rules live here so `execute` and the chain
+    /// builder cannot disagree about what was configured. The caller is
+    /// responsible for rejecting `--no-umi` with `--strategy paired` and for
+    /// logging the override — this method only computes.
+    #[must_use]
+    pub fn resolve_strategy_and_edits(&self) -> (Strategy, u32) {
+        if self.no_umi {
+            return (Strategy::Identity, 0);
+        }
+        let edits = if matches!(self.strategy, Strategy::Identity) { 0 } else { self.edits };
+        (self.strategy, edits)
+    }
+
+    /// Project the parsed CLI flags into [`GroupOptions`].
+    #[must_use]
+    pub fn to_group_options(&self) -> GroupOptions {
+        let (effective_strategy, effective_edits) = self.resolve_strategy_and_edits();
+        GroupOptions {
+            min_map_q: self.resolved_min_map_q(),
+            include_non_pf_reads: self.include_non_pf_reads,
+            allow_unmapped: self.allow_unmapped,
+            strategy: self.strategy,
+            edits: self.edits,
+            min_umi_length: self.min_umi_length,
+            index_threshold: self.index_threshold,
+            no_umi: self.no_umi,
+            parallel_group_min_templates: self.parallel_group_min_templates.clone(),
+            effective_strategy,
+            effective_edits,
+            family_size_histogram: self.family_size_histogram.clone(),
+            grouping_metrics: self.grouping_metrics.clone(),
+            metrics_prefix: self.metrics.clone(),
+        }
+    }
+}
+
 /// Build [`UmiGroupingMetrics`] from filter metrics and family size counts.
 ///
 /// Shared by both the pipeline and single-threaded execution paths.
@@ -963,23 +1060,10 @@ impl Command for GroupReadsByUmi {
         }
 
         // Handle --no-umi mode: force identity strategy
-        let (effective_strategy, no_umi_edits_override) = if self.no_umi {
-            if !matches!(self.strategy, Strategy::Identity) {
-                info!("--no-umi mode: overriding strategy to identity");
-            }
-            (Strategy::Identity, true)
-        } else {
-            (self.strategy, false)
-        };
-
-        // Identity strategy requires edits=0, others use the configured value
-        // Also force edits=0 in no-umi mode
-        let effective_edits =
-            if no_umi_edits_override || matches!(effective_strategy, Strategy::Identity) {
-                0
-            } else {
-                self.edits
-            };
+        if self.no_umi && !matches!(self.strategy, Strategy::Identity) {
+            info!("--no-umi mode: overriding strategy to identity");
+        }
+        let (effective_strategy, effective_edits) = self.resolve_strategy_and_edits();
 
         // `--index-threshold always` asserts that indexing will happen; reject it when
         // the resolved strategy/edits can never index rather than ignoring the flag.
@@ -993,7 +1077,7 @@ impl Command for GroupReadsByUmi {
         self.io.validate()?;
 
         // Set minimum mapping quality
-        let min_mapq: u8 = self.min_map_q.unwrap_or(1);
+        let min_mapq: u8 = self.resolved_min_map_q();
 
         // Initialize tracking infrastructure
         let timer = OperationTimer::new("Grouping reads by UMI");
@@ -1958,6 +2042,161 @@ fn with_extension(prefix: &Path, suffix: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The `--no-umi` and identity-implies-zero-edits rules, pinned as a table.
+    ///
+    /// These moved out of `execute` into [`GroupReadsByUmi::resolve_strategy_and_edits`]
+    /// so the command and the chain builder read them from one place; this is
+    /// the regression test for that move. Identity forces zero edits because a
+    /// non-zero edit distance would silently change which reads group together,
+    /// and `--no-umi` forces identity because there is no UMI to compare.
+    #[rstest]
+    #[case::adjacency_passes_through(Strategy::Adjacency, 2, false, Strategy::Adjacency, 2)]
+    #[case::edit_passes_through(Strategy::Edit, 3, false, Strategy::Edit, 3)]
+    #[case::paired_passes_through(Strategy::Paired, 1, false, Strategy::Paired, 1)]
+    #[case::identity_forces_zero_edits(Strategy::Identity, 2, false, Strategy::Identity, 0)]
+    #[case::no_umi_forces_identity_and_zero(Strategy::Adjacency, 2, true, Strategy::Identity, 0)]
+    #[case::no_umi_over_identity(Strategy::Identity, 0, true, Strategy::Identity, 0)]
+    fn resolve_strategy_and_edits_applies_the_no_umi_and_identity_rules(
+        #[case] strategy: Strategy,
+        #[case] edits: u32,
+        #[case] no_umi: bool,
+        #[case] expected_strategy: Strategy,
+        #[case] expected_edits: u32,
+    ) {
+        let mut cmd = GroupReadsByUmi::try_parse_from([
+            "group",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "-s",
+            "adjacency",
+        ])
+        .expect("parses");
+        cmd.strategy = strategy;
+        cmd.edits = edits;
+        cmd.no_umi = no_umi;
+
+        assert_eq!(cmd.resolve_strategy_and_edits(), (expected_strategy, expected_edits));
+    }
+
+    /// `--min-map-q` is optional on the command line but not optional for
+    /// grouping, so the projection applies the same default `execute` does.
+    #[rstest]
+    #[case::absent_defaults_to_one(None, 1)]
+    #[case::zero_is_honored_not_treated_as_absent(Some(0), 0)]
+    #[case::explicit_value(Some(30), 30)]
+    fn resolved_min_map_q_applies_the_default(#[case] flag: Option<u8>, #[case] expected: u8) {
+        let mut cmd = GroupReadsByUmi::try_parse_from([
+            "group",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "-s",
+            "adjacency",
+        ])
+        .expect("parses");
+        cmd.min_map_q = flag;
+
+        assert_eq!(cmd.resolved_min_map_q(), expected);
+    }
+
+    /// Every tuning flag must survive the projection into [`GroupOptions`].
+    ///
+    /// Parsed rather than constructed so a renamed or unwired flag fails here.
+    /// `metrics_prefix` is the one renamed field — it is fed by `--metrics` —
+    /// and `effective_*` are the resolved ones, so both are asserted explicitly.
+    #[test]
+    fn to_group_options_carries_every_tuning_flag() {
+        let cmd = GroupReadsByUmi::try_parse_from([
+            "group",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "-s",
+            "adjacency",
+            "-e",
+            "2",
+            "-m",
+            "30",
+            "--min-umi-length",
+            "8",
+            "--index-threshold",
+            "250",
+            "--family-size-histogram",
+            "fs.txt",
+            "--grouping-metrics",
+            "gm.txt",
+            "--metrics",
+            "prefix",
+            "--include-non-pf-reads=true",
+            "--allow-unmapped=true",
+            "--parallel-group-min-templates",
+            "500",
+        ])
+        .expect("parses");
+
+        let opts = cmd.to_group_options();
+
+        assert_eq!(opts.min_map_q, 30);
+        assert!(opts.include_non_pf_reads);
+        assert!(opts.allow_unmapped);
+        assert_eq!(opts.strategy, Strategy::Adjacency);
+        assert_eq!(opts.edits, 2);
+        assert_eq!(opts.min_umi_length, Some(8));
+        assert_eq!(opts.index_threshold, IndexThreshold::MinUmis(250));
+        assert_eq!(opts.parallel_group_min_templates, Some(ParallelMinTemplates::Fixed(500)));
+        assert!(!opts.no_umi);
+        assert_eq!(opts.family_size_histogram, Some(std::path::PathBuf::from("fs.txt")));
+        assert_eq!(opts.grouping_metrics, Some(std::path::PathBuf::from("gm.txt")));
+        assert_eq!(
+            opts.metrics_prefix,
+            Some(std::path::PathBuf::from("prefix")),
+            "metrics_prefix is fed by --metrics, not by a flag of its own",
+        );
+
+        // Not overridden here, so the resolved pair matches what was requested.
+        assert_eq!(opts.effective_strategy, Strategy::Adjacency);
+        assert_eq!(opts.effective_edits, 2);
+    }
+
+    /// The projection must carry defaults faithfully too — a field hard-coded to
+    /// the value the non-default test happens to pass would slip through it.
+    ///
+    /// `min_map_q` is the interesting one: the CLI holds `Option<u8>` and the
+    /// projection resolves the absent case to 1, so this pins the resolution
+    /// rather than the raw flag.
+    #[test]
+    fn to_group_options_carries_defaults() {
+        let cmd = GroupReadsByUmi::try_parse_from([
+            "group",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "-s",
+            "adjacency",
+        ])
+        .expect("parses");
+
+        let opts = cmd.to_group_options();
+
+        assert_eq!(opts.min_map_q, 1, "an absent --min-map-q resolves to 1");
+        assert!(!opts.include_non_pf_reads);
+        assert!(!opts.allow_unmapped);
+        assert_eq!(opts.edits, 1);
+        assert_eq!(opts.min_umi_length, None);
+        assert_eq!(opts.index_threshold, IndexThreshold::MinUmis(100));
+        assert_eq!(opts.parallel_group_min_templates, None);
+        assert!(!opts.no_umi);
+        assert_eq!(opts.family_size_histogram, None);
+        assert_eq!(opts.grouping_metrics, None);
+        assert_eq!(opts.metrics_prefix, None);
+    }
+
     use crate::assigner::{IdentityUmiAssigner, PairedUmiAssigner, Strategy};
     use bstr::BString;
     use fgumi_raw_bam::{

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -240,6 +240,86 @@ pub struct Simplex {
     pub reference: Option<std::path::PathBuf>,
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// SimplexOptions — the stage's tuning knobs, projected out of the CLI struct
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Simplex-stage tuning, independent of how the values were supplied.
+///
+/// See [`crate::commands::zipper::ZipperOptions`] for why this is a plain
+/// struct rather than a flattened `clap::Args`. Note that the consensus-calling
+/// knobs are held **flat** here even though [`Simplex`] nests them behind
+/// `#[command(flatten)]` sub-structs: the chain builder wants one bag per stage,
+/// not a re-run of the CLI's grouping.
+#[derive(Debug, Clone)]
+pub struct SimplexOptions {
+    /// Pre-UMI error rate (phred).
+    pub error_rate_pre_umi: u8,
+    /// Post-UMI error rate (phred).
+    pub error_rate_post_umi: u8,
+    /// Minimum input base quality.
+    pub min_input_base_quality: u8,
+    /// Emit per-base consensus tags.
+    pub output_per_base_tags: bool,
+    /// Trim consensus reads.
+    pub trim: bool,
+    /// Minimum consensus base quality.
+    pub min_consensus_base_quality: u8,
+    /// How to resolve a near-tie between the two most likely consensus bases.
+    pub tie_rule: fgumi_consensus::TieRule,
+    /// Call overlapping bases jointly.
+    pub consensus_call_overlapping_bases: bool,
+    /// Minimum reads per consensus.
+    pub min_reads: usize,
+    /// Cap on reads per consensus.
+    pub max_reads: Option<usize>,
+    /// Let fully-unmapped primary templates through the pre-group filter.
+    ///
+    /// Carried as the whole flattened sub-struct, like `io` / `rejects_opts` /
+    /// `read_group`, rather than as a bare `bool`.
+    pub allow_unmapped: AllowUnmappedOptions,
+    /// Input/output paths and reader mode.
+    pub io: BamIoOptions,
+    /// Optional rejects output.
+    pub rejects_opts: RejectsOptions,
+    /// Optional stats output.
+    pub stats_opts: StatsOptions,
+    /// Read-group identity for emitted reads.
+    pub read_group: ReadGroupOptions,
+    /// Resolved methylation calling mode (`Disabled` when the flag is unset).
+    pub methylation_mode: fgumi_consensus::MethylationMode,
+    /// Reference FASTA for methylation-aware modes.
+    pub reference: Option<std::path::PathBuf>,
+}
+
+impl Simplex {
+    /// Project the parsed CLI flags into [`SimplexOptions`].
+    #[must_use]
+    pub fn to_simplex_options(&self) -> SimplexOptions {
+        SimplexOptions {
+            error_rate_pre_umi: self.consensus.error_rate_pre_umi,
+            error_rate_post_umi: self.consensus.error_rate_post_umi,
+            min_input_base_quality: self.consensus.min_input_base_quality,
+            output_per_base_tags: self.consensus.output_per_base_tags,
+            trim: self.consensus.trim,
+            min_consensus_base_quality: self.consensus.min_consensus_base_quality,
+            tie_rule: self.consensus.tie_rule.into(),
+            consensus_call_overlapping_bases: self.overlapping.consensus_call_overlapping_bases,
+            min_reads: self.min_reads,
+            max_reads: self.max_reads,
+            allow_unmapped: self.allow_unmapped.clone(),
+            io: self.io.clone(),
+            rejects_opts: self.rejects_opts.clone(),
+            stats_opts: self.stats_opts.clone(),
+            read_group: self.read_group.clone(),
+            methylation_mode: crate::commands::common::resolve_methylation_mode(
+                self.methylation_mode,
+            ),
+            reference: self.reference.clone(),
+        }
+    }
+}
+
 impl Command for Simplex {
     fn execute(&self, command_line: &str) -> Result<()> {
         // Start timing
@@ -810,6 +890,122 @@ impl Simplex {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every tuning flag must survive the projection into [`SimplexOptions`].
+    ///
+    /// Driven through `try_parse_from` rather than a struct literal: a literal
+    /// would still compile if a flag were renamed or unwired, whereas parsing
+    /// pins the whole path from command line to option struct. Non-default
+    /// values throughout, so a field read from the wrong source fails rather
+    /// than coincidentally matching its default.
+    #[test]
+    fn to_simplex_options_carries_every_tuning_flag() {
+        let cmd = Simplex::try_parse_from([
+            "simplex",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--error-rate-pre-umi",
+            "40",
+            "--error-rate-post-umi",
+            "35",
+            "--min-input-base-quality",
+            "17",
+            "--output-per-base-tags=false",
+            "--trim=true",
+            "--min-consensus-base-quality",
+            "19",
+            "--tie-rule",
+            "ulp-relative",
+            "--consensus-call-overlapping-bases=false",
+            "--min-reads",
+            "3",
+            "--max-reads",
+            "77",
+            "--rejects",
+            "rej.bam",
+            "--stats",
+            "stats.txt",
+            "--read-group-id",
+            "Z",
+            "--read-name-prefix",
+            "pfx",
+            "--methylation-mode",
+            "em-seq",
+            "--ref",
+            "ref.fa",
+            "--allow-unmapped=true",
+        ])
+        .expect("parses");
+
+        let opts = cmd.to_simplex_options();
+
+        assert_eq!(opts.error_rate_pre_umi, 40);
+        assert_eq!(opts.error_rate_post_umi, 35);
+        assert_eq!(opts.min_input_base_quality, 17);
+        assert!(!opts.output_per_base_tags, "an explicit false must not be lost");
+        assert!(opts.trim);
+        assert_eq!(opts.min_consensus_base_quality, 19);
+        assert_eq!(
+            opts.tie_rule,
+            fgumi_consensus::TieRule::UlpRelative,
+            "--tie-rule must reach the projection"
+        );
+        assert!(!opts.consensus_call_overlapping_bases);
+        assert_eq!(opts.min_reads, 3);
+        assert_eq!(opts.max_reads, Some(77));
+        assert!(opts.allow_unmapped.enabled, "--allow-unmapped must reach the projection");
+        assert_eq!(opts.reference, Some(std::path::PathBuf::from("ref.fa")));
+        assert_eq!(
+            opts.methylation_mode,
+            fgumi_consensus::MethylationMode::EmSeq,
+            "--methylation-mode must reach the projection",
+        );
+        // The flattened sub-structs must come across whole, not field by field.
+        assert_eq!(opts.io.input, std::path::PathBuf::from("in.bam"));
+        assert_eq!(opts.io.output, std::path::PathBuf::from("out.bam"));
+        assert_eq!(opts.read_group.read_group_id, "Z");
+        assert_eq!(opts.read_group.read_name_prefix, Some("pfx".to_string()));
+        assert_eq!(opts.rejects_opts.rejects, Some(std::path::PathBuf::from("rej.bam")));
+        assert_eq!(opts.stats_opts.stats, Some(std::path::PathBuf::from("stats.txt")));
+    }
+
+    /// The projection must carry defaults faithfully too — a field hard-coded to
+    /// the value the non-default test happens to pass would slip through it.
+    #[test]
+    fn to_simplex_options_carries_defaults() {
+        let cmd = Simplex::try_parse_from([
+            "simplex",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--min-reads",
+            "1",
+        ])
+        .expect("parses");
+
+        let opts = cmd.to_simplex_options();
+
+        assert_eq!(opts.error_rate_pre_umi, 45);
+        assert_eq!(opts.error_rate_post_umi, 40);
+        assert_eq!(opts.min_input_base_quality, 10);
+        assert!(opts.output_per_base_tags);
+        assert!(!opts.trim);
+        assert_eq!(opts.min_consensus_base_quality, 2);
+        assert_eq!(opts.tie_rule, fgumi_consensus::TieRule::FgbioCompat);
+        assert!(opts.consensus_call_overlapping_bases);
+        assert_eq!(opts.max_reads, None);
+        assert!(!opts.allow_unmapped.enabled);
+        assert_eq!(opts.methylation_mode, fgumi_consensus::MethylationMode::Disabled);
+        assert_eq!(opts.reference, None);
+        assert_eq!(opts.rejects_opts.rejects, None);
+        assert_eq!(opts.stats_opts.stats, None);
+        assert_eq!(opts.read_group.read_group_id, "A");
+        assert_eq!(opts.read_group.read_name_prefix, None);
+    }
+
     use crate::metrics::consensus::ConsensusKvMetric;
     use noodles::sam::alignment::record::data::field::Tag;
     use noodles::sam::alignment::record_buf::RecordBuf;

--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -226,6 +226,62 @@ pub struct Zipper {
     pub restore_unconverted_bases: bool,
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// ZipperOptions — the stage's tuning knobs, projected out of the CLI struct
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Zipper-stage tuning, independent of how the values were supplied.
+///
+/// The chain builder needs these knobs without knowing where they came from:
+/// the standalone `fgumi zipper` command fills them from its own flags, and a
+/// fused pipeline fills them from its own. Holding them in a plain struct —
+/// rather than having the builder reach into [`Zipper`] — is what lets a chain
+/// be constructed with no CLI struct behind it at all.
+///
+/// This deliberately does **not** derive `clap::Args`. Flattening it into
+/// [`Zipper`] would move the fields off that struct and rewrite every
+/// `self.<field>` reference in this module and its tests, which buys the chain
+/// builder nothing — it only ever reads the values. That refactor belongs with
+/// the fused command that actually needs prefixed `--zipper::<flag>` flags, so
+/// the CLI surface here is untouched.
+#[derive(Debug, Clone)]
+pub struct ZipperOptions {
+    /// Tags to remove from mapped reads before copying unmapped tags.
+    pub tags_to_remove: Vec<String>,
+    /// Tags to reverse for reads mapped to the negative strand.
+    pub tags_to_reverse: Vec<String>,
+    /// Tags to reverse complement for reads mapped to the negative strand.
+    pub tags_to_revcomp: Vec<String>,
+    /// Buffer size for the template channel.
+    pub buffer: usize,
+    /// Accepted for backward compatibility; has no effect. Carried so the
+    /// projection stays total — see [`Zipper::bwa_chunk_size`].
+    pub bwa_chunk_size: u64,
+    /// Drop unmapped-BAM reads absent from the aligned BAM.
+    pub exclude_missing_reads: bool,
+    /// Skip adding `tc` tags to secondary/supplementary reads.
+    pub skip_tc_tags: bool,
+    /// Restore unconverted bases in EM-seq consensus reads.
+    pub restore_unconverted_bases: bool,
+}
+
+impl Zipper {
+    /// Project the parsed CLI flags into [`ZipperOptions`].
+    #[must_use]
+    pub fn to_zipper_options(&self) -> ZipperOptions {
+        ZipperOptions {
+            tags_to_remove: self.tags_to_remove.clone(),
+            tags_to_reverse: self.tags_to_reverse.clone(),
+            tags_to_revcomp: self.tags_to_revcomp.clone(),
+            buffer: self.buffer,
+            bwa_chunk_size: self.bwa_chunk_size,
+            exclude_missing_reads: self.exclude_missing_reads,
+            skip_tc_tags: self.skip_tc_tags,
+            restore_unconverted_bases: self.restore_unconverted_bases,
+        }
+    }
+}
+
 /// Builds the output BAM header from unmapped and mapped headers
 ///
 /// Merges information from both input headers:
@@ -3559,6 +3615,71 @@ mod tests {
     fn test_skip_tc_tags_parsing(#[case] args: &[&str], #[case] expected: bool) {
         let cmd = Zipper::try_parse_from(args).expect("failed to parse Zipper arguments");
         assert_eq!(cmd.skip_tc_tags, expected);
+    }
+
+    /// Every tuning flag must survive the projection into [`ZipperOptions`].
+    ///
+    /// Driven through `try_parse_from` rather than a struct literal on purpose:
+    /// a struct literal would still compile if a flag were renamed or unwired,
+    /// whereas parsing pins the whole path from command line to option struct.
+    /// Non-default values throughout, so a field copied from the wrong source —
+    /// or left at its default — fails rather than coincidentally matching.
+    #[test]
+    fn to_zipper_options_carries_every_tuning_flag() {
+        let cmd = Zipper::try_parse_from([
+            "zipper",
+            "-u",
+            "u.bam",
+            "-r",
+            "ref.fa",
+            "-o",
+            "out.bam",
+            "--tags-to-remove",
+            "RX,MI",
+            "--tags-to-reverse",
+            "QX",
+            "--tags-to-revcomp",
+            "OX,ZA",
+            "--buffer",
+            "1234",
+            "--bwa-chunk-size",
+            "4242",
+            "--exclude-missing-reads=true",
+            "--skip-tc-tags=true",
+            "--restore-unconverted-bases=true",
+        ])
+        .expect("failed to parse Zipper arguments");
+
+        let opts = cmd.to_zipper_options();
+
+        assert_eq!(opts.tags_to_remove, vec!["RX".to_string(), "MI".to_string()]);
+        assert_eq!(opts.tags_to_reverse, vec!["QX".to_string()]);
+        assert_eq!(opts.tags_to_revcomp, vec!["OX".to_string(), "ZA".to_string()]);
+        assert_eq!(opts.buffer, 1234);
+        assert_eq!(opts.bwa_chunk_size, 4242);
+        assert!(opts.exclude_missing_reads);
+        assert!(opts.skip_tc_tags);
+        assert!(opts.restore_unconverted_bases);
+    }
+
+    /// The projection must also carry defaults faithfully — a field hard-coded
+    /// to `true`/`0` would pass the all-non-default test above.
+    #[test]
+    fn to_zipper_options_carries_defaults() {
+        let cmd =
+            Zipper::try_parse_from(["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam"])
+                .expect("failed to parse Zipper arguments");
+
+        let opts = cmd.to_zipper_options();
+
+        assert!(opts.tags_to_remove.is_empty());
+        assert!(opts.tags_to_reverse.is_empty());
+        assert!(opts.tags_to_revcomp.is_empty());
+        assert_eq!(opts.buffer, 50_000);
+        assert_eq!(opts.bwa_chunk_size, 150_000_000);
+        assert!(!opts.exclude_missing_reads);
+        assert!(!opts.skip_tc_tags);
+        assert!(!opts.restore_unconverted_bases);
     }
 
     /// The rendered long help for `--skip-tc-tags`.


### PR DESCRIPTION
Prerequisite for porting the chain builder. Based on `main-runall` rather than stacked on #736/#741/#743 — it touches only `src/lib/commands/`, disjoint from those, so it can merge in parallel.

## Why

The chain builder needs each stage's tuning knobs without depending on how they were supplied, so a chain can be constructed with no CLI struct behind it. Today those knobs are reachable only as fields on the clap command structs.

This adds one plain `<Command>Options` struct per stage plus a `to_<command>_options()` projection, for **correct, group, simplex, duplex, codec, filter, zipper**.

## Why these are not `clap::Args`

Flattening them into the command structs — the shape the fused command will eventually want, so it can expose `--<stage>::<flag>` — would move the fields off those structs and rewrite every `self.<field>` reference and its tests. That buys the chain builder nothing: it only ever reads the values, and never touches clap. So that refactor is deferred to the change that actually needs prefixed flags.

The consequence is that this PR is **additive**: no CLI surface moves, no existing field is relocated, and the existing suite covers the seven commands unchanged. The trade is that those fields get touched twice — once here, once when they become flattened `Args`. The field *names* do not change, so nothing downstream churns.

## Resolved vs. raw values

Two `GroupOptions` fields hold resolved values, because grouping cannot be configured from the raw flags alone:

- `min_map_q` applies the default `execute` would otherwise apply at run time.
- `effective_strategy` / `effective_edits` carry the `--no-umi` and identity-implies-zero-edits rules.

Both now come from `GroupReadsByUmi::resolved_min_map_q` and `resolve_strategy_and_edits`, **extracted from `execute`** so the command and the chain builder read them from one place rather than duplicating the rules. `execute` keeps its own validation and its override log line; the new methods only compute. This is the only behavior-adjacent change in the PR, and a case table pins both sets of rules as a regression test for the extraction.

`GroupOptions::index_threshold` keeps the richer `IndexThreshold` type rather than a bare count, since the flag also accepts `always` / `never`.

## Testing

Each projection has a test that drives the command through `try_parse_from` rather than a struct literal, with non-default values throughout — so a renamed or unwired flag fails the test instead of silently compiling, and a field read from the wrong source fails rather than coincidentally matching its default. Zipper additionally has a defaults test, since an all-non-default assertion cannot catch a field hard-coded to a non-default constant.

`Strategy` gains `PartialEq`/`Eq` (additive, fieldless enum) so the resolution table can assert on it.

8322 → 8339 tests, all passing. `ci-fmt`, `ci-lint`, `ci-tag-literals`, `ci-doc` (with `RUSTDOCFLAGS="-D warnings"`), and `publish-crates.sh --check` all pass.

## Deliberately not included

`warn_unwired_pipeline_flags` is part of the same upstream surface, but it warns that `--scheduler` is a deprecated no-op. On this branch the pluggable scheduler is still live — `SchedulerOptions::scheduler` is a `SchedulerStrategy` with a default, not an `Option`, and `unified_pipeline` still consumes it. Porting the warning now would announce a removal that has not happened, so it travels with the change that actually removes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: command output changes: none; `unsafe`: none, and `CLAUDE.md` allowlist: unchanged; memory bounds, queue capacity, and thread/backpressure policy: none. Fix: add stage option projections without changing CLI interfaces.

- Added `CorrectOptions`, `GroupOptions`, `SimplexOptions`, `DuplexOptions`, `CodecOptions`, `FilterOptions`, and `ZipperOptions`.
- Added `to_*_options()` methods for each stage.
- Shared group resolution for MAPQ defaults, UMI strategy, and edit behavior while preserving validation and logging.
- Added projection and default-value tests.
- Added `PartialEq` and `Eq` to `Strategy`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->