### PR TITLE
fix(pipeline): admit the gap-filler serial to Decode under memory-high

### DIFF
--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -966,6 +966,36 @@ impl<G: Send, P: Send + MemoryEstimate> BamPipelineState<G, P> {
         Some((serial, batch))
     }
 
+    /// Decide whether a boundary batch just popped from Q2b should be decoded
+    /// now or handed back to Q2b under per-serial memory backpressure (fgumi#746).
+    ///
+    /// The Q3 reorder buffer's own [`ReorderBufferState::can_proceed`] always
+    /// admits the serial Group needs next (the gap-filler), even when memory is
+    /// high, and backpressures only *future* serials once the buffer is half
+    /// full. Returns:
+    ///
+    /// - `Some((serial, batch))` — decode it now: either it is the gap-filler,
+    ///   or it is a future batch whose requeue lost the race to a full Q2b (a
+    ///   rare, bounded overshoot — never a lost or reordered-into-loss batch,
+    ///   since Q3 reassembles by serial).
+    /// - `None` — the batch was requeued to Q2b so another worker can still
+    ///   reach the gap-filler, avoiding the "all workers hold a non-`next_seq`
+    ///   batch and nobody can produce `next_seq`" deadlock.
+    fn admit_or_requeue_decode(
+        &self,
+        serial: u64,
+        batch: BoundaryBatch,
+    ) -> Option<(u64, BoundaryBatch)> {
+        if self.q3_reorder_state.can_proceed(serial) {
+            return Some((serial, batch));
+        }
+        // On requeue-success (`Ok`) return `None` so the caller advances no work;
+        // on requeue-failure the batch is handed back to be decoded directly
+        // (bounded overshoot). `Result::err` maps exactly that: `Ok` -> `None`,
+        // `Err(returned)` -> `Some(returned)`.
+        self.q2b_push(serial, batch).err()
+    }
+
     /// Push a raw block batch onto Q1, charging its heap bytes on success.
     ///
     /// Mirrors [`Self::q2b_push`]: the charge precedes the push (see that method
@@ -2514,11 +2544,14 @@ fn try_step_decode<G: Send, P: Send + MemoryEstimate>(
     }
 
     // =========================================================================
-    // Priority 2: Check backpressure (physical capacity AND memory)
+    // Priority 2: Check physical-capacity backpressure
     // =========================================================================
-    // Memory check gates new work when the Q3 reorder buffer is large.
-    // Same deadlock-safe pattern as Decompress P2 — see comment there.
-    if state.q3_decoded.is_full() || state.q3_reorder_state.is_memory_high() {
+    // Only the output queue being physically full blocks new work here. Memory
+    // backpressure is applied *per serial* after the pop (below), because a
+    // blanket `is_memory_high()` guard at this point is not deadlock-safe for
+    // Decode the way it is for Decompress: it can stall the very serial the Q3
+    // reorder buffer needs next, starving Group (fgumi#746).
+    if state.q3_decoded.is_full() {
         return advanced_held;
     }
 
@@ -2536,6 +2569,18 @@ fn try_step_decode<G: Send, P: Send + MemoryEstimate>(
                 stats.record_queue_empty(2);
             }
         }
+        return advanced_held;
+    };
+
+    // Per-serial memory backpressure (fgumi#746). A blanket `is_memory_high()`
+    // guard before the pop instead stalled the gap-filler: when a slow writer
+    // backed the pipeline up, Decode declined to decode the very serial the Q3
+    // reorder buffer was waiting on, so it never released to Group and the
+    // pipeline wedged. `admit_or_requeue_decode` applies the buffer's own
+    // per-serial `can_proceed` after the pop instead — see it for the requeue
+    // and bounded-overshoot semantics.
+    let Some((serial, boundary_batch)) = state.admit_or_requeue_decode(serial, boundary_batch)
+    else {
         return advanced_held;
     };
     state.deadlock_state.record_q2b_pop();
