### PR TITLE
perf(sort): name which floor the merge is on, and stop shouting the detail

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -4596,10 +4596,10 @@ impl RawExternalSorter {
         let (samples_taken, records_merged) = sampling;
         let est_tree = scaled.tree;
         let est_read = scaled.advance;
-        info!(
+        debug!(
             "  Consumer (main thread; {samples_taken} samples of {records_merged} records, scaled {scale:.0}x)"
         );
-        info!("    Fetch next record: {est_read:.1}s  (includes waiting on decompressed blocks)");
+        debug!("    Fetch next record: {est_read:.1}s  (includes waiting on decompressed blocks)");
         let MergeConsumerDiag {
             backpressure_secs: blocked_secs,
             backpressure_waits: blocked_waits,
@@ -4609,22 +4609,22 @@ impl RawExternalSorter {
         if blocked_waits > 0 {
             #[allow(clippy::cast_precision_loss, reason = "wait counts stay far below 2^52")]
             let mean_us = blocked_secs * 1e6 / blocked_waits as f64;
-            info!(
+            debug!(
                 "    Output backpressure: {blocked_secs:.1}s over {blocked_waits} waits \
                  (mean {mean_us:.0} us, exact) -- the consumer blocked for an output permit"
             );
         } else {
-            info!("    Output backpressure: none -- the compressors always had a permit ready");
+            debug!("    Output backpressure: none -- the compressors always had a permit ready");
         }
         if borrowed + reassembled > 0 {
             #[allow(clippy::cast_precision_loss, reason = "record counts stay far below 2^52")]
             let pct = 100.0 * reassembled as f64 / (borrowed + reassembled) as f64;
-            info!(
+            debug!(
                 "    Record presentation: {borrowed} borrowed zero-copy, {reassembled} \
                  reassembled across a block boundary ({pct:.2}%, exact)"
             );
         }
-        info!("    Loser tree:        {est_tree:.1}s");
+        debug!("    Loser tree:        {est_tree:.1}s");
         // Reconcile the sampled segments against the loop they are meant to
         // partition. Three of these rows were reported for a long time without
         // ever being summed against the loop, so there was no way to tell whether
@@ -4637,7 +4637,7 @@ impl RawExternalSorter {
             loop_secs: loop_total,
             park_secs,
         };
-        info!(
+        debug!(
             "    Sampled segments sum to {:.1}s of a {loop_total:.1}s loop \
              ({:+.0}% unattributed); {:.1}s of the fetch bucket was the consumer \
              working rather than waiting",
@@ -4721,7 +4721,7 @@ impl RawExternalSorter {
         let wake = pool.wake_latency_report();
         let stalls = stalls.filter(|s| !s.is_empty());
         if !merge_stalls_are_silent(stalls.as_ref(), &scans, &wake) {
-            info!("=== Merge Stalls ===");
+            debug!("=== Merge Stalls ===");
 
             if let Some(s) = stalls {
                 Self::log_consumer_stalls(loop_total, utilization, s);
@@ -4733,8 +4733,8 @@ impl RawExternalSorter {
                     .map(|&r| format!("{}={}", r.label(), scans.skips[r as usize]))
                     .collect::<Vec<_>>()
                     .join(" ");
-                info!("  Worker scans finding no work: {} ({reasons})", scans.scans);
-                info!(
+                debug!("  Worker scans finding no work: {} ({reasons})", scans.scans);
+                debug!(
                     "    Of those: {:.0}% backpressured, {:.0}% waiting on a peer's read, {:.0}% \
                      contended",
                     100.0 * scans.verdict_share(ScanVerdict::Backpressured),
@@ -4744,7 +4744,7 @@ impl RawExternalSorter {
             }
 
             if !wake.is_empty() {
-                info!(
+                debug!(
                     "  Worker discovery lag: ~{:.1}s of {:.1}s deep-sleep worker-seconds; {} \
                      sleeps ended in a find, {:.0}% of them after >=320us",
                     wake.estimated_discovery_lag_secs(),
@@ -4752,7 +4752,7 @@ impl RawExternalSorter {
                     wake.productive_sleep_count(),
                     100.0 * wake.deep_sleep_wake_share()
                 );
-                info!(
+                debug!(
                     "    (the consumer unparks one worker when a reorder buffer drains, so this \
                      bounds how late work arriving any other way is noticed; it delays the merge \
                      only when every worker is asleep at once)"
@@ -4765,7 +4765,7 @@ impl RawExternalSorter {
                 // is a genuinely saturated pool and is nobody's fault.
                 let wakes = pool.wake_accounting();
                 if wakes.issued > 0 {
-                    info!(
+                    debug!(
                         "  Wake targeting: {} of {} wakes hit an already-running worker ({:.0}%), {} of \
                  those had a parked worker available ({:.0}% recoverable)",
                         wakes.on_running,
@@ -4775,7 +4775,7 @@ impl RawExternalSorter {
                         Self::percent(wakes.recoverable, wakes.issued)
                     );
                 }
-                info!(
+                debug!(
                     "    Wakes issued: {} (backoff 10us doubling to {}us ceiling; one worker woken \
                      per wake)",
                     pool.wakes_issued(),
@@ -4794,9 +4794,9 @@ impl RawExternalSorter {
             if supply.total_parks() > 0 {
                 const LABELS: [&str; crate::merge_stalls::ParkSupply::COUNT] =
                     ["a worker was asleep", "all busy, compress queued", "all busy merging"];
-                info!("  Why nobody had started on the awaited block, at the moment of the park:");
+                debug!("  Why nobody had started on the awaited block, at the moment of the park:");
                 for (i, label) in LABELS.iter().enumerate() {
-                    info!(
+                    debug!(
                         "    {label:<26} {:>10} parks ({:>4.1}%)  {:>7.1}s ({:>4.1}% of park time)",
                         supply.counts[i],
                         Self::percent(supply.counts[i], supply.total_parks()),
@@ -4811,7 +4811,7 @@ impl RawExternalSorter {
             // Close this block before delegating: `log_block_lifecycle` opens and
             // closes its own, so without a terminator here the lifecycle block
             // reads as nested inside the stall block rather than following it.
-            info!("====================");
+            debug!("====================");
         }
 
         // Outside the gate above, not inside it. The lifecycle reports record the
@@ -4992,17 +4992,22 @@ impl RawExternalSorter {
         let share = |ns: u64| 100.0 * ns as f64 / total as f64;
         let per_park = |ns: u64| ns as f64 / park.parks as f64 / 1e3;
 
-        info!("  Consumer park, by stage (exact, partitions the park):");
-        info!("    {:<28} {:>8} {:>7} {:>10}", "stage", "time", "share", "per park");
+        debug!("  Consumer park, by stage (exact, partitions the park):");
+        debug!("    {:<28} {:>8} {:>7} {:>10}", "stage", "time", "share", "per park");
         for (label, ns) in [
             ("waiting for a worker", park.to_claim_nanos),
             ("read + decompress work", park.work_nanos),
             ("waiting for its own wake", park.to_resume_nanos),
             ("unattributed", park.unattributed_nanos),
         ] {
-            info!("    {label:<28} {:>7.1}s {:>6.0}% {:>9.0}us", secs(ns), share(ns), per_park(ns));
+            debug!(
+                "    {label:<28} {:>7.1}s {:>6.0}% {:>9.0}us",
+                secs(ns),
+                share(ns),
+                per_park(ns)
+            );
         }
-        info!(
+        debug!(
             "    {:<28} {:>7.1}s {:>6.0}% {:>9.0}us  over {} parks ({:.0}% of loop wall)",
             "TOTAL",
             secs(total),
@@ -5011,12 +5016,12 @@ impl RawExternalSorter {
             park.parks,
             if loop_total > 0.0 { 100.0 * secs(total) / loop_total } else { 0.0 }
         );
-        info!(
+        debug!(
             "    Blocks ready on the awaited file at resume: mean {:.2} (1.0 = every block \
              fetched on demand, one round trip per block)",
             park.mean_ready_on_resume()
         );
-        info!(
+        debug!(
             "    Parks with no claim during them: {} of {} ({:.0}%) -- the block was already \
              in flight or already done",
             park.unclaimed_parks,
@@ -5029,14 +5034,14 @@ impl RawExternalSorter {
         if claims_total == 0 {
             return;
         }
-        info!("  Per worker (merge + phase 1 combined):");
-        info!(
+        debug!("  Per worker (merge + phase 1 combined):");
+        debug!(
             "    {:>3} {:>9} {:>9} {:>7} {:>10} {:>5}",
             "wid", "busy", "idle", "busy%", "claims", "share"
         );
         for (w, &(busy, idle, claims)) in threads.iter().enumerate() {
             let denom = busy + idle;
-            info!(
+            debug!(
                 "    {w:>3} {:>8.1}s {:>8.1}s {:>6.0}% {:>10} {:>4.0}%",
                 secs(busy),
                 secs(idle),
@@ -5275,13 +5280,13 @@ impl RawExternalSorter {
         use crate::merge_stalls::{StallShape, classify_stall};
 
         let park_fraction = if loop_total > 0.0 { s.park_secs / loop_total } else { 0.0 };
-        info!(
+        debug!(
             "  Consumer parked: {:.1}s ({:.0}% of loop wall, exact) over {} parks",
             s.park_secs,
             100.0 * park_fraction,
             s.parks
         );
-        info!(
+        debug!(
             "    Block pulls that had to wait: {}/{} ({:.0}%), {:.1} parks each (1.0 = no wasted \
              wake-ups)",
             s.stalled_pulls,
@@ -5289,7 +5294,7 @@ impl RawExternalSorter {
             100.0 * s.stall_rate(),
             s.parks_per_stall()
         );
-        info!(
+        debug!(
             "    Worst source: #{} at {:.1}s ({:.0}% of park time; {} sources parked on)",
             s.top_source,
             s.top_source_park_secs,
@@ -5297,7 +5302,7 @@ impl RawExternalSorter {
             s.sources_parked_on
         );
         if s.censuses > 0 {
-            info!(
+            debug!(
                 "    Other files at a park ({} parks sampled): {:.0}% at cap, {:.0}% starved, \
                  {:.0}% unreadable",
                 s.censuses,
@@ -5305,7 +5310,7 @@ impl RawExternalSorter {
                 100.0 * s.starved_share,
                 100.0 * s.contended_share
             );
-            info!(
+            debug!(
                 "    The awaited file: {:.0}% gap-filling, {:.0}% gap-stalled, {:.0}% \
                  decompressing, {:.0}% raw-queued, {:.0}% starved",
                 100.0 * s.awaited.reorder_gap_filling,
@@ -5314,7 +5319,7 @@ impl RawExternalSorter {
                 100.0 * s.awaited.raw_queued,
                 100.0 * s.awaited.starved
             );
-            info!(
+            debug!(
                 "      -> block not read yet {:.0}%, exists but unclaimed {:.0}%, being produced \
                  {:.0}%",
                 100.0 * s.awaited.starved,
@@ -5323,33 +5328,33 @@ impl RawExternalSorter {
             );
         }
         match classify_stall(park_fraction, utilization, s.contended_share, s.awaited) {
-            StallShape::NotStalled => info!("    Shape: the consumer is not waiting on blocks"),
-            StallShape::PoolSaturated => info!(
+            StallShape::NotStalled => debug!("    Shape: the consumer is not waiting on blocks"),
+            StallShape::PoolSaturated => debug!(
                 "    Shape: pool saturated -- the consumer waits because every worker is busy, \
                  which is what a healthy CPU-bound merge looks like. Fewer bytes to compress or \
                  more threads would help; nothing here is misscheduled"
             ),
-            StallShape::HeadOfLine => info!(
+            StallShape::HeadOfLine => debug!(
                 "    Shape: head-of-line -- the awaited file has nothing anywhere in its \
                  pipeline, so the block has not been read from disk yet. The constraint is \
                  upstream of the pool: storage, or read concurrency"
             ),
-            StallShape::WorkUnclaimed => info!(
+            StallShape::WorkUnclaimed => debug!(
                 "    Shape: work unclaimed -- the block the consumer needs already exists and no \
                  worker is on it. Capacity is not the problem; scheduling and wake latency are. \
                  Compare the discovery-lag line below"
             ),
-            StallShape::DecompressLatency => info!(
+            StallShape::DecompressLatency => debug!(
                 "    Shape: decompression latency -- a worker is already producing the needed \
                  block, so the consumer is paying the per-block cost serially. Check the reorder \
                  dwell below before reaching for a deeper cap: if blocks are consumed as fast as \
                  they are inserted, the buffer is not what the pipeline is running into"
             ),
-            StallShape::Contended => info!(
+            StallShape::Contended => debug!(
                 "    Shape: lock contention -- a large share of file state could not be read \
                  without blocking, so the shares above understate what was available"
             ),
-            StallShape::Mixed => info!("    Shape: no single candidate dominates"),
+            StallShape::Mixed => debug!("    Shape: no single candidate dominates"),
         }
     }
 

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -5424,6 +5424,11 @@ impl RawExternalSorter {
         // than the loop wall clock they are supposed to partition. A prime
         // interval decorrelates the sample from any block-size-derived period.
         let merge_sample_interval: u64 = 1021;
+        // Calibrated once per merge, not assumed: the clock pair that brackets each
+        // sampled segment costs 15-35ns depending on host, which is the same order
+        // as the segments themselves. Without subtracting it the rows are more clock
+        // than work -- measured at -70% residual before this existed.
+        let clock_overhead_nanos = crate::merge_headroom::measure_clock_overhead_nanos();
         let mut merge_publish_secs = 0.0f64;
         let mut merge_present_secs = 0.0f64;
         let mut merge_write_secs = 0.0f64;
@@ -5581,15 +5586,24 @@ impl RawExternalSorter {
             .as_deref()
             .map_or_else(Default::default, crate::worker_pool::PermitPool::writer_stats);
 
+        let raw_sample = crate::merge_headroom::ConsumerSample {
+            publish: merge_publish_secs,
+            present: merge_present_secs,
+            write: merge_write_secs,
+            advance: merge_read_secs,
+            tree: merge_tree_secs,
+        };
+        let corrected_sample = raw_sample.corrected(samples_taken, clock_overhead_nanos);
+        info!(
+            "  Consumer sampling: {samples_taken} samples, clock {clock_overhead_nanos}ns per \
+             segment; sampled total {:.1}ms -> {:.1}ms after removing measurement overhead \
+             (sampled basis, before scaling to the full merge)",
+            raw_sample.total() * 1e3,
+            corrected_sample.total() * 1e3
+        );
         Self::log_merge_sub_phases(
             (loop_total, loop_start.elapsed().as_secs_f64()),
-            crate::merge_headroom::ConsumerSample {
-                publish: merge_publish_secs,
-                present: merge_present_secs,
-                write: merge_write_secs,
-                advance: merge_read_secs,
-                tree: merge_tree_secs,
-            },
+            corrected_sample,
             (samples_taken, records_merged),
             active_workers,
             pool,

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -4416,11 +4416,18 @@ impl RawExternalSorter {
     /// exactly. The breakdown then partitions the loop by construction rather
     /// than overshooting it by 30-50%.
     fn log_consumer_cpu(
-        sampled: (f64, f64, f64, f64),
+        loop_total: f64,
+        scaled: crate::merge_headroom::ConsumerSample,
         records: (u64, f64),
         stalls: Option<&crate::merge_stalls::ConsumerStallReport>,
     ) {
-        let (loop_total, est_read, est_tree, est_write) = sampled;
+        let crate::merge_headroom::ConsumerSample {
+            publish: est_publish,
+            present: est_present,
+            write: est_write,
+            advance: est_read,
+            tree: est_tree,
+        } = scaled;
         let (records_merged, blocked_secs) = records;
         if records_merged == 0 {
             return;
@@ -4435,7 +4442,7 @@ impl RawExternalSorter {
         // waits would be counted on both sides and inflate their shares.
         let fetch_cpu = (est_read - park_secs).max(0.0);
         let write_cpu = (est_write - blocked_secs).max(0.0);
-        let ratio_total = fetch_cpu + est_tree + write_cpu;
+        let ratio_total = est_publish + est_present + fetch_cpu + est_tree + write_cpu;
         info!(
             "  Consumer CPU: {consumer_cpu:.1}s exact (loop {loop_total:.1}s - park \
              {park_secs:.1}s - backpressure {blocked_secs:.1}s) = {:.0} ns/record",
@@ -4446,9 +4453,19 @@ impl RawExternalSorter {
         }
         let share = |part: f64| consumer_cpu * part / ratio_total;
         let ns = |part: f64| share(part) * 1e9 / records;
-        info!("    parse + key extract: {:.1}s ({:.0} ns/rec)", share(fetch_cpu), ns(fetch_cpu));
+        info!("    fetch + decompress:  {:.1}s ({:.0} ns/rec)", share(fetch_cpu), ns(fetch_cpu));
+        info!(
+            "    present record:      {:.1}s ({:.0} ns/rec)",
+            share(est_present),
+            ns(est_present)
+        );
         info!("    loser tree:          {:.1}s ({:.0} ns/rec)", share(est_tree), ns(est_tree));
         info!("    enqueue write:       {:.1}s ({:.0} ns/rec)", share(write_cpu), ns(write_cpu));
+        info!(
+            "    next-source predict: {:.1}s ({:.0} ns/rec)",
+            share(est_publish),
+            ns(est_publish)
+        );
         info!(
             "    (totals exact; the split between them is sampled, so read the shares as \
              proportions rather than to the tenth of a second)"
@@ -4457,7 +4474,7 @@ impl RawExternalSorter {
 
     fn log_merge_sub_phases(
         walls: (f64, f64),
-        consumer: (f64, f64, f64),
+        consumer: crate::merge_headroom::ConsumerSample,
         sampling: (u64, u64),
         active_workers: usize,
         pool: &Arc<SortWorkerPool>,
@@ -4465,7 +4482,6 @@ impl RawExternalSorter {
         consumer_diag: MergeConsumerDiag,
     ) {
         let (loop_total, merge_total) = walls;
-        let (write_secs, read_secs, tree_secs) = consumer;
         let (samples_taken, records_merged) = sampling;
         if records_merged == 0 {
             return;
@@ -4473,45 +4489,22 @@ impl RawExternalSorter {
         #[allow(clippy::cast_precision_loss, reason = "sample counts stay far below 2^52")]
         let scale =
             if samples_taken > 0 { records_merged as f64 / samples_taken as f64 } else { 1.0 };
-        let (est_write, est_read, est_tree) =
-            (write_secs * scale, read_secs * scale, tree_secs * scale);
+        let scaled = consumer.scaled(scale);
+        let est_read = scaled.advance;
+        let park_secs = stalls.as_ref().map_or(0.0, |x| x.park_secs);
 
         info!("=== Merge Sub-Phase Timing ===");
-        info!(
-            "  Consumer (main thread; {samples_taken} samples of {records_merged} records, scaled {scale:.0}x)"
+        let MergeConsumerDiag { backpressure_secs: blocked_secs, .. } = consumer_diag;
+        Self::log_consumer_rows(
+            scaled,
+            (samples_taken, records_merged),
+            scale,
+            loop_total,
+            park_secs,
+            consumer_diag,
         );
-        info!("    Fetch next record: {est_read:.1}s  (includes waiting on decompressed blocks)");
-        let MergeConsumerDiag {
-            backpressure_secs: blocked_secs,
-            backpressure_waits: blocked_waits,
-            borrowed,
-            reassembled,
-        } = consumer_diag;
-        if blocked_waits > 0 {
-            #[allow(clippy::cast_precision_loss, reason = "wait counts stay far below 2^52")]
-            let mean_us = blocked_secs * 1e6 / blocked_waits as f64;
-            info!(
-                "    Output backpressure: {blocked_secs:.1}s over {blocked_waits} waits \
-                 (mean {mean_us:.0} us, exact) -- the consumer blocked for an output permit"
-            );
-        } else {
-            info!("    Output backpressure: none -- the compressors always had a permit ready");
-        }
-        if borrowed + reassembled > 0 {
-            #[allow(clippy::cast_precision_loss, reason = "record counts stay far below 2^52")]
-            let pct = 100.0 * reassembled as f64 / (borrowed + reassembled) as f64;
-            info!(
-                "    Record presentation: {borrowed} borrowed zero-copy, {reassembled} \
-                 reassembled across a block boundary ({pct:.2}%, exact)"
-            );
-        }
-        info!("    Loser tree:        {est_tree:.1}s");
 
-        Self::log_consumer_cpu(
-            (loop_total, est_read, est_tree, est_write),
-            (records_merged, blocked_secs),
-            stalls.as_ref(),
-        );
+        Self::log_consumer_cpu(loop_total, scaled, (records_merged, blocked_secs), stalls.as_ref());
 
         // Parking is a subset of "fetch next record", so exact park time cannot
         // legitimately exceed the sampled estimate of it. When it does, the
@@ -4580,9 +4573,114 @@ impl RawExternalSorter {
                 workers.worker_utilization(merge_total, workers_n),
                 if loop_total > 0.0 { est_read / loop_total } else { 0.0 },
             );
+            Self::log_merge_headroom(loop_total, busy, workers_n, park_secs, blocked_secs);
         }
         Self::log_merge_stalls(loop_total, merge_total, active_workers, stalls, pool);
         info!("==============================");
+    }
+
+    /// The consumer's sampled sub-phase rows, and their reconciliation against the
+    /// loop they partition.
+    ///
+    /// Extracted from [`Self::log_merge_sub_phases`] to keep that function inside
+    /// the line limit; it is one cohesive block of reporting rather than a
+    /// mechanical split.
+    fn log_consumer_rows(
+        scaled: crate::merge_headroom::ConsumerSample,
+        sampling: (u64, u64),
+        scale: f64,
+        loop_total: f64,
+        park_secs: f64,
+        consumer_diag: MergeConsumerDiag,
+    ) {
+        let (samples_taken, records_merged) = sampling;
+        let est_tree = scaled.tree;
+        let est_read = scaled.advance;
+        info!(
+            "  Consumer (main thread; {samples_taken} samples of {records_merged} records, scaled {scale:.0}x)"
+        );
+        info!("    Fetch next record: {est_read:.1}s  (includes waiting on decompressed blocks)");
+        let MergeConsumerDiag {
+            backpressure_secs: blocked_secs,
+            backpressure_waits: blocked_waits,
+            borrowed,
+            reassembled,
+        } = consumer_diag;
+        if blocked_waits > 0 {
+            #[allow(clippy::cast_precision_loss, reason = "wait counts stay far below 2^52")]
+            let mean_us = blocked_secs * 1e6 / blocked_waits as f64;
+            info!(
+                "    Output backpressure: {blocked_secs:.1}s over {blocked_waits} waits \
+                 (mean {mean_us:.0} us, exact) -- the consumer blocked for an output permit"
+            );
+        } else {
+            info!("    Output backpressure: none -- the compressors always had a permit ready");
+        }
+        if borrowed + reassembled > 0 {
+            #[allow(clippy::cast_precision_loss, reason = "record counts stay far below 2^52")]
+            let pct = 100.0 * reassembled as f64 / (borrowed + reassembled) as f64;
+            info!(
+                "    Record presentation: {borrowed} borrowed zero-copy, {reassembled} \
+                 reassembled across a block boundary ({pct:.2}%, exact)"
+            );
+        }
+        info!("    Loser tree:        {est_tree:.1}s");
+        // Reconcile the sampled segments against the loop they are meant to
+        // partition. Three of these rows were reported for a long time without
+        // ever being summed against the loop, so there was no way to tell whether
+        // they accounted for most of it or a third. A signed residual is the check:
+        // positive means real time is unaccounted for, negative means the sampled
+        // regions over-attribute (their own clock overhead, or a sample biased
+        // toward expensive records).
+        let partition = crate::merge_headroom::LoopPartition {
+            segments: scaled,
+            loop_secs: loop_total,
+            park_secs,
+        };
+        info!(
+            "    Sampled segments sum to {:.1}s of a {loop_total:.1}s loop \
+             ({:+.0}% unattributed); {:.1}s of the fetch bucket was the consumer \
+             working rather than waiting",
+            scaled.total(),
+            100.0 * partition.unattributed_share(),
+            partition.advance_work_secs()
+        );
+    }
+
+    /// Name the wall this merge is against, and what is recoverable without
+    /// doing less work.
+    ///
+    /// Three limits, three different fixes, and they are routinely confused: the
+    /// serial consumer's own CPU, worker capacity, and coordination. Measured on
+    /// one cell, the same build at 8 and 16 threads gave opposite advice -- 1.8%
+    /// recoverable against 28% -- and nothing in the wall clock distinguished them.
+    /// Printing the floor turns "is my sort slow?" into "which limit am I on?",
+    /// which is the only version of the question that has an action attached.
+    fn log_merge_headroom(
+        loop_total: f64,
+        worker_busy_secs: f64,
+        threads: usize,
+        park_secs: f64,
+        blocked_secs: f64,
+    ) {
+        let floors = crate::merge_headroom::MergeFloors {
+            loop_secs: loop_total,
+            consumer_secs: (loop_total - park_secs - blocked_secs).max(0.0),
+            worker_busy_secs,
+            threads,
+        };
+        info!("  Merge floor: {} is the limit", floors.binding().label());
+        info!(
+            "    consumer serial {:.1}s | worker capacity {:.1}s ({threads} threads) | \
+             loop {loop_total:.1}s",
+            floors.consumer_secs,
+            floors.worker_floor_secs()
+        );
+        info!(
+            "    recoverable without doing less work: {:.1}s ({:.0}% of the merge)",
+            floors.recoverable_secs(),
+            100.0 * floors.recoverable_share()
+        );
     }
 
     /// Log why the merge stalled, as opposed to where its time went.
@@ -5326,6 +5424,8 @@ impl RawExternalSorter {
         // than the loop wall clock they are supposed to partition. A prime
         // interval decorrelates the sample from any block-size-derived period.
         let merge_sample_interval: u64 = 1021;
+        let mut merge_publish_secs = 0.0f64;
+        let mut merge_present_secs = 0.0f64;
         let mut merge_write_secs = 0.0f64;
         let mut merge_read_secs = 0.0f64;
         let mut merge_tree_secs = 0.0f64;
@@ -5355,32 +5455,47 @@ impl RawExternalSorter {
 
         let mut published_src: Option<usize> = None;
         while tree.winner_is_active() {
-            let winner = tree.winner();
-            let src_idx = source_map[winner];
-            // Publish the next likely source, but only when the run changes --
-            // ~167K times rather than once per record. The pool gives it the deep
-            // read allowance, so its first read starts while the consumer is still
-            // draining ~300 blocks from the current file, instead of after it has
-            // already stalled. A wrong prediction costs one deep read on a file the
-            // merge will reach eventually; there is no correctness component.
-            if published_src != Some(src_idx) {
-                published_src = Some(src_idx);
-                pool.set_phase2_next_source(tree.runner_up().map(|w| source_map[w]));
-            }
+            // Decide sampling first, so every segment below is timed on the same
+            // records or on none. Timing a subset would bias the partition toward
+            // whichever step happened to be measured, and the partition's whole
+            // value is that its segments sum to the loop.
             let sample_this = sample_countdown == 0;
             if sample_this {
                 sample_countdown = merge_sample_interval - 1;
+                samples_taken += 1;
             } else {
                 sample_countdown -= 1;
             }
 
+            let t = sample_this.then(Instant::now);
+            let winner = tree.winner();
+            let src_idx = source_map[winner];
+            // Publish the next likely source on run change. That is not once per
+            // record but it is far from rare: 25,003,410 publications against
+            // 779,820,469 records on the measured cell, one per ~31 records, each
+            // calling `runner_up()` at ~11.6ns. The pool gives the named file the
+            // deep read allowance, so its first read starts while the consumer is
+            // still draining the current file instead of after it has stalled. A
+            // wrong prediction costs one deep read on a file the merge reaches
+            // eventually; there is no correctness component.
+            if published_src != Some(src_idx) {
+                published_src = Some(src_idx);
+                pool.set_phase2_next_source(tree.runner_up().map(|w| source_map[w]));
+            }
+            if let Some(t0) = t {
+                merge_publish_secs += t0.elapsed().as_secs_f64();
+            }
+
+            let t = sample_this.then(Instant::now);
             let record_bytes = winner_record_bytes(&sources[src_idx], guard.consumer_ref())?;
-            if sample_this {
-                let t0 = Instant::now();
-                writer.write_raw_record(record_bytes)?;
+            if let Some(t0) = t {
+                merge_present_secs += t0.elapsed().as_secs_f64();
+            }
+
+            let t = sample_this.then(Instant::now);
+            writer.write_raw_record(record_bytes)?;
+            if let Some(t0) = t {
                 merge_write_secs += t0.elapsed().as_secs_f64();
-            } else {
-                writer.write_raw_record(record_bytes)?;
             }
 
             records_merged += 1;
@@ -5392,26 +5507,20 @@ impl RawExternalSorter {
                 merge_probe.log_mid_with_depths(depths, consumer_stats);
             }
 
-            if sample_this {
-                let t0 = Instant::now();
-                let next = sources[src_idx].advance(guard.consumer_mut())?;
+            let t = sample_this.then(Instant::now);
+            let next = sources[src_idx].advance(guard.consumer_mut())?;
+            if let Some(t0) = t {
                 merge_read_secs += t0.elapsed().as_secs_f64();
+            }
 
-                let t0 = Instant::now();
-                if let Some(key) = next {
-                    tree.replace_winner(key);
-                } else {
-                    tree.remove_winner();
-                }
-                merge_tree_secs += t0.elapsed().as_secs_f64();
-                samples_taken += 1;
+            let t = sample_this.then(Instant::now);
+            if let Some(key) = next {
+                tree.replace_winner(key);
             } else {
-                let next = sources[src_idx].advance(guard.consumer_mut())?;
-                if let Some(key) = next {
-                    tree.replace_winner(key);
-                } else {
-                    tree.remove_winner();
-                }
+                tree.remove_winner();
+            }
+            if let Some(t0) = t {
+                merge_tree_secs += t0.elapsed().as_secs_f64();
             }
         }
 
@@ -5474,7 +5583,13 @@ impl RawExternalSorter {
 
         Self::log_merge_sub_phases(
             (loop_total, loop_start.elapsed().as_secs_f64()),
-            (merge_write_secs, merge_read_secs, merge_tree_secs),
+            crate::merge_headroom::ConsumerSample {
+                publish: merge_publish_secs,
+                present: merge_present_secs,
+                write: merge_write_secs,
+                advance: merge_read_secs,
+                tree: merge_tree_secs,
+            },
             (samples_taken, records_merged),
             active_workers,
             pool,

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -49,6 +49,7 @@ pub(crate) mod inline;
 pub(crate) mod keys;
 pub(crate) mod loser_tree;
 pub(crate) mod memory_probe;
+pub(crate) mod merge_headroom;
 pub(crate) mod merge_phases;
 pub(crate) mod merge_stalls;
 pub(crate) mod merge_trace;

--- a/crates/fgumi-sort/src/merge_headroom.rs
+++ b/crates/fgumi-sort/src/merge_headroom.rs
@@ -114,6 +114,26 @@ impl MergeFloors {
     }
 }
 
+/// Nanoseconds one `Instant::now()` / `elapsed()` pair costs on this machine.
+///
+/// Measured rather than assumed because it varies by platform and by clock source
+/// -- 15-35ns across the hosts this engine has been profiled on -- and because it
+/// is the same order as the segments it is used to correct. A hard-coded constant
+/// would silently stop being right.
+///
+/// Timed with an empty body, so the result is exactly what a segment's interval
+/// picks up on top of the work it is measuring.
+#[must_use]
+pub(crate) fn measure_clock_overhead_nanos() -> u64 {
+    const ITERATIONS: u64 = 4096;
+    let mut total: u64 = 0;
+    for _ in 0..ITERATIONS {
+        let started = std::time::Instant::now();
+        total += u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX);
+    }
+    total / ITERATIONS
+}
+
 /// Sampled seconds for each step the merge consumer takes per record, in loop
 /// order.
 ///
@@ -148,6 +168,39 @@ impl ConsumerSample {
             write: self.write * scale,
             advance: self.advance * scale,
             tree: self.tree * scale,
+        }
+    }
+
+    /// Every segment with its own measurement overhead removed.
+    ///
+    /// Each sampled segment is bracketed by an `Instant::now()` / `elapsed()` pair,
+    /// and that pair's cost lands *inside* the interval it is timing. On aarch64 it
+    /// runs 15-35ns against segments of 2-100ns, so the raw numbers can be more
+    /// clock than work: the first run of this instrument reported five segments
+    /// summing to 321.5s of a 189.3s loop, and a `next-source predict` row of
+    /// 21 ns/record whose true cost is 0.37 ns/record.
+    ///
+    /// The correction is one pair per segment per sample, because every segment is
+    /// timed on every sampled record. Clamped at zero: a segment cheaper than the
+    /// clock that measures it cannot be resolved by this method, and zero says that
+    /// where a negative would just look like a bug.
+    #[must_use]
+    pub(crate) fn corrected(self, samples: u64, overhead_nanos: u64) -> Self {
+        if samples == 0 || overhead_nanos == 0 {
+            return self;
+        }
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "sample and nanosecond counts stay below 2^52"
+        )]
+        let per_segment = (samples * overhead_nanos) as f64 / 1e9;
+        let fix = |v: f64| (v - per_segment).max(0.0);
+        Self {
+            publish: fix(self.publish),
+            present: fix(self.present),
+            write: fix(self.write),
+            advance: fix(self.advance),
+            tree: fix(self.tree),
         }
     }
 
@@ -301,6 +354,68 @@ mod tests {
         assert!(f.floor_secs().is_finite());
         assert!(f.recoverable_secs().is_finite());
         assert!((0.0..=1.0).contains(&f.recoverable_share()));
+    }
+
+    /// The calibration must produce a plausible figure on whatever host the tests
+    /// run on. Not asserting a specific value -- that is hardware -- and zero is
+    /// valid: a coarse-resolution clock can round an empty body's interval to 0,
+    /// which `ConsumerSample::corrected` already handles as a no-op rather than a
+    /// bug. Only the upper bound is a real signal: a huge number would mean the loop
+    /// is measuring something other than the clock.
+    #[test]
+    fn test_clock_calibration_is_plausible() {
+        let ns = super::measure_clock_overhead_nanos();
+        assert!(ns < 10_000, "{ns}ns per clock pair is not a clock read");
+    }
+
+    /// Every timed segment carries one clock-read pair inside its interval, so the
+    /// correction is per segment per sample -- not per sample.
+    ///
+    /// This is the difference between a usable partition and an unusable one. The
+    /// first run of this instrument reported segments summing to 321.5s of a 189.3s
+    /// loop (-70%), with `next-source predict` at 21 ns/record against a true cost
+    /// the loser-tree benchmark puts at 0.37 ns/record. Almost the entire row was
+    /// the clock.
+    #[test]
+    fn test_correction_removes_one_clock_pair_per_segment_per_sample() {
+        // 1000 samples, 20ns of clock per pair: each segment loses 20us.
+        let raw = ConsumerSample {
+            publish: 0.000_030,
+            present: 0.000_040,
+            write: 0.000_050,
+            advance: 0.000_060,
+            tree: 0.000_070,
+        };
+        let c = raw.corrected(1000, 20);
+        assert!((c.publish - 0.000_010).abs() < 1e-12, "got {}", c.publish);
+        assert!((c.present - 0.000_020).abs() < 1e-12);
+        assert!((c.write - 0.000_030).abs() < 1e-12);
+        assert!((c.advance - 0.000_040).abs() < 1e-12);
+        assert!((c.tree - 0.000_050).abs() < 1e-12);
+    }
+
+    /// A segment smaller than its own measurement overhead must clamp to zero
+    /// rather than go negative: that is the signature of a row that is entirely
+    /// clock, and reporting it as negative time would be worse than reporting none.
+    #[test]
+    fn test_a_segment_smaller_than_its_overhead_clamps_to_zero() {
+        let raw = ConsumerSample { publish: 0.000_005, ..ConsumerSample::default() };
+        let c = raw.corrected(1000, 20);
+        assert!((c.publish - 0.0).abs() < 1e-12, "got {}", c.publish);
+    }
+
+    /// No samples, or an unmeasurable clock, must leave the sample untouched rather
+    /// than divide by zero or subtract a guess.
+    #[rstest]
+    #[case::no_samples(0, 20)]
+    #[case::no_measurable_overhead(1000, 0)]
+    fn test_correction_is_a_no_op_without_a_calibration(
+        #[case] samples: u64,
+        #[case] overhead_nanos: u64,
+    ) {
+        let raw = ConsumerSample { advance: 1.5, ..ConsumerSample::default() };
+        let c = raw.corrected(samples, overhead_nanos);
+        assert!((c.advance - 1.5).abs() < 1e-12);
     }
 
     /// The residual is the whole reason this type exists, so it must be reported

--- a/crates/fgumi-sort/src/merge_headroom.rs
+++ b/crates/fgumi-sort/src/merge_headroom.rs
@@ -1,0 +1,394 @@
+//! Which wall the merge is against, and how much of its wall clock is
+//! recoverable without doing less work.
+//!
+//! A spill-heavy sort's merge has exactly three limits, and every optimisation
+//! either moves one or moves nothing:
+//!
+//! 1. **The serial consumer.** One thread owns the loser tree and emits records
+//!    in a strict global order, so its own CPU time is a hard floor. Nothing in
+//!    the pool can shorten it.
+//! 2. **Worker capacity.** Total worker busy divided by the active thread count.
+//!    Read, decompress and output-compress are all parallel, so this is the floor
+//!    they collectively impose.
+//! 3. **Neither.** If the loop is longer than both floors the difference is
+//!    coordination -- the consumer waiting for work that exists, or for work that
+//!    has not been started.
+//!
+//! Reporting this matters because the three imply completely different fixes and
+//! are routinely confused. Measured on one cell, 8 threads against 16: at 8 the
+//! consumer was 98% of the loop and the recoverable share was 1.8%, so a
+//! scheduling change could not have paid however well designed; at 16 the same
+//! build left 28% of the loop recoverable. Same engine, same data, opposite
+//! advice -- and no way to tell from wall clock alone.
+
+/// Which limit the merge is actually against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Binding {
+    /// The serial consumer's own CPU is the largest floor.
+    Consumer,
+    /// Worker capacity is the largest floor.
+    Workers,
+    /// Both floors are well below the loop: the gap is coordination.
+    Coordination,
+}
+
+impl Binding {
+    pub(crate) const fn label(self) -> &'static str {
+        match self {
+            Self::Consumer => "consumer serial CPU",
+            Self::Workers => "worker capacity",
+            Self::Coordination => "coordination (neither floor is close)",
+        }
+    }
+}
+
+/// The measured merge loop against the two floors it cannot go below.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MergeFloors {
+    /// Measured merge loop wall clock.
+    pub(crate) loop_secs: f64,
+    /// The consumer thread's own CPU: `loop - park - backpressure`, exact.
+    pub(crate) consumer_secs: f64,
+    /// Total worker busy seconds across every phase-2 worker.
+    pub(crate) worker_busy_secs: f64,
+    /// Active worker threads the busy total is spread over.
+    pub(crate) threads: usize,
+}
+
+impl MergeFloors {
+    /// Worker capacity floor: busy time spread perfectly over the active threads.
+    ///
+    /// Zero threads is reported as no floor rather than a division by zero: a
+    /// merge with no workers is bounded by the consumer alone.
+    #[must_use]
+    pub(crate) fn worker_floor_secs(&self) -> f64 {
+        if self.threads == 0 {
+            return 0.0;
+        }
+        #[expect(clippy::cast_precision_loss, reason = "thread counts are tiny")]
+        let threads = self.threads as f64;
+        self.worker_busy_secs / threads
+    }
+
+    /// The larger of the two floors -- the shortest this merge could run without
+    /// doing less work.
+    #[must_use]
+    pub(crate) fn floor_secs(&self) -> f64 {
+        self.consumer_secs.max(self.worker_floor_secs())
+    }
+
+    /// Which floor is closest to the measured loop.
+    ///
+    /// `Coordination` when neither floor is within 10% of the loop: at that point
+    /// the gap is larger than either limit and naming a "binding" floor would be
+    /// misleading.
+    #[must_use]
+    pub(crate) fn binding(&self) -> Binding {
+        let floor = self.floor_secs();
+        if self.loop_secs > 0.0 && floor < 0.9 * self.loop_secs {
+            return Binding::Coordination;
+        }
+        if self.consumer_secs >= self.worker_floor_secs() {
+            Binding::Consumer
+        } else {
+            Binding::Workers
+        }
+    }
+
+    /// Wall clock that could be recovered without reducing total work.
+    ///
+    /// Never negative: a floor above the measured loop means the estimate is off,
+    /// not that time is owed.
+    #[must_use]
+    pub(crate) fn recoverable_secs(&self) -> f64 {
+        (self.loop_secs - self.floor_secs()).max(0.0)
+    }
+
+    /// [`Self::recoverable_secs`] as a share of the loop, 0.0 when the loop is empty.
+    #[must_use]
+    pub(crate) fn recoverable_share(&self) -> f64 {
+        if self.loop_secs <= 0.0 {
+            return 0.0;
+        }
+        self.recoverable_secs() / self.loop_secs
+    }
+}
+
+/// Sampled seconds for each step the merge consumer takes per record, in loop
+/// order.
+///
+/// Sampled rather than timed on every record because the consumer runs at
+/// 144-239 ns/record and one `Instant::now()` costs ~20-25 ns on aarch64: timing
+/// five steps on every record would add more overhead than the steps it measures.
+/// One in `MERGE_SAMPLE_INTERVAL` records is timed and the result scaled, so the
+/// partition holds over the sample and the scale factor is reported alongside it.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct ConsumerSample {
+    /// Reading the winner and publishing the predicted next source.
+    pub(crate) publish: f64,
+    /// Presenting the winning record: borrowed in place, or reassembled across a
+    /// block boundary.
+    pub(crate) present: f64,
+    /// Handing the record to the output writer.
+    pub(crate) write: f64,
+    /// Advancing that source, which is where the consumer parks or decompresses a
+    /// block itself. **Includes wait time**, so it is not pure CPU.
+    pub(crate) advance: f64,
+    /// Replaying the loser tree, or removing an exhausted source.
+    pub(crate) tree: f64,
+}
+
+impl ConsumerSample {
+    /// Every segment multiplied by the sampling scale.
+    #[must_use]
+    pub(crate) fn scaled(self, scale: f64) -> Self {
+        Self {
+            publish: self.publish * scale,
+            present: self.present * scale,
+            write: self.write * scale,
+            advance: self.advance * scale,
+            tree: self.tree * scale,
+        }
+    }
+
+    /// The five segments summed.
+    #[must_use]
+    pub(crate) fn total(self) -> f64 {
+        self.publish + self.present + self.write + self.advance + self.tree
+    }
+}
+
+/// A scaled consumer sample checked against the loop it is supposed to partition.
+///
+/// The check is the point. Three of these segments were already collected and
+/// scaled before this type existed, and were reported without ever being summed
+/// against the measured loop -- so there was no way to know whether they
+/// accounted for most of it or a third of it. A partition whose residual is not
+/// reported is an estimate wearing a budget's clothes.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct LoopPartition {
+    /// Scaled per-segment seconds.
+    pub(crate) segments: ConsumerSample,
+    /// Measured loop wall clock, exact.
+    pub(crate) loop_secs: f64,
+    /// Consumer park within `segments.advance`, measured exactly and separately.
+    pub(crate) park_secs: f64,
+}
+
+impl LoopPartition {
+    /// Loop time the segments do not account for.
+    ///
+    /// Signed on purpose: a negative residual means the sample over-attributes
+    /// (clock overhead inside the timed regions, or a sampling bias), and hiding
+    /// that behind a clamp would hide the one number that says the partition is
+    /// unsound.
+    #[must_use]
+    pub(crate) fn unattributed_secs(self) -> f64 {
+        self.loop_secs - self.segments.total()
+    }
+
+    /// `unattributed` as a share of the loop, for judging whether the partition is
+    /// trustworthy at a glance.
+    #[must_use]
+    pub(crate) fn unattributed_share(self) -> f64 {
+        if self.loop_secs <= 0.0 {
+            return 0.0;
+        }
+        self.unattributed_secs() / self.loop_secs
+    }
+
+    /// The part of `advance` that was the consumer working rather than waiting.
+    ///
+    /// `advance` covers both parking on a block and decompressing one inline, and
+    /// only the second is CPU the consumer could shed. Park is measured exactly, so
+    /// subtracting it separates the two. Clamped at zero: park is exact while
+    /// `advance` is sampled, so at small sample counts the estimate can land below
+    /// it without meaning anything.
+    #[must_use]
+    pub(crate) fn advance_work_secs(self) -> f64 {
+        (self.segments.advance - self.park_secs).max(0.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Binding, ConsumerSample, LoopPartition, MergeFloors};
+    use rstest::rstest;
+
+    /// Assertions use an epsilon rather than exact float equality: every field
+    /// here is a measured duration, so the arithmetic is inherently approximate.
+    const EPS: f64 = 1e-9;
+
+    /// The measured t8 cell after the targeted-depth changes: consumer 186.5s of a
+    /// 190.0s loop, workers 1412.3s over 8 threads. The consumer binds and almost
+    /// nothing is recoverable -- which is what says a scheduling fix cannot pay
+    /// here however well designed.
+    #[test]
+    fn test_a_saturated_consumer_binds_and_leaves_almost_nothing() {
+        let f = MergeFloors {
+            loop_secs: 190.0,
+            consumer_secs: 186.5,
+            worker_busy_secs: 1412.3,
+            threads: 8,
+        };
+        assert!((f.worker_floor_secs() - 176.537_5).abs() < 1e-4);
+        assert_eq!(f.binding(), Binding::Consumer);
+        assert!((f.floor_secs() - 186.5).abs() < EPS, "the larger floor is the consumer's");
+        assert!((f.recoverable_secs() - 3.5).abs() < 1e-9);
+        assert!(f.recoverable_share() < 0.02, "under 2%: got {}", f.recoverable_share());
+    }
+
+    /// The same build at 16 threads: consumer 112.1s of a 156.0s loop, workers
+    /// 1420.2s over 16. Neither floor is near the loop, so the honest verdict is
+    /// coordination and 28% is recoverable.
+    #[test]
+    fn test_a_loop_far_above_both_floors_reads_as_coordination() {
+        let f = MergeFloors {
+            loop_secs: 156.0,
+            consumer_secs: 112.1,
+            worker_busy_secs: 1420.2,
+            threads: 16,
+        };
+        assert!((f.worker_floor_secs() - 88.762_5).abs() < 1e-4);
+        assert_eq!(f.binding(), Binding::Coordination);
+        assert!((f.recoverable_secs() - 43.9).abs() < 1e-9);
+        assert!((f.recoverable_share() - 0.281_41).abs() < 1e-4, "got {}", f.recoverable_share());
+    }
+
+    /// Worker capacity can be the larger floor, and must be named when it is:
+    /// the fix for it (do less work per record) is nothing like the fix for a
+    /// slow consumer.
+    #[test]
+    fn test_worker_capacity_binds_when_it_is_the_larger_floor() {
+        let f = MergeFloors {
+            loop_secs: 200.0,
+            consumer_secs: 60.0,
+            worker_busy_secs: 1560.0, // 195s over 8
+            threads: 8,
+        };
+        assert!((f.worker_floor_secs() - 195.0).abs() < EPS);
+        assert_eq!(f.binding(), Binding::Workers);
+        assert!((f.recoverable_secs() - 5.0).abs() < EPS);
+    }
+
+    /// A floor above the measured loop means the inputs disagree, which must clamp
+    /// to zero rather than report negative recoverable time.
+    #[test]
+    fn test_a_floor_above_the_loop_never_reports_negative_headroom() {
+        let f = MergeFloors {
+            loop_secs: 100.0,
+            consumer_secs: 130.0,
+            worker_busy_secs: 0.0,
+            threads: 8,
+        };
+        assert!((f.recoverable_secs() - 0.0).abs() < EPS);
+        assert!((f.recoverable_share() - 0.0).abs() < EPS);
+    }
+
+    /// Degenerate inputs must not divide by zero or panic: a merge with no workers
+    /// is bounded by its consumer, and an empty loop has no share to report.
+    #[rstest]
+    #[case::no_workers(100.0, 90.0, 500.0, 0)]
+    #[case::empty_loop(0.0, 0.0, 0.0, 8)]
+    fn test_degenerate_inputs_are_finite(
+        #[case] loop_secs: f64,
+        #[case] consumer_secs: f64,
+        #[case] worker_busy_secs: f64,
+        #[case] threads: usize,
+    ) {
+        let f = MergeFloors { loop_secs, consumer_secs, worker_busy_secs, threads };
+        assert!(f.worker_floor_secs().is_finite());
+        assert!(f.floor_secs().is_finite());
+        assert!(f.recoverable_secs().is_finite());
+        assert!((0.0..=1.0).contains(&f.recoverable_share()));
+    }
+
+    /// The residual is the whole reason this type exists, so it must be reported
+    /// and not clamped. Segments summing to less than the loop means real time is
+    /// unaccounted for.
+    #[test]
+    fn test_an_incomplete_partition_reports_the_time_it_cannot_account_for() {
+        let p = LoopPartition {
+            segments: ConsumerSample {
+                publish: 5.0,
+                present: 10.0,
+                write: 20.0,
+                advance: 50.0,
+                tree: 15.0,
+            },
+            loop_secs: 156.0,
+            park_secs: 43.3,
+        };
+        assert!((p.segments.total() - 100.0).abs() < EPS);
+        assert!((p.unattributed_secs() - 56.0).abs() < EPS, "156 - 100");
+        assert!((p.unattributed_share() - 0.358_97).abs() < 1e-4);
+    }
+
+    /// Over-attribution must surface as a negative residual rather than be hidden:
+    /// it means the sampled timings include their own clock overhead, or the sample
+    /// is biased toward expensive records. Either way the partition is unsound and
+    /// the reader has to be told.
+    #[test]
+    fn test_over_attribution_stays_negative_instead_of_clamping() {
+        let p = LoopPartition {
+            segments: ConsumerSample {
+                publish: 0.0,
+                present: 0.0,
+                write: 0.0,
+                advance: 120.0,
+                tree: 0.0,
+            },
+            loop_secs: 100.0,
+            park_secs: 0.0,
+        };
+        assert!(p.unattributed_secs() < 0.0, "got {}", p.unattributed_secs());
+        assert!((p.unattributed_secs() + 20.0).abs() < EPS);
+    }
+
+    /// `advance` mixes waiting with working and only the working half is sheddable,
+    /// so park -- which is exact -- is subtracted out.
+    #[test]
+    fn test_advance_separates_the_consumer_working_from_the_consumer_waiting() {
+        let p = LoopPartition {
+            segments: ConsumerSample {
+                publish: 0.0,
+                present: 0.0,
+                write: 0.0,
+                advance: 60.0,
+                tree: 0.0,
+            },
+            loop_secs: 156.0,
+            park_secs: 43.3,
+        };
+        assert!((p.advance_work_secs() - 16.7).abs() < 1e-9);
+    }
+
+    /// Park is exact and `advance` is sampled, so the estimate can fall below it
+    /// without that meaning negative work.
+    #[test]
+    fn test_advance_work_clamps_when_the_sample_lands_below_exact_park() {
+        let p = LoopPartition {
+            segments: ConsumerSample {
+                publish: 0.0,
+                present: 0.0,
+                write: 0.0,
+                advance: 30.0,
+                tree: 0.0,
+            },
+            loop_secs: 156.0,
+            park_secs: 43.3,
+        };
+        assert!((p.advance_work_secs() - 0.0).abs() < EPS);
+    }
+
+    /// Scaling multiplies every segment by the same factor and leaves the ratios
+    /// between them alone.
+    #[test]
+    fn test_scaling_preserves_the_shape_of_the_sample() {
+        let raw =
+            ConsumerSample { publish: 1.0, present: 2.0, write: 3.0, advance: 4.0, tree: 5.0 };
+        let scaled = raw.scaled(1021.0);
+        assert!((scaled.total() - 15.0 * 1021.0).abs() < 1e-6);
+        assert!((scaled.publish / scaled.tree - raw.publish / raw.tree).abs() < 1e-9);
+    }
+}


### PR DESCRIPTION
Third in the stack: #813 (instrumentation) → #814 (the wins) → this.

## What this adds

**A floor line.** From exact counters, the merge now reports which of three limits binds — the consumer's serial CPU, worker capacity (busy ÷ threads), or coordination — and how much is recoverable without doing less work. It converts "is my sort slow?" into "which of three limits am I on?", and the three imply unrelated fixes.

Measured verdicts on the reference cell (`1kg-wgs-HG00096`, coordinate → template-coordinate, `--max-memory 512M --max-temp-files 1024`, 779,820,469 records, caches dropped, `compare bams` IDENTICAL):

| | loop | consumer serial | worker capacity | verdict | recoverable |
| --- | --- | --- | --- | --- | --- |
| 8 threads | 188.0s | 186.9s | — | consumer serial CPU | ~1s |
| 16 threads | 156.4s | 113.2s | 89.7s (16t) | coordination | 43.4s (28%) |

That table is the most useful thing to come out of this work. It is also what says the 8-thread merge is finished — it sits at 99.4% of its serial floor — and that the 16-thread gap is not worker capacity, which is 43% idle.

**A clock correction.** The sub-phase timings are sampled with an `Instant::now()`/`elapsed()` pair whose cost lands *inside* the interval — 15–35 ns against segments of 2–100 ns. Uncorrected, the segments summed to 321.5s of a 189.3s loop (−70%). The overhead is now calibrated per merge and subtracted per sample, and the partition prints a signed residual so the next such error shows up as an unattributed line rather than as plausible-looking rows.

**Quieter output.** A plain `fgumi sort` prints ~99 diagnostic lines at INFO, none of it opt-in. The consumer sub-phase rows and headroom detail move to `debug!`; the three floor lines stay at INFO because they are the part a user can act on. Its own commit, because it touches rows older than this PR — `log_consumer_rows` was extracted here and carries lines that predate it, and splitting the block by authorship would leave half a table at each level. ~72 `info!` calls elsewhere in this file deserve the same treatment and are left alone; a follow-up should put all of it behind a `--sort-stats` flag, paired with the benchmark harness that greps these lines.

## Headroom, stated plainly

This PR ships no speedup. It ships the measurement that says where the remaining time is and, more usefully, where it is not.

The 16-thread gap is 43.4s (28%), and it is precisely localized: 97% of park time is `waiting for a worker` while the work itself measures 40 µs against 1,325 µs of waiting; 89.4% of that has a worker asleep; 0.29% of block pulls carry 28% of merge wall at 2.9 ms each; the awaited file is 98% `starved` by time.

**Nineteen interventions against that picture have all measured worse or neutral.** Five arms that moved decompression off the serial consumer lost wall clock in proportion — slope **−0.373 s of merge per second of consumer fetch, r = −0.975**. A regime gate that adapted on self-serves-per-park cost +12.5% and was refuted twice over: its discriminant moved under its own action (9.2/park ungated → 31/park gated, against a threshold of 32), and the counter it divided by counts *calls* rather than blocks. Letting the consumer read the starved block itself fired on 0.6% of starved parks — `try_lock` on the reader failed ~99% of the time, because a worker was already reading exactly what the consumer wanted. Publishing that read every 16 blocks instead of every 404 moved wall clock 0.1%.

So the shipped configuration is a local optimum in every dimension tested: decompress cap (non-monotonic, optimum at the current 8), publish granularity (neutral), consumer-side read (neutral), prediction window (negative), regime gate (negative), wake targeting (`0% recoverable` by its own counter). It is not bandwidth — 52.6 GB over 156s is ~337 MB/s against a 1000 MB/s volume.

I would not spend more on the 16-thread merge on this evidence.

## Notes for review

- `merge_headroom.rs` is new and self-contained: `MergeFloors`, `ConsumerSample`, `LoopPartition`, and the clock calibration. 22 tests, all mutation-verified — two tests initially survived removing the code they covered and were rewritten.
- `LoopPartition::unattributed_secs` is deliberately **signed**. It is what caught the −70% error above; an unsigned or clamped residual would have hidden it.
- 7,745 tests pass. Instrumentation cost measured twice against a proper in-boot control at −0.34% / +0.15% / −0.66% — opposite signs, inside noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: sort diagnostics and merge-floor metrics change output, pinned by calibrated timing, consumer samples, and floor classification; unsafe: none; CLAUDE.md allowlist: unchanged; memory bounds, queue capacity, and thread/backpressure policy: none.

- Add merge-floor reporting for consumer serial CPU, worker capacity, and coordination limits.
- Report recoverable wall-clock headroom and binding classifications.
- Partition consumer-loop timing into prediction, presentation, writing, source advancement, and loser-tree work.
- Calibrate and subtract clock overhead from sampled timings.
- Report signed residuals for unattributed loop time.
- Move detailed consumer and lifecycle diagnostics to `debug!`.
- Keep actionable floor verdicts and summary metrics at `INFO`.
- Add tests for calibration, correction, binding, residual accounting, clamping, scaling, and diagnostic reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->