### PR TITLE
test(pipeline): stabilize read-ahead backpressure assertion (#809)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,13 @@
 [profile.default]
 slow-timeout = { period = "60s", terminate-after = 2 }
+
+# `read_ahead_under_a_stalled_writer_shrinks_with_the_queue_memory_budget` measures
+# each budget arm's read-ahead as the maximum over READ_AHEAD_REPS stalled-writer
+# runs (issue #809), so it spawns the stalled pipeline several times back to back,
+# each with its own settle wait. That is legitimately slow (~30s locally, and 2-3x
+# that under llvm-cov instrumentation plus CI's 2x CPU oversubscription), enough to
+# trip the default 120s (60s x 2) terminate-after. Give this one test a longer leash
+# rather than dropping reps and weakening the flake-suppression the maximum provides.
+[[profile.default.overrides]]
+filter = 'test(=test_pipeline_memory_backpressure::read_ahead_under_a_stalled_writer_shrinks_with_the_queue_memory_budget)'
+slow-timeout = { period = "60s", terminate-after = 4 }

--- a/tests/integration/test_pipeline_memory_backpressure.rs
+++ b/tests/integration/test_pipeline_memory_backpressure.rs
@@ -445,6 +445,19 @@ fn read_ahead_under_a_stalled_writer_shrinks_with_the_queue_memory_budget() {
     /// Read batch small enough that read-ahead tracks the byte budget instead of
     /// the ~1 MiB production batch quantum.
     const FINE_READ_BLOCKS: usize = 4;
+    /// Reps per arm whose maximum read-ahead is taken as that arm's measurement.
+    ///
+    /// The budget-bounded stopping point is an *upper* bound the reader
+    /// approaches from below, and the only scheduler noise on it is one-sided and
+    /// downward: if the reader is starved of CPU for a full second mid-read,
+    /// [`wait_for_consumption_to_settle`] can call the arm settled at a partial
+    /// read-ahead — well short of where the budget would actually stop it. That
+    /// rare downward tail (observed on the generous arm) is what made a single
+    /// sample flap (issue #809). It never lifts an arm *above* its true ceiling,
+    /// so the maximum across a few reps recovers that ceiling and is immune to
+    /// the tail; three reps drive the odds of every rep tailing at once low
+    /// enough to be irrelevant while keeping the test cheap.
+    const READ_AHEAD_REPS: usize = 3;
 
     let (header, bam_bytes) = shared_bam_bytes();
     let input_len = bam_bytes.len() as u64;
@@ -456,8 +469,10 @@ fn read_ahead_under_a_stalled_writer_shrinks_with_the_queue_memory_budget() {
     let generous_budget = 3 * TEST_BUDGET_BYTES / 2; // 3 MiB
     let budget_difference = generous_budget - tight_budget;
 
-    let mut consumption = Vec::new();
-    for budget in [tight_budget, generous_budget] {
+    // Measure one arm's read-ahead: how far the reader runs before a stalled
+    // writer backs it up under `budget`. Returned as the settled input-bytes
+    // consumed, after asserting the arm actually settled short of EOF.
+    let measure_read_ahead = |budget: u64| -> u64 {
         let StalledRun { consumed, released, handle, .. } =
             spawn_stalled_pipeline(header, bam_bytes.clone(), 4, budget, Some(FINE_READ_BLOCKS));
         let settled = wait_for_consumption_to_settle(&consumed, input_len, Duration::from_secs(30));
@@ -472,8 +487,17 @@ fn read_ahead_under_a_stalled_writer_shrinks_with_the_queue_memory_budget() {
         );
         released.store(true, Ordering::Release);
         join_pipeline_within(handle, &consumed, input_len, JOIN_DEADLINE);
-        consumption.push(settled.bytes);
-    }
+        settled.bytes
+    };
+
+    // Take each arm's *maximum* read-ahead over a few reps, not a single sample:
+    // the measurement noise is a one-sided downward tail (see `READ_AHEAD_REPS`),
+    // so the max is the robust estimator of the arm's true budget-bounded ceiling.
+    let arm_read_ahead = |budget: u64| -> u64 {
+        (0..READ_AHEAD_REPS).map(|_| measure_read_ahead(budget)).max().expect("at least one rep")
+    };
+    let tight = arm_read_ahead(tight_budget);
+    let generous = arm_read_ahead(generous_budget);
 
     // A margin tied to the budget difference, not bare ordering: `tight < generous`
     // alone could be one stray block, and if a bound ignored the budget entirely
@@ -482,7 +506,6 @@ fn read_ahead_under_a_stalled_writer_shrinks_with_the_queue_memory_budget() {
     // bound, while tolerating the few-block overshoot the fine read batch still
     // leaves. (Measured gap is ~0.9x the budget difference; the reader trails the
     // budget sub-linearly because part of it is spent on decoded, expanded data.)
-    let (tight, generous) = (consumption[0], consumption[1]);
     assert!(
         generous.saturating_sub(tight) >= budget_difference / 2,
         "read-ahead was {tight} bytes under a {tight_budget}-byte budget and {generous} bytes \


### PR DESCRIPTION
Closes #809.

## Problem

`read_ahead_under_a_stalled_writer_shrinks_with_the_queue_memory_budget` compared a single read-ahead sample per budget arm. It still flakes on `main` — reproduced 1 failure in ~20 uncontended reps locally, and ~5% under CPU contention.

The failing shape is always the same: the generous (3 MiB) arm reads anomalously little and lands close to the tight (1 MiB) arm, so `generous - tight` dips under the `budget_difference / 2` threshold. Example failure: `tight = 1,145,011`, `generous = 1,585,185`, gap `440,174 < 1,048,576`.

## Root cause

The reader's budget-bounded stopping point is an *upper* bound it approaches from below, and the scheduler noise on it is one-sided and downward. If the reader is starved of CPU for a full second mid-read, `wait_for_consumption_to_settle` (which calls an arm settled after 4×250 ms of no observed progress) declares it settled at a *partial* read-ahead — well short of where the budget would actually stop it. The generous arm reads ~3× further than the tight arm, so it is far more exposed to that rare downward tail. Characterization confirmed both arms are well-separated and stable in the common case (tight ≈ 1.06–1.19 MB, generous ≈ 2.60–2.99 MB); the failure is a rare downward outlier on the generous arm, not the budget failing to bound the queues.

## Fix

Measure each arm's read-ahead as the **maximum over a few reps** instead of a single sample. The tail never lifts an arm above its true ceiling, so the maximum recovers that ceiling and is immune to it — without weakening what the test proves (the assertion, the sub-saturation budgets, and the `budget_difference / 2` margin are unchanged). Three reps drive the odds of every rep tailing at once low enough to be irrelevant while keeping the test cheap.

## Verification

- 40/40 passes under 2× CPU oversubscription (the contention that reproduced the tail), where a single-sample run failed ~5%.
- Full `test_pipeline_memory_backpressure` module green; `cargo ci-fmt` and `clippy --all-features --tests -D warnings` clean.
- Test-only change; no pipeline/production code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: command output changes: none; `unsafe` changes: none, so the `CLAUDE.md` allowlist is unchanged; memory bounds, queue capacity, or thread/backpressure policy changes: none.

The test now repeats each budget measurement three times and uses the maximum read-ahead value. This reduces scheduler-related false failures without weakening the existing assertion or budget settings. The nextest timeout for this slow test increases to four 60-second periods.

Verification passed 40/40 runs under 2× CPU oversubscription, the memory backpressure test module, formatting, and clippy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->