### PR TITLE
test(codec): assert the bases the codec_template consensus tests are named for

### DIFF
--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -4050,12 +4050,11 @@ mod tests {
     /// Both reads are cut from the same shared reference bases, so the alignment geometry is
     /// the only variable between them.
     ///
-    /// The tests below assert consensus *lengths* rather than consensus *bases*, because
-    /// [`create_fr_pair`] stores the reverse read's `SEQ` in read orientation where a BAM
-    /// stores it in reference orientation — so its two strands point opposite ways and the
-    /// consensus comes out mostly `N` for every family the fixture builds, not just these.
-    /// Tracked as fulcrumgenomics/fgumi#763; the length is what this fix is about, and it is
-    /// unaffected.
+    /// With the reverse read stored in reference orientation (fulcrumgenomics/fgumi#763, fixed
+    /// by #768), a family with no strand disagreement consenses to the reference sequence over
+    /// the region the two strands share — so the tests below assert the consensus *bases*, not
+    /// merely its length. Positions only one strand covers — the soft-clip read-through edges —
+    /// resolve to `N`.
     fn codec_template(
         pos_start: usize,
         pos_cigar: &[(Kind, usize)],
@@ -4140,6 +4139,14 @@ mod tests {
             128,
             "the reverse read gives up two bases to the overlap clip, leaving both strands 128"
         );
+        // The consensus is the reference sequence the two strands share: `REF_BASES[200..326]`
+        // for the 126 positions both align, bracketed by the soft-clip read-through edge. A
+        // mis-placed clip would shift these bases while leaving the length intact.
+        assert_eq!(
+            &consensus[0].bases[..],
+            b"ANTAACTTTTTGATAGTAGCGGGAGTAGGAGTAAATCTTGTACTAATTAGTGAATATTCTGTTGATGGTGGCTGAAAATTTATAGCTACACAACCAAAAAAATAAAAAACGTTAGTCAATAGCATTTA",
+            "the consensus must be the reference sequence the two strands share",
+        );
     }
 
     /// The duplex overlap is measured over the region both strands align, so a threshold
@@ -4207,6 +4214,14 @@ mod tests {
             consensus[0].bases.len(),
             127,
             "both strands keep 127 bases after the overlap clip, so the consensus is 127 long"
+        );
+        // The consensus is the reference sequence the two strands share, with the terminal
+        // deletion skipped; the lone `N` is the single-strand edge past the reverse read's
+        // close. A mis-placed clip would shift these bases while leaving the length intact.
+        assert_eq!(
+            &consensus[0].bases[..],
+            b"ANTAACTTTTTGATAGTAGCGGGAGTAGGAGTAAATCTTGTACTAATTAGTGAATATTCTGTTGATGGTGGCTGAAAATTTATAGCTACACAACCAAAAAAATAAAAAACGTTAGTCAATAGCATNA",
+            "the consensus must be the reference sequence the two strands share",
         );
     }
 


### PR DESCRIPTION
Closes #807.

## What

Two CODEC tests added with #767 assert only the consensus **length**, under a `codec_template` doc comment that still claimed the bases were unusable and pointed at #763. #768 (the fix for #763) stores the reverse CODEC read in reference orientation, so `codec_template` families now consense to the reference sequence over the region the two strands share — not the mostly-`N` output the `create_fr_pair` orientation bug used to produce. This makes those tests assert the bases they are named for, and corrects the stale doc.

## Changes

- `test_dovetailed_starts_without_an_indel_call_a_consensus` — now asserts the 128 emitted consensus bases (was length-only).
- `test_terminal_indel_outside_the_shared_region_calls_a_consensus` — now asserts the 127 emitted consensus bases (was length-only).
- Corrected the `codec_template` doc comment (removed the false "consensus comes out mostly `N` … Tracked as #763" rationale).

The two sibling `codec_template` tests are appropriate as-is: `test_min_duplex_length_is_measured_over_the_shared_region` is a threshold test and `test_indel_inside_the_shared_region_is_still_rejected` rejects (no bases to assert).

## Verification

Each new expected literal was verified byte-for-byte against `REF_BASES`, not merely captured from the code:

- **dovetail** (128): the body after the 2-base soft-clip edge equals `REF_BASES[200..326]` exactly (0 non-`N` mismatches, 0 `N`s in the body).
- **terminal-indel** (127): the body equals the reference over the shared span with the terminal deletion skipped (0 non-`N` mismatches); the lone `N` is the single-strand edge past the reverse read's close.

Test-only; no production change. `cargo nextest run -p fgumi-consensus` (1267 passed), `cargo fmt --check`, and `cargo clippy -p fgumi-consensus --all-targets` all clean.
