### PR TITLE
test(sort): bound the Phase 1 input path's cost with two harnesses

### DIFF
--- a/crates/fgumi-bgzf/Cargo.toml
+++ b/crates/fgumi-bgzf/Cargo.toml
@@ -20,5 +20,9 @@ rstest = { workspace = true }
 name = "stored_block_decode"
 harness = false
 
+[[bench]]
+name = "raw_block_read"
+harness = false
+
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }

--- a/crates/fgumi-bgzf/benches/raw_block_read.rs
+++ b/crates/fgumi-bgzf/benches/raw_block_read.rs
@@ -1,0 +1,257 @@
+//! Where the sort pipeline's input reader spends its per-block time.
+//!
+//! `fgumi sort`'s Phase 1 has one thread doing all input reading (worker 0 owns
+//! `ReadInputBlocks` exclusively). On the production cell it occupies that thread
+//! for 124.5s across 5,114,408 blocks — **24.3 µs per 8.4 KB block** — while the
+//! same volume at the measured single-stream disk ceiling is only ~71s. That
+//! leaves ~10.8 µs per block that no disk model explains.
+//!
+//! This bench bounds how much of that gap userspace framing can possibly account
+//! for, by running the production framing path over a BGZF stream already in RAM.
+//! Four arms partition the cost additively:
+//!
+//! * `full` — `read_raw_blocks` exactly as the pipeline calls it. The production path.
+//! * `reuse_buf` — the same framing, but reading into one reused `Vec` instead of a
+//!   fresh `Vec::with_capacity(block_size)` per block. `full - reuse_buf` is what the
+//!   5.11M per-block allocations cost.
+//! * `frame_only` — parse and validate each header, then skip the body via
+//!   `BufRead::consume` rather than copying it. `reuse_buf - frame_only` is the body
+//!   memcpy.
+//! * `drain` — walk every byte through the same `BufReader` with no framing at all.
+//!   The floor. `frame_only - drain` is header parse, validation, and loop overhead.
+//!
+//! **What this bench cannot tell you:** whether the production reader actually pays
+//! those costs. Reads here come from a `Cursor` over RAM, so the underlying refill is
+//! a memcpy rather than a syscall against page cache or EBS. That makes `drain` an
+//! optimistic floor by construction. The bench answers "can framing cost 10.8 µs per
+//! block?", not "does it, on that host" — in-situ instrumentation answers the latter.
+//!
+//! Block payloads are pseudo-random filler because this path never inflates them:
+//! `read_raw_blocks` frames on `BSIZE` and copies bytes. Only block *size* is
+//! load-bearing, so it is swept — 4 KiB, the production mean, 16 KiB, and the 64 KiB
+//! maximum — which separates fixed per-block overhead from cost proportional to bytes.
+//!
+//! Run with: `cargo bench -p fgumi-bgzf --bench raw_block_read`
+//! Quick sanity: `cargo bench -p fgumi-bgzf --bench raw_block_read -- --quick`
+
+#![deny(unsafe_code)]
+
+use std::hint::black_box;
+use std::io::{self, BufRead, BufReader, Cursor, Read};
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use fgumi_bgzf::header::{BGZF_HEADER_SIZE, MIN_BLOCK_SIZE, block_size_checked, validate};
+use fgumi_bgzf::reader::{BGZF_EOF, read_raw_blocks};
+
+/// Input buffer the sort pipeline wraps its BAM in (`SORT_INPUT_BUFFER_SIZE`).
+const INPUT_BUFFER_SIZE: usize = 2 * 1024 * 1024;
+
+/// Blocks requested per `read_raw_blocks` call (`INPUT_READ_BATCH_SIZE`).
+const BLOCKS_PER_BATCH: usize = 16;
+
+/// Stream size per iteration. Large enough that the 2 MiB buffer refills ~32 times
+/// and the per-block allocations cannot all be served from a warm free list, small
+/// enough to keep each arm's measurement under a second.
+const STREAM_BYTES: usize = 64 * 1024 * 1024;
+
+/// Mean compressed block size on the production cell: 43,131,188,552 bytes across
+/// 5,114,408 blocks.
+const PRODUCTION_BLOCK_SIZE: usize = 8433;
+
+/// Compressed block sizes to sweep.
+const BLOCK_SIZES: [usize; 4] = [4096, PRODUCTION_BLOCK_SIZE, 16 * 1024, 64 * 1024];
+
+/// The fixed 16 bytes of a BGZF header that precede `BSIZE`, per `header::validate`:
+/// gzip magic, deflate, `FEXTRA` alone, empty MTIME/XFL, unknown OS, `XLEN` 6, and
+/// the `BC` subfield id and length.
+const HEADER_PREFIX: [u8; 16] =
+    [0x1f, 0x8b, 0x08, 0x04, 0, 0, 0, 0, 0, 0xff, 0x06, 0x00, b'B', b'C', 0x02, 0x00];
+
+/// Build a BGZF stream of fixed-size blocks, terminated by the EOF marker.
+///
+/// Bodies are pseudo-random filler: the framing path under test never inflates them.
+fn build_stream(block_size: usize, total_bytes: usize) -> Vec<u8> {
+    assert!(block_size >= MIN_BLOCK_SIZE, "block size below the BGZF floor");
+    let bsize = u16::try_from(block_size - 1).expect("block size must fit in BSIZE");
+
+    let body_len = block_size - BGZF_HEADER_SIZE;
+    let mut body = Vec::with_capacity(body_len + 8);
+    let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
+    while body.len() < body_len {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        body.extend_from_slice(&state.to_le_bytes());
+    }
+    body.truncate(body_len);
+
+    let mut out = Vec::with_capacity(total_bytes + BGZF_EOF.len());
+    while out.len() + block_size <= total_bytes {
+        out.extend_from_slice(&HEADER_PREFIX);
+        out.extend_from_slice(&bsize.to_le_bytes());
+        out.extend_from_slice(&body);
+    }
+    out.extend_from_slice(&BGZF_EOF);
+    out
+}
+
+/// Wrap a stream in the same buffered reader the sort pipeline uses.
+fn buffered(stream: &[u8]) -> BufReader<Cursor<&[u8]>> {
+    BufReader::with_capacity(INPUT_BUFFER_SIZE, Cursor::new(stream))
+}
+
+/// `full`: the production path, `read_raw_blocks` in batches of 16.
+fn arm_full(stream: &[u8]) -> usize {
+    let mut reader = buffered(stream);
+    let mut blocks = 0usize;
+    loop {
+        let batch = read_raw_blocks(&mut reader, BLOCKS_PER_BATCH).expect("framing");
+        if batch.is_empty() {
+            break;
+        }
+        blocks += batch.len();
+        black_box(&batch);
+    }
+    blocks
+}
+
+/// Frame one block into `buf`, reusing its allocation. Mirrors `read_raw_block`'s
+/// header handling exactly so the delta against `full` is only the allocation.
+///
+/// Returns `false` at a clean EOF.
+fn read_block_into(reader: &mut BufReader<Cursor<&[u8]>>, buf: &mut Vec<u8>) -> io::Result<bool> {
+    let mut header = [0u8; BGZF_HEADER_SIZE];
+    loop {
+        match reader.read(&mut header[..1]) {
+            Ok(0) => return Ok(false),
+            Ok(_) => break,
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+    reader.read_exact(&mut header[1..])?;
+    validate(&header).map_err(|r| io::Error::new(io::ErrorKind::InvalidData, r))?;
+    let block_size = block_size_checked(&header)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "BGZF block too small"))?;
+
+    buf.clear();
+    buf.extend_from_slice(&header);
+    let remaining = u64::try_from(block_size - BGZF_HEADER_SIZE).expect("block size fits in u64");
+    reader.take(remaining).read_to_end(buf)?;
+    if buf.len() != block_size {
+        return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "truncated BGZF block"));
+    }
+    Ok(true)
+}
+
+/// `reuse_buf`: identical framing, one reused block buffer.
+fn arm_reuse_buf(stream: &[u8]) -> usize {
+    let mut reader = buffered(stream);
+    let mut buf: Vec<u8> = Vec::with_capacity(BGZF_MAX_FRAME);
+    let mut blocks = 0usize;
+    while read_block_into(&mut reader, &mut buf).expect("framing") {
+        if buf.as_slice() == BGZF_EOF {
+            continue;
+        }
+        blocks += 1;
+        black_box(buf.as_slice());
+    }
+    blocks
+}
+
+/// Largest block a `BSIZE` can describe, so `reuse_buf` never reallocates.
+const BGZF_MAX_FRAME: usize = 65536;
+
+/// Advance `reader` by `n` bytes without copying them out of its buffer.
+fn skip_exact(reader: &mut BufReader<Cursor<&[u8]>>, mut n: usize) -> io::Result<()> {
+    while n > 0 {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "truncated BGZF block"));
+        }
+        let taken = available.len().min(n);
+        reader.consume(taken);
+        n -= taken;
+    }
+    Ok(())
+}
+
+/// `frame_only`: parse and validate every header, skip every body.
+fn arm_frame_only(stream: &[u8]) -> usize {
+    let mut reader = buffered(stream);
+    let mut header = [0u8; BGZF_HEADER_SIZE];
+    let mut blocks = 0usize;
+    loop {
+        match reader.read(&mut header[..1]) {
+            Ok(0) => break,
+            Ok(_) => {}
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+            Err(e) => panic!("framing: {e}"),
+        }
+        reader.read_exact(&mut header[1..]).expect("header");
+        validate(&header).expect("valid header");
+        let block_size = block_size_checked(&header).expect("block size");
+        skip_exact(&mut reader, block_size - BGZF_HEADER_SIZE).expect("body");
+        blocks += 1;
+        black_box(&header);
+    }
+    blocks
+}
+
+/// `drain`: walk every byte through the same `BufReader`, no framing.
+fn arm_drain(stream: &[u8]) -> usize {
+    let mut reader = buffered(stream);
+    let mut total = 0usize;
+    loop {
+        let available = reader.fill_buf().expect("fill");
+        let n = available.len();
+        if n == 0 {
+            break;
+        }
+        black_box(available);
+        reader.consume(n);
+        total += n;
+    }
+    total
+}
+
+/// Confirm the synthetic stream frames the way every arm assumes before any timing
+/// is taken — otherwise an arm that silently bails early looks like a fast one.
+fn check_arms_agree(stream: &[u8], block_size: usize) -> usize {
+    let expected = STREAM_BYTES / block_size;
+    let full = arm_full(stream);
+    assert!(full > 0, "synthetic stream framed zero blocks");
+    assert_eq!(full, arm_reuse_buf(stream), "reuse_buf framed a different block count");
+    // `frame_only` counts the trailing EOF marker, which `read_raw_blocks` drops.
+    assert_eq!(full + 1, arm_frame_only(stream), "frame_only framed a different block count");
+    assert_eq!(stream.len(), arm_drain(stream), "drain walked a different byte count");
+    assert!(
+        full.abs_diff(expected) <= 1,
+        "expected ~{expected} blocks of {block_size} bytes, framed {full}"
+    );
+    full
+}
+
+fn bench_raw_block_read(c: &mut Criterion) {
+    let mut group = c.benchmark_group("raw_block_read");
+    for block_size in BLOCK_SIZES {
+        let stream = build_stream(block_size, STREAM_BYTES);
+        let blocks = check_arms_agree(&stream, block_size);
+        group.throughput(Throughput::Elements(u64::try_from(blocks).expect("block count")));
+
+        for (name, arm) in [
+            ("full", arm_full as fn(&[u8]) -> usize),
+            ("reuse_buf", arm_reuse_buf),
+            ("frame_only", arm_frame_only),
+            ("drain", arm_drain),
+        ] {
+            group.bench_with_input(BenchmarkId::new(name, block_size), &stream, |b, stream| {
+                b.iter(|| black_box(arm(black_box(stream))));
+            });
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_raw_block_read);
+criterion_main!(benches);

--- a/crates/fgumi-sort/examples/read_ladder.rs
+++ b/crates/fgumi-sort/examples/read_ladder.rs
@@ -1,0 +1,571 @@
+//! An additive ladder over Phase 1's input path, one stage at a time.
+//!
+//! Phase 1's in-process instrumentation says what each stage costs *in situ*, but
+//! two things it structurally cannot say:
+//!
+//! 1. **What the disk can actually deliver to this process.** The 605 MB/s
+//!    single-stream / 1110 MB/s four-stream figures the campaign quotes were taken
+//!    with direct I/O in a different session. `raw` re-measures them buffered, from
+//!    the same binary and the same boot, which is also the *actionable* ceiling —
+//!    an `O_DIRECT` reader would need aligned buffers and `unsafe`.
+//! 2. **What our reader does with nothing downstream.** `record_step` times the
+//!    `ReadInputBlocks` step only when it *runs*; a reader sitting ineligible
+//!    because `raw_input_blocks` is full (cap = `num_workers * 8` = 128) or because
+//!    it is holding blocks is invisible to it. So the measured 358 MB/s is
+//!    consistent with both "one buffered stream can do no better" and "the reader
+//!    is fine and backpressure is throttling it" — which imply opposite fixes.
+//!    `blocks` separates them: it is the same framing code with no consumer at all.
+//!
+//! # Reading the result — the ladder is serial, the pipeline is not
+//!
+//! Each rung adds one stage to the one below it, so `rung(n) - rung(n-1)` is that
+//! stage's cost **on one thread, with nothing else running**. The real sort does
+//! not work that way: reading is one exclusive thread, decompression is spread over
+//! all 16 workers, and framing/key/push are the serial main thread. The pipeline's
+//! floor is the **max over its serial resources**, not the sum of these rungs.
+//!
+//! Concretely: decompression is the largest single block of CPU in Phase 1
+//! (231.4s of worker busy) and would dominate this ladder, but across 16 workers it
+//! is ~14.5s of effective wall and nowhere near binding. A rung being expensive
+//! here does **not** mean it binds in production. The `resource` column names where
+//! each stage actually lands, and that is the column that decides whether a rung's
+//! cost matters.
+//!
+//! What the ladder is good for: per-stage *ceilings*, and cross-validating the
+//! in-process partition by a completely independent method.
+//!
+//! # Usage
+//!
+//! One rung per process, so no rung inherits a warm page cache from the one below
+//! it — drop caches between invocations (see `scripts/read-ladder.sh`).
+//!
+//! ```text
+//! read_ladder <rung> <bam> [--buf BYTES] [--streams N] [--limit-gb G]
+//!
+//! rungs, each adding one stage to the previous:
+//!   raw         read() into a reused buffer                       [reader thread]
+//!   blocks      + BGZF framing (read_raw_blocks)                  [reader thread]
+//!   decompress  + inflate each block                              [16 workers]
+//!   records     + walk the BAM records in the stream              [main thread]
+//!   key         + extract the template-coordinate sort key        [main thread]
+//!   push        + copy the record into an arena and keep a ref    [main thread]
+//! ```
+
+#![deny(unsafe_code)]
+
+use std::fs::File;
+use std::io::BufReader;
+use std::os::unix::fs::FileExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::{Context, Result, bail};
+use fgumi_bgzf::reader::{decompress_block_into, read_raw_blocks};
+use fgumi_raw_bam::BAM_MAGIC;
+use fgumi_sort::{LibraryLookup, cb_hasher, extract_template_key_inline};
+use libdeflater::Decompressor;
+
+/// The sort pipeline's own input buffer (`SORT_INPUT_BUFFER_SIZE`).
+const DEFAULT_BUF_BYTES: usize = 2 * 1024 * 1024;
+
+/// The sort pipeline's own batch size (`INPUT_READ_BATCH_SIZE`).
+const BLOCKS_PER_BATCH: usize = 16;
+
+/// Which resource a stage lands on in the real pipeline. Printed with every rung
+/// because a serial ladder over a concurrent pipeline is misread by default.
+fn resource_for(rung: &str) -> &'static str {
+    match rung {
+        "raw" | "blocks" => "reader thread (exclusive, worker 0)",
+        "decompress" => "16-worker pool",
+        _ => "ingest thread (serial, main)",
+    }
+}
+
+/// How the `raw` rung's streams divide the file.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Pattern {
+    /// Each stream owns one large contiguous span. Every stream is purely
+    /// sequential, which is the friendliest case for kernel read-ahead -- and is
+    /// *not* what an in-order reader can do, since stream 3 would be delivering
+    /// bytes from 30 GB in while the framer still needs byte 0.
+    Contiguous,
+    /// Streams take turns on fixed-size chunks (stream k takes chunk k, k+N, ...).
+    /// This is the access pattern an in-order parallel reader actually generates,
+    /// so it is the one worth believing.
+    Interleaved,
+}
+
+struct Args {
+    rung: String,
+    path: PathBuf,
+    buf_bytes: usize,
+    streams: usize,
+    limit_bytes: u64,
+    pattern: Pattern,
+    chunk_bytes: u64,
+    writer_mbps: u64,
+    writer_dir: Option<PathBuf>,
+}
+
+fn parse_args() -> Result<Args> {
+    let mut it = std::env::args().skip(1);
+    let rung = it
+        .next()
+        .context("usage: read_ladder <rung> <bam> [--buf N] [--streams N] [--limit-gb G]")?;
+    let path = PathBuf::from(it.next().context("missing <bam>")?);
+    let mut buf_bytes = DEFAULT_BUF_BYTES;
+    let mut streams = 1usize;
+    let mut limit_bytes = u64::MAX;
+    let mut pattern = Pattern::Contiguous;
+    let mut chunk_bytes = 4 * 1024 * 1024u64;
+    let mut writer_mbps = 0u64;
+    let mut writer_dir = None;
+    while let Some(flag) = it.next() {
+        let value = it.next().with_context(|| format!("{flag} needs a value"))?;
+        match flag.as_str() {
+            "--buf" => buf_bytes = value.parse().context("--buf")?,
+            "--streams" => streams = value.parse().context("--streams")?,
+            "--limit-gb" => {
+                let gb: f64 = value.parse().context("--limit-gb")?;
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                {
+                    limit_bytes = (gb * 1e9) as u64;
+                }
+            }
+            "--pattern" => {
+                pattern = match value.as_str() {
+                    "contiguous" => Pattern::Contiguous,
+                    "interleaved" => Pattern::Interleaved,
+                    other => bail!("--pattern must be contiguous|interleaved, got {other}"),
+                };
+            }
+            "--chunk" => chunk_bytes = value.parse().context("--chunk")?,
+            "--writer-mbps" => writer_mbps = value.parse().context("--writer-mbps")?,
+            "--writer-dir" => writer_dir = Some(PathBuf::from(value)),
+            other => bail!("unknown flag {other}"),
+        }
+    }
+    if streams == 0 {
+        bail!("--streams must be at least 1");
+    }
+    if chunk_bytes == 0 {
+        bail!("--chunk must be positive");
+    }
+    if buf_bytes == 0 {
+        bail!("--buf must be positive");
+    }
+    if writer_mbps > 0 && writer_dir.is_none() {
+        bail!("--writer-mbps needs --writer-dir");
+    }
+    // Only `raw` spawns the concurrent Writer; the pipeline rungs share a single
+    // reader loop with no writer, so accepting these flags there would silently
+    // ignore them (and, unthrottled, could write a multi-GB temp file for
+    // nothing). Reject them instead of pretending to honor them.
+    if (writer_mbps > 0 || writer_dir.is_some()) && rung != "raw" {
+        bail!("--writer-mbps/--writer-dir only apply to the `raw` rung");
+    }
+    Ok(Args {
+        rung,
+        path,
+        buf_bytes,
+        streams,
+        limit_bytes,
+        pattern,
+        chunk_bytes,
+        writer_mbps,
+        writer_dir,
+    })
+}
+
+#[derive(Default)]
+struct Tally {
+    bytes: u64,
+    blocks: u64,
+    records: u64,
+    wrote_bytes: u64,
+}
+
+fn main() -> Result<()> {
+    let args = parse_args()?;
+    let started = Instant::now();
+    let tally = match args.rung.as_str() {
+        "raw" => rung_raw(&args)?,
+        "blocks" | "decompress" | "records" | "key" | "push" => rung_pipeline(&args)?,
+        other => bail!("unknown rung {other}"),
+    };
+    report(&args, &tally, started.elapsed().as_secs_f64());
+    Ok(())
+}
+
+#[allow(clippy::cast_precision_loss, reason = "byte and record counts stay far below 2^52")]
+fn report(args: &Args, tally: &Tally, secs: f64) {
+    let mb_per_sec = if secs > 0.0 { tally.bytes as f64 / secs / 1e6 } else { 0.0 };
+    let per = |n: u64| if n == 0 { 0.0 } else { secs * 1e9 / n as f64 };
+    let write_mb_per_sec = if secs > 0.0 { tally.wrote_bytes as f64 / secs / 1e6 } else { 0.0 };
+    let pattern = match args.pattern {
+        Pattern::Contiguous => "contiguous",
+        Pattern::Interleaved => "interleaved",
+    };
+    println!(
+        "rung={rung} streams={streams} pattern={pattern} chunk={chunk} buf={buf} \
+         secs={secs:.2} MBps={mb:.0} write_MBps={wmb:.0} \
+         bytes={bytes} blocks={blocks} ns_per_block={npb:.0} records={records} \
+         ns_per_record={npr:.1} resource=\"{res}\"",
+        rung = args.rung,
+        streams = args.streams,
+        chunk = args.chunk_bytes,
+        buf = args.buf_bytes,
+        wmb = write_mb_per_sec,
+        mb = mb_per_sec,
+        bytes = tally.bytes,
+        blocks = tally.blocks,
+        npb = per(tally.blocks),
+        records = tally.records,
+        npr = per(tally.records),
+        res = resource_for(&args.rung),
+    );
+}
+
+/// `raw`: how fast the file's bytes can be pulled into this process at all.
+///
+/// `streams > 1` splits the file into contiguous ranges and reads each on its own
+/// thread with `read_at`, which is what a parallel reader would do — the volume
+/// measured 605 MB/s at one stream and 1110 MB/s at four, and nothing in the
+/// current reader can exploit that.
+fn rung_raw(args: &Args) -> Result<Tally> {
+    let file =
+        Arc::new(File::open(&args.path).with_context(|| format!("open {}", args.path.display()))?);
+    let total = file.metadata()?.len().min(args.limit_bytes);
+    let streams = u64::try_from(args.streams).expect("stream count fits in u64");
+    let span = total.div_ceil(streams);
+
+    // Production reads and writes the same volume at once: Phase 1 spills 52.6 GB
+    // while it reads 43.1 GB. A read rate measured on an idle device is therefore
+    // an upper bound that production can never see, and the gap is the whole
+    // question -- the volume is provisioned near 1000 MB/s, so a 1048 MB/s read
+    // plus a ~363 MB/s spill stream cannot both be served.
+    let writer = args.writer_dir.as_ref().map(|dir| Writer::spawn(dir, args.writer_mbps));
+
+    let mut handles = Vec::with_capacity(args.streams);
+    for stream in 0..streams {
+        let file = Arc::clone(&file);
+        let buf_bytes = args.buf_bytes;
+        let pattern = args.pattern;
+        let chunk = args.chunk_bytes;
+        let start = stream * span;
+        let end = ((stream + 1) * span).min(total);
+        handles.push(std::thread::spawn(move || -> Result<u64> {
+            let mut buf = vec![0u8; buf_bytes];
+            let mut read_total = 0u64;
+            match pattern {
+                Pattern::Contiguous => {
+                    let mut offset = start;
+                    while offset < end {
+                        let want = usize::try_from((end - offset).min(buf_bytes as u64))
+                            .expect("clamped to buffer size");
+                        let n = file.read_at(&mut buf[..want], offset)?;
+                        if n == 0 {
+                            break;
+                        }
+                        offset += n as u64;
+                        read_total += n as u64;
+                    }
+                }
+                Pattern::Interleaved => {
+                    // Stream k takes chunk k, k + N, k + 2N ... so the file is
+                    // covered in order across the pool rather than in N disjoint
+                    // spans. Each stream strides by `streams * chunk`, which is
+                    // what makes this a different ask of kernel read-ahead.
+                    let stride = chunk * streams;
+                    let mut chunk_start = stream * chunk;
+                    while chunk_start < total {
+                        let chunk_end = (chunk_start + chunk).min(total);
+                        let mut offset = chunk_start;
+                        while offset < chunk_end {
+                            let want = usize::try_from((chunk_end - offset).min(buf_bytes as u64))
+                                .expect("clamped to buffer size");
+                            let n = file.read_at(&mut buf[..want], offset)?;
+                            if n == 0 {
+                                break;
+                            }
+                            offset += n as u64;
+                            read_total += n as u64;
+                        }
+                        chunk_start += stride;
+                    }
+                }
+            }
+            Ok(read_total)
+        }));
+    }
+
+    // Join every reader before propagating a failure, so the writer is always
+    // stopped and its temp file removed by `finish` -- returning through `??`
+    // here would leave the writer thread running and `read_ladder_writer.tmp`
+    // (written unthrottled when --writer-mbps is 0) on disk.
+    let mut tally = Tally::default();
+    let mut read_result = Ok(());
+    for handle in handles {
+        match handle.join().map_err(|_| anyhow::anyhow!("reader thread panicked"))? {
+            Ok(n) => tally.bytes += n,
+            Err(e) => read_result = Err(e),
+        }
+    }
+    if let Some(writer) = writer {
+        tally.wrote_bytes = writer.finish()?;
+    }
+    read_result?;
+    Ok(tally)
+}
+
+/// A rate-limited background writer, so the read rungs can be measured against
+/// the spill load production actually runs alongside them.
+struct Writer {
+    stop: Arc<std::sync::atomic::AtomicBool>,
+    handle: std::thread::JoinHandle<Result<u64>>,
+    path: PathBuf,
+}
+
+impl Writer {
+    fn spawn(dir: &Path, target_mbps: u64) -> Self {
+        use std::io::Write;
+        let path = dir.join("read_ladder_writer.tmp");
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let thread_stop = Arc::clone(&stop);
+        let thread_path = path.clone();
+        let handle = std::thread::spawn(move || -> Result<u64> {
+            let mut file = File::create(&thread_path)
+                .with_context(|| format!("create {}", thread_path.display()))?;
+            let block = vec![0x5Au8; 4 * 1024 * 1024];
+            let started = Instant::now();
+            let mut written = 0u64;
+            while !thread_stop.load(std::sync::atomic::Ordering::Relaxed) {
+                file.write_all(&block)?;
+                written += block.len() as u64;
+                if target_mbps > 0 {
+                    // Token bucket: hold the writer at the target rate rather than
+                    // letting it race the reader for the device, which would
+                    // measure contention at some arbitrary ratio instead of the
+                    // one production generates.
+                    #[allow(clippy::cast_precision_loss, reason = "byte totals stay below 2^52")]
+                    let due = written as f64 / (target_mbps as f64 * 1e6);
+                    let elapsed = started.elapsed().as_secs_f64();
+                    if due > elapsed {
+                        std::thread::sleep(std::time::Duration::from_secs_f64(due - elapsed));
+                    }
+                }
+            }
+            file.sync_all()?;
+            Ok(written)
+        });
+        Self { stop, handle, path }
+    }
+
+    fn finish(self) -> Result<u64> {
+        self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        let written = self.handle.join().map_err(|_| anyhow::anyhow!("writer thread panicked"))?;
+        let _ = std::fs::remove_file(&self.path);
+        written
+    }
+}
+
+/// Everything from `blocks` up, sharing one loop so the rungs differ by exactly the
+/// stage each adds and nothing else.
+fn rung_pipeline(args: &Args) -> Result<Tally> {
+    let rung = args.rung.as_str();
+    let want_decompress = matches!(rung, "decompress" | "records" | "key" | "push");
+    let want_records = matches!(rung, "records" | "key" | "push");
+    let want_key = matches!(rung, "key" | "push");
+    let want_push = rung == "push";
+
+    // The header is read through the crate's own opener, so the key rung sees the
+    // same library ordinals production does rather than an invented mapping.
+    let lookup = if want_key {
+        let (_reader, header) = fgumi_sort::open_raw_bam_record_reader_with_header(&args.path)?;
+        Some(LibraryLookup::from_header(&header))
+    } else {
+        None
+    };
+    let hasher = cb_hasher();
+
+    let file = File::open(&args.path).with_context(|| format!("open {}", args.path.display()))?;
+    let mut reader = BufReader::with_capacity(args.buf_bytes, file);
+
+    let mut tally = Tally::default();
+    let mut decompressed = Vec::with_capacity(64 * 1024);
+    // Reused across every block, as the worker pool does -- constructing one per
+    // block would put allocator noise in the decompress rung's delta.
+    let mut decompressor = Decompressor::new();
+    let mut framer = RecordFramer::default();
+    let mut arena: Vec<u8> = Vec::new();
+    let mut refs: Vec<(u64, usize)> = Vec::new();
+
+    loop {
+        let batch = read_raw_blocks(&mut reader, BLOCKS_PER_BATCH)?;
+        if batch.is_empty() {
+            break;
+        }
+        for block in &batch {
+            tally.bytes += block.len() as u64;
+            tally.blocks += 1;
+            if !want_decompress {
+                continue;
+            }
+            // `decompress_block_into` *appends*. Without this the buffer accumulates
+            // the whole file, which costs the decompress rung a realloc storm and
+            // makes the records rung quadratic -- it re-frames every prior block,
+            // which is ~2 TB of copying on a 43 GB input and eats RAM until the
+            // OOM killer intervenes. This cost a workstation once; leave it here.
+            decompressed.clear();
+            decompress_block_into(block, &mut decompressor, &mut decompressed)?;
+            if !want_records {
+                continue;
+            }
+            framer.push(&decompressed);
+            while let Some(record) = framer.next_record() {
+                tally.records += 1;
+                if want_key {
+                    let key = extract_template_key_inline(
+                        record,
+                        lookup.as_ref().expect("key rung builds a lookup"),
+                        None,
+                        &hasher,
+                    );
+                    if want_push {
+                        refs.push((key.primary, arena.len()));
+                        arena.extend_from_slice(record);
+                        // The real ingest spills at a memory bound; here the arena
+                        // is reset instead, so the rung measures the copy rather
+                        // than this process's willingness to hold 40 GB.
+                        if arena.len() >= 512 * 1024 * 1024 {
+                            arena.clear();
+                            refs.clear();
+                        }
+                    } else {
+                        std::hint::black_box(&key);
+                    }
+                }
+            }
+        }
+        if tally.bytes >= args.limit_bytes {
+            break;
+        }
+    }
+    Ok(tally)
+}
+
+/// Frames BAM records out of the decompressed byte stream.
+///
+/// Records straddle BGZF block boundaries, so this carries the tail of one block
+/// into the next — the same job `PooledInputStream` does in production, minus the
+/// reorder buffer, which only exists because production decompresses out of order.
+#[derive(Default)]
+struct RecordFramer {
+    carry: Vec<u8>,
+    start: usize,
+    header_skipped: bool,
+}
+
+/// The carry may hold one partial record plus one decompressed block. A BGZF
+/// block is at most 64 KiB and a BAM record in any real file is far below this,
+/// so exceeding the bound does not mean "unusual input" -- it means the consumer
+/// has stopped draining and the buffer is growing without limit. Asserting it is
+/// cheaper than discovering it through the OOM killer.
+const CARRY_LIMIT: usize = 16 * 1024 * 1024;
+
+impl RecordFramer {
+    fn push(&mut self, bytes: &[u8]) {
+        // Reclaim consumed bytes before growing, so the carry stays near one block
+        // rather than the whole file.
+        if self.start > 0 {
+            self.carry.drain(..self.start);
+            self.start = 0;
+        }
+        self.carry.extend_from_slice(bytes);
+        assert!(
+            self.carry.len() <= CARRY_LIMIT,
+            "record framer carry reached {} bytes, past the {CARRY_LIMIT}-byte bound: \
+             the consumer is not draining and this is about to exhaust memory",
+            self.carry.len(),
+        );
+    }
+
+    fn next_record(&mut self) -> Option<&[u8]> {
+        if !self.header_skipped && !self.try_skip_header() {
+            return None;
+        }
+        let available = &self.carry[self.start..];
+        if available.len() < 4 {
+            return None;
+        }
+        let len = u32::from_le_bytes(available[..4].try_into().ok()?) as usize;
+        // A real BAM record is far below CARRY_LIMIT (a BGZF block is <= 64 KiB), so
+        // an oversized length is a corrupt or misframed record, not one still
+        // waiting for more data. Without this guard `available.len() < 4 + len`
+        // never clears, `next_record` returns None on every call, and `push` grows
+        // the carry until it asserts "the consumer is not draining" -- blaming the
+        // wrong cause. Surface the real one here instead.
+        assert!(
+            len <= CARRY_LIMIT,
+            "record framer read a record length of {len} bytes, past the {CARRY_LIMIT}-byte \
+             bound: the input is corrupt or misframed",
+        );
+        if available.len() < 4 + len {
+            return None;
+        }
+        let from = self.start + 4;
+        self.start += 4 + len;
+        Some(&self.carry[from..from + len])
+    }
+
+    /// Skip `magic | l_text | text | n_ref | (l_name, name, l_ref) * n_ref`.
+    ///
+    /// Returns false while the header is still incomplete, so the caller simply
+    /// feeds another block.
+    fn try_skip_header(&mut self) -> bool {
+        let buf = &self.carry[self.start..];
+        if buf.len() < 12 {
+            return false;
+        }
+        assert_eq!(&buf[..4], BAM_MAGIC, "input is not a BAM stream");
+        let l_text = u32::from_le_bytes(buf[4..8].try_into().expect("4 bytes")) as usize;
+        let Some(after_text) = 8usize.checked_add(l_text) else { return false };
+        if buf.len() < after_text + 4 {
+            return false;
+        }
+        let n_ref = u32::from_le_bytes(buf[after_text..after_text + 4].try_into().expect("4 bytes"))
+            as usize;
+        let mut at = after_text + 4;
+        for _ in 0..n_ref {
+            if buf.len() < at + 4 {
+                return false;
+            }
+            let l_name = u32::from_le_bytes(buf[at..at + 4].try_into().expect("4 bytes")) as usize;
+            // Parity with `next_record`: an oversized name length is corruption, not
+            // a header still arriving, so reject it with the real cause.
+            assert!(
+                l_name <= CARRY_LIMIT,
+                "BAM header declared a reference-name length of {l_name} bytes, past the \
+                 {CARRY_LIMIT}-byte bound: the input is corrupt or misframed",
+            );
+            // Checked like `l_text` above: a length that overflows the cursor is
+            // treated as an incomplete header (feed another block) rather than
+            // wrapping past the buffer.
+            let Some(next_at) = at
+                .checked_add(4)
+                .and_then(|x| x.checked_add(l_name))
+                .and_then(|x| x.checked_add(4))
+            else {
+                return false;
+            };
+            at = next_at;
+            if buf.len() < at {
+                return false;
+            }
+        }
+        self.start += at;
+        self.header_skipped = true;
+        true
+    }
+}


