### PR TITLE
fix(clip): clip dovetail FR overlaps and make the TLEN FR check crate-internal

### DIFF
--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -1933,11 +1933,6 @@ impl CodecConsensusCaller {
     reason = "test-only methods use owned values and numeric casts"
 )]
 impl CodecConsensusCaller {
-    /// Test-only wrapper: check if a `RawRecord` is part of an FR pair.
-    pub fn is_fr_pair(&self, rec: &RawRecord) -> bool {
-        bam_fields::is_fr_pair_raw(rec)
-    }
-
     /// Test-only wrapper: filter `RawRecord`s to most common alignment,
     /// returning the surviving records (index-stable relative to the input).
     pub fn filter_to_most_common_alignment(&mut self, recs: Vec<RawRecord>) -> Vec<RawRecord> {
@@ -2147,53 +2142,6 @@ mod tests {
             .template_length(tlen);
         b.add_string_tag(SamTag::MI, b"UMI123");
         b.build()
-    }
-
-    #[test]
-    fn test_is_fr_pair() {
-        use noodles::sam::alignment::record::cigar::op::Kind;
-
-        let options = CodecConsensusOptions::default();
-        let caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
-
-        // FR pair: R1 forward, R2 reverse
-        let r1_fr = create_test_paired_read(
-            "read1",
-            b"ACGT",
-            b"####",
-            true,
-            false,
-            true,
-            100,
-            &[(Kind::Match, 4)],
-        );
-        assert!(caller.is_fr_pair(&r1_fr));
-
-        // RF pair: R1 reverse, R2 forward - still considered FR orientation
-        let r1_rf = create_test_paired_read(
-            "read1",
-            b"ACGT",
-            b"####",
-            true,
-            true,
-            false,
-            100,
-            &[(Kind::Match, 4)],
-        );
-        assert!(caller.is_fr_pair(&r1_rf));
-
-        // FF pair: both forward - not FR
-        let r1_ff = create_test_paired_read(
-            "read1",
-            b"ACGT",
-            b"####",
-            true,
-            false,
-            false,
-            100,
-            &[(Kind::Match, 4)],
-        );
-        assert!(!caller.is_fr_pair(&r1_ff));
     }
 
     #[test]

--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -97,8 +97,8 @@ pub use cigar::{
 
 // -- overlap --
 pub use overlap::{
-    bases_extending_past_mate_ops, is_fr_pair_raw, is_primary_fr_pair_raw,
-    num_bases_extending_past_mate_raw, num_bases_extending_past_mate_vs_mate_raw,
+    bases_extending_past_mate_ops, is_primary_fr_pair_raw, num_bases_extending_past_mate_raw,
+    num_bases_extending_past_mate_vs_mate_raw,
 };
 
 // -- raw_bam_record --

--- a/crates/fgumi-raw-bam/src/overlap.rs
+++ b/crates/fgumi-raw-bam/src/overlap.rs
@@ -5,13 +5,20 @@ use crate::cigar::{
 use crate::fields::{RawRecordView, aux_data_slice, flags, mate_pos, mate_ref_id, template_length};
 use crate::tags::RawTagsView;
 
-/// Check if a single read is part of an FR (forward-reverse) pair using raw BAM bytes.
+/// Crate-internal per-record FR (forward-reverse) classification from raw BAM bytes.
 ///
-/// This is the raw-byte equivalent of `record_utils::is_fr_pair_from_tags`.
+/// **Per-record, and not a gate for pair decisions.** The forward-strand arm derives the mate's
+/// 5' end from `TLEN`, which misclassifies dovetail FR pairs whose aligned ends coincide
+/// (htsjdk/samtools#1771). It is therefore crate-internal: it exists only as the reverse-arm
+/// building block for the correct, TLEN-independent gates. Callers that need to classify a pair
+/// must use `is_primary_fr_pair_raw` (both records in hand) or `is_fr_pair_with_mate_cigar_raw`
+/// (a read plus its MC tag) instead. Raw-byte counterpart of
+/// `record_utils::is_fr_pair_from_tags`.
+///
 /// Returns `true` if the read is paired, both read and mate are mapped,
 /// on the same reference, and in FR orientation (positive strand 5' < negative strand 5').
 #[must_use]
-pub fn is_fr_pair_raw(bam: &[u8]) -> bool {
+pub(crate) fn is_fr_pair_raw(bam: &[u8]) -> bool {
     let v = RawRecordView::new(bam);
     let flg = v.flags();
 
@@ -63,7 +70,7 @@ pub fn is_fr_pair_raw(bam: &[u8]) -> bool {
 /// Symmetric per-pair FR classification for a template's two primary reads.
 ///
 /// This is the raw-byte port of fgbio `CodecConsensusCaller.isPrimaryFrPair(a, b)`
-/// (`CodecConsensusCaller.scala:424-433`). Unlike [`is_fr_pair_raw`], which is a *per-record*
+/// (`CodecConsensusCaller.scala:424-433`). Unlike `is_fr_pair_raw`, which is a *per-record*
 /// test, this evaluates a *pair* and is order-independent: after confirming both reads are
 /// mapped with mapped mates, on the same reference, and on opposite strands, it derives the FR
 /// orientation from the **reverse-strand record only**. That branch of the orientation test is
@@ -101,19 +108,19 @@ pub fn is_primary_fr_pair_raw(a: &[u8], b: &[u8]) -> bool {
 }
 
 /// FR classification for the MC-tag consensus path, evaluated per-*pair* rather than via the
-/// per-record TLEN arm of [`is_fr_pair_raw`].
+/// per-record TLEN arm of `is_fr_pair_raw`.
 ///
-/// [`is_fr_pair_raw`]'s forward-strand arm derives the negative-strand 5' end from `TLEN`, which
+/// `is_fr_pair_raw`'s forward-strand arm derives the negative-strand 5' end from `TLEN`, which
 /// misclassifies dovetail FR pairs whose aligned ends coincide (htsjdk/samtools#1771) and zeroes
 /// the read-through clip for the forward read. The simplex/duplex callers hold the read plus its
 /// `MC` tag (mate CIGAR), so the reverse-strand record's CIGAR-derived orientation — the branch
 /// [`is_primary_fr_pair_raw`] evaluates — can be reconstructed for either strand:
 /// - a reverse-strand read *is* the reverse record, so its own CIGAR-based arm (exactly
-///   [`is_fr_pair_raw`]) is already correct and TLEN-independent;
+///   `is_fr_pair_raw`) is already correct and TLEN-independent;
 /// - a forward-strand read's mate is the reverse record: its leftmost (5') is `mate_pos` and its
 ///   inclusive alignment end is `mate_pos + mate_ref_len - 1` (from the `MC` CIGAR), and the pair
 ///   is FR iff the forward read's own 5' (its leftmost) is `<` that end — the same
-///   `positive_five_prime < negative_five_prime` test [`is_fr_pair_raw`]'s reverse arm applies.
+///   `positive_five_prime < negative_five_prime` test `is_fr_pair_raw`'s reverse arm applies.
 ///
 /// `mate_ref_len` is the reference span of the mate's CIGAR (from the `MC` tag), clamped by
 /// [`saturating_reference_length`]. This matches `is_primary_fr_pair_raw(read, mate)` on dovetail
@@ -208,7 +215,7 @@ pub fn num_bases_extending_past_mate_raw(bam: &[u8]) -> usize {
 /// distance as [`num_bases_extending_past_mate_raw`].
 ///
 /// Because both records are in hand, FR classification uses the symmetric per-pair
-/// [`is_primary_fr_pair_raw`] rather than the per-record [`is_fr_pair_raw`]. The per-record test is
+/// [`is_primary_fr_pair_raw`] rather than the per-record `is_fr_pair_raw`. The per-record test is
 /// asymmetric for dovetail pairs (htsjdk/samtools#1771): a valid dovetail-forward pair can be
 /// mis-classified as non-FR from the forward read's perspective, which would zero its clip even
 /// though the caller (e.g. the codec caller's `is_primary_fr_pair_raw` gate) accepted the pair.
@@ -283,7 +290,7 @@ pub fn num_bases_extending_past_mate_vs_mate_raw(rec: &[u8], mate: &[u8]) -> usi
 /// aligned bases — the destructive answer fulcrumgenomics/fgumi#752 exists to remove — on a
 /// geometry this function cannot verify.
 ///
-/// It is reachable two ways, one per strand. [`is_fr_pair_raw`] mirrors htsjdk's *per-record*
+/// It is reachable two ways, one per strand. `is_fr_pair_raw` mirrors htsjdk's *per-record*
 /// orientation test, whose forward-strand arm reads `TLEN`, so a forward record can be accepted
 /// as one end of an FR pair while the mate CIGAR it carries places the mate to its left.
 /// (htsjdk 5 prefers the mate CIGAR when the MC tag is present, which is why fgbio does not admit
@@ -2031,7 +2038,7 @@ mod tests {
     }
 
     /// The negative-strand mirror of the case above, which only the mate-record entry point can
-    /// reach: [`is_fr_pair_raw`]'s reverse arm compares the mate position recorded *on the read*
+    /// reach: `is_fr_pair_raw`'s reverse arm compares the mate position recorded *on the read*
     /// against the read's own end, while [`num_bases_extending_past_mate_vs_mate_raw`] measures
     /// against the mate record in hand, and the two disagree when that field is stale.
     ///

--- a/crates/fgumi-sam/src/clipper.rs
+++ b/crates/fgumi-sam/src/clipper.rs
@@ -598,9 +598,12 @@ impl RawRecordClipper {
         r1: &mut fgumi_raw_bam::RawRecord,
         r2: &mut fgumi_raw_bam::RawRecord,
     ) -> (usize, usize) {
-        if !fgumi_raw_bam::is_fr_pair_raw(r1.as_ref())
-            || !fgumi_raw_bam::is_fr_pair_raw(r2.as_ref())
-        {
+        // Gate on the symmetric, order-independent per-*pair* FR classifier. The per-record
+        // `is_fr_pair_raw` derives the mate 5' from TLEN on its forward-strand arm, which
+        // misclassifies dovetail FR pairs (htsjdk/samtools#1771) and would skip overlap clipping
+        // on a valid pair. Both records are in hand here, so `is_primary_fr_pair_raw` (the same
+        // gate the sibling `clip_extending_past_mate_ends` uses) is the correct check.
+        if !fgumi_raw_bam::is_primary_fr_pair_raw(r1.as_ref(), r2.as_ref()) {
             return (0, 0);
         }
 
@@ -2118,8 +2121,9 @@ mod tests {
         use noodles::sam::header::record::value::map::ReferenceSequence;
         use std::num::NonZeroUsize;
 
-        // Build a valid FR pair, then mark r2 as self-unmapped. r1's flags still
-        // claim the mate is mapped, so is_fr_pair_raw(r1) passes but r2 doesn't.
+        // Build a valid FR pair, then mark r2 as self-unmapped. r1's flags still claim the mate
+        // is mapped, but the pair is not a valid primary FR pair because r2 itself is unmapped,
+        // so the symmetric gate must reject it (validating both records, not just r1).
         let r1_buf =
             create_paired_record("100M", &"A".repeat(100), 1000, false, true, 1100, "100M");
         let mut r2_buf =
@@ -2134,12 +2138,55 @@ mod tests {
         let mut r1 = encode_record_buf_to_raw(&r1_buf, &header).expect("encode r1");
         let mut r2 = encode_record_buf_to_raw(&r2_buf, &header).expect("encode r2");
 
-        assert!(fgumi_raw_bam::is_fr_pair_raw(r1.as_ref()));
-        assert!(!fgumi_raw_bam::is_fr_pair_raw(r2.as_ref()));
+        // Not a valid primary FR pair: r2 is self-unmapped.
+        assert!(!fgumi_raw_bam::is_primary_fr_pair_raw(r1.as_ref(), r2.as_ref()));
 
         let clipper = RawRecordClipper::new(ClippingMode::Soft);
         assert_eq!(clipper.clip_overlapping_reads(&mut r1, &mut r2), (0, 0));
         assert_eq!(clipper.clip_extending_past_mate_ends(&mut r1, &mut r2), (0, 0));
+    }
+
+    /// Retro sibling of #839: `clip_overlapping_reads` must clip a valid dovetail FR pair whose
+    /// FORWARD read carries a leftmost-to-rightmost `TLEN`. `is_fr_pair_raw`'s per-record
+    /// forward arm derives the mate 5' from `TLEN`, so it mis-reports the forward read as non-FR
+    /// on such dovetails (htsjdk/samtools#1771); the old `is_fr_pair_raw(r1) || is_fr_pair_raw(r2)`
+    /// gate then short-circuited to `(0, 0)` and left the read-through/adapter overlap unclipped.
+    /// The symmetric `is_primary_fr_pair_raw(r1, r2)` gate — both records in hand, the same fix
+    /// the sibling `clip_extending_past_mate_ends` already uses — classifies the pair correctly.
+    #[test]
+    fn test_raw_clip_overlapping_reads_dovetail_fr_forward_tlen() {
+        use fgumi_raw_bam::encode_record_buf_to_raw;
+        use noodles::sam::header::record::value::Map;
+        use noodles::sam::header::record::value::map::ReferenceSequence;
+        use std::num::NonZeroUsize;
+
+        // Dovetail FR pair: forward 100M @ 101 (ref 101..200), reverse 100M @ 61 (ref 61..160).
+        // Overlap is ref 101..160; the reference midpoint between the forward 5' (101) and the
+        // reverse 3' (160) is 130, so each read clips 70 query bases back to the midpoint.
+        let seq = "A".repeat(100);
+        let mut fwd_buf = create_paired_record("100M", &seq, 101, false, true, 61, "100M");
+        // An aligner writing TLEN under SAM v1 §1.4's leftmost-to-rightmost convention emits a
+        // negative TLEN on the rightmost (here forward) read, which is what mis-drives
+        // is_fr_pair_raw's per-record forward arm. create_paired_record's own 5'-to-5' TLEN would
+        // sidestep the bug, so override it to the leftmost-to-rightmost value (span 61..200).
+        *fwd_buf.template_length_mut() = -140;
+        let rev_buf = create_paired_record("100M", &seq, 61, true, false, 101, "100M");
+
+        let ref_seq =
+            Map::<ReferenceSequence>::new(NonZeroUsize::new(100_000).expect("ref length nonzero"));
+        let header =
+            noodles::sam::Header::builder().add_reference_sequence(b"chr1", ref_seq).build();
+        let mut fwd = encode_record_buf_to_raw(&fwd_buf, &header).expect("encode fwd");
+        let mut rev = encode_record_buf_to_raw(&rev_buf, &header).expect("encode rev");
+
+        // The pair is a valid primary FR pair (classified on the reverse record's CIGAR arm),
+        // even though the forward read's per-record TLEN arm misclassifies it.
+        assert!(fgumi_raw_bam::is_primary_fr_pair_raw(fwd.as_ref(), rev.as_ref()));
+
+        // Before the fix this returned (0, 0); the dovetail overlap must be clipped to the
+        // reference midpoint on both reads.
+        let clipper = RawRecordClipper::new(ClippingMode::Soft);
+        assert_eq!(clipper.clip_overlapping_reads(&mut fwd, &mut rev), (70, 70));
     }
 
     #[test]

--- a/tests/integration/test_clip_command.rs
+++ b/tests/integration/test_clip_command.rs
@@ -802,9 +802,9 @@ fn test_clip_command_threads_mode_primary_pair_all_options() {
         mapped_read(b"p", flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE, 99, 150, 60);
     let mut r2 =
         mapped_read(b"p", flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE, 99, 100, 60);
-    // A non-zero TLEN is required for `is_fr_pair_raw` to recognize the pair (htsjdk keys FR
-    // detection off the insert size); without it overlap and mate-extension clipping would
-    // silently no-op and only the fixed 5'/3' clips would apply.
+    // Set a realistic FR insert size on the pair. Overlap and mate-extension clipping gate on the
+    // symmetric `is_primary_fr_pair_raw` (the reverse read's CIGAR-derived arm), so FR detection is
+    // TLEN-independent; the values are set only because a real FR pair carries them.
     fgumi_raw_bam::set_template_length(r1.as_mut_vec(), 150);
     fgumi_raw_bam::set_template_length(r2.as_mut_vec(), -150);
     create_bam_from_records(&input_bam, &[r1, r2]);


### PR DESCRIPTION
## Summary

`RawRecordClipper::clip_overlapping_reads` (the `fgumi clip` overlap path) gated on the per-record `is_fr_pair_raw` for both reads. That check's forward-strand arm derives the mate 5' from `TLEN`, so it misclassifies dovetail FR pairs whose aligned ends coincide (htsjdk/samtools#1771): the forward read reads as non-FR, the guard returns `(0, 0)`, and read-through/adapter is left unclipped on an otherwise valid FR pair. This is the same class of bug #839 fixes for the MC-tag consensus path; this consumer was not covered.

Both records are in hand at this call site, so it now gates on the symmetric, order-independent `is_primary_fr_pair_raw(r1, r2)` instead — the same gate the sibling `clip_extending_past_mate_ends` already uses.

## Consolidation

To stop the per-record TLEN check from being grabbed as a pair-classification gate again:

- `is_fr_pair_raw` is demoted to `pub(crate)` and dropped from the crate's public re-export. It remains the reverse-arm building block for `is_primary_fr_pair_raw` and `is_fr_pair_with_mate_cigar_raw`.
- The test-only `CodecConsensusCaller::is_fr_pair` wrapper (and its test) are removed; the per-record FR/RF/FF coverage already lives in `overlap.rs`.

## Testing

- New `clip_overlapping_reads` dovetail-forward regression test (RED without the gate change, GREEN with it).
- Full `cargo ci-test` (7930 tests), `ci-fmt`, `ci-lint`, and `cargo doc -D warnings` pass.

## Stacking

Stacked on #839 (`839/nhomer/consensus-dovetail-fr-trim`); please merge after that PR — the FR-classification primitives this builds on land there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: command output changes for overlap clipping, pinned by symmetric FR-pair classification and regression tests; `unsafe`: none; memory bounds, queue capacity, and thread/backpressure policy: none.

- Fix dovetail FR-pair clipping in `RawRecordClipper::clip_overlapping_reads`.
- Use `is_primary_fr_pair_raw(r1, r2)` for symmetric pair classification.
- Add regression coverage for dovetail-forward pairs and inconsistent unmapped pairs.
- Make `is_fr_pair_raw` crate-private.
- Remove its public re-export and test-only wrapper.
- Update integration-test documentation for TLEN-independent FR detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->