### PR TITLE
perf(sort): honor --check-crc in the fgumi-sort reader stack (#817)

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -2192,6 +2192,11 @@ pub struct RawExternalSorter {
     initial_capacity: Option<usize>,
     /// When true, wrap input in a `PrefetchReader` for async I/O.
     async_reader: bool,
+    /// Verify each input BGZF block's CRC32 while decompressing it. Defaults to
+    /// `true` (the safe, pre-existing behavior); the sort command lowers it per
+    /// the `--check-crc` / `--no-check-crc` policy. Applies to input decode only,
+    /// never to spill chunks.
+    verify_crc: bool,
     /// Which optional template-key lanes to retain (template-coordinate only).
     ///
     /// Defaults to [`KeyTypesSpec::Auto`], which provisions the narrowest key
@@ -2300,6 +2305,7 @@ impl RawExternalSorter {
             cell_tag: None,
             initial_capacity: None,
             async_reader: false,
+            verify_crc: true,
             key_types: KeyTypesSpec::default(),
         }
     }
@@ -2510,6 +2516,17 @@ impl RawExternalSorter {
     #[must_use]
     pub fn async_reader(mut self, enabled: bool) -> Self {
         self.async_reader = enabled;
+        self
+    }
+
+    /// Set whether to verify each input BGZF block's CRC32 while decompressing.
+    ///
+    /// Defaults to `true`. Pass `false` to skip verification on trusted input
+    /// (the decompressed-size check always runs). Applies to the Phase 1 input
+    /// decode only; spill chunks are always verified.
+    #[must_use]
+    pub fn verify_crc(mut self, enabled: bool) -> Self {
+        self.verify_crc = enabled;
         self
     }
 
@@ -2814,6 +2831,8 @@ impl RawExternalSorter {
             self.output_compression,
             self.spill_codec,
         );
+        // Set before any input decode begins (workers read it at decode time).
+        pool.set_verify_crc(self.verify_crc);
         // Phase 1 runs first; the merge raises this to `phase2_threads()`.
         pool.set_active_workers(self.phase1_threads());
         Ok(Arc::new(pool))
@@ -7311,6 +7330,66 @@ mod tests {
         let expected = (num_pairs * 2) as u64;
         let observed = count_bam_records(&output);
         assert_eq!(observed, expected, "chunk filename collision likely lost data");
+    }
+
+    /// Flip a byte in the last real BGZF block's CRC32 footer of the BAM at
+    /// `path`. `read_raw_blocks` skips the EOF marker, so this targets a data
+    /// block; the file must span >= 2 blocks so it is not the header's.
+    fn corrupt_last_block_crc(path: &Path) {
+        let mut bytes = std::fs::read(path).expect("read bam for corruption");
+        let blocks = {
+            let mut cursor: &[u8] = &bytes;
+            fgumi_bgzf::read_raw_blocks(&mut cursor, 1_000_000).expect("read bgzf blocks")
+        };
+        assert!(blocks.len() >= 2, "test input must span >= 2 BGZF blocks; got {}", blocks.len());
+        let offset: usize =
+            blocks[..blocks.len() - 1].iter().map(fgumi_bgzf::RawBgzfBlock::len).sum();
+        let last = blocks.last().expect("checked len >= 2 above");
+        let crc_off = offset + last.len() - fgumi_bgzf::BGZF_FOOTER_SIZE;
+        bytes[crc_off] ^= 0x01;
+        std::fs::write(path, bytes).expect("write corrupted bam");
+    }
+
+    /// The worker-pool sort path must honor `verify_crc` on its input decode: a
+    /// corrupted block is rejected by default (verify on) and read clean with it
+    /// off (#817). Against the old always-verify decode the `verify_crc: false`
+    /// case could not pass.
+    #[test]
+    fn test_sort_honors_verify_crc_on_corrupted_input() {
+        use fgumi_sam::SamBuilder;
+
+        // Enough pairs to span several 64 KiB BGZF blocks so the corrupted block
+        // is a data block the sort must decode.
+        let mut builder = SamBuilder::new();
+        for i in 0..3000usize {
+            let descending = 2999 - i;
+            let _ = builder
+                .add_pair()
+                .name(&format!("read{descending:05}"))
+                .start1(descending * 50 + 1)
+                .start2(descending * 50 + 101)
+                .build();
+        }
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let input = dir.path().join("input.bam");
+        builder.write_bam(&input).expect("write bam");
+        corrupt_last_block_crc(&input);
+
+        // Default (verify on): the corrupted input CRC32 is rejected.
+        let out_verify = dir.path().join("verify.bam");
+        assert!(
+            RawExternalSorter::new(SortOrder::Coordinate).sort(&input, &out_verify).is_err(),
+            "verify_crc: true (default) must reject a corrupted input CRC32"
+        );
+
+        // verify_crc(false): the same file sorts clean, all records preserved.
+        let out_skip = dir.path().join("skip.bam");
+        RawExternalSorter::new(SortOrder::Coordinate)
+            .verify_crc(false)
+            .sort(&input, &out_skip)
+            .expect("verify_crc: false must accept a corrupted input CRC32");
+        assert_eq!(count_bam_records(&out_skip), 6000, "all records read with verify_crc: false");
     }
 
     /// Collect (name, pos) for every record in a BAM, in file order.

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -216,7 +216,7 @@ pub use keys::{
 };
 pub use reader::{
     OwnedRawBamRecordReader, RawBamRecordReader, open_raw_bam_record_reader,
-    open_raw_bam_record_reader_with_header,
+    open_raw_bam_record_reader_with_header, open_raw_bam_record_reader_with_header_opts,
 };
 pub use verify::{VerifySummary, verify_sort_order};
 

--- a/crates/fgumi-sort/src/reader.rs
+++ b/crates/fgumi-sort/src/reader.rs
@@ -30,7 +30,7 @@
 //! This module is currently not integrated into the sort pipeline.
 //! It provides infrastructure for future optimization.
 
-use fgumi_bgzf::reader::{decompress_block_into, read_raw_blocks};
+use fgumi_bgzf::reader::{decompress_block_into_opts, read_raw_blocks};
 use libdeflater::Decompressor;
 use std::io::{self, BufReader, Read};
 
@@ -61,7 +61,7 @@ pub fn open_raw_bam_record_reader<P: AsRef<std::path::Path>>(
 ) -> anyhow::Result<OwnedRawBamRecordReader> {
     let path = path.as_ref();
     let normalized = fgumi_bam_io::open_normalized_input(path)?;
-    skip_header_for(normalized, path)
+    skip_header_for(normalized, path, true)
 }
 
 /// Open `path` for raw BAM record reading and return its parsed header too.
@@ -78,18 +78,35 @@ pub fn open_raw_bam_record_reader<P: AsRef<std::path::Path>>(
 pub fn open_raw_bam_record_reader_with_header<P: AsRef<std::path::Path>>(
     path: P,
 ) -> anyhow::Result<(OwnedRawBamRecordReader, noodles::sam::Header)> {
+    open_raw_bam_record_reader_with_header_opts(path, true)
+}
+
+/// Variant of [`open_raw_bam_record_reader_with_header`] that chooses whether to
+/// verify each input BGZF block's CRC32 (`verify_crc`). The header parse always
+/// verifies (it runs through noodles-bgzf); only the record decode honors the
+/// flag.
+///
+/// # Errors
+///
+/// Returns an error if the input cannot be opened, is neither BAM nor SAM, or
+/// its header cannot be parsed or skipped.
+pub fn open_raw_bam_record_reader_with_header_opts<P: AsRef<std::path::Path>>(
+    path: P,
+    verify_crc: bool,
+) -> anyhow::Result<(OwnedRawBamRecordReader, noodles::sam::Header)> {
     let path = path.as_ref();
     let normalized = fgumi_bam_io::open_normalized_input(path)?;
     let (header, replayed) = fgumi_bam_io::read_header_and_replay(normalized, path)?;
-    Ok((skip_header_for(replayed, path)?, header))
+    Ok((skip_header_for(replayed, path, verify_crc)?, header))
 }
 
 /// Wrap `reader` in a [`RawBamRecordReader`] positioned at the first record.
 fn skip_header_for(
     reader: Box<dyn Read + Send>,
     path: &std::path::Path,
+    verify_crc: bool,
 ) -> anyhow::Result<OwnedRawBamRecordReader> {
-    let mut reader = RawBamRecordReader::new(reader)
+    let mut reader = RawBamRecordReader::new_with_opts(reader, verify_crc)
         .map_err(|e| anyhow::anyhow!("Failed to read BAM header from {}: {e}", path.display()))?;
     reader
         .skip_header()
@@ -114,6 +131,9 @@ pub struct RawBamRecordReader<R: Read> {
     eof: bool,
     /// Whether the BAM header has been skipped.
     header_skipped: bool,
+    /// Whether to verify each BGZF block's CRC32 while decompressing. Defaults to
+    /// `true`; lowered via [`new_with_opts`](Self::new_with_opts) for trusted input.
+    verify_crc: bool,
 }
 
 impl<R: Read> RawBamRecordReader<R> {
@@ -126,6 +146,19 @@ impl<R: Read> RawBamRecordReader<R> {
     ///
     /// Returns an error if the input is not a valid BAM file.
     pub fn new(reader: R) -> io::Result<Self> {
+        Self::new_with_opts(reader, true)
+    }
+
+    /// Create a new raw BAM record reader, choosing whether to verify each BGZF
+    /// block's CRC32 while decompressing.
+    ///
+    /// `verify_crc = true` matches [`new`](Self::new); `false` skips CRC32
+    /// verification for trusted input (the decompressed-size check always runs).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the input is not a valid BAM file.
+    pub fn new_with_opts(reader: R, verify_crc: bool) -> io::Result<Self> {
         let reader = BufReader::with_capacity(256 * 1024, reader);
 
         let mut this = Self {
@@ -135,6 +168,7 @@ impl<R: Read> RawBamRecordReader<R> {
             position: 0,
             eof: false,
             header_skipped: false,
+            verify_crc,
         };
 
         // Decompress initial blocks to access BAM header
@@ -177,6 +211,7 @@ impl<R: Read> RawBamRecordReader<R> {
             position: 0,
             eof: false,
             header_skipped: false,
+            verify_crc: true,
         };
 
         // Decompress initial blocks
@@ -361,9 +396,14 @@ impl<R: Read> RawBamRecordReader<R> {
             return Ok(());
         }
 
-        // Decompress blocks
+        // Decompress blocks, honoring the CRC-verification policy.
         for block in &blocks {
-            decompress_block_into(block, &mut self.decompressor, &mut self.decompressed)?;
+            decompress_block_into_opts(
+                block,
+                &mut self.decompressor,
+                &mut self.decompressed,
+                self.verify_crc,
+            )?;
         }
 
         Ok(())
@@ -503,6 +543,58 @@ mod tests {
         let data = build_test_bam("@HD\tVN:1.6\n", &[], &[]);
         let reader = RawBamRecordReader::new(io::Cursor::new(data));
         assert!(reader.is_ok(), "Expected valid BAM to succeed: {:?}", reader.err());
+    }
+
+    /// Flip a byte in the last BGZF block's CRC32 footer. Requires the input to
+    /// span at least two blocks so the corrupted block is a data block, not the
+    /// header's (the header parse always verifies through noodles-bgzf).
+    fn corrupt_last_block_crc(bam: &mut [u8]) {
+        let blocks = {
+            let mut cursor: &[u8] = bam;
+            fgumi_bgzf::read_raw_blocks(&mut cursor, 100_000).expect("read bgzf blocks")
+        };
+        assert!(blocks.len() >= 2, "test input must span >= 2 BGZF blocks; got {}", blocks.len());
+        let offset: usize =
+            blocks[..blocks.len() - 1].iter().map(fgumi_bgzf::RawBgzfBlock::len).sum();
+        let last = blocks.last().expect("checked len >= 2 above");
+        let crc_off = offset + last.len() - fgumi_bgzf::BGZF_FOOTER_SIZE;
+        bam[crc_off] ^= 0x01;
+    }
+
+    /// Construct, skip the header, and drain all records, returning the count or
+    /// the first error from any step. The corrupted block is decompressed during
+    /// the reader's first refill, so the error can surface at construction.
+    fn read_all_records(bam: Vec<u8>, verify_crc: bool) -> io::Result<usize> {
+        let mut reader = RawBamRecordReader::new_with_opts(io::Cursor::new(bam), verify_crc)?;
+        reader.skip_header()?;
+        let mut count = 0;
+        while reader.next_record()?.is_some() {
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    /// The single-threaded raw reader must honor `verify_crc`: a corrupted block
+    /// errors with verification on and reads clean with it off (#817). Against the
+    /// old always-verify decode the `verify_crc: false` case could not pass.
+    #[test]
+    fn test_raw_bam_record_reader_honors_verify_crc() {
+        // Enough records to span >= 2 BGZF blocks (minimal records are ~38 bytes;
+        // 5000 gives ~190 KiB uncompressed, several 64 KiB blocks).
+        let records: Vec<Vec<u8>> =
+            (0..5000).map(|i| make_minimal_record(format!("r{i}").as_bytes())).collect();
+        let mut bam = build_test_bam("@HD\tVN:1.6\n", &[("chr1", 1000)], &records);
+        corrupt_last_block_crc(&mut bam);
+
+        assert!(
+            read_all_records(bam.clone(), true).is_err(),
+            "verify_crc: true must reject a corrupted BGZF CRC32"
+        );
+        assert_eq!(
+            read_all_records(bam, false).expect("verify_crc: false must accept a corrupted CRC32"),
+            5000,
+            "all records read with verify_crc: false"
+        );
     }
 
     #[test]

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -46,7 +46,7 @@ use crossbeam_channel::{Receiver, Sender, bounded};
 use crossbeam_queue::ArrayQueue;
 use fgumi_bgzf::reader::read_raw_blocks;
 use fgumi_bgzf::writer::InlineBgzfCompressor;
-use fgumi_bgzf::{RawBgzfBlock, decompress_block};
+use fgumi_bgzf::{RawBgzfBlock, decompress_block, decompress_block_into_opts};
 use log::debug;
 use std::collections::VecDeque;
 use std::fmt::Write as FmtWrite;
@@ -1239,6 +1239,14 @@ pub(crate) struct SharedPipelineState {
     /// Current phase: 0=shutdown, 1=Phase1, 2=Phase2, 255=Legacy.
     pub(crate) phase: AtomicU8,
 
+    /// Whether to verify each input BGZF block's CRC32 while decompressing it.
+    /// Defaults to `true`; the sort driver lowers it via
+    /// [`SortWorkerPool::set_verify_crc`] before Phase 1 decode begins, per the
+    /// `--check-crc` policy. Applies only to the input decode (Phase 1), not to
+    /// fgumi's own spill chunks, whose integrity is a separate concern. Atomic so
+    /// the already-spawned workers observe the driver's setting.
+    pub(crate) verify_crc: AtomicBool,
+
     /// Number of workers permitted to be active in the current phase. Workers
     /// with `worker_id >= active_worker_limit` idle (backoff) instead of taking
     /// work. Lets the sort driver run Phase 1 (accumulate/sort/spill) on fewer
@@ -1394,6 +1402,7 @@ impl SharedPipelineState {
             consumer_trace: crate::merge_trace::ConsumerTraceStats::default(),
             fruitless_scan: crate::merge_trace::DurationHistogram::default(),
             phase: AtomicU8::new(phase::LEGACY),
+            verify_crc: AtomicBool::new(true),
             active_worker_limit: AtomicUsize::new(num_workers),
 
             input_file: std::sync::Mutex::new(None),
@@ -1852,6 +1861,9 @@ impl SortWorkerPool {
     /// - `temp_compression`: BGZF level for Phase 1 spill writes (typically 1 for speed).
     /// - `output_compression`: BGZF level for Phase 2 merge output (typically 6 for size).
     /// - `spill_codec`: codec used for spill chunks (BGZF or Zstd). Output is always BGZF.
+    ///
+    /// Input CRC verification defaults to on; lower it with
+    /// [`set_verify_crc`](Self::set_verify_crc) before Phase 1 decode begins.
     #[must_use]
     pub fn new(
         num_workers: usize,
@@ -2348,8 +2360,18 @@ impl SortWorkerPool {
             return StepResult::InputEmpty;
         };
 
-        let data = match decompress_block(&block, &mut worker.decompressor) {
-            Ok(d) => d,
+        // Input decode honors the `--check-crc` policy (unlike spill decode,
+        // which always verifies fgumi's own temp files). `decompress_block_into_opts`
+        // appends into a fresh buffer pre-sized to the block's ISIZE, matching what
+        // `decompress_block` did.
+        let mut decompressed = Vec::with_capacity(block.uncompressed_size());
+        let data = match decompress_block_into_opts(
+            &block,
+            &mut worker.decompressor,
+            &mut decompressed,
+            shared.verify_crc.load(Ordering::Relaxed),
+        ) {
+            Ok(()) => decompressed,
             Err(e) => {
                 log::error!("BGZF decompression error (input block serial {serial}): {e}");
                 shared.decompression_error.store(true, Ordering::Release);
@@ -3199,6 +3221,14 @@ impl SortWorkerPool {
     pub fn set_active_workers(&self, n: usize) {
         let n = n.clamp(1, self.num_workers);
         self.shared.active_worker_limit.store(n, Ordering::Release);
+    }
+
+    /// Set whether Phase 1 input decode verifies each BGZF block's CRC32.
+    ///
+    /// Must be called before input decode begins (the sort driver does so right
+    /// after constructing the pool). Spill-chunk decode is unaffected.
+    pub fn set_verify_crc(&self, enabled: bool) {
+        self.shared.verify_crc.store(enabled, Ordering::Relaxed);
     }
 
     /// Hand the pool over to Phase 2 once ingest is done, widening it to

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -393,6 +393,27 @@ pub struct Sort {
     /// on disk. Prototype flag; defaults to off.
     #[arg(long = "async-reader", default_value_t = false, hide = true)]
     pub async_reader: bool,
+
+    /// Verify each input BGZF block's CRC32 checksum while decoding.
+    ///
+    /// Without either `--check-crc` or `--no-check-crc`, verification defaults on
+    /// for file input and off for stdin input: a freshly-piped aligner stream is
+    /// trusted, since any corruption there is a bug in the upstream process rather
+    /// than data at rest, while a file may have been archived, transferred, or
+    /// copied since it was written, where a flipped bit is exactly what CRC32
+    /// exists to catch. Pass `--check-crc` to force verification on. Mutually
+    /// exclusive with `--no-check-crc`. Honored on both the sort and `--verify`
+    /// input decode; spill files are always verified. Every run logs a
+    /// `CRC verify:` line at startup.
+    #[arg(long = "check-crc", default_value_t = false, conflicts_with = "no_check_crc")]
+    pub check_crc: bool,
+
+    /// Skip CRC32 verification while decoding the input.
+    ///
+    /// Trades the input CRC32 integrity check for faster decode. See `--check-crc`
+    /// for the default policy this overrides. Mutually exclusive with `--check-crc`.
+    #[arg(long = "no-check-crc", default_value_t = false, conflicts_with = "check_crc")]
+    pub no_check_crc: bool,
 }
 
 /// Environment variable name for the fallback temp-dir list, parsed as a
@@ -571,6 +592,7 @@ impl Sort {
             .spill_codec(self.temp_codec)
             .write_index(self.write_index)
             .async_reader(self.async_reader)
+            .verify_crc(self.effective_check_crc())
             .pg_info(crate::version::VERSION.to_string(), command_line.to_string());
 
         // Each per-phase override is optional and falls back to `--threads`.
@@ -601,6 +623,39 @@ impl Sort {
     /// for other sort orders.
     fn parse_cell_tag(&self) -> Result<Option<SamTag>> {
         parse_cell_tag(self.order)
+    }
+
+    /// Resolve the effective input-CRC-verification policy from `--check-crc` /
+    /// `--no-check-crc` and the input's stdin-vs-file status, matching the policy
+    /// the BAM-input commands use: `--check-crc` forces it on, `--no-check-crc`
+    /// forces it off, and with neither given it defaults on for a file and off
+    /// for trusted stdin. The two flags are mutually exclusive at the CLI layer.
+    #[must_use]
+    fn effective_check_crc(&self) -> bool {
+        if self.check_crc {
+            true
+        } else if self.no_check_crc {
+            false
+        } else {
+            !fgumi_bam_io::is_stdin_path(&self.input)
+        }
+    }
+
+    /// Log the effective CRC-verification setting once at run start, so the
+    /// policy — a default that varies with file-vs-stdin — is visible rather
+    /// than silent.
+    fn log_effective_check_crc(&self) {
+        let effective = self.effective_check_crc();
+        let reason = if self.check_crc {
+            " (--check-crc)"
+        } else if self.no_check_crc {
+            " (--no-check-crc)"
+        } else if fgumi_bam_io::is_stdin_path(&self.input) {
+            " (trusted stdin)"
+        } else {
+            ""
+        };
+        info!("CRC verify: {}{reason}", if effective { "on" } else { "off" });
     }
 }
 
@@ -700,6 +755,7 @@ impl Sort {
         info!("Input: {}", self.input.display());
         info!("Output: {}", output.display());
         info!("Sort order: {:?}", self.order);
+        self.log_effective_check_crc();
         if let Some(ct) = cell_tag {
             let ct_bytes = *ct;
             info!("Cell tag: {}{}", ct_bytes[0] as char, ct_bytes[1] as char);
@@ -792,7 +848,7 @@ impl Sort {
 
     /// Execute verify mode: read records and check sort order.
     fn execute_verify(&self) -> Result<()> {
-        use fgumi_sort::open_raw_bam_record_reader_with_header;
+        use fgumi_sort::open_raw_bam_record_reader_with_header_opts;
         use fgumi_sort::{
             LibraryLookup, RawQuerynameKey, RawQuerynameLexKey, RawSortKey, SortContext, cb_hasher,
             extract_coordinate_key_inline, extract_template_key_inline,
@@ -806,6 +862,7 @@ impl Sort {
         debug!("Starting Sort Verification");
         info!("Input: {}", self.input.display());
         info!("Expected order: {:?}", self.order);
+        self.log_effective_check_crc();
         if let Some(ct) = cell_tag {
             let ct_bytes = *ct;
             info!("Cell tag: {}{}", ct_bytes[0] as char, ct_bytes[1] as char);
@@ -814,7 +871,8 @@ impl Sort {
         // One open yields both the header and the records: the header is parsed
         // through a tee and the consumed bytes replayed. Reading the path twice
         // is what used to make `--verify` reject a pipe.
-        let (raw_reader, header) = open_raw_bam_record_reader_with_header(&self.input)?;
+        let (raw_reader, header) =
+            open_raw_bam_record_reader_with_header_opts(&self.input, self.effective_check_crc())?;
 
         let (total_records, violations, first_violation) = match self.order {
             SortOrderArg::Coordinate => {
@@ -1552,7 +1610,33 @@ mod tests {
             max_temp_files: MaxTempFiles::Auto,
             write_index: false,
             async_reader: false,
+            check_crc: false,
+            no_check_crc: false,
         }
+    }
+
+    /// The `--check-crc` / `--no-check-crc` policy: explicit flags win; with
+    /// neither, verify defaults on for a file and off for trusted stdin.
+    #[rstest]
+    #[case::default_file(false, false, "in.bam", true)]
+    #[case::default_stdin(false, false, "-", false)]
+    #[case::force_on_file(true, false, "in.bam", true)]
+    #[case::force_on_stdin(true, false, "-", true)]
+    #[case::force_off_file(false, true, "in.bam", false)]
+    #[case::force_off_stdin(false, true, "-", false)]
+    fn test_sort_effective_check_crc(
+        #[case] check_crc: bool,
+        #[case] no_check_crc: bool,
+        #[case] input: &str,
+        #[case] expected: bool,
+    ) {
+        let sort = Sort {
+            input: PathBuf::from(input),
+            check_crc,
+            no_check_crc,
+            ..make_sort(SortOrderArg::Coordinate)
+        };
+        assert_eq!(sort.effective_check_crc(), expected);
     }
 
     #[rstest]


### PR DESCRIPTION
Closes #817. Stacked on #798 (base `786/nhomer/perf-bgzf-crc-skip`) — review after #798.

## What

`fgumi sort` decoded its input BGZF through its own reader stack — the worker-pool decode workers (`worker_pool.rs`) and the single-threaded `RawBamRecordReader` (`reader.rs`) — using the always-verify fgumi-bgzf primitives, so the `--check-crc` / `--no-check-crc` policy from #798 never reached it. This routes both paths through the CRC-skip-capable `_opts` primitives and adds the flag to the command. It's the `fgumi-sort` follow-up #800 explicitly deferred.

## How

- **Worker pool (main sort path).** A `verify_crc` bit lives in `SharedPipelineState` as an `AtomicBool`, set via `SortWorkerPool::set_verify_crc` right after pool construction so the already-spawned workers observe it — this keeps `SortWorkerPool::new`'s signature (and its ~30 test call sites) unchanged. It's wired from a new `RawExternalSorter::verify_crc()` builder option. Only the **Phase 1 input** decode honors it; **spill-chunk** decode is deliberately left always-verifying, since fgumi's own temp files are a separate integrity concern from the input.
- **Single-threaded path (`--verify`).** `RawBamRecordReader` gains a `verify_crc` field (`new_with_opts`), and `open_raw_bam_record_reader_with_header_opts` threads it.
- **Command.** `fgumi sort` gains `--check-crc` / `--no-check-crc` with the #798 policy (verify on for files, off for trusted stdin; explicit flags override), logged as a `CRC verify:` line at startup for both sort and `--verify` mode.

## Tests

- `RawBamRecordReader` (single-threaded) and `RawExternalSorter` (worker pool) each honor `verify_crc` on a CRC-corrupted multi-block BAM: rejected by default, read clean with it off. Both are dependency-free (no samtools).
- The command's `effective_check_crc` policy truth table (file/stdin × the two flags).

Full workspace suite green (2552 passing), clippy clean, fmt/tag-literals/publish-order clean.

## Benchmark

The CRC-skip decode primitive (`decompress_block_into_opts`) was benchmarked at parity vs always-verify in #798/#801, and the incremental change here is a like-for-like allocation at one call site. The expected ~6% *decode* saving on trusted input is a small fraction of total sort CPU and below this dev host's wall-time noise floor, so a dedicated decode-bound sort hot-path benchmark is deferred to a quiet/EC2 host rather than reported from noisy local numbers.
