### PR TITLE
perf: avoid three per-record heap allocations (group / downsample / overlapping consensus)

### DIFF
--- a/crates/fgumi-consensus/src/overlapping.rs
+++ b/crates/fgumi-consensus/src/overlapping.rs
@@ -641,11 +641,25 @@ pub fn apply_overlapping_consensus(
             continue;
         }
 
-        let name = view.read_name().to_vec();
+        // Look the name up by borrow and only copy it into an owned key when a
+        // new pair is inserted. `entry(name.to_vec())` would allocate a QNAME
+        // `Vec` for every record and then discard it whenever the key already
+        // exists (i.e. on the second read of each pair).
+        let name = view.read_name();
         if flg & fgumi_raw_bam::flags::FIRST_SEGMENT != 0 {
-            read_pairs.entry(name).or_insert((None, None)).0 = Some(idx);
+            match read_pairs.get_mut(name) {
+                Some(pair) => pair.0 = Some(idx),
+                None => {
+                    read_pairs.insert(name.to_vec(), (Some(idx), None));
+                }
+            }
         } else if flg & fgumi_raw_bam::flags::LAST_SEGMENT != 0 {
-            read_pairs.entry(name).or_insert((None, None)).1 = Some(idx);
+            match read_pairs.get_mut(name) {
+                Some(pair) => pair.1 = Some(idx),
+                None => {
+                    read_pairs.insert(name.to_vec(), (None, Some(idx)));
+                }
+            }
         }
     }
 

