### PR TITLE
fix(extract)!: reject FASTQ inputs with different record counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,18 @@ All notable changes to this project will be documented in this file.
   `simplex` went from 6 of 6 raw reads rejected and no consensus emitted, to 6 of 6 used and
   both strands emitted.
 
+- **Breaking:** `extract --threads N` now fails when the input FASTQs hold different numbers of
+  records, matching the no-`--threads` path, which has always failed with "FASTQ sources out of
+  sync". The threaded pipeline instead exited 0 on such a pair. On gzip and plain inputs the
+  surplus records that shared a batch index with the shorter stream were silently discarded, and
+  the rest were written as single-end fragments; measured on a synthetic pair of 100,150 and
+  100,050 records, 100 records vanished with no warning and no non-zero exit. On BGZF inputs the
+  surplus records were parked in the block merger and never released, so the run spun forever
+  without producing output. A mismatched pair is what a truncated download or an interrupted
+  upstream tool produces, so it is now rejected with a message naming which input ended first
+  and how many records were left unmated. Matched inputs are unaffected and byte-identical
+  ([#773](https://github.com/fulcrumgenomics/fgumi/issues/773)).
+
 - `dedup --metrics` now reports the templates dropped by its template filter, broken out by
   reason. `dedup` is a read filter as well as a duplicate marker, but the drop counts were
   collected, merged across workers, and then discarded at the serialization boundary: a run

--- a/src/lib/commands/extract.rs
+++ b/src/lib/commands/extract.rs
@@ -28,7 +28,9 @@ use crate::fastq_parse::strip_read_suffix;
 use crate::grouper::FastqTemplate;
 use crate::logging::OperationTimer;
 use crate::sam::SamTag;
-use crate::unified_pipeline::{FastqPipelineConfig, MemoryEstimate, run_fastq_pipeline};
+use crate::unified_pipeline::{
+    FastqPipelineConfig, MemoryEstimate, fastq_out_of_sync_error, run_fastq_pipeline,
+};
 use crate::validation::validate_input_exists;
 use anyhow::{Context, Result, bail, ensure};
 use bstr::{BString, ByteSlice};
@@ -456,6 +458,13 @@ skipped over.
 
 Only template bases will be retained as read bases (stored in the `SEQ` field) as specified by
 the read structure.
+
+## Input Requirements
+
+All input FASTQs must contain the same number of records, in the same order. A pair whose
+streams disagree on record count is rejected with a non-zero exit status naming which input
+ended first — surplus records are neither discarded nor emitted as unpaired reads, since a
+short input almost always means a truncated transfer or an interrupted upstream tool.
 
 ## Read Structures
 
@@ -1189,24 +1198,33 @@ impl Extract {
         let mut read_pair_count: u64 = 0;
         let mut builder = UnmappedSamBuilder::new();
 
+        // One record per stream at this position; `1` = a record was read, `0` =
+        // the stream ended. Naming the streams (rather than a vague "some ended
+        // before others") matches the threaded pipeline and the help text's
+        // promise to name which input ended first. Hoisted out of the loop and
+        // reset each iteration to avoid a per-template allocation on this fast path.
+        let mut counts = vec![0usize; fq_iterators.len()];
         loop {
+            counts.fill(0);
             let mut next_read_sets = Vec::with_capacity(fq_iterators.len());
-            let mut saw_eof = false;
-            for iter in fq_iterators.iter_mut() {
+            for (idx, iter) in fq_iterators.iter_mut().enumerate() {
                 match iter.next() {
-                    Some(Ok(rec)) if !saw_eof => next_read_sets.push(rec),
-                    Some(Ok(_)) => bail!("FASTQ sources out of sync: some ended before others"),
+                    Some(Ok(rec)) => {
+                        counts[idx] = 1;
+                        next_read_sets.push(rec);
+                    }
                     Some(Err(e)) => return Err(e),
-                    None => saw_eof = true,
+                    None => {} // stream ended; leave its count at 0
                 }
             }
 
-            if saw_eof {
-                ensure!(
-                    next_read_sets.is_empty(),
-                    "FASTQ sources out of sync: some ended before others"
-                );
+            // Every stream ended together: clean EOF.
+            if counts.iter().all(|count| *count == 0) {
                 break;
+            }
+            // Some streams still had a record while others ended: out of sync.
+            if counts.iter().any(|count| *count != counts[0]) {
+                return Err(fastq_out_of_sync_error(&counts).into());
             }
 
             //  Validate read names match across all FASTQs
@@ -1288,14 +1306,10 @@ impl Extract {
             output,
             // process_fn: FastqTemplate → ExtractedBatch
             move |template: FastqTemplate| -> std::io::Result<ExtractedBatch> {
-                // Debug: Log template record count
-                if template.records.len() != read_structures.len() {
-                    log::warn!(
-                        "Template has {} records but expected {} (read_structures.len())",
-                        template.records.len(),
-                        read_structures.len()
-                    );
-                }
+                // A template must carry one record per read structure; a short
+                // template would silently drop that read's segments below (see
+                // `validate_template_record_count`, issue #773).
+                validate_template_record_count(&template, read_structures.len())?;
 
                 // Validate read names match (synchronized mode defers this from Group step)
                 if template.records.len() >= 2 {
@@ -1700,6 +1714,33 @@ impl Command for Extract {
 /// upper-case `N`); the read-name extraction path uses fgbio's strict alphabet.
 fn is_valid_umi_char(b: u8) -> bool {
     matches!(b, b'A' | b'C' | b'G' | b'T' | b'N' | b'-')
+}
+
+/// Reject an assembled template that does not carry exactly one record per read
+/// structure.
+///
+/// `--inputs` and `--read-structures` are validated to be the same length, and
+/// the pipeline now rejects inputs of unequal record count, so a short template
+/// cannot normally be assembled. This enforces the invariant rather than logging
+/// it: the segment `zip` downstream stops at the shorter side, so a short
+/// template would silently drop that read's segments (issue #773).
+fn validate_template_record_count(
+    template: &FastqTemplate,
+    read_structure_count: usize,
+) -> std::io::Result<()> {
+    if template.records.len() != read_structure_count {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "FASTQ sources out of sync: template '{}' has {} record(s) but {} \
+                 read structure(s) were given",
+                String::from_utf8_lossy(&template.name),
+                template.records.len(),
+                read_structure_count,
+            ),
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -4558,5 +4599,56 @@ mod tests {
         assert_eq!(rg.as_deref(), Some("RG1"), "RG tag should match read_group_id");
 
         Ok(())
+    }
+
+    /// Build a `FastqTemplate` carrying `record_count` records under a shared name.
+    fn template_with_record_count(name: &str, record_count: usize) -> FastqTemplate {
+        let records = (0..record_count)
+            .map(|_| {
+                crate::fastq_parse::FastqRecord::from_slice(
+                    format!("@{name}\nACGT\n+\nIIII\n").as_bytes(),
+                )
+                .expect("failed to parse synthetic FASTQ record")
+            })
+            .collect();
+        FastqTemplate { records, name: name.as_bytes().to_vec() }
+    }
+
+    /// A template with one record per read structure passes validation.
+    #[rstest]
+    #[case::single_end(1)]
+    #[case::paired_end(2)]
+    #[case::triple(3)]
+    fn test_validate_template_record_count_matched_is_accepted(#[case] count: usize) {
+        let template = template_with_record_count("read0", count);
+        validate_template_record_count(&template, count)
+            .expect("a template matching the read-structure count must be accepted");
+    }
+
+    /// A template whose record count differs from the read-structure count is
+    /// rejected, naming the template and both counts (issue #773).
+    #[rstest]
+    #[case::short(1, 2)]
+    #[case::surplus(3, 2)]
+    #[case::empty(0, 2)]
+    fn test_validate_template_record_count_mismatch_is_rejected(
+        #[case] record_count: usize,
+        #[case] read_structure_count: usize,
+    ) {
+        let template = template_with_record_count("read0", record_count);
+        let error = validate_template_record_count(&template, read_structure_count)
+            .expect_err("a template that disagrees with the read-structure count must be rejected");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        let message = error.to_string();
+        assert!(message.contains("out of sync"), "unexpected message: {message}");
+        assert!(message.contains("read0"), "message must name the template: {message}");
+        assert!(
+            message.contains(&format!("{record_count} record(s)")),
+            "message must report the record count: {message}"
+        );
+        assert!(
+            message.contains(&format!("{read_structure_count} read structure(s)")),
+            "message must report the read-structure count: {message}"
+        );
     }
 }

--- a/src/lib/unified_pipeline/fastq.rs
+++ b/src/lib/unified_pipeline/fastq.rs
@@ -1134,27 +1134,61 @@ fn decompress_bgzf_chunk(raw_data: &[u8], decompressor: &mut Decompressor) -> io
 // Phase 6 & 7: FASTQ Pipeline State and Entry Point
 // ============================================================================
 
-/// Align record counts across multiple streams, truncating excess to the minimum.
+/// The error reported when the input FASTQ streams do not hold the same number
+/// of records.
 ///
-/// When streams have different record counts (e.g., at EOF), excess records
-/// are discarded since they have no mate and cannot form valid templates.
-fn align_stream_records(
-    mut streams: Vec<FastqStreamBoundaries>,
+/// `counts` is indexed by stream (`0` = R1, `1` = R2, ...) and holds the number
+/// of records each stream contributed at the position where they diverged — `0`
+/// for a stream that had already ended. Streams are named `R1`/`R2`/... to match
+/// the `--inputs` order and the wording of the single-threaded path in
+/// `commands::extract`.
+pub(crate) fn fastq_out_of_sync_error(counts: &[usize]) -> io::Error {
+    debug_assert!(
+        counts.len() >= 2 && counts.iter().any(|count| *count != counts[0]),
+        "fastq_out_of_sync_error called with counts that are not out of sync: {counts:?}"
+    );
+    let longest = counts.iter().enumerate().max_by_key(|(_, count)| **count).map_or(0, |(i, _)| i);
+    let shortest = counts.iter().enumerate().min_by_key(|(_, count)| **count).map_or(0, |(i, _)| i);
+    let surplus =
+        counts.iter().max().copied().unwrap_or(0) - counts.iter().min().copied().unwrap_or(0);
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!(
+            "FASTQ sources out of sync: R{} ended before R{}, leaving at least {surplus} \
+             record(s) in R{} with no mate. Paired FASTQ inputs must contain the same number \
+             of records — a shorter input usually means a truncated or interrupted transfer.",
+            shortest + 1,
+            longest + 1,
+            longest + 1,
+        ),
+    )
+}
+
+/// Assemble one boundary batch, rejecting streams that disagree on record count.
+///
+/// The Read step fills every chunk to `records_per_batch` unless it hits EOF, so
+/// a short chunk means that stream ended; a stream missing from `streams`
+/// entirely means it ended at an earlier batch index. Either way the inputs hold
+/// different numbers of records and the surplus records have no mate. Those
+/// records are neither discarded nor emitted as fragments — the run fails, so a
+/// truncated input cannot masquerade as a complete one (issue #773).
+fn assemble_boundary_batch(
+    streams: Vec<FastqStreamBoundaries>,
     serial: u64,
-) -> FastqBoundaryBatch {
-    if streams.len() > 1 {
-        let min_records =
-            streams.iter().map(|s| s.offsets.len().saturating_sub(1)).min().unwrap_or(0);
-        for stream in &mut streams {
-            let record_count = stream.offsets.len().saturating_sub(1);
-            if record_count > min_records && min_records > 0 {
-                let excess_start = stream.offsets[min_records];
-                stream.data.truncate(excess_start);
-                stream.offsets.truncate(min_records + 1);
+    num_streams: usize,
+) -> io::Result<FastqBoundaryBatch> {
+    if num_streams > 1 {
+        let mut counts = vec![0usize; num_streams];
+        for stream in &streams {
+            if let Some(count) = counts.get_mut(stream.stream_idx) {
+                *count = stream.offsets.len().saturating_sub(1);
             }
         }
+        if counts.iter().any(|count| *count != counts[0]) {
+            return Err(fastq_out_of_sync_error(&counts));
+        }
     }
-    FastqBoundaryBatch { streams, serial }
+    Ok(FastqBoundaryBatch { streams, serial })
 }
 
 /// Default serialization buffer capacity.
@@ -2475,6 +2509,13 @@ fn drain_exhausted_stream<R: BufRead + Send, P: Send + MemoryEstimate>(
         // Pair with any available surplus from the other stream.
         let all_other: Vec<FastqRecord> = std::mem::take(other_surplus);
         let pair_count = all_this.len().min(all_other.len());
+        // This drain only runs once the *other* stream is exhausted, so an empty
+        // `all_other` means no further mate can arrive. Reject here rather than
+        // letting the records pile up in the surplus vector (issue #773).
+        if all_other.is_empty() && !all_this.is_empty() {
+            let counts = if drain_r1 { [all_this.len(), 0] } else { [0, all_this.len()] };
+            return DrainResult::Error(fastq_out_of_sync_error(&counts));
+        }
         if pair_count > 0 {
             // Ensure R1 is always first in the template regardless of which stream
             // we're draining.
@@ -2559,34 +2600,168 @@ fn drain_exhausted_stream<R: BufRead + Send, P: Send + MemoryEstimate>(
 /// [`FastqPipelineState::is_complete`] separately requires the output queues to be
 /// empty, and the BGZF path skips `Group` entirely, so there is no one-way
 /// `finished` latch to trip.
-fn block_merge_is_complete<R: BufRead + Send, P: Send + MemoryEstimate>(
+fn block_merge_input_drained<R: BufRead + Send, P: Send + MemoryEstimate>(
     state: &FastqPipelineState<R, P>,
     merge: &BlockMergeState,
-    held_parsed_is_none: bool,
 ) -> bool {
     state.read_done.load(Ordering::Acquire)
         && state.chunks_block_parsed.load(Ordering::Acquire)
             == state.batches_read.load(Ordering::Acquire)
         // Must be observed *after* the counter load above — see the doc comment.
         && state.q2_block_parsed.is_empty()
-        && merge.is_empty()
-        && held_parsed_is_none
+        && merge.r1_pending.is_empty()
+        && merge.r2_pending.is_empty()
 }
 
-/// Publishes `BlockMerge`'s completion flags if [`block_merge_is_complete`] holds.
+/// Publishes `BlockMerge`'s completion flags, or the out-of-sync error, once
+/// [`block_merge_input_drained`] holds.
 ///
-/// Both of `BlockMerge`'s exits end in the same three stores, and the drift between
-/// its two completion *conditions* is what stranded blocks in the first place, so
+/// Both of `BlockMerge`'s exits end in the same stores, and the drift between its
+/// two completion *conditions* is what stranded blocks in the first place, so
 /// condition and action are kept together in one place rather than repeated.
+///
+/// Once the input is drained, leftover surplus records can never be paired: they
+/// are the tail of the longer FASTQ, and the shorter one has ended. Before issue
+/// #773 that state simply failed `merge.is_empty()` forever, so `BlockMerge`
+/// spun without ever publishing completion and the run produced no output and no
+/// error. Reject it instead, naming the stream that ended first.
 fn finish_block_merge_if_complete<R: BufRead + Send, P: Send + MemoryEstimate>(
     state: &FastqPipelineState<R, P>,
     merge: &BlockMergeState,
     worker: &FastqWorkerState<P>,
 ) {
-    if block_merge_is_complete(state, merge, worker.held_parsed.is_none()) {
+    if !block_merge_input_drained(state, merge) {
+        return;
+    }
+    if !merge.r1_surplus.is_empty() || !merge.r2_surplus.is_empty() {
+        // `fastq_out_of_sync_error` requires the counts to actually differ; the
+        // pairing loop and `drain_exhausted_stream` both drain `min(len, len)`, so
+        // at most one surplus vector is ever non-empty here. Enforce that invariant
+        // at the call site so a future change that leaves both non-empty and equal
+        // trips this assert rather than degrading the error message.
+        debug_assert!(
+            merge.r1_surplus.is_empty()
+                || merge.r2_surplus.is_empty()
+                || merge.r1_surplus.len() != merge.r2_surplus.len(),
+            "both surplus vectors non-empty and equal length ({}); \
+             fastq_out_of_sync_error cannot name a stream",
+            merge.r1_surplus.len()
+        );
+        state.set_error(fastq_out_of_sync_error(&[merge.r1_surplus.len(), merge.r2_surplus.len()]));
+        return;
+    }
+    if merge.is_empty() && worker.held_parsed.is_none() {
         state.block_merge_done.store(true, Ordering::Release);
         state.parse_done.store(true, Ordering::Release);
         state.group_done.store(true, Ordering::Release);
+    }
+}
+
+/// Parse and emit the final record of each stream when it does not end in a
+/// trailing newline.
+///
+/// `detect_suffix_start` treats a record without a trailing newline as an
+/// incomplete trailing fragment and leaves it in `suffix_bytes`. During normal
+/// processing that fragment is stitched with the next block's `prefix_bytes`, but
+/// the *last* block of a stream has no successor, so a residual complete record
+/// stays parked in `suffix_bytes` forever. Because [`BlockMergeState::is_empty`]
+/// requires the suffix buffers to be empty, completion would never fire: a valid
+/// matched pair whose FASTQ files simply do not end in a newline would hang the
+/// BGZF path (both single-stream and paired) with no output and no error.
+///
+/// Once all input is drained, parse any such residual as the stream's final
+/// record (with an empty successor prefix), move it into the surplus, and run it
+/// through the same pairing and emission as any other record. Leftover surplus is
+/// left for [`finish_block_merge_if_complete`] to reject as out of sync, and a
+/// genuinely truncated fragment surfaces as a parse error rather than being
+/// silently dropped (issue #773).
+///
+/// Returns `true` if it emitted a template or is now holding one for the caller.
+fn flush_residual_suffixes_at_eof<R: BufRead + Send, P: Send + MemoryEstimate>(
+    state: &FastqPipelineState<R, P>,
+    merge: &mut BlockMergeState,
+    worker: &mut FastqWorkerState<P>,
+) -> bool {
+    // A held template must be pushed by Priority 1 first (ordering/backpressure);
+    // only act once every block has been read, parsed, and merged.
+    if worker.held_parsed.is_some() || !block_merge_input_drained(state, merge) {
+        return false;
+    }
+    if merge.r1_suffix_bytes.is_empty() && merge.r2_suffix_bytes.is_empty() {
+        return false;
+    }
+
+    for from_r1 in [true, false] {
+        let (suffix, surplus) = if from_r1 {
+            (&mut merge.r1_suffix_bytes, &mut merge.r1_surplus)
+        } else {
+            (&mut merge.r2_suffix_bytes, &mut merge.r2_surplus)
+        };
+        if suffix.is_empty() {
+            continue;
+        }
+        match stitch_cross_block_record(suffix, &[]) {
+            Ok(Some(rec)) => {
+                surplus.push(rec);
+                suffix.clear();
+            }
+            // Unreachable for a non-empty suffix (`stitch_cross_block_record`
+            // only returns `None` when both slices are empty), but clear it so a
+            // future change cannot strand it and re-introduce the hang.
+            Ok(None) => suffix.clear(),
+            Err(e) => {
+                state.set_error(e);
+                return true;
+            }
+        }
+    }
+
+    // Emit the newly flushed records through the normal pairing path.
+    let templates: Vec<FastqTemplate> = if state.num_streams == 1 {
+        std::mem::take(&mut merge.r1_surplus)
+            .into_iter()
+            .map(|record| {
+                let name = record.name().to_vec();
+                FastqTemplate { name, records: vec![record] }
+            })
+            .collect()
+    } else {
+        let pair_count = merge.r1_surplus.len().min(merge.r2_surplus.len());
+        merge
+            .r1_surplus
+            .drain(..pair_count)
+            .zip(merge.r2_surplus.drain(..pair_count))
+            .map(|(r1, r2)| {
+                let name = r1.name().to_vec();
+                FastqTemplate { name, records: vec![r1, r2] }
+            })
+            .collect()
+    };
+
+    if templates.is_empty() {
+        // Paired input where only one stream had a residual record: it stays in
+        // the surplus for `finish_block_merge_if_complete` to reject as out of
+        // sync. The suffix buffers are now empty, so completion is no longer
+        // blocked on them.
+        return false;
+    }
+
+    let serial = merge.serial_out;
+    merge.serial_out += 1;
+    let count = templates.len();
+    match state.output.groups.push((serial, templates)) {
+        Ok(()) => {
+            state.total_templates_pushed.fetch_add(count as u64, Ordering::Release);
+            if let Some(stats) = state.stats() {
+                stats.groups_produced.fetch_add(count as u64, Ordering::Relaxed);
+            }
+            state.deadlock_state.record_q4_push();
+            true
+        }
+        Err((serial, returned)) => {
+            worker.held_parsed = Some((serial, returned, count));
+            true
+        }
     }
 }
 
@@ -2678,9 +2853,11 @@ fn fastq_try_step_block_merge<R: BufRead + Send, P: Send + MemoryEstimate>(
         }
     }
     if drained == 0 && merge.r1_pending.is_empty() && merge.r2_pending.is_empty() {
-        // Nothing to do. Check for completion.
+        // Nothing left in the pending maps: flush any trailing-newline-less final
+        // record, then check for completion.
+        let flushed = flush_residual_suffixes_at_eof(state, &mut merge, worker);
         finish_block_merge_if_complete(state, &merge, worker);
-        return (did_work, false);
+        return (did_work || flushed, false);
     }
 
     let mut batches_this_call = 0;
@@ -2889,10 +3066,12 @@ fn fastq_try_step_block_merge<R: BufRead + Send, P: Send + MemoryEstimate>(
         }
     }
 
-    // Check for completion: all chunks processed, queue drained, and merge state empty.
+    // Flush any trailing-newline-less final record, then check for completion:
+    // all chunks processed, queue drained, and merge state empty.
+    let flushed = flush_residual_suffixes_at_eof(state, &mut merge, worker);
     finish_block_merge_if_complete(state, &merge, worker);
 
-    (did_work, false)
+    (did_work || flushed, false)
 }
 
 // ============================================================================
@@ -2987,7 +3166,13 @@ fn fastq_try_step_find_boundaries<R: BufRead + Send, P: Send + MemoryEstimate>(
                     offsets: c.offsets.expect("gzip chunks must have pre-computed offsets"),
                 })
                 .collect();
-            align_stream_records(streams, serial)
+            match assemble_boundary_batch(streams, serial, state.num_streams) {
+                Ok(batch) => batch,
+                Err(e) => {
+                    state.set_error(e);
+                    return (true, false);
+                }
+            }
         } else {
             // BGZF path: need to find record boundaries in decompressed data.
             let decompressed = FastqDecompressedBatch {
@@ -4913,43 +5098,87 @@ mod tests {
         assert!(pair.is_empty());
     }
 
+    /// An equal-length batch passes through byte-for-byte: no record is
+    /// rewritten, reordered or dropped.
     #[test]
-    fn test_align_stream_records_equal() {
+    fn test_assemble_boundary_batch_equal_counts_passes_records_through() {
+        let r1_data = b"@r1\nACGT\n+\nIIII\n@r2\nACGT\n+\nIIII\n".to_vec();
+        let r2_data = b"@r1\nTTTT\n+\nJJJJ\n@r2\nTTTT\n+\nJJJJ\n".to_vec();
         let streams = vec![
             FastqStreamBoundaries {
                 stream_idx: 0,
-                data: b"@r1\nACGT\n+\nIIII\n@r2\nACGT\n+\nIIII\n".to_vec(),
-                offsets: vec![0, 18, 36],
+                data: r1_data.clone(),
+                offsets: vec![0, 16, 32],
             },
             FastqStreamBoundaries {
                 stream_idx: 1,
-                data: b"@r1\nTTTT\n+\nJJJJ\n@r2\nTTTT\n+\nJJJJ\n".to_vec(),
-                offsets: vec![0, 18, 36],
+                data: r2_data.clone(),
+                offsets: vec![0, 16, 32],
             },
         ];
-        let batch = align_stream_records(streams, 0);
-        assert_eq!(batch.streams[0].offsets.len() - 1, 2);
-        assert_eq!(batch.streams[1].offsets.len() - 1, 2);
+        let batch = assemble_boundary_batch(streams, 7, 2)
+            .expect("equal record counts must assemble cleanly");
+        assert_eq!(batch.serial, 7);
+        assert_eq!(batch.streams[0].data, r1_data, "R1 bytes must be untouched");
+        assert_eq!(batch.streams[0].offsets, vec![0, 16, 32], "R1 offsets must be untouched");
+        assert_eq!(batch.streams[1].data, r2_data, "R2 bytes must be untouched");
+        assert_eq!(batch.streams[1].offsets, vec![0, 16, 32], "R2 offsets must be untouched");
     }
 
+    /// Unequal counts within one batch index are rejected, naming both streams
+    /// and the surplus — the old behavior silently truncated to the shorter
+    /// stream, dropping the surplus records (issue #773).
     #[test]
-    fn test_align_stream_records_unequal() {
+    fn test_assemble_boundary_batch_unequal_counts_is_rejected() {
         let streams = vec![
             FastqStreamBoundaries {
                 stream_idx: 0,
                 data: b"@r1\nACGT\n+\nIIII\n@r2\nACGT\n+\nIIII\n@r3\nACGT\n+\nIIII\n".to_vec(),
-                offsets: vec![0, 18, 36, 54],
+                offsets: vec![0, 16, 32, 48],
             },
             FastqStreamBoundaries {
                 stream_idx: 1,
                 data: b"@r1\nTTTT\n+\nJJJJ\n@r2\nTTTT\n+\nJJJJ\n".to_vec(),
-                offsets: vec![0, 18, 36],
+                offsets: vec![0, 16, 32],
             },
         ];
-        let batch = align_stream_records(streams, 0);
-        // Both should be truncated to min(3, 2) = 2 records
-        assert_eq!(batch.streams[0].offsets.len() - 1, 2);
-        assert_eq!(batch.streams[1].offsets.len() - 1, 2);
+        let error = assemble_boundary_batch(streams, 0, 2)
+            .expect_err("unequal record counts must be rejected");
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        let message = error.to_string();
+        assert!(message.contains("out of sync"), "unexpected message: {message}");
+        assert!(message.contains("R2 ended before R1"), "unexpected message: {message}");
+        assert!(message.contains("at least 1 record"), "unexpected message: {message}");
+    }
+
+    /// A stream that ended at an earlier batch index is absent from `streams`
+    /// entirely; that is still an out-of-sync input, not a single-end batch.
+    #[test]
+    fn test_assemble_boundary_batch_missing_stream_is_rejected() {
+        let streams = vec![FastqStreamBoundaries {
+            stream_idx: 0,
+            data: b"@r1\nACGT\n+\nIIII\n@r2\nACGT\n+\nIIII\n".to_vec(),
+            offsets: vec![0, 16, 32],
+        }];
+        let error = assemble_boundary_batch(streams, 0, 2)
+            .expect_err("a batch missing a stream must be rejected");
+        let message = error.to_string();
+        assert!(message.contains("R2 ended before R1"), "unexpected message: {message}");
+        assert!(message.contains("at least 2 record"), "unexpected message: {message}");
+    }
+
+    /// Single-stream (single-end) input has no mate to be out of sync with.
+    #[test]
+    fn test_assemble_boundary_batch_single_stream_is_accepted() {
+        let streams = vec![FastqStreamBoundaries {
+            stream_idx: 0,
+            data: b"@r1\nACGT\n+\nIIII\n".to_vec(),
+            offsets: vec![0, 16],
+        }];
+        let batch = assemble_boundary_batch(streams, 3, 1)
+            .expect("single-end batches must assemble cleanly");
+        assert_eq!(batch.streams.len(), 1);
+        assert_eq!(batch.streams[0].offsets, vec![0, 16]);
     }
 
     // ========================================================================
@@ -5457,30 +5686,49 @@ mod tests {
         assert_eq!(first_key, 0, "BTreeMap must yield block 0 first");
     }
 
+    /// What `BlockMerge` is expected to publish for a given state.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum MergeOutcome {
+        /// Neither complete nor failed — the step must run again.
+        KeepGoing,
+        /// Completion flags published.
+        Complete,
+        /// Rejected: the inputs hold different numbers of records.
+        OutOfSync,
+    }
+
     /// `BlockMerge` may only declare completion when every parsed block has been
-    /// *consumed*, so each of the three places a block can sit must independently
-    /// veto completion.
+    /// *consumed*, so each of the places a block can sit must independently veto
+    /// completion — and leftover surplus records, which no later block can pair,
+    /// must be reported rather than waited on forever.
     ///
-    /// `blocks_still_queued` is the regression — it stalled the run until the deadlock
-    /// detector fired (`Q2b=2, merged=0, block_merge_done=true`). See
-    /// [`block_merge_is_complete`] for why a counters-only predicate strands blocks.
+    /// `blocks_still_queued` is the earlier regression — it stalled the run until the
+    /// deadlock detector fired (`Q2b=2, merged=0, block_merge_done=true`). See
+    /// [`block_merge_input_drained`] for why a counters-only predicate strands blocks.
+    /// `surplus_unpairable` is issue #773, which had no such backstop at all: the run
+    /// spun forever with no output and no error.
     #[rstest]
-    #[case::all_drained(true, true, false, false, false, true)]
-    #[case::blocks_still_queued(true, true, true, false, false, false)]
-    #[case::counters_behind(true, false, false, false, false, false)]
-    #[case::reader_still_going(false, true, false, false, false, false)]
-    #[case::merge_state_pending(true, true, false, true, false, false)]
-    #[case::batch_held_downstream(true, true, false, false, true, false)]
+    #[case::all_drained(true, true, false, false, false, false, MergeOutcome::Complete)]
+    #[case::blocks_still_queued(true, true, true, false, false, false, MergeOutcome::KeepGoing)]
+    #[case::counters_behind(true, false, false, false, false, false, MergeOutcome::KeepGoing)]
+    #[case::reader_still_going(false, true, false, false, false, false, MergeOutcome::KeepGoing)]
+    #[case::merge_state_pending(true, true, false, true, false, false, MergeOutcome::KeepGoing)]
+    #[case::batch_held_downstream(true, true, false, false, true, false, MergeOutcome::KeepGoing)]
+    #[case::surplus_unpairable(true, true, false, false, false, true, MergeOutcome::OutOfSync)]
+    #[case::surplus_wins_over_held(true, true, false, false, true, true, MergeOutcome::OutOfSync)]
     fn test_block_merge_completion_requires_every_block_consumed(
         #[case] read_done: bool,
         #[case] counters_caught_up: bool,
         #[case] blocks_queued: bool,
         #[case] merge_pending: bool,
         #[case] batch_held: bool,
-        #[case] expected_complete: bool,
+        #[case] surplus_left: bool,
+        #[case] expected: MergeOutcome,
     ) {
         let state = make_fastq_state();
         let mut merge = BlockMergeState::new();
+        let mut worker: FastqWorkerState<Vec<u8>> =
+            FastqWorkerState::new(6, 0, 2, SchedulerStrategy::default(), ActiveSteps::all());
 
         // `read_done` plus a counter level with `batches_read` is what tells
         // BlockMerge that no further blocks will ever be produced.
@@ -5499,11 +5747,86 @@ mod tests {
                 make_block_parsed(0, 0, vec![make_record("r1", "ACGT", "IIII")], vec![], vec![]),
             );
         }
+        if batch_held {
+            worker.held_parsed = Some((0, Vec::new(), 0));
+        }
+        if surplus_left {
+            merge.r1_surplus.push(make_record("r1", "ACGT", "IIII"));
+        }
 
-        assert_eq!(
-            block_merge_is_complete(&state, &merge, !batch_held),
-            expected_complete,
-            "completion must require an empty queue, empty merge state and no held batch"
+        finish_block_merge_if_complete(&state, &merge, &worker);
+
+        let error = state.take_error();
+        let actual = match (state.block_merge_done.load(Ordering::Acquire), &error) {
+            (_, Some(_)) => MergeOutcome::OutOfSync,
+            (true, None) => MergeOutcome::Complete,
+            (false, None) => MergeOutcome::KeepGoing,
+        };
+        assert_eq!(actual, expected, "unexpected BlockMerge outcome");
+
+        if expected == MergeOutcome::OutOfSync {
+            let message = error.expect("out-of-sync outcome must carry an error").to_string();
+            assert!(message.contains("out of sync"), "unexpected message: {message}");
+            assert!(message.contains("R2 ended before R1"), "unexpected message: {message}");
+            assert!(
+                !state.block_merge_done.load(Ordering::Acquire),
+                "a rejected run must not also publish completion"
+            );
+        } else {
+            assert_eq!(
+                state.parse_done.load(Ordering::Acquire),
+                expected == MergeOutcome::Complete,
+                "parse_done must track block_merge_done"
+            );
+            assert_eq!(
+                state.group_done.load(Ordering::Acquire),
+                expected == MergeOutcome::Complete,
+                "group_done must track block_merge_done"
+            );
+        }
+    }
+
+    /// When one BGZF stream is exhausted but the other still has blocks with no
+    /// mate to pair against, the drain must reject the input rather than let the
+    /// records pile up in the surplus vector (issue #773). Both drain directions
+    /// name the stream that ended first.
+    #[rstest]
+    #[case::drain_r1_r2_ended(true, "R2 ended before R1")]
+    #[case::drain_r2_r1_ended(false, "R1 ended before R2")]
+    fn test_drain_exhausted_stream_rejects_unpairable_surplus(
+        #[case] drain_r1: bool,
+        #[case] expected_direction: &str,
+    ) {
+        let state = make_fastq_state();
+        let mut merge = BlockMergeState::new();
+
+        // The stream being drained still has a block of records; the other
+        // stream is exhausted, so its surplus is empty and no mate can arrive.
+        // R1 is stream 0, R2 is stream 1.
+        let stream_idx = usize::from(!drain_r1);
+        let block = make_block_parsed(
+            0,
+            stream_idx,
+            vec![make_record("r1", "ACGT", "IIII"), make_record("r2", "GGGG", "JJJJ")],
+            vec![],
+            vec![],
+        );
+        if drain_r1 {
+            merge.r1_pending.insert(0, block);
+        } else {
+            merge.r2_pending.insert(0, block);
+        }
+
+        let result = drain_exhausted_stream(&state, &mut merge, drain_r1, false, 0);
+        let DrainResult::Error(error) = result else {
+            panic!("draining a stream with no mate must return an error");
+        };
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        let message = error.to_string();
+        assert!(message.contains("out of sync"), "unexpected message: {message}");
+        assert!(
+            message.contains(expected_direction),
+            "rejection must name the stream that ended first: {message}"
         );
     }
 

--- a/tests/integration/test_extract_command.rs
+++ b/tests/integration/test_extract_command.rs
@@ -4,7 +4,7 @@
 
 use std::fs::File;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::Parser;
 use fgumi_lib::commands::command::Command;
@@ -68,10 +68,24 @@ fn create_bgzf_fastq(dir: &TempDir, name: &str, records: &[(&str, &str, &str)]) 
 }
 
 /// Read BAM records from a file.
-fn read_bam_records(path: &PathBuf) -> Vec<RecordBuf> {
+fn read_bam_records(path: &Path) -> Vec<RecordBuf> {
     let mut reader = File::open(path).map(bam::io::Reader::new).unwrap();
     let header = reader.read_header().unwrap();
     reader.record_bufs(&header).map(|r| r.expect("Failed to read BAM record")).collect()
+}
+
+/// The number of records in `path` if it can be read as a BAM, or `None` if the
+/// file is absent or does not parse as one. Used to inspect the partial output a
+/// rejected run may leave behind without panicking on a truncated file.
+fn try_bam_record_count(path: &Path) -> Option<usize> {
+    let mut reader = File::open(path).map(bam::io::Reader::new).ok()?;
+    let header = reader.read_header().ok()?;
+    let mut count = 0;
+    for record in reader.record_bufs(&header) {
+        record.ok()?;
+        count += 1;
+    }
+    Some(count)
 }
 
 /// Standard test records for paired-end FASTQs.
@@ -1306,4 +1320,401 @@ fn test_extract_compression_level_out_of_range_rejected() {
         "Expected clap range-validation error mentioning `0..=12` or `invalid value`, \
          got stderr: {stderr}"
     );
+}
+
+// ============================================================================
+// Mismatched-Length FASTQ Pair (issue #773)
+// ============================================================================
+
+/// Build `count` synthetic paired-end FASTQ records named `read00000..`.
+///
+/// Sequences are constant; only the name distinguishes records, which is what
+/// the identity assertions below key on.
+fn numbered_records(count: usize) -> Vec<(String, String, String)> {
+    (0..count)
+        .map(|i| {
+            (format!("read{i:06}"), "ACGTACGTACGTACGT".to_string(), "IIIIIIIIIIIIIIII".to_string())
+        })
+        .collect()
+}
+
+/// Borrow a `Vec<(String, String, String)>` as the `&str` triples the FASTQ
+/// writers take.
+fn as_str_records(records: &[(String, String, String)]) -> Vec<(&str, &str, &str)> {
+    records.iter().map(|(a, b, c)| (a.as_str(), b.as_str(), c.as_str())).collect()
+}
+
+/// The FASTQ compression formats `extract` dispatches on. Each selects a
+/// different pipeline: BGZF uses `BlockParseFast`/`BlockMerge`, gzip and plain
+/// use `FindBoundaries`/`Decode`.
+#[derive(Clone, Copy, Debug)]
+enum FastqFlavor {
+    Plain,
+    Gzip,
+    Bgzf,
+}
+
+impl FastqFlavor {
+    fn write(self, dir: &TempDir, name: &str, records: &[(&str, &str, &str)]) -> PathBuf {
+        match self {
+            Self::Plain => create_plain_fastq(dir, name, records),
+            Self::Gzip => create_gzip_fastq(dir, name, records),
+            Self::Bgzf => create_bgzf_fastq(dir, name, records),
+        }
+    }
+
+    /// Write raw FASTQ `bytes` through this flavor's compressor. Unlike
+    /// [`Self::write`], the caller controls the exact bytes, so a file that does
+    /// not end in a newline can be produced.
+    fn write_bytes(self, dir: &TempDir, name: &str, bytes: &[u8]) -> PathBuf {
+        let path = dir.path().join(name);
+        let file = File::create(&path).unwrap();
+        match self {
+            Self::Plain => {
+                let mut file = file;
+                file.write_all(bytes).unwrap();
+            }
+            Self::Gzip => {
+                let mut encoder = GzEncoder::new(file, Compression::default());
+                encoder.write_all(bytes).unwrap();
+                encoder.finish().unwrap();
+            }
+            Self::Bgzf => {
+                let mut writer = BgzfWriter::new(file);
+                writer.write_all(bytes).unwrap();
+                writer.finish().unwrap();
+            }
+        }
+        path
+    }
+}
+
+/// Serialize `records` as FASTQ text, optionally omitting the newline after the
+/// final record. A file that does not end in a newline leaves its last record in
+/// `suffix_bytes` on the BGZF path, which is the shape the no-trailing-newline
+/// regression test exercises.
+fn fastq_bytes(records: &[(&str, &str, &str)], trailing_newline: bool) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    for (name, seq, qual) in records {
+        bytes.extend_from_slice(format!("@{name}\n{seq}\n+\n{qual}\n").as_bytes());
+    }
+    if !trailing_newline && bytes.last() == Some(&b'\n') {
+        bytes.pop();
+    }
+    bytes
+}
+
+/// Run `fgumi extract` over a paired FASTQ input, returning the command result.
+fn run_extract_pair(r1: &Path, r2: &Path, output: &Path, threads: usize) -> anyhow::Result<()> {
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "+T",
+        "+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--threads",
+        &threads.to_string(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("fgumi extract")
+}
+
+/// Run `fgumi extract` over a paired FASTQ input on the single-threaded fast
+/// path (no `--threads`), returning the command result. This path runs
+/// `process_singlethreaded` rather than the 7-step pipeline.
+fn run_extract_pair_single_threaded(r1: &Path, r2: &Path, output: &Path) -> anyhow::Result<()> {
+    let cmd = Extract::try_parse_from([
+        "extract",
+        "--inputs",
+        r1.to_str().unwrap(),
+        r2.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--read-structures",
+        "+T",
+        "+T",
+        "--sample",
+        "test_sample",
+        "--library",
+        "test_library",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse extract args");
+    cmd.execute("fgumi extract")
+}
+
+/// Every read name in `path`, in file order (one entry per BAM record, so a
+/// properly paired template contributes its name twice).
+fn bam_read_names(path: &Path) -> Vec<String> {
+    read_bam_records(path)
+        .iter()
+        .map(|record| {
+            let name: &[u8] = record.name().expect("BAM record must have a name").as_ref();
+            String::from_utf8(name.to_vec()).expect("read name must be UTF-8")
+        })
+        .collect()
+}
+
+/// Describe, by record identity, how a BAM written from a mismatched FASTQ pair
+/// differs from the long input stream.
+///
+/// Used only to build the failure message when `extract` wrongly accepts such a
+/// pair, so the failure names the records that were lost rather than reporting a
+/// bare count mismatch.
+fn describe_mismatched_output(output: &Path, long_stream: &[(String, String, String)]) -> String {
+    let emitted = bam_read_names(output);
+    let present: std::collections::HashSet<&str> = emitted.iter().map(String::as_str).collect();
+    let missing: Vec<&str> = long_stream
+        .iter()
+        .map(|(name, _, _)| name.as_str())
+        .filter(|name| !present.contains(name))
+        .collect();
+    format!(
+        "{} of {} input records reached the output, {} were dropped (first missing: {:?}), \
+         and {} records were emitted unpaired",
+        present.len(),
+        long_stream.len(),
+        missing.len(),
+        missing.first(),
+        unpaired_record_count(output),
+    )
+}
+
+/// Number of BAM records in `path` that are not flagged as paired (`0x1`).
+fn unpaired_record_count(path: &Path) -> usize {
+    read_bam_records(path).iter().filter(|record| !record.flags().is_segmented()).count()
+}
+
+/// A matched pair must survive extract with every template intact — asserted by
+/// exact read-name identity, not by a count.
+///
+/// This is the control for [`test_extract_rejects_mismatched_fastq_pair`]: the
+/// rejection added for issue #773 must not reject a well-formed input, and the
+/// record set it emits must be exactly the input record set. `RECORD_COUNT`
+/// straddles the per-batch record limit (200 at 1 thread, 800 at 4+) so the
+/// final batch is partial — the shape in which the old truncation silently
+/// dropped records.
+#[rstest]
+#[case::plain_t1(FastqFlavor::Plain, 1)]
+#[case::plain_t4(FastqFlavor::Plain, 4)]
+#[case::gzip_t1(FastqFlavor::Gzip, 1)]
+#[case::gzip_t4(FastqFlavor::Gzip, 4)]
+#[case::bgzf_t1(FastqFlavor::Bgzf, 1)]
+#[case::bgzf_t4(FastqFlavor::Bgzf, 4)]
+fn test_extract_matched_pair_emits_every_template(
+    #[case] flavor: FastqFlavor,
+    #[case] threads: usize,
+) {
+    const RECORD_COUNT: usize = 950;
+
+    let tmp = TempDir::new().unwrap();
+    let records = numbered_records(RECORD_COUNT);
+    let as_str = as_str_records(&records);
+    let r1 = flavor.write(&tmp, "r1.fq", &as_str);
+    let r2 = flavor.write(&tmp, "r2.fq", &as_str);
+    let output = tmp.path().join("matched.bam");
+
+    run_extract_pair(&r1, &r2, &output, threads).unwrap_or_else(|e| {
+        panic!("matched pair must extract cleanly ({flavor:?}, t{threads}): {e}")
+    });
+
+    // Identity: exactly two records per input template, one per mate, and the
+    // emitted name multiset equals the input name multiset.
+    let mut emitted = bam_read_names(&output);
+    emitted.sort();
+    let mut expected: Vec<String> =
+        records.iter().flat_map(|(name, _, _)| [name.clone(), name.clone()]).collect();
+    expected.sort();
+    assert_eq!(
+        emitted, expected,
+        "emitted read names must equal the input read names ({flavor:?}, t{threads})"
+    );
+    assert_eq!(
+        unpaired_record_count(&output),
+        0,
+        "every emitted record must be flagged paired ({flavor:?}, t{threads})"
+    );
+}
+
+/// A well-formed matched pair whose FASTQ files do not end in a trailing newline
+/// must still extract cleanly (#773).
+///
+/// `detect_suffix_start` treats the final record of a file without a trailing
+/// newline as an incomplete fragment and parks it in `suffix_bytes`. On the BGZF
+/// path the last block has no successor to stitch that fragment with, so before
+/// the EOF flush a valid matched pair simply hung — completion required the
+/// suffix buffers to be empty, and they never were. `RECORD_COUNT` spans several
+/// BGZF blocks so both cross-block stitching and the terminal flush are covered.
+/// gzip and plain (which never park a suffix) are included so the guarantee reads
+/// as uniform across flavors.
+#[rstest]
+#[case::plain_t1(FastqFlavor::Plain, 1)]
+#[case::plain_t4(FastqFlavor::Plain, 4)]
+#[case::gzip_t1(FastqFlavor::Gzip, 1)]
+#[case::gzip_t4(FastqFlavor::Gzip, 4)]
+#[case::bgzf_t1(FastqFlavor::Bgzf, 1)]
+#[case::bgzf_t4(FastqFlavor::Bgzf, 4)]
+fn test_extract_matched_pair_without_trailing_newline(
+    #[case] flavor: FastqFlavor,
+    #[case] threads: usize,
+) {
+    const RECORD_COUNT: usize = 3_000;
+
+    let tmp = TempDir::new().unwrap();
+    let records = numbered_records(RECORD_COUNT);
+    let bytes = fastq_bytes(&as_str_records(&records), false);
+    let r1 = flavor.write_bytes(&tmp, "r1.fq", &bytes);
+    let r2 = flavor.write_bytes(&tmp, "r2.fq", &bytes);
+    let output = tmp.path().join("matched.bam");
+
+    run_extract_pair(&r1, &r2, &output, threads).unwrap_or_else(|e| {
+        panic!("matched pair without a trailing newline must extract cleanly ({flavor:?}, t{threads}): {e}")
+    });
+
+    // Identity: the final record (the one parked in `suffix_bytes`) must be
+    // present, so the emitted name multiset equals the input name multiset.
+    let mut emitted = bam_read_names(&output);
+    emitted.sort();
+    let mut expected: Vec<String> =
+        records.iter().flat_map(|(name, _, _)| [name.clone(), name.clone()]).collect();
+    expected.sort();
+    assert_eq!(
+        emitted, expected,
+        "emitted read names must equal the input read names ({flavor:?}, t{threads})"
+    );
+    assert_eq!(
+        unpaired_record_count(&output),
+        0,
+        "every emitted record must be flagged paired ({flavor:?}, t{threads})"
+    );
+}
+
+/// A FASTQ pair whose two streams hold different numbers of records must be
+/// rejected, not silently truncated or silently emitted as fragments (#773).
+///
+/// The two shapes reach the rejection through different code, so both are run.
+/// In `within_batch` the streams first disagree inside a batch index they both
+/// reached, which the old `align_stream_records` truncated to the shorter stream,
+/// dropping the surplus outright. In `whole_batches` the short stream ends on an
+/// exact batch boundary, so the first divergent batch index carries *only* the
+/// long stream — which the old code emitted as single-end fragments (gzip and
+/// plain) or parked in the block merger forever (BGZF).
+///
+/// The short length is a multiple of the pipeline's per-batch record count at
+/// every thread count under test (200 at 1 thread, 800 at 4+), which is what puts
+/// `whole_batches` on the missing-stream path instead of the truncation path.
+///
+/// Assertions are by record identity: when the run wrongly succeeds, the panic
+/// names the specific records lost and the specific records emitted unpaired.
+#[rstest]
+#[case::plain_t1(FastqFlavor::Plain, 1)]
+#[case::plain_t4(FastqFlavor::Plain, 4)]
+#[case::gzip_t1(FastqFlavor::Gzip, 1)]
+#[case::gzip_t4(FastqFlavor::Gzip, 4)]
+#[case::bgzf_t1(FastqFlavor::Bgzf, 1)]
+#[case::bgzf_t4(FastqFlavor::Bgzf, 4)]
+fn test_extract_rejects_mismatched_fastq_pair(#[case] flavor: FastqFlavor, #[case] threads: usize) {
+    /// `(shape, short_count, long_count)`. 800 is a whole number of batches at
+    /// both 200 and 800 records per batch; 850 leaves a partial one.
+    const SHAPES: [(&str, usize, usize); 2] =
+        [("within_batch", 850, 950), ("whole_batches", 800, 2_600)];
+
+    for (shape, short_count, long_count) in SHAPES {
+        // Run both orientations: the surplus in R1 and the surplus in R2.
+        for surplus_in_r1 in [true, false] {
+            let tmp = TempDir::new().unwrap();
+            let long = numbered_records(long_count);
+            let short = numbered_records(short_count);
+            let (r1_recs, r2_recs) = if surplus_in_r1 { (&long, &short) } else { (&short, &long) };
+            let r1 = flavor.write(&tmp, "r1.fq", &as_str_records(r1_recs));
+            let r2 = flavor.write(&tmp, "r2.fq", &as_str_records(r2_recs));
+            let output = tmp.path().join("mismatched.bam");
+            let label = format!("{flavor:?}, t{threads}, {shape}, surplus_in_r1={surplus_in_r1}");
+
+            let Err(error) = run_extract_pair(&r1, &r2, &output, threads) else {
+                panic!(
+                    "extract accepted a mismatched FASTQ pair ({label}): {}",
+                    describe_mismatched_output(&output, &long)
+                );
+            };
+
+            // The message must identify which input ran out, so the operator
+            // knows which file to re-fetch — not merely that something is wrong.
+            let message = format!("{error:#}");
+            let expected_direction =
+                if surplus_in_r1 { "R2 ended before R1" } else { "R1 ended before R2" };
+            assert!(
+                message.contains("out of sync"),
+                "rejection must say the sources are out of sync ({label}): {message}"
+            );
+            assert!(
+                message.contains(expected_direction),
+                "rejection must name the stream that ended first ({label}): {message}"
+            );
+
+            // `extract` streams its output, so by the time it rejects the pair a
+            // BAM header and some record blocks may already be on disk — a
+            // rejected run does NOT guarantee the output is absent. What it must
+            // guarantee is that the leftover is never a *complete-looking* BAM: if
+            // it parses at all, it holds fewer records than the long stream alone
+            // would, so a downstream tool cannot mistake it for a full extraction
+            // (the truncated-but-valid-output failure class of #773).
+            if let Some(emitted) = try_bam_record_count(&output) {
+                assert!(
+                    emitted < 2 * long_count,
+                    "a rejected run must not leave a complete-looking BAM ({label}): \
+                     found {emitted} record(s), long stream has {long_count}"
+                );
+            }
+        }
+    }
+}
+
+/// The single-threaded fast path (no `--threads`) must reject a mismatched pair
+/// with a message that names which stream ended first, matching the threaded
+/// pipeline and the help text's promise (#773). `--threads N` (even `N == 1`)
+/// runs the pipeline, so `process_singlethreaded` is reachable only with no
+/// `--threads` flag at all — the other rejection test never exercises it.
+#[rstest]
+#[case::plain(FastqFlavor::Plain)]
+#[case::gzip(FastqFlavor::Gzip)]
+#[case::bgzf(FastqFlavor::Bgzf)]
+fn test_extract_single_threaded_rejects_mismatched_fastq_pair(#[case] flavor: FastqFlavor) {
+    for surplus_in_r1 in [true, false] {
+        let tmp = TempDir::new().unwrap();
+        let long = numbered_records(950);
+        let short = numbered_records(850);
+        let (r1_recs, r2_recs) = if surplus_in_r1 { (&long, &short) } else { (&short, &long) };
+        let r1 = flavor.write(&tmp, "r1.fq", &as_str_records(r1_recs));
+        let r2 = flavor.write(&tmp, "r2.fq", &as_str_records(r2_recs));
+        let output = tmp.path().join("mismatched.bam");
+        let label = format!("{flavor:?}, single-threaded, surplus_in_r1={surplus_in_r1}");
+
+        let Err(error) = run_extract_pair_single_threaded(&r1, &r2, &output) else {
+            panic!("single-threaded extract accepted a mismatched FASTQ pair ({label})");
+        };
+
+        let message = format!("{error:#}");
+        let expected_direction =
+            if surplus_in_r1 { "R2 ended before R1" } else { "R1 ended before R2" };
+        assert!(
+            message.contains("out of sync"),
+            "rejection must say the sources are out of sync ({label}): {message}"
+        );
+        assert!(
+            message.contains(expected_direction),
+            "rejection must name the stream that ended first ({label}): {message}"
+        );
+    }
 }


### PR DESCRIPTION
Closes #773.

## What was wrong

`fgumi extract --threads N` accepted a paired FASTQ input whose two streams held different numbers of records and exited 0. The no-`--threads` path has always rejected exactly this input — `extract.rs` bails with *"FASTQ sources out of sync: some ended before others"* — so the same files produced an error or a wrong BAM depending only on whether `--threads` was passed.

The issue pointed at the batch-release condition in `PairState` / `BlockMergeState` ("a batch is released only when every stream delivers the matching index, or every stream hits EOF"). That release condition turned out not to be the cause on the gzip/plain path. The actual causes are two, one per pipeline:

**gzip / plain (`FindBoundaries` → `Decode`).** `align_stream_records` deliberately truncated every stream in a batch down to the shortest one, documented as *"excess records are discarded since they have no mate and cannot form valid templates."* That is the silent loss, and it is a discard, not a release-ordering bug. Once the shorter stream reached EOF, the *later* batch indices arrived carrying a single stream and `create_templates_from_streams` turned each surplus record into a **single-end template**, so they were emitted as unpaired fragments rather than dropped.

**BGZF (`BlockParseFast` → `BlockMerge`).** `drain_exhausted_stream` accumulated the surplus into `r1_surplus` / `r2_surplus` and never emitted it, while the completion predicate required `merge.is_empty()` — which includes those vectors. The run **spun forever**: no output, no error, no deadlock-detector line.

### Measured on my own fixtures

Built with the release binary at every thread count (1, 4, 8), read structures `+T +T`:

| input | before | after |
| --- | --- | --- |
| gzip, R1 100,150 / R2 100,050 | exit 0, **100 records silently lost** (`read000850`… absent), no warning | exit 1, out-of-sync error |
| gzip, R1 130,000 / R2 100,000 | exit 0, 30,000 surplus records emitted as **single-end fragments**, plus 30,000 `WARN` lines | exit 1, out-of-sync error |
| BGZF, R1 5,000 / R2 4,000 | **hangs** — killed at 10 min with a 0-record output | exit 1, out-of-sync error, immediate |
| gzip, R1 = R2 = 100,050 (control) | 200,100 records | 200,100 records, unchanged |

The loss magnitude on the gzip path is bounded by the per-batch record count (`200 * min(threads, 4)`, capped at 800), so it is largest at high thread counts and it is entirely invisible without a record-level diff.

## The behavior chosen, and why

**Fail loudly** (option 2 in the issue), with no opt-out flag.

1. **It is already fgumi's contract.** The single-threaded `extract` path bails on this input (`extract.rs:1198`, `:1207`) and `FastqGrouper::finish` errors with *"Unmatched FASTQ records at EOF - files out of sync"* (`grouper.rs:888`). The threaded pipeline is meant to be an optimization of the same tool. Before this change the tool disagreed with itself about whether the input was legal.
2. **fgbio does the same** — checked, not assumed. `FastqSource.zipped` (`FastqSource.scala:62-75`) has `require(sources.forall(_.hasNext) == sources.head.hasNext, "Iterators are out of sync.")` and then unconditionally calls `next()` on every source, so a short source throws either the `IllegalArgumentException` or a `NoSuchElementException`. `FastqToBam` aborts non-zero either way.
3. **The user does not have a legitimate single-end tail.** Paired FASTQs are produced together; unequal counts mean a truncated download, a killed upstream process, or a full disk. The surplus records are not fragments — they have mates, in the part of the file that never arrived.
4. **Processing the surplus would corrupt the analysis `extract` exists to feed.** That is what `main` does today on gzip inputs, and unpaired reads carrying the R1 read structure change family composition in `group` and, for `duplex`, silently make both-strand families look single-stranded.
5. **Warn-and-continue does not fix the reported problem.** The complaint is that a zero exit status hid the loss. A warning still exits 0, so no workflow engine stops, and 30,000 warnings are indistinguishable from log noise.

**No compatibility flag.** The behavior being removed is not one anyone can be relying on deliberately: on this input `main` either loses records, emits fragments, or hangs, and all three are indistinguishable from a good run. A `--allow-unequal-lengths` escape hatch would only re-arm the footgun. Flagged as **breaking** in the CHANGELOG all the same, because a run that previously "succeeded" now fails.

## The fix

- `align_stream_records` → `assemble_boundary_batch`, which returns `io::Result` and rejects any batch whose streams disagree on record count — including one a stream is **missing from entirely**, which means it ended at an earlier batch index. This is sound because `read_n_fastq_records` returns fewer than `records_per_batch` records only when it sets `at_eof`, so a short or absent chunk can only mean that stream ended.
- BGZF: `block_merge_input_drained` is split out of the completion predicate so `BlockMerge` can distinguish *"still waiting on input"* from *"input exhausted with records left unpaired"*, and reject the latter instead of spinning on a `merge.is_empty()` that can never become true. `drain_exhausted_stream` additionally rejects the moment it sees records that can no longer be mated, so the whole surplus is not buffered first.
- One error constructor, `fastq_out_of_sync_error`, so both pipelines produce the same message, naming which stream ended first and how many records were left unmated.
- The same shape one stage downstream: a template whose record count did not match `--read-structures` was a `log::warn!` followed by a `zip` that stops at the shorter side, silently dropping that read's segments. It is now an error.
- The input contract is stated in `extract --help`.

```
FASTQ sources out of sync: R2 ended before R1, leaving at least 800 record(s) in R1
with no mate. Paired FASTQ inputs must contain the same number of records — a shorter
input usually means a truncated or interrupted transfer.
```

## Tests

TDD: the integration test was written first and failed against `main` with a record-level message, not a count —

```
extract accepted a mismatched FASTQ pair (Plain, t1, within_batch, surplus_in_r1=true):
850 of 950 input records reached the output, 100 were dropped
(first missing: Some("read000850")), and 0 records were emitted unpaired
```

- `test_extract_rejects_mismatched_fastq_pair` — plain/gzip/BGZF × 1 and 4 threads × two mismatch shapes × both orientations. `within_batch` (850/950) makes the streams first disagree inside a shared batch index, the truncation path; `whole_batches` (800/2,600) ends the short stream on an exact batch boundary at both 200 and 800 records per batch, so the first divergent index carries only the long stream — the missing-stream path. Asserts the rejection **names which input ended first**, and on a wrongly-successful run reports the exact missing read names.
- `test_extract_matched_pair_emits_every_template` — the control, asserting **record identity**: the sorted emitted read-name multiset equals the input multiset (two records per template), and zero records are unpaired. 950 records, so the final batch is partial at every thread count — the shape in which the truncation used to bite.
- Unit tests on `assemble_boundary_batch`: equal counts pass through **byte-for-byte** (data and offsets unmodified), unequal counts and a missing stream are rejected with the expected wording, single-end input is accepted.
- `test_block_merge_completion_requires_every_block_consumed` now drives `finish_block_merge_if_complete` itself and asserts the published outcome, with new `surplus_unpairable` and `surplus_wins_over_held` cases.

Gate: `cargo ci-fmt`, `cargo ci-lint`, `cargo ci-test` (7,510 passed), `cargo ci-doctest`.

## Base and merge order

Based on **`main`**, not on #772 or #764. The gzip loss is a discard in `align_stream_records` and the BGZF hang is in `BlockMerge`'s completion predicate; neither is touched by the queue-memory work, and the fix needs nothing from it. Reproduced on `main` before and after.

**#772 needs one adjustment when the two meet.** Its `mismatched_stream_lengths_still_complete_under_a_tight_budget` runs a 1:10 mismatched pair through the pipeline twice — gated and ungated — and both calls go through `run_to_completion`, which does `.expect("pipeline should succeed")`. After this change both runs return `Err`, so that test fails on whichever branch merges second. Its *intent* survives intact: the budget still must not change the outcome, so the harness just has to compare the two `Result`s (or their error text) rather than assert success. The oracle choice was right — it does not encode the dropped records as expected — it is only the success assumption that has to go. The liveness hazard #772 designs around is also still real: when the short stream ends on an exact batch boundary, the surplus batches are still only released once every stream reaches EOF.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: `extract` now fails instead of emitting incomplete output for mismatched FASTQ pairs; grouping, consensus, sort order, corrected UMIs, and metrics are unchanged; unsafe: none, and the `CLAUDE.md` allowlist is unchanged; memory bounds, queue capacity, and thread/backpressure policy: none.

Fix: Validate paired FASTQ synchronization across plain, gzip, and BGZF inputs. Reject read-structure count mismatches. Add coverage for thread counts, orientations, boundary batches, and BGZF completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->