### PR TITLE
feat(bam-io): honor --check-crc on correct/group single-threaded paths (#800)

### DIFF
--- a/crates/fgumi-bam-io/src/lib.rs
+++ b/crates/fgumi-bam-io/src/lib.rs
@@ -33,8 +33,8 @@ pub use reader::{
     BamReaderAuto, BgzfReaderEnum, ChainedReader, FgumiBgzfReader, PipelineReaderOpts,
     RawBamReaderAuto, TeeReader, create_bam_reader, create_bam_reader_for_pipeline,
     create_bam_reader_for_pipeline_with_opts, create_bam_reader_with_opts, create_raw_bam_reader,
-    create_raw_bam_reader_with_opts, make_bgzf_reader, open_normalized_input,
-    read_header_and_replay, read_prefix,
+    create_raw_bam_reader_from_stream_with_opts, create_raw_bam_reader_with_opts, make_bgzf_reader,
+    open_normalized_input, read_header_and_replay, read_prefix,
 };
 pub use reorder::{DrainReady, ReorderBuffer};
 pub use writer::{

--- a/crates/fgumi-bam-io/src/reader.rs
+++ b/crates/fgumi-bam-io/src/reader.rs
@@ -537,18 +537,60 @@ pub fn create_raw_bam_reader_with_opts<P: AsRef<Path>>(
 ) -> Result<(RawBamReaderAuto, Header)> {
     let path_ref = path.as_ref();
     let bgzf_reader = open_bgzf_reader(path_ref, opts, threads, "raw BAM reader")?;
+    finish_raw_bam_reader(bgzf_reader, &path_ref.display().to_string())
+}
 
-    // Use noodles to read the header, then extract the BGZF reader
+/// Build a raw BAM reader over an already-opened, still-compressed BGZF byte
+/// stream, decoding through fgumi-bgzf so `opts.verify_crc` is honored.
+///
+/// The single-threaded `correct` and `group` fast paths open their input exactly
+/// once (required for stdin, which cannot be re-opened), parse the header for the
+/// output, then must skip the header again to reach records. That second decode
+/// is what this factory provides: routing it through [`FgumiBgzfReader`] — rather
+/// than noodles' always-verify BGZF reader — makes `--no-check-crc` take effect
+/// on those fast paths too (#800), matching the `--threads N` unified pipeline
+/// (which already honors `PipelineConfig::verify_crc`).
+///
+/// The input is decoded single-threaded: this is the fast path taken precisely
+/// when the caller passed no `--threads`, so no worker pool is warranted.
+///
+/// The returned header is the stream's own header, re-parsed here; callers that
+/// have already augmented a header (e.g. synthesized @HD or added @PG) keep their
+/// own copy and use this only to position the reader past the header bytes.
+///
+/// # Errors
+///
+/// Returns an error if the BAM header cannot be read from the stream.
+pub fn create_raw_bam_reader_from_stream_with_opts(
+    reader: Box<dyn Read + Send>,
+    opts: PipelineReaderOpts,
+) -> Result<(RawBamReaderAuto, Header)> {
+    // Buffer before the frame reader for the same reason as `open_bgzf_reader`:
+    // the BGZF frame reader asks for an 18-byte header and then a block body, so
+    // an unbuffered source pays a syscall per block (and worse on stdin).
+    let buffered: Box<dyn Read + Send> =
+        Box::new(BufReader::with_capacity(BGZF_INPUT_BUFFER_SIZE, reader));
+    let bgzf_reader = BgzfReaderEnum::Fgumi(FgumiBgzfReader::new(buffered, opts.verify_crc));
+    finish_raw_bam_reader(bgzf_reader, "BAM stream")
+}
+
+/// Parse the BAM header from `bgzf_reader` and wrap the positioned decoder in a
+/// [`RawBamReader`]. Shared tail of [`create_raw_bam_reader_with_opts`] and
+/// [`create_raw_bam_reader_from_stream_with_opts`]: noodles is used only to
+/// consume the header, after which the underlying BGZF decoder — already the
+/// fgumi-bgzf or multithreaded arm chosen by the caller — is handed to the raw
+/// reader for record access. `source` names the input in the header-read error.
+fn finish_raw_bam_reader(
+    bgzf_reader: BgzfReaderEnum,
+    source: &str,
+) -> Result<(RawBamReaderAuto, Header)> {
     let mut noodles_reader = noodles::bam::io::Reader::from(bgzf_reader);
     let header = noodles_reader
         .read_header()
-        .with_context(|| format!("Failed to read header from: {}", path_ref.display()))?;
+        .with_context(|| format!("Failed to read header from: {source}"))?;
 
-    // Get back the BGZF reader (header has been consumed)
-    let bgzf_reader = noodles_reader.into_inner();
-
-    // Wrap in our raw reader
-    let raw_reader = RawBamReader::new(bgzf_reader);
+    // Get back the BGZF reader (header has been consumed) and wrap it.
+    let raw_reader = RawBamReader::new(noodles_reader.into_inner());
 
     Ok((raw_reader, header))
 }
@@ -1244,6 +1286,40 @@ mod tests {
         // verify_crc: false -> the same file reads clean (RED on the noodles path).
         let opts_skip = PipelineReaderOpts { verify_crc: false, ..PipelineReaderOpts::default() };
         let (mut reader, _header) = create_raw_bam_reader_with_opts(file.path(), 1, opts_skip)?;
+        let count = count_raw_records(&mut reader)
+            .expect("verify_crc: false must accept a corrupted BGZF CRC32");
+        assert_eq!(count, 8000, "all records read with verify_crc: false");
+        Ok(())
+    }
+
+    /// The from-stream raw reader must honor `verify_crc` exactly as the
+    /// from-path reader does. This is the factory the single-threaded `correct`
+    /// and `group` fast paths use on their already-opened stream (opened once so
+    /// stdin — which cannot be re-opened — works), so `--no-check-crc` must take
+    /// effect there too (#800). Against the noodles path these commands used
+    /// before, the `verify_crc: false` case could not pass — noodles always
+    /// verifies — so it is the red test for routing them through fgumi-bgzf.
+    #[test]
+    fn test_raw_reader_from_stream_honors_verify_crc() -> Result<()> {
+        let file = tempfile::Builder::new().suffix(".bam").tempfile()?;
+        write_bgzf_bam(file.path(), &many_record_sam_text(8000));
+        corrupt_last_block_crc(file.path());
+        let bytes = std::fs::read(file.path())?;
+
+        // verify_crc: true -> reading the corrupted block must error.
+        let opts_verify = PipelineReaderOpts { verify_crc: true, ..PipelineReaderOpts::default() };
+        let stream: Box<dyn Read + Send> = Box::new(io::Cursor::new(bytes.clone()));
+        let (mut reader, _header) =
+            create_raw_bam_reader_from_stream_with_opts(stream, opts_verify)?;
+        assert!(
+            count_raw_records(&mut reader).is_err(),
+            "verify_crc: true must reject a corrupted BGZF CRC32"
+        );
+
+        // verify_crc: false -> the same bytes read clean (RED on the noodles path).
+        let opts_skip = PipelineReaderOpts { verify_crc: false, ..PipelineReaderOpts::default() };
+        let stream: Box<dyn Read + Send> = Box::new(io::Cursor::new(bytes));
+        let (mut reader, _header) = create_raw_bam_reader_from_stream_with_opts(stream, opts_skip)?;
         let count = count_raw_records(&mut reader)
             .expect("verify_crc: false must accept a corrupted BGZF CRC32");
         assert_eq!(count, 8000, "all records read with verify_crc: false");

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -447,18 +447,12 @@ pub struct BamIoOptions {
     /// transferred, or copied since it was written, where a flipped bit is
     /// exactly what CRC32 exists to catch. Pass `--check-crc` to force
     /// verification on (e.g. for stdin input you don't trust). Mutually
-    /// exclusive with `--no-check-crc`. Coverage varies by command:
-    /// `clip`/`codec`/`duplex`/`simplex`/`downsample` honor it whether run
-    /// single- or multi-threaded; `correct`/`group` honor it only with
-    /// `--threads N` (their single-threaded mode falls back to a reader that
-    /// always verifies). Every run logs a `CRC verify:` line at startup stating
-    /// what actually happened. For `correct`/`group` the BAM **header** block is
-    /// always CRC-verified regardless of this flag, because their header parse
-    /// goes through a decoder with no CRC-skip knob; there `--no-check-crc`
-    /// applies to the record body only. The raw-reader commands
-    /// (`clip`/`codec`/`duplex`/`simplex`/`downsample`) parse the header through
-    /// the same fgumi-bgzf decoder as the body when single-threaded, so
-    /// `--no-check-crc` skips the header block's CRC there too.
+    /// exclusive with `--no-check-crc`. Honored on every command's input decode,
+    /// in both single- and multi-threaded modes: single-threaded decodes route
+    /// through fgumi-bgzf, and `--threads N` runs (e.g. `clip --threads N`) decode
+    /// through the unified pipeline, which takes its CRC policy from the same
+    /// flag. Every run logs a `CRC verify:` line at startup stating what actually
+    /// happened.
     #[arg(long = "check-crc", default_value_t = false, conflicts_with = "no_check_crc")]
     pub check_crc: bool,
 
@@ -536,27 +530,6 @@ impl BamIoOptions {
             ""
         };
         log::info!("CRC verify: {}{reason}", if effective { "on" } else { "off" });
-    }
-
-    /// Log the CRC-verification setting for a command whose single-threaded
-    /// fast path bypasses the CRC-skip-capable fgumi-bgzf decoder in favor of
-    /// noodles-bgzf's own BGZF reader (which always verifies and has no
-    /// public knob to disable it). Since the raw-reader unify (#800), only
-    /// `correct` and `group` still take this path: their single-threaded mode
-    /// reads through `create_bam_reader_for_pipeline_with_opts` + a manual
-    /// noodles BGZF decode, not through `create_raw_bam_reader[_with_opts]`.
-    /// `pipeline_mode` is `true` when the wireable 7-step pipeline will run
-    /// instead of the fast path, in which case this defers to
-    /// [`log_effective_check_crc`](Self::log_effective_check_crc).
-    pub fn log_effective_check_crc_for_fast_path(&self, pipeline_mode: bool) {
-        if pipeline_mode {
-            self.log_effective_check_crc();
-        } else {
-            log::info!(
-                "CRC verify: on (single-threaded fast path always verifies; \
-                 --check-crc/--no-check-crc apply only with --threads)"
-            );
-        }
     }
 
     /// Build [`fgumi_bam_io::PipelineReaderOpts`] from the async-reader flag

--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -70,15 +70,15 @@ use crate::unified_pipeline::{
     run_bam_pipeline_from_reader_with_secondary,
 };
 use ahash::AHashMap;
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use clap::Parser;
 use fgumi_bam_io::ProgressTracker;
 use fgumi_bam_io::{
-    BamWriter, create_bam_reader_for_pipeline_with_opts, create_bam_writer,
-    create_optional_bam_writer,
+    BamWriter, PipelineReaderOpts, create_bam_reader_for_pipeline_with_opts, create_bam_writer,
+    create_optional_bam_writer, create_raw_bam_reader_from_stream_with_opts,
 };
 use fgumi_raw_bam;
-use fgumi_raw_bam::{RawBamReader, RawRecord};
+use fgumi_raw_bam::RawRecord;
 use log::{error, info, warn};
 use lru::LruCache;
 use noodles::sam::Header;
@@ -491,7 +491,7 @@ impl Command for CorrectUmis {
         // Warn about UMIs that are too close together
         self.check_umi_distances(&umi_sequences);
 
-        self.io.log_effective_check_crc_for_fast_path(self.threading.threads.is_some());
+        self.io.log_effective_check_crc();
 
         // Open input using streaming-capable reader for pipeline use
         let reader_opts = self.io.pipeline_reader_opts();
@@ -523,6 +523,7 @@ impl Command for CorrectUmis {
             // re-opening would double-consume a pipe). Mirrors group::execute_single_threaded.
             self.execute_single_thread_mode(
                 reader,
+                reader_opts.verify_crc,
                 header,
                 encoded_umi_set,
                 umi_length,
@@ -1256,6 +1257,7 @@ impl CorrectUmis {
     fn execute_single_thread_mode(
         &self,
         reader: Box<dyn std::io::Read + Send>,
+        verify_crc: bool,
         header: Header,
         encoded_umi_set: EncodedUmiSet,
         umi_length: usize,
@@ -1264,12 +1266,12 @@ impl CorrectUmis {
         info!("Using single-threaded mode with template-level UMI correction");
 
         // Reuse the already-opened reader (required for stdin: re-opening a pipe
-        // double-consumes it). Skip past the BAM header to reach records, then
-        // wrap in RawBamReader for zero-copy processing.
-        let buf_reader = std::io::BufReader::new(reader);
-        let mut noodles_reader = noodles::bam::io::Reader::new(buf_reader);
-        let _ = noodles_reader.read_header().context("Failed to skip BAM header")?;
-        let mut bam_reader = RawBamReader::new(noodles_reader.into_inner());
+        // double-consumes it). Decode through fgumi-bgzf so `--no-check-crc`
+        // takes effect on this fast path too (#800); the re-parsed header is
+        // discarded because `header` already carries the synthesized @HD/@PG.
+        let reader_opts = PipelineReaderOpts { verify_crc, ..PipelineReaderOpts::default() };
+        let (mut bam_reader, _skipped_header) =
+            create_raw_bam_reader_from_stream_with_opts(reader, reader_opts)?;
 
         // Open output writer (single-threaded)
         let mut writer =

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -31,13 +31,16 @@ use anyhow::{Context, Result, bail};
 use clap::Parser;
 use fgoxide::io::DelimFile;
 use fgumi_bam_io::ProgressTracker;
-use fgumi_bam_io::{create_bam_reader_for_pipeline_with_opts, create_bam_writer};
+use fgumi_bam_io::{
+    PipelineReaderOpts, create_bam_reader_for_pipeline_with_opts, create_bam_writer,
+    create_raw_bam_reader_from_stream_with_opts,
+};
 use fgumi_umi::IndexThreshold;
 // MemoryEstimate is gated because it's only used in memory-debug blocks below
 use crate::sam::SamTag;
 #[cfg(feature = "memory-debug")]
 use crate::unified_pipeline::MemoryEstimate;
-use fgumi_raw_bam::{RawBamReader, RawRecord};
+use fgumi_raw_bam::RawRecord;
 use log::{info, warn};
 use noodles::sam::Header;
 use noodles::sam::alignment::record::data::field::Tag;
@@ -866,14 +869,13 @@ impl Command for GroupReadsByUmi {
 
         // Log threading configuration
         info!("{}", self.threading.log_message());
-        self.io.log_effective_check_crc_for_fast_path(self.threading.threads.is_some());
+        self.io.log_effective_check_crc();
 
         // Open input BAM using streaming-capable reader for pipeline use
         info!("Reading input BAM");
-        let (reader, header) = create_bam_reader_for_pipeline_with_opts(
-            &self.io.input,
-            self.io.pipeline_reader_opts(),
-        )?;
+        let reader_opts = self.io.pipeline_reader_opts();
+        let (reader, header) =
+            create_bam_reader_for_pipeline_with_opts(&self.io.input, reader_opts)?;
 
         // Sort order: see `classify_input_ordering` for why template-coordinate
         // is required, and why `--allow-unmapped` relaxes it to query grouping.
@@ -936,6 +938,7 @@ impl Command for GroupReadsByUmi {
             // Single-threaded fast path - pass reader (required for stdin support)
             return self.execute_single_threaded(
                 reader,
+                reader_opts.verify_crc,
                 &header,
                 effective_strategy,
                 effective_edits,
@@ -1428,6 +1431,7 @@ impl GroupReadsByUmi {
     fn execute_single_threaded(
         &self,
         reader: Box<dyn std::io::Read + Send>,
+        verify_crc: bool,
         header: &Header,
         effective_strategy: Strategy,
         effective_edits: u32,
@@ -1439,16 +1443,14 @@ impl GroupReadsByUmi {
     ) -> Result<()> {
         info!("Using single-threaded mode");
 
-        // Wrap the reader in a BufReader and use noodles to skip past the BAM header bytes.
-        // The reader is positioned at file start; we must discard the header to reach records.
-        // This reuses the already-opened reader (required for stdin support).
-        let buf_reader = std::io::BufReader::new(reader);
-        let mut noodles_reader = noodles::bam::io::Reader::new(buf_reader);
-        let _ = noodles_reader.read_header().context("Failed to skip BAM header")?;
-
-        // After the header skip, extract the inner BufReader and wrap in RawBamReader.
-        // Raw-byte mode avoids the noodles decode/encode round-trip (~15% CPU savings).
-        let mut raw_reader = RawBamReader::new(noodles_reader.into_inner());
+        // Reuse the already-opened reader (required for stdin support) and skip
+        // past the BAM header to reach records. Decode through fgumi-bgzf so
+        // `--no-check-crc` takes effect on this fast path too (#800); raw-byte
+        // mode avoids the noodles decode/encode round-trip (~15% CPU savings).
+        // The re-parsed header is discarded — the caller already holds `header`.
+        let reader_opts = PipelineReaderOpts { verify_crc, ..PipelineReaderOpts::default() };
+        let (mut raw_reader, _skipped_header) =
+            create_raw_bam_reader_from_stream_with_opts(reader, reader_opts)?;
 
         // Create output writer (single-threaded for strict thread control)
         let mut writer =

--- a/tests/integration/test_clip_command.rs
+++ b/tests/integration/test_clip_command.rs
@@ -47,6 +47,174 @@ fn write_paired_bam_with_header(
     writer.try_finish().expect("Failed to finish BAM");
 }
 
+// ============================================================================
+// --check-crc / --no-check-crc on the multi-threaded (`--threads N`) path (#800)
+//
+// clip is the one command whose `--threads N` mode decodes its input through the
+// unified pipeline (not the single-threaded raw reader). These prove that path
+// honors the flag: `--no-check-crc` accepts a corrupted block, while the default
+// and `--check-crc` reject it.
+// ============================================================================
+
+/// Flip a byte in the last BGZF block's CRC32 footer, so decoding that block
+/// fails only when CRC verification is on. The input must span at least two
+/// blocks so the corrupted block is not the header's block (which always
+/// verifies during the header parse).
+fn corrupt_last_block_crc(path: &Path) {
+    use fgumi_lib::bgzf_reader::{BGZF_FOOTER_SIZE, RawBgzfBlock, read_raw_blocks};
+    let mut bytes = fs::read(path).expect("read bam for corruption");
+    let mut cursor: &[u8] = &bytes;
+    let blocks = read_raw_blocks(&mut cursor, 100_000).expect("read bgzf blocks from test bam");
+    assert!(
+        blocks.len() >= 2,
+        "test input must span >= 2 BGZF blocks so the corrupted block isn't the header's; got {}",
+        blocks.len()
+    );
+    let offset: usize = blocks[..blocks.len() - 1].iter().map(RawBgzfBlock::len).sum();
+    let last = blocks.last().expect("checked len >= 2 above");
+    let crc_off = offset + last.len() - BGZF_FOOTER_SIZE;
+    bytes[crc_off] ^= 0x01;
+    fs::write(path, bytes).expect("write corrupted bam");
+}
+
+/// Write enough query-grouped read pairs to span more than one BGZF block, so
+/// the corrupted last block is a record block rather than the header's.
+fn create_multiblock_clip_bam(path: &Path) {
+    let header = create_minimal_header("chr1", 10000);
+    let mut writer =
+        bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
+    writer.write_header(&header).expect("Failed to write header");
+    for i in 0..3000u32 {
+        let name = format!("read{i}");
+        let mut r1 = SamBuilder::new();
+        r1.read_name(name.as_bytes())
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .cigar_ops(&[8 << 4])
+            .mate_ref_id(0)
+            .mate_pos(103)
+            .template_length(12);
+        let mut r2 = SamBuilder::new();
+        r2.read_name(name.as_bytes())
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .ref_id(0)
+            .pos(103)
+            .mapq(60)
+            .cigar_ops(&[8 << 4])
+            .mate_ref_id(0)
+            .mate_pos(99)
+            .template_length(-12);
+        writer.write_alignment_record(&header, &to_record_buf(&r1.build())).expect("R1");
+        writer.write_alignment_record(&header, &to_record_buf(&r2.build())).expect("R2");
+    }
+    writer.try_finish().expect("Failed to finish BAM");
+}
+
+/// Build clip's `--threads N` argv with a clipping option set (clip requires at
+/// least one), appending any extra flags (e.g. `--no-check-crc`).
+fn clip_threads_args<'a>(
+    input: &'a str,
+    output: &'a str,
+    reference: &'a str,
+    extra: &[&'a str],
+) -> Vec<&'a str> {
+    let mut args = vec![
+        "clip",
+        "--input",
+        input,
+        "--output",
+        output,
+        "--ref",
+        reference,
+        "--clip-overlapping-reads",
+        "--threads",
+        "2",
+    ];
+    args.extend_from_slice(extra);
+    args
+}
+
+/// `--no-check-crc` must let clip's `--threads N` pipeline decode accept a
+/// corrupted BGZF CRC32 and complete (#800).
+#[test]
+fn test_clip_threads_no_check_crc_accepts_corrupted_crc() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let ref_path = create_test_reference(temp_dir.path());
+    create_multiblock_clip_bam(&input_bam);
+    corrupt_last_block_crc(&input_bam);
+
+    let cmd = Clip::try_parse_from(clip_threads_args(
+        input_bam.to_str().unwrap(),
+        output_bam.to_str().unwrap(),
+        ref_path.to_str().unwrap(),
+        &["--no-check-crc"],
+    ))
+    .expect("failed to parse clip args");
+    cmd.execute("fgumi clip")
+        .expect("--no-check-crc must accept a corrupted BGZF CRC32 under --threads");
+    assert!(output_bam.exists(), "Output BAM not created");
+}
+
+/// Default (verify-on for file input) must reject the same corrupted CRC32 under
+/// `--threads N`.
+#[test]
+fn test_clip_threads_rejects_corrupted_crc_by_default() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let ref_path = create_test_reference(temp_dir.path());
+    create_multiblock_clip_bam(&input_bam);
+    corrupt_last_block_crc(&input_bam);
+
+    let cmd = Clip::try_parse_from(clip_threads_args(
+        input_bam.to_str().unwrap(),
+        output_bam.to_str().unwrap(),
+        ref_path.to_str().unwrap(),
+        &[],
+    ))
+    .expect("failed to parse clip args");
+    let err = cmd
+        .execute("fgumi clip")
+        .expect_err("default (verify-on for file input) must reject a corrupted BGZF CRC32");
+    assert!(
+        format!("{err:#}").to_uppercase().contains("CRC32"),
+        "error should mention CRC32: {err:#}"
+    );
+}
+
+/// `--check-crc` must also reject the corrupted CRC32 under `--threads N`.
+#[test]
+fn test_clip_threads_check_crc_rejects_corrupted_crc() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let ref_path = create_test_reference(temp_dir.path());
+    create_multiblock_clip_bam(&input_bam);
+    corrupt_last_block_crc(&input_bam);
+
+    let cmd = Clip::try_parse_from(clip_threads_args(
+        input_bam.to_str().unwrap(),
+        output_bam.to_str().unwrap(),
+        ref_path.to_str().unwrap(),
+        &["--check-crc"],
+    ))
+    .expect("failed to parse clip args");
+    let err =
+        cmd.execute("fgumi clip").expect_err("--check-crc must reject a corrupted BGZF CRC32");
+    assert!(
+        format!("{err:#}").to_uppercase().contains("CRC32"),
+        "error should mention CRC32: {err:#}"
+    );
+}
+
 /// CLIP3-05: clip must reject coordinate-sorted (non-query-grouped) input,
 /// matching fgbio's `Bams.requireQueryGrouped`. On coordinate-sorted input mates
 /// scatter, so pair clip / overlap / mate-fix silently no-op — hard-fail instead.

--- a/tests/integration/test_correct_command.rs
+++ b/tests/integration/test_correct_command.rs
@@ -504,3 +504,126 @@ fn correct_barcode_leaves_umi_tags_untouched() {
     }
     assert_eq!(actual, expected);
 }
+
+// ============================================================================
+// --check-crc / --no-check-crc on the single-threaded fast path (#800)
+// ============================================================================
+
+/// Flip a byte in the last BGZF block's CRC32 footer, so decoding that block
+/// fails only when CRC verification is on. Requires the file to span at least
+/// two blocks so the corrupted block is not the header's block (the header
+/// parse always verifies).
+fn corrupt_last_block_crc(path: &std::path::Path) {
+    let mut bytes = fs::read(path).expect("read bam for corruption");
+    let mut cursor: &[u8] = &bytes;
+    let blocks = fgumi_lib::bgzf_reader::read_raw_blocks(&mut cursor, 100_000)
+        .expect("read bgzf blocks from test bam");
+    assert!(
+        blocks.len() >= 2,
+        "test input must span >= 2 BGZF blocks so the corrupted block isn't the header's; \
+         got {} -- generate more records",
+        blocks.len()
+    );
+    let offset: usize =
+        blocks[..blocks.len() - 1].iter().map(fgumi_lib::bgzf_reader::RawBgzfBlock::len).sum();
+    let last = blocks.last().expect("checked len >= 2 above");
+    let crc_off = offset + last.len() - fgumi_lib::bgzf_reader::BGZF_FOOTER_SIZE;
+    bytes[crc_off] ^= 0x01;
+    fs::write(path, bytes).expect("write corrupted bam");
+}
+
+/// Write a single UMI family large enough to span more than one BGZF block, so
+/// the corrupted last block is a record block rather than the header's.
+fn create_multiblock_umi_bam(path: &PathBuf, umi: &str) {
+    create_umi_bam(path, vec![create_umi_family(umi, 3000, "read", "ACGTACGT", 30)]);
+}
+
+/// Build correct's argv for the single-threaded fast path (no `--threads`),
+/// appending any extra flags (e.g. `--no-check-crc`).
+fn correct_args<'a>(input: &'a str, output: &'a str, extra: &[&'a str]) -> Vec<&'a str> {
+    let mut args = vec![
+        "correct",
+        "--input",
+        input,
+        "--output",
+        output,
+        "--umis",
+        "ACGTACGT",
+        "--max-mismatches",
+        "1",
+        "--min-distance",
+        "1",
+        "--compression-level",
+        "1",
+    ];
+    args.extend_from_slice(extra);
+    args
+}
+
+/// `--no-check-crc` must let correct's single-threaded reader accept a corrupted
+/// BGZF CRC32: it decodes through fgumi-bgzf, honoring the flag (#800). Against
+/// the noodles reader this path used before, this could not pass.
+#[test]
+fn test_correct_no_check_crc_accepts_corrupted_crc() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    create_multiblock_umi_bam(&input_bam, "ACGTACGT");
+    corrupt_last_block_crc(&input_bam);
+
+    let cmd = CorrectUmis::try_parse_from(correct_args(
+        input_bam.to_str().unwrap(),
+        output_bam.to_str().unwrap(),
+        &["--no-check-crc"],
+    ))
+    .expect("failed to parse correct args");
+    cmd.execute("fgumi correct")
+        .expect("--no-check-crc must accept a corrupted BGZF CRC32 and complete");
+    assert!(output_bam.exists(), "Output BAM not created");
+}
+
+/// Default (verify-on for file input) must reject the same corrupted CRC32.
+#[test]
+fn test_correct_rejects_corrupted_crc_by_default() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    create_multiblock_umi_bam(&input_bam, "ACGTACGT");
+    corrupt_last_block_crc(&input_bam);
+
+    let cmd = CorrectUmis::try_parse_from(correct_args(
+        input_bam.to_str().unwrap(),
+        output_bam.to_str().unwrap(),
+        &[],
+    ))
+    .expect("failed to parse correct args");
+    let err = cmd
+        .execute("fgumi correct")
+        .expect_err("default (verify-on for file input) must reject a corrupted BGZF CRC32");
+    let message = format!("{err:#}");
+    assert!(message.to_uppercase().contains("CRC32"), "error should mention CRC32: {message}");
+}
+
+/// `--check-crc` must also reject the corrupted CRC32 (forces verification on).
+#[test]
+fn test_correct_check_crc_rejects_corrupted_crc() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    create_multiblock_umi_bam(&input_bam, "ACGTACGT");
+    corrupt_last_block_crc(&input_bam);
+
+    let cmd = CorrectUmis::try_parse_from(correct_args(
+        input_bam.to_str().unwrap(),
+        output_bam.to_str().unwrap(),
+        &["--check-crc"],
+    ))
+    .expect("failed to parse correct args");
+    let err =
+        cmd.execute("fgumi correct").expect_err("--check-crc must reject a corrupted BGZF CRC32");
+    let message = format!("{err:#}");
+    assert!(message.to_uppercase().contains("CRC32"), "error should mention CRC32: {message}");
+}

--- a/tests/integration/test_group_command.rs
+++ b/tests/integration/test_group_command.rs
@@ -196,3 +196,134 @@ fn create_test_bam_with_n_umis(path: &PathBuf) {
 
     writer.try_finish().expect("Failed to finish BAM");
 }
+
+// ============================================================================
+// --check-crc / --no-check-crc on the single-threaded fast path (#800)
+// ============================================================================
+
+/// Flip a byte in the last BGZF block's CRC32 footer, so decoding that block
+/// fails only when CRC verification is on. Requires the file to span at least
+/// two blocks so the corrupted block is not the header's block (the header
+/// parse always verifies).
+fn corrupt_last_block_crc(path: &std::path::Path) {
+    let mut bytes = fs::read(path).expect("read bam for corruption");
+    let mut cursor: &[u8] = &bytes;
+    let blocks = fgumi_lib::bgzf_reader::read_raw_blocks(&mut cursor, 100_000)
+        .expect("read bgzf blocks from test bam");
+    assert!(
+        blocks.len() >= 2,
+        "test input must span >= 2 BGZF blocks so the corrupted block isn't the header's; \
+         got {} -- generate more records",
+        blocks.len()
+    );
+    let offset: usize =
+        blocks[..blocks.len() - 1].iter().map(fgumi_lib::bgzf_reader::RawBgzfBlock::len).sum();
+    let last = blocks.last().expect("checked len >= 2 above");
+    let crc_off = offset + last.len() - fgumi_lib::bgzf_reader::BGZF_FOOTER_SIZE;
+    bytes[crc_off] ^= 0x01;
+    fs::write(path, bytes).expect("write corrupted bam");
+}
+
+/// Write a single UMI family large enough to span more than one BGZF block (all
+/// reads sit at one position on reference 0, so the input is template-coordinate
+/// sorted), so the corrupted last block is a record block, not the header's.
+fn create_multiblock_group_bam(path: &PathBuf) {
+    let header = create_minimal_header("chr1", 10000);
+    let mut writer =
+        bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
+    writer.write_header(&header).expect("Failed to write header");
+    for record in &create_umi_family("AAAAAAAA", 3000, "read", "ACGTACGT", 30) {
+        writer
+            .write_alignment_record(&header, &to_record_buf(record))
+            .expect("Failed to write record");
+    }
+    writer.try_finish().expect("Failed to finish BAM");
+}
+
+/// Build group's argv for the single-threaded fast path (no `--threads`),
+/// appending any extra flags (e.g. `--no-check-crc`).
+fn group_args<'a>(input: &'a str, output: &'a str, extra: &[&'a str]) -> Vec<&'a str> {
+    let mut args = vec![
+        "group",
+        "--input",
+        input,
+        "--output",
+        output,
+        "--strategy",
+        "identity",
+        "--edits",
+        "0",
+        "--compression-level",
+        "1",
+    ];
+    args.extend_from_slice(extra);
+    args
+}
+
+/// `--no-check-crc` must let group's single-threaded reader accept a corrupted
+/// BGZF CRC32: it decodes through fgumi-bgzf, honoring the flag (#800). Against
+/// the noodles reader this path used before, this could not pass.
+#[test]
+fn test_group_no_check_crc_accepts_corrupted_crc() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    create_multiblock_group_bam(&input_bam);
+    corrupt_last_block_crc(&input_bam);
+
+    let cmd = GroupReadsByUmi::try_parse_from(group_args(
+        input_bam.to_str().unwrap(),
+        output_bam.to_str().unwrap(),
+        &["--no-check-crc"],
+    ))
+    .expect("failed to parse group args");
+    cmd.execute("fgumi group")
+        .expect("--no-check-crc must accept a corrupted BGZF CRC32 and complete");
+    assert!(output_bam.exists(), "Output BAM not created");
+}
+
+/// Default (verify-on for file input) must reject the same corrupted CRC32.
+#[test]
+fn test_group_rejects_corrupted_crc_by_default() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    create_multiblock_group_bam(&input_bam);
+    corrupt_last_block_crc(&input_bam);
+
+    let cmd = GroupReadsByUmi::try_parse_from(group_args(
+        input_bam.to_str().unwrap(),
+        output_bam.to_str().unwrap(),
+        &[],
+    ))
+    .expect("failed to parse group args");
+    let err = cmd
+        .execute("fgumi group")
+        .expect_err("default (verify-on for file input) must reject a corrupted BGZF CRC32");
+    let message = format!("{err:#}");
+    assert!(message.to_uppercase().contains("CRC32"), "error should mention CRC32: {message}");
+}
+
+/// `--check-crc` must also reject the corrupted CRC32 (forces verification on).
+#[test]
+fn test_group_check_crc_rejects_corrupted_crc() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    create_multiblock_group_bam(&input_bam);
+    corrupt_last_block_crc(&input_bam);
+
+    let cmd = GroupReadsByUmi::try_parse_from(group_args(
+        input_bam.to_str().unwrap(),
+        output_bam.to_str().unwrap(),
+        &["--check-crc"],
+    ))
+    .expect("failed to parse group args");
+    let err =
+        cmd.execute("fgumi group").expect_err("--check-crc must reject a corrupted BGZF CRC32");
+    let message = format!("{err:#}");
+    assert!(message.to_uppercase().contains("CRC32"), "error should mention CRC32: {message}");
+}


