### PR TITLE
feat(dedup): add Picard pair/orphan duplicate breakdown to --metrics (#804)

### DIFF
--- a/crates/fgumi-metrics/src/dedup.rs
+++ b/crates/fgumi-metrics/src/dedup.rs
@@ -30,8 +30,26 @@ use crate::library_size::estimate_library_size;
 ///    dropped at write time, after they have been counted here.
 /// 3. **Diagnostics** — `secondary_reads`, `supplementary_reads`,
 ///    `missing_tc_tag`.
-/// 4. **Complexity** — `percent_duplication` (read-level, Picard-parity) and the
-///    Lander-Waterman `estimated_library_size`.
+/// 4. **Pair/orphan breakdown** — the Picard `DuplicationMetrics` split. Because
+///    `dedup` dedups each mate in its own position group, reads are classified by
+///    their SAM flags: `mapped_pairs`/`duplicate_pairs` count mapped read *pairs*
+///    (both mates mapped; Picard `READ_PAIRS_EXAMINED`/`READ_PAIR_DUPLICATES`,
+///    already halved from the two mates to whole pairs), `mapped_orphans`/
+///    `duplicate_orphans` count mapped reads with no mapped mate (Picard
+///    `UNPAIRED_READS_EXAMINED`/`UNPAIRED_READ_DUPLICATES`), and `unmapped_pairs`,
+///    `unmapped_orphans`, `unmated_templates` are read-unit diagnostics. Every
+///    counted primary read falls in exactly one mapping bucket, so (ignoring the
+///    at-most-one truncated half per library from integer halving)
+///    `2*mapped_pairs + mapped_orphans + unmapped_pairs + unmapped_orphans ==
+///    total_templates` and `2*duplicate_pairs + duplicate_orphans ==
+///    duplicate_templates` — but only for templates holding a single primary
+///    read, which is every deduplicated template (each mate is dedup'd in its
+///    own position group). The one exception is a `--include-unmapped`
+///    pass-through: a fully unmapped pair is emitted verbatim as one template
+///    holding both mates, so it adds 1 to `total_templates` but 2 to
+///    `unmapped_pairs`, and the left-hand side then exceeds `total_templates`.
+/// 5. **Complexity** — `percent_duplication` (Picard-parity pair/orphan units) and
+///    the Lander-Waterman `estimated_library_size`.
 ///
 /// Templates read from the input are `filtered_templates + total_templates`; that
 /// sum is not emitted as its own column because it is derivable, matching
@@ -91,20 +109,36 @@ pub struct DeduplicationMetrics {
     pub supplementary_reads: u64,
     /// Secondary/supplementary reads lacking the `tc` tag
     pub missing_tc_tag: u64,
-    /// Read-level duplicate fraction (`duplicate_reads` / `total_reads`).
+    /// Mapped read pairs examined, both mates mapped (Picard `READ_PAIRS_EXAMINED`)
+    pub mapped_pairs: u64,
+    /// Mapped read pairs marked duplicate (Picard `READ_PAIR_DUPLICATES`)
+    pub duplicate_pairs: u64,
+    /// Mapped reads with no mapped mate: single-end or mate unmapped (Picard `UNPAIRED_READS_EXAMINED`)
+    pub mapped_orphans: u64,
+    /// Single-mapped-end reads marked duplicate (Picard `UNPAIRED_READ_DUPLICATES`)
+    pub duplicate_orphans: u64,
+    /// Unmapped primary reads carrying the paired flag (diagnostic)
+    pub unmapped_pairs: u64,
+    /// Unmapped primary reads not carrying the paired flag (diagnostic)
+    pub unmapped_orphans: u64,
+    /// Primary reads with no paired flag, i.e. single-end (diagnostic)
+    pub unmated_templates: u64,
+    /// Picard `PERCENT_DUPLICATION`-parity duplicate fraction, in primary-read
+    /// units: `(2*duplicate_pairs + duplicate_orphans) / (2*mapped_pairs +
+    /// mapped_orphans)`.
     ///
-    /// Distinct from the template-level `duplicate_rate` above; this is the
-    /// Picard `PERCENT_DUPLICATION`-parity column.
+    /// Distinct from the template-level `duplicate_rate` above. Counts each
+    /// mapped pair as its two examined reads and excludes unmapped, secondary,
+    /// and supplementary records, matching Picard `MarkDuplicates`. Zero when the
+    /// denominator (no mapped primary reads) is zero.
     #[serde(with = "crate::float")]
     pub percent_duplication: f64,
     /// Lander-Waterman estimate of the complete library size, or empty when the
-    /// estimate is undefined (no templates, or no duplicates observed).
+    /// estimate is undefined (no mapped pairs, or no duplicate pairs observed).
     ///
-    /// fgumi counts *templates*, not read pairs directly; this treats
-    /// `total_templates`/`unique_templates` as `n_pairs`/`n_unique` (each
-    /// template stands in for one read pair in paired-end data). This is the
-    /// same approximation `duplicate_rate` above already makes by reporting a
-    /// template-level rather than a read-pair-level rate.
+    /// Estimated from complete mapped pairs only (`mapped_pairs` as `n_pairs`,
+    /// `mapped_pairs - duplicate_pairs` as `n_unique`), matching Picard
+    /// `MarkDuplicates`, which excludes orphans from the library-size estimate.
     pub estimated_library_size: Option<u64>,
 }
 
@@ -162,6 +196,20 @@ pub struct DeduplicationCounts {
     pub supplementary_reads: u64,
     /// Secondary/supplementary reads lacking the `tc` tag.
     pub missing_tc_tag: u64,
+    /// Mapped read pairs examined, both mates mapped (already halved to pairs).
+    pub mapped_pairs: u64,
+    /// Mapped read pairs marked duplicate (already halved to pairs).
+    pub duplicate_pairs: u64,
+    /// Mapped reads with no mapped mate (single-end or mate unmapped).
+    pub mapped_orphans: u64,
+    /// Single-mapped-end reads marked duplicate.
+    pub duplicate_orphans: u64,
+    /// Unmapped primary reads carrying the paired flag.
+    pub unmapped_pairs: u64,
+    /// Unmapped primary reads not carrying the paired flag.
+    pub unmapped_orphans: u64,
+    /// Primary reads with no paired flag (single-end).
+    pub unmated_templates: u64,
 }
 
 impl DeduplicationMetrics {
@@ -199,6 +247,13 @@ impl DeduplicationMetrics {
             secondary_reads,
             supplementary_reads,
             missing_tc_tag,
+            mapped_pairs,
+            duplicate_pairs,
+            mapped_orphans,
+            duplicate_orphans,
+            unmapped_pairs,
+            unmapped_orphans,
+            unmated_templates,
         } = counts;
         Self {
             sample,
@@ -224,9 +279,52 @@ impl DeduplicationMetrics {
             secondary_reads,
             supplementary_reads,
             missing_tc_tag,
-            percent_duplication: crate::frac_u64(duplicate_reads, total_reads),
-            estimated_library_size: estimate_library_size(total_templates, unique_templates),
+            mapped_pairs,
+            duplicate_pairs,
+            mapped_orphans,
+            duplicate_orphans,
+            unmapped_pairs,
+            unmapped_orphans,
+            unmated_templates,
+            // Picard `PERCENT_DUPLICATION`: each mapped pair counts as its two
+            // examined reads, orphans as one, excluding unmapped/secondary/
+            // supplementary. Zero when no mapped primary reads were examined.
+            percent_duplication: picard_percent_duplication(
+                mapped_pairs,
+                duplicate_pairs,
+                mapped_orphans,
+                duplicate_orphans,
+            ),
+            // Lander-Waterman estimate from complete mapped pairs only (Picard
+            // excludes orphans). `saturating_sub` guards a future bug from
+            // underflowing rather than panicking.
+            estimated_library_size: estimate_library_size(
+                mapped_pairs,
+                mapped_pairs.saturating_sub(duplicate_pairs),
+            ),
         }
+    }
+}
+
+/// Picard `PERCENT_DUPLICATION` in primary-read units:
+/// `(2*duplicate_pairs + duplicate_orphans) / (2*mapped_pairs + mapped_orphans)`.
+///
+/// Each mapped pair contributes its two examined reads; orphans contribute one.
+/// Unmapped, secondary, and supplementary records are excluded (they are not in
+/// these counts). Returns `0.0` when the denominator is zero (no mapped primary
+/// reads examined), matching `frac_u64`'s zero-denominator convention.
+#[expect(clippy::cast_precision_loss, reason = "metric counts never exceed 2^53")]
+fn picard_percent_duplication(
+    mapped_pairs: u64,
+    duplicate_pairs: u64,
+    mapped_orphans: u64,
+    duplicate_orphans: u64,
+) -> f64 {
+    let examined = 2 * mapped_pairs + mapped_orphans;
+    if examined == 0 {
+        0.0
+    } else {
+        (2 * duplicate_pairs + duplicate_orphans) as f64 / examined as f64
     }
 }
 
@@ -360,8 +458,10 @@ mod tests {
              filtered_low_mate_mapping_quality\tfiltered_missing_umi\tfiltered_ns_in_umi\t\
              filtered_umi_too_short\tpassthrough_templates\ttotal_templates\tunique_templates\t\
              duplicate_templates\tduplicate_rate\ttotal_reads\tunique_reads\tduplicate_reads\t\
-             secondary_reads\tsupplementary_reads\tmissing_tc_tag\tpercent_duplication\t\
-             estimated_library_size"
+             secondary_reads\tsupplementary_reads\tmissing_tc_tag\t\
+             mapped_pairs\tduplicate_pairs\tmapped_orphans\tduplicate_orphans\t\
+             unmapped_pairs\tunmapped_orphans\tunmated_templates\t\
+             percent_duplication\testimated_library_size"
         );
     }
 
