### PR TITLE
fix(consensus): count and route reads dropped by downsampling

### DIFF
--- a/crates/fgumi-consensus/src/caller.rs
+++ b/crates/fgumi-consensus/src/caller.rs
@@ -436,6 +436,10 @@ pub enum RejectionReason {
     PotentialCollision,
     /// Template did not have a single primary FR pair of reads (codec)
     NotPrimaryFrPair,
+    /// Read was discarded by consensus downsampling (a deliberate `--max-reads` cap, not a
+    /// quality or alignment failure). Counted so `raw_reads_used` excludes it and routed to
+    /// the `--rejects` output (fgumi#724).
+    Downsampled,
     /// Other unspecified reason
     Other,
 }
@@ -464,6 +468,7 @@ impl RejectionReason {
             Self::HighDuplexDisagreement => 'H',
             Self::PotentialCollision => 'C',
             Self::NotPrimaryFrPair => 'R',
+            Self::Downsampled => 'd',
             Self::Other => 'O',
         }
     }
@@ -493,6 +498,7 @@ impl RejectionReason {
                 "Potential collisions (reads with the same MI but different strands)"
             }
             Self::NotPrimaryFrPair => "Template did not have a single primary FR pair of reads",
+            Self::Downsampled => "Downsampled to the maximum reads per consensus",
             Self::Other => "Other reason",
         }
     }
@@ -530,6 +536,9 @@ impl RejectionReason {
             Self::OrphanConsensus => CentralReason::OrphanConsensus,
             Self::PotentialCollision => CentralReason::DuplicateUmi,
             Self::NotPrimaryFrPair => CentralReason::NotPrimaryFrPair,
+            // fgumi-specific: fgbio has no downsampled rejection metric yet
+            // (fulcrumgenomics/fgbio#1166, #1167), so this diverges from fgbio under a cap.
+            Self::Downsampled => CentralReason::Downsampled,
         }
     }
 }

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -756,8 +756,16 @@ impl CodecConsensusCaller {
                 );
                 return Ok(ConsensusOutput::default());
             }
-            Self::cap_infos_to_lowest_ranking(records, &mut r1_infos, max_reads);
-            Self::cap_infos_to_lowest_ranking(records, &mut r2_infos, max_reads);
+            // Count the reads the cap discards as Downsampled so `raw_reads_used` excludes
+            // them rather than over-counting the downsampled reads as used (fgumi#724). This
+            // mirrors how the codec caller already counts its other per-read rejections (e.g.
+            // MinorityAlignment above); routing them individually to the `--rejects` output
+            // waits on the codec's per-read reject-mask machinery (fgumi#751).
+            let downsampled = Self::cap_infos_to_lowest_ranking(records, &mut r1_infos, max_reads)
+                + Self::cap_infos_to_lowest_ranking(records, &mut r2_infos, max_reads);
+            if downsampled > 0 {
+                self.reject_records_count(downsampled, CallerRejectionReason::Downsampled);
+            }
         }
 
         // Phase 4: Overlap/phase calculation on ClippedRecordInfo
