### PR TITLE
perf(umi): use fixed-seed ahash on hot per-item maps to remove RandomState global-counter contention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,6 +820,7 @@ dependencies = [
 name = "fgumi-dna"
 version = "0.7.0"
 dependencies = [
+ "ahash",
  "rstest",
 ]
 
@@ -901,6 +902,7 @@ dependencies = [
  "crossbeam-utils",
  "fgumi-bam-io",
  "fgumi-bgzf",
+ "fgumi-dna",
  "fgumi-raw-bam",
  "fgumi-sam",
  "fs4",

--- a/crates/fgumi-consensus/src/hashing.rs
+++ b/crates/fgumi-consensus/src/hashing.rs
@@ -1,0 +1,6 @@
+//! Deterministic, contention-free hashing for hot per-item maps.
+//!
+//! Re-exports the shared fixed-seed hasher so the seed table lives in exactly one place; see
+//! [`fgumi_dna::hashing::deterministic_state`] for the full rationale.
+
+pub(crate) use fgumi_dna::deterministic_state;

--- a/crates/fgumi-consensus/src/lib.rs
+++ b/crates/fgumi-consensus/src/lib.rs
@@ -16,6 +16,7 @@
 pub mod base_builder;
 pub mod caller;
 pub mod filter;
+pub(crate) mod hashing;
 pub mod overlapping;
 pub mod phred;
 pub mod sequence;

--- a/crates/fgumi-consensus/src/overlapping.rs
+++ b/crates/fgumi-consensus/src/overlapping.rs
@@ -631,7 +631,8 @@ pub fn apply_overlapping_consensus(
     use ahash::AHashMap;
 
     // Group reads by name for pairing
-    let mut read_pairs: AHashMap<Vec<u8>, (Option<usize>, Option<usize>)> = AHashMap::new();
+    let mut read_pairs: AHashMap<Vec<u8>, (Option<usize>, Option<usize>)> =
+        AHashMap::with_hasher(crate::hashing::deterministic_state());
 
     for (idx, record) in records.iter().enumerate() {
         let view = RawRecordView::new(record);

--- a/crates/fgumi-dna/Cargo.toml
+++ b/crates/fgumi-dna/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+ahash = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/fgumi-dna/src/hashing.rs
+++ b/crates/fgumi-dna/src/hashing.rs
@@ -1,0 +1,48 @@
+//! Deterministic, contention-free hashing for hot per-item maps.
+
+use ahash::RandomState;
+
+/// A fixed-seed [`RandomState`] for `AHashMap`s created in hot per-item loops
+/// (per-position-group, per-assign call).
+///
+/// `AHashMap::new()` / `::default()` derives its state from [`RandomState::new`], which bumps a
+/// process-global atomic counter on every construction. Under UMI grouping's
+/// many-small-maps-per-thread pattern that counter's cache line ping-pongs across cores and
+/// dominates CPU; giving each map a fixed seed skips the counter entirely (measured: `group`
+/// throughput +12-37% at 16 threads on a 53M-record BAM, every output byte-identical).
+///
+/// The seed is arbitrary and reproducible across runs. Output never depends on it: every consumer
+/// sorts before assigning molecule IDs or mints IDs in input order, so map iteration order cannot
+/// reach the result. This is a throughput fix, not a determinism fix.
+///
+/// This is the single home for the fixed seed table; `fgumi_sort::cb_hasher` and the per-crate
+/// `hashing` re-exports all delegate here.
+#[inline]
+#[must_use]
+pub fn deterministic_state() -> RandomState {
+    // Arbitrary fixed seeds — chosen for uniqueness, not cryptographic strength.
+    RandomState::with_seeds(
+        0xa1b2_c3d4_e5f6_0718,
+        0x9182_7364_5546_3728,
+        0xfede_dcba_0987_6543,
+        0x0011_2233_4455_6677,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two independently-constructed `deterministic_state()` values must hash an identical key to
+    /// the identical value. This is the fixed-seed contract the throughput fix relies on: it holds
+    /// for `RandomState::with_seeds` but would fail if `deterministic_state` were ever swapped back
+    /// to `RandomState::new()`, whose seeds differ on every construction.
+    #[rstest::rstest]
+    #[case::empty(b"")]
+    #[case::short(b"ACGT")]
+    #[case::umi(b"ACGT-TGCA")]
+    #[case::long(b"the quick brown fox jumps over the lazy dog")]
+    fn deterministic_state_hashes_key_identically_across_instances(#[case] key: &[u8]) {
+        assert_eq!(deterministic_state().hash_one(key), deterministic_state().hash_one(key));
+    }
+}

--- a/crates/fgumi-dna/src/lib.rs
+++ b/crates/fgumi-dna/src/lib.rs
@@ -9,10 +9,12 @@
 
 pub mod bitenc;
 pub mod dna;
+pub mod hashing;
 
 // Re-export submodule contents at crate root for convenience
 pub use bitenc::BitEnc;
 pub use dna::{COMPLEMENT, complement_base, reverse_complement, reverse_complement_str};
+pub use hashing::deterministic_state;
 
 /// No-call base character (matches fgbio's `NoCallBase`).
 pub const NO_CALL_BASE: u8 = b'N';

--- a/crates/fgumi-sort/Cargo.toml
+++ b/crates/fgumi-sort/Cargo.toml
@@ -17,6 +17,7 @@ pedantic = { level = "deny", priority = -1 }
 fgumi-raw-bam = { workspace = true, features = ["noodles"] }
 fgumi-bgzf = { workspace = true }
 fgumi-bam-io = { workspace = true }
+fgumi-dna = { workspace = true }
 noodles = { workspace = true, features = ["bam", "sam", "core", "csi"] }
 noodles-bgzf = { workspace = true }
 libdeflater = { workspace = true }

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -588,16 +588,11 @@ pub(crate) struct Phase1FloorInputs {
 
 /// Deterministic hasher for cell barcode hashing in template-coordinate sort.
 ///
-/// Uses arbitrary fixed seeds so that hash values are reproducible across runs.
+/// Delegates to the shared [`fgumi_dna::deterministic_state`] so the fixed seed table lives in
+/// exactly one place; hash values remain reproducible across runs.
 #[must_use]
 pub fn cb_hasher() -> ahash::RandomState {
-    // Arbitrary fixed seeds — chosen for uniqueness, not cryptographic strength.
-    ahash::RandomState::with_seeds(
-        0xa1b2_c3d4_e5f6_0718,
-        0x9182_7364_5546_3728,
-        0xfede_dcba_0987_6543,
-        0x0011_2233_4455_6677,
-    )
+    fgumi_dna::deterministic_state()
 }
 
 /// Where a merge writes its output.

--- a/crates/fgumi-umi/src/assigner.rs
+++ b/crates/fgumi-umi/src/assigner.rs
@@ -481,8 +481,9 @@ impl NgramIndex {
             return None;
         }
 
-        let mut partitions: Vec<AHashMap<u32, Vec<(usize, BitEnc)>>> =
-            (0..num_partitions).map(|_| AHashMap::new()).collect();
+        let mut partitions: Vec<AHashMap<u32, Vec<(usize, BitEnc)>>> = (0..num_partitions)
+            .map(|_| AHashMap::with_hasher(crate::hashing::deterministic_state()))
+            .collect();
 
         for &(idx, umi) in umis {
             // Verify consistent length
@@ -787,7 +788,8 @@ fn assign_with_invalid_fallback(
     mut resolve: impl FnMut(usize, &str) -> Option<MoleculeId>,
     mut mint: impl FnMut() -> MoleculeId,
 ) -> Vec<MoleculeId> {
-    let mut invalid_to_id: AHashMap<String, MoleculeId> = AHashMap::new();
+    let mut invalid_to_id: AHashMap<String, MoleculeId> =
+        AHashMap::with_hasher(crate::hashing::deterministic_state());
     raw_umis
         .iter()
         .enumerate()
@@ -1242,7 +1244,8 @@ impl SimpleErrorUmiAssigner {
             }
         }
 
-        let mut by_root: AHashMap<usize, BTreeSet<Umi>> = AHashMap::new();
+        let mut by_root: AHashMap<usize, BTreeSet<Umi>> =
+            AHashMap::with_hasher(crate::hashing::deterministic_state());
         for (i, umi) in distinct.iter().enumerate() {
             by_root.entry(components.find(i)).or_default().insert((*umi).clone());
         }
@@ -1407,7 +1410,8 @@ impl UmiAssigner for SimpleErrorUmiAssigner {
         });
 
         // Build map from UMI string to MoleculeId
-        let mut umi_to_id: AHashMap<String, MoleculeId> = AHashMap::new();
+        let mut umi_to_id: AHashMap<String, MoleculeId> =
+            AHashMap::with_hasher(crate::hashing::deterministic_state());
         for set in umi_sets {
             let id = MoleculeId::Single(self.next_id());
             for umi in set {
@@ -1952,8 +1956,10 @@ impl UmiAssigner for AdjacencyUmiAssigner {
         // Also build a map from BitEnc -> unique_index for result lookup
         let mut umi_counts: Vec<(BitEnc, usize, usize)> = {
             // Map from BitEnc -> (count, first_raw_index)
-            let mut counts: AHashMap<BitEnc, (usize, usize)> =
-                AHashMap::with_capacity(raw_umis.len() / 4); // Estimate ~4 reads per UMI
+            let mut counts: AHashMap<BitEnc, (usize, usize)> = AHashMap::with_capacity_and_hasher(
+                raw_umis.len() / 4,
+                crate::hashing::deterministic_state(),
+            ); // Estimate ~4 reads per UMI
 
             for (i, encoded) in encodings.iter().enumerate() {
                 // Skip UMIs that contain invalid characters
@@ -2001,8 +2007,10 @@ impl UmiAssigner for AdjacencyUmiAssigner {
         });
 
         // Build lookup from BitEnc to sorted index (after sorting)
-        let bitenc_to_unique_idx: AHashMap<BitEnc, usize> =
-            umi_counts.iter().enumerate().map(|(idx, (enc, _, _))| (*enc, idx)).collect();
+        let mut bitenc_to_unique_idx: AHashMap<BitEnc, usize> =
+            AHashMap::with_hasher(crate::hashing::deterministic_state());
+        bitenc_to_unique_idx
+            .extend(umi_counts.iter().enumerate().map(|(idx, (enc, _, _))| (*enc, idx)));
 
         #[cfg(feature = "profile-adjacency")]
         let t_after_sort = std::time::Instant::now();
@@ -2396,7 +2404,8 @@ impl PairedUmiAssigner {
         umis: &[Umi],
         underlying: &[Option<usize>],
     ) -> Vec<(Umi, usize, Option<usize>)> {
-        let mut counts: AHashMap<Umi, (usize, Option<usize>)> = AHashMap::new();
+        let mut counts: AHashMap<Umi, (usize, Option<usize>)> =
+            AHashMap::with_hasher(crate::hashing::deterministic_state());
         for (umi, len) in umis.iter().zip(underlying) {
             let canonical = Self::canonicalize_paired(umi)
                 .expect("UMI should be valid paired format (validated in assign())");
@@ -2581,7 +2590,8 @@ impl UmiAssigner for PairedUmiAssigner {
 
         // Assign IDs with A/B variants - build a map from UMI string to MoleculeId
         // Use owned strings since we need to store reversed UMIs
-        let mut umi_to_id: AHashMap<String, MoleculeId> = AHashMap::new();
+        let mut umi_to_id: AHashMap<String, MoleculeId> =
+            AHashMap::with_hasher(crate::hashing::deterministic_state());
 
         for &root_idx in &roots {
             let id = self.adjacency.next_id();

--- a/crates/fgumi-umi/src/hashing.rs
+++ b/crates/fgumi-umi/src/hashing.rs
@@ -1,0 +1,6 @@
+//! Deterministic, contention-free hashing for hot per-item maps.
+//!
+//! Re-exports the shared fixed-seed hasher so the seed table lives in exactly one place; see
+//! [`fgumi_dna::hashing::deterministic_state`] for the full rationale.
+
+pub(crate) use fgumi_dna::deterministic_state;

--- a/crates/fgumi-umi/src/lib.rs
+++ b/crates/fgumi-umi/src/lib.rs
@@ -8,6 +8,7 @@
 //! - UMI grouping and family analysis
 
 pub mod assigner;
+pub(crate) mod hashing;
 pub mod index_threshold;
 
 // Re-export commonly used items

--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -1011,7 +1011,8 @@ impl CorrectUmis {
                 let mut missing_umis = 0u64;
                 let mut wrong_length = 0u64;
                 let mut mismatched = 0u64;
-                let mut umi_matches_map: AHashMap<String, UmiCorrectionMetrics> = AHashMap::new();
+                let mut umi_matches_map: AHashMap<String, UmiCorrectionMetrics> =
+                    AHashMap::with_hasher(crate::hashing::deterministic_state());
                 let templates_count = batch.len() as u64;
                 // Count ALL input records for progress tracking (not just kept/rejected)
                 let mut total_input_records = 0u64;

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -728,7 +728,8 @@ fn assign_umi_groups(
     no_umi: bool,
 ) -> Result<()> {
     if splits_by_strand_of_origin(assigner, no_umi) {
-        let mut subgroups: AHashMap<(bool, bool), Vec<usize>> = AHashMap::new();
+        let mut subgroups: AHashMap<(bool, bool), Vec<usize>> =
+            AHashMap::with_hasher(crate::hashing::deterministic_state());
         for (idx, template) in templates.iter().enumerate() {
             let orientation = get_pair_orientation(template);
             subgroups.entry(orientation).or_default().push(idx);
@@ -942,7 +943,7 @@ fn process_position_group(
     if filtered_templates.is_empty() && passthrough_templates.is_empty() {
         return Ok(ProcessedDedupGroup {
             templates: Vec::new(),
-            family_sizes: AHashMap::new(),
+            family_sizes: AHashMap::with_hasher(crate::hashing::deterministic_state()),
             dedup_counts,
             library_idx,
             input_record_count,
@@ -973,7 +974,8 @@ fn process_position_group(
     });
 
     // Group by MI and mark duplicates
-    let mut family_sizes: AHashMap<usize, u64> = AHashMap::with_capacity(50);
+    let mut family_sizes: AHashMap<usize, u64> =
+        AHashMap::with_capacity_and_hasher(50, crate::hashing::deterministic_state());
 
     if !templates.is_empty() {
         // Collect family boundaries

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -659,7 +659,8 @@ impl Filter {
 
             for template in batch {
                 let mut template_records: Vec<RawRecord> = template.into_records();
-                let mut pass_map: AHashMap<usize, bool> = AHashMap::new();
+                let mut pass_map: AHashMap<usize, bool> =
+                    AHashMap::with_hasher(crate::hashing::deterministic_state());
                 let mut masked_by_record: Vec<u64> = Vec::with_capacity(template_records.len());
 
                 for (idx, record) in template_records.iter_mut().enumerate() {

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -341,7 +341,8 @@ fn assign_umi_groups_impl(
     // deliberately does not, so do not "harmonize" the two by adding `&& !no_umi` here.
     if assigner.split_templates_by_pair_orientation() {
         // Group by pair orientation
-        let mut subgroups: AHashMap<(bool, bool), Vec<usize>> = AHashMap::new();
+        let mut subgroups: AHashMap<(bool, bool), Vec<usize>> =
+            AHashMap::with_hasher(crate::hashing::deterministic_state());
         for (idx, template) in templates.iter().enumerate() {
             let orientation = get_pair_orientation_raw(template);
             subgroups.entry(orientation).or_default().push(idx);

--- a/src/lib/hashing.rs
+++ b/src/lib/hashing.rs
@@ -1,0 +1,6 @@
+//! Deterministic, contention-free hashing for hot per-item maps.
+//!
+//! Re-exports the shared fixed-seed hasher so the seed table lives in exactly one place; see
+//! [`fgumi_dna::hashing::deterministic_state`] for the full rationale.
+
+pub(crate) use fgumi_dna::deterministic_state;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -138,6 +138,7 @@ pub mod errors;
 pub mod fastq;
 pub mod fastq_parse;
 pub mod grouper;
+pub(crate) mod hashing;
 pub mod logging;
 pub mod metrics;
 pub mod mi_group;

--- a/src/lib/umi/parallel_assigner.rs
+++ b/src/lib/umi/parallel_assigner.rs
@@ -68,7 +68,8 @@ impl MoleculeIdCounter {
 /// molecule) and the sequential assigners. Used for the "all UMIs invalid" edge case shared by
 /// every parallel assigner.
 fn all_invalid_molecule_ids(raw_umis: &[Umi]) -> Vec<MoleculeId> {
-    let mut invalid_to_id: AHashMap<String, MoleculeId> = AHashMap::new();
+    let mut invalid_to_id: AHashMap<String, MoleculeId> =
+        AHashMap::with_hasher(crate::hashing::deterministic_state());
     let mut next_mol_id: u64 = 0;
     raw_umis
         .iter()
@@ -241,8 +242,9 @@ pub fn discover_edges_parallel_k1(
     umis: &[(BitEnc, usize)], // (encoded UMI, count)
 ) -> Vec<(usize, usize)> {
     // Build lookup map: BitEnc -> index
-    let umi_to_idx: AHashMap<BitEnc, usize> =
-        umis.iter().enumerate().map(|(i, (enc, _))| (*enc, i)).collect();
+    let mut umi_to_idx: AHashMap<BitEnc, usize> =
+        AHashMap::with_hasher(crate::hashing::deterministic_state());
+    umi_to_idx.extend(umis.iter().enumerate().map(|(i, (enc, _))| (*enc, i)));
 
     umis.par_iter()
         .enumerate()
@@ -276,8 +278,9 @@ pub fn discover_edges_parallel_k(
     }
 
     // Build lookup map: BitEnc -> index
-    let umi_to_idx: AHashMap<BitEnc, usize> =
-        umis.iter().enumerate().map(|(i, (enc, _))| (*enc, i)).collect();
+    let mut umi_to_idx: AHashMap<BitEnc, usize> =
+        AHashMap::with_hasher(crate::hashing::deterministic_state());
+    umi_to_idx.extend(umis.iter().enumerate().map(|(i, (enc, _))| (*enc, i)));
 
     // For k > 1, generate all neighbors within distance k and check hash map
     // This is still faster than O(n²) for reasonable k (1-3) and large n
@@ -316,8 +319,9 @@ fn discover_paired_reverse_edges(
     reverse_encs: &[BitEnc],
     max_mismatches: u32,
 ) -> Vec<(usize, usize)> {
-    let umi_to_idx: AHashMap<BitEnc, usize> =
-        forward.iter().enumerate().map(|(i, (enc, _))| (*enc, i)).collect();
+    let mut umi_to_idx: AHashMap<BitEnc, usize> =
+        AHashMap::with_hasher(crate::hashing::deterministic_state());
+    umi_to_idx.extend(forward.iter().enumerate().map(|(i, (enc, _))| (*enc, i)));
 
     reverse_encs
         .par_iter()
@@ -562,11 +566,14 @@ impl ParallelIdentityAssigner {
         unique_canonicals.sort_unstable();
 
         // Assign IDs in sorted order
-        let canonical_to_id: AHashMap<&str, MoleculeId> = unique_canonicals
-            .into_iter()
-            .enumerate()
-            .map(|(i, umi)| (umi, MoleculeId::Single(i as u64)))
-            .collect();
+        let mut canonical_to_id: AHashMap<&str, MoleculeId> =
+            AHashMap::with_hasher(crate::hashing::deterministic_state());
+        canonical_to_id.extend(
+            unique_canonicals
+                .into_iter()
+                .enumerate()
+                .map(|(i, umi)| (umi, MoleculeId::Single(i as u64))),
+        );
 
         // Phase 3: Parallel final mapping
         self.pool.install(|| {
@@ -625,7 +632,8 @@ impl ParallelEditAssigner {
 
         // Encode UMIs and count occurrences
         // Use a single pass to build both the count map and the encoding vector
-        let mut umi_counts: AHashMap<BitEnc, usize> = AHashMap::new();
+        let mut umi_counts: AHashMap<BitEnc, usize> =
+            AHashMap::with_hasher(crate::hashing::deterministic_state());
         let mut umi_to_original: Vec<Option<BitEnc>> = Vec::with_capacity(raw_umis.len());
 
         for umi in raw_umis {
@@ -652,8 +660,9 @@ impl ParallelEditAssigner {
         // Reject differing-length UMIs the way fgbio (and the sequential assigner) does.
         assert_uniform_umi_length(unique_umis.iter().map(|(enc, _)| enc.len()));
 
-        let enc_to_idx: AHashMap<BitEnc, usize> =
-            unique_umis.iter().enumerate().map(|(i, (enc, _))| (*enc, i)).collect();
+        let mut enc_to_idx: AHashMap<BitEnc, usize> =
+            AHashMap::with_hasher(crate::hashing::deterministic_state());
+        enc_to_idx.extend(unique_umis.iter().enumerate().map(|(i, (enc, _))| (*enc, i)));
 
         // Discover edges and build components using the configured thread pool
         let max_mismatches = self.max_mismatches;
@@ -666,8 +675,10 @@ impl ParallelEditAssigner {
         drop(edges);
 
         // Assign molecule IDs based on connected components
-        let mut root_to_mol: AHashMap<usize, MoleculeId> = AHashMap::new();
-        let mut invalid_to_id: AHashMap<String, MoleculeId> = AHashMap::new();
+        let mut root_to_mol: AHashMap<usize, MoleculeId> =
+            AHashMap::with_hasher(crate::hashing::deterministic_state());
+        let mut invalid_to_id: AHashMap<String, MoleculeId> =
+            AHashMap::with_hasher(crate::hashing::deterministic_state());
         let mut next_mol_id: u64 = 0;
 
         let mut result = Vec::with_capacity(raw_umis.len());
@@ -747,7 +758,8 @@ impl ParallelAdjacencyAssigner {
         }
 
         // Count unique UMIs
-        let mut umi_counts: AHashMap<String, usize> = AHashMap::new();
+        let mut umi_counts: AHashMap<String, usize> =
+            AHashMap::with_hasher(crate::hashing::deterministic_state());
         for umi in raw_umis {
             *umi_counts.entry(umi.to_uppercase()).or_insert(0) += 1;
         }
@@ -837,17 +849,18 @@ impl ParallelAdjacencyAssigner {
 
         // Build map from uppercase UMI string to molecule ID
         // Use references to avoid cloning
-        let str_to_mol: AHashMap<&str, MoleculeId> = sorted_umis
-            .iter()
-            .enumerate()
-            .map(|(i, (umi, _, _))| (umi.as_str(), mol_ids[i]))
-            .collect();
+        let mut str_to_mol: AHashMap<&str, MoleculeId> =
+            AHashMap::with_hasher(crate::hashing::deterministic_state());
+        str_to_mol.extend(
+            sorted_umis.iter().enumerate().map(|(i, (umi, _, _))| (umi.as_str(), mol_ids[i])),
+        );
 
         // Map back to original UMI order. Each distinct invalid (non-encodable) UMI gets its own
         // molecule (identical strings share, continuing the `next_mol_id` sequence), mirroring
         // fgbio's per-string assignment and the sequential adjacency assigner. Invalid UMIs never
         // join a valid molecule. See the cross-assigner parity note in the tests module.
-        let mut invalid_to_id: AHashMap<String, MoleculeId> = AHashMap::new();
+        let mut invalid_to_id: AHashMap<String, MoleculeId> =
+            AHashMap::with_hasher(crate::hashing::deterministic_state());
         raw_umis
             .iter()
             .map(|umi| {
@@ -961,7 +974,8 @@ impl ParallelPairedAssigner {
         }
 
         // Count unique UMIs using canonical form
-        let mut canonical_counts: AHashMap<String, usize> = AHashMap::new();
+        let mut canonical_counts: AHashMap<String, usize> =
+            AHashMap::with_hasher(crate::hashing::deterministic_state());
         for umi in raw_umis {
             let canonical = Self::canonicalize(umi);
             *canonical_counts.entry(canonical).or_insert(0) += 1;
@@ -1172,9 +1186,12 @@ impl ParallelPairedAssigner {
         // and all-invalid paths keep them distinct -- a `--threads`-dependent divergence. fgumi's
         // chosen model is one molecule per distinct raw UMI string (an intentional fgbio
         // divergence, since `BitEnc` cannot represent the invalid base).
-        let canonical_to_idx: AHashMap<&str, usize> =
-            sorted_umis.iter().enumerate().map(|(i, (umi, _, _))| (umi.as_str(), i)).collect();
-        let mut invalid_to_id: AHashMap<String, MoleculeId> = AHashMap::new();
+        let mut canonical_to_idx: AHashMap<&str, usize> =
+            AHashMap::with_hasher(crate::hashing::deterministic_state());
+        canonical_to_idx
+            .extend(sorted_umis.iter().enumerate().map(|(i, (umi, _, _))| (umi.as_str(), i)));
+        let mut invalid_to_id: AHashMap<String, MoleculeId> =
+            AHashMap::with_hasher(crate::hashing::deterministic_state());
         raw_umis
             .iter()
             .map(|umi| {


### PR DESCRIPTION
UMI grouping creates many small `AHashMap`s per thread (per-position-group, per-assign call). `AHashMap::new()`/`::default()`/`::with_capacity()`/`.collect()` all derive their state from `ahash::RandomState::new()`, which bumps a **process-global atomic counter** on every construction. At 16 threads that counter's cache line ping-pongs across cores and dominates CPU — a profile put `gen_hasher_seed` at ~28% of `group` CPU.

This gives each hot per-item map a **fixed seed** via a shared `deterministic_state()` helper (`ahash::RandomState::with_seeds(<4 consts>)`, `const fn`, no atomic), applied only at genuinely-hot per-item sites. The seed table lives in exactly one place (`fgumi-dna`); `fgumi_sort::cb_hasher` and the per-crate re-exports all delegate to it.

**Measured (WGS, 53,139,936 records, 16 threads, Graviton4, CPU-seconds):**

| `group` strategy | baseline | fixed-seed | throughput |
|---|---|---|---|
| adjacency | 117.7 | 86.1 | **+37%** |
| edit | 109.3 | 86.7 | **+26%** |
| paired | 99.6 | 88.6 | **+12%** |

`filter` +5.5%. `dedup`/`simplex` flat — expected: dedup creates maps less densely and spends ~21% between `assign()` calls in BGZF compression, so the counter never becomes the bottleneck (confirmed via a 2×2 build×workload matrix + sampling).

**Output is byte-identical.** This is a throughput fix, not a determinism fix: every seeded map is either sorted before molecule-ID assignment, or mints IDs in raw-input order, or is a lookup/accumulator whose iteration order never reaches output. Verified three ways — output histograms are MD5-identical before/after for all three `group` strategies (`db4dd08d` / `4c49dc67` / `a1fc4c9a`), the full suite (9467 tests) stays green and non-flaky (it would flake if any of these were order-dependent), and `with_seeds` (not `with_seed(0)`) makes the seed fixed across runs, not merely per-process.

Internal UMI/molecule maps over bounded, trusted per-template data — not attacker-controlled input — so fixing the seed carries no HashDoS exposure. Once-per-run counters, setup, and test maps are deliberately left unseeded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: output remains pinned by fixed hash seeds; no `unsafe` changes and no CLAUDE.md allowlist update; no memory-bound, queue-capacity, or thread/backpressure changes.

Fix: use a shared deterministic `ahash::RandomState` for hot per-item maps. This removes global seed-counter contention while preserving byte-identical output. Validation includes fixed-seed runs, MD5 comparisons, and 9,467 tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->