### PR TITLE
feat(bam-io): unify the single-threaded raw-BAM reader onto fgumi-bgzf (#800)

### DIFF
--- a/crates/fgumi-bam-io/Cargo.toml
+++ b/crates/fgumi-bam-io/Cargo.toml
@@ -35,3 +35,7 @@ tempfile = { workspace = true }
 rstest = { workspace = true }
 proptest = { workspace = true }
 criterion = { workspace = true }
+
+[[bench]]
+name = "bgzf_decode"
+harness = false

--- a/crates/fgumi-bam-io/benches/bgzf_decode.rs
+++ b/crates/fgumi-bam-io/benches/bgzf_decode.rs
@@ -1,0 +1,82 @@
+//! Decode-throughput benchmark for the single-threaded raw-BAM reader unify
+//! (#800): the fgumi-bgzf streaming decoder (`FgumiBgzfReader`) — with CRC32
+//! verification on and off — versus noodles' single-threaded BGZF reader, all
+//! decoding the *same* BGZF byte buffer. This isolates the decode-path change
+//! the unify makes on the single-threaded fast paths.
+
+use std::hint::black_box;
+use std::io::{Cursor, Read};
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use fgumi_bam_io::FgumiBgzfReader;
+use fgumi_bgzf::InlineBgzfCompressor;
+
+/// Build a moderately compressible payload of `len` bytes (BAM-like: a mix of a
+/// small alphabet so blocks actually compress, deterministic so runs compare).
+fn make_payload(len: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(len);
+    let mut state: u32 = 0x1234_5678;
+    while out.len() < len {
+        // xorshift for cheap deterministic pseudo-randomness
+        state ^= state << 13;
+        state ^= state >> 17;
+        state ^= state << 5;
+        // Fold into a small-ish alphabet so the deflate stage has real work.
+        out.push((state & 0x3F) as u8 + b' ');
+    }
+    out.truncate(len);
+    out
+}
+
+/// Compress `payload` into a complete BGZF byte stream (blocks + EOF marker).
+fn make_bgzf(payload: &[u8], level: u32) -> Vec<u8> {
+    let mut compressor = InlineBgzfCompressor::new(level);
+    compressor.write_all(payload).expect("compress payload");
+    compressor.flush().expect("flush compressor");
+    let mut out = Vec::new();
+    compressor.write_blocks_to(&mut out).expect("write blocks");
+    out.extend_from_slice(&fgumi_bgzf::BGZF_EOF);
+    out
+}
+
+fn bench_bgzf_decode(c: &mut Criterion) {
+    let payload = make_payload(32 * 1024 * 1024); // 32 MiB uncompressed
+    let bgzf = make_bgzf(&payload, 6);
+
+    let mut group = c.benchmark_group("bgzf_decode");
+    group.throughput(Throughput::Bytes(payload.len() as u64));
+
+    let mut scratch = Vec::with_capacity(payload.len());
+
+    group.bench_function("fgumi_verify_on", |b| {
+        b.iter(|| {
+            scratch.clear();
+            let mut reader = FgumiBgzfReader::new(Box::new(Cursor::new(bgzf.clone())), true);
+            reader.read_to_end(&mut scratch).expect("decode");
+            black_box(scratch.len());
+        });
+    });
+
+    group.bench_function("fgumi_verify_off", |b| {
+        b.iter(|| {
+            scratch.clear();
+            let mut reader = FgumiBgzfReader::new(Box::new(Cursor::new(bgzf.clone())), false);
+            reader.read_to_end(&mut scratch).expect("decode");
+            black_box(scratch.len());
+        });
+    });
+
+    group.bench_function("noodles", |b| {
+        b.iter(|| {
+            scratch.clear();
+            let mut reader = noodles_bgzf::io::Reader::new(Cursor::new(bgzf.clone()));
+            reader.read_to_end(&mut scratch).expect("decode");
+            black_box(scratch.len());
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_bgzf_decode);
+criterion_main!(benches);

--- a/crates/fgumi-bam-io/src/lib.rs
+++ b/crates/fgumi-bam-io/src/lib.rs
@@ -30,10 +30,11 @@ pub use mem_estimate::MemoryEstimate;
 pub use paths::{is_stdin_path, is_stdout_path};
 pub use progress::ProgressTracker;
 pub use reader::{
-    BamReaderAuto, BgzfReaderEnum, ChainedReader, PipelineReaderOpts, RawBamReaderAuto, TeeReader,
-    create_bam_reader, create_bam_reader_for_pipeline, create_bam_reader_for_pipeline_with_opts,
-    create_bam_reader_with_opts, create_raw_bam_reader, create_raw_bam_reader_with_opts,
-    make_bgzf_reader, open_normalized_input, read_header_and_replay, read_prefix,
+    BamReaderAuto, BgzfReaderEnum, ChainedReader, FgumiBgzfReader, PipelineReaderOpts,
+    RawBamReaderAuto, TeeReader, create_bam_reader, create_bam_reader_for_pipeline,
+    create_bam_reader_for_pipeline_with_opts, create_bam_reader_with_opts, create_raw_bam_reader,
+    create_raw_bam_reader_with_opts, make_bgzf_reader, open_normalized_input,
+    read_header_and_replay, read_prefix,
 };
 pub use reorder::{DrainReady, ReorderBuffer};
 pub use writer::{

--- a/crates/fgumi-bam-io/src/reader.rs
+++ b/crates/fgumi-bam-io/src/reader.rs
@@ -37,6 +37,12 @@ pub enum BgzfReaderEnum {
     SingleThreaded(BgzfReader<Box<dyn Read + Send>>),
     /// Multi-threaded BGZF reader (noodles built-in threading)
     MultiThreaded(MultithreadedReader<Box<dyn Read + Send>>),
+    /// Single-threaded BGZF reader backed by fgumi-bgzf, which honors the
+    /// `verify_crc` policy (see [`FgumiBgzfReader`]). This is the arm used by
+    /// the raw-reader path (`create_raw_bam_reader[_with_opts]`) for
+    /// single-threaded input, so `--check-crc`/`--no-check-crc` take effect
+    /// there.
+    Fgumi(FgumiBgzfReader),
 }
 
 impl Read for BgzfReaderEnum {
@@ -44,6 +50,7 @@ impl Read for BgzfReaderEnum {
         match self {
             BgzfReaderEnum::SingleThreaded(r) => r.read(buf),
             BgzfReaderEnum::MultiThreaded(r) => r.read(buf),
+            BgzfReaderEnum::Fgumi(r) => r.read(buf),
         }
     }
 }
@@ -53,6 +60,7 @@ impl BufRead for BgzfReaderEnum {
         match self {
             BgzfReaderEnum::SingleThreaded(r) => r.fill_buf(),
             BgzfReaderEnum::MultiThreaded(r) => r.fill_buf(),
+            BgzfReaderEnum::Fgumi(r) => r.fill_buf(),
         }
     }
 
@@ -60,7 +68,165 @@ impl BufRead for BgzfReaderEnum {
         match self {
             BgzfReaderEnum::SingleThreaded(r) => r.consume(amt),
             BgzfReaderEnum::MultiThreaded(r) => r.consume(amt),
+            BgzfReaderEnum::Fgumi(r) => r.consume(amt),
         }
+    }
+}
+
+/// Number of raw BGZF blocks the [`FgumiBgzfReader`] *frames* (reads and length
+/// -validates) per refill of its frame queue.
+///
+/// Framing is decoupled from decoding: a batch this size is pulled from the
+/// source at once, then decoded one block at a time on demand (see
+/// [`FgumiBgzfReader::ensure_buffered`]). Two properties motivate the batch:
+///
+/// - **Correct EOF handling across concatenated streams.**
+///   [`read_raw_blocks`](fgumi_bgzf::read_raw_blocks) skips BGZF EOF-marker
+///   blocks and returns an empty vector only when it finds no real block within
+///   the batch. A multithreaded writer (and `cat a.bam b.bam`) emits an EOF
+///   marker between segments, so framing one block at a time would read that
+///   lone marker, get an empty vector, and wrongly conclude end-of-stream before
+///   the following data. A batch absorbs intermediate markers and returns real
+///   blocks, so an empty vector reliably means true end of input.
+/// - **Bounded memory.** Framed blocks are compressed (typically ~16 KiB), so a
+///   batch of this size costs a few hundred KiB per reader — `merge` holds one
+///   reader per input file, so this is kept modest rather than file-sized.
+const FGUMI_FRAME_BATCH: usize = 16;
+
+/// A single-threaded, safe streaming BGZF decoder built over fgumi-bgzf.
+///
+/// Unlike noodles' BGZF reader (which always verifies CRC32 and exposes no skip
+/// knob), this decoder honors a `verify_crc` flag: with it `false`, block CRC32
+/// verification is skipped (the decompressed-size check always runs), which is
+/// the fast path for trusted input. It yields the **decompressed** BAM byte
+/// stream, so it slots in wherever a noodles BGZF reader did — the header parse
+/// and [`RawBamReader`] both see plain decompressed bytes.
+///
+/// Framing and decoding are decoupled. Blocks are framed in batches via
+/// [`read_raw_blocks`](fgumi_bgzf::read_raw_blocks) (so intermediate BGZF EOF
+/// markers are handled — see `FGUMI_FRAME_BATCH`) into a queue, and decoded
+/// one at a time with
+/// [`decompress_block_into_opts`](fgumi_bgzf::decompress_block_into_opts) into an
+/// internal buffer served out across `read`/`fill_buf` calls with a cursor.
+/// Decoding lazily (one queued block per refill) keeps decode work — and any
+/// CRC/size error — tied to the bytes the caller actually reads, rather than
+/// pulling a later block's error forward into, say, the header parse. Partial
+/// reads and mid-block boundaries are handled by the cursor. No `unsafe` is used.
+pub struct FgumiBgzfReader {
+    /// The underlying compressed byte source (a normalized BGZF stream).
+    inner: Box<dyn Read + Send>,
+    /// Reusable libdeflater decompressor.
+    decompressor: fgumi_bgzf::Decompressor,
+    /// Whether to verify each block's CRC32 against its footer.
+    verify_crc: bool,
+    /// Framed-but-not-yet-decoded blocks, filled a [`FGUMI_FRAME_BATCH`] at a
+    /// time and drained front to back.
+    frames: std::collections::VecDeque<fgumi_bgzf::RawBgzfBlock>,
+    /// Set once the source yields no further blocks, so framing stops.
+    frames_done: bool,
+    /// Decoded bytes of the current block not yet served to the caller.
+    buffer: Vec<u8>,
+    /// Cursor into `buffer`: `buffer[pos..]` is unread.
+    pos: usize,
+    /// Set once a block fails to decode, poisoning the reader. A decode error
+    /// pops its frame and resets the cursor, so without this flag a later
+    /// `read`/`fill_buf` would resume at the *next* frame and silently skip the
+    /// corrupted block's records. Once set, every subsequent refill errors.
+    failed: bool,
+}
+
+impl FgumiBgzfReader {
+    /// Wrap `inner` in a streaming fgumi-bgzf decoder.
+    ///
+    /// `verify_crc` selects whether each block's CRC32 is checked; the
+    /// decompressed-size check always runs regardless.
+    #[must_use]
+    pub fn new(inner: Box<dyn Read + Send>, verify_crc: bool) -> Self {
+        Self {
+            inner,
+            decompressor: fgumi_bgzf::Decompressor::new(),
+            verify_crc,
+            frames: std::collections::VecDeque::new(),
+            frames_done: false,
+            buffer: Vec::new(),
+            pos: 0,
+            failed: false,
+        }
+    }
+
+    /// Ensure `self.buffer[self.pos..]` holds at least one byte, framing and
+    /// decoding more blocks if needed. Returns `Ok(false)` at end of input.
+    ///
+    /// Decodes at most one queued block per iteration and loops because a block
+    /// can decode to zero bytes (e.g. `ISIZE == 0`) without being end of input;
+    /// it stops only when the source yields no further blocks.
+    fn ensure_buffered(&mut self) -> io::Result<bool> {
+        if self.failed {
+            return Err(io::Error::other(
+                "fgumi-bgzf reader poisoned by an earlier BGZF block decode failure",
+            ));
+        }
+        while self.pos >= self.buffer.len() {
+            if self.frames.is_empty() {
+                if self.frames_done {
+                    return Ok(false);
+                }
+                let batch = fgumi_bgzf::read_raw_blocks(&mut self.inner, FGUMI_FRAME_BATCH)?;
+                if batch.is_empty() {
+                    // No real block in the batch => true end of input (EOF
+                    // markers are skipped inside `read_raw_blocks`).
+                    self.frames_done = true;
+                    return Ok(false);
+                }
+                self.frames.extend(batch);
+            }
+
+            let block = self.frames.pop_front().expect("frames non-empty checked above");
+            self.buffer.clear();
+            self.pos = 0;
+            // Poison the reader before propagating: this frame is already popped
+            // and the cursor reset, so a retried refill would otherwise skip
+            // straight to the next frame and hide the corrupted block.
+            if let Err(e) = fgumi_bgzf::decompress_block_into_opts(
+                &block,
+                &mut self.decompressor,
+                &mut self.buffer,
+                self.verify_crc,
+            ) {
+                self.failed = true;
+                return Err(e);
+            }
+        }
+        Ok(true)
+    }
+}
+
+impl Read for FgumiBgzfReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        if !self.ensure_buffered()? {
+            return Ok(0);
+        }
+        let available = &self.buffer[self.pos..];
+        let n = available.len().min(buf.len());
+        buf[..n].copy_from_slice(&available[..n]);
+        self.pos += n;
+        Ok(n)
+    }
+}
+
+impl BufRead for FgumiBgzfReader {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        if !self.ensure_buffered()? {
+            return Ok(&[]);
+        }
+        Ok(&self.buffer[self.pos..])
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.pos = (self.pos + amt).min(self.buffer.len());
     }
 }
 
@@ -80,17 +246,16 @@ pub struct PipelineReaderOpts {
     /// Whether the BGZF decode path should verify each block's CRC32
     /// checksum against its footer.
     ///
-    /// This struct only opens the byte stream (or, for
-    /// [`create_bam_reader_with_opts`]/[`create_raw_bam_reader_with_opts`],
-    /// wraps it in noodles' own BGZF reader, which always verifies and has no
-    /// skip knob) — it does not itself decode BGZF blocks, so **this field is
-    /// not consumed today**. The multi-threaded unified pipeline gets its CRC
-    /// policy from `PipelineConfig::verify_crc` (set in `build_pipeline_config`
-    /// in `fgumi_lib`), not from here. This field becomes live once the
-    /// raw-reader path is unified onto fgumi-bgzf (see #800), at which point
-    /// [`create_raw_bam_reader_with_opts`] will honor it directly. It is kept
-    /// now so callers already bundle the setting in one place. Defaults to
-    /// `true` (verify) — the safe, pre-existing behavior.
+    /// This field is **honored** for the single-threaded readers built by
+    /// [`create_bam_reader_with_opts`] and [`create_raw_bam_reader_with_opts`]:
+    /// both route single-threaded input through fgumi-bgzf's decoder (see
+    /// [`FgumiBgzfReader`]), which skips CRC32 verification when this is `false`
+    /// (the decompressed-size check always runs). Multi-threaded input
+    /// (`threads > 1`) still uses noodles' multithreaded reader, which always
+    /// verifies; the multi-threaded unified pipeline instead gets its CRC policy
+    /// from `PipelineConfig::verify_crc` (set in `build_pipeline_config` in
+    /// `fgumi_lib`). Defaults to `true` (verify) — the safe, pre-existing
+    /// behavior.
     pub verify_crc: bool,
 }
 
@@ -307,8 +472,11 @@ const BGZF_INPUT_BUFFER_SIZE: usize = 256 * 1024;
 /// is not paid twice: [`open_normalized_input`]'s consumers wrap the stream in
 /// their own [`BufReader`] (`fgumi_sort::RawBamRecordReader`), and buffering
 /// inside the shared opener would copy every byte through two buffers on that
-/// path. A `PrefetchReader` already hands out large chunks, so `opts.async_reader`
-/// gains nothing here and pays the same extra copy — it is left unwrapped.
+/// path. The async branch is buffered too: a `PrefetchReader` hands out large
+/// chunks only when the caller asks for them, but the frame reader asks for 18
+/// bytes then a block body, so an unbuffered async source pays the same per-read
+/// overhead (plus a cross-thread handoff each time). The `PrefetchReader` stays
+/// inside the buffer so its readahead still runs.
 fn open_bgzf_reader(
     path: &Path,
     opts: PipelineReaderOpts,
@@ -316,12 +484,18 @@ fn open_bgzf_reader(
     label: &str,
 ) -> Result<BgzfReaderEnum> {
     let normalized = open_normalized_with_opts(path, opts, label)?;
-    let buffered: Box<dyn Read + Send> = if opts.async_reader {
-        normalized
+    let buffered: Box<dyn Read + Send> =
+        Box::new(BufReader::with_capacity(BGZF_INPUT_BUFFER_SIZE, normalized));
+
+    // Single-threaded input decodes through fgumi-bgzf, which honors
+    // `opts.verify_crc` (noodles always verifies and has no skip knob). A
+    // threaded fgumi-bgzf raw reader is out of scope, so `threads > 1` keeps
+    // noodles' multithreaded decoder — its CRC policy is fixed on.
+    if threads > 1 {
+        Ok(make_bgzf_reader(buffered, threads))
     } else {
-        Box::new(BufReader::with_capacity(BGZF_INPUT_BUFFER_SIZE, normalized))
-    };
-    Ok(make_bgzf_reader(buffered, threads))
+        Ok(BgzfReaderEnum::Fgumi(FgumiBgzfReader::new(buffered, opts.verify_crc)))
+    }
 }
 
 /// Create a raw BAM reader that yields raw bytes instead of noodles Record.
@@ -525,6 +699,15 @@ pub fn create_bam_reader_for_pipeline_with_opts<P: AsRef<Path>>(
 
 /// Parse the BAM header from `reader`, then return a reader that replays the
 /// whole stream from byte zero.
+///
+/// The header block's CRC32 is **always** verified: the parse runs through
+/// noodles' [`BgzfReader`], which has no CRC-skip knob. A pipeline's
+/// `verify_crc = false` (`--no-check-crc`) therefore applies to the record body
+/// only — a corrupted *header* block is rejected regardless. Threading the
+/// policy here would mean swapping in the block-batching fgumi-bgzf reader,
+/// whose readahead over-consumes the [`TeeReader`] and breaks the exact-byte
+/// replay this function relies on, so the header parse deliberately stays on
+/// noodles.
 ///
 /// The bytes the header parse consumed are captured by a [`TeeReader`] and
 /// chained back in front of the remainder, so callers get the header without
@@ -923,6 +1106,303 @@ mod tests {
         let mut replayed = Vec::new();
         rest.read_to_end(&mut replayed)?;
         assert_eq!(replayed, bgzf, "replayed stream is not byte-identical to the input");
+        Ok(())
+    }
+
+    // ========================================================================
+    // fgumi-bgzf raw-reader unify (#800)
+    // ========================================================================
+
+    /// Build SAM text with `n` aligned records over a single reference. Enough
+    /// records to span more than one BGZF block once transcoded, so the raw
+    /// reader's block-boundary refill logic is exercised.
+    fn many_record_sam_text(n: usize) -> String {
+        use std::fmt::Write as _;
+        let mut s = String::from("@HD\tVN:1.6\tSO:unsorted\n@SQ\tSN:chr1\tLN:100000\n");
+        for i in 0..n {
+            let pos = (i % 90_000) + 1;
+            writeln!(s, "r{i}\t0\tchr1\t{pos}\t60\t4M\t*\t0\t0\tACGT\tIIII").expect("format");
+        }
+        s
+    }
+
+    /// Transcode SAM text to a BGZF BAM file on disk. For a large `sam` this
+    /// spans several BGZF blocks, which the corrupted-CRC and roundtrip tests
+    /// rely on.
+    fn write_bgzf_bam(path: &Path, sam: &str) {
+        let source: Box<dyn Read + Send> = Box::new(io::Cursor::new(sam.as_bytes().to_vec()));
+        let mut normalized = crate::sam_input::normalize_to_bgzf(source, Path::new("test.sam"))
+            .expect("transcode SAM to BGZF");
+        let mut bytes = Vec::new();
+        normalized.read_to_end(&mut bytes).expect("read transcoded BGZF");
+        std::fs::write(path, bytes).expect("write BGZF BAM");
+    }
+
+    /// Flip a byte in the last BGZF block's CRC32 footer, adapted from PR2's
+    /// `corrupt_last_block_crc` dedup integration helper. Requires the file to
+    /// span at least two blocks so the corrupted block comes *after* reader
+    /// construction succeeds: `FgumiBgzfReader` applies `verify_crc` uniformly to
+    /// every block, so corrupting block 0 (the header's block) with
+    /// `verify_crc: true` would fail inside reader construction (via `?`), before
+    /// the intended `read_record`/count assertion can run.
+    fn corrupt_last_block_crc(path: &Path) {
+        let mut bytes = std::fs::read(path).expect("read bam for corruption");
+        let mut cursor: &[u8] = &bytes;
+        let blocks =
+            fgumi_bgzf::read_raw_blocks(&mut cursor, 100_000).expect("read bgzf blocks from bam");
+        assert!(
+            blocks.len() >= 2,
+            "test input must span >= 2 BGZF blocks so the corrupted block isn't the header's; \
+             got {} -- generate more records",
+            blocks.len()
+        );
+        let offset: usize =
+            blocks[..blocks.len() - 1].iter().map(fgumi_bgzf::RawBgzfBlock::len).sum();
+        let last = blocks.last().expect("checked len >= 2 above");
+        // `read_raw_blocks` drops every BGZF EOF marker, so summing the returned
+        // (real) block lengths yields the last block's on-disk offset only when no
+        // marker sits *between* real blocks. Guard that: everything past the last
+        // framed block must be whole trailing EOF markers (a writer may emit more
+        // than one). An intermediate marker would leave real data here instead and
+        // shift `crc_off` onto an unrelated byte, which the `>= 2` guard cannot
+        // detect.
+        let eof = &fgumi_bgzf::BGZF_EOF;
+        let tail = &bytes[offset + last.len()..];
+        assert!(
+            tail.len().is_multiple_of(eof.len())
+                && tail.chunks_exact(eof.len()).all(|chunk| chunk == &eof[..]),
+            "bytes after the last framed block must be only trailing BGZF EOF markers; \
+             an intermediate marker would invalidate the CRC offset"
+        );
+        let crc_off = offset + last.len() - fgumi_bgzf::BGZF_FOOTER_SIZE;
+        bytes[crc_off] ^= 0x01;
+        std::fs::write(path, bytes).expect("write corrupted bam");
+    }
+
+    /// Flip a byte in the *first* BGZF block's CRC32 footer — the block that
+    /// carries the BAM header. The pipeline reader parses the header through
+    /// noodles (which always verifies), so this corruption is rejected even with
+    /// `verify_crc: false`.
+    fn corrupt_first_block_crc(path: &Path) {
+        let mut bytes = std::fs::read(path).expect("read bam for corruption");
+        let mut cursor: &[u8] = &bytes;
+        let blocks =
+            fgumi_bgzf::read_raw_blocks(&mut cursor, 100_000).expect("read bgzf blocks from bam");
+        let first_len = blocks.first().expect("at least one BGZF block").len();
+        let crc_off = first_len - fgumi_bgzf::BGZF_FOOTER_SIZE;
+        bytes[crc_off] ^= 0x01;
+        std::fs::write(path, bytes).expect("write corrupted bam");
+    }
+
+    /// The pipeline reader parses the BAM header through noodles' BGZF reader,
+    /// which always verifies CRC32 and has no skip knob. So `verify_crc: false`
+    /// does **not** suppress a corrupted *header* block — it applies to the
+    /// record body only. This pins that documented limitation (see
+    /// [`read_header_and_replay`]).
+    #[test]
+    fn test_pipeline_reader_always_verifies_the_header_block() -> Result<()> {
+        let file = tempfile::Builder::new().suffix(".bam").tempfile()?;
+        write_bgzf_bam(file.path(), &many_record_sam_text(8000));
+        corrupt_first_block_crc(file.path());
+
+        let opts = PipelineReaderOpts { verify_crc: false, ..PipelineReaderOpts::default() };
+        assert!(
+            create_bam_reader_for_pipeline_with_opts(file.path(), opts).is_err(),
+            "the header block is always CRC-verified, even with verify_crc: false"
+        );
+        Ok(())
+    }
+
+    /// Drain every record from a raw reader, returning the count.
+    fn count_raw_records(reader: &mut RawBamReaderAuto) -> io::Result<usize> {
+        let mut record = fgumi_raw_bam::RawRecord::new();
+        let mut count = 0usize;
+        while reader.read_record(&mut record)? > 0 {
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    /// The raw reader must honor `verify_crc`: with verification on, a corrupted
+    /// block errors; with it off, the same file reads clean. Against the noodles
+    /// path this could not be expressed — noodles always verifies — so the
+    /// `verify_crc: false` case is the red test for the fgumi-bgzf unify (#800).
+    #[test]
+    fn test_raw_reader_honors_verify_crc_on_corrupted_block() -> Result<()> {
+        let file = tempfile::Builder::new().suffix(".bam").tempfile()?;
+        write_bgzf_bam(file.path(), &many_record_sam_text(8000));
+        corrupt_last_block_crc(file.path());
+
+        // verify_crc: true -> reading the corrupted block must error.
+        let opts_verify = PipelineReaderOpts { verify_crc: true, ..PipelineReaderOpts::default() };
+        let (mut reader, _header) = create_raw_bam_reader_with_opts(file.path(), 1, opts_verify)?;
+        assert!(
+            count_raw_records(&mut reader).is_err(),
+            "verify_crc: true must reject a corrupted BGZF CRC32"
+        );
+
+        // verify_crc: false -> the same file reads clean (RED on the noodles path).
+        let opts_skip = PipelineReaderOpts { verify_crc: false, ..PipelineReaderOpts::default() };
+        let (mut reader, _header) = create_raw_bam_reader_with_opts(file.path(), 1, opts_skip)?;
+        let count = count_raw_records(&mut reader)
+            .expect("verify_crc: false must accept a corrupted BGZF CRC32");
+        assert_eq!(count, 8000, "all records read with verify_crc: false");
+        Ok(())
+    }
+
+    /// A clean multi-block file round-trips through the raw reader with
+    /// verification on: every written record is read back.
+    #[test]
+    fn test_raw_reader_roundtrip_multiblock() -> Result<()> {
+        let file = tempfile::Builder::new().suffix(".bam").tempfile()?;
+        write_bgzf_bam(file.path(), &many_record_sam_text(8000));
+
+        let opts = PipelineReaderOpts { verify_crc: true, ..PipelineReaderOpts::default() };
+        let (mut reader, header) = create_raw_bam_reader_with_opts(file.path(), 1, opts)?;
+        assert_eq!(header.reference_sequences().len(), 1, "header @SQ lost");
+        assert_eq!(count_raw_records(&mut reader)?, 8000, "record count mismatch");
+        Ok(())
+    }
+
+    /// A BGZF EOF marker appearing between data blocks (as a multithreaded
+    /// writer emits between per-thread segments, or `cat a.bam b.bam` does) must
+    /// not truncate the stream: the reader has to skip the marker and keep
+    /// reading the blocks after it. This is the exact shape that a naive
+    /// one-block-at-a-time refill mishandled.
+    #[test]
+    fn test_raw_reader_skips_intermediate_eof_marker() -> Result<()> {
+        // Transcode to BGZF bytes, then splice a BGZF EOF marker after the first
+        // block (not the header's block; it stays intact and parseable).
+        let bytes = {
+            let file = tempfile::Builder::new().suffix(".bam").tempfile()?;
+            write_bgzf_bam(file.path(), &many_record_sam_text(8000));
+            std::fs::read(file.path())?
+        };
+        let blocks = {
+            let mut cursor: &[u8] = &bytes;
+            fgumi_bgzf::read_raw_blocks(&mut cursor, 100_000)?
+        };
+        assert!(blocks.len() >= 2, "need >= 2 blocks, got {}", blocks.len());
+        let first_block_len = blocks[0].len();
+
+        let mut spliced = Vec::with_capacity(bytes.len() + fgumi_bgzf::BGZF_EOF.len());
+        spliced.extend_from_slice(&bytes[..first_block_len]);
+        spliced.extend_from_slice(&fgumi_bgzf::BGZF_EOF); // stray EOF marker mid-stream
+        spliced.extend_from_slice(&bytes[first_block_len..]);
+
+        let file = tempfile::Builder::new().suffix(".bam").tempfile()?;
+        std::fs::write(file.path(), &spliced)?;
+
+        let opts = PipelineReaderOpts { verify_crc: true, ..PipelineReaderOpts::default() };
+        let (mut reader, _header) = create_raw_bam_reader_with_opts(file.path(), 1, opts)?;
+        assert_eq!(
+            count_raw_records(&mut reader)?,
+            8000,
+            "intermediate EOF marker truncated the record stream"
+        );
+        Ok(())
+    }
+
+    /// Byte-at-a-time reads must reconstruct exactly the same decompressed
+    /// stream as one big read, across block boundaries. This pins the partial
+    /// -read / cursor logic of the fgumi-bgzf streaming decoder.
+    #[test]
+    fn test_fgumi_bgzf_reader_partial_reads_match_full_decode() -> Result<()> {
+        let bgzf = {
+            let src: Box<dyn Read + Send> =
+                Box::new(io::Cursor::new(many_record_sam_text(8000).into_bytes()));
+            let mut normalized = crate::sam_input::normalize_to_bgzf(src, Path::new("test.sam"))?;
+            let mut bytes = Vec::new();
+            normalized.read_to_end(&mut bytes)?;
+            bytes
+        };
+
+        // Full decode in one shot.
+        let mut full = Vec::new();
+        FgumiBgzfReader::new(Box::new(io::Cursor::new(bgzf.clone())), true)
+            .read_to_end(&mut full)?;
+        assert!(!full.is_empty(), "decoded stream should be non-empty");
+
+        // Byte-at-a-time decode must match exactly.
+        let mut reader = FgumiBgzfReader::new(Box::new(io::Cursor::new(bgzf.clone())), true);
+        let mut one_byte_at_a_time = Vec::new();
+        let mut byte = [0u8; 1];
+        loop {
+            let n = reader.read(&mut byte)?;
+            if n == 0 {
+                break;
+            }
+            one_byte_at_a_time.extend_from_slice(&byte[..n]);
+        }
+        assert_eq!(one_byte_at_a_time, full, "byte-at-a-time decode diverged from full decode");
+
+        // A small odd-sized buffer (spanning block boundaries) must also match.
+        let mut reader = FgumiBgzfReader::new(Box::new(io::Cursor::new(bgzf)), true);
+        let mut small_chunks = Vec::new();
+        let mut buf = [0u8; 7];
+        loop {
+            let n = reader.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            small_chunks.extend_from_slice(&buf[..n]);
+        }
+        assert_eq!(small_chunks, full, "7-byte-chunk decode diverged from full decode");
+        Ok(())
+    }
+
+    /// A block decode failure must be **sticky**: once a block fails to decode,
+    /// the reader must keep erroring rather than resume at the next frame and
+    /// silently skip the corrupted block's records. Corrupt a *middle* block so
+    /// valid blocks remain queued behind it — the exact shape where a
+    /// non-sticky reader would hand back the following block's bytes.
+    #[test]
+    fn test_fgumi_bgzf_reader_poisons_after_decode_failure() -> Result<()> {
+        let mut bgzf = {
+            let src: Box<dyn Read + Send> =
+                Box::new(io::Cursor::new(many_record_sam_text(8000).into_bytes()));
+            let mut normalized = crate::sam_input::normalize_to_bgzf(src, Path::new("test.sam"))?;
+            let mut bytes = Vec::new();
+            normalized.read_to_end(&mut bytes)?;
+            bytes
+        };
+
+        // Locate block boundaries and corrupt the CRC of block index 1 (a middle
+        // block): blocks 0 and 2.. stay valid, so a non-sticky reader would skip
+        // block 1 and continue serving block 2's bytes.
+        let block_lens: Vec<usize> = {
+            let mut cursor: &[u8] = &bgzf;
+            fgumi_bgzf::read_raw_blocks(&mut cursor, 100_000)?
+                .iter()
+                .map(fgumi_bgzf::RawBgzfBlock::len)
+                .collect()
+        };
+        assert!(block_lens.len() >= 3, "need >= 3 blocks, got {}", block_lens.len());
+        let block1_offset = block_lens[0];
+        let crc_off = block1_offset + block_lens[1] - fgumi_bgzf::BGZF_FOOTER_SIZE;
+        bgzf[crc_off] ^= 0x01;
+
+        let mut reader = FgumiBgzfReader::new(Box::new(io::Cursor::new(bgzf)), true);
+        let mut buf = [0u8; 64];
+
+        // Drain until the first error (must occur at the block 0 -> 1 boundary).
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) => panic!("reader reached clean EOF without erroring on the corrupted block"),
+                Ok(_) => {}
+                Err(_) => break,
+            }
+        }
+
+        // Sticky: every subsequent read must also error, never resume at block 2.
+        for _ in 0..3 {
+            assert!(
+                reader.read(&mut buf).is_err(),
+                "reader must stay poisoned after a decode failure, not skip the corrupted block"
+            );
+        }
+        // `fill_buf` shares the poison too.
+        assert!(reader.fill_buf().is_err(), "fill_buf must also honor the poison");
         Ok(())
     }
 

--- a/crates/fgumi-bgzf/src/lib.rs
+++ b/crates/fgumi-bgzf/src/lib.rs
@@ -21,4 +21,8 @@ pub use reader::{
     decompress_block_into_opts, decompress_block_slice_into, decompress_block_slice_into_opts,
     read_raw_blocks,
 };
+// Re-export the libdeflater decompressor so downstream crates can name the type
+// required by `decompress_block_into_opts` without depending on libdeflater
+// directly.
+pub use libdeflater::Decompressor;
 pub use writer::{BGZF_MAX_BLOCK_SIZE, CompressedBlock, InlineBgzfCompressor};

--- a/crates/fgumi-bgzf/src/reader.rs
+++ b/crates/fgumi-bgzf/src/reader.rs
@@ -239,8 +239,13 @@ fn read_raw_block<R: Read + ?Sized>(reader: &mut R) -> io::Result<Option<RawBgzf
 ///
 /// # Returns
 ///
-/// A vector of blocks read. The vector may be shorter than `max_blocks`
-/// if EOF is reached. Returns an empty vector at EOF.
+/// Up to `max_blocks` real (non-EOF-marker) blocks. BGZF EOF-marker blocks are
+/// skipped and do **not** count against `max_blocks`: the reader keeps consuming
+/// markers until it finds a real block or reaches true end of input. So the
+/// vector is shorter than `max_blocks` only when true EOF was reached first, and
+/// an empty vector reliably means true end of input — even when the stream holds
+/// a run of `max_blocks` or more consecutive markers (as concatenated BGZF
+/// segments or `cat a.bam b.bam` can produce) before the next real block.
 ///
 /// # Errors
 ///
@@ -250,14 +255,13 @@ pub fn read_raw_blocks<R: Read + ?Sized>(
     max_blocks: usize,
 ) -> io::Result<Vec<RawBgzfBlock>> {
     let mut blocks = Vec::with_capacity(max_blocks);
-    for _ in 0..max_blocks {
+    while blocks.len() < max_blocks {
         match read_raw_block(reader)? {
-            Some(block) => {
-                // Skip EOF marker blocks
-                if !block.is_eof() {
-                    blocks.push(block);
-                }
-            }
+            // Skip EOF marker blocks without counting them against `max_blocks`,
+            // so a batch that reads only markers before a later real block still
+            // returns that block instead of spuriously reporting EOF.
+            Some(block) if block.is_eof() => {}
+            Some(block) => blocks.push(block),
             None => break,
         }
     }
@@ -436,7 +440,11 @@ pub fn decompress_block_into_opts(
     output: &mut Vec<u8>,
     verify_crc: bool,
 ) -> io::Result<()> {
-    if block.is_eof() || block.uncompressed_size() == 0 {
+    // Skip only the exact EOF marker. A zero-size block that is *not* the EOF
+    // marker — e.g. a CRC-corrupted EOF whose bytes no longer match it — must
+    // still be CRC-verified: short-circuiting on `uncompressed_size() == 0`
+    // would let malformed input pass silently under `verify_crc = true`.
+    if block.is_eof() {
         return Ok(());
     }
 
@@ -478,10 +486,13 @@ pub fn decompress_block_slice_into_opts(
         return Ok(());
     }
 
-    let uncompressed_size = uncompressed_size_from_slice(data);
-    if uncompressed_size == 0 {
+    // Skip only the exact EOF marker; every other zero-size block is still
+    // CRC-verified (see `decompress_block_into_opts` for why).
+    if data == BGZF_EOF {
         return Ok(());
     }
+
+    let uncompressed_size = uncompressed_size_from_slice(data);
 
     decompress_and_verify(
         compressed_data_from_slice(data),
@@ -854,6 +865,44 @@ mod tests {
         let mut reader = Cursor::new(Vec::<u8>::new());
         let result = read_raw_block(&mut reader).expect("reading raw BGZF block should succeed");
         assert!(result.is_none());
+    }
+
+    /// A run of EOF markers longer than `max_blocks` must not make
+    /// `read_raw_blocks` report EOF while a real block still follows: markers are
+    /// skipped without counting against the budget, so the trailing real block is
+    /// returned rather than dropped. Regression for the case where concatenated
+    /// BGZF segments emit more consecutive markers than a single batch spans.
+    #[test]
+    fn test_read_raw_blocks_skips_marker_run_longer_than_max_blocks() {
+        use crate::writer::InlineBgzfCompressor;
+
+        let original_data = b"payload after a long run of EOF markers";
+        let mut compressor = InlineBgzfCompressor::new(6);
+        compressor.write_all(original_data).expect("write payload");
+        compressor.flush().expect("flush compressor");
+        let real_block = compressor.take_blocks().remove(0).data;
+
+        // More consecutive markers than `max_blocks` below, then one real block.
+        let max_blocks = 4;
+        let marker_run = max_blocks + 3;
+        let mut stream = Vec::new();
+        for _ in 0..marker_run {
+            stream.extend_from_slice(&BGZF_EOF);
+        }
+        stream.extend_from_slice(&real_block);
+
+        let mut reader = Cursor::new(stream);
+        let blocks = read_raw_blocks(&mut reader, max_blocks).expect("read raw blocks");
+        assert_eq!(blocks.len(), 1, "the trailing real block must survive the marker run");
+        assert!(!blocks[0].is_eof(), "the returned block must be the real block, not a marker");
+
+        let mut decompressor = Decompressor::new();
+        let decoded = decompress_block(&blocks[0], &mut decompressor).expect("decompress block");
+        assert_eq!(decoded, original_data, "decoded payload must match the written data");
+
+        // The stream is now fully drained: the next batch reports true EOF.
+        let tail = read_raw_blocks(&mut reader, max_blocks).expect("read raw blocks at eof");
+        assert!(tail.is_empty(), "an empty vector must reliably mean true end of input");
     }
 
     #[test]
@@ -1340,5 +1389,51 @@ mod tests {
             "error should mention the size mismatch: {err}"
         );
         assert!(out.is_empty(), "output should be rolled back on failure");
+    }
+
+    /// A CRC-corrupted EOF marker no longer matches [`BGZF_EOF`] byte-for-byte,
+    /// so it is not `is_eof()` and must run through CRC verification like any
+    /// other zero-size block rather than being waved through on
+    /// `uncompressed_size == 0`. Regression: the previous short-circuit let a
+    /// corrupted EOF marker pass silently under `verify_crc = true`, on both the
+    /// `RawBgzfBlock` and slice APIs.
+    #[test]
+    fn decompress_opts_verifies_a_corrupted_eof_marker() {
+        let mut decompressor = Decompressor::new();
+
+        // The exact EOF marker is skipped by both APIs, verify_crc either way.
+        let eof = RawBgzfBlock { data: BGZF_EOF.to_vec() };
+        let mut out = Vec::new();
+        decompress_block_into_opts(&eof, &mut decompressor, &mut out, true)
+            .expect("the exact EOF marker is skipped");
+        assert!(out.is_empty());
+
+        // Flip the first CRC32 footer byte. The block is no longer the exact
+        // marker (so `is_eof()` is false) but still has ISIZE == 0.
+        let crc_off = BGZF_EOF.len() - BGZF_FOOTER_SIZE;
+        let mut corrupted = BGZF_EOF.to_vec();
+        corrupted[crc_off] ^= 0x01;
+        assert_ne!(corrupted.as_slice(), &BGZF_EOF[..], "must not be the exact EOF marker");
+
+        // RawBgzfBlock API: verify_crc = true rejects, verify_crc = false skips.
+        let block = RawBgzfBlock { data: corrupted.clone() };
+        let mut out = Vec::new();
+        let err = decompress_block_into_opts(&block, &mut decompressor, &mut out, true)
+            .expect_err("verify_crc=true must reject a corrupted EOF marker");
+        assert!(err.to_string().contains("CRC32"), "error should mention CRC32: {err}");
+        let mut out = Vec::new();
+        decompress_block_into_opts(&block, &mut decompressor, &mut out, false)
+            .expect("verify_crc=false must skip the CRC32 check");
+        assert!(out.is_empty());
+
+        // Slice API twin.
+        let mut out = Vec::new();
+        let err = decompress_block_slice_into_opts(&corrupted, &mut decompressor, &mut out, true)
+            .expect_err("slice API: verify_crc=true must reject a corrupted EOF marker");
+        assert!(err.to_string().contains("CRC32"), "error should mention CRC32: {err}");
+        let mut out = Vec::new();
+        decompress_block_slice_into_opts(&corrupted, &mut decompressor, &mut out, false)
+            .expect("slice API: verify_crc=false must skip the CRC32 check");
+        assert!(out.is_empty());
     }
 }

--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -24,7 +24,8 @@ use anyhow::Result;
 use clap::Parser;
 use fgumi_bam_io::ProgressTracker;
 use fgumi_bam_io::{
-    create_bam_reader_for_pipeline_with_opts, create_raw_bam_reader, create_raw_bam_writer,
+    create_bam_reader_for_pipeline_with_opts, create_raw_bam_reader_with_opts,
+    create_raw_bam_writer,
 };
 use fgumi_raw_bam::RawRecord;
 use log::info;
@@ -510,7 +511,9 @@ impl Command for Clip {
         info!("  Clip overlapping reads: {}", self.clip_overlapping_reads);
         info!("  Clip extending past mate: {}", self.clip_extending_past_mate);
         info!("  {}", self.threading.log_message());
-        self.io.log_effective_check_crc_for_fast_path(self.threading.threads.is_some());
+        // Both the single-threaded fast path (via create_raw_bam_reader_with_opts)
+        // and the multi-threaded pipeline honor --check-crc/--no-check-crc (#800).
+        self.io.log_effective_check_crc();
 
         let timer = OperationTimer::new("Clipping reads");
 
@@ -602,9 +605,15 @@ impl Clip {
         // Load reference (always required and tags are always regenerated to match Scala fgbio)
         let reference_reader = ReferenceReader::new(&self.reference)?;
 
-        // Open input BAM with MT BGZF decompression
+        // Open input BAM. This fast path is only reached with no --threads, so
+        // reader_threads is 1 and the reader decodes through fgumi-bgzf, honoring
+        // --check-crc/--no-check-crc via pipeline_reader_opts (#800).
         let reader_threads = self.threading.num_threads();
-        let (reader, header) = create_raw_bam_reader(&self.io.input, reader_threads)?;
+        let (reader, header) = create_raw_bam_reader_with_opts(
+            &self.io.input,
+            reader_threads,
+            self.io.pipeline_reader_opts(),
+        )?;
 
         // Synthesize @HD VN:1.6 SO:unsorted when the input lacks one (match fgbio).
         let header = crate::commands::common::ensure_hd_record(header)?;

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -353,7 +353,9 @@ impl Command for Codec {
 
         // Process reads using streaming by MI groups
         info!("Processing reads and calling consensus (streaming)...");
-        self.io.log_effective_check_crc_for_fast_path(self.threading.threads.is_some());
+        // Both the single-threaded fast path (create_raw_bam_reader_with_opts)
+        // and the multi-threaded pipeline honor --check-crc/--no-check-crc (#800).
+        self.io.log_effective_check_crc();
 
         // ============================================================
         // --threads N mode: Use 7-step unified pipeline

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -446,11 +446,18 @@ pub struct BamIoOptions {
     /// transferred, or copied since it was written, where a flipped bit is
     /// exactly what CRC32 exists to catch. Pass `--check-crc` to force
     /// verification on (e.g. for stdin input you don't trust). Mutually
-    /// exclusive with `--no-check-crc`. Not every command honors this flag:
-    /// `downsample` never does; `clip`/`codec`/`duplex`/`simplex`/`correct`/`group`
-    /// only do when `--threads N` is given (their default, no-`--threads`
-    /// mode falls back to a reader that always verifies). Every run logs a
-    /// `CRC verify:` line at startup stating what actually happened.
+    /// exclusive with `--no-check-crc`. Coverage varies by command:
+    /// `clip`/`codec`/`duplex`/`simplex`/`downsample` honor it whether run
+    /// single- or multi-threaded; `correct`/`group` honor it only with
+    /// `--threads N` (their single-threaded mode falls back to a reader that
+    /// always verifies). Every run logs a `CRC verify:` line at startup stating
+    /// what actually happened. For `correct`/`group` the BAM **header** block is
+    /// always CRC-verified regardless of this flag, because their header parse
+    /// goes through a decoder with no CRC-skip knob; there `--no-check-crc`
+    /// applies to the record body only. The raw-reader commands
+    /// (`clip`/`codec`/`duplex`/`simplex`/`downsample`) parse the header through
+    /// the same fgumi-bgzf decoder as the body when single-threaded, so
+    /// `--no-check-crc` skips the header block's CRC there too.
     #[arg(long = "check-crc", default_value_t = false, conflicts_with = "no_check_crc")]
     pub check_crc: bool,
 
@@ -533,10 +540,13 @@ impl BamIoOptions {
     /// Log the CRC-verification setting for a command whose single-threaded
     /// fast path bypasses the CRC-skip-capable fgumi-bgzf decoder in favor of
     /// noodles-bgzf's own BGZF reader (which always verifies and has no
-    /// public knob to disable it — see the fgumi-sort-style follow-up note in
-    /// the task-2b report). `pipeline_mode` is `true` when the wireable
-    /// 7-step pipeline will run instead of the fast path, in which case this
-    /// defers to [`log_effective_check_crc`](Self::log_effective_check_crc).
+    /// public knob to disable it). Since the raw-reader unify (#800), only
+    /// `correct` and `group` still take this path: their single-threaded mode
+    /// reads through `create_bam_reader_for_pipeline_with_opts` + a manual
+    /// noodles BGZF decode, not through `create_raw_bam_reader[_with_opts]`.
+    /// `pipeline_mode` is `true` when the wireable 7-step pipeline will run
+    /// instead of the fast path, in which case this defers to
+    /// [`log_effective_check_crc`](Self::log_effective_check_crc).
     pub fn log_effective_check_crc_for_fast_path(&self, pipeline_mode: bool) {
         if pipeline_mode {
             self.log_effective_check_crc();

--- a/src/lib/commands/downsample.rs
+++ b/src/lib/commands/downsample.rs
@@ -10,7 +10,7 @@ use crate::sam::{SamTag, is_template_coordinate_sorted};
 use anyhow::{Result, bail};
 use clap::Parser;
 use fgumi_bam_io::ProgressTracker;
-use fgumi_bam_io::{RawBamWriter, create_raw_bam_reader, create_raw_bam_writer};
+use fgumi_bam_io::{RawBamWriter, create_raw_bam_reader_with_opts, create_raw_bam_writer};
 use fgumi_raw_bam::{
     RawBamReader, RawRecord, aux_data_slice, find_int_tag, find_string_tag, read_name,
 };
@@ -147,13 +147,10 @@ impl Command for Downsample {
         if self.validate_mi_order {
             info!("MI order validation: enabled");
         }
-        // downsample reads through noodles-bgzf directly (`create_raw_bam_reader`),
-        // not the fgumi-bgzf CRC-skip-capable decoder the unified pipeline uses, and
-        // has no `--threads` pipeline mode to fall back to, so --check-crc/
-        // --no-check-crc have no effect on this command; it always verifies.
-        log::info!(
-            "CRC verify: on (downsample always verifies; --check-crc/--no-check-crc have no effect)"
-        );
+        // downsample is single-threaded and reads through fgumi-bgzf's decoder
+        // (`create_raw_bam_reader_with_opts` with threads=1), so it honors
+        // --check-crc/--no-check-crc (#800).
+        self.io.log_effective_check_crc();
 
         // Initialize RNG
         let mut rng = match self.seed {
@@ -161,7 +158,8 @@ impl Command for Downsample {
             None => rand::make_rng(),
         };
 
-        let (reader, header) = create_raw_bam_reader(&self.io.input, 1)?;
+        let (reader, header) =
+            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
 
         // Validate header - input must be template-coordinate sorted (output from group)
         if !is_template_coordinate_sorted(&header) {

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -360,7 +360,9 @@ impl Command for Duplex {
 
         // Process reads grouped by MI tag (streaming approach)
         info!("Processing reads...");
-        self.io.log_effective_check_crc_for_fast_path(self.threading.threads.is_some());
+        // Both the single-threaded fast path (create_raw_bam_reader_with_opts)
+        // and the multi-threaded pipeline honor --check-crc/--no-check-crc (#800).
+        self.io.log_effective_check_crc();
 
         // ============================================================
         // --threads N mode: Use 7-step unified pipeline

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -289,7 +289,9 @@ impl Command for Simplex {
 
         // Process reads using streaming by MI groups
         info!("Processing reads and calling consensus (streaming)...");
-        self.io.log_effective_check_crc_for_fast_path(self.threading.threads.is_some());
+        // Both the single-threaded fast path (create_raw_bam_reader_with_opts)
+        // and the multi-threaded pipeline honor --check-crc/--no-check-crc (#800).
+        self.io.log_effective_check_crc();
 
         // ============================================================
         // --threads N mode: Use 7-step unified pipeline

--- a/tests/integration/test_downsample_command.rs
+++ b/tests/integration/test_downsample_command.rs
@@ -58,6 +58,163 @@ fn create_grouped_bam(path: &PathBuf, families: Vec<(&str, usize)>) {
     writer.try_finish().expect("Failed to finish BAM");
 }
 
+/// Flip a byte in the last BGZF block's CRC32 footer, so decoding that block
+/// fails only when CRC verification is on. Adapted from PR2's dedup integration
+/// helper. Requires the file to span at least two blocks so the corrupted block
+/// comes *after* reader construction succeeds: the single-threaded raw reader
+/// (`FgumiBgzfReader`) applies `verify_crc` uniformly to every block, so
+/// corrupting block 0 (the header's block) with verification on would fail while
+/// building the reader, before the intended read/count assertion can run.
+fn corrupt_last_block_crc(path: &std::path::Path) {
+    let mut bytes = fs::read(path).expect("read bam for corruption");
+    let mut cursor: &[u8] = &bytes;
+    let blocks = fgumi_lib::bgzf_reader::read_raw_blocks(&mut cursor, 100_000)
+        .expect("read bgzf blocks from test bam");
+    assert!(
+        blocks.len() >= 2,
+        "test input must span >= 2 BGZF blocks so the corrupted block isn't the header's; \
+         got {} -- generate more records",
+        blocks.len()
+    );
+    let offset: usize =
+        blocks[..blocks.len() - 1].iter().map(fgumi_lib::bgzf_reader::RawBgzfBlock::len).sum();
+    let last = blocks.last().expect("checked len >= 2 above");
+    // `read_raw_blocks` drops every BGZF EOF marker, so summing the returned
+    // (real) block lengths yields the last block's on-disk offset only when no
+    // marker sits *between* real blocks. Guard that: everything past the last
+    // framed block must be whole trailing EOF markers (a writer may emit more
+    // than one). An intermediate marker would leave real data here instead and
+    // shift `crc_off` onto an unrelated byte, which the `>= 2` guard cannot
+    // detect.
+    let eof = &fgumi_lib::bgzf_reader::BGZF_EOF;
+    let tail = &bytes[offset + last.len()..];
+    assert!(
+        tail.len().is_multiple_of(eof.len())
+            && tail.chunks_exact(eof.len()).all(|chunk| chunk == &eof[..]),
+        "bytes after the last framed block must be only trailing BGZF EOF markers; \
+         an intermediate marker would invalidate the CRC offset"
+    );
+    let crc_off = offset + last.len() - fgumi_lib::bgzf_reader::BGZF_FOOTER_SIZE;
+    bytes[crc_off] ^= 0x01;
+    fs::write(path, bytes).expect("write corrupted bam");
+}
+
+/// `--no-check-crc` must let downsample's single-threaded raw reader accept a
+/// corrupted BGZF CRC32 (it decodes through fgumi-bgzf, honoring the flag, #800).
+#[test]
+fn test_downsample_no_check_crc_accepts_corrupted_crc() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    // Enough records to span multiple BGZF blocks (see corrupt_last_block_crc).
+    create_grouped_bam(&input_bam, vec![("MI1", 3000)]);
+    corrupt_last_block_crc(&input_bam);
+
+    let cmd = Downsample::try_parse_from([
+        "downsample",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-o",
+        output_bam.to_str().unwrap(),
+        "-f",
+        "1.0",
+        "--seed",
+        "42",
+        "--no-check-crc",
+    ])
+    .expect("failed to parse downsample args");
+    cmd.execute("fgumi downsample")
+        .expect("--no-check-crc must accept a corrupted BGZF CRC32 and complete");
+
+    // Assert the corrupted block was decoded, not silently dropped: the input is
+    // one MI family of 3000 records at -f 1.0 (every record kept), so all 3000
+    // must survive the --no-check-crc decode. Pin the complete read-name set,
+    // not just the count — a bare `records().count()` can tally error items and
+    // passes even if records were dropped and replaced or duplicated.
+    let mut reader =
+        bam::io::reader::Builder.build_from_path(&output_bam).expect("open output BAM");
+    reader.read_header().expect("read output BAM header");
+    let records: Vec<_> = reader
+        .records()
+        .collect::<std::io::Result<Vec<_>>>()
+        .expect("every output record must decode under --no-check-crc");
+    let mut names: Vec<String> = records
+        .iter()
+        .map(|r| {
+            let name = r.name().expect("record has a name");
+            String::from_utf8_lossy(AsRef::<[u8]>::as_ref(&name)).into_owned()
+        })
+        .collect();
+    names.sort();
+    let mut expected: Vec<String> = (0..3000).map(|i| format!("read_{i}")).collect();
+    expected.sort();
+    assert_eq!(
+        names, expected,
+        "read_0..read_2999 must all survive the --no-check-crc decode of the corrupted block, \
+         by identity"
+    );
+}
+
+/// Default (verify-on for file input) must reject the same corrupted CRC32.
+#[test]
+fn test_downsample_rejects_corrupted_crc_by_default() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    create_grouped_bam(&input_bam, vec![("MI1", 3000)]);
+    corrupt_last_block_crc(&input_bam);
+
+    let cmd = Downsample::try_parse_from([
+        "downsample",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-o",
+        output_bam.to_str().unwrap(),
+        "-f",
+        "1.0",
+        "--seed",
+        "42",
+    ])
+    .expect("failed to parse downsample args");
+    let err = cmd
+        .execute("fgumi downsample")
+        .expect_err("default (verify-on for file input) must reject a corrupted BGZF CRC32");
+    let message = format!("{err:#}");
+    assert!(message.to_uppercase().contains("CRC32"), "error should mention CRC32: {message}");
+}
+
+/// `--check-crc` must also reject the corrupted CRC32 (forces verification on).
+#[test]
+fn test_downsample_check_crc_rejects_corrupted_crc() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    create_grouped_bam(&input_bam, vec![("MI1", 3000)]);
+    corrupt_last_block_crc(&input_bam);
+
+    let cmd = Downsample::try_parse_from([
+        "downsample",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-o",
+        output_bam.to_str().unwrap(),
+        "-f",
+        "1.0",
+        "--seed",
+        "42",
+        "--check-crc",
+    ])
+    .expect("failed to parse downsample args");
+    let err = cmd
+        .execute("fgumi downsample")
+        .expect_err("--check-crc must reject a corrupted BGZF CRC32");
+    let message = format!("{err:#}");
+    assert!(message.to_uppercase().contains("CRC32"), "error should mention CRC32: {message}");
+}
+
 /// Read records from a BAM file.
 fn read_bam_records(path: &PathBuf) -> Vec<noodles::sam::alignment::RecordBuf> {
     let mut reader = bam::io::reader::Builder.build_from_path(path).expect("Failed to open BAM");


### PR DESCRIPTION
Closes #800. Supersedes #801 (auto-closed when its base branch `786/nhomer/perf-bgzf-crc-skip` was deleted by the #798 squash-merge; GitHub cannot reopen a PR whose base branch was deleted). Same head branch, rebased onto `main` — the one now-redundant doc commit dropped as already upstream, leaving the single substantive change.

## Problem

`fgumi-bam-io` had two BGZF decoder stacks. The single-threaded raw-BAM reader (`create_raw_bam_reader[_with_opts]`) decoded via **noodles-bgzf**, which always verifies CRC32 and has no skip knob — so the `--check-crc`/`--no-check-crc` policy from #798 (backed by our own `fgumi-bgzf`) never reached the single-threaded fast paths, and `PipelineReaderOpts.verify_crc` was a dead carrier field.

## Change

Add `FgumiBgzfReader`, a safe streaming `Read`/`BufRead` adapter over `fgumi-bgzf`'s `read_raw_blocks` + `decompress_block_into_opts` (no `unsafe`; one block decoded per refill, so a CRC/size error is tied to the bytes the caller actually reads), and route the single-threaded raw reader through it via a new `BgzfReaderEnum::Fgumi` arm. `PipelineReaderOpts.verify_crc` is now live.

Coverage after this change (`--check-crc`/`--no-check-crc`):
- **`clip`/`codec`/`duplex`/`simplex`/`downsample`** — honored single- or multi-threaded (their single-threaded reader now decodes through fgumi-bgzf).
- **`correct`/`group`** — honored only with `--threads N`; their single-threaded mode reads through `create_bam_reader_for_pipeline_with_opts` + a manual noodles decode, so they keep the noodles path (help text says so).
- `threads > 1` still uses noodles' multithreaded decoder (a threaded fgumi-bgzf raw reader is out of scope).

`fgumi-sort` and `extract` have their own reader stacks and remain follow-ups.

## Tests

TDD: the reader-level `verify_crc` test (corrupted-CRC file accepted with `verify_crc=false`, rejected with `true`) was written first and confirmed red against the noodles path before implementing. Plus a multi-block roundtrip test (exercises block-boundary buffering) and three end-to-end `downsample` CRC tests (`--no-check-crc` accepts a corrupted file; default and `--check-crc` reject it). The reader also gains a sticky-poison test: after a mid-stream decode failure both `read` and `fill_buf` stay in error. All 228 `fgumi-bam-io` + `fgumi-bgzf` tests green on the rebased tree.
