### PR TITLE
perf(sort): overlap key extraction, reuse arena pages, and read with real queue depth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,16 @@ of records) and a safe rewrite measurably regresses sort throughput.
   `RawQuerynameKey::new`).
 - **`crates/fgumi-sort/src/radix.rs`** — internal radix-sort helpers; see file
   comments for the `SAFETY:` invariants.
+- **`crates/fgumi-sort/src/phase1_keys.rs`** — one `#[allow(unsafe_code)]` site in
+  `prefetch_read_l1`, a software-prefetch hint issued while a deferred key batch
+  scans record bodies out of a sealed arena segment. Those bytes were written up
+  to a segment ago and are cold by the time a worker reads them, so the scan is
+  latency-bound on cache misses. SAFETY: both `prfm pldl1keep` (aarch64) and
+  `_mm_prefetch` (x86_64) are *non-faulting hints* — they never read or write
+  observable memory and never trap, even on an unmapped address — and the
+  argument is a live `&u8`, so the pointer is valid to name. A no-op on other
+  architectures. Approved for the same reason as the other sort hot paths: it
+  runs once per record over hundreds of millions of records.
 
 ### Approved natural-order comparator (fgumi-raw-bam)
 

--- a/crates/fgumi-sort/examples/read_ladder.rs
+++ b/crates/fgumi-sort/examples/read_ladder.rs
@@ -96,6 +96,57 @@ enum Pattern {
     Interleaved,
 }
 
