### PR TITLE
feat(sort): split the input reader's time between the disk and framing

### DIFF
--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -360,7 +360,65 @@ impl SortPhaseTimer {
                 ingest.spill_waits
             );
         }
+        Self::log_reader_partition(phase1.reader);
         self.log_ingest_partition(phase1);
+    }
+
+    /// What the input reader's exclusively-owned thread spent its time on.
+    ///
+    /// The reader is Phase 1's *second* serial resource and the one the floor
+    /// line cannot see: `phase1_input_busy_secs` folds it in with decompression
+    /// and divides by the thread count, which is right for a step any worker may
+    /// run and wrong for one only worker 0 ever runs. So a reader at its limit
+    /// disappears into a worker-capacity figure that looks comfortable.
+    ///
+    /// The split that matters is refill against framing, because they have
+    /// nothing in common: refill time is the disk (compare it to the volume's
+    /// measured ceiling) and framing time is header parse, per-block allocation
+    /// and the body copy (compare it to the `raw_block_read` bench). Reporting
+    /// only the step total gives a number -- 24.3 us/block on the production
+    /// cell -- that is consistent with either being the whole cost.
+    #[allow(clippy::cast_precision_loss, reason = "call and byte counts stay below 2^52")]
+    fn log_reader_partition(reader: crate::phase1_stats::ReaderReport) {
+        if reader.batches == 0 {
+            return;
+        }
+        stat!(
+            "  Phase 1 input reader: {:.1}s over {} batches ({:.1} us/block, {} blocks)",
+            reader.step_secs,
+            reader.batches,
+            reader.per_block_micros(reader.step_secs),
+            reader.blocks
+        );
+        if reader.refills > 0 {
+            stat!(
+                "    refill reads: {:.1}s over {} calls ({:.2} ms each, {:.0} MB/s, {:.1} GB)",
+                reader.refill_secs,
+                reader.refills,
+                reader.refill_secs * 1000.0 / reader.refills as f64,
+                reader.refill_mb_per_sec(),
+                reader.refill_bytes as f64 / 1e9
+            );
+        } else {
+            stat!(
+                "    refill reads: none on this thread (async reader, or input already buffered)"
+            );
+        }
+        stat!(
+            "    framing:      {:.1}s ({:.1} us/block)",
+            reader.framing_secs(),
+            reader.per_block_micros(reader.framing_secs())
+        );
+        stat!(
+            "    dispatch:     {:.1}s ({:.1} us/block)",
+            reader.dispatch_secs,
+            reader.per_block_micros(reader.dispatch_secs)
+        );
+        stat!(
+            "    unattributed: {:.1}s ({:.0}% of the step)",
+            reader.residual_secs(),
+            100.0 * reader.residual_share()
+        );
     }
 
     /// What the ingest thread's serial CPU is made of, per segment.
@@ -454,6 +512,10 @@ pub(crate) struct Phase1FloorInputs {
     /// Measured cost of one `Instant::now()`/`elapsed()` pair, subtracted once
     /// per segment per sample.
     pub(crate) clock_overhead_nanos: u64,
+    /// How the exclusively-owned input reader spent its time. Unlike `sample`,
+    /// this is order-independent -- every sort order reads the same way -- so it
+    /// is filled in on all four paths.
+    pub(crate) reader: crate::phase1_stats::ReaderReport,
 }
 
 /// Deterministic hasher for cell barcode hashing in template-coordinate sort.
@@ -3619,6 +3681,7 @@ impl RawExternalSorter {
             input_busy_secs: pool.phase1_input_busy_secs(),
             threads: self.phase1_threads(),
             ingest: pool.phase1_ingest_stats().snapshot(),
+            reader: pool.phase1_reader_report(),
             ..Phase1FloorInputs::default()
         };
         self.enter_output_phase(&pool);
@@ -3830,6 +3893,7 @@ impl RawExternalSorter {
             input_busy_secs: pool.phase1_input_busy_secs(),
             threads: self.phase1_threads(),
             ingest: pool.phase1_ingest_stats().snapshot(),
+            reader: pool.phase1_reader_report(),
             ..Phase1FloorInputs::default()
         };
         self.enter_output_phase(&pool);
@@ -4097,6 +4161,7 @@ impl RawExternalSorter {
             input_busy_secs: pool.phase1_input_busy_secs(),
             threads: self.phase1_threads(),
             ingest: pool.phase1_ingest_stats().snapshot(),
+            reader: pool.phase1_reader_report(),
             ..Phase1FloorInputs::default()
         };
         self.enter_output_phase(&pool);