@@ -1021,20 +1029,24 @@ impl CodecConsensusCaller {
     /// Reduces `infos` in place to the `max_reads` lowest-ranking records, keeping input order.
     ///
     /// A no-op when the strand is already at or below the cap.
+    /// Caps `infos` to the `max_reads` lowest-ranking reads, returning the number discarded so
+    /// the caller can count them as `Downsampled` rejections (fgumi#724).
     fn cap_infos_to_lowest_ranking(
         records: &[RawRecord],
         infos: &mut Vec<ClippedRecordInfo>,
         max_reads: usize,
-    ) {
+    ) -> usize {
         if infos.len() <= max_reads {
-            return;
+            return 0;
         }
+        let dropped = infos.len() - max_reads;
         let keep = Self::keep_indices_for_infos(records, infos, max_reads);
         // Move the survivors out rather than cloning: a clipped CIGAR owns a heap buffer, and
         // families reaching here are by definition larger than the cap.
         let mut kept: Vec<ClippedRecordInfo> =
             keep.iter().map(|&i| std::mem::replace(&mut infos[i], Self::dummy_info())).collect();
         std::mem::swap(infos, &mut kept);
+        dropped
     }
 
     /// Filter `ClippedRecordInfo`s to the most common alignment pattern.
@@ -5101,6 +5113,55 @@ mod tests {
         assert_eq!(
             output.count, 1,
             "filtering before capping must keep the majority-alignment reads and emit a consensus"
+        );
+    }
+
+    /// fgumi#724: the reads the per-strand `--max-reads` cap discards must be counted as
+    /// `Downsampled`, so `raw_reads_used` (derived from `reads_filtered`) excludes them rather
+    /// than counting the downsampled reads as used. Six identical-alignment templates with a
+    /// cap of three discard three R1s and three R2s — six reads in all.
+    #[test]
+    fn codec_downsampled_reads_are_counted_as_rejected() {
+        let options = CodecConsensusOptions {
+            min_reads_per_strand: 1,
+            max_reads_per_strand: Some(3),
+            min_duplex_length: 1,
+            ..Default::default()
+        };
+        let mut caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
+
+        // One family of six templates, all sharing the majority alignment, so the alignment
+        // filter keeps all six and the cap draws three from each strand's six.
+        let cigar: Vec<(Kind, usize)> = vec![(Kind::Match, 30)];
+        let mut reads: Vec<RawRecord> = Vec::new();
+        for i in 0..6 {
+            reads.extend(create_fr_pair(
+                &format!("q{i}"),
+                1,
+                11,
+                30,
+                35,
+                &cigar,
+                &cigar,
+                "mi",
+                Some("ACC-TGA"),
+                false,
+                true,
+            ));
+        }
+
+        let output =
+            caller.consensus_reads_from_sam_records(reads).expect("the survivors must consense");
+        assert_eq!(output.count, 1, "the capped survivors must still emit a consensus");
+
+        assert_eq!(
+            caller.statistics().rejection_reasons.get(&CallerRejectionReason::Downsampled),
+            Some(&6),
+            "three R1 and three R2 reads are discarded by the cap and must be counted"
+        );
+        assert!(
+            caller.statistics().reads_filtered >= 6,
+            "reads_filtered must include the downsampled reads so raw_reads_used excludes them"
         );
     }
 

--- a/crates/fgumi-consensus/src/vanilla_caller.rs
+++ b/crates/fgumi-consensus/src/vanilla_caller.rs
@@ -807,33 +807,43 @@ impl VanillaUmiConsensusCaller {
         accepted
     }
 
-    /// Downsamples reads if there are more than `max_reads`
-    fn downsample_reads(&self, mut reads: Vec<RawRecord>) -> Vec<RawRecord> {
-        if let Some(max_reads) = self.options.max_reads
-            && reads.len() > max_reads
-        {
-            // Rank once per record, not inside the sort key: `sort_by_key` may evaluate its
-            // closure more than once per element, which would re-hash on every comparison.
-            let ranks: Vec<i32> = reads
-                .iter()
-                .map(|raw| fgbio_read_name_rank(RawRecordView::new(raw.as_ref()).read_name()))
-                .collect();
-            let keep_indices = select_lowest_ranking(&ranks, max_reads);
-
-            // Drop the non-survivors in place. `retain` preserves input order and moves the
-            // retained records rather than cloning them — families reaching here can be large.
-            let mut keep = vec![false; reads.len()];
-            for i in keep_indices {
-                keep[i] = true;
-            }
-            let mut idx = 0;
-            reads.retain(|_| {
-                let keeping = keep[idx];
-                idx += 1;
-                keeping
-            });
+    /// Downsamples reads if there are more than `max_reads`, returning `(kept, dropped)`.
+    ///
+    /// Both halves preserve input order. The `dropped` reads are the ones the cap discards;
+    /// the caller counts them as rejected (so `raw_reads_used` excludes them) and routes them
+    /// to the `--rejects` output rather than silently discarding them (fgumi#724).
+    fn downsample_reads(&self, reads: Vec<RawRecord>) -> (Vec<RawRecord>, Vec<RawRecord>) {
+        let Some(max_reads) = self.options.max_reads else {
+            return (reads, Vec::new());
+        };
+        if reads.len() <= max_reads {
+            return (reads, Vec::new());
         }
-        reads
+
+        // Rank once per record, not inside the sort key: `sort_by_key` may evaluate its
+        // closure more than once per element, which would re-hash on every comparison.
+        let ranks: Vec<i32> = reads
+            .iter()
+            .map(|raw| fgbio_read_name_rank(RawRecordView::new(raw.as_ref()).read_name()))
+            .collect();
+        let keep_indices = select_lowest_ranking(&ranks, max_reads);
+
+        // Partition into survivors and discards, each in input order. Records are moved, not
+        // cloned — families reaching here are by definition larger than the cap.
+        let mut keep = vec![false; reads.len()];
+        for i in keep_indices {
+            keep[i] = true;
+        }
+        let mut kept = Vec::with_capacity(max_reads);
+        let mut dropped = Vec::with_capacity(reads.len() - max_reads);
+        for (i, read) in reads.into_iter().enumerate() {
+            if keep[i] {
+                kept.push(read);
+            } else {
+                dropped.push(read);
+            }
+        }
+        (kept, dropped)
     }
 
     /// Downsamples already-filtered `SourceReads` to at most `max_reads`, keeping the
@@ -1214,7 +1224,7 @@ impl VanillaUmiConsensusCaller {
 
         // Filter reads
         let pre_filter_count = records.len();
-        let mut reads = self.filter_reads(records);
+        let reads = self.filter_reads(records);
         let filtered_count = pre_filter_count - reads.len();
         if filtered_count > 0 {
             self.stats.record_rejection(RejectionReason::SecondaryOrSupplementary, filtered_count);
@@ -1233,8 +1243,16 @@ impl VanillaUmiConsensusCaller {
             return Ok(ConsensusOutput::default());
         }
 
-        // Downsample if necessary
-        reads = self.downsample_reads(reads);
+        // Downsample if necessary, routing the reads the cap discards to the --rejects output
+        // and counting them so `raw_reads_used` excludes them rather than over-counting the
+        // downsampled reads as used (fgumi#724).
+        let (reads, downsampled) = self.downsample_reads(reads);
+        if !downsampled.is_empty() {
+            self.stats.record_rejection(RejectionReason::Downsampled, downsampled.len());
+            if self.track_rejects {
+                self.rejected_reads.extend(downsampled.into_iter().map(RawRecord::into_inner));
+            }
+        }
 
         // Sub-group by read type
         let (fragment_reads, r1_reads, r2_reads) = self.subgroup_reads(reads);
@@ -2241,6 +2259,7 @@ mod tests {
 
         let mut names: Vec<String> = caller
             .downsample_reads(reads)
+            .0
             .iter()
             .map(|r| {
                 String::from_utf8(RawRecordView::new(r.as_ref()).read_name().to_vec())
@@ -2249,6 +2268,54 @@ mod tests {
             .collect();
         names.sort();
         assert_eq!(names, vec!["q0", "q2", "q3"]);
+    }
+
+    /// fgumi#724: reads the `--max-reads` cap discards must be counted as rejected — so
+    /// `raw_reads_used` (derived from `filtered_reads`) excludes them — and, with rejects
+    /// tracking on, routed to the `--rejects` output byte-for-byte in input order rather than
+    /// silently dropped. Ranks put `q3 < q2 < q0` lowest, so a cap of 3 keeps exactly those
+    /// three and discards the other seven.
+    #[test]
+    fn downsampled_reads_are_rejected_and_routed_to_the_rejects_output() {
+        let options =
+            VanillaUmiConsensusOptions { min_reads: 1, max_reads: Some(3), ..Default::default() };
+        let mut caller = VanillaUmiConsensusCaller::new_with_rejects_tracking(
+            "c".to_string(),
+            "A".to_string(),
+            options,
+            true,
+        );
+
+        let reads: Vec<RawRecord> = (0..10)
+            .map(|i| create_test_read(&format!("q{i}"), b"ACGT", b"####", false, false))
+            .collect();
+
+        // Snapshot the discarded records — everything except the kept q0/q2/q3 — in input
+        // order, before the group is moved into the caller.
+        let kept: [&[u8]; 3] = ["q0", "q2", "q3"].map(str::as_bytes);
+        let expected_dropped: Vec<Vec<u8>> = reads
+            .iter()
+            .filter(|r| !kept.contains(&RawRecordView::new(r.as_ref()).read_name()))
+            .map(|r| r.as_ref().to_vec())
+            .collect();
+        assert_eq!(expected_dropped.len(), 7, "a cap of 3 over 10 reads discards seven");
+
+        caller.process_group("UMI123", reads).expect("the three kept reads must still consense");
+
+        assert_eq!(
+            caller.stats.rejection_reasons.get(&RejectionReason::Downsampled),
+            Some(&7),
+            "the seven downsampled reads must be counted under Downsampled"
+        );
+        assert_eq!(
+            caller.stats.filtered_reads, 7,
+            "filtered_reads must include the downsampled reads so raw_reads_used excludes them"
+        );
+        assert_eq!(
+            caller.rejected_reads(),
+            expected_dropped.as_slice(),
+            "the downsampled reads must reach --rejects byte-for-byte, in input order"
+        );
     }
 
     /// Both ends of a template share a read name and therefore a rank, so they sort adjacently
@@ -2286,6 +2353,7 @@ mod tests {
 
         let kept: Vec<(String, bool)> = caller
             .downsample_reads(reads)
+            .0
             .iter()
             .map(|r| {
                 let view = RawRecordView::new(r.as_ref());

--- a/crates/fgumi-metrics/src/consensus.rs
+++ b/crates/fgumi-metrics/src/consensus.rs
@@ -146,6 +146,11 @@ pub struct ConsensusMetrics {
     /// codec)
     pub rejected_clip_overlap_failed: u64,
 
+    /// Reads discarded by consensus downsampling (a deliberate `--max-reads` cap).
+    /// fgumi-specific: fgbio has no equivalent metric yet (fulcrumgenomics/fgbio#1166,
+    /// #1167), so this row is emitted only when non-zero (fgumi#724).
+    pub rejected_downsampled: u64,
+
     /// Consensus reads rejected for high duplex disagreement (fgbio
     /// `consensusReadsFilteredHighDisagreement`, emitted as
     /// `consensus_reads_rejected_hdd`; codec)
@@ -229,7 +234,7 @@ impl ConsensusCallerKind {
 /// fgumi's taxonomy is finer-grained than fgbio's; the reasons not in any caller's
 /// seeded set (e.g. `LowBaseQuality`) are fgumi-specific and are emitted only when
 /// non-zero.
-const ALL_REJECTIONS: [RejectionReason; 24] = [
+const ALL_REJECTIONS: [RejectionReason; 25] = [
     RejectionReason::InsufficientSupport,
     RejectionReason::MinorityAlignment,
     RejectionReason::OrphanConsensus,
@@ -254,6 +259,7 @@ const ALL_REJECTIONS: [RejectionReason; 24] = [
     RejectionReason::InsufficientMinDepth,
     RejectionReason::ExcessiveErrorRate,
     RejectionReason::UmiTooShort,
+    RejectionReason::Downsampled,
 ];
 
 /// Returns an iterator over all rejection reasons fgumi tracks.
@@ -300,6 +306,7 @@ impl ConsensusMetrics {
             rejected_indel_error_between_strands: 0,
             rejected_high_duplex_disagreement: 0,
             rejected_clip_overlap_failed: 0,
+            rejected_downsampled: 0,
             consensus_reads_rejected_hdd: 0,
             consensus_bases_emitted: 0,
             consensus_duplex_bases_emitted: 0,
@@ -346,6 +353,7 @@ impl ConsensusMetrics {
             RejectionReason::IndelErrorBetweenStrands => self.rejected_indel_error_between_strands,
             RejectionReason::HighDuplexDisagreement => self.rejected_high_duplex_disagreement,
             RejectionReason::ClipOverlapFailed => self.rejected_clip_overlap_failed,
+            RejectionReason::Downsampled => self.rejected_downsampled,
         }
     }
 
@@ -386,6 +394,7 @@ impl ConsensusMetrics {
                 self.rejected_high_duplex_disagreement += count;
             }
             RejectionReason::ClipOverlapFailed => self.rejected_clip_overlap_failed += count,
+            RejectionReason::Downsampled => self.rejected_downsampled += count,
         }
     }
 

--- a/crates/fgumi-metrics/src/rejection.rs
+++ b/crates/fgumi-metrics/src/rejection.rs
@@ -66,6 +66,11 @@ pub enum RejectionReason {
     HighDuplexDisagreement,
     /// Overlap clipping failed (fgbio `clip_overlap_failed`; used by codec)
     ClipOverlapFailed,
+    /// Reads discarded by consensus downsampling (a deliberate `--max-reads` cap, not a
+    /// quality or alignment failure). fgbio has no equivalent metric row yet
+    /// (fulcrumgenomics/fgbio#1166, #1167), so this is fgumi-specific and diverges from
+    /// fgbio's stats under a cap (fgumi#724).
+    Downsampled,
 }
 
 impl RejectionReason {
@@ -99,6 +104,7 @@ impl RejectionReason {
             // fgbio's exact string (note the "top/bottoms" typo), matched for parity.
             Self::HighDuplexDisagreement => "Too many errors between top/bottoms strands",
             Self::ClipOverlapFailed => "See https://github.com/fulcrumgenomics/fgbio/issues/1090",
+            Self::Downsampled => "Reads discarded by consensus downsampling",
         }
     }
 
@@ -130,6 +136,7 @@ impl RejectionReason {
             Self::IndelErrorBetweenStrands => "raw_reads_rejected_for_indel_error_between_strands",
             Self::HighDuplexDisagreement => "raw_reads_rejected_for_high_duplex_disagreement",
             Self::ClipOverlapFailed => "raw_reads_rejected_for_clip_overlap_failed",
+            Self::Downsampled => "raw_reads_rejected_for_downsampled",
         }
     }
 
@@ -162,6 +169,7 @@ impl RejectionReason {
             Self::IndelErrorBetweenStrands => "Indel error between top/bottom strands",
             Self::HighDuplexDisagreement => "Too many errors between top/bottoms strands",
             Self::ClipOverlapFailed => "See https://github.com/fulcrumgenomics/fgbio/issues/1090",
+            Self::Downsampled => "Reads discarded by downsampling to the max reads per consensus",
         }
     }
 }


### PR DESCRIPTION
## Summary

Reads discarded by the `--max-reads` consensus-downsampling cap were counted as *used* and never reached `--rejects`. Because `raw_reads_used = total_input_reads - filtered_reads` and only a recorded rejection increments `filtered_reads`, a family of 10 capped to 3 reported `raw_reads_used = 10` against a consensus of depth 3 (`cD:i:3`), and the 7 discarded reads were dropped silently.

Closes #724.

## What changed

A new `Downsampled` rejection reason (caller code `d`) is recorded at each site that actually *drops* reads under the cap, so `raw_reads_used` excludes them:

- **simplex** (`VanillaUmiConsensusCaller::process_group`): `downsample_reads` now returns `(kept, dropped)`; the dropped reads are counted and, when rejects tracking is enabled, routed to the `--rejects` output byte-for-byte in input order — matching how the vanilla caller already routes its other per-read rejections.
- **codec** (`CodecConsensusCaller`): the per-strand cap counts the discarded reads, mirroring how the codec caller already counts its other per-read rejections (e.g. `MinorityAlignment`).

## Scope notes

- **#727 already mooted the duplex/codec `consensus_call` path.** Since #727, that path retains the full uncapped `source_reads` (the cap shapes only the consensus bases/quals/depths), so no reads are dropped there and nothing needs routing. The remaining drop sites are the simplex group-level cap and the codec per-strand cap — the two this PR addresses. The issue text predates #727 and references stale line numbers.
- **Codec is count-only here.** The codec caller does not yet route *any* per-read rejection to `--rejects` (only whole-group failures); that machinery is added by #751. Routing the downsampled codec reads now would double-count on the whole-group-failure path and collide with #751, so this PR fixes the codec *count* (which is what `raw_reads_used` depends on) and leaves per-read codec routing to land with #751.
- **fgbio divergence.** `Downsampled` is fgumi-specific: fgbio has no equivalent metric yet (fulcrumgenomics/fgbio#1166, #1167). Under a cap, fgumi's `raw_reads_used` and the new `raw_reads_rejected_for_downsampled` row now differ from fgbio until fgbio#1167 lands. The new metric row is emitted only when non-zero, so runs without a cap are unchanged.

## Tests

- `vanilla_caller::downsampled_reads_are_rejected_and_routed_to_the_rejects_output` — a family of 10 capped to 3 records 7 `Downsampled` rejections, includes them in `filtered_reads`, and emits them to `--rejects` byte-for-byte in input order.
- `codec_caller::codec_downsampled_reads_are_counted_as_rejected` — six identical-alignment templates capped to 3 per strand record 6 `Downsampled` rejections.

Full workspace suite green (6682 tests); `cargo ci-fmt` and `cargo ci-lint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: output changes for `--rejects` BAM and rejection metrics, pinned by `RejectionReason::Downsampled` and input order; unsafe changes none, so `CLAUDE.md` allowlist changes none; memory, queue, and thread/backpressure policy changes none.

Fix: Count reads discarded by consensus downsampling as `Downsampled` rejections.

- Add `Downsampled` rejection metadata and consensus metrics.
- Route discarded simplex reads to `--rejects`.
- Count discarded CODEC reads per strand.
- Preserve existing duplex and CODEC `consensus_call` behavior.
- Add regression tests for rejection routing and counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->