### PR TITLE
fix(pipeline): enforce the queue memory budget at the FASTQ Read step

### DIFF
--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -1228,15 +1228,18 @@ fn resolve_memory_budget_with_total(
 /// a hard RSS cap — a single pathological position group is still processed
 /// whole, and each worker has transient working-set memory on top of the queue.
 ///
-/// In the **BAM** pipeline the budget is enforced at the Read step: the
-/// pipeline stops admitting input once the bytes queued between its stages
-/// reach it, so a slow or contended output device backs pressure up to the
-/// reader instead of filling every queue to its slot count. See
-/// `BamPipelineState::read_admission_allowed`.
+/// Both pipelines enforce the budget at the Read step: they stop admitting
+/// input once the bytes queued between their stages reach it, so a slow or
+/// contended output device backs pressure up to the reader instead of filling
+/// every queue to its slot count. See `BamPipelineState::read_admission_allowed`
+/// and `FastqPipelineState::read_admission_allowed`.
 ///
-/// The FASTQ pipeline (`fgumi extract`) shares these options and logs the same
-/// budget, but has no equivalent admission gate yet: there it still bounds only
-/// the reorder buffers, each capped at
+/// Memory held *outside* those aggregates is not covered: a worker's
+/// in-progress batch is bounded by the thread count rather than by this budget.
+/// The write reorder buffers, by contrast, *are* summed into the aggregates
+/// (the FASTQ aggregate counts its write reorder state and the BAM aggregate its
+/// input and write reorder states), so this budget bounds them through the Read
+/// gate; they additionally apply their own threshold, capped at
 /// [`BACKPRESSURE_THRESHOLD_BYTES`](crate::unified_pipeline::BACKPRESSURE_THRESHOLD_BYTES).
 #[derive(Debug, Clone, Args)]
 pub struct QueueMemoryOptions {

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -33,7 +33,7 @@ use super::base::{
     QueueSample, RawBlockBatch, ReorderBufferState, SerializePipelineState, SerializedBatch,
     StepContext, WorkerCoreState, WorkerStateCommon, WritePipelineState,
     finalize_pipeline_with_buffers, generic_worker_loop, handle_worker_panic, join_monitor_thread,
-    join_worker_threads, shared_try_step_compress,
+    join_worker_threads, push_charged, refund_queue_bytes, shared_try_step_compress,
 };
 use super::deadlock::{
     DeadlockAction, DeadlockConfig, DeadlockState, QueueSnapshot, check_deadlock_and_restore,
@@ -74,19 +74,6 @@ impl MemoryEstimate for BoundaryBatch {
     fn estimate_heap_size(&self) -> usize {
         self.buffer.capacity() + self.offsets.capacity() * std::mem::size_of::<usize>()
     }
-}
-
-/// Release `bytes` from a queue byte counter, saturating at zero.
-///
-/// The counters summed by [`BamPipelineState::queue_bytes_in_flight`] gate the
-/// Read step, so an unpaired refund would not merely skew a statistic: a plain
-/// `fetch_sub` past zero wraps to `u64::MAX` and stops the pipeline reading for
-/// the rest of the run. Saturating turns that class of bug into a bounded
-/// accounting error rather than a hang.
-fn refund_queue_bytes(counter: &AtomicU64, bytes: u64) {
-    let _ = counter.fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
-        Some(current.saturating_sub(bytes))
-    });
 }
 
 /// State for the `FindBoundaries` step (sequential).
@@ -942,21 +929,14 @@ impl<G: Send, P: Send + MemoryEstimate> BamPipelineState<G, P> {
     /// Returns the batch unchanged when Q2b is out of slots, so callers keep
     /// the existing held-item retry behaviour.
     fn q2b_push(&self, serial: u64, batch: BoundaryBatch) -> Result<(), (u64, BoundaryBatch)> {
-        // Charge before the push so the batch is never visible to a consumer
-        // while its bytes are still uncharged: a pop in that window would refund
-        // bytes never added and, because `q2b_heap_bytes` gates Read via
-        // `queue_bytes_in_flight`, permanently over-state the counter and close
-        // the Read gate. Refund on the out-of-slots path so a rejected push
-        // leaves the counter unchanged.
+        // `push_charged` charges before the push so the batch is never visible to
+        // a consumer while its bytes are still uncharged: a pop in that window
+        // would refund bytes never added and, because `q2b_heap_bytes` gates Read
+        // via `queue_bytes_in_flight`, permanently over-state the counter and
+        // close the Read gate. It refunds on the out-of-slots path so a rejected
+        // push leaves the counter unchanged.
         let heap_size = batch.estimate_heap_size() as u64;
-        self.q2b_heap_bytes.fetch_add(heap_size, Ordering::AcqRel);
-        match self.q2b_boundaries.push((serial, batch)) {
-            Ok(()) => Ok(()),
-            Err(returned) => {
-                refund_queue_bytes(&self.q2b_heap_bytes, heap_size);
-                Err(returned)
-            }
-        }
+        push_charged(&self.q2b_boundaries, &self.q2b_heap_bytes, heap_size, (serial, batch))
     }
 
     /// Pop a boundary batch from Q2b, refunding its heap bytes.
@@ -974,14 +954,7 @@ impl<G: Send, P: Send + MemoryEstimate> BamPipelineState<G, P> {
     /// counter unchanged. Callers record the deadlock-detector push on `Ok`.
     fn q1_push(&self, serial: u64, batch: RawBlockBatch) -> Result<(), (u64, RawBlockBatch)> {
         let heap_size = batch.estimate_heap_size() as u64;
-        self.q1_heap_bytes.fetch_add(heap_size, Ordering::AcqRel);
-        match self.q1_raw_blocks.push((serial, batch)) {
-            Ok(()) => Ok(()),
-            Err(returned) => {
-                refund_queue_bytes(&self.q1_heap_bytes, heap_size);
-                Err(returned)
-            }
-        }
+        push_charged(&self.q1_raw_blocks, &self.q1_heap_bytes, heap_size, (serial, batch))
     }
 
     /// Pop a raw block batch from Q1, refunding its heap bytes.
@@ -4780,15 +4753,6 @@ mod tests {
             Q1_CHARGE + Q4_CHARGE + 1 + 2 + 4 + 8 + 16 + 32,
             "every accounted counter must contribute to the aggregate"
         );
-    }
-
-    /// An unpaired refund saturates at zero rather than wrapping to
-    /// `u64::MAX`, which would gate Read shut for the rest of the run.
-    #[test]
-    fn refunding_more_than_was_charged_saturates_at_zero() {
-        let counter = AtomicU64::new(100);
-        refund_queue_bytes(&counter, 250);
-        assert_eq!(counter.load(Ordering::Acquire), 0);
     }
 
     /// A `q2b_push` rejected because Q2b is out of slots must refund its charge

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -726,6 +726,72 @@ pub const PROGRESS_LOG_INTERVAL: u64 = 1_000_000;
 /// so if a smaller memory limit is configured, backpressure activates at that limit.
 pub const BACKPRESSURE_THRESHOLD_BYTES: u64 = 512 * 1024 * 1024; // 512 MB
 
+/// Release `bytes` from a queue byte counter, saturating at zero.
+///
+/// The counters summed by a pipeline's `queue_bytes_in_flight` gate its Read
+/// step, so an unpaired refund would not merely skew a statistic: a plain
+/// `fetch_sub` past zero wraps to `u64::MAX` and stops the pipeline reading for
+/// the rest of the run. Saturating turns that class of bug into a bounded
+/// accounting error rather than a hang.
+///
+/// Saturating is the right release behaviour but it also makes an unpaired
+/// refund invisible, so a `debug_assert!` fails the test suite on one rather
+/// than letting the budget quietly under-bound for the rest of the run. The
+/// saturating arithmetic itself lives in [`saturating_refund`] so it stays
+/// testable independently of that assertion.
+pub(crate) fn refund_queue_bytes(counter: &AtomicU64, bytes: u64) {
+    let previous = counter
+        .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+            Some(saturating_refund(current, bytes))
+        })
+        .unwrap_or_else(|current| current);
+    debug_assert!(
+        previous >= bytes,
+        "refunded {bytes} queue bytes against a counter holding {previous}; every refund must be \
+         paired with the charge that preceded it"
+    );
+}
+
+/// Push `item` onto `queue`, charging `heap_size` to `counter` **before** the
+/// item becomes visible to a consumer, and refunding it if the push fails.
+///
+/// The order is the point. `counter` is summed by a pipeline's
+/// `queue_bytes_in_flight`, which gates the Read step, and [`refund_queue_bytes`]
+/// saturates at zero. Charging *after* a successful push leaves a window in which
+/// a consumer pops the item and refunds bytes that were never charged; when the
+/// counter is near zero — the normal state of a queue that is draining as fast as
+/// it fills — that refund saturates, and the charge landing afterwards is then
+/// never released. Each occurrence permanently inflates the counter, and once the
+/// accumulated phantom bytes reach the budget the pipeline stops reading for the
+/// rest of the run.
+///
+/// Charging first inverts the failure: the counter can only ever be *over* the
+/// true figure for the span of a failed push, which makes the gate briefly
+/// conservative rather than permanently shut.
+pub(crate) fn push_charged<T>(
+    queue: &ArrayQueue<(u64, T)>,
+    counter: &AtomicU64,
+    heap_size: u64,
+    item: (u64, T),
+) -> Result<(), (u64, T)> {
+    counter.fetch_add(heap_size, Ordering::AcqRel);
+    match queue.push(item) {
+        Ok(()) => Ok(()),
+        Err(returned) => {
+            refund_queue_bytes(counter, heap_size);
+            Err(returned)
+        }
+    }
+}
+
+/// The arithmetic [`refund_queue_bytes`] applies: subtract, saturating at zero.
+///
+/// Extracted so the wrap-to-`u64::MAX` guarantee can be tested without tripping
+/// that function's `debug_assert!` on an unpaired refund.
+const fn saturating_refund(current: u64, bytes: u64) -> u64 {
+    current.saturating_sub(bytes)
+}
+
 /// Q5 (processed queue) backpressure threshold.
 ///
 /// This is set lower than the Q3 threshold (256 MB vs 512 MB) because items in Q5
@@ -4798,7 +4864,9 @@ where
     // write reorder buffer's bytes are charged to the queue memory budget and the
     // Read step declines to admit more input once that budget is reached — see
     // `BamPipelineState::read_admission_allowed` (issue #746). The FASTQ pipeline
-    // has no equivalent admission gate yet.
+    // bounds its write side the same way through
+    // `FastqPipelineState::read_admission_allowed`, which additionally exempts a
+    // stream whose data the multi-stream assembly steps are waiting on (issue #766).
     if state.q6_is_full() {
         return if advanced_held { StepResult::Success } else { StepResult::OutputFull };
     }
@@ -5414,6 +5482,36 @@ mod tests {
         if let Err(err) = merged {
             assert_eq!(err.non_empty_queues, vec!["q1_raw_blocks (1)".to_string()]);
         }
+    }
+
+    /// An unpaired refund saturates at zero rather than wrapping to `u64::MAX`,
+    /// which would gate both pipelines' Read step shut for the rest of the run.
+    ///
+    /// Asserted against [`saturating_refund`] rather than [`refund_queue_bytes`]
+    /// because the latter carries a `debug_assert!` that an unpaired refund must
+    /// not happen; this pins what the arithmetic does if one ever does.
+    #[rstest]
+    #[case::paired(100, 100, 0)]
+    #[case::partial(100, 40, 60)]
+    #[case::unpaired_saturates(100, 250, 0)]
+    #[case::unpaired_from_zero(0, 1, 0)]
+    fn refunding_more_than_was_charged_saturates_at_zero(
+        #[case] current: u64,
+        #[case] bytes: u64,
+        #[case] expected: u64,
+    ) {
+        assert_eq!(saturating_refund(current, bytes), expected);
+    }
+
+    /// A paired refund leaves the counter at the difference, and does not trip
+    /// [`refund_queue_bytes`]'s unpaired-refund assertion.
+    #[test]
+    fn a_paired_refund_debits_the_counter() {
+        let counter = AtomicU64::new(100);
+        refund_queue_bytes(&counter, 40);
+        assert_eq!(counter.load(Ordering::Acquire), 60);
+        refund_queue_bytes(&counter, 60);
+        assert_eq!(counter.load(Ordering::Acquire), 0);
     }
 
     #[test]

--- a/src/lib/unified_pipeline/fastq.rs
+++ b/src/lib/unified_pipeline/fastq.rs
@@ -47,7 +47,8 @@ use super::base::{
     PipelineStep, PipelineValidationError, ProcessPipelineState, SerializePipelineState,
     SerializedBatch, StepContext, WorkerCoreState, WorkerStateCommon, WritePipelineState,
     finalize_pipeline, generic_worker_loop, handle_worker_panic, join_monitor_thread,
-    join_worker_threads, run_monitor_loop, shared_try_step_compress,
+    join_worker_threads, push_charged, refund_queue_bytes, run_monitor_loop,
+    shared_try_step_compress,
 };
 use super::deadlock::{DeadlockConfig, DeadlockState, QueueSnapshot};
 use super::scheduler::{BackpressureState, SchedulerStrategy};
@@ -124,20 +125,46 @@ impl PairState {
         Self { pending: BTreeMap::new(), next_emit: 0, num_streams }
     }
 
