### PR TITLE
fix(raw-bam): capture overlapping selected aux tags independently

### DIFF
--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -314,16 +314,25 @@ pub fn extract_aux_string_tags(
             let start = p + 3;
             if let Some(end) = nul_offset(&aux_data[start..]) {
                 let value = &aux_data[start..start + end];
+                // Independent `if` checks (not a chained `else if`) so a caller
+                // that configures overlapping selected tags -- e.g. `cell_tag ==
+                // MC`, or `umi_tag` equal to RG/cell/MC -- still captures every
+                // selected field from the one matching aux entry. A chained
+                // `else if` would populate only the first-matching field. This
+                // mirrors the sibling `extract_template_aux_tags`.
                 if t == SamTag::RG {
                     result.rg = Some(value);
                     found |= 1;
-                } else if t == *cell_tag {
+                }
+                if t == *cell_tag {
                     result.cell = Some(value);
                     found |= 2;
-                } else if t == SamTag::MC {
+                }
+                if t == SamTag::MC {
                     result.mc = Some(value);
                     found |= 4;
-                } else if matches!(umi_tag, Some(ut) if t == ut) {
+                }
+                if matches!(umi_tag, Some(ut) if t == ut) {
                     // Width checks are defensive only (BAM records < 4 GiB,
                     // aux values < 64 KiB); silently skip if they fail.
                     if let (Ok(off_u32), Ok(len_u16)) = (u32::try_from(start), u16::try_from(end)) {
@@ -2881,6 +2890,49 @@ mod tests {
         let aux = b"RXZACGT\x00";
         let result = extract_aux_string_tags(aux, SamTag::CB, None);
         assert!(result.umi_position.is_none());
+    }
+
+    /// Overlapping selection: when `cell_tag == MC`, the single `MC` aux entry
+    /// must populate BOTH the cell field and the mc field. The chained
+    /// `else if` this replaced captured only the first-matching field (cell) and
+    /// left `mc` = None, which on the grouping/dedup key path silently dropped
+    /// the mate-CIGAR contribution to the group key. Parity with the sibling
+    /// `extract_template_aux_tags`, which already uses independent `if` checks.
+    #[test]
+    fn test_extract_aux_string_tags_captures_overlapping_cell_and_mc() {
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"RGZlib1\x00");
+        aux.extend_from_slice(b"MCZ5M\x00");
+        // cell_tag == MC: the one MC entry is selected as both cell and mc.
+        let result = extract_aux_string_tags(&aux, SamTag::MC, None);
+        assert_eq!(result.rg, Some(b"lib1".as_ref()));
+        assert_eq!(result.cell, Some(b"5M".as_ref()), "cell must capture the MC entry");
+        assert_eq!(result.mc, Some(b"5M".as_slice()), "mc must still capture the same entry");
+    }
+
+    /// Overlapping selection on the UMI axis: when `umi_tag == RG`, the single
+    /// `RG` entry must populate BOTH the rg field and the UMI position.
+    #[test]
+    fn test_extract_aux_string_tags_captures_overlapping_rg_and_umi() {
+        let aux = b"RGZlib1\x00";
+        let result = extract_aux_string_tags(aux, SamTag::CB, Some(*SamTag::RG));
+        assert_eq!(result.rg, Some(b"lib1".as_ref()), "rg must still capture");
+        let (off, len) = result.umi_position.expect("UMI position must also capture the RG entry");
+        assert_eq!(&aux[off as usize..off as usize + len as usize], b"lib1");
+    }
+
+    /// Non-overlap pin: with disjoint selected tags (the default `cell_tag ==
+    /// CB`), each field is sourced from its own entry and nothing cross-fills.
+    #[test]
+    fn test_extract_aux_string_tags_non_overlapping_tags_stay_separate() {
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"RGZlib1\x00");
+        aux.extend_from_slice(b"CBZbc1\x00");
+        aux.extend_from_slice(b"MCZ5M\x00");
+        let result = extract_aux_string_tags(&aux, SamTag::CB, None);
+        assert_eq!(result.rg, Some(b"lib1".as_ref()));
+        assert_eq!(result.cell, Some(b"bc1".as_ref()));
+        assert_eq!(result.mc, Some(b"5M".as_slice()));
     }
 
     // ========================================================================


### PR DESCRIPTION
## The bug

`extract_aux_string_tags` (`crates/fgumi-raw-bam/src/tags.rs`) — the single-pass RG / cell-barcode / MC / UMI extractor on the grouping and dedup **group-key** path — used a chained `else if` over the four selected tags:

```rust
if t == SamTag::RG { ... }
else if t == *cell_tag { ... }
else if t == SamTag::MC { ... }
else if matches!(umi_tag, Some(ut) if t == ut) { ... }
```

When a caller configures **overlapping** selected tags, one aux entry can satisfy two of these branches — but the chain fires only the first and drops the rest. Concretely:

- `cell_tag == MC`: an `MC` aux entry sets `cell` and leaves `mc = None`.
- `umi_tag` equal to `RG` / cell / `MC`: the entry sets the earlier field and never records the UMI position.

On the group-key path this silently drops a field (e.g. the mate-CIGAR contribution) from the key, so reads that should key differently can collide. Default config (`cell_tag == CB`, `umi_tag == RX`) never overlaps, so the common path is unaffected — this is a latent edge case reachable only via an overlapping tag configuration.

## The fix — sibling parity

The sibling extractor `extract_template_aux_tags` (same file, ~L420-431) already uses **independent `if` checks** for exactly this reason. This change brings `extract_aux_string_tags` to parity: each selected field is captured independently from the one matching entry.

The early-exit remains `if found == target { return }`. `found` never exceeds `target` (the UMI bit is only ever set when the caller requested a UMI tag, which is the only conditional bit in `target`), so the loop still returns as soon as every requested field is present.

## Repro config

Any grouping/dedup run whose cell-barcode tag is set to `MC`, or whose UMI tag collides with `RG`/the cell tag/`MC`. The added unit tests reproduce it directly at the function boundary (`cell_tag == MC` and `umi_tag == RG`).

## Regression tests

Added to the existing `extract_aux_string_tags` tests in `tags.rs`:

- `..._captures_overlapping_cell_and_mc` — `cell_tag == MC` with a record carrying an `MC` entry; asserts **both** `cell` and `mc` populate.
- `..._captures_overlapping_rg_and_umi` — `umi_tag == RG`; asserts **both** `rg` and the UMI position populate.
- `..._non_overlapping_tags_stay_separate` — default disjoint tags land in their own fields and never cross-fill (pins default behavior).

## Hot-path note

`extract_aux_string_tags` runs once per record on the Phase-1 group-key path, so cost matters. No micro-benchmark exercises this function directly (the sort `template_key` bench targets the sibling template path), so per the repo's benchmarking guidance this is a reasoned note rather than a fresh harness:

The change replaces a short-circuiting `else if` chain with four independent `if`s. For a Z-typed aux entry that matches one selected tag, this adds at most three more comparisons — each a two-byte tag equality (`[u8; 2] == [u8; 2]`), a register compare. That is negligible next to the per-entry `nul_offset` scan of the value bytes that already runs for every Z entry, and the `found == target` early-exit still returns the moment all requested fields are seen, so a record with its tags up front exits just as early as before. Net per-record cost is well under the measurement floor; correctness for the overlapping-tag configuration is restored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: changes grouping and deduplication output when auxiliary tags overlap, pinned by regression tests; `unsafe`: none, and CLAUDE.md allowlist: unchanged; memory, queue, thread, and backpressure policy: none.

Fix: `extract_aux_string_tags` now checks each selected tag independently. One auxiliary entry can populate multiple fields, including overlapping `MC`/cell and `RG`/UMI selections. Tests cover overlapping and default configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->