### PR TITLE
docs(cli): correct the TieRuleArg default and pin it with a test

### DIFF
--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -54,15 +54,17 @@ impl From<MethylationModeArg> for fgumi_consensus::MethylationMode {
 pub enum TieRuleArg {
     /// No-call a maximum separated from the runner-up by only a few ULPs.
     ///
-    /// The default. A separation that small is summation-order noise rather than evidence,
-    /// and the rule is independent of both read order and family depth.
+    /// A separation that small is summation-order noise rather than evidence, and the rule is
+    /// independent of both read order and family depth — the better rule on the merits, but
+    /// not the fgbio-compatible one, which is why it is not the default.
     #[value(name = "ulp-relative")]
     UlpRelative,
     /// Reproduce fgbio's tie rule exactly, defects included.
     ///
-    /// For byte-parity with fgbio output — chiefly cross-tool equivalency testing. Inherits
-    /// fgbio's order dependence and scale dependence, so it will call a base off one ULP of
-    /// accumulation noise.
+    /// The default: fgumi is a drop-in replacement for fgbio, so matching its output is the
+    /// contract. For byte-parity with fgbio output — chiefly cross-tool equivalency testing.
+    /// Inherits fgbio's order dependence and scale dependence, so it will call a base off one
+    /// ULP of accumulation noise.
     #[default]
     #[value(name = "fgbio-compat")]
     FgbioCompat,
@@ -681,7 +683,7 @@ impl Default for ConsensusCallingOptions {
             output_per_base_tags: true,
             trim: false,
             min_consensus_base_quality: 2,
-            tie_rule: TieRuleArg::default(),
+            tie_rule: TieRuleArg::FgbioCompat,
         }
     }
 }
@@ -2310,6 +2312,53 @@ mod tests {
     fn test_overlapping_bases_parsing(#[case] args: &[&str], #[case] expected: bool) {
         let cmd = TestBoolFlags::try_parse_from(args).expect("valid CLI args should parse");
         assert_eq!(cmd.overlapping.consensus_call_overlapping_bases, expected);
+    }
+
+    /// The tie-rule default is `fgbio-compat`, and all three declarations of it agree.
+    ///
+    /// It is declared three times, independently: `#[default]` on the [`TieRuleArg`]
+    /// variant, `default_value = "fgbio-compat"` on the `--tie-rule` arg, and the
+    /// hand-written [`ConsensusCallingOptions::default`]. Nothing tied them together,
+    /// which is how the variant doc came to claim `ulp-relative` was the default long
+    /// after #666 switched it — a wrong doc on the flag that decides whether fgumi
+    /// reproduces fgbio's base calls.
+    ///
+    /// Pinning the *value* matters as much as pinning the agreement: `fgbio-compat` is
+    /// a compatibility contract, so a silent flip would change consensus output on
+    /// near-ties rather than fail anything.
+    #[test]
+    fn tie_rule_defaults_to_fgbio_compat_everywhere() {
+        assert_eq!(
+            TieRuleArg::default(),
+            TieRuleArg::FgbioCompat,
+            "the #[default] variant must stay fgbio-compat",
+        );
+        assert_eq!(
+            TestBoolFlags::try_parse_from(["test"]).expect("no args parses").consensus.tie_rule,
+            TieRuleArg::FgbioCompat,
+            "clap's default_value must agree with the #[default] variant",
+        );
+        assert_eq!(
+            ConsensusCallingOptions::default().tie_rule,
+            TieRuleArg::FgbioCompat,
+            "the hand-written Default impl must agree too",
+        );
+    }
+
+    /// The two `TieRuleArg` variants must map onto the matching
+    /// [`fgumi_consensus::TieRule`] variants.
+    ///
+    /// The CLI enum mirrors the domain enum, so the `From` impl is the seam where a
+    /// mirrored pair could be crossed — and crossing them would silently select the
+    /// opposite tie rule rather than fail to compile.
+    #[rstest]
+    #[case::ulp_relative(TieRuleArg::UlpRelative, fgumi_consensus::TieRule::UlpRelative)]
+    #[case::fgbio_compat(TieRuleArg::FgbioCompat, fgumi_consensus::TieRule::FgbioCompat)]
+    fn tie_rule_arg_maps_onto_the_matching_domain_variant(
+        #[case] arg: TieRuleArg,
+        #[case] expected: fgumi_consensus::TieRule,
+    ) {
+        assert_eq!(fgumi_consensus::TieRule::from(arg), expected);
     }
 
     #[rstest]


### PR DESCRIPTION
The `--tie-rule` variant docs claimed `ulp-relative` was the default. It has not been since #666 ("restore fgbio-identical near-tie calls by default"), which moved `#[default]` to `FgbioCompat` and set `default_value = "fgbio-compat"` but left the variant doc comment untouched.

This is not a typo-class fix: `--tie-rule` decides whether fgumi reproduces fgbio's base calls on near-ties, and the doc told readers the opposite of what the tool does. Anyone reading the enum to decide whether they needed the flag would have concluded, wrongly, that fgumi defaults away from fgbio parity.

## Which side was stale

Two independent corroborations that the attribute is right and the prose is wrong, both from the same commit that introduced the drift:

- The `--tie-rule` field doc in `ConsensusCallingOptions` already says `` `fgbio-compat` (default)``.
- The domain enum `fgumi_consensus::TieRule` documents the same choice **correctly** — "The default:" sits on `FgbioCompat`.

So only the CLI mirror drifted. Both variants are reworded to match the domain enum's phrasing rather than newly invented text, which keeps the two enums readable side by side.

## Why a doc fix carries tests

The default is declared **three times, independently**, with nothing tying them together:

1. `#[default]` on the `TieRuleArg` variant
2. `default_value = "fgbio-compat"` on the `--tie-rule` arg
3. the hand-written `ConsensusCallingOptions::default`

That is the channel this drift came through, and nothing pinned the value at all. `tie_rule_defaults_to_fgbio_compat_everywhere` asserts all three agree *and* that the value is `fgbio-compat` — pinning the value matters as much as pinning the agreement, because `fgbio-compat` is a compatibility contract and a silent flip would change consensus output on near-ties rather than fail anything.

A second `#[rstest]` case table pins the `From<TieRuleArg> for TieRule` mapping. The CLI enum mirrors the domain enum, so that impl is the seam where the mirrored pair could be crossed — and crossing it would select the opposite tie rule silently rather than fail to compile.

The guard was verified by mutation: moving `#[default]` to `UlpRelative` fails the test with `left: UlpRelative, right: FgbioCompat`.

## Verification

- `cargo ci-test` — 7497 passed, 0 failures
- `cargo ci-fmt`, `cargo ci-lint`, `cargo ci-tag-literals` — clean
- `RUSTDOCFLAGS="-D warnings" cargo ci-doc` — clean
- `./scripts/publish-crates.sh --check` — clean

## Scope

`main-runall` and the three open PR branches stacked on it all carry the same stale doc, since they descend from `main`. Only `main` is fixed here; the integration branch picks it up on its next sync, which avoids four conflicting copies of the same edit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: command output changes none; `unsafe` changes none and `CLAUDE.md` allowlist changes none; memory bounds, queue capacity, and thread/backpressure policy changes none.

Fix: Correct `TieRuleArg` documentation and verify `fgbio-compat` defaults and CLI-to-domain mappings.

- Added coverage for enum, Clap, and `ConsensusCallingOptions` defaults.
- Confirmed both CLI variants map to the correct domain variants.
- Tests, formatting, linting, documentation, and crate-publishing checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->