### PR TITLE
perf(sort): measure where the merge consumer's park time actually goes

### DIFF
--- a/crates/fgumi-sort/src/bgzf_io.rs
+++ b/crates/fgumi-sort/src/bgzf_io.rs
@@ -48,29 +48,25 @@ pub(crate) struct StagingBuffer {
 }
 
 impl StagingBuffer {
-    /// Create a new staging buffer.
-    #[must_use]
-    /// Seconds this buffer's producer spent blocked waiting for an output
-    /// permit, and the number of waits. See [`PermitPool::blocked`].
-    /// Writer-side distributions: per-block write, reorder wait, reorder depth.
-    pub(crate) fn writer_stats(
-        &self,
-    ) -> (
-        crate::merge_trace::HistogramReport,
-        crate::merge_trace::HistogramReport,
-        crate::merge_trace::HistogramReport,
-    ) {
-        (
-            self.permit_pool.write_dur.snapshot(),
-            self.permit_pool.write_reorder_wait.snapshot(),
-            self.permit_pool.write_reorder_depth.snapshot(),
-        )
+    /// The permit pool that carries this writer's histograms.
+    ///
+    /// Exposed so a caller can retain the [`Arc`] and harvest
+    /// [`PermitPool::writer_stats`] *after* the output drain. The writer's own
+    /// `finish` consumes the staging to run that drain, so the pool is the only
+    /// handle that outlives it. See that method for why the drain must be
+    /// included.
+    pub(crate) fn permit_pool(&self) -> &Arc<PermitPool> {
+        &self.permit_pool
     }
 
+    /// Seconds this buffer's producer spent blocked waiting for an output
+    /// permit, and the number of waits. See [`PermitPool::blocked`].
     pub(crate) fn write_backpressure(&self) -> (f64, u64) {
         self.permit_pool.blocked()
     }
 
+    /// Create a new staging buffer.
+    #[must_use]
     pub(crate) fn new(
         pool: Arc<SortWorkerPool>,
         result_tx: Sender<CompressResult>,
@@ -306,7 +302,10 @@ fn io_writer_loop_inner<W: Write>(
         }
         // Sampled on every arrival, in-order or not, so the depth reflects the
         // queue the writer is actually carrying rather than only its bad moments.
-        permit_pool.write_reorder_depth.record(reorder_buf.len() as u64);
+        // A block count rides a duration histogram, so `record_count` scales it
+        // into the microsecond lane; recording the raw count would bucket every
+        // depth below `BLOCKS_TO_NANOS` to zero and the report would read zero.
+        permit_pool.write_reorder_depth.record_count(reorder_buf.len() as u64);
     }
 
     // Drain remaining buffered blocks — any gap means a worker dropped a result.

--- a/crates/fgumi-sort/src/bgzf_io.rs
+++ b/crates/fgumi-sort/src/bgzf_io.rs
@@ -52,6 +52,21 @@ impl StagingBuffer {
     #[must_use]
     /// Seconds this buffer's producer spent blocked waiting for an output
     /// permit, and the number of waits. See [`PermitPool::blocked`].
+    /// Writer-side distributions: per-block write, reorder wait, reorder depth.
+    pub(crate) fn writer_stats(
+        &self,
+    ) -> (
+        crate::merge_trace::HistogramReport,
+        crate::merge_trace::HistogramReport,
+        crate::merge_trace::HistogramReport,
+    ) {
+        (
+            self.permit_pool.write_dur.snapshot(),
+            self.permit_pool.write_reorder_wait.snapshot(),
+            self.permit_pool.write_reorder_depth.snapshot(),
+        )
+    }
+
     pub(crate) fn write_backpressure(&self) -> (f64, u64) {
         self.permit_pool.blocked()
     }
@@ -192,7 +207,7 @@ fn write_block_in_order<W: Write>(
         // Best-effort: the indexing consumer keeps the receiver alive until finish.
         let _ = tx.send(BlockOffset { serial, compressed_start: *compressed_offset });
     }
-    writer.write_all(data)?;
+    permit_pool.write_dur.time(|| writer.write_all(data))?;
     *compressed_offset += data.len() as u64;
     permit_pool.release();
     Ok(())
@@ -252,7 +267,10 @@ fn io_writer_loop_inner<W: Write>(
     block_offset_tx: Option<&Sender<BlockOffset>>,
 ) -> Result<()> {
     let mut next_expected: u64 = 0;
-    let mut reorder_buf: BTreeMap<u64, Vec<u8>> = BTreeMap::new();
+    // Value carries the arrival instant so the wait for an earlier serial is
+    // measurable; a block written straight through never enters the map and so
+    // records no wait, which is the correct reading.
+    let mut reorder_buf: BTreeMap<u64, (Vec<u8>, std::time::Instant)> = BTreeMap::new();
     let mut compressed_offset: u64 = 0;
     let tx = block_offset_tx;
 
@@ -270,7 +288,8 @@ fn io_writer_loop_inner<W: Write>(
             )?;
             next_expected += 1;
 
-            while let Some(data) = reorder_buf.remove(&next_expected) {
+            while let Some((data, arrived)) = reorder_buf.remove(&next_expected) {
+                permit_pool.write_reorder_wait.record(crate::merge_trace::elapsed_nanos(arrived));
                 write_block_in_order(
                     writer,
                     next_expected,
@@ -282,15 +301,19 @@ fn io_writer_loop_inner<W: Write>(
                 next_expected += 1;
             }
         } else {
-            reorder_buf.insert(result.serial, result.compressed);
+            reorder_buf.insert(result.serial, (result.compressed, std::time::Instant::now()));
             // Permit held: released when this block is written in the cascade above.
         }
+        // Sampled on every arrival, in-order or not, so the depth reflects the
+        // queue the writer is actually carrying rather than only its bad moments.
+        permit_pool.write_reorder_depth.record(reorder_buf.len() as u64);
     }
 
     // Drain remaining buffered blocks — any gap means a worker dropped a result.
     while let Some((&serial, _)) = reorder_buf.first_key_value() {
         if serial == next_expected {
-            let data = reorder_buf.remove(&serial).expect("key just checked");
+            let (data, arrived) = reorder_buf.remove(&serial).expect("key just checked");
+            permit_pool.write_reorder_wait.record(crate::merge_trace::elapsed_nanos(arrived));
             write_block_in_order(
                 writer,
                 next_expected,

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -4573,6 +4573,44 @@ impl RawExternalSorter {
                      bounds how late work arriving any other way is noticed; it delays the merge \
                      only when every worker is asleep at once)"
                 );
+                // Why the discovery lag above is as large as it is. A wake aimed at a
+                // worker that is already running does nothing, and the consumer then
+                // waits for some other worker's backoff to expire -- bounded by
+                // MAX_BACKOFF_US, not by unpark cost. `recoverable` is the subset where a
+                // parked worker existed and the rotating target passed it over; the rest
+                // is a genuinely saturated pool and is nobody's fault.
+                let wakes = pool.wake_accounting();
+                if wakes.issued > 0 {
+                    info!(
+                        "  Wake targeting: {} of {} wakes hit an already-running worker ({:.0}%), {} of \
+                 those had a parked worker available ({:.0}% recoverable)",
+                        wakes.on_running,
+                        wakes.issued,
+                        Self::percent(wakes.on_running, wakes.issued),
+                        wakes.recoverable,
+                        Self::percent(wakes.recoverable, wakes.issued)
+                    );
+                }
+                // The decisive split: if the backoff timer recruited more critical-path
+                // claims than the wake did, the wake path is not what sets recruitment
+                // latency and tuning unpark cost cannot help. Inferred from elapsed vs
+                // requested park time -- park_timeout does not report its reason.
+                let recruited = wakes.from_unpark + wakes.from_timeout;
+                if recruited > 0 {
+                    info!(
+                        "  Critical-path recruitment (inferred): {} by our wake, {} by the worker's own \
+                 backoff expiring ({:.0}% timer)",
+                        wakes.from_unpark,
+                        wakes.from_timeout,
+                        Self::percent(wakes.from_timeout, recruited)
+                    );
+                }
+                info!(
+                    "    Wakes issued: {} (backoff 10us doubling to {}us ceiling; one worker woken \
+                     per wake)",
+                    pool.wakes_issued(),
+                    crate::worker_pool::MAX_BACKOFF_US
+                );
             }
 
             Self::log_park_attribution(pool, loop_total);
@@ -4611,6 +4649,15 @@ impl RawExternalSorter {
     /// the same split [`Self::log_block_lifecycle`] uses: a percentile table is
     /// for an investigation, not for someone who just sorted a BAM. Collection
     /// is unconditional either way.
+    /// `part` as a percentage of `whole`, or 0.0 when `whole` is zero.
+    #[expect(clippy::cast_precision_loss, reason = "counts stay far below 2^52")]
+    fn percent(part: u64, whole: u64) -> f64 {
+        if whole == 0 {
+            return 0.0;
+        }
+        100.0 * part as f64 / whole as f64
+    }
+
     fn log_stage_latency(
         pool: &SortWorkerPool,
         writer: &(

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -4590,6 +4590,102 @@ impl RawExternalSorter {
         Self::log_block_lifecycle(pool);
     }
 
+    /// Log a latency distribution for every stage a block passes through.
+    ///
+    /// [`crate::merge_phases::MergePhaseBreakdown`] already gives each stage a
+    /// busy total and a block count, which yields a mean. A mean cannot settle
+    /// an argument: output compression averages ~187 us over five million blocks
+    /// and a uniform 187 us behaves nothing like a bimodal mix with a long tail,
+    /// yet only the tail explains a worker being unavailable when the consumer
+    /// needs one. So report count, total, mean and three percentiles for each,
+    /// including the writer -- previously visible only as the consumer's
+    /// backpressure wait, which jumped 0.0s to 29.9s across one sweep with no
+    /// way to attribute it.
+    ///
+    /// `wasted visits` is the other half: files a worker passed over before one
+    /// gave it work. The scan tally is published only when a scan finds nothing,
+    /// so the walk to a *successful* claim was never counted -- and on an 89-way
+    /// merge that walk is most of what an "idle" worker is doing.
+    ///
+    /// The distributions log at **debug** and the wasted-visit line at **info**,
+    /// the same split [`Self::log_block_lifecycle`] uses: a percentile table is
+    /// for an investigation, not for someone who just sorted a BAM. Collection
+    /// is unconditional either way.
+    fn log_stage_latency(
+        pool: &SortWorkerPool,
+        writer: &(
+            crate::merge_trace::HistogramReport,
+            crate::merge_trace::HistogramReport,
+            crate::merge_trace::HistogramReport,
+        ),
+    ) {
+        let stage = pool.stage_latency();
+        let &(write_dur, reorder_wait, reorder_depth) = writer;
+        let rows: [(&str, crate::merge_trace::HistogramReport); 6] = [
+            ("read (batched)", stage.read.snapshot()),
+            ("decompress spill", stage.decompress.snapshot()),
+            ("compress output", stage.output_compress.snapshot()),
+            ("compress spill (ph1)", stage.spill_compress.snapshot()),
+            ("write block", write_dur),
+            ("write reorder wait", reorder_wait),
+        ];
+        if rows.iter().all(|(_, r)| r.is_empty()) {
+            return;
+        }
+        // Distributions go to debug and decision-changing numbers stay at info,
+        // matching `log_block_lifecycle` above: a six-row percentile table is
+        // what an investigation needs and far more than someone who just sorted
+        // a BAM should have to scroll past. Collection stays unconditional --
+        // gating collection is what made these questions unanswerable from logs
+        // already in hand.
+        debug!("=== Stage Latency ===");
+        debug!(
+            "  {:<22} {:>10} {:>9} {:>9} {:>9} {:>9} {:>9}",
+            "stage", "count", "total", "mean", "p50", "p90", "p99"
+        );
+        for (label, r) in rows {
+            if r.is_empty() {
+                continue;
+            }
+            debug!(
+                "  {label:<22} {:>10} {:>8.1}s {:>8.0}us {:>8}us {:>8}us {:>8}us",
+                r.count,
+                r.total_secs(),
+                r.mean_micros(),
+                r.percentile_micros(0.50),
+                r.percentile_micros(0.90),
+                r.percentile_micros(0.99)
+            );
+        }
+        if !reorder_depth.is_empty() {
+            debug!(
+                "  Writer reorder depth: mean {:.1} blocks, p90 {}, p99 {} (blocks held waiting \
+                 for an earlier serial)",
+                reorder_depth.mean_micros(),
+                reorder_depth.percentile_micros(0.90),
+                reorder_depth.percentile_micros(0.99)
+            );
+        }
+        // Closes the debug block above, so the separator does not outlive its
+        // header when only info is enabled.
+        debug!("=====================");
+        // Stays at info: this one is a decision-changer, not a distribution. It
+        // is how much of an "idle" worker is scanning rather than waiting, and
+        // reading it wrong sends an investigation at the scan loop -- filling
+        // the walk with more work per claim was measured at +36% (see
+        // `PHASE2_DECOMP_CAP`).
+        let claims = stage.useful_claims.load(std::sync::atomic::Ordering::Relaxed);
+        if claims > 0 {
+            info!(
+                "  Wasted file visits: {:.1} per claim over {} claims ({} visits produced \
+                 nothing) -- what an idle worker is actually doing",
+                stage.wasted_visits_per_claim(),
+                claims,
+                stage.wasted_visits.load(std::sync::atomic::Ordering::Relaxed)
+            );
+        }
+    }
+
     /// Log where consumer park time went, and what each worker did.
     ///
     /// The park table is the one figure in this report that partitions an exact
@@ -5123,6 +5219,7 @@ impl RawExternalSorter {
         // compressors are behind, which the sampled breakdown charged to "enqueue
         // write" -- a bucket documented as a handoff that excludes compression.
         let (write_blocked_secs, write_blocked_waits) = writer.write_backpressure();
+        let writer_stats = writer.writer_stats();
 
         // Harvest the consumer's stall report before finalizing: `finish_output`
         // releases the merge sources and with them the consumer, and the report
@@ -5158,6 +5255,7 @@ impl RawExternalSorter {
                 reassembled: reassembled_this_merge,
             },
         );
+        Self::log_stage_latency(pool, &writer_stats);
 
         merge_progress.log_final();
         log_snapshot("phase2.end", 0);
@@ -5265,6 +5363,14 @@ impl RawExternalSorter {
             guard.consumer_ref().map(MainThreadChunkConsumer::stall_report)
         };
 
+        // Retain the permit pool so the writer histograms can be harvested *after*
+        // `finish_index` drains the output queue, exactly as the generic path
+        // does: the pool outlives the writer, and the block writes and reorder
+        // waits incurred during that drain belong in the "write block" and
+        // "write reorder wait" rows. A snapshot taken here, before the drain,
+        // would omit the tail.
+        let writer_permit_pool = writer.permit_pool();
+
         // Finalize before logging, for the reason the generic path does: `finish`
         // drains the output queue, and every block still in it is compressed by
         // the same workers `log_merge_stalls` divides into `merge_total`. Logging
@@ -5275,6 +5381,14 @@ impl RawExternalSorter {
         // number. `loop_total` stays the consumer's park-fraction denominator,
         // which is a fraction of the merge loop alone.
         let index = guard.finish_output(|| writer.finish_index())?;
+
+        // Harvest now, after the drain, from the retained pool. Empty only if the
+        // writer was already finalized when the pool was retained, which cannot
+        // happen on this path.
+        let writer_stats = writer_permit_pool
+            .as_deref()
+            .map_or_else(Default::default, crate::worker_pool::PermitPool::writer_stats);
+
         Self::log_merge_stalls(
             loop_total,
             loop_start.elapsed().as_secs_f64(),
@@ -5282,6 +5396,11 @@ impl RawExternalSorter {
             stalls,
             pool,
         );
+        // `--write-index` is the default for a coordinate sort, so wiring the
+        // stage-latency table here -- matching `merge_chunks_generic` -- is what
+        // gives most production merges any stage-latency and writer-histogram
+        // rows at all.
+        Self::log_stage_latency(pool, &writer_stats);
 
         merge_progress.log_final();
         Ok((index, records_merged))

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1774,11 +1774,40 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
             self.shared
                 .phase2_awaited_source
                 .store(source_id, std::sync::atomic::Ordering::Relaxed);
+            // Arm the park handshake. Workers stamp when the awaited block is
+            // first claimed and when the consumer is woken; the difference from
+            // `park_start` splits this park into additive stages. Cleared here
+            // rather than after so a stamp can only ever be attributed to a park
+            // that had already begun.
+            let ord = std::sync::atomic::Ordering::Relaxed;
+            self.shared.awaited_claim_nanos.store(0, ord);
+            self.shared.awaited_publish_nanos.store(0, ord);
+            let park_started_at = self.shared.now_nanos();
+
             let park_start = Instant::now();
             std::thread::park();
             let parked_ns = crate::merge_trace::elapsed_nanos(park_start);
             self.stalls.record_park(source_id, parked_ns, !parked_yet);
             self.shared.consumer_trace.record_park(state, parked_ns, in_flight);
+
+            // Split the park. `now_nanos` is the same clock the workers stamp
+            // with, so the segments are comparable; `parked_ns` comes from
+            // `Instant` and is only used for the existing counters.
+            let resumed_at = self.shared.now_nanos();
+            let claim = self.shared.awaited_claim_nanos.load(ord);
+            let publish = self.shared.awaited_publish_nanos.load(ord);
+            let segments = crate::merge_stalls::split_park(
+                park_started_at,
+                (claim != 0).then_some(claim),
+                (publish != 0).then_some(publish),
+                resumed_at,
+            );
+            // Depth on the critical path: how many blocks the awaited file had
+            // ready the moment the consumer could run again. A mean near 1 means
+            // every block is fetched on demand, which is a different problem
+            // from a slow fetch.
+            let (_, ready, _) = self.files[source_id].depths();
+            self.shared.park_attribution.record(segments, claim != 0, ready as u64);
             parked_yet = true;
         }
     }
@@ -4546,6 +4575,8 @@ impl RawExternalSorter {
                 );
             }
 
+            Self::log_park_attribution(pool, loop_total);
+
             // Close this block before delegating: `log_block_lifecycle` opens and
             // closes its own, so without a terminator here the lifecycle block
             // reads as nested inside the stall block rather than following it.
@@ -4557,6 +4588,87 @@ impl RawExternalSorter {
         // never stalled is precisely the run with a complete lifecycle trace and
         // nothing to say above. `log_block_lifecycle` carries its own gate.
         Self::log_block_lifecycle(pool);
+    }
+
+    /// Log where consumer park time went, and what each worker did.
+    ///
+    /// The park table is the one figure in this report that partitions an exact
+    /// total by construction, which is why it is the one to read first. Earlier
+    /// attempts to explain park were shares of park *events* (blind to a
+    /// rare-but-long cause) or sums over workers (which overcount, because the
+    /// consumer waits for whichever worker arrives first). `unattributed` is the
+    /// honesty term: a large value means the model is incomplete, not that the
+    /// merge is idle for no reason.
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "nanosecond and count totals are within f64's exact-integer range here"
+    )]
+    fn log_park_attribution(pool: &SortWorkerPool, loop_total: f64) {
+        let park = pool.park_attribution_report();
+        if park.is_empty() {
+            return;
+        }
+        let total = park.total_nanos();
+        if total == 0 {
+            return;
+        }
+        let secs = |ns: u64| ns as f64 / 1e9;
+        let share = |ns: u64| 100.0 * ns as f64 / total as f64;
+        let per_park = |ns: u64| ns as f64 / park.parks as f64 / 1e3;
+
+        info!("  Consumer park, by stage (exact, partitions the park):");
+        info!("    {:<28} {:>8} {:>7} {:>10}", "stage", "time", "share", "per park");
+        for (label, ns) in [
+            ("waiting for a worker", park.to_claim_nanos),
+            ("read + decompress work", park.work_nanos),
+            ("waiting for its own wake", park.to_resume_nanos),
+            ("unattributed", park.unattributed_nanos),
+        ] {
+            info!("    {label:<28} {:>7.1}s {:>6.0}% {:>9.0}us", secs(ns), share(ns), per_park(ns));
+        }
+        info!(
+            "    {:<28} {:>7.1}s {:>6.0}% {:>9.0}us  over {} parks ({:.0}% of loop wall)",
+            "TOTAL",
+            secs(total),
+            100.0,
+            per_park(total),
+            park.parks,
+            if loop_total > 0.0 { 100.0 * secs(total) / loop_total } else { 0.0 }
+        );
+        info!(
+            "    Blocks ready on the awaited file at resume: mean {:.2} (1.0 = every block \
+             fetched on demand, one round trip per block)",
+            park.mean_ready_on_resume()
+        );
+        info!(
+            "    Parks with no claim during them: {} of {} ({:.0}%) -- the block was already \
+             in flight or already done",
+            park.unclaimed_parks,
+            park.parks,
+            100.0 * park.unclaimed_parks as f64 / park.parks as f64
+        );
+
+        let threads = pool.per_thread_report();
+        let claims_total: u64 = threads.iter().map(|&(_, _, c)| c).sum();
+        if claims_total == 0 {
+            return;
+        }
+        info!("  Per worker (merge + phase 1 combined):");
+        info!(
+            "    {:>3} {:>9} {:>9} {:>7} {:>10} {:>5}",
+            "wid", "busy", "idle", "busy%", "claims", "share"
+        );
+        for (w, &(busy, idle, claims)) in threads.iter().enumerate() {
+            let denom = busy + idle;
+            info!(
+                "    {w:>3} {:>8.1}s {:>8.1}s {:>6.0}% {:>10} {:>4.0}%",
+                secs(busy),
+                secs(idle),
+                if denom > 0 { 100.0 * busy as f64 / denom as f64 } else { 0.0 },
+                claims,
+                100.0 * claims as f64 / claims_total as f64
+            );
+        }
     }
 
     /// Log every stage of a spill block's journey, and the refill cycle.

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1783,10 +1783,15 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
             self.shared.awaited_claim_nanos.store(0, ord);
             self.shared.awaited_publish_nanos.store(0, ord);
             let park_started_at = self.shared.now_nanos();
+            // Sampled BEFORE the park, not after: the question is why nobody had
+            // already started on this block, and the pool's state on *resume* is
+            // the answer to a different question -- by then somebody has.
+            let supply = self.shared.park_supply_now();
 
             let park_start = Instant::now();
             std::thread::park();
             let parked_ns = crate::merge_trace::elapsed_nanos(park_start);
+            self.shared.park_supply.record(supply, parked_ns);
             self.stalls.record_park(source_id, parked_ns, !parked_yet);
             self.shared.consumer_trace.record_park(state, parked_ns, in_flight);
 
@@ -4591,26 +4596,35 @@ impl RawExternalSorter {
                         Self::percent(wakes.recoverable, wakes.issued)
                     );
                 }
-                // The decisive split: if the backoff timer recruited more critical-path
-                // claims than the wake did, the wake path is not what sets recruitment
-                // latency and tuning unpark cost cannot help. Inferred from elapsed vs
-                // requested park time -- park_timeout does not report its reason.
-                let recruited = wakes.from_unpark + wakes.from_timeout;
-                if recruited > 0 {
-                    info!(
-                        "  Critical-path recruitment (inferred): {} by our wake, {} by the worker's own \
-                 backoff expiring ({:.0}% timer)",
-                        wakes.from_unpark,
-                        wakes.from_timeout,
-                        Self::percent(wakes.from_timeout, recruited)
-                    );
-                }
                 info!(
                     "    Wakes issued: {} (backoff 10us doubling to {}us ceiling; one worker woken \
                      per wake)",
                     pool.wakes_issued(),
                     crate::worker_pool::MAX_BACKOFF_US
                 );
+            }
+
+            // What the pool looked like when the consumer parked, which is the
+            // question "why did nobody start on this block yet" reduced to three
+            // mutually exclusive answers with three different fixes. Splitting park
+            // *time* as well as park counts matters: a rare-but-long class is
+            // invisible in counts alone. Outside the wake gate above so it stands
+            // on its own park count: a heavy-parking consumer whose wake report is
+            // empty would otherwise collect this census and never print it.
+            let supply = pool.park_supply_report();
+            if supply.total_parks() > 0 {
+                const LABELS: [&str; crate::merge_stalls::ParkSupply::COUNT] =
+                    ["a worker was asleep", "all busy, compress queued", "all busy merging"];
+                info!("  Why nobody had started on the awaited block, at the moment of the park:");
+                for (i, label) in LABELS.iter().enumerate() {
+                    info!(
+                        "    {label:<26} {:>10} parks ({:>4.1}%)  {:>7.1}s ({:>4.1}% of park time)",
+                        supply.counts[i],
+                        Self::percent(supply.counts[i], supply.total_parks()),
+                        Self::secs(supply.nanos[i]),
+                        Self::percent(supply.nanos[i], supply.total_nanos())
+                    );
+                }
             }
 
             Self::log_park_attribution(pool, loop_total);
@@ -4626,6 +4640,21 @@ impl RawExternalSorter {
         // never stalled is precisely the run with a complete lifecycle trace and
         // nothing to say above. `log_block_lifecycle` carries its own gate.
         Self::log_block_lifecycle(pool);
+    }
+
+    /// Nanoseconds as seconds.
+    #[expect(clippy::cast_precision_loss, reason = "nanosecond totals stay below 2^52")]
+    fn secs(nanos: u64) -> f64 {
+        nanos as f64 / 1e9
+    }
+
+    /// `part` as a percentage of `whole`, or 0.0 when `whole` is zero.
+    #[expect(clippy::cast_precision_loss, reason = "counts stay far below 2^52")]
+    fn percent(part: u64, whole: u64) -> f64 {
+        if whole == 0 {
+            return 0.0;
+        }
+        100.0 * part as f64 / whole as f64
     }
 
     /// Log a latency distribution for every stage a block passes through.
@@ -4649,15 +4678,6 @@ impl RawExternalSorter {
     /// the same split [`Self::log_block_lifecycle`] uses: a percentile table is
     /// for an investigation, not for someone who just sorted a BAM. Collection
     /// is unconditional either way.
-    /// `part` as a percentage of `whole`, or 0.0 when `whole` is zero.
-    #[expect(clippy::cast_precision_loss, reason = "counts stay far below 2^52")]
-    fn percent(part: u64, whole: u64) -> f64 {
-        if whole == 0 {
-            return 0.0;
-        }
-        100.0 * part as f64 / whole as f64
-    }
-
     fn log_stage_latency(
         pool: &SortWorkerPool,
         writer: &(
@@ -4851,6 +4871,30 @@ impl RawExternalSorter {
             if !hist.is_empty() {
                 debug!("    {:<14} {}", state.label(), hist.summary());
             }
+        }
+        // The same five states weighted by TIME, not by park count, and at info
+        // because the two disagree and only one of them is a cost.
+        //
+        // The park-supply census made this concrete: by count its largest class
+        // was "all busy, compress queued" at 41%, by time that class was 13%
+        // while "a worker was asleep" was 81%. Counts named the wrong fix,
+        // confidently. These histograms have always carried the nanoseconds --
+        // they were simply reported one level down, so every arm collected the
+        // answer and none printed it.
+        let state_secs: [f64; AwaitedState::COUNT] =
+            std::array::from_fn(|i| consumer.park_by_state[i].total_secs());
+        let state_total: f64 = state_secs.iter().sum();
+        if state_total > 0.0 {
+            let share = |i: usize| 100.0 * state_secs[i] / state_total;
+            info!(
+                "    The awaited file by park TIME ({state_total:.1}s): {:.0}% gap-filling, \
+                 {:.0}% gap-stalled, {:.0}% decompressing, {:.0}% raw-queued, {:.0}% starved",
+                share(AwaitedState::ReorderGapFilling as usize),
+                share(AwaitedState::ReorderGapStalled as usize),
+                share(AwaitedState::Decompressing as usize),
+                share(AwaitedState::RawQueued as usize),
+                share(AwaitedState::Starved as usize)
+            );
         }
 
         let parks_pct = |count: u64| {
@@ -5266,7 +5310,13 @@ impl RawExternalSorter {
         // compressors are behind, which the sampled breakdown charged to "enqueue
         // write" -- a bucket documented as a handoff that excludes compression.
         let (write_blocked_secs, write_blocked_waits) = writer.write_backpressure();
-        let writer_stats = writer.writer_stats();
+        // Retain the permit pool so the writer histograms can be harvested *after*
+        // `finish` drains the output queue: the pool outlives the writer, and the
+        // block writes and reorder waits incurred during that drain belong in the
+        // "write block" and "write reorder wait" rows. A snapshot taken here,
+        // before the drain, would omit the tail -- the same reason the stall
+        // report below is harvested pre-finalize but the histograms are not.
+        let writer_permit_pool = writer.permit_pool();
 
         // Harvest the consumer's stall report before finalizing: `finish_output`
         // releases the merge sources and with them the consumer, and the report
@@ -5287,6 +5337,13 @@ impl RawExternalSorter {
         // `output_compress` and divides the rest by a wall clock that stops
         // before the drain.
         guard.finish_output(|| writer.finish())?;
+
+        // Harvest now, after the drain, from the retained pool. Empty only if the
+        // writer was already finalized when the pool was retained, which cannot
+        // happen on this path.
+        let writer_stats = writer_permit_pool
+            .as_deref()
+            .map_or_else(Default::default, crate::worker_pool::PermitPool::writer_stats);
 
         Self::log_merge_sub_phases(
             (loop_total, loop_start.elapsed().as_secs_f64()),

--- a/crates/fgumi-sort/src/merge_phases.rs
+++ b/crates/fgumi-sort/src/merge_phases.rs
@@ -85,6 +85,61 @@ pub(crate) struct MergePhaseCounters {
     pub(crate) spill_compress: ComponentCounter,
 }
 
+/// Latency distributions for the four stages a block passes through, plus the
+/// writer, plus how much scanning was wasted getting there.
+///
+/// [`MergePhaseCounters`] already gives each stage a busy total and a block
+/// count, which yields a *mean*. That is not enough to settle an argument: a
+/// stage averaging 187 us could be uniform or bimodal with a long tail, and only
+/// the tail explains why a worker is unavailable when the consumer needs one.
+/// Output compression is 69% of all worker busy on the measured cell and had no
+/// distribution at all; the writer had none either, so a jump in consumer
+/// backpressure from 0.0s to 29.9s could not be attributed.
+#[derive(Debug, Default)]
+pub(crate) struct StageLatency {
+    /// One batched read of compressed blocks from a spill file.
+    pub(crate) read: crate::merge_trace::DurationHistogram,
+    /// Decompressing one spill block.
+    pub(crate) decompress: crate::merge_trace::DurationHistogram,
+    /// Compressing one output block.
+    pub(crate) output_compress: crate::merge_trace::DurationHistogram,
+    /// Compressing one Phase 1 spill block.
+    pub(crate) spill_compress: crate::merge_trace::DurationHistogram,
+    // The writer's own histograms live on `PermitPool`: the I/O writer thread
+    // already holds that `Arc`, and one pool per writer keeps the output
+    // writer's stats separate from a spill writer's.
+    /// Files a worker passed over before one gave it work, summed over all
+    /// productive scans.
+    ///
+    /// The scan tally is published only when a scan finds *nothing*, so the
+    /// files skipped on the way to a successful claim were invisible. On an
+    /// 89-way merge a worker can walk most of the file set before finding work,
+    /// and that walk is the cost this counts.
+    pub(crate) wasted_visits: std::sync::atomic::AtomicU64,
+    /// Scans that ended in a claim. The denominator for `wasted_visits`.
+    pub(crate) useful_claims: std::sync::atomic::AtomicU64,
+}
+
+impl StageLatency {
+    /// Record a productive scan that skipped `skipped` files before claiming.
+    pub(crate) fn record_claim(&self, skipped: u64) {
+        use std::sync::atomic::Ordering;
+        self.wasted_visits.fetch_add(skipped, Ordering::Relaxed);
+        self.useful_claims.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Mean files visited fruitlessly per unit of work claimed.
+    #[expect(clippy::cast_precision_loss, reason = "counts stay far below 2^52")]
+    pub(crate) fn wasted_visits_per_claim(&self) -> f64 {
+        use std::sync::atomic::Ordering;
+        let claims = self.useful_claims.load(Ordering::Relaxed);
+        if claims == 0 {
+            return 0.0;
+        }
+        self.wasted_visits.load(Ordering::Relaxed) as f64 / claims as f64
+    }
+}
+
 /// A read-only view of the counters, for logging.
 #[derive(Debug, Clone, Copy)]
 pub struct MergePhaseBreakdown {

--- a/crates/fgumi-sort/src/merge_stalls.rs
+++ b/crates/fgumi-sort/src/merge_stalls.rs
@@ -1381,50 +1381,123 @@ pub fn classify_stall(
 // Worker recruitment: why the consumer waits for a worker it already woke
 // ============================================================================
 
-/// How a worker's `park_timeout` ended.
+/// Why nobody had already started on the block the consumer is about to wait for.
 ///
-/// `park_timeout` does not report its reason, so this is **inferred** from the
-/// elapsed time against the duration the worker asked for. A worker that
-/// returned meaningfully early was unparked; one that ran to its deadline timed
-/// out. Label any conclusion drawn from it as inferred.
+/// The three cases are not degrees of one problem -- they imply different fixes,
+/// which is why they are counted apart:
+///
+/// - `SleeperAvailable`: capacity was idle and unused. Pure coordination loss;
+///   the pool should have been on it.
+/// - `AllBusyCompressing`: every worker was busy and output compression was
+///   queued. Priority inversion -- `get_sort_priorities` puts `Compress` ahead
+///   of `Phase2FileWork` whenever the compress queue is non-empty, so the block
+///   the consumer is blocked on waits behind output work.
+/// - `AllBusyMerging`: every worker was busy on merge work. Genuine capacity;
+///   nothing to schedule better.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ParkExit {
-    /// Returned early -- something unparked it.
-    Unparked,
-    /// Ran to its deadline -- nobody did.
-    TimedOut,
+pub(crate) enum ParkSupply {
+    /// At least one worker was parked.
+    SleeperAvailable,
+    /// Nobody parked, and output compression was queued.
+    AllBusyCompressing,
+    /// Nobody parked, and the compress queue was empty.
+    AllBusyMerging,
 }
 
-/// Classify a park exit from elapsed vs requested microseconds.
-///
-/// The margin exists because a timed-out park overshoots its deadline by
-/// scheduler latency, so "elapsed < requested" alone would classify almost every
-/// timeout as an unpark. Requiring the wake to be clearly early instead means a
-/// *late* unpark is misread as a timeout -- the safe direction, because it
-/// under-counts the wake path's effectiveness rather than crediting it for
-/// recruitment it did not do.
-pub(crate) fn classify_park_exit(elapsed_us: u64, requested_us: u64) -> ParkExit {
-    // A park that never asked for a wait (the `yield_now` path) cannot have been
-    // cut short by anything.
-    if requested_us == 0 {
-        return ParkExit::TimedOut;
+impl ParkSupply {
+    /// Number of variants, so the census arrays indexed by [`Self::index`]
+    /// cannot fall behind the enum. Sizing them with a literal instead lets a
+    /// new variant compile and then index out of bounds inside
+    /// [`ParkSupplyCensus::record`] -- on a worker-adjacent path, where it
+    /// surfaces only as a panicked sort worker.
+    pub(crate) const COUNT: usize = 3;
+
+    /// Stable index for the census arrays.
+    fn index(self) -> usize {
+        match self {
+            Self::SleeperAvailable => 0,
+            Self::AllBusyCompressing => 1,
+            Self::AllBusyMerging => Self::COUNT - 1,
+        }
     }
-    // Three quarters of the deadline: comfortably past scheduler overshoot, and
-    // far enough from the deadline that a genuine unpark is unambiguous.
-    if elapsed_us.saturating_mul(4) < requested_us.saturating_mul(3) {
-        ParkExit::Unparked
+}
+
+// Keeps `COUNT` honest: the match is exhaustive, so a fourth variant fails to
+// compile here instead of indexing past the end of the census arrays at run
+// time.
+const _: () = {
+    const fn assert_count(supply: ParkSupply) -> usize {
+        match supply {
+            ParkSupply::SleeperAvailable => 0,
+            ParkSupply::AllBusyCompressing => 1,
+            ParkSupply::AllBusyMerging => ParkSupply::COUNT - 1,
+        }
+    }
+    assert!(assert_count(ParkSupply::AllBusyMerging) == 2);
+};
+
+/// Classify the pool's state at the instant the consumer parks.
+pub(crate) fn classify_park_supply(parked_workers: usize, compress_depth: usize) -> ParkSupply {
+    // A sleeper outranks a queued compress deliberately: the two fixes are not
+    // interchangeable. Waking an idle worker costs nothing, while reordering
+    // priorities trades output throughput for merge latency, so a park with both
+    // conditions true belongs in the cheaper bucket.
+    if parked_workers > 0 {
+        ParkSupply::SleeperAvailable
+    } else if compress_depth > 0 {
+        ParkSupply::AllBusyCompressing
     } else {
-        ParkExit::TimedOut
+        ParkSupply::AllBusyMerging
     }
 }
 
-/// The first parked worker at or after `cursor`, or `None` if none are parked.
-///
-/// Rotating blindly is what makes a wake cheap, and also what makes it
-/// unreliable: at low utilization most workers are parked, but the cursor can
-/// still land on the one that is running, and that wake is simply lost. The
-/// consumer then waits for some other worker's backoff to expire instead --
-/// bounded by `MAX_BACKOFF_US`, not by wake cost.
+/// Park time and park counts split by [`ParkSupply`].
+#[derive(Debug, Default)]
+pub(crate) struct ParkSupplyCensus {
+    counts: [AtomicU64; ParkSupply::COUNT],
+    nanos: [AtomicU64; ParkSupply::COUNT],
+}
+
+impl ParkSupplyCensus {
+    /// Attribute one park of `nanos` to `supply`.
+    pub(crate) fn record(&self, supply: ParkSupply, nanos: u64) {
+        let i = supply.index();
+        self.counts[i].fetch_add(1, Ordering::Relaxed);
+        self.nanos[i].fetch_add(nanos, Ordering::Relaxed);
+    }
+
+    /// Counts and nanoseconds per class, indexed as [`ParkSupply::index`].
+    pub(crate) fn snapshot(&self) -> ParkSupplyReport {
+        ParkSupplyReport {
+            counts: std::array::from_fn(|i| self.counts[i].load(Ordering::Relaxed)),
+            nanos: std::array::from_fn(|i| self.nanos[i].load(Ordering::Relaxed)),
+        }
+    }
+}
+
+/// Read-only view of [`ParkSupplyCensus`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ParkSupplyReport {
+    /// Parks per class: sleeper-available, all-busy-compressing, all-busy-merging.
+    pub counts: [u64; ParkSupply::COUNT],
+    /// Park nanoseconds per class, same order.
+    pub nanos: [u64; ParkSupply::COUNT],
+}
+
+impl ParkSupplyReport {
+    /// Total parks censused.
+    #[must_use]
+    pub fn total_parks(self) -> u64 {
+        self.counts.iter().sum()
+    }
+
+    /// Total park nanoseconds censused.
+    #[must_use]
+    pub fn total_nanos(self) -> u64 {
+        self.nanos.iter().sum()
+    }
+}
+
 /// Takes a predicate rather than a slice so the wake path can read the atomics
 /// directly: this runs on every wake -- millions of them -- and materializing a
 /// `Vec<bool>` there would allocate on the hottest coordination path in the
@@ -2067,22 +2140,50 @@ mod tests {
     // Worker recruitment
     // ========================================================================
 
-    /// A timed-out park overshoots its deadline by scheduler latency, so
-    /// `elapsed < requested` alone would call almost every timeout an unpark and
-    /// credit the wake path with recruitment it never did.
+    /// The three classes imply three different fixes, so the boundaries matter
+    /// more than the counts: a parked worker means coordination lost the block,
+    /// a queued compress means priority did, and neither means capacity did.
     #[rstest]
-    #[case::clearly_early_is_an_unpark(10, 1000, ParkExit::Unparked)]
-    #[case::ran_to_the_deadline_timed_out(1000, 1000, ParkExit::TimedOut)]
-    #[case::overshot_the_deadline_timed_out(1180, 1000, ParkExit::TimedOut)]
-    #[case::a_hair_early_is_not_credited_as_a_wake(995, 1000, ParkExit::TimedOut)]
-    #[case::half_the_deadline_is_a_wake(500, 1000, ParkExit::Unparked)]
-    #[case::yield_path_never_requested_a_wait(0, 0, ParkExit::TimedOut)]
-    fn test_park_exit_is_inferred_conservatively(
-        #[case] elapsed_us: u64,
-        #[case] requested_us: u64,
-        #[case] expected: ParkExit,
+    #[case::one_sleeper_is_coordination_loss(1, 0, ParkSupply::SleeperAvailable)]
+    #[case::a_sleeper_outranks_a_full_compress_queue(3, 9, ParkSupply::SleeperAvailable)]
+    #[case::nobody_free_with_compress_queued_is_priority(0, 5, ParkSupply::AllBusyCompressing)]
+    #[case::nobody_free_and_nothing_queued_is_capacity(0, 0, ParkSupply::AllBusyMerging)]
+    fn test_park_supply_separates_coordination_from_priority_from_capacity(
+        #[case] parked_workers: usize,
+        #[case] compress_depth: usize,
+        #[case] expected: ParkSupply,
     ) {
-        assert_eq!(classify_park_exit(elapsed_us, requested_us), expected);
+        assert_eq!(classify_park_supply(parked_workers, compress_depth), expected);
+    }
+
+    /// A sleeper is reported even when compression is also backed up, because the
+    /// fixes are not interchangeable: waking the sleeper costs nothing, whereas
+    /// reordering priorities trades output throughput for merge latency.
+    #[test]
+    fn test_a_sleeper_is_not_masked_by_a_busy_compress_queue() {
+        assert_eq!(classify_park_supply(1, 100), ParkSupply::SleeperAvailable);
+    }
+
+    #[test]
+    fn test_census_attributes_parks_and_time_by_class() {
+        let census = ParkSupplyCensus::default();
+        census.record(ParkSupply::SleeperAvailable, 100);
+        census.record(ParkSupply::SleeperAvailable, 50);
+        census.record(ParkSupply::AllBusyCompressing, 700);
+        census.record(ParkSupply::AllBusyMerging, 5);
+
+        let report = census.snapshot();
+        assert_eq!(report.counts, [2, 1, 1]);
+        assert_eq!(report.nanos, [150, 700, 5]);
+        assert_eq!(report.total_parks(), 4);
+        assert_eq!(report.total_nanos(), 855);
+    }
+
+    #[test]
+    fn test_census_starts_empty() {
+        let report = ParkSupplyCensus::default().snapshot();
+        assert_eq!(report.total_parks(), 0);
+        assert_eq!(report.total_nanos(), 0);
     }
 
     #[test]

--- a/crates/fgumi-sort/src/merge_stalls.rs
+++ b/crates/fgumi-sort/src/merge_stalls.rs
@@ -660,6 +660,172 @@ impl WakeLatencyReport {
 const DEEP_SLEEP_FIRST_BUCKET: usize = 5;
 
 // ============================================================================
+// Consumer park decomposition
+// ============================================================================
+
+/// One consumer park, split into the stages of fetching the block it wanted.
+///
+/// The four fields partition the park by construction — see [`split_park`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct ParkSegments {
+    /// Park spent before any worker claimed the needed block: the cost of
+    /// getting *a* worker onto it, whichever one arrives first.
+    pub to_claim: u64,
+    /// Park spent between the claim and the block being published: the read and
+    /// decompress work itself.
+    pub work: u64,
+    /// Park spent after the block was published, before the consumer resumed:
+    /// the consumer's own wake latency.
+    pub to_resume: u64,
+    /// Park not attributable to fetching this block — the honesty term.
+    pub unattributed: u64,
+}
+
+/// Split a park into [`ParkSegments`].
+///
+/// `claim` and `publish` are `None` when that stamp did not land inside this
+/// park: the block may have been claimed before the consumer parked, or not yet
+/// claimed when it resumed. Both are ordinary, and neither may be allowed to
+/// inflate a segment — an unstamped stage contributes to `unattributed`
+/// instead, so the reader can see how much of park the model fails to explain.
+///
+/// Stamps come from other threads and are only `Relaxed`, so they can be
+/// observed out of order relative to `park_start`. Every subtraction therefore
+/// saturates and every segment is clamped to what remains, which is what keeps
+/// the sum exactly equal to `resume - park_start` rather than merely close.
+pub(crate) fn split_park(
+    park_start: u64,
+    claim: Option<u64>,
+    publish: Option<u64>,
+    resume: u64,
+) -> ParkSegments {
+    let total = resume.saturating_sub(park_start);
+    let mut seg = ParkSegments::default();
+    let mut spent = 0u64;
+
+    // Each stage is measured from the later of its own start and the previous
+    // stage's end, so a stamp that predates the park contributes zero rather
+    // than borrowing time from a neighbour.
+    let mut cursor = park_start;
+    if let Some(claim) = claim {
+        seg.to_claim = claim.saturating_sub(cursor).min(total - spent);
+        spent += seg.to_claim;
+        cursor = cursor.max(claim);
+    }
+    if let Some(publish) = publish {
+        seg.work = publish.saturating_sub(cursor).min(total - spent);
+        spent += seg.work;
+        cursor = cursor.max(publish);
+        seg.to_resume = resume.saturating_sub(cursor).min(total - spent);
+        spent += seg.to_resume;
+    }
+    seg.unattributed = total - spent;
+    seg
+}
+
+/// Where the merge consumer's park time actually goes.
+///
+/// Every earlier attempt to explain park was either a share of park *events* —
+/// which hides a rare-but-long cause — or a sum over workers, which overcounts
+/// because the consumer waits for the *first* worker to deliver while the sum
+/// counts all of them. Measured on one 16-thread merge, the worker-side sum read
+/// 96.7s of critical-path lag against 97.0s of park, then a change that removed
+/// 62.9s of that lag moved park by 7.8s. These counters are consumer-side and
+/// additive instead, so the segments cannot exceed the park they came from.
+#[derive(Debug, Default)]
+pub(crate) struct ParkAttribution {
+    to_claim_nanos: AtomicU64,
+    work_nanos: AtomicU64,
+    to_resume_nanos: AtomicU64,
+    unattributed_nanos: AtomicU64,
+    parks: AtomicU64,
+    /// Parks where no worker claimed the block during the park, so the whole
+    /// wait was for a stage that had already started or already finished.
+    unclaimed_parks: AtomicU64,
+    /// Blocks the awaited file had ready when the consumer resumed, summed.
+    ///
+    /// Divided by [`Self::parks`] this is pipeline depth on the critical path. A
+    /// mean near 1 means every block the consumer needs is fetched on demand and
+    /// costs a full round trip, which is a different problem from a slow round
+    /// trip and has different fixes.
+    ready_on_resume: AtomicU64,
+}
+
+impl ParkAttribution {
+    /// Record one park, split by [`split_park`].
+    pub(crate) fn record(&self, seg: ParkSegments, claimed: bool, ready_on_resume: u64) {
+        self.to_claim_nanos.fetch_add(seg.to_claim, Ordering::Relaxed);
+        self.work_nanos.fetch_add(seg.work, Ordering::Relaxed);
+        self.to_resume_nanos.fetch_add(seg.to_resume, Ordering::Relaxed);
+        self.unattributed_nanos.fetch_add(seg.unattributed, Ordering::Relaxed);
+        self.parks.fetch_add(1, Ordering::Relaxed);
+        if !claimed {
+            self.unclaimed_parks.fetch_add(1, Ordering::Relaxed);
+        }
+        self.ready_on_resume.fetch_add(ready_on_resume, Ordering::Relaxed);
+    }
+
+    /// Snapshot for logging.
+    pub(crate) fn snapshot(&self) -> ParkAttributionReport {
+        ParkAttributionReport {
+            to_claim_nanos: self.to_claim_nanos.load(Ordering::Relaxed),
+            work_nanos: self.work_nanos.load(Ordering::Relaxed),
+            to_resume_nanos: self.to_resume_nanos.load(Ordering::Relaxed),
+            unattributed_nanos: self.unattributed_nanos.load(Ordering::Relaxed),
+            parks: self.parks.load(Ordering::Relaxed),
+            unclaimed_parks: self.unclaimed_parks.load(Ordering::Relaxed),
+            ready_on_resume: self.ready_on_resume.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Read-only view of [`ParkAttribution`].
+#[derive(Debug, Clone, Copy)]
+pub struct ParkAttributionReport {
+    /// Park spent waiting for any worker to claim the needed block.
+    pub to_claim_nanos: u64,
+    /// Park spent on the read and decompress themselves.
+    pub work_nanos: u64,
+    /// Park spent after publication, waiting for the consumer's own wake.
+    pub to_resume_nanos: u64,
+    /// Park the model does not explain.
+    pub unattributed_nanos: u64,
+    /// Parks recorded.
+    pub parks: u64,
+    /// Parks in which no claim landed.
+    pub unclaimed_parks: u64,
+    /// Summed blocks ready on the awaited file at resume.
+    pub ready_on_resume: u64,
+}
+
+impl ParkAttributionReport {
+    /// Whether anything was recorded.
+    #[must_use]
+    pub fn is_empty(self) -> bool {
+        self.parks == 0
+    }
+
+    /// Total park accounted for, which must match the exact park clock.
+    #[must_use]
+    pub fn total_nanos(self) -> u64 {
+        self.to_claim_nanos + self.work_nanos + self.to_resume_nanos + self.unattributed_nanos
+    }
+
+    /// Mean blocks ready on the awaited file when the consumer resumed.
+    ///
+    /// Near 1.0 means the critical path has no pipeline depth: each block is
+    /// fetched on demand, so the merge pays one full round trip per block.
+    #[must_use]
+    #[expect(clippy::cast_precision_loss, reason = "counts are well within f64's exact range")]
+    pub fn mean_ready_on_resume(self) -> f64 {
+        if self.parks == 0 {
+            return 0.0;
+        }
+        self.ready_on_resume as f64 / self.parks as f64
+    }
+}
+
+// ============================================================================
 // Consumer side: where the merge loop blocks
 // ============================================================================
 
@@ -1396,6 +1562,78 @@ mod tests {
         let report = stats.snapshot(WakePhase::Merge);
         assert!((report.estimated_discovery_lag_secs() - 0.5).abs() < 1e-9);
         assert_eq!(report.sleeps[7], 2000);
+    }
+
+    /// The four segments must partition the park exactly, whatever order the
+    /// stamps arrive in.
+    ///
+    /// This is the property that makes the decomposition trustworthy where the
+    /// worker-side lag sum was not: a segment cannot be inflated without another
+    /// shrinking, so no single number can be read as larger than the park it
+    /// came from.
+    #[rstest::rstest]
+    // Ordinary case: claimed then published inside the park.
+    #[case(1_000, Some(1_100), Some(1_150), 1_200, (100, 50, 50, 0))]
+    // Claimed but not yet published when the consumer resumed: no work segment,
+    // and the remainder is unattributed rather than silently folded into work.
+    #[case(1_000, Some(1_100), None, 1_200, (100, 0, 0, 100))]
+    // Already claimed before the park: nothing to wait for a worker on.
+    #[case(1_000, None, Some(1_050), 1_200, (0, 50, 150, 0))]
+    // Neither stamp: the block was already available, so the park is not
+    // attributable to fetching it at all.
+    #[case(1_000, None, None, 1_200, (0, 0, 0, 200))]
+    // Both stamps predate the park: the block was already published when the
+    // consumer parked, so the whole wait is the consumer failing to notice --
+    // charged to `to_resume`, not to a fetch that had already finished. Stamps
+    // arrive from other threads under `Relaxed`, so this ordering is reachable
+    // and must not yield a negative segment or a sum over the park.
+    #[case(1_000, Some(900), Some(950), 1_200, (0, 0, 200, 0))]
+    fn test_park_segments_always_partition_the_park(
+        #[case] park_start: u64,
+        #[case] claim: Option<u64>,
+        #[case] publish: Option<u64>,
+        #[case] resume: u64,
+        #[case] want: (u64, u64, u64, u64),
+    ) {
+        let (want_to_claim, want_work, want_to_resume, want_unattributed) = want;
+        let seg = split_park(park_start, claim, publish, resume);
+        assert_eq!(seg.to_claim, want_to_claim, "to_claim");
+        assert_eq!(seg.work, want_work, "work");
+        assert_eq!(seg.to_resume, want_to_resume, "to_resume");
+        assert_eq!(seg.unattributed, want_unattributed, "unattributed");
+        assert_eq!(
+            seg.to_claim + seg.work + seg.to_resume + seg.unattributed,
+            resume - park_start,
+            "segments must sum to the measured park"
+        );
+    }
+
+    proptest::proptest! {
+        /// Property: the segments partition the park for *any* arrangement of
+        /// stamps, including ones that predate the park or arrive reversed.
+        ///
+        /// This is the whole basis for trusting the decomposition over the
+        /// worker-side lag sum it replaces, and the case list cannot cover the
+        /// orderings that `Relaxed` loads across threads make reachable.
+        #[test]
+        fn prop_park_segments_partition_the_park(
+            park_start in 0u64..1_000_000,
+            span in 1u64..1_000_000,
+            claim_off in proptest::option::of(-500_000i64..1_500_000),
+            publish_off in proptest::option::of(-500_000i64..1_500_000),
+        ) {
+            let resume = park_start + span;
+            let stamp = |off: Option<i64>| {
+                off.map(|o| u64::try_from(i64::try_from(park_start).unwrap_or(i64::MAX) + o)
+                    .unwrap_or(0))
+            };
+            let seg = split_park(park_start, stamp(claim_off), stamp(publish_off), resume);
+            proptest::prop_assert_eq!(
+                seg.to_claim + seg.work + seg.to_resume + seg.unattributed,
+                span,
+                "segments must sum to the park exactly"
+            );
+        }
     }
 
     #[test]

--- a/crates/fgumi-sort/src/merge_stalls.rs
+++ b/crates/fgumi-sort/src/merge_stalls.rs
@@ -1377,6 +1377,68 @@ pub fn classify_stall(
     }
 }
 
+// ============================================================================
+// Worker recruitment: why the consumer waits for a worker it already woke
+// ============================================================================
+
+/// How a worker's `park_timeout` ended.
+///
+/// `park_timeout` does not report its reason, so this is **inferred** from the
+/// elapsed time against the duration the worker asked for. A worker that
+/// returned meaningfully early was unparked; one that ran to its deadline timed
+/// out. Label any conclusion drawn from it as inferred.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ParkExit {
+    /// Returned early -- something unparked it.
+    Unparked,
+    /// Ran to its deadline -- nobody did.
+    TimedOut,
+}
+
+/// Classify a park exit from elapsed vs requested microseconds.
+///
+/// The margin exists because a timed-out park overshoots its deadline by
+/// scheduler latency, so "elapsed < requested" alone would classify almost every
+/// timeout as an unpark. Requiring the wake to be clearly early instead means a
+/// *late* unpark is misread as a timeout -- the safe direction, because it
+/// under-counts the wake path's effectiveness rather than crediting it for
+/// recruitment it did not do.
+pub(crate) fn classify_park_exit(elapsed_us: u64, requested_us: u64) -> ParkExit {
+    // A park that never asked for a wait (the `yield_now` path) cannot have been
+    // cut short by anything.
+    if requested_us == 0 {
+        return ParkExit::TimedOut;
+    }
+    // Three quarters of the deadline: comfortably past scheduler overshoot, and
+    // far enough from the deadline that a genuine unpark is unambiguous.
+    if elapsed_us.saturating_mul(4) < requested_us.saturating_mul(3) {
+        ParkExit::Unparked
+    } else {
+        ParkExit::TimedOut
+    }
+}
+
+/// The first parked worker at or after `cursor`, or `None` if none are parked.
+///
+/// Rotating blindly is what makes a wake cheap, and also what makes it
+/// unreliable: at low utilization most workers are parked, but the cursor can
+/// still land on the one that is running, and that wake is simply lost. The
+/// consumer then waits for some other worker's backoff to expire instead --
+/// bounded by `MAX_BACKOFF_US`, not by wake cost.
+/// Takes a predicate rather than a slice so the wake path can read the atomics
+/// directly: this runs on every wake -- millions of them -- and materializing a
+/// `Vec<bool>` there would allocate on the hottest coordination path in the
+/// merge. Production and tests call the same function.
+pub(crate) fn first_parked_from<F>(cursor: usize, width: usize, is_parked: F) -> Option<usize>
+where
+    F: Fn(usize) -> bool,
+{
+    if width == 0 {
+        return None;
+    }
+    (0..width).map(|offset| (cursor + offset) % width).find(|&i| is_parked(i))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2000,5 +2062,64 @@ mod tests {
         let shares = awaited_shares([0.2, 0.3, 0.15, 0.25, 0.1]);
         let total = shares.starved + shares.unclaimed() + shares.in_progress();
         assert!((total - 1.0).abs() < 1e-9);
+    }
+    // ========================================================================
+    // Worker recruitment
+    // ========================================================================
+
+    /// A timed-out park overshoots its deadline by scheduler latency, so
+    /// `elapsed < requested` alone would call almost every timeout an unpark and
+    /// credit the wake path with recruitment it never did.
+    #[rstest]
+    #[case::clearly_early_is_an_unpark(10, 1000, ParkExit::Unparked)]
+    #[case::ran_to_the_deadline_timed_out(1000, 1000, ParkExit::TimedOut)]
+    #[case::overshot_the_deadline_timed_out(1180, 1000, ParkExit::TimedOut)]
+    #[case::a_hair_early_is_not_credited_as_a_wake(995, 1000, ParkExit::TimedOut)]
+    #[case::half_the_deadline_is_a_wake(500, 1000, ParkExit::Unparked)]
+    #[case::yield_path_never_requested_a_wait(0, 0, ParkExit::TimedOut)]
+    fn test_park_exit_is_inferred_conservatively(
+        #[case] elapsed_us: u64,
+        #[case] requested_us: u64,
+        #[case] expected: ParkExit,
+    ) {
+        assert_eq!(classify_park_exit(elapsed_us, requested_us), expected);
+    }
+
+    #[test]
+    fn test_first_parked_starts_at_the_cursor_and_wraps() {
+        let parked = [false, false, true, false];
+        let at = |i: usize| parked[i];
+        assert_eq!(first_parked_from(0, 4, at), Some(2), "scans forward from the cursor");
+        assert_eq!(first_parked_from(3, 4, at), Some(2), "and wraps around to find it");
+        assert_eq!(first_parked_from(2, 4, at), Some(2), "the cursor itself counts");
+    }
+
+    /// The point of the counter this feeds: when nobody is parked a wake has
+    /// nowhere useful to go, and must be recorded as wasted rather than silently
+    /// spent on a running worker.
+    #[test]
+    fn test_first_parked_reports_none_when_every_worker_is_running() {
+        assert_eq!(first_parked_from(0, 3, |_| false), None);
+    }
+
+    /// Wakes stay inside the active window, exactly as `wake_target` does -- a
+    /// capped worker will not take Phase 2 work, so waking it is the same lost
+    /// wake by another route.
+    #[test]
+    fn test_first_parked_ignores_workers_outside_the_active_limit() {
+        let parked = [false, false, true, true];
+        let at = |i: usize| parked[i];
+        assert_eq!(
+            first_parked_from(0, 2, at),
+            None,
+            "workers 2 and 3 are parked but capped out of Phase 2"
+        );
+        assert_eq!(first_parked_from(0, 3, at), Some(2));
+    }
+
+    #[test]
+    fn test_first_parked_tolerates_an_empty_pool() {
+        assert_eq!(first_parked_from(0, 0, |_| true), None);
+        assert_eq!(first_parked_from(5, 0, |_| true), None, "a zero limit admits nobody");
     }
 }

--- a/crates/fgumi-sort/src/merge_trace.rs
+++ b/crates/fgumi-sort/src/merge_trace.rs
@@ -105,6 +105,18 @@ impl DurationHistogram {
         self.total_nanos.fetch_add(nanos, Ordering::Relaxed);
     }
 
+    /// Record one *count* observation (a queue depth, a run length) into a
+    /// histogram built for durations, scaling one unit to [`BLOCKS_TO_NANOS`]
+    /// so counts land in the microsecond lane the log2 bucketing is built
+    /// around. Without the scale every count below `BLOCKS_TO_NANOS` buckets to
+    /// zero and both the mean and the tail read as zero.
+    ///
+    /// Read the result back with [`HistogramReport::summary_blocks`], never
+    /// [`HistogramReport::summary`] -- the latter labels these as durations.
+    pub(crate) fn record_count(&self, count: u64) {
+        self.record(count.saturating_mul(BLOCKS_TO_NANOS));
+    }
+
     /// Time `f`, recording how long it took, and return its value.
     pub(crate) fn time<R>(&self, f: impl FnOnce() -> R) -> R {
         let start = Instant::now();
@@ -549,7 +561,7 @@ impl ConsumerTraceStats {
     /// Read the result back with [`HistogramReport::summary_blocks`], never
     /// [`HistogramReport::summary`] -- the latter labels these as durations.
     pub(crate) fn record_source_run(&self, blocks: u64) {
-        self.source_run_length.record(blocks.saturating_mul(BLOCKS_TO_NANOS));
+        self.source_run_length.record_count(blocks);
     }
 
     pub(crate) fn snapshot(&self) -> ConsumerTraceReport {
@@ -704,6 +716,44 @@ mod tests {
         assert_eq!(report.percentile_micros(1.00), 8192);
     }
 
+    /// A queue depth is a single-digit count. Recording it raw drops every
+    /// observation into bucket 0 and the report reads zero -- the merge-trace
+    /// bug this guards. [`DurationHistogram::record_count`] scales one unit to
+    /// [`BLOCKS_TO_NANOS`] first, so the mean and the tail read as the depths
+    /// themselves.
+    #[test]
+    fn test_record_count_scales_small_counts_out_of_the_zero_bucket() {
+        let depths = [2_u64, 3, 4, 9];
+
+        // Raw counts collapse: every depth below `BLOCKS_TO_NANOS` buckets to
+        // zero, so the mean rounds to 0.0 and the tail is a flat zero.
+        let raw = DurationHistogram::default();
+        for &depth in &depths {
+            raw.record(depth);
+        }
+        let raw = raw.snapshot();
+        assert_eq!(raw.count, 4);
+        assert_eq!(format!("{:.1}", raw.mean_micros()), "0.0", "raw counts read as zero");
+        assert_eq!(raw.percentile_micros(1.0), 0, "raw counts collapse to a zero tail");
+
+        // Scaled through `record_count`, the same depths read back as blocks.
+        let scaled = DurationHistogram::default();
+        for &depth in &depths {
+            scaled.record_count(depth);
+        }
+        let scaled = scaled.snapshot();
+        assert_eq!(scaled.count, 4);
+        // (2 + 3 + 4 + 9) / 4 = 4.5 blocks, reported exactly.
+        assert!((scaled.mean_micros() - 4.5).abs() < 0.01, "{}", scaled.mean_micros());
+        // Bucketed as if microseconds, so the tail reads as blocks (log2 floor).
+        assert_eq!(scaled.percentile_micros(1.0), 8);
+        assert_eq!(
+            scaled.summary_blocks(),
+            "n=4 total=18 blocks mean=4.5 p50=2 p90=8 p99=8",
+            "the depth line must read as blocks"
+        );
+    }
+
     /// A mean alone cannot tell these two apart, and they have different
     /// causes: one is uniformly slow, the other is fast with a bad tail.
     #[test]
@@ -845,6 +895,46 @@ mod tests {
         assert_eq!(report.idle_file_parks(), 1);
         assert_eq!(report.in_flight_at_park[MAX_TRACKED_IN_FLIGHT], 1);
         assert_eq!(report.park_by_state[AwaitedState::Decompressing as usize].count, 3);
+    }
+
+    /// Park time per state, not just park count.
+    ///
+    /// The two disagree and only one is a cost: the park-supply census had a class
+    /// that was 41% of parks and 13% of park time, and reading the counts picked a
+    /// fix that then measured at 0.06%. These nanoseconds were collected from the
+    /// start and reported one log level down, so every experiment in that
+    /// investigation had the answer and none printed it.
+    #[test]
+    fn test_consumer_trace_carries_park_time_per_state_not_only_counts() {
+        let stats = ConsumerTraceStats::default();
+        // Many cheap parks in one state, one expensive park in another: the count
+        // majority and the time majority are deliberately opposite.
+        for _ in 0..10 {
+            stats.record_park(AwaitedState::Decompressing, 1_000, 1);
+        }
+        stats.record_park(AwaitedState::RawQueued, 500_000, 0);
+
+        let report = stats.snapshot();
+        let decomp = report.park_by_state[AwaitedState::Decompressing as usize];
+        let raw = report.park_by_state[AwaitedState::RawQueued as usize];
+
+        assert_eq!(decomp.count, 10, "counts say Decompressing dominates 10:1");
+        assert_eq!(raw.count, 1);
+        assert!(
+            (decomp.total_secs() - 10e-6).abs() < 1e-12,
+            "10 parks of 1us is 10us, got {}",
+            decomp.total_secs()
+        );
+        assert!(
+            (raw.total_secs() - 500e-6).abs() < 1e-12,
+            "one park of 500us is 500us, got {}",
+            raw.total_secs()
+        );
+        assert!(
+            raw.total_secs() > decomp.total_secs() * 40.0,
+            "time says RawQueued dominates 50:1 -- the opposite of the counts, which is \
+             precisely the reading that must be available at info level"
+        );
     }
 
     #[test]

--- a/crates/fgumi-sort/src/pooled_bam_writer.rs
+++ b/crates/fgumi-sort/src/pooled_bam_writer.rs
@@ -63,6 +63,17 @@ struct IndexState {
 }
 
 impl PooledBamWriter {
+    /// Writer-side distributions: per-block write, reorder wait, reorder depth.
+    pub(crate) fn writer_stats(
+        &self,
+    ) -> (
+        crate::merge_trace::HistogramReport,
+        crate::merge_trace::HistogramReport,
+        crate::merge_trace::HistogramReport,
+    ) {
+        self.staging.as_ref().map_or_else(Default::default, StagingBuffer::writer_stats)
+    }
+
     /// Seconds the producer spent blocked waiting for an output permit, and the
     /// number of waits.
     ///

--- a/crates/fgumi-sort/src/pooled_bam_writer.rs
+++ b/crates/fgumi-sort/src/pooled_bam_writer.rs
@@ -63,15 +63,16 @@ struct IndexState {
 }
 
 impl PooledBamWriter {
-    /// Writer-side distributions: per-block write, reorder wait, reorder depth.
-    pub(crate) fn writer_stats(
-        &self,
-    ) -> (
-        crate::merge_trace::HistogramReport,
-        crate::merge_trace::HistogramReport,
-        crate::merge_trace::HistogramReport,
-    ) {
-        self.staging.as_ref().map_or_else(Default::default, StagingBuffer::writer_stats)
+    /// The permit pool carrying this writer's histograms, if the writer has not
+    /// yet been finalized.
+    ///
+    /// Retain this [`Arc`] before [`finish`](Self::finish) and read
+    /// [`PermitPool::writer_stats`] afterwards: the pool outlives the writer, so
+    /// the snapshot then includes the block writes and reorder waits performed
+    /// during the output drain that `finish` runs — a snapshot taken through the
+    /// live writer would omit that tail.
+    pub(crate) fn permit_pool(&self) -> Option<Arc<PermitPool>> {
+        self.staging.as_ref().map(|staging| Arc::clone(staging.permit_pool()))
     }
 
     /// Seconds the producer spent blocked waiting for an output permit, and the
@@ -621,6 +622,51 @@ mod tests {
             .expect("records should read cleanly")
             .len();
         assert_eq!(record_count, num_records);
+
+        if let Ok(pool) = Arc::try_unwrap(pool) {
+            pool.shutdown();
+        }
+    }
+
+    /// The writer histograms must be harvested *after* `finish` drains the output
+    /// queue, not before: the drain flushes the final partial block (and any
+    /// still-queued blocks) through the I/O thread, so a snapshot taken while the
+    /// writer is still alive omits those drain-time writes. Retaining the permit
+    /// pool and reading [`PermitPool::writer_stats`] after `finish` captures the
+    /// full write count.
+    #[test]
+    fn test_writer_stats_include_finish_drain() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let bam_path = dir.path().join("drain.bam");
+        let header = test_header();
+        let pool = Arc::new(SortWorkerPool::new(4, 1, 6, crate::codec::SpillCodec::Bgzf));
+
+        // Retain the permit pool before finalizing, exactly as the merge path does,
+        // and snapshot the block-write count both before and after the drain.
+        let (before, after) = {
+            let mut writer =
+                PooledBamWriter::new(Arc::clone(&pool), &bam_path, &header).expect("create writer");
+            for i in 0..5000 {
+                let rec = make_test_record(format!("read_{i:06}").as_bytes(), 100);
+                writer.write_raw_record(&rec).expect("write record");
+            }
+            let permit_pool = writer.permit_pool().expect("permit pool present before finish");
+
+            let before = permit_pool.writer_stats().0.count;
+            writer.finish().expect("finish writer");
+            let after = permit_pool.writer_stats().0.count;
+            (before, after)
+        };
+
+        // The final flush and drain happen inside `finish`, so the post-drain
+        // count must exceed the pre-drain count -- the exact regression the
+        // pre-finalize snapshot silently dropped.
+        assert!(after > 0, "drain-inclusive snapshot must record block writes, got {after}");
+        assert!(
+            after > before,
+            "finish drain must add block writes the pre-finish snapshot missed: \
+             before={before}, after={after}"
+        );
 
         if let Ok(pool) = Arc::try_unwrap(pool) {
             pool.shutdown();

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -515,14 +515,6 @@ pub(crate) struct PermitPool {
     /// finally surfaced. This never produced wrong output or a hang; it just
     /// wasted work on the failure path.
     closed: AtomicBool,
-    /// Nanoseconds producers spent blocked waiting for a permit, and how many
-    /// waits that was.
-    ///
-    /// This is the *output* backpressure stall. On the merge it lands on the
-    /// consumer thread -- the one thread that touches every record -- so it is
-    /// directly on the critical path, and it was previously invisible: the
-    /// sampled sub-phase breakdown folded it into "enqueue write", which is
-    /// documented as a handoff that excludes compression.
     /// Writing one compressed block to the file.
     ///
     /// Lives here rather than on the pool because the I/O writer thread already
@@ -534,6 +526,14 @@ pub(crate) struct PermitPool {
     pub(crate) write_reorder_wait: crate::merge_trace::DurationHistogram,
     /// Blocks held in that map, sampled on each arrival. Read "us" as "blocks".
     pub(crate) write_reorder_depth: crate::merge_trace::DurationHistogram,
+    /// Nanoseconds producers spent blocked waiting for a permit, and how many
+    /// waits that was.
+    ///
+    /// This is the *output* backpressure stall. On the merge it lands on the
+    /// consumer thread -- the one thread that touches every record -- so it is
+    /// directly on the critical path, and it was previously invisible: the
+    /// sampled sub-phase breakdown folded it into "enqueue write", which is
+    /// documented as a handoff that excludes compression.
     blocked_nanos: AtomicU64,
     blocked_waits: AtomicU64,
 }
@@ -596,6 +596,27 @@ impl PermitPool {
         #[allow(clippy::cast_precision_loss, reason = "nanosecond totals stay far below 2^52")]
         let secs = nanos as f64 / 1e9;
         (secs, self.blocked_waits.load(Ordering::Relaxed))
+    }
+
+    /// Writer-side distributions: per-block write, reorder wait, reorder depth.
+    ///
+    /// Read from the pool rather than the writer's staging buffer because the
+    /// pool outlives `PooledBamWriter::finish`, which consumes the staging: the
+    /// output drain happens inside `finish`, so a snapshot taken through the
+    /// still-live writer would omit every block written and every reorder wait
+    /// incurred during the drain.
+    pub(crate) fn writer_stats(
+        &self,
+    ) -> (
+        crate::merge_trace::HistogramReport,
+        crate::merge_trace::HistogramReport,
+        crate::merge_trace::HistogramReport,
+    ) {
+        (
+            self.write_dur.snapshot(),
+            self.write_reorder_wait.snapshot(),
+            self.write_reorder_depth.snapshot(),
+        )
     }
 
     /// Release a permit back to the pool after a block has been written to disk.
@@ -1437,13 +1458,10 @@ pub(crate) struct SharedPipelineState {
     /// The recoverable half: targeting a parked worker would have delivered these.
     /// A wake with nobody parked at all is not the targeting rule's fault.
     pub(crate) wakes_recoverable: AtomicU64,
-    /// Critical-path awaited claims, split by how the serving worker's park ended.
-    ///
-    /// `from_timeout` winning means the wake never reached anyone and recruitment
-    /// latency is set by the backoff, not by unpark cost. Inferred -- see
-    /// [`crate::merge_stalls::classify_park_exit`].
-    pub(crate) awaited_from_unpark: AtomicU64,
-    pub(crate) awaited_from_timeout: AtomicU64,
+    /// Consumer parks split by what the pool looked like at the instant of the
+    /// park: a sleeper was available, everyone was busy compressing, or everyone
+    /// was busy merging. See [`crate::merge_stalls::ParkSupply`].
+    pub(crate) park_supply: crate::merge_stalls::ParkSupplyCensus,
 
     /// Read batches taken at the deep frontier allowance, and the blocks they
     /// returned; and the same for batches taken at the uniform allowance.
@@ -1528,8 +1546,7 @@ impl SharedPipelineState {
             worker_parked: (0..num_workers).map(|_| AtomicBool::new(false)).collect(),
             wakes_on_running_worker: AtomicU64::new(0),
             wakes_recoverable: AtomicU64::new(0),
-            awaited_from_unpark: AtomicU64::new(0),
-            awaited_from_timeout: AtomicU64::new(0),
+            park_supply: crate::merge_stalls::ParkSupplyCensus::default(),
             deep_read_batches: AtomicU64::new(0),
             deep_read_blocks: AtomicU64::new(0),
             shallow_read_batches: AtomicU64::new(0),
@@ -1554,19 +1571,6 @@ impl SharedPipelineState {
         }
     }
 
-    /// Wake one idle worker, rotating which one.
-    ///
-    /// The consumer calls this the instant a reorder buffer drains. Without it
-    /// the wake path runs one way — workers to main thread — so a file that
-    /// runs dry waits out an idle worker's backoff (up to [`MAX_BACKOFF_US`])
-    /// before anyone even looks at it. That wait is pure latency: the work is
-    /// available and unclaimed.
-    ///
-    /// One worker, not all: the refill it needs to start is a disk read, which
-    /// is serialized by the file's reader mutex anyway, and a woken worker
-    /// resets its own backoff to [`MIN_BACKOFF_US`] on success and so stays hot
-    /// for the blocks that follow. Waking the whole pool would spend N fruitless
-    /// scans to get the one read that matters.
     /// Wake the merge consumer, stamping when it became runnable.
     ///
     /// Every consumer wake goes through here so the park decomposition cannot
@@ -1587,6 +1591,19 @@ impl SharedPipelineState {
         self.main_thread_handle.unpark();
     }
 
+    /// Wake one idle worker, rotating which one.
+    ///
+    /// The consumer calls this the instant a reorder buffer drains. Without it
+    /// the wake path runs one way — workers to main thread — so a file that
+    /// runs dry waits out an idle worker's backoff (up to [`MAX_BACKOFF_US`])
+    /// before anyone even looks at it. That wait is pure latency: the work is
+    /// available and unclaimed.
+    ///
+    /// One worker, not all: the refill it needs to start is a disk read, which
+    /// is serialized by the file's reader mutex anyway, and a woken worker
+    /// resets its own backoff to [`MIN_BACKOFF_US`] on success and so stays hot
+    /// for the blocks that follow. Waking the whole pool would spend N fruitless
+    /// scans to get the one read that matters.
     pub(crate) fn wake_one_worker(&self) {
         if self.worker_threads.is_empty() {
             return;
@@ -1616,13 +1633,19 @@ impl SharedPipelineState {
         }
     }
 
-    /// Record which kind of park exit produced a critical-path awaited claim.
-    pub(crate) fn record_awaited_recruitment(&self, exit: crate::merge_stalls::ParkExit) {
-        let counter = match exit {
-            crate::merge_stalls::ParkExit::Unparked => &self.awaited_from_unpark,
-            crate::merge_stalls::ParkExit::TimedOut => &self.awaited_from_timeout,
-        };
-        counter.fetch_add(1, Ordering::Relaxed);
+    /// How many workers are parked right now, and whether output compression is
+    /// queued -- the two facts that say why nobody had already started on the
+    /// block the consumer is about to wait for.
+    ///
+    /// Scans the parked flags rather than keeping a running count: it runs once
+    /// per consumer park against at most `SORT_MAX_THREADS` relaxed loads, and a
+    /// counter would need an atomic add on both sides of every worker's wait --
+    /// the far hotter path.
+    pub(crate) fn park_supply_now(&self) -> crate::merge_stalls::ParkSupply {
+        let limit = self.active_worker_limit.load(Ordering::Acquire);
+        let width = limit.min(self.worker_parked.len());
+        let parked = (0..width).filter(|&i| self.worker_parked[i].load(Ordering::Relaxed)).count();
+        crate::merge_stalls::classify_park_supply(parked, self.compress_queue.len())
     }
 
     /// Which worker slot the next wake should target.
@@ -1720,10 +1743,6 @@ struct SortWorkerState {
     /// Monotonic counter incremented on each idle sleep; mixed with `worker_id` to
     /// produce per-worker jitter so all workers don't wake simultaneously.
     idle_iter: u64,
-    /// How this worker's last Phase 2 park ended, inferred from elapsed vs
-    /// requested. Read when the worker wins a critical-path awaited claim, to
-    /// say whether the wake path or the backoff timer recruited it.
-    last_park_exit: crate::merge_stalls::ParkExit,
     /// The wait the previous loop iteration took, if it waited. Taken (and
     /// cleared) by the next iteration that finds work, which is what makes that
     /// wait "productive" — see [`crate::merge_stalls::WakeLatencyStats`].
@@ -1869,11 +1888,24 @@ fn get_sort_priorities(bp: &SortBackpressureState) -> &'static [SortStep] {
 /// Where the consumer's wakes went, and what recruited the worker that served
 /// the critical path.
 ///
-/// A wake aimed at an already-running worker does nothing; the consumer then
-/// waits for some other worker's backoff to expire, which is bounded by
-/// [`MAX_BACKOFF_US`] rather than by unpark cost. `from_timeout` exceeding
-/// `from_unpark` therefore means recruitment latency is set by the backoff timer
-/// and tuning the wake cannot help.
+/// **These numbers do not explain the merge's idle time. Measured, both regimes.**
+/// A wake aimed at an already-running worker does nothing, which looks like a
+/// defect worth fixing until both thread counts are measured:
+///
+/// | | t8 (fast) | t16 (slow) |
+/// | --- | --- | --- |
+/// | hit an already-running worker | **100%** | 88% |
+/// | a parked worker was available | **0%** | 27% |
+/// | consumer's wait for a worker | **10us** | 72us |
+///
+/// t8 scores worse on every count and waits 7x less, because at 91% utilization
+/// there is nobody parked to hit and a running worker reaches the awaited file
+/// almost at once. So "wakes land on busy workers" is what a *healthy* pool looks
+/// like, and targeting parked workers is not the fix for t16.
+///
+/// Kept because they are cheap and because rediscovering this costs a machine
+/// day. What does separate the regimes is
+/// [`crate::merge_stalls::ParkSupply`].
 #[derive(Debug, Clone, Copy)]
 pub struct WakeAccounting {
     /// Wakes issued.
@@ -1882,10 +1914,6 @@ pub struct WakeAccounting {
     pub on_running: u64,
     /// The subset of `on_running` where a parked worker existed and was skipped.
     pub recoverable: u64,
-    /// Critical-path awaited claims by a worker our wake cut short.
-    pub from_unpark: u64,
-    /// Critical-path awaited claims by a worker whose own backoff expired.
-    pub from_timeout: u64,
 }
 
 pub(crate) const MIN_BACKOFF_US: u64 = 10;
@@ -1910,17 +1938,12 @@ pub(crate) const MAX_BACKOFF_US: u64 = 1000;
 /// a spurious early wake, which costs one scan and is harmless — the caller
 /// loops.
 ///
-/// Returns the wait it actually asked for, in microseconds, or 0 on the
-/// `yield_now` path. The caller needs it to tell an unpark from a timeout: the
-/// jitter is applied here, so only this function knows the real deadline.
-fn idle_wait_with_jitter(backoff_us: u64, worker_id: usize, iter: u64) -> u64 {
+fn idle_wait_with_jitter(backoff_us: u64, worker_id: usize, iter: u64) {
     if backoff_us <= MIN_BACKOFF_US {
         std::thread::yield_now();
-        0
     } else {
         let actual_us = jittered_wait_micros(backoff_us, worker_id, iter);
         std::thread::park_timeout(std::time::Duration::from_micros(actual_us));
-        actual_us
     }
 }
 
@@ -2100,7 +2123,6 @@ impl SortWorkerPool {
                         held_raw_input_blocks: Vec::new(),
                         held_decompressed_input: None,
                         backoff_us: MIN_BACKOFF_US,
-                        last_park_exit: crate::merge_stalls::ParkExit::TimedOut,
                         served_awaited: false,
                         won_awaited_claim: false,
                         idle_iter: 0,
@@ -2131,29 +2153,22 @@ impl SortWorkerPool {
         }
     }
 
-    /// Park for the current backoff, publish the parked state, and record how
-    /// the park ended. Returns the elapsed park in nanoseconds.
+    /// Park for the current backoff, publish the parked state, and return the
+    /// elapsed park in nanoseconds.
     ///
     /// `worker_parked` is set before the wait and cleared after, so the window
     /// the wake path reads as "parked" is a superset of the real one: a wake is
     /// never withheld from a worker that is about to park. The reverse error --
     /// reading "running" for a worker that has just parked -- would lose a wake,
     /// so the asymmetry is deliberate.
-    ///
-    /// The exit classification needs the *jittered* deadline, which only
-    /// `idle_wait_with_jitter` knows, so it is returned rather than recomputed.
-    fn park_and_classify(shared: &SharedPipelineState, worker: &mut SortWorkerState) -> u64 {
+    fn park_and_measure(shared: &SharedPipelineState, worker: &mut SortWorkerState) -> u64 {
         let idle_start = Instant::now();
         shared.worker_parked[worker.worker_id].store(true, Ordering::Relaxed);
-        let requested_us =
-            idle_wait_with_jitter(worker.backoff_us, worker.worker_id, worker.idle_iter);
+        idle_wait_with_jitter(worker.backoff_us, worker.worker_id, worker.idle_iter);
         shared.worker_parked[worker.worker_id].store(false, Ordering::Relaxed);
         worker.idle_iter = worker.idle_iter.wrapping_add(1);
         worker.backoff_us = (worker.backoff_us * 2).min(MAX_BACKOFF_US);
-        let idle_ns = Self::nanos_u64(idle_start.elapsed());
-        worker.last_park_exit =
-            crate::merge_stalls::classify_park_exit(idle_ns / 1_000, requested_us);
-        idle_ns
+        Self::nanos_u64(idle_start.elapsed())
     }
 
     // ========================================================================
@@ -2196,11 +2211,7 @@ impl SortWorkerPool {
                 if Self::try_advance_all_held(shared, worker) {
                     worker.backoff_us = MIN_BACKOFF_US;
                 } else {
-                    let _ = idle_wait_with_jitter(
-                        worker.backoff_us,
-                        worker.worker_id,
-                        worker.idle_iter,
-                    );
+                    idle_wait_with_jitter(worker.backoff_us, worker.worker_id, worker.idle_iter);
                     worker.idle_iter = worker.idle_iter.wrapping_add(1);
                     worker.backoff_us = (worker.backoff_us * 2).min(MAX_BACKOFF_US);
                 }
@@ -2213,8 +2224,7 @@ impl SortWorkerPool {
             // 2. Check phase completion — wait for next phase, only exit on SHUTDOWN.
             //    Workers must survive across Phase 1 → Phase 2 transitions.
             if Self::is_phase_complete(shared, current_phase) && !worker.has_any_held_items() {
-                let _ =
-                    idle_wait_with_jitter(worker.backoff_us, worker.worker_id, worker.idle_iter);
+                idle_wait_with_jitter(worker.backoff_us, worker.worker_id, worker.idle_iter);
                 worker.idle_iter = worker.idle_iter.wrapping_add(1);
                 worker.backoff_us = (worker.backoff_us * 2).min(MAX_BACKOFF_US);
                 // Waiting for the next phase, not for work — see above.
@@ -2308,15 +2318,11 @@ impl SortWorkerPool {
                 }
                 if worker.won_awaited_claim {
                     pstats.record_awaited_claim(worker.worker_id);
-                    // Whether the wake path or the backoff timer recruited this
-                    // worker is the difference between a fixable wake and an
-                    // irreducible one.
-                    shared.record_awaited_recruitment(worker.last_park_exit);
                 }
                 worker.backoff_us = MIN_BACKOFF_US;
             } else {
                 let slept_us = worker.backoff_us;
-                let idle_ns = Self::park_and_classify(shared, worker);
+                let idle_ns = Self::park_and_measure(shared, worker);
                 pstats.record_idle(worker.worker_id, idle_ns);
                 shared.wake_latency.record_sleep(wake_phase(current_phase), slept_us, idle_ns);
                 worker.last_wait = Some(PendingWait { phase: current_phase, nanos: idle_ns });
@@ -3341,8 +3347,6 @@ impl SortWorkerPool {
         (mean, cap, batch)
     }
 
-    /// Why worker scans passed over the file the consumer was parked on,
-    /// as `[raw-lock, raw-empty, decomp-lock, decomp-capped]`.
     /// Where the merge consumer's park time went, split into additive stages.
     pub(crate) fn park_attribution_report(&self) -> crate::merge_stalls::ParkAttributionReport {
         self.shared.park_attribution.snapshot()
@@ -3370,14 +3374,17 @@ impl SortWorkerPool {
         &self.shared.stage_latency
     }
 
-    /// Where the consumer's wakes landed, and what actually recruited a worker.
+    /// Consumer parks split by what the pool looked like when the park began.
+    pub(crate) fn park_supply_report(&self) -> crate::merge_stalls::ParkSupplyReport {
+        self.shared.park_supply.snapshot()
+    }
+
+    /// Where the consumer's wakes landed.
     pub(crate) fn wake_accounting(&self) -> WakeAccounting {
         WakeAccounting {
             issued: self.shared.wakes_issued.load(Ordering::Relaxed),
             on_running: self.shared.wakes_on_running_worker.load(Ordering::Relaxed),
             recoverable: self.shared.wakes_recoverable.load(Ordering::Relaxed),
-            from_unpark: self.shared.awaited_from_unpark.load(Ordering::Relaxed),
-            from_timeout: self.shared.awaited_from_timeout.load(Ordering::Relaxed),
         }
     }
 
@@ -3386,6 +3393,8 @@ impl SortWorkerPool {
         self.shared.wakes_issued.load(Ordering::Relaxed)
     }
 
+    /// Why worker scans passed over the file the consumer was parked on,
+    /// as `[raw-lock, raw-empty, decomp-lock, decomp-capped]`.
     pub(crate) fn awaited_skip_counts(&self) -> [u64; 4] {
         std::array::from_fn(|i| self.shared.awaited_skips[i].load(Ordering::Relaxed))
     }

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -523,6 +523,17 @@ pub(crate) struct PermitPool {
     /// directly on the critical path, and it was previously invisible: the
     /// sampled sub-phase breakdown folded it into "enqueue write", which is
     /// documented as a handoff that excludes compression.
+    /// Writing one compressed block to the file.
+    ///
+    /// Lives here rather than on the pool because the I/O writer thread already
+    /// holds this `Arc`, and one pool per writer keeps the output writer's stats
+    /// from being mixed with a spill writer's.
+    pub(crate) write_dur: crate::merge_trace::DurationHistogram,
+    /// How long a block sat in the writer's reorder map waiting for an earlier
+    /// serial to arrive.
+    pub(crate) write_reorder_wait: crate::merge_trace::DurationHistogram,
+    /// Blocks held in that map, sampled on each arrival. Read "us" as "blocks".
+    pub(crate) write_reorder_depth: crate::merge_trace::DurationHistogram,
     blocked_nanos: AtomicU64,
     blocked_waits: AtomicU64,
 }
@@ -538,6 +549,9 @@ impl PermitPool {
             tx: std::sync::Mutex::new(Some(tx)),
             rx,
             closed: AtomicBool::new(false),
+            write_dur: crate::merge_trace::DurationHistogram::default(),
+            write_reorder_wait: crate::merge_trace::DurationHistogram::default(),
+            write_reorder_depth: crate::merge_trace::DurationHistogram::default(),
             blocked_nanos: AtomicU64::new(0),
             blocked_waits: AtomicU64::new(0),
         }
@@ -634,6 +648,37 @@ pub(crate) const PHASE2_RAW_CAP: usize = 8;
 /// `ZSTD_FRAME_DECOMP_CAP` (256 KB) for zstd frames. This is a soft cap — the
 /// "always accept the next-expected serial" rule lets it transiently exceed by
 /// up to ~`num_workers` blocks per file.
+/// **Filling this cap was measured, and it is a large regression. Do not retry.**
+///
+/// The pool sits ~0.84 blocks deep on the awaited file while permitted 8, and
+/// `decomp-capped` is 2% at t8 -- an obvious invitation to make each claim serve
+/// several blocks from the file it already walked to, amortizing the 77.2
+/// fruitless file visits every claim pays. Measured on `1kg-wgs-HG00096`,
+/// template-coordinate, 89 spill runs, paired controls in one session:
+///
+/// | arm | grab depth | wasted visits/block | merge wall | util |
+/// | --- | --- | --- | --- | --- |
+/// | t8, one block per claim | 1.00 | 77.6 | 193.8s | 91% |
+/// | t8, up to 8 per claim | 6.07 (p50 8) | **10.6** | **263.7s (+36%)** | 66% |
+/// | t16, one block per claim | 1.00 | 41.5 | 169.5s | 52% |
+/// | t16, up to 8 per claim | 3.16 (p50 2) | 12.6 | 171.8s (+1.4%) | 51% |
+///
+/// The target metric moved 7.3x and the sort got 36% slower. **This cap is per
+/// file, so depth bought on file X does nothing for a consumer parked on file
+/// Y** -- and it consumes the pool capacity that would otherwise have issued Y's
+/// disk read. `fully-buffered` scan skips rose 10x (8.6M -> 83.6M): workers
+/// scan, find every buffer at cap, and sleep, while the awaited file sits
+/// `raw-empty` 98% of the times it is passed over (33% before). Utilization
+/// *falls* to 66% -- idle workers and a consumer waiting 158s for one.
+///
+/// At t16 the grab could not even deepen (3.16, p50 2) because `decomp-capped`
+/// is already 66% there. Raising the cap instead is also measured negative: 8 to
+/// 32 cost 1.3%. And `blocks ready on the awaited file at resume` -- the
+/// invariant no intervention in this campaign has moved -- stayed at 0.81.
+///
+/// The lesson generalizes past this knob: per-file depth is the wrong currency
+/// when the consumer needs one specific file's next serial. Breadth is what
+/// keeps that file served.
 pub(crate) const PHASE2_DECOMP_CAP: usize = 8;
 
 /// Number of raw blocks to read from disk per `ReadRawBlocks` call.
@@ -1355,6 +1400,8 @@ pub(crate) struct SharedPipelineState {
     /// slot that is still empty simply cannot be woken yet, which is harmless
     /// because a worker that has not reached its loop is not sleeping either.
     worker_threads: Vec<std::sync::OnceLock<std::thread::Thread>>,
+    /// Per-stage latency distributions and wasted-scan accounting.
+    pub(crate) stage_latency: crate::merge_phases::StageLatency,
     /// When the first worker claimed a block for the awaited source during the
     /// consumer's current park, or 0 if none has. Reset by the consumer at park.
     pub(crate) awaited_claim_nanos: AtomicU64,
@@ -1452,6 +1499,7 @@ impl SharedPipelineState {
             shallow_read_blocks: AtomicU64::new(0),
             phase2_lowest_active: AtomicUsize::new(0),
             phase2_awaited_source: AtomicUsize::new(NO_AWAITED_SOURCE),
+            stage_latency: crate::merge_phases::StageLatency::default(),
             awaited_claim_nanos: AtomicU64::new(0),
             awaited_publish_nanos: AtomicU64::new(0),
             park_attribution: crate::merge_stalls::ParkAttribution::default(),
@@ -2558,6 +2606,10 @@ impl SortWorkerPool {
             let pop_skip = match Self::try_pop_raw_for_decompress(file) {
                 Err(skip) => skip,
                 Ok(entry) => {
+                    // `offset` files gave nothing before this one did. The scan
+                    // tally is published only on fruitless scans, so without this
+                    // the walk to a *successful* claim went uncounted.
+                    shared.stage_latency.record_claim(offset as u64);
                     worker.phase2_file_cursor = (i + 1) % n;
                     worker.served_awaited =
                         shared.phase2_awaited_source.load(Ordering::Relaxed) == i;
@@ -2692,7 +2744,7 @@ impl SortWorkerPool {
             // dispatched on the codec but the failure is handled once. The two
             // arms previously carried identical error handling differing only
             // in one word of the message, which had to be kept in step by hand.
-            let read = match file.codec {
+            let read = shared.stage_latency.read.time(|| match file.codec {
                 SpillCodec::Bgzf => shared
                     .merge_phases
                     .read
@@ -2701,7 +2753,7 @@ impl SortWorkerPool {
                 SpillCodec::Zstd => shared.merge_phases.read.time(|| {
                     read_raw_zstd_frames(&mut reader_guard.inner, read_batch, read_byte_budget)
                 }),
-            };
+            });
             let raw_bytes: Vec<Vec<u8>> = match read {
                 Ok(bytes) => bytes,
                 Err(e) => {
@@ -2783,6 +2835,7 @@ impl SortWorkerPool {
                 shared.refill.read_lag.record(enqueued_nanos.saturating_sub(emptied));
             }
 
+            shared.stage_latency.record_claim(offset as u64);
             worker.phase2_file_cursor = (i + 1) % n;
             // Reading for the awaited file is on the critical path as much as
             // decompressing for it: `raw-empty` is 47-70% of the reasons the pool
@@ -2854,11 +2907,12 @@ impl SortWorkerPool {
         let data = match file.codec {
             SpillCodec::Bgzf => {
                 let raw_block = RawBgzfBlock { data: raw_bytes };
-                match shared
-                    .merge_phases
-                    .decompress
-                    .time(|| decompress_block(&raw_block, &mut worker.decompressor))
-                {
+                match shared.stage_latency.decompress.time(|| {
+                    shared
+                        .merge_phases
+                        .decompress
+                        .time(|| decompress_block(&raw_block, &mut worker.decompressor))
+                }) {
                     Ok(d) => d,
                     Err(e) => {
                         log::error!(
@@ -2877,10 +2931,12 @@ impl SortWorkerPool {
                 if worker.zstd_decompress_buf.len() < ZSTD_FRAME_DECOMP_CAP {
                     worker.zstd_decompress_buf.resize(ZSTD_FRAME_DECOMP_CAP, 0);
                 }
-                match shared.merge_phases.decompress.time(|| {
-                    worker
-                        .zstd_decompressor
-                        .decompress_to_buffer(&raw_bytes, &mut worker.zstd_decompress_buf)
+                match shared.stage_latency.decompress.time(|| {
+                    shared.merge_phases.decompress.time(|| {
+                        worker
+                            .zstd_decompressor
+                            .decompress_to_buffer(&raw_bytes, &mut worker.zstd_decompress_buf)
+                    })
                 }) {
                     // Copy the `n` decompressed bytes (≤ one staging-buffer's
                     // worth, typically ~65 KB) into a fresh Vec for the
@@ -3043,8 +3099,12 @@ impl SortWorkerPool {
         };
         // Only the compression is timed; the handoff below can block on a full
         // result channel, which is writer backpressure rather than CPU work.
-        let compressed =
-            counter.time(|| Self::compress_job(&job, bgzf_compressor, zstd_compressor));
+        let latency = match target {
+            CompressTarget::Spill => &shared.stage_latency.spill_compress,
+            CompressTarget::Output => &shared.stage_latency.output_compress,
+        };
+        let compressed = latency
+            .time(|| counter.time(|| Self::compress_job(&job, bgzf_compressor, zstd_compressor)));
         Self::deliver_compress_result(shared, job, compressed);
         StepResult::Success
     }
@@ -3178,6 +3238,11 @@ impl SortWorkerPool {
                 )
             })
             .collect()
+    }
+
+    /// Per-stage latency distributions and wasted-scan accounting.
+    pub(crate) fn stage_latency(&self) -> &crate::merge_phases::StageLatency {
+        &self.shared.stage_latency
     }
 
     pub(crate) fn awaited_skip_counts(&self) -> [u64; 4] {

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -284,6 +284,16 @@ pub(crate) struct SortPipelineStats {
     pub per_thread_step_counts: Box<[[AtomicU64; SortStep::COUNT]; SORT_MAX_THREADS]>,
     /// Per-thread idle time in nanoseconds (time in backoff/yield).
     pub per_thread_idle_ns: Box<[AtomicU64; SORT_MAX_THREADS]>,
+    /// Nanoseconds each worker spent inside a successful step.
+    ///
+    /// The existing per-thread array counts steps but not their duration, so a
+    /// worker doing few expensive steps was indistinguishable from one doing
+    /// many cheap ones.
+    pub per_thread_busy_ns: Box<[AtomicU64; SORT_MAX_THREADS]>,
+    /// Times each worker was the *first* to claim the block the consumer was
+    /// parked on. Says whether critical-path service is spread across the pool
+    /// or concentrated on a few workers.
+    pub per_thread_awaited_claims: Box<[AtomicU64; SORT_MAX_THREADS]>,
 
     /// Number of worker threads (for display bounds).
     pub num_threads: usize,
@@ -298,6 +308,8 @@ impl SortPipelineStats {
             step_count: std::array::from_fn(|_| AtomicU64::new(0)),
             per_thread_step_counts: new_sort_2d_array(),
             per_thread_idle_ns: new_sort_1d_array(),
+            per_thread_busy_ns: new_sort_1d_array(),
+            per_thread_awaited_claims: new_sort_1d_array(),
             num_threads,
         }
     }
@@ -309,6 +321,14 @@ impl SortPipelineStats {
         self.step_count[step_idx].fetch_add(1, Ordering::Relaxed);
         if thread_id < SORT_MAX_THREADS {
             self.per_thread_step_counts[thread_id][step_idx].fetch_add(1, Ordering::Relaxed);
+            self.per_thread_busy_ns[thread_id].fetch_add(elapsed_ns, Ordering::Relaxed);
+        }
+    }
+
+    /// Credit a worker with first-claiming the consumer's awaited block.
+    pub fn record_awaited_claim(&self, thread_id: usize) {
+        if thread_id < SORT_MAX_THREADS {
+            self.per_thread_awaited_claims[thread_id].fetch_add(1, Ordering::Relaxed);
         }
     }
 
@@ -1335,6 +1355,13 @@ pub(crate) struct SharedPipelineState {
     /// slot that is still empty simply cannot be woken yet, which is harmless
     /// because a worker that has not reached its loop is not sleeping either.
     worker_threads: Vec<std::sync::OnceLock<std::thread::Thread>>,
+    /// When the first worker claimed a block for the awaited source during the
+    /// consumer's current park, or 0 if none has. Reset by the consumer at park.
+    pub(crate) awaited_claim_nanos: AtomicU64,
+    /// When the consumer was last woken, or 0 if not yet during this park.
+    pub(crate) awaited_publish_nanos: AtomicU64,
+    /// Where consumer park time goes, split into additive stages.
+    pub(crate) park_attribution: crate::merge_stalls::ParkAttribution,
     /// Rotates the target of [`Self::wake_one_worker`] so repeated wakes spread
     /// across the pool rather than always hitting worker 0.
     wake_cursor: AtomicUsize,
@@ -1425,6 +1452,9 @@ impl SharedPipelineState {
             shallow_read_blocks: AtomicU64::new(0),
             phase2_lowest_active: AtomicUsize::new(0),
             phase2_awaited_source: AtomicUsize::new(NO_AWAITED_SOURCE),
+            awaited_claim_nanos: AtomicU64::new(0),
+            awaited_publish_nanos: AtomicU64::new(0),
+            park_attribution: crate::merge_stalls::ParkAttribution::default(),
             awaited_skips: std::array::from_fn(|_| AtomicU64::new(0)),
             phase2_read_bytes: AtomicU64::new(0),
             phase2_read_blocks: AtomicU64::new(0),
@@ -1451,6 +1481,26 @@ impl SharedPipelineState {
     /// resets its own backoff to [`MIN_BACKOFF_US`] on success and so stays hot
     /// for the blocks that follow. Waking the whole pool would spend N fruitless
     /// scans to get the one read that matters.
+    /// Wake the merge consumer, stamping when it became runnable.
+    ///
+    /// Every consumer wake goes through here so the park decomposition cannot
+    /// silently miss one of the six unpark sites. The stamp is the moment the
+    /// consumer *could* run, so the gap to it actually resuming is its own wake
+    /// latency rather than fetch time.
+    ///
+    /// Only the first wake in a park is stamped (compare-exchange from 0): a
+    /// park ends on the first wake, and later ones belong to the next park.
+    pub(crate) fn wake_consumer(&self) {
+        let now = self.now_nanos();
+        let _ = self.awaited_publish_nanos.compare_exchange(
+            0,
+            now,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        );
+        self.main_thread_handle.unpark();
+    }
+
     pub(crate) fn wake_one_worker(&self) {
         if self.worker_threads.is_empty() {
             return;
@@ -1564,6 +1614,23 @@ struct SortWorkerState {
     /// cleared) by the next iteration that finds work, which is what makes that
     /// wait "productive" — see [`crate::merge_stalls::WakeLatencyStats`].
     last_wait: Option<PendingWait>,
+    /// Whether the step this iteration completed produced for the file the merge
+    /// consumer was parked on.
+    ///
+    /// Set and read at the two Phase-2 claim sites, where the file index is in
+    /// hand: it gates the `stamp_awaited_claim` call, so only a worker that
+    /// served the awaited file can credit the first claim. The
+    /// productive-wait path reads `won_awaited_claim` instead, not this field.
+    /// Discovery lag is only paid in wall clock on the awaited file — a
+    /// late wake for any other file is absorbed by idle capacity — so without
+    /// this the aggregate lag cannot be told apart from free lag. Cleared at the
+    /// top of every iteration so a stale `true` cannot survive into a step that
+    /// served a different file.
+    served_awaited: bool,
+    /// Whether this worker won the race to first-claim the consumer's awaited
+    /// block this iteration. Credited per thread by the main loop, which is
+    /// where the stats handle is in scope.
+    won_awaited_claim: bool,
 }
 
 impl SortWorkerState {
@@ -1839,7 +1906,7 @@ impl Drop for WorkerPanicGuard {
         }
         // Reached only when the worker loop unwound.
         self.shared.worker_panicked.store(true, Ordering::Release);
-        self.shared.main_thread_handle.unpark();
+        self.shared.wake_consumer();
     }
 }
 
@@ -1891,6 +1958,8 @@ impl SortWorkerPool {
                         held_raw_input_blocks: Vec::new(),
                         held_decompressed_input: None,
                         backoff_us: MIN_BACKOFF_US,
+                        served_awaited: false,
+                        won_awaited_claim: false,
                         idle_iter: 0,
                         last_wait: None,
                     };
@@ -1981,6 +2050,8 @@ impl SortWorkerPool {
             }
 
             let mut did_work = false;
+            worker.served_awaited = false;
+            worker.won_awaited_claim = false;
 
             // 3. Try to advance ALL held items first (deadlock prevention)
             did_work |= Self::try_advance_all_held(shared, worker);
@@ -2061,6 +2132,9 @@ impl SortWorkerPool {
                     shared
                         .wake_latency
                         .record_productive_sleep(wake_phase(current_phase), waited_ns);
+                }
+                if worker.won_awaited_claim {
+                    pstats.record_awaited_claim(worker.worker_id);
                 }
                 worker.backoff_us = MIN_BACKOFF_US;
             } else {
@@ -2222,7 +2296,7 @@ impl SortWorkerPool {
             let pushed =
                 try_advance_held(&shared.decompressed_input, &mut worker.held_decompressed_input);
             if pushed {
-                shared.main_thread_handle.unpark();
+                shared.wake_consumer();
                 advanced = true;
                 // This may have been the last block. Increment `input_blocks_queued` now
                 // that the block is actually in the queue (not held), then re-check the
@@ -2237,7 +2311,7 @@ impl SortWorkerPool {
                     && !shared.decompressed_input_done.load(Ordering::Acquire)
                 {
                     shared.decompressed_input_done.store(true, Ordering::Release);
-                    shared.main_thread_handle.unpark();
+                    shared.wake_consumer();
                 }
             }
         }
@@ -2277,7 +2351,7 @@ impl SortWorkerPool {
                 log::error!("I/O error reading input BAM: {e}");
                 shared.input_read_error.store(true, Ordering::Release);
                 shared.input_eof.store(true, Ordering::Release);
-                shared.main_thread_handle.unpark();
+                shared.wake_consumer();
                 return StepResult::InputEmpty;
             }
         };
@@ -2342,7 +2416,7 @@ impl SortWorkerPool {
                 let total = shared.input_read_serial.load(Ordering::Acquire);
                 if queued >= total {
                     shared.decompressed_input_done.store(true, Ordering::Release);
-                    shared.main_thread_handle.unpark();
+                    shared.wake_consumer();
                 }
             }
             return StepResult::InputEmpty;
@@ -2353,7 +2427,7 @@ impl SortWorkerPool {
             Err(e) => {
                 log::error!("BGZF decompression error (input block serial {serial}): {e}");
                 shared.decompression_error.store(true, Ordering::Release);
-                shared.main_thread_handle.unpark();
+                shared.wake_consumer();
                 return StepResult::InputEmpty;
             }
         };
@@ -2364,13 +2438,13 @@ impl SortWorkerPool {
         // Try to push to decompressed_input ArrayQueue
         let pushed = match shared.decompressed_input.push((serial, data)) {
             Ok(()) => {
-                shared.main_thread_handle.unpark();
+                shared.wake_consumer();
                 true
             }
             Err(item) => {
                 worker.held_decompressed_input = Some(item);
                 // Queue full — wake main thread to drain so we can push next time
-                shared.main_thread_handle.unpark();
+                shared.wake_consumer();
                 false
             }
         };
@@ -2385,7 +2459,7 @@ impl SortWorkerPool {
             let total = shared.input_read_serial.load(Ordering::Acquire);
             if input_eof && raw_empty && queued >= total {
                 shared.decompressed_input_done.store(true, Ordering::Release);
-                shared.main_thread_handle.unpark();
+                shared.wake_consumer();
             }
         }
 
@@ -2485,6 +2559,11 @@ impl SortWorkerPool {
                 Err(skip) => skip,
                 Ok(entry) => {
                     worker.phase2_file_cursor = (i + 1) % n;
+                    worker.served_awaited =
+                        shared.phase2_awaited_source.load(Ordering::Relaxed) == i;
+                    if worker.served_awaited {
+                        worker.won_awaited_claim = Self::stamp_awaited_claim(shared);
+                    }
                     Self::note_claim(shared, file, &entry);
                     return Self::decompress_and_publish(shared, worker, file, i, entry);
                 }
@@ -2705,6 +2784,14 @@ impl SortWorkerPool {
             }
 
             worker.phase2_file_cursor = (i + 1) % n;
+            // Reading for the awaited file is on the critical path as much as
+            // decompressing for it: `raw-empty` is 47-70% of the reasons the pool
+            // passes that file over, so a late wake that ends in a read is a late
+            // wake the consumer paid for.
+            worker.served_awaited = shared.phase2_awaited_source.load(Ordering::Relaxed) == i;
+            if worker.served_awaited {
+                worker.won_awaited_claim = Self::stamp_awaited_claim(shared);
+            }
             return StepResult::Success;
         }
 
@@ -2779,7 +2866,7 @@ impl SortWorkerPool {
                         );
                         shared.decompression_error.store(true, Ordering::Release);
                         file.decomp_in_flight.fetch_sub(1, Ordering::AcqRel);
-                        shared.main_thread_handle.unpark();
+                        shared.wake_consumer();
                         return StepResult::Success;
                     }
                 }
@@ -2807,7 +2894,7 @@ impl SortWorkerPool {
                         );
                         shared.decompression_error.store(true, Ordering::Release);
                         file.decomp_in_flight.fetch_sub(1, Ordering::AcqRel);
-                        shared.main_thread_handle.unpark();
+                        shared.wake_consumer();
                         return StepResult::Success;
                     }
                 }
@@ -2851,9 +2938,23 @@ impl SortWorkerPool {
             // Wake the consumer either because new data is available or because
             // the last in-flight decompression for this file just completed and
             // the file is now fully drained.
-            shared.main_thread_handle.unpark();
+            shared.wake_consumer();
         }
         StepResult::Success
+    }
+
+    /// Stamp the first claim of the consumer's awaited block, and credit the
+    /// worker that made it.
+    ///
+    /// Compare-exchange from 0 so only the first claim in a park is recorded --
+    /// the consumer waits for whichever worker arrives first, so a sum over all
+    /// of them would overcount exactly the way the worker-side lag total does.
+    fn stamp_awaited_claim(shared: &SharedPipelineState) -> bool {
+        let now = shared.now_nanos();
+        shared
+            .awaited_claim_nanos
+            .compare_exchange(0, now, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
     }
 
     /// Try to pop a raw block from `file` for decompression, applying
@@ -2978,7 +3079,7 @@ impl SortWorkerPool {
     ) -> StepResult {
         file.mark_reader_eof(&mut reader_guard);
         drop(reader_guard);
-        shared.main_thread_handle.unpark();
+        shared.wake_consumer();
         Self::maybe_mark_all_eof(shared);
         worker.phase2_file_cursor = (source + 1) % num_sources;
         StepResult::Success
@@ -2990,7 +3091,7 @@ impl SortWorkerPool {
         let total = shared.total_sources.load(Ordering::Acquire);
         if total > 0 && eof_count >= total {
             shared.all_chunks_eof.store(true, Ordering::Release);
-            shared.main_thread_handle.unpark();
+            shared.wake_consumer();
         }
     }
 
@@ -3057,6 +3158,28 @@ impl SortWorkerPool {
 
     /// Why worker scans passed over the file the consumer was parked on,
     /// as `[raw-lock, raw-empty, decomp-lock, decomp-capped]`.
+    /// Where the merge consumer's park time went, split into additive stages.
+    pub(crate) fn park_attribution_report(&self) -> crate::merge_stalls::ParkAttributionReport {
+        self.shared.park_attribution.snapshot()
+    }
+
+    /// Per-worker busy time, idle time and critical-path claims, worker 0 first.
+    ///
+    /// Truncated to the workers this pool actually started, so a 16-thread merge
+    /// does not print 32 rows of zeros.
+    pub(crate) fn per_thread_report(&self) -> Vec<(u64, u64, u64)> {
+        let stats = &self.pipeline_stats;
+        (0..self.num_workers.min(SORT_MAX_THREADS))
+            .map(|w| {
+                (
+                    stats.per_thread_busy_ns[w].load(Ordering::Relaxed),
+                    stats.per_thread_idle_ns[w].load(Ordering::Relaxed),
+                    stats.per_thread_awaited_claims[w].load(Ordering::Relaxed),
+                )
+            })
+            .collect()
+    }
+
     pub(crate) fn awaited_skip_counts(&self) -> [u64; 4] {
         std::array::from_fn(|i| self.shared.awaited_skips[i].load(Ordering::Relaxed))
     }
@@ -3386,7 +3509,7 @@ impl SortWorkerPool {
                     // Worker panicked — set flag and wake main thread so it doesn't
                     // park forever waiting for work that will never arrive.
                     self.shared.worker_panicked.store(true, Ordering::Release);
-                    self.shared.main_thread_handle.unpark();
+                    self.shared.wake_consumer();
                 }
             }
         }

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -1402,6 +1402,12 @@ pub(crate) struct SharedPipelineState {
     worker_threads: Vec<std::sync::OnceLock<std::thread::Thread>>,
     /// Per-stage latency distributions and wasted-scan accounting.
     pub(crate) stage_latency: crate::merge_phases::StageLatency,
+    /// Wakes issued by [`Self::wake_one_worker`].
+    ///
+    /// The denominator for the targeting figures above it: a wake that lands on
+    /// an already-running worker does nothing, so the hit rate is only meaningful
+    /// against how many wakes were issued at all.
+    pub(crate) wakes_issued: AtomicU64,
     /// When the first worker claimed a block for the awaited source during the
     /// consumer's current park, or 0 if none has. Reset by the consumer at park.
     pub(crate) awaited_claim_nanos: AtomicU64,
@@ -1412,6 +1418,32 @@ pub(crate) struct SharedPipelineState {
     /// Rotates the target of [`Self::wake_one_worker`] so repeated wakes spread
     /// across the pool rather than always hitting worker 0.
     wake_cursor: AtomicUsize,
+    /// Whether each worker is currently inside `park_timeout`.
+    ///
+    /// Written by the worker around its own wait and read by the wake path, so a
+    /// stale read is possible and harmless -- it can only misclassify a wake in
+    /// the counters below, never lose one. Set before parking and cleared after,
+    /// so the window that reads "parked" is a superset of the real one.
+    worker_parked: Vec<AtomicBool>,
+    /// Wakes whose rotating target was not parked, so the unpark was a no-op.
+    ///
+    /// The consumer then waits for some *other* worker's backoff to expire, which
+    /// is bounded by [`MAX_BACKOFF_US`] rather than by wake cost. That is the
+    /// difference between recruitment costing microseconds and costing a
+    /// millisecond, and it is invisible in every other counter.
+    pub(crate) wakes_on_running_worker: AtomicU64,
+    /// The subset of those where a parked worker *did* exist and was passed over.
+    ///
+    /// The recoverable half: targeting a parked worker would have delivered these.
+    /// A wake with nobody parked at all is not the targeting rule's fault.
+    pub(crate) wakes_recoverable: AtomicU64,
+    /// Critical-path awaited claims, split by how the serving worker's park ended.
+    ///
+    /// `from_timeout` winning means the wake never reached anyone and recruitment
+    /// latency is set by the backoff, not by unpark cost. Inferred -- see
+    /// [`crate::merge_stalls::classify_park_exit`].
+    pub(crate) awaited_from_unpark: AtomicU64,
+    pub(crate) awaited_from_timeout: AtomicU64,
 
     /// Read batches taken at the deep frontier allowance, and the blocks they
     /// returned; and the same for batches taken at the uniform allowance.
@@ -1493,6 +1525,11 @@ impl SharedPipelineState {
             main_thread_handle,
             worker_threads: (0..num_workers).map(|_| std::sync::OnceLock::new()).collect(),
             wake_cursor: AtomicUsize::new(0),
+            worker_parked: (0..num_workers).map(|_| AtomicBool::new(false)).collect(),
+            wakes_on_running_worker: AtomicU64::new(0),
+            wakes_recoverable: AtomicU64::new(0),
+            awaited_from_unpark: AtomicU64::new(0),
+            awaited_from_timeout: AtomicU64::new(0),
             deep_read_batches: AtomicU64::new(0),
             deep_read_blocks: AtomicU64::new(0),
             shallow_read_batches: AtomicU64::new(0),
@@ -1500,6 +1537,7 @@ impl SharedPipelineState {
             phase2_lowest_active: AtomicUsize::new(0),
             phase2_awaited_source: AtomicUsize::new(NO_AWAITED_SOURCE),
             stage_latency: crate::merge_phases::StageLatency::default(),
+            wakes_issued: AtomicU64::new(0),
             awaited_claim_nanos: AtomicU64::new(0),
             awaited_publish_nanos: AtomicU64::new(0),
             park_attribution: crate::merge_stalls::ParkAttribution::default(),
@@ -1553,14 +1591,38 @@ impl SharedPipelineState {
         if self.worker_threads.is_empty() {
             return;
         }
-        let idx = Self::wake_target(
-            self.wake_cursor.fetch_add(1, Ordering::Relaxed),
-            self.active_worker_limit.load(Ordering::Acquire),
-            self.worker_threads.len(),
-        );
+        self.wakes_issued.fetch_add(1, Ordering::Relaxed);
+        let cursor = self.wake_cursor.fetch_add(1, Ordering::Relaxed);
+        let limit = self.active_worker_limit.load(Ordering::Acquire);
+        let idx = Self::wake_target(cursor, limit, self.worker_threads.len());
+        // Accounting only -- the target is unchanged. A wake aimed at a worker
+        // that is already running does nothing, and the consumer then waits for
+        // some other worker's backoff to expire instead. Splitting "landed on a
+        // running worker" from "nobody was parked" separates a targeting defect
+        // from a genuinely saturated pool; only the former is recoverable.
+        if !self.worker_parked[idx].load(Ordering::Relaxed) {
+            self.wakes_on_running_worker.fetch_add(1, Ordering::Relaxed);
+            let width = limit.min(self.worker_parked.len());
+            if crate::merge_stalls::first_parked_from(cursor, width, |i| {
+                self.worker_parked[i].load(Ordering::Relaxed)
+            })
+            .is_some()
+            {
+                self.wakes_recoverable.fetch_add(1, Ordering::Relaxed);
+            }
+        }
         if let Some(handle) = self.worker_threads[idx].get() {
             handle.unpark();
         }
+    }
+
+    /// Record which kind of park exit produced a critical-path awaited claim.
+    pub(crate) fn record_awaited_recruitment(&self, exit: crate::merge_stalls::ParkExit) {
+        let counter = match exit {
+            crate::merge_stalls::ParkExit::Unparked => &self.awaited_from_unpark,
+            crate::merge_stalls::ParkExit::TimedOut => &self.awaited_from_timeout,
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Which worker slot the next wake should target.
@@ -1658,6 +1720,10 @@ struct SortWorkerState {
     /// Monotonic counter incremented on each idle sleep; mixed with `worker_id` to
     /// produce per-worker jitter so all workers don't wake simultaneously.
     idle_iter: u64,
+    /// How this worker's last Phase 2 park ended, inferred from elapsed vs
+    /// requested. Read when the worker wins a critical-path awaited claim, to
+    /// say whether the wake path or the backoff timer recruited it.
+    last_park_exit: crate::merge_stalls::ParkExit,
     /// The wait the previous loop iteration took, if it waited. Taken (and
     /// cleared) by the next iteration that finds work, which is what makes that
     /// wait "productive" — see [`crate::merge_stalls::WakeLatencyStats`].
@@ -1800,6 +1866,28 @@ fn get_sort_priorities(bp: &SortBackpressureState) -> &'static [SortStep] {
 // ============================================================================
 
 /// Minimum backoff duration in microseconds.
+/// Where the consumer's wakes went, and what recruited the worker that served
+/// the critical path.
+///
+/// A wake aimed at an already-running worker does nothing; the consumer then
+/// waits for some other worker's backoff to expire, which is bounded by
+/// [`MAX_BACKOFF_US`] rather than by unpark cost. `from_timeout` exceeding
+/// `from_unpark` therefore means recruitment latency is set by the backoff timer
+/// and tuning the wake cannot help.
+#[derive(Debug, Clone, Copy)]
+pub struct WakeAccounting {
+    /// Wakes issued.
+    pub issued: u64,
+    /// Wakes whose target was not parked.
+    pub on_running: u64,
+    /// The subset of `on_running` where a parked worker existed and was skipped.
+    pub recoverable: u64,
+    /// Critical-path awaited claims by a worker our wake cut short.
+    pub from_unpark: u64,
+    /// Critical-path awaited claims by a worker whose own backoff expired.
+    pub from_timeout: u64,
+}
+
 pub(crate) const MIN_BACKOFF_US: u64 = 10;
 /// Maximum backoff duration in microseconds (1ms).
 ///
@@ -1821,12 +1909,18 @@ pub(crate) const MAX_BACKOFF_US: u64 = 1000;
 /// A pending unpark token makes the next `park_timeout` return at once. That is
 /// a spurious early wake, which costs one scan and is harmless — the caller
 /// loops.
-fn idle_wait_with_jitter(backoff_us: u64, worker_id: usize, iter: u64) {
+///
+/// Returns the wait it actually asked for, in microseconds, or 0 on the
+/// `yield_now` path. The caller needs it to tell an unpark from a timeout: the
+/// jitter is applied here, so only this function knows the real deadline.
+fn idle_wait_with_jitter(backoff_us: u64, worker_id: usize, iter: u64) -> u64 {
     if backoff_us <= MIN_BACKOFF_US {
         std::thread::yield_now();
+        0
     } else {
         let actual_us = jittered_wait_micros(backoff_us, worker_id, iter);
         std::thread::park_timeout(std::time::Duration::from_micros(actual_us));
+        actual_us
     }
 }
 
@@ -2006,6 +2100,7 @@ impl SortWorkerPool {
                         held_raw_input_blocks: Vec::new(),
                         held_decompressed_input: None,
                         backoff_us: MIN_BACKOFF_US,
+                        last_park_exit: crate::merge_stalls::ParkExit::TimedOut,
                         served_awaited: false,
                         won_awaited_claim: false,
                         idle_iter: 0,
@@ -2034,6 +2129,31 @@ impl SortWorkerPool {
             num_workers,
             spill_codec,
         }
+    }
+
+    /// Park for the current backoff, publish the parked state, and record how
+    /// the park ended. Returns the elapsed park in nanoseconds.
+    ///
+    /// `worker_parked` is set before the wait and cleared after, so the window
+    /// the wake path reads as "parked" is a superset of the real one: a wake is
+    /// never withheld from a worker that is about to park. The reverse error --
+    /// reading "running" for a worker that has just parked -- would lose a wake,
+    /// so the asymmetry is deliberate.
+    ///
+    /// The exit classification needs the *jittered* deadline, which only
+    /// `idle_wait_with_jitter` knows, so it is returned rather than recomputed.
+    fn park_and_classify(shared: &SharedPipelineState, worker: &mut SortWorkerState) -> u64 {
+        let idle_start = Instant::now();
+        shared.worker_parked[worker.worker_id].store(true, Ordering::Relaxed);
+        let requested_us =
+            idle_wait_with_jitter(worker.backoff_us, worker.worker_id, worker.idle_iter);
+        shared.worker_parked[worker.worker_id].store(false, Ordering::Relaxed);
+        worker.idle_iter = worker.idle_iter.wrapping_add(1);
+        worker.backoff_us = (worker.backoff_us * 2).min(MAX_BACKOFF_US);
+        let idle_ns = Self::nanos_u64(idle_start.elapsed());
+        worker.last_park_exit =
+            crate::merge_stalls::classify_park_exit(idle_ns / 1_000, requested_us);
+        idle_ns
     }
 
     // ========================================================================
@@ -2076,7 +2196,11 @@ impl SortWorkerPool {
                 if Self::try_advance_all_held(shared, worker) {
                     worker.backoff_us = MIN_BACKOFF_US;
                 } else {
-                    idle_wait_with_jitter(worker.backoff_us, worker.worker_id, worker.idle_iter);
+                    let _ = idle_wait_with_jitter(
+                        worker.backoff_us,
+                        worker.worker_id,
+                        worker.idle_iter,
+                    );
                     worker.idle_iter = worker.idle_iter.wrapping_add(1);
                     worker.backoff_us = (worker.backoff_us * 2).min(MAX_BACKOFF_US);
                 }
@@ -2089,7 +2213,8 @@ impl SortWorkerPool {
             // 2. Check phase completion — wait for next phase, only exit on SHUTDOWN.
             //    Workers must survive across Phase 1 → Phase 2 transitions.
             if Self::is_phase_complete(shared, current_phase) && !worker.has_any_held_items() {
-                idle_wait_with_jitter(worker.backoff_us, worker.worker_id, worker.idle_iter);
+                let _ =
+                    idle_wait_with_jitter(worker.backoff_us, worker.worker_id, worker.idle_iter);
                 worker.idle_iter = worker.idle_iter.wrapping_add(1);
                 worker.backoff_us = (worker.backoff_us * 2).min(MAX_BACKOFF_US);
                 // Waiting for the next phase, not for work — see above.
@@ -2183,15 +2308,15 @@ impl SortWorkerPool {
                 }
                 if worker.won_awaited_claim {
                     pstats.record_awaited_claim(worker.worker_id);
+                    // Whether the wake path or the backoff timer recruited this
+                    // worker is the difference between a fixable wake and an
+                    // irreducible one.
+                    shared.record_awaited_recruitment(worker.last_park_exit);
                 }
                 worker.backoff_us = MIN_BACKOFF_US;
             } else {
                 let slept_us = worker.backoff_us;
-                let idle_start = Instant::now();
-                idle_wait_with_jitter(slept_us, worker.worker_id, worker.idle_iter);
-                worker.idle_iter = worker.idle_iter.wrapping_add(1);
-                worker.backoff_us = (worker.backoff_us * 2).min(MAX_BACKOFF_US);
-                let idle_ns = Self::nanos_u64(idle_start.elapsed());
+                let idle_ns = Self::park_and_classify(shared, worker);
                 pstats.record_idle(worker.worker_id, idle_ns);
                 shared.wake_latency.record_sleep(wake_phase(current_phase), slept_us, idle_ns);
                 worker.last_wait = Some(PendingWait { phase: current_phase, nanos: idle_ns });
@@ -3243,6 +3368,22 @@ impl SortWorkerPool {
     /// Per-stage latency distributions and wasted-scan accounting.
     pub(crate) fn stage_latency(&self) -> &crate::merge_phases::StageLatency {
         &self.shared.stage_latency
+    }
+
+    /// Where the consumer's wakes landed, and what actually recruited a worker.
+    pub(crate) fn wake_accounting(&self) -> WakeAccounting {
+        WakeAccounting {
+            issued: self.shared.wakes_issued.load(Ordering::Relaxed),
+            on_running: self.shared.wakes_on_running_worker.load(Ordering::Relaxed),
+            recoverable: self.shared.wakes_recoverable.load(Ordering::Relaxed),
+            from_unpark: self.shared.awaited_from_unpark.load(Ordering::Relaxed),
+            from_timeout: self.shared.awaited_from_timeout.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Wakes issued by the consumer to cut a worker's backoff short.
+    pub(crate) fn wakes_issued(&self) -> u64 {
+        self.shared.wakes_issued.load(Ordering::Relaxed)
     }
 
     pub(crate) fn awaited_skip_counts(&self) -> [u64; 4] {


### PR DESCRIPTION
Stacked on #806 (base `nh/merge-read-ahead-on-blocked-file`). **Instrumentation only: no scheduling constant is retuned, no algorithm changes.** It is split out because it is what made the follow-up PR's wins findable, because it is what bounds the headroom that is left, and because it is independently useful for the Phase 1 work that comes next.

The merge is 55-60% of a spill-heavy sort's wall clock, and before this the only measurable thing about its stalls was their total. These four commits partition that total.

## What it adds

- **Consumer park, decomposed into additive segments** that sum to the measured park: waiting for a worker, the work itself, the consumer's own wake, unattributed. Unattributed lands at 0.1%, which is the check that the decomposition is real rather than plausible.
- **A park-supply census** — what the pool looked like at the instant each park began: a worker was asleep / all busy compressing / all busy merging. Also sums to park (92.2s against a measured 92.1s at t16; 119.0 against 118.9 at t8).
- **Per-stage latency distributions** for every merge stage with p50/p90/p99 and exact totals, plus a count of scans that found no work.
- **What the awaited file was doing**, weighted by park *time* rather than park count.
- Wake-targeting hit rates, a per-worker busy/idle/claims table, and a docs-only record of a measured dead end so the next reader does not retry it.

## Why the time-weighting is the whole point

The same classifier read two ways:

| awaited file was… | by park count | by park time |
| --- | --- | --- |
| decompressing | 62% | 0% |
| **starved** (nothing read yet) | 7% | **98-99%** |

The count-majority class is not the cost. `park_by_state` was already a duration histogram, so every experiment ever run against this engine collected the time-weighted number and printed it one level below the default — present in every log, absent from every conclusion drawn from those logs. One commit here does nothing but promote that line to `info`, and it is the commit that ended a long search.

The same trap hit the supply census: by count its largest class is "all busy, compress queued" at 41%, which is 13% of park *time*, while "a worker was asleep" is 81% of the time and a minority of the counts. A scheduling change aimed at the count reading subsequently measured **0.06%**.

## What it costs: nothing measurable

This ships enabled in release builds, including a per-block clock read on the output path over ~5.1M blocks, so the cost is a fair question. `main` against this branch's tip differ by instrumentation only, measured in one boot on `c7g.4xlarge`, `1kg-wgs-HG00096`, coordinate → template-coordinate, `--max-memory 512M --max-temp-files 1024`, 779,820,469 records:

| t8 | merge wall | consumer CPU | park | worker util | peak RSS |
| --- | --- | --- | --- | --- | --- |
| `main` | 197.2s | 75.4s | 121.6s | 89% | 4.813 GB |
| this branch | **195.9s** | 76.4s | 119.3s | 90% | 4.818 GB |

**Below the measurement floor, and on the wrong side of zero.** The instrumented build is 1.3s *faster* (−0.66%) against an in-boot reproducibility band of ±0.9%, which cannot be a real effect — read it as noise. Peak RSS moves +5 MB on a 4.8 GB footprint. t8 is the config where this would show if anywhere: the consumer is the serial bottleneck there, so per-record overhead has nowhere to hide.

The same pair measured against #806's pre-merge head, before it was squash-merged, gave the same answer at both thread counts: t16 175.5 → 174.9s, t8 198.2 → 198.5s — again opposite signs, again inside the band.

So the claim is "no cost detectable at ≤±0.4% of wall and ≤16 MB of RSS", not "free". Worth re-checking if a future counter lands on the per-record path — the sibling PR contains a commit that exists precisely because one did.

## Reading order

1. `81b86f61` — the park decomposition, and why it is built to sum to an exact total
2. `59eb5499` — the stage-latency table (the most reusable piece), plus the docs record of a dead end
3. `f2efed08` — wake accounting
4. `910b7128` — the park-supply census and the time-weighted awaited-state line, with its test

## Verification

`cargo ci-fmt` and `ci-lint` clean; `cargo ci-test` **7526 passed / 30 skipped**. Every commit builds independently (checked commit by commit). `fgumi compare bams --command sort` reports IDENTICAL on 779,820,469 records with 0 sort-order violations.

Nothing here is per-record: every site is per-park, per-scan or per-block. Distributions log at `debug`; numbers a decision would rest on log at `info`.

One caution worth carrying: four *other* instruments were built alongside these and **discarded for misleading me** — per-worker sums presented as critical-path costs, and a recruitment split that read stale state. The rule that separates the survivors is that each partitions an exactly measured total by construction, so no segment can exceed it. Anything that merely correlated with the total was wrong every time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: command output — none; `unsafe` — none, and no `CLAUDE.md` allowlist update applies; memory bounds, queue capacity, and thread/backpressure policy — none.

- Adds instrumentation for park-time attribution, park supply, wake targeting, stage latency, wasted scans, awaited-file states, and per-worker activity.
- Adds write and reorder-buffer histograms.
- Adds reporting APIs and regression tests for duration-based accounting.
- No scheduling constants or algorithms change.
- Formatting, linting, 7,526 tests, and identical BAM output comparison passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->