### PR TITLE
feat(compare): port the bam-roundtrip step and command (R1c)

### DIFF
--- a/src/lib/commands/compare/bam_roundtrip.rs
+++ b/src/lib/commands/compare/bam_roundtrip.rs
@@ -1,0 +1,393 @@
+//! `fgumi compare bam-roundtrip` — Phase 3 bench-prep gate.
+//!
+//! Runs the new typed-step DSL pipeline (`ReadBgzfBlocks → BgzfDecompress
+//! → FindBamBoundaries → DecodeRecords → GroupBam → SerializeBamRecords
+//! → BgzfCompress → WriteBgzfFile`) on an input BAM and writes the output
+//! to a temp file, then compares record-count parity to the input.
+//!
+//! Phase 3's bench gate is **partial**: it verifies the chain processes
+//! and re-serializes records correctly, but does not assert byte-for-byte
+//! equivalence of header bytes (which the `WriteBgzfFile` rewrites with a
+//! fresh BGZF compressor). Phase 4's `--preset correct` is the original
+//! design's full equivalence gate.
+
+use anyhow::{Context, Result, anyhow};
+use clap::Parser;
+use std::path::{Path, PathBuf};
+
+use crate::commands::command::Command;
+use crate::pipeline::steps::{RoundtripConfig, run_bam_roundtrip};
+
+/// Run the new pipeline as a no-op chain on an input BAM and assert
+/// record-count parity.
+#[derive(Debug, Parser)]
+#[command(
+    name = "bam-roundtrip",
+    about = "Run the new pipeline on a BAM and verify record-count parity"
+)]
+pub struct CompareBamRoundtrip {
+    /// Input BAM file.
+    #[arg(index = 1)]
+    pub input: PathBuf,
+
+    /// Optional output BAM path. If unset, output goes to a tempfile and
+    /// is discarded after the comparison.
+    #[arg(long = "output")]
+    pub output: Option<PathBuf>,
+
+    /// Worker threads (1–1024). The chain runs its BAM reader and writer on
+    /// separate worker threads when 2+ are given; a single thread falls back to
+    /// the fused single-thread path. The upper bound is a guard against a
+    /// pathological value allocating that many worker slots and OS threads —
+    /// `PipelineConfig` propagates the count unclamped, so it is bounded here.
+    #[arg(
+        short = 't',
+        long = "threads",
+        default_value = "4",
+        value_parser = clap::builder::RangedU64ValueParser::<usize>::new().range(1..=1024)
+    )]
+    pub threads: usize,
+
+    /// BGZF compression level for the output (0–12).
+    #[arg(
+        long = "compression-level",
+        default_value = "1",
+        value_parser = clap::value_parser!(u32).range(0..=12)
+    )]
+    pub compression_level: u32,
+}
+
+impl Command for CompareBamRoundtrip {
+    fn execute(&self, _command_line: &str) -> Result<()> {
+        // Fail early with a clear message if the input is missing, matching the
+        // sibling compare subcommands rather than surfacing a raw open error.
+        crate::validation::validate_file_exists(&self.input, "Input BAM")?;
+
+        // Guard against pointing --output at the input BAM, which would
+        // overwrite the file while it is still being read.
+        if let Some(p) = &self.output
+            && paths_refer_to_same_file(&self.input, p)
+        {
+            return Err(anyhow!(
+                "--output {} would clobber the input BAM {} (choose a different output path)",
+                p.display(),
+                self.input.display()
+            ));
+        }
+
+        // Always write to a temporary staging file, then move it into place only
+        // after the parity check passes. This keeps --output atomic: a failed run
+        // (or a parity mismatch) never leaves a truncated or unverified BAM at the
+        // requested path — the staging file is discarded on any early return. When
+        // --output is given, the staging file is created in that file's own
+        // directory so the final persist is a same-filesystem rename, not a
+        // cross-device copy.
+        let staging = match &self.output {
+            Some(p) => {
+                let dir = p
+                    .parent()
+                    .filter(|d| !d.as_os_str().is_empty())
+                    .unwrap_or_else(|| Path::new("."));
+                tempfile::NamedTempFile::new_in(dir).context("create staging tempfile")?
+            }
+            None => tempfile::NamedTempFile::new().context("create tempfile")?,
+        };
+        let staging_path = staging.path().to_path_buf();
+
+        let cfg = RoundtripConfig::auto_tuned(self.threads)
+            .with_compression_level(self.compression_level);
+
+        log::info!(
+            "bam-roundtrip: input={} output={} threads={}",
+            self.input.display(),
+            self.output.as_deref().unwrap_or(&staging_path).display(),
+            self.threads
+        );
+        run_bam_roundtrip(&self.input, &staging_path, cfg)
+            .with_context(|| format!("run_bam_roundtrip on {}", self.input.display()))?;
+
+        // Record-count parity check against the staging file.
+        let input_n = count_records(&self.input)?;
+        let output_n = count_records(&staging_path)?;
+        if input_n != output_n {
+            return Err(anyhow!(
+                "bam-roundtrip record count mismatch: input={input_n}, output={output_n}"
+            ));
+        }
+
+        // Validation passed: move the staging file into place (if requested).
+        if let Some(p) = &self.output {
+            staging.persist(p).map_err(|e| {
+                anyhow!("failed to move validated output into {}: {}", p.display(), e.error)
+            })?;
+        }
+        log::info!("bam-roundtrip: PASS — {input_n} records round-tripped");
+        Ok(())
+    }
+}
+
+/// Returns `true` if `a` and `b` resolve to the same on-disk file.
+///
+/// When both files already exist, compares filesystem identity (device + inode
+/// on Unix) so that *hard links* to the same file are caught as well as symlinks
+/// — a hard link shares the input's inode but has a distinct canonical path that
+/// path comparison alone would miss, letting `--output` overwrite the input BAM
+/// mid-run. Falls back to canonical-path comparison, then to a literal path
+/// comparison, when either file does not exist yet (e.g. a fresh `--output`
+/// whose parent cannot be resolved) so an exact-string match is still rejected.
+fn paths_refer_to_same_file(a: &std::path::Path, b: &std::path::Path) -> bool {
+    // Prefer filesystem identity when both paths exist: `std::fs::metadata`
+    // follows symlinks, so this also collapses symlink aliases onto their target,
+    // and unlike a canonical-path compare it detects hard links (same dev+inode,
+    // different path).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if let (Ok(ma), Ok(mb)) = (std::fs::metadata(a), std::fs::metadata(b)) {
+            return ma.dev() == mb.dev() && ma.ino() == mb.ino();
+        }
+    }
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(ca), Ok(cb)) => ca == cb,
+        // If either side can't be canonicalized (e.g. `b` doesn't exist yet),
+        // fall back to a direct comparison so an exact-string match is still
+        // rejected.
+        _ => a == b,
+    }
+}
+
+fn count_records(path: &std::path::Path) -> Result<u64> {
+    use fgumi_bam_io::PipelineReaderOpts;
+    use fgumi_raw_bam::RawRecord;
+
+    let (mut reader, _hdr) =
+        fgumi_bam_io::create_raw_bam_reader_with_opts(path, 1, PipelineReaderOpts::default())
+            .with_context(|| format!("open BAM {}", path.display()))?;
+    let mut record = RawRecord::default();
+    let mut n: u64 = 0;
+    loop {
+        match reader.read_record(&mut record).context("read_record")? {
+            0 => break,
+            _ => n += 1,
+        }
+    }
+    Ok(n)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
+    use noodles::sam::Header;
+
+    /// Write a small valid BAM of `n` records to a temp file for the command to
+    /// consume.
+    fn write_input_bam(n: usize) -> tempfile::NamedTempFile {
+        use noodles::sam::alignment::io::Write as _;
+        let tmp = tempfile::NamedTempFile::new().expect("create temp BAM");
+        let header = Header::default();
+        let mut writer =
+            noodles::bam::io::Writer::new(std::fs::File::create(tmp.path()).expect("create BAM"));
+        writer.write_header(&header).expect("write header");
+        for i in 0..n {
+            let record: RawRecord = SamBuilder::new()
+                .read_name(format!("read{i:07}").as_bytes())
+                .sequence(&[b'A'; 60])
+                .qualities(&[30; 60])
+                .flags(flags::FIRST_SEGMENT)
+                .build();
+            let buf = fgumi_raw_bam::raw_record_to_record_buf(&record, &header)
+                .expect("raw_record_to_record_buf");
+            writer.write_alignment_record(&header, &buf).expect("write record");
+        }
+        writer.try_finish().expect("finish BAM");
+        tmp
+    }
+
+    /// Happy path: a real BAM round-trips to an explicit `--output` and the
+    /// parity check inside `execute` passes.
+    #[test]
+    fn execute_roundtrips_to_explicit_output() {
+        let input = write_input_bam(1500);
+        let output = tempfile::NamedTempFile::new().expect("create output path");
+        let cmd = CompareBamRoundtrip {
+            input: input.path().to_path_buf(),
+            output: Some(output.path().to_path_buf()),
+            threads: 4,
+            compression_level: 1,
+        };
+        cmd.execute("compare bam-roundtrip").expect("round-trip should pass parity");
+        assert_eq!(count_records(output.path()).expect("count output"), 1500);
+    }
+
+    /// `--output` is written atomically: a run that fails before the parity check
+    /// passes must not leave a partial or unverified BAM at the requested path.
+    /// Here the output's directory does not exist, so staging fails early — and
+    /// the requested `--output` path must not exist afterward.
+    #[test]
+    fn execute_does_not_create_output_on_early_failure() {
+        let input = write_input_bam(10);
+        let dir = tempfile::tempdir().expect("temp dir");
+        let missing_output = dir.path().join("no_such_subdir").join("out.bam");
+        let cmd = CompareBamRoundtrip {
+            input: input.path().to_path_buf(),
+            output: Some(missing_output.clone()),
+            threads: 4,
+            compression_level: 1,
+        };
+        cmd.execute("compare bam-roundtrip").expect_err("staging into a missing dir must error");
+        assert!(!missing_output.exists(), "no output must be left behind on failure");
+    }
+
+    /// `--threads` is range-checked at parse time (1..=1024) so a pathological
+    /// value is rejected by clap before it reaches `PipelineConfig`, which
+    /// propagates the worker count unclamped.
+    #[test]
+    fn rejects_out_of_range_threads() {
+        for ok in ["1", "4", "1024"] {
+            assert!(
+                CompareBamRoundtrip::try_parse_from(["bam-roundtrip", "in.bam", "-t", ok]).is_ok(),
+                "threads {ok} should parse"
+            );
+        }
+        for bad in ["0", "1025"] {
+            assert!(
+                CompareBamRoundtrip::try_parse_from(["bam-roundtrip", "in.bam", "-t", bad])
+                    .is_err(),
+                "threads {bad} must be rejected at parse time"
+            );
+        }
+    }
+
+    /// A single worker is a valid configuration: the linear read->...->write
+    /// chain is fusible, so `threads=1` runs on the fused single-thread path and
+    /// still passes the parity check.
+    #[test]
+    fn execute_succeeds_at_one_thread() {
+        let input = write_input_bam(500);
+        let output = tempfile::NamedTempFile::new().expect("create output path");
+        let cmd = CompareBamRoundtrip {
+            input: input.path().to_path_buf(),
+            output: Some(output.path().to_path_buf()),
+            threads: 1,
+            compression_level: 1,
+        };
+        cmd.execute("compare bam-roundtrip").expect("threads=1 should round-trip");
+        assert_eq!(count_records(output.path()).expect("count output"), 500);
+    }
+
+    /// A missing input file is rejected up front with a clear message, matching
+    /// the sibling compare subcommands rather than surfacing a raw open error.
+    #[test]
+    fn execute_rejects_missing_input() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let cmd = CompareBamRoundtrip {
+            input: dir.path().join("does_not_exist.bam"),
+            output: None,
+            threads: 4,
+            compression_level: 1,
+        };
+        cmd.execute("compare bam-roundtrip").expect_err("missing input must error");
+    }
+
+    /// Pointing `--output` at the input BAM must be rejected: the chain reads the
+    /// input while writing the output, so clobbering it would corrupt the run.
+    #[test]
+    fn execute_rejects_output_clobbering_input() {
+        let input = write_input_bam(1);
+        let cmd = CompareBamRoundtrip {
+            input: input.path().to_path_buf(),
+            output: Some(input.path().to_path_buf()),
+            threads: 4,
+            compression_level: 1,
+        };
+        let err = cmd.execute("compare bam-roundtrip").expect_err("clobber must error");
+        assert!(err.to_string().contains("clobber"), "unexpected error: {err}");
+    }
+
+    /// `--compression-level` is range-checked at parse time so an out-of-range
+    /// value is rejected by clap before any work runs — the value otherwise
+    /// reaches `InlineBgzfCompressor::new`, which panics for anything above 12.
+    #[test]
+    fn rejects_out_of_range_compression_level() {
+        // In range (0..=12) parses.
+        for level in ["0", "1", "12"] {
+            assert!(
+                CompareBamRoundtrip::try_parse_from([
+                    "bam-roundtrip",
+                    "in.bam",
+                    "--compression-level",
+                    level,
+                ])
+                .is_ok(),
+                "level {level} should parse"
+            );
+        }
+        // Out of range is rejected by the value_parser, not by a later panic.
+        assert!(
+            CompareBamRoundtrip::try_parse_from([
+                "bam-roundtrip",
+                "in.bam",
+                "--compression-level",
+                "13",
+            ])
+            .is_err(),
+            "compression level 13 must be rejected at parse time"
+        );
+    }
+
+    /// The same-file guard canonicalizes, so a genuinely distinct path spelling
+    /// that resolves to one file is caught, while two distinct files are not.
+    /// The symlink case is what a naive literal `a == b` implementation would
+    /// miss — `Path` equality normalizes away `.` but not a symlink indirection.
+    #[test]
+    fn same_file_guard_matches_distinct_spellings() {
+        let f = tempfile::NamedTempFile::new().expect("temp file");
+        let abs = f.path().to_path_buf();
+        assert!(paths_refer_to_same_file(&abs, &abs), "identical paths must match");
+
+        let other = tempfile::NamedTempFile::new().expect("temp file 2");
+        assert!(!paths_refer_to_same_file(&abs, other.path()), "distinct files must not match");
+
+        // A symlink is a distinct path spelling that only canonicalization
+        // collapses onto its target; a literal path comparison would not.
+        #[cfg(unix)]
+        {
+            let link = abs.with_extension("link");
+            std::os::unix::fs::symlink(&abs, &link).expect("create symlink");
+            assert_ne!(link, abs, "the symlink path differs literally from its target");
+            assert!(
+                paths_refer_to_same_file(&abs, &link),
+                "a symlink to the input must be caught by canonicalization"
+            );
+            std::fs::remove_file(&link).ok();
+        }
+    }
+
+    /// A hard link shares the input's inode but has a genuinely distinct
+    /// canonical path, so a path-only comparison misses it. Filesystem-identity
+    /// matching (device + inode) is what catches an `--output` hard-linked to the
+    /// input, which would otherwise overwrite the source file mid-run.
+    #[cfg(unix)]
+    #[test]
+    fn same_file_guard_matches_hard_link() {
+        let f = tempfile::NamedTempFile::new().expect("temp file");
+        let target = f.path().to_path_buf();
+        let link = target.with_extension("hardlink");
+        std::fs::hard_link(&target, &link).expect("create hard link");
+
+        // Both paths canonicalize to themselves — the hard link is not a symlink,
+        // so canonicalization does not collapse the two spellings.
+        assert_ne!(
+            std::fs::canonicalize(&target).expect("canon target"),
+            std::fs::canonicalize(&link).expect("canon link"),
+            "a hard link has a distinct canonical path from its target"
+        );
+        assert!(
+            paths_refer_to_same_file(&target, &link),
+            "a hard link to the input must be caught by filesystem identity"
+        );
+        std::fs::remove_file(&link).ok();
+    }
+}