@@ -4819,6 +4864,78 @@ mod tests {
             state.q2b_heap_bytes.load(Ordering::Acquire),
             0,
             "a rejected push must leave the Q2b counter unchanged"
+        );
+    }
+
+    /// The gap-filler serial (`serial == next_seq`) is admitted for decoding
+    /// even when the Q3 reorder buffer is over its memory limit — otherwise the
+    /// very serial Group is waiting on would be requeued and the pipeline would
+    /// wedge (fgumi#746).
+    #[test]
+    fn admit_or_requeue_decode_admits_the_gap_filler_even_over_the_limit() {
+        let state = create_test_state(1024);
+        // next_seq = 0 and heap well over the 50% (512-byte) backpressure mark,
+        // so `can_proceed` would reject any *future* serial here.
+        state.q3_reorder_state.next_seq.store(0, Ordering::SeqCst);
+        state.q3_reorder_state.heap_bytes.store(800, Ordering::SeqCst);
+
+        let batch = BoundaryBatch { buffer: vec![0u8; 4096], offsets: vec![0, 4096] };
+        let admitted = state.admit_or_requeue_decode(0, batch);
+        let Some((serial, returned)) = admitted else {
+            panic!("the gap-filler serial must be admitted for decoding");
+        };
+        assert_eq!(serial, 0, "the gap-filler serial is returned for decoding");
+        assert_eq!(returned.buffer.len(), 4096, "the gap-filler batch is returned unchanged");
+        assert!(state.q2b_boundaries.is_empty(), "the gap-filler is not requeued to Q2b");
+    }
+
+    /// A future serial over the backpressure mark is requeued to Q2b (not
+    /// decoded) so another worker can still reach the gap-filler.
+    #[test]
+    fn admit_or_requeue_decode_requeues_a_future_serial_under_pressure() {
+        let state = create_test_state(1024);
+        state.q3_reorder_state.next_seq.store(0, Ordering::SeqCst);
+        state.q3_reorder_state.heap_bytes.store(800, Ordering::SeqCst);
+
+        let batch = BoundaryBatch { buffer: vec![0u8; 4096], offsets: vec![0, 4096] };
+        assert!(
+            state.admit_or_requeue_decode(50, batch).is_none(),
+            "a future serial under memory pressure is requeued, not decoded"
+        );
+        assert_eq!(state.q2b_boundaries.len(), 1, "the future serial is handed back to Q2b");
+        let (serial, _) = state.q2b_pop().expect("the requeued batch should pop");
+        assert_eq!(serial, 50, "the requeued serial is preserved");
+    }
+
+    /// When a future serial cannot be requeued because Q2b is full, it is
+    /// decoded directly — the bounded-overshoot path. This is safe because Q3
+    /// reassembles by serial, so the batch is never lost or reordered.
+    #[test]
+    fn admit_or_requeue_decode_decodes_directly_when_q2b_is_full() {
+        let state = create_test_state(1024);
+        state.q3_reorder_state.next_seq.store(0, Ordering::SeqCst);
+        state.q3_reorder_state.heap_bytes.store(800, Ordering::SeqCst);
+
+        // Fill Q2b to capacity so the requeue push must fail.
+        let cap = state.q2b_boundaries.capacity();
+        for filler in 0..cap as u64 {
+            let batch = BoundaryBatch { buffer: Vec::new(), offsets: vec![0] };
+            assert!(state.q2b_boundaries.push((filler, batch)).is_ok());
+        }
+        assert!(state.q2b_boundaries.is_full());
+        let charged_before = state.q2b_heap_bytes.load(Ordering::Acquire);
+
+        let batch = BoundaryBatch { buffer: vec![0u8; 4096], offsets: vec![0, 4096] };
+        let admitted = state.admit_or_requeue_decode(50, batch);
+        let Some((serial, returned)) = admitted else {
+            panic!("a future serial that cannot be requeued must be decoded directly");
+        };
+        assert_eq!(serial, 50, "the overshoot serial is returned for decoding");
+        assert_eq!(returned.buffer.len(), 4096, "the overshoot batch is returned unchanged");
+        assert_eq!(
+            state.q2b_heap_bytes.load(Ordering::Acquire),
+            charged_before,
+            "the failed requeue refunds its charge, leaving the Q2b counter unchanged"
         );
     }
 

