### PR TITLE
fix(compare): qualify the content-mode diff count when pairing stopped early

### DIFF
--- a/src/lib/commands/compare/bams.rs
+++ b/src/lib/commands/compare/bams.rs
@@ -623,6 +623,33 @@ pub(crate) fn start_raw_batch_reader(
     Ok((rx, header))
 }
 
+/// Renders the `Content diffs:` line of the content-mode report.
+///
+/// `content_diffs` counts only the pairs compared *before* the first `RecordKey`
+/// mismatch: pairing stops at the first desync and never resyncs, so every record from
+/// there on is left unexamined (see
+/// [`PositionalOutcome`](super::engines::positional::PositionalOutcome)). Unqualified,
+/// `Content diffs: 0` on such a run reads as "these files have no content differences",
+/// close to the opposite of what was established. So when `key_mismatch_at` is set the
+/// count carries the size of the prefix it actually covers; when pairing ran to
+/// completion it covers every index-paired record and the line is exactly what it has
+/// always been. (Pairing running to completion is not the same as both files being fully
+/// examined: an unequal record count leaves the longer file's tail unpaired. That case is
+/// already explicit one line above, in `Record counts: {bam1} vs {bam2}`, which a
+/// truncated pairing has no counterpart for.)
+fn content_diffs_line(content_diffs: u64, key_mismatch_at: Option<u64>) -> String {
+    let Some(records_compared) = key_mismatch_at else {
+        return format!("Content diffs: {content_diffs}");
+    };
+    // `key_mismatch_at` is the 0-based index of the first mismatching pair, hence also
+    // the number of pairs examined before the stop.
+    let plural = if records_compared == 1 { "" } else { "s" };
+    format!(
+        "Content diffs: {content_diffs} \
+         (of {records_compared} record{plural} compared before pairing stopped)"
+    )
+}
+
 impl Command for CompareBams {
     fn execute(&self, _command_line: &str) -> Result<()> {
         validate_file_exists(&self.bam1, "First BAM")?;
@@ -851,7 +878,7 @@ impl CompareBams {
             println!("BAM2: {}", self.bam2.display());
             println!();
             println!("Record counts: {} vs {}", outcome.bam1_count, outcome.bam2_count);
-            println!("Content diffs: {}", outcome.content_diffs);
+            println!("{}", content_diffs_line(outcome.content_diffs, outcome.key_mismatch_at));
             if let Some(index) = outcome.key_mismatch_at {
                 println!("First RecordKey mismatch: record {index} (pairing stopped)");
             }
@@ -1289,5 +1316,54 @@ mod tests {
         assert_eq!(MiKey::Int(42).to_string(), "42");
         assert_eq!(MiKey::Strand { base: 3, strand: b'A' }.to_string(), "3/A");
         assert_eq!(MiKey::Strand { base: 3, strand: b'B' }.to_string(), "3/B");
+    }
+
+    // ==================== content-mode summary line ====================
+
+    /// The happy path — pairing ran to completion — must keep the line byte-for-byte
+    /// what it has always been: with no key mismatch the count covers every index-paired
+    /// record, and downstream tooling greps this report.
+    #[rstest]
+    #[case(0, "Content diffs: 0")]
+    #[case(7, "Content diffs: 7")]
+    fn content_diffs_line_is_unqualified_when_pairing_completed(
+        #[case] content_diffs: u64,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(content_diffs_line(content_diffs, None), expected);
+    }
+
+    /// A truncated comparison must say so on the same line as the count: `Content diffs: 0`
+    /// alone reads as "these files have no content differences", which is close to the
+    /// opposite of what a stopped pairing establishes (fulcrumgenomics/fgumi#747).
+    #[test]
+    fn content_diffs_line_qualifies_count_when_pairing_stopped_early() {
+        assert_eq!(
+            content_diffs_line(0, Some(2_468_528)),
+            "Content diffs: 0 (of 2468528 records compared before pairing stopped)"
+        );
+    }
+
+    /// `key_mismatch_at` is the 0-based index of the first mismatching pair, so it is
+    /// also the number of pairs examined before the stop: a mismatch at record 0 means
+    /// nothing was compared at all, and a mismatch at record 1 means exactly one was.
+    #[rstest]
+    #[case(0, "Content diffs: 0 (of 0 records compared before pairing stopped)")]
+    #[case(1, "Content diffs: 0 (of 1 record compared before pairing stopped)")]
+    fn content_diffs_line_counts_records_compared_before_the_stop(
+        #[case] key_mismatch_at: u64,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(content_diffs_line(0, Some(key_mismatch_at)), expected);
+    }
+
+    /// Diffs found before the stop are still reported; the qualifier bounds what the
+    /// count covers, it does not replace it.
+    #[test]
+    fn content_diffs_line_keeps_a_nonzero_count_when_pairing_stopped_early() {
+        assert_eq!(
+            content_diffs_line(3, Some(12)),
+            "Content diffs: 3 (of 12 records compared before pairing stopped)"
+        );
     }
 }

--- a/tests/integration/test_compare_bams.rs
+++ b/tests/integration/test_compare_bams.rs
@@ -219,6 +219,74 @@ fn test_content_mode_different_mi_tags() {
     );
 }
 
+/// The reported `Content diffs:` count must say how much of the file it covers whenever
+/// pairing stopped early (fulcrumgenomics/fgumi#747). Here the two files agree on records
+/// 0 and 1 and desync at record 2, so the content comparison examined two records and
+/// found no diff — `Content diffs: 0` on its own would read as "these files have no
+/// content differences", which is the line that gets copied into summaries.
+///
+/// Driven through the real CLI rather than the formatter's unit tests because the defect
+/// being pinned is the *wiring*: a report that formats the qualifier correctly but passes
+/// `None` for the stop index is exactly the reported bug, and it would leave those unit
+/// tests green.
+#[test]
+fn test_content_mode_report_qualifies_diff_count_when_pairing_stopped_early() {
+    let tmp = TempDir::new().unwrap();
+    let header = create_minimal_header("chr1", 10000);
+
+    let shared = vec![mapped_record(b"read1", 100), mapped_record(b"read2", 200)];
+    let mut records1 = shared.clone();
+    records1.push(mapped_record(b"read3", 300));
+    let mut records2 = shared;
+    records2.push(mapped_record(b"read4", 300));
+
+    let bam1 = tmp.path().join("a.bam");
+    let bam2 = tmp.path().join("b.bam");
+    write_bam(&bam1, &header, &records1);
+    write_bam(&bam2, &header, &records2);
+
+    let (code, stdout, _stderr) = run_compare(&bam1, &bam2, "content", &[]);
+    assert_eq!(code, Some(1), "a desync must still DIFFER, stdout:\n{stdout}");
+    let content_diffs_line = stdout
+        .lines()
+        .find(|line| line.starts_with("Content diffs: "))
+        .unwrap_or_else(|| panic!("expected a `Content diffs: ` line, got:\n{stdout}"));
+    assert_eq!(
+        content_diffs_line,
+        "Content diffs: 0 (of 2 records compared before pairing stopped)"
+    );
+}
+
+/// The counterpart to the test above: when pairing runs to completion the count needs no
+/// qualifier, so the line must stay exactly what downstream tooling has always grepped.
+/// Both files here differ at record 1 in position only — same `RecordKey`, so pairing
+/// never stops and the single content diff covers every paired record.
+#[test]
+fn test_content_mode_report_leaves_diff_count_unqualified_when_pairing_completed() {
+    let tmp = TempDir::new().unwrap();
+    let header = create_minimal_header("chr1", 10000);
+
+    let records1 = vec![mapped_record(b"read1", 100), mapped_record(b"read2", 200)];
+    let records2 = vec![mapped_record(b"read1", 100), mapped_record(b"read2", 250)];
+
+    let bam1 = tmp.path().join("a.bam");
+    let bam2 = tmp.path().join("b.bam");
+    write_bam(&bam1, &header, &records1);
+    write_bam(&bam2, &header, &records2);
+
+    let (code, stdout, _stderr) = run_compare(&bam1, &bam2, "content", &[]);
+    assert_eq!(code, Some(1), "a content diff must DIFFER, stdout:\n{stdout}");
+    let content_diffs_line = stdout
+        .lines()
+        .find(|line| line.starts_with("Content diffs: "))
+        .unwrap_or_else(|| panic!("expected a `Content diffs: ` line, got:\n{stdout}"));
+    assert_eq!(content_diffs_line, "Content diffs: 1");
+    assert!(
+        !stdout.contains("pairing stopped"),
+        "no key mismatch here, so nothing may claim pairing stopped:\n{stdout}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Grouping mode tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #747.

## What

`compare bams` content mode pairs records by index and stops at the first `RecordKey` mismatch, never resyncing — so `PositionalOutcome::content_diffs` counts only the records paired *before* that stop. The struct documents exactly that; the printed summary did not. A run that examined 2,468,528 of 103,045,729 records reported a bare `Content diffs: 0`, which in isolation reads as "these files have no content differences" — close to the opposite of what the comparison established. The `RESULT: BAM files DIFFER` verdict was always correct; the count line is the one that gets copied into summaries.

The count now names the prefix it actually covers whenever `key_mismatch_at` is set:

```
Record counts: 103045729 vs 103045851
Content diffs: 0 (of 2468528 records compared before pairing stopped)
First RecordKey mismatch: record 2468528 (pairing stopped)
```

When pairing ran to completion the line is byte-for-byte what it has always been, so nothing grepping the completed-pairing report changes, and the `RESULT:` contract is untouched either way.

## How

The formatting is extracted into a pure `content_diffs_line(content_diffs, key_mismatch_at)` rather than inlined into the `println!`, so both branches are unit-testable directly instead of only through a subprocess capturing stdout. `key_mismatch_at` is the 0-based index of the first mismatching pair, hence also the number of pairs examined before the stop — that identity is what the qualifier reports, and it is pinned by its own cases (index 0 → "0 records", index 1 → the singular "1 record").

Two notes on the rendering, both deliberate:

- The count is printed unseparated (`2468528`, not `2,468,528` as sketched in the issue) to match the adjacent `Record counts:` line and every other number in these reports; the repo has no thousands-separator helper and adding one for a single line would make this report internally inconsistent.
- The qualifier repeats "pairing stopped" from the line below it. That redundancy is the point — the failure being fixed is this line being read on its own.

## Tests

Six `#[rstest]`/`#[test]` cases on `content_diffs_line` covering the unqualified branch, the qualified branch, singular/zero record counts, and a non-zero diff count surviving the qualifier. Plus two subprocess tests in `tests/integration/test_compare_bams.rs`: one pinning that a real desync report carries the qualifier (a report that formats it correctly but passes `None` for the stop index is precisely the reported bug, and would leave the unit tests green), and one pinning that a completed pairing leaves the line unqualified and never claims pairing stopped.

`cargo ci-fmt`, `cargo ci-lint`, `cargo ci-test` (7502 passed), `cargo ci-doctest` and `RUSTDOCFLAGS=-D warnings cargo ci-doc` all pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: `compare bams` content-mode output changes; tests pin qualified early-stop counts, while completed output and `RESULT:` remain unchanged; `unsafe`: none, so the `CLAUDE.md` allowlist is unchanged; memory bounds, queue capacity, and thread/backpressure policy: none.

Fix: Added `content_diffs_line` and unit and integration tests for early desynchronization, completed pairing, zero and non-zero counts, and singular/plural wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->