### PR TITLE
fix(pipeline): charge queue bytes before publishing on the processed queue

### DIFF
--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -1466,11 +1466,18 @@ impl<G: Send + MemoryEstimate + 'static, P: Send + MemoryEstimate + 'static>
     }
 
     fn process_output_push(&self, item: (u64, Vec<P>)) -> Result<(), (u64, Vec<P>)> {
-        // Calculate heap size before push for memory tracking
-        let heap_size: usize = item.1.iter().map(MemoryEstimate::estimate_heap_size).sum();
-        let result = self.output.processed.push(item);
+        // Charge before publishing (via `push_charged`) so a consumer cannot pop
+        // and refund the batch before the charge lands; it refunds on a failed
+        // push. Charging after the push strands a phantom counter (see `q6_push`).
+        let heap_size: u64 =
+            item.1.iter().map(|p| MemoryEstimate::estimate_heap_size(p) as u64).sum();
+        let result = push_charged(
+            &self.output.processed,
+            &self.output.processed_heap_bytes,
+            heap_size,
+            item,
+        );
         if result.is_ok() {
-            self.output.processed_heap_bytes.fetch_add(heap_size as u64, Ordering::AcqRel);
             self.deadlock_state.record_q5_push();
         }
         result
@@ -2966,14 +2973,16 @@ fn try_step_process<G: Send + MemoryEstimate + 'static, P: Send + MemoryEstimate
     // Priority 1: Try to advance any held processed batch first
     // =========================================================================
     if let Some((serial, held, heap_size)) = worker.held_processed.take() {
+        // Charge before publishing so a consumer cannot pop and refund the batch
+        // before the charge lands; refund on a failed push (see `q6_push`).
+        state.output.processed_heap_bytes.fetch_add(heap_size as u64, Ordering::AcqRel);
         match state.output.processed.push((serial, held)) {
             Ok(()) => {
-                // Successfully advanced held item - memory tracking handled by trait impl
-                state.output.processed_heap_bytes.fetch_add(heap_size as u64, Ordering::AcqRel);
                 state.deadlock_state.record_q5_push();
             }
             Err((serial, held)) => {
-                // Still can't push - put it back and signal output full
+                // Still can't push - refund the charge, put it back, signal output full
+                refund_queue_bytes(&state.output.processed_heap_bytes, heap_size as u64);
                 worker.held_processed = Some((serial, held, heap_size));
                 return false;
             }
@@ -3031,15 +3040,17 @@ fn try_step_process<G: Send + MemoryEstimate + 'static, P: Send + MemoryEstimate
         // Calculate heap size for memory tracking
         let heap_size: usize = results.iter().map(MemoryEstimate::estimate_heap_size).sum();
 
-        // Try to push result
+        // Charge before publishing so a consumer cannot pop and refund the batch
+        // before the charge lands; refund on a failed push (see `q6_push`).
+        state.output.processed_heap_bytes.fetch_add(heap_size as u64, Ordering::AcqRel);
         match state.output.processed.push((serial, results)) {
             Ok(()) => {
-                state.output.processed_heap_bytes.fetch_add(heap_size as u64, Ordering::AcqRel);
                 state.deadlock_state.record_q5_push();
                 did_work = true;
             }
             Err((serial, results)) => {
-                // Output full - hold the result for next attempt
+                // Output full - refund the charge and hold the result for next attempt
+                refund_queue_bytes(&state.output.processed_heap_bytes, heap_size as u64);
                 worker.held_processed = Some((serial, results, heap_size));
                 break;
             }

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -2620,12 +2620,12 @@ impl<G: Send + 'static, P: Send + MemoryEstimate + 'static> ProcessPipelineState
     }
 
     fn process_output_push(&self, item: (u64, Vec<P>)) -> Result<(), (u64, Vec<P>)> {
-        let heap_size: usize = item.1.iter().map(MemoryEstimate::estimate_heap_size).sum();
-        let result = self.processed.push(item);
-        if result.is_ok() {
-            self.processed_heap_bytes.fetch_add(heap_size as u64, Ordering::AcqRel);
-        }
-        result
+        // Charge before publishing (via `push_charged`) so a consumer cannot pop
+        // and refund the batch before the charge lands; it refunds on a failed
+        // push. Charging after the push strands a phantom counter (see `q6_push`).
+        let heap_size: u64 =
+            item.1.iter().map(|p| MemoryEstimate::estimate_heap_size(p) as u64).sum();
+        push_charged(&self.processed, &self.processed_heap_bytes, heap_size, item)
     }
 
     fn has_error(&self) -> bool {


### PR DESCRIPTION
## Problem

The merge-queue `coverage` job intermittently panicked with:

```
refunded N queue bytes against a counter holding 0
```

at `src/lib/unified_pipeline/base.rs` (`refund_queue_bytes`). This was a flaky, timing-dependent failure that surfaced under llvm-cov instrumentation (which perturbs thread scheduling), repeatedly ejecting otherwise-clean PRs from the merge queue.

## Root cause

The `processed` queue's byte counter (`processed_heap_bytes`) was charged **after** the batch was pushed onto the queue — in `try_step_process` (both the held-item advance and the result push) and in both `process_output_push` trait impls. Once a batch is visible on the queue, a Serialize worker can pop it and refund its bytes via `serialize_input_pop` **before** the charge lands. `refund_queue_bytes` then sees a counter below the refund amount: it saturates at zero (stranding a phantom charge that under-bounds the Read gate in release) and trips its `debug_assert!(previous >= bytes)` under coverage/debug builds — the observed panic.

## Fix

Charge before publishing, and refund on a failed push — the ordering already used by the serialized (`serialize_output_push`) and compressed (`q6_push`) counters, and by the FASTQ process step (`push_charged`). The two `process_output_push` trait impls now route through `push_charged`. Every queue-byte counter summed into `queue_bytes_in_flight` is now charged before its item becomes poppable, so no consumer can refund ahead of the charge.

No behavior change in the success path; only the charge/refund ordering is corrected.

## Verification

- `test_pipeline_concurrency::test_bam_pipeline_multithreaded_determinism` under llvm-cov: **0 failures / 120 iterations** (was ~9/10 failing before the fix), 0 panic lines.
- 50/50 debug-build concurrency iterations clean.
- Widened-window stress (artificially delayed charge): 0/20 (was 9/10).