--- a/src/lib/commands/downsample.rs
+++ b/src/lib/commands/downsample.rs
@@ -365,8 +365,10 @@ where
         while let Some(peek_result) = self.records.peek() {
             match peek_result {
                 Ok(record) => {
-                    let record_mi = get_mi_tag(record)?;
-                    if record_mi != mi {
+                    // Compare the MI against the family key without allocating a
+                    // `String` per record — the family key was already materialized
+                    // once above.
+                    if !mi_tag_equals(record, mi.as_bytes())? {
                         break;
                     }
                     // Consume the record — next() is Some because peek() was Some
@@ -399,6 +401,32 @@ fn get_mi_tag(record: &RawRecord) -> Result<String> {
 
     if let Some(v) = find_int_tag(aux, SamTag::MI) {
         return Ok(v.to_string());
+    }
+
+    let name = String::from_utf8_lossy(read_name(record.as_ref())).into_owned();
+    let display_name = if name.is_empty() { "<unknown>".to_string() } else { name };
+    bail!("Read '{display_name}' is missing required MI tag")
+}
+
+/// Whether a record's MI tag equals `target`, without allocating.
+///
+/// Mirrors [`get_mi_tag`]'s type handling (Z-typed first, then an integer
+/// encoding), but compares against `target` in place rather than building a
+/// `String` for every record — the family-key `String` is materialized only
+/// once per family. The Z path still validates UTF-8 so an invalid MI is an
+/// error exactly as in [`get_mi_tag`]; the legacy integer path is rare and falls
+/// back to rendering.
+fn mi_tag_equals(record: &RawRecord, target: &[u8]) -> Result<bool> {
+    let aux = aux_data_slice(record.as_ref());
+
+    if let Some(bytes) = find_string_tag(aux, SamTag::MI) {
+        std::str::from_utf8(bytes)
+            .map_err(|e| anyhow::anyhow!("MI tag is not valid UTF-8: {e}"))?;
+        return Ok(bytes == target);
+    }
+
+    if let Some(v) = find_int_tag(aux, SamTag::MI) {
+        return Ok(v.to_string().as_bytes() == target);
     }
 
     let name = String::from_utf8_lossy(read_name(record.as_ref())).into_owned();
@@ -445,11 +473,55 @@ mod tests {
         b.build()
     }
 
+    /// Create a test record with a raw-bytes (Z-typed) MI tag, allowing invalid
+    /// UTF-8 that `&str` cannot express.
+    fn create_test_record_bytes_mi(name: &str, mi: &[u8]) -> RawRecord {
+        let mut b = RawSamBuilder::new();
+        b.read_name(name.as_bytes());
+        b.add_string_tag(SamTag::MI, mi);
+        b.build()
+    }
+
     /// Create a test record without an MI tag.
     fn create_test_record_no_mi(name: &str) -> RawRecord {
         let mut b = RawSamBuilder::new();
         b.read_name(name.as_bytes());
         b.build()
+    }
+
+    /// `mi_tag_equals` must agree with a `get_mi_tag` + compare for both Z and
+    /// integer MI encodings, and error on a missing MI exactly as `get_mi_tag`
+    /// does — it is the allocation-free replacement for that comparison.
+    #[test]
+    fn test_mi_tag_equals_matches_get_mi_tag() {
+        // Z-typed MI: match and mismatch.
+        let z = create_test_record("read1", "12345");
+        assert!(mi_tag_equals(&z, b"12345").unwrap());
+        assert!(!mi_tag_equals(&z, b"12346").unwrap());
+        assert!(!mi_tag_equals(&z, b"1234").unwrap()); // prefix is not a match
+        assert!(mi_tag_equals(&z, get_mi_tag(&z).unwrap().as_bytes()).unwrap());
+
+        // Integer-typed MI renders the same way get_mi_tag does.
+        let i = create_test_record_int_mi("read2", 421);
+        assert!(mi_tag_equals(&i, b"421").unwrap());
+        assert!(!mi_tag_equals(&i, b"420").unwrap());
+        assert!(mi_tag_equals(&i, get_mi_tag(&i).unwrap().as_bytes()).unwrap());
+
+        // A Z-typed MI with invalid UTF-8 is an error, and mi_tag_equals must
+        // surface the same UTF-8 error as get_mi_tag rather than reporting a
+        // (mis)match against the raw bytes.
+        let bad_utf8 = create_test_record_bytes_mi("read3", &[0xff, 0xfe]);
+        let equals_err =
+            mi_tag_equals(&bad_utf8, &[0xff, 0xfe]).expect_err("invalid UTF-8 MI must be an error");
+        let get_err = get_mi_tag(&bad_utf8).expect_err("invalid UTF-8 MI must be an error");
+        assert!(equals_err.to_string().contains("not valid UTF-8"));
+        assert!(get_err.to_string().contains("not valid UTF-8"));
+        assert_eq!(equals_err.to_string(), get_err.to_string());
+
+        // Missing MI is an error, matching get_mi_tag.
+        let none = create_test_record_no_mi("read4");
+        assert!(mi_tag_equals(&none, b"anything").is_err());
+        assert!(get_mi_tag(&none).is_err());
     }
 
     /// Canonical `BamIoOptions` used by `Downsample` test constructors.

--- a/src/lib/grouper.rs
+++ b/src/lib/grouper.rs
@@ -595,13 +595,18 @@ fn group_by_name_and_build<T>(
 
     for decoded in records {
         let name_hash = decoded.key.name_hash;
-        let read_name = fgumi_raw_bam::read_name(&decoded.data).to_vec();
-        let item = extract(decoded)?;
 
         // name_hash is a fast pre-check; confirm QNAME bytes to guard against
-        // hash collisions merging unrelated templates.
-        let same = current_name_hash == Some(name_hash)
-            && current_name.as_deref() == Some(read_name.as_slice());
+        // hash collisions merging unrelated templates. Compare the name via a
+        // borrow (and only copy it out when a new group starts) so records within
+        // a group don't each allocate a QNAME `Vec` — the borrow must end before
+        // `extract` consumes `decoded`.
+        let read_name = fgumi_raw_bam::read_name(&decoded.data);
+        let same =
+            current_name_hash == Some(name_hash) && current_name.as_deref() == Some(read_name);
+        let new_name = if same { None } else { Some(read_name.to_vec()) };
+
+        let item = extract(decoded)?;
         if same {
             current_items.push(item);
         } else if current_name_hash.is_some() {
@@ -609,11 +614,11 @@ fn group_by_name_and_build<T>(
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
             templates.push(template);
             current_name_hash = Some(name_hash);
-            current_name = Some(read_name);
+            current_name = new_name;
             current_items.push(item);
         } else {
             current_name_hash = Some(name_hash);
-            current_name = Some(read_name);
+            current_name = new_name;
             current_items.push(item);
         }
     }


### PR DESCRIPTION
## Summary

Three independent per-record heap allocations, each a short buffer built only to be compared once and dropped. Removing them is a small, zero-risk cleanup (measured at ~9–10 ns/record each under mimalloc — the allocator's per-alloc bookkeeping, not the copy). One commit per site; suggested reading order below.

## Commits

1. **`perf(group)`** — `group_by_name_and_build` allocated a QNAME `Vec` (`read_name().to_vec()`) for every record just to compare it against the current group's name. Now compares via a borrow and copies the owned name only on a group change (the borrow must end before `extract` consumes the decoded record) — mirroring the sibling in `TemplateGrouper::add_records`.
2. **`perf(downsample)`** — `FamilyIterator::next_family` allocated a `String` per record's MI tag (`get_mi_tag`) only to compare it against the family key. New `mi_tag_equals` compares in place: a Z-typed MI compares bytes directly; the legacy integer form falls back to rendering. The family-key `String` is still built once per family. A test cross-checks `mi_tag_equals` against `get_mi_tag` for the Z, integer, and missing-MI cases.
3. **`perf(consensus)`** — `apply_overlapping_consensus` built its read-pair map with `entry(read_name().to_vec())`, allocating a QNAME `Vec` for every record and discarding it whenever the key already existed (the second read of each pair). Now looks the name up by borrow and copies an owned key only when inserting a new pair.

## Safety

All three are behavior-preserving. (1) and (2) keep the exact comparison/error semantics — (2)'s test pins parity with `get_mi_tag`. (3)'s map is read via `.values()` only, so iteration order is never observed and the `get_mut`/`insert` split is equivalent to the old `entry().or_insert()`. Full suite (7704 tests) + clippy-pedantic + docs + tag-literals green.

## Scale

Each site is ~10 ns/record — individually minor, but zero-risk and on default-on paths (grouping every template; downsample per family member; overlapping consensus with `--consensus-call-overlapping-bases`, which defaults to `true`). Part of a per-record-hot-path audit; the larger wins (zipper tag probe, filter progress atomic) ship separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: command output changes: none; `unsafe` changes: none; memory bounds, queue capacity, and thread/backpressure policy changes: none.

- Avoids per-record QNAME allocation during template grouping and overlapping-consensus pairing.
- Avoids per-record MI `String` allocation during downsampling.
- Preserves grouping, pairing, consensus, hash-collision checks, UTF-8 validation, and missing-tag errors.
- Adds MI comparison tests for matching, mismatching, prefix, integer, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->