### PR TITLE
fix(pipeline): separate the per-stage high-water mark from --max-memory

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -187,9 +187,12 @@ reviews:
         producer gating as liveness- and memory-critical. Require that no path
         lets a queue or reorder buffer grow without a byte bound, so steady-state
         memory stays a function of config rather than input size: the per-queue
-        bound is `OrderedQueue::limit_bytes` (`queue.rs`), and the shared
-        pipeline budget is consulted through `MemoryTracker::is_at_limit` /
-        `MemoryTracker::is_below_drain_threshold` (`base.rs`). Flag a cap
+        bound is `OrderedQueue::limit_bytes` (`queue.rs`); the pipeline total is
+        gated at Read by `BamPipelineState::read_admission_allowed` (`bam.rs`);
+        and each stage's own high-water mark comes from `stage_high_water_mark`
+        (`base.rs`), which caps the mark rather than scaling it with the budget.
+        `MemoryTracker` (`base.rs`) is NOT on that path — nothing in this crate
+        constructs one, so do not cite it as the live budget check. Flag a cap
         checked on only one sub-condition so another code path bypasses it; flag
         capping a consumer drain loop (consumers must stay unbounded — bound the
         producers instead); and flag byte accounting that measures logical length

--- a/docs/src/guide/performance-tuning.md
+++ b/docs/src/guide/performance-tuning.md
@@ -78,6 +78,28 @@ total budget to avoid OOM.
 With `--max-memory auto`, the total budget is instead `host RAM − reserve`
 (divided across threads when per-thread), so it never scales past the host.
 