--- a/tests/integration/test_pipeline_memory_backpressure.rs
+++ b/tests/integration/test_pipeline_memory_backpressure.rs
@@ -224,11 +224,18 @@ struct StalledRun {
 }
 
 /// Spawn a pass-through pipeline over `bam_bytes` whose writer never completes.
+///
+/// `blocks_per_read_batch` overrides the reader's batch granularity when `Some`;
+/// `None` keeps the thread-count-derived production default. Only the read-ahead
+/// *scaling* test needs to shrink it — see
+/// [`read_ahead_under_a_stalled_writer_shrinks_with_the_queue_memory_budget`] for
+/// why the production ~1 MiB batch quantum would otherwise swamp the signal.
 fn spawn_stalled_pipeline(
     header: &Header,
     bam_bytes: Vec<u8>,
     num_threads: usize,
     queue_memory_limit: u64,
+    blocks_per_read_batch: Option<usize>,
 ) -> StalledRun {
     let consumed = Arc::new(AtomicU64::new(0));
     let released = Arc::new(AtomicBool::new(false));
@@ -243,6 +250,12 @@ fn spawn_stalled_pipeline(
     // observes comes from the byte budget and not from a queue running out of
     // slots.
     let mut config = PipelineConfig::auto_tuned(num_threads, 1);
+    // The read granularity, by contrast, is not a slot count and is overridable
+    // per test: a finer batch lets the reader stop closer to the byte budget
+    // instead of overshooting by up to a whole read batch.
+    if let Some(blocks) = blocks_per_read_batch {
+        config.blocks_per_read_batch = blocks;
+    }
     config.queue_memory_limit = queue_memory_limit;
     // A permanently stalled writer is exactly what the deadlock detector is
     // meant to flag, and flagging it would tear the pipeline down before the
@@ -380,7 +393,7 @@ fn stalled_writer_stops_the_reader_within_the_queue_memory_budget() {
     );
 
     let StalledRun { consumed, released, handle, .. } =
-        spawn_stalled_pipeline(header, bam_bytes.clone(), 4, TEST_BUDGET_BYTES);
+        spawn_stalled_pipeline(header, bam_bytes.clone(), 4, TEST_BUDGET_BYTES, None);
 
     let settled = wait_for_consumption_to_settle(&consumed, input_len, Duration::from_secs(30));
     assert!(settled.settled, "reader never stopped under a stalled writer within the timeout");
@@ -411,30 +424,43 @@ fn stalled_writer_stops_the_reader_within_the_queue_memory_budget() {
 /// satisfied by the queues simply running out of *slots*; this one holds the
 /// input and the slot counts fixed and varies only `--max-memory`, so a budget
 /// that bounds nothing shows up as two identical read-ahead figures.
+///
+/// Two things keep the signal clean and the assertion stable:
+///
+/// - **A fine read batch.** With the production ~1 MiB read batch the reader
+///   overshoots the budget by up to a whole batch, and *which* batch it stops on
+///   is scheduling-dependent — so the read-ahead is quantised in ~1 MiB steps
+///   and a loaded CI host can land one step off, swamping a budget difference of
+///   the same order (that quantisation, not the byte gate, is what made this
+///   assertion flap). Shrinking the batch lets the reader stop within a few
+///   blocks of the byte budget, so the read-ahead tracks the budget rather than
+///   the batch and both arms are deterministic across hosts.
+/// - **Sub-saturation budgets.** The compressed read-ahead only rises with the
+///   budget while the budget is small: Q3 parks *decoded* (expanded) records, so
+///   once the budget is a few MiB the reorder buffer's per-serial cap is what
+///   bounds the queue and lifting the budget further barely moves the compressed
+///   bytes consumed. Both arms therefore sit in the responsive regime (1 MiB and
+///   3 MiB), where doubling-plus the budget produces a clear read-ahead gap.
 #[test]
 fn read_ahead_under_a_stalled_writer_shrinks_with_the_queue_memory_budget() {
+    /// Read batch small enough that read-ahead tracks the byte budget instead of
+    /// the ~1 MiB production batch quantum.
+    const FINE_READ_BLOCKS: usize = 4;
+
     let (header, bam_bytes) = shared_bam_bytes();
     let input_len = bam_bytes.len() as u64;
 
-    // Both arms must stay gated: the generous budget has to leave the reader
-    // stopping short of EOF, or the comparison degenerates into
-    // `stalled_writer_stops_the_reader_within_the_queue_memory_budget`'s
-    // assertion, which a slot-count-only bound would also satisfy. The reader
-    // stops near `budget + overhead`, so the generous budget must clear both that
-    // overhead and one further `TEST_BUDGET_BYTES` of gap below `input_len`.
-    // Twice the tight budget is the largest multiple this fixture (~4 budgets)
-    // admits while keeping the generous arm off EOF.
-    let generous_budget = 2 * TEST_BUDGET_BYTES;
-    assert!(
-        generous_budget + TEST_BUDGET_BYTES < input_len,
-        "the generous budget ({generous_budget}) plus one tight budget must stay below the input \
-         ({input_len}) so both runs are gated with the reader stopping short of EOF"
-    );
+    // Both budgets stay in the sub-saturation regime (see the doc comment) so the
+    // budget actually moves the read-ahead, and both leave the reader well short
+    // of EOF on this fixture.
+    let tight_budget = TEST_BUDGET_BYTES / 2; // 1 MiB
+    let generous_budget = 3 * TEST_BUDGET_BYTES / 2; // 3 MiB
+    let budget_difference = generous_budget - tight_budget;
 
     let mut consumption = Vec::new();
-    for budget in [TEST_BUDGET_BYTES, generous_budget] {
+    for budget in [tight_budget, generous_budget] {
         let StalledRun { consumed, released, handle, .. } =
-            spawn_stalled_pipeline(header, bam_bytes.clone(), 4, budget);
+            spawn_stalled_pipeline(header, bam_bytes.clone(), 4, budget, Some(FINE_READ_BLOCKS));
         let settled = wait_for_consumption_to_settle(&consumed, input_len, Duration::from_secs(30));
         assert!(
             settled.settled,
@@ -450,18 +476,19 @@ fn read_ahead_under_a_stalled_writer_shrinks_with_the_queue_memory_budget() {
         consumption.push(settled.bytes);
     }
 
-    // A margin tied to the budget difference, not bare ordering: a scheduler
-    // hiccup that made the tight run read one extra block would still pass
-    // `tight < generous`, and if the generous run read to EOF a bounded gate would
-    // be indistinguishable from none. Requiring the gap to span at least one
-    // tight budget pins that the budget — not slot counts or timing — is the
-    // bound.
+    // A margin tied to the budget difference, not bare ordering: `tight < generous`
+    // alone could be one stray block, and if a bound ignored the budget entirely
+    // the two figures would coincide. Requiring the gap to span at least half the
+    // budget difference pins that the budget — not slot counts or timing — is the
+    // bound, while tolerating the few-block overshoot the fine read batch still
+    // leaves. (Measured gap is ~0.9x the budget difference; the reader trails the
+    // budget sub-linearly because part of it is spent on decoded, expanded data.)
     let (tight, generous) = (consumption[0], consumption[1]);
     assert!(
-        generous.saturating_sub(tight) >= TEST_BUDGET_BYTES,
-        "read-ahead was {tight} bytes under a {TEST_BUDGET_BYTES}-byte budget and {generous} \
-         bytes under a {generous_budget}-byte one; the gap is smaller than one tight budget, so \
-         the budget is not bounding the queues"
+        generous.saturating_sub(tight) >= budget_difference / 2,
+        "read-ahead was {tight} bytes under a {tight_budget}-byte budget and {generous} bytes \
+         under a {generous_budget}-byte one; the gap is under half the {budget_difference}-byte \
+         budget difference, so the budget is not bounding the queues"
     );
 }
 
@@ -481,7 +508,7 @@ fn a_budget_smaller_than_one_batch_still_completes_with_every_record() {
 
     // Release the writer immediately so it never blocks — a healthy sink — and
     // set a budget far below one decompressed batch.
-    let run = spawn_stalled_pipeline(header, bam_bytes.clone(), 4, 8);
+    let run = spawn_stalled_pipeline(header, bam_bytes.clone(), 4, 8, None);
     run.released.store(true, Ordering::Release);
 
     let written =
@@ -514,7 +541,7 @@ fn reader_resumes_and_completes_after_the_writer_recovers() {
     assert_eq!(expected_names.len(), FAMILIES * DEPTH, "input should hold every generated read");
 
     let StalledRun { consumed, released, sink, handle } =
-        spawn_stalled_pipeline(header, bam_bytes.clone(), 4, TEST_BUDGET_BYTES);
+        spawn_stalled_pipeline(header, bam_bytes.clone(), 4, TEST_BUDGET_BYTES, None);
 
     let settled =
         wait_for_consumption_to_settle(&consumed, bam_bytes.len() as u64, Duration::from_secs(30));


### PR DESCRIPTION
> **Draft, stacked on #764** (base = `746/nhomer/bound-consensus-memory-under-writer-stall`). It fixes a deadlock that #764's tests still hit — see below. Rebase onto #764 when that lands.

## The problem: #764's deadlock is not fixed, and green CI is masking it

#764's three `test_pipeline_memory_backpressure` tests **pass in CI but reliably hang on a loaded host**. The hang is a real, scheduling-sensitive deadlock in the Decode step, not flaky tests:

- The Decode step gates new work with a blanket `q3_reorder_state.is_memory_high()` check *before* popping Q2b (bam.rs, `try_step_decode`). It was copied from the Decompress step, whose comment argues the guard is deadlock-safe because "Q1 is FIFO, so `next_seq` for the reorder buffer has already been produced."
- That invariant does **not** hold for Decode. When a slow writer backs the pipeline up and the Q3 reorder buffer reaches its high-water mark, the guard also stops Decode from decoding **the very serial the reorder buffer is waiting on**. That serial never reaches Q3, Group starves on it, and the pipeline wedges with the reader gated — exactly the OOM-avoidance path #764 adds.

**Evidence (controlled A/B on the loaded host, same commit, only this guard toggled):**

| Decode Q3 `is_memory_high` guard | 4 backpressure tests |
| --- | --- |
| ON (as in #764) | 4/4 **TIMEOUT** (hang) |
| OFF | 4/4 pass |

CI's lighter scheduling doesn't trip the race, so #764 goes green — a false negative for this deadlock class.

## The fix

Replace the blanket guard with the reorder buffer's own per-serial `can_proceed`, applied *after* the pop:

- It **always admits the gap-filler** (`serial == next_seq`), even over the memory limit, so the serial Group is waiting on can never be starved.
- It backpressures only **future** serials, once the buffer is half full.
- A future batch rejected by `can_proceed` is **returned to Q2b** so another worker can still reach the gap-filler — avoiding the "all workers hold a non-`next_seq` batch and nobody can produce `next_seq`" deadlock the code hit when `can_proceed` was previously wired into Decompress (see that step's comment).

On the healthy path (memory below the high-water mark) `can_proceed` is always `true`, so throughput is unchanged — the new backpressure engages only under the exact memory-high condition that used to deadlock.

## Validation

- The four backpressure tests pass on the loaded reproducer across **3 repeated runs** (they reliably hang without this change).
- Full workspace suite: **6675/6675 pass**. `cargo ci-fmt` and `cargo ci-lint` clean.

## Caveat worth raising separately

CI cannot currently catch this deadlock class (it needs constrained scheduling to reproduce). A follow-up that reproduces it under load in CI would keep it from regressing silently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: output for grouping, consensus, sort order, corrected UMIs, and metrics: none; `unsafe`: none, and no CLAUDE.md allowlist update; memory bound, queue capacity, and thread/backpressure policy: changed for Decode under memory-high conditions.

Fix: Decode applies per-serial admission after popping Q2b. It requeues future serials and admits the required Q3 gap-filler serial. This prevents stalls while preserving serial order.

Validation:
- Four backpressure tests pass across three loaded-reproducer runs.
- Full workspace suite passes: 6675/6675 tests.
- Formatting and lint checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->