### PR TITLE
fix(pipeline): bound Q3 decode admission by serial skew, not bytes

### DIFF
--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -736,6 +736,12 @@ impl<G: Send, P: Send + MemoryEstimate> BamPipelineState<G, P> {
         group_key_config: GroupKeyConfig,
     ) -> Self {
         let cap = config.queue_capacity;
+        // Q3 decode admission window: bound reorder *skew* to concurrency (a few
+        // batches per worker), capped by queue capacity. This is not a byte
+        // limit — total memory is bounded upstream by the Read admission gate —
+        // see `ReorderBufferState::can_proceed`. Restores decode parallelism
+        // lost to fgumi#787's per-serial byte backpressure.
+        let q3_decode_window = config.num_threads.saturating_mul(4).min(cap).max(1);
         let memory_limit = config.queue_memory_limit;
         let stats = if config.collect_stats {
             config.shared_stats.clone().or_else(|| Some(Arc::new(PipelineStats::new())))
@@ -785,7 +791,8 @@ impl<G: Send, P: Send + MemoryEstimate> BamPipelineState<G, P> {
             q3_decoded: ArrayQueue::new(cap),
             q3_reorder: Mutex::new(ReorderBuffer::new()),
             // Q3 reorder buffer atomic state (for lock-free admission control)
-            q3_reorder_state: ReorderBufferState::new(memory_limit),
+            q3_reorder_state: ReorderBufferState::new(memory_limit)
+                .with_window(q3_decode_window as u64),
             q3_reorder_can_pop: AtomicBool::new(false),
             // Step 5: Group
             group_done: AtomicBool::new(false),
@@ -881,8 +888,10 @@ impl<G: Send, P: Send + MemoryEstimate> BamPipelineState<G, P> {
 
     /// Check if Decode step can proceed with pushing decoded records to Q3.
     ///
-    /// This implements memory-based backpressure on the Q3 reorder buffer to prevent
-    /// unbounded memory growth when Group (exclusive step) falls behind.
+    /// Bounds the Q3 reorder buffer by *serial skew* -- how far ahead of the
+    /// serial Group needs (`next_seq`) decode may run -- rather than by a byte
+    /// threshold. Total in-flight memory is bounded upstream by the Read
+    /// admission gate; see [`super::base::ReorderBufferState::can_proceed`].
     ///
     /// # Deadlock Prevention
     ///
@@ -949,13 +958,17 @@ impl<G: Send, P: Send + MemoryEstimate> BamPipelineState<G, P> {
     ///
     /// The Q3 reorder buffer's own [`ReorderBufferState::can_proceed`] always
     /// admits the serial Group needs next (the gap-filler), even when memory is
-    /// high, and backpressures only *future* serials once the buffer is half
-    /// full. Returns:
+    /// high, and backpressures only *future* serials that fall outside the
+    /// serial-skew window. Returns:
     ///
     /// - `Some((serial, batch))` — decode it now: either it is the gap-filler,
     ///   or it is a future batch whose requeue lost the race to a full Q2b (a
     ///   rare, bounded overshoot — never a lost or reordered-into-loss batch,
-    ///   since Q3 reassembles by serial).
+    ///   since Q3 reassembles by serial). Decoding it here skips the per-serial
+    ///   Q3 memory backstop, but only as defense-in-depth: the Read admission
+    ///   gate enforces the same `queue_memory_limit` on `queue_bytes_in_flight`,
+    ///   a sum that already includes the Q3 and Q2b heap, so the overshoot
+    ///   cannot push total in-flight memory past the global bound.
     /// - `None` — the batch was requeued to Q2b so another worker can still
     ///   reach the gap-filler, avoiding the "all workers hold a non-`next_seq`
     ///   batch and nobody can produce `next_seq`" deadlock.
@@ -5198,10 +5211,19 @@ mod tests {
 
     #[test]
     fn test_can_decode_proceed_no_limit() {
-        let state = create_test_state(0); // No limit (uses default 512MB threshold)
-        // Under default threshold, should proceed
+        // With no memory limit, Q3 admission is governed purely by the
+        // serial-skew window (W = min(4 * num_threads, queue_capacity) = 8 for
+        // this 2-thread test config); memory is bounded upstream by the Read
+        // admission gate.
+        let state = create_test_state(0);
+        // next_seq (0) always proceeds.
         assert!(state.can_decode_proceed(0));
-        assert!(state.can_decode_proceed(100));
+        // Serials within [next_seq, next_seq + W) proceed.
+        assert!(state.can_decode_proceed(7));
+        // Serials at/beyond the window are held back (bounded skew), even with
+        // no memory limit.
+        assert!(!state.can_decode_proceed(8));
+        assert!(!state.can_decode_proceed(100));
     }
 
     #[test]
@@ -5215,12 +5237,14 @@ mod tests {
     #[test]
     fn test_can_decode_proceed_over_limit_but_needed_serial() {
         let state = create_test_state(1024 * 1024); // 1MB limit
-        // Over 50% of limit
-        state.q3_reorder_state.heap_bytes.store(600_000, Ordering::SeqCst);
+        // Heap at the raw memory backstop, next_seq = 5.
+        state.q3_reorder_state.heap_bytes.store(1024 * 1024, Ordering::SeqCst);
         state.q3_reorder_state.next_seq.store(5, Ordering::SeqCst);
-        // Should still proceed for the needed serial (deadlock prevention)
+        // The needed serial (next_seq) always proceeds, even over memory
+        // (deadlock prevention).
         assert!(state.can_decode_proceed(5));
-        // But not for other serials
+        // A future serial within the window is still held back by the
+        // giant-batch memory backstop once heap reaches the limit.
         assert!(!state.can_decode_proceed(6));
     }
 

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -877,6 +877,10 @@ pub struct ReorderBufferState {
     pub heap_bytes: AtomicU64,
     /// Memory limit for backpressure. 0 means use default threshold.
     memory_limit: u64,
+    /// Serial-skew admission window (Q3 decode). `0` = legacy byte-threshold
+    /// backpressure; `> 0` bounds how many serials ahead of `next_seq` the
+    /// reorder buffer may run, decoupling decode parallelism from bytes.
+    window: u64,
 }
 
 impl ReorderBufferState {
@@ -886,29 +890,63 @@ impl ReorderBufferState {
     /// * `memory_limit` - Memory limit in bytes. Use 0 for default threshold.
     #[must_use]
     pub fn new(memory_limit: u64) -> Self {
-        Self { next_seq: AtomicU64::new(0), heap_bytes: AtomicU64::new(0), memory_limit }
+        Self { next_seq: AtomicU64::new(0), heap_bytes: AtomicU64::new(0), memory_limit, window: 0 }
+    }
+
+    /// Enable windowed admission with the given serial-skew window.
+    ///
+    /// Used by the Q3 decode reorder buffer: future serials are admitted while
+    /// within `[next_seq, next_seq + window)`, rather than while under a byte
+    /// threshold. Total in-flight memory is bounded upstream by the Read
+    /// admission gate, so decode parallelism no longer collapses under a
+    /// capped per-stage byte limit (fgumi#787 follow-up).
+    #[must_use]
+    pub fn with_window(mut self, window: u64) -> Self {
+        self.window = window;
+        self
     }
 
     /// Check if a producer can proceed with the given serial number.
     ///
     /// Always allows the serial that the consumer needs (`next_seq`) to proceed,
     /// even if over memory limit. This ensures the consumer can always make progress.
-    /// For other serials, applies backpressure if over 50% of the limit.
+    ///
+    /// For other serials, admission depends on the mode: with a window set (Q3
+    /// decode), the serial must be within `[next_seq, next_seq + window)` and
+    /// under a raw-memory backstop (total memory is bounded upstream by the Read
+    /// admission gate); otherwise (legacy Q2 / write) it is admitted while heap
+    /// is under 50% of the effective limit.
     #[must_use]
     pub fn can_proceed(&self, serial: u64) -> bool {
-        let limit = self.effective_limit();
         let next_seq = self.next_seq.load(Ordering::Acquire);
-        let heap_bytes = self.heap_bytes.load(Ordering::Acquire);
 
-        // Always accept the serial the reorder buffer needs to make progress.
-        // This fills gaps and allows the consumer to pop items, reducing memory.
+        // Always admit the gap-filler (the serial the consumer needs), even
+        // over memory. Preserves deadlock-freedom (fgumi#746).
         if serial == next_seq {
             return true;
         }
 
-        // Apply backpressure if over 50% of limit.
-        let effective_limit = limit / 2;
-        heap_bytes < effective_limit
+        if self.window > 0 {
+            // Windowed admission (Q3 decode): bound reorder *skew* to
+            // concurrency, not bytes. A future serial is admitted while it is
+            // within `[next_seq, next_seq + window)`. Total in-flight memory is
+            // already bounded upstream by the Read admission gate, so the heap
+            // check here is only a backstop against a single pathologically
+            // large batch (compared against the raw limit, uncapped). This
+            // replaces the per-serial byte threshold that collapsed decode
+            // parallelism (fgumi#787 gated future serials at `heap < limit/2`
+            // with `limit` capped at 512 MiB, serializing decode once the Q3
+            // buffer held ~256 MiB regardless of `--max-memory` or threads).
+            let heap_bytes = self.heap_bytes.load(Ordering::Acquire);
+            return serial < next_seq.wrapping_add(self.window)
+                && (self.memory_limit == 0 || heap_bytes < self.memory_limit);
+        }
+
+        // Legacy byte-threshold backpressure (Q2 / write / others): apply
+        // backpressure once heap is over 50% of the effective limit.
+        let limit = self.effective_limit();
+        let heap_bytes = self.heap_bytes.load(Ordering::Acquire);
+        heap_bytes < limit / 2
     }
 
     /// Check if memory is at the backpressure threshold.
@@ -5811,6 +5849,35 @@ mod tests {
         assert!(!state.can_proceed(1));
         // Serial 0 is next_seq, should still proceed
         assert!(state.can_proceed(0));
+    }
+
+    #[test]
+    fn test_reorder_buffer_state_windowed_admission() {
+        // Regression guard for the Q3 decode serialization fix (fgumi#787
+        // follow-up). With a window set, admission bounds reorder *skew*
+        // (serials ahead of next_seq), not bytes. Heap is driven above the
+        // legacy 50% byte gate to prove the window path — not the byte
+        // threshold — governs future-serial admission.
+        let window = 8u64;
+        let state = ReorderBufferState::new(1000).with_window(window);
+        state.add_heap_bytes(600); // over legacy gate (500), under memory_limit (1000)
+
+        // next_seq (0) is always admitted, even over memory.
+        assert!(state.can_proceed(0));
+        // Future serials within [next_seq, next_seq + window) are admitted
+        // despite heap being over the legacy byte gate that serialized decode.
+        assert!(state.can_proceed(1));
+        assert!(state.can_proceed(window - 1));
+        // Serials at/beyond the window boundary are rejected: skew stays bounded.
+        assert!(!state.can_proceed(window));
+        assert!(!state.can_proceed(window + 4));
+
+        // Giant-batch backstop: at/over memory_limit even an in-window future
+        // serial is rejected, while next_seq still proceeds.
+        let tight = ReorderBufferState::new(1000).with_window(window);
+        tight.add_heap_bytes(1000); // == memory_limit
+        assert!(tight.can_proceed(0));
+        assert!(!tight.can_proceed(1));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The multi-threaded BAM pipeline serializes decode under load: at 16 threads the decode stage runs at ~3.6× effective parallelism instead of ~15×, making every consensus/group/filter/sort operation 1.7× (t8) to 3.3× average / 8.5× worst (t16) slower than v0.6.0. This restores full decode parallelism by bounding the Q3 reorder buffer's admission by *serial skew* (how far ahead of `next_seq` it may run) rather than by a capped byte threshold.

## Root cause

`#787` (`c900eb0`, "admit the gap-filler serial to Decode under memory-high", fixing the `#746` deadlock) replaced the Decode step's blanket `is_memory_high()` guard with a per-serial `can_proceed` check. That check admits a *future* serial only while `heap_bytes < effective_limit / 2`, where `effective_limit = min(--max-memory, 512 MiB)`.

The consequence: the Q3 decoded-record reorder buffer stops admitting anything but the exact `next_seq` once it holds ~256 MiB — a ceiling **capped at a constant that scales with neither `--max-memory` nor thread count**. Decoded records are heavy, so with N decode workers the buffer crosses 256 MiB almost immediately; thereafter only `next_seq` is admitted (serial), and rejected future serials churn back through Q2b. Decode parallelism collapses.

This was found by `git bisect` (clean flip, GOOD ≈13–14× / BAD ≈3.1–3.5× decode parallelism) against a deterministic `simulate grouped-reads` → `simplex --threads 16` reproducer, confirmed on both AWS Graviton (c7g.4xlarge) and a 28-core arm64 host, with host memory-contention probes in the normal DRAM-latency band (i.e. the slowdown is code, not host noise).

## Fix

Bound Q3 decode admission by **serial skew**, which is what the reorder buffer's own docstring already prescribes ("reorder capacity is bounded by serial skew, not by bytes … the number of batches in flight"):

- `serial == next_seq` → admit unconditionally (unchanged — the `#746` deadlock-freedom core).
- otherwise → admit iff `serial < next_seq + W` **and** `heap_bytes < memory_limit` (raw, uncapped — a backstop against a single pathologically large batch only).
- `W = clamp(4 · num_threads, .., queue_capacity)`, resolved at construction from config-time knowns.

Total in-flight memory remains bounded upstream by the Read admission gate, so decode no longer needs a per-stage byte throttle that doubled as a parallelism cap. The change is scoped to the Q3 decode buffer via a new `window` field (`0` = the existing byte-threshold behavior), so Q2 / write / other reorder buffers are unchanged.

No worker is ever parked and rejects still return to Q2b, so deadlock-freedom is preserved structurally: `next_seq` is always admissible, and any worker stays free to run Group/Write, which drains Q3 and advances `next_seq`.

## Validation

Against the deterministic reproducer (2M molecules, `simplex --threads 16`):

| build | t16 wall | decode parallelism |
| --- | --- | --- |
| v0.6.0 | 2.5s | 15.2× |
| main (regressed) | 10.4s | 3.6× |
| this PR | 2.45s | 15.5× |

- Output is **record-identical** to v0.6.0 (`compare bams --command simplex`: 4,000,000 = 4,000,000 records, 0 content diffs) — the window changes admission *timing*, not the serial-reassembled order.
- The `#746` backpressure integration suite passes (10/10), and a tight `--max-memory 64M` run at t16 completes without wedging or OOM while staying parallel.
- New regression unit test `test_reorder_buffer_state_windowed_admission` pins the windowed admission contract (gap-filler always admitted; future serials admitted within the window even above the legacy byte gate; rejected at the window boundary; giant-batch backstop honored).

Fixes the decode-parallelism regression introduced in #787; complements #746.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: output changes: none; `unsafe` changes: none, and the `CLAUDE.md` allowlist is unchanged; memory and backpressure policy changes: Q3 admission now uses a serial-skew window with a raw memory backstop.

Fix: bound Q3 future-serial admission by `clamp(4 * num_threads, ..., queue_capacity)` while always admitting `next_seq`.

- Add optional `ReorderBufferState::window` admission.
- Preserve legacy byte-threshold behavior for reorder buffers without a window.
- Keep memory protection for future serials.
- Add regression tests for window limits, next-sequence admission, and memory backpressure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->