### PR TITLE
perf(sort): give read-ahead depth to the file the merge is actually on

### DIFF
--- a/crates/fgumi-sort/src/bgzf_io.rs
+++ b/crates/fgumi-sort/src/bgzf_io.rs
@@ -15,8 +15,37 @@ use std::collections::BTreeMap;
 use std::io::{BufWriter, Write};
 use std::sync::Arc;
 
-/// Padding beyond `BGZF_MAX_BLOCK_SIZE` for the staging buffer capacity.
+/// Padding beyond the frame size for the staging buffer capacity.
 const STAGING_PADDING: usize = 4096;
+
+/// Uncompressed bytes per zstd **spill** frame.
+///
+/// BGZF mandates blocks of at most 64 KiB; zstd has no such limit, and spill
+/// files are a private temporary format that nothing outside this crate reads.
+/// Pinning zstd frames to the BGZF ceiling was therefore vestigial, and it set
+/// the merge's block count -- 5,368,249 blocks on a measured 89-way merge, of
+/// which the consumer takes roughly one per round trip. Fewer, larger frames cut
+/// round trips proportionally.
+///
+/// Raising this costs memory in two places, both worth watching: the per-worker
+/// zstd decompress buffer ([`crate::worker_pool::zstd_decomp_cap`]) and the
+/// per-file reorder buffer, which holds up to `PHASE2_DECOMP_CAP` *uncompressed*
+/// frames for each of K files. Read-ahead itself does not scale with it, because
+/// the refill allowance is sized in bytes rather than blocks.
+pub(crate) const SPILL_FRAME_BYTES: usize = BGZF_MAX_BLOCK_SIZE;
+
+/// Bytes a staging buffer accumulates before it submits a compress job.
+///
+/// Keyed on the codec so BAM output stays inside the BGZF format: output always
+/// uses [`SpillCodec::Bgzf`], so it cannot pick up a spill-only frame size by
+/// accident.
+#[must_use]
+pub(crate) const fn spill_frame_bytes(codec: SpillCodec) -> usize {
+    match codec {
+        SpillCodec::Bgzf => BGZF_MAX_BLOCK_SIZE,
+        SpillCodec::Zstd => SPILL_FRAME_BYTES,
+    }
+}
 
 /// Per-block position notification emitted by the I/O writer loop when index
 /// generation is enabled.
