### PR TITLE
fix(simulate): renumber grouped-reads MI ids into monotonic file order

### DIFF
--- a/src/lib/commands/simulate/grouped_reads.rs
+++ b/src/lib/commands/simulate/grouped_reads.rs
@@ -22,15 +22,18 @@ use crate::simulate::{
 };
 use anyhow::{Context, Result};
 use clap::Parser;
-use fgumi_bam_io::ProgressTracker;
-use fgumi_raw_bam::{RawRecord, SamBuilder, flags as raw_flags};
+use fgumi_bam_io::{ProgressTracker, create_raw_bam_reader, create_raw_bam_writer};
+use fgumi_raw_bam::{
+    RawRecord, SamBuilder, aux_data_slice, find_string_tag, flags as raw_flags, update_string_tag,
+};
 use fgumi_sort::{KeyTypesSpec, RawExternalSorter, SortOrder};
 use log::info;
 use noodles::sam::header::Header;
 use rand::{Rng, RngExt};
+use std::collections::HashMap;
 use std::fs::File;
-use std::io::{BufWriter, Write};
-use std::path::PathBuf;
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
 
 /// Generate template-coordinate sorted BAM with MI tags for consensus callers.
 #[derive(Parser, Debug)]
@@ -228,12 +231,35 @@ impl Command for GroupedReads {
         // sorted chunks exactly like `fgumi sort` would.
         info!("Generating records and sorting into template-coordinate order...");
 
+        // The sort produces same-MI-consecutive output, but `simulate` mints MI
+        // ids as a pre-sort counter, so the ids come out of the template-coordinate
+        // sort in position order rather than monotonically increasing in file
+        // order. The grouped-input engine (`fgumi compare bams --command group`,
+        // `compare::molecule`) treats a strictly-increasing MI base as the
+        // definition of grouped input and rejects anything else, so the sorted BAM
+        // is written to a temporary file first and then renumbered in a second
+        // streaming pass (`renumber_sorted_mi`) that mints a fresh base each time
+        // the MI base changes. The temp BAM is compressed at a fast level since it
+        // is immediately re-read and re-compressed at the requested output level by
+        // the renumber pass; the final output compression is applied there.
+        //
+        // Both final artifacts are staged to sibling temp paths and renamed into
+        // place only once *both* are fully written, so a failure never leaves a
+        // truncated BAM or a BAM whose ids no longer match its truth TSV. `temp_bam`
+        // holds the sort's fast-compressed output and `temp_truth` holds
+        // generation's pre-renumber truth; `staged_bam` and `staged_truth` hold the
+        // renumbered BAM and remapped truth before they are published.
+        let temp_bam = temp_sibling(&self.output, "sort");
+        let temp_truth = temp_sibling(&self.truth_output, "gen");
+        let staged_bam = temp_sibling(&self.output, "staged");
+        let staged_truth = temp_sibling(&self.truth_output, "staged");
+
         let sorter = self
             .sort_resources
             .apply(
                 RawExternalSorter::new(SortOrder::TemplateCoordinate)
                     .threads(self.threads)
-                    .output_compression(self.compression.compression_level)
+                    .output_compression(TEMP_BAM_COMPRESSION_LEVEL)
                     // grouped-reads always writes MI tags, so include the tertiary
                     // (library|mi) lane in the template-coordinate key rather than
                     // relying on first-record auto-detection (equivalent to
@@ -254,10 +280,10 @@ impl Command for GroupedReads {
             let generator = scope.spawn(|| {
                 self.generate_records(
                     sink,
+                    &temp_truth,
                     &params,
                     &ref_genome,
                     &position_table,
-                    num_positions,
                     &mut seed_rng,
                 )
             });
@@ -265,17 +291,223 @@ impl Command for GroupedReads {
             // Consumes `records`, so a sort failure drops the receiver and the
             // generator's next `send` returns false, unblocking it.
             sorter
-                .sort_records(into_record_stream(records), &header, &self.output)
+                .sort_records(into_record_stream(records), &header, &temp_bam)
                 .context("Failed to template-coordinate sort simulated reads")?;
 
             generator.join().unwrap_or_else(|payload| std::panic::resume_unwind(payload))
         })?;
+
+        // Renumber the sorted temp BAM and remap the truth TSV (written during
+        // generation with the pre-sort ids) into their staging paths, then publish
+        // both with renames only after both writes succeed.
+        info!("Renumbering molecule ids into monotonic file order...");
+        let publish = (|| -> Result<()> {
+            let old_to_new = renumber_sorted_mi(
+                &temp_bam,
+                &staged_bam,
+                self.threads,
+                self.compression.compression_level,
+            )
+            .context("Failed to renumber molecule ids in the sorted output")?;
+
+            remap_truth_mi(&temp_truth, &staged_truth, &old_to_new)
+                .context("Failed to remap molecule ids in the truth file")?;
+
+            // Publish both finals only after both staged files are complete, so a
+            // failure above never exposes a truncated BAM or a mismatched pair.
+            std::fs::rename(&staged_bam, &self.output)
+                .with_context(|| format!("Failed to publish {}", self.output.display()))?;
+            std::fs::rename(&staged_truth, &self.truth_output)
+                .with_context(|| format!("Failed to publish {}", self.truth_output.display()))?;
+            Ok(())
+        })();
+
+        // Always remove the sort/generation intermediates. Remove the staged finals
+        // only on failure (a successful publish renamed them away), leaving any
+        // pre-existing destinations untouched.
+        let _ = std::fs::remove_file(&temp_bam);
+        let _ = std::fs::remove_file(&temp_truth);
+        if publish.is_err() {
+            let _ = std::fs::remove_file(&staged_bam);
+            let _ = std::fs::remove_file(&staged_truth);
+        }
+        publish?;
 
         info!("Generated {total_pairs} read pairs");
         info!("Done");
 
         Ok(())
     }
+}
+
+/// Fast BGZF level for the intermediate sorted BAM.
+///
+/// The temp BAM is transient: it is re-read and re-compressed at the requested
+/// output level by [`renumber_sorted_mi`], so it is written at a fast level to
+/// avoid compressing the same records twice. The final output compression is
+/// applied by the renumber pass, not here.
+const TEMP_BAM_COMPRESSION_LEVEL: u32 = 1;
+
+/// Build a temporary sibling path next to `path`.
+///
+/// The intermediate lands on the same filesystem as the final output (so the
+/// renumber pass reads and writes the same disk, not a possibly-tmpfs `TMPDIR`),
+/// and the process id keeps concurrent runs writing distinct outputs from
+/// colliding on the temp name.
+fn temp_sibling(path: &Path, tag: &str) -> PathBuf {
+    let mut name = path.file_name().map(std::ffi::OsStr::to_os_string).unwrap_or_default();
+    name.push(format!(".{tag}.{}.tmp", std::process::id()));
+    path.with_file_name(name)
+}
+
+/// Split an MI tag value into its integer base and trailing strand suffix.
+///
+/// `b"381"` → `(381, b"")`; `b"381/A"` → `(381, b"/A")`. The suffix (including the
+/// `/`) is returned verbatim so duplex `/A`,`/B` strand labels round-trip
+/// unchanged when only the base is renumbered.
+fn split_mi_base(mi: &[u8]) -> Result<(u64, &[u8])> {
+    let split = mi.iter().position(|&c| c == b'/').unwrap_or(mi.len());
+    let (base_bytes, suffix) = mi.split_at(split);
+    let base = std::str::from_utf8(base_bytes)
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "MI tag {:?} does not start with an integer molecule id",
+                String::from_utf8_lossy(mi)
+            )
+        })?;
+    Ok((base, suffix))
+}
+
+/// Renumber the MI tags of a template-coordinate-sorted grouped BAM so molecule
+/// ids increase monotonically in file order.
+///
+/// Reads the sorted `input` — whose records are same-MI-consecutive but carry the
+/// pre-sort MI ids — mints a fresh base `1, 2, 3, …` each time the MI base
+/// changes, and writes the result to `output` at `compression_level`. Because
+/// each simulated molecule maps to a single position, its records form one
+/// contiguous run in template-coordinate order, so a monotonic counter over
+/// base changes yields strictly-increasing, same-MI-consecutive bases regardless
+/// of the pre-sort id order. Duplex `/A`,`/B` strands share a molecule (and a
+/// base), so the suffix is preserved and only the base is rewritten. Returns the
+/// `old base → new base` map so the truth TSV can be remapped to match.
+fn renumber_sorted_mi(
+    input: &Path,
+    output: &Path,
+    threads: usize,
+    compression_level: u32,
+) -> Result<HashMap<u64, u64>> {
+    let (mut reader, header) = create_raw_bam_reader(input, threads)?;
+    let mut writer = create_raw_bam_writer(output, &header, threads, compression_level)?;
+
+    let mut old_to_new: HashMap<u64, u64> = HashMap::new();
+    let mut current_old_base: Option<u64> = None;
+    let mut next_new_base: u64 = 0;
+    let mut mi_buf: Vec<u8> = Vec::new();
+
+    let mut record = RawRecord::default();
+    while reader.read_record(&mut record)? != 0 {
+        let mi = find_string_tag(aux_data_slice(record.as_ref()), SamTag::MI).ok_or_else(|| {
+            anyhow::anyhow!(
+                "simulated record is missing an MI tag; every grouped-reads record must be \
+                 MI-tagged"
+            )
+        })?;
+        let (old_base, suffix) = split_mi_base(mi)?;
+
+        // Records are same-MI-consecutive, so the base only changes at a molecule
+        // boundary. Mint a fresh, strictly-increasing base there; a duplex
+        // molecule's /A and /B strands share the base minted for its run.
+        let new_base = if current_old_base == Some(old_base) {
+            next_new_base
+        } else {
+            next_new_base += 1;
+            current_old_base = Some(old_base);
+            old_to_new.insert(old_base, next_new_base);
+            next_new_base
+        };
+
+        // `suffix` borrows `record`; capture the new value before the mutable
+        // borrow taken by `update_string_tag`.
+        mi_buf.clear();
+        write!(mi_buf, "{new_base}").expect("writing to a Vec cannot fail");
+        mi_buf.extend_from_slice(suffix);
+        update_string_tag(record.as_mut_vec(), SamTag::MI, &mi_buf);
+
+        writer.write_raw_record(record.as_ref())?;
+    }
+    writer.finish()?;
+    Ok(old_to_new)
+}
+
+/// Stream the truth TSV from `input` to `output`, rewriting the `molecule_id` and
+/// `mi_tag` columns so they match the renumbered BAM.
+///
+/// The truth file is written during generation with the pre-sort molecule ids
+/// (see [`GroupedReads::generate_records_inner`]); this maps both id columns
+/// through `old_to_new` so a consumer that joins the truth to the renumbered BAM
+/// by MI still lines up. Rows are read and written line by line (never buffering
+/// the whole file) to preserve the command's streaming design on large
+/// simulations. Every id that appears in the truth was emitted to the BAM (truth
+/// rows are written per generated pair), so an unmapped id is a bug rather than an
+/// expected case, and is surfaced as an error.
+fn remap_truth_mi(input: &Path, output: &Path, old_to_new: &HashMap<u64, u64>) -> Result<()> {
+    /// Column indices in the truth TSV header
+    /// (`read_name  true_umi  molecule_id  mi_tag  chrom  position  strand`).
+    const MOLECULE_ID_COL: usize = 2;
+    const MI_TAG_COL: usize = 3;
+
+    let reader = BufReader::new(
+        File::open(input)
+            .with_context(|| format!("Failed to read truth file {}", input.display()))?,
+    );
+    let mut writer = BufWriter::new(
+        File::create(output).with_context(|| format!("Failed to create {}", output.display()))?,
+    );
+
+    for (row, line) in reader.lines().enumerate() {
+        let line = line?;
+        // Row 0 is the column header; pass it through unchanged.
+        if row == 0 {
+            writeln!(writer, "{line}")?;
+            continue;
+        }
+
+        let mut cols: Vec<String> = line.split('\t').map(str::to_owned).collect();
+        anyhow::ensure!(
+            cols.len() > MI_TAG_COL,
+            "truth row has too few columns to remap: {line:?}"
+        );
+
+        let old_mol: u64 = cols[MOLECULE_ID_COL]
+            .parse()
+            .with_context(|| format!("truth molecule_id is not an integer: {line:?}"))?;
+        cols[MOLECULE_ID_COL] = lookup_new(old_to_new, old_mol)?.to_string();
+
+        // `split_mi_base` borrows `cols[MI_TAG_COL]`; own the suffix before the
+        // column is reassigned.
+        let (old_base, suffix) = {
+            let (base, suffix) = split_mi_base(cols[MI_TAG_COL].as_bytes())?;
+            (base, suffix.to_vec())
+        };
+        let new_base = lookup_new(old_to_new, old_base)?;
+        cols[MI_TAG_COL] = format!("{new_base}{}", String::from_utf8_lossy(&suffix));
+
+        writeln!(writer, "{}", cols.join("\t"))?;
+    }
+    writer.flush()?;
+    Ok(())
+}
+
+/// Look up a renumbered molecule id, erroring if the pre-sort id was never seen
+/// in the sorted BAM (which would mean the truth and BAM disagree on membership).
+fn lookup_new(old_to_new: &HashMap<u64, u64>, old_base: u64) -> Result<u64> {
+    old_to_new.get(&old_base).copied().ok_or_else(|| {
+        anyhow::anyhow!(
+            "truth references molecule id {old_base}, which is absent from the sorted BAM"
+        )
+    })
 }
 
 impl GroupedReads {
@@ -292,18 +524,18 @@ impl GroupedReads {
     fn generate_records(
         &self,
         mut sink: RecordSink,
+        truth_path: &Path,
         params: &GenerationParams,
         ref_genome: &ReferenceGenome,
         position_table: &[(usize, usize)],
-        num_positions: usize,
         seed_rng: &mut impl Rng,
     ) -> Result<usize> {
         let result = self.generate_records_inner(
             &mut sink,
+            truth_path,
             params,
             ref_genome,
             position_table,
-            num_positions,
             seed_rng,
         );
         match result {
@@ -327,15 +559,21 @@ impl GroupedReads {
     fn generate_records_inner(
         &self,
         sink: &mut RecordSink,
+        truth_path: &Path,
         params: &GenerationParams,
         ref_genome: &ReferenceGenome,
         position_table: &[(usize, usize)],
-        num_positions: usize,
         seed_rng: &mut impl Rng,
     ) -> Result<usize> {
-        // Create truth file
-        let truth_file = File::create(&self.truth_output)
-            .with_context(|| format!("Failed to create {}", self.truth_output.display()))?;
+        // `sample_positions` returns exactly one entry per requested position, so
+        // the table length is the position count the molecule stride wraps over.
+        let num_positions = position_table.len();
+
+        // Create truth file. This is a staging path (see `execute`): it holds the
+        // pre-renumber ids and is remapped and published only once the renumbered
+        // BAM is also written.
+        let truth_file = File::create(truth_path)
+            .with_context(|| format!("Failed to create {}", truth_path.display()))?;
         let mut truth_writer = BufWriter::new(truth_file);
         writeln!(
             truth_writer,
@@ -1638,5 +1876,28 @@ mod tests {
                  A-strand and a B-strand pair; saw_a={saw_a}, saw_b={saw_b}"
             );
         }
+    }
+
+    #[rstest]
+    #[case::simplex_zero(b"0", 0, b"")]
+    #[case::simplex(b"381", 381, b"")]
+    #[case::duplex_a(b"381/A", 381, b"/A")]
+    #[case::duplex_b(b"42/B", 42, b"/B")]
+    fn split_mi_base_parses_base_and_suffix(
+        #[case] mi: &[u8],
+        #[case] expected_base: u64,
+        #[case] expected_suffix: &[u8],
+    ) {
+        let (base, suffix) = split_mi_base(mi).expect("valid MI");
+        assert_eq!(base, expected_base);
+        assert_eq!(suffix, expected_suffix);
+    }
+
+    #[rstest]
+    #[case::empty(b"")]
+    #[case::non_numeric(b"abc")]
+    #[case::suffix_only(b"/A")]
+    fn split_mi_base_rejects_non_integer_base(#[case] mi: &[u8]) {
+        assert!(split_mi_base(mi).is_err(), "expected {mi:?} to be rejected");
     }
 }

--- a/tests/integration/test_e2e_regression.rs
+++ b/tests/integration/test_e2e_regression.rs
@@ -871,3 +871,180 @@ fn simulate_bam_commands_report_the_writer_error_not_the_send_failure(#[case] co
         "the send failure is the symptom, not the cause: {rendered}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Regression (#687): `simulate grouped-reads` output must be accepted by the
+// grouped-input engine it exists to feed.
+// ---------------------------------------------------------------------------
+
+/// Generate a `simulate grouped-reads` BAM, optionally in duplex mode.
+///
+/// Mirrors [`simulate_grouped_reads`] but adds `--duplex` when requested, so the
+/// regression test can cover both the simplex (`<id>`) and duplex (`<id>/A`,
+/// `<id>/B`) MI-tag shapes.
+fn simulate_grouped_reads_mode(
+    output: &Path,
+    truth: &Path,
+    reference: &Path,
+    seed: u32,
+    num_molecules: u32,
+    duplex: bool,
+) {
+    let num_molecules_str = num_molecules.to_string();
+    let seed_str = seed.to_string();
+    let mut argv: Vec<&OsStr> = vec![
+        OsStr::new("grouped-reads"),
+        OsStr::new("-o"),
+        output.as_os_str(),
+        OsStr::new("--truth"),
+        truth.as_os_str(),
+        OsStr::new("--reference"),
+        reference.as_os_str(),
+        OsStr::new("--num-molecules"),
+        OsStr::new(&num_molecules_str),
+        OsStr::new("--seed"),
+        OsStr::new(&seed_str),
+        OsStr::new("--read-length"),
+        OsStr::new("100"),
+        OsStr::new("--umi-length"),
+        OsStr::new("6"),
+        OsStr::new("--min-family-size"),
+        OsStr::new("2"),
+    ];
+    if duplex {
+        argv.push(OsStr::new("--duplex"));
+    }
+    let cmd = GroupedReads::try_parse_from(argv).expect("failed to parse grouped-reads args");
+    cmd.execute("fgumi simulate grouped-reads").expect("simulate grouped-reads failed");
+}
+
+/// Run `fgumi compare bams <a> <b> --command group` in-process, returning the raw
+/// `execute` result so the caller can distinguish a clean match (`Ok`) from the
+/// grouped-input precondition rejection (`Err`) that #687 is about.
+fn compare_bams_group_command(bam1: &Path, bam2: &Path) -> anyhow::Result<()> {
+    let cmd = CompareBams::try_parse_from([
+        OsStr::new("bams"),
+        bam1.as_os_str(),
+        bam2.as_os_str(),
+        OsStr::new("--command"),
+        OsStr::new("group"),
+    ])
+    .expect("failed to parse compare bams args");
+    cmd.execute("fgumi compare bams")
+}
+
+/// `simulate grouped-reads` exists to produce grouping test input, so its output
+/// must round-trip through the engine that consumes grouped BAMs: comparing the
+/// file against a byte-identical copy of itself must report a match, not fail the
+/// grouped-input precondition.
+///
+/// Regression test for #687: MI ids were minted as a pre-sort counter and emerged
+/// non-monotonic in the template-coordinate-sorted file, so
+/// `compare bams --command group` rejected `simulate`'s own output with
+/// "input is not grouped: MI base N is not greater than a previously seen base M".
+#[rstest]
+#[case::simplex(false)]
+#[case::duplex(true)]
+fn simulate_grouped_reads_roundtrips_through_compare_group(#[case] duplex: bool) {
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    let reference = create_test_reference(tmp.path());
+    let bam = tmp.path().join("grouped.bam");
+    let truth = tmp.path().join("truth.tsv");
+    simulate_grouped_reads_mode(&bam, &truth, &reference, 42, 500, duplex);
+
+    // A byte-identical copy: comparing a file against itself cannot legitimately
+    // DIFFER, so any failure here is the grouped-input precondition rejecting the
+    // simulated input, not a comparison result.
+    let copy = tmp.path().join("grouped.copy.bam");
+    std::fs::copy(&bam, &copy).expect("copy grouped bam");
+
+    compare_bams_group_command(&bam, &copy).unwrap_or_else(|e| {
+        panic!(
+            "`compare bams --command group` rejected simulate grouped-reads output \
+             (duplex={duplex}): {e:#}"
+        )
+    });
+}
+
+/// The truth TSV must stay consistent with the renumbered BAM. After #687's
+/// post-sort MI renumber, a consumer that joins truth rows to BAM records by read
+/// name must still see the same MI: this asserts every BAM record's MI equals its
+/// truth row's `mi_tag`, the truth `molecule_id` equals the MI base, and the
+/// renumbered bases are exactly `1..=N` in file order (monotonic and contiguous).
+#[rstest]
+#[case::simplex(false)]
+#[case::duplex(true)]
+fn simulate_grouped_reads_truth_matches_renumbered_bam(#[case] duplex: bool) {
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    let reference = create_test_reference(tmp.path());
+    let bam = tmp.path().join("grouped.bam");
+    let truth = tmp.path().join("truth.tsv");
+    simulate_grouped_reads_mode(&bam, &truth, &reference, 7, 300, duplex);
+
+    // truth: read_name -> (molecule_id, mi_tag)
+    let truth_txt = std::fs::read_to_string(&truth).expect("read truth");
+    let mut truth_by_name: std::collections::HashMap<String, (String, String)> =
+        std::collections::HashMap::new();
+    let mut lines = truth_txt.lines();
+    lines.next().expect("truth header"); // skip header
+    for line in lines {
+        let cols: Vec<&str> = line.split('\t').collect();
+        assert!(cols.len() > 3, "malformed truth row: {line:?}");
+        // Reject duplicate read names: each pair has a unique name, and a
+        // silently-overwritten row would let a stale/duplicate entry pass the
+        // relation check below.
+        let prior =
+            truth_by_name.insert(cols[0].to_string(), (cols[2].to_string(), cols[3].to_string()));
+        assert!(prior.is_none(), "duplicate truth read name: {}", cols[0]);
+    }
+
+    let mut prev_base: Option<u64> = None;
+    let mut distinct_bases: Vec<u64> = Vec::new();
+    let mut bam_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for bytes in read_all_record_bytes(&bam) {
+        let view = fgumi_raw_bam::RawRecordView::new(&bytes);
+        let qname: String =
+            String::from_utf8(view.read_name().iter().copied().take_while(|&b| b != 0).collect())
+                .expect("read name is UTF-8");
+        let mi_bytes = fgumi_raw_bam::find_string_tag_in_record(&bytes, SamTag::MI)
+            .expect("record has MI tag");
+        let mi = std::str::from_utf8(mi_bytes).expect("MI is UTF-8").to_string();
+
+        let (truth_mol_id, truth_mi) = truth_by_name
+            .get(&qname)
+            .unwrap_or_else(|| panic!("BAM read {qname} absent from truth"));
+        assert_eq!(&mi, truth_mi, "BAM MI != truth mi_tag for {qname} (duplex={duplex})");
+
+        let base: u64 = mi.split('/').next().unwrap().parse().expect("MI base is an integer");
+        assert_eq!(
+            &base.to_string(),
+            truth_mol_id,
+            "truth molecule_id != MI base for {qname} (duplex={duplex})"
+        );
+
+        if prev_base != Some(base) {
+            if let Some(p) = prev_base {
+                assert!(base > p, "MI base not strictly increasing in file order: {p} then {base}");
+            }
+            distinct_bases.push(base);
+            prev_base = Some(base);
+        }
+        bam_names.insert(qname);
+    }
+
+    let n = distinct_bases.len() as u64;
+    assert_eq!(
+        distinct_bases,
+        (1..=n).collect::<Vec<_>>(),
+        "renumbered bases must be exactly 1..=N in file order (duplex={duplex})"
+    );
+
+    // Check the relation in both directions: every truth row is realized in the
+    // BAM and vice versa, so a stale/extra truth row (or a dropped BAM read) fails
+    // rather than slipping through the per-record lookup above.
+    let truth_names: std::collections::HashSet<String> = truth_by_name.into_keys().collect();
+    assert_eq!(
+        bam_names, truth_names,
+        "BAM read-name set != truth read-name set (duplex={duplex})"
+    );
+}


### PR DESCRIPTION
## Problem

`fgumi simulate grouped-reads` mints MI (molecule id) tags as a sequential counter at generation time, then streams records into the canonical template-coordinate sorter. That sort reorders molecules by genomic position, so the emitted MI ids are same-MI-consecutive but **not** monotonically increasing in file order.

`fgumi compare bams --command group` — the engine `simulate grouped-reads` exists to feed — enforces strictly-increasing MI bases as its definition of grouped input (an O(1) stand-in for "no MI base reappears later"). So it rejected `simulate`'s own output outright:

```
Error: input is not grouped: MI base 29977 is not greater than a previously seen base 93481; grouping comparison requires same-MI-consecutive (grouped) input with monotonically increasing molecule ids
```

Comparing a file against a byte-identical copy of itself cannot legitimately fail, so this was the simulated input being rejected, not a comparison result.

Closes #687.

## Approach

Rather than changing the shared `fgumi-sort` engine, the fix is localized to `simulate`:

1. Sort into a **fast (BGZF level 1), multithreaded** temporary BAM. Compression is paid once, at the requested output level in step 2 — not twice.
2. **Renumber pass** (`renumber_sorted_mi`): stream the sorted temp BAM, minting a fresh MI base `1, 2, 3, …` each time the MI base changes, and write the final output at the requested compression level. Each simulated molecule maps to a single position, so its records form one contiguous run in template-coordinate order — a monotonic counter over base changes therefore yields strictly-increasing, same-MI-consecutive bases regardless of the pre-sort id order. Duplex `/A`,`/B` strands share a molecule (and a base), so the suffix is preserved and only the base is rewritten.
3. **Truth remap** (`remap_truth_mi`): the truth TSV is written during generation with the pre-sort ids, so its `molecule_id` and `mi_tag` columns are remapped through the same `old → new` map, keeping truth joinable to the renumbered BAM by MI.

The temp BAM is written next to the final output (same filesystem, not a possibly-tmpfs `TMPDIR`) and removed once the final output is in place.

## Tests

- `simulate_grouped_reads_roundtrips_through_compare_group` (simplex + duplex) — the issue's exact reproducer: generate, copy, then `compare bams --command group` must report a match. Red before the fix, green after.
- `simulate_grouped_reads_truth_matches_renumbered_bam` (simplex + duplex) — every BAM record's MI equals its truth row's `mi_tag`, the truth `molecule_id` equals the MI base, and the renumbered bases are exactly `1..=N` in file order.
- `split_mi_base` rstest cases — base/suffix parsing and rejection of non-integer bases.

Verified with `cargo ci-test` (targeted), `cargo ci-lint`, and `cargo ci-fmt` (all clean). Real-binary smoke at 100k molecules / `--threads 4`: `compare --command group` reports equivalent, `sort --verify` passes, and MI bases emerge `1..12` monotonic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: changes `simulate grouped-reads` BAM and truth TSV output, pinned by sorted-file MI renumbering and truth remapping; no `unsafe` changes, and no CLAUDE.md allowlist update applies; no memory bound, queue capacity, or thread/backpressure policy changes.

`simulate grouped-reads` now sorts records into a temporary BAM, renumbers MI bases in file order, preserves duplex suffixes, and remaps truth TSV identifiers. The temporary BAM is removed after final output creation.

Added simplex and duplex integration tests for grouped comparison, MI ordering, and truth-to-BAM consistency. Added tests for MI parsing and invalid MI values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->