### PR DESCRIPTION
The input reader occupies one exclusive thread for **24.3 µs per 8.4 KB block** on a whole-genome sort (`1kg-wgs-HG00096`, 43.1 GB, 779,820,469 records, template-coordinate, 16 threads), and nothing accounted for it. These two harnesses answer different halves of that, and neither question can be answered from in-process counters.

## `fgumi-bgzf` — `benches/raw_block_read.rs`

Partitions userspace framing over a BGZF stream already in RAM, behind the same 2 MiB `BufReader` and 16-block batches the pipeline uses. Four additive arms: `full` → `reuse_buf` (isolates the per-block `Vec`) → `frame_only` (isolates the body copy) → `drain` (the floor).

At the production mean block size of 8433 bytes:

| component | ns/block |
| --- | --- |
| buffer walk floor | 123.3 |
| header parse + validate + BSIZE + loop | **1.3** |
| body copy | 132.3 |
| per-block `Vec::with_capacity` | 66.0 |
| **total** | **322.9** |

It is a null result by design. Framing is ~3% of the 24.3 µs it was proposed to explain, header validation does not register at all across seven field comparisons, and the per-block allocation is worth 66 ns. Committing the bench is what stops either from being re-proposed as a fix.

It also settles a plausible-but-false story: `read_to_end` on an exactly-sized `Vec` does **not** reallocate — modern `default_read_to_end` probes with a 32-byte stack buffer first. Removing the allocation entirely saves 66 ns, not an 8 KB memcpy.

