### PR TITLE
fix(duplex): reconcile single-strand rejections with --stats and --rejects

### DIFF
--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -214,6 +214,23 @@ use crate::vanilla_caller::{
 use crate::{ReadType, SourceRead};
 use fgumi_raw_bam::{self as bam_fields, RawRecord, RawRecordView, UnmappedSamBuilder, flags};
 use fgumi_sam::SamTag;
+use std::collections::HashSet;
+
+/// What the duplex layer did with one MI group's raw input records.
+///
+/// The two variants cannot be told apart by the payload: records are collected only when
+/// rejects tracking is on, so an empty payload means "nothing to emit", not "the group
+/// survived". The single-strand layer's rejections are folded in on exactly one of these
+/// two paths, so conflating them would double-count every run made without `--rejects`.
+enum DuplexGroupOutcome {
+    /// The duplex layer did not reject the group as a whole. Any rejections for this group
+    /// came from the single-strand layer, and are held by the single-strand caller.
+    Kept,
+    /// The duplex layer rejected the whole group and already counted every one of its raw
+    /// records, so the single-strand layer's subset is covered. The payload is every raw
+    /// input record when rejects tracking is on, and empty when it is off.
+    RejectedWholeGroup(Vec<Vec<u8>>),
+}
 
 /// Duplex consensus read - matches fgbio's `DuplexConsensusRead`
 ///
@@ -304,7 +321,9 @@ pub struct DuplexConsensusCaller {
     produce_per_base_tags: bool,
     /// Cell barcode tag (e.g., CB) for preserving cell barcodes
     cell_tag: Option<Tag>,
-    /// Statistics tracking
+    /// Statistics tracking, including the single-strand caller's rejections: `consensus_reads`
+    /// folds that caller's per-molecule delta in here, so `ss_caller` keeps no running totals
+    /// of its own and this is the one place duplex counters live.
     stats: ConsensusCallingStats,
     /// Single-strand consensus caller (used for both /A and /B families)
     /// Uses `min_reads=1` like fgbio; filtering happens at duplex level
@@ -1810,6 +1829,61 @@ impl DuplexConsensusCaller {
         Ok(Some(duplex))
     }
 
+    /// Ordinals into the group's canonical (`a` records then `b` records) input order for the
+    /// records matching `a_pred` among `a_records`, followed by those matching `b_pred` among
+    /// `b_records`. Built with the same filter+chain the partition's raws vector uses, so the
+    /// result is parallel to it: pass `(is_paired_r1, is_paired_r2)` for X (AB-R1 + BA-R2) and
+    /// `(is_paired_r2, is_paired_r1)` for Y (AB-R2 + BA-R1).
+    fn group_ordinals<A, B>(
+        a_records: &[RawRecord],
+        b_records: &[RawRecord],
+        a_pred: A,
+        b_pred: B,
+    ) -> Vec<usize>
+    where
+        A: Fn(&RawRecord) -> bool,
+        B: Fn(&RawRecord) -> bool,
+    {
+        a_records
+            .iter()
+            .enumerate()
+            .filter(|&(_, r)| a_pred(r))
+            .map(|(i, _)| i)
+            .chain(
+                b_records
+                    .iter()
+                    .enumerate()
+                    .filter(|&(_, r)| b_pred(r))
+                    .map(|(j, _)| a_records.len() + j),
+            )
+            .collect()
+    }
+
+    /// Collects the raw records behind a single-strand alignment rejection, tagged with each
+    /// record's ordinal in the group's canonical (`a` records then `b` records) input order.
+    ///
+    /// `rejected` holds indices into `raws`, and `ordinals[i]` is the group ordinal of
+    /// `raws[i]`. Returning `(ordinal, record)` pairs — rather than recording them straight
+    /// away — lets the caller merge the X and Y partitions' rejects into a single
+    /// input-ordered sequence before handing them to `ss_caller`. The two partitions split a
+    /// template's ends across strands (X = AB-R1 + BA-R2, Y = AB-R2 + BA-R1), so recording X
+    /// before Y would write a `/B` template's R2 ahead of its R1 even though the input wrote
+    /// R1 first; sorting by ordinal restores input order.
+    fn collect_ss_rejects<'a>(
+        raws: &[&'a RawRecord],
+        ordinals: &[usize],
+        rejected: &HashSet<usize>,
+        out: &mut Vec<(usize, &'a RawRecord)>,
+    ) {
+        out.extend(
+            raws.iter()
+                .zip(ordinals)
+                .enumerate()
+                .filter(|(idx, _)| rejected.contains(idx))
+                .map(|(_, (raw, &ordinal))| (ordinal, *raw)),
+        );
+    }
+
     /// Processes a single UMI group to generate duplex consensus
     #[expect(clippy::too_many_arguments, reason = "group processing requires many parameters")]
     #[expect(
@@ -1833,31 +1907,33 @@ impl DuplexConsensusCaller {
         read_group_id: &str,
         cell_tag: Option<Tag>,
         track_rejects: bool,
-    ) -> Result<(ConsensusOutput, ConsensusCallingStats, Vec<Vec<u8>>)> {
+    ) -> Result<(ConsensusOutput, ConsensusCallingStats, DuplexGroupOutcome)> {
         let mut stats = ConsensusCallingStats::new();
         let mut builder = UnmappedSamBuilder::new();
         let mut read_name_buf = Vec::new();
         let mut output = ConsensusOutput::default();
         let methylation_mode = ss_caller.options.methylation_mode;
 
-        // Helper: move raw input records into the reject payload if rejects are being
-        // tracked. Each rejection site moves `a_records`/`b_records` into the reject
-        // vec so we never hold both the input and reject copies simultaneously.
-        // Single-strand rejections are captured separately by `ss_caller`.
+        // Helper: mark the whole group as rejected by the duplex layer, moving its raw input
+        // records into the reject payload if rejects are being tracked. Each rejection site
+        // moves `a_records`/`b_records` into the reject vec so we never hold both the input
+        // and reject copies simultaneously. Single-strand rejections are captured separately
+        // by `ss_caller` and are subsumed by this whole-group set.
         let collect_rejected_raw =
-            |track: bool, a: Vec<RawRecord>, b: Vec<RawRecord>| -> Vec<Vec<u8>> {
-                if track {
+            |track: bool, a: Vec<RawRecord>, b: Vec<RawRecord>| -> DuplexGroupOutcome {
+                let records = if track {
                     let mut v: Vec<Vec<u8>> = a.into_iter().map(RawRecord::into_inner).collect();
                     v.extend(b.into_iter().map(RawRecord::into_inner));
                     v
                 } else {
                     Vec::new()
-                }
+                };
+                DuplexGroupOutcome::RejectedWholeGroup(records)
             };
 
         // Check if we have both strands
         if a_records.is_empty() && b_records.is_empty() {
-            return Ok((ConsensusOutput::default(), stats, Vec::new()));
+            return Ok((ConsensusOutput::default(), stats, DuplexGroupOutcome::Kept));
         }
 
         // Check if we have enough input reads (matching fgbio's hasMinimumNumberOfReads)
@@ -1945,7 +2021,7 @@ impl DuplexConsensusCaller {
             ab_r2s.len() + ba_r1s.len()
         );
 
-        // Keep references to original raw records for later tag extraction
+        // Keep references to original raw records for later tag extraction.
         let x_raws: Vec<&RawRecord> = ab_r1s.iter().chain(ba_r2s.iter()).copied().collect();
         let x_sources: Vec<SourceRead> = x_raws
             .iter()
@@ -1973,9 +2049,38 @@ impl DuplexConsensusCaller {
             y_sources.len()
         );
 
-        // Filter by common alignment (combined across strands)
-        let (filtered_xs, _) = ss_caller.filter_by_alignment(x_sources);
-        let (filtered_ys, _) = ss_caller.filter_by_alignment(y_sources);
+        // Filter by common alignment (combined across strands). The filter counts what it
+        // dropped on `ss_caller` but returns only the rejected indices, because the raw
+        // records belong to this caller — hand them back so they reach `--rejects` too.
+        // Merge both partitions' rejects by group ordinal before recording so a template
+        // whose ends are split across X and Y (e.g. a `/B` template) still lands in the
+        // rejects BAM in input order rather than X-before-Y order.
+        let (filtered_xs, x_rejected) = ss_caller.filter_by_alignment(x_sources);
+        let (filtered_ys, y_rejected) = ss_caller.filter_by_alignment(y_sources);
+        if track_rejects {
+            // Each raw record's ordinal is its position in the group's canonical `a`
+            // records-then-`b` records input order — the same order the whole-group reject
+            // path emits. The ordinal vectors are built with the same filter+chain as
+            // `x_raws`/`y_raws` so they stay parallel, and are computed here (only when
+            // tracking rejects) to keep the common `--rejects`-off path allocation-free.
+            let x_ordinals = Self::group_ordinals(
+                &a_records,
+                &b_records,
+                Self::is_paired_r1,
+                Self::is_paired_r2,
+            );
+            let y_ordinals = Self::group_ordinals(
+                &a_records,
+                &b_records,
+                Self::is_paired_r2,
+                Self::is_paired_r1,
+            );
+            let mut ss_rejects: Vec<(usize, &RawRecord)> = Vec::new();
+            Self::collect_ss_rejects(&x_raws, &x_ordinals, &x_rejected, &mut ss_rejects);
+            Self::collect_ss_rejects(&y_raws, &y_ordinals, &y_rejected, &mut ss_rejects);
+            ss_rejects.sort_by_key(|&(ordinal, _)| ordinal);
+            ss_caller.record_rejected_raw(ss_rejects.iter().map(|&(_, raw)| raw));
+        }
 
         debug!(
             "MI {}: After alignment filtering (X={}, Y={})",
@@ -2186,7 +2291,7 @@ impl DuplexConsensusCaller {
                             cell_barcode.as_deref(),
                         )?;
                         stats.record_consensus_pair();
-                        return Ok((output, stats, Vec::new()));
+                        return Ok((output, stats, DuplexGroupOutcome::Kept));
                     }
                     stats.record_rejection(
                         RejectionReason::InsufficientReads,
@@ -2264,7 +2369,7 @@ impl DuplexConsensusCaller {
                             cell_barcode.as_deref(),
                         )?;
                         stats.record_consensus_pair();
-                        return Ok((output, stats, Vec::new()));
+                        return Ok((output, stats, DuplexGroupOutcome::Kept));
                     }
                 }
             }
@@ -2338,7 +2443,7 @@ impl DuplexConsensusCaller {
                             cell_barcode.as_deref(),
                         )?;
                         stats.record_consensus_pair();
-                        return Ok((output, stats, Vec::new()));
+                        return Ok((output, stats, DuplexGroupOutcome::Kept));
                     }
                 }
             }
