### PR TITLE
feat(dedup): sample column and marginal duplication-ladder columns (#802)

### DIFF
--- a/crates/fgumi-metrics/src/dedup.rs
+++ b/crates/fgumi-metrics/src/dedup.rs
@@ -42,6 +42,10 @@ use crate::library_size::estimate_library_size;
 // Description column of that page's table.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct DeduplicationMetrics {
+    /// Sample name — the comma-joined unique `@RG SM:` values from the header,
+    /// or the `--sample` override. Constant across every row of a run; leads
+    /// the schema to match dupblaster/Picard `--stats` output.
+    pub sample: String,
     /// Library name, "Unknown Library", or "All Reads" (the aggregate row)
     pub library: String,
     /// Templates dropped by the filter (any reason)
@@ -114,6 +118,8 @@ pub struct DeduplicationMetrics {
 /// per library, plus the total) readable and self-labeling.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct DeduplicationCounts {
+    /// Sample name (comma-joined `@RG SM:` values or the `--sample` override).
+    pub sample: String,
     /// Library name, "Unknown Library", or "All Reads".
     pub library: String,
     /// Templates dropped by the filter (any reason).
@@ -171,6 +177,7 @@ impl DeduplicationMetrics {
     #[must_use]
     pub fn from_counts(counts: DeduplicationCounts) -> Self {
         let DeduplicationCounts {
+            sample,
             library,
             filtered_templates,
             filtered_malformed_record,
@@ -194,6 +201,7 @@ impl DeduplicationMetrics {
             missing_tc_tag,
         } = counts;
         Self {
+            sample,
             library,
             filtered_templates,
             filtered_malformed_record,
@@ -262,16 +270,41 @@ pub struct DuplicationLadderMetrics {
     /// at this snapshot.
     #[serde(with = "crate::float")]
     pub duplicate_fraction: f64,
+    /// Templates added since the previous snapshot (this window's depth). Equals
+    /// `templates_seen` on the first snapshot.
+    pub window_templates: u64,
+    /// Marginal duplicate fraction over just this window's templates
+    /// (`window_duplicate_templates / window_templates`). Often the more legible
+    /// view of the saturation curve than the cumulative `duplicate_fraction`,
+    /// since it isolates each depth band instead of averaging over all prior
+    /// ones. Mirrors dupblaster's per-window complexity columns.
+    #[serde(with = "crate::float")]
+    pub window_duplicate_fraction: f64,
 }
 
 impl DuplicationLadderMetrics {
-    /// Builds one snapshot row from cumulative per-library counts.
+    /// Builds one snapshot row from cumulative and per-window per-library counts.
+    ///
+    /// `templates_seen`/`duplicate_templates` are the cumulative totals at this
+    /// snapshot; `window_templates`/`window_duplicate_templates` cover only the
+    /// templates added since the previous snapshot.
     #[must_use]
-    pub fn new(library: String, templates_seen: u64, duplicate_templates: u64) -> Self {
+    pub fn new(
+        library: String,
+        templates_seen: u64,
+        duplicate_templates: u64,
+        window_templates: u64,
+        window_duplicate_templates: u64,
+    ) -> Self {
         Self {
             library,
             templates_seen,
             duplicate_fraction: crate::frac_u64(duplicate_templates, templates_seen),
+            window_templates,
+            window_duplicate_fraction: crate::frac_u64(
+                window_duplicate_templates,
+                window_templates,
+            ),
         }
     }
 }
@@ -322,7 +355,7 @@ mod tests {
     fn serializes_expected_columns_in_order() {
         assert_eq!(
             header_of(DeduplicationMetrics::default()),
-            "library\tfiltered_templates\tfiltered_malformed_record\tfiltered_no_primary_reads\t\
+            "sample\tlibrary\tfiltered_templates\tfiltered_malformed_record\tfiltered_no_primary_reads\t\
              filtered_unmapped\tfiltered_not_passing_filter\tfiltered_low_mapping_quality\t\
              filtered_low_mate_mapping_quality\tfiltered_missing_umi\tfiltered_ns_in_umi\t\
              filtered_umi_too_short\tpassthrough_templates\ttotal_templates\tunique_templates\t\
@@ -450,18 +483,19 @@ mod tests {
         let mut lines = content.lines();
 
         let header: Vec<&str> = lines.next().expect("header line").split('\t').collect();
-        assert_eq!(header.first(), Some(&"library"), "library column must be first: {header:?}");
+        assert_eq!(header.first(), Some(&"sample"), "sample column must be first: {header:?}");
+        assert_eq!(header.get(1), Some(&"library"), "library column must be second: {header:?}");
         let size_col = header
             .iter()
             .position(|&h| h == "estimated_library_size")
             .expect("estimated_library_size column present");
 
         let lib1_row: Vec<&str> = lines.next().expect("lib1 row").split('\t').collect();
-        assert_eq!(lib1_row.first(), Some(&"lib1"));
+        assert_eq!(lib1_row.get(1), Some(&"lib1"), "library is the second column: {lib1_row:?}");
         assert!(!lib1_row[size_col].is_empty(), "lib1 has duplicates: {lib1_row:?}");
 
         let lib2_row: Vec<&str> = lines.next().expect("lib2 row").split('\t').collect();
-        assert_eq!(lib2_row.first(), Some(&"lib2"));
+        assert_eq!(lib2_row.get(1), Some(&"lib2"), "library is the second column: {lib2_row:?}");
         assert!(
             lib2_row[size_col].is_empty(),
             "lib2's None estimate must render empty: {lib2_row:?}"
@@ -469,13 +503,17 @@ mod tests {
     }
 
     #[test]
-    fn ladder_metric_computes_cumulative_fraction() {
-        let row = DuplicationLadderMetrics::new("lib1".to_string(), 100, 25);
+    fn ladder_metric_computes_cumulative_and_window_fractions() {
+        // Cumulative 25/100 = 0.25; this window 20/40 = 0.5 (a denser band).
+        let row = DuplicationLadderMetrics::new("lib1".to_string(), 100, 25, 40, 20);
         assert_eq!(row.library, "lib1");
         assert_eq!(row.templates_seen, 100);
         assert!((row.duplicate_fraction - 0.25).abs() < 1e-9);
-        // Div-by-zero guard: zero templates yields a defined 0.0 fraction.
-        let empty = DuplicationLadderMetrics::new("lib2".to_string(), 0, 0);
+        assert_eq!(row.window_templates, 40);
+        assert!((row.window_duplicate_fraction - 0.5).abs() < 1e-9);
+        // Div-by-zero guard: zero templates yields defined 0.0 fractions.
+        let empty = DuplicationLadderMetrics::new("lib2".to_string(), 0, 0, 0, 0);
         assert!(empty.duplicate_fraction.abs() < 1e-9);
+        assert!(empty.window_duplicate_fraction.abs() < 1e-9);
     }
 }

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -140,10 +140,15 @@ impl DedupCounts {
 /// reporting a template-level rather than read-pair-level rate. That is why
 /// `estimated_library_size` is fed `total_templates`/`unique_templates` as its
 /// `n_pairs`/`n_unique` inputs.
-fn to_deduplication_metrics(library: String, counts: &DedupCounts) -> DeduplicationMetrics {
+fn to_deduplication_metrics(
+    sample: String,
+    library: String,
+    counts: &DedupCounts,
+) -> DeduplicationMetrics {
     use TemplateFilterReason as Reason;
     let filter = &counts.filter_counts;
     DeduplicationMetrics::from_counts(DeduplicationCounts {
+        sample,
         library,
         filtered_templates: filter.total_rejected_templates(),
         filtered_malformed_record: filter.rejected_templates(Reason::MalformedRecord),
@@ -179,6 +184,26 @@ fn library_display_name(idx: u16, library_index: &LibraryIndex) -> String {
     } else {
         library_index.library_name(idx).to_string()
     }
+}
+
+/// Resolves the `sample` column value for the `--metrics` output: the
+/// `--sample` override when given, otherwise the comma-joined unique `@RG SM:`
+/// values from the header (empty string when the header declares none).
+fn resolve_sample(header: &Header, override_sample: Option<&str>) -> String {
+    use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
+    if let Some(s) = override_sample {
+        return s.to_string();
+    }
+    let mut samples: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for (_id, rg) in header.read_groups() {
+        if let Some(sm) = rg.other_fields().get(&rg_tag::SAMPLE) {
+            let s = sm.to_string();
+            if !s.is_empty() {
+                samples.insert(s);
+            }
+        }
+    }
+    samples.into_iter().collect::<Vec<_>>().join(",")
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -229,7 +254,10 @@ struct DuplicationLadderRecorder {
     /// groups are processed, plus the final per-library rows appended by
     /// [`Self::finish`]). Sorted into deterministic (library, `templates_seen`)
     /// order only at write time.
-    rows: Vec<(u16, u64, u64)>,
+    /// `(library_idx, templates_seen, duplicate_templates, window_templates,
+    /// window_duplicate_templates)`. The two `window_*` values cover only the
+    /// templates added since the previous snapshot for that library.
+    rows: Vec<(u16, u64, u64, u64, u64)>,
 }
 
 /// Running cumulative state for one library's saturation ladder.
@@ -243,8 +271,12 @@ struct LadderLibraryState {
     next_threshold: u64,
     /// `templates_seen` at the last emitted row, used by [`Self::finish`] (via
     /// [`DuplicationLadderRecorder::finish`]) to avoid a duplicate final row
-    /// when the true total already landed exactly on an interval crossing.
+    /// when the true total already landed exactly on an interval crossing, and
+    /// to size each snapshot's window (`templates_seen - last_emitted_at`).
     last_emitted_at: u64,
+    /// `duplicate_templates` at the last emitted row, so a snapshot's window
+    /// duplicate count is `duplicate_templates - last_emitted_duplicates`.
+    last_emitted_duplicates: u64,
 }
 
 impl DuplicationLadderRecorder {
@@ -276,6 +308,7 @@ impl DuplicationLadderRecorder {
             duplicate_templates: 0,
             next_threshold: interval,
             last_emitted_at: 0,
+            last_emitted_duplicates: 0,
         });
         state.templates_seen += group_counts.total_templates;
         state.duplicate_templates += group_counts.duplicate_templates;
@@ -287,8 +320,17 @@ impl DuplicationLadderRecorder {
         // `+= interval` step, so the next crossing check is correct instead
         // of re-firing on the very next call.
         if state.templates_seen >= state.next_threshold {
-            self.rows.push((library_idx, state.templates_seen, state.duplicate_templates));
+            let window_templates = state.templates_seen - state.last_emitted_at;
+            let window_duplicates = state.duplicate_templates - state.last_emitted_duplicates;
+            self.rows.push((
+                library_idx,
+                state.templates_seen,
+                state.duplicate_templates,
+                window_templates,
+                window_duplicates,
+            ));
             state.last_emitted_at = state.templates_seen;
+            state.last_emitted_duplicates = state.duplicate_templates;
             state.next_threshold =
                 state.templates_seen - (state.templates_seen % interval) + interval;
         }
@@ -299,7 +341,13 @@ impl DuplicationLadderRecorder {
     fn finish(&mut self) {
         for (&library_idx, state) in &self.per_library {
             if state.templates_seen > state.last_emitted_at {
-                self.rows.push((library_idx, state.templates_seen, state.duplicate_templates));
+                self.rows.push((
+                    library_idx,
+                    state.templates_seen,
+                    state.duplicate_templates,
+                    state.templates_seen - state.last_emitted_at,
+                    state.duplicate_templates - state.last_emitted_duplicates,
+                ));
             }
         }
     }
@@ -1065,6 +1113,12 @@ pub struct MarkDuplicates {
     #[arg(short = 'm', long = "metrics")]
     pub metrics: Option<PathBuf>,
 
+    /// Sample name written to the `sample` column of the `--metrics` output.
+    /// Defaults to the comma-joined unique `@RG SM:` values from the input
+    /// header (empty when none are present).
+    #[arg(long = "sample")]
+    pub sample: Option<String>,
+
     /// Path to write family size histogram
     #[arg(short = 'H', long = "family-size-histogram")]
     pub family_size_histogram: Option<PathBuf>,
@@ -1277,6 +1331,9 @@ impl Command for MarkDuplicates {
         // the metrics writer can still map `library_idx -> name` after the
         // pipeline consumes the original.
         let library_index_for_metrics = library_index.clone();
+        // Resolve the metrics `sample` value now, while `header` is still
+        // available — the pipeline consumes `header` by value below.
+        let sample_for_metrics = resolve_sample(&header, self.sample.as_deref());
         // Cache the UMI tag's value position on each DecodedRecord so the
         // Process step's UMI-assignment pass can slice the value without
         // re-scanning aux data (issue #334). In `--no-umi` mode the
@@ -1453,6 +1510,7 @@ impl Command for MarkDuplicates {
                 &final_counts_by_library,
                 &final_counts,
                 &library_index_for_metrics,
+                &sample_for_metrics,
                 metrics_path,
             )?;
         }
@@ -1545,6 +1603,7 @@ fn write_dedup_metrics(
     per_library: &AHashMap<u16, DedupCounts>,
     total: &DedupCounts,
     library_index: &LibraryIndex,
+    sample: &str,
     path: &PathBuf,
 ) -> Result<()> {
     let mut ordered: Vec<(u16, &DedupCounts)> =
@@ -1560,11 +1619,16 @@ fn write_dedup_metrics(
     let mut rows: Vec<DeduplicationMetrics> = ordered
         .into_iter()
         .map(|(idx, counts)| {
-            to_deduplication_metrics(library_display_name(idx, library_index), counts)
+            to_deduplication_metrics(
+                sample.to_string(),
+                library_display_name(idx, library_index),
+                counts,
+            )
         })
         .collect();
 
-    let mut total_row = to_deduplication_metrics("All Reads".to_string(), total);
+    let mut total_row =
+        to_deduplication_metrics(sample.to_string(), "All Reads".to_string(), total);
     if per_library.len() > 1 {
         total_row.estimated_library_size = None;
     }
@@ -1594,11 +1658,13 @@ fn write_duplication_ladder(
     let mut rows: Vec<DuplicationLadderMetrics> = recorder
         .rows
         .iter()
-        .map(|&(idx, templates_seen, duplicate_templates)| {
+        .map(|&(idx, templates_seen, duplicate_templates, window_templates, window_duplicates)| {
             DuplicationLadderMetrics::new(
                 library_display_name(idx, library_index),
                 templates_seen,
                 duplicate_templates,
+                window_templates,
+                window_duplicates,
             )
         })
         .collect();
@@ -2911,7 +2977,7 @@ mod tests {
             passthrough_templates: 3,
             filter_counts,
         };
-        let output = to_deduplication_metrics("lib1".to_string(), &counts);
+        let output = to_deduplication_metrics("smpl".to_string(), "lib1".to_string(), &counts);
 
         assert_eq!(output.library, "lib1");
         assert_eq!(output.filtered_malformed_record, 1);
@@ -2967,7 +3033,7 @@ mod tests {
             filter_counts,
             ..DedupCounts::default()
         };
-        let output = to_deduplication_metrics("lib1".to_string(), &counts);
+        let output = to_deduplication_metrics("smpl".to_string(), "lib1".to_string(), &counts);
 
         assert_eq!(
             output.filtered_templates + output.total_templates,
@@ -2993,7 +3059,7 @@ mod tests {
 
         let dir = tempfile::tempdir()?;
         let path = dir.path().join("dedup.metrics.txt");
-        write_dedup_metrics(&per_library, &counts, &library_index, &path)?;
+        write_dedup_metrics(&per_library, &counts, &library_index, "test-sample", &path)?;
 
         let text = std::fs::read_to_string(&path)?;
         let header: Vec<&str> = text.lines().next().expect("header").split('\t').collect();

--- a/tests/integration/test_dedup_command.rs
+++ b/tests/integration/test_dedup_command.rs
@@ -246,6 +246,19 @@ fn test_dedup_command_with_metrics() {
 /// Build a template-coordinate-sorted SAM header with two `@RG` lines that have
 /// distinct `LB` values ("libA"/"libB"), for the per-library metrics test below.
 fn create_multi_library_header(ref_name: &str, ref_len: usize) -> noodles::sam::Header {
+    // Both read groups share one sample, so the resolved `sample` column is a
+    // single value; the distinct-sample ordering is exercised separately.
+    create_multi_library_header_with_samples(ref_name, ref_len, "sampleX", "sampleX")
+}
+
+/// Like [`create_multi_library_header`], but lets each read group declare its
+/// own `@RG SM:` value so a test can pin how distinct samples resolve.
+fn create_multi_library_header_with_samples(
+    ref_name: &str,
+    ref_len: usize,
+    sample_rg1: &str,
+    sample_rg2: &str,
+) -> noodles::sam::Header {
     use bstr::BString;
     use noodles::sam::header::record::value::Map;
     use noodles::sam::header::record::value::map::Map as HeaderRecordMap;
@@ -271,10 +284,12 @@ fn create_multi_library_header(ref_name: &str, ref_len: usize) -> noodles::sam::
 
     let rg_a = Map::<ReadGroup>::builder()
         .insert(rg_tag::LIBRARY, String::from("libA"))
+        .insert(rg_tag::SAMPLE, String::from(sample_rg1))
         .build()
         .expect("building read group RG1 should succeed");
     let rg_b = Map::<ReadGroup>::builder()
         .insert(rg_tag::LIBRARY, String::from("libB"))
+        .insert(rg_tag::SAMPLE, String::from(sample_rg2))
         .build()
         .expect("building read group RG2 should succeed");
 
@@ -354,6 +369,114 @@ fn read_dedup_metrics_rows(path: &Path) -> Vec<std::collections::HashMap<String,
         .collect()
 }
 
+/// Validate one library's `--duplication-ladder` rows and return their count.
+///
+/// Checks: `templates_seen` matches the derived interval-crossing sequence
+/// exactly (which also pins the snapshot-row count) and is strictly increasing;
+/// cumulative and per-window `duplicate_fraction` both in `[0, 1]`; each
+/// `window_templates` equals the increment over the previous snapshot and the
+/// windows sum to the true per-library total; the final snapshot lands at that
+/// total with a cumulative fraction matching the metrics file's
+/// `duplicate_rate`.
+/// Assert `row[field]` parses to the exact fraction `num/den` (within a small
+/// float tolerance), so a pinned expected table catches wrong saturation values,
+/// not merely out-of-range ones.
+fn assert_fraction_eq(
+    row: &std::collections::HashMap<String, String>,
+    field: &str,
+    (num, den): (u64, u64),
+    label: &str,
+) {
+    let actual: f64 = row[field].parse().unwrap_or_else(|_| panic!("{field} is f64"));
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "numerator and denominator are small test constants (< 100)"
+    )]
+    let expected = num as f64 / den as f64;
+    assert!(
+        (actual - expected).abs() < 1e-9,
+        "{label} {field} ({actual}) must equal {num}/{den} ({expected}): {row:?}"
+    );
+}
+
+#[expect(clippy::type_complexity, reason = "an inline pinned table of expected rows")]
+fn assert_ladder_library_ok(
+    ladder_rows: &[std::collections::HashMap<String, String>],
+    library: &str,
+    expected_rows: &[(u64, (u64, u64), (u64, u64))],
+    library_metrics: &std::collections::HashMap<String, String>,
+) -> usize {
+    let rows: Vec<_> = ladder_rows.iter().filter(|r| r["library"] == library).collect();
+
+    // Pin every row's snapshot exactly, in file order (not merely by count), so a
+    // regression that emits the right number of rows at the wrong interval
+    // crossings — or with the wrong cumulative/marginal saturation values — is
+    // caught.
+    assert_eq!(
+        rows.len(),
+        expected_rows.len(),
+        "{library}: expected {} ladder rows: {rows:?}",
+        expected_rows.len()
+    );
+
+    let mut previous_seen = 0u64;
+    let mut window_sum = 0u64;
+    for (row, &(expected_seen, cumulative, window)) in rows.iter().zip(expected_rows) {
+        let templates_seen: u64 = row["templates_seen"].parse().expect("templates_seen is u64");
+        assert_eq!(
+            templates_seen, expected_seen,
+            "{library}: snapshot must land on the derived interval crossing: {row:?}"
+        );
+        assert!(
+            templates_seen > previous_seen,
+            "{library}: templates_seen must be strictly increasing: {rows:?}"
+        );
+
+        // Cumulative duplicate_fraction, pinned exactly (not merely in [0, 1]).
+        assert_fraction_eq(
+            row,
+            "duplicate_fraction",
+            cumulative,
+            &format!("{library}: cumulative"),
+        );
+
+        // Marginal (window) columns: this window's depth is the increment over
+        // the previous snapshot, and its fraction is pinned exactly.
+        let window_templates: u64 =
+            row["window_templates"].parse().expect("window_templates is u64");
+        assert_eq!(
+            window_templates,
+            templates_seen - previous_seen,
+            "{library}: window_templates must equal the increment since the last snapshot: {row:?}"
+        );
+        assert_fraction_eq(row, "window_duplicate_fraction", window, &format!("{library}: window"));
+        window_sum += window_templates;
+        previous_seen = templates_seen;
+    }
+
+    let last_row = rows.last().unwrap_or_else(|| panic!("{library}: no ladder rows emitted"));
+    assert_eq!(
+        last_row["templates_seen"], library_metrics["total_templates"],
+        "{library}: final ladder snapshot must land at the true per-library total: {last_row:?}"
+    );
+    // The per-window depths partition the cumulative total exactly.
+    assert_eq!(
+        window_sum.to_string(),
+        library_metrics["total_templates"],
+        "{library}: window_templates must sum to the per-library total"
+    );
+    let expected_fraction: f64 =
+        library_metrics["duplicate_rate"].parse().expect("duplicate_rate is f64");
+    let actual_fraction: f64 =
+        last_row["duplicate_fraction"].parse().expect("duplicate_fraction is f64");
+    assert!(
+        (actual_fraction - expected_fraction).abs() < 1e-9,
+        "{library}: final duplicate_fraction ({actual_fraction}) must match the metrics \
+         file's cumulative duplicate_rate ({expected_fraction})"
+    );
+    rows.len()
+}
+
 /// Dedup over a two-library input (library A: 3 duplicate pairs at one
 /// position; library B: 2 duplicate pairs at a different position) and verify
 /// the metrics file has one row per library, sorted by name, plus a final
@@ -406,6 +529,12 @@ fn test_dedup_command_per_library_metrics() {
         "rows must be library-name-sorted, with the total row last: {libraries:?}"
     );
 
+    // The `sample` column is resolved from the header's @RG SM tags (both read
+    // groups declare SM:sampleX) and is the same on every row.
+    for row in &rows {
+        assert_eq!(row["sample"], "sampleX", "sample resolved from @RG SM: {row:?}");
+    }
+
     // Each position group in `fgumi dedup` holds a single mate (R1's group and
     // R2's group are template-coordinate-adjacent but distinct groups), so a
     // library's `count` duplicate pairs contribute `2 * count` templates/reads
@@ -453,6 +582,90 @@ fn test_dedup_command_per_library_metrics() {
         total["estimated_library_size"].is_empty(),
         "the aggregate row spans >1 library, so its estimate must be empty: {total:?}"
     );
+}
+
+/// Distinct `@RG SM:` values resolve deterministically: the `sample` column is
+/// the sorted, comma-joined set of unique samples, identical on every row,
+/// regardless of the order the read groups declare them in the header. The
+/// header here lists `sampleB` before `sampleA` so a non-sorting resolver would
+/// emit `sampleB,sampleA`.
+#[test]
+fn test_dedup_command_metrics_sample_column_sorts_distinct_samples() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let metrics_path = temp_dir.path().join("metrics.txt");
+
+    // RG1 declares the lexically-later sample, RG2 the earlier one, so the
+    // header order is the reverse of the expected sorted output.
+    let header = create_multi_library_header_with_samples("chr1", 10000, "sampleB", "sampleA");
+    let mut records = create_duplicate_group_with_rg("libA_dup", "ACGTACGT", 3, 100, "RG1");
+    records.extend(create_duplicate_group_with_rg("libB_dup", "TGCATGCA", 2, 500, "RG2"));
+    create_sorted_bam_with_header(&input_bam, &header, records);
+
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--metrics",
+        metrics_path.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse dedup args");
+    cmd.execute("fgumi dedup").expect("Dedup command with distinct samples failed");
+
+    let rows = read_dedup_metrics_rows(&metrics_path);
+    assert!(!rows.is_empty(), "expected at least one metrics row: {rows:?}");
+    for row in &rows {
+        assert_eq!(
+            row["sample"], "sampleA,sampleB",
+            "the sample column must be the sorted, comma-joined unique @RG SM values, \
+             independent of header order: {row:?}"
+        );
+    }
+}
+
+/// `--sample` overrides the header-derived `@RG SM:` value on every metrics row.
+#[test]
+fn test_dedup_command_sample_override_wins_over_header() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let metrics_path = temp_dir.path().join("metrics.txt");
+
+    // The header declares @RG SM:sampleX; --sample must win.
+    let header = create_multi_library_header("chr1", 10000);
+    let records = create_duplicate_group_with_rg("libA_dup", "ACGTACGT", 3, 100, "RG1");
+    create_sorted_bam_with_header(&input_bam, &header, records);
+
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--metrics",
+        metrics_path.to_str().unwrap(),
+        "--sample",
+        "OVERRIDE",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse dedup args");
+    cmd.execute("fgumi dedup").expect("Dedup command with --sample override failed");
+
+    let rows = read_dedup_metrics_rows(&metrics_path);
+    assert!(!rows.is_empty(), "expected at least one metrics row");
+    for row in &rows {
+        assert_eq!(row["sample"], "OVERRIDE", "--sample must override @RG SM: {row:?}");
+    }
 }
 
 /// Row order with named libraries AND reads lacking `@RG`/`LB`: named
@@ -618,67 +831,38 @@ fn test_dedup_duplication_ladder_multi_library() {
     // interval at 6, 8, 12, then gets a final row at its true total (14), which
     // doesn't land on a crossing — 4 rows. libB crosses at 4 and 8, with 8
     // landing exactly on its true total, so no extra final row — 2 rows.
-    // Per snapshot row, keyed by library: (templates_seen, (duplicate
-    // numerator, denominator)), pinned so the table reads as a spec.
+    // Per snapshot row, keyed by library: (templates_seen, cumulative (num,
+    // den), window (num, den)), pinned so the table reads as a spec. The window
+    // duplicate count is the cumulative duplicates minus the previous snapshot's,
+    // over the window's templates: libA cumulative dups run 4, 5, 7, 8 over seen
+    // 6, 8, 12, 14, so the windows are 4/6, 1/2, 2/4, 1/2; libB runs 2, 4 over 4,
+    // 8, so 2/4, 2/4.
     #[expect(clippy::type_complexity, reason = "an inline pinned table of expected rows")]
-    let expected_sequences: [(&str, &[(u64, (u64, u64))]); 2] = [
-        ("libA", &[(6, (4, 6)), (8, (5, 8)), (12, (7, 12)), (14, (8, 14))]),
-        ("libB", &[(4, (2, 4)), (8, (4, 8))]),
+    let expected_sequences: [(&str, &[(u64, (u64, u64), (u64, u64))]); 2] = [
+        (
+            "libA",
+            &[
+                (6, (4, 6), (4, 6)),
+                (8, (5, 8), (1, 2)),
+                (12, (7, 12), (2, 4)),
+                (14, (8, 14), (1, 2)),
+            ],
+        ),
+        ("libB", &[(4, (2, 4), (2, 4)), (8, (4, 8), (2, 4))]),
     ];
     let mut matched_row_count = 0usize;
 
-    // For each library: every row's templates_seen and duplicate_fraction match
-    // the pinned sequence in file order, the last row's templates_seen equals
-    // the true per-library total (from the metrics file), and the last row's
-    // duplicate_fraction matches the metrics file's template-level
-    // duplicate_rate exactly (both are the same cumulative
-    // duplicate_templates / total_templates ratio).
+    // For each library: every row's templates_seen, cumulative duplicate_fraction,
+    // window_templates and window_duplicate_fraction match the pinned sequence in
+    // file order; the windows sum to the true per-library total; and the last
+    // row's cumulative fraction matches the metrics file's template-level
+    // duplicate_rate exactly.
     for (library, expected_rows) in expected_sequences {
-        let rows: Vec<_> = ladder_rows.iter().filter(|r| r["library"] == library).collect();
-        matched_row_count += rows.len();
-
-        assert_eq!(
-            rows.len(),
-            expected_rows.len(),
-            "{library}: expected {} ladder rows: {rows:?}",
-            expected_rows.len()
-        );
-
-        for (row, &(expected_seen, (num, den))) in rows.iter().zip(expected_rows) {
-            let seen: u64 = row["templates_seen"].parse().expect("templates_seen is u64");
-            assert_eq!(
-                seen, expected_seen,
-                "{library}: snapshot must land on the derived interval crossing: {row:?}"
-            );
-            let duplicate_fraction: f64 =
-                row["duplicate_fraction"].parse().expect("duplicate_fraction is f64");
-            #[expect(
-                clippy::cast_precision_loss,
-                reason = "numerator and denominator are small test constants (< 100)"
-            )]
-            let expected_fraction = num as f64 / den as f64;
-            assert!(
-                (duplicate_fraction - expected_fraction).abs() < 1e-9,
-                "{library}: row duplicate_fraction ({duplicate_fraction}) must equal \
-                 {num}/{den} ({expected_fraction}): {row:?}"
-            );
-        }
-
-        let last_row = rows.last().unwrap_or_else(|| panic!("{library}: no ladder rows emitted"));
-        let library_metrics = metrics_by_library[library];
-        assert_eq!(
-            last_row["templates_seen"], library_metrics["total_templates"],
-            "{library}: final ladder snapshot must land at the true per-library total: {last_row:?}"
-        );
-
-        let expected_fraction: f64 =
-            library_metrics["duplicate_rate"].parse().expect("duplicate_rate is f64");
-        let actual_fraction: f64 =
-            last_row["duplicate_fraction"].parse().expect("duplicate_fraction is f64");
-        assert!(
-            (actual_fraction - expected_fraction).abs() < 1e-9,
-            "{library}: final duplicate_fraction ({actual_fraction}) must match the metrics \
-             file's cumulative duplicate_rate ({expected_fraction})"
+        matched_row_count += assert_ladder_library_ok(
+            &ladder_rows,
+            library,
+            expected_rows,
+            metrics_by_library[library],
         );
     }
 
@@ -722,10 +906,66 @@ fn test_dedup_duplication_ladder_off_by_default() {
         "duplication ladder file must not be created when --duplication-ladder is not passed"
     );
 
+    // Record-identity oracle: dedup marks duplicates in place, so the output must
+    // hold exactly the input's 10 records (both segments of all five templates),
+    // none dropped, added, or renamed — and carrying the duplicate marks the
+    // identity strategy assigns. A bare count of 10 would still pass if a record
+    // were dropped and another duplicated, or the wrong templates were marked.
     let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
-    let _header = reader.read_header().unwrap();
-    let count = reader.records().count();
-    assert_eq!(count, 10, "All reads should be in output (marked, not removed)");
+    let header = reader.read_header().unwrap();
+    let mut names: Vec<String> = Vec::new();
+    // Per template name, the duplicate flag of each of its segments.
+    let mut duplicate_flags_by_template: std::collections::BTreeMap<String, Vec<bool>> =
+        std::collections::BTreeMap::new();
+    for record in reader.record_bufs(&header) {
+        let record = record.expect("read output record");
+        let name =
+            String::from_utf8(record.name().expect("output record must have a name").to_vec())
+                .expect("read name is UTF-8");
+        duplicate_flags_by_template
+            .entry(name.clone())
+            .or_default()
+            .push(record.flags().is_duplicate());
+        names.push(name);
+    }
+
+    names.sort_unstable();
+    assert_eq!(
+        names,
+        vec![
+            "dup1_0", "dup1_0", "dup1_1", "dup1_1", "dup1_2", "dup1_2", "dup2_0", "dup2_0",
+            "dup2_1", "dup2_1",
+        ],
+        "output must hold exactly the input records (both segments of every template): {names:?}"
+    );
+
+    // Both segments of a template must carry the same duplicate mark, and the
+    // identity strategy keeps exactly one primary per position group: dup1's three
+    // templates yield two duplicates, dup2's two yield one.
+    for (name, flags) in &duplicate_flags_by_template {
+        assert_eq!(flags.len(), 2, "template {name} must have both segments in output");
+        assert_eq!(
+            flags[0], flags[1],
+            "template {name}: both segments must share the duplicate mark"
+        );
+    }
+    let marked_duplicate_templates = |prefix: &str| {
+        duplicate_flags_by_template
+            .iter()
+            .filter(|(name, _)| name.starts_with(prefix))
+            .filter(|(_, flags)| flags[0])
+            .count()
+    };
+    assert_eq!(
+        marked_duplicate_templates("dup1"),
+        2,
+        "dup1: 3 templates at one position -> 1 primary kept, 2 marked duplicate"
+    );
+    assert_eq!(
+        marked_duplicate_templates("dup2"),
+        1,
+        "dup2: 2 templates at one position -> 1 primary kept, 1 marked duplicate"
+    );
 }
 
 /// Regression test: a single position group whose template increment is
@@ -799,6 +1039,20 @@ fn test_dedup_duplication_ladder_single_group_exceeds_interval() {
             window[1] > window[0],
             "templates_seen must be strictly increasing: {templates_seen:?}"
         );
+    }
+
+    // Pin the marginal (window) columns on the multi-threshold path too, not just
+    // the cumulative fraction: a defect in `window_templates` or
+    // `window_duplicate_fraction` — e.g. one that mis-attributes depth when a
+    // single `record()` call crosses several interval multiples — can pass a
+    // cumulative-only check. Each position group contributes exactly 10 templates
+    // with 9 duplicates, so every window is 10 templates at 9/10.
+    for row in &ladder_rows {
+        assert_eq!(
+            row["window_templates"], "10",
+            "each window covers exactly one 10-template position group: {row:?}"
+        );
+        assert_fraction_eq(row, "window_duplicate_fraction", (9, 10), "multi-threshold window");
     }
 
     // Pin the intermediate row's fraction too, not just the final one: the


### PR DESCRIPTION
Closes #802. Builds on #799.

> **Stacked on #799** (`786/nhomer/feat-dedup-complexity-metrics`). Review/merge #799 first; this PR's base retargets to `main` once #799 lands.

Toward Picard `DuplicationMetrics` / dupblaster `--stats` parity, two dupblaster-derived additions to `fgumi dedup`'s QC output:

## `sample` column
`--metrics` gains a leading `sample` column, resolved from the header's unique `@RG SM:` values (comma-joined), with an optional `--sample` override. Constant across every row of a run; leads the schema, matching dupblaster/Picard.

## Marginal duplication-ladder columns
`--duplication-ladder` gains per-window columns (`window_templates`, `window_duplicate_fraction`) alongside the cumulative ones. The marginal rate isolates each depth band instead of averaging over all prior templates — "usually the more legible view" of the saturation curve (dupblaster's `complexity.rs`). The windows partition the cumulative total exactly.

## Not included
The pair/orphan duplicate breakdown (Picard `READ_PAIRS_EXAMINED` / `READ_PAIR_DUPLICATES` / `UNPAIRED_*`) is a distinct algorithmic change — it requires classifying each template as pair vs orphan during marking — so it's tracked as its own follow-up rather than bundled here.

## Verification
Full workspace suite 2544/2544. New tests: `sample` resolved from `@RG SM` and via `--sample` override; ladder window columns present, marginal fraction in `[0,1]`, and windows summing to the per-library total. The pinned column-order test is updated (`sample` first).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: dedup QC output changes, pinned by integration tests for sample resolution, override behavior, ladder values, reconciliation, and column order; unsafe changes: none, so the `CLAUDE.md` allowlist remains unchanged; memory bounds, queue capacity, and thread/backpressure policy changes: none.

Fix: Add `sample` to `--metrics` and marginal window columns to `--duplication-ladder`.

Pair and orphan duplicate metrics remain out of scope. The full workspace suite and targeted integration tests provide verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->