@@ -76,7 +105,7 @@ impl StagingBuffer {
     ) -> Self {
         Self {
             pool,
-            buf: Vec::with_capacity(BGZF_MAX_BLOCK_SIZE + STAGING_PADDING),
+            buf: Vec::with_capacity(spill_frame_bytes(codec) + STAGING_PADDING),
             next_serial: 0,
             result_tx,
             permit_pool,
@@ -96,7 +125,7 @@ impl StagingBuffer {
     /// Returns true if the staging buffer has reached the BGZF block size threshold.
     #[inline]
     pub(crate) fn is_full(&self) -> bool {
-        self.buf.len() >= BGZF_MAX_BLOCK_SIZE
+        self.buf.len() >= spill_frame_bytes(self.codec)
     }
 
     /// Current uncompressed length of the pending (not-yet-flushed) block.
@@ -136,8 +165,9 @@ impl StagingBuffer {
         self.permit_pool.acquire()?;
 
         let data = std::mem::replace(&mut self.buf, self.pool.buffer_pool.checkout());
-        if self.buf.capacity() < BGZF_MAX_BLOCK_SIZE + STAGING_PADDING {
-            self.buf.reserve(BGZF_MAX_BLOCK_SIZE + STAGING_PADDING - self.buf.capacity());
+        let want = spill_frame_bytes(self.codec) + STAGING_PADDING;
+        if self.buf.capacity() < want {
+            self.buf.reserve(want - self.buf.capacity());
         }
 
         let serial = self.next_serial;
@@ -174,7 +204,7 @@ impl StagingBuffer {
     pub(crate) fn write_chunked(&mut self, data: &[u8]) -> anyhow::Result<()> {
         let mut remaining = data;
         while !remaining.is_empty() {
-            let space = BGZF_MAX_BLOCK_SIZE.saturating_sub(self.buf.len());
+            let space = spill_frame_bytes(self.codec).saturating_sub(self.buf.len());
             let n = remaining.len().min(space);
             self.buf.extend_from_slice(&remaining[..n]);
             remaining = &remaining[n..];
@@ -435,12 +465,118 @@ mod tests {
         );
 
         assert!(!staging.is_full(), "empty buffer should not be full");
-        staging.buf().extend(vec![0u8; BGZF_MAX_BLOCK_SIZE]);
-        assert!(staging.is_full(), "buffer at BGZF_MAX_BLOCK_SIZE should be full");
+        staging.buf().extend(vec![0u8; spill_frame_bytes(codec)]);
+        assert!(staging.is_full(), "buffer at the codec's frame size should be full");
 
         if let Ok(p) = Arc::try_unwrap(pool) {
             p.shutdown();
         }
+    }
+
+    /// BGZF's 64 KiB block ceiling is a *format* requirement; zstd has none.
+    ///
+    /// Spill files are a private temporary format, so pinning their zstd frames
+    /// to the BGZF limit is vestigial — and it sets the block count, which is
+    /// what the merge pays per round trip (measured: 5,368,249 blocks on an
+    /// 89-way merge, ~1 consumed per consumer round trip). BAM output must stay
+    /// at the BGZF size regardless, and it always uses the BGZF codec, so keying
+    /// the threshold on the codec keeps output correct by construction.
+    #[test]
+    fn test_only_zstd_spill_frames_escape_the_bgzf_block_ceiling() {
+        assert_eq!(
+            spill_frame_bytes(SpillCodec::Bgzf),
+            BGZF_MAX_BLOCK_SIZE,
+            "BGZF blocks are capped by the format and must not grow"
+        );
+        assert!(
+            spill_frame_bytes(SpillCodec::Zstd) >= BGZF_MAX_BLOCK_SIZE,
+            "zstd frames must never be smaller than the BGZF block they replace"
+        );
+        assert!(
+            crate::worker_pool::zstd_decomp_cap() >= spill_frame_bytes(SpillCodec::Zstd),
+            "the decompress buffer must hold the largest frame the writer can emit, or every \
+             frame at the new size fails to decompress"
+        );
+        assert!(
+            crate::worker_pool::MAX_ZSTD_FRAME_BYTES >= spill_frame_bytes(SpillCodec::Zstd),
+            "the read-side length guard must admit a frame the writer can emit"
+        );
+    }
+
+    /// Both zstd frame caps must admit the largest frame the writer can emit.
+    ///
+    /// There are two, on two different read paths: the pool's, used by the merge,
+    /// and `zspill_stream`'s, used by consolidation. They were previously held
+    /// equal by a comment saying "kept in sync", which is not enforcement -- and
+    /// the consolidation path is exercised only by the spill-heavy
+    /// configurations, so a mismatch would pass the standard matrix and fail
+    /// exactly where spill volume is largest.
+    #[test]
+    fn test_frame_caps_admit_the_largest_frame_the_writer_emits() {
+        let frame = spill_frame_bytes(SpillCodec::Zstd);
+        assert!(
+            crate::worker_pool::zstd_decomp_cap() >= frame,
+            "the merge path's decompress cap is below the writer's frame size"
+        );
+        assert!(
+            crate::zspill_stream::frame_decomp_cap() >= frame,
+            "the consolidation path's decompress cap is below the writer's frame size"
+        );
+    }
+
+    /// The spill writer's pre-flush budget must *be* the staging buffer's frame
+    /// size, not a copy of it.
+    ///
+    /// `PooledChunkWriter` pre-flushes so a record never straddles a frame
+    /// boundary -- which is what lets the merge borrow most records in place. That
+    /// budget was `BGZF_MAX_BLOCK_SIZE` outright, so it flushed at 64 KiB no
+    /// matter what the staging buffer was configured for, and raising the frame
+    /// size changed the block count *not at all*: 5,368,249 blocks measured at
+    /// both 64 KiB and 256 KiB. The sweep looked like a 4% regression rather than
+    /// a no-op, so nothing about the wall time revealed that the knob was inert.
+    ///
+    /// Third duplicated threshold found this way, after the two zstd decompress
+    /// caps. Derive, then pin.
+    #[rstest]
+    #[case(SpillCodec::Bgzf)]
+    #[case(SpillCodec::Zstd)]
+    fn test_spill_writer_pre_flushes_at_the_staging_frame_size(#[case] codec: SpillCodec) {
+        let pool = Arc::new(SortWorkerPool::new(1, 1, 6, codec));
+        let dir = tempfile::tempdir().expect("tempdir");
+        let writer =
+            crate::pooled_chunk_writer::PooledChunkWriter::<crate::keys::RawCoordinateKey>::new(
+                Arc::clone(&pool),
+                &dir.path().join("c.keyed"),
+                codec,
+            )
+            .expect("writer");
+        assert_eq!(
+            writer.frame_bytes(),
+            spill_frame_bytes(codec),
+            "the writer's pre-flush budget must equal the frame size the staging buffer              flushes at, or the frame size has no effect on the block count"
+        );
+        drop(writer);
+        if let Ok(p) = Arc::try_unwrap(pool) {
+            p.shutdown();
+        }
+    }
+
+    /// At the default frame size the derived cap must equal the 256 KiB constant
+    /// it replaced.
+    ///
+    /// This buffer is per-worker scratch touched once per decompressed frame, so
+    /// its size is a cache parameter. Deriving it with a *fixed* 4 MiB of slack
+    /// instead of a proportional 4x inflated it 16x at the default frame size and
+    /// cost 25% of merge wall (249.5s against a 199.2s baseline) with peak RSS
+    /// essentially unchanged -- a regression invisible to any memory check.
+    #[test]
+    fn test_default_frame_size_preserves_the_original_decompress_cap() {
+        assert_eq!(SPILL_FRAME_BYTES, BGZF_MAX_BLOCK_SIZE, "guard: default frame size");
+        assert_eq!(
+            crate::worker_pool::zstd_decomp_cap(),
+            256 * 1024,
+            "the derived cap must reproduce the tuned constant at the default frame size"
+        );
     }
 
     #[rstest]

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1357,6 +1357,9 @@ pub(crate) struct MainThreadChunkConsumer<K: RawSortKey + 'static> {
     /// Shared pool state, for the epoch clock and the trace counters that
     /// record both halves of a producer/consumer handoff.
     shared: Arc<crate::worker_pool::SharedPipelineState>,
+    /// Decompression state, so this thread can serve itself a block that has been
+    /// read but not yet claimed instead of parking for a worker to do it.
+    decomp: crate::worker_pool::DecompressorSet,
     /// Source the previous block came from, and how many consecutive blocks
     /// have now come from it. Says whether the merge dwells on one run at a
     /// time -- in which case lookahead on that run would pay -- or hops.
@@ -1495,9 +1498,11 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
     ) -> Self {
         let parser_state = (0..files.len()).map(|_| SourceParserState::new()).collect();
         let stalls = crate::merge_stalls::ConsumerStallTracker::new(files.len());
+        let codec = files.first().map_or(crate::codec::SpillCodec::Bgzf, |f| f.codec);
         Self {
             files,
             parser_state,
+            decomp: crate::worker_pool::DecompressorSet::for_codec(codec),
             decompression_error,
             chunk_read_error,
             worker_panicked,
@@ -1786,6 +1791,32 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
             // Sampled BEFORE the park, not after: the question is why nobody had
             // already started on this block, and the pool's state on *resume* is
             // the answer to a different question -- by then somebody has.
+            // Before sleeping: if the block this thread is waiting for has already
+            // been read and nobody has claimed it, decompress it here rather than
+            // parking. That trades ~53us of work for a ~190us wait on a worker
+            // that has to be woken first, and it removes the producer-to-consumer
+            // handoff instead of trying to schedule around it -- which is what
+            // eight scheduling interventions failed to do.
+            //
+            // Loops while it keeps succeeding: the same argument applies to the
+            // blocks after the one immediately needed, and serving them here is
+            // depth on exactly the file being drained, which is where >=94% of
+            // consumed blocks come from. Bounded by the FIFO running dry or the
+            // reorder cap, both of which `try_pop_raw_for_decompress` enforces, so
+            // this cannot spin.
+            //
+            // Only on the way into a park, never in place of merging: this thread
+            // is the serial bottleneck at 76s of a 166s merge, and taking work it
+            // could have delegated while it still has records to emit would be
+            // strictly worse.
+            if self.serve_self_instead_of_parking(source_id) {
+                // Self-service is not a park: leave `parked_yet` untouched so the
+                // first real park of this pull still records a `stalled_pull`.
+                // Serving before the first park would otherwise suppress that
+                // increment and understate the stall rate.
+                continue;
+            }
+
             let supply = self.shared.park_supply_now();
 
             let park_start = Instant::now();
@@ -1815,6 +1846,46 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
             self.shared.park_attribution.record(segments, claim != 0, ready as u64);
             parked_yet = true;
         }
+    }
+
+    /// Decompress this source's already-read blocks on this thread, returning
+    /// whether anything was published.
+    ///
+    /// Called only on the way into a park. If the block the merge is waiting for
+    /// has been read and nobody has claimed it -- 12% of parks -- decompressing it
+    /// here trades ~53us of work for a ~190us wait on a worker that has to be
+    /// woken first. It removes the producer-to-consumer handoff instead of trying
+    /// to schedule around it, which is what eight scheduling interventions failed
+    /// to do. The decisive evidence: raising `PHASE2_DECOMP_CAP` 8 -> 128 cut parks
+    /// from 978,325 to 400,487 and left total park time at 89.6s against 89.7s, so
+    /// the cost is per block, not per park, and no amount of buffering reaches it.
+    ///
+    /// Loops while it keeps succeeding, because the same argument applies to the
+    /// blocks after the one immediately needed, and serving them here is depth on
+    /// exactly the file being drained -- where >=94% of consumed blocks come from
+    /// (median run is 1 block, but the mean is 31.7 and p99 is 512). It cannot
+    /// spin: each iteration either pops a block or stops, bounded by the FIFO
+    /// emptying or the reorder cap, both enforced inside
+    /// `try_pop_raw_for_decompress`.
+    ///
+    /// **Never in place of merging.** This thread is the serial bottleneck, 76s of
+    /// a 166s merge, so taking work it could have delegated while it still has
+    /// records to emit would be strictly worse. The only safe moment is the one
+    /// where it was about to sleep anyway.
+    fn serve_self_instead_of_parking(&mut self, source_id: usize) -> bool {
+        let mut served = false;
+        while crate::worker_pool::SortWorkerPool::consumer_decompress_one(
+            &self.shared,
+            &mut self.decomp,
+            &self.files[source_id],
+            source_id,
+        ) {
+            served = true;
+        }
+        if served {
+            self.shared.consumer_self_served.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+        served
     }
 
     /// Parse the next record from a source's byte stream.
@@ -4640,6 +4711,10 @@ impl RawExternalSorter {
         // never stalled is precisely the run with a complete lifecycle trace and
         // nothing to say above. `log_block_lifecycle` carries its own gate.
         Self::log_block_lifecycle(pool);
+
+        // Also outside the gate: these two counters say whether the targeted-depth
+        // paths ran at all, which matters most on the runs that did not stall.
+        Self::log_merge_validity_gates(pool);
     }
 
     /// Nanoseconds as seconds.
@@ -4655,6 +4730,31 @@ impl RawExternalSorter {
             return 0.0;
         }
         100.0 * part as f64 / whole as f64
+    }
+
+    /// Validity gates for the merge's targeted-depth paths.
+    ///
+    /// This one is inert in a way wall clock cannot reveal: if the consumer never
+    /// finds an unclaimed block to decompress, the change does nothing and the run
+    /// still reports a plausible time. So it gets a counter, and the counter is
+    /// printed. Later targeted-depth paths join it here.
+    fn log_merge_validity_gates(pool: &SortWorkerPool) {
+        let self_served = pool.consumer_self_served();
+        if self_served > 0 {
+            info!(
+                "  Consumer served itself: {self_served} parks avoided by decompressing an \
+                 already-read block inline"
+            );
+        }
+    }
+
+    /// `total` divided over `claims`, or 0.0 when there are none.
+    #[expect(clippy::cast_precision_loss, reason = "counts stay far below 2^52")]
+    fn per_claim(total: u64, claims: u64) -> f64 {
+        if claims == 0 {
+            return 0.0;
+        }
+        total as f64 / claims as f64
     }
 
     /// Log a latency distribution for every stage a block passes through.

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -1818,9 +1818,15 @@ impl<K: RawSortKey + 'static> MainThreadChunkConsumer<K> {
             }
 
             let supply = self.shared.park_supply_now();
+            // Published for `get_sort_priorities`: while this is set, a worker
+            // serves the awaited file before it drains output compression.
+            // Ordering is Release/Acquire-free on purpose -- a worker reading it
+            // one iteration late costs one deferred block, not correctness.
+            self.shared.consumer_parked.store(true, ord);
 
             let park_start = Instant::now();
             std::thread::park();
+            self.shared.consumer_parked.store(false, ord);
             let parked_ns = crate::merge_trace::elapsed_nanos(park_start);
             self.shared.park_supply.record(supply, parked_ns);
             self.stalls.record_park(source_id, parked_ns, !parked_yet);

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -3166,6 +3166,7 @@ impl RawExternalSorter {
         )?;
 
         let mut records_merged = 0u64;
+        let mut merge_progress_batch = crate::progress_batch::BatchedProgress::new();
         let merge_progress = ProgressTracker::new("Merged records").with_interval(1_000_000);
         // Set when an input is found not to be monotonic in the merge order:
         // (source index into `inputs`, 1-based record number within that input).
@@ -3180,7 +3181,7 @@ impl RawExternalSorter {
 
             writer.write_raw_record(&records[winner])?;
             records_merged += 1;
-            merge_progress.log_if_needed(1);
+            merge_progress_batch.tick(&merge_progress);
 
             let reader_idx = source_map[winner];
             if let Some(raw_record) = readers[reader_idx].next() {
@@ -3226,6 +3227,9 @@ impl RawExternalSorter {
 
         writer.finish()?;
         out_target.persist()?;
+        // Must precede log_final: the tracker has not seen the last partial batch,
+        // and without this the reported total comes up short by up to one batch.
+        merge_progress_batch.flush(&merge_progress);
         merge_progress.log_final();
 
         Ok(records_merged)
@@ -5290,6 +5294,7 @@ impl RawExternalSorter {
         let mut writer = PooledBamWriter::new(Arc::clone(pool), output, &output_header)?;
 
         let mut records_merged = 0u64;
+        let mut merge_progress_batch = crate::progress_batch::BatchedProgress::new();
         let merge_progress = ProgressTracker::new("Merged records")
             .with_interval(1_000_000)
             .with_total(total_records);
@@ -5357,7 +5362,7 @@ impl RawExternalSorter {
             }
 
             records_merged += 1;
-            merge_progress.log_if_needed(1);
+            merge_progress_batch.tick(&merge_progress);
 
             if merge_probe.should_sample(records_merged) {
                 let depths = pool.phase1_queue_depths();
@@ -5461,6 +5466,9 @@ impl RawExternalSorter {
         );
         Self::log_stage_latency(pool, &writer_stats);
 
+        // Must precede log_final: the tracker has not seen the last partial batch,
+        // and without this the reported total comes up short by up to one batch.
+        merge_progress_batch.flush(&merge_progress);
         merge_progress.log_final();
         log_snapshot("phase2.end", 0);
 
@@ -5516,6 +5524,7 @@ impl RawExternalSorter {
         let mut tree = LoserTree::new(initial_keys);
 
         let mut writer = PooledBamWriter::new_indexing(Arc::clone(pool), output, &output_header)?;
+        let mut merge_progress_batch = crate::progress_batch::BatchedProgress::new();
         let merge_progress = ProgressTracker::new("Merged records")
             .with_interval(1_000_000)
             .with_total(total_records);
@@ -5537,7 +5546,7 @@ impl RawExternalSorter {
             let record_bytes = winner_record_bytes(&sources[src_idx], guard.consumer_ref())?;
             writer.write_raw_record(record_bytes)?;
             records_merged += 1;
-            merge_progress.log_if_needed(1);
+            merge_progress_batch.tick(&merge_progress);
 
             if let Some(key) = sources[src_idx].advance(guard.consumer_mut())? {
                 tree.replace_winner(key);
@@ -5606,6 +5615,9 @@ impl RawExternalSorter {
         // rows at all.
         Self::log_stage_latency(pool, &writer_stats);
 
+        // Must precede log_final: the tracker has not seen the last partial batch,
+        // and without this the reported total comes up short by up to one batch.
+        merge_progress_batch.flush(&merge_progress);
         merge_progress.log_final();
         Ok((index, records_merged))
     }

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -4736,12 +4736,13 @@ impl RawExternalSorter {
         100.0 * part as f64 / whole as f64
     }
 
-    /// Validity gates for the merge's targeted-depth paths.
+    /// Validity gates for the two targeted-depth paths in the merge.
     ///
-    /// This one is inert in a way wall clock cannot reveal: if the consumer never
-    /// finds an unclaimed block to decompress, the change does nothing and the run
-    /// still reports a plausible time. So it gets a counter, and the counter is
-    /// printed. Later targeted-depth paths join it here.
+    /// Both changes are inert in a way that a wall-clock number cannot reveal: the
+    /// consumer may never find an unclaimed block to decompress, and the loser tree
+    /// may never name a next source. Either would land as "no measurable change"
+    /// rather than as "the mechanism did not run", so each gets a counter and each
+    /// counter is printed.
     fn log_merge_validity_gates(pool: &SortWorkerPool) {
         let self_served = pool.consumer_self_served();
         if self_served > 0 {
@@ -4749,6 +4750,10 @@ impl RawExternalSorter {
                 "  Consumer served itself: {self_served} parks avoided by decompressing an \
                  already-read block inline"
             );
+        }
+        let predictions = pool.phase2_predictions();
+        if predictions > 0 {
+            info!("  Next-source predictions published: {predictions}");
         }
     }
 
@@ -5342,9 +5347,20 @@ impl RawExternalSorter {
         let reassembled_before = RECORD_REASSEMBLED.load(std::sync::atomic::Ordering::Relaxed);
         let loop_start = Instant::now();
 
+        let mut published_src: Option<usize> = None;
         while tree.winner_is_active() {
             let winner = tree.winner();
             let src_idx = source_map[winner];
+            // Publish the next likely source, but only when the run changes --
+            // ~167K times rather than once per record. The pool gives it the deep
+            // read allowance, so its first read starts while the consumer is still
+            // draining ~300 blocks from the current file, instead of after it has
+            // already stalled. A wrong prediction costs one deep read on a file the
+            // merge will reach eventually; there is no correctness component.
+            if published_src != Some(src_idx) {
+                published_src = Some(src_idx);
+                pool.set_phase2_next_source(tree.runner_up().map(|w| source_map[w]));
+            }
             let sample_this = sample_countdown == 0;
             if sample_this {
                 sample_countdown = merge_sample_interval - 1;
@@ -5540,9 +5556,22 @@ impl RawExternalSorter {
         }
         let loop_start = Instant::now();
         let mut records_merged: u64 = 0;
+        let mut published_src: Option<usize> = None;
         while tree.winner_is_active() {
             let winner = tree.winner();
             let src_idx = source_map[winner];
+            // Publish the next likely source, but only when the run changes. The
+            // pool gives it the deep read allowance, so its first read starts
+            // while the consumer is still draining the current file instead of
+            // after it has already stalled. A wrong prediction costs one deep
+            // read on a file the merge will reach anyway; there is no correctness
+            // component. Mirrors `merge_chunks_generic`; without it the indexed
+            // path -- the default coordinate sort -- gets no predictive
+            // read-ahead.
+            if published_src != Some(src_idx) {
+                published_src = Some(src_idx);
+                pool.set_phase2_next_source(tree.runner_up().map(|w| source_map[w]));
+            }
             let record_bytes = winner_record_bytes(&sources[src_idx], guard.consumer_ref())?;
             writer.write_raw_record(record_bytes)?;
             records_merged += 1;

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -55,6 +55,7 @@ pub(crate) mod merge_trace;
 pub(crate) mod pipeline;
 pub(crate) mod pooled_bam_writer;
 pub(crate) mod pooled_chunk_writer;
+pub(crate) mod progress_batch;
 pub(crate) mod radix;
 pub(crate) mod read_ahead;
 pub(crate) mod reader;

--- a/crates/fgumi-sort/src/loser_tree.rs
+++ b/crates/fgumi-sort/src/loser_tree.rs
@@ -134,6 +134,47 @@ impl<K: Ord> LoserTree<K> {
         self.losers[0]
     }
 
+    /// The source most likely to be consumed after the winner, or `None` when
+    /// fewer than two sources remain.
+    ///
+    /// The runner-up is always among the losers stored along the winner's
+    /// root-to-leaf path -- anything eliminated elsewhere in the tree lost to a
+    /// source that itself lost to the winner. So this is O(log k) comparisons over
+    /// existing state, ~6 for a 44-way merge, and needs no new bookkeeping.
+    ///
+    /// `losers[1]` alone is NOT the answer, which is the tempting O(1) shortcut:
+    /// after a replay that node holds whoever lost the final comparison of *that*
+    /// replay, not the global second-smallest. With keys `[50, 100, 30, 20]` the
+    /// winner is source 3 and `losers[1]` is source 0 (key 50), while the true
+    /// runner-up is source 2 (key 30).
+    ///
+    /// It exists to be read *predictively*. The merge starves at run transitions:
+    /// only 2,475 of 167,624 source switches starve, but each costs ~20ms against
+    /// an 8.4ms read latency -- the read had not been started when the consumer
+    /// arrived. Depth cannot fix that (doubling the read-ahead cap moved the
+    /// starved share of park time not at all, 99% to 99%), but knowing which file
+    /// is next, ~300 blocks before it is needed, can.
+    #[must_use]
+    pub fn runner_up(&self) -> Option<usize> {
+        if self.num_active < 2 {
+            return None;
+        }
+        let winner = self.losers[0];
+        let mut node = self.leaf_to_node(winner);
+        let mut best: Option<usize> = None;
+        while node > 0 {
+            let candidate = self.losers[node];
+            if candidate != EMPTY && self.active[candidate] {
+                best = Some(match best {
+                    Some(b) if self.is_greater(candidate, b) => b,
+                    _ => candidate,
+                });
+            }
+            node >>= 1;
+        }
+        best
+    }
+
     /// Check if the winner is still an active source.
     #[inline]
     #[must_use]
@@ -384,5 +425,42 @@ mod tests {
         }
 
         assert_eq!(result, (1..=10).collect::<Vec<i32>>());
+    }
+    /// The runner-up predicts the source the merge will consume after the current
+    /// winner run. It starts that source's disk read ~300 blocks early. Getting it
+    /// wrong prefetches the wrong file, which is how grab-N cost 36%.
+    #[test]
+    fn test_runner_up_is_the_second_smallest_key() {
+        let tree = LoserTree::new(vec![50u32, 10, 30, 20]);
+        assert_eq!(tree.winner(), 1, "guard: 10 is the winner");
+        assert_eq!(tree.runner_up(), Some(3), "20 is next, at source 3");
+    }
+
+    /// Must track the tree, not a stale snapshot: after the winner advances the
+    /// prediction has to move with it.
+    #[test]
+    fn test_runner_up_follows_the_tree_as_the_winner_advances() {
+        let mut tree = LoserTree::new(vec![50u32, 10, 30, 20]);
+        tree.replace_winner(100);
+        assert_eq!(tree.winner(), 3, "20 now wins");
+        assert_eq!(tree.runner_up(), Some(2), "30 is next, at source 2");
+    }
+
+    /// One source has no next source; predicting one would send a read at the file
+    /// already being drained, which already has the deep allowance.
+    #[test]
+    fn test_runner_up_is_none_with_a_single_source() {
+        assert_eq!(LoserTree::new(vec![7u32]).runner_up(), None);
+    }
+
+    /// Exhausted sources must never be predicted: a read issued for a drained file
+    /// is pure waste, and `active` is what distinguishes them.
+    #[test]
+    fn test_runner_up_skips_an_exhausted_source() {
+        let mut tree = LoserTree::new(vec![10u32, 20]);
+        assert_eq!(tree.winner(), 0);
+        tree.remove_winner();
+        assert_eq!(tree.winner(), 1, "guard: source 0 is gone");
+        assert_eq!(tree.runner_up(), None, "no live source remains behind the winner");
     }
 }

--- a/crates/fgumi-sort/src/merge_trace.rs
+++ b/crates/fgumi-sort/src/merge_trace.rs
@@ -546,12 +546,28 @@ impl ConsumerTraceStats {
     /// Record that the merge drew `blocks` consecutive blocks from one source.
     ///
     /// This is the test for whether the merge has a *hot file* worth steering
-    /// workers toward. A run length of 1 means it does not: the loser tree
-    /// interleaves records from every run at once, so by the time one source's
-    /// block is exhausted the merge has already pulled from many others.
-    /// Demand is spread evenly and continuously across all K files, and any fix
-    /// framed as "prefetch the file the consumer needs next" is answering a
-    /// question the workload does not pose.
+    /// workers toward, and it must be read weighted by **blocks, not by runs** --
+    /// the two give opposite answers.
+    ///
+    /// By run count the merge looks perfectly interleaved: the measured median run
+    /// is 1 block, so most of the time the loser tree does pull the next record
+    /// from some other source. An earlier version of this comment stopped there and
+    /// concluded that any fix framed as "prefetch the file the consumer needs next"
+    /// was answering a question the workload does not pose.
+    ///
+    /// Weighted by blocks the same histogram says the opposite. On a measured
+    /// 44-way merge (`n=167624 total=5306698 mean=31.7 p50=1 p90=2 p99=512`), if
+    /// the bottom 90% of runs average two blocks or fewer they account for at most
+    /// 302k of 5.31M blocks -- so **at least 94% of all blocks come from the top
+    /// decile of runs**, which are hundreds of consecutive blocks from one source.
+    /// Steering read-ahead at the source the merge is draining, and at the one it
+    /// will drain next, is worth 2.8-5.2% and 2.7% of merge wall respectively.
+    ///
+    /// Both readings are true; only the block-weighted one predicted a result. It
+    /// is the same count-versus-time trap that made the park census point at a
+    /// scheduling change that then measured 0.06%. A short floor for the frequent
+    /// one-block runs still has to exist -- what does not work is spreading depth
+    /// uniformly, which has been measured negative four separate times.
     ///
     /// Reuses the duration histogram's bucketing for a count: run lengths are as
     /// heavy-tailed as the timings and want the same log2 treatment. One block

--- a/crates/fgumi-sort/src/pooled_chunk_writer.rs
+++ b/crates/fgumi-sort/src/pooled_chunk_writer.rs
@@ -28,7 +28,7 @@ use crate::keys::RawSortKey;
 use crate::worker_pool::{CompressResult, CompressTarget, PermitPool, SortWorkerPool};
 use anyhow::Result;
 use crossbeam_channel::bounded;
-use fgumi_bgzf::{BGZF_EOF, BGZF_MAX_BLOCK_SIZE};
+use fgumi_bgzf::BGZF_EOF;
 use std::io::BufWriter;
 use std::marker::PhantomData;
 use std::path::Path;
@@ -45,6 +45,16 @@ pub struct PooledChunkWriter<K: RawSortKey> {
     staging: Option<StagingBuffer>,
     /// Reusable scratch buffer for key serialization (non-embedded keys only).
     key_buf: Vec<u8>,
+    /// Bytes a frame may hold, resolved from the codec once.
+    ///
+    /// This writer pre-flushes so a record never straddles a frame boundary --
+    /// which is what lets the merge borrow most records in place instead of
+    /// reassembling them. That budget must be the size the staging buffer will
+    /// actually flush at: when this was `BGZF_MAX_BLOCK_SIZE` outright, it
+    /// pre-flushed at 64 KiB no matter what the staging buffer was configured
+    /// for, so raising the frame size changed the block count not at all
+    /// (measured: 5,368,249 blocks at both 64 KiB and 256 KiB).
+    frame_bytes: usize,
     io_handle: Option<JoinHandle<Result<()>>>,
     _phantom: PhantomData<K>,
 }
@@ -161,6 +171,7 @@ impl<K: RawSortKey> PooledChunkWriter<K> {
                 CompressTarget::Spill,
             )),
             key_buf: Vec::new(),
+            frame_bytes: crate::bgzf_io::spill_frame_bytes(codec),
             io_handle: Some(io_handle),
             _phantom: PhantomData,
         })
@@ -185,11 +196,12 @@ impl<K: RawSortKey> PooledChunkWriter<K> {
             // Fast path: key is part of the record bytes, no extra serialization.
             // Budget: 4-byte length prefix + record bytes.
             let needed = 4 + record.len();
-            if staging.buf().len() + needed > BGZF_MAX_BLOCK_SIZE {
+            let frame = self.frame_bytes;
+            if staging.buf().len() + needed > frame {
                 staging.flush()?;
             }
             staging.buf().extend_from_slice(&(record.len() as u32).to_le_bytes());
-            if record.len() > BGZF_MAX_BLOCK_SIZE.saturating_sub(4) {
+            if record.len() > frame.saturating_sub(4) {
                 staging.write_chunked(record)?;
             } else {
                 staging.buf().extend_from_slice(record);
@@ -201,10 +213,10 @@ impl<K: RawSortKey> PooledChunkWriter<K> {
             self.key_buf.clear();
             key.write_to(&mut self.key_buf)?;
             let needed = self.key_buf.len() + 4 + record.len();
-            // No size limit check: records larger than one BGZF block are handled
-            // by write_chunked(), which splits them across multiple blocks. The
+            // No size limit check: records larger than one frame are handled by
+            // write_chunked(), which splits them across multiple blocks. The
             // reader uses streaming read_exact() that transparently spans blocks.
-            if staging.buf().len() + needed > BGZF_MAX_BLOCK_SIZE {
+            if staging.buf().len() + needed > self.frame_bytes {
                 staging.flush()?;
             }
             staging.buf().extend_from_slice(&self.key_buf);
@@ -212,6 +224,16 @@ impl<K: RawSortKey> PooledChunkWriter<K> {
             staging.write_chunked(record)?;
         }
         Ok(())
+    }
+
+    /// The frame budget this writer pre-flushes against.
+    ///
+    /// Exposed so it can be pinned to [`crate::bgzf_io::spill_frame_bytes`]
+    /// rather than trusted to match it.
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn frame_bytes(&self) -> usize {
+        self.frame_bytes
     }
 
     /// Finish writing: flush remaining data, wait for I/O thread.

--- a/crates/fgumi-sort/src/progress_batch.rs
+++ b/crates/fgumi-sort/src/progress_batch.rs
@@ -1,0 +1,106 @@
+//! Batched progress ticks for per-record loops.
+
+use fgumi_bam_io::progress::ProgressTracker;
+
+/// Records counted locally before touching the tracker's atomic.
+///
+/// A merge emits hundreds of millions of records on ONE serial thread, and
+/// `ProgressTracker::log_if_needed` does a relaxed `fetch_add` per call. On
+/// aarch64 Rust defaults to outline-atomics, so that is not an inline `LDADD`
+/// but a call into `__aarch64_ldadd8_relax`, which runtime-checks for LSE and
+/// can fall back to an `ldxr`/`stxr` loop. Profiling the merge consumer on
+/// `c7g.4xlarge` put that helper at **28% of the thread's cycles** -- the single
+/// largest entry, ahead of `LoserTree::replay` at 11% and the record memcpy at
+/// 8% -- on a thread whose 145 ns/record now sets the merge's wall clock.
+///
+/// 4096 against a 1,000,000-record logging interval means a milestone is noticed
+/// at most 0.4% late, which no progress line cares about, and removes 99.98% of
+/// the atomic traffic.
+const TICK_BATCH: u64 = 4096;
+
+/// Accumulates record counts and forwards them to a [`ProgressTracker`] in
+/// batches.
+///
+/// [`Self::flush`] must be called before the tracker's final log, or the last
+/// partial batch is never counted and the totals come up short.
+pub(crate) struct BatchedProgress {
+    pending: u64,
+}
+
+impl BatchedProgress {
+    pub(crate) const fn new() -> Self {
+        Self { pending: 0 }
+    }
+
+    /// Count one record, forwarding to `tracker` once a batch has accumulated.
+    #[inline]
+    pub(crate) fn tick(&mut self, tracker: &ProgressTracker) {
+        self.pending += 1;
+        if self.pending >= TICK_BATCH {
+            tracker.log_if_needed(self.pending);
+            self.pending = 0;
+        }
+    }
+
+    /// Forward whatever is left. Idempotent.
+    pub(crate) fn flush(&mut self, tracker: &ProgressTracker) {
+        if self.pending > 0 {
+            tracker.log_if_needed(self.pending);
+            self.pending = 0;
+        }
+    }
+
+    /// Records not yet forwarded. For tests.
+    #[cfg(test)]
+    pub(crate) const fn pending(&self) -> u64 {
+        self.pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The whole point is that the tracker's total is unchanged: batching may
+    /// notice a milestone late, but it must never lose a record.
+    #[test]
+    fn test_batched_ticks_preserve_the_total() {
+        let tracker = ProgressTracker::new("test").with_interval(1_000_000);
+        let mut batch = BatchedProgress::new();
+        for _ in 0..10_000 {
+            batch.tick(&tracker);
+        }
+        batch.flush(&tracker);
+        assert_eq!(tracker.count(), 10_000, "every record must reach the tracker");
+    }
+
+    /// Without the flush the last partial batch is silently dropped, which is the
+    /// one way this change can corrupt a total.
+    #[test]
+    fn test_unflushed_remainder_is_the_only_loss_and_flush_recovers_it() {
+        let tracker = ProgressTracker::new("test").with_interval(1_000_000);
+        let mut batch = BatchedProgress::new();
+        for _ in 0..(TICK_BATCH + 5) {
+            batch.tick(&tracker);
+        }
+        assert_eq!(tracker.count(), TICK_BATCH, "one full batch forwarded");
+        assert_eq!(batch.pending(), 5, "remainder still held locally");
+
+        batch.flush(&tracker);
+        assert_eq!(tracker.count(), TICK_BATCH + 5);
+        batch.flush(&tracker);
+        assert_eq!(tracker.count(), TICK_BATCH + 5, "flush is idempotent");
+    }
+
+    #[test]
+    fn test_atomic_is_touched_once_per_batch_not_once_per_record() {
+        let tracker = ProgressTracker::new("test").with_interval(1_000_000);
+        let mut batch = BatchedProgress::new();
+        for _ in 0..(TICK_BATCH - 1) {
+            batch.tick(&tracker);
+        }
+        assert_eq!(tracker.count(), 0, "nothing forwarded until a batch fills");
+        batch.tick(&tracker);
+        assert_eq!(tracker.count(), TICK_BATCH);
+    }
+}

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -773,13 +773,34 @@ pub(crate) const NO_AWAITED_SOURCE: usize = usize::MAX;
 /// | --- | --- | --- | --- |
 /// | (none: 4 blocks) | 4 | 326.5s | 54% |
 /// | 1 MiB | 101 | 212.4s | 83% |
-/// | **2 MiB** | 201 | **197.5s** | 89% |
-/// | 4 MiB | 402 | 194.5s | 90% |
+/// | 2 MiB | 201 | 197.5s | 89% |
+/// | **4 MiB** | 402 | **194.5s** | 90% |
 ///
-/// 2 MiB is the knee; 4 MiB buys 3s for twice the read-ahead. Peak RSS was flat
-/// across the whole sweep (4793-4828 MB against a 4794 MB baseline), because
-/// the deep allowance is scoped to one file and fewer stalls mean less
-/// transient buffering elsewhere.
+/// Peak RSS was flat across that sweep (4793-4828 MB against a 4794 MB
+/// baseline), because the deep allowance is scoped to one file and fewer stalls
+/// mean less transient buffering elsewhere.
+///
+/// Re-measured later with paired controls in one session, which moved the
+/// default here from 2 MiB to 4 MiB and bounded it from above:
+///
+/// | threads | 2 MiB | 4 MiB | 32 MiB |
+/// | --- | --- | --- | --- |
+/// | t8 (89 spill runs) | 199.1s (mean of 5) | **193.5 / 193.8s** | 199.3s, **RSS +58%** |
+/// | t16 (44 spill runs) | 178.9s | **169.6s** | not run |
+///
+/// So -2.8% at t8 and -5.2% at t16. **Do not raise it further.** At 32 MiB the
+/// merge is *slower* than at 4 MiB and peak RSS goes 4793 -> 7562 MB, because
+/// `raw-lock` contention climbs with batch depth (29% -> 52% -> 38% of
+/// awaited-file skips): more workers collide on one file's `raw_blocks` mutex.
+/// A wall-clock-only reading would have called that arm harmless.
+///
+/// It helps t16 *more* than t8, and the mechanism is worth knowing because it is
+/// not a scheduling improvement. Critical-path worker discovery lag halves
+/// (98.5s -> 59.8s) and the share of finds arriving after 320us drops 23% ->
+/// 16%: deeper read-ahead does not make recruiting a worker faster, it just
+/// needs fewer recruitments. So it pays most where each recruitment is most
+/// expensive, which is the regime with the *most* idle capacity. See
+/// [`SharedPipelineState::wake_one_worker`] for why recruitment is slow there.
 ///
 /// The floor read-ahead is working against is total worker busy / threads:
 /// ~1400 worker-seconds over 8 threads is ~175s, and an uncorrelated merge of
@@ -788,13 +809,13 @@ pub(crate) const NO_AWAITED_SOURCE: usize = usize::MAX;
 /// compression is 68% of the worker total -- or shortening the serial limits
 /// read-ahead does not touch: the merge consumer's per-record cost, and the
 /// per-block decompress chain on the file the merge is blocked on.
-pub(crate) const PHASE2_STARVING_READ_TARGET_BYTES: u64 = 2 << 20;
+pub(crate) const PHASE2_STARVING_READ_TARGET_BYTES: u64 = 4 << 20;
 
 /// [`PHASE2_STARVING_READ_TARGET_BYTES`] as a `usize`, for the byte budgets that
 /// bound the deep FIFO and a single deep read (both of which count `usize`
 /// bytes). The const assert keeps the two spellings in step, so the target has a
 /// single source of truth without an `as` cast the pedantic lints reject.
-pub(crate) const PHASE2_STARVING_READ_TARGET_BYTES_USIZE: usize = 2 << 20;
+pub(crate) const PHASE2_STARVING_READ_TARGET_BYTES_USIZE: usize = 4 << 20;
 const _: () =
     assert!(PHASE2_STARVING_READ_TARGET_BYTES_USIZE as u64 == PHASE2_STARVING_READ_TARGET_BYTES);
 

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -922,8 +922,10 @@ fn phase2_scan_start(
 ///
 /// [`NO_AWAITED_SOURCE`] means the consumer has not parked yet, and matches no
 /// index.
-fn phase2_deserves_deep_read(index: usize, frontier: usize, awaited: usize) -> bool {
-    index == frontier || (awaited != NO_AWAITED_SOURCE && index == awaited)
+fn phase2_deserves_deep_read(index: usize, frontier: usize, awaited: usize, next: usize) -> bool {
+    index == frontier
+        || (awaited != NO_AWAITED_SOURCE && index == awaited)
+        || (next != NO_AWAITED_SOURCE && index == next)
 }
 
 fn phase2_read_allowance(is_frontier: bool) -> (usize, usize) {
@@ -1509,6 +1511,25 @@ pub(crate) struct SharedPipelineState {
     /// The validity gate for that path: if this stays near zero the consumer never
     /// found an unclaimed block and the change is inert, whatever the clock says.
     pub(crate) consumer_self_served: AtomicU64,
+    /// The source the merge expects to consume *after* the current one, or
+    /// [`NO_AWAITED_SOURCE`].
+    ///
+    /// `phase2_awaited_source` is reactive -- it can only be set once the consumer
+    /// has already stalled. This is predictive, and the distinction is the whole
+    /// point: the merge starves at run transitions, where only 2,475 of 167,624
+    /// source switches starve but each costs ~20ms against an 8.4ms read latency,
+    /// because the read had not been *started* when the consumer arrived. Depth
+    /// cannot fix that -- doubling the read-ahead cap left the starved share of
+    /// park time at 99% -- but ~300 blocks of advance notice can.
+    pub(crate) phase2_next_source: AtomicUsize,
+    /// Predictions actually published to the pool.
+    ///
+    /// The validity gate for the predictive read-ahead path. `runner_up()` returns
+    /// `None` whenever fewer than two sources are active, and a version that
+    /// returned `None` always would look exactly like a null wall-clock result --
+    /// the deep-read path just never fires and nothing says so. A timing gain is
+    /// only attributable to prediction if this is non-zero.
+    pub(crate) phase2_predictions: AtomicU64,
 
     /// Read batches taken at the deep frontier allowance, and the blocks they
     /// returned; and the same for batches taken at the uniform allowance.
@@ -1594,6 +1615,8 @@ impl SharedPipelineState {
             wakes_on_running_worker: AtomicU64::new(0),
             wakes_recoverable: AtomicU64::new(0),
             park_supply: crate::merge_stalls::ParkSupplyCensus::default(),
+            phase2_next_source: AtomicUsize::new(NO_AWAITED_SOURCE),
+            phase2_predictions: AtomicU64::new(0),
             consumer_self_served: AtomicU64::new(0),
             deep_read_batches: AtomicU64::new(0),
             deep_read_blocks: AtomicU64::new(0),
@@ -1679,6 +1702,20 @@ impl SharedPipelineState {
         if let Some(handle) = self.worker_threads[idx].get() {
             handle.unpark();
         }
+    }
+
+    /// Publish the source the merge expects to consume next, so the pool can start
+    /// its read before the consumer gets there.
+    pub(crate) fn set_phase2_next_source(&self, next: Option<usize>) {
+        if next.is_some() {
+            self.phase2_predictions.fetch_add(1, Ordering::Relaxed);
+        }
+        self.phase2_next_source.store(next.unwrap_or(NO_AWAITED_SOURCE), Ordering::Relaxed);
+    }
+
+    /// Predictions published to the pool. See [`Self::phase2_predictions`].
+    pub(crate) fn phase2_predictions(&self) -> u64 {
+        self.phase2_predictions.load(Ordering::Relaxed)
     }
 
     /// How many workers are parked right now, and whether output compression is
@@ -2898,10 +2935,11 @@ impl SortWorkerPool {
             // entry-count allowances and an unbounded (`usize::MAX`) byte budget,
             // so they behave exactly as before.
             let awaited = shared.phase2_awaited_source.load(Ordering::Relaxed);
+            let next_source = shared.phase2_next_source.load(Ordering::Relaxed);
             let (raw_cap, read_batch, fifo_byte_budget, read_byte_budget) = if i == frontier {
                 let (cap, batch) = phase2_read_allowance(true);
                 (cap, batch, usize::MAX, usize::MAX)
-            } else if phase2_deserves_deep_read(i, frontier, awaited) {
+            } else if phase2_deserves_deep_read(i, frontier, awaited, next_source) {
                 let read_blocks = shared.phase2_read_blocks.load(Ordering::Relaxed);
                 let mean_block_bytes = if read_blocks == 0 {
                     0
@@ -2976,7 +3014,8 @@ impl SortWorkerPool {
             // allowance selection uses, so an awaited non-frontier source --
             // which reads at the deep allowance via `awaited_allowance_for` --
             // is counted as deep, not shallow.
-            let (batches, blocks) = if phase2_deserves_deep_read(i, frontier, awaited) {
+            let (batches, blocks) = if phase2_deserves_deep_read(i, frontier, awaited, next_source)
+            {
                 (&shared.deep_read_batches, &shared.deep_read_blocks)
             } else {
                 (&shared.shallow_read_batches, &shared.shallow_read_blocks)
@@ -3449,6 +3488,12 @@ impl SortWorkerPool {
         &self.shared.stage_latency
     }
 
+    /// Publish the source the merge expects to consume next, so the pool can start
+    /// that file's read before the consumer arrives.
+    pub(crate) fn set_phase2_next_source(&self, next: Option<usize>) {
+        self.shared.set_phase2_next_source(next);
+    }
+
     /// Consumer parks split by what the pool looked like when the park began.
     pub(crate) fn park_supply_report(&self) -> crate::merge_stalls::ParkSupplyReport {
         self.shared.park_supply.snapshot()
@@ -3494,6 +3539,11 @@ impl SortWorkerPool {
     /// Parks the consumer avoided by decompressing a block itself.
     pub(crate) fn consumer_self_served(&self) -> u64 {
         self.shared.consumer_self_served.load(Ordering::Relaxed)
+    }
+
+    /// Predictions published to the pool by the merge's loser tree.
+    pub(crate) fn phase2_predictions(&self) -> u64 {
+        self.shared.phase2_predictions()
     }
 
     /// Where the consumer's wakes landed.
@@ -3716,6 +3766,12 @@ impl SortWorkerPool {
         // forward, so neither is self-correcting.
         self.shared.phase2_lowest_active.store(0, Ordering::Release);
         self.shared.phase2_awaited_source.store(NO_AWAITED_SOURCE, Ordering::Release);
+        // The read-ahead prediction indexes the file vector being replaced, so a
+        // pool that merges twice would expose the prior merge's `runner_up`
+        // through `phase2_next_source` while the new merge seeds its sources --
+        // handing deep-read priority to an unrelated file until the new merge
+        // publishes its own prediction. Reset it to the sentinel here.
+        self.shared.phase2_next_source.store(NO_AWAITED_SOURCE, Ordering::Release);
         // The refill allowance is derived from `phase2_read_bytes /
         // phase2_read_blocks`, so these must describe only the set being
         // installed: mean spill-block size moves with the codec, the
@@ -4550,17 +4606,24 @@ mod tests {
     /// shallow allowance: the pool sat 1.9 decompressions deep of a tracked 8
     /// while the consumer waited 73% of the merge loop.
     #[rstest]
-    #[case::frontier_only(0, usize::MAX, 0, true)]
-    #[case::awaited_only(0, 5, 5, true)]
-    #[case::neither(0, 5, 3, false)]
-    #[case::no_awaited_source_yet(0, usize::MAX, 7, false)]
+    #[case::frontier_only(0, usize::MAX, usize::MAX, 0, true)]
+    #[case::awaited_only(0, 5, usize::MAX, 5, true)]
+    #[case::neither(0, 5, usize::MAX, 3, false)]
+    #[case::no_awaited_source_yet(0, usize::MAX, usize::MAX, 7, false)]
+    // The predicted next source reads deep too: reactive signals fire only after
+    // the consumer has already stalled, and a run transition costs ~20ms because
+    // the read had not been started when it arrived.
+    #[case::predicted_next_source(0, usize::MAX, 9, 9, true)]
+    #[case::predicted_next_is_not_the_candidate(0, usize::MAX, 9, 4, false)]
+    #[case::no_prediction_yet(0, usize::MAX, usize::MAX, 4, false)]
     fn the_blocked_file_reads_deep_even_when_it_is_not_the_frontier(
         #[case] frontier: usize,
         #[case] awaited: usize,
+        #[case] next: usize,
         #[case] candidate: usize,
         #[case] expect_deep: bool,
     ) {
-        let deep = phase2_deserves_deep_read(candidate, frontier, awaited);
+        let deep = phase2_deserves_deep_read(candidate, frontier, awaited, next);
         assert_eq!(deep, expect_deep);
         let expected = if expect_deep {
             (PHASE2_STARVING_RAW_CAP, PHASE2_STARVING_READ_BATCH)
@@ -4710,6 +4773,26 @@ mod tests {
     /// over the pool width instead sends most wakes to workers idled by the
     /// Phase 2 cap, which re-park without looking at the starving file — and
     /// the workers that could have refilled it wait out their full backoff.
+    /// A published prediction must be counted, and "no prediction" must not be.
+    ///
+    /// Without this counter a `runner_up()` that returned `None` on every call
+    /// would be indistinguishable from a null result: the deep-read path simply
+    /// never fires, wall clock lands wherever it lands, and nothing in the log
+    /// says the mechanism was inert. The measured -2.7% is only attributable to
+    /// prediction if predictions were actually published.
+    #[test]
+    fn test_published_predictions_are_counted_and_absent_ones_are_not() {
+        let shared = SharedPipelineState::new(2, std::thread::current());
+        assert_eq!(shared.phase2_predictions(), 0, "nothing published yet");
+
+        shared.set_phase2_next_source(Some(3));
+        shared.set_phase2_next_source(Some(1));
+        assert_eq!(shared.phase2_predictions(), 2, "each published source counts once");
+
+        shared.set_phase2_next_source(None);
+        assert_eq!(shared.phase2_predictions(), 2, "clearing the prediction is not a prediction");
+    }
+
     #[rstest]
     // A pool 8 wide capped to 3 must never select a worker above the cap, at
     // any point in the rotation.
@@ -5650,6 +5733,52 @@ mod tests {
             pool.shared.phase2_lowest_active.load(Ordering::Relaxed),
             0,
             "the new source set must be prioritized from its own first file"
+        );
+
+        pool.shutdown();
+    }
+
+    /// A pool that merges twice must not carry the first merge's read-ahead
+    /// prediction into the second.
+    ///
+    /// `phase2_next_source` indexes the file vector `set_phase2_files` replaces
+    /// and hands the named source deep-read priority. A value left from a
+    /// completed merge would give that priority to an unrelated file while the
+    /// new merge is still seeding its sources, before it has published a
+    /// prediction of its own -- so a fresh source set must reset it to the
+    /// sentinel.
+    #[test]
+    fn test_set_phase2_files_clears_the_read_ahead_prediction() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let spill = |name: &str| {
+            let path = dir.path().join(name);
+            let mut file = std::fs::File::create(&path).expect("create");
+            file.write_all(&[0x1f, 0x8b, 0x00, 0x00]).expect("write magic");
+            path
+        };
+
+        let pool = SortWorkerPool::new(1, 1, 6, SpillCodec::Bgzf);
+
+        // First merge: install a source and publish a prediction, as the merge
+        // loop does when the winning run changes.
+        pool.set_phase2_files(std::slice::from_ref(&spill("first.spill")))
+            .expect("set_phase2_files");
+        pool.set_phase2_next_source(Some(0));
+        assert_eq!(
+            pool.shared.phase2_next_source.load(Ordering::Relaxed),
+            0,
+            "guard: the first merge's prediction is published"
+        );
+
+        // Second merge: a fresh set must start with no prediction so no
+        // unrelated file inherits the previous merge's deep-read priority.
+        pool.set_phase2_files(&[spill("second-a.spill"), spill("second-b.spill")])
+            .expect("set_phase2_files");
+        assert_eq!(
+            pool.shared.phase2_next_source.load(Ordering::Relaxed),
+            NO_AWAITED_SOURCE,
+            "a fresh source set must clear the read-ahead prediction"
         );
 
         pool.shutdown();

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -879,24 +879,51 @@ fn awaited_allowance_for(mean_block_bytes: u64) -> (usize, usize) {
 
 /// The file index a Phase 2 scan starts at.
 ///
-/// The frontier -- the lowest source that has not delivered everything -- when
-/// it is starving, and the worker's own round-robin cursor otherwise. Gated on
-/// starving rather than applied always: a frontier that is merely *active* is
-/// the common case in an interleaved merge, and sending every worker to file 0
-/// there would undo the spread that makes that case fast.
+/// Three candidates, in order of how well each predicts what the merge needs
+/// next:
 ///
-/// `frontier` is only meaningful while it indexes a live file; past the end it
-/// names no source and the cursor stands.
+/// 1. The **awaited source** when starving -- the file the consumer is actually
+///    parked on. This is measured demand.
+/// 2. The **frontier** when starving -- the lowest source that has not delivered
+///    everything. A *proxy* for demand, correct only while sources drain in index
+///    order, which is what an input already in the requested order produces.
+/// 3. The worker's own round-robin cursor, which spreads workers over the file
+///    set and is what keeps a genuinely interleaved merge saturated.
 ///
-/// Pure so both branches of the gate are testable without racing a live pool,
+/// The awaited source outranks the frontier because the proxy is wrong exactly
+/// where it matters: on a partially-correlated input the merge parks on a source
+/// that is not the lowest undrained one, and pointing workers at the frontier
+/// sends them to a file nobody is waiting for. Measured on an 89-way merge, 71%
+/// of consumer park at 16 threads was spent waiting for *any* worker to claim
+/// the needed block while 94% of the other files sat at their buffer cap.
+///
+/// Both redirects are gated on starving rather than applied always. For the
+/// frontier, a merely *active* frontier is the common interleaved case and
+/// sending every worker to file 0 would undo the spread. For the awaited source
+/// the reason is sharper: it is never cleared between parks, so an ungated
+/// version would point every worker at one index permanently, trading a spread
+/// problem for a herd problem.
+///
+/// Neither index is meaningful past the end of the file set, where it names no
+/// source and the next candidate stands.
+///
+/// Pure so every branch of the gate is testable without racing a live pool,
 /// following [`classify_scan`](crate::merge_stalls::classify_scan).
 fn phase2_scan_start(
+    awaited: usize,
+    awaited_starving: bool,
     frontier: usize,
     num_files: usize,
     frontier_starving: bool,
     cursor: usize,
 ) -> usize {
-    if frontier < num_files && frontier_starving { frontier } else { cursor }
+    if awaited < num_files && awaited_starving {
+        awaited
+    } else if frontier < num_files && frontier_starving {
+        frontier
+    } else {
+        cursor
+    }
 }
 
 /// The `(raw_cap, read_batch)` a file may read at.
@@ -1530,6 +1557,12 @@ pub(crate) struct SharedPipelineState {
     /// the deep-read path just never fires and nothing says so. A timing gain is
     /// only attributable to prediction if this is non-zero.
     pub(crate) phase2_predictions: AtomicU64,
+    /// Set while the merge consumer is parked on a specific spill file.
+    ///
+    /// `phase2_awaited_source` cannot serve this purpose: it is never cleared
+    /// between parks, so keying on it would rank Phase 2 work first permanently
+    /// and undo the compress-first policy entirely.
+    pub(crate) consumer_parked: AtomicBool,
 
     /// Read batches taken at the deep frontier allowance, and the blocks they
     /// returned; and the same for batches taken at the uniform allowance.
@@ -1618,6 +1651,7 @@ impl SharedPipelineState {
             phase2_next_source: AtomicUsize::new(NO_AWAITED_SOURCE),
             phase2_predictions: AtomicU64::new(0),
             consumer_self_served: AtomicU64::new(0),
+            consumer_parked: AtomicBool::new(false),
             deep_read_batches: AtomicU64::new(0),
             deep_read_blocks: AtomicU64::new(0),
             shallow_read_batches: AtomicU64::new(0),
@@ -1682,12 +1716,15 @@ impl SharedPipelineState {
         self.wakes_issued.fetch_add(1, Ordering::Relaxed);
         let cursor = self.wake_cursor.fetch_add(1, Ordering::Relaxed);
         let limit = self.active_worker_limit.load(Ordering::Acquire);
-        let idx = Self::wake_target(cursor, limit, self.worker_threads.len());
-        // Accounting only -- the target is unchanged. A wake aimed at a worker
-        // that is already running does nothing, and the consumer then waits for
-        // some other worker's backoff to expire instead. Splitting "landed on a
-        // running worker" from "nobody was parked" separates a targeting defect
-        // from a genuinely saturated pool; only the former is recoverable.
+        let idx =
+            Self::wake_target_preferring_parked(cursor, limit, self.worker_threads.len(), |i| {
+                self.worker_parked[i].load(Ordering::Relaxed)
+            });
+        // The same accounting now doubles as this preference's validity gate: if
+        // it works, "hit an already-running worker" must fall and "recoverable"
+        // must go to roughly zero, because a passed-over sleeper is exactly what
+        // the preference removes. A `recoverable` share that stays high means the
+        // parked flags are going stale between the scan and the unpark.
         if !self.worker_parked[idx].load(Ordering::Relaxed) {
             self.wakes_on_running_worker.fetch_add(1, Ordering::Relaxed);
             let width = limit.min(self.worker_parked.len());
@@ -1750,6 +1787,33 @@ impl SharedPipelineState {
         cursor % active_limit.clamp(1, pool_width.max(1))
     }
 
+    /// The worker a wake should target, preferring one that is actually parked.
+    ///
+    /// The rotating cursor alone is blind to park state, and at low utilization
+    /// that is where the merge's idle time comes from: a wake spent on a running
+    /// worker leaves an available sleeper asleep for up to `MAX_BACKOFF_US`.
+    /// Measured at t16, parks where a sleeper existed cost 190us against 30us
+    /// when every worker was genuinely busy -- 391,007 of them, 74.4s of a 92.1s
+    /// park. At t8, where workers are 91% busy and essentially never sleep, that
+    /// class is 0.1% of parks and this preference has nothing to act on.
+    ///
+    /// Falls back to the rotating target when nobody is parked, which keeps the
+    /// spread that a genuinely interleaved merge needs. The scan still starts at
+    /// the cursor, so it rotates too rather than concentrating on low indices.
+    fn wake_target_preferring_parked<F>(
+        cursor: usize,
+        active_limit: usize,
+        pool_width: usize,
+        is_parked: F,
+    ) -> usize
+    where
+        F: Fn(usize) -> bool,
+    {
+        let width = active_limit.clamp(1, pool_width.max(1));
+        crate::merge_stalls::first_parked_from(cursor, width, is_parked)
+            .unwrap_or_else(|| Self::wake_target(cursor, active_limit, pool_width))
+    }
+
     /// Advance the drain frontier past every source that is now fully drained.
     ///
     /// Called by the merge consumer when a source reports drained. Walks rather
@@ -1787,6 +1851,7 @@ impl SharedPipelineState {
 
             compress_has_items: !self.compress_queue.is_empty(),
             phase: current_phase,
+            consumer_parked: self.consumer_parked.load(Ordering::Relaxed),
         }
     }
 }
@@ -1949,6 +2014,15 @@ struct SortBackpressureState {
     // Shared
     compress_has_items: bool,
     phase: u8,
+    /// Whether the merge consumer is parked right now, waiting on one specific
+    /// spill file.
+    ///
+    /// Output compression is throughput work any worker can do at any time; the
+    /// awaited block is the only thing that can unblock the merge. Measured at
+    /// t16 before this existed: only 10.8% of recruitments served the consumer as
+    /// the woken worker's first action, the rest completing a mean 3.5 other
+    /// steps first, ~2 of them output compress at 188us each.
+    consumer_parked: bool,
 }
 
 /// Backpressure-driven priority selection — the sort pipeline's equivalent
@@ -1981,7 +2055,13 @@ fn get_sort_priorities(bp: &SortBackpressureState) -> &'static [SortStep] {
             // worker grabs whatever has work. We never gate on `all_chunks_eof`
             // — even after disk reads finish, decompression and parser drain
             // continue until all per-file reorder buffers empty.
-            if bp.compress_has_items {
+            if bp.consumer_parked {
+                // The merge is blocked on one specific file. Output compression
+                // is throughput work any worker can do at any time; this block is
+                // the only thing that can unblock the consumer, so it goes first
+                // even though the compress queue is the writer-side bottleneck.
+                &[SortStep::Phase2FileWork, SortStep::Compress]
+            } else if bp.compress_has_items {
                 // Drain output compression while we can; it's the writer-side bottleneck.
                 &[SortStep::Compress, SortStep::Phase2FileWork]
             } else {
@@ -2818,7 +2898,18 @@ impl SortWorkerPool {
         // that makes that case fast.
         let frontier = shared.phase2_lowest_active.load(Ordering::Relaxed);
         let frontier_starving = files.get(frontier).is_some_and(Phase2FileState::is_starving);
-        let start = phase2_scan_start(frontier, n, frontier_starving, worker.phase2_file_cursor);
+        // The file the consumer is parked on, which the frontier only coincides
+        // with when sources drain in index order.
+        let awaited = shared.phase2_awaited_source.load(Ordering::Relaxed);
+        let awaited_starving = files.get(awaited).is_some_and(Phase2FileState::is_starving);
+        let start = phase2_scan_start(
+            awaited,
+            awaited_starving,
+            frontier,
+            n,
+            frontier_starving,
+            worker.phase2_file_cursor,
+        );
 
         for offset in 0..n {
             let i = (start + offset) % n;
@@ -4486,7 +4577,63 @@ mod tests {
         #[case] cursor: usize,
         #[case] expected: usize,
     ) {
-        assert_eq!(phase2_scan_start(frontier, num_files, frontier_starving, cursor), expected);
+        assert_eq!(
+            phase2_scan_start(
+                NO_AWAITED_SOURCE,
+                false,
+                frontier,
+                num_files,
+                frontier_starving,
+                cursor
+            ),
+            expected
+        );
+    }
+
+    /// A starving *awaited* source outranks the frontier, because it is measured
+    /// demand rather than a proxy for it.
+    ///
+    /// The frontier is only the file the merge reaches next when sources drain in
+    /// index order. On a partially-correlated input they do not, which is the
+    /// assumption that cost this merge 126s of read-ahead going to the wrong
+    /// file. The consumer knows which file it is parked on; this is what lets the
+    /// pool act on it.
+    ///
+    /// Gated on starving for the same reason the frontier is: `awaited` is never
+    /// cleared between parks, so an ungated version would send every worker to
+    /// one index permanently and trade a spread problem for a herd problem.
+    #[rstest]
+    // Measured demand beats the proxy, and beats the cursor.
+    #[case::starving_awaited_outranks_a_starving_frontier(5, true, 0, 8, true, 2, 5)]
+    #[case::starving_awaited_outranks_an_active_frontier(5, true, 0, 8, false, 2, 5)]
+    #[case::starving_awaited_beats_the_cursor(6, true, 9, 8, false, 2, 6)]
+    // An awaited file with data to give must not pull workers off the spread.
+    #[case::active_awaited_defers_to_a_starving_frontier(5, false, 3, 8, true, 2, 3)]
+    #[case::active_awaited_defers_to_the_cursor(5, false, 0, 8, false, 2, 2)]
+    // Unset, or past the end, names no live source.
+    #[case::unset_awaited_defers(NO_AWAITED_SOURCE, true, 3, 8, true, 2, 3)]
+    #[case::awaited_past_the_end_defers(8, true, 3, 8, true, 2, 3)]
+    #[case::no_files_defers(0, true, 0, 0, true, 0, 0)]
+    fn phase2_scan_prefers_a_starving_awaited_source(
+        #[case] awaited: usize,
+        #[case] awaited_starving: bool,
+        #[case] frontier: usize,
+        #[case] num_files: usize,
+        #[case] frontier_starving: bool,
+        #[case] cursor: usize,
+        #[case] expected: usize,
+    ) {
+        assert_eq!(
+            phase2_scan_start(
+                awaited,
+                awaited_starving,
+                frontier,
+                num_files,
+                frontier_starving,
+                cursor
+            ),
+            expected
+        );
     }
 
     /// Only the drain frontier gets the deep allowance.
@@ -4793,6 +4940,64 @@ mod tests {
         assert_eq!(shared.phase2_predictions(), 2, "clearing the prediction is not a prediction");
     }
 
+    /// A wake spent on a running worker while a sleeper sits idle is the merge's
+    /// largest single idle cost at t16 -- 74.4s of a 92.1s park. The preference
+    /// must actually find the sleeper.
+    #[test]
+    fn test_wake_prefers_a_parked_worker_over_the_rotating_target() {
+        let parked = [false, false, true, false];
+        let at = |i: usize| parked[i];
+        assert_eq!(
+            SharedPipelineState::wake_target_preferring_parked(0, 4, 4, at),
+            2,
+            "the rotating target is 0 and running; worker 2 is asleep and gets the wake"
+        );
+    }
+
+    /// Falling back to the rotation is what preserves the spread an interleaved
+    /// merge needs, so a saturated pool must behave exactly as before.
+    #[test]
+    fn test_wake_falls_back_to_rotation_when_nobody_is_parked() {
+        for cursor in 0..8 {
+            assert_eq!(
+                SharedPipelineState::wake_target_preferring_parked(cursor, 4, 4, |_| false),
+                SharedPipelineState::wake_target(cursor, 4, 4),
+                "with nobody parked the target must be unchanged at cursor {cursor}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_wake_keeps_the_rotating_target_when_it_is_itself_parked() {
+        let parked = [true, true, true, true];
+        assert_eq!(SharedPipelineState::wake_target_preferring_parked(2, 4, 4, |i| parked[i]), 2);
+    }
+
+    /// Capped workers will not take Phase 2 work, so waking one is the same lost
+    /// wake by another route -- the preference must stay inside the active window.
+    #[test]
+    fn test_wake_preference_ignores_workers_outside_the_active_limit() {
+        let parked = [false, false, true, true];
+        let at = |i: usize| parked[i];
+        assert_eq!(
+            SharedPipelineState::wake_target_preferring_parked(0, 2, 4, at),
+            SharedPipelineState::wake_target(0, 2, 4),
+            "workers 2 and 3 are parked but capped out, so the rotation stands"
+        );
+    }
+
+    /// The scan starts at the cursor, so successive wakes with several sleepers
+    /// spread rather than piling onto the lowest index.
+    #[test]
+    fn test_wake_preference_rotates_across_several_sleepers() {
+        let parked = [true, false, true, false];
+        let at = |i: usize| parked[i];
+        let picks: Vec<usize> = (0..4)
+            .map(|c| SharedPipelineState::wake_target_preferring_parked(c, 4, 4, at))
+            .collect();
+        assert_eq!(picks, vec![0, 2, 2, 0], "each wake starts scanning from its own cursor");
+    }
+
     #[rstest]
     // A pool 8 wide capped to 3 must never select a worker above the cap, at
     // any point in the rotation.
@@ -5012,6 +5217,7 @@ mod tests {
             input_eof: false,
             decompressed_input_done: false,
             compress_has_items: false,
+            consumer_parked: false,
             phase: phase::PHASE1,
         };
         let priorities = get_sort_priorities(&bp);
@@ -5025,6 +5231,7 @@ mod tests {
             input_eof: false,
             decompressed_input_done: false,
             compress_has_items: true,
+            consumer_parked: false,
             phase: phase::PHASE1,
         };
         let priorities = get_sort_priorities(&bp);
@@ -5038,6 +5245,7 @@ mod tests {
             input_eof: true,
             decompressed_input_done: true,
             compress_has_items: false,
+            consumer_parked: false,
             phase: phase::PHASE1,
         };
         assert!(get_sort_priorities(&bp).is_empty());
@@ -5050,6 +5258,7 @@ mod tests {
             input_eof: false,
             decompressed_input_done: false,
             compress_has_items: false,
+            consumer_parked: false,
             phase: phase::PHASE2,
         };
         let priorities = get_sort_priorities(&bp);
@@ -5063,6 +5272,7 @@ mod tests {
             input_eof: false,
             decompressed_input_done: false,
             compress_has_items: true,
+            consumer_parked: false,
             phase: phase::PHASE2,
         };
         let priorities = get_sort_priorities(&bp);
@@ -5078,10 +5288,62 @@ mod tests {
             input_eof: false,
             decompressed_input_done: false,
             compress_has_items: false,
+            consumer_parked: false,
             phase: phase::PHASE2,
         };
         let priorities = get_sort_priorities(&bp);
         assert_eq!(priorities[0], SortStep::Phase2FileWork);
+    }
+
+    /// Output compression is throughput work any worker can do at any time. The
+    /// awaited block is the only thing that can unblock the merge, so a parked
+    /// consumer must outrank compression.
+    #[test]
+    fn test_sort_priorities_phase2_parked_consumer_outranks_compression() {
+        let bp = SortBackpressureState {
+            decompressed_input_low: false,
+            input_eof: false,
+            decompressed_input_done: false,
+            compress_has_items: true,
+            consumer_parked: true,
+            phase: phase::PHASE2,
+        };
+        assert_eq!(get_sort_priorities(&bp)[0], SortStep::Phase2FileWork);
+    }
+
+    /// With the consumer running, compress-first is preserved exactly: it is the
+    /// writer-side bottleneck and draining it is what keeps output moving.
+    #[test]
+    fn test_sort_priorities_phase2_keeps_compress_first_when_consumer_runs() {
+        let bp = SortBackpressureState {
+            decompressed_input_low: false,
+            input_eof: false,
+            decompressed_input_done: false,
+            compress_has_items: true,
+            consumer_parked: false,
+            phase: phase::PHASE2,
+        };
+        assert_eq!(get_sort_priorities(&bp)[0], SortStep::Compress);
+    }
+
+    /// Both steps stay reachable either way -- dropping one would starve it
+    /// outright rather than deprioritize it, and output must keep draining even
+    /// while the consumer is blocked.
+    #[rstest]
+    #[case::consumer_parked(true)]
+    #[case::consumer_running(false)]
+    fn test_sort_priorities_phase2_always_offers_both_steps(#[case] consumer_parked: bool) {
+        let bp = SortBackpressureState {
+            decompressed_input_low: false,
+            input_eof: false,
+            decompressed_input_done: false,
+            compress_has_items: true,
+            consumer_parked,
+            phase: phase::PHASE2,
+        };
+        let p = get_sort_priorities(&bp);
+        assert!(p.contains(&SortStep::Compress), "compression must stay reachable");
+        assert!(p.contains(&SortStep::Phase2FileWork), "file work must stay reachable");
     }
 
     #[test]
@@ -5091,6 +5353,7 @@ mod tests {
             input_eof: false,
             decompressed_input_done: false,
             compress_has_items: true,
+            consumer_parked: false,
             phase: phase::LEGACY,
         };
         let priorities = get_sort_priorities(&bp);

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -1504,6 +1504,11 @@ pub(crate) struct SharedPipelineState {
     /// park: a sleeper was available, everyone was busy compressing, or everyone
     /// was busy merging. See [`crate::merge_stalls::ParkSupply`].
     pub(crate) park_supply: crate::merge_stalls::ParkSupplyCensus,
+    /// Parks avoided because the consumer decompressed the block itself.
+    ///
+    /// The validity gate for that path: if this stays near zero the consumer never
+    /// found an unclaimed block and the change is inert, whatever the clock says.
+    pub(crate) consumer_self_served: AtomicU64,
 
     /// Read batches taken at the deep frontier allowance, and the blocks they
     /// returned; and the same for batches taken at the uniform allowance.
@@ -1589,6 +1594,7 @@ impl SharedPipelineState {
             wakes_on_running_worker: AtomicU64::new(0),
             wakes_recoverable: AtomicU64::new(0),
             park_supply: crate::merge_stalls::ParkSupplyCensus::default(),
+            consumer_self_served: AtomicU64::new(0),
             deep_read_batches: AtomicU64::new(0),
             deep_read_blocks: AtomicU64::new(0),
             shallow_read_batches: AtomicU64::new(0),
@@ -1748,6 +1754,39 @@ impl SharedPipelineState {
     }
 }
 
+/// The decompression state one thread needs to turn a spill block into records.
+///
+/// Extracted from [`SortWorkerState`] so the merge consumer can run
+/// [`SortWorkerPool::decompress_and_publish`] itself instead of parking. A second
+/// copy of the codec branch would be the alternative, and a spill format that
+/// disagreed between the two paths is exactly the class of bug that passes the
+/// standard matrix and fails where spill volume is largest.
+pub(crate) struct DecompressorSet {
+    zstd: ZstdDecompressor<'static>,
+    /// Scratch for one zstd frame, sized by [`zstd_decomp_cap`]. Allocated lazily:
+    /// a BGZF-only sort must not pay for it.
+    zstd_buf: Vec<u8>,
+    bgzf: libdeflater::Decompressor,
+}
+
+impl DecompressorSet {
+    /// Sized for `codec`: the zstd scratch is pre-allocated only for zstd spills,
+    /// so a BGZF-only sort does not carry `zstd_decomp_cap()` per thread. The
+    /// decompress path still resizes on demand, so this is an optimization rather
+    /// than a precondition.
+    pub(crate) fn for_codec(codec: SpillCodec) -> Self {
+        let zstd_buf = match codec {
+            SpillCodec::Zstd => vec![0u8; zstd_decomp_cap()],
+            SpillCodec::Bgzf => Vec::new(),
+        };
+        Self {
+            zstd: ZstdDecompressor::new().expect("zstd decompressor init"),
+            zstd_buf,
+            bgzf: libdeflater::Decompressor::new(),
+        }
+    }
+}
+
 /// Per-worker mutable state — no sharing, no locks.
 ///
 /// Every step output has a held-item slot. If an `ArrayQueue::push()` fails
@@ -1763,12 +1802,8 @@ struct SortWorkerState {
     output_compressor: InlineBgzfCompressor,
     /// Zstd compressor reused across spill frames when `SpillCodec::Zstd`.
     zstd_compressor: ZstdCompressor<'static>,
-    /// Zstd decompressor reused across Phase 2 frames when `SpillCodec::Zstd`.
-    zstd_decompressor: ZstdDecompressor<'static>,
-    /// Scratch buffer reused across zstd frame decompressions to avoid
-    /// allocating a fresh Vec for every frame on the merge hot path.
-    zstd_decompress_buf: Vec<u8>,
-    decompressor: libdeflater::Decompressor,
+    /// Decompression state, shared in shape with the merge consumer.
+    decomp: DecompressorSet,
     /// Phase 2 file scan cursor — starts at `worker_id` and advances on success
     /// for cache locality and reduced lock contention. Workers no longer own a
     /// fixed subset of files; any worker can do work on any file.
@@ -2147,20 +2182,13 @@ impl SortWorkerPool {
                 thread::spawn(move || {
                     let zstd_level =
                         i32::try_from(temp_compression.clamp(1, ZSTD_MAX_CLEVEL)).expect("clamped");
-                    let zstd_decompress_buf = if matches!(spill_codec, SpillCodec::Zstd) {
-                        vec![0u8; zstd_decomp_cap()]
-                    } else {
-                        Vec::new()
-                    };
                     let mut worker = SortWorkerState {
                         worker_id,
                         compressor: InlineBgzfCompressor::new(temp_compression),
                         output_compressor: InlineBgzfCompressor::new(output_compression),
                         zstd_compressor: ZstdCompressor::new(zstd_level)
                             .expect("zstd compressor init"),
-                        zstd_decompressor: ZstdDecompressor::new().expect("zstd decompressor init"),
-                        zstd_decompress_buf,
-                        decompressor: libdeflater::Decompressor::new(),
+                        decomp: DecompressorSet::for_codec(spill_codec),
                         phase2_file_cursor: worker_id,
                         held_raw_input_blocks: Vec::new(),
                         held_decompressed_input: None,
@@ -2643,7 +2671,7 @@ impl SortWorkerPool {
             return StepResult::InputEmpty;
         };
 
-        let data = match decompress_block(&block, &mut worker.decompressor) {
+        let data = match decompress_block(&block, &mut worker.decomp.bgzf) {
             Ok(d) => d,
             Err(e) => {
                 log::error!("BGZF decompression error (input block serial {serial}): {e}");
@@ -2790,7 +2818,13 @@ impl SortWorkerPool {
                         worker.won_awaited_claim = Self::stamp_awaited_claim(shared);
                     }
                     Self::note_claim(shared, file, &entry);
-                    return Self::decompress_and_publish(shared, worker, file, i, entry);
+                    return Self::decompress_and_publish(
+                        shared,
+                        &mut worker.decomp,
+                        file,
+                        i,
+                        entry,
+                    );
                 }
             };
 
@@ -3071,7 +3105,7 @@ impl SortWorkerPool {
     /// responsible for releasing.
     fn decompress_and_publish(
         shared: &SharedPipelineState,
-        worker: &mut SortWorkerState,
+        decomp: &mut DecompressorSet,
         file: &Phase2FileState,
         source_idx: usize,
         entry: RawEntry,
@@ -3084,7 +3118,7 @@ impl SortWorkerPool {
                     shared
                         .merge_phases
                         .decompress
-                        .time(|| decompress_block(&raw_block, &mut worker.decompressor))
+                        .time(|| decompress_block(&raw_block, &mut decomp.bgzf))
                 }) {
                     Ok(d) => d,
                     Err(e) => {
@@ -3101,22 +3135,21 @@ impl SortWorkerPool {
             SpillCodec::Zstd => {
                 // Allocate the scratch buffer lazily so BGZF-only sorts don't
                 // pay 256 KiB × num_workers of dead memory.
-                if worker.zstd_decompress_buf.len() < zstd_decomp_cap() {
-                    worker.zstd_decompress_buf.resize(zstd_decomp_cap(), 0);
+                if decomp.zstd_buf.len() < zstd_decomp_cap() {
+                    decomp.zstd_buf.resize(zstd_decomp_cap(), 0);
                 }
                 match shared.stage_latency.decompress.time(|| {
-                    shared.merge_phases.decompress.time(|| {
-                        worker
-                            .zstd_decompressor
-                            .decompress_to_buffer(&raw_bytes, &mut worker.zstd_decompress_buf)
-                    })
+                    shared
+                        .merge_phases
+                        .decompress
+                        .time(|| decomp.zstd.decompress_to_buffer(&raw_bytes, &mut decomp.zstd_buf))
                 }) {
                     // Copy the `n` decompressed bytes (≤ one staging-buffer's
                     // worth, typically ~65 KB) into a fresh Vec for the
                     // consumer. The scratch buffer keeps its 256 KiB capacity so
                     // the next frame on this worker reuses it without
                     // reallocating.
-                    Ok(n) => worker.zstd_decompress_buf[..n].to_vec(),
+                    Ok(n) => decomp.zstd_buf[..n].to_vec(),
                     Err(e) => {
                         log::error!(
                             "zstd decompression error (chunk source {source_idx} serial {serial}): {e}"
@@ -3419,6 +3452,48 @@ impl SortWorkerPool {
     /// Consumer parks split by what the pool looked like when the park began.
     pub(crate) fn park_supply_report(&self) -> crate::merge_stalls::ParkSupplyReport {
         self.shared.park_supply.snapshot()
+    }
+
+    /// Decompress one already-read block for `source_idx` on the calling thread,
+    /// returning whether it published anything.
+    ///
+    /// For the merge consumer to call instead of parking. The block it needs is
+    /// sitting in the raw FIFO, read but unclaimed, in 12% of parks -- and parking
+    /// there trades ~53us of work for a ~190us wait on a worker that has to be
+    /// woken first.
+    ///
+    /// The deeper reason is that the consumer's exposed latency is **per block,
+    /// not per park**: raising `PHASE2_DECOMP_CAP` from 8 to 128 cut parks from
+    /// 978,325 to 400,487 and left total park time at 89.6s against 89.7s, while
+    /// wall clock got monotonically worse. A cost that survives a 16x change in
+    /// buffer depth is not a buffering problem and not a signalling one -- eight
+    /// scheduling interventions moved their own metrics and left the clock alone.
+    /// What is left is the producer-to-consumer handoff itself, and the only way
+    /// to remove a handoff is for one thread to do both halves.
+    ///
+    /// Goes through the same [`Self::try_pop_raw_for_decompress`] and
+    /// [`Self::decompress_and_publish`] as a worker, so the in-flight counter and
+    /// the reorder-buffer protocol cannot drift between the two paths. Publishing
+    /// rather than consuming the block directly is deliberate: the consumer then
+    /// picks it up through its ordinary path, and nothing about serial ordering
+    /// gets a second implementation.
+    ///
+    /// Safe to call while parked-pending: the consumer holds no locks, so it
+    /// cannot participate in a cycle with a worker.
+    pub(crate) fn consumer_decompress_one(
+        shared: &SharedPipelineState,
+        decomp: &mut DecompressorSet,
+        file: &Phase2FileState,
+        source_idx: usize,
+    ) -> bool {
+        let Ok(entry) = Self::try_pop_raw_for_decompress(file) else { return false };
+        let _ = Self::decompress_and_publish(shared, decomp, file, source_idx, entry);
+        true
+    }
+
+    /// Parks the consumer avoided by decompressing a block itself.
+    pub(crate) fn consumer_self_served(&self) -> u64 {
+        self.shared.consumer_self_served.load(Ordering::Relaxed)
     }
 
     /// Where the consumer's wakes landed.

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -138,17 +138,38 @@ pub(crate) fn read_length_prefix<R: std::io::Read + ?Sized>(
     Ok(Some(frame_len))
 }
 
-/// Cap on uncompressed size of a zstd spill frame. Production frames are
-/// bounded by the staging buffer (`BGZF_MAX_BLOCK_SIZE` + padding ~= 68 KB);
-/// this leaves slack but stays small enough that per-frame allocations don't
-/// dominate the merge phase when there are many tens of thousands of frames.
-const ZSTD_FRAME_DECOMP_CAP: usize = 256 * 1024;
+/// Cap on the uncompressed size of a zstd spill frame.
+///
+/// Derived from the writer's frame size rather than fixed, because a buffer
+/// smaller than the largest frame the writer can emit fails to decompress
+/// *every* frame at that size -- a total-failure mode, not a slow one.
+///
+/// The slack is **proportional** (4x), not a fixed addend, and that is
+/// load-bearing rather than tidiness. This buffer is per-worker scratch touched
+/// once per decompressed frame -- millions of times in a spill-heavy merge -- so
+/// its size is a cache-locality parameter, not just an allocation. A fixed
+/// `+ 4 MiB` of slack measured **249.5s against a 199.2s baseline (+25%)** at the
+/// default frame size, because it took 8 workers from 2 MiB of hot scratch to
+/// 32.5 MiB while peak RSS barely moved. At 4x it evaluates to exactly the 256
+/// KiB this constant held before it was derived, so the default path is
+/// unchanged and larger frames scale with it.
+///
+/// The 256 KiB floor matters because `BGZF_MAX_BLOCK_SIZE` is 65,280 -- not
+/// 65,536 -- so a bare 4x lands 1 KiB *under* the tuned value rather than on it.
+#[must_use]
+pub(crate) const fn zstd_decomp_cap() -> usize {
+    let scaled = 4 * crate::bgzf_io::SPILL_FRAME_BYTES;
+    if scaled > 256 * 1024 { scaled } else { 256 * 1024 }
+}
 
-/// Hard cap on the `u32 LE` length prefix of any zstd spill frame. Frames are
-/// produced one per ~64 KiB of input by `compress_job`; even
-/// pathological expansion can't reach this. Beyond it, we treat the value as
-/// corruption rather than allocate gigabytes.
-pub(crate) const MAX_ZSTD_FRAME_BYTES: usize = 2 * 1024 * 1024;
+/// Hard cap on the `u32 LE` length prefix of any zstd spill frame.
+///
+/// Scaled from the writer's frame size so the guard can never reject a frame
+/// this build is capable of emitting, while still refusing to allocate gigabytes
+/// on a corrupt prefix. Compressed frames are smaller than their input in
+/// practice, so the doubling is pure slack.
+pub(crate) const MAX_ZSTD_FRAME_BYTES: usize =
+    2 * 1024 * 1024 + 2 * crate::bgzf_io::SPILL_FRAME_BYTES;
 
 /// Maximum zstd compression level recognized by the `zstd` crate.
 const ZSTD_MAX_CLEVEL: u32 = 22;
@@ -2106,7 +2127,7 @@ impl SortWorkerPool {
                     let zstd_level =
                         i32::try_from(temp_compression.clamp(1, ZSTD_MAX_CLEVEL)).expect("clamped");
                     let zstd_decompress_buf = if matches!(spill_codec, SpillCodec::Zstd) {
-                        vec![0u8; ZSTD_FRAME_DECOMP_CAP]
+                        vec![0u8; zstd_decomp_cap()]
                     } else {
                         Vec::new()
                     };
@@ -3059,8 +3080,8 @@ impl SortWorkerPool {
             SpillCodec::Zstd => {
                 // Allocate the scratch buffer lazily so BGZF-only sorts don't
                 // pay 256 KiB × num_workers of dead memory.
-                if worker.zstd_decompress_buf.len() < ZSTD_FRAME_DECOMP_CAP {
-                    worker.zstd_decompress_buf.resize(ZSTD_FRAME_DECOMP_CAP, 0);
+                if worker.zstd_decompress_buf.len() < zstd_decomp_cap() {
+                    worker.zstd_decompress_buf.resize(zstd_decomp_cap(), 0);
                 }
                 match shared.stage_latency.decompress.time(|| {
                     shared.merge_phases.decompress.time(|| {

--- a/crates/fgumi-sort/src/zspill_stream.rs
+++ b/crates/fgumi-sort/src/zspill_stream.rs
@@ -17,14 +17,27 @@
 use crate::codec::ZSPILL_MAGIC;
 use std::io::{self, Read};
 
-/// Cap on the uncompressed size of a single zstd spill frame. Production
-/// frames are bounded by the producer's staging buffer
-/// (`BGZF_MAX_BLOCK_SIZE` + padding ~= 68 KB), so 256 KiB leaves comfortable
-/// slack. If a frame ever decompresses to more bytes than this,
+/// Cap on the uncompressed size of a single zstd spill frame.
+///
+/// If a frame decompresses to more than this,
 /// `zstd::bulk::Decompressor::decompress_to_buffer` surfaces a clear error
-/// rather than silently truncating. Kept in sync with `ZSTD_FRAME_DECOMP_CAP`
-/// in `worker_pool.rs`.
-const FRAME_DECOMP_CAP: usize = 256 * 1024;
+/// rather than silently truncating.
+///
+/// **Derived** from the pool's cap rather than kept in step with it by comment.
+/// This reader serves the consolidation path while `worker_pool` serves the
+/// merge, so a cap that is smaller than the writer's frame size fails only the
+/// consolidating configurations -- the ones the standard matrix does not
+/// exercise. `test_frame_caps_admit_the_largest_frame_the_writer_emits` pins
+/// them together.
+const FRAME_DECOMP_CAP: usize = crate::worker_pool::zstd_decomp_cap();
+
+/// The frame cap this reader enforces, exposed so it can be pinned against the
+/// writer's frame size rather than trusted to stay in step.
+#[cfg(test)]
+#[must_use]
+pub(crate) const fn frame_decomp_cap() -> usize {
+    FRAME_DECOMP_CAP
+}
 
 /// Streaming decompressor for "ZSP1" spill files.
 pub struct ZspillStreamReader<R: Read> {


### PR DESCRIPTION
Stacked on the instrumentation PR. The changes that moved wall clock, plus four pieces of hygiene found along the way — and an honest account of how much is left, because it turns out to be the more useful result.

**Every number below is a paired control and arm in one boot on one host.** `c7g.4xlarge`, `1kg-wgs-HG00096`, coordinate → template-coordinate, `--max-memory 512M --max-temp-files 1024 --temp-compression 1 --compression-level 1`, 779,820,469 records. `--max-memory` is per thread, so t8 spills 89 runs and t16 spills 44 — different merges, whose absolute walls are not comparable to each other.

## Result

Control is `main`, which now contains #806.

| | merge wall | consumer CPU | park | worker util | peak RSS |
| --- | --- | --- | --- | --- | --- |
| **t16** `main` | 174.6s | 74.3s | 97.8s | 51% | 9.599 GB |
| **t16** this PR | **157.7s (−9.7%)** | 113.0s | 44.2s | 57% | 10.568 GB |
| **t8** `main` | 197.2s | 75.4s | 121.6s | 89% | 4.813 GB |
| **t8** this PR | **189.8s (−3.8%)** | 187.8s | 1.4s | 93% | 9.344 GB |

`fgumi compare bams --command sort` reports **IDENTICAL** on the full 779,820,469 records — which is what licenses reading these gaps as overhead removed rather than work skipped.

**These are marginal figures for this PR alone.** An earlier draft of this work quoted −42.5% at t8; that was cumulative from before #806, which did the heavy lifting (326.5s → ~200s). This PR is the next 4.3% at t8 and 10.8% at t16.

## What it costs

**Peak RSS grows, and at t8 it nearly doubles: 4.813 → 9.344 GB (+94%). At t16 it is +10% (9.599 → 10.568 GB).** Phase 2 read-ahead is not charged against `--max-memory`, so this is real footprint on top of the budget, and it scales with the number of spill files rather than with the budget — t8 has 89 files against t16's 44, which is why the same change costs so much more there.

At t16 the growth is attributable: disabling only the predictive read-ahead returns RSS to baseline (9.594 GB against an uninstrumented 9.572 GB, measured on #806's pre-merge head). **So top-k is essentially all of the t16 growth — for −4.6% of wall.** The t8 split is not isolated; if a reviewer wants it attributed before merge, say so and I will run it.

Anyone sizing a host on `--max-memory` alone should know this. It is the hazard the sort sweep's own documentation warns about: a tighter budget spills more runs, so the widest merges land on the hosts least able to absorb them.

## The one finding worth carrying forward

**Targeted depth wins; uniform depth fails.** Fifteen interventions were measured. Three paid, and all three gave depth to the single file the consumer was blocked on or about to reach:

| change | measured |
| --- | --- |
| read ahead 4 MiB rather than 2 MiB on the blocked file | −2.8% t8, −5.2% t16 |
| let the consumer decompress a block itself instead of parking | park 122.2 → 2.8s at t8 |
| let the loser tree name the *next* source so its read starts early | **−4.6% t16**, isolated |

Everything that spread depth uniformly failed: decompress cap 32/128 (+2.3%/+3.4%), raw cap 16/32 (~0%/−0.6%), filling the cap on every claim (+36%). Everything that tried to signal workers better also failed: wake targeting (−0.9%), priority reorder (0.06%), scan-start redirect (0%).

Both failure modes share one cause. 98-99% of residual park time is `starved` — nothing buffered, nothing in flight, nothing read at all — while the device runs at 323 of 1000 MB/s provisioned. Uniform depth offers somewhere to put work that does not exist yet; better signalling wakes a worker to do work that does not exist yet. Only naming *which* file to start reading changes anything.

## Headroom left, stated plainly

This is the part I would want to read first as a reviewer, and it is not flattering to the PR.

**At t8 the merge is now at its floor — but the floor moved.** Merge 189.8s = consumer serial CPU 187.8s (98.9%) + park 1.4s, with a worker floor of 1410.5s ÷ 8 = 176.3s. Recoverable without doing less work: **2.0s, 1.1%.**

That is worth reading carefully, because it is not the same as "we captured the available headroom". On `main` at t8 the merge was *worker*-bound: loop 197.2s against a 175.4s worker floor, 21.8s recoverable. This PR lowered the loop by 7.4s and simultaneously **raised the consumer floor from 75.4s to 187.8s**, because self-decompression moves work onto the serial thread. The merge is now consumer-bound where it was worker-bound. **~13.5s (7%) sits between the current 189.8s and the 176.3s worker floor, and it is reachable only by giving that decompression back to the workers without reintroducing the park.** That is the clearest next target this work produces.

**At t16, 44.7s (28%) is recoverable**, all of it consumer park, 99% `starved`, with workers 43% idle and a worker floor of only 89.8s. That is the largest identified prize. But a control says most of it is a property of the *input shape*: the same records sorted queryname → coordinate merge in **126.7s** with the consumer 97% busy and park ~3s. Sorting an already-`SO:coordinate` file into template-coordinate is what produces the starving run structure — and that is also the production path for dedup, so it is worth attacking; it is just not general engine headroom.

**And the number that actually binds has never been decomposed.** Consumer serial CPU is the floor in all three configurations — 186.5s at t8 (239 ns/record), 112.1s at t16 (144 ns/record), 123.2s on the queryname→coordinate control (158 ns/record). Same records, same block count, near-identical worker-side decompress, and a 66% spread in per-record cost that is unexplained. A loser-tree microbenchmark accounts for ~5% of it. The other ~95% is unattributed, and it is larger than everything this PR delivers.

This PR also demonstrates why: at t8 it removed **119.4s of park** and gained **8.2s of wall**, because park converted almost 1:1 into consumer serial CPU (74.6 → 186.5s). The work was not removed, it was relocated onto the critical path. That is a real win where the consumer had idle capacity and nearly a no-op where it did not.

## Reading order

**The three wins:** `3d08ea8d` (read-ahead 4 MiB), `8b66d5d1` (consumer self-decompress), `5f52205c` (top-k prediction). `dca835cf` batches a per-record atomic off the consumer path (−1.5% at t8, null at t16).

**Hygiene, near-zero on wall, kept for correctness or clarity:** `ff7824ad` makes the zstd spill frame size a knob *and fixes a latent bug it exposed* — the spill writer pre-flushed at a hardcoded 64 KiB rather than the configured frame size, so the knob was inert and a frame-size sweep measured a no-op as a 4% regression. `bc0ab690` squashes three scheduling tidy-ups that measured 0%, −0.9% and 0.06%, kept because each removes a wrong behaviour the next reader would otherwise re-derive.

## Notes for review

- **`losers[1]` is not the runner-up**, which is the tempting O(1) shortcut in the top-k commit. After a replay that node holds whoever lost *that* replay's final comparison, not the global second-smallest. `runner_up()` walks the losers along the winner's root-to-leaf path instead, O(log k). There is a test on exactly the case the shortcut gets wrong, and it fails against the shortcut.
- **Self-decompress happens only on the way into a park, never in place of merging.** The consumer is the serial bottleneck; taking delegable work while it still has records to emit would be strictly worse. Bounding it to one block per park instead of draining costs +7.6%.
- **`runner_up()` is called 25,003,410 times**, once per ~31 records, not once per run as an earlier draft claimed. At 11.63 ns/call that is ~0.29s of serial consumer time — 0.19% of merge wall, so the design holds, but with less margin than "once per run" implied.
- **The two validity counters are not decoration.** `Consumer served itself` and `Next-source predictions published` each guard a silent failure mode: the mechanism can fail to run at all and still report a plausible wall time. During this work the gate function was briefly defined but never called, so both were dead-code eliminated — and neither `clippy -D warnings` nor rustc's `dead_code` reported it. Grepping the built binary is what caught it.
- A byte-budgeted uniform read-ahead floor was developed and **left out**: it showed −3.6% once and nothing at all on an identical repeat in the same boot, and the sweep meant to settle it had clamped two of three arms to the same value.

## Verification

`cargo ci-fmt`, `ci-lint` clean; `cargo ci-test` **7559 passed / 30 skipped**; every commit builds independently. Correctness gated on `compare bams --command sort` throughout — IDENTICAL every time, 0 sort-order violations, 0 run-multiset mismatches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: output changes: none; identical sorted output and sort-order checks pin behavior. `unsafe` changes: none; CLAUDE.md allowlist update: none. Memory and scheduling policy changes: yes; targeted read-ahead increases peak RSS outside `--max-memory`.

Fix: steer read-ahead to blocked and predicted merge sources, and let the consumer decompress queued blocks before parking.

- Add codec-specific BGZF and Zstd spill frame sizing.
- Add loser-tree runner-up prediction.
- Increase targeted read-ahead to 4 MiB with byte bounds.
- Prioritize starving and predicted sources.
- Batch progress updates every 4096 records.
- Add tests for frame sizing, decompression, scheduling, prediction, and progress.
- Report self-served parks and predictions.

Merge wall time decreases by 9.7% at t16 and 3.8% at t8. Peak RSS increases by 10% at t16 and 94% at t8. Correctness, formatting, lint, and CI checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->