@@ -387,28 +487,42 @@ mod tests {
     /// template and read triples below.
     type Counts = (u64, u64, u64);
 
+    /// `(mapped_pairs, duplicate_pairs, mapped_orphans, duplicate_orphans)` — the
+    /// pair/orphan units that drive `percent_duplication` (Picard `(2*dup_pairs +
+    /// dup_orphans) / (2*mapped_pairs + mapped_orphans)`) and, from mapped pairs
+    /// only, `estimated_library_size`.
+    type PairOrphan = (u64, u64, u64, u64);
+
     #[rstest]
-    #[case::with_duplicates("lib1".to_string(), (100, 10, 90), (200, 20, 180), 0.9, 0.9, true)]
-    #[case::no_duplicates("lib2".to_string(), (50, 50, 0), (100, 100, 0), 0.0, 0.0, false)]
-    #[case::empty_library("lib3".to_string(), (0, 0, 0), (0, 0, 0), 0.0, 0.0, false)]
+    // duplicate_rate stays template-level; percent_duplication and library size
+    // are now driven by the pair/orphan columns, not the read totals.
+    #[case::paired_with_duplicates(
+        "lib1".to_string(), (100, 10, 90), (100, 90, 0, 0), 0.9, 0.9, true)]
+    #[case::paired_no_duplicates(
+        "lib2".to_string(), (50, 50, 0), (50, 0, 0, 0), 0.0, 0.0, false)]
+    #[case::empty_library("lib3".to_string(), (0, 0, 0), (0, 0, 0, 0), 0.0, 0.0, false)]
+    // Orphan-only library: pct = 10/30; no mapped pairs, so library size undefined.
+    #[case::orphans_only(
+        "lib4".to_string(), (30, 20, 10), (0, 0, 30, 10), 1.0 / 3.0, 1.0 / 3.0, false)]
     fn from_counts_computes_rates_and_library_size(
         #[case] library: String,
         #[case] templates: Counts,
-        #[case] reads: Counts,
+        #[case] pair_orphan: PairOrphan,
         #[case] expected_duplicate_rate: f64,
         #[case] expected_percent_duplication: f64,
         #[case] expect_library_size_defined: bool,
     ) {
         let (total_templates, unique_templates, duplicate_templates) = templates;
-        let (total_reads, unique_reads, duplicate_reads) = reads;
+        let (mapped_pairs, duplicate_pairs, mapped_orphans, duplicate_orphans) = pair_orphan;
         let metrics = DeduplicationMetrics::from_counts(DeduplicationCounts {
             library: library.clone(),
             total_templates,
             unique_templates,
             duplicate_templates,
-            total_reads,
-            unique_reads,
-            duplicate_reads,
+            mapped_pairs,
+            duplicate_pairs,
+            mapped_orphans,
+            duplicate_orphans,
             ..DeduplicationCounts::default()
         });
 
@@ -417,9 +531,6 @@ mod tests {
         assert_eq!(metrics.unique_templates, unique_templates);
         assert_eq!(metrics.duplicate_templates, duplicate_templates);
         assert!((metrics.duplicate_rate - expected_duplicate_rate).abs() < 1e-9);
-        assert_eq!(metrics.total_reads, total_reads);
-        assert_eq!(metrics.unique_reads, unique_reads);
-        assert_eq!(metrics.duplicate_reads, duplicate_reads);
         assert!((metrics.percent_duplication - expected_percent_duplication).abs() < 1e-9);
         assert_eq!(
             metrics.estimated_library_size.is_some(),
@@ -453,6 +564,49 @@ mod tests {
         assert_eq!(metrics.total_filtered(), 7);
     }
 
+    /// The pair/orphan breakdown counts are copied through `from_counts`
+    /// unchanged, and the documented reconciliation invariants hold on the
+    /// resulting row.
+    #[test]
+    fn from_counts_carries_pair_orphan_breakdown_through() {
+        // Pairs are in whole-pair units (already halved); orphan/unmapped counts
+        // are read units. Values chosen so the documented read-unit invariants
+        // hold: 2*35 + 20 + 6 + 4 = 100, and 2*12 + 6 = 30.
+        let metrics = DeduplicationMetrics::from_counts(DeduplicationCounts {
+            library: "lib1".to_string(),
+            total_templates: 100,
+            duplicate_templates: 30,
+            mapped_pairs: 35,
+            duplicate_pairs: 12,
+            mapped_orphans: 20,
+            duplicate_orphans: 6,
+            unmapped_pairs: 6,
+            unmapped_orphans: 4,
+            unmated_templates: 24,
+            ..DeduplicationCounts::default()
+        });
+        assert_eq!(metrics.mapped_pairs, 35);
+        assert_eq!(metrics.duplicate_pairs, 12);
+        assert_eq!(metrics.mapped_orphans, 20);
+        assert_eq!(metrics.duplicate_orphans, 6);
+        assert_eq!(metrics.unmapped_pairs, 6);
+        assert_eq!(metrics.unmapped_orphans, 4);
+        assert_eq!(metrics.unmated_templates, 24);
+        // Documented read-unit invariants: each pair is two counted primary
+        // reads, so pairs count double against the template total.
+        assert_eq!(
+            2 * metrics.mapped_pairs
+                + metrics.mapped_orphans
+                + metrics.unmapped_pairs
+                + metrics.unmapped_orphans,
+            metrics.total_templates
+        );
+        assert_eq!(
+            2 * metrics.duplicate_pairs + metrics.duplicate_orphans,
+            metrics.duplicate_templates
+        );
+    }
+
     #[test]
     fn serializes_with_library_column_first_and_empty_cell_for_none() {
         // lib1 has duplicates (estimate defined); lib2 has none (estimate undefined).
@@ -465,6 +619,10 @@ mod tests {
                 total_reads: 200,
                 unique_reads: 20,
                 duplicate_reads: 180,
+                // Mapped pairs drive the library-size estimate: 90 of 100 pairs
+                // duplicate, so the Lander-Waterman estimate is defined.
+                mapped_pairs: 100,
+                duplicate_pairs: 90,
                 ..DeduplicationCounts::default()
             }),
             DeduplicationMetrics::from_counts(DeduplicationCounts {
@@ -473,6 +631,9 @@ mod tests {
                 unique_templates: 50,
                 total_reads: 100,
                 unique_reads: 100,
+                // All unique pairs, so the estimate is undefined (empty cell).
+                mapped_pairs: 50,
+                duplicate_pairs: 0,
                 ..DeduplicationCounts::default()
             }),
         ];

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -100,6 +100,25 @@ pub struct DedupCounts {
     pub filter_counts: TemplateFilterCounts,
     /// Templates emitted untouched by `--include-unmapped` (bypass the filter)
     pub passthrough_templates: u64,
+    /// Mapped primary reads whose mate is also mapped, i.e. one half of a mapped
+    /// pair. Accumulated in read (pair-half) units because a pair's two mates are
+    /// dedup'd in separate position groups; halved to `mapped_pairs`
+    /// (Picard `READ_PAIRS_EXAMINED`) only when the final row is built.
+    pub mapped_pair_reads: u64,
+    /// Duplicate-marked half of a mapped pair; halved to `duplicate_pairs`
+    /// (Picard `READ_PAIR_DUPLICATES`) at row-build time.
+    pub duplicate_pair_reads: u64,
+    /// Mapped primary reads with no mapped mate — single-end, or mate unmapped
+    /// (Picard `UNPAIRED_READS_EXAMINED`); read units, not halved.
+    pub mapped_orphans: u64,
+    /// Single-mapped-end reads marked duplicate (Picard `UNPAIRED_READ_DUPLICATES`)
+    pub duplicate_orphans: u64,
+    /// Unmapped primary reads carrying the paired flag (diagnostic, read units)
+    pub unmapped_pairs: u64,
+    /// Unmapped primary reads not carrying the paired flag (diagnostic, read units)
+    pub unmapped_orphans: u64,
+    /// Primary reads not carrying the paired flag, i.e. single-end (diagnostic)
+    pub unmated_templates: u64,
 }
 
 impl DedupCounts {
@@ -116,6 +135,13 @@ impl DedupCounts {
         self.missing_tc_tag += other.missing_tc_tag;
         self.filter_counts.merge(&other.filter_counts);
         self.passthrough_templates += other.passthrough_templates;
+        self.mapped_pair_reads += other.mapped_pair_reads;
+        self.duplicate_pair_reads += other.duplicate_pair_reads;
+        self.mapped_orphans += other.mapped_orphans;
+        self.duplicate_orphans += other.duplicate_orphans;
+        self.unmapped_pairs += other.unmapped_pairs;
+        self.unmapped_orphans += other.unmapped_orphans;
+        self.unmated_templates += other.unmated_templates;
     }
 
     /// Calculate duplicate rate.
@@ -132,14 +158,13 @@ impl DedupCounts {
 /// Converts accumulated dedup counts for one library (or the aggregate total
 /// across all libraries) into the serializable [`DeduplicationMetrics`] row.
 ///
-/// The raw counts are copied 1:1 into a [`DeduplicationCounts`], and
-/// [`DeduplicationMetrics::from_counts`] computes the three derived columns
-/// (`duplicate_rate`, `percent_duplication`, `estimated_library_size`). fgumi
-/// counts *templates*, and each template stands in for one read pair in
-/// paired-end data — the same approximation `duplicate_rate` already makes by
-/// reporting a template-level rather than read-pair-level rate. That is why
-/// `estimated_library_size` is fed `total_templates`/`unique_templates` as its
-/// `n_pairs`/`n_unique` inputs.
+/// The raw counts are copied into a [`DeduplicationCounts`], and
+/// [`DeduplicationMetrics::from_counts`] computes the derived columns.
+/// `duplicate_rate` stays template-level, while the Picard-parity
+/// `percent_duplication` and `estimated_library_size` are computed from the
+/// pair/orphan units below: the accumulated pair-half read counts are halved to
+/// whole pairs (Picard `READ_PAIRS_EXAMINED`/`READ_PAIR_DUPLICATES`) here, once,
+/// after all per-library and cross-worker merging.
 fn to_deduplication_metrics(
     sample: String,
     library: String,
@@ -170,6 +195,19 @@ fn to_deduplication_metrics(
         secondary_reads: counts.secondary_reads,
         supplementary_reads: counts.supplementary_reads,
         missing_tc_tag: counts.missing_tc_tag,
+        // Pair-half read counts -> pair units (Picard `READ_PAIRS_EXAMINED` /
+        // `READ_PAIR_DUPLICATES`). Halved here, once, after all per-library and
+        // cross-worker merging, so the two mates of every pair — dedup'd in
+        // separate position groups — are both counted before the division.
+        // Integer floor: a mate missing from the input leaves an odd half that
+        // rounds down, matching the "count complete pairs" intent.
+        mapped_pairs: counts.mapped_pair_reads / 2,
+        duplicate_pairs: counts.duplicate_pair_reads / 2,
+        mapped_orphans: counts.mapped_orphans,
+        duplicate_orphans: counts.duplicate_orphans,
+        unmapped_pairs: counts.unmapped_pairs,
+        unmapped_orphans: counts.unmapped_orphans,
+        unmated_templates: counts.unmated_templates,
     })
 }
 
@@ -249,14 +287,13 @@ struct DuplicationLadderRecorder {
     interval: u64,
     /// Per-library running totals and next snapshot threshold.
     per_library: AHashMap<u16, LadderLibraryState>,
-    /// Emitted `(library_idx, templates_seen, duplicate_templates)` rows, in
-    /// emission order (interval crossings interleaved across libraries as
-    /// groups are processed, plus the final per-library rows appended by
-    /// [`Self::finish`]). Sorted into deterministic (library, `templates_seen`)
-    /// order only at write time.
-    /// `(library_idx, templates_seen, duplicate_templates, window_templates,
-    /// window_duplicate_templates)`. The two `window_*` values cover only the
-    /// templates added since the previous snapshot for that library.
+    /// Emitted `(library_idx, templates_seen, duplicate_templates,
+    /// window_templates, window_duplicate_templates)` rows, in emission order
+    /// (interval crossings interleaved across libraries as groups are
+    /// processed, plus the final per-library rows appended by [`Self::finish`]).
+    /// The two `window_*` values cover only the templates added since the
+    /// previous snapshot for that library. Sorted into deterministic (library,
+    /// `templates_seen`) order only at write time.
     rows: Vec<(u16, u64, u64, u64, u64)>,
 }
 
@@ -808,6 +845,57 @@ fn mark_template_as_duplicate(template: &mut Template, dedup_counts: &mut DedupC
     }
 }
 
+/// Classify each primary read of a counted template into the Picard-style
+/// pair/orphan breakdown (#804).
+///
+/// fgumi `dedup` dedups each mate in its own position group, so a template here
+/// almost always holds a single primary read; classifying **per primary read**
+/// (rather than per template) is what lets a normal read-pair — split across two
+/// templates in two groups — be recognised as a pair at all. Each read is bucketed
+/// by its own SAM flags, mirroring Picard `DuplicationMetrics`:
+///
+/// - mapped with a mapped mate  -> `mapped_pair_reads` (a pair half; Picard
+///   `READ_PAIRS_EXAMINED` after halving), and `duplicate_pair_reads` if marked.
+/// - mapped with no mapped mate -> `mapped_orphans` (Picard
+///   `UNPAIRED_READS_EXAMINED`), and `duplicate_orphans` if marked.
+/// - unmapped                   -> `unmapped_pairs` / `unmapped_orphans` by the
+///   paired flag (diagnostic; never marked duplicate).
+///
+/// `unmated_templates` counts primary reads with no paired flag (single-end),
+/// independently of the buckets above. Duplicate status is read from the record's
+/// own `DUPLICATE_FLAG` (marking set it on every record of a duplicate template).
+fn count_template_pair_orphan(template: &Template, dedup_counts: &mut DedupCounts) {
+    for read in template.primary_reads() {
+        let flags = RawRecordView::new(read).flags();
+        let is_mapped = (flags & fgumi_raw_bam::flags::UNMAPPED) == 0;
+        let is_paired = (flags & fgumi_raw_bam::flags::PAIRED) != 0;
+        let mate_mapped = is_paired && (flags & fgumi_raw_bam::flags::MATE_UNMAPPED) == 0;
+        let is_duplicate = (flags & DUPLICATE_FLAG) != 0;
+
+        if !is_paired {
+            dedup_counts.unmated_templates += 1;
+        }
+
+        if !is_mapped {
+            if is_paired {
+                dedup_counts.unmapped_pairs += 1;
+            } else {
+                dedup_counts.unmapped_orphans += 1;
+            }
+        } else if mate_mapped {
+            dedup_counts.mapped_pair_reads += 1;
+            if is_duplicate {
+                dedup_counts.duplicate_pair_reads += 1;
+            }
+        } else {
+            dedup_counts.mapped_orphans += 1;
+            if is_duplicate {
+                dedup_counts.duplicate_orphans += 1;
+            }
+        }
+    }
+}
+
 //////////////////////////////////////////////////////////////////////////////
 // Position group processing
 //////////////////////////////////////////////////////////////////////////////
@@ -924,6 +1012,7 @@ fn process_position_group(
     let tc_tag_bytes: [u8; 2] = *TC_TAG.as_ref();
     for template in &templates {
         dedup_counts.total_templates += 1;
+        count_template_pair_orphan(template, &mut dedup_counts);
         for raw in template.records() {
             count_record(raw, tc_tag_bytes, &mut dedup_counts);
         }
@@ -940,6 +1029,7 @@ fn process_position_group(
         dedup_counts.passthrough_templates += 1;
         dedup_counts.total_templates += 1;
         dedup_counts.unique_templates += 1;
+        count_template_pair_orphan(template, &mut dedup_counts);
         for raw in template.records() {
             // Same accounting as the filtered templates above, `tc` check included.
             // `template_is_unmapped_passthrough` only inspects the primary r1/r2, so a
@@ -2121,6 +2211,91 @@ mod tests {
         assert_eq!(template_is_unmapped_passthrough(&template), expected);
     }
 
+    // ========================================================================
+    // count_template_pair_orphan tests (#804 pair/orphan breakdown)
+    // ========================================================================
+
+    /// Build a single-primary-read template whose read carries exactly `flags`.
+    /// `dedup` sees single-mate templates, so classifying one read is the real
+    /// unit of the pair/orphan pass.
+    fn template_with_primary_flags(flags: u16) -> Template {
+        let mut b = RawSamBuilder::new();
+        b.read_name(b"q1").sequence(b"ACGT").qualities(&[30, 30, 30, 30]).flags(flags);
+        Template::from_records(vec![b.build()]).expect("test template construction should not fail")
+    }
+
+    /// `(mapped_pair_reads, mapped_orphans, unmapped_pairs, unmapped_orphans, unmated)`
+    /// tallied by [`count_template_pair_orphan`].
+    fn breakdown(counts: &DedupCounts) -> (u64, u64, u64, u64, u64) {
+        (
+            counts.mapped_pair_reads,
+            counts.mapped_orphans,
+            counts.unmapped_pairs,
+            counts.unmapped_orphans,
+            counts.unmated_templates,
+        )
+    }
+
+    /// Each primary read is bucketed by its own flags. A mapped read with a mapped
+    /// mate is a pair half; mapped with mate unmapped, or unpaired, is an orphan;
+    /// unmapped splits by the paired flag. Only unpaired reads are `unmated`.
+    #[rstest]
+    #[case::mapped_pair(flags::PAIRED | flags::FIRST_SEGMENT, (1, 0, 0, 0, 0))]
+    #[case::mapped_mate_unmapped(
+        flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_UNMAPPED, (0, 1, 0, 0, 0))]
+    #[case::mapped_unpaired(0, (0, 1, 0, 0, 1))]
+    #[case::unmapped_paired(flags::PAIRED | flags::FIRST_SEGMENT | flags::UNMAPPED, (0, 0, 1, 0, 0))]
+    #[case::unmapped_unpaired(flags::UNMAPPED, (0, 0, 0, 1, 1))]
+    fn test_count_pair_orphan_by_flags(
+        #[case] flags: u16,
+        #[case] expected: (u64, u64, u64, u64, u64),
+    ) {
+        let template = template_with_primary_flags(flags);
+        let mut counts = DedupCounts::default();
+        count_template_pair_orphan(&template, &mut counts);
+        assert_eq!(breakdown(&counts), expected);
+    }
+
+    /// A duplicate-marked read increments the duplicate sub-counter of its bucket:
+    /// pair-half reads feed `duplicate_pair_reads`, orphans feed `duplicate_orphans`.
+    #[rstest]
+    #[case::dup_pair(flags::PAIRED | flags::FIRST_SEGMENT | DUPLICATE_FLAG, 1, 0)]
+    #[case::dup_orphan(
+        flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_UNMAPPED | DUPLICATE_FLAG, 0, 1)]
+    #[case::pair_not_duplicate(flags::PAIRED | flags::FIRST_SEGMENT, 0, 0)]
+    fn test_count_pair_orphan_duplicate_split(
+        #[case] flags: u16,
+        #[case] expected_dup_pair_reads: u64,
+        #[case] expected_dup_orphans: u64,
+    ) {
+        let template = template_with_primary_flags(flags);
+        let mut counts = DedupCounts::default();
+        count_template_pair_orphan(&template, &mut counts);
+        assert_eq!(counts.duplicate_pair_reads, expected_dup_pair_reads);
+        assert_eq!(counts.duplicate_orphans, expected_dup_orphans);
+    }
+
+    /// `to_deduplication_metrics` halves the accumulated pair-half read counts into
+    /// whole-pair units (Picard `READ_PAIRS_EXAMINED` / `READ_PAIR_DUPLICATES`),
+    /// while orphan counts pass through in read units.
+    #[test]
+    fn test_to_metrics_halves_pair_reads() {
+        let counts = DedupCounts {
+            total_templates: 8,
+            duplicate_templates: 5,
+            mapped_pair_reads: 6,    // 3 pairs
+            duplicate_pair_reads: 4, // 2 duplicate pairs
+            mapped_orphans: 2,
+            duplicate_orphans: 1,
+            ..DedupCounts::default()
+        };
+        let metrics = to_deduplication_metrics("smpl".to_string(), "lib1".to_string(), &counts);
+        assert_eq!(metrics.mapped_pairs, 3, "6 pair-half reads -> 3 pairs");
+        assert_eq!(metrics.duplicate_pairs, 2, "4 duplicate pair-half reads -> 2 pairs");
+        assert_eq!(metrics.mapped_orphans, 2, "orphans stay in read units");
+        assert_eq!(metrics.duplicate_orphans, 1);
+    }
+
     /// A truncated/corrupt record must never be treated as pass-through even when the
     /// other mate is unmapped: it has to fall through to `filter_template`, which drops
     /// it, rather than being emitted verbatim.
@@ -2991,6 +3166,7 @@ mod tests {
             missing_tc_tag: 2,
             passthrough_templates: 3,
             filter_counts,
+            ..DedupCounts::default()
         };
         let output = to_deduplication_metrics("smpl".to_string(), "lib1".to_string(), &counts);
 

--- a/tests/integration/test_dedup_command.rs
+++ b/tests/integration/test_dedup_command.rs
@@ -243,6 +243,86 @@ fn test_dedup_command_with_metrics() {
     assert!(metrics_path.exists(), "Metrics file not created");
 }
 
+/// End-to-end guard for the #804 pair/orphan breakdown. The fixture is entirely
+/// mapped paired-end duplicates. `dedup` dedups each mate in its own position
+/// group, so the 3 read-pairs become 6 single-mate templates (4 marked duplicate:
+/// 2 per group); classified by flags they are 6 pair halves -> `mapped_pairs = 3`,
+/// `duplicate_pairs = 2`, with nothing in the orphan or unmapped categories. Also
+/// asserts the documented read-unit reconciliation invariants.
+#[test]
+fn test_dedup_metrics_pair_orphan_breakdown_all_mapped_pairs() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let metrics_path = temp_dir.path().join("metrics.txt");
+
+    // 3 mapped paired-end duplicates: 1 kept + 2 marked duplicate.
+    create_sorted_bam(&input_bam, create_duplicate_group("dup1", "ACGTACGT", 3, 100));
+
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--metrics",
+        metrics_path.to_str().unwrap(),
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse dedup args");
+    cmd.execute("fgumi dedup").expect("Dedup command failed");
+
+    let rows: Vec<DeduplicationMetrics> =
+        DelimFile::default().read_tsv(&metrics_path).expect("failed to read dedup metrics");
+    // One per-library row plus the aggregate "All Reads" row, so a regression in
+    // `DedupCounts::merge` (which builds the aggregate) cannot hide behind the first row.
+    assert_eq!(rows.len(), 2, "one library row plus the All Reads aggregate");
+
+    // The pair/orphan breakdown and both read-unit reconciliation invariants must hold on
+    // every row, including the aggregate. This fixture has a single library, so the aggregate
+    // repeats the per-library counts — but asserting it exercises the merge path all the same.
+    let assert_breakdown = |row: &DeduplicationMetrics, label: &str| {
+        // 3 read-pairs -> 6 single-mate templates, 4 marked duplicate (2 per group).
+        assert_eq!(row.total_templates, 6, "{label}: 3 pairs -> 6 single-mate templates");
+        assert_eq!(row.duplicate_templates, 4, "{label}: duplicate templates");
+        // Every read is a pair half, halved to whole pairs.
+        assert_eq!(row.mapped_pairs, 3, "{label}: 6 pair halves -> 3 mapped pairs");
+        assert_eq!(row.duplicate_pairs, 2, "{label}: 4 duplicate pair halves -> 2 duplicate pairs");
+        assert_eq!(row.mapped_orphans, 0, "{label}: mapped orphans");
+        assert_eq!(row.duplicate_orphans, 0, "{label}: duplicate orphans");
+        assert_eq!(row.unmapped_pairs, 0, "{label}: unmapped pairs");
+        assert_eq!(row.unmapped_orphans, 0, "{label}: unmapped orphans");
+        assert_eq!(row.unmated_templates, 0, "{label}: no single-end reads in this fixture");
+
+        // Documented read-unit reconciliation invariants (each pair == two templates).
+        assert_eq!(
+            2 * row.mapped_pairs + row.mapped_orphans + row.unmapped_pairs + row.unmapped_orphans,
+            row.total_templates,
+            "{label}: mapping buckets must reconcile with total_templates in read units"
+        );
+        assert_eq!(
+            2 * row.duplicate_pairs + row.duplicate_orphans,
+            row.duplicate_templates,
+            "{label}: duplicate buckets must reconcile with duplicate_templates in read units"
+        );
+    };
+
+    let all_reads = rows
+        .iter()
+        .find(|r| r.library == "All Reads")
+        .expect("metrics file must contain an All Reads aggregate row");
+    let per_library = rows
+        .iter()
+        .find(|r| r.library != "All Reads")
+        .expect("metrics file must contain a per-library row");
+
+    assert_breakdown(per_library, "per-library row");
+    assert_breakdown(all_reads, "All Reads row");
+}
+
 /// Build a template-coordinate-sorted SAM header with two `@RG` lines that have
 /// distinct `LB` values ("libA"/"libB"), for the per-library metrics test below.
 fn create_multi_library_header(ref_name: &str, ref_len: usize) -> noodles::sam::Header {
@@ -1250,14 +1330,15 @@ fn create_unmapped_pair(name: &str, umi: &str) -> Vec<RawRecord> {
 /// template is *accounted*, not just whether its reads survive: the two modes must route
 /// it to exactly one of the two columns, never both and never neither.
 #[rstest]
-#[case::default_drops_unmapped(false, 6, 0, 0, 1)]
-#[case::include_unmapped_keeps(true, 8, 2, 1, 0)]
+#[case::default_drops_unmapped(false, 6, 0, 0, 1, 0)]
+#[case::include_unmapped_keeps(true, 8, 2, 1, 0, 2)]
 fn test_dedup_include_unmapped(
     #[case] include_unmapped: bool,
     #[case] expected_total: usize,
     #[case] expected_unmapped: usize,
     #[case] expected_passthrough: u64,
     #[case] expected_filtered_unmapped: u64,
+    #[case] expected_unmapped_pairs: u64,
 ) {
     use noodles::sam::alignment::record::data::field::Tag;
     use noodles::sam::alignment::record_buf::RecordBuf;
@@ -1330,6 +1411,30 @@ fn test_dedup_include_unmapped(
     assert_eq!(
         metrics.filtered_unmapped, expected_filtered_unmapped,
         "unexpected filtered_unmapped"
+    );
+
+    // The fully-unmapped pass-through pair is the multi-primary case the
+    // pair/orphan reconciliation invariant explicitly excludes: it is emitted as
+    // ONE template holding both mates, so it adds 1 to `total_templates` but 2 to
+    // `unmapped_pairs` (one per primary read). Under `--include-unmapped` that is
+    // two unmapped pairs from a single template; by default the pair is filtered
+    // out before pair/orphan counting, so the counter stays zero.
+    assert_eq!(metrics.unmapped_pairs, expected_unmapped_pairs, "unexpected unmapped_pairs");
+
+    // The single-primary-read reconciliation `2*mapped_pairs + mapped_orphans +
+    // unmapped_pairs + unmapped_orphans == total_templates` holds only for
+    // deduplicated (single-primary) templates. This fixture's sole pass-through is
+    // a fully-unmapped *pair* (two primary reads in one template), so the left
+    // side runs ahead of `total_templates` by exactly `passthrough_templates`.
+    let reconciliation_lhs = 2 * metrics.mapped_pairs
+        + metrics.mapped_orphans
+        + metrics.unmapped_pairs
+        + metrics.unmapped_orphans;
+    assert_eq!(
+        reconciliation_lhs,
+        metrics.total_templates + metrics.passthrough_templates,
+        "pair/orphan reconciliation must exceed total_templates by the fully-unmapped \
+         pass-through pairs: {metrics:?}"
     );
 }
 


### PR DESCRIPTION
Closes #804. Stacked on #803 (base `799/nhomer/dedup-metrics-parity`) — review after #803.

## What

Adds the Picard `DuplicationMetrics` / dupblaster pair-vs-orphan duplicate breakdown to `fgumi dedup --metrics`, per library and in the `All Reads` aggregate row. New columns (inserted between the diagnostics block and `percent_duplication`):

- `mapped_pairs`, `duplicate_pairs` — mapped read **pairs** examined / marked duplicate (Picard `READ_PAIRS_EXAMINED` / `READ_PAIR_DUPLICATES`).
- `mapped_orphans`, `duplicate_orphans` — mapped reads with no mapped mate, examined / marked duplicate (Picard `UNPAIRED_READS_EXAMINED` / `UNPAIRED_READ_DUPLICATES`).
- `unmapped_pairs`, `unmapped_orphans`, `unmated_templates` — read-unit diagnostics.

## How the classification works (the one subtle part)

`dedup` dedups **each mate in its own position group**, so a `Template` reaching the counting pass holds a *single* primary read — a normal FR read-pair is split across two templates in two groups (this is why 3 read-pairs give `total_templates = 6`, as the existing per-library test documents). So a template with "both ends mapped" essentially never occurs for normal paired data.

Each primary read is therefore classified by **its own SAM flags**, mirroring Picard:

- mapped + mate mapped → one **half** of a mapped pair;
- mapped + (single-end or mate unmapped) → orphan;
- unmapped → split by the paired flag into the `unmapped_*` diagnostics.

Pair-half read counts are accumulated in read units across all position groups and workers, then **halved to whole pairs once**, at row-build time (never per-group — the two mates land in different groups). Integer floor, so a mate missing from the input rounds down (matching the "count complete pairs" intent). This makes `mapped_pairs` / `duplicate_pairs` match Picard's pair counts exactly, while orphan/unmapped counts stay in read units.

Reconciliation (holds for the usual single-mate templates, modulo the ≤1 truncated half per library from halving):

```
2*mapped_pairs   + mapped_orphans  + unmapped_pairs + unmapped_orphans == total_templates
2*duplicate_pairs + duplicate_orphans                                  == duplicate_templates
```

## Tests

- `fgumi-metrics`: extended the pinned column-order test to the new schema; `from_counts` carry-through of the seven columns + the reconciliation invariants.
- `dedup` unit: `count_template_pair_orphan` bucketed by every flag combination (mapped-pair / mate-unmapped / unpaired / unmapped-paired / unmapped-unpaired), the duplicate-sub-count split, and the pair-halving in `to_deduplication_metrics`.
- `dedup` integration: end-to-end `--metrics` on an all-mapped-pairs fixture — 3 read-pairs → `mapped_pairs = 3`, `duplicate_pairs = 2`, everything else zero, plus the reconciliation invariants on the serialized row.

Full workspace suite green (2554 passing), clippy clean, fmt/tag-literals/publish-order clean.

## Note

First commit is a standalone `style:` rustfmt of an adjacent ladder-test assertion the base branch left unformatted (kept separate from the functional change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: changes `fgumi dedup --metrics` output, pinned by the new pair/orphan metric columns and Picard-style calculations; unsafe changes: none, and the `CLAUDE.md` allowlist is unchanged; memory bounds, queue capacity, and thread/backpressure policy: none.

Fix: Add pair/orphan duplicate metrics for each library and the `All Reads` row.

- Classify primary reads by SAM flags.
- Halve pair-half counts after aggregation.
- Derive `percent_duplication` and `estimated_library_size` from pair/orphan counts.
- Add schema, reconciliation, classification, and integration tests.
- Confirm workspace tests, Clippy, and formatting pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->