### PR TITLE
docs(pipeline): fix redundant explicit intra-doc links breaking the docs CI job

### DIFF
--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -1243,17 +1243,17 @@ fn resolve_memory_budget_with_total(
 /// (the FASTQ aggregate counts its write reorder state and the BAM aggregate its
 /// input and write reorder states), so this budget bounds them through the Read
 /// gate; they additionally apply their own threshold, capped at
-/// [`BACKPRESSURE_THRESHOLD_BYTES`](crate::unified_pipeline::BACKPRESSURE_THRESHOLD_BYTES).
+/// [`BACKPRESSURE_THRESHOLD_BYTES`].
 ///
 /// The budget is a **total**, and it is not the same thing as what any one stage
 /// may hold. Stages back off at their own high-water marks —
-/// [`BACKPRESSURE_THRESHOLD_BYTES`](crate::unified_pipeline::BACKPRESSURE_THRESHOLD_BYTES)
+/// [`BACKPRESSURE_THRESHOLD_BYTES`]
 /// (512 MiB) for the queues and reorder buffers,
-/// [`Q5_BACKPRESSURE_THRESHOLD_BYTES`](crate::unified_pipeline::Q5_BACKPRESSURE_THRESHOLD_BYTES)
+/// [`Q5_BACKPRESSURE_THRESHOLD_BYTES`]
 /// (256 MiB) for the processed queue. A budget below one of those marks tightens
 /// it; a budget above it leaves it alone. So raising `--max-memory` raises how
 /// much the pipeline may hold in total, not how much any one stage may hold —
-/// see [`stage_high_water_mark`](crate::unified_pipeline::stage_high_water_mark)
+/// see [`stage_high_water_mark`]
 /// for why a per-stage trigger should not scale with the total (issue #765).
 #[derive(Debug, Clone, Args)]
 pub struct QueueMemoryOptions {


### PR DESCRIPTION
## What

The `docs` CI job is currently **failing on `main`** (HEAD, from #775). `RUSTDOCFLAGS=-D warnings` promotes `rustdoc::redundant_explicit_links` to an error, and `QueueMemoryOptions`' doc comment in `src/lib/commands/common.rs` links three pipeline constants with explicit `crate::unified_pipeline::…` targets that are identical to what rustdoc already resolves from the backticked link text:

- `BACKPRESSURE_THRESHOLD_BYTES` (twice)
- `Q5_BACKPRESSURE_THRESHOLD_BYTES`
- `stage_high_water_mark`

## Fix

Collapse the four links to shortcut intra-doc links (`[`Foo`]`), so the destination is inferred. The rendered documentation is unchanged; only the redundant explicit targets are removed.

## Verification

`RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` now completes cleanly.

This unblocks the `docs` job on `main` and on every open PR rebased onto it (e.g. #793).