### PR TITLE
perf(pipeline): decouple deadlock liveness from stats and stop polling at teardown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,6 +216,12 @@ harness = false
 required-features = ["simplex"]
 
 [[bench]]
+name = "pipeline_dispatch"
+harness = false
+# Dispatch-overhead A/B for the typed-step runtime; no command drives the
+# pipeline yet, so this is the only way to measure a hot-path change.
+
+[[bench]]
 name = "raw_bam_accessors"
 harness = false
 

--- a/benches/pipeline_dispatch.rs
+++ b/benches/pipeline_dispatch.rs
@@ -1,0 +1,223 @@
+//! Dispatch-throughput benchmark for the typed-step pipeline runtime.
+//!
+//! This measures the runtime's *per-dispatch overhead*, not the work steps do:
+//! every step here is a near-no-op, so wall time is dominated by the scheduler
+//! loop, queue push/pop, and the reorder stage. That is exactly the path any
+//! change to the driver's inner loop lands on.
+//!
+//! It exists because the pipeline had no benchmark at all — no command on this
+//! branch drives it yet (the chain builders and command rewiring arrive later),
+//! so there was no way to tell whether a hot-path change cost anything.
+//!
+//! Read the numbers as *relative* only. Absolute throughput here is meaningless
+//! as a product metric (real steps decompress BGZF and parse records, which
+//! dwarfs dispatch); the point is A/B on the same host.
+
+use std::collections::VecDeque;
+use std::hint::black_box;
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use fgumi_pipeline_core::Unpushed;
+use fgumi_pipeline_core::builder::{Pipeline, PipelineConfig};
+use fgumi_pipeline_core::held::HeldSlot;
+use fgumi_pipeline_core::item::{HeapSize, Ordered};
+use fgumi_pipeline_core::outputs::OrderedBytesSingle;
+use fgumi_pipeline_core::queues::QueueSpec;
+use fgumi_pipeline_core::reorder::BranchOrdering;
+use fgumi_pipeline_core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+
+/// Per-edge byte budget. Large enough that the queues never bind — this
+/// benchmark measures dispatch cost, and backpressure stalls would swamp it
+/// with scheduling noise.
+const EDGE_LIMIT_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Items pushed through the chain per iteration.
+const N_ITEMS: u64 = 50_000;
+
+/// A minimal ordered item. `heap_size` is a small constant rather than 0 so the
+/// byte-bounded accounting does real work per item, as it would in production.
+#[derive(Clone, Copy)]
+struct Item {
+    ordinal: u64,
+}
+
+impl HeapSize for Item {
+    fn heap_size(&self) -> usize {
+        64
+    }
+}
+
+impl Ordered for Item {
+    fn ordinal(&self) -> u64 {
+        self.ordinal
+    }
+}
+
+/// Emits `n` items and finishes. `Exclusive` so it owns its cursor.
+struct CountingSource {
+    remaining: VecDeque<Item>,
+    held: HeldSlot<Unpushed<Item>>,
+}
+
+impl CountingSource {
+    fn new(n: u64) -> Self {
+        Self { remaining: (0..n).map(|ordinal| Item { ordinal }).collect(), held: HeldSlot::new() }
+    }
+}
+
+impl Step for CountingSource {
+    type Input = ();
+    type Outputs = OrderedBytesSingle<Item>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "BenchSource",
+            kind: StepKind::Exclusive,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: EDGE_LIMIT_BYTES }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        let Some(item) = self.remaining.pop_front() else {
+            return Ok(StepOutcome::Finished);
+        };
+        if let Err(unpushed) = ctx.outputs.push(item) {
+            self.held.put(unpushed);
+        }
+        Ok(StepOutcome::Progress)
+    }
+}
+
+/// A `Parallel` pass-through. Cloned per worker, so at `threads > 1` this is
+/// what puts several workers on the dispatch path at once.
+struct PassThrough {
+    held: HeldSlot<Unpushed<Item>>,
+}
+
+impl Step for PassThrough {
+    type Input = Item;
+    type Outputs = OrderedBytesSingle<Item>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "BenchPassThrough",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: EDGE_LIMIT_BYTES }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        let Some(item) = ctx.input.pop() else {
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        // A trivial amount of real work so the compiler cannot fold the step away.
+        let out = Item { ordinal: black_box(item).ordinal };
+        if let Err(unpushed) = ctx.outputs.push(out) {
+            self.held.put(unpushed);
+        }
+        Ok(StepOutcome::Progress)
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        Self { held: HeldSlot::new() }
+    }
+}
+
+/// Terminal sink; counts arrivals into a shared atomic so the run is verifiable.
+struct CountingSink {
+    seen: Arc<AtomicU64>,
+}
+
+impl Step for CountingSink {
+    type Input = Item;
+    type Outputs = ();
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "BenchSink",
+            kind: StepKind::Exclusive,
+            sticky: false,
+            output_queues: vec![],
+            branch_ordering: vec![],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        match ctx.input.pop() {
+            Some(item) => {
+                black_box(item);
+                self.seen.fetch_add(1, Ordering::Relaxed);
+                Ok(StepOutcome::Progress)
+            }
+            None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+            None => Ok(StepOutcome::NoProgress),
+        }
+    }
+}
+
+/// Run the chain once, asserting every item arrived.
+///
+/// The assert is not decoration: a timing harness reports a wall figure for a
+/// run that failed or short-circuited just as happily as for a correct one, and
+/// a chain that drops items would look like a speedup.
+fn run_chain(threads: usize) {
+    let seen = Arc::new(AtomicU64::new(0));
+    let sink_handle = Arc::clone(&seen);
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(CountingSource::new(N_ITEMS))
+        .chain(PassThrough { held: HeldSlot::new() })
+        .chain(CountingSink { seen: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("bench chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("bench chain runs");
+
+    assert_eq!(
+        seen.load(Ordering::Relaxed),
+        N_ITEMS,
+        "every item must reach the sink — a short run is an invalid measurement",
+    );
+}
+
+fn bench_dispatch(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pipeline_dispatch");
+    group.throughput(criterion::Throughput::Elements(N_ITEMS));
+    for threads in [1usize, 4, 8] {
+        group.bench_function(format!("threads_{threads}"), |b| {
+            b.iter(|| run_chain(threads));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_dispatch);
+criterion_main!(benches);

--- a/crates/fgumi-pipeline-core/src/builder.rs
+++ b/crates/fgumi-pipeline-core/src/builder.rs
@@ -5,6 +5,7 @@
 //! Move semantics on `Chain` enforce single-consumer per branch at the
 //! type-system level; the `ChainGraph` performs the runtime all-wired check.
 
+use crate::liveness::LivenessCounter;
 use std::cell::RefCell;
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -152,6 +153,31 @@ impl Default for PipelineConfig {
         Self {
             threads: std::thread::available_parallelism().map_or(1, std::num::NonZero::get),
             stats: None,
+            // Still disarmed by default — but for a different reason than
+            // before, and the remaining blocker is now the only one.
+            //
+            // It used to be unaffordable: liveness came from `PipelineStats`,
+            // so arming the monitor meant paying `Instant::now()` on every
+            // dispatch. That is fixed — liveness is now a sharded counter
+            // (`crate::liveness`), and the monitor's teardown no longer polls a
+            // flag in 25ms slices, which cost up to a full slice of dead time on
+            // every run (measured at +80% wall on a 27ms pipeline). Both costs
+            // are gone; benchmarking shows arming it is now free within noise.
+            //
+            // What still blocks flipping this to `DEFAULT_DEADLOCK_TIMEOUT_SECS`
+            // is `PipelineError::MonitorBlindTransport`: an armed monitor
+            // *rejects* any chain with a non-`ByteBounded` edge, because its
+            // stall verdict distinguishes "idle" from "wedged" by counting bytes
+            // in flight and cannot see an `Unbounded` or `CountBounded` queue.
+            // `Process2` uses `CountBounded`, so defaulting this on would fail
+            // those chains outright rather than merely watching them. Teaching
+            // the verdict to handle byte-blind edges is its own change.
+            //
+            // Both the arming and the transport requirement are properties of
+            // the *scheduled* path only: a run that fuses to a single thread
+            // returns before either, so it would neither gain the monitor nor
+            // be rejected for a byte-blind edge. It is bounded by the fused
+            // path's own stall budget instead.
             deadlock_timeout_secs: 0,
             queue_memory_total: None,
             instrumentation: InstrumentationLevel::Off,
@@ -170,8 +196,20 @@ impl PipelineConfig {
     }
 
     /// Builder-style helper to set the deadlock-detection timeout.
-    /// `0` disables; the monitor only spawns when this is non-zero
-    /// AND `stats` is set.
+    /// [`DEFAULT_DEADLOCK_TIMEOUT_SECS`] is the recommended value.
+    /// `0` disables it.
+    ///
+    /// **Scheduled path only.** A non-zero value arms the monitor, and arming
+    /// additionally requires every output transport to be `ByteBounded` — see
+    /// [`crate::signal::PipelineError::MonitorBlindTransport`]. A run that
+    /// fuses to a single thread returns before either the transport check or
+    /// the monitor spawn, so it accepts a non-zero timeout with `CountBounded`
+    /// or `Unbounded` edges and simply ignores it; the fused path is bounded by
+    /// its own stall budget instead.
+    ///
+    /// `stats` is **optional** and independent of arming: liveness comes from
+    /// [`crate::liveness::LivenessCounter`], and a stats handle only adds the
+    /// per-step snapshot to the stall report.
     #[must_use]
     pub fn with_deadlock_timeout(mut self, timeout_secs: u64) -> Self {
         self.deadlock_timeout_secs = timeout_secs;
@@ -909,13 +947,12 @@ impl Pipeline {
                 steps.len()
             );
         }
-        if deadlock_timeout_secs > 0 && stats_arc.is_none() {
-            log::warn!(
-                "PipelineConfig::deadlock_timeout_secs is {deadlock_timeout_secs} but \
-                 PipelineConfig::stats is None; deadlock monitor cannot run without \
-                 stats. Disable one or pair them via the helpers in commands/common.rs."
-            );
-        }
+        // Always-on liveness signal for the deadlock monitor. Sized for the
+        // worker pool plus a slot per possible driver thread, so every bumper
+        // gets its own cache line (see `crate::liveness`). Deliberately NOT
+        // gated on `stats`: the monitor must be armable without paying for
+        // per-dispatch timing, which is exactly what kept it disarmed before.
+        let liveness = Arc::new(LivenessCounter::new(n_threads + steps.len()));
 
         // 0. Fused single-thread fast path (issue #330). A single-source
         // source→sink chain at one worker is driven inline over direct buffers,
@@ -975,7 +1012,17 @@ impl Pipeline {
         // `steps` is still alive, before it is consumed by
         // `build_worker_storage` below. Test chains use CountBounded/Unbounded
         // but do not arm the monitor, so this only fires for a fail-fast run.
-        if deadlock_timeout_secs > 0 && stats_arc.is_some() {
+        //
+        // Keyed on the timeout ALONE, deliberately: liveness now comes from
+        // `LivenessCounter`, so the monitor arms on a non-zero timeout whether
+        // or not a stats handle is attached. Gating this on `stats.is_some()`
+        // too — as it was when liveness was read out of `PipelineStats` — would
+        // let an armed, stats-less run start on a blind edge, where
+        // `in_flight_bytes` reports 0, `classify_stall` reads that as
+        // `Starving`, and the stall clock resets on every poll, so the wedge
+        // never reaches the fatal timeout. The arming condition here must track
+        // the one at the monitor spawn below.
+        if deadlock_timeout_secs > 0 {
             ensure_monitor_visible_transports(&steps, &graph)?;
         }
 
@@ -1025,11 +1072,12 @@ impl Pipeline {
         // `deadlock_timeout_secs` seconds, it logs the snapshot at
         // `warn` level so the user has a starting point. Polls every
         // `max(1, deadlock_timeout_secs / 4)` seconds.
-        let (monitor_stop, monitor_handle) = match (deadlock_timeout_secs, stats_arc.as_ref()) {
-            (n, Some(stats)) if n > 0 => {
-                let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let (monitor_stop, monitor_handle) = match deadlock_timeout_secs {
+            n if n > 0 => {
+                let stop = Arc::new(StopSignal::default());
                 let stop_clone = Arc::clone(&stop);
-                let stats_clone = Arc::clone(stats);
+                let liveness_monitor = Arc::clone(&liveness);
+                let stats_for_monitor = stats_arc.as_ref().map(Arc::clone);
                 let contexts_clone = Arc::clone(&contexts);
                 let signal_clone = Arc::clone(&signal);
                 let warn_timeout = std::time::Duration::from_secs(deadlock_timeout_secs);
@@ -1043,7 +1091,8 @@ impl Pipeline {
                     .spawn(move || {
                         run_deadlock_monitor(
                             &stop_clone,
-                            &stats_clone,
+                            &liveness_monitor,
+                            stats_for_monitor.as_ref(),
                             &contexts_clone,
                             &signal_clone,
                             warn_timeout,
@@ -1064,7 +1113,7 @@ impl Pipeline {
         // consistently-empty ones. Total budget is preserved.
         let (rebalancer_stop, rebalancer_handle) =
             if config.queue_memory_total.is_some() && !contexts.bounded_queues.is_empty() {
-                let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+                let stop = Arc::new(StopSignal::default());
                 let stop_clone = Arc::clone(&stop);
                 // Capture handles into a contiguous Vec — the monitor
                 // doesn't need step indices/names beyond debug logging.
@@ -1139,6 +1188,7 @@ impl Pipeline {
                 let drain_counters_clone: Vec<Arc<StepDrainCounter>> =
                     drain_counters.iter().map(Arc::clone).collect();
                 let stats_clone = stats_arc.as_ref().map(Arc::clone);
+                let liveness_clone = Arc::clone(&liveness);
                 let thread_name = match group.label() {
                     DetachedGroup::Shared(label) => format!("fgumi-driver-{label}"),
                     DetachedGroup::PerStep => {
@@ -1161,6 +1211,7 @@ impl Pipeline {
                                     &drain_counters_clone,
                                     &signal_clone,
                                     stats_clone.as_ref(),
+                                    &liveness_clone,
                                 );
                             }))
                         {
@@ -1217,6 +1268,7 @@ impl Pipeline {
                     &drain_counters,
                     &signal_arc,
                     stats_arc.as_ref(),
+                    &liveness,
                     scheduler.as_ref(),
                 );
             })) {
@@ -1237,6 +1289,7 @@ impl Pipeline {
                 let drain_counters_clone: Vec<Arc<StepDrainCounter>> =
                     drain_counters.iter().map(Arc::clone).collect();
                 let stats_clone = stats_arc.as_ref().map(Arc::clone);
+                let liveness_clone = Arc::clone(&liveness);
                 let scheduler_clone = Arc::clone(&scheduler);
 
                 let handle = thread::Builder::new()
@@ -1263,6 +1316,7 @@ impl Pipeline {
                                     &drain_counters_clone,
                                     &signal_clone,
                                     stats_clone.as_ref(),
+                                    &liveness_clone,
                                     scheduler_clone.as_ref(),
                                 );
                             }))
@@ -1307,7 +1361,7 @@ impl Pipeline {
         // normal pipeline shutdown (where steps stop progressing
         // because they're done, not stuck).
         if let Some(stop) = monitor_stop {
-            stop.store(true, std::sync::atomic::Ordering::Relaxed);
+            stop.stop();
         }
         if let Some(handle) = monitor_handle {
             let _ = handle.join();
@@ -1315,7 +1369,7 @@ impl Pipeline {
 
         // 6b. Stop and join the queue rebalancer (if spawned).
         if let Some(stop) = rebalancer_stop {
-            stop.store(true, std::sync::atomic::Ordering::Relaxed);
+            stop.stop();
         }
         if let Some(handle) = rebalancer_handle {
             let _ = handle.join();
@@ -1369,6 +1423,16 @@ impl Pipeline {
 /// (busy-locus group, large sort merge) can legitimately flatten progress for
 /// many seconds, so we only fail after the stall persists well past the warn
 /// window. A real deadlock hangs forever, so waiting longer to be sure is free.
+/// Recommended stall patience for the deadlock monitor, in seconds, for callers
+/// arming it via [`PipelineConfig::with_deadlock_timeout`].
+///
+/// Matches the fused path's `DEFAULT_STALL_BUDGET` so both runtimes bound a
+/// wedge alike, and for the same reason: this catches a PERMANENT wedge, not a
+/// slow source, and the costs are asymmetric — err long.
+///
+/// Not yet the `PipelineConfig::default()` value; see the note there.
+pub const DEFAULT_DEADLOCK_TIMEOUT_SECS: u64 = 60;
+
 const DEADLOCK_FATAL_MULTIPLE: u64 = 6;
 
 /// Total bytes currently held across the **byte-bounded** transport queues and
@@ -1485,9 +1549,11 @@ fn ensure_monitor_visible_transports(
 ///     of hanging forever.
 ///
 /// Exits when `stop` is set (workers joined) or the pipeline is already done.
+#[allow(clippy::too_many_arguments)] // one monitor's worth of shared state; a struct would only rename it
 fn run_deadlock_monitor(
-    stop: &Arc<std::sync::atomic::AtomicBool>,
-    stats: &Arc<PipelineStats>,
+    stop: &Arc<StopSignal>,
+    liveness: &Arc<LivenessCounter>,
+    stats: Option<&Arc<PipelineStats>>,
     contexts: &Arc<crate::runtime::contexts::ChainContexts>,
     signal: &Arc<PipelineSignal>,
     warn_timeout: std::time::Duration,
@@ -1495,17 +1561,17 @@ fn run_deadlock_monitor(
     poll_interval: std::time::Duration,
 ) {
     let mut mon_state = StallMonitorState {
-        last_total: total_progress(stats),
+        last_total: liveness.total(),
         stall_start: std::time::Instant::now(),
         last_warn: None,
     };
-    while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+    while !stop.is_stopped() {
         sleep_until_stop(stop, poll_interval);
-        if stop.load(std::sync::atomic::Ordering::Relaxed) || signal.is_done() {
+        if stop.is_stopped() || signal.is_done() {
             break;
         }
         let now = std::time::Instant::now();
-        let now_total = total_progress(stats);
+        let now_total = liveness.total();
         let progressed = now_total != mon_state.last_total;
         let stall_secs = now.duration_since(mon_state.stall_start).as_secs();
         let stuck = in_flight_bytes(contexts);
@@ -1523,7 +1589,7 @@ fn run_deadlock_monitor(
             stall_secs,
             stuck,
             warn_timeout,
-            stats,
+            stats.map(std::convert::AsRef::as_ref),
             signal,
             &mut mon_state,
         ) {
@@ -1554,7 +1620,11 @@ fn apply_stall_verdict(
     stall_secs: u64,
     stuck: u64,
     warn_timeout: std::time::Duration,
-    stats: &PipelineStats,
+    // Optional: the monitor no longer requires instrumentation to run, so an
+    // uninstrumented run still reports the stall — just without the per-step
+    // snapshot. Losing the snapshot is far better than losing the detection,
+    // which is what requiring `stats` used to cost.
+    stats: Option<&PipelineStats>,
     signal: &PipelineSignal,
     mon_state: &mut StallMonitorState,
 ) -> bool {
@@ -1580,9 +1650,16 @@ fn apply_stall_verdict(
                     "Pipeline stall: no progress for {stall_secs}s with {stuck} bytes \
                      still in flight. Snapshot follows."
                 );
-                let snapshot = stats.snapshot();
-                for line in format!("{snapshot}").lines() {
-                    log::warn!("{line}");
+                if let Some(stats) = stats {
+                    let snapshot = stats.snapshot();
+                    for line in format!("{snapshot}").lines() {
+                        log::warn!("{line}");
+                    }
+                } else {
+                    log::warn!(
+                        "(no per-step snapshot: PipelineConfig::stats is not set; \
+                         attach a stats handle to see which step is stuck)"
+                    );
                 }
                 mon_state.last_warn = Some(now);
             }
@@ -1592,9 +1669,16 @@ fn apply_stall_verdict(
                 "Pipeline deadlock: no progress for {stall_secs}s with {stuck} bytes \
                  stuck in flight; failing the pipeline. Snapshot follows."
             );
-            let snapshot = stats.snapshot();
-            for line in format!("{snapshot}").lines() {
-                log::error!("{line}");
+            if let Some(stats) = stats {
+                let snapshot = stats.snapshot();
+                for line in format!("{snapshot}").lines() {
+                    log::error!("{line}");
+                }
+            } else {
+                log::error!(
+                    "(no per-step snapshot: PipelineConfig::stats is not set; \
+                     attach a stats handle to see which step is stuck)"
+                );
             }
             signal.record_error(PipelineError::TimedOut { stalled_secs: stall_secs });
             signal.cancel();
@@ -1607,11 +1691,6 @@ fn apply_stall_verdict(
 /// Sum of `progress_count + finished_count` across all steps. The
 /// monitor uses this as a single scalar progress watermark; a change
 /// means *some* step is making forward progress.
-fn total_progress(stats: &PipelineStats) -> u64 {
-    let snap = stats.snapshot();
-    snap.steps.iter().map(|(_, s)| s.progress_count + s.finished_count).sum()
-}
-
 /// Sleep up to `dur`, returning early as soon as `stop` is set. Polls the
 /// flag in short slices so a background helper thread (deadlock monitor,
 /// queue rebalancer) exits within tens of milliseconds at teardown instead
@@ -1620,18 +1699,62 @@ fn total_progress(stats: &PipelineStats) -> u64 {
 /// here adds a fixed dead-time tail (up to `poll_interval`) to every run —
 /// negligible on long jobs but a large *relative* regression on short ones
 /// (e.g. FASTQ extract), since the worker pool is already idle and waiting.
-fn sleep_until_stop(stop: &std::sync::atomic::AtomicBool, dur: std::time::Duration) {
-    const SLICE: std::time::Duration = std::time::Duration::from_millis(25);
-    let deadline = std::time::Instant::now() + dur;
-    loop {
-        if stop.load(std::sync::atomic::Ordering::Relaxed) {
-            return;
+fn sleep_until_stop(stop: &StopSignal, dur: std::time::Duration) {
+    // A condvar, not a polled sleep. The previous shape slept in 25ms slices and
+    // re-checked a flag, so teardown waited up to a full slice for the monitor to
+    // notice — dead time on the critical path of *every* run, since `Pipeline::run`
+    // joins this thread before returning.
+    //
+    // That is not a rounding error at the short end. With the monitor armed by
+    // default, a 27ms pipeline measured +80% wall on the dispatch benchmark, and
+    // the excess was almost exactly one slice. Waking the sleeper directly takes
+    // that to zero, which is what makes arming the monitor by default affordable.
+    let (lock, cvar) = (&stop.stopped, &stop.waker);
+    let mut stopped = lock.lock().expect("stop mutex not poisoned");
+    if *stopped {
+        return;
+    }
+    // `Instant::now() + dur` panics when the deadline is not representable (a
+    // caller could pass an enormous `deadlock_timeout_secs`). `Pipeline::run`
+    // discards this thread's join error, so a panic here would silently disarm
+    // the monitor while the run reports success. Guard with `checked_add`: an
+    // unrepresentable deadline means "effectively never", so wait untimed until
+    // `stop()` wakes us — the only teardown path that matters.
+    let Some(deadline) = std::time::Instant::now().checked_add(dur) else {
+        while !*stopped {
+            stopped = cvar.wait(stopped).expect("stop condvar not poisoned");
         }
-        let now = std::time::Instant::now();
-        if now >= deadline {
+        return;
+    };
+    // `wait_timeout` can wake spuriously; the loop re-checks both the flag and
+    // the deadline, so a spurious wake just resumes waiting for the remainder.
+    while !*stopped {
+        let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) else {
             return;
-        }
-        std::thread::sleep(SLICE.min(deadline - now));
+        };
+        let (guard, _) = cvar.wait_timeout(stopped, remaining).expect("stop condvar not poisoned");
+        stopped = guard;
+    }
+}
+
+/// Stop flag for a background helper thread, with a condvar so a waiting thread
+/// wakes the instant it is set rather than on its next poll tick.
+#[derive(Debug, Default)]
+pub(crate) struct StopSignal {
+    stopped: std::sync::Mutex<bool>,
+    waker: std::sync::Condvar,
+}
+
+impl StopSignal {
+    /// Whether `stop` has been called.
+    pub(crate) fn is_stopped(&self) -> bool {
+        *self.stopped.lock().expect("stop mutex not poisoned")
+    }
+
+    /// Set the flag and wake the sleeper immediately.
+    pub(crate) fn stop(&self) {
+        *self.stopped.lock().expect("stop mutex not poisoned") = true;
+        self.waker.notify_all();
     }
 }
 
@@ -1756,7 +1879,7 @@ fn reorder_cap_for(per_queue: u64) -> u64 {
 /// Exits when `stop` is set (typically after workers join).
 #[allow(clippy::cast_precision_loss, clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 fn run_queue_rebalancer(
-    stop: &Arc<std::sync::atomic::AtomicBool>,
+    stop: &Arc<StopSignal>,
     handles: &[Arc<dyn super::queues::BoundedQueueHandle>],
     names: &[&'static str],
 ) {
@@ -1767,9 +1890,9 @@ fn run_queue_rebalancer(
     let poll_interval = std::time::Duration::from_secs(1);
     let shift_fraction: f64 = 0.10;
 
-    while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+    while !stop.is_stopped() {
         sleep_until_stop(stop, poll_interval);
-        if stop.load(std::sync::atomic::Ordering::Relaxed) {
+        if stop.is_stopped() {
             break;
         }
 
@@ -3313,7 +3436,8 @@ mod tests {
     /// must not block for a poll interval afterward.
     #[test]
     fn sleep_until_stop_returns_immediately_when_already_stopped() {
-        let stop = std::sync::atomic::AtomicBool::new(true);
+        let stop = StopSignal::default();
+        stop.stop();
         let start = std::time::Instant::now();
         sleep_until_stop(&stop, std::time::Duration::from_secs(10));
         assert!(
@@ -3328,11 +3452,11 @@ mod tests {
     /// slices), proving it interrupts a long sleep rather than waiting it out.
     #[test]
     fn sleep_until_stop_wakes_when_stopped_midway() {
-        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop = Arc::new(StopSignal::default());
         let stop_clone = Arc::clone(&stop);
         let setter = std::thread::spawn(move || {
             std::thread::sleep(std::time::Duration::from_millis(50));
-            stop_clone.store(true, std::sync::atomic::Ordering::Relaxed);
+            stop_clone.stop();
         });
         let start = std::time::Instant::now();
         sleep_until_stop(&stop, std::time::Duration::from_secs(10));
@@ -3343,12 +3467,34 @@ mod tests {
         assert!(elapsed < std::time::Duration::from_millis(500), "woke too late: {elapsed:?}");
     }
 
+    /// A duration so large that `Instant::now() + dur` is unrepresentable must
+    /// not panic: the helper falls back to an untimed wait and still wakes the
+    /// instant `stop()` fires. Regression test for the `checked_add` guard —
+    /// before it, `Duration::MAX` panicked here and silently disarmed the
+    /// monitor (whose join error `Pipeline::run` discards).
+    #[test]
+    fn sleep_until_stop_survives_an_unrepresentable_deadline() {
+        let stop = Arc::new(StopSignal::default());
+        let stop_clone = Arc::clone(&stop);
+        let setter = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            stop_clone.stop();
+        });
+        let start = std::time::Instant::now();
+        sleep_until_stop(&stop, std::time::Duration::MAX);
+        let elapsed = start.elapsed();
+        setter.join().unwrap();
+        // Woke shortly after the 50ms flag flip, not after an (impossible) MAX wait.
+        assert!(elapsed >= std::time::Duration::from_millis(40), "woke too early: {elapsed:?}");
+        assert!(elapsed < std::time::Duration::from_millis(500), "woke too late: {elapsed:?}");
+    }
+
     /// When `stop` is never set, the helper sleeps for approximately the full
     /// duration (it does not return early). Generous upper bound keeps it
     /// non-flaky on a loaded CI host.
     #[test]
     fn sleep_until_stop_sleeps_full_duration_when_never_stopped() {
-        let stop = std::sync::atomic::AtomicBool::new(false);
+        let stop = StopSignal::default();
         let start = std::time::Instant::now();
         sleep_until_stop(&stop, std::time::Duration::from_millis(100));
         let elapsed = start.elapsed();
@@ -3563,6 +3709,49 @@ mod tests {
         );
     }
 
+    /// Arming the monitor must enforce the monitor-visible-transport invariant
+    /// even with no stats handle attached.
+    ///
+    /// This goes through `Pipeline::run` rather than calling
+    /// `ensure_monitor_visible_transports` directly on purpose: the helper's own
+    /// unit tests above pass whatever condition guards the *call site*, so they
+    /// cannot catch a guard that skips the check. Only a run-level test can.
+    ///
+    /// The failure it pins is silent, which is what makes it worth a test: on a
+    /// blind edge `in_flight_bytes` reports 0, `classify_stall` reads that as
+    /// `Starving`, and `Starving` resets the stall clock on every poll — so an
+    /// armed monitor would watch a wedged pipeline forever and never fail it.
+    ///
+    /// The converse — that a blind transport is still legal on a *disarmed* run
+    /// — needs no test of its own: most chains in this suite pair a
+    /// `CountBounded` edge with the default `deadlock_timeout_secs: 0`, so an
+    /// over-broad guard would fail them by the hundred.
+    #[test]
+    fn pipeline_run_rejects_a_monitor_blind_transport_without_stats() {
+        // `StubSource` declares `CountBounded`, which the byte-accounting probe
+        // cannot see. The chain never terminates (`StubSinkU32` always reports
+        // `NoProgress`), which is fine here and load-bearing for the assertion:
+        // the transport check runs before any worker is spawned, so a passing
+        // run proves the rejection happened at startup rather than after any
+        // work.
+        let builder = PipelineBuilder::new();
+        builder.chain(StubSource).chain(StubSinkU32).into_sink_marker();
+        let pipeline = builder.build().unwrap();
+
+        let err = pipeline
+            .run(PipelineConfig {
+                threads: 2,
+                stats: None,
+                deadlock_timeout_secs: 5,
+                ..Default::default()
+            })
+            .expect_err("an armed monitor on a blind transport must fail the run");
+        assert!(
+            matches!(err, PipelineError::MonitorBlindTransport { step: "Source", .. }),
+            "expected MonitorBlindTransport for the blind source, got {err:?}",
+        );
+    }
+
     #[test]
     fn apply_stall_verdict_wedged_records_timeout_and_cancels() {
         use crate::signal::PipelineError;
@@ -3578,7 +3767,7 @@ mod tests {
             60,
             4096,
             std::time::Duration::from_secs(10),
-            &stats,
+            Some(&stats),
             &signal,
             &mut mon_state,
         );
@@ -3609,7 +3798,7 @@ mod tests {
             15,
             4096,
             warn,
-            &stats,
+            Some(&stats),
             &signal,
             &mut mon_state,
         );
@@ -3626,7 +3815,7 @@ mod tests {
             16,
             4096,
             warn,
-            &stats,
+            Some(&stats),
             &signal,
             &mut mon_state,
         );
@@ -3652,7 +3841,7 @@ mod tests {
             0,
             0,
             warn,
-            &stats,
+            Some(&stats),
             &signal,
             &mut mon_state,
         );
@@ -3672,7 +3861,7 @@ mod tests {
             0,
             0,
             warn,
-            &stats,
+            Some(&stats),
             &signal,
             &mut mon_state,
         );

--- a/crates/fgumi-pipeline-core/src/lib.rs
+++ b/crates/fgumi-pipeline-core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod handles;
 pub mod header;
 pub mod held;
 pub mod item;
+pub mod liveness;
 pub mod outputs;
 pub mod queues;
 pub mod reorder;
@@ -35,8 +36,8 @@ pub mod topology;
 mod tests;
 
 pub use builder::{
-    BuildError, Chain, InstrumentationLevel, MultiChain2, MultiChain2Ordered, MultiChain3,
-    MultiChain4, Pipeline, PipelineBuilder, PipelineConfig,
+    BuildError, Chain, DEFAULT_DEADLOCK_TIMEOUT_SECS, InstrumentationLevel, MultiChain2,
+    MultiChain2Ordered, MultiChain3, MultiChain4, Pipeline, PipelineBuilder, PipelineConfig,
 };
 pub use erased::{ErasedStep, ErasedStepCtx, TypedStep, TypedStep2};
 pub use finalize::FinalizeHook;
@@ -47,6 +48,7 @@ pub use handles::{
 pub use header::{AlreadySetError, HeaderHandle};
 pub use held::HeldSlot;
 pub use item::{HeapSize, Ordered};
+pub use liveness::LivenessCounter;
 pub use outputs::{
     MAX_ARITY, OrderedBytesSingle, OrderedBytesTuple2, OrderedBytesTuple3, Single, StepOutputs,
 };

--- a/crates/fgumi-pipeline-core/src/liveness.rs
+++ b/crates/fgumi-pipeline-core/src/liveness.rs
@@ -1,0 +1,206 @@
+//! A cheap, always-on liveness signal for the deadlock monitor.
+//!
+//! # Why this exists separately from [`PipelineStats`](crate::runtime::stats::PipelineStats)
+//!
+//! The deadlock monitor needs to answer exactly one question: *has anything in
+//! the pipeline made progress since I last looked?* It compares one total
+//! against the previous total and cares about nothing else.
+//!
+//! It used to get that total from `PipelineStats`, which coupled the monitor to
+//! full instrumentation — and full instrumentation is deliberately not free.
+//! `dispatch_one_step` times each dispatch with `Instant::now()` (~20–50 ns on
+//! Apple Silicon, ~50–100 ns on `x86_64`) and gates that on `stats.is_some()`
+//! precisely to keep the uninstrumented path zero-cost. So the monitor could
+//! only be armed by paying a per-dispatch timing cost on every run, which is why
+//! it shipped disarmed by default and every wedge hung silently instead.
+//!
+//! This type breaks that coupling: liveness is a counter, profiling is a
+//! separate opt-in. The monitor can therefore run with no `PipelineStats`
+//! attached at all — a stats handle now only adds the per-step snapshot to the
+//! stall report, and its absence costs the diagnostic, not the detection.
+//!
+//! That removes the *cost* argument for shipping disarmed; it does not by
+//! itself arm anything. `PipelineConfig::default()` still sets
+//! `deadlock_timeout_secs: 0`, because an armed monitor additionally requires
+//! every output transport to be `ByteBounded` (see
+//! [`PipelineError::MonitorBlindTransport`](crate::signal::PipelineError)) and
+//! chains such as `Process2` use `CountBounded` today.
+//!
+//! Both of those are properties of the **scheduled** path. A run that fuses to
+//! a single thread returns before the transport check and before the monitor
+//! spawns, so it neither gains the monitor nor is rejected for a byte-blind
+//! edge; it is bounded by the fused path's own stall budget instead.
+//!
+//! # Why the counter is sharded
+//!
+//! A single shared `AtomicU64` bumped by every worker on every productive
+//! dispatch is a false-sharing hotspot: each increment is a read-modify-write on
+//! one cache line, so N workers ping-pong that line between cores and the cost
+//! grows with thread count — exactly the wrong shape, since more threads is when
+//! the monitor matters most.
+//!
+//! Each worker therefore owns a slot padded to its own cache line, so a bump is
+//! an uncontended increment on a line no other worker touches. The monitor sums
+//! the slots, which it does once per poll interval (seconds), so the read side's
+//! cost is irrelevant.
+//!
+//! The sum is not a synchronized snapshot — slots are read one at a time under
+//! `Relaxed`, so the total may mix values from slightly different instants. That
+//! is fine for the only question asked of it: a torn total still *changes* when
+//! any worker makes progress, and monotonicity per slot means it can never
+//! spuriously appear frozen while work is happening.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Cache-line padding. 128 rather than 64 because Apple Silicon and some `x86_64`
+/// prefetchers pair adjacent 64-byte lines, so a 64-byte stride can still share
+/// a coherence unit.
+const CACHE_LINE_BYTES: usize = 128;
+
+#[repr(align(128))]
+struct PaddedCounter(AtomicU64);
+
+const _: () = assert!(std::mem::size_of::<PaddedCounter>() == CACHE_LINE_BYTES);
+
+/// Per-worker progress counters, summed by the deadlock monitor.
+pub struct LivenessCounter {
+    slots: Box<[PaddedCounter]>,
+    /// `slots.len() - 1`, valid because the slot count is always a power of two.
+    /// The bump path masks with this instead of `%`: a runtime modulo is an
+    /// integer division (tens of cycles on both `aarch64` and `x86_64`) on a path
+    /// that runs once per productive dispatch, which measured as a double-digit
+    /// percentage of dispatch cost.
+    mask: usize,
+}
+
+impl LivenessCounter {
+    /// One slot per worker. `n_workers` must cover every index passed to
+    /// [`Self::bump`]; indices are taken modulo the slot count so an unexpected
+    /// worker id degrades to sharing a slot rather than panicking on the hot
+    /// path.
+    #[must_use]
+    pub fn new(n_workers: usize) -> Self {
+        // Round up to a power of two so the bump path can mask instead of
+        // dividing. The slack is a few unused cache lines — irrelevant next to
+        // removing a division from a per-dispatch path.
+        let n = n_workers.max(1).next_power_of_two();
+        Self { slots: (0..n).map(|_| PaddedCounter(AtomicU64::new(0))).collect(), mask: n - 1 }
+    }
+
+    /// Record one unit of progress for `worker`.
+    ///
+    /// `Relaxed` is sufficient: the value only has to change, and the monitor
+    /// re-reads it on a multi-second cadence, so no ordering relative to other
+    /// memory is required.
+    #[inline]
+    pub fn bump(&self, worker: usize) {
+        // Mask, not modulo — see `mask`. The slot count is a power of two, so
+        // this is exact for in-range ids and wraps harmlessly for anything else.
+        let slot = &self.slots[worker & self.mask];
+        slot.0.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Sum every worker's progress. Called once per monitor poll.
+    #[must_use]
+    pub fn total(&self) -> u64 {
+        self.slots.iter().map(|s| s.0.load(Ordering::Relaxed)).sum()
+    }
+
+    /// Number of slots. This is the requested worker count rounded up to a
+    /// power of two, not the requested count itself.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.slots.len()
+    }
+
+    /// Always false — `new` clamps to at least one slot. Present because clippy
+    /// requires it alongside `len`.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+}
+
+impl std::fmt::Debug for LivenessCounter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Hand-written rather than derived: the per-slot atomics are an
+        // implementation detail, and the only useful facts are how many slots
+        // there are and what they currently sum to.
+        f.debug_struct("LivenessCounter")
+            .field("slots", &self.slots.len())
+            .field("mask", &self.mask)
+            .field("total", &self.total())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn total_sums_every_slot() {
+        let counter = LivenessCounter::new(4);
+        counter.bump(0);
+        counter.bump(1);
+        counter.bump(1);
+        counter.bump(3);
+        assert_eq!(counter.total(), 4);
+    }
+
+    #[test]
+    fn an_out_of_range_worker_wraps_rather_than_panicking() {
+        // The hot path must never panic on an unexpected worker id; sharing a
+        // slot only costs contention, and the total stays correct.
+        let counter = LivenessCounter::new(2);
+        counter.bump(7);
+        assert_eq!(counter.total(), 1);
+    }
+
+    #[test]
+    fn a_single_worker_pipeline_still_gets_a_slot() {
+        let counter = LivenessCounter::new(0);
+        assert_eq!(counter.len(), 1, "the slot count is clamped to at least one");
+        counter.bump(0);
+        assert_eq!(counter.total(), 1);
+    }
+
+    /// Every increment must be observed — the point of the type is that a frozen
+    /// total means a frozen pipeline, so a lost bump would be a false wedge
+    /// report.
+    #[test]
+    fn concurrent_bumps_are_all_counted() {
+        const WORKERS: usize = 8;
+        const PER_WORKER: u64 = 10_000;
+
+        let counter = Arc::new(LivenessCounter::new(WORKERS));
+        let handles: Vec<_> = (0..WORKERS)
+            .map(|w| {
+                let counter = Arc::clone(&counter);
+                std::thread::spawn(move || {
+                    for _ in 0..PER_WORKER {
+                        counter.bump(w);
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("worker thread joins");
+        }
+        assert_eq!(counter.total(), WORKERS as u64 * PER_WORKER);
+    }
+
+    /// Each slot must sit on its own cache line — the whole reason for sharding.
+    #[test]
+    fn slots_are_cache_line_separated() {
+        let counter = LivenessCounter::new(4);
+        let a = std::ptr::from_ref(&counter.slots[0]) as usize;
+        let b = std::ptr::from_ref(&counter.slots[1]) as usize;
+        assert_eq!(
+            b - a,
+            CACHE_LINE_BYTES,
+            "adjacent slots must be a full cache line apart or they false-share",
+        );
+    }
+}

--- a/crates/fgumi-pipeline-core/src/runtime/detached.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/detached.rs
@@ -323,6 +323,7 @@ pub fn run_detached_driver(
     drain_counters: &[Arc<StepDrainCounter>],
     signal: &Arc<PipelineSignal>,
     stats: Option<&Arc<PipelineStats>>,
+    liveness: &crate::liveness::LivenessCounter,
 ) {
     let primary = group.primary_step();
     let mut row = build_driver_storage(group.into_steps(), contexts.inputs.len());
@@ -334,6 +335,7 @@ pub fn run_detached_driver(
         drain_counters,
         signal,
         stats,
+        liveness,
         &DrainFirstScheduler,
     );
 }
@@ -469,7 +471,14 @@ mod tests {
         let drain_counters: Vec<Arc<StepDrainCounter>> =
             (0..contexts.inputs.len()).map(|_| StepDrainCounter::new(1)).collect();
         let group = DetachedDriverGroup::new(vec![(step_idx, step)]);
-        run_detached_driver(group, contexts, &drain_counters, signal, None);
+        run_detached_driver(
+            group,
+            contexts,
+            &drain_counters,
+            signal,
+            None,
+            &crate::liveness::LivenessCounter::new(1),
+        );
     }
 
     /// Items pushed onto a Detached step's input flow through to its output;

--- a/crates/fgumi-pipeline-core/src/runtime/driver.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/driver.rs
@@ -27,6 +27,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crate::erased::ErasedStepCtx;
+use crate::liveness::LivenessCounter;
 use crate::runtime::contexts::ChainContexts;
 use crate::runtime::drain::StepDrainCounter;
 use crate::runtime::live::LiveSteps;
@@ -63,6 +64,7 @@ const STICKY_BURST_LIMIT: usize = 1024;
 /// output close on `Finished` (init N for Parallel so only the last clone
 /// closes the shared output; init 1 for Serial/Exclusive).
 /// `signal` — error/cancel broadcast.
+#[allow(clippy::too_many_arguments)] // per-step shared state plus the liveness shard; a struct would only rename it
 pub fn run_worker_loop(
     worker: &mut WorkerCore,
     entries: &mut [WorkerStepEntry],
@@ -70,6 +72,7 @@ pub fn run_worker_loop(
     drain_counters: &[Arc<StepDrainCounter>],
     signal: &Arc<PipelineSignal>,
     stats: Option<&Arc<PipelineStats>>,
+    liveness: &LivenessCounter,
     scheduler: &dyn Scheduler,
 ) {
     // Per-worker worklist of still-dispatchable steps, in chain order. A step
@@ -141,6 +144,8 @@ pub fn run_worker_loop(
                     &drain_counters[owned_idx.0],
                     signal,
                     stats,
+                    liveness,
+                    worker.thread_id,
                     is_driver,
                 ) else {
                     break; // Skip
@@ -183,6 +188,8 @@ pub fn run_worker_loop(
                 drain_counters,
                 signal,
                 stats,
+                liveness,
+                worker.thread_id,
                 scheduler.walk(),
                 is_driver,
             );
@@ -260,6 +267,8 @@ fn round_robin_dispatch(
     drain_counters: &[Arc<StepDrainCounter>],
     signal: &Arc<PipelineSignal>,
     stats: Option<&Arc<PipelineStats>>,
+    liveness: &LivenessCounter,
+    worker_slot: usize,
     walk: WalkDirection,
     is_driver: bool,
 ) -> RoundRobinOutcome {
@@ -294,6 +303,8 @@ fn round_robin_dispatch(
             &drain_counters[step_idx.0],
             signal,
             stats,
+            liveness,
+            worker_slot,
             is_driver,
         ) else {
             continue; // Skip (build-time placeholder; should not appear in `live`)
@@ -365,6 +376,7 @@ struct DispatchInfo {
 /// `Finished` here rather than re-`try_lock`-ing and re-running an already-done
 /// step. The winning worker sets the latch under the dispatch guard before
 /// `mark_outputs_drained`, so a non-idempotent flusher can never be re-entered.
+#[allow(clippy::too_many_arguments)] // per-step shared state plus the liveness shard; a struct would only rename it
 fn dispatch_one_step(
     entry: &mut WorkerStepEntry,
     step_idx: StepIdx,
@@ -372,6 +384,12 @@ fn dispatch_one_step(
     counter: &StepDrainCounter,
     signal: &Arc<PipelineSignal>,
     stats: Option<&Arc<PipelineStats>>,
+    // Always-on liveness signal for the deadlock monitor, sharded per worker so
+    // the bump is an uncontended increment. Separate from `stats` on purpose:
+    // liveness must be free enough to leave armed, while `stats` pays for
+    // per-dispatch timing and stays opt-in. See `crate::liveness`.
+    liveness: &LivenessCounter,
+    worker_slot: usize,
     // When true (a dedicated driver thread), attribute this dispatch's wall time
     // to the off-pool detached line keyed by `step_idx` — so each grouped step
     // reports its own busy. Pool workers pass `false` and record aggregate busy
@@ -457,6 +475,17 @@ fn dispatch_one_step(
         WorkerStepEntry::Skip => None,
     };
 
+    // Liveness first, and unconditionally: this is what the deadlock monitor
+    // samples, so it must not depend on `stats` being attached. Only productive
+    // outcomes count — a wedged pipeline still spins through `NoProgress` and
+    // `Contention` dispatches forever, so counting those would make a wedge look
+    // alive and defeat the whole detector.
+    if let Some(i) = info.as_ref()
+        && matches!(i.result, Ok(StepOutcome::Progress | StepOutcome::Finished))
+    {
+        liveness.bump(worker_slot);
+    }
+
     if let (Some(stats), Some(start)) = (stats, start) {
         let elapsed_ns = u64::try_from(start.elapsed().as_nanos()).unwrap_or(u64::MAX);
         // Wall ns at dispatch start, relative to pipeline start.
@@ -517,6 +546,7 @@ mod tests {
             &drain_counters,
             &signal,
             None,
+            &crate::liveness::LivenessCounter::new(1),
             &crate::runtime::scheduler::ChainOrderScheduler,
         );
         // If we reach this line, the loop exited cleanly.
@@ -713,8 +743,18 @@ mod tests {
                 !InputHandle::is_drained(sink_input),
                 "downstream input drained before the last clone finished (after {i} of {N})"
             );
-            let info =
-                dispatch_one_step(clone, mid, &contexts, &counter, &signal, None, false).unwrap();
+            let info = dispatch_one_step(
+                clone,
+                mid,
+                &contexts,
+                &counter,
+                &signal,
+                None,
+                &LivenessCounter::new(1),
+                0,
+                false,
+            )
+            .unwrap();
             assert!(matches!(info.result, Ok(StepOutcome::Finished)));
         }
         assert!(
@@ -744,8 +784,18 @@ mod tests {
         // Worker 1 finishes the step: runs once, sets the latch.
         let mut entry1 =
             WorkerStepEntry::Shared { step: Arc::clone(&shared), drain: Arc::clone(&drain) };
-        let info1 =
-            dispatch_one_step(&mut entry1, mid, &contexts, &counter, &signal, None, false).unwrap();
+        let info1 = dispatch_one_step(
+            &mut entry1,
+            mid,
+            &contexts,
+            &counter,
+            &signal,
+            None,
+            &LivenessCounter::new(1),
+            0,
+            false,
+        )
+        .unwrap();
         assert!(matches!(info1.result, Ok(StepOutcome::Finished)));
         assert_eq!(runs.load(Ordering::Relaxed), 1, "step ran exactly once on the first worker");
         assert!(drain.is_finished(), "first finisher must set the DrainGate latch");
@@ -753,8 +803,18 @@ mod tests {
         // Worker 2 dispatches the same step: short-circuit, no re-run.
         let mut entry2 =
             WorkerStepEntry::Shared { step: Arc::clone(&shared), drain: Arc::clone(&drain) };
-        let info2 =
-            dispatch_one_step(&mut entry2, mid, &contexts, &counter, &signal, None, false).unwrap();
+        let info2 = dispatch_one_step(
+            &mut entry2,
+            mid,
+            &contexts,
+            &counter,
+            &signal,
+            None,
+            &LivenessCounter::new(1),
+            0,
+            false,
+        )
+        .unwrap();
         assert!(matches!(info2.result, Ok(StepOutcome::Finished)));
         assert_eq!(
             info2.name, "<finished-serial-step>",
@@ -806,6 +866,7 @@ mod tests {
             &drain_counters,
             &signal,
             None,
+            &crate::liveness::LivenessCounter::new(1),
             &crate::runtime::scheduler::ChainOrderScheduler,
         );
     }
@@ -867,6 +928,7 @@ mod tests {
             &drain_counters,
             &signal,
             None,
+            &crate::liveness::LivenessCounter::new(1),
             &crate::runtime::scheduler::ChainOrderScheduler,
         );
 
@@ -1008,6 +1070,7 @@ mod tests {
             &drain_counters,
             &signal,
             None,
+            &crate::liveness::LivenessCounter::new(1),
             &crate::runtime::scheduler::ChainOrderScheduler,
         );
         done.store(true, Ordering::SeqCst);
@@ -1165,6 +1228,7 @@ mod tests {
             &drain_counters,
             &signal,
             None,
+            &crate::liveness::LivenessCounter::new(1),
             &crate::runtime::scheduler::ChainOrderScheduler,
         );
         done.store(true, Ordering::SeqCst);
@@ -1234,8 +1298,17 @@ mod tests {
         // to step 0 (not some group primary).
         let stats = Arc::new(PipelineStats::new(vec!["SlowFinish", "Sink"]));
         let mut entry = WorkerStepEntry::Owned { step: Box::new(TypedStep::new(SlowFinish)) };
-        let _ =
-            dispatch_one_step(&mut entry, mid, &contexts, &counter, &signal, Some(&stats), true);
+        let _ = dispatch_one_step(
+            &mut entry,
+            mid,
+            &contexts,
+            &counter,
+            &signal,
+            Some(&stats),
+            &LivenessCounter::new(1),
+            0,
+            true,
+        );
         let snap = stats.snapshot();
         assert!(
             snap.detached.iter().any(|&(step, name, busy, ..)| {
@@ -1259,6 +1332,8 @@ mod tests {
             &counter_pool,
             &signal,
             Some(&stats_pool),
+            &LivenessCounter::new(1),
+            0,
             false,
         );
         assert!(


### PR DESCRIPTION
Makes the pipeline's deadlock monitor cheap enough to arm, and adds the benchmark that proves it. Split out of the #736 review — that PR fixed one *producer* of gapped ordinals; this one is about the framework's response to a wedge from any producer.

## The problem

The scheduled runtime's deadlock monitor ships disarmed (`deadlock_timeout_secs: 0`), so a wedged pipeline hangs silently and forever — measured directly while reviewing #736: a gapped ordinal sequence ran past 120s with no diagnostic. The fused path, which has no monitor, carries an unremovable 60s stall bound precisely because it knows nothing would otherwise catch it. The two runtimes disagree about whether a wedge should be survivable, and the one every multi-threaded run uses is the unprotected one.

It was disarmed for a reason, though — arming it cost real throughput. This removes both costs.

## Liveness no longer rides on instrumentation

The monitor needs one fact: has anything progressed since the last poll? It read that from `PipelineStats`, which is deliberately not free — `dispatch_one_step` times every dispatch with `Instant::now()` (~20–50ns aarch64, ~50–100ns x86_64) and gates it on `stats.is_some()` to keep the uninstrumented path zero-cost. Arming the monitor therefore meant buying per-dispatch timing for a fact that is one integer.

`LivenessCounter` supplies it directly: one counter per worker, each padded to its own cache line so a bump is an uncontended increment on a line nobody else touches, summed by the monitor once per poll interval. A single shared atomic would have been a false-sharing hotspot that got worse with thread count — the wrong shape, since more threads is when a wedge matters most. Profiling stays opt-in.

## Teardown no longer polls

`sleep_until_stop` slept in 25ms slices and re-checked a flag, so `Pipeline::run` waited up to a full slice for the monitor to notice the stop before joining it — dead time on the critical path of **every** run. A condvar wakes it immediately. The existing comment already predicted this shape ("a fixed dead-time tail … a large *relative* regression on short ones"); the slices made it smaller, not absent.

## Measurements

No command drives the typed pipeline on this branch yet and it had no benchmark, so a hot-path change was unmeasurable. `benches/pipeline_dispatch.rs` closes that: a near-no-op chain whose wall time is dominated by scheduler loop, queue push/pop, and reorder — read it as relative-only, since real steps do BGZF decode and parsing that dwarf dispatch.

Run on a quiet `c8g.4xlarge` (aarch64), three reps per configuration against one shared baseline, with a **clean-vs-clean control first** to establish the noise floor:

| configuration | 1 thread | 4 threads | 8 threads |
| --- | --- | --- | --- |
| control (identical code) | −0.8% | −7.9% | +2.1% |
| liveness counter alone | +8.3 / +1.6 / +0.3% | +6.2 / −1.6 / −9.8% | −6.0 / −0.1 / −2.8% |
| monitor armed, polled teardown | +1.8 / +11.8 / +2.4% | **+80.7 / +79.8 / +80.7%** | **+23.41 / +23.41 / +23.42%** |
| monitor armed, condvar teardown | +13.3 / +11.6 / +2.3% | +2.2 / +6.3 / +2.4% | −2.0 / −2.2 / +1.5% |

The counter's numbers scatter across reps and straddle zero — that is drift, not cost. The polled-teardown numbers reproduce to three significant figures, which is what makes them a real regression, and they match the mechanism: ~one 25ms slice added to a 27ms run. After the condvar they fall back inside the control's own spread.

Worth stating plainly: the first attempt at this measurement was run on a loaded laptop and produced +84%/+291%/+221% **for identical code**. The control run is the only reason that was caught, and it is why the table above leads with one.

## Why the default is still 0

Neither cost blocks it any more. `MonitorBlindTransport` does: an armed monitor *rejects* any chain with a non-`ByteBounded` edge, because its stall verdict counts bytes in flight to tell "idle waiting on a slow source" from "wedged". `Process2` uses `CountBounded`, so flipping the default today would fail those chains outright rather than watch them. Teaching the verdict to handle byte-blind edges is a separate change; this PR makes it the *only* remaining blocker, and exports `DEFAULT_DEADLOCK_TIMEOUT_SECS` for callers who want to arm it now on byte-bounded chains.

## Notes for review

- `apply_stall_verdict` takes `Option<&PipelineStats>` now: an uninstrumented run still reports the stall, just without the per-step snapshot. Losing the snapshot beats losing the detection.
- `LivenessCounter::bump` masks rather than takes a modulo; slot counts round up to a power of two. A runtime integer division per productive dispatch is the wrong thing to put there regardless of what the benchmark can resolve.
- The `#[allow(clippy::too_many_arguments)]` additions are the liveness shard threading through `dispatch_one_step` / `run_worker_loop`; a parameter struct would rename the problem, not fix it.

Full gate green: fmt, clippy, tag-literals, `RUSTDOCFLAGS="-D warnings"` doc, publish-check, 8327 tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: command output changes—none; `unsafe` changes—none, so no `CLAUDE.md` allowlist update; memory or queue bounds and thread/backpressure policy—none. Fix: decouple deadlock monitoring from `PipelineStats` with cache-padded `LivenessCounter`s and replace teardown polling with condition-variable shutdown.

- Add public `LivenessCounter` and `DEFAULT_DEADLOCK_TIMEOUT_SECS`.
- Propagate liveness state through worker, detached-driver, and single-thread paths.
- Validate monitor-blind transports only when monitoring is enabled.
- Add stats-less monitoring diagnostics and `Duration::MAX` deadline handling.
- Add the `pipeline_dispatch` benchmark.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->