+/// What the reader tells the kernel about the access pattern it is about to make.
+///
+/// The question these exist to answer: a blocking `read()` keeps roughly one
+/// read-ahead window outstanding at the device, and on this volume that is ~3x
+/// too little to saturate it (358 MB/s single-stream against a ~1050 MB/s cap).
+/// Four threads fix that by carrying four windows. These advise calls try to fix
+/// it *without* extra threads, by asking the kernel to keep the queue primed on
+/// a single ordered stream -- which, unlike parallel streams, cannot deliver
+/// blocks out of order.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Advice {
+    /// No hint: the default read-ahead window and nothing else.
+    None,
+    /// `POSIX_FADV_SEQUENTIAL` once per stream. Linux doubles the read-ahead
+    /// window for the file; a 2x lever at most.
+    Sequential,
+    /// `POSIX_FADV_WILLNEED` for a window ahead of the cursor, reissued as the
+    /// cursor advances. Not bounded by the read-ahead window, so this is the one
+    /// that can actually fill the device queue.
+    WillNeed,
+}
+
+/// Issue one `posix_fadvise` call, or do nothing where it does not exist.
+///
+/// Errors are deliberately ignored: `fadvise` is a *hint*, and a kernel that
+/// declines it (memory pressure, an unsupported filesystem) must not fail the
+/// read. A hint that was dropped shows up as a throughput number that did not
+/// move, which is exactly the result the experiment is testing for.
+#[cfg(target_os = "linux")]
+fn advise(file: &File, offset: u64, len: u64, advice: nix::fcntl::PosixFadviseAdvice) {
+    let offset = i64::try_from(offset).unwrap_or(i64::MAX);
+    let len = i64::try_from(len).unwrap_or(i64::MAX);
+    let _ = nix::fcntl::posix_fadvise(file, offset, len, advice);
+}
+
+#[cfg(target_os = "linux")]
+fn advise_sequential(file: &File, offset: u64, len: u64) {
+    advise(file, offset, len, nix::fcntl::PosixFadviseAdvice::POSIX_FADV_SEQUENTIAL);
+}
+
+#[cfg(target_os = "linux")]
+fn advise_willneed(file: &File, offset: u64, len: u64) {
+    advise(file, offset, len, nix::fcntl::PosixFadviseAdvice::POSIX_FADV_WILLNEED);
+}
+
+#[cfg(not(target_os = "linux"))]
+fn advise_sequential(_file: &File, _offset: u64, _len: u64) {}
+
+#[cfg(not(target_os = "linux"))]
+fn advise_willneed(_file: &File, _offset: u64, _len: u64) {}
+
 struct Args {
     rung: String,
     path: PathBuf,
@@ -106,6 +157,9 @@ struct Args {
     chunk_bytes: u64,
     writer_mbps: u64,
     writer_dir: Option<PathBuf>,
+    advice: Advice,
+    /// Bytes ahead of the cursor to keep advised, for `Advice::WillNeed`.
+    advise_ahead: u64,
 }
 
 fn parse_args() -> Result<Args> {
@@ -121,6 +175,11 @@ fn parse_args() -> Result<Args> {
     let mut chunk_bytes = 4 * 1024 * 1024u64;
     let mut writer_mbps = 0u64;
     let mut writer_dir = None;
+    let mut advice = Advice::None;
+    // 8 MiB: four 2 MiB reads of lead, comfortably more than the ~400 KB the
+    // device's bandwidth-delay product asks for, so a null result cannot be
+    // blamed on advising too little.
+    let mut advise_ahead = 8 * 1024 * 1024u64;
     while let Some(flag) = it.next() {
         let value = it.next().with_context(|| format!("{flag} needs a value"))?;
         match flag.as_str() {
@@ -142,6 +201,15 @@ fn parse_args() -> Result<Args> {
             }
             "--chunk" => chunk_bytes = value.parse().context("--chunk")?,
             "--writer-mbps" => writer_mbps = value.parse().context("--writer-mbps")?,
+            "--fadvise" => {
+                advice = match value.as_str() {
+                    "none" => Advice::None,
+                    "sequential" => Advice::Sequential,
+                    "willneed" => Advice::WillNeed,
+                    other => bail!("--fadvise must be none|sequential|willneed, got {other}"),
+                };
+            }
+            "--advise-ahead" => advise_ahead = value.parse().context("--advise-ahead")?,
             "--writer-dir" => writer_dir = Some(PathBuf::from(value)),
             other => bail!("unknown flag {other}"),
         }
@@ -175,6 +243,8 @@ fn parse_args() -> Result<Args> {
         chunk_bytes,
         writer_mbps,
         writer_dir,
+        advice,
+        advise_ahead,
     })
 }
 
@@ -255,15 +325,38 @@ fn rung_raw(args: &Args) -> Result<Tally> {
         let chunk = args.chunk_bytes;
         let start = stream * span;
         let end = ((stream + 1) * span).min(total);
+        let advice = args.advice;
+        let advise_ahead = args.advise_ahead;
         handles.push(std::thread::spawn(move || -> Result<u64> {
             let mut buf = vec![0u8; buf_bytes];
             let mut read_total = 0u64;
+            if advice == Advice::Sequential {
+                advise_sequential(&file, start, end.saturating_sub(start));
+            }
             match pattern {
                 Pattern::Contiguous => {
                     let mut offset = start;
+                    // Prime the queue before the first read, so the very first
+                    // call is not the one uncovered case.
+                    if advice == Advice::WillNeed {
+                        advise_willneed(&file, offset, advise_ahead.min(end - offset));
+                    }
                     while offset < end {
                         let want = usize::try_from((end - offset).min(buf_bytes as u64))
                             .expect("clamped to buffer size");
+                        // Advise the window *beyond* what this read will consume,
+                        // so the device is working on the next span while this
+                        // one is being copied out.
+                        if advice == Advice::WillNeed {
+                            let ahead_start = offset + want as u64;
+                            if ahead_start < end {
+                                advise_willneed(
+                                    &file,
+                                    ahead_start,
+                                    advise_ahead.min(end - ahead_start),
+                                );
+                            }
+                        }
                         let n = file.read_at(&mut buf[..want], offset)?;
                         if n == 0 {
                             break;

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -6522,6 +6522,31 @@ pub(crate) use crate::SortStats as RawSortStats;
 // rather than in `fgumi-bam-io`.
 // ============================================================================
 
+/// Fills the phase-1 input reader keeps in flight ahead of the framer.
+///
+/// One, and deeper does not help. Swept in a single boot on
+/// `1kg-wgs-HG00096` (t16, 4 streams), read span against total wall:
+///
+/// | depth | read span | wall |
+/// | --- | --- | --- |
+/// | 0 | 69.4s | 271.8s |
+/// | 1 | 66.9s | 267.7s |
+/// | 2 | 66.7s | 269.4s |
+/// | 4 | 66.4s | 268.5s |
+///
+/// Depths 2 and 4 move the span by less than a second and the wall clock not
+/// at all -- all three sit inside the +/-0.7% in-boot noise floor -- and depth
+/// 2 cost 277 MB of peak RSS for it. One is enough because the span is not
+/// fetch-bound: the fetch runs at 1327 MB/s and takes 32.5s of a 66.4s span
+/// against an ingest-serial floor of 53.0s, so what is left is coordination
+/// between the reader, the decompress workers and the ingest thread, which no
+/// amount of read-ahead touches.
+///
+/// Costs `(n + 1) * FILL_BYTES` of buffers on one reader, which is also why
+/// the merge's spill readers -- there are K of them, and the merge is already
+/// at its consumer-serial floor -- get none.
+const PHASE1_LOOKAHEAD_FILLS: usize = 1;
+
 /// Create a raw BAM reader using the pool's Phase 1 integrated reading.
 ///
 /// Workers in the pool do `ReadInputBlocks` + `DecompressInput`. The main
@@ -6595,8 +6620,9 @@ fn create_raw_bam_reader_pool_integrated<P: AsRef<Path>>(
                 read_streams,
                 Some(pool.fetch_queue()),
             )
-            .map(|reader| reader.timed(Arc::clone(&reader_stats)))
-            {
+            .map(|reader| {
+                reader.timed(Arc::clone(&reader_stats)).looking_ahead(PHASE1_LOOKAHEAD_FILLS)
+            }) {
                 Ok(reader) => {
                     log::debug!(
                         "scattered sort reader: {read_streams} streams over {}",

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -250,7 +250,7 @@ impl SortPhaseTimer {
         sort_threads: usize,
         merge_threads: usize,
         max_temp_files: usize,
-        phase1: Phase1FloorInputs,
+        phase1: &Phase1FloorInputs,
     ) {
         let overall = self.overall_start.map_or(0.0, |s| s.elapsed().as_secs_f64());
         // Guard against division by zero when sort completes in negligible time.
@@ -314,7 +314,7 @@ impl SortPhaseTimer {
     /// with its main thread 91% busy while 16 cores average 5.3. If that holds
     /// in-process, the binding limit is the ingest thread and no amount of
     /// additional worker capacity moves it.
-    fn log_phase1_floor(&self, phase1: Phase1FloorInputs) {
+    fn log_phase1_floor(&self, phase1: &Phase1FloorInputs) {
         if self.read_secs <= 0.0 {
             return;
         }
@@ -360,7 +360,7 @@ impl SortPhaseTimer {
                 ingest.spill_waits
             );
         }
-        Self::log_reader_partition(phase1.reader);
+        Self::log_reader_partition(&phase1.reader);
         self.log_ingest_partition(phase1);
     }
 
@@ -379,7 +379,7 @@ impl SortPhaseTimer {
     /// only the step total gives a number -- 24.3 us/block on the production
     /// cell -- that is consistent with either being the whole cost.
     #[allow(clippy::cast_precision_loss, reason = "call and byte counts stay below 2^52")]
-    fn log_reader_partition(reader: crate::phase1_stats::ReaderReport) {
+    fn log_reader_partition(reader: &crate::phase1_stats::ReaderReport) {
         if reader.batches == 0 {
             return;
         }
@@ -414,6 +414,26 @@ impl SortPhaseTimer {
             reader.dispatch_secs,
             reader.per_block_micros(reader.dispatch_secs)
         );
+        stat!("    refill latency: {}", reader.refill_latency.summary());
+        // The discriminator. A `read()` that got slower because the thread kept
+        // losing the CPU shows runqueue wait and extra timeslices; one that got
+        // slower because the device or the memory system delivered fewer bytes
+        // per second shows neither, because the thread was blocked on I/O
+        // throughout. Wall-clock timing cannot separate those, and the whole
+        // question of what a busier worker pool does to the reader turns on it.
+        if reader.refill_sched_samples > 0 {
+            stat!(
+                "    refill scheduling: runqueue wait {:.2}s ({:.1}% of refill), on-CPU {:.2}s, \
+                 {} timeslices over {} sampled calls",
+                reader.refill_runqueue_secs,
+                100.0 * reader.refill_runqueue_share(),
+                reader.refill_oncpu_secs,
+                reader.refill_timeslices,
+                reader.refill_sched_samples,
+            );
+        } else {
+            stat!("    refill scheduling: unavailable (needs /proc/thread-self/schedstat)");
+        }
         stat!(
             "    unattributed: {:.1}s ({:.0}% of the step)",
             reader.residual_secs(),
@@ -428,7 +448,7 @@ impl SortPhaseTimer {
     /// correction by the scale factor, which on a 1-in-1021 sample is three
     /// orders of magnitude.
     #[allow(clippy::cast_precision_loss, reason = "record counts stay below 2^52")]
-    fn log_ingest_partition(&self, phase1: Phase1FloorInputs) {
+    fn log_ingest_partition(&self, phase1: &Phase1FloorInputs) {
         if phase1.samples == 0 || phase1.records == 0 {
             return;
         }
@@ -3669,7 +3689,9 @@ impl RawExternalSorter {
                     },
                 )?);
 
-                buffer.clear();
+                // Keep the arena's pages mapped for the next chunk; `clear` would
+                // hand them back and cost a minor fault per page on the refill.
+                buffer.reset_for_reuse();
                 force_mi_collect();
                 probe.post_spill(Some(pool.phase1_queue_depths()));
                 timer.begin_read_span();
@@ -3773,7 +3795,7 @@ impl RawExternalSorter {
             self.phase1_threads(),
             self.phase2_threads(),
             self.max_temp_files,
-            phase1_floor,
+            &phase1_floor,
         );
         debug!("Sort complete: {} records processed", stats.total_records);
 
@@ -3880,7 +3902,9 @@ impl RawExternalSorter {
                     },
                 )?);
 
-                buffer.clear();
+                // Keep the arena's pages mapped for the next chunk; `clear` would
+                // hand them back and cost a minor fault per page on the refill.
+                buffer.reset_for_reuse();
                 force_mi_collect();
                 probe.post_spill(Some(pool.phase1_queue_depths()));
                 timer.begin_read_span();
@@ -3995,7 +4019,7 @@ impl RawExternalSorter {
             self.phase1_threads(),
             self.phase2_threads(),
             self.max_temp_files,
-            phase1_floor,
+            &phase1_floor,
         );
         debug!("Sort complete: {} records processed", stats.total_records);
 
@@ -4293,7 +4317,7 @@ impl RawExternalSorter {
             self.phase1_threads(),
             self.phase2_threads(),
             self.max_temp_files,
-            phase1_floor,
+            &phase1_floor,
         );
         debug!("Sort complete: {} records processed", stats.total_records);
 
@@ -4604,7 +4628,9 @@ impl RawExternalSorter {
                     },
                 )?);
 
-                buffer.clear();
+                // Keep the arena's pages mapped for the next chunk; `clear` would
+                // hand them back and cost a minor fault per page on the refill.
+                buffer.reset_for_reuse();
                 deferred.reset();
                 force_mi_collect();
                 probe.post_spill(Some(pool.phase1_queue_depths()));
@@ -4622,6 +4648,11 @@ impl RawExternalSorter {
         // report a shorter span, which is the one way this optimization could
         // look successful while doing nothing.
         let violation = deferred.finish(&mut buffer, &pool)?;
+
+        // Ingest is over, so the arena segments held for the next chunk have no
+        // next chunk. Holding them through the merge costs peak RSS and buys
+        // nothing.
+        buffer.release_retained();
 
         timer.end_read_span();
 
@@ -4725,7 +4756,7 @@ impl RawExternalSorter {
             self.phase1_threads(),
             self.phase2_threads(),
             self.max_temp_files,
-            phase1_floor,
+            &phase1_floor,
         );
         debug!("Sort complete: {} records processed", stats.total_records);
 
@@ -9750,7 +9781,7 @@ mod tests {
 
         // log_summary must not panic (output goes to log sink). `consolidate_count`
         // is 1 here, so the consolidation branch is exercised too.
-        timer.log_summary(4, 4, 64, Phase1FloorInputs::default());
+        timer.log_summary(4, 4, 64, &Phase1FloorInputs::default());
     }
 
     // ========================================================================

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -454,16 +454,6 @@ impl SortPhaseTimer {
             partition.park_secs
         );
         stat!(
-            "      extract key:       {:.1}s ({:.0} ns/rec)",
-            segments.key,
-            per_record(segments.key)
-        );
-        stat!(
-            "      verify lanes:      {:.1}s ({:.0} ns/rec)",
-            segments.verify,
-            per_record(segments.verify)
-        );
-        stat!(
             "      push to arena:     {:.1}s ({:.0} ns/rec)",
             segments.push,
             per_record(segments.push)
@@ -478,6 +468,25 @@ impl SortPhaseTimer {
             segments.probe,
             per_record(segments.probe)
         );
+        // Exact, not sampled, and reported outside the partition above: both
+        // costs are per-batch or per-chunk, so the per-record sampler cannot see
+        // them honestly. `dispatch` is what deferral costs the serial thread;
+        // `barrier` is the extraction the pool failed to hide.
+        let census = phase1.key_overlap;
+        if let Some(pct) = census.overlap_percent() {
+            stat!(
+                "    Deferred key extraction: {pct:.1}% overlapped ({} of {} records; \
+                 {} keyed at a barrier)",
+                census.overlapped_records,
+                census.total_records(),
+                census.barrier_records,
+            );
+            stat!(
+                "      dispatch (exact):  {:.1}s      barrier wait (exact): {:.1}s",
+                census.dispatch_secs,
+                census.barrier_secs,
+            );
+        }
         // Signed: a negative residual means the segments over-attribute, which is
         // the failure mode this partition exists to make visible.
         stat!(
@@ -516,6 +525,9 @@ pub(crate) struct Phase1FloorInputs {
     /// this is order-independent -- every sort order reads the same way -- so it
     /// is filled in on all four paths.
     pub(crate) reader: crate::phase1_stats::ReaderReport,
+    /// What deferred key extraction achieved, on the orders that defer it
+    /// (template-coordinate). Default (all zero) elsewhere.
+    pub(crate) key_overlap: crate::phase1_keys::KeyOverlapCensus,
 }
 
 /// Deterministic hasher for cell barcode hashing in template-coordinate sort.
@@ -748,6 +760,15 @@ type RgOrdinalMap = HashMap<Vec<u8>, u32, ahash::RandomState>;
 ///
 /// Pre-computes ordinals by sorting library names alphabetically.
 /// Empty/unknown library sorts first (ordinal 0).
+///
+/// `Clone` is derived so the deferred key-extraction context can own a copy
+/// rather than borrow one, and it is **seed-preserving on purpose**: cloning
+/// `ahash::RandomState` copies its keys rather than drawing new ones, so a clone
+/// hashes read names identically to its original. Anything that reseeded here
+/// would change the template-coordinate sort key and break byte-identity
+/// silently — the output would still be correctly sorted, just not the same
+/// order twice.
+#[derive(Clone)]
 pub struct LibraryLookup {
     /// RG ID -> library ordinal
     rg_to_ordinal: RgOrdinalMap,
@@ -4442,24 +4463,31 @@ impl RawExternalSorter {
         debug!("Phase 1: Reading and sorting chunks (inline buffer)...");
         let mut probe = SpillProbe::new("phase1");
 
-        // Process the captured first record before draining the rest: extract its
-        // full key, verify the dropped lanes match `first` (trivially true for the
-        // first record itself), and push the narrowed key. A single record cannot
-        // exceed the memory limit, so no spill check is needed here.
+        // Key extraction runs on the pool, not here: at 120 ns/record it was the
+        // single largest cost on this thread (93.6s of a 137.5s ingest against a
+        // 145.4s read span), and it has no ordering requirement. The ingest
+        // thread now pushes bytes and hands out batches; `deferred` cuts them,
+        // the pool runs them, and the keys are spliced back before any sort.
+        let mut deferred = crate::phase1_keys::DeferredKeys::<K>::new(
+            Arc::new(crate::phase1_keys::KeyContext {
+                lib_lookup: lib_lookup.clone(),
+                cell_tag: self.cell_tag,
+                cb_hasher: cb_hasher.clone(),
+                first_key: first,
+                variant,
+            }),
+            self.phase1_threads(),
+        );
+
+        // Process the captured first record before draining the rest. Its key is
+        // deferred like every other record's, including the dropped-lane verify
+        // (trivially satisfied for the first record, since it *is* the baseline).
+        // A single record cannot exceed the memory limit, so no spill check is
+        // needed here.
         if let Some(record) = first_record {
             stats.total_records += 1;
             progress_batch.tick(&progress);
-
-            let bam_bytes = record.as_ref();
-            let full = extract_template_key_inline(bam_bytes, lib_lookup, self.cell_tag, cb_hasher);
-            if let Some(violation) = verify_dropped_lanes(&first, &full, variant) {
-                let name = String::from_utf8_lossy(
-                    fgumi_raw_bam::RawRecordView::new(bam_bytes).read_name(),
-                )
-                .into_owned();
-                return Err(dropped_lane_error(&name, violation));
-            }
-            buffer.push(bam_bytes, K::from_full(&full))?;
+            deferred.push(&mut buffer, &pool, record.as_ref())?;
         }
 
         // Sub-phase timing for the ingest thread's serial CPU, which the floor
@@ -4502,35 +4530,24 @@ impl RawExternalSorter {
                 ingest_raw.tick += t0.elapsed().as_secs_f64();
             }
 
-            // Extract the full template key, verify the lanes the chosen variant
-            // dropped are constant relative to the first record, then push the
-            // narrowed key.
+            // Push the bytes and get a key onto them. With workers to spare the
+            // key is extracted on the pool and spliced in before anything sorts
+            // this buffer; with a single worker it is extracted right here, as
+            // it always was. `push` therefore covers extraction on the
+            // single-worker path and not on the deferred one -- read it against
+            // the deferred-extraction census below, not on its own.
             let t = sample_this.then(Instant::now);
-            let full = extract_template_key_inline(bam_bytes, lib_lookup, self.cell_tag, cb_hasher);
-            if let Some(t0) = t {
-                ingest_raw.key += t0.elapsed().as_secs_f64();
-            }
-            let t = sample_this.then(Instant::now);
-            let violation = verify_dropped_lanes(&first, &full, variant);
-            if let Some(t0) = t {
-                ingest_raw.verify += t0.elapsed().as_secs_f64();
-            }
-            if let Some(violation) = violation {
-                let name = String::from_utf8_lossy(
-                    fgumi_raw_bam::RawRecordView::new(bam_bytes).read_name(),
-                )
-                .into_owned();
-                return Err(dropped_lane_error(&name, violation));
-            }
-            let t = sample_this.then(Instant::now);
-            buffer.push(bam_bytes, K::from_full(&full))?;
+            deferred.push(&mut buffer, &pool, bam_bytes)?;
             if let Some(t0) = t {
                 ingest_raw.push += t0.elapsed().as_secs_f64();
             }
 
             let t = sample_this.then(Instant::now);
             let should_probe = probe.should_sample_read(stats.total_records);
-            let over_limit = buffer.memory_usage() >= self.memory_limit;
+            // Records whose keys are still in flight are charged here, so a
+            // lagging pool cannot let the buffer overrun the memory limit.
+            let over_limit =
+                buffer.memory_usage() + deferred.in_flight_bytes() >= self.memory_limit;
             if let Some(t0) = t {
                 ingest_raw.probe += t0.elapsed().as_secs_f64();
             }
@@ -4540,6 +4557,16 @@ impl RawExternalSorter {
 
             // Check memory usage
             if over_limit {
+                // Finish the chunk's keys *inside* the read span. This is ingest
+                // work for records already read, and accounting it to the spill
+                // region instead would let a pool that never keeps up still
+                // report a shorter read span -- the one way this change could
+                // look successful while doing nothing.
+                let violation = deferred.finish(&mut buffer, &pool)?;
+                if let Some(v) = violation {
+                    return Err(dropped_lane_error(&v.name, v.violation));
+                }
+
                 timer.end_read_span();
                 let bstats = probe_stats(&buffer);
                 let depths = Some(pool.phase1_queue_depths());
@@ -4578,13 +4605,30 @@ impl RawExternalSorter {
                 )?);
 
                 buffer.clear();
+                deferred.reset();
                 force_mi_collect();
                 probe.post_spill(Some(pool.phase1_queue_depths()));
                 timer.begin_read_span();
             }
         }
 
+        // Drain the tail before closing the read span: the records still held in
+        // the live arena segment have no keys yet, and everything below this
+        // point either sorts or spills the buffer.
+        //
+        // Inside the span on purpose. This is ingest work for records already
+        // read, and the read span is the number this whole change is trying to
+        // move -- excluding the drain would let a pool that never kept up still
+        // report a shorter span, which is the one way this optimization could
+        // look successful while doing nothing.
+        let violation = deferred.finish(&mut buffer, &pool)?;
+
         timer.end_read_span();
+
+        if let Some(v) = violation {
+            return Err(dropped_lane_error(&v.name, v.violation));
+        }
+
         progress_batch.flush(&progress);
         progress.log_final();
         if let Some(err) = record_source.take_error() {
@@ -4611,6 +4655,7 @@ impl RawExternalSorter {
             threads: self.phase1_threads(),
             ingest: pool.phase1_ingest_stats().snapshot(),
             reader: pool.phase1_reader_report(),
+            key_overlap: deferred.overlap_census(),
             sample: ingest_raw,
             samples: ingest_samples,
             records: stats.total_records,
@@ -6738,7 +6783,7 @@ pub fn verify_dropped_lanes(
 }
 
 /// Build the actionable error message for a dropped-lane violation.
-fn dropped_lane_error(name: &str, v: DroppedLaneViolation) -> anyhow::Error {
+pub(crate) fn dropped_lane_error(name: &str, v: DroppedLaneViolation) -> anyhow::Error {
     let field = match v {
         DroppedLaneViolation::Cb => "CB",
         DroppedLaneViolation::Mi => "MI",

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -2616,9 +2616,9 @@ pub struct RawExternalSorter {
     /// a modest allocation and let `Vec` grow on demand, while explicit limits
     /// pre-allocate the full budget upfront (preserving prior behavior).
     initial_capacity: Option<usize>,
-    /// Prefetch streams for a seekable input; 1 keeps the single sequential
-    /// reader. See [`crate::parallel_reader`] for why more than one is needed.
-    read_streams: usize,
+    /// How the input and the merge's spill files are read. See
+    /// `spill_reader` for why more than one stream is needed.
+    read_streams: ReadStreams,
     /// Which optional template-key lanes to retain (template-coordinate only).
     ///
     /// Defaults to [`KeyTypesSpec::Auto`], which provisions the narrowest key
@@ -2726,7 +2726,7 @@ impl RawExternalSorter {
             max_temp_files: crate::fd_limit::FALLBACK_MAX_TEMP_FILES,
             cell_tag: None,
             initial_capacity: None,
-            read_streams: 1,
+            read_streams: ReadStreams::default(),
             key_types: KeyTypesSpec::default(),
         }
     }
@@ -2930,15 +2930,10 @@ impl RawExternalSorter {
         self
     }
 
-    /// Number of prefetch streams to read a seekable input with.
-    ///
-    /// One keeps today's single sequential reader. More than one spawns that
-    /// many positional-read workers, which is the only way a process can create
-    /// device queue depth without root (`read_ahead_kb`) — see
-    /// [`crate::parallel_reader`].
+    /// How to read the input and the merge's spill files.
     #[must_use]
-    pub fn read_streams(mut self, streams: usize) -> Self {
-        self.read_streams = streams.max(1);
+    pub fn read_streams(mut self, streams: ReadStreams) -> Self {
+        self.read_streams = streams;
         self
     }
 
@@ -6522,6 +6517,71 @@ pub(crate) use crate::SortStats as RawSortStats;
 // rather than in `fgumi-bam-io`.
 // ============================================================================
 
+/// How many concurrent streams to read a file with.
+///
+/// `Auto` starts at one and grows only when fills are demonstrably occupying
+/// the span (see `spill_reader`); a fixed value pins it. One measured
+/// device wants four and another wants one, and the difference is 28% on the
+/// first and -1.8% on the second, which is why the default measures rather
+/// than guesses.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ReadStreams {
+    /// Measure and grow. The default.
+    #[default]
+    Auto,
+    /// Exactly this many; `1` is the plain sequential reader.
+    Fixed(usize),
+}
+
+impl std::fmt::Display for ReadStreams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Auto => f.write_str("auto"),
+            Self::Fixed(n) => write!(f, "{n}"),
+        }
+    }
+}
+
+impl ReadStreams {
+    /// Whether this asks for the plain sequential reader, which is what every
+    /// phase did before scattered reads existed.
+    #[must_use]
+    pub fn is_sequential(self) -> bool {
+        matches!(self, Self::Fixed(1))
+    }
+
+    /// Streams to start with. `Auto` starts at one and grows from what it
+    /// measures, so it costs nothing until it has evidence.
+    #[must_use]
+    pub fn initial(self) -> usize {
+        match self {
+            Self::Auto => 1,
+            Self::Fixed(n) => n.max(1),
+        }
+    }
+
+    /// Whether the reader should tune itself as it goes.
+    #[must_use]
+    pub fn is_auto(self) -> bool {
+        matches!(self, Self::Auto)
+    }
+}
+
+impl std::str::FromStr for ReadStreams {
+    type Err = String;
+
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
+        if text.eq_ignore_ascii_case("auto") {
+            return Ok(Self::Auto);
+        }
+        match text.parse::<usize>() {
+            Ok(0) => Err("--read-streams must be `auto` or at least 1".to_string()),
+            Ok(n) => Ok(Self::Fixed(n)),
+            Err(_) => Err(format!("expected `auto` or a positive number, got `{text}`")),
+        }
+    }
+}
+
 /// Fills the phase-1 input reader keeps in flight ahead of the framer.
 ///
 /// One, and deeper does not help. Swept in a single boot on
@@ -6554,7 +6614,7 @@ const PHASE1_LOOKAHEAD_FILLS: usize = 1;
 ///
 /// No extra threads are spawned either way: with one stream the pool's block
 /// reader reads directly from the input file, and with several it offers byte
-/// slices to the pool (see [`crate::spill_reader`]).
+/// slices to the pool (see `spill_reader`).
 ///
 /// # Flow
 ///
@@ -6572,7 +6632,7 @@ const PHASE1_LOOKAHEAD_FILLS: usize = 1;
 fn create_raw_bam_reader_pool_integrated<P: AsRef<Path>>(
     path: P,
     pool: &Arc<SortWorkerPool>,
-    read_streams: usize,
+    read_streams: ReadStreams,
 ) -> Result<(fgumi_raw_bam::RawBamReader<PooledInputStream>, Header)> {
     use crate::worker_pool::phase;
     use std::io;
@@ -6605,7 +6665,14 @@ fn create_raw_bam_reader_pool_integrated<P: AsRef<Path>>(
         // applies however the bytes are subsequently read.
         fgumi_bam_io::os_hints::advise_sequential(&file);
 
-        if read_streams > 1 {
+        if read_streams.is_sequential() {
+            // `--read-streams 1`: the plain buffered reader every phase used
+            // before scattered reads existed.
+            Box::new(io::BufReader::with_capacity(
+                SORT_INPUT_BUFFER_SIZE,
+                crate::phase1_stats::TimedReader::new(file, reader_stats),
+            ))
+        } else {
             // Scattered positional reads, the same mechanism the merge uses on
             // spill files: slices are offered to the pool so the device sees
             // real queue depth, which one blocking `read()` cannot produce
@@ -6614,7 +6681,7 @@ fn create_raw_bam_reader_pool_integrated<P: AsRef<Path>>(
             //
             // Only reachable on a real file: stdin and other non-seekable inputs
             // take the branch above, where positional reads do not exist.
-            match crate::spill_reader::ScatterReader::new(
+            match crate::spill_reader::ScatterReader::for_streams(
                 file,
                 0,
                 read_streams,
@@ -6625,7 +6692,7 @@ fn create_raw_bam_reader_pool_integrated<P: AsRef<Path>>(
             }) {
                 Ok(reader) => {
                     log::debug!(
-                        "scattered sort reader: {read_streams} streams over {}",
+                        "scattered sort reader: {read_streams} over {}",
                         path_ref.display()
                     );
                     Box::new(reader)
@@ -6643,11 +6710,6 @@ fn create_raw_bam_reader_pool_integrated<P: AsRef<Path>>(
                     ))
                 }
             }
-        } else {
-            Box::new(io::BufReader::with_capacity(
-                SORT_INPUT_BUFFER_SIZE,
-                crate::phase1_stats::TimedReader::new(file, reader_stats),
-            ))
         }
     };
 

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -2616,8 +2616,9 @@ pub struct RawExternalSorter {
     /// a modest allocation and let `Vec` grow on demand, while explicit limits
     /// pre-allocate the full budget upfront (preserving prior behavior).
     initial_capacity: Option<usize>,
-    /// When true, wrap input in a `PrefetchReader` for async I/O.
-    async_reader: bool,
+    /// Prefetch streams for a seekable input; 1 keeps the single sequential
+    /// reader. See [`crate::parallel_reader`] for why more than one is needed.
+    read_streams: usize,
     /// Which optional template-key lanes to retain (template-coordinate only).
     ///
     /// Defaults to [`KeyTypesSpec::Auto`], which provisions the narrowest key
@@ -2725,7 +2726,7 @@ impl RawExternalSorter {
             max_temp_files: crate::fd_limit::FALLBACK_MAX_TEMP_FILES,
             cell_tag: None,
             initial_capacity: None,
-            async_reader: false,
+            read_streams: 1,
             key_types: KeyTypesSpec::default(),
         }
     }
@@ -2929,13 +2930,15 @@ impl RawExternalSorter {
         self
     }
 
-    /// Enable/disable the async prefetch reader on input.
+    /// Number of prefetch streams to read a seekable input with.
     ///
-    /// When enabled, the input BAM is wrapped in a `PrefetchReader` before the
-    /// BGZF layer, which overlaps block I/O with decompression.
+    /// One keeps today's single sequential reader. More than one spawns that
+    /// many positional-read workers, which is the only way a process can create
+    /// device queue depth without root (`read_ahead_kb`) — see
+    /// [`crate::parallel_reader`].
     #[must_use]
-    pub fn async_reader(mut self, enabled: bool) -> Self {
-        self.async_reader = enabled;
+    pub fn read_streams(mut self, streams: usize) -> Self {
+        self.read_streams = streams.max(1);
         self
     }
 
@@ -3165,7 +3168,7 @@ impl RawExternalSorter {
         );
         let (record_source, header) = {
             let (reader, header) =
-                create_raw_bam_reader_pool_integrated(input, &pool, self.async_reader)?;
+                create_raw_bam_reader_pool_integrated(input, &pool, self.read_streams)?;
             (RecordSource::direct(reader), header)
         };
 
@@ -3243,12 +3246,13 @@ impl RawExternalSorter {
 
         // One worker pool spans both phases, so size it to the wider of the two
         // and cap the active count per phase via `set_active_workers`.
-        let pool = SortWorkerPool::new(
+        let mut pool = SortWorkerPool::new(
             self.phase1_threads().max(self.phase2_threads()),
             self.temp_compression,
             self.output_compression,
             self.spill_codec,
         );
+        pool.read_streams = self.read_streams;
         // Phase 1 runs first; the merge raises this to `phase2_threads()`.
         pool.set_active_workers(self.phase1_threads());
         Ok(Arc::new(pool))
@@ -6523,11 +6527,9 @@ pub(crate) use crate::SortStats as RawSortStats;
 /// Workers in the pool do `ReadInputBlocks` + `DecompressInput`. The main
 /// thread consumes decompressed bytes via `PooledInputStream`.
 ///
-/// When `async_reader` is false, no extra threads are spawned: the pool's
-/// block reader reads directly from the input file. When `async_reader` is
-/// true, the input file is wrapped in a `PrefetchReader`, which spawns one
-/// dedicated OS thread (`fgumi-prefetch`) that reads raw bytes ahead into a
-/// bounded queue so the pool's block reader never blocks on disk I/O.
+/// No extra threads are spawned either way: with one stream the pool's block
+/// reader reads directly from the input file, and with several it offers byte
+/// slices to the pool (see [`crate::spill_reader`]).
 ///
 /// # Flow
 ///
@@ -6545,53 +6547,76 @@ pub(crate) use crate::SortStats as RawSortStats;
 fn create_raw_bam_reader_pool_integrated<P: AsRef<Path>>(
     path: P,
     pool: &Arc<SortWorkerPool>,
-    async_reader: bool,
+    read_streams: usize,
 ) -> Result<(fgumi_raw_bam::RawBamReader<PooledInputStream>, Header)> {
     use crate::worker_pool::phase;
     use std::io;
 
     let path_ref = path.as_ref();
 
-    // Times the reads that refill the buffer below. Only the synchronous paths
-    // are wrapped: `--async-reader` moves the read onto a prefetch thread, so
-    // the reader step no longer pays for it and there is nothing on this thread
-    // to separate from framing. A zero refill row on an async run is that, not a
-    // measurement failure.
+    // Times the reads that refill the buffer below, so that `framing_secs` --
+    // time inside `read_raw_blocks` that was *not* spent fetching -- means what
+    // it says. Both arms report into it: the sequential one through
+    // `TimedReader`, the scattered one by timing its own fills. Leaving the
+    // scattered arm out booked its fill waits as framing and showed 10.9
+    // us/block against a true 0.9.
     let reader_stats = pool.reader_stats();
 
     let opened: Box<dyn io::Read + Send> = if is_stdin_path(path_ref) {
-        if async_reader {
-            // `--async-reader` is about decoupling the read from the block
-            // reader, which stdin needs at least as much as a file does: the
-            // prefetch thread also subsumes the buffering below, reading ahead
-            // in chunks into a bounded queue.
-            log::debug!("async sort reader enabled: spawning fgumi-prefetch thread for stdin");
-            Box::new(fgumi_bam_io::prefetch_reader::PrefetchReader::new(io::stdin()))
-        } else {
-            // `io::Stdin` re-acquires a mutex and reads through an 8 KiB buffer
-            // on every call; the pool's block reader wants far bigger gulps than
-            // that, so give the stdin path the same 2 MiB buffer the file path
-            // gets.
-            Box::new(io::BufReader::with_capacity(
-                SORT_INPUT_BUFFER_SIZE,
-                crate::phase1_stats::TimedReader::new(io::stdin(), reader_stats),
-            ))
-        }
+        // `io::Stdin` re-acquires a mutex and reads through an 8 KiB buffer on
+        // every call; the pool's block reader wants far bigger gulps than that,
+        // so give the stdin path the same 2 MiB buffer the file path gets.
+        // Scattered reads are not available here -- a pipe has no offsets.
+        Box::new(io::BufReader::with_capacity(
+            SORT_INPUT_BUFFER_SIZE,
+            crate::phase1_stats::TimedReader::new(io::stdin(), reader_stats),
+        ))
     } else {
         let file = std::fs::File::open(path_ref)
             .with_context(|| format!("Failed to open input BAM: {}", path_ref.display()))?;
 
-        // Grow the per-fd readahead window. This is the plain sequential hint
-        // and applies however the bytes are subsequently read; the WILLNEED
-        // hints that `PrefetchReader` issues are a separate, async-only extra.
+        // Grow the per-fd readahead window. Measured worth almost nothing on
+        // its own (359 MB/s against 360 with no hint), but it is free and
+        // applies however the bytes are subsequently read.
         fgumi_bam_io::os_hints::advise_sequential(&file);
 
-        if async_reader {
-            log::debug!(
-                "async sort reader enabled: spawning fgumi-prefetch thread for {}",
-                path_ref.display()
-            );
-            Box::new(fgumi_bam_io::prefetch_reader::PrefetchReader::from_file(file))
+        if read_streams > 1 {
+            // Scattered positional reads, the same mechanism the merge uses on
+            // spill files: slices are offered to the pool so the device sees
+            // real queue depth, which one blocking `read()` cannot produce
+            // however large its buffer. The framer downstream is unchanged --
+            // this still presents a sequential `Read`.
+            //
+            // Only reachable on a real file: stdin and other non-seekable inputs
+            // take the branch above, where positional reads do not exist.
+            match crate::spill_reader::ScatterReader::new(
+                file,
+                0,
+                read_streams,
+                Some(pool.fetch_queue()),
+            )
+            .map(|reader| reader.timed(Arc::clone(&reader_stats)))
+            {
+                Ok(reader) => {
+                    log::debug!(
+                        "scattered sort reader: {read_streams} streams over {}",
+                        path_ref.display()
+                    );
+                    Box::new(reader)
+                }
+                Err(e) => {
+                    // A file whose length we cannot read is one we cannot slice.
+                    // Fall back rather than fail a sort over a prefetch tweak.
+                    log::warn!("scattered sort reader unavailable ({e}); using one stream");
+                    let file = std::fs::File::open(path_ref).with_context(|| {
+                        format!("Failed to reopen input BAM: {}", path_ref.display())
+                    })?;
+                    Box::new(io::BufReader::with_capacity(
+                        SORT_INPUT_BUFFER_SIZE,
+                        crate::phase1_stats::TimedReader::new(file, reader_stats),
+                    ))
+                }
+            }
         } else {
             Box::new(io::BufReader::with_capacity(
                 SORT_INPUT_BUFFER_SIZE,

--- a/crates/fgumi-sort/src/inline.rs
+++ b/crates/fgumi-sort/src/inline.rs
@@ -547,6 +547,25 @@ impl RecordBuffer {
     }
 
     /// Clear the buffer for reuse.
+    /// Give back the arena segments held for reuse; see
+    /// [`SegmentedBuf::release_retained`](crate::segmented_buf::SegmentedBuf::release_retained).
+    /// Call once ingest is finished — holding them through the merge costs peak
+    /// RSS and buys nothing, because nothing more is pushed.
+    pub fn release_retained(&mut self) {
+        self.data.release_retained();
+    }
+
+    /// Empty the buffer between chunks, **keeping the arena's segment
+    /// allocations** so the next chunk does not fault every page back in.
+    ///
+    /// See [`SegmentedBuf::reset_for_reuse`](crate::segmented_buf::SegmentedBuf::reset_for_reuse)
+    /// for the measurement. Use this rather than [`clear`](Self::clear)
+    /// anywhere the buffer is about to be refilled; `clear` is for teardown.
+    pub fn reset_for_reuse(&mut self) {
+        self.data.reset_for_reuse();
+        self.refs.clear();
+    }
+
     pub fn clear(&mut self) {
         self.data.clear();
         self.refs.clear();
@@ -1620,6 +1639,25 @@ impl<K: TemplateLaneKey> TemplateRecordBuffer<K> {
     }
 
     /// Clear the buffer for reuse.
+    /// Give back the arena segments held for reuse; see
+    /// [`SegmentedBuf::release_retained`](crate::segmented_buf::SegmentedBuf::release_retained).
+    /// Call once ingest is finished — holding them through the merge costs peak
+    /// RSS and buys nothing, because nothing more is pushed.
+    pub fn release_retained(&mut self) {
+        self.data.release_retained();
+    }
+
+    /// Empty the buffer between chunks, **keeping the arena's segment
+    /// allocations** so the next chunk does not fault every page back in.
+    ///
+    /// See [`SegmentedBuf::reset_for_reuse`](crate::segmented_buf::SegmentedBuf::reset_for_reuse)
+    /// for the measurement. Use this rather than [`clear`](Self::clear)
+    /// anywhere the buffer is about to be refilled; `clear` is for teardown.
+    pub fn reset_for_reuse(&mut self) {
+        self.data.reset_for_reuse();
+        self.refs.clear();
+    }
+
     pub fn clear(&mut self) {
         self.data.clear();
         self.refs.clear();

--- a/crates/fgumi-sort/src/inline.rs
+++ b/crates/fgumi-sort/src/inline.rs
@@ -1412,9 +1412,25 @@ impl<K: TemplateLaneKey> TemplateRecordBuffer<K> {
     /// Create a new buffer with estimated capacity.
     #[must_use]
     pub fn with_capacity(estimated_records: usize, estimated_bytes: usize) -> Self {
+        Self::with_segment_size(estimated_records, estimated_bytes, SORT_SEGMENT_SIZE)
+    }
+
+    /// Create a new buffer with an explicit arena segment size.
+    ///
+    /// Production always uses [`SORT_SEGMENT_SIZE`]. This exists so tests can
+    /// drive the behaviour that only appears once the arena has *sealed* a
+    /// segment — deferred key batches are cut per sealed segment, and at 256 MiB
+    /// a segment no realistic test input ever fills, leaving that path
+    /// unexercised by everything short of a quarter-gigabyte fixture.
+    #[must_use]
+    pub fn with_segment_size(
+        estimated_records: usize,
+        estimated_bytes: usize,
+        segment_size: usize,
+    ) -> Self {
         let header_bytes = estimated_records * TEMPLATE_HEADER_SIZE;
         Self {
-            data: SegmentedBuf::with_capacity(estimated_bytes + header_bytes, SORT_SEGMENT_SIZE),
+            data: SegmentedBuf::with_capacity(estimated_bytes + header_bytes, segment_size),
             refs: Vec::with_capacity(estimated_records),
         }
     }
@@ -1454,6 +1470,72 @@ impl<K: TemplateLaneKey> TemplateRecordBuffer<K> {
         // Add ref with cached key for O(1) sort comparisons
         self.refs.push(TemplateRecordRef { key, offset, len: record_len, padding: 0 });
         Ok(())
+    }
+
+    /// Push a record whose sort key will be supplied later by
+    /// [`fill_keys`](Self::fill_keys).
+    ///
+    /// The ref lands with `K::default()` in its key field, which is **not** a
+    /// valid sort position — sorting before every deferred key has been filled
+    /// would silently collate records under a constant key rather than fail.
+    /// The ingest thread's barrier is what guarantees that cannot happen; it
+    /// counts filled keys against `refs.len()` before it sorts.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the record (plus header) exceeds the segment size
+    /// (256 MiB) or if the record length exceeds `u32::MAX`.
+    #[inline]
+    pub fn push_deferred(&mut self, record: &[u8]) -> anyhow::Result<()> {
+        self.push(record, K::default())
+    }
+
+    /// Write keys for the refs at `first_ref .. first_ref + keys.len()`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the range runs past the end of the ref array — that means a
+    /// batch outlived the chunk it belonged to, which would otherwise corrupt a
+    /// later chunk's keys silently.
+    pub fn fill_keys(&mut self, first_ref: usize, keys: &[K]) {
+        let end = first_ref + keys.len();
+        assert!(
+            end <= self.refs.len(),
+            "key batch covers refs {first_ref}..{end} but the buffer holds only {}",
+            self.refs.len(),
+        );
+        for (r, k) in self.refs[first_ref..end].iter_mut().zip(keys) {
+            r.key = *k;
+        }
+    }
+
+    /// Number of arena segments that are sealed — finished and safe to share
+    /// with a worker. See [`SegmentedBuf::sealed_len`](crate::segmented_buf::SegmentedBuf::sealed_len).
+    #[must_use]
+    pub fn sealed_segments(&self) -> usize {
+        self.data.sealed_len()
+    }
+
+    /// A shared handle to sealed arena segment `idx`, or `None` if it is the
+    /// live segment.
+    #[must_use]
+    pub fn sealed_segment(&self, idx: usize) -> Option<std::sync::Arc<Vec<u8>>> {
+        self.data.sealed_segment(idx)
+    }
+
+    /// Seal the live arena segment, so every record pushed so far lives in a
+    /// segment that can be shared with a worker.
+    ///
+    /// Called at the chunk barrier, where the buffer is about to be sorted and
+    /// cleared, so the tail of the sealed segment is never wasted in practice.
+    pub fn seal_arena_segment(&mut self) {
+        self.data.seal_current();
+    }
+
+    /// The arena's segment size, for mapping a global offset to its segment.
+    #[must_use]
+    pub fn segment_size(&self) -> usize {
+        self.data.segment_size()
     }
 
     /// Sort the index by cached key using stable LSD radix sort.
@@ -2607,6 +2689,56 @@ mod tests {
                     refs[i].offset
                 );
             }
+        }
+    }
+
+    #[test]
+    fn test_deferring_a_key_and_filling_it_matches_pushing_it_outright() {
+        // Deferred extraction is only safe if the buffer it produces is
+        // indistinguishable from the one the serial push produced — same bytes
+        // at the same offsets, same keys on the same refs.
+        let keys: Vec<TemplateKey> = (0..16i32)
+            .map(|i| {
+                let name_hash = u64::from(i.unsigned_abs());
+                TemplateKey::new(
+                    0,
+                    100 + i,
+                    false,
+                    0,
+                    200,
+                    false,
+                    0,
+                    0,
+                    (1, true),
+                    name_hash,
+                    false,
+                )
+            })
+            .collect();
+        let records: Vec<Vec<u8>> = (0..16u8).map(|i| vec![i; 40 + usize::from(i)]).collect();
+
+        let mut direct = TemplateRecordBuffer::<TemplateKey40>::with_capacity(16, 4096);
+        for (record, key) in records.iter().zip(&keys) {
+            direct.push(record, TemplateLaneKey::from_full(key)).expect("push");
+        }
+
+        let mut deferred = TemplateRecordBuffer::<TemplateKey40>::with_capacity(16, 4096);
+        for record in &records {
+            deferred.push_deferred(record).expect("push_deferred");
+        }
+        // Fill in two uneven batches, as the pool would.
+        let narrowed: Vec<TemplateKey40> = keys.iter().map(TemplateLaneKey::from_full).collect();
+        deferred.fill_keys(0, &narrowed[..5]);
+        deferred.fill_keys(5, &narrowed[5..]);
+
+        assert_eq!(direct.refs().len(), deferred.refs().len());
+        for (a, b) in direct.refs().iter().zip(deferred.refs()) {
+            assert_eq!(a.key, b.key, "keys must match");
+            assert_eq!(a.offset, b.offset, "record bytes must land at the same offset");
+            assert_eq!(a.len, b.len);
+        }
+        for (i, r) in deferred.refs().iter().enumerate() {
+            assert_eq!(deferred.get_record(r), &records[i][..], "record bytes must survive");
         }
     }
 

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -94,6 +94,7 @@ pub(crate) mod merge_headroom;
 pub(crate) mod merge_phases;
 pub(crate) mod merge_stalls;
 pub(crate) mod merge_trace;
+pub(crate) mod phase1_keys;
 pub(crate) mod phase1_stats;
 pub(crate) mod pipeline;
 pub(crate) mod pooled_bam_writer;

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -104,6 +104,7 @@ pub(crate) mod radix;
 pub(crate) mod read_ahead;
 pub(crate) mod reader;
 pub(crate) mod segmented_buf;
+pub(crate) mod spill_reader;
 pub(crate) mod tmp_dir_alloc;
 pub(crate) mod verify;
 pub(crate) mod worker_pool;

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -245,8 +245,8 @@ fn create_temp_dir(base: Option<&Path>) -> Result<TempDir> {
 
 pub use codec::SpillCodec;
 pub use external::{
-    KeyTypesSpec, LibraryLookup, RawExternalSorter, cb_hasher, extract_template_key_inline,
-    format_thread_counts,
+    KeyTypesSpec, LibraryLookup, RawExternalSorter, ReadStreams, cb_hasher,
+    extract_template_key_inline, format_thread_counts,
 };
 pub use fd_limit::{
     FALLBACK_MAX_TEMP_FILES, fits_nofile_budget, resolve_temp_file_limit, soft_nofile,

--- a/crates/fgumi-sort/src/phase1_keys.rs
+++ b/crates/fgumi-sort/src/phase1_keys.rs
@@ -1,0 +1,971 @@
+//! Deferred sort-key extraction — the ingest thread's largest serial cost,
+//! moved onto the worker pool.
+//!
+//! Phase 1's ingest thread is a serial consumer, and the floor line names it as
+//! the phase's binding limit: on a 16-thread whole-genome sort it is 137.5s of a
+//! 145.4s read span, against a worker-capacity floor of 22.2s. Of that 137.5s,
+//! **93.6s is `extract_template_key_inline`** — one aux-tag scan, one name hash
+//! and one unclipped-5' computation per record, at 120 ns each over 780M
+//! records. It is pure per-record CPU with no ordering requirement, so the only
+//! reason it sat on the serial thread was that it ran where the record bytes
+//! happened to be in hand.
+//!
+//! This module moves it. The ingest thread pushes a record's bytes into the
+//! arena and records its extent, leaving the ref's key unset; batches of extents
+//! are handed to the pool as [`KeyExtractionJob`]s, and the filled keys come
+//! back over a channel to be spliced into the ref array. The pool has the
+//! capacity to absorb it — 22.2s of worker busy across a 145s span — so the work
+//! disappears rather than relocating.
+//!
+//! # Why batches are cut at arena segment boundaries
+//!
+//! A worker reads record bytes straight out of the arena while the ingest thread
+//! is still appending to it. That is only sound against a segment the writer has
+//! finished with, which is why [`SegmentedBuf`](crate::segmented_buf::SegmentedBuf)
+//! splits its sealed segments from its live one: a batch names exactly one
+//! sealed segment, holds it alive by `Arc`, and the writer never touches it
+//! again. Records still in the live segment keep their keys unextracted until it
+//! seals, or until the chunk barrier, whichever comes first.
+
+use std::sync::Arc;
+use std::sync::mpsc::{Receiver, Sender};
+
+use fgumi_raw_bam::{RawRecordView, SamTag};
+
+use crate::external::{
+    DroppedLaneViolation, LibraryLookup, TemplateKeyVariant, extract_template_key_inline,
+    verify_dropped_lanes,
+};
+use crate::inline::{TEMPLATE_HEADER_SIZE, TemplateKey, TemplateLaneKey, TemplateRecordBuffer};
+use crate::worker_pool::SortWorkerPool;
+
+/// Everything a deferred batch needs to reproduce the serial extraction exactly.
+///
+/// Built once per sort and shared by `Arc`, so a batch carries one pointer
+/// rather than a copy of the library table and hasher.
+pub(crate) struct KeyContext {
+    /// Read-group to library-ordinal table, from the BAM header.
+    pub(crate) lib_lookup: LibraryLookup,
+    /// The cell-barcode tag to fold into the key, when the sort was asked for one.
+    pub(crate) cell_tag: Option<SamTag>,
+    /// Fixed-seed hasher for cell-barcode values. **Never reseed this** — it
+    /// feeds the sort key, so a random seed would break byte-identity.
+    pub(crate) cb_hasher: ahash::RandomState,
+    /// The first record's full key: the baseline every later record's dropped
+    /// lanes are verified against.
+    pub(crate) first_key: TemplateKey,
+    /// Which lanes the chosen narrowed key retains.
+    pub(crate) variant: TemplateKeyVariant,
+}
+
+/// A dropped-lane violation, tagged with the record that carried it.
+///
+/// Carries the record's index within the whole chunk (not within the batch) so
+/// the ingest thread can report the *first* offending record deterministically,
+/// however the batches happened to be scheduled.
+pub(crate) struct KeyViolation {
+    /// Index of the offending record in the chunk's ref array.
+    pub(crate) ref_index: usize,
+    /// Which lane disagreed with the first record.
+    pub(crate) violation: DroppedLaneViolation,
+    /// The offending record's read name, for the error message.
+    pub(crate) name: String,
+}
+
+/// One completed batch of keys, addressed by where they belong.
+pub(crate) struct KeyBatchResult<K> {
+    /// Index of this batch's first record in the chunk's ref array.
+    pub(crate) first_ref: usize,
+    /// Keys for `first_ref .. first_ref + keys.len()`, in ref order.
+    pub(crate) keys: Box<[K]>,
+    /// The lowest-indexed violation this batch found, if any.
+    pub(crate) violation: Option<KeyViolation>,
+}
+
+/// A unit of deferred key extraction that any pool worker can run.
+///
+/// Type-erased on purpose: the worker pool is not generic over the sort key, and
+/// making it so would thread `K` through every step, queue and stats array for
+/// the benefit of one step. The batch carries its own sender instead, so the
+/// pool only ever sees "run this".
+pub(crate) trait KeyExtractionJob: Send {
+    /// Extract every key in the batch and publish the result.
+    ///
+    /// Consumes the job: a batch runs exactly once.
+    fn run(self: Box<Self>);
+}
+
+/// Extract one record's full key and check the lanes the chosen variant drops.
+///
+/// The single extraction implementation, shared by the batched path and the
+/// immediate one, so the two cannot drift into producing different keys.
+fn extract_one(ctx: &KeyContext, bam: &[u8]) -> (TemplateKey, Option<DroppedLaneViolation>) {
+    let full = extract_template_key_inline(bam, &ctx.lib_lookup, ctx.cell_tag, &ctx.cb_hasher);
+    let violation = verify_dropped_lanes(&ctx.first_key, &full, ctx.variant);
+    (full, violation)
+}
+
+/// A batch of template-coordinate records awaiting key extraction.
+pub(crate) struct TemplateKeyBatch<K: TemplateLaneKey> {
+    /// Shared extraction context.
+    pub(crate) ctx: Arc<KeyContext>,
+    /// The sealed arena segment holding every record body in this batch.
+    pub(crate) segment: Arc<Vec<u8>>,
+    /// Byte offset of `segment`'s first byte in the arena's global address space.
+    pub(crate) segment_base: u64,
+    /// Index of this batch's first record in the chunk's ref array.
+    pub(crate) first_ref: usize,
+    /// Per record, in ref order: the global offset of its BAM bytes (the inline
+    /// header already skipped) and their length.
+    pub(crate) extents: Box<[(u64, u32)]>,
+    /// Where the filled keys are published.
+    pub(crate) results: Sender<KeyBatchResult<K>>,
+}
+
+impl<K: TemplateLaneKey> KeyExtractionJob for TemplateKeyBatch<K>
+where
+    K: Send,
+{
+    fn run(self: Box<Self>) {
+        let me = *self;
+        let ctx = &me.ctx;
+        let mut keys: Vec<K> = Vec::with_capacity(me.extents.len());
+        let mut violation: Option<KeyViolation> = None;
+
+        for (i, &(offset, len)) in me.extents.iter().enumerate() {
+            let local = usize::try_from(offset - me.segment_base)
+                .expect("record offset precedes its own segment");
+            let bam = &me.segment[local..local + len as usize];
+
+            let (full, lane) = extract_one(ctx, bam);
+
+            // First violation wins: batches are scheduled in whatever order the
+            // pool picks them up, so only the lowest index is reproducible.
+            if violation.is_none()
+                && let Some(v) = lane
+            {
+                let name =
+                    String::from_utf8_lossy(RawRecordView::new(bam).read_name()).into_owned();
+                violation = Some(KeyViolation { ref_index: me.first_ref + i, violation: v, name });
+            }
+
+            keys.push(K::from_full(&full));
+        }
+
+        // A closed channel means the ingest thread has already failed and gone
+        // away; there is nobody left to report to and nothing to clean up.
+        drop(me.results.send(KeyBatchResult {
+            first_ref: me.first_ref,
+            keys: keys.into_boxed_slice(),
+            violation,
+        }));
+    }
+}
+
+// ============================================================================
+// Ingest-side driver
+// ============================================================================
+
+/// What deferral actually achieved over a whole sort.
+///
+/// Reported because a deferral that silently stops engaging is invisible any
+/// other way: the keys are correct whether a worker extracted them or the
+/// barrier did, so no output check, equivalence test or record count can tell
+/// the difference. Only this ratio can.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct KeyOverlapCensus {
+    /// Records whose keys were extracted while the ingest thread kept reading.
+    pub(crate) overlapped_records: u64,
+    /// Records whose keys the ingest thread had to wait at a barrier for.
+    pub(crate) barrier_records: u64,
+    /// Exact seconds spent cutting and handing out batches.
+    pub(crate) dispatch_secs: f64,
+    /// Exact seconds spent waiting at barriers for keys.
+    pub(crate) barrier_secs: f64,
+}
+
+impl KeyOverlapCensus {
+    /// Share of records keyed off the serial thread's critical path, as a
+    /// percentage. `None` when nothing was deferred at all.
+    pub(crate) fn overlap_percent(self) -> Option<f64> {
+        let total = self.total_records();
+        if total == 0 {
+            return None;
+        }
+        #[allow(clippy::cast_precision_loss)]
+        Some(100.0 * self.overlapped_records as f64 / total as f64)
+    }
+
+    /// Total records accounted for.
+    pub(crate) fn total_records(self) -> u64 {
+        self.overlapped_records + self.barrier_records
+    }
+}
+
+/// Records per deferred batch.
+///
+/// Big enough that the per-batch cost (one `Box`, one queue push, one channel
+/// send, 48 KiB of extents) is noise against ~4k extractions — each batch is
+/// still ~0.5 ms of work — and small enough that a batch's key array (4k x up to
+/// 56 B = 224 KiB) stays inside L2, so splicing it back into the ref array hits
+/// warm cache rather than a second trip to memory. Batches are also cut at arena
+/// segment boundaries, so this is an upper bound rather than an exact size.
+const KEY_BATCH_RECORDS: usize = 4 * 1024;
+
+/// Drives deferred key extraction for one sort: cuts batches, hands them to the
+/// pool, and splices the results back into the buffer's ref array.
+///
+/// One instance spans the whole sort and is [`reset`](Self::reset) per chunk, so
+/// the channel and its context are allocated once rather than per spill.
+pub(crate) struct DeferredKeys<K: TemplateLaneKey> {
+    /// Shared extraction context, cloned into every batch by `Arc`.
+    ctx: Arc<KeyContext>,
+    /// Kept alive for the whole sort so the receiver never disconnects while
+    /// batches are outstanding.
+    tx: Sender<KeyBatchResult<K>>,
+    /// Completed batches come back here.
+    rx: Receiver<KeyBatchResult<K>>,
+    /// Refs `0..dispatched` have been handed to some batch.
+    dispatched: usize,
+    /// Batches handed out whose result has not been absorbed yet.
+    outstanding: usize,
+    /// Refs whose key has actually been written back.
+    filled: usize,
+    /// Sealed arena segment count as of the last dispatch check.
+    sealed_seen: usize,
+    /// Lowest-indexed dropped-lane violation seen across all batches.
+    violation: Option<KeyViolation>,
+    /// Records dispatched *before* their chunk's barrier, summed over the whole
+    /// sort. Not cleared by [`reset`](Self::reset).
+    overlapped_records: u64,
+    /// Records still unbatched when their chunk's barrier ran, so their keys
+    /// were extracted with the ingest thread waiting. Not cleared by `reset`.
+    barrier_records: u64,
+    /// Seconds the ingest thread spent cutting and handing out batches.
+    ///
+    /// Timed exactly rather than sampled: dispatch fires once per sealed arena
+    /// segment — a few thousand times across a whole sort, against hundreds of
+    /// millions of records — so a 1-in-N per-record sample would be estimating a
+    /// rare event with a method built for a uniform one. A few thousand clock
+    /// pairs is unmeasurable overhead.
+    dispatch_secs: f64,
+    /// Seconds the ingest thread spent at a barrier waiting for keys.
+    ///
+    /// The number to watch: it is the part of extraction the pool did not manage
+    /// to hide, and so the part that is still serial. Exact, per chunk.
+    barrier_secs: f64,
+    /// Whether to defer at all.
+    ///
+    /// False when the pool has fewer than two workers, because then there is no
+    /// second thread for a batch to run on — deferral could only ever move the
+    /// same extraction onto the same thread, later, having paid for an extent
+    /// list, a key array and a splice on the way. That is not a judgement call
+    /// about which is faster; with one worker the batched path is strictly more
+    /// work. The single-threaded fast path (`--threads` absent) is exactly this
+    /// case, so it keeps its original inline extraction.
+    defer: bool,
+}
+
+impl<K: TemplateLaneKey> DeferredKeys<K> {
+    /// Build a driver over `ctx`, deferring when Phase 1 has the workers to make
+    /// deferral worth its bookkeeping.
+    ///
+    /// `phase1_threads` is the count of workers *active during Phase 1*, not the
+    /// pool's size. The pool is sized to the wider of the two phases and capped
+    /// per phase, so `--threads 1 --merge-threads 16` builds 16 workers of which
+    /// exactly one is awake while ingest runs — gating on the pool size there
+    /// would defer batches to a pool that is not allowed to run them.
+    pub(crate) fn new(ctx: Arc<KeyContext>, phase1_threads: usize) -> Self {
+        let defer = phase1_threads >= 2;
+        let (tx, rx) = std::sync::mpsc::channel();
+        Self {
+            ctx,
+            tx,
+            rx,
+            dispatched: 0,
+            outstanding: 0,
+            filled: 0,
+            sealed_seen: 0,
+            violation: None,
+            overlapped_records: 0,
+            barrier_records: 0,
+            dispatch_secs: 0.0,
+            barrier_secs: 0.0,
+            defer,
+        }
+    }
+
+    /// Get one record into the buffer with a sort key, now or later.
+    ///
+    /// The ingest loop's single entry point, so the deferred and immediate modes
+    /// cannot diverge at the call site. Immediate mode extracts and pushes in one
+    /// step exactly as the pre-deferral loop did; deferred mode pushes a
+    /// placeholder and lets the pool fill it in.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the record cannot be pushed into the arena, or (in
+    /// immediate mode) if it carries a value in a lane the chosen key drops.
+    pub(crate) fn push(
+        &mut self,
+        buffer: &mut TemplateRecordBuffer<K>,
+        pool: &SortWorkerPool,
+        bam: &[u8],
+    ) -> anyhow::Result<()> {
+        if !self.defer {
+            let (full, lane) = extract_one(&self.ctx, bam);
+            if let Some(v) = lane {
+                let name =
+                    String::from_utf8_lossy(RawRecordView::new(bam).read_name()).into_owned();
+                return Err(crate::external::dropped_lane_error(&name, v));
+            }
+            buffer.push(bam, K::from_full(&full))?;
+            // Counted as overlapped-with-nothing so the census still sums to the
+            // record count and a single-worker run reads as 0% overlapped rather
+            // than as no deferral information at all.
+            self.barrier_records += 1;
+            self.filled += 1;
+            self.dispatched += 1;
+            return Ok(());
+        }
+        buffer.push_deferred(bam)?;
+        self.after_push(buffer, pool);
+        Ok(())
+    }
+
+    /// Records whose keys were extracted while the ingest thread kept reading,
+    /// and records whose keys it had to wait at the barrier for.
+    ///
+    /// This is how you tell the difference between deferral *working* and
+    /// deferral silently not engaging: the second is indistinguishable from the
+    /// first by output, by test, and by every equivalence check — the keys are
+    /// right either way, they were just paid for serially. A run where
+    /// `overlapped` is near zero has the cost of the old code plus the
+    /// bookkeeping of the new.
+    pub(crate) fn overlap_census(&self) -> KeyOverlapCensus {
+        KeyOverlapCensus {
+            overlapped_records: self.overlapped_records,
+            barrier_records: self.barrier_records,
+            dispatch_secs: self.dispatch_secs,
+            barrier_secs: self.barrier_secs,
+        }
+    }
+
+    /// Bytes currently held by in-flight batches, to be counted against the
+    /// sort's memory limit.
+    ///
+    /// A record whose key is still outstanding is charged twice — once for the
+    /// placeholder key already in its ref, once for the copy the batch is
+    /// filling — plus its extent. Leaving this out would let the buffer overrun
+    /// the limit by however much extraction happens to be lagging.
+    pub(crate) fn in_flight_bytes(&self) -> usize {
+        let per_record = std::mem::size_of::<K>() + std::mem::size_of::<(u64, u32)>();
+        self.dispatched.saturating_sub(self.filled) * per_record
+    }
+
+    /// Hand out batches for every record that has become shareable, if the
+    /// arena has sealed a segment since the last call.
+    ///
+    /// Cheap enough to call after every push: the common case is one integer
+    /// comparison.
+    pub(crate) fn after_push(
+        &mut self,
+        buffer: &mut TemplateRecordBuffer<K>,
+        pool: &SortWorkerPool,
+    ) {
+        let sealed = buffer.sealed_segments();
+        if !self.defer || sealed == self.sealed_seen {
+            return;
+        }
+        self.sealed_seen = sealed;
+        let started = std::time::Instant::now();
+        // The record that triggered the seal landed in the new live segment, so
+        // it is not shareable yet; everything before it is.
+        let shareable = buffer.refs().len().saturating_sub(1);
+        self.dispatch_upto(buffer, pool, shareable);
+        self.absorb_ready(buffer);
+        self.dispatch_secs += started.elapsed().as_secs_f64();
+    }
+
+    /// Cut and dispatch batches covering refs `self.dispatched..end`.
+    ///
+    /// Batches never span an arena segment: a batch names exactly one sealed
+    /// segment and holds it by `Arc`, which is what makes reading it concurrent
+    /// with the ingest thread's appends sound.
+    fn dispatch_upto(
+        &mut self,
+        buffer: &TemplateRecordBuffer<K>,
+        pool: &SortWorkerPool,
+        end: usize,
+    ) {
+        let segment_size = buffer.segment_size() as u64;
+        while self.dispatched < end {
+            let refs = buffer.refs();
+            let start = self.dispatched;
+            let segment_index = refs[start].offset / segment_size;
+            let limit = end.min(start + KEY_BATCH_RECORDS);
+            let mut stop = start;
+            while stop < limit && refs[stop].offset / segment_size == segment_index {
+                stop += 1;
+            }
+
+            let segment_index = usize::try_from(segment_index).expect("segment index fits usize");
+            let Some(segment) = buffer.sealed_segment(segment_index) else {
+                // The segment is still live, so nothing from here on is
+                // shareable yet. Leave it for the next seal or the barrier.
+                return;
+            };
+
+            let extents: Box<[(u64, u32)]> = refs[start..stop]
+                .iter()
+                .map(|r| (r.offset + TEMPLATE_HEADER_SIZE as u64, r.len))
+                .collect();
+            let batch = TemplateKeyBatch::<K> {
+                ctx: Arc::clone(&self.ctx),
+                segment,
+                segment_base: segment_index as u64 * segment_size,
+                first_ref: start,
+                extents,
+                results: self.tx.clone(),
+            };
+
+            self.dispatched = stop;
+            self.outstanding += 1;
+            // A full queue means the pool is saturated, not that the batch can
+            // be dropped: run it here rather than lose its keys.
+            if let Err(batch) = pool.submit_key_job(Box::new(batch)) {
+                batch.run();
+            }
+        }
+    }
+
+    /// Absorb every batch that has already finished, without waiting.
+    fn absorb_ready(&mut self, buffer: &mut TemplateRecordBuffer<K>) {
+        while let Ok(result) = self.rx.try_recv() {
+            self.absorb(buffer, result);
+        }
+    }
+
+    /// Write one batch's keys into the buffer and fold in its violation.
+    fn absorb(&mut self, buffer: &mut TemplateRecordBuffer<K>, result: KeyBatchResult<K>) {
+        buffer.fill_keys(result.first_ref, &result.keys);
+        self.filled += result.keys.len();
+        self.outstanding -= 1;
+        if let Some(v) = result.violation
+            && self.violation.as_ref().is_none_or(|seen| v.ref_index < seen.ref_index)
+        {
+            self.violation = Some(v);
+        }
+    }
+
+    /// Wait until every record in the buffer has its real key, then report the
+    /// first dropped-lane violation if there was one.
+    ///
+    /// Must be called before the buffer is sorted or spilled. Runs queued
+    /// batches on the calling thread while it waits, so it cannot deadlock
+    /// against a pool whose workers have already parked for the phase.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a worker panicked while holding a batch. That batch's
+    /// sender is dropped by the unwind without ever publishing, so its keys can
+    /// never arrive — and because this driver holds its own sender, the channel
+    /// never disconnects and a plain blocking wait would hang forever. The wait
+    /// is therefore bounded and re-checks the pool's panic flag.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer still holds a record whose key was never filled —
+    /// that would otherwise sort those records under a constant placeholder key
+    /// and produce a wrong order that still looks like a valid BAM.
+    pub(crate) fn finish(
+        &mut self,
+        buffer: &mut TemplateRecordBuffer<K>,
+        pool: &SortWorkerPool,
+    ) -> anyhow::Result<Option<KeyViolation>> {
+        let started = std::time::Instant::now();
+        let all = buffer.refs().len();
+        if self.defer {
+            // Everything left is in the live segment; seal it so it can be
+            // shared. Skipped in immediate mode, where it would only churn a
+            // fresh full-size segment allocation per chunk for no reader.
+            buffer.seal_arena_segment();
+            self.sealed_seen = buffer.sealed_segments();
+            let overlapped = self.dispatched.min(all);
+            self.overlapped_records += overlapped as u64;
+            self.barrier_records += (all - overlapped) as u64;
+            self.dispatch_upto(buffer, pool, all);
+        }
+
+        while self.outstanding > 0 {
+            match self.rx.try_recv() {
+                Ok(result) => {
+                    self.absorb(buffer, result);
+                    continue;
+                }
+                Err(std::sync::mpsc::TryRecvError::Empty) => {}
+                // Unreachable: `self.tx` is alive for as long as `self` is.
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => break,
+            }
+            if pool.run_one_key_job() {
+                continue;
+            }
+            // Nothing ready and nothing queued: every outstanding batch is
+            // running on a worker right now, so waiting is the cheap move. The
+            // timeout exists only so a panicked worker surfaces as an error
+            // instead of an indefinite hang.
+            match self.rx.recv_timeout(std::time::Duration::from_millis(50)) {
+                Ok(result) => self.absorb(buffer, result),
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                    anyhow::ensure!(
+                        !pool.worker_panicked(),
+                        "a sort worker panicked while extracting sort keys; {} key \
+                         batches can never complete",
+                        self.outstanding,
+                    );
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+
+        self.barrier_secs += started.elapsed().as_secs_f64();
+        assert_eq!(
+            self.filled,
+            all,
+            "{} of {all} records were never given a sort key; sorting now would collate them \
+             under the placeholder",
+            all - self.filled,
+        );
+        Ok(self.violation.take())
+    }
+
+    /// Forget the previous chunk's accounting, after the buffer was cleared.
+    pub(crate) fn reset(&mut self) {
+        self.dispatched = 0;
+        self.outstanding = 0;
+        self.filled = 0;
+        self.sealed_seen = 0;
+        self.violation = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::external::cb_hasher;
+    use crate::inline::TemplateKey40;
+    use noodles::sam::Header;
+
+    /// Minimal mapped BAM record: paired, forward, mate at the same locus, with
+    /// `aux` appended verbatim.
+    #[allow(clippy::cast_possible_truncation)]
+    fn mapped_bam(tid: i32, pos: i32, name: &[u8], aux: &[u8]) -> Vec<u8> {
+        let mut bam = vec![0u8; 32];
+        bam[0..4].copy_from_slice(&tid.to_le_bytes());
+        bam[4..8].copy_from_slice(&pos.to_le_bytes());
+        bam[8] = (name.len() + 1) as u8;
+        bam[14..16].copy_from_slice(&3u16.to_le_bytes());
+        bam[20..24].copy_from_slice(&tid.to_le_bytes());
+        bam[24..28].copy_from_slice(&pos.to_le_bytes());
+        bam.extend_from_slice(name);
+        bam.push(0);
+        bam.extend_from_slice(aux);
+        bam
+    }
+
+    /// `CB:Z:<value>` aux bytes.
+    fn cb_aux(value: &[u8]) -> Vec<u8> {
+        let mut aux = b"CBZ".to_vec();
+        aux.extend_from_slice(value);
+        aux.push(0);
+        aux
+    }
+
+    /// Pack `records` into one segment and describe them as a batch would see
+    /// them, returning `(segment, extents)`.
+    /// A packed fixture segment and the extents describing the records in it.
+    type PackedSegment = (Arc<Vec<u8>>, Box<[(u64, u32)]>);
+
+    fn pack(records: &[Vec<u8>]) -> PackedSegment {
+        let mut segment = Vec::new();
+        let mut extents = Vec::new();
+        for r in records {
+            let len = u32::try_from(r.len()).expect("fixture records are small");
+            extents.push((segment.len() as u64, len));
+            segment.extend_from_slice(r);
+        }
+        (Arc::new(segment), extents.into_boxed_slice())
+    }
+
+    /// A context whose baseline is `records[0]` and which retains every lane, so
+    /// no record can trip the dropped-lane check.
+    fn context(records: &[Vec<u8>], cell_tag: Option<SamTag>) -> Arc<KeyContext> {
+        let lib_lookup = LibraryLookup::from_header(&Header::default());
+        let hasher = cb_hasher();
+        let first_key = extract_template_key_inline(&records[0], &lib_lookup, cell_tag, &hasher);
+        Arc::new(KeyContext {
+            lib_lookup,
+            cell_tag,
+            cb_hasher: hasher,
+            first_key,
+            variant: TemplateKeyVariant { cb: true, tertiary: true },
+        })
+    }
+
+    fn run_batch<K: TemplateLaneKey + Send + 'static>(
+        ctx: Arc<KeyContext>,
+        segment: Arc<Vec<u8>>,
+        extents: Box<[(u64, u32)]>,
+        first_ref: usize,
+    ) -> Option<KeyBatchResult<K>> {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let job: Box<dyn KeyExtractionJob> = Box::new(TemplateKeyBatch::<K> {
+            ctx,
+            segment,
+            segment_base: 0,
+            first_ref,
+            extents,
+            results: tx,
+        });
+        job.run();
+        rx.try_recv().ok()
+    }
+
+    #[test]
+    fn test_a_batch_extracts_the_keys_serial_extraction_would_have() {
+        // The whole change is only safe if deferring extraction cannot alter the
+        // key, so this compares against the serial call the ingest loop used to
+        // make, record for record.
+        let records: Vec<Vec<u8>> =
+            (0..8).map(|i| mapped_bam(1, 100 + i, format!("read{i}").as_bytes(), &[])).collect();
+        let ctx = context(&records, None);
+        let (segment, extents) = pack(&records);
+
+        let result: KeyBatchResult<TemplateKey40> =
+            run_batch(Arc::clone(&ctx), segment, extents, 0).expect("batch publishes a result");
+
+        let expected: Vec<TemplateKey40> = records
+            .iter()
+            .map(|r| {
+                let full =
+                    extract_template_key_inline(r, &ctx.lib_lookup, ctx.cell_tag, &ctx.cb_hasher);
+                TemplateLaneKey::from_full(&full)
+            })
+            .collect();
+
+        assert_eq!(result.first_ref, 0);
+        assert_eq!(result.keys.len(), 8);
+        assert_eq!(&result.keys[..], &expected[..]);
+        assert!(result.violation.is_none());
+    }
+
+    #[test]
+    fn test_a_batch_reports_the_lowest_indexed_violation_not_the_last() {
+        // Batches run in whatever order the pool picks them up, so the reported
+        // record has to be the first offending one or the error message is not
+        // reproducible across runs. Two records violate here; the earlier must win.
+        let mut records = vec![mapped_bam(1, 100, b"r0", &cb_aux(b"AAAA"))];
+        records.push(mapped_bam(1, 101, b"r1", &cb_aux(b"AAAA")));
+        records.push(mapped_bam(1, 102, b"r2", &cb_aux(b"CCCC")));
+        records.push(mapped_bam(1, 103, b"r3", &cb_aux(b"AAAA")));
+        records.push(mapped_bam(1, 104, b"r4", &cb_aux(b"GGGG")));
+
+        // Force the CB lane to be dropped so the differing barcodes violate.
+        let lib_lookup = LibraryLookup::from_header(&Header::default());
+        let hasher = cb_hasher();
+        let first_key =
+            extract_template_key_inline(&records[0], &lib_lookup, Some(SamTag::CB), &hasher);
+        let ctx = Arc::new(KeyContext {
+            lib_lookup,
+            cell_tag: Some(SamTag::CB),
+            cb_hasher: hasher,
+            first_key,
+            variant: TemplateKeyVariant { cb: false, tertiary: false },
+        });
+
+        let (segment, extents) = pack(&records);
+        // `first_ref` is deliberately non-zero: the reported index must be the
+        // record's position in the chunk, not in the batch.
+        let result: KeyBatchResult<crate::inline::TemplateKey24> =
+            run_batch(ctx, segment, extents, 1000).expect("batch publishes a result");
+
+        let v = result.violation.expect("a dropped CB lane must be reported");
+        assert_eq!(v.ref_index, 1002, "the first violating record is r2, at chunk index 1002");
+        assert_eq!(v.name, "r2");
+    }
+
+    #[test]
+    fn test_a_multi_segment_ingest_keys_every_record_exactly_once() {
+        // The end-to-end contract, and the only test that reaches the
+        // dispatch-on-seal path: drive a real buffer and a real pool across
+        // several arena segments, then check every key against what the serial
+        // extraction this replaced would have produced. A batch that read the
+        // wrong segment, double-counted a range, or silently skipped the live
+        // segment's tail all show up here as a wrong or placeholder key.
+        use crate::codec::SpillCodec;
+        use crate::inline::TemplateRecordBuffer;
+        use crate::worker_pool::SortWorkerPool;
+
+        // Small enough that a few hundred records fill several segments.
+        const SEGMENT: usize = 4096;
+
+        let records: Vec<Vec<u8>> = (0..600i32)
+            .map(|i| {
+                let name = format!("read{i:05}");
+                // Vary length so records straddle segment boundaries unevenly.
+                let filler = vec![b'N'; usize::try_from(i % 37).expect("non-negative")];
+                let mut aux = b"MCZ".to_vec();
+                aux.extend_from_slice(&filler);
+                aux.push(0);
+                mapped_bam(1, 1000 + (i % 97), name.as_bytes(), &aux)
+            })
+            .collect();
+        let ctx = context(&records, None);
+
+        let pool = SortWorkerPool::new(4, 1, 6, SpillCodec::Bgzf);
+        pool.set_phase(crate::worker_pool::phase::PHASE1);
+
+        let mut buffer =
+            TemplateRecordBuffer::<TemplateKey40>::with_segment_size(600, SEGMENT, SEGMENT);
+        let mut deferred = DeferredKeys::<TemplateKey40>::new(Arc::clone(&ctx), 4);
+        for record in &records {
+            buffer.push_deferred(record).expect("push");
+            deferred.after_push(&mut buffer, &pool);
+        }
+        assert!(
+            buffer.sealed_segments() > 2,
+            "the fixture must span several segments to exercise seal-driven dispatch, got {}",
+            buffer.sealed_segments(),
+        );
+
+        // Most records must have been dispatched *before* the barrier. Without
+        // this the test passes with mid-stream dispatch disabled entirely — the
+        // barrier would extract everything and the keys would still be right,
+        // which is exactly how this optimization could silently do nothing.
+        assert_eq!(
+            deferred.overlap_census().total_records(),
+            0,
+            "the census is only taken at the barrier"
+        );
+
+        let violation = deferred.finish(&mut buffer, &pool).expect("no worker panics");
+        assert!(violation.is_none(), "no record drops a retained lane here");
+
+        let census = deferred.overlap_census();
+        let overlapped = census.overlapped_records;
+        assert_eq!(census.total_records(), records.len() as u64);
+        assert!(
+            overlapped > (records.len() as u64) / 2,
+            "most keys must be extracted while ingest is still reading; \
+             only {overlapped} of {} were",
+            records.len(),
+        );
+
+        let expected: Vec<TemplateKey40> = records
+            .iter()
+            .map(|r| {
+                let full =
+                    extract_template_key_inline(r, &ctx.lib_lookup, ctx.cell_tag, &ctx.cb_hasher);
+                TemplateLaneKey::from_full(&full)
+            })
+            .collect();
+        let got: Vec<TemplateKey40> = buffer.refs().iter().map(|r| r.key).collect();
+        assert_eq!(got, expected, "every record must carry the key serial extraction gives it");
+
+        // And the bytes must still be retrievable at the offsets the refs claim.
+        for (i, r) in buffer.refs().iter().enumerate() {
+            assert_eq!(buffer.get_record(r), &records[i][..], "record {i} bytes");
+        }
+    }
+
+    #[test]
+    fn test_a_single_worker_pool_keys_inline_and_reports_no_overlap() {
+        // With one worker there is no second thread for a batch to run on, so
+        // deferral is skipped and extraction happens in the push, as it did
+        // before this change. The keys must be identical either way, and the
+        // census must say plainly that nothing overlapped rather than going
+        // silent — a run reporting no deferral information at all would be
+        // indistinguishable from deferral that broke.
+        use crate::codec::SpillCodec;
+        use crate::inline::TemplateRecordBuffer;
+        use crate::worker_pool::SortWorkerPool;
+
+        const SEGMENT: usize = 4096;
+
+        let records: Vec<Vec<u8>> = (0..200i32)
+            .map(|i| mapped_bam(1, 500 + i, format!("q{i:04}").as_bytes(), &[]))
+            .collect();
+        let ctx = context(&records, None);
+
+        let pool = SortWorkerPool::new(1, 1, 6, SpillCodec::Bgzf);
+        pool.set_phase(crate::worker_pool::phase::PHASE1);
+
+        let mut buffer =
+            TemplateRecordBuffer::<TemplateKey40>::with_segment_size(200, SEGMENT, SEGMENT);
+        let mut deferred = DeferredKeys::<TemplateKey40>::new(Arc::clone(&ctx), 1);
+        for record in &records {
+            deferred.push(&mut buffer, &pool, record).expect("push");
+        }
+        let violation = deferred.finish(&mut buffer, &pool).expect("no worker panics");
+        assert!(violation.is_none());
+
+        let expected: Vec<TemplateKey40> = records
+            .iter()
+            .map(|r| {
+                let full =
+                    extract_template_key_inline(r, &ctx.lib_lookup, ctx.cell_tag, &ctx.cb_hasher);
+                TemplateLaneKey::from_full(&full)
+            })
+            .collect();
+        let got: Vec<TemplateKey40> = buffer.refs().iter().map(|r| r.key).collect();
+        assert_eq!(got, expected, "inline extraction must give the same keys");
+
+        let census = deferred.overlap_census();
+        assert_eq!(census.total_records(), records.len() as u64, "the census still sums");
+        assert_eq!(census.overlap_percent(), Some(0.0), "nothing can overlap with one worker");
+    }
+
+    #[test]
+    fn test_a_single_worker_pool_still_rejects_a_dropped_lane() {
+        // The immediate path has its own error return, so it needs its own
+        // coverage: a violation must surface as an error from the push rather
+        // than silently keying the record under a lane the sort dropped.
+        use crate::codec::SpillCodec;
+        use crate::inline::{TemplateKey24, TemplateRecordBuffer};
+        use crate::worker_pool::SortWorkerPool;
+
+        let records = [
+            mapped_bam(1, 100, b"okay", &cb_aux(b"AAAA")),
+            mapped_bam(1, 101, b"bad", &cb_aux(b"TTTT")),
+        ];
+        let lib_lookup = LibraryLookup::from_header(&Header::default());
+        let hasher = cb_hasher();
+        let first_key =
+            extract_template_key_inline(&records[0], &lib_lookup, Some(SamTag::CB), &hasher);
+        let ctx = Arc::new(KeyContext {
+            lib_lookup,
+            cell_tag: Some(SamTag::CB),
+            cb_hasher: hasher,
+            first_key,
+            variant: TemplateKeyVariant { cb: false, tertiary: false },
+        });
+
+        let pool = SortWorkerPool::new(1, 1, 6, SpillCodec::Bgzf);
+        pool.set_phase(crate::worker_pool::phase::PHASE1);
+        let mut buffer = TemplateRecordBuffer::<TemplateKey24>::with_capacity(2, 4096);
+        let mut deferred = DeferredKeys::<TemplateKey24>::new(ctx, 1);
+
+        deferred.push(&mut buffer, &pool, &records[0]).expect("the baseline record is fine");
+        let err = deferred
+            .push(&mut buffer, &pool, &records[1])
+            .expect_err("the offending record must be rejected");
+        assert!(err.to_string().contains("bad"), "the error names the record: {err}");
+    }
+
+    #[test]
+    fn test_a_multi_segment_ingest_reports_a_violation_in_a_sealed_segment() {
+        // A dropped-lane violation found by a *worker*, mid-stream, has to reach
+        // the ingest thread — the serial path could return the error inline, and
+        // this one cannot.
+        use crate::codec::SpillCodec;
+        use crate::inline::{TemplateKey24, TemplateRecordBuffer};
+        use crate::worker_pool::SortWorkerPool;
+
+        const SEGMENT: usize = 4096;
+
+        let mut records: Vec<Vec<u8>> = (0..400)
+            .map(|i| mapped_bam(1, 1000 + i, format!("r{i:04}").as_bytes(), &cb_aux(b"AAAA")))
+            .collect();
+        // One offender, early enough to land in a sealed segment.
+        records[7] = mapped_bam(1, 1007, b"offender", &cb_aux(b"TTTT"));
+
+        let lib_lookup = LibraryLookup::from_header(&Header::default());
+        let hasher = cb_hasher();
+        let first_key =
+            extract_template_key_inline(&records[0], &lib_lookup, Some(SamTag::CB), &hasher);
+        let ctx = Arc::new(KeyContext {
+            lib_lookup,
+            cell_tag: Some(SamTag::CB),
+            cb_hasher: hasher,
+            first_key,
+            variant: TemplateKeyVariant { cb: false, tertiary: false },
+        });
+
+        let pool = SortWorkerPool::new(4, 1, 6, SpillCodec::Bgzf);
+        pool.set_phase(crate::worker_pool::phase::PHASE1);
+
+        let mut buffer =
+            TemplateRecordBuffer::<TemplateKey24>::with_segment_size(400, SEGMENT, SEGMENT);
+        let mut deferred = DeferredKeys::<TemplateKey24>::new(ctx, 4);
+        for record in &records {
+            buffer.push_deferred(record).expect("push");
+            deferred.after_push(&mut buffer, &pool);
+        }
+        let violation = deferred
+            .finish(&mut buffer, &pool)
+            .expect("no worker panics")
+            .expect("the offender must be reported");
+        assert_eq!(violation.ref_index, 7);
+        assert_eq!(violation.name, "offender");
+    }
+
+    #[test]
+    fn test_a_batch_whose_receiver_is_gone_finishes_quietly() {
+        // The ingest thread drops the receiver when it fails, and outstanding
+        // batches must not panic on the way out or a real error is replaced by a
+        // worker panic.
+        let records = vec![mapped_bam(1, 100, b"r0", &[])];
+        let ctx = context(&records, None);
+        let (segment, extents) = pack(&records);
+
+        let (tx, rx) = std::sync::mpsc::channel::<KeyBatchResult<TemplateKey40>>();
+        drop(rx);
+        let job: Box<dyn KeyExtractionJob> = Box::new(TemplateKeyBatch::<TemplateKey40> {
+            ctx,
+            segment,
+            segment_base: 0,
+            first_ref: 0,
+            extents,
+            results: tx,
+        });
+        job.run();
+    }
+
+    #[test]
+    fn test_a_batch_reads_at_its_segments_base_not_the_arenas() {
+        // Extents are global arena offsets while the segment handle is local, so
+        // the batch has to subtract its base. Getting this wrong reads the wrong
+        // record and silently produces a plausible-but-wrong key rather than
+        // failing, which is why it is pinned separately.
+        const BASE: u64 = 4096;
+
+        let records: Vec<Vec<u8>> =
+            (0..4).map(|i| mapped_bam(1, 200 + i, format!("s{i}").as_bytes(), &[])).collect();
+        let ctx = context(&records, None);
+        let (segment, local_extents) = pack(&records);
+        let shifted: Box<[(u64, u32)]> =
+            local_extents.iter().map(|&(o, l)| (o + BASE, l)).collect();
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let job: Box<dyn KeyExtractionJob> = Box::new(TemplateKeyBatch::<TemplateKey40> {
+            ctx: Arc::clone(&ctx),
+            segment,
+            segment_base: BASE,
+            first_ref: 0,
+            extents: shifted,
+            results: tx,
+        });
+        job.run();
+        let result = rx.try_recv().expect("batch publishes a result");
+
+        let expected: Vec<TemplateKey40> = records
+            .iter()
+            .map(|r| {
+                let full =
+                    extract_template_key_inline(r, &ctx.lib_lookup, ctx.cell_tag, &ctx.cb_hasher);
+                TemplateLaneKey::from_full(&full)
+            })
+            .collect();
+        assert_eq!(&result.keys[..], &expected[..]);
+    }
+}

--- a/crates/fgumi-sort/src/phase1_keys.rs
+++ b/crates/fgumi-sort/src/phase1_keys.rs
@@ -95,6 +95,51 @@ pub(crate) trait KeyExtractionJob: Send {
     fn run(self: Box<Self>);
 }
 
+/// Bytes ahead of the current record to software-prefetch while extracting keys.
+///
+/// A batch reads record bodies out of a **sealed** arena segment — bytes the
+/// ingest thread wrote up to a segment ago and which are long gone from cache by
+/// the time a worker gets to them. The scan is therefore latency-bound on cache
+/// misses rather than compute-bound, and prefetching ahead hides them.
+///
+/// 2 KiB is `main-runall`'s measured value for the same shape of scan (a cold
+/// ~2.6 GiB arena at ~220 B/record): 2 KiB gave the best speedup (~15%), ≤1 KiB
+/// was negligible (too little lead time) and 4 KiB matched 2 KiB. At our ~250
+/// B/record that is ~8 records of lead.
+const KEY_PREFETCH_DISTANCE: usize = 2048;
+
+/// Software-prefetch (read, into L1, temporal) the cache line containing `byte`.
+///
+/// SAFETY: both `prfm pldl1keep` (`aarch64`) and `_mm_prefetch` (`x86_64`) are
+/// *non-faulting hints* — they never read or write observable memory and never
+/// trap, even on an unmapped address. `byte` is a live `&u8`, so the pointer is
+/// valid to name. Cribbed from `main-runall`'s `prefetch_read_l1`; a no-op on
+/// other architectures.
+#[inline]
+fn prefetch_read_l1(byte: &u8) {
+    let ptr: *const u8 = byte;
+    #[cfg(target_arch = "aarch64")]
+    #[allow(unsafe_code)]
+    // SAFETY: a non-faulting prefetch hint over a valid pointer.
+    unsafe {
+        core::arch::asm!(
+            "prfm pldl1keep, [{p}]",
+            p = in(reg) ptr,
+            options(nostack, readonly, preserves_flags),
+        );
+    }
+    #[cfg(target_arch = "x86_64")]
+    #[allow(unsafe_code)]
+    // SAFETY: a non-faulting prefetch hint over a valid pointer.
+    unsafe {
+        core::arch::x86_64::_mm_prefetch::<{ core::arch::x86_64::_MM_HINT_T0 }>(ptr.cast());
+    }
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+    {
+        let _ = ptr; // no portable stable prefetch; the hint is a no-op elsewhere
+    }
+}
+
 /// Extract one record's full key and check the lanes the chosen variant drops.
 ///
 /// The single extraction implementation, shared by the batched path and the
@@ -135,6 +180,11 @@ where
         for (i, &(offset, len)) in me.extents.iter().enumerate() {
             let local = usize::try_from(offset - me.segment_base)
                 .expect("record offset precedes its own segment");
+            // Pull the bytes this scan will reach shortly into L1 while the
+            // current record is being parsed.
+            if let Some(ahead) = me.segment.get(local + KEY_PREFETCH_DISTANCE) {
+                prefetch_read_l1(ahead);
+            }
             let bam = &me.segment[local..local + len as usize];
 
             let (full, lane) = extract_one(ctx, bam);

--- a/crates/fgumi-sort/src/phase1_stats.rs
+++ b/crates/fgumi-sort/src/phase1_stats.rs
@@ -130,6 +130,12 @@ pub(crate) const INGEST_SAMPLE_INTERVAL: u64 = 1021;
 
 /// Where the ingest thread's serial CPU goes, per record.
 ///
+/// **Per-record segments only.** Deferred key extraction is deliberately absent:
+/// its costs are per-*batch* and per-*chunk*, not per-record, so sampling one
+/// record in [`INGEST_SAMPLE_INTERVAL`] and scaling would be measuring a rare
+/// event with a method built for a uniform one. Those two are timed exactly
+/// instead and reported beside this partition, the same way `park_secs` is.
+///
 /// The floor line says this thread *is* the limit -- on a 16-thread whole-genome
 /// sort it is 137.2s of a 145.7s read span, against a worker-capacity floor of
 /// 22.4s -- so the only question left is what the 137.2s is made of. Nothing else
@@ -155,10 +161,6 @@ pub(crate) struct IngestSample {
     /// **Includes park time**, so it is not pure CPU -- `park_secs` measures that
     /// part exactly and separately.
     pub(crate) fetch: f64,
-    /// Extracting the sort key from the record bytes.
-    pub(crate) key: f64,
-    /// Verifying that the lanes the chosen key variant drops are constant.
-    pub(crate) verify: f64,
     /// Copying the record into the arena and appending its ref.
     pub(crate) push: f64,
     /// Counting the record toward the progress log.
@@ -173,8 +175,6 @@ impl IngestSample {
     pub(crate) fn scaled(self, scale: f64) -> Self {
         Self {
             fetch: self.fetch * scale,
-            key: self.key * scale,
-            verify: self.verify * scale,
             push: self.push * scale,
             tick: self.tick * scale,
             probe: self.probe * scale,
@@ -197,8 +197,6 @@ impl IngestSample {
         let fix = |v: f64| (v - per_segment).max(0.0);
         Self {
             fetch: fix(self.fetch),
-            key: fix(self.key),
-            verify: fix(self.verify),
             push: fix(self.push),
             tick: fix(self.tick),
             probe: fix(self.probe),
@@ -208,7 +206,7 @@ impl IngestSample {
     /// The six segments summed.
     #[must_use]
     pub(crate) fn total(self) -> f64 {
-        self.fetch + self.key + self.verify + self.push + self.tick + self.probe
+        self.fetch + self.push + self.tick + self.probe
     }
 }
 
@@ -519,22 +517,16 @@ mod tests {
 
     #[test]
     fn test_clock_correction_subtracts_one_pair_per_segment_per_sample() {
-        // Ten samples, 20 ns per pair, five segments: each segment carries
+        // Ten samples, 20 ns per pair, four segments: each segment carries
         // 10 x 20 ns = 200 ns of clock, and each is corrected independently.
-        let raw = IngestSample {
-            fetch: 1e-6,
-            key: 1e-6,
-            verify: 1e-7,
-            push: 1e-6,
-            tick: 1e-6,
-            probe: 1e-6,
-        };
+        // `tick` is deliberately *below* that, to exercise the clamp.
+        let raw = IngestSample { fetch: 1e-6, push: 1e-6, tick: 1e-7, probe: 1e-6 };
         let fixed = raw.corrected(10, 20);
         assert!((fixed.fetch - 0.8e-6).abs() < 1e-12, "got {}", fixed.fetch);
         // A segment cheaper than the clock that measured it clamps to zero rather
         // than going negative, which would read as a bug rather than as
         // "unresolvable by this method".
-        assert!((fixed.verify - 0.0).abs() < 1e-12, "got {}", fixed.verify);
+        assert!((fixed.tick - 0.0).abs() < 1e-12, "got {}", fixed.tick);
     }
 
     #[test]
@@ -543,10 +535,10 @@ mod tests {
         // works on the sampled scale. Applying them in the wrong order would
         // subtract one pair's cost from the *scaled* total rather than from each
         // sample, understating the correction by the scale factor.
-        let raw = IngestSample { key: 2e-6, ..IngestSample::default() };
+        let raw = IngestSample { push: 2e-6, ..IngestSample::default() };
         let corrected_then_scaled = raw.corrected(10, 20).scaled(1000.0);
         let scaled_then_corrected = raw.scaled(1000.0).corrected(10, 20);
-        assert!(corrected_then_scaled.key < scaled_then_corrected.key);
+        assert!(corrected_then_scaled.push < scaled_then_corrected.push);
     }
 
     #[test]

--- a/crates/fgumi-sort/src/phase1_stats.rs
+++ b/crates/fgumi-sort/src/phase1_stats.rs
@@ -271,6 +271,46 @@ impl IngestPartition {
 /// ~30 ns clock is well under 30 ms of measurement on a 124.5s step, five orders
 /// of magnitude below the quantity. [`IngestSample`] has to sample only because
 /// its loop runs 780 million times; this one does not.
+/// One thread's scheduler accounting: `(on_cpu_nanos, runqueue_wait_nanos,
+/// timeslices)`, read from `/proc/thread-self/schedstat`.
+///
+/// This is the measurement that separates the two stories a slower `read()`
+/// could be telling. If the call got slower because the thread lost the CPU —
+/// to the fifteen workers now extracting keys, or to anything else — the
+/// runqueue-wait delta across the call grows and the timeslice count rises. If
+/// it got slower because the *device* or the memory system delivered bytes more
+/// slowly, the thread was blocked on I/O the whole time and both stay flat.
+/// Wall-clock timing alone cannot tell those apart.
+///
+/// `/proc/thread-self` is Linux-only and needs no thread-id lookup; elsewhere
+/// this returns `None` and the report simply omits the section, which is why
+/// nothing downstream treats a missing sample as a zero.
+#[cfg(target_os = "linux")]
+pub(crate) fn thread_schedstat() -> Option<(u64, u64, u64)> {
+    let text = std::fs::read_to_string("/proc/thread-self/schedstat").ok()?;
+    parse_schedstat(&text)
+}
+
+/// Non-Linux stub: no scheduler accounting is available.
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn thread_schedstat() -> Option<(u64, u64, u64)> {
+    None
+}
+
+/// Parse a `schedstat` line: on-CPU nanos, runqueue-wait nanos, timeslices.
+///
+/// Split out from the read so it can be tested off Linux, where the proc file
+/// does not exist and the whole path would otherwise be unexercised — which is
+/// also why it is `dead_code`-exempt there: only the tests call it.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub(crate) fn parse_schedstat(text: &str) -> Option<(u64, u64, u64)> {
+    let mut fields = text.split_whitespace();
+    let on_cpu = fields.next()?.parse().ok()?;
+    let runqueue = fields.next()?.parse().ok()?;
+    let timeslices = fields.next()?.parse().ok()?;
+    Some((on_cpu, runqueue, timeslices))
+}
+
 #[derive(Debug, Default)]
 pub(crate) struct ReaderStats {
     /// `read()` calls made against the file, below the 2 MiB buffer.
@@ -287,6 +327,26 @@ pub(crate) struct ReaderStats {
     read_raw_nanos: AtomicU64,
     /// Nanoseconds pushing framed blocks onto the decompress queue.
     dispatch_nanos: AtomicU64,
+    /// Per-`read()` latency distribution.
+    ///
+    /// A uniform shift and a heavy tail are different diagnoses: the first says
+    /// every call got slower (the device or the memory system is delivering less
+    /// bandwidth), the second says most calls were fine and some stalled
+    /// (reclaim, contention spikes). The mean alone cannot tell them apart.
+    refill_latency: crate::merge_trace::DurationHistogram,
+    /// Runqueue wait accumulated by the reading thread *inside* `read()` calls.
+    refill_runqueue_nanos: AtomicU64,
+    /// On-CPU time accumulated by the reading thread inside `read()` calls.
+    refill_oncpu_nanos: AtomicU64,
+    /// Timeslices the reading thread was granted inside `read()` calls.
+    refill_timeslices: AtomicU64,
+    /// Refills for which a scheduler sample was actually available.
+    ///
+    /// Separate from `refills` on purpose: on a platform without
+    /// `/proc/thread-self/schedstat` this stays zero and the report omits the
+    /// section, rather than printing a zero runqueue wait that would read as
+    /// evidence the reader never lost the CPU.
+    refill_sched_samples: AtomicU64,
 }
 
 impl ReaderStats {
@@ -295,6 +355,18 @@ impl ReaderStats {
         self.refills.fetch_add(1, Ordering::Relaxed);
         self.refill_nanos.fetch_add(elapsed_nanos, Ordering::Relaxed);
         self.refill_bytes.fetch_add(bytes as u64, Ordering::Relaxed);
+        self.refill_latency.record(elapsed_nanos);
+    }
+
+    /// Record what the scheduler did to the reading thread during one `read()`.
+    ///
+    /// `on_cpu` and `runqueue` are deltas in nanoseconds and `timeslices` a
+    /// delta in count, taken across the call.
+    pub(crate) fn record_refill_sched(&self, on_cpu: u64, runqueue: u64, timeslices: u64) {
+        self.refill_oncpu_nanos.fetch_add(on_cpu, Ordering::Relaxed);
+        self.refill_runqueue_nanos.fetch_add(runqueue, Ordering::Relaxed);
+        self.refill_timeslices.fetch_add(timeslices, Ordering::Relaxed);
+        self.refill_sched_samples.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Record one framed batch: how long `read_raw_blocks` took and what it returned.
@@ -321,6 +393,11 @@ impl ReaderStats {
             read_raw_secs: secs(self.read_raw_nanos.load(Ordering::Relaxed)),
             dispatch_secs: secs(self.dispatch_nanos.load(Ordering::Relaxed)),
             step_secs,
+            refill_latency: self.refill_latency.snapshot(),
+            refill_runqueue_secs: secs(self.refill_runqueue_nanos.load(Ordering::Relaxed)),
+            refill_oncpu_secs: secs(self.refill_oncpu_nanos.load(Ordering::Relaxed)),
+            refill_timeslices: self.refill_timeslices.load(Ordering::Relaxed),
+            refill_sched_samples: self.refill_sched_samples.load(Ordering::Relaxed),
         }
     }
 }
@@ -338,9 +415,32 @@ pub(crate) struct ReaderReport {
     pub(crate) dispatch_secs: f64,
     /// Exact `ReadInputBlocks` busy total the parts should add up to.
     pub(crate) step_secs: f64,
+    /// Per-`read()` latency distribution.
+    pub(crate) refill_latency: crate::merge_trace::HistogramReport,
+    /// Seconds the reading thread spent waiting for a CPU inside `read()`.
+    pub(crate) refill_runqueue_secs: f64,
+    /// Seconds it spent on-CPU inside `read()`.
+    pub(crate) refill_oncpu_secs: f64,
+    /// Timeslices granted to it inside `read()`.
+    pub(crate) refill_timeslices: u64,
+    /// Refills that produced a scheduler sample; zero means unavailable here.
+    pub(crate) refill_sched_samples: u64,
 }
 
 impl ReaderReport {
+    /// Share of refill wall time the reading thread spent waiting for a CPU.
+    ///
+    /// The number that decides whether a slower `read()` is a scheduling
+    /// problem. Near zero means the thread was blocked on I/O the whole time and
+    /// the bytes simply arrived more slowly; a material share means it was
+    /// runnable and waiting, and the fix is scheduling rather than bandwidth.
+    pub(crate) fn refill_runqueue_share(&self) -> f64 {
+        if self.refill_secs <= 0.0 {
+            return 0.0;
+        }
+        self.refill_runqueue_secs / self.refill_secs
+    }
+
     /// Time inside `read_raw_blocks` that was **not** spent in a `read()`:
     /// header parse, validation, per-block allocation, and the body copy.
     ///
@@ -406,9 +506,20 @@ impl<R> TimedReader<R> {
 
 impl<R: std::io::Read> std::io::Read for TimedReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        // Two ~2 us proc reads per refill, against ~21k refills on a ~125s step:
+        // under 0.1% of the quantity measured, and the only way to tell a slower
+        // device from a thread that keeps losing the CPU.
+        let sched_before = thread_schedstat();
         let started = std::time::Instant::now();
         let result = self.inner.read(buf);
         let elapsed = u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX);
+        if let (Some(before), Some(after)) = (sched_before, thread_schedstat()) {
+            self.stats.record_refill_sched(
+                after.0.saturating_sub(before.0),
+                after.1.saturating_sub(before.1),
+                after.2.saturating_sub(before.2),
+            );
+        }
         // A failed read still cost time; counting zero bytes for it keeps the
         // throughput figure honest rather than crediting the failure with bytes.
         self.stats.record_refill(elapsed, result.as_ref().copied().unwrap_or(0));
@@ -418,6 +529,24 @@ impl<R: std::io::Read> std::io::Read for TimedReader<R> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn test_schedstat_parses_the_kernel_format() {
+        // Format is "<on_cpu_ns> <runqueue_wait_ns> <timeslices>"; the kernel
+        // appends a trailing newline.
+        assert_eq!(parse_schedstat("12345 678 9\n"), Some((12345, 678, 9)));
+        assert_eq!(parse_schedstat("0 0 0"), Some((0, 0, 0)));
+    }
+
+    #[test]
+    fn test_schedstat_refuses_a_line_it_does_not_understand() {
+        // A silently-wrong parse would report zero runqueue wait, which reads as
+        // "the reader never lost the CPU" -- the exact conclusion this
+        // measurement exists to test. Better to have no sample than a false one.
+        assert_eq!(parse_schedstat(""), None, "empty");
+        assert_eq!(parse_schedstat("12345 678"), None, "truncated: only two fields");
+        assert_eq!(parse_schedstat("version 15"), None, "not numeric");
+    }
+
     use super::*;
 
     /// A reader report built from the production cell's shape: 124.5s of step
@@ -432,6 +561,7 @@ mod tests {
             read_raw_secs: 121.4,
             dispatch_secs: 3.1,
             step_secs: 124.5,
+            ..ReaderReport::default()
         }
     }
 

--- a/crates/fgumi-sort/src/segmented_buf.rs
+++ b/crates/fgumi-sort/src/segmented_buf.rs
@@ -37,6 +37,14 @@ pub struct SegmentedBuf {
     /// The segment currently being appended to, with capacity `segment_size`
     /// (the first may be smaller — see [`with_capacity`](Self::with_capacity)).
     current: Vec<u8>,
+    /// Segment allocations reclaimed by [`reset_for_reuse`](Self::reset_for_reuse),
+    /// waiting to be used again.
+    ///
+    /// This is the whole point of `reset_for_reuse`: keeping the pages mapped
+    /// across a fill→spill→reset cycle instead of returning them to the
+    /// allocator, which returns them to the OS, which makes the next chunk fault
+    /// every page back in one at a time.
+    free: Vec<Vec<u8>>,
     /// Total bytes stored across all segments.
     total_len: usize,
 }
@@ -59,6 +67,7 @@ impl SegmentedBuf {
             segment_size,
             sealed: Vec::with_capacity(estimated_segments),
             current: Vec::with_capacity(first_cap),
+            free: Vec::new(),
             total_len: 0,
         }
     }
@@ -186,7 +195,52 @@ impl SegmentedBuf {
     /// Total allocated capacity in bytes across all segments.
     #[must_use]
     pub fn allocated_capacity(&self) -> usize {
-        self.sealed.iter().map(|s| s.capacity()).sum::<usize>() + self.current.capacity()
+        self.sealed.iter().map(|s| s.capacity()).sum::<usize>()
+            + self.free.iter().map(Vec::capacity).sum::<usize>()
+            + self.current.capacity()
+    }
+
+    /// Give back every retained segment allocation.
+    ///
+    /// Call once ingest is done. [`reset_for_reuse`](Self::reset_for_reuse)
+    /// keeps segments mapped so the *next* chunk does not re-fault them, but
+    /// after the last chunk there is no next fill and holding them just carries
+    /// the arena's peak footprint through the merge — measured at +1.68 GB of
+    /// peak RSS on the production cell, for no benefit.
+    pub fn release_retained(&mut self) {
+        self.free = Vec::new();
+    }
+
+    /// Segment allocations held for reuse but not currently part of the buffer.
+    #[must_use]
+    pub fn retained_segments(&self) -> usize {
+        self.free.len()
+    }
+
+    /// Empty the buffer **keeping every segment allocation** for the next fill.
+    ///
+    /// The counterpart to [`clear`](Self::clear), and the one a sort should use
+    /// between chunks. `clear` drops the sealed segments, which hands their
+    /// pages to the allocator and ultimately back to the OS; the next chunk then
+    /// takes a minor fault on every page it touches again. Measured on the
+    /// production cell (780M records, 44 chunks, ~8 GB of arena per chunk):
+    /// **25.9M minor faults** and ~25s of wall clock with `clear`, against
+    /// **18k faults** when the pages are simply kept.
+    ///
+    /// A segment a reader still holds cannot be reclaimed — its `Arc` is
+    /// dropped instead and the next fill allocates a replacement. That is a
+    /// correctness requirement, not an optimization: reusing storage a
+    /// key-extraction batch was still reading would overwrite its records
+    /// mid-flight.
+    pub fn reset_for_reuse(&mut self) {
+        for segment in std::mem::take(&mut self.sealed) {
+            if let Ok(mut owned) = Arc::try_unwrap(segment) {
+                owned.clear();
+                self.free.push(owned);
+            }
+        }
+        self.current.clear();
+        self.total_len = 0;
     }
 
     /// Number of allocated segments, sealed plus the one being appended to.
@@ -223,6 +277,7 @@ impl SegmentedBuf {
     /// rather than while it is still being read.
     pub fn clear(&mut self) {
         self.sealed.clear();
+        self.free.clear();
         self.current.clear();
         self.total_len = 0;
     }
@@ -249,7 +304,10 @@ impl SegmentedBuf {
         if remainder > 0 {
             self.total_len += self.segment_size - remainder;
         }
-        let filled = std::mem::replace(&mut self.current, Vec::with_capacity(self.segment_size));
+        // Reuse a retained allocation when there is one; only ask the OS for
+        // fresh pages when there is not.
+        let next = self.free.pop().unwrap_or_else(|| Vec::with_capacity(self.segment_size));
+        let filled = std::mem::replace(&mut self.current, next);
         self.sealed.push(Arc::new(filled));
     }
 
@@ -360,6 +418,61 @@ mod tests {
 
         assert_eq!(buf.slice(o1, 7), b"1234567");
         assert_eq!(buf.slice(o2, 5), b"abcde");
+    }
+
+    #[test]
+    fn test_reset_for_reuse_keeps_the_segment_allocations() {
+        // The whole point: a sort cycles fill -> spill -> reset once per chunk,
+        // and dropping the segments each time hands their pages back to the
+        // allocator, which returns them to the OS. The next chunk then faults
+        // every page back in. Measured on the production cell: 25.9M minor
+        // faults and ~25s of wall clock, against 18k faults when the pages are
+        // simply kept.
+        let mut buf = SegmentedBuf::with_capacity(0, 10);
+        for _ in 0..4 {
+            buf.extend_from_slice(b"0123456789");
+        }
+        let segments_before = buf.num_segments();
+        let capacity_before = buf.allocated_capacity();
+        assert!(segments_before >= 4, "fixture must span several segments");
+
+        buf.reset_for_reuse();
+
+        assert_eq!(buf.len(), 0, "the buffer is logically empty");
+        assert_eq!(
+            buf.allocated_capacity(),
+            capacity_before,
+            "reset must not give the allocations back",
+        );
+        assert_eq!(
+            buf.retained_segments(),
+            segments_before - 1,
+            "every sealed segment is retained for the next fill",
+        );
+
+        // Refilling consumes the retained segments rather than allocating.
+        for _ in 0..4 {
+            buf.extend_from_slice(b"0123456789");
+        }
+        assert_eq!(buf.retained_segments(), 0, "the refill reused them");
+        assert_eq!(buf.allocated_capacity(), capacity_before, "and allocated nothing new");
+        assert_eq!(buf.slice(0, 10), b"0123456789", "and the data is correct");
+    }
+
+    #[test]
+    fn test_reset_for_reuse_lets_go_of_a_segment_a_reader_still_holds() {
+        // A reclaimed segment must be exclusively owned. A key-extraction batch
+        // that outlived its chunk would otherwise have its bytes overwritten by
+        // the next chunk's records while it read them.
+        let mut buf = SegmentedBuf::with_capacity(0, 10);
+        buf.extend_from_slice(b"0123456789");
+        buf.extend_from_slice(b"abcde");
+        let held = buf.sealed_segment(0).expect("segment 0 is sealed");
+
+        buf.reset_for_reuse();
+
+        assert_eq!(buf.retained_segments(), 0, "the held segment cannot be reused");
+        assert_eq!(&held[..], b"0123456789", "and the reader still sees its bytes");
     }
 
     #[test]

--- a/crates/fgumi-sort/src/segmented_buf.rs
+++ b/crates/fgumi-sort/src/segmented_buf.rs
@@ -9,6 +9,8 @@
 //! Designed as a drop-in replacement for `Vec<u8>` in the sort buffer, where
 //! records are appended sequentially and later accessed by `(offset, len)`.
 
+use std::sync::Arc;
+
 /// Default segment size: 256 MiB.
 const DEFAULT_SEGMENT_SIZE: usize = 256 * 1024 * 1024;
 
@@ -23,8 +25,18 @@ const DEFAULT_SEGMENT_SIZE: usize = 256 * 1024 * 1024;
 pub struct SegmentedBuf {
     /// The fixed capacity of each segment.
     segment_size: usize,
-    /// Backing storage: one `Vec<u8>` per segment, each with capacity `segment_size`.
-    segments: Vec<Vec<u8>>,
+    /// Segments that are complete and will never be appended to again.
+    ///
+    /// Held behind `Arc` so a reader can be handed one segment while the writer
+    /// keeps appending to [`current`](Self::current). Splitting the finished
+    /// segments from the live one is what makes that safe *by construction*
+    /// rather than by asserting that a `Vec<Vec<u8>>` will not reallocate: the
+    /// writer never names a sealed segment again, so no `&mut` can alias the
+    /// `&` a reader holds.
+    sealed: Vec<Arc<Vec<u8>>>,
+    /// The segment currently being appended to, with capacity `segment_size`
+    /// (the first may be smaller — see [`with_capacity`](Self::with_capacity)).
+    current: Vec<u8>,
     /// Total bytes stored across all segments.
     total_len: usize,
 }
@@ -43,9 +55,12 @@ impl SegmentedBuf {
         // re-allocations as the buffer grows.
         let first_cap = capacity.min(segment_size);
         let estimated_segments = (capacity / segment_size).max(1);
-        let mut segments = Vec::with_capacity(estimated_segments);
-        segments.push(Vec::with_capacity(first_cap));
-        Self { segment_size, segments, total_len: 0 }
+        Self {
+            segment_size,
+            sealed: Vec::with_capacity(estimated_segments),
+            current: Vec::with_capacity(first_cap),
+            total_len: 0,
+        }
     }
 
     /// Create a new buffer with a default segment size of 256 MiB.
@@ -76,18 +91,12 @@ impl SegmentedBuf {
             self.segment_size,
         );
 
-        let seg = self.segments.last().expect("segments is never empty");
-        if seg.len() + data.len() > self.segment_size {
-            // Pad total_len to the next segment boundary so locate() works.
-            let remainder = self.total_len % self.segment_size;
-            if remainder > 0 {
-                self.total_len += self.segment_size - remainder;
-            }
-            self.segments.push(Vec::with_capacity(self.segment_size));
+        if self.current.len() + data.len() > self.segment_size {
+            self.advance_segment();
         }
 
         let offset = self.total_len;
-        self.segments.last_mut().expect("segments is never empty").extend_from_slice(data);
+        self.current.extend_from_slice(data);
         self.total_len += data.len();
         offset
     }
@@ -112,13 +121,8 @@ impl SegmentedBuf {
             self.segment_size,
         );
 
-        let seg = self.segments.last().expect("segments is never empty");
-        if seg.len() + additional > self.segment_size {
-            let remainder = self.total_len % self.segment_size;
-            if remainder > 0 {
-                self.total_len += self.segment_size - remainder;
-            }
-            self.segments.push(Vec::with_capacity(self.segment_size));
+        if self.current.len() + additional > self.segment_size {
+            self.advance_segment();
         }
         self.total_len
     }
@@ -134,10 +138,10 @@ impl SegmentedBuf {
     #[inline]
     pub fn extend_in_place(&mut self, data: &[u8]) {
         debug_assert!(
-            self.segments.last().is_some_and(|s| s.len() + data.len() <= self.segment_size),
+            self.current.len() + data.len() <= self.segment_size,
             "extend_in_place exceeds segment capacity; use reserve_contiguous first"
         );
-        self.segments.last_mut().expect("segments is never empty").extend_from_slice(data);
+        self.current.extend_from_slice(data);
         self.total_len += data.len();
     }
 
@@ -168,7 +172,8 @@ impl SegmentedBuf {
     #[must_use]
     pub fn slice(&self, offset: usize, len: usize) -> &[u8] {
         let (seg_idx, seg_offset) = self.locate(offset);
-        let seg = &self.segments[seg_idx];
+        let seg: &[u8] =
+            if seg_idx == self.sealed.len() { &self.current } else { &self.sealed[seg_idx] };
         assert!(
             seg_offset + len <= seg.len(),
             "slice ({offset}..{}) spans segment boundary (seg {seg_idx}, seg_offset {seg_offset}, seg_len {})",
@@ -181,20 +186,71 @@ impl SegmentedBuf {
     /// Total allocated capacity in bytes across all segments.
     #[must_use]
     pub fn allocated_capacity(&self) -> usize {
-        self.segments.iter().map(Vec::capacity).sum()
+        self.sealed.iter().map(|s| s.capacity()).sum::<usize>() + self.current.capacity()
     }
 
-    /// Number of allocated segments.
+    /// Number of allocated segments, sealed plus the one being appended to.
     #[must_use]
     pub fn num_segments(&self) -> usize {
-        self.segments.len()
+        self.sealed.len() + 1
     }
 
-    /// Clear all data, retaining the first segment's allocation.
+    /// Number of sealed segments — those that will never be appended to again.
+    ///
+    /// Segment indices `0..sealed_len()` are stable and shareable; index
+    /// `sealed_len()` is the live segment and is not.
+    #[must_use]
+    pub fn sealed_len(&self) -> usize {
+        self.sealed.len()
+    }
+
+    /// A shared handle to sealed segment `idx`, or `None` if `idx` is the live
+    /// segment (or past the end).
+    ///
+    /// The returned handle stays valid and byte-stable for as long as it is
+    /// held, including across [`clear`](Self::clear) — which is what lets a
+    /// worker read record bytes out of it while the writer fills later segments.
+    #[must_use]
+    pub fn sealed_segment(&self, idx: usize) -> Option<Arc<Vec<u8>>> {
+        self.sealed.get(idx).map(Arc::clone)
+    }
+
+    /// Clear all data, retaining the live segment's allocation.
+    ///
+    /// Sealed segments are released here. A handle handed out by
+    /// [`sealed_segment`](Self::sealed_segment) keeps its own segment alive
+    /// past this call, so the storage is freed when the last reader drops it
+    /// rather than while it is still being read.
     pub fn clear(&mut self) {
-        self.segments.truncate(1);
-        self.segments[0].clear();
+        self.sealed.clear();
+        self.current.clear();
         self.total_len = 0;
+    }
+
+    /// Seal the live segment so its bytes can be shared, if it holds anything.
+    ///
+    /// A no-op on an empty live segment, so calling it twice does not push an
+    /// empty segment or open a spurious gap. The writer's next append starts a
+    /// fresh segment, which wastes the tail of the sealed one — acceptable only
+    /// because the caller (the ingest thread's chunk barrier) is about to
+    /// [`clear`](Self::clear) the whole buffer anyway.
+    pub fn seal_current(&mut self) {
+        if !self.current.is_empty() {
+            self.advance_segment();
+        }
+    }
+
+    /// Seal the live segment and start a fresh one.
+    ///
+    /// Pads `total_len` to the next segment boundary first, so
+    /// [`locate`](Self::locate)'s division arithmetic stays exact.
+    fn advance_segment(&mut self) {
+        let remainder = self.total_len % self.segment_size;
+        if remainder > 0 {
+            self.total_len += self.segment_size - remainder;
+        }
+        let filled = std::mem::replace(&mut self.current, Vec::with_capacity(self.segment_size));
+        self.sealed.push(Arc::new(filled));
     }
 
     /// Translate a global byte offset to `(segment_index, offset_within_segment)`.
@@ -210,9 +266,9 @@ impl SegmentedBuf {
         let seg_idx = offset / self.segment_size;
         let seg_offset = offset % self.segment_size;
         debug_assert!(
-            seg_idx < self.segments.len(),
+            seg_idx <= self.sealed.len(),
             "locate({offset}): seg_idx {seg_idx} out of bounds (len {})",
-            self.segments.len()
+            self.sealed.len() + 1
         );
         (seg_idx, seg_offset)
     }
@@ -304,6 +360,43 @@ mod tests {
 
         assert_eq!(buf.slice(o1, 7), b"1234567");
         assert_eq!(buf.slice(o2, 5), b"abcde");
+    }
+
+    #[test]
+    fn test_a_segment_seals_only_once_a_later_one_starts() {
+        let mut buf = SegmentedBuf::with_capacity(0, 10);
+        buf.extend_from_slice(b"0123456789");
+
+        // The segment being appended to is never sealed: a worker handed it
+        // could observe a partial write, and the ingest thread still owns it.
+        assert_eq!(buf.sealed_len(), 0);
+        assert!(buf.sealed_segment(0).is_none());
+
+        // Starting segment 1 seals segment 0.
+        buf.extend_from_slice(b"abcde");
+        assert_eq!(buf.sealed_len(), 1);
+        assert_eq!(&buf.sealed_segment(0).expect("segment 0 is sealed")[..], b"0123456789");
+        assert!(buf.sealed_segment(1).is_none(), "the live segment is not sealed");
+    }
+
+    #[test]
+    fn test_a_sealed_segment_is_readable_while_later_segments_are_written() {
+        // The invariant the parallel key-extraction path rests on: a handle to a
+        // sealed segment stays valid and byte-stable no matter how much is
+        // appended afterwards. Without it, a worker reading record bytes races
+        // the ingest thread's growth.
+        let mut buf = SegmentedBuf::with_capacity(0, 10);
+        buf.extend_from_slice(b"0123456789");
+        buf.extend_from_slice(b"abcde");
+
+        let held = buf.sealed_segment(0).expect("segment 0 is sealed");
+
+        // Fill several more segments; segment 0's bytes must not move or change.
+        for _ in 0..4 {
+            buf.extend_from_slice(b"0123456789");
+        }
+        assert_eq!(&held[..], b"0123456789");
+        assert!(buf.num_segments() >= 5);
     }
 
     #[test]

--- a/crates/fgumi-sort/src/spill_reader.rs
+++ b/crates/fgumi-sort/src/spill_reader.rs
@@ -47,7 +47,7 @@ use std::collections::VecDeque;
 use std::fs::File;
 use std::io::{self, BufReader, Read};
 use std::os::unix::fs::FileExt;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 
 use crossbeam_queue::ArrayQueue;
@@ -59,6 +59,55 @@ use crossbeam_queue::ArrayQueue;
 /// 975 MB/s against 1081 MB/s at 4 MiB, so slices much below a megabyte start
 /// giving the gain back.
 pub(crate) const FILL_BYTES: usize = 4 * 1024 * 1024;
+
+/// Most streams the ramp will ever reach.
+///
+/// Eight already matched four on the storage that needs concurrency at all
+/// (1080 MB/s against 1081 on EBS gp3), and past this each extra stream is
+/// pool work that buys nothing.
+const MAX_STREAMS: usize = 8;
+
+/// Fills measured at one stream before choosing a stream count.
+///
+/// Long enough that one slow fill cannot move the decision, short enough that
+/// the probe costs 32 MiB of reading at whatever the device does unaided.
+const AUTO_PROBE_FILLS: usize = 8;
+
+/// Single-stream throughput at or above which concurrency has nothing to buy.
+///
+/// Derived from the consumer, not from the device: the ingest thread reads
+/// 43.1 GB in ~53s, so it can absorb about 810 MB/s, and a reader that already
+/// beats that is not what the sort is waiting on. This leaves ~1.5x headroom
+/// over that floor.
+///
+/// The two devices measured sit either side of it by a wide margin -- EBS gp3
+/// sustains 358 MB/s on one stream and wants four; a local instance-store SSD
+/// sustains 2214 MB/s and wants one, where forcing eight measured 1.8%
+/// *slower*. Anything from roughly 900 MB/s to 2 GB/s separates them.
+const AUTO_TARGET_BYTES_PER_SEC: f64 = 1_200_000_000.0;
+
+/// Streams to use, from what one stream measured.
+///
+/// `ceil(target / measured)`: enough streams to reach a rate the consumer
+/// cannot outrun, and no more. Measuring the *device* rather than the pipeline
+/// is what makes this work -- an earlier version compared fetch time against
+/// the reader's own elapsed time, which is a high fraction on every device
+/// because a reader mostly reads, and it duly ramped both gp3 and a local SSD
+/// to the cap.
+fn streams_for_measured_rate(bytes: u64, nanos: u64) -> usize {
+    if bytes == 0 || nanos == 0 {
+        return 1;
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let rate = bytes as f64 * 1e9 / nanos as f64;
+    let wanted = (AUTO_TARGET_BYTES_PER_SEC / rate).ceil();
+    if !wanted.is_finite() || wanted <= 1.0 {
+        return 1;
+    }
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let wanted = wanted as usize;
+    wanted.min(MAX_STREAMS)
+}
 
 /// Smallest slice worth offering to another worker.
 ///
@@ -110,6 +159,15 @@ pub(crate) struct FetchQueue {
     jobs: ArrayQueue<Arc<FetchSlice>>,
     offered: AtomicU64,
     taken: AtomicU64,
+    /// The stream count one uncontended probe measured, or 0 while none has.
+    ///
+    /// Shared because the thing being measured is the *device*, and a merge
+    /// reads K spill files at once: each reader would otherwise measure its own
+    /// share of a contended device, conclude it needs more streams, and add
+    /// contention. Measured on EBS gp3 -- phase 1 alone saw 335 MB/s and chose
+    /// four, while the 44 spill readers each saw 224-229 MB/s and chose six or
+    /// seven, which took the merge from 119.3s to 129.1s.
+    chosen_streams: AtomicUsize,
 }
 
 /// A [`Read`] over a file whose buffer is filled by concurrent positional reads.
@@ -140,6 +198,13 @@ pub(crate) struct ScatterReader {
     /// merge already sits at its consumer-serial floor, so all lookahead would
     /// buy there is `K * depth * FILL_BYTES` of extra buffers.
     lookahead: usize,
+    /// Whether to grow `streams` from what the fills measure. See
+    /// [`ramped_streams`].
+    auto: bool,
+    /// Bytes and nanoseconds the probe has measured at one stream so far.
+    probe_bytes: u64,
+    probe_nanos: u64,
+    probe_fills: usize,
 }
 
 /// A fill in flight: its slices, where they report, and where it began.
@@ -173,6 +238,7 @@ impl FetchQueue {
             jobs: ArrayQueue::new(workers.max(1) * 8),
             offered: AtomicU64::new(0),
             taken: AtomicU64::new(0),
+            chosen_streams: AtomicUsize::new(0),
         })
     }
 
@@ -202,6 +268,20 @@ impl FetchQueue {
     /// which no output check would ever notice.
     pub(crate) fn census(&self) -> (u64, u64) {
         (self.offered.load(Ordering::Relaxed), self.taken.load(Ordering::Relaxed))
+    }
+
+    /// The stream count a probe has already settled on, if any.
+    fn settled_streams(&self) -> Option<usize> {
+        match self.chosen_streams.load(Ordering::Relaxed) {
+            0 => None,
+            n => Some(n),
+        }
+    }
+
+    /// Publish what one uncontended probe measured, if nobody has yet.
+    fn settle_streams(&self, streams: usize) {
+        let _ =
+            self.chosen_streams.compare_exchange(0, streams, Ordering::Relaxed, Ordering::Relaxed);
     }
 
     /// Offer a slice, ignoring a full queue -- the filler reclaims either way.
@@ -273,7 +353,23 @@ impl ScatterReader {
             stats: None,
             pending: VecDeque::new(),
             lookahead: 0,
+            auto: false,
+            probe_bytes: 0,
+            probe_nanos: 0,
+            probe_fills: 0,
         })
+    }
+
+    /// Grow the stream count from what the fills measure, starting at one.
+    ///
+    /// Costs nothing before it has measured anything -- one stream is exactly
+    /// the pre-change path -- and only grows when the consumer is demonstrably
+    /// waiting on fills. See [`ramped_streams`].
+    #[must_use]
+    pub(crate) fn auto_tuned(mut self) -> Self {
+        self.auto = true;
+        self.streams = 1;
+        self
     }
 
     /// Keep `fills` in flight ahead of the consumer.
@@ -297,6 +393,22 @@ impl ScatterReader {
     pub(crate) fn timed(mut self, stats: Arc<crate::phase1_stats::ReaderStats>) -> Self {
         self.stats = Some(stats);
         self
+    }
+
+    /// Build a reader for a [`crate::external::ReadStreams`] setting, tuning
+    /// itself when asked.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file's length cannot be determined.
+    pub(crate) fn for_streams(
+        file: File,
+        offset: u64,
+        streams: crate::external::ReadStreams,
+        fetch: Option<Arc<FetchQueue>>,
+    ) -> io::Result<Self> {
+        let reader = Self::new(file, offset, streams.initial(), fetch)?;
+        Ok(if streams.is_auto() { reader.auto_tuned() } else { reader })
     }
 
     /// A buffer of exactly `len` bytes, recycled where possible.
@@ -400,6 +512,41 @@ impl ScatterReader {
         Ok(())
     }
 
+    /// Fold one single-stream fill into the probe, and decide once it has seen
+    /// enough. Decides exactly once; after that the reader stops measuring.
+    fn probe_fill(&mut self, bytes: u64, nanos: u64) {
+        // Self-guarding rather than relying on the caller to stop: deciding
+        // twice is exactly how the previous design went wrong, and a probe that
+        // cannot be re-armed cannot repeat it. Later fills also run at the
+        // chosen stream count, so they no longer measure one stream and would
+        // answer a different question.
+        if !self.auto {
+            return;
+        }
+        // Adopt an answer someone else already measured rather than measuring a
+        // contended device. In a merge this is every spill reader but the first.
+        if let Some(settled) = self.fetch.as_ref().and_then(|q| q.settled_streams()) {
+            self.streams = settled;
+            self.auto = false;
+            return;
+        }
+        self.probe_bytes = self.probe_bytes.saturating_add(bytes);
+        self.probe_nanos = self.probe_nanos.saturating_add(nanos);
+        self.probe_fills += 1;
+        if self.probe_fills < AUTO_PROBE_FILLS {
+            return;
+        }
+        let chosen = streams_for_measured_rate(self.probe_bytes, self.probe_nanos);
+        #[allow(clippy::cast_precision_loss)]
+        let mbps = self.probe_bytes as f64 * 1e3 / self.probe_nanos.max(1) as f64;
+        log::debug!("read streams: one stream measured {mbps:.0} MB/s, using {chosen}");
+        if let Some(queue) = &self.fetch {
+            queue.settle_streams(chosen);
+        }
+        self.streams = chosen;
+        self.auto = false;
+    }
+
     /// Make bytes available in `ready`, leaving it empty only at EOF.
     fn fill(&mut self) -> io::Result<()> {
         if self.pending.is_empty() {
@@ -409,7 +556,15 @@ impl ScatterReader {
             self.pending.push_back(first);
         }
         let pending = self.pending.pop_front().expect("just ensured non-empty");
+        let started = self.auto.then(std::time::Instant::now);
+        let fill_start = pending.start;
         self.collect(&pending)?;
+        if let Some(t0) = started {
+            self.probe_fill(
+                self.offset.saturating_sub(fill_start),
+                u64::try_from(t0.elapsed().as_nanos()).unwrap_or(u64::MAX),
+            );
+        }
         // Topped up after collecting rather than before, so the fills issued
         // here overlap the framing of what just landed rather than the wait for
         // it. At depth 0 this loop does nothing and the reader is demand-driven.
@@ -544,6 +699,155 @@ mod tests {
     fn scattered(path: &std::path::Path, offset: u64, streams: usize) -> ScatterReader {
         let file = File::open(path).expect("open");
         ScatterReader::new(file, offset, streams, Some(FetchQueue::new(4))).expect("reader")
+    }
+
+    #[test]
+    fn test_read_streams_parses_what_a_user_would_type() {
+        use crate::external::ReadStreams;
+        use std::str::FromStr;
+        assert_eq!(ReadStreams::from_str("auto"), Ok(ReadStreams::Auto));
+        assert_eq!(ReadStreams::from_str("AUTO"), Ok(ReadStreams::Auto), "case-insensitive");
+        assert_eq!(ReadStreams::from_str("1"), Ok(ReadStreams::Fixed(1)));
+        assert_eq!(ReadStreams::from_str("4"), Ok(ReadStreams::Fixed(4)));
+        // Zero streams cannot read anything, and silently promoting it to one
+        // would hide a typo behind a plausible-looking run.
+        assert!(ReadStreams::from_str("0").is_err(), "zero is rejected, not rounded up");
+        assert!(ReadStreams::from_str("four").is_err());
+        assert!(ReadStreams::from_str("-1").is_err());
+        assert!(ReadStreams::from_str("").is_err());
+    }
+
+    #[test]
+    fn test_read_streams_round_trips_through_its_display() {
+        // clap prints the default in `--help` via `Display`, so a value it
+        // shows has to be one it accepts.
+        use crate::external::ReadStreams;
+        use std::str::FromStr;
+        for value in [ReadStreams::Auto, ReadStreams::Fixed(1), ReadStreams::Fixed(8)] {
+            assert_eq!(ReadStreams::from_str(&value.to_string()), Ok(value));
+        }
+    }
+
+    /// Bytes and nanos for a device sustaining `mbps` on one stream.
+    fn probe_of(mbps: u64) -> (u64, u64) {
+        (mbps * 1_000_000, 1_000_000_000)
+    }
+
+    #[test]
+    fn test_the_probe_picks_the_stream_count_each_measured_device_wanted() {
+        // The two devices actually measured, at the rate one stream sustained
+        // on each. gp3 gained 28% from four streams; the instance-store SSD
+        // lost 1.8% from being pushed past one.
+        let (bytes, nanos) = probe_of(358);
+        assert_eq!(streams_for_measured_rate(bytes, nanos), 4, "EBS gp3 at 358 MB/s wants four");
+        let (bytes, nanos) = probe_of(2214);
+        assert_eq!(
+            streams_for_measured_rate(bytes, nanos),
+            1,
+            "a local SSD at 2214 MB/s wants one"
+        );
+    }
+
+    #[test]
+    fn test_the_probe_scales_between_those_two_points() {
+        // "Smarter than 1 or 4" is the point: the count is computed from the
+        // measurement, so storage between the two measured devices gets a
+        // count between the two answers.
+        assert_eq!(streams_for_measured_rate(probe_of(700).0, probe_of(700).1), 2);
+        assert_eq!(streams_for_measured_rate(probe_of(1199).0, probe_of(1199).1), 2);
+        assert_eq!(streams_for_measured_rate(probe_of(1200).0, probe_of(1200).1), 1);
+        assert_eq!(streams_for_measured_rate(probe_of(5000).0, probe_of(5000).1), 1);
+    }
+
+    #[test]
+    fn test_the_probe_is_capped_however_slow_the_device() {
+        // A very slow mount would ask for dozens of streams; past the cap they
+        // are pool work that buys nothing.
+        assert_eq!(streams_for_measured_rate(probe_of(10).0, probe_of(10).1), MAX_STREAMS);
+        assert_eq!(streams_for_measured_rate(1, u64::MAX), MAX_STREAMS);
+    }
+
+    #[test]
+    fn test_the_probe_refuses_to_divide_by_a_degenerate_measurement() {
+        // A zero-length or zero-byte probe would produce an infinity or a NaN,
+        // and a NaN comparison is false, which would silently pin the reader at
+        // whatever it happened to be.
+        assert_eq!(streams_for_measured_rate(0, 1_000), 1);
+        assert_eq!(streams_for_measured_rate(1_000, 0), 1);
+        assert_eq!(streams_for_measured_rate(0, 0), 1);
+    }
+
+    #[test]
+    fn test_the_probe_decides_once_and_then_stops_measuring() {
+        // Deciding repeatedly is what the previous design did, and it ramped
+        // every device to the cap. One decision on a device-rate measurement
+        // has no such failure mode -- but only if it really does stop.
+        let (file, _) = fixture(1024);
+        let handle = File::open(file.path()).expect("open");
+        let mut reader = ScatterReader::new(handle, 0, 1, Some(FetchQueue::new(4)))
+            .expect("reader")
+            .auto_tuned();
+        for _ in 0..AUTO_PROBE_FILLS {
+            reader.probe_fill(FILL_BYTES as u64, 12_000_000);
+        }
+        assert!(!reader.auto, "the probe must disarm itself");
+        assert_eq!(reader.streams, 4, "4 MiB in 12ms is ~350 MB/s, which wants four");
+        let settled = reader.streams;
+        for _ in 0..AUTO_PROBE_FILLS * 4 {
+            reader.probe_fill(FILL_BYTES as u64, 1);
+        }
+        assert_eq!(reader.streams, settled, "a disarmed probe must not revisit its answer");
+    }
+
+    #[test]
+    fn test_readers_sharing_a_queue_share_one_measurement() {
+        // What is being measured is the device, and a merge reads K spill files
+        // at once. Measured on EBS gp3: phase 1 alone saw 335 MB/s and chose
+        // four, while 44 concurrent spill readers each saw 224-229 MB/s of a
+        // device they were contending for and chose six or seven -- which took
+        // the merge from 119.3s to 129.1s. A second reader must adopt, not
+        // re-measure.
+        let (file, _) = fixture(1024);
+        let queue = FetchQueue::new(4);
+        let reader_with = || {
+            ScatterReader::new(
+                File::open(file.path()).expect("open"),
+                0,
+                1,
+                Some(Arc::clone(&queue)),
+            )
+            .expect("reader")
+            .auto_tuned()
+        };
+
+        let mut first = reader_with();
+        for _ in 0..AUTO_PROBE_FILLS {
+            first.probe_fill(FILL_BYTES as u64, 12_000_000);
+        }
+        assert_eq!(first.streams, 4, "the uncontended probe chooses four");
+
+        // The second reader is handed a *slow* measurement, as a contended one
+        // would be. It must ignore it and take the settled answer.
+        let mut second = reader_with();
+        second.probe_fill(FILL_BYTES as u64, 900_000_000);
+        assert_eq!(second.streams, 4, "adopted, not re-measured");
+        assert!(!second.auto, "and disarmed on the spot");
+        assert_eq!(second.probe_fills, 0, "without accumulating a probe of its own");
+    }
+
+    #[test]
+    fn test_an_incomplete_probe_decides_nothing() {
+        // Deciding early would let one slow fill choose the count for the run.
+        let (file, _) = fixture(1024);
+        let handle = File::open(file.path()).expect("open");
+        let mut reader = ScatterReader::new(handle, 0, 1, Some(FetchQueue::new(4)))
+            .expect("reader")
+            .auto_tuned();
+        for _ in 0..AUTO_PROBE_FILLS - 1 {
+            reader.probe_fill(FILL_BYTES as u64, 900_000_000);
+        }
+        assert_eq!(reader.streams, 1, "a probe one fill short must not decide");
+        assert!(reader.auto, "and must still be armed");
     }
 
     #[test]

--- a/crates/fgumi-sort/src/spill_reader.rs
+++ b/crates/fgumi-sort/src/spill_reader.rs
@@ -1,0 +1,691 @@
+//! Scattered reads for the sort's input and spill files.
+//!
+//! Both phases read a file through one blocking sequential `read()` at a time:
+//! phase 1 behind the exclusive `ReadInputBlocks` step, phase 2 behind each
+//! spill file's reader mutex. That is queue depth 1, and a device serves one
+//! stream far worse than several -- measured on the production volume, 358 MB/s
+//! against 1177 MB/s for four concurrent streams, with buffer size making no
+//! difference at all (2, 8 and 32 MiB all landed within 0.1%). A bigger single
+//! request is not more concurrency.
+//!
+//! Measured consequence on `1kg-wgs-HG00096` (t16, 44 spill runs): the merge
+//! read 52.6 GB of spill back at **313 MB/s**, costing 168.3s of worker-busy
+//! time, and phase 1's read span was 141.5s. Raising `read_ahead_kb` to 4096
+//! fixes both, but it is root-only and system-wide, so a tool cannot rely on
+//! it. `posix_fadvise` was measured as the per-file substitute and does not
+//! work -- `SEQUENTIAL` 359 MB/s and `WILLNEED` 348-350 MB/s against 360 with
+//! no hint, `strace` confirming the calls succeed and the kernel simply
+//! declines. That leaves doing the concurrency ourselves.
+//!
+//! # Why bytes and not blocks
+//!
+//! BGZF blocks and zstd frames are variable-length, so block *N*'s offset is
+//! unknowable without scanning from block 0 -- which is why framing is serial.
+//! It can stay that way: framing is ~4% of the reader's time. So a fill fetches
+//! fixed-size *byte* slices at known offsets and this type serves them in file
+//! order through a plain [`Read`]. The framers above are generic over `Read`
+//! and do not change.
+//!
+//! # Why the slices run on the pool
+//!
+//! The obvious implementation gives each reader its own threads. That was
+//! measured, and it works -- and it is wrong, because `--threads N` then buys
+//! the user N pool workers plus an ingest thread plus however many readers are
+//! live. On a 16 vCPU host the 4-stream configuration ran 21 threads and
+//! doubled involuntary context switches (1.39M to 2.81M). It won 31% of wall
+//! clock only because that box had five idle cores to lend.
+//!
+//! So a fill is offered to the pool as [`FetchSlice`] work any worker may
+//! steal, and the thread budget stays exactly `--threads` + the ingest thread.
+//! The filling thread reads the first slice itself and then **reclaims** every
+//! slice no worker has started, rather than waiting on it: submitting and
+//! blocking would deadlock the moment every worker is a filler waiting for
+//! slices nobody is left to run. Reclaim makes the worst case "exactly the
+//! single sequential read we do today", which is a slowdown and never a wedge.
+
+use std::collections::VecDeque;
+use std::fs::File;
+use std::io::{self, BufReader, Read};
+use std::os::unix::fs::FileExt;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+
+use crossbeam_queue::ArrayQueue;
+
+/// Bytes one fill fetches, across all its slices.
+///
+/// Twice the 2 MiB buffer the sequential path uses, so that at four streams a
+/// slice is still 1 MiB: the read ladder measured four 1 MiB streams at
+/// 975 MB/s against 1081 MB/s at 4 MiB, so slices much below a megabyte start
+/// giving the gain back.
+pub(crate) const FILL_BYTES: usize = 4 * 1024 * 1024;
+
+/// Smallest slice worth offering to another worker.
+///
+/// Below this the per-request overhead and the fill's own barrier cost more
+/// than the concurrency buys, so a small fill uses fewer slices than the stream
+/// count allows rather than splitting into pinpricks.
+const MIN_SLICE_BYTES: usize = 512 * 1024;
+
+/// One slice of a fill: read a byte range into the buffer waiting for it.
+///
+/// Cloned into the pool's queue as an `Arc` and also kept by the filling
+/// thread, so whichever gets to it first runs it and the other no-ops.
+pub(crate) struct FetchSlice {
+    file: Arc<File>,
+    offset: u64,
+    index: usize,
+    state: Arc<FillState>,
+}
+
+/// The parts of a fill its slices report back into.
+struct FillState {
+    progress: Mutex<FillProgress>,
+    completed: Condvar,
+}
+
+/// Slice buffers and how many are still outstanding.
+struct FillProgress {
+    slots: Vec<SlotState>,
+    remaining: usize,
+    error: Option<io::Error>,
+}
+
+/// A slice's buffer, and who has it.
+///
+/// The transition out of `Pending` under the mutex *is* the claim: exactly one
+/// thread can take the buffer, so a worker and the filling thread racing for
+/// the same slice cannot both read it, and no separate flag is needed.
+enum SlotState {
+    /// Sized and waiting for someone to read into it.
+    Pending(Vec<u8>),
+    /// Claimed; a thread is in `read_exact_at` right now.
+    InFlight,
+    /// Read, and holding its bytes.
+    Done(Vec<u8>),
+}
+
+/// Fill slices offered to the pool, with the census of what it took.
+pub(crate) struct FetchQueue {
+    jobs: ArrayQueue<Arc<FetchSlice>>,
+    offered: AtomicU64,
+    taken: AtomicU64,
+}
+
+/// A [`Read`] over a file whose buffer is filled by concurrent positional reads.
+pub(crate) struct ScatterReader {
+    file: Arc<File>,
+    len: u64,
+    offset: u64,
+    ready: VecDeque<Vec<u8>>,
+    /// How far the consumer has read into `ready`'s front slice. A cursor
+    /// rather than draining the front: the framers read a few bytes at a time,
+    /// and shifting a megabyte down by thirteen bytes per call would cost more
+    /// than the reads this saves.
+    front_pos: usize,
+    free: Vec<Vec<u8>>,
+    /// Where slices are offered. `None` reads every fill on this thread, which
+    /// is what the tests and any pool-less caller get.
+    fetch: Option<Arc<FetchQueue>>,
+    streams: usize,
+    /// Where to book fill time, when this reader is the one the phase-1
+    /// reader report describes. A fill is exactly what `TimedReader` measures
+    /// on the sequential arm -- the fetch, as opposed to the framing above it.
+    stats: Option<Arc<crate::phase1_stats::ReaderStats>>,
+}
+
+/// How one file's bytes are read.
+pub(crate) enum SpillSource {
+    /// One sequential stream -- what both phases did before, and what
+    /// `--read-streams 1` still does.
+    Sequential(BufReader<File>),
+    /// Several positional reads at once, run by pool workers.
+    Scattered(ScatterReader),
+}
+
+impl FetchQueue {
+    /// A queue sized for `workers` workers.
+    ///
+    /// Capacity only bounds how many slices can be *waiting*; a push that finds
+    /// it full is not an error, because the filling thread reclaims anything the
+    /// pool did not take.
+    pub(crate) fn new(workers: usize) -> Arc<Self> {
+        Arc::new(Self {
+            jobs: ArrayQueue::new(workers.max(1) * 8),
+            offered: AtomicU64::new(0),
+            taken: AtomicU64::new(0),
+        })
+    }
+
+    /// Whether any slice is waiting. Drives the step's eligibility.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.jobs.is_empty()
+    }
+
+    /// Run one offered slice. `false` means there was nothing left to do --
+    /// either the queue was empty, or the filling thread had already reclaimed
+    /// the slice this worker popped.
+    pub(crate) fn run_one(&self) -> bool {
+        let Some(slice) = self.jobs.pop() else {
+            return false;
+        };
+        if slice.run() {
+            self.taken.fetch_add(1, Ordering::Relaxed);
+            return true;
+        }
+        false
+    }
+
+    /// `(slices offered, slices a worker actually ran)`.
+    ///
+    /// The census for "did this engage at all". Zero taken means every fill was
+    /// read by the thread that wanted it, which is the pre-change behaviour and
+    /// which no output check would ever notice.
+    pub(crate) fn census(&self) -> (u64, u64) {
+        (self.offered.load(Ordering::Relaxed), self.taken.load(Ordering::Relaxed))
+    }
+
+    /// Offer a slice, ignoring a full queue -- the filler reclaims either way.
+    fn offer(&self, slice: &Arc<FetchSlice>) {
+        if self.jobs.push(Arc::clone(slice)).is_ok() {
+            self.offered.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+impl FetchSlice {
+    /// Read this slice, unless someone else already claimed it.
+    ///
+    /// Returns whether this call did the read, which is what lets a worker tell
+    /// "I helped" from "the filler beat me to it".
+    fn run(&self) -> bool {
+        let mut buf = {
+            let mut progress = self.state.progress.lock().expect("fill state poisoned");
+            match std::mem::replace(&mut progress.slots[self.index], SlotState::InFlight) {
+                SlotState::Pending(buf) => buf,
+                claimed => {
+                    progress.slots[self.index] = claimed;
+                    return false;
+                }
+            }
+        };
+        let result = self.file.read_exact_at(&mut buf, self.offset);
+        let mut progress = self.state.progress.lock().expect("fill state poisoned");
+        match result {
+            Ok(()) => progress.slots[self.index] = SlotState::Done(buf),
+            Err(e) => {
+                if progress.error.is_none() {
+                    progress.error = Some(e);
+                }
+            }
+        }
+        progress.remaining -= 1;
+        let last = progress.remaining == 0;
+        drop(progress);
+        if last {
+            self.state.completed.notify_all();
+        }
+        true
+    }
+}
+
+impl ScatterReader {
+    /// Read `file` from `offset`, offering slices to `fetch`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file's length cannot be determined.
+    pub(crate) fn new(
+        file: File,
+        offset: u64,
+        streams: usize,
+        fetch: Option<Arc<FetchQueue>>,
+    ) -> io::Result<Self> {
+        let len = file.metadata()?.len();
+        Ok(Self {
+            file: Arc::new(file),
+            len,
+            offset,
+            ready: VecDeque::new(),
+            front_pos: 0,
+            free: Vec::new(),
+            fetch,
+            streams: streams.max(1),
+            stats: None,
+        })
+    }
+
+    /// Book this reader's fills into `stats`, so framing and fetching stay
+    /// separable in the phase-1 reader report.
+    #[must_use]
+    pub(crate) fn timed(mut self, stats: Arc<crate::phase1_stats::ReaderStats>) -> Self {
+        self.stats = Some(stats);
+        self
+    }
+
+    /// A buffer of exactly `len` bytes, recycled where possible.
+    ///
+    /// Sized rather than cleared and refilled: `read_exact_at` overwrites every
+    /// byte, so zero-filling a recycled buffer of the right length is pure cost
+    /// over the gigabytes a sort reads.
+    fn take_buf(&mut self, len: usize) -> Vec<u8> {
+        let mut buf = self.free.pop().unwrap_or_default();
+        if buf.len() != len {
+            buf.resize(len, 0);
+        }
+        buf
+    }
+
+    /// Fetch the next [`FILL_BYTES`] as concurrent slices, appending them to
+    /// `ready` in file order. Leaves `ready` empty at EOF.
+    fn fill(&mut self) -> io::Result<()> {
+        let remaining = self.len.saturating_sub(self.offset);
+        if remaining == 0 {
+            return Ok(());
+        }
+        let want = usize::try_from(remaining.min(FILL_BYTES as u64)).expect("a fill fits usize");
+        // Never split below `MIN_SLICE_BYTES`: a fill near EOF is small, and
+        // cutting it into pinpricks costs more than the concurrency returns.
+        let slices = self.streams.min(want.div_ceil(MIN_SLICE_BYTES)).max(1);
+        let slice_len = want.div_ceil(slices);
+        let base = self.offset;
+
+        if slices == 1 {
+            // The single-stream arm: no state, no offer, no barrier -- just the
+            // read this thread was going to do anyway.
+            let mut buf = self.take_buf(want);
+            self.file.read_exact_at(&mut buf, base)?;
+            self.ready.push_back(buf);
+            self.offset += want as u64;
+            return Ok(());
+        }
+
+        let bufs: Vec<Vec<u8>> = (0..slices)
+            .map(|index| self.take_buf(slice_len.min(want - index * slice_len)))
+            .collect();
+        let state = Arc::new(FillState {
+            progress: Mutex::new(FillProgress {
+                slots: bufs.into_iter().map(SlotState::Pending).collect(),
+                remaining: slices,
+                error: None,
+            }),
+            completed: Condvar::new(),
+        });
+        let mine: Vec<Arc<FetchSlice>> = (0..slices)
+            .map(|index| {
+                Arc::new(FetchSlice {
+                    file: Arc::clone(&self.file),
+                    offset: base + (index * slice_len) as u64,
+                    index,
+                    state: Arc::clone(&state),
+                })
+            })
+            .collect();
+
+        // Offer the later slices first so they can already be in flight, then
+        // walk every slice in order: the first is this thread's own, and the
+        // rest are reclaimed if no worker has started them. `run` no-ops on a
+        // slice someone else took, so this is both "do my share" and "take back
+        // what nobody wanted" in one pass -- and it is why a full queue, an
+        // empty pool, or a pool of workers all busy filling cannot wedge here.
+        if let Some(queue) = &self.fetch {
+            for slice in &mine[1..] {
+                queue.offer(slice);
+            }
+        }
+        for slice in &mine {
+            slice.run();
+        }
+
+        let mut progress = state.progress.lock().expect("fill state poisoned");
+        // Only slices a worker claimed before we got to them remain, and that
+        // worker is inside `read_exact_at` rather than waiting on anything, so
+        // this wait is bounded by one disk read.
+        while progress.remaining > 0 {
+            progress = state.completed.wait(progress).expect("fill state poisoned");
+        }
+        if let Some(e) = progress.error.take() {
+            // Nothing is published and `offset` has not moved, so the reader is
+            // exactly where it was and a caller that reads again re-reads the
+            // same range. That is why this needs no error latch.
+            return Err(e);
+        }
+        for slot in &mut progress.slots {
+            match std::mem::replace(slot, SlotState::InFlight) {
+                SlotState::Done(buf) => self.ready.push_back(buf),
+                _ => unreachable!("a fill with no error has every slice done"),
+            }
+        }
+        drop(progress);
+        self.offset += want as u64;
+        Ok(())
+    }
+}
+
+impl Read for ScatterReader {
+    fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+        if out.is_empty() {
+            return Ok(0);
+        }
+        if self.ready.is_empty() {
+            let before = self.offset;
+            let sched_before =
+                self.stats.as_ref().and_then(|_| crate::phase1_stats::thread_schedstat());
+            let started = std::time::Instant::now();
+            let outcome = self.fill();
+            if let Some(stats) = &self.stats {
+                let elapsed = u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX);
+                if let (Some(a), Some(b)) = (sched_before, crate::phase1_stats::thread_schedstat())
+                {
+                    stats.record_refill_sched(
+                        b.0.saturating_sub(a.0),
+                        b.1.saturating_sub(a.1),
+                        b.2.saturating_sub(a.2),
+                    );
+                }
+                // A failed fill still cost time; crediting it zero bytes keeps
+                // the throughput figure honest.
+                let fetched = usize::try_from(self.offset - before).unwrap_or(0);
+                stats.record_refill(elapsed, fetched);
+            }
+            outcome?;
+            if self.ready.is_empty() {
+                return Ok(0);
+            }
+        }
+        let front = self.ready.front().expect("just filled");
+        let n = out.len().min(front.len() - self.front_pos);
+        out[..n].copy_from_slice(&front[self.front_pos..self.front_pos + n]);
+        self.front_pos += n;
+        if self.front_pos == front.len() {
+            let done = self.ready.pop_front().expect("just borrowed");
+            self.free.push(done);
+            self.front_pos = 0;
+        }
+        Ok(n)
+    }
+}
+
+#[cfg(test)]
+impl ScatterReader {
+    /// Offset of the next byte the consumer will read.
+    fn position(&self) -> u64 {
+        let unconsumed: usize =
+            self.ready.iter().map(Vec::len).sum::<usize>().saturating_sub(self.front_pos);
+        self.offset.saturating_sub(unconsumed as u64)
+    }
+}
+
+#[cfg(test)]
+impl SpillSource {
+    /// Offset of the next byte the consumer will read.
+    ///
+    /// Test-only: production never asks. The codec-detection tests assert that
+    /// a zstd spill starts past `ZSPILL_MAGIC` and a BGZF one at byte 0, and
+    /// that has to hold on whichever arm the stream count selects.
+    pub(crate) fn position(&mut self) -> io::Result<u64> {
+        match self {
+            Self::Sequential(reader) => std::io::Seek::stream_position(reader),
+            Self::Scattered(reader) => Ok(reader.position()),
+        }
+    }
+}
+
+impl Read for SpillSource {
+    fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+        match self {
+            Self::Sequential(reader) => reader.read(out),
+            Self::Scattered(reader) => reader.read(out),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// A temp file of `len` pseudo-random bytes, plus the bytes themselves.
+    fn fixture(len: usize) -> (tempfile::NamedTempFile, Vec<u8>) {
+        let mut state = 0x2545_F491_4F6C_DD1Du64;
+        let bytes: Vec<u8> = (0..len)
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                u8::try_from((state >> 24) & 0xff).expect("masked to a byte")
+            })
+            .collect();
+        let mut f = tempfile::NamedTempFile::new().expect("temp file");
+        f.write_all(&bytes).expect("write");
+        f.flush().expect("flush");
+        (f, bytes)
+    }
+
+    fn read_all(reader: &mut impl Read, buf_size: usize) -> Vec<u8> {
+        let mut out = Vec::new();
+        let mut buf = vec![0u8; buf_size];
+        loop {
+            let n = reader.read(&mut buf).expect("read");
+            if n == 0 {
+                break;
+            }
+            out.extend_from_slice(&buf[..n]);
+        }
+        out
+    }
+
+    /// A reader whose slices are offered to a queue **nobody drains**, which is
+    /// the reclaim path: every test below therefore exercises it by default.
+    fn scattered(path: &std::path::Path, offset: u64, streams: usize) -> ScatterReader {
+        let file = File::open(path).expect("open");
+        ScatterReader::new(file, offset, streams, Some(FetchQueue::new(4))).expect("reader")
+    }
+
+    #[test]
+    fn test_delivers_the_file_verbatim_at_every_stream_count() {
+        // The contract that matters: splitting a fill must be invisible. A slice
+        // delivered out of order corrupts every BGZF block or zstd frame the
+        // sort then tries to parse.
+        let (file, expected) = fixture(FILL_BYTES * 2 + 98_765);
+        for streams in [1usize, 2, 4, 8] {
+            let got = read_all(&mut scattered(file.path(), 0, streams), 64 * 1024);
+            assert_eq!(got.len(), expected.len(), "length at {streams} streams");
+            assert!(got == expected, "bytes differ at {streams} streams");
+        }
+    }
+
+    #[test]
+    fn test_a_fill_completes_when_no_worker_ever_takes_a_slice() {
+        // Deadlock-freedom, stated directly. Every worker could be a filler
+        // waiting on slices nobody is left to run, so a fill that only ever
+        // *waits* for the pool wedges the sort. It must reclaim instead.
+        let (file, expected) = fixture(FILL_BYTES * 2);
+        let queue = FetchQueue::new(4);
+        let file_handle = File::open(file.path()).expect("open");
+        let mut reader =
+            ScatterReader::new(file_handle, 0, 4, Some(Arc::clone(&queue))).expect("reader");
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || drop(tx.send(read_all(&mut reader, 64 * 1024))));
+        let got = rx
+            .recv_timeout(std::time::Duration::from_secs(30))
+            .expect("the fill waited on a worker that never came");
+        assert!(got == expected, "reclaimed slices must still deliver the file");
+        let (offered, taken) = queue.census();
+        assert!(offered > 0, "slices were offered");
+        assert_eq!(taken, 0, "no worker was running, so none can have been taken");
+    }
+
+    #[test]
+    fn test_exactly_one_caller_ever_runs_a_slice() {
+        // The claim is a state transition under the fill's mutex, and this is
+        // what it has to guarantee: a worker and the reclaiming filler racing
+        // for the same slice must not both read it (a wasted read, and two
+        // buffers where one is expected) nor both skip it (a fill that never
+        // completes). Deterministic -- it asserts a count, not who won.
+        let (file, expected) = fixture(64 * 1024);
+        let state = Arc::new(FillState {
+            progress: Mutex::new(FillProgress {
+                slots: vec![SlotState::Pending(vec![0u8; expected.len()])],
+                remaining: 1,
+                error: None,
+            }),
+            completed: Condvar::new(),
+        });
+        let slice = Arc::new(FetchSlice {
+            file: Arc::new(File::open(file.path()).expect("open")),
+            offset: 0,
+            index: 0,
+            state: Arc::clone(&state),
+        });
+
+        let racers: Vec<_> = (0..8)
+            .map(|_| {
+                let slice = Arc::clone(&slice);
+                std::thread::spawn(move || usize::from(slice.run()))
+            })
+            .collect();
+        let winners: usize = racers.into_iter().map(|h| h.join().expect("racer")).sum();
+        assert_eq!(winners, 1, "exactly one caller may read a given slice");
+
+        let mut progress = state.progress.lock().expect("state");
+        assert_eq!(progress.remaining, 0, "the single read completed the fill");
+        match std::mem::replace(&mut progress.slots[0], SlotState::InFlight) {
+            SlotState::Done(buf) => assert!(buf == expected, "the winner read the right bytes"),
+            _ => panic!("the slice should be done"),
+        }
+    }
+
+    #[test]
+    fn test_a_worker_draining_the_queue_never_corrupts_the_bytes() {
+        // A live pool worker racing the filler for every slice of every fill.
+        // Deliberately asserts bytes only: whether the worker wins any given
+        // race depends on how long slice 0 takes, which is a page-cache hit
+        // here and a disk read in production. `test_exactly_one_caller...`
+        // covers the race itself; this covers the result.
+        let (file, expected) = fixture(FILL_BYTES * 6);
+        let queue = FetchQueue::new(4);
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let worker = {
+            let (queue, stop) = (Arc::clone(&queue), Arc::clone(&stop));
+            std::thread::spawn(move || {
+                while !stop.load(Ordering::Acquire) {
+                    if !queue.run_one() {
+                        std::thread::yield_now();
+                    }
+                }
+            })
+        };
+        let file_handle = File::open(file.path()).expect("open");
+        let mut reader =
+            ScatterReader::new(file_handle, 0, 4, Some(Arc::clone(&queue))).expect("reader");
+        let got = read_all(&mut reader, 64 * 1024);
+        stop.store(true, Ordering::Release);
+        worker.join().expect("worker");
+
+        assert!(got == expected, "bytes must match however the slices were shared");
+    }
+
+    #[test]
+    fn test_reading_starts_at_the_requested_offset() {
+        // A zstd spill's reader is positioned past `ZSPILL_MAGIC` rather than at
+        // byte 0. Ignoring the offset would feed the frame parser four bytes of
+        // magic it does not expect.
+        let (file, expected) = fixture(FILL_BYTES + 4096);
+        let got = read_all(&mut scattered(file.path(), 4, 4), 32 * 1024);
+        assert!(got == expected[4..], "did not start at byte 4");
+    }
+
+    #[test]
+    fn test_a_failed_fill_keeps_failing_instead_of_hanging() {
+        // Fills are demand-driven, so truncating the file after the reader has
+        // measured it makes the next fill read past EOF deterministically. A
+        // caller may call `read` again after an error; it must not park.
+        let (file, _) = fixture(FILL_BYTES * 2);
+        let mut reader = scattered(file.path(), 0, 4);
+        file.as_file().set_len(0).expect("truncate");
+        assert!(reader.read(&mut [0u8; 4096]).is_err(), "the first read reports the failure");
+        assert!(reader.read(&mut [0u8; 4096]).is_err(), "and so does every read after it");
+    }
+
+    #[test]
+    fn test_an_empty_file_reads_as_eof_rather_than_hanging() {
+        let (file, _) = fixture(0);
+        assert!(read_all(&mut scattered(file.path(), 0, 4), 4096).is_empty());
+    }
+
+    #[test]
+    fn test_tiny_reads_reassemble_across_slice_boundaries() {
+        // The framers read a few bytes at a time, so slice hand-offs land
+        // mid-call-sequence. Getting the advance wrong duplicates or skips bytes
+        // exactly at the seam between two slices of one fill.
+        let (file, expected) = fixture(FILL_BYTES + 7);
+        assert!(read_all(&mut scattered(file.path(), 0, 3), 13) == expected);
+    }
+
+    #[test]
+    fn test_one_stream_offers_nothing() {
+        // `--read-streams 1` must stay exactly as cheap as it is today: no
+        // slicing, no offer, no barrier -- just the read the caller wanted.
+        let (file, expected) = fixture(FILL_BYTES * 2);
+        let queue = FetchQueue::new(4);
+        let mut reader = ScatterReader::new(
+            File::open(file.path()).expect("open"),
+            0,
+            1,
+            Some(Arc::clone(&queue)),
+        )
+        .expect("reader");
+        assert!(read_all(&mut reader, 64 * 1024) == expected);
+        assert_eq!(queue.census().0, 0, "a single stream offered work to the pool");
+    }
+
+    #[test]
+    fn test_buffers_recycled_through_many_fills_deliver_the_file_verbatim() {
+        // Seven fills' worth, so every fill after the first reuses buffers the
+        // consumer handed back. Reusing one at a stale length corrupts the seam
+        // between one slice and the next, and only once recycling happens.
+        let (file, expected) = fixture(FILL_BYTES * 6 + 3);
+        assert!(read_all(&mut scattered(file.path(), 0, 2), 128 * 1024) == expected);
+    }
+
+    /// Threads in this process, from the kernel's own accounting.
+    ///
+    /// Linux-only, which is where CI and every benchmark host run. `nextest`
+    /// gives each test its own process, so this is a clean count rather than a
+    /// number shared with a test harness.
+    #[cfg(target_os = "linux")]
+    fn thread_count() -> usize {
+        std::fs::read_dir("/proc/self/task").expect("procfs").count()
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_scattered_reading_spawns_no_threads_of_its_own() {
+        // The whole reason this reader offers slices to the pool instead of
+        // owning threads: `--threads N` must buy N workers and the ingest
+        // thread, full stop. The previous design spawned N more per reader, and
+        // nothing in this suite noticed -- it took a 16 vCPU host running 21
+        // threads and double the involuntary context switches to surface it.
+        let (file, expected) = fixture(FILL_BYTES * 3);
+        let before = thread_count();
+        let mut reader = scattered(file.path(), 0, 8);
+        assert!(read_all(&mut reader, 64 * 1024) == expected, "and it still reads correctly");
+        assert_eq!(thread_count(), before, "the reader spawned threads outside the pool");
+    }
+
+    #[test]
+    fn test_a_scattered_read_matches_the_sequential_one_it_replaces() {
+        // The two `SpillSource` arms are chosen by a flag, so they have to be
+        // interchangeable byte for byte -- otherwise the flag changes results,
+        // not just speed.
+        let (file, _) = fixture(FILL_BYTES * 2 + 1234);
+        let mut sequential = SpillSource::Sequential(BufReader::with_capacity(
+            2 * 1024 * 1024,
+            File::open(file.path()).expect("open"),
+        ));
+        let mut scatter = SpillSource::Scattered(scattered(file.path(), 0, 4));
+        assert!(read_all(&mut sequential, 8192) == read_all(&mut scatter, 8192));
+    }
+}

--- a/crates/fgumi-sort/src/spill_reader.rs
+++ b/crates/fgumi-sort/src/spill_reader.rs
@@ -132,6 +132,25 @@ pub(crate) struct ScatterReader {
     /// reader report describes. A fill is exactly what `TimedReader` measures
     /// on the sequential arm -- the fetch, as opposed to the framing above it.
     stats: Option<Arc<crate::phase1_stats::ReaderStats>>,
+    /// Fills whose slices have been offered but whose bytes are not collected,
+    /// oldest first and contiguous in the file.
+    pending: VecDeque<PendingFill>,
+    /// How many fills to keep in flight ahead of the consumer, so the device
+    /// works while the framer frames. Zero for the merge's spill readers: the
+    /// merge already sits at its consumer-serial floor, so all lookahead would
+    /// buy there is `K * depth * FILL_BYTES` of extra buffers.
+    lookahead: usize,
+}
+
+/// A fill in flight: its slices, where they report, and where it began.
+///
+/// Its length is not stored because it is always `offset - start`: only the
+/// most recently issued fill is ever pending, and `issue` advances `offset` by
+/// exactly that fill's size.
+struct PendingFill {
+    slices: Vec<Arc<FetchSlice>>,
+    state: Arc<FillState>,
+    start: u64,
 }
 
 /// How one file's bytes are read.
@@ -252,7 +271,24 @@ impl ScatterReader {
             fetch,
             streams: streams.max(1),
             stats: None,
+            pending: VecDeque::new(),
+            lookahead: 0,
         })
+    }
+
+    /// Keep `fills` in flight ahead of the consumer.
+    ///
+    /// Without this a fill is issued only once the previous one is exhausted,
+    /// so the device idles for as long as framing and decompression take.
+    /// Measured on the phase-1 read span: 69.4s at depth 0, 66.9s at depth 1,
+    /// and 62.3s for a reader that prefetched continuously with its own
+    /// threads -- so depth is worth something well past one.
+    ///
+    /// Costs `(fills + 1) * FILL_BYTES` of buffers for this reader.
+    #[must_use]
+    pub(crate) fn looking_ahead(mut self, fills: usize) -> Self {
+        self.lookahead = fills;
+        self
     }
 
     /// Book this reader's fills into `stats`, so framing and fetching stay
@@ -276,29 +312,22 @@ impl ScatterReader {
         buf
     }
 
-    /// Fetch the next [`FILL_BYTES`] as concurrent slices, appending them to
-    /// `ready` in file order. Leaves `ready` empty at EOF.
-    fn fill(&mut self) -> io::Result<()> {
+    /// Offer the next [`FILL_BYTES`] as slices and advance the fetch offset.
+    ///
+    /// Returns `None` at EOF. Nothing is read here beyond what a worker happens
+    /// to pick up: the bytes are claimed in [`Self::collect`], which is what
+    /// lets a fill be in flight while the caller does something else.
+    fn issue(&mut self) -> Option<PendingFill> {
         let remaining = self.len.saturating_sub(self.offset);
         if remaining == 0 {
-            return Ok(());
+            return None;
         }
         let want = usize::try_from(remaining.min(FILL_BYTES as u64)).expect("a fill fits usize");
         // Never split below `MIN_SLICE_BYTES`: a fill near EOF is small, and
         // cutting it into pinpricks costs more than the concurrency returns.
         let slices = self.streams.min(want.div_ceil(MIN_SLICE_BYTES)).max(1);
         let slice_len = want.div_ceil(slices);
-        let base = self.offset;
-
-        if slices == 1 {
-            // The single-stream arm: no state, no offer, no barrier -- just the
-            // read this thread was going to do anyway.
-            let mut buf = self.take_buf(want);
-            self.file.read_exact_at(&mut buf, base)?;
-            self.ready.push_back(buf);
-            self.offset += want as u64;
-            return Ok(());
-        }
+        let start = self.offset;
 
         let bufs: Vec<Vec<u8>> = (0..slices)
             .map(|index| self.take_buf(slice_len.min(want - index * slice_len)))
@@ -311,43 +340,55 @@ impl ScatterReader {
             }),
             completed: Condvar::new(),
         });
-        let mine: Vec<Arc<FetchSlice>> = (0..slices)
+        let slices: Vec<Arc<FetchSlice>> = (0..slices)
             .map(|index| {
                 Arc::new(FetchSlice {
                     file: Arc::clone(&self.file),
-                    offset: base + (index * slice_len) as u64,
+                    offset: start + (index * slice_len) as u64,
                     index,
                     state: Arc::clone(&state),
                 })
             })
             .collect();
 
-        // Offer the later slices first so they can already be in flight, then
-        // walk every slice in order: the first is this thread's own, and the
-        // rest are reclaimed if no worker has started them. `run` no-ops on a
-        // slice someone else took, so this is both "do my share" and "take back
-        // what nobody wanted" in one pass -- and it is why a full queue, an
-        // empty pool, or a pool of workers all busy filling cannot wedge here.
+        // Slice 0 stays for the collecting thread, which has nothing better to
+        // do than read it; the rest go where a worker can reach them.
         if let Some(queue) = &self.fetch {
-            for slice in &mine[1..] {
+            for slice in &slices[1..] {
                 queue.offer(slice);
             }
         }
-        for slice in &mine {
+        self.offset += want as u64;
+        Some(PendingFill { slices, state, start })
+    }
+
+    /// Claim whatever the pool has not taken, wait for the rest, and publish the
+    /// fill's bytes in file order.
+    fn collect(&mut self, pending: &PendingFill) -> io::Result<()> {
+        // Walk every slice: the first is this thread's own share, and the rest
+        // are reclaimed if no worker has started them. `run` no-ops on a slice
+        // someone else took, so this is both "do my share" and "take back what
+        // nobody wanted" in one pass -- and it is why a full queue, an empty
+        // pool, or a pool of workers all busy filling cannot wedge here.
+        for slice in &pending.slices {
             slice.run();
         }
 
-        let mut progress = state.progress.lock().expect("fill state poisoned");
+        let mut progress = pending.state.progress.lock().expect("fill state poisoned");
         // Only slices a worker claimed before we got to them remain, and that
         // worker is inside `read_exact_at` rather than waiting on anything, so
         // this wait is bounded by one disk read.
         while progress.remaining > 0 {
-            progress = state.completed.wait(progress).expect("fill state poisoned");
+            progress = pending.state.completed.wait(progress).expect("fill state poisoned");
         }
         if let Some(e) = progress.error.take() {
-            // Nothing is published and `offset` has not moved, so the reader is
-            // exactly where it was and a caller that reads again re-reads the
-            // same range. That is why this needs no error latch.
+            drop(progress);
+            // `issue` moved the fetch offset before the bytes were claimed, so
+            // put it back: a caller that reads again must retry this range, not
+            // skip it. Anything issued after it covers bytes past the failure
+            // and is dropped for the same reason.
+            self.offset = pending.start;
+            self.pending.clear();
             return Err(e);
         }
         for slot in &mut progress.slots {
@@ -356,8 +397,28 @@ impl ScatterReader {
                 _ => unreachable!("a fill with no error has every slice done"),
             }
         }
-        drop(progress);
-        self.offset += want as u64;
+        Ok(())
+    }
+
+    /// Make bytes available in `ready`, leaving it empty only at EOF.
+    fn fill(&mut self) -> io::Result<()> {
+        if self.pending.is_empty() {
+            let Some(first) = self.issue() else {
+                return Ok(());
+            };
+            self.pending.push_back(first);
+        }
+        let pending = self.pending.pop_front().expect("just ensured non-empty");
+        self.collect(&pending)?;
+        // Topped up after collecting rather than before, so the fills issued
+        // here overlap the framing of what just landed rather than the wait for
+        // it. At depth 0 this loop does nothing and the reader is demand-driven.
+        while self.pending.len() < self.lookahead {
+            let Some(next) = self.issue() else {
+                break;
+            };
+            self.pending.push_back(next);
+        }
         Ok(())
     }
 }
@@ -412,7 +473,10 @@ impl ScatterReader {
     fn position(&self) -> u64 {
         let unconsumed: usize =
             self.ready.iter().map(Vec::len).sum::<usize>().saturating_sub(self.front_pos);
-        self.offset.saturating_sub(unconsumed as u64)
+        // Pending fills are contiguous and end at the fetch offset, so the
+        // oldest one's start is where the in-flight region begins.
+        let in_flight = self.pending.front().map_or(0, |p| self.offset - p.start);
+        self.offset.saturating_sub(unconsumed as u64).saturating_sub(in_flight)
     }
 }
 
@@ -585,6 +649,89 @@ mod tests {
         worker.join().expect("worker");
 
         assert!(got == expected, "bytes must match however the slices were shared");
+    }
+
+    /// A reader that keeps one fill in flight, like the phase-1 input reader.
+    fn ahead(path: &std::path::Path, streams: usize) -> ScatterReader {
+        let file = File::open(path).expect("open");
+        ScatterReader::new(file, 0, streams, Some(FetchQueue::new(4)))
+            .expect("reader")
+            .looking_ahead(1)
+    }
+
+    #[test]
+    fn test_lookahead_delivers_the_file_verbatim_at_every_stream_count() {
+        // Prefetching the next fill must not change a byte, and it is the case
+        // most likely to: two fills are alive at once, so a buffer recycled or
+        // an offset advanced at the wrong moment corrupts the seam between them.
+        let (file, expected) = fixture(FILL_BYTES * 3 + 12_345);
+        for streams in [2usize, 4, 8] {
+            let got = read_all(&mut ahead(file.path(), streams), 64 * 1024);
+            assert_eq!(got.len(), expected.len(), "length at {streams} streams");
+            assert!(got == expected, "bytes differ at {streams} streams");
+        }
+    }
+
+    #[test]
+    fn test_lookahead_keeps_the_next_fill_in_flight_while_the_consumer_reads() {
+        // The whole point: the device should be working on the next fill while
+        // the framer is still consuming this one. Without it the disk idles for
+        // exactly as long as framing takes, which is what the demand-driven
+        // reader measured as 18s of unrecovered read span.
+        let (file, _) = fixture(FILL_BYTES * 3);
+        let mut reader = ahead(file.path(), 4);
+        assert!(reader.pending.is_empty(), "nothing is in flight before the first read");
+        assert!(reader.read(&mut [0u8; 64]).expect("first read") > 0, "the fixture is not empty");
+        assert_eq!(reader.pending.len(), 1, "the next fill should already be issued");
+    }
+
+    #[test]
+    fn test_lookahead_keeps_the_depth_it_was_given_in_flight() {
+        // Depth is the knob that decides how much of the framing time the fetch
+        // can hide behind, so it has to actually take effect.
+        let (file, _) = fixture(FILL_BYTES * 6);
+        let handle = File::open(file.path()).expect("open");
+        let mut reader = ScatterReader::new(handle, 0, 4, Some(FetchQueue::new(4)))
+            .expect("reader")
+            .looking_ahead(3);
+        assert!(reader.read(&mut [0u8; 64]).expect("read") > 0, "the fixture is not empty");
+        assert_eq!(reader.pending.len(), 3, "three fills should be in flight");
+    }
+
+    #[test]
+    fn test_lookahead_does_not_run_ahead_of_the_end_of_the_file() {
+        // The last fill has no successor. Issuing one anyway would read past EOF
+        // and turn a clean finish into an error.
+        let (file, expected) = fixture(FILL_BYTES + 16);
+        let mut reader = ahead(file.path(), 4);
+        assert!(read_all(&mut reader, 1024) == expected);
+        assert!(reader.pending.is_empty(), "nothing may be in flight at EOF");
+    }
+
+    #[test]
+    fn test_a_failed_fill_rewinds_so_the_next_read_retries_the_same_bytes() {
+        // A fill is issued before it is collected, so the fetch offset moves
+        // first. If a failure left it moved, the retry would silently skip the
+        // range that failed -- losing records rather than reporting an error.
+        let (file, _) = fixture(FILL_BYTES * 3);
+        let mut reader = ahead(file.path(), 4);
+        let before = reader.position();
+        file.as_file().set_len(0).expect("truncate");
+        assert!(reader.read(&mut [0u8; 4096]).is_err(), "the read reports the failure");
+        assert_eq!(reader.position(), before, "a failed fill must not advance the reader");
+        assert!(reader.read(&mut [0u8; 4096]).is_err(), "and it keeps reporting it");
+    }
+
+    #[test]
+    fn test_position_ignores_bytes_that_are_only_in_flight() {
+        // `position` is where the consumer is, not how far ahead the fetch has
+        // run. Counting an in-flight fill would make it jump forward by a whole
+        // `FILL_BYTES` the moment lookahead was enabled.
+        let (file, _) = fixture(FILL_BYTES * 3);
+        let mut reader = ahead(file.path(), 4);
+        let consumed = reader.read(&mut [0u8; 100]).expect("read");
+        assert_eq!(consumed, 100, "a 100-byte read from a full fill returns 100");
+        assert_eq!(reader.position(), 100, "only consumed bytes count");
     }
 
     #[test]

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -2621,6 +2621,19 @@ impl SortWorkerPool {
         }
     }
 
+    /// Whether a worker owning `owned_step` may also take key-extraction batches.
+    ///
+    /// The worker that exclusively owns [`SortStep::ReadInputBlocks`] may not.
+    /// A batch is ~0.5 ms of pure CPU, and for that long its worker is not
+    /// reading — and nobody else can read, because the step is exclusive. On the
+    /// production cell, letting the reader's owner take batches cost the reader
+    /// 358 → 345 MB/s and 125.2s → 129.8s, against a phase whose whole remaining
+    /// cost *is* the reader. Every other worker is free to extract, so this
+    /// gives up 1/16th of the extraction capacity to protect the critical path.
+    fn worker_may_extract_keys(owned_step: Option<SortStep>) -> bool {
+        owned_step != Some(SortStep::ReadInputBlocks)
+    }
+
     /// Whether a step is exclusive (requires ownership).
     ///
     /// Only `ReadInputBlocks` is exclusive — it reads from a shared input file
@@ -2676,7 +2689,14 @@ impl SortWorkerPool {
             // Deliberately not gated on the phase: a batch queued late in
             // Phase 1 must still be reachable while the ingest thread drains at
             // the chunk barrier, which can coincide with the phase flip.
-            SortStep::ExtractKeys => !shared.key_jobs.is_empty(),
+            SortStep::ExtractKeys => {
+                !shared.key_jobs.is_empty()
+                    && Self::worker_may_extract_keys(Self::exclusive_step_for(
+                        worker.worker_id,
+                        shared,
+                        current_phase,
+                    ))
+            }
         }
     }
 
@@ -4682,6 +4702,27 @@ mod tests {
         let mut seen: Vec<usize> = rx.iter().collect();
         seen.sort_unstable();
         assert_eq!(seen, (0..num_jobs).collect::<Vec<_>>(), "every batch must run exactly once");
+    }
+
+    #[test]
+    fn test_the_worker_that_owns_the_reader_does_not_take_key_batches() {
+        // Measured on the production cell: adding key extraction to the pool
+        // slowed the input reader from 358 to 345 MB/s and its step from 125.2s
+        // to 129.8s. The reader is one exclusively-owned worker, and a key batch
+        // is ~0.5 ms during which that worker is not reading. Everyone else may
+        // take batches; the reader's owner may not.
+        assert!(
+            !SortWorkerPool::worker_may_extract_keys(Some(SortStep::ReadInputBlocks)),
+            "the reader's owner must stay on the reader"
+        );
+        assert!(
+            SortWorkerPool::worker_may_extract_keys(None),
+            "a worker owning no exclusive step is free to extract"
+        );
+        assert!(
+            SortWorkerPool::worker_may_extract_keys(Some(SortStep::Compress)),
+            "owning some other step does not bar extraction"
+        );
     }
 
     #[test]

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -265,11 +265,19 @@ pub enum SortStep {
     Compress = 2,
     /// Read+decompress one unit of work for some Phase 2 spill file (work-stealing).
     Phase2FileWork = 3,
+    /// Extract the sort keys for one batch of already-ingested records.
+    ///
+    /// Phase 1 slack work: the ingest thread defers key extraction rather than
+    /// paying 120 ns/record for it serially, and any worker can pick a batch up.
+    /// It is scheduled *last* everywhere on purpose — a batch that waits costs
+    /// nothing until the chunk barrier, whereas displacing `DecompressInput`
+    /// would starve the very thread this step exists to unblock.
+    ExtractKeys = 4,
 }
 
 impl SortStep {
     /// Number of distinct sort steps.
-    pub const COUNT: usize = 4;
+    pub const COUNT: usize = 5;
 
     /// Short label for display.
     #[must_use]
@@ -279,6 +287,7 @@ impl SortStep {
             Self::DecompressInput => "DecInp",
             Self::Compress => "Cmprs",
             Self::Phase2FileWork => "P2File",
+            Self::ExtractKeys => "ExtKey",
         }
     }
 }
@@ -372,6 +381,7 @@ impl SortPipelineStats {
             SortStep::DecompressInput,
             SortStep::Compress,
             SortStep::Phase2FileWork,
+            SortStep::ExtractKeys,
         ];
 
         for &step in &all_steps {
@@ -1483,6 +1493,14 @@ pub(crate) struct SharedPipelineState {
     /// Compress jobs: main thread → workers (`ArrayQueue`, non-blocking push).
     pub(crate) compress_queue: Arc<ArrayQueue<CompressJob>>,
 
+    /// Deferred key-extraction batches: ingest thread → workers.
+    ///
+    /// Bounded like every other queue here, and a full queue is *not* an error:
+    /// [`SortWorkerPool::submit_key_job`] hands the batch back and the ingest
+    /// thread runs it inline. That fallback is what makes the ingest thread's
+    /// barrier deadlock-free — it never waits on a batch no worker can reach.
+    pub(crate) key_jobs: Arc<ArrayQueue<Box<dyn crate::phase1_keys::KeyExtractionJob>>>,
+
     /// Number of workers (for `low_water` threshold in backpressure).
     num_workers: usize,
 
@@ -1616,6 +1634,11 @@ impl SharedPipelineState {
     fn new(num_workers: usize, main_thread_handle: std::thread::Thread) -> Self {
         let data_queue_cap = num_workers * 8;
         let compress_queue_cap = num_workers * 4;
+        // Deeper than the compress queue: batches are pure CPU with no
+        // downstream, so a backlog costs only memory, and a shallow queue would
+        // push the ingest thread onto the inline fallback exactly when the pool
+        // is busiest — reintroducing the serial cost this step removes.
+        let key_job_queue_cap = num_workers * 16;
 
         Self {
             merge_phases: crate::merge_phases::MergePhaseCounters::default(),
@@ -1649,6 +1672,7 @@ impl SharedPipelineState {
             total_sources: AtomicU64::new(0),
 
             compress_queue: Arc::new(ArrayQueue::new(compress_queue_cap)),
+            key_jobs: Arc::new(ArrayQueue::new(key_job_queue_cap)),
 
             num_workers,
             main_thread_handle,
@@ -2049,15 +2073,27 @@ fn get_sort_priorities(bp: &SortBackpressureState) -> &'static [SortStep] {
     match bp.phase {
         phase::PHASE1 => {
             if bp.input_eof && !bp.compress_has_items && bp.decompressed_input_done {
-                // Input fully decompressed and no compress work — nothing productive to do
-                &[]
+                // Input fully decompressed and no compress work — only leftover
+                // key batches remain, and eligibility drops the step when there
+                // are none.
+                &[SortStep::ExtractKeys]
             } else if bp.compress_has_items && !bp.decompressed_input_low {
                 // Spill compression is the bottleneck (13.7s at t4). Drain compress
                 // while decompressed blocks are plentiful for the main thread.
-                &[SortStep::Compress, SortStep::DecompressInput, SortStep::ReadInputBlocks]
+                &[
+                    SortStep::Compress,
+                    SortStep::DecompressInput,
+                    SortStep::ReadInputBlocks,
+                    SortStep::ExtractKeys,
+                ]
             } else {
                 // Default/starving: feed the main thread first, compress if available
-                &[SortStep::DecompressInput, SortStep::ReadInputBlocks, SortStep::Compress]
+                &[
+                    SortStep::DecompressInput,
+                    SortStep::ReadInputBlocks,
+                    SortStep::Compress,
+                    SortStep::ExtractKeys,
+                ]
             }
         }
         phase::PHASE2 => {
@@ -2070,17 +2106,17 @@ fn get_sort_priorities(bp: &SortBackpressureState) -> &'static [SortStep] {
                 // is throughput work any worker can do at any time; this block is
                 // the only thing that can unblock the consumer, so it goes first
                 // even though the compress queue is the writer-side bottleneck.
-                &[SortStep::Phase2FileWork, SortStep::Compress]
+                &[SortStep::Phase2FileWork, SortStep::Compress, SortStep::ExtractKeys]
             } else if bp.compress_has_items {
                 // Drain output compression while we can; it's the writer-side bottleneck.
-                &[SortStep::Compress, SortStep::Phase2FileWork]
+                &[SortStep::Compress, SortStep::Phase2FileWork, SortStep::ExtractKeys]
             } else {
-                &[SortStep::Phase2FileWork, SortStep::Compress]
+                &[SortStep::Phase2FileWork, SortStep::Compress, SortStep::ExtractKeys]
             }
         }
         // Legacy/transition: compress only (drain any remaining jobs, of either
         // kind — each carries its own `CompressTarget`).
-        _ => &[SortStep::Compress],
+        _ => &[SortStep::Compress, SortStep::ExtractKeys],
     }
 }
 
@@ -2535,6 +2571,12 @@ impl SortWorkerPool {
             phase::PHASE1 => {
                 shared.decompressed_input_done.load(Ordering::Acquire)
                     && shared.compress_queue.is_empty()
+                    // Deferred key batches outlive the input: the last chunk's
+                    // barrier runs after the input is fully decompressed, so
+                    // without this the pool parks precisely when the ingest
+                    // thread is waiting on it and the final chunk's extraction
+                    // collapses back to serial.
+                    && shared.key_jobs.is_empty()
             }
             phase::PHASE2 => {
                 if !shared.all_chunks_eof.load(Ordering::Acquire) {
@@ -2631,6 +2673,10 @@ impl SortWorkerPool {
             }
             SortStep::Compress => !shared.compress_queue.is_empty(),
             SortStep::Phase2FileWork => current_phase == phase::PHASE2,
+            // Deliberately not gated on the phase: a batch queued late in
+            // Phase 1 must still be reachable while the ingest thread drains at
+            // the chunk barrier, which can coincide with the phase flip.
+            SortStep::ExtractKeys => !shared.key_jobs.is_empty(),
         }
     }
 
@@ -2645,7 +2691,20 @@ impl SortWorkerPool {
             SortStep::DecompressInput => Self::try_decompress_input(shared, worker),
             SortStep::Compress => Self::try_compress(shared, worker),
             SortStep::Phase2FileWork => Self::try_phase2_file_work(shared, worker),
+            SortStep::ExtractKeys => Self::try_extract_keys(shared),
         }
+    }
+
+    /// Run one deferred key-extraction batch, if any is queued.
+    ///
+    /// Takes no worker state: a batch owns everything it needs and publishes its
+    /// own result, so there is nothing to hold and nothing to advance.
+    fn try_extract_keys(shared: &SharedPipelineState) -> StepResult {
+        let Some(job) = shared.key_jobs.pop() else {
+            return StepResult::InputEmpty;
+        };
+        job.run();
+        StepResult::Success
     }
 
     // ========================================================================
@@ -4020,6 +4079,51 @@ impl SortWorkerPool {
         }
     }
 
+    /// Offer a deferred key-extraction batch to the pool.
+    ///
+    /// Returns the batch unrun in `Err` when the queue is full or the pool has
+    /// shut down; the caller must run it inline rather than drop it. Unlike
+    /// [`submit_compress`](Self::submit_compress) this does **not** spin waiting
+    /// for room: the submitter is the ingest thread, and blocking it to hand off
+    /// work whose whole purpose is to unblock it would be self-defeating.
+    ///
+    /// # Errors
+    ///
+    /// Returns the batch when it could not be queued.
+    pub(crate) fn submit_key_job(
+        &self,
+        job: Box<dyn crate::phase1_keys::KeyExtractionJob>,
+    ) -> Result<(), Box<dyn crate::phase1_keys::KeyExtractionJob>> {
+        if self.shared.phase.load(Ordering::Acquire) == phase::SHUTDOWN {
+            return Err(job); // Workers have exited; no one will pop the queue
+        }
+        self.shared.key_jobs.push(job)?;
+        self.shared.wake_one_worker();
+        Ok(())
+    }
+
+    /// Whether any worker has published a panic.
+    pub(crate) fn worker_panicked(&self) -> bool {
+        self.shared.worker_panicked.load(Ordering::Acquire)
+    }
+
+    /// Run one queued key-extraction batch on the calling thread, if any is
+    /// queued. Returns whether a batch ran.
+    ///
+    /// The ingest thread's self-help path: at the chunk barrier it drains the
+    /// queue itself rather than waiting on workers that may already have parked
+    /// for the phase. Without it the barrier could wait on a batch nobody is
+    /// scheduled to run.
+    pub(crate) fn run_one_key_job(&self) -> bool {
+        match self.shared.key_jobs.pop() {
+            Some(job) => {
+                job.run();
+                true
+            }
+            None => false,
+        }
+    }
+
     /// Create a new result channel pair for compress results.
     ///
     /// The result channel stays as `crossbeam_channel::bounded()` because the
@@ -4542,6 +4646,79 @@ mod tests {
         assert!(result.recycled_buf.is_empty());
 
         pool.shutdown();
+    }
+
+    #[test]
+    fn test_the_pool_runs_every_submitted_key_job() {
+        // Deferred key extraction is only a win if the pool actually drains the
+        // batches; a batch the pool never picks up would stall the ingest
+        // thread's barrier instead. Submits more batches than the queue holds,
+        // so the full-queue path is exercised too.
+        use crate::phase1_keys::KeyExtractionJob;
+
+        struct CountingBatch(std::sync::mpsc::Sender<usize>, usize);
+        impl KeyExtractionJob for CountingBatch {
+            fn run(self: Box<Self>) {
+                // The receiver outlives every batch here; a closed channel would
+                // just mean the test already finished.
+                let _ = self.0.send(self.1);
+            }
+        }
+
+        let pool = SortWorkerPool::new(4, 1, 6, crate::codec::SpillCodec::Bgzf);
+        pool.set_phase(phase::PHASE1);
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        let num_jobs = 64usize;
+        for i in 0..num_jobs {
+            // A full queue hands the batch back rather than dropping it; the
+            // ingest thread runs those inline, so the test does the same.
+            if let Err(job) = pool.submit_key_job(Box::new(CountingBatch(tx.clone(), i))) {
+                job.run();
+            }
+        }
+        drop(tx);
+
+        let mut seen: Vec<usize> = rx.iter().collect();
+        seen.sort_unstable();
+        assert_eq!(seen, (0..num_jobs).collect::<Vec<_>>(), "every batch must run exactly once");
+    }
+
+    #[test]
+    fn test_workers_stay_awake_for_key_batches_after_the_input_is_drained() {
+        // The final chunk's barrier lands exactly here: the input is read and
+        // decompressed, so Phase 1 looks finished, but a chunk's worth of key
+        // batches is still queued. If the phase counts as complete the workers
+        // all park and the ingest thread drains them one at a time on its own —
+        // correct output, but the last chunk's extraction becomes fully serial,
+        // which is the cost this step exists to remove.
+        use crate::phase1_keys::KeyExtractionJob;
+
+        struct Ping(std::sync::mpsc::Sender<()>);
+        impl KeyExtractionJob for Ping {
+            fn run(self: Box<Self>) {
+                let _ = self.0.send(());
+            }
+        }
+
+        let pool = SortWorkerPool::new(4, 1, 6, crate::codec::SpillCodec::Bgzf);
+        pool.set_phase(phase::PHASE1);
+        // Everything the phase-completion check looks at is now satisfied.
+        pool.shared.decompressed_input_done.store(true, Ordering::Release);
+        pool.shared.input_eof.store(true, Ordering::Release);
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let submitted = 8usize;
+        for _ in 0..submitted {
+            pool.submit_key_job(Box::new(Ping(tx.clone()))).ok().expect("queue has room");
+        }
+        drop(tx);
+
+        for i in 0..submitted {
+            rx.recv_timeout(std::time::Duration::from_secs(10)).unwrap_or_else(|_| {
+                panic!("workers parked with key batches still queued; only {i} of {submitted} ran")
+            });
+        }
     }
 
     #[test]
@@ -5303,7 +5480,13 @@ mod tests {
     }
 
     #[test]
-    fn test_sort_priorities_phase1_all_done_returns_empty() {
+    fn test_sort_priorities_phase1_all_done_offers_no_input_or_compress_work() {
+        // Once the input is read and decompressed and nothing is queued to
+        // compress, no worker should be offered work that produces more of it —
+        // that is what makes them back off instead of spinning. `ExtractKeys` is
+        // exempt and may appear: it self-gates on a non-empty batch queue, and a
+        // batch queued just before EOF must still be reachable while the ingest
+        // thread drains at the barrier.
         let bp = SortBackpressureState {
             decompressed_input_low: false,
             input_eof: true,
@@ -5312,7 +5495,10 @@ mod tests {
             consumer_parked: false,
             phase: phase::PHASE1,
         };
-        assert!(get_sort_priorities(&bp).is_empty());
+        let priorities = get_sort_priorities(&bp);
+        for step in [SortStep::ReadInputBlocks, SortStep::DecompressInput, SortStep::Compress] {
+            assert!(!priorities.contains(&step), "{step:?} must not be offered once input is done");
+        }
     }
 
     #[test]
@@ -5411,7 +5597,10 @@ mod tests {
     }
 
     #[test]
-    fn test_sort_priorities_legacy_returns_compress_only() {
+    fn test_sort_priorities_legacy_drains_compress_and_no_phased_work() {
+        // The legacy/transition phase exists to drain queued jobs, so compression
+        // must be reachable and the phase-specific steps must not be. As above,
+        // `ExtractKeys` self-gates and is exempt.
         let bp = SortBackpressureState {
             decompressed_input_low: false,
             input_eof: false,
@@ -5421,8 +5610,11 @@ mod tests {
             phase: phase::LEGACY,
         };
         let priorities = get_sort_priorities(&bp);
-        assert_eq!(priorities.len(), 1);
-        assert_eq!(priorities[0], SortStep::Compress);
+        assert_eq!(priorities[0], SortStep::Compress, "compression drains first");
+        for step in [SortStep::ReadInputBlocks, SortStep::DecompressInput, SortStep::Phase2FileWork]
+        {
+            assert!(!priorities.contains(&step), "{step:?} belongs to a real phase");
+        }
     }
 
     #[test]

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -1377,9 +1377,9 @@ pub struct SortWorkerPool {
     pub buffer_pool: BufferPool,
     num_workers: usize,
     pub(crate) spill_codec: SpillCodec,
-    /// Concurrent positional reads the merge may use per spill file. One keeps
-    /// the sequential `BufReader` a merge has always used.
-    pub(crate) read_streams: usize,
+    /// How the merge reads each spill file. `Fixed(1)` keeps the sequential
+    /// `BufReader` a merge has always used.
+    pub(crate) read_streams: crate::external::ReadStreams,
 }
 
 /// Shared state visible to all workers and the main thread.
@@ -2423,7 +2423,7 @@ impl SortWorkerPool {
             buffer_pool,
             num_workers,
             spill_codec,
-            read_streams: 1,
+            read_streams: crate::external::ReadStreams::Fixed(1),
         }
     }
 
@@ -4113,11 +4113,16 @@ impl SortWorkerPool {
             file.seek(SeekFrom::Start(body_start)).map_err(|e| {
                 anyhow::anyhow!("Failed to seek chunk file {}: {e}", path.display())
             })?;
-            let reader = if self.read_streams > 1 {
+            let reader = if self.read_streams.is_sequential() {
+                crate::spill_reader::SpillSource::Sequential(BufReader::with_capacity(
+                    2 * 1024 * 1024,
+                    file,
+                ))
+            } else {
                 // Positional reads need no file position, so the seek above is
                 // irrelevant here -- `body_start` is passed explicitly instead.
                 crate::spill_reader::SpillSource::Scattered(
-                    crate::spill_reader::ScatterReader::new(
+                    crate::spill_reader::ScatterReader::for_streams(
                         file,
                         body_start,
                         self.read_streams,
@@ -4127,11 +4132,6 @@ impl SortWorkerPool {
                         anyhow::anyhow!("Failed to size chunk file {}: {e}", path.display())
                     })?,
                 )
-            } else {
-                crate::spill_reader::SpillSource::Sequential(BufReader::with_capacity(
-                    2 * 1024 * 1024,
-                    file,
-                ))
             };
             states.push(Phase2FileState::new(reader, codec));
         }
@@ -6336,7 +6336,13 @@ mod tests {
         file.write_all(&[0xAA, 0xBB, 0xCC]).expect("write body");
         drop(file);
 
-        for read_streams in [1usize, 4] {
+        // All three shapes: the sequential reader, a pinned scattered one, and
+        // the auto-tuning one that is now the default.
+        for read_streams in [
+            crate::external::ReadStreams::Fixed(1),
+            crate::external::ReadStreams::Fixed(4),
+            crate::external::ReadStreams::Auto,
+        ] {
             let mut pool = SortWorkerPool::new(1, 1, 6, SpillCodec::Bgzf);
             pool.read_streams = read_streams;
             pool.set_phase2_files(std::slice::from_ref(&path)).expect("set_phase2_files");
@@ -6346,7 +6352,7 @@ mod tests {
             assert_eq!(
                 phase2_file_position(&files[0]),
                 ZSPILL_MAGIC.len() as u64,
-                "zstd reader must start past the 4-byte magic at {read_streams} streams"
+                "zstd reader must start past the 4-byte magic at {read_streams:?}"
             );
             pool.shutdown();
         }
@@ -6363,7 +6369,13 @@ mod tests {
         file.write_all(&[0x1f, 0x8b, 0x00, 0x00, 0x55, 0x66]).expect("write magic");
         drop(file);
 
-        for read_streams in [1usize, 4] {
+        // All three shapes: the sequential reader, a pinned scattered one, and
+        // the auto-tuning one that is now the default.
+        for read_streams in [
+            crate::external::ReadStreams::Fixed(1),
+            crate::external::ReadStreams::Fixed(4),
+            crate::external::ReadStreams::Auto,
+        ] {
             let mut pool = SortWorkerPool::new(1, 1, 6, SpillCodec::Zstd);
             pool.read_streams = read_streams;
             pool.set_phase2_files(std::slice::from_ref(&path)).expect("set_phase2_files");
@@ -6373,7 +6385,7 @@ mod tests {
             assert_eq!(
                 phase2_file_position(&files[0]),
                 0,
-                "bgzf reader must start at byte 0 at {read_streams} streams, for the header"
+                "bgzf reader must start at byte 0 at {read_streams:?}, for the header"
             );
             pool.shutdown();
         }

--- a/crates/fgumi-sort/src/worker_pool.rs
+++ b/crates/fgumi-sort/src/worker_pool.rs
@@ -273,11 +273,19 @@ pub enum SortStep {
     /// nothing until the chunk barrier, whereas displacing `DecompressInput`
     /// would starve the very thread this step exists to unblock.
     ExtractKeys = 4,
+    /// Read one byte slice of some reader's in-flight fill.
+    ///
+    /// Scheduled *first* everywhere, the mirror image of `ExtractKeys`: a
+    /// pending slice is what a thread holding an exclusive reader is blocked
+    /// on, so every moment it waits is a moment nothing downstream is fed. A
+    /// deferred key batch costs nothing until the chunk barrier; a deferred
+    /// slice costs the pipeline immediately.
+    FetchBytes = 5,
 }
 
 impl SortStep {
     /// Number of distinct sort steps.
-    pub const COUNT: usize = 5;
+    pub const COUNT: usize = 6;
 
     /// Short label for display.
     #[must_use]
@@ -288,6 +296,7 @@ impl SortStep {
             Self::Compress => "Cmprs",
             Self::Phase2FileWork => "P2File",
             Self::ExtractKeys => "ExtKey",
+            Self::FetchBytes => "Fetch",
         }
     }
 }
@@ -382,6 +391,7 @@ impl SortPipelineStats {
             SortStep::Compress,
             SortStep::Phase2FileWork,
             SortStep::ExtractKeys,
+            SortStep::FetchBytes,
         ];
 
         for &step in &all_steps {
@@ -1040,7 +1050,7 @@ pub(crate) struct TimedBlock {
 
 /// Reader state for a single spill file. Locked when reading from disk.
 pub(crate) struct Phase2Reader {
-    pub(crate) inner: BufReader<std::fs::File>,
+    pub(crate) inner: crate::spill_reader::SpillSource,
     pub(crate) next_serial: u64,
     pub(crate) eof: bool,
 }
@@ -1119,7 +1129,7 @@ pub(crate) struct Phase2FileState {
 }
 
 impl Phase2FileState {
-    pub(crate) fn new(reader: BufReader<std::fs::File>, codec: SpillCodec) -> Self {
+    pub(crate) fn new(reader: crate::spill_reader::SpillSource, codec: SpillCodec) -> Self {
         Self {
             reader: Mutex::new(Phase2Reader { inner: reader, next_serial: 0, eof: false }),
             reader_eof: AtomicBool::new(false),
@@ -1367,6 +1377,9 @@ pub struct SortWorkerPool {
     pub buffer_pool: BufferPool,
     num_workers: usize,
     pub(crate) spill_codec: SpillCodec,
+    /// Concurrent positional reads the merge may use per spill file. One keeps
+    /// the sequential `BufReader` a merge has always used.
+    pub(crate) read_streams: usize,
 }
 
 /// Shared state visible to all workers and the main thread.
@@ -1500,6 +1513,15 @@ pub(crate) struct SharedPipelineState {
     /// thread runs it inline. That fallback is what makes the ingest thread's
     /// barrier deadlock-free — it never waits on a batch no worker can reach.
     pub(crate) key_jobs: Arc<ArrayQueue<Box<dyn crate::phase1_keys::KeyExtractionJob>>>,
+
+    /// Byte slices offered by whichever reader is filling: reader → workers.
+    ///
+    /// Shared by both phases because the job is identical -- read a range at an
+    /// offset into a waiting buffer. A full queue is not an error and neither is
+    /// an idle pool: the offering thread reclaims anything nobody started, which
+    /// is what keeps a fill from waiting on workers that are all themselves
+    /// filling. See [`crate::spill_reader`].
+    pub(crate) fetch_jobs: Arc<crate::spill_reader::FetchQueue>,
 
     /// Number of workers (for `low_water` threshold in backpressure).
     num_workers: usize,
@@ -1673,6 +1695,7 @@ impl SharedPipelineState {
 
             compress_queue: Arc::new(ArrayQueue::new(compress_queue_cap)),
             key_jobs: Arc::new(ArrayQueue::new(key_job_queue_cap)),
+            fetch_jobs: crate::spill_reader::FetchQueue::new(num_workers),
 
             num_workers,
             main_thread_handle,
@@ -2076,11 +2099,12 @@ fn get_sort_priorities(bp: &SortBackpressureState) -> &'static [SortStep] {
                 // Input fully decompressed and no compress work — only leftover
                 // key batches remain, and eligibility drops the step when there
                 // are none.
-                &[SortStep::ExtractKeys]
+                &[SortStep::FetchBytes, SortStep::ExtractKeys]
             } else if bp.compress_has_items && !bp.decompressed_input_low {
                 // Spill compression is the bottleneck (13.7s at t4). Drain compress
                 // while decompressed blocks are plentiful for the main thread.
                 &[
+                    SortStep::FetchBytes,
                     SortStep::Compress,
                     SortStep::DecompressInput,
                     SortStep::ReadInputBlocks,
@@ -2089,6 +2113,7 @@ fn get_sort_priorities(bp: &SortBackpressureState) -> &'static [SortStep] {
             } else {
                 // Default/starving: feed the main thread first, compress if available
                 &[
+                    SortStep::FetchBytes,
                     SortStep::DecompressInput,
                     SortStep::ReadInputBlocks,
                     SortStep::Compress,
@@ -2106,17 +2131,32 @@ fn get_sort_priorities(bp: &SortBackpressureState) -> &'static [SortStep] {
                 // is throughput work any worker can do at any time; this block is
                 // the only thing that can unblock the consumer, so it goes first
                 // even though the compress queue is the writer-side bottleneck.
-                &[SortStep::Phase2FileWork, SortStep::Compress, SortStep::ExtractKeys]
+                &[
+                    SortStep::FetchBytes,
+                    SortStep::Phase2FileWork,
+                    SortStep::Compress,
+                    SortStep::ExtractKeys,
+                ]
             } else if bp.compress_has_items {
                 // Drain output compression while we can; it's the writer-side bottleneck.
-                &[SortStep::Compress, SortStep::Phase2FileWork, SortStep::ExtractKeys]
+                &[
+                    SortStep::FetchBytes,
+                    SortStep::Compress,
+                    SortStep::Phase2FileWork,
+                    SortStep::ExtractKeys,
+                ]
             } else {
-                &[SortStep::Phase2FileWork, SortStep::Compress, SortStep::ExtractKeys]
+                &[
+                    SortStep::FetchBytes,
+                    SortStep::Phase2FileWork,
+                    SortStep::Compress,
+                    SortStep::ExtractKeys,
+                ]
             }
         }
         // Legacy/transition: compress only (drain any remaining jobs, of either
         // kind — each carries its own `CompressTarget`).
-        _ => &[SortStep::Compress, SortStep::ExtractKeys],
+        _ => &[SortStep::FetchBytes, SortStep::Compress, SortStep::ExtractKeys],
     }
 }
 
@@ -2383,6 +2423,7 @@ impl SortWorkerPool {
             buffer_pool,
             num_workers,
             spill_codec,
+            read_streams: 1,
         }
     }
 
@@ -2689,6 +2730,10 @@ impl SortWorkerPool {
             // Deliberately not gated on the phase: a batch queued late in
             // Phase 1 must still be reachable while the ingest thread drains at
             // the chunk barrier, which can coincide with the phase flip.
+            // Not gated on the phase either: both phases fill through the
+            // same queue, and a slice offered as Phase 1 drains must stay
+            // reachable across the flip.
+            SortStep::FetchBytes => !shared.fetch_jobs.is_empty(),
             SortStep::ExtractKeys => {
                 !shared.key_jobs.is_empty()
                     && Self::worker_may_extract_keys(Self::exclusive_step_for(
@@ -2712,7 +2757,17 @@ impl SortWorkerPool {
             SortStep::Compress => Self::try_compress(shared, worker),
             SortStep::Phase2FileWork => Self::try_phase2_file_work(shared, worker),
             SortStep::ExtractKeys => Self::try_extract_keys(shared),
+            SortStep::FetchBytes => Self::try_fetch_bytes(shared),
         }
+    }
+
+    /// Read one offered byte slice, if any is still unclaimed.
+    ///
+    /// `InputEmpty` covers both "nothing queued" and "the offering thread
+    /// reclaimed this one first" -- neither did work, and reporting progress
+    /// for a no-op would keep a worker spinning on a queue of stale slices.
+    fn try_fetch_bytes(shared: &SharedPipelineState) -> StepResult {
+        if shared.fetch_jobs.run_one() { StepResult::Success } else { StepResult::InputEmpty }
     }
 
     /// Run one deferred key-extraction batch, if any is queued.
@@ -3986,6 +4041,7 @@ impl SortWorkerPool {
     ///
     /// Panics if the `phase2_files` rwlock is poisoned.
     pub fn set_phase2_files(&self, files: &[std::path::PathBuf]) -> anyhow::Result<()> {
+        let scatter = Arc::clone(&self.shared.fetch_jobs);
         let total_sources = files.len();
         self.shared.total_sources.store(total_sources as u64, Ordering::Release);
 
@@ -4057,13 +4113,37 @@ impl SortWorkerPool {
             file.seek(SeekFrom::Start(body_start)).map_err(|e| {
                 anyhow::anyhow!("Failed to seek chunk file {}: {e}", path.display())
             })?;
-            let reader = BufReader::with_capacity(2 * 1024 * 1024, file);
+            let reader = if self.read_streams > 1 {
+                // Positional reads need no file position, so the seek above is
+                // irrelevant here -- `body_start` is passed explicitly instead.
+                crate::spill_reader::SpillSource::Scattered(
+                    crate::spill_reader::ScatterReader::new(
+                        file,
+                        body_start,
+                        self.read_streams,
+                        Some(Arc::clone(&scatter)),
+                    )
+                    .map_err(|e| {
+                        anyhow::anyhow!("Failed to size chunk file {}: {e}", path.display())
+                    })?,
+                )
+            } else {
+                crate::spill_reader::SpillSource::Sequential(BufReader::with_capacity(
+                    2 * 1024 * 1024,
+                    file,
+                ))
+            };
             states.push(Phase2FileState::new(reader, codec));
         }
 
         let mut guard = self.shared.phase2_files.write().expect("phase2_files rwlock poisoned");
         *guard = Arc::new(states);
         Ok(())
+    }
+
+    /// The queue readers offer byte slices to. See [`crate::spill_reader`].
+    pub(crate) fn fetch_queue(&self) -> Arc<crate::spill_reader::FetchQueue> {
+        Arc::clone(&self.shared.fetch_jobs)
     }
 
     /// Clear the Phase 2 file vector. Call this after Phase 2 finishes (and
@@ -4169,6 +4249,19 @@ impl SortWorkerPool {
     /// Internal shutdown: signal workers and join them. Safe to call multiple times
     /// (idempotent via `Option::take`). Called by both `shutdown` and `Drop`.
     fn do_shutdown(&mut self) {
+        // The census for "did scattered reading engage at all". Zero taken means
+        // every fill was read by the thread that wanted it -- the pre-change
+        // behaviour, and something no output check would ever notice. Reported
+        // here because the queue spans both phases and this is the one point
+        // every sort passes through. Gated on the workers still being present so
+        // it prints once: `do_shutdown` runs from both `shutdown` and `Drop`,
+        // and only the join below is idempotent on its own.
+        if self.workers.is_some() {
+            let (offered, taken) = self.shared.fetch_jobs.census();
+            if offered > 0 {
+                log::info!("Byte fetch: {offered} slices offered, {taken} run by workers");
+            }
+        }
         self.shared.phase.store(phase::SHUTDOWN, Ordering::Release);
         if let Some(workers) = self.workers.take() {
             for w in workers {
@@ -5503,7 +5596,7 @@ mod tests {
             phase: phase::PHASE1,
         };
         let priorities = get_sort_priorities(&bp);
-        assert_eq!(priorities[0], SortStep::DecompressInput);
+        assert!(rank(priorities, SortStep::DecompressInput) < rank(priorities, SortStep::Compress));
     }
 
     #[test]
@@ -5517,7 +5610,7 @@ mod tests {
             phase: phase::PHASE1,
         };
         let priorities = get_sort_priorities(&bp);
-        assert_eq!(priorities[0], SortStep::Compress);
+        assert!(rank(priorities, SortStep::Compress) < rank(priorities, SortStep::DecompressInput));
     }
 
     #[test]
@@ -5553,7 +5646,7 @@ mod tests {
             phase: phase::PHASE2,
         };
         let priorities = get_sort_priorities(&bp);
-        assert_eq!(priorities[0], SortStep::Phase2FileWork);
+        assert!(rank(priorities, SortStep::Phase2FileWork) < rank(priorities, SortStep::Compress));
     }
 
     #[test]
@@ -5567,7 +5660,7 @@ mod tests {
             phase: phase::PHASE2,
         };
         let priorities = get_sort_priorities(&bp);
-        assert_eq!(priorities[0], SortStep::Compress);
+        assert!(rank(priorities, SortStep::Compress) < rank(priorities, SortStep::DecompressInput));
     }
 
     #[test]
@@ -5583,7 +5676,49 @@ mod tests {
             phase: phase::PHASE2,
         };
         let priorities = get_sort_priorities(&bp);
-        assert_eq!(priorities[0], SortStep::Phase2FileWork);
+        assert!(rank(priorities, SortStep::Phase2FileWork) < rank(priorities, SortStep::Compress));
+    }
+
+    /// A pending byte slice is what some thread holding an exclusive reader is
+    /// blocked on, and that thread reclaims the slice if nobody takes it -- so
+    /// the whole benefit lives in the short window between offer and reclaim.
+    /// Anything scheduled above `FetchBytes` spends that window, which is why
+    /// it leads every list. This is the mirror image of `ExtractKeys`, which
+    /// goes last everywhere because a deferred key batch costs nothing until
+    /// the chunk barrier.
+    #[test]
+    fn test_fetch_bytes_outranks_every_other_step_in_every_state() {
+        for phase in [phase::PHASE1, phase::PHASE2, phase::SHUTDOWN] {
+            for &(low, eof, done, compress, parked) in &[
+                (false, false, false, false, false),
+                (true, false, false, true, false),
+                (false, true, true, false, false),
+                (false, false, false, true, true),
+                (true, true, true, true, true),
+            ] {
+                let bp = SortBackpressureState {
+                    decompressed_input_low: low,
+                    input_eof: eof,
+                    decompressed_input_done: done,
+                    compress_has_items: compress,
+                    consumer_parked: parked,
+                    phase,
+                };
+                assert_eq!(
+                    get_sort_priorities(&bp)[0],
+                    SortStep::FetchBytes,
+                    "phase {phase} state {low}{eof}{done}{compress}{parked}"
+                );
+            }
+        }
+    }
+
+    /// Where `step` sits in a priority list, for tests that mean "A outranks B"
+    /// rather than "A is literally first". Index-based assertions broke the
+    /// moment `FetchBytes` was inserted above them, though nothing they were
+    /// asserting had changed.
+    fn rank(priorities: &[SortStep], step: SortStep) -> usize {
+        priorities.iter().position(|&s| s == step).unwrap_or(usize::MAX)
     }
 
     /// Output compression is throughput work any worker can do at any time. The
@@ -5599,7 +5734,8 @@ mod tests {
             consumer_parked: true,
             phase: phase::PHASE2,
         };
-        assert_eq!(get_sort_priorities(&bp)[0], SortStep::Phase2FileWork);
+        let p = get_sort_priorities(&bp);
+        assert!(rank(p, SortStep::Phase2FileWork) < rank(p, SortStep::Compress));
     }
 
     /// With the consumer running, compress-first is preserved exactly: it is the
@@ -5614,7 +5750,8 @@ mod tests {
             consumer_parked: false,
             phase: phase::PHASE2,
         };
-        assert_eq!(get_sort_priorities(&bp)[0], SortStep::Compress);
+        let p = get_sort_priorities(&bp);
+        assert!(rank(p, SortStep::Compress) < rank(p, SortStep::Phase2FileWork));
     }
 
     /// Both steps stay reachable either way -- dropping one would starve it
@@ -5651,7 +5788,10 @@ mod tests {
             phase: phase::LEGACY,
         };
         let priorities = get_sort_priorities(&bp);
-        assert_eq!(priorities[0], SortStep::Compress, "compression drains first");
+        assert!(
+            rank(priorities, SortStep::Compress) < rank(priorities, SortStep::Phase2FileWork),
+            "compression drains first"
+        );
         for step in [SortStep::ReadInputBlocks, SortStep::DecompressInput, SortStep::Phase2FileWork]
         {
             assert!(!priorities.contains(&step), "{step:?} belongs to a real phase");
@@ -5675,7 +5815,7 @@ mod tests {
     fn empty_phase2_file() -> Phase2FileState {
         let tmp = tempfile::tempfile().expect("failed to create tempfile");
         let reader = BufReader::with_capacity(1024, tmp);
-        Phase2FileState::new(reader, SpillCodec::Bgzf)
+        Phase2FileState::new(crate::spill_reader::SpillSource::Sequential(reader), SpillCodec::Bgzf)
     }
 
     /// Build a tiny placeholder raw entry whose contents we never decode.
@@ -6178,13 +6318,12 @@ mod tests {
     // for BGZF (whose decoder reads the gzip header itself).
     // ========================================================================
 
-    /// Snapshot the file position by locking the per-file reader. `BufReader`'s
-    /// `stream_position` accounts for any buffered bytes — for a fresh
-    /// `BufReader` whose buffer hasn't been filled this equals the underlying
-    /// `File`'s seek position.
+    /// Snapshot the position of the next byte the per-file reader will serve.
+    /// Both `SpillSource` arms account for whatever they have already buffered,
+    /// so on a reader nothing has read from this is where it will start.
     fn phase2_file_position(state: &Phase2FileState) -> u64 {
         let mut guard = state.reader.lock().expect("reader lock");
-        guard.inner.stream_position().expect("stream_position")
+        guard.inner.position().expect("position")
     }
 
     #[test]
@@ -6197,17 +6336,20 @@ mod tests {
         file.write_all(&[0xAA, 0xBB, 0xCC]).expect("write body");
         drop(file);
 
-        let pool = SortWorkerPool::new(1, 1, 6, SpillCodec::Bgzf);
-        pool.set_phase2_files(std::slice::from_ref(&path)).expect("set_phase2_files");
-        let files = pool.phase2_files();
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].codec, SpillCodec::Zstd, "ZSPILL_MAGIC must select zstd codec");
-        assert_eq!(
-            phase2_file_position(&files[0]),
-            ZSPILL_MAGIC.len() as u64,
-            "zstd reader must be positioned past the 4-byte magic"
-        );
-        pool.shutdown();
+        for read_streams in [1usize, 4] {
+            let mut pool = SortWorkerPool::new(1, 1, 6, SpillCodec::Bgzf);
+            pool.read_streams = read_streams;
+            pool.set_phase2_files(std::slice::from_ref(&path)).expect("set_phase2_files");
+            let files = pool.phase2_files();
+            assert_eq!(files.len(), 1);
+            assert_eq!(files[0].codec, SpillCodec::Zstd, "ZSPILL_MAGIC must select zstd codec");
+            assert_eq!(
+                phase2_file_position(&files[0]),
+                ZSPILL_MAGIC.len() as u64,
+                "zstd reader must start past the 4-byte magic at {read_streams} streams"
+            );
+            pool.shutdown();
+        }
     }
 
     #[test]
@@ -6221,17 +6363,20 @@ mod tests {
         file.write_all(&[0x1f, 0x8b, 0x00, 0x00, 0x55, 0x66]).expect("write magic");
         drop(file);
 
-        let pool = SortWorkerPool::new(1, 1, 6, SpillCodec::Zstd);
-        pool.set_phase2_files(std::slice::from_ref(&path)).expect("set_phase2_files");
-        let files = pool.phase2_files();
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].codec, SpillCodec::Bgzf, "BGZF magic must select bgzf codec");
-        assert_eq!(
-            phase2_file_position(&files[0]),
-            0,
-            "bgzf reader must be rewound to byte 0 so the decoder sees the header"
-        );
-        pool.shutdown();
+        for read_streams in [1usize, 4] {
+            let mut pool = SortWorkerPool::new(1, 1, 6, SpillCodec::Zstd);
+            pool.read_streams = read_streams;
+            pool.set_phase2_files(std::slice::from_ref(&path)).expect("set_phase2_files");
+            let files = pool.phase2_files();
+            assert_eq!(files.len(), 1);
+            assert_eq!(files[0].codec, SpillCodec::Bgzf, "BGZF magic must select bgzf codec");
+            assert_eq!(
+                phase2_file_position(&files[0]),
+                0,
+                "bgzf reader must start at byte 0 at {read_streams} streams, for the header"
+            );
+            pool.shutdown();
+        }
     }
 
     #[test]

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -386,13 +386,24 @@ pub struct Sort {
     #[arg(long = "write-index", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub write_index: bool,
 
-    /// Enable async userspace prefetch on the input BAM.
+    /// Read the input BAM and the merge's spill files with this many
+    /// concurrent streams.
     ///
-    /// Spawns a dedicated I/O thread that reads raw bytes into a bounded
-    /// queue ahead of the decompression step, so pool workers do not block
-    /// on disk. Prototype flag; defaults to off.
-    #[arg(long = "async-reader", default_value_t = false, hide = true)]
-    pub async_reader: bool,
+    /// One blocking read keeps only about one read-ahead window outstanding at
+    /// the device, which on network-attached storage is far below what it can
+    /// serve -- and no buffer size fixes it, because a bigger single request is
+    /// not more concurrency. On EBS gp3, four streams measured 1177 MB/s
+    /// against 358 MB/s for one, and a whole-genome sort ran 28% faster.
+    ///
+    /// **4 is the measured value for network-attached storage.** The default is
+    /// 1 (today's behaviour) because direct-attached storage has far lower latency
+    /// and may need fewer; that has not been measured yet. The streams are pool
+    /// workers, not new threads, so this never exceeds `--threads`.
+    ///
+    /// Clamped to 16 and to the input's chunk count. Ignored for stdin and
+    /// other non-seekable inputs, where positional reads do not exist.
+    #[arg(long = "read-streams", default_value_t = 1)]
+    pub read_streams: usize,
 
     /// Emit the sort's performance diagnostics.
     ///
@@ -584,7 +595,7 @@ impl Sort {
             .temp_compression(self.temp_compression)
             .spill_codec(self.temp_codec)
             .write_index(self.write_index)
-            .async_reader(self.async_reader)
+            .read_streams(self.read_streams)
             .pg_info(crate::version::VERSION.to_string(), command_line.to_string());
 
         // Each per-phase override is optional and falls back to `--threads`.
@@ -1582,7 +1593,7 @@ mod tests {
             temp_codec: fgumi_sort::SpillCodec::default(),
             max_temp_files: MaxTempFiles::Auto,
             write_index: false,
-            async_reader: false,
+            read_streams: 1,
             sort_stats: false,
         }
     }

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -386,24 +386,28 @@ pub struct Sort {
     #[arg(long = "write-index", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub write_index: bool,
 
-    /// Read the input BAM and the merge's spill files with this many
-    /// concurrent streams.
+    /// Concurrent streams to read the input BAM and the merge's spill files
+    /// with: `auto`, or a fixed count.
     ///
     /// One blocking read keeps only about one read-ahead window outstanding at
     /// the device, which on network-attached storage is far below what it can
     /// serve -- and no buffer size fixes it, because a bigger single request is
-    /// not more concurrency. On EBS gp3, four streams measured 1177 MB/s
-    /// against 358 MB/s for one, and a whole-genome sort ran 28% faster.
+    /// not more concurrency. How much that matters depends entirely on the
+    /// storage: on EBS gp3 four streams took a whole-genome sort 28% faster,
+    /// while on a direct-attached instance-store SSD one stream is already faster than four
+    /// are on gp3 and adding more costs 1.8%.
     ///
-    /// **4 is the measured value for network-attached storage.** The default is
-    /// 1 (today's behaviour) because direct-attached storage has far lower latency
-    /// and may need fewer; that has not been measured yet. The streams are pool
-    /// workers, not new threads, so this never exceeds `--threads`.
+    /// `auto` therefore measures instead of guessing. It starts at one stream
+    /// -- exactly the pre-existing behaviour -- and doubles only while fills
+    /// are occupying most of the read span, which is the condition under which
+    /// concurrency has something to buy. It lands on four for gp3 and stays at
+    /// one for `NVMe` without being told which is which.
     ///
-    /// Clamped to 16 and to the input's chunk count. Ignored for stdin and
-    /// other non-seekable inputs, where positional reads do not exist.
-    #[arg(long = "read-streams", default_value_t = 1)]
-    pub read_streams: usize,
+    /// The streams are existing pool workers, not new threads, so this never
+    /// exceeds `--threads`. Ignored for stdin and other non-seekable inputs,
+    /// where positional reads do not exist.
+    #[arg(long = "read-streams", default_value_t = fgumi_sort::ReadStreams::Auto)]
+    pub read_streams: fgumi_sort::ReadStreams,
 
     /// Emit the sort's performance diagnostics.
     ///
@@ -978,7 +982,6 @@ mod tests {
     /// rendering is suppressed.
     #[rstest]
     #[case::sort_stats("sort-stats")]
-    #[case::async_reader("async-reader")]
     fn test_advanced_flags_are_hidden_from_help(#[case] long: &str) {
         let command = Sort::command();
         let arg = command
@@ -1593,7 +1596,7 @@ mod tests {
             temp_codec: fgumi_sort::SpillCodec::default(),
             max_temp_files: MaxTempFiles::Auto,
             write_index: false,
-            read_streams: 1,
+            read_streams: fgumi_sort::ReadStreams::Auto,
             sort_stats: false,
         }
     }

--- a/tests/integration/test_async_reader.rs
+++ b/tests/integration/test_async_reader.rs
@@ -1,11 +1,14 @@
-//! Integration tests for the `--async-reader` flag across all supported input paths.
+//! Integration tests that a command's choice of *reader* never changes its output.
 //!
-//! Each test runs a command twice — once without `--async-reader` and once with it —
-//! then asserts that the outputs are identical record-by-record. This ensures the
-//! prefetch reader is transparent across:
+//! Each test runs a command twice — once with the default reader and once with an
+//! alternative — then asserts the outputs are identical record-by-record:
 //!
-//! - **Extract:** BGZF, gzip, and plain FASTQ inputs (single- and multi-threaded)
-//! - **BAM commands:** file input with/without `--threads`, and piped stdin
+//! - **Extract and group, `--async-reader`:** BGZF, gzip and plain FASTQ inputs,
+//!   and BAM input, single- and multi-threaded
+//! - **Sort, `--read-streams`:** every sort order, single- and multi-threaded,
+//!   with spilling forced so the merge reads its spill files back through the
+//!   scattered reader too. That is where a mis-ordered slice would corrupt a
+//!   BGZF block or zstd frame, and it is only reachable end to end.
 
 use std::fs::{self, File};
 use std::io::Write;
@@ -565,7 +568,7 @@ fn test_simplex_async_reader_stdin() {
 }
 
 // ============================================================================
-// Sort: async-reader regression tests
+// Sort: --read-streams regression tests
 // ============================================================================
 
 /// Check if samtools is available for sort tests.
@@ -639,7 +642,7 @@ fn run_sort(
     order: &str,
     threads: usize,
     max_memory: &str,
-    async_reader: bool,
+    read_streams: usize,
 ) -> PathBuf {
     let output = tmp.path().join(output_name);
     let mut args: Vec<std::ffi::OsString> = vec![
@@ -659,15 +662,16 @@ fn run_sort(
         "--compression-level".into(),
         "1".into(),
     ];
-    if async_reader {
-        args.push("--async-reader".into());
+    if read_streams > 1 {
+        args.push("--read-streams".into());
+        args.push(read_streams.to_string().into());
     }
 
     let result =
         Command::new(env!("CARGO_BIN_EXE_fgumi")).args(&args).output().expect("fgumi sort");
     assert!(
         result.status.success(),
-        "fgumi sort failed (order={order}, threads={threads}, async={async_reader}):\n{}",
+        "fgumi sort failed (order={order}, threads={threads}, streams={read_streams}):\n{}",
         String::from_utf8_lossy(&result.stderr),
     );
     output
@@ -675,126 +679,56 @@ fn run_sort(
 
 #[test]
 #[ignore = "requires samtools"]
-fn test_sort_coordinate_async_reader_single_threaded() {
+fn test_sort_coordinate_read_streams_single_threaded() {
     if !samtools_available() {
         return;
     }
     let tmp = TempDir::new().unwrap();
     let input = create_unsorted_bam(tmp.path(), 500);
 
-    let baseline = run_sort(&tmp, &input, "baseline.bam", "coordinate", 1, "100M", false);
-    let async_out = run_sort(&tmp, &input, "async.bam", "coordinate", 1, "100M", true);
-    assert_bam_records_equal(&baseline, &async_out);
+    let baseline = run_sort(&tmp, &input, "baseline.bam", "coordinate", 1, "100M", 1);
+    let scattered = run_sort(&tmp, &input, "scattered.bam", "coordinate", 1, "100M", 4);
+    assert_bam_records_equal(&baseline, &scattered);
 }
 
 #[test]
 #[ignore = "requires samtools"]
-fn test_sort_coordinate_async_reader_multithreaded() {
+fn test_sort_coordinate_read_streams_multithreaded() {
     if !samtools_available() {
         return;
     }
     let tmp = TempDir::new().unwrap();
     let input = create_unsorted_bam(tmp.path(), 2000);
 
-    let baseline = run_sort(&tmp, &input, "baseline.bam", "coordinate", 4, "50K", false);
-    let async_out = run_sort(&tmp, &input, "async.bam", "coordinate", 4, "50K", true);
-    assert_bam_records_equal(&baseline, &async_out);
+    let baseline = run_sort(&tmp, &input, "baseline.bam", "coordinate", 4, "50K", 1);
+    let scattered = run_sort(&tmp, &input, "scattered.bam", "coordinate", 4, "50K", 4);
+    assert_bam_records_equal(&baseline, &scattered);
 }
 
 #[test]
 #[ignore = "requires samtools"]
-fn test_sort_queryname_async_reader_multithreaded() {
+fn test_sort_queryname_read_streams_multithreaded() {
     if !samtools_available() {
         return;
     }
     let tmp = TempDir::new().unwrap();
     let input = create_unsorted_bam(tmp.path(), 2000);
 
-    let baseline = run_sort(&tmp, &input, "baseline.bam", "queryname", 4, "50K", false);
-    let async_out = run_sort(&tmp, &input, "async.bam", "queryname", 4, "50K", true);
-    assert_bam_records_equal(&baseline, &async_out);
+    let baseline = run_sort(&tmp, &input, "baseline.bam", "queryname", 4, "50K", 1);
+    let scattered = run_sort(&tmp, &input, "scattered.bam", "queryname", 4, "50K", 4);
+    assert_bam_records_equal(&baseline, &scattered);
 }
 
 #[test]
 #[ignore = "requires samtools"]
-fn test_sort_template_coordinate_async_reader_multithreaded() {
+fn test_sort_template_coordinate_read_streams_multithreaded() {
     if !samtools_available() {
         return;
     }
     let tmp = TempDir::new().unwrap();
     let input = create_unsorted_bam(tmp.path(), 2000);
 
-    let baseline = run_sort(&tmp, &input, "baseline.bam", "template-coordinate", 4, "50K", false);
-    let async_out = run_sort(&tmp, &input, "async.bam", "template-coordinate", 4, "50K", true);
-    assert_bam_records_equal(&baseline, &async_out);
-}
-
-// ============================================================================
-// BAM commands: sort with stdin input
-// ============================================================================
-
-/// Runs `fgumi sort` over stdin at debug verbosity, returning `(output, stderr)`.
-fn run_sort_from_stdin(
-    tmp: &TempDir,
-    input: &Path,
-    output_name: &str,
-    async_reader: bool,
-) -> (PathBuf, String) {
-    let output = tmp.path().join(output_name);
-    let mut args: Vec<std::ffi::OsString> = vec![
-        "-v".into(), // the prefetch decision is logged at debug level
-        "sort".into(),
-        "-i".into(),
-        "-".into(),
-        "-o".into(),
-        output.as_os_str().to_owned(),
-        "--order".into(),
-        "queryname".into(),
-    ];
-    if async_reader {
-        args.push("--async-reader".into());
-    }
-
-    let result = Command::new(env!("CARGO_BIN_EXE_fgumi"))
-        .args(&args)
-        .stdin(Stdio::from(File::open(input).expect("open sort input")))
-        .output()
-        .expect("fgumi sort");
-    assert!(
-        result.status.success(),
-        "fgumi sort from stdin failed (async={async_reader}):\n{}",
-        String::from_utf8_lossy(&result.stderr),
-    );
-    (output, String::from_utf8_lossy(&result.stderr).into_owned())
-}
-
-/// `--async-reader` must reach the stdin path, not only file inputs.
-///
-/// sort's pool-integrated reader spawns a `fgumi-prefetch` thread when the flag is
-/// given, but its stdin branch used to hand back a plain buffered reader whatever
-/// the flag said — so `fgumi sort --async-reader -i -` silently ran without the
-/// prefetch thread while the same command over a file got one.
-///
-/// The assertion is on the log rather than on the records: both readers deliver the
-/// same bytes, so comparing output alone cannot tell whether the flag was honored.
-/// Output equality is checked too, because honoring it must not change the result.
-#[test]
-fn test_sort_async_reader_reaches_stdin() {
-    let tmp = TempDir::new().unwrap();
-    let input = tmp.path().join("input.bam");
-    create_test_bam(&input);
-
-    let (baseline, baseline_log) = run_sort_from_stdin(&tmp, &input, "baseline.bam", false);
-    assert!(
-        !baseline_log.contains("fgumi-prefetch thread for stdin"),
-        "no prefetch thread should be spawned without --async-reader:\n{baseline_log}"
-    );
-
-    let (async_out, async_log) = run_sort_from_stdin(&tmp, &input, "async.bam", true);
-    assert!(
-        async_log.contains("fgumi-prefetch thread for stdin"),
-        "--async-reader must spawn the prefetch thread for stdin too:\n{async_log}"
-    );
-
-    assert_bam_records_equal(&baseline, &async_out);
+    let baseline = run_sort(&tmp, &input, "baseline.bam", "template-coordinate", 4, "50K", 1);
+    let scattered = run_sort(&tmp, &input, "scattered.bam", "template-coordinate", 4, "50K", 4);
+    assert_bam_records_equal(&baseline, &scattered);
 }


### PR DESCRIPTION
Five optimisations to `fgumi sort`, measured against `1kg-wgs-HG00096` (43.13 GB, template-coordinate, 16 threads, 779,820,469 records, `read_ahead_kb` left at its 128 default). Together they take the sort from **~377s to ~268s, about -29%**, with peak RSS unchanged, thread count unchanged, and output byte-identical.

Each change is paired against its own control in a single boot; the combined figure spans two boots, so treat it as approximate (in-boot noise is ±0.7%, cross-boot ±2.3%).

Stacked on #838. Suggested reading order is commit order — each one only makes sense given the last, and the later numbers are only interpretable once the earlier costs are gone.

## Reading order

**1. `0152e316` — extract template sort keys on the pool, not the ingest thread.** 93.6s of `extract_template_key_inline` at ~122 ns/record moves off the serial ingest thread onto the worker pool as a new `SortStep::ExtractKeys`, scheduled last everywhere so it can never displace the step that feeds the ingest thread. `SegmentedBuf` splits into sealed `Arc` segments plus a live one, so a worker can read a finished segment while ingest appends to a later one — safe by construction, no `unsafe`. Ingest serial goes 137.3s to 57.2s with 96.9% of keys overlapped and a 0.2s barrier wait.

**2. `bfa4d1d5` — keep the arena's pages across chunks instead of re-faulting them.** `SegmentedBuf::reset_for_reuse` replaces `clear()` at the three spill sites, and `release_retained` gives the segments back once ingest is over. -13.9s, minor faults 23.6M to 12.7M, and 1.16 GB of the retention cost recovered.

**3. `63dd566e` — read input and spill files with concurrent positional reads.** The bulk of the change; see below.

**4. `6ffe651c` — keep a fill in flight while the framer frames.** The scattered reader was demand-driven, so the device idled for as long as framing took. `fill` splits into `issue` and `collect`, and the phase-1 reader issues the next fill as soon as one is collected. Read span 69.4s to 66.9s, wall 271.8s to 267.7s, paired in one boot against a ±1.9s noise floor. Depth is a knob and **one is the answer** — the sweep is recorded next to the constant.

**5. `89d1f66b` — choose the stream count from a one-stream probe.** `--read-streams` gains `auto`, now the default. Whether concurrency helps depends entirely on the storage: EBS gp3 wants four (28% faster), a direct-attached instance-store SSD wants one (forcing eight is 1.8% slower). Auto measures the device's single-stream throughput over the first eight fills — costing nothing, since that *is* one stream — and picks `ceil(1.2 GB/s ÷ measured)`, capped at eight. The measurement is taken once and shared through the pool's `FetchQueue`, so a merge's 44 spill readers don't each measure a device they're contending for and over-provision. **Validated paired on both devices**: gp3 auto 273.7s vs pinned-four 273.3s (a dead heat, probed 351 MB/s → 4); instance SSD probed 1920 MB/s → 1, its best. The `~377s → ~268s` headline is the gp3 case; a fast-NVMe host sees far less, because there the read was never the bottleneck.

## The third commit

Both phases read a file through one blocking sequential `read()` at a time — phase 1 behind the exclusive `ReadInputBlocks` step, phase 2 behind each spill file's reader mutex. That is queue depth 1, and this device serves one stream far worse than several: **358 MB/s against 1177 MB/s for four concurrent streams**, with buffer size making no difference at all (2, 8 and 32 MiB all landed within 0.1%). A bigger single request is not more concurrency.

`read_ahead_kb=4096` fixes both, but it is root-only and system-wide, so a tool cannot rely on it. `posix_fadvise` was measured as the per-file substitute and does not work — `SEQUENTIAL` 359 MB/s and `WILLNEED` 348-350 MB/s against 360 with no hint, with `strace` confirming the calls land and the kernel simply declines. So `--read-streams N` cuts a fill into slices read at once and serves them in file order behind a plain `Read`. BGZF blocks and zstd frames are variable-length, so block N's offset is unknowable without scanning from block 0 — but framing is ~4% of the reader's time, so parallelising the byte fetch and leaving the framer, the block serials and the reorder buffer untouched is enough.

**The slices run on the existing worker pool, as a new `SortStep::FetchBytes` — not on threads of the reader's own.** I built the dedicated-thread version first and measured it: at four streams a `--threads 16` sort ran **38 threads instead of 34** and doubled involuntary context switches (1.39M to 2.81M). It was faster only because the host had idle cores to lend, and it silently broke what `--threads` means.

The filling thread reads the first slice itself and then **reclaims** any slice no worker has started, rather than waiting on one. Submitting and blocking would deadlock the moment every worker is a filler waiting for slices nobody is left to run; reclaim makes the worst case "the single sequential read we do today" instead of a wedge. In practice reclaim almost never fires — **70,211 of 70,310 slices (99.8%) were run by workers**, because slice 0 is a real disk read and that is a wide window.

## Measurements

| arm | wall | phase 1 read | k-way merge | peak threads | involuntary ctx sw |
| --- | --- | --- | --- | --- | --- |
| `--read-streams 1` | 377.7s | 141.8s | 155.1s | 34 | 1,390,118 |
| `--read-streams 4` | **271.2s** | **69.9s** | **120.2s** | **34** | **1,345,637** |

And the lookahead commit, paired separately in a later boot:

| lookahead depth | wall | phase 1 read span | peak RSS |
| --- | --- | --- | --- |
| 0 | 271.8s | 69.4s | 11,253 MB |
| **1** | **267.7s** | **66.9s** | 11,281 MB |
| 2 | 269.4s | 66.7s | 11,559 MB |
| 4 | 268.5s | 66.4s | 11,290 MB |

Depths past one move the read span by under a second and the wall clock not at all, and depth 2 cost 277 MB of peak RSS for it. One is enough because **the span is not fetch-bound**: the fetch runs at 1327 MB/s — above the 1177 MB/s the four-stream ladder measured — and takes 32.5s of a 66.4s span against an ingest-serial floor of 53.0s. What remains is coordination between the reader, the decompress workers and the ingest thread, which read-ahead does not touch.

That settles the phase-1 read path. At device speed and half the span, the reader is no longer the constraint there; the remaining headroom is the ingest thread's own serial cost and the coordination gap, not I/O.

The merge's own reads fall from 169.3s of worker-busy time to 79.5s, consumer park from 42.3s to 1.1s, and the merge reaches its consumer-serial floor: 118.0s of serial consumer inside a 120.1s loop, so 2% is all that remains recoverable there without doing less work per record. Peak RSS is unchanged at 10.7 GB. Total CPU rises 1.4%, all of it system time from roughly double the read syscalls.

`tricorder --trace` confirms no arm ever saturates the box: cores in use peak at 13.9 of 16 and no tick reaches 15.2, so the 34 threads are mostly idle rayon and writer threads rather than contention. Worth knowing that a `--threads 16` sort has always run ~34 threads.

## Correctness

`compare bams --command sort` reports **IDENTICAL** between one and four streams, across both spill codecs, and against the pre-change binary's output on the full 779,820,469-record sort. Locally, a spilling sort (11 spill runs) compares identical across bgzf/zstd x 1/4 streams.

The lookahead commit is separately verified IDENTICAL against the pre-change binary on the same full sort.

The unit tests cover in-order delivery at 1/2/4/8 streams, a short final slice, an empty file, 13-byte reads across slice seams, buffer recycling, offset starts (the zstd `ZSPILL_MAGIC` case), a failed fill reporting rather than hanging, that exactly one caller ever runs a given slice under an 8-way race, that a fill completes when **no** worker ever takes a slice, that lookahead keeps the depth it was given in flight and never runs past EOF, that **a failed fill rewinds the fetch offset** so a retry re-reads the failed range instead of skipping it, and — Linux only — that scattered reading spawns no threads of its own. Each was checked by mutation; the thread-ceiling one fails if a single thread is spawned.

The four sort arms of the `--async-reader` integration test now vary `--read-streams` instead, with spilling forced, so the merge's spill reads are covered end to end and not only at unit level.

## Two things to weigh

**`--async-reader` is removed from sort.** It was a hidden prototype whose whole job was decoupling the read from the block reader, which `--read-streams` now does without spawning a thread outside `--threads`. `extract` and `group` keep their own, which is unrelated. The one capability genuinely lost is prefetch on **piped stdin** — scattered reads need offsets, so a pipe falls back to the plain buffered reader. I think that is right, since the pool's `ReadInputBlocks` step already decouples that read from the consumer, but it is a removal rather than a refactor.

**The default is `auto`** (commit 5). The `c7gd` local-NVMe sweep that motivated it is done and is why: 1/2/4/8 streams there gave 248.4/249.4/251.4/252.9s — monotonically *worse*, because one stream already sustains 2214 MB/s and the ingest thread can only absorb ~810. So a fixed 4 would have been a 1.8% regression on instance storage while winning 28% on gp3; auto gets both by measuring. The one axis not measured is a CPU-saturated host — but auto only spawns extra streams on measurably slow storage, so the fetch/compression contention is only ever paid where it earns 28%.

