### PR TITLE
refactor(pipeline): resolve clippy::pedantic cast-precision lints in base.rs

### DIFF
--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -318,6 +318,11 @@ pub fn log_comprehensive_memory_stats(stats: &PipelineStats) {
 
     // Main memory line with RSS vs tracked accuracy
     if breakdown.system_rss_gb > 0.0 {
+        // rationale: an integer percentage for a log line. The ratio is non-negative
+        // (this branch is guarded by `system_rss_gb > 0.0` and tracked totals are
+        // non-negative), so truncating toward zero and dropping the (never-present) sign
+        // is the intended display behavior.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let pct = (breakdown.tracked_total_gb / breakdown.system_rss_gb * 100.0) as u32;
         log::info!(
             "MEMORY: RSS={:.1}GB Tracked={:.1}GB ({}%) | Queue: Q1:{:.0}MB Q2:{:.0}MB Q3:{:.0}MB Q4:{:.1}GB Q5:{:.1}GB Q6:{:.0}MB Q7:{:.0}MB | Proc: Pos={:.1}GB Tmpl={:.1}GB | Infra={:.0}MB",
@@ -354,6 +359,11 @@ pub fn log_comprehensive_memory_stats(stats: &PipelineStats) {
 
     // Untracked memory details (only if RSS is available)
     if breakdown.system_rss_gb > 0.0 {
+        // rationale: an integer percentage for a log line. The ratio is non-negative
+        // (this branch is guarded by `system_rss_gb > 0.0` and `untracked_gb` is a
+        // saturating subtraction, so never negative), so truncating toward zero and
+        // dropping the (never-present) sign is the intended display behavior.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let untracked_pct = ((breakdown.untracked_gb / breakdown.system_rss_gb) * 100.0) as u32;
         if breakdown.untracked_gb > 1.0 {
             log::info!(
@@ -4086,6 +4096,12 @@ impl PipelineStats {
     }
 
     /// Get current memory breakdown
+    // rationale: every cast below converts a `u64` byte count to an `f64` number of
+    // gigabytes/megabytes purely for the human-readable memory-debug log lines. Real RSS
+    // and queue sizes are far below `f64`'s 2^52-byte exact-integer limit (4 PiB), so the
+    // precision loss is unobservable and the truncated GB/MB figure is exactly what we want
+    // to display.
+    #[allow(clippy::cast_precision_loss)]
     pub fn get_memory_breakdown(&self) -> MemoryBreakdown {
         let m = &self.memory;
 


### PR DESCRIPTION
Resolves the pre-existing `clippy::pedantic` cast-precision warnings in `src/lib/unified_pipeline/base.rs`. These live entirely in the `#[cfg(feature = "memory-debug")]` reporting path, so they only surface under a full `cargo clippy --all-features --all-targets` run and never tripped the `ci-lint` gate (which enables `compare,simulate,profile-adjacency`, not `memory-debug`). All are lint-only display conversions; no computed value changed.

- `PipelineStats::get_memory_breakdown` — 25 `u64 as f64` byte→GB/MB conversions (`clippy::cast_precision_loss`): kept the casts and added a single function-scoped `#[allow(clippy::cast_precision_loss)]` with a rationale. Real RSS/queue sizes are far below `f64`'s 2^52-byte exact-integer limit (4 PiB), so the precision loss is unobservable and the truncated GB/MB figure is exactly what the log line wants.
- `log_comprehensive_memory_stats` — two `f64 as u32` integer-percentage casts (`clippy::cast_possible_truncation`, `clippy::cast_sign_loss`): kept the casts and added statement-scoped allows. Both are guarded by `system_rss_gb > 0.0` with non-negative numerators (one via saturating subtraction), so truncating toward zero and dropping the never-present sign is the intended display behavior.

No crate- or module-wide blanket allow was added and the `ci-lint` gate is unchanged. Verified: `cargo ci-fmt` and `cargo ci-lint` stay green, `cargo clippy --all-features --all-targets -- -W clippy::pedantic` shows no remaining cast warnings in `base.rs`, and the 346 `unified_pipeline` unit tests (run with `memory-debug` enabled) pass.

Closes #788