@@ -2388,7 +2493,7 @@ impl ConsensusCaller for DuplexConsensusCaller {
 
         let produce_per_base_tags = self.produce_per_base_tags;
 
-        let (output, group_stats, duplex_rejected_raw) = Self::process_group(
+        let (output, group_stats, duplex_outcome) = Self::process_group(
             base_mi,
             a_records,
             b_records,
@@ -2405,17 +2510,28 @@ impl ConsensusCaller for DuplexConsensusCaller {
 
         self.stats.merge(&group_stats);
 
-        if self.track_rejects {
-            // When the duplex layer rejects the group, `duplex_rejected_raw`
-            // already contains every raw input record (collected via
-            // `collect_rejected_raw`), so the ss-layer rejects — which are a
-            // subset of those same records — would be duplicates. Drain the
-            // ss-caller regardless to reset its state, but only emit one source.
-            let ss_rejected_raw = self.ss_caller.take_rejected_reads();
-            if duplex_rejected_raw.is_empty() {
-                self.rejected_reads.extend(ss_rejected_raw);
-            } else {
-                self.rejected_reads.extend(duplex_rejected_raw);
+        // The single-strand caller accumulates its own counters and rejects for this group;
+        // drain both unconditionally so nothing leaks into the next group, then fold in
+        // whichever source is the group's authoritative one.
+        //
+        // When the duplex layer rejects the group it counts and returns *every* raw input
+        // record, so the single-strand layer's rejections — a subset of those same records —
+        // are already covered. Adding them on top would report more rejected reads than the
+        // rejects BAM holds. Otherwise the group survived, and the single-strand drops are
+        // the only rejections it produced: they belong in both outputs.
+        let ss_stats = self.ss_caller.take_statistics();
+        let ss_rejected_raw = self.ss_caller.take_rejected_reads();
+        match duplex_outcome {
+            DuplexGroupOutcome::Kept => {
+                self.stats.merge(&ss_stats);
+                if self.track_rejects {
+                    self.rejected_reads.extend(ss_rejected_raw);
+                }
+            }
+            DuplexGroupOutcome::RejectedWholeGroup(duplex_rejected_raw) => {
+                if self.track_rejects {
+                    self.rejected_reads.extend(duplex_rejected_raw);
+                }
             }
         }
 
@@ -2444,14 +2560,12 @@ impl ConsensusCaller for DuplexConsensusCaller {
         info!("  Consensus reads constructed: {}", self.consensus_reads_constructed());
         info!("  Total filtered: {}", self.total_filtered());
 
-        // Log rejection breakdown
+        // Log rejection breakdown. The single-strand caller's rejections are folded into
+        // `self.stats` per molecule, so they are already in this breakdown; logging that
+        // caller separately would report zeroes and imply its drops went uncounted.
         for (reason, count) in &self.stats.rejection_reasons {
             info!("    {}: {}", reason.description(), count);
         }
-
-        // Log single-strand caller statistics
-        info!("Single-strand caller:");
-        self.ss_caller.log_statistics();
     }
 }
 
@@ -3779,6 +3893,236 @@ mod tests {
             result.count
         );
 
+        Ok(())
+    }
+
+    /// Builds one duplex molecule, optionally seeded with minority-alignment templates.
+    ///
+    /// Each strand gets `majority_templates` templates carrying `10M`. When `gapped_a` (or
+    /// `gapped_b`) is set, that strand also gets one `4M1D6M` template named `minority_a`
+    /// (`minority_b`): same query length, different alignment pattern. Both halves of such a
+    /// template land in the minority of their combined alignment group — R1 among
+    /// AB-R1 + BA-R2, R2 among AB-R2 + BA-R1 — so the single-strand layer drops both while
+    /// the majority reads go on to consense.
+    fn duplex_molecule(
+        majority_templates: usize,
+        gapped_a: bool,
+        gapped_b: bool,
+    ) -> Vec<RawRecord> {
+        let cigar_10m = &[encode_op(0, 10)];
+        let cigar_gapped = &[encode_op(0, 4), encode_op(2, 1), encode_op(0, 6)];
+        let quals = &[20u8; 10];
+        let mut b = SamBuilder::new();
+
+        let mut reads = Vec::new();
+        for i in 0..majority_templates {
+            let ab = format!("ab{i}");
+            let ba = format!("ba{i}");
+            reads.push(ab_r1(
+                &mut b,
+                ab.as_bytes(),
+                b"AAAAAAAAAA",
+                quals,
+                cigar_10m,
+                b"foo/A",
+                &[],
+            ));
+            reads.push(ab_r2(
+                &mut b,
+                ab.as_bytes(),
+                b"CCCCCCCCCC",
+                quals,
+                cigar_10m,
+                b"foo/A",
+                &[],
+            ));
+            reads.push(ba_r1(
+                &mut b,
+                ba.as_bytes(),
+                b"CCCCCCCCCC",
+                quals,
+                cigar_10m,
+                b"foo/B",
+                &[],
+            ));
+            reads.push(ba_r2(
+                &mut b,
+                ba.as_bytes(),
+                b"AAAAAAAAAA",
+                quals,
+                cigar_10m,
+                b"foo/B",
+                &[],
+            ));
+        }
+        if gapped_a {
+            let n = b"minority_a";
+            reads.push(ab_r1(&mut b, n, b"AAAAAAAAAA", quals, cigar_gapped, b"foo/A", &[]));
+            reads.push(ab_r2(&mut b, n, b"CCCCCCCCCC", quals, cigar_gapped, b"foo/A", &[]));
+        }
+        if gapped_b {
+            let n = b"minority_b";
+            reads.push(ba_r1(&mut b, n, b"CCCCCCCCCC", quals, cigar_gapped, b"foo/B", &[]));
+            reads.push(ba_r2(&mut b, n, b"AAAAAAAAAA", quals, cigar_gapped, b"foo/B", &[]));
+        }
+        reads
+    }
+
+    /// Builds a duplex caller for the #757 fixtures above.
+    fn rejection_accounting_caller(
+        min_reads: Vec<usize>,
+        track_rejects: bool,
+    ) -> Result<DuplexConsensusCaller> {
+        DuplexConsensusCaller::new(
+            "consensus".to_string(),
+            "RG1".to_string(),
+            min_reads,
+            10,
+            false,
+            false,
+            None,
+            None,
+            track_rejects,
+            45,
+            40,
+        )
+    }
+
+    /// #757: single-strand rejections inside a surviving molecule must reach `statistics()`.
+    ///
+    /// The single-strand caller keeps its own [`ConsensusCallingStats`], and the duplex caller
+    /// returned only its own. A read the single-strand layer dropped from a molecule that still
+    /// produced a duplex consensus was therefore counted nowhere, so `raw_reads_rejected`
+    /// under-reported and `--stats` could not reconcile with `--rejects`.
+    ///
+    /// Also pins that the merge adds only rejections: `total_reads` and `consensus_reads` must
+    /// stay at the duplex layer's own values, because the single-strand caller's input and
+    /// consensus counters are untouched on this path and folding them in would double-count.
+    #[test]
+    fn test_single_strand_rejections_reach_the_duplex_statistics() -> Result<()> {
+        let mut caller = rejection_accounting_caller(vec![1], true)?;
+
+        let reads = duplex_molecule(3, true, false);
+        let input_count = reads.len();
+        // The `--rejects` contract is byte-for-byte preservation, so keep the input bytes to
+        // compare against rather than checking read names: a reject path that re-serialized
+        // the record or dropped a tag would satisfy a name-and-count assertion.
+        let expected_rejects: Vec<Vec<u8>> = reads
+            .iter()
+            .filter(|record| fgumi_raw_bam::read_name(record) == b"minority_a")
+            .map(|record| record.to_vec())
+            .collect();
+        assert_eq!(expected_rejects.len(), 2, "the minority template contributes two records");
+        let result = caller.consensus_reads(reads)?;
+
+        assert_eq!(result.count, 2, "the majority-alignment reads must still emit a duplex pair");
+
+        let stats = caller.statistics();
+        assert_eq!(
+            stats.rejection_reasons.get(&RejectionReason::MinorityAlignment).copied().unwrap_or(0),
+            2,
+            "both halves of the minority template must be counted as minority-alignment"
+        );
+        assert_eq!(stats.filtered_reads, 2, "raw_reads_rejected must count the two dropped reads");
+        assert_eq!(
+            stats.total_reads, input_count,
+            "merging the single-strand counters must not inflate the input count"
+        );
+        assert_eq!(
+            stats.consensus_reads, 2,
+            "merging the single-strand counters must not inflate the consensus count"
+        );
+
+        assert_eq!(
+            caller.rejected_reads, expected_rejects,
+            "the rejects buffer must hold exactly the minority template's two records, \
+             byte-for-byte and in input order"
+        );
+        assert_eq!(
+            caller.rejected_reads.len(),
+            stats.filtered_reads,
+            "the rejects buffer must reconcile with raw_reads_rejected"
+        );
+        Ok(())
+    }
+
+    /// #757: the single-strand delta must be dropped when the duplex layer rejects the group.
+    ///
+    /// A whole-group duplex rejection counts *every* raw input record and moves every one of
+    /// them to the rejects buffer, so the single-strand layer's earlier rejections are already
+    /// covered — folding its counters in on top would report more rejected reads than the
+    /// rejects BAM holds.
+    ///
+    /// `min_reads = 4` is met before single-strand filtering (four templates per strand) and
+    /// missed after it (three survive per strand), which is the only way to reach a whole-group
+    /// rejection *downstream* of the single-strand layer. The control run pins that: the same
+    /// depth with no minority templates consenses under the same threshold, so the rejection
+    /// below is caused by the single-strand drops rather than by the raw depth.
+    #[test]
+    fn test_single_strand_rejections_are_not_double_counted_on_whole_group_rejection() -> Result<()>
+    {
+        let mut control = rejection_accounting_caller(vec![4], true)?;
+        let control_result = control.consensus_reads(duplex_molecule(4, false, false))?;
+        assert_eq!(
+            control_result.count, 2,
+            "four clean templates per strand must clear min_reads = 4, so the rejection below \
+             is downstream of the single-strand filter rather than at the pre-filter check"
+        );
+
+        let mut caller = rejection_accounting_caller(vec![4], true)?;
+        let reads = duplex_molecule(3, true, true);
+        let input_count = reads.len();
+
+        let result = caller.consensus_reads(reads)?;
+        assert_eq!(result.count, 0, "the molecule must fail the post-filter depth threshold");
+
+        let stats = caller.statistics();
+        assert_eq!(
+            stats.filtered_reads, input_count,
+            "a whole-group rejection counts every input record exactly once"
+        );
+        assert_eq!(
+            stats.rejection_reasons.get(&RejectionReason::InsufficientReads).copied().unwrap_or(0),
+            input_count,
+            "the whole group is attributed to the duplex layer's own reason"
+        );
+        assert_eq!(
+            stats.rejection_reasons.get(&RejectionReason::MinorityAlignment),
+            None,
+            "the single-strand reasons must not be added on top of the whole-group count"
+        );
+        assert_eq!(
+            caller.rejected_reads.len(),
+            stats.filtered_reads,
+            "the rejects buffer must reconcile with raw_reads_rejected"
+        );
+        Ok(())
+    }
+
+    /// #757: the counters must not depend on whether `--rejects` was requested.
+    ///
+    /// The reject payload is empty whenever tracking is off, so "the duplex layer rejected the
+    /// whole group" cannot be inferred from an empty payload — inferring it that way would fold
+    /// the single-strand delta in on top of the whole-group count on every untracked run, i.e.
+    /// exactly the double-count above but visible only without `--rejects`.
+    #[test]
+    fn test_whole_group_rejection_counts_are_independent_of_rejects_tracking() -> Result<()> {
+        let stats_for = |track_rejects: bool| -> Result<ConsensusCallingStats> {
+            let mut caller = rejection_accounting_caller(vec![4], track_rejects)?;
+            caller.consensus_reads(duplex_molecule(3, true, true))?;
+            Ok(caller.statistics())
+        };
+
+        let tracked = stats_for(true)?;
+        let untracked = stats_for(false)?;
+        assert_eq!(
+            tracked.filtered_reads, untracked.filtered_reads,
+            "rejects tracking must not change the rejected-read count"
+        );
+        assert_eq!(
+            tracked.rejection_reasons, untracked.rejection_reasons,
+            "rejects tracking must not change the per-reason breakdown"
+        );
         Ok(())
     }
 

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -535,6 +535,31 @@ impl VanillaUmiConsensusCaller {
         self.rejected_reads.clear();
     }
 
+    /// Records `records` as rejected by this caller, when rejects tracking is enabled.
+    ///
+    /// [`Self::filter_by_alignment`] returns the *indices* it rejected rather than the raw
+    /// records, because a composing caller — not this one — owns those bytes. A caller that
+    /// reaches the filter directly instead of through [`Self::consensus_reads`] hands the
+    /// matching records back here so [`Self::take_rejected_reads`] drains them alongside this
+    /// caller's own rejections.
+    pub(crate) fn record_rejected_raw<'a, I>(&mut self, records: I)
+    where
+        I: IntoIterator<Item = &'a RawRecord>,
+    {
+        if self.track_rejects {
+            self.rejected_reads.extend(records.into_iter().map(|record| record.to_vec()));
+        }
+    }
+
+    /// Takes the accumulated statistics, leaving this caller's counters at zero.
+    ///
+    /// A composing caller drives this one per molecule and folds the resulting delta into its
+    /// own statistics; taking rather than cloning is what keeps that fold from re-counting
+    /// every molecule processed so far.
+    pub(crate) fn take_statistics(&mut self) -> ConsensusCallingStats {
+        std::mem::take(&mut self.stats)
+    }
+
     /// Clears all per-group state to prepare for reuse
     ///
     /// This resets statistics and rejected reads while preserving the caller's

--- a/tests/integration/test_duplex_command.rs
+++ b/tests/integration/test_duplex_command.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 use fgumi_lib::commands::command::Command;
 use fgumi_lib::commands::duplex::Duplex;
 use fgumi_lib::sam::SamTag;
-use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
+use fgumi_raw_bam::{RawRecord, RawRecordView, SamBuilder, flags};
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use rstest::rstest;
@@ -55,10 +55,36 @@ fn create_duplex_read_pair_with_sequences(
     ref_start: i32,
     is_b_strand: bool,
 ) -> (RawRecord, RawRecord) {
+    let cigar_ops = [u32::try_from(r1_sequence.len()).expect("read_len fits u32") << 4];
+    create_duplex_read_pair_with_cigar(
+        name,
+        mi_tag,
+        r1_sequence,
+        r2_sequence,
+        quality,
+        ref_start,
+        is_b_strand,
+        &cigar_ops,
+    )
+}
+
+/// As [`create_duplex_read_pair_with_sequences`], but with a caller-supplied CIGAR on both
+/// reads. The other constructors derive an all-`M` CIGAR from the sequence length, so they
+/// cannot express the differing alignment patterns the minority-alignment filter keys on.
+#[expect(clippy::too_many_arguments, reason = "test fixture builder mirrors the BAM fields")]
+fn create_duplex_read_pair_with_cigar(
+    name: &str,
+    mi_tag: &str,
+    r1_sequence: &str,
+    r2_sequence: &str,
+    quality: u8,
+    ref_start: i32,
+    is_b_strand: bool,
+    cigar_ops: &[u32],
+) -> (RawRecord, RawRecord) {
     assert_eq!(r1_sequence.len(), r2_sequence.len(), "R1 and R2 must be the same length");
     let seq = r1_sequence.as_bytes();
     let read_len = seq.len();
-    let cigar_op = u32::try_from(read_len).expect("read_len fits u32") << 4;
 
     let (r1_start, r2_start, r1_rev, r2_rev) = if is_b_strand {
         // B strand: RF orientation — R1 reverse at far position, R2 forward at near
@@ -94,7 +120,7 @@ fn create_duplex_read_pair_with_sequences(
             .ref_id(0)
             .pos(r1_start - 1)
             .mapq(60)
-            .cigar_ops(&[cigar_op])
+            .cigar_ops(cigar_ops)
             .mate_ref_id(0)
             .mate_pos(r2_start - 1)
             .template_length(tlen)
@@ -111,7 +137,7 @@ fn create_duplex_read_pair_with_sequences(
             .ref_id(0)
             .pos(r2_start - 1)
             .mapq(60)
-            .cigar_ops(&[cigar_op])
+            .cigar_ops(cigar_ops)
             .mate_ref_id(0)
             .mate_pos(r1_start - 1)
             .template_length(-tlen)
@@ -286,10 +312,13 @@ fn test_duplex_command_with_rejects() {
 /// already includes anything the ss layer would have rejected. Appending both
 /// sources naively would emit the overlapping records twice.
 ///
-/// This test drives several independent rejection paths in a single pipeline
-/// run and asserts that the rejects BAM contains each `(read_name, flags)`
+/// The molecules below all reject at the duplex layer, so this pins the
+/// deduplication of the *whole-group* source across several independent
+/// rejection paths: the rejects BAM must contain each `(read_name, flags)`
 /// tuple at most once, with the total record count matching the expected
-/// input-record count.
+/// input-record count. The single-strand source, and its reconciliation with
+/// `--stats`, is covered by
+/// `test_duplex_rejects_bam_reconciles_with_stats`.
 #[test]
 fn test_duplex_command_rejects_contain_no_duplicates() {
     let temp_dir = TempDir::new().unwrap();
@@ -361,6 +390,205 @@ fn test_duplex_command_rejects_contain_no_duplicates() {
             "record ({name}, flags={flags}) appears {count} times in the rejects BAM",
         );
     }
+}
+
+/// #757: the rejects BAM must reconcile with `--stats`.
+///
+/// The molecule here emits a duplex consensus *and* drops reads: `minority` carries a
+/// minority indel pattern on both ends, so the single-strand layer drops it from both
+/// combined alignment groups (AB-R1 + BA-R2 and AB-R2 + BA-R1) while the three majority
+/// templates per strand still consense. Those drops used to be recorded on the composed
+/// single-strand caller, whose statistics the duplex caller never merged and whose rejected
+/// records it never received, so they reached neither output — `raw_reads_rejected`
+/// under-reported and the rejects BAM was empty for a molecule that plainly rejected reads.
+///
+/// Asserted in both the single-threaded and pipeline paths, since they drain the caller's
+/// rejects and statistics through different code.
+#[rstest]
+#[case::single_threaded(None)]
+#[case::threaded(Some("2"))]
+fn test_duplex_rejects_bam_reconciles_with_stats(#[case] threads: Option<&str>) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let rejects_bam = temp_dir.path().join("rejects.bam");
+    let stats_path = temp_dir.path().join("stats.txt");
+
+    // 3M1D5M against the majority 8M: same query length, different alignment pattern.
+    let gapped = [3u32 << 4, (1u32 << 4) | 2, 5u32 << 4];
+    let mut molecule = create_duplex_molecule("1", "ACGTACGT", 30, 100, 3);
+    molecule.push(create_duplex_read_pair_with_cigar(
+        "minority", "1/A", "ACGTACGT", "ACGTACGT", 30, 100, false, &gapped,
+    ));
+    create_duplex_bam(&input_bam, vec![molecule]);
+
+    let mut args = vec![
+        "duplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--rejects",
+        rejects_bam.to_str().unwrap(),
+        "--stats",
+        stats_path.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--compression-level",
+        "1",
+    ];
+    if let Some(threads) = threads {
+        args.extend_from_slice(&["--threads", threads]);
+    }
+    Duplex::try_parse_from(args)
+        .expect("failed to parse duplex args")
+        .execute("fgumi duplex")
+        .expect("Duplex command failed");
+
+    let mut output_reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    output_reader.read_header().expect("read output header");
+    assert_eq!(
+        output_reader.records().count(),
+        2,
+        "the majority-alignment reads must still emit a duplex R1/R2 pair"
+    );
+
+    // Key the input records by (name, flags) so each reject can be compared against the
+    // exact bytes it came from: a rejects BAM that dropped a tag or rewrote a CIGAR would
+    // still satisfy a name-and-count assertion.
+    let expected_rejects: HashMap<(Vec<u8>, u16), Vec<u8>> = read_raw_records(&input_bam)
+        .into_iter()
+        .filter(|record| fgumi_raw_bam::read_name(record) == b"minority")
+        .map(|record| {
+            let view = RawRecordView::new(&record);
+            ((view.read_name().to_vec(), view.flags()), record)
+        })
+        .collect();
+    assert_eq!(expected_rejects.len(), 2, "the minority template contributes two records");
+
+    let mut seen: Vec<(Vec<u8>, u16)> = Vec::new();
+    for record in read_raw_records(&rejects_bam) {
+        let view = RawRecordView::new(&record);
+        let key = (view.read_name().to_vec(), view.flags());
+        let expected = expected_rejects.get(&key).unwrap_or_else(|| {
+            panic!("unexpected reject record {}", String::from_utf8_lossy(&key.0))
+        });
+        assert_eq!(
+            &record, expected,
+            "each reject must be byte-for-byte identical to its input record — every field \
+             and tag preserved on the --rejects path"
+        );
+        assert!(!seen.contains(&key), "a reject record was written more than once");
+        seen.push(key);
+    }
+
+    let stats = fs::read_to_string(&stats_path).expect("read stats");
+    let stat = |key: &str| -> usize {
+        stats
+            .lines()
+            .find_map(|line| line.strip_prefix(&format!("{key}\t")))
+            .and_then(|rest| rest.split('\t').next())
+            .unwrap_or_else(|| panic!("stats must contain a {key} row"))
+            .parse()
+            .unwrap_or_else(|_| panic!("{key} must be an integer"))
+    };
+    assert_eq!(
+        seen.len(),
+        expected_rejects.len(),
+        "the rejects BAM must hold both ends of the minority template"
+    );
+    assert_eq!(
+        stat("raw_reads_rejected_for_minority_alignment"),
+        2,
+        "both ends of the minority template must be counted as minority-alignment"
+    );
+    assert_eq!(
+        seen.len(),
+        stat("raw_reads_rejected"),
+        "the rejects BAM record count must equal raw_reads_rejected"
+    );
+}
+
+/// #757 (follow-up): single-strand rejects must reach the rejects BAM in input order.
+///
+/// The two combined alignment groups split a template's ends across strands: X = AB-R1 +
+/// BA-R2 and Y = AB-R2 + BA-R1. For a `/B` template that means X carries its R2 while Y
+/// carries its R1, so recording X's rejects before Y's would write R2 ahead of R1 — the
+/// reverse of input order, which wrote R1 then R2. The reconciliation must merge both
+/// strands' rejects back into the group's canonical order before appending them.
+///
+/// Mirrors `test_duplex_rejects_bam_reconciles_with_stats`, but puts the minority template on
+/// the `/B` strand and asserts the serialized reject *sequence* equals the input sequence,
+/// which a name-and-count check (as the reconcile test uses) cannot catch.
+#[rstest]
+#[case::single_threaded(None)]
+#[case::threaded(Some("2"))]
+fn test_duplex_rejects_preserve_input_order_for_b_strand_minority(#[case] threads: Option<&str>) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let rejects_bam = temp_dir.path().join("rejects.bam");
+
+    // 3M1D5M against the majority 8M: same query length, minority alignment pattern.
+    let gapped = [3u32 << 4, (1u32 << 4) | 2, 5u32 << 4];
+    let mut molecule = create_duplex_molecule("1", "ACGTACGT", 30, 100, 3);
+    // Minority template on the *B* strand: its R1 becomes BA-R1 (lands in Y) and its R2
+    // becomes BA-R2 (lands in X), so the two ends are dropped by separate
+    // `filter_by_alignment` calls — exactly the split that can invert their order.
+    molecule.push(create_duplex_read_pair_with_cigar(
+        "minority", "1/B", "ACGTACGT", "ACGTACGT", 30, 100, true, &gapped,
+    ));
+    create_duplex_bam(&input_bam, vec![molecule]);
+
+    let mut args = vec![
+        "duplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--rejects",
+        rejects_bam.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--compression-level",
+        "1",
+    ];
+    if let Some(threads) = threads {
+        args.extend_from_slice(&["--threads", threads]);
+    }
+    Duplex::try_parse_from(args)
+        .expect("failed to parse duplex args")
+        .execute("fgumi duplex")
+        .expect("Duplex command failed");
+
+    // The minority template's two input records, in the exact order the input wrote them
+    // (R1 then R2). The majority templates all consense, so they contribute no rejects and
+    // the rejects BAM must reproduce this sequence and nothing else.
+    let expected_sequence: Vec<Vec<u8>> = read_raw_records(&input_bam)
+        .into_iter()
+        .filter(|record| fgumi_raw_bam::read_name(record) == b"minority")
+        .collect();
+    assert_eq!(expected_sequence.len(), 2, "the minority template contributes two records");
+
+    let reject_sequence = read_raw_records(&rejects_bam);
+    assert_eq!(
+        reject_sequence, expected_sequence,
+        "the /B minority template's rejects must be serialized in input order (R1 then R2), \
+         not X-before-Y order (R2 then R1)"
+    );
+}
+
+/// Reads every record of a BAM back as raw bytes, so tests can compare whole serialized
+/// records rather than only the fields noodles decodes ergonomically.
+fn read_raw_records(path: &Path) -> Vec<Vec<u8>> {
+    let (mut reader, _header) =
+        fgumi_bam_io::create_raw_bam_reader(path, 1).expect("open BAM for raw reading");
+    let mut records = Vec::new();
+    let mut record = RawRecord::new();
+    while reader.read_record(&mut record).expect("read raw record") != 0 {
+        records.push(record.as_ref().to_vec());
+    }
+    records
 }
 
 /// Test duplex command with statistics output.


### PR DESCRIPTION
Closes #757.

## Where the issue was wrong

The issue says the records "are routed correctly" and reach `--rejects` while only the counts are stranded. They do not. `DuplexConsensusCaller` reaches the single-strand caller through `filter_by_alignment`, which *counts* what it dropped on `ss_caller.stats` but returns the rejected indices rather than the records — the raw bytes belong to the duplex caller, and the duplex caller discarded the indices (`let (filtered_xs, _) = ...`). The vanilla caller populates `rejected_reads` only inside `process_subgroup`, which the duplex path never enters, so `ss_caller.take_rejected_reads()` at the drain site always returned an empty vec.

So the single-strand drops reached **neither** output, not just `--stats`. `raw_reads_rejected` under-reported *and* the rejects BAM was missing records — which is what #756's own "Not changed here" section said ("they appear in neither output"), and is the stronger claim.

The issue is also wrong that the numbers were "visible in the run log". `log_statistics()` has no callers anywhere in the repo — the commands log through `log_consensus_summary(&metrics)`, derived from `statistics()`. The counts were invisible everywhere.

Everything else holds: `statistics()` returned only `self.stats`, nothing merged the sub-caller's, the reasons involved are recorded at `vanilla_caller.rs`'s alignment filter, and record-count-equals-`raw_reads_rejected` is the right invariant to pin.

## The fix

Two halves, both required for the invariant:

- `filter_by_alignment`'s rejected indices are mapped back to their raw records and handed to the sub-caller via a new `record_rejected_raw`, in **input order** (iterating the record slice, not the `HashSet`). They then drain through the existing `take_rejected_reads` path.
- `take_statistics` drains the sub-caller's counters per molecule, and `consensus_reads` folds that delta into its own.

## Avoiding the double count

A whole-group duplex rejection counts *and* emits every raw input record, so the single-strand layer's rejections are a subset already covered; adding them on top reports more rejected reads than the rejects BAM holds. The fold therefore runs on exactly one of the two paths.

The discriminator is the load-bearing detail. The pre-existing code used `duplex_rejected_raw.is_empty()`, which works only because it ran under `if track_rejects` — the payload is *also* empty whenever tracking is off, so reusing it to gate a *statistics* decision would double-count every run made without `--rejects`, i.e. the common case for `--stats`. `process_group` now returns an explicit `DuplexGroupOutcome::{Kept, RejectedWholeGroup(records)}` instead, and the enum's doc says why the payload cannot stand in for it.

Both hazards are pinned by tests that were confirmed to fail against the naive fix, not merely written alongside the right one:

- folding unconditionally makes `test_single_strand_rejections_are_not_double_counted_on_whole_group_rejection` report 20 rejected reads against 16 input records;
- returning `Kept` when tracking is off makes `test_whole_group_rejection_counts_are_independent_of_rejects_tracking` report 16 tracked vs 20 untracked.

Which reasons can collide was worked out rather than assumed. The sub-caller records exactly two reasons on this path — `Unmapped` (from `drop_unmapped_if_any_mapped`) and `MinorityAlignment` — and they are disjoint by construction, since the unmapped reads are removed before the minority pass counts what is left. Its `record_input` / `record_consensus` sites are in `process_group` and `consensus_reads`, which the duplex path does not call, so `total_reads` and `consensus_reads` are structurally zero in the delta; both are asserted to stay at the duplex layer's own values rather than left to trust.

## Tests

TDD; all four failed before the fix.

- `test_single_strand_rejections_reach_the_duplex_statistics` — a molecule that survives with one minority-alignment template on `/A`. Pins the two counters, that `total_reads`/`consensus_reads` are not inflated by the fold, and that the retained bytes are *exactly* that template's two records — byte-for-byte, in input order — not merely the right count.
- `test_single_strand_rejections_are_not_double_counted_on_whole_group_rejection` — `min_reads = 4` is met before single-strand filtering and missed after it, the only way to reach a whole-group rejection downstream of that layer. A control run pins the fixture is not vacuous: four clean templates per strand clear the same threshold, so the rejection is caused by the single-strand drops rather than by the raw depth.
- `test_whole_group_rejection_counts_are_independent_of_rejects_tracking` — the same molecule with and without tracking must report identical counters and per-reason breakdown.
- `test_duplex_rejects_bam_reconciles_with_stats` (integration, single-threaded and `--threads 2`) — the end-to-end invariant: rejects BAM record count equals `raw_reads_rejected` for an input where one molecule both emits a consensus and drops reads, with each reject compared byte-for-byte against the record it came from.

`test_duplex_command_rejects_contain_no_duplicates`'s doc claimed to cover the single-strand source; every molecule in it rejects at the duplex layer, so it never could. Reworded to say what it actually pins and to point at the new test for the other half.

`log_statistics` no longer logs the sub-caller separately — its counters are drained per molecule now, so the block would print zeroes and imply the drops went uncounted.

## Parity with fgbio

This moves the surviving-molecule path onto fgbio's behavior exactly. `DuplexConsensusCaller.scala:321-322` calls the inherited `filterToMostCommonAlignment`, so `rejectRecords(..., MinorityAlignment)` lands on the duplex caller's own counter and its own rejects writer — one layer, both outputs.

## Not changed here

- **The per-reason split on the whole-group path.** fgbio's `rejectRecords` is first-writer-wins (`recs.filterNot(_.contains(RejectReasonTag))`), so a record already rejected as `MinorityAlignment` keeps that reason and the whole-group reason applies only to the survivors — `DuplexConsensusCaller.scala:359-362` says so in a comment. fgumi attributes the entire raw group to the duplex reason instead. The **totals** agree either way (one record, one count), which is what this issue is about; the split does not, and fixing it means touching all five whole-group sites and their reject payloads. It belongs with the rejection-attribution work in #749.
- **Reads dropped by `create_source_read` returning `None`** (zero length after trimming, absent qualities). The duplex path drops them silently via `filter_map`, where `process_subgroup` counts them as `ZeroLengthAfterTrimming` and writes them. They are missing from both outputs symmetrically, so they do not break reconciliation — a separate under-count, not this one.
- **`codec`** — audited, no equivalent defect. Its composed single-strand caller is reached only through `consensus_call`, which records no statistics and touches no rejects buffer; codec does its own alignment filtering and counts it on its own stats. Nothing is stranded there.

## Memory

Bounded by one molecule's rejected records, and only when `--rejects` is set: the bytes are copied into the sub-caller's buffer and moved into the duplex caller's on the same call. Worth noting separately that single-threaded `duplex` never drains its rejects buffer inside the group loop the way `simplex` and `codec` do (`simplex.rs:467`, `codec.rs:513`), so that buffer holds every rejected record until the loop ends; this change adds to what accumulates there. That is a pre-existing shape, not introduced here, and the `--threads` path drains per batch.

## Gate

`cargo ci-fmt`, `cargo ci-lint`, `cargo ci-test` (7499 passed, 30 skipped) and `cargo ci-doctest` all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: output changes affect `--stats` and `--rejects` only, pinned by raw-record order, deduplication, and reconciliation tests; grouping, consensus, sort order, and corrected UMIs: none; `unsafe`: none; memory bounds, queue capacity, and thread/backpressure policy: none.

Fixes duplex rejection accounting. Single-strand rejected records now use the rejects buffer in raw-record order. Single-strand statistics now merge into duplex statistics without double counting whole-group rejections. Post-filter read thresholds prevent invalid single-strand consensus output.

Adds regression coverage for statistics, reject records, deduplication, tracking modes, alignment filtering, and single- versus multi-threaded execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->