## `fgumi-sort` — `examples/read_ladder.rs`

Adds one stage at a time — raw read, BGZF framing, decompress, record framing, key extraction, arena push — so each stage has a standalone ceiling, optionally measured against a rate-limited concurrent writer standing in for spill I/O.

It measures the two things no in-process counter can see: what the device delivers at N streams, and what the reader achieves with **nothing downstream**. The latter is what separates "the disk is the limit" from "backpressure is throttling the reader", and those imply opposite fixes.

## Reading it correctly

Both carry the caveat prominently: **a serial ladder over a concurrent pipeline is misread by default.** Decompression dominates the ladder and is nowhere near binding once spread across 16 workers. Every rung therefore names the resource it lands on.

## Safety

`RecordFramer` asserts its carry stays under 16 MiB. The carry structurally holds one partial record plus one ≤64 KiB block, so exceeding that means the consumer stopped draining. This is not hypothetical: an early draft omitted a `clear()` on a buffer that `decompress_block_into` *appends* to, which made the records rung quadratic — roughly 2 TB of copying and 20+ GB of RSS before anything printed. The assert turns that class of bug into an immediate, obvious failure.

Validated against known counts: the ladder frames 1,589,044 records on a small BAM (matching `samtools view -c`) and 5,114,408 blocks on the production file (matching the pipeline).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: sort metrics output changes, pinned by `Phase1IngestReport` timing and wait accounting; `unsafe` changes: none, with no `CLAUDE.md` allowlist update required; memory and backpressure policy changes: bounded 16 MiB carry and optional writer contention modeling.

Fix: Parse MC CIGAR data as bytes to support non-UTF-8 input without UTF-8 conversion.

- Add `raw_block_read` and `read_ladder` input-path harnesses.
- Add Phase 1 ingest timing, wait-cause, spill-wait, sampling, and residual metrics.
- Optimize auxiliary-tag scanning, record borrowing, progress accounting, merge counters, and read-group lookup.
- Add malformed, overflow, boundary, saturation, and non-UTF-8 parsing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->