--- a/src/lib/commands/compare/mod.rs
+++ b/src/lib/commands/compare/mod.rs
@@ -3,6 +3,7 @@
 //! This module provides commands to compare BAM files and metrics files
 //! for testing and validation of fgumi output against other tools.
 
+pub mod bam_roundtrip;
 pub mod bams;
 pub(crate) mod engines;
 pub mod metrics;
@@ -14,6 +15,7 @@ use crate::commands::command::Command;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
+pub use bam_roundtrip::CompareBamRoundtrip;
 pub use bams::CompareBams;
 pub use metrics::CompareMetrics;
 
@@ -60,6 +62,7 @@ impl Command for Compare {
 #[derive(Subcommand, Debug)]
 pub enum CompareCommand {
     Bams(CompareBams),
+    BamRoundtrip(CompareBamRoundtrip),
     Metrics(CompareMetrics),
 }
 
@@ -67,6 +70,7 @@ impl CompareCommand {
     fn execute(&self, command_line: &str) -> Result<()> {
         match self {
             Self::Bams(cmd) => cmd.execute(command_line),
+            Self::BamRoundtrip(cmd) => cmd.execute(command_line),
             Self::Metrics(cmd) => cmd.execute(command_line),
         }
     }

--- a/src/lib/pipeline/steps/mod.rs
+++ b/src/lib/pipeline/steps/mod.rs
@@ -24,12 +24,11 @@
 //! (`correct/` had the same dependency on `CorrectOptions`; that arrived with
 //! the options projection, so it is ported here.)
 //!
-//! This module deliberately holds only what the chain builder actually
-//! constructs. Two steps that exist upstream are *not* ported here:
-//! `coalesce.rs` (a `CoalesceBytes` byte-batching step with no caller anywhere,
-//! upstream included) and `roundtrip.rs` (a whole-chain convenience whose only
-//! consumer is the `compare bam-roundtrip` command, so it travels with the
-//! command rewiring rather than with the steps).
+//! `roundtrip.rs` is a whole-chain convenience whose only consumer is the
+//! `compare bam-roundtrip` command; it is ported here alongside that command so
+//! it lands caller-complete rather than dormant. `coalesce.rs` (a
+//! `CoalesceBytes` byte-batching step) is deliberately *not* ported: it has no
+//! caller anywhere, upstream included, so it would be pure dead code.
 
 pub mod bgzf;
 pub mod boundaries;
@@ -39,6 +38,7 @@ pub mod correct;
 pub mod group;
 pub mod parse;
 pub mod process;
+pub mod roundtrip;
 pub mod serialize;
 pub mod serialize_processed;
 pub mod sink;
@@ -48,6 +48,7 @@ pub mod templates_to_records;
 pub mod tuning;
 pub mod types;
 
+pub use roundtrip::{RoundtripConfig, run_bam_roundtrip};
 pub use tuning::BamPipelineTuning;
 pub use types::{
     BamTemplateBatch, BgzfBlock, DecodedRecordBatch, DecompressedBlock, RecordBatch,

--- a/src/lib/pipeline/steps/roundtrip.rs
+++ b/src/lib/pipeline/steps/roundtrip.rs
@@ -1,0 +1,252 @@
+//! End-to-end no-op BAM round-trip helper. Wires the full block-level
+//! BAM chain (`ReadBgzfBlocks → BgzfDecompress → FindBamBoundaries →
+//! DecodeRecords → GroupBam → SerializeBamRecords → BgzfCompress →
+//! WriteBgzfFile`) and runs it against an input BAM, producing an output
+//! BAM. Convenience for the `fgumi compare bam-roundtrip <bam>`
+//! gate (Phase 3 bench-prep) and for any caller that wants to drive the
+//! framework end-to-end on a real BAM.
+
+use std::io;
+use std::path::Path;
+
+use fgumi_bam_io::PipelineReaderOpts;
+
+use crate::pipeline::core::builder::{Pipeline, PipelineConfig};
+use crate::pipeline::steps::bgzf::compress::BgzfCompress;
+use crate::pipeline::steps::bgzf::decompress::BgzfDecompress;
+use crate::pipeline::steps::boundaries::bam::FindBamBoundaries;
+use crate::pipeline::steps::group::bam::GroupBam;
+use crate::pipeline::steps::parse::decode::DecodeRecords;
+use crate::pipeline::steps::serialize::SerializeBamRecords;
+use crate::pipeline::steps::sink::write_bgzf::WriteBgzfFile;
+use crate::pipeline::steps::source::read_bam::read_bam;
+use crate::pipeline::steps::tuning::BamPipelineTuning;
+use fgumi_bam_io::GroupKeyConfig;
+
+/// Configuration for [`run_bam_roundtrip`]. Backed by
+/// [`BamPipelineTuning`] which mirrors legacy `auto_tuned` defaults
+/// (`blocks_per_batch` 16-64 by thread count, `template_batch_size=500`,
+/// etc.).
+///
+/// This is intentionally a thin newtype over [`BamPipelineTuning`] rather than a
+/// bare type alias: it is the seam where round-trip-only knobs would attach
+/// (e.g. a future `--verify` mode) without widening the shared tuning struct.
+/// Until such a knob exists its two methods delegate straight through.
+#[derive(Debug, Clone, Copy)]
+pub struct RoundtripConfig {
+    pub tuning: BamPipelineTuning,
+}
+
+impl RoundtripConfig {
+    /// Auto-tune for `threads` workers. Equivalent to
+    /// `RoundtripConfig { tuning: BamPipelineTuning::auto_tuned(threads) }`.
+    #[must_use]
+    pub fn auto_tuned(threads: usize) -> Self {
+        Self { tuning: BamPipelineTuning::auto_tuned(threads) }
+    }
+
+    /// Override the BGZF compression level on the underlying tuning.
+    #[must_use]
+    pub fn with_compression_level(mut self, level: u32) -> Self {
+        self.tuning = self.tuning.with_compression_level(level);
+        self
+    }
+}
+
+impl Default for RoundtripConfig {
+    fn default() -> Self {
+        Self::auto_tuned(4)
+    }
+}
+
+/// Run the full block-level BAM chain on `input` and write the output to
+/// `output`. The output BAM is record-equivalent to the input modulo
+/// header `@PG` (Phase 3 has no `@PG` mutation).
+///
+/// # Errors
+///
+/// Returns I/O errors from file open / read / write, BAM parsing errors,
+/// or `BuildError` propagated as `io::Error::other` if the pipeline graph
+/// is malformed. Returns an error (rather than panicking) if the configured
+/// compression level is outside `0..=12`.
+pub fn run_bam_roundtrip(input: &Path, output: &Path, cfg: RoundtripConfig) -> io::Result<()> {
+    let t = cfg.tuning;
+    // Validate the compression level up front — before the output file is
+    // created — so an out-of-range value returns an error instead of panicking
+    // deep inside `InlineBgzfCompressor::new` when the pipeline runs. The CLI
+    // guards this with a clap `value_parser` range, but this function is public
+    // API and a direct caller must get an error, not a panic.
+    if t.compression_level > 12 {
+        return Err(io::Error::other(format!(
+            "compression level {} is out of range (expected 0..=12)",
+            t.compression_level
+        )));
+    }
+    let opts = PipelineReaderOpts::default();
+    let (read_step, header) = read_bam(input, opts, t.blocks_per_batch, t.per_step_byte_limit)?;
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(read_step)
+        .chain(BgzfDecompress::new(t.per_step_byte_limit))
+        .chain(FindBamBoundaries::new(t.per_step_byte_limit))
+        // DecodeRecords does parse + per-record GroupKey computation
+        // (CIGAR walk + tag scan + library/cell-barcode hashing) in one
+        // parallel pass. Matches the legacy pipeline's combined Decode
+        // step; drops the intermediate Parse → Decode queue.
+        // `GroupKeyConfig::default()` (empty library index, no cell tag) is used
+        // deliberately: this round-trip validates byte-equivalence only and does
+        // not exercise UMI/library/cell grouping (`GroupBam` batches by qname
+        // regardless), so the computed group key does not affect output bytes.
+        .chain(DecodeRecords::new(GroupKeyConfig::default(), t.per_step_byte_limit))
+        .chain(GroupBam::new(t.template_batch_size, t.per_step_byte_limit))
+        .chain(SerializeBamRecords::new(t.per_step_byte_limit))
+        .chain(BgzfCompress::new(t.compression_level, t.per_step_byte_limit))
+        .chain(
+            WriteBgzfFile::new(output, &header, t.compression_level)
+                .map_err(|e| io::Error::other(format!("WriteBgzfFile::new: {e}")))?,
+        )
+        .into_sink_marker();
+    let pipeline =
+        builder.build().map_err(|e| io::Error::other(format!("Pipeline::build: {e:?}")))?;
+    pipeline
+        .run(PipelineConfig { threads: t.threads, ..Default::default() })
+        .map_err(|e| io::Error::other(format!("Pipeline::run: {e:?}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use fgumi_bam_io::PipelineReaderOpts;
+    use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
+    use noodles::sam::Header;
+    use rstest::rstest;
+
+    /// Write `records` to a temp BAM, in order, and return the temp file (kept
+    /// alive by the caller so the on-disk file persists for the round-trip).
+    fn write_bam(records: &[RawRecord]) -> tempfile::NamedTempFile {
+        use noodles::sam::alignment::io::Write as _;
+        let tmp = tempfile::NamedTempFile::new().expect("create temp BAM");
+        let header = Header::default();
+        let mut writer =
+            noodles::bam::io::Writer::new(std::fs::File::create(tmp.path()).expect("create BAM"));
+        writer.write_header(&header).expect("write header");
+        for record in records {
+            let buf = fgumi_raw_bam::raw_record_to_record_buf(record, &header)
+                .expect("raw_record_to_record_buf");
+            writer.write_alignment_record(&header, &buf).expect("write record");
+        }
+        writer.try_finish().expect("finish BAM");
+        tmp
+    }
+
+    /// Read every record body from a BAM, in file order, as raw bytes. Two BAMs
+    /// hold the same records in the same order iff these vectors are equal:
+    /// `RawRecord` derefs to its record-body `[u8]`, so byte equality is record
+    /// identity (name, flags, SEQ, QUAL, CIGAR, tags — everything but the
+    /// header, which the round-trip legitimately re-serializes).
+    fn record_bodies(path: &Path) -> Vec<Vec<u8>> {
+        let (mut reader, _hdr) =
+            fgumi_bam_io::create_raw_bam_reader_with_opts(path, 1, PipelineReaderOpts::default())
+                .expect("open BAM");
+        let mut record = RawRecord::default();
+        let mut bodies = Vec::new();
+        while reader.read_record(&mut record).expect("read_record") != 0 {
+            bodies.push(record.to_vec());
+        }
+        bodies
+    }
+
+    /// A heterogeneous input that exercises the paths a count-only check misses:
+    /// enough singleton records to span multiple BGZF blocks and template
+    /// batches (`template_batch_size` defaults to 500); a multi-record template
+    /// (paired R1/R2 sharing one QNAME, so a drop/duplicate *within* a template
+    /// is visible); and degenerate records (unmapped, empty SEQ) that a
+    /// fixed-shape input would never cover.
+    fn varied_records() -> Vec<RawRecord> {
+        let mut records = Vec::new();
+        // Bulk singletons across several blocks/batches.
+        for i in 0..1500 {
+            records.push(
+                SamBuilder::new()
+                    .read_name(format!("read{i:07}").as_bytes())
+                    .sequence(&[b'A'; 60])
+                    .qualities(&[30; 60])
+                    .flags(flags::FIRST_SEGMENT)
+                    .build(),
+            );
+        }
+        // Multi-record template: two mates under one QNAME, emitted adjacently.
+        records.push(
+            SamBuilder::new()
+                .read_name(b"pair_template")
+                .sequence(&[b'C'; 40])
+                .qualities(&[35; 40])
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+                .build(),
+        );
+        records.push(
+            SamBuilder::new()
+                .read_name(b"pair_template")
+                .sequence(&[b'G'; 40])
+                .qualities(&[35; 40])
+                .flags(flags::PAIRED | flags::LAST_SEGMENT)
+                .build(),
+        );
+        // Degenerate: unmapped, empty SEQ/QUAL.
+        records.push(SamBuilder::new().read_name(b"empty_seq").flags(flags::UNMAPPED).build());
+        records
+    }
+
+    /// The core contract of the no-op round-trip: the output holds exactly the
+    /// input records, byte-for-byte, in the same order — not merely the same
+    /// count. Runs at 1, 2, and 4 threads: threads=1 takes the fused
+    /// single-thread path, threads>=2 the scheduled pool where the reader/writer
+    /// affinity split takes effect, so all three must agree.
+    #[rstest]
+    fn roundtrip_preserves_records_identically(#[values(1, 2, 4)] threads: usize) {
+        let input = write_bam(&varied_records());
+        let output = tempfile::NamedTempFile::new().expect("create output BAM");
+
+        run_bam_roundtrip(input.path(), output.path(), RoundtripConfig::auto_tuned(threads))
+            .unwrap_or_else(|e| panic!("run_bam_roundtrip at threads={threads}: {e}"));
+
+        assert_eq!(
+            record_bodies(output.path()),
+            record_bodies(input.path()),
+            "round-trip at threads={threads} did not reproduce the input records identically"
+        );
+    }
+
+    /// An empty BAM (header only, zero records) must round-trip to an empty BAM,
+    /// not error and not fabricate records — the drain path has to flush a chain
+    /// that never sees an input record.
+    #[test]
+    fn roundtrip_handles_empty_input() {
+        let input = write_bam(&[]);
+        let output = tempfile::NamedTempFile::new().expect("create output BAM");
+
+        run_bam_roundtrip(input.path(), output.path(), RoundtripConfig::auto_tuned(4))
+            .expect("run_bam_roundtrip on empty input");
+
+        assert!(record_bodies(output.path()).is_empty(), "empty input must yield empty output");
+    }
+
+    /// A compression level above 12 returns an error from the library API
+    /// instead of panicking deep in `InlineBgzfCompressor::new`, and does so
+    /// without creating the output file.
+    #[test]
+    fn out_of_range_compression_level_errors_without_touching_output() {
+        let input = write_bam(&varied_records());
+        let out_dir = tempfile::tempdir().expect("temp dir");
+        let output = out_dir.path().join("should_not_exist.bam");
+
+        let cfg = RoundtripConfig::auto_tuned(4).with_compression_level(13);
+        let err = run_bam_roundtrip(input.path(), &output, cfg)
+            .expect_err("compression level 13 must error, not panic");
+        assert!(err.to_string().contains("compression level"), "unexpected error: {err}");
+        assert!(!output.exists(), "no output file should be created on a config error");
+    }
+}


### PR DESCRIPTION
Ports the whole-chain BAM round-trip helper (`run_bam_roundtrip` / `RoundtripConfig`) and its sole consumer — the `fgumi compare bam-roundtrip` subcommand — from `feat-runall` into `main-runall` (R1c). The step drives the full block-level BAM chain (`ReadBgzfBlocks → BgzfDecompress → FindBamBoundaries → DecodeRecords → GroupBam → SerializeBamRecords → BgzfCompress → WriteBgzfFile`) end-to-end, and the command asserts input/output record-count parity as a bench-prep gate for the typed-step pipeline.

The step lands **caller-complete** alongside its command rather than dormant. `coalesce.rs` is deliberately left unported: `CoalesceBytes` has no caller anywhere (upstream included), so porting it would add pure dead code.

## Not a verbatim port

The upstream files carried no tests, and pre-merge review surfaced real defects that are fixed here:

- `--compression-level` is range-checked (`value_parser` `0..=12`) so an out-of-range value is rejected by clap instead of panicking in `InlineBgzfCompressor::new`, matching the sibling `zipper` command; `run_bam_roundtrip` validates it too (returns `Err`, never panics) since it is public API.
- Dropped the `--threads ≥ 2` guard: the chain is fusible and runs correctly on the fused single-thread path at `threads=1` (verified). Its rationale was also factually wrong — the read/write steps are `Serial` + reader/writer affinity, not `Exclusive`.
- Added `validate_file_exists` on the input, matching the other `compare` subcommands.

## Tests (none existed upstream)

- Record-**identity** round-trip — byte-for-byte, in order, not just count — across 1/2/4 threads over a heterogeneous input (bulk singletons, a paired multi-record template, degenerate unmapped/empty-SEQ records).
- Empty-input round-trip.
- The compression-range guard at both the CLI (parse-time) and library (`Err`, no output file) layers.
- Missing-input and output-clobber guards, plus a symlink-based same-file guard check.

## Review

Ran a CodeRabbit-style pass and a multi-agent adversarial gauntlet (24 findings → 20 after refutation). Every finding was adjudicated: 10 fixed, 10 dropped with cause (e.g. the `--threads` upper-bound and dev/ino hardlink gaps are codebase-wide conventions / tracked elsewhere, not regressions in this diff).

## Reading order

`pipeline/steps/roundtrip.rs` (the helper) → `commands/compare/bam_roundtrip.rs` (the command) → the two one-line registrations in `steps/mod.rs` and `compare/mod.rs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: round-trip output is pinned by record-count and byte/order identity tests; no `unsafe` changes or CLAUDE.md allowlist update; no memory-bound, queue-capacity, or backpressure-policy changes.

Fix: Add the whole-chain BAM round-trip helper and `fgumi compare bam-roundtrip`. Validate inputs, compression levels, output clobbering, same-file paths, and single-thread execution.

Tests cover multiple thread counts, empty inputs, invalid compression, missing inputs, symlinks, hard links, and atomic failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->