### PR TITLE
fix(duplex): split whole-group rejection reasons first-writer-wins

### DIFF
--- a/crates/fgumi-consensus/src/duplex_caller.rs
+++ b/crates/fgumi-consensus/src/duplex_caller.rs
@@ -1884,6 +1884,53 @@ impl DuplexConsensusCaller {
         );
     }
 
+    /// Reattributes single-strand rejections out of a whole-group reason, matching fgbio's
+    /// first-writer-wins reason assignment (#791).
+    ///
+    /// On a whole-group rejection downstream of the single-strand filter, `process_group` counted
+    /// the entire raw group (`N` reads) under one duplex reason, and `stats` has already had that
+    /// `group_stats` merged in. But the `M` reads the single-strand layer already rejected
+    /// (`MinorityAlignment`, `Unmapped`, …) should keep *their* reason; only the `N - M` survivors
+    /// belong to the whole-group reason. This moves those `M` reads from the whole-group reason
+    /// bucket into the single-strand reasons, leaving the reject-count *total* unchanged — so
+    /// `--rejects` still reconciles with `raw_reads_rejected` — while the per-reason split now
+    /// matches fgbio.
+    ///
+    /// `group_stats` holds exactly the one whole-group reason on this path (pre-filter rejections
+    /// leave `ss_stats` empty, so this is a no-op for them). The single-strand rejections are a
+    /// subset of the group, so `M <= N`.
+    fn reattribute_single_strand_rejections(
+        stats: &mut ConsensusCallingStats,
+        group_stats: &ConsensusCallingStats,
+        ss_stats: &ConsensusCallingStats,
+    ) {
+        let ss_rejected = ss_stats.filtered_reads;
+        if ss_rejected == 0 {
+            return;
+        }
+        debug_assert_eq!(
+            group_stats.rejection_reasons.len(),
+            1,
+            "a whole-group rejection records exactly one duplex reason"
+        );
+        if let Some((&whole_group_reason, &whole_group_count)) =
+            group_stats.rejection_reasons.iter().next()
+        {
+            debug_assert!(
+                ss_rejected <= whole_group_count,
+                "single-strand rejections are a subset of the whole group"
+            );
+            if let Some(count) = stats.rejection_reasons.get_mut(&whole_group_reason) {
+                *count = count.saturating_sub(ss_rejected);
+            }
+            stats.filtered_reads = stats.filtered_reads.saturating_sub(ss_rejected);
+        }
+        // Fold the single-strand reasons back in: this re-adds the `M` reads under
+        // `MinorityAlignment`/`Unmapped` and restores `filtered_reads`, so the net effect is a
+        // reason move, not a change to the total.
+        stats.merge(ss_stats);
+    }
+
     /// Processes a single UMI group to generate duplex consensus
     #[expect(clippy::too_many_arguments, reason = "group processing requires many parameters")]
     #[expect(
@@ -2544,9 +2591,13 @@ impl ConsensusCaller for DuplexConsensusCaller {
         //
         // When the duplex layer rejects the group it counts and returns *every* raw input
         // record, so the single-strand layer's rejections — a subset of those same records —
-        // are already covered. Adding them on top would report more rejected reads than the
-        // rejects BAM holds. Otherwise the group survived, and the single-strand drops are
-        // the only rejections it produced: they belong in both outputs.
+        // are already covered in the reject *count*. But fgbio attributes reasons
+        // first-writer-wins: a read the single-strand filter already rejected keeps its own
+        // reason, and only the survivors carry the whole-group reason. The whole-group site
+        // counted the entire raw group under one duplex reason, so reattribute the
+        // single-strand-rejected reads from that reason to their own. Otherwise the group
+        // survived, and the single-strand drops are the only rejections it produced: they belong
+        // in both outputs.
         let ss_stats = self.ss_caller.take_statistics();
         let ss_rejected_raw = self.ss_caller.take_rejected_reads();
         match duplex_outcome {
@@ -2557,6 +2608,11 @@ impl ConsensusCaller for DuplexConsensusCaller {
                 }
             }
             DuplexGroupOutcome::RejectedWholeGroup(duplex_rejected_raw) => {
+                Self::reattribute_single_strand_rejections(
+                    &mut self.stats,
+                    &group_stats,
+                    &ss_stats,
+                );
                 if self.track_rejects {
                     self.rejected_reads.extend(duplex_rejected_raw);
                 }
@@ -4159,12 +4215,16 @@ mod tests {
         Ok(())
     }
 
-    /// #757: the single-strand delta must be dropped when the duplex layer rejects the group.
+    /// #757/#791: a whole-group rejection downstream of the single-strand filter must split its
+    /// reasons the way fgbio does — first-writer-wins.
     ///
-    /// A whole-group duplex rejection counts *every* raw input record and moves every one of
-    /// them to the rejects buffer, so the single-strand layer's earlier rejections are already
-    /// covered — folding its counters in on top would report more rejected reads than the
-    /// rejects BAM holds.
+    /// Every raw input record is still rejected exactly once, and the rejects buffer still holds
+    /// all of them (the #757 no-double-count invariant). But the reads the single-strand layer
+    /// already rejected keep *their* reason (`MinorityAlignment`); only the survivors are
+    /// attributed to the duplex layer's whole-group reason. fgbio's `rejectRecords` is
+    /// first-writer-wins (`recs.filterNot(_.contains(RejectReasonTag))`), so a record already
+    /// tagged `MinorityAlignment` in `filterToMostCommonAlignment` keeps it and the whole-group
+    /// reason lands only on the rest (`DuplexConsensusCaller.scala:359-362`).
     ///
     /// `min_reads = 4` is met before single-strand filtering (four templates per strand) and
     /// missed after it (three survive per strand), which is the only way to reach a whole-group
@@ -4172,8 +4232,7 @@ mod tests {
     /// depth with no minority templates consenses under the same threshold, so the rejection
     /// below is caused by the single-strand drops rather than by the raw depth.
     #[test]
-    fn test_single_strand_rejections_are_not_double_counted_on_whole_group_rejection() -> Result<()>
-    {
+    fn test_whole_group_rejection_preserves_single_strand_reasons() -> Result<()> {
         let mut control = rejection_accounting_caller(vec![4], true)?;
         let control_result = control.consensus_reads(duplex_molecule(4, false, false))?;
         assert_eq!(
@@ -4183,8 +4242,11 @@ mod tests {
         );
 
         let mut caller = rejection_accounting_caller(vec![4], true)?;
+        // Two minority-alignment templates (one per strand) contribute four reads the
+        // single-strand filter rejects as MinorityAlignment before the whole-group check.
         let reads = duplex_molecule(3, true, true);
         let input_count = reads.len();
+        let minority_reads = 4;
 
         let result = caller.consensus_reads(reads)?;
         assert_eq!(result.count, 0, "the molecule must fail the post-filter depth threshold");
@@ -4195,15 +4257,85 @@ mod tests {
             "a whole-group rejection counts every input record exactly once"
         );
         assert_eq!(
-            stats.rejection_reasons.get(&RejectionReason::InsufficientReads).copied().unwrap_or(0),
-            input_count,
-            "the whole group is attributed to the duplex layer's own reason"
+            stats.rejection_reasons.get(&RejectionReason::MinorityAlignment).copied().unwrap_or(0),
+            minority_reads,
+            "the single-strand-rejected reads must keep their MinorityAlignment reason",
         );
         assert_eq!(
-            stats.rejection_reasons.get(&RejectionReason::MinorityAlignment),
-            None,
-            "the single-strand reasons must not be added on top of the whole-group count"
+            stats.rejection_reasons.get(&RejectionReason::InsufficientReads).copied().unwrap_or(0),
+            input_count - minority_reads,
+            "only the survivors of the single-strand filter are attributed to the whole-group reason",
         );
+        assert_eq!(
+            caller.rejected_reads.len(),
+            stats.filtered_reads,
+            "the rejects buffer must reconcile with raw_reads_rejected"
+        );
+        Ok(())
+    }
+
+    /// #791 × #792: a whole-group rejection carrying *both* single-strand reasons must split them
+    /// all first-writer-wins.
+    ///
+    /// This pins the composition of the two fixes: the minority-alignment reads (dropped by the
+    /// alignment filter) and the zero-length reads (dropped by `create_source_read` under `--trim`)
+    /// must each keep their own reason, and only the survivors carry the whole-group reason. Without
+    /// #792 the zero-length reads would never reach the sub-caller's stats, so the reattribution
+    /// would leave them folded into the whole-group reason — this asserts they do not.
+    ///
+    /// Fixture: three clean templates per strand, one minority-alignment template per strand
+    /// (`MinorityAlignment`), and one `/A` template whose bases are all below the minimum input base
+    /// quality so it trims to zero (`ZeroLengthAfterTrimming`). `min_reads = 4` is met before the
+    /// single-strand filter and missed after it, so the group is rejected as `InsufficientReads`.
+    #[test]
+    fn test_whole_group_rejection_splits_all_single_strand_reasons() -> Result<()> {
+        // Quality trimming enabled (6th arg) so the all-low-quality template trims to zero length.
+        let mut caller = DuplexConsensusCaller::new(
+            "consensus".to_string(),
+            "RG1".to_string(),
+            vec![4],
+            10, // min_input_base_quality
+            false,
+            true, // trim
+            None,
+            None,
+            true, // track_rejects
+            45,
+            40,
+        )?;
+
+        let mut reads = duplex_molecule(3, true, true);
+        let minority_reads = 4; // one minority template per strand, two reads each
+        // One /A template whose bases are all below the minimum input base quality: trims to zero.
+        let mut b = SamBuilder::new();
+        let cigar_10m = &[encode_op(0, 10)];
+        let low_quals = &[2u8; 10];
+        reads.push(ab_r1(&mut b, b"trimmed", b"AAAAAAAAAA", low_quals, cigar_10m, b"foo/A", &[]));
+        reads.push(ab_r2(&mut b, b"trimmed", b"CCCCCCCCCC", low_quals, cigar_10m, b"foo/A", &[]));
+        let zero_length_reads = 2;
+        let input_count = reads.len();
+
+        let result = caller.consensus_reads(reads)?;
+        assert_eq!(result.count, 0, "the molecule must fail the post-filter depth threshold");
+
+        let stats = caller.statistics();
+        let reason = |r: RejectionReason| stats.rejection_reasons.get(&r).copied().unwrap_or(0);
+        assert_eq!(
+            reason(RejectionReason::MinorityAlignment),
+            minority_reads,
+            "the minority-alignment reads must keep their reason",
+        );
+        assert_eq!(
+            reason(RejectionReason::ZeroLengthAfterTrimming),
+            zero_length_reads,
+            "the zero-length reads must keep their reason, not fold into the whole-group reason",
+        );
+        assert_eq!(
+            reason(RejectionReason::InsufficientReads),
+            input_count - minority_reads - zero_length_reads,
+            "only the survivors of the single-strand filter carry the whole-group reason",
+        );
+        assert_eq!(stats.filtered_reads, input_count, "every input read is rejected exactly once");
         assert_eq!(
             caller.rejected_reads.len(),
             stats.filtered_reads,

--- a/tests/integration/test_duplex_command.rs
+++ b/tests/integration/test_duplex_command.rs
@@ -834,6 +834,97 @@ fn test_duplex_zero_length_rejects_preserve_input_order_for_b_strand(
     );
 }
 
+/// #791: a whole-group rejection downstream of the single-strand filter must split its `--stats`
+/// reasons the way fgbio does (first-writer-wins).
+///
+/// `--min-reads 4` is met before single-strand filtering (four templates per strand) and missed
+/// after the two minority-alignment templates are dropped (three survive per strand), so the group
+/// is rejected as `InsufficientSupport` downstream of the filter. The four minority reads must be
+/// counted under `raw_reads_rejected_for_minority_alignment`, and only the twelve survivors under
+/// `raw_reads_rejected_for_insufficient_support` — not the whole group under one reason. The reject
+/// total is unchanged, so `--rejects` still reconciles.
+#[rstest]
+#[case::single_threaded(None)]
+#[case::threaded(Some("2"))]
+fn test_duplex_whole_group_rejection_splits_stats_reasons(#[case] threads: Option<&str>) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let rejects_bam = temp_dir.path().join("rejects.bam");
+    let stats_path = temp_dir.path().join("stats.txt");
+
+    // 3M1D5M against the majority 8M: same query length, different alignment pattern.
+    let gapped = [3u32 << 4, (1u32 << 4) | 2, 5u32 << 4];
+    let mut molecule = create_duplex_molecule("1", "ACGTACGT", 30, 100, 3);
+    molecule.push(create_duplex_read_pair_with_cigar(
+        "min_a", "1/A", "ACGTACGT", "ACGTACGT", 30, 100, false, &gapped,
+    ));
+    molecule.push(create_duplex_read_pair_with_cigar(
+        "min_b", "1/B", "ACGTACGT", "ACGTACGT", 30, 100, true, &gapped,
+    ));
+    create_duplex_bam(&input_bam, vec![molecule]);
+
+    let mut args = vec![
+        "duplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--rejects",
+        rejects_bam.to_str().unwrap(),
+        "--stats",
+        stats_path.to_str().unwrap(),
+        "--min-reads",
+        "4",
+        "--compression-level",
+        "1",
+    ];
+    if let Some(threads) = threads {
+        args.extend_from_slice(&["--threads", threads]);
+    }
+    Duplex::try_parse_from(args)
+        .expect("failed to parse duplex args")
+        .execute("fgumi duplex")
+        .expect("Duplex command failed");
+
+    let mut output_reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    output_reader.read_header().expect("read output header");
+    assert_eq!(
+        output_reader.records().count(),
+        0,
+        "the group must be rejected once the minority templates drop it below --min-reads"
+    );
+
+    let reject_count = read_raw_records(&rejects_bam).len();
+
+    let stats = fs::read_to_string(&stats_path).expect("read stats");
+    let stat = |key: &str| -> usize {
+        stats
+            .lines()
+            .find_map(|line| line.strip_prefix(&format!("{key}\t")))
+            .and_then(|rest| rest.split('\t').next())
+            .unwrap_or_else(|| panic!("stats must contain a {key} row"))
+            .parse()
+            .unwrap_or_else(|_| panic!("{key} must be an integer"))
+    };
+    assert_eq!(
+        stat("raw_reads_rejected_for_minority_alignment"),
+        4,
+        "the four minority reads must keep their single-strand reason"
+    );
+    assert_eq!(
+        stat("raw_reads_rejected_for_insufficient_support"),
+        12,
+        "only the twelve survivors are attributed to the whole-group reason"
+    );
+    assert_eq!(stat("raw_reads_rejected"), 16, "every input read is rejected exactly once");
+    assert_eq!(
+        reject_count,
+        stat("raw_reads_rejected"),
+        "the rejects BAM record count must equal raw_reads_rejected"
+    );
+}
+
 /// #757 (follow-up): single-strand rejects must reach the rejects BAM in input order.
 ///
 /// The two combined alignment groups split a template's ends across strands: X = AB-R1 +


### PR DESCRIPTION
Closes #791.

## The bug

On the duplex whole-group rejection path, reads the single-strand layer had already rejected as `MinorityAlignment` were re-attributed *entirely* to the duplex whole-group reason (e.g. `InsufficientSupport`). fgbio instead keeps the single-strand reason on those records (first-writer-wins) and applies the whole-group reason only to the survivors. The reject-count **total** agreed either way — which is why #758's reconciliation held — but the per-reason split in `--stats` did not, so the reason rows were not comparable to fgbio on this path.

Mechanism: when the duplex layer rejects the whole group downstream of the single-strand filter, `process_group` counts the entire raw group (`N` reads) under one duplex reason, and the drain site dropped the single-strand caller's stats delta (the `M` `MinorityAlignment` reads) to avoid double-counting the total. So those `M` reads were counted only under the duplex reason, never under `MinorityAlignment`.

## The fix

The rejects BAM carries no per-record reason (records are byte-for-byte identical to their input, as #758's tests assert), so this is purely a `--stats` attribution fix — handled at the drain site, not the five whole-group sites.

New `reattribute_single_strand_rejections` moves the `M` single-strand-rejected reads out of the whole-group reason bucket and into their own (`MinorityAlignment`/`Unmapped`), matching fgbio's first-writer-wins. It is a **reason move, not a total change**: `filtered_reads` is decremented by `M` then the single-strand stats are folded back in, so the net total is unchanged and `--rejects` still reconciles with `raw_reads_rejected`. Pre-filter rejections leave the single-strand stats empty, so it is a no-op for them.

## Parity with fgbio

fgbio's `rejectRecords` is first-writer-wins (`recs.filterNot(_.contains(RejectReasonTag))`): a record already tagged `MinorityAlignment` in `filterToMostCommonAlignment` keeps that reason, and the whole-group `rejectRecords(groups.flatten, …)` lands only on the survivors (`DuplexConsensusCaller.scala:359-362`). This change makes the fgumi `--stats` split match.

## Tests

TDD; the unit assertions were confirmed to fail (`MinorityAlignment` `0` vs `4`) against the pre-fix code before implementing.

- `test_whole_group_rejection_preserves_single_strand_reasons` (unit, was `test_single_strand_rejections_are_not_double_counted_on_whole_group_rejection`) — a molecule met by `min_reads = 4` before the single-strand filter and missed after it, with a control run pinning the fixture is not vacuous. Now asserts the four minority reads keep `MinorityAlignment`, the twelve survivors carry `InsufficientReads`, the total is still every input read once, and the rejects buffer reconciles. The pre-existing no-double-count invariant is retained.
- `test_whole_group_rejection_counts_are_independent_of_rejects_tracking` (unchanged) — still passes: the reattribution reads the single-strand stats, which are independent of `--rejects` tracking, so the per-reason breakdown is identical with and without it.
- `test_duplex_whole_group_rejection_splits_stats_reasons` (integration, single-threaded and `--threads 2`) — the split in the actual `--stats` file: `raw_reads_rejected_for_minority_alignment = 4`, `raw_reads_rejected_for_insufficient_support = 12`, `raw_reads_rejected = 16`, and the rejects BAM record count equals `raw_reads_rejected`.

## Not changed here

The other "Not changed here" items from #758 (the `create_source_read` zero-length drop, tracked in #792/PR #793; the absent-qualities divergence in #794) are separate and untouched.

## Gate

`cargo ci-fmt`, `cargo ci-lint`, `cargo ci-test` all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: command output changes only in `--stats` reason attribution; grouping, consensus, sort order, corrected UMIs, and rejection totals are unchanged; no `unsafe` changes or CLAUDE.md allowlist update; no memory-bound, queue-capacity, or thread/backpressure changes.

Fix: Preserve first-writer-wins attribution for single-strand rejection reasons. Apply the duplex whole-group reason only to surviving reads.

- Track `ZeroLengthAfterTrimming` reads and retain them in rejects output order.
- Preserve rejection totals and `raw_reads_rejected` reconciliation.
- Add single-threaded and multithreaded integration coverage for mixed rejection reasons, ordering, deduplication, output counts, and `--stats`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->