### PR TITLE
fix(codec): route per-read rejections to the --rejects output

### DIFF
--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -294,6 +294,21 @@ struct SingleStrandConsensus {
     is_negative_strand: bool,
 }
 
+/// Per-molecule duplex base tallies produced while building a duplex consensus.
+///
+/// These are returned rather than folded straight into [`CodecStats`] so the caller can
+/// apply them only *after* the consensus record has been serialized. A molecule whose output
+/// fails to build — an over-long input-derived UMI makes `try_build_record` reject the read
+/// name — emits nothing, so its duplex bases must not be counted, exactly as
+/// `consensus_reads_generated`/`consensus_bases_emitted` are only bumped on the success path.
+#[derive(Debug, Clone, Copy, Default)]
+struct DuplexBaseTally {
+    /// Duplex bases the molecule would contribute to `consensus_duplex_bases_emitted`.
+    bases_emitted: u64,
+    /// Duplex disagreements the molecule would contribute to `duplex_disagreement_base_count`.
+    disagreement_bases: u64,
+}
+
 /// Convert a per-base depth/error array to the `i16` `Array[Short]` form fgbio
 /// emits, saturating any value above the `Short` ceiling at `i16::MAX` (32767)
 /// rather than letting a raw `as i16` cast wrap it to a negative value. Matches
@@ -358,6 +373,12 @@ pub struct CodecConsensusCaller {
 
     /// Rejected raw BAM records (only populated when `track_rejects` is true)
     rejected_reads: Vec<Vec<u8>>,
+
+    /// Per-group mark of which input records were rejected, indexed by position in the
+    /// group's record slice. Sized at the top of [`Self::consensus_reads_raw`] and
+    /// consumed by [`Self::drain_marked_rejects`]; left empty (so marking is a no-op)
+    /// when `track_rejects` is false.
+    reject_mask: Vec<bool>,
 }
 
 #[expect(
@@ -422,6 +443,7 @@ impl CodecConsensusCaller {
             read_name_buf: Vec::new(),
             track_rejects: false,
             rejected_reads: Vec::new(),
+            reject_mask: Vec::new(),
         }
     }
 
@@ -455,6 +477,7 @@ impl CodecConsensusCaller {
         self.stats = CodecConsensusStats::default();
         self.ss_caller.clear();
         self.rejected_reads.clear();
+        self.reject_mask.clear();
     }
 
     /// Returns a reference to the rejected reads (raw BAM bytes).
