### PR TITLE
feat(codec): add --legacy-overlap-window for fgbio-parity output

### DIFF
--- a/crates/fgumi-consensus/src/caller.rs
+++ b/crates/fgumi-consensus/src/caller.rs
@@ -441,6 +441,12 @@ pub enum RejectionReason {
     /// quality or alignment failure). Counted so `raw_reads_used` excludes it and routed to
     /// the `--rejects` output (fgumi#724).
     Downsampled,
+    /// The two strands' alignments dovetail (each runs past the far end of the other), so the
+    /// legacy `[neg.start, pos.end]` overlap window rejects them with no indel present. Only
+    /// produced by the codec caller under `--legacy-overlap-window`; the corrected default
+    /// window admits these pairs. Replaces the misleading `IndelErrorBetweenStrands` label
+    /// fgbio uses for the same pairs (fgumi#761, fulcrumgenomics/fgbio#1173).
+    Dovetail,
     /// Other unspecified reason
     Other,
 }
@@ -470,6 +476,7 @@ impl RejectionReason {
             Self::PotentialCollision => 'C',
             Self::NotPrimaryFrPair => 'R',
             Self::Downsampled => 'd',
+            Self::Dovetail => 'w',
             Self::Other => 'O',
         }
     }
@@ -500,6 +507,7 @@ impl RejectionReason {
             }
             Self::NotPrimaryFrPair => "Template did not have a single primary FR pair of reads",
             Self::Downsampled => "Downsampled to the maximum reads per consensus",
+            Self::Dovetail => "Alignments dovetail (rejected only under the legacy overlap window)",
             Self::Other => "Other reason",
         }
     }
