### PR TITLE
fix(codec): emit the five codec stats rows fgbio reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,9 +53,16 @@ All notable changes to this project will be documented in this file.
   `duplex_disagreement_rate` — using fgbio's key names, descriptions and row order, so a diff
   of the two tools' stats files reports value differences rather than absent keys.
   `duplex_disagreement_rate` is the headline strand-concordance signal for a duplex run and
-  previously had to be reconstructed by hand from per-read `ac`/`bc` tags. Relatedly,
-  `consensus_bases_emitted` was never incremented and so reported 0 everywhere it was
-  surfaced, including the run log ([#748](https://github.com/fulcrumgenomics/fgumi/issues/748)).
+  previously had to be reconstructed by hand from per-read `ac`/`bc` tags
+  ([#748](https://github.com/fulcrumgenomics/fgumi/issues/748)).
+
+  Two counters behind those rows were also wrong. `consensus_bases_emitted` was never
+  incremented and so reported 0 everywhere it was surfaced, including the run log. And
+  `consensus_duplex_bases_emitted` / `duplex_disagreement_base_count` were accumulated before
+  the high-duplex-disagreement check rather than after it, so molecules that were *rejected*
+  for disagreeing were counted as emitted — inflating the logged `duplex_disagreement_rate` by
+  exactly the templates it is meant to exclude. All three now count only emitted consensus
+  reads, matching fgbio.
 
 - `dedup --metrics` now reports the templates dropped by its template filter, broken out by
   reason. `dedup` is a read filter as well as a duplicate marker, but the drop counts were

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+- `codec --stats` now writes the five codec-specific rows fgbio's `CallCodecConsensusReads
+  --stats` writes — `consensus_reads_rejected_hdd`, `consensus_bases_emitted`,
+  `consensus_duplex_bases_emitted`, `duplex_disagreement_base_count` and
+  `duplex_disagreement_rate` — using fgbio's key names, descriptions and row order, so a diff
+  of the two tools' stats files reports value differences rather than absent keys.
+  `duplex_disagreement_rate` is the headline strand-concordance signal for a duplex run and
+  previously had to be reconstructed by hand from per-read `ac`/`bc` tags. Relatedly,
+  `consensus_bases_emitted` was never incremented and so reported 0 everywhere it was
+  surfaced, including the run log ([#748](https://github.com/fulcrumgenomics/fgumi/issues/748)).
+
 - `dedup --metrics` now reports the templates dropped by its template filter, broken out by
   reason. `dedup` is a read filter as well as a duplicate marker, but the drop counts were
   collected, merged across workers, and then discarded at the serialization boundary: a run

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -927,6 +927,7 @@ impl CodecConsensusCaller {
         )?;
 
         self.stats.consensus_reads_generated += 1;
+        self.stats.consensus_bases_emitted += consensus.bases.len() as u64;
         Ok(output)
     }
 
@@ -2943,6 +2944,76 @@ mod tests {
             false,
             true,
         )
+    }
+
+    /// Permissive disagreement thresholds that accept
+    /// [`duplex_disagreement_fixture`], so it is consensus-called rather than
+    /// rejected.
+    fn permissive_disagreement_options() -> CodecConsensusOptions {
+        CodecConsensusOptions {
+            min_reads_per_strand: 1,
+            min_duplex_length: 1,
+            max_duplex_disagreements: usize::MAX,
+            max_duplex_disagreement_rate: 1.0,
+            ..Default::default()
+        }
+    }
+
+    /// `consensus_bases_emitted` must total the bases of the consensus reads the
+    /// caller actually emits, mirroring fgbio's `totalConsensusBases +=
+    /// consensus.length` inside the accepted branch
+    /// (`CodecConsensusCaller.scala:266`). The field existed, was merged across
+    /// threads and was logged, but nothing ever incremented it, so it reported 0
+    /// for every run.
+    #[test]
+    fn test_consensus_bases_emitted_totals_emitted_consensus_bases() {
+        let mut caller = CodecConsensusCaller::new(
+            "codec".to_string(),
+            "RG1".to_string(),
+            permissive_disagreement_options(),
+        );
+
+        let output = caller
+            .consensus_reads_from_sam_records(duplex_disagreement_fixture())
+            .expect("permissive thresholds should emit a consensus");
+        assert_eq!(output.count, 1, "fixture should produce exactly one consensus read");
+
+        let emitted_bases: u64 = ParsedBamRecord::parse_all(&output.data)
+            .iter()
+            .map(|record| record.bases.len() as u64)
+            .sum();
+        assert!(emitted_bases > 0, "fixture must emit a non-empty consensus");
+        assert_eq!(
+            caller.statistics().consensus_bases_emitted,
+            emitted_bases,
+            "consensus_bases_emitted must total the bases of the emitted consensus reads"
+        );
+    }
+
+    /// A molecule rejected for high duplex disagreement emits no consensus, so it
+    /// must contribute nothing to `consensus_bases_emitted` — fgbio increments
+    /// `totalConsensusBases` only in the accepted branch, after the rejection
+    /// check (`CodecConsensusCaller.scala:258-266`).
+    #[test]
+    fn test_consensus_bases_emitted_excludes_rejected_molecules() {
+        let options = CodecConsensusOptions {
+            min_reads_per_strand: 1,
+            min_duplex_length: 1,
+            max_duplex_disagreements: 0,
+            max_duplex_disagreement_rate: 1.0,
+            ..Default::default()
+        };
+        let mut caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
+
+        let Err(err) = caller.consensus_reads_typed(duplex_disagreement_fixture()) else {
+            panic!("zero-tolerance count threshold should produce an error");
+        };
+        assert!(err.is_duplex_disagreement());
+        assert_eq!(
+            caller.statistics().consensus_bases_emitted,
+            0,
+            "a rejected molecule emits no consensus bases"
+        );
     }
 
     /// Verifies that `consensus_reads_typed` returns the typed

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -1348,8 +1348,6 @@ impl CodecConsensusCaller {
         // Check duplex disagreement rate
         if duplex_bases_count > 0 {
             let duplex_error_rate = duplex_disagreements as f64 / duplex_bases_count as f64;
-            self.stats.consensus_duplex_bases_emitted += duplex_bases_count as u64;
-            self.stats.duplex_disagreement_base_count += duplex_disagreements as u64;
 
             if duplex_disagreements > self.options.max_duplex_disagreements {
                 return Err(CodecConsensusError::DuplexDisagreementCount {
@@ -1361,6 +1359,13 @@ impl CodecConsensusCaller {
                     rate: duplex_error_rate,
                 });
             }
+
+            // Accumulate only once the molecule has survived both rejection checks:
+            // a rejected molecule emits nothing, so it contributes no duplex bases.
+            // fgbio does the same, incrementing `totalDuplexBases`/`duplexErrorBases`
+            // in the accepted branch only (`CodecConsensusCaller.scala:264-268`).
+            self.stats.consensus_duplex_bases_emitted += duplex_bases_count as u64;
+            self.stats.duplex_disagreement_base_count += duplex_disagreements as u64;
         }
 
         Ok(SingleStrandConsensus {
@@ -2991,28 +2996,52 @@ mod tests {
     }
 
     /// A molecule rejected for high duplex disagreement emits no consensus, so it
-    /// must contribute nothing to `consensus_bases_emitted` — fgbio increments
-    /// `totalConsensusBases` only in the accepted branch, after the rejection
-    /// check (`CodecConsensusCaller.scala:258-266`).
-    #[test]
-    fn test_consensus_bases_emitted_excludes_rejected_molecules() {
+    /// must contribute nothing to any of the three "emitted" base counters — fgbio
+    /// increments `totalConsensusBases`, `totalDuplexBases` and `duplexErrorBases`
+    /// only in the accepted branch, after the rejection check
+    /// (`CodecConsensusCaller.scala:258-268`). Counting a reject would inflate
+    /// `duplex_disagreement_rate` by exactly the molecules thrown out for
+    /// disagreeing, which is the opposite of what that metric reports.
+    ///
+    /// Each case isolates one rejection trigger by making the other threshold
+    /// permissive, so both early returns are covered.
+    #[rstest]
+    #[case::by_count(0, 1.0)]
+    #[case::by_rate(usize::MAX, 0.0)]
+    fn test_rejected_molecules_contribute_no_emitted_bases(
+        #[case] max_duplex_disagreements: usize,
+        #[case] max_duplex_disagreement_rate: f64,
+    ) {
         let options = CodecConsensusOptions {
             min_reads_per_strand: 1,
             min_duplex_length: 1,
-            max_duplex_disagreements: 0,
-            max_duplex_disagreement_rate: 1.0,
+            max_duplex_disagreements,
+            max_duplex_disagreement_rate,
             ..Default::default()
         };
         let mut caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
 
         let Err(err) = caller.consensus_reads_typed(duplex_disagreement_fixture()) else {
-            panic!("zero-tolerance count threshold should produce an error");
+            panic!("zero-tolerance disagreement threshold should produce an error");
         };
         assert!(err.is_duplex_disagreement());
+
+        let stats = caller.statistics();
         assert_eq!(
-            caller.statistics().consensus_bases_emitted,
-            0,
+            stats.consensus_bases_emitted, 0,
             "a rejected molecule emits no consensus bases"
+        );
+        assert_eq!(
+            stats.consensus_duplex_bases_emitted, 0,
+            "a rejected molecule emits no duplex-supported bases"
+        );
+        assert_eq!(
+            stats.duplex_disagreement_base_count, 0,
+            "a rejected molecule's disagreements are not disagreements within emitted output"
+        );
+        assert!(
+            stats.duplex_disagreement_rate().abs() < f64::EPSILON,
+            "the rate must not be inflated by the molecules rejected for disagreeing"
         );
     }
 

--- a/crates/fgumi-metrics/src/consensus.rs
+++ b/crates/fgumi-metrics/src/consensus.rs
@@ -145,6 +145,25 @@ pub struct ConsensusMetrics {
     /// Reads rejected because overlap clipping failed (fgbio `clip_overlap_failed`;
     /// codec)
     pub rejected_clip_overlap_failed: u64,
+
+    /// Consensus reads rejected for high duplex disagreement (fgbio
+    /// `consensus_reads_rejected_hdd`; codec)
+    ///
+    /// Counts whole molecules, unlike `rejected_high_duplex_disagreement`, which
+    /// counts the raw reads those molecules were built from.
+    pub consensus_reads_rejected_hdd: u64,
+
+    /// Total consensus bases emitted in consensus reads (fgbio
+    /// `consensus_bases_emitted`; codec)
+    pub consensus_bases_emitted: u64,
+
+    /// Consensus bases emitted with support from both strands of the duplex (fgbio
+    /// `consensus_duplex_bases_emitted`; codec)
+    pub consensus_duplex_bases_emitted: u64,
+
+    /// Consensus bases at which the top and bottom strands disagreed (fgbio
+    /// `duplex_disagreement_base_count`; codec)
+    pub duplex_disagreement_base_count: u64,
 }
 
 /// The consensus caller whose statistics are being rendered.
@@ -280,7 +299,22 @@ impl ConsensusMetrics {
             rejected_indel_error_between_strands: 0,
             rejected_high_duplex_disagreement: 0,
             rejected_clip_overlap_failed: 0,
+            consensus_reads_rejected_hdd: 0,
+            consensus_bases_emitted: 0,
+            consensus_duplex_bases_emitted: 0,
+            duplex_disagreement_base_count: 0,
         }
+    }
+
+    /// The fraction of emitted duplex bases at which the two strands disagreed.
+    ///
+    /// Returns 0.0 when no duplex bases were emitted, matching fgbio's
+    /// `if (this.totalDuplexBases == 0) 0` guard in `CodecConsensusCaller`.
+    /// Only meaningful for the codec caller; the other callers leave both
+    /// counters at zero.
+    #[must_use]
+    pub fn duplex_disagreement_rate(&self) -> f64 {
+        frac_u64(self.duplex_disagreement_base_count, self.consensus_duplex_bases_emitted)
     }
 
     /// Returns the rejection count for a specific reason.
@@ -385,6 +419,10 @@ impl ConsensusMetrics {
     /// `indel_error_between_strands`, `high_duplex_disagreement`,
     /// `clip_overlap_failed`) plus `not_primary_fr_pair`.
     /// fgumi-specific finer-grained reasons are emitted only when non-zero.
+    ///
+    /// The codec kind additionally appends fgbio's five codec-only rows
+    /// (`consensus_reads_rejected_hdd` through `duplex_disagreement_rate`) after
+    /// `consensus_reads_emitted`, matching `CodecConsensusCaller.statistics`.
     #[must_use]
     pub fn to_kv_metrics(&self, kind: ConsensusCallerKind) -> Vec<ConsensusKvMetric> {
         let mut metrics = Vec::new();
@@ -444,6 +482,37 @@ impl ConsensusMetrics {
             self.consensus_reads.to_string(),
             "Total number of consensus reads (R1+R2=2) emitted.",
         ));
+
+        // Codec-only tail: fgbio's `CodecConsensusCaller.statistics` is
+        // `super.statistics ++` these five rows, so they trail the shared rows in
+        // exactly this order.
+        if matches!(kind, ConsensusCallerKind::Codec) {
+            metrics.push(ConsensusKvMetric::new(
+                "consensus_reads_rejected_hdd",
+                self.consensus_reads_rejected_hdd.to_string(),
+                "Consensus Reads Rejected: High Duplex Disagreement",
+            ));
+            metrics.push(ConsensusKvMetric::new(
+                "consensus_bases_emitted",
+                self.consensus_bases_emitted.to_string(),
+                "Total consensus bases emitted in consensus reads",
+            ));
+            metrics.push(ConsensusKvMetric::new(
+                "consensus_duplex_bases_emitted",
+                self.consensus_duplex_bases_emitted.to_string(),
+                "Consensus bases emitted with support from both strands of the duplex",
+            ));
+            metrics.push(ConsensusKvMetric::new(
+                "duplex_disagreement_base_count",
+                self.duplex_disagreement_base_count.to_string(),
+                "Number of consensus bases at which the top and bottom strands disagreed",
+            ));
+            metrics.push(ConsensusKvMetric::new(
+                "duplex_disagreement_rate",
+                format_float(self.duplex_disagreement_rate()),
+                "Rate of top/bottom strand disagreement within duplex regions of consensus reads",
+            ));
+        }
 
         metrics
     }
@@ -841,6 +910,112 @@ mod tests {
             find("raw_reads_rejected_for_potential_umi_collision").as_deref(),
             Some("Potential collision between independent duplex molecules")
         );
+    }
+
+    /// The five codec-only rows fgbio appends after `consensus_reads_emitted`
+    /// (`CodecConsensusCaller.statistics`), in fgbio's order, with fgbio's exact
+    /// key names and description strings.
+    const EXPECTED_CODEC_TAIL: &[(&str, &str)] = &[
+        ("consensus_reads_rejected_hdd", "Consensus Reads Rejected: High Duplex Disagreement"),
+        ("consensus_bases_emitted", "Total consensus bases emitted in consensus reads"),
+        (
+            "consensus_duplex_bases_emitted",
+            "Consensus bases emitted with support from both strands of the duplex",
+        ),
+        (
+            "duplex_disagreement_base_count",
+            "Number of consensus bases at which the top and bottom strands disagreed",
+        ),
+        (
+            "duplex_disagreement_rate",
+            "Rate of top/bottom strand disagreement within duplex regions of consensus reads",
+        ),
+    ];
+
+    /// #748: fgbio's `CodecConsensusCaller.statistics` is `super.statistics ++` five
+    /// codec-only rows, so they must trail `consensus_reads_emitted` in that exact
+    /// order with fgbio's exact descriptions — the two tools' stats files are meant
+    /// to be diffable, and fgumi previously dropped all five.
+    #[test]
+    fn test_to_kv_metrics_codec_emits_codec_only_tail() {
+        let mut metrics = ConsensusMetrics::new();
+        metrics.consensus_reads = 450;
+        metrics.consensus_reads_rejected_hdd = 7;
+        metrics.consensus_bases_emitted = 45_000;
+        metrics.consensus_duplex_bases_emitted = 400;
+        metrics.duplex_disagreement_base_count = 10;
+
+        let codec = metrics.to_kv_metrics(ConsensusCallerKind::Codec);
+
+        // The five rows must be the *tail* of the file, immediately after the final
+        // `consensus_reads_emitted` row, not merely present somewhere.
+        let tail = codec
+            .get(codec.len() - EXPECTED_CODEC_TAIL.len() - 1..)
+            .expect("codec KV metrics should be longer than the codec-only tail");
+        assert_eq!(tail[0].key, "consensus_reads_emitted", "codec-only rows must trail the file");
+        let emitted_tail: Vec<(&str, &str)> =
+            tail[1..].iter().map(|m| (m.key.as_str(), m.description.as_str())).collect();
+        assert_eq!(
+            emitted_tail.as_slice(),
+            EXPECTED_CODEC_TAIL,
+            "codec-only KV rows must match fgbio's order, keys and descriptions"
+        );
+
+        let value_for = |key: &str| {
+            codec.iter().find(|m| m.key == key).map_or_else(
+                || panic!("codec KV metrics should contain a `{key}` row"),
+                |m| m.value.as_str(),
+            )
+        };
+        assert_eq!(value_for("consensus_reads_rejected_hdd"), "7");
+        assert_eq!(value_for("consensus_bases_emitted"), "45000");
+        assert_eq!(value_for("consensus_duplex_bases_emitted"), "400");
+        assert_eq!(value_for("duplex_disagreement_base_count"), "10");
+        // 10 / 400, rendered through the same fixed-precision helper as
+        // `frac_raw_reads_used` so every float row in the file agrees.
+        assert_eq!(value_for("duplex_disagreement_rate"), format_float(0.025));
+    }
+
+    /// fgbio adds these rows in `CodecConsensusCaller` only; the vanilla and duplex
+    /// callers must not emit them, even at zero.
+    #[test]
+    fn test_to_kv_metrics_non_codec_omits_codec_only_tail() {
+        let mut metrics = ConsensusMetrics::new();
+        metrics.consensus_reads_rejected_hdd = 7;
+        metrics.consensus_bases_emitted = 45_000;
+        metrics.consensus_duplex_bases_emitted = 400;
+        metrics.duplex_disagreement_base_count = 10;
+
+        for kind in [ConsensusCallerKind::Vanilla, ConsensusCallerKind::Duplex] {
+            let kv = metrics.to_kv_metrics(kind);
+            assert_eq!(
+                kv.last().map(|m| m.key.as_str()),
+                Some("consensus_reads_emitted"),
+                "{kind:?} stats must still end at consensus_reads_emitted"
+            );
+            for (key, _) in EXPECTED_CODEC_TAIL {
+                assert!(
+                    !kv.iter().any(|m| m.key == *key),
+                    "{kind:?} KV metrics must not emit the codec-only row {key}"
+                );
+            }
+        }
+    }
+
+    /// `duplex_disagreement_rate` divides by `consensus_duplex_bases_emitted`, which
+    /// is zero whenever no duplex bases were emitted. fgbio guards this with
+    /// `if (this.totalDuplexBases == 0) 0`; the row must still be emitted, as 0.
+    #[test]
+    fn test_duplex_disagreement_rate_zero_denominator() {
+        let metrics = ConsensusMetrics::new();
+        assert!(metrics.duplex_disagreement_rate().abs() < f64::EPSILON);
+
+        let codec = metrics.to_kv_metrics(ConsensusCallerKind::Codec);
+        let rate = codec
+            .iter()
+            .find(|m| m.key == "duplex_disagreement_rate")
+            .expect("duplex_disagreement_rate row should be emitted even at zero");
+        assert_eq!(rate.value, format_float(0.0));
     }
 
     #[test]

--- a/crates/fgumi-metrics/src/consensus.rs
+++ b/crates/fgumi-metrics/src/consensus.rs
@@ -147,6 +147,7 @@ pub struct ConsensusMetrics {
     pub rejected_clip_overlap_failed: u64,
 
     /// Consensus reads rejected for high duplex disagreement (fgbio
+    /// `consensusReadsFilteredHighDisagreement`, emitted as
     /// `consensus_reads_rejected_hdd`; codec)
     ///
     /// Counts whole molecules, unlike `rejected_high_duplex_disagreement`, which

--- a/docs/src/guide/working-with-metrics.md
+++ b/docs/src/guide/working-with-metrics.md
@@ -23,7 +23,7 @@ Most metrics files are tab-separated values (TSV) with a header row. There are t
 
 ### Horizontal TSV (Most Commands)
 
-A header row followed by a single data row. Used by `dedup`, `codec`, `duplex-metrics`,
+A header row followed by a single data row. Used by `dedup`, `duplex-metrics`,
 `simplex-metrics`, and `group`.
 
 ```text
@@ -39,9 +39,9 @@ Note that `dedup` and `group` count their discards in **different units**. `dedu
 records* — the latter match fgbio's `UmiGroupingMetric` schema exactly, so they are readable
 by fgbio's `Metric.read`. Do not compare the two files' discard counts directly.
 
-### Vertical Key-Value (Simplex/Duplex)
+### Vertical Key-Value (Simplex/Duplex/Codec)
 
-The `simplex` and `duplex` commands use a three-column format with one metric per row:
+The `simplex`, `duplex`, and `codec` commands use a three-column format with one metric per row:
 
 ```text
 key	value	description
@@ -51,6 +51,20 @@ consensus_reads_emitted	12000	Total number of consensus reads (R1+R2=2) emitted
 ```
 
 This format is compatible with fgbio's `CallMolecularConsensusReads` output.
+
+`codec` appends five codec-specific rows after `consensus_reads_emitted`, matching fgbio's
+`CallCodecConsensusReads`:
+
+```text
+consensus_reads_rejected_hdd	14	Consensus Reads Rejected: High Duplex Disagreement
+consensus_bases_emitted	1560000	Total consensus bases emitted in consensus reads
+consensus_duplex_bases_emitted	1240000	Consensus bases emitted with support from both strands of the duplex
+duplex_disagreement_base_count	620	Number of consensus bases at which the top and bottom strands disagreed
+duplex_disagreement_rate	0.000500	Rate of top/bottom strand disagreement within duplex regions of consensus reads
+```
+
+`duplex_disagreement_rate` is `duplex_disagreement_base_count / consensus_duplex_bases_emitted`,
+and is 0 when no duplex bases were emitted.
 
 ### Filter Stats (Special Case)
 

--- a/src/lib/commands/consensus_runner.rs
+++ b/src/lib/commands/consensus_runner.rs
@@ -72,6 +72,13 @@ impl ConsensusStatsOps for CodecConsensusStats {
         metrics.consensus_reads = self.consensus_reads_generated;
         metrics.filtered_reads = self.reads_filtered;
 
+        // Codec-only counters backing fgbio's five codec `statistics` rows. The
+        // rate is derived from the last two, so it is not carried separately.
+        metrics.consensus_reads_rejected_hdd = self.consensus_reads_rejected_hdd;
+        metrics.consensus_bases_emitted = self.consensus_bases_emitted;
+        metrics.consensus_duplex_bases_emitted = self.consensus_duplex_bases_emitted;
+        metrics.duplex_disagreement_base_count = self.duplex_disagreement_base_count;
+
         // Convert rejection reasons to centralized reasons
         for (reason, count) in &self.rejection_reasons {
             metrics.add_rejection(reason.to_centralized(), *count as u64);
@@ -400,6 +407,43 @@ mod tests {
         assert_eq!(metrics.total_input_reads, 100);
         assert_eq!(metrics.consensus_reads, 50);
         assert_eq!(metrics.filtered_reads, 10);
+    }
+
+    /// #748: the codec-only counters must survive the hop from the caller's stats
+    /// into `ConsensusMetrics`, which is the only thing `to_kv_metrics` can see.
+    /// They were dropped here, so all five fgbio codec rows were absent from
+    /// `codec --stats` regardless of what the caller had counted.
+    #[cfg(feature = "codec")]
+    #[test]
+    fn test_codec_stats_to_metrics_carries_codec_counters() {
+        let mut stats = CodecConsensusStats {
+            total_input_reads: 100,
+            consensus_reads_generated: 40,
+            reads_filtered: 10,
+            consensus_reads_rejected_hdd: 3,
+            consensus_bases_emitted: 4_000,
+            consensus_duplex_bases_emitted: 400,
+            duplex_disagreement_base_count: 10,
+            ..Default::default()
+        };
+        // Rate is derived from the two duplex counters, so merging must keep the
+        // metrics view consistent with the caller's own view of the same run.
+        let extra = stats.clone();
+        ConsensusStatsOps::merge(&mut stats, &extra);
+
+        let metrics = stats.to_metrics();
+        assert_eq!(metrics.total_input_reads, 200);
+        assert_eq!(metrics.consensus_reads, 80);
+        assert_eq!(metrics.filtered_reads, 20);
+        assert_eq!(metrics.consensus_reads_rejected_hdd, 6);
+        assert_eq!(metrics.consensus_bases_emitted, 8_000);
+        assert_eq!(metrics.consensus_duplex_bases_emitted, 800);
+        assert_eq!(metrics.duplex_disagreement_base_count, 20);
+        assert!(
+            (metrics.duplex_disagreement_rate() - stats.duplex_disagreement_rate()).abs()
+                < f64::EPSILON,
+            "the metrics view must derive the same rate as the caller's stats"
+        );
     }
 
     #[test]

--- a/tests/integration/test_codec_command.rs
+++ b/tests/integration/test_codec_command.rs
@@ -455,8 +455,16 @@ fn test_codec_stats_consensus_reads_matches_records_written(#[case] threads: Opt
 ///
 /// The counts are checked against the output BAM rather than hard-coded, so the
 /// rows are pinned to what the run actually emitted.
-#[test]
-fn test_codec_stats_emits_fgbio_codec_only_rows() {
+///
+/// The `with_rejected_molecule` case adds a molecule whose two strands disagree at
+/// every base, rejected by `--max-duplex-disagreements 0`. It pins the "emitted"
+/// half of the contract: a rejected molecule bumps `consensus_reads_rejected_hdd`
+/// and contributes to *none* of the three base counters. Counting it would inflate
+/// `duplex_disagreement_rate` by exactly the molecules discarded for disagreeing.
+#[rstest]
+#[case::all_molecules_emitted(false)]
+#[case::with_rejected_molecule(true)]
+fn test_codec_stats_emits_fgbio_codec_only_rows(#[case] add_disagreeing_molecule: bool) {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let input_bam = temp_dir.path().join("input.bam");
     let output_bam = temp_dir.path().join("output.bam");
@@ -478,6 +486,23 @@ fn test_codec_stats_emits_fgbio_codec_only_rows() {
             pairs.push((r1, r2));
         }
     }
+    if add_disagreeing_molecule {
+        // Same shape as the molecules above, but the second strand carries a
+        // different base at every position, so the molecule is rejected.
+        for read in 0..3 {
+            let (r1, r2) = create_codec_read_pair(
+                &format!("hdd_read{read}"),
+                b"ACGTACGT",
+                b"TTTTTTTT",
+                &[30; 8],
+                &[30; 8],
+                400,
+                "UMI_HDD",
+                None,
+            );
+            pairs.push((r1, r2));
+        }
+    }
     create_codec_test_bam(&input_bam, pairs);
 
     Codec::try_parse_from(vec![
@@ -492,6 +517,8 @@ fn test_codec_stats_emits_fgbio_codec_only_rows() {
         "1",
         "--min-duplex-length",
         "1",
+        "--max-duplex-disagreements",
+        "0",
         "--compression-level",
         "1",
     ])
@@ -499,10 +526,13 @@ fn test_codec_stats_emits_fgbio_codec_only_rows() {
     .execute("fgumi codec")
     .expect("Failed to run codec command");
 
+    // The three agreeing molecules are always emitted; the disagreeing one never is,
+    // so the emitted-base totals are identical across both cases.
     let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
     let _header = reader.read_header().unwrap();
     let records =
         reader.records().collect::<Result<Vec<_>, _>>().expect("failed to read the consensus BAM");
+    assert_eq!(records.len(), 3, "only the three agreeing molecules are consensus-called");
     let bases_written: usize = records.iter().map(|record| record.sequence().len()).sum();
     assert!(bases_written > 0, "the run must emit at least one consensus base");
 
@@ -520,10 +550,14 @@ fn test_codec_stats_emits_fgbio_codec_only_rows() {
     };
 
     // fgbio's descriptions, verbatim (`CodecConsensusCaller.statistics`).
+    let expected_rejected = usize::from(add_disagreeing_molecule);
     assert_eq!(
         row("consensus_reads_rejected_hdd"),
-        ("0".to_string(), "Consensus Reads Rejected: High Duplex Disagreement".to_string()),
-        "no molecule in this fixture disagrees between strands"
+        (
+            expected_rejected.to_string(),
+            "Consensus Reads Rejected: High Duplex Disagreement".to_string()
+        ),
+        "one molecule per disagreeing template is counted, once"
     );
     assert_eq!(
         row("consensus_bases_emitted"),
@@ -536,7 +570,7 @@ fn test_codec_stats_emits_fgbio_codec_only_rows() {
             bases_written.to_string(),
             "Consensus bases emitted with support from both strands of the duplex".to_string()
         ),
-        "R1 and R2 fully overlap in this fixture, so every emitted base is duplex-supported"
+        "R1 and R2 fully overlap in the emitted molecules, and the rejected one emits nothing"
     );
     assert_eq!(
         row("duplex_disagreement_base_count"),
@@ -544,7 +578,7 @@ fn test_codec_stats_emits_fgbio_codec_only_rows() {
             "0".to_string(),
             "Number of consensus bases at which the top and bottom strands disagreed".to_string()
         ),
-        "the two strands carry identical bases in this fixture"
+        "the emitted molecules' strands agree; the rejected molecule's disagreements do not count"
     );
     assert_eq!(
         row("duplex_disagreement_rate"),
@@ -553,7 +587,7 @@ fn test_codec_stats_emits_fgbio_codec_only_rows() {
             "Rate of top/bottom strand disagreement within duplex regions of consensus reads"
                 .to_string()
         ),
-        "zero disagreements over a non-zero duplex base count is a rate of zero"
+        "the rate covers emitted output only, so a rejected molecule cannot inflate it"
     );
 }
 

--- a/tests/integration/test_codec_command.rs
+++ b/tests/integration/test_codec_command.rs
@@ -448,6 +448,115 @@ fn test_codec_stats_consensus_reads_matches_records_written(#[case] threads: Opt
     );
 }
 
+/// #748: `codec --stats` must emit the five codec-only rows fgbio's
+/// `CallCodecConsensusReads --stats` writes, with fgbio's exact key names and
+/// description strings, so the two tools' stats files stay diffable. All five were
+/// absent, which made a diff report missing keys rather than value differences.
+///
+/// The counts are checked against the output BAM rather than hard-coded, so the
+/// rows are pinned to what the run actually emitted.
+#[test]
+fn test_codec_stats_emits_fgbio_codec_only_rows() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let stats_file = temp_dir.path().join("stats.tsv");
+
+    let mut pairs = Vec::new();
+    for molecule in 0..3 {
+        for read in 0..3 {
+            let (r1, r2) = create_codec_read_pair(
+                &format!("mol{molecule}_read{read}"),
+                b"ACGTACGT",
+                b"ACGTACGT",
+                &[30; 8],
+                &[30; 8],
+                100 + molecule * 100,
+                &format!("UMI00{molecule}"),
+                None,
+            );
+            pairs.push((r1, r2));
+        }
+    }
+    create_codec_test_bam(&input_bam, pairs);
+
+    Codec::try_parse_from(vec![
+        "codec",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--stats",
+        stats_file.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--min-duplex-length",
+        "1",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse codec args")
+    .execute("fgumi codec")
+    .expect("Failed to run codec command");
+
+    let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    let _header = reader.read_header().unwrap();
+    let records =
+        reader.records().collect::<Result<Vec<_>, _>>().expect("failed to read the consensus BAM");
+    let bases_written: usize = records.iter().map(|record| record.sequence().len()).sum();
+    assert!(bases_written > 0, "the run must emit at least one consensus base");
+
+    let stats = fs::read_to_string(&stats_file).expect("Failed to read stats");
+    let row = |key: &str| -> (String, String) {
+        let mut fields = stats
+            .lines()
+            .find(|line| line.starts_with(&format!("{key}\t")))
+            .unwrap_or_else(|| panic!("stats must contain a `{key}` row"))
+            .split('\t');
+        let _key = fields.next();
+        let value = fields.next().expect("row must have a value column").to_string();
+        let description = fields.next().expect("row must have a description column").to_string();
+        (value, description)
+    };
+
+    // fgbio's descriptions, verbatim (`CodecConsensusCaller.statistics`).
+    assert_eq!(
+        row("consensus_reads_rejected_hdd"),
+        ("0".to_string(), "Consensus Reads Rejected: High Duplex Disagreement".to_string()),
+        "no molecule in this fixture disagrees between strands"
+    );
+    assert_eq!(
+        row("consensus_bases_emitted"),
+        (bases_written.to_string(), "Total consensus bases emitted in consensus reads".to_string()),
+        "consensus_bases_emitted must total the bases written to the output BAM"
+    );
+    assert_eq!(
+        row("consensus_duplex_bases_emitted"),
+        (
+            bases_written.to_string(),
+            "Consensus bases emitted with support from both strands of the duplex".to_string()
+        ),
+        "R1 and R2 fully overlap in this fixture, so every emitted base is duplex-supported"
+    );
+    assert_eq!(
+        row("duplex_disagreement_base_count"),
+        (
+            "0".to_string(),
+            "Number of consensus bases at which the top and bottom strands disagreed".to_string()
+        ),
+        "the two strands carry identical bases in this fixture"
+    );
+    assert_eq!(
+        row("duplex_disagreement_rate"),
+        (
+            "0.000000".to_string(),
+            "Rate of top/bottom strand disagreement within duplex regions of consensus reads"
+                .to_string()
+        ),
+        "zero disagreements over a non-zero duplex base count is a rate of zero"
+    );
+}
+
 /// Test CODEC command with rejected reads output.
 #[test]
 fn test_codec_command_with_rejects() {


### PR DESCRIPTION
Closes #748.

`fgumi codec --stats` wrote 18 rows where fgbio's `CallCodecConsensusReads --stats` writes 23 for the same input. The five missing rows are now emitted, with fgbio's exact key names, description strings and row order, so a `diff` of the two tools' stats files reports value differences rather than absent keys.

## Where the rows were lost

`CodecConsensusStats` carried four of the five values, but `CodecConsensusStats::to_metrics` (`src/lib/commands/consensus_runner.rs`) dropped them at the boundary into `ConsensusMetrics` — which is the only thing `to_kv_metrics` can see — so nothing downstream could serialize them. `ConsensusMetrics` gains the four counters plus a derived `duplex_disagreement_rate()`, and `to_kv_metrics` appends the five rows after `consensus_reads_emitted` for `ConsensusCallerKind::Codec` only, mirroring fgbio's `super.statistics ++ IndexedSeq(...)` in `CodecConsensusCaller.statistics`. The rate uses fgbio's zero-denominator guard and renders through the same `format_float` helper as the existing `frac_raw_reads_used` row, so every float row in the file agrees.

**`simplex` and `duplex` do not share this gap.** Only `CodecConsensusCaller` overrides `statistics` in fgbio (`UmiConsensusCaller.scala:524` is the sole other definition), so there is no simplex/duplex analogue of these five rows to drop.

## Two counters behind the rows were also wrong

The issue's premise is that all five values are already computed. Two of them were not, and serializing them as-is would have published known-wrong numbers, so each is fixed in its own commit for reviewability:

- `ff0b46f3` — `consensus_bases_emitted` was declared, merged across threads, and logged, but nothing ever incremented it. It reported 0 for every run, including in the run log at `codec_caller.rs:1717`. It is now accumulated at the point the consensus read is produced, matching fgbio's `totalConsensusBases += consensus.length`.
- `c9a8a5db` — `consensus_duplex_bases_emitted` and `duplex_disagreement_base_count` were accumulated *before* the two high-duplex-disagreement checks, so a molecule rejected for disagreeing contributed its bases and its disagreements to both totals anyway. fgbio increments them only in the accepted branch. The practical effect is that `duplex_disagreement_rate` — a rate over *emitted* duplex bases, and the headline signal this PR exists to expose — was inflated by exactly the molecules the threshold excluded, and grew with the rejection rate. The new end-to-end case adds a molecule whose strands disagree at every base; before the fix it reported 32 duplex bases against 24 bases of output.

Both are counter-population fixes, not changes to consensus base or quality math: no emitted record changes, and every existing test passes unmodified.

## Tests

- `crates/fgumi-metrics/src/consensus.rs` — `test_to_kv_metrics_codec_emits_codec_only_tail` pins the five rows as the *tail* of the file (keys, order, values, and fgbio's descriptions verbatim), `test_to_kv_metrics_non_codec_omits_codec_only_tail` pins that vanilla and duplex still end at `consensus_reads_emitted`, and `test_duplex_disagreement_rate_zero_denominator` pins the zero-denominator guard.
- `src/lib/commands/consensus_runner.rs` — `test_codec_stats_to_metrics_carries_codec_counters` pins the boundary the rows were lost at, across a merge.
- `crates/fgumi-consensus/src/codec_caller.rs` — `test_consensus_bases_emitted_totals_emitted_consensus_bases` checks the counter against the emitted record's own base count; `test_rejected_molecules_contribute_no_emitted_bases` covers both rejection triggers and asserts all three counters and the rate stay at zero.
- `tests/integration/test_codec_command.rs` — `test_codec_stats_emits_fgbio_codec_only_rows` runs the command end to end and reads the written stats file, checking counts against the output BAM rather than hard-coding them. Its second case adds a rejected molecule.

The metrics guide claimed `codec` used the horizontal TSV format; it has used the vertical key-value format since the codec stats moved to fgbio's layout. Corrected, and the five new rows are documented there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: codec stats output changes, pinned by fgbio-compatible keys, descriptions, and row order; `unsafe`: none; CLAUDE.md allowlist: unchanged; memory bounds, queue capacity, and thread/backpressure policy: none.

Fix: `fgumi codec --stats` now emits five fgbio-compatible codec metrics and tracks emitted and rejected consensus counters correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->