+### What the Budget Bounds
+
+`--max-memory` is a **total**: the BAM pipeline stops admitting input once the
+bytes queued between its stages reach it, so a slow or contended output device
+backs pressure up to the reader instead of filling every queue.
+
+It is not a per-stage allowance. The reorder-buffered stages back off at
+512 MiB and the processed queue at 256 MiB, and those marks do not rise with
+the budget. A budget below one of them pulls it down; a budget above it leaves
+it where it is. Raising `--max-memory` therefore raises how much the pipeline
+may hold in total, not how much any one stage may hold, and the startup line
+reports both numbers:
+
+```
+Queue memory budget: 6.0 GiB total (768.0 MiB/thread × 8 threads); per-stage high-water marks 512.0 MiB (reorder-buffered stages), 256.0 MiB (processed queue)
+```
+
+Note also that `fgumi extract`'s FASTQ pipeline shares this option and logs the
+same line, but does not yet enforce the total — there only the per-stage marks
+bind. That gap is tracked in
+[fgumi#766](https://github.com/fulcrumgenomics/fgumi/issues/766).
+
 ## Compression Options
 
 ### Compression Level

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -10,7 +10,10 @@ use std::sync::Arc;
 use crate::assigner::Strategy;
 #[cfg(feature = "simplex")]
 use crate::logging::OperationTimer;
-use crate::unified_pipeline::{BamPipelineConfig, SchedulerStrategy};
+use crate::unified_pipeline::{
+    BACKPRESSURE_THRESHOLD_BYTES, BamPipelineConfig, Q5_BACKPRESSURE_THRESHOLD_BYTES,
+    SchedulerStrategy, stage_high_water_mark,
+};
 use crate::validation::validate_input_exists;
 use bytesize::ByteSize;
 use clap::Args;
@@ -1241,9 +1244,20 @@ fn resolve_memory_budget_with_total(
 /// input and write reorder states), so this budget bounds them through the Read
 /// gate; they additionally apply their own threshold, capped at
 /// [`BACKPRESSURE_THRESHOLD_BYTES`](crate::unified_pipeline::BACKPRESSURE_THRESHOLD_BYTES).
+///
+/// The budget is a **total**, and it is not the same thing as what any one stage
+/// may hold. Stages back off at their own high-water marks —
+/// [`BACKPRESSURE_THRESHOLD_BYTES`](crate::unified_pipeline::BACKPRESSURE_THRESHOLD_BYTES)
+/// (512 MiB) for the queues and reorder buffers,
+/// [`Q5_BACKPRESSURE_THRESHOLD_BYTES`](crate::unified_pipeline::Q5_BACKPRESSURE_THRESHOLD_BYTES)
+/// (256 MiB) for the processed queue. A budget below one of those marks tightens
+/// it; a budget above it leaves it alone. So raising `--max-memory` raises how
+/// much the pipeline may hold in total, not how much any one stage may hold —
+/// see [`stage_high_water_mark`](crate::unified_pipeline::stage_high_water_mark)
+/// for why a per-stage trigger should not scale with the total (issue #765).
 #[derive(Debug, Clone, Args)]
 pub struct QueueMemoryOptions {
-    /// Maximum memory for the pipeline queues.
+    /// Maximum total memory for the pipeline queues.
     ///
     /// Default is "768" (768 MiB) per thread. Pass "auto" to detect host memory
     /// (cgroup-aware) and subtract --memory-reserve, so the budget shrinks to
@@ -1251,6 +1265,13 @@ pub struct QueueMemoryOptions {
     /// values like "512M", "1G", "4GiB" are per-thread when --memory-per-thread
     /// is enabled (default); plain numbers are MiB. Mirrors `fgumi sort`'s
     /// --max-memory.
+    ///
+    /// This bounds the bytes held in the queues *between* pipeline stages, in
+    /// total. It is not a hard RSS cap: per-thread working memory and a single
+    /// oversized group sit outside it. Individual stages also back off at their
+    /// own lower high-water marks (512 MiB, and 256 MiB for the processed
+    /// queue); a smaller budget tightens those marks, a larger one raises the
+    /// total but leaves them where they are.
     #[arg(long = "max-memory", default_value = "768", value_parser = parse_memory)]
     pub max_memory: MemoryLimit,
 
@@ -1301,23 +1322,43 @@ impl QueueMemoryOptions {
         Ok(bytes as u64)
     }
 
+    /// Renders the resolved memory configuration as a single log line.
+    ///
+    /// The budget is reported as what it is — a **total** — alongside the
+    /// per-stage high-water marks actually in force, so the line cannot be read
+    /// as a promise that raising `--max-memory` raises what any one stage holds.
+    /// It does not: a budget above a stage's default mark leaves that mark
+    /// alone, and only a budget below it pulls it down (issue #765).
+    ///
+    /// # Arguments
+    /// * `num_threads` - Number of threads used for the calculation.
+    /// * `total_memory` - The resolved total budget from `calculate_memory_limit`.
+    #[must_use]
+    pub fn memory_config_summary(&self, num_threads: usize, total_memory: u64) -> String {
+        let budget = if self.memory_per_thread && num_threads > 1 {
+            format!(
+                "{} total ({}/thread × {} threads)",
+                ByteSize(total_memory),
+                ByteSize(total_memory / num_threads as u64),
+                num_threads,
+            )
+        } else {
+            format!("{} total", ByteSize(total_memory))
+        };
+        format!(
+            "Queue memory budget: {budget}; per-stage high-water marks {} (reorder-buffered stages), {} (processed queue)",
+            ByteSize(stage_high_water_mark(total_memory, BACKPRESSURE_THRESHOLD_BYTES)),
+            ByteSize(stage_high_water_mark(total_memory, Q5_BACKPRESSURE_THRESHOLD_BYTES)),
+        )
+    }
+
     /// Logs the resolved memory configuration.
     ///
     /// # Arguments
     /// * `num_threads` - Number of threads used for the calculation.
     /// * `total_memory` - The resolved total budget from `calculate_memory_limit`.
     pub fn log_memory_config(&self, num_threads: usize, total_memory: u64) {
-        let per_thread = self.memory_per_thread;
-        if per_thread && num_threads > 1 {
-            log::info!(
-                "Queue memory budget: {} total ({}/thread × {} threads)",
-                ByteSize(total_memory),
-                ByteSize(total_memory / num_threads as u64),
-                num_threads
-            );
-        } else {
-            log::info!("Queue memory budget: {} total", ByteSize(total_memory));
-        }
+        log::info!("{}", self.memory_config_summary(num_threads, total_memory));
     }
 }
 
@@ -2191,6 +2232,42 @@ mod tests {
         let fixed_total =
             QueueMemoryOptions { memory_per_thread: false, ..QueueMemoryOptions::default() };
         fixed_total.log_memory_config(8, 1024 * 1024 * 1024); // fixed total branch
+    }
+
+    /// The startup line must name the budget as a total *and* report the
+    /// per-stage marks in force, so it cannot be read as promising that a
+    /// larger `--max-memory` gives any one stage more room (issue #765).
+    #[test]
+    fn test_memory_config_summary_reports_the_per_stage_marks() {
+        let per_thread = QueueMemoryOptions::default();
+        let line = per_thread.memory_config_summary(8, 8 * 768 * 1024 * 1024);
+        assert!(line.contains("6.0 GiB total"), "{line}");
+        assert!(line.contains("768.0 MiB/thread × 8 threads"), "{line}");
+        assert!(line.contains("512.0 MiB (reorder-buffered stages)"), "{line}");
+        assert!(line.contains("256.0 MiB (processed queue)"), "{line}");
+    }
+
+    /// A budget larger than every per-stage mark must still report the marks at
+    /// their defaults — that is precisely the fact the old line hid.
+    #[test]
+    fn test_memory_config_summary_does_not_inflate_the_marks_for_a_huge_budget() {
+        let fixed_total =
+            QueueMemoryOptions { memory_per_thread: false, ..QueueMemoryOptions::default() };
+        let line = fixed_total.memory_config_summary(8, 32 * 1024 * 1024 * 1024);
+        assert!(line.contains("32.0 GiB total"), "{line}");
+        assert!(line.contains("512.0 MiB (reorder-buffered stages)"), "{line}");
+        assert!(line.contains("256.0 MiB (processed queue)"), "{line}");
+    }
+
+    /// A budget below the marks pulls them down, and the line says so.
+    #[test]
+    fn test_memory_config_summary_reports_tightened_marks_for_a_small_budget() {
+        let fixed_total =
+            QueueMemoryOptions { memory_per_thread: false, ..QueueMemoryOptions::default() };
+        let line = fixed_total.memory_config_summary(8, 64 * 1024 * 1024);
+        assert!(line.contains("64.0 MiB total"), "{line}");
+        assert!(line.contains("64.0 MiB (reorder-buffered stages)"), "{line}");
+        assert!(line.contains("64.0 MiB (processed queue)"), "{line}");
     }
 
     #[test]

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -4715,6 +4715,32 @@ mod tests {
         assert!(state.read_admission_allowed(), "drained below budget: reading resumes");
     }
 
+    /// The budget keeps discriminating above 512 MiB (issue #765).
+    ///
+    /// The per-stage high-water marks are capped at
+    /// [`BACKPRESSURE_THRESHOLD_BYTES`](crate::unified_pipeline::BACKPRESSURE_THRESHOLD_BYTES),
+    /// and for a long time those marks were the only thing `--max-memory`
+    /// reached — which made every budget above 512 MiB behave identically. The
+    /// budget's capacity role lives here instead, where nothing caps it: at
+    /// 4 GiB in flight a 512 MiB budget must refuse and a 32 GiB budget must
+    /// admit. If both answers ever agree again, the knob has gone inert.
+    #[test]
+    fn read_admission_still_discriminates_above_the_per_stage_marks() {
+        let in_flight = 4 * 1024 * 1024 * 1024;
+
+        let at_the_mark =
+            create_test_state(crate::unified_pipeline::base::BACKPRESSURE_THRESHOLD_BYTES);
+        at_the_mark.q2b_heap_bytes.store(in_flight, Ordering::Release);
+        assert!(!at_the_mark.read_admission_allowed(), "512 MiB budget must gate 4 GiB in flight");
+
+        let above_the_mark = create_test_state(32 * 1024 * 1024 * 1024);
+        above_the_mark.q2b_heap_bytes.store(in_flight, Ordering::Release);
+        assert!(
+            above_the_mark.read_admission_allowed(),
+            "32 GiB budget must admit 4 GiB in flight; a budget above 512 MiB is not inert"
+        );
+    }
+
     /// With nothing accounted for in flight, Read is always admitted — so an
     /// input whose first batch alone exceeds the whole budget still makes
     /// progress instead of wedging the pipeline.

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -459,6 +459,15 @@ pub use fgumi_bam_io::MemoryEstimate;
 /// It's designed to provide backpressure when queue memory exceeds a limit,
 /// preventing unbounded memory growth in threaded pipelines.
 ///
+/// # Not on the `--max-memory` path
+///
+/// No code path in this crate constructs a `MemoryTracker`; it is exercised
+/// only by this module's tests. The budget reaches the BAM and FASTQ pipelines
+/// through [`ReorderBufferState`] and [`OutputPipelineQueues`], and is enforced
+/// as a total by `BamPipelineState::read_admission_allowed`. Reading this
+/// struct as the live budget mechanism is a mistake that has been made before
+/// (issue #765), hence this note.
+///
 /// # Usage
 ///
 /// ```ignore
@@ -608,44 +617,23 @@ impl MemoryTracker {
         self.peak_bytes.load(Ordering::Relaxed)
     }
 
-    /// Check if we're at or above the backpressure threshold.
+    /// Check if we're at or above this tracker's high-water mark.
     ///
-    /// For optimal performance, we apply backpressure at a capped threshold
-    /// (512MB) regardless of the configured limit. This keeps the pipeline
-    /// lean with good cache behavior. The configured limit acts as a safety
-    /// cap but doesn't delay backpressure.
-    ///
-    /// Even with no limit (`limit_bytes` == 0), we still apply backpressure
-    /// at 512MB to maintain optimal throughput.
+    /// The mark is [`stage_high_water_mark`] of the configured limit: a limit
+    /// below [`BACKPRESSURE_THRESHOLD_BYTES`] tightens it, one above leaves it
+    /// alone, and no limit at all (`limit_bytes` == 0) still marks at 512 MiB.
     #[must_use]
     pub fn is_at_limit(&self) -> bool {
-        // Always apply backpressure at 512MB for optimal cache behavior.
-        // If a lower limit is configured, use that instead.
-        let backpressure_threshold = if self.limit_bytes == 0 {
-            BACKPRESSURE_THRESHOLD_BYTES
-        } else {
-            self.limit_bytes.min(BACKPRESSURE_THRESHOLD_BYTES)
-        };
-        self.current() >= backpressure_threshold
+        self.current() >= stage_high_water_mark(self.limit_bytes, BACKPRESSURE_THRESHOLD_BYTES)
     }
 
     /// Check if we've drained below the low-water mark.
     ///
     /// This is used for hysteresis to prevent thrashing: we enter drain mode
-    /// when at the backpressure threshold, but only exit when we've drained
-    /// to half that threshold.
-    ///
-    /// The threshold is 256MB (half of the 512MB backpressure cap), or half
-    /// of a lower configured limit if one is set.
+    /// at the high-water mark, but only exit when we've drained to half of it.
     #[must_use]
     pub fn is_below_drain_threshold(&self) -> bool {
-        // Drain threshold is half of the backpressure threshold
-        let backpressure_threshold = if self.limit_bytes == 0 {
-            BACKPRESSURE_THRESHOLD_BYTES
-        } else {
-            self.limit_bytes.min(BACKPRESSURE_THRESHOLD_BYTES)
-        };
-        self.current() < backpressure_threshold / 2
+        self.current() < stage_high_water_mark(self.limit_bytes, BACKPRESSURE_THRESHOLD_BYTES) / 2
     }
 }
 
@@ -692,39 +680,48 @@ impl StepResult {
 /// Progress logging interval for the 7-step pipeline.
 pub const PROGRESS_LOG_INTERVAL: u64 = 1_000_000;
 
-/// Memory threshold for scheduler backpressure signaling (512 MB).
+/// Default high-water mark for a reorder-buffered stage (512 MiB).
 ///
-/// This constant controls when the pipeline signals memory pressure to the scheduler,
-/// which responds by prioritizing downstream steps (Process, Serialize, Compress, Write)
-/// to drain buffered data before allowing more input.
+/// This is the point at which one stage stops taking on new work and the
+/// scheduler starts prioritizing downstream steps (Process, Serialize,
+/// Compress, Write) so the stage can drain.
 ///
-/// # Architecture
+/// It is reached only through `ReorderBufferState::effective_limit`, so it
+/// applies to exactly three stages: Q2 and Q3 (whose counters span the queue
+/// and its reorder buffer both) and the post-Group write reorder buffer. The
+/// remaining queues — Q1, Q2b, Q4, Q6, Q7 — carry byte counters but no byte
+/// mark of their own; they are bounded by their slot count and by the
+/// pipeline-wide total gated at the Read step.
 ///
-/// Memory is tracked at the reorder buffer BEFORE the Group step:
-/// - **BAM pipeline**: `q3_reorder_heap_bytes` (after Decode, before Group)
-/// - **FASTQ pipeline**: `q2_reorder_heap_bytes` (after Decompress, before Group)
+/// # Architecture — where the scheduler reads its drain signal
 ///
-/// This placement is critical: we track memory before the exclusive Group step rather
-/// than after it. Tracking after Group creates a coordination problem where memory is
-/// released from the pre-Group buffer before knowing if the post-Group queue can accept
-/// it, potentially leaving data in an untracked intermediate buffer.
+/// Only one of the three feeds the scheduler's `memory_high` / `memory_drained`
+/// pair, and the two pipelines pick different ones:
+/// - **BAM pipeline**: `q3_reorder_state`, the reorder buffer after Decode and
+///   before Group (`BamPipelineState::is_memory_high`)
+/// - **FASTQ pipeline**: `output.write_reorder_state`, the post-Compress write
+///   reorder buffer (`FastqStepContext::get_backpressure`)
 ///
-/// # Threshold Behavior
+/// For the BAM pipeline that placement is deliberate: memory is tracked before
+/// the exclusive Group step rather than after it, because tracking after Group
+/// releases the pre-Group buffer's bytes before knowing whether the post-Group
+/// queue can accept them, leaving data in an untracked intermediate buffer.
 ///
-/// - When tracked memory >= `BACKPRESSURE_THRESHOLD_BYTES`, `is_memory_high()` returns true
-/// - The scheduler enters "drain mode" and prioritizes output steps
-/// - When tracked memory < `BACKPRESSURE_THRESHOLD_BYTES / 2`, `is_memory_drained()` returns true
-/// - The scheduler exits drain mode (hysteresis prevents thrashing)
+/// # Threshold behaviour
 ///
-/// # Relationship to Queue Memory Limit
+/// - When tracked memory >= the mark, `is_memory_high()` returns true: the
+///   producing step declines new work and the scheduler enters "drain mode"
+/// - When tracked memory < half the mark, `is_memory_drained()` returns true
+///   and the scheduler exits drain mode (hysteresis prevents thrashing)
 ///
-/// This threshold is independent of `queue_memory_limit` (default 4GB), which controls
-/// the hard limit for `can_decompress_proceed()` / `can_decode_proceed()`. The backpressure
-/// threshold is deliberately lower to allow gradual slowdown before hitting hard limits.
+/// # Relationship to `--max-memory`
 ///
-/// The effective threshold is `min(queue_memory_limit, BACKPRESSURE_THRESHOLD_BYTES)`,
-/// so if a smaller memory limit is configured, backpressure activates at that limit.
-pub const BACKPRESSURE_THRESHOLD_BYTES: u64 = 512 * 1024 * 1024; // 512 MB
+/// This is a *per-stage trigger*, not the user's capacity budget; see
+/// [`stage_high_water_mark`] for why the two are separate and why a larger
+/// budget does not raise this. The budget's capacity role is enforced on the
+/// pipeline's total in-flight bytes at the Read step
+/// (`BamPipelineState::read_admission_allowed`).
+pub const BACKPRESSURE_THRESHOLD_BYTES: u64 = 512 * 1024 * 1024; // 512 MiB
 
 /// Release `bytes` from a queue byte counter, saturating at zero.
 ///
@@ -792,13 +789,58 @@ const fn saturating_refund(current: u64, bytes: u64) -> u64 {
     current.saturating_sub(bytes)
 }
 
-/// Q5 (processed queue) backpressure threshold.
+/// Default high-water mark for Q5, the processed queue (256 MiB).
 ///
-/// This is set lower than the Q3 threshold (256 MB vs 512 MB) because items in Q5
+/// This is set lower than the Q3 mark (256 MiB vs 512 MiB) because items in Q5
 /// are typically larger (e.g., `SimplexProcessedBatch` with `RecordBuf` vectors).
-/// When Q5 memory exceeds this threshold, the Process step pauses to let
+/// When Q5 memory reaches this mark, the Process step pauses to let
 /// downstream steps (Serialize, Compress, Write) catch up.
-pub const Q5_BACKPRESSURE_THRESHOLD_BYTES: u64 = 256 * 1024 * 1024; // 256 MB
+///
+/// Like [`BACKPRESSURE_THRESHOLD_BYTES`] it is applied through
+/// [`stage_high_water_mark`], so a `--max-memory` below it tightens it and one
+/// above it leaves it alone.
+pub const Q5_BACKPRESSURE_THRESHOLD_BYTES: u64 = 256 * 1024 * 1024; // 256 MiB
+
+/// The high-water mark one pipeline stage backs off at, given the declared
+/// queue memory budget and that stage's default mark.
+///
+/// Returns `default_mark` when `queue_memory_limit` is 0 (meaning "unset"),
+/// and `min(queue_memory_limit, default_mark)` otherwise.
+///
+/// # Why the budget cannot raise the mark (issue #765)
+///
+/// `--max-memory` is a *capacity* budget: how many bytes the pipeline may hold
+/// in total. A stage's high-water mark is a *trigger*: the depth at which that
+/// one stage stops pulling in work so the rest of the pipeline can catch up.
+/// Historically the mark was the only place the budget reached, which fused the
+/// two ideas into one number and made `--max-memory` above 512 MiB inert. The
+/// capacity half now lives where it belongs — on the pipeline's total in-flight
+/// bytes, gated at the Read step — and what is left here is only the trigger.
+///
+/// A trigger should not scale with the total budget, for three reasons:
+///
+/// - **It would buy no throughput.** The scheduler's response to `memory_high`
+///   is a priority reordering, not a stop. Raising the mark only postpones the
+///   moment output steps are favoured, so the stage parks more bytes and the
+///   pipeline runs no faster.
+/// - **Reorder capacity is bounded by serial skew, not by bytes.** The
+///   pre-Group reorder buffers exist to absorb out-of-order completion between
+///   workers. That skew is bounded by the number of batches in flight, which is
+///   bounded by the queue slot count, so bytes past the skew window are dead
+///   weight.
+/// - **It would let one stage monopolize the budget.** These marks are the only
+///   byte bound on Q2, Q3 and Q5 individually. Uncapped, a single stage could
+///   park the entire budget and the total gate would fire before any other
+///   stage buffered anything — converting a pipeline into a queue.
+///
+/// The downward direction is the useful one and is preserved: a budget smaller
+/// than the default mark pulls the mark down with it, so no single stage can
+/// hold more than the whole declared budget.
+#[inline]
+#[must_use]
+pub fn stage_high_water_mark(queue_memory_limit: u64, default_mark: u64) -> u64 {
+    if queue_memory_limit == 0 { default_mark } else { queue_memory_limit.min(default_mark) }
+}
 
 // ============================================================================
 // Input-Half Reorder Buffer State (shared between BAM and FASTQ pipelines)
@@ -889,15 +931,14 @@ impl ReorderBufferState {
         self.heap_bytes.load(Ordering::Acquire) < threshold / 2
     }
 
-    /// Get the effective memory limit (respecting default threshold).
+    /// The high-water mark this buffer backs off at.
+    ///
+    /// A `--max-memory` below [`BACKPRESSURE_THRESHOLD_BYTES`] tightens it; one
+    /// above leaves it alone. See [`stage_high_water_mark`] for why.
     #[inline]
     #[must_use]
     fn effective_limit(&self) -> u64 {
-        if self.memory_limit == 0 {
-            BACKPRESSURE_THRESHOLD_BYTES
-        } else {
-            self.memory_limit.min(BACKPRESSURE_THRESHOLD_BYTES)
-        }
+        stage_high_water_mark(self.memory_limit, BACKPRESSURE_THRESHOLD_BYTES)
     }
 
     /// Add heap bytes to the tracker (after pushing to reorder buffer).
@@ -1807,8 +1848,12 @@ pub struct OutputPipelineQueues<G, P: MemoryEstimate> {
     // ========== Queue: Group → Process ==========
     /// Batches of groups/templates waiting to be processed.
     pub groups: ArrayQueue<(u64, Vec<G>)>,
-    /// Current heap bytes in groups queue (stats/reporting only, not used for backpressure).
-    /// Mutations are gated behind the `memory-debug` feature; reads are zero without the feature.
+    /// Current heap bytes in the groups (Q4) queue.
+    ///
+    /// Charged by the Group step and refunded by the Process step (see
+    /// `bam.rs`'s `push_batch` / `try_step_process`), and summed into
+    /// `BamPipelineState::queue_bytes_in_flight` for Read admission, so it is
+    /// maintained unconditionally rather than only under `memory-debug`.
     pub groups_heap_bytes: AtomicU64,
 
     // ========== Queue: Process → Serialize ==========
@@ -1816,6 +1861,12 @@ pub struct OutputPipelineQueues<G, P: MemoryEstimate> {
     pub processed: ArrayQueue<(u64, Vec<P>)>,
     /// Current heap bytes in processed queue.
     pub processed_heap_bytes: AtomicU64,
+    /// High-water mark at which the Process step stops taking on new work.
+    ///
+    /// [`stage_high_water_mark`] of the configured queue memory budget and
+    /// [`Q5_BACKPRESSURE_THRESHOLD_BYTES`]. Resolved once at construction so
+    /// the hot `is_processed_memory_high` check stays a single load and compare.
+    processed_high_water_mark: u64,
 
     /// Serial-keyed reorder buffer used by the optional MI Assign hook
     /// (see [`crate::unified_pipeline::PipelineFunctions::mi_assign_fn`]).
@@ -1882,7 +1933,10 @@ impl<G: Send, P: Send + MemoryEstimate> OutputPipelineQueues<G, P> {
     /// - `output`: Output writer (will be wrapped in Mutex)
     /// - `stats`: Optional performance statistics collector
     /// - `progress_name`: Name for the progress tracker (e.g., "Processed records")
-    /// - `queue_memory_limit`: Memory limit for the write reorder buffer in bytes (0 = 512 MiB default)
+    /// - `queue_memory_limit`: The declared queue memory budget in bytes (0 =
+    ///   unset). It tightens the write reorder buffer's and the processed
+    ///   queue's high-water marks when it is below their defaults; see
+    ///   [`stage_high_water_mark`].
     #[must_use]
     pub fn new(
         queue_capacity: usize,
@@ -1896,6 +1950,10 @@ impl<G: Send, P: Send + MemoryEstimate> OutputPipelineQueues<G, P> {
             groups_heap_bytes: AtomicU64::new(0),
             processed: ArrayQueue::new(queue_capacity),
             processed_heap_bytes: AtomicU64::new(0),
+            processed_high_water_mark: stage_high_water_mark(
+                queue_memory_limit,
+                Q5_BACKPRESSURE_THRESHOLD_BYTES,
+            ),
             mi_assign_reorder: Mutex::new(ReorderBuffer::new()),
             serialized: ArrayQueue::new(queue_capacity),
             serialized_heap_bytes: AtomicU64::new(0),
@@ -1945,10 +2003,14 @@ impl<G: Send, P: Send + MemoryEstimate> OutputPipelineQueues<G, P> {
 
     // ========== Memory Backpressure ==========
 
-    /// Check if processed queue memory is at the backpressure threshold.
+    /// Check if processed queue memory is at its high-water mark.
+    ///
+    /// The mark is [`Q5_BACKPRESSURE_THRESHOLD_BYTES`], tightened by a smaller
+    /// `--max-memory` — so the processed queue alone can never park more than
+    /// the whole declared budget (issue #765).
     #[must_use]
     pub fn is_processed_memory_high(&self) -> bool {
-        self.processed_heap_bytes.load(Ordering::Acquire) >= Q5_BACKPRESSURE_THRESHOLD_BYTES
+        self.processed_heap_bytes.load(Ordering::Acquire) >= self.processed_high_water_mark
     }
 
     /// Check if pipeline is in drain mode.
@@ -5735,6 +5797,77 @@ mod tests {
         assert!(state_small.is_memory_high()); // 100 >= min(100, 512MB) = 100
     }
 
+    // ========================================================================
+    // Stage high-water mark tests (issue #765)
+    // ========================================================================
+
+    #[test]
+    fn test_stage_high_water_mark_treats_zero_as_unset() {
+        assert_eq!(
+            stage_high_water_mark(0, BACKPRESSURE_THRESHOLD_BYTES),
+            BACKPRESSURE_THRESHOLD_BYTES
+        );
+        assert_eq!(
+            stage_high_water_mark(0, Q5_BACKPRESSURE_THRESHOLD_BYTES),
+            Q5_BACKPRESSURE_THRESHOLD_BYTES
+        );
+    }
+
+    #[test]
+    fn test_stage_high_water_mark_tightens_under_a_small_budget() {
+        // A budget below the default mark pulls the mark down with it, so a
+        // single stage can never park more than the whole declared budget.
+        assert_eq!(
+            stage_high_water_mark(64 * 1024 * 1024, BACKPRESSURE_THRESHOLD_BYTES),
+            64 * 1024 * 1024
+        );
+        assert_eq!(
+            stage_high_water_mark(64 * 1024 * 1024, Q5_BACKPRESSURE_THRESHOLD_BYTES),
+            64 * 1024 * 1024
+        );
+    }
+
+    #[test]
+    fn test_stage_high_water_mark_does_not_scale_above_the_default() {
+        // Deliberate: the mark is a per-stage trigger, not the user's capacity
+        // budget. See the `stage_high_water_mark` docs for why raising it buys
+        // nothing. The budget's capacity role lives at the Read admission gate.
+        let huge = 32 * 1024 * 1024 * 1024;
+        assert_eq!(
+            stage_high_water_mark(huge, BACKPRESSURE_THRESHOLD_BYTES),
+            BACKPRESSURE_THRESHOLD_BYTES
+        );
+        assert_eq!(
+            stage_high_water_mark(huge, Q5_BACKPRESSURE_THRESHOLD_BYTES),
+            Q5_BACKPRESSURE_THRESHOLD_BYTES
+        );
+    }
+
+    #[test]
+    fn test_reorder_buffer_high_water_mark_does_not_scale_with_the_budget() {
+        // `--max-memory 32G` must not let one reorder buffer park 32 GiB before
+        // its producer backs off; it trips at the same 512 MiB a default run does.
+        let state = ReorderBufferState::new(32 * 1024 * 1024 * 1024);
+        state.add_heap_bytes(BACKPRESSURE_THRESHOLD_BYTES - 1);
+        assert!(!state.is_memory_high());
+        state.add_heap_bytes(1);
+        assert!(state.is_memory_high(), "trips at 512 MiB regardless of a larger budget");
+    }
+
+    #[test]
+    fn test_reorder_buffer_high_water_mark_is_identical_at_default_and_huge_budgets() {
+        // Guards the "default path unchanged" claim: the default 768 MiB/thread
+        // budget is already above the mark, so nothing about it is budget-derived.
+        let default_budget = ReorderBufferState::new(8 * 768 * 1024 * 1024);
+        let huge_budget = ReorderBufferState::new(32 * 1024 * 1024 * 1024);
+        for state in [&default_budget, &huge_budget] {
+            state.add_heap_bytes(BACKPRESSURE_THRESHOLD_BYTES);
+            assert!(state.is_memory_high());
+            state.sub_heap_bytes(BACKPRESSURE_THRESHOLD_BYTES / 2 + 1);
+            assert!(state.is_memory_drained());
+        }
+    }
+
     #[test]
     fn test_reorder_buffer_state_add_sub_heap_bytes() {
         let state = ReorderBufferState::new(0);
@@ -6433,6 +6566,72 @@ mod tests {
             "Should include secondary data, got {}",
             batch.estimate_heap_size()
         );
+    }
+
+    /// Q5's high-water mark must be derived from the declared queue memory
+    /// budget, not hardcoded (issue #765). Before this it was a flat 256 MiB,
+    /// so `--max-memory 64M` left the processed queue free to park four times
+    /// the entire declared budget on its own.
+    #[test]
+    fn test_processed_queue_high_water_mark_tightens_under_a_small_budget() {
+        let budget = 64 * 1024 * 1024;
+        let output: Box<dyn std::io::Write + Send> = Box::new(Vec::<u8>::new());
+        let queues: OutputPipelineQueues<(), TestProcessed> =
+            OutputPipelineQueues::new(16, output, None, "test", budget);
+
+        queues.processed_heap_bytes.store(budget - 1, Ordering::SeqCst);
+        assert!(!queues.is_processed_memory_high());
+
+        queues.processed_heap_bytes.store(budget, Ordering::SeqCst);
+        assert!(
+            queues.is_processed_memory_high(),
+            "Q5 must back off at the declared budget, not at the 256 MiB default"
+        );
+    }
+
+    /// The complement of the test above: at any budget at or above the default
+    /// mark the behaviour is byte-identical to before, which is what makes this
+    /// change one-directional (it can only lower memory, never raise it).
+    #[test]
+    fn test_processed_queue_high_water_mark_is_unchanged_at_the_default_budget() {
+        // 768 MiB/thread × 8 threads — the shipped default for an 8-thread run.
+        let budget = 8 * 768 * 1024 * 1024;
+        let output: Box<dyn std::io::Write + Send> = Box::new(Vec::<u8>::new());
+        let queues: OutputPipelineQueues<(), TestProcessed> =
+            OutputPipelineQueues::new(16, output, None, "test", budget);
+
+        queues.processed_heap_bytes.store(Q5_BACKPRESSURE_THRESHOLD_BYTES - 1, Ordering::SeqCst);
+        assert!(!queues.is_processed_memory_high());
+
+        queues.processed_heap_bytes.store(Q5_BACKPRESSURE_THRESHOLD_BYTES, Ordering::SeqCst);
+        assert!(queues.is_processed_memory_high());
+    }
+
+    /// A budget of 0 means "unset" everywhere else in the pipeline, and must
+    /// keep meaning that here rather than pinning the mark to 0 — which would
+    /// make `should_apply_process_backpressure` permanently true and stall the
+    /// Process step for the whole run.
+    #[test]
+    fn test_processed_queue_high_water_mark_treats_a_zero_budget_as_unset() {
+        let output: Box<dyn std::io::Write + Send> = Box::new(Vec::<u8>::new());
+        let queues: OutputPipelineQueues<(), TestProcessed> =
+            OutputPipelineQueues::new(16, output, None, "test", 0);
+        assert!(!queues.is_processed_memory_high());
+        assert!(!queues.should_apply_process_backpressure());
+    }
+
+    /// Forward progress: however small the budget, an empty Q5 must always
+    /// admit the next batch. `is_processed_memory_high` compares with `>=`, so
+    /// a mark of zero would deadlock the Process step; a mark of at least one
+    /// byte cannot.
+    #[test]
+    fn test_processed_queue_admits_work_when_empty_under_a_tiny_budget() {
+        let output: Box<dyn std::io::Write + Send> = Box::new(Vec::<u8>::new());
+        let queues: OutputPipelineQueues<(), TestProcessed> =
+            OutputPipelineQueues::new(16, output, None, "test", 1);
+        assert_eq!(queues.processed_heap_bytes.load(Ordering::SeqCst), 0);
+        assert!(!queues.is_processed_memory_high());
+        assert!(!queues.should_apply_process_backpressure());
     }
 
     // ========================================================================

--- a/tests/integration/test_pipeline_memory_backpressure.rs
+++ b/tests/integration/test_pipeline_memory_backpressure.rs
@@ -30,7 +30,8 @@ use crate::helpers::bam_generator::{create_minimal_header, create_umi_family, to
 use fgumi_lib::grouper::SingleRecordGrouper;
 use fgumi_lib::read_info::LibraryIndex;
 use fgumi_lib::unified_pipeline::{
-    GroupKeyConfig, PipelineConfig, PipelineFunctions, run_bam_pipeline, serialize_bam_record_into,
+    BatchOrdinal, GroupKeyConfig, PipelineConfig, PipelineFunctions, run_bam_pipeline,
+    serialize_bam_record_into,
 };
 
 /// Queue memory budget used by the tests, in bytes.
@@ -158,18 +159,16 @@ fn bam_header_bytes(header: &Header) -> Vec<u8> {
     bgzf.into_inner()
 }
 
-/// Read the record names out of a BAM byte stream, in order.
-fn record_names(bam_bytes: &[u8]) -> Vec<String> {
+/// Decode every record out of a BAM byte stream, in order.
+///
+/// Returns fully decoded [`RecordBuf`]s rather than just names so the identity
+/// assertions can compare flags, coordinates, CIGAR, sequence, qualities, and
+/// tags — not only that the right names arrived in the right order. Name-only
+/// comparison would pass even if the pipeline corrupted any of those fields.
+fn record_bufs(bam_bytes: &[u8]) -> Vec<RecordBuf> {
     let mut reader = bam::io::Reader::new(io::Cursor::new(bam_bytes));
     let header = reader.read_header().expect("read header");
-    reader
-        .record_bufs(&header)
-        .map(|r| {
-            let record = r.expect("read record");
-            String::from_utf8_lossy(record.name().expect("record should have a name").as_ref())
-                .into_owned()
-        })
-        .collect()
+    reader.record_bufs(&header).map(|r| r.expect("read record")).collect()
 }
 
 /// Build a BAM whose compressed size comfortably exceeds the test budget, so a
@@ -504,7 +503,7 @@ fn read_ahead_under_a_stalled_writer_shrinks_with_the_queue_memory_budget() {
 #[test]
 fn a_budget_smaller_than_one_batch_still_completes_with_every_record() {
     let (header, bam_bytes) = shared_bam_bytes();
-    let expected_names = record_names(bam_bytes);
+    let expected_records = record_bufs(bam_bytes);
 
     // Release the writer immediately so it never blocks — a healthy sink — and
     // set a budget far below one decompressed batch.
@@ -513,17 +512,122 @@ fn a_budget_smaller_than_one_batch_still_completes_with_every_record() {
 
     let written =
         join_pipeline_within(run.handle, &run.consumed, bam_bytes.len() as u64, JOIN_DEADLINE);
-    assert_eq!(written, expected_names.len() as u64, "every input record must reach the writer");
+    assert_eq!(written, expected_records.len() as u64, "every input record must reach the writer");
 
     // `run_bam_pipeline` writes record blocks only, so re-attach a header before
     // reading the captured stream back as a BAM.
     let mut output = bam_header_bytes(header);
     output.extend_from_slice(&run.sink.lock().expect("sink mutex should not be poisoned"));
     assert_eq!(
-        record_names(&output),
-        expected_names,
+        record_bufs(&output),
+        expected_records,
         "output records must match the input exactly, in order"
     );
+}
+
+/// A budget small enough to bind the processed queue must not wedge the
+/// MI-assign stage.
+///
+/// The processed queue's high-water mark is `min(budget, 256 MiB)` (issue
+/// #765), so a small `--max-memory` can pull it below the size of a single
+/// processed batch. That matters most with `mi_assign_fn` installed: batches
+/// drained out of Q5 stay charged to `processed_heap_bytes` while they sit in
+/// `mi_assign_reorder`, so a reorder buffer waiting on a missing serial holds
+/// the Process step off at its backpressure check. Forward progress then rests
+/// entirely on the Process step pushing an already-held batch unconditionally,
+/// ahead of that check.
+///
+/// Two budgets, because they bind differently. At 4 KiB the Read gate admits
+/// one batch at a time, so the mark fires constantly but skew is minimal; at
+/// 8 MiB several batches are in flight at once, which is what actually gives
+/// the reorder buffer out-of-order serials to park. Both must complete.
+///
+/// The writer is not stalled here: the hazard is internal to the pipeline, and
+/// a stalled writer would mask it behind the Read gate.
+#[test]
+fn mi_assign_makes_progress_under_a_budget_that_binds_the_processed_queue() {
+    let header = create_minimal_header("chr1", 100_000);
+    // Enough families to span many batches, few enough to stay quick.
+    let bam_bytes = build_bam_bytes(&header, 20_000, DEPTH);
+    let expected_records = record_bufs(&bam_bytes);
+
+    for budget in [4096u64, 8 * 1024 * 1024] {
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let writer =
+            StalledWriter { released: Arc::new(AtomicBool::new(true)), sink: Arc::clone(&sink) };
+
+        let mut config = PipelineConfig::auto_tuned(4, 1);
+        config.queue_memory_limit = budget;
+        // Unlike the stalled-writer tests above, the deadlock detector stays
+        // ON here (default: 10s, detection only). This test asserts liveness,
+        // so a wedge should surface as a failed run rather than as a hang that
+        // only the harness timeout catches.
+        assert!(!config.deadlock_recover_enabled, "detection only, so a wedge is not papered over");
+
+        let grouper = Box::new(SingleRecordGrouper::with_header(header.clone()));
+        let output_header = header.clone();
+        // Record each hook invocation's ordinal in call order. The contract is
+        // that `mi_assign_fn` runs in strict `(batch_serial, idx_in_batch)`
+        // order (see `BatchOrdinal`); the write reorder buffer can restore
+        // output order even if the hook fired out of order, so a name-order
+        // check on the output alone cannot see a violation of that contract.
+        let hook_ordinals = Arc::new(Mutex::new(Vec::<(u64, usize)>::new()));
+        let hook_ordinals_inner = Arc::clone(&hook_ordinals);
+        let fns = PipelineFunctions::new(
+            |record: RecordBuf| Ok(record),
+            move |record: RecordBuf, buf: &mut Vec<u8>| {
+                serialize_bam_record_into(&record, &output_header, buf)
+            },
+        )
+        .with_mi_assign(move |ordinal: BatchOrdinal, _item: &mut RecordBuf| {
+            hook_ordinals_inner
+                .lock()
+                .expect("hook ordinals mutex should not be poisoned")
+                .push((ordinal.batch_serial, ordinal.idx_in_batch));
+            Ok(())
+        });
+        let group_key_config = GroupKeyConfig::new_raw_no_cell(LibraryIndex::from_header(&header));
+
+        let written = run_bam_pipeline(
+            config,
+            Box::new(io::Cursor::new(bam_bytes.clone())),
+            Box::new(writer),
+            grouper,
+            fns,
+            group_key_config,
+            None,
+        )
+        .unwrap_or_else(|e| panic!("budget {budget}: pipeline must complete, got {e}"));
+
+        assert_eq!(
+            written,
+            expected_records.len() as u64,
+            "budget {budget}: every input record must reach the writer"
+        );
+
+        let ordinals = hook_ordinals.lock().expect("hook ordinals mutex should not be poisoned");
+        assert_eq!(
+            ordinals.len(),
+            expected_records.len(),
+            "budget {budget}: the MI-assign hook must run once per item"
+        );
+        // The hook must be invoked in strictly increasing `(batch_serial,
+        // idx_in_batch)` order — the serial-order contract it exists to
+        // provide. `Vec::is_sorted` alone would accept duplicates, so pair it
+        // with a strict-monotonicity check via `windows`.
+        assert!(
+            ordinals.windows(2).all(|w| w[0] < w[1]),
+            "budget {budget}: MI-assign hook fired out of serial order: {ordinals:?}"
+        );
+
+        let mut output = bam_header_bytes(&header);
+        output.extend_from_slice(&sink.lock().expect("sink mutex should not be poisoned"));
+        assert_eq!(
+            record_bufs(&output),
+            expected_records,
+            "budget {budget}: output must match the input exactly, in order"
+        );
+    }
 }
 
 /// The pipeline must still emit every record, in order, once the writer
@@ -537,8 +641,8 @@ fn a_budget_smaller_than_one_batch_still_completes_with_every_record() {
 #[test]
 fn reader_resumes_and_completes_after_the_writer_recovers() {
     let (header, bam_bytes) = shared_bam_bytes();
-    let expected_names = record_names(bam_bytes);
-    assert_eq!(expected_names.len(), FAMILIES * DEPTH, "input should hold every generated read");
+    let expected_records = record_bufs(bam_bytes);
+    assert_eq!(expected_records.len(), FAMILIES * DEPTH, "input should hold every generated read");
 
     let StalledRun { consumed, released, sink, handle } =
         spawn_stalled_pipeline(header, bam_bytes.clone(), 4, TEST_BUDGET_BYTES, None);
@@ -549,7 +653,7 @@ fn reader_resumes_and_completes_after_the_writer_recovers() {
     released.store(true, Ordering::Release);
 
     let written = join_pipeline_within(handle, &consumed, bam_bytes.len() as u64, JOIN_DEADLINE);
-    assert_eq!(written, expected_names.len() as u64, "every input record must reach the writer");
+    assert_eq!(written, expected_records.len() as u64, "every input record must reach the writer");
     assert_eq!(
         consumed.load(Ordering::Relaxed),
         bam_bytes.len() as u64,
@@ -561,8 +665,8 @@ fn reader_resumes_and_completes_after_the_writer_recovers() {
     let mut output = bam_header_bytes(header);
     output.extend_from_slice(&sink.lock().expect("sink mutex should not be poisoned"));
     assert_eq!(
-        record_names(&output),
-        expected_names,
+        record_bufs(&output),
+        expected_records,
         "output records must match the input exactly, in order"
     );
 }


### PR DESCRIPTION
Closes #765. Stacked on #764 — this branch is based on `746/nhomer/bound-consensus-memory-under-writer-stall`, so only the last commit is new.

## What the clamp turned out to be

`ReorderBufferState::effective_limit` returns `min(budget, BACKPRESSURE_THRESHOLD_BYTES)`, and that constant is 512 MiB. The issue reads that as a plain bug. It is not — it is two ideas sharing one number.

A stage's **high-water mark** is a *trigger*: the depth at which one stage stops pulling in work so the rest of the pipeline can catch up. A **budget** is a *capacity*: how many bytes the pipeline may hold in total. Before #764 the mark was the only place `--max-memory` reached, so the two fused, and the capacity half did not exist at all. That is why `--max-memory 32G` looked inert: the only number it set was a trigger — and a trigger that is capped for good reasons.

#764 moved the capacity half to where it belongs, onto total in-flight bytes gated at Read. What is left in `effective_limit` is only the trigger.

## Recommendation: honour the budget as a total, keep the per-stage cap

The reasons, then the numbers that back them:

- **Raising a trigger buys no throughput.** The scheduler's response to `memory_high` is a priority reordering, not a stop. A higher mark only postpones the moment output steps are favoured, so the stage parks more bytes and the pipeline runs no faster.
- **Reorder capacity is bounded by serial skew, not by bytes.** The pre-Group reorder buffers absorb out-of-order completion between workers; that skew is bounded by the queue slot count. Bytes past the skew window are dead weight.
- **These marks are the only byte bound on Q2, Q3 and Q5 individually.** Uncapped, one stage parks the entire budget and the total gate fires before any other stage buffers anything.

So `--max-memory 32G` is honoured in the sense a user means it — the pipeline may hold 32 GiB in total — without becoming a 32 GiB allowance for each reorder buffer.

## Measurements

`group --strategy adjacency --threads 8 --compression-level 1` over a 24,033,782-record synthetic BAM (`fgumi simulate mapped-reads -n 4000000 --seed 42`), `--memory-per-thread false` so each budget is a total, peak RSS from `/usr/bin/time -l`. Two sinks: `fast` writes straight to disk; `slow` writes through a 60 MB/s rate limiter, roughly 4.5x slower than the pipeline produces.

Three builds: **base** = #764 as it stands; **uncapped** = an experimental build with the clamp lifted (`effective_limit` returns the budget); **this PR**.

| declared budget | base fast | uncapped fast | PR fast | base slow | uncapped slow | PR slow |
| --- | --- | --- | --- | --- | --- | --- |
| 64 MiB | 616 | 584 | 560 | 573 | 507 | 493 |
| 256 MiB | 1264 | 1264 | 1231 | 1227 | 1173 | 1088 |
| 512 MiB | 1673 | 1650 | 1606 | 1422 | 1543 | 1454 |
| 4 GiB | 2360 | **5433** | 2413 | 4453 | **7984** | 4377 |
| 32 GiB | 2602 | **7190** | 2480 | 4422 | **17117** | 4357 |
| default (6 GiB) | 2443 | **7565** | 2580 | 4359 | **10541** | 4398 |

Peak RSS in MB. Every run exited 0 and emitted all 24,033,782 records.

Two things fall out of that table.

**The knob is not inert.** Peak RSS rises monotonically with the declared budget from 64 MiB to 4 GiB on both sinks — that is #764's Read gate doing the work the budget was always supposed to do. Above 4 GiB the input itself becomes the ceiling, which is why 32 GiB does not exceed 4 GiB here.

**Lifting the clamp is not free, and the price lands on the default path.** At the shipped default the uncapped build peaks at 7,565 / 10,541 MB against the base's 2,443 / 4,359 — 3.1x and 2.4x. At 32 GiB with a slow sink it reaches 17,117 MB against 4,422. It is not buying anything for that: wall time is unchanged, and the output is byte-identical. This is the one-stage-monopolises-the-budget failure mode, measured.

**The default path does not move.** Three replicates each, same session, interleaved:

| cell | base | this PR |
| --- | --- | --- |
| default, fast | 2427, 2399, 2438 | 2449, 2575, 2662 |
| default, slow | 4391, 4405, 4424 | 4386, 4392, 4384 |
| 64 MiB, fast | 626, 615, 627 | 589, 591, 579 |
| 64 MiB, slow | 573, 568, 599 | 505, 480, 524 |

Default is unchanged (fast-sink spread overlaps; slow-sink figures agree to within 0.5%). The 64 MiB rows are the Q5 fix showing up: 6% lower on a fast sink and 15% lower on a slow one, with no overlap between the two sets. Wall time is unchanged everywhere; the slow-sink cells are all 42.0s because the sink, not the pipeline, sets the pace.

**Output identity.** Eight independent runs — all three builds at 64 MiB and 32 GiB, base and this PR at 256 MiB — produce the same record stream, digest `a5829f1a…` on `samtools view` output. The whole-file digests differ between builds because BGZF block framing follows batch boundaries; the records do not.

Caveat: a shared laptop, so wall times are noisy and cross-cell RSS carries roughly ±100 MB of session noise. That is why the decisive cells were replicated and interleaved rather than read off a single pass.

## What changed

- **`stage_high_water_mark(budget, default_mark)`** is the single home for the rule, and carries the argument above in its docs. `ReorderBufferState::effective_limit` and `MemoryTracker`'s two threshold checks route through it. No behaviour change.
- **Q5 is the one behavioural fix.** Its 256 MiB mark was not derived from the budget at all, so `--max-memory 64M` left the processed queue free to park four times the whole declared budget on its own. It is now `min(budget, 256 MiB)`, resolved once at construction. This can only lower memory: at any budget at or above 256 MiB the mark is byte-identical, which covers every default configuration.
- **A liveness test covers the regime that widens as a result.** With `mi_assign_fn` installed, batches drained out of Q5 stay charged to `processed_heap_bytes` while they sit in `mi_assign_reorder`, so a mark below one batch holds the Process step off at its backpressure check. Forward progress then rests entirely on the unconditional held-batch push ahead of that check, and nothing pinned it. The new test drives the pipeline at 4 KiB and at 8 MiB — the first binds Read to one batch at a time, the second leaves several in flight so the reorder buffer actually has out-of-order serials to park — and asserts every record comes out, in order, with the hook run once per item.
- **The startup line and `--max-memory`'s help stop overclaiming.** The line now reports the marks actually in force beside the total:

  ```
  Queue memory budget: 6.0 GiB total (768.0 MiB/thread × 8 threads); per-stage high-water marks 512.0 MiB (reorder-buffered stages), 256.0 MiB (processed queue)
  ```

  A smaller budget shows tightened marks, which is the case where they move.
- **Two stale doc claims corrected.** `BACKPRESSURE_THRESHOLD_BYTES` said the FASTQ pipeline reads its drain signal from a pre-Group `q2_reorder_heap_bytes`; there is no such counter — `FastqStepContext::get_backpressure` reads `output.write_reorder_state`, the post-Compress write reorder buffer. And `MemoryTracker` now says outright that nothing in this crate constructs one.
- **The review config** claimed the budget is consulted through `MemoryTracker`. It points at the real gates now.

Also clears three `RUSTDOCFLAGS="-D warnings"` failures: two private-item links on `q2b_boundaries` carried in from the parent branch, and the redundant explicit link targets this change introduced.

## Two things the issue got wrong

Neither changes the conclusion, but both are worth recording.

**The cited lines point at dead code.** The issue attributes the clamp to `ReorderBufferState::effective_limit` "at `base.rs:609-611`, and again at `:628-630`". On `main` at `3d83a55d` those lines are `MemoryTracker::is_at_limit` and `MemoryTracker::is_below_drain_threshold`, which contain the identical `.min()` expression — hence the mix-up. `MemoryTracker` has no constructor anywhere outside this module's own tests, so `--max-memory` never reaches it. The live site is `effective_limit` at `:813-819`. The substance of the report is right; only the citation is off.

**"Raising `--max-memory` above 512M does not change peak RSS" is no longer true on top of #764**, as the table shows. It was true on `main`, which is where the issue was filed. What survives on this base is narrower: the *per-stage* marks do not scale, which is deliberate, plus Q5's mark not deriving from the budget at all, which was not.

## Scope

The FASTQ pipeline's missing total gate is #766 and is untouched here. This PR does change the shared `OutputPipelineQueues::is_processed_memory_high`, so `fgumi extract` picks up the Q5 derivation too — the only overlap, and it is additive.

## Verification

`cargo ci-fmt`, `cargo ci-lint`, `cargo ci-test` (7,516 passed), `cargo ci-doctest`, and `RUSTDOCFLAGS="-D warnings" cargo ci-doc` all green. The Q5 test was confirmed to fail against the pre-change implementation before the fix was applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: output changes none, pinned by full `RecordBuf` identity, ordering, and liveness tests; `unsafe` changes none, so CLAUDE.md allowlist changes none; memory bounds and backpressure policy change.

Fix: Separate the total `--max-memory` budget from capped per-stage high-water marks through `stage_high_water_mark`.

- Enforce total in-flight memory at Read admission.
- Derive Q5’s mark from the configured budget, capped at 256 MiB.
- Add liveness coverage for small-budget backpressure.
- Report total and per-stage limits at startup and in help text.
- Update documentation and review guidance.
- Fix documentation warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->