### PR TITLE
test(pipeline): enforce backpressure fixture headroom centrally (#789)

### DIFF
--- a/tests/integration/test_pipeline_memory_backpressure.rs
+++ b/tests/integration/test_pipeline_memory_backpressure.rs
@@ -73,25 +73,44 @@ const DEPTH: usize = 1;
 /// The compressed fixture must be at least this many `TEST_BUDGET_BYTES` in
 /// size for the read-ahead margin assertions to carry drift headroom.
 ///
-/// The reader's stopping point sits near `budget + overhead` (~1.5 budgets),
-/// and the margin assertions demand one further budget left unread, so anything
-/// below three budgets has no slack for BGZF block-size drift (issue #789). The
-/// precondition in [`stalled_writer_stops_the_reader_within_the_queue_memory_budget`]
-/// enforces this so a future shrink of `FAMILIES` fails loudly here rather than
-/// silently reintroducing a thin margin.
+/// The reader's stopping point sits near `budget + overhead`. The largest
+/// budget any test uses is the read-ahead test's generous arm at
+/// `3 * TEST_BUDGET_BYTES / 2`, and the margin assertions demand one further
+/// budget left unread on top of wherever the reader stops, so anything below
+/// three budgets has no slack for BGZF block-size drift (issue #789). The floor
+/// holds with room to spare at the current `FAMILIES`: the input measures
+/// ~4 budgets and the reader stops by ~1.5, leaving ~2.5 budgets unread on
+/// every arm. [`shared_bam_bytes`] asserts this floor once at fixture
+/// construction so a future shrink of `FAMILIES` fails loudly for *every* test
+/// — not only the one that happens to re-check it — rather than silently
+/// reintroducing a thin margin.
 const MIN_INPUT_HEADROOM_BUDGETS: u64 = 3;
 
 /// The generated BAM input and the header it was built with, materialized once
 /// and shared by every test.
 ///
-/// Building the fixture dominates each test's runtime, and all three want the
+/// Building the fixture dominates each test's runtime, and every test wants the
 /// same bytes, so this amortizes it across the suite. Tests clone the byte
 /// vector when the pipeline needs to own it.
+///
+/// Enforces the [`MIN_INPUT_HEADROOM_BUDGETS`] floor here, at the single point
+/// where the fixture is built, so the guarantee covers every test that reads it
+/// — including the read-ahead test, which uses the largest budget and would
+/// otherwise have no fixture-size guard at all. A future `FAMILIES` shrink that
+/// erodes the read-ahead margin therefore fails loudly and unambiguously.
 fn shared_bam_bytes() -> &'static (Header, Vec<u8>) {
     static FIXTURE: OnceLock<(Header, Vec<u8>)> = OnceLock::new();
     FIXTURE.get_or_init(|| {
         let header = create_minimal_header("chr1", 100_000);
         let bytes = build_bam_bytes(&header, FAMILIES, DEPTH);
+        let input_len = bytes.len() as u64;
+        assert!(
+            input_len >= MIN_INPUT_HEADROOM_BUDGETS * TEST_BUDGET_BYTES,
+            "test fixture ({input_len} bytes) must be at least {MIN_INPUT_HEADROOM_BUDGETS} \
+             budgets ({} bytes) so every read-ahead margin assertion has BGZF block-size drift \
+             headroom (issue #789); raise FAMILIES",
+            MIN_INPUT_HEADROOM_BUDGETS * TEST_BUDGET_BYTES
+        );
         (header, bytes)
     })
 }
