### PR TITLE
fix(pipeline)!: fail on data left unflushed at end of stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **Breaking:** end-of-stream flush paths now fail instead of discarding what they were holding,
+  so an input that used to produce a short output and exit 0 now exits non-zero. A BAM whose last
+  record is truncated is the case a user can hit: the boundary finder dropped a 1-3 byte record
+  fragment at EOF (though its own documentation promised an error), and in `--threads` mode
+  nothing checked its leftover bytes at all. The other four paths report an internal invariant
+  that a correct run never reaches: `simulate`'s parallel gzip writer emitted whatever blocks
+  were left without checking the serial sequence, so a block that never arrived produced a valid
+  gzip file with a hole in it; `RecordPositionGrouper::finish` guarded its flush with a
+  `debug_assert!`, so release builds dropped the buffered records while `has_pending()` went on
+  reporting them; the BAM pipeline's completion validation checked none of the three internal
+  buffers it is documented to cover (the grouper's partial group, groups never pushed to Q4, and
+  the boundary finder's leftover bytes); and `simulate`'s record sink lost its last partial batch
+  if it was dropped without `finish()`. Each now reports what was left unflushed
+  ([#782](https://github.com/fulcrumgenomics/fgumi/issues/782)).
+
 ## [0.6.0] - 2026-08-14
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ All notable changes to this project will be documented in this file.
   if it was dropped without `finish()`. Each now reports what was left unflushed
   ([#782](https://github.com/fulcrumgenomics/fgumi/issues/782)).
 
+- The pipeline's reorder buffer now rejects a duplicate serial, and a serial below its base, in
+  every build rather than only in debug. Both were `debug_assert!`s, so a release build silently
+  overwrote the buffered batch in the first case — losing its records while double-counting them
+  in the memory accounting — and underflowed the `u64` index computation in the second
+  ([#782](https://github.com/fulcrumgenomics/fgumi/issues/782)).
+
 ## [0.6.0] - 2026-08-14
 
 ### Bug Fixes

--- a/crates/fgumi-bam-io/src/reorder.rs
+++ b/crates/fgumi-bam-io/src/reorder.rs
@@ -78,8 +78,8 @@ impl<T> ReorderBuffer<T> {
     ///
     /// # Panics
     ///
-    /// Panics in debug mode if an item with the same sequence number is already buffered,
-    /// or if the sequence number is before the current base.
+    /// Panics if an item with the same sequence number is already buffered, or
+    /// if the sequence number is before the current base.
     pub fn insert(&mut self, seq: u64, item: T) {
         self.insert_with_size(seq, item, 0);
     }
@@ -97,15 +97,20 @@ impl<T> ReorderBuffer<T> {
     ///
     /// # Panics
     ///
-    /// Panics in debug mode if an item with the same sequence number is already buffered,
-    /// or if the sequence number is before the current base.
+    /// Panics if an item with the same sequence number is already buffered, or
+    /// if the sequence number is before the current base.
+    ///
+    /// Both checks are unconditional, not `debug_assert!`s. Serial accounting
+    /// here is data-integrity-critical, and in a release build the compiled-out
+    /// assertions left two silent failures: a duplicate serial overwrote the
+    /// buffered item — dropping a whole batch of records while `count` and
+    /// `heap_bytes` counted it twice — and a serial below the base underflowed
+    /// `seq - next_seq`, so the extend loop below tried to grow the buffer to
+    /// an unreachable index. Neither is recoverable in place, so this fails
+    /// loudly; the pipeline's `catch_unwind` turns it into a reported error.
     #[allow(clippy::cast_possible_truncation)]
     pub fn insert_with_size(&mut self, seq: u64, item: T, heap_size: usize) {
-        debug_assert!(
-            seq >= self.next_seq,
-            "Sequence number {seq} is before base {}",
-            self.next_seq
-        );
+        assert!(seq >= self.next_seq, "Sequence number {seq} is before base {}", self.next_seq);
 
         let index = (seq - self.next_seq) as usize;
 
@@ -114,7 +119,7 @@ impl<T> ReorderBuffer<T> {
             self.buffer.push_back(None);
         }
 
-        debug_assert!(self.buffer[index].is_none(), "Duplicate sequence number: {seq}");
+        assert!(self.buffer[index].is_none(), "Duplicate sequence number: {seq}");
         self.buffer[index] = Some((item, heap_size));
         self.count += 1;
         self.heap_bytes += heap_size as u64;
@@ -534,5 +539,33 @@ mod tests {
 
         // With limit 2000, we're under limit, should accept
         assert!(buffer.would_accept(1, 2000));
+    }
+
+    /// A duplicate serial must abort, not overwrite the buffered item.
+    ///
+    /// Under the old `debug_assert!` a release build silently replaced the
+    /// item — losing a whole batch of records — while `count` and `heap_bytes`
+    /// counted it twice, so the accounting the pipeline's backpressure reads
+    /// drifted at the same time.
+    #[test]
+    #[should_panic(expected = "Duplicate sequence number: 1")]
+    fn test_duplicate_serial_panics_instead_of_overwriting() {
+        let mut buffer: ReorderBuffer<i32> = ReorderBuffer::new();
+        buffer.insert(1, 100);
+        buffer.insert(1, 200);
+    }
+
+    /// A serial below the base must abort, not underflow the index.
+    ///
+    /// `(seq - self.next_seq)` is `u64` arithmetic, so in a release build a
+    /// stale serial wrapped to an astronomically large index and the extend
+    /// loop tried to grow the buffer to reach it.
+    #[test]
+    #[should_panic(expected = "is before base")]
+    fn test_serial_before_base_panics_instead_of_underflowing() {
+        let mut buffer: ReorderBuffer<i32> = ReorderBuffer::new();
+        buffer.insert(0, 100);
+        assert_eq!(buffer.try_pop_next(), Some(100), "base advances to 1");
+        buffer.insert(0, 200);
     }
 }

--- a/src/lib/commands/simulate/common.rs
+++ b/src/lib/commands/simulate/common.rs
@@ -649,8 +649,10 @@ impl RecordSink {
     /// The generator must **own** the sink and drop it when it finishes:
     /// dropping the sender is what signals end-of-stream. A sink kept alive
     /// elsewhere (e.g. left in the caller's scope) leaves the sort blocked
-    /// waiting for records that will never arrive. Call [`Self::finish`] before
-    /// dropping so the last partial batch is not lost.
+    /// waiting for records that will never arrive. Call [`Self::finish`] to
+    /// deliver the last partial batch; a sink dropped with records still
+    /// buffered fails the sort rather than silently truncating it (see the
+    /// [`Drop`] impl).
     pub(super) fn new() -> (Self, Receiver<RecordBatch>) {
         let (sender, receiver) = bounded(RECORD_CHANNEL_CAPACITY);
         (Self { sender, batch: Vec::with_capacity(RECORD_BATCH_SIZE) }, receiver)
@@ -683,7 +685,10 @@ impl RecordSink {
     ///
     /// Buffered records are dropped: the stream is being abandoned, and sending
     /// them would only delay the abort.
-    pub(super) fn fail(self, error: anyhow::Error) {
+    pub(super) fn fail(mut self, error: anyhow::Error) {
+        // Deliberate: this abort is the error the caller should see, so clear
+        // the buffer before dropping rather than let `Drop` report a second one.
+        self.batch.clear();
         // If the sorter already hung up it is failing on its own error, which
         // is the one the user should see; dropping ours is correct.
         let _ = self.sender.send(Err(error));
@@ -696,6 +701,31 @@ impl RecordSink {
         }
         let batch = std::mem::replace(&mut self.batch, Vec::with_capacity(RECORD_BATCH_SIZE));
         self.sender.send(Ok(batch)).is_ok()
+    }
+}
+
+impl Drop for RecordSink {
+    /// Report records still buffered when the sink is abandoned.
+    ///
+    /// Dropping the sender is how end-of-stream is signalled, so a sink dropped
+    /// with a partial batch — a `?` on the generator's path, or a panic —
+    /// looked exactly like a clean end of input: the sort finished and wrote a
+    /// complete, short output. Sending the loss as the stream's terminal error
+    /// makes the sort abort instead, so no truncated output is written.
+    ///
+    /// [`Self::finish`] and [`Self::fail`] both leave the buffer empty, so this
+    /// is a no-op after either of them.
+    fn drop(&mut self) {
+        if self.batch.is_empty() {
+            return;
+        }
+        let unflushed = self.batch.len();
+        // A closed receiver means the sort already failed on its own error,
+        // which is the one to report; ours would only mask it.
+        let _ = self.sender.send(Err(anyhow!(
+            "The record generator was abandoned with {unflushed} generated record(s) still \
+             buffered; they were never handed to the sort"
+        )));
     }
 }
 
@@ -1925,5 +1955,101 @@ mod tests {
             "100 positions should span at least 2 chromosomes, got {}",
             unique_chroms.len()
         );
+    }
+
+    // ========================================================================
+    // RecordSink tests
+    // ========================================================================
+
+    /// Build a minimal named record for the sink tests.
+    fn sink_record(name: &str) -> RawRecord {
+        let mut builder = fgumi_raw_bam::SamBuilder::new();
+        builder
+            .read_name(name.as_bytes())
+            .flags(fgumi_raw_bam::flags::UNMAPPED)
+            .sequence(b"ACGT")
+            .qualities(&[30; 4]);
+        builder.build()
+    }
+
+    /// The names the sink actually delivered, in order, plus any error it sent.
+    fn drain(receiver: &Receiver<RecordBatch>) -> (Vec<String>, Vec<String>) {
+        let mut names = Vec::new();
+        let mut errors = Vec::new();
+        for batch in receiver {
+            match batch {
+                Ok(records) => names.extend(
+                    records
+                        .iter()
+                        .map(|r| String::from_utf8_lossy(fgumi_raw_bam::read_name(r)).into_owned()),
+                ),
+                Err(e) => errors.push(format!("{e:#}")),
+            }
+        }
+        (names, errors)
+    }
+
+    /// `finish` must deliver the last partial batch, by record identity.
+    #[test]
+    fn test_record_sink_finish_delivers_the_partial_batch() {
+        let (mut sink, receiver) = RecordSink::new();
+        assert!(sink.send(sink_record("readA")), "the receiver is still open");
+        assert!(sink.send(sink_record("readB")), "the receiver is still open");
+        assert!(sink.finish(), "finish must succeed while the receiver is open");
+
+        let (names, errors) = drain(&receiver);
+        assert_eq!(names, vec!["readA".to_string(), "readB".to_string()]);
+        assert!(errors.is_empty(), "a clean finish must not report an error: {errors:?}");
+    }
+
+    /// Dropping a sink with records still buffered must abort the sort.
+    ///
+    /// Dropping the sender is what signals end-of-stream, so a sink abandoned
+    /// with a partial batch — a `?` on the generator's path, or a panic —
+    /// used to look exactly like a clean end of input: the sort finished and
+    /// wrote a complete, short BAM. Reporting the loss as the stream's terminal
+    /// error is what makes the sort fail instead.
+    #[test]
+    fn test_record_sink_drop_reports_the_unflushed_batch() {
+        let (mut sink, receiver) = RecordSink::new();
+        assert!(sink.send(sink_record("readA")), "the receiver is still open");
+        drop(sink);
+
+        let (names, errors) = drain(&receiver);
+        assert!(
+            names.is_empty(),
+            "an abandoned partial batch must not be delivered as if it were complete: {names:?}"
+        );
+        assert_eq!(errors.len(), 1, "the stream must end in exactly one error: {errors:?}");
+        assert!(
+            errors[0].contains("1 generated record"),
+            "the error must name how many records were left unflushed, got: {}",
+            errors[0]
+        );
+    }
+
+    /// A finished sink has nothing left, so its drop must stay silent.
+    #[test]
+    fn test_record_sink_drop_after_finish_reports_nothing() {
+        let (mut sink, receiver) = RecordSink::new();
+        assert!(sink.send(sink_record("readA")), "the receiver is still open");
+        assert!(sink.finish(), "finish must succeed while the receiver is open");
+
+        let (names, errors) = drain(&receiver);
+        assert_eq!(names, vec!["readA".to_string()]);
+        assert!(errors.is_empty(), "a finished sink must not also report a loss: {errors:?}");
+    }
+
+    /// `fail` abandons its buffer deliberately, and must report only its own error.
+    #[test]
+    fn test_record_sink_fail_reports_only_the_generator_error() {
+        let (mut sink, receiver) = RecordSink::new();
+        assert!(sink.send(sink_record("readA")), "the receiver is still open");
+        sink.fail(anyhow!("generator exploded"));
+
+        let (names, errors) = drain(&receiver);
+        assert!(names.is_empty(), "an aborted stream delivers no records: {names:?}");
+        assert_eq!(errors.len(), 1, "the abort must not be followed by a drop error: {errors:?}");
+        assert!(errors[0].contains("generator exploded"), "got: {}", errors[0]);
     }
 }

--- a/src/lib/commands/simulate/grouped_reads.rs
+++ b/src/lib/commands/simulate/grouped_reads.rs
@@ -309,7 +309,9 @@ impl GroupedReads {
         match result {
             // Flush the final partial batch, then close the stream.
             Ok(total_pairs) => {
-                sink.finish();
+                // `false` means the sort had already hung up on its own error,
+                // which `sort_records` surfaces; reporting ours would mask it.
+                let _delivered = sink.finish();
                 Ok(total_pairs)
             }
             // Surface the failure to the sort so it aborts instead of treating

--- a/src/lib/commands/simulate/mapped_reads.rs
+++ b/src/lib/commands/simulate/mapped_reads.rs
@@ -316,7 +316,9 @@ impl MappedReads {
         match result {
             // Flush the final partial batch, then close the stream.
             Ok(total_pairs) => {
-                sink.finish();
+                // `false` means the sort had already hung up on its own error,
+                // which `sort_records` surfaces; reporting ours would mask it.
+                let _delivered = sink.finish();
                 Ok(total_pairs)
             }
             // Surface the failure to the sort so it aborts instead of treating

--- a/src/lib/grouper.rs
+++ b/src/lib/grouper.rs
@@ -549,19 +549,27 @@ impl Grouper for RecordPositionGrouper {
     }
 
     fn finish(&mut self) -> io::Result<Option<Self::Group>> {
-        if !self.current_records.is_empty() {
-            debug_assert!(
-                self.current_group_key.is_some(),
-                "RecordPositionGrouper has {} buffered records but no group key",
-                self.current_records.len()
-            );
-            if let Some(key) = self.current_group_key.take() {
-                let records = std::mem::take(&mut self.current_records);
-                self.current_position_key = None;
-                return Ok(Some(RawPositionGroup { group_key: key, records }));
-            }
+        if self.current_records.is_empty() {
+            return Ok(None);
         }
-        Ok(None)
+
+        // Unconditional, not a `debug_assert!`: the assertion compiled out in
+        // release builds, so the `if let` below simply failed and the buffered
+        // records were dropped on the floor while `has_pending()` went on
+        // reporting them. Buffered records with no key to emit them under are a
+        // bug in this grouper, and reporting it is the only way the caller can
+        // tell that data was left behind.
+        let Some(key) = self.current_group_key.take() else {
+            return Err(io::Error::other(format!(
+                "RecordPositionGrouper reached EOF with {} buffered record(s) but no group key; \
+                 the records cannot be emitted and must not be discarded",
+                self.current_records.len()
+            )));
+        };
+
+        let records = std::mem::take(&mut self.current_records);
+        self.current_position_key = None;
+        Ok(Some(RawPositionGroup { group_key: key, records }))
     }
 
     fn has_pending(&self) -> bool {
@@ -1517,6 +1525,68 @@ mod tests {
     fn test_record_position_grouper_default_impl() {
         let grouper = RecordPositionGrouper::default();
         assert!(!grouper.has_pending());
+    }
+
+    /// `finish` must hand back every record it is still holding, by identity.
+    ///
+    /// The contract the release-only flush bug broke: the records buffered for
+    /// the last position are the records the final group contains. A count-only
+    /// assertion would pass on a flush that emitted the wrong records, so this
+    /// compares read names.
+    #[test]
+    fn test_record_position_grouper_finish_emits_every_buffered_record() {
+        let mut grouper = RecordPositionGrouper::new();
+        for name in [b"readA", b"readB", b"readC"] {
+            let decoded = decoded_via_decode(PRIMARY_PAIRED, 99, Some("4M"), name);
+            let emitted =
+                grouper.add_records(vec![decoded]).expect("records at one position accumulate");
+            assert!(emitted.is_empty(), "a single position emits nothing before finish");
+        }
+
+        let group = grouper
+            .finish()
+            .expect("finish must succeed with a group key set")
+            .expect("the buffered position must be emitted");
+        let names: Vec<Vec<u8>> =
+            group.records.iter().map(|r| fgumi_raw_bam::read_name(&r.data).to_vec()).collect();
+        assert_eq!(
+            names,
+            vec![b"readA".to_vec(), b"readB".to_vec(), b"readC".to_vec()],
+            "finish must emit exactly the buffered records, in order"
+        );
+        assert!(!grouper.has_pending(), "a flushed grouper must report nothing pending");
+    }
+
+    /// Records that cannot be emitted must be reported, not dropped.
+    ///
+    /// The flush used to sit behind a `debug_assert!` that the group key was
+    /// set. In a release build the assertion compiles out, the `if let
+    /// Some(key)` fails, and `finish` returns `Ok(None)` with the records still
+    /// buffered — silent data loss that `has_pending()` then reports forever.
+    /// The check is unconditional now, so the loss is an error in every build
+    /// profile. Only the internals can reach this state, which is exactly why
+    /// the old assertion could not observe it in a release binary.
+    #[test]
+    fn test_record_position_grouper_finish_rejects_records_it_cannot_emit() {
+        let mut grouper = RecordPositionGrouper::new();
+        let decoded = decoded_via_decode(PRIMARY_PAIRED, 99, Some("4M"), b"readA");
+        grouper.add_records(vec![decoded]).expect("one record accumulates");
+
+        // Drive the inconsistency the `debug_assert!` claimed to rule out.
+        grouper.current_group_key = None;
+
+        let err = grouper
+            .finish()
+            .expect_err("buffered records with no group key must not be discarded silently");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("1 buffered record"),
+            "the error must name how many records were left unflushed, got: {msg}"
+        );
+        assert!(
+            grouper.has_pending(),
+            "the records must still be held, not discarded, when finish fails"
+        );
     }
 
     // ========================================================================

--- a/src/lib/simulate/parallel_gzip_writer.rs
+++ b/src/lib/simulate/parallel_gzip_writer.rs
@@ -168,6 +168,16 @@ impl ParallelGzipWriter {
     }
 
     /// The I/O writer thread main loop.
+    ///
+    /// Writes compressed blocks in strict serial order, buffering any that
+    /// arrive early.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a write fails, if a worker reported a compression
+    /// failure, or if a block is missing from the serial sequence once the
+    /// channel closes — writing around a gap would produce a valid gzip stream
+    /// with a hole in it.
     #[allow(clippy::needless_pass_by_value)]
     fn io_writer_loop<W: Write>(
         mut writer: W,
@@ -196,8 +206,18 @@ impl ParallelGzipWriter {
             }
         }
 
-        // Write any remaining pending blocks
-        for (_, block) in pending {
+        // Drain the remaining buffered blocks — any gap means a block was never
+        // produced, and writing around it yields a *valid* gzip file missing that
+        // block's payload: readable, complete-looking, and short. Mirrors the
+        // check in `fgumi-sort`'s `io_writer_loop`.
+        while let Some((&serial, _)) = pending.first_key_value() {
+            if serial != next_expected {
+                return Err(io::Error::other(format!(
+                    "missing compressed block {next_expected}: next available is {serial}; \
+                     the output would be silently truncated"
+                )));
+            }
+            let block = pending.remove(&serial).expect("key just checked");
             match block {
                 CompressedBlock::Ok { data, .. } => writer.write_all(&data)?,
                 CompressedBlock::Err { serial, error } => {
@@ -206,6 +226,7 @@ impl ParallelGzipWriter {
                     )));
                 }
             }
+            next_expected += 1;
         }
 
         writer.flush()?;
@@ -336,6 +357,104 @@ mod tests {
     use std::fs::File;
     use std::io::Read;
     use tempfile::NamedTempFile;
+
+    /// A sink that keeps every byte written to it, so a test can decode the
+    /// stream the I/O loop actually produced.
+    #[derive(Clone)]
+    struct SharedSink(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl SharedSink {
+        fn new() -> Self {
+            Self(std::sync::Arc::new(std::sync::Mutex::new(Vec::new())))
+        }
+
+        /// The bytes written so far, decompressed as a (possibly concatenated)
+        /// gzip stream. An empty sink decodes to nothing — `MultiGzDecoder`
+        /// rejects zero bytes as a truncated header, which is not what a sink
+        /// that was never written to means.
+        fn decoded(&self) -> Vec<u8> {
+            let raw = self.0.lock().expect("sink mutex").clone();
+            if raw.is_empty() {
+                return Vec::new();
+            }
+            let mut decoded = Vec::new();
+            MultiGzDecoder::new(raw.as_slice())
+                .read_to_end(&mut decoded)
+                .expect("the sink must hold a decodable gzip stream");
+            decoded
+        }
+    }
+
+    impl Write for SharedSink {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().expect("sink mutex").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Compress `payload` as block `serial`, ready to hand to the I/O loop.
+    fn compressed_block(serial: u64, payload: &[u8]) -> CompressedBlock {
+        let mut compressor = Compressor::new(CompressionLvl::default());
+        compress_block(UncompressedBlock { serial, data: payload.to_vec() }, &mut compressor)
+            .expect("compression of a small payload")
+    }
+
+    /// A gap in the serial sequence must fail, not be written around.
+    ///
+    /// The leftover drain used to emit whatever was still buffered in serial
+    /// order without checking for a gap, so a block that never arrived produced
+    /// a *valid* gzip file missing that block's payload — readable,
+    /// complete-looking, and short. `fgumi-sort`'s `io_writer_loop` already
+    /// rejects exactly this. The assertion is on the emitted bytes, not just on
+    /// the error: a file with a hole in it is the failure being pinned.
+    #[test]
+    fn test_io_writer_loop_rejects_a_gap_in_the_serial_sequence() {
+        let (tx, rx) = bounded::<CompressedBlock>(4);
+        // Serial 0 is never produced — it is the hole.
+        tx.send(compressed_block(1, b"BBBB")).expect("send block 1");
+        tx.send(compressed_block(2, b"CCCC")).expect("send block 2");
+        drop(tx);
+
+        let sink = SharedSink::new();
+        let err = ParallelGzipWriter::io_writer_loop(sink.clone(), rx)
+            .expect_err("a missing block must fail the write, not be skipped over");
+
+        assert!(
+            err.to_string().contains("missing compressed block 0"),
+            "the error must name the block that never arrived, got: {err}"
+        );
+        assert!(
+            sink.decoded().is_empty(),
+            "blocks past the gap were written anyway, leaving a valid gzip stream with a hole: {:?}",
+            String::from_utf8_lossy(&sink.decoded())
+        );
+    }
+
+    /// Blocks that merely arrive out of order still have to be drained in full.
+    ///
+    /// The gap check must not reject a run whose leftover blocks are contiguous
+    /// from `next_expected` — that is the ordinary case the drain exists for.
+    #[test]
+    fn test_io_writer_loop_drains_out_of_order_blocks() {
+        let (tx, rx) = bounded::<CompressedBlock>(4);
+        tx.send(compressed_block(2, b"CCCC")).expect("send block 2");
+        tx.send(compressed_block(0, b"AAAA")).expect("send block 0");
+        tx.send(compressed_block(1, b"BBBB")).expect("send block 1");
+        drop(tx);
+
+        let sink = SharedSink::new();
+        ParallelGzipWriter::io_writer_loop(sink.clone(), rx).expect("a complete run must succeed");
+
+        assert_eq!(
+            sink.decoded(),
+            b"AAAABBBBCCCC",
+            "every block must be written exactly once, in serial order"
+        );
+    }
 
     /// A sink that fails every write, to drive the I/O thread's error path.
     struct FailingSink;

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -31,9 +31,9 @@ use super::base::{
     OutputPipelineQueues, OutputPipelineState, PROGRESS_LOG_INTERVAL, PipelineConfig,
     PipelineLifecycle, PipelineStats, PipelineStep, PipelineValidationError, ProcessPipelineState,
     QueueSample, RawBlockBatch, ReorderBufferState, SerializePipelineState, SerializedBatch,
-    StepContext, WorkerCoreState, WorkerStateCommon, WritePipelineState, finalize_pipeline,
-    generic_worker_loop, handle_worker_panic, join_monitor_thread, join_worker_threads,
-    shared_try_step_compress,
+    StepContext, WorkerCoreState, WorkerStateCommon, WritePipelineState,
+    finalize_pipeline_with_buffers, generic_worker_loop, handle_worker_panic, join_monitor_thread,
+    join_worker_threads, shared_try_step_compress,
 };
 use super::deadlock::{
     DeadlockAction, DeadlockConfig, DeadlockState, QueueSnapshot, check_deadlock_and_restore,
@@ -98,6 +98,15 @@ impl BoundaryState {
     #[must_use]
     pub fn new_no_header() -> Self {
         Self { leftover: Vec::new(), work_buffer: Vec::new(), header_skipped: true }
+    }
+
+    /// Number of bytes currently held from an incomplete record.
+    ///
+    /// Non-zero at pipeline completion means input was read but never became a
+    /// record, so completion validation reports it.
+    #[must_use]
+    pub fn leftover_len(&self) -> usize {
+        self.leftover.len()
     }
 
     /// Parse BAM header and return the number of bytes consumed.
@@ -294,9 +303,23 @@ impl BoundaryState {
             offsets.push(cursor);
         }
 
-        if cursor == 0 {
-            return Ok(None);
+        // Fewer than four bytes left: not even a `block_size`, so the record's
+        // own length is unknown. The scan loop above cannot see this — it stops
+        // at `cursor + 4 > len` — and the tail used to be discarded, silently
+        // with `Ok(None)` when no complete record preceded it and by sitting
+        // past the final offset when one did.
+        if cursor < self.leftover.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!(
+                    "Incomplete BAM record at EOF: {} trailing byte(s) are too few to hold a \
+                     record length",
+                    self.leftover.len() - cursor
+                ),
+            ));
         }
+
+        debug_assert!(cursor > 0, "cursor == 0 is caught by the trailing-byte check above");
 
         Ok(Some(BoundaryBatch { buffer: std::mem::take(&mut self.leftover), offsets }))
     }
@@ -919,6 +942,12 @@ impl<G: Send, P: Send + MemoryEstimate> BamPipelineState<G, P> {
     /// Checks that:
     /// 1. All queues are empty
     /// 2. All batch counters match between stages
+    /// 3. The boundary finder holds no partial record
+    ///
+    /// The Group step's buffers are *not* visible here — the grouper and its
+    /// pending groups sit behind their own mutex — so
+    /// [`super::base::finalize_pipeline_with_buffers`] folds
+    /// [`GroupState::unflushed_buffers`] into this result.
     ///
     /// Note: Heap byte tracking is reported but advisory only (set to 0) because
     /// estimation can be imprecise. Only queue emptiness and counter checks
@@ -982,6 +1011,17 @@ impl<G: Send, P: Send + MemoryEstimate> BamPipelineState<G, P> {
             let write_reorder = self.output.write_reorder.lock();
             if !write_reorder.is_empty() {
                 non_empty_queues.push(format!("write_reorder ({})", write_reorder.len()));
+            }
+        }
+
+        // Check the boundary finder holds no partial record. Leftover bytes at
+        // completion are input that never became a record, which is exactly the
+        // internal-buffer case `PipelineLifecycle::validate_completion`
+        // documents (and which the FASTQ side already reports per stream).
+        {
+            let leftover_len = self.boundary_state.lock().leftover_len();
+            if leftover_len > 0 {
+                non_empty_queues.push(format!("boundary_leftover ({leftover_len})"));
             }
         }
 
@@ -1500,6 +1540,29 @@ impl<G: Send> GroupState<G> {
     #[must_use]
     pub fn has_pending(&self) -> bool {
         self.grouper.has_pending()
+    }
+
+    /// Names of this step's buffers that still hold data, for completion
+    /// validation.
+    ///
+    /// Two of the three states [`super::base::PipelineLifecycle::validate_completion`]
+    /// documents live here rather than on the pipeline state: groups that were
+    /// never pushed to Q4, and records the grouper is still holding after
+    /// [`Self::finish`]. The state cannot reach them — they sit behind this
+    /// step's own mutex — so the run function folds this list into the
+    /// validation result.
+    ///
+    /// Empty means the Group step is genuinely drained.
+    #[must_use]
+    pub fn unflushed_buffers(&self) -> Vec<String> {
+        let mut buffers = Vec::new();
+        if !self.pending_groups.is_empty() {
+            buffers.push(format!("group_pending_groups ({})", self.pending_groups.len()));
+        }
+        if self.grouper.has_pending() {
+            buffers.push("grouper (partial group pending)".to_string());
+        }
+        buffers
     }
 }
 
@@ -3531,6 +3594,19 @@ where
         progress.log_if_needed(record_count);
     }
 
+    // The threaded path validates completion against the pipeline state; this
+    // path has no such state, so the same contract is checked directly here. A
+    // grouper that still reports pending records after `finish()` has swallowed
+    // them, and finishing the output now would leave a valid, complete-looking
+    // BAM missing exactly those records.
+    if grouper.has_pending() {
+        return Err(io::Error::other(PipelineValidationError {
+            non_empty_queues: vec!["grouper (partial group pending after finish)".to_string()],
+            counter_mismatches: Vec::new(),
+            leaked_heap_bytes: 0,
+        }));
+    }
+
     // Flush any remaining data in compression buffer
     compressor.flush()?;
     compressor.write_blocks_to(output.as_mut())?;
@@ -3794,8 +3870,11 @@ where
     join_worker_threads(handles)?;
     join_monitor_thread(monitor_handle);
 
-    // Finalize: check errors, flush output, log stats
-    let result = finalize_pipeline(&*state);
+    // Finalize: check errors, flush output, log stats. The Group step's own
+    // buffers are folded in: the state cannot reach them, and records stranded
+    // in the grouper (or groups never pushed to Q4) are data loss that would
+    // otherwise be reported as a clean run.
+    let result = finalize_pipeline_with_buffers(&*state, || group_state.lock().unflushed_buffers());
 
     // Finalize secondary output writer (if present)
     if let Some(ref secondary_mutex) = state.output.secondary_output {
@@ -4530,8 +4609,181 @@ mod tests {
     }
 
     // ========================================================================
+    // BoundaryState Tests
+    // ========================================================================
+
+    /// Frame `payload` as a BAM record: a little-endian `block_size` prefix
+    /// followed by the payload bytes. `find_boundaries` only reads that prefix,
+    /// so the payload's contents are irrelevant to boundary finding.
+    fn framed_record(payload: &[u8]) -> Vec<u8> {
+        let mut framed =
+            u32::try_from(payload.len()).expect("payload fits in u32").to_le_bytes()[..].to_vec();
+        framed.extend_from_slice(payload);
+        framed
+    }
+
+    /// A record fragment too short to hold even a `block_size` must fail at EOF.
+    ///
+    /// `finish` scanned with `cursor + 4 <= leftover.len()`, so a 1-3 byte tail
+    /// fell out of the loop and was dropped: with no complete record ahead of it
+    /// the whole leftover was discarded with `Ok(None)`, and with one it was
+    /// left past the final offset where nothing reads it. Either way the run
+    /// ended successfully on a truncated file, which its own documentation
+    /// already promised was an error.
+    #[rstest]
+    #[case::fragment_only(0)]
+    #[case::record_then_fragment(1)]
+    fn test_boundary_state_finish_rejects_a_sub_header_fragment(#[case] complete_records: usize) {
+        let mut state = BoundaryState::new_no_header();
+        let record = framed_record(&[b'A'; 32]);
+        let mut data: Vec<u8> =
+            std::iter::repeat_n(record.as_slice(), complete_records).flatten().copied().collect();
+        // Three bytes: a truncated `block_size`, so its record length is unknown.
+        data.extend_from_slice(&[0x01, 0x02, 0x03]);
+
+        let batch = state.find_boundaries(&data).expect("complete records must be found");
+        assert_eq!(
+            batch.offsets.len() - 1,
+            complete_records,
+            "only the complete records may be emitted before EOF"
+        );
+        assert_eq!(
+            batch.buffer,
+            data[..data.len() - 3],
+            "the complete records must come through byte-for-byte"
+        );
+
+        let err = state
+            .finish()
+            .expect_err("a record fragment at EOF must fail, as the doc comment promises");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        assert!(
+            err.to_string().contains("3 trailing byte"),
+            "the error must name the number of bytes left unread, got: {err}"
+        );
+    }
+
+    /// A record split across two calls must be reassembled, not rejected.
+    ///
+    /// The control for the case above: leftover bytes are the normal state
+    /// between blocks, so the EOF check must fire only at EOF and only on bytes
+    /// that never became a record.
+    #[test]
+    fn test_boundary_state_reassembles_a_record_split_across_calls() {
+        let mut state = BoundaryState::new_no_header();
+        let record = framed_record(&[b'C'; 32]);
+        let (head, tail) = record.split_at(20);
+
+        let first = state.find_boundaries(head).expect("a partial record is held, not rejected");
+        assert_eq!(first.offsets.len(), 1, "no complete record yet");
+
+        let second = state.find_boundaries(tail).expect("the completing chunk must parse");
+        assert_eq!(second.buffer, record, "the reassembled record must be byte-identical");
+
+        assert!(
+            state.finish().expect("nothing may remain after the record completed").is_none(),
+            "a fully consumed stream leaves no final batch"
+        );
+    }
+
+    // ========================================================================
     // Pipeline Validation Tests
     // ========================================================================
+
+    /// A grouper that holds records forever, to drive completion validation.
+    struct StuckGrouper;
+
+    impl Grouper for StuckGrouper {
+        type Group = ();
+
+        fn add_records(&mut self, _records: Vec<DecodedRecord>) -> io::Result<Vec<Self::Group>> {
+            Ok(Vec::new())
+        }
+
+        fn finish(&mut self) -> io::Result<Option<Self::Group>> {
+            Ok(None)
+        }
+
+        fn has_pending(&self) -> bool {
+            true
+        }
+    }
+
+    /// A grouper that is genuinely drained.
+    struct DrainedGrouper;
+
+    impl Grouper for DrainedGrouper {
+        type Group = ();
+
+        fn add_records(&mut self, _records: Vec<DecodedRecord>) -> io::Result<Vec<Self::Group>> {
+            Ok(Vec::new())
+        }
+
+        fn finish(&mut self) -> io::Result<Option<Self::Group>> {
+            Ok(None)
+        }
+
+        fn has_pending(&self) -> bool {
+            false
+        }
+    }
+
+    /// Leftover bytes in the boundary finder are data loss and must be reported.
+    ///
+    /// `base.rs` names boundary leftovers as one of the three internal buffers
+    /// completion validation exists to catch; the BAM implementation checked
+    /// none of them. The FASTQ side already reports its own per-stream
+    /// leftovers, so this brings the two into line.
+    #[test]
+    fn test_validation_detects_boundary_leftover() {
+        let state = create_test_state(0);
+        state.read_done.store(true, Ordering::SeqCst);
+        state.group_done.store(true, Ordering::SeqCst);
+
+        {
+            let mut boundary = state.boundary_state.lock();
+            *boundary = BoundaryState::new_no_header();
+            // A record announcing 32 bytes but delivering 8: held as leftover.
+            let mut partial = 32u32.to_le_bytes().to_vec();
+            partial.extend_from_slice(&[b'A'; 8]);
+            boundary.find_boundaries(&partial).expect("a partial record is held");
+        }
+
+        let err = state.validate_completion().expect_err("held bytes must fail validation");
+        assert!(
+            err.non_empty_queues.iter().any(|s| s.contains("boundary_leftover")),
+            "validation must name the boundary leftover, got: {err}"
+        );
+    }
+
+    /// The Group step's own buffers are the other two states `base.rs` names.
+    ///
+    /// The pipeline state cannot see them — the grouper and its pending groups
+    /// live behind a separate mutex — so they are folded into the same
+    /// validation result by the run function.
+    #[test]
+    fn test_group_state_reports_unflushed_records_and_groups() {
+        let mut group_state = GroupState::new(Box::new(StuckGrouper));
+        assert_eq!(
+            group_state.unflushed_buffers(),
+            vec!["grouper (partial group pending)".to_string()],
+            "a grouper reporting pending records must be named"
+        );
+
+        group_state.pending_groups.push_back(());
+        group_state.pending_groups.push_back(());
+        assert_eq!(
+            group_state.unflushed_buffers(),
+            vec![
+                "group_pending_groups (2)".to_string(),
+                "grouper (partial group pending)".to_string(),
+            ],
+            "groups never pushed to Q4 must be named alongside the grouper"
+        );
+
+        let drained: GroupState<()> = GroupState::new(Box::new(DrainedGrouper));
+        assert!(drained.unflushed_buffers().is_empty(), "a drained Group step must report nothing");
+    }
 
     #[test]
     fn test_validation_passes_when_complete() {

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -2176,6 +2176,12 @@ pub trait PipelineLifecycle {
     /// 2. All batch counters match (no batches lost between stages)
     /// 3. Internal buffers are empty (grouper state, boundary leftovers)
     ///
+    /// An implementation can only check the buffers its state owns. Buffers held
+    /// by a stage behind its own lock — the BAM pipeline's grouper and its
+    /// pending groups — are folded into the same result by
+    /// [`finalize_pipeline_with_buffers`], which the run function calls in place
+    /// of [`finalize_pipeline`].
+    ///
     /// Note: Heap byte tracking is reported in `PipelineValidationError::leaked_heap_bytes`
     /// but is currently advisory only (implementations set it to 0) because estimation
     /// can be imprecise. Only queue emptiness and counter checks cause validation failure.
@@ -2355,13 +2361,36 @@ pub fn join_monitor_thread(handle: Option<thread::JoinHandle<()>>) {
 ///
 /// Returns an I/O error if an error occurred during processing or output flush fails.
 pub fn finalize_pipeline<S: PipelineLifecycle>(state: &S) -> io::Result<u64> {
+    finalize_pipeline_with_buffers(state, Vec::new)
+}
+
+/// Finalize a pipeline, folding in buffers the state itself cannot see.
+///
+/// Same as [`finalize_pipeline`], except that `unflushed_buffers` names any
+/// stage-local buffer that still holds data — the BAM pipeline's Group step
+/// keeps its grouper and its pending groups behind their own mutex, so
+/// `validate_completion` has no way to reach them on its own. The closure runs
+/// only after the error check, so a real failure is still reported ahead of the
+/// buffers it stranded.
+///
+/// # Errors
+///
+/// Returns an I/O error if an error occurred during processing, if completion
+/// validation fails (including on any named buffer), or if the output flush
+/// fails.
+pub fn finalize_pipeline_with_buffers<S, F>(state: &S, unflushed_buffers: F) -> io::Result<u64>
+where
+    S: PipelineLifecycle,
+    F: FnOnce() -> Vec<String>,
+{
     // Check for errors
     if let Some(error) = state.take_error() {
         return Err(error);
     }
 
     // Validate pipeline completion to detect data loss
-    state.validate_completion().map_err(io::Error::other)?;
+    merge_unflushed_buffers(state.validate_completion(), unflushed_buffers())
+        .map_err(io::Error::other)?;
 
     // Flush output
     state.flush_output()?;
@@ -2372,6 +2401,33 @@ pub fn finalize_pipeline<S: PipelineLifecycle>(state: &S) -> io::Result<u64> {
     }
 
     Ok(state.items_written())
+}
+
+/// Fold externally-reported buffers into a completion validation result.
+///
+/// Buffers named here are reported exactly like a non-empty queue, so a caller
+/// sees one error listing everything that still held data rather than learning
+/// about the queues and the stage buffers separately.
+///
+/// # Errors
+///
+/// Returns `result`'s own error when `unflushed_buffers` is empty, and
+/// otherwise a `PipelineValidationError` naming those buffers — extending
+/// `result`'s error if it already had one.
+pub fn merge_unflushed_buffers(
+    result: Result<(), PipelineValidationError>,
+    unflushed_buffers: Vec<String>,
+) -> Result<(), PipelineValidationError> {
+    if unflushed_buffers.is_empty() {
+        return result;
+    }
+    let mut error = result.err().unwrap_or_else(|| PipelineValidationError {
+        non_empty_queues: Vec::new(),
+        counter_mismatches: Vec::new(),
+        leaked_heap_bytes: 0,
+    });
+    error.non_empty_queues.extend(unflushed_buffers);
+    Err(error)
 }
 
 // ============================================================================
@@ -5260,6 +5316,74 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+
+    /// Buffers a state cannot see must fail an otherwise-clean validation.
+    ///
+    /// The BAM pipeline's Group step keeps its grouper and its pending groups
+    /// behind their own mutex, so `validate_completion` returns `Ok` while
+    /// records sit in them. Folding those names in here is what turns a
+    /// silently truncated run into a failure.
+    #[test]
+    fn test_merge_unflushed_buffers_fails_an_otherwise_clean_validation() {
+        let merged =
+            merge_unflushed_buffers(Ok(()), vec!["grouper (partial group pending)".into()])
+                .expect_err("named buffers must fail validation");
+        assert_eq!(merged.non_empty_queues, vec!["grouper (partial group pending)".to_string()]);
+        assert!(merged.counter_mismatches.is_empty());
+    }
+
+    /// One error listing everything, not two reported separately.
+    #[test]
+    fn test_merge_unflushed_buffers_extends_an_existing_error() {
+        let existing = Err(PipelineValidationError {
+            non_empty_queues: vec!["q4_groups (2)".to_string()],
+            counter_mismatches: vec![
+                "batches_grouped (1) != batches_boundary_found (2)".to_string(),
+            ],
+            leaked_heap_bytes: 0,
+        });
+
+        let merged = merge_unflushed_buffers(existing, vec!["group_pending_groups (3)".into()])
+            .expect_err("the existing failure must be preserved");
+        assert_eq!(
+            merged.non_empty_queues,
+            vec!["q4_groups (2)".to_string(), "group_pending_groups (3)".to_string()],
+            "both the queue and the stage buffer must be reported together"
+        );
+        assert_eq!(
+            merged.counter_mismatches,
+            vec!["batches_grouped (1) != batches_boundary_found (2)".to_string()],
+            "the original counter mismatch must survive the merge"
+        );
+    }
+
+    /// Nothing buffered must leave the result exactly as it was, either way.
+    #[rstest]
+    #[case::clean(true)]
+    #[case::already_failing(false)]
+    fn test_merge_unflushed_buffers_passes_through_when_nothing_is_buffered(
+        #[case] validation_passed: bool,
+    ) {
+        let result = if validation_passed {
+            Ok(())
+        } else {
+            Err(PipelineValidationError {
+                non_empty_queues: vec!["q1_raw_blocks (1)".to_string()],
+                counter_mismatches: Vec::new(),
+                leaked_heap_bytes: 0,
+            })
+        };
+
+        let merged = merge_unflushed_buffers(result, Vec::new());
+        assert_eq!(
+            merged.is_ok(),
+            validation_passed,
+            "an empty buffer list must not change the outcome"
+        );
+        if let Err(err) = merged {
+            assert_eq!(err.non_empty_queues, vec!["q1_raw_blocks (1)".to_string()]);
+        }
+    }
 
     #[test]
     fn test_stats_record_step_timing() {

--- a/tests/integration/test_bam_pipeline.rs
+++ b/tests/integration/test_bam_pipeline.rs
@@ -6,6 +6,7 @@ use noodles::bam;
 use noodles::sam::Header;
 use noodles::sam::alignment::RecordBuf;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
+use rstest::rstest;
 use std::fs::File;
 use std::io::{self, BufReader};
 use std::path::Path;
@@ -397,4 +398,80 @@ fn test_error_corrupted_bgzf() {
 
     // Error could be from header reading or BGZF decompression
     assert!(result.is_err(), "Expected error for corrupted BAM file");
+}
+
+/// A grouper that swallows every record: it buffers them, emits nothing, and
+/// reports the buffer through `has_pending()`.
+///
+/// This is the shape of an end-of-stream flush that discards rather than fails
+/// — the pipeline consumed the records, wrote none of them, and reported
+/// success. Completion validation exists to catch exactly that.
+struct SwallowingGrouper {
+    buffered: usize,
+}
+
+impl Grouper for SwallowingGrouper {
+    type Group = RecordBuf;
+
+    fn add_records(&mut self, records: Vec<DecodedRecord>) -> io::Result<Vec<Self::Group>> {
+        self.buffered += records.len();
+        Ok(Vec::new())
+    }
+
+    fn finish(&mut self) -> io::Result<Option<Self::Group>> {
+        // Deliberately reports "nothing left" while still holding records.
+        Ok(None)
+    }
+
+    fn has_pending(&self) -> bool {
+        self.buffered > 0
+    }
+}
+
+/// A grouper still holding records at EOF must fail the run, not truncate it.
+///
+/// Both pipeline paths are pinned because they finalize differently: the
+/// single-threaded path calls the grouper's `finish()` inline, and the threaded
+/// path validates completion against the shared state. Before this check,
+/// either one accepted a grouper that reported `has_pending()` after `finish()`
+/// and wrote a valid, complete-looking BAM with none of the input in it.
+#[rstest]
+#[case::single_threaded(1)]
+#[case::threaded(4)]
+fn test_pipeline_rejects_a_grouper_still_holding_records(#[case] threads: usize) {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    let header = create_minimal_header("chr1", 10000);
+    let input_records = create_test_bam(&input_bam, &header);
+    assert!(!input_records.is_empty(), "precondition: the input must hold records to lose");
+
+    let config = BamPipelineConfig::new(threads, 6);
+    let result = run_bam_pipeline_with_grouper(
+        config,
+        &input_bam,
+        &output_bam,
+        |_| Box::new(SwallowingGrouper { buffered: 0 }),
+        |r: RecordBuf| Ok(r),
+        |r: RecordBuf, h: &Header, output: &mut Vec<u8>| serialize_bam_record_into(&r, h, output),
+    );
+
+    let err = match result {
+        Err(err) => err,
+        Ok(count) => {
+            let written = read_bam_records(&output_bam);
+            panic!(
+                "the pipeline reported success ({count} records) with the grouper still \
+                 holding {} record(s); the output holds {} of {} input records",
+                input_records.len(),
+                written.len(),
+                input_records.len()
+            );
+        }
+    };
+    assert!(
+        err.to_string().contains("grouper (partial group pending"),
+        "the failure must name the grouper's unflushed records, got: {err}"
+    );
 }


### PR DESCRIPTION
Closes #782.

## What was wrong

Five end-of-stream paths ended a run *successfully* while still holding data, so the loss looked exactly like a clean finish. Each site was re-verified against `main` before it was touched — the results are in the table, including the one the issue got wrong.

| # | Site | Real? | Failure it produced |
| --- | --- | --- | --- |
| 1 | `simulate/parallel_gzip_writer.rs` final flush | yes | a valid gzip file with a hole in it |
| 2 | `RecordPositionGrouper::finish` | yes | release-only: buffered records dropped, `has_pending()` still `true` |
| 3 | `BoundaryState::finish` | yes | a 1-3 byte record fragment discarded at EOF |
| 4 | `validate_completion` (BAM) | yes | none of the three internal buffers it documents were checked |
| 4b | `validate_completion` (FASTQ) | **no — already safe** | it already checks pair state, block-merge state and per-stream boundary leftovers |
| 5 | `simulate/common.rs` `RecordSink` | partly | last partial batch lost on drop; the two call sites' discarded `bool` is benign |
| 6 | failed `extract` leaves an empty BAM | out of scope | output-file lifecycle, not a flush path — see below |

**Site 1** wrote whatever reorder blocks were left, in serial order, with no gap check. `fgumi-sort/src/bgzf_io.rs` already rejects exactly this; the fix follows it, including its wording.

**Site 2** guarded its flush with `debug_assert!`. With assertions compiled out the `if let Some(key)` simply failed, `finish` returned `Ok(None)`, and the records stayed buffered forever.

**Site 3** scanned with `cursor + 4 <= leftover.len()`, so a 1-3 byte tail fell out of the loop: discarded with `Ok(None)` when no complete record preceded it, and left past the final offset when one did. Its own doc comment already promised an error. **This one has real reach**: the `--threads` path never calls `finish()` at all, so a truncated BAM's trailing bytes were dropped there too — now caught by site 4's `boundary_leftover` check.

**Site 4** — `base.rs` says completion validation covers "internal buffers ... (grouper state, boundary leftovers)". The BAM implementation checked none of the three. Two of them are not reachable from the pipeline state at all: the grouper and its pending groups sit behind the Group step's own mutex.

**Site 5** — `RecordSink` had no `Drop`, and dropping the sender is what signals end-of-stream, so an abandoned sink looked like a clean end of input and the sort wrote a short output. The issue also flags the two call sites discarding `finish()`'s `bool`; that turned out benign — `false` only happens when the sorter has already hung up, and `sort_records` surfaces that error itself. The call sites now say so instead of discarding silently.

### Corrections to the issue

- **The FASTQ side does not have the same `validate_completion` gap.** It already reports `pair_state`, `block_merge_state` and every stream's `boundary_leftover`. Its BGZF branch skips the boundary-leftover check, but `boundary_state` is only touched on the gzip/plain path (`fastq_try_step_find_boundaries` runs only when `!inputs_are_bgzf`), so there is nothing to miss. No change was needed there.
- **Site 5's "both call sites discard `finish()`'s bool" is not itself a loss.** The drop path is; the discarded bool is not.
- **Site 6 stayed out of scope**, as the issue itself suggests and as #776's agent decided. It is about when the output file is created and finalized, not about a flush path, and fixing it means an output-lifecycle change (temp-file + persist, or unlink-on-error) across every command. It did not fall out naturally: this PR makes the pipeline *return* an error where it used to succeed, which is the input side of the same problem, but the empty-BAM artifact is still written.

## One site the issue does not list

Sweeping for site 2's shape — *a `debug_assert!` standing in for a check whose failure is silent data loss in release* — found `ReorderBuffer::insert_with_size` (`crates/fgumi-bam-io/src/reorder.rs`), which asserted **both** of its preconditions that way. Compiled out, a duplicate serial overwrote the buffered item, dropping a whole batch of records while `count` and `heap_bytes` counted it twice; and a serial below the base underflowed the `u64` `seq - next_seq`, leaving the extend loop growing the buffer toward an unreachable index. `.coderabbit.yaml` calls reorder accounting "data-integrity-critical" for exactly this reason. It is a separate commit (`fix(bam-io): ...`) so it can be split out if preferred.

## The fix

- **Site 1** — the leftover drain walks `first_key_value()` and errors on a gap: `missing compressed block 0: next available is 1; the output would be silently truncated`.
- **Site 2** — the guard is unconditional and returns an error naming the record count, so it is observable in a release build (verified: `cargo nextest run --release` on that test).
- **Site 3** — trailing bytes below a `block_size` are an `UnexpectedEof` naming how many.
- **Site 4** — `validate_completion` reports `boundary_leftover (n)`; `finalize_pipeline_with_buffers` folds `GroupState::unflushed_buffers()` (`group_pending_groups (n)`, `grouper (partial group pending)`) into the same `PipelineValidationError`, so one error lists everything that still held data. The single-threaded path, which has no pipeline state, checks the grouper directly after `finish()`.
- **Site 5** — `Drop for RecordSink` sends the loss as the stream's terminal error, so the sort aborts rather than finishing short. `finish()` and `fail()` both leave the buffer empty, so it is a no-op after either.

## Tests

TDD — every test below was written first and observed failing against `main`:

```
the pipeline reported success (0 records) with the grouper still holding 30 record(s);
the output holds 0 of 30 input records
```

```
thread '...test_io_writer_loop_rejects_a_gap_in_the_serial_sequence' panicked:
a missing block must fail the write, not be skipped over: ()
```

- `test_io_writer_loop_rejects_a_gap_in_the_serial_sequence` — asserts the **emitted bytes**, not just the error: on `main` the sink decodes to `BBBBCCCC`, a valid gzip stream missing block 0. Its control, `test_io_writer_loop_drains_out_of_order_blocks`, asserts `AAAABBBBCCCC` from blocks fed 2-0-1.
- `test_record_position_grouper_finish_rejects_records_it_cannot_emit` — drives the state the `debug_assert!` claimed to rule out, asserts the error names the count *and* that the records are still held. `test_record_position_grouper_finish_emits_every_buffered_record` pins the happy path by **read name**, not count.
- `test_boundary_state_finish_rejects_a_sub_header_fragment` (fragment-only and record-then-fragment) — asserts the error kind and text, and that the complete records came through **byte-for-byte**. Control: `test_boundary_state_reassembles_a_record_split_across_calls`.
- `test_pipeline_rejects_a_grouper_still_holding_records` (1 and 4 threads) — a grouper that swallows records must fail the run; on a wrongly-successful run it reports how many of the 30 input records reached the output.
- `test_validation_detects_boundary_leftover`, `test_group_state_reports_unflushed_records_and_groups`, and three `merge_unflushed_buffers` cases (clean, already-failing, nothing-buffered).
- Four `RecordSink` tests asserting delivered records **by name** plus the terminal error, covering `finish`, drop-with-buffer, drop-after-finish, and `fail`.
- Two `ReorderBuffer` `#[should_panic]` tests for the duplicate and stale serials.

Gate: `cargo ci-fmt`, `cargo ci-lint`, `cargo ci-test` (7,515 passed), `cargo ci-doctest`.

## Base

Based on **`main`**. #764, #772 and #775 all touch `bam.rs`/`base.rs`, but in the queue-memory accounting and the `try_step_*` bodies; this PR touches `BoundaryState`, `validate_completion`, `GroupState`, and the finalize helper, and needs nothing from them. #776 touches `fastq.rs`, which this PR does not modify at all — the FASTQ side turned out already safe. The one point of contact is textual proximity in `bam.rs`, not a semantic conflict.

## Behavior change

Marked breaking on the same reasoning as #776: a BAM whose last record is truncated used to produce a short output and exit 0, and now exits non-zero. The other four sites fire only on an internal invariant a correct run never reaches, so no well-formed input changes behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: command output changes: none on successful runs; EOF data-loss cases now fail instead; `unsafe`: none; memory bounds, queue capacity, and thread/backpressure policy: none.

Fix: reject unflushed or invalid EOF state across BAM, gzip, grouper, and simulation record sinks.

- Reject missing gzip block serials during final output draining.
- Report grouper flush failures in release builds.
- Reject truncated BAM fragments, boundary leftovers, pending groups, and unflushed group buffers.
- Report dropped `RecordSink` buffers as terminal errors.
- Reject duplicate and stale reorder serials without relying on `debug_assert!`.
- Add tests for each failure mode.
- Leave FASTQ validation and failed `extract` output-file handling unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->