@@ -605,6 +628,13 @@ impl CodecConsensusCaller {
     ) -> std::result::Result<ConsensusOutput, CodecConsensusError> {
         self.stats.total_input_reads += records.len() as u64;
 
+        // Size the per-group reject mark before any rejection site can run. Left empty when
+        // tracking is off, which makes `reject_records_at`'s marking a no-op.
+        self.reject_mask.clear();
+        if self.track_rejects {
+            self.reject_mask.resize(records.len(), false);
+        }
+
         if records.is_empty() {
             return Ok(ConsensusOutput::default());
         }
@@ -620,11 +650,11 @@ impl CodecConsensusCaller {
         // is_fr_pair_raw check is asymmetric on dovetails whose aligned ends coincide and would
         // silently drop legitimate FR pairs (CODEC-01).
         let mut paired_indices: Vec<usize> = Vec::new();
-        let mut frag_count = 0usize;
+        let mut frag_indices: Vec<usize> = Vec::new();
         for (i, raw) in records.iter().enumerate() {
             let flg = RawRecordView::new(raw).flags();
             if flg & flags::PAIRED == 0 {
-                frag_count += 1;
+                frag_indices.push(i);
                 continue;
             }
             // Drop secondary/supplementary alignments (fgbio filters these out of the primary
@@ -635,8 +665,8 @@ impl CodecConsensusCaller {
             paired_indices.push(i);
         }
 
-        if frag_count > 0 {
-            self.reject_records_count(frag_count, CallerRejectionReason::FragmentRead);
+        if !frag_indices.is_empty() {
+            self.reject_records_at(frag_indices, CallerRejectionReason::FragmentRead);
         }
 
         if paired_indices.is_empty() {
@@ -667,7 +697,10 @@ impl CodecConsensusCaller {
             let is_primary_fr = indices.len() == 2
                 && bam_fields::is_primary_fr_pair_raw(&records[indices[0]], &records[indices[1]]);
             if !is_primary_fr {
-                self.reject_records_count(indices.len(), CallerRejectionReason::NotPrimaryFrPair);
+                self.reject_records_at(
+                    indices.iter().copied(),
+                    CallerRejectionReason::NotPrimaryFrPair,
+                );
                 continue;
             }
 
@@ -704,8 +737,8 @@ impl CodecConsensusCaller {
 
         // Check we have enough reads
         if r1_infos.len() < self.options.min_reads_per_strand {
-            self.reject_records_count(
-                r1_infos.len() + r2_infos.len(),
+            self.reject_records_at(
+                Self::strand_raw_indices(&r1_infos, &r2_infos),
                 CallerRejectionReason::InsufficientReads,
             );
             return Ok(ConsensusOutput::default());
@@ -722,8 +755,8 @@ impl CodecConsensusCaller {
         if r1_infos.len() < self.options.min_reads_per_strand
             || r2_infos.len() < self.options.min_reads_per_strand
         {
-            self.reject_records_count(
-                r1_infos.len() + r2_infos.len(),
+            self.reject_records_at(
+                Self::strand_raw_indices(&r1_infos, &r2_infos),
                 CallerRejectionReason::InsufficientReads,
             );
             return Ok(ConsensusOutput::default());
@@ -750,8 +783,8 @@ impl CodecConsensusCaller {
             // `CodecConsensusOptions` directly, and it rejects the family for the thing that is
             // actually true of it: after the cap there are no reads left to consense.
             if max_reads == 0 {
-                self.reject_records_count(
-                    r1_infos.len() + r2_infos.len(),
+                self.reject_records_at(
+                    Self::strand_raw_indices(&r1_infos, &r2_infos),
                     CallerRejectionReason::InsufficientReads,
                 );
                 return Ok(ConsensusOutput::default());
@@ -787,8 +820,8 @@ impl CodecConsensusCaller {
         let duplex_length = overlap_end as i64 - overlap_start as i64 + 1;
 
         if duplex_length < self.options.min_duplex_length as i64 {
-            self.reject_records_count(
-                r1_infos.len() + r2_infos.len(),
+            self.reject_records_at(
+                Self::strand_raw_indices(&r1_infos, &r2_infos),
                 CallerRejectionReason::InsufficientOverlap,
             );
             return Ok(ConsensusOutput::default());
@@ -796,8 +829,8 @@ impl CodecConsensusCaller {
 
         // Phase check using raw CIGAR ops
         if !Self::check_overlap_phase_raw(longest_r1, longest_r2, overlap_start, overlap_end) {
-            self.reject_records_count(
-                r1_infos.len() + r2_infos.len(),
+            self.reject_records_at(
+                Self::strand_raw_indices(&r1_infos, &r2_infos),
                 CallerRejectionReason::IndelErrorBetweenStrands,
             );
             return Ok(ConsensusOutput::default());
@@ -809,8 +842,8 @@ impl CodecConsensusCaller {
         let consensus_length =
             Self::compute_consensus_length_raw(longest_pos, longest_neg, overlap_end);
         let Some(consensus_length) = consensus_length else {
-            self.reject_records_count(
-                r1_infos.len() + r2_infos.len(),
+            self.reject_records_at(
+                Self::strand_raw_indices(&r1_infos, &r2_infos),
                 CallerRejectionReason::IndelErrorBetweenStrands,
             );
             return Ok(ConsensusOutput::default());
@@ -862,8 +895,8 @@ impl CodecConsensusCaller {
             // fgbio labels this the `ClipOverlapFailed` reason (the consensus is
             // shorter than a single strand, so the overlapping ends could not be
             // clipped) rather than an indel error (CodecConsensusCaller.scala:243).
-            self.reject_records_count(
-                r1_infos.len() + r2_infos.len(),
+            self.reject_records_at(
+                Self::strand_raw_indices(&r1_infos, &r2_infos),
                 CallerRejectionReason::ClipOverlapFailed,
             );
             return Ok(ConsensusOutput::default());
@@ -884,18 +917,19 @@ impl CodecConsensusCaller {
         // before propagating the (recoverable) error, matching fgbio, which does
         // `rejectRecords(..., HighDuplexDisagreement)` and
         // `consensusReadsFilteredHighDisagreement += 1` (CodecConsensusCaller.scala:255-256).
-        let consensus = match self.build_duplex_consensus_from_padded(&padded_r1, &padded_r2) {
-            Ok(consensus) => consensus,
-            Err(e) if e.is_duplex_disagreement() => {
-                self.reject_records_count(
-                    r1_infos.len() + r2_infos.len(),
-                    CallerRejectionReason::HighDuplexDisagreement,
-                );
-                self.stats.consensus_reads_rejected_hdd += 1;
-                return Err(e);
-            }
-            Err(e) => return Err(e),
-        };
+        let (consensus, duplex_tally) =
+            match self.build_duplex_consensus_from_padded(&padded_r1, &padded_r2) {
+                Ok(built) => built,
+                Err(e) if e.is_duplex_disagreement() => {
+                    self.reject_records_at(
+                        Self::strand_raw_indices(&r1_infos, &r2_infos),
+                        CallerRejectionReason::HighDuplexDisagreement,
+                    );
+                    self.stats.consensus_reads_rejected_hdd += 1;
+                    return Err(e);
+                }
+                Err(e) => return Err(e),
+            };
         let consensus = self.mask_consensus_quals_query_based(consensus, &padded_r1, &padded_r2);
         let consensus =
             if r1_is_negative { Self::reverse_complement_ss(&consensus) } else { consensus };
@@ -926,6 +960,12 @@ impl CodecConsensusCaller {
             records,
         )?;
 
+        // Serialization succeeded: the record is emitted, so commit every emitted counter
+        // together. The duplex tallies are applied here rather than inside
+        // `build_duplex_consensus_from_padded` so an over-long-UMI failure above leaves them
+        // at zero, consistent with `consensus_reads_generated`/`consensus_bases_emitted`.
+        self.stats.consensus_duplex_bases_emitted += duplex_tally.bases_emitted;
+        self.stats.duplex_disagreement_base_count += duplex_tally.disagreement_bases;
         self.stats.consensus_reads_generated += 1;
         self.stats.consensus_bases_emitted += consensus.bases.len() as u64;
         Ok(output)
@@ -1037,6 +1077,19 @@ impl CodecConsensusCaller {
         std::mem::swap(infos, &mut kept);
     }
 
+    /// The raw-record indices behind both strands' reads, R1s first then R2s.
+    ///
+    /// Every whole-family reject reason counts `r1_infos.len() + r2_infos.len()` records;
+    /// this is the same set expressed as indices, so [`Self::reject_records_at`] can also
+    /// route them to the `--rejects` output. A `ClippedRecordInfo` is never shared between
+    /// the two strands, so the indices cannot repeat.
+    fn strand_raw_indices<'a>(
+        r1_infos: &'a [ClippedRecordInfo],
+        r2_infos: &'a [ClippedRecordInfo],
+    ) -> impl Iterator<Item = usize> + 'a {
+        r1_infos.iter().chain(r2_infos.iter()).map(|info| info.raw_idx)
+    }
+
     /// Filter `ClippedRecordInfo`s to the most common alignment pattern.
     fn filter_to_most_common_alignment_raw(
         &mut self,
@@ -1062,17 +1115,20 @@ impl CodecConsensusCaller {
 
         let best_indices = select_most_common_alignment_group(&indexed);
 
-        let rejected_count = infos.len() - best_indices.len();
-        if rejected_count > 0 {
-            *self
-                .stats
-                .rejection_reasons
-                .entry(CallerRejectionReason::MinorityAlignment)
-                .or_insert(0) += rejected_count;
-            self.stats.reads_filtered += rejected_count as u64;
+        let best_set: std::collections::HashSet<usize> = best_indices.into_iter().collect();
+
+        // The minority reads are dropped from a family that usually still consenses, so
+        // they must be routed to the --rejects output and not merely counted (#751).
+        let rejected: Vec<usize> = infos
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| !best_set.contains(i))
+            .map(|(_, info)| info.raw_idx)
+            .collect();
+        if !rejected.is_empty() {
+            self.reject_records_at(rejected, CallerRejectionReason::MinorityAlignment);
         }
 
-        let best_set: std::collections::HashSet<usize> = best_indices.into_iter().collect();
         infos
             .into_iter()
             .enumerate()
@@ -1254,7 +1310,7 @@ impl CodecConsensusCaller {
         &mut self,
         ss_a: &SingleStrandConsensus,
         ss_b: &SingleStrandConsensus,
-    ) -> std::result::Result<SingleStrandConsensus, CodecConsensusError> {
+    ) -> std::result::Result<(SingleStrandConsensus, DuplexBaseTally), CodecConsensusError> {
         let len = ss_a.bases.len();
         assert_eq!(ss_b.bases.len(), len, "Padded consensuses must be the same length");
 
@@ -1392,6 +1448,7 @@ impl CodecConsensusCaller {
         }
 
         // Check duplex disagreement rate
+        let mut tally = DuplexBaseTally::default();
         if duplex_bases_count > 0 {
             let duplex_error_rate = duplex_disagreements as f64 / duplex_bases_count as f64;
 
@@ -1406,24 +1463,30 @@ impl CodecConsensusCaller {
                 });
             }
 
-            // Accumulate only once the molecule has survived both rejection checks:
-            // a rejected molecule emits nothing, so it contributes no duplex bases.
-            // fgbio does the same, incrementing `totalDuplexBases`/`duplexErrorBases`
-            // in the accepted branch only (`CodecConsensusCaller.scala:264-268`).
-            self.stats.consensus_duplex_bases_emitted += duplex_bases_count as u64;
-            self.stats.duplex_disagreement_base_count += duplex_disagreements as u64;
+            // Carry the per-molecule duplex tallies back to the caller, which applies them to
+            // `self.stats` only once the consensus record has been serialized. A molecule that
+            // survives both rejection checks here can still fail to emit (an over-long UMI makes
+            // `build_output_record_into` return an error), and a molecule that emits nothing must
+            // contribute no duplex bases. fgbio increments `totalDuplexBases`/`duplexErrorBases`
+            // in the accepted branch only (`CodecConsensusCaller.scala:264-268`); we defer that
+            // increment to the same success point as `consensus_reads_generated`.
+            tally.bases_emitted = duplex_bases_count as u64;
+            tally.disagreement_bases = duplex_disagreements as u64;
         }
 
-        Ok(SingleStrandConsensus {
-            bases,
-            quals,
-            depths,
-            errors,
-            raw_read_count: ss_a.raw_read_count + ss_b.raw_read_count,
-            ref_start: 0,
-            ref_end: len.saturating_sub(1),
-            is_negative_strand: ss_a.is_negative_strand,
-        })
+        Ok((
+            SingleStrandConsensus {
+                bases,
+                quals,
+                depths,
+                errors,
+                raw_read_count: ss_a.raw_read_count + ss_b.raw_read_count,
+                ref_start: 0,
+                ref_end: len.saturating_sub(1),
+                is_negative_strand: ss_a.is_negative_strand,
+            },
+            tally,
+        ))
     }
 
     /// Masks consensus qualities for query-based consensus, matching fgbio's
@@ -1675,6 +1738,52 @@ impl CodecConsensusCaller {
         self.stats.reads_filtered += count as u64;
     }
 
+    /// Rejects the records at `indices` (positions in the group's record slice) with the
+    /// given reason: counts them, and marks them for the `--rejects` output.
+    ///
+    /// Every counted rejection goes through here so the rejects BAM reconciles with
+    /// `--stats` — a reason counted without marking is a read that `raw_reads_rejected`
+    /// reports and the rejects BAM silently omits, which is what issue #751 describes.
+    /// Marking is a no-op when reject tracking is off, because `reject_mask` is then empty.
+    fn reject_records_at(
+        &mut self,
+        indices: impl IntoIterator<Item = usize>,
+        reason: CallerRejectionReason,
+    ) {
+        let mut count = 0usize;
+        for index in indices {
+            count += 1;
+            if let Some(marked) = self.reject_mask.get_mut(index) {
+                *marked = true;
+            } else {
+                // Out of range is expected only when tracking is off, where the mask is
+                // deliberately empty. With tracking on the mask spans the whole group, so an
+                // out-of-range index would be a record counted in `--stats` and silently
+                // omitted from the rejects BAM — the exact divergence this method prevents.
+                debug_assert!(
+                    !self.track_rejects,
+                    "reject index {index} is outside the group's reject mask"
+                );
+            }
+        }
+        self.reject_records_count(count, reason);
+    }
+
+    /// Moves every record marked by [`Self::reject_records_at`] into the pending
+    /// `--rejects` buffer, in input order, and resets the mark for the next group.
+    ///
+    /// Takes the group by value so the marked records' bytes are moved rather than copied.
+    /// The buffer is drained by the caller after each group (single-threaded) or each batch
+    /// (pipeline mode), so it never grows past what is already resident.
+    fn drain_marked_rejects(&mut self, records: Vec<RawRecord>) {
+        for (index, record) in records.into_iter().enumerate() {
+            if self.reject_mask.get(index).copied().unwrap_or(false) {
+                self.rejected_reads.push(record.into_inner());
+            }
+        }
+        self.reject_mask.clear();
+    }
+
     /// Calls consensus and returns a typed [`CodecConsensusError`] so callers can
     /// distinguish recoverable duplex disagreements (see
     /// [`CodecConsensusError::is_duplex_disagreement`]) from fatal failures
@@ -1690,25 +1799,26 @@ impl CodecConsensusCaller {
         &mut self,
         records: Vec<RawRecord>,
     ) -> std::result::Result<ConsensusOutput, CodecConsensusError> {
-        let result = match self.consensus_reads_raw(&records) {
-            Ok(result) => result,
-            Err(e) => {
-                // On a recoverable duplex-disagreement reject, still route the
-                // group's raw records to the --rejects output when tracking is
-                // enabled, mirroring the count==0 path below and fgbio's
-                // rejectsWriter. The reject reason/counters were already recorded
-                // by consensus_reads_raw before it returned the error.
-                if self.track_rejects && e.is_duplex_disagreement() && !records.is_empty() {
-                    self.rejected_reads.extend(records.into_iter().map(RawRecord::into_inner));
-                }
-                return Err(e);
-            }
-        };
-        // When a group fails to produce consensus, all its records are rejected
-        if self.track_rejects && result.count == 0 && !records.is_empty() {
-            self.rejected_reads.extend(records.into_iter().map(RawRecord::into_inner));
+        let result = self.consensus_reads_raw(&records);
+        // Route to the --rejects output exactly the records `consensus_reads_raw` counted
+        // as rejected, whether the whole group failed, the group hit a (recoverable)
+        // duplex disagreement, or individual reads were dropped from a group that still
+        // consensed. Mirrors fgbio's `rejectRecords`, which tags, counts and writes the
+        // same set in one step, so the rejects BAM and `--stats` cannot disagree (#751).
+        //
+        // This deliberately replaces a blanket "on `result.count == 0`, dump every record in
+        // the group" pass. That pass covered the counted rejects only by coincidence (their
+        // counts happen to sum to the group size), it double-wrote any read this method now
+        // routes at its own site, and it also emitted reads nothing counted -- which is what
+        // made the two outputs disagree in the first place. Records that reach the caller and
+        // are neither used nor counted (secondary/supplementary alignments, which the `codec`
+        // command already drops before grouping, and reads dropped by the `--max-reads` cap)
+        // are therefore not written, matching fgbio, which leaves both outside its rejects
+        // BAM as well.
+        if self.track_rejects {
+            self.drain_marked_rejects(records);
         }
-        Ok(result)
+        result
     }
 }
 
@@ -2567,6 +2677,64 @@ mod tests {
         assert_eq!(&rx[..], b"ACC-TGA", "RX tag should be preserved");
     }
 
+    /// A molecule whose consensus builds cleanly but cannot be serialized — an over-long
+    /// input-derived UMI drives the `<prefix>:<UMI>` read name past BAM's 254-byte limit — must
+    /// emit nothing AND leave every emitted counter at zero. The duplex tallies in particular
+    /// are computed while building the consensus (before serialization), so a regression that
+    /// folded them into `stats` eagerly would count duplex bases for a record that was never
+    /// written, desyncing `--stats` from the output BAM.
+    #[test]
+    fn duplex_counters_stay_zero_when_read_name_serialization_fails() {
+        let options = CodecConsensusOptions {
+            min_reads_per_strand: 1,
+            min_duplex_length: 1,
+            ..Default::default()
+        };
+        let mut caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
+
+        // An FR pair that overlaps for its full length produces duplex bases (so the tallies are
+        // non-zero), carried on an MI tag long enough that "codec:<umi>" exceeds 254 bytes.
+        let over_long_umi = "N".repeat(300);
+        let reads = create_fr_pair(
+            "read1",
+            1,
+            1,
+            30,
+            35,
+            &[(Kind::Match, 30)],
+            &[(Kind::Match, 30)],
+            &over_long_umi,
+            None,
+            false, // R1 forward
+            true,  // R2 reverse
+        );
+
+        let Err(err) = caller.consensus_reads_from_sam_records(reads) else {
+            panic!("an over-long UMI must fail to serialize the consensus record");
+        };
+        assert!(
+            format!("{err:#}").contains("could not write the consensus record"),
+            "error should name the un-writable consensus record, got: {err:#}",
+        );
+
+        assert_eq!(
+            caller.stats.consensus_duplex_bases_emitted, 0,
+            "no record was emitted, so no duplex bases may be counted",
+        );
+        assert_eq!(
+            caller.stats.duplex_disagreement_base_count, 0,
+            "no record was emitted, so no duplex disagreements may be counted",
+        );
+        assert_eq!(
+            caller.stats.consensus_reads_generated, 0,
+            "no record was emitted, so no consensus read may be counted",
+        );
+        assert_eq!(
+            caller.stats.consensus_bases_emitted, 0,
+            "no record was emitted, so no consensus bases may be counted",
+        );
+    }
+
     /// Port of fgbio test: "make a consensus where R1 has a deletion outside of the overlap region"
     #[test]
     fn test_make_consensus_r1_deletion() {
@@ -3233,18 +3401,163 @@ mod tests {
         );
     }
 
+    /// #751: a per-read rejection inside a molecule that *still* emits a consensus must
+    /// reach the `--rejects` output, not merely bump a counter.
+    ///
+    /// Before the fix `rejected_reads` was appended to only when the whole group failed
+    /// (`result.count == 0`) or hit a duplex disagreement, so `MinorityAlignment` — the
+    /// most common rejection on real data — reported a non-zero `raw_reads_rejected` in
+    /// `--stats` against a rejects BAM holding nothing at all. The two outputs must
+    /// reconcile, so this asserts the retained bytes are exactly the minority template's
+    /// records (identity, in input order), not merely that the count is right.
+    #[test]
+    fn test_minority_alignment_rejects_are_tracked_when_the_family_still_consenses() {
+        let options = CodecConsensusOptions {
+            min_reads_per_strand: 1,
+            min_duplex_length: 1,
+            ..Default::default()
+        };
+        let mut caller = CodecConsensusCaller::new_with_rejects_tracking(
+            "codec".to_string(),
+            "RG1".to_string(),
+            options,
+            true,
+        );
+
+        // Four templates; `tpl3` carries a minority indel pattern on both strands while the
+        // other three carry the majority ungapped one, so the family consenses from the
+        // three survivors and `tpl3`'s two records are rejected for MinorityAlignment.
+        let majority: Vec<(Kind, usize)> = vec![(Kind::Match, 30)];
+        let minority: Vec<(Kind, usize)> =
+            vec![(Kind::Match, 10), (Kind::Deletion, 2), (Kind::Match, 20)];
+        let mut reads: Vec<RawRecord> = Vec::new();
+        for i in 0..4 {
+            let cigar = if i == 3 { &minority } else { &majority };
+            reads.extend(create_fr_pair(
+                &format!("tpl{i}"),
+                1,
+                11,
+                30,
+                35,
+                cigar,
+                cigar,
+                "molecule1",
+                Some("ACC-TGA"),
+                false,
+                true,
+            ));
+        }
+
+        // Snapshot the minority template's raw bytes before `reads` is moved into the
+        // caller; `consensus_reads_typed` retains rejects in input order.
+        let expected_rejects: Vec<Vec<u8>> = reads
+            .iter()
+            .filter(|record| RawRecordView::new(record).read_name() == b"tpl3")
+            .map(|record| record.as_ref().to_vec())
+            .collect();
+        assert_eq!(expected_rejects.len(), 2, "the minority template contributes R1 and R2");
+
+        let output =
+            caller.consensus_reads_typed(reads).expect("the majority reads must still consense");
+        assert_eq!(output.count, 1, "the majority-alignment reads must still emit a consensus");
+
+        assert_eq!(
+            caller.statistics().rejection_reasons.get(&CallerRejectionReason::MinorityAlignment),
+            Some(&2),
+            "both minority records must be counted"
+        );
+        assert_eq!(
+            caller.statistics().reads_filtered,
+            2,
+            "raw_reads_rejected is derived from reads_filtered"
+        );
+        assert_eq!(
+            caller.rejected_reads(),
+            expected_rejects.as_slice(),
+            "the rejects output must hold exactly the counted records, byte-for-byte, so the \
+             rejects BAM reconciles with --stats"
+        );
+    }
+
+    /// #751: fragment reads are rejected per-read while the paired reads of the same
+    /// molecule go on to consense, so they too must reach the `--rejects` output.
+    #[test]
+    fn test_fragment_read_rejects_are_tracked_when_the_family_still_consenses() {
+        let options = CodecConsensusOptions {
+            min_reads_per_strand: 1,
+            min_duplex_length: 1,
+            ..Default::default()
+        };
+        let mut caller = CodecConsensusCaller::new_with_rejects_tracking(
+            "codec".to_string(),
+            "RG1".to_string(),
+            options,
+            true,
+        );
+
+        let mut reads = create_fr_pair(
+            "tpl0",
+            1,
+            11,
+            30,
+            35,
+            &[(Kind::Match, 30)],
+            &[(Kind::Match, 30)],
+            "molecule1",
+            Some("ACC-TGA"),
+            false,
+            true,
+        );
+        // An unpaired record in the same molecule: counted as FragmentRead, dropped before
+        // pairing, and the FR pair still consenses.
+        let mut fragment = SamBuilder::new();
+        fragment
+            .read_name(b"fragment")
+            .flags(0)
+            .ref_id(0)
+            .pos(0)
+            .mapq(60)
+            .cigar_ops(&[encode_op(0, 30)])
+            .sequence(&[b'A'; 30])
+            .qualities(&[35; 30]);
+        fragment.add_string_tag(SamTag::MI, b"molecule1");
+        let fragment = fragment.build();
+        let expected_reject = fragment.as_ref().to_vec();
+        reads.push(fragment);
+
+        let output = caller.consensus_reads_typed(reads).expect("the FR pair must still consense");
+        assert_eq!(output.count, 1, "the FR pair must still emit a consensus");
+
+        assert_eq!(
+            caller.statistics().rejection_reasons.get(&CallerRejectionReason::FragmentRead),
+            Some(&1),
+            "the fragment must be counted"
+        );
+        assert_eq!(
+            caller.rejected_reads(),
+            std::slice::from_ref(&expected_reject),
+            "the fragment must also reach the --rejects output"
+        );
+    }
+
     /// CODEC3-08: the `ClipOverlapFailed` reject (consensus shorter than a single
     /// strand — the overlapping ends could not be clipped, `CodecConsensusCaller.scala:243`)
     /// must be counted under its own reason and populate a metrics row under fgbio's
     /// verbatim label, *not* leak into `IndelErrorBetweenStrands` the way it did before
     /// the fix.
     ///
-    /// This exercises the counting/labeling contract at the reject-tallying seam:
-    /// `reject_records_count` is the single site every reject flows through, so pinning
-    /// the count, the filtered total, and the central-reason mapping here is what
-    /// guarantees the emitted metrics row is right when the branch fires.
-    /// `test_clip_overlap_failed_attribution_matches_fgbio` covers the complementary
-    /// half — reaching the branch through the whole pipeline.
+    /// The caller-level trigger (`consensus_length < ss.bases.len()` at the
+    /// `ClipOverlapFailed` site) is a degenerate overlap-clip boundary that fgbio itself
+    /// only reaches on specific real-data alignments; a synthetic pipeline fixture that
+    /// lands there without first tripping the earlier `IndelErrorBetweenStrands` phase
+    /// check would have to replicate fgbio's exact clip arithmetic and would be brittle.
+    /// This exercises the counting/labeling contract at the reject-tallying seam instead:
+    /// `reject_records_count` is the single site every reject is tallied at (the production
+    /// sites reach it through `reject_records_at`, which also routes the records to
+    /// `--rejects`), so pinning the count, the filtered total, and the central-reason
+    /// mapping here is what guarantees the emitted metrics row is right when the branch
+    /// does fire. `test_clip_overlap_failed_attribution_matches_fgbio` covers the
+    /// complementary half — reaching the branch through the whole pipeline.
     #[test]
     fn test_clip_overlap_failed_counted_and_labeled() {
         let options = CodecConsensusOptions {
@@ -3946,7 +4259,7 @@ mod tests {
             is_negative_strand: true,
         };
 
-        let duplex = caller
+        let (duplex, _tally) = caller
             .build_duplex_consensus_from_padded(&ss_a, &ss_b)
             .expect("Should build duplex consensus");
 
@@ -4003,7 +4316,7 @@ mod tests {
         let ss_a = deep.clone();
         let ss_b = SingleStrandConsensus { is_negative_strand: true, ..deep };
 
-        let duplex = caller
+        let (duplex, _tally) = caller
             .build_duplex_consensus_from_padded(&ss_a, &ss_b)
             .expect("Should build duplex consensus without overflowing");
 
@@ -4046,7 +4359,7 @@ mod tests {
         let ss_a = deep.clone();
         let ss_b = SingleStrandConsensus { is_negative_strand: true, ..deep };
 
-        let duplex = caller
+        let (duplex, _tally) = caller
             .build_duplex_consensus_from_padded(&ss_a, &ss_b)
             .expect("Should build duplex consensus without overflowing the error sum");
 

--- a/tests/integration/test_codec_command.rs
+++ b/tests/integration/test_codec_command.rs
@@ -12,9 +12,10 @@ use fgumi_dna::reverse_complement;
 use fgumi_lib::commands::codec::Codec;
 use fgumi_lib::commands::command::Command;
 use fgumi_lib::sam::SamTag;
-use fgumi_raw_bam::{RawRecord, SamBuilder, flags as raw_flags};
+use fgumi_raw_bam::{RawRecord, RawRecordView, SamBuilder, flags as raw_flags};
 use noodles::bam;
 use rstest::rstest;
+use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 use tempfile::TempDir;
@@ -668,6 +669,239 @@ fn test_codec_command_with_rejects() {
     let _rejects_header = rejects_reader.read_header().unwrap();
     let rejects_count = rejects_reader.records().count();
     assert_eq!(rejects_count, 2, "Rejects BAM should contain both reads of the failing molecule");
+}
+
+/// Builds a CODEC FR pair carrying an explicit CIGAR on both reads.
+///
+/// [`create_codec_read_pair`] derives an all-`M` CIGAR from the sequence length, so it
+/// cannot express the differing indel patterns the minority-alignment filter keys on.
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+fn create_codec_read_pair_with_cigar(
+    name: &str,
+    seq: &[u8],
+    ref_start: usize,
+    umi: &str,
+    cigar_ops: &[u32],
+) -> (RawRecord, RawRecord) {
+    let pos = i32::try_from(ref_start).expect("ref_start fits i32") - 1;
+    let qual = vec![30u8; seq.len()];
+
+    let mut b1 = SamBuilder::new();
+    b1.read_name(name.as_bytes())
+        .sequence(seq)
+        .qualities(&qual)
+        .cigar_ops(cigar_ops)
+        .flags(raw_flags::PAIRED | raw_flags::FIRST_SEGMENT | raw_flags::MATE_REVERSE)
+        .ref_id(0)
+        .pos(pos)
+        .mapq(60)
+        .mate_ref_id(0)
+        .mate_pos(pos)
+        .template_length(seq.len() as i32)
+        .add_string_tag(SamTag::MI, umi.as_bytes());
+
+    let mut b2 = SamBuilder::new();
+    b2.read_name(name.as_bytes())
+        .sequence(seq)
+        .qualities(&qual)
+        .cigar_ops(cigar_ops)
+        .flags(raw_flags::PAIRED | raw_flags::LAST_SEGMENT | raw_flags::REVERSE)
+        .ref_id(0)
+        .pos(pos)
+        .mapq(60)
+        .mate_ref_id(0)
+        .mate_pos(pos)
+        .template_length(-(seq.len() as i32))
+        .add_string_tag(SamTag::MI, umi.as_bytes());
+
+    (b1.build(), b2.build())
+}
+
+/// #751: the rejects BAM must reconcile with `--stats`.
+///
+/// The molecule here emits a consensus *and* drops reads: `minority` carries a minority
+/// indel pattern (`raw_reads_rejected_for_minority_alignment`) and `fragment` is unpaired
+/// (`raw_reads_rejected_for_non_paired_reads`). Both rejections happen inside a group
+/// that goes on to produce a consensus, which is exactly the case that used to be counted
+/// in `--stats` and written nowhere — `raw_reads_rejected` was non-zero against a rejects
+/// BAM of zero records. Asserted in both the single-threaded and pipeline paths, since
+/// they drain the caller's rejects through different code.
+#[rstest]
+#[case::single_threaded(None)]
+#[case::threaded(Some("2"))]
+fn test_codec_rejects_bam_reconciles_with_stats(#[case] threads: Option<&str>) {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let rejects_bam = temp_dir.path().join("rejects.bam");
+    let stats_file = temp_dir.path().join("stats.tsv");
+
+    // Three majority (30M) templates and one minority (10M2D20M) template, all in one
+    // molecule, so the majority reads still consense while the minority pair is dropped.
+    let ungapped = [30u32 << 4];
+    let gapped = [10u32 << 4, (2u32 << 4) | 2, 20u32 << 4];
+    let seq = [b'A'; 30];
+    let mut pairs = Vec::new();
+    for i in 0..3 {
+        pairs.push(create_codec_read_pair_with_cigar(
+            &format!("majority{i}"),
+            &seq,
+            1,
+            "UMI_MIX",
+            &ungapped,
+        ));
+    }
+    pairs.push(create_codec_read_pair_with_cigar("minority", &seq, 1, "UMI_MIX", &gapped));
+
+    // An unpaired read in the same molecule: rejected on its own while the FR pairs consense.
+    let mut fragment = SamBuilder::new();
+    fragment
+        .read_name(b"fragment")
+        .sequence(&seq)
+        .qualities(&[30u8; 30])
+        .cigar_ops(&ungapped)
+        .flags(0)
+        .ref_id(0)
+        .pos(0)
+        .mapq(60)
+        .add_string_tag(SamTag::MI, b"UMI_MIX");
+
+    let mut input_records: Vec<RawRecord> = Vec::new();
+    for (r1, r2) in pairs {
+        input_records.push(r1);
+        input_records.push(r2);
+    }
+    input_records.push(fragment.build());
+
+    // The --rejects contract is byte-for-byte preservation of the input record, so key the
+    // three expected rejects by (name, flags) and compare whole serialized records below.
+    let expected_rejects: HashMap<(Vec<u8>, u16), Vec<u8>> = input_records
+        .iter()
+        .filter(|record| {
+            matches!(RawRecordView::new(record).read_name(), b"minority" | b"fragment")
+        })
+        .map(|record| {
+            let view = RawRecordView::new(record);
+            ((view.read_name().to_vec(), view.flags()), record.as_ref().to_vec())
+        })
+        .collect();
+    assert_eq!(expected_rejects.len(), 3, "the minority pair and the fragment must be rejected");
+
+    let header = create_minimal_header("chr1", 10000);
+    let mut writer =
+        create_raw_bam_writer(&input_bam, &header, 1, 6).expect("Failed to create raw BAM writer");
+    for record in &input_records {
+        writer.write_raw_record(record.as_ref()).expect("Failed to write record");
+    }
+    writer.finish().expect("Failed to finish BAM");
+
+    let mut args = vec![
+        "codec",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--rejects",
+        rejects_bam.to_str().unwrap(),
+        "--stats",
+        stats_file.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--min-duplex-length",
+        "1",
+        "--compression-level",
+        "1",
+    ];
+    if let Some(threads) = threads {
+        args.extend_from_slice(&["--threads", threads]);
+    }
+    Codec::try_parse_from(args)
+        .expect("failed to parse codec args")
+        .execute("fgumi codec")
+        .expect("Failed to run codec command");
+
+    let mut output_reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    let _output_header = output_reader.read_header().unwrap();
+    assert_eq!(
+        output_reader.records().count(),
+        1,
+        "the majority-alignment reads must still emit a consensus"
+    );
+
+    let stats = fs::read_to_string(&stats_file).expect("Failed to read stats");
+    let stat = |key: &str| -> usize {
+        stats
+            .lines()
+            .find_map(|line| line.strip_prefix(&format!("{key}\t")))
+            .and_then(|rest| rest.split('\t').next())
+            .unwrap_or_else(|| panic!("stats must contain a {key} row"))
+            .parse()
+            .unwrap_or_else(|_| panic!("{key} must be an integer"))
+    };
+    assert_eq!(
+        stat("raw_reads_rejected_for_minority_alignment"),
+        2,
+        "the minority template's R1 and R2 must be rejected"
+    );
+    assert_eq!(
+        stat("raw_reads_rejected_for_non_paired_reads"),
+        1,
+        "the fragment read must be rejected"
+    );
+
+    // Read the rejects back as raw records so the whole serialized record is compared, not
+    // just the fields noodles decodes ergonomically: a rejects BAM that dropped tags or
+    // rewrote a CIGAR would satisfy a name-and-count assertion.
+    let (mut rejects_reader, _rejects_header) =
+        fgumi_bam_io::create_raw_bam_reader(&rejects_bam, 1).expect("open rejects BAM");
+    let mut seen: Vec<(Vec<u8>, u16)> = Vec::new();
+    let mut record = RawRecord::new();
+    while rejects_reader.read_record(&mut record).expect("read reject record") != 0 {
+        let key = (RawRecordView::new(&record).read_name().to_vec(), record.flags());
+        let expected = expected_rejects.get(&key).unwrap_or_else(|| {
+            panic!("unexpected reject record {}", String::from_utf8_lossy(&key.0))
+        });
+        assert_eq!(
+            record.as_ref(),
+            expected.as_slice(),
+            "each reject must be byte-for-byte identical to its input record — every field \
+             and tag preserved on the --rejects path"
+        );
+        assert!(!seen.contains(&key), "a reject record was written more than once");
+        seen.push(key);
+    }
+
+    assert_eq!(
+        seen.len(),
+        expected_rejects.len(),
+        "the rejects BAM must hold exactly the reads counted as rejected"
+    );
+    assert_eq!(
+        seen.len(),
+        stat("raw_reads_rejected"),
+        "the rejects BAM record count must equal raw_reads_rejected"
+    );
+
+    // The --rejects path preserves input order: `drain_marked_rejects` walks each group's
+    // records in input order (see `CodecConsensusCaller::drain_marked_rejects`), and this
+    // molecule is a single group, so both the single-threaded and pipeline paths emit the
+    // rejects in the order they appeared in the input. Assert the exact ordered sequence —
+    // including both the minority-alignment pair and the fragment reject — so a reordering
+    // regression on the mixed-rejection path cannot pass on membership and count alone.
+    let expected_reject_order: Vec<(Vec<u8>, u16)> = input_records
+        .iter()
+        .filter(|record| {
+            matches!(RawRecordView::new(record).read_name(), b"minority" | b"fragment")
+        })
+        .map(|record| {
+            let view = RawRecordView::new(record);
+            (view.read_name().to_vec(), view.flags())
+        })
+        .collect();
+    assert_eq!(
+        seen, expected_reject_order,
+        "the rejects BAM must emit the rejected reads in their original input order"
+    );
 }
 
 /// Test CODEC command with minimum duplex length filter.


### PR DESCRIPTION
Closes #751.

## What was broken

`codec --rejects` appended to the rejects buffer at exactly two sites, both whole-group conditions in `consensus_reads_typed`: a recoverable duplex disagreement, and a molecule that produced no consensus at all. Reads dropped *inside* a molecule that still consensed were counted in `--stats` and written nowhere, so the two outputs could not be reconciled. The issue's reproduction reports `raw_reads_rejected = 42` (all `minority_alignment`) against a rejects BAM holding zero records.

## Where the issue was wrong

The issue says per-read rejections are "recorded via `reject_records_count`" and never routed onward. The routing claim is right; the attribution is not. `MinorityAlignment` — the reason the reproduction is entirely made of — did **not** go through `reject_records_count` at all. `filter_to_most_common_alignment_raw` bumped `stats.rejection_reasons` and `stats.reads_filtered` inline, bypassing the shared tallying helper. The doc comment on `test_clip_overlap_failed_counted_and_labeled` asserting `reject_records_count` "is the single site every reject flows through" was therefore inaccurate when written. It is accurate now, and has been reworded to say so precisely.

Everything else in the issue holds: both append sites are whole-group, the per-read reasons never reach the writer, and record-count-equals-`raw_reads_rejected` is the right invariant to pin.

## The fix

Every rejection site records *which* records it rejected as it counts them, via a new `reject_records_at(indices, reason)` that both tallies and marks a per-group `reject_mask`. `consensus_reads_typed` then moves exactly the marked set into the rejects buffer, in input order, taking the group by value so the bytes are moved rather than copied.

That replaces the blanket "on `result.count == 0`, dump every record in the group" pass. Worth being explicit that this is a deliberate narrowing rather than a pure addition: the old pass matched the counters only by coincidence (the per-reason counts happen to sum to the group size when no record is filtered out uncounted), it would have double-written anything the new per-read routing emits, and it also emitted records that nothing counted. The records that are now *not* written are the ones neither used nor counted: secondary/supplementary alignments (which `codec` already drops before grouping via `consensus_pregroup_keep_flags`, so this is unreachable from the CLI) and reads dropped by the `--max-reads` cap. fgbio leaves both outside its rejects BAM as well — its whole-family codec rejects pass `(r1s.view ++ r2s.view)`, i.e. the survivors of `filterToMostCommonAlignment`, not the raw group.

## Tests

TDD; all three failed before the fix with an empty rejects output and passed after, with the counters already correct in the failing runs.

- `test_minority_alignment_rejects_are_tracked_when_the_family_still_consenses` — four templates, one carrying a minority indel pattern on both strands. Asserts a consensus is still emitted, the two counters, and that the retained bytes are *exactly* the minority template's two records (identity, in input order), not merely the right count.
- `test_fragment_read_rejects_are_tracked_when_the_family_still_consenses` — the same shape for a second reason, so the fix is pinned as a class rather than one branch.
- `test_codec_rejects_bam_reconciles_with_stats` (integration, single-threaded and `--threads 2`) — pins the invariant end to end: the rejects BAM record count equals `raw_reads_rejected` from `--stats` for an input where one molecule both emits a consensus and drops reads. Each reject is compared byte-for-byte against its input record, so a rejects BAM that dropped a tag or rewrote a CIGAR fails rather than passing a name-and-count check.

The existing rejects tests keep passing unchanged, which is what covers the narrowing: `test_codec_command_with_rejects` (whole molecule below `--min-reads`) and `test_high_duplex_disagreement_tracks_rejects` (byte identity on the HDD path) both still get every record of the failed molecule.

## Not changed here

- **`simplex` and `duplex` do not share this gap** — checked site by site rather than assumed. `VanillaUmiConsensusCaller` already routes its per-read rejections (`MinorityAlignment`, `Unmapped`, `ZeroLengthAfterTrimming`, `SecondaryOrSupplementary`) into `rejected_reads` at the point of rejection, and every duplex-level rejection is whole-group and routes the same records it counts. Both reconcile today. Duplex does have the *dual* defect — reads the single-strand caller drops inside a surviving molecule are counted into `ss_caller.stats`, which `DuplexConsensusCaller::statistics()` never merges, so they appear in neither output and `raw_reads_rejected` under-reports. That is a different bug and belongs in its own issue.
- **No `rr` tag.** fgbio tags every rejected record with `rr` = the reason code (`minority_alignment`, `insufficient_support`, …) in `UmiConsensusCaller.rejectRecords`, first-writer-wins. fgumi writes no `rr` tag anywhere, on any command — so this is a pre-existing gap across the whole rejects surface, not something codec lost. Adding it means rewriting the record bytes to append a tag and touching all four commands, so it wants its own change rather than being smuggled in here.

## Memory

No new growth. `reject_mask` is a `Vec<bool>` sized to one MI group and reused across groups. The rejected records themselves are moved out of the group's own `Vec<RawRecord>`, which is already fully resident, and both drain sites (`codec.rs` single-threaded per group, threaded per batch) already existed and are unchanged — the pre-fix worst case, a batch in which every group fails, dominates the post-fix one.

## Gate

`cargo ci-fmt`, `cargo ci-lint`, `cargo ci-test` (7498 passed, 30 skipped) and `cargo ci-doctest` all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: rejects output changes, pinned by original record bytes, input order, and matching `raw_reads_rejected` statistics; `unsafe` changes: none, with no `CLAUDE.md` allowlist update; memory bounds, queue capacity, and thread/backpressure policy changes: none.

The fix routes per-read rejections to the rejects output, including reads from molecules that still produce a consensus. Whole-group fallback rejection avoids duplicate or uncounted records. Single-threaded and multithreaded tests verify byte-preserving rejects output and statistics reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->