### PR DESCRIPTION
Part of #800. Stacked on #801 (base branch `800/nhomer/unify-raw-reader-fgumi-bgzf`).

#801 unified the single-threaded *raw* reader (`clip`/`codec`/`duplex`/`simplex`/`downsample`) onto fgumi-bgzf so `--check-crc`/`--no-check-crc` took effect there. This PR closes the two remaining single-threaded gaps `#800` called out: the `correct` and `group` fast paths, which decoded through noodles' always-verify BGZF reader and so silently ignored `--no-check-crc`.

## What changed

- **`fgumi-bam-io`**: new `create_raw_bam_reader_from_stream_with_opts`, which decodes an already-opened, still-compressed BGZF byte stream through `FgumiBgzfReader` (honoring `verify_crc`) and wraps it in a `RawBamReader`. This is the stream `correct`/`group` open once up front (required for stdin, which cannot be re-opened). The header-parse-and-wrap tail is factored into a shared `finish_raw_bam_reader` used by both this and the from-path `create_raw_bam_reader_with_opts`.
- **`correct` / `group`**: single-threaded fast paths now decode via the new factory instead of a hand-rolled `noodles::bam::io::Reader` + header skip, threading `verify_crc` through from `pipeline_reader_opts()`.
- **`common.rs`**: removed `log_effective_check_crc_for_fast_path` — its only purpose was to log that the single-threaded path always verifies, which is no longer true for its only two callers. `correct`/`group` now log the real effective policy. Updated the `--check-crc` help text: honored on every command's input decode in both modes, with the single remaining exception of `clip --threads N`.

## Coverage after this PR

| command | single-threaded | multi-threaded |
| --- | --- | --- |
| `downsample`, `codec`, `simplex`, `duplex` | ✅ | ✅ (input decode is always single-threaded) |
| `correct`, `group` | ✅ (this PR) | ✅ (unified pipeline, #798) |
| `clip` | ✅ | ❌ still verifies (`--threads N` uses noodles' multithreaded reader) |

The remaining `clip --threads N` gap — and the multithreaded raw reader generally — is the last piece of #800 and is tracked as a follow-up.

## Tests

- `fgumi-bam-io`: `test_raw_reader_from_stream_honors_verify_crc` — corrupted CRC32 rejected with verify on, accepted with it off (the case that could not pass against noodles).
- `correct` / `group`: `--no-check-crc` accepts a CRC-corrupted file; default and `--check-crc` reject it — mirroring the existing `downsample` trio.

Full suite green (2552 passed); fmt / clippy / tag-literals / publish-order clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: command output changes—none; `unsafe` changes—none, and `CLAUDE.md` needs no allowlist update; memory bounds, queue capacity, and thread/backpressure policy changes—none.

- Added stream-based BAM reading with configurable `verify_crc`.
- Applied CRC options to single-threaded `correct` and `group` paths.
- Shared header parsing between reader paths.
- Removed obsolete fast-path CRC logging and updated help text.
- Added corrupted-BGZF CRC tests for `correct`, `group`, and `clip --threads N`.
- Full suite passes with 2552 tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->