@@ -540,6 +548,10 @@ impl RejectionReason {
             // fgumi-specific: fgbio has no downsampled rejection metric yet
             // (fulcrumgenomics/fgbio#1166, #1167), so this diverges from fgbio under a cap.
             Self::Downsampled => CentralReason::Downsampled,
+            // fgumi-specific: only produced under `--legacy-overlap-window`. fgbio buckets
+            // these dovetail rejections under `indel_error_between_strands`; fgumi labels them
+            // honestly instead, so the legacy-window stats diverge from fgbio here (fgumi#761).
+            Self::Dovetail => CentralReason::Dovetail,
         }
     }
 }

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -166,6 +166,17 @@ pub struct CodecConsensusOptions {
     /// Minimum duplex overlap length (in bases)
     pub min_duplex_length: usize,
 
+    /// Use fgbio's legacy `[negative.start, positive.end]` duplex overlap window instead of the
+    /// corrected intersection `[max(starts), min(ends)]` (fgumi#761).
+    ///
+    /// The legacy window equals the intersection only when one alignment nests within the span
+    /// of the other. On CODEC's short inserts the two strands routinely *dovetail* (each aligns
+    /// past the far end of the other), and the legacy window then overshoots past one read and
+    /// rejects the pair as [`CallerRejectionReason::Dovetail`] even with no indel. `false` (the
+    /// default) admits those pairs; `true` reproduces fgbio's consensus output for the current
+    /// fgbio release (fulcrumgenomics/fgbio#1173).
+    pub legacy_overlap_window: bool,
+
     /// Reduce quality of single-strand regions to this value (if set)
     pub single_strand_qual: Option<PhredScore>,
 
@@ -208,6 +219,7 @@ impl Default for CodecConsensusOptions {
             min_reads_per_strand: 1,
             max_reads_per_strand: None,
             min_duplex_length: 1,
+            legacy_overlap_window: false,
             single_strand_qual: None,
             outer_bases_qual: None,
             outer_bases_length: 5,
@@ -844,11 +856,20 @@ impl CodecConsensusCaller {
         // (fulcrumgenomics/fgumi#761). Clamping to the intersection is inert whenever the
         // alignments do not dovetail, since `max`/`min` then select the same two boundaries.
         //
+        // `--legacy-overlap-window` opts back into fgbio's `[negative.start, positive.end]`
+        // window to reproduce fgbio's consensus output for its current release; it differs from
+        // the intersection only on dovetailed pairs, which it rejects rather than consenses.
+        //
         // An empty intersection is not a special case: it can only arise when the two
         // alignments do not overlap, where these are still the same two boundaries fgbio
         // computes, and `min_duplex_length` (at least 1, enforced by the command) rejects it
         // just below.
-        let (overlap_start, overlap_end) = (neg_start.max(pos_start), pos_end.min(neg_end));
+        let (inter_start, inter_end) = (neg_start.max(pos_start), pos_end.min(neg_end));
+        let (overlap_start, overlap_end) = if self.options.legacy_overlap_window {
+            (neg_start, pos_end)
+        } else {
+            (inter_start, inter_end)
+        };
         let duplex_length = overlap_end as i64 - overlap_start as i64 + 1;
 
         if duplex_length < self.options.min_duplex_length as i64 {
@@ -859,27 +880,36 @@ impl CodecConsensusCaller {
             return Ok(ConsensusOutput::default());
         }
 
-        // Phase check using raw CIGAR ops
-        if !Self::check_overlap_phase_raw(longest_r1, longest_r2, overlap_start, overlap_end) {
-            self.reject_records_at(
-                Self::strand_raw_indices(&r1_infos, &r2_infos),
-                CallerRejectionReason::IndelErrorBetweenStrands,
-            );
-            return Ok(ConsensusOutput::default());
-        }
-
-        let r2_is_negative = longest_r2.flags & flags::REVERSE != 0;
-
-        // Compute consensus length using clipped info
-        let consensus_length =
-            Self::compute_consensus_length_raw(longest_pos, longest_neg, overlap_end);
+        // Phase and consensus-length checks on the active window (raw CIGAR ops). A pair that
+        // fails either is rejected; classify why. Under `--legacy-overlap-window`, a pair the
+        // corrected (intersection) window would have accepted is rejected solely because it
+        // dovetails, so label it `Dovetail` rather than the misleading `IndelErrorBetweenStrands`
+        // (which fgbio uses for these). In the default mode the active window *is* the
+        // intersection, so the `legacy_overlap_window &&` guard short-circuits and the reason is
+        // unchanged.
+        let phase_ok =
+            Self::check_overlap_phase_raw(longest_r1, longest_r2, overlap_start, overlap_end);
+        let consensus_length = if phase_ok {
+            Self::compute_consensus_length_raw(longest_pos, longest_neg, overlap_end)
+        } else {
+            None
+        };
         let Some(consensus_length) = consensus_length else {
-            self.reject_records_at(
-                Self::strand_raw_indices(&r1_infos, &r2_infos),
-                CallerRejectionReason::IndelErrorBetweenStrands,
-            );
+            let reason = if self.options.legacy_overlap_window
+                && (inter_end as i64 - inter_start as i64 + 1)
+                    >= self.options.min_duplex_length as i64
+                && Self::check_overlap_phase_raw(longest_r1, longest_r2, inter_start, inter_end)
+                && Self::compute_consensus_length_raw(longest_pos, longest_neg, inter_end).is_some()
+            {
+                CallerRejectionReason::Dovetail
+            } else {
+                CallerRejectionReason::IndelErrorBetweenStrands
+            };
+            self.reject_records_at(Self::strand_raw_indices(&r1_infos, &r2_infos), reason);
             return Ok(ConsensusOutput::default());
         };
+
+        let r2_is_negative = longest_r2.flags & flags::REVERSE != 0;
 
         // Phase 5: Build SourceReads and call single-strand consensus
         let r1_is_neg_strand = r1_infos.first().is_some_and(|i| i.flags & flags::REVERSE != 0);
@@ -4059,6 +4089,22 @@ mod tests {
         (caller, output)
     }
 
+    /// As [`call_codec_family`], but with `--legacy-overlap-window` (fgbio-parity window) on.
+    fn call_codec_family_legacy_window(
+        records: Vec<RawRecord>,
+    ) -> (CodecConsensusCaller, ConsensusOutput) {
+        let options = CodecConsensusOptions {
+            min_reads_per_strand: 1,
+            legacy_overlap_window: true,
+            ..Default::default()
+        };
+        let mut caller = CodecConsensusCaller::new("codec".to_string(), "RG1".to_string(), options);
+        let output = caller
+            .consensus_reads_from_sam_records(records)
+            .expect("a rejected family is not an error");
+        (caller, output)
+    }
+
     /// The dovetailed geometry of
     /// [`test_dovetailed_starts_without_an_indel_call_a_consensus`]: forward `2S126M` at 201
     /// (reference span 201-326) against reverse `3S127M` at 200 (200-326).
@@ -4107,6 +4153,70 @@ mod tests {
             b"ANTAACTTTTTGATAGTAGCGGGAGTAGGAGTAAATCTTGTACTAATTAGTGAATATTCTGTTGATGGTGGCTGAAAATTTATAGCTACACAACCAAAAAAATAAAAAACGTTAGTCAATAGCATTTA",
             "the consensus must be the reference sequence the two strands share",
         );
+    }
+
+    /// `--legacy-overlap-window` reproduces fgbio's rejection of a dovetailed pair, but labels
+    /// it honestly as [`CallerRejectionReason::Dovetail`] rather than `IndelErrorBetweenStrands`.
+    ///
+    /// [`dovetailed_start_template`] contains no indel, so the corrected default window
+    /// consenses it ([`test_dovetailed_starts_without_an_indel_call_a_consensus`]). Under the
+    /// legacy window the same family is rejected — but because it dovetails, not because of an
+    /// indel — so its reason must be `Dovetail`, and nothing may land under
+    /// `IndelErrorBetweenStrands`.
+    #[test]
+    fn test_legacy_overlap_window_labels_dovetail_rejection() {
+        let records = dovetailed_start_template();
+        let record_count = records.len();
+        let (caller, output) = call_codec_family_legacy_window(records);
+
+        let stats = caller.statistics();
+        assert_eq!(output.count, 0, "the legacy window rejects a dovetailed pair");
+        assert_eq!(
+            stats.rejection_reasons.get(&CallerRejectionReason::Dovetail),
+            Some(&record_count),
+            "a dovetail with no indel must be counted as Dovetail: {:?}",
+            stats.rejection_reasons
+        );
+        assert!(
+            !stats.rejection_reasons.contains_key(&CallerRejectionReason::IndelErrorBetweenStrands),
+            "no indel is present, so nothing may be counted under IndelErrorBetweenStrands: {:?}",
+            stats.rejection_reasons
+        );
+        assert_rejected_whole_family(&caller, &output, record_count);
+    }
+
+    /// `Dovetail` is reserved for pairs the corrected window would have accepted. A pair that
+    /// *both* dovetails and carries a real indel in the region both strands cover fails the
+    /// intersection check too, so under `--legacy-overlap-window` it stays
+    /// `IndelErrorBetweenStrands` — the same reason the default window gives it — not `Dovetail`.
+    ///
+    /// Reuses [`test_indel_inside_the_shared_region_is_still_rejected`]'s geometry: the reverse
+    /// read starts one base left of the forward read (a dovetail), and the forward read carries a
+    /// deletion in the middle of the shared region.
+    #[test]
+    fn test_legacy_overlap_window_keeps_indel_rejection_over_dovetail() {
+        let records = codec_template(
+            201,
+            &[(Kind::SoftClip, 2), (Kind::Match, 60), (Kind::Deletion, 1), (Kind::Match, 67)],
+            200,
+            &[(Kind::SoftClip, 3), (Kind::Match, 124), (Kind::SoftClip, 2)],
+        );
+        let record_count = records.len();
+        let (caller, output) = call_codec_family_legacy_window(records);
+
+        let stats = caller.statistics();
+        assert_eq!(
+            stats.rejection_reasons.get(&CallerRejectionReason::IndelErrorBetweenStrands),
+            Some(&record_count),
+            "a real indel in the shared region is an indel error, not a dovetail: {:?}",
+            stats.rejection_reasons
+        );
+        assert!(
+            !stats.rejection_reasons.contains_key(&CallerRejectionReason::Dovetail),
+            "a genuine indel must not be relabeled Dovetail under the legacy window: {:?}",
+            stats.rejection_reasons
+        );
+        assert_rejected_whole_family(&caller, &output, record_count);
     }
 
     /// The duplex overlap is measured over the region both strands align, so a threshold

--- a/crates/fgumi-metrics/src/consensus.rs
+++ b/crates/fgumi-metrics/src/consensus.rs
@@ -151,6 +151,11 @@ pub struct ConsensusMetrics {
     /// #1167), so this row is emitted only when non-zero (fgumi#724).
     pub rejected_downsampled: u64,
 
+    /// Reads rejected because their alignments dovetail, under the legacy overlap window
+    /// (`--legacy-overlap-window`). fgumi-specific: the corrected default window admits
+    /// these, so this row is emitted only when non-zero (fgumi#761).
+    pub rejected_dovetail: u64,
+
     /// Consensus reads rejected for high duplex disagreement (fgbio
     /// `consensusReadsFilteredHighDisagreement`, emitted as
     /// `consensus_reads_rejected_hdd`; codec)
@@ -234,7 +239,7 @@ impl ConsensusCallerKind {
 /// fgumi's taxonomy is finer-grained than fgbio's; the reasons not in any caller's
 /// seeded set (e.g. `LowBaseQuality`) are fgumi-specific and are emitted only when
 /// non-zero.
-const ALL_REJECTIONS: [RejectionReason; 25] = [
+const ALL_REJECTIONS: [RejectionReason; 26] = [
     RejectionReason::InsufficientSupport,
     RejectionReason::MinorityAlignment,
     RejectionReason::OrphanConsensus,
@@ -260,6 +265,7 @@ const ALL_REJECTIONS: [RejectionReason; 25] = [
     RejectionReason::ExcessiveErrorRate,
     RejectionReason::UmiTooShort,
     RejectionReason::Downsampled,
+    RejectionReason::Dovetail,
 ];
 
 /// Returns an iterator over all rejection reasons fgumi tracks.
@@ -307,6 +313,7 @@ impl ConsensusMetrics {
             rejected_high_duplex_disagreement: 0,
             rejected_clip_overlap_failed: 0,
             rejected_downsampled: 0,
+            rejected_dovetail: 0,
             consensus_reads_rejected_hdd: 0,
             consensus_bases_emitted: 0,
             consensus_duplex_bases_emitted: 0,
@@ -354,6 +361,7 @@ impl ConsensusMetrics {
             RejectionReason::HighDuplexDisagreement => self.rejected_high_duplex_disagreement,
             RejectionReason::ClipOverlapFailed => self.rejected_clip_overlap_failed,
             RejectionReason::Downsampled => self.rejected_downsampled,
+            RejectionReason::Dovetail => self.rejected_dovetail,
         }
     }
 
@@ -395,6 +403,7 @@ impl ConsensusMetrics {
             }
             RejectionReason::ClipOverlapFailed => self.rejected_clip_overlap_failed += count,
             RejectionReason::Downsampled => self.rejected_downsampled += count,
+            RejectionReason::Dovetail => self.rejected_dovetail += count,
         }
     }
 

--- a/crates/fgumi-metrics/src/rejection.rs
+++ b/crates/fgumi-metrics/src/rejection.rs
@@ -71,6 +71,14 @@ pub enum RejectionReason {
     /// (fulcrumgenomics/fgbio#1166, #1167), so this is fgumi-specific and diverges from
     /// fgbio's stats under a cap (fgumi#724).
     Downsampled,
+    /// The two strands' alignments dovetail — each runs past the far end of the other rather
+    /// than one nesting within the span of the other — and the legacy `[neg.start, pos.end]`
+    /// overlap window (fgbio parity, `--legacy-overlap-window`) therefore rejects them even
+    /// though neither CIGAR contains an indel. fgumi-specific: the corrected default window
+    /// admits these pairs, so this reason is only produced under `--legacy-overlap-window`,
+    /// where it is reported in place of the `indel_error_between_strands` bucket fgbio
+    /// mislabels them under (fulcrumgenomics/fgbio#1173, fgumi#761).
+    Dovetail,
 }
 
 impl RejectionReason {
@@ -105,6 +113,7 @@ impl RejectionReason {
             Self::HighDuplexDisagreement => "Too many errors between top/bottoms strands",
             Self::ClipOverlapFailed => "See https://github.com/fulcrumgenomics/fgbio/issues/1090",
             Self::Downsampled => "Reads discarded by consensus downsampling",
+            Self::Dovetail => "Alignments dovetail (rejected only under the legacy overlap window)",
         }
     }
 
@@ -137,6 +146,7 @@ impl RejectionReason {
             Self::HighDuplexDisagreement => "raw_reads_rejected_for_high_duplex_disagreement",
             Self::ClipOverlapFailed => "raw_reads_rejected_for_clip_overlap_failed",
             Self::Downsampled => "raw_reads_rejected_for_downsampled",
+            Self::Dovetail => "raw_reads_rejected_for_dovetail",
         }
     }
 
@@ -170,6 +180,7 @@ impl RejectionReason {
             Self::HighDuplexDisagreement => "Too many errors between top/bottoms strands",
             Self::ClipOverlapFailed => "See https://github.com/fulcrumgenomics/fgbio/issues/1090",
             Self::Downsampled => "Reads discarded by downsampling to the max reads per consensus",
+            Self::Dovetail => "Alignments dovetail; rejected under the legacy overlap window",
         }
     }
 }

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -200,6 +200,10 @@ Duplex agreement filters
   --max-duplex-disagreement-rate  maximum fraction of overlapping positions where the strands may
                                disagree (default 1.0, i.e. no limit)
   --max-duplex-disagreements   maximum absolute count of such disagreements
+  --legacy-overlap-window      use fgbio's legacy `[neg.start, pos.end]` overlap window, which
+                               rejects dovetailed short-insert pairs as dovetails and matches
+                               fgbio's current-release consensus output (off by default; the
+                               corrected intersection window admits those pairs)
 
 Note that `--methylation-mode` is not supported for CODEC data.
 "#
@@ -256,6 +260,18 @@ pub struct Codec {
     /// Minimum duplex overlap length in bases
     #[arg(short = 'd', long = "min-duplex-length", default_value = "1")]
     pub min_duplex_length: usize,
+
+    /// Use fgbio's legacy `[negative.start, positive.end]` duplex overlap window instead of the
+    /// corrected intersection window (fgumi#761).
+    ///
+    /// Reproduces fgbio's CODEC consensus *output* for the current fgbio release: dovetailed FR
+    /// pairs — common on short inserts, where each strand's alignment runs past the far end of
+    /// the other — are rejected rather than consensed, so far fewer consensus reads are emitted.
+    /// Those rejections are reported under `raw_reads_rejected_for_dovetail`, whereas fgbio
+    /// buckets them under `indel_error_between_strands`, so the `--stats` breakdown is not
+    /// byte-identical to fgbio's. Off by default (fulcrumgenomics/fgbio#1173).
+    #[arg(long = "legacy-overlap-window")]
+    pub legacy_overlap_window: bool,
 
     /// Set single-strand region quality to this value (0-93). Assigned
     /// unconditionally, so a lower quality is raised to it.
@@ -444,6 +460,7 @@ impl Command for Codec {
             min_reads_per_strand: self.min_reads,
             max_reads_per_strand: self.max_reads,
             min_duplex_length: self.min_duplex_length,
+            legacy_overlap_window: self.legacy_overlap_window,
             single_strand_qual: self.single_strand_qual,
             outer_bases_qual: self.outer_bases_qual,
             outer_bases_length: self.outer_bases_length,
@@ -677,6 +694,7 @@ impl Codec {
             min_reads_per_strand: self.min_reads,
             max_reads_per_strand: self.max_reads,
             min_duplex_length: self.min_duplex_length,
+            legacy_overlap_window: self.legacy_overlap_window,
             single_strand_qual: self.single_strand_qual,
             outer_bases_qual: self.outer_bases_qual,
             outer_bases_length: self.outer_bases_length,
@@ -898,6 +916,7 @@ mod tests {
             min_reads: 1,
             max_reads: None,
             min_duplex_length: 1,
+            legacy_overlap_window: false,
             single_strand_qual: None,
             outer_bases_qual: None,
             outer_bases_length: 5,


### PR DESCRIPTION
## Summary

The corrected duplex overlap window (#761) admits dovetailed FR pairs that fgbio's `[negative.start, positive.end]` window rejects. On short-insert CODEC data — where the two strands routinely dovetail (each aligns a base to tens of bp past the far end of the other, from asymmetric terminal soft-clipping) — this recovers ~2.4× more consensus reads (108K → 263K on a real CODEC library). Those recovered pairs are legitimate short-insert molecules, not artifacts: their overhangs are all bounded by read length (median 26 bp, none > read length, so no mismapped/chimeric admission), they still pass the indel/phase check over the corrected window, and their realigned substitution error is ~1.9% vs reference — *below* the baseline consensus reads' ~3.3% (three methods agree, incl. fgbio's own `ErrorRateByReadPosition`).

This adds `--legacy-overlap-window` (off by default) so a run can reproduce fgbio's current-release CODEC consensus **output**, where those dovetailed pairs are rejected. fgbio's own fix for the same defect is in flight as fulcrumgenomics/fgbio#1174 (fixes fulcrumgenomics/fgbio#1173); until it lands and a new fgbio release ships, this flag is the escape hatch for anyone needing byte-for-byte fgbio parity.

## Honest stats labeling

Under `--legacy-overlap-window`, the rejected dovetails are reported with a new `Dovetail` rejection reason (`raw_reads_rejected_for_dovetail`) instead of the misleading `indel_error_between_strands` bucket fgbio mislabels them under (there is no indel in the CIGARs). This makes visible exactly how many pairs fgbio-parity is costing — flip the flag off to recover them.

Consequence, called out deliberately: the `--stats` breakdown under the flag is **not** byte-identical to fgbio's (fgbio buckets these under `indel_error_between_strands`), though the consensus BAM is. A pair that both dovetails **and** carries a real indel in the region both strands cover still fails the intersection check and is counted as `IndelErrorBetweenStrands`.

## Scope

- The flag gates only the reference window fed to `check_overlap_phase_raw` / `compute_consensus_length_raw`. The default path is unchanged: the `legacy_overlap_window &&` guard short-circuits, so record output and rejection reasons are byte-identical to `main` when the flag is off.
- New `Dovetail` reason threaded through the caller (`RejectionReason`) and metrics (`fgumi_metrics::rejection::RejectionReason`) enums — char code, `tsv_key` `raw_reads_rejected_for_dovetail`, emitted only when non-zero (mirroring `Downsampled`).
- Tests pin all three arms of the classifier: the default window still consenses the dovetail; the legacy window rejects the indel-free dovetail as `Dovetail` (not `IndelErrorBetweenStrands`); and a dovetail that also carries a real shared-region indel stays `IndelErrorBetweenStrands`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: consensus BAM output changes only when `--legacy-overlap-window` is enabled; corrected alignment intersection remains the default. Unsafe changes: none. Memory bounds, queue capacity, and thread/backpressure policy: none.

Add the `--legacy-overlap-window` option to reproduce legacy fgbio consensus output by rejecting dovetailed FR pairs.

- Keep the option disabled by default.
- Add `Dovetail` rejection classification with code `w`.
- Add `raw_reads_rejected_for_dovetail` metrics.
- Preserve `IndelErrorBetweenStrands` for pairs with a shared-region indel.
- Propagate the option through threaded and single-threaded CODEC paths.
- Add regression coverage for default acceptance, legacy rejection, and indel classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->