### PR TITLE
perf(cigar): iterate raw CIGAR ops without a per-record Vec at four hot sites

### DIFF
--- a/crates/fgumi-consensus/src/filter.rs
+++ b/crates/fgumi-consensus/src/filter.rs
@@ -1092,12 +1092,11 @@ pub fn resolve_ref_bases_for_record(
     // avoiding a HashMap lookup per position.
     let ref_seq = reference.sequence_for(ref_name);
 
-    let cigar_ops = bam_fields::get_cigar_ops(record);
     let len = RawRecordView::new(record).l_seq() as usize;
     let mut result = Vec::with_capacity(len);
     let mut ref_pos = alignment_start;
 
-    for &op in &cigar_ops {
+    for op in RawRecordView::new(record).cigar_ops_iter() {
         let op_len = (op >> 4) as usize;
         let kind = bam_fields::cigar_op_kind(op);
         match kind {

--- a/crates/fgumi-consensus/src/overlapping.rs
+++ b/crates/fgumi-consensus/src/overlapping.rs
@@ -422,9 +422,11 @@ impl ReadAndRefPosIterator {
         let min_ref_pos = rec_start_i32.max(mate_start as i32);
         let max_ref_pos = rec_end_i32.min(mate_end as i32);
 
-        let raw_ops = fgumi_raw_bam::get_cigar_ops(bam);
-        let cigar_ops: Vec<(u8, usize)> =
-            raw_ops.iter().map(|&op| ((op & 0xF) as u8, (op >> 4) as usize)).collect();
+        // Decode CIGAR ops straight from the raw bytes (no intermediate `Vec<u32>`).
+        let cigar_ops: Vec<(u8, usize)> = RawRecordView::new(bam)
+            .cigar_ops_iter()
+            .map(|op| ((op & 0xF) as u8, (op >> 4) as usize))
+            .collect();
 
         let start_read_pos = 1i32;
         let end_read_pos = rec_len;

--- a/crates/fgumi-metrics/src/clip.rs
+++ b/crates/fgumi-metrics/src/clip.rs
@@ -120,18 +120,15 @@ impl ClippingMetrics {
     /// * `counts` - The clip counts for this operation
     #[cfg(feature = "clip")]
     pub fn update_raw(&mut self, record: &fgumi_raw_bam::RawRecord, counts: ClipCounts) {
-        use fgumi_raw_bam::get_cigar_ops;
+        use fgumi_raw_bam::RawRecordView;
 
         self.reads += 1;
 
-        // Count aligned bases (M/=/X ops) from raw CIGAR
-        let cigar_ops = get_cigar_ops(record.as_ref());
-        let aligned_bases: usize = cigar_ops
-            .iter()
-            .filter(|&&op| {
-                matches!(op & 0xF, 0 | 7 | 8) // Match, SequenceMatch, SequenceMismatch
-            })
-            .map(|&op| (op >> 4) as usize)
+        // Count aligned bases (M/=/X ops) directly from raw CIGAR bytes (zero allocation).
+        let aligned_bases: usize = RawRecordView::new(record.as_ref())
+            .cigar_ops_iter()
+            .filter(|&op| matches!(op & 0xF, 0 | 7 | 8)) // Match, SequenceMatch, SequenceMismatch
+            .map(|op| (op >> 4) as usize)
             .sum();
         self.bases += aligned_bases;
 

--- a/crates/fgumi-sam/src/alignment_tags.rs
+++ b/crates/fgumi-sam/src/alignment_tags.rs
@@ -305,11 +305,8 @@ pub fn regenerate_alignment_tags_raw(
     let ref_start = Position::new((alignment_start_0based + 1) as usize)
         .context("Invalid alignment start position")?;
 
-    // Get CIGAR ops (one small Vec allocation - typically 1-5 ops)
-    let cigar_ops = fgumi_raw_bam::get_cigar_ops(record);
-
-    // Calculate reference span from CIGAR ops
-    let ref_span = usize::try_from(fgumi_raw_bam::reference_length_from_cigar(&cigar_ops))
+    // Calculate reference span directly from the raw CIGAR bytes (zero allocation).
+    let ref_span = usize::try_from(fgumi_raw_bam::reference_length_from_raw_bam(record))
         .context("CIGAR-derived reference span is negative")?;
 
     // Handle edge case: CIGAR with no reference-consuming operations
@@ -345,7 +342,7 @@ pub fn regenerate_alignment_tags_raw(
     let mut seq_pos = 0;
     let mut match_count: usize = 0;
 
-    for &op in &cigar_ops {
+    for op in RawRecordView::new(record).cigar_ops_iter() {
         let op_type = op & 0xF;
         let op_len = (op >> 4) as usize;
 


### PR DESCRIPTION
## What

`get_cigar_ops(&[u8]) -> Vec<u32>` allocates a short `Vec` per call that is walked exactly once and immediately dropped. At four per-record consumers that single walk can read the packed ops straight from the raw bytes via the existing zero-allocation `RawRecordView::cigar_ops_iter()` — and, for the reference-span computation in the NM/UQ/MD updater, the existing `reference_length_from_raw_bam` twin (which is the documented zero-alloc equivalent of `reference_length_from_cigar(&get_cigar_ops(bam))`).

Migrated sites:

- `fgumi-metrics` `ClippingMetrics::update_raw` — aligned-base sum (per record on `clip`)
- `fgumi-consensus` `ReadAndRefPosIterator::new_raw_with_mate` — removes the intermediate `Vec<u32>` before decoding into the `(op, len)` pairs it keeps (per read-pair, overlap clipping, default-on)
- `fgumi-consensus` `resolve_ref_bases_for_record` (filter) — per-op walk (per record on `filter --ref`)
- `fgumi-sam` `regenerate_alignment_tags_raw` — reference span + per-op MD walk (runs once per record for every `fgumi clip` / `fgumi filter`)

The public `get_cigar_ops` API is unchanged, as are the ~11 call sites that genuinely need the materialized slice — ops passed onward as `&[u32]` to `*_raw` / `simplify` / `clip` helpers, or walked more than once. Migrating those would require changing `pub` helper signatures and is deliberately out of scope.

## Why it is behavior-preserving

`cigar_ops_iter()` yields the identical packed `u32` ops as `get_cigar_ops()` (same `chunks_exact(4)` decode; both yield empty on `n_cigar_op == 0` / truncated). `reference_length_from_raw_bam` sums the same `consumes_ref` op lengths over the same bytes; the only difference is on a malformed CIGAR whose ref-length sum exceeds `i32::MAX` (>2.1 billion reference bases — unreachable for any single-record alignment), where it fails closed to `0` by design rather than wrapping.

## Measurement (M3 Ultra, aarch64, mimalloc)

`fgumi clip` on a queryname-sorted 3,689,310-record BAM (idt-cfdna, hs38DH), single-threaded, 3 interleaved reps, old (`3ff9306d`) vs this branch:

- **Output is byte-identical** at the record level — decompressed streams differ in exactly 41 bytes, all inside the SAM header (`@PG` VN commit hash, argv, and the `-o` filename); zero record-data bytes differ.
- **Instructions retired: −232.3 M (−0.28%), ≈ −63 instructions/record.** Rep ranges are non-overlapping (old 82.373–82.397 B vs new 82.140–82.172 B).
- **Cycles: −103.2 M (−0.50%), ≈ −28 cycles/record (~7 ns/record at ~4 GHz)** — consistent with the ~10 ns/record allocation-removal class.
- **Wall-clock: neutral** (within rep noise). This is an allocation removal, not an algorithmic change; at this record count it is below the I/O floor, as expected.

A small, deterministic, zero-risk cleanup on genuinely hot serial paths.

## Testing

`cargo ci-fmt`, `cargo ci-lint`, `cargo ci-tag-literals`, `cargo ci-doc`, and `cargo ci-test` (7703 passed / 30 skipped) all green. Behavior is covered by the existing tests for all four functions; per the crate review policy, a provably-not-output-changing allocation removal needs no new baseline test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: command output changes—none; `unsafe` changes—none, and `CLAUDE.md` allowlist updates—none; memory bounds, queue capacity, and thread/backpressure policy changes—none. The fix replaces temporary CIGAR vectors with zero-allocation raw CIGAR iteration at four hot sites while preserving behavior and the public `get_cigar_ops` API. Validation reported byte-identical output, 0.28% fewer instructions, 0.50% fewer cycles, 7,703 tests passed, and 30 skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->