-    /// Insert a data chunk into the pending map.
-    fn insert(&mut self, chunk: PerStreamChunk) {
+    /// Insert a data chunk into the pending map, charging `heap_bytes`.
+    ///
+    /// The counter is passed in rather than mirrored in a field so there is
+    /// exactly one place the pending bytes are tracked: it is summed by
+    /// [`FastqPipelineState::queue_bytes_in_flight`], which gates the Read step,
+    /// and a second copy that could drift from this one would either leak the
+    /// budget or hold it shut.
+    ///
+    /// Read assigns each `(stream_idx, batch_num)` exactly once, under the
+    /// per-stream reader lock, so a slot should never already be occupied. The
+    /// displaced chunk is refunded rather than assumed away because the counter
+    /// now gates Read: a leaked charge would not skew a statistic, it would
+    /// inflate the gate until the pipeline stopped reading for the rest of the
+    /// run.
+    fn insert(&mut self, chunk: PerStreamChunk, heap_bytes: &AtomicU64) {
         let stream_idx = chunk.stream_idx;
         let batch_num = chunk.batch_num;
+        heap_bytes.fetch_add(chunk.estimate_heap_size() as u64, Ordering::AcqRel);
         let slots = self.pending.entry(batch_num).or_insert_with(|| vec![None; self.num_streams]);
-        slots[stream_idx] = Some(chunk);
+        if let Some(displaced) = slots[stream_idx].replace(chunk) {
+            debug_assert!(
+                false,
+                "stream {stream_idx} delivered batch {batch_num} twice; Read assigns each \
+                 (stream, batch) pair once"
+            );
+            refund_queue_bytes(heap_bytes, displaced.estimate_heap_size() as u64);
+        }
     }
 
-    /// Try to pop a complete set of chunks for the next `batch_num`.
+    /// Try to pop a complete set of chunks for the next `batch_num`, refunding
+    /// their charge against `heap_bytes`.
     ///
     /// When `all_arrived` is false (normal operation), ALL streams must have
     /// delivered their chunk. When `all_arrived` is true (all Read chunks have
     /// been consumed), incomplete batches are emitted with whatever data is present.
-    fn try_pop_complete(&mut self, all_arrived: bool) -> Option<Vec<PerStreamChunk>> {
+    fn try_pop_complete(
+        &mut self,
+        all_arrived: bool,
+        heap_bytes: &AtomicU64,
+    ) -> Option<Vec<PerStreamChunk>> {
         let slots = self.pending.get(&self.next_emit)?;
         let complete = if all_arrived {
             slots.iter().any(Option::is_some)
@@ -153,7 +180,10 @@ impl PairState {
             .remove(&self.next_emit)
             .expect("next_emit key must exist in pending map after get() succeeded");
         self.next_emit += 1;
-        Some(slots.into_iter().flatten().collect())
+        let chunks: Vec<PerStreamChunk> = slots.into_iter().flatten().collect();
+        let released: u64 = chunks.iter().map(|c| c.estimate_heap_size() as u64).sum();
+        refund_queue_bytes(heap_bytes, released);
+        Some(chunks)
     }
 
     fn is_empty(&self) -> bool {
@@ -613,6 +643,28 @@ impl BlockMergeState {
         );
         empty
     }
+}
+
+/// Charge `bytes` to `BlockMergeState::pending_heap_bytes`, mirroring into
+/// `mirror`.
+///
+/// `mirror` is [`FastqPipelineState::block_merge_pending_heap_bytes`], which the
+/// Read gate reads without taking the merge lock. Routing every mutation
+/// through this pair is what keeps the two in step: the local figure decides
+/// [`PENDING_BACKPRESSURE_BYTES`], the mirror contributes to the queue memory
+/// budget, and neither can drift from the other. They take the counter by
+/// `&mut` rather than the whole `BlockMergeState` so they can be called from
+/// code that has already split-borrowed the per-stream fields.
+fn charge_block_merge_pending(pending_heap_bytes: &mut u64, mirror: &AtomicU64, bytes: u64) {
+    *pending_heap_bytes += bytes;
+    mirror.fetch_add(bytes, Ordering::AcqRel);
+}
+
+/// Release `bytes` from `BlockMergeState::pending_heap_bytes`, mirroring into
+/// `mirror`. See `charge_block_merge_pending`.
+fn refund_block_merge_pending(pending_heap_bytes: &mut u64, mirror: &AtomicU64, bytes: u64) {
+    *pending_heap_bytes = pending_heap_bytes.saturating_sub(bytes);
+    refund_queue_bytes(mirror, bytes);
 }
 
 /// Detect where the first complete FASTQ record begins in `data`.
@@ -1388,11 +1440,30 @@ pub struct FastqPipelineState<R: BufRead + Send, P: Send + MemoryEstimate> {
 
     // ========== Q0: Read → Decompress ==========
     /// Per-stream chunks waiting to be decompressed.
+    ///
+    /// Push and pop through `FastqPipelineState::q0_push` /
+    /// `FastqPipelineState::q0_pop` so `q0_heap_bytes` stays accurate.
     pub q0_chunks: ArrayQueue<(u64, PerStreamChunk)>,
+    /// Heap bytes currently held in Q0 (raw BGZF or record-aligned chunks).
+    ///
+    /// Charged against the queue memory budget by
+    /// [`FastqPipelineState::queue_bytes_in_flight`].
+    pub q0_heap_bytes: AtomicU64,
 
     // ========== Q1: Decompress → BlockParseFast (parallel) ==========
     /// Decompressed per-stream chunks waiting for parallel block parsing.
+    ///
+    /// Push and pop through `FastqPipelineState::q1_push` /
+    /// `FastqPipelineState::q1_pop` so `q1_heap_bytes` stays accurate.
     pub q1_decompressed: ArrayQueue<(u64, PerStreamChunk)>,
+    /// Heap bytes currently held in Q1 (decompressed chunks).
+    ///
+    /// Q1 holds whole decompressed BGZF payloads on the BGZF path, and the
+    /// record-aligned chunks Read produced on the gzip/plain path, so it is one
+    /// of the larger consumers when the pipeline backs up; it is charged
+    /// against the queue memory budget by
+    /// [`FastqPipelineState::queue_bytes_in_flight`].
+    pub q1_heap_bytes: AtomicU64,
 
     // ========== BlockParseFast → BlockMerge ==========
     /// Count of per-stream chunks consumed by `BlockParseFast` from q1.
@@ -1404,6 +1475,13 @@ pub struct FastqPipelineState<R: BufRead + Send, P: Send + MemoryEstimate> {
     pub q2_block_parsed_heap_bytes: AtomicU64,
     /// Serial `BlockMerge` step state (locked via `try_lock` for serial execution).
     pub(crate) block_merge_state: Mutex<BlockMergeState>,
+    /// Heap bytes held in `BlockMergeState`'s pending maps (BGZF path).
+    ///
+    /// A lock-free mirror of `BlockMergeState::pending_heap_bytes`, maintained
+    /// by `charge_block_merge_pending` / `refund_block_merge_pending`, so
+    /// the Read gate can include blocks parked in the merge step without taking
+    /// the merge lock.
+    pub block_merge_pending_heap_bytes: AtomicU64,
     /// Flag indicating all blocks have been merged and templates emitted.
     pub block_merge_done: AtomicBool,
     /// Count of `BlockParsed` items consumed by `BlockMerge`.
@@ -1414,6 +1492,12 @@ pub struct FastqPipelineState<R: BufRead + Send, P: Send + MemoryEstimate> {
     pub chunks_paired: AtomicU64,
     /// Pair state: accumulates per-stream chunks by `batch_num` (gzip path).
     pub(crate) pair_state: Mutex<PairState>,
+    /// Heap bytes held in `PairState`'s pending map (gzip path).
+    ///
+    /// Chunks move out of Q1 and into the pair buffer while they wait for the
+    /// matching `batch_num` from the other stream, so without this counter the
+    /// Read gate would stop seeing them the moment they were paired-in-waiting.
+    pub pair_heap_bytes: AtomicU64,
     /// State for finding FASTQ record boundaries (gzip path).
     pub boundary_state: FastqBoundaryState,
     /// Flag indicating pair assembly / boundary finding is complete (gzip path).
@@ -1486,15 +1570,19 @@ impl<R: BufRead + Send, P: Send + MemoryEstimate> FastqPipelineState<R, P> {
             read_done: AtomicBool::new(false),
             batches_read: AtomicU64::new(0),
             q0_chunks: ArrayQueue::new(cap),
+            q0_heap_bytes: AtomicU64::new(0),
             q1_decompressed: ArrayQueue::new(cap),
+            q1_heap_bytes: AtomicU64::new(0),
             chunks_block_parsed: AtomicU64::new(0),
             q2_block_parsed: ArrayQueue::new(cap),
             q2_block_parsed_heap_bytes: AtomicU64::new(0),
             block_merge_state: Mutex::new(BlockMergeState::new()),
+            block_merge_pending_heap_bytes: AtomicU64::new(0),
             block_merge_done: AtomicBool::new(false),
             blocks_merged: AtomicU64::new(0),
             chunks_paired: AtomicU64::new(0),
             pair_state: Mutex::new(PairState::new(num_streams)),
+            pair_heap_bytes: AtomicU64::new(0),
             boundary_state: FastqBoundaryState::new(num_streams),
             boundaries_done: AtomicBool::new(false),
             batches_boundaries_found: AtomicU64::new(0),
@@ -1545,6 +1633,176 @@ impl<R: BufRead + Send, P: Send + MemoryEstimate> FastqPipelineState<R, P> {
     #[must_use]
     pub fn is_q4_memory_high(&self) -> bool {
         self.output.is_processed_memory_high()
+    }
+
+    /// Push a chunk onto Q0 through [`push_charged`], which charges its heap
+    /// bytes *before* the push and refunds them if it fails.
+    ///
+    /// Returns the chunk unchanged when Q0 is out of slots, so callers keep the
+    /// existing held-item retry behaviour.
+    fn q0_push(&self, serial: u64, chunk: PerStreamChunk) -> Result<(), (u64, PerStreamChunk)> {
+        let heap_size = chunk.estimate_heap_size() as u64;
+        push_charged(&self.q0_chunks, &self.q0_heap_bytes, heap_size, (serial, chunk))
+    }
+
+    /// Pop a chunk from Q0, refunding its heap bytes.
+    fn q0_pop(&self) -> Option<(u64, PerStreamChunk)> {
+        let (serial, chunk) = self.q0_chunks.pop()?;
+        refund_queue_bytes(&self.q0_heap_bytes, chunk.estimate_heap_size() as u64);
+        Some((serial, chunk))
+    }
+
+    /// Push a decompressed chunk onto Q1 through [`push_charged`], which charges
+    /// its heap bytes *before* the push and refunds them if it fails.
+    fn q1_push(&self, serial: u64, chunk: PerStreamChunk) -> Result<(), (u64, PerStreamChunk)> {
+        let heap_size = chunk.estimate_heap_size() as u64;
+        push_charged(&self.q1_decompressed, &self.q1_heap_bytes, heap_size, (serial, chunk))
+    }
+
+    /// Pop a decompressed chunk from Q1, refunding its heap bytes.
+    fn q1_pop(&self) -> Option<(u64, PerStreamChunk)> {
+        let (serial, chunk) = self.q1_decompressed.pop()?;
+        refund_queue_bytes(&self.q1_heap_bytes, chunk.estimate_heap_size() as u64);
+        Some((serial, chunk))
+    }
+
+    /// Push a batch of templates onto Q3 through [`push_charged`], which charges
+    /// its heap bytes *before* the push and refunds them if it fails.
+    ///
+    /// Q3 holds fully parsed `FastqTemplate`s — names, sequences and qualities
+    /// as owned buffers — so it is the largest single consumer when the writer
+    /// stalls. It used to be charged only under `memory-debug`, and then only
+    /// with a hardcoded `0` on the way in, which left the counter permanently
+    /// zero (issue #766).
+    fn q3_push(
+        &self,
+        serial: u64,
+        templates: Vec<FastqTemplate>,
+    ) -> Result<(), (u64, Vec<FastqTemplate>)> {
+        let heap_size: u64 = templates.iter().map(|t| t.estimate_heap_size() as u64).sum();
+        push_charged(
+            &self.output.groups,
+            &self.output.groups_heap_bytes,
+            heap_size,
+            (serial, templates),
+        )
+    }
+
+    /// Pop a batch of templates from Q3, refunding its heap bytes.
+    ///
+    /// The batch is unchanged since `q3_push` charged it, so the two estimates
+    /// agree exactly.
+    fn q3_pop(&self) -> Option<(u64, Vec<FastqTemplate>)> {
+        let (serial, templates) = self.output.groups.pop()?;
+        let heap_size: u64 = templates.iter().map(|t| t.estimate_heap_size() as u64).sum();
+        refund_queue_bytes(&self.output.groups_heap_bytes, heap_size);
+        Some((serial, templates))
+    }
+
+    /// Heap bytes the pipeline is currently holding in its accounted queues.
+    ///
+    /// Sums every byte counter the pipeline maintains: Q0 (raw chunks), Q1
+    /// (decompressed chunks), Q2 and the merge step's pending maps (BGZF path),
+    /// the pair buffer and Q2.5 (gzip path), Q3 (templates), Q4 (processed),
+    /// Q5 (serialized), Q6 (compressed) and the write reorder buffer.
+    ///
+    /// This is an estimate, not an exact figure: it counts queued batches, not
+    /// the per-thread working memory a stage allocates while operating on one
+    /// (a worker's held item is counted only for Q2, where the charge is taken
+    /// at creation; elsewhere it is uncharged until it reaches its queue, and
+    /// is bounded by the thread count either way), and it uses `Vec::capacity`
+    /// rather than the allocator's true block sizes. It is nonetheless the whole of the data the pipeline parks
+    /// between stages, which is what grows without bound when the writer
+    /// stalls.
+    #[must_use]
+    pub fn queue_bytes_in_flight(&self) -> u64 {
+        self.q0_heap_bytes.load(Ordering::Acquire)
+            + self.q1_heap_bytes.load(Ordering::Acquire)
+            + self.q2_block_parsed_heap_bytes.load(Ordering::Acquire)
+            + self.block_merge_pending_heap_bytes.load(Ordering::Acquire)
+            + self.pair_heap_bytes.load(Ordering::Acquire)
+            + self.q2_5_boundaries_heap_bytes.load(Ordering::Acquire)
+            + self.output.groups_heap_bytes.load(Ordering::Acquire)
+            + self.output.processed_heap_bytes.load(Ordering::Acquire)
+            + self.output.serialized_heap_bytes.load(Ordering::Acquire)
+            + self.output.compressed_heap_bytes.load(Ordering::Acquire)
+            + self.output.write_reorder_state.get_heap_bytes()
+    }
+
+    /// Whether `stream_idx` has been read less far than some other stream.
+    ///
+    /// Half of `Self::read_is_required_for_liveness`; see it for why a laggard
+    /// must stay readable.
+    #[must_use]
+    fn stream_is_behind(&self, stream_idx: usize) -> bool {
+        let mine = self.batch_counters[stream_idx].load(Ordering::Relaxed);
+        self.batch_counters.iter().any(|c| c.load(Ordering::Relaxed) > mine)
+    }
+
+    /// Whether some stream other than `stream_idx` has reached EOF.
+    ///
+    /// The other half of `Self::read_is_required_for_liveness`.
+    #[must_use]
+    fn another_stream_is_at_eof(&self, stream_idx: usize) -> bool {
+        self.stream_eof
+            .iter()
+            .enumerate()
+            .any(|(i, eof)| i != stream_idx && eof.load(Ordering::Acquire))
+    }
+
+    /// Whether Read must be allowed to pull from `stream_idx` regardless of the
+    /// queue memory budget, to keep the pipeline live.
+    ///
+    /// Both multi-stream assembly steps — the gzip Pair step and the BGZF
+    /// `BlockMerge` step — release a batch only once every stream has delivered
+    /// the matching index, or once every stream has reached EOF
+    /// (`read_done` / `stream_eof`). Only Read can satisfy either condition, so
+    /// there are two states in which refusing to read wedges the pipeline
+    /// holding data it can never release:
+    ///
+    /// * **This stream has fallen behind another.** What Pair/`BlockMerge` are
+    ///   holding is waiting on exactly this stream's next batch. Exempting only
+    ///   the laggard bounds the extra read-ahead at the skew that already
+    ///   existed: once the streams are level the gate closes completely, and by
+    ///   then every index below the common one is inside the pipeline.
+    /// * **Another stream has reached EOF.** Everything past the shorter
+    ///   stream's end is unreleasable until `read_done`, which needs *this*
+    ///   stream at EOF too. For equal-length inputs that covers the last batch
+    ///   or two. For mismatched-length inputs it deliberately trades the bound
+    ///   for liveness on the surplus tail: a run that cannot finish is worse
+    ///   than one that exceeds its budget on malformed input.
+    #[must_use]
+    fn read_is_required_for_liveness(&self, stream_idx: usize) -> bool {
+        self.stream_is_behind(stream_idx) || self.another_stream_is_at_eof(stream_idx)
+    }
+
+    /// Whether the Read step may admit another batch from `stream_idx` under
+    /// the queue memory budget.
+    ///
+    /// Every other stage is bounded by a slot count rather than by bytes — so
+    /// when the output device stalls, each stage fills with however many bytes
+    /// its slots happen to hold and the configured budget bounds nothing.
+    /// Gating Read on [`Self::queue_bytes_in_flight`] is what turns that budget
+    /// into a real ceiling (issue #766).
+    ///
+    /// This cannot deadlock. Nothing downstream waits on Read to make progress:
+    /// `read_done` is set only once every stream is at EOF, so declining to
+    /// read leaves every stage free to drain, which lowers the in-flight total
+    /// and lets reading resume. Admission is also always granted when nothing
+    /// is accounted for in flight, so a single batch larger than the whole
+    /// budget still gets through instead of stalling the pipeline forever, and
+    /// a stream whose data the assembly steps are waiting on is always
+    /// admitted — see `Self::read_is_required_for_liveness`.
+    ///
+    /// A `queue_memory_limit` of 0 means "no limit" and disables the gate.
+    #[must_use]
+    pub fn read_admission_allowed(&self, stream_idx: usize) -> bool {
+        let limit = self.config.queue_memory_limit;
+        if limit == 0 {
+            return true;
+        }
+        let in_flight = self.queue_bytes_in_flight();
+        in_flight == 0 || in_flight < limit || self.read_is_required_for_liveness(stream_idx)
     }
 
     /// Check if the pipeline is in drain mode (input exhausted, completing remaining work).
@@ -1859,6 +2117,10 @@ impl<R: BufRead + Send + 'static, P: Send + MemoryEstimate + 'static> Monitorabl
                 )),
             )
         };
+        // Include the Read gate's own view: when the gate is what stopped the
+        // pipeline, the queue lengths alone look like an idle run.
+        let in_flight_mb = self.queue_bytes_in_flight() / (1024 * 1024);
+        let extra_state = extra_state.map(|s| format!("{s}, queue_in_flight={in_flight_mb}MB"));
         QueueSnapshot {
             q1_len: self.q0_chunks.len(),
             q2_len: self.q1_decompressed.len(),
@@ -1898,7 +2160,8 @@ impl<R: BufRead + Send + 'static, P: Send + MemoryEstimate + 'static> OutputPipe
     }
 
     fn q5_push(&self, item: (u64, SerializedBatch)) -> Result<(), (u64, SerializedBatch)> {
-        self.output.serialized.push(item)
+        let heap_size = item.1.estimate_heap_size() as u64;
+        push_charged(&self.output.serialized, &self.output.serialized_heap_bytes, heap_size, item)
     }
 
     fn q5_is_full(&self) -> bool {
@@ -1906,7 +2169,7 @@ impl<R: BufRead + Send + 'static, P: Send + MemoryEstimate + 'static> OutputPipe
     }
 
     fn q5_track_pop(&self, heap_size: u64) {
-        self.output.serialized_heap_bytes.fetch_sub(heap_size, Ordering::AcqRel);
+        refund_queue_bytes(&self.output.serialized_heap_bytes, heap_size);
     }
 
     fn q6_pop(&self) -> Option<(u64, CompressedBlockBatch)> {
@@ -1917,12 +2180,8 @@ impl<R: BufRead + Send + 'static, P: Send + MemoryEstimate + 'static> OutputPipe
         &self,
         item: (u64, CompressedBlockBatch),
     ) -> Result<(), (u64, CompressedBlockBatch)> {
-        let heap_size = item.1.estimate_heap_size();
-        let result = self.output.compressed.push(item);
-        if result.is_ok() {
-            self.output.compressed_heap_bytes.fetch_add(heap_size as u64, Ordering::AcqRel);
-        }
-        result
+        let heap_size = item.1.estimate_heap_size() as u64;
+        push_charged(&self.output.compressed, &self.output.compressed_heap_bytes, heap_size, item)
     }
 
     fn q6_is_full(&self) -> bool {
@@ -1930,7 +2189,7 @@ impl<R: BufRead + Send + 'static, P: Send + MemoryEstimate + 'static> OutputPipe
     }
 
     fn q6_track_pop(&self, heap_size: u64) {
-        self.output.compressed_heap_bytes.fetch_sub(heap_size, Ordering::AcqRel);
+        refund_queue_bytes(&self.output.compressed_heap_bytes, heap_size);
     }
 
     fn q6_reorder_insert(&self, serial: u64, batch: CompressedBlockBatch) {
@@ -1986,7 +2245,7 @@ impl<R: BufRead + Send + 'static, P: Send + MemoryEstimate + 'static>
     ProcessPipelineState<FastqTemplate, P> for FastqPipelineState<R, P>
 {
     fn process_input_pop(&self) -> Option<(u64, Vec<FastqTemplate>)> {
-        self.output.groups.pop()
+        self.q3_pop()
     }
 
     fn process_output_is_full(&self) -> bool {
@@ -1994,7 +2253,9 @@ impl<R: BufRead + Send + 'static, P: Send + MemoryEstimate + 'static>
     }
 
     fn process_output_push(&self, item: (u64, Vec<P>)) -> Result<(), (u64, Vec<P>)> {
-        self.output.processed.push(item)
+        let heap_size: u64 =
+            item.1.iter().map(|p| MemoryEstimate::estimate_heap_size(p) as u64).sum();
+        push_charged(&self.output.processed, &self.output.processed_heap_bytes, heap_size, item)
     }
 
     fn has_error(&self) -> bool {
@@ -2029,7 +2290,11 @@ impl<R: BufRead + Send + 'static, P: Send + MemoryEstimate + 'static> SerializeP
         &self,
         item: (u64, SerializedBatch),
     ) -> Result<(), (u64, SerializedBatch)> {
-        self.output.serialized.push(item)
+        // Q5 and the serialize step push to the same queue with the same charge;
+        // delegate so the heap estimate and charge live in one place and cannot
+        // diverge (a divergent charge on one path would silently bias the Read
+        // gate).
+        OutputPipelineState::q5_push(self, item)
     }
 
     fn has_error(&self) -> bool {
@@ -2097,7 +2362,7 @@ fn fastq_try_step_read<R: BufRead + Send, P: Send + MemoryEstimate>(
 ) -> bool {
     // Priority 1: Try to advance held chunk
     if let Some((serial, held)) = worker.held_chunk.take() {
-        match state.q0_chunks.push((serial, held)) {
+        match state.q0_push(serial, held) {
             Ok(()) => {
                 state.deadlock_state.record_q1_push();
             }
@@ -2123,6 +2388,15 @@ fn fastq_try_step_read<R: BufRead + Send, P: Send + MemoryEstimate>(
     for i in 0..state.num_streams {
         let stream_idx = (start + i) % state.num_streams;
         if state.stream_eof[stream_idx].load(Ordering::Relaxed) {
+            continue;
+        }
+        // Priority 4a: Check the queue memory budget.
+        //
+        // Every other stage is bounded by a slot count, not by bytes, so this
+        // is the only place the configured budget can actually cap the
+        // pipeline. See `FastqPipelineState::read_admission_allowed` for why
+        // declining here cannot deadlock, and why a lagging stream is exempt.
+        if !state.read_admission_allowed(stream_idx) {
             continue;
         }
         let Some(mut guard) = state.readers[stream_idx].try_lock() else {
@@ -2158,7 +2432,7 @@ fn fastq_try_step_read<R: BufRead + Send, P: Send + MemoryEstimate>(
                         let serial = state.batches_read.fetch_add(1, Ordering::Release);
                         let chunk =
                             PerStreamChunk { stream_idx, batch_num, data: raw_data, offsets: None };
-                        match state.q0_chunks.push((serial, chunk)) {
+                        match state.q0_push(serial, chunk) {
                             Ok(()) => {
                                 state.deadlock_state.record_q1_push();
                                 return true;
@@ -2215,7 +2489,7 @@ fn fastq_try_step_read<R: BufRead + Send, P: Send + MemoryEstimate>(
                         }
                         let chunk =
                             PerStreamChunk { stream_idx, batch_num, data, offsets: Some(offsets) };
-                        match state.q0_chunks.push((serial, chunk)) {
+                        match state.q0_push(serial, chunk) {
                             Ok(()) => {
                                 state.deadlock_state.record_q1_push();
                                 return true;
@@ -2248,7 +2522,7 @@ fn fastq_try_step_decompress<R: BufRead + Send, P: Send + MemoryEstimate>(
 ) -> bool {
     // Priority 1: Try to advance held decompressed chunk
     if let Some((serial, held)) = worker.held_decompressed_chunk.take() {
-        match state.q1_decompressed.push((serial, held)) {
+        match state.q1_push(serial, held) {
             Ok(()) => {
                 state.deadlock_state.record_q2_push();
             }
@@ -2270,7 +2544,7 @@ fn fastq_try_step_decompress<R: BufRead + Send, P: Send + MemoryEstimate>(
     }
 
     // Priority 4: Pop from input queue
-    let Some((serial, chunk)) = state.q0_chunks.pop() else {
+    let Some((serial, chunk)) = state.q0_pop() else {
         if let Some(stats) = state.stats() {
             stats.record_queue_empty(1);
         }
@@ -2299,7 +2573,7 @@ fn fastq_try_step_decompress<R: BufRead + Send, P: Send + MemoryEstimate>(
     };
 
     // Priority 6: Push result
-    match state.q1_decompressed.push((serial, decompressed)) {
+    match state.q1_push(serial, decompressed) {
         Ok(()) => {
             state.deadlock_state.record_q2_push();
             true
@@ -2361,7 +2635,7 @@ fn fastq_try_step_block_parse<R: BufRead + Send, P: Send + MemoryEstimate>(
     }
 
     // Priority 3: Pop a decompressed chunk from q1.
-    let Some((serial, chunk)) = state.q1_decompressed.pop() else {
+    let Some((serial, chunk)) = state.q1_pop() else {
         return false;
     };
     state.deadlock_state.record_q2_pop();
@@ -2416,9 +2690,13 @@ fn fastq_try_step_block_parse<R: BufRead + Send, P: Send + MemoryEstimate>(
 
     let block_parsed = BlockParsed { block_idx, stream_idx, records, prefix_bytes, suffix_bytes };
 
-    // Track heap bytes at creation time. BlockMerge subtracts when it pops.
+    // Charge at creation time, before the item can become visible to BlockMerge
+    // (which refunds when it pops) — see `push_charged` for why the order
+    // matters. Unlike the `push_charged` sites this charge survives a failed
+    // push: the item is then held by the worker and is still resident, so
+    // keeping it charged is the accurate answer.
     let heap_bytes = block_parsed.estimate_heap_size() as u64;
-    state.q2_block_parsed_heap_bytes.fetch_add(heap_bytes, Ordering::Release);
+    state.q2_block_parsed_heap_bytes.fetch_add(heap_bytes, Ordering::AcqRel);
 
     match state.q2_block_parsed.push(block_parsed) {
         Ok(()) => {
@@ -2467,6 +2745,7 @@ fn drain_exhausted_stream<R: BufRead + Send, P: Send + MemoryEstimate>(
     mut did_work: bool,
     mut batches_this_call: usize,
 ) -> DrainResult {
+    let pending_heap_bytes = &mut merge.pending_heap_bytes;
     let (pending, suffix, surplus, other_surplus, next) = if drain_r1 {
         (
             &mut merge.r1_pending,
@@ -2490,8 +2769,11 @@ fn drain_exhausted_stream<R: BufRead + Send, P: Send + MemoryEstimate>(
         let Some(block) = pending.remove(&block_next) else {
             break;
         };
-        merge.pending_heap_bytes =
-            merge.pending_heap_bytes.saturating_sub(block.estimate_heap_size() as u64);
+        refund_block_merge_pending(
+            pending_heap_bytes,
+            &state.block_merge_pending_heap_bytes,
+            block.estimate_heap_size() as u64,
+        );
         *next += 1;
 
         let cross = match stitch_cross_block_record(suffix, &block.prefix_bytes) {
@@ -2544,7 +2826,7 @@ fn drain_exhausted_stream<R: BufRead + Send, P: Send + MemoryEstimate>(
             merge.serial_out += 1;
             let count = templates.len();
 
-            match state.output.groups.push((serial, templates)) {
+            match state.q3_push(serial, templates) {
                 Ok(()) => {
                     state.total_templates_pushed.fetch_add(count as u64, Ordering::Release);
                     if let Some(stats) = state.stats() {
@@ -2749,7 +3031,10 @@ fn flush_residual_suffixes_at_eof<R: BufRead + Send, P: Send + MemoryEstimate>(
     let serial = merge.serial_out;
     merge.serial_out += 1;
     let count = templates.len();
-    match state.output.groups.push((serial, templates)) {
+    // Charge Q3 through `q3_push` like every other producer: `groups_heap_bytes`
+    // gates Read and `q3_pop` refunds it unconditionally, so a batch pushed here
+    // uncharged would leave that later refund unpaired (issue `#766`).
+    match state.q3_push(serial, templates) {
         Ok(()) => {
             state.total_templates_pushed.fetch_add(count as u64, Ordering::Release);
             if let Some(stats) = state.stats() {
@@ -2785,7 +3070,7 @@ fn fastq_try_step_block_merge<R: BufRead + Send, P: Send + MemoryEstimate>(
     // Priority 1: Advance held templates first (same pattern as FindBoundaries).
     let mut did_work = false;
     if let Some((serial, held_templates, count)) = worker.held_parsed.take() {
-        match state.output.groups.push((serial, held_templates)) {
+        match state.q3_push(serial, held_templates) {
             Ok(()) => {
                 state.total_templates_pushed.fetch_add(count as u64, Ordering::Release);
                 if let Some(stats) = state.stats() {
@@ -2840,14 +3125,31 @@ fn fastq_try_step_block_merge<R: BufRead + Send, P: Send + MemoryEstimate>(
     if within_limit || !can_process {
         while let Some(block) = state.q2_block_parsed.pop() {
             let heap_bytes = block.estimate_heap_size() as u64;
-            state.q2_block_parsed_heap_bytes.fetch_sub(heap_bytes, Ordering::Release);
-            merge.pending_heap_bytes += heap_bytes;
+            refund_queue_bytes(&state.q2_block_parsed_heap_bytes, heap_bytes);
+            charge_block_merge_pending(
+                &mut merge.pending_heap_bytes,
+                &state.block_merge_pending_heap_bytes,
+                heap_bytes,
+            );
             state.deadlock_state.record_q2_5_pop();
             state.blocks_merged.fetch_add(1, Ordering::Release);
-            if block.stream_idx == 0 {
-                merge.r1_pending.insert(block.block_idx, block);
+            let block_idx = block.block_idx;
+            let displaced = if block.stream_idx == 0 {
+                merge.r1_pending.insert(block_idx, block)
             } else {
-                merge.r2_pending.insert(block.block_idx, block);
+                merge.r2_pending.insert(block_idx, block)
+            };
+            // `block_idx` is unique per stream, so a displaced block means the
+            // BGZF reader handed the same index over twice. Refund it rather
+            // than leak its charge: `block_merge_pending_heap_bytes` gates Read,
+            // so a leak stops the run rather than skewing a statistic.
+            if let Some(displaced) = displaced {
+                debug_assert!(false, "block {block_idx} was merged twice");
+                refund_block_merge_pending(
+                    &mut merge.pending_heap_bytes,
+                    &state.block_merge_pending_heap_bytes,
+                    displaced.estimate_heap_size() as u64,
+                );
             }
             drained += 1;
         }
@@ -2869,8 +3171,11 @@ fn fastq_try_step_block_merge<R: BufRead + Send, P: Send + MemoryEstimate>(
             let Some(r1_block) = merge.r1_pending.remove(&r1_next) else {
                 break;
             };
-            merge.pending_heap_bytes =
-                merge.pending_heap_bytes.saturating_sub(r1_block.estimate_heap_size() as u64);
+            refund_block_merge_pending(
+                &mut merge.pending_heap_bytes,
+                &state.block_merge_pending_heap_bytes,
+                r1_block.estimate_heap_size() as u64,
+            );
             merge.r1_next += 1;
 
             // Stitch cross-block record.
@@ -2904,7 +3209,7 @@ fn fastq_try_step_block_merge<R: BufRead + Send, P: Send + MemoryEstimate>(
             merge.serial_out += 1;
             let count = templates.len();
 
-            match state.output.groups.push((serial, templates)) {
+            match state.q3_push(serial, templates) {
                 Ok(()) => {
                     state.total_templates_pushed.fetch_add(count as u64, Ordering::Release);
                     if let Some(stats) = state.stats() {
@@ -2933,7 +3238,9 @@ fn fastq_try_step_block_merge<R: BufRead + Send, P: Send + MemoryEstimate>(
 
             let r1_block = merge.r1_pending.remove(&r1_next).expect("just checked");
             let r2_block = merge.r2_pending.remove(&r2_next).expect("just checked");
-            merge.pending_heap_bytes = merge.pending_heap_bytes.saturating_sub(
+            refund_block_merge_pending(
+                &mut merge.pending_heap_bytes,
+                &state.block_merge_pending_heap_bytes,
                 (r1_block.estimate_heap_size() + r2_block.estimate_heap_size()) as u64,
             );
             merge.r1_next += 1;
@@ -2992,7 +3299,7 @@ fn fastq_try_step_block_merge<R: BufRead + Send, P: Send + MemoryEstimate>(
             merge.serial_out += 1;
             let count = templates.len();
 
-            match state.output.groups.push((serial, templates)) {
+            match state.q3_push(serial, templates) {
                 Ok(()) => {
                     state.total_templates_pushed.fetch_add(count as u64, Ordering::Release);
                     if let Some(stats) = state.stats() {
@@ -3099,12 +3406,14 @@ fn fastq_try_step_find_boundaries<R: BufRead + Send, P: Send + MemoryEstimate>(
     // first, the held batch would never be pushed to q2_5, deadlocking the pipeline.
     let mut did_work = false;
     if let Some((serial, held)) = worker.held_boundaries.take() {
-        let boundary_heap_size = held.estimate_heap_size();
-        match state.q2_5_boundaries.push((serial, held)) {
+        let boundary_heap_size = held.estimate_heap_size() as u64;
+        match push_charged(
+            &state.q2_5_boundaries,
+            &state.q2_5_boundaries_heap_bytes,
+            boundary_heap_size,
+            (serial, held),
+        ) {
             Ok(()) => {
-                state
-                    .q2_5_boundaries_heap_bytes
-                    .fetch_add(boundary_heap_size as u64, Ordering::Relaxed);
                 // Note: batches_boundaries_found was already incremented at serial
                 // assignment time (fetch_add in Priority 5), not here.
                 state.deadlock_state.record_q2_5_push();
@@ -3133,10 +3442,10 @@ fn fastq_try_step_find_boundaries<R: BufRead + Send, P: Send + MemoryEstimate>(
     };
 
     // Priority 4: Drain q1_decompressed into pair buffer
-    while let Some((_, chunk)) = state.q1_decompressed.pop() {
+    while let Some((_, chunk)) = state.q1_pop() {
         state.deadlock_state.record_q2_pop();
         state.chunks_paired.fetch_add(1, Ordering::Release);
-        pair.insert(chunk);
+        pair.insert(chunk, &state.pair_heap_bytes);
     }
 
     // Check if ALL chunks from Read have arrived at the Pair.
@@ -3149,7 +3458,9 @@ fn fastq_try_step_find_boundaries<R: BufRead + Send, P: Send + MemoryEstimate>(
     // Cap batches processed per lock hold to avoid starving other workers (mirrors BAM pipeline).
     let mut batches_this_call = 0;
     while batches_this_call < MAX_BATCHES_PER_LOCK {
-        let Some(chunks) = pair.try_pop_complete(all_arrived) else { break };
+        let Some(chunks) = pair.try_pop_complete(all_arrived, &state.pair_heap_bytes) else {
+            break;
+        };
         // Atomically assign a unique serial. This must be fetch_add (not load)
         // because the held_boundaries path can race: Worker A creates a batch
         // but push fails (goes to held_boundaries without incrementing), then
@@ -3191,12 +3502,14 @@ fn fastq_try_step_find_boundaries<R: BufRead + Send, P: Send + MemoryEstimate>(
             }
         };
 
-        let boundary_heap_size = boundary_batch.estimate_heap_size();
-        match state.q2_5_boundaries.push((serial, boundary_batch)) {
+        let boundary_heap_size = boundary_batch.estimate_heap_size() as u64;
+        match push_charged(
+            &state.q2_5_boundaries,
+            &state.q2_5_boundaries_heap_bytes,
+            boundary_heap_size,
+            (serial, boundary_batch),
+        ) {
             Ok(()) => {
-                state
-                    .q2_5_boundaries_heap_bytes
-                    .fetch_add(boundary_heap_size as u64, Ordering::Relaxed);
                 // Note: batches_boundaries_found was already incremented by
                 // fetch_add above when the serial was assigned.
                 state.deadlock_state.record_q2_5_push();
@@ -3252,13 +3565,8 @@ fn fastq_try_step_parse<R: BufRead + Send, P: Send + MemoryEstimate>(
 
     // Priority 1: Try to advance held parsed templates
     if let Some((serial, held_templates, count)) = worker.held_parsed.take() {
-        match state.output.groups.push((serial, held_templates)) {
+        match state.q3_push(serial, held_templates) {
             Ok(()) => {
-                #[cfg(feature = "memory-debug")]
-                {
-                    let q4_heap: u64 = 0; // already tracked when first parsed
-                    state.output.groups_heap_bytes.fetch_add(q4_heap, Ordering::AcqRel);
-                }
                 state.total_templates_pushed.fetch_add(count as u64, Ordering::Release);
                 if let Some(stats) = state.stats() {
                     stats.groups_produced.fetch_add(count as u64, Ordering::Relaxed);
@@ -3309,7 +3617,7 @@ fn fastq_try_step_parse<R: BufRead + Send, P: Send + MemoryEstimate>(
     match FastqFormat::parse_records(boundary_batch) {
         Ok(parsed_batch) => {
             // Only decrement input memory AFTER successful parse
-            state.q2_5_boundaries_heap_bytes.fetch_sub(input_heap_size as u64, Ordering::Relaxed);
+            refund_queue_bytes(&state.q2_5_boundaries_heap_bytes, input_heap_size as u64);
 
             // Create templates by zipping records at matching positions
             let templates = match create_templates_from_streams(parsed_batch.streams) {
@@ -3323,15 +3631,8 @@ fn fastq_try_step_parse<R: BufRead + Send, P: Send + MemoryEstimate>(
             let count = templates.len();
 
             // Priority 5: Push templates to Q3 using held-item pattern
-            match state.output.groups.push((serial, templates)) {
+            match state.q3_push(serial, templates) {
                 Ok(()) => {
-                    #[cfg(feature = "memory-debug")]
-                    {
-                        // Heap size tracking for pushed templates is not yet implemented;
-                        // queue memory is tracked through estimates only for now.
-                        let q4_heap: u64 = 0;
-                        state.output.groups_heap_bytes.fetch_add(q4_heap, Ordering::AcqRel);
-                    }
                     state.total_templates_pushed.fetch_add(count as u64, Ordering::Release);
                     if let Some(stats) = state.stats() {
                         stats.groups_produced.fetch_add(count as u64, Ordering::Relaxed);
@@ -3352,7 +3653,7 @@ fn fastq_try_step_parse<R: BufRead + Send, P: Send + MemoryEstimate>(
         }
         Err(e) => {
             // Batch already removed from Q2.5; keep heap tracking consistent
-            state.q2_5_boundaries_heap_bytes.fetch_sub(input_heap_size as u64, Ordering::Relaxed);
+            refund_queue_bytes(&state.q2_5_boundaries_heap_bytes, input_heap_size as u64);
             state.set_error(e);
             false
         }
@@ -3435,10 +3736,14 @@ where
     // Priority 1: Try to advance any held item first
     // =========================================================================
     if let Some((serial, held, heap_size)) = worker.held_processed.take() {
-        match state.output.processed.push((serial, held)) {
+        match push_charged(
+            &state.output.processed,
+            &state.output.processed_heap_bytes,
+            heap_size as u64,
+            (serial, held),
+        ) {
             Ok(()) => {
                 // Successfully advanced held item
-                state.output.processed_heap_bytes.fetch_add(heap_size as u64, Ordering::AcqRel);
                 state.deadlock_state.record_q5_push();
             }
             Err((serial, held)) => {
@@ -3480,19 +3785,13 @@ where
             break;
         }
 
-        let Some((serial, batch)) = state.output.groups.pop() else {
+        let Some((serial, batch)) = state.q3_pop() else {
             if let Some(stats) = state.stats() {
                 stats.record_queue_empty(4);
             }
             break;
         };
         state.deadlock_state.record_q4_pop();
-
-        #[cfg(feature = "memory-debug")]
-        {
-            let q4_heap: u64 = batch.iter().map(|t| t.estimate_heap_size() as u64).sum();
-            state.output.groups_heap_bytes.fetch_sub(q4_heap, Ordering::AcqRel);
-        }
 
         log::trace!(
             "fastq_try_step_process: processing batch of {} templates, serial={}",
@@ -3519,9 +3818,13 @@ where
         let heap_size: usize = results.iter().map(MemoryEstimate::estimate_heap_size).sum();
 
         // Try to push result (non-blocking)
-        match state.output.processed.push((serial, results)) {
+        match push_charged(
+            &state.output.processed,
+            &state.output.processed_heap_bytes,
+            heap_size as u64,
+            (serial, results),
+        ) {
             Ok(()) => {
-                state.output.processed_heap_bytes.fetch_add(heap_size as u64, Ordering::AcqRel);
                 state.deadlock_state.record_q5_push();
                 did_work = true;
             }
@@ -3550,10 +3853,14 @@ where
     // Priority 1: Try to advance any held item first
     // =========================================================================
     if let Some((serial, held, heap_size)) = worker.held_serialized.take() {
-        match state.output.serialized.push((serial, held)) {
+        match push_charged(
+            &state.output.serialized,
+            &state.output.serialized_heap_bytes,
+            heap_size as u64,
+            (serial, held),
+        ) {
             Ok(()) => {
                 // Successfully advanced held item
-                state.output.serialized_heap_bytes.fetch_add(heap_size as u64, Ordering::AcqRel);
                 state.deadlock_state.record_q6_push();
             }
             Err((serial, held)) => {
@@ -3591,7 +3898,7 @@ where
 
     // Track memory being removed from Q4
     let q4_heap_size: usize = batch.iter().map(MemoryEstimate::estimate_heap_size).sum();
-    state.output.processed_heap_bytes.fetch_sub(q4_heap_size as u64, Ordering::AcqRel);
+    refund_queue_bytes(&state.output.processed_heap_bytes, q4_heap_size as u64);
 
     // =========================================================================
     // Priority 5: Serialize all items
@@ -3649,9 +3956,13 @@ where
         secondary_data: None,
     };
     let heap_size = batch.estimate_heap_size();
-    match state.output.serialized.push((serial, batch)) {
+    match push_charged(
+        &state.output.serialized,
+        &state.output.serialized_heap_bytes,
+        heap_size as u64,
+        (serial, batch),
+    ) {
         Ok(()) => {
-            state.output.serialized_heap_bytes.fetch_add(heap_size as u64, Ordering::AcqRel);
             state.deadlock_state.record_q6_push();
             true
         }
@@ -4981,24 +5292,32 @@ mod tests {
 
     #[test]
     fn test_pair_state_insert_and_pop() {
+        let heap_bytes = AtomicU64::new(0);
         let mut pair = PairState::new(2);
 
         // Insert both streams for batch 0
-        pair.insert(PerStreamChunk {
-            stream_idx: 0,
-            batch_num: 0,
-            data: b"data0".to_vec(),
-            offsets: Some(vec![0, 5]),
-        });
-        assert!(pair.try_pop_complete(false).is_none()); // Not complete yet
+        pair.insert(
+            PerStreamChunk {
+                stream_idx: 0,
+                batch_num: 0,
+                data: b"data0".to_vec(),
+                offsets: Some(vec![0, 5]),
+            },
+            &heap_bytes,
+        );
+        assert!(pair.try_pop_complete(false, &heap_bytes).is_none()); // Not complete yet
 
-        pair.insert(PerStreamChunk {
-            stream_idx: 1,
-            batch_num: 0,
-            data: b"data1".to_vec(),
-            offsets: Some(vec![0, 5]),
-        });
-        let chunks = pair.try_pop_complete(false).expect("try_pop_complete should succeed");
+        pair.insert(
+            PerStreamChunk {
+                stream_idx: 1,
+                batch_num: 0,
+                data: b"data1".to_vec(),
+                offsets: Some(vec![0, 5]),
+            },
+            &heap_bytes,
+        );
+        let chunks =
+            pair.try_pop_complete(false, &heap_bytes).expect("try_pop_complete should succeed");
         assert_eq!(chunks.len(), 2);
         assert!(pair.is_empty());
     }
@@ -5008,36 +5327,48 @@ mod tests {
         // Stream 0 produces 2 batches, stream 1 produces 1 batch.
         // With all_arrived=false, batch 1 won't emit (stream 1 missing).
         // With all_arrived=true, batch 1 emits with just stream 0's data.
+        let heap_bytes = AtomicU64::new(0);
         let mut pair = PairState::new(2);
 
-        pair.insert(PerStreamChunk {
-            stream_idx: 0,
-            batch_num: 0,
-            data: b"d00".to_vec(),
-            offsets: Some(vec![0, 3]),
-        });
-        pair.insert(PerStreamChunk {
-            stream_idx: 1,
-            batch_num: 0,
-            data: b"d10".to_vec(),
-            offsets: Some(vec![0, 3]),
-        });
-        pair.insert(PerStreamChunk {
-            stream_idx: 0,
-            batch_num: 1,
-            data: b"d01".to_vec(),
-            offsets: Some(vec![0, 3]),
-        });
+        pair.insert(
+            PerStreamChunk {
+                stream_idx: 0,
+                batch_num: 0,
+                data: b"d00".to_vec(),
+                offsets: Some(vec![0, 3]),
+            },
+            &heap_bytes,
+        );
+        pair.insert(
+            PerStreamChunk {
+                stream_idx: 1,
+                batch_num: 0,
+                data: b"d10".to_vec(),
+                offsets: Some(vec![0, 3]),
+            },
+            &heap_bytes,
+        );
+        pair.insert(
+            PerStreamChunk {
+                stream_idx: 0,
+                batch_num: 1,
+                data: b"d01".to_vec(),
+                offsets: Some(vec![0, 3]),
+            },
+            &heap_bytes,
+        );
 
         // Batch 0: complete
-        let chunks = pair.try_pop_complete(false).expect("try_pop_complete should succeed");
+        let chunks =
+            pair.try_pop_complete(false, &heap_bytes).expect("try_pop_complete should succeed");
         assert_eq!(chunks.len(), 2);
 
         // Batch 1: only stream 0 — not complete without all_arrived
-        assert!(pair.try_pop_complete(false).is_none());
+        assert!(pair.try_pop_complete(false, &heap_bytes).is_none());
 
         // With all_arrived, batch 1 emits with just stream 0
-        let chunks = pair.try_pop_complete(true).expect("try_pop_complete should succeed");
+        let chunks =
+            pair.try_pop_complete(true, &heap_bytes).expect("try_pop_complete should succeed");
         assert_eq!(chunks.len(), 1);
         assert_eq!(chunks[0].stream_idx, 0);
         assert!(pair.is_empty());
@@ -5051,48 +5382,62 @@ mod tests {
     /// a counter at the destination (Pair).
     #[test]
     fn test_pair_state_count_based_completion() {
+        let heap_bytes = AtomicU64::new(0);
         let mut pair = PairState::new(2);
 
         // Simulate: 2 streams, stream 0 produces batches 0..2, stream 1 produces batch 0 only.
         // Total batches_read = 3, chunks arriving at pair counted by chunks_paired.
 
         // Insert batch 0 from both streams.
-        pair.insert(PerStreamChunk {
-            stream_idx: 0,
-            batch_num: 0,
-            data: b"s0b0".to_vec(),
-            offsets: Some(vec![0, 4]),
-        });
-        pair.insert(PerStreamChunk {
-            stream_idx: 1,
-            batch_num: 0,
-            data: b"s1b0".to_vec(),
-            offsets: Some(vec![0, 4]),
-        });
+        pair.insert(
+            PerStreamChunk {
+                stream_idx: 0,
+                batch_num: 0,
+                data: b"s0b0".to_vec(),
+                offsets: Some(vec![0, 4]),
+            },
+            &heap_bytes,
+        );
+        pair.insert(
+            PerStreamChunk {
+                stream_idx: 1,
+                batch_num: 0,
+                data: b"s1b0".to_vec(),
+                offsets: Some(vec![0, 4]),
+            },
+            &heap_bytes,
+        );
 
         // Simulate: batches_read=2 (still reading), chunks_paired=2.
         // all_arrived = read_done(false) && ... → false.
         let all_arrived = false;
-        let chunks = pair.try_pop_complete(all_arrived).expect("try_pop_complete should succeed");
+        let chunks = pair
+            .try_pop_complete(all_arrived, &heap_bytes)
+            .expect("try_pop_complete should succeed");
         assert_eq!(chunks.len(), 2);
 
         // Insert batch 1 from stream 0 only (stream 1 hit EOF earlier).
-        pair.insert(PerStreamChunk {
-            stream_idx: 0,
-            batch_num: 1,
-            data: b"s0b1".to_vec(),
-            offsets: Some(vec![0, 4]),
-        });
+        pair.insert(
+            PerStreamChunk {
+                stream_idx: 0,
+                batch_num: 1,
+                data: b"s0b1".to_vec(),
+                offsets: Some(vec![0, 4]),
+            },
+            &heap_bytes,
+        );
 
         // Simulate: batches_read=3, chunks_paired=2 (third chunk just inserted, not yet counted).
         // all_arrived = read_done(true) && 2 == 3 → false.
         let all_arrived = false;
-        assert!(pair.try_pop_complete(all_arrived).is_none());
+        assert!(pair.try_pop_complete(all_arrived, &heap_bytes).is_none());
 
         // Simulate: chunks_paired catches up to 3.
         // all_arrived = read_done(true) && 3 == 3 → true.
         let all_arrived = true;
-        let chunks = pair.try_pop_complete(all_arrived).expect("try_pop_complete should succeed");
+        let chunks = pair
+            .try_pop_complete(all_arrived, &heap_bytes)
+            .expect("try_pop_complete should succeed");
         assert_eq!(chunks.len(), 1);
         assert_eq!(chunks[0].stream_idx, 0);
         assert!(pair.is_empty());
@@ -5811,6 +6156,17 @@ mod tests {
             vec![],
             vec![],
         );
+        // Production charges a pending block's bytes when it is buffered (see the
+        // `charge_block_merge_pending` call beside the real `*_pending.insert`),
+        // and `drain_exhausted_stream` refunds them as it consumes the block.
+        // Charge them here too so that refund is paired — otherwise it trips
+        // `refund_queue_bytes`'s unpaired-refund assertion.
+        let block_bytes = block.estimate_heap_size() as u64;
+        charge_block_merge_pending(
+            &mut merge.pending_heap_bytes,
+            &state.block_merge_pending_heap_bytes,
+            block_bytes,
+        );
         if drain_r1 {
             merge.r1_pending.insert(0, block);
         } else {
@@ -5830,6 +6186,95 @@ mod tests {
         );
     }
 
+    /// Drive `block_merge_input_drained` true: read done, every read batch
+    /// parsed, and nothing left queued or pending.
+    fn mark_block_merge_input_drained(state: &FastqPipelineState<Cursor<Vec<u8>>, Vec<u8>>) {
+        state.read_done.store(true, Ordering::Release);
+        state.batches_read.store(1, Ordering::Release);
+        state.chunks_block_parsed.store(1, Ordering::Release);
+    }
+
+    /// A worker with no held batch, so `flush_residual_suffixes_at_eof` acts.
+    fn idle_worker() -> FastqWorkerState<Vec<u8>> {
+        FastqWorkerState::new(6, 0, 1, SchedulerStrategy::default(), ActiveSteps::all())
+    }
+
+    /// At EOF, a single-stream residual with no trailing newline must be flushed
+    /// as a template and charged onto Q3 — the shape the `--rejects`-off/`-on`
+    /// integration paths exercise end to end, pinned here directly.
+    #[test]
+    fn flush_residual_suffix_emits_a_single_stream_record_without_a_trailing_newline() {
+        let state = make_fastq_state_with_budget(0, 1);
+        let mut merge = BlockMergeState::new();
+        let mut worker = idle_worker();
+        mark_block_merge_input_drained(&state);
+
+        // A complete record whose final newline never arrived: the whole record
+        // is left in the suffix at EOF.
+        merge.r1_suffix_bytes = b"@r1\nACGT\n+\nIIII".to_vec();
+
+        let flushed = flush_residual_suffixes_at_eof(&state, &mut merge, &mut worker);
+        assert!(flushed, "a residual record must be flushed at EOF");
+        assert!(merge.r1_suffix_bytes.is_empty(), "the suffix must be consumed");
+        assert!(worker.held_parsed.is_none(), "an accepted push holds nothing");
+        let (_serial, templates) = state.q3_pop().expect("the flushed record must reach Q3");
+        assert_eq!(templates.len(), 1);
+        assert_eq!(templates[0].name, b"r1");
+    }
+
+    /// A paired input with a residual on only one stream forms no pair, so
+    /// nothing is flushed — but both suffixes are still drained so completion is
+    /// no longer blocked on them, and the unpairable record stays in the surplus
+    /// for `finish_block_merge_if_complete` to reject as out of sync (issue #773).
+    #[test]
+    fn flush_residual_suffix_leaves_a_one_sided_paired_residual_for_rejection() {
+        let state = make_fastq_state_with_budget(0, 2);
+        let mut merge = BlockMergeState::new();
+        let mut worker = idle_worker();
+        mark_block_merge_input_drained(&state);
+
+        // Only R1 has a residual; R2 ended cleanly, so no mate can arrive.
+        merge.r1_suffix_bytes = b"@r1\nACGT\n+\nIIII".to_vec();
+
+        let flushed = flush_residual_suffixes_at_eof(&state, &mut merge, &mut worker);
+        assert!(!flushed, "a one-sided residual forms no template, so nothing is flushed");
+        assert!(
+            merge.r1_suffix_bytes.is_empty(),
+            "the suffix must still be drained to unblock completion"
+        );
+        assert_eq!(
+            merge.r1_surplus.len(),
+            1,
+            "the unpairable record stays in the surplus for rejection"
+        );
+        assert!(state.q3_pop().is_none(), "no template reaches Q3");
+    }
+
+    /// When Q3 is full the flush cannot publish, so it must hand the batch back
+    /// to `worker.held_parsed` for Priority 1 to retry — never drop it.
+    #[test]
+    fn flush_residual_suffix_holds_the_batch_when_q3_is_full() {
+        let state = make_fastq_state_with_budget(0, 1);
+        let mut merge = BlockMergeState::new();
+        let mut worker = idle_worker();
+        mark_block_merge_input_drained(&state);
+        merge.r1_suffix_bytes = b"@r1\nACGT\n+\nIIII".to_vec();
+
+        // Saturate Q3 so the flush's push is refused.
+        let mut filler_serial = 1_000u64;
+        while state.output.groups.push((filler_serial, Vec::new())).is_ok() {
+            filler_serial += 1;
+        }
+
+        let flushed = flush_residual_suffixes_at_eof(&state, &mut merge, &mut worker);
+        assert!(flushed, "the flush did work even though the push was refused");
+        let (_serial, held, count) =
+            worker.held_parsed.as_ref().expect("the un-pushable batch must be held for retry");
+        assert_eq!(*count, 1);
+        assert_eq!(held.len(), 1, "the held batch carries the flushed template");
+        assert_eq!(held[0].name, b"r1");
+    }
+
     #[test]
     fn test_block_merge_state_empty() {
         let state = BlockMergeState::new();
@@ -5845,10 +6290,261 @@ mod tests {
 
     /// Helper to create a minimal FASTQ pipeline state for backpressure tests.
     fn make_fastq_state() -> FastqPipelineState<Cursor<Vec<u8>>, Vec<u8>> {
-        let config = FastqPipelineConfig::new(2, false, 6);
-        let readers = vec![StreamReader::Decompressed(Cursor::new(Vec::new()))];
+        make_fastq_state_with_budget(4 * 1024 * 1024 * 1024, 1)
+    }
+
+    /// A minimal two-stream-capable FASTQ pipeline state with an explicit queue
+    /// memory budget, for the Read-admission tests.
+    fn make_fastq_state_with_budget(
+        queue_memory_limit: u64,
+        num_streams: usize,
+    ) -> FastqPipelineState<Cursor<Vec<u8>>, Vec<u8>> {
+        let config =
+            FastqPipelineConfig::new(2, false, 6).with_queue_memory_limit(queue_memory_limit);
+        let readers =
+            (0..num_streams).map(|_| StreamReader::Decompressed(Cursor::new(Vec::new()))).collect();
         let output: Box<dyn std::io::Write + Send> = Box::new(Vec::<u8>::new());
         FastqPipelineState::new(config, readers, output)
+    }
+
+    /// A chunk holding `len` bytes of data, for exercising the queue charges.
+    fn chunk_of(stream_idx: usize, batch_num: u64, len: usize) -> PerStreamChunk {
+        PerStreamChunk { stream_idx, batch_num, data: vec![0u8; len], offsets: None }
+    }
+
+    /// A `queue_memory_limit` of 0 means "no limit", so Read is never gated.
+    #[test]
+    fn read_admission_is_unconditional_without_a_limit() {
+        let state = make_fastq_state_with_budget(0, 1);
+        state.q0_heap_bytes.store(u64::MAX / 2, Ordering::Release);
+        assert!(state.read_admission_allowed(0));
+    }
+
+    /// Read is gated once the accounted queues reach the budget, and reopens as
+    /// soon as a stage drains below it.
+    #[test]
+    fn read_admission_tracks_the_queue_memory_budget() {
+        let state = make_fastq_state_with_budget(1024, 1);
+
+        state.q1_heap_bytes.store(512, Ordering::Release);
+        assert!(state.read_admission_allowed(0), "under budget: reading continues");
+
+        state.q1_heap_bytes.store(1024, Ordering::Release);
+        assert!(!state.read_admission_allowed(0), "at budget: reading stops");
+
+        state.q1_heap_bytes.store(256, Ordering::Release);
+        assert!(state.read_admission_allowed(0), "drained below budget: reading resumes");
+    }
+
+    /// With nothing accounted for in flight, Read is always admitted — so an
+    /// input whose first batch alone exceeds the whole budget still makes
+    /// progress instead of wedging the pipeline.
+    #[test]
+    fn read_admission_always_allows_the_first_batch() {
+        let state = make_fastq_state_with_budget(1, 1);
+        assert_eq!(state.queue_bytes_in_flight(), 0);
+        assert!(state.read_admission_allowed(0));
+    }
+
+    /// A stream that has fallen behind stays readable even over budget.
+    ///
+    /// Both the BGZF merge step and the gzip pair step hold a batch until every
+    /// stream has delivered the matching index, and only Read can supply the
+    /// missing one — so gating the laggard would wedge the pipeline holding
+    /// data it can never release.
+    #[test]
+    fn read_admission_still_allows_a_lagging_stream() {
+        let state = make_fastq_state_with_budget(1024, 2);
+        state.q0_heap_bytes.store(4096, Ordering::Release);
+        state.batch_counters[0].store(10, Ordering::Release);
+        state.batch_counters[1].store(3, Ordering::Release);
+
+        assert!(!state.read_admission_allowed(0), "the stream that ran ahead is gated");
+        assert!(state.read_admission_allowed(1), "the stream that fell behind is not");
+
+        // Once the streams are level the gate closes for both, and every index
+        // below the common one is already inside the pipeline.
+        state.batch_counters[1].store(10, Ordering::Release);
+        assert!(!state.read_admission_allowed(0));
+        assert!(!state.read_admission_allowed(1));
+    }
+
+    /// A stream whose sibling has already hit EOF stays readable over budget.
+    ///
+    /// Nothing past the shorter stream's end can be released by the Pair or
+    /// `BlockMerge` steps until every stream is at EOF, and only Read can get
+    /// there — so gating the surviving stream would wedge the run holding data
+    /// it can never emit.
+    #[test]
+    fn read_admission_still_allows_a_stream_whose_sibling_hit_eof() {
+        let state = make_fastq_state_with_budget(1024, 2);
+        state.q0_heap_bytes.store(4096, Ordering::Release);
+        state.batch_counters[0].store(10, Ordering::Release);
+        state.batch_counters[1].store(10, Ordering::Release);
+        assert!(!state.read_admission_allowed(1), "level streams under budget pressure are gated");
+
+        state.stream_eof[0].store(true, Ordering::Release);
+        assert!(
+            state.read_admission_allowed(1),
+            "the surviving stream must still reach its own EOF"
+        );
+    }
+
+    /// Every accounted counter must reach the Read gate; a queue left out of
+    /// the sum is a queue the budget does not bound.
+    #[test]
+    fn queue_bytes_in_flight_sums_every_accounted_queue() {
+        let state = make_fastq_state_with_budget(1024, 1);
+        let counters: [&AtomicU64; 10] = [
+            &state.q0_heap_bytes,
+            &state.q1_heap_bytes,
+            &state.q2_block_parsed_heap_bytes,
+            &state.block_merge_pending_heap_bytes,
+            &state.pair_heap_bytes,
+            &state.q2_5_boundaries_heap_bytes,
+            &state.output.groups_heap_bytes,
+            &state.output.processed_heap_bytes,
+            &state.output.serialized_heap_bytes,
+            &state.output.compressed_heap_bytes,
+        ];
+        for (i, counter) in counters.iter().enumerate() {
+            counter.store(1 << i, Ordering::Release);
+        }
+        state.output.write_reorder_state.add_heap_bytes(1 << counters.len());
+
+        let expected = (1u64 << (counters.len() + 1)) - 1;
+        assert_eq!(state.queue_bytes_in_flight(), expected);
+    }
+
+    /// A push that fails for want of a slot must leave no charge behind.
+    ///
+    /// `push_charged` charges before the item can become visible, so a failed
+    /// push has to refund; otherwise every rejected push would inflate a
+    /// counter that gates the Read step, and the pipeline would eventually stop
+    /// reading with its queues empty.
+    #[test]
+    fn a_failed_push_leaves_no_charge_behind() {
+        let counter = AtomicU64::new(0);
+        let queue: ArrayQueue<(u64, Vec<u8>)> = ArrayQueue::new(1);
+
+        assert!(push_charged(&queue, &counter, 4096, (0, vec![0u8; 4096])).is_ok());
+        assert_eq!(counter.load(Ordering::Acquire), 4096);
+
+        let rejected = push_charged(&queue, &counter, 4096, (1, vec![0u8; 4096]));
+        assert!(rejected.is_err(), "a full queue must reject the second push");
+        assert_eq!(
+            counter.load(Ordering::Acquire),
+            4096,
+            "the rejected push must not leave its charge on the counter"
+        );
+    }
+
+    /// Q0's and Q1's charges are refunded exactly on pop, so the counters
+    /// return to zero.
+    #[test]
+    fn q0_and_q1_charges_are_refunded_on_pop() {
+        let state = make_fastq_state_with_budget(1024 * 1024, 1);
+
+        let charged = chunk_of(0, 0, 4096).estimate_heap_size() as u64;
+        assert!(charged >= 4096, "a 4 KiB payload must be charged as at least 4 KiB");
+
+        assert!(state.q0_push(7, chunk_of(0, 0, 4096)).is_ok());
+        assert_eq!(state.q0_heap_bytes.load(Ordering::Acquire), charged);
+        let (serial, _chunk) = state.q0_pop().expect("pushed chunk should pop");
+        assert_eq!(serial, 7);
+        assert_eq!(state.q0_heap_bytes.load(Ordering::Acquire), 0);
+
+        assert!(state.q1_push(9, chunk_of(0, 1, 4096)).is_ok());
+        assert_eq!(state.q1_heap_bytes.load(Ordering::Acquire), charged);
+        let (serial, _chunk) = state.q1_pop().expect("pushed chunk should pop");
+        assert_eq!(serial, 9);
+        assert_eq!(state.q1_heap_bytes.load(Ordering::Acquire), 0);
+    }
+
+    /// Q3 (templates) is charged on push and refunded on pop.
+    ///
+    /// It used to be tracked only under `memory-debug`, and even then charged a
+    /// hardcoded `0` on the way in, so the counter read zero however much the
+    /// queue held (issue #766).
+    #[test]
+    fn q3_charge_is_refunded_on_pop() {
+        let state = make_fastq_state_with_budget(1024 * 1024, 1);
+        let record = FastqRecord::from_slice(b"@read1\nACGTACGT\n+\nIIIIIIII\n")
+            .expect("valid FASTQ record");
+        let templates = vec![FastqTemplate { name: b"read1".to_vec(), records: vec![record] }];
+        let charged: u64 = templates.iter().map(|t| t.estimate_heap_size() as u64).sum();
+        assert!(charged > 0, "a non-empty template must carry a non-zero charge");
+
+        assert!(state.q3_push(3, templates).is_ok());
+        assert_eq!(state.output.groups_heap_bytes.load(Ordering::Acquire), charged);
+
+        let (serial, _batch) = state.q3_pop().expect("pushed batch should pop");
+        assert_eq!(serial, 3);
+        assert_eq!(state.output.groups_heap_bytes.load(Ordering::Acquire), 0);
+    }
+
+    /// The pair buffer's charge survives the move out of Q1 and is refunded
+    /// when the batch is emitted.
+    ///
+    /// Chunks leave Q1 the moment the Pair step runs, so if the pair buffer did
+    /// not carry the charge the Read gate would stop seeing data that is still
+    /// resident.
+    #[test]
+    fn pair_buffer_charge_is_refunded_when_the_batch_is_emitted() {
+        let state = make_fastq_state_with_budget(1024 * 1024, 2);
+        let charged = 2 * chunk_of(0, 0, 4096).estimate_heap_size() as u64;
+
+        let mut pair = state.pair_state.lock();
+        pair.insert(chunk_of(0, 0, 4096), &state.pair_heap_bytes);
+        pair.insert(chunk_of(1, 0, 4096), &state.pair_heap_bytes);
+        assert_eq!(state.pair_heap_bytes.load(Ordering::Acquire), charged);
+
+        let chunks = pair
+            .try_pop_complete(false, &state.pair_heap_bytes)
+            .expect("both streams delivered batch 0");
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(state.pair_heap_bytes.load(Ordering::Acquire), 0);
+    }
+
+    /// The merge step's pending maps are mirrored into a lock-free counter, so
+    /// blocks parked there still count against the budget.
+    #[test]
+    fn block_merge_pending_charge_is_mirrored_and_refunded() {
+        let state = make_fastq_state_with_budget(1024 * 1024, 2);
+        let mut merge = state.block_merge_state.lock();
+
+        charge_block_merge_pending(
+            &mut merge.pending_heap_bytes,
+            &state.block_merge_pending_heap_bytes,
+            4096,
+        );
+        assert_eq!(merge.pending_heap_bytes, 4096);
+        assert_eq!(state.block_merge_pending_heap_bytes.load(Ordering::Acquire), 4096);
+
+        refund_block_merge_pending(
+            &mut merge.pending_heap_bytes,
+            &state.block_merge_pending_heap_bytes,
+            4096,
+        );
+        assert_eq!(merge.pending_heap_bytes, 0);
+        assert_eq!(state.block_merge_pending_heap_bytes.load(Ordering::Acquire), 0);
+    }
+
+    /// The local `pending_heap_bytes` saturates at zero on an over-refund rather
+    /// than wrapping to `u64::MAX`, which would hold the merge step's
+    /// `PENDING_BACKPRESSURE_BYTES` gate shut for the rest of the run.
+    ///
+    /// The mirror is charged the full amount first so only the *local* side is
+    /// over-refunded: `refund_queue_bytes` carries a `debug_assert!` that its own
+    /// refunds are paired, and this test is about the local counter's arithmetic.
+    #[test]
+    fn refunding_more_block_merge_pending_than_was_charged_saturates_at_zero() {
+        let state = make_fastq_state_with_budget(1024, 1);
+        let mut local = 100u64;
+        state.block_merge_pending_heap_bytes.store(250, Ordering::Release);
+        refund_block_merge_pending(&mut local, &state.block_merge_pending_heap_bytes, 250);
+        assert_eq!(local, 0);
+        assert_eq!(state.block_merge_pending_heap_bytes.load(Ordering::Acquire), 0);
     }
 
     /// Verify that the FASTQ pipeline's scheduler backpressure reports memory

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -33,6 +33,7 @@ mod test_e2e_regression;
 mod test_error_paths;
 mod test_extract_command;
 mod test_fastq_command;
+mod test_fastq_pipeline_memory_backpressure;
 mod test_filter_command;
 mod test_group_command;
 mod test_group_determinism;

--- a/tests/integration/test_fastq_pipeline_memory_backpressure.rs
+++ b/tests/integration/test_fastq_pipeline_memory_backpressure.rs
@@ -1,0 +1,668 @@
+//! Queue-memory backpressure from the output side back to the FASTQ Read step.
+//!
+//! The threaded FASTQ pipeline (`fgumi extract`) advertises a queue memory
+//! budget (`--max-memory`, logged as "Queue memory budget: N total"). Every
+//! stage between Read and Write is bounded, but the bound on most of them is a
+//! *slot count*, not a byte count — so when the output device stalls, each
+//! stage saturates with however many bytes its slots happen to hold and the
+//! budget is not what decides the ceiling.
+//!
+//! Read is the pipeline's only source of new bytes, and nothing downstream
+//! waits on it to make progress, so gating Read on the accounted in-flight
+//! bytes bounds the whole pipeline without risking deadlock. These tests pin
+//! that behaviour: with a writer that never completes, the pipeline must stop
+//! pulling input rather than draining both FASTQ files into its queues.
+//!
+//! These are the FASTQ siblings of `test_pipeline_memory_backpressure.rs`.
+//!
+//! See <https://github.com/fulcrumgenomics/fgumi/issues/766>.
+
+#![allow(clippy::cast_possible_truncation)]
+
+use noodles::bam;
+use noodles::sam::Header;
+use noodles::sam::alignment::RecordBuf;
+use noodles::sam::alignment::record_buf::{QualityScores, Sequence};
+use noodles_bgzf::io::Writer as BgzfWriter;
+use std::fs::File;
+use std::io::{self, BufRead, Cursor, Read, Write};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+use fgumi_lib::fastq_parse::strip_read_suffix;
+use fgumi_lib::grouper::FastqTemplate;
+use fgumi_lib::unified_pipeline::{
+    FastqPipelineConfig, run_fastq_pipeline, serialize_bam_record_into,
+};
+
+/// Queue memory budget used by the tests, in bytes.
+const TEST_BUDGET_BYTES: u64 = 2 * 1024 * 1024;
+
+/// A budget generous enough to swallow the whole test input.
+const GENEROUS_BUDGET_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Templates in the test input, and bases per read.
+///
+/// Sized so the input is many times what the pipeline can hold under
+/// `TEST_BUDGET_BYTES`; a smaller input would be swallowed whole and the
+/// assertions would prove nothing.
+const TEMPLATES: usize = 30_000;
+const READ_LENGTH: usize = 150;
+
+/// Worker threads for the pipeline under test.
+const NUM_THREADS: usize = 4;
+
+/// Bytes the stalled writer accepts before it starts blocking.
+///
+/// `run_fastq_pipeline` writes the BAM header on the calling thread before it
+/// spawns a single worker, so a writer that blocked from the very first byte
+/// would stall the header write and the pipeline would never start. This
+/// allowance lets the header (a few hundred bytes for a minimal one) through
+/// and is negligible beside `TEST_BUDGET_BYTES`.
+const WRITER_PRELUDE_BYTES: usize = 64 * 1024;
+
+/// A reader that records how many bytes the pipeline has pulled from a stream.
+///
+/// `read_n_fastq_records` consumes exclusively through `BufRead::read_until`,
+/// so `consume` sees every byte the Read step takes. `Read::read` is counted
+/// too for completeness; it cannot double-count because it delegates to the
+/// inner cursor rather than to `Self::consume`.
+struct CountingReader {
+    inner: Cursor<Vec<u8>>,
+    consumed: Arc<AtomicU64>,
+}
+
+impl Read for CountingReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.consumed.fetch_add(n as u64, Ordering::Relaxed);
+        Ok(n)
+    }
+}
+
+impl BufRead for CountingReader {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.consumed.fetch_add(amt as u64, Ordering::Relaxed);
+        self.inner.consume(amt);
+    }
+}
+
+/// A writer that blocks every write until it is released, then keeps the bytes.
+///
+/// Stands in for a saturated output device: the pipeline stays healthy (no
+/// error, no panic) but makes no write progress at all. Retaining what it
+/// eventually accepts lets the recovery test check record identity rather than
+/// just a record count.
+struct StalledWriter {
+    released: Arc<AtomicBool>,
+    sink: Arc<Mutex<Vec<u8>>>,
+}
+
+impl Write for StalledWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // Generous enough never to fire in a passing run; bounded so a failed
+        // assertion that unwinds before `released.store(true)` does not leave
+        // this thread spinning for the rest of the test binary under
+        // `cargo test` (where all tests share one process).
+        let deadline = Instant::now() + Duration::from_secs(300);
+        loop {
+            {
+                let sink = self.sink.lock().expect("sink mutex should not be poisoned");
+                if self.released.load(Ordering::Acquire) || sink.len() < WRITER_PRELUDE_BYTES {
+                    break;
+                }
+            }
+            if Instant::now() >= deadline {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "StalledWriter was never released",
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        self.sink.lock().expect("sink mutex should not be poisoned").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Build one FASTQ stream's bytes, and the read names it contains, in order.
+///
+/// Sequences vary per record so the queues have to hold real bytes rather than
+/// a handful of repeated ones.
+fn build_fastq_stream(num_records: usize, read_number: u8) -> (Vec<u8>, Vec<String>) {
+    let bases = [b'A', b'C', b'G', b'T'];
+    let mut data = Vec::with_capacity(num_records * (READ_LENGTH * 2 + 40));
+    let mut names = Vec::with_capacity(num_records);
+    for i in 0..num_records {
+        let name = format!("read{i}");
+        let mut lcg = (i as u64).wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+        let sequence: Vec<u8> = (0..READ_LENGTH)
+            .map(|_| {
+                lcg = lcg
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1_442_695_040_888_963_407);
+                bases[((lcg >> 33) & 3) as usize]
+            })
+            .collect();
+        data.extend_from_slice(format!("@{name}/{read_number}\n").as_bytes());
+        data.extend_from_slice(&sequence);
+        data.push(b'\n');
+        data.extend_from_slice(b"+\n");
+        data.extend(std::iter::repeat_n(b'I', READ_LENGTH));
+        data.push(b'\n');
+        names.push(name);
+    }
+    (data, names)
+}
+
+/// Read the record names out of a BAM byte stream, in order.
+fn record_names(bam_bytes: &[u8]) -> Vec<String> {
+    let mut reader = bam::io::Reader::new(Cursor::new(bam_bytes));
+    let header = reader.read_header().expect("read header");
+    reader
+        .record_bufs(&header)
+        .map(|r| {
+            let record = r.expect("read record");
+            String::from_utf8_lossy(record.name().expect("record should have a name").as_ref())
+                .into_owned()
+        })
+        .collect()
+}
+
+/// A running pipeline whose writer is stalled, with the handles a test needs to
+/// observe it, release it, and inspect what it eventually wrote.
+struct StalledRun {
+    /// Input bytes the Read step has pulled so far, summed over both streams.
+    consumed: Arc<AtomicU64>,
+    /// Set to release the writer.
+    released: Arc<AtomicBool>,
+    /// Output bytes accepted, as a complete BAM stream.
+    sink: Arc<Mutex<Vec<u8>>>,
+    /// The pipeline itself, yielding the count of records written.
+    handle: std::thread::JoinHandle<io::Result<u64>>,
+}
+
+/// Spawn a paired-end pass-through pipeline whose writer never completes.
+///
+/// The streams are handed in already decompressed, which is the plain/gzip
+/// input path: Read → Decompress (pass-through) → Pair → Parse → Process →
+/// Serialize → Compress → Write.
+fn spawn_stalled_pipeline(
+    header: &Header,
+    streams: Vec<Vec<u8>>,
+    queue_memory_limit: u64,
+) -> StalledRun {
+    let consumed = Arc::new(AtomicU64::new(0));
+    let released = Arc::new(AtomicBool::new(false));
+    let sink = Arc::new(Mutex::new(Vec::new()));
+
+    let readers: Vec<Box<dyn BufRead + Send>> = streams
+        .into_iter()
+        .map(|bytes| {
+            let reader =
+                CountingReader { inner: Cursor::new(bytes), consumed: Arc::clone(&consumed) };
+            Box::new(reader) as Box<dyn BufRead + Send>
+        })
+        .collect();
+    let writer = StalledWriter { released: Arc::clone(&released), sink: Arc::clone(&sink) };
+
+    // Production auto-tuning on purpose: the slot counts must stay large enough
+    // to swallow the whole test input, so that any bound the test observes comes
+    // from the byte budget and not from a queue running out of slots.
+    let mut config = FastqPipelineConfig::new(NUM_THREADS, false, 1);
+    config.queue_memory_limit = queue_memory_limit;
+    // A permanently stalled writer is exactly what the deadlock detector is
+    // meant to flag, and flagging it would tear the pipeline down before the
+    // assertion. Disable it so the test observes backpressure, not recovery.
+    config.deadlock_timeout_secs = 0;
+
+    let owned_header = header.clone();
+    let handle = std::thread::spawn(move || {
+        run_fastq_pipeline(
+            config,
+            &[],
+            Some(readers),
+            &owned_header,
+            Box::new(writer),
+            |template: FastqTemplate| -> io::Result<RecordBuf> {
+                let record = template
+                    .records
+                    .first()
+                    .ok_or_else(|| io::Error::other("template with no records"))?;
+                Ok(RecordBuf::builder()
+                    .set_name(strip_read_suffix(record.name()).to_vec())
+                    .set_sequence(Sequence::from(record.sequence().to_vec()))
+                    .set_quality_scores(QualityScores::from(
+                        record.quality().iter().map(|q| q - 33).collect::<Vec<_>>(),
+                    ))
+                    .build())
+            },
+            |record: RecordBuf, header: &Header, buf: &mut Vec<u8>| -> io::Result<u64> {
+                serialize_bam_record_into(&record, header, buf)
+            },
+        )
+    });
+
+    StalledRun { consumed, released, sink, handle }
+}
+
+/// Outcome of waiting for the reader to stop pulling input.
+struct Consumption {
+    /// Input bytes consumed when the wait ended.
+    bytes: u64,
+    /// Whether consumption actually settled (or reached EOF), as opposed to the
+    /// wait timing out with the counter still moving. A timeout means the
+    /// caller's premise — that the reader had stopped — never held, so tests
+    /// assert on this to fail loudly rather than silently comparing a
+    /// still-moving figure.
+    settled: bool,
+}
+
+/// Wait until input consumption stops growing, or `timeout` elapses.
+///
+/// Reports the number of input bytes consumed once the counter has held still
+/// across `STABLE_SAMPLES` consecutive samples, or as soon as the whole input
+/// has been read, with `settled: true`. Several samples rather than one guards
+/// against a loaded CI machine descheduling the reader briefly and looking like
+/// backpressure. If the deadline is reached with the counter still moving, it
+/// reports the last figure with `settled: false`.
+fn wait_for_consumption_to_settle(
+    consumed: &AtomicU64,
+    input_len: u64,
+    timeout: Duration,
+) -> Consumption {
+    /// Consecutive unchanged samples required before calling it settled.
+    const STABLE_SAMPLES: u32 = 4;
+
+    let deadline = Instant::now() + timeout;
+    let mut previous = u64::MAX;
+    let mut stable = 0u32;
+    while Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(250));
+        let current = consumed.load(Ordering::Relaxed);
+        if current >= input_len {
+            return Consumption { bytes: current, settled: true };
+        }
+        if current == previous {
+            stable += 1;
+            if stable >= STABLE_SAMPLES {
+                return Consumption { bytes: current, settled: true };
+            }
+        } else {
+            stable = 0;
+        }
+        previous = current;
+    }
+    Consumption { bytes: consumed.load(Ordering::Relaxed), settled: false }
+}
+
+/// Build the paired-end test input: the two stream buffers, the expected
+/// template names, and the total input size in bytes.
+fn build_paired_input() -> (Vec<Vec<u8>>, Vec<String>, u64) {
+    let (r1, names) = build_fastq_stream(TEMPLATES, 1);
+    let (r2, _) = build_fastq_stream(TEMPLATES, 2);
+    let input_len = (r1.len() + r2.len()) as u64;
+    (vec![r1, r2], names, input_len)
+}
+
+/// A stalled writer must stop the Read step, not let it drain both FASTQ files
+/// into the pipeline's queues.
+///
+/// Without a byte-aware admission gate on Read, every downstream queue
+/// saturates at its slot count and the reader runs to EOF regardless of
+/// `--max-memory` — which is how a slow output device turns into an OOM kill on
+/// an input far larger than the host's memory (issue #766).
+#[test]
+fn stalled_writer_stops_the_fastq_reader_within_the_queue_memory_budget() {
+    let header = Header::default();
+    let (streams, expected_names, input_len) = build_paired_input();
+    assert!(
+        input_len > TEST_BUDGET_BYTES,
+        "test input ({input_len} bytes) must exceed the budget ({TEST_BUDGET_BYTES} bytes) \
+         for the assertion to mean anything"
+    );
+
+    let StalledRun { consumed, released, sink, handle } =
+        spawn_stalled_pipeline(&header, streams, TEST_BUDGET_BYTES);
+
+    let settled = wait_for_consumption_to_settle(&consumed, input_len, Duration::from_secs(30));
+    assert!(settled.settled, "reader never stopped under a stalled writer within the timeout");
+    assert!(
+        settled.bytes < input_len / 2,
+        "reader consumed {} of {input_len} input bytes while the writer was stalled; \
+         the queue memory budget bounded nothing",
+        settled.bytes
+    );
+
+    // Throttling the reader is only worth anything if the run still emits every
+    // record afterwards, so release and check identity rather than exit status.
+    released.store(true, Ordering::Release);
+    let written =
+        handle.join().expect("pipeline thread should not panic").expect("pipeline should succeed");
+    assert_eq!(written, expected_names.len() as u64);
+    let output = sink.lock().expect("sink mutex should not be poisoned").clone();
+    assert_eq!(record_names(&output), expected_names, "throttling must not change the output");
+}
+
+/// How far the reader runs ahead of a stalled writer must depend on the queue
+/// memory budget.
+///
+/// This is the discriminating check. The previous test could in principle be
+/// satisfied by the queues simply running out of *slots*; this one holds the
+/// input and the slot counts fixed and varies only `--max-memory`, so a budget
+/// that bounds nothing shows up as two identical read-ahead figures.
+#[test]
+fn fastq_read_ahead_under_a_stalled_writer_shrinks_with_the_queue_memory_budget() {
+    let header = Header::default();
+    let (streams, expected_names, input_len) = build_paired_input();
+
+    let mut consumption = Vec::new();
+    for budget in [TEST_BUDGET_BYTES, GENEROUS_BUDGET_BYTES] {
+        let StalledRun { consumed, released, sink, handle } =
+            spawn_stalled_pipeline(&header, streams.clone(), budget);
+        let settled = wait_for_consumption_to_settle(&consumed, input_len, Duration::from_secs(30));
+        assert!(
+            settled.settled,
+            "reader never stopped under a {budget}-byte budget within the timeout"
+        );
+        released.store(true, Ordering::Release);
+        handle.join().expect("pipeline thread should not panic").expect("pipeline should succeed");
+        let output = sink.lock().expect("sink mutex should not be poisoned").clone();
+        assert_eq!(
+            record_names(&output),
+            expected_names,
+            "budget {budget} changed the output, not just the read-ahead"
+        );
+        consumption.push(settled.bytes);
+    }
+
+    // A margin tied to the budget difference, not bare ordering: a scheduler
+    // hiccup that made the tight run read one extra block would still pass
+    // `tight < generous`, and the generous budget exceeds the whole input, so
+    // that run reads to EOF and a bounded gate would be indistinguishable from
+    // none. Requiring the gap to span at least one tight budget pins that the
+    // budget — not slot counts or timing — is the bound.
+    let (tight, generous) = (consumption[0], consumption[1]);
+    assert!(
+        generous.saturating_sub(tight) >= TEST_BUDGET_BYTES,
+        "read-ahead was {tight} bytes under a {TEST_BUDGET_BYTES}-byte budget and {generous} \
+         bytes under a {GENEROUS_BUDGET_BYTES}-byte one; the gap is smaller than one tight \
+         budget, so the budget is not bounding the queues"
+    );
+}
+
+/// The pipeline must still emit every template, in order, once the writer
+/// recovers.
+///
+/// Backpressure that stalls the reader is only safe if releasing the writer
+/// lets every record through. The oracle is the input's own read names read
+/// back off the output, not a record count: a gate that dropped, duplicated or
+/// reordered records while the pipeline was throttled would keep the count
+/// intact and change the sequence.
+#[test]
+fn fastq_reader_resumes_and_completes_after_the_writer_recovers() {
+    let header = Header::default();
+    let (streams, expected_names, input_len) = build_paired_input();
+
+    let StalledRun { consumed, released, sink, handle } =
+        spawn_stalled_pipeline(&header, streams, TEST_BUDGET_BYTES);
+
+    let settled = wait_for_consumption_to_settle(&consumed, input_len, Duration::from_secs(30));
+    assert!(settled.settled, "reader never stopped under a stalled writer within the timeout");
+    released.store(true, Ordering::Release);
+
+    let written = handle.join().expect("pipeline thread should not panic").expect("pipeline");
+    assert_eq!(written, expected_names.len() as u64, "every input template must reach the writer");
+    assert_eq!(
+        consumed.load(Ordering::Relaxed),
+        input_len,
+        "the whole input must be consumed once the writer recovers"
+    );
+
+    let output = sink.lock().expect("sink mutex should not be poisoned").clone();
+    assert_eq!(
+        record_names(&output),
+        expected_names,
+        "output records must match the input exactly, in order"
+    );
+}
+
+/// A record-count-mismatched FASTQ pair must be rejected under a tight budget
+/// too, and rejected the same way it is with no budget at all.
+///
+/// This is the liveness hazard the Read gate has to design around. Neither the
+/// Pair step nor `BlockMerge` can release a batch that is missing a stream
+/// until *every* stream has reached EOF, so once the shorter file is exhausted
+/// the longer file's surplus piles up unreleasable — and it counts against the
+/// budget. A gate that simply stopped reading at the budget would wedge there,
+/// because only Read can bring the surviving stream to the EOF that reveals the
+/// mismatch. `read_is_required_for_liveness` is what keeps that from happening:
+/// Read stays admitted so the pipeline reaches EOF, detects the unequal record
+/// counts, and fails with the out-of-sync error (issue `#773`) rather than
+/// hanging on the surplus tail.
+///
+/// What this test pins is that the budget changes neither the outcome (the
+/// out-of-sync rejection) nor the ability to reach it within the timeout.
+///
+/// The writer is deliberately fast here: the stall is not what closes the gate,
+/// the unreleasable surplus is.
+#[test]
+fn mismatched_stream_lengths_are_rejected_under_a_tight_budget() {
+    let header = Header::default();
+    let short = TEMPLATES / 10;
+    let (r1, _) = build_fastq_stream(short, 1);
+    let (r2, _) = build_fastq_stream(TEMPLATES, 2);
+    let streams = vec![r1, r2];
+
+    let ungated = run_expecting_out_of_sync(&header, streams.clone(), 0);
+    let gated = run_expecting_out_of_sync(&header, streams, TEST_BUDGET_BYTES);
+    // R1 is the shorter stream, so it must be named as the one that ended first
+    // regardless of the budget — the surplus count itself can legitimately vary
+    // with which stage detects the mismatch, so it is not part of the oracle.
+    for (label, message) in [("ungated", &ungated), ("gated", &gated)] {
+        assert!(
+            message.contains("R1 ended before R2"),
+            "the {label} run must identify R1 as the short stream; got: {message}"
+        );
+    }
+}
+
+/// Run a pipeline with an immediately-released writer and return the terminal
+/// error message it produced, failing the test rather than hanging if the Read
+/// gate wedges on the surplus tail.
+///
+/// The message rather than a bare `is_err`: what this pins is that the pipeline
+/// reached EOF on the surviving stream and rejected the *mismatch*, not that it
+/// stopped for some unrelated reason.
+fn run_expecting_out_of_sync(
+    header: &Header,
+    streams: Vec<Vec<u8>>,
+    queue_memory_limit: u64,
+) -> String {
+    let StalledRun { released, handle, .. } =
+        spawn_stalled_pipeline(header, streams, queue_memory_limit);
+    // Never stall: this test is about the gate, not about writer backpressure.
+    released.store(true, Ordering::Release);
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(handle.join());
+    });
+    let joined = rx.recv_timeout(Duration::from_secs(45)).unwrap_or_else(|_| {
+        panic!(
+            "pipeline did not finish within 45s under a {queue_memory_limit}-byte budget; \
+             the Read gate wedged on the surplus tail of the longer stream"
+        )
+    });
+    let error = joined
+        .expect("pipeline thread should not panic")
+        .expect_err("a record-count-mismatched pair must be rejected");
+    assert_eq!(
+        error.kind(),
+        io::ErrorKind::InvalidData,
+        "a mismatched pair must fail with InvalidData, got {error:?}"
+    );
+    let message = error.to_string();
+    assert!(
+        message.contains("FASTQ sources out of sync"),
+        "expected the out-of-sync rejection under a {queue_memory_limit}-byte budget, got: {message}"
+    );
+    message
+}
+
+// ============================================================================
+// BGZF input path
+// ============================================================================
+//
+// The tests above hand the pipeline already-decompressed readers, which is the
+// gzip/plain path: Read -> Decompress -> Pair -> Parse. BGZF inputs take a
+// different route -- Read -> Decompress -> BlockParseFast -> BlockMerge -- with
+// its own byte accounting that nothing above exercises:
+// `block_merge_pending_heap_bytes` (the lock-free mirror of
+// `BlockMergeState::pending_heap_bytes`), the `q2_block_parsed` charge taken at
+// creation rather than at push, and `drain_exhausted_stream`'s refund.
+//
+// A leak on any of those inflates a counter the Read gate sums, so under a
+// tight budget the gate closes on phantom bytes and never reopens -- the run
+// wedges instead of finishing. That is what these tests detect, which is why
+// they assert completion and record identity rather than a read-ahead figure:
+// `run_fastq_pipeline` opens BGZF inputs from paths itself, so there is no
+// `CountingReader` to interpose on this path.
+
+/// Write one stream's bytes to a BGZF-compressed FASTQ file.
+///
+/// Flushes every `RECORDS_PER_BLOCK` records so the input spans many BGZF
+/// blocks: `BlockMerge` pairs blocks by index across the two streams, so a
+/// single-block input would never exercise its pending maps at all.
+fn write_bgzf_fastq(dir: &TempDir, name: &str, num_records: usize, read_number: u8) -> PathBuf {
+    /// Records per BGZF block, chosen so the fixture spans hundreds of blocks.
+    const RECORDS_PER_BLOCK: usize = 64;
+
+    let path = dir.path().join(name);
+    let mut writer = BgzfWriter::new(File::create(&path).expect("create BGZF FASTQ"));
+    let (data, _) = build_fastq_stream(num_records, read_number);
+    // Read names vary in width, so this is the mean record size rather than an
+    // exact one — which is if anything better here, since the resulting block
+    // boundaries fall mid-record and exercise the cross-block stitching too.
+    let bytes_per_block = (data.len() / num_records).max(1) * RECORDS_PER_BLOCK;
+    for chunk in data.chunks(bytes_per_block) {
+        writer.write_all(chunk).expect("write BGZF FASTQ");
+        writer.flush().expect("flush BGZF block");
+    }
+    writer.finish().expect("finish BGZF FASTQ");
+    path
+}
+
+/// Run the BGZF input path to completion under `queue_memory_limit` and return
+/// the read names emitted, failing rather than hanging if the Read gate wedges.
+fn run_bgzf_to_completion(
+    header: &Header,
+    paths: &[PathBuf],
+    queue_memory_limit: u64,
+) -> Vec<String> {
+    let sink = Arc::new(Mutex::new(Vec::new()));
+    let writer =
+        StalledWriter { released: Arc::new(AtomicBool::new(true)), sink: Arc::clone(&sink) };
+
+    let mut config = FastqPipelineConfig::new(NUM_THREADS, true, 1);
+    config.queue_memory_limit = queue_memory_limit;
+    config.deadlock_timeout_secs = 0;
+
+    let owned_header = header.clone();
+    let owned_paths = paths.to_vec();
+    let handle = std::thread::spawn(move || {
+        run_fastq_pipeline(
+            config,
+            &owned_paths,
+            None,
+            &owned_header,
+            Box::new(writer),
+            |template: FastqTemplate| -> io::Result<RecordBuf> {
+                let record = template
+                    .records
+                    .first()
+                    .ok_or_else(|| io::Error::other("template with no records"))?;
+                Ok(RecordBuf::builder()
+                    .set_name(strip_read_suffix(record.name()).to_vec())
+                    .set_sequence(Sequence::from(record.sequence().to_vec()))
+                    .set_quality_scores(QualityScores::from(
+                        record.quality().iter().map(|q| q - 33).collect::<Vec<_>>(),
+                    ))
+                    .build())
+            },
+            |record: RecordBuf, header: &Header, buf: &mut Vec<u8>| -> io::Result<u64> {
+                serialize_bam_record_into(&record, header, buf)
+            },
+        )
+    });
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(handle.join());
+    });
+    let joined = rx.recv_timeout(Duration::from_secs(60)).unwrap_or_else(|_| {
+        panic!(
+            "BGZF pipeline did not finish within 60s under a {queue_memory_limit}-byte budget; \
+             the Read gate is holding on bytes the BGZF accounting never refunded"
+        )
+    });
+    let written =
+        joined.expect("pipeline thread should not panic").expect("pipeline should succeed");
+    let output = sink.lock().expect("sink mutex should not be poisoned").clone();
+    let names = record_names(&output);
+    assert_eq!(names.len() as u64, written, "every reported write must be in the output");
+    names
+}
+
+/// The BGZF input path must finish under a budget far smaller than its input,
+/// and emit exactly what an unbudgeted run of the same input emits.
+///
+/// This is the BGZF half of the accounting the Read gate depends on. Its
+/// charges and refunds are paired across three sites the gzip path never
+/// touches — the `q2_block_parsed` charge taken at creation, the
+/// `block_merge_pending_heap_bytes` mirror, and `drain_exhausted_stream`'s
+/// refund — and an unpaired one there does not merely skew a statistic: the
+/// phantom bytes accumulate in a counter `queue_bytes_in_flight` sums, so the
+/// gate eventually closes for good and the run never terminates. A tight budget
+/// is what makes that reachable inside a test's lifetime; the timeout in
+/// `run_bgzf_to_completion` is what reports it.
+#[test]
+fn bgzf_inputs_complete_under_a_tight_budget_and_match_an_unbudgeted_run() {
+    let header = Header::default();
+    let dir = TempDir::new().expect("create tempdir");
+    let r1 = write_bgzf_fastq(&dir, "r1.fastq.gz", TEMPLATES, 1);
+    let r2 = write_bgzf_fastq(&dir, "r2.fastq.gz", TEMPLATES, 2);
+    let paths = vec![r1, r2];
+
+    let input_len: u64 =
+        paths.iter().map(|p| std::fs::metadata(p).expect("stat BGZF input").len()).sum();
+    assert!(
+        input_len > TEST_BUDGET_BYTES,
+        "compressed input ({input_len} bytes) must exceed the budget ({TEST_BUDGET_BYTES} bytes) \
+         for the gate to engage at all"
+    );
+
+    let (_, expected_names) = build_fastq_stream(TEMPLATES, 1);
+    let ungated = run_bgzf_to_completion(&header, &paths, 0);
+    assert_eq!(
+        ungated, expected_names,
+        "the unbudgeted BGZF run must emit every template in order"
+    );
+
+    let gated = run_bgzf_to_completion(&header, &paths, TEST_BUDGET_BYTES);
+    assert_eq!(
+        gated, ungated,
+        "the queue memory budget must throttle the BGZF path without changing its output"
+    );
+}


### PR DESCRIPTION
Closes #766. **Based on #764** — that PR does the same job for the BAM pipeline and lays the `refund_queue_bytes` groundwork this one reuses, so this branch targets it rather than `main`. Retarget to `main` once #764 lands.

## The defect holds, and it is wider than the BAM one

`fgumi extract --threads 8` logs `Queue memory budget: 6.0 GiB total (768.0 MiB/thread × 8 threads)` and then bounds almost none of it. `--max-memory` reaches exactly two places in the FASTQ pipeline: `ReorderBufferState::new` for the write reorder buffer (itself clamped to `BACKPRESSURE_THRESHOLD_BYTES`, 512 MiB) and `DeadlockState::new`. Everything between Read and Write is bounded by a *slot count* — `queue_capacity = (threads * 128).min(1024)`, four times larger than BAM's `clamp(threads * 16, 64, 256)` — with no bound on the bytes those slots hold.

Where FASTQ differs from `bam.rs`, it differs for the worse:

- **Q0 (raw chunks), Q1 (decompressed chunks) and the Pair buffer had no byte accounting at all.** Q1 in particular holds whole decompressed payloads.
- **Q3 (templates) had a counter that was pure fiction.** `groups_heap_bytes` was mutated only under `memory-debug`, and even then the push side added a hardcoded `0` (`let q4_heap: u64 = 0;`) while the pop side subtracted a real figure. With the feature off both were no-ops, so the counter read zero however much the queue held — and Q3 holds fully parsed `FastqTemplate`s, the single largest consumer when the writer stalls.
- **The accounting that did exist was not derived from the budget.** `Q2_BLOCK_PARSED_BACKPRESSURE_BYTES` (128 MiB), `PENDING_BACKPRESSURE_BYTES` (256 MiB) and `Q5_BACKPRESSURE_THRESHOLD_BYTES` (256 MiB) are hardcoded per-stage thresholds; none scales with `--max-memory`, and together they bound only three of ten stages.
- **Two stages park data that has already left a queue.** `BlockMergeState`'s pending maps (BGZF path) and `PairState`'s pending map (gzip path) hold chunks that Q1/Q2 have already refunded, so a naive port would lose sight of them entirely.

## Reproduction

3,000,000 synthetic 150 bp read pairs (8 bp UMI in R1), gzip, through `fgumi extract --threads 8 --output -` into a 2 MB/s sink, varying only the declared budget. The deadlock detector is disabled on both arms so both complete and the peaks are comparable — see the next section for what happens with it left on.

| declared budget | logged as | before | after |
| --- | --- | --- | --- |
| `--max-memory 256M --memory-per-thread false` | `244.1 MiB total` | 2,031 MB | **273 MB** |
| default (`768` per thread) | `6.0 GiB total` | 2,038 MB | 2,045 MB |
| `--max-memory 32G --memory-per-thread false` | `29.8 GiB total` | 2,039 MB | 2,059 MB |

Before, peak RSS is flat within 0.4% across a 128× range of declared budgets: it is a function of the data and the slot counts, not of the configuration. After, the tight budget is honored and the generous ones are untouched, because the gate never fires when the budget is far above what the queues hold.

Every run above exited 0 and wrote all 6,000,000 records (`samtools view -c`), and the three `after` runs produced byte-identical output sizes to each other.

**A side effect worth knowing:** with the deadlock detector at its default 10 s, the pre-fix binary does not merely use too much memory on this workload — it **aborts**. It swallows the entire input in ~12 s, then makes no queue progress at 2 MB/s, and the detector fires: `DEADLOCK DETECTED: No progress for 10s`, exit 1, 1,208,000 of 6,000,000 records written. The post-fix binary completes the same cell cleanly with the detector at its default, because reading and draining stay interleaved.

| `--max-memory 256M --memory-per-thread false`, detector at default | exit | records | peak RSS |
| --- | --- | --- | --- |
| before | **1** (deadlock abort) | 1,208,000 / 6,000,000 | 1,680 MB |
| after | 0 | 6,000,000 / 6,000,000 | 293 MB |

## The default path is unchanged

Same input, fast sink, default budget, three reps each:

| | before | after |
| --- | --- | --- |
| wall | 1.34 / 1.29 / 1.31 s | 1.29 / 1.28 / 1.28 s |
| peak RSS | 364 / 232 / 198 MB | 165 / 164 / 186 MB |

Wall time is unchanged. Peak RSS is noisy on an unbounded pipeline (198–364 MB across three identical runs) and settles tighter afterwards; there is no regression in either.

## The fix

Read is the pipeline's only source of new bytes and nothing downstream waits on it, so gating Read is both the one place a total can be enforced and a place where enforcing it cannot deadlock.

- Charge the unaccounted queues — Q0, Q1, Q3, the Pair buffer, and the merge step's pending maps. The merge maps get a lock-free mirror of `BlockMergeState::pending_heap_bytes` so the gate can read them without taking the merge lock; every mutation goes through one `charge_block_merge_pending` / `refund_block_merge_pending` pair, so the two cannot drift.
- Sum all eleven counters in `FastqPipelineState::queue_bytes_in_flight` and gate `fastq_try_step_read` on it, after the held-item advance so a held chunk can always still be placed.
- Refunds go through `refund_queue_bytes`, promoted from `bam.rs` to `base.rs` now that both pipelines use it.
- The deadlock snapshot now reports `queue_in_flight=NNNMB`. A run the gate has stopped looks idle in the queue lengths alone, which is exactly the wrong impression to give whoever reads that dump.

### Liveness: two exemptions, one of which is load-bearing

The Pair and `BlockMerge` steps release a batch only once every stream has delivered the matching index, or once every stream has reached EOF. Only Read can satisfy either condition, so `read_is_required_for_liveness` exempts two cases from the gate:

- **A stream that has fallen behind another.** What the assembly step is holding is waiting on exactly this stream's next batch. Exempting only the laggard bounds the extra read-ahead at the skew that already existed.
- **A stream whose sibling has already reached EOF.** Everything past the shorter stream's end is unreleasable until `read_done`, which needs *this* stream at EOF too. For equal-length inputs that covers the last batch or two.

The second is not defensive decoration. A mismatched-length FASTQ pair accumulates unreleasable surplus in the Pair buffer, that surplus counts against the budget, and the budget is then what prevents it ever being drained. `mismatched_stream_lengths_still_complete_under_a_tight_budget` hangs for the full 120 s timeout with that exemption removed, and passes with it. For malformed input this deliberately trades the bound for liveness — a run that cannot finish is worse than one that exceeds its budget.

### Charge before push, not after

Every charge now lands before its item becomes visible to a consumer (`push_charged`). The previous idiom throughout this file was

```rust
let result = queue.push(item);
if result.is_ok() { counter.fetch_add(heap_size, ...); }
```

which leaves a window in which a consumer pops the item and refunds bytes that were never charged. `refund_queue_bytes` saturates at zero — which is what keeps an unpaired refund from wrapping to `u64::MAX` — so when the counter is near zero, the normal state of a queue draining as fast as it fills, that refund is simply lost and the charge landing afterwards is never released. Each occurrence permanently inflates a counter that gates Read; enough of them and the pipeline stops reading with its queues empty, which cannot resolve. Charging first inverts the failure into a brief over-count during a rejected push.

This was latent before #746/#766 made these counters load-bearing, which is why it has never been observed. `a_failed_push_leaves_no_charge_behind` pins the contract.

## Tests

`tests/integration/test_fastq_pipeline_memory_backpressure.rs`, the sibling of #764's file, drives `run_fastq_pipeline` over a paired-end input with a `CountingReader` per stream and a writer that blocks until released:

- `stalled_writer_stops_the_fastq_reader_within_the_queue_memory_budget` — read-ahead must stay under half the input. Before: the reader consumed all 18,997,780 bytes.
- `fastq_read_ahead_under_a_stalled_writer_shrinks_with_the_queue_memory_budget` — the discriminating one. Input and slot counts fixed, only `--max-memory` varies; before, both budgets produced the identical 18,997,780 bytes.
- `fastq_reader_resumes_and_completes_after_the_writer_recovers` — every record reaches the output, in order, once the writer recovers.
- `mismatched_stream_lengths_still_complete_under_a_tight_budget` — liveness, with the same input run at `queue_memory_limit = 0` as the oracle so the budget is shown to change neither the outcome nor the ability to reach it.

Every one of the four checks the emitted read names against the input's, in order, rather than an exit status or a record count: throttling that dropped, duplicated or reordered records would leave both of those intact and change the sequence.

Unit tests in `fastq.rs` pin the gate's algebra (no-limit, at-budget, drained-below-budget, first-batch-always-admitted, both liveness exemptions), that every counter reaches the sum, and that each charge is refunded exactly on pop.

The integration tests exercise the gzip/plain path, which is where injectable readers are possible and which is what `.fastq.gz` inputs actually take. The BGZF-specific counters (Q2, merge pending) are covered by unit tests.

## Three findings on #764, two of them fixed here

Both of #764's failing CI jobs are caused by its own diff, and this branch inherits them, so both are fixed here. They should be fixed there too so that PR can go green on its own.

- **`docs` fails.** `q2b_boundaries`' new doc links `BamPipelineState::q2b_push` / `::q2b_pop` as intra-doc links; both are private, and `cargo ci-doc` runs under `RUSTDOCFLAGS=-D warnings`. Fixed by demoting the two to plain backticks.
- **`test` fails on a timeout, not an assertion.** Its three backpressure tests build a 600,000-record BAM in a debug build and run 29-42 s on an M-series laptop; on a GitHub runner they exceed the repo's standing `slow-timeout = 60s, terminate-after = 2` and are killed at 120 s, taking 3,652 unrun tests down with them. Scaled the fixture to 60,000 families against a 512 KiB budget — 15-21 s locally, and still a 7.6x input-to-budget ratio. Verified the retuned tests still discriminate: with `read_admission_allowed` removed from `try_step_read`, the reader again consumes all 3,996,131 input bytes and both budgets produce identical read-ahead.
- **`q2b_push` has the charge-after-push shape described above**, as do the two `q1_heap_bytes.fetch_add` sites in `try_step_read`. Left alone here — that is BAM's behavior and that PR's code — but it is the same latent permanent-over-count and deserves the same reorder.

## Known, out of scope, worth their own issues

- **`OutputPipelineQueues::process_output_push` / `serialize_output_push` in `base.rs` still charge after push**, and their pops use plain `fetch_sub`. They are unreachable from the FASTQ pipeline (it pushes those queues directly, and those two helpers are only called from `shared_try_step_process` / `shared_try_step_serialize`, which nothing calls), so they do not affect this gate — but they are the same shape and should be fixed or deleted.
- **`fgumi extract` drops templates from the surplus tail of a mismatched-length FASTQ pair** — 29,800 of 30,000 in the new test's fixture. Confirmed pre-existing: identical loss with the gate disabled entirely. The new test uses the ungated run as its oracle precisely so it pins the budget's neutrality without baking that defect in.
- **`ReorderBufferState::effective_limit`'s 512 MiB clamp is untouched**, as in #764.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: output change none; `unsafe` change none and CLAUDE.md allowlist update none; memory bounds and read-stage backpressure change yes.

FASTQ extraction now enforces `--max-memory` across all in-flight queues and pending buffers. Charges occur before enqueue, and failed pushes or pops use saturating refunds.

The change adds Q2b accounting, aggregate memory diagnostics, liveness exemptions, and deadlock snapshot reporting. BAM queue sites now use the shared accounting helper.

FASTQ pairing and BGZF merge now reject mismatched input lengths and flush EOF residuals. Integration tests cover stalled writers, memory budgets, recovery, plain/gzip/BGZF input, accounting, and output ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->