@@ -4545,6 +4610,7 @@ impl RawExternalSorter {
             input_busy_secs: pool.phase1_input_busy_secs(),
             threads: self.phase1_threads(),
             ingest: pool.phase1_ingest_stats().snapshot(),
+            reader: pool.phase1_reader_report(),
             sample: ingest_raw,
             samples: ingest_samples,
             records: stats.total_records,
@@ -6410,6 +6476,13 @@ fn create_raw_bam_reader_pool_integrated<P: AsRef<Path>>(
 
     let path_ref = path.as_ref();
 
+    // Times the reads that refill the buffer below. Only the synchronous paths
+    // are wrapped: `--async-reader` moves the read onto a prefetch thread, so
+    // the reader step no longer pays for it and there is nothing on this thread
+    // to separate from framing. A zero refill row on an async run is that, not a
+    // measurement failure.
+    let reader_stats = pool.reader_stats();
+
     let opened: Box<dyn io::Read + Send> = if is_stdin_path(path_ref) {
         if async_reader {
             // `--async-reader` is about decoupling the read from the block
@@ -6423,7 +6496,10 @@ fn create_raw_bam_reader_pool_integrated<P: AsRef<Path>>(
             // on every call; the pool's block reader wants far bigger gulps than
             // that, so give the stdin path the same 2 MiB buffer the file path
             // gets.
-            Box::new(io::BufReader::with_capacity(SORT_INPUT_BUFFER_SIZE, io::stdin()))
+            Box::new(io::BufReader::with_capacity(
+                SORT_INPUT_BUFFER_SIZE,
+                crate::phase1_stats::TimedReader::new(io::stdin(), reader_stats),
+            ))
         }
     } else {
         let file = std::fs::File::open(path_ref)
@@ -6441,7 +6517,10 @@ fn create_raw_bam_reader_pool_integrated<P: AsRef<Path>>(
             );
             Box::new(fgumi_bam_io::prefetch_reader::PrefetchReader::from_file(file))
         } else {
-            Box::new(io::BufReader::with_capacity(SORT_INPUT_BUFFER_SIZE, file))
+            Box::new(io::BufReader::with_capacity(
+                SORT_INPUT_BUFFER_SIZE,
+                crate::phase1_stats::TimedReader::new(file, reader_stats),
+            ))
         }
     };
 

--- a/crates/fgumi-sort/src/phase1_stats.rs
+++ b/crates/fgumi-sort/src/phase1_stats.rs
@@ -245,9 +245,263 @@ impl IngestPartition {
     }
 }
 
+// ============================================================================
+// The input reader
+// ============================================================================
+
+/// What the input reader's exclusive thread spends its time on.
+///
+/// `ReadInputBlocks` is a *second* serial resource in Phase 1, and its cost is
+/// not explained by the disk. Worker 0 owns the step exclusively
+/// (`exclusive_step_for` returns `None` for every other worker), so one thread
+/// frames the whole file: on the production cell that is 124.5s across 5,114,408
+/// blocks -- **24.3 us per 8.4 KB block** -- while the same 43.1 GB at that
+/// volume's measured single-stream ceiling (605 MB/s, direct I/O, caches
+/// dropped) is only ~71s. The step is not disk-bound, and nothing accounts for
+/// the remaining ~55s.
+///
+/// It cannot be split from outside the reader, because the disk wait is *inside*
+/// it: `read_raw_blocks` frames blocks out of a 2 MiB `BufReader`, so whichever
+/// block happens to exhaust the buffer pays for the refill and every other block
+/// pays nothing. Timing the step measures framing and I/O fused together, and no
+/// per-block average can separate them. [`TimedReader`] sits one layer *below*
+/// the buffer and times the underlying `read()` itself, which is what makes
+/// [`ReaderReport::framing_secs`] -- time inside `read_raw_blocks` that was not
+/// spent in a `read()` -- mean anything.
+///
+/// Timed exactly rather than sampled: ~320k batches and ~21k refills against a
+/// ~30 ns clock is well under 30 ms of measurement on a 124.5s step, five orders
+/// of magnitude below the quantity. [`IngestSample`] has to sample only because
+/// its loop runs 780 million times; this one does not.
+#[derive(Debug, Default)]
+pub(crate) struct ReaderStats {
+    /// `read()` calls made against the file, below the 2 MiB buffer.
+    refills: AtomicU64,
+    /// Nanoseconds inside those calls.
+    refill_nanos: AtomicU64,
+    /// Bytes they returned.
+    refill_bytes: AtomicU64,
+    /// Successful `ReadInputBlocks` batches.
+    batches: AtomicU64,
+    /// Blocks those batches framed.
+    blocks: AtomicU64,
+    /// Nanoseconds inside `read_raw_blocks`, refill time included.
+    read_raw_nanos: AtomicU64,
+    /// Nanoseconds pushing framed blocks onto the decompress queue.
+    dispatch_nanos: AtomicU64,
+}
+
+impl ReaderStats {
+    /// Record one `read()` against the underlying file.
+    pub(crate) fn record_refill(&self, elapsed_nanos: u64, bytes: usize) {
+        self.refills.fetch_add(1, Ordering::Relaxed);
+        self.refill_nanos.fetch_add(elapsed_nanos, Ordering::Relaxed);
+        self.refill_bytes.fetch_add(bytes as u64, Ordering::Relaxed);
+    }
+
+    /// Record one framed batch: how long `read_raw_blocks` took and what it returned.
+    pub(crate) fn record_batch(&self, elapsed_nanos: u64, blocks: usize) {
+        self.batches.fetch_add(1, Ordering::Relaxed);
+        self.blocks.fetch_add(blocks as u64, Ordering::Relaxed);
+        self.read_raw_nanos.fetch_add(elapsed_nanos, Ordering::Relaxed);
+    }
+
+    /// Record one dispatch of a framed batch onto the queue.
+    pub(crate) fn record_dispatch(&self, elapsed_nanos: u64) {
+        self.dispatch_nanos.fetch_add(elapsed_nanos, Ordering::Relaxed);
+    }
+
+    /// A consistent view of the counters, against the step total that should
+    /// contain them.
+    pub(crate) fn snapshot(&self, step_secs: f64) -> ReaderReport {
+        ReaderReport {
+            refills: self.refills.load(Ordering::Relaxed),
+            refill_secs: secs(self.refill_nanos.load(Ordering::Relaxed)),
+            refill_bytes: self.refill_bytes.load(Ordering::Relaxed),
+            batches: self.batches.load(Ordering::Relaxed),
+            blocks: self.blocks.load(Ordering::Relaxed),
+            read_raw_secs: secs(self.read_raw_nanos.load(Ordering::Relaxed)),
+            dispatch_secs: secs(self.dispatch_nanos.load(Ordering::Relaxed)),
+            step_secs,
+        }
+    }
+}
+
+/// Where the input reader's serial time went, as reported.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct ReaderReport {
+    pub(crate) refills: u64,
+    pub(crate) refill_secs: f64,
+    pub(crate) refill_bytes: u64,
+    pub(crate) batches: u64,
+    pub(crate) blocks: u64,
+    /// Time inside `read_raw_blocks`, **including** the refills it triggered.
+    pub(crate) read_raw_secs: f64,
+    pub(crate) dispatch_secs: f64,
+    /// Exact `ReadInputBlocks` busy total the parts should add up to.
+    pub(crate) step_secs: f64,
+}
+
+impl ReaderReport {
+    /// Time inside `read_raw_blocks` that was **not** spent in a `read()`:
+    /// header parse, validation, per-block allocation, and the body copy.
+    ///
+    /// This is the number the whole struct exists to produce. It is signed, and
+    /// a small negative is a known, benign case rather than a bug: the header
+    /// parse refills the buffer once before Phase 1 starts, so a few
+    /// milliseconds of refill can sit outside every timed batch. A *large*
+    /// negative means the reader was rebuilt or the counters were shared across
+    /// runs, and should not be explained away.
+    pub(crate) fn framing_secs(&self) -> f64 {
+        self.read_raw_secs - self.refill_secs
+    }
+
+    /// Step time the parts do not account for -- the `try_lock`, the serial
+    /// reservation, and dropping the guard.
+    ///
+    /// **Signed on purpose**, for the reason [`IngestPartition::residual_secs`]
+    /// gives: the merge's first partition summed to 321.5s of a 189.3s loop, and
+    /// only the sign made that visible.
+    pub(crate) fn residual_secs(&self) -> f64 {
+        self.step_secs - self.read_raw_secs - self.dispatch_secs
+    }
+
+    /// Residual as a share of the step, for judging the partition at a glance.
+    pub(crate) fn residual_share(&self) -> f64 {
+        if self.step_secs > 0.0 { self.residual_secs() / self.step_secs } else { 0.0 }
+    }
+
+    /// Spread `secs` over the blocks framed, in microseconds -- the unit the
+    /// 24.3 us/block question is asked in.
+    #[allow(clippy::cast_precision_loss, reason = "block counts stay far below 2^52")]
+    pub(crate) fn per_block_micros(&self, secs: f64) -> f64 {
+        if self.blocks == 0 { 0.0 } else { secs * 1_000_000.0 / self.blocks as f64 }
+    }
+
+    /// Throughput the refills actually achieved, in MB/s.
+    ///
+    /// The discriminant against the volume's measured ceiling: at the ceiling the
+    /// refills are disk-bound and the remaining time is framing; well under it,
+    /// the reader is leaving bandwidth on the floor and the fix is upstream of
+    /// framing entirely.
+    #[allow(clippy::cast_precision_loss, reason = "byte totals stay far below 2^52")]
+    pub(crate) fn refill_mb_per_sec(&self) -> f64 {
+        if self.refill_secs > 0.0 { self.refill_bytes as f64 / self.refill_secs / 1e6 } else { 0.0 }
+    }
+}
+
+/// Times every `read()` made against whatever it wraps.
+///
+/// Belongs *below* the input `BufReader`, so it sees buffer refills rather than
+/// per-block reads -- see [`ReaderStats`] for why that placement is the whole
+/// point.
+pub(crate) struct TimedReader<R> {
+    inner: R,
+    stats: std::sync::Arc<ReaderStats>,
+}
+
+impl<R> TimedReader<R> {
+    pub(crate) fn new(inner: R, stats: std::sync::Arc<ReaderStats>) -> Self {
+        Self { inner, stats }
+    }
+}
+
+impl<R: std::io::Read> std::io::Read for TimedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let started = std::time::Instant::now();
+        let result = self.inner.read(buf);
+        let elapsed = u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX);
+        // A failed read still cost time; counting zero bytes for it keeps the
+        // throughput figure honest rather than crediting the failure with bytes.
+        self.stats.record_refill(elapsed, result.as_ref().copied().unwrap_or(0));
+        result
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A reader report built from the production cell's shape: 124.5s of step
+    /// time over 5,114,408 blocks, of which ~71s is disk.
+    fn production_shape() -> ReaderReport {
+        ReaderReport {
+            refills: 20_560,
+            refill_secs: 71.0,
+            refill_bytes: 43_131_188_552,
+            batches: 319_651,
+            blocks: 5_114_408,
+            read_raw_secs: 121.4,
+            dispatch_secs: 3.1,
+            step_secs: 124.5,
+        }
+    }
+
+    #[test]
+    fn test_framing_is_read_raw_time_with_the_refills_taken_out() {
+        // The whole point of putting a timer below the BufReader: the refill
+        // happens inside `read_raw_blocks`, so the raw span is framing and I/O
+        // fused. Reporting the raw span as framing would credit userspace with
+        // every second the disk spent.
+        let report = production_shape();
+        assert!((report.framing_secs() - 50.4).abs() < 1e-9, "got {}", report.framing_secs());
+    }
+
+    #[test]
+    fn test_a_reader_report_partitions_the_step_with_a_signed_residual() {
+        let report = production_shape();
+        assert!((report.residual_secs() - 0.0).abs() < 1e-9, "got {}", report.residual_secs());
+
+        // Over-attribution must be visible. If the parts claim more than the
+        // step, a clamped residual reports a tidy zero and the partition gets
+        // believed -- exactly how the merge's first partition summed to 321.5s
+        // of a 189.3s loop and survived a reading.
+        let over = ReaderReport { read_raw_secs: 200.0, ..production_shape() };
+        assert!(over.residual_secs() < 0.0, "got {}", over.residual_secs());
+        assert!(over.residual_share() < 0.0, "got {}", over.residual_share());
+    }
+
+    #[test]
+    fn test_per_block_micros_reproduces_the_number_under_investigation() {
+        // 124.5s over 5,114,408 blocks is the 24.3 us/block the campaign is
+        // trying to explain; the report has to say so in that unit.
+        let report = production_shape();
+        let per_block = report.per_block_micros(report.step_secs);
+        assert!((per_block - 24.34).abs() < 0.01, "got {per_block}");
+        assert!((report.per_block_micros(0.0) - 0.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_refill_throughput_is_measured_against_the_bytes_actually_returned() {
+        // 43.1 GB in 71.0s is ~607 MB/s, which is what makes "the disk is at its
+        // ceiling" a claim rather than an assumption.
+        let report = production_shape();
+        assert!(
+            (report.refill_mb_per_sec() - 607.5).abs() < 1.0,
+            "got {}",
+            report.refill_mb_per_sec()
+        );
+        assert!((ReaderReport::default().refill_mb_per_sec() - 0.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_a_failed_read_is_timed_but_credited_no_bytes() {
+        use std::io::Read;
+        struct Failing;
+        impl Read for Failing {
+            fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("device fell off"))
+            }
+        }
+        let stats = std::sync::Arc::new(ReaderStats::default());
+        let mut reader = TimedReader::new(Failing, std::sync::Arc::clone(&stats));
+        let mut buf = [0u8; 8];
+        assert!(reader.read(&mut buf).is_err());
+
+        let report = stats.snapshot(0.0);
+        assert_eq!(report.refills, 1, "the attempt still cost time and must be counted");
+        assert_eq!(report.refill_bytes, 0, "a failed read must not inflate throughput");
+    }
 
     #[test]
     fn test_the_residual_is_signed_so_over_attribution_is_visible() {

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -1436,6 +1436,10 @@ pub(crate) struct SharedPipelineState {
     /// input stream records into it and the sorter reports from it, and neither
     /// owns the other.
     pub(crate) phase1_ingest: Arc<crate::phase1_stats::Phase1IngestStats>,
+    /// What the exclusively-owned input reader spends its time on. Shared with
+    /// the `TimedReader` wrapped around the input file, which is the only place
+    /// the refill syscalls are visible.
+    pub(crate) reader_stats: Arc<crate::phase1_stats::ReaderStats>,
     /// Next serial for input block reading (atomic increment for ordering).
     input_read_serial: AtomicU64,
     /// Raw input blocks: `ReadInputBlocks` → `DecompressInput`.
@@ -1632,6 +1636,7 @@ impl SharedPipelineState {
             chunk_read_error: Arc::new(AtomicBool::new(false)),
             worker_panicked: Arc::new(AtomicBool::new(false)),
             phase1_ingest: Arc::new(crate::phase1_stats::Phase1IngestStats::default()),
+            reader_stats: Arc::new(crate::phase1_stats::ReaderStats::default()),
             input_read_serial: AtomicU64::new(0),
             raw_input_blocks: Arc::new(ArrayQueue::new(data_queue_cap)),
             decompressed_input: Arc::new(ArrayQueue::new(data_queue_cap)),
@@ -2715,7 +2720,14 @@ impl SortWorkerPool {
             return StepResult::InputEmpty; // No input file set
         };
 
-        // Read a batch of raw BGZF blocks
+        // Read a batch of raw BGZF blocks.
+        //
+        // Timed as one region because that is the only honest boundary: the
+        // 2 MiB refill happens *inside* this call, on whichever block exhausts
+        // the buffer. Splitting disk from framing needs a timer below the
+        // buffer, which is what the `TimedReader` on the input file is for --
+        // `ReaderReport::framing_secs` is this span minus that one.
+        let framing_started = Instant::now();
         let blocks = match read_raw_blocks(reader.as_mut(), INPUT_READ_BATCH_SIZE) {
             Ok(b) => b,
             Err(e) => {
@@ -2731,6 +2743,13 @@ impl SortWorkerPool {
             shared.input_eof.store(true, Ordering::Release);
             return StepResult::InputEmpty;
         }
+
+        // Recorded only past the empty check, so the partition covers exactly the
+        // calls `record_step` charges to `ReadInputBlocks` -- that step is timed
+        // on `StepResult::Success` alone, and the EOF-detecting call returns
+        // `InputEmpty`. Counting it here would put time in the parts that is not
+        // in the total and drive the residual negative for no reason.
+        shared.reader_stats.record_batch(Self::nanos_u64(framing_started.elapsed()), blocks.len());
 
         // Reserve this batch's serial range while STILL HOLDING the input lock.
         //
@@ -2754,12 +2773,14 @@ impl SortWorkerPool {
         // Drop the lock before pushing to queue
         drop(guard);
 
+        let dispatch_started = Instant::now();
         dispatch_reserved_blocks(
             base_serial,
             blocks,
             &shared.raw_input_blocks,
             &mut worker.held_raw_input_blocks,
         );
+        shared.reader_stats.record_dispatch(Self::nanos_u64(dispatch_started.elapsed()));
 
         StepResult::Success
     }
@@ -3546,6 +3567,22 @@ impl SortWorkerPool {
     /// Counters for what Phase 1's ingest thread waited on.
     pub(crate) fn phase1_ingest_stats(&self) -> Arc<crate::phase1_stats::Phase1IngestStats> {
         Arc::clone(&self.shared.phase1_ingest)
+    }
+
+    /// Counters for the input reader, shared with the `TimedReader` that has to
+    /// be built before the pool is handed the file.
+    pub(crate) fn reader_stats(&self) -> Arc<crate::phase1_stats::ReaderStats> {
+        Arc::clone(&self.shared.reader_stats)
+    }
+
+    /// The input reader's partition, checked against the exact `ReadInputBlocks`
+    /// busy total it should add up to.
+    pub(crate) fn phase1_reader_report(&self) -> crate::phase1_stats::ReaderReport {
+        let ns =
+            self.pipeline_stats.step_ns[SortStep::ReadInputBlocks as usize].load(Ordering::Relaxed);
+        #[allow(clippy::cast_precision_loss, reason = "nanosecond totals stay far below 2^52")]
+        let step_secs = ns as f64 / 1_000_000_000.0;
+        self.shared.reader_stats.snapshot(step_secs)
     }
 
     /// The pool's shared state, for the merge consumer's own instrumentation.


### PR DESCRIPTION
Stacked on #837.

`ReadInputBlocks` is Phase 1's second serial resource — `exclusive_step_for` gives worker 0 sole ownership, so one thread frames the whole input — and its cost could not be attributed to anything.

## Why the timer has to sit below the buffer

The 2 MiB refill happens **inside** `read_raw_blocks`, on whichever block exhausts the buffer. Timing the step therefore measures framing and I/O fused together, and no per-block average separates them.

`TimedReader` wraps the input file *inside* the `BufReader` and times every underlying `read()` with a byte count. That is what makes `ReaderReport::framing_secs` — the batch span minus its refills — mean anything.

## The answer

`1kg-wgs-HG00096` (43.1 GB, 779,820,469 records, template-coordinate, t16, caches dropped):

```
Phase 1 input reader: 125.4s over 319651 batches (24.5 us/block, 5114408 blocks)
  refill reads: 120.6s over 20569 calls (5.86 ms each, 358 MB/s, 43.1 GB)
  framing:      4.4s (0.9 us/block)
  dispatch:     0.3s (0.1 us/block)
  unattributed: 0.1s (0% of the step)
```

**96% of the step is inside `read()`**, and the residual closes to 0.1s. This refutes every remaining idea about the reader's own code — removing the per-block `Vec` entirely would buy ~0.3s of 125.4s.

Independently confirmed by the `read_ladder` harness in the parent PR: raw `read()` with nothing downstream is 358 MB/s / 120.38s against the production reader's 358 MB/s / 120.6s — identical to three digits, so there is no backpressure loss either.

## Details worth knowing

- Batches are recorded **past** the empty check, so the partition covers exactly the calls `record_step` charges to the step: it is timed on `StepResult::Success` alone and the EOF-detecting call returns `InputEmpty`. Recording it would put time in the parts that is not in the total and drive the residual negative for no reason.
- Only the synchronous input paths are wrapped. `--async-reader` moves the read onto a prefetch thread, so a zero refill row on an async run is correct rather than a measurement failure.
- Timed exactly rather than sampled: ~320k batches and ~21k refills against a ~30 ns clock is under 30 ms of measurement on a 125s step, five orders of magnitude below the quantity.
- `framing_secs` and `residual_secs` are **signed**. A small negative framing figure is a known benign case — the header parse refills once before Phase 1 starts, so a few ms of refill can sit outside every timed batch. A large negative means something else and should not be explained away.

The report is gated behind `--sort-stats`, like the rest of the Phase 1 diagnostics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: adds `--sort-stats` timing output, pinned by reader timing and report calculations; no `unsafe` changes; no memory bound, queue capacity, or thread/backpressure policy changes.

Fix: none required. Phase 1 reader timing now separates disk refills, framing, dispatch, and residual time. `TimedReader` instruments synchronous readers, while async readers remain unwrapped because they read on the prefetch thread. `ReaderReport` exposes throughput and per-block metrics through `--sort-stats`. Tests cover timing partitioning, signed residuals, throughput, and failed reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->