@@ -379,17 +398,11 @@ const JOIN_DEADLINE: Duration = Duration::from_secs(60);
 fn stalled_writer_stops_the_reader_within_the_queue_memory_budget() {
     let (header, bam_bytes) = shared_bam_bytes();
     let input_len = bam_bytes.len() as u64;
-    // Not merely "exceeds the budget": the reader stops near `budget + overhead`
-    // and the assertion below requires a further whole budget left unread, so
-    // the fixture needs clear headroom above `read_ahead + TEST_BUDGET_BYTES`.
-    // Enforcing a multi-budget floor here keeps that headroom robust to BGZF
-    // block-size drift and makes a future `FAMILIES` shrink fail loudly (#789).
-    assert!(
-        input_len >= MIN_INPUT_HEADROOM_BUDGETS * TEST_BUDGET_BYTES,
-        "test input ({input_len} bytes) must be at least {MIN_INPUT_HEADROOM_BUDGETS} budgets \
-         ({} bytes) so the read-ahead margin has drift headroom",
-        MIN_INPUT_HEADROOM_BUDGETS * TEST_BUDGET_BYTES
-    );
+    // The fixture's drift headroom — the reader stops near `budget + overhead`
+    // and the assertion below requires a further whole budget left unread — is
+    // enforced once for every test by the `MIN_INPUT_HEADROOM_BUDGETS` floor in
+    // `shared_bam_bytes`, so a `FAMILIES` shrink fails there before reaching here
+    // (#789).
 
     let StalledRun { consumed, released, handle, .. } =
         spawn_stalled_pipeline(header, bam_bytes.clone(), 4, TEST_BUDGET_BYTES, None);


### PR DESCRIPTION
Closes #789.

## Audit

Issue #789 asked to harden the fixture sizing and any remaining fraction-based margins in `tests/integration/test_pipeline_memory_backpressure.rs` against BGZF block-size drift. Most of that concern is already resolved on `main` by #764/#775:

- The formerly brittle `settled.bytes < input_len / 2` assertion is now budget-relative (`unread >= TEST_BUDGET_BYTES`).
- The fixture was resized so read-ahead has comfortable headroom.

Measured on `main` (M2 Max), `input_len` is now **8.07 MiB (~4 budgets)** while the reader stops by ~1.5 budgets, leaving:

| arm | budget | read-ahead | unread |
|---|---|---|---|
| `stalled_writer_stops` | 2 MiB | 2.14 MiB | **5.93 MiB (≈3.0 budgets)** |
| `read_ahead` generous | 3 MiB | 2.81 MiB | **5.26 MiB (≈2.6 budgets)** |

The issue's original worry (~2.46 MiB read-ahead under a ~2.7 MiB `input_len/2` threshold — 0.24 MiB of slack) is fully gone.

## The one remaining gap

The fixture-size floor (`input_len >= MIN_INPUT_HEADROOM_BUDGETS * TEST_BUDGET_BYTES`) was asserted **only inside** `stalled_writer_stops_the_reader_within_the_queue_memory_budget`. But the `read_ahead` test uses the **largest** budget (the 3 MiB generous arm) and had **no fixture-size guard at all** — so a future `FAMILIES` shrink could erode its headroom silently, exactly the drift-fragility this issue tracks.

## Change

Assert the floor once in `shared_bam_bytes()`, at the single point the fixture is built, so the guarantee covers every test that reads it. A `FAMILIES` shrink below the floor now fails loudly and unambiguously for the whole module rather than depending on which test happens to run. The now-redundant local precondition in `stalled_writer_stops...` is replaced with a pointer to the central guard.

The remaining `settled.bytes < input_len` EOF guard in the `read_ahead` test carries 2.6 budgets of slack and is further hardened by #827's multi-rep max, so it needs no separate budget-relative rewrite — keeping this PR independent of #827.

## Verification

- Guard fires as intended: temporarily shrinking `FAMILIES` to `1_000` panics with `test fixture (48580 bytes) must be at least 3 budgets ... raise FAMILIES`.
- Full `test_pipeline_memory_backpressure` module green (4.1s — fixture size and coverage-job runtime unchanged).
- `cargo ci-fmt` and `clippy --all-features --tests -D warnings` clean.
- Test-only change; no production code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: command output changes: none; `unsafe` changes: none, so no `CLAUDE.md` allowlist update; memory bounds, queue capacity, and thread/backpressure policy changes: none.

Centralized the fixture-size headroom assertion in `shared_bam_bytes()` so all tests using the shared fixture enforce the minimum size. Removed the duplicate local assertion and updated the related documentation. Test-only change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->