### PR TITLE
feat(dedup): per-library complexity metrics and duplication saturation ladder (#786)

### DIFF
--- a/crates/fgumi-metrics/src/dedup.rs
+++ b/crates/fgumi-metrics/src/dedup.rs
@@ -1,13 +1,23 @@
 //! Metrics for the `dedup` command.
+//!
+//! [`DeduplicationMetrics`] is the serializable row type written by `fgumi dedup
+//! --metrics`. One row is written per library observed in the input, plus a
+//! final aggregate row summing across all libraries (see the `dedup` command
+//! for the exact library-splitting and total-row naming).
 
 use serde::{Deserialize, Serialize};
 
 use crate::Metric;
+use crate::library_size::estimate_library_size;
 
-/// Metrics written by `fgumi dedup --metrics`.
+/// Metrics written by `fgumi dedup --metrics`, one row per library plus an
+/// aggregate total row.
 ///
-/// Three sections, in column order:
+/// Columns are grouped, in order:
 ///
+/// 0. **Identity** — `library`: the library the row summarizes, or a sentinel
+///    ("Unknown Library" for reads with no resolvable `@RG`/`LB`, "All Reads"
+///    for the aggregate row) — see the `dedup` command for the exact naming.
 /// 1. **Filtering** — `filtered_templates` through `passthrough_templates`.
 ///    `dedup` is a read *filter* as well as a duplicate marker: templates failing
 ///    the pre-grouping filter are dropped and never reach the output. The
@@ -20,6 +30,8 @@ use crate::Metric;
 ///    dropped at write time, after they have been counted here.
 /// 3. **Diagnostics** — `secondary_reads`, `supplementary_reads`,
 ///    `missing_tc_tag`.
+/// 4. **Complexity** — `percent_duplication` (read-level, Picard-parity) and the
+///    Lander-Waterman `estimated_library_size`.
 ///
 /// Templates read from the input are `filtered_templates + total_templates`; that
 /// sum is not emitted as its own column because it is derivable, matching
@@ -28,8 +40,10 @@ use crate::Metric;
 // into docs/src/metrics/deduplication-metrics.md, where a rustdoc link would come
 // out as literal markdown. Keep field docs to a single short line: they become the
 // Description column of that page's table.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct DeduplicationMetrics {
+    /// Library name, "Unknown Library", or "All Reads" (the aggregate row)
+    pub library: String,
     /// Templates dropped by the filter (any reason)
     pub filtered_templates: u64,
     /// Templates dropped (record shorter than the minimum BAM record length)
@@ -73,6 +87,75 @@ pub struct DeduplicationMetrics {
     pub supplementary_reads: u64,
     /// Secondary/supplementary reads lacking the `tc` tag
     pub missing_tc_tag: u64,
+    /// Read-level duplicate fraction (`duplicate_reads` / `total_reads`).
+    ///
+    /// Distinct from the template-level `duplicate_rate` above; this is the
+    /// Picard `PERCENT_DUPLICATION`-parity column.
+    #[serde(with = "crate::float")]
+    pub percent_duplication: f64,
+    /// Lander-Waterman estimate of the complete library size, or empty when the
+    /// estimate is undefined (no templates, or no duplicates observed).
+    ///
+    /// fgumi counts *templates*, not read pairs directly; this treats
+    /// `total_templates`/`unique_templates` as `n_pairs`/`n_unique` (each
+    /// template stands in for one read pair in paired-end data). This is the
+    /// same approximation `duplicate_rate` above already makes by reporting a
+    /// template-level rather than a read-pair-level rate.
+    pub estimated_library_size: Option<u64>,
+}
+
+/// Raw per-library (or aggregate) counts used to build a [`DeduplicationMetrics`]
+/// row.
+///
+/// Everything except the three derived columns — `duplicate_rate`,
+/// `percent_duplication`, and `estimated_library_size` — is copied through 1:1
+/// by [`DeduplicationMetrics::from_counts`], which computes those three. Using a
+/// struct rather than a 20-plus-argument constructor keeps the call sites (one
+/// per library, plus the total) readable and self-labeling.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct DeduplicationCounts {
+    /// Library name, "Unknown Library", or "All Reads".
+    pub library: String,
+    /// Templates dropped by the filter (any reason).
+    pub filtered_templates: u64,
+    /// Templates dropped (record shorter than the minimum BAM record length).
+    pub filtered_malformed_record: u64,
+    /// Templates dropped (no primary R1 or R2).
+    pub filtered_no_primary_reads: u64,
+    /// Templates dropped (no mapped primary read).
+    pub filtered_unmapped: u64,
+    /// Templates dropped (QC-fail flag).
+    pub filtered_not_passing_filter: u64,
+    /// Templates dropped (mapping quality below `--min-map-q`).
+    pub filtered_low_mapping_quality: u64,
+    /// Templates dropped (mate `MQ` below `--min-map-q`).
+    pub filtered_low_mate_mapping_quality: u64,
+    /// Templates dropped (no UMI tag).
+    pub filtered_missing_umi: u64,
+    /// Templates dropped (N base in the UMI).
+    pub filtered_ns_in_umi: u64,
+    /// Templates dropped (UMI shorter than `--min-umi-length`).
+    pub filtered_umi_too_short: u64,
+    /// Templates emitted untouched by `--include-unmapped`.
+    pub passthrough_templates: u64,
+    /// Templates that passed the filter.
+    pub total_templates: u64,
+    /// Templates kept as their family's representative.
+    pub unique_templates: u64,
+    /// Templates marked as duplicates.
+    pub duplicate_templates: u64,
+    /// Reads in templates that passed the filter.
+    pub total_reads: u64,
+    /// Reads not marked as duplicates.
+    pub unique_reads: u64,
+    /// Reads marked as duplicates.
+    pub duplicate_reads: u64,
+    /// Secondary alignments that passed the filter.
+    pub secondary_reads: u64,
+    /// Supplementary alignments that passed the filter.
+    pub supplementary_reads: u64,
+    /// Secondary/supplementary reads lacking the `tc` tag.
+    pub missing_tc_tag: u64,
 }
 
 impl DeduplicationMetrics {
@@ -80,6 +163,62 @@ impl DeduplicationMetrics {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Builds a metrics row from summed counts for one library (or the aggregate
+    /// total across all libraries), computing the derived `duplicate_rate`,
+    /// `percent_duplication`, and `estimated_library_size` columns.
+    #[must_use]
+    pub fn from_counts(counts: DeduplicationCounts) -> Self {
+        let DeduplicationCounts {
+            library,
+            filtered_templates,
+            filtered_malformed_record,
+            filtered_no_primary_reads,
+            filtered_unmapped,
+            filtered_not_passing_filter,
+            filtered_low_mapping_quality,
+            filtered_low_mate_mapping_quality,
+            filtered_missing_umi,
+            filtered_ns_in_umi,
+            filtered_umi_too_short,
+            passthrough_templates,
+            total_templates,
+            unique_templates,
+            duplicate_templates,
+            total_reads,
+            unique_reads,
+            duplicate_reads,
+            secondary_reads,
+            supplementary_reads,
+            missing_tc_tag,
+        } = counts;
+        Self {
+            library,
+            filtered_templates,
+            filtered_malformed_record,
+            filtered_no_primary_reads,
+            filtered_unmapped,
+            filtered_not_passing_filter,
+            filtered_low_mapping_quality,
+            filtered_low_mate_mapping_quality,
+            filtered_missing_umi,
+            filtered_ns_in_umi,
+            filtered_umi_too_short,
+            passthrough_templates,
+            total_templates,
+            unique_templates,
+            duplicate_templates,
+            duplicate_rate: crate::frac_u64(duplicate_templates, total_templates),
+            total_reads,
+            unique_reads,
+            duplicate_reads,
+            secondary_reads,
+            supplementary_reads,
+            missing_tc_tag,
+            percent_duplication: crate::frac_u64(duplicate_reads, total_reads),
+            estimated_library_size: estimate_library_size(total_templates, unique_templates),
+        }
     }
 }
 
@@ -103,11 +242,52 @@ impl crate::ProcessingMetrics for DeduplicationMetrics {
     }
 }
 
+/// Serializable row for the `--duplication-ladder` sampled duplication
+/// saturation curve: "after `templates_seen` templates processed (in
+/// coordinate order) for this library, what cumulative fraction were
+/// duplicates".
+///
+/// One row per (library, snapshot) — a library gets a row each time its
+/// cumulative `templates_seen` crosses a multiple of `--ladder-interval`,
+/// plus a final row at its true total. See the `dedup` command for the
+/// serial-order accumulation this depends on.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct DuplicationLadderMetrics {
+    /// Library name this row summarizes (or "Unknown Library"; never an
+    /// aggregate "All Reads" row — the ladder is inherently per-library).
+    pub library: String,
+    /// Cumulative templates seen for this library at this snapshot.
+    pub templates_seen: u64,
+    /// Cumulative duplicate fraction (`duplicate_templates / templates_seen`)
+    /// at this snapshot.
+    #[serde(with = "crate::float")]
+    pub duplicate_fraction: f64,
+}
+
+impl DuplicationLadderMetrics {
+    /// Builds one snapshot row from cumulative per-library counts.
+    #[must_use]
+    pub fn new(library: String, templates_seen: u64, duplicate_templates: u64) -> Self {
+        Self {
+            library,
+            templates_seen,
+            duplicate_fraction: crate::frac_u64(duplicate_templates, templates_seen),
+        }
+    }
+}
+
+impl Metric for DuplicationLadderMetrics {
+    fn metric_name() -> &'static str {
+        "duplication_ladder"
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::template_filter::TemplateFilterReason;
     use fgoxide::io::DelimFile;
+    use rstest::rstest;
     use tempfile::NamedTempFile;
 
     fn header_of(metrics: DeduplicationMetrics) -> String {
@@ -135,17 +315,20 @@ mod tests {
     }
 
     /// Column order is the file's contract; pin it whole so a field reorder is a
-    /// deliberate, reviewed change rather than a silent schema break.
+    /// deliberate, reviewed change rather than a silent schema break. `library`
+    /// leads; the filtering/dedup/diagnostics block matches the pre-per-library
+    /// schema; `percent_duplication` and `estimated_library_size` trail.
     #[test]
     fn serializes_expected_columns_in_order() {
         assert_eq!(
             header_of(DeduplicationMetrics::default()),
-            "filtered_templates\tfiltered_malformed_record\tfiltered_no_primary_reads\t\
+            "library\tfiltered_templates\tfiltered_malformed_record\tfiltered_no_primary_reads\t\
              filtered_unmapped\tfiltered_not_passing_filter\tfiltered_low_mapping_quality\t\
              filtered_low_mate_mapping_quality\tfiltered_missing_umi\tfiltered_ns_in_umi\t\
              filtered_umi_too_short\tpassthrough_templates\ttotal_templates\tunique_templates\t\
              duplicate_templates\tduplicate_rate\ttotal_reads\tunique_reads\tduplicate_reads\t\
-             secondary_reads\tsupplementary_reads\tmissing_tc_tag"
+             secondary_reads\tsupplementary_reads\tmissing_tc_tag\tpercent_duplication\t\
+             estimated_library_size"
         );
     }
 
@@ -160,5 +343,139 @@ mod tests {
         assert_eq!(metrics.total_input(), 100);
         assert_eq!(metrics.total_output(), 90);
         assert_eq!(metrics.total_filtered(), 10);
+    }
+
+    #[test]
+    fn metric_name_is_deduplication() {
+        assert_eq!(DeduplicationMetrics::metric_name(), "deduplication");
+    }
+
+    /// `(total, unique, duplicate)` counts — shared shape for both the
+    /// template and read triples below.
+    type Counts = (u64, u64, u64);
+
+    #[rstest]
+    #[case::with_duplicates("lib1".to_string(), (100, 10, 90), (200, 20, 180), 0.9, 0.9, true)]
+    #[case::no_duplicates("lib2".to_string(), (50, 50, 0), (100, 100, 0), 0.0, 0.0, false)]
+    #[case::empty_library("lib3".to_string(), (0, 0, 0), (0, 0, 0), 0.0, 0.0, false)]
+    fn from_counts_computes_rates_and_library_size(
+        #[case] library: String,
+        #[case] templates: Counts,
+        #[case] reads: Counts,
+        #[case] expected_duplicate_rate: f64,
+        #[case] expected_percent_duplication: f64,
+        #[case] expect_library_size_defined: bool,
+    ) {
+        let (total_templates, unique_templates, duplicate_templates) = templates;
+        let (total_reads, unique_reads, duplicate_reads) = reads;
+        let metrics = DeduplicationMetrics::from_counts(DeduplicationCounts {
+            library: library.clone(),
+            total_templates,
+            unique_templates,
+            duplicate_templates,
+            total_reads,
+            unique_reads,
+            duplicate_reads,
+            ..DeduplicationCounts::default()
+        });
+
+        assert_eq!(metrics.library, library);
+        assert_eq!(metrics.total_templates, total_templates);
+        assert_eq!(metrics.unique_templates, unique_templates);
+        assert_eq!(metrics.duplicate_templates, duplicate_templates);
+        assert!((metrics.duplicate_rate - expected_duplicate_rate).abs() < 1e-9);
+        assert_eq!(metrics.total_reads, total_reads);
+        assert_eq!(metrics.unique_reads, unique_reads);
+        assert_eq!(metrics.duplicate_reads, duplicate_reads);
+        assert!((metrics.percent_duplication - expected_percent_duplication).abs() < 1e-9);
+        assert_eq!(
+            metrics.estimated_library_size.is_some(),
+            expect_library_size_defined,
+            "estimated_library_size definedness mismatch: got {:?}",
+            metrics.estimated_library_size
+        );
+    }
+
+    /// `from_counts` copies the per-reason filter counts through unchanged, and
+    /// `ProcessingMetrics` reconciles input from them.
+    #[test]
+    fn from_counts_carries_filter_counts_through() {
+        use crate::ProcessingMetrics;
+        let metrics = DeduplicationMetrics::from_counts(DeduplicationCounts {
+            library: "lib1".to_string(),
+            filtered_templates: 7,
+            filtered_unmapped: 4,
+            filtered_missing_umi: 3,
+            passthrough_templates: 2,
+            total_templates: 90,
+            unique_templates: 80,
+            duplicate_templates: 10,
+            ..DeduplicationCounts::default()
+        });
+        assert_eq!(metrics.filtered_templates, 7);
+        assert_eq!(metrics.filtered_unmapped, 4);
+        assert_eq!(metrics.filtered_missing_umi, 3);
+        assert_eq!(metrics.passthrough_templates, 2);
+        assert_eq!(metrics.total_input(), 97);
+        assert_eq!(metrics.total_filtered(), 7);
+    }
+
+    #[test]
+    fn serializes_with_library_column_first_and_empty_cell_for_none() {
+        // lib1 has duplicates (estimate defined); lib2 has none (estimate undefined).
+        let metrics = vec![
+            DeduplicationMetrics::from_counts(DeduplicationCounts {
+                library: "lib1".to_string(),
+                total_templates: 100,
+                unique_templates: 10,
+                duplicate_templates: 90,
+                total_reads: 200,
+                unique_reads: 20,
+                duplicate_reads: 180,
+                ..DeduplicationCounts::default()
+            }),
+            DeduplicationMetrics::from_counts(DeduplicationCounts {
+                library: "lib2".to_string(),
+                total_templates: 50,
+                unique_templates: 50,
+                total_reads: 100,
+                unique_reads: 100,
+                ..DeduplicationCounts::default()
+            }),
+        ];
+
+        let file = NamedTempFile::new().expect("temp file");
+        DelimFile::default().write_tsv(file.path(), &metrics).expect("write");
+        let content = std::fs::read_to_string(file.path()).expect("read");
+        let mut lines = content.lines();
+
+        let header: Vec<&str> = lines.next().expect("header line").split('\t').collect();
+        assert_eq!(header.first(), Some(&"library"), "library column must be first: {header:?}");
+        let size_col = header
+            .iter()
+            .position(|&h| h == "estimated_library_size")
+            .expect("estimated_library_size column present");
+
+        let lib1_row: Vec<&str> = lines.next().expect("lib1 row").split('\t').collect();
+        assert_eq!(lib1_row.first(), Some(&"lib1"));
+        assert!(!lib1_row[size_col].is_empty(), "lib1 has duplicates: {lib1_row:?}");
+
+        let lib2_row: Vec<&str> = lines.next().expect("lib2 row").split('\t').collect();
+        assert_eq!(lib2_row.first(), Some(&"lib2"));
+        assert!(
+            lib2_row[size_col].is_empty(),
+            "lib2's None estimate must render empty: {lib2_row:?}"
+        );
+    }
+
+    #[test]
+    fn ladder_metric_computes_cumulative_fraction() {
+        let row = DuplicationLadderMetrics::new("lib1".to_string(), 100, 25);
+        assert_eq!(row.library, "lib1");
+        assert_eq!(row.templates_seen, 100);
+        assert!((row.duplicate_fraction - 0.25).abs() < 1e-9);
+        // Div-by-zero guard: zero templates yields a defined 0.0 fraction.
+        let empty = DuplicationLadderMetrics::new("lib2".to_string(), 0, 0);
+        assert!(empty.duplicate_fraction.abs() < 1e-9);
     }
 }

--- a/crates/fgumi-metrics/src/lib.rs
+++ b/crates/fgumi-metrics/src/lib.rs
@@ -16,6 +16,7 @@ pub mod dedup;
 pub mod duplex;
 pub mod float;
 pub mod group;
+pub mod library_size;
 pub mod rejection;
 pub mod shared;
 pub mod simplex;

--- a/crates/fgumi-metrics/src/lib.rs
+++ b/crates/fgumi-metrics/src/lib.rs
@@ -101,7 +101,7 @@ pub trait ProcessingMetrics {
 pub use clip::{ClipCounts, ClippingMetrics, ClippingMetricsCollection, ReadType};
 pub use consensus::{ConsensusCallerKind, ConsensusKvMetric, ConsensusMetrics};
 pub use correct::UmiCorrectionMetrics;
-pub use dedup::DeduplicationMetrics;
+pub use dedup::{DeduplicationCounts, DeduplicationMetrics, DuplicationLadderMetrics};
 pub use duplex::{
     DuplexFamilySizeMetric, DuplexMetricsCollector, DuplexUmiMetric, DuplexYieldMetric,
     FamilySizeMetric,

--- a/crates/fgumi-metrics/src/library_size.rs
+++ b/crates/fgumi-metrics/src/library_size.rs
@@ -1,0 +1,97 @@
+//! Lander–Waterman library-size estimation, a faithful port of Picard/HTSJDK
+//! `DuplicationMetrics.estimateLibrarySize`. Pure and IO-free.
+
+/// Estimate the number of unique molecules in a library from the observed
+/// read-pair counts, using the Lander–Waterman / Picard model.
+///
+/// `n_pairs` is the total number of (observed) read pairs; `n_unique` is the
+/// number of unique (non-duplicate) read pairs. Returns `None` when the
+/// estimate is undefined: no pairs, no duplicates (`n_unique == n_pairs`), or
+/// `n_unique >= n_pairs`.
+///
+/// This mirrors Picard's implementation bit-for-bit: it bisects a ratio `r`
+/// (library size `= n_unique * r`) over `f(x) = c/x - 1 + exp(-n/x)` for 40
+/// iterations after bracketing, and returns `n_unique * r` truncated to an
+/// integer.
+#[must_use]
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "read-pair counts stay well under 2^52 for any realistic library"
+)]
+#[expect(
+    clippy::many_single_char_names,
+    reason = "faithful port of Picard's estimateLibrarySize; names mirror the math (n, c, f, m, r, u)"
+)]
+pub fn estimate_library_size(n_pairs: u64, n_unique: u64) -> Option<u64> {
+    // Undefined cases (Picard returns null / guards these).
+    if n_pairs == 0 || n_unique == 0 || n_unique >= n_pairs {
+        return None;
+    }
+    let n = n_pairs as f64;
+    let c = n_unique as f64;
+
+    // f(x) = c/x - 1 + exp(-n/x); x = c * ratio.
+    let f = |x: f64| c / x - 1.0 + (-n / x).exp();
+
+    let mut m = 1.0_f64;
+    let mut big_m = 100.0_f64;
+
+    // Picard bails if f(m*c) < 0 at the low end; treat as undefined.
+    if f(m * c) < 0.0 {
+        return None;
+    }
+    // Expand the upper bracket until f(M*c) < 0.
+    while f(big_m * c) >= 0.0 {
+        big_m *= 10.0;
+    }
+    // 40-step bisection over the ratio.
+    for _ in 0..40 {
+        let r = f64::midpoint(m, big_m);
+        let u = f(r * c);
+        if u == 0.0 {
+            break;
+        } else if u > 0.0 {
+            m = r;
+        } else {
+            big_m = r;
+        }
+    }
+    let estimate = c * f64::midpoint(m, big_m);
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Picard truncates the final ratio*c product to an integer library size"
+    )]
+    #[expect(clippy::cast_sign_loss, reason = "estimate is always non-negative by construction")]
+    let estimate = estimate as u64;
+    Some(estimate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::estimate_library_size;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::typical_1m(1_000_000, 900_000, Some(4_660_793))]
+    #[case::typical_1k(1_000, 900, Some(4_660))]
+    #[case::half_unique(500_000, 250_000, Some(313_750))]
+    #[case::high_complexity(10_000, 9_500, Some(96_638))]
+    #[case::no_duplicates(100, 100, None)] // unique == pairs
+    #[case::unique_exceeds(100, 200, None)] // unique > pairs
+    #[case::zero_pairs(0, 0, None)]
+    #[case::zero_unique(1000, 0, None)]
+    fn matches_picard_reference(
+        #[case] n_pairs: u64,
+        #[case] n_unique: u64,
+        #[case] expected: Option<u64>,
+    ) {
+        let got = estimate_library_size(n_pairs, n_unique);
+        match (got, expected) {
+            (Some(g), Some(e)) => assert!(
+                (i128::from(g) - i128::from(e)).abs() <= 1,
+                "n_pairs={n_pairs} n_unique={n_unique}: got {g}, expected {e}"
+            ),
+            (a, b) => assert_eq!(a, b, "n_pairs={n_pairs} n_unique={n_unique}"),
+        }
+    }
+}

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -1524,28 +1524,51 @@ impl Command for MarkDuplicates {
 // Metrics writing
 //////////////////////////////////////////////////////////////////////////////
 
-/// Writes one metrics row per library observed in `per_library`, sorted by
-/// library name for deterministic output, followed by a final "All Reads"
-/// row summing across every library.
+/// Writes one metrics row per library observed in `per_library`, followed by a
+/// final "All Reads" row summing across every library.
+///
+/// Row order is deterministic: named libraries first (alphabetical), then the
+/// idx-0 "Unknown Library" catch-all (a sentinel, grouped after the real
+/// libraries), then the "All Reads" total last.
 ///
 /// Single-library inputs still get two rows (the one library, then "All
 /// Reads") rather than collapsing to a single row: this keeps the output
 /// shape uniform regardless of how many libraries the input actually has, so
 /// downstream readers never need to special-case the single-library count.
+///
+/// The aggregate "All Reads" row leaves `estimated_library_size` empty whenever
+/// it spans more than one library: a Lander-Waterman estimate is only meaningful
+/// within a single library, so a value pooled across distinct libraries would be
+/// misleading. This matches dupblaster, which never estimates library size across
+/// libraries; the per-library rows carry the meaningful estimates.
 fn write_dedup_metrics(
     per_library: &AHashMap<u16, DedupCounts>,
     total: &DedupCounts,
     library_index: &LibraryIndex,
     path: &PathBuf,
 ) -> Result<()> {
-    let mut rows: Vec<DeduplicationMetrics> = per_library
-        .iter()
-        .map(|(&idx, counts)| {
+    let mut ordered: Vec<(u16, &DedupCounts)> =
+        per_library.iter().map(|(&idx, counts)| (idx, counts)).collect();
+    // Named libraries sort alphabetically; the idx-0 "Unknown Library" catch-all
+    // sorts after them (`false` before `true`), so it lands just before the
+    // "All Reads" total appended below.
+    ordered.sort_by(|a, b| {
+        (a.0 == 0).cmp(&(b.0 == 0)).then_with(|| {
+            library_display_name(a.0, library_index).cmp(&library_display_name(b.0, library_index))
+        })
+    });
+    let mut rows: Vec<DeduplicationMetrics> = ordered
+        .into_iter()
+        .map(|(idx, counts)| {
             to_deduplication_metrics(library_display_name(idx, library_index), counts)
         })
         .collect();
-    rows.sort_by(|a, b| a.library.cmp(&b.library));
-    rows.push(to_deduplication_metrics("All Reads".to_string(), total));
+
+    let mut total_row = to_deduplication_metrics("All Reads".to_string(), total);
+    if per_library.len() > 1 {
+        total_row.estimated_library_size = None;
+    }
+    rows.push(total_row);
 
     DelimFile::default()
         .write_tsv(path, rows)

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -26,7 +26,7 @@ use crate::assigner::{PairedUmiAssigner, Strategy, UmiAssigner};
 use crate::grouper::{RawPositionGroup, RecordPositionGrouper, build_templates_from_records};
 use crate::logging::OperationTimer;
 use crate::metrics::group::FamilySizeMetrics;
-use crate::metrics::{DeduplicationCounts, DeduplicationMetrics};
+use crate::metrics::{DeduplicationCounts, DeduplicationMetrics, DuplicationLadderMetrics};
 use crate::metrics::{TemplateFilterCounts, TemplateFilterReason};
 use crate::read_info::LibraryIndex;
 use crate::sam::SamTag;
@@ -196,6 +196,113 @@ struct CollectedDedupCounts {
     /// Family size counts, global across all libraries (out of scope for
     /// per-library splitting).
     family_sizes: AHashMap<usize, u64>,
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Duplication saturation ladder (--duplication-ladder)
+//////////////////////////////////////////////////////////////////////////////
+
+/// Per-library cumulative counters and emitted snapshot rows backing
+/// `--duplication-ladder`.
+///
+/// # Ordering
+///
+/// A saturation curve plots "after N templates processed, in coordinate
+/// order, what cumulative fraction were duplicates" — so [`Self::record`]
+/// MUST be called in strict serial/coordinate order, one call per position
+/// group. It is wired into the `mi_assign_fn` hook installed on the pipeline
+/// (`run_bam_pipeline_from_reader_with_mi_assign`), which the pipeline
+/// harness runs in serial order by the MI Assign zone before each item's
+/// `serialize_fn`. `dedup` installs this hook unconditionally — not gated on
+/// `--no-umi`, strategy, or any other flag — so it runs for every position
+/// group in every mode, making it the correct accumulation point. Do NOT
+/// accumulate this in `serialize_fn`: that closure also runs once per group,
+/// but workers execute it in parallel completion order, not coordinate order.
+#[derive(Default)]
+struct DuplicationLadderRecorder {
+    /// Snapshot interval in cumulative templates (`--ladder-interval`).
+    interval: u64,
+    /// Per-library running totals and next snapshot threshold.
+    per_library: AHashMap<u16, LadderLibraryState>,
+    /// Emitted `(library_idx, templates_seen, duplicate_templates)` rows, in
+    /// emission order (interval crossings interleaved across libraries as
+    /// groups are processed, plus the final per-library rows appended by
+    /// [`Self::finish`]). Sorted into deterministic (library, `templates_seen`)
+    /// order only at write time.
+    rows: Vec<(u16, u64, u64)>,
+}
+
+/// Running cumulative state for one library's saturation ladder.
+#[derive(Default)]
+struct LadderLibraryState {
+    /// Cumulative templates seen so far for this library.
+    templates_seen: u64,
+    /// Cumulative duplicate templates seen so far for this library.
+    duplicate_templates: u64,
+    /// Next cumulative `templates_seen` value that triggers a snapshot row.
+    next_threshold: u64,
+    /// `templates_seen` at the last emitted row, used by [`Self::finish`] (via
+    /// [`DuplicationLadderRecorder::finish`]) to avoid a duplicate final row
+    /// when the true total already landed exactly on an interval crossing.
+    last_emitted_at: u64,
+}
+
+impl DuplicationLadderRecorder {
+    fn new(interval: u64) -> Self {
+        Self { interval, per_library: AHashMap::new(), rows: Vec::new() }
+    }
+
+    /// Adds one position group's per-library template/duplicate counts.
+    ///
+    /// A position group always belongs to a single library (library
+    /// partitions the grouping key), so `group_counts`'s counts belong
+    /// entirely to `library_idx`. Emits at most one snapshot row per call,
+    /// the moment cumulative `templates_seen` reaches or passes a multiple of
+    /// `interval` — even when a single group's increment is large enough to
+    /// leap past more than one multiple at once (a small `--ladder-interval`
+    /// against a large position group), only one row is emitted, at the
+    /// group's true cumulative total, and `next_threshold` is re-based to the
+    /// next multiple strictly above it.
+    ///
+    /// MUST be called in serial/coordinate order — see the ordering note on
+    /// [`DuplicationLadderRecorder`].
+    fn record(&mut self, library_idx: u16, group_counts: &DedupCounts) {
+        if group_counts.total_templates == 0 {
+            return;
+        }
+        let interval = self.interval;
+        let state = self.per_library.entry(library_idx).or_insert_with(|| LadderLibraryState {
+            templates_seen: 0,
+            duplicate_templates: 0,
+            next_threshold: interval,
+            last_emitted_at: 0,
+        });
+        state.templates_seen += group_counts.total_templates;
+        state.duplicate_templates += group_counts.duplicate_templates;
+        // At most one row per `record()` call, even if this group's increment
+        // is large enough to cross more than one `interval` multiple at once
+        // (e.g. a single big position group with a small `--ladder-interval`).
+        // Jump `next_threshold` to the first multiple of `interval` strictly
+        // above the new cumulative `templates_seen` rather than a single
+        // `+= interval` step, so the next crossing check is correct instead
+        // of re-firing on the very next call.
+        if state.templates_seen >= state.next_threshold {
+            self.rows.push((library_idx, state.templates_seen, state.duplicate_templates));
+            state.last_emitted_at = state.templates_seen;
+            state.next_threshold =
+                state.templates_seen - (state.templates_seen % interval) + interval;
+        }
+    }
+
+    /// Emits a final snapshot per library at its true total, unless the last
+    /// interval snapshot already landed exactly on that total.
+    fn finish(&mut self) {
+        for (&library_idx, state) in &self.per_library {
+            if state.templates_seen > state.last_emitted_at {
+                self.rows.push((library_idx, state.templates_seen, state.duplicate_templates));
+            }
+        }
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -962,6 +1069,19 @@ pub struct MarkDuplicates {
     #[arg(short = 'H', long = "family-size-histogram")]
     pub family_size_histogram: Option<PathBuf>,
 
+    /// Path to write the sampled duplication saturation ladder: per-library
+    /// cumulative duplicate fraction vs. templates seen (in coordinate
+    /// order), snapshotted every `--ladder-interval` templates. Off by
+    /// default (no recorder is built, so no added work).
+    #[arg(long = "duplication-ladder")]
+    pub duplication_ladder: Option<PathBuf>,
+
+    /// Snapshot interval (in per-library cumulative templates) for
+    /// `--duplication-ladder`. Only meaningful when `--duplication-ladder`
+    /// is set.
+    #[arg(long = "ladder-interval", default_value = "1000000", value_parser = clap::value_parser!(u64).range(1..))]
+    pub ladder_interval: u64,
+
     /// Remove duplicates instead of just marking them
     #[arg(short = 'r', long = "remove-duplicates", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub remove_duplicates: bool,
@@ -1178,6 +1298,17 @@ impl Command for MarkDuplicates {
         // its final value.
         let next_mi_base_for_hook = Arc::new(AtomicU64::new(0));
 
+        // Duplication saturation ladder recorder (--duplication-ladder). `None`
+        // when the flag is off, so the hook below does zero added work
+        // (a single `Option` check, no lock, no allocation) — see the ordering
+        // note on `DuplicationLadderRecorder` for why this must be populated
+        // from the serial MI Assign hook rather than `serialize_fn`.
+        let duplication_ladder_recorder: Option<Arc<Mutex<DuplicationLadderRecorder>>> = self
+            .duplication_ladder
+            .as_ref()
+            .map(|_| Arc::new(Mutex::new(DuplicationLadderRecorder::new(self.ladder_interval))));
+        let duplication_ladder_recorder_for_hook = duplication_ladder_recorder.clone();
+
         // Run the pipeline
         let _records_processed = run_bam_pipeline_from_reader_with_mi_assign(
             pipeline_config,
@@ -1287,6 +1418,17 @@ impl Command for MarkDuplicates {
                 for template in &mut processed.templates {
                     template.mi = template.mi.with_offset(base);
                 }
+
+                // Accumulate the duplication saturation ladder here, in this
+                // same serial/coordinate-order hook — not in `serialize_fn`,
+                // which runs in parallel completion order. See the ordering
+                // note on `DuplicationLadderRecorder`. `dedup_counts` belongs
+                // entirely to `processed.library_idx` (a position group is
+                // always single-library).
+                if let Some(recorder) = &duplication_ladder_recorder_for_hook {
+                    recorder.lock().record(processed.library_idx, &processed.dedup_counts);
+                }
+
                 Ok(())
             },
         )?;
@@ -1318,6 +1460,19 @@ impl Command for MarkDuplicates {
         // Write family size histogram
         if let Some(histogram_path) = &self.family_size_histogram {
             write_family_size_histogram(&final_family_sizes, histogram_path)?;
+        }
+
+        // Write duplication saturation ladder
+        if let Some(path) = &self.duplication_ladder {
+            let mut recorder = Arc::try_unwrap(duplication_ladder_recorder.expect(
+                "bug: duplication_ladder_recorder must be Some when --duplication-ladder is set",
+            ))
+            .unwrap_or_else(|_| {
+                panic!("bug: duplication ladder recorder Arc still shared after pipeline join")
+            })
+            .into_inner();
+            recorder.finish();
+            write_duplication_ladder(&recorder, &library_index_for_metrics, path)?;
         }
 
         // Log summary
@@ -1403,6 +1558,32 @@ fn write_family_size_histogram(family_sizes: &AHashMap<usize, u64>, path: &PathB
     DelimFile::default()
         .write_tsv(path, metrics)
         .with_context(|| format!("Failed to write family size histogram: {}", path.display()))?;
+    Ok(())
+}
+
+/// Writes the `--duplication-ladder` TSV: one row per (library, snapshot),
+/// sorted deterministically by library name then ascending `templates_seen`.
+fn write_duplication_ladder(
+    recorder: &DuplicationLadderRecorder,
+    library_index: &LibraryIndex,
+    path: &PathBuf,
+) -> Result<()> {
+    let mut rows: Vec<DuplicationLadderMetrics> = recorder
+        .rows
+        .iter()
+        .map(|&(idx, templates_seen, duplicate_templates)| {
+            DuplicationLadderMetrics::new(
+                library_display_name(idx, library_index),
+                templates_seen,
+                duplicate_templates,
+            )
+        })
+        .collect();
+    rows.sort_by(|a, b| a.library.cmp(&b.library).then(a.templates_seen.cmp(&b.templates_seen)));
+
+    DelimFile::default()
+        .write_tsv(path, rows)
+        .with_context(|| format!("Failed to write duplication ladder: {}", path.display()))?;
     Ok(())
 }
 

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -25,8 +25,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use crate::assigner::{PairedUmiAssigner, Strategy, UmiAssigner};
 use crate::grouper::{RawPositionGroup, RecordPositionGrouper, build_templates_from_records};
 use crate::logging::OperationTimer;
-use crate::metrics::DeduplicationMetrics;
 use crate::metrics::group::FamilySizeMetrics;
+use crate::metrics::{DeduplicationCounts, DeduplicationMetrics};
 use crate::metrics::{TemplateFilterCounts, TemplateFilterReason};
 use crate::read_info::LibraryIndex;
 use crate::sam::SamTag;
@@ -129,34 +129,55 @@ impl DedupCounts {
     }
 }
 
-impl From<&DedupCounts> for DeduplicationMetrics {
-    fn from(counts: &DedupCounts) -> Self {
-        use TemplateFilterReason as Reason;
-        let filter = &counts.filter_counts;
-        Self {
-            filtered_templates: filter.total_rejected_templates(),
-            filtered_malformed_record: filter.rejected_templates(Reason::MalformedRecord),
-            filtered_no_primary_reads: filter.rejected_templates(Reason::NoPrimaryReads),
-            filtered_unmapped: filter.rejected_templates(Reason::Unmapped),
-            filtered_not_passing_filter: filter.rejected_templates(Reason::NotPassingFilter),
-            filtered_low_mapping_quality: filter.rejected_templates(Reason::LowMappingQuality),
-            filtered_low_mate_mapping_quality: filter
-                .rejected_templates(Reason::LowMateMappingQuality),
-            filtered_missing_umi: filter.rejected_templates(Reason::MissingUmi),
-            filtered_ns_in_umi: filter.rejected_templates(Reason::NsInUmi),
-            filtered_umi_too_short: filter.rejected_templates(Reason::UmiTooShort),
-            passthrough_templates: counts.passthrough_templates,
-            total_templates: counts.total_templates,
-            unique_templates: counts.unique_templates,
-            duplicate_templates: counts.duplicate_templates,
-            duplicate_rate: counts.duplicate_rate(),
-            total_reads: counts.total_reads,
-            unique_reads: counts.unique_reads,
-            duplicate_reads: counts.duplicate_reads,
-            secondary_reads: counts.secondary_reads,
-            supplementary_reads: counts.supplementary_reads,
-            missing_tc_tag: counts.missing_tc_tag,
-        }
+/// Converts accumulated dedup counts for one library (or the aggregate total
+/// across all libraries) into the serializable [`DeduplicationMetrics`] row.
+///
+/// The raw counts are copied 1:1 into a [`DeduplicationCounts`], and
+/// [`DeduplicationMetrics::from_counts`] computes the three derived columns
+/// (`duplicate_rate`, `percent_duplication`, `estimated_library_size`). fgumi
+/// counts *templates*, and each template stands in for one read pair in
+/// paired-end data — the same approximation `duplicate_rate` already makes by
+/// reporting a template-level rather than read-pair-level rate. That is why
+/// `estimated_library_size` is fed `total_templates`/`unique_templates` as its
+/// `n_pairs`/`n_unique` inputs.
+fn to_deduplication_metrics(library: String, counts: &DedupCounts) -> DeduplicationMetrics {
+    use TemplateFilterReason as Reason;
+    let filter = &counts.filter_counts;
+    DeduplicationMetrics::from_counts(DeduplicationCounts {
+        library,
+        filtered_templates: filter.total_rejected_templates(),
+        filtered_malformed_record: filter.rejected_templates(Reason::MalformedRecord),
+        filtered_no_primary_reads: filter.rejected_templates(Reason::NoPrimaryReads),
+        filtered_unmapped: filter.rejected_templates(Reason::Unmapped),
+        filtered_not_passing_filter: filter.rejected_templates(Reason::NotPassingFilter),
+        filtered_low_mapping_quality: filter.rejected_templates(Reason::LowMappingQuality),
+        filtered_low_mate_mapping_quality: filter.rejected_templates(Reason::LowMateMappingQuality),
+        filtered_missing_umi: filter.rejected_templates(Reason::MissingUmi),
+        filtered_ns_in_umi: filter.rejected_templates(Reason::NsInUmi),
+        filtered_umi_too_short: filter.rejected_templates(Reason::UmiTooShort),
+        passthrough_templates: counts.passthrough_templates,
+        total_templates: counts.total_templates,
+        unique_templates: counts.unique_templates,
+        duplicate_templates: counts.duplicate_templates,
+        total_reads: counts.total_reads,
+        unique_reads: counts.unique_reads,
+        duplicate_reads: counts.duplicate_reads,
+        secondary_reads: counts.secondary_reads,
+        supplementary_reads: counts.supplementary_reads,
+        missing_tc_tag: counts.missing_tc_tag,
+    })
+}
+
+/// Resolves the display name for a metrics row's library index.
+///
+/// `LibraryIndex` reserves index 0 for reads whose `@RG` has no `LB` field
+/// (or no `RG` tag at all). For metrics *display*, match Picard
+/// `DuplicationMetrics`' convention of naming that bucket "Unknown Library".
+fn library_display_name(idx: u16, library_index: &LibraryIndex) -> String {
+    if idx == 0 {
+        "Unknown Library".to_string()
+    } else {
+        library_index.library_name(idx).to_string()
     }
 }
 
@@ -167,9 +188,13 @@ impl From<&DedupCounts> for DeduplicationMetrics {
 /// Metrics collected per position group, aggregated after pipeline completion.
 #[derive(Default, Debug)]
 struct CollectedDedupCounts {
-    /// Dedup-specific metrics
-    dedup_counts: DedupCounts,
-    /// Family size counts
+    /// Dedup-specific counts, aggregated per library (keyed by
+    /// `GroupKey::library_idx` / `ProcessedDedupGroup::library_idx`). One
+    /// position group always belongs to exactly one library (library is part
+    /// of the grouping key), so merging is unambiguous per group.
+    dedup_counts_by_library: AHashMap<u16, DedupCounts>,
+    /// Family size counts, global across all libraries (out of scope for
+    /// per-library splitting).
     family_sizes: AHashMap<usize, u64>,
 }
 
@@ -185,6 +210,10 @@ pub struct ProcessedDedupGroup {
     pub family_sizes: AHashMap<usize, u64>,
     /// Dedup metrics for this group.
     pub dedup_counts: DedupCounts,
+    /// Library index (`GroupKey::library_idx`) all templates in this group
+    /// belong to. A position group is always a single library — library
+    /// partitions the grouping key — so this is unambiguous per group.
+    pub library_idx: u16,
     /// Total input records processed (for progress tracking).
     pub input_record_count: u64,
     /// Number of distinct numeric `MoleculeId`s assigned in this group.
@@ -640,6 +669,9 @@ fn process_position_group(
 ) -> io::Result<ProcessedDedupGroup> {
     let mut dedup_counts = DedupCounts::default();
     let input_record_count = group.records.len() as u64;
+    // One position group is always a single library (library partitions the
+    // grouping key), so this is unambiguous.
+    let library_idx = group.group_key.library_idx;
 
     // Build templates from raw records (deferred from Group step)
     let all_templates = build_templates_from_records(group.records)?;
@@ -669,6 +701,7 @@ fn process_position_group(
             templates: Vec::new(),
             family_sizes: AHashMap::new(),
             dedup_counts,
+            library_idx,
             input_record_count,
             distinct_mi_count: 0,
         });
@@ -777,6 +810,7 @@ fn process_position_group(
         templates,
         family_sizes,
         dedup_counts,
+        library_idx,
         input_record_count,
         distinct_mi_count,
     })
@@ -1119,6 +1153,10 @@ impl Command for MarkDuplicates {
         info!("Using pipeline with {num_threads} threads");
 
         let library_index = LibraryIndex::from_header(&header);
+        // `GroupKeyConfig::new` takes `library_index` by value; keep a clone so
+        // the metrics writer can still map `library_idx -> name` after the
+        // pipeline consumes the original.
+        let library_index_for_metrics = library_index.clone();
         // Cache the UMI tag's value position on each DecodedRecord so the
         // Process step's UMI-assignment pass can slice the value without
         // re-scanning aux data (issue #334). In `--no-umi` mode the
@@ -1173,7 +1211,10 @@ impl Command for MarkDuplicates {
                 // Collect metrics
                 {
                     let mut agg = collected_metrics_clone.lock();
-                    agg.dedup_counts.merge(&processed.dedup_counts);
+                    agg.dedup_counts_by_library
+                        .entry(processed.library_idx)
+                        .or_default()
+                        .merge(&processed.dedup_counts);
                     for (size, count) in &processed.family_sizes {
                         *agg.family_sizes.entry(*size).or_insert(0) += count;
                     }
@@ -1254,12 +1295,24 @@ impl Command for MarkDuplicates {
         let aggregated = Arc::try_unwrap(collected_metrics)
             .expect("bug: metrics Arc still shared after pipeline join")
             .into_inner();
-        let final_counts = aggregated.dedup_counts;
+        let final_counts_by_library = aggregated.dedup_counts_by_library;
         let final_family_sizes = aggregated.family_sizes;
+
+        // Total across all libraries: used both for the summary log / `tc`-tag
+        // check below and as the metrics file's aggregate "All Reads" row.
+        let mut final_counts = DedupCounts::default();
+        for library_counts in final_counts_by_library.values() {
+            final_counts.merge(library_counts);
+        }
 
         // Write metrics file
         if let Some(metrics_path) = &self.metrics {
-            write_dedup_metrics(&final_counts, metrics_path)?;
+            write_dedup_metrics(
+                &final_counts_by_library,
+                &final_counts,
+                &library_index_for_metrics,
+                metrics_path,
+            )?;
         }
 
         // Write family size histogram
@@ -1316,10 +1369,31 @@ impl Command for MarkDuplicates {
 // Metrics writing
 //////////////////////////////////////////////////////////////////////////////
 
-fn write_dedup_metrics(counts: &DedupCounts, path: &PathBuf) -> Result<()> {
-    let output: DeduplicationMetrics = counts.into();
+/// Writes one metrics row per library observed in `per_library`, sorted by
+/// library name for deterministic output, followed by a final "All Reads"
+/// row summing across every library.
+///
+/// Single-library inputs still get two rows (the one library, then "All
+/// Reads") rather than collapsing to a single row: this keeps the output
+/// shape uniform regardless of how many libraries the input actually has, so
+/// downstream readers never need to special-case the single-library count.
+fn write_dedup_metrics(
+    per_library: &AHashMap<u16, DedupCounts>,
+    total: &DedupCounts,
+    library_index: &LibraryIndex,
+    path: &PathBuf,
+) -> Result<()> {
+    let mut rows: Vec<DeduplicationMetrics> = per_library
+        .iter()
+        .map(|(&idx, counts)| {
+            to_deduplication_metrics(library_display_name(idx, library_index), counts)
+        })
+        .collect();
+    rows.sort_by(|a, b| a.library.cmp(&b.library));
+    rows.push(to_deduplication_metrics("All Reads".to_string(), total));
+
     DelimFile::default()
-        .write_tsv(path, [output])
+        .write_tsv(path, rows)
         .with_context(|| format!("Failed to write dedup metrics: {}", path.display()))?;
     Ok(())
 }
@@ -2633,8 +2707,9 @@ mod tests {
             passthrough_templates: 3,
             filter_counts,
         };
-        let output = DeduplicationMetrics::from(&counts);
+        let output = to_deduplication_metrics("lib1".to_string(), &counts);
 
+        assert_eq!(output.library, "lib1");
         assert_eq!(output.filtered_malformed_record, 1);
         assert_eq!(output.filtered_no_primary_reads, 2);
         assert_eq!(output.filtered_unmapped, 3);
@@ -2656,6 +2731,12 @@ mod tests {
         assert_eq!(output.secondary_reads, 10);
         assert_eq!(output.supplementary_reads, 5);
         assert_eq!(output.missing_tc_tag, 2);
+    }
+
+    #[test]
+    fn test_library_display_name_unknown_bucket() {
+        let library_index = LibraryIndex::default();
+        assert_eq!(library_display_name(0, &library_index), "Unknown Library");
     }
 
     /// Nothing may vanish silently: everything read is either filtered or written.
@@ -2682,7 +2763,7 @@ mod tests {
             filter_counts,
             ..DedupCounts::default()
         };
-        let output = DeduplicationMetrics::from(&counts);
+        let output = to_deduplication_metrics("lib1".to_string(), &counts);
 
         assert_eq!(
             output.filtered_templates + output.total_templates,
@@ -2702,9 +2783,13 @@ mod tests {
             unique_templates: 0,
             ..DedupCounts::default()
         };
+        let mut per_library = AHashMap::new();
+        per_library.insert(0u16, counts.clone());
+        let library_index = LibraryIndex::default();
+
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("dedup.metrics.txt");
-        write_dedup_metrics(&counts, &path)?;
+        write_dedup_metrics(&per_library, &counts, &library_index, &path)?;
 
         let text = std::fs::read_to_string(&path)?;
         let header: Vec<&str> = text.lines().next().expect("header").split('\t').collect();
@@ -3091,6 +3176,7 @@ mod tests {
             templates,
             family_sizes: AHashMap::new(),
             dedup_counts: DedupCounts::default(),
+            library_idx: 0,
             input_record_count: 1,
             distinct_mi_count: 0,
         };

--- a/src/lib/metrics/mod.rs
+++ b/src/lib/metrics/mod.rs
@@ -32,7 +32,7 @@ pub use fgumi_metrics::writer;
 pub use clip::{ClippingMetrics, ClippingMetricsCollection, ReadType};
 pub use consensus::{ConsensusKvMetric, ConsensusMetrics};
 pub use correct::UmiCorrectionMetrics;
-pub use dedup::DeduplicationMetrics;
+pub use dedup::{DeduplicationCounts, DeduplicationMetrics, DuplicationLadderMetrics};
 pub use duplex::{
     DuplexFamilySizeMetric, DuplexMetricsCollector, DuplexUmiMetric, DuplexYieldMetric,
     FamilySizeMetric,

--- a/tests/integration/test_dedup_command.rs
+++ b/tests/integration/test_dedup_command.rs
@@ -488,6 +488,292 @@ fn test_dedup_command_single_library_metrics_has_unknown_and_total_rows() {
     assert_eq!(rows[0]["total_templates"], rows[1]["total_templates"]);
 }
 
+/// Dedup over a two-library input with `--duplication-ladder` and a small
+/// `--ladder-interval`, verifying per-library snapshot rows are correct.
+///
+/// libA gets three duplicate-group positions with `count` = 3, 2, 2 pairs
+/// (spaced far enough apart to fall in distinct position groups). Per
+/// [`test_dedup_command_per_library_metrics`]'s documented shape, each
+/// position's mate groups (R1 then R2, in coordinate order) each contribute
+/// `count` templates, so libA's cumulative per-group `templates_seen`
+/// sequence is 3, 6, 8, 10, 12, 14 (true total 14). With `--ladder-interval
+/// 4`, thresholds are crossed at cumulative values 6, 8, 12 — three interval
+/// rows — and the true total (14) does not land on a crossing, so a fourth,
+/// final row is appended at 14: four rows total.
+///
+/// libB gets two duplicate-group positions with `count` = 2 each, giving the
+/// cumulative sequence 2, 4, 6, 8 (true total 8). Thresholds are crossed at 4
+/// and 8 — two interval rows — and the second crossing lands exactly on the
+/// true total, so no extra final row is appended: two rows total.
+#[test]
+fn test_dedup_duplication_ladder_multi_library() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let metrics_path = temp_dir.path().join("metrics.txt");
+    let ladder_path = temp_dir.path().join("ladder.txt");
+
+    let header = create_multi_library_header("chr1", 10000);
+    let mut records = create_duplicate_group_with_rg("libA_p1", "AAAAAAAA", 3, 100, "RG1");
+    records.extend(create_duplicate_group_with_rg("libA_p2", "CCCCCCCC", 2, 500, "RG1"));
+    records.extend(create_duplicate_group_with_rg("libA_p3", "GGGGGGGG", 2, 900, "RG1"));
+    records.extend(create_duplicate_group_with_rg("libB_p1", "TTTTTTTT", 2, 1300, "RG2"));
+    records.extend(create_duplicate_group_with_rg("libB_p2", "ACACACAC", 2, 1700, "RG2"));
+    create_sorted_bam_with_header(&input_bam, &header, records);
+
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--metrics",
+        metrics_path.to_str().unwrap(),
+        "--duplication-ladder",
+        ladder_path.to_str().unwrap(),
+        "--ladder-interval",
+        "4",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse dedup args");
+    cmd.execute("fgumi dedup").expect("Dedup command with duplication ladder failed");
+
+    assert!(ladder_path.exists(), "duplication ladder file must be created when requested");
+
+    let metrics_rows = read_dedup_metrics_rows(&metrics_path);
+    let metrics_by_library: std::collections::HashMap<
+        &str,
+        &std::collections::HashMap<String, String>,
+    > = metrics_rows.iter().map(|r| (r["library"].as_str(), r)).collect();
+
+    let ladder_rows = read_dedup_metrics_rows(&ladder_path);
+
+    // Expected snapshot sequence per library, pinned exactly (not merely by row
+    // count) so a regression that emitted the right number of rows at the wrong
+    // interval crossings is still caught: libA crosses the interval at 6, 8, 12,
+    // then gets a final row at its true total (14), which doesn't land on a
+    // crossing — 4 rows. libB crosses at 4 and 8, with 8 landing exactly on its
+    // true total, so no extra final row — 2 rows.
+    // Every snapshot row is pinned exactly — both `templates_seen` and the
+    // cumulative `duplicate_fraction` (as `(numerator, denominator)`) — so a
+    // regression that emits the right row count at the wrong interval crossings,
+    // reorders the library rows, or writes the wrong intermediate saturation
+    // values is caught, not just one with a wrong final row. libA crosses the
+    // interval at 6, 8, 12, then gets a final row at its true total (14), which
+    // doesn't land on a crossing — 4 rows. libB crosses at 4 and 8, with 8
+    // landing exactly on its true total, so no extra final row — 2 rows.
+    // Per snapshot row, keyed by library: (templates_seen, (duplicate
+    // numerator, denominator)), pinned so the table reads as a spec.
+    #[expect(clippy::type_complexity, reason = "an inline pinned table of expected rows")]
+    let expected_sequences: [(&str, &[(u64, (u64, u64))]); 2] = [
+        ("libA", &[(6, (4, 6)), (8, (5, 8)), (12, (7, 12)), (14, (8, 14))]),
+        ("libB", &[(4, (2, 4)), (8, (4, 8))]),
+    ];
+    let mut matched_row_count = 0usize;
+
+    // For each library: every row's templates_seen and duplicate_fraction match
+    // the pinned sequence in file order, the last row's templates_seen equals
+    // the true per-library total (from the metrics file), and the last row's
+    // duplicate_fraction matches the metrics file's template-level
+    // duplicate_rate exactly (both are the same cumulative
+    // duplicate_templates / total_templates ratio).
+    for (library, expected_rows) in expected_sequences {
+        let rows: Vec<_> = ladder_rows.iter().filter(|r| r["library"] == library).collect();
+        matched_row_count += rows.len();
+
+        assert_eq!(
+            rows.len(),
+            expected_rows.len(),
+            "{library}: expected {} ladder rows: {rows:?}",
+            expected_rows.len()
+        );
+
+        for (row, &(expected_seen, (num, den))) in rows.iter().zip(expected_rows) {
+            let seen: u64 = row["templates_seen"].parse().expect("templates_seen is u64");
+            assert_eq!(
+                seen, expected_seen,
+                "{library}: snapshot must land on the derived interval crossing: {row:?}"
+            );
+            let duplicate_fraction: f64 =
+                row["duplicate_fraction"].parse().expect("duplicate_fraction is f64");
+            #[expect(
+                clippy::cast_precision_loss,
+                reason = "numerator and denominator are small test constants (< 100)"
+            )]
+            let expected_fraction = num as f64 / den as f64;
+            assert!(
+                (duplicate_fraction - expected_fraction).abs() < 1e-9,
+                "{library}: row duplicate_fraction ({duplicate_fraction}) must equal \
+                 {num}/{den} ({expected_fraction}): {row:?}"
+            );
+        }
+
+        let last_row = rows.last().unwrap_or_else(|| panic!("{library}: no ladder rows emitted"));
+        let library_metrics = metrics_by_library[library];
+        assert_eq!(
+            last_row["templates_seen"], library_metrics["total_templates"],
+            "{library}: final ladder snapshot must land at the true per-library total: {last_row:?}"
+        );
+
+        let expected_fraction: f64 =
+            library_metrics["duplicate_rate"].parse().expect("duplicate_rate is f64");
+        let actual_fraction: f64 =
+            last_row["duplicate_fraction"].parse().expect("duplicate_fraction is f64");
+        assert!(
+            (actual_fraction - expected_fraction).abs() < 1e-9,
+            "{library}: final duplicate_fraction ({actual_fraction}) must match the metrics \
+             file's cumulative duplicate_rate ({expected_fraction})"
+        );
+    }
+
+    assert_eq!(
+        matched_row_count,
+        ladder_rows.len(),
+        "the ladder is inherently per-library: no unexpected library names: {ladder_rows:?}"
+    );
+}
+
+/// Without `--duplication-ladder`, no ladder file is written and dedup's
+/// ordinary behavior is unaffected (mirrors [`test_dedup_command_basic`]).
+#[test]
+fn test_dedup_duplication_ladder_off_by_default() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let ladder_path = temp_dir.path().join("ladder_never_written.txt");
+
+    let mut records = create_duplicate_group("dup1", "ACGTACGT", 3, 100);
+    records.extend(create_duplicate_group("dup2", "TGCATGCA", 2, 500));
+    create_sorted_bam(&input_bam, records);
+
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse dedup args");
+    cmd.execute("fgumi dedup").expect("Dedup command without duplication ladder failed");
+
+    assert!(output_bam.exists(), "Output BAM not created");
+    assert!(
+        !ladder_path.exists(),
+        "duplication ladder file must not be created when --duplication-ladder is not passed"
+    );
+
+    let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    let _header = reader.read_header().unwrap();
+    let count = reader.records().count();
+    assert_eq!(count, 10, "All reads should be in output (marked, not removed)");
+}
+
+/// Regression test: a single position group whose template increment is
+/// large enough to leap past more than one `--ladder-interval` multiple in a
+/// single `DuplicationLadderRecorder::record` call must still emit only one
+/// row per call, not one row per crossed multiple.
+///
+/// A single 10-pair duplicate group (no `@RG`, so library = "Unknown
+/// Library") with `--ladder-interval 3` produces two position groups (R1
+/// then R2, in coordinate order), each contributing 10 templates in one
+/// `record()` call — each call alone crosses three interval multiples (the
+/// first call crosses 3, 6, 9; the second crosses 12, 15, 18). Before the fix
+/// this produced duplicate rows `[10, 10, 10, 20, 20, 20]`; after the fix it
+/// must produce exactly `[10, 20]`.
+#[test]
+fn test_dedup_duplication_ladder_single_group_exceeds_interval() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let metrics_path = temp_dir.path().join("metrics.txt");
+    let ladder_path = temp_dir.path().join("ladder.txt");
+
+    let records = create_duplicate_group("dup1", "ACGTACGT", 10, 100);
+    create_sorted_bam(&input_bam, records);
+
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--metrics",
+        metrics_path.to_str().unwrap(),
+        "--duplication-ladder",
+        ladder_path.to_str().unwrap(),
+        "--ladder-interval",
+        "3",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse dedup args");
+    cmd.execute("fgumi dedup").expect("Dedup command with duplication ladder failed");
+
+    let metrics_rows = read_dedup_metrics_rows(&metrics_path);
+    let unknown_library = metrics_rows
+        .iter()
+        .find(|r| r["library"] == "Unknown Library")
+        .expect("Unknown Library row present");
+
+    let ladder_rows = read_dedup_metrics_rows(&ladder_path);
+    let templates_seen: Vec<u64> = ladder_rows
+        .iter()
+        .map(|r| r["templates_seen"].parse().expect("templates_seen is u64"))
+        .collect();
+
+    assert_eq!(
+        templates_seen,
+        vec![10, 20],
+        "a single group whose increment leaps past more than one interval \
+         multiple must still emit exactly one row per record() call, not one \
+         row per crossed multiple (regression: previously produced \
+         [10, 10, 10, 20, 20, 20]): {ladder_rows:?}"
+    );
+
+    // Redundant with the exact-sequence check above, but states the general
+    // invariant explicitly: no duplicate/non-increasing templates_seen.
+    for window in templates_seen.windows(2) {
+        assert!(
+            window[1] > window[0],
+            "templates_seen must be strictly increasing: {templates_seen:?}"
+        );
+    }
+
+    // Pin the intermediate row's fraction too, not just the final one: the
+    // first snapshot lands at 10 templates_seen with 9 cumulative duplicates.
+    let first_row = ladder_rows.first().expect("at least one ladder row");
+    let first_fraction: f64 =
+        first_row["duplicate_fraction"].parse().expect("duplicate_fraction is f64");
+    assert!(
+        (first_fraction - 9.0 / 10.0).abs() < 1e-9,
+        "the first snapshot's duplicate_fraction must be 9/10: {first_row:?}"
+    );
+
+    let last_row = ladder_rows.last().expect("at least one ladder row");
+    assert_eq!(
+        last_row["templates_seen"], unknown_library["total_templates"],
+        "final ladder snapshot must land at the true total: {last_row:?}"
+    );
+    let expected_fraction: f64 =
+        unknown_library["duplicate_rate"].parse().expect("duplicate_rate is f64");
+    let actual_fraction: f64 =
+        last_row["duplicate_fraction"].parse().expect("duplicate_fraction is f64");
+    assert!(
+        (actual_fraction - expected_fraction).abs() < 1e-9,
+        "final duplicate_fraction ({actual_fraction}) must match the metrics \
+         file's cumulative duplicate_rate ({expected_fraction})"
+    );
+}
+
 /// Test dedup command with remove-duplicates flag.
 #[test]
 fn test_dedup_command_remove_duplicates() {

--- a/tests/integration/test_dedup_command.rs
+++ b/tests/integration/test_dedup_command.rs
@@ -446,6 +446,59 @@ fn test_dedup_command_per_library_metrics() {
     assert_eq!(total["duplicate_templates"], "6");
     assert_eq!(total["total_reads"], "10");
     assert_eq!(total["duplicate_reads"], "6");
+    // The aggregate row spans two distinct libraries, so a pooled Lander-Waterman
+    // estimate would be meaningless: it must be left empty (the per-library rows
+    // above carry the meaningful estimates). Matches dupblaster.
+    assert!(
+        total["estimated_library_size"].is_empty(),
+        "the aggregate row spans >1 library, so its estimate must be empty: {total:?}"
+    );
+}
+
+/// Row order with named libraries AND reads lacking `@RG`/`LB`: named
+/// libraries first (alphabetical), then the "Unknown Library" catch-all, then
+/// the "All Reads" total last. The catch-all is a sentinel, not a real
+/// library, so it is grouped after the named libraries rather than sorted in
+/// among them by name.
+#[test]
+fn test_dedup_command_metrics_orders_unknown_after_named_before_total() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let metrics_path = temp_dir.path().join("metrics.txt");
+
+    let header = create_multi_library_header("chr1", 10000);
+    // Named libraries (RG1 -> libA, RG2 -> libB) plus reads with no @RG, which
+    // fall into the idx-0 "Unknown Library" bucket. Distinct positions keep them
+    // in separate position groups.
+    let mut records = create_duplicate_group_with_rg("libA_dup", "ACGTACGT", 3, 100, "RG1");
+    records.extend(create_duplicate_group_with_rg("libB_dup", "TGCATGCA", 2, 500, "RG2"));
+    records.extend(create_duplicate_group("noRG_dup", "GGCCGGCC", 2, 900));
+    create_sorted_bam_with_header(&input_bam, &header, records);
+
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--metrics",
+        metrics_path.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse dedup args");
+    cmd.execute("fgumi dedup").expect("Dedup command with mixed-library metrics failed");
+
+    let rows = read_dedup_metrics_rows(&metrics_path);
+    let libraries: Vec<&str> = rows.iter().map(|r| r["library"].as_str()).collect();
+    assert_eq!(
+        libraries,
+        vec!["libA", "libB", "Unknown Library", "All Reads"],
+        "named libraries first (alphabetical), then Unknown Library, then the total: {libraries:?}"
+    );
 }
 
 /// Single-library input (no `@RG`/`LB` at all) must still produce two rows:

--- a/tests/integration/test_dedup_command.rs
+++ b/tests/integration/test_dedup_command.rs
@@ -30,43 +30,31 @@ use crate::helpers::bam_generator::{create_minimal_header, to_record_buf};
 /// Template-coordinate sort groups reads by position, then by name within each position.
 /// The header must have SO:unsorted GO:query SS:template-coordinate tags.
 fn create_sorted_bam(path: &Path, records: Vec<RawRecord>) {
-    // Write the records to a temp BAM, then sort it into `path` with fgumi's own
-    // template-coordinate sorter so the dedup input is *genuinely* in
-    // template-coordinate order rather than merely labelled as such. (dedup trusts
-    // the header's SS tag; feeding it mislabelled-but-unsorted input produces
-    // mislabelled-but-unsorted output.)
-    let unsorted = path.with_file_name("dedup_input_unsorted.bam");
+    // Delegate to the header-aware variant with the default minimal header so the
+    // two helpers share a single implementation and can never drift apart.
     let header = create_minimal_header("chr1", 10000);
-    let mut writer =
-        bam::io::Writer::new(fs::File::create(&unsorted).expect("Failed to create BAM file"));
-    writer.write_header(&header).expect("Failed to write header");
-    for record in records {
-        writer
-            .write_alignment_record(&header, &to_record_buf(&record))
-            .expect("Failed to write record");
-    }
-    writer.try_finish().expect("Failed to finish BAM");
-
-    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args([
-            "sort",
-            "-i",
-            unsorted.to_str().unwrap(),
-            "-o",
-            path.to_str().unwrap(),
-            "--order",
-            "template-coordinate",
-            "--key-types",
-            "mi",
-        ])
-        .status()
-        .expect("failed to spawn `fgumi sort` for dedup test input");
-    assert!(status.success(), "failed to template-coordinate sort dedup test input");
+    create_sorted_bam_with_header(path, &header, records);
 }
 
 /// Create a group of paired-end reads at the same position with the same UMI
 /// (simulating PCR duplicates).
 fn create_duplicate_group(base_name: &str, umi: &str, count: usize, start: i32) -> Vec<RawRecord> {
+    create_duplicate_group_inner(base_name, umi, count, start, None)
+}
+
+/// Shared implementation for [`create_duplicate_group`] and
+/// [`create_duplicate_group_with_rg`]: builds `count` paired-end duplicate
+/// templates, tagging each record with `RG:Z:{rg_id}` only when `rg_id` is
+/// `Some`. Keeping one implementation means the exact record shape the per-library
+/// and ladder tests derive their template counts from can never diverge between
+/// the RG and non-RG variants.
+fn create_duplicate_group_inner(
+    base_name: &str,
+    umi: &str,
+    count: usize,
+    start: i32,
+    rg_id: Option<&str>,
+) -> Vec<RawRecord> {
     let mut records = Vec::new();
     for i in 0..count {
         let name = format!("{base_name}_{i}");
@@ -86,6 +74,9 @@ fn create_duplicate_group(base_name: &str, umi: &str, count: usize, start: i32) 
                 .template_length(108)
                 .add_string_tag(SamTag::RX, umi.as_bytes())
                 .add_string_tag(SamTag::MC, b"8M");
+            if let Some(rg_id) = rg_id {
+                b.add_string_tag(SamTag::RG, rg_id.as_bytes());
+            }
             b.build()
         };
 
@@ -104,6 +95,9 @@ fn create_duplicate_group(base_name: &str, umi: &str, count: usize, start: i32) 
                 .template_length(-108)
                 .add_string_tag(SamTag::RX, umi.as_bytes())
                 .add_string_tag(SamTag::MC, b"8M");
+            if let Some(rg_id) = rg_id {
+                b.add_string_tag(SamTag::RG, rg_id.as_bytes());
+            }
             b.build()
         };
 
@@ -247,6 +241,251 @@ fn test_dedup_command_with_metrics() {
     .expect("failed to parse dedup args");
     cmd.execute("fgumi dedup").expect("Dedup command with metrics failed");
     assert!(metrics_path.exists(), "Metrics file not created");
+}
+
+/// Build a template-coordinate-sorted SAM header with two `@RG` lines that have
+/// distinct `LB` values ("libA"/"libB"), for the per-library metrics test below.
+fn create_multi_library_header(ref_name: &str, ref_len: usize) -> noodles::sam::Header {
+    use bstr::BString;
+    use noodles::sam::header::record::value::Map;
+    use noodles::sam::header::record::value::map::Map as HeaderRecordMap;
+    use noodles::sam::header::record::value::map::header::tag::Tag as HeaderTag;
+    use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
+    use noodles::sam::header::record::value::map::{
+        Header as HeaderRecord, ReadGroup, ReferenceSequence,
+    };
+    use std::num::NonZeroUsize;
+
+    let mut header_builder = HeaderRecordMap::<HeaderRecord>::builder();
+    for &(tag_bytes, value) in
+        &[(*b"SO", "unsorted"), (*b"GO", "query"), (*b"SS", "template-coordinate")]
+    {
+        let HeaderTag::Other(tag) = HeaderTag::from(tag_bytes) else { unreachable!() };
+        header_builder = header_builder.insert(tag, value);
+    }
+    let header_map = header_builder.build().expect("valid header map");
+
+    let reference_sequence = Map::<ReferenceSequence>::new(
+        NonZeroUsize::new(ref_len).expect("reference length must be non-zero"),
+    );
+
+    let rg_a = Map::<ReadGroup>::builder()
+        .insert(rg_tag::LIBRARY, String::from("libA"))
+        .build()
+        .expect("building read group RG1 should succeed");
+    let rg_b = Map::<ReadGroup>::builder()
+        .insert(rg_tag::LIBRARY, String::from("libB"))
+        .build()
+        .expect("building read group RG2 should succeed");
+
+    noodles::sam::Header::builder()
+        .set_header(header_map)
+        .add_reference_sequence(BString::from(ref_name), reference_sequence)
+        .add_read_group(BString::from("RG1"), rg_a)
+        .add_read_group(BString::from("RG2"), rg_b)
+        .build()
+}
+
+/// Like [`create_duplicate_group`], but tags every record with `RG:Z:{rg_id}`
+/// so it is attributed to a specific library at dedup time.
+fn create_duplicate_group_with_rg(
+    base_name: &str,
+    umi: &str,
+    count: usize,
+    start: i32,
+    rg_id: &str,
+) -> Vec<RawRecord> {
+    create_duplicate_group_inner(base_name, umi, count, start, Some(rg_id))
+}
+
+/// Shared implementation for [`create_sorted_bam`]: writes `records` against the
+/// caller-supplied `header`, then template-coordinate sorts the result into
+/// `path` with fgumi's own sorter so the dedup input is *genuinely* in
+/// template-coordinate order rather than merely labelled as such. (dedup trusts
+/// the header's SS tag; feeding it mislabelled-but-unsorted input produces
+/// mislabelled-but-unsorted output.) [`create_sorted_bam`] passes the default
+/// [`create_minimal_header`]; the per-library tests pass a multi-`@RG` header so
+/// each read is attributed to a specific library at dedup time.
+fn create_sorted_bam_with_header(
+    path: &Path,
+    header: &noodles::sam::Header,
+    records: Vec<RawRecord>,
+) {
+    let unsorted = path.with_file_name("dedup_input_unsorted.bam");
+    let mut writer =
+        bam::io::Writer::new(fs::File::create(&unsorted).expect("Failed to create BAM file"));
+    writer.write_header(header).expect("Failed to write header");
+    for record in records {
+        writer
+            .write_alignment_record(header, &to_record_buf(&record))
+            .expect("Failed to write record");
+    }
+    writer.try_finish().expect("Failed to finish BAM");
+
+    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "sort",
+            "-i",
+            unsorted.to_str().unwrap(),
+            "-o",
+            path.to_str().unwrap(),
+            "--order",
+            "template-coordinate",
+            "--key-types",
+            "mi",
+        ])
+        .status()
+        .expect("failed to spawn `fgumi sort` for dedup test input");
+    assert!(status.success(), "failed to template-coordinate sort dedup test input");
+}
+
+/// Reads the dedup metrics TSV back as one `column name -> value` map per data
+/// row, in file order.
+fn read_dedup_metrics_rows(path: &Path) -> Vec<std::collections::HashMap<String, String>> {
+    let content = fs::read_to_string(path).expect("failed to read metrics file");
+    let mut lines = content.lines();
+    let header: Vec<String> =
+        lines.next().expect("metrics header row").split('\t').map(String::from).collect();
+    lines
+        .map(|line| {
+            let values: Vec<&str> = line.split('\t').collect();
+            header.iter().cloned().zip(values.iter().map(ToString::to_string)).collect()
+        })
+        .collect()
+}
+
+/// Dedup over a two-library input (library A: 3 duplicate pairs at one
+/// position; library B: 2 duplicate pairs at a different position) and verify
+/// the metrics file has one row per library, sorted by name, plus a final
+/// "All Reads" total row summing across libraries — with correct per-library
+/// `duplicate_templates`/`percent_duplication`, and `estimated_library_size`
+/// populated for both (both libraries have duplicates).
+///
+/// Each mate's position group is dedup'd independently (R1's group and R2's
+/// group are template-coordinate-adjacent but distinct `RawPositionGroup`s,
+/// each holding single-mate templates), so a library's `count` duplicate
+/// pairs contribute `2 * count` templates/reads to its row: `count` from R1's
+/// group (1 unique + `count - 1` duplicate) and `count` from R2's group
+/// (same split) — e.g. library A's 3 pairs give `total_templates = 6`,
+/// `unique_templates = 2`, `duplicate_templates = 4`.
+#[test]
+fn test_dedup_command_per_library_metrics() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let metrics_path = temp_dir.path().join("metrics.txt");
+
+    let header = create_multi_library_header("chr1", 10000);
+    let mut records = create_duplicate_group_with_rg("libA_dup", "ACGTACGT", 3, 100, "RG1");
+    records.extend(create_duplicate_group_with_rg("libB_dup", "TGCATGCA", 2, 500, "RG2"));
+    create_sorted_bam_with_header(&input_bam, &header, records);
+
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--metrics",
+        metrics_path.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse dedup args");
+    cmd.execute("fgumi dedup").expect("Dedup command with per-library metrics failed");
+
+    let rows = read_dedup_metrics_rows(&metrics_path);
+    assert_eq!(rows.len(), 3, "expected libA row + libB row + All Reads total row: {rows:?}");
+
+    let libraries: Vec<&str> = rows.iter().map(|r| r["library"].as_str()).collect();
+    assert_eq!(
+        libraries,
+        vec!["libA", "libB", "All Reads"],
+        "rows must be library-name-sorted, with the total row last: {libraries:?}"
+    );
+
+    // Each position group in `fgumi dedup` holds a single mate (R1's group and
+    // R2's group are template-coordinate-adjacent but distinct groups), so a
+    // library's `count` duplicate pairs contribute `2 * count` templates/reads
+    // (one per mate's own position group), each with exactly one record.
+    let lib_a = &rows[0];
+    assert_eq!(lib_a["total_templates"], "6");
+    assert_eq!(lib_a["unique_templates"], "2");
+    assert_eq!(lib_a["duplicate_templates"], "4");
+    assert_eq!(lib_a["total_reads"], "6");
+    assert_eq!(lib_a["duplicate_reads"], "4");
+    assert!(
+        (lib_a["percent_duplication"].parse::<f64>().unwrap() - 4.0 / 6.0).abs() < 1e-6,
+        "lib_a percent_duplication (read-level 4/6): {lib_a:?}"
+    );
+    assert!(
+        !lib_a["estimated_library_size"].is_empty(),
+        "lib_a has duplicates, so the library-size estimate must be populated: {lib_a:?}"
+    );
+
+    let lib_b = &rows[1];
+    assert_eq!(lib_b["total_templates"], "4");
+    assert_eq!(lib_b["unique_templates"], "2");
+    assert_eq!(lib_b["duplicate_templates"], "2");
+    assert_eq!(lib_b["total_reads"], "4");
+    assert_eq!(lib_b["duplicate_reads"], "2");
+    assert!(
+        (lib_b["percent_duplication"].parse::<f64>().unwrap() - 2.0 / 4.0).abs() < 1e-6,
+        "lib_b percent_duplication (read-level 2/4): {lib_b:?}"
+    );
+    assert!(
+        !lib_b["estimated_library_size"].is_empty(),
+        "lib_b has duplicates, so the library-size estimate must be populated: {lib_b:?}"
+    );
+
+    let total = &rows[2];
+    assert_eq!(total["total_templates"], "10");
+    assert_eq!(total["unique_templates"], "4");
+    assert_eq!(total["duplicate_templates"], "6");
+    assert_eq!(total["total_reads"], "10");
+    assert_eq!(total["duplicate_reads"], "6");
+}
+
+/// Single-library input (no `@RG`/`LB` at all) must still produce two rows:
+/// the "Unknown Library" bucket, then the "All Reads" total — the metrics
+/// writer never collapses to a single row, regardless of library count, so
+/// the output shape is uniform across single- and multi-library inputs.
+#[test]
+fn test_dedup_command_single_library_metrics_has_unknown_and_total_rows() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let metrics_path = temp_dir.path().join("metrics.txt");
+
+    let records = create_duplicate_group("dup1", "ACGTACGT", 3, 100);
+    create_sorted_bam(&input_bam, records);
+
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--metrics",
+        metrics_path.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse dedup args");
+    cmd.execute("fgumi dedup").expect("Dedup command with metrics failed");
+
+    let rows = read_dedup_metrics_rows(&metrics_path);
+    let libraries: Vec<&str> = rows.iter().map(|r| r["library"].as_str()).collect();
+    assert_eq!(
+        libraries,
+        vec!["Unknown Library", "All Reads"],
+        "no @RG/LB in the input: expect the Unknown Library bucket, then the total: {libraries:?}"
+    );
+    assert_eq!(rows[0]["total_templates"], rows[1]["total_templates"]);
 }
 
 /// Test dedup command with remove-duplicates flag.


### PR DESCRIPTION
Part of #786 (dupblaster→fgumi optimizations): QC output for library complexity.

`fgumi dedup --metrics` now writes **one row per library plus an "All Reads" aggregate total row**, and gains two Picard-parity columns: `percent_duplication` (read-level `DuplicationMetrics.PERCENT_DUPLICATION`) and `estimated_library_size` (Lander-Waterman, ported faithfully from Picard `estimateLibrarySize` with 8 oracle test cases). This merges cleanly with #740's per-reason `filtered_*` columns — every column set is preserved and the per-reason filter counts are reported per library (the aggregate row folds all libraries, including the "Unknown Library" bucket).

A new optional `--duplication-ladder <PATH>` (with `--ladder-interval N`, default 1,000,000) emits a per-library saturation curve: cumulative duplicate fraction vs. templates seen, snapshotted in coordinate order at each interval plus a final row at the true total. Off by default (zero added work).

## Notes

- `estimated_library_size` on the "All Reads" row uses pooled cross-library counts (consistent with how the aggregate `duplicate_rate` is computed); the per-library rows are the statistically meaningful estimates.
- Suggested reading order: `crates/fgumi-metrics/src/library_size.rs` and `crates/fgumi-metrics/src/dedup.rs` (the estimator + the metrics schema), then `src/lib/commands/dedup.rs` (per-library aggregation, writer, ladder).

## Verification

Full workspace suite 2542/2542; new per-library, single-library, and ladder integration tests, including a regression test for the ladder emitting exactly one row per interval crossing (a group spanning multiple intervals must not double-emit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Output risk: metrics and optional duplication-ladder TSV output change; deterministic library ordering, fixed column order, and configurable ladder intervals pin the new output. `unsafe`: none added, and no `CLAUDE.md` allowlist update applies. Memory bounds, queue capacity, and thread/backpressure policy: none.

- Adds per-library deduplication metrics, an “All Reads” row, preserved `filtered_*` counts, and Picard-parity `percent_duplication` and `estimated_library_size` fields.
- Adds optional per-library duplication saturation ladders with configurable `--ladder-interval`; output is disabled by default.
- Adds the Lander-Waterman estimator and public metric types for count conversion and ladder snapshots.
- Adds integration coverage for multiple libraries, single-library behavior, library ordering, ladder intervals, default omission, and final snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->