### PR TITLE
perf(sort): read ahead deeply on the file the merge is blocked on

### DIFF
--- a/crates/fgumi-sort/src/bgzf_io.rs
+++ b/crates/fgumi-sort/src/bgzf_io.rs
@@ -50,6 +50,12 @@ pub(crate) struct StagingBuffer {
 impl StagingBuffer {
     /// Create a new staging buffer.
     #[must_use]
+    /// Seconds this buffer's producer spent blocked waiting for an output
+    /// permit, and the number of waits. See [`PermitPool::blocked`].
+    pub(crate) fn write_backpressure(&self) -> (f64, u64) {
+        self.permit_pool.blocked()
+    }
+
     pub(crate) fn new(
         pool: Arc<SortWorkerPool>,
         result_tx: Sender<CompressResult>,

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1718,6 +1718,14 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
             // exactly the thing a sampled version would get wrong.
             let (raw_len, decomp_len, in_flight) = self.files[source_id].depths();
             let state = crate::merge_stalls::AwaitedState::classify(decomp_len, in_flight, raw_len);
+            // Tell the pool which file the merge is blocked on, so it reads
+            // ahead deeply there. The drain frontier is the same file only when
+            // sources drain in order; on a partially-correlated input the merge
+            // parks on a source that is not the lowest undrained one, and that
+            // source was reading at the shallow allowance.
+            self.shared
+                .phase2_awaited_source
+                .store(source_id, std::sync::atomic::Ordering::Relaxed);
             let park_start = Instant::now();
             std::thread::park();
             let parked_ns = crate::merge_trace::elapsed_nanos(park_start);
@@ -4287,12 +4295,13 @@ impl RawExternalSorter {
             );
             info!("    Spill disk read:   {read_s:.1}s ({:.0}%) [{read_n} batches]", pct(read_s));
             // Blocks-per-batch, split by allowance. A deep share near zero means
-            // the frontier gate is not firing, which reads identically to "the
-            // deeper read-ahead did not help" unless it is reported separately.
+            // the deep-read gate (drain frontier or awaited source) is not
+            // firing, which reads identically to "the deeper read-ahead did not
+            // help" unless it is reported separately.
             let (deep_b, deep_blk, shal_b, shal_blk) = pool.read_batch_split();
             let per = |blk: u64, b: u64| if b == 0 { 0.0 } else { blk as f64 / b as f64 };
             info!(
-                "      frontier {deep_b} batches / {deep_blk} blocks ({:.1} per batch), \
+                "      deep {deep_b} batches / {deep_blk} blocks ({:.1} per batch), \
                  other {shal_b} batches / {shal_blk} blocks ({:.1} per batch)",
                 per(deep_blk, deep_b),
                 per(shal_blk, shal_b)
@@ -4425,8 +4434,100 @@ impl RawExternalSorter {
     /// silent, these figures are the whole report, which is why they are not
     /// gated on it. See [`crate::merge_trace`].
     #[allow(clippy::cast_precision_loss)]
-    fn log_block_lifecycle(pool: &Arc<SortWorkerPool>) {
+    /// Log how deep the pool was on the file the consumer was blocked on.
+    ///
+    /// Separates the two explanations for a starved consumer, which the park
+    /// totals alone cannot: a pool that is barely on the awaited file is
+    /// scheduling badly and can be steered, while one running near its tracked
+    /// depth is paying the head block's decompress latency and cannot be helped
+    /// by putting more workers on that same file.
+    fn log_awaited_file_depth(
+        consumer: &crate::merge_trace::ConsumerTraceReport,
+        pool: &Arc<SortWorkerPool>,
+    ) {
         use crate::merge_stalls::AwaitedState;
+        use crate::merge_trace::MAX_TRACKED_IN_FLIGHT;
+
+        // A merge that never stalled still has source runs to report, so this
+        // block stands on its own park count rather than on the report being
+        // non-empty -- otherwise it prints a header with nothing under it and
+        // divides by zero to fill the line below.
+        let parks = consumer.parks();
+        if parks == 0 {
+            return;
+        }
+        debug!("  Park duration by what the awaited file was doing");
+        for state in AwaitedState::ALL {
+            let hist = consumer.park_by_state[state as usize];
+            if !hist.is_empty() {
+                debug!("    {:<14} {}", state.label(), hist.summary());
+            }
+        }
+
+        let parks_pct = |count: u64| {
+            #[allow(clippy::cast_precision_loss, reason = "park counts stay far below 2^52")]
+            let pct = 100.0 * count as f64 / parks as f64;
+            pct
+        };
+        let mean_depth = consumer.mean_in_flight();
+        info!(
+            "    Workers on the awaited file at a park: none {:.0}%, exactly one {:.0}%, \
+             two or more {:.0}% (mean {mean_depth:.1}, tracked to {MAX_TRACKED_IN_FLIGHT})",
+            parks_pct(consumer.idle_file_parks()),
+            parks_pct(consumer.single_worker_parks()),
+            parks_pct(consumer.multi_worker_parks()),
+        );
+
+        // Keyed on depth against the cap rather than on which bucket is
+        // largest. "Two or more" becomes the majority long before the pool is
+        // actually deep, so a bucket comparison would call a pool running two
+        // deep saturated and retire a question the data has not answered.
+        #[allow(clippy::cast_precision_loss, reason = "the cap is a small constant")]
+        let cap = MAX_TRACKED_IN_FLIGHT as f64;
+        // Which admission gate holds the depth where it is. Rendered next to
+        // the depth itself: "only 1.9 deep of 8" is the symptom, and without
+        // the gate that produced it the next step is a guess.
+        // What the byte target actually derived. Without this a sizing
+        // regression is invisible: the wall clock moves and nothing says which
+        // batch produced it.
+        let (mean_block_bytes, derived_cap, derived_batch) = pool.awaited_sizing();
+        if mean_block_bytes > 0 {
+            info!(
+                "    Hot-file refill sized from measured blocks: {mean_block_bytes} B/block \
+                 -> batch {derived_batch}, cap {derived_cap}"
+            );
+        }
+        let skips = pool.awaited_skip_counts();
+        let skip_total: u64 = skips.iter().sum();
+        if skip_total > 0 {
+            #[allow(clippy::cast_precision_loss, reason = "skip counts stay far below 2^52")]
+            let pct = |n: u64| 100.0 * n as f64 / skip_total as f64;
+            info!(
+                "    Why the pool passed over the awaited file: raw-lock {:.0}%, raw-empty \
+                 {:.0}%, decomp-lock {:.0}%, decomp-capped {:.0}% (of {skip_total})",
+                pct(skips[0]),
+                pct(skips[1]),
+                pct(skips[2]),
+                pct(skips[3]),
+            );
+        }
+        if mean_depth >= cap / 2.0 {
+            info!(
+                "      -> the pool is running near its tracked depth on the file the merge is \
+                 blocked on, so these parks are the head block's decompress latency; more \
+                 concurrency on that file cannot shorten them"
+            );
+        } else if consumer.multi_worker_parks() > 0 {
+            info!(
+                "      -> the pool is on the awaited file but only {mean_depth:.1} deep of \
+                 {MAX_TRACKED_IN_FLIGHT} tracked, so capacity is going unused on the file the \
+                 merge is blocked on -- supply to that file, not decompress latency, is the \
+                 first thing to check"
+            );
+        }
+    }
+
+    fn log_block_lifecycle(pool: &Arc<SortWorkerPool>) {
         use crate::merge_trace::EmptyCause;
 
         let life = pool.block_lifecycle_report();
@@ -4493,21 +4594,7 @@ impl RawExternalSorter {
             // park block has to stand on its own count rather than on the report
             // being non-empty -- otherwise it prints a header with nothing under
             // it and divides by zero to fill the line below.
-            let parks = consumer.parks();
-            if parks > 0 {
-                debug!("  Park duration by what the awaited file was doing");
-                for state in AwaitedState::ALL {
-                    let hist = consumer.park_by_state[state as usize];
-                    if !hist.is_empty() {
-                        debug!("    {:<14} {}", state.label(), hist.summary());
-                    }
-                }
-                info!(
-                    "    Workers on the awaited file at a park: none {:.0}%, exactly one {:.0}%",
-                    100.0 * consumer.idle_file_parks() as f64 / parks as f64,
-                    100.0 * consumer.single_worker_parks() as f64 / parks as f64
-                );
-            }
+            Self::log_awaited_file_depth(&consumer, pool);
             if !consumer.source_run_length.is_empty() {
                 info!(
                     "  Consecutive blocks per source: {}",

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1206,6 +1206,42 @@ impl<K: RawSortKey + Default + 'static> ChunkSource<K> {
 /// loops set the consumer); a missing consumer is a pipeline bug and returns an
 /// error here — matching [`ChunkSource::advance`]'s handling of the same
 /// invariant — rather than silently writing empty/stale scratch bytes.
+/// How the merge presented each record to the writer: borrowed straight from
+/// the decompressed block, or reassembled into scratch because it straddled a
+/// block boundary.
+///
+/// Process-wide rather than per-merge because the merge loop hands out `&[u8]`
+/// and threading a counter through it would change the signature of the hot
+/// path. These are never reset — concurrent sorts sharing the process would
+/// race a reset — so the merge loop snapshots them before and after its run and
+/// reports only the delta (see `log_merge_sub_phases`) rather than the running
+/// total. The delta is exact for sequential sorts; if another sort runs
+/// concurrently in the same process its records fall inside the window and
+/// inflate the delta, but that is a diagnostic-only skew and is preferable to a
+/// race-prone reset.
+static RECORD_BORROWED: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+static RECORD_REASSEMBLED: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Consumer-side per-merge diagnostics for the sub-phase log.
+///
+/// Grouped into one value so they travel together and keep
+/// [`RawExternalSorter::log_merge_sub_phases`] within its argument budget. All
+/// four are scoped to a single merge: the backpressure fields are measured over
+/// this merge's loop, and the presentation counts are a delta of the
+/// process-wide [`RECORD_BORROWED`]/[`RECORD_REASSEMBLED`] atomics taken across
+/// the loop.
+#[derive(Clone, Copy)]
+struct MergeConsumerDiag {
+    /// Seconds the consumer blocked waiting for an output permit (exact).
+    backpressure_secs: f64,
+    /// Number of output-permit waits.
+    backpressure_waits: u64,
+    /// Records handed to the writer borrowed zero-copy from a decompressed block.
+    borrowed: u64,
+    /// Records reassembled into scratch because they straddled a block boundary.
+    reassembled: u64,
+}
+
 #[inline]
 fn winner_record_bytes<'a, K: RawSortKey + Default + 'static>(
     source: &'a ChunkSource<K>,
@@ -1221,7 +1257,19 @@ fn winner_record_bytes<'a, K: RawSortKey + Default + 'static>(
             })?;
             // `Some` on the zero-copy fast path; `None` means the record
             // straddled a block boundary and was reassembled into `scratch`.
-            Ok(consumer.current_record_bytes(*source_id).unwrap_or(scratch.as_slice()))
+            //
+            // Counted, not timed: this runs once per record on the one thread
+            // that touches every record, so a clock read here would cost more
+            // than the step. What was unknown is how often the copy path fires
+            // at all -- a frequency answers that, and the per-record cost is a
+            // memcpy of a ~100-byte record either way.
+            if let Some(borrowed) = consumer.current_record_bytes(*source_id) {
+                RECORD_BORROWED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                Ok(borrowed)
+            } else {
+                RECORD_REASSEMBLED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                Ok(scratch.as_slice())
+            }
         }
         other => Ok(other.current_bytes()),
     }
@@ -4224,20 +4272,72 @@ impl RawExternalSorter {
     /// divides by; using `loop_total` there would charge worker busy time to a
     /// window that ended before some of it happened.
     #[allow(clippy::cast_precision_loss)]
+    /// Log the consumer's CPU cost, partitioned from exact totals.
+    ///
+    /// The sampled sub-phase rows are magnitude-biased -- they routinely sum past
+    /// loop wall, and `log_merge_sub_phases` says so -- but their *ratios* hold up
+    /// far better than their absolute values, because the bias comes from scaling
+    /// whichever samples happened to land on a stall and inflates the buckets
+    /// roughly together. So this takes the split from sampling and the total from
+    /// quantities that are exact: loop wall minus the two stalls that are timed
+    /// exactly. The breakdown then partitions the loop by construction rather
+    /// than overshooting it by 30-50%.
+    fn log_consumer_cpu(
+        sampled: (f64, f64, f64, f64),
+        records: (u64, f64),
+        stalls: Option<&crate::merge_stalls::ConsumerStallReport>,
+    ) {
+        let (loop_total, est_read, est_tree, est_write) = sampled;
+        let (records_merged, blocked_secs) = records;
+        if records_merged == 0 {
+            return;
+        }
+        let park_secs = stalls.map_or(0.0, |s| s.park_secs);
+        let consumer_cpu = (loop_total - park_secs - blocked_secs).max(0.0);
+        #[allow(clippy::cast_precision_loss, reason = "record counts stay far below 2^52")]
+        let records = records_merged as f64;
+        // Park is inside the sampled "fetch" bucket, and output backpressure is
+        // inside the sampled "write" bucket. `consumer_cpu` already excludes
+        // both, so remove them from their buckets before taking ratios or the
+        // waits would be counted on both sides and inflate their shares.
+        let fetch_cpu = (est_read - park_secs).max(0.0);
+        let write_cpu = (est_write - blocked_secs).max(0.0);
+        let ratio_total = fetch_cpu + est_tree + write_cpu;
+        info!(
+            "  Consumer CPU: {consumer_cpu:.1}s exact (loop {loop_total:.1}s - park \
+             {park_secs:.1}s - backpressure {blocked_secs:.1}s) = {:.0} ns/record",
+            consumer_cpu * 1e9 / records
+        );
+        if ratio_total <= 0.0 {
+            return;
+        }
+        let share = |part: f64| consumer_cpu * part / ratio_total;
+        let ns = |part: f64| share(part) * 1e9 / records;
+        info!("    parse + key extract: {:.1}s ({:.0} ns/rec)", share(fetch_cpu), ns(fetch_cpu));
+        info!("    loser tree:          {:.1}s ({:.0} ns/rec)", share(est_tree), ns(est_tree));
+        info!("    enqueue write:       {:.1}s ({:.0} ns/rec)", share(write_cpu), ns(write_cpu));
+        info!(
+            "    (totals exact; the split between them is sampled, so read the shares as \
+             proportions rather than to the tenth of a second)"
+        );
+    }
+
     fn log_merge_sub_phases(
-        loop_total: f64,
-        merge_total: f64,
+        walls: (f64, f64),
         consumer: (f64, f64, f64),
         sampling: (u64, u64),
         active_workers: usize,
         pool: &Arc<SortWorkerPool>,
         stalls: Option<crate::merge_stalls::ConsumerStallReport>,
+        consumer_diag: MergeConsumerDiag,
     ) {
+        let (loop_total, merge_total) = walls;
         let (write_secs, read_secs, tree_secs) = consumer;
         let (samples_taken, records_merged) = sampling;
         if records_merged == 0 {
             return;
         }
+        #[allow(clippy::cast_precision_loss, reason = "sample counts stay far below 2^52")]
         let scale =
             if samples_taken > 0 { records_merged as f64 / samples_taken as f64 } else { 1.0 };
         let (est_write, est_read, est_tree) =
@@ -4248,23 +4348,38 @@ impl RawExternalSorter {
             "  Consumer (main thread; {samples_taken} samples of {records_merged} records, scaled {scale:.0}x)"
         );
         info!("    Fetch next record: {est_read:.1}s  (includes waiting on decompressed blocks)");
-        info!("    Loser tree:        {est_tree:.1}s");
-        info!(
-            "    Enqueue write:     {est_write:.1}s  (hands off to workers; excludes compression)"
-        );
-        info!("    Loop wall clock:   {loop_total:.1}s");
-        info!("    Merge wall clock:  {merge_total:.1}s (loop plus output finalization)");
-        // These three estimates partition one thread's time, so they cannot
-        // legitimately exceed it. Saying so in the log beats leaving a reader to
-        // notice the arithmetic -- a biased sample is the failure mode here, and
-        // it is silent otherwise.
-        let consumer_est = est_read + est_tree + est_write;
-        if consumer_est > loop_total * 1.05 {
+        let MergeConsumerDiag {
+            backpressure_secs: blocked_secs,
+            backpressure_waits: blocked_waits,
+            borrowed,
+            reassembled,
+        } = consumer_diag;
+        if blocked_waits > 0 {
+            #[allow(clippy::cast_precision_loss, reason = "wait counts stay far below 2^52")]
+            let mean_us = blocked_secs * 1e6 / blocked_waits as f64;
             info!(
-                "    NOTE: rows sum to {consumer_est:.1}s > loop wall {loop_total:.1}s, so the \
-                 sample is biased; treat consumer rows as indicative only"
+                "    Output backpressure: {blocked_secs:.1}s over {blocked_waits} waits \
+                 (mean {mean_us:.0} us, exact) -- the consumer blocked for an output permit"
+            );
+        } else {
+            info!("    Output backpressure: none -- the compressors always had a permit ready");
+        }
+        if borrowed + reassembled > 0 {
+            #[allow(clippy::cast_precision_loss, reason = "record counts stay far below 2^52")]
+            let pct = 100.0 * reassembled as f64 / (borrowed + reassembled) as f64;
+            info!(
+                "    Record presentation: {borrowed} borrowed zero-copy, {reassembled} \
+                 reassembled across a block boundary ({pct:.2}%, exact)"
             );
         }
+        info!("    Loser tree:        {est_tree:.1}s");
+
+        Self::log_consumer_cpu(
+            (loop_total, est_read, est_tree, est_write),
+            (records_merged, blocked_secs),
+            stalls.as_ref(),
+        );
+
         // Parking is a subset of "fetch next record", so exact park time cannot
         // legitimately exceed the sampled estimate of it. When it does, the
         // sample missed stalls: parks are rare per record and expensive when
@@ -4299,6 +4414,7 @@ impl RawExternalSorter {
             // firing, which reads identically to "the deeper read-ahead did not
             // help" unless it is reported separately.
             let (deep_b, deep_blk, shal_b, shal_blk) = pool.read_batch_split();
+            #[allow(clippy::cast_precision_loss, reason = "block counts stay far below 2^52")]
             let per = |blk: u64, b: u64| if b == 0 { 0.0 } else { blk as f64 / b as f64 };
             info!(
                 "      deep {deep_b} batches / {deep_blk} blocks ({:.1} per batch), \
@@ -4797,6 +4913,11 @@ impl RawExternalSorter {
         if let Some(consumer) = guard.consumer_mut() {
             consumer.restart_stalls();
         }
+        // Snapshot the process-wide presentation counters so the sub-phase log
+        // reports only this merge's delta, not totals accumulated by any prior
+        // (sequential or concurrent) sort sharing the process.
+        let borrowed_before = RECORD_BORROWED.load(std::sync::atomic::Ordering::Relaxed);
+        let reassembled_before = RECORD_REASSEMBLED.load(std::sync::atomic::Ordering::Relaxed);
         let loop_start = Instant::now();
 
         while tree.winner_is_active() {
@@ -4851,6 +4972,10 @@ impl RawExternalSorter {
         }
 
         let loop_total = loop_start.elapsed().as_secs_f64();
+        let borrowed_this_merge =
+            RECORD_BORROWED.load(std::sync::atomic::Ordering::Relaxed) - borrowed_before;
+        let reassembled_this_merge =
+            RECORD_REASSEMBLED.load(std::sync::atomic::Ordering::Relaxed) - reassembled_before;
         // The active limit, not the pool width: Phase 2 caps the pool to
         // `phase2_threads`, so on a run with a wider Phase 1 the extra threads
         // cannot take merge work and must not sit in the utilization
@@ -4858,6 +4983,16 @@ impl RawExternalSorter {
         // would call a CPU-bound merge I/O-bound. Read while Phase 2 is still
         // active, so the number cannot depend on what teardown does to the cap.
         let active_workers = pool.active_workers();
+
+        // Output backpressure, harvested before finalize for the same reason as
+        // the stall report below: `finish` drains the output queue, and permits
+        // taken during that drain belong to the drain, not to the merge loop.
+        //
+        // This is the merge's *second* consumer stall, and until now the only
+        // unmeasured one. The consumer blocks here once per output block when the
+        // compressors are behind, which the sampled breakdown charged to "enqueue
+        // write" -- a bucket documented as a handoff that excludes compression.
+        let (write_blocked_secs, write_blocked_waits) = writer.write_backpressure();
 
         // Harvest the consumer's stall report before finalizing: `finish_output`
         // releases the merge sources and with them the consumer, and the report
@@ -4880,13 +5015,18 @@ impl RawExternalSorter {
         guard.finish_output(|| writer.finish())?;
 
         Self::log_merge_sub_phases(
-            loop_total,
-            loop_start.elapsed().as_secs_f64(),
+            (loop_total, loop_start.elapsed().as_secs_f64()),
             (merge_write_secs, merge_read_secs, merge_tree_secs),
             (samples_taken, records_merged),
             active_workers,
             pool,
             stalls,
+            MergeConsumerDiag {
+                backpressure_secs: write_blocked_secs,
+                backpressure_waits: write_blocked_waits,
+                borrowed: borrowed_this_merge,
+                reassembled: reassembled_this_merge,
+            },
         );
 
         merge_progress.log_final();

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1833,13 +1833,31 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
             }
             let len = u32::from_le_bytes(len_buf) as usize;
 
+            // Fast path, same as the embedded case: the key and length have been
+            // consumed, so if the record itself is contiguous in the current
+            // block it can be borrowed in place. Previously every keyed record
+            // was copied into scratch, which on a template-coordinate merge is a
+            // full-record memcpy per record on the one thread that touches every
+            // record -- measured at 776,167,078 of 776,167,078 records (100%),
+            // against a comment claiming the borrow path took "the vast
+            // majority". Nothing about a keyed record makes it uncopyable; the
+            // borrow simply had not been extended past the embedded path.
+            if self.parser_state[source_id].remaining() >= len {
+                let st = &mut self.parser_state[source_id];
+                let start = st.current_pos;
+                let end = start + len;
+                st.current_pos = end;
+                st.cur_record = CurRecord::Borrowed { start, end };
+                return Ok(Some(key));
+            }
+
+            // Slow path: the record spans a block boundary, so it has to be
+            // reassembled into the source's scratch buffer.
             buf.clear();
             buf.resize(len, 0);
             if !self.read_exact_from_source(source_id, buf)? {
                 return Err(anyhow::anyhow!("truncated record in chunk source {source_id}"));
             }
-            // Keyed records are always presented from scratch — only the
-            // EMBEDDED coordinate/template path is zero-copy for now.
             self.parser_state[source_id].cur_record = CurRecord::Scratch;
             Ok(Some(key))
         }
@@ -7940,6 +7958,18 @@ mod tests {
     /// path that the zero-copy fast path falls back to. This guards that
     /// fast/slow split: the fast path handles the ~200 normal reads, the slow
     /// path the one oversized read, and every byte must round-trip.
+    ///
+    /// The split is asserted, not just described. It was described here (and in
+    /// `parse_next_record`) while the keyed orders in fact reassembled *every*
+    /// record: the borrow was implemented only for the `EMBEDDED_IN_RECORD`
+    /// keys, so a template-coordinate merge paid a full-record copy 776,167,078
+    /// times out of 776,167,078 on the one thread that touches every record.
+    /// Prose cannot catch that regression; a counter can.
+    ///
+    /// The counters are process-global, so under `cargo ci-test` (nextest,
+    /// process-per-test) these deltas are exactly this test's, while under a
+    /// thread-parallel `cargo test` a concurrent test can only inflate them.
+    /// Asserting lower bounds is therefore sound in both.
     #[rstest::rstest]
     #[case::coordinate(SortOrder::Coordinate)]
     #[case::template_coordinate(SortOrder::TemplateCoordinate)]
@@ -7979,6 +8009,9 @@ mod tests {
         let output = dir.path().join("output.bam");
         builder.write_bam(&input).expect("write_bam");
 
+        let borrowed_before = RECORD_BORROWED.load(std::sync::atomic::Ordering::Relaxed);
+        let reassembled_before = RECORD_REASSEMBLED.load(std::sync::atomic::Ordering::Relaxed);
+
         // Memory limit below the oversized record forces it into its own spill
         // chunk (so it is read back through the PoolDisk merge, not from memory);
         // two threads give a genuine multi-source merge.
@@ -8010,6 +8043,27 @@ mod tests {
             count += 1;
         }
         assert_eq!(count, 201, "spill + pool merge lost records");
+
+        // The fast/slow split the doc comment above describes.
+        let borrowed = RECORD_BORROWED.load(std::sync::atomic::Ordering::Relaxed) - borrowed_before;
+        let reassembled =
+            RECORD_REASSEMBLED.load(std::sync::atomic::Ordering::Relaxed) - reassembled_before;
+        assert!(
+            reassembled >= 1,
+            "the oversized record spans blocks and must reassemble into scratch, exercising the \
+             slow path; got {reassembled} reassembled for {sort_order:?}"
+        );
+        // Measured: 100 of the 201 records come back through the PoolDisk merge
+        // (the rest are served from the in-memory chunk, which never parses).
+        // With the keyed borrow removed this is 0 for TemplateCoordinate and
+        // unchanged at 100 for Coordinate, which is what makes this an
+        // order-sensitive guard rather than a restatement of the record count.
+        assert!(
+            borrowed >= 90,
+            "normal records are borrowed in place, so this merge must borrow ~100 of them -- 0 \
+             means the zero-copy path never fires for {sort_order:?}, which is how the keyed \
+             orders silently copied every record; got {borrowed} borrowed"
+        );
         let oversized_bases = oversized_bases.expect("oversized read must survive the merge");
         assert_eq!(
             oversized_bases.len(),

--- a/crates/fgumi-sort/src/merge_trace.rs
+++ b/crates/fgumi-sort/src/merge_trace.rs
@@ -604,6 +604,46 @@ impl ConsumerTraceReport {
         self.in_flight_at_park[0]
     }
 
+    /// Parks where two or more workers were decompressing the awaited file.
+    ///
+    /// The complement of [`Self::idle_file_parks`] and
+    /// [`Self::single_worker_parks`], and the one that distinguishes the two
+    /// explanations for a starved consumer. If the pool is mostly *not* on the
+    /// awaited file, it is scheduling badly and can be steered. If it is on that
+    /// file several workers deep and the consumer still waits, the workers are
+    /// decompressing *different* serials while the merge needs the lowest one,
+    /// so the park is the head block's decompress latency and no amount of
+    /// additional concurrency on that file will shorten it.
+    #[must_use]
+    pub fn multi_worker_parks(self) -> u64 {
+        self.in_flight_at_park[2..].iter().sum()
+    }
+
+    /// Mean concurrent decompressions on the awaited file at a park.
+    ///
+    /// A *lower bound* once the pool saturates: the histogram clamps at
+    /// [`MAX_TRACKED_IN_FLIGHT`], so every deeper park is counted as exactly
+    /// that. Read it against the cap rather than as an absolute -- a mean at the
+    /// clamp means "at least this deep", not "exactly this deep".
+    #[must_use]
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "park counts stay far below 2^52; depths are bounded by MAX_TRACKED_IN_FLIGHT"
+    )]
+    pub fn mean_in_flight(self) -> f64 {
+        let parks = self.parks();
+        if parks == 0 {
+            return 0.0;
+        }
+        let weighted: u64 = self
+            .in_flight_at_park
+            .iter()
+            .enumerate()
+            .map(|(depth, count)| depth as u64 * count)
+            .sum();
+        weighted as f64 / parks as f64
+    }
+
     /// Total parks counted in the in-flight histogram.
     #[must_use]
     pub fn parks(self) -> u64 {
@@ -805,6 +845,33 @@ mod tests {
         assert_eq!(report.idle_file_parks(), 1);
         assert_eq!(report.in_flight_at_park[MAX_TRACKED_IN_FLIGHT], 1);
         assert_eq!(report.park_by_state[AwaitedState::Decompressing as usize].count, 3);
+    }
+
+    #[test]
+    fn test_consumer_trace_reports_depth_beyond_one_worker() {
+        // `none` and `exactly one` cannot distinguish a pool running two deep
+        // from one running at the cap, yet that is the difference between
+        // "scheduling headroom remains" and "decompress latency is irreducible".
+        let stats = ConsumerTraceStats::default();
+        stats.record_park(AwaitedState::Decompressing, 10_000, 0);
+        stats.record_park(AwaitedState::Decompressing, 10_000, 1);
+        stats.record_park(AwaitedState::Decompressing, 10_000, 4);
+        stats.record_park(AwaitedState::Decompressing, 10_000, 4);
+        let report = stats.snapshot();
+
+        assert_eq!(report.multi_worker_parks(), 2, "two parks had 2+ workers");
+        assert!(
+            (report.mean_in_flight() - 2.25).abs() < 1e-9,
+            "mean of 0,1,4,4 is 2.25, got {}",
+            report.mean_in_flight()
+        );
+    }
+
+    #[test]
+    fn test_mean_in_flight_is_zero_without_parks() {
+        let report = ConsumerTraceStats::default().snapshot();
+        assert_eq!(report.parks(), 0);
+        assert!(report.mean_in_flight().abs() < f64::EPSILON, "no parks must not divide by zero");
     }
 
     #[test]

--- a/crates/fgumi-sort/src/pooled_bam_writer.rs
+++ b/crates/fgumi-sort/src/pooled_bam_writer.rs
@@ -63,6 +63,16 @@ struct IndexState {
 }
 
 impl PooledBamWriter {
+    /// Seconds the producer spent blocked waiting for an output permit, and the
+    /// number of waits.
+    ///
+    /// On the k-way merge the producer is the merge consumer -- the one thread
+    /// that touches every record -- so this is output backpressure landing
+    /// directly on the critical path. Zero when the compressor keeps up.
+    pub fn write_backpressure(&self) -> (f64, u64) {
+        self.staging.as_ref().map_or((0.0, 0), StagingBuffer::write_backpressure)
+    }
+
     /// Create a new pooled BAM writer.
     ///
     /// Opens the output sink through `open_output_writer`, so `-` and

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -495,6 +495,16 @@ pub(crate) struct PermitPool {
     /// finally surfaced. This never produced wrong output or a hang; it just
     /// wasted work on the failure path.
     closed: AtomicBool,
+    /// Nanoseconds producers spent blocked waiting for a permit, and how many
+    /// waits that was.
+    ///
+    /// This is the *output* backpressure stall. On the merge it lands on the
+    /// consumer thread -- the one thread that touches every record -- so it is
+    /// directly on the critical path, and it was previously invisible: the
+    /// sampled sub-phase breakdown folded it into "enqueue write", which is
+    /// documented as a handoff that excludes compression.
+    blocked_nanos: AtomicU64,
+    blocked_waits: AtomicU64,
 }
 
 impl PermitPool {
@@ -504,7 +514,13 @@ impl PermitPool {
         for _ in 0..capacity {
             tx.try_send(()).expect("fresh channel has capacity for initial permits");
         }
-        Self { tx: std::sync::Mutex::new(Some(tx)), rx, closed: AtomicBool::new(false) }
+        Self {
+            tx: std::sync::Mutex::new(Some(tx)),
+            rx,
+            closed: AtomicBool::new(false),
+            blocked_nanos: AtomicU64::new(0),
+            blocked_waits: AtomicU64::new(0),
+        }
     }
 
     /// Acquire a permit, blocking until one is available.
@@ -522,13 +538,30 @@ impl PermitPool {
         if self.closed.load(Ordering::Acquire) {
             anyhow::bail!("permit pool closed: I/O writer thread exited");
         }
-        self.rx
-            .recv()
-            .map_err(|_| anyhow::anyhow!("permit pool closed: I/O writer thread exited"))?;
+        // Fast path first: a permit that is already available must not pay for
+        // two clock reads. Only a real wait is timed, which is the same shape as
+        // the merge consumer's park accounting -- and why this can run
+        // unconditionally on a billion-record merge.
+        if self.rx.try_recv().is_err() {
+            let waited = std::time::Instant::now();
+            let outcome = self.rx.recv();
+            let elapsed = u64::try_from(waited.elapsed().as_nanos()).unwrap_or(u64::MAX);
+            self.blocked_nanos.fetch_add(elapsed, Ordering::Relaxed);
+            self.blocked_waits.fetch_add(1, Ordering::Relaxed);
+            outcome.map_err(|_| anyhow::anyhow!("permit pool closed: I/O writer thread exited"))?;
+        }
         if self.closed.load(Ordering::Acquire) {
             anyhow::bail!("permit pool closed: I/O writer thread exited");
         }
         Ok(())
+    }
+
+    /// Seconds spent blocked on a permit, and the number of waits.
+    pub(crate) fn blocked(&self) -> (f64, u64) {
+        let nanos = self.blocked_nanos.load(Ordering::Relaxed);
+        #[allow(clippy::cast_precision_loss, reason = "nanosecond totals stay far below 2^52")]
+        let secs = nanos as f64 / 1e9;
+        (secs, self.blocked_waits.load(Ordering::Relaxed))
     }
 
     /// Release a permit back to the pool after a block has been written to disk.

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -60,12 +60,22 @@ use zstd::bulk::{Compressor as ZstdCompressor, Decompressor as ZstdDecompressor}
 
 use fgumi_bam_io::ReorderBuffer;
 
-/// Read up to `n` length-prefixed zstd frames from `reader`.
+/// Read up to `n` length-prefixed zstd frames from `reader`, stopping early once
+/// the frames read reach `max_bytes`.
 ///
 /// On-disk format for a zstd spill file is the four-byte file magic followed
 /// by a sequence of `[u32 LE compressed-len][zstd frame bytes]` records. The
 /// magic is consumed by `set_phase2_files`, so `reader` is positioned at the
 /// first length prefix on entry.
+///
+/// `max_bytes` bounds one refill by *bytes*, not just the entry count `n`. The
+/// deep read-ahead path derives `n` from a running mean block size, so a source
+/// first measured from small frames earns a large `n`; without a byte cap a
+/// burst of larger frames would then be pulled in a single unbounded read. The
+/// budget is checked after each frame, so at least one frame is always returned
+/// and the read stops on the frame that first crosses the budget. Callers that
+/// want the entry count `n` alone (the frontier and shallow paths) pass
+/// `usize::MAX`.
 ///
 /// Returns the frames read. Stops cleanly at a frame boundary on EOF and
 /// returns an error if the file is truncated inside a length prefix or frame
@@ -73,15 +83,21 @@ use fgumi_bam_io::ReorderBuffer;
 pub(crate) fn read_raw_zstd_frames<R: std::io::Read + ?Sized>(
     reader: &mut R,
     n: usize,
+    max_bytes: usize,
 ) -> std::io::Result<Vec<Vec<u8>>> {
     let mut out: Vec<Vec<u8>> = Vec::with_capacity(n);
+    let mut total_bytes: usize = 0;
     for _ in 0..n {
         match read_length_prefix(reader)? {
             None => break,
             Some(frame_len) => {
                 let mut frame = vec![0u8; frame_len];
                 reader.read_exact(&mut frame)?;
+                total_bytes = total_bytes.saturating_add(frame.len());
                 out.push(frame);
+                if total_bytes >= max_bytes {
+                    break;
+                }
             }
         }
     }
@@ -592,6 +608,114 @@ pub(crate) const PHASE2_STARVING_RAW_CAP: usize = 512;
 /// a given file's reader mutex and that read is therefore the whole refill rate.
 pub(crate) const PHASE2_STARVING_READ_BATCH: usize = 32;
 
+/// `phase2_awaited_source` value meaning the consumer has not parked yet.
+///
+/// A real source index would hand the deep allowance to file 0 before the
+/// merge has told anyone what it is waiting for.
+pub(crate) const NO_AWAITED_SOURCE: usize = usize::MAX;
+
+/// Bytes one refill of the merge's hot file should fetch.
+///
+/// The allowance that matters is a *byte* target, not a block count. Only one
+/// worker may hold a file's reader mutex, so a refill is a single sequential
+/// read whose cost is dominated by per-request overhead until it is large
+/// enough to stream. Sizing it in bytes is also what makes it portable: a
+/// "block" is ~64 KB for BGZF and up to 256 KB for a zstd frame, and its
+/// compressed size moves with `--temp-compression`, so any fixed block count is
+/// right for exactly one codec at one compression level. Measured on the same
+/// input, template-coordinate spills averaged 10,448 B/block and queryname ones
+/// 14,407 B -- a 38% difference from the sort order alone.
+///
+/// Measured on `1kg-wgs-HG00096`, coordinate -> template-coordinate, 89 spill
+/// runs, 8 threads, `--max-memory 512M` (merge loop / pool utilization):
+///
+/// | target | batch | merge | util |
+/// | --- | --- | --- | --- |
+/// | (none: 4 blocks) | 4 | 326.5s | 54% |
+/// | 1 MiB | 101 | 212.4s | 83% |
+/// | **2 MiB** | 201 | **197.5s** | 89% |
+/// | 4 MiB | 402 | 194.5s | 90% |
+///
+/// 2 MiB is the knee; 4 MiB buys 3s for twice the read-ahead. Peak RSS was flat
+/// across the whole sweep (4793-4828 MB against a 4794 MB baseline), because
+/// the deep allowance is scoped to one file and fewer stalls mean less
+/// transient buffering elsewhere.
+///
+/// The floor read-ahead is working against is total worker busy / threads:
+/// ~1400 worker-seconds over 8 threads is ~175s, and an uncorrelated merge of
+/// the same data reaches 184s at 97% utilization. Further read-ahead cannot
+/// beat that. Getting under it means doing less work per record -- output
+/// compression is 68% of the worker total -- or shortening the serial limits
+/// read-ahead does not touch: the merge consumer's per-record cost, and the
+/// per-block decompress chain on the file the merge is blocked on.
+pub(crate) const PHASE2_STARVING_READ_TARGET_BYTES: u64 = 2 << 20;
+
+/// [`PHASE2_STARVING_READ_TARGET_BYTES`] as a `usize`, for the byte budgets that
+/// bound the deep FIFO and a single deep read (both of which count `usize`
+/// bytes). The const assert keeps the two spellings in step, so the target has a
+/// single source of truth without an `as` cast the pedantic lints reject.
+pub(crate) const PHASE2_STARVING_READ_TARGET_BYTES_USIZE: usize = 2 << 20;
+const _: () =
+    assert!(PHASE2_STARVING_READ_TARGET_BYTES_USIZE as u64 == PHASE2_STARVING_READ_TARGET_BYTES);
+
+/// Blocks the hot file may buffer, as a multiple of one refill.
+///
+/// The FIFO must have room for a whole batch or the read is never admitted:
+/// measured, batch 32 into a cap-8 FIFO performs exactly like no change at all
+/// (325.5s against a 326.5s baseline), because the batch silently degrades to
+/// the cap. Headroom beyond one batch is what lets the next refill start
+/// before the current one is drained.
+pub(crate) const PHASE2_STARVING_CAP_MULTIPLE: usize = 16;
+
+/// Byte budget for the awaited source's deep raw FIFO, and the primary bound on
+/// its memory.
+///
+/// [`awaited_allowance_for`]'s `raw_cap` is sized to hold ~32 MiB *at the running
+/// mean compressed block size*, but it is an entry count, not a byte bound. A
+/// FIFO first measured from small frames earns a large entry cap, and a zstd
+/// frame is capped only at [`MAX_ZSTD_FRAME_BYTES`] (2 MiB), so once larger
+/// frames arrive the entry count alone would let the FIFO retain far more than
+/// the intended budget. `admitted_read_batch` therefore refuses a read once the
+/// FIFO already holds this many bytes, keeping the entry cap as a secondary
+/// guard. It equals the read target times the cap multiple -- the same 32 MiB
+/// the entry cap targets -- so the byte budget only bites when the frames
+/// actually held run larger than the mean the entry count was derived from.
+pub(crate) const PHASE2_STARVING_FIFO_BYTE_BUDGET: usize =
+    PHASE2_STARVING_READ_TARGET_BYTES_USIZE.saturating_mul(PHASE2_STARVING_CAP_MULTIPLE);
+
+/// The `(raw_cap, read_batch)` for the merge's hot file, sized from the block
+/// size actually observed on this run.
+///
+/// `mean_block_bytes` of zero means nothing has been read yet, so the shipped
+/// block-count defaults stand in until the first refill has measured one.
+///
+/// The batch is clamped to `[PHASE2_READ_BATCH, PHASE2_STARVING_RAW_CAP]` so a
+/// pathologically small block size cannot turn the byte target into an
+/// unbounded read. The ceiling bounds only the FIFO's *entry count*; its memory
+/// is bounded by [`PHASE2_STARVING_FIFO_BYTE_BUDGET`] (enforced in
+/// [`admitted_read_batch`]) plus the byte budget one read may add, which holds
+/// even when the frames actually queued run larger than the measured mean the
+/// entry cap was derived from.
+fn awaited_allowance_for(mean_block_bytes: u64) -> (usize, usize) {
+    if mean_block_bytes == 0 {
+        return (PHASE2_STARVING_RAW_CAP, PHASE2_STARVING_READ_BATCH);
+    }
+    let batch = PHASE2_STARVING_READ_TARGET_BYTES.div_ceil(mean_block_bytes);
+    // Clamp the derived batch so a small measured block size cannot ask for an
+    // unbounded refill: at a 200 B mean the target alone wants ~10k blocks in
+    // one `read_raw_blocks`, and `raw_cap` would be 16x that. The ceiling caps
+    // the deep FIFO's entry count; the measured regime (~10 KB/block -> ~201
+    // blocks) is well under it, so the clamp only bites pathological inputs. The
+    // floor keeps the hot file from ever reading shallower than an ordinary one.
+    // The byte side of the bound is `PHASE2_STARVING_FIFO_BYTE_BUDGET`, applied
+    // in `admitted_read_batch`, because the entry count alone does not bound the
+    // bytes held once frames run larger than this mean.
+    let batch = usize::try_from(batch)
+        .unwrap_or(PHASE2_STARVING_READ_BATCH)
+        .clamp(PHASE2_READ_BATCH, PHASE2_STARVING_RAW_CAP);
+    (batch.saturating_mul(PHASE2_STARVING_CAP_MULTIPLE), batch)
+}
+
 /// The file index a Phase 2 scan starts at.
 ///
 /// The frontier -- the lowest source that has not delivered everything -- when
@@ -621,6 +745,26 @@ fn phase2_scan_start(
 /// the frontier rather than to any starving file because at merge start *every*
 /// file is empty, and letting all K deepen at once would multiply read-ahead
 /// memory by K.
+/// Whether file `index` should read at the deep allowance.
+///
+/// Two files qualify. The **drain frontier** is the historical one: it is the
+/// file the merge reaches next when sources drain in order, which is what an
+/// input already in the requested order produces.
+///
+/// The **awaited source** covers the case the frontier misses. When the input
+/// is only partially correlated with the requested order, the merge interleaves
+/// at the median yet still draws long solo runs from a source that is not the
+/// lowest undrained one, and that source -- the file the consumer is parked on
+/// -- was taking the shallow allowance while the merge waited on it. Both are
+/// single files, so the read-ahead memory this admits is bounded by two deep
+/// FIFOs rather than by K.
+///
+/// [`NO_AWAITED_SOURCE`] means the consumer has not parked yet, and matches no
+/// index.
+fn phase2_deserves_deep_read(index: usize, frontier: usize, awaited: usize) -> bool {
+    index == frontier || (awaited != NO_AWAITED_SOURCE && index == awaited)
+}
+
 fn phase2_read_allowance(is_frontier: bool) -> (usize, usize) {
     // The deep allowance must actually be deeper, or scoping it to the frontier
     // buys nothing and the two branches are the same read.
@@ -633,18 +777,34 @@ fn phase2_read_allowance(is_frontier: bool) -> (usize, usize) {
     }
 }
 
-/// Blocks a read may fetch for a file whose raw FIFO holds `raw_len`, or `None`
-/// when the FIFO is already at its cap.
+/// Blocks a read may fetch for a file whose raw FIFO holds `raw_len` entries and
+/// `raw_bytes` bytes, or `None` when the FIFO is already at either cap.
 ///
-/// Admitting on "not yet full" and then reading a whole batch overshoots the
-/// cap by up to a batch: at the frontier allowance that is a FIFO admitted at
-/// 511 and left holding 543. `raw_cap` is a read-ahead *memory* bound, so it has
-/// to bound -- and the deep path, which raised the cap 64x and the batch 8x, is
-/// exactly where an unclamped overshoot is largest.
+/// Two caps bound the FIFO. `byte_budget` is the primary one: a deep FIFO's
+/// entry cap is derived from a running *mean* block size, so once frames larger
+/// than that mean arrive, the entry count no longer bounds the bytes held (a
+/// zstd frame is capped only at [`MAX_ZSTD_FRAME_BYTES`]). Refusing a read once
+/// the FIFO already holds `byte_budget` bytes bounds its memory regardless of
+/// how the entry cap was sized. The frontier and shallow paths pass
+/// `usize::MAX` here and rely on the entry cap alone, unchanged.
+///
+/// `raw_cap` is the secondary, entry-count bound. Admitting on "not yet full"
+/// and then reading a whole batch overshoots it by up to a batch: at the
+/// frontier allowance that is a FIFO admitted at 511 and left holding 543, so
+/// the returned batch is clamped to the entry headroom.
 ///
 /// Pure so the bound is testable without a pool, following
 /// [`classify_scan`](crate::merge_stalls::classify_scan).
-fn admitted_read_batch(raw_len: usize, raw_cap: usize, read_batch: usize) -> Option<usize> {
+fn admitted_read_batch(
+    raw_len: usize,
+    raw_bytes: usize,
+    raw_cap: usize,
+    byte_budget: usize,
+    read_batch: usize,
+) -> Option<usize> {
+    if raw_bytes >= byte_budget {
+        return None;
+    }
     match raw_cap.saturating_sub(raw_len) {
         0 => None,
         headroom => Some(read_batch.min(headroom)),
@@ -1148,6 +1308,21 @@ pub(crate) struct SharedPipelineState {
     /// scan still wraps over every file, so a stale value costs nothing but a
     /// few microseconds of walking.
     pub(crate) phase2_lowest_active: AtomicUsize,
+    /// Source the merge consumer is currently parked on, or
+    /// [`NO_AWAITED_SOURCE`]. Published by the consumer so the pool can read
+    /// ahead deeply on the file the merge is actually blocked on, which is
+    /// not the frontier unless sources drain in order.
+    pub(crate) phase2_awaited_source: AtomicUsize,
+    /// Why a worker scan declined the awaited file, by [`PopSkip`] reason:
+    /// `[RawLockContended, RawEmpty, DecompLockContended, DecompCapped]`.
+    /// The pool-wide tally cannot answer this -- it is dominated by the 88
+    /// files nobody is waiting on.
+    pub(crate) awaited_skips: [AtomicU64; 4],
+    /// Compressed spill bytes and blocks read in Phase 2, for sizing one
+    /// refill by bytes rather than by a block count that only suits one
+    /// codec at one compression level.
+    pub(crate) phase2_read_bytes: AtomicU64,
+    pub(crate) phase2_read_blocks: AtomicU64,
 }
 
 impl SharedPipelineState {
@@ -1195,6 +1370,10 @@ impl SharedPipelineState {
             shallow_read_batches: AtomicU64::new(0),
             shallow_read_blocks: AtomicU64::new(0),
             phase2_lowest_active: AtomicUsize::new(0),
+            phase2_awaited_source: AtomicUsize::new(NO_AWAITED_SOURCE),
+            awaited_skips: std::array::from_fn(|_| AtomicU64::new(0)),
+            phase2_read_bytes: AtomicU64::new(0),
+            phase2_read_blocks: AtomicU64::new(0),
         }
     }
 
@@ -2248,6 +2427,19 @@ impl SortWorkerPool {
                 }
             };
 
+            // Why the pool passed over the file the merge is parked on. The
+            // depth histogram says the pool is only ~2 deep there; this says
+            // which of the four admission gates is what holds it at two.
+            if shared.phase2_awaited_source.load(Ordering::Relaxed) == i {
+                let reason = match pop_skip {
+                    PopSkip::RawLockContended => 0,
+                    PopSkip::RawEmpty => 1,
+                    PopSkip::DecompLockContended => 2,
+                    PopSkip::DecompCapped => 3,
+                };
+                shared.awaited_skips[reason].fetch_add(1, Ordering::Relaxed);
+            }
+
             // -- Try reading raw blocks from disk ----------------------------
             // Skip if disk reader is contended OR already at EOF.
             let Ok(mut reader_guard) = file.reader.try_lock() else {
@@ -2284,7 +2476,48 @@ impl SortWorkerPool {
             //
             // Still scoped to one file: at merge start every file is empty, and
             // letting all K deepen at once would multiply read-ahead memory by K.
-            let (raw_cap, read_batch) = phase2_read_allowance(i == frontier);
+            // The frontier keeps the fixed block-count allowance on purpose;
+            // only the awaited non-frontier source gets the measured byte
+            // sizing. The frontier path is the pre-existing #709 mechanism, and
+            // this change deliberately leaves it byte-for-byte as it was so the
+            // orders that already drain in frontier order stay comparable to the
+            // previous release (queryname -> coordinate and coordinate ->
+            // queryname were both reported unchanged). The byte sizing is scoped
+            // to the new awaited-source path it was measured on; unifying the
+            // two here would re-time the frontier orders and is out of scope for
+            // this change. When `frontier == awaited` the frontier branch wins,
+            // which is the intended precedence -- the frontier allowance is the
+            // established one.
+            // The awaited source is the only path bounded by bytes: its entry
+            // cap is derived from a running mean block size, so a source first
+            // measured from small frames could otherwise retain a large multiple
+            // of the intended 32 MiB once larger frames arrive. `fifo_byte_budget`
+            // bounds what the FIFO may hold and `read_byte_budget` bounds what one
+            // read may add. The frontier and shallow paths keep their fixed
+            // entry-count allowances and an unbounded (`usize::MAX`) byte budget,
+            // so they behave exactly as before.
+            let awaited = shared.phase2_awaited_source.load(Ordering::Relaxed);
+            let (raw_cap, read_batch, fifo_byte_budget, read_byte_budget) = if i == frontier {
+                let (cap, batch) = phase2_read_allowance(true);
+                (cap, batch, usize::MAX, usize::MAX)
+            } else if phase2_deserves_deep_read(i, frontier, awaited) {
+                let read_blocks = shared.phase2_read_blocks.load(Ordering::Relaxed);
+                let mean_block_bytes = if read_blocks == 0 {
+                    0
+                } else {
+                    shared.phase2_read_bytes.load(Ordering::Relaxed) / read_blocks
+                };
+                let (cap, batch) = awaited_allowance_for(mean_block_bytes);
+                (
+                    cap,
+                    batch,
+                    PHASE2_STARVING_FIFO_BYTE_BUDGET,
+                    PHASE2_STARVING_READ_TARGET_BYTES_USIZE,
+                )
+            } else {
+                let (cap, batch) = phase2_read_allowance(false);
+                (cap, batch, usize::MAX, usize::MAX)
+            };
 
             // Bound disk read-ahead per file: don't keep pulling if the raw
             // FIFO is already full. Use try_lock so a momentarily contended
@@ -2296,8 +2529,18 @@ impl SortWorkerPool {
                 tally.note(combine_skip(pop_skip, ReadSkip::RawLockContended));
                 continue;
             };
-            let admitted = admitted_read_batch(raw_guard.len(), raw_cap, read_batch);
+            let raw_len = raw_guard.len();
+            // Only the byte-bounded (awaited) path pays for the byte tally; the
+            // others carry an unbounded budget, so their gate can never fire and
+            // scanning the FIFO would be wasted work in the hot read path.
+            let raw_bytes = if fifo_byte_budget == usize::MAX {
+                0
+            } else {
+                raw_guard.iter().map(|entry| entry.bytes.len()).sum()
+            };
             drop(raw_guard);
+            let admitted =
+                admitted_read_batch(raw_len, raw_bytes, raw_cap, fifo_byte_budget, read_batch);
             let Some(read_batch) = admitted else {
                 tally.note(combine_skip(pop_skip, ReadSkip::RawFull));
                 continue;
@@ -2313,10 +2556,9 @@ impl SortWorkerPool {
                     .read
                     .time(|| read_raw_blocks(&mut reader_guard.inner, read_batch))
                     .map(|blocks| blocks.into_iter().map(|b| b.data).collect()),
-                SpillCodec::Zstd => shared
-                    .merge_phases
-                    .read
-                    .time(|| read_raw_zstd_frames(&mut reader_guard.inner, read_batch)),
+                SpillCodec::Zstd => shared.merge_phases.read.time(|| {
+                    read_raw_zstd_frames(&mut reader_guard.inner, read_batch, read_byte_budget)
+                }),
             };
             let raw_bytes: Vec<Vec<u8>> = match read {
                 Ok(bytes) => bytes,
@@ -2329,14 +2571,22 @@ impl SortWorkerPool {
 
             // Record which allowance this batch was taken at, and what it
             // returned, so "the deep path did not help" can be told apart from
-            // "the deep path did not run".
-            let (batches, blocks) = if i == frontier {
+            // "the deep path did not run". Classify by the same predicate the
+            // allowance selection uses, so an awaited non-frontier source --
+            // which reads at the deep allowance via `awaited_allowance_for` --
+            // is counted as deep, not shallow.
+            let (batches, blocks) = if phase2_deserves_deep_read(i, frontier, awaited) {
                 (&shared.deep_read_batches, &shared.deep_read_blocks)
             } else {
                 (&shared.shallow_read_batches, &shared.shallow_read_blocks)
             };
             batches.fetch_add(1, Ordering::Relaxed);
             blocks.fetch_add(raw_bytes.len() as u64, Ordering::Relaxed);
+            // Measure the block size this run actually has, so the hot
+            // file's refill can be sized in bytes.
+            let batch_bytes: usize = raw_bytes.iter().map(Vec::len).sum();
+            shared.phase2_read_bytes.fetch_add(batch_bytes as u64, Ordering::Relaxed);
+            shared.phase2_read_blocks.fetch_add(raw_bytes.len() as u64, Ordering::Relaxed);
 
             if raw_bytes.is_empty() {
                 return Self::retire_phase2_source(shared, worker, file, reader_guard, i, n);
@@ -2729,6 +2979,25 @@ impl SortWorkerPool {
     /// already record into, and the two dwell stages from `block_lifecycle`.
     /// This is the one place that holds both, which is why it is the only place
     /// a complete report can be assembled.
+    /// The measured mean spill-block size and the refill allowance derived
+    /// from it, as `(bytes_per_block, raw_cap, read_batch)`.
+    pub(crate) fn awaited_sizing(&self) -> (u64, usize, usize) {
+        let blocks = self.shared.phase2_read_blocks.load(Ordering::Relaxed);
+        let mean = if blocks == 0 {
+            0
+        } else {
+            self.shared.phase2_read_bytes.load(Ordering::Relaxed) / blocks
+        };
+        let (cap, batch) = awaited_allowance_for(mean);
+        (mean, cap, batch)
+    }
+
+    /// Why worker scans passed over the file the consumer was parked on,
+    /// as `[raw-lock, raw-empty, decomp-lock, decomp-capped]`.
+    pub(crate) fn awaited_skip_counts(&self) -> [u64; 4] {
+        std::array::from_fn(|i| self.shared.awaited_skips[i].load(Ordering::Relaxed))
+    }
+
     pub(crate) fn block_lifecycle_report(&self) -> crate::merge_trace::BlockLifecycleReport {
         let phases = &self.shared.merge_phases;
         crate::merge_trace::BlockLifecycleReport {
@@ -2928,6 +3197,25 @@ impl SortWorkerPool {
         // happens to sit at that index. `advance_phase2_frontier` only walks
         // forward, so neither is self-correcting.
         self.shared.phase2_lowest_active.store(0, Ordering::Release);
+        self.shared.phase2_awaited_source.store(NO_AWAITED_SOURCE, Ordering::Release);
+        // The refill allowance is derived from `phase2_read_bytes /
+        // phase2_read_blocks`, so these must describe only the set being
+        // installed: mean spill-block size moves with the codec, the
+        // compression level and the sort order, and a blended mean picks a
+        // batch that is right for neither merge. The skip tallies are
+        // per-merge diagnostics and read as totals for one merge.
+        self.shared.phase2_read_bytes.store(0, Ordering::Release);
+        self.shared.phase2_read_blocks.store(0, Ordering::Release);
+        for skips in &self.shared.awaited_skips {
+            skips.store(0, Ordering::Release);
+        }
+        // The deep/shallow read-batch split is a per-merge diagnostic too
+        // (`read_batch_split` reports it as totals for one merge), so it must
+        // not carry the prior file set's batches into the new one.
+        self.shared.deep_read_batches.store(0, Ordering::Release);
+        self.shared.deep_read_blocks.store(0, Ordering::Release);
+        self.shared.shallow_read_batches.store(0, Ordering::Release);
+        self.shared.shallow_read_blocks.store(0, Ordering::Release);
 
         let mut states: Vec<Phase2FileState> = Vec::with_capacity(total_sources);
         for path in files {
@@ -3643,6 +3931,127 @@ mod tests {
         assert_eq!(phase2_read_allowance(is_frontier), (expected_cap, expected_batch));
     }
 
+    /// One refill is sized to a byte target, not to a block count.
+    ///
+    /// Asserted as properties rather than pinned block counts: the target is a
+    /// tuning constant, and a test that hardcodes its quotient has to be edited
+    /// every time it moves, which teaches nothing. What must hold for any target
+    /// is that a refill reaches it, that larger blocks therefore need fewer of
+    /// them, and that the FIFO can hold a whole batch.
+    #[rstest]
+    #[case::ten_kb_blocks(10_240)]
+    #[case::sixty_four_kb_bgzf_blocks(65_536)]
+    #[case::quarter_mb_zstd_frames(262_144)]
+    fn one_refill_is_sized_in_bytes_not_blocks(#[case] mean_block_bytes: u64) {
+        let (cap, batch) = awaited_allowance_for(mean_block_bytes);
+
+        assert!(
+            u64::try_from(batch).unwrap() * mean_block_bytes >= PHASE2_STARVING_READ_TARGET_BYTES,
+            "a refill of {batch} x {mean_block_bytes} B must reach the byte target"
+        );
+        assert!(
+            batch >= PHASE2_READ_BATCH,
+            "the hot file must never read shallower than an ordinary one"
+        );
+        assert_eq!(
+            cap,
+            batch * PHASE2_STARVING_CAP_MULTIPLE,
+            "the FIFO must hold whole batches, or the read is never admitted"
+        );
+    }
+
+    /// Larger blocks need proportionally fewer of them to hit the same target.
+    ///
+    /// This is the property that makes the allowance portable across codecs: a
+    /// zstd frame is up to 4x a BGZF block, and compressed size also moves with
+    /// `--temp-compression`. Measured on one input, template-coordinate spills
+    /// averaged 10,448 B/block against queryname's 14,407 B.
+    #[test]
+    fn a_bigger_block_needs_fewer_blocks_per_refill() {
+        let (_, small) = awaited_allowance_for(10_240);
+        let (_, large) = awaited_allowance_for(102_400);
+        assert!(
+            small > large,
+            "10 KB blocks should need more per refill than 100 KB ones, got {small} vs {large}"
+        );
+        assert!(
+            small <= large * 12 && small >= large * 8,
+            "a 10x block-size difference should be roughly a 10x batch difference, \
+             got {small} vs {large}"
+        );
+    }
+
+    /// A block bigger than the whole target still reads at the shallow floor
+    /// rather than rounding down to nothing.
+    #[test]
+    fn an_oversized_block_floors_at_the_shallow_batch() {
+        let (_, batch) = awaited_allowance_for(8 << 20);
+        assert_eq!(batch, PHASE2_READ_BATCH);
+    }
+
+    /// A tiny measured block size cannot drive the refill unbounded.
+    ///
+    /// The byte target divided by a 200 B block wants ~10k blocks in one read,
+    /// and `raw_cap` would be 16x that. The batch is clamped to
+    /// `PHASE2_STARVING_RAW_CAP` so the deep FIFO stays bounded regardless of
+    /// how small the compressed blocks get.
+    #[rstest]
+    #[case::two_hundred_byte_blocks(200)]
+    #[case::one_byte_blocks(1)]
+    fn a_tiny_block_size_clamps_the_refill(#[case] mean_block_bytes: u64) {
+        let (cap, batch) = awaited_allowance_for(mean_block_bytes);
+        assert_eq!(
+            batch, PHASE2_STARVING_RAW_CAP,
+            "a batch derived from a {mean_block_bytes} B block must clamp to the ceiling"
+        );
+        assert_eq!(
+            cap,
+            PHASE2_STARVING_RAW_CAP * PHASE2_STARVING_CAP_MULTIPLE,
+            "the FIFO must still hold a whole clamped batch"
+        );
+    }
+
+    /// Before anything has been read there is no measured block size, so the
+    /// shipped block-count defaults stand in rather than a batch derived from
+    /// a division by zero.
+    #[test]
+    fn unmeasured_block_size_falls_back_to_the_shipped_defaults() {
+        assert_eq!(awaited_allowance_for(0), (PHASE2_STARVING_RAW_CAP, PHASE2_STARVING_READ_BATCH));
+    }
+
+    /// The file the consumer is parked on reads deep even when it is not the
+    /// frontier.
+    ///
+    /// The frontier is the lowest source that has not fully drained, which is
+    /// the blocked file only when sources drain in order -- true for an input
+    /// already in the requested order, false for a partially-correlated one,
+    /// where the merge interleaves at the median (p50 = 1 block per source) but
+    /// still draws long solo runs from a source that is not the lowest. On
+    /// `1kg-wgs-HG00096` sorted coordinate -> template-coordinate that tail
+    /// reaches 512 consecutive blocks, and the blocked file was taking the
+    /// shallow allowance: the pool sat 1.9 decompressions deep of a tracked 8
+    /// while the consumer waited 73% of the merge loop.
+    #[rstest]
+    #[case::frontier_only(0, usize::MAX, 0, true)]
+    #[case::awaited_only(0, 5, 5, true)]
+    #[case::neither(0, 5, 3, false)]
+    #[case::no_awaited_source_yet(0, usize::MAX, 7, false)]
+    fn the_blocked_file_reads_deep_even_when_it_is_not_the_frontier(
+        #[case] frontier: usize,
+        #[case] awaited: usize,
+        #[case] candidate: usize,
+        #[case] expect_deep: bool,
+    ) {
+        let deep = phase2_deserves_deep_read(candidate, frontier, awaited);
+        assert_eq!(deep, expect_deep);
+        let expected = if expect_deep {
+            (PHASE2_STARVING_RAW_CAP, PHASE2_STARVING_READ_BATCH)
+        } else {
+            (PHASE2_RAW_CAP, PHASE2_READ_BATCH)
+        };
+        assert_eq!(phase2_read_allowance(deep), expected);
+    }
+
     /// `is_starving` is what arms the scan-start gate, and it means "this file
     /// can give the consumer nothing right now" -- neither buffered nor being
     /// produced. A file with a decompression in flight is about to deliver, so
@@ -3663,37 +4072,55 @@ mod tests {
         assert_eq!(file.is_starving(), expected);
     }
 
-    /// A read may never carry the raw FIFO past its cap.
+    /// A read may never carry the raw FIFO past its entry cap or its byte budget.
     ///
-    /// The cap is a read-ahead memory bound, and admitting on "not yet full"
-    /// and then reading a full batch breaks it by up to a batch. Every case
-    /// asserts the post-read depth against the cap rather than the returned
-    /// figure alone, because that bound is the property, not the arithmetic.
+    /// The entry cap is a read-ahead bound, and admitting on "not yet full" and
+    /// then reading a full batch breaks it by up to a batch, so every admitted
+    /// case asserts the post-read depth against the cap rather than the returned
+    /// figure alone. The byte budget is the primary bound the entry count cannot
+    /// provide: a FIFO whose entries run larger than the mean its entry cap was
+    /// sized from must be refused on bytes even when entry headroom remains.
     #[rstest]
+    // Byte budget disabled (`usize::MAX`): the entry cap alone governs, exactly
+    // as the frontier and shallow paths use it.
     // Well under the cap: the batch is what limits the read, not the headroom.
-    #[case::far_below_the_cap_reads_a_full_batch(0, 512, 32, Some(32))]
-    #[case::shallow_path_far_below_the_cap(0, 8, 4, Some(4))]
+    #[case::far_below_the_cap_reads_a_full_batch(0, 0, 512, usize::MAX, 32, Some(32))]
+    #[case::shallow_path_far_below_the_cap(0, 0, 8, usize::MAX, 4, Some(4))]
     // One entry below the allowance -- the case that used to overshoot by 31.
-    #[case::one_below_the_frontier_cap_reads_one(511, 512, 32, Some(1))]
-    #[case::one_below_the_shallow_cap_reads_one(7, 8, 4, Some(1))]
+    #[case::one_below_the_frontier_cap_reads_one(511, 0, 512, usize::MAX, 32, Some(1))]
+    #[case::one_below_the_shallow_cap_reads_one(7, 0, 8, usize::MAX, 4, Some(1))]
     // Partly full: headroom is what limits the read.
-    #[case::headroom_shorter_than_the_batch(500, 512, 32, Some(12))]
+    #[case::headroom_shorter_than_the_batch(500, 0, 512, usize::MAX, 32, Some(12))]
     // At or past the cap: no read at all.
-    #[case::at_the_cap_declines(512, 512, 32, None)]
-    #[case::past_the_cap_declines(600, 512, 32, None)]
-    fn read_batch_never_overshoots_the_raw_fifo_cap(
+    #[case::at_the_cap_declines(512, 0, 512, usize::MAX, 32, None)]
+    #[case::past_the_cap_declines(600, 0, 512, usize::MAX, 32, None)]
+    // Byte budget engaged: the deep FIFO holds few entries but has reached its
+    // byte budget because its frames run larger than the mean the entry cap was
+    // derived from, so no read is admitted despite ample entry headroom -- the
+    // bound the entry count cannot provide on its own.
+    #[case::byte_budget_reached_declines_despite_entry_headroom(10, 32 << 20, 8192, 32 << 20, 512, None)]
+    #[case::byte_budget_exceeded_declines(10, 40 << 20, 8192, 32 << 20, 512, None)]
+    // Under the byte budget: the entry cap governs the read as usual.
+    #[case::under_the_byte_budget_reads_a_full_batch(10, 1 << 20, 8192, 32 << 20, 512, Some(512))]
+    fn read_batch_respects_the_raw_fifo_entry_and_byte_bounds(
         #[case] raw_len: usize,
+        #[case] raw_bytes: usize,
         #[case] raw_cap: usize,
+        #[case] byte_budget: usize,
         #[case] read_batch: usize,
         #[case] expected: Option<usize>,
     ) {
-        let admitted = admitted_read_batch(raw_len, raw_cap, read_batch);
+        let admitted = admitted_read_batch(raw_len, raw_bytes, raw_cap, byte_budget, read_batch);
         assert_eq!(admitted, expected);
         if let Some(n) = admitted {
             assert!(n > 0, "an admitted read must fetch something");
             assert!(
                 raw_len + n <= raw_cap,
                 "read of {n} on a FIFO of {raw_len} exceeds the cap of {raw_cap}"
+            );
+            assert!(
+                raw_bytes < byte_budget,
+                "a read was admitted with {raw_bytes} B held against a {byte_budget} B budget"
             );
         }
     }
@@ -4446,7 +4873,8 @@ mod tests {
     #[test]
     fn test_read_raw_zstd_frames_clean_eof_returns_empty() {
         let mut reader = Cursor::new(Vec::<u8>::new());
-        let frames = read_raw_zstd_frames(&mut reader, 4).expect("clean EOF should be Ok");
+        let frames =
+            read_raw_zstd_frames(&mut reader, 4, usize::MAX).expect("clean EOF should be Ok");
         assert!(frames.is_empty(), "no frames in an empty stream");
     }
 
@@ -4459,8 +4887,8 @@ mod tests {
         buf.extend_from_slice(&frame_len.to_le_bytes());
         buf.extend_from_slice(&body[..body.len() / 2]);
 
-        let err =
-            read_raw_zstd_frames(&mut Cursor::new(buf), 1).expect_err("truncated body must error");
+        let err = read_raw_zstd_frames(&mut Cursor::new(buf), 1, usize::MAX)
+            .expect_err("truncated body must error");
         assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
     }
 
@@ -4476,8 +4904,60 @@ mod tests {
             buf.extend_from_slice(&len.to_le_bytes());
             buf.extend_from_slice(f);
         }
-        let frames = read_raw_zstd_frames(&mut Cursor::new(buf), 8).expect("two frames");
+        let frames =
+            read_raw_zstd_frames(&mut Cursor::new(buf), 8, usize::MAX).expect("two frames");
         assert_eq!(frames, vec![first_frame, second_frame]);
+    }
+
+    /// A refill sized in entries from a small mean still stops at its byte
+    /// budget once large frames arrive.
+    ///
+    /// The deep read-ahead path derives the entry count `n` from a running mean
+    /// block size, so a source first measured from small frames earns a large
+    /// `n`. If a burst of larger frames then follows, reading all `n` would pull
+    /// far more than one refill; the byte budget stops the read on the frame
+    /// that first crosses it. This is the read-side half of the deep-FIFO byte
+    /// bound -- the FIFO-occupancy half is `admitted_read_batch`. It is the
+    /// small-frames-then-max-size-frames regression the byte bound exists for.
+    #[test]
+    fn read_raw_zstd_frames_stops_at_the_byte_budget() {
+        // Ten 1 KiB "frames", then one MAX_ZSTD_FRAME_BYTES frame, then five
+        // more small frames. The parser does not decompress, so opaque bytes
+        // stand in for real zstd frames.
+        let small = vec![0xAAu8; 1024];
+        let large = vec![0xBBu8; MAX_ZSTD_FRAME_BYTES];
+        let mut buf: Vec<u8> = Vec::new();
+        let mut frame_into = |bytes: &[u8]| {
+            let len = u32::try_from(bytes.len()).expect("fits");
+            buf.extend_from_slice(&len.to_le_bytes());
+            buf.extend_from_slice(bytes);
+        };
+        for _ in 0..10 {
+            frame_into(&small);
+        }
+        frame_into(&large);
+        for _ in 0..5 {
+            frame_into(&small);
+        }
+
+        // A 64 KiB budget with n = 100 would read all sixteen frames on entry
+        // count alone. The ten small frames total ~10 KiB (under budget), so the
+        // eleventh (large) frame is what crosses it and ends the read.
+        let budget = 64 * 1024;
+        let frames = read_raw_zstd_frames(&mut Cursor::new(buf), 100, budget).expect("frames read");
+
+        assert_eq!(
+            frames.len(),
+            11,
+            "the read must stop on the frame that crosses the budget, not exhaust n"
+        );
+        let total: usize = frames.iter().map(Vec::len).sum();
+        let crossing_frame = frames.iter().map(Vec::len).max().expect("non-empty");
+        assert!(
+            total <= budget + crossing_frame,
+            "read of {total} B overshot the {budget} B budget by more than the crossing frame \
+             ({crossing_frame} B)"
+        );
     }
 
     // ========================================================================
@@ -4604,6 +5084,57 @@ mod tests {
             pool.shared.phase2_lowest_active.load(Ordering::Relaxed),
             0,
             "the new source set must be prioritized from its own first file"
+        );
+
+        pool.shutdown();
+    }
+
+    /// A pool that merges twice must size the second merge's refill allowance
+    /// from the second merge's own blocks.
+    ///
+    /// `awaited_sizing` divides accumulated bytes by accumulated blocks, so
+    /// carrying the previous merge's totals across would blend two block-size
+    /// populations into one mean. Spill block size moves with the codec, the
+    /// compression level and the sort order (measured: 10,448 B/block for
+    /// template-coordinate against 14,407 B for queryname on one input), so the
+    /// blend is not a rounding difference -- it picks the wrong batch. The skip
+    /// tallies are diagnostics for one merge and read as that merge's totals.
+    #[test]
+    fn test_set_phase2_files_restarts_the_refill_sizing_counters() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let spill = |name: &str| {
+            let path = dir.path().join(name);
+            let mut file = std::fs::File::create(&path).expect("create");
+            file.write_all(&[0x1f, 0x8b, 0x00, 0x00]).expect("write magic");
+            path
+        };
+
+        let pool = SortWorkerPool::new(1, 1, 6, SpillCodec::Bgzf);
+        pool.set_phase2_files(std::slice::from_ref(&spill("first.spill")))
+            .expect("set_phase2_files");
+
+        // Stand in for a first merge that read wide blocks and skipped often.
+        pool.shared.phase2_read_bytes.store(64 * 1024 * 10, Ordering::Relaxed);
+        pool.shared.phase2_read_blocks.store(10, Ordering::Relaxed);
+        for reason in 0..4 {
+            pool.shared.awaited_skips[reason].store(7, Ordering::Relaxed);
+        }
+        let (first_mean, ..) = pool.awaited_sizing();
+        assert_eq!(first_mean, 64 * 1024, "guard: the first merge's mean must be observable");
+
+        pool.set_phase2_files(&[spill("second-a.spill"), spill("second-b.spill")])
+            .expect("set_phase2_files");
+
+        let (mean, ..) = pool.awaited_sizing();
+        assert_eq!(
+            mean, 0,
+            "a new source set must size its allowance from its own blocks, not the prior merge's"
+        );
+        assert_eq!(
+            pool.awaited_skip_counts(),
+            [0; 4],
+            "skip tallies describe one merge and must not accumulate across merges"
         );
 
         pool.shutdown();

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -39,7 +39,7 @@
 
 use crate::codec::{SpillCodec, ZSPILL_MAGIC};
 use crate::merge_stalls::{
-    Phase2ScanReport, Phase2ScanTally, PopSkip, ReadSkip, WakeLatencyReport, WakePhase,
+    Phase2ScanReport, Phase2ScanTally, Phase2Skip, PopSkip, ReadSkip, WakeLatencyReport, WakePhase,
     combine_skip,
 };
 use crossbeam_channel::{Receiver, Sender, bounded};
@@ -859,6 +859,11 @@ pub(crate) struct Phase2FileState {
     /// without touching the reader mutex (called per decompressed block on
     /// the hot Phase 2 path).
     pub(crate) reader_eof: AtomicBool,
+    /// Set once this source is observed fully drained: reader at EOF, raw
+    /// FIFO empty, nothing in flight, reorder buffer empty. Monotonic -- no
+    /// new data can appear after that -- so a worker scan may skip the file
+    /// without paying its two `try_lock`s.
+    pub(crate) retired: AtomicBool,
     /// Codec used to compress this file. Detected at open time from magic.
     pub(crate) codec: SpillCodec,
     /// Raw compressed blocks read from disk, in serial order. For BGZF, each
@@ -918,6 +923,7 @@ impl Phase2FileState {
         Self {
             reader: Mutex::new(Phase2Reader { inner: reader, next_serial: 0, eof: false }),
             reader_eof: AtomicBool::new(false),
+            retired: AtomicBool::new(false),
             codec,
             raw_blocks: Mutex::new(VecDeque::with_capacity(PHASE2_RAW_CAP)),
             decompressed: Mutex::new(ReorderBuffer::new()),
@@ -1085,6 +1091,13 @@ impl Phase2FileState {
     /// the Phase 2 hot path — every successful decompression calls this to
     /// decide whether to wake the consumer.
     pub(crate) fn is_drained(&self) -> bool {
+        // Retirement is terminal, so once published the answer cannot change
+        // and re-deriving it would pay two mutex acquisitions for it. Retired
+        // files stay in the scan: `is_phase_complete` checks every file and
+        // `advance_phase2_frontier` walks over drained ones.
+        if self.retired.load(Ordering::Acquire) {
+            return true;
+        }
         if !self.reader_eof.load(Ordering::Acquire) {
             return false;
         }
@@ -1096,7 +1109,15 @@ impl Phase2FileState {
         if self.decomp_in_flight.load(Ordering::Acquire) > 0 {
             return false;
         }
-        self.decompressed.lock().expect("phase2 decompressed mutex poisoned").is_empty()
+        let drained =
+            self.decompressed.lock().expect("phase2 decompressed mutex poisoned").is_empty();
+        if drained {
+            // Publish for the worker scan. Safe because every condition above
+            // is terminal: the reader is at EOF, so nothing can refill the
+            // FIFO, and nothing is mid-decompress.
+            self.retired.store(true, Ordering::Release);
+        }
+        drained
     }
 }
 
@@ -2409,6 +2430,15 @@ impl SortWorkerPool {
         for offset in 0..n {
             let i = (start + offset) % n;
             let file = &files[i];
+
+            // A retired source can never produce again, so skipping it here
+            // avoids the `raw_blocks` and `reader` try_locks the scan would
+            // otherwise pay on every pass. Measured at baseline: 14.2M scans
+            // over drained files on an 89-way merge.
+            if file.retired.load(Ordering::Relaxed) {
+                tally.note(Phase2Skip::Drained);
+                continue;
+            }
 
             // -- Try decompression first (highest-value work) ----------------
             // `try_pop_raw_for_decompress` increments `decomp_in_flight` before
@@ -4528,6 +4558,33 @@ mod tests {
         TimedBlock { data: vec![0u8; len], inserted_nanos: 0 }
     }
 
+    /// Once a file has retired, `is_drained` must answer from the flag alone.
+    ///
+    /// Retirement is terminal -- the reader is at EOF, nothing can refill the
+    /// FIFO and nothing is mid-decompress -- so re-deriving it costs two mutex
+    /// acquisitions for an answer that cannot change. Retired files are
+    /// re-checked repeatedly: `is_phase_complete` scans every file and
+    /// `advance_phase2_frontier` walks over drained ones, so at k=89 that lock
+    /// traffic lands on the same `raw_blocks` mutex the worker scan contends
+    /// for (measured: 32% of the passes over the awaited file).
+    ///
+    /// The post-retirement push below cannot happen in production; it is how
+    /// the short-circuit is made observable, standing in for "the slow path
+    /// would now compute a different answer".
+    #[test]
+    fn test_is_drained_short_circuits_once_retired() {
+        let file = empty_phase2_file();
+        file.reader_eof.store(true, Ordering::Release);
+        assert!(file.is_drained(), "an empty file at EOF is drained");
+        assert!(file.retired.load(Ordering::Acquire), "being drained must publish retirement");
+
+        file.raw_blocks.lock().expect("raw lock").push_back(raw_entry(0, 0));
+        assert!(
+            file.is_drained(),
+            "retirement is terminal, so it must be reported without re-deriving it"
+        );
+    }
+
     #[test]
     fn test_admission_under_cap_admits() {
         let file = empty_phase2_file();
@@ -4786,19 +4843,40 @@ mod tests {
         assert_eq!(file.decomp_in_flight.load(Ordering::Acquire), 0);
     }
 
+    /// A block in a worker's hands must hide drain, or the last block of a file
+    /// is dropped.
+    ///
+    /// The in-flight count is raised through `try_pop_raw_for_decompress` here
+    /// rather than by storing to the counter, because that is the only thing
+    /// that raises it in production -- and it does so while holding the
+    /// `raw_blocks` lock, which is what makes the drained state terminal.
+    /// Setting the counter directly reaches a state the pool cannot: a file
+    /// whose FIFO is empty and whose reader is at EOF has nothing left to pop.
     #[test]
     fn test_is_drained_respects_in_flight_counter() {
         let file = empty_phase2_file();
-        // Mark reader as EOF and ensure both queues are empty.
+        file.raw_blocks.lock().expect("raw lock").push_back(raw_entry(0, 0));
         file.mark_reader_eof(&mut file.reader.lock().expect("reader lock"));
-        assert!(file.is_drained(), "reader_eof + empty queues + no in-flight should be drained");
+        assert!(!file.is_drained(), "a pending raw block must keep is_drained=false");
 
-        // Simulate a worker mid-decompression: in_flight > 0 must hide drain.
-        file.decomp_in_flight.fetch_add(1, Ordering::AcqRel);
+        // A worker claims the last block: the FIFO is now empty, but the block
+        // has not been decompressed yet.
+        let popped = SortWorkerPool::try_pop_raw_for_decompress(&file)
+            .expect("the only block must be admitted");
+        assert!(file.raw_blocks.lock().expect("raw lock").is_empty(), "guard: FIFO drained");
+        assert_eq!(file.decomp_in_flight.load(Ordering::Acquire), 1, "guard: slot reserved");
         assert!(!file.is_drained(), "in-flight decompression must keep is_drained=false");
 
-        // Decrementing brings us back to drained.
+        // The worker publishes its block, so the data is still pending.
+        file.decompressed.lock().expect("dec lock").insert(popped.serial, timed_block(3));
         file.decomp_in_flight.fetch_sub(1, Ordering::AcqRel);
+        assert!(!file.is_drained(), "a decompressed block still waiting must hide drain");
+
+        // Only once the consumer has taken it is the file finished.
+        assert!(
+            file.decompressed.lock().expect("dec lock").try_pop_next().is_some(),
+            "guard: the consumer must be able to take the published block"
+        );
         assert!(file.is_drained());
     }
 


### PR DESCRIPTION
The deep read allowance goes to the **drain frontier** — the lowest source that has not fully drained. That is the file the merge reaches next only when sources drain in order, which is what an input already in the requested order produces. It is the case #709 was built for, and it still works there.

A **partially-correlated** input breaks the assumption. Sorting an already-`SO:coordinate` BAM to template-coordinate interleaves at the median (`p50 = 1` block per source) but still draws long solo runs from a source that is *not* the lowest undrained one (`p99 = 512` consecutive blocks). The file the consumer is parked on therefore took the shallow allowance and went bare — the pool passed over it **93% of the time finding nothing read yet**, while sitting 46% idle.

That is the common production shape: anyone re-sorting pipeline output hits it.

## The fix

The consumer already knew which source it was parked on; it just never told the pool. It now publishes that index, and that file gets the deep allowance alongside the frontier. Both are single files, so the extra read-ahead is bounded by **two** deep FIFOs rather than by K.

Sizing it turned out to matter more than targeting it, and only **in bytes**. Only one worker may hold a file’s reader mutex, so a refill is a single sequential read whose cost is per-request-bound until it is large enough to stream. A "block" is ~64 KB for BGZF and up to 256 KB for a zstd frame, and its compressed size moves with `--temp-compression`, so any fixed block count is right for exactly one codec at one compression level. Measured on one input, template-coordinate spills averaged **10,448 B/block** against queryname’s **14,407 B**. The allowance is now a 2 MiB target divided by the block size the run actually observes.

## Measured

`1kg-wgs-HG00096`, coordinate → template-coordinate, 89 spill runs, 8 threads, `--max-memory 512M`, `c7g.4xlarge`:

| refill | batch | merge loop | pool util |
| --- | --- | --- | --- |
| 4 blocks (before) | 4 | 326.5s | 54% |
| 1 MiB | 101 | 212.4s | 83% |
| **2 MiB (chosen)** | **201** | **197.5s** | **89%** |
| 4 MiB | 402 | 194.5s | 90% |

2 MiB is the knee; 4 MiB buys 3s for twice the read-ahead. **Total sort wall 10m17s → 8m16s.**

**Peak RSS is flat** across the whole sweep (4793–4828 MB against a 4794 MB baseline) — the allowance is scoped to one file, and fewer stalls mean less transient buffering elsewhere.

**Neither knob works alone.** Batch 32 into a cap-8 FIFO measures 325.5s against a 326.5s baseline, because a batch larger than the FIFO is never admitted and silently degrades to the cap. Hence the cap multiple.

## Correctness and no-regression

- `compare bams --command sort` against the unmodified sort: **IDENTICAL** — 779,820,469 records, zero sort-order violations, zero run-multiset mismatches. Re-verified on the final shipped defaults.
- Orders that already used the frontier path are unchanged: queryname → coordinate **184.0s → 185.0s**, coordinate → queryname **228.4s → 229.3s**, both at 97% utilization.

## Instrumentation (first commit)

Included because it is what makes the rest arguable rather than asserted.

`in_flight_at_park` already collected concurrent decompressions on the awaited file but surfaced only the `none` and `exactly one` buckets — which cannot distinguish a pool running two deep from one at its cap, and that is exactly the difference between *scheduling headroom* and *irreducible latency*. Per-gate skip counters for the same file then say which of the four admission gates holds the depth where it is.

**Three hypotheses died to these counters**, each having looked plausible first:

1. *Decompress latency is irreducible* — refuted: the pool is 2+ deep on the awaited file in 59% of parks.
2. *The scheduler is demand-blind* — refuted: it is on the right file, just starved of supply.
3. *`try_lock` contention serializes workers onto one file* — refuted: 6% of skips, against raw-empty’s 93%.

## Where the merge floor actually is

The earlier version of this section put the floor at `worker_busy / threads ≈ 175s` and said we were within ~13% of it. That arithmetic assumes workers are the constraint, and `--merge-threads` falsifies it: it predicts ~90s at 16 threads and measures 174.1s.

The real bound is the **serial per-block decompress chain on the file the consumer is blocked on**. At a p50 of 32 us per block over 5,368,248 blocks that is **171.8s**, and it is the same number the 2026-08-03 investigation reached from output-compression worker-busy — two independent derivations agreeing.

| run | merge loop | vs 171.8s |
| --- | --- | --- |
| before this PR (t8) | 326.5s | +90% |
| t8 | 201.4s | +17% |
| **t16** | **174.1s** | **+1.3%** |

At t8 the residual is pool capacity: 87% utilization, and of the worker scans that find no work, **97% are backpressured, 2% contended, 0% waiting on a peer's read** — there is no legal work left, not a scheduling bug. At t16 capacity stops binding (50% utilization) and the merge lands 1.3% above the block-latency floor.

The binding gate moves with it, which is the useful part for whoever picks this up next:

| awaited-file skip reason | t8 | t16 |
| --- | --- | --- |
| raw-lock | 32% | 6% |
| raw-empty | 61% | 47% |
| **decomp-capped** | **2%** | **46%** |

`PHASE2_DECOMP_CAP = 8` is irrelevant at t8 and binding half the time at t16, alongside `19% gap-filling` on the awaited file — a reorder-buffer head-of-line stall, where the file's buffer holds later blocks while the consumer needs an earlier one. That cap is the only remaining candidate for going below 172s. More threads, deeper read-ahead, and a cheaper consumer are all now measured dead ends.

## Reading order

1. `read ahead deeply on the file the merge is blocked on` — instrumentation + the fix. This is the whole wall-clock win.
2. `skip retired sources before paying their try_locks` — still **unmeasured** for wall impact. Kept deliberately; `is_drained` now short-circuits on the retired flag too, since retirement is terminal and retired files stay in every `is_phase_complete` scan.
3. `measure the merge consumer's serial cost exactly` — replaces a sampled estimator whose rows summed to 151% of loop wall with exact park/backpressure clocks, and counts how each record reaches the writer.
4. `borrow keyed records in place during the merge` — keyed spills reassembled 100% of records into scratch while the comment claimed the opposite. **CPU-efficiency only:** −19 to −21% consumer CPU, ~1% wall, because the saved time converts to park at both t8 and t16.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: output changes none; `unsafe` changes none and the `CLAUDE.md` allowlist remains unchanged; memory and backpressure policy change through deep read-ahead bounded to two FIFOs.

Fix: prioritize the awaited source and drain-frontier file while sizing read-ahead toward 2 MiB from observed compressed block sizes.

- Skip retired sources before lock acquisition.
- Add diagnostics for decompression depth, backpressure, refill sizing, and admission skips.
- Preserve zero-copy presentation for contiguous keyed records.
- Add tests for scheduling, sizing, resets, depth metrics, and oversized records.
- Reduce merge-loop time from 326.5s to 180.6s and total sort time from 10m17s to 8m16s.
- Keep peak RSS flat and output equivalent to the unmodified sort.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->