### PR TITLE
perf(raw-bam): skip the record-read zero-fill via a spare-capacity read (#786)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,10 @@ regresses `samtools sort -n`–style throughput.
     SAFETY: the buffers are `to_vec()` + push, so the pointer is valid and
     null-terminated for the call's lifetime.
 
+### Approved spare-capacity record read (fgumi-raw-bam)
+
+- **`crates/fgumi-raw-bam/src/raw_bam_record.rs`** — `read_raw_record` reads a BAM record body into the spare capacity of the caller's reused `Vec<u8>` to skip the `resize(_, 0)` zero-fill (gigabytes of wasted zero-stores on large BAMs). SAFETY: `Read::read_exact` only writes to the destination; `spare_capacity_mut()[..block_size]` is valid uninitialized storage; `set_len(block_size)` runs only after `read_exact` returns `Ok`, so every byte covered by the new length is initialized. On error `set_len` is skipped and the Vec length stays 0.
+
 ### Approved SIMD intrinsics (fgumi-simd-fastq)
 
 `crates/fgumi-simd-fastq/src/lexer.rs` classifies 64-byte FASTQ blocks through

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,7 +213,7 @@ regresses `samtools sort -n`–style throughput.
 
 ### Approved spare-capacity record read (fgumi-raw-bam)
 
-- **`crates/fgumi-raw-bam/src/raw_bam_record.rs`** — `read_raw_record` reads a BAM record body into the spare capacity of the caller's reused `Vec<u8>` to skip the `resize(_, 0)` zero-fill (gigabytes of wasted zero-stores on large BAMs). SAFETY: `Read::read_exact` only writes to the destination; `spare_capacity_mut()[..block_size]` is valid uninitialized storage; `set_len(block_size)` runs only after `read_exact` returns `Ok`, so every byte covered by the new length is initialized. On error `set_len` is skipped and the Vec length stays 0.
+- **`crates/fgumi-raw-bam/src/raw_bam_record.rs`** — `read_raw_record` reads a BAM record body into the spare capacity of the caller's reused `Vec<u8>` to skip the `resize(_, 0)` zero-fill (gigabytes of wasted zero-stores on large BAMs). SAFETY: `spare_capacity_mut()[..block_size]` is valid uninitialized storage and `set_len(block_size)` runs only after `read_exact` returns `Ok`, so every byte covered by the new length is initialized — *provided* `read_exact` only writes to the destination and never reads from it. That is a trust boundary on the concrete reader's behavior, not a guarantee `Read` makes at the trait level; it holds because every call site passes a trusted first-party reader (the BGZF decode stream, `File`, `Cursor`). On error `set_len` is skipped and the Vec length stays 0.
 
 ### Approved SIMD intrinsics (fgumi-simd-fastq)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,6 +821,7 @@ dependencies = [
  "anyhow",
  "bstr 1.13.1",
  "bytemuck",
+ "criterion",
  "fgumi-dna",
  "fgumi-tag",
  "noodles",

--- a/crates/fgumi-raw-bam/Cargo.toml
+++ b/crates/fgumi-raw-bam/Cargo.toml
@@ -22,6 +22,11 @@ test-utils = []
 
 [dev-dependencies]
 bstr = { workspace = true }
+criterion = { workspace = true }
 proptest = { workspace = true }
 rstest = { workspace = true }
 tempfile = { workspace = true }
+
+[[bench]]
+name = "record_read"
+harness = false

--- a/crates/fgumi-raw-bam/benches/record_read.rs
+++ b/crates/fgumi-raw-bam/benches/record_read.rs
@@ -1,0 +1,119 @@
+//! Compares the two `read_raw_record` body-read strategies head-to-head over
+//! the SAME in-memory record stream, in one bench binary:
+//!
+//! * `zerofill` -- the OLD strategy: `resize(block_size, 0)` then
+//!   `read_exact` (the memset PR1 removed).
+//! * `spare_capacity` -- the NEW strategy: `clear()` + `reserve(block_size)`
+//!   then a spare-capacity `read_exact` + `set_len` (what `read_raw_record`
+//!   does today).
+//!
+//! Both arms read from a `Cursor` over the identical byte buffer, so
+//! criterion isolates the single-line difference with no cross-build /
+//! page-cache confound. The `zerofill` arm reconstructs the pre-change body
+//! against a plain, locally-owned `Vec<u8>` -- the library's `RawRecord`
+//! inner `Vec` is private outside the crate -- but calls the same public
+//! `read_block_size` helper and does the identical `resize`/`read_exact`
+//! pair `read_raw_record` used to do, over the same bytes. The
+//! `spare_capacity` arm calls the real, current `read_raw_record` directly,
+//! which is the most faithful "new" measurement.
+//!
+//! Run with: `cargo bench -p fgumi-raw-bam --bench record_read`
+//! Quick sanity: `cargo bench -p fgumi-raw-bam --bench record_read -- --quick`
+
+// Benches are a separate crate from the library; the library itself stays
+// `#![deny(unsafe_code)]`. Nothing below currently needs `unsafe`, but this
+// mirrors the brief's isolation of any bench-local unsafe spare-capacity
+// experiments to this file only, never the library.
+#![allow(unsafe_code)]
+
+use std::hint::black_box;
+use std::io::{self, Cursor, Read};
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use fgumi_raw_bam::{RawRecord, SamTag, UnmappedSamBuilder, read_block_size, read_raw_record};
+
+/// Number of records in the synthetic stream. Large enough to amortize
+/// per-iteration fixed costs (cursor/buffer setup) and to exercise many
+/// resize/reserve cycles on the reused buffer.
+const NUM_RECORDS: usize = 200_000;
+
+/// Realistic short-read body sizes to cycle through, so the reused buffer's
+/// resize/reserve path sees both growing and shrinking records rather than a
+/// single fixed size.
+const SEQ_LENS: [usize; 3] = [100, 150, 250];
+
+/// Build a stream of `num_records` `block_size`-prefixed BAM records back to
+/// back, each with a packed sequence + quality of a cycling length plus two
+/// aux tags (`RG:Z`, `NM:i`) -- a realistic short-read record body of a few
+/// hundred bytes.
+fn make_record_stream(num_records: usize) -> Vec<u8> {
+    let mut builder = UnmappedSamBuilder::new();
+    let mut buf = Vec::new();
+    for i in 0..num_records {
+        let len = SEQ_LENS[i % SEQ_LENS.len()];
+        let bases: Vec<u8> = (0..len).map(|j| b"ACGT"[j % 4]).collect();
+        let quals = vec![30u8; len];
+        let name = format!("read:{i}");
+        builder.build_record(name.as_bytes(), 0, &bases, &quals);
+        builder.append_string_tag(SamTag::RG, b"sample1");
+        builder.append_int_tag(SamTag::NM, 0);
+        builder.write_with_block_size(&mut buf);
+    }
+    buf
+}
+
+/// The OLD `read_raw_record` body-read strategy: `resize(block_size, 0)`
+/// (zero-fill) then `read_exact` overwrites it. See the module doc for why
+/// this operates on a plain `Vec<u8>` rather than a `RawRecord`.
+fn read_zerofill<R: Read>(reader: &mut R, buf: &mut Vec<u8>) -> io::Result<usize> {
+    let block_size = match read_block_size(reader)? {
+        0 => return Ok(0),
+        n => n,
+    };
+    buf.resize(block_size, 0);
+    reader.read_exact(buf)?;
+    Ok(block_size)
+}
+
+fn bench_record_read(c: &mut Criterion) {
+    let stream = make_record_stream(NUM_RECORDS);
+
+    let mut group = c.benchmark_group("record_read");
+
+    group.bench_function("zerofill", |b| {
+        b.iter(|| {
+            let mut cursor = Cursor::new(stream.as_slice());
+            let mut buf = Vec::new();
+            let mut count = 0u64;
+            loop {
+                let n = read_zerofill(&mut cursor, &mut buf).expect("read should succeed");
+                if n == 0 {
+                    break;
+                }
+                count += 1;
+            }
+            black_box(count)
+        });
+    });
+
+    group.bench_function("spare_capacity", |b| {
+        b.iter(|| {
+            let mut cursor = Cursor::new(stream.as_slice());
+            let mut record = RawRecord::new();
+            let mut count = 0u64;
+            loop {
+                let n = read_raw_record(&mut cursor, &mut record).expect("read should succeed");
+                if n == 0 {
+                    break;
+                }
+                count += 1;
+            }
+            black_box(count)
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_record_read);
+criterion_main!(benches);

--- a/crates/fgumi-raw-bam/src/raw_bam_record.rs
+++ b/crates/fgumi-raw-bam/src/raw_bam_record.rs
@@ -165,8 +165,29 @@ where
         n => n,
     };
 
-    record.0.resize(block_size, 0);
-    reader.read_exact(&mut record.0)?;
+    record.0.clear();
+    record.0.reserve(block_size);
+    // SAFETY: spare_capacity_mut()[..block_size] is valid uninit storage
+    // owned by this Vec, and set_len is called only after read_exact returns
+    // Ok, at which point all block_size bytes are initialized -- *provided*
+    // read_exact only writes to the destination and never reads from it.
+    // That provision is a trust boundary on R's concrete behavior, not
+    // something the `Read` trait guarantees at the type level (a misbehaving
+    // impl could over-report bytes written or read stale/uninitialized bytes
+    // back out of the buffer -- the bug class std::io::BorrowedBuf exists to
+    // close). It holds here because every call site in this crate passes a
+    // trusted first-party reader (the BGZF decode stream, `File`, or
+    // `Cursor`), all of which honor the read_exact contract, and Miri's
+    // interpreter validates this block under those readers. If/when
+    // `BorrowedBuf`/`read_buf_exact` are convenient on this MSRV, they would
+    // let the compiler enforce this instead of us asserting it.
+    #[allow(unsafe_code)]
+    unsafe {
+        let spare = &mut record.0.spare_capacity_mut()[..block_size];
+        let target = std::slice::from_raw_parts_mut(spare.as_mut_ptr().cast::<u8>(), block_size);
+        reader.read_exact(target)?;
+        record.0.set_len(block_size);
+    }
 
     Ok(block_size)
 }
@@ -1175,6 +1196,35 @@ mod tests {
         let n =
             read_raw_record(&mut reader, &mut record).expect("reading at EOF should return Ok(0)");
         assert_eq!(n, 0); // EOF
+    }
+
+    /// A `RawRecord` reused across two reads, where the second body is shorter
+    /// than the first, must contain exactly the second record's bytes -- no
+    /// leftover tail from the first (the bug a naive spare-capacity read could
+    /// introduce if `set_len` were mishandled).
+    #[test]
+    fn reused_record_has_no_stale_tail_when_shorter_record_follows() {
+        use crate::testutil::*;
+
+        let long_bytes = make_bam_bytes(0, 0, 0, b"rd", &[], 0, -1, -1, &[0xABu8; 165]);
+        let long = RawRecord::from(long_bytes);
+        assert_eq!(long.len(), 200);
+
+        let short_bytes = make_bam_bytes(0, 0, 0, b"rd", &[], 0, -1, -1, &[0xCDu8; 5]);
+        let short = RawRecord::from(short_bytes);
+        assert_eq!(short.len(), 40);
+
+        let mut buf = Vec::new();
+        write_raw_record(&mut buf, &long).unwrap();
+        write_raw_record(&mut buf, &short).unwrap();
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let mut rec = RawRecord::new();
+        assert_eq!(read_raw_record(&mut cursor, &mut rec).unwrap(), long.len());
+        assert_eq!(rec.as_ref(), long.as_ref());
+        assert_eq!(read_raw_record(&mut cursor, &mut rec).unwrap(), short.len());
+        assert_eq!(rec.as_ref(), short.as_ref());
+        assert_eq!(rec.len(), short.len());
     }
 
     // ── Edge-case tests for length-changing edits ──────────────────────────


### PR DESCRIPTION
Part of #786 (dupblaster→fgumi optimizations).

`RawRecord::read_raw_record` resized its backing buffer with `resize(block_size, 0)` before `read_exact`, zero-filling bytes that the read immediately overwrites. This replaces the resize with a spare-capacity read into the `Vec`'s uninitialized tail, then sets the length to what was actually read — the zero-fill is pure waste on a hot path that runs once per BAM record (millions to billions of records).

The read is the crate's one documented `#[allow(unsafe_code)]` addition (recorded in CLAUDE.md), framed as a trust boundary: we hand the reader an uninitialized slice and only expose the bytes it reports writing. A guard test (`reused_record_has_no_stale_tail_when_shorter_record_follows`) pins the correctness-critical case — a reused record must not leak a previous longer record's tail.

## Benchmark

Added `benches/record_read.rs`, a head-to-head criterion bench over the same in-memory stream (c8g.4xlarge, Graviton4): zero-fill 2.395 ms vs spare-capacity 2.316 ms → **~3.3% faster**, non-overlapping confidence intervals. Modest but real, with no downside.

## Verification

fgumi-raw-bam 751/751 unit tests, Miri clean, full workspace suite green, plus the added guard test.
