### PR TITLE
feat(pipeline): declarative chain-builder layer + group --threads pilot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,6 +729,7 @@ dependencies = [
  "fgumi",
  "fgumi-bam-io",
  "fgumi-bgzf",
+ "fgumi-cli-macros",
  "fgumi-consensus",
  "fgumi-dna",
  "fgumi-metrics",
@@ -765,6 +766,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "thiserror 2.0.20",
+ "which",
 ]
 
 [[package]]
@@ -2939,6 +2941,15 @@ checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "8.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ sysinfo = { version = "0.38", default-features = false, features = ["system"] }
 tempfile = "3.3.0"
 thiserror = "2"
 trybuild = "1.0"
+which = "8"
 wide = "1.5"
 
 [package]
@@ -167,6 +168,8 @@ fgumi-bam-io = { workspace = true }
 fgumi-sort = { workspace = true }
 fgumi-pipeline-core = { workspace = true }
 fgumi-pipeline-io = { workspace = true }
+fgumi-cli-macros = { workspace = true }
+which = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mach2 = { workspace = true }
@@ -175,20 +178,33 @@ mach2 = { workspace = true }
 nix = { workspace = true }
 
 [features]
-default = ["simplex", "duplex", "codec"]
+default = ["consensus"]
 simplex = ["fgumi-consensus/simplex"]
 # duplex and codec depend on simplex (mirrors fgumi-consensus: `duplex = ["simplex"]`
 # and `codec = ["simplex"]`), and their commands share methylation/filter paths
 # that live behind the `simplex` feature in this crate.
 duplex = ["simplex", "fgumi-consensus/duplex"]
 codec = ["simplex", "fgumi-consensus/codec"]
+# Umbrella for all consensus calling (simplex + duplex + codec). The command
+# modules gate individually on `simplex`/`duplex`/`codec`, but the always-
+# compiled chain/runall layer (`pipeline::chains`) references the consensus
+# option-bag surface all-or-nothing: gating those references per-codec lets a
+# reduced-feature build reference a half-present surface and fail to compile, so
+# `consensus` gates them as one unit. This is about consensus *coherence* only — it
+# is NOT a claim that `--no-default-features` compiles: the crate has other
+# always-on references (e.g. the methylation path) that a bare
+# `--no-default-features` build still fails on. Enabled by default and by
+# `simulate`.
+consensus = ["simplex", "duplex", "codec"]
 dhat-heap = ["dep:dhat"]
 # Enable comprehensive memory debugging infrastructure (monitor thread, hot-path atomics, CLI args)
 memory-debug = ["fgumi-sort/memory-debug"]
 # Enable compare subcommand with bams and metrics (developer tools)
 compare = []
-# Enable simulate commands for generating synthetic test data
-simulate = ["simplex"]
+# Enable simulate commands for generating synthetic test data. Pulls the full
+# consensus umbrella so the chain-builder's consensus stages are present when
+# simulate-driven end-to-end tests exercise them.
+simulate = ["consensus"]
 # Enable profiling output for adjacency UMI assigner
 profile-adjacency = []
 # Enable slow stress tests for concurrency testing

--- a/crates/fgumi-raw-bam/src/builder.rs
+++ b/crates/fgumi-raw-bam/src/builder.rs
@@ -294,11 +294,32 @@ impl UnmappedSamBuilder {
     #[inline]
     pub fn write_with_block_size(&self, output: &mut Vec<u8>) {
         debug_assert!(self.sealed, "must call build_record first");
-        let block_size =
-            u32::try_from(self.buf.len()).expect("record too large for BAM block_size");
-        output.extend_from_slice(&block_size.to_le_bytes());
-        output.extend_from_slice(&self.buf);
+        write_framed_record(output, &self.buf).expect("record too large for BAM block_size");
     }
+}
+
+/// Append `rec` to `dst` framed as a BAM record block: a 4-byte little-endian
+/// `block_size` length prefix followed by the record bytes. This is the
+/// canonical BAM record framing used by the pipeline serialize path and the
+/// BGZF compression step; call it instead of re-implementing the prefix
+/// arithmetic so every framing site stays in agreement.
+///
+/// # Errors
+///
+/// Returns [`std::io::ErrorKind::InvalidData`] if `rec.len()` exceeds
+/// `u32::MAX` — a single BAM record's `block_size` is a `u32` field, so a
+/// larger record cannot be framed without silently truncating the length.
+#[inline]
+pub fn write_framed_record(dst: &mut Vec<u8>, rec: &[u8]) -> std::io::Result<()> {
+    let block_size = u32::try_from(rec.len()).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("BAM record too large ({} bytes)", rec.len()),
+        )
+    })?;
+    dst.extend_from_slice(&block_size.to_le_bytes());
+    dst.extend_from_slice(rec);
+    Ok(())
 }
 
 impl Default for UnmappedSamBuilder {
@@ -666,6 +687,34 @@ mod tests {
     use crate::testutil::*;
     use fgumi_tag::SamTag;
     use rstest::rstest;
+
+    // ── write_framed_record: 4-byte LE block_size prefix + record bytes ──────
+
+    #[test]
+    fn write_framed_record_prefixes_le_block_size() {
+        let rec = [0xAA_u8, 0xBB, 0xCC];
+        let mut dst = vec![0x01_u8]; // pre-existing byte: framing must append, not overwrite
+        write_framed_record(&mut dst, &rec).expect("small record frames");
+        // Existing byte preserved, then a 4-byte LE length (3), then the bytes.
+        assert_eq!(dst, vec![0x01, 3, 0, 0, 0, 0xAA, 0xBB, 0xCC]);
+    }
+
+    #[test]
+    fn write_framed_record_empty_record() {
+        let mut dst = Vec::new();
+        write_framed_record(&mut dst, &[]).expect("empty record frames");
+        assert_eq!(dst, vec![0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn write_framed_record_appends_across_calls() {
+        // Two framed records concatenate into one buffer (the DecompressedBlock
+        // shape the rejects-serialization paths emit).
+        let mut dst = Vec::new();
+        write_framed_record(&mut dst, &[0x11]).unwrap();
+        write_framed_record(&mut dst, &[0x22, 0x33]).unwrap();
+        assert_eq!(dst, vec![1, 0, 0, 0, 0x11, 2, 0, 0, 0, 0x22, 0x33]);
+    }
 
     // ── try_build_record: data-derived names must error, not panic ───────────
 

--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -67,7 +67,7 @@ pub use bin::{UNMAPPED_BIN, bin_from_raw_bam, reg2bin, set_bin_from_raw_bam};
 pub use hash::{fgbio_read_name_rank, htsjdk_murmur3_hash_unencoded_chars};
 
 // -- builder --
-pub use builder::{ReadNameTooLong, SamBuilder, UnmappedSamBuilder};
+pub use builder::{ReadNameTooLong, SamBuilder, UnmappedSamBuilder, write_framed_record};
 
 // -- cigar --
 #[cfg(feature = "noodles")]

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -141,7 +141,13 @@ pub(crate) fn header_declares_order(header: &Header, sort_order: keys::SortOrder
 /// Preserves all existing header content (reference sequences, read groups, programs,
 /// comments, and `@HD` fields like `VN`), then overwrites only the sort-related tags
 /// (`SO`, `GO`, `SS`) based on the requested sort order.
-pub(crate) fn create_output_header(sort_order: keys::SortOrder, header: &Header) -> Header {
+///
+/// # Panics
+///
+/// Panics only if constructing the default `@HD` map fails, which cannot happen for
+/// the hard-coded default built here.
+#[must_use]
+pub fn create_output_header(sort_order: keys::SortOrder, header: &Header) -> Header {
     let mut builder = Header::builder();
 
     // Copy reference sequences

--- a/crates/fgumi-umi/src/assigner.rs
+++ b/crates/fgumi-umi/src/assigner.rs
@@ -906,6 +906,14 @@ pub trait UmiAssigner: Send + Sync {
     /// `Vec<MoleculeId>` where `result[i]` is the assignment for `raw_umis[i]`.
     fn assign(&self, raw_umis: &[Umi]) -> Vec<MoleculeId>;
 
+    /// Reset any internal per-run state (e.g. a monotonic molecule-id counter)
+    /// so the assigner can be reused across batches within one chain run.
+    ///
+    /// Default is a no-op; assigners that carry a counter override this to zero
+    /// it. See `chains/commands/{group,dedup}.rs`, which reset the assigner
+    /// between position groups.
+    fn reset(&self) {}
+
     /// Check if two UMIs are the same
     ///
     /// Default implementation uses simple string equality. Override for custom
@@ -1007,6 +1015,10 @@ impl Default for IdentityUmiAssigner {
 }
 
 impl UmiAssigner for IdentityUmiAssigner {
+    fn reset(&self) {
+        self.counter.store(0, Ordering::SeqCst);
+    }
+
     fn assign(&self, raw_umis: &[Umi]) -> Vec<MoleculeId> {
         if raw_umis.is_empty() {
             return Vec::new();
@@ -1265,6 +1277,10 @@ impl SimpleErrorUmiAssigner {
 }
 
 impl UmiAssigner for SimpleErrorUmiAssigner {
+    fn reset(&self) {
+        self.counter.store(0, Ordering::SeqCst);
+    }
+
     fn assign(&self, raw_umis: &[Umi]) -> Vec<MoleculeId> {
         if raw_umis.is_empty() {
             return Vec::new();
@@ -1934,6 +1950,10 @@ impl AdjacencyUmiAssigner {
 }
 
 impl UmiAssigner for AdjacencyUmiAssigner {
+    fn reset(&self) {
+        self.counter.store(0, Ordering::SeqCst);
+    }
+
     fn assign(&self, raw_umis: &[Umi]) -> Vec<MoleculeId> {
         if raw_umis.is_empty() {
             return Vec::new();
@@ -2484,6 +2504,16 @@ impl PairedUmiAssigner {
 }
 
 impl UmiAssigner for PairedUmiAssigner {
+    fn reset(&self) {
+        // Molecule ids are produced via `self.adjacency.next_id()`, so the
+        // counter that must be zeroed for per-position-group reuse lives in the
+        // wrapped adjacency assigner. Delegate to its `reset` (a no-op default
+        // here would leave the counter accumulating across groups, breaking the
+        // chain's local-`0..k` per-group numbering that `distinct_mi_count` and
+        // `assign_mi_offsets` rely on — see `chains/commands/{group,dedup}.rs`).
+        self.adjacency.reset();
+    }
+
     fn assign(&self, raw_umis: &[Umi]) -> Vec<MoleculeId> {
         if raw_umis.is_empty() {
             return Vec::new();
@@ -2850,6 +2880,61 @@ mod tests {
             ids[2],
             MoleculeId::None,
             "invalid-base UMI gets its own molecule (fgbio assigns every UMI a molecule)"
+        );
+    }
+
+    /// `reset()` must return a reused assigner to its initial molecule-id
+    /// numbering. The chain group/dedup loops reuse ONE assigner across
+    /// position groups and call `reset()` per group so each group emits local
+    /// ids `0..k` (which `distinct_mi_count` and the downstream
+    /// `assign_mi_offsets` global rebase depend on). The trait's default
+    /// `reset()` is a no-op, so an assigner that carries a counter but forgets
+    /// to override it silently leaves the counter accumulating — corrupting the
+    /// per-group MI numbering. This pins that every sequential strategy actually
+    /// resets, including `Paired` (which delegates to its wrapped adjacency
+    /// counter and would otherwise inherit the no-op default).
+    #[rstest]
+    #[case::identity(
+        crate::assigner::Strategy::Identity,
+        0,
+        vec!["AAAA".to_string(), "AAAA".to_string(), "CCCC".to_string()]
+    )]
+    #[case::edit(
+        crate::assigner::Strategy::Edit,
+        1,
+        vec!["AAAA".to_string(), "AAAT".to_string(), "CCCC".to_string()]
+    )]
+    #[case::adjacency(
+        crate::assigner::Strategy::Adjacency,
+        1,
+        vec!["AAAA".to_string(), "AAAT".to_string(), "CCCC".to_string()]
+    )]
+    #[case::paired(
+        crate::assigner::Strategy::Paired,
+        1,
+        vec!["ACT-ACT".to_string(), "ACT-ACT".to_string(), "TGA-TGA".to_string()]
+    )]
+    fn reset_restores_initial_molecule_numbering(
+        #[case] strategy: crate::assigner::Strategy,
+        #[case] edits: u32,
+        #[case] umis: Vec<Umi>,
+    ) {
+        let assigner = strategy.new_assigner_full(edits, 1, 100);
+        let first = assigner.assign(&umis);
+        // Advance the internal counter with an extra batch (no reset here).
+        let _ = assigner.assign(&umis);
+        // Without reset, the reused assigner's ids drift past the first block —
+        // this guards against a no-op `reset()` making the assertion below pass
+        // trivially.
+        let reused = assigner.assign(&umis);
+        assert_ne!(reused, first, "reused assign without reset must advance ids for {strategy:?}");
+        // reset() must restore the initial local numbering, so a reused
+        // (reset) assigner is byte-identical to a fresh one per group.
+        assigner.reset();
+        let after_reset = assigner.assign(&umis);
+        assert_eq!(
+            after_reset, first,
+            "reset() must restore local `0..k` molecule numbering for {strategy:?}"
         );
     }
 

--- a/src/lib/aligner.rs
+++ b/src/lib/aligner.rs
@@ -412,7 +412,7 @@ impl std::fmt::Display for AlignerPreset {
 impl AlignerPreset {
     /// Default binary name (without path) for this preset. Also the
     /// kebab-case CLI value (`bwa`, `bwa-mem3`). Internal helper —
-    /// callers outside this module should use [`Display`] instead.
+    /// callers outside this module should use [`Display`](std::fmt::Display) instead.
     #[must_use]
     pub(crate) fn binary_name(self) -> &'static str {
         match self {
@@ -454,8 +454,13 @@ impl AlignerPreset {
     ///   When `Some`, replaces the preset's default binary name; when
     ///   `None`, the bare binary name is used and the shell resolves it
     ///   via `PATH`.
+    // `pub(crate)`, not `pub`: this interpolates `reference` / `binary_override`
+    // into a string later run via `/bin/bash -c`, and it does not itself validate
+    // those paths — it trusts that `validate` (which runs `check_shell_safe_path`)
+    // was called first. Restricting the method to in-crate callers keeps a direct
+    // external caller from bypassing that validation and injecting shell syntax.
     #[must_use]
-    pub fn build_command(
+    pub(crate) fn build_command(
         self,
         reference: &Path,
         threads: usize,
@@ -641,7 +646,7 @@ pub const DEFAULT_ALIGNER_CHUNK_SIZE: u64 = 150_000_000;
 /// Annotated with `#[multi_options("aligner", "Aligner Options")]` so
 /// `runall` exposes each field as `--aligner::<flag>` via the generated
 /// `MultiAlignerOptions` companion struct. Mutual-exclusion between
-/// `preset` and `command` is enforced inside [`Self::resolve`] rather
+/// `preset` and `command` is enforced inside `Self::resolve` rather
 /// than at clap-parse time — the macro doesn't rewrite clap's
 /// `conflicts_with` field-name references when the prefixed identifiers
 /// shift, so we validate logically after `MultiAlignerOptions::validate`.
@@ -649,9 +654,9 @@ pub const DEFAULT_ALIGNER_CHUNK_SIZE: u64 = 150_000_000;
 /// Field shapes:
 /// - `preset` — `Option<AlignerPreset>` so clap parses it as
 ///   `--aligner::preset {bwa-mem3|bwa}` (no default; if unset and
-///   `command` is also unset, [`Self::resolve`] errors).
+///   `command` is also unset, `Self::resolve` errors).
 /// - `command` — `Option<String>` for the free-form mode.
-/// - `threads` — `Option<usize>` so [`Self::resolve`] can default it
+/// - `threads` — `Option<usize>` so `Self::resolve` can default it
 ///   from `std::thread::available_parallelism()` at runtime (the macro
 ///   can't represent "all cores" as a const default).
 /// - `chunk_size` — `u64` with a const default; drives the `-K` flag
@@ -951,10 +956,12 @@ mod tests {
         proc.wait().expect("process should exit successfully");
     }
 
-    /// Spawn a command that writes to both stdout and stderr; verify
-    /// both are captured.
+    /// Spawn a command that writes to both stdout and stderr; verify the stderr
+    /// relay does not corrupt or interleave into stdout. The stderr ring itself
+    /// is pinned by `test_nonzero_exit_surfaces_stderr`, since `wait()` discards
+    /// the ring on a successful exit.
     #[test]
-    fn test_stderr_capture() {
+    fn test_stderr_does_not_leak_into_stdout() {
         let mut proc = AlignerProcess::spawn("bash -c 'echo err >&2; echo out'", 10)
             .expect("spawn should succeed");
 

--- a/src/lib/aligner.rs
+++ b/src/lib/aligner.rs
@@ -1,0 +1,1409 @@
+//! Aligner subprocess management for the runall `AlignAndMerge` stage.
+//!
+//! Two halves:
+//!
+//! * [`AlignerProcess`] spawns an aligner as a child process via
+//!   `/bin/bash -c <command>` and exposes managed stdin / stdout / stderr
+//!   handles. A background thread continuously drains the child's stderr
+//!   to fgumi's own stderr (so aligner progress / warnings are visible
+//!   live) AND retains the last `ring_size` lines in a ring buffer that
+//!   gets surfaced in the error message if the subprocess exits non-zero.
+//!
+//! * [`AlignerPreset`] builds well-formed aligner shell commands for the
+//!   two presets fgumi knows about (`bwa-mem3`, `bwa`) and validates
+//!   that the reference's index files exist before any input is read.
+//!   For `--aligner::command "..."` users (free-form mode), the
+//!   [`substitute_template`] helper fills the `{ref}` / `{threads}`
+//!   placeholders.
+//!
+//! Used by the `AlignAndMergeStep` in
+//! `src/lib/pipeline/steps/align_and_merge.rs`. This module is the
+//! framework-agnostic subprocess primitive; the typed `Step` impl that owns the
+//! I/O threads lives in that step module.
+
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use clap::Args;
+use fgumi_cli_macros::multi_options;
+
+// ============================================================================
+// AlignerProcess
+// ============================================================================
+
+/// A running aligner subprocess with managed stdin, stdout, and stderr.
+///
+/// The aligner is spawned via `/bin/bash -c`, allowing the command string
+/// to contain pipes, redirects, and other shell constructs. Stderr from
+/// the child process is relayed to fgumi's own stderr in real time, and
+/// the last `ring_size` lines are retained for inclusion in error
+/// messages if the process exits non-zero.
+///
+/// # Drain contract (avoid deadlock)
+///
+/// The child is spawned with all three standard pipes piped. The stderr
+/// pipe is drained automatically by a background thread. Stdin and
+/// stdout, however, are NOT drained by the framework — the caller MUST
+/// arrange to:
+///
+///   * write FASTQ to `take_stdin()`'s handle, then drop it to signal EOF,
+///   * concurrently read SAM/BAM from `take_stdout()`'s handle,
+///
+/// before calling [`Self::wait`]. If the caller writes stdin without
+/// concurrently draining stdout, the kernel's ~64 KB stdout pipe buffer
+/// fills, the aligner blocks on `write`, the caller blocks on `write` to
+/// stdin, and the pipeline deadlocks with no error. The intended caller
+/// is Step 2 of the runall `AlignAndMerge` chain, which spawns paired
+/// reader/writer threads precisely for this reason.
+///
+/// [`Self::wait`] additionally drops any not-yet-taken stdin handle
+/// before waiting so a misuse (caller forgets to take stdin) surfaces
+/// as a fast subprocess exit rather than a hang.
+pub struct AlignerProcess {
+    child: Child,
+    /// The child's stdin pipe, available until [`Self::take_stdin`] is called.
+    stdin: Option<ChildStdin>,
+    /// The child's stdout pipe, available until [`Self::take_stdout`] is called.
+    stdout: Option<ChildStdout>,
+    /// Background thread that relays child stderr; returns the captured ring buffer.
+    stderr_thread: Option<JoinHandle<Vec<String>>>,
+}
+
+impl AlignerProcess {
+    /// Spawn an aligner subprocess with the given shell command.
+    ///
+    /// The command is run via `/bin/bash -c`, so it supports pipes and
+    /// redirects. A background thread is started immediately to relay
+    /// the child's stderr to fgumi's stderr in real time; the last
+    /// `ring_size` lines are captured for failure diagnostics.
+    ///
+    /// # Arguments
+    ///
+    /// * `command`   - Shell command to run (passed to `/bin/bash -c`).
+    /// * `ring_size` - Number of stderr lines to retain for error reporting.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the subprocess cannot be spawned.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the OS does not provide the stderr pipe after
+    /// configuring `Stdio::piped()`, which should never happen in
+    /// practice.
+    pub fn spawn(command: &str, ring_size: usize) -> Result<Self> {
+        let mut child = Command::new("/bin/bash")
+            .args(["-c", command])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .with_context(|| format!("failed to spawn aligner command: {command}"))?;
+
+        let stdin = child.stdin.take();
+        let stdout = child.stdout.take();
+        let child_stderr = child.stderr.take().expect("stderr was configured as piped");
+
+        let stderr_thread = thread::spawn(move || relay_stderr(child_stderr, ring_size));
+
+        Ok(Self { child, stdin, stdout, stderr_thread: Some(stderr_thread) })
+    }
+
+    /// Take the stdin pipe for writing FASTQ data.
+    ///
+    /// Returns `None` if stdin has already been taken. **The caller
+    /// must also drain stdout concurrently (via [`Self::take_stdout`]
+    /// on a separate thread) — otherwise the kernel pipe buffer fills
+    /// and the pipeline deadlocks.** See the struct-level "Drain
+    /// contract" section.
+    pub fn take_stdin(&mut self) -> Option<ChildStdin> {
+        self.stdin.take()
+    }
+
+    /// Take the stdout pipe for reading SAM data.
+    ///
+    /// Returns `None` if stdout has already been taken. **The caller
+    /// must also feed stdin concurrently (via [`Self::take_stdin`] on
+    /// a separate thread) — otherwise the aligner produces no output
+    /// and the reader blocks indefinitely.** See the struct-level
+    /// "Drain contract" section.
+    pub fn take_stdout(&mut self) -> Option<ChildStdout> {
+        self.stdout.take()
+    }
+
+    /// Wait for the aligner process to finish.
+    ///
+    /// Drops any not-yet-taken stdin/stdout handle before waiting — most
+    /// aligners (bwa-mem3, bwa) read stdin until EOF, so an undropped
+    /// stdin would hang the child forever. A caller who legitimately
+    /// wants to feed stdin from a thread should call `take_stdin()`
+    /// first, write+drop in that thread, then call `wait()`.
+    ///
+    /// Joins the stderr relay thread and includes the last captured
+    /// stderr lines in the error message if the process exits with a
+    /// non-zero status.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the process exits with a non-zero status
+    /// code or if waiting on the process fails.
+    pub fn wait(mut self) -> Result<()> {
+        // Close any retained stdin/stdout BEFORE waiting. If a caller
+        // never called `take_stdin()`, the child would block on
+        // `read(0, ...)` forever and `child.wait()` would deadlock.
+        // Dropping signals EOF to the child. Same logic applies to
+        // stdout (less common) — an undrained stdout pipe blocks the
+        // child on write. The intended caller drains both via spawned
+        // threads before calling `wait()`; this is the safety net for
+        // direct / partial use.
+        drop(self.stdin.take());
+        drop(self.stdout.take());
+
+        let status = self.child.wait().context("failed to wait for aligner process")?;
+
+        // Join the stderr relay thread so its resources are cleaned up.
+        // A panic in the relay thread is logged (not silently dropped)
+        // so operators can tell apart "child produced no stderr" from
+        // "our relay died" in the error message.
+        let last_lines = match self.stderr_thread.take().map(JoinHandle::join) {
+            Some(Ok(lines)) => lines,
+            Some(Err(_)) => {
+                log::warn!("aligner stderr relay thread panicked; captured ring may be incomplete");
+                Vec::new()
+            }
+            None => Vec::new(),
+        };
+
+        if !status.success() {
+            let code = status.code().map_or_else(|| "signal".to_string(), |c| c.to_string());
+            let tail = if last_lines.is_empty() {
+                "(no stderr captured)".to_string()
+            } else {
+                last_lines.join("\n")
+            };
+            bail!("aligner process exited with status {code}. Last stderr lines:\n{tail}");
+        }
+
+        Ok(())
+    }
+
+    /// Kill the aligner process.
+    ///
+    /// Sends SIGKILL immediately (`Child::kill()` always sends SIGKILL
+    /// on Unix). Waits up to 1 second for the process to exit.
+    ///
+    /// Returns `true` if the child was reaped within the 1s deadline (or was
+    /// already gone), and `false` if it was still running when the deadline
+    /// expired (i.e. stuck, e.g. in uninterruptible I/O). Callers MUST honor a
+    /// `false` return by NOT issuing a subsequent unbounded [`wait`](Self::wait)
+    /// on the child, which would re-introduce the very teardown hang this
+    /// bounded kill exists to prevent.
+    pub fn kill(&mut self) -> bool {
+        let pid = self.child.id();
+        let _ = self.child.kill();
+
+        // Wait for the process to actually exit so its resources are cleaned up.
+        let deadline = std::time::Instant::now() + Duration::from_secs(1);
+        // Tracks whether the loop gave up because the 1s deadline elapsed while
+        // the process was still alive. Only that case warrants the leak warning.
+        let mut deadline_exceeded = false;
+        // Set only when exit is *positively confirmed*: a clean reap
+        // (`Ok(Some)`) or an `ECHILD` error (already reaped by a SIGCHLD
+        // handler). A deadline timeout or an unclassified `try_wait` errno
+        // leaves this `false`, so the caller must NOT follow up with an
+        // unbounded `wait()`.
+        let mut reaped = false;
+        loop {
+            match self.child.try_wait() {
+                // Reaped cleanly: resources cleaned up, no warning.
+                Ok(Some(_)) => {
+                    reaped = true;
+                    break;
+                }
+                // Still alive: keep polling until the deadline.
+                Ok(None) => {
+                    if std::time::Instant::now() >= deadline {
+                        deadline_exceeded = true;
+                        break;
+                    }
+                    thread::sleep(Duration::from_millis(50));
+                }
+                // `try_wait` failed. `ECHILD` (the child was already reaped,
+                // e.g. by a SIGCHLD handler) is a benign non-leak that confirms
+                // exit. Any *other* errno is unexpected — the process may still
+                // be around — so we do NOT report it as reaped; we cannot make
+                // progress on a `try_wait` error either way, so stop polling.
+                Err(err) => {
+                    if is_already_reaped(&err) {
+                        log::debug!(
+                            "aligner process (pid {pid}) try_wait returned ECHILD after \
+                             SIGKILL; already reaped"
+                        );
+                        reaped = true;
+                    } else {
+                        log::warn!(
+                            "aligner process (pid {pid}) try_wait failed after SIGKILL: {err}; \
+                             unable to confirm exit, treating as not reaped"
+                        );
+                    }
+                    break;
+                }
+            }
+        }
+        if deadline_exceeded {
+            log::warn!(
+                "aligner process (pid {pid}) did not exit within 1s of SIGKILL; it may be \
+                 stuck (e.g. uninterruptible I/O) and left unreaped"
+            );
+        }
+        // Report reaped only when exit was positively confirmed (clean reap or
+        // `ECHILD`). A timeout on a still-running child or an unclassified
+        // `try_wait` errno reports `false` so the caller avoids a follow-up
+        // unbounded `wait()`.
+        reaped
+    }
+
+    /// Return the process ID of the aligner child process.
+    #[must_use]
+    pub fn pid(&self) -> u32 {
+        self.child.id()
+    }
+}
+
+/// `ECHILD` errno. POSIX assigns it the value 10 on every Unix fgumi runs an
+/// external aligner on (Linux, macOS, the BSDs); `std::io` exposes no
+/// `ErrorKind` for it, and `nix`/`libc` are not available on all targets here,
+/// so we match the raw errno directly. On non-Unix targets nothing returns this
+/// value, so [`is_already_reaped`] simply never matches — the conservative
+/// "not confirmed reaped" default.
+const ECHILD: i32 = 10;
+
+/// Whether a `try_wait` error means the child was *already reaped* (and so its
+/// exit is confirmed). Only `ECHILD` qualifies — it is what the OS returns once
+/// a SIGCHLD handler (or a prior wait) has already collected the child. Any
+/// other errno is unexpected and must NOT be treated as a confirmed exit.
+fn is_already_reaped(err: &std::io::Error) -> bool {
+    err.raw_os_error() == Some(ECHILD)
+}
+
+impl Drop for AlignerProcess {
+    fn drop(&mut self) {
+        // Determine whether the child's exit is *confirmed*. Only then is it
+        // safe to join the stderr relay thread: that thread blocks reading the
+        // child's stderr fd, which stays open while the child lives, so joining
+        // a still-alive child would hang teardown forever — the very hang the
+        // bounded `kill()` exists to prevent.
+        let exit_confirmed = match self.child.try_wait() {
+            // Already exited: stderr fd is closed, relay will finish.
+            Ok(Some(_)) => true,
+            // Still running: kill() reports `true` only on a confirmed reap
+            // (clean exit or ECHILD); `false` means it may still be alive.
+            Ok(None) => self.kill(),
+            // `try_wait` errored. ECHILD (already reaped) confirms exit. For any
+            // other errno the child may still be alive, so fall back to the
+            // bounded `kill()` — returning `is_already_reaped` alone here would
+            // drop the handle without ever attempting SIGKILL and leak the
+            // subprocess. `kill()` re-classifies ECHILD as a confirmed reap.
+            Err(err) => {
+                if is_already_reaped(&err) {
+                    true
+                } else {
+                    log::warn!(
+                        "aligner process (pid {}) try_wait failed in Drop: {err}; \
+                         attempting bounded kill",
+                        self.child.id()
+                    );
+                    self.kill()
+                }
+            }
+        };
+        // Join the stderr relay only when exit is confirmed. If the child could
+        // not be confirmed dead (kill timed out / unclassified errno), skip the
+        // join: leaking a detached relay thread is the lesser evil versus
+        // hanging Drop indefinitely on a still-open stderr fd.
+        if let Some(handle) = self.stderr_thread.take()
+            && exit_confirmed
+        {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Read lines from `stderr`, print each to fgumi's stderr, and retain
+/// the last `ring_size` lines in a [`VecDeque`] ring buffer.
+///
+/// Returns the captured lines when the child closes its stderr fd.
+fn relay_stderr(stderr: impl std::io::Read, ring_size: usize) -> Vec<String> {
+    let mut reader = BufReader::new(stderr);
+    let mut ring: VecDeque<String> = VecDeque::with_capacity(ring_size);
+    let mut buf: Vec<u8> = Vec::new();
+
+    // Byte-oriented drain: `BufRead::lines()` yields `Err` on a non-UTF-8 line,
+    // and breaking on it would STOP draining the aligner's stderr — the aligner
+    // then blocks once its stderr pipe fills (~64 KiB) and the whole align
+    // pipeline deadlocks. Read raw lines and decode lossily so invalid UTF-8
+    // never halts the relay.
+    loop {
+        buf.clear();
+        match reader.read_until(b'\n', &mut buf) {
+            // EOF (child closed stderr) or an unrecoverable pipe read error:
+            // stop draining either way.
+            Ok(0) | Err(_) => break,
+            Ok(_) => {}
+        }
+        // Strip the line terminator to match `lines()` semantics.
+        if buf.last() == Some(&b'\n') {
+            buf.pop();
+            if buf.last() == Some(&b'\r') {
+                buf.pop();
+            }
+        }
+        let line = String::from_utf8_lossy(&buf).into_owned();
+        eprintln!("{line}");
+        if ring_size > 0 {
+            if ring.len() == ring_size {
+                ring.pop_front();
+            }
+            ring.push_back(line);
+        }
+    }
+
+    ring.into_iter().collect()
+}
+
+// ============================================================================
+// AlignerPreset
+// ============================================================================
+
+/// Preset aligner configurations with command-building and index validation.
+///
+/// Two presets at landing — `bwa-mem3` (the project's primary aligner)
+/// and `bwa` (legacy reference). Methylation-aware presets (e.g.
+/// `bwameth`, `bwa-mem3 --methylation-mode em-seq`) are a follow-up;
+/// EM-seq users today route through `--aligner::command "..."`
+/// (free-form mode) instead of a preset.
+///
+/// The CLI value for each variant matches the on-disk binary name
+/// (`bwa`, `bwa-mem3`). Variant identifiers (`Bwa`, `BwaMem3`) are
+/// chosen so `rename_all = "kebab-case"` round-trips through the
+/// identifier ↔ binary-name mapping without divergence: `Bwa` ↔
+/// `"bwa"`, `BwaMem3` ↔ `"bwa-mem3"`. `Display` emits the same
+/// strings so error messages match what the user typed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+pub enum AlignerPreset {
+    /// Classic BWA aligner (`bwa mem`). CLI value: `bwa`.
+    Bwa,
+    /// BWA-MEM3 aligner (`bwa-mem3 mem`). CLI value: `bwa-mem3`.
+    BwaMem3,
+}
+
+impl std::fmt::Display for AlignerPreset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.binary_name())
+    }
+}
+
+impl AlignerPreset {
+    /// Default binary name (without path) for this preset. Also the
+    /// kebab-case CLI value (`bwa`, `bwa-mem3`). Internal helper —
+    /// callers outside this module should use [`Display`] instead.
+    #[must_use]
+    pub(crate) fn binary_name(self) -> &'static str {
+        match self {
+            Self::Bwa => "bwa",
+            Self::BwaMem3 => "bwa-mem3",
+        }
+    }
+
+    /// Index file extensions this preset requires alongside the reference
+    /// FASTA. All must be present for `validate` to succeed.
+    #[must_use]
+    pub(crate) fn index_extensions(self) -> &'static [&'static str] {
+        match self {
+            // BWA classic: amb / ann / bwt / pac / sa
+            Self::Bwa => &[".amb", ".ann", ".bwt", ".pac", ".sa"],
+            // BWA-MEM3: amb / ann / bwt.2bit.64 / pac. `bwa-mem3 0.4.0+` pac-fetches
+            // the reference from `.pac` on demand and no longer writes `.0123` by
+            // default (fg-labs/bwa-mem3#177); `.0123` is now opt-in via `index
+            // --emit-unpacked-ref` and `mem` ignores any present, so requiring it
+            // here rejects a valid 0.4.0 index. `.bwt.2bit.64` is the canonical
+            // index sentinel. Indexes built by older bwa-mem3 still carry these
+            // four files, so dropping `.0123` is backward-compatible.
+            Self::BwaMem3 => &[".amb", ".ann", ".bwt.2bit.64", ".pac"],
+        }
+    }
+
+    /// Build the aligner shell command for this preset.
+    ///
+    /// The command reads FASTQ from `/dev/stdin` and writes SAM to
+    /// stdout, allowing it to be connected to fgumi's pipeline via
+    /// stdin/stdout pipes.
+    ///
+    /// # Arguments
+    ///
+    /// * `reference` - Path to the reference FASTA (index must already exist).
+    /// * `threads` - Number of threads to pass to the aligner (`-t`).
+    /// * `chunk_size` - Chunk size in bases to pass to the aligner (`-K`).
+    /// * `binary_override` - Optional explicit path to the aligner binary.
+    ///   When `Some`, replaces the preset's default binary name; when
+    ///   `None`, the bare binary name is used and the shell resolves it
+    ///   via `PATH`.
+    #[must_use]
+    pub fn build_command(
+        self,
+        reference: &Path,
+        threads: usize,
+        chunk_size: u64,
+        binary_override: Option<&Path>,
+    ) -> String {
+        let binary = match binary_override {
+            Some(path) => path.display().to_string(),
+            None => self.binary_name().to_string(),
+        };
+        let ref_str = reference.display();
+        format!("{binary} mem -p -K {chunk_size} -t {threads} {ref_str} /dev/stdin")
+    }
+
+    /// Validate that the aligner binary and required index files are present.
+    ///
+    /// Checks, in order:
+    /// 1. The reference FASTA itself exists (so a typo in `--ref`
+    ///    surfaces with a clean error rather than "index file not
+    ///    found").
+    /// 2. The reference path does not contain shell-unsafe characters
+    ///    (preset mode hands the path through `/bin/bash -c`, so a
+    ///    path like `/data/my refs/genome.fa` would be word-split into
+    ///    two arguments).
+    /// 3. The aligner binary is reachable: `--aligner-bin` override
+    ///    path (must be an existing file), else `which::which("<binary_name>")`
+    ///    on `PATH`. `--aligner-bin` paths are also checked for
+    ///    shell-unsafe characters.
+    /// 4. All expected index file(s) exist alongside the reference.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error with a fix-it hint if any of the above fail.
+    pub fn validate(self, reference: &Path, binary_override: Option<&Path>) -> Result<()> {
+        let binary_name = self.binary_name();
+
+        // 1. Reference FASTA presence (separated from the index-loop
+        //    error so users see "ref doesn't exist" before "index
+        //    missing" when the path is wrong).
+        if !reference.is_file() {
+            bail!(
+                "reference FASTA not found or not a regular file: {} \
+                 (preset `{binary_name}` requires the FASTA + its index files)",
+                reference.display()
+            );
+        }
+
+        // 2. Reference path shell-safety (preset mode argv flows through
+        //    /bin/bash -c, so paths with spaces, quotes, or shell metas
+        //    silently break).
+        check_shell_safe_path(reference, "--ref")?;
+
+        // 3. Binary discovery.
+        match binary_override {
+            Some(path) => {
+                check_shell_safe_path(path, "--aligner-bin")?;
+                if !path.is_file() {
+                    bail!(
+                        "--aligner-bin path is not a regular file: {} \
+                         (preset `{binary_name}` requires the binary)",
+                        path.display()
+                    );
+                }
+                // Verify executability up front so the failure stays
+                // actionable here, instead of being deferred until
+                // `/bin/bash -c` tries to exec the path.
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    let mode = std::fs::metadata(path)
+                        .with_context(|| {
+                            format!("reading metadata for --aligner-bin path: {}", path.display())
+                        })?
+                        .permissions()
+                        .mode();
+                    if mode & 0o111 == 0 {
+                        bail!(
+                            "--aligner-bin path is not executable: {} \
+                             (preset `{binary_name}` requires an executable binary; \
+                             `chmod +x` it or pass a different path)",
+                            path.display()
+                        );
+                    }
+                }
+            }
+            None => {
+                which::which(binary_name).with_context(|| {
+                    format!(
+                        "aligner binary `{binary_name}` not found on PATH \
+                         (preset `{binary_name}`; pass --aligner-bin <path> to override)"
+                    )
+                })?;
+            }
+        }
+
+        // 4. Index files for the chosen preset.
+        for ext in self.index_extensions() {
+            let index_path = append_extension(reference, ext);
+            if !index_path.is_file() {
+                bail!(
+                    "required index file not found: {} (run `{binary_name} index {}`)",
+                    index_path.display(),
+                    reference.display()
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Command-mode template substitution
+// ============================================================================
+
+/// Substitute `{ref}` and `{threads}` placeholders in a free-form
+/// aligner command template.
+///
+/// Used by `--aligner::command "..."` (command mode) to fill in the
+/// reference path and thread count from runall's `--ref` / `--threads`
+/// flags before the command is handed to `/bin/bash -c`.
+///
+/// Substitution is literal text replacement — there is no shell
+/// escaping. A user who wants to put a literal `{ref}` in their
+/// command must work around the collision themselves.
+///
+/// # Errors
+///
+/// Returns an error if `template` does not contain `{ref}` — without
+/// a reference path the aligner has nothing to align against and
+/// would fail at run time with a less-clear error.
+pub fn substitute_template(template: &str, reference: &Path, threads: usize) -> Result<String> {
+    if !template.contains("{ref}") {
+        bail!(
+            "--aligner::command template does not contain `{{ref}}`; \
+             the aligner needs a reference path. Example: \
+             \"bwa-mem3 mem -p -K 150000000 -t {{threads}} {{ref}} /dev/stdin\""
+        );
+    }
+    // Single left-to-right pass so injected text is never re-scanned. Two
+    // sequential `str::replace` calls would corrupt a reference path that
+    // literally contains `{threads}`: the `{ref}` pass injects it, then the
+    // `{threads}` pass rewrites the path's own `{threads}` into the thread
+    // count. Consuming each placeholder exactly once and never re-examining
+    // emitted text closes that collision in both directions.
+    let ref_str = reference.display().to_string();
+    let threads_str = threads.to_string();
+    let mut out = String::with_capacity(template.len());
+    let mut rest = template;
+    while !rest.is_empty() {
+        if let Some(after) = rest.strip_prefix("{ref}") {
+            out.push_str(&ref_str);
+            rest = after;
+        } else if let Some(after) = rest.strip_prefix("{threads}") {
+            out.push_str(&threads_str);
+            rest = after;
+        } else {
+            let mut chars = rest.chars();
+            // `rest` is non-empty (loop guard), so `next()` is always `Some`;
+            // the `None` arm is unreachable but keeps this panic-free.
+            match chars.next() {
+                Some(c) => out.push(c),
+                None => break,
+            }
+            rest = chars.as_str();
+        }
+    }
+    Ok(out)
+}
+
+// ============================================================================
+// AlignerOptions — runall CLI surface
+// ============================================================================
+
+/// Default chunk size in bases per aligner batch (`-K` flag). Matches the
+/// `bwa mem -K` examples in the bwa-mem3 documentation; large enough that
+/// the aligner sees full batches but small enough that ~2 batches in
+/// flight fit in a few GB of RAM.
+pub const DEFAULT_ALIGNER_CHUNK_SIZE: u64 = 150_000_000;
+
+/// Per-stage aligner tuning knobs.
+///
+/// Annotated with `#[multi_options("aligner", "Aligner Options")]` so
+/// `runall` exposes each field as `--aligner::<flag>` via the generated
+/// `MultiAlignerOptions` companion struct. Mutual-exclusion between
+/// `preset` and `command` is enforced inside [`Self::resolve`] rather
+/// than at clap-parse time — the macro doesn't rewrite clap's
+/// `conflicts_with` field-name references when the prefixed identifiers
+/// shift, so we validate logically after `MultiAlignerOptions::validate`.
+///
+/// Field shapes:
+/// - `preset` — `Option<AlignerPreset>` so clap parses it as
+///   `--aligner::preset {bwa-mem3|bwa}` (no default; if unset and
+///   `command` is also unset, [`Self::resolve`] errors).
+/// - `command` — `Option<String>` for the free-form mode.
+/// - `threads` — `Option<usize>` so [`Self::resolve`] can default it
+///   from `std::thread::available_parallelism()` at runtime (the macro
+///   can't represent "all cores" as a const default).
+/// - `chunk_size` — `u64` with a const default; drives the `-K` flag
+///   in preset mode and the Step-1 batch size in both modes.
+#[multi_options("aligner", "Aligner Options")]
+#[derive(Args, Debug, Clone)]
+pub struct AlignerOptions {
+    /// Named aligner preset. Mutually exclusive with `--aligner::command`.
+    #[arg(long = "preset", value_enum)]
+    pub preset: Option<AlignerPreset>,
+
+    /// Free-form aligner command template. Supports `{ref}` and
+    /// `{threads}` placeholders. Mutually exclusive with
+    /// `--aligner::preset` and every other `--aligner::*` flag.
+    #[arg(long = "command")]
+    pub command: Option<String>,
+
+    /// Thread count passed to the aligner via `-t` (preset mode only).
+    /// Defaults to runall's top-level `--threads` value when unset.
+    /// The aligner uses these threads concurrently with the rest of
+    /// the AAM pipeline; oversubscription is the OS scheduler's
+    /// problem.
+    #[arg(long = "threads")]
+    pub threads: Option<usize>,
+
+    /// Bases per aligner batch (preset mode `-K` flag; also drives the
+    /// Step-1 batch size in both modes).
+    #[arg(long = "chunk-size", default_value_t = DEFAULT_ALIGNER_CHUNK_SIZE)]
+    pub chunk_size: u64,
+}
+
+/// Hand-rolled `Default` impl. **Must** match each field's clap
+/// `default_value_t` exactly: the `multi_options` macro emits
+/// `default_value_t = AlignerOptions::default().<field>` on the
+/// generated `MultiAlignerOptions`, so a `#[derive(Default)]` here
+/// would set `chunk_size = 0` and propagate that as `--aligner::chunk-size
+/// [default: 0]` — and from there as `bwa-mem3 -K 0` at runtime. The
+/// macro's smoke tests document this trap explicitly; this impl is
+/// the antidote.
+impl Default for AlignerOptions {
+    fn default() -> Self {
+        Self { preset: None, command: None, threads: None, chunk_size: DEFAULT_ALIGNER_CHUNK_SIZE }
+    }
+}
+
+/// Result of [`AlignerOptions::resolve`] — a ready-to-spawn aligner
+/// invocation plus the parameters the downstream chain needs.
+///
+/// `pub(crate)` because only the runall AAM dispatch consumes it;
+/// promote to `pub` if a cross-crate caller materializes.
+///
+/// Every field is read when the chain builder wires the AAM stage
+/// (`chains/builder.rs`): `command` seeds `AlignAndMergeStep`, `chunk_size`
+/// derives the step's `in_flight_unmapped_budget` (via
+/// `in_flight_budget_for_chunk_size`), and `mode`/`threads` are info-logged.
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedAligner {
+    /// The shell command to spawn (already substituted and validated).
+    /// Passed directly to [`AlignerProcess::spawn`].
+    pub command: String,
+    /// The aligner's `-K` chunk size, in bases. The chain builder converts
+    /// it into `AlignAndMergeStep`'s `in_flight_unmapped_budget` so the
+    /// resident unmapped backlog stays proportional to one aligner chunk.
+    pub chunk_size: u64,
+    /// Resolved thread count (default-substituted for preset mode;
+    /// `None` if command mode let the user hardcode their own).
+    pub threads: Option<usize>,
+    /// Which mode produced this — preset (with which preset) or
+    /// command. Used in info-logging.
+    pub mode: ResolvedAlignerMode,
+}
+
+/// How a [`ResolvedAligner`] was produced. The AAM chain builder logs the mode
+/// (`chains/builder.rs`), so the `Preset` payload is consumed only through the
+/// derived `Debug` — the `allow(dead_code)` suppresses the never-read lint,
+/// which fires for a field read solely via a derived trait.
+#[allow(dead_code)] // `Preset`'s payload is diagnostic-only (Debug-logged).
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ResolvedAlignerMode {
+    /// `--aligner::preset <preset>`. Carries the chosen preset so the
+    /// caller can log it.
+    Preset(AlignerPreset),
+    /// `--aligner::command "..."`.
+    Command,
+}
+
+impl AlignerOptions {
+    /// Validate the option combination and produce a [`ResolvedAligner`]
+    /// ready for [`AlignerProcess::spawn`].
+    ///
+    /// # Arguments
+    ///
+    /// * `reference` - From `runall --ref`. Required in both modes.
+    /// * `top_threads` - From `runall --threads`. Used as the preset
+    ///   default if `--aligner::threads` is unset.
+    /// * `aligner_bin` - From `runall --aligner-bin`. Preset-mode-only
+    ///   binary override; must be `None` in command mode (rejected
+    ///   here with a clear error).
+    ///
+    /// # Errors
+    ///
+    /// - Neither `--aligner::preset` nor `--aligner::command` was set.
+    /// - Both were set (mutual exclusion violation).
+    /// - Command mode + a preset-only flag (`--aligner-bin` or
+    ///   `--aligner::threads`).
+    /// - Command mode template missing `{ref}`.
+    /// - Preset-mode index files / binary missing (delegated to
+    ///   [`AlignerPreset::validate`]).
+    pub(crate) fn resolve(
+        self,
+        reference: &Path,
+        top_threads: usize,
+        aligner_bin: Option<&Path>,
+    ) -> Result<ResolvedAligner> {
+        // A zero chunk size reaches the aligner as `-K 0` in preset mode and
+        // zeroes the pipeline's in-flight unmapped budget in both modes;
+        // attribute the failure to the flag rather than to a cryptic aligner
+        // error downstream.
+        if self.chunk_size == 0 {
+            bail!(
+                "--aligner::chunk-size must be greater than 0 (got 0); it sets the \
+                 aligner's -K batch size and the pipeline's in-flight unmapped budget"
+            );
+        }
+        match (self.preset, self.command) {
+            (None, None) => bail!(
+                "--start-from align requires one of `--aligner::preset` \
+                 (e.g. bwa-mem3, bwa) or `--aligner::command \"...\"`"
+            ),
+            (Some(_), Some(_)) => bail!(
+                "--aligner::preset and --aligner::command are mutually exclusive; \
+                 pass only one"
+            ),
+            (Some(preset), None) => {
+                // Preset mode: validate indexes + binary, build argv.
+                preset.validate(reference, aligner_bin)?;
+                // An explicit `--aligner::threads 0` would reach the aligner as
+                // `-t 0`. `None` means "default to runall's --threads" (not
+                // zero), so only reject an explicit zero.
+                if self.threads == Some(0) {
+                    bail!("--aligner::threads must be greater than 0 (got 0)");
+                }
+                let threads = self.threads.unwrap_or(top_threads);
+                let command =
+                    preset.build_command(reference, threads, self.chunk_size, aligner_bin);
+                Ok(ResolvedAligner {
+                    command,
+                    chunk_size: self.chunk_size,
+                    threads: Some(threads),
+                    mode: ResolvedAlignerMode::Preset(preset),
+                })
+            }
+            (None, Some(template)) => {
+                // Command mode: only `--aligner-bin` and
+                // `--aligner::threads` are preset-only knobs; rejecting
+                // them surfaces the misuse loud.
+                //
+                // `--aligner::chunk-size` is NOT preset-only — the chain
+                // builder derives the AAM step's
+                // `in_flight_unmapped_budget` from it regardless of mode
+                // (see `in_flight_budget_for_chunk_size`), and
+                // command-mode users may legitimately want to align it
+                // with their `-K` choice in the template.
+                if aligner_bin.is_some() {
+                    bail!(
+                        "--aligner-bin is only valid with --aligner::preset; \
+                         pass the binary path inside --aligner::command \"...\" instead"
+                    );
+                }
+                if self.threads.is_some() {
+                    bail!(
+                        "--aligner::threads is only valid with --aligner::preset; \
+                         hardcode the thread count in --aligner::command \"...\" \
+                         or use the `{{threads}}` placeholder"
+                    );
+                }
+                // Substitute {ref} / {threads}. {ref} is required;
+                // {threads} is optional in command mode (the user may
+                // hardcode any thread count).
+                let command = substitute_template(&template, reference, top_threads)?;
+                Ok(ResolvedAligner {
+                    command,
+                    chunk_size: self.chunk_size,
+                    threads: None,
+                    mode: ResolvedAlignerMode::Command,
+                })
+            }
+        }
+    }
+}
+
+/// Append a suffix to a path without replacing the existing extension.
+///
+/// For example, `append_extension("/ref/genome.fa", ".bwt")` →
+/// `/ref/genome.fa.bwt`.
+fn append_extension(path: &Path, suffix: &str) -> PathBuf {
+    let mut s = path.as_os_str().to_owned();
+    s.push(suffix);
+    PathBuf::from(s)
+}
+
+/// Reject paths containing characters that bash interprets specially
+/// inside an unquoted command argument. Used by preset-mode `validate`
+/// — the argv it builds is interpolated into `/bin/bash -c "..."` so
+/// any whitespace, quote, or metacharacter would break word-splitting.
+///
+/// The check is conservative: we allow only `[A-Za-z0-9_./:-]` plus
+/// non-ASCII (UTF-8 bytes that aren't whitespace or metas). `:` is
+/// permitted because it is not a shell metacharacter in argument position
+/// (it only matters to bash inside parameter expansions / as the `PATH`
+/// separator, neither of which applies to an interpolated argv word).
+/// Users with paths outside this set can switch to `--aligner::command
+/// "..."` (free-form mode), where they own the quoting.
+///
+/// `flag_label` is interpolated into the error message so the user
+/// sees which flag they need to clean up.
+fn check_shell_safe_path(path: &Path, flag_label: &str) -> Result<()> {
+    let s = path.to_string_lossy();
+    // A leading '-' makes the interpolated word look like a flag to the aligner
+    // (e.g. `-genome.fa` parsed as an option). The per-character allowlist below
+    // permits '-' (it is legal mid-path), so guard the leading position here.
+    if s.starts_with('-') {
+        bail!(
+            "{flag_label} path {:?} starts with '-', which the aligner would parse \
+             as a flag; prefix it with `./` or use `--aligner::command \"...\"` \
+             (free-form mode) instead.",
+            path.display().to_string()
+        );
+    }
+    for ch in s.chars() {
+        let safe = ch.is_alphanumeric()
+            || matches!(ch, '_' | '.' | '/' | '-' | ':')
+            || (!ch.is_ascii() && !ch.is_whitespace());
+        if !safe {
+            bail!(
+                "{flag_label} path {:?} contains a shell-unsafe character ({ch:?}); \
+                 preset-mode commands flow through `/bin/bash -c` and cannot safely \
+                 handle this path. Use `--aligner::command \"...\"` (free-form mode, \
+                 with your own quoting) for paths with spaces or shell metacharacters.",
+                path.display().to_string()
+            );
+        }
+    }
+    Ok(())
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+
+    use rstest::rstest;
+
+    use super::*;
+
+    /// A non-UTF-8 stderr line must NOT halt the relay: draining has to
+    /// continue to EOF, otherwise the aligner blocks once its stderr pipe fills
+    /// (~64 KiB) and the whole align pipeline deadlocks. Regression test for the
+    /// `lines()`-breaks-on-invalid-UTF-8 hang.
+    #[test]
+    fn relay_stderr_keeps_draining_past_non_utf8_line() {
+        let mut data: Vec<u8> = Vec::new();
+        data.extend_from_slice(b"first line\n");
+        data.extend_from_slice(&[0xff, 0xfe, b'\n']); // invalid UTF-8 line
+        data.extend_from_slice(b"third line\n");
+
+        let ring = relay_stderr(std::io::Cursor::new(data), 8);
+
+        // All three lines were read (the invalid one lossily decoded), proving
+        // the drain continued past the bad line to EOF.
+        assert_eq!(ring.len(), 3, "drain must not stop at the non-UTF-8 line");
+        assert_eq!(ring[0], "first line");
+        // Pin the "lossily decoded" claim itself: 0xff and 0xfe are each individually
+        // ill-formed in UTF-8 (never a valid lead or continuation byte), so
+        // `String::from_utf8_lossy` emits one U+FFFD per byte — the bad bytes are
+        // replaced, not dropped.
+        assert_eq!(
+            ring[1], "\u{FFFD}\u{FFFD}",
+            "invalid bytes must be lossily decoded, not dropped"
+        );
+        assert_eq!(ring[2], "third line");
+    }
+
+    /// Spawn a simple `echo` command and verify that stdout can be read.
+    #[test]
+    fn test_spawn_echo() {
+        let mut proc = AlignerProcess::spawn("echo hello", 10).expect("spawn should succeed");
+        let mut stdout = proc.take_stdout().expect("stdout should be available");
+
+        let mut output = String::new();
+        stdout.read_to_string(&mut output).expect("should read stdout");
+        assert_eq!(output.trim(), "hello");
+
+        proc.wait().expect("process should exit successfully");
+    }
+
+    /// Spawn a command that writes to both stdout and stderr; verify
+    /// both are captured.
+    #[test]
+    fn test_stderr_capture() {
+        let mut proc = AlignerProcess::spawn("bash -c 'echo err >&2; echo out'", 10)
+            .expect("spawn should succeed");
+
+        let mut stdout = proc.take_stdout().expect("stdout should be available");
+        let mut stdout_buf = String::new();
+        stdout.read_to_string(&mut stdout_buf).expect("should read stdout");
+        assert_eq!(stdout_buf.trim(), "out");
+
+        proc.wait().expect("process should exit successfully");
+    }
+
+    /// Spawn a command that exits with a non-zero status and verify
+    /// that `wait` returns an error containing the captured stderr.
+    #[test]
+    fn test_nonzero_exit_surfaces_stderr() {
+        let proc = AlignerProcess::spawn("bash -c 'echo oh-no >&2; exit 1'", 10).expect("spawn ok");
+        let result = proc.wait();
+        assert!(result.is_err(), "wait() should return Err for non-zero exit");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("status"), "error message should mention status: {msg}");
+        assert!(msg.contains("oh-no"), "error should include stderr ring: {msg}");
+    }
+
+    /// Verify that stdin can be written to and the subprocess reads it.
+    #[test]
+    fn test_stdin_write() {
+        let mut proc = AlignerProcess::spawn("bash -c 'cat'", 10).expect("spawn should succeed");
+        let mut stdin = proc.take_stdin().expect("stdin should be available");
+        let mut stdout = proc.take_stdout().expect("stdout should be available");
+
+        stdin.write_all(b"hello pipe\n").expect("should write to stdin");
+        drop(stdin); // close stdin so the child process can exit
+
+        let mut output = String::new();
+        stdout.read_to_string(&mut output).expect("should read stdout");
+        assert_eq!(output.trim(), "hello pipe");
+
+        proc.wait().expect("process should exit successfully");
+    }
+
+    /// `kill()` reports `true` when the child is reaped within the deadline.
+    /// A plain `sleep` responds to SIGKILL immediately, so the bounded kill
+    /// reaps it well inside the 1s window — and a `true` return is what lets
+    /// `AlignAndMergeStep::Drop` safely issue its follow-up `wait()` without
+    /// risking a teardown hang.
+    #[test]
+    fn test_kill_reports_reaped_for_killable_child() {
+        let mut proc = AlignerProcess::spawn("sleep 30", 10).expect("spawn should succeed");
+        assert!(proc.kill(), "a killable child must be reaped within the deadline");
+        // A second kill on an already-gone child still reports reaped, never
+        // a spurious timeout.
+        assert!(proc.kill(), "killing an already-reaped child must still report reaped");
+    }
+
+    /// `is_already_reaped` confirms exit only for `ECHILD`. An unrelated errno
+    /// (e.g. `EINVAL`) must NOT be treated as a confirmed reap, so `kill()`
+    /// reports `false` and the caller avoids a follow-up unbounded `wait()`.
+    #[test]
+    fn test_is_already_reaped_only_for_echild() {
+        let echild = std::io::Error::from_raw_os_error(ECHILD);
+        assert!(is_already_reaped(&echild), "ECHILD must count as already reaped");
+
+        // EINVAL (22) stands in for any unrelated errno: it must NOT count.
+        let einval = std::io::Error::from_raw_os_error(22);
+        assert!(!is_already_reaped(&einval), "an unrelated errno must not count as reaped");
+
+        // A non-OS error (no errno at all) is likewise not a confirmed reap.
+        let not_os = std::io::Error::other("synthetic non-os error");
+        assert!(!is_already_reaped(&not_os), "a non-OS error must not count as reaped");
+    }
+
+    /// Preset command strings with the default-PATH binary (bare binary name,
+    /// resolved by the shell via `PATH`).
+    #[rstest]
+    #[case::bwa(
+        AlignerPreset::Bwa,
+        8,
+        10_000_000,
+        "bwa mem -p -K 10000000 -t 8 /ref/genome.fa /dev/stdin"
+    )]
+    #[case::bwa_mem3(
+        AlignerPreset::BwaMem3,
+        4,
+        5_000_000,
+        "bwa-mem3 mem -p -K 5000000 -t 4 /ref/genome.fa /dev/stdin"
+    )]
+    fn preset_build_command_default_binary(
+        #[case] preset: AlignerPreset,
+        #[case] threads: usize,
+        #[case] chunk_size: u64,
+        #[case] expected: &str,
+    ) {
+        let reference = Path::new("/ref/genome.fa");
+        let cmd = preset.build_command(reference, threads, chunk_size, None);
+        assert_eq!(cmd, expected);
+    }
+
+    /// `--aligner-bin` override replaces the bare binary name.
+    #[test]
+    fn test_build_command_with_binary_override() {
+        let reference = Path::new("/data/hg38.fa");
+        let override_path = PathBuf::from("/opt/bwa-mem3-2.2.1/bwa-mem3");
+        let cmd =
+            AlignerPreset::BwaMem3.build_command(reference, 16, 100_000, Some(&override_path));
+        assert!(cmd.contains("/opt/bwa-mem3-2.2.1/bwa-mem3"), "override binary not in cmd: {cmd}");
+        assert!(!cmd.starts_with("bwa-mem3 "), "bare name should not appear: {cmd}");
+    }
+
+    /// `index_extensions` shape per preset.
+    #[test]
+    fn test_index_extensions() {
+        assert_eq!(AlignerPreset::Bwa.index_extensions(), &[".amb", ".ann", ".bwt", ".pac", ".sa"]);
+        // `bwa-mem3 0.4.0+` no longer writes `.0123` (fg-labs/bwa-mem3#177), so it
+        // is not a required index file.
+        assert_eq!(
+            AlignerPreset::BwaMem3.index_extensions(),
+            &[".amb", ".ann", ".bwt.2bit.64", ".pac"]
+        );
+    }
+
+    /// `AlignerPreset` CLI parsing — both kebab-case variants
+    /// (`bwa`, `bwa-mem3`) round-trip cleanly through `clap::ValueEnum`.
+    #[test]
+    fn test_aligner_preset_parses() {
+        use clap::ValueEnum;
+        assert_eq!(AlignerPreset::from_str("bwa", true).unwrap(), AlignerPreset::Bwa);
+        assert_eq!(AlignerPreset::from_str("BWA", true).unwrap(), AlignerPreset::Bwa);
+        assert_eq!(AlignerPreset::from_str("bwa-mem3", true).unwrap(), AlignerPreset::BwaMem3);
+        assert_eq!(AlignerPreset::from_str("BWA-MEM3", true).unwrap(), AlignerPreset::BwaMem3);
+        // `bwa-mem` would be the kebab of the old `BwaMem` variant —
+        // ensure the variant rename ($BwaMem → Bwa) cleared this
+        // stale CLI value.
+        assert!(AlignerPreset::from_str("bwa-mem", true).is_err());
+    }
+
+    /// `Display` round-trips through the CLI value — what the user
+    /// types matches what error messages print.
+    #[test]
+    fn test_aligner_preset_display_roundtrips() {
+        use clap::ValueEnum;
+        for preset in [AlignerPreset::Bwa, AlignerPreset::BwaMem3] {
+            let printed = preset.to_string();
+            let parsed = AlignerPreset::from_str(&printed, false).unwrap();
+            assert_eq!(parsed, preset, "Display value {printed:?} should re-parse to {preset:?}");
+        }
+    }
+
+    /// `AlignerOptions::default()` must produce field values that
+    /// match each `default_value_t` on the clap derive. The macro
+    /// emits `default_value_t = AlignerOptions::default().<field>`
+    /// for the `Multi`-side, so any divergence here would surface as
+    /// `--aligner::<flag> [default: 0]` in `--help` (and worse,
+    /// `-K 0` reaching the aligner). Pin the contract.
+    #[test]
+    fn test_aligner_options_default_pins_clap_defaults() {
+        let d = AlignerOptions::default();
+        assert!(d.preset.is_none());
+        assert!(d.command.is_none());
+        assert!(d.threads.is_none());
+        assert_eq!(
+            d.chunk_size, DEFAULT_ALIGNER_CHUNK_SIZE,
+            "chunk_size must default to DEFAULT_ALIGNER_CHUNK_SIZE, NOT to u64::default() (0). \
+             A `#[derive(Default)]` here would zero this and propagate -K 0 to the aligner."
+        );
+    }
+
+    /// `resolve` returns the right `ResolvedAligner` for command mode.
+    #[test]
+    fn test_resolve_command_mode_basic() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ref_path = tmp.path().join("ref.fa");
+        std::fs::write(&ref_path, b">chr1\nACGT\n").unwrap();
+        let opts = AlignerOptions {
+            preset: None,
+            command: Some("bwa-mem3 mem -p -K 1000 -t {threads} {ref} /dev/stdin".to_string()),
+            threads: None,
+            chunk_size: DEFAULT_ALIGNER_CHUNK_SIZE,
+        };
+        let resolved = opts.resolve(&ref_path, 4, None).unwrap();
+        assert!(resolved.command.contains(&ref_path.display().to_string()));
+        assert!(resolved.command.contains("-t 4"));
+        assert!(matches!(resolved.mode, ResolvedAlignerMode::Command));
+    }
+
+    /// `resolve` rejects `--aligner-bin` with command mode.
+    #[test]
+    fn test_resolve_command_mode_rejects_aligner_bin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ref_path = tmp.path().join("ref.fa");
+        std::fs::write(&ref_path, b">chr1\nACGT\n").unwrap();
+        let bin = tmp.path().join("mock-aligner");
+        std::fs::write(&bin, b"#!/bin/sh\n").unwrap();
+        let opts = AlignerOptions {
+            preset: None,
+            command: Some("bwa-mem3 mem {ref} /dev/stdin".to_string()),
+            threads: None,
+            chunk_size: DEFAULT_ALIGNER_CHUNK_SIZE,
+        };
+        let err = opts.resolve(&ref_path, 4, Some(&bin)).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("--aligner-bin is only valid with --aligner::preset"), "got: {msg}");
+    }
+
+    /// `resolve` rejects neither preset nor command set.
+    #[test]
+    fn test_resolve_rejects_no_mode_selected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ref_path = tmp.path().join("ref.fa");
+        std::fs::write(&ref_path, b">chr1\nACGT\n").unwrap();
+        let opts = AlignerOptions::default();
+        let err = opts.resolve(&ref_path, 4, None).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("requires one of"), "got: {msg}");
+    }
+
+    /// Helper: create a known-existing binary path for tests that
+    /// want validate's binary check to pass. Uses a file inside the
+    /// tempdir so the test does not depend on `/bin/bash` (or any
+    /// system path).
+    fn make_existing_binary(dir: &std::path::Path) -> PathBuf {
+        let p = dir.join("mock-aligner");
+        std::fs::write(&p, b"#!/bin/sh\n").unwrap();
+        // `validate` now verifies executability as part of the binary check,
+        // so mark the mock +x. Tests using this helper want the binary check
+        // to pass and to exercise the *next* check (e.g. index files).
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&p).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&p, perms).unwrap();
+        }
+        p
+    }
+
+    /// `validate` errors out on missing index files (binary + FASTA
+    /// checks are arranged to pass so we exercise only the index check).
+    #[test]
+    fn test_validate_missing_indexes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ref_path = tmp.path().join("ref.fa");
+        std::fs::write(&ref_path, b">chr1\nACGT\n").unwrap();
+        let bin = make_existing_binary(tmp.path());
+        let err = AlignerPreset::BwaMem3.validate(&ref_path, Some(&bin)).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("index file not found"), "expected index error, got: {msg}");
+        assert!(msg.contains("bwa-mem3 index"), "expected fix-it hint, got: {msg}");
+    }
+
+    /// `validate` errors out on a nonexistent `--aligner-bin` override path.
+    #[test]
+    fn test_validate_override_path_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ref_path = tmp.path().join("ref.fa");
+        std::fs::write(&ref_path, b">chr1\nACGT\n").unwrap();
+        let missing = tmp.path().join("not-a-real-binary");
+        let err = AlignerPreset::BwaMem3.validate(&ref_path, Some(&missing)).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("--aligner-bin path"), "got: {msg}");
+        assert!(msg.contains("not a regular file"), "got: {msg}");
+    }
+
+    /// `validate` errors out when `--aligner-bin` points at a directory.
+    #[test]
+    fn test_validate_override_path_is_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ref_path = tmp.path().join("ref.fa");
+        std::fs::write(&ref_path, b">chr1\nACGT\n").unwrap();
+        let err = AlignerPreset::BwaMem3.validate(&ref_path, Some(tmp.path())).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("not a regular file"), "got: {msg}");
+    }
+
+    /// `validate` reports the FASTA-missing error BEFORE the
+    /// index-missing error so users see the right fix-it hint.
+    #[test]
+    fn test_validate_missing_reference() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ref_path = tmp.path().join("does-not-exist.fa");
+        let bin = make_existing_binary(tmp.path());
+        let err = AlignerPreset::BwaMem3.validate(&ref_path, Some(&bin)).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("reference FASTA not found"), "got: {msg}");
+        // Must NOT mention indexes — that error would be confusing.
+        assert!(!msg.contains("index file not found"), "got: {msg}");
+    }
+
+    /// `validate` rejects a reference path containing a space (preset
+    /// mode flows through `/bin/bash -c` so unquoted spaces break
+    /// word-splitting).
+    #[test]
+    fn test_validate_rejects_shell_unsafe_reference() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ref_dir = tmp.path().join("dir with space");
+        std::fs::create_dir(&ref_dir).unwrap();
+        let ref_path = ref_dir.join("ref.fa");
+        std::fs::write(&ref_path, b">chr1\nACGT\n").unwrap();
+        let bin = make_existing_binary(tmp.path());
+        let err = AlignerPreset::BwaMem3.validate(&ref_path, Some(&bin)).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("shell-unsafe"), "got: {msg}");
+        assert!(msg.contains("--aligner::command"), "should point to escape hatch: {msg}");
+    }
+
+    /// `relay_stderr` with `ring_size = 0` still drains the pipe (so
+    /// the child doesn't block on stderr-write) but returns an empty
+    /// ring buffer.
+    #[test]
+    fn test_stderr_ring_size_zero_disables_capture() {
+        let proc =
+            AlignerProcess::spawn("bash -c 'echo lost-line >&2; exit 1'", 0).expect("spawn ok");
+        let err = proc.wait().unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("(no stderr captured)"), "ring=0 should disable capture: {msg}");
+    }
+
+    /// `substitute_template` fills both placeholders.
+    #[test]
+    fn test_substitute_template_both_placeholders() {
+        let reference = Path::new("/ref/genome.fa");
+        let template = "bwa-mem3 mem -p -K 150000000 -t {threads} {ref} /dev/stdin";
+        let result = substitute_template(template, reference, 16).unwrap();
+        assert_eq!(result, "bwa-mem3 mem -p -K 150000000 -t 16 /ref/genome.fa /dev/stdin");
+    }
+
+    /// `substitute_template` fills `{ref}` even if `{threads}` is missing.
+    #[test]
+    fn test_substitute_template_threads_optional() {
+        let reference = Path::new("/ref/genome.fa");
+        let template = "bwa mem -t 8 {ref} /dev/stdin";
+        let result = substitute_template(template, reference, 16).unwrap();
+        assert_eq!(result, "bwa mem -t 8 /ref/genome.fa /dev/stdin");
+    }
+
+    /// `substitute_template` errors if `{ref}` is missing.
+    #[test]
+    fn test_substitute_template_requires_ref() {
+        let reference = Path::new("/ref/genome.fa");
+        let template = "bwa mem -t {threads} /dev/stdin";
+        let err = substitute_template(template, reference, 16).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("{ref}"), "error should mention {{ref}}: {msg}");
+    }
+
+    /// A reference path that literally contains `{threads}` must be emitted
+    /// verbatim, not rewritten into the thread count: the single-pass
+    /// substitution never re-scans injected text. Regression for the
+    /// replace-`{ref}`-then-replace-`{threads}` collision.
+    #[test]
+    fn test_substitute_template_ref_path_containing_threads_token_is_not_mangled() {
+        let reference = Path::new("/data/{threads}/genome.fa");
+        let template = "bwa-mem3 mem -t {threads} {ref} /dev/stdin";
+        let result = substitute_template(template, reference, 8).unwrap();
+        assert_eq!(result, "bwa-mem3 mem -t 8 /data/{threads}/genome.fa /dev/stdin");
+    }
+
+    /// `resolve` rejects `--aligner::chunk-size 0` (would reach the aligner as
+    /// `-K 0` and zero the in-flight budget) with a flag-attributed error.
+    #[test]
+    fn test_resolve_rejects_zero_chunk_size() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ref_path = tmp.path().join("ref.fa");
+        std::fs::write(&ref_path, b">chr1\nACGT\n").unwrap();
+        let opts = AlignerOptions {
+            preset: None,
+            command: Some("bwa-mem3 mem {ref} /dev/stdin".to_string()),
+            threads: None,
+            chunk_size: 0,
+        };
+        let err = opts.resolve(&ref_path, 4, None).unwrap_err();
+        assert!(err.to_string().contains("--aligner::chunk-size must be greater than 0"));
+    }
+
+    /// `resolve` rejects an explicit `--aligner::threads 0` in preset mode
+    /// (`None` means "default to runall --threads", so only a literal 0 is
+    /// rejected).
+    #[test]
+    fn test_resolve_rejects_zero_preset_threads() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ref_path = tmp.path().join("ref.fa");
+        std::fs::write(&ref_path, b">chr1\nACGT\n").unwrap();
+        let bin = make_existing_binary(tmp.path());
+        // Index files present so we reach the threads check, not the index bail.
+        for ext in AlignerPreset::BwaMem3.index_extensions() {
+            std::fs::write(append_extension(&ref_path, ext), b"x").unwrap();
+        }
+        let opts = AlignerOptions {
+            preset: Some(AlignerPreset::BwaMem3),
+            command: None,
+            threads: Some(0),
+            chunk_size: DEFAULT_ALIGNER_CHUNK_SIZE,
+        };
+        let err = opts.resolve(&ref_path, 4, Some(&bin)).unwrap_err();
+        assert!(err.to_string().contains("--aligner::threads must be greater than 0"));
+    }
+
+    /// `validate` errors when the `--aligner-bin` override exists but is not
+    /// executable (mode & 0o111 == 0).
+    #[test]
+    #[cfg(unix)]
+    fn test_validate_rejects_non_executable_binary() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let ref_path = tmp.path().join("ref.fa");
+        std::fs::write(&ref_path, b">chr1\nACGT\n").unwrap();
+        let bin = tmp.path().join("mock-aligner");
+        std::fs::write(&bin, b"#!/bin/sh\n").unwrap();
+        let mut perms = std::fs::metadata(&bin).unwrap().permissions();
+        perms.set_mode(0o644); // readable but not executable
+        std::fs::set_permissions(&bin, perms).unwrap();
+        let err = AlignerPreset::BwaMem3.validate(&ref_path, Some(&bin)).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("not executable"), "got: {msg}");
+    }
+
+    /// `check_shell_safe_path` flags the `--aligner-bin` path too (not just
+    /// `--ref`), interpolating the flag label into the message.
+    #[test]
+    fn test_validate_rejects_shell_unsafe_aligner_bin() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ref_path = tmp.path().join("ref.fa");
+        std::fs::write(&ref_path, b">chr1\nACGT\n").unwrap();
+        // A binary path with a space is shell-unsafe.
+        let bin_dir = tmp.path().join("dir with space");
+        std::fs::create_dir(&bin_dir).unwrap();
+        let bin = make_existing_binary(&bin_dir);
+        let err = AlignerPreset::BwaMem3.validate(&ref_path, Some(&bin)).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("shell-unsafe"), "got: {msg}");
+        assert!(msg.contains("--aligner-bin"), "flag label must be named: {msg}");
+    }
+
+    /// A reference path whose interpolated word starts with `-` is rejected
+    /// (the aligner would parse it as a flag).
+    #[test]
+    fn test_check_shell_safe_path_rejects_leading_dash() {
+        let err = check_shell_safe_path(Path::new("-genome.fa"), "--ref").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("starts with '-'"), "got: {msg}");
+        // A `./`-prefixed sibling of the same name is accepted.
+        check_shell_safe_path(Path::new("./-genome.fa"), "--ref").unwrap();
+    }
+
+    /// `relay_stderr` retains only the last `ring_size` lines, evicting the
+    /// oldest, and drains the whole stream regardless.
+    #[test]
+    fn test_relay_stderr_ring_cap_evicts_oldest() {
+        let data = b"l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9\nl10\n".to_vec();
+        let ring = relay_stderr(std::io::Cursor::new(data), 3);
+        assert_eq!(ring, vec!["l8".to_string(), "l9".to_string(), "l10".to_string()]);
+    }
+}

--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -1140,6 +1140,40 @@ fn clipped_bases_raw(record: &RawRecord) -> usize {
         .sum()
 }
 
+// ==== ported from feat-runall for the chain builder (R2) ====
+/// Updates mate information tags (MC and MQ) for a read based on its mate.
+///
+/// After clipping operations, mate information tags need to be updated to reflect
+/// the new state of the mate read. This function updates:
+/// - MC tag: Mate CIGAR string
+/// - MQ tag: Mate mapping quality
+///
+/// These tags are standard SAM optional tags that store information about the mate
+/// to enable single-ended processing.
+///
+/// KNOWN DIVERGENCE — resolve in the clip WIRING PR: this is a NARROWER update
+/// than the canonical [`set_mate_info_raw`]. It updates only the MC/MQ tags and
+/// still does not update mate ref/pos/strand or TLEN; the clip wiring PR must
+/// delegate to `ClipParams::clip_template` / `set_mate_info_raw` and add
+/// byte-parity tests (same deferral as the Cluster-4 chain-clip divergence). The
+/// MC/MQ unmapped-mate divergence is closed here (see below) rather than
+/// deferred, so it cannot survive to the wiring PR.
+///
+/// # Arguments
+///
+/// * `record` - The record to update (mutable)
+/// * `mate` - The mate record to read information from
+pub(crate) fn update_mate_info_raw(record: &mut RawRecord, mate: &RawRecord) {
+    use fgumi_raw_bam::flags as rflags;
+    // An unmapped mate has no CIGAR and no meaningful MAPQ: remove MC/MQ rather
+    // than writing an empty `MC:Z:` and a stale MQ. Matches `set_mate_info_raw`.
+    if mate.flags() & rflags::UNMAPPED != 0 {
+        clear_mate_mq_mc_raw(record);
+        return;
+    }
+    set_mate_mq_mc_raw(record, mate.mapq(), &mate.cigar_to_string());
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -355,6 +355,9 @@ pub struct CodecOptions {
     pub max_duplex_disagreement_rate: f64,
     /// Maximum duplex disagreements.
     pub max_duplex_disagreements: Option<usize>,
+    /// Use fgbio's legacy `[neg.start, pos.end]` overlap window for the duplex
+    /// consensus region instead of the strict intersection (`--legacy-overlap-window`).
+    pub legacy_overlap_window: bool,
     /// Let fully-unmapped primary templates through the pre-group filter.
     ///
     /// Carried as the whole flattened sub-struct, like `io` / `rejects_opts` /
@@ -391,6 +394,7 @@ impl Codec {
             outer_bases_length: self.outer_bases_length,
             max_duplex_disagreement_rate: self.max_duplex_disagreement_rate,
             max_duplex_disagreements: self.max_duplex_disagreements,
+            legacy_overlap_window: self.legacy_overlap_window,
             allow_unmapped: self.allow_unmapped.clone(),
             io: self.io.clone(),
             rejects_opts: self.rejects_opts.clone(),
@@ -416,6 +420,25 @@ fn recover_or_propagate_codec_error(e: CodecConsensusError, umi: &str) -> Result
     } else {
         Err(anyhow::Error::from(e))
             .with_context(|| format!("Failed to call consensus for UMI: {umi}"))
+    }
+}
+
+impl CodecOptions {
+    /// Reconstruct the shared [`ConsensusCallingOptions`] from the inlined flat
+    /// fields, so the chain builder can read `.consensus().error_rate_pre_umi`
+    /// etc. `tie_rule` is stored resolved on `CodecOptions`; convert it back to
+    /// the CLI-facing [`crate::commands::common::TieRuleArg`] via the 1:1 mapping.
+    #[must_use]
+    pub fn consensus(&self) -> ConsensusCallingOptions {
+        ConsensusCallingOptions {
+            error_rate_pre_umi: self.error_rate_pre_umi,
+            error_rate_post_umi: self.error_rate_post_umi,
+            min_input_base_quality: self.min_input_base_quality,
+            output_per_base_tags: self.output_per_base_tags,
+            trim: self.trim,
+            min_consensus_base_quality: self.min_consensus_base_quality,
+            tie_rule: self.tie_rule.into(),
+        }
     }
 }
 

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -355,9 +355,6 @@ pub struct CodecOptions {
     pub max_duplex_disagreement_rate: f64,
     /// Maximum duplex disagreements.
     pub max_duplex_disagreements: Option<usize>,
-    /// Use fgbio's legacy `[neg.start, pos.end]` overlap window for the duplex
-    /// consensus region instead of the strict intersection (`--legacy-overlap-window`).
-    pub legacy_overlap_window: bool,
     /// Let fully-unmapped primary templates through the pre-group filter.
     ///
     /// Carried as the whole flattened sub-struct, like `io` / `rejects_opts` /
@@ -394,7 +391,6 @@ impl Codec {
             outer_bases_length: self.outer_bases_length,
             max_duplex_disagreement_rate: self.max_duplex_disagreement_rate,
             max_duplex_disagreements: self.max_duplex_disagreements,
-            legacy_overlap_window: self.legacy_overlap_window,
             allow_unmapped: self.allow_unmapped.clone(),
             io: self.io.clone(),
             rejects_opts: self.rejects_opts.clone(),

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -1687,8 +1687,6 @@ pub fn validate_index_threshold(
     )
 }
 
-
-
 // ==== ported from feat-runall for the chain builder (R2) ====
 /// Log warnings for `SchedulerOptions` / `QueueMemoryOptions` flags that the
 /// typed-step pipeline doesn't honor. Called from each command's multi-
@@ -1723,8 +1721,6 @@ pub fn warn_unwired_pipeline_flags(
     let _ = queue_memory; // signal intentional use; dead-code lint dampener
 }
 
-
-
 // ==== ported from feat-runall for the chain builder (R2) ====
 /// Print the new-pipeline `PipelineStats` snapshot to the log if any
 /// were collected. Pairs with `attach_new_pipeline_stats`.
@@ -1740,50 +1736,113 @@ pub fn log_new_pipeline_stats(
     }
 }
 
-/// Validate that `header` advertises a sort order the group stage accepts, and
-/// emit the accompanying info logging.
+/// How an input header satisfies `group`'s record-ordering requirement.
 ///
-/// Accepts template-coordinate order always, and queryname order when
-/// `allow_unmapped` is set. On rejection, bails with the order-specific
-/// remediation hint. Shared by `Group::execute`'s single-threaded path and the
-/// chain builder's `add_group` so the two orchestrations of the same stage
-/// cannot drift on the accepted orders, the error text, or the info logging —
-/// the standalone-vs-runall divergence class. The predicates themselves are the
-/// shared `crate::sam::{is_template_coordinate_sorted, is_sorted}`.
-pub(crate) fn require_group_input_sort(
+/// The three cases are mutually exclusive and are what the diagnostics and the
+/// rejection message key off. They must be decided in priority order: a
+/// template-coordinate header also advertises `GO:query`, so it satisfies
+/// [`crate::sam::is_query_grouped`] too and would otherwise be misreported as
+/// merely query-grouped whenever `--allow-unmapped` is set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InputOrdering {
+    /// Template-coordinate sorted: records sharing a position key are adjacent,
+    /// so mapped templates group by position as intended.
+    TemplateCoordinate,
+    /// Query-grouped but not template-coordinate sorted. Accepted only under
+    /// `--allow-unmapped`, which groups unmapped reads by UMI alone.
+    QueryGroupedUnmapped,
+    /// Neither ordering holds, so a template's records may not be adjacent.
+    Unusable,
+}
+
+/// Classify how an input header orders its records.
+///
+/// Template-coordinate is the ordering `group` is built around. The streaming
+/// `RecordPositionGrouper` emits a group whenever the position key changes
+/// between consecutive records, so any input where records sharing a position
+/// key aren't already adjacent (queryname-sorted, coordinate-sorted,
+/// FASTQ-order, etc.) would be split into many small groups and assigned
+/// distinct `MoleculeIds` -- silently wrong. Template-coordinate sort is what
+/// makes adjacency match the grouping key.
+///
+/// `--allow-unmapped` places every unmapped read in a single position group, so
+/// the position adjacency that template-coordinate sort exists to provide is not
+/// needed: every unmapped record lands in that one group regardless of order.
+/// Requiring a template-coordinate sort there would tell a user with unaligned
+/// data to sort by coordinates that do not exist, which is not actionable -- it
+/// blocked the unaligned-only workflow (ribosome display, for example)
+/// outright.
+///
+/// Query grouping is still required, and that is a correctness requirement
+/// rather than a policy choice: templates are assembled by comparing each
+/// record's name to the previous one, so if a template's records are not
+/// adjacent an R1/R2 pair splits into two partial templates.
+///
+/// Mapped reads in a query-grouped (rather than template-coordinate) input are
+/// not position-adjacent, so each mapped template forms its own position group
+/// and therefore its own family. That under-groups rather than merging unrelated
+/// molecules, and `--allow-unmapped` already warns that it groups by UMI alone;
+/// the caller's warning names the case explicitly so it is not a surprise.
+pub(crate) fn classify_input_ordering(header: &Header, allow_unmapped: bool) -> InputOrdering {
+    if crate::sam::is_template_coordinate_sorted(header) {
+        InputOrdering::TemplateCoordinate
+    } else if allow_unmapped && crate::sam::is_query_grouped(header) {
+        InputOrdering::QueryGroupedUnmapped
+    } else {
+        InputOrdering::Unusable
+    }
+}
+
+/// Validate that `header` advertises a record ordering the group stage accepts,
+/// emitting the accompanying info/warn logging and bailing with the
+/// order-specific remediation hint on rejection.
+///
+/// This is the single implementation shared by `Group::execute` and the chain
+/// builder's `add_group`, so the two orchestrations of the same stage cannot
+/// drift on the accepted orders, the error text, or the info/warn logging. It
+/// replaces an earlier `require_group_input_sort` whose doc claimed the same
+/// sharing but which `Group::execute` never actually called — the two paths had
+/// silently diverged (a stricter `SO:queryname` predicate and different
+/// messages), which is exactly the failure this consolidation removes.
+pub(crate) fn require_group_input_ordering(
     header: &Header,
     allow_unmapped: bool,
 ) -> anyhow::Result<()> {
-    use crate::sam::{is_sorted, is_template_coordinate_sorted};
     use anyhow::bail;
-    use log::info;
-    use noodles::sam::header::record::value::map::header::sort_order::QUERY_NAME;
+    use log::{info, warn};
 
-    let is_tc_sorted = is_template_coordinate_sorted(header);
-    let is_qname_sorted = is_sorted(header, QUERY_NAME);
-
-    if !(is_tc_sorted || allow_unmapped && is_qname_sorted) {
-        if allow_unmapped {
+    match classify_input_ordering(header, allow_unmapped) {
+        InputOrdering::TemplateCoordinate => {
+            info!("Input is template-coordinate sorted");
+        }
+        InputOrdering::QueryGroupedUnmapped => {
+            info!("Input is query-grouped; grouping unmapped reads by UMI only");
+            if !header.reference_sequences().is_empty() {
+                warn!(
+                    "Input declares reference sequences but is not template-coordinate \
+                     sorted. Any mapped templates will not be position-grouped, so each \
+                     will form its own family. Sort with --order template-coordinate if \
+                     the input contains mapped reads you want grouped by position."
+                );
+            }
+        }
+        InputOrdering::Unusable => {
+            if allow_unmapped {
+                bail!(
+                    "With --allow-unmapped the input must be either template-coordinate \
+                     sorted or query-grouped, so that a template's records are adjacent \
+                     (header must advertise SO:queryname or GO:query).\n\n\
+                     To sort your BAM file, run:\n  \
+                     fgumi sort -i input.bam -o sorted.bam --order queryname"
+                );
+            }
             bail!(
-                "Input BAM must be template-coordinate sorted or queryname sorted \
-                when --allow-unmapped is enabled.\n\n\
-                To queryname sort your BAM file, run:\n  \
-                samtools sort -n input.bam -o sorted.bam"
+                "Input BAM must be template-coordinate sorted (header must advertise \
+                 SO:unsorted, GO:query, and SS:template-coordinate).\n\n\
+                 To sort your BAM file, run:\n  \
+                 fgumi sort -i input.bam -o sorted.bam --order template-coordinate"
             );
         }
-        bail!(
-            "Input BAM must be template-coordinate sorted (header must advertise \
-            SO:unsorted, GO:query, and SS:template-coordinate).\n\n\
-            To sort your BAM file, run:\n  \
-            fgumi sort -i input.bam -o sorted.bam --order template-coordinate"
-        );
-    }
-
-    if is_tc_sorted {
-        info!("Input is template-coordinate sorted");
-    } else {
-        info!("Input is queryname sorted (accepted with --allow-unmapped)");
-        info!("All unmapped reads will form a single position group per library/cell");
     }
     Ok(())
 }

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -83,6 +83,19 @@ impl From<TieRuleArg> for fgumi_consensus::TieRule {
     }
 }
 
+impl From<fgumi_consensus::TieRule> for TieRuleArg {
+    /// Reverse of the `TieRuleArg → TieRule` resolution. The two enums are a
+    /// 1:1 pairing, so the `Options` projections that store the resolved
+    /// [`fgumi_consensus::TieRule`] can reconstruct the CLI-facing
+    /// [`ConsensusCallingOptions`] without losing information.
+    fn from(rule: fgumi_consensus::TieRule) -> Self {
+        match rule {
+            fgumi_consensus::TieRule::UlpRelative => Self::UlpRelative,
+            fgumi_consensus::TieRule::FgbioCompat => Self::FgbioCompat,
+        }
+    }
+}
+
 /// Resolves an optional `--methylation-mode` CLI arg to a [`MethylationMode`].
 ///
 /// Returns `Disabled` when `None` (flag not provided).
@@ -1672,6 +1685,107 @@ pub fn validate_index_threshold(
          {reason}. Drop --index-threshold to leave indexing to the default threshold, \
          or pass --index-threshold never to state that a linear scan is intended."
     )
+}
+
+
+
+// ==== ported from feat-runall for the chain builder (R2) ====
+/// Log warnings for `SchedulerOptions` / `QueueMemoryOptions` flags that the
+/// typed-step pipeline doesn't honor. Called from each command's multi-
+/// threaded dispatch so users see why their flags might appear to be
+/// ignored. `--pipeline-stats` is honored separately via
+/// `attach_new_pipeline_stats`; this only warns about the others.
+pub fn warn_unwired_pipeline_flags(
+    scheduler_opts: &SchedulerOptions,
+    queue_memory: &QueueMemoryOptions,
+) {
+    // --scheduler was fully removed on `main-runall` (no pluggable strategy
+    // field to inspect), so there is nothing to warn about here; the field is a
+    // plain non-optional `SchedulerStrategy` set programmatically.
+    // --deadlock-recover: the legacy progressive-doubling recovery
+    // addressed a failure mode (a worker pinned on a stuck step under
+    // legacy's static scheduler) that doesn't exist in the typed-step
+    // dispatch model — every worker round-robins through every step
+    // each iteration, so there's nothing to "recover" from.
+    if scheduler_opts.deadlock_recover_enabled() {
+        log::info!(
+            "--deadlock-recover has no effect in the typed-step pipeline: \
+             the dispatch model round-robins all workers across all steps, \
+             so the failure mode legacy's progressive recovery addressed \
+             does not occur"
+        );
+    }
+    // `--queue-memory` is now honored: the total bytes flow into
+    // `PipelineConfig::queue_memory_total`, which both seeds the
+    // initial per-queue budget AND enables the rebalancer that
+    // shifts budget between consistently-full / consistently-empty
+    // queues at runtime. No warning needed.
+    let _ = queue_memory; // signal intentional use; dead-code lint dampener
+}
+
+
+
+// ==== ported from feat-runall for the chain builder (R2) ====
+/// Print the new-pipeline `PipelineStats` snapshot to the log if any
+/// were collected. Pairs with `attach_new_pipeline_stats`.
+pub fn log_new_pipeline_stats(
+    stats: Option<std::sync::Arc<crate::pipeline::core::runtime::stats::PipelineStats>>,
+) {
+    if let Some(stats) = stats {
+        let snapshot = stats.snapshot();
+        log::info!("=== Pipeline statistics ===");
+        for line in format!("{snapshot}").lines() {
+            log::info!("{line}");
+        }
+    }
+}
+
+/// Validate that `header` advertises a sort order the group stage accepts, and
+/// emit the accompanying info logging.
+///
+/// Accepts template-coordinate order always, and queryname order when
+/// `allow_unmapped` is set. On rejection, bails with the order-specific
+/// remediation hint. Shared by `Group::execute`'s single-threaded path and the
+/// chain builder's `add_group` so the two orchestrations of the same stage
+/// cannot drift on the accepted orders, the error text, or the info logging —
+/// the standalone-vs-runall divergence class. The predicates themselves are the
+/// shared `crate::sam::{is_template_coordinate_sorted, is_sorted}`.
+pub(crate) fn require_group_input_sort(
+    header: &Header,
+    allow_unmapped: bool,
+) -> anyhow::Result<()> {
+    use crate::sam::{is_sorted, is_template_coordinate_sorted};
+    use anyhow::bail;
+    use log::info;
+    use noodles::sam::header::record::value::map::header::sort_order::QUERY_NAME;
+
+    let is_tc_sorted = is_template_coordinate_sorted(header);
+    let is_qname_sorted = is_sorted(header, QUERY_NAME);
+
+    if !(is_tc_sorted || allow_unmapped && is_qname_sorted) {
+        if allow_unmapped {
+            bail!(
+                "Input BAM must be template-coordinate sorted or queryname sorted \
+                when --allow-unmapped is enabled.\n\n\
+                To queryname sort your BAM file, run:\n  \
+                samtools sort -n input.bam -o sorted.bam"
+            );
+        }
+        bail!(
+            "Input BAM must be template-coordinate sorted (header must advertise \
+            SO:unsorted, GO:query, and SS:template-coordinate).\n\n\
+            To sort your BAM file, run:\n  \
+            fgumi sort -i input.bam -o sorted.bam --order template-coordinate"
+        );
+    }
+
+    if is_tc_sorted {
+        info!("Input is template-coordinate sorted");
+    } else {
+        info!("Input is queryname sorted (accepted with --allow-unmapped)");
+        info!("All unmapped reads will form a single position group per library/cell");
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -1694,10 +1694,7 @@ pub fn validate_index_threshold(
 /// dispatch) so users see why their flags might appear to be ignored.
 /// `--pipeline-stats` is honored separately via `attach_new_pipeline_stats`;
 /// this only warns about the others.
-pub(crate) fn warn_unwired_pipeline_flags(
-    scheduler_opts: &SchedulerOptions,
-    queue_memory: &QueueMemoryOptions,
-) {
+pub(crate) fn warn_unwired_pipeline_flags(scheduler_opts: &SchedulerOptions) {
     // --scheduler selects a legacy unified-pipeline scheduler strategy that the
     // typed-step chain engine does not consume, so setting it (a hidden dev flag)
     // has no effect on any chain-backed command. Mirror the --deadlock-recover
@@ -1726,12 +1723,10 @@ pub(crate) fn warn_unwired_pipeline_flags(
              does not occur"
         );
     }
-    // `--queue-memory` is now honored: the total bytes flow into
-    // `PipelineConfig::queue_memory_total`, which both seeds the
-    // initial per-queue budget AND enables the rebalancer that
-    // shifts budget between consistently-full / consistently-empty
-    // queues at runtime. No warning needed.
-    let _ = queue_memory; // signal intentional use; dead-code lint dampener
+    // `--queue-memory` needs no warning here: it is honored by the chain
+    // engine — the total bytes flow into `PipelineConfig::queue_memory_total`,
+    // which seeds the initial per-queue budget AND enables the runtime
+    // rebalancer that shifts budget between consistently-full / empty queues.
 }
 
 // ==== ported from feat-runall for the chain builder (R2) ====

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -1689,24 +1689,37 @@ pub fn validate_index_threshold(
 
 // ==== ported from feat-runall for the chain builder (R2) ====
 /// Log warnings for `SchedulerOptions` / `QueueMemoryOptions` flags that the
-/// typed-step pipeline doesn't honor. Called from each command's multi-
-/// threaded dispatch so users see why their flags might appear to be
-/// ignored. `--pipeline-stats` is honored separately via
-/// `attach_new_pipeline_stats`; this only warns about the others.
-pub fn warn_unwired_pipeline_flags(
+/// typed-step pipeline doesn't honor. Called from the chain builder's
+/// `add_*` stage methods (which back every command's multi-threaded chain
+/// dispatch) so users see why their flags might appear to be ignored.
+/// `--pipeline-stats` is honored separately via `attach_new_pipeline_stats`;
+/// this only warns about the others.
+pub(crate) fn warn_unwired_pipeline_flags(
     scheduler_opts: &SchedulerOptions,
     queue_memory: &QueueMemoryOptions,
 ) {
-    // --scheduler was fully removed on `main-runall` (no pluggable strategy
-    // field to inspect), so there is nothing to warn about here; the field is a
-    // plain non-optional `SchedulerStrategy` set programmatically.
+    // --scheduler selects a legacy unified-pipeline scheduler strategy that the
+    // typed-step chain engine does not consume, so setting it (a hidden dev flag)
+    // has no effect on any chain-backed command. Mirror the --deadlock-recover
+    // diagnostic below: surface it when set to a non-default value so a developer
+    // sees the flag was inert rather than silently ignored. Use `warn!` (not
+    // `info!`) to match the sibling "flag has no effect on the chain path"
+    // diagnostics in `group::execute_chain` (--debug-memory, FGUMI_SHORT_CIRCUIT).
+    let requested_scheduler = scheduler_opts.strategy();
+    if requested_scheduler != crate::unified_pipeline::scheduler::SchedulerStrategy::default() {
+        log::warn!(
+            "--scheduler has no effect in the typed-step pipeline: the chain engine \
+             does not use a pluggable scheduler strategy, so the requested strategy \
+             ({requested_scheduler:?}) is ignored"
+        );
+    }
     // --deadlock-recover: the legacy progressive-doubling recovery
     // addressed a failure mode (a worker pinned on a stuck step under
     // legacy's static scheduler) that doesn't exist in the typed-step
     // dispatch model — every worker round-robins through every step
     // each iteration, so there's nothing to "recover" from.
     if scheduler_opts.deadlock_recover_enabled() {
-        log::info!(
+        log::warn!(
             "--deadlock-recover has no effect in the typed-step pipeline: \
              the dispatch model round-robins all workers across all steps, \
              so the failure mode legacy's progressive recovery addressed \
@@ -1724,7 +1737,7 @@ pub fn warn_unwired_pipeline_flags(
 // ==== ported from feat-runall for the chain builder (R2) ====
 /// Print the new-pipeline `PipelineStats` snapshot to the log if any
 /// were collected. Pairs with `attach_new_pipeline_stats`.
-pub fn log_new_pipeline_stats(
+pub(crate) fn log_new_pipeline_stats(
     stats: Option<std::sync::Arc<crate::pipeline::core::runtime::stats::PipelineStats>>,
 ) {
     if let Some(stats) = stats {

--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -1816,7 +1816,7 @@ impl CorrectOptions {
     ///
     /// This is the runall/chain-builder validator. It is **not yet wired to the
     /// standalone `fgumi correct` CLI**, which validates via its own
-    /// [`CorrectUmis::validate`] and — unlike this — still accepts
+    /// `CorrectUmis::validate` and — unlike this — still accepts
     /// `--min-distance 0` (fgbio parity; `check_umi_distances` early-returns on
     /// it, matching `CorrectUmis.scala:180`). The follow-up EC-C2/EC-C3 commits
     /// will plumb this into runall via the `MultiCorrectOptions::validate()`
@@ -1846,7 +1846,8 @@ impl CorrectOptions {
     }
 }
 
-/// Log line emitted by `build_correct_chain` on entry.
+/// Log line emitted when the chain builder wires the typed-step correct path
+/// (the log site lives in `pipeline::chains::builder`).
 /// Pinned as a `pub const` so integration tests that assert the
 /// typed-step path was taken share a single source of truth with the
 /// log site and cannot drift. Mirrors `commands::zipper::NEW_PIPELINE_START_LOG`.

--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -392,6 +392,112 @@ impl CorrectUmis {
     }
 }
 
+impl CorrectOptions {
+    /// Loads the known-UMI set from `--umis` and `--umi-files`, upper-cased and
+    /// de-duplicated, and returns the sorted sequences plus their common length.
+    ///
+    /// Shared by the non-chain [`CorrectUmis`] path and the chain builder, which
+    /// holds these tuning knobs directly.
+    pub(crate) fn load_umi_sequences(&self) -> Result<(Vec<String>, usize)> {
+        let mut umi_set: std::collections::HashSet<String> =
+            self.umis.iter().map(|s| s.to_uppercase()).collect();
+
+        for file in &self.umi_files {
+            let content = std::fs::read_to_string(file)?;
+            for line in content.lines() {
+                let umi = line.trim().to_uppercase();
+                if !umi.is_empty() {
+                    umi_set.insert(umi);
+                }
+            }
+        }
+
+        if umi_set.is_empty() {
+            bail!("No UMIs provided.");
+        }
+
+        let mut umi_sequences: Vec<String> = umi_set.into_iter().collect();
+        umi_sequences.sort_unstable();
+
+        // Check all UMIs have the same length
+        let first_len = umi_sequences[0].len();
+        if !umi_sequences.iter().all(|u| u.len() == first_len) {
+            bail!("All UMIs must have the same length.");
+        }
+
+        info!("Loaded {} UMI sequences of length {}", umi_sequences.len(), first_len);
+        Ok((umi_sequences, first_len))
+    }
+
+    /// Checks distances between UMI pairs and warns about ambiguities.
+    ///
+    /// Identifies pairs of UMIs that are within `min_distance_diff` of each other,
+    /// which could lead to ambiguous matching situations.
+    pub(crate) fn check_umi_distances(&self, umi_sequences: &[String]) {
+        // fgbio computes `findUmiPairsWithinDistance(umis, minDistanceDiff - 1)`
+        // with signed arithmetic, so `--min-distance 0` yields a threshold of -1
+        // and reports no pairs (CorrectUmis.scala:180, exercised by
+        // CorrectUmisTest.scala:187). Reproduce that — and avoid the `usize`
+        // underflow that would otherwise wrap to `usize::MAX` and flag every pair.
+        if self.min_distance_diff == 0 {
+            return;
+        }
+        let pairs = find_umi_pairs_within_distance(umi_sequences, self.min_distance_diff - 1);
+
+        if !pairs.is_empty() {
+            warn!("###################################################################");
+            warn!("# WARNING: Found pairs of UMIs within min-distance-diff threshold!");
+            warn!("# These pairs may be ambiguous and fail to match:");
+            for (umi1, umi2, dist) in &pairs {
+                warn!("#   {umi1} <-> {umi2} (distance {dist})");
+            }
+            warn!("###################################################################");
+        }
+    }
+
+    /// Finalizes per-UMI correction metrics (fractions + representation) and
+    /// writes the TSV when `--metrics` was given. Reads only the `metrics` path,
+    /// so it lives on [`CorrectOptions`] and is shared with the chain builder's
+    /// finalize hook.
+    pub(crate) fn finalize_metrics(
+        &self,
+        umi_metrics: &mut AHashMap<String, UmiCorrectionMetrics>,
+        unmatched_umi: &str,
+    ) -> Result<()> {
+        // Calculate totals
+        let total: u64 = umi_metrics.values().map(|m| m.total_matches).sum();
+        let matched_total: u64 = umi_metrics
+            .iter()
+            .filter(|(umi, _)| *umi != unmatched_umi)
+            .map(|(_, m)| m.total_matches)
+            .sum();
+
+        // Calculate fractions (allow NaN when total is 0, matching fgbio behavior)
+        #[allow(clippy::cast_precision_loss)]
+        for metric in umi_metrics.values_mut() {
+            metric.fraction_of_matches = metric.total_matches as f64 / total as f64;
+        }
+
+        // Calculate representations (allow NaN/Infinity, matching fgbio behavior)
+        let umi_count = umi_metrics.keys().filter(|umi| *umi != unmatched_umi).count();
+
+        #[allow(clippy::cast_precision_loss)]
+        let mean = matched_total as f64 / umi_count as f64;
+        for metric in umi_metrics.values_mut() {
+            metric.representation = metric.total_matches as f64 / mean;
+        }
+
+        // Write metrics if requested
+        if let Some(path) = &self.metrics {
+            let mut metrics: Vec<UmiCorrectionMetrics> = umi_metrics.values().cloned().collect();
+            metrics.sort_by(|a, b| a.umi.cmp(&b.umi));
+            UmiCorrectionMetrics::write_metrics(&metrics, path)?;
+        }
+
+        Ok(())
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RejectionReason {
     WrongLength,
@@ -654,65 +760,15 @@ impl CorrectUmis {
     /// - No UMIs are provided
     /// - UMI files cannot be read
     /// - UMIs have different lengths
-    fn load_umi_sequences(&self) -> Result<(Vec<String>, usize)> {
-        let mut umi_set: std::collections::HashSet<String> =
-            self.umis.iter().map(|s| s.to_uppercase()).collect();
-
-        for file in &self.umi_files {
-            let content = std::fs::read_to_string(file)?;
-            for line in content.lines() {
-                let umi = line.trim().to_uppercase();
-                if !umi.is_empty() {
-                    umi_set.insert(umi);
-                }
-            }
-        }
-
-        if umi_set.is_empty() {
-            bail!("No UMIs provided.");
-        }
-
-        let mut umi_sequences: Vec<String> = umi_set.into_iter().collect();
-        umi_sequences.sort_unstable();
-
-        // Check all UMIs have the same length
-        let first_len = umi_sequences[0].len();
-        if !umi_sequences.iter().all(|u| u.len() == first_len) {
-            bail!("All UMIs must have the same length.");
-        }
-
-        info!("Loaded {} UMI sequences of length {}", umi_sequences.len(), first_len);
-        Ok((umi_sequences, first_len))
+    pub(crate) fn load_umi_sequences(&self) -> Result<(Vec<String>, usize)> {
+        self.to_correct_options().load_umi_sequences()
     }
 
     /// Checks distances between UMI pairs and warns about ambiguities.
     ///
-    /// Identifies pairs of UMIs that are within `min_distance_diff` of each other,
-    /// which could lead to ambiguous matching situations.
-    ///
-    /// # Arguments
-    ///
-    /// * `umi_sequences` - Slice of UMI sequences to check
-    fn check_umi_distances(&self, umi_sequences: &[String]) {
-        // fgbio computes `findUmiPairsWithinDistance(umis, minDistanceDiff - 1)`
-        // with signed arithmetic, so `--min-distance 0` yields a threshold of -1
-        // and reports no pairs (CorrectUmis.scala:180, exercised by
-        // CorrectUmisTest.scala:187). Reproduce that — and avoid the `usize`
-        // underflow that would otherwise wrap to `usize::MAX` and flag every pair.
-        if self.min_distance_diff == 0 {
-            return;
-        }
-        let pairs = find_umi_pairs_within_distance(umi_sequences, self.min_distance_diff - 1);
-
-        if !pairs.is_empty() {
-            warn!("###################################################################");
-            warn!("# WARNING: Found pairs of UMIs within min-distance-diff threshold!");
-            warn!("# These pairs may be ambiguous and fail to match:");
-            for (umi1, umi2, dist) in &pairs {
-                warn!("#   {umi1} <-> {umi2} (distance {dist})");
-            }
-            warn!("###################################################################");
-        }
+    /// Delegates to [`CorrectOptions::check_umi_distances`].
+    pub(crate) fn check_umi_distances(&self, umi_sequences: &[String]) {
+        self.to_correct_options().check_umi_distances(umi_sequences);
     }
 
     /// Compute UMI correction for a template (called once per template).
@@ -957,42 +1013,12 @@ impl CorrectUmis {
         }
     }
 
-    fn finalize_metrics(
+    pub(crate) fn finalize_metrics(
         &self,
         umi_metrics: &mut AHashMap<String, UmiCorrectionMetrics>,
         unmatched_umi: &str,
     ) -> Result<()> {
-        // Calculate totals
-        let total: u64 = umi_metrics.values().map(|m| m.total_matches).sum();
-        let matched_total: u64 = umi_metrics
-            .iter()
-            .filter(|(umi, _)| *umi != unmatched_umi)
-            .map(|(_, m)| m.total_matches)
-            .sum();
-
-        // Calculate fractions (allow NaN when total is 0, matching fgbio behavior)
-        #[allow(clippy::cast_precision_loss)]
-        for metric in umi_metrics.values_mut() {
-            metric.fraction_of_matches = metric.total_matches as f64 / total as f64;
-        }
-
-        // Calculate representations (allow NaN/Infinity, matching fgbio behavior)
-        let umi_count = umi_metrics.keys().filter(|umi| *umi != unmatched_umi).count();
-
-        #[allow(clippy::cast_precision_loss)]
-        let mean = matched_total as f64 / umi_count as f64;
-        for metric in umi_metrics.values_mut() {
-            metric.representation = metric.total_matches as f64 / mean;
-        }
-
-        // Write metrics if requested
-        if let Some(path) = &self.metrics {
-            let mut metrics: Vec<UmiCorrectionMetrics> = umi_metrics.values().cloned().collect();
-            metrics.sort_by(|a, b| a.umi.cmp(&b.umi));
-            UmiCorrectionMetrics::write_metrics(&metrics, path)?;
-        }
-
-        Ok(())
+        self.to_correct_options().finalize_metrics(umi_metrics, unmatched_umi)
     }
 
     /// Execute using the 7-step unified pipeline.
@@ -1564,7 +1590,7 @@ impl CorrectUmis {
 /// Merges `counts` into `dst[umi]`, creating a zero-initialized entry if the
 /// key is absent. Uses `or_insert_with_key` so `umi` is only cloned on insert,
 /// not on hit.
-fn merge_umi_counts(
+pub(crate) fn merge_umi_counts(
     dst: &mut AHashMap<String, UmiCorrectionMetrics>,
     umi: String,
     counts: &UmiCorrectionMetrics,
@@ -1631,7 +1657,7 @@ pub struct EncodedUmiSet {
     /// Bit-encoded sequences for fast comparison (None if encoding failed)
     encoded: Vec<Option<BitEnc>>,
     /// Original strings for output
-    strings: Vec<String>,
+    pub(crate) strings: Vec<String>,
 }
 
 impl EncodedUmiSet {
@@ -1775,6 +1801,56 @@ pub fn find_umi_pairs_within_distance(
     }
     pairs
 }
+
+// ==== methods/symbols ported from feat-runall for the chain builder (R2) ====
+impl CorrectOptions {
+    /// Validate semantic constraints the `multi_options` macro can't
+    /// express:
+    ///
+    /// - At least one of `umis` / `umi_files` is provided (the macro
+    ///   only sees each as a separately optional `Vec<>`, so it
+    ///   cannot enforce "at least one of two Vecs must be non-empty").
+    /// - `min_distance_diff >= 1` (a value of 0 would disable the ambiguity
+    ///   check and underflow the `min_distance_diff - 1` window).
+    /// - `min_corrected`, when set, lies in `[0.0, 1.0]`.
+    ///
+    /// This is the runall/chain-builder validator. It is **not yet wired to the
+    /// standalone `fgumi correct` CLI**, which validates via its own
+    /// [`CorrectUmis::validate`] and — unlike this — still accepts
+    /// `--min-distance 0` (fgbio parity; `check_umi_distances` early-returns on
+    /// it, matching `CorrectUmis.scala:180`). The follow-up EC-C2/EC-C3 commits
+    /// will plumb this into runall via the `MultiCorrectOptions::validate()`
+    /// round-trip when `--start-from <= correct`; the standalone/runall
+    /// divergence on `--min-distance 0` must be reconciled then.
+    pub fn validate(&self) -> Result<()> {
+        if self.umis.is_empty() && self.umi_files.is_empty() {
+            bail!(
+                "At least one UMI or UMI file must be provided \
+                 (via --umis / --umi-files for `fgumi correct`, or \
+                 --correct::umis / --correct::umi-files for `fgumi runall`)."
+            );
+        }
+        if self.min_distance_diff == 0 {
+            bail!(
+                "--min-distance must be >= 1 \
+                 (a value of 0 would disable the ambiguity check and underflow \
+                 the `min_distance_diff - 1` distance window)."
+            );
+        }
+        if let Some(min) = self.min_corrected
+            && !(0.0..=1.0).contains(&min)
+        {
+            bail!("--min-corrected must be between 0 and 1.");
+        }
+        Ok(())
+    }
+}
+
+/// Log line emitted by `build_correct_chain` on entry.
+/// Pinned as a `pub const` so integration tests that assert the
+/// typed-step path was taken share a single source of truth with the
+/// log site and cannot drift. Mirrors `commands::zipper::NEW_PIPELINE_START_LOG`.
+pub const NEW_PIPELINE_START_LOG: &str = "Starting correct (new pipeline)";
 
 #[cfg(test)]
 mod tests {

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -62,7 +62,7 @@ use fgumi_raw_bam;
 use fgumi_raw_bam::{RawRecord, RawRecordView};
 
 /// Duplicate flag bit in SAM flags (0x400)
-const DUPLICATE_FLAG: u16 = 0x400;
+pub(crate) const DUPLICATE_FLAG: u16 = 0x400;
 
 //////////////////////////////////////////////////////////////////////////////
 // Metrics
@@ -227,7 +227,7 @@ fn library_display_name(idx: u16, library_index: &LibraryIndex) -> String {
 /// Resolves the `sample` column value for the `--metrics` output: the
 /// `--sample` override when given, otherwise the comma-joined unique `@RG SM:`
 /// values from the header (empty string when the header declares none).
-fn resolve_sample(header: &Header, override_sample: Option<&str>) -> String {
+pub(crate) fn resolve_sample(header: &Header, override_sample: Option<&str>) -> String {
     use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
     if let Some(s) = override_sample {
         return s.to_string();
@@ -249,16 +249,22 @@ fn resolve_sample(header: &Header, override_sample: Option<&str>) -> String {
 //////////////////////////////////////////////////////////////////////////////
 
 /// Metrics collected per position group, aggregated after pipeline completion.
+///
+/// The single aggregator shape for both dedup paths: `Dedup::execute` reduces
+/// one shared `Mutex`-guarded instance, and the chain's `DedupFinalizeHook`
+/// reduces per-thread slots of it (aliased as `CollectedDedupMetrics`). Keeping
+/// one type guarantees the two paths cannot emit different metric fields for the
+/// same input.
 #[derive(Default, Debug)]
-struct CollectedDedupCounts {
+pub(crate) struct CollectedDedupCounts {
     /// Dedup-specific counts, aggregated per library (keyed by
     /// `GroupKey::library_idx` / `ProcessedDedupGroup::library_idx`). One
     /// position group always belongs to exactly one library (library is part
     /// of the grouping key), so merging is unambiguous per group.
-    dedup_counts_by_library: AHashMap<u16, DedupCounts>,
+    pub(crate) dedup_counts_by_library: AHashMap<u16, DedupCounts>,
     /// Family size counts, global across all libraries (out of scope for
     /// per-library splitting).
-    family_sizes: AHashMap<usize, u64>,
+    pub(crate) family_sizes: AHashMap<usize, u64>,
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -902,7 +908,7 @@ fn count_template_pair_orphan(template: &Template, dedup_counts: &mut DedupCount
 //////////////////////////////////////////////////////////////////////////////
 
 /// Process a position group for deduplication.
-fn process_position_group(
+pub(crate) fn process_position_group(
     group: RawPositionGroup,
     filter_config: &TemplateFilterConfig,
     assigner: &dyn UmiAssigner,
@@ -1706,7 +1712,7 @@ impl Command for MarkDuplicates {
 /// within a single library, so a value pooled across distinct libraries would be
 /// misleading. This matches dupblaster, which never estimates library size across
 /// libraries; the per-library rows carry the meaningful estimates.
-fn write_dedup_metrics(
+pub(crate) fn write_dedup_metrics(
     per_library: &AHashMap<u16, DedupCounts>,
     total: &DedupCounts,
     library_index: &LibraryIndex,
@@ -1747,7 +1753,10 @@ fn write_dedup_metrics(
     Ok(())
 }
 
-fn write_family_size_histogram(family_sizes: &AHashMap<usize, u64>, path: &PathBuf) -> Result<()> {
+pub(crate) fn write_family_size_histogram(
+    family_sizes: &AHashMap<usize, u64>,
+    path: &PathBuf,
+) -> Result<()> {
     let metrics = FamilySizeMetrics::from_size_counts(family_sizes.iter().map(|(&s, &c)| (s, c)));
     DelimFile::default()
         .write_tsv(path, metrics)
@@ -1786,6 +1795,36 @@ fn write_duplication_ladder(
 //////////////////////////////////////////////////////////////////////////////
 // Tests
 //////////////////////////////////////////////////////////////////////////////
+
+/// Metrics collected per position group, aggregated after pipeline completion.
+///
+/// The chain finalize hook's aggregator is the same shape as the non-chain
+/// path's; alias the two so a metric field added to one is shared by both (they
+/// differ only in the reduction site — per-thread slots vs one shared `Mutex`).
+pub(crate) use self::CollectedDedupCounts as CollectedDedupMetrics;
+
+/// A batch of `ProcessedDedupGroup`s carrying a monotonic ordinal so the
+/// downstream `mi_assign` + `serialize` steps preserve input order. Same
+/// shape as `BatchedProcessedPositionGroups` (used by group); see
+/// `pipeline::steps::group::position` for the rationale.
+pub struct BatchedProcessedDedupGroups {
+    pub batch_serial: u64,
+    pub groups: Vec<ProcessedDedupGroup>,
+}
+
+// ==== impls ported from feat-runall for the chain builder (R2) ====
+impl crate::pipeline::core::item::HeapSize for BatchedProcessedDedupGroups {
+    fn heap_size(&self) -> usize {
+        self.groups.iter().map(MemoryEstimate::estimate_heap_size).sum::<usize>()
+            + self.groups.capacity() * std::mem::size_of::<ProcessedDedupGroup>()
+    }
+}
+
+impl crate::pipeline::core::item::Ordered for BatchedProcessedDedupGroups {
+    fn ordinal(&self) -> u64 {
+        self.batch_serial
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -290,6 +290,34 @@ pub struct DuplexOptions {
     pub reference: Option<std::path::PathBuf>,
 }
 
+impl Default for DuplexOptions {
+    /// Test/`runall`-construction default: consensus/overlapping knobs from the
+    /// shared option defaults, `min_reads = [1]`, methylation disabled.
+    fn default() -> Self {
+        let consensus = ConsensusCallingOptions::default();
+        let overlapping = OverlappingConsensusOptions::default();
+        Self {
+            error_rate_pre_umi: consensus.error_rate_pre_umi,
+            error_rate_post_umi: consensus.error_rate_post_umi,
+            min_input_base_quality: consensus.min_input_base_quality,
+            output_per_base_tags: consensus.output_per_base_tags,
+            trim: consensus.trim,
+            min_consensus_base_quality: consensus.min_consensus_base_quality,
+            tie_rule: consensus.tie_rule.into(),
+            consensus_call_overlapping_bases: overlapping.consensus_call_overlapping_bases,
+            min_reads: vec![1],
+            max_reads_per_strand: None,
+            allow_unmapped: AllowUnmappedOptions { enabled: false },
+            io: BamIoOptions::default(),
+            rejects_opts: RejectsOptions::default(),
+            stats_opts: StatsOptions::default(),
+            read_group: ReadGroupOptions::default(),
+            methylation_mode: fgumi_consensus::MethylationMode::default(),
+            reference: None,
+        }
+    }
+}
+
 impl Duplex {
     /// Project the parsed CLI flags into [`DuplexOptions`].
     #[must_use]
@@ -314,6 +342,34 @@ impl Duplex {
                 self.methylation_mode,
             ),
             reference: self.reference.clone(),
+        }
+    }
+}
+
+impl DuplexOptions {
+    /// Reconstruct the shared [`ConsensusCallingOptions`] from the inlined flat
+    /// fields, so the chain builder can read `.consensus().error_rate_pre_umi`
+    /// etc. `tie_rule` is stored resolved on `DuplexOptions`; convert it back to
+    /// the CLI-facing [`crate::commands::common::TieRuleArg`] via the 1:1 mapping.
+    #[must_use]
+    pub fn consensus(&self) -> ConsensusCallingOptions {
+        ConsensusCallingOptions {
+            error_rate_pre_umi: self.error_rate_pre_umi,
+            error_rate_post_umi: self.error_rate_post_umi,
+            min_input_base_quality: self.min_input_base_quality,
+            output_per_base_tags: self.output_per_base_tags,
+            trim: self.trim,
+            min_consensus_base_quality: self.min_consensus_base_quality,
+            tie_rule: self.tie_rule.into(),
+        }
+    }
+
+    /// Reconstruct the shared [`OverlappingConsensusOptions`] from the inlined
+    /// flat field.
+    #[must_use]
+    pub fn overlapping(&self) -> OverlappingConsensusOptions {
+        OverlappingConsensusOptions {
+            consensus_call_overlapping_bases: self.consensus_call_overlapping_bases,
         }
     }
 }
@@ -1019,7 +1075,7 @@ impl Duplex {
 /// It examines the MI tag of each record to check for /A and /B suffixes.
 /// Returns `true` only if there is at least one read with /A suffix AND at least
 /// one read with /B suffix.
-fn has_both_strands_raw(records: &[RawRecord]) -> bool {
+pub(crate) fn has_both_strands_raw(records: &[RawRecord]) -> bool {
     if records.len() < 2 {
         return false;
     }

--- a/src/lib/commands/extract.rs
+++ b/src/lib/commands/extract.rs
@@ -1917,7 +1917,7 @@ fn validate_template_record_count(
 ///
 /// - **Header-synthesis fields** (`sample`, `library`, `platform`,
 ///   `platform_unit`, `read_group_id`, `comments`) map directly to the
-///   corresponding `@RG` and `@CO` entries written by [`Extract::create_header`].
+///   corresponding `@RG` and `@CO` entries written by `Extract::create_header`.
 /// - **Behavior options** control tag output and name annotation in the same
 ///   way as the identically-named [`Extract`] CLI flags.
 ///
@@ -1972,11 +1972,11 @@ pub struct ExtractOptions {
     pub async_reader: bool,
 }
 
-/// Build raw BAM [`RawRecord`]s from a [`FastqSet`].
+/// Build raw BAM `RawRecord`s from a [`FastqSet`].
 ///
 /// This is the core extract logic: applies read structures (via the segments
 /// already present in `read_set`), extracts UMI / cell-barcode / sample-barcode
-/// tags, and produces one [`RawRecord`] per template segment. The caller wraps
+/// tags, and produces one `RawRecord` per template segment. The caller wraps
 /// the result in a [`crate::template::Template`] for the typed-step pipeline.
 ///
 /// KNOWN DUPLICATION — resolve in the extract WIRING PR: this is a third
@@ -1991,7 +1991,7 @@ pub struct ExtractOptions {
 ///
 /// Returns an error if the read set contains no template segments, or if a read
 /// name is 255 bytes or longer (via `try_build_record`).
-pub fn make_raw_records_from_fastq_set(
+pub(crate) fn make_raw_records_from_fastq_set(
     read_set: &FastqSet,
     opts: &ExtractOptions,
 ) -> Result<Vec<fgumi_raw_bam::RawRecord>> {
@@ -2155,7 +2155,7 @@ impl ExtractOptions {
     /// Validate that [`Self::single_tag`] does not collide with any of the
     /// SAM tags that the extractor emits internally.
     ///
-    /// This mirrors the check in [`Extract::validate`]; keeping both guards in
+    /// This mirrors the check in `Extract::validate`; keeping both guards in
     /// sync ensures that the error fires whether the caller constructs an
     /// `ExtractOptions` directly (chain path) or via the CLI struct (command path).
     ///

--- a/src/lib/commands/extract.rs
+++ b/src/lib/commands/extract.rs
@@ -148,7 +148,7 @@ fn classify_compression_header(header: &[u8]) -> CompressionFormat {
 ///
 /// # Returns
 /// A boxed reader that implements `BufRead` + `Send`
-fn open_fastq_reader(
+pub(crate) fn open_fastq_reader(
     path: &Path,
     threads: usize,
     async_reader: bool,
@@ -288,7 +288,7 @@ fn detect_compression_format_from_stream(
 
 /// Quality encoding type
 #[derive(Debug, Clone, Copy, PartialEq)]
-enum QualityEncoding {
+pub enum QualityEncoding {
     Standard, // Phred+33 (Sanger)
     Illumina, // Phred+64 (Illumina 1.3-1.7)
 }
@@ -859,7 +859,7 @@ impl Extract {
         if let Some(tag) = self.single_tag {
             ensure!(
                 !RESERVED_OUTPUT_TAGS.contains(&tag),
-                "Single tag cannot collide with tags emitted by extract \
+                "Single tag (--single-tag) cannot collide with tags emitted by extract \
                  (RX, QX, CB, CY, BC, QT, RG): {tag}"
             );
         }
@@ -1906,6 +1906,281 @@ fn validate_template_record_count(
         ));
     }
     Ok(())
+}
+
+// ==== ported from feat-runall for the chain builder (R2) ====
+/// Per-stage options for [`crate::pipeline::chains::Stage::Extract`].
+///
+/// Carries all the knobs that [`crate::pipeline::chains::commands::extract`]
+/// (T5.6) will need when building the extract step sequence and synthesizing the
+/// unmapped-BAM header:
+///
+/// - **Header-synthesis fields** (`sample`, `library`, `platform`,
+///   `platform_unit`, `read_group_id`, `comments`) map directly to the
+///   corresponding `@RG` and `@CO` entries written by [`Extract::create_header`].
+/// - **Behavior options** control tag output and name annotation in the same
+///   way as the identically-named [`Extract`] CLI flags.
+///
+/// Constructed by `Extract::execute` (T5.7) from the parsed CLI struct and
+/// placed into [`crate::pipeline::chains::StageOptionsBag::extract`].
+#[derive(Debug, Clone)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct ExtractOptions {
+    // ── Header-synthesis fields (map to @RG / @CO in the unmapped BAM header) ──
+    /// Sample name (`@RG SM:`).
+    pub sample: String,
+    /// Library name (`@RG LB:`).
+    pub library: String,
+    /// Sequencing platform (`@RG PL:`, e.g. `"illumina"`).
+    pub platform: Option<String>,
+    /// Platform unit (`@RG PU:`).
+    pub platform_unit: Option<String>,
+    /// Read-group identifier (`@RG ID:`). Defaults to `"A"`.
+    pub read_group_id: String,
+    /// Comments to add as `@CO` lines in the header.
+    pub comments: Vec<String>,
+    /// Library or sample barcode sequence (`@RG BC:`).
+    pub barcode: Option<String>,
+    /// Platform model (`@RG PM:`, e.g. `"hiseq2500"`).
+    pub platform_model: Option<String>,
+    /// Sequencing center (`@RG CN:`).
+    pub sequencing_center: Option<String>,
+    /// Predicted median insert size (`@RG PI:`).
+    pub predicted_insert_size: Option<u32>,
+    /// Description of the read group (`@RG DS:`).
+    pub description: Option<String>,
+    /// Date the run was produced (`@RG DT:`).
+    pub run_date: Option<String>,
+
+    // ── Extract behavior options ──
+    /// Quality encoding of the input FASTQ files.
+    pub quality_encoding: QualityEncoding,
+    /// Store UMI base qualities in the `QX` tag.
+    pub store_umi_quals: bool,
+    /// Store cell-barcode base qualities in the `CY` tag.
+    pub store_cell_quals: bool,
+    /// Single SAM tag to store all concatenated UMIs (must not collide with
+    /// reserved tags `RX`, `QX`, `CB`, `CY`, `BC`, `QT`, `RG`).
+    pub single_tag: Option<SamTag>,
+    /// Append `+<UMIs>` to each read name.
+    pub annotate_read_names: bool,
+    /// Extract UMIs from read names (last `:`-separated field, ≥8 fields).
+    pub extract_umis_from_read_names: bool,
+    /// Store sample-barcode qualities in the `QT` tag.
+    pub store_sample_barcode_qualities: bool,
+    /// Wrap FASTQ readers in a userspace async prefetch thread.
+    pub async_reader: bool,
+}
+
+/// Build raw BAM [`RawRecord`]s from a [`FastqSet`].
+///
+/// This is the core extract logic: applies read structures (via the segments
+/// already present in `read_set`), extracts UMI / cell-barcode / sample-barcode
+/// tags, and produces one [`RawRecord`] per template segment. The caller wraps
+/// the result in a [`crate::template::Template`] for the typed-step pipeline.
+///
+/// KNOWN DUPLICATION — resolve in the extract WIRING PR: this is a third
+/// near-identical copy of the FASTQ→`RawRecord` per-read loop, alongside
+/// `Extract::make_raw_records` (writes to a `RawBamWriter`) and
+/// `make_raw_records_static` (builds an `ExtractedBatch`). The three differ only
+/// in output target, so tag-extraction/flag logic can drift between them. The
+/// extract wiring PR should unify them (sharing `Extract::create_header` and the
+/// per-read tag loop) once the chain extract path is live; dormant today.
+///
+/// # Errors
+///
+/// Returns an error if the read set contains no template segments, or if a read
+/// name is 255 bytes or longer (via `try_build_record`).
+pub fn make_raw_records_from_fastq_set(
+    read_set: &FastqSet,
+    opts: &ExtractOptions,
+) -> Result<Vec<fgumi_raw_bam::RawRecord>> {
+    let templates: Vec<&FastqSegment> = read_set.template_segments().collect();
+
+    let read_name = String::from_utf8_lossy(&read_set.header);
+    ensure!(!templates.is_empty(), "No template segments found for read: {read_name}");
+
+    // Extract various barcode types as BString
+    let cell_barcode_bs = Extract::join_bytes_with_separator(
+        read_set.cell_barcode_segments().map(|s| s.seq.as_slice()),
+        b'-',
+    );
+    let cell_quals_bs = Extract::join_bytes_with_separator(
+        read_set.cell_barcode_segments().map(|s| s.quals.as_slice()),
+        b' ',
+    );
+    let sample_barcode_bs = Extract::join_bytes_with_separator(
+        read_set.sample_barcode_segments().map(|s| s.seq.as_slice()),
+        b'-',
+    );
+    let sample_quals_bs = Extract::join_bytes_with_separator(
+        read_set.sample_barcode_segments().map(|s| s.quals.as_slice()),
+        b' ',
+    );
+    let umi_bs = Extract::join_bytes_with_separator(
+        read_set.molecular_barcode_segments().map(|s| s.seq.as_slice()),
+        b'-',
+    );
+    let umi_qual_bs = Extract::join_bytes_with_separator(
+        read_set.molecular_barcode_segments().map(|s| s.quals.as_slice()),
+        b' ',
+    );
+
+    // Extract UMI from read name if requested
+    let (read_name_bytes, umi_from_name) =
+        Extract::extract_read_name_and_umi(&read_set.header, opts.extract_umis_from_read_names)?;
+
+    // Prepare final UMI
+    let final_umi_bs: BString = match (umi_bs.is_empty(), &umi_from_name) {
+        (true, Some(from_name)) => BString::from(from_name.as_slice()),
+        (true, None) => BString::default(),
+        (false, Some(from_name)) => {
+            let mut combined = Vec::with_capacity(from_name.len() + 1 + umi_bs.len());
+            combined.extend_from_slice(from_name);
+            combined.push(b'-');
+            combined.extend_from_slice(umi_bs.as_bytes());
+            BString::from(combined)
+        }
+        (false, None) => umi_bs,
+    };
+
+    let num_templates = templates.len();
+    let mut builder = UnmappedSamBuilder::new();
+    let mut records = Vec::with_capacity(num_templates);
+
+    for (index, template) in templates.iter().enumerate() {
+        // Compute flags for unmapped reads
+        let mut flag = flags::UNMAPPED;
+        if num_templates == 2 {
+            flag |= flags::PAIRED | flags::MATE_UNMAPPED;
+            if index == 0 {
+                flag |= flags::FIRST_SEGMENT;
+            } else {
+                flag |= flags::LAST_SEGMENT;
+            }
+        }
+
+        // Set read name (optionally with UMI annotation)
+        let annotated_name: Option<Vec<u8>> =
+            if opts.annotate_read_names && !final_umi_bs.is_empty() {
+                let mut name = Vec::with_capacity(read_name_bytes.len() + 1 + final_umi_bs.len());
+                name.extend_from_slice(&read_name_bytes);
+                name.push(b'+');
+                name.extend_from_slice(final_umi_bs.as_bytes());
+                Some(name)
+            } else {
+                None
+            };
+        let final_read_name: &[u8] = annotated_name.as_deref().unwrap_or(&read_name_bytes);
+
+        // Build the record - if empty seq, substitute with single N @ Q2.
+        // Use try_build_record (not the panicking build_record): the name is
+        // derived from the input FASTQ header (plus an optional `+<UMI>`), so an
+        // over-long (>=255-byte) name is bad input, not a bug — fail cleanly with
+        // context instead of panicking partway through the batch and truncating
+        // the output BAM. Mirrors the standalone path's `build_template_record`.
+        if template.seq.is_empty() {
+            builder.try_build_record(final_read_name, flag, b"N", &[2u8])
+        } else {
+            let numeric_quals = opts.quality_encoding.to_standard_numeric(&template.quals);
+            builder.try_build_record(final_read_name, flag, &template.seq, &numeric_quals)
+        }
+        .with_context(|| Extract::read_name_too_long_context(final_read_name))?;
+
+        // Append tags
+        // Read group
+        builder.append_string_tag(SamTag::RG, opts.read_group_id.as_bytes());
+
+        // Cell barcode
+        if !cell_barcode_bs.is_empty() {
+            builder.append_string_tag(SamTag::CB, cell_barcode_bs.as_bytes());
+        }
+
+        if !cell_quals_bs.is_empty() && opts.store_cell_quals {
+            builder.append_string_tag(SamTag::CY, cell_quals_bs.as_bytes());
+        }
+
+        // Sample barcode
+        if !sample_barcode_bs.is_empty() {
+            builder.append_string_tag(SamTag::BC, sample_barcode_bs.as_bytes());
+        }
+
+        if opts.store_sample_barcode_qualities && !sample_quals_bs.is_empty() {
+            builder.append_string_tag(SamTag::QT, sample_quals_bs.as_bytes());
+        }
+
+        // UMI
+        if !final_umi_bs.is_empty() {
+            builder.append_string_tag(SamTag::RX, final_umi_bs.as_bytes());
+
+            // Single tag for all concatenated UMIs (if specified)
+            if let Some(st) = opts.single_tag {
+                builder.append_string_tag(st, final_umi_bs.as_bytes());
+            }
+
+            // Only add UMI qualities if not extracted from read names
+            if umi_from_name.is_none() && !umi_qual_bs.is_empty() && opts.store_umi_quals {
+                builder.append_string_tag(SamTag::QX, umi_qual_bs.as_bytes());
+            }
+        }
+
+        records.push(builder.build());
+    }
+
+    Ok(records)
+}
+
+/// Validate that the read structures produce a valid SAM template: 1 or 2
+/// template (`T`) reads total. 0 template reads yields records with no sequence;
+/// 3+ produce more segments than a SAM template (R1/R2) can hold — either way
+/// the output BAM would be malformed. Shared by the standalone `Extract` command
+/// and the chain/runall `ChainBuilder::add_extract` so both paths reject it
+/// (the chain path previously skipped this check — silent malformed output).
+///
+/// # Errors
+///
+/// Returns an error unless the total template-read count is 1 or 2.
+pub(crate) fn validate_template_count(read_structures: &[ReadStructure]) -> anyhow::Result<()> {
+    let template_count: usize =
+        read_structures.iter().map(|rs| rs.segments_by_type(SegmentType::Template).count()).sum();
+    anyhow::ensure!(
+        (1..=2).contains(&template_count),
+        "read structures must contain 1-2 template reads total."
+    );
+    Ok(())
+}
+
+// ==== impls ported from feat-runall for the chain builder (R2) ====
+impl ExtractOptions {
+    /// Validate that [`Self::single_tag`] does not collide with any of the
+    /// SAM tags that the extractor emits internally.
+    ///
+    /// This mirrors the check in [`Extract::validate`]; keeping both guards in
+    /// sync ensures that the error fires whether the caller constructs an
+    /// `ExtractOptions` directly (chain path) or via the CLI struct (command path).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `single_tag` matches `RX`, `QX`, `CB`, `CY`,
+    /// `BC`, `QT`, or `RG`, or when `extract_umis_from_read_names` is combined
+    /// with `store_umi_quals` (read-name UMIs carry no qualities, so
+    /// `make_raw_records_from_fastq_set` would silently omit `QX`).
+    pub fn validate(&self) -> anyhow::Result<()> {
+        const RESERVED_OUTPUT_TAGS: &[SamTag] =
+            &[SamTag::RX, SamTag::QX, SamTag::CB, SamTag::CY, SamTag::BC, SamTag::QT, SamTag::RG];
+        if let Some(ref tag) = self.single_tag {
+            anyhow::ensure!(
+                !RESERVED_OUTPUT_TAGS.contains(tag),
+                "Single tag (--single-tag) cannot collide with tags emitted by extract \
+                 (RX, QX, CB, CY, BC, QT, RG): {tag}"
+            );
+        }
+        anyhow::ensure!(
+            !self.extract_umis_from_read_names || !self.store_umi_quals,
+            "Cannot store UMI qualities (--store-umi-quals) when also extracting UMIs from read names (--extract-umis-from-read-names)."
+        );
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -3936,7 +4211,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Single tag cannot collide with tags emitted by extract")]
+    #[should_panic(
+        expected = "Single tag (--single-tag) cannot collide with tags emitted by extract"
+    )]
     fn test_single_tag_same_as_umi_tag() {
         let tmp = TempDir::new().expect("failed to create temp dir");
         let r1 = create_fastq(&tmp, "r1.fq", &[("q1", "ACGTAAAAAA", "IIII======")]);
@@ -5500,5 +5777,89 @@ mod tests {
             key_set(&plain_out),
             "BGZF interleaved output must match plaintext interleaved output"
         );
+    }
+
+    /// `validate_template_count` accepts exactly 1-2 template reads (a SAM
+    /// template is R1, or R1/R2); 0 yields sequence-less records and 3+ produce
+    /// more segments than a template can hold. Pins the guard the chain path
+    /// previously skipped (silent malformed output) — see the fn's doc.
+    #[rstest]
+    #[case::zero_no_structures(&[], false)]
+    #[case::zero_no_template_segment(&["8M"], false)]
+    #[case::one_template(&["+T"], true)]
+    #[case::two_templates(&["+T", "+T"], true)]
+    #[case::two_templates_with_barcodes(&["4M+T", "4M+T"], true)]
+    #[case::three_templates(&["+T", "+T", "+T"], false)]
+    fn validate_template_count_accepts_one_or_two_templates(
+        #[case] structures: &[&str],
+        #[case] expected_ok: bool,
+    ) {
+        let read_structures: Vec<ReadStructure> = structures
+            .iter()
+            .map(|s| ReadStructure::from_str(s).expect("valid read structure"))
+            .collect();
+        assert_eq!(validate_template_count(&read_structures).is_ok(), expected_ok);
+    }
+
+    /// Minimal `ExtractOptions` with every field at a benign default, so a test
+    /// can set exactly the field under scrutiny. `ExtractOptions` has no `Default`
+    /// (it is normally projected from the parsed CLI struct).
+    fn minimal_extract_options() -> ExtractOptions {
+        ExtractOptions {
+            sample: "sample".to_string(),
+            library: "lib".to_string(),
+            platform: None,
+            platform_unit: None,
+            read_group_id: "A".to_string(),
+            comments: Vec::new(),
+            barcode: None,
+            platform_model: None,
+            sequencing_center: None,
+            predicted_insert_size: None,
+            description: None,
+            run_date: None,
+            quality_encoding: QualityEncoding::Standard,
+            store_umi_quals: false,
+            store_cell_quals: false,
+            single_tag: None,
+            annotate_read_names: false,
+            extract_umis_from_read_names: false,
+            store_sample_barcode_qualities: false,
+            async_reader: false,
+        }
+    }
+
+    /// `ExtractOptions::validate` must reject a `--single-tag` that collides with
+    /// any tag extract emits (RX/QX/CB/CY/BC/QT/RG) and accept any other tag,
+    /// mirroring `Extract::validate`.
+    #[rstest]
+    #[case::reserved_rx(Some(SamTag::RX), false)]
+    #[case::reserved_rg(Some(SamTag::RG), false)]
+    #[case::non_reserved_mi(Some(SamTag::MI), true)]
+    #[case::none(None, true)]
+    fn extract_options_validate_single_tag_collision(
+        #[case] single_tag: Option<SamTag>,
+        #[case] expected_ok: bool,
+    ) {
+        let mut opts = minimal_extract_options();
+        opts.single_tag = single_tag;
+        assert_eq!(opts.validate().is_ok(), expected_ok);
+    }
+
+    /// Extracting UMIs from read names carries no qualities, so pairing it with
+    /// `--store-umi-quals` (which would silently omit `QX`) must be rejected.
+    #[test]
+    fn extract_options_validate_rejects_umi_from_name_with_store_umi_quals() {
+        let mut opts = minimal_extract_options();
+        opts.extract_umis_from_read_names = true;
+        opts.store_umi_quals = true;
+        assert!(
+            opts.validate().is_err(),
+            "extract-umis-from-read-names + store-umi-quals must be rejected"
+        );
+        // Either flag alone is fine.
+        let mut only_from_name = minimal_extract_options();
+        only_from_name.extract_umis_from_read_names = true;
+        only_from_name.validate().expect("extract-umis-from-read-names alone must validate");
     }
 }

--- a/src/lib/commands/fastq.rs
+++ b/src/lib/commands/fastq.rs
@@ -528,7 +528,7 @@ impl UmiNameAnnotation {
 /// Reusable per-record scratch buffers, kept across the conversion loop so the
 /// hot path does not allocate.
 #[derive(Debug, Default)]
-struct FastqRecordBuffers {
+pub(crate) struct FastqRecordBuffers {
     /// Decoded sequence bases.
     seq: Vec<u8>,
     /// Phred+33 encoded qualities.
@@ -538,7 +538,7 @@ struct FastqRecordBuffers {
 }
 
 impl FastqRecordBuffers {
-    fn with_capacity(capacity: usize) -> Self {
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
         Self {
             seq: Vec::with_capacity(capacity),
             qual: Vec::with_capacity(capacity),
@@ -549,7 +549,7 @@ impl FastqRecordBuffers {
 
 /// Write a single FASTQ record to the writer.
 #[inline]
-fn write_fastq_record<W: Write>(
+pub(crate) fn write_fastq_record<W: Write>(
     writer: &mut W,
     record: &RawRecord,
     flags: u16,
@@ -610,6 +610,71 @@ fn write_fastq_record<W: Write>(
     writer.write_all(b"\n")?;
 
     Ok(())
+}
+
+// ==== ported from feat-runall for the chain builder (R2) ====
+/// Which FASTQ stream a record belongs to, based on its segment flags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Segment {
+    /// First segment of a pair (`FIRST_SEGMENT` set, `LAST_SEGMENT` clear) → R1.
+    Read1,
+    /// Last segment of a pair (`LAST_SEGMENT` set, `FIRST_SEGMENT` clear) → R2.
+    Read2,
+    /// Neither or both segment bits set (single-end or ambiguous) → "other".
+    Other,
+}
+
+/// Classify a record into R1 / R2 / other from its flags, matching how
+/// `samtools fastq` routes reads to `-1` / `-2` / `-0`.
+pub(crate) fn classify_segment(flags: u16) -> Segment {
+    use fgumi_raw_bam::flags as flag_bits;
+    let is_first = (flags & flag_bits::FIRST_SEGMENT) != 0;
+    let is_last = (flags & flag_bits::LAST_SEGMENT) != 0;
+    match (is_first, is_last) {
+        (true, false) => Segment::Read1,
+        (false, true) => Segment::Read2,
+        _ => Segment::Other,
+    }
+}
+
+/// Returns `true` if `path` should be written compressed (ends in
+/// `.gz`/`.bgz`/`.bgzf`).
+///
+/// KNOWN DIVERGENCE — reconcile in the fastq WIRING PR: this is case-SENSITIVE
+/// and also matches `.bgzf`, whereas the live standalone equivalent
+/// [`is_gzip_output_path`] is case-INSENSITIVE and matches only `gz`/`bgz`. The
+/// two decide the same thing ("is this output gzip-compressed?") and should be a
+/// single shared function once the fastq stage is wired onto the chain; they
+/// cannot diverge in observable behavior today because this path is dormant.
+pub(crate) fn path_is_gzip(path: &Path) -> bool {
+    matches!(path.extension().and_then(|e| e.to_str()), Some("gz" | "bgz" | "bgzf"))
+}
+
+// ==== ported from feat-runall for the chain builder (R2) ====
+/// Per-stage options for [`crate::pipeline::chains::Stage::Fastq`] — the
+/// BAM→FASTQ encode. Carries the flag filters, read-name suffix behavior, and
+/// the optional UMI-in-read-name config the encode step needs. The output
+/// destination(s) and compression are carried by the chain's `SinkSpec`, not
+/// here.
+#[derive(Clone)]
+pub struct FastqOptions {
+    /// Exclude reads with any of these flag bits set.
+    pub exclude_flags: u16,
+    /// Only include reads with all of these flag bits set.
+    pub require_flags: u16,
+    /// When `true`, omit the `/1` `/2` read-name suffix.
+    pub no_suffix: bool,
+    /// When `Some`, append the UMI (from the configured tag) to the read name.
+    pub umi_header: Option<UmiNameAnnotation>,
+}
+
+// ==== impls ported from feat-runall for the chain builder (R2) ====
+impl FastqOptions {
+    /// Returns `true` if a record with `flags` passes the include/exclude filters.
+    #[must_use]
+    pub(crate) fn passes_filters(&self, flags: u16) -> bool {
+        (flags & self.exclude_flags) == 0 && (flags & self.require_flags) == self.require_flags
+    }
 }
 
 #[cfg(test)]
@@ -942,5 +1007,72 @@ mod tests {
         write_quality_bytes(&mut output, &[94, 100, 255])
             .expect("write_quality_bytes should succeed");
         assert_eq!(output, vec![126, 126, 126]);
+    }
+
+    /// `classify_segment` routes by the FIRST/LAST segment bits exactly as
+    /// `samtools fastq` does: first-only → R1, last-only → R2, neither/both → other.
+    #[rstest]
+    #[case::read1(fgumi_raw_bam::flags::FIRST_SEGMENT, Segment::Read1)]
+    #[case::read2(fgumi_raw_bam::flags::LAST_SEGMENT, Segment::Read2)]
+    #[case::both_bits(
+        fgumi_raw_bam::flags::FIRST_SEGMENT | fgumi_raw_bam::flags::LAST_SEGMENT,
+        Segment::Other
+    )]
+    #[case::neither(0, Segment::Other)]
+    fn classify_segment_routes_by_first_last_bits(#[case] flags: u16, #[case] expected: Segment) {
+        assert_eq!(classify_segment(flags), expected);
+    }
+
+    /// `passes_filters` requires ALL `require_flags` set and NONE of
+    /// `exclude_flags` set (an inverted bit-mask here would pass silently).
+    #[rstest]
+    // exclude FIRST_SEGMENT: an R1 read is excluded, others pass.
+    #[case::excluded(
+        fgumi_raw_bam::flags::FIRST_SEGMENT,
+        0,
+        fgumi_raw_bam::flags::FIRST_SEGMENT,
+        false
+    )]
+    #[case::not_excluded(fgumi_raw_bam::flags::FIRST_SEGMENT, 0, 0, true)]
+    // require PAIRED: only paired reads pass.
+    #[case::required_present(0, fgumi_raw_bam::flags::PAIRED, fgumi_raw_bam::flags::PAIRED, true)]
+    #[case::required_absent(0, fgumi_raw_bam::flags::PAIRED, 0, false)]
+    // both: must satisfy require AND avoid exclude.
+    #[case::require_met_exclude_hit(
+        fgumi_raw_bam::flags::FIRST_SEGMENT,
+        fgumi_raw_bam::flags::PAIRED,
+        fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::FIRST_SEGMENT,
+        false
+    )]
+    #[case::require_met_exclude_clear(
+        fgumi_raw_bam::flags::FIRST_SEGMENT,
+        fgumi_raw_bam::flags::PAIRED,
+        fgumi_raw_bam::flags::PAIRED,
+        true
+    )]
+    fn passes_filters_applies_exclude_and_require(
+        #[case] exclude_flags: u16,
+        #[case] require_flags: u16,
+        #[case] flags: u16,
+        #[case] expected: bool,
+    ) {
+        let opts =
+            FastqOptions { exclude_flags, require_flags, no_suffix: false, umi_header: None };
+        assert_eq!(opts.passes_filters(flags), expected);
+    }
+
+    /// `path_is_gzip` matches `gz`/`bgz`/`bgzf`, case-sensitively. See the fn's
+    /// KNOWN DIVERGENCE note vs the live `is_gzip_output_path` (the uppercase
+    /// case below pins that divergence, to be reconciled at fastq wiring).
+    #[rstest]
+    #[case::gz("out.fq.gz", true)]
+    #[case::bgz("out.fq.bgz", true)]
+    #[case::bgzf("out.fq.bgzf", true)]
+    #[case::plain_fq("out.fq", false)]
+    #[case::no_extension("out", false)]
+    #[case::gz_in_stem("out.gz.fq", false)]
+    #[case::uppercase_not_matched("OUT.FQ.GZ", false)]
+    fn path_is_gzip_matches_gz_bgz_bgzf(#[case] path: &str, #[case] expected: bool) {
+        assert_eq!(path_is_gzip(std::path::Path::new(path)), expected);
     }
 }

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -458,11 +458,7 @@ impl FilterOptions {
     /// The [`BamPipelineConfig`] is *not* built here: the chain builder derives
     /// it from its [`crate::pipeline::chains::ChainSpec`], and the non-chain run
     /// builds it via [`Filter::build_filter_pipeline_config`].
-    pub(crate) fn setup_pipeline(
-        &self,
-        num_threads: usize,
-        _header: &Header,
-    ) -> Result<FilterPipelineSetup> {
+    pub(crate) fn setup_pipeline(&self, num_threads: usize) -> Result<FilterPipelineSetup> {
         let config = Arc::new(FilterConfig::new(
             &self.min_reads,
             &self.max_read_error_rate,
@@ -705,12 +701,8 @@ impl Filter {
     /// Build the shared filter config, reference, metrics queue, and progress
     /// counter. Delegates to [`FilterOptions::setup_pipeline`] so the chain
     /// builder and the non-chain run share one implementation.
-    pub(crate) fn setup_pipeline(
-        &self,
-        num_threads: usize,
-        header: &Header,
-    ) -> Result<FilterPipelineSetup> {
-        self.to_filter_options().setup_pipeline(num_threads, header)
+    pub(crate) fn setup_pipeline(&self, num_threads: usize) -> Result<FilterPipelineSetup> {
+        self.to_filter_options().setup_pipeline(num_threads)
     }
 
     /// Build the process closure captures. Delegates to
@@ -837,7 +829,7 @@ impl Filter {
         header: Header,
         track_rejects: bool,
     ) -> Result<u64> {
-        let setup = self.setup_pipeline(num_threads, &header)?;
+        let setup = self.setup_pipeline(num_threads)?;
         let pipeline_config = self.build_filter_pipeline_config(num_threads, &header)?;
         let ctx = self.process_captures(&setup, &header);
 
@@ -904,7 +896,7 @@ impl Filter {
         header: Header,
         track_rejects: bool,
     ) -> Result<u64> {
-        let setup = self.setup_pipeline(num_threads, &header)?;
+        let setup = self.setup_pipeline(num_threads)?;
         let pipeline_config = self.build_filter_pipeline_config(num_threads, &header)?;
         let ctx = self.process_captures(&setup, &header);
 

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -323,41 +323,41 @@ impl MemoryEstimate for FilterProcessedBatchRaw {
 
 /// Per-thread accumulator merged into final counts after pipeline completion.
 #[derive(Default)]
-struct CollectedFilterMetrics {
+pub(crate) struct CollectedFilterMetrics {
     /// Total records processed.
-    total_records: u64,
+    pub(crate) total_records: u64,
     /// Records that passed.
-    passed_records: u64,
+    pub(crate) passed_records: u64,
     /// Records that failed.
-    failed_records: u64,
+    pub(crate) failed_records: u64,
     /// Total bases masked.
-    total_bases_masked: u64,
+    pub(crate) total_bases_masked: u64,
 }
 
 /// Shared state for a filter pipeline run, built by `setup_pipeline`.
-struct FilterPipelineSetup {
-    pipeline_config: BamPipelineConfig,
-    config: Arc<FilterConfig>,
-    reference: Option<Arc<ReferenceReader>>,
-    collected_metrics: Arc<PerThreadAccumulator<CollectedFilterMetrics>>,
-    progress_counter: Arc<AtomicU64>,
+pub(crate) struct FilterPipelineSetup {
+    pub(crate) config: Arc<FilterConfig>,
+    pub(crate) reference: Option<Arc<ReferenceReader>>,
+    pub(crate) collected_metrics: Arc<PerThreadAccumulator<CollectedFilterMetrics>>,
+    pub(crate) progress_counter: Arc<AtomicU64>,
 }
 
 /// Captures needed by the process closure, extracted from `Filter` and `FilterPipelineSetup`.
-struct FilterProcessCaptures {
-    config: Arc<FilterConfig>,
-    reference: Option<Arc<ReferenceReader>>,
-    min_base_quality: Option<u8>,
-    should_reverse_tags: bool,
-    min_mean_base_quality: Option<f64>,
-    max_no_call_fraction: f64,
-    require_single_strand_agreement: bool,
-    methylation_depth_thresholds: Option<MethylationDepthThresholds>,
-    require_strand_methylation_agreement: bool,
-    min_conversion_fraction: Option<f64>,
-    methylation_mode: fgumi_consensus::MethylationMode,
-    ref_names: Arc<Vec<String>>,
-    header: Header,
+pub(crate) struct FilterProcessCaptures {
+    pub(crate) config: Arc<FilterConfig>,
+    pub(crate) reference: Option<Arc<ReferenceReader>>,
+    pub(crate) min_base_quality: Option<u8>,
+    pub(crate) should_reverse_tags: bool,
+    pub(crate) min_mean_base_quality: Option<f64>,
+    pub(crate) max_no_call_fraction: f64,
+    pub(crate) require_single_strand_agreement: bool,
+    pub(crate) methylation_depth_thresholds: Option<MethylationDepthThresholds>,
+    pub(crate) require_strand_methylation_agreement: bool,
+    pub(crate) min_conversion_fraction: Option<f64>,
+    pub(crate) methylation_mode: fgumi_consensus::MethylationMode,
+    pub(crate) ref_names: Arc<Vec<String>>,
+    pub(crate) progress: Arc<AtomicU64>,
+    pub(crate) header: Header,
 }
 
 impl Command for Filter {
@@ -450,32 +450,19 @@ impl Command for Filter {
     }
 }
 
-impl Filter {
-    // ========================================================================
-    // 7-Step Unified Pipeline Implementation
-    // ========================================================================
-
-    /// Build the shared pipeline configuration, filter config, reference, metrics
-    /// queue, and progress counter used by both pipeline modes.
-    fn setup_pipeline(&self, num_threads: usize, header: &Header) -> Result<FilterPipelineSetup> {
-        let mut pipeline_config = build_pipeline_config(
-            &self.scheduler_opts,
-            &self.compression,
-            &self.queue_memory,
-            &self.io,
-            num_threads,
-        )?;
-
-        // Template mode groups by QNAME and reads the key's `name_hash` fast-path
-        // (see `TemplateGrouper`), so it needs the key. Single-read mode uses
-        // `SingleRawRecordGrouper`, which discards the decoded record entirely and
-        // never reads the key — so skip its per-record computation with `None`.
-        pipeline_config.group_key_config = if self.filter_by_template {
-            Some(GroupKeyConfig::new_raw_no_cell(LibraryIndex::from_header(header)))
-        } else {
-            None
-        };
-
+impl FilterOptions {
+    /// Build the shared filter config, reference, per-thread metrics
+    /// accumulators, and progress counter used by both the chain builder and
+    /// the non-chain unified pipeline.
+    ///
+    /// The [`BamPipelineConfig`] is *not* built here: the chain builder derives
+    /// it from its [`crate::pipeline::chains::ChainSpec`], and the non-chain run
+    /// builds it via [`Filter::build_filter_pipeline_config`].
+    pub(crate) fn setup_pipeline(
+        &self,
+        num_threads: usize,
+        _header: &Header,
+    ) -> Result<FilterPipelineSetup> {
         let config = Arc::new(FilterConfig::new(
             &self.min_reads,
             &self.max_read_error_rate,
@@ -499,17 +486,14 @@ impl Filter {
         let collected_metrics = PerThreadAccumulator::<CollectedFilterMetrics>::new(num_threads);
         let progress_counter = Arc::new(AtomicU64::new(0));
 
-        Ok(FilterPipelineSetup {
-            pipeline_config,
-            config,
-            reference,
-            collected_metrics,
-            progress_counter,
-        })
+        Ok(FilterPipelineSetup { config, reference, collected_metrics, progress_counter })
     }
 
-    /// Build the process closure captures from self and setup.
-    fn process_captures(
+    /// Build the process closure captures from these options and the setup.
+    ///
+    /// `methylation_mode` is already resolved on [`FilterOptions`] (`Disabled`
+    /// when the flag was unset), so it is used directly rather than re-resolved.
+    pub(crate) fn process_captures(
         &self,
         setup: &FilterPipelineSetup,
         header: &Header,
@@ -531,12 +515,212 @@ impl Filter {
             },
             require_strand_methylation_agreement: self.require_strand_methylation_agreement,
             min_conversion_fraction: self.min_conversion_fraction,
-            methylation_mode: crate::commands::common::resolve_methylation_mode(
-                self.methylation_mode,
-            ),
+            methylation_mode: self.methylation_mode,
             ref_names: Arc::new(ref_names),
+            progress: Arc::clone(&setup.progress_counter),
             header: header.clone(),
         }
+    }
+
+    /// Validates that parameter vectors have 1-3 values and are in valid ranges
+    ///
+    /// Also validates stringency ordering requirements from Scala (lines 161-167):
+    /// - For min-reads: ba <= ab <= cc (more reads required = more stringent)
+    /// - For error rates: ab <= ba (lower error allowed = more stringent)
+    pub(crate) fn validate_parameters(&self) -> Result<()> {
+        // Validate min-reads
+        if self.min_reads.is_empty() || self.min_reads.len() > 3 {
+            bail!("--min-reads must have 1-3 values, got {}", self.min_reads.len());
+        }
+
+        // Validate max-read-error-rate
+        if self.max_read_error_rate.len() > 3 {
+            bail!(
+                "--max-read-error-rate must have 1-3 values, got {}",
+                self.max_read_error_rate.len()
+            );
+        }
+        for &rate in &self.max_read_error_rate {
+            if !(0.0..=1.0).contains(&rate) {
+                bail!("--max-read-error-rate must be between 0.0 and 1.0, got {rate}");
+            }
+        }
+
+        // Validate max-base-error-rate
+        if self.max_base_error_rate.len() > 3 {
+            bail!(
+                "--max-base-error-rate must have 1-3 values, got {}",
+                self.max_base_error_rate.len()
+            );
+        }
+        for &rate in &self.max_base_error_rate {
+            if !(0.0..=1.0).contains(&rate) {
+                bail!("--max-base-error-rate must be between 0.0 and 1.0, got {rate}");
+            }
+        }
+
+        // Validate max-no-call-fraction
+        // If >= 1.0, it should be an integer (count of bases)
+        // If < 1.0, it's a fraction
+        if self.max_no_call_fraction < 0.0 {
+            bail!("--max-no-call-fraction must be >= 0.0, got {}", self.max_no_call_fraction);
+        }
+        if self.max_no_call_fraction >= 1.0 && self.max_no_call_fraction.fract() != 0.0 {
+            bail!(
+                "--max-no-call-fraction >= 1.0 must be an integer (count of bases), got {}",
+                self.max_no_call_fraction
+            );
+        }
+
+        // Validate stringency ordering for duplex parameters (following Scala lines 161-167)
+        if self.min_reads.len() >= 2 {
+            // ab_min_reads <= cc_min_reads (more reads = more stringent)
+            let cc_min = self.min_reads[0];
+            let ab_min = self.min_reads[1];
+            if ab_min > cc_min {
+                bail!(
+                    "min-reads values must be specified high to low (duplex >= AB), got {cc_min} < {ab_min}"
+                );
+            }
+        }
+
+        if self.min_reads.len() == 3 {
+            // ba_min_reads <= ab_min_reads
+            let ab_min = self.min_reads[1];
+            let ba_min = self.min_reads[2];
+            if ba_min > ab_min {
+                bail!(
+                    "min-reads values must be specified high to low (AB >= BA), got {ab_min} < {ba_min}"
+                );
+            }
+        }
+
+        // Validate error rate ordering (AB must be more stringent or equal to BA)
+        if self.max_read_error_rate.len() >= 3 {
+            let ab_error = self.max_read_error_rate[1];
+            let ba_error = self.max_read_error_rate[2];
+            if ab_error > ba_error {
+                bail!(
+                    "max-read-error-rate for AB must be <= BA (more stringent), got AB={ab_error} > BA={ba_error}"
+                );
+            }
+        }
+
+        if self.max_base_error_rate.len() >= 3 {
+            let ab_error = self.max_base_error_rate[1];
+            let ba_error = self.max_base_error_rate[2];
+            if ab_error > ba_error {
+                bail!(
+                    "max-base-error-rate for AB must be <= BA (more stringent), got AB={ab_error} > BA={ba_error}"
+                );
+            }
+        }
+
+        // Validate min-methylation-depth
+        if self.min_methylation_depth.len() > 3 {
+            bail!(
+                "--min-methylation-depth must have 1-3 values, got {}",
+                self.min_methylation_depth.len()
+            );
+        }
+
+        // Validate min-methylation-depth ordering (same as min-reads: CC >= AB >= BA)
+        if self.min_methylation_depth.len() >= 2 {
+            let cc = self.min_methylation_depth[0];
+            let ab = self.min_methylation_depth[1];
+            if ab > cc {
+                bail!(
+                    "min-methylation-depth values must be specified high to low (duplex >= AB), got {cc} < {ab}"
+                );
+            }
+        }
+        if self.min_methylation_depth.len() == 3 {
+            let ab = self.min_methylation_depth[1];
+            let ba = self.min_methylation_depth[2];
+            if ba > ab {
+                bail!(
+                    "min-methylation-depth values must be specified high to low (AB >= BA), got {ab} < {ba}"
+                );
+            }
+        }
+
+        // Validate require-strand-methylation-agreement requires --ref
+        if self.require_strand_methylation_agreement && self.reference.is_none() {
+            bail!("--require-strand-methylation-agreement requires --ref to identify CpG sites");
+        }
+
+        // Validate min-conversion-fraction
+        if let Some(frac) = self.min_conversion_fraction {
+            if !(0.0..=1.0).contains(&frac) {
+                bail!("--min-conversion-fraction must be between 0.0 and 1.0, got {frac}");
+            }
+            if self.reference.is_none() {
+                bail!("--min-conversion-fraction requires --ref to identify non-CpG cytosines");
+            }
+            // `methylation_mode` is resolved on `FilterOptions`; `Disabled` is
+            // exactly the "flag not provided" case (see `resolve_methylation_mode`).
+            if self.methylation_mode == fgumi_consensus::MethylationMode::Disabled {
+                bail!("--min-conversion-fraction requires --methylation-mode to be set");
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Filter {
+    // ========================================================================
+    // 7-Step Unified Pipeline Implementation
+    // ========================================================================
+
+    /// Build the pipeline configuration for the non-chain (`unified_pipeline`)
+    /// filter run. The chain builder assembles its own [`BamPipelineConfig`]
+    /// from the [`crate::pipeline::chains::ChainSpec`], so this lives on
+    /// [`Filter`] (which carries the io/compression/scheduler/queue flags)
+    /// rather than on [`FilterOptions`] (tuning knobs only).
+    fn build_filter_pipeline_config(
+        &self,
+        num_threads: usize,
+        header: &Header,
+    ) -> Result<BamPipelineConfig> {
+        let mut pipeline_config = build_pipeline_config(
+            &self.scheduler_opts,
+            &self.compression,
+            &self.queue_memory,
+            &self.io,
+            num_threads,
+        )?;
+        // Template mode groups by QNAME and reads the key's `name_hash` fast-path
+        // (see `TemplateGrouper`), so it needs the key. Single-read mode uses
+        // `SingleRawRecordGrouper`, which discards the decoded record entirely and
+        // never reads the key — so skip its per-record computation with `None`.
+        pipeline_config.group_key_config = if self.filter_by_template {
+            Some(GroupKeyConfig::new_raw_no_cell(LibraryIndex::from_header(header)))
+        } else {
+            None
+        };
+        Ok(pipeline_config)
+    }
+
+    /// Build the shared filter config, reference, metrics queue, and progress
+    /// counter. Delegates to [`FilterOptions::setup_pipeline`] so the chain
+    /// builder and the non-chain run share one implementation.
+    pub(crate) fn setup_pipeline(
+        &self,
+        num_threads: usize,
+        header: &Header,
+    ) -> Result<FilterPipelineSetup> {
+        self.to_filter_options().setup_pipeline(num_threads, header)
+    }
+
+    /// Build the process closure captures. Delegates to
+    /// [`FilterOptions::process_captures`].
+    pub(crate) fn process_captures(
+        &self,
+        setup: &FilterPipelineSetup,
+        header: &Header,
+    ) -> FilterProcessCaptures {
+        self.to_filter_options().process_captures(setup, header)
     }
 
     /// Run the filter pipeline with the given grouper and process function.
@@ -546,6 +730,7 @@ impl Filter {
     /// output for rejects), and aggregates metrics.
     fn run_filter_pipeline<G, GrouperFn, ProcessFn>(
         &self,
+        pipeline_config: BamPipelineConfig,
         setup: FilterPipelineSetup,
         reader: Box<dyn std::io::Read + Send>,
         header: Header,
@@ -590,7 +775,7 @@ impl Filter {
                 };
 
             run_bam_pipeline_from_reader_with_secondary(
-                setup.pipeline_config,
+                pipeline_config,
                 reader,
                 header,
                 &self.io.output,
@@ -604,7 +789,7 @@ impl Filter {
             )?;
         } else {
             run_bam_pipeline_from_reader(
-                setup.pipeline_config,
+                pipeline_config,
                 reader,
                 header,
                 &self.io.output,
@@ -653,6 +838,7 @@ impl Filter {
         track_rejects: bool,
     ) -> Result<u64> {
         let setup = self.setup_pipeline(num_threads, &header)?;
+        let pipeline_config = self.build_filter_pipeline_config(num_threads, &header)?;
         let ctx = self.process_captures(&setup, &header);
 
         let grouper_fn = move |_header: &Header| {
@@ -705,7 +891,7 @@ impl Filter {
             })
         };
 
-        self.run_filter_pipeline(setup, reader, header, grouper_fn, process_fn)
+        self.run_filter_pipeline(pipeline_config, setup, reader, header, grouper_fn, process_fn)
     }
 
     /// Execute using the 7-step unified pipeline (template-aware mode).
@@ -719,6 +905,7 @@ impl Filter {
         track_rejects: bool,
     ) -> Result<u64> {
         let setup = self.setup_pipeline(num_threads, &header)?;
+        let pipeline_config = self.build_filter_pipeline_config(num_threads, &header)?;
         let ctx = self.process_captures(&setup, &header);
 
         #[cfg(test)]
@@ -812,7 +999,7 @@ impl Filter {
             })
         };
 
-        self.run_filter_pipeline(setup, reader, header, grouper_fn, process_fn)
+        self.run_filter_pipeline(pipeline_config, setup, reader, header, grouper_fn, process_fn)
     }
 
     /// Write filtering statistics to a file.
@@ -841,7 +1028,7 @@ impl Filter {
     ///
     /// Returns `(bases_masked, pass)`.
     #[allow(clippy::too_many_arguments)]
-    fn process_record_raw(
+    pub(crate) fn process_record_raw(
         record: &mut RawRecord,
         config: &FilterConfig,
         reference: Option<&ReferenceReader>,
@@ -1095,147 +1282,12 @@ impl Filter {
         Ok(Self::check_no_call_and_quality(bam, mean_qual, min_mean_qual, max_no_call_frac))
     }
 
-    /// Validates that parameter vectors have 1-3 values and are in valid ranges
+    /// Validates that parameter vectors have 1-3 values and are in valid ranges.
     ///
-    /// Also validates stringency ordering requirements from Scala (lines 161-167):
-    /// - For min-reads: ba <= ab <= cc (more reads required = more stringent)
-    /// - For error rates: ab <= ba (lower error allowed = more stringent)
-    fn validate_parameters(&self) -> Result<()> {
-        // Validate min-reads
-        if self.min_reads.is_empty() || self.min_reads.len() > 3 {
-            bail!("--min-reads must have 1-3 values, got {}", self.min_reads.len());
-        }
-
-        // Validate max-read-error-rate
-        if self.max_read_error_rate.len() > 3 {
-            bail!(
-                "--max-read-error-rate must have 1-3 values, got {}",
-                self.max_read_error_rate.len()
-            );
-        }
-        for &rate in &self.max_read_error_rate {
-            if !(0.0..=1.0).contains(&rate) {
-                bail!("--max-read-error-rate must be between 0.0 and 1.0, got {rate}");
-            }
-        }
-
-        // Validate max-base-error-rate
-        if self.max_base_error_rate.len() > 3 {
-            bail!(
-                "--max-base-error-rate must have 1-3 values, got {}",
-                self.max_base_error_rate.len()
-            );
-        }
-        for &rate in &self.max_base_error_rate {
-            if !(0.0..=1.0).contains(&rate) {
-                bail!("--max-base-error-rate must be between 0.0 and 1.0, got {rate}");
-            }
-        }
-
-        // Validate max-no-call-fraction
-        // If >= 1.0, it should be an integer (count of bases)
-        // If < 1.0, it's a fraction
-        if self.max_no_call_fraction < 0.0 {
-            bail!("--max-no-call-fraction must be >= 0.0, got {}", self.max_no_call_fraction);
-        }
-        if self.max_no_call_fraction >= 1.0 && self.max_no_call_fraction.fract() != 0.0 {
-            bail!(
-                "--max-no-call-fraction >= 1.0 must be an integer (count of bases), got {}",
-                self.max_no_call_fraction
-            );
-        }
-
-        // Validate stringency ordering for duplex parameters (following Scala lines 161-167)
-        if self.min_reads.len() >= 2 {
-            // ab_min_reads <= cc_min_reads (more reads = more stringent)
-            let cc_min = self.min_reads[0];
-            let ab_min = self.min_reads[1];
-            if ab_min > cc_min {
-                bail!(
-                    "min-reads values must be specified high to low (duplex >= AB), got {cc_min} < {ab_min}"
-                );
-            }
-        }
-
-        if self.min_reads.len() == 3 {
-            // ba_min_reads <= ab_min_reads
-            let ab_min = self.min_reads[1];
-            let ba_min = self.min_reads[2];
-            if ba_min > ab_min {
-                bail!(
-                    "min-reads values must be specified high to low (AB >= BA), got {ab_min} < {ba_min}"
-                );
-            }
-        }
-
-        // Validate error rate ordering (AB must be more stringent or equal to BA)
-        if self.max_read_error_rate.len() >= 3 {
-            let ab_error = self.max_read_error_rate[1];
-            let ba_error = self.max_read_error_rate[2];
-            if ab_error > ba_error {
-                bail!(
-                    "max-read-error-rate for AB must be <= BA (more stringent), got AB={ab_error} > BA={ba_error}"
-                );
-            }
-        }
-
-        if self.max_base_error_rate.len() >= 3 {
-            let ab_error = self.max_base_error_rate[1];
-            let ba_error = self.max_base_error_rate[2];
-            if ab_error > ba_error {
-                bail!(
-                    "max-base-error-rate for AB must be <= BA (more stringent), got AB={ab_error} > BA={ba_error}"
-                );
-            }
-        }
-
-        // Validate min-methylation-depth
-        if self.min_methylation_depth.len() > 3 {
-            bail!(
-                "--min-methylation-depth must have 1-3 values, got {}",
-                self.min_methylation_depth.len()
-            );
-        }
-
-        // Validate min-methylation-depth ordering (same as min-reads: CC >= AB >= BA)
-        if self.min_methylation_depth.len() >= 2 {
-            let cc = self.min_methylation_depth[0];
-            let ab = self.min_methylation_depth[1];
-            if ab > cc {
-                bail!(
-                    "min-methylation-depth values must be specified high to low (duplex >= AB), got {cc} < {ab}"
-                );
-            }
-        }
-        if self.min_methylation_depth.len() == 3 {
-            let ab = self.min_methylation_depth[1];
-            let ba = self.min_methylation_depth[2];
-            if ba > ab {
-                bail!(
-                    "min-methylation-depth values must be specified high to low (AB >= BA), got {ab} < {ba}"
-                );
-            }
-        }
-
-        // Validate require-strand-methylation-agreement requires --ref
-        if self.require_strand_methylation_agreement && self.reference.is_none() {
-            bail!("--require-strand-methylation-agreement requires --ref to identify CpG sites");
-        }
-
-        // Validate min-conversion-fraction
-        if let Some(frac) = self.min_conversion_fraction {
-            if !(0.0..=1.0).contains(&frac) {
-                bail!("--min-conversion-fraction must be between 0.0 and 1.0, got {frac}");
-            }
-            if self.reference.is_none() {
-                bail!("--min-conversion-fraction requires --ref to identify non-CpG cytosines");
-            }
-            if self.methylation_mode.is_none() {
-                bail!("--min-conversion-fraction requires --methylation-mode to be set");
-            }
-        }
-
-        Ok(())
+    /// Delegates to [`FilterOptions::validate_parameters`] so the chain builder
+    /// and the non-chain run share one implementation.
+    pub(crate) fn validate_parameters(&self) -> Result<()> {
+        self.to_filter_options().validate_parameters()
     }
 }
 
@@ -3526,6 +3578,131 @@ mod tests {
         // Only the first read should pass (depth=10 >= 5)
         // The second read fails (depth=2 < 5)
         assert_eq!(records.len(), 1);
+
+        Ok(())
+    }
+
+    /// Non-template filtering through the *multi-threaded* pipeline. With
+    /// `filter_by_template: false`, `build_filter_pipeline_config` leaves
+    /// `group_key_config = None`, so the threaded run must route records through
+    /// `SingleRawRecordGrouper` — which discards the decoded key entirely — and
+    /// filter each read independently. Every other non-template execution test
+    /// runs single-threaded, so this pins the `> 1`-thread path over that `None`
+    /// branch.
+    #[test]
+    fn test_filter_execute_non_template_mode_multithreaded() -> Result<()> {
+        let dir = TempDir::new()?;
+        let ref_path = create_test_reference(&dir);
+        let input_path = dir.path().join("input.bam");
+        let output_path = dir.path().join("output.bam");
+
+        // Six independent reads; each is kept iff its depth >= min_reads (5).
+        write_test_bam(
+            &input_path,
+            vec![
+                create_simplex_consensus_record(
+                    "r0",
+                    100,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    10,
+                    0.01,
+                    &[10, 10, 10, 10],
+                    &[0, 0, 0, 0],
+                ),
+                create_simplex_consensus_record(
+                    "r1",
+                    200,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    2,
+                    0.01,
+                    &[2, 2, 2, 2],
+                    &[0, 0, 0, 0],
+                ),
+                create_simplex_consensus_record(
+                    "r2",
+                    300,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    8,
+                    0.01,
+                    &[8, 8, 8, 8],
+                    &[0, 0, 0, 0],
+                ),
+                create_simplex_consensus_record(
+                    "r3",
+                    400,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    1,
+                    0.01,
+                    &[1, 1, 1, 1],
+                    &[0, 0, 0, 0],
+                ),
+                create_simplex_consensus_record(
+                    "r4",
+                    500,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    6,
+                    0.01,
+                    &[6, 6, 6, 6],
+                    &[0, 0, 0, 0],
+                ),
+                create_simplex_consensus_record(
+                    "r5",
+                    600,
+                    b"AAAA",
+                    &[30, 30, 30, 30],
+                    3,
+                    0.01,
+                    &[3, 3, 3, 3],
+                    &[0, 0, 0, 0],
+                ),
+            ],
+        )?;
+
+        let cmd = Filter {
+            io: BamIoOptions {
+                input: input_path.clone(),
+                output: output_path.clone(),
+                async_reader: false,
+                check_crc: false,
+                no_check_crc: false,
+            },
+            reference: Some(ref_path.clone()),
+            min_reads: vec![5],
+            max_read_error_rate: vec![0.1],
+            max_base_error_rate: vec![0.3],
+            min_base_quality: Some(10),
+            min_mean_base_quality: None,
+            max_no_call_fraction: 0.5,
+            reverse_per_base_tags: false,
+
+            threading: ThreadingOptions::new(4),
+            compression: CompressionOptions { compression_level: 1 },
+            filter_by_template: false, // Independent filtering, threaded.
+            rejects: None,
+            stats: None,
+            require_single_strand_agreement: false,
+            min_methylation_depth: vec![],
+            require_strand_methylation_agreement: false,
+            min_conversion_fraction: None,
+            methylation_mode: None,
+            scheduler_opts: SchedulerOptions::default(),
+            queue_memory: QueueMemoryOptions::default(),
+        };
+        cmd.execute("test")?;
+
+        let records = read_bam_records(&output_path)?;
+        // Reads with depth >= 5 pass: r0(10), r2(8), r4(6). Order is not asserted
+        // (the multi-threaded path does not preserve input order).
+        assert_eq!(
+            records.len(),
+            3,
+            "non-template multi-threaded filter must keep exactly the depth>=5 reads"
+        );
 
         Ok(())
     }

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -14,7 +14,6 @@ use crate::metrics::TemplateFilterCounts;
 use crate::metrics::group::{FamilySizeMetrics, PositionGroupSizeMetrics, UmiGroupingMetrics};
 use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::read_info::LibraryIndex;
-use crate::sam::is_template_coordinate_sorted;
 use crate::template::Template;
 use crate::template_filter::{TemplateFilterConfig, filter_template};
 use crate::umi::parallel_assigner::{
@@ -210,63 +209,6 @@ fn parallel_threshold(strategy: Strategy, opt: &ParallelMinTemplates) -> usize {
             // 20x at 1k, 95x at 4k, 390x at 16k.
             Strategy::Paired => 128,
         },
-    }
-}
-
-/// How an input header satisfies `group`'s record-ordering requirement.
-///
-/// The three cases are mutually exclusive and are what the diagnostics and the
-/// rejection message key off. They must be decided in priority order: a
-/// template-coordinate header also advertises `GO:query`, so it satisfies
-/// [`crate::sam::is_query_grouped`] too and would otherwise be misreported as
-/// merely query-grouped whenever `--allow-unmapped` is set.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum InputOrdering {
-    /// Template-coordinate sorted: records sharing a position key are adjacent,
-    /// so mapped templates group by position as intended.
-    TemplateCoordinate,
-    /// Query-grouped but not template-coordinate sorted. Accepted only under
-    /// `--allow-unmapped`, which groups unmapped reads by UMI alone.
-    QueryGroupedUnmapped,
-    /// Neither ordering holds, so a template's records may not be adjacent.
-    Unusable,
-}
-
-/// Classify how an input header orders its records.
-///
-/// Template-coordinate is the ordering `group` is built around. The streaming
-/// `RecordPositionGrouper` emits a group whenever the position key changes
-/// between consecutive records, so any input where records sharing a position
-/// key aren't already adjacent (queryname-sorted, coordinate-sorted,
-/// FASTQ-order, etc.) would be split into many small groups and assigned
-/// distinct `MoleculeIds` -- silently wrong. Template-coordinate sort is what
-/// makes adjacency match the grouping key.
-///
-/// `--allow-unmapped` places every unmapped read in a single position group, so
-/// the position adjacency that template-coordinate sort exists to provide is not
-/// needed: every unmapped record lands in that one group regardless of order.
-/// Requiring a template-coordinate sort there would tell a user with unaligned
-/// data to sort by coordinates that do not exist, which is not actionable -- it
-/// blocked the unaligned-only workflow (ribosome display, for example)
-/// outright.
-///
-/// Query grouping is still required, and that is a correctness requirement
-/// rather than a policy choice: templates are assembled by comparing each
-/// record's name to the previous one, so if a template's records are not
-/// adjacent an R1/R2 pair splits into two partial templates.
-///
-/// Mapped reads in a query-grouped (rather than template-coordinate) input are
-/// not position-adjacent, so each mapped template forms its own position group
-/// and therefore its own family. That under-groups rather than merging unrelated
-/// molecules, and `--allow-unmapped` already warns that it groups by UMI alone;
-/// the caller's warning names the case explicitly so it is not a surprise.
-fn classify_input_ordering(header: &Header, allow_unmapped: bool) -> InputOrdering {
-    if is_template_coordinate_sorted(header) {
-        InputOrdering::TemplateCoordinate
-    } else if allow_unmapped && crate::sam::is_query_grouped(header) {
-        InputOrdering::QueryGroupedUnmapped
-    } else {
-        InputOrdering::Unusable
     }
 }
 
@@ -986,41 +928,11 @@ impl Command for GroupReadsByUmi {
         let (reader, header) =
             create_bam_reader_for_pipeline_with_opts(&self.io.input, reader_opts)?;
 
-        // Sort order: see `classify_input_ordering` for why template-coordinate
-        // is required, and why `--allow-unmapped` relaxes it to query grouping.
-        match classify_input_ordering(&header, self.allow_unmapped) {
-            InputOrdering::TemplateCoordinate => {
-                info!("Input is template-coordinate sorted");
-            }
-            InputOrdering::QueryGroupedUnmapped => {
-                info!("Input is query-grouped; grouping unmapped reads by UMI only");
-                if !header.reference_sequences().is_empty() {
-                    warn!(
-                        "Input declares reference sequences but is not template-coordinate \
-                         sorted. Any mapped templates will not be position-grouped, so each \
-                         will form its own family. Sort with --order template-coordinate if \
-                         the input contains mapped reads you want grouped by position."
-                    );
-                }
-            }
-            InputOrdering::Unusable => {
-                if self.allow_unmapped {
-                    bail!(
-                        "With --allow-unmapped the input must be either template-coordinate \
-                         sorted or query-grouped, so that a template's records are adjacent \
-                         (header must advertise SO:queryname or GO:query).\n\n\
-                         To sort your BAM file, run:\n  \
-                         fgumi sort -i input.bam -o sorted.bam --order queryname"
-                    );
-                }
-                bail!(
-                    "Input BAM must be template-coordinate sorted (header must advertise \
-                     SO:unsorted, GO:query, and SS:template-coordinate).\n\n\
-                     To sort your BAM file, run:\n  \
-                     fgumi sort -i input.bam -o sorted.bam --order template-coordinate"
-                );
-            }
-        }
+        // Validate the input's record ordering (template-coordinate, or
+        // query-grouped under --allow-unmapped) and emit the accompanying
+        // info/warn logging. Shared with the chain builder's `add_group` so the
+        // two paths cannot drift — see `require_group_input_ordering`.
+        crate::commands::common::require_group_input_ordering(&header, self.allow_unmapped)?;
 
         // Add @PG record with PP chaining to input's last program
         let header = crate::commands::common::add_pg_record(header, command_line)?;
@@ -1906,7 +1818,6 @@ fn with_extension(prefix: &Path, suffix: &str) -> PathBuf {
     s.push(suffix);
     PathBuf::from(s)
 }
-
 
 /// Write all group metrics files for the chain-builder finalize hook.
 ///
@@ -6765,6 +6676,8 @@ mod tests {
         Ok(())
     }
 
+    use crate::commands::common::{InputOrdering, classify_input_ordering};
+
     /// The acceptance table above pins accept-vs-reject; this pins *which*
     /// ordering the input was accepted as, which is what the diagnostics and the
     /// rejection message key off.
@@ -6774,6 +6687,10 @@ mod tests {
     /// correctly-sorted BAM as merely query-grouped whenever `--allow-unmapped`
     /// is set -- warning that its mapped templates "will not be position-grouped"
     /// when in fact they are.
+    ///
+    /// `classify_input_ordering`/`InputOrdering` now live in `commands::common`
+    /// (shared by `Group::execute` and the chain builder's `add_group`); this
+    /// test moved its references there accordingly.
     #[rstest]
     // Template-coordinate wins over the weaker query-grouped match, flag or not.
     #[case::tc_sorted(

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -4,16 +4,14 @@ use crate::assigner::{PairedUmiAssigner, Strategy, UmiAssigner};
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
-    build_pipeline_config, is_r1_genomically_earlier_raw,
+    is_r1_genomically_earlier_raw,
 };
-use crate::grouper::{
-    ProcessedPositionGroup, RawPositionGroup, RecordPositionGrouper, build_templates_from_records,
-};
+use crate::grouper::{RawPositionGroup, RecordPositionGrouper, build_templates_from_records};
 use crate::logging::{OperationTimer, log_umi_grouping_summary};
 use crate::metrics::TemplateFilterCounts;
-use crate::metrics::group::{FamilySizeMetrics, PositionGroupSizeMetrics, UmiGroupingMetrics};
-use crate::per_thread_accumulator::PerThreadAccumulator;
+use crate::metrics::group::UmiGroupingMetrics;
 use crate::read_info::LibraryIndex;
+use crate::sam::SamTag;
 use crate::template::Template;
 use crate::template_filter::{TemplateFilterConfig, filter_template};
 use crate::umi::parallel_assigner::{
@@ -21,10 +19,8 @@ use crate::umi::parallel_assigner::{
     ParallelPairedAssigner,
 };
 use crate::unified_pipeline::DecodedRecord;
+use crate::unified_pipeline::Grouper;
 use crate::unified_pipeline::compute_group_key_from_raw;
-use crate::unified_pipeline::{
-    GroupKeyConfig, Grouper, run_bam_pipeline_from_reader_with_mi_assign,
-};
 use ahash::AHashMap;
 use anyhow::{Context, Result, bail};
 use clap::Parser;
@@ -34,34 +30,12 @@ use fgumi_bam_io::{
     PipelineReaderOpts, create_bam_reader_for_pipeline_with_opts, create_bam_writer,
     create_raw_bam_reader_from_stream_with_opts,
 };
-use fgumi_umi::IndexThreshold;
-// MemoryEstimate is gated because it's only used in memory-debug blocks below
-use crate::sam::SamTag;
-#[cfg(feature = "memory-debug")]
-use crate::unified_pipeline::MemoryEstimate;
 use fgumi_raw_bam::RawRecord;
+use fgumi_umi::IndexThreshold;
 use log::{info, warn};
 use noodles::sam::Header;
 use noodles::sam::alignment::record::data::field::Tag;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
-
-/// Estimate total heap size of a template slice using sampling for large batches.
-/// For small batches (<=10), computes exact total. For larger batches, samples the
-/// first 5 templates and extrapolates. This avoids O(n) overhead on every call but
-/// may underestimate for groups with heterogeneous read lengths.
-#[cfg(feature = "memory-debug")]
-fn estimate_templates_heap_size(templates: &[Template]) -> usize {
-    if templates.len() <= 10 {
-        templates.iter().map(|t| t.estimate_heap_size()).sum()
-    } else {
-        let sample_size = 5;
-        let sample_total: usize =
-            templates.iter().take(sample_size).map(|t| t.estimate_heap_size()).sum();
-        // Use multiply-before-divide to avoid truncation bias
-        (sample_total * templates.len()) / sample_size
-    }
-}
 
 // UmiGroupingMetrics and FamilySizeMetrics are imported from crate::metrics
 
@@ -658,7 +632,13 @@ pub struct GroupReadsByUmi {
     #[arg(long, value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub debug_memory: bool,
 
-    /// Memory report interval in seconds (default: 1, minimum: 1)
+    /// Memory report interval in seconds (default: 1, minimum: 1).
+    ///
+    /// Only meaningful together with `--debug-memory`, which drives the legacy
+    /// memory monitor. That monitor is not carried by the `--threads` chain
+    /// engine, so this flag is inert there — kept (rather than removed) so a
+    /// `memory-debug` build accepts it instead of hard-erroring; the
+    /// `--debug-memory` warning in `execute_chain` covers the whole feature.
     #[cfg(feature = "memory-debug")]
     #[arg(long, default_value = "1", value_parser = clap::value_parser!(u64).range(1..))]
     pub memory_report_interval: u64,
@@ -885,6 +865,15 @@ impl Command for GroupReadsByUmi {
         // Set minimum mapping quality
         let min_mapq: u8 = self.resolved_min_map_q();
 
+        // --threads N: run the group stage on the declarative chain builder.
+        // Dispatch BEFORE the timer/banner/reader below: the chain re-emits the
+        // timer and banner via `add_group` and opens its own source, so running
+        // them here too would double-log and pre-consume stdin. CRC-verify status
+        // (which `add_group` does not log) is emitted by `execute_chain` instead.
+        if self.threading.threads.is_some() {
+            return self.execute_chain(command_line);
+        }
+
         // Initialize tracking infrastructure
         let timer = OperationTimer::new("Grouping reads by UMI");
 
@@ -922,7 +911,11 @@ impl Command for GroupReadsByUmi {
         info!("{}", self.threading.log_message());
         self.io.log_effective_check_crc();
 
-        // Open input BAM using streaming-capable reader for pipeline use
+        // ============================================================
+        // Single-threaded fast path (no --threads flag; --threads N returned
+        // to execute_chain above, before this banner/timer block).
+        // ============================================================
+        // Open input BAM using a streaming-capable reader (required for stdin).
         info!("Reading input BAM");
         let reader_opts = self.io.pipeline_reader_opts();
         let (reader, header) =
@@ -934,15 +927,15 @@ impl Command for GroupReadsByUmi {
         // two paths cannot drift — see `require_group_input_ordering`.
         crate::commands::common::require_group_input_ordering(&header, self.allow_unmapped)?;
 
-        // Add @PG record with PP chaining to input's last program
+        // Add @PG record with PP chaining to input's last program.
         let header = crate::commands::common::add_pg_record(header, command_line)?;
 
-        // Tag constants per SAM specification — all derived from SamTag to ensure type safety.
+        // Tag constants per SAM specification — all derived from SamTag.
         let raw_tag: [u8; 2] = *SamTag::RX;
         let assign_tag_bytes: [u8; 2] = *SamTag::MI;
         let cell_tag = Tag::from(SamTag::CB);
 
-        // Create filter configuration
+        // Create filter configuration.
         let filter_config = TemplateFilterConfig {
             umi_tag: raw_tag,
             min_mapq,
@@ -952,498 +945,76 @@ impl Command for GroupReadsByUmi {
             allow_unmapped: self.allow_unmapped,
         };
 
-        // ============================================================
-        // Check for single-threaded fast path (no --threads flag)
-        // ============================================================
-        if self.threading.threads.is_none() {
-            // Single-threaded fast path - pass reader (required for stdin support)
-            return self.execute_single_threaded(
-                reader,
-                reader_opts.verify_crc,
-                &header,
-                effective_strategy,
-                effective_edits,
-                raw_tag,
-                assign_tag_bytes,
-                cell_tag,
-                &filter_config,
-                &timer,
-            );
-        }
-
-        // ============================================================
-        // Use 7-step unified pipeline (--threads N was specified)
-        // ============================================================
-        // Per-thread metric accumulators: each worker merges into its own slot,
-        // so retained memory is O(threads × distinct sizes) rather than growing
-        // one hashmap per position group (see issue #285).
-        let num_threads = self.threading.num_threads();
-        let accumulators = PerThreadAccumulator::<GroupMetricsAccumulator>::new(num_threads);
-
-        // Clone values needed by closures
-        let strategy = effective_strategy;
-        let index_threshold = self.index_threshold;
-        let no_umi = self.no_umi;
-        let allow_unmapped = self.allow_unmapped;
-        let parallel_group_min_templates = self.parallel_group_min_templates.clone();
-        let accumulators_clone = Arc::clone(&accumulators);
-
-        // Setup comprehensive memory monitoring first if debug mode is enabled
-        #[cfg(feature = "memory-debug")]
-        let debug_memory_flag = self.debug_memory;
-        #[cfg(feature = "memory-debug")]
-        let (memory_monitor_handle, shared_stats) = if self.debug_memory {
-            use crate::unified_pipeline::{PipelineStats, start_memory_monitor};
-            use std::sync::atomic::AtomicBool;
-
-            info!("Memory debugging enabled - reporting every {}s", self.memory_report_interval);
-
-            let stats = Arc::new(PipelineStats::new());
-            let shutdown_signal = Arc::new(AtomicBool::new(false));
-            let shutdown_signal_clone = shutdown_signal.clone();
-
-            let handle = start_memory_monitor(
-                stats.clone(),
-                shutdown_signal_clone,
-                self.memory_report_interval,
-            );
-            (Some((handle, shutdown_signal)), Some(stats))
-        } else {
-            (None, None)
-        };
-        #[cfg(not(feature = "memory-debug"))]
-        let shared_stats: Option<Arc<crate::unified_pipeline::PipelineStats>> = None;
-
-        // Clone stats for hot path tracking (process_fn and serialize_fn closures)
-        #[cfg(feature = "memory-debug")]
-        let stats_for_tracking = shared_stats.clone();
-        #[cfg(feature = "memory-debug")]
-        let stats_for_serialize = shared_stats.clone();
-
-        // Configure 7-step pipeline
-        let mut pipeline_config = build_pipeline_config(
-            &self.scheduler_opts,
-            &self.compression,
-            &self.queue_memory,
-            &self.io,
-            num_threads,
-        )?;
-
-        // Override stats: use shared stats if available (memory-debug feature)
-        if let Some(stats) = shared_stats.as_ref() {
-            pipeline_config.pipeline = pipeline_config.pipeline.with_shared_stats(stats.clone());
-        }
-        info!("Scheduler: {:?}", self.scheduler_opts.strategy());
-        // Template-based batching is enabled by default in auto_tuned() with target=500 templates.
-        // This provides consistent batch sizes across datasets with varying templates-per-group ratios.
-
-        let library_index = LibraryIndex::from_header(&header);
-        // Cache the UMI tag's value position on each DecodedRecord so the Process
-        // step's UMI-assignment pass can slice the value without re-scanning aux
-        // data (issue #334). Skip the cache in --no-umi mode where the assignment
-        // site emits String::new() and never reads the cache.
-        let group_key_config = GroupKeyConfig::new(library_index, cell_tag);
-        pipeline_config.group_key_config = Some(if self.no_umi {
-            group_key_config
-        } else {
-            group_key_config.with_umi_tag(raw_tag)
-        });
-
-        // Short-circuit support for memory bisection debugging.
-        // Set FGUMI_SHORT_CIRCUIT=process|serialize|compress to skip downstream steps.
-        #[cfg(feature = "memory-debug")]
-        let short_circuit = std::env::var("FGUMI_SHORT_CIRCUIT").unwrap_or_default();
-        #[cfg(feature = "memory-debug")]
-        if !short_circuit.is_empty() {
-            match short_circuit.as_str() {
-                "process" | "serialize" | "compress" => {
-                    log::warn!(
-                        "SHORT-CIRCUIT mode: pipeline truncated at '{}' — OUTPUT WILL BE INVALID",
-                        short_circuit
-                    );
-                }
-                other => {
-                    bail!(
-                        "Invalid FGUMI_SHORT_CIRCUIT value '{}'. Valid: process, serialize, compress",
-                        other
-                    );
-                }
-            }
-        }
-        #[cfg(feature = "memory-debug")]
-        let short_circuit_process = short_circuit == "process";
-        #[cfg(feature = "memory-debug")]
-        let short_circuit_serialize = short_circuit == "serialize";
-        #[cfg(feature = "memory-debug")]
-        let short_circuit_compress = short_circuit == "compress";
-
-        // Cumulative MoleculeId counter, advanced **only** by the
-        // serial-ordered MI Assign hook installed below. The hook is
-        // invoked in pipeline-input order (`(batch_serial, idx_in_batch)`)
-        // by the unified pipeline's MI Assign zone, so two runs of
-        // `fgumi group` on the same input observe the same `fetch_add`
-        // sequence and produce byte-identical `MI:Z` integers — see
-        // `docs/design/deterministic-mi-numbering.md`. The `Arc` is owned
-        // by the hook closure; nothing outside the closure needs to read
-        // its final value.
-        let next_mi_base_for_hook = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
-
-        // Run the 7-step unified pipeline with the already-opened reader (supports streaming)
-        let records_processed = run_bam_pipeline_from_reader_with_mi_assign(
-            pipeline_config,
+        self.execute_single_threaded(
             reader,
-            header,
-            &self.io.output,
-            None, // Use input header for output
-            // grouper_fn: Create RecordPositionGrouper (lightweight, no Template building)
-            move |_header: &Header| {
-                Box::new(RecordPositionGrouper::new())
-                    as Box<dyn Grouper<Group = RawPositionGroup> + Send>
-            },
-            // process_fn: Build Templates + Filter + assign UMIs (parallel)
-            move |group: RawPositionGroup| -> std::io::Result<ProcessedPositionGroup> {
-                #[cfg(feature = "memory-debug")]
-                if short_circuit_process {
-                    let input_record_count = group.records.len() as u64;
-                    drop(group);
-                    return Ok(ProcessedPositionGroup {
-                        templates: Vec::new(),
-                        family_sizes: AHashMap::new(),
-                        filter_counts: TemplateFilterCounts::new(),
-                        input_record_count,
-                        distinct_mi_count: 0,
-                    });
-                }
-                let mut filter_counts = TemplateFilterCounts::new();
-
-                // Track memory usage if debug mode is enabled (optimized for hot path)
-                #[cfg(feature = "memory-debug")]
-                let initial_group_size = if debug_memory_flag {
-                    let size = group.estimate_heap_size();
-                    if let Some(stats) = stats_for_tracking.as_ref() {
-                        use crate::unified_pipeline::get_or_assign_thread_id;
-                        let thread_id = get_or_assign_thread_id();
-                        let record_count = group.records.len();
-
-                        stats.track_position_group_memory(size, true);
-
-                        if record_count > 200 {
-                            let group_size_gb = size as f64 / 1e9;
-                            log::debug!("Processing large position group: {:.2}GB ({} records) on thread {}",
-                                       group_size_gb, record_count, thread_id);
-                        }
-                    }
-                    size
-                } else {
-                    0
-                };
-
-                // Build Templates from raw records (was serial, now parallel!)
-                let all_templates = build_templates_from_records(group.records)?;
-
-                // Count ALL input records for progress tracking
-                let input_record_count: u64 =
-                    all_templates.iter().map(|t| t.read_count() as u64).sum();
-
-                // Filter templates
-                let filtered_templates: Vec<Template> = all_templates
-                    .into_iter()
-                    .filter(|t| filter_template(t, &filter_config, &mut filter_counts))
-                    .collect();
-
-                // Track filtered template memory (optimized for hot path).
-                // Note: alloc/dealloc estimates may diverge since templates are mutated between
-                // estimation points (e.g. MI fields populated, records reordered). This is
-                // acceptable for debug instrumentation — counters may drift slightly.
-                #[cfg(feature = "memory-debug")]
-                let _template_memory_size = if debug_memory_flag && !filtered_templates.is_empty() {
-                    let estimated_size = estimate_templates_heap_size(&filtered_templates);
-
-                    if let Some(stats) = stats_for_tracking.as_ref() {
-                        let thread_id = crate::unified_pipeline::get_or_assign_thread_id();
-
-                        stats.track_template_memory(estimated_size, true);
-
-                        if filtered_templates.len() > 50 {
-                            let estimated_total_mb = estimated_size as f64 / 1e6;
-                            if estimated_total_mb > 10.0 {
-                                log::debug!("Filtered templates: ~{:.1}MB ({} templates) on thread {}",
-                                           estimated_total_mb, filtered_templates.len(), thread_id);
-                            }
-                        }
-                    }
-                    estimated_size
-                } else {
-                    0
-                };
-
-                if filtered_templates.is_empty() {
-                    #[cfg(feature = "memory-debug")]
-                    if debug_memory_flag
-                        && let Some(stats) = stats_for_tracking.as_ref() {
-                            stats.track_position_group_memory(initial_group_size, false);
-                        }
-                    return Ok(ProcessedPositionGroup {
-                        templates: Vec::new(),
-                        family_sizes: AHashMap::new(),
-                        filter_counts,
-                        input_record_count,
-                        distinct_mi_count: 0,
-                    });
-                }
-
-                // Create UMI assigner for this group. See `should_use_parallel`
-                // for the two triggers: (a) `--allow-unmapped` parallelizes
-                // every group (these runs are dominated by one huge unmapped
-                // group); (b) the user-set `--parallel-group-min-templates`
-                // threshold is met for this group's strategy.
-                let use_parallel = should_use_parallel(
-                    allow_unmapped,
-                    filtered_templates.len(),
-                    strategy,
-                    parallel_group_min_templates.as_ref(),
-                );
-                let assigner = create_umi_assigner(
-                    strategy,
-                    effective_edits,
-                    index_threshold,
-                    num_threads,
-                    use_parallel,
-                );
-
-                // Assign UMI groups using the unified _impl function
-                let mut templates = filtered_templates;
-                if let Err(e) = assign_umi_groups_impl(
-                    &mut templates,
-                    assigner.as_ref(),
-                    raw_tag,
-                    filter_config.min_umi_length,
-                    no_umi,
-                ) {
-                    // A failed assignment means this position group's reads cannot be
-                    // grouped at all — an unparseable UMI for the chosen strategy, a
-                    // missing `RX` tag, mixed UMI lengths. Substituting an empty group
-                    // would silently drop every read in it and still exit 0, so fail
-                    // the run and let the user fix the input or the strategy.
-                    #[cfg(feature = "memory-debug")]
-                    if debug_memory_flag
-                        && let Some(stats) = stats_for_tracking.as_ref() {
-                            stats.track_position_group_memory(initial_group_size, false);
-                            stats.track_template_memory(_template_memory_size, false);
-                        }
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        format!("Failed to assign UMI groups: {e:#}"),
-                    ));
-                }
-
-                // Compute the number of distinct numeric molecule IDs assigned in this group.
-                // Assigners hand out numeric IDs 0, 1, 2, ... contiguously, so `max(id) + 1`
-                // equals the count of distinct IDs used. This can be less than
-                // `templates.len()` when multiple templates share a UMI family (and hence a
-                // MoleculeId) or when paired A/B variants share the same numeric id.
-                let distinct_mi_count: u64 = templates
-                    .iter()
-                    .filter_map(|t| t.mi.id())
-                    .max()
-                    .map(|max_id| max_id + 1)
-                    .unwrap_or(0);
-
-                // Sort templates directly by (MI index, name) - avoids Vec<Vec<Template>> allocation
-                templates.sort_by(|a, b| {
-                    let a_idx = a.mi.to_vec_index();
-                    let b_idx = b.mi.to_vec_index();
-                    a_idx.cmp(&b_idx).then_with(|| a.name.cmp(&b.name))
-                });
-
-                // Count family sizes in one pass through sorted templates
-                // Family sizes rarely exceed 50 distinct sizes
-                let mut family_sizes: AHashMap<usize, u64> = AHashMap::with_capacity(50);
-                if !templates.is_empty() {
-                    let mut current_mi = templates[0].mi.to_vec_index();
-                    let mut current_count = 1usize;
-
-                    for template in templates.iter().skip(1) {
-                        let mi = template.mi.to_vec_index();
-                        if mi == current_mi {
-                            current_count += 1;
-                        } else {
-                            // Finish previous MI group
-                            if current_mi.is_some() {
-                                *family_sizes.entry(current_count).or_insert(0) += 1;
-                            }
-                            current_mi = mi;
-                            current_count = 1;
-                        }
-                    }
-                    // Don't forget the last group
-                    if current_mi.is_some() {
-                        *family_sizes.entry(current_count).or_insert(0) += 1;
-                    }
-                }
-
-                // Templates are now sorted by MI, no need for additional collection
-
-                // Track memory deallocation when processing completes (if debug mode)
-                #[cfg(feature = "memory-debug")]
-                if debug_memory_flag
-                    && let Some(stats) = stats_for_tracking.as_ref() {
-                        stats.track_position_group_memory(initial_group_size, false);
-                    }
-
-                Ok(ProcessedPositionGroup {
-                    templates,
-                    family_sizes,
-                    filter_counts,
-                    input_record_count,
-                    distinct_mi_count,
-                })
-            },
-            // serialize_fn: Serialize records + collect metrics (serial, ordered)
-            move |processed: ProcessedPositionGroup,
-                  _header: &Header,
-                  output: &mut Vec<u8>|
-                  -> std::io::Result<u64> {
-                #[cfg(feature = "memory-debug")]
-                if short_circuit_serialize {
-                    let count = processed.input_record_count;
-                    if debug_memory_flag
-                        && let Some(stats) = stats_for_serialize.as_ref() {
-                            let tmpl_size = estimate_templates_heap_size(&processed.templates);
-                            stats.track_template_memory(tmpl_size, false);
-                        }
-                    drop(processed);
-                    return Ok(count);
-                }
-                // Merge per-group metrics into this worker's accumulator slot.
-                // Memory stays O(threads × distinct sizes) instead of growing
-                // one hashmap per position group.
-                accumulators_clone.with_slot(|acc| {
-                    acc.record_group(processed.family_sizes, &processed.filter_counts);
-                });
-
-                // Save input record count for progress tracking
-                let input_record_count = processed.input_record_count;
-
-                // Track template memory deallocation (templates are consumed here)
-                #[cfg(feature = "memory-debug")]
-                if debug_memory_flag
-                    && let Some(stats) = stats_for_serialize.as_ref() {
-                        let tmpl_size = estimate_templates_heap_size(&processed.templates);
-                        stats.track_template_memory(tmpl_size, false);
-                    }
-
-                // Serialize primary reads directly from templates — no
-                // intermediate `Vec<RecordBuf>`. Templates already carry
-                // their final global `MoleculeId`s because the MI Assign
-                // hook (installed below) ran in serial order before this
-                // closure was called, so we pass `base_mi = 0` to the
-                // emitter. Each record is serialized and dropped
-                // immediately, keeping per-thread peak memory low.
-                // Pre-allocate output buffer: ~2 records/template × ~400 bytes/record.
-                output.reserve(processed.templates.len() * 2 * 400);
-                let mut scratch = Vec::with_capacity(512);
-                let mut mi_buf = String::with_capacity(16);
-                emit_templates_raw_with_mi(
-                    &processed.templates,
-                    0,
-                    assign_tag_bytes,
-                    &mut scratch,
-                    &mut mi_buf,
-                    |bytes| {
-                        output.extend_from_slice(bytes);
-                        Ok(())
-                    },
-                )?;
-                // Short-circuit: let serialize run fully but starve compress/write
-                #[cfg(feature = "memory-debug")]
-                if short_circuit_compress {
-                    output.clear();
-                }
-                // Return INPUT record count for progress tracking (not output count)
-                Ok(input_record_count)
-            },
-            // mi_assign_fn: called in serial order by the MI Assign zone
-            // before each item's `serialize_fn`. Folds a cumulative offset
-            // into every template's local `MoleculeId`, turning per-position-
-            // group local IDs (0..N-1) into globally contiguous IDs that
-            // `serialize_fn` can emit verbatim.
-            move |_ord, processed: &mut ProcessedPositionGroup| {
-                // `fetch_update` + `checked_add` so wraparound is detected and surfaced
-                // rather than silently reusing MI integers (which would defeat
-                // `MoleculeId::with_offset`'s own overflow check on the per-template add).
-                let base = next_mi_base_for_hook
-                    .fetch_update(
-                        std::sync::atomic::Ordering::Relaxed,
-                        std::sync::atomic::Ordering::Relaxed,
-                        |current| current.checked_add(processed.distinct_mi_count),
-                    )
-                    .map_err(|_| {
-                        std::io::Error::new(
-                            std::io::ErrorKind::InvalidData,
-                            "MoleculeId offset overflow: cumulative MI counter exceeded u64::MAX",
-                        )
-                    })?;
-                for template in &mut processed.templates {
-                    template.mi = template.mi.with_offset(base);
-                }
-                Ok(())
-            },
+            reader_opts.verify_crc,
+            &header,
+            effective_strategy,
+            effective_edits,
+            raw_tag,
+            assign_tag_bytes,
+            cell_tag,
+            &filter_config,
+            &timer,
         )
-        .context("Pipeline execution failed")?;
-
-        // Cleanup memory monitoring if it was enabled
-        #[cfg(feature = "memory-debug")]
-        if let Some((handle, shutdown_signal)) = memory_monitor_handle {
-            use crate::unified_pipeline::log_comprehensive_memory_stats;
-
-            shutdown_signal.store(true, std::sync::atomic::Ordering::Relaxed);
-            let _: Result<(), _> = handle.join();
-
-            if let Some(stats) = shared_stats.as_ref() {
-                log_comprehensive_memory_stats(stats);
-                info!("Memory monitoring stopped - final stats logged above");
-            }
-        }
-
-        info!("Wrote output to {}", self.io.output.display());
-
-        // Reduce per-thread accumulators into final counters. The pipeline has
-        // returned, so `accumulators_clone` inside serialize_fn has been dropped
-        // along with the closure; remaining Arc holders are this call site and
-        // any debug monitor, so we iterate slots by reference rather than
-        // requiring unique ownership.
-        let mut family_size_counter: AHashMap<usize, u64> = AHashMap::with_capacity(50);
-        let mut position_group_size_counter: AHashMap<usize, u64> = AHashMap::with_capacity(50);
-        let mut total_filter_counts = TemplateFilterCounts::new();
-
-        for slot in accumulators.slots() {
-            let acc = slot.lock();
-            for (&size, &count) in &acc.family_sizes {
-                *family_size_counter.entry(size).or_insert(0) += count;
-            }
-            for (&size, &count) in &acc.position_group_sizes {
-                *position_group_size_counter.entry(size).or_insert(0) += count;
-            }
-            total_filter_counts.merge(&acc.filter_counts);
-        }
-
-        let metrics = build_grouping_metrics(&total_filter_counts, &family_size_counter);
-        log_umi_grouping_summary(&metrics);
-
-        // Write all metrics (individual flags and --metrics prefix)
-        self.write_all_metrics(&metrics, &family_size_counter, &position_group_size_counter)?;
-
-        // Log completion with timing
-        timer.log_completion(metrics.accepted_records);
-
-        info!("group completed successfully");
-        info!("Records processed by pipeline: {records_processed}");
-        Ok(())
     }
 }
 
 impl GroupReadsByUmi {
+    /// Run the group stage on the declarative chain builder (the `--threads N`
+    /// path).
+    ///
+    /// Replaces the former hand-rolled unified-pipeline construction. The chain
+    /// opens its own source, injects `@PG`, validates record ordering, assigns
+    /// `MoleculeId`s deterministically, writes the output BAM, and writes the
+    /// grouping metrics via its finalize hook — all through the same shared
+    /// helpers (`require_group_input_ordering`, `add_pg_record`,
+    /// `write_metrics_for_chain`) as the single-threaded path, so the two
+    /// orchestrations of the group stage stay in parity.
+    fn execute_chain(&self, command_line: &str) -> Result<()> {
+        use crate::pipeline::chains::{
+            ChainSpec, SingleStageContext, Stage, StageOptionsBag, build_for,
+        };
+
+        // The chain's `add_group` re-emits the timer/banner/threading log lines
+        // but not the CRC-verify status; emit it here so the --threads path
+        // reports it once, matching the single-threaded path.
+        self.io.log_effective_check_crc();
+
+        // The chain engine does not carry the legacy unified-pipeline memory
+        // monitor, so the memory-debug knobs the old --threads path honored have
+        // no effect here. Warn rather than silently no-op; FGUMI_PIPELINE_STATS
+        // is the chain's equivalent stats hook.
+        #[cfg(feature = "memory-debug")]
+        if self.debug_memory {
+            warn!(
+                "--debug-memory is not supported on the --threads chain path and is ignored; \
+                 set FGUMI_PIPELINE_STATS=1 for chain pipeline stats"
+            );
+        }
+        // `FGUMI_SHORT_CIRCUIT` is an env var, not part of the `memory-debug`
+        // feature, so warn about it in every build rather than only when
+        // `memory-debug` is compiled in.
+        if std::env::var("FGUMI_SHORT_CIRCUIT").is_ok_and(|v| !v.is_empty()) {
+            warn!(
+                "FGUMI_SHORT_CIRCUIT is not supported on the --threads chain path and is ignored"
+            );
+        }
+
+        let stage_opts =
+            StageOptionsBag { group: Some(self.to_group_options()), ..Default::default() };
+        let ctx = SingleStageContext {
+            io: &self.io,
+            threading: &self.threading,
+            compression: &self.compression,
+            scheduler: &self.scheduler_opts,
+            queue_memory: &self.queue_memory,
+            command_line,
+        };
+        let spec = ChainSpec::single_stage(Stage::Group, stage_opts, &ctx);
+        build_for(spec)?.run()
+    }
+
     /// Execute in single-threaded mode for `--threads 1`.
     ///
     /// This provides a simpler, streaming implementation that avoids pipeline overhead
@@ -1709,47 +1280,25 @@ impl GroupReadsByUmi {
     }
 
     /// Write all metrics files: individual flags and --metrics prefix outputs.
+    ///
+    /// Delegates to [`write_metrics_for_chain`] so the single-threaded path and
+    /// the chain builder's `GroupFinalizeHook` share one implementation and
+    /// cannot emit divergent metrics files (same filenames, order, and labels)
+    /// for the same input.
     fn write_all_metrics(
         &self,
         grouping_metrics: &UmiGroupingMetrics,
         family_sizes: &AHashMap<usize, u64>,
         position_group_sizes: &AHashMap<usize, u64>,
     ) -> Result<()> {
-        let family_size_metrics =
-            FamilySizeMetrics::from_size_counts(family_sizes.iter().map(|(&s, &c)| (s, c)));
-        let position_group_size_metrics = PositionGroupSizeMetrics::from_size_counts(
-            position_group_sizes.iter().map(|(&s, &c)| (s, c)),
-        );
-
-        // Write individual flag outputs (fgbio-compatible)
-        if let Some(path) = &self.family_size_histogram {
-            write_metrics(path, &family_size_metrics, "family size histogram")?;
-        }
-        if let Some(path) = &self.grouping_metrics {
-            write_metrics(path, std::slice::from_ref(grouping_metrics), "grouping metrics")?;
-        }
-
-        // Write --metrics prefix outputs (all three files)
-        if let Some(prefix) = &self.metrics {
-            let family_path = with_extension(prefix, "family_sizes.txt");
-            write_metrics(&family_path, &family_size_metrics, "family size histogram")?;
-
-            let grouping_path = with_extension(prefix, "grouping_metrics.txt");
-            write_metrics(
-                &grouping_path,
-                std::slice::from_ref(grouping_metrics),
-                "grouping metrics",
-            )?;
-
-            let position_path = with_extension(prefix, "position_group_sizes.txt");
-            write_metrics(
-                &position_path,
-                &position_group_size_metrics,
-                "position group size histogram",
-            )?;
-        }
-
-        Ok(())
+        write_metrics_for_chain(
+            grouping_metrics,
+            family_sizes,
+            position_group_sizes,
+            self.family_size_histogram.as_deref(),
+            self.grouping_metrics.as_deref(),
+            self.metrics.as_deref(),
+        )
     }
 }
 
@@ -1871,6 +1420,9 @@ pub(crate) fn write_metrics_for_chain(
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Production code now writes metrics via `write_metrics_for_chain` (which
+    // imports these itself); the tests still construct them directly.
+    use crate::metrics::group::{FamilySizeMetrics, PositionGroupSizeMetrics};
 
     /// The `--no-umi` and identity-implies-zero-edits rules, pinned as a table.
     ///

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -70,14 +70,14 @@ fn estimate_templates_heap_size(templates: &[Template]) -> usize {
 /// per-position-group results into its own slot, so memory is O(threads ×
 /// distinct family/position-group sizes) rather than O(position groups).
 #[derive(Default, Debug)]
-struct GroupMetricsAccumulator {
-    family_sizes: AHashMap<usize, u64>,
-    position_group_sizes: AHashMap<usize, u64>,
-    filter_counts: TemplateFilterCounts,
+pub(crate) struct GroupMetricsAccumulator {
+    pub(crate) family_sizes: AHashMap<usize, u64>,
+    pub(crate) position_group_sizes: AHashMap<usize, u64>,
+    pub(crate) filter_counts: TemplateFilterCounts,
 }
 
 impl GroupMetricsAccumulator {
-    fn record_group(
+    pub(crate) fn record_group(
         &mut self,
         family_sizes: AHashMap<usize, u64>,
         filter_counts: &TemplateFilterCounts,
@@ -283,7 +283,7 @@ fn classify_input_ordering(header: &Header, allow_unmapped: bool) -> InputOrderi
 ///    huge group", so *every* group in the run takes the parallel path.
 /// 2. `parallel_group_min_templates` is set and this group has at least the
 ///    per-strategy threshold number of templates (see `parallel_threshold`).
-fn should_use_parallel(
+pub(crate) fn should_use_parallel(
     allow_unmapped: bool,
     template_count: usize,
     strategy: Strategy,
@@ -303,7 +303,7 @@ fn should_use_parallel(
 /// pool delivers no parallelism while still paying pool-construction overhead,
 /// so `--threads 1` and `execute_single_threaded` (which passes `threads = 1`)
 /// always fall back to the sequential assigner regardless of `use_parallel`.
-fn create_umi_assigner(
+pub(crate) fn create_umi_assigner(
     strategy: Strategy,
     effective_edits: u32,
     index_threshold: IndexThreshold,
@@ -325,7 +325,7 @@ fn create_umi_assigner(
 }
 
 /// Assign UMI groups to templates (static implementation).
-fn assign_umi_groups_impl(
+pub(crate) fn assign_umi_groups_impl(
     templates: &mut [Template],
     assigner: &dyn UmiAssigner,
     raw_tag: [u8; 2],
@@ -773,6 +773,30 @@ pub struct GroupOptions {
     pub metrics_prefix: Option<PathBuf>,
 }
 
+impl Default for GroupOptions {
+    /// Test/`runall`-construction default. `strategy` has no meaningful default
+    /// (it is a required CLI flag), so the most conservative `Identity` is used
+    /// for the placeholder; callers that care set it explicitly.
+    fn default() -> Self {
+        Self {
+            min_map_q: 1,
+            include_non_pf_reads: false,
+            allow_unmapped: false,
+            strategy: Strategy::Identity,
+            edits: 1,
+            min_umi_length: None,
+            index_threshold: IndexThreshold::default(),
+            no_umi: false,
+            parallel_group_min_templates: None,
+            effective_strategy: Strategy::Identity,
+            effective_edits: 0,
+            family_size_histogram: None,
+            grouping_metrics: None,
+            metrics_prefix: None,
+        }
+    }
+}
+
 impl GroupReadsByUmi {
     /// The minimum mapping quality to apply, defaulting when the flag is absent.
     #[must_use]
@@ -822,7 +846,7 @@ impl GroupReadsByUmi {
 /// Build [`UmiGroupingMetrics`] from filter metrics and family size counts.
 ///
 /// Shared by both the pipeline and single-threaded execution paths.
-fn build_grouping_metrics(
+pub(crate) fn build_grouping_metrics(
     filter_counts: &TemplateFilterCounts,
     family_size_counter: &AHashMap<usize, u64>,
 ) -> UmiGroupingMetrics {
@@ -1881,6 +1905,56 @@ fn with_extension(prefix: &Path, suffix: &str) -> PathBuf {
     s.push(".");
     s.push(suffix);
     PathBuf::from(s)
+}
+
+
+/// Write all group metrics files for the chain-builder finalize hook.
+///
+/// Called from `GroupFinalizeHook::finalize` with the fully reduced
+/// per-thread accumulators. Mirrors the logic in
+/// `GroupReadsByUmi::write_all_metrics` but takes explicit paths rather than
+/// reading from `&self`.
+pub(crate) fn write_metrics_for_chain(
+    grouping_metrics: &crate::metrics::group::UmiGroupingMetrics,
+    family_sizes: &AHashMap<usize, u64>,
+    position_group_sizes: &AHashMap<usize, u64>,
+    family_size_histogram: Option<&Path>,
+    grouping_metrics_path: Option<&Path>,
+    metrics_prefix: Option<&Path>,
+) -> Result<()> {
+    use crate::metrics::group::{FamilySizeMetrics, PositionGroupSizeMetrics};
+
+    let family_size_metrics =
+        FamilySizeMetrics::from_size_counts(family_sizes.iter().map(|(&s, &c)| (s, c)));
+    let position_group_size_metrics = PositionGroupSizeMetrics::from_size_counts(
+        position_group_sizes.iter().map(|(&s, &c)| (s, c)),
+    );
+
+    // Individual flag outputs (fgbio-compatible)
+    if let Some(path) = family_size_histogram {
+        write_metrics(path, &family_size_metrics, "family size histogram")?;
+    }
+    if let Some(path) = grouping_metrics_path {
+        write_metrics(path, std::slice::from_ref(grouping_metrics), "grouping metrics")?;
+    }
+
+    // --metrics prefix outputs (all three files)
+    if let Some(prefix) = metrics_prefix {
+        let family_path = with_extension(prefix, "family_sizes.txt");
+        write_metrics(&family_path, &family_size_metrics, "family size histogram")?;
+
+        let gm_path = with_extension(prefix, "grouping_metrics.txt");
+        write_metrics(&gm_path, std::slice::from_ref(grouping_metrics), "grouping metrics")?;
+
+        let position_path = with_extension(prefix, "position_group_sizes.txt");
+        write_metrics(
+            &position_path,
+            &position_group_size_metrics,
+            "position group size histogram",
+        )?;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -333,7 +333,7 @@ impl SimplexOptions {
     /// Reconstruct the shared [`ConsensusCallingOptions`] from the inlined flat
     /// fields, so the chain builder can read `.consensus().error_rate_pre_umi`
     /// etc. `tie_rule` is stored resolved on `SimplexOptions`; convert it back to
-    /// the CLI-facing [`TieRuleArg`] via the 1:1 mapping.
+    /// the CLI-facing `TieRuleArg` via the 1:1 mapping.
     #[must_use]
     pub fn consensus(&self) -> ConsensusCallingOptions {
         ConsensusCallingOptions {

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -329,6 +329,52 @@ impl Simplex {
     }
 }
 
+impl SimplexOptions {
+    /// Reconstruct the shared [`ConsensusCallingOptions`] from the inlined flat
+    /// fields, so the chain builder can read `.consensus().error_rate_pre_umi`
+    /// etc. `tie_rule` is stored resolved on `SimplexOptions`; convert it back to
+    /// the CLI-facing [`TieRuleArg`] via the 1:1 mapping.
+    #[must_use]
+    pub fn consensus(&self) -> ConsensusCallingOptions {
+        ConsensusCallingOptions {
+            error_rate_pre_umi: self.error_rate_pre_umi,
+            error_rate_post_umi: self.error_rate_post_umi,
+            min_input_base_quality: self.min_input_base_quality,
+            output_per_base_tags: self.output_per_base_tags,
+            trim: self.trim,
+            min_consensus_base_quality: self.min_consensus_base_quality,
+            tie_rule: self.tie_rule.into(),
+        }
+    }
+
+    /// Reconstruct the shared [`OverlappingConsensusOptions`] from the inlined
+    /// flat field.
+    #[must_use]
+    pub fn overlapping(&self) -> OverlappingConsensusOptions {
+        OverlappingConsensusOptions {
+            consensus_call_overlapping_bases: self.consensus_call_overlapping_bases,
+        }
+    }
+
+    /// Validate the `--min-reads` / `--max-reads` range.
+    ///
+    /// `min_reads` must be `>= 1` (a value of 0 admits empty groups) and, when
+    /// `max_reads` is set, it must be `>= min_reads`. Shared by the standalone
+    /// `Simplex::execute` and the chain builder's `add_simplex` so `runall`
+    /// rejects the same degenerate configurations the standalone command does.
+    pub(crate) fn validate_read_bounds(&self) -> Result<()> {
+        if self.min_reads == 0 {
+            bail!("--min-reads must be >= 1 (a value of 0 admits empty groups)");
+        }
+        if let Some(max) = self.max_reads
+            && max < self.min_reads
+        {
+            bail!("--max-reads ({}) must be >= --min-reads ({})", max, self.min_reads);
+        }
+        Ok(())
+    }
+}
+
 impl Command for Simplex {
     fn execute(&self, command_line: &str) -> Result<()> {
         // Start timing
@@ -618,15 +664,7 @@ impl Simplex {
     ///
     /// Returns an error if `min_reads` is 0, or if `max_reads` is below `min_reads`.
     fn validate_read_bounds(&self) -> Result<()> {
-        if self.min_reads == 0 {
-            bail!("--min-reads must be >= 1 (a value of 0 admits empty groups)");
-        }
-        if let Some(max) = self.max_reads
-            && max < self.min_reads
-        {
-            bail!("--max-reads ({}) must be >= --min-reads ({})", max, self.min_reads);
-        }
-        Ok(())
+        self.to_simplex_options().validate_read_bounds()
     }
 
     /// Execute using 7-step unified pipeline with --threads.

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -421,6 +421,71 @@ pub struct Sort {
     pub sort_stats: bool,
 }
 
+/// Sort-stage tuning, projected out of the [`Sort`] CLI struct for the chain
+/// builder's `add_sort` (which reads these values from the
+/// [`crate::pipeline::chains::StageOptionsBag`] rather than from `Sort`
+/// directly).
+///
+/// `block_batch` and `file_granularity` are chain-engine knobs that `Sort`
+/// does not yet expose as CLI flags; until the sort command is rewired onto the
+/// chain they take the engine defaults (`block_batch = 4`, the original
+/// `MAX_BATCH_PER_CALL`; `file_granularity = false`, block-parallel).
+#[derive(Debug, Clone)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct SortOptions {
+    /// Requested output sort order.
+    pub order: SortOrderArg,
+    /// Expert override for the provisioned template-coordinate key lanes.
+    pub key_types: Option<KeyTypesSpec>,
+    /// In-memory sort budget before spilling.
+    pub max_memory: MemoryLimit,
+    /// Memory reserved for other processes under `--max-memory=auto`.
+    pub memory_reserve: MemoryReserve,
+    /// Whether `max_memory` is per-thread (samtools behavior).
+    pub memory_per_thread: bool,
+    /// Temp directories for spill chunks (free-space-aware round-robin).
+    pub tmp_dirs: Vec<PathBuf>,
+    /// Worker threads for the accumulate/sort/spill phase (Phase 1).
+    pub sort_threads: Option<usize>,
+    /// Worker threads for the k-way merge phase (Phase 2).
+    pub merge_threads: Option<usize>,
+    /// Compression level for temporary spill files (0-9).
+    pub temp_compression: u32,
+    /// Codec for temporary spill files.
+    pub temp_codec: fgumi_sort::SpillCodec,
+    /// Spill-file consolidation limit (`--max-temp-files`). Resolved against the
+    /// host `RLIMIT_NOFILE` when `Auto`; without this the chain sorter fell back
+    /// to the engine's portable default and ignored the CLI value.
+    pub max_temp_files: MaxTempFiles,
+    /// Records batched per parallel sort call (chain engine; not a CLI flag).
+    pub block_batch: usize,
+    /// Spill at file rather than block granularity (chain engine; not a CLI flag).
+    pub file_granularity: bool,
+}
+
+impl Sort {
+    /// Projects the parsed CLI flags into [`SortOptions`] for the chain builder.
+    #[must_use]
+    pub fn to_sort_options(&self) -> SortOptions {
+        SortOptions {
+            order: self.order,
+            key_types: self.key_types,
+            max_memory: self.max_memory,
+            memory_reserve: self.memory_reserve,
+            memory_per_thread: self.memory_per_thread,
+            tmp_dirs: self.tmp_dirs.clone(),
+            sort_threads: self.sort_threads,
+            merge_threads: self.merge_threads,
+            temp_compression: self.temp_compression,
+            temp_codec: self.temp_codec,
+            max_temp_files: self.max_temp_files,
+            // Chain-engine defaults (see `SortOptions` docs) — not yet CLI flags.
+            block_batch: 4,
+            file_granularity: false,
+        }
+    }
+}
+
 /// Environment variable name for the fallback temp-dir list, parsed as a
 /// `PATH`-style list when no `-T/--tmp-dir` flags are passed.
 pub(crate) const TMP_DIRS_ENV: &str = "FGUMI_TMP_DIRS";

--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -1345,6 +1345,496 @@ impl Command for Zipper {
     }
 }
 
+// ==== ported from feat-runall for the chain builder (R2) ====
+/// Log line emitted when the chain builder wires the typed-step zipper path
+/// (the log site lives in `pipeline::chains::builder`). Pinned as a `pub const`
+/// so integration tests that assert the new typed-step path was taken (e.g.
+/// `runall_zipper_self_pair_uses_new_pipeline`) share a single source of truth
+/// with the log site and cannot drift.
+pub const NEW_PIPELINE_START_LOG: &str = "Starting zipper (new pipeline)";
+
+/// Apply the full zipper merge body to a single (unmapped, mapped)
+/// template pair. Runs `merge_raw`, then (when `reference` is `Some`)
+/// `restore_unconverted_bases_in_raw_template` for the bisulfite path.
+///
+/// Returned errors are bare — callers add their own context (e.g. the
+/// caller's step name) via `.map_err`/`?` at the call site so the
+/// surfaced error is attributable to the dispatching context.
+///
+/// Used by:
+/// - `ZipperMergeStep::emit_merged` (typed-step zipper)
+/// - `AlignAndMergeStep::merge_zipper_batch` (AAM dispatcher)
+pub(crate) fn merge_one_template(
+    unmapped: &Template,
+    mapped: &mut Template,
+    tag_info: &TagInfo,
+    skip_tc_tags: bool,
+    reference: Option<&ReferenceReader>,
+    output_header: &Header,
+) -> Result<()> {
+    merge_raw(unmapped, mapped, tag_info, skip_tc_tags)?;
+    if let Some(ref_reader) = reference {
+        restore_unconverted_bases_in_raw_template(mapped, ref_reader, output_header)?;
+    }
+    Ok(())
+}
+
+// ── ported from feat-runall for the chain builder (R2): the Step2 merge step ──
+pub(crate) mod merge_step {
+    use std::io;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use noodles::sam::Header;
+
+    use crate::pipeline::core::Unpushed;
+    use crate::pipeline::core::held::HeldSlot;
+    use crate::pipeline::core::outputs::OrderedBytesSingle;
+    use crate::pipeline::core::queues::QueueSpec;
+    use crate::pipeline::core::reorder::BranchOrdering;
+    use crate::pipeline::core::step::{Step2, StepCtx2, StepKind, StepOutcome, StepProfile};
+    use crate::pipeline::steps::types::BamTemplateBatch;
+    use crate::reference::ReferenceReader;
+    use crate::template::Template;
+    use crate::umi::TagInfo;
+
+    /// Cap on the number of templates one `try_run` call processes
+    /// before yielding. Bounds per-call wall time so the Serial mutex
+    /// doesn't starve other workers. Mirrors the
+    /// `MAX_BATCHES_PER_LOCK` discipline used by `GroupByQueryname`,
+    /// but in template-units since the merge body's work is
+    /// per-template.
+    const MAX_TEMPLATES_PER_CALL: usize = 1024;
+
+    /// Immutable configuration shared by the step.
+    ///
+    /// Cloning is one `Arc` clone per field — cheap; intentionally
+    /// crammed into one struct so the call-site builder stays small.
+    #[derive(Clone)]
+    pub struct ZipperMergeConfig {
+        pub tag_info: Arc<TagInfo>,
+        pub skip_tc_tags: bool,
+        pub exclude_missing_reads: bool,
+        pub reference: Option<Arc<ReferenceReader>>,
+        pub output_header: Arc<Header>,
+        /// Counter for unmapped templates that had no mapped match.
+        /// Exposed back to the command after `Pipeline::run` so the
+        /// summary log (`"Excluded N templates..."`) reflects the
+        /// final missing-mapped count.
+        pub missing_count: Arc<AtomicU64>,
+        /// Counter for records pushed into the output stream (matched
+        /// merges + unmapped-only emits). Exposed back to the command
+        /// after `Pipeline::run` so the final `log_completion` line
+        /// reports a real throughput number instead of zero.
+        pub records_emitted: Arc<AtomicU64>,
+        pub target_batch_count: usize,
+        pub output_byte_limit: u64,
+    }
+
+    /// One batch's templates in flight on a branch + the cursor into them.
+    /// Owns the `Vec<Template>` moved out of the batch (via
+    /// [`BamTemplateBatch::into_parts`]) so the drain cursor can replace
+    /// slots in place — the cached `total_bytes` is dropped with the batch,
+    /// so there is no stale accounting to worry about.
+    struct PendingBatch {
+        templates: Vec<Template>,
+        cursor: usize,
+    }
+
+    impl PendingBatch {
+        fn new(batch: BamTemplateBatch) -> Self {
+            let (_, templates) = batch.into_parts();
+            Self { templates, cursor: 0 }
+        }
+
+        fn current(&self) -> Option<&Template> {
+            self.templates.get(self.cursor)
+        }
+
+        fn take_current(&mut self) -> Option<Template> {
+            let i = self.cursor;
+            if i >= self.templates.len() {
+                return None;
+            }
+            self.cursor += 1;
+            // Replace the slot with an empty placeholder so the
+            // surrounding `Vec` can keep its length without the
+            // `Template: Default` bound (Template carries a
+            // `MoleculeId` enum that has no canonical default).
+            Some(std::mem::replace(&mut self.templates[i], Template::new(Vec::new())))
+        }
+
+        fn is_exhausted(&self) -> bool {
+            self.cursor >= self.templates.len()
+        }
+    }
+
+    /// `Serial + ByItemOrdinal` Step2 merger that pairs unmapped
+    /// (`InputA`) and mapped (`InputB`) templates by queryname order
+    /// and emits merged [`BamTemplateBatch`]es.
+    pub struct ZipperMergeStep {
+        cfg: ZipperMergeConfig,
+        pending_a: Option<PendingBatch>,
+        pending_b: Option<PendingBatch>,
+        accumulator: Vec<Template>,
+        next_ordinal: u64,
+        held: HeldSlot<Unpushed<BamTemplateBatch>>,
+        name: &'static str,
+    }
+
+    impl ZipperMergeStep {
+        #[must_use]
+        pub fn new(mut cfg: ZipperMergeConfig) -> Self {
+            // Clamp the batching threshold the loop actually compares against,
+            // not just the accumulator capacity: with `target_batch_count == 0`
+            // the `accumulator.len() >= target_batch_count` checks in `try_run`
+            // / `push_template` are true on an empty accumulator, so the step
+            // livelocks emitting empty batches and never pulls input. The
+            // sibling batch-emitting steps (`GroupByQueryname`,
+            // `GroupByPosition`, `MiAssign`) clamp the stored field the same
+            // way; clamping `cfg` here makes every `self.cfg.target_batch_count`
+            // read see the floored value.
+            cfg.target_batch_count = cfg.target_batch_count.max(1);
+            let target = cfg.target_batch_count;
+            Self {
+                cfg,
+                pending_a: None,
+                pending_b: None,
+                accumulator: Vec::with_capacity(target),
+                next_ordinal: 0,
+                held: HeldSlot::new(),
+                name: "ZipperMerge",
+            }
+        }
+
+        /// Push a fully-merged template into the accumulator and emit
+        /// a batch if the target count is reached. Increments the
+        /// records-emitted counter by the template's record count so
+        /// the post-run `log_completion` reports an accurate throughput
+        /// number.
+        fn push_template(
+            &mut self,
+            template: Template,
+            ctx: &mut StepCtx2<'_, Self>,
+        ) -> Option<StepOutcome> {
+            self.cfg.records_emitted.fetch_add(template.read_count() as u64, Ordering::Relaxed);
+            self.accumulator.push(template);
+            if self.accumulator.len() >= self.cfg.target_batch_count {
+                Some(self.emit_batch(ctx))
+            } else {
+                None
+            }
+        }
+
+        /// Both input branches are drained and every template has been
+        /// processed: flush the final partial accumulator (if any) and report
+        /// `Finished`. A bounced flush is parked in `held` and retried by
+        /// `try_run`'s held-drain preamble on the next pass (which then
+        /// re-reaches this path with an empty accumulator → `Finished`).
+        fn finish_accumulator(&mut self, ctx: &mut StepCtx2<'_, Self>) -> StepOutcome {
+            if self.accumulator.is_empty() {
+                return StepOutcome::Finished;
+            }
+            self.emit_batch(ctx)
+        }
+
+        /// Package the accumulator into a [`BamTemplateBatch`] and
+        /// emit. On rejection, hold; retry on the next `try_run`.
+        fn emit_batch(&mut self, ctx: &mut StepCtx2<'_, Self>) -> StepOutcome {
+            let serial = self.next_ordinal;
+            self.next_ordinal += 1;
+            let templates = std::mem::replace(
+                &mut self.accumulator,
+                Vec::with_capacity(self.cfg.target_batch_count),
+            );
+            let out = BamTemplateBatch::new(serial, templates);
+            if let Err(unpushed) = ctx.outputs.push(out) {
+                self.held.put(unpushed);
+            }
+            StepOutcome::Progress
+        }
+
+        /// Emit an unmapped-only template (missing-mapped path).
+        fn emit_unmapped_only(
+            &mut self,
+            unmapped: Template,
+            ctx: &mut StepCtx2<'_, Self>,
+        ) -> io::Result<Option<StepOutcome>> {
+            if self.cfg.exclude_missing_reads {
+                self.cfg.missing_count.fetch_add(1, Ordering::Relaxed);
+                Ok(None)
+            } else {
+                let records =
+                    super::encode_unmapped_template_records(&unmapped, &self.cfg.output_header)
+                        .map_err(|e| {
+                            io::Error::other(format!("encode_unmapped_template_records: {e}"))
+                        })?;
+                let template = Template::from_records(records).map_err(|e| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("Template::from_records for unmapped-only: {e}"),
+                    )
+                })?;
+                Ok(self.push_template(template, ctx))
+            }
+        }
+
+        /// Apply the merge body to a matched (unmapped, mapped) pair
+        /// and emit the merged mapped template.
+        fn emit_merged(
+            &mut self,
+            unmapped: Template,
+            mut mapped: Template,
+            ctx: &mut StepCtx2<'_, Self>,
+        ) -> io::Result<Option<StepOutcome>> {
+            super::merge_one_template(
+                &unmapped,
+                &mut mapped,
+                &self.cfg.tag_info,
+                self.cfg.skip_tc_tags,
+                self.cfg.reference.as_deref(),
+                &self.cfg.output_header,
+            )
+            .map_err(|e| io::Error::other(format!("ZipperMergeStep: {e}")))?;
+            Ok(self.push_template(mapped, ctx))
+        }
+    }
+
+    impl Step2 for ZipperMergeStep {
+        type InputA = BamTemplateBatch;
+        type InputB = BamTemplateBatch;
+        type Outputs = OrderedBytesSingle<BamTemplateBatch>;
+
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: self.name,
+                kind: StepKind::Serial,
+                sticky: false,
+                output_queues: vec![QueueSpec::ByteBounded {
+                    limit_bytes: self.cfg.output_byte_limit,
+                }],
+                branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+            }
+        }
+
+        fn try_run(&mut self, ctx: &mut StepCtx2<'_, Self>) -> io::Result<StepOutcome> {
+            // 1. Drain held output slot first.
+            if let Some(unpushed) = self.held.take() {
+                match ctx.outputs.retry(unpushed) {
+                    Ok(()) => {}
+                    Err(again) => {
+                        self.held.put(again);
+                        return Ok(StepOutcome::Contention);
+                    }
+                }
+            }
+
+            // 2. If the accumulator is already full, emit before pulling more input.
+            if self.accumulator.len() >= self.cfg.target_batch_count {
+                return Ok(self.emit_batch(ctx));
+            }
+
+            let mut did_work = false;
+
+            // 3. Process up to `MAX_TEMPLATES_PER_CALL` templates per try_run.
+            for _ in 0..MAX_TEMPLATES_PER_CALL {
+                // Ensure pending_a has a non-exhausted current template.
+                loop {
+                    match self.pending_a.as_ref() {
+                        Some(pa) if !pa.is_exhausted() => break,
+                        Some(_) => self.pending_a = None,
+                        None => {
+                            if let Some(b) = ctx.a.pop() {
+                                self.pending_a = Some(PendingBatch::new(b));
+                            } else {
+                                // Unmapped queue is empty right now. If A is
+                                // also fully drained (producer signalled
+                                // end-of-stream) we'll never get another
+                                // unmapped template, so check for leftover
+                                // mapped reads *now*: the both-branches-drained
+                                // completion below only fires once B is drained
+                                // too, but B may still hold records here, so
+                                // surfacing the mismatch eagerly avoids looping
+                                // forever returning `NoProgress`.
+                                if ctx.a.is_drained() {
+                                    let leftover_b = self
+                                        .pending_b
+                                        .as_ref()
+                                        .and_then(|pb| pb.current())
+                                        .map(|t| t.name.clone())
+                                        .or_else(|| {
+                                            ctx.b.pop().and_then(|batch| {
+                                                batch.templates().first().map(|t| t.name.clone())
+                                            })
+                                        });
+                                    if let Some(name) = leftover_b {
+                                        return Err(io::Error::new(
+                                            io::ErrorKind::InvalidData,
+                                            format!(
+                                                "Error: processed all unmapped reads but there are mapped reads remaining. \
+                                                 Found template '{}'. Please ensure the unmapped and mapped reads have the \
+                                                 same set of read names in the same order, and reads with the same name \
+                                                 are consecutive (grouped) in each input.",
+                                                String::from_utf8_lossy(&name)
+                                            ),
+                                        ));
+                                    }
+                                    // Unmapped fully consumed and no mapped
+                                    // remaining. If the mapped branch is also
+                                    // drained the merge is complete — flush the
+                                    // final partial accumulator and report
+                                    // `Finished`. Otherwise (B still open) fall
+                                    // through and wait for more mapped reads.
+                                    if ctx.b.is_drained() {
+                                        return Ok(self.finish_accumulator(ctx));
+                                    }
+                                }
+                                // A not yet drained, or B still open — no input
+                                // ready right now.
+                                return Ok(if did_work {
+                                    StepOutcome::Progress
+                                } else {
+                                    StepOutcome::NoProgress
+                                });
+                            }
+                        }
+                    }
+                }
+
+                // Ensure pending_b has a non-exhausted current template
+                // (or set to None if its queue is currently empty).
+                loop {
+                    match self.pending_b.as_ref() {
+                        Some(pb) if !pb.is_exhausted() => break,
+                        Some(_) => self.pending_b = None,
+                        None => match ctx.b.pop() {
+                            Some(b) => self.pending_b = Some(PendingBatch::new(b)),
+                            None => break, // No mapped available right now; fall through.
+                        },
+                    }
+                }
+
+                // Peek both currents.
+                let pa_name: Vec<u8> = self
+                    .pending_a
+                    .as_ref()
+                    .and_then(|pa| pa.current())
+                    .expect("pending_a guaranteed non-exhausted above")
+                    .name
+                    .clone();
+                let pb_name: Option<Vec<u8>> =
+                    self.pending_b.as_ref().and_then(|pb| pb.current()).map(|t| t.name.clone());
+
+                let mapped_drained = self.pending_b.is_none() && ctx.b.is_drained();
+
+                let outcome = match pb_name {
+                    Some(ref n) if n == &pa_name => {
+                        // MERGE PATH — match.
+                        let unmapped = self.pending_a.as_mut().unwrap().take_current().unwrap();
+                        let mapped = self.pending_b.as_mut().unwrap().take_current().unwrap();
+                        self.emit_merged(unmapped, mapped, ctx)?
+                    }
+                    Some(_) => {
+                        // MISMATCH: the mapped head names a different template.
+                        // The mapped BAM is a subsequence of the unmapped BAM in
+                        // the same queryname order, so a name mismatch means the
+                        // current unmapped read is simply missing from the mapped
+                        // BAM — emit it as unmapped-only and advance the unmapped
+                        // cursor (leaving the mapped cursor put), exactly as fgbio
+                        // ZipperBams does (name-equality only).
+                        //
+                        // We deliberately do NOT compare sort order here. The
+                        // inputs may be query-GROUPED (records with the same name
+                        // consecutive) rather than queryname-sorted, in which case
+                        // successive groups can be in any order and a `natural`
+                        // comparison would spuriously reject valid input. A
+                        // genuinely orphaned mapped read (no unmapped counterpart)
+                        // is still caught by the end-of-stream "mapped reads
+                        // remaining" check once the unmapped branch drains.
+                        let unmapped = self.pending_a.as_mut().unwrap().take_current().unwrap();
+                        self.emit_unmapped_only(unmapped, ctx)?
+                    }
+                    None if mapped_drained => {
+                        // No more mapped will ever arrive.
+                        let unmapped = self.pending_a.as_mut().unwrap().take_current().unwrap();
+                        self.emit_unmapped_only(unmapped, ctx)?
+                    }
+                    None => {
+                        // No mapped right now, but ctx.b not drained — wait.
+                        return Ok(if did_work {
+                            StepOutcome::Progress
+                        } else {
+                            StepOutcome::NoProgress
+                        });
+                    }
+                };
+
+                did_work = true;
+
+                // If `emit_*` filled the accumulator and dispatched a
+                // batch, the next iteration starts with an empty
+                // accumulator — that's fine. The early-return below
+                // makes the per-call work bound predictable.
+                if let Some(stepwise) = outcome {
+                    debug_assert_eq!(stepwise, StepOutcome::Progress);
+                    return Ok(StepOutcome::Progress);
+                }
+            }
+
+            Ok(if did_work { StepOutcome::Progress } else { StepOutcome::NoProgress })
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::pipeline::core::reorder::BranchOrdering;
+        use crate::umi::TagInfo;
+        use noodles::sam::Header;
+        use std::sync::Arc;
+
+        fn make_cfg(exclude: bool) -> ZipperMergeConfig {
+            ZipperMergeConfig {
+                tag_info: Arc::new(TagInfo::new(vec![], vec![], vec![])),
+                skip_tc_tags: true,
+                exclude_missing_reads: exclude,
+                reference: None,
+                output_header: Arc::new(Header::default()),
+                missing_count: Arc::new(AtomicU64::new(0)),
+                records_emitted: Arc::new(AtomicU64::new(0)),
+                target_batch_count: 4,
+                output_byte_limit: 1024 * 1024,
+            }
+        }
+
+        #[test]
+        fn profile_advertises_serial_byordinal() {
+            let s = ZipperMergeStep::new(make_cfg(false));
+            let p = s.profile();
+            assert_eq!(p.name, "ZipperMerge");
+            assert_eq!(p.kind, StepKind::Serial);
+            assert!(!p.sticky);
+            assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+        }
+
+        /// A `target_batch_count` of 0 must be clamped to 1 in the stored
+        /// config, not just in the accumulator capacity: the `try_run` /
+        /// `push_template` emit checks compare against `self.cfg.target_batch_count`,
+        /// and an unclamped 0 would livelock emitting empty batches. Mirrors the
+        /// clamp the sibling group steps apply to their stored field.
+        #[test]
+        fn new_clamps_zero_target_batch_count_in_stored_config() {
+            let mut cfg = make_cfg(false);
+            cfg.target_batch_count = 0;
+            let step = ZipperMergeStep::new(cfg);
+            assert_eq!(
+                step.cfg.target_batch_count, 1,
+                "stored target_batch_count must be floored to 1, not left at 0"
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -126,6 +126,7 @@
 //! - [fgbio](https://github.com/fulcrumgenomics/fgbio) - Scala implementation
 //! - [noodles](https://github.com/zaeleus/noodles) - Rust bioinformatics I/O
 
+pub mod aligner;
 pub mod commands;
 pub mod version;
 pub use fgumi_bgzf::reader as bgzf_reader;

--- a/src/lib/pipeline/chains/build.rs
+++ b/src/lib/pipeline/chains/build.rs
@@ -1,0 +1,108 @@
+//! [`build_for`] — the single chain-construction entry point.
+//!
+//! `build_for` constructs the chain as a stage-by-stage loop:
+//!
+//!   1. Validates the spec (progression, options presence, cross-stage constraints).
+//!   2. Constructs a [`ChainBuilder`] from the spec.
+//!   3. Calls `add_source`.
+//!   4. Walks `spec.stages`, calling `add_stage(stage, position)` for each,
+//!      where `position` is `Terminal` for the last stage and `Intermediate` for all
+//!      earlier ones.
+//!   5. Calls `add_sink`.
+//!   6. Calls `build()` to produce the [`BuiltPipeline`].
+//!
+//! Every chain — including the sole-`[Stage::Sort]` standalone sort — runs
+//! through this uniform `add_source` → stages → `add_sink` topology on the
+//! work-stealing pool. There is no longer a Sort-terminal special case: the
+//! former self-contained file→file `SortBamFile` step was removed, and
+//! standalone sort now streams (`ParseBamRecords` → arena sort ingest →
+//! `SpillGather` → `SpillBlockCompress` → `SpillWrite` → `SortSpillDecompress` →
+//! `SortMerge` → sink) like every other command.
+
+use anyhow::{Result, bail};
+
+use crate::pipeline::chains::{
+    BuiltPipeline, ChainSpec,
+    builder::{ChainBuilder, StagePosition},
+    validate::{
+        validate_cross_stage_constraints, validate_stage_opts_present, validate_stage_progression,
+    },
+};
+
+/// Construct a [`BuiltPipeline`] from a [`ChainSpec`]. See the design
+/// doc (`docs/design/refactor/2026-05-20-unified-chain-builder-design.md`)
+/// for the architectural rationale.
+///
+/// Does NOT execute the pipeline — the caller picks `PipelineConfig`
+/// (threads, scheduler) and calls `built.pipeline.run(built.config)`,
+/// then drains `built.finalize` in order. The convenience method
+/// [`BuiltPipeline::run`] wraps both steps.
+///
+/// ## Dispatch
+///
+/// `build_for` constructs a [`ChainBuilder`] and drives it stage-by-stage:
+///
+/// ```text
+/// chain.add_source()?
+/// for (i, stage) in stages.iter().enumerate() {
+///     let pos = if i == last { Terminal } else { Intermediate };
+///     chain.add_stage(*stage, pos)?;
+/// }
+/// chain.add_sink()?
+/// chain.build()
+/// ```
+///
+/// Each `add_<stage>` method reads its options from `spec.stage_opts` and pushes
+/// the appropriate typed-step sequence onto the pipeline builder. The position
+/// argument controls whether a serialise-to-bytes step is appended (Terminal)
+/// or whether the native typed output is left for the next stage (Intermediate).
+///
+/// # Errors
+///
+/// Returns the first validator violation, or any underlying step
+/// construction error (header parse, file-open, etc.).
+#[allow(clippy::needless_pass_by_value)]
+pub fn build_for(spec: ChainSpec) -> Result<BuiltPipeline> {
+    validate_stage_progression(&spec)?;
+    validate_stage_opts_present(&spec)?;
+    validate_cross_stage_constraints(&spec)?;
+    // Re-check source invariants the variant types cannot encode (e.g. a
+    // struct-literal `Fastqs` with mismatched paths/read_structures lengths),
+    // so the safety net documented on `SourceSpec::validate` is delivered on
+    // the build path rather than left to construction-site discipline.
+    spec.source.validate()?;
+
+    // Defensive: `validate_stage_progression` above already rejects an empty
+    // `stages`, so this guard is unreachable in practice. It is kept to
+    // protect the `spec.stages.len() - 1` below from underflowing if the
+    // validator order is ever changed.
+    if spec.stages.is_empty() {
+        bail!("ChainSpec must specify at least one stage");
+    }
+
+    let mut chain = ChainBuilder::new(&spec)?;
+
+    // NOTE: `--threads 1` whole-chain fusion is NOT wired here. It is applied
+    // generically by the runtime (`Pipeline::run` → `run_fused_single_thread`)
+    // to ANY linear source→sink chain at one worker — see
+    // `pipeline::core::runtime::fused`. `build_for` therefore constructs the
+    // same staged chain regardless of thread count; the runtime fuses it.
+    //
+    // Every chain — including the sole-`[Stage::Sort]` chain — runs through the
+    // normal `add_source` → stages → `add_sink` topology on the work-stealing
+    // pool. The former Sort-terminal special case (which skipped source/sink so
+    // a self-contained `SortBamFile` could read/write files itself) was removed:
+    // standalone sort now streams like every other command.
+    chain.add_source()?;
+
+    let last_idx = spec.stages.len() - 1;
+    for (i, &stage) in spec.stages.iter().enumerate() {
+        let position =
+            if i == last_idx { StagePosition::Terminal } else { StagePosition::Intermediate };
+        chain.add_stage(stage, position)?;
+    }
+
+    chain.add_sink()?;
+
+    chain.build()
+}

--- a/src/lib/pipeline/chains/build_helpers.rs
+++ b/src/lib/pipeline/chains/build_helpers.rs
@@ -1,0 +1,112 @@
+//! Shared helpers for per-command chain builders.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use crate::commands::common::{QueueMemoryOptions, SchedulerOptions};
+use crate::pipeline::core::builder::{Pipeline, PipelineConfig};
+use crate::pipeline::core::runtime::stats::PipelineStats;
+
+/// Truthiness of a boolean-ish environment variable: `true` iff `name` is set
+/// and its value is neither `"0"` nor `"false"`. Shared by the
+/// `FGUMI_PIPELINE_STATS` diagnostic checks here and in
+/// [`ChainBuilder::build`](super::builder::ChainBuilder::build) so the two
+/// cannot drift if the parsing rules ever change.
+pub(crate) fn env_flag_enabled(name: &str) -> bool {
+    flag_os_value_enabled(std::env::var_os(name).as_deref())
+}
+
+/// Pure predicate behind [`env_flag_enabled`]: `true` iff `value` is present
+/// and is neither `"0"` nor `"false"` (so any other non-empty — or empty —
+/// value counts as enabled). Split out from the env read so the parsing rule
+/// is unit-testable without mutating the process environment (mutating it would
+/// require `unsafe` under edition 2024, which this crate forbids).
+fn flag_os_value_enabled(value: Option<&std::ffi::OsStr>) -> bool {
+    value.is_some_and(|v| v != "0" && v != "false")
+}
+
+/// Build the [`PipelineConfig`] for a chain run and optionally attach
+/// [`PipelineStats`]. Centralizes the threads + deadlock-timeout +
+/// queue-memory + stats wiring that every per-command builder needs
+/// identically.
+///
+/// Returns the constructed config and the `Arc<PipelineStats>` if stats
+/// were attached. Stats are attached (`Some`) when any of:
+/// - `--pipeline-stats` is set (`scheduler.collect_stats()`), or
+/// - `--deadlock-timeout > 0`, since the deadlock monitor reads stats
+///   counters to detect stalls, or
+/// - `FGUMI_PIPELINE_STATS` is set (the standalone diagnostic knob), or
+/// - tracing is on (`config.instrumentation.is_on()`), whose end-of-run
+///   edge table and wall clock render through the stats snapshot.
+///
+/// The caller decides whether to push a [`PipelineStatsFinalizeHook`]
+/// based on `user_wants_stats` (which is separate from the deadlock
+/// monitor's need for stats counters — the monitor wants the counters
+/// attached but doesn't need the post-run log).
+///
+/// [`PipelineStatsFinalizeHook`]: crate::pipeline::chains::PipelineStatsFinalizeHook
+///
+/// # Errors
+///
+/// Returns an error if `queue_memory.calculate_memory_limit` fails
+/// (e.g. invalid memory limit specification).
+pub(crate) fn build_pipeline_config_for_chain(
+    pipeline: &Pipeline,
+    num_threads: usize,
+    scheduler: &SchedulerOptions,
+    queue_memory: &QueueMemoryOptions,
+) -> Result<(PipelineConfig, Option<Arc<PipelineStats>>)> {
+    let mut config = PipelineConfig { threads: num_threads, ..Default::default() };
+    config.deadlock_timeout_secs = scheduler.deadlock_timeout_secs();
+    config.queue_memory_total = Some(queue_memory.calculate_memory_limit(num_threads)?);
+    // `main-runall`'s command-layer `SchedulerOptions` does not carry per-edge
+    // instrumentation (`--pipeline-trace`); `config.instrumentation` / `trace_path`
+    // stay at their `Off` / `None` defaults from `PipelineConfig::default()`.
+
+    let user_wants_stats = scheduler.collect_stats();
+    let monitor_needs_stats = config.deadlock_timeout_secs > 0;
+    // Tracing implies stats: the end-of-run edge table + verdict render through
+    // the stats snapshot, and the wall clock comes from PipelineStats.
+    let trace_wants_stats = config.instrumentation.is_on();
+    // DIAGNOSTIC: `FGUMI_PIPELINE_STATS=1` force-creates the stats Arc even on
+    // paths (standalone `fgumi sort`) that neither flatten `--pipeline-stats`
+    // nor enable the deadlock monitor, so the per-step timing report can be dumped.
+    let env_wants_stats = env_flag_enabled("FGUMI_PIPELINE_STATS");
+    let stats = if user_wants_stats || monitor_needs_stats || env_wants_stats || trace_wants_stats {
+        let s = pipeline.stats();
+        config.stats = Some(Arc::clone(&s));
+        Some(s)
+    } else {
+        None
+    };
+
+    Ok((config, stats))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+
+    use super::flag_os_value_enabled;
+
+    #[test]
+    fn flag_value_unset_is_disabled() {
+        assert!(!flag_os_value_enabled(None));
+    }
+
+    #[test]
+    fn flag_value_zero_and_false_are_disabled() {
+        assert!(!flag_os_value_enabled(Some(OsStr::new("0"))));
+        assert!(!flag_os_value_enabled(Some(OsStr::new("false"))));
+    }
+
+    #[test]
+    fn flag_value_other_values_are_enabled() {
+        // Any present value that is not exactly "0"/"false" enables — including
+        // an empty string, per the documented contract.
+        for v in ["1", "true", "yes", "on", "", "FALSE", "00"] {
+            assert!(flag_os_value_enabled(Some(OsStr::new(v))), "value {v:?} should enable");
+        }
+    }
+}

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -27,9 +27,10 @@
 //!
 //! `ChainBuilder`'s callers are constrained: each `add_<stage>` method
 //! pushes a known-typed step sequence onto the chain, and the sequencing
-//! is verified by the unit tests that drive `build_<command>_chain`
-//! end-to-end. Misuse from outside `chains::builder` is prevented by
-//! the `pub(crate)` scope.
+//! is verified by the unit tests that drive the builder end-to-end.
+//! `ChainBuilder` is `pub` deliberately as the chains layer's declarative
+//! entry surface; [`super::build::build_for`] is the live dispatch that
+//! drives it stage-by-stage.
 
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
@@ -257,19 +258,17 @@ impl HeapSize for FuseState {}
 /// even when their mate is mapped (fgbio#1168). Keeping the two orchestrations
 /// on the one shared predicate is what stops them drifting.
 #[cfg(feature = "consensus")]
-fn templates_to_mi_step<F>(
+fn templates_to_mi_step(
     limit_bytes: u64,
     duplex_strip_strand: bool,
-    record_filter: Option<F>,
+    allow_unmapped: bool,
 ) -> impl crate::pipeline::core::step::Step<
     Input = crate::pipeline::steps::group::position::BatchedProcessedPositionGroups,
     Outputs = crate::pipeline::core::outputs::OrderedBytesSingle<
         crate::pipeline::steps::group::mi::BatchedMiGroups,
     >,
->
-where
-    F: Fn(&[u8]) -> bool + Send + Sync + 'static,
-{
+> {
+    use crate::commands::common::consensus_pregroup_keep_raw;
     use crate::mi_group::MiGroup;
     use crate::pipeline::steps::group::mi::BatchedMiGroups;
     use crate::pipeline::steps::group::position::BatchedProcessedPositionGroups;
@@ -324,12 +323,10 @@ where
                         Some(_) => {}
                     }
                     for raw in [template.r1(), template.r2()].into_iter().flatten() {
-                        // Apply the optional per-record filter (duplex) so the
-                        // fused bridge drops the same records the non-fused
-                        // `GroupByMi::with_record_filter` would (NEW-002).
-                        if let Some(filter) = &record_filter
-                            && !filter(raw)
-                        {
+                        // Apply the same per-record filter the non-fused
+                        // `GroupByMi::with_record_filter` would, so the fused
+                        // bridge drops the same records (NEW-002).
+                        if !consensus_pregroup_keep_raw(raw, allow_unmapped) {
                             continue;
                         }
                         state.scratch.clear();
@@ -1515,7 +1512,7 @@ impl<'a> ChainBuilder<'a> {
     /// `"dedup"` (single stage) or `"group→simplex"` (multi-stage), making
     /// the log line unambiguous for fused chains.
     ///
-    /// Also calls [`build_pipeline_config_for_chain`] for shared threading /
+    /// Also calls `build_pipeline_config_for_chain` for shared threading /
     /// deadlock-timeout / queue-memory wiring. Registers
     /// [`PipelineStatsFinalizeHook`] if the user requested stats.
     ///
@@ -1811,7 +1808,7 @@ impl<'a> ChainBuilder<'a> {
 
         let track_rejects = correct_opts.rejects_path.is_some();
 
-        warn_unwired_pipeline_flags(&self.spec.scheduler, &self.spec.queue_memory);
+        warn_unwired_pipeline_flags(&self.spec.scheduler);
         info!("{}", self.spec.threading.log_message());
         info!("Using pipeline with {num_threads} threads");
 
@@ -2109,7 +2106,9 @@ impl<'a> ChainBuilder<'a> {
         }
 
         let timer = OperationTimer::new("AlignAndMerge");
-        self.finalize.push(Box::new(AlignFinalizeHook { records_emitted, timer }));
+        // Success-only: the hook logs "pipeline completed successfully" and
+        // records completion timing, which must not fire on a failed run.
+        self.finalize_on_success.push(Box::new(AlignFinalizeHook { records_emitted, timer }));
 
         Ok(())
     }
@@ -2195,7 +2194,7 @@ impl<'a> ChainBuilder<'a> {
 
         // Emit the start log and pipeline-info lines (mirrors build_zipper_chain).
         info!("{NEW_PIPELINE_START_LOG}");
-        warn_unwired_pipeline_flags(&self.spec.scheduler, &self.spec.queue_memory);
+        warn_unwired_pipeline_flags(&self.spec.scheduler);
         info!("{}", self.spec.threading.log_message());
         info!("Using pipeline with {num_threads} threads");
 
@@ -2432,6 +2431,18 @@ impl<'a> ChainBuilder<'a> {
             if !sort.tmp_dirs.is_empty() {
                 sorter = sorter.temp_dirs(sort.tmp_dirs.clone());
             }
+
+            // Thread `--max-temp-files` through: `Auto` resolves against the host
+            // `RLIMIT_NOFILE` (one snapshot), matching the standalone
+            // `Sort::build_sorter`. Without this the chain used the engine's
+            // portable fallback and silently ignored the CLI value.
+            let resolved_max_temp_files = match sort.max_temp_files {
+                crate::commands::common::MaxTempFiles::Auto => {
+                    fgumi_sort::temp_file_limit_from_nofile(fgumi_sort::soft_nofile())
+                }
+                crate::commands::common::MaxTempFiles::Fixed(n) => n,
+            };
+            sorter = sorter.max_temp_files(resolved_max_temp_files);
 
             // NOTE: the legacy `build_sort_step` clamped the sorter's *initial*
             // in-memory capacity (768 MiB/thread) for standalone `--max-memory
@@ -2848,7 +2859,7 @@ impl<'a> ChainBuilder<'a> {
             }
         }
 
-        warn_unwired_pipeline_flags(&self.spec.scheduler, &self.spec.queue_memory);
+        warn_unwired_pipeline_flags(&self.spec.scheduler);
         let num_threads = self.spec.threading.num_threads();
         info!("{}", self.spec.threading.log_message());
         info!("Using pipeline with {num_threads} threads");
@@ -3079,7 +3090,7 @@ impl<'a> ChainBuilder<'a> {
             info!("Overlapping consensus calling enabled");
         }
 
-        warn_unwired_pipeline_flags(&self.spec.scheduler, &self.spec.queue_memory);
+        warn_unwired_pipeline_flags(&self.spec.scheduler);
         let num_threads = self.spec.threading.num_threads();
         info!("{}", self.spec.threading.log_message());
         info!("Using pipeline with {num_threads} threads");
@@ -3178,11 +3189,7 @@ impl<'a> ChainBuilder<'a> {
         let tail = if self.chain_tail_kind == ChainTailKind::BatchedProcessedPositionGroups {
             // simplex: no `/A` `/B` strand stripping; apply the canonical filter.
             self.pipeline.append_step(
-                templates_to_mi_step(
-                    self.tuning.per_step_byte_limit,
-                    false,
-                    Some(move |raw: &[u8]| consensus_pregroup_keep_raw(raw, allow_unmapped)),
-                ),
+                templates_to_mi_step(self.tuning.per_step_byte_limit, false, allow_unmapped),
                 tail,
             )
         } else {
@@ -3348,7 +3355,7 @@ impl<'a> ChainBuilder<'a> {
             info!("Overlapping consensus calling enabled");
         }
 
-        warn_unwired_pipeline_flags(&self.spec.scheduler, &self.spec.queue_memory);
+        warn_unwired_pipeline_flags(&self.spec.scheduler);
         let num_threads = self.spec.threading.num_threads();
         info!("{}", self.spec.threading.log_message());
         info!("Using pipeline with {num_threads} threads");
@@ -3447,11 +3454,7 @@ impl<'a> ChainBuilder<'a> {
             // duplex: strip `/A` `/B` so both strands group together, and apply
             // the same canonical per-record filter the non-fused path applies.
             self.pipeline.append_step(
-                templates_to_mi_step(
-                    self.tuning.per_step_byte_limit,
-                    true,
-                    Some(move |raw: &[u8]| consensus_pregroup_keep_raw(raw, allow_unmapped)),
-                ),
+                templates_to_mi_step(self.tuning.per_step_byte_limit, true, allow_unmapped),
                 tail,
             )
         } else {
@@ -3594,7 +3597,7 @@ impl<'a> ChainBuilder<'a> {
         info!("Error rate post-UMI: Q{}", consensus.error_rate_post_umi);
         info!("Min duplex length: {}", codec.min_duplex_length);
 
-        warn_unwired_pipeline_flags(&self.spec.scheduler, &self.spec.queue_memory);
+        warn_unwired_pipeline_flags(&self.spec.scheduler);
         let num_threads = self.spec.threading.num_threads();
         info!("Worker threads: {num_threads}");
         info!("Reader threads: {num_threads}");
@@ -3695,11 +3698,7 @@ impl<'a> ChainBuilder<'a> {
         let tail = if self.chain_tail_kind == ChainTailKind::BatchedProcessedPositionGroups {
             // codec: no `/A` `/B` strand stripping; apply the canonical filter.
             self.pipeline.append_step(
-                templates_to_mi_step(
-                    self.tuning.per_step_byte_limit,
-                    false,
-                    Some(move |raw: &[u8]| consensus_pregroup_keep_raw(raw, allow_unmapped)),
-                ),
+                templates_to_mi_step(self.tuning.per_step_byte_limit, false, allow_unmapped),
                 tail,
             )
         } else {
@@ -3862,7 +3861,7 @@ impl<'a> ChainBuilder<'a> {
         info!("  Clip extending past mate: {}", clip.clip_extending_past_mate);
         info!("  {}", self.spec.threading.log_message());
 
-        warn_unwired_pipeline_flags(&self.spec.scheduler, &self.spec.queue_memory);
+        warn_unwired_pipeline_flags(&self.spec.scheduler);
         info!("{}", self.spec.threading.log_message());
         info!("Using pipeline with {num_threads} threads");
 
@@ -3941,7 +3940,7 @@ impl<'a> ChainBuilder<'a> {
         use crate::commands::common::warn_unwired_pipeline_flags;
         use crate::logging::OperationTimer;
         use crate::pipeline::chains::commands::filter::{
-            FilterFinalizeHook, build_filter_step_single_no_rejects,
+            FilterFinalizeHook, FilterStatsFinalizeHook, build_filter_step_single_no_rejects,
             build_filter_step_single_with_rejects, build_filter_step_template_no_rejects,
             build_filter_step_template_with_rejects,
         };
@@ -4032,13 +4031,13 @@ impl<'a> ChainBuilder<'a> {
             info!("Methylation mode: {:?}", filter.methylation_mode);
         }
 
-        warn_unwired_pipeline_flags(&self.spec.scheduler, &self.spec.queue_memory);
+        warn_unwired_pipeline_flags(&self.spec.scheduler);
         let num_threads = self.spec.threading.num_threads();
         info!("{}", self.spec.threading.log_message());
         info!("Using pipeline with {num_threads} threads");
 
         // Build shared FilterPipelineSetup (config, reference, accumulators, progress).
-        let setup = filter.setup_pipeline(num_threads, &self.header)?;
+        let setup = filter.setup_pipeline(num_threads)?;
         let accumulators = Arc::clone(&setup.collected_metrics);
 
         let filter_by_template = filter.filter_by_template;
@@ -4119,13 +4118,21 @@ impl<'a> ChainBuilder<'a> {
         // Branch 0 of process_tail (kept) becomes current_tail for add_sink.
         self.current_tail = Some(process_tail);
 
-        // Register the filter finalize hook.
+        // Register the filter finalize hooks. The stats file is written by a
+        // success-only hook so a failed/partial run never publishes counts; the
+        // summary banner stays on the always-run hook so it reports even after a
+        // failure.
         // The chain-level StageTimingFinalizeHook is inserted at index 0 by
         // build() after all stages have been added — that way a single timer
         // covers the full pipeline run regardless of how many stages there are.
+        if let Some(stats_path) = filter.stats.clone() {
+            self.finalize_on_success.push(Box::new(FilterStatsFinalizeHook {
+                accumulators: Arc::clone(&accumulators),
+                stats_path,
+            }));
+        }
         self.finalize.push(Box::new(FilterFinalizeHook {
             accumulators,
-            stats_path: filter.stats.clone(),
             has_rejects: track_rejects,
             timer,
         }));
@@ -4252,7 +4259,7 @@ impl<'a> ChainBuilder<'a> {
             info!("Index threshold: {}", dedup.index_threshold);
         }
 
-        warn_unwired_pipeline_flags(&self.spec.scheduler, &self.spec.queue_memory);
+        warn_unwired_pipeline_flags(&self.spec.scheduler);
         let num_threads = self.spec.threading.num_threads();
         info!("{}", self.spec.threading.log_message());
         info!("Using pipeline with {num_threads} threads");

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -1,0 +1,4380 @@
+//! Stage-by-stage chain builder.
+//!
+//! The principled endpoint sketched in
+//! `docs/design/refactor/2026-05-20-unified-chain-builder-design.md`
+//! and implemented in Phase 3: `build_for` constructs a `ChainBuilder`,
+//! calls `add_source`, walks `spec.stages` calling `add_stage` per
+//! variant, calls `add_sink`, then `build()`s the final `BuiltPipeline`.
+//!
+//! Each `add_<stage>` method:
+//!   1. Reads `self.spec.stage_opts.<stage>` (already validated present).
+//!   2. Pushes the stage's canonical step sequence onto `self.pipeline`
+//!      via [`PipelineBuilder::append_source`] /
+//!      [`PipelineBuilder::append_step`].
+//!   3. Pushes any `FinalizeHook` impl(s) onto `self.finalize`.
+//!
+//! ## Type-erasure compatibility note
+//!
+//! `PipelineBuilder::append_source` / `append_step` bypass the typed
+//! `Chain<'b, O>` API. Type correctness is NOT checked at `build()` time —
+//! `PipelineBuilder::build()` only validates that every output is wired
+//! (there is no `Step<Input=A>` consuming an output of `Step<Output=B>`
+//! check at compile time or at `build()` time). A type mismatch panics in
+//! `TypedStep::resolve_input` at the first dispatch with "input handle
+//! downcast failed — chain topology invariant" once `Pipeline::run` begins.
+//! The panic is loud and immediate but it is a runtime check, not a
+//! compile-time or build-time one.
+//!
+//! `ChainBuilder`'s callers are constrained: each `add_<stage>` method
+//! pushes a known-typed step sequence onto the chain, and the sequencing
+//! is verified by the unit tests that drive `build_<command>_chain`
+//! end-to-end. Misuse from outside `chains::builder` is prevented by
+//! the `pub(crate)` scope.
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+
+use anyhow::{Result, anyhow, bail};
+use noodles::sam::Header;
+
+use crate::pipeline::chains::{
+    BuiltPipeline, ChainSpec, FinalizeHook, PipelineStatsFinalizeHook, SinkSpec, SourceSpec, Stage,
+    StageTimingFinalizeHook, build_pipeline_config_for_chain,
+};
+use crate::pipeline::core::builder::PipelineBuilder;
+// Only the `consensus`-gated `FuseState` implements `HeapSize` in this module.
+#[cfg(feature = "consensus")]
+use crate::pipeline::core::item::HeapSize;
+use crate::pipeline::core::topology::{BranchIdx, StepIdx};
+use crate::pipeline::steps::tuning::BamPipelineTuning;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PendingSource — opened input held between new() and add_source().
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Holds the opened input(s) between [`ChainBuilder::new`] (which opens them)
+/// and [`ChainBuilder::add_source`] (which consumes them to push the source
+/// preamble onto the pipeline). The variant matches the [`SourceSpec`] the
+/// spec carries; each variant carries enough state to construct the source
+/// step sequence.
+///
+/// `add_source` matches on `PendingSource` and routes each variant to the
+/// correct preamble: `Single` → BAM/SAM decode, `Paired` → zipper's dual-input
+/// merge, `Fastq` → the FASTQ read preamble.
+///
+/// All variants that carry large structs box them to prevent
+/// `clippy::large_enum_variant` from flagging this enum.
+pub(crate) enum PendingSource {
+    /// `SourceSpec::Bam` or `SourceSpec::Sam` — a single open
+    /// [`InputSource`](crate::pipeline::steps::source::InputSource).
+    /// Boxed to keep enum size comparable to the smaller variants.
+    Single(Box<crate::pipeline::steps::source::InputSource>),
+
+    /// `SourceSpec::PairedBams` — zipper's two-input form: mapped BAM +
+    /// unmapped BAM + reference path, consumed by `add_source` to build both
+    /// source preambles for the zipper merge.
+    Paired {
+        mapped: Box<crate::pipeline::steps::source::InputSource>,
+        unmapped: Box<crate::pipeline::steps::source::InputSource>,
+        reference: std::path::PathBuf,
+    },
+
+    /// `SourceSpec::Fastqs` — extract's input form.
+    /// `add_source` consumes this to build the FASTQ read preamble:
+    /// `ReadFastqInputs → ZipFastqRecords`. Read structures are read
+    /// from `self.spec.source` by `add_extract`, not carried here.
+    Fastq { paths: Vec<std::path::PathBuf> },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// StagePosition — terminal vs intermediate position in the chain.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Whether a stage is the last step before the output sink (`Terminal`) or is
+/// followed by at least one more stage (`Intermediate`).
+///
+/// Each `add_<stage>` method receives a `StagePosition` argument. For
+/// `Terminal`, the stage appends its serialise-to-bytes step so the chain tail
+/// is [`DecompressedBlock`] ready for `BgzfCompress → WriteBgzfFile`. For
+/// `Intermediate`, the stage leaves its native typed output on the chain tail
+/// (e.g., `BatchedProcessedDedupGroups` for dedup) so the next stage can
+/// consume it directly without a round-trip through bytes.
+///
+/// [`build_for`][`crate::pipeline::chains::build_for`] computes the
+/// position for each stage from the spec's stage list:
+///
+/// ```text
+/// let last_idx = spec.stages.len() - 1;
+/// for (i, stage) in spec.stages.iter().enumerate() {
+///     let position = if i == last_idx { StagePosition::Terminal }
+///                    else             { StagePosition::Intermediate };
+///     chain.add_stage(*stage, position)?;
+/// }
+/// ```
+///
+/// Single-stage chains always pass `Terminal`. Multi-stage chains (Phase 3b
+/// runall fused paths) pass `Intermediate` for every stage except the last.
+///
+/// [`DecompressedBlock`]: crate::pipeline::steps::types::DecompressedBlock
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StagePosition {
+    /// This stage is the last before the output sink. Append any
+    /// serialise-to-bytes step needed to feed `BgzfCompress`.
+    Terminal,
+    /// This stage is followed by at least one more stage. Leave the native
+    /// typed output on the chain tail for the next stage to consume.
+    Intermediate,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ChainTailKind — tracks what type the current chain tail produces.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Tracks the logical output type of the chain tail at each point in
+/// construction. Used by multi-stage `add_<stage>` methods to decide how to
+/// wire their preamble steps: the source preamble, or the previous stage's
+/// output, may produce different types depending on the chain layout.
+///
+/// ## Why this is needed
+///
+/// `ChainBuilder` erases types after each `append_step` call (there is no
+/// compile-time check that a downstream step's `Input` matches the upstream
+/// step's `Output`). For most stages the source preamble always ends at
+/// [`DecodedRecordBatch`] and the stages are type-compatible. However, two
+/// multi-stage fused patterns need a different preamble:
+///
+/// 1. **Sort intermediate** — Sort consumes `RecordBatch`. When Sort is the
+///    first stage, `add_source` emits `RecordBatch` via `ParseBamRecords`.
+///    When Sort follows Align/Zipper/Correct (which emit `BamTemplateBatch`),
+///    `add_sort` prepends `TemplatesToRecordBatch`. After Sort's three-step
+///    chain, the tail is `DecodedRecordBatch` again.
+///
+/// 2. **Group→Consensus** — Consensus stages normally receive `DecodedRecordBatch`
+///    and prepend `GroupByMi`. When Group runs as an intermediate stage,
+///    the tail is `BatchedProcessedPositionGroups` after `MiAssign`. The
+///    consensus stages must then prepend `TemplatesToMiGroups` instead of
+///    `GroupByMi` to bridge the two types.
+///
+/// [`DecodedRecordBatch`]: crate::pipeline::steps::types::DecodedRecordBatch
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChainTailKind {
+    /// The chain tail produces [`DecodedRecordBatch`]. This is the default
+    /// after the source preamble (`DecodeRecords`) and after Sort (via
+    /// `DecodeFromRecords`).
+    ///
+    /// [`DecodedRecordBatch`]: crate::pipeline::steps::types::DecodedRecordBatch
+    DecodedRecordBatch,
+
+    /// The chain tail produces serialized BGZF-ready bytes
+    /// ([`DecompressedBlock`]) after a Terminal serialize step
+    /// (`SerializeBamRecords` / `SerializeGroups`, the terminal
+    /// `SortMerge<BlockOutput>` for sort, or the record-aligned block emitted by
+    /// a terminal consensus stage). No
+    /// stage downstream of a Terminal stage reads `chain_tail_kind`, so this is
+    /// a terminal-only marker; it exists so the kind is never a lie. `add_sink`
+    /// wires `BgzfCompress → WriteBgzfFile` regardless of this value.
+    ///
+    /// [`DecompressedBlock`]: crate::pipeline::steps::types::DecompressedBlock
+    SerializedBytes,
+
+    /// The chain tail produces [`BamTemplateBatch`]. Set by `add_align`
+    /// (Intermediate) and `add_correct` (Intermediate).
+    ///
+    /// [`BamTemplateBatch`]: crate::pipeline::steps::types::BamTemplateBatch
+    BamTemplateBatch,
+
+    /// The chain tail produces `BgzfBlock` (raw compressed BGZF blocks, NOT yet
+    /// decompressed), with an arena-backed front waiting for the parallel-inflate
+    /// sort ingest steps. Set by `add_source` when the first stage is a sort over
+    /// a BAM source (all four orders): `ReadBgzfBlocks` is emitted but
+    /// `BgzfDecompress` is NOT — the new front (`ReadBlocks` → `InflateToArena`
+    /// → `FindBoundariesAndSort`) handles decompression + boundary-find + sort
+    /// inline.
+    ///
+    /// `add_sort` consumes this tail for every BAM sort order.
+    BgzfBlockArena,
+
+    /// The chain tail produces [`BatchedProcessedPositionGroups`]. Set by
+    /// `add_group` (Intermediate) — after `GroupByPosition → ProcessOrdered
+    /// → MiAssign` but before `SerializeBamRecords`.
+    ///
+    /// [`BatchedProcessedPositionGroups`]: crate::pipeline::steps::group::position::BatchedProcessedPositionGroups
+    BatchedProcessedPositionGroups,
+
+    /// The chain tail produces
+    /// [`FastqTemplateBatch`]. Set by `add_source` on the `Fastqs` arm,
+    /// after `ReadFastqInputs → ZipFastqRecords`. The only consumer is
+    /// `add_extract`, which converts it to `BamTemplateBatch`.
+    ///
+    /// [`FastqTemplateBatch`]: crate::pipeline::steps::source::zip_fastq::FastqTemplateBatch
+    FastqTemplateBatch,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ChainBuilder
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Per-worker scratch state for the `templates_to_mi_step` bridge: a reusable
+/// byte buffer and an MI-key string buffer, reset per template.
+#[cfg(feature = "consensus")]
+pub(crate) struct FuseState {
+    scratch: Vec<u8>,
+    mi_buf: String,
+}
+
+#[cfg(feature = "consensus")]
+impl HeapSize for FuseState {}
+
+/// Build the `TemplatesToMiGroups` bridge step that fuses an intermediate
+/// `add_group` (which emits `BatchedProcessedPositionGroups`) into a consensus
+/// stage (which consumes `BatchedMiGroups`). For each template it splices the
+/// assigned molecular identifier into the `MI` tag and runs the records into
+/// per-MI groups in a single pass. This is the in-builder successor of the
+/// former `runall.rs` `templates_to_mi_step` (folded into the chain builder).
+///
+/// Grouping on the MI alone (without a cell-barcode partition) is exactly
+/// equivalent to the non-fused `GroupByMi::with_cell_tag(Some(CB))` path
+/// (S5b1-003): MI values are globally unique across cell barcodes. The cell
+/// barcode is part of the upstream `GroupByPosition` key (so reads from
+/// different cells land in different position groups), and `assign_mi_offsets`
+/// shifts every group's local MI ids by a single global monotonic counter, so
+/// every distinct molecule receives a unique integer MI regardless of cell.
+/// Two templates with the same MI but different CB therefore cannot exist, so
+/// the bridge needs no cell-tag partition.
+///
+/// `duplex_strip_strand` controls whether the `/A` `/B` strand suffix is
+/// stripped from the MI key so both strands of a duplex molecule group
+/// together (`true` for duplex; `false` for simplex and codec).
+///
+/// `record_filter` is an optional per-record predicate applied to each emitted
+/// `r1()`/`r2()` raw record; records for which it returns `false` are dropped.
+/// All three consensus stages pass
+/// [`consensus_pregroup_keep_raw`](crate::commands::common::consensus_pregroup_keep_raw)`(raw, allow_unmapped)`
+/// here so the fused group→consensus path applies the **same** canonical
+/// pre-group filter the non-fused `GroupByMi::with_record_filter` path and the
+/// standalone consensus commands apply — dropping secondary/supplementary
+/// always, and (unless `--allow-unmapped`) dropping unmapped primary records
+/// even when their mate is mapped (fgbio#1168). Keeping the two orchestrations
+/// on the one shared predicate is what stops them drifting.
+#[cfg(feature = "consensus")]
+fn templates_to_mi_step<F>(
+    limit_bytes: u64,
+    duplex_strip_strand: bool,
+    record_filter: Option<F>,
+) -> impl crate::pipeline::core::step::Step<
+    Input = crate::pipeline::steps::group::position::BatchedProcessedPositionGroups,
+    Outputs = crate::pipeline::core::outputs::OrderedBytesSingle<
+        crate::pipeline::steps::group::mi::BatchedMiGroups,
+    >,
+>
+where
+    F: Fn(&[u8]) -> bool + Send + Sync + 'static,
+{
+    use crate::mi_group::MiGroup;
+    use crate::pipeline::steps::group::mi::BatchedMiGroups;
+    use crate::pipeline::steps::group::position::BatchedProcessedPositionGroups;
+    use crate::pipeline::steps::process::process_with_worker_state;
+    use crate::sam::SamTag;
+    use fgumi_raw_bam::RawRecord;
+    use std::io;
+
+    // The assign tag is always `MI` (== [b'M', b'I']), matching `add_group`.
+    let assign_tag_bytes: [u8; 2] = *SamTag::MI;
+
+    process_with_worker_state::<BatchedProcessedPositionGroups, BatchedMiGroups, _, FuseState, _>(
+        "TemplatesToMiGroups",
+        limit_bytes,
+        || FuseState { scratch: Vec::with_capacity(512), mi_buf: String::with_capacity(16) },
+        move |state: &mut FuseState,
+              item: BatchedProcessedPositionGroups|
+              -> io::Result<BatchedMiGroups> {
+            let BatchedProcessedPositionGroups { batch_serial, groups } = item;
+            let mut mi_groups: Vec<MiGroup> = Vec::new();
+            for processed in &groups {
+                let mut current_mi: Option<String> = None;
+                let mut current_records: Vec<RawRecord> = Vec::new();
+                for template in &processed.templates {
+                    if !template.mi.is_assigned() {
+                        continue;
+                    }
+                    // Write the full strand-suffixed MI into `mi_buf` for the
+                    // per-record `MI` tag exactly once. On the strip path the
+                    // grouping key is the strand-stripped base id (so both
+                    // strands group together); on the non-strip path the full
+                    // MI is also the grouping key (reuse `mi_buf`).
+                    template.mi.write_with_offset(0, &mut state.mi_buf);
+                    let mi_key = if duplex_strip_strand {
+                        template.mi.id().unwrap().to_string()
+                    } else {
+                        state.mi_buf.clone()
+                    };
+                    match &current_mi {
+                        Some(curr) if curr != &mi_key => {
+                            if !current_records.is_empty() {
+                                mi_groups.push(MiGroup::new(
+                                    std::mem::take(&mut current_mi).unwrap(),
+                                    std::mem::take(&mut current_records),
+                                ));
+                            }
+                            current_mi = Some(mi_key);
+                        }
+                        None => {
+                            current_mi = Some(mi_key);
+                        }
+                        Some(_) => {}
+                    }
+                    for raw in [template.r1(), template.r2()].into_iter().flatten() {
+                        // Apply the optional per-record filter (duplex) so the
+                        // fused bridge drops the same records the non-fused
+                        // `GroupByMi::with_record_filter` would (NEW-002).
+                        if let Some(filter) = &record_filter
+                            && !filter(raw)
+                        {
+                            continue;
+                        }
+                        state.scratch.clear();
+                        state.scratch.extend_from_slice(raw);
+                        fgumi_raw_bam::update_string_tag(
+                            &mut state.scratch,
+                            assign_tag_bytes,
+                            state.mi_buf.as_bytes(),
+                        );
+                        // Move the tagged bytes into the record instead of
+                        // cloning them (no per-record copy of the payload). This
+                        // hands the buffer off, so a fresh scratch Vec is
+                        // allocated for the next record — pre-sized to the same
+                        // capacity so filling it does not repeatedly grow/realloc
+                        // mid-record.
+                        let cap = state.scratch.capacity();
+                        let record = std::mem::replace(&mut state.scratch, Vec::with_capacity(cap));
+                        current_records.push(RawRecord::from(record));
+                    }
+                }
+                if !current_records.is_empty()
+                    && let Some(mi) = current_mi.take()
+                {
+                    mi_groups.push(MiGroup::new(mi, current_records));
+                }
+            }
+            Ok(BatchedMiGroups::new(batch_serial, mi_groups))
+        },
+    )
+}
+
+/// In-progress chain builder. Constructed by
+/// [`crate::pipeline::chains::build_for`] (or by a per-command
+/// builder during Phase 3a).
+///
+/// Owns the resolved output header, an accumulating `PipelineBuilder`, and a
+/// growing `Vec<Box<dyn FinalizeHook>>` populated by `add_<stage>`
+/// methods. Per-stage methods are private — callers drive the chain
+/// via the public `add_source` / `add_stage(Stage, StagePosition)` /
+/// `add_sink` / `build()` flow.
+///
+/// ## Type erasure
+///
+/// The framework's `Chain<'b, O>` provides compile-time step-compatibility
+/// enforcement but cannot span method boundaries on `&mut self`. Instead,
+/// `ChainBuilder` tracks the chain tail as `(StepIdx, BranchIdx)` and uses
+/// `PipelineBuilder::append_source` / `append_step`, which bypass the
+/// typed-chain API. See the module-level type-erasure note for the runtime
+/// behaviour when a type mismatch is introduced.
+pub struct ChainBuilder<'a> {
+    spec: &'a ChainSpec,
+    tuning: BamPipelineTuning,
+
+    /// Output header (with `@PG` record injected). Populated by `new()`,
+    /// consumed by `add_sink()` (for the BAM writer header) and by
+    /// `add_source()` (SAM parse step uses it).
+    header: Header,
+
+    /// In-progress chain state. `None` before the first step (before
+    /// `add_source` runs); `Some((producer, branch))` after. Updated
+    /// by every `add_source` / `add_<stage>` / `add_sink` call.
+    current_tail: Option<(StepIdx, BranchIdx)>,
+
+    /// Accumulating pipeline. Steps are registered via
+    /// `append_source` / `append_step` in `add_*` methods.
+    pipeline: PipelineBuilder,
+
+    /// Post-pipeline cleanup hooks. Populated by `add_<stage>` methods.
+    /// Always drained, even when the run fails (see [`BuiltPipeline::run`]).
+    finalize: Vec<Box<dyn FinalizeHook>>,
+
+    /// Post-pipeline hooks that run **only on a fully successful run**.
+    /// Populated by `add_<stage>` methods for actions that publish a derived
+    /// artifact from the run's output (currently only `add_sort`'s
+    /// `IndexBamFinalizeHook`, which writes the `.bai` sidecar by re-reading
+    /// the finished BAM). Gating these mirrors the standalone `fgumi sort`
+    /// flow, where the index write is behind `run_result?`: a failed run
+    /// leaves a partial BAM, so publishing its index would be stale.
+    finalize_on_success: Vec<Box<dyn FinalizeHook>>,
+
+    /// Shared progress counter threaded through source + stage steps for
+    /// progress logging. `Arc` so the stage step and the finalize hook can
+    /// both reference it.
+    #[allow(dead_code)] // populated by add_<stage>; used by finalize hooks
+    progress_records: Arc<AtomicU64>,
+
+    /// The opened input source(s), held here until `add_source` consumes them.
+    /// `None` after `add_source` has been called.
+    pending_source: Option<PendingSource>,
+
+    /// Second source chain tail for zipper's `PairedBams` path.
+    ///
+    /// Set by `add_source` when the pending source is
+    /// [`PendingSource::Paired`]: `current_tail` holds the unmapped
+    /// source chain tail and `paired_tail` holds the mapped source
+    /// chain tail. `add_zipper` consumes both to build
+    /// `ZipperMergeStep` via `PipelineBuilder::append_step2`.
+    /// `None` for all single-source stages.
+    paired_tail: Option<(
+        crate::pipeline::core::topology::StepIdx,
+        crate::pipeline::core::topology::BranchIdx,
+    )>,
+
+    /// Override for `PipelineConfig::threads` applied in [`Self::build`].
+    ///
+    /// `None` (the default) leaves `config.threads` set to
+    /// `spec.threading.num_threads()`. `Some(n)` forces it to `n`.
+    ///
+    /// Set by stages whose framework thread count differs from the requested
+    /// `--threads` (e.g. [`Self::add_zipper`] / [`Self::add_align`], which
+    /// reserve a driver thread for an external aligner process). Sort no longer
+    /// sets it: standalone sort streams through the normal multi-step pipeline
+    /// and uses the requested thread count like every other stage.
+    override_pipeline_threads: Option<usize>,
+
+    /// Set when a BAM sort source is wired through the parallel-inflate arena
+    /// front (`ReadBlocks → InflateToArena → FindBoundariesAndSort`), for any
+    /// sort order. [`Self::build`] then opts the ENTIRE sort-first pipeline —
+    /// including fused `Sort → Group/Simplex/Duplex/Codec` chains — into the
+    /// downstream-first [`DrainFirstScheduler`](crate::pipeline::core::runtime::DrainFirstScheduler), so the sort's serial
+    /// boundary/key scan overlaps the parallel inflate (drained ahead of
+    /// production) instead of starving behind it on the shared pool. Chains
+    /// without a sort source keep the default upstream-first scheduler.
+    use_drain_first_scheduler: bool,
+
+    /// `HeaderHandle` stashed by [`Self::add_align`] for consumption by
+    /// [`Self::add_sink`].
+    ///
+    /// `AlignAndMergeStep` resolves the final merged header at runtime
+    /// (after the aligner emits its own `@PG`/`@RG`/`@CO` lines). The
+    /// downstream [`WriteBgzfFile`] must therefore be constructed with
+    /// [`WriteBgzfFile::new_with_handle`], which blocks until the handle
+    /// is resolved before writing the BAM header bytes.
+    ///
+    /// `add_align` sets this; `add_sink` checks it and dispatches to
+    /// `new_with_handle` when `Some`, falling back to the usual `new`
+    /// path when `None` (all other stages).
+    ///
+    /// [`WriteBgzfFile`]: crate::pipeline::steps::sink::write_bgzf::WriteBgzfFile
+    /// [`WriteBgzfFile::new_with_handle`]: crate::pipeline::steps::sink::write_bgzf::WriteBgzfFile::new_with_handle
+    pending_header_handle: Option<crate::pipeline::core::header::HeaderHandle>,
+
+    /// When an aligner `HeaderHandle` is pending, this accumulates the header
+    /// changes made by later stages that *modify* the header (sort-order rewrite,
+    /// clip) so they are re-applied to the aligner's runtime-resolved header at
+    /// sink time — preserving the aligner `@PG`/`@RG`/`@CO` — instead of being
+    /// discarded. Forwarded to `WriteBgzfFile::new_with_handle` by `add_sink`.
+    pending_header_transform: Option<fgumi_pipeline_io::sink::write_bgzf::ResolvedHeaderTransform>,
+
+    /// Tracks the logical output type of the current chain tail. Updated by
+    /// `add_source` and each `add_<stage>` method. See [`ChainTailKind`]
+    /// for the full enumeration and rationale.
+    ///
+    /// Default is [`ChainTailKind::DecodedRecordBatch`], set by `add_source`
+    /// on the normal BAM/SAM source path. Changes:
+    ///
+    /// - `add_source` sets `BgzfBlockArena` when Sort is the first stage over a
+    ///   BAM source (leaves raw BGZF blocks for the parallel-inflate arena front
+    ///   instead of `DecodeRecords`; SAM sort-first input is rejected).
+    /// - `add_correct(Intermediate)` sets `BamTemplateBatch`.
+    /// - `add_align(Intermediate)` sets `BamTemplateBatch`.
+    /// - `add_sort(Intermediate)` reads the kind to decide its preamble,
+    ///   then sets `DecodedRecordBatch` after `DecodeFromRecords`.
+    /// - `add_group(Intermediate)` sets `BatchedProcessedPositionGroups`.
+    /// - Consensus stages read the kind to decide their grouping preamble
+    ///   (`GroupByMi` for `DecodedRecordBatch`, `TemplatesToMiGroups` for
+    ///   `BatchedProcessedPositionGroups`).
+    chain_tail_kind: ChainTailKind,
+
+    /// Lever 2: run the terminal `WriteBgzfFile` on its own dedicated
+    /// `StepKind::Detached` thread instead of as a pool-scheduled
+    /// `Serial + Affinity::Writer` step. Set ONLY by `add_sort` on the
+    /// standalone-sort terminal (`spec.is_sort_terminal()`), so every other
+    /// chain (runall / group / consensus / zipper / correct / dedup / filter /
+    /// clip) keeps the pool-scheduled writer. `add_sink` reads this flag.
+    /// Default `false`.
+    detached_writer: bool,
+}
+
+impl<'a> ChainBuilder<'a> {
+    /// Construct a `ChainBuilder` from a validated [`ChainSpec`].
+    ///
+    /// Opens the input source (for BAM/SAM specs) to resolve the header
+    /// and stores the reader in `pending_source` for [`Self::add_source`]
+    /// to consume. Applies `@PG` injection; stores the output header.
+    ///
+    /// # Errors
+    ///
+    /// Returns I/O errors from input file open or header parsing.
+    pub fn new(spec: &'a ChainSpec) -> Result<Self> {
+        let num_threads = spec.threading.num_threads();
+        // Validate the thread count up front, before `add_sink` opens (and
+        // truncates) the output file. `build()` also rejects `threads == 0`
+        // (via `calculate_memory_limit`), but that runs after the sink is
+        // already created — so a degenerate `--threads 0` would otherwise
+        // destroy an existing output before erroring. Checking here keeps it
+        // check-then-truncate.
+        if num_threads == 0 {
+            bail!("--threads must be at least 1");
+        }
+        let tuning = BamPipelineTuning::auto_tuned(num_threads)
+            .with_compression_level(spec.compression.compression_level);
+
+        // Every chain — including the sole-`[Stage::Sort]` chain — opens its
+        // source exactly once here (header read; the reader continues in
+        // `add_source` for the body, which is the single-open contract stdin
+        // relies on). The former sort-terminal skip (where `SortBamFile` opened
+        // the input itself) is gone: standalone sort now streams through the
+        // normal source path, so `@PG` injection applies to it too.
+        let (raw_header, pending_source) = Self::open_source(spec)?;
+        let header = crate::commands::common::add_pg_record(raw_header, &spec.command_line)?;
+
+        Ok(Self {
+            spec,
+            tuning,
+            header,
+            current_tail: None,
+            pipeline: PipelineBuilder::new(),
+            finalize: Vec::new(),
+            finalize_on_success: Vec::new(),
+            progress_records: Arc::new(AtomicU64::new(0)),
+            pending_source,
+            paired_tail: None,
+            override_pipeline_threads: None,
+            use_drain_first_scheduler: false,
+            pending_header_handle: None,
+            pending_header_transform: None,
+            // Initialise to the default; add_source will set the correct kind
+            // based on whether sort is the first intermediate stage.
+            chain_tail_kind: ChainTailKind::DecodedRecordBatch,
+            // Pool-scheduled writer by default; add_sort opts the standalone
+            // sort terminal into a Detached writer (lever 2).
+            detached_writer: false,
+        })
+    }
+
+    /// Open the input source and extract the header. For `Bam`/`Sam` specs,
+    /// opens the file and wraps it in [`PendingSource::Single`]. For
+    /// `PairedBams`, opens both inputs, resolves the dict path, builds the
+    /// merged output header via `build_output_header`, and wraps them in
+    /// [`PendingSource::Paired`]. For `Fastqs`, builds the FASTQ header from the
+    /// extract options and wraps the paths in [`PendingSource::Fastq`].
+    fn open_source(spec: &ChainSpec) -> Result<(Header, Option<PendingSource>)> {
+        use crate::pipeline::steps::source::InputSource;
+
+        match &spec.source {
+            SourceSpec::Bam(path) | SourceSpec::Sam(path) => {
+                // Validate the file exists before opening (stdin exempt).
+                if !fgumi_bam_io::is_stdin_path(path) {
+                    crate::validation::validate_file_exists(path, "input BAM/SAM file")?;
+                }
+                let input = InputSource::open_with_opts(
+                    path,
+                    fgumi_bam_io::PipelineReaderOpts {
+                        async_reader: spec.async_reader,
+                        ..Default::default()
+                    },
+                )
+                .map_err(|e| anyhow!("open input: {e}"))?;
+                let header = input.header().clone();
+                Ok((header, Some(PendingSource::Single(Box::new(input)))))
+            }
+            SourceSpec::PairedBams { unmapped, mapped, reference } => {
+                // Validate inputs exist (stdin exempt for both).
+                if !fgumi_bam_io::is_stdin_path(unmapped) {
+                    crate::validation::validate_file_exists(unmapped, "unmapped BAM file")?;
+                }
+                if !fgumi_bam_io::is_stdin_path(mapped) {
+                    crate::validation::validate_file_exists(mapped, "mapped BAM file")?;
+                }
+                crate::validation::validate_file_exists(reference, "reference FASTA file")?;
+
+                let dict_path = crate::reference::find_dict_path(reference)
+                    .ok_or_else(|| dict_not_found_error(reference))?;
+
+                // Unmapped source must be BAM (fgumi extract always produces BAM).
+                let unmapped_input = InputSource::open_with_opts(
+                    unmapped,
+                    fgumi_bam_io::PipelineReaderOpts {
+                        async_reader: spec.async_reader,
+                        ..Default::default()
+                    },
+                )
+                .map_err(|e| anyhow!("open unmapped: {e}"))?;
+                if matches!(unmapped_input, InputSource::Sam { .. }) {
+                    bail!(
+                        "SAM input is not supported for --unmapped \
+                        (expected `fgumi extract` BAM output)"
+                    );
+                }
+                let unmapped_header = unmapped_input.header().clone();
+
+                // Mapped source: BAM or SAM (SAM from aligner is preferred).
+                let mapped_input = InputSource::open_with_opts(
+                    mapped,
+                    fgumi_bam_io::PipelineReaderOpts {
+                        async_reader: spec.async_reader,
+                        ..Default::default()
+                    },
+                )
+                .map_err(|e| anyhow!("open mapped: {e}"))?;
+                let mapped_header = mapped_input.header().clone();
+
+                // Build the merged output header from the two inputs + dict.
+                // `new()` will apply `add_pg_record` on top of this.
+                let output_header = crate::commands::zipper::build_output_header(
+                    &unmapped_header,
+                    &mapped_header,
+                    &dict_path,
+                )?;
+
+                Ok((
+                    output_header,
+                    Some(PendingSource::Paired {
+                        mapped: Box::new(mapped_input),
+                        unmapped: Box::new(unmapped_input),
+                        reference: reference.clone(),
+                    }),
+                ))
+            }
+            SourceSpec::Fastqs { paths, read_structures: _ } => {
+                let extract_opts = spec.stage_opts.extract.as_ref().ok_or_else(|| {
+                    anyhow!("Fastqs source requires extract options in StageOptionsBag")
+                })?;
+                let header =
+                    crate::pipeline::chains::commands::extract::build_fastq_header(extract_opts)?;
+                Ok((header, Some(PendingSource::Fastq { paths: paths.clone() })))
+            }
+        }
+    }
+
+    /// Add the input source step(s) to the pipeline.
+    ///
+    /// Consumes the `PendingSource` stored by `new()`.
+    /// - `PendingSource::Single` with a BAM reader: 4-step preamble
+    ///   (`ReadBgzfBlocks → BgzfDecompress → FindBamBoundaries → DecodeRecords`).
+    /// - `PendingSource::Single` with a SAM reader: 2-step preamble
+    ///   (`ReadSamChunks → ParseSamChunk`).
+    /// - `PendingSource::Paired`: Builds both source preambles for zipper's
+    ///   dual-input path. `current_tail` = unmapped chain tail;
+    ///   `paired_tail` = mapped chain tail. No standard single-output tail is
+    ///   set — `add_zipper` consumes both tails to assemble `ZipperMergeStep`.
+    ///   Note that both preamble chains end at `GroupByQueryname` so their
+    ///   output type is `OrderedBytesSingle<BamTemplateBatch>`, matching
+    ///   `ZipperMergeStep: Step2<InputA = BamTemplateBatch, InputB = BamTemplateBatch>`.
+    ///   The reference path is stashed in `PendingSource::Paired` but is
+    ///   consumed later by `add_zipper` (reference loading is deferred because
+    ///   `restore_unconverted_bases` controls whether the FASTA is opened at all).
+    /// - `PendingSource::Fastq`: builds the FASTQ read preamble
+    ///   (`ReadFastqInputs → …`), with a stream-count-specific topology (1 / 2 /
+    ///   ≥3 streams).
+    ///
+    /// # Errors
+    ///
+    /// Returns errors from step construction or from unsupported source variants.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called twice (after `pending_source` is already consumed).
+    #[allow(clippy::too_many_lines)]
+    pub fn add_source(&mut self) -> Result<()> {
+        use crate::pipeline::steps::source::InputSource;
+        use crate::pipeline::steps::source::read_bam::read_bam_from_reader;
+        use crate::sam::check_sort;
+
+        let source = self.pending_source.take().expect("add_source called twice");
+
+        // Detect whether Sort is the FIRST stage (whether or not it is the
+        // only one). When it is over a BAM source, the preamble stops at the
+        // raw `ReadBgzfBlocks` step (tail = `ChainTailKind::BgzfBlockArena`)
+        // instead of `DecodeRecords → DecodedRecordBatch`, so `add_sort`'s
+        // parallel-inflate arena front (`ReadBlocks → InflateToArena →
+        // FindBoundariesAndSort`) can consume it directly without an extra
+        // round-trip. SAM sort-first is rejected outright (see the `Sam` arm
+        // below); `SortBuffer` is only reached by the non-arena path in
+        // `add_sort`, where sort is *not* first (a fused earlier stage feeds it
+        // `DecodedRecordBatch` / `BamTemplateBatch`). This covers both the
+        // sole-`[Sort]` chain (standalone `fgumi sort`) and
+        // sort-as-first-intermediate (`--start-from sort --stop-after
+        // {group,consensus}`); the former used to be special-cased out of
+        // `add_source` entirely.
+        let sort_is_first_intermediate = matches!(self.spec.stages.as_slice(), [Stage::Sort, ..]);
+
+        match source {
+            PendingSource::Single(boxed_input) => {
+                let input = *boxed_input;
+                // GroupKeyConfig: used by DecodeRecords (BAM) and ParseSamChunk (SAM).
+                // Queryname-grouping first stages (correct) skip cell-barcode
+                // extraction — see `source_group_key_config`.
+                let group_key_config = self.source_group_key_config();
+
+                match input {
+                    InputSource::Bam { reader, .. } => {
+                        if sort_is_first_intermediate {
+                            // All four sort orders use the arena-backed
+                            // parallel-inflate front (ReadBgzfBlocks only — no
+                            // BgzfDecompress); ReadBlocks → InflateToArena →
+                            // FindBoundariesAndSort (with the per-order strategy)
+                            // are wired in add_sort. Leave the BgzfBlock tail for
+                            // that front. SAM / fused inputs still use SortBuffer.
+                            let (read_step, _) = read_bam_from_reader(
+                                reader,
+                                self.header.clone(),
+                                self.tuning.blocks_per_batch,
+                                self.tuning.per_step_byte_limit,
+                            );
+                            let tail = self.pipeline.append_source(read_step);
+                            self.current_tail = Some(tail);
+                            self.chain_tail_kind = ChainTailKind::BgzfBlockArena;
+                        } else {
+                            let tail = self.build_bam_decode_preamble(
+                                reader,
+                                self.header.clone(),
+                                group_key_config,
+                            );
+                            self.current_tail = Some(tail);
+                            self.chain_tail_kind = ChainTailKind::DecodedRecordBatch;
+                        }
+                    }
+                    InputSource::Sam { reader: sam_reader, .. } => {
+                        // Sort-as-first-stage needs a `RecordBatch` source, but the
+                        // SAM preamble only produces `DecodedRecordBatch`; feeding
+                        // that into the sort ingest (`SortBuffer`) is a handle-type
+                        // mismatch (see `add_sort`). SAM input to a sort-first chain was never
+                        // supported (the legacy file→file sorter read BAM only), so
+                        // reject it with a clear message instead of a downstream
+                        // typed-step panic.
+                        if sort_is_first_intermediate {
+                            anyhow::bail!(
+                                "sort requires BAM input; SAM input is not supported \
+                                 (convert with `samtools view -b` first)"
+                            );
+                        }
+                        let buf = sam_reader.into_inner();
+                        let tail = self.build_sam_parse_preamble(
+                            buf,
+                            self.header.clone(),
+                            group_key_config,
+                        );
+                        self.current_tail = Some(tail);
+                        self.chain_tail_kind = ChainTailKind::DecodedRecordBatch;
+                    }
+                }
+            }
+            PendingSource::Paired { mapped: boxed_mapped, unmapped: boxed_unmapped, reference } => {
+                // Zipper's two-input preamble. Both chains end at GroupByQueryname
+                // so their output type is OrderedBytesSingle<BamTemplateBatch>,
+                // matching ZipperMergeStep's InputA / InputB.
+                //
+                // The reference path is carried in PendingSource::Paired but
+                // add_zipper reads it directly from self.spec.source, which is
+                // always SourceSpec::PairedBams for zipper. Dropping `reference`
+                // here is intentional.
+
+                let mapped = *boxed_mapped;
+                let unmapped = *boxed_unmapped;
+                let _ = reference; // consumed by add_zipper via self.spec.source
+
+                let unmapped_header = unmapped.header().clone();
+                let mapped_header = mapped.header().clone();
+
+                // Resolve paths for check_sort log messages (stdin → "<stdin>").
+                let (unmapped_path, mapped_path) = match &self.spec.source {
+                    SourceSpec::PairedBams { unmapped: u, mapped: m, .. } => (u.clone(), m.clone()),
+                    _ => unreachable!("PendingSource::Paired with non-PairedBams spec"),
+                };
+
+                check_sort(&unmapped_header, &unmapped_path, "unmapped");
+                check_sort(&mapped_header, &mapped_path, "mapped");
+
+                // Warn if mapped input is BAM (SAM from aligner is the fast path).
+                if matches!(mapped, InputSource::Bam { .. }) {
+                    log::warn!(
+                        "BAM input detected for --input. For best performance, pipe SAM directly \
+                         from the aligner (e.g. bwa mem ... | fgumi zipper ...)."
+                    );
+                }
+
+                // GroupKeyConfig used by DecodeRecords (BAM) and ParseSamChunk (SAM).
+                let group_key_config = self.bam_group_key_config();
+
+                // ── Unmapped preamble: always BAM (guaranteed by open_source) ──
+                let unmapped_tail = match unmapped {
+                    InputSource::Bam { reader, header: bam_header } => self
+                        .build_bam_decode_then_group_preamble(
+                            reader,
+                            bam_header,
+                            group_key_config.clone(),
+                        ),
+                    InputSource::Sam { .. } => {
+                        // Guarded in open_source; belt-and-suspenders.
+                        bail!(
+                            "SAM input is not supported for --unmapped \
+                            (expected `fgumi extract` BAM output)"
+                        );
+                    }
+                };
+
+                // ── Mapped preamble: BAM or SAM ────────────────────────────────
+                let mapped_tail = match mapped {
+                    InputSource::Bam { reader, header: bam_header } => self
+                        .build_bam_decode_then_group_preamble(reader, bam_header, group_key_config),
+                    InputSource::Sam { reader: rdr, header: hdr } => {
+                        let buf = rdr.into_inner();
+                        self.build_sam_parse_then_group_preamble(buf, hdr, group_key_config)
+                    }
+                };
+
+                // Store both tails. current_tail = unmapped; paired_tail = mapped.
+                // add_zipper will consume both via PipelineBuilder::append_step2.
+                self.current_tail = Some(unmapped_tail);
+                self.paired_tail = Some(mapped_tail);
+            }
+            PendingSource::Fastq { paths } => {
+                use crate::pipeline::core::step::Affinity;
+                use crate::pipeline::steps::source::pair_fastq::PairRawFastq;
+                use crate::pipeline::steps::source::parse_fastq::ParseFastqChunks;
+                use crate::pipeline::steps::source::parse_zip_fastq::ParseAndZipFastq;
+                use crate::pipeline::steps::source::read_fastq::{
+                    FastqOrdinalSequence, ReadFastqInputs,
+                };
+                use crate::pipeline::steps::source::zip_fastq::ZipFastqRecords;
+
+                // Open one BufRead reader per FASTQ path. Extract's
+                // `open_fastq_reader` handles BGZF / gzip / plain
+                // detection and optional async prefetch wrapping.
+                let extract_opts = self.spec.stage_opts.extract.as_ref().ok_or_else(|| {
+                    anyhow!("Fastq source requires extract options in StageOptionsBag")
+                })?;
+                let async_reader = extract_opts.async_reader;
+                // CRC-verification policy: `ExtractOptions` (the projection) does
+                // not yet carry the `--check-crc` / `--no-check-crc` flags — that
+                // wiring lands when `Extract::execute` builds the projection at the
+                // extract rewire. Until the chain is the live extract caller, use
+                // the default policy (verify a file, trust stdin), which
+                // `open_fastq_reader` selects when both flags are false.
+                let check_crc = false;
+                let no_check_crc = false;
+                // FASTQ decompression threads: for BGZF inputs the reader
+                // can multi-thread; for gzip/plain it is single-threaded
+                // regardless.  Pass 1 here — the pipeline framework
+                // provides the parallelism via typed steps.
+                let mut readers: Vec<Box<dyn std::io::BufRead + Send>> = paths
+                    .iter()
+                    .map(|p| {
+                        crate::commands::extract::open_fastq_reader(
+                            p,
+                            1,
+                            async_reader,
+                            check_crc,
+                            no_check_crc,
+                        )
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                let n_streams = readers.len();
+                // batch_record_count — same default as the legacy pipeline.
+                let batch_records = 400usize;
+                let byte_limit = self.tuning.per_step_byte_limit;
+                // Worker count the pipeline will actually run with. Used to
+                // pin per-stream readers to distinct, in-range workers.
+                let num_threads = self.spec.threading.num_threads().max(1);
+
+                // gzip decompression is the FASTQ bottleneck. The framework
+                // runs distinct `Serial` steps on distinct workers
+                // concurrently (Serial = per-step mutex, not global), so we
+                // instantiate one reader PER stream for the common paired-end
+                // (N == 2) case — both decompressors run at once. For N == 1 a
+                // single reader is trivially enough; for N >= 3 we fall back to
+                // a single all-streams round-robin reader.
+                //
+                // Topology by stream count (all arms produce a
+                // `FastqTemplateBatch`-yielding tail):
+                //   N == 2: ReadFastqInputs×2 → PairRawFastq (Serial, cheap
+                //           chunk-level pairing + serial ordinal mint) →
+                //           ParseAndZipFastq (Parallel: parse both streams'
+                //           bytes AND build templates). This mirrors the legacy
+                //           pipeline's pair-then-parse order and moves the
+                //           expensive record-level template build into a
+                //           parallel step.
+                //   N != 2: ReadFastqInputs → ParseFastqChunks (Parallel parse)
+                //           → ZipFastqRecords (Serial record-level join). The
+                //           2-way `PairRawFastq` Step2 only handles two inputs,
+                //           so single- and ≥3-stream cases keep this structure.
+                //
+                // Each per-stream reader is pinned to a DISTINCT worker via
+                // `Affinity::Worker`. Two `Serial` sources sharing a mutex
+                // dispatched by more than one worker each would race on the
+                // runtime's `try_lock`-after-`Finished` source-drain path, so
+                // disjoint single-worker affinities (never `Affinity::None`)
+                // are required for correctness — not just throughput. The
+                // worker index is clamped to `num_threads - 1` so a low
+                // `--threads` count can never request a non-existent worker
+                // (which would deadlock).
+                let tail = match n_streams {
+                    1 => {
+                        let only = readers.pop().expect("n_streams == 1");
+                        let read_step = ReadFastqInputs::new_single(
+                            only,
+                            0, // global_stream_idx
+                            FastqOrdinalSequence::new(),
+                            Affinity::Worker(0),
+                            batch_records,
+                            byte_limit,
+                        );
+                        let tail = self.pipeline.append_source(read_step);
+                        let parse_tail =
+                            self.pipeline.append_step(ParseFastqChunks::new(byte_limit), tail);
+                        self.pipeline.append_step(ZipFastqRecords::new(1, byte_limit), parse_tail)
+                    }
+                    2 => {
+                        // Two concurrent single-stream readers (R1, R2) →
+                        // PairRawFastq (Step2) → ParseAndZipFastq.
+                        let r2_in = readers.pop().expect("n_streams == 2");
+                        let r1_in = readers.pop().expect("n_streams == 2");
+                        // R1 → worker 0; R2 → worker 1 when it exists
+                        // (clamped to worker 0 at --threads 1, where the two
+                        // readers necessarily serialize on the sole worker).
+                        let r2_worker = (num_threads - 1).min(1);
+                        // One shared ordinal sequence, cloned into both readers,
+                        // keeps the combined R1/R2 ordinal stream gap-free (the
+                        // reorder stage relies on a single monotonic counter).
+                        let ordinals = FastqOrdinalSequence::new();
+                        let r1_step = ReadFastqInputs::new_single(
+                            r1_in,
+                            0,
+                            ordinals.clone(),
+                            Affinity::Worker(0),
+                            batch_records,
+                            byte_limit,
+                        );
+                        let r2_step = ReadFastqInputs::new_single(
+                            r2_in,
+                            1,
+                            ordinals,
+                            Affinity::Worker(r2_worker),
+                            batch_records,
+                            byte_limit,
+                        );
+                        let r1_tail = self.pipeline.append_source(r1_step);
+                        let r2_tail = self.pipeline.append_source(r2_step);
+                        // `PairRawFastq` (Serial) does cheap chunk-level
+                        // pairing and mints the globally-unique ordinal that
+                        // `ParseAndZipFastq` (Parallel) reorders by. The latter
+                        // parses both streams' bytes and builds the templates,
+                        // so no separate `ZipFastqRecords` is appended for
+                        // N == 2.
+                        let pair_tail = self.pipeline.append_step2(
+                            PairRawFastq::new(byte_limit),
+                            r1_tail,
+                            r2_tail,
+                        );
+                        self.pipeline.append_step(ParseAndZipFastq::new(byte_limit), pair_tail)
+                    }
+                    _ => {
+                        // N >= 3 fallback: single all-streams round-robin
+                        // reader (Affinity::Reader), serial decompress.
+                        let read_step = ReadFastqInputs::new(readers, batch_records, byte_limit);
+                        let tail = self.pipeline.append_source(read_step);
+                        let parse_tail =
+                            self.pipeline.append_step(ParseFastqChunks::new(byte_limit), tail);
+                        self.pipeline
+                            .append_step(ZipFastqRecords::new(n_streams, byte_limit), parse_tail)
+                    }
+                };
+
+                self.current_tail = Some(tail);
+                // Every arm's tail emits FastqTemplateBatch; the only
+                // consumer is add_extract.
+                self.chain_tail_kind = ChainTailKind::FastqTemplateBatch;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Resolve the input path used for log messages. For `PairedBams`,
+    /// returns the mapped path (the user-facing "main" input). For
+    /// `Fastqs`, returns the first path (R1). The result is for display only —
+    /// the actual source reader(s) are created by [`Self::add_source`] from
+    /// the full [`SourceSpec`].
+    ///
+    /// Lets per-stage methods (`add_group`, `add_simplex`, `add_duplex`,
+    /// `add_codec`, `add_clip`, `add_filter`, `add_correct`) accept all
+    /// `SourceSpec` variants for logging without having to bail on
+    /// fused-chain compositions where their upstream is a multi-input source.
+    fn resolve_log_input_path(&self) -> std::path::PathBuf {
+        match &self.spec.source {
+            SourceSpec::Bam(p) | SourceSpec::Sam(p) => p.clone(),
+            SourceSpec::PairedBams { mapped, .. } => mapped.clone(),
+            SourceSpec::Fastqs { paths, .. } => paths.first().cloned().unwrap_or_default(),
+        }
+    }
+
+    /// Build a [`GroupKeyConfig`] from the **current** `self.header`.
+    ///
+    /// Reads the library index (from `@RG` `LB` fields) and the cell-barcode
+    /// tag. Callers must invoke this at the point in chain construction where
+    /// `self.header` already reflects the records being decoded: `add_source`
+    /// calls it before any stage replaces the header; the consensus stages call
+    /// it *after* `self.header` has been replaced with the consensus output
+    /// header (the records being decoded are consensus output records). Do not
+    /// hoist a call above a `self.header = …` reassignment.
+    ///
+    /// [`GroupKeyConfig`]: fgumi_bam_io::GroupKeyConfig
+    fn bam_group_key_config(&self) -> fgumi_bam_io::GroupKeyConfig {
+        use crate::sam::SamTag;
+        use noodles::sam::alignment::record::data::field::Tag;
+        let cell_tag = Tag::from(SamTag::CB);
+        let library_index = fgumi_bam_io::LibraryIndex::from_header(&self.header);
+        let config = fgumi_bam_io::GroupKeyConfig::new(library_index, cell_tag);
+        // When a Group stage is in the chain, cache the UMI (RX) value position
+        // during decode so `fgumi group`'s per-template UMI-assignment lookup can
+        // slice it without re-scanning aux data (#334). Group's UMI tag is fixed
+        // to RX (see `add_group`'s `raw_tag`). Chains without a Group stage skip
+        // the cache to avoid the extra per-record aux scan.
+        if self.spec.stages.contains(&Stage::Group) {
+            config.with_umi_tag(*SamTag::RX)
+        } else {
+            config
+        }
+    }
+
+    /// Group-key config for the **source preamble's** `DecodeRecords`.
+    ///
+    /// A first stage that groups by queryname (correct's `GroupByQueryname`)
+    /// reads only `key.name_hash` and discards the rest of the `GroupKey`, so
+    /// the source decode uses
+    /// [`fgumi_bam_io::GroupKeyConfig::name_hash_only`] — skipping the CIGAR
+    /// 5′-position walk and the RG/CB/MC aux-tag extraction pass entirely.
+    /// (The legacy single-threaded path uses `new_raw_no_cell`, which still
+    /// pays the combined aux pass; name-hash-only is strictly less work.) All
+    /// other first stages (group/dedup/consensus/clip) need the full
+    /// position/cell key, so they fall through to [`Self::bam_group_key_config`].
+    fn source_group_key_config(&self) -> fgumi_bam_io::GroupKeyConfig {
+        if matches!(self.spec.stages.first(), Some(Stage::Correct)) {
+            let library_index = fgumi_bam_io::LibraryIndex::from_header(&self.header);
+            fgumi_bam_io::GroupKeyConfig::name_hash_only(library_index)
+        } else {
+            self.bam_group_key_config()
+        }
+    }
+
+    /// Finish a consensus stage's chain tail.
+    ///
+    /// The consensus step emits a record-aligned [`DecompressedBlock`]. For a
+    /// [`StagePosition::Terminal`] consensus stage, that block IS the chain tail
+    /// (`add_sink` wires `BgzfCompress → Write`); `chain_tail_kind` is set to
+    /// [`ChainTailKind::SerializedBytes`] (the honest marker for "serialized
+    /// bytes ready for sink"; nothing downstream of a terminal consensus reads
+    /// it). For a
+    /// [`StagePosition::Intermediate`] consensus stage, a downstream stage
+    /// (e.g. filter) consumes records, so append the existing [`DecodeRecords`]
+    /// step — consensus output is already record-aligned, so no
+    /// `FindBamBoundaries`/`ParseBamRecords` is needed — yielding
+    /// [`DecodedRecordBatch`].
+    ///
+    /// [`DecompressedBlock`]: crate::pipeline::steps::types::DecompressedBlock
+    /// [`DecodedRecordBatch`]: crate::pipeline::steps::types::DecodedRecordBatch
+    /// [`DecodeRecords`]: crate::pipeline::steps::parse::decode::DecodeRecords
+    #[cfg(feature = "consensus")]
+    fn finish_consensus_tail(
+        &mut self,
+        tail: (
+            crate::pipeline::core::topology::StepIdx,
+            crate::pipeline::core::topology::BranchIdx,
+        ),
+        position: StagePosition,
+    ) -> (crate::pipeline::core::topology::StepIdx, crate::pipeline::core::topology::BranchIdx)
+    {
+        match position {
+            // terminal: tail is DecompressedBlock (serialized bytes) → SerializedBytes.
+            StagePosition::Terminal => {
+                self.chain_tail_kind = ChainTailKind::SerializedBytes;
+                tail
+            }
+            StagePosition::Intermediate => {
+                use crate::pipeline::steps::parse::decode::DecodeRecords;
+                let group_key_config = self.bam_group_key_config();
+                let tail = self.pipeline.append_step(
+                    DecodeRecords::new(group_key_config, self.tuning.per_step_byte_limit),
+                    tail,
+                );
+                self.chain_tail_kind = ChainTailKind::DecodedRecordBatch;
+                tail
+            }
+        }
+    }
+
+    /// Wire the rejects fan-out branch (branch 1) of a 2-output consensus step:
+    /// `BgzfCompress` → `WriteBgzfFile` with the **input** header, in input
+    /// order — the PR #332 fan-out contract (rejects flow through the ordered
+    /// serialize/compress stages, not a mutex side-channel).
+    ///
+    /// `consensus_pt` is the just-appended consensus step (branch 0 is its kept
+    /// output, consumed by the caller); `label` names the command for error
+    /// context. Shared by `add_simplex`/`add_duplex`/`add_codec`, whose
+    /// rejects wiring is otherwise identical — only the consensus step's type
+    /// (built inline by the caller) differs.
+    #[cfg(feature = "consensus")]
+    fn wire_consensus_rejects_branch(
+        &self,
+        consensus_pt: (StepIdx, BranchIdx),
+        rejects_path: Option<&std::path::Path>,
+        input_header: &Header,
+        label: &str,
+    ) -> Result<()> {
+        use crate::pipeline::steps::bgzf::compress::BgzfCompress;
+        use crate::pipeline::steps::sink::write_bgzf::WriteBgzfFile;
+
+        let rejects_path = rejects_path
+            .ok_or_else(|| anyhow!("rejects path unexpectedly None when track_rejects is set"))?;
+        let rejects_write =
+            WriteBgzfFile::new(rejects_path, input_header, self.tuning.compression_level)
+                .map_err(|e| anyhow!("WriteBgzfFile ({label} rejects): {e}"))?;
+
+        let rejects_branch = (consensus_pt.0, BranchIdx(1));
+        let rejects_compress_tail = self.pipeline.append_step(
+            BgzfCompress::new(self.tuning.compression_level, self.tuning.per_step_byte_limit),
+            rejects_branch,
+        );
+        self.pipeline.append_step(rejects_write, rejects_compress_tail);
+        Ok(())
+    }
+
+    /// Append the 4-step BAM decode preamble:
+    /// `ReadBgzfBlocks → BgzfDecompress → FindBamBoundaries → DecodeRecords`.
+    fn build_bam_decode_preamble(
+        &mut self,
+        reader: Box<dyn std::io::Read + Send>,
+        header: Header,
+        group_key_config: fgumi_bam_io::GroupKeyConfig,
+    ) -> (crate::pipeline::core::topology::StepIdx, crate::pipeline::core::topology::BranchIdx)
+    {
+        use crate::pipeline::steps::bgzf::decompress::BgzfDecompress;
+        use crate::pipeline::steps::boundaries::bam::FindBamBoundaries;
+        use crate::pipeline::steps::parse::decode::DecodeRecords;
+        use crate::pipeline::steps::source::read_bam::read_bam_from_reader;
+
+        let (read_step, _) = read_bam_from_reader(
+            reader,
+            header,
+            self.tuning.blocks_per_batch,
+            self.tuning.per_step_byte_limit,
+        );
+        let tail = self.pipeline.append_source(read_step);
+        let tail =
+            self.pipeline.append_step(BgzfDecompress::new(self.tuning.per_step_byte_limit), tail);
+        let tail = self
+            .pipeline
+            .append_step(FindBamBoundaries::new(self.tuning.per_step_byte_limit), tail);
+        self.pipeline.append_step(
+            DecodeRecords::new(group_key_config, self.tuning.per_step_byte_limit),
+            tail,
+        )
+    }
+
+    /// Append the BAM decode preamble followed by `GroupByQueryname`:
+    /// `ReadBgzfBlocks → BgzfDecompress → FindBamBoundaries → DecodeRecords → GroupByQueryname`.
+    fn build_bam_decode_then_group_preamble(
+        &mut self,
+        reader: Box<dyn std::io::Read + Send>,
+        header: Header,
+        group_key_config: fgumi_bam_io::GroupKeyConfig,
+    ) -> (crate::pipeline::core::topology::StepIdx, crate::pipeline::core::topology::BranchIdx)
+    {
+        use crate::pipeline::steps::group::queryname::GroupByQueryname;
+
+        let tail = self.build_bam_decode_preamble(reader, header, group_key_config);
+        self.pipeline.append_step(GroupByQueryname::new(self.tuning.per_step_byte_limit), tail)
+    }
+
+    /// Append the 2-step SAM parse preamble:
+    /// `ReadSamChunks → ParseSamChunk`.
+    fn build_sam_parse_preamble(
+        &mut self,
+        buf: Box<dyn std::io::BufRead + Send>,
+        header: Header,
+        group_key_config: fgumi_bam_io::GroupKeyConfig,
+    ) -> (crate::pipeline::core::topology::StepIdx, crate::pipeline::core::topology::BranchIdx)
+    {
+        use crate::pipeline::steps::parse::sam::ParseSamChunk;
+        use crate::pipeline::steps::source::read_sam_chunks::{
+            DEFAULT_SAM_CHUNK_BYTES, ReadSamChunks,
+        };
+
+        let read_step =
+            ReadSamChunks::new(buf, DEFAULT_SAM_CHUNK_BYTES, self.tuning.per_step_byte_limit);
+        let parse_step =
+            ParseSamChunk::new(Arc::new(header), group_key_config, self.tuning.per_step_byte_limit);
+        let tail = self.pipeline.append_source(read_step);
+        self.pipeline.append_step(parse_step, tail)
+    }
+
+    /// Append the SAM parse preamble followed by `GroupByQueryname`:
+    /// `ReadSamChunks → ParseSamChunk → GroupByQueryname`.
+    fn build_sam_parse_then_group_preamble(
+        &mut self,
+        buf: Box<dyn std::io::BufRead + Send>,
+        header: Header,
+        group_key_config: fgumi_bam_io::GroupKeyConfig,
+    ) -> (crate::pipeline::core::topology::StepIdx, crate::pipeline::core::topology::BranchIdx)
+    {
+        use crate::pipeline::steps::group::queryname::GroupByQueryname;
+
+        let tail = self.build_sam_parse_preamble(buf, header, group_key_config);
+        self.pipeline.append_step(GroupByQueryname::new(self.tuning.per_step_byte_limit), tail)
+    }
+
+    /// Dispatch by `Stage` variant to the per-stage internal builder.
+    ///
+    /// `position` controls whether the stage appends a serialise-to-bytes step
+    /// (Terminal) or leaves its native typed output on the chain tail
+    /// (Intermediate). See [`StagePosition`] for the contract.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors from step construction or pipeline building.
+    pub fn add_stage(&mut self, stage: Stage, position: StagePosition) -> Result<()> {
+        match stage {
+            Stage::Dedup => self.add_dedup(position),
+            Stage::Filter => self.add_filter(position),
+            Stage::Clip => self.add_clip(position),
+            Stage::Sort => self.add_sort(position),
+            Stage::Group => self.add_group(position),
+            Stage::Simplex => self.add_simplex(position),
+            Stage::Duplex => self.add_duplex(position),
+            Stage::Codec => self.add_codec(position),
+            Stage::Correct => self.add_correct(position),
+            Stage::Zipper => self.add_zipper(position),
+            Stage::Align => self.add_align(position),
+            Stage::Extract => self.add_extract(position),
+            Stage::Fastq => self.add_fastq(position),
+            Stage::Downsample => {
+                Err(anyhow!("Stage::Downsample is out of scope — not on the typed-step pipeline"))
+            }
+        }
+    }
+
+    /// Add the terminal BAM → FASTQ encode stage.
+    ///
+    /// Consumes the `DecodedRecordBatch` tail from the BAM source preamble.
+    /// For a single-output sink, appends the `Parallel` FASTQ-encode step
+    /// (pool-spread), leaving a `DecompressedBlock` byte tail for `add_sink`
+    /// to route to a raw writer (optionally through `BgzfCompress` for
+    /// `.gz`/`.bgz` output). For a `SinkSpec::FastqPaired` sink, appends the
+    /// 3-output `Process3` encode step and wires branch b (R2) to `out2` and
+    /// branch c (other) to `out0`/stdout in-method (mirroring how
+    /// `add_filter`/`wire_consensus_rejects_branch` wire secondary branches),
+    /// leaving branch a (R1) as `current_tail` for `add_sink` to route to
+    /// `out1`.
+    fn add_fastq(&mut self, position: StagePosition) -> Result<()> {
+        use std::sync::atomic::AtomicU64;
+
+        use crate::logging::OperationTimer;
+        use crate::pipeline::chains::commands::fastq::{
+            FastqFinalizeHook, build_fastq_encode_step, build_fastq_paired_encode_step,
+        };
+        use crate::pipeline::core::topology::BranchIdx;
+
+        debug_assert_eq!(position, StagePosition::Terminal, "Stage::Fastq is always terminal");
+
+        let opts = self
+            .spec
+            .stage_opts
+            .fastq
+            .as_ref()
+            .ok_or_else(|| anyhow!("Stage::Fastq options missing from StageOptionsBag"))?;
+
+        let tail = self.current_tail.expect("add_fastq called before add_source");
+        let timer = OperationTimer::new("Converting BAM to FASTQ");
+        let records_written = Arc::new(AtomicU64::new(0));
+
+        if let SinkSpec::FastqPaired { out2, out0, .. } = &self.spec.sink {
+            let out2 = out2.clone();
+            let out0 = out0.clone();
+            let step = build_fastq_paired_encode_step(
+                Arc::new(opts.clone()),
+                self.tuning.per_step_byte_limit,
+                Arc::clone(&records_written),
+            );
+            let process_tail = self.pipeline.append_step(step, tail);
+            // Branch 1 = R2 → out2; branch 2 = "other" → out0 (or stdout via `-`).
+            self.wire_fastq_output((process_tail.0, BranchIdx(1)), &out2)?;
+            let out0_path = out0.unwrap_or_else(|| std::path::PathBuf::from("-"));
+            self.wire_fastq_output((process_tail.0, BranchIdx(2)), &out0_path)?;
+            // Branch 0 = R1 → current_tail for add_sink → out1.
+            self.current_tail = Some(process_tail);
+        } else {
+            let step = build_fastq_encode_step(
+                Arc::new(opts.clone()),
+                self.tuning.per_step_byte_limit,
+                Arc::clone(&records_written),
+            );
+            self.current_tail = Some(self.pipeline.append_step(step, tail));
+        }
+        self.chain_tail_kind = ChainTailKind::SerializedBytes;
+
+        self.finalize.push(Box::new(FastqFinalizeHook { records_written, timer }));
+        Ok(())
+    }
+
+    /// Add the output sink step(s) to the pipeline.
+    ///
+    /// Appends `BgzfCompress` + `WriteBgzfFile`. Reads `spec.sink` for the
+    /// output path and uses the output header from `self.header`.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors from sink step construction (e.g., cannot create output file).
+    ///
+    /// # Panics
+    ///
+    /// Panics if called before [`Self::add_source`].
+    pub fn add_sink(&mut self) -> Result<()> {
+        use crate::pipeline::steps::bgzf::compress::BgzfCompress;
+        use crate::pipeline::steps::sink::write_bgzf::WriteBgzfFile;
+
+        // FASTQ sinks write raw bytes (no BAM header, no BGZF EOF) via a
+        // dedicated writer, optionally through `BgzfCompress` for `.gz`/`.bgz`.
+        if let SinkSpec::Fastq(path) = &self.spec.sink {
+            let path = path.clone();
+            return self.add_fastq_sink(&path);
+        }
+        if let SinkSpec::FastqPaired { out1, .. } = &self.spec.sink {
+            let out1 = out1.clone();
+            // Branches b (R2) and c (other) were wired in add_fastq; branch a
+            // (R1) is current_tail here.
+            let tail = self.current_tail.expect("add_sink called before add_source");
+            return self.wire_fastq_output(tail, &out1);
+        }
+
+        let tail = self.current_tail.expect("add_sink called before add_source");
+        let output_path = self.spec.sink.path();
+
+        let compress_step =
+            BgzfCompress::new(self.tuning.compression_level, self.tuning.per_step_byte_limit);
+        let tail = self.pipeline.append_step(compress_step, tail);
+
+        // When Stage::Align is in the chain, the merged output header is
+        // resolved at pipeline-run time (the aligner contributes @PG/@RG/@CO
+        // lines that aren't known until it emits its SAM/BAM header). The
+        // `HeaderHandle` stashed by `add_align` must be forwarded here so the
+        // writer blocks until the handle is resolved before emitting any bytes.
+        let write_step = if let Some(handle) = self.pending_header_handle.take() {
+            WriteBgzfFile::new_with_handle(
+                output_path,
+                handle,
+                self.tuning.compression_level,
+                self.pending_header_transform.take(),
+            )
+            .map_err(|e| anyhow!("WriteBgzfFile::new_with_handle: {e}"))?
+        } else {
+            WriteBgzfFile::new(output_path, &self.header, self.tuning.compression_level)
+                .map_err(|e| anyhow!("WriteBgzfFile::new: {e}"))?
+        };
+        // Lever 2: on the standalone-sort terminal only, run the writer on the
+        // sort's I/O driver thread (legacy "N + 2"), sharing it with the phase-1
+        // `SpillWrite`. Every other chain keeps the pool-scheduled Serial +
+        // Affinity::Writer writer.
+        let write_step = if self.detached_writer {
+            use crate::pipeline::core::step::DetachedGroup;
+            use crate::pipeline::steps::sort::SORT_IO_GROUP;
+            write_step.with_detached(DetachedGroup::Shared(SORT_IO_GROUP))
+        } else {
+            write_step
+        };
+        let tail = self.pipeline.append_step(write_step, tail);
+
+        self.current_tail = Some(tail);
+        Ok(())
+    }
+
+    /// Route the FASTQ byte tail to a single (interleaved) raw writer.
+    fn add_fastq_sink(&mut self, path: &std::path::Path) -> Result<()> {
+        let tail = self.current_tail.expect("add_sink called before add_source");
+        self.wire_fastq_output(tail, path)?;
+        // add_fastq_sink terminates the chain; no downstream tail.
+        Ok(())
+    }
+
+    /// Wire one FASTQ byte branch (`tail`) to its own writer: a `.gz`/`.bgz`
+    /// `path` is compressed via the shared-pool `BgzfCompress` step first
+    /// (appending the BGZF EOF marker so the stream is a complete BGZF file);
+    /// otherwise the bytes are written verbatim (file, or stdout via `-`).
+    fn wire_fastq_output(
+        &mut self,
+        tail: (StepIdx, BranchIdx),
+        path: &std::path::Path,
+    ) -> Result<()> {
+        use crate::commands::fastq::path_is_gzip;
+        use crate::pipeline::steps::bgzf::compress::BgzfCompress;
+        use crate::pipeline::steps::sink::write_raw::WriteRawFile;
+        use crate::pipeline::steps::types::{BgzfBlock, DecompressedBlock};
+
+        if path_is_gzip(path) {
+            let compress =
+                BgzfCompress::new(self.tuning.compression_level, self.tuning.per_step_byte_limit);
+            let compress_tail = self.pipeline.append_step(compress, tail);
+            let writer = WriteRawFile::<BgzfBlock>::new(path, &fgumi_bgzf::BGZF_EOF)
+                .map_err(|e| anyhow!("WriteRawFile: {e}"))?;
+            self.pipeline.append_step(writer, compress_tail);
+        } else {
+            let writer = WriteRawFile::<DecompressedBlock>::new(path, b"")
+                .map_err(|e| anyhow!("WriteRawFile: {e}"))?;
+            self.pipeline.append_step(writer, tail);
+        }
+        Ok(())
+    }
+
+    /// Replace `self.header` with `header`, invalidating any pending
+    /// [`HeaderHandle`] stashed by [`Self::add_align`].
+    ///
+    /// `add_align` stashes a `HeaderHandle` so `add_sink` can block on the
+    /// aligner's runtime-resolved mapped-read header. When a *later* stage
+    /// (e.g. an intermediate `add_align` followed by sort, consensus, or clip)
+    /// builds a new output header, that stale handle would otherwise win in
+    /// `add_sink` and the wrong header (the aligner's, missing the downstream
+    /// stage's `@HD`/`@PG`/`@CO` updates) would be written. Routing every
+    /// post-construction `self.header` reassignment through this helper drops
+    /// the stale handle so `add_sink` falls back to the up-to-date
+    /// `self.header`. Stages that leave the header unchanged (e.g. `add_group`)
+    /// do not call this, preserving the handle for `align → group` chains.
+    ///
+    /// [`HeaderHandle`]: crate::pipeline::core::header::HeaderHandle
+    fn replace_header(&mut self, header: noodles::sam::Header) {
+        self.header = header;
+        // A from-scratch header carries no aligner provenance, so drop BOTH the pending
+        // handle and any transform composed for it. Clearing only the handle would leave a
+        // stale transform that a later `add_align` handle would wrongly re-apply at sink time.
+        self.pending_header_handle = None;
+        self.pending_header_transform = None;
+    }
+
+    /// Apply a header transform for a post-`Align` stage that *modifies* the
+    /// header (e.g. a sort-order rewrite or clip's `@HD` annotation).
+    ///
+    /// Updates the build-time `self.header` immediately (so downstream stage
+    /// construction and static checks see the change), and — when an aligner
+    /// `HeaderHandle` is still pending — composes the transform into
+    /// `self.pending_header_transform` so the same change is re-applied to the
+    /// aligner's runtime-resolved header at sink time, preserving its
+    /// `@PG`/`@RG`/`@CO`. When no handle is pending, `self.header` is
+    /// authoritative and no transform is retained.
+    ///
+    /// Prefer this over [`Self::replace_header`] for post-`Align` header
+    /// *modifications*. Stages that intentionally build a *fresh* header (e.g.
+    /// consensus, which emits an unmapped header with a single collapsed read
+    /// group and its own `@PG`) still use `replace_header`: there is no aligner
+    /// provenance to carry into a from-scratch header.
+    fn apply_output_header_transform<F>(&mut self, transform: F) -> Result<()>
+    where
+        F: Fn(noodles::sam::Header) -> std::io::Result<noodles::sam::Header>
+            + Send
+            + Sync
+            + 'static,
+    {
+        // Build-time: reflect the change now for downstream stages / static checks.
+        self.header = transform(self.header.clone())?;
+        // Runtime: compose onto the pending aligner-header transform chain so it
+        // re-runs on the resolved header at sink time.
+        if self.pending_header_handle.is_some() {
+            let prev = self.pending_header_transform.take();
+            self.pending_header_transform = Some(Box::new(move |header| match &prev {
+                Some(prev) => transform(prev(header)?),
+                None => transform(header),
+            }));
+        }
+        Ok(())
+    }
+
+    /// Build the final [`BuiltPipeline`] from the accumulated state.
+    ///
+    /// Prepends a chain-level [`StageTimingFinalizeHook`] whose `Instant` is
+    /// captured here — at the moment `build()` is called — so the reported
+    /// wall time covers the full pipeline run, not the chain-construction
+    /// phase. The label is derived from `spec.stages` formatted as
+    /// `"dedup"` (single stage) or `"group→simplex"` (multi-stage), making
+    /// the log line unambiguous for fused chains.
+    ///
+    /// Also calls [`build_pipeline_config_for_chain`] for shared threading /
+    /// deadlock-timeout / queue-memory wiring. Registers
+    /// [`PipelineStatsFinalizeHook`] if the user requested stats.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors from pipeline configuration, memory-limit calculation,
+    /// or if the pipeline has unwired output branches (indicates a programming
+    /// error in an `add_*` method).
+    pub fn build(mut self) -> Result<BuiltPipeline> {
+        let num_threads = self.spec.threading.num_threads();
+        // Format with Display (`{e}`), not Debug: `BuildError` carries a
+        // hand-written, user-facing Display impl that a `{e:?}` variant dump
+        // would discard (matches the `BuiltPipeline::run` error formatting).
+        let pipeline = self.pipeline.build().map_err(|e| anyhow!("Pipeline::build: {e}"))?;
+        let (mut config, pipeline_stats) = build_pipeline_config_for_chain(
+            &pipeline,
+            num_threads,
+            &self.spec.scheduler,
+            &self.spec.queue_memory,
+        )?;
+        // Apply per-stage thread override, if set (currently only sort).
+        if let Some(t) = self.override_pipeline_threads {
+            config.threads = t;
+        }
+        // Opt the whole sort-first pipeline into downstream-first dispatch so the
+        // arena front's serial scan overlaps the parallel inflate (flag set in
+        // add_sort for any sort order). Chains without a sort source keep the
+        // default upstream-first scheduler.
+        if self.use_drain_first_scheduler {
+            config = config.with_scheduler(std::sync::Arc::new(
+                crate::pipeline::core::runtime::DrainFirstScheduler,
+            ));
+        }
+        // DIAGNOSTIC: the stats `Arc` already exists whenever the deadlock
+        // monitor is on (default), so allow `FGUMI_PIPELINE_STATS=1` to dump the
+        // per-step timing report even on paths (e.g. standalone `fgumi sort`)
+        // that do not flatten `--pipeline-stats`.
+        // `--pipeline-trace` (any instrumentation level above Off) also produces a
+        // stats `Arc` in `build_pipeline_config_for_chain`; without this clause a
+        // trace-only run would collect edge metrics but never emit the end-of-run
+        // report, since neither `collect_stats()` nor the env var is set.
+        let user_wants_stats = self.spec.scheduler.collect_stats()
+            || super::build_helpers::env_flag_enabled("FGUMI_PIPELINE_STATS");
+        if user_wants_stats
+            && let Some(s) = pipeline_stats
+        {
+            self.finalize.push(Box::new(PipelineStatsFinalizeHook { stats: s }));
+        }
+
+        // Prepend a single chain-level timing hook. Capturing Instant::now()
+        // here (at build() time, not at add_<stage>() time) means the timer
+        // starts just before Pipeline::run() is called, so elapsed ≈ pipeline
+        // wall time. For multi-stage chains (e.g. [Group, Simplex]) we get
+        // one timing line ("Pipeline `group→simplex` ran in Xs") rather than
+        // one per stage — each showing the full pipeline duration.
+        let chain_label = self
+            .spec
+            .stages
+            .iter()
+            .map(|s| format!("{s:?}").to_lowercase())
+            .collect::<Vec<_>>()
+            .join("→");
+        // Box<dyn FinalizeHook> is not Clone, so we prepend by inserting at 0.
+        // The timing hook fires first (before per-stage hooks like DedupFinalize).
+        self.finalize.insert(0, Box::new(StageTimingFinalizeHook::new_with_label(chain_label)));
+
+        Ok(BuiltPipeline {
+            pipeline,
+            config,
+            finalize: self.finalize,
+            finalize_on_success: self.finalize_on_success,
+        })
+    }
+
+    // -- private per-stage methods, one per Stage variant --
+    // Each method's body fills in starting in 3a.3 (dedup) and is
+    // mechanically extended for the other 9 stages in 3a.4-3a.12.
+
+    /// Extract-specific step sequence:
+    ///
+    /// ```text
+    /// (source: ReadFastqInputs → ZipFastqRecords)
+    ///     ↓ FastqTemplateBatch
+    /// ExtractStep (Parallel) — via build_extract_step
+    ///     ↓ BamTemplateBatch
+    /// (Terminal) SerializeBamRecords
+    ///     ↓ DecompressedBlock
+    /// ```
+    ///
+    /// For [`StagePosition::Terminal`], `SerializeBamRecords` is appended and
+    /// the chain tail is `DecompressedBlock` (bytes ready for
+    /// `BgzfCompress → WriteBgzfFile`).
+    ///
+    /// For [`StagePosition::Intermediate`], the tail is left as
+    /// `BamTemplateBatch` so the next stage can consume it directly.
+    ///
+    /// Registers an [`ExtractFinalizeHook`] for record count + timer
+    /// logging.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors if extract options are missing from the spec bag,
+    /// if validation fails, or if the source is not `SourceSpec::Fastqs`.
+    ///
+    /// [`ExtractFinalizeHook`]: crate::pipeline::chains::commands::extract::ExtractFinalizeHook
+    fn add_extract(&mut self, position: StagePosition) -> Result<()> {
+        use std::sync::atomic::AtomicU64;
+
+        use crate::logging::OperationTimer;
+        use crate::pipeline::chains::commands::extract::ExtractFinalizeHook;
+        use crate::pipeline::steps::extract::build_extract_step;
+        use crate::pipeline::steps::serialize::SerializeBamRecords;
+
+        let extract_opts = self
+            .spec
+            .stage_opts
+            .extract
+            .as_ref()
+            .ok_or_else(|| anyhow!("Stage::Extract options missing from StageOptionsBag"))?;
+
+        extract_opts.validate()?;
+
+        let tail = self.current_tail.expect("add_extract called before add_source");
+
+        let output_path = self.spec.sink.path().clone();
+
+        let timer = OperationTimer::new("Extracting UMIs");
+
+        let read_structures = match &self.spec.source {
+            SourceSpec::Fastqs { read_structures, .. } => Arc::new(read_structures.clone()),
+            other => bail!("add_extract requires SourceSpec::Fastqs, got {other:?}"),
+        };
+
+        // Enforce the same read-structure guard the standalone `Extract` command
+        // applies (1-2 template reads total): the chain/runall path previously
+        // skipped it and would silently emit malformed BAM templates.
+        crate::commands::extract::validate_template_count(read_structures.as_slice())?;
+
+        let input_path = self.resolve_log_input_path();
+        log::info!("Starting Extract");
+        log::info!("Input: {}", input_path.display());
+        log::info!("Output: {}", output_path.display());
+
+        let records_emitted = Arc::new(AtomicU64::new(0));
+
+        let step = build_extract_step(
+            read_structures,
+            Arc::new(extract_opts.clone()),
+            Arc::clone(&records_emitted),
+            self.tuning.per_step_byte_limit,
+        );
+        let tail = self.pipeline.append_step(step, tail);
+
+        if position == StagePosition::Terminal {
+            let tail = self
+                .pipeline
+                .append_step(SerializeBamRecords::new(self.tuning.per_step_byte_limit), tail);
+            self.current_tail = Some(tail);
+            // SerializeBamRecords emits DecompressedBlock (serialized bytes), not
+            // DecodedRecordBatch. Mark the tail honestly as SerializedBytes, matching
+            // every other terminal serialize path (e.g. add_dedup); nothing downstream
+            // of a Terminal stage reads this, but the kind must never lie.
+            self.chain_tail_kind = ChainTailKind::SerializedBytes;
+        } else {
+            self.current_tail = Some(tail);
+            self.chain_tail_kind = ChainTailKind::BamTemplateBatch;
+        }
+
+        self.finalize.push(Box::new(ExtractFinalizeHook { records_emitted, timer }));
+
+        Ok(())
+    }
+
+    /// Correct-specific step sequence:
+    ///
+    /// `GroupByQueryname` →
+    /// `correct_step_kept_only` (single output → `BamTemplateBatch`) OR
+    /// `correct_step_with_rejects` (two outputs: branch 0 kept `BamTemplateBatch`,
+    /// branch 1 rejects `DecompressedBlock`) →
+    /// `SerializeBamRecords` — **Terminal only** (on branch 0 / kept branch).
+    ///
+    /// For [`StagePosition::Terminal`], `SerializeBamRecords` is appended and
+    /// the chain tail is [`DecompressedBlock`] (bytes ready for `BgzfCompress`).
+    ///
+    /// For [`StagePosition::Intermediate`], `SerializeBamRecords` is **not**
+    /// appended: the chain tail is left as `BamTemplateBatch` so the next stage
+    /// (`add_align` → `AlignAndMergeStep`) can consume the correct step's kept
+    /// output (branch 0) directly; `add_align` skips `GroupByQueryname` on an
+    /// incoming `BamTemplateBatch`. This is the correct→align fused path.
+    ///
+    /// When `--rejects` is set, branch 1 of the correct step carries pre-framed
+    /// `DecompressedBlock` bytes and is wired here directly to its own
+    /// `BgzfCompress → WriteBgzfFile` sink (same dual-sink pattern as
+    /// `add_filter`, T3a.4). Branch 0 (kept `BamTemplateBatch`) becomes
+    /// `current_tail` for the `SerializeBamRecords` step and, after that, for
+    /// `add_sink`.
+    ///
+    /// Applies `correct_opts.validate()` for semantic option checks (UMI source
+    /// presence + numeric ranges). Loads UMI sequences and encodes them into
+    /// [`EncodedUmiSet`] up front.
+    ///
+    /// The `rejects_header` is the **input header verbatim** (PR #332 contract:
+    /// rejects are raw-input records, so they carry the input's `@HD` sort
+    /// fields + RG/PG — not the consensus/output header). For `correct`,
+    /// `self.header` is the input header (correct preserves input order and does
+    /// not replace `self.header` with a consensus header), so it is used as-is.
+    ///
+    /// Registers a [`CorrectFinalizeHook`] for: per-thread accumulator reduce →
+    /// `finalize_metrics` → summary + warn banners → `--min-corrected` ratio
+    /// gate (bail!) → `timer.log_completion`.
+    /// The chain-level [`StageTimingFinalizeHook`] is registered by
+    /// [`Self::build`] (not here), so it captures the correct `Instant`.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors if correct options are missing from the spec bag or if UMI
+    /// sequence loading fails.
+    ///
+    /// [`EncodedUmiSet`]: crate::commands::correct::EncodedUmiSet
+    /// [`DecompressedBlock`]: crate::pipeline::steps::types::DecompressedBlock
+    /// [`CorrectFinalizeHook`]: crate::pipeline::chains::commands::correct::CorrectFinalizeHook
+    #[allow(clippy::too_many_lines)]
+    fn add_correct(&mut self, position: StagePosition) -> Result<()> {
+        use crate::commands::common::warn_unwired_pipeline_flags;
+        use crate::commands::correct::{CollectedCorrectMetrics, EncodedUmiSet};
+        use crate::logging::OperationTimer;
+        use crate::per_thread_accumulator::PerThreadAccumulator;
+        use crate::pipeline::chains::commands::correct::CorrectFinalizeHook;
+        use crate::pipeline::steps::correct::{
+            CorrectStepConfig, correct_step_kept_only, correct_step_with_rejects,
+        };
+        use crate::pipeline::steps::group::queryname::GroupByQueryname;
+        use crate::pipeline::steps::serialize::SerializeBamRecords;
+        use crate::sam::SamTag;
+        use log::info;
+
+        // `Intermediate` is used when correct feeds into align-and-merge
+        // (the `--start-from correct --stop-after ≥ zipper` fused chain).
+        // In that case we skip `SerializeBamRecords` and leave the tail at
+        // the correct step's `BamTemplateBatch` output (branch 0) so
+        // `add_align` can wire `GroupByQueryname → AlignAndMergeStep` next.
+
+        let correct_opts = self
+            .spec
+            .stage_opts
+            .correct
+            .as_ref()
+            .ok_or_else(|| anyhow!("Stage::Correct options missing from StageOptionsBag"))?;
+
+        // Semantic option-level checks (UMI source presence + numeric ranges).
+        correct_opts.validate()?;
+
+        let tail = self.current_tail.expect("add_correct called before add_source");
+
+        // Resolve source path for log messages only.
+        let input_path = self.resolve_log_input_path();
+        let output_path = self.spec.sink.path().clone();
+
+        let timer = OperationTimer::new("Correcting UMIs (new pipeline)");
+
+        info!("{}", crate::commands::correct::NEW_PIPELINE_START_LOG);
+        info!("Input: {}", input_path.display());
+        info!("Output: {}", output_path.display());
+
+        // The UMI-set loading and distance check read only tuning knobs, which
+        // live directly on `CorrectOptions` — no `CorrectUmis` wrapper needed.
+        let (umi_sequences, umi_length) = correct_opts.load_umi_sequences()?;
+        let encoded_umi_set = Arc::new(EncodedUmiSet::new(&umi_sequences));
+        correct_opts.check_umi_distances(&umi_sequences);
+        let unmatched_umi = "N".repeat(umi_length);
+
+        let num_threads = self.spec.threading.num_threads();
+
+        // Build per-thread metrics accumulators and records-emitted counter.
+        // Note: PerThreadAccumulator::new() already returns Arc<Self>.
+        let metrics_slots = num_threads.max(1);
+        let metrics = PerThreadAccumulator::<CollectedCorrectMetrics>::new(metrics_slots);
+        let records_emitted = Arc::new(std::sync::atomic::AtomicU64::new(0));
+
+        let umi_tag_bytes: [u8; 2] = SamTag::RX.into();
+        // Original-sequence stash tag, derived from the correction target (RX→OX
+        // for umi, BC→ob for barcode), matching the non-chain correct path.
+        let original_tag_bytes: [u8; 2] = correct_opts.target.original_tag().into();
+        let cfg = CorrectStepConfig {
+            encoded_umi_set: Arc::clone(&encoded_umi_set),
+            umi_length,
+            umi_tag: umi_tag_bytes,
+            original_tag: original_tag_bytes,
+            opts: correct_opts.clone(),
+            metrics: Arc::clone(&metrics),
+            records_emitted: Arc::clone(&records_emitted),
+            output_byte_limit: self.tuning.per_step_byte_limit,
+            unmatched_umi: unmatched_umi.clone(),
+        };
+
+        let track_rejects = correct_opts.rejects_path.is_some();
+
+        warn_unwired_pipeline_flags(&self.spec.scheduler, &self.spec.queue_memory);
+        info!("{}", self.spec.threading.log_message());
+        info!("Using pipeline with {num_threads} threads");
+
+        // Wire GroupByQueryname before the correct step.
+        let tail =
+            self.pipeline.append_step(GroupByQueryname::new(self.tuning.per_step_byte_limit), tail);
+
+        // Dispatch on rejects presence: either a 2-output or a 1-output step.
+        let process_tail = if track_rejects {
+            use crate::pipeline::core::topology::BranchIdx;
+            use crate::pipeline::steps::bgzf::compress::BgzfCompress;
+            use crate::pipeline::steps::sink::write_bgzf::WriteBgzfFile;
+
+            let rejects_path = correct_opts.rejects_path.as_ref().ok_or_else(|| {
+                anyhow!("rejects_path unexpectedly None (build_for dispatch bug)")
+            })?;
+            // PR #332 contract: rejects carry the INPUT header verbatim (raw-input
+            // records, input order). For correct, `self.header` IS the input header.
+            let rejects_header = self.header.clone();
+            let rejects_write =
+                WriteBgzfFile::new(rejects_path, &rejects_header, self.tuning.compression_level)
+                    .map_err(|e| anyhow!("WriteBgzfFile (rejects): {e}"))?;
+
+            let step = correct_step_with_rejects(cfg);
+            let pt = self.pipeline.append_step(step, tail);
+
+            // Branch 1 = pre-framed rejects bytes → BgzfCompress → WriteBgzfFile.
+            let rejects_branch = (pt.0, BranchIdx(1));
+            let rejects_compress_tail = self.pipeline.append_step(
+                BgzfCompress::new(self.tuning.compression_level, self.tuning.per_step_byte_limit),
+                rejects_branch,
+            );
+            let _rejects_write_tail =
+                self.pipeline.append_step(rejects_write, rejects_compress_tail);
+
+            // Branch 0 = kept BamTemplateBatch (needs SerializeBamRecords).
+            pt
+        } else {
+            let step = correct_step_kept_only(cfg);
+            self.pipeline.append_step(step, tail)
+        };
+        // process_tail = (process_step_idx, BranchIdx(0)) = kept BamTemplateBatch.
+
+        if position == StagePosition::Terminal {
+            // Append SerializeBamRecords on the Terminal path so the tail is
+            // DecompressedBlock, ready for BgzfCompress → WriteBgzfFile.
+            let tail = self.pipeline.append_step(
+                SerializeBamRecords::new(self.tuning.per_step_byte_limit),
+                process_tail,
+            );
+            self.current_tail = Some(tail);
+            // tail is DecompressedBlock (serialized bytes) → SerializedBytes.
+            self.chain_tail_kind = ChainTailKind::SerializedBytes;
+        } else {
+            // Intermediate: leave the tail as BamTemplateBatch so the next
+            // stage (add_align → GroupByQueryname → AlignAndMergeStep) can
+            // consume it directly.
+            self.current_tail = Some(process_tail);
+            self.chain_tail_kind = ChainTailKind::BamTemplateBatch;
+        }
+
+        // Register the correct finalize hook.
+        // The chain-level StageTimingFinalizeHook is inserted at index 0 by
+        // build() after all stages have been added — that way a single timer
+        // covers the full pipeline run regardless of how many stages there are.
+        self.finalize.push(Box::new(CorrectFinalizeHook {
+            metrics,
+            records_emitted,
+            encoded_umi_set,
+            unmatched_umi,
+            min_corrected: correct_opts.min_corrected,
+            correct: correct_opts.clone(),
+            timer,
+        }));
+
+        Ok(())
+    }
+
+    /// AlignAndMerge-specific step sequence (subprocess source):
+    ///
+    /// ```text
+    /// (source preamble: ReadBgzfBlocks → BgzfDecompress → FindBamBoundaries → DecodeRecords)
+    ///     ↓
+    /// GroupByQueryname  ← appended here
+    ///     ↓
+    /// AlignAndMergeStep ← appended here (spawns aligner subprocess)
+    ///     ↓
+    /// (Terminal) SerializeBamRecords  ← appended only when Terminal
+    ///     ↓
+    /// (next stage consumes BamTemplateBatch — Intermediate only)
+    /// ```
+    ///
+    /// Both [`StagePosition::Terminal`] and [`StagePosition::Intermediate`]
+    /// are supported:
+    ///
+    /// - **Terminal** — `SerializeBamRecords` is appended after the AAM step
+    ///   so the chain tail is `DecompressedBlock` ready for
+    ///   `BgzfCompress → WriteBgzfFile`. This is the `--stop-after zipper`
+    ///   path when `--start-from align-and-merge`: the merged BAM is
+    ///   written directly to the output file.
+    /// - **Intermediate** — the tail is left as `BamTemplateBatch` so the
+    ///   next stage (Sort, Group, Consensus) can wire the correct preamble.
+    ///
+    /// ## Header handling
+    ///
+    /// The aligner contributes `@PG`/`@RG`/`@CO` lines to the output
+    /// BAM header at runtime (not at chain-construction time). The
+    /// `AlignAndMergeStep` resolves a [`HeaderHandle`] once the aligner
+    /// emits its SAM/BAM header; the downstream [`WriteBgzfFile`]
+    /// (added by [`Self::add_sink`]) blocks on the handle before
+    /// writing any record bytes.
+    ///
+    /// To prepare the correct partial header (dict-derived `@SQ` +
+    /// unmapped-BAM headers + fgumi `@PG`) for `AlignAndMergeConfig`,
+    /// `add_align` calls [`build_output_header`] with the current
+    /// `self.header` (which was built from the unmapped BAM by
+    /// `ChainBuilder::new`) and the reference FASTA's `.dict` path.
+    /// The result replaces `self.header` so downstream stages and
+    /// `add_sink` see the dict-derived `@SQ` table.
+    ///
+    /// The `HeaderHandle` is stashed in `self.pending_header_handle` for
+    /// `add_sink` to consume.
+    ///
+    /// ## Thread floor
+    ///
+    /// AAM spawns two daemon threads (FASTQ writer + SAM/BAM reader) plus
+    /// the aligner subprocess. The pipeline needs at least 4 framework
+    /// workers for steady-state progress:
+    ///
+    /// - 1 worker to drive the source preamble
+    /// - 1 worker dispatching `AlignAndMergeStep` (Serial)
+    /// - 1+ workers for any downstream Parallel steps
+    /// - 1 spare for progress / bookkeeping
+    ///
+    /// `override_pipeline_threads` is raised to `threads.max(4)` so
+    /// `build()` forwards the correct value to `PipelineConfig::threads`.
+    ///
+    /// ## Errors
+    ///
+    /// Returns errors if:
+    /// - align options are missing from the spec bag,
+    /// - the reference `.dict` file cannot be found,
+    /// - `AlignAndMergeStep::new` fails to spawn the aligner subprocess.
+    ///
+    /// [`HeaderHandle`]: crate::pipeline::core::header::HeaderHandle
+    /// [`WriteBgzfFile`]: crate::pipeline::steps::sink::write_bgzf::WriteBgzfFile
+    /// [`build_output_header`]: crate::commands::zipper::build_output_header
+    fn add_align(&mut self, position: StagePosition) -> Result<()> {
+        use std::sync::atomic::AtomicU64;
+
+        use crate::commands::zipper::build_output_header;
+        use crate::logging::OperationTimer;
+        use crate::pipeline::chains::commands::align::AlignFinalizeHook;
+        use crate::pipeline::core::header::HeaderHandle;
+        use crate::pipeline::steps::align_and_merge::{AlignAndMergeConfig, AlignAndMergeStep};
+        use crate::pipeline::steps::group::queryname::GroupByQueryname;
+        use crate::pipeline::steps::serialize::SerializeBamRecords;
+        use crate::reference::find_dict_path;
+        use crate::sam::check_sort;
+        use crate::umi::TagInfo;
+        use log::info;
+
+        let align_opts = self
+            .spec
+            .stage_opts
+            .aligner
+            .as_ref()
+            .ok_or_else(|| anyhow!("Stage::Align options missing from StageOptionsBag"))?;
+
+        let num_threads = self.spec.threading.num_threads();
+
+        // Resolve the aligner command. This validates the option combination
+        // (preset vs command, index files, binary path) before spawning.
+        let resolved = align_opts.aligner.clone().resolve(
+            &align_opts.reference,
+            num_threads,
+            align_opts.aligner_bin.as_deref(),
+        )?;
+
+        info!(
+            "AlignAndMerge: mode = {:?}, chunk_size = {}, threads = {:?}",
+            resolved.mode, resolved.chunk_size, resolved.threads,
+        );
+        info!("AlignAndMerge command: {}", resolved.command);
+
+        // Validate the unmapped BAM source has queryname sort order — but only
+        // when Align reads directly from the chain source (a file). When an
+        // upstream stage already produced `BamTemplateBatch` (extract → align,
+        // correct → align), Align's input is that in-pipeline tail — wired below
+        // via `align_input_tail` — not `spec.source`. In that case `spec.source`
+        // is the chain's *original* start input (e.g. `Fastqs` for
+        // `--start-from extract`), which is neither a Bam/Sam file to sort-check
+        // nor Align's actual input, so the check must be skipped. The upstream
+        // stage's output is queryname-grouped by construction. This mirrors the
+        // `chain_tail_kind == BamTemplateBatch` distinction used for
+        // `align_input_tail` just below.
+        if self.chain_tail_kind != ChainTailKind::BamTemplateBatch {
+            let input_path = match &self.spec.source {
+                SourceSpec::Bam(p) | SourceSpec::Sam(p) => p.clone(),
+                other => {
+                    bail!("Stage::Align requires SourceSpec::Bam (unmapped BAM); got {other:?}")
+                }
+            };
+            check_sort(&self.header, &input_path, "unmapped");
+        }
+
+        // Build the correct partial output header:
+        //   dict-derived @SQ + unmapped-BAM @HD/@CO/@RG/@PG + fgumi @PG.
+        // `self.header` already has add_pg_record applied, so the fgumi PG
+        // record is present; build_output_header merges the unmapped header's
+        // PG/RG/CO lines with the dict @SQ and leaves the aligner's runtime
+        // contributions to be folded in via HeaderHandle.
+        let dict_path = find_dict_path(&align_opts.reference)
+            .ok_or_else(|| dict_not_found_error(&align_opts.reference))?;
+        let partial_header =
+            build_output_header(&self.header, &noodles::sam::Header::default(), &dict_path)?;
+        let partial_header = std::sync::Arc::new(partial_header);
+
+        // Replace self.header with the dict-corrected partial header so
+        // downstream stages (sort, group) and add_sink see the correct @SQ.
+        self.header = partial_header.as_ref().clone();
+
+        let header_handle = HeaderHandle::new();
+        let records_emitted = std::sync::Arc::new(AtomicU64::new(0));
+
+        let aam_cfg = AlignAndMergeConfig {
+            tag_info: std::sync::Arc::new(TagInfo::new(Vec::new(), Vec::new(), Vec::new())),
+            skip_tc_tags: false,
+            reference: None,
+            partial_output_header: std::sync::Arc::clone(&partial_header),
+            header_handle: header_handle.clone(),
+            records_emitted: std::sync::Arc::clone(&records_emitted),
+            output_byte_limit: self.tuning.per_step_byte_limit,
+            // Bound AAM's in-flight unmapped backlog to the aligner's `-K`
+            // chunk size so a fast-draining aligner can't accumulate the
+            // whole input's unmapped reads in RAM (issue #382).
+            in_flight_unmapped_budget:
+                crate::pipeline::steps::align_and_merge::in_flight_budget_for_chunk_size(
+                    resolved.chunk_size,
+                ),
+        };
+
+        let aam_step = AlignAndMergeStep::new(aam_cfg, &resolved.command)
+            .map_err(|e| anyhow!("AlignAndMergeStep::new: {e:#}"))?;
+
+        let tail = self.current_tail.expect("add_align called before add_source");
+
+        // Wire GroupByQueryname before the AAM step — but only when the upstream
+        // stage emits DecodedRecordBatch (the normal source preamble path).
+        // When `chain_tail_kind == BamTemplateBatch`, an upstream stage (e.g.
+        // Correct) has already grouped records into BamTemplateBatch, which is
+        // exactly the input type AlignAndMergeStep expects. Skip GroupByQueryname
+        // in that case to avoid a DecodedRecordBatch→BamTemplateBatch type mismatch.
+        let align_input_tail = if self.chain_tail_kind == ChainTailKind::BamTemplateBatch {
+            // Upstream is already BamTemplateBatch — wire AAM directly.
+            tail
+        } else {
+            // Upstream is DecodedRecordBatch (source preamble). Group by queryname
+            // to produce BamTemplateBatch for AlignAndMergeStep.
+            self.pipeline.append_step(GroupByQueryname::new(self.tuning.per_step_byte_limit), tail)
+        };
+        let aam_tail = self.pipeline.append_step(aam_step, align_input_tail);
+
+        if position == StagePosition::Terminal {
+            // Terminal: append SerializeBamRecords so the chain tail is
+            // DecompressedBlock ready for BgzfCompress → WriteBgzfFile in add_sink.
+            // This is the --stop-after zipper path: merged BAM written directly.
+            let tail = self
+                .pipeline
+                .append_step(SerializeBamRecords::new(self.tuning.per_step_byte_limit), aam_tail);
+            self.current_tail = Some(tail);
+            // tail is DecompressedBlock (serialized bytes) after SerializeBamRecords
+            // → SerializedBytes.
+            self.chain_tail_kind = ChainTailKind::SerializedBytes;
+        } else {
+            self.current_tail = Some(aam_tail);
+            // AAM output is BamTemplateBatch; downstream stages (Sort, Group,
+            // Consensus) must know this so they can wire the correct preamble.
+            self.chain_tail_kind = ChainTailKind::BamTemplateBatch;
+        }
+
+        // Stash the HeaderHandle for add_sink to pick up. This is a fresh aligner, so any
+        // transform composed for a *previous* align's handle is stale — drop it so it cannot
+        // be re-applied to this aligner's runtime-resolved header at sink time.
+        self.pending_header_transform = None;
+        self.pending_header_handle = Some(header_handle);
+
+        // AAM spawns two daemon threads + aligner subprocess; 4 workers
+        // minimum for steady-state progress.
+        let effective = num_threads.max(4);
+        if let Some(prev) = self.override_pipeline_threads {
+            self.override_pipeline_threads = Some(prev.max(effective));
+        } else {
+            self.override_pipeline_threads = Some(effective);
+        }
+
+        let timer = OperationTimer::new("AlignAndMerge");
+        self.finalize.push(Box::new(AlignFinalizeHook { records_emitted, timer }));
+
+        Ok(())
+    }
+
+    /// Zipper-specific step sequence (dual-input):
+    ///
+    /// Precondition: `add_source` has already been called with a
+    /// `PendingSource::Paired` spec, which set `current_tail` to the
+    /// unmapped source chain tail and `paired_tail` to the mapped
+    /// source chain tail. Both chains end at `GroupByQueryname`, so
+    /// their output type is `OrderedBytesSingle<BamTemplateBatch>`,
+    /// matching `ZipperMergeStep: Step2<InputA = BamTemplateBatch,
+    /// InputB = BamTemplateBatch>`.
+    ///
+    /// Appends `ZipperMergeStep` (via `PipelineBuilder::append_step2`
+    /// which wires the two tails into input slots 0 and 1), then — for
+    /// `Terminal` — appends `SerializeBamRecords` so the chain tail is
+    /// `DecompressedBlock` ready for `BgzfCompress → WriteBgzfFile`.
+    ///
+    /// Applies the thread floor: zipper requires at least 4 worker
+    /// threads (`≥ 3 Exclusive steps + 1`); `override_pipeline_threads`
+    /// is set to `spec.threading.num_threads().max(4)` so that
+    /// `build()` forwards the correct value to `PipelineConfig::threads`.
+    ///
+    /// Registers a [`ZipperFinalizeHook`] for the missing-reads summary,
+    /// "zipper completed successfully" log, and `timer.log_completion`.
+    /// The chain-level [`StageTimingFinalizeHook`] is registered by
+    /// [`Self::build`], so a single timer covers the full pipeline run.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors if zipper options are missing from the spec bag, or if
+    /// `add_source` has not been called with a `PairedBams` spec (missing
+    /// `paired_tail`). Both `Terminal` and `Intermediate` positions are
+    /// supported (Intermediate leaves the `BamTemplateBatch` tail for the next
+    /// stage, e.g. `zipper → sort`).
+    ///
+    /// [`ZipperFinalizeHook`]: crate::pipeline::chains::commands::zipper::ZipperFinalizeHook
+    fn add_zipper(&mut self, position: StagePosition) -> Result<()> {
+        use crate::commands::common::warn_unwired_pipeline_flags;
+        use crate::commands::zipper::NEW_PIPELINE_START_LOG;
+        use crate::logging::OperationTimer;
+        use crate::pipeline::chains::commands::zipper::{
+            ZipperFinalizeHook, ZipperMergeCaptures, build_zipper_merge_step,
+        };
+        use crate::pipeline::steps::serialize::SerializeBamRecords;
+        use log::info;
+
+        let zipper_opts = self
+            .spec
+            .stage_opts
+            .zipper
+            .as_ref()
+            .ok_or_else(|| anyhow!("Stage::Zipper options missing from StageOptionsBag"))?
+            .clone();
+
+        // Consume both source tails set by add_source for PairedBams.
+        let unmapped_tail =
+            self.current_tail.expect("add_zipper called before add_source (Paired)");
+        let mapped_tail = self
+            .paired_tail
+            .take()
+            .ok_or_else(|| anyhow!("add_zipper: paired_tail missing — spec must be PairedBams"))?;
+
+        // Resolve the reference path from the spec (the reference is always
+        // SourceSpec::PairedBams for zipper — validated by the cross-stage validator).
+        let reference_path = match &self.spec.source {
+            SourceSpec::PairedBams { reference, .. } => reference.clone(),
+            other => bail!("Stage::Zipper requires SourceSpec::PairedBams, got {other:?}"),
+        };
+
+        // Apply the thread floor: zipper needs ≥ 4 workers (2 Exclusive source
+        // readers + 1 Exclusive write step + at least 1 Serial worker).
+        let raw_threads = self.spec.threading.num_threads();
+        let num_threads = raw_threads.max(4);
+
+        // Recompute tuning with the floored thread count so that batch-sizing
+        // parameters (template_batch_size, per_step_byte_limit) are consistent
+        // with the actual concurrency. This replaces self.tuning (which was
+        // built from raw_threads in new()).
+        let floored_tuning = BamPipelineTuning::auto_tuned(num_threads)
+            .with_compression_level(self.spec.compression.compression_level);
+
+        // Emit the start log and pipeline-info lines (mirrors build_zipper_chain).
+        info!("{NEW_PIPELINE_START_LOG}");
+        warn_unwired_pipeline_flags(&self.spec.scheduler, &self.spec.queue_memory);
+        info!("{}", self.spec.threading.log_message());
+        info!("Using pipeline with {num_threads} threads");
+
+        let timer = OperationTimer::new("Zipping BAMs (new pipeline)");
+
+        let missing_count = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let records_emitted = Arc::new(std::sync::atomic::AtomicU64::new(0));
+
+        let merge_step = build_zipper_merge_step(ZipperMergeCaptures {
+            zipper_opts: zipper_opts.clone(),
+            output_header: Arc::new(self.header.clone()),
+            reference_path,
+            tuning: floored_tuning,
+            missing_count: Arc::clone(&missing_count),
+            records_emitted: Arc::clone(&records_emitted),
+        })?;
+
+        // Wire both source chains into ZipperMergeStep via the 2-input append.
+        let merge_tail = self.pipeline.append_step2(merge_step, unmapped_tail, mapped_tail);
+
+        // Gate SerializeBamRecords on Terminal position. For Intermediate
+        // (e.g., zipper → sort → ...), the chain tail stays at ZipperMergeStep's
+        // BamTemplateBatch output, ready for the next stage to consume.
+        if position == StagePosition::Terminal {
+            let tail = self.pipeline.append_step(
+                SerializeBamRecords::new(floored_tuning.per_step_byte_limit),
+                merge_tail,
+            );
+            self.current_tail = Some(tail);
+            // tail is DecompressedBlock (serialized bytes) after SerializeBamRecords
+            // → SerializedBytes.
+            self.chain_tail_kind = ChainTailKind::SerializedBytes;
+        } else {
+            self.current_tail = Some(merge_tail);
+            // Intermediate: ZipperMergeStep emits BamTemplateBatch so the
+            // next stage (typically add_sort) prepends TemplatesToRecordBatch.
+            self.chain_tail_kind = ChainTailKind::BamTemplateBatch;
+        }
+
+        // Set the thread override to the floored count so build() forwards it
+        // to PipelineConfig::threads. Take the max with any prior override (e.g.
+        // a preceding align stage) so we never lower an earlier stage's floor
+        // (S5b1-004).
+        if let Some(prev) = self.override_pipeline_threads {
+            self.override_pipeline_threads = Some(prev.max(num_threads));
+        } else {
+            self.override_pipeline_threads = Some(num_threads);
+        }
+
+        // Register ZipperFinalizeHook.
+        // The chain-level StageTimingFinalizeHook is inserted at index 0 by
+        // build() after all stages have been added — that way a single timer
+        // covers the full pipeline run regardless of how many stages there are.
+        self.finalize.push(Box::new(ZipperFinalizeHook {
+            missing_count,
+            records_emitted,
+            exclude_missing_reads: zipper_opts.exclude_missing_reads,
+            timer,
+        }));
+
+        Ok(())
+    }
+
+    /// Sort-specific step sequence — a single streaming pipeline used for
+    /// every sort, whether standalone (`[Stage::Sort]`), intermediate, or
+    /// terminal-after-upstream-stages.
+    ///
+    /// `add_source` always runs before this method (even for a sole-`[Sort]`
+    /// chain), so `current_tail` is always `Some`. Sort emits the in-pipeline
+    /// step sequence:
+    ///
+    /// ```text
+    /// [BamTemplateBatch or RecordBatch at current_tail]
+    ///     ↓ (TemplatesToRecordBatch if BamTemplateBatch)
+    /// RecordBatch (SAM) │ BgzfBlockArena (BAM)
+    ///     ↓ arena sort ingest:
+    ///        SAM → SortBuffer (Serial)
+    ///        BAM → ReadBlocks → InflateToArena → FindBoundariesAndSort
+    ///     ↓ SpillGather (Serial) → SpillBlockCompress (Parallel) → SpillWrite (Serial)
+    /// SortPhase1Event
+    ///     ↓ SortSpillDecompress (Parallel)
+    /// SortPhase2Event
+    ///     ↓ [Terminal]     SortMerge<BlockOutput> (Serial) → DecompressedBlock
+    ///     ↓ [Intermediate] SortMerge (Serial) → RecordBatch → DecodeFromRecords
+    /// ```
+    ///
+    /// For a `SinkSpec::BamWithIndex` (terminal sort only), an
+    /// [`IndexBamFinalizeHook`] is registered on the success-gated finalize
+    /// list. `--sort::max-memory=auto` is only honoured for a sole-`[Sort]`
+    /// chain (it owns the whole budget); a fused chain must pass a fixed value.
+    ///
+    /// The chain-level [`StageTimingFinalizeHook`] (registered by [`Self::build`])
+    /// covers the wall time; sort does not register a per-stage summary hook.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors if sort options are missing from the spec bag, or if
+    /// `--sort::max-memory=auto` is requested in a fused multi-stage pipeline.
+    ///
+    /// [`IndexBamFinalizeHook`]: crate::pipeline::chains::commands::sort::IndexBamFinalizeHook
+    #[allow(clippy::too_many_lines)]
+    fn add_sort(&mut self, position: StagePosition) -> Result<()> {
+        use crate::commands::common::{MemoryLimit, resolve_memory_budget};
+        use crate::pipeline::chains::commands::sort::IndexBamFinalizeHook;
+
+        let sort = self
+            .spec
+            .stage_opts
+            .sort
+            .as_ref()
+            .ok_or_else(|| anyhow!("Stage::Sort options missing from StageOptionsBag"))?
+            .clone();
+
+        {
+            // ── Streaming sort (standalone, Intermediate, OR Terminal-after-upstream) ──
+            //
+            // Every sort — including a sole-`[Stage::Sort]` standalone sort —
+            // runs through the streaming source → arena sort ingest →
+            // SpillGather → SpillBlockCompress → SpillWrite → SortSpillDecompress →
+            // SortMerge → sink pipeline. `add_source` always runs first (even
+            // for `[Sort]`), so `current_tail` is always `Some` here.
+            //
+            // Chain topology (continuing from current_tail):
+            //
+            //   [BamTemplateBatch or RecordBatch at current_tail]
+            //       ↓ (TemplatesToRecordBatch if BamTemplateBatch)
+            //   RecordBatch (SAM) │ BgzfBlockArena (BAM)
+            //       ↓ arena sort ingest (SortBuffer, or ReadBlocks →
+            //         InflateToArena → FindBoundariesAndSort for BAM)
+            //       ↓
+            //   SpillGather (Serial) → SpillBlockCompress (Parallel) → SpillWrite
+            //       (Serial) → SortPhase1Event
+            //       ↓
+            //   SortSpillDecompress (Parallel)
+            //       ↓ SortPhase2Event
+            //   SortMerge<RecordBatchOutput> (Serial) → RecordBatch      [Intermediate]
+            //   SortMerge<BlockOutput>       (Serial) → DecompressedBlock [Terminal]
+            //       ↓
+            //   [Intermediate] DecodeFromRecords (Parallel) → DecodedRecordBatch
+            //   [Terminal]     (none — SortMerge<BlockOutput> emits DecompressedBlock directly)
+            //
+            // For Intermediate: chain_tail_kind = DecodedRecordBatch;
+            // add_group / add_simplex / etc. can proceed normally.
+            //
+            // For Terminal: chain_tail_kind = SerializedBytes (DecompressedBlock
+            // bytes ready for sink) — add_sink appends BgzfCompress → WriteBgzfFile.
+            //
+            // `Auto` memory is honored only for a sole-`[Sort]` chain (see
+            // `is_standalone_sort` below), where sort owns the whole budget. In a
+            // multi-stage pipeline the budget is shared across stages, so `Auto`
+            // cannot be resolved here and a fixed value is required.
+            use crate::pipeline::core::step::Affinity;
+            use crate::pipeline::steps::parse::decode::DecodeFromRecords;
+            use crate::pipeline::steps::sort::{
+                BlockOutput, RecordBatchOutput, SortBuffer, SortDecompressTuning, SortMerge,
+                SortSpillDecompress, SpillBlockCompress, SpillGather, SpillWrite,
+            };
+            use fgumi_sort::{RawExternalSorter, SortOrder};
+
+            // `auto` is honorable only for a sole-`[Sort]` chain (standalone
+            // sort): it owns the whole budget. In a fused chain sort shares the
+            // budget with the other stages, so `auto` can't be split — require
+            // a fixed value there.
+            // Single-sourced from the spec classifier (sole-`[Sort]` layout).
+            let is_standalone_sort = self.spec.is_sort_terminal();
+
+            // Lever 2: on the standalone-sort terminal, run the output writer on
+            // its own dedicated thread (legacy "N + 2"). Gated to the standalone
+            // sort terminal ONLY — any intermediate sort, or a sort inside a
+            // fused runall chain, keeps the pool-scheduled writer so no streaming
+            // command's terminal is affected. `add_sink` reads this flag.
+            if is_standalone_sort && matches!(position, StagePosition::Terminal) {
+                self.detached_writer = true;
+            }
+            if matches!(sort.max_memory, MemoryLimit::Auto) && !is_standalone_sort {
+                bail!(
+                    "--sort::max-memory=auto is not supported in a fused multi-stage pipeline \
+                     (sort is not standalone); pass a fixed value (e.g. --sort::max-memory 768M)"
+                );
+            }
+            let num_threads = self.spec.threading.num_threads();
+            // Per-phase worker counts default to --threads; runall forwards
+            // --sort::sort-threads / --sort::merge-threads via SortOptions.
+            // Phase 1 caps the streaming sort/spill worker pool; Phase 2 caps
+            // concurrent spill-decompression (the merge step itself is serial).
+            let num_phase1_threads = resolve_phase_threads(sort.sort_threads, num_threads);
+            let num_phase2_threads = resolve_phase_threads(sort.merge_threads, num_threads);
+            if sort.sort_threads.is_some() || sort.merge_threads.is_some() {
+                log::debug!(
+                    "streaming sort: per-phase thread split (phase1={num_phase1_threads}, \
+                     phase2={num_phase2_threads}); phase2 caps decompress concurrency, merge is serial"
+                );
+            }
+            // Reuse the same helper as the standalone path so `--sort::memory-per-thread`
+            // is honored (the previous inline `× num_threads` ignored it).
+            let total_memory = resolve_memory_budget(
+                sort.max_memory,
+                sort.memory_reserve,
+                num_threads,
+                sort.memory_per_thread,
+            )?;
+
+            // Honor the requested order (standalone sort can request any of the
+            // four; runall always passes `TemplateCoordinate`). The cell tag is
+            // only meaningful for cell-grouped orders — `parse_cell_tag` returns
+            // `Some(CB)` for template-coordinate and `None` otherwise — so it is
+            // applied conditionally rather than hardcoded.
+            let sort_order: SortOrder = sort.order.into();
+            let cell_tag = crate::commands::sort::parse_cell_tag(sort.order)?;
+            // Honor the requested spill codec (`SortSpillDecompress` handles both
+            // BGZF and zstd). Standalone sort may request `bgzf` to pair with
+            // `--temp-compression 0` (uncompressed spill); runall leaves it at
+            // the zstd default. Omitting this previously forced the sorter's
+            // default codec, breaking the uncompressed-bgzf spill path.
+            let mut sorter = RawExternalSorter::new(sort_order)
+                .memory_limit(total_memory)
+                .threads(num_threads.max(1))
+                .sort_threads(num_phase1_threads)
+                .merge_threads(num_phase2_threads)
+                .output_compression(1)
+                .temp_compression(sort.temp_compression)
+                .spill_codec(sort.temp_codec);
+            if let Some(ct) = cell_tag {
+                sorter = sorter.cell_tag(ct);
+            }
+            // Honor `--key-types` (template-coordinate only): the arena template
+            // accumulator (`TemplateArenaAccumulator`) provisions the dropped-lane
+            // variant from this and validates that dropped lanes are constant.
+            // Previously the streaming production path ignored it entirely.
+            if let Some(kt) = sort.key_types {
+                sorter = sorter.key_types(kt);
+            }
+
+            if !sort.tmp_dirs.is_empty() {
+                sorter = sorter.temp_dirs(sort.tmp_dirs.clone());
+            }
+
+            // NOTE: the legacy `build_sort_step` clamped the sorter's *initial*
+            // in-memory capacity (768 MiB/thread) for standalone `--max-memory
+            // auto`, relying on the old `RawExternalSorter`'s lazy buffer growth.
+            // That knob does not carry over to the arena front used below
+            // (`ReadBlocks`): it sizes its arena segment to the FULL budget
+            // (`run_cap = memory_limit`) so a run that fits `--max-memory` sorts
+            // in memory with zero spills (see `ReadBlocks::new`). Capping the
+            // segment would cap `run_cap` and force premature spills — the exact
+            // wall-clock regression that doc warns against — so there is no
+            // separate initial-capacity clamp here.
+
+            let affinity = if num_threads >= 3 { Affinity::Worker(1) } else { Affinity::Reader };
+
+            // Phase-2 decompression granularity knobs (`--sort::file-granularity`,
+            // `--sort::block-batch`). The default is the block-parallel path
+            // (P5c, hardened by loom/TSan + the soak matrix); its reorder window
+            // is bounded by the per-step byte limit (see SortSpillDecompress).
+            // `block_batch` defaults to 4 (the original MAX_BATCH_PER_CALL),
+            // pending a fleet decompress-throughput bench.
+            let decompress_tuning = SortDecompressTuning {
+                file_granularity: sort.file_granularity,
+                block_batch: sort.block_batch,
+            };
+            // `--merge-threads` (Phase-2) caps how many decompress workers run
+            // concurrently; the block-parallel path still does the work, but the
+            // admission counter bounds concurrency to `num_phase2_threads`.
+            let decompress =
+                SortSpillDecompress::new(self.tuning.per_step_byte_limit, decompress_tuning)
+                    .with_max_concurrency(Some(num_phase2_threads));
+            // Standalone sort gets an end-of-run summary (records processed /
+            // written / temporary chunks); the fused runall path does not (the
+            // chain-level timing hook covers it). The slot is filled by
+            // `SortMerge` on completion and read by `SortSummaryFinalizeHook`.
+            let sort_stats_slot = is_standalone_sort
+                .then(|| Arc::new(parking_lot::Mutex::new(None::<fgumi_sort::SortStats>)));
+            // `SortMerge` is constructed inside the Terminal/Intermediate branch
+            // below, because its output-framing strategy differs by position:
+            //
+            // - Terminal: `SortMerge<BlockOutput>` frames each merged record as
+            //   `[u32 LE block_size][body]` directly into a `DecompressedBlock`,
+            //   wired straight to `BgzfCompress` — the former
+            //   `SortMerge → SerializeRecordBatch → BgzfCompress` triple folded to
+            //   `SortMerge → BgzfCompress` (lever 1: one fewer pool step, one
+            //   fewer reorder stage, one fewer memcpy per record). The framing is
+            //   byte-for-byte identical to the removed `SerializeRecordBatch`.
+            // - Intermediate: `SortMerge<RecordBatchOutput>` (the default) emits
+            //   `RecordBatch` for the downstream `DecodeFromRecords`.
+
+            let tail = self.current_tail.expect("streaming sort called before add_source");
+
+            // If the upstream stage produced BamTemplateBatch (from Align or
+            // Correct), flatten it to RecordBatch before feeding the sort ingest.
+            let tail = if self.chain_tail_kind == ChainTailKind::BamTemplateBatch {
+                use crate::pipeline::steps::templates_to_records::TemplatesToRecordBatch;
+                self.pipeline
+                    .append_step(TemplatesToRecordBatch::new(self.tuning.per_step_byte_limit), tail)
+            } else {
+                // chain_tail_kind == RecordBatch (from ParseBamRecords in add_source)
+                // or DecodedRecordBatch would be a bug caught at runtime.
+                tail
+            };
+
+            // Phase-1 head — the block-parallel spill-write split for ALL sort
+            // orders: `SortBuffer` (Serial: ingest + par-sort + emit sorted
+            // chunks) → `SpillGather` (Serial: fan each chunk into raw blocks,
+            // mint a dense ordinal) → `SpillBlockCompress` (Parallel + ByItemOrdinal:
+            // compress blocks across the work-stealing pool) → `SpillWrite`
+            // (Serial + Writer: demux blocks to per-file spill files, emit
+            // `SortPhase1Event`). This mirrors the output BAM tail
+            // (Serialize → BgzfCompress → WriteBgzfFile) so a single spill's
+            // compression saturates cores instead of pinning one worker, while
+            // keeping `SortBuffer` Serial (no N² rayon oversubscription). The head
+            // emits `SortPhase1Event`, so `SortSpillDecompress`/`SortMerge` are
+            // identical downstream regardless of order.
+            let phase1_tail = {
+                let (temp_dirs, alloc) = sorter
+                    .create_spill_dirs()
+                    .map_err(|e| anyhow!("create spill temp dirs: {e}"))?;
+                let temp_codec = sort.temp_codec;
+                let temp_compression = sort.temp_compression;
+                let temp_dirs = Arc::new(temp_dirs);
+                let alloc = Arc::new(parking_lot::Mutex::new(alloc));
+                let byte_limit = self.tuning.per_step_byte_limit;
+                // Sort head: two cases depending on the source tail kind.
+                // BgzfBlockArena (BAM): use the parallel-inflate front
+                // (ReadBlocks → InflateToArena → FindBoundariesAndSort).
+                // Else (RecordBatch from SAM or upstream stage): use SortBuffer.
+                let head_tail = if self.chain_tail_kind == ChainTailKind::BgzfBlockArena {
+                    // BAM sort through the parallel-inflate arena front
+                    // (ReadBlocks → InflateToArena → FindBoundariesAndSort).
+                    // Each order selects its per-order strategy.
+                    use fgumi_pipeline_io::sort::protocol::MemoryChunkErased;
+                    use fgumi_pipeline_io::sort::{
+                        CoordinateStrategy, FindBoundariesAndSort, InflateToArena,
+                        QuerynameStrategy, ReadBlocks, TemplateStrategy,
+                    };
+                    use fgumi_sort::{QuerynameComparator, RawQuerynameKey, RawQuerynameLexKey};
+                    let n_ref = u32::try_from(self.header.reference_sequences().len())
+                        .map_err(|_| anyhow!("reference sequence count overflows u32"))?;
+                    // sorter is not consumed by this branch; the spill dirs/alloc it
+                    // owns were already taken above (create_spill_dirs). Drop it to
+                    // silence the unused-variable warning.
+                    drop(sorter);
+                    // `total_memory` is the full in-memory budget (--max-memory ×
+                    // threads). ReadBlocks sizes its arena segment to hold one
+                    // full-budget run, so data that fits the budget sorts entirely
+                    // in memory with zero spills — matching legacy.
+                    let read_blocks = ReadBlocks::new(total_memory, byte_limit);
+                    let inflate = InflateToArena::new(byte_limit);
+                    // Hand the resolved Phase-1 count (honoring `--sort-threads`,
+                    // else `--threads`) to the per-chunk sort so large chunks use
+                    // the parallel radix. Using the raw global `num_threads()` here
+                    // silently dropped the `--sort-threads` override.
+                    let sort_threads = num_phase1_threads;
+                    let t = self.pipeline.append_step(read_blocks, tail);
+                    let t = self.pipeline.append_step(inflate, t);
+                    let out = match sort_order {
+                        SortOrder::TemplateCoordinate => {
+                            // Template-coordinate: the accumulator carries the
+                            // library / cell-barcode / MI and `--key-types`
+                            // narrowed-lane machinery the template key needs, built
+                            // from the header exactly as the legacy
+                            // TemplateChunkSorter.
+                            let key_types = sort.key_types.unwrap_or_default();
+                            let acc = fgumi_sort::TemplateArenaAccumulator::from_header(
+                                &self.header,
+                                cell_tag,
+                                key_types,
+                            );
+                            self.pipeline.append_step(
+                                FindBoundariesAndSort::new(
+                                    TemplateStrategy::new(acc),
+                                    sort_threads,
+                                    byte_limit,
+                                ),
+                                t,
+                            )
+                        }
+                        SortOrder::Queryname(QuerynameComparator::Lexicographic) => {
+                            // Queryname (lexicographic): the read name IS the key,
+                            // embedded in the record; the strategy comparator-sorts
+                            // arena refs into an InMemoryChunk<RawQuerynameLexKey>.
+                            self.pipeline.append_step(
+                                FindBoundariesAndSort::new(
+                                    QuerynameStrategy::<RawQuerynameLexKey>::new(
+                                        MemoryChunkErased::QuerynameLex,
+                                    ),
+                                    sort_threads,
+                                    byte_limit,
+                                ),
+                                t,
+                            )
+                        }
+                        SortOrder::Queryname(QuerynameComparator::Natural) => {
+                            self.pipeline.append_step(
+                                FindBoundariesAndSort::new(
+                                    QuerynameStrategy::<RawQuerynameKey>::new(
+                                        MemoryChunkErased::QuerynameNatural,
+                                    ),
+                                    sort_threads,
+                                    byte_limit,
+                                ),
+                                t,
+                            )
+                        }
+                        SortOrder::Coordinate => self.pipeline.append_step(
+                            FindBoundariesAndSort::new(
+                                CoordinateStrategy::new(n_ref),
+                                sort_threads,
+                                byte_limit,
+                            ),
+                            t,
+                        ),
+                    };
+                    // Opt this chain into downstream-first dispatch: the serial
+                    // FindBoundariesAndSort scan then overlaps the 8-way parallel
+                    // InflateToArena instead of starving behind it on the pool.
+                    self.use_drain_first_scheduler = true;
+                    out
+                } else {
+                    let sort_buffer = SortBuffer::from_sorter(sorter, &self.header, byte_limit)
+                        .map_err(|e| anyhow!("SortBuffer::from_sorter: {e}"))?
+                        .with_affinity(affinity);
+                    self.pipeline.append_step(sort_buffer, tail)
+                };
+                // `SpillGather` runs on the off-pool coordination driver
+                // (`StepKind::Detached`, group `sort-coord`) alongside the sort
+                // head, so it never contends a pool worker — the driver frames the
+                // just-sorted chunk into blocks while the pool inflates/compresses.
+                let serialize = SpillGather::new(byte_limit);
+                let compress = SpillBlockCompress::new(temp_codec, temp_compression, byte_limit);
+                let write = SpillWrite::new(alloc, temp_codec, byte_limit, temp_dirs);
+                // Lever 2, Phase-1 analogue: on the standalone-sort terminal,
+                // detach the spill writer onto its own dedicated thread as well,
+                // so the single serial spill-write stream stops occupying a pool
+                // worker that could be running the compression-bound
+                // `SpillBlockCompress`. One persistent writer thread for the whole run
+                // (not one per spill chunk). Same gate as the terminal output
+                // writer set above; every other chain keeps the pool-scheduled
+                // `Serial + Affinity::Writer` spill writer.
+                let write = if self.detached_writer { write.with_detached() } else { write };
+                let tail = self.pipeline.append_step(serialize, head_tail);
+                let tail = self.pipeline.append_step(compress, tail);
+                self.pipeline.append_step(write, tail)
+            };
+            let decompress_tail = self.pipeline.append_step(decompress, phase1_tail);
+
+            if position == StagePosition::Terminal {
+                // Terminal sort: `SortMerge<BlockOutput>` frames merged records
+                // directly into `DecompressedBlock`s (lever 1), wired straight to
+                // `BgzfCompress → WriteBgzfFile` in add_sink. No
+                // `SerializeRecordBatch` step (and so no extra reorder stage) —
+                // the framing is byte-for-byte identical to what that step
+                // produced, but emitted on the already-in-order `Detached` merge
+                // thread, dropping one pool step and one memcpy per record.
+                let mut merge =
+                    SortMerge::<BlockOutput>::new(sort_order, self.tuning.per_step_byte_limit);
+                if let Some(slot) = &sort_stats_slot {
+                    merge = merge.with_stats_slot(Arc::clone(slot));
+                }
+                let merge_tail = self.pipeline.append_step(merge, decompress_tail);
+                self.current_tail = Some(merge_tail);
+                // tail is DecompressedBlock (serialized bytes) directly from
+                // SortMerge → SerializedBytes.
+                self.chain_tail_kind = ChainTailKind::SerializedBytes;
+
+                // Standalone sort: log the `=== Summary ===` block from the
+                // SortMerge stats slot. Success-gated (`finalize_on_success`), NOT
+                // always-run: the always-run `finalize` hooks drain even on the
+                // error path, and the stats slot is unset (default zeros) whenever
+                // SortMerge never reached `Done`, so an always-run summary would
+                // report a bogus "Records processed: 0 ... completed" line on a
+                // failed run. Registered before the index hook so on success the
+                // summary still lands before any "Indexing BAM:" line, mirroring
+                // the legacy SortFinalizeHook ordering.
+                if let Some(slot) = sort_stats_slot {
+                    let output_path = self.spec.sink.path().clone();
+                    self.finalize_on_success.push(Box::new(
+                        crate::pipeline::chains::commands::sort::SortSummaryFinalizeHook {
+                            stats_slot: slot,
+                            output_path,
+                            timer: crate::logging::OperationTimer::new("Sorting BAM"),
+                        },
+                    ));
+                }
+
+                // When the spec asks for a sidecar BAI, queue the
+                // `IndexBamFinalizeHook` on the *success-gated* finalize list
+                // so the indexer runs after the chain has flushed the final
+                // BAM on a successful run only (a failed run leaves a partial
+                // BAM whose index would be stale). Every Sort-terminal chain —
+                // standalone `[Stage::Sort]` or fused (e.g.
+                // `[Stage::Correct, Stage::Sort]`) — lands here in the unified
+                // `add_sort` flow, so without this wire a `BamWithIndex` request
+                // would pass Rule 3 and silently skip indexing. Today only
+                // standalone `fgumi sort` builds such specs (runall never
+                // constructs `SinkSpec::BamWithIndex` because its sort output is
+                // template-coordinate, where BAI is undefined), but the
+                // architectural invariant — "BamWithIndex triggers the hook in
+                // every terminal-sort path" — is enforced here for future
+                // producers.
+                if let SinkSpec::BamWithIndex(p) = &self.spec.sink {
+                    self.finalize_on_success
+                        .push(Box::new(IndexBamFinalizeHook { output_path: p.clone() }));
+                }
+            } else {
+                // Intermediate: `SortMerge<RecordBatchOutput>` (the default)
+                // emits `RecordBatch`, decoded to `DecodedRecordBatch` for the
+                // downstream stages. Route through `bam_group_key_config` so a
+                // `[Sort, Group]` chain still caches the UMI (RX) value position
+                // during this decode — otherwise group would re-scan aux per
+                // template and lose the #334/#343 optimization on the sort→group
+                // path. The intermediate sort is never standalone, so the stats
+                // slot is `None`; no `with_stats_slot` call is needed.
+                let merge = SortMerge::<RecordBatchOutput>::new(
+                    sort_order,
+                    self.tuning.per_step_byte_limit,
+                );
+                let merge_tail = self.pipeline.append_step(merge, decompress_tail);
+                let group_key_config = self.bam_group_key_config();
+                let tail = self.pipeline.append_step(
+                    DecodeFromRecords::new(group_key_config, self.tuning.per_step_byte_limit),
+                    merge_tail,
+                );
+                self.current_tail = Some(tail);
+                self.chain_tail_kind = ChainTailKind::DecodedRecordBatch;
+            }
+
+            // Update self.header to reflect the sort order so downstream
+            // add_group's sort-order header check passes. This is the same header
+            // update the external sorter writes into the temp BAM. Applied as a
+            // header *transform* so that, when Align is upstream, the sort-order
+            // rewrite is re-applied to the aligner's runtime-resolved header at
+            // sink time (preserving its @PG/@RG/@CO) instead of dropping it.
+            self.apply_output_header_transform(move |header| {
+                Ok(fgumi_sort::create_output_header(sort_order, &header))
+            })?;
+
+            // Streaming sort does NOT register a SortFinalizeHook
+            // (no output-path stats to log; the overall chain timing hook
+            // registered by build() covers the full pipeline wall time).
+        }
+
+        Ok(())
+    }
+
+    /// Group-specific step sequence:
+    ///
+    /// `GroupByPosition` →
+    /// `ProcessOrdered` (filter + UMI assign + metrics accumulation) →
+    /// `MiAssign` (serial MI counter) →
+    /// `ProcessWithWorkerState` (serialize records with MI tags) — **Terminal only**.
+    ///
+    /// For [`StagePosition::Terminal`], all four steps are appended and the
+    /// chain tail is [`DecompressedBlock`] (bytes ready for `BgzfCompress`).
+    ///
+    /// For [`StagePosition::Intermediate`], only the first three steps are
+    /// appended; the chain tail stays as [`BatchedProcessedPositionGroups`] so
+    /// the consensus stages (`add_simplex`/`add_duplex`/`add_codec`) can prepend
+    /// `templates_to_mi_step` and consume it. This is the fused group→consensus
+    /// path.
+    ///
+    /// Accepts both template-coordinate-sorted and (with `--allow-unmapped`)
+    /// queryname-sorted inputs, matching `GroupReadsByUmi::execute`'s validation.
+    ///
+    /// Registers a `GroupFinalizeHook` for accumulators reduce + family-size
+    /// histogram + grouping-metrics + summary banner + timer.
+    /// The chain-level [`StageTimingFinalizeHook`] is registered by
+    /// [`Self::build`] (not here), so it captures the correct `Instant`.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors if the sort order is wrong or if the group options are
+    /// missing from the spec bag.
+    ///
+    /// [`BatchedProcessedPositionGroups`]: crate::pipeline::steps::group::position::BatchedProcessedPositionGroups
+    /// [`DecompressedBlock`]: crate::pipeline::steps::types::DecompressedBlock
+    #[allow(clippy::too_many_lines)]
+    fn add_group(&mut self, position: StagePosition) -> Result<()> {
+        use crate::commands::common::warn_unwired_pipeline_flags;
+        use crate::logging::OperationTimer;
+        use crate::per_thread_accumulator::PerThreadAccumulator;
+        use crate::pipeline::chains::commands::group::{
+            GroupFinalizeHook, build_group_mi_assign_step, build_group_process_step,
+            build_group_serialize_step,
+        };
+        use crate::pipeline::steps::group::position::GroupByPosition;
+        use crate::sam::SamTag;
+        use log::{info, warn};
+
+        let group = self
+            .spec
+            .stage_opts
+            .group
+            .as_ref()
+            .ok_or_else(|| anyhow!("Stage::Group options missing from StageOptionsBag"))?;
+
+        // Reject the same incompatible flag combinations that standalone
+        // `fgumi group` rejects up front, so the runall path enforces them too
+        // (S5c2-003). These read the user-supplied `strategy`/`no_umi`/
+        // `min_umi_length` (not the derived `effective_*`), matching
+        // `GroupReadsByUmi::execute`.
+        if group.min_umi_length.is_some()
+            && matches!(group.strategy, crate::assigner::Strategy::Paired)
+        {
+            bail!("Paired strategy cannot be used with --min-umi-length");
+        }
+        if group.no_umi && matches!(group.strategy, crate::assigner::Strategy::Paired) {
+            bail!("--no-umi cannot be used with --strategy paired");
+        }
+
+        let tail = self.current_tail.expect("add_group called before add_source");
+
+        // Resolve source path for log messages only.
+        let input_path = self.resolve_log_input_path();
+        let output_path = self.spec.sink.path().clone();
+
+        let timer = OperationTimer::new("Grouping reads by UMI");
+
+        info!("Starting group");
+        info!("Input: {}", input_path.display());
+        info!("Output: {}", output_path.display());
+        info!("Strategy: {:?}", group.effective_strategy);
+        info!("Edits: {}", group.effective_edits);
+        if group.no_umi {
+            info!("No-UMI mode: grouping by position only");
+        }
+        if matches!(
+            group.effective_strategy,
+            crate::assigner::Strategy::Adjacency | crate::assigner::Strategy::Paired
+        ) {
+            info!("Index threshold: {}", group.index_threshold);
+        }
+        if group.allow_unmapped {
+            info!("Allow unmapped: enabled (unmapped templates will be grouped by UMI only)");
+            warn!(
+                "WARNING: All unmapped reads are placed in a single position group. \
+                 Reads with identical/similar UMIs will be grouped together even if they \
+                 originate from different genomic locations."
+            );
+            if matches!(
+                group.strategy,
+                crate::assigner::Strategy::Edit
+                    | crate::assigner::Strategy::Adjacency
+                    | crate::assigner::Strategy::Paired
+            ) {
+                warn!(
+                    "WARNING: For paired UMIs (e.g., ACGT-TGCA), edit distance is computed \
+                     on the concatenated sequence with dashes removed. With --edits {}, \
+                     only {} mismatch(es) allowed across ALL bases.",
+                    group.edits, group.edits
+                );
+            }
+        }
+
+        warn_unwired_pipeline_flags(&self.spec.scheduler, &self.spec.queue_memory);
+        let num_threads = self.spec.threading.num_threads();
+        info!("{}", self.spec.threading.log_message());
+        info!("Using pipeline with {num_threads} threads");
+
+        // Check sort order — identical validation to GroupReadsByUmi::execute.
+        // Sort-order precondition + info logging, shared verbatim with
+        // `Group::execute`'s single-threaded path (see `require_group_input_sort`).
+        crate::commands::common::require_group_input_sort(&self.header, group.allow_unmapped)?;
+
+        // Tag constants per SAM specification.
+        let raw_tag: [u8; 2] = *SamTag::RX;
+        let assign_tag_bytes: [u8; 2] = *SamTag::MI;
+
+        // Build filter configuration from GroupOptions fields (mirrors
+        // GroupReadsByUmi::execute's construction of filter_config).
+        let filter_config = crate::template_filter::TemplateFilterConfig {
+            umi_tag: raw_tag,
+            min_mapq: group.min_map_q,
+            include_non_pf: group.include_non_pf_reads,
+            min_umi_length: group.min_umi_length,
+            no_umi: group.no_umi,
+            allow_unmapped: group.allow_unmapped,
+        };
+
+        // Per-thread metric accumulators.
+        let accumulators =
+            PerThreadAccumulator::<crate::commands::group::GroupMetricsAccumulator>::new(
+                num_threads,
+            );
+        let accumulators_for_process = Arc::clone(&accumulators);
+
+        // ── Step factories (see chains::commands::group) ──────────────────
+        let process_step = build_group_process_step(
+            self.tuning.per_step_byte_limit,
+            group.effective_strategy,
+            group.effective_edits,
+            group.index_threshold,
+            raw_tag,
+            group.no_umi,
+            group.allow_unmapped,
+            group.parallel_group_min_templates.clone(),
+            num_threads,
+            filter_config,
+            accumulators_for_process,
+        );
+        let mi_assign_step = build_group_mi_assign_step(self.tuning.per_step_byte_limit);
+
+        // Wire GroupByPosition → ProcessOrdered → MiAssign (always appended).
+        let tail =
+            self.pipeline.append_step(GroupByPosition::new(self.tuning.per_step_byte_limit), tail);
+        let tail = self.pipeline.append_step(process_step, tail);
+        let tail = self.pipeline.append_step(mi_assign_step, tail);
+
+        if position == StagePosition::Terminal {
+            // Terminal: append SerializeGroups so the chain tail is DecompressedBlock,
+            // ready for BgzfCompress → WriteBgzfFile.
+            let serialize_step = build_group_serialize_step(
+                self.tuning.per_step_byte_limit,
+                assign_tag_bytes,
+                Arc::clone(&self.progress_records),
+            );
+            let tail = self.pipeline.append_step(serialize_step, tail);
+            self.current_tail = Some(tail);
+            // tail is DecompressedBlock (serialized bytes) after SerializeGroups
+            // → SerializedBytes.
+            self.chain_tail_kind = ChainTailKind::SerializedBytes;
+        } else {
+            // Intermediate: leave tail as BatchedProcessedPositionGroups so the
+            // next stage (add_simplex / add_duplex / add_codec) can wire
+            // TemplatesToMiGroups instead of GroupByMi.
+            self.current_tail = Some(tail);
+            self.chain_tail_kind = ChainTailKind::BatchedProcessedPositionGroups;
+        }
+
+        // The assign tag is always `MI` (`assign_tag_bytes == *SamTag::MI`, a
+        // pub const). On the Terminal path it was passed to the serialize step
+        // above; on the Intermediate (fused group→consensus) path the consensus
+        // stages re-derive it from `*SamTag::MI` directly (see
+        // `templates_to_mi_step`), so it is not carried on `ChainBuilder`.
+
+        // Register the group finalize hook.
+        // The chain-level StageTimingFinalizeHook is inserted at index 0 by
+        // build() after all stages have been added — that way a single timer
+        // covers the full pipeline run regardless of how many stages there are.
+        self.finalize.push(Box::new(GroupFinalizeHook {
+            accumulators,
+            output_path,
+            family_size_histogram: group.family_size_histogram.clone(),
+            grouping_metrics: group.grouping_metrics.clone(),
+            metrics_prefix: group.metrics_prefix.clone(),
+            timer,
+        }));
+
+        Ok(())
+    }
+
+    // ----------------------------------------------------------------------
+    // Consensus stages (simplex / duplex / codec).
+    //
+    // The full method bodies below are compiled only with the `consensus`
+    // feature, which gates the consensus command modules and their option
+    // types. When the crate is built without `consensus`, the consensus CLI
+    // commands and option-bag slots are compiled out, so these stages are
+    // unreachable — but `add_stage`'s match must still resolve all three
+    // `Stage` variants. These stubs provide that resolution and fail loudly
+    // if ever reached.
+    // ----------------------------------------------------------------------
+    // `&mut self` matches the consensus-enabled signatures so the call sites are
+    // identical; the stub bails before touching any field, hence `unused_self`.
+    #[cfg(not(feature = "consensus"))]
+    #[allow(clippy::unused_self)]
+    fn add_simplex(&mut self, _position: StagePosition) -> Result<()> {
+        bail!("fgumi was built without consensus support; rebuild with `--features consensus`")
+    }
+
+    #[cfg(not(feature = "consensus"))]
+    #[allow(clippy::unused_self)]
+    fn add_duplex(&mut self, _position: StagePosition) -> Result<()> {
+        bail!("fgumi was built without consensus support; rebuild with `--features consensus`")
+    }
+
+    #[cfg(not(feature = "consensus"))]
+    #[allow(clippy::unused_self)]
+    fn add_codec(&mut self, _position: StagePosition) -> Result<()> {
+        bail!("fgumi was built without consensus support; rebuild with `--features consensus`")
+    }
+
+    /// Simplex-specific step sequence:
+    ///
+    /// `GroupByMi` →
+    /// `ProcessWithWorkerState` (consensus calling + rejects streaming + metrics).
+    ///
+    /// For [`StagePosition::Terminal`], the chain tail is [`DecompressedBlock`]
+    /// (bytes ready for `BgzfCompress`).
+    ///
+    /// For [`StagePosition::Intermediate`] (e.g. fused `consensus → filter`),
+    /// [`Self::finish_consensus_tail`] appends a [`DecodeRecords`] step so the
+    /// chain tail is [`DecodedRecordBatch`] for the next stage — consensus
+    /// output is already record-aligned, so no boundary/parse step is needed.
+    ///
+    /// Applies the M5 fix: enforces that `--ref` requires `--methylation-mode`
+    /// to be set (mirrors the same check in `Simplex::execute`'s
+    /// single-threaded fast path).
+    ///
+    /// Registers a `SimplexFinalizeHook` for accumulators reduce, stats write,
+    /// overlapping-consensus stats log, summary banner, rejects-writer
+    /// finalize, and timer.
+    /// The chain-level [`StageTimingFinalizeHook`] is registered by
+    /// [`Self::build`] (not here), so it captures the correct `Instant`.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors if simplex options are missing from the spec bag, or if
+    /// `--ref` is set without `--methylation-mode`.
+    ///
+    /// [`BatchedMiGroups`]: crate::pipeline::steps::group::mi::BatchedMiGroups
+    /// [`DecompressedBlock`]: crate::pipeline::steps::types::DecompressedBlock
+    /// [`DecodedRecordBatch`]: crate::pipeline::steps::types::DecodedRecordBatch
+    /// [`DecodeRecords`]: crate::pipeline::steps::parse::decode::DecodeRecords
+    #[cfg(feature = "consensus")]
+    #[allow(clippy::too_many_lines)]
+    fn add_simplex(&mut self, position: StagePosition) -> Result<()> {
+        use crate::commands::common::{
+            MethylationRef, consensus_pregroup_keep_raw, load_methylation_reference,
+            warn_unwired_pipeline_flags,
+        };
+        use crate::commands::consensus_runner::create_unmapped_consensus_header;
+        use crate::logging::OperationTimer;
+        use crate::per_thread_accumulator::PerThreadAccumulator;
+        use crate::pipeline::chains::commands::simplex::{
+            CollectedSimplexMetrics, SimplexConsensusCaptures, SimplexFinalizeHook,
+            build_simplex_consensus_step_kept_only, build_simplex_consensus_step_with_rejects,
+        };
+        use crate::pipeline::steps::group::mi::GroupByMi;
+        use crate::sam::SamTag;
+        use crate::vanilla_consensus_caller::VanillaUmiConsensusOptions;
+        use log::info;
+        use noodles::sam::alignment::record::data::field::Tag;
+
+        let simplex = self
+            .spec
+            .stage_opts
+            .simplex
+            .as_ref()
+            .ok_or_else(|| anyhow!("Stage::Simplex options missing from StageOptionsBag"))?;
+
+        // M5 fix: mirrors the same check in Simplex::execute's single-threaded
+        // fast path. Enforced here so runall's execute_consensus_only path also
+        // rejects --ref without --methylation-mode.
+        if simplex.reference.is_some()
+            && simplex.methylation_mode == fgumi_consensus::MethylationMode::Disabled
+        {
+            bail!("--ref requires --methylation-mode to be set");
+        }
+
+        // V5 fix: runall never calls Simplex::execute, so mirror its
+        // --min-reads / --max-reads range check here. Without this, runall
+        // silently accepts degenerate configs (`--simplex::min-reads 0`,
+        // `--simplex::max-reads < --simplex::min-reads`) the standalone command
+        // rejects, breaking the "same as standalone" contract.
+        simplex.validate_read_bounds()?;
+
+        let tail = self.current_tail.expect("add_simplex called before add_source");
+
+        // Resolve source path for log messages only.
+        let input_path = self.resolve_log_input_path();
+        let output_path = self.spec.sink.path().clone();
+
+        let timer = OperationTimer::new("Calling simplex consensus");
+
+        info!("Starting Simplex");
+        info!("Input: {}", input_path.display());
+        info!("Output: {}", output_path.display());
+        info!("Min reads: {}", simplex.min_reads);
+        if let Some(max) = simplex.max_reads {
+            info!("Max reads: {max}");
+        }
+        // Reconstruct the shared option structs from the inlined SimplexOptions
+        // flat fields.
+        let consensus = simplex.consensus();
+        let overlapping = simplex.overlapping();
+        info!("Error rate pre-UMI: Q{}", consensus.error_rate_pre_umi);
+        info!("Error rate post-UMI: Q{}", consensus.error_rate_post_umi);
+
+        let overlapping_enabled = overlapping.is_enabled();
+        if overlapping_enabled {
+            info!("Overlapping consensus calling enabled");
+        }
+
+        warn_unwired_pipeline_flags(&self.spec.scheduler, &self.spec.queue_memory);
+        let num_threads = self.spec.threading.num_threads();
+        info!("{}", self.spec.threading.log_message());
+        info!("Using pipeline with {num_threads} threads");
+
+        info!("Processing reads and calling consensus (streaming)...");
+
+        // Resolve methylation mode and load reference if needed.
+        let methylation_mode = simplex.methylation_mode;
+        let methylation_ref: MethylationRef =
+            load_methylation_reference(methylation_mode, &simplex.reference, &self.header)?;
+
+        // create_unmapped_consensus_header already inserts the @PG record via
+        // add_pg_to_builder, so no second add_pg_record call is needed here.
+        // We pass self.header (the input header with @PG) for reference
+        // sequence lines, RG, etc.
+        let output_header = create_unmapped_consensus_header(
+            &self.header,
+            &simplex.read_group.read_group_id,
+            "Read group",
+            &self.spec.command_line,
+        )?;
+
+        // Derive read_name_prefix from the *input* header (before replacing
+        // self.header) so the prefix is consistent with the original input
+        // read groups — mirrors what the old build_simplex_chain did, where
+        // `prefix_or_from_header` was called on `input_header` (not on the
+        // freshly constructed output_header). If the input has no read groups,
+        // make_prefix_from_header returns "" which is the correct empty prefix.
+        let read_name_prefix = simplex.read_group.prefix_or_from_header(&self.header);
+
+        // Capture the input header (raw-input RG/PG + @HD sort fields) BEFORE
+        // replacing self.header with the consensus output header. Per the PR
+        // #332 rejects contract, the rejects branch is written with this input
+        // header verbatim (rejects are raw-input records in input order).
+        let input_header = self.header.clone();
+
+        // Replace self.header with the consensus output header so add_sink()
+        // uses the correct header for WriteBgzfFile.
+        self.replace_header(output_header);
+
+        let track_rejects = simplex.rejects_opts.is_enabled();
+
+        // Per-thread metrics accumulator.
+        let accumulators = PerThreadAccumulator::<CollectedSimplexMetrics>::new(num_threads);
+        let accumulators_for_step = Arc::clone(&accumulators);
+
+        // Tag constants.
+        let cell_tag = Tag::from(SamTag::CB);
+
+        let read_group_id = simplex.read_group.read_group_id.clone();
+        let consensus_options = VanillaUmiConsensusOptions {
+            tag: "MI".to_string(),
+            error_rate_pre_umi: consensus.error_rate_pre_umi,
+            error_rate_post_umi: consensus.error_rate_post_umi,
+            min_input_base_quality: consensus.min_input_base_quality,
+            min_reads: simplex.min_reads,
+            max_reads: simplex.max_reads,
+            produce_per_base_tags: consensus.output_per_base_tags,
+            trim: consensus.trim,
+            min_consensus_base_quality: consensus.min_consensus_base_quality,
+            cell_tag: Some(cell_tag),
+            methylation_mode,
+            // `simplex.tie_rule` is already the resolved `TieRule` on `SimplexOptions`.
+            tie_rule: simplex.tie_rule,
+        };
+
+        let progress_records = Arc::clone(&self.progress_records);
+
+        // ── Step factories (see chains::commands::simplex) ────────────────
+
+        let consensus_cap = SimplexConsensusCaptures {
+            track_rejects,
+            overlapping_enabled,
+            consensus_options,
+            read_name_prefix,
+            read_group_id,
+            methylation_ref,
+            accumulators: accumulators_for_step,
+            min_reads: simplex.min_reads,
+            progress: progress_records,
+        };
+
+        // ── Group-MI preamble: two paths depending on the incoming tail type ──
+        //
+        // Path 1 (normal): tail is DecodedRecordBatch → prepend GroupByMi.
+        // Path 2 (fused group→simplex): tail is BatchedProcessedPositionGroups
+        //   (from add_group(Intermediate)) → prepend the `templates_to_mi_step`
+        //   bridge. Simplex passes `duplex_strip_strand = false` (no /A /B
+        //   suffixes).
+        // Canonical pre-group record filter, honoring `--allow-unmapped`, applied
+        // on BOTH the fused and non-fused paths so the chain matches standalone
+        // `fgumi simplex` (`consensus_pregroup_keep_raw`): drop
+        // secondary/supplementary always, and (unless `--allow-unmapped`) drop
+        // unmapped primary records even when the mate is mapped (fgbio#1168).
+        let allow_unmapped = simplex.allow_unmapped.enabled;
+        let tail = if self.chain_tail_kind == ChainTailKind::BatchedProcessedPositionGroups {
+            // simplex: no `/A` `/B` strand stripping; apply the canonical filter.
+            self.pipeline.append_step(
+                templates_to_mi_step(
+                    self.tuning.per_step_byte_limit,
+                    false,
+                    Some(move |raw: &[u8]| consensus_pregroup_keep_raw(raw, allow_unmapped)),
+                ),
+                tail,
+            )
+        } else {
+            // Normal path: DecodedRecordBatch → GroupByMi → BatchedMiGroups.
+            // The cell-tag partition is defensive/redundant given MI uniqueness
+            // (see `templates_to_mi_step` doc, S5b1-003): MI is globally unique
+            // across cell barcodes, so MI-only grouping is already cell-correct.
+            let group_mi_step = GroupByMi::new(*SamTag::MI, self.tuning.per_step_byte_limit)
+                .with_cell_tag(Some(*SamTag::CB))
+                .with_record_filter(move |raw| consensus_pregroup_keep_raw(raw, allow_unmapped));
+            self.pipeline.append_step(group_mi_step, tail)
+        };
+
+        // Wire the simplex consensus step. With `--rejects` it is a 2-output
+        // step (branch 0 = consensus DecompressedBlock, branch 1 = rejects
+        // DecompressedBlock → BgzfCompress → WriteBgzfFile with the INPUT
+        // header, in input order — the PR #332 fan-out contract); without
+        // rejects it is the 1-output kept-only variant (the framework has no
+        // public discard sink). Mirrors add_correct.
+        let limit = self.tuning.per_step_byte_limit;
+        let consensus_branch0 = if track_rejects {
+            let step = build_simplex_consensus_step_with_rejects(limit, consensus_cap);
+            let pt = self.pipeline.append_step(step, tail);
+            self.wire_consensus_rejects_branch(
+                pt,
+                simplex.rejects_opts.rejects.as_deref(),
+                &input_header,
+                "simplex",
+            )?;
+            pt
+        } else {
+            let step = build_simplex_consensus_step_kept_only(limit, consensus_cap);
+            self.pipeline.append_step(step, tail)
+        };
+        // Branch 0 = consensus DecompressedBlock. For an Intermediate consensus
+        // stage finish_consensus_tail appends DecodeRecords; Terminal leaves the
+        // DecompressedBlock for add_sink.
+        let tail = self.finish_consensus_tail(consensus_branch0, position);
+        self.current_tail = Some(tail);
+
+        // Register the simplex finalize hook.
+        // The chain-level StageTimingFinalizeHook is inserted at index 0 by
+        // build() after all stages have been added — that way a single timer
+        // covers the full pipeline run regardless of how many stages there are.
+        self.finalize.push(Box::new(SimplexFinalizeHook {
+            accumulators,
+            stats_path: simplex.stats_opts.stats.clone(),
+            overlapping_enabled,
+            timer,
+        }));
+
+        Ok(())
+    }
+
+    /// Duplex-specific step sequence:
+    ///
+    /// `GroupByMi` (with record filter + MI transform) →
+    /// `ProcessWithWorkerState` (duplex consensus calling + rejects streaming + metrics).
+    ///
+    /// For [`StagePosition::Terminal`], the chain tail is [`DecompressedBlock`]
+    /// (bytes ready for `BgzfCompress`).
+    ///
+    /// For [`StagePosition::Intermediate`] (e.g. fused `consensus → filter`),
+    /// [`Self::finish_consensus_tail`] appends a [`DecodeRecords`] step so the
+    /// chain tail is [`DecodedRecordBatch`] for the next stage.
+    ///
+    /// The record filter skips secondary/supplementary reads and requires each
+    /// record to be mapped or have a mapped mate. The MI transform strips `/A`
+    /// and `/B` suffixes so both strands group into the same `MiGroup`.
+    ///
+    /// Applies the read_name_prefix-from-input-header fix: derives the prefix
+    /// from `self.header` (the input header, before it is replaced with the
+    /// consensus output header) so the prefix is consistent with the original
+    /// input read groups — mirrors the Phase 2 behaviour in `build_duplex_chain`
+    /// where `prefix_or_from_header` was called on `input_header`.
+    ///
+    /// Applies the M5 fix: enforces that `--ref` requires `--methylation-mode`
+    /// to be set (mirrors the same check in `Duplex::execute`'s single-threaded
+    /// fast path).
+    ///
+    /// Registers a `DuplexFinalizeHook` for accumulators reduce, stats write,
+    /// overlapping-consensus stats log, summary banner, rejects-writer
+    /// finalize, and timer.
+    /// The chain-level [`StageTimingFinalizeHook`] is registered by
+    /// [`Self::build`] (not here), so it captures the correct `Instant`.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors if duplex options are missing from the spec bag, or if
+    /// `--ref` is set without `--methylation-mode`.
+    ///
+    /// [`BatchedMiGroups`]: crate::pipeline::steps::group::mi::BatchedMiGroups
+    /// [`DecompressedBlock`]: crate::pipeline::steps::types::DecompressedBlock
+    /// [`DecodedRecordBatch`]: crate::pipeline::steps::types::DecodedRecordBatch
+    /// [`DecodeRecords`]: crate::pipeline::steps::parse::decode::DecodeRecords
+    #[cfg(feature = "consensus")]
+    #[allow(clippy::too_many_lines)]
+    fn add_duplex(&mut self, position: StagePosition) -> Result<()> {
+        use crate::commands::common::{
+            consensus_pregroup_keep_raw, load_methylation_reference, warn_unwired_pipeline_flags,
+        };
+        use crate::commands::consensus_runner::create_unmapped_consensus_header;
+        use crate::logging::OperationTimer;
+        use crate::per_thread_accumulator::PerThreadAccumulator;
+        use crate::pipeline::chains::commands::duplex::{
+            CollectedDuplexMetrics, DuplexConsensusCaptures, DuplexFinalizeHook,
+            build_duplex_consensus_step_kept_only, build_duplex_consensus_step_with_rejects,
+        };
+        use crate::pipeline::steps::group::mi::GroupByMi;
+        use crate::sam::SamTag;
+        use crate::umi::extract_mi_base;
+        use log::info;
+        use noodles::sam::alignment::record::data::field::Tag;
+
+        let duplex = self
+            .spec
+            .stage_opts
+            .duplex
+            .as_ref()
+            .ok_or_else(|| anyhow!("Stage::Duplex options missing from StageOptionsBag"))?;
+
+        // M5 fix: mirrors the same check in Duplex::execute's single-threaded
+        // fast path. Enforced here so runall's execute_consensus_only path also
+        // rejects --ref without --methylation-mode.
+        if duplex.reference.is_some()
+            && duplex.methylation_mode == fgumi_consensus::MethylationMode::Disabled
+        {
+            bail!("--ref requires --methylation-mode to be set");
+        }
+
+        // Validate min_reads UP FRONT (mirrors Duplex::execute's single-threaded
+        // path). The per-worker init closure builds DuplexConsensusCaller with
+        // `.expect()`, so an invalid ordering (e.g. `--duplex::min-reads 1 5`)
+        // would otherwise panic inside a worker thread — likely wedging the
+        // pipeline — instead of surfacing a clean error here before it is built.
+        fgumi_consensus::DuplexConsensusCaller::validate_min_reads(&duplex.min_reads)?;
+
+        let tail = self.current_tail.expect("add_duplex called before add_source");
+
+        // Resolve source path for log messages only.
+        let input_path = self.resolve_log_input_path();
+        let output_path = self.spec.sink.path().clone();
+
+        let timer = OperationTimer::new("Calling duplex consensus");
+
+        // Reconstruct the shared option structs from the inlined DuplexOptions
+        // flat fields.
+        let consensus = duplex.consensus();
+        let overlapping = duplex.overlapping();
+
+        info!("Starting Duplex");
+        info!("Input: {}", input_path.display());
+        info!("Output: {}", output_path.display());
+        info!("Min reads: {:?}", duplex.min_reads);
+        info!("Min base quality: {}", consensus.min_input_base_quality);
+        info!("Output per-base tags: {}", consensus.output_per_base_tags);
+        info!("Trim reads: {}", consensus.trim);
+        info!("Max reads per strand: {:?}", duplex.max_reads_per_strand);
+        info!("Consensus call overlapping bases: {}", overlapping.consensus_call_overlapping_bases);
+
+        let overlapping_enabled = overlapping.consensus_call_overlapping_bases;
+        if overlapping_enabled {
+            info!("Overlapping consensus calling enabled");
+        }
+
+        warn_unwired_pipeline_flags(&self.spec.scheduler, &self.spec.queue_memory);
+        let num_threads = self.spec.threading.num_threads();
+        info!("{}", self.spec.threading.log_message());
+        info!("Using pipeline with {num_threads} threads");
+
+        info!("Processing reads and calling duplex consensus (streaming)...");
+        info!("Reading input");
+
+        // Resolve methylation mode and load reference if needed.
+        let methylation_mode = duplex.methylation_mode;
+        let methylation_ref =
+            load_methylation_reference(methylation_mode, &duplex.reference, &self.header)?;
+
+        // create_unmapped_consensus_header already inserts the @PG record via
+        // add_pg_to_builder, so no second add_pg_record call is needed here.
+        // We pass self.header (the input header with @PG) for reference
+        // sequence lines, RG, etc.
+        let output_header = create_unmapped_consensus_header(
+            &self.header,
+            &duplex.read_group.read_group_id,
+            "Read group",
+            &self.spec.command_line,
+        )?;
+
+        // Derive read_name_prefix from the *input* header (before replacing
+        // self.header) so the prefix is consistent with the original input
+        // read groups — mirrors what the old build_duplex_chain did, where
+        // `prefix_or_from_header` was called on `input_header` (not on the
+        // freshly constructed output_header). If the input has no read groups,
+        // make_prefix_from_header returns "" which is the correct empty prefix.
+        let read_name_prefix = duplex.read_group.prefix_or_from_header(&self.header);
+
+        // Capture the input header BEFORE replacing self.header with the
+        // consensus output header — the rejects branch is written with the
+        // input header verbatim (PR #332 contract).
+        let input_header = self.header.clone();
+
+        // Replace self.header with the consensus output header so add_sink()
+        // uses the correct header for WriteBgzfFile.
+        self.replace_header(output_header);
+
+        let track_rejects = duplex.rejects_opts.is_enabled();
+
+        // Per-thread metrics accumulator.
+        let accumulators = PerThreadAccumulator::<CollectedDuplexMetrics>::new(num_threads);
+        let accumulators_for_step = Arc::clone(&accumulators);
+
+        // Tag constants.
+        let cell_tag = Tag::from(SamTag::CB);
+
+        let read_group_id = duplex.read_group.read_group_id.clone();
+        let min_reads = duplex.min_reads.clone();
+        let min_input_base_quality = consensus.min_input_base_quality;
+        let output_per_base_tags = consensus.output_per_base_tags;
+        let trim = consensus.trim;
+        let max_reads_per_strand = duplex.max_reads_per_strand;
+        let error_rate_pre_umi = consensus.error_rate_pre_umi;
+        let error_rate_post_umi = consensus.error_rate_post_umi;
+
+        let progress_records = Arc::clone(&self.progress_records);
+
+        // ── Step factories (see chains::commands::duplex) ────────────────────
+
+        let consensus_cap = DuplexConsensusCaptures {
+            track_rejects,
+            overlapping_enabled,
+            methylation_ref,
+            methylation_mode,
+            read_name_prefix,
+            read_group_id,
+            min_reads,
+            min_input_base_quality,
+            output_per_base_tags,
+            trim,
+            max_reads_per_strand,
+            error_rate_pre_umi,
+            error_rate_post_umi,
+            cell_tag,
+            accumulators: accumulators_for_step,
+            progress: progress_records,
+        };
+
+        // ── Group-MI preamble: two paths depending on the incoming tail type ──
+        //
+        // Path 1 (normal): tail is DecodedRecordBatch → prepend GroupByMi with
+        //   record filter (skip secondary/supplementary) + MI transform (strip /A /B).
+        // Path 2 (fused group→duplex): tail is BatchedProcessedPositionGroups
+        //   (from add_group(Intermediate)) → prepend TemplatesToMiGroups bridge
+        //   with duplex_strip_strand = true.
+        // Canonical pre-group record filter, honoring `--allow-unmapped`, applied
+        // on BOTH the fused and non-fused paths so the chain matches standalone
+        // `fgumi duplex` (`consensus_pregroup_keep_raw`): drop
+        // secondary/supplementary always, and (unless `--allow-unmapped`) drop
+        // unmapped primary records even when the mate is mapped (fgbio#1168).
+        let allow_unmapped = duplex.allow_unmapped.enabled;
+        let tail = if self.chain_tail_kind == ChainTailKind::BatchedProcessedPositionGroups {
+            // duplex: strip `/A` `/B` so both strands group together, and apply
+            // the same canonical per-record filter the non-fused path applies.
+            self.pipeline.append_step(
+                templates_to_mi_step(
+                    self.tuning.per_step_byte_limit,
+                    true,
+                    Some(move |raw: &[u8]| consensus_pregroup_keep_raw(raw, allow_unmapped)),
+                ),
+                tail,
+            )
+        } else {
+            // Normal path: DecodedRecordBatch → GroupByMi → BatchedMiGroups.
+            // Record filter: the canonical `consensus_pregroup_keep_raw` shared
+            // with the fused bridge above and standalone duplex.
+            // MI transform: strip /A and /B so both strands group together.
+            let mi_transform = |mi_bytes: &[u8]| -> String {
+                let mi_str = std::borrow::Cow::from(std::str::from_utf8(mi_bytes).unwrap_or(""));
+                extract_mi_base(&mi_str).to_string()
+            };
+            // `with_cell_tag` is defensive/redundant given MI uniqueness
+            // (S5b1-003); `with_record_filter` is the load-bearing duplex filter.
+            let group_mi_step = GroupByMi::new(*SamTag::MI, self.tuning.per_step_byte_limit)
+                .with_cell_tag(Some(*SamTag::CB))
+                .with_record_filter(move |raw| consensus_pregroup_keep_raw(raw, allow_unmapped))
+                .with_mi_transform(mi_transform);
+            self.pipeline.append_step(group_mi_step, tail)
+        };
+
+        // Wire the duplex consensus step. With `--rejects` it is a 2-output step
+        // (branch 0 = consensus, branch 1 = rejects → BgzfCompress → WriteBgzfFile
+        // with the INPUT header, in input order — the PR #332 fan-out contract);
+        // without rejects it is the 1-output kept-only variant. Mirrors add_correct.
+        let limit = self.tuning.per_step_byte_limit;
+        let consensus_branch0 = if track_rejects {
+            let step = build_duplex_consensus_step_with_rejects(limit, consensus_cap);
+            let pt = self.pipeline.append_step(step, tail);
+            self.wire_consensus_rejects_branch(
+                pt,
+                duplex.rejects_opts.rejects.as_deref(),
+                &input_header,
+                "duplex",
+            )?;
+            pt
+        } else {
+            let step = build_duplex_consensus_step_kept_only(limit, consensus_cap);
+            self.pipeline.append_step(step, tail)
+        };
+        // Branch 0 = consensus DecompressedBlock. Intermediate appends
+        // DecodeRecords; Terminal leaves the DecompressedBlock for add_sink.
+        let tail = self.finish_consensus_tail(consensus_branch0, position);
+        self.current_tail = Some(tail);
+
+        // Register the duplex finalize hook.
+        // The chain-level StageTimingFinalizeHook is inserted at index 0 by
+        // build() after all stages have been added — that way a single timer
+        // covers the full pipeline run regardless of how many stages there are.
+        self.finalize.push(Box::new(DuplexFinalizeHook {
+            accumulators,
+            stats_path: duplex.stats_opts.stats.clone(),
+            overlapping_enabled,
+            timer,
+        }));
+
+        Ok(())
+    }
+
+    /// Codec-specific step sequence:
+    ///
+    /// `GroupByMi` →
+    /// `ProcessWithWorkerState` (codec consensus calling + rejects streaming + metrics).
+    ///
+    /// For [`StagePosition::Terminal`], the chain tail is [`DecompressedBlock`]
+    /// (bytes ready for `BgzfCompress`).
+    ///
+    /// For [`StagePosition::Intermediate`] (e.g. fused `consensus → filter`),
+    /// [`Self::finish_consensus_tail`] appends a [`DecodeRecords`] step so the
+    /// chain tail is [`DecodedRecordBatch`] for the next stage.
+    ///
+    /// Codec applies the same canonical `consensus_pregroup_keep_raw` pre-group
+    /// filter as simplex/duplex (honoring `--allow-unmapped`), but — unlike
+    /// duplex — applies **no** MI-tag `/A` `/B` strand transform, and no
+    /// overlapping consensus or methylation mode, matching fgbio's
+    /// `CallCodecConsensusReads` behaviour.
+    ///
+    /// Applies the read_name_prefix-from-input-header fix: derives the prefix
+    /// from `self.header` (the input header, before it is replaced with the
+    /// consensus output header) so the prefix is consistent with the original
+    /// input read groups — mirrors the Phase 2 behaviour in `build_codec_chain`
+    /// where `prefix_or_from_header` was called on `input_header`.
+    ///
+    /// Registers a `CodecFinalizeHook` for accumulators reduce, stats write,
+    /// summary banner, rejects-writer finalize, and timer.
+    /// The chain-level [`StageTimingFinalizeHook`] is registered by
+    /// [`Self::build`] (not here), so it captures the correct `Instant`.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors if codec options are missing from the spec bag.
+    ///
+    /// [`BatchedMiGroups`]: crate::pipeline::steps::group::mi::BatchedMiGroups
+    /// [`DecompressedBlock`]: crate::pipeline::steps::types::DecompressedBlock
+    /// [`DecodedRecordBatch`]: crate::pipeline::steps::types::DecodedRecordBatch
+    /// [`DecodeRecords`]: crate::pipeline::steps::parse::decode::DecodeRecords
+    #[cfg(feature = "consensus")]
+    #[allow(clippy::too_many_lines)]
+    fn add_codec(&mut self, position: StagePosition) -> Result<()> {
+        use crate::commands::common::{consensus_pregroup_keep_raw, warn_unwired_pipeline_flags};
+        use crate::commands::consensus_runner::create_unmapped_consensus_header;
+        use crate::consensus::codec_caller::CodecConsensusOptions;
+        use crate::logging::OperationTimer;
+        use crate::per_thread_accumulator::PerThreadAccumulator;
+        use crate::pipeline::chains::commands::codec::{
+            CodecConsensusCaptures, CodecFinalizeHook, CollectedCodecMetrics,
+            build_codec_consensus_step_kept_only, build_codec_consensus_step_with_rejects,
+        };
+        use crate::pipeline::steps::group::mi::GroupByMi;
+        use crate::sam::SamTag;
+        use log::info;
+        use noodles::sam::alignment::record::data::field::Tag;
+
+        let codec = self
+            .spec
+            .stage_opts
+            .codec
+            .as_ref()
+            .ok_or_else(|| anyhow!("Stage::Codec options missing from StageOptionsBag"))?;
+
+        let tail = self.current_tail.expect("add_codec called before add_source");
+
+        // Resolve source path for log messages only.
+        let input_path = self.resolve_log_input_path();
+        let output_path = self.spec.sink.path().clone();
+
+        let timer = OperationTimer::new("Calling CODEC consensus");
+
+        // Reconstruct the shared ConsensusCallingOptions from the inlined
+        // CodecOptions flat fields.
+        let consensus = codec.consensus();
+
+        info!("Starting CODEC consensus calling");
+        info!("Input: {}", input_path.display());
+        info!("Output: {}", output_path.display());
+        info!("Min reads: {}", codec.min_reads);
+        if let Some(max) = codec.max_reads {
+            info!("Max reads: {max}");
+        }
+        info!("Error rate pre-UMI: Q{}", consensus.error_rate_pre_umi);
+        info!("Error rate post-UMI: Q{}", consensus.error_rate_post_umi);
+        info!("Min duplex length: {}", codec.min_duplex_length);
+
+        warn_unwired_pipeline_flags(&self.spec.scheduler, &self.spec.queue_memory);
+        let num_threads = self.spec.threading.num_threads();
+        info!("Worker threads: {num_threads}");
+        info!("Reader threads: {num_threads}");
+        if consensus.trim {
+            info!("Quality trimming enabled");
+        }
+
+        info!("Processing reads and calling consensus (streaming)...");
+        info!("Reading input");
+
+        // create_unmapped_consensus_header already inserts the @PG record via
+        // add_pg_to_builder, so no second add_pg_record call is needed here.
+        // We pass self.header (the input header with @PG) for reference
+        // sequence lines, RG, etc.
+        let output_header = create_unmapped_consensus_header(
+            &self.header,
+            &codec.read_group.read_group_id,
+            "Read group",
+            &self.spec.command_line,
+        )?;
+
+        // Derive read_name_prefix from the *input* header (before replacing
+        // self.header) so the prefix is consistent with the original input
+        // read groups — mirrors what the old build_codec_chain did, where
+        // `prefix_or_from_header` was called on `input_header` (not on the
+        // freshly constructed output_header). If the input has no read groups,
+        // make_prefix_from_header returns "" which is the correct empty prefix.
+        let read_name_prefix = codec.read_group.prefix_or_from_header(&self.header);
+
+        // Capture the input header BEFORE replacing self.header with the
+        // consensus output header — the rejects branch is written with the
+        // input header verbatim (PR #332 contract).
+        let input_header = self.header.clone();
+
+        // Replace self.header with the consensus output header so add_sink()
+        // uses the correct header for WriteBgzfFile.
+        self.replace_header(output_header);
+
+        let track_rejects = codec.rejects_opts.is_enabled();
+
+        // Per-thread metrics accumulator.
+        let accumulators = PerThreadAccumulator::<CollectedCodecMetrics>::new(num_threads);
+        let accumulators_for_step = Arc::clone(&accumulators);
+
+        // Tag constants.
+        let cell_tag = Tag::from(SamTag::CB);
+
+        let read_group_id = codec.read_group.read_group_id.clone();
+        let consensus_options = CodecConsensusOptions {
+            min_input_base_quality: consensus.min_input_base_quality,
+            error_rate_pre_umi: consensus.error_rate_pre_umi,
+            error_rate_post_umi: consensus.error_rate_post_umi,
+            min_reads_per_strand: codec.min_reads,
+            max_reads_per_strand: codec.max_reads,
+            min_duplex_length: codec.min_duplex_length,
+            single_strand_qual: codec.single_strand_qual,
+            outer_bases_qual: codec.outer_bases_qual,
+            outer_bases_length: codec.outer_bases_length,
+            max_duplex_disagreements: codec.max_duplex_disagreements.unwrap_or(usize::MAX),
+            max_duplex_disagreement_rate: codec.max_duplex_disagreement_rate,
+            legacy_overlap_window: codec.legacy_overlap_window,
+            cell_tag: Some(cell_tag),
+            produce_per_base_tags: consensus.output_per_base_tags,
+            trim: consensus.trim,
+            min_consensus_base_quality: consensus.min_consensus_base_quality,
+            // `codec.tie_rule` is already the resolved `TieRule` on `CodecOptions`.
+            tie_rule: codec.tie_rule,
+        };
+
+        let progress_records = Arc::clone(&self.progress_records);
+
+        // ── Step factories (see chains::commands::codec) ─────────────────────
+
+        let consensus_cap = CodecConsensusCaptures {
+            track_rejects,
+            read_name_prefix,
+            read_group_id,
+            consensus_options,
+            accumulators: accumulators_for_step,
+            progress: progress_records,
+        };
+
+        // ── Group-MI preamble: two paths depending on the incoming tail type ──
+        //
+        // Path 1 (normal): tail is DecodedRecordBatch → prepend GroupByMi.
+        //   Codec: no record filter, no MI transform.
+        // Path 2 (fused group→codec): tail is BatchedProcessedPositionGroups
+        //   (from add_group(Intermediate)) → prepend TemplatesToMiGroups bridge.
+        //   duplex_strip_strand = false (codec does not use /A /B suffixes).
+        // Canonical pre-group record filter, honoring `--allow-unmapped`, applied
+        // on BOTH the fused and non-fused paths so the chain matches standalone
+        // `fgumi codec` (`consensus_pregroup_keep_raw`): drop
+        // secondary/supplementary always, and (unless `--allow-unmapped`) drop
+        // unmapped primary records even when the mate is mapped (fgbio#1168).
+        // (codec's caller further requires a mapped primary FR pair, but that is
+        // a downstream decision — the pre-group admission filter still matches.)
+        let allow_unmapped = codec.allow_unmapped.enabled;
+        let tail = if self.chain_tail_kind == ChainTailKind::BatchedProcessedPositionGroups {
+            // codec: no `/A` `/B` strand stripping; apply the canonical filter.
+            self.pipeline.append_step(
+                templates_to_mi_step(
+                    self.tuning.per_step_byte_limit,
+                    false,
+                    Some(move |raw: &[u8]| consensus_pregroup_keep_raw(raw, allow_unmapped)),
+                ),
+                tail,
+            )
+        } else {
+            // Normal path: DecodedRecordBatch → GroupByMi → BatchedMiGroups.
+            // Codec: canonical pre-group filter, no MI transform. The cell-tag
+            // partition is defensive/redundant given MI uniqueness (S5b1-003).
+            let group_mi_step = GroupByMi::new(*SamTag::MI, self.tuning.per_step_byte_limit)
+                .with_cell_tag(Some(*SamTag::CB))
+                .with_record_filter(move |raw| consensus_pregroup_keep_raw(raw, allow_unmapped));
+            self.pipeline.append_step(group_mi_step, tail)
+        };
+
+        // Wire the codec consensus step. With `--rejects` it is a 2-output step
+        // (branch 0 = consensus, branch 1 = rejects → BgzfCompress → WriteBgzfFile
+        // with the INPUT header, in input order — the PR #332 fan-out contract);
+        // without rejects it is the 1-output kept-only variant. Mirrors add_correct.
+        let limit = self.tuning.per_step_byte_limit;
+        let consensus_branch0 = if track_rejects {
+            let step = build_codec_consensus_step_with_rejects(limit, consensus_cap);
+            let pt = self.pipeline.append_step(step, tail);
+            self.wire_consensus_rejects_branch(
+                pt,
+                codec.rejects_opts.rejects.as_deref(),
+                &input_header,
+                "codec",
+            )?;
+            pt
+        } else {
+            let step = build_codec_consensus_step_kept_only(limit, consensus_cap);
+            self.pipeline.append_step(step, tail)
+        };
+        // Branch 0 = consensus DecompressedBlock. Intermediate appends
+        // DecodeRecords; Terminal leaves the DecompressedBlock for add_sink.
+        let tail = self.finish_consensus_tail(consensus_branch0, position);
+        self.current_tail = Some(tail);
+
+        // Register the codec finalize hook.
+        // The chain-level StageTimingFinalizeHook is inserted at index 0 by
+        // build() after all stages have been added — that way a single timer
+        // covers the full pipeline run regardless of how many stages there are.
+        self.finalize.push(Box::new(CodecFinalizeHook {
+            accumulators,
+            stats_path: codec.stats_opts.stats.clone(),
+            timer,
+        }));
+
+        Ok(())
+    }
+
+    /// Clip-specific step sequence:
+    ///
+    /// `GroupBam` →
+    /// `ProcessOrdered` (clip templates + metrics accumulation) →
+    /// `SerializeBamRecords` — **Terminal only**.
+    ///
+    /// For [`StagePosition::Terminal`], all three steps are appended and the
+    /// chain tail is [`DecompressedBlock`] (bytes ready for `BgzfCompress`).
+    ///
+    /// For [`StagePosition::Intermediate`], only the first two steps are
+    /// appended; the chain tail stays as [`BamTemplateBatch`] for the next
+    /// stage to consume. Intermediate clip is not yet needed by any Phase 3
+    /// runall combination; calling `add_clip` with `Intermediate` returns
+    /// `Err` as a guard until a concrete fused path requires it.
+    ///
+    /// The output BAM carries the input header verbatim (clip preserves the
+    /// query-grouped order it requires on input), matching `main`'s non-chain
+    /// clip, which writes `&header` unchanged.
+    ///
+    /// Registers a `ClipFinalizeHook` for metrics logging + timer.
+    /// The chain-level [`StageTimingFinalizeHook`] is registered by
+    /// [`Self::build`] (not here), so it captures the correct `Instant`.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors if clip options are missing from the spec bag, if the
+    /// reference FASTA is absent, if no clipping operation is requested, if
+    /// `--metrics` is used with `--threads` mode, or if `position` is
+    /// `Intermediate` (not yet implemented).
+    ///
+    /// [`DecompressedBlock`]: crate::pipeline::steps::types::DecompressedBlock
+    /// [`BamTemplateBatch`]: crate::pipeline::steps::types::BamTemplateBatch
+    #[allow(clippy::too_many_lines)]
+    fn add_clip(&mut self, position: StagePosition) -> Result<()> {
+        use crate::commands::common::warn_unwired_pipeline_flags;
+        use crate::logging::OperationTimer;
+        use crate::pipeline::chains::commands::clip::{
+            ClipAtomicMetrics, ClipFinalizeHook, ClipProcessCaptures, build_clip_process_step,
+            build_clip_serialize_step,
+        };
+        use crate::pipeline::steps::group::bam::GroupBam;
+        use log::info;
+
+        if position == StagePosition::Intermediate {
+            bail!(
+                "intermediate clip not implemented; clip is typically terminal \
+                (no Phase 3 runall combination requires it as an intermediate stage)"
+            );
+        }
+
+        // Clip groups the record stream internally (GroupBam), so it consumes a
+        // DecodedRecordBatch tail. If an upstream stage left a different tail type
+        // (e.g. an intermediate Group emits BatchedProcessedPositionGroups), the
+        // type-erased pipeline would build but panic at dispatch — reject it here
+        // with a clear error.
+        if self.chain_tail_kind != ChainTailKind::DecodedRecordBatch {
+            bail!(
+                "Stage::Clip requires a record-stream input (DecodedRecordBatch), but the chain \
+                 tail is {:?}; clip cannot follow a stage that emits grouped templates or \
+                 serialized bytes.",
+                self.chain_tail_kind
+            );
+        }
+
+        let clip = self
+            .spec
+            .stage_opts
+            .clip
+            .as_ref()
+            .ok_or_else(|| anyhow!("Stage::Clip options missing from StageOptionsBag"))?;
+
+        let tail = self.current_tail.expect("add_clip called before add_source");
+
+        // Resolve source path for log messages only.
+        let input_path = self.resolve_log_input_path();
+        let output_path = self.spec.sink.path().clone();
+
+        // Reference is always required for clip.
+        crate::validation::validate_file_exists(&clip.reference, "Reference FASTA")?;
+
+        // Validate that at least one clipping operation is requested.
+        if !clip.upgrade_clipping
+            && !clip.clip_overlapping_reads
+            && !clip.clip_extending_past_mate
+            && clip.read_one_five_prime == 0
+            && clip.read_one_three_prime == 0
+            && clip.read_two_five_prime == 0
+            && clip.read_two_three_prime == 0
+        {
+            bail!("At least one clipping option is required");
+        }
+
+        // --metrics is not produced in --threads mode; fail fast rather than
+        // silently dropping a user-requested output file.
+        let num_threads = self.spec.threading.num_threads();
+        if let Some(path) = &clip.metrics {
+            anyhow::bail!(
+                "--metrics {} cannot be used with --threads: detailed clipping metrics \
+                 are only produced by the single-threaded path",
+                path.display()
+            );
+        }
+
+        let timer = OperationTimer::new("Clipping reads");
+
+        info!("Clip");
+        info!("  Input: {}", input_path.display());
+        info!("  Output: {}", output_path.display());
+        info!("  Clipping mode: {}", clip.clipping_mode);
+        info!("  Clip overlapping reads: {}", clip.clip_overlapping_reads);
+        info!("  Clip extending past mate: {}", clip.clip_extending_past_mate);
+        info!("  {}", self.spec.threading.log_message());
+
+        warn_unwired_pipeline_flags(&self.spec.scheduler, &self.spec.queue_memory);
+        info!("{}", self.spec.threading.log_message());
+        info!("Using pipeline with {num_threads} threads");
+
+        // No output-header sort-order rewrite: `main`'s clip writes the input
+        // header verbatim (clip preserves the query-grouped order it requires on
+        // input), so the chain matches that rather than re-annotating `SO`.
+
+        // Load reference (always required for clip).
+        let reference = Arc::new(crate::reference::ReferenceReader::new(&clip.reference)?);
+
+        // Shared atomic metric counters.
+        let metrics = Arc::new(ClipAtomicMetrics::default());
+        let progress_counter = Arc::new(std::sync::atomic::AtomicU64::new(0));
+
+        // ── Step factories (see chains::commands::clip) ──────────────────
+        let process_step = build_clip_process_step(
+            self.tuning.per_step_byte_limit,
+            ClipProcessCaptures {
+                clipping_mode: clip.clipping_mode,
+                auto_clip_attributes: clip.auto_clip_attributes,
+                upgrade_clipping: clip.upgrade_clipping,
+                clip_overlapping_reads: clip.clip_overlapping_reads,
+                clip_extending_past_mate: clip.clip_extending_past_mate,
+                read_one_five_prime: clip.read_one_five_prime,
+                read_one_three_prime: clip.read_one_three_prime,
+                read_two_five_prime: clip.read_two_five_prime,
+                read_two_three_prime: clip.read_two_three_prime,
+                header: self.header.clone(),
+                reference: Arc::clone(&reference),
+                metrics: Arc::clone(&metrics),
+                progress: Arc::clone(&progress_counter),
+            },
+        );
+        let serialize_step = build_clip_serialize_step(self.tuning.per_step_byte_limit);
+
+        // Wire the clip-specific steps.
+        let tail = self.pipeline.append_step(
+            GroupBam::new(self.tuning.template_batch_size, self.tuning.per_step_byte_limit),
+            tail,
+        );
+        let tail = self.pipeline.append_step(process_step, tail);
+        let tail = self.pipeline.append_step(serialize_step, tail);
+        self.current_tail = Some(tail);
+
+        // Register the clip finalize hook.
+        // The chain-level StageTimingFinalizeHook is inserted at index 0 by
+        // build() after all stages have been added — that way a single timer
+        // covers the full pipeline run regardless of how many stages there are.
+        self.finalize.push(Box::new(ClipFinalizeHook { metrics, progress_counter, timer }));
+
+        Ok(())
+    }
+
+    /// Filter-specific step sequence:
+    ///
+    /// - If `filter.filter_by_template`: `GroupByQueryname` inserted before the process step.
+    /// - No-rejects path: `ProcessOrdered` (single output → `DecompressedBlock`).
+    /// - With-rejects path: `Process2Ordered` (two outputs: branch 0 kept, branch 1 rejects).
+    ///   Branch 1 is wired here to its own `BgzfCompress → WriteBgzfFile` sink; branch 0
+    ///   becomes `current_tail` for `add_sink` to wire the primary output.
+    ///
+    /// Only [`StagePosition::Terminal`] is supported; intermediate filter is not needed by
+    /// any Phase 3 runall combination and bails with a clear error.
+    ///
+    /// Registers a `FilterFinalizeHook` for metrics reduction + summary banner.
+    /// The chain-level [`StageTimingFinalizeHook`] is registered by
+    /// [`Self::build`] (not here), so it captures the correct `Instant`.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors if filter options are missing from the spec bag, if the
+    /// rejects path is missing when rejects is enabled, or if `position` is
+    /// `Intermediate` (not yet implemented).
+    #[allow(clippy::too_many_lines)]
+    fn add_filter(&mut self, position: StagePosition) -> Result<()> {
+        use crate::commands::common::warn_unwired_pipeline_flags;
+        use crate::logging::OperationTimer;
+        use crate::pipeline::chains::commands::filter::{
+            FilterFinalizeHook, build_filter_step_single_no_rejects,
+            build_filter_step_single_with_rejects, build_filter_step_template_no_rejects,
+            build_filter_step_template_with_rejects,
+        };
+        use crate::validation::validate_file_exists;
+        use fgumi_bam_io::is_stdin_path;
+        use log::info;
+
+        if position == StagePosition::Intermediate {
+            bail!(
+                "intermediate filter not implemented; filter is typically terminal \
+                (no Phase 3 runall combination requires it as an intermediate stage)"
+            );
+        }
+
+        // Filter consumes a record stream (either a GroupByQueryname step in
+        // filter-by-template mode or a single-record filter step), so it needs a
+        // DecodedRecordBatch tail — the same requirement as clip/dedup. If an upstream
+        // stage left a different tail type (e.g. an intermediate Group emits
+        // BatchedProcessedPositionGroups), the type-erased pipeline would build but
+        // panic at dispatch — reject it here.
+        if self.chain_tail_kind != ChainTailKind::DecodedRecordBatch {
+            bail!(
+                "Stage::Filter requires a record-stream input (DecodedRecordBatch), but the chain \
+                 tail is {:?}; filter cannot follow a stage that emits grouped templates or \
+                 serialized bytes.",
+                self.chain_tail_kind
+            );
+        }
+
+        let filter = self
+            .spec
+            .stage_opts
+            .filter
+            .as_ref()
+            .ok_or_else(|| anyhow!("Stage::Filter options missing from StageOptionsBag"))?;
+
+        let tail = self.current_tail.expect("add_filter called before add_source");
+
+        // Resolve input path for validation log messages.
+        let input_path = self.resolve_log_input_path();
+
+        // Validate input file exists (stdin exempt). The PairedBams path here
+        // returns the mapped BAM, which `open_source` has already validated;
+        // re-validating is cheap and harmless.
+        if !is_stdin_path(&input_path) {
+            validate_file_exists(&input_path, "Input BAM")?;
+        }
+
+        if let Some(ref reference) = filter.reference {
+            validate_file_exists(reference, "Reference FASTA")?;
+        }
+
+        // Validate parameter counts (1-3 values for duplex support).
+        filter.validate_parameters()?;
+
+        let timer = OperationTimer::new("Filtering consensus reads");
+
+        // Resolve output path for log.
+        let output_path = self.spec.sink.path().clone();
+
+        info!("Starting Filter");
+        info!("Input: {}", input_path.display());
+        info!("Output: {}", output_path.display());
+        match &filter.reference {
+            Some(r) => info!("Reference: {}", r.display()),
+            None => info!("Reference: <none> (tag regeneration disabled)"),
+        }
+        info!("Min reads: {:?}", filter.min_reads);
+        info!("Max read error rate: {:?}", filter.max_read_error_rate);
+        info!("Max base error rate: {:?}", filter.max_base_error_rate);
+        if let Some(q) = filter.min_base_quality {
+            info!("Min base quality: {q}");
+        }
+        if let Some(q) = filter.min_mean_base_quality {
+            info!("Min mean base quality: {q}");
+        }
+        info!("Max no-call fraction: {}", filter.max_no_call_fraction);
+        if !filter.min_methylation_depth.is_empty() {
+            info!("Min methylation depth: {:?}", filter.min_methylation_depth);
+        }
+        if filter.require_strand_methylation_agreement {
+            info!("Require strand methylation agreement: true");
+        }
+        if let Some(frac) = filter.min_conversion_fraction {
+            info!("Min conversion fraction: {frac}");
+        }
+        if filter.methylation_mode != fgumi_consensus::MethylationMode::Disabled {
+            info!("Methylation mode: {:?}", filter.methylation_mode);
+        }
+
+        warn_unwired_pipeline_flags(&self.spec.scheduler, &self.spec.queue_memory);
+        let num_threads = self.spec.threading.num_threads();
+        info!("{}", self.spec.threading.log_message());
+        info!("Using pipeline with {num_threads} threads");
+
+        // Build shared FilterPipelineSetup (config, reference, accumulators, progress).
+        let setup = filter.setup_pipeline(num_threads, &self.header)?;
+        let accumulators = Arc::clone(&setup.collected_metrics);
+
+        let filter_by_template = filter.filter_by_template;
+        let track_rejects = filter.rejects.is_some();
+
+        // If template-aware, insert GroupByQueryname step before process.
+        let tail = if filter_by_template {
+            use crate::pipeline::steps::group::queryname::GroupByQueryname;
+            self.pipeline.append_step(GroupByQueryname::new(self.tuning.per_step_byte_limit), tail)
+        } else {
+            tail
+        };
+
+        // Select and append the process step (kept-only or kept+rejects).
+        let process_tail = match (filter_by_template, track_rejects) {
+            (false, false) => {
+                let captures = filter.process_captures(&setup, &self.header);
+                let step = build_filter_step_single_no_rejects(
+                    self.tuning.per_step_byte_limit,
+                    captures,
+                    Arc::clone(&accumulators),
+                );
+                self.pipeline.append_step(step, tail)
+            }
+            (false, true) => {
+                let captures = filter.process_captures(&setup, &self.header);
+                let step = build_filter_step_single_with_rejects(
+                    self.tuning.per_step_byte_limit,
+                    captures,
+                    Arc::clone(&accumulators),
+                );
+                self.pipeline.append_step(step, tail)
+            }
+            (true, false) => {
+                let captures = filter.process_captures(&setup, &self.header);
+                let step = build_filter_step_template_no_rejects(
+                    self.tuning.per_step_byte_limit,
+                    captures,
+                    Arc::clone(&accumulators),
+                );
+                self.pipeline.append_step(step, tail)
+            }
+            (true, true) => {
+                let captures = filter.process_captures(&setup, &self.header);
+                let step = build_filter_step_template_with_rejects(
+                    self.tuning.per_step_byte_limit,
+                    captures,
+                    Arc::clone(&accumulators),
+                );
+                self.pipeline.append_step(step, tail)
+            }
+        };
+        // process_tail = (process_step_idx, BranchIdx(0)) = kept branch.
+
+        // Wire the rejects branch (branch 1) to its own compress+write sink, when present.
+        if track_rejects {
+            use crate::pipeline::steps::bgzf::compress::BgzfCompress;
+            use crate::pipeline::steps::sink::write_bgzf::WriteBgzfFile;
+
+            let rejects_path = filter
+                .rejects
+                .as_ref()
+                .ok_or_else(|| anyhow!("rejects path missing (build_for dispatch bug)"))?;
+            let rejects_compress =
+                BgzfCompress::new(self.tuning.compression_level, self.tuning.per_step_byte_limit);
+            let rejects_writer =
+                WriteBgzfFile::new(rejects_path, &self.header, self.tuning.compression_level)
+                    .map_err(|e| anyhow!("WriteBgzfFile (rejects)::new: {e}"))?;
+
+            // Branch 1 of process_tail is the rejects output.
+            let rejects_branch = (process_tail.0, BranchIdx(1));
+            let rejects_compress_tail = self.pipeline.append_step(rejects_compress, rejects_branch);
+            // Sink: no tail needed after this.
+            let _rejects_write_tail =
+                self.pipeline.append_step(rejects_writer, rejects_compress_tail);
+        }
+
+        // Branch 0 of process_tail (kept) becomes current_tail for add_sink.
+        self.current_tail = Some(process_tail);
+
+        // Register the filter finalize hook.
+        // The chain-level StageTimingFinalizeHook is inserted at index 0 by
+        // build() after all stages have been added — that way a single timer
+        // covers the full pipeline run regardless of how many stages there are.
+        self.finalize.push(Box::new(FilterFinalizeHook {
+            accumulators,
+            stats_path: filter.stats.clone(),
+            has_rejects: track_rejects,
+            timer,
+        }));
+
+        Ok(())
+    }
+
+    /// Dedup-specific step sequence:
+    ///
+    /// `GroupByPosition::with_secondary_supplementary` →
+    /// `ProcessOrdered` (dedup + metrics accumulation) →
+    /// `MiAssign` (serial MI counter) →
+    /// `ProcessWithWorkerState` (serialize records with MI tags) — **Terminal only**.
+    ///
+    /// For [`StagePosition::Terminal`], all four steps are appended and the
+    /// chain tail is [`DecompressedBlock`] (bytes ready for `BgzfCompress`).
+    ///
+    /// For [`StagePosition::Intermediate`], only the first three steps are
+    /// appended; the chain tail stays as [`BatchedProcessedDedupGroups`] for
+    /// the next stage to consume. Intermediate dedup is not yet needed by any
+    /// Phase 3 runall combination; calling `add_dedup` with `Intermediate`
+    /// returns `Err` as a guard until a concrete fused path requires it.
+    ///
+    /// Registers a `DedupFinalizeHook` for metrics reduction + summary banner.
+    /// The chain-level [`StageTimingFinalizeHook`] is registered by
+    /// [`Self::build`] (not here), so it captures the correct `Instant`.
+    ///
+    /// # Errors
+    ///
+    /// Returns errors if the input is not template-coordinate sorted, if the
+    /// dedup options are missing from the spec bag, or if `position` is
+    /// `Intermediate` (not yet implemented).
+    ///
+    /// [`DecompressedBlock`]: crate::pipeline::steps::types::DecompressedBlock
+    /// [`BatchedProcessedDedupGroups`]: crate::commands::dedup::BatchedProcessedDedupGroups
+    #[allow(clippy::too_many_lines)]
+    fn add_dedup(&mut self, position: StagePosition) -> Result<()> {
+        use crate::assigner::Strategy;
+        use crate::commands::common::warn_unwired_pipeline_flags;
+        use crate::logging::OperationTimer;
+        use crate::per_thread_accumulator::PerThreadAccumulator;
+        use crate::pipeline::chains::commands::dedup::{
+            DedupFinalizeHook, build_mi_assign_step, build_process_step, build_serialize_step,
+        };
+        use crate::pipeline::steps::group::position::GroupByPosition;
+        use crate::sam::SamTag;
+        use crate::sam::is_template_coordinate_sorted;
+        use log::info;
+
+        if position == StagePosition::Intermediate {
+            bail!(
+                "intermediate dedup not implemented; dedup is typically terminal \
+                (no Phase 3 runall combination requires it as an intermediate stage)"
+            );
+        }
+
+        // Dedup groups the record stream internally (GroupByPosition), so it
+        // consumes a DecodedRecordBatch tail. Reject an incompatible upstream
+        // tail (e.g. an intermediate Group's BatchedProcessedPositionGroups) here
+        // rather than dispatch-panicking in the type-erased pipeline.
+        if self.chain_tail_kind != ChainTailKind::DecodedRecordBatch {
+            bail!(
+                "Stage::Dedup requires a record-stream input (DecodedRecordBatch), but the chain \
+                 tail is {:?}; dedup cannot follow a stage that emits grouped templates or \
+                 serialized bytes.",
+                self.chain_tail_kind
+            );
+        }
+
+        let dedup = self
+            .spec
+            .stage_opts
+            .dedup
+            .as_ref()
+            .ok_or_else(|| anyhow!("Stage::Dedup options missing from StageOptionsBag"))?;
+
+        let tail = self.current_tail.expect("add_dedup called before add_source");
+
+        // Validate template-coordinate sort order.
+        if !is_template_coordinate_sorted(&self.header) {
+            bail!(
+                "Input BAM must be template-coordinate sorted (header must advertise \
+                 SO:unsorted, GO:query, and SS:template-coordinate).\n\n\
+                 To prepare your BAM file, run:\n  \
+                 fgumi zipper -i mapped.bam -u unmapped.bam -r reference.fa -o merged.bam\n  \
+                 fgumi sort -i merged.bam -o sorted.bam --order template-coordinate"
+            );
+        }
+        info!("Template-coordinate sorted");
+
+        let timer = OperationTimer::new("Marking duplicates");
+
+        let output_path = self.spec.sink.path().clone();
+
+        info!("Starting dedup");
+        info!("Output: {}", output_path.display());
+
+        // Handle --no-umi mode: force identity strategy.
+        let (effective_strategy, no_umi_edits_override) = if dedup.no_umi {
+            if !matches!(dedup.strategy, Strategy::Identity) {
+                info!("--no-umi mode: overriding strategy to identity");
+            }
+            (Strategy::Identity, true)
+        } else {
+            (dedup.strategy, false)
+        };
+
+        info!("Strategy: {effective_strategy:?}");
+
+        let min_mapq: u8 = dedup.min_map_q.unwrap_or(0);
+        let effective_edits =
+            if no_umi_edits_override || matches!(effective_strategy, Strategy::Identity) {
+                0
+            } else {
+                dedup.edits
+            };
+
+        info!("Edits: {effective_edits}");
+        info!("Remove duplicates: {}", dedup.remove_duplicates);
+        if dedup.no_umi {
+            info!("No-UMI mode: deduplicating by position only");
+        }
+        if matches!(effective_strategy, Strategy::Adjacency | Strategy::Paired) {
+            info!("Index threshold: {}", dedup.index_threshold);
+        }
+
+        warn_unwired_pipeline_flags(&self.spec.scheduler, &self.spec.queue_memory);
+        let num_threads = self.spec.threading.num_threads();
+        info!("{}", self.spec.threading.log_message());
+        info!("Using pipeline with {num_threads} threads");
+
+        let raw_tag = SamTag::RX;
+        let assign_tag_bytes: [u8; 2] = *SamTag::MI;
+        let filter_config = crate::template_filter::TemplateFilterConfig {
+            umi_tag: *raw_tag,
+            min_mapq,
+            include_non_pf: dedup.include_non_pf_reads,
+            min_umi_length: dedup.min_umi_length,
+            no_umi: dedup.no_umi,
+            // Always false: `--include-unmapped` splits no-mapped-read templates
+            // off *before* the filter runs, so an unmapped template reaching the
+            // filter is always a rejection (matches the non-chain dedup path).
+            allow_unmapped: false,
+        };
+
+        let accumulators =
+            PerThreadAccumulator::<crate::commands::dedup::CollectedDedupMetrics>::new(num_threads);
+        let accumulators_for_process = Arc::clone(&accumulators);
+
+        // ── Step factories (see chains::commands::dedup) ──────────────────
+        let process_step = build_process_step(
+            self.tuning.per_step_byte_limit,
+            filter_config,
+            effective_strategy,
+            effective_edits,
+            dedup.index_threshold,
+            raw_tag,
+            dedup.min_umi_length,
+            dedup.no_umi,
+            dedup.include_unmapped,
+            accumulators_for_process,
+        );
+        let mi_assign_step = build_mi_assign_step(self.tuning.per_step_byte_limit);
+        let serialize_step = build_serialize_step(
+            self.tuning.per_step_byte_limit,
+            dedup.remove_duplicates,
+            assign_tag_bytes,
+            Arc::clone(&self.progress_records),
+        );
+
+        // Wire the dedup-specific steps.
+        let tail = self.pipeline.append_step(
+            GroupByPosition::with_secondary_supplementary(self.tuning.per_step_byte_limit),
+            tail,
+        );
+        let tail = self.pipeline.append_step(process_step, tail);
+        let tail = self.pipeline.append_step(mi_assign_step, tail);
+        let tail = self.pipeline.append_step(serialize_step, tail);
+        self.current_tail = Some(tail);
+
+        // Register the dedup finalize hook.
+        // The chain-level StageTimingFinalizeHook is inserted at index 0 by
+        // build() after all stages have been added — that way a single timer
+        // covers the full pipeline run regardless of how many stages there are.
+        self.finalize.push(Box::new(DedupFinalizeHook {
+            accumulators,
+            metrics_path: dedup.metrics.clone(),
+            family_size_histogram_path: dedup.family_size_histogram.clone(),
+            library_index: fgumi_bam_io::LibraryIndex::from_header(&self.header),
+            sample: crate::commands::dedup::resolve_sample(&self.header, dedup.sample.as_deref()),
+            timer,
+        }));
+
+        Ok(())
+    }
+}
+
+/// Resolve a sort phase's worker-thread count.
+///
+/// A per-phase override (`--sort::sort-threads` / `--sort::merge-threads`, or
+/// the standalone `--sort-threads` / `--merge-threads`) is used as-is when
+/// present; otherwise the phase falls back to the chain's base sorter-thread
+/// count (`--threads`). The result is clamped to at least 1 so a `0` override
+/// never disables a phase. This is the single source of truth for both the
+/// sole-stage (`SortStepCaptures`) and streaming (`RawExternalSorter`) sort
+/// paths in `add_sort`.
+fn resolve_phase_threads(override_threads: Option<usize>, num_sorter_threads: usize) -> usize {
+    override_threads.unwrap_or(num_sorter_threads).max(1)
+}
+
+/// Uniform "reference dictionary not found" error, shared by the zipper source
+/// open (`open_source`) and `add_align`, so both dict-resolution sites report
+/// the same actionable message (which paths were tried + the `samtools dict`
+/// remedy) rather than two divergent wordings for the same condition.
+fn dict_not_found_error(reference: &std::path::Path) -> anyhow::Error {
+    anyhow!(
+        "Reference dictionary file not found. Tried:\n  \
+            - {}\n  \
+            - {}.dict\n\
+            Please run: samtools dict {} -o {}",
+        reference.with_extension("dict").display(),
+        reference.display(),
+        reference.display(),
+        reference.with_extension("dict").display()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_phase_threads;
+
+    /// Pin the per-phase thread resolution contract shared by the standalone and
+    /// streaming sort branches in `add_sort`: each phase falls back to the base
+    /// sorter-thread count when no explicit override is supplied, and is clamped
+    /// to at least 1. Exercises the production `resolve_phase_threads` helper
+    /// directly so it cannot drift from the code `add_sort` actually runs.
+    #[test]
+    fn sole_stage_sort_resolves_per_phase_threads() {
+        let num_sorter_threads = 8usize;
+
+        // Explicit overrides are used as-is (clamped ≥ 1).
+        assert_eq!(resolve_phase_threads(Some(1), num_sorter_threads), 1);
+        assert_eq!(resolve_phase_threads(Some(2), num_sorter_threads), 2);
+        // Zero is clamped to 1.
+        assert_eq!(resolve_phase_threads(Some(0), num_sorter_threads), 1);
+        // None falls back to num_sorter_threads.
+        assert_eq!(resolve_phase_threads(None, num_sorter_threads), 8);
+        // The `>= 1` clamp also applies to the fallback branch: a zero base
+        // sorter-thread count is clamped to 1, not passed through as 0. (Pins
+        // the fallback clamp so an impl that clamps only the override branch
+        // fails here.)
+        assert_eq!(resolve_phase_threads(None, 0), 1);
+        // And both zero at once still clamps to 1.
+        assert_eq!(resolve_phase_threads(Some(0), 0), 1);
+    }
+}

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -1176,8 +1176,13 @@ impl<'a> ChainBuilder<'a> {
             self.tuning.per_step_byte_limit,
         );
         let tail = self.pipeline.append_source(read_step);
-        let tail =
-            self.pipeline.append_step(BgzfDecompress::new(self.tuning.per_step_byte_limit), tail);
+        // Honor the command's CRC-verification policy (`--check-crc` /
+        // `--no-check-crc`, via `effective_check_crc`) so the chain's BAM
+        // decode matches the non-chain path rather than always verifying.
+        let tail = self.pipeline.append_step(
+            BgzfDecompress::new_with_crc(self.tuning.per_step_byte_limit, self.spec.verify_crc),
+            tail,
+        );
         let tail = self
             .pipeline
             .append_step(FindBamBoundaries::new(self.tuning.per_step_byte_limit), tail);

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -1554,9 +1554,7 @@ impl<'a> ChainBuilder<'a> {
         // report, since neither `collect_stats()` nor the env var is set.
         let user_wants_stats = self.spec.scheduler.collect_stats()
             || super::build_helpers::env_flag_enabled("FGUMI_PIPELINE_STATS");
-        if user_wants_stats
-            && let Some(s) = pipeline_stats
-        {
+        if user_wants_stats && let Some(s) = pipeline_stats {
             self.finalize.push(Box::new(PipelineStatsFinalizeHook { stats: s }));
         }
 
@@ -2850,10 +2848,11 @@ impl<'a> ChainBuilder<'a> {
         info!("{}", self.spec.threading.log_message());
         info!("Using pipeline with {num_threads} threads");
 
-        // Check sort order — identical validation to GroupReadsByUmi::execute.
-        // Sort-order precondition + info logging, shared verbatim with
-        // `Group::execute`'s single-threaded path (see `require_group_input_sort`).
-        crate::commands::common::require_group_input_sort(&self.header, group.allow_unmapped)?;
+        // Record-ordering precondition + info/warn logging, shared verbatim
+        // with `Group::execute` (see `require_group_input_ordering`) so the two
+        // orchestrations of the group stage cannot drift on accepted orders,
+        // error text, or logging.
+        crate::commands::common::require_group_input_ordering(&self.header, group.allow_unmapped)?;
 
         // Tag constants per SAM specification.
         let raw_tag: [u8; 2] = *SamTag::RX;

--- a/src/lib/pipeline/chains/commands/align.rs
+++ b/src/lib/pipeline/chains/commands/align.rs
@@ -1,0 +1,40 @@
+//! Chain builder support for [`crate::pipeline::chains::Stage::Align`].
+//!
+//! `AlignFinalizeHook` is the post-pipeline hook for the `AlignAndMerge`
+//! stage. It logs the records-aligned count and calls
+//! `timer.log_completion`.
+//!
+//! `add_align` (on [`crate::pipeline::chains::builder::ChainBuilder`])
+//! registers this hook for every chain that includes `Stage::Align`.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::Result;
+use log::info;
+
+use crate::logging::OperationTimer;
+use crate::pipeline::chains::FinalizeHook;
+
+/// Post-pipeline finalize hook for the `AlignAndMerge` stage.
+///
+/// Logs the number of records that left the aligner and were merged
+/// downstream (AAM's `records_emitted` counter), then calls
+/// `timer.log_completion` so the per-stage wall-time line appears in
+/// the log.
+pub(crate) struct AlignFinalizeHook {
+    /// Counter atomically incremented by `AlignAndMergeStep` as it
+    /// emits `BamTemplateBatch`es downstream.
+    pub(crate) records_emitted: Arc<AtomicU64>,
+    pub(crate) timer: OperationTimer,
+}
+
+impl FinalizeHook for AlignFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let AlignFinalizeHook { records_emitted, timer } = *self;
+        let n = records_emitted.load(Ordering::Relaxed);
+        info!("AlignAndMerge: pipeline completed successfully ({n} records emitted)");
+        timer.log_completion(n);
+        Ok(())
+    }
+}

--- a/src/lib/pipeline/chains/commands/clip.rs
+++ b/src/lib/pipeline/chains/commands/clip.rs
@@ -4,10 +4,8 @@
 //! Phase 3 (T3a.5) lifts that logic into
 //! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
 //! now holds the clip-specific types and step factories that the builder
-//! imports: [`ClipAtomicMetrics`], [`ClipFinalizeHook`], and the two
+//! imports: `ClipAtomicMetrics`, `ClipFinalizeHook`, and the two
 //! step-factory functions used by `ChainBuilder::add_clip`.
-//!
-//! [`build_clip_chain`] shrinks to a ~10-line delegate.
 
 use std::io;
 use std::sync::Arc;
@@ -18,8 +16,7 @@ use log::info;
 
 use crate::clipper::RawRecordClipper;
 use crate::logging::OperationTimer;
-use crate::pipeline::chains::builder::ChainBuilder;
-use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
+use crate::pipeline::chains::FinalizeHook;
 use crate::pipeline::steps::process::{ProcessOrdered, process_ordered};
 use crate::pipeline::steps::serialize::SerializeBamRecords;
 use crate::pipeline::steps::types::BamTemplateBatch;
@@ -34,7 +31,7 @@ use fgumi_raw_bam::RawRecord;
 /// the `ClipTemplates` step; each closure call adds its per-batch counts
 /// via `fetch_add(_, Relaxed)`.
 ///
-/// `pub(crate)` so [`ChainBuilder`] can construct and pass it to the step
+/// `pub(crate)` so `ChainBuilder` can construct and pass it to the step
 /// factories and the finalize hook in `add_clip`.
 pub(crate) struct ClipAtomicMetrics {
     pub(crate) total_templates: AtomicU64,
@@ -59,7 +56,7 @@ impl Default for ClipAtomicMetrics {
 /// Post-pipeline finalize hook for clip. Reads atomic counters, logs
 /// the summary banner, and calls `timer.log_completion`.
 ///
-/// `pub(crate)` so [`ChainBuilder`] can construct and register it in
+/// `pub(crate)` so `ChainBuilder` can construct and register it in
 /// `add_clip`.
 pub(crate) struct ClipFinalizeHook {
     pub(crate) metrics: Arc<ClipAtomicMetrics>,
@@ -102,7 +99,7 @@ impl FinalizeHook for ClipFinalizeHook {
 /// Bundles all the cloned scalars and Arcs the closure needs so `add_clip`
 /// can prepare them once and hand them off cleanly.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_clip`] and
+/// `pub(crate)` — consumed only by `ChainBuilder::add_clip` and
 /// [`build_clip_process_step`].
 ///
 /// The five boolean fields reflect the five independent clipping control
@@ -131,7 +128,7 @@ pub(crate) struct ClipProcessCaptures {
 /// emitting a fresh [`BamTemplateBatch`] carrying the same `batch_serial`
 /// so downstream order is preserved.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_clip`].
+/// `pub(crate)` — consumed only by `ChainBuilder::add_clip`.
 #[allow(clippy::type_complexity)]
 pub(crate) fn build_clip_process_step(
     limit_bytes: u64,
@@ -287,32 +284,7 @@ pub(crate) fn build_clip_process_step(
 /// for `Intermediate` the chain tail stays as [`BamTemplateBatch`] for the
 /// next stage's input.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_clip`].
+/// `pub(crate)` — consumed only by `ChainBuilder::add_clip`.
 pub(crate) fn build_clip_serialize_step(limit_bytes: u64) -> SerializeBamRecords {
     SerializeBamRecords::new(limit_bytes)
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// build_clip_chain — thin delegate (Phase 3 T3a.5)
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Build a [`BuiltPipeline`] for a clip-only chain.
-///
-/// Delegates to [`ChainBuilder`]. The full step sequence lives in
-/// [`ChainBuilder`]'s `add_clip` method in
-/// [`crate::pipeline::chains::builder`].
-///
-/// # Errors
-///
-/// Returns input-validation errors (reference FASTA missing, no clipping
-/// operation requested, `--metrics` + `--threads` conflict, etc.), or any
-/// underlying pipeline construction error.
-#[allow(clippy::needless_pass_by_value)]
-pub fn build_clip_chain(spec: ChainSpec) -> Result<BuiltPipeline> {
-    use crate::pipeline::chains::{Stage, builder::StagePosition};
-    let mut chain = ChainBuilder::new(&spec)?;
-    chain.add_source()?;
-    chain.add_stage(Stage::Clip, StagePosition::Terminal)?;
-    chain.add_sink()?;
-    chain.build()
 }

--- a/src/lib/pipeline/chains/commands/clip.rs
+++ b/src/lib/pipeline/chains/commands/clip.rs
@@ -1,0 +1,318 @@
+//! Chain builder for `Stage::Clip`.
+//!
+//! Phase 2 (T2.15) held the full ~400-LOC chain construction here.
+//! Phase 3 (T3a.5) lifts that logic into
+//! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
+//! now holds the clip-specific types and step factories that the builder
+//! imports: [`ClipAtomicMetrics`], [`ClipFinalizeHook`], and the two
+//! step-factory functions used by `ChainBuilder::add_clip`.
+//!
+//! [`build_clip_chain`] shrinks to a ~10-line delegate.
+
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::Result;
+use log::info;
+
+use crate::clipper::RawRecordClipper;
+use crate::logging::OperationTimer;
+use crate::pipeline::chains::builder::ChainBuilder;
+use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
+use crate::pipeline::steps::process::{ProcessOrdered, process_ordered};
+use crate::pipeline::steps::serialize::SerializeBamRecords;
+use crate::pipeline::steps::types::BamTemplateBatch;
+use crate::reference::ReferenceReader;
+use fgumi_raw_bam::RawRecord;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ClipAtomicMetrics
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Atomic counters for clip metrics. Shared across all worker clones of
+/// the `ClipTemplates` step; each closure call adds its per-batch counts
+/// via `fetch_add(_, Relaxed)`.
+///
+/// `pub(crate)` so [`ChainBuilder`] can construct and pass it to the step
+/// factories and the finalize hook in `add_clip`.
+pub(crate) struct ClipAtomicMetrics {
+    pub(crate) total_templates: AtomicU64,
+    pub(crate) overlap_clipped: AtomicU64,
+    pub(crate) extend_clipped: AtomicU64,
+}
+
+impl Default for ClipAtomicMetrics {
+    fn default() -> Self {
+        Self {
+            total_templates: AtomicU64::new(0),
+            overlap_clipped: AtomicU64::new(0),
+            extend_clipped: AtomicU64::new(0),
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ClipFinalizeHook
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Post-pipeline finalize hook for clip. Reads atomic counters, logs
+/// the summary banner, and calls `timer.log_completion`.
+///
+/// `pub(crate)` so [`ChainBuilder`] can construct and register it in
+/// `add_clip`.
+pub(crate) struct ClipFinalizeHook {
+    pub(crate) metrics: Arc<ClipAtomicMetrics>,
+    pub(crate) progress_counter: Arc<AtomicU64>,
+    pub(crate) timer: OperationTimer,
+}
+
+impl FinalizeHook for ClipFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let ClipFinalizeHook { metrics, progress_counter, timer } = *self;
+
+        let total_templates = metrics.total_templates.load(Ordering::Relaxed);
+        let total_overlap_clipped = metrics.overlap_clipped.load(Ordering::Relaxed);
+        let total_extend_clipped = metrics.extend_clipped.load(Ordering::Relaxed);
+        let records_written = progress_counter.load(Ordering::Relaxed);
+
+        info!("Total templates processed: {total_templates}");
+        info!("Templates with overlap clipping: {total_overlap_clipped}");
+        info!("Templates with mate extension clipping: {total_extend_clipped}");
+        info!("Done!");
+
+        timer.log_completion(records_written);
+
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Step factories — extracted from build_clip_chain (T3a.5).
+//
+// Each factory receives its captured state as plain arguments and returns the
+// concrete step type. Returning `impl Step<...>` is blocked here because the
+// closure types embed in opaque-return position and cannot name themselves, so
+// we return the concrete `Process*` structs directly (the same pattern used by
+// the dedup factories in `chains::commands::dedup`).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Captures passed into [`build_clip_process_step`] from `add_clip`.
+///
+/// Bundles all the cloned scalars and Arcs the closure needs so `add_clip`
+/// can prepare them once and hand them off cleanly.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_clip`] and
+/// [`build_clip_process_step`].
+///
+/// The five boolean fields reflect the five independent clipping control
+/// flags from the `Clip` command struct. Refactoring into a state-machine
+/// enum is not warranted here — each flag is checked individually in the
+/// hot-path closure.
+#[allow(clippy::struct_excessive_bools)]
+pub(crate) struct ClipProcessCaptures {
+    pub(crate) clipping_mode: crate::clipper::ClippingMode,
+    pub(crate) auto_clip_attributes: bool,
+    pub(crate) upgrade_clipping: bool,
+    pub(crate) clip_overlapping_reads: bool,
+    pub(crate) clip_extending_past_mate: bool,
+    pub(crate) read_one_five_prime: usize,
+    pub(crate) read_one_three_prime: usize,
+    pub(crate) read_two_five_prime: usize,
+    pub(crate) read_two_three_prime: usize,
+    pub(crate) header: noodles::sam::Header,
+    pub(crate) reference: Arc<ReferenceReader>,
+    pub(crate) metrics: Arc<ClipAtomicMetrics>,
+    pub(crate) progress: Arc<AtomicU64>,
+}
+
+/// Build the `ClipTemplates` step: parallel, `ByItemOrdinal`. Operates in
+/// place on the records of each [`BamTemplateBatch`], regenerating tags and
+/// emitting a fresh [`BamTemplateBatch`] carrying the same `batch_serial`
+/// so downstream order is preserved.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_clip`].
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_clip_process_step(
+    limit_bytes: u64,
+    cap: ClipProcessCaptures,
+) -> ProcessOrdered<
+    BamTemplateBatch,
+    BamTemplateBatch,
+    impl Fn(BamTemplateBatch) -> io::Result<BamTemplateBatch> + Send + Sync + 'static,
+> {
+    process_ordered::<BamTemplateBatch, BamTemplateBatch, _>(
+        "ClipTemplates",
+        limit_bytes,
+        move |batch: BamTemplateBatch| -> io::Result<BamTemplateBatch> {
+            use crate::alignment_tags::regenerate_alignment_tags_raw;
+            use crate::commands::clip::update_mate_info_raw;
+
+            // Per-worker clipper: cheap to construct (no large state).
+            let clipper = if cap.auto_clip_attributes {
+                RawRecordClipper::with_auto_clip(cap.clipping_mode, true)
+            } else {
+                RawRecordClipper::new(cap.clipping_mode)
+            };
+
+            let (batch_serial, mut templates) = batch.into_parts();
+            let mut local_templates: u64 = 0;
+            let mut local_overlap_clipped: u64 = 0;
+            let mut local_extend_clipped: u64 = 0;
+            let mut local_record_count: u64 = 0;
+
+            for template in &mut templates {
+                local_templates += 1;
+                // Mutate the template's records in place. The earlier
+                // version of this closure cloned `template.name` and
+                // re-allocated a fresh `Template` per template — that
+                // showed up as ~6% extra mimalloc CPU in profiling
+                // (mi_page_free_list_extend, mi_free) and pushed the
+                // new pipeline ~7% behind legacy at threads=4. Mutating
+                // in place keeps allocation count near-equal to legacy.
+                let records: &mut Vec<RawRecord> = &mut template.records;
+
+                // KNOWN DIVERGENCE — MUST be resolved in the clip wiring PR
+                // (this chain path is dormant / has no callers today, so the
+                // divergence cannot yet reach output; the wiring PR must add
+                // byte-parity tests vs the standalone `clip`). This closure
+                // reimplements per-template clipping and has drifted from the
+                // canonical `ClipParams::clip_template` (src/lib/commands/clip.rs)
+                // in two ways:
+                //   1. It selects R1/R2 by POSITIONAL index (records[0]/[1]) and
+                //      does nothing for templates with >=3 records
+                //      (secondary/supplementary), whereas `clip_template` finds
+                //      the primary pair by SAM flag and upgrades all reads.
+                //   2. Fixed-position clipping calls `clip_*_end_of_alignment`
+                //      (clip N MORE aligned bases) where the canonical path calls
+                //      `clip_*_end_of_read_raw` (ensure at least N total clipped),
+                //      so this over-clips any read already carrying soft/hard clips.
+                // Fix: expose `ClipParams`/`clip_template` as `pub(crate)` and
+                // delegate to it here instead of reimplementing the loop.
+                if records.len() == 1 {
+                    let record = &mut records[0];
+                    if cap.upgrade_clipping {
+                        clipper.upgrade_all_clipping_raw(record).map_err(io::Error::other)?;
+                    }
+                    if cap.read_one_five_prime > 0 {
+                        clipper.clip_5_prime_end_of_alignment(record, cap.read_one_five_prime);
+                    }
+                    if cap.read_one_three_prime > 0 {
+                        clipper.clip_3_prime_end_of_alignment(record, cap.read_one_three_prime);
+                    }
+                } else if records.len() == 2 {
+                    let (r1_slice, r2_slice) = records.split_at_mut(1);
+                    let r1 = &mut r1_slice[0];
+                    let r2 = &mut r2_slice[0];
+
+                    if cap.upgrade_clipping {
+                        clipper.upgrade_all_clipping_raw(r1).map_err(io::Error::other)?;
+                        clipper.upgrade_all_clipping_raw(r2).map_err(io::Error::other)?;
+                    }
+
+                    let is_r1_first = r1.is_first_segment();
+                    let is_r2_last = r2.is_last_segment();
+
+                    if is_r1_first && cap.read_one_five_prime > 0 {
+                        clipper.clip_5_prime_end_of_alignment(r1, cap.read_one_five_prime);
+                    } else if !is_r1_first && cap.read_two_five_prime > 0 {
+                        clipper.clip_5_prime_end_of_alignment(r1, cap.read_two_five_prime);
+                    }
+                    if is_r1_first && cap.read_one_three_prime > 0 {
+                        clipper.clip_3_prime_end_of_alignment(r1, cap.read_one_three_prime);
+                    } else if !is_r1_first && cap.read_two_three_prime > 0 {
+                        clipper.clip_3_prime_end_of_alignment(r1, cap.read_two_three_prime);
+                    }
+                    if is_r2_last && cap.read_two_five_prime > 0 {
+                        clipper.clip_5_prime_end_of_alignment(r2, cap.read_two_five_prime);
+                    } else if !is_r2_last && cap.read_one_five_prime > 0 {
+                        clipper.clip_5_prime_end_of_alignment(r2, cap.read_one_five_prime);
+                    }
+                    if is_r2_last && cap.read_two_three_prime > 0 {
+                        clipper.clip_3_prime_end_of_alignment(r2, cap.read_two_three_prime);
+                    } else if !is_r2_last && cap.read_one_three_prime > 0 {
+                        clipper.clip_3_prime_end_of_alignment(r2, cap.read_one_three_prime);
+                    }
+
+                    if cap.clip_overlapping_reads {
+                        let (n1, n2) = clipper.clip_overlapping_reads(r1, r2);
+                        if n1 > 0 || n2 > 0 {
+                            local_overlap_clipped += 1;
+                        }
+                    }
+                    if cap.clip_extending_past_mate {
+                        let (n1, n2) = clipper.clip_extending_past_mate_ends(r1, r2);
+                        if n1 > 0 || n2 > 0 {
+                            local_extend_clipped += 1;
+                        }
+                    }
+
+                    update_mate_info_raw(r1, r2);
+                    update_mate_info_raw(r2, r1);
+                }
+
+                // Regenerate alignment tags for every record.
+                for record in records.iter_mut() {
+                    regenerate_alignment_tags_raw(record.as_mut_vec(), &cap.header, &cap.reference)
+                        .map_err(io::Error::other)?;
+                }
+
+                local_record_count += records.len() as u64;
+            }
+
+            // Aggregate metrics (relaxed atomics, lock-free).
+            cap.metrics.total_templates.fetch_add(local_templates, Ordering::Relaxed);
+            cap.metrics.overlap_clipped.fetch_add(local_overlap_clipped, Ordering::Relaxed);
+            cap.metrics.extend_clipped.fetch_add(local_extend_clipped, Ordering::Relaxed);
+
+            // Progress logging (record granularity matches legacy).
+            let prev = cap.progress.fetch_add(local_record_count, Ordering::Relaxed);
+            if (prev + local_record_count) / 1_000_000 > prev / 1_000_000 {
+                info!("Processed {} records", prev + local_record_count);
+            }
+
+            // Recompute total_bytes since clipping changed record sizes;
+            // BamTemplateBatch::new sums Template::heap_size for us.
+            Ok(BamTemplateBatch::new(batch_serial, templates))
+        },
+    )
+}
+
+/// Build the `SerializeBamRecords` step for clip: parallel, `ByItemOrdinal`.
+/// Serializes each [`BamTemplateBatch`] to raw BAM bytes
+/// ([`crate::pipeline::steps::types::DecompressedBlock`]).
+///
+/// Only included in the chain when the stage is
+/// [`StagePosition::Terminal`][`crate::pipeline::chains::builder::StagePosition`];
+/// for `Intermediate` the chain tail stays as [`BamTemplateBatch`] for the
+/// next stage's input.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_clip`].
+pub(crate) fn build_clip_serialize_step(limit_bytes: u64) -> SerializeBamRecords {
+    SerializeBamRecords::new(limit_bytes)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// build_clip_chain — thin delegate (Phase 3 T3a.5)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build a [`BuiltPipeline`] for a clip-only chain.
+///
+/// Delegates to [`ChainBuilder`]. The full step sequence lives in
+/// [`ChainBuilder`]'s `add_clip` method in
+/// [`crate::pipeline::chains::builder`].
+///
+/// # Errors
+///
+/// Returns input-validation errors (reference FASTA missing, no clipping
+/// operation requested, `--metrics` + `--threads` conflict, etc.), or any
+/// underlying pipeline construction error.
+#[allow(clippy::needless_pass_by_value)]
+pub fn build_clip_chain(spec: ChainSpec) -> Result<BuiltPipeline> {
+    use crate::pipeline::chains::{Stage, builder::StagePosition};
+    let mut chain = ChainBuilder::new(&spec)?;
+    chain.add_source()?;
+    chain.add_stage(Stage::Clip, StagePosition::Terminal)?;
+    chain.add_sink()?;
+    chain.build()
+}

--- a/src/lib/pipeline/chains/commands/codec.rs
+++ b/src/lib/pipeline/chains/commands/codec.rs
@@ -1,0 +1,393 @@
+//! Chain builder for `Stage::Codec`.
+//!
+//! Phase 2 (T2.20) held the full ~490-LOC chain construction here.
+//! Phase 3 (T3a.10) lifts that logic into
+//! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
+//! now holds the codec-specific types and step factory that the builder
+//! imports: [`CodecFinalizeHook`] and the `build_codec_consensus_step_with_rejects` / `build_codec_consensus_step_kept_only` factories, used
+//! by `ChainBuilder::add_codec`.
+//!
+//! [`build_codec_chain`] shrinks to a ~10-line delegate.
+//!
+//! Mirrors duplex (2dc8bd8). Codec's chain is structurally the same with a
+//! different consensus caller and no MI-tag transform, overlapping consensus,
+//! or methylation mode — matching fgbio's `CallCodecConsensusReads` behaviour.
+//!
+//! This is the chain-builder construction path for the codec stage, consumed via
+//! [`ChainBuilder`] / [`crate::pipeline::chains::build::build_for`]. It is not
+//! yet wired as `Codec::execute`'s live path.
+
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::Result;
+use log::info;
+
+use crate::commands::consensus_runner::ConsensusStatsOps;
+use crate::consensus::codec_caller::{
+    CodecConsensusCaller, CodecConsensusOptions, CodecConsensusStats,
+};
+use crate::consensus_caller::ConsensusOutput;
+use crate::logging::OperationTimer;
+use crate::mi_group::MiGroup;
+use crate::per_thread_accumulator::PerThreadAccumulator;
+use crate::pipeline::chains::builder::ChainBuilder;
+use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
+use crate::pipeline::core::outputs::OrderedBytesTuple2;
+use crate::pipeline::core::step::Step;
+use crate::pipeline::steps::group::mi::BatchedMiGroups;
+use crate::pipeline::steps::process::{
+    Process2Output, ProcessWithWorkerState, process_with_worker_state, process2_with_worker_state,
+};
+use crate::pipeline::steps::types::DecompressedBlock;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CollectedCodecMetrics
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Per-thread accumulator for codec consensus metrics (mirrors
+/// `commands::codec::CollectedCodecMetrics`).
+///
+/// Merged into final aggregates after the pipeline completes; one instance
+/// per worker slot (see [`PerThreadAccumulator`]).
+///
+/// `pub(crate)` so [`ChainBuilder`] can construct it in `add_codec`.
+#[derive(Default)]
+pub(crate) struct CollectedCodecMetrics {
+    /// CODEC consensus calling statistics.
+    pub(crate) stats: CodecConsensusStats,
+    /// Number of MI groups processed.
+    pub(crate) groups_processed: u64,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CodecState
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Per-worker state for the codec consensus step.
+///
+/// Defined at module level (not inside a function body) to avoid the
+/// `clippy::items_after_statements` lint that fires when a struct is defined
+/// after executable statements in a function body.
+pub(crate) struct CodecState {
+    pub(crate) caller: CodecConsensusCaller,
+}
+
+impl crate::pipeline::core::item::HeapSize for CodecState {}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CodecFinalizeHook
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Post-pipeline finalize hook for codec. Reduces per-thread metrics,
+/// writes the optional stats file, logs the summary banner, finalizes
+/// the rejects writer, and calls `timer.log_completion`.
+///
+/// `pub(crate)` so [`ChainBuilder`] can construct and register it in
+/// `add_codec`.
+pub(crate) struct CodecFinalizeHook {
+    pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedCodecMetrics>>,
+    pub(crate) stats_path: Option<std::path::PathBuf>,
+    pub(crate) timer: OperationTimer,
+}
+
+impl FinalizeHook for CodecFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let CodecFinalizeHook { accumulators, stats_path, timer } = *self;
+
+        // Reduce per-thread accumulators.
+        let mut total_groups = 0u64;
+        let mut merged_stats = CodecConsensusStats::default();
+
+        for slot in accumulators.slots() {
+            let m = slot.lock();
+            total_groups += m.groups_processed;
+            merged_stats.merge(&m.stats);
+        }
+
+        info!("CODEC consensus calling complete");
+        info!("Total MI groups processed: {total_groups}");
+
+        let metrics = merged_stats.to_metrics();
+        let consensus_count = metrics.consensus_reads;
+        crate::logging::log_consensus_summary(&metrics);
+
+        if let Some(ref stats_path) = stats_path {
+            use fgoxide::io::DelimFile;
+            // Write the key-value stats format, matching the standalone
+            // `Codec::finalize_stats` and the sibling simplex/duplex chain hooks;
+            // the wide-table `[metrics]` form diverged from both.
+            let kv_metrics = metrics.to_kv_metrics(fgumi_metrics::ConsensusCallerKind::Codec);
+            DelimFile::default().write_tsv(stats_path, kv_metrics).map_err(|e| {
+                anyhow::anyhow!("Failed to write statistics: {}: {e}", stats_path.display())
+            })?;
+            info!("Wrote statistics to: {}", stats_path.display());
+        }
+
+        info!("Wrote {consensus_count} CODEC consensus reads");
+
+        // Rejects are emitted on the consensus step's second output branch
+        // (fan-out) and finalized by the rejects branch's WriteBgzfFile sink.
+
+        timer.log_completion(consensus_count);
+
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Step factory — extracted from build_codec_chain (T3a.10).
+//
+// Returns the concrete `ProcessWithWorkerState` type directly (the same
+// pattern used by duplex and simplex in this module family). Returning
+// `impl Step<...>` is blocked here because the closure types embed in
+// opaque-return position and cannot name themselves.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Captures passed into [`build_codec_consensus_step_with_rejects`] / [`build_codec_consensus_step_kept_only`] from `add_codec`.
+///
+/// Bundles all the cloned scalars and Arcs the closure needs so `add_codec`
+/// can prepare them once and hand them off cleanly.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_codec`] and
+/// [`build_codec_consensus_step_with_rejects`] / [`build_codec_consensus_step_kept_only`].
+pub(crate) struct CodecConsensusCaptures {
+    pub(crate) track_rejects: bool,
+    pub(crate) read_name_prefix: String,
+    pub(crate) read_group_id: String,
+    pub(crate) consensus_options: CodecConsensusOptions,
+    pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedCodecMetrics>>,
+    pub(crate) progress: Arc<AtomicU64>,
+}
+
+/// Per-worker init: build the `CodecConsensusCaller` once, reused across
+/// batches. Shared by both step variants.
+fn make_codec_consensus_init(
+    read_name_prefix: String,
+    read_group_id: String,
+    consensus_options: CodecConsensusOptions,
+    track_rejects: bool,
+) -> impl Fn() -> CodecState + Send + Sync + 'static {
+    move || {
+        let caller = CodecConsensusCaller::new_with_rejects_tracking(
+            read_name_prefix.clone(),
+            read_group_id.clone(),
+            consensus_options.clone(),
+            track_rejects,
+        );
+        CodecState { caller }
+    }
+}
+
+/// Per-batch CODEC consensus body, shared by both step variants.
+///
+/// Returns the consensus `DecompressedBlock` (branch 0) and, when
+/// `track_rejects` is set and any record was rejected, a rejects
+/// `DecompressedBlock` (branch 1) of `[len][record]`-framed raw-input records
+/// in input order — the PR #332 fan-out contract (rejects flow through the
+/// ordered serialize/compress stages, not a mutex side-channel; the rejects
+/// writer is configured with the input header by `add_codec`).
+fn run_codec_consensus_batch(
+    state: &mut CodecState,
+    item: BatchedMiGroups,
+    track_rejects: bool,
+    accumulators: &Arc<PerThreadAccumulator<CollectedCodecMetrics>>,
+    progress: &Arc<AtomicU64>,
+) -> io::Result<(DecompressedBlock, Option<DecompressedBlock>)> {
+    let BatchedMiGroups { batch_serial, groups } = item;
+    let groups_count = groups.len() as u64;
+
+    let mut all_output = ConsensusOutput::default();
+    let mut batch_stats = CodecConsensusStats::default();
+    let mut rejects_bytes: Vec<u8> = Vec::new();
+
+    let mut total_input_records: u64 = 0;
+    for MiGroup { mi, records } in groups {
+        state.caller.clear();
+        total_input_records += records.len() as u64;
+
+        // Use the typed entry point so recoverable "duplex disagreement" errors
+        // are classified by the `CodecConsensusError::is_duplex_disagreement()`
+        // predicate, matching the standalone `recover_or_propagate_codec_error`.
+        // The generic `consensus_reads` erases the typed variant into
+        // `anyhow::Error`, which would force a fragile substring match on the
+        // Display text.
+        let result = state.caller.consensus_reads_typed(records);
+        match result {
+            Ok(group_output) => {
+                all_output.merge(group_output);
+                batch_stats.merge(state.caller.statistics());
+                if track_rejects {
+                    for raw in &state.caller.take_rejected_reads() {
+                        super::append_framed_bytes(&mut rejects_bytes, raw)?;
+                    }
+                }
+            }
+            Err(e) => {
+                // A "duplex disagreement" error isn't fatal — preserve stats +
+                // rejects and move on. Anything else is hard.
+                if e.is_duplex_disagreement() {
+                    batch_stats.merge(state.caller.statistics());
+                    if track_rejects {
+                        for raw in &state.caller.take_rejected_reads() {
+                            super::append_framed_bytes(&mut rejects_bytes, raw)?;
+                        }
+                    }
+                } else {
+                    // `{:#}` on the anyhow view preserves the nested cause chain,
+                    // matching the context group.rs keeps for an equivalent failure.
+                    let err = anyhow::Error::from(e);
+                    return Err(io::Error::other(format!(
+                        "CODEC consensus error for MI {mi}: {err:#}"
+                    )));
+                }
+            }
+        }
+    }
+
+    // Merge per-batch metrics into this worker's slot.
+    accumulators.with_slot(|m| {
+        m.stats.merge(&batch_stats);
+        m.groups_processed += groups_count;
+    });
+
+    // Progress logging at million-record boundaries.
+    let prev = progress.fetch_add(total_input_records, Ordering::Relaxed);
+    if (prev + total_input_records) / 1_000_000 > prev / 1_000_000 {
+        info!("Processed {} records", prev + total_input_records);
+    }
+
+    let consensus = DecompressedBlock { batch_serial, bytes: all_output.data };
+    let rejects = if rejects_bytes.is_empty() {
+        None
+    } else {
+        Some(DecompressedBlock { batch_serial, bytes: rejects_bytes })
+    };
+    Ok((consensus, rejects))
+}
+
+/// Build the 2-output `CodecConsensus` step (used when `--rejects` is set):
+/// branch 0 = consensus, branch 1 = rejects.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_codec`].
+pub(crate) fn build_codec_consensus_step_with_rejects(
+    limit_bytes: u64,
+    cap: CodecConsensusCaptures,
+) -> impl Step<Input = BatchedMiGroups, Outputs = OrderedBytesTuple2<DecompressedBlock, DecompressedBlock>>
+{
+    let CodecConsensusCaptures {
+        track_rejects,
+        read_name_prefix,
+        read_group_id,
+        consensus_options,
+        accumulators,
+        progress,
+    } = cap;
+
+    let init = make_codec_consensus_init(
+        read_name_prefix,
+        read_group_id,
+        consensus_options,
+        track_rejects,
+    );
+    let body = move |state: &mut CodecState,
+                     item: BatchedMiGroups|
+          -> io::Result<Process2Output<DecompressedBlock, DecompressedBlock>> {
+        let (consensus, rejects) =
+            run_codec_consensus_batch(state, item, track_rejects, &accumulators, &progress)?;
+        if let Some(r) = rejects {
+            Ok(Process2Output::both(consensus, r))
+        } else {
+            // X5-001: an all-clean batch must still emit a (zero-byte) rejects
+            // block so the rejects branch's `ByItemOrdinal` reorder stage sees a
+            // dense serial sequence; pushing nothing (`only_a`) leaves a gap at
+            // this serial that wedges the rejects sink. The empty `Vec` does not
+            // allocate and produces no physical BGZF block.
+            let batch_serial = consensus.batch_serial;
+            Ok(Process2Output::both(
+                consensus,
+                DecompressedBlock { batch_serial, bytes: Vec::new() },
+            ))
+        }
+    };
+
+    process2_with_worker_state::<
+        BatchedMiGroups,
+        DecompressedBlock,
+        DecompressedBlock,
+        CodecState,
+        _,
+        _,
+    >("CodecConsensus", limit_bytes, limit_bytes, init, body)
+}
+
+/// Build the 1-output kept-only `CodecConsensus` step (used when `--rejects`
+/// is unset). The framework has no public discard sink, so omitting the rejects
+/// branch requires this single-output variant.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_codec`].
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_codec_consensus_step_kept_only(
+    limit_bytes: u64,
+    cap: CodecConsensusCaptures,
+) -> ProcessWithWorkerState<
+    BatchedMiGroups,
+    DecompressedBlock,
+    impl Fn(&mut CodecState, BatchedMiGroups) -> io::Result<DecompressedBlock> + Send + Sync + 'static,
+    CodecState,
+    impl Fn() -> CodecState + Send + Sync + 'static,
+> {
+    let CodecConsensusCaptures {
+        track_rejects,
+        read_name_prefix,
+        read_group_id,
+        consensus_options,
+        accumulators,
+        progress,
+    } = cap;
+
+    let init = make_codec_consensus_init(
+        read_name_prefix,
+        read_group_id,
+        consensus_options,
+        track_rejects,
+    );
+    let body =
+        move |state: &mut CodecState, item: BatchedMiGroups| -> io::Result<DecompressedBlock> {
+            let (consensus, _rejects) =
+                run_codec_consensus_batch(state, item, track_rejects, &accumulators, &progress)?;
+            Ok(consensus)
+        };
+
+    process_with_worker_state::<BatchedMiGroups, DecompressedBlock, _, CodecState, _>(
+        "CodecConsensus",
+        limit_bytes,
+        init,
+        body,
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// build_codec_chain — thin delegate (Phase 3 T3a.10)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build a [`BuiltPipeline`] for a codec-only chain.
+///
+/// Delegates to [`ChainBuilder`]. The full step sequence lives in
+/// [`ChainBuilder`]'s `add_codec` method in
+/// [`crate::pipeline::chains::builder`].
+///
+/// # Errors
+///
+/// Returns input-validation errors (missing file, etc.) or any underlying
+/// pipeline construction error.
+#[allow(clippy::needless_pass_by_value)]
+pub fn build_codec_chain(spec: ChainSpec) -> Result<BuiltPipeline> {
+    use crate::pipeline::chains::{Stage, builder::StagePosition};
+    let mut chain = ChainBuilder::new(&spec)?;
+    chain.add_source()?;
+    chain.add_stage(Stage::Codec, StagePosition::Terminal)?;
+    chain.add_sink()?;
+    chain.build()
+}

--- a/src/lib/pipeline/chains/commands/codec.rs
+++ b/src/lib/pipeline/chains/commands/codec.rs
@@ -4,17 +4,15 @@
 //! Phase 3 (T3a.10) lifts that logic into
 //! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
 //! now holds the codec-specific types and step factory that the builder
-//! imports: [`CodecFinalizeHook`] and the `build_codec_consensus_step_with_rejects` / `build_codec_consensus_step_kept_only` factories, used
+//! imports: `CodecFinalizeHook` and the `build_codec_consensus_step_with_rejects` / `build_codec_consensus_step_kept_only` factories, used
 //! by `ChainBuilder::add_codec`.
-//!
-//! [`build_codec_chain`] shrinks to a ~10-line delegate.
 //!
 //! Mirrors duplex (2dc8bd8). Codec's chain is structurally the same with a
 //! different consensus caller and no MI-tag transform, overlapping consensus,
 //! or methylation mode — matching fgbio's `CallCodecConsensusReads` behaviour.
 //!
 //! This is the chain-builder construction path for the codec stage, consumed via
-//! [`ChainBuilder`] / [`crate::pipeline::chains::build::build_for`]. It is not
+//! `ChainBuilder` / [`crate::pipeline::chains::build::build_for`]. It is not
 //! yet wired as `Codec::execute`'s live path.
 
 use std::io;
@@ -32,8 +30,7 @@ use crate::consensus_caller::ConsensusOutput;
 use crate::logging::OperationTimer;
 use crate::mi_group::MiGroup;
 use crate::per_thread_accumulator::PerThreadAccumulator;
-use crate::pipeline::chains::builder::ChainBuilder;
-use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
+use crate::pipeline::chains::FinalizeHook;
 use crate::pipeline::core::outputs::OrderedBytesTuple2;
 use crate::pipeline::core::step::Step;
 use crate::pipeline::steps::group::mi::BatchedMiGroups;
@@ -52,7 +49,7 @@ use crate::pipeline::steps::types::DecompressedBlock;
 /// Merged into final aggregates after the pipeline completes; one instance
 /// per worker slot (see [`PerThreadAccumulator`]).
 ///
-/// `pub(crate)` so [`ChainBuilder`] can construct it in `add_codec`.
+/// `pub(crate)` so `ChainBuilder` can construct it in `add_codec`.
 #[derive(Default)]
 pub(crate) struct CollectedCodecMetrics {
     /// CODEC consensus calling statistics.
@@ -84,7 +81,7 @@ impl crate::pipeline::core::item::HeapSize for CodecState {}
 /// writes the optional stats file, logs the summary banner, finalizes
 /// the rejects writer, and calls `timer.log_completion`.
 ///
-/// `pub(crate)` so [`ChainBuilder`] can construct and register it in
+/// `pub(crate)` so `ChainBuilder` can construct and register it in
 /// `add_codec`.
 pub(crate) struct CodecFinalizeHook {
     pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedCodecMetrics>>,
@@ -150,7 +147,7 @@ impl FinalizeHook for CodecFinalizeHook {
 /// Bundles all the cloned scalars and Arcs the closure needs so `add_codec`
 /// can prepare them once and hand them off cleanly.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_codec`] and
+/// `pub(crate)` — consumed only by `ChainBuilder::add_codec` and
 /// [`build_codec_consensus_step_with_rejects`] / [`build_codec_consensus_step_kept_only`].
 pub(crate) struct CodecConsensusCaptures {
     pub(crate) track_rejects: bool,
@@ -270,7 +267,7 @@ fn run_codec_consensus_batch(
 /// Build the 2-output `CodecConsensus` step (used when `--rejects` is set):
 /// branch 0 = consensus, branch 1 = rejects.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_codec`].
+/// `pub(crate)` — consumed only by `ChainBuilder::add_codec`.
 pub(crate) fn build_codec_consensus_step_with_rejects(
     limit_bytes: u64,
     cap: CodecConsensusCaptures,
@@ -326,7 +323,7 @@ pub(crate) fn build_codec_consensus_step_with_rejects(
 /// is unset). The framework has no public discard sink, so omitting the rejects
 /// branch requires this single-output variant.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_codec`].
+/// `pub(crate)` — consumed only by `ChainBuilder::add_codec`.
 #[allow(clippy::type_complexity)]
 pub(crate) fn build_codec_consensus_step_kept_only(
     limit_bytes: u64,
@@ -366,28 +363,4 @@ pub(crate) fn build_codec_consensus_step_kept_only(
         init,
         body,
     )
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// build_codec_chain — thin delegate (Phase 3 T3a.10)
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Build a [`BuiltPipeline`] for a codec-only chain.
-///
-/// Delegates to [`ChainBuilder`]. The full step sequence lives in
-/// [`ChainBuilder`]'s `add_codec` method in
-/// [`crate::pipeline::chains::builder`].
-///
-/// # Errors
-///
-/// Returns input-validation errors (missing file, etc.) or any underlying
-/// pipeline construction error.
-#[allow(clippy::needless_pass_by_value)]
-pub fn build_codec_chain(spec: ChainSpec) -> Result<BuiltPipeline> {
-    use crate::pipeline::chains::{Stage, builder::StagePosition};
-    let mut chain = ChainBuilder::new(&spec)?;
-    chain.add_source()?;
-    chain.add_stage(Stage::Codec, StagePosition::Terminal)?;
-    chain.add_sink()?;
-    chain.build()
 }

--- a/src/lib/pipeline/chains/commands/correct.rs
+++ b/src/lib/pipeline/chains/commands/correct.rs
@@ -1,0 +1,219 @@
+//! Chain builder for `Stage::Correct`.
+//!
+//! Phase 2 (T2.21) held the full ~400-LOC chain construction here.
+//! Phase 3 (T3a.11) lifts that logic into
+//! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
+//! now holds the correct-specific types and step factories that the builder
+//! imports: [`CorrectFinalizeHook`] used by `ChainBuilder::add_correct`.
+//!
+//! [`build_correct_chain`] shrinks to a ~10-line delegate.
+//!
+//! ## Four chain shapes
+//!
+//! Correct dispatches on `(input_source, track_rejects)`:
+//!
+//! - `(Bam,  false)`: `[read preamble] → GroupByQueryname → correct_step_kept_only → SerializeBamRecords`
+//! - `(Bam,  true)`:  `[read preamble] → GroupByQueryname → correct_step_with_rejects` (branch 0 kept → `SerializeBamRecords`; branch 1 rejects bytes → `BgzfCompress`+Write)
+//! - `(Sam,  false)`: `[sam preamble]  → GroupByQueryname → correct_step_kept_only  → SerializeBamRecords`
+//! - `(Sam,  true)`:  `[sam preamble]  → GroupByQueryname → correct_step_with_rejects` (same as Bam/true)
+//!
+//! The source preamble differences (BAM vs SAM) are handled by `add_source`
+//! in [`ChainBuilder`]; `add_correct` always receives a
+//! `BamTemplateBatch`-typed tail (after `GroupByQueryname`).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use ahash::AHashMap;
+use anyhow::Result;
+use log::{info, warn};
+
+use crate::commands::correct::{
+    CollectedCorrectMetrics, CorrectOptions, EncodedUmiSet, merge_umi_counts,
+};
+use crate::logging::OperationTimer;
+use crate::metrics::correct::UmiCorrectionMetrics;
+use crate::per_thread_accumulator::PerThreadAccumulator;
+use crate::pipeline::chains::builder::ChainBuilder;
+use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
+
+/// Post-pipeline finalize hook for correct. Reduces per-thread metrics,
+/// writes the optional metrics TSV, logs summary + warn banners, enforces
+/// the `--min-corrected` ratio gate, and calls `timer.log_completion`.
+///
+/// Mirrors the body of `CorrectUmis::finalize_correct_run`, extracted here so
+/// `BuiltPipeline::run` can call it after `Pipeline::run` returns.
+///
+/// `pub(crate)` so [`ChainBuilder`] can construct and register it in
+/// `add_correct`.
+pub(crate) struct CorrectFinalizeHook {
+    pub(crate) metrics: Arc<PerThreadAccumulator<CollectedCorrectMetrics>>,
+    pub(crate) records_emitted: Arc<AtomicU64>,
+    pub(crate) encoded_umi_set: Arc<EncodedUmiSet>,
+    pub(crate) unmatched_umi: String,
+    /// `--min-corrected` gate value (if set).
+    pub(crate) min_corrected: Option<f64>,
+    /// Used by `finalize_metrics` to compute and write the metrics TSV.
+    pub(crate) correct: CorrectOptions,
+    pub(crate) timer: OperationTimer,
+}
+
+impl FinalizeHook for CorrectFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let CorrectFinalizeHook {
+            metrics,
+            records_emitted,
+            encoded_umi_set,
+            unmatched_umi,
+            min_corrected,
+            correct,
+            timer,
+        } = *self;
+
+        // Drain all PerThreadAccumulator slots into per-counter totals +
+        // a single AHashMap that finalize_metrics consumes.
+        let mut total_templates = 0u64;
+        let mut total_missing = 0u64;
+        let mut total_wrong_length = 0u64;
+        let mut total_mismatched = 0u64;
+        let mut merged_umi_matches: AHashMap<String, UmiCorrectionMetrics> = AHashMap::new();
+        for slot in metrics.slots() {
+            let mut m = slot.lock();
+            total_templates += m.templates_processed;
+            total_missing += m.missing_umis;
+            total_wrong_length += m.wrong_length;
+            total_mismatched += m.mismatched;
+            for (umi, counts) in m.umi_matches.drain() {
+                merge_umi_counts(&mut merged_umi_matches, umi, &counts);
+            }
+        }
+
+        // Ensure ALL UMI rows present (matches fgbio behavior).
+        for umi in encoded_umi_set.strings.iter().chain(std::iter::once(&unmatched_umi.clone())) {
+            merged_umi_matches
+                .entry(umi.clone())
+                .or_insert_with(|| UmiCorrectionMetrics::new(umi.clone()));
+        }
+        correct.finalize_metrics(&mut merged_umi_matches, &unmatched_umi)?;
+
+        // Log summary.
+        let records_written = records_emitted.load(Ordering::Relaxed);
+        let rejected = total_missing + total_wrong_length + total_mismatched;
+        let total_records = records_written + rejected;
+        info!("Read {total_records}; kept {records_written} and rejected {rejected}");
+        info!("Total templates processed: {total_templates}");
+
+        // Warn banner on missing/wrong-length UMIs.
+        if total_missing > 0 || total_wrong_length > 0 {
+            warn!("###################################################################");
+            if total_missing > 0 {
+                warn!("# {total_missing} were missing UMI attributes in the BAM file!");
+            }
+            if total_wrong_length > 0 {
+                warn!(
+                    "# {total_wrong_length} had unexpected UMIs of differing lengths in the BAM file!"
+                );
+            }
+            warn!("###################################################################");
+        }
+
+        // Check minimum correction ratio.
+        if let Some(min) = min_corrected {
+            check_min_corrected(records_written, total_records, min)?;
+        }
+
+        timer.log_completion(records_written);
+
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// build_correct_chain — thin delegate
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Enforce the `--min-corrected` floor on the ratio of kept records.
+///
+/// Errors when `records_written / total_records` falls below `min`. When no
+/// records were processed (`total_records == 0`) the ratio is undefined, so a
+/// positive `min` errors (it cannot be met) while a zero `min` passes.
+fn check_min_corrected(records_written: u64, total_records: u64, min: f64) -> Result<()> {
+    // No reads processed: the kept ratio is undefined (0 / 0 = NaN), and
+    // `NaN < min` is always false — which would silently bypass the gate. A
+    // positive minimum cannot be satisfied with zero reads, so fail explicitly;
+    // a zero minimum imposes no requirement and passes.
+    if total_records == 0 {
+        if min > 0.0 {
+            anyhow::bail!(
+                "No reads were processed, so the minimum ratio of reads kept (user specified minimum was {min:.2}) \
+                could not be met. This could indicate empty input or a mismatch between library \
+                preparation and the provided UMI file."
+            );
+        }
+        return Ok(());
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let ratio_kept = records_written as f64 / total_records as f64;
+    if ratio_kept < min {
+        anyhow::bail!(
+            "Final ratio of reads kept / total was {ratio_kept:.2} (user specified minimum was {min:.2}). \
+            This could indicate a mismatch between library preparation and the provided UMI file."
+        );
+    }
+    Ok(())
+}
+
+/// Build a [`BuiltPipeline`] for a correct-only chain.
+///
+/// Delegates to [`ChainBuilder`]. The full step sequence lives in
+/// [`ChainBuilder`]'s `add_correct` method in
+/// [`crate::pipeline::chains::builder`].
+///
+/// # Errors
+///
+/// Returns input-validation errors or any underlying pipeline construction error.
+#[allow(clippy::needless_pass_by_value)]
+pub fn build_correct_chain(spec: ChainSpec) -> Result<BuiltPipeline> {
+    use crate::pipeline::chains::{Stage, builder::StagePosition};
+    let mut chain = ChainBuilder::new(&spec)?;
+    chain.add_source()?;
+    chain.add_stage(Stage::Correct, StagePosition::Terminal)?;
+    chain.add_sink()?;
+    chain.build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_records_with_positive_min_is_an_error() {
+        // Regression: with no reads processed, `records_written / total_records`
+        // is 0/0 = NaN and `NaN < min` is always false, which silently bypassed
+        // the --min-corrected gate. A positive minimum cannot be satisfied with
+        // zero reads, so this must fail explicitly.
+        assert!(
+            check_min_corrected(0, 0, 0.9).is_err(),
+            "zero records with a positive minimum must error, not silently pass"
+        );
+    }
+
+    #[test]
+    fn zero_records_with_zero_min_is_ok() {
+        // A zero minimum imposes no requirement, so an empty run passes.
+        assert!(check_min_corrected(0, 0, 0.0).is_ok());
+    }
+
+    #[test]
+    fn ratio_below_min_is_an_error() {
+        // 5 / 100 = 0.05 < 0.90.
+        assert!(check_min_corrected(5, 100, 0.9).is_err());
+    }
+
+    #[test]
+    fn ratio_at_or_above_min_is_ok() {
+        // 95 / 100 = 0.95 >= 0.90, and an exact match passes.
+        assert!(check_min_corrected(95, 100, 0.9).is_ok());
+        assert!(check_min_corrected(90, 100, 0.9).is_ok());
+    }
+}

--- a/src/lib/pipeline/chains/commands/correct.rs
+++ b/src/lib/pipeline/chains/commands/correct.rs
@@ -4,9 +4,7 @@
 //! Phase 3 (T3a.11) lifts that logic into
 //! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
 //! now holds the correct-specific types and step factories that the builder
-//! imports: [`CorrectFinalizeHook`] used by `ChainBuilder::add_correct`.
-//!
-//! [`build_correct_chain`] shrinks to a ~10-line delegate.
+//! imports: `CorrectFinalizeHook` used by `ChainBuilder::add_correct`.
 //!
 //! ## Four chain shapes
 //!
@@ -18,7 +16,7 @@
 //! - `(Sam,  true)`:  `[sam preamble]  → GroupByQueryname → correct_step_with_rejects` (same as Bam/true)
 //!
 //! The source preamble differences (BAM vs SAM) are handled by `add_source`
-//! in [`ChainBuilder`]; `add_correct` always receives a
+//! in `ChainBuilder`; `add_correct` always receives a
 //! `BamTemplateBatch`-typed tail (after `GroupByQueryname`).
 
 use std::sync::Arc;
@@ -34,8 +32,7 @@ use crate::commands::correct::{
 use crate::logging::OperationTimer;
 use crate::metrics::correct::UmiCorrectionMetrics;
 use crate::per_thread_accumulator::PerThreadAccumulator;
-use crate::pipeline::chains::builder::ChainBuilder;
-use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
+use crate::pipeline::chains::FinalizeHook;
 
 /// Post-pipeline finalize hook for correct. Reduces per-thread metrics,
 /// writes the optional metrics TSV, logs summary + warn banners, enforces
@@ -44,7 +41,7 @@ use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
 /// Mirrors the body of `CorrectUmis::finalize_correct_run`, extracted here so
 /// `BuiltPipeline::run` can call it after `Pipeline::run` returns.
 ///
-/// `pub(crate)` so [`ChainBuilder`] can construct and register it in
+/// `pub(crate)` so `ChainBuilder` can construct and register it in
 /// `add_correct`.
 pub(crate) struct CorrectFinalizeHook {
     pub(crate) metrics: Arc<PerThreadAccumulator<CollectedCorrectMetrics>>,
@@ -128,10 +125,6 @@ impl FinalizeHook for CorrectFinalizeHook {
     }
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// build_correct_chain — thin delegate
-// ─────────────────────────────────────────────────────────────────────────────
-
 /// Enforce the `--min-corrected` floor on the ratio of kept records.
 ///
 /// Errors when `records_written / total_records` falls below `min`. When no
@@ -161,25 +154,6 @@ fn check_min_corrected(records_written: u64, total_records: u64, min: f64) -> Re
         );
     }
     Ok(())
-}
-
-/// Build a [`BuiltPipeline`] for a correct-only chain.
-///
-/// Delegates to [`ChainBuilder`]. The full step sequence lives in
-/// [`ChainBuilder`]'s `add_correct` method in
-/// [`crate::pipeline::chains::builder`].
-///
-/// # Errors
-///
-/// Returns input-validation errors or any underlying pipeline construction error.
-#[allow(clippy::needless_pass_by_value)]
-pub fn build_correct_chain(spec: ChainSpec) -> Result<BuiltPipeline> {
-    use crate::pipeline::chains::{Stage, builder::StagePosition};
-    let mut chain = ChainBuilder::new(&spec)?;
-    chain.add_source()?;
-    chain.add_stage(Stage::Correct, StagePosition::Terminal)?;
-    chain.add_sink()?;
-    chain.build()
 }
 
 #[cfg(test)]

--- a/src/lib/pipeline/chains/commands/dedup.rs
+++ b/src/lib/pipeline/chains/commands/dedup.rs
@@ -4,10 +4,8 @@
 //! Phase 3 (T3a.3) lifts that logic into
 //! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
 //! now holds the dedup-specific types and step factories that the builder
-//! imports: [`DedupSerializeState`], [`DedupFinalizeHook`], and the three
+//! imports: `DedupSerializeState`, `DedupFinalizeHook`, and the three
 //! step-factory functions used by `ChainBuilder::add_dedup`.
-//!
-//! [`build_dedup_chain`] shrinks to a ~10-line delegate.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -21,8 +19,7 @@ use crate::commands::dedup::{
 };
 use crate::logging::OperationTimer;
 use crate::per_thread_accumulator::PerThreadAccumulator;
-use crate::pipeline::chains::builder::ChainBuilder;
-use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
+use crate::pipeline::chains::FinalizeHook;
 use crate::pipeline::steps::group::position::BatchedRawPositionGroups;
 use crate::pipeline::steps::process::{
     MiAssign, ProcessOrdered, ProcessWithWorkerState, mi_assign, process_ordered,
@@ -40,7 +37,7 @@ use fgumi_raw_bam::RawRecordView;
 /// `clippy::items_after_statements` lint that fires when a struct is defined
 /// after executable statements in a function body.
 ///
-/// `pub(crate)` so [`ChainBuilder`] can reference it when constructing the
+/// `pub(crate)` so `ChainBuilder` can reference it when constructing the
 /// dedup step sequence in `add_dedup`.
 pub(crate) struct DedupSerializeState {
     scratch: Vec<u8>,
@@ -78,7 +75,7 @@ impl crate::pipeline::core::item::HeapSize for DedupSerializeState {}
 /// summary banner, checks for missing `tc` tags, and calls
 /// `timer.log_completion`.
 ///
-/// `pub(crate)` so [`ChainBuilder`] can construct and register it in
+/// `pub(crate)` so `ChainBuilder` can construct and register it in
 /// `add_dedup`.
 pub(crate) struct DedupFinalizeHook {
     pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedDedupMetrics>>,
@@ -184,7 +181,7 @@ impl FinalizeHook for DedupFinalizeHook {
 /// position group through [`process_position_group`] and accumulates per-thread
 /// metrics.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_dedup`].
+/// `pub(crate)` — consumed only by `ChainBuilder::add_dedup`.
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
 pub(crate) fn build_process_step(
     limit_bytes: u64,
@@ -245,7 +242,7 @@ pub(crate) fn build_process_step(
 /// Build the `MiAssignDedup` step: serial, `ByItemOrdinal`, assigns
 /// monotonically increasing MI offsets to each batch.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_dedup`].
+/// `pub(crate)` — consumed only by `ChainBuilder::add_dedup`.
 #[allow(clippy::type_complexity)]
 pub(crate) fn build_mi_assign_step(
     limit_bytes: u64,
@@ -277,7 +274,7 @@ pub(crate) fn build_mi_assign_step(
 ///
 /// # Errors
 ///
-/// Returns an [`io::Error`] if the cumulative MI counter would exceed
+/// Returns an `io::Error` if the cumulative MI counter would exceed
 /// [`u64::MAX`].
 fn assign_mi_offsets(
     next_mi: &mut u64,
@@ -301,11 +298,11 @@ fn assign_mi_offsets(
 
 /// Build the `DedupSerialize` step: parallel, `ByItemOrdinal`, serializes
 /// each processed batch to raw BAM bytes with MI tags applied. Only included
-/// in the chain when the stage is [`StagePosition::Terminal`]; for
-/// [`StagePosition::Intermediate`] the chain tail stays as
+/// in the chain when the stage is `StagePosition::Terminal`; for
+/// `StagePosition::Intermediate` the chain tail stays as
 /// [`BatchedProcessedDedupGroups`] for the next stage's input.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_dedup`].
+/// `pub(crate)` — consumed only by `ChainBuilder::add_dedup`.
 #[allow(clippy::type_complexity)]
 pub(crate) fn build_serialize_step(
     limit_bytes: u64,
@@ -379,26 +376,6 @@ pub(crate) fn build_serialize_step(
             Ok(DecompressedBlock { batch_serial, bytes: output })
         },
     )
-}
-
-/// Build a [`BuiltPipeline`] for a dedup-only chain.
-///
-/// Delegates to [`ChainBuilder`]. The full step sequence lives in
-/// [`ChainBuilder`]'s `add_dedup` method in
-/// [`crate::pipeline::chains::builder`].
-///
-/// # Errors
-///
-/// Returns input-validation errors (BAM not template-coordinate sorted,
-/// etc.), or any underlying pipeline construction error.
-#[allow(clippy::needless_pass_by_value)]
-pub fn build_dedup_chain(spec: ChainSpec) -> Result<BuiltPipeline> {
-    use crate::pipeline::chains::{Stage, builder::StagePosition};
-    let mut chain = ChainBuilder::new(&spec)?;
-    chain.add_source()?;
-    chain.add_stage(Stage::Dedup, StagePosition::Terminal)?;
-    chain.add_sink()?;
-    chain.build()
 }
 
 #[cfg(test)]

--- a/src/lib/pipeline/chains/commands/dedup.rs
+++ b/src/lib/pipeline/chains/commands/dedup.rs
@@ -1,0 +1,466 @@
+//! Chain builder for `Stage::Dedup`.
+//!
+//! Phase 2 (T2.12) held the full ~500-LOC chain construction here.
+//! Phase 3 (T3a.3) lifts that logic into
+//! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
+//! now holds the dedup-specific types and step factories that the builder
+//! imports: [`DedupSerializeState`], [`DedupFinalizeHook`], and the three
+//! step-factory functions used by `ChainBuilder::add_dedup`.
+//!
+//! [`build_dedup_chain`] shrinks to a ~10-line delegate.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use ahash::AHashMap;
+use anyhow::{Result, bail};
+
+use crate::commands::dedup::{
+    BatchedProcessedDedupGroups, CollectedDedupMetrics, DedupCounts, ProcessedDedupGroup,
+    process_position_group, write_dedup_metrics, write_family_size_histogram,
+};
+use crate::logging::OperationTimer;
+use crate::per_thread_accumulator::PerThreadAccumulator;
+use crate::pipeline::chains::builder::ChainBuilder;
+use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
+use crate::pipeline::steps::group::position::BatchedRawPositionGroups;
+use crate::pipeline::steps::process::{
+    MiAssign, ProcessOrdered, ProcessWithWorkerState, mi_assign, process_ordered,
+    process_with_worker_state,
+};
+use crate::pipeline::steps::types::DecompressedBlock;
+use crate::sam::SamTag;
+use crate::template_filter::TemplateFilterConfig;
+use fgumi_bam_io::LibraryIndex;
+use fgumi_raw_bam::RawRecordView;
+
+/// Serialize worker state for the dedup pipeline's output step.
+///
+/// Defined at module level (not inside a function body) to avoid the
+/// `clippy::items_after_statements` lint that fires when a struct is defined
+/// after executable statements in a function body.
+///
+/// `pub(crate)` so [`ChainBuilder`] can reference it when constructing the
+/// dedup step sequence in `add_dedup`.
+pub(crate) struct DedupSerializeState {
+    scratch: Vec<u8>,
+    mi_buf: String,
+}
+
+impl DedupSerializeState {
+    pub(crate) fn new() -> Self {
+        Self { scratch: Vec::with_capacity(512), mi_buf: String::with_capacity(16) }
+    }
+
+    pub(crate) fn mi_buf_mut(&mut self) -> &mut String {
+        &mut self.mi_buf
+    }
+
+    /// Load `raw` into scratch, update the MI tag in-place, and return the
+    /// resulting bytes. Encapsulates the split-borrow needed to update both
+    /// `scratch` and use `mi_buf` as the new tag value.
+    pub(crate) fn apply_mi_tag(&mut self, raw: &[u8], assign_tag_bytes: [u8; 2]) -> &[u8] {
+        self.scratch.clear();
+        self.scratch.extend_from_slice(raw);
+        fgumi_raw_bam::update_string_tag(
+            &mut self.scratch,
+            assign_tag_bytes,
+            self.mi_buf.as_bytes(),
+        );
+        &self.scratch
+    }
+}
+
+impl crate::pipeline::core::item::HeapSize for DedupSerializeState {}
+
+/// Post-pipeline finalize hook for dedup. Reduces per-thread metrics,
+/// writes the optional metrics file and family-size histogram, logs the
+/// summary banner, checks for missing `tc` tags, and calls
+/// `timer.log_completion`.
+///
+/// `pub(crate)` so [`ChainBuilder`] can construct and register it in
+/// `add_dedup`.
+pub(crate) struct DedupFinalizeHook {
+    pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedDedupMetrics>>,
+    pub(crate) metrics_path: Option<std::path::PathBuf>,
+    pub(crate) family_size_histogram_path: Option<std::path::PathBuf>,
+    /// Library index resolved from the input header, needed for the per-library
+    /// metrics rows.
+    pub(crate) library_index: LibraryIndex,
+    /// Metrics `sample` value (resolved from `--sample` or the read groups).
+    pub(crate) sample: String,
+    pub(crate) timer: OperationTimer,
+}
+
+impl FinalizeHook for DedupFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let DedupFinalizeHook {
+            accumulators,
+            metrics_path,
+            family_size_histogram_path,
+            library_index,
+            sample,
+            timer,
+        } = *self;
+
+        // Reduce per-thread accumulators into per-library counts + a grand total.
+        let mut final_counts_by_library: AHashMap<u16, DedupCounts> = AHashMap::new();
+        let mut final_family_sizes: AHashMap<usize, u64> = AHashMap::new();
+        for slot in accumulators.slots() {
+            let acc = slot.lock();
+            for (&library_idx, counts) in &acc.dedup_counts_by_library {
+                final_counts_by_library.entry(library_idx).or_default().merge(counts);
+            }
+            for (&size, &count) in &acc.family_sizes {
+                *final_family_sizes.entry(size).or_insert(0) += count;
+            }
+        }
+
+        // Total across all libraries: the summary log, the `tc`-tag check, and
+        // the metrics file's aggregate "All Reads" row.
+        let mut final_counts = DedupCounts::default();
+        for library_counts in final_counts_by_library.values() {
+            final_counts.merge(library_counts);
+        }
+
+        // Write metrics file if requested (per-library rows + aggregate).
+        if let Some(ref path) = metrics_path {
+            write_dedup_metrics(
+                &final_counts_by_library,
+                &final_counts,
+                &library_index,
+                &sample,
+                path,
+            )?;
+        }
+
+        // Write family-size histogram if requested.
+        if let Some(ref path) = family_size_histogram_path {
+            write_family_size_histogram(&final_family_sizes, path)?;
+        }
+
+        // Log summary banner (verbatim from the original execute).
+        log::info!(
+            "Deduplication complete: {} templates ({} unique, {} duplicates, {:.2}% duplicate rate)",
+            final_counts.total_templates,
+            final_counts.unique_templates,
+            final_counts.duplicate_templates,
+            final_counts.duplicate_rate() * 100.0
+        );
+
+        // Check for missing tc tags (bail verbatim from the original execute).
+        if final_counts.missing_tc_tag > 0 {
+            bail!(
+                "{} secondary/supplementary reads are missing the `tc` tag.\n\n\
+                The `tc` tag is required for correct UMI-aware deduplication of \
+                secondary and supplementary alignments. This tag is added by \
+                `fgumi zipper` during the merge of unmapped and mapped BAMs.\n\n\
+                To fix this, re-run your pipeline starting from `fgumi zipper`:\n  \
+                fgumi zipper -i aligned.bam --unmapped unmapped.bam -r reference.fa -o merged.bam\n  \
+                fgumi sort -i merged.bam -o sorted.bam --order template-coordinate\n  \
+                fgumi dedup -i sorted.bam -o deduped.bam",
+                final_counts.missing_tc_tag
+            );
+        }
+
+        timer.log_completion(final_counts.total_reads);
+
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Step factories — extracted from ChainBuilder::add_dedup (T3a.3 review M2).
+//
+// Each factory receives its captured state as plain arguments and returns the
+// concrete step type (via the constructor's return type). Returning
+// `impl Step<...>` is blocked here because the closure types embed in
+// opaque-return position and cannot name themselves, so we return the concrete
+// `Process*` structs directly (the same pattern used by the correct-step
+// factories in `steps::correct`).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build the `DedupProcess` step: parallel, `ByItemOrdinal`, processes each
+/// position group through [`process_position_group`] and accumulates per-thread
+/// metrics.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_dedup`].
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
+pub(crate) fn build_process_step(
+    limit_bytes: u64,
+    filter_config: TemplateFilterConfig,
+    effective_strategy: crate::assigner::Strategy,
+    effective_edits: u32,
+    index_threshold: fgumi_umi::IndexThreshold,
+    raw_tag: SamTag,
+    min_umi_length: Option<usize>,
+    no_umi: bool,
+    include_unmapped: bool,
+    accumulators: Arc<PerThreadAccumulator<CollectedDedupMetrics>>,
+) -> ProcessOrdered<
+    BatchedRawPositionGroups,
+    BatchedProcessedDedupGroups,
+    impl Fn(BatchedRawPositionGroups) -> std::io::Result<BatchedProcessedDedupGroups>
+    + Send
+    + Sync
+    + 'static,
+> {
+    process_ordered::<BatchedRawPositionGroups, BatchedProcessedDedupGroups, _>(
+        "DedupProcess",
+        limit_bytes,
+        move |item: BatchedRawPositionGroups| -> std::io::Result<BatchedProcessedDedupGroups> {
+            let BatchedRawPositionGroups { batch_serial, groups } = item;
+            let mut processed_batch: Vec<ProcessedDedupGroup> = Vec::with_capacity(groups.len());
+            let assigner =
+                effective_strategy.new_assigner_full(effective_edits, 1, index_threshold);
+            for group in groups {
+                assigner.reset();
+                let processed = process_position_group(
+                    group,
+                    &filter_config,
+                    assigner.as_ref(),
+                    raw_tag,
+                    min_umi_length,
+                    no_umi,
+                    include_unmapped,
+                )?;
+                accumulators.with_slot(|acc| {
+                    // A position group is always single-library, so its counts
+                    // belong entirely to `processed.library_idx`.
+                    acc.dedup_counts_by_library
+                        .entry(processed.library_idx)
+                        .or_default()
+                        .merge(&processed.dedup_counts);
+                    for (size, count) in &processed.family_sizes {
+                        *acc.family_sizes.entry(*size).or_insert(0) += count;
+                    }
+                });
+                processed_batch.push(processed);
+            }
+            Ok(BatchedProcessedDedupGroups { batch_serial, groups: processed_batch })
+        },
+    )
+}
+
+/// Build the `MiAssignDedup` step: serial, `ByItemOrdinal`, assigns
+/// monotonically increasing MI offsets to each batch.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_dedup`].
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_mi_assign_step(
+    limit_bytes: u64,
+) -> MiAssign<
+    BatchedProcessedDedupGroups,
+    BatchedProcessedDedupGroups,
+    impl Fn(&mut u64, BatchedProcessedDedupGroups) -> std::io::Result<BatchedProcessedDedupGroups>
+    + Send
+    + Sync
+    + 'static,
+> {
+    mi_assign::<BatchedProcessedDedupGroups, BatchedProcessedDedupGroups, _>(
+        "MiAssignDedup",
+        limit_bytes,
+        move |next_mi: &mut u64, mut item: BatchedProcessedDedupGroups| {
+            assign_mi_offsets(next_mi, &mut item)?;
+            Ok(item)
+        },
+    )
+}
+
+/// Assign global `MoleculeId` offsets to every template in `item`, advancing the
+/// running `next_mi` counter by each group's `distinct_mi_count`.
+///
+/// Each group reserves a contiguous block `[base, base + distinct_mi_count)`
+/// from the global counter and shifts its templates' local MI ids by `base`.
+/// Mirrors `chains::commands::group::assign_mi_offsets` (which operates on
+/// `BatchedProcessedPositionGroups`); the two are kept in step by design.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if the cumulative MI counter would exceed
+/// [`u64::MAX`].
+fn assign_mi_offsets(
+    next_mi: &mut u64,
+    item: &mut BatchedProcessedDedupGroups,
+) -> std::io::Result<()> {
+    for processed in &mut item.groups {
+        let count = processed.distinct_mi_count;
+        let base = *next_mi;
+        *next_mi = next_mi.checked_add(count).ok_or_else(|| {
+            std::io::Error::other(
+                "MoleculeId offset overflow: cumulative MI counter \
+                 exceeded u64::MAX",
+            )
+        })?;
+        for template in &mut processed.templates {
+            template.mi = template.mi.with_offset(base);
+        }
+    }
+    Ok(())
+}
+
+/// Build the `DedupSerialize` step: parallel, `ByItemOrdinal`, serializes
+/// each processed batch to raw BAM bytes with MI tags applied. Only included
+/// in the chain when the stage is [`StagePosition::Terminal`]; for
+/// [`StagePosition::Intermediate`] the chain tail stays as
+/// [`BatchedProcessedDedupGroups`] for the next stage's input.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_dedup`].
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_serialize_step(
+    limit_bytes: u64,
+    remove_duplicates: bool,
+    assign_tag_bytes: [u8; 2],
+    progress: Arc<AtomicU64>,
+) -> ProcessWithWorkerState<
+    BatchedProcessedDedupGroups,
+    DecompressedBlock,
+    impl Fn(&mut DedupSerializeState, BatchedProcessedDedupGroups) -> std::io::Result<DecompressedBlock>
+    + Send
+    + Sync
+    + 'static,
+    DedupSerializeState,
+    fn() -> DedupSerializeState,
+> {
+    use crate::commands::dedup::DUPLICATE_FLAG;
+
+    process_with_worker_state::<
+        BatchedProcessedDedupGroups,
+        DecompressedBlock,
+        _,
+        DedupSerializeState,
+        _,
+    >(
+        "DedupSerialize",
+        limit_bytes,
+        DedupSerializeState::new,
+        move |state: &mut DedupSerializeState,
+              item: BatchedProcessedDedupGroups|
+              -> std::io::Result<DecompressedBlock> {
+            let BatchedProcessedDedupGroups { batch_serial, groups } = item;
+            let total_records: usize = groups
+                .iter()
+                .map(|g| g.templates.iter().map(|t| t.records().len()).sum::<usize>())
+                .sum();
+            let mut output = Vec::with_capacity(total_records * 800);
+            let mut total_input_records: u64 = 0;
+            for processed in &groups {
+                total_input_records += processed.input_record_count;
+                for template in &processed.templates {
+                    let mi = template.mi;
+                    let has_mi = mi.is_assigned();
+                    if has_mi {
+                        mi.write_with_offset(0, state.mi_buf_mut());
+                    }
+                    for raw in template.records() {
+                        if remove_duplicates
+                            && (RawRecordView::new(raw).flags() & DUPLICATE_FLAG) != 0
+                        {
+                            continue;
+                        }
+                        if has_mi {
+                            // `apply_mi_tag` clears scratch, writes raw,
+                            // and applies the MI tag — encapsulates the
+                            // split-borrow needed for scratch + mi_buf.
+                            let tagged = state.apply_mi_tag(raw, assign_tag_bytes);
+                            fgumi_raw_bam::write_framed_record(&mut output, tagged)?;
+                        } else {
+                            fgumi_raw_bam::write_framed_record(&mut output, raw)?;
+                        }
+                    }
+                }
+            }
+
+            let prev = progress.fetch_add(total_input_records, Ordering::Relaxed);
+            if (prev + total_input_records) / 1_000_000 > prev / 1_000_000 {
+                log::info!("Processed {} records", prev + total_input_records);
+            }
+
+            Ok(DecompressedBlock { batch_serial, bytes: output })
+        },
+    )
+}
+
+/// Build a [`BuiltPipeline`] for a dedup-only chain.
+///
+/// Delegates to [`ChainBuilder`]. The full step sequence lives in
+/// [`ChainBuilder`]'s `add_dedup` method in
+/// [`crate::pipeline::chains::builder`].
+///
+/// # Errors
+///
+/// Returns input-validation errors (BAM not template-coordinate sorted,
+/// etc.), or any underlying pipeline construction error.
+#[allow(clippy::needless_pass_by_value)]
+pub fn build_dedup_chain(spec: ChainSpec) -> Result<BuiltPipeline> {
+    use crate::pipeline::chains::{Stage, builder::StagePosition};
+    let mut chain = ChainBuilder::new(&spec)?;
+    chain.add_source()?;
+    chain.add_stage(Stage::Dedup, StagePosition::Terminal)?;
+    chain.add_sink()?;
+    chain.build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::template::Template;
+    use fgumi_umi::MoleculeId;
+
+    /// Build a [`ProcessedDedupGroup`] carrying `distinct_mi_count` and the
+    /// given local-id templates (each as a `MoleculeId::Single`).
+    fn make_group(distinct_mi_count: u64, local_ids: &[u64]) -> ProcessedDedupGroup {
+        let templates = local_ids
+            .iter()
+            .map(|&id| {
+                let mut template = Template::new(Vec::new());
+                template.mi = MoleculeId::Single(id);
+                template
+            })
+            .collect();
+        ProcessedDedupGroup {
+            templates,
+            family_sizes: AHashMap::default(),
+            dedup_counts: DedupCounts::default(),
+            library_idx: 0,
+            input_record_count: 0,
+            distinct_mi_count,
+        }
+    }
+
+    #[test]
+    fn assign_mi_offsets_advances_counter_and_shifts_local_ids() {
+        // Two groups; the second must be offset past the first's block.
+        let mut item = BatchedProcessedDedupGroups {
+            batch_serial: 0,
+            groups: vec![make_group(2, &[0, 1]), make_group(3, &[0, 1, 2])],
+        };
+        let mut next_mi = 10;
+
+        assign_mi_offsets(&mut next_mi, &mut item).expect("no overflow");
+
+        // Counter advanced by 2 + 3 over the starting value of 10.
+        assert_eq!(next_mi, 15);
+        // First group offset by base 10.
+        assert_eq!(item.groups[0].templates[0].mi, MoleculeId::Single(10));
+        assert_eq!(item.groups[0].templates[1].mi, MoleculeId::Single(11));
+        // Second group offset by base 12 (10 + first group's count of 2).
+        assert_eq!(item.groups[1].templates[0].mi, MoleculeId::Single(12));
+        assert_eq!(item.groups[1].templates[2].mi, MoleculeId::Single(14));
+    }
+
+    #[test]
+    fn assign_mi_offsets_errors_on_counter_overflow() {
+        // A non-zero starting counter plus a u64::MAX block overflows.
+        let mut item = BatchedProcessedDedupGroups {
+            batch_serial: 0,
+            groups: vec![make_group(u64::MAX, &[])],
+        };
+        let mut next_mi = 1;
+
+        let err = assign_mi_offsets(&mut next_mi, &mut item)
+            .expect_err("cumulative MI counter should overflow");
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+        assert!(err.to_string().contains("MoleculeId offset overflow"));
+    }
+}

--- a/src/lib/pipeline/chains/commands/duplex.rs
+++ b/src/lib/pipeline/chains/commands/duplex.rs
@@ -1,0 +1,495 @@
+//! Chain builder for `Stage::Duplex`.
+//!
+//! Phase 2 (T2.19) held the full ~550-LOC chain construction here.
+//! Phase 3 (T3a.9) lifts that logic into
+//! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
+//! now holds the duplex-specific types and step factory that the builder
+//! imports: [`DuplexFinalizeHook`] and the `build_duplex_consensus_step_with_rejects` / `build_duplex_consensus_step_kept_only` factories, used
+//! by `ChainBuilder::add_duplex`.
+//!
+//! [`build_duplex_chain`] shrinks to a ~10-line delegate.
+//!
+//! Mirrors simplex (5cce86c). Duplex's chain is structurally the same with a
+//! different consensus caller, a record filter, and an MI-tag transform that
+//! strips `/A`/`/B` suffixes.
+//!
+//! This module supplies the chain-builder pieces for the duplex stage; the
+//! chain is constructed via [`ChainBuilder`] /
+//! [`crate::pipeline::chains::build::build_for`]. It is not yet wired as
+//! `Duplex::execute`'s live path.
+
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::Result;
+use log::info;
+
+use crate::commands::common::MethylationRef;
+use crate::commands::consensus_runner::{ConsensusStatsOps, log_overlapping_stats};
+use crate::consensus_caller::{ConsensusCaller, ConsensusCallingStats, ConsensusOutput};
+use crate::duplex_consensus_caller::DuplexConsensusCaller;
+use crate::logging::OperationTimer;
+use crate::mi_group::MiGroup;
+use crate::overlapping_consensus::{
+    AgreementStrategy, CorrectionStats, DisagreementStrategy, OverlappingBasesConsensusCaller,
+    apply_overlapping_consensus,
+};
+use crate::per_thread_accumulator::PerThreadAccumulator;
+use crate::pipeline::chains::builder::ChainBuilder;
+use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
+use crate::pipeline::core::outputs::OrderedBytesTuple2;
+use crate::pipeline::core::step::Step;
+use crate::pipeline::steps::group::mi::BatchedMiGroups;
+use crate::pipeline::steps::process::{
+    Process2Output, ProcessWithWorkerState, process_with_worker_state, process2_with_worker_state,
+};
+use crate::pipeline::steps::types::DecompressedBlock;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CollectedDuplexMetrics
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Per-thread accumulator for duplex consensus metrics (mirrors
+/// `commands::duplex::CollectedDuplexMetrics`).
+///
+/// Merged into final aggregates after the pipeline completes; one instance
+/// per worker slot (see [`PerThreadAccumulator`]).
+///
+/// `pub(crate)` so [`ChainBuilder`] can construct it in `add_duplex`.
+#[derive(Default)]
+pub(crate) struct CollectedDuplexMetrics {
+    /// Consensus calling statistics.
+    pub(crate) stats: ConsensusCallingStats,
+    /// Overlapping consensus stats (if enabled).
+    pub(crate) overlapping_stats: Option<CorrectionStats>,
+    /// Number of MI groups processed.
+    pub(crate) groups_processed: u64,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DuplexState
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Per-worker state for the duplex consensus step.
+///
+/// Defined at module level (not inside a function body) to avoid the
+/// `clippy::items_after_statements` lint that fires when a struct is defined
+/// after executable statements in a function body.
+pub(crate) struct DuplexState {
+    pub(crate) caller: DuplexConsensusCaller,
+    pub(crate) overlapping: Option<OverlappingBasesConsensusCaller>,
+}
+
+impl crate::pipeline::core::item::HeapSize for DuplexState {}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DuplexFinalizeHook
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Post-pipeline finalize hook for duplex. Reduces per-thread metrics,
+/// writes the optional stats file, logs the overlapping-consensus stats
+/// (if enabled), logs the summary banner, finalizes the rejects writer,
+/// and calls `timer.log_completion`.
+///
+/// `pub(crate)` so [`ChainBuilder`] can construct and register it in
+/// `add_duplex`.
+pub(crate) struct DuplexFinalizeHook {
+    pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedDuplexMetrics>>,
+    pub(crate) stats_path: Option<std::path::PathBuf>,
+    pub(crate) overlapping_enabled: bool,
+    pub(crate) timer: OperationTimer,
+}
+
+impl FinalizeHook for DuplexFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let DuplexFinalizeHook { accumulators, stats_path, overlapping_enabled, timer } = *self;
+
+        // Reduce per-thread accumulators.
+        let mut total_groups = 0u64;
+        let mut merged_stats = ConsensusCallingStats::new();
+        let mut merged_overlapping_stats = CorrectionStats::new();
+
+        for slot in accumulators.slots() {
+            let m = slot.lock();
+            total_groups += m.groups_processed;
+            merged_stats.merge(&m.stats);
+            if let Some(ref ocs) = m.overlapping_stats {
+                merged_overlapping_stats.merge(ocs);
+            }
+        }
+
+        if overlapping_enabled {
+            log_overlapping_stats(&merged_overlapping_stats);
+        }
+
+        info!("Duplex consensus calling complete");
+        info!("Total MI groups processed: {total_groups}");
+
+        let metrics = merged_stats.to_metrics();
+        let consensus_count = metrics.consensus_reads;
+        crate::logging::log_consensus_summary(&metrics);
+
+        if let Some(ref stats_path) = stats_path {
+            use fgoxide::io::DelimFile;
+            let kv_metrics = metrics.to_kv_metrics(fgumi_metrics::ConsensusCallerKind::Duplex);
+            DelimFile::default().write_tsv(stats_path, kv_metrics).map_err(|e| {
+                anyhow::anyhow!("Failed to write statistics: {}: {e}", stats_path.display())
+            })?;
+            info!("Wrote statistics to: {}", stats_path.display());
+        }
+
+        info!("Wrote {consensus_count} duplex consensus reads");
+
+        // Rejects are emitted on the consensus step's second output branch
+        // (fan-out) and finalized by the rejects branch's WriteBgzfFile sink.
+
+        timer.log_completion(consensus_count);
+
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Step factory — extracted from build_duplex_chain (T3a.9).
+//
+// Returns the concrete `ProcessWithWorkerState` type directly (the same
+// pattern used by the other step factories in this module family). Returning
+// `impl Step<...>` is blocked here because the closure types embed in
+// opaque-return position and cannot name themselves.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Captures passed into [`build_duplex_consensus_step_with_rejects`] / [`build_duplex_consensus_step_kept_only`] from `add_duplex`.
+///
+/// Bundles all the cloned scalars and Arcs the closure needs so `add_duplex`
+/// can prepare them once and hand them off cleanly.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_duplex`] and
+/// [`build_duplex_consensus_step_with_rejects`] / [`build_duplex_consensus_step_kept_only`].
+#[allow(clippy::struct_excessive_bools)]
+pub(crate) struct DuplexConsensusCaptures {
+    pub(crate) track_rejects: bool,
+    pub(crate) overlapping_enabled: bool,
+    pub(crate) methylation_ref: MethylationRef,
+    pub(crate) methylation_mode: fgumi_consensus::MethylationMode,
+    pub(crate) read_name_prefix: String,
+    pub(crate) read_group_id: String,
+    pub(crate) min_reads: Vec<usize>,
+    pub(crate) min_input_base_quality: u8,
+    pub(crate) output_per_base_tags: bool,
+    pub(crate) trim: bool,
+    pub(crate) max_reads_per_strand: Option<usize>,
+    pub(crate) error_rate_pre_umi: u8,
+    pub(crate) error_rate_post_umi: u8,
+    pub(crate) cell_tag: noodles::sam::alignment::record::data::field::Tag,
+    pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedDuplexMetrics>>,
+    pub(crate) progress: Arc<AtomicU64>,
+}
+
+/// Per-worker init: build the `DuplexConsensusCaller` (+ optional overlapping
+/// caller) once, reused across batches. Shared by both step variants.
+///
+/// # Panics
+///
+/// Panics if `DuplexConsensusCaller::new` fails (only on invalid `min_reads`,
+/// validated before the pipeline is built) — the init closure type
+/// `Fn() -> DuplexState` cannot propagate a `Result`.
+#[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+fn make_duplex_consensus_init(
+    read_name_prefix: String,
+    read_group_id: String,
+    min_reads: Vec<usize>,
+    min_input_base_quality: u8,
+    output_per_base_tags: bool,
+    trim: bool,
+    max_reads_per_strand: Option<usize>,
+    cell_tag: noodles::sam::alignment::record::data::field::Tag,
+    track_rejects: bool,
+    error_rate_pre_umi: u8,
+    error_rate_post_umi: u8,
+    methylation_ref: MethylationRef,
+    methylation_mode: fgumi_consensus::MethylationMode,
+    overlapping_enabled: bool,
+) -> impl Fn() -> DuplexState + Send + Sync + 'static {
+    move || {
+        let mut caller = DuplexConsensusCaller::new(
+            read_name_prefix.clone(),
+            read_group_id.clone(),
+            min_reads.clone(),
+            min_input_base_quality,
+            output_per_base_tags,
+            trim,
+            max_reads_per_strand,
+            Some(cell_tag),
+            track_rejects,
+            error_rate_pre_umi,
+            error_rate_post_umi,
+        )
+        .expect("DuplexConsensusCaller::new failed during worker init");
+        if let Some((ref reference, ref ref_names)) = methylation_ref {
+            caller.set_reference(Arc::clone(reference), Arc::clone(ref_names), methylation_mode);
+        }
+        let overlapping = if overlapping_enabled {
+            Some(OverlappingBasesConsensusCaller::new(
+                AgreementStrategy::Consensus,
+                DisagreementStrategy::Consensus,
+            ))
+        } else {
+            None
+        };
+        DuplexState { caller, overlapping }
+    }
+}
+
+/// Per-batch duplex consensus body, shared by both step variants.
+///
+/// Returns the consensus `DecompressedBlock` (branch 0) and, when
+/// `track_rejects` is set and any record was rejected, a rejects
+/// `DecompressedBlock` (branch 1) of `[len][record]`-framed raw-input records
+/// in input order — the PR #332 fan-out contract (rejects flow through the
+/// ordered serialize/compress stages, not a mutex side-channel; the rejects
+/// writer is configured with the input header by `add_duplex`).
+fn run_duplex_consensus_batch(
+    state: &mut DuplexState,
+    item: BatchedMiGroups,
+    track_rejects: bool,
+    overlapping_enabled: bool,
+    accumulators: &Arc<PerThreadAccumulator<CollectedDuplexMetrics>>,
+    progress: &Arc<AtomicU64>,
+) -> io::Result<(DecompressedBlock, Option<DecompressedBlock>)> {
+    let BatchedMiGroups { batch_serial, groups } = item;
+    let groups_count = groups.len() as u64;
+
+    let mut all_output = ConsensusOutput::default();
+    let mut batch_stats = ConsensusCallingStats::new();
+    let mut batch_overlapping = CorrectionStats::new();
+    let mut rejects_bytes: Vec<u8> = Vec::new();
+
+    let mut total_input_records: u64 = 0;
+    for MiGroup { mi, records: mut group_reads } in groups {
+        state.caller.clear();
+        total_input_records += group_reads.len() as u64;
+
+        if let Some(ref mut oc) = state.overlapping
+            && crate::commands::duplex::has_both_strands_raw(&group_reads)
+        {
+            oc.reset_stats();
+            apply_overlapping_consensus(&mut group_reads, oc).map_err(|e| {
+                io::Error::other(format!("Overlapping consensus error for MI {mi}: {e}"))
+            })?;
+            batch_overlapping.merge(oc.stats());
+        }
+
+        let group_output = state
+            .caller
+            .consensus_reads(group_reads)
+            .map_err(|e| io::Error::other(format!("Duplex consensus error for MI {mi}: {e}")))?;
+        all_output.merge(group_output);
+        batch_stats.merge(&state.caller.statistics());
+        if track_rejects {
+            for raw in &state.caller.take_rejected_reads() {
+                super::append_framed_bytes(&mut rejects_bytes, raw)?;
+            }
+        }
+    }
+
+    // Merge per-batch metrics into this worker's slot.
+    accumulators.with_slot(|m| {
+        m.stats.merge(&batch_stats);
+        if overlapping_enabled {
+            m.overlapping_stats.get_or_insert_with(CorrectionStats::new).merge(&batch_overlapping);
+        }
+        m.groups_processed += groups_count;
+    });
+
+    // Progress logging at million-record boundaries.
+    let prev = progress.fetch_add(total_input_records, Ordering::Relaxed);
+    if (prev + total_input_records) / 1_000_000 > prev / 1_000_000 {
+        info!("Processed {} records", prev + total_input_records);
+    }
+
+    let consensus = DecompressedBlock { batch_serial, bytes: all_output.data };
+    let rejects = if rejects_bytes.is_empty() {
+        None
+    } else {
+        Some(DecompressedBlock { batch_serial, bytes: rejects_bytes })
+    };
+    Ok((consensus, rejects))
+}
+
+/// Build the 2-output `DuplexConsensus` step (used when `--rejects` is set):
+/// branch 0 = consensus, branch 1 = rejects.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_duplex`].
+pub(crate) fn build_duplex_consensus_step_with_rejects(
+    limit_bytes: u64,
+    cap: DuplexConsensusCaptures,
+) -> impl Step<Input = BatchedMiGroups, Outputs = OrderedBytesTuple2<DecompressedBlock, DecompressedBlock>>
+{
+    let DuplexConsensusCaptures {
+        track_rejects,
+        overlapping_enabled,
+        methylation_ref,
+        methylation_mode,
+        read_name_prefix,
+        read_group_id,
+        min_reads,
+        min_input_base_quality,
+        output_per_base_tags,
+        trim,
+        max_reads_per_strand,
+        error_rate_pre_umi,
+        error_rate_post_umi,
+        cell_tag,
+        accumulators,
+        progress,
+    } = cap;
+
+    let init = make_duplex_consensus_init(
+        read_name_prefix,
+        read_group_id,
+        min_reads,
+        min_input_base_quality,
+        output_per_base_tags,
+        trim,
+        max_reads_per_strand,
+        cell_tag,
+        track_rejects,
+        error_rate_pre_umi,
+        error_rate_post_umi,
+        methylation_ref,
+        methylation_mode,
+        overlapping_enabled,
+    );
+    let body = move |state: &mut DuplexState,
+                     item: BatchedMiGroups|
+          -> io::Result<Process2Output<DecompressedBlock, DecompressedBlock>> {
+        let (consensus, rejects) = run_duplex_consensus_batch(
+            state,
+            item,
+            track_rejects,
+            overlapping_enabled,
+            &accumulators,
+            &progress,
+        )?;
+        if let Some(r) = rejects {
+            Ok(Process2Output::both(consensus, r))
+        } else {
+            // X5-001: an all-clean batch must still emit a (zero-byte) rejects
+            // block so the rejects branch's `ByItemOrdinal` reorder stage sees a
+            // dense serial sequence; pushing nothing (`only_a`) leaves a gap at
+            // this serial that wedges the rejects sink. The empty `Vec` does not
+            // allocate and produces no physical BGZF block.
+            let batch_serial = consensus.batch_serial;
+            Ok(Process2Output::both(
+                consensus,
+                DecompressedBlock { batch_serial, bytes: Vec::new() },
+            ))
+        }
+    };
+
+    process2_with_worker_state::<
+        BatchedMiGroups,
+        DecompressedBlock,
+        DecompressedBlock,
+        DuplexState,
+        _,
+        _,
+    >("DuplexConsensus", limit_bytes, limit_bytes, init, body)
+}
+
+/// Build the 1-output kept-only `DuplexConsensus` step (used when `--rejects`
+/// is unset). The framework has no public discard sink, so omitting the rejects
+/// branch requires this single-output variant.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_duplex`].
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_duplex_consensus_step_kept_only(
+    limit_bytes: u64,
+    cap: DuplexConsensusCaptures,
+) -> ProcessWithWorkerState<
+    BatchedMiGroups,
+    DecompressedBlock,
+    impl Fn(&mut DuplexState, BatchedMiGroups) -> io::Result<DecompressedBlock> + Send + Sync + 'static,
+    DuplexState,
+    impl Fn() -> DuplexState + Send + Sync + 'static,
+> {
+    let DuplexConsensusCaptures {
+        track_rejects,
+        overlapping_enabled,
+        methylation_ref,
+        methylation_mode,
+        read_name_prefix,
+        read_group_id,
+        min_reads,
+        min_input_base_quality,
+        output_per_base_tags,
+        trim,
+        max_reads_per_strand,
+        error_rate_pre_umi,
+        error_rate_post_umi,
+        cell_tag,
+        accumulators,
+        progress,
+    } = cap;
+
+    let init = make_duplex_consensus_init(
+        read_name_prefix,
+        read_group_id,
+        min_reads,
+        min_input_base_quality,
+        output_per_base_tags,
+        trim,
+        max_reads_per_strand,
+        cell_tag,
+        track_rejects,
+        error_rate_pre_umi,
+        error_rate_post_umi,
+        methylation_ref,
+        methylation_mode,
+        overlapping_enabled,
+    );
+    let body =
+        move |state: &mut DuplexState, item: BatchedMiGroups| -> io::Result<DecompressedBlock> {
+            let (consensus, _rejects) = run_duplex_consensus_batch(
+                state,
+                item,
+                track_rejects,
+                overlapping_enabled,
+                &accumulators,
+                &progress,
+            )?;
+            Ok(consensus)
+        };
+
+    process_with_worker_state::<BatchedMiGroups, DecompressedBlock, _, DuplexState, _>(
+        "DuplexConsensus",
+        limit_bytes,
+        init,
+        body,
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// build_duplex_chain — thin delegate (Phase 3 T3a.9)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build a [`BuiltPipeline`] for a duplex-only chain.
+///
+/// Delegates to [`ChainBuilder`]. The full step sequence lives in
+/// [`ChainBuilder`]'s `add_duplex` method in
+/// [`crate::pipeline::chains::builder`].
+///
+/// # Errors
+///
+/// Returns input-validation errors (missing reference for methylation mode,
+/// etc.) or any underlying pipeline construction error.
+#[allow(clippy::needless_pass_by_value)]
+pub fn build_duplex_chain(spec: ChainSpec) -> Result<BuiltPipeline> {
+    use crate::pipeline::chains::{Stage, builder::StagePosition};
+    let mut chain = ChainBuilder::new(&spec)?;
+    chain.add_source()?;
+    chain.add_stage(Stage::Duplex, StagePosition::Terminal)?;
+    chain.add_sink()?;
+    chain.build()
+}

--- a/src/lib/pipeline/chains/commands/duplex.rs
+++ b/src/lib/pipeline/chains/commands/duplex.rs
@@ -4,17 +4,15 @@
 //! Phase 3 (T3a.9) lifts that logic into
 //! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
 //! now holds the duplex-specific types and step factory that the builder
-//! imports: [`DuplexFinalizeHook`] and the `build_duplex_consensus_step_with_rejects` / `build_duplex_consensus_step_kept_only` factories, used
+//! imports: `DuplexFinalizeHook` and the `build_duplex_consensus_step_with_rejects` / `build_duplex_consensus_step_kept_only` factories, used
 //! by `ChainBuilder::add_duplex`.
-//!
-//! [`build_duplex_chain`] shrinks to a ~10-line delegate.
 //!
 //! Mirrors simplex (5cce86c). Duplex's chain is structurally the same with a
 //! different consensus caller, a record filter, and an MI-tag transform that
 //! strips `/A`/`/B` suffixes.
 //!
 //! This module supplies the chain-builder pieces for the duplex stage; the
-//! chain is constructed via [`ChainBuilder`] /
+//! chain is constructed via `ChainBuilder` /
 //! [`crate::pipeline::chains::build::build_for`]. It is not yet wired as
 //! `Duplex::execute`'s live path.
 
@@ -36,8 +34,7 @@ use crate::overlapping_consensus::{
     apply_overlapping_consensus,
 };
 use crate::per_thread_accumulator::PerThreadAccumulator;
-use crate::pipeline::chains::builder::ChainBuilder;
-use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
+use crate::pipeline::chains::FinalizeHook;
 use crate::pipeline::core::outputs::OrderedBytesTuple2;
 use crate::pipeline::core::step::Step;
 use crate::pipeline::steps::group::mi::BatchedMiGroups;
@@ -56,7 +53,7 @@ use crate::pipeline::steps::types::DecompressedBlock;
 /// Merged into final aggregates after the pipeline completes; one instance
 /// per worker slot (see [`PerThreadAccumulator`]).
 ///
-/// `pub(crate)` so [`ChainBuilder`] can construct it in `add_duplex`.
+/// `pub(crate)` so `ChainBuilder` can construct it in `add_duplex`.
 #[derive(Default)]
 pub(crate) struct CollectedDuplexMetrics {
     /// Consensus calling statistics.
@@ -92,7 +89,7 @@ impl crate::pipeline::core::item::HeapSize for DuplexState {}
 /// (if enabled), logs the summary banner, finalizes the rejects writer,
 /// and calls `timer.log_completion`.
 ///
-/// `pub(crate)` so [`ChainBuilder`] can construct and register it in
+/// `pub(crate)` so `ChainBuilder` can construct and register it in
 /// `add_duplex`.
 pub(crate) struct DuplexFinalizeHook {
     pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedDuplexMetrics>>,
@@ -164,7 +161,7 @@ impl FinalizeHook for DuplexFinalizeHook {
 /// Bundles all the cloned scalars and Arcs the closure needs so `add_duplex`
 /// can prepare them once and hand them off cleanly.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_duplex`] and
+/// `pub(crate)` — consumed only by `ChainBuilder::add_duplex` and
 /// [`build_duplex_consensus_step_with_rejects`] / [`build_duplex_consensus_step_kept_only`].
 #[allow(clippy::struct_excessive_bools)]
 pub(crate) struct DuplexConsensusCaptures {
@@ -320,7 +317,7 @@ fn run_duplex_consensus_batch(
 /// Build the 2-output `DuplexConsensus` step (used when `--rejects` is set):
 /// branch 0 = consensus, branch 1 = rejects.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_duplex`].
+/// `pub(crate)` — consumed only by `ChainBuilder::add_duplex`.
 pub(crate) fn build_duplex_consensus_step_with_rejects(
     limit_bytes: u64,
     cap: DuplexConsensusCaptures,
@@ -402,7 +399,7 @@ pub(crate) fn build_duplex_consensus_step_with_rejects(
 /// is unset). The framework has no public discard sink, so omitting the rejects
 /// branch requires this single-output variant.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_duplex`].
+/// `pub(crate)` — consumed only by `ChainBuilder::add_duplex`.
 #[allow(clippy::type_complexity)]
 pub(crate) fn build_duplex_consensus_step_kept_only(
     limit_bytes: u64,
@@ -468,28 +465,4 @@ pub(crate) fn build_duplex_consensus_step_kept_only(
         init,
         body,
     )
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// build_duplex_chain — thin delegate (Phase 3 T3a.9)
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Build a [`BuiltPipeline`] for a duplex-only chain.
-///
-/// Delegates to [`ChainBuilder`]. The full step sequence lives in
-/// [`ChainBuilder`]'s `add_duplex` method in
-/// [`crate::pipeline::chains::builder`].
-///
-/// # Errors
-///
-/// Returns input-validation errors (missing reference for methylation mode,
-/// etc.) or any underlying pipeline construction error.
-#[allow(clippy::needless_pass_by_value)]
-pub fn build_duplex_chain(spec: ChainSpec) -> Result<BuiltPipeline> {
-    use crate::pipeline::chains::{Stage, builder::StagePosition};
-    let mut chain = ChainBuilder::new(&spec)?;
-    chain.add_source()?;
-    chain.add_stage(Stage::Duplex, StagePosition::Terminal)?;
-    chain.add_sink()?;
-    chain.build()
 }

--- a/src/lib/pipeline/chains/commands/extract.rs
+++ b/src/lib/pipeline/chains/commands/extract.rs
@@ -1,8 +1,8 @@
 //! Chain builder support for [`crate::pipeline::chains::Stage::Extract`].
 //!
-//! Provides the extract-specific finalize hook, the `build_fastq_header`
+//! Provides the extract-specific finalize hook and the `build_fastq_header`
 //! helper that synthesizes an unmapped-BAM `@HD`/`@RG`/`@CO` header from
-//! [`ExtractOptions`], and the `build_extract_chain` delegate.
+//! [`ExtractOptions`], both consumed by `ChainBuilder::add_extract`.
 //!
 //! The header builder reproduces the same `@HD`, `@RG`, and `@CO` records
 //! that [`Extract::create_header`] emits, minus the `@PG` record —
@@ -65,7 +65,7 @@ impl FinalizeHook for ExtractFinalizeHook {
 /// Conditionally add a read-group tag value to a [`Builder<ReadGroup>`].
 ///
 /// If `value` is `Some`, inserts the tag with the value. Otherwise returns
-/// the builder unchanged. Mirrors [`Extract::add_to_read_group`].
+/// the builder unchanged. Mirrors `Extract::add_to_read_group`.
 fn add_to_read_group(
     rg: Builder<ReadGroup>,
     tag: noodles::sam::header::record::value::map::tag::Other<rg_tag::Standard>,
@@ -132,33 +132,6 @@ pub(crate) fn build_fastq_header(extract_opts: &ExtractOptions) -> Result<Header
     header = header.add_read_group(extract_opts.read_group_id.clone(), rg.build()?);
 
     Ok(header.build())
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// build_extract_chain — 10-line delegate
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Build a [`BuiltPipeline`] for an extract-only chain.
-///
-/// `spec.stages == [Stage::Extract]`. Delegates to [`ChainBuilder`].
-///
-/// # Errors
-///
-/// Returns validation errors (missing extract options, invalid source type)
-/// or any underlying pipeline construction error.
-///
-/// [`BuiltPipeline`]: crate::pipeline::chains::BuiltPipeline
-/// [`ChainBuilder`]: crate::pipeline::chains::builder::ChainBuilder
-#[allow(clippy::needless_pass_by_value)]
-pub fn build_extract_chain(
-    spec: crate::pipeline::chains::ChainSpec,
-) -> Result<crate::pipeline::chains::BuiltPipeline> {
-    use crate::pipeline::chains::{Stage, builder::StagePosition};
-    let mut chain = crate::pipeline::chains::builder::ChainBuilder::new(&spec)?;
-    chain.add_source()?;
-    chain.add_stage(Stage::Extract, StagePosition::Terminal)?;
-    chain.add_sink()?;
-    chain.build()
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/lib/pipeline/chains/commands/extract.rs
+++ b/src/lib/pipeline/chains/commands/extract.rs
@@ -1,0 +1,277 @@
+//! Chain builder support for [`crate::pipeline::chains::Stage::Extract`].
+//!
+//! Provides the extract-specific finalize hook, the `build_fastq_header`
+//! helper that synthesizes an unmapped-BAM `@HD`/`@RG`/`@CO` header from
+//! [`ExtractOptions`], and the `build_extract_chain` delegate.
+//!
+//! The header builder reproduces the same `@HD`, `@RG`, and `@CO` records
+//! that [`Extract::create_header`] emits, minus the `@PG` record —
+//! [`ChainBuilder::new`] adds that uniformly for all chains.
+//!
+//! [`ExtractOptions`]: crate::commands::extract::ExtractOptions
+//! [`Extract::create_header`]: crate::commands::extract::Extract
+//! [`ChainBuilder::new`]: crate::pipeline::chains::builder::ChainBuilder
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::Result;
+use log::info;
+use noodles::sam::header::Header;
+use noodles::sam::header::record::value::Map;
+use noodles::sam::header::record::value::map::ReadGroup;
+use noodles::sam::header::record::value::map::builder::Builder;
+use noodles::sam::header::record::value::map::header::group_order;
+use noodles::sam::header::record::value::map::header::sort_order;
+use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
+use noodles::sam::header::record::value::{
+    Map as HeaderRecordMap,
+    map::{Header as HeaderRecord, Tag as HeaderTag},
+};
+
+use crate::commands::extract::ExtractOptions;
+use crate::logging::OperationTimer;
+use crate::pipeline::chains::FinalizeHook;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ExtractFinalizeHook
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Post-pipeline finalize hook for the extract stage.
+///
+/// Logs the records-emitted count and calls `timer.log_completion` so the
+/// per-stage wall-time line appears in the log.
+pub(crate) struct ExtractFinalizeHook {
+    /// Counter atomically incremented by `ExtractStep` as it emits
+    /// `BamTemplateBatch`es downstream.
+    pub(crate) records_emitted: Arc<AtomicU64>,
+    pub(crate) timer: OperationTimer,
+}
+
+impl FinalizeHook for ExtractFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let ExtractFinalizeHook { records_emitted, timer } = *self;
+        let n = records_emitted.load(Ordering::Relaxed);
+        info!("Extract: completed ({n} records emitted)");
+        timer.log_completion(n);
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// build_fastq_header — reproduce Extract::create_header sans @PG
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Conditionally add a read-group tag value to a [`Builder<ReadGroup>`].
+///
+/// If `value` is `Some`, inserts the tag with the value. Otherwise returns
+/// the builder unchanged. Mirrors [`Extract::add_to_read_group`].
+fn add_to_read_group(
+    rg: Builder<ReadGroup>,
+    tag: noodles::sam::header::record::value::map::tag::Other<rg_tag::Standard>,
+    value: Option<&String>,
+) -> Builder<ReadGroup> {
+    if let Some(v) = value { rg.insert(tag, v.clone()) } else { rg }
+}
+
+/// Build a SAM header for an unmapped BAM produced from FASTQ input.
+///
+/// The returned header contains:
+/// - `@HD` with `VN:1.6`, `SO:unsorted`, `GO:query`.
+/// - `@RG` with the read-group fields from `extract_opts` (SM, LB, PL, PU).
+/// - `@CO` comment lines from `extract_opts.comments`.
+///
+/// The header does **not** include a `@PG` record — [`ChainBuilder::new`]
+/// injects that uniformly for every chain.
+///
+/// This reproduces the header structure of [`Extract::create_header`] so the
+/// two code paths produce byte-identical headers (modulo `@PG`).
+///
+/// [`ChainBuilder::new`]: crate::pipeline::chains::builder::ChainBuilder
+/// [`Extract::create_header`]: crate::commands::extract::Extract
+pub(crate) fn build_fastq_header(extract_opts: &ExtractOptions) -> Result<Header> {
+    let mut header = Header::builder();
+
+    // @HD: sort order = unsorted, group order = query.
+    let HeaderTag::Other(so_tag) = HeaderTag::from([b'S', b'O']) else { unreachable!() };
+    let HeaderTag::Other(go_tag) = HeaderTag::from([b'G', b'O']) else { unreachable!() };
+    let map = HeaderRecordMap::<HeaderRecord>::builder()
+        .insert(so_tag, sort_order::UNSORTED)
+        .insert(go_tag, group_order::QUERY)
+        .build()?;
+    header = header.set_header(map);
+
+    // @CO comment lines.
+    for comment in &extract_opts.comments {
+        header = header.add_comment(comment.clone());
+    }
+
+    // @RG read group. SM and LB are required; all other tags are optional.
+    let mut rg = Map::<ReadGroup>::builder();
+    rg = add_to_read_group(rg, rg_tag::SAMPLE, Some(&extract_opts.sample));
+    rg = add_to_read_group(rg, rg_tag::LIBRARY, Some(&extract_opts.library));
+    rg = add_to_read_group(rg, rg_tag::BARCODE, extract_opts.barcode.as_ref());
+    // PLATFORM/PL is always written, defaulting to "illumina" — the standalone
+    // `Extract::create_header` takes a non-optional platform (CLI default
+    // "illumina") and always emits PL, so omitting it when `platform` is None
+    // would diverge. (Reusing `Extract::create_header` outright to erase this
+    // whole duplication is deferred to the extract wiring PR.)
+    let platform = extract_opts.platform.clone().unwrap_or_else(|| "illumina".to_string());
+    rg = add_to_read_group(rg, rg_tag::PLATFORM, Some(&platform));
+    rg = add_to_read_group(rg, rg_tag::PLATFORM_UNIT, extract_opts.platform_unit.as_ref());
+    rg = add_to_read_group(rg, rg_tag::PLATFORM_MODEL, extract_opts.platform_model.as_ref());
+    rg = add_to_read_group(rg, rg_tag::SEQUENCING_CENTER, extract_opts.sequencing_center.as_ref());
+    rg = add_to_read_group(
+        rg,
+        rg_tag::PREDICTED_MEDIAN_INSERT_SIZE,
+        extract_opts.predicted_insert_size.map(|i| i.to_string()).as_ref(),
+    );
+    rg = add_to_read_group(rg, rg_tag::DESCRIPTION, extract_opts.description.as_ref());
+    rg = add_to_read_group(rg, rg_tag::PRODUCED_AT, extract_opts.run_date.as_ref());
+
+    header = header.add_read_group(extract_opts.read_group_id.clone(), rg.build()?);
+
+    Ok(header.build())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// build_extract_chain — 10-line delegate
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build a [`BuiltPipeline`] for an extract-only chain.
+///
+/// `spec.stages == [Stage::Extract]`. Delegates to [`ChainBuilder`].
+///
+/// # Errors
+///
+/// Returns validation errors (missing extract options, invalid source type)
+/// or any underlying pipeline construction error.
+///
+/// [`BuiltPipeline`]: crate::pipeline::chains::BuiltPipeline
+/// [`ChainBuilder`]: crate::pipeline::chains::builder::ChainBuilder
+#[allow(clippy::needless_pass_by_value)]
+pub fn build_extract_chain(
+    spec: crate::pipeline::chains::ChainSpec,
+) -> Result<crate::pipeline::chains::BuiltPipeline> {
+    use crate::pipeline::chains::{Stage, builder::StagePosition};
+    let mut chain = crate::pipeline::chains::builder::ChainBuilder::new(&spec)?;
+    chain.add_source()?;
+    chain.add_stage(Stage::Extract, StagePosition::Terminal)?;
+    chain.add_sink()?;
+    chain.build()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::extract::QualityEncoding;
+    use bstr::BString;
+
+    /// Build a minimal `ExtractOptions` for tests.
+    fn test_extract_opts() -> ExtractOptions {
+        ExtractOptions {
+            sample: "TestSample".to_string(),
+            library: "TestLibrary".to_string(),
+            platform: Some("illumina".to_string()),
+            platform_unit: Some("HXXXXX.1.ATCACG".to_string()),
+            read_group_id: "A".to_string(),
+            comments: vec!["comment one".to_string(), "comment two".to_string()],
+            barcode: None,
+            platform_model: None,
+            sequencing_center: None,
+            predicted_insert_size: None,
+            description: None,
+            run_date: None,
+            quality_encoding: QualityEncoding::Standard,
+            store_umi_quals: false,
+            store_cell_quals: false,
+            single_tag: None,
+            annotate_read_names: false,
+            extract_umis_from_read_names: false,
+            store_sample_barcode_qualities: false,
+            async_reader: false,
+        }
+    }
+
+    #[test]
+    fn build_fastq_header_has_expected_hd() {
+        let opts = test_extract_opts();
+        let header = build_fastq_header(&opts).expect("build_fastq_header");
+        let hd = header.header().expect("@HD should be present");
+        // sort order = unsorted
+        let HeaderTag::Other(so_tag) = HeaderTag::from([b'S', b'O']) else { unreachable!() };
+        assert_eq!(
+            hd.other_fields().get(&so_tag).map(std::string::ToString::to_string),
+            Some("unsorted".to_string())
+        );
+        // group order = query
+        let HeaderTag::Other(go_tag) = HeaderTag::from([b'G', b'O']) else { unreachable!() };
+        assert_eq!(
+            hd.other_fields().get(&go_tag).map(std::string::ToString::to_string),
+            Some("query".to_string())
+        );
+    }
+
+    #[test]
+    fn build_fastq_header_has_expected_rg() {
+        let opts = test_extract_opts();
+        let header = build_fastq_header(&opts).expect("build_fastq_header");
+        let rg_id = BString::from("A");
+        let rg = header.read_groups().get(&rg_id).expect("@RG ID:A should be present");
+        assert_eq!(
+            rg.other_fields().get(&rg_tag::SAMPLE).map(std::string::ToString::to_string),
+            Some("TestSample".to_string())
+        );
+        assert_eq!(
+            rg.other_fields().get(&rg_tag::LIBRARY).map(std::string::ToString::to_string),
+            Some("TestLibrary".to_string())
+        );
+        assert_eq!(
+            rg.other_fields().get(&rg_tag::PLATFORM).map(std::string::ToString::to_string),
+            Some("illumina".to_string())
+        );
+        assert_eq!(
+            rg.other_fields().get(&rg_tag::PLATFORM_UNIT).map(std::string::ToString::to_string),
+            Some("HXXXXX.1.ATCACG".to_string())
+        );
+    }
+
+    #[test]
+    fn build_fastq_header_has_expected_comments() {
+        let opts = test_extract_opts();
+        let header = build_fastq_header(&opts).expect("build_fastq_header");
+        let comments: Vec<String> =
+            header.comments().iter().map(std::string::ToString::to_string).collect();
+        assert_eq!(comments, vec!["comment one", "comment two"]);
+    }
+
+    #[test]
+    fn build_fastq_header_has_no_pg() {
+        let opts = test_extract_opts();
+        let header = build_fastq_header(&opts).expect("build_fastq_header");
+        assert!(header.programs().as_ref().is_empty(), "@PG should not be present");
+    }
+
+    #[test]
+    fn build_fastq_header_platform_defaults_unit_omitted() {
+        // With platform unset, PL is still written (defaulted to "illumina"),
+        // matching the standalone `Extract::create_header`, which always emits
+        // PL. Platform-unit has no default and is omitted when None.
+        let mut opts = test_extract_opts();
+        opts.platform = None;
+        opts.platform_unit = None;
+        let header = build_fastq_header(&opts).expect("build_fastq_header");
+        let rg_id = BString::from("A");
+        let rg = header.read_groups().get(&rg_id).expect("@RG ID:A");
+        assert_eq!(
+            rg.other_fields().get(&rg_tag::PLATFORM).map(std::string::ToString::to_string),
+            Some("illumina".to_string()),
+            "PL must default to illumina when platform is None, matching standalone create_header"
+        );
+        assert!(rg.other_fields().get(&rg_tag::PLATFORM_UNIT).is_none());
+    }
+}

--- a/src/lib/pipeline/chains/commands/fastq.rs
+++ b/src/lib/pipeline/chains/commands/fastq.rs
@@ -1,0 +1,345 @@
+//! Chain-builder support for [`crate::pipeline::chains::Stage::Fastq`] — the
+//! terminal BAM → FASTQ encode.
+//!
+//! The encode step consumes the [`DecodedRecordBatch`] tail produced by the
+//! BAM source preamble and emits a [`DecompressedBlock`] of FASTQ text per
+//! batch, reusing [`write_fastq_record`] (the same encoder the standalone
+//! command used). It is a `Parallel` step, so the work-stealing pool spreads
+//! the encode across N workers; `add_sink` then routes the byte tail to a
+//! (optionally BGZF-compressing) raw-file/stdout writer.
+
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::Result;
+use log::info;
+
+use crate::commands::fastq::{FastqOptions, Segment, classify_segment, write_fastq_record};
+use crate::logging::OperationTimer;
+use crate::pipeline::chains::FinalizeHook;
+use crate::pipeline::steps::process::{
+    Process3Output, Process3WithWorkerState, ProcessWithWorkerState, process_with_worker_state,
+    process3_with_worker_state,
+};
+use crate::pipeline::steps::types::{DecodedRecordBatch, DecompressedBlock};
+
+/// Post-pipeline finalize hook for the fastq stage: logs the record count and
+/// the per-stage wall-time line.
+pub(crate) struct FastqFinalizeHook {
+    pub(crate) records_written: Arc<AtomicU64>,
+    pub(crate) timer: OperationTimer,
+}
+
+impl FinalizeHook for FastqFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let FastqFinalizeHook { records_written, timer } = *self;
+        let n = records_written.load(Ordering::Relaxed);
+        info!("Fastq: completed ({n} FASTQ records written)");
+        timer.log_completion(n);
+        Ok(())
+    }
+}
+
+/// Per-worker scratch for the FASTQ encoder: the reusable sequence and quality
+/// decode buffers `write_fastq_record` fills per record.
+pub(crate) struct FastqEncodeState {
+    buffers: crate::commands::fastq::FastqRecordBuffers,
+}
+
+impl crate::pipeline::core::item::HeapSize for FastqEncodeState {}
+
+fn new_encode_state() -> FastqEncodeState {
+    FastqEncodeState { buffers: crate::commands::fastq::FastqRecordBuffers::with_capacity(512) }
+}
+
+/// Bump the shared record counter and log a progress line every million records.
+fn bump_progress(counter: &AtomicU64, written: u64) {
+    if written == 0 {
+        return;
+    }
+    let prev = counter.fetch_add(written, Ordering::Relaxed);
+    if (prev + written) / 1_000_000 > prev / 1_000_000 {
+        info!("Wrote {} FASTQ records", prev + written);
+    }
+}
+
+/// Interleaved FASTQ encode step: [`DecodedRecordBatch`] → one
+/// [`DecompressedBlock`] of FASTQ text (all passing records, in input order).
+pub(crate) fn build_fastq_encode_step(
+    opts: Arc<FastqOptions>,
+    per_step_byte_limit: u64,
+    records_written: Arc<AtomicU64>,
+) -> ProcessWithWorkerState<
+    DecodedRecordBatch,
+    DecompressedBlock,
+    impl Fn(&mut FastqEncodeState, DecodedRecordBatch) -> io::Result<DecompressedBlock>
+    + Send
+    + Sync
+    + 'static,
+    FastqEncodeState,
+    impl Fn() -> FastqEncodeState + Send + Sync + 'static,
+> {
+    process_with_worker_state::<DecodedRecordBatch, DecompressedBlock, _, FastqEncodeState, _>(
+        "FastqEncode",
+        per_step_byte_limit,
+        new_encode_state,
+        move |state: &mut FastqEncodeState,
+              batch: DecodedRecordBatch|
+              -> io::Result<DecompressedBlock> {
+            let batch_serial = batch.batch_serial();
+            let records = batch.into_records();
+            let mut out = Vec::with_capacity(records.len().saturating_mul(512));
+            let mut written = 0u64;
+            for record in &records {
+                let flags = record.record().flags();
+                if !opts.passes_filters(flags) {
+                    continue;
+                }
+                write_fastq_record(
+                    &mut out,
+                    record.record(),
+                    flags,
+                    opts.no_suffix,
+                    &mut state.buffers,
+                    opts.umi_header.as_ref(),
+                )
+                .map_err(|e| io::Error::other(format!("fastq encode: {e:#}")))?;
+                written += 1;
+            }
+            bump_progress(&records_written, written);
+            Ok(DecompressedBlock { batch_serial, bytes: out })
+        },
+    )
+}
+
+/// Routes and encodes a single [`DecodedRecordBatch`] into R1/R2/other FASTQ
+/// byte blocks.
+///
+/// Routing matches `samtools fastq -1/-2/-0`: R1 = `FIRST_SEGMENT` set /
+/// `LAST_SEGMENT` clear, R2 = the reverse, "other" = single-end or ambiguous
+/// (see [`classify_segment`]). Split mode always omits the `/1`/`/2` suffix.
+///
+/// **Emits a block on all three branches for every batch** — an empty
+/// `Vec<u8>` where a branch has no records this batch — to keep each ordered
+/// branch's `batch_serial` sequence gap-free (a skipped serial would wedge that
+/// branch's reorder stage). Never returns `None` on a branch.
+///
+/// Extracted from [`build_fastq_paired_encode_step`]'s closure so the routing
+/// logic is directly unit-testable without going through the pipeline
+/// machinery (see `mod tests`).
+fn encode_paired_batch(
+    state: &mut FastqEncodeState,
+    batch: DecodedRecordBatch,
+    opts: &FastqOptions,
+    records_written: &AtomicU64,
+) -> io::Result<Process3Output<DecompressedBlock, DecompressedBlock, DecompressedBlock>> {
+    let batch_serial = batch.batch_serial();
+    let records = batch.into_records();
+    let mut r1: Vec<u8> = Vec::new();
+    let mut r2: Vec<u8> = Vec::new();
+    let mut other: Vec<u8> = Vec::new();
+    let mut written = 0u64;
+    for record in &records {
+        let flags = record.record().flags();
+        if !opts.passes_filters(flags) {
+            continue;
+        }
+        // Split mode: the R1/R2 file already identifies the mate, so the
+        // `/1`/`/2` suffix is always omitted (matches `samtools fastq -1/-2`).
+        let out = match classify_segment(flags) {
+            Segment::Read1 => &mut r1,
+            Segment::Read2 => &mut r2,
+            Segment::Other => &mut other,
+        };
+        write_fastq_record(
+            out,
+            record.record(),
+            flags,
+            /* no_suffix */ true,
+            &mut state.buffers,
+            opts.umi_header.as_ref(),
+        )
+        .map_err(|e| io::Error::other(format!("fastq encode: {e:#}")))?;
+        written += 1;
+    }
+    bump_progress(records_written, written);
+    // Always emit all three branches (empty Vec where none) — no gaps.
+    Ok(Process3Output::both3(
+        DecompressedBlock { batch_serial, bytes: r1 },
+        DecompressedBlock { batch_serial, bytes: r2 },
+        DecompressedBlock { batch_serial, bytes: other },
+    ))
+}
+
+/// Paired-split FASTQ encode step: [`DecodedRecordBatch`] → three
+/// [`DecompressedBlock`]s of FASTQ text (R1, R2, other), one per output file.
+///
+/// See [`encode_paired_batch`] for the per-batch routing/encode logic; this
+/// function only wires that logic into the `Process3WithWorkerState` step
+/// shape.
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_fastq_paired_encode_step(
+    opts: Arc<FastqOptions>,
+    per_step_byte_limit: u64,
+    records_written: Arc<AtomicU64>,
+) -> Process3WithWorkerState<
+    DecodedRecordBatch,
+    DecompressedBlock,
+    DecompressedBlock,
+    DecompressedBlock,
+    FastqEncodeState,
+    impl Fn() -> FastqEncodeState + Send + Sync + 'static,
+    impl Fn(
+        &mut FastqEncodeState,
+        DecodedRecordBatch,
+    ) -> io::Result<Process3Output<DecompressedBlock, DecompressedBlock, DecompressedBlock>>
+    + Send
+    + Sync
+    + 'static,
+> {
+    process3_with_worker_state::<
+        DecodedRecordBatch,
+        DecompressedBlock,
+        DecompressedBlock,
+        DecompressedBlock,
+        FastqEncodeState,
+        _,
+        _,
+    >(
+        "FastqEncodePaired",
+        per_step_byte_limit,
+        per_step_byte_limit,
+        per_step_byte_limit,
+        new_encode_state,
+        move |state: &mut FastqEncodeState, batch: DecodedRecordBatch| {
+            encode_paired_batch(state, batch, &opts, &records_written)
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn paired_encode_step_profile_is_parallel_three_branches() {
+        use crate::commands::fastq::FastqOptions;
+        use crate::pipeline::core::step::{Step, StepKind};
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicU64;
+
+        let opts = Arc::new(FastqOptions {
+            exclude_flags: 0,
+            require_flags: 0,
+            no_suffix: true,
+            umi_header: None,
+        });
+        let step = build_fastq_paired_encode_step(opts, 1 << 20, Arc::new(AtomicU64::new(0)));
+        let profile = step.profile();
+        assert_eq!(profile.kind, StepKind::Parallel);
+        assert_eq!(profile.output_queues.len(), 3);
+        assert_eq!(profile.branch_ordering.len(), 3);
+    }
+
+    /// Build a `DecodedRecord` for a single-segment (unpaired-flags-wise
+    /// simple) paired read: `PAIRED` plus exactly one of `FIRST_SEGMENT` /
+    /// `LAST_SEGMENT`, matching how `classify_segment` routes R1 vs R2.
+    fn decoded_record(name: &str, first_segment: bool) -> fgumi_bam_io::DecodedRecord {
+        use fgumi_bam_io::{DecodedRecord, GroupKey};
+        use fgumi_raw_bam::{SamBuilder as RawSamBuilder, flags as raw_flags};
+
+        let mut flags = raw_flags::PAIRED;
+        flags |= if first_segment { raw_flags::FIRST_SEGMENT } else { raw_flags::LAST_SEGMENT };
+        let mut b = RawSamBuilder::new();
+        b.read_name(name.as_bytes())
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags)
+            .ref_id(0)
+            .pos(99)
+            .mapq(60);
+        DecodedRecord::from_raw_bytes(b.build(), GroupKey::default())
+    }
+
+    fn no_filter_opts() -> FastqOptions {
+        FastqOptions { exclude_flags: 0, require_flags: 0, no_suffix: true, umi_header: None }
+    }
+
+    /// Direct, deterministic regression test for the no-ordinal-gaps rule
+    /// (see the doc comment on `encode_paired_batch`): a batch containing
+    /// ONLY R1 records must still return `Some(empty block)` on the R2 and
+    /// "other" branches, never `None`. Unlike the integration-level
+    /// `test_fastq_paired_empty_r2_batch_no_hang` (which depends on the
+    /// fixture fitting in a single BGZF block to avoid a real hang), this
+    /// calls the routing/encode logic directly and asserts on `Process3Output`
+    /// itself, so it fails immediately — no subprocess, no timing, no
+    /// block-size heuristics — if a regression ever changes `b`/`c` to `None`.
+    #[test]
+    fn encode_paired_batch_emits_empty_block_not_none_when_branch_has_no_records() {
+        use std::sync::atomic::AtomicU64;
+
+        let opts = no_filter_opts();
+        let mut state = new_encode_state();
+        let records_written = AtomicU64::new(0);
+
+        let batch = DecodedRecordBatch::new(0, vec![decoded_record("read1", true)]);
+        let out = encode_paired_batch(&mut state, batch, &opts, &records_written)
+            .expect("encode_paired_batch should succeed");
+
+        let r1 = out.a.expect("R1 branch must be Some: this batch has an R1 record");
+        assert!(!r1.bytes.is_empty(), "R1 branch must contain the encoded R1 record");
+
+        let r2 = out.b.expect(
+            "R2 branch must be Some (empty block) even though this batch has no R2 \
+             records -- returning None here is exactly the regression that wedges \
+             the R2 reorder stage",
+        );
+        assert!(r2.bytes.is_empty(), "R2 branch must be an empty block, not populated");
+
+        let other = out.c.expect(
+            "other branch must be Some (empty block) even though this batch has no \
+             single-end/ambiguous records",
+        );
+        assert!(other.bytes.is_empty(), "other branch must be an empty block, not populated");
+    }
+
+    /// Sanity check for the routing side of `encode_paired_batch`: a batch
+    /// with one record on each branch produces non-empty bytes on all three,
+    /// so the "empty means absent" assertions above aren't trivially true for
+    /// every branch regardless of content.
+    #[test]
+    fn encode_paired_batch_routes_mixed_batch_to_all_three_branches() {
+        use std::sync::atomic::AtomicU64;
+
+        let opts = no_filter_opts();
+        let mut state = new_encode_state();
+        let records_written = AtomicU64::new(0);
+
+        // "Other" = neither/both segment flags set; use an unpaired single-end read.
+        let mut other_builder = fgumi_raw_bam::SamBuilder::new();
+        other_builder
+            .read_name(b"single1")
+            .sequence(b"GGGGCCCC")
+            .qualities(&[30; 8])
+            .flags(0)
+            .ref_id(0)
+            .pos(199)
+            .mapq(60);
+        let other_record = fgumi_bam_io::DecodedRecord::from_raw_bytes(
+            other_builder.build(),
+            fgumi_bam_io::GroupKey::default(),
+        );
+
+        let batch = DecodedRecordBatch::new(
+            0,
+            vec![decoded_record("read1", true), decoded_record("read1", false), other_record],
+        );
+        let out = encode_paired_batch(&mut state, batch, &opts, &records_written)
+            .expect("encode_paired_batch should succeed");
+
+        assert!(out.a.is_some_and(|b| !b.bytes.is_empty()), "R1 branch should be non-empty");
+        assert!(out.b.is_some_and(|b| !b.bytes.is_empty()), "R2 branch should be non-empty");
+        assert!(out.c.is_some_and(|b| !b.bytes.is_empty()), "other branch should be non-empty");
+    }
+}

--- a/src/lib/pipeline/chains/commands/fastq.rs
+++ b/src/lib/pipeline/chains/commands/fastq.rs
@@ -3,7 +3,7 @@
 //!
 //! The encode step consumes the [`DecodedRecordBatch`] tail produced by the
 //! BAM source preamble and emits a [`DecompressedBlock`] of FASTQ text per
-//! batch, reusing [`write_fastq_record`] (the same encoder the standalone
+//! batch, reusing `write_fastq_record` (the same encoder the standalone
 //! command used). It is a `Parallel` step, so the work-stealing pool spreads
 //! the encode across N workers; `add_sink` then routes the byte tail to a
 //! (optionally BGZF-compressing) raw-file/stdout writer.

--- a/src/lib/pipeline/chains/commands/filter.rs
+++ b/src/lib/pipeline/chains/commands/filter.rs
@@ -1,0 +1,472 @@
+//! Chain builder for `Stage::Filter`.
+//!
+//! Phase 2 (T2.14) held the full ~500-LOC chain construction here.
+//! Phase 3 (T3a.4) lifts that logic into
+//! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
+//! now holds the filter-specific types and step factories that the builder
+//! imports: [`FilterFinalizeHook`] and the step-factory functions used by
+//! `ChainBuilder::add_filter`.
+//!
+//! [`build_filter_chain`] shrinks to a ~10-line delegate.
+//!
+//! ## Four chain shapes
+//!
+//! Filter dispatches on `(filter_by_template, track_rejects)`:
+//!
+//! - `(false, false)`: `ProcessOrdered<DecodedRecordBatch, DecompressedBlock>`
+//! - `(false, true)`: `Process2Ordered<DecodedRecordBatch, DecompressedBlock, DecompressedBlock>`
+//! - `(true, false)`: `GroupByQueryname` + `ProcessOrdered<BamTemplateBatch, DecompressedBlock>`
+//! - `(true, true)`: `GroupByQueryname` + `Process2Ordered<BamTemplateBatch, DecompressedBlock, DecompressedBlock>`
+//!
+//! For shapes with rejects (`track_rejects = true`), branch 0 is kept (flows
+//! to `add_sink`) and branch 1 is the rejects output (wired to its own
+//! compress+write inside `add_filter`).
+
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use ahash::AHashMap;
+use anyhow::Result;
+use fgumi_raw_bam::RawRecord;
+use log::info;
+
+use crate::commands::filter::{CollectedFilterMetrics, Filter, FilterProcessCaptures};
+use crate::logging::OperationTimer;
+use crate::per_thread_accumulator::PerThreadAccumulator;
+use crate::pipeline::chains::builder::ChainBuilder;
+use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
+use crate::pipeline::steps::process::{
+    Process2Ordered, ProcessOrdered, process_ordered, process2_ordered,
+};
+use crate::pipeline::steps::types::{BamTemplateBatch, DecodedRecordBatch, DecompressedBlock};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FilterFinalizeHook
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Post-pipeline finalize hook for filter. Reduces per-thread metrics,
+/// writes the optional stats file, and logs the summary banner.
+///
+/// `pub(crate)` so [`ChainBuilder`] can construct and register it in
+/// `add_filter`.
+pub(crate) struct FilterFinalizeHook {
+    pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedFilterMetrics>>,
+    pub(crate) stats_path: Option<std::path::PathBuf>,
+    pub(crate) has_rejects: bool,
+    pub(crate) timer: OperationTimer,
+}
+
+impl FinalizeHook for FilterFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let FilterFinalizeHook { accumulators, stats_path, has_rejects, timer } = *self;
+
+        let mut total_reads = 0u64;
+        let mut passed_reads = 0u64;
+        let mut failed_reads = 0u64;
+        let mut total_bases_masked = 0u64;
+        for slot in accumulators.slots() {
+            let m = slot.lock();
+            total_reads += m.total_records;
+            passed_reads += m.passed_records;
+            failed_reads += m.failed_records;
+            total_bases_masked += m.total_bases_masked;
+        }
+
+        if let Some(ref path) = stats_path {
+            write_filter_stats(path, total_reads, passed_reads, failed_reads)?;
+        }
+
+        info!("Processed {total_reads} reads; kept {passed_reads} and rejected {failed_reads}");
+        if has_rejects && failed_reads > 0 {
+            info!("Wrote {failed_reads} rejected records to rejects file");
+        }
+        info!("Total bases masked: {total_bases_masked}");
+
+        timer.log_completion(total_reads);
+
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Write filtering statistics to a file.
+pub(crate) fn write_filter_stats(
+    path: &std::path::Path,
+    total: u64,
+    passed: u64,
+    failed: u64,
+) -> Result<()> {
+    use std::fs::File;
+    use std::io::Write;
+
+    let mut file = File::create(path)?;
+    writeln!(file, "total_reads\t{total}")?;
+    writeln!(file, "passed_reads\t{passed}")?;
+    writeln!(file, "failed_reads\t{failed}")?;
+    #[allow(clippy::cast_precision_loss)]
+    let pass_rate = if total > 0 { passed as f64 / total as f64 } else { 0.0 };
+    writeln!(file, "pass_rate\t{pass_rate:.4}")?;
+    Ok(())
+}
+
+/// Thin wrapper that calls `Filter::process_record_raw` with captures,
+/// so the four pipeline-mode closures share identical call sites.
+pub(crate) fn process_record_raw_call(
+    record: &mut fgumi_raw_bam::RawRecord,
+    captures: &FilterProcessCaptures,
+) -> anyhow::Result<(u64, bool)> {
+    Filter::process_record_raw(
+        record,
+        &captures.config,
+        captures.reference.as_deref(),
+        &captures.header,
+        captures.should_reverse_tags,
+        captures.min_base_quality,
+        captures.require_single_strand_agreement,
+        captures.min_mean_base_quality,
+        captures.max_no_call_fraction,
+        captures.methylation_depth_thresholds.as_ref(),
+        captures.require_strand_methylation_agreement,
+        captures.min_conversion_fraction,
+        captures.methylation_mode,
+        &captures.ref_names,
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Step factories — extracted from build_filter_chain (T3a.4).
+//
+// Each factory receives its captured state as plain arguments and returns the
+// concrete step type (via the constructor's return type). Returning
+// `impl Step<...>` is blocked here because the closure types embed in
+// opaque-return position and cannot name themselves, so we return the concrete
+// `Process*` structs directly (the same pattern used by the dedup factories
+// in `chains::commands::dedup`).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build the single-read, no-rejects filter step.
+///
+/// `DecodedRecordBatch → DecompressedBlock`. Parallel, `ByItemOrdinal`.
+/// Rejected records are dropped; kept records are serialised to raw BAM bytes.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_filter`].
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_filter_step_single_no_rejects(
+    limit_bytes: u64,
+    captures: FilterProcessCaptures,
+    accumulators: Arc<PerThreadAccumulator<CollectedFilterMetrics>>,
+) -> ProcessOrdered<
+    DecodedRecordBatch,
+    DecompressedBlock,
+    impl Fn(DecodedRecordBatch) -> io::Result<DecompressedBlock> + Send + Sync + 'static,
+> {
+    process_ordered::<DecodedRecordBatch, DecompressedBlock, _>(
+        "FilterProcess",
+        limit_bytes,
+        move |item: DecodedRecordBatch| -> io::Result<DecompressedBlock> {
+            let batch_serial = item.batch_serial();
+            let records = item.into_records();
+            let records_count = records.len() as u64;
+            let mut kept_bytes: Vec<u8> = Vec::new();
+            let mut passed_count: u64 = 0;
+            let mut bases_masked_total: u64 = 0;
+
+            for decoded in records {
+                let mut record = decoded.into_raw_bytes();
+                let (bases_masked, pass) =
+                    process_record_raw_call(&mut record, &captures).map_err(io::Error::other)?;
+                bases_masked_total += bases_masked;
+
+                if pass {
+                    passed_count += 1;
+                    fgumi_raw_bam::write_framed_record(&mut kept_bytes, record.as_ref())?;
+                }
+                // No rejects: rejected records are simply dropped.
+            }
+
+            let prev = captures.progress.fetch_add(records_count, Ordering::Relaxed);
+            if (prev + records_count) / 1_000_000 > prev / 1_000_000 {
+                info!("Processed {} records", prev + records_count);
+            }
+            accumulators.with_slot(|m| {
+                m.total_records += records_count;
+                m.passed_records += passed_count;
+                m.failed_records += records_count - passed_count;
+                m.total_bases_masked += bases_masked_total;
+            });
+
+            Ok(DecompressedBlock { batch_serial, bytes: kept_bytes })
+        },
+    )
+}
+
+/// Build the single-read, with-rejects filter step.
+///
+/// `DecodedRecordBatch → (DecompressedBlock kept, DecompressedBlock rejects)`.
+/// Parallel, `ByItemOrdinal`. Branch 0 = kept records; branch 1 = rejected.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_filter`].
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_filter_step_single_with_rejects(
+    limit_bytes: u64,
+    captures: FilterProcessCaptures,
+    accumulators: Arc<PerThreadAccumulator<CollectedFilterMetrics>>,
+) -> Process2Ordered<
+    DecodedRecordBatch,
+    DecompressedBlock,
+    DecompressedBlock,
+    impl Fn(
+        DecodedRecordBatch,
+    ) -> io::Result<
+        crate::pipeline::steps::process::Process2Output<DecompressedBlock, DecompressedBlock>,
+    > + Send
+    + Sync
+    + 'static,
+> {
+    use crate::pipeline::steps::process::Process2Output;
+
+    const _: fn() = || {
+        fn assert_heap<T: crate::pipeline::core::item::HeapSize>() {}
+        assert_heap::<DecompressedBlock>();
+    };
+
+    process2_ordered::<DecodedRecordBatch, DecompressedBlock, DecompressedBlock, _>(
+        "FilterProcess",
+        limit_bytes,
+        limit_bytes,
+        move |item: DecodedRecordBatch|
+              -> io::Result<Process2Output<DecompressedBlock, DecompressedBlock>> {
+            let batch_serial = item.batch_serial();
+            let records = item.into_records();
+            let records_count = records.len() as u64;
+            let mut kept_bytes: Vec<u8> = Vec::new();
+            let mut rejected_bytes: Vec<u8> = Vec::new();
+            let mut passed_count: u64 = 0;
+            let mut bases_masked_total: u64 = 0;
+
+            for decoded in records {
+                let mut record = decoded.into_raw_bytes();
+                let (bases_masked, pass) = process_record_raw_call(&mut record, &captures)
+                    .map_err(io::Error::other)?;
+                bases_masked_total += bases_masked;
+
+                let target = if pass {
+                    passed_count += 1;
+                    &mut kept_bytes
+                } else {
+                    &mut rejected_bytes
+                };
+                fgumi_raw_bam::write_framed_record(target, record.as_ref())?;
+            }
+
+            let prev = captures.progress.fetch_add(records_count, Ordering::Relaxed);
+            if (prev + records_count) / 1_000_000 > prev / 1_000_000 {
+                info!("Processed {} records", prev + records_count);
+            }
+            accumulators.with_slot(|m| {
+                m.total_records += records_count;
+                m.passed_records += passed_count;
+                m.failed_records += records_count - passed_count;
+                m.total_bases_masked += bases_masked_total;
+            });
+
+            Ok(Process2Output::both(
+                DecompressedBlock { batch_serial, bytes: kept_bytes },
+                DecompressedBlock { batch_serial, bytes: rejected_bytes },
+            ))
+        },
+    )
+}
+
+/// Build the template-aware, no-rejects filter step.
+///
+/// `BamTemplateBatch → DecompressedBlock`. Parallel, `ByItemOrdinal`.
+/// Templates failing the filter are dropped; kept records are serialised.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_filter`].
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_filter_step_template_no_rejects(
+    limit_bytes: u64,
+    captures: FilterProcessCaptures,
+    accumulators: Arc<PerThreadAccumulator<CollectedFilterMetrics>>,
+) -> ProcessOrdered<
+    BamTemplateBatch,
+    DecompressedBlock,
+    impl Fn(BamTemplateBatch) -> io::Result<DecompressedBlock> + Send + Sync + 'static,
+> {
+    use crate::consensus_filter::template_passes;
+
+    process_ordered::<BamTemplateBatch, DecompressedBlock, _>(
+        "FilterProcess",
+        limit_bytes,
+        move |item: BamTemplateBatch| -> io::Result<DecompressedBlock> {
+            let (batch_serial, templates) = item.into_parts();
+            let mut kept_bytes: Vec<u8> = Vec::new();
+            let mut total_records: u64 = 0;
+            let mut passed_count: u64 = 0;
+            let mut bases_masked_total: u64 = 0;
+
+            for template in templates {
+                let mut template_records: Vec<RawRecord> = template.into_records();
+                let mut pass_map: AHashMap<usize, bool> = AHashMap::new();
+
+                for (idx, record) in template_records.iter_mut().enumerate() {
+                    total_records += 1;
+                    let (masked, pass) =
+                        process_record_raw_call(record, &captures).map_err(io::Error::other)?;
+                    bases_masked_total += masked;
+                    pass_map.insert(idx, pass);
+                }
+
+                let template_pass = template_passes(&template_records, &pass_map);
+
+                for (idx, record) in template_records.into_iter().enumerate() {
+                    let flags = fgumi_raw_bam::RawRecordView::new(&record).flags();
+                    let is_primary = (flags & fgumi_raw_bam::flags::SECONDARY) == 0
+                        && (flags & fgumi_raw_bam::flags::SUPPLEMENTARY) == 0;
+                    let keep = if is_primary {
+                        template_pass
+                    } else {
+                        template_pass && pass_map.get(&idx).copied().unwrap_or(false)
+                    };
+                    if keep {
+                        passed_count += 1;
+                        fgumi_raw_bam::write_framed_record(&mut kept_bytes, record.as_ref())?;
+                    }
+                }
+            }
+
+            let prev = captures.progress.fetch_add(total_records, Ordering::Relaxed);
+            if (prev + total_records) / 1_000_000 > prev / 1_000_000 {
+                info!("Processed {} records", prev + total_records);
+            }
+            accumulators.with_slot(|m| {
+                m.total_records += total_records;
+                m.passed_records += passed_count;
+                m.failed_records += total_records - passed_count;
+                m.total_bases_masked += bases_masked_total;
+            });
+
+            Ok(DecompressedBlock { batch_serial, bytes: kept_bytes })
+        },
+    )
+}
+
+/// Build the template-aware, with-rejects filter step.
+///
+/// `BamTemplateBatch → (DecompressedBlock kept, DecompressedBlock rejects)`.
+/// Parallel, `ByItemOrdinal`. Branch 0 = kept records; branch 1 = rejected.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_filter`].
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_filter_step_template_with_rejects(
+    limit_bytes: u64,
+    captures: FilterProcessCaptures,
+    accumulators: Arc<PerThreadAccumulator<CollectedFilterMetrics>>,
+) -> Process2Ordered<
+    BamTemplateBatch,
+    DecompressedBlock,
+    DecompressedBlock,
+    impl Fn(
+        BamTemplateBatch,
+    ) -> io::Result<
+        crate::pipeline::steps::process::Process2Output<DecompressedBlock, DecompressedBlock>,
+    > + Send
+    + Sync
+    + 'static,
+> {
+    use crate::consensus_filter::template_passes;
+    use crate::pipeline::steps::process::Process2Output;
+
+    process2_ordered::<BamTemplateBatch, DecompressedBlock, DecompressedBlock, _>(
+        "FilterProcess",
+        limit_bytes,
+        limit_bytes,
+        move |item: BamTemplateBatch|
+              -> io::Result<Process2Output<DecompressedBlock, DecompressedBlock>> {
+            let (batch_serial, templates) = item.into_parts();
+            let mut kept_bytes: Vec<u8> = Vec::new();
+            let mut rejected_bytes: Vec<u8> = Vec::new();
+            let mut total_records: u64 = 0;
+            let mut passed_count: u64 = 0;
+            let mut bases_masked_total: u64 = 0;
+
+            for template in templates {
+                let mut template_records: Vec<RawRecord> = template.into_records();
+                let mut pass_map: AHashMap<usize, bool> = AHashMap::new();
+
+                for (idx, record) in template_records.iter_mut().enumerate() {
+                    total_records += 1;
+                    let (masked, pass) = process_record_raw_call(record, &captures)
+                        .map_err(io::Error::other)?;
+                    bases_masked_total += masked;
+                    pass_map.insert(idx, pass);
+                }
+
+                let template_pass = template_passes(&template_records, &pass_map);
+
+                for (idx, record) in template_records.into_iter().enumerate() {
+                    let flags = fgumi_raw_bam::RawRecordView::new(&record).flags();
+                    let is_primary = (flags & fgumi_raw_bam::flags::SECONDARY) == 0
+                        && (flags & fgumi_raw_bam::flags::SUPPLEMENTARY) == 0;
+
+                    let keep = if is_primary {
+                        template_pass
+                    } else {
+                        template_pass && pass_map.get(&idx).copied().unwrap_or(false)
+                    };
+                    let target = if keep {
+                        passed_count += 1;
+                        &mut kept_bytes
+                    } else {
+                        &mut rejected_bytes
+                    };
+                    fgumi_raw_bam::write_framed_record(target, record.as_ref())?;
+                }
+            }
+
+            let prev = captures.progress.fetch_add(total_records, Ordering::Relaxed);
+            if (prev + total_records) / 1_000_000 > prev / 1_000_000 {
+                info!("Processed {} records", prev + total_records);
+            }
+            accumulators.with_slot(|m| {
+                m.total_records += total_records;
+                m.passed_records += passed_count;
+                m.failed_records += total_records - passed_count;
+                m.total_bases_masked += bases_masked_total;
+            });
+
+            Ok(Process2Output::both(
+                DecompressedBlock { batch_serial, bytes: kept_bytes },
+                DecompressedBlock { batch_serial, bytes: rejected_bytes },
+            ))
+        },
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// build_filter_chain — thin delegate
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build a [`BuiltPipeline`] for a filter-only chain.
+///
+/// Delegates to [`ChainBuilder`]. The full step sequence lives in
+/// [`ChainBuilder`]'s `add_filter` method in
+/// [`crate::pipeline::chains::builder`].
+///
+/// # Errors
+///
+/// Returns input-validation errors or any underlying pipeline construction error.
+#[allow(clippy::needless_pass_by_value)]
+pub fn build_filter_chain(spec: ChainSpec) -> Result<BuiltPipeline> {
+    use crate::pipeline::chains::{Stage, builder::StagePosition};
+    let mut chain = ChainBuilder::new(&spec)?;
+    chain.add_source()?;
+    chain.add_stage(Stage::Filter, StagePosition::Terminal)?;
+    chain.add_sink()?;
+    chain.build()
+}

--- a/src/lib/pipeline/chains/commands/filter.rs
+++ b/src/lib/pipeline/chains/commands/filter.rs
@@ -4,10 +4,8 @@
 //! Phase 3 (T3a.4) lifts that logic into
 //! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
 //! now holds the filter-specific types and step factories that the builder
-//! imports: [`FilterFinalizeHook`] and the step-factory functions used by
+//! imports: `FilterFinalizeHook` and the step-factory functions used by
 //! `ChainBuilder::add_filter`.
-//!
-//! [`build_filter_chain`] shrinks to a ~10-line delegate.
 //!
 //! ## Four chain shapes
 //!
@@ -34,8 +32,7 @@ use log::info;
 use crate::commands::filter::{CollectedFilterMetrics, Filter, FilterProcessCaptures};
 use crate::logging::OperationTimer;
 use crate::per_thread_accumulator::PerThreadAccumulator;
-use crate::pipeline::chains::builder::ChainBuilder;
-use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
+use crate::pipeline::chains::FinalizeHook;
 use crate::pipeline::steps::process::{
     Process2Ordered, ProcessOrdered, process_ordered, process2_ordered,
 };
@@ -45,21 +42,23 @@ use crate::pipeline::steps::types::{BamTemplateBatch, DecodedRecordBatch, Decomp
 // FilterFinalizeHook
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Post-pipeline finalize hook for filter. Reduces per-thread metrics,
-/// writes the optional stats file, and logs the summary banner.
+/// Post-pipeline finalize hook for filter. Reduces per-thread metrics and logs
+/// the summary banner. Registered on the **always-run** `finalize` list so the
+/// summary is reported even after a failure; the stats *file* is written by the
+/// success-only [`FilterStatsFinalizeHook`] instead, so a partial run never
+/// publishes counts.
 ///
-/// `pub(crate)` so [`ChainBuilder`] can construct and register it in
+/// `pub(crate)` so `ChainBuilder` can construct and register it in
 /// `add_filter`.
 pub(crate) struct FilterFinalizeHook {
     pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedFilterMetrics>>,
-    pub(crate) stats_path: Option<std::path::PathBuf>,
     pub(crate) has_rejects: bool,
     pub(crate) timer: OperationTimer,
 }
 
 impl FinalizeHook for FilterFinalizeHook {
     fn finalize(self: Box<Self>) -> Result<()> {
-        let FilterFinalizeHook { accumulators, stats_path, has_rejects, timer } = *self;
+        let FilterFinalizeHook { accumulators, has_rejects, timer } = *self;
 
         let mut total_reads = 0u64;
         let mut passed_reads = 0u64;
@@ -73,10 +72,6 @@ impl FinalizeHook for FilterFinalizeHook {
             total_bases_masked += m.total_bases_masked;
         }
 
-        if let Some(ref path) = stats_path {
-            write_filter_stats(path, total_reads, passed_reads, failed_reads)?;
-        }
-
         info!("Processed {total_reads} reads; kept {passed_reads} and rejected {failed_reads}");
         if has_rejects && failed_reads > 0 {
             info!("Wrote {failed_reads} rejected records to rejects file");
@@ -86,6 +81,33 @@ impl FinalizeHook for FilterFinalizeHook {
         timer.log_completion(total_reads);
 
         Ok(())
+    }
+}
+
+/// Success-only finalize hook that writes the `--filter::stats` file. Registered
+/// on `finalize_on_success` (not the always-run `finalize`) so a failed or
+/// partial run never publishes filter counts. Shares the accumulators with
+/// [`FilterFinalizeHook`] via `Arc`.
+pub(crate) struct FilterStatsFinalizeHook {
+    pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedFilterMetrics>>,
+    pub(crate) stats_path: std::path::PathBuf,
+}
+
+impl FinalizeHook for FilterStatsFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let FilterStatsFinalizeHook { accumulators, stats_path } = *self;
+
+        let mut total_reads = 0u64;
+        let mut passed_reads = 0u64;
+        let mut failed_reads = 0u64;
+        for slot in accumulators.slots() {
+            let m = slot.lock();
+            total_reads += m.total_records;
+            passed_reads += m.passed_records;
+            failed_reads += m.failed_records;
+        }
+
+        write_filter_stats(&stats_path, total_reads, passed_reads, failed_reads)
     }
 }
 
@@ -148,12 +170,35 @@ pub(crate) fn process_record_raw_call(
 // in `chains::commands::dedup`).
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Emit the per-batch progress milestone and fold this batch's counts into the
+/// per-thread accumulator. Shared by all four `build_filter_step_*` factories so
+/// the metrics contract lives in exactly one place (four copies of it is the
+/// sibling-divergence pattern that has shipped bugs in this module).
+fn record_batch_metrics(
+    captures: &FilterProcessCaptures,
+    accumulators: &PerThreadAccumulator<CollectedFilterMetrics>,
+    total_records: u64,
+    passed_count: u64,
+    bases_masked_total: u64,
+) {
+    let prev = captures.progress.fetch_add(total_records, Ordering::Relaxed);
+    if (prev + total_records) / 1_000_000 > prev / 1_000_000 {
+        info!("Processed {} records", prev + total_records);
+    }
+    accumulators.with_slot(|m| {
+        m.total_records += total_records;
+        m.passed_records += passed_count;
+        m.failed_records += total_records - passed_count;
+        m.total_bases_masked += bases_masked_total;
+    });
+}
+
 /// Build the single-read, no-rejects filter step.
 ///
 /// `DecodedRecordBatch → DecompressedBlock`. Parallel, `ByItemOrdinal`.
 /// Rejected records are dropped; kept records are serialised to raw BAM bytes.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_filter`].
+/// `pub(crate)` — consumed only by `ChainBuilder::add_filter`.
 #[allow(clippy::type_complexity)]
 pub(crate) fn build_filter_step_single_no_rejects(
     limit_bytes: u64,
@@ -188,16 +233,13 @@ pub(crate) fn build_filter_step_single_no_rejects(
                 // No rejects: rejected records are simply dropped.
             }
 
-            let prev = captures.progress.fetch_add(records_count, Ordering::Relaxed);
-            if (prev + records_count) / 1_000_000 > prev / 1_000_000 {
-                info!("Processed {} records", prev + records_count);
-            }
-            accumulators.with_slot(|m| {
-                m.total_records += records_count;
-                m.passed_records += passed_count;
-                m.failed_records += records_count - passed_count;
-                m.total_bases_masked += bases_masked_total;
-            });
+            record_batch_metrics(
+                &captures,
+                &accumulators,
+                records_count,
+                passed_count,
+                bases_masked_total,
+            );
 
             Ok(DecompressedBlock { batch_serial, bytes: kept_bytes })
         },
@@ -209,7 +251,7 @@ pub(crate) fn build_filter_step_single_no_rejects(
 /// `DecodedRecordBatch → (DecompressedBlock kept, DecompressedBlock rejects)`.
 /// Parallel, `ByItemOrdinal`. Branch 0 = kept records; branch 1 = rejected.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_filter`].
+/// `pub(crate)` — consumed only by `ChainBuilder::add_filter`.
 #[allow(clippy::type_complexity)]
 pub(crate) fn build_filter_step_single_with_rejects(
     limit_bytes: u64,
@@ -263,16 +305,13 @@ pub(crate) fn build_filter_step_single_with_rejects(
                 fgumi_raw_bam::write_framed_record(target, record.as_ref())?;
             }
 
-            let prev = captures.progress.fetch_add(records_count, Ordering::Relaxed);
-            if (prev + records_count) / 1_000_000 > prev / 1_000_000 {
-                info!("Processed {} records", prev + records_count);
-            }
-            accumulators.with_slot(|m| {
-                m.total_records += records_count;
-                m.passed_records += passed_count;
-                m.failed_records += records_count - passed_count;
-                m.total_bases_masked += bases_masked_total;
-            });
+            record_batch_metrics(
+                &captures,
+                &accumulators,
+                records_count,
+                passed_count,
+                bases_masked_total,
+            );
 
             Ok(Process2Output::both(
                 DecompressedBlock { batch_serial, bytes: kept_bytes },
@@ -287,7 +326,7 @@ pub(crate) fn build_filter_step_single_with_rejects(
 /// `BamTemplateBatch → DecompressedBlock`. Parallel, `ByItemOrdinal`.
 /// Templates failing the filter are dropped; kept records are serialised.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_filter`].
+/// `pub(crate)` — consumed only by `ChainBuilder::add_filter`.
 #[allow(clippy::type_complexity)]
 pub(crate) fn build_filter_step_template_no_rejects(
     limit_bytes: u64,
@@ -340,16 +379,13 @@ pub(crate) fn build_filter_step_template_no_rejects(
                 }
             }
 
-            let prev = captures.progress.fetch_add(total_records, Ordering::Relaxed);
-            if (prev + total_records) / 1_000_000 > prev / 1_000_000 {
-                info!("Processed {} records", prev + total_records);
-            }
-            accumulators.with_slot(|m| {
-                m.total_records += total_records;
-                m.passed_records += passed_count;
-                m.failed_records += total_records - passed_count;
-                m.total_bases_masked += bases_masked_total;
-            });
+            record_batch_metrics(
+                &captures,
+                &accumulators,
+                total_records,
+                passed_count,
+                bases_masked_total,
+            );
 
             Ok(DecompressedBlock { batch_serial, bytes: kept_bytes })
         },
@@ -361,7 +397,7 @@ pub(crate) fn build_filter_step_template_no_rejects(
 /// `BamTemplateBatch → (DecompressedBlock kept, DecompressedBlock rejects)`.
 /// Parallel, `ByItemOrdinal`. Branch 0 = kept records; branch 1 = rejected.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_filter`].
+/// `pub(crate)` — consumed only by `ChainBuilder::add_filter`.
 #[allow(clippy::type_complexity)]
 pub(crate) fn build_filter_step_template_with_rejects(
     limit_bytes: u64,
@@ -429,16 +465,13 @@ pub(crate) fn build_filter_step_template_with_rejects(
                 }
             }
 
-            let prev = captures.progress.fetch_add(total_records, Ordering::Relaxed);
-            if (prev + total_records) / 1_000_000 > prev / 1_000_000 {
-                info!("Processed {} records", prev + total_records);
-            }
-            accumulators.with_slot(|m| {
-                m.total_records += total_records;
-                m.passed_records += passed_count;
-                m.failed_records += total_records - passed_count;
-                m.total_bases_masked += bases_masked_total;
-            });
+            record_batch_metrics(
+                &captures,
+                &accumulators,
+                total_records,
+                passed_count,
+                bases_masked_total,
+            );
 
             Ok(Process2Output::both(
                 DecompressedBlock { batch_serial, bytes: kept_bytes },
@@ -446,27 +479,4 @@ pub(crate) fn build_filter_step_template_with_rejects(
             ))
         },
     )
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// build_filter_chain — thin delegate
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Build a [`BuiltPipeline`] for a filter-only chain.
-///
-/// Delegates to [`ChainBuilder`]. The full step sequence lives in
-/// [`ChainBuilder`]'s `add_filter` method in
-/// [`crate::pipeline::chains::builder`].
-///
-/// # Errors
-///
-/// Returns input-validation errors or any underlying pipeline construction error.
-#[allow(clippy::needless_pass_by_value)]
-pub fn build_filter_chain(spec: ChainSpec) -> Result<BuiltPipeline> {
-    use crate::pipeline::chains::{Stage, builder::StagePosition};
-    let mut chain = ChainBuilder::new(&spec)?;
-    chain.add_source()?;
-    chain.add_stage(Stage::Filter, StagePosition::Terminal)?;
-    chain.add_sink()?;
-    chain.build()
 }

--- a/src/lib/pipeline/chains/commands/group.rs
+++ b/src/lib/pipeline/chains/commands/group.rs
@@ -1,0 +1,488 @@
+//! Chain builder for `Stage::Group`.
+//!
+//! Phase 2 (T2.17) held the full ~500-LOC chain construction here.
+//! Phase 3 (T3a.7) lifts that logic into
+//! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
+//! now holds the group-specific types and step factories that the builder
+//! imports: [`GroupFinalizeHook`] and the three step-factory functions used
+//! by `ChainBuilder::add_group`.
+//!
+//! [`build_group_chain`] shrinks to a ~10-line delegate.
+//!
+//! Mirrors the dedup (6423252), filter (8eead93), clip (8e95428) reference
+//! migrations.
+
+use std::io;
+use std::sync::Arc;
+
+use ahash::AHashMap;
+use anyhow::Result;
+
+use crate::assigner::Strategy;
+use crate::commands::group::{
+    GroupMetricsAccumulator, ParallelMinTemplates, assign_umi_groups_impl, build_grouping_metrics,
+    create_umi_assigner, should_use_parallel, write_metrics_for_chain,
+};
+use crate::grouper::{ProcessedPositionGroup, build_templates_from_records};
+use crate::logging::OperationTimer;
+use crate::per_thread_accumulator::PerThreadAccumulator;
+use crate::pipeline::chains::builder::ChainBuilder;
+use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
+use crate::pipeline::steps::group::position::{
+    BatchedProcessedPositionGroups, BatchedRawPositionGroups,
+};
+use crate::pipeline::steps::process::{
+    MiAssign, ProcessOrdered, ProcessWithWorkerState, mi_assign, process_ordered,
+};
+use crate::pipeline::steps::serialize_processed::{
+    SerializeState, build_serialize_processed_groups_step,
+};
+use crate::pipeline::steps::types::DecompressedBlock;
+use crate::template::Template;
+use crate::template_filter::{TemplateFilterConfig, filter_template};
+use fgumi_metrics::TemplateFilterCounts;
+use fgumi_umi::IndexThreshold;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GroupFinalizeHook
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Post-pipeline finalize hook for group. Reduces per-thread metric
+/// accumulators, writes the optional metrics files (family-size histogram,
+/// grouping-metrics, position-group-size histogram, and `--metrics PREFIX`
+/// outputs), logs the UMI grouping summary banner, and calls
+/// `timer.log_completion`.
+///
+/// `pub(crate)` so [`ChainBuilder`] can construct and register it in
+/// `add_group`.
+pub(crate) struct GroupFinalizeHook {
+    pub(crate) accumulators: Arc<PerThreadAccumulator<GroupMetricsAccumulator>>,
+    pub(crate) output_path: std::path::PathBuf,
+    pub(crate) family_size_histogram: Option<std::path::PathBuf>,
+    pub(crate) grouping_metrics: Option<std::path::PathBuf>,
+    pub(crate) metrics_prefix: Option<std::path::PathBuf>,
+    pub(crate) timer: OperationTimer,
+}
+
+impl FinalizeHook for GroupFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        use crate::logging::log_umi_grouping_summary;
+        use log::info;
+
+        let GroupFinalizeHook {
+            accumulators,
+            output_path,
+            family_size_histogram,
+            grouping_metrics,
+            metrics_prefix,
+            timer,
+        } = *self;
+
+        // Reduce per-thread accumulators.
+        let mut family_size_counter: AHashMap<usize, u64> = AHashMap::new();
+        let mut position_group_size_counter: AHashMap<usize, u64> = AHashMap::new();
+        let mut total_filter_counts = TemplateFilterCounts::new();
+        for slot in accumulators.slots() {
+            let acc = slot.lock();
+            for (&size, &count) in &acc.family_sizes {
+                *family_size_counter.entry(size).or_insert(0) += count;
+            }
+            for (&size, &count) in &acc.position_group_sizes {
+                *position_group_size_counter.entry(size).or_insert(0) += count;
+            }
+            total_filter_counts.merge(&acc.filter_counts);
+        }
+
+        let metrics = build_grouping_metrics(&total_filter_counts, &family_size_counter);
+
+        // Log summary banner (verbatim from the original execute).
+        log_umi_grouping_summary(&metrics);
+
+        // Write individual flag outputs and --metrics prefix outputs when any
+        // output path was requested.
+        if family_size_histogram.is_some() || grouping_metrics.is_some() || metrics_prefix.is_some()
+        {
+            write_metrics_for_chain(
+                &metrics,
+                &family_size_counter,
+                &position_group_size_counter,
+                family_size_histogram.as_deref(),
+                grouping_metrics.as_deref(),
+                metrics_prefix.as_deref(),
+            )?;
+        }
+
+        timer.log_completion(metrics.accepted_records);
+
+        info!("Wrote output to {}", output_path.display());
+        info!("group completed successfully");
+        info!("Records accepted by group: {}", metrics.accepted_records);
+
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Step factories — extracted from build_group_chain (T3a.7).
+//
+// Each factory receives its captured state as plain arguments and returns the
+// concrete step type. Returning `impl Step<...>` is blocked here because the
+// closure types embed in opaque-return position and cannot name themselves, so
+// we return the concrete `Process*` structs directly (the same pattern used by
+// the dedup factories in `chains::commands::dedup`).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build the `GroupProcess` step: parallel, `ByItemOrdinal`. Filters
+/// templates, assigns UMI groups, tracks per-thread family-size and filter
+/// metrics, and emits [`BatchedProcessedPositionGroups`].
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_group`].
+#[allow(clippy::type_complexity, clippy::too_many_arguments, clippy::too_many_lines)]
+pub(crate) fn build_group_process_step(
+    limit_bytes: u64,
+    strategy: Strategy,
+    effective_edits: u32,
+    index_threshold: IndexThreshold,
+    raw_tag: [u8; 2],
+    no_umi: bool,
+    allow_unmapped: bool,
+    parallel_group_min_templates: Option<ParallelMinTemplates>,
+    num_threads: usize,
+    filter_config: TemplateFilterConfig,
+    accumulators: Arc<PerThreadAccumulator<GroupMetricsAccumulator>>,
+) -> ProcessOrdered<
+    BatchedRawPositionGroups,
+    BatchedProcessedPositionGroups,
+    impl Fn(BatchedRawPositionGroups) -> io::Result<BatchedProcessedPositionGroups>
+    + Send
+    + Sync
+    + 'static,
+> {
+    process_ordered::<BatchedRawPositionGroups, BatchedProcessedPositionGroups, _>(
+        "GroupProcess",
+        limit_bytes,
+        move |item: BatchedRawPositionGroups| -> io::Result<BatchedProcessedPositionGroups> {
+            let BatchedRawPositionGroups { batch_serial, groups } = item;
+            let mut processed_batch: Vec<ProcessedPositionGroup> = Vec::with_capacity(groups.len());
+
+            // Uniform cases build one assigner for the whole batch and reuse it
+            // across every group (preserving the per-batch reuse):
+            // `--allow-unmapped` always goes parallel, and the no-threshold
+            // default always stays sequential. The per-group
+            // `--parallel-group-min-templates` threshold must decide per group
+            // (template counts vary), so it builds inside the loop below. See
+            // `should_use_parallel` / `create_umi_assigner` in `commands::group`.
+            let batch_assigner: Option<Box<dyn crate::assigner::UmiAssigner>> =
+                if allow_unmapped || parallel_group_min_templates.is_none() {
+                    Some(create_umi_assigner(
+                        strategy,
+                        effective_edits,
+                        index_threshold,
+                        num_threads,
+                        allow_unmapped,
+                    ))
+                } else {
+                    None
+                };
+
+            for group in groups {
+                let mut filter_counts = TemplateFilterCounts::new();
+                let all_templates =
+                    build_templates_from_records(group.records).map_err(io::Error::other)?;
+                let input_record_count: u64 =
+                    all_templates.iter().map(|t| t.read_count() as u64).sum();
+
+                let filtered_templates: Vec<Template> = all_templates
+                    .into_iter()
+                    .filter(|t| filter_template(t, &filter_config, &mut filter_counts))
+                    .collect();
+
+                if filtered_templates.is_empty() {
+                    accumulators.with_slot(|acc| {
+                        acc.record_group(AHashMap::new(), &filter_counts);
+                    });
+                    processed_batch.push(ProcessedPositionGroup {
+                        templates: Vec::new(),
+                        family_sizes: AHashMap::new(),
+                        filter_counts,
+                        input_record_count,
+                        distinct_mi_count: 0,
+                    });
+                    continue;
+                }
+
+                // Pick the assigner for this group: reuse the batch-wide one for
+                // the uniform cases, or build a per-group one when the threshold
+                // flag is set (the decision depends on this group's size).
+                let per_group_assigner;
+                let assigner: &dyn crate::assigner::UmiAssigner =
+                    if let Some(batch) = &batch_assigner {
+                        batch.as_ref()
+                    } else {
+                        let use_parallel = should_use_parallel(
+                            allow_unmapped,
+                            filtered_templates.len(),
+                            strategy,
+                            parallel_group_min_templates.as_ref(),
+                        );
+                        per_group_assigner = create_umi_assigner(
+                            strategy,
+                            effective_edits,
+                            index_threshold,
+                            num_threads,
+                            use_parallel,
+                        );
+                        per_group_assigner.as_ref()
+                    };
+
+                assigner.reset();
+
+                let mut templates = filtered_templates;
+                if let Err(e) = assign_umi_groups_impl(
+                    &mut templates,
+                    assigner,
+                    raw_tag,
+                    filter_config.min_umi_length,
+                    no_umi,
+                ) {
+                    // A failed assignment means this position group's reads cannot be
+                    // grouped at all — an unparseable UMI for the chosen strategy, a
+                    // missing `RX` tag, mixed UMI lengths. Substituting an empty group
+                    // would silently drop every read in it and still exit 0, so fail
+                    // the run and let the user fix the input or the strategy. (Matches
+                    // the non-chain `Group::execute` path.)
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("Failed to assign UMI groups: {e:#}"),
+                    ));
+                }
+
+                let distinct_mi_count: u64 =
+                    templates.iter().filter_map(|t| t.mi.id()).max().map_or(0, |max_id| max_id + 1);
+
+                templates.sort_by(|a, b| {
+                    let a_idx = a.mi.to_vec_index();
+                    let b_idx = b.mi.to_vec_index();
+                    a_idx.cmp(&b_idx).then_with(|| a.name.cmp(&b.name))
+                });
+
+                let mut family_sizes: AHashMap<usize, u64> = AHashMap::with_capacity(50);
+                if !templates.is_empty() {
+                    let mut current_mi = templates[0].mi.to_vec_index();
+                    let mut current_count = 1usize;
+                    for template in templates.iter().skip(1) {
+                        let mi = template.mi.to_vec_index();
+                        if mi == current_mi {
+                            current_count += 1;
+                        } else {
+                            if current_mi.is_some() {
+                                *family_sizes.entry(current_count).or_insert(0) += 1;
+                            }
+                            current_mi = mi;
+                            current_count = 1;
+                        }
+                    }
+                    if current_mi.is_some() {
+                        *family_sizes.entry(current_count).or_insert(0) += 1;
+                    }
+                }
+                accumulators.with_slot(|acc| {
+                    acc.record_group(family_sizes.clone(), &filter_counts);
+                });
+
+                processed_batch.push(ProcessedPositionGroup {
+                    templates,
+                    family_sizes,
+                    filter_counts,
+                    input_record_count,
+                    distinct_mi_count,
+                });
+            }
+
+            Ok(BatchedProcessedPositionGroups::new(batch_serial, processed_batch))
+        },
+    )
+}
+
+/// Build the `MiAssignGroups` step: serial, `ByItemOrdinal`. Assigns
+/// monotonically increasing MI offsets to each batch of processed position
+/// groups.
+///
+/// Group uses [`BatchedProcessedPositionGroups`] (not the dedup-specific
+/// `BatchedProcessedDedupGroups`), so this factory is distinct from
+/// `chains::commands::dedup::build_mi_assign_step`.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_group`].
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_group_mi_assign_step(
+    limit_bytes: u64,
+) -> MiAssign<
+    BatchedProcessedPositionGroups,
+    BatchedProcessedPositionGroups,
+    impl Fn(&mut u64, BatchedProcessedPositionGroups) -> io::Result<BatchedProcessedPositionGroups>
+    + Send
+    + Sync
+    + 'static,
+> {
+    mi_assign::<BatchedProcessedPositionGroups, BatchedProcessedPositionGroups, _>(
+        "MiAssignGroups",
+        limit_bytes,
+        move |next_mi: &mut u64, mut item: BatchedProcessedPositionGroups| {
+            assign_mi_offsets(next_mi, &mut item)?;
+            Ok(item)
+        },
+    )
+}
+
+/// Assign global `MoleculeId` offsets to every template in `item`, advancing the
+/// running `next_mi` counter by each group's `distinct_mi_count`.
+///
+/// Each group reserves a contiguous block `[base, base + distinct_mi_count)`
+/// from the global counter and shifts its templates' local MI ids by `base`.
+///
+/// # Errors
+///
+/// Returns an [`io::Error`] if the cumulative MI counter would exceed
+/// [`u64::MAX`].
+fn assign_mi_offsets(
+    next_mi: &mut u64,
+    item: &mut BatchedProcessedPositionGroups,
+) -> io::Result<()> {
+    for processed in &mut item.groups {
+        let count = processed.distinct_mi_count;
+        let base = *next_mi;
+        *next_mi = next_mi.checked_add(count).ok_or_else(|| {
+            io::Error::other(
+                "MoleculeId offset overflow: cumulative MI counter \
+                 exceeded u64::MAX",
+            )
+        })?;
+        for template in &mut processed.templates {
+            template.mi = template.mi.with_offset(base);
+        }
+    }
+    Ok(())
+}
+
+/// Build the `SerializeGroups` step for group: parallel, `ByItemOrdinal`.
+/// Serializes each [`BatchedProcessedPositionGroups`] to raw BAM bytes
+/// ([`DecompressedBlock`]).
+///
+/// Delegates to the shared
+/// [`build_serialize_processed_groups_step`][`crate::pipeline::steps::serialize_processed::build_serialize_processed_groups_step`]
+/// used by both the standalone `fgumi group` chain and the runall
+/// `--stop-after group` fused path.
+///
+/// Only included in the chain when the stage is
+/// [`StagePosition::Terminal`][`crate::pipeline::chains::builder::StagePosition`];
+/// for `Intermediate` the chain tail stays as [`BatchedProcessedPositionGroups`]
+/// for the next stage's input.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_group`].
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_group_serialize_step(
+    limit_bytes: u64,
+    assign_tag_bytes: [u8; 2],
+    progress_counter: Arc<std::sync::atomic::AtomicU64>,
+) -> ProcessWithWorkerState<
+    BatchedProcessedPositionGroups,
+    DecompressedBlock,
+    impl Fn(&mut SerializeState, BatchedProcessedPositionGroups) -> io::Result<DecompressedBlock>
+    + Send
+    + Sync
+    + 'static,
+    SerializeState,
+    impl Fn() -> SerializeState + Send + Sync + 'static,
+> {
+    build_serialize_processed_groups_step(limit_bytes, assign_tag_bytes, progress_counter)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// build_group_chain — thin delegate (Phase 3 T3a.7)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build a [`BuiltPipeline`] for a group-only chain.
+///
+/// Delegates to [`ChainBuilder`]. The full step sequence lives in
+/// [`ChainBuilder`]'s `add_group` method in
+/// [`crate::pipeline::chains::builder`].
+///
+/// The live `group --threads` path is served by the chain builder via
+/// [`crate::pipeline::chains::build::build_for`] (which `GroupReadsByUmi::execute`
+/// calls when `--threads` is set); with `--threads` unset the command still uses
+/// its single-threaded executor. This `build_group_chain` is the group-only
+/// chain delegate.
+///
+/// # Errors
+///
+/// Returns input-validation errors (sort-order mismatch, strategy/UMI
+/// incompatibility) or any underlying pipeline construction error.
+#[allow(clippy::needless_pass_by_value)]
+pub fn build_group_chain(spec: ChainSpec) -> Result<BuiltPipeline> {
+    use crate::pipeline::chains::{Stage, builder::StagePosition};
+    let mut chain = ChainBuilder::new(&spec)?;
+    chain.add_source()?;
+    chain.add_stage(Stage::Group, StagePosition::Terminal)?;
+    chain.add_sink()?;
+    chain.build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grouper::ProcessedPositionGroup;
+    use fgumi_umi::MoleculeId;
+
+    /// Build a [`ProcessedPositionGroup`] carrying `distinct_mi_count` and the
+    /// given local-id templates (each as a `MoleculeId::Single`).
+    fn make_group(distinct_mi_count: u64, local_ids: &[u64]) -> ProcessedPositionGroup {
+        let templates = local_ids
+            .iter()
+            .map(|&id| {
+                let mut template = Template::new(Vec::new());
+                template.mi = MoleculeId::Single(id);
+                template
+            })
+            .collect();
+        ProcessedPositionGroup {
+            templates,
+            family_sizes: AHashMap::default(),
+            filter_counts: TemplateFilterCounts::default(),
+            input_record_count: 0,
+            distinct_mi_count,
+        }
+    }
+
+    #[test]
+    fn assign_mi_offsets_advances_counter_and_shifts_local_ids() {
+        // Two groups; the second must be offset past the first's block.
+        let mut item = BatchedProcessedPositionGroups::new(
+            0,
+            vec![make_group(2, &[0, 1]), make_group(3, &[0, 1, 2])],
+        );
+        let mut next_mi = 10;
+
+        assign_mi_offsets(&mut next_mi, &mut item).expect("no overflow");
+
+        // Counter advanced by 2 + 3 over the starting value of 10.
+        assert_eq!(next_mi, 15);
+        // First group offset by base 10.
+        assert_eq!(item.groups[0].templates[0].mi, MoleculeId::Single(10));
+        assert_eq!(item.groups[0].templates[1].mi, MoleculeId::Single(11));
+        // Second group offset by base 12 (10 + first group's count of 2).
+        assert_eq!(item.groups[1].templates[0].mi, MoleculeId::Single(12));
+        assert_eq!(item.groups[1].templates[2].mi, MoleculeId::Single(14));
+    }
+
+    #[test]
+    fn assign_mi_offsets_errors_on_counter_overflow() {
+        // A non-zero starting counter plus a u64::MAX block overflows.
+        let mut item = BatchedProcessedPositionGroups::new(0, vec![make_group(u64::MAX, &[])]);
+        let mut next_mi = 1;
+
+        let err = assign_mi_offsets(&mut next_mi, &mut item)
+            .expect_err("cumulative MI counter should overflow");
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert!(err.to_string().contains("MoleculeId offset overflow"));
+    }
+}

--- a/src/lib/pipeline/chains/commands/group.rs
+++ b/src/lib/pipeline/chains/commands/group.rs
@@ -4,10 +4,8 @@
 //! Phase 3 (T3a.7) lifts that logic into
 //! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
 //! now holds the group-specific types and step factories that the builder
-//! imports: [`GroupFinalizeHook`] and the three step-factory functions used
+//! imports: `GroupFinalizeHook` and the three step-factory functions used
 //! by `ChainBuilder::add_group`.
-//!
-//! [`build_group_chain`] shrinks to a ~10-line delegate.
 //!
 //! Mirrors the dedup (6423252), filter (8eead93), clip (8e95428) reference
 //! migrations.
@@ -26,8 +24,7 @@ use crate::commands::group::{
 use crate::grouper::{ProcessedPositionGroup, build_templates_from_records};
 use crate::logging::OperationTimer;
 use crate::per_thread_accumulator::PerThreadAccumulator;
-use crate::pipeline::chains::builder::ChainBuilder;
-use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
+use crate::pipeline::chains::FinalizeHook;
 use crate::pipeline::steps::group::position::{
     BatchedProcessedPositionGroups, BatchedRawPositionGroups,
 };
@@ -53,7 +50,7 @@ use fgumi_umi::IndexThreshold;
 /// outputs), logs the UMI grouping summary banner, and calls
 /// `timer.log_completion`.
 ///
-/// `pub(crate)` so [`ChainBuilder`] can construct and register it in
+/// `pub(crate)` so `ChainBuilder` can construct and register it in
 /// `add_group`.
 pub(crate) struct GroupFinalizeHook {
     pub(crate) accumulators: Arc<PerThreadAccumulator<GroupMetricsAccumulator>>,
@@ -136,7 +133,7 @@ impl FinalizeHook for GroupFinalizeHook {
 /// templates, assigns UMI groups, tracks per-thread family-size and filter
 /// metrics, and emits [`BatchedProcessedPositionGroups`].
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_group`].
+/// `pub(crate)` — consumed only by `ChainBuilder::add_group`.
 #[allow(clippy::type_complexity, clippy::too_many_arguments, clippy::too_many_lines)]
 pub(crate) fn build_group_process_step(
     limit_bytes: u64,
@@ -312,7 +309,7 @@ pub(crate) fn build_group_process_step(
 /// `BatchedProcessedDedupGroups`), so this factory is distinct from
 /// `chains::commands::dedup::build_mi_assign_step`.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_group`].
+/// `pub(crate)` — consumed only by `ChainBuilder::add_group`.
 #[allow(clippy::type_complexity)]
 pub(crate) fn build_group_mi_assign_step(
     limit_bytes: u64,
@@ -378,7 +375,7 @@ fn assign_mi_offsets(
 /// for `Intermediate` the chain tail stays as [`BatchedProcessedPositionGroups`]
 /// for the next stage's input.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_group`].
+/// `pub(crate)` — consumed only by `ChainBuilder::add_group`.
 #[allow(clippy::type_complexity)]
 pub(crate) fn build_group_serialize_step(
     limit_bytes: u64,
@@ -395,36 +392,6 @@ pub(crate) fn build_group_serialize_step(
     impl Fn() -> SerializeState + Send + Sync + 'static,
 > {
     build_serialize_processed_groups_step(limit_bytes, assign_tag_bytes, progress_counter)
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// build_group_chain — thin delegate (Phase 3 T3a.7)
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Build a [`BuiltPipeline`] for a group-only chain.
-///
-/// Delegates to [`ChainBuilder`]. The full step sequence lives in
-/// [`ChainBuilder`]'s `add_group` method in
-/// [`crate::pipeline::chains::builder`].
-///
-/// The live `group --threads` path is served by the chain builder via
-/// [`crate::pipeline::chains::build::build_for`] (which `GroupReadsByUmi::execute`
-/// calls when `--threads` is set); with `--threads` unset the command still uses
-/// its single-threaded executor. This `build_group_chain` is the group-only
-/// chain delegate.
-///
-/// # Errors
-///
-/// Returns input-validation errors (sort-order mismatch, strategy/UMI
-/// incompatibility) or any underlying pipeline construction error.
-#[allow(clippy::needless_pass_by_value)]
-pub fn build_group_chain(spec: ChainSpec) -> Result<BuiltPipeline> {
-    use crate::pipeline::chains::{Stage, builder::StagePosition};
-    let mut chain = ChainBuilder::new(&spec)?;
-    chain.add_source()?;
-    chain.add_stage(Stage::Group, StagePosition::Terminal)?;
-    chain.add_sink()?;
-    chain.build()
 }
 
 #[cfg(test)]

--- a/src/lib/pipeline/chains/commands/mod.rs
+++ b/src/lib/pipeline/chains/commands/mod.rs
@@ -1,0 +1,39 @@
+//! Per-command chain-builder support. Each module holds the pieces
+//! [`super::builder::ChainBuilder`] needs for one command's stage: a
+//! `FinalizeHook` and any concrete-typed step factories.
+//!
+//! Stage dispatch is driven by [`super::build::build_for`], which matches on
+//! `spec.stages` and drives `ChainBuilder` directly.
+
+pub mod align;
+pub mod clip;
+#[cfg(feature = "consensus")]
+pub mod codec;
+pub mod correct;
+pub mod dedup;
+#[cfg(feature = "consensus")]
+pub mod duplex;
+pub mod extract;
+pub mod fastq;
+pub mod filter;
+pub mod group;
+#[cfg(feature = "consensus")]
+pub mod simplex;
+pub mod sort;
+pub mod zipper;
+
+/// Append `rec` to `dst` framed as a BAM record block: a 4-byte little-endian
+/// length prefix followed by the record bytes. Shared by the consensus
+/// command builders' rejects-serialization paths (codec/simplex/duplex), which
+/// emit raw record bytes into a `DecompressedBlock` buffer.
+///
+/// Thin wrapper over [`fgumi_raw_bam::write_framed_record`], the canonical BAM
+/// record framing (also used by `UnmappedSamBuilder::write_with_block_size`), so
+/// the length-prefix arithmetic lives in exactly one place and cannot drift.
+//
+// Only the consensus command builders (codec/simplex/duplex) call this, so it
+// is gated under `consensus` to avoid a dead-code warning when consensus is off.
+#[cfg(feature = "consensus")]
+pub(crate) fn append_framed_bytes(dst: &mut Vec<u8>, rec: &[u8]) -> std::io::Result<()> {
+    fgumi_raw_bam::write_framed_record(dst, rec)
+}

--- a/src/lib/pipeline/chains/commands/simplex.rs
+++ b/src/lib/pipeline/chains/commands/simplex.rs
@@ -4,16 +4,14 @@
 //! Phase 3 (T3a.8) lifts that logic into
 //! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
 //! now holds the simplex-specific types and step factory that the builder
-//! imports: [`SimplexFinalizeHook`] and the `build_simplex_consensus_step_with_rejects` / `build_simplex_consensus_step_kept_only` factories, used
+//! imports: `SimplexFinalizeHook` and the `build_simplex_consensus_step_with_rejects` / `build_simplex_consensus_step_kept_only` factories, used
 //! by `ChainBuilder::add_simplex`.
-//!
-//! [`build_simplex_chain`] shrinks to a ~10-line delegate.
 //!
 //! Mirrors the dedup (6423252), filter (8eead93), clip (8e95428), group
 //! (d371d84) reference migrations.
 //!
 //! This module supplies the chain-builder pieces for the simplex stage; the
-//! chain is constructed via [`ChainBuilder`] /
+//! chain is constructed via `ChainBuilder` /
 //! [`crate::pipeline::chains::build::build_for`]. It is not yet wired as
 //! `Simplex::execute`'s live path.
 
@@ -36,8 +34,7 @@ use crate::overlapping_consensus::{
     apply_overlapping_consensus,
 };
 use crate::per_thread_accumulator::PerThreadAccumulator;
-use crate::pipeline::chains::builder::ChainBuilder;
-use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
+use crate::pipeline::chains::FinalizeHook;
 use crate::pipeline::core::outputs::OrderedBytesTuple2;
 use crate::pipeline::core::step::Step;
 use crate::pipeline::steps::group::mi::BatchedMiGroups;
@@ -57,7 +54,7 @@ use crate::vanilla_consensus_caller::{VanillaUmiConsensusCaller, VanillaUmiConse
 /// Merged into final aggregates after the pipeline completes; one instance
 /// per worker slot (see [`PerThreadAccumulator`]).
 ///
-/// `pub(crate)` so [`ChainBuilder`] can construct it in `add_simplex`.
+/// `pub(crate)` so `ChainBuilder` can construct it in `add_simplex`.
 #[derive(Default)]
 pub(crate) struct CollectedSimplexMetrics {
     /// Consensus calling statistics.
@@ -93,7 +90,7 @@ impl crate::pipeline::core::item::HeapSize for ConsensusState {}
 /// (if enabled), logs the summary banner, finalizes the rejects writer,
 /// and calls `timer.log_completion`.
 ///
-/// `pub(crate)` so [`ChainBuilder`] can construct and register it in
+/// `pub(crate)` so `ChainBuilder` can construct and register it in
 /// `add_simplex`.
 pub(crate) struct SimplexFinalizeHook {
     pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedSimplexMetrics>>,
@@ -166,7 +163,7 @@ impl FinalizeHook for SimplexFinalizeHook {
 /// Bundles all the cloned scalars and Arcs the closure needs so `add_simplex`
 /// can prepare them once and hand them off cleanly.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_simplex`] and
+/// `pub(crate)` — consumed only by `ChainBuilder::add_simplex` and
 /// [`build_simplex_consensus_step_with_rejects`] / [`build_simplex_consensus_step_kept_only`].
 pub(crate) struct SimplexConsensusCaptures {
     pub(crate) track_rejects: bool,
@@ -310,7 +307,7 @@ fn run_simplex_consensus_batch(
 /// branch 0 carries the consensus `DecompressedBlock`, branch 1 carries the
 /// rejects `DecompressedBlock`. Parallel, `ByItemOrdinal`.
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_simplex`].
+/// `pub(crate)` — consumed only by `ChainBuilder::add_simplex`.
 pub(crate) fn build_simplex_consensus_step_with_rejects(
     limit_bytes: u64,
     cap: SimplexConsensusCaptures,
@@ -381,7 +378,7 @@ pub(crate) fn build_simplex_consensus_step_with_rejects(
 /// produced; the framework has no public discard sink, so omitting the rejects
 /// branch requires this single-output variant (mirrors `correct_step_kept_only`).
 ///
-/// `pub(crate)` — consumed only by [`ChainBuilder::add_simplex`].
+/// `pub(crate)` — consumed only by `ChainBuilder::add_simplex`.
 #[allow(clippy::type_complexity)]
 pub(crate) fn build_simplex_consensus_step_kept_only(
     limit_bytes: u64,
@@ -436,28 +433,4 @@ pub(crate) fn build_simplex_consensus_step_kept_only(
         init,
         body,
     )
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// build_simplex_chain — thin delegate (Phase 3 T3a.8)
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Build a [`BuiltPipeline`] for a simplex-only chain.
-///
-/// Delegates to [`ChainBuilder`]. The full step sequence lives in
-/// [`ChainBuilder`]'s `add_simplex` method in
-/// [`crate::pipeline::chains::builder`].
-///
-/// # Errors
-///
-/// Returns input-validation errors (missing reference for methylation mode,
-/// etc.) or any underlying pipeline construction error.
-#[allow(clippy::needless_pass_by_value)]
-pub fn build_simplex_chain(spec: ChainSpec) -> Result<BuiltPipeline> {
-    use crate::pipeline::chains::{Stage, builder::StagePosition};
-    let mut chain = ChainBuilder::new(&spec)?;
-    chain.add_source()?;
-    chain.add_stage(Stage::Simplex, StagePosition::Terminal)?;
-    chain.add_sink()?;
-    chain.build()
 }

--- a/src/lib/pipeline/chains/commands/simplex.rs
+++ b/src/lib/pipeline/chains/commands/simplex.rs
@@ -1,0 +1,463 @@
+//! Chain builder for `Stage::Simplex`.
+//!
+//! Phase 2 (T2.18) held the full ~500-LOC chain construction here.
+//! Phase 3 (T3a.8) lifts that logic into
+//! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
+//! now holds the simplex-specific types and step factory that the builder
+//! imports: [`SimplexFinalizeHook`] and the `build_simplex_consensus_step_with_rejects` / `build_simplex_consensus_step_kept_only` factories, used
+//! by `ChainBuilder::add_simplex`.
+//!
+//! [`build_simplex_chain`] shrinks to a ~10-line delegate.
+//!
+//! Mirrors the dedup (6423252), filter (8eead93), clip (8e95428), group
+//! (d371d84) reference migrations.
+//!
+//! This module supplies the chain-builder pieces for the simplex stage; the
+//! chain is constructed via [`ChainBuilder`] /
+//! [`crate::pipeline::chains::build::build_for`]. It is not yet wired as
+//! `Simplex::execute`'s live path.
+
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::Result;
+use log::info;
+
+use crate::commands::common::MethylationRef;
+use crate::commands::consensus_runner::{ConsensusStatsOps, log_overlapping_stats};
+use crate::consensus_caller::{
+    ConsensusCaller, ConsensusCallingStats, ConsensusOutput, RejectionReason,
+};
+use crate::logging::OperationTimer;
+use crate::mi_group::MiGroup;
+use crate::overlapping_consensus::{
+    AgreementStrategy, CorrectionStats, DisagreementStrategy, OverlappingBasesConsensusCaller,
+    apply_overlapping_consensus,
+};
+use crate::per_thread_accumulator::PerThreadAccumulator;
+use crate::pipeline::chains::builder::ChainBuilder;
+use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook};
+use crate::pipeline::core::outputs::OrderedBytesTuple2;
+use crate::pipeline::core::step::Step;
+use crate::pipeline::steps::group::mi::BatchedMiGroups;
+use crate::pipeline::steps::process::{
+    Process2Output, ProcessWithWorkerState, process_with_worker_state, process2_with_worker_state,
+};
+use crate::pipeline::steps::types::DecompressedBlock;
+use crate::vanilla_consensus_caller::{VanillaUmiConsensusCaller, VanillaUmiConsensusOptions};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CollectedSimplexMetrics
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Per-thread accumulator for simplex consensus metrics (mirrors
+/// `commands::simplex::CollectedSimplexMetrics`).
+///
+/// Merged into final aggregates after the pipeline completes; one instance
+/// per worker slot (see [`PerThreadAccumulator`]).
+///
+/// `pub(crate)` so [`ChainBuilder`] can construct it in `add_simplex`.
+#[derive(Default)]
+pub(crate) struct CollectedSimplexMetrics {
+    /// Consensus calling statistics.
+    pub(crate) stats: ConsensusCallingStats,
+    /// Overlapping consensus stats (if enabled).
+    pub(crate) overlapping_stats: Option<CorrectionStats>,
+    /// Number of MI groups processed.
+    pub(crate) groups_processed: u64,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ConsensusState
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Per-worker state for the simplex consensus step.
+///
+/// Defined at module level (not inside a function body) to avoid the
+/// `clippy::items_after_statements` lint that fires when a struct is defined
+/// after executable statements in a function body.
+pub(crate) struct ConsensusState {
+    pub(crate) caller: VanillaUmiConsensusCaller,
+    pub(crate) overlapping: Option<OverlappingBasesConsensusCaller>,
+}
+
+impl crate::pipeline::core::item::HeapSize for ConsensusState {}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SimplexFinalizeHook
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Post-pipeline finalize hook for simplex. Reduces per-thread metrics,
+/// writes the optional stats file, logs the overlapping-consensus stats
+/// (if enabled), logs the summary banner, finalizes the rejects writer,
+/// and calls `timer.log_completion`.
+///
+/// `pub(crate)` so [`ChainBuilder`] can construct and register it in
+/// `add_simplex`.
+pub(crate) struct SimplexFinalizeHook {
+    pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedSimplexMetrics>>,
+    pub(crate) stats_path: Option<std::path::PathBuf>,
+    pub(crate) overlapping_enabled: bool,
+    pub(crate) timer: OperationTimer,
+}
+
+impl FinalizeHook for SimplexFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let SimplexFinalizeHook { accumulators, stats_path, overlapping_enabled, timer } = *self;
+
+        // Reduce per-thread accumulators.
+        let mut total_groups = 0u64;
+        let mut merged_stats = ConsensusCallingStats::new();
+        let mut merged_overlapping_stats = CorrectionStats::new();
+
+        for slot in accumulators.slots() {
+            let m = slot.lock();
+            total_groups += m.groups_processed;
+            merged_stats.merge(&m.stats);
+            if let Some(ref ocs) = m.overlapping_stats {
+                merged_overlapping_stats.merge(ocs);
+            }
+        }
+
+        if overlapping_enabled {
+            log_overlapping_stats(&merged_overlapping_stats);
+        }
+
+        info!("Consensus calling complete");
+        info!("Total MI groups processed: {total_groups}");
+
+        let metrics = merged_stats.to_metrics();
+        let consensus_count = metrics.consensus_reads;
+        crate::logging::log_consensus_summary(&metrics);
+
+        if let Some(ref stats_path) = stats_path {
+            use fgoxide::io::DelimFile;
+            let kv_metrics = metrics.to_kv_metrics(fgumi_metrics::ConsensusCallerKind::Vanilla);
+            DelimFile::default().write_tsv(stats_path, kv_metrics).map_err(|e| {
+                anyhow::anyhow!("Failed to write statistics: {}: {e}", stats_path.display())
+            })?;
+            info!("Wrote statistics to: {}", stats_path.display());
+        }
+
+        info!("Wrote {consensus_count} consensus reads");
+
+        // Rejects are now emitted on the consensus step's second output branch
+        // (fan-out) and finalized by the rejects branch's own WriteBgzfFile sink,
+        // so there is no rejects writer to finish here.
+
+        timer.log_completion(consensus_count);
+
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Step factory — extracted from build_simplex_chain (T3a.8).
+//
+// Returns the concrete `ProcessWithWorkerState` type directly (the same
+// pattern used by the other step factories in this module family). Returning
+// `impl Step<...>` is blocked here because the closure types embed in
+// opaque-return position and cannot name themselves.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Captures passed into [`build_simplex_consensus_step_with_rejects`] / [`build_simplex_consensus_step_kept_only`] from `add_simplex`.
+///
+/// Bundles all the cloned scalars and Arcs the closure needs so `add_simplex`
+/// can prepare them once and hand them off cleanly.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_simplex`] and
+/// [`build_simplex_consensus_step_with_rejects`] / [`build_simplex_consensus_step_kept_only`].
+pub(crate) struct SimplexConsensusCaptures {
+    pub(crate) track_rejects: bool,
+    pub(crate) overlapping_enabled: bool,
+    pub(crate) consensus_options: VanillaUmiConsensusOptions,
+    pub(crate) read_name_prefix: String,
+    pub(crate) read_group_id: String,
+    pub(crate) methylation_ref: MethylationRef,
+    pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedSimplexMetrics>>,
+    pub(crate) min_reads: usize,
+    pub(crate) progress: Arc<AtomicU64>,
+}
+
+/// Per-worker init: build the `VanillaUmiConsensusCaller` (+ optional
+/// overlapping caller) once, reused across batches. Shared by both step
+/// variants.
+fn make_simplex_consensus_init(
+    read_name_prefix: String,
+    read_group_id: String,
+    consensus_options: VanillaUmiConsensusOptions,
+    methylation_ref: MethylationRef,
+    track_rejects: bool,
+    overlapping_enabled: bool,
+) -> impl Fn() -> ConsensusState + Send + Sync + 'static {
+    move || {
+        let mut caller = VanillaUmiConsensusCaller::new_with_rejects_tracking(
+            read_name_prefix.clone(),
+            read_group_id.clone(),
+            consensus_options.clone(),
+            track_rejects,
+        );
+        if let Some((ref reference, ref ref_names)) = methylation_ref {
+            caller.set_reference(Arc::clone(reference), Arc::clone(ref_names));
+        }
+        let overlapping = if overlapping_enabled {
+            Some(OverlappingBasesConsensusCaller::new(
+                AgreementStrategy::Consensus,
+                DisagreementStrategy::Consensus,
+            ))
+        } else {
+            None
+        };
+        ConsensusState { caller, overlapping }
+    }
+}
+
+/// Per-batch simplex consensus body, shared by both step variants.
+///
+/// Returns the consensus `DecompressedBlock` (branch 0) and, when
+/// `track_rejects` is set and at least one record was rejected, a rejects
+/// `DecompressedBlock` (branch 1) of `[len][record]`-framed raw-input records
+/// in input order. Per the PR #332 contract the rejects flow out through the
+/// ordered serialize/compress stages (input order) rather than a mutex
+/// side-channel (mutex-acquisition order); the rejects writer is configured
+/// with the input header by `add_simplex`.
+fn run_simplex_consensus_batch(
+    state: &mut ConsensusState,
+    item: BatchedMiGroups,
+    track_rejects: bool,
+    overlapping_enabled: bool,
+    min_reads: usize,
+    accumulators: &Arc<PerThreadAccumulator<CollectedSimplexMetrics>>,
+    progress: &Arc<AtomicU64>,
+) -> io::Result<(DecompressedBlock, Option<DecompressedBlock>)> {
+    let BatchedMiGroups { batch_serial, groups } = item;
+    let groups_count = groups.len() as u64;
+
+    let mut all_output = ConsensusOutput::default();
+    let mut batch_stats = ConsensusCallingStats::new();
+    let mut batch_overlapping = CorrectionStats::new();
+    let mut rejects_bytes: Vec<u8> = Vec::new();
+
+    let mut total_input_records: u64 = 0;
+    for MiGroup { mi, records: mut raw_records } in groups {
+        state.caller.clear();
+        total_input_records += raw_records.len() as u64;
+
+        if raw_records.len() < min_reads {
+            batch_stats.record_input(raw_records.len());
+            batch_stats.record_rejection(RejectionReason::InsufficientReads, raw_records.len());
+            if track_rejects {
+                for raw in &raw_records {
+                    super::append_framed_bytes(&mut rejects_bytes, raw.as_ref())?;
+                }
+            }
+            continue;
+        }
+
+        if let Some(ref mut oc) = state.overlapping {
+            oc.reset_stats();
+            // A failure here must be fatal to match the single-thread fast path
+            // in `src/lib/commands/simplex.rs`, which propagates
+            // `apply_overlapping_consensus` errors with `?`. Downgrading to a
+            // `RejectionReason::Other` reject would make the same input fail
+            // without `--threads` but succeed with it.
+            apply_overlapping_consensus(&mut raw_records, oc).map_err(|e| {
+                io::Error::other(format!("Overlapping consensus error for MI {mi}: {e}"))
+            })?;
+            batch_overlapping.merge(oc.stats());
+        }
+
+        let group_output = state
+            .caller
+            .consensus_reads(raw_records)
+            .map_err(|e| io::Error::other(format!("Consensus error for MI {mi}: {e}")))?;
+        all_output.merge(group_output);
+        batch_stats.merge(&state.caller.statistics());
+        if track_rejects {
+            for raw in &state.caller.take_rejected_reads() {
+                super::append_framed_bytes(&mut rejects_bytes, raw)?;
+            }
+        }
+    }
+
+    // Merge per-batch metrics into this worker's slot.
+    accumulators.with_slot(|m| {
+        m.stats.merge(&batch_stats);
+        if overlapping_enabled {
+            m.overlapping_stats.get_or_insert_with(CorrectionStats::new).merge(&batch_overlapping);
+        }
+        m.groups_processed += groups_count;
+    });
+
+    // Progress logging at million-record boundaries (mirrors legacy's
+    // `ProgressTracker::log_if_needed`).
+    let prev = progress.fetch_add(total_input_records, Ordering::Relaxed);
+    if (prev + total_input_records) / 1_000_000 > prev / 1_000_000 {
+        info!("Processed {} records", prev + total_input_records);
+    }
+
+    let consensus = DecompressedBlock { batch_serial, bytes: all_output.data };
+    let rejects = if rejects_bytes.is_empty() {
+        None
+    } else {
+        Some(DecompressedBlock { batch_serial, bytes: rejects_bytes })
+    };
+    Ok((consensus, rejects))
+}
+
+/// Build the 2-output `SimplexConsensus` step (used when `--rejects` is set):
+/// branch 0 carries the consensus `DecompressedBlock`, branch 1 carries the
+/// rejects `DecompressedBlock`. Parallel, `ByItemOrdinal`.
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_simplex`].
+pub(crate) fn build_simplex_consensus_step_with_rejects(
+    limit_bytes: u64,
+    cap: SimplexConsensusCaptures,
+) -> impl Step<Input = BatchedMiGroups, Outputs = OrderedBytesTuple2<DecompressedBlock, DecompressedBlock>>
+{
+    let SimplexConsensusCaptures {
+        track_rejects,
+        overlapping_enabled,
+        consensus_options,
+        read_name_prefix,
+        read_group_id,
+        methylation_ref,
+        accumulators,
+        min_reads,
+        progress,
+    } = cap;
+
+    let init = make_simplex_consensus_init(
+        read_name_prefix,
+        read_group_id,
+        consensus_options,
+        methylation_ref,
+        track_rejects,
+        overlapping_enabled,
+    );
+    let body = move |state: &mut ConsensusState,
+                     item: BatchedMiGroups|
+          -> io::Result<Process2Output<DecompressedBlock, DecompressedBlock>> {
+        let (consensus, rejects) = run_simplex_consensus_batch(
+            state,
+            item,
+            track_rejects,
+            overlapping_enabled,
+            min_reads,
+            &accumulators,
+            &progress,
+        )?;
+        if let Some(r) = rejects {
+            Ok(Process2Output::both(consensus, r))
+        } else {
+            // X5-001: an all-clean batch must still emit a (zero-byte) rejects
+            // block so the rejects branch's `ByItemOrdinal` reorder stage sees a
+            // dense serial sequence. Pushing nothing here (`only_a`) leaves a
+            // permanent gap at this serial that wedges `try_pop_in_order`, so
+            // the rejects sink never drains. The empty `Vec` does not allocate
+            // and produces no physical BGZF block (compress/write of `&[]` are
+            // no-ops; the single EOF is appended once at drain).
+            let batch_serial = consensus.batch_serial;
+            Ok(Process2Output::both(
+                consensus,
+                DecompressedBlock { batch_serial, bytes: Vec::new() },
+            ))
+        }
+    };
+
+    process2_with_worker_state::<
+        BatchedMiGroups,
+        DecompressedBlock,
+        DecompressedBlock,
+        ConsensusState,
+        _,
+        _,
+    >("SimplexConsensus", limit_bytes, limit_bytes, init, body)
+}
+
+/// Build the 1-output (kept-only) `SimplexConsensus` step (used when
+/// `--rejects` is unset). `track_rejects` is `false`, so no rejects are
+/// produced; the framework has no public discard sink, so omitting the rejects
+/// branch requires this single-output variant (mirrors `correct_step_kept_only`).
+///
+/// `pub(crate)` — consumed only by [`ChainBuilder::add_simplex`].
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_simplex_consensus_step_kept_only(
+    limit_bytes: u64,
+    cap: SimplexConsensusCaptures,
+) -> ProcessWithWorkerState<
+    BatchedMiGroups,
+    DecompressedBlock,
+    impl Fn(&mut ConsensusState, BatchedMiGroups) -> io::Result<DecompressedBlock>
+    + Send
+    + Sync
+    + 'static,
+    ConsensusState,
+    impl Fn() -> ConsensusState + Send + Sync + 'static,
+> {
+    let SimplexConsensusCaptures {
+        track_rejects,
+        overlapping_enabled,
+        consensus_options,
+        read_name_prefix,
+        read_group_id,
+        methylation_ref,
+        accumulators,
+        min_reads,
+        progress,
+    } = cap;
+
+    let init = make_simplex_consensus_init(
+        read_name_prefix,
+        read_group_id,
+        consensus_options,
+        methylation_ref,
+        track_rejects,
+        overlapping_enabled,
+    );
+    let body =
+        move |state: &mut ConsensusState, item: BatchedMiGroups| -> io::Result<DecompressedBlock> {
+            let (consensus, _rejects) = run_simplex_consensus_batch(
+                state,
+                item,
+                track_rejects,
+                overlapping_enabled,
+                min_reads,
+                &accumulators,
+                &progress,
+            )?;
+            Ok(consensus)
+        };
+
+    process_with_worker_state::<BatchedMiGroups, DecompressedBlock, _, ConsensusState, _>(
+        "SimplexConsensus",
+        limit_bytes,
+        init,
+        body,
+    )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// build_simplex_chain — thin delegate (Phase 3 T3a.8)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build a [`BuiltPipeline`] for a simplex-only chain.
+///
+/// Delegates to [`ChainBuilder`]. The full step sequence lives in
+/// [`ChainBuilder`]'s `add_simplex` method in
+/// [`crate::pipeline::chains::builder`].
+///
+/// # Errors
+///
+/// Returns input-validation errors (missing reference for methylation mode,
+/// etc.) or any underlying pipeline construction error.
+#[allow(clippy::needless_pass_by_value)]
+pub fn build_simplex_chain(spec: ChainSpec) -> Result<BuiltPipeline> {
+    use crate::pipeline::chains::{Stage, builder::StagePosition};
+    let mut chain = ChainBuilder::new(&spec)?;
+    chain.add_source()?;
+    chain.add_stage(Stage::Simplex, StagePosition::Terminal)?;
+    chain.add_sink()?;
+    chain.build()
+}

--- a/src/lib/pipeline/chains/commands/sort.rs
+++ b/src/lib/pipeline/chains/commands/sort.rs
@@ -1,0 +1,110 @@
+//! Chain builder support for `Stage::Sort`.
+//!
+//! The stage-by-stage construction lives in
+//! [`crate::pipeline::chains::builder::ChainBuilder`]'s `add_sort` method.
+//! This module provides the standalone-sort summary finalize hook
+//! ([`SortSummaryFinalizeHook`]) and the [`IndexBamFinalizeHook`] BAI indexer
+//! (defined locally — see its doc), which `add_sort` registers for a
+//! `SinkSpec::BamWithIndex` request.
+//!
+//! ## Sort pipeline topology
+//!
+//! A sole-`[Stage::Sort]` chain runs through the same streaming source → arena
+//! sort ingest → `SpillGather` → `SpillBlockCompress` → `SpillWrite` →
+//! `SortSpillDecompress` → `SortMerge` → sink pipeline as a
+//! fused sort stage, via the normal `add_source` / `add_sink` flow that
+//! [`crate::pipeline::chains::build::build_for`] drives for every stage; there
+//! is no longer a self-contained file→file sort step or a sort-only chain
+//! builder.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::logging::OperationTimer;
+use anyhow::Result;
+use log::info;
+use parking_lot::Mutex;
+
+use crate::pipeline::chains::FinalizeHook;
+
+/// Post-pipeline summary for standalone `fgumi sort`.
+///
+/// Reads the `SortMerge` stats slot (records processed/written + spill-chunk
+/// count) and logs the `=== Summary ===` block, then the timer's
+/// records-per-second completion line. Registered by
+/// [`ChainBuilder::add_sort`] only for a sole-`[Stage::Sort]` chain; the fused
+/// `runall` path leaves the slot unset and gets no summary block.
+pub(crate) struct SortSummaryFinalizeHook {
+    pub(crate) stats_slot: Arc<Mutex<Option<fgumi_sort::SortStats>>>,
+    pub(crate) output_path: PathBuf,
+    pub(crate) timer: OperationTimer,
+}
+
+impl FinalizeHook for SortSummaryFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let SortSummaryFinalizeHook { stats_slot, output_path, timer } = *self;
+        let stats = stats_slot.lock().take().unwrap_or_default();
+        info!("=== Summary ===");
+        info!("Records processed: {}", stats.total_records);
+        info!("Records written: {}", stats.output_records);
+        if stats.runs_written > 0 {
+            info!("Temporary runs: {}", stats.runs_written);
+        }
+        info!("Output: {}", output_path.display());
+        timer.log_completion(stats.total_records);
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// IndexBamFinalizeHook
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Post-pipeline action that builds a BAI index for a finished
+/// coordinate-sorted BAM, writing the `.bai` sidecar next to the BAM.
+///
+/// Reads the BAM via `noodles::bam::fs::index` (walking BGZF block offsets) and
+/// writes the sidecar via [`fgumi_bam_io::write_bai_sidecar`], which appends
+/// `.bai` to the full output path (samtools convention), so `foo.bam` →
+/// `foo.bam.bai` and `foo.sorted` → `foo.sorted.bai`.
+///
+/// **Invariant:** the BAM at `output_path` must be writer-closed before
+/// `finalize` runs — guaranteed by `Pipeline::run` returning (every step's
+/// writer has dropped). The hook does not `fsync`: the same process re-reading
+/// via the OS page cache sees all flushed bytes on every supported local
+/// filesystem.
+///
+/// `pub(crate)` so [`crate::pipeline::chains::builder::ChainBuilder::add_sort`]
+/// can construct and register it. Defined here (rather than re-exported from a
+/// sort-cli crate as upstream did) because `main-runall` keeps the sort command
+/// local to `crate::commands::sort`.
+pub(crate) struct IndexBamFinalizeHook {
+    /// Path of the finished coordinate-sorted BAM to index.
+    pub(crate) output_path: PathBuf,
+}
+
+impl FinalizeHook for IndexBamFinalizeHook {
+    /// Build and write the BAI index alongside the BAM.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if indexing or writing the BAI sidecar fails.
+    fn finalize(self: Box<Self>) -> Result<()> {
+        use std::time::Instant;
+
+        use crate::logging::format_duration;
+
+        let IndexBamFinalizeHook { output_path } = *self;
+
+        info!("Indexing BAM: {}", output_path.display());
+        let start = Instant::now();
+
+        // Index + write the `<output>.bai` sidecar in one call; the path is
+        // derived by appending `.bai` to the full BAM path (samtools
+        // convention), correct for any path — not just `*.bam`.
+        let index_path = fgumi_bam_io::write_bai_sidecar(&output_path)?;
+        info!("Wrote BAM index: {} ({})", index_path.display(), format_duration(start.elapsed()));
+
+        Ok(())
+    }
+}

--- a/src/lib/pipeline/chains/commands/sort.rs
+++ b/src/lib/pipeline/chains/commands/sort.rs
@@ -3,7 +3,7 @@
 //! The stage-by-stage construction lives in
 //! [`crate::pipeline::chains::builder::ChainBuilder`]'s `add_sort` method.
 //! This module provides the standalone-sort summary finalize hook
-//! ([`SortSummaryFinalizeHook`]) and the [`IndexBamFinalizeHook`] BAI indexer
+//! (`SortSummaryFinalizeHook`) and the `IndexBamFinalizeHook` BAI indexer
 //! (defined locally — see its doc), which `add_sort` registers for a
 //! `SinkSpec::BamWithIndex` request.
 //!
@@ -32,7 +32,7 @@ use crate::pipeline::chains::FinalizeHook;
 /// Reads the `SortMerge` stats slot (records processed/written + spill-chunk
 /// count) and logs the `=== Summary ===` block, then the timer's
 /// records-per-second completion line. Registered by
-/// [`ChainBuilder::add_sort`] only for a sole-`[Stage::Sort]` chain; the fused
+/// `ChainBuilder::add_sort` only for a sole-`[Stage::Sort]` chain; the fused
 /// `runall` path leaves the slot unset and gets no summary block.
 pub(crate) struct SortSummaryFinalizeHook {
     pub(crate) stats_slot: Arc<Mutex<Option<fgumi_sort::SortStats>>>,

--- a/src/lib/pipeline/chains/commands/zipper.rs
+++ b/src/lib/pipeline/chains/commands/zipper.rs
@@ -1,0 +1,155 @@
+//! Chain builder for `Stage::Zipper`.
+//!
+//! Body extracted from `commands::zipper::Zipper::execute_new_pipeline`
+//! in Phase 2 (T2.22). Zipper is a two-input command, so the spec carries
+//! `SourceSpec::PairedBams { unmapped, mapped, reference }`; this function
+//! destructures it and bails with a clear message on any other variant.
+//!
+//! In Phase 3a T3a.12 the bulk of the chain-construction logic moved into
+//! [`ChainBuilder::add_zipper`] and the step-construction details were
+//! extracted into [`build_zipper_merge_step`]. `build_zipper_chain` is now
+//! the canonical 10-line entry point.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::Result;
+use log::info;
+
+use crate::commands::zipper::{ZipperOptions, merge_step};
+use crate::logging::OperationTimer;
+use crate::pipeline::chains::builder::StagePosition;
+use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook, Stage};
+use crate::pipeline::steps::tuning::BamPipelineTuning;
+use crate::reference::ReferenceReader;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ZipperFinalizeHook
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Post-pipeline finalize hook for zipper. Logs the optional
+/// `--exclude-missing-reads` summary, logs "zipper completed
+/// successfully", and calls `timer.log_completion`.
+pub(crate) struct ZipperFinalizeHook {
+    pub(crate) missing_count: Arc<AtomicU64>,
+    pub(crate) records_emitted: Arc<AtomicU64>,
+    pub(crate) exclude_missing_reads: bool,
+    pub(crate) timer: OperationTimer,
+}
+
+impl FinalizeHook for ZipperFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let ZipperFinalizeHook { missing_count, records_emitted, exclude_missing_reads, timer } =
+            *self;
+
+        let missing = missing_count.load(Ordering::Relaxed);
+        if exclude_missing_reads && missing > 0 {
+            info!("Excluded {missing} templates that were not present in the aligned BAM.");
+        }
+
+        info!("zipper completed successfully");
+        timer.log_completion(records_emitted.load(Ordering::Relaxed));
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// build_zipper_merge_step factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Captures for [`build_zipper_merge_step`] construction.
+pub(crate) struct ZipperMergeCaptures {
+    pub(crate) zipper_opts: ZipperOptions,
+    pub(crate) output_header: Arc<noodles::sam::Header>,
+    pub(crate) reference_path: std::path::PathBuf,
+    pub(crate) tuning: BamPipelineTuning,
+    pub(crate) missing_count: Arc<AtomicU64>,
+    pub(crate) records_emitted: Arc<AtomicU64>,
+}
+
+/// Build a [`ZipperMergeStep`] from the supplied captures.
+///
+/// Logs tag-manipulation summary lines, loads the reference FASTA if
+/// `--restore-unconverted-bases` is set, constructs the
+/// [`ZipperMergeConfig`], and returns the configured step.
+///
+/// [`ZipperMergeStep`]: merge_step::ZipperMergeStep
+/// [`ZipperMergeConfig`]: merge_step::ZipperMergeConfig
+pub(crate) fn build_zipper_merge_step(
+    caps: ZipperMergeCaptures,
+) -> Result<merge_step::ZipperMergeStep> {
+    use crate::umi::TagInfo;
+
+    let ZipperMergeCaptures {
+        zipper_opts,
+        output_header,
+        reference_path,
+        tuning,
+        missing_count,
+        records_emitted,
+    } = caps;
+
+    let tag_info = TagInfo::new(
+        zipper_opts.tags_to_remove.clone(),
+        zipper_opts.tags_to_reverse.clone(),
+        zipper_opts.tags_to_revcomp.clone(),
+    );
+    if !tag_info.remove.is_empty() {
+        info!("Tags for removal: {:?}", tag_info.remove);
+    }
+    if !tag_info.reverse.is_empty() {
+        info!("Tags being reversed: {:?}", tag_info.reverse);
+    }
+    if !tag_info.revcomp.is_empty() {
+        info!("Tags being reverse complemented: {:?}", tag_info.revcomp);
+    }
+
+    let reference = if zipper_opts.restore_unconverted_bases {
+        info!("Loading reference FASTA for unconverted base restoration");
+        Some(Arc::new(ReferenceReader::new(&reference_path)?))
+    } else {
+        None
+    };
+
+    let cfg = merge_step::ZipperMergeConfig {
+        tag_info: Arc::new(tag_info),
+        skip_tc_tags: zipper_opts.skip_tc_tags,
+        exclude_missing_reads: zipper_opts.exclude_missing_reads,
+        reference,
+        output_header,
+        missing_count,
+        records_emitted,
+        target_batch_count: tuning.template_batch_size,
+        output_byte_limit: tuning.per_step_byte_limit,
+    };
+    Ok(merge_step::ZipperMergeStep::new(cfg))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// build_zipper_chain — 10-line entry point
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build a [`BuiltPipeline`] for a zipper-only chain.
+///
+/// `spec.stages == [Stage::Zipper]`. Other layouts are caller errors
+/// caught by the dispatch match in [`crate::pipeline::chains::build`].
+///
+/// `spec.source` must be `SourceSpec::PairedBams { unmapped, mapped, reference }`.
+/// The mapped source supports both BAM and SAM input; the unmapped source
+/// is BAM-only (as `fgumi extract` always produces BAM). The function
+/// bails with a clear message if the unmapped source turns out to be SAM.
+///
+/// # Errors
+///
+/// Returns input-validation errors or any underlying pipeline
+/// construction error.
+#[allow(clippy::needless_pass_by_value)]
+pub fn build_zipper_chain(spec: ChainSpec) -> Result<BuiltPipeline> {
+    use crate::pipeline::chains::builder::ChainBuilder;
+
+    let mut chain = ChainBuilder::new(&spec)?;
+    chain.add_source()?;
+    chain.add_stage(Stage::Zipper, StagePosition::Terminal)?;
+    chain.add_sink()?;
+    chain.build()
+}

--- a/src/lib/pipeline/chains/commands/zipper.rs
+++ b/src/lib/pipeline/chains/commands/zipper.rs
@@ -6,9 +6,8 @@
 //! destructures it and bails with a clear message on any other variant.
 //!
 //! In Phase 3a T3a.12 the bulk of the chain-construction logic moved into
-//! [`ChainBuilder::add_zipper`] and the step-construction details were
-//! extracted into [`build_zipper_merge_step`]. `build_zipper_chain` is now
-//! the canonical 10-line entry point.
+//! `ChainBuilder::add_zipper` and the step-construction details were
+//! extracted into `build_zipper_merge_step`.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -18,8 +17,7 @@ use log::info;
 
 use crate::commands::zipper::{ZipperOptions, merge_step};
 use crate::logging::OperationTimer;
-use crate::pipeline::chains::builder::StagePosition;
-use crate::pipeline::chains::{BuiltPipeline, ChainSpec, FinalizeHook, Stage};
+use crate::pipeline::chains::FinalizeHook;
 use crate::pipeline::steps::tuning::BamPipelineTuning;
 use crate::reference::ReferenceReader;
 
@@ -123,33 +121,4 @@ pub(crate) fn build_zipper_merge_step(
         output_byte_limit: tuning.per_step_byte_limit,
     };
     Ok(merge_step::ZipperMergeStep::new(cfg))
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// build_zipper_chain — 10-line entry point
-// ─────────────────────────────────────────────────────────────────────────────
-
-/// Build a [`BuiltPipeline`] for a zipper-only chain.
-///
-/// `spec.stages == [Stage::Zipper]`. Other layouts are caller errors
-/// caught by the dispatch match in [`crate::pipeline::chains::build`].
-///
-/// `spec.source` must be `SourceSpec::PairedBams { unmapped, mapped, reference }`.
-/// The mapped source supports both BAM and SAM input; the unmapped source
-/// is BAM-only (as `fgumi extract` always produces BAM). The function
-/// bails with a clear message if the unmapped source turns out to be SAM.
-///
-/// # Errors
-///
-/// Returns input-validation errors or any underlying pipeline
-/// construction error.
-#[allow(clippy::needless_pass_by_value)]
-pub fn build_zipper_chain(spec: ChainSpec) -> Result<BuiltPipeline> {
-    use crate::pipeline::chains::builder::ChainBuilder;
-
-    let mut chain = ChainBuilder::new(&spec)?;
-    chain.add_source()?;
-    chain.add_stage(Stage::Zipper, StagePosition::Terminal)?;
-    chain.add_sink()?;
-    chain.build()
 }

--- a/src/lib/pipeline/chains/finalize.rs
+++ b/src/lib/pipeline/chains/finalize.rs
@@ -1,0 +1,308 @@
+//! Post-pipeline cleanup hooks.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use crate::pipeline::core::builder::{Pipeline, PipelineConfig};
+use crate::pipeline::core::runtime::stats::PipelineStats;
+
+// The bare `FinalizeHook` trait lives in `fgumi-pipeline-core` so CLI crates
+// built directly on the pipeline core (e.g. `fgumi-sort-cli`) can implement it
+// without redefining a parallel trait (X1-005). It is re-exported here so the
+// canonical `crate::pipeline::chains::FinalizeHook` path — used by every
+// in-crate `impl FinalizeHook` and by `BuiltPipeline` below — is unchanged.
+pub use crate::pipeline::core::FinalizeHook;
+
+/// Logs [`PipelineStats`] after the pipeline finishes, when
+/// `--pipeline-stats` was requested. Builders construct this and push
+/// it onto [`BuiltPipeline::finalize`] as the first hook (so it logs
+/// before command-specific finalize hooks).
+pub struct PipelineStatsFinalizeHook {
+    pub stats: Arc<PipelineStats>,
+}
+
+impl FinalizeHook for PipelineStatsFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        crate::commands::common::log_new_pipeline_stats(Some(self.stats));
+        Ok(())
+    }
+}
+
+/// Logs wall-time elapsed since the hook was constructed. One instance is
+/// registered per chain — by [`ChainBuilder::build`], not by individual
+/// `add_<stage>` methods — so for a fused multi-stage chain like
+/// `[Group, Simplex]` a single line is logged rather than two lines each
+/// reporting the full pipeline duration.
+///
+/// The `chain_label` identifies the chain shape in the log line, e.g.
+/// `"dedup"` for a single-stage dedup chain or `"group→simplex"` for a
+/// fused group+simplex chain.
+pub struct StageTimingFinalizeHook {
+    pub chain_label: String,
+    pub start: std::time::Instant,
+}
+
+impl StageTimingFinalizeHook {
+    /// Construct the hook with a static stage name and `start` captured now.
+    ///
+    /// Kept for unit tests and any call site that still uses static names;
+    /// production code should prefer [`Self::new_with_label`].
+    #[must_use]
+    pub fn new(stage_name: &'static str) -> Self {
+        Self { chain_label: stage_name.to_owned(), start: std::time::Instant::now() }
+    }
+
+    /// Construct the hook with an owned `chain_label` string and `start`
+    /// captured at call time. [`ChainBuilder::build`] uses this form,
+    /// generating the label from `spec.stages` (e.g. `"dedup"` or
+    /// `"group→simplex"`).
+    #[must_use]
+    pub fn new_with_label(chain_label: String) -> Self {
+        Self { chain_label, start: std::time::Instant::now() }
+    }
+}
+
+impl FinalizeHook for StageTimingFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let elapsed = self.start.elapsed();
+        log::info!("Pipeline `{}` ran in {:.2}s", self.chain_label, elapsed.as_secs_f64());
+        Ok(())
+    }
+}
+
+/// Output of [`crate::pipeline::chains::build_for`]. The
+/// caller calls [`BuiltPipeline::run`] which executes the pipeline and
+/// drains the finalize hooks in order.
+pub struct BuiltPipeline {
+    pub pipeline: Pipeline,
+    pub config: PipelineConfig,
+    pub finalize: Vec<Box<dyn FinalizeHook>>,
+    /// Hooks that run **only after a fully successful run** — the pipeline
+    /// completed and every always-drain `finalize` hook succeeded.
+    ///
+    /// Use this for actions that publish a derived artifact from the output
+    /// the run produced (e.g. writing a `.bai` sidecar by re-reading the
+    /// finished BAM). On the error path the output is incomplete, so running
+    /// these would publish a stale/partial artifact — exactly the
+    /// `IndexBamFinalizeHook` footgun the standalone `fgumi sort` flow guards
+    /// against by gating the index write behind `run_result?`.
+    pub finalize_on_success: Vec<Box<dyn FinalizeHook>>,
+}
+
+impl BuiltPipeline {
+    /// Convenience: run the pipeline and drain finalize hooks in order.
+    ///
+    /// `finalize` hooks are *always* drained in a finally-style path, even
+    /// when `Pipeline::run` fails: the hooks own the metrics drains,
+    /// summary logging, `--min-corrected`-style gates, and rejects-file
+    /// finalization that must happen regardless of how the run ended.
+    /// Every hook is run even if an earlier hook errors, so one failing
+    /// hook cannot prevent later cleanup. The first error encountered
+    /// (pipeline run first, then hooks in registration order) is
+    /// returned.
+    ///
+    /// `finalize_on_success` hooks run only once the run and every
+    /// always-drain hook have succeeded — see the field docs.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first pipeline-run error or, if the pipeline
+    /// succeeded, the first finalize-hook error.
+    pub fn run(self) -> Result<()> {
+        let BuiltPipeline { pipeline, config, finalize, finalize_on_success } = self;
+
+        // Capture the run result but do not short-circuit: the finalize
+        // hooks must still drain on the error path.
+        // Format the error with Display (`{e}`), not Debug: `PipelineError`
+        // carries hand-written, user-facing Display messages that a `{e:?}`
+        // derived-struct dump would discard.
+        let run_result = pipeline.run(config).map_err(|e| anyhow::anyhow!("Pipeline::run: {e}"));
+
+        drain_finalize(run_result, finalize, finalize_on_success)
+    }
+}
+
+/// Drains every always-run finalize hook in registration order, then — only
+/// if the run and all of those hooks succeeded — runs the success-gated hooks.
+///
+/// Always-run hooks are drained even on the `run_result == Err` path, and a
+/// failing hook does not prevent later always-run hooks from running. The
+/// pipeline-run error takes precedence over any hook error. Success-gated
+/// hooks are skipped entirely unless everything above succeeded; once running,
+/// the first of them to error short-circuits the rest (they publish derived
+/// artifacts, so there is no "drain everything" obligation on their path).
+fn drain_finalize(
+    run_result: Result<()>,
+    finalize: Vec<Box<dyn FinalizeHook>>,
+    finalize_on_success: Vec<Box<dyn FinalizeHook>>,
+) -> Result<()> {
+    // Drain every always-run hook, keeping the first hook error.
+    let mut first_hook_error: Option<anyhow::Error> = None;
+    for hook in finalize {
+        if let Err(e) = hook.finalize()
+            && first_hook_error.is_none()
+        {
+            first_hook_error = Some(e);
+        }
+    }
+
+    // The pipeline-run error takes precedence over hook errors. Resolve the
+    // combined result of the run plus the always-run hooks first.
+    run_result.and_then(|()| first_hook_error.map_or(Ok(()), Err))?;
+
+    // Reached only on full success: now safe to publish derived artifacts.
+    for hook in finalize_on_success {
+        hook.finalize()?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    /// Test hook that bumps a shared counter on finalize and optionally
+    /// returns an error, so tests can assert every hook ran.
+    struct CountingHook {
+        ran: Arc<AtomicUsize>,
+        fail: bool,
+    }
+
+    impl FinalizeHook for CountingHook {
+        fn finalize(self: Box<Self>) -> Result<()> {
+            self.ran.fetch_add(1, Ordering::SeqCst);
+            if self.fail { Err(anyhow::anyhow!("hook failed")) } else { Ok(()) }
+        }
+    }
+
+    fn counting_hook(ran: &Arc<AtomicUsize>, fail: bool) -> Box<dyn FinalizeHook> {
+        Box::new(CountingHook { ran: Arc::clone(ran), fail })
+    }
+
+    #[test]
+    fn drain_finalize_runs_all_hooks_when_pipeline_fails() {
+        // Even though the pipeline "failed", all hooks must still run so
+        // metrics drains / rejects finalization are not skipped.
+        let ran = Arc::new(AtomicUsize::new(0));
+        let hooks = vec![counting_hook(&ran, false), counting_hook(&ran, false)];
+        let result = drain_finalize(Err(anyhow::anyhow!("pipeline boom")), hooks, vec![]);
+        assert_eq!(ran.load(Ordering::SeqCst), 2, "all hooks should run on the error path");
+        // The pipeline error takes precedence and is propagated.
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("pipeline boom"));
+    }
+
+    #[test]
+    fn drain_finalize_runs_later_hooks_after_a_failing_hook() {
+        // A failing hook must not prevent later cleanup hooks from running.
+        let ran = Arc::new(AtomicUsize::new(0));
+        let hooks =
+            vec![counting_hook(&ran, true), counting_hook(&ran, false), counting_hook(&ran, false)];
+        let result = drain_finalize(Ok(()), hooks, vec![]);
+        assert_eq!(ran.load(Ordering::SeqCst), 3, "all hooks should run despite an early failure");
+        // With a successful run, the first hook error is surfaced.
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("hook failed"));
+    }
+
+    #[test]
+    fn drain_finalize_ok_when_run_and_hooks_succeed() {
+        let ran = Arc::new(AtomicUsize::new(0));
+        let hooks = vec![counting_hook(&ran, false)];
+        let result = drain_finalize(Ok(()), hooks, vec![]);
+        assert_eq!(ran.load(Ordering::SeqCst), 1);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn drain_finalize_runs_success_hooks_only_on_full_success() {
+        // Success-gated hooks run once the pipeline and all always-run hooks
+        // succeed.
+        let always = Arc::new(AtomicUsize::new(0));
+        let on_success = Arc::new(AtomicUsize::new(0));
+        let result = drain_finalize(
+            Ok(()),
+            vec![counting_hook(&always, false)],
+            vec![counting_hook(&on_success, false)],
+        );
+        assert!(result.is_ok());
+        assert_eq!(always.load(Ordering::SeqCst), 1);
+        assert_eq!(on_success.load(Ordering::SeqCst), 1, "success hook should run on full success");
+    }
+
+    #[test]
+    fn drain_finalize_skips_success_hooks_when_pipeline_fails() {
+        // A failed run must not run success-gated hooks — the output is
+        // incomplete, so e.g. a `.bai` sidecar would be stale. The always-run
+        // hooks still drain.
+        let always = Arc::new(AtomicUsize::new(0));
+        let on_success = Arc::new(AtomicUsize::new(0));
+        let result = drain_finalize(
+            Err(anyhow::anyhow!("pipeline boom")),
+            vec![counting_hook(&always, false)],
+            vec![counting_hook(&on_success, false)],
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("pipeline boom"));
+        assert_eq!(always.load(Ordering::SeqCst), 1, "always-run hook still drains on failure");
+        assert_eq!(on_success.load(Ordering::SeqCst), 0, "success hook must not run on failure");
+    }
+
+    #[test]
+    fn drain_finalize_skips_success_hooks_when_an_always_hook_fails() {
+        // If an always-run hook fails (even with a successful pipeline run),
+        // the output is not trustworthy, so success-gated hooks are skipped.
+        let always = Arc::new(AtomicUsize::new(0));
+        let on_success = Arc::new(AtomicUsize::new(0));
+        let result = drain_finalize(
+            Ok(()),
+            vec![counting_hook(&always, true)],
+            vec![counting_hook(&on_success, false)],
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("hook failed"));
+        assert_eq!(
+            on_success.load(Ordering::SeqCst),
+            0,
+            "success hook must not run after a failure"
+        );
+    }
+
+    #[test]
+    fn stage_timing_hook_finalize_succeeds() {
+        // Construct the hook with a test stage name and immediately
+        // finalize. Verifies the hook is wired correctly and produces
+        // no error. The "Pipeline `X` ran in Ys" log line is emitted via
+        // log::info!; the call path is exercised by this test.
+        let hook = StageTimingFinalizeHook::new("test_stage");
+        assert_eq!(hook.chain_label, "test_stage");
+        let result = Box::new(hook).finalize();
+        assert!(result.is_ok(), "StageTimingFinalizeHook::finalize should succeed: {result:?}");
+    }
+
+    #[test]
+    fn stage_timing_hook_new_with_label() {
+        // Verify that new_with_label stores the label correctly.
+        let hook = StageTimingFinalizeHook::new_with_label("group→simplex".to_owned());
+        assert_eq!(hook.chain_label, "group→simplex");
+        let result = Box::new(hook).finalize();
+        assert!(
+            result.is_ok(),
+            "StageTimingFinalizeHook::finalize (new_with_label) should succeed: {result:?}"
+        );
+    }
+
+    #[test]
+    fn pipeline_stats_hook_finalize_succeeds() {
+        // Construct a PipelineStatsFinalizeHook with minimal stats
+        // and finalize it. Verifies the hook wiring and that
+        // finalize() succeeds without error.
+        let stats: Arc<PipelineStats> = Arc::new(PipelineStats::new(vec!["test_step"]));
+        let hook = PipelineStatsFinalizeHook { stats };
+        let result = Box::new(hook).finalize();
+        assert!(result.is_ok(), "PipelineStatsFinalizeHook::finalize should succeed: {result:?}");
+    }
+}

--- a/src/lib/pipeline/chains/finalize.rs
+++ b/src/lib/pipeline/chains/finalize.rs
@@ -30,7 +30,7 @@ impl FinalizeHook for PipelineStatsFinalizeHook {
 }
 
 /// Logs wall-time elapsed since the hook was constructed. One instance is
-/// registered per chain — by [`ChainBuilder::build`], not by individual
+/// registered per chain — by `ChainBuilder::build`, not by individual
 /// `add_<stage>` methods — so for a fused multi-stage chain like
 /// `[Group, Simplex]` a single line is logged rather than two lines each
 /// reporting the full pipeline duration.
@@ -54,7 +54,7 @@ impl StageTimingFinalizeHook {
     }
 
     /// Construct the hook with an owned `chain_label` string and `start`
-    /// captured at call time. [`ChainBuilder::build`] uses this form,
+    /// captured at call time. `ChainBuilder::build` uses this form,
     /// generating the label from `spec.stages` (e.g. `"dedup"` or
     /// `"group→simplex"`).
     #[must_use]
@@ -268,6 +268,29 @@ mod tests {
             on_success.load(Ordering::SeqCst),
             0,
             "success hook must not run after a failure"
+        );
+    }
+
+    #[test]
+    fn drain_finalize_short_circuits_success_hooks_on_first_failure() {
+        // Unlike the always-run list (which drains fully), the success-gated
+        // hooks short-circuit: the first to error stops the rest. Pin that, so a
+        // change to `?` semantics (e.g. draining all success hooks) is caught —
+        // the second hook must NOT run, and the first hook's error propagates.
+        let first = Arc::new(AtomicUsize::new(0));
+        let second = Arc::new(AtomicUsize::new(0));
+        let result = drain_finalize(
+            Ok(()),
+            vec![],
+            vec![counting_hook(&first, true), counting_hook(&second, false)],
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("hook failed"));
+        assert_eq!(first.load(Ordering::SeqCst), 1, "the first success hook ran");
+        assert_eq!(
+            second.load(Ordering::SeqCst),
+            0,
+            "the second success hook must be short-circuited by the first's failure"
         );
     }
 

--- a/src/lib/pipeline/chains/mod.rs
+++ b/src/lib/pipeline/chains/mod.rs
@@ -1,11 +1,3 @@
-// TEMPORARY (go-green tracking): this dormant chain-builder layer still has
-// unresolved intra-doc links to not-yet-in-scope items across the subtree
-// (e.g. `DecompressedBlock`, `DecodeRecords`, `ChainBuilder::build`). They are
-// repaired per-cluster as each command/step is reviewed; this blanket allow is
-// removed in the final go-green doc pass once `cargo ci-doc` is clean. Do NOT
-// add new broken links under its cover.
-#![allow(rustdoc::broken_intra_doc_links)]
-
 //! Unified chain-builder API for the typed-step pipeline framework.
 //!
 //! Single declarative entry point — [`build_for`] — that constructs a
@@ -42,9 +34,8 @@ pub mod build;
 pub use build::build_for;
 
 pub mod builder;
-pub use builder::ChainBuilder;
 
 pub mod build_helpers;
-pub use build_helpers::build_pipeline_config_for_chain;
+pub(crate) use build_helpers::build_pipeline_config_for_chain;
 
 pub mod commands;

--- a/src/lib/pipeline/chains/mod.rs
+++ b/src/lib/pipeline/chains/mod.rs
@@ -1,0 +1,50 @@
+// TEMPORARY (go-green tracking): this dormant chain-builder layer still has
+// unresolved intra-doc links to not-yet-in-scope items across the subtree
+// (e.g. `DecompressedBlock`, `DecodeRecords`, `ChainBuilder::build`). They are
+// repaired per-cluster as each command/step is reviewed; this blanket allow is
+// removed in the final go-green doc pass once `cargo ci-doc` is clean. Do NOT
+// add new broken links under its cover.
+#![allow(rustdoc::broken_intra_doc_links)]
+
+//! Unified chain-builder API for the typed-step pipeline framework.
+//!
+//! Single declarative entry point — [`build_for`] — that constructs a
+//! ready-to-run [`BuiltPipeline`] from a [`ChainSpec`]. Both standalone
+//! commands and `runall` route through here; the only behavioral
+//! difference between them is how the spec is constructed.
+//!
+//! See `docs/design/refactor/2026-05-20-unified-chain-builder-design.md`
+//! for the architectural rationale.
+
+pub mod stage;
+pub use stage::Stage;
+
+pub mod source_spec;
+pub use source_spec::SourceSpec;
+
+pub mod sink_spec;
+pub use sink_spec::SinkSpec;
+
+pub mod finalize;
+pub use finalize::{
+    BuiltPipeline, FinalizeHook, PipelineStatsFinalizeHook, StageTimingFinalizeHook,
+};
+
+pub mod options_bag;
+pub use options_bag::StageOptionsBag;
+
+pub mod spec;
+pub use spec::{ChainSpec, SingleStageContext};
+
+pub mod validate;
+
+pub mod build;
+pub use build::build_for;
+
+pub mod builder;
+pub use builder::ChainBuilder;
+
+pub mod build_helpers;
+pub use build_helpers::build_pipeline_config_for_chain;
+
+pub mod commands;

--- a/src/lib/pipeline/chains/options_bag.rs
+++ b/src/lib/pipeline/chains/options_bag.rs
@@ -1,0 +1,103 @@
+//! Typed option bag for [`super::ChainSpec`].
+
+use std::path::PathBuf;
+
+// Re-export each command's options type so spec construction reads
+// naturally at the call site. Each is imported from its existing
+// home, not redefined.
+pub use crate::aligner::AlignerOptions;
+pub use crate::commands::clip::Clip;
+#[cfg(feature = "consensus")]
+pub use crate::commands::codec::CodecOptions;
+pub use crate::commands::correct::CorrectOptions;
+pub use crate::commands::dedup::MarkDuplicates;
+#[cfg(feature = "consensus")]
+pub use crate::commands::duplex::DuplexOptions;
+pub use crate::commands::extract::ExtractOptions;
+pub use crate::commands::fastq::FastqOptions;
+pub use crate::commands::filter::FilterOptions;
+pub use crate::commands::group::GroupOptions;
+#[cfg(feature = "consensus")]
+pub use crate::commands::simplex::SimplexOptions;
+pub use crate::commands::sort::SortOptions;
+pub use crate::commands::zipper::ZipperOptions;
+
+/// Per-stage options for [`crate::pipeline::chains::Stage::Align`].
+///
+/// Bundles the aligner tuning knobs ([`AlignerOptions`]) with the two
+/// additional parameters that `AlignerOptions::resolve` needs but
+/// that `AlignerOptions` does not carry directly:
+///
+/// - `reference` — the reference FASTA path (required; used to locate
+///   the accompanying `.dict` file and to validate aligner index files
+///   in preset mode).
+/// - `aligner_bin` — optional binary path override (preset mode only;
+///   `None` in command mode).
+///
+/// Constructed by runall's `--start-from align` dispatch (T3b.3) and
+/// by integration tests that exercise the chain builder directly.
+pub struct AlignOptions {
+    /// Per-stage aligner tuning: `--aligner::preset`, `--aligner::command`,
+    /// `--aligner::threads`, `--aligner::chunk-size`.
+    pub aligner: AlignerOptions,
+    /// Reference FASTA path. Must have a `.dict` sibling (or
+    /// `<ref>.dict` fallback). Passed to `AlignerOptions::resolve`.
+    pub reference: PathBuf,
+    /// Optional aligner binary override for preset mode (`--aligner-bin`
+    /// in runall). Ignored in command mode.
+    pub aligner_bin: Option<PathBuf>,
+}
+
+/// Per-stage option bag for [`crate::pipeline::chains::ChainSpec`].
+///
+/// Each field is `Option<T>` so callers fill in only the stages they
+/// need. [`crate::pipeline::chains::build_for`] validates
+/// that every stage in `spec.stages` has its matching options
+/// present before constructing any chain steps.
+///
+/// Thirteen fields are wired: Correct, Zipper, Sort, Group, Duplex, Codec,
+/// Filter, Simplex, Align, Extract, and Fastq hold free-standing
+/// `<Command>Options` structs, while Dedup and Clip hold the command struct
+/// directly (`MarkDuplicates` / `Clip`) — no separate `DedupOptions`/
+/// `ClipOptions` is extracted, because test code constructs those via
+/// `clap::Parser::parse_from` and extracting a sub-struct would destabilise
+/// that surface. The remaining stage (Downsample) has no slot yet; it is
+/// added incrementally in T2.19–T2.22.
+#[derive(Default)]
+pub struct StageOptionsBag {
+    pub correct: Option<CorrectOptions>,
+    pub zipper: Option<ZipperOptions>,
+    pub sort: Option<SortOptions>,
+    pub group: Option<GroupOptions>,
+    #[cfg(feature = "consensus")]
+    pub duplex: Option<DuplexOptions>,
+    #[cfg(feature = "consensus")]
+    pub codec: Option<CodecOptions>,
+    /// Dedup options. Holds `MarkDuplicates` directly (approach 2 from
+    /// the T2.12 design note) to keep the test surface stable.
+    pub dedup: Option<MarkDuplicates>,
+    /// Filter options. Holds the free-standing `FilterOptions` struct
+    /// (same approach as Sort/Group/Correct), so runall can re-expose
+    /// the tuning knobs via `--filter::*` through `MultiFilterOptions`.
+    pub filter: Option<FilterOptions>,
+    /// Clip options. Holds `Clip` directly (same approach as Dedup/Filter).
+    pub clip: Option<Clip>,
+    /// Simplex options. Holds the free-standing `SimplexOptions` struct
+    /// (same approach as Duplex/Codec), so runall can re-expose the tuning
+    /// knobs via `--simplex::*` through `MultiSimplexOptions`.
+    #[cfg(feature = "consensus")]
+    pub simplex: Option<SimplexOptions>,
+    /// Align (`AlignAndMerge`) options. Carries [`AlignerOptions`] +
+    /// reference path + optional aligner-binary override.
+    pub aligner: Option<AlignOptions>,
+    /// Extract options. Carries header-synthesis fields and behavior knobs
+    /// for the FASTQ→unmapped-BAM extract stage (Phase 5 T5.3).
+    pub extract: Option<ExtractOptions>,
+    /// Fastq options. Carries flag filters, read-name suffix, and UMI-in-name
+    /// config for the terminal BAM→FASTQ encode stage.
+    pub fastq: Option<FastqOptions>,
+    // Additional fields added during command migrations:
+    //   - downsample (T2.13).
+    // Cross-stage fields (read_group, methylation_mode, reference, …)
+    // resolve in Phase 3 when runall lands on the façade.
+}

--- a/src/lib/pipeline/chains/sink_spec.rs
+++ b/src/lib/pipeline/chains/sink_spec.rs
@@ -1,0 +1,59 @@
+//! Where the chain writes its output.
+
+use std::path::PathBuf;
+
+/// The sink for a chain.
+///
+/// **Note for programmatic callers constructing a `ChainSpec` directly:**
+/// `Bam` is the default — picking it on a sort-terminal chain produces
+/// a coordinate-sorted BAM with **no** companion `.bai`. If you want a
+/// sidecar BAI, use `BamWithIndex`; the chain-builder will register an
+/// `IndexBamFinalizeHook` that reads the finished BAM and emits
+/// `<output>.bam.bai`. There is no "auto-index" inference from sort
+/// order; the caller must opt in via this variant.
+///
+/// `BamWithIndex` is sort-only (other stages can't produce a coordinate-
+/// sorted output that warrants a `.bai` write). The sort command's
+/// post-pipeline `--write-index` flag selects this variant; standalone
+/// commands that don't sort use `Bam`. Cross-stage validator Rule 3
+/// (in `chains::validate`) rejects `BamWithIndex` on any chain whose
+/// terminal stage isn't `Stage::Sort`.
+///
+/// Future CRAM output should be parallel `Cram(PathBuf)` /
+/// `CramWithIndex(PathBuf)` variants — not a `format: IndexFormat`
+/// field grafted onto `BamWithIndex`, because BAI vs. CRAI is a
+/// file-format-physics distinction (different on-disk encoding for the
+/// same logical chunk-offset index), not a runtime choice.
+#[derive(Debug, Clone)]
+pub enum SinkSpec {
+    /// BAM file write (or `-` for stdout). No sidecar index.
+    Bam(PathBuf),
+    /// BAM file write + `.bai` index write after the BAM finishes.
+    /// Only valid when the final stage emits coordinate-sorted output.
+    BamWithIndex(PathBuf),
+    /// Interleaved FASTQ file write (or `-` for stdout). A `.gz`/`.bgz`
+    /// path is written as BGZF. Only valid on a `Stage::Fastq`-terminal chain.
+    ///
+    /// Paired split output uses the [`SinkSpec::FastqPaired`] variant.
+    Fastq(PathBuf),
+    /// Paired split FASTQ output: R1 → `out1`, R2 → `out2`, and "other"
+    /// (single-end / ambiguous) reads → `out0` if given, else stdout. Each
+    /// `.gz`/`.bgz` path is written as BGZF. Only valid on a `Stage::Fastq`-
+    /// terminal chain. The three streams are fanned out by the paired FASTQ
+    /// encode step (a 3-output `Process3WithWorkerState`).
+    FastqPaired { out1: PathBuf, out2: PathBuf, out0: Option<PathBuf> },
+}
+
+impl SinkSpec {
+    /// A representative output path for the sink, used for logging (and
+    /// available to a caller's input-clobber guard). For [`SinkSpec::FastqPaired`]
+    /// this is `out1`; the chains layer itself does not currently guard against
+    /// clobbering the input.
+    #[must_use]
+    pub fn path(&self) -> &PathBuf {
+        match self {
+            SinkSpec::Bam(p) | SinkSpec::BamWithIndex(p) | SinkSpec::Fastq(p) => p,
+            SinkSpec::FastqPaired { out1, .. } => out1,
+        }
+    }
+}

--- a/src/lib/pipeline/chains/source_spec.rs
+++ b/src/lib/pipeline/chains/source_spec.rs
@@ -1,0 +1,142 @@
+//! What feeds the chain.
+
+use std::path::PathBuf;
+
+use crate::read_structure::ReadStructure;
+use anyhow::{Result, ensure};
+
+/// The source feeding a chain. Variants encode the source shape; the
+/// chain builder resolves each variant to the appropriate source step(s).
+#[derive(Debug, Clone)]
+pub enum SourceSpec {
+    /// Single BAM file (or `-` for stdin). Used by standalone correct,
+    /// sort, group, consensus, clip, filter, dedup, downsample, and by
+    /// runall when `--start-from` lands at any of those stages.
+    Bam(PathBuf),
+
+    /// Paired BAMs joined by `ZipperMergeStep`. Used by standalone
+    /// zipper and by `runall --start-from zipper`.
+    PairedBams { unmapped: PathBuf, mapped: PathBuf, reference: PathBuf },
+
+    /// FASTQ inputs feeding `fgumi extract`. Used by standalone extract
+    /// and by `runall --start-from extract` (the latter unlocks in
+    /// Phase 5).
+    ///
+    /// `paths` and `read_structures` are positional pairs and **must** be
+    /// the same length: `read_structures[i]` describes `paths[i]`. Build
+    /// this variant via [`SourceSpec::fastqs`] (which enforces the
+    /// invariant) rather than a struct literal; [`SourceSpec::validate`]
+    /// re-checks it for any spec that was constructed directly.
+    Fastqs { paths: Vec<PathBuf>, read_structures: Vec<ReadStructure> },
+
+    /// SAM text file (or `-` for stdin). Standalone-only — runall does
+    /// not accept SAM input (it always reads from a BAM intermediate).
+    Sam(PathBuf),
+}
+
+impl SourceSpec {
+    /// Constructs a [`SourceSpec::Fastqs`] source, enforcing that `paths`
+    /// and `read_structures` are positional pairs of equal length.
+    ///
+    /// Prefer this over a `SourceSpec::Fastqs { .. }` struct literal so a
+    /// mis-sized pairing fails here — at construction — rather than being
+    /// pushed downstream into the chain builder.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `paths.len() != read_structures.len()`.
+    pub fn fastqs(paths: Vec<PathBuf>, read_structures: Vec<ReadStructure>) -> Result<Self> {
+        let spec = Self::Fastqs { paths, read_structures };
+        // Route through validate() so the length invariant lives in exactly one
+        // place; a struct-literal Fastqs is re-checked by the same code.
+        spec.validate()?;
+        Ok(spec)
+    }
+
+    /// Re-checks structural invariants that the variant types cannot
+    /// encode. Currently this validates that a [`SourceSpec::Fastqs`]
+    /// source has one read structure per path. Call this when accepting a
+    /// `SourceSpec` that may have been built via a struct literal rather
+    /// than [`SourceSpec::fastqs`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a `Fastqs` source has diverging `paths` and
+    /// `read_structures` lengths.
+    pub fn validate(&self) -> Result<()> {
+        if let Self::Fastqs { paths, read_structures } = self {
+            ensure!(
+                paths.len() == read_structures.len(),
+                "FASTQ source is mis-sized: {} path(s) but {} read structure(s); \
+                 each path needs exactly one read structure",
+                paths.len(),
+                read_structures.len(),
+            );
+        }
+        Ok(())
+    }
+
+    /// Returns `true` if this source is permissible inside runall.
+    /// SAM input is standalone-only; runall always reads from one of
+    /// `Bam`, `PairedBams`, or `Fastqs`.
+    #[must_use]
+    pub fn is_runall_compatible(&self) -> bool {
+        match self {
+            Self::Bam(_) | Self::PairedBams { .. } | Self::Fastqs { .. } => true,
+            Self::Sam(_) => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runall_compatibility() {
+        assert!(SourceSpec::Bam(PathBuf::from("a.bam")).is_runall_compatible());
+        assert!(!SourceSpec::Sam(PathBuf::from("a.sam")).is_runall_compatible());
+    }
+
+    fn read_structure() -> ReadStructure {
+        use std::str::FromStr;
+        ReadStructure::from_str("8M+T").expect("valid read structure")
+    }
+
+    #[test]
+    fn fastqs_constructor_accepts_matched_lengths() {
+        let spec = SourceSpec::fastqs(
+            vec![PathBuf::from("r1.fq"), PathBuf::from("r2.fq")],
+            vec![read_structure(), read_structure()],
+        )
+        .expect("matched lengths should construct");
+        assert!(spec.validate().is_ok());
+    }
+
+    #[test]
+    fn fastqs_constructor_rejects_mismatched_lengths() {
+        let err = SourceSpec::fastqs(
+            vec![PathBuf::from("r1.fq"), PathBuf::from("r2.fq")],
+            vec![read_structure()],
+        )
+        .expect_err("mismatched lengths should fail");
+        assert!(err.to_string().contains("mis-sized"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_catches_mismatched_struct_literal() {
+        // A directly-constructed (struct literal) mis-sized Fastqs source
+        // is caught by validate(), even though the constructor was bypassed.
+        let spec = SourceSpec::Fastqs {
+            paths: vec![PathBuf::from("r1.fq")],
+            read_structures: vec![read_structure(), read_structure()],
+        };
+        assert!(spec.validate().is_err());
+    }
+
+    #[test]
+    fn validate_is_ok_for_non_fastq_sources() {
+        assert!(SourceSpec::Bam(PathBuf::from("a.bam")).validate().is_ok());
+        assert!(SourceSpec::Sam(PathBuf::from("a.sam")).validate().is_ok());
+    }
+}

--- a/src/lib/pipeline/chains/spec.rs
+++ b/src/lib/pipeline/chains/spec.rs
@@ -1,0 +1,90 @@
+//! Declarative chain specification — input to [`super::build_for`].
+
+use crate::commands::common::{
+    BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
+};
+use crate::pipeline::chains::{SinkSpec, SourceSpec, Stage, StageOptionsBag};
+
+/// Declarative chain specification. Both standalone commands and
+/// `runall` construct one of these and pass it to
+/// [`crate::pipeline::chains::build_for`].
+///
+/// Construction is mechanical: parse CLI → fill in the relevant
+/// `stage_opts` slots → set `source`/`sink`/`stages` based on input
+/// shape and the requested operation → pass to `build_for`. Validators
+/// inside `build_for` enforce ordering, mutual exclusions, and
+/// stage-options presence.
+pub struct ChainSpec {
+    /// Ordered list of stages — must be a valid progression
+    /// (validated by
+    /// [`crate::pipeline::chains::validate::validate_stage_progression`]).
+    pub stages: Vec<Stage>,
+    pub source: SourceSpec,
+    pub sink: SinkSpec,
+    pub stage_opts: StageOptionsBag,
+    pub threading: ThreadingOptions,
+    pub compression: CompressionOptions,
+    pub scheduler: SchedulerOptions,
+    pub queue_memory: QueueMemoryOptions,
+    /// When true, the BAM/SAM source is opened with a userspace async
+    /// prefetch reader (`--async-reader`), overlapping disk I/O with compute.
+    pub async_reader: bool,
+    /// For `@PG` line injection into the output header.
+    pub command_line: String,
+}
+
+/// The CLI option blocks every BAM-in/BAM-out single-stage command carries.
+///
+/// Exists so [`ChainSpec::single_stage`] can take them as one argument instead of
+/// six positional ones; the fields are borrowed straight off the command struct.
+pub struct SingleStageContext<'a> {
+    pub io: &'a BamIoOptions,
+    pub threading: &'a ThreadingOptions,
+    pub compression: &'a CompressionOptions,
+    pub scheduler: &'a SchedulerOptions,
+    pub queue_memory: &'a QueueMemoryOptions,
+    /// For `@PG` line injection into the output header.
+    pub command_line: &'a str,
+}
+
+impl ChainSpec {
+    /// Build the spec for a command that runs exactly one stage, BAM in to BAM out.
+    ///
+    /// `simplex`, `duplex`, and `codec` are all this shape, differing only in their
+    /// [`Stage`] and which [`StageOptionsBag`] slot they fill. Constructing the
+    /// full `ChainSpec` here rather than in each `execute` means a new field
+    /// is wired once: previously each command hand-built the struct, so a
+    /// field added to one and missed in the others left that command silently
+    /// running on a default its siblings did not use.
+    #[must_use]
+    pub fn single_stage(
+        stage: Stage,
+        stage_opts: StageOptionsBag,
+        ctx: &SingleStageContext<'_>,
+    ) -> Self {
+        Self {
+            stages: vec![stage],
+            source: SourceSpec::Bam(ctx.io.input.clone()),
+            sink: SinkSpec::Bam(ctx.io.output.clone()),
+            stage_opts,
+            threading: ctx.threading.clone(),
+            compression: ctx.compression.clone(),
+            scheduler: ctx.scheduler.clone(),
+            queue_memory: ctx.queue_memory.clone(),
+            async_reader: ctx.io.async_reader,
+            command_line: ctx.command_line.to_string(),
+        }
+    }
+
+    /// Whether this is the standalone sort chain (`[Stage::Sort]` only).
+    ///
+    /// Standalone sort no longer has a special build path — like every other
+    /// chain it runs through `add_source` → sort stage → `add_sink`. This
+    /// predicate is the spec classifier for the sole-`[Sort]` layout: `add_sort`
+    /// calls it (as `is_standalone_sort`) to honour `--sort::max-memory=auto`
+    /// only when sort owns the whole memory budget, and `validate` uses it.
+    #[must_use]
+    pub fn is_sort_terminal(&self) -> bool {
+        matches!(self.stages.as_slice(), [Stage::Sort])
+    }
+}

--- a/src/lib/pipeline/chains/spec.rs
+++ b/src/lib/pipeline/chains/spec.rs
@@ -29,6 +29,12 @@ pub struct ChainSpec {
     /// When true, the BAM/SAM source is opened with a userspace async
     /// prefetch reader (`--async-reader`), overlapping disk I/O with compute.
     pub async_reader: bool,
+    /// Whether the BAM source's BGZF decode verifies each block's CRC32. Set
+    /// from the command's `--check-crc`/`--no-check-crc` policy (via
+    /// [`crate::commands::common::BamIoOptions::effective_check_crc`]) so the
+    /// chain reproduces the non-chain path's CRC behavior. Inert for the SAM
+    /// source (no BGZF) and for the FASTQ source (which carries its own policy).
+    pub verify_crc: bool,
     /// For `@PG` line injection into the output header.
     pub command_line: String,
 }
@@ -72,6 +78,7 @@ impl ChainSpec {
             scheduler: ctx.scheduler.clone(),
             queue_memory: ctx.queue_memory.clone(),
             async_reader: ctx.io.async_reader,
+            verify_crc: ctx.io.effective_check_crc(),
             command_line: ctx.command_line.to_string(),
         }
     }

--- a/src/lib/pipeline/chains/stage.rs
+++ b/src/lib/pipeline/chains/stage.rs
@@ -1,0 +1,132 @@
+//! Stage labels for the unified chain-builder.
+
+/// One pipeline stage. Each variant is a label, not data — the canonical
+/// multi-step sequence each variant expands to lives in
+/// [`chains::build_for`](crate::pipeline::chains::build_for)'s
+/// match arms.
+///
+/// **Mutual exclusions** (enforced by
+/// [`crate::pipeline::chains::validate::validate_stage_progression`]):
+///
+/// - [`Stage::Align`] and [`Stage::Zipper`] both produce
+///   `BamTemplateBatch` from different sources — at most one per chain.
+/// - [`Stage::Simplex`], [`Stage::Duplex`], [`Stage::Codec`] are
+///   terminal consensus stages — at most one per chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Stage {
+    Extract,
+    Correct,
+    Align,
+    Zipper,
+    Sort,
+    Group,
+    Simplex,
+    Duplex,
+    Codec,
+    Clip,
+    Filter,
+    Dedup,
+    Downsample,
+    /// Terminal BAM → FASTQ encode (interleaved or paired split output).
+    Fastq,
+}
+
+impl Stage {
+    /// Returns `true` if this stage is a terminal consensus stage.
+    /// Used by validators that reject post-consensus stages.
+    #[must_use]
+    pub fn is_consensus(self) -> bool {
+        matches!(self, Stage::Simplex | Stage::Duplex | Stage::Codec)
+    }
+
+    /// Returns `true` if this stage produces `BamTemplateBatch` from
+    /// an external source (AAM subprocess or zipper merge).
+    #[must_use]
+    pub fn is_template_producer(self) -> bool {
+        matches!(self, Stage::Align | Stage::Zipper)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every `Stage` variant, so the classifier tests below cover the whole
+    /// enum rather than a hand-picked subset. A new variant that is not added
+    /// here is still forced through the exhaustive `match`es in the
+    /// `expected_*` helpers, which fail to compile until it is classified.
+    const ALL_STAGES: [Stage; 14] = [
+        Stage::Extract,
+        Stage::Correct,
+        Stage::Align,
+        Stage::Zipper,
+        Stage::Sort,
+        Stage::Group,
+        Stage::Simplex,
+        Stage::Duplex,
+        Stage::Codec,
+        Stage::Clip,
+        Stage::Filter,
+        Stage::Dedup,
+        Stage::Downsample,
+        Stage::Fastq,
+    ];
+
+    /// Expected `is_consensus` truth per variant, spelled out with an
+    /// exhaustive `match` so adding a `Stage` variant is a compile error here
+    /// until it is deliberately classified.
+    fn expected_is_consensus(stage: Stage) -> bool {
+        match stage {
+            Stage::Simplex | Stage::Duplex | Stage::Codec => true,
+            Stage::Extract
+            | Stage::Correct
+            | Stage::Align
+            | Stage::Zipper
+            | Stage::Sort
+            | Stage::Group
+            | Stage::Clip
+            | Stage::Filter
+            | Stage::Dedup
+            | Stage::Downsample
+            | Stage::Fastq => false,
+        }
+    }
+
+    /// Expected `is_template_producer` truth per variant, exhaustive for the
+    /// same reason as [`expected_is_consensus`].
+    fn expected_is_template_producer(stage: Stage) -> bool {
+        match stage {
+            Stage::Align | Stage::Zipper => true,
+            Stage::Extract
+            | Stage::Correct
+            | Stage::Sort
+            | Stage::Group
+            | Stage::Simplex
+            | Stage::Duplex
+            | Stage::Codec
+            | Stage::Clip
+            | Stage::Filter
+            | Stage::Dedup
+            | Stage::Downsample
+            | Stage::Fastq => false,
+        }
+    }
+
+    #[test]
+    fn consensus_classifier_matches_every_variant() {
+        for s in ALL_STAGES {
+            assert_eq!(s.is_consensus(), expected_is_consensus(s), "is_consensus({s:?})");
+        }
+    }
+
+    #[test]
+    fn template_producer_classifier_matches_every_variant() {
+        for s in ALL_STAGES {
+            assert_eq!(
+                s.is_template_producer(),
+                expected_is_template_producer(s),
+                "is_template_producer({s:?})"
+            );
+        }
+    }
+}

--- a/src/lib/pipeline/chains/validate.rs
+++ b/src/lib/pipeline/chains/validate.rs
@@ -225,7 +225,7 @@ pub fn validate_stage_opts_present(spec: &ChainSpec) -> Result<()> {
 /// and the strategy is not re-checkable from the spec alone.
 ///
 /// **Deferred rule.** Dedup's "input must be template-coordinate sorted"
-/// rule is checked at chain-build time (`build_dedup_chain` reads the
+/// rule is checked at chain-build time (the chain builder reads the
 /// input BAM header) — it cannot be determined from `spec.stages` alone,
 /// so it intentionally stays out of this validator.
 ///
@@ -259,7 +259,7 @@ pub fn validate_cross_stage_constraints(spec: &ChainSpec) -> Result<()> {
     // stages are present in the same chain.
     //
     // Dedup's "input must be template-coordinate sorted" rule is checked at
-    // chain-build time (build_dedup_chain reads the input BAM header) — it
+    // chain-build time (the chain builder reads the input BAM header) — it
     // can't be checked from spec.stages alone, so it stays out of this
     // validator by design.
     if spec.stages.contains(&Stage::Duplex)
@@ -354,6 +354,7 @@ mod tests {
             scheduler: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
             async_reader: false,
+            verify_crc: true,
             command_line: String::new(),
         }
     }

--- a/src/lib/pipeline/chains/validate.rs
+++ b/src/lib/pipeline/chains/validate.rs
@@ -1,0 +1,731 @@
+//! Three independent validators for [`super::ChainSpec`]:
+//!
+//! 1. [`validate_stage_progression`] — ordering rules and mutual exclusions.
+//! 2. [`validate_stage_opts_present`] — each stage has its options in the bag.
+//! 3. [`validate_cross_stage_constraints`] — Zipper source, Duplex/Group
+//!    strategy, `BamWithIndex` terminal-sort, and Extract source rules.
+
+use anyhow::{Result, bail};
+
+use crate::pipeline::chains::{ChainSpec, Stage};
+
+/// Linear position of a stage in the canonical pipeline order. Used
+/// by [`validate_stage_progression`] to enforce that stages appear
+/// in a buildable order.
+///
+/// Mirrors `runall.rs::RunAllStage::ord` and extends it for the
+/// standalone-only stages. Consensus stages share ord = 7 because
+/// they're mutually exclusive in a chain.
+///
+/// Adjustments vs runall's ord:
+/// - Extract = 0 (input-producing, must precede everything)
+/// - Correct = 1 (was 0)
+/// - Align = 2 (was 1, was `AlignAndMerge`)
+/// - Zipper = 3 (was 2)
+/// - Sort = 4 (was 3)
+/// - Group = 5 (was 4)
+/// - Clip, Dedup, Downsample = 6 (post-group standalone-only)
+/// - Simplex, Duplex, Codec = 7 (terminal consensus, was 5)
+/// - Filter = 8 (post-consensus filtering; follows the consensus caller
+///   in a runall `consensus → filter` chain, so it sorts after the
+///   consensus bucket)
+fn stage_ord(stage: Stage) -> usize {
+    match stage {
+        Stage::Extract => 0,
+        Stage::Correct => 1,
+        Stage::Align => 2,
+        Stage::Zipper => 3,
+        Stage::Sort => 4,
+        Stage::Group => 5,
+        Stage::Clip | Stage::Dedup | Stage::Downsample => 6,
+        Stage::Simplex | Stage::Duplex | Stage::Codec => 7,
+        Stage::Filter => 8,
+        // Terminal BAM→FASTQ export. Only ever appears as the sole stage of a
+        // `fgumi fastq` chain, so its rank is nominal; place it last.
+        Stage::Fastq => 9,
+    }
+}
+
+/// Reject illegal stage orderings.
+///
+/// Rules:
+/// - At least one stage (empty chain is meaningless).
+/// - Each adjacent pair must be non-decreasing in `stage_ord`.
+/// - At most one `Align` per chain (mutually exclusive with `Zipper`).
+/// - At most one `Zipper` per chain (mutually exclusive with `Align`).
+/// - At most one consensus stage (`Simplex`/`Duplex`/`Codec`).
+/// - If a consensus stage is present, it must be either the last stage
+///   or immediately followed by a single trailing `Filter` (the
+///   `consensus → filter` runall chain) — nothing else may follow
+///   consensus.
+/// - `Extract` must be first when present.
+///
+/// # Errors
+///
+/// Returns the first violation with a human-readable message.
+pub fn validate_stage_progression(spec: &ChainSpec) -> Result<()> {
+    let stages = &spec.stages;
+    if stages.is_empty() {
+        bail!("ChainSpec.stages is empty — a chain needs at least one stage");
+    }
+
+    // Extract must be first when present.
+    if let Some(extract_pos) = stages.iter().position(|s| *s == Stage::Extract)
+        && extract_pos != 0
+    {
+        bail!("Stage::Extract must be the first stage in the chain (got position {extract_pos})");
+    }
+
+    // Non-decreasing ord (allowing equality for stages that share an ord bucket,
+    // e.g. multiple post-group standalone-only stages).
+    for window in stages.windows(2) {
+        let a = window[0];
+        let b = window[1];
+        if stage_ord(a) > stage_ord(b) {
+            bail!(
+                "Stage {a:?} (ord {}) cannot precede stage {b:?} (ord {}); \
+                 stages must appear in canonical pipeline order",
+                stage_ord(a),
+                stage_ord(b),
+            );
+        }
+    }
+
+    // Mutually-exclusive: at most one Align, at most one Zipper.
+    let align_count = stages.iter().filter(|s| **s == Stage::Align).count();
+    let zipper_count = stages.iter().filter(|s| **s == Stage::Zipper).count();
+    if align_count > 1 {
+        bail!("At most one Stage::Align per chain; got {align_count}");
+    }
+    if zipper_count > 1 {
+        bail!("At most one Stage::Zipper per chain; got {zipper_count}");
+    }
+    if align_count > 0 && zipper_count > 0 {
+        bail!(
+            "Stage::Align and Stage::Zipper are mutually exclusive in a chain; \
+             got both"
+        );
+    }
+
+    // At most one consensus stage, and it must be terminal.
+    let consensus_positions: Vec<usize> =
+        stages.iter().enumerate().filter(|(_, s)| s.is_consensus()).map(|(i, _)| i).collect();
+    if consensus_positions.len() > 1 {
+        bail!(
+            "At most one consensus stage per chain; got {} ({:?})",
+            consensus_positions.len(),
+            consensus_positions.iter().map(|i| stages[*i]).collect::<Vec<_>>()
+        );
+    }
+    if let Some(&pos) = consensus_positions.first() {
+        let last = stages.len() - 1;
+        // Consensus may be last, or second-to-last followed by a single
+        // trailing Filter (the runall `consensus → filter` chain). Any
+        // other stage after consensus is illegal.
+        let consensus_terminal = pos == last;
+        let consensus_then_filter = pos + 1 == last && stages[last] == Stage::Filter;
+        if !consensus_terminal && !consensus_then_filter {
+            bail!(
+                "Consensus stage {:?} at position {pos} must be terminal \
+                 (last in the chain) or immediately followed by a single \
+                 trailing Filter; chain has {} stages total",
+                stages[pos],
+                stages.len()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Reject specs where a referenced stage has no options in the bag.
+///
+/// As of Phase 5 T5.3, thirteen stages have their options in the bag:
+/// Correct, Sort, Group, Zipper, Duplex, Codec, Dedup, Filter, Clip, Simplex,
+/// Align, Extract, and Fastq. The remaining stage (Downsample) adds its slot
+/// incrementally during its migration task (T2.19–T2.22). For now that stage
+/// skips the options-presence check — once its slot lands in the bag, add the
+/// check here.
+///
+/// # Errors
+///
+/// Returns the first stage with a referenced-but-missing entry.
+pub fn validate_stage_opts_present(spec: &ChainSpec) -> Result<()> {
+    let bag = &spec.stage_opts;
+    for stage in &spec.stages {
+        // Downsample has no bag slot yet — fail early with a clear message.
+        if *stage == Stage::Downsample {
+            bail!(
+                "Stage::Downsample has no bag slot yet — \
+                 downsample isn't migrated to chains::build_for"
+            );
+        }
+
+        // Check wired stages have their options present.
+        let present = match stage {
+            Stage::Correct => bag.correct.is_some(),
+            Stage::Zipper => bag.zipper.is_some(),
+            Stage::Sort => bag.sort.is_some(),
+            Stage::Group => bag.group.is_some(),
+            #[cfg(feature = "consensus")]
+            Stage::Duplex => bag.duplex.is_some(),
+            #[cfg(feature = "consensus")]
+            Stage::Codec => bag.codec.is_some(),
+            Stage::Dedup => bag.dedup.is_some(),
+            Stage::Filter => bag.filter.is_some(),
+            Stage::Clip => bag.clip.is_some(),
+            #[cfg(feature = "consensus")]
+            Stage::Simplex => bag.simplex.is_some(),
+            // Without the `consensus` feature the consensus option-bag slots do
+            // not exist, so this stage can never be satisfied. Bail with an
+            // explicit feature-disabled error rather than returning `false`,
+            // which would surface the generic "options not provided" message
+            // below and tell reduced-feature callers to populate bag slots that
+            // do not exist. Unreachable in practice — the consensus CLI commands
+            // are compiled out too — but the message is correct if reached.
+            #[cfg(not(feature = "consensus"))]
+            Stage::Duplex | Stage::Codec | Stage::Simplex => {
+                bail!("Stage {stage:?} requires building fgumi with the `consensus` feature");
+            }
+            Stage::Align => bag.aligner.is_some(),
+            Stage::Extract => bag.extract.is_some(),
+            Stage::Fastq => bag.fastq.is_some(),
+            // Downsample is rejected by the early `bail!` above (no bag slot
+            // yet). Report "not provided" rather than `unreachable!()` so that
+            // if the early guard is ever removed without adding a slot here, the
+            // validator returns the clean "options not provided" error instead
+            // of panicking on a valid `[Downsample]` spec (S5b2-003).
+            Stage::Downsample => false,
+        };
+        if !present {
+            bail!(
+                "Stage {stage:?} requested but its options are not provided \
+                 in StageOptionsBag"
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Reject specs that violate cross-stage constraints (e.g. duplex
+/// requires group's strategy to be Paired).
+///
+/// Currently enforces two rules:
+///
+/// 1. `Stage::Zipper` requires `SourceSpec::PairedBams`.
+/// 2. `Stage::Duplex` following `Stage::Group` in the same chain
+///    requires `GroupOptions::strategy` to be `Strategy::Paired`.
+///    Other strategies don't tag `/A` vs `/B` endpoints in the way
+///    `DuplexConsensusCaller` expects.
+///
+/// **Rule 2 scope.** The rule fires only when both `Stage::Group` and
+/// `Stage::Duplex` appear in the same chain. Standalone `fgumi duplex`
+/// (chain = `[Stage::Duplex]`) skips the check because the input BAM is
+/// already MI-tagged with `/A`/`/B` annotations from a prior group run
+/// and the strategy is not re-checkable from the spec alone.
+///
+/// **Deferred rule.** Dedup's "input must be template-coordinate sorted"
+/// rule is checked at chain-build time (`build_dedup_chain` reads the
+/// input BAM header) — it cannot be determined from `spec.stages` alone,
+/// so it intentionally stays out of this validator.
+///
+/// # Errors
+///
+/// Returns an error on the first violated constraint.
+pub fn validate_cross_stage_constraints(spec: &ChainSpec) -> Result<()> {
+    use crate::assigner::Strategy;
+    use crate::pipeline::chains::{SinkSpec, SourceSpec};
+
+    // Rule 1: Zipper requires a PairedBams source.
+    if spec.stages.contains(&Stage::Zipper) {
+        match &spec.source {
+            SourceSpec::PairedBams { .. } => {}
+            _ => {
+                bail!(
+                    "Stage::Zipper requires SourceSpec::PairedBams (unmapped + mapped + reference); \
+                     got a different source variant"
+                );
+            }
+        }
+    }
+
+    // Rule 2: Duplex (terminal) following Group (assigning MI ids) requires
+    // Group's strategy to be Paired. Other strategies don't tag /A vs /B
+    // endpoints in the way DuplexConsensusCaller expects.
+    //
+    // Standalone duplex (chain = [Stage::Duplex]) skips Group; the input is
+    // already MI-tagged with /A/B annotations from a prior group run. We can't
+    // validate that at spec-construct time, so the rule only fires when both
+    // stages are present in the same chain.
+    //
+    // Dedup's "input must be template-coordinate sorted" rule is checked at
+    // chain-build time (build_dedup_chain reads the input BAM header) — it
+    // can't be checked from spec.stages alone, so it stays out of this
+    // validator by design.
+    if spec.stages.contains(&Stage::Duplex)
+        && spec.stages.contains(&Stage::Group)
+        && let Some(group_opts) = spec.stage_opts.group.as_ref()
+        && !matches!(group_opts.strategy, Strategy::Paired)
+    {
+        bail!(
+            "Stage::Duplex requires Stage::Group to use Strategy::Paired \
+             (got Strategy::{:?})",
+            group_opts.strategy
+        );
+    }
+
+    // Rule 3: `SinkSpec::BamWithIndex` requires the terminal stage to be
+    // `Stage::Sort`. The BAI file format indexes BGZF virtual offsets of a
+    // coordinate-sorted BAM; emitting one for a non-sort terminal stage (or
+    // for a chain where sort is intermediate, leaving some other stage as
+    // terminal) would either reference a file that isn't coordinate-sorted
+    // or attempt to index an output type the hook isn't equipped to handle.
+    // The per-command CLI check (`Sort::execute` rejects
+    // `--write-index --order queryname`) handles the "coordinate
+    // specifically, not template-coordinate or queryname" constraint.
+    if matches!(spec.sink, SinkSpec::BamWithIndex(_)) {
+        let terminal_is_sort = spec.stages.last().is_some_and(|s| *s == Stage::Sort);
+        if !terminal_is_sort {
+            // `validate_stage_progression` rejects empty `stages` before
+            // this validator runs, so `last()` is guaranteed `Some` here.
+            // Rather than `unreachable!()`, the invariant is documented with a
+            // descriptive error via `ok_or_else` so an out-of-order validator
+            // change degrades to a clean error instead of a panic.
+            let terminal = spec.stages.last().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "SinkSpec::BamWithIndex requires Stage::Sort as the terminal chain stage; \
+                     got an empty chain (should have been caught by validate_stage_progression)",
+                )
+            })?;
+            bail!(
+                "SinkSpec::BamWithIndex requires Stage::Sort as the terminal chain stage; \
+                 got terminal stage {terminal:?}",
+            );
+        }
+    }
+
+    // Rule 4: `Stage::Extract` requires a `SourceSpec::Fastqs` source.
+    // Extract reads directly from FASTQ files; feeding it a BAM, SAM, or
+    // paired-BAM source is a programmer error that would be caught late
+    // (at chain-build time) without this guard. Catching it here at
+    // spec-validation time gives a clearer error message.
+    if spec.stages.contains(&Stage::Extract) && !matches!(spec.source, SourceSpec::Fastqs { .. }) {
+        bail!("Stage::Extract requires SourceSpec::Fastqs; got {:?}", spec.source);
+    }
+
+    // Rule 5: the FASTQ sink and `Stage::Fastq` must go together. A `Fastq`
+    // sink pushes raw bytes through `add_fastq_sink` with no BAM header, and
+    // `Stage::Fastq` emits FASTQ text, not serialized BAM records — pairing
+    // either with the other format's counterpart would silently write a
+    // corrupt file (FASTQ text wrapped in a BAM header, or BAM bytes with no
+    // header). Require the biconditional.
+    let sink_is_fastq = matches!(spec.sink, SinkSpec::Fastq(_) | SinkSpec::FastqPaired { .. });
+    let terminal_is_fastq = spec.stages.last() == Some(&Stage::Fastq);
+    if sink_is_fastq != terminal_is_fastq {
+        bail!(
+            "SinkSpec::Fastq requires Stage::Fastq as the terminal chain stage and vice versa; \
+             got sink={:?}, terminal stage={:?}",
+            spec.sink,
+            spec.stages.last()
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::chains::{SinkSpec, SourceSpec};
+    use std::path::PathBuf;
+
+    fn empty_spec(stages: Vec<Stage>) -> ChainSpec {
+        use crate::commands::common::{
+            CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
+        };
+        use crate::pipeline::chains::StageOptionsBag;
+        ChainSpec {
+            stages,
+            source: SourceSpec::Bam(PathBuf::from("in.bam")),
+            sink: SinkSpec::Bam(PathBuf::from("out.bam")),
+            stage_opts: StageOptionsBag::default(),
+            threading: ThreadingOptions { threads: None },
+            compression: CompressionOptions::default(),
+            scheduler: SchedulerOptions::default(),
+            queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
+            command_line: String::new(),
+        }
+    }
+
+    #[test]
+    fn empty_chain_rejected() {
+        let err = validate_stage_progression(&empty_spec(vec![])).unwrap_err();
+        assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn is_sort_terminal_only_for_lone_sort() {
+        // The single-sourced predicate that both `build_for` (source/sink skip)
+        // and `ChainBuilder::new` (header-open skip) rely on.
+        assert!(empty_spec(vec![Stage::Sort]).is_sort_terminal());
+        assert!(!empty_spec(vec![]).is_sort_terminal());
+        assert!(!empty_spec(vec![Stage::Group, Stage::Sort]).is_sort_terminal());
+        assert!(!empty_spec(vec![Stage::Sort, Stage::Group]).is_sort_terminal());
+        assert!(!empty_spec(vec![Stage::Correct, Stage::Sort]).is_sort_terminal());
+    }
+
+    #[test]
+    fn good_chain_accepted() {
+        let spec = empty_spec(vec![Stage::Sort, Stage::Group, Stage::Simplex]);
+        validate_stage_progression(&spec).expect("good chain should validate");
+    }
+
+    #[test]
+    fn out_of_order_rejected() {
+        let spec = empty_spec(vec![Stage::Group, Stage::Sort]);
+        let err = validate_stage_progression(&spec).unwrap_err();
+        assert!(err.to_string().contains("canonical pipeline order"));
+    }
+
+    #[test]
+    fn align_and_zipper_mutually_exclusive() {
+        let spec = empty_spec(vec![Stage::Align, Stage::Zipper]);
+        let err = validate_stage_progression(&spec).unwrap_err();
+        assert!(err.to_string().contains("mutually exclusive"));
+    }
+
+    #[test]
+    fn consensus_must_be_terminal() {
+        // Consensus followed by a non-Filter stage (Clip) is illegal:
+        // Clip (ord 6) cannot follow Simplex (ord 7), and Clip is not the
+        // permitted trailing Filter. Either the ordering check or the
+        // terminal check fires first — both are valid rejections.
+        let spec = empty_spec(vec![Stage::Simplex, Stage::Clip]);
+        let err = validate_stage_progression(&spec).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("terminal") || msg.contains("canonical pipeline order"), "got: {msg}");
+    }
+
+    #[test]
+    fn consensus_then_filter_is_valid() {
+        // The runall `consensus → filter` chain: Simplex (ord 7) followed
+        // by a single trailing Filter (ord 8) is permitted.
+        let spec = empty_spec(vec![Stage::Group, Stage::Simplex, Stage::Filter]);
+        assert!(
+            validate_stage_progression(&spec).is_ok(),
+            "group → simplex → filter must be a valid progression"
+        );
+    }
+
+    #[test]
+    fn multiple_consensus_rejected() {
+        let spec = empty_spec(vec![Stage::Simplex, Stage::Duplex]);
+        let err = validate_stage_progression(&spec).unwrap_err();
+        // Caught either by "mutually exclusive" or "at most one consensus" or "terminal"
+        // depending on which check fires first; either is acceptable.
+        let msg = err.to_string();
+        assert!(msg.contains("consensus") || msg.contains("terminal"), "got: {msg}");
+    }
+
+    #[test]
+    fn extract_must_be_first() {
+        let spec = empty_spec(vec![Stage::Correct, Stage::Extract]);
+        let err = validate_stage_progression(&spec).unwrap_err();
+        assert!(err.to_string().contains("first"));
+    }
+
+    #[test]
+    fn missing_options_caught() {
+        let spec = empty_spec(vec![Stage::Correct]);
+        let err = validate_stage_opts_present(&spec).unwrap_err();
+        assert!(err.to_string().contains("Correct"));
+    }
+
+    #[test]
+    fn cross_stage_correct_accepted() {
+        // Non-Zipper stages are unaffected by the PairedBams constraint.
+        let spec = empty_spec(vec![Stage::Correct]);
+        validate_cross_stage_constraints(&spec).expect("Correct with Bam source is valid");
+    }
+
+    #[test]
+    fn cross_stage_zipper_requires_paired_bams() {
+        use crate::pipeline::chains::SourceSpec;
+
+        // Zipper with a Bam source should be rejected.
+        let mut spec = empty_spec(vec![Stage::Zipper]);
+        spec.source = SourceSpec::Bam(std::path::PathBuf::from("in.bam"));
+        let err = validate_cross_stage_constraints(&spec).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("PairedBams"), "expected PairedBams message, got: {msg}");
+    }
+
+    #[test]
+    fn cross_stage_zipper_with_paired_bams_accepted() {
+        use crate::pipeline::chains::SourceSpec;
+
+        let mut spec = empty_spec(vec![Stage::Zipper]);
+        spec.source = SourceSpec::PairedBams {
+            unmapped: std::path::PathBuf::from("u.bam"),
+            mapped: std::path::PathBuf::from("m.bam"),
+            reference: std::path::PathBuf::from("ref.fa"),
+        };
+        validate_cross_stage_constraints(&spec).expect("Zipper with PairedBams is valid");
+    }
+
+    #[test]
+    fn cross_stage_bam_with_index_accepted_on_terminal_sort() {
+        let mut spec = empty_spec(vec![Stage::Sort]);
+        spec.sink = SinkSpec::BamWithIndex(std::path::PathBuf::from("out.bam"));
+        validate_cross_stage_constraints(&spec)
+            .expect("BamWithIndex on a Stage::Sort-terminal chain is valid");
+    }
+
+    #[test]
+    fn cross_stage_bam_with_index_rejected_on_non_sort_terminal() {
+        // Sort → Group (Sort is intermediate, Group is terminal) — BAI makes
+        // no sense because Group's output doesn't go through the indexer's
+        // BGZF-virtual-offset assumptions.
+        let mut spec = empty_spec(vec![Stage::Sort, Stage::Group]);
+        spec.sink = SinkSpec::BamWithIndex(std::path::PathBuf::from("out.bam"));
+        let err = validate_cross_stage_constraints(&spec).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("BamWithIndex"), "expected BamWithIndex in error, got: {msg}");
+        assert!(msg.contains("Stage::Sort"), "expected Stage::Sort in error, got: {msg}");
+    }
+
+    #[test]
+    fn cross_stage_bam_with_index_rejected_on_no_sort_chain() {
+        // Group only — no sort at all.
+        let mut spec = empty_spec(vec![Stage::Group]);
+        spec.sink = SinkSpec::BamWithIndex(std::path::PathBuf::from("out.bam"));
+        let err = validate_cross_stage_constraints(&spec).unwrap_err();
+        assert!(err.to_string().contains("BamWithIndex"));
+    }
+
+    #[test]
+    fn cross_stage_bam_with_index_accepted_on_multi_stage_terminal_sort() {
+        // Multi-stage chain with Sort as the terminal stage — e.g. a
+        // hypothetical `[Stage::Correct, Stage::Sort]` runall invocation
+        // that asks for BAI. Validator accepts; `add_sort`'s streaming
+        // branch (where this chain lands because `current_tail.is_some()`
+        // after the upstream Correct step) registers the hook in mirror of
+        // the standalone branch.
+        let mut spec = empty_spec(vec![Stage::Correct, Stage::Sort]);
+        spec.sink = SinkSpec::BamWithIndex(std::path::PathBuf::from("out.bam"));
+        validate_cross_stage_constraints(&spec)
+            .expect("BamWithIndex on a multi-stage chain with Sort terminal is valid");
+    }
+
+    #[test]
+    fn cross_stage_bam_with_index_error_message_unwraps_terminal_stage() {
+        // Regression guard against formatting `spec.stages.last()` as
+        // `Option<&Stage>` (which would emit "Some(Group)") instead of
+        // the unwrapped stage name. The user-facing error should read
+        // "got terminal stage Group", not "got terminal stage Some(Group)".
+        let mut spec = empty_spec(vec![Stage::Group]);
+        spec.sink = SinkSpec::BamWithIndex(std::path::PathBuf::from("out.bam"));
+        let msg = validate_cross_stage_constraints(&spec).unwrap_err().to_string();
+        assert!(!msg.contains("Some("), "error message wrapped terminal stage in Some(): {msg}");
+        assert!(msg.contains("Group"), "expected stage name in error, got: {msg}");
+    }
+
+    #[test]
+    fn opts_present_downsample_not_wired() {
+        // Stage::Downsample has no bag slot yet; should fail at options-presence time.
+        let spec = empty_spec(vec![Stage::Downsample]);
+        let err = validate_stage_opts_present(&spec).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Downsample"), "expected Downsample in error, got: {msg}");
+        assert!(msg.contains("no bag slot"), "expected 'no bag slot' in error, got: {msg}");
+    }
+
+    #[test]
+    fn opts_present_extract_missing_fails() {
+        // Stage::Extract is now wired (T5.3); missing options should fail with
+        // "options not provided" — not "no bag slot".
+        let spec = empty_spec(vec![Stage::Extract]);
+        let err = validate_stage_opts_present(&spec).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Extract"), "expected Extract in error, got: {msg}");
+        assert!(
+            !msg.contains("no bag slot"),
+            "expected options-missing error (not 'no bag slot') for Extract, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn opts_present_align_missing_fails() {
+        // Stage::Align is now wired; missing options should fail with a
+        // "options not provided" error (not "no bag slot").
+        let spec = empty_spec(vec![Stage::Align]);
+        let err = validate_stage_opts_present(&spec).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Align"), "expected Align in error, got: {msg}");
+        assert!(
+            !msg.contains("no bag slot"),
+            "expected options-missing error (not 'no bag slot') for Align, got: {msg}"
+        );
+    }
+
+    // These three exercise the consensus option-bag slots, which only exist
+    // with the `consensus` feature.
+    #[cfg(feature = "consensus")]
+    #[test]
+    fn duplex_after_group_requires_paired_strategy() {
+        use crate::assigner::Strategy;
+        use crate::commands::duplex::DuplexOptions;
+        use crate::commands::group::GroupOptions;
+
+        let mut spec = empty_spec(vec![Stage::Group, Stage::Duplex]);
+        spec.stage_opts.group =
+            Some(GroupOptions { strategy: Strategy::Identity, ..Default::default() });
+        spec.stage_opts.duplex = Some(DuplexOptions::default());
+
+        let err = validate_cross_stage_constraints(&spec).unwrap_err();
+        assert!(err.to_string().contains("Paired"), "got: {err}");
+    }
+
+    #[cfg(feature = "consensus")]
+    #[test]
+    fn duplex_after_group_with_paired_strategy_accepted() {
+        use crate::assigner::Strategy;
+        use crate::commands::duplex::DuplexOptions;
+        use crate::commands::group::GroupOptions;
+
+        let mut spec = empty_spec(vec![Stage::Group, Stage::Duplex]);
+        spec.stage_opts.group =
+            Some(GroupOptions { strategy: Strategy::Paired, ..Default::default() });
+        spec.stage_opts.duplex = Some(DuplexOptions::default());
+
+        validate_cross_stage_constraints(&spec).expect("paired strategy should pass");
+    }
+
+    #[cfg(feature = "consensus")]
+    #[test]
+    fn standalone_duplex_skips_paired_check() {
+        // Chain has only Stage::Duplex (no Stage::Group). Rule 2 does not fire
+        // because the check requires both Stage::Group AND Stage::Duplex to be
+        // present in the same chain.
+        use crate::commands::duplex::DuplexOptions;
+
+        let mut spec = empty_spec(vec![Stage::Duplex]);
+        spec.stage_opts.duplex = Some(DuplexOptions::default());
+
+        validate_cross_stage_constraints(&spec).expect("standalone duplex skips paired check");
+    }
+
+    // ── Rule 4: Stage::Extract requires SourceSpec::Fastqs ──────────────────
+
+    /// Helper: a minimal `ExtractOptions` suitable for tests.
+    fn minimal_extract_opts() -> crate::commands::extract::ExtractOptions {
+        use crate::commands::extract::{ExtractOptions, QualityEncoding};
+        ExtractOptions {
+            sample: "sample".to_string(),
+            library: "library".to_string(),
+            platform: None,
+            platform_unit: None,
+            read_group_id: "A".to_string(),
+            comments: vec![],
+            barcode: None,
+            platform_model: None,
+            sequencing_center: None,
+            predicted_insert_size: None,
+            description: None,
+            run_date: None,
+            quality_encoding: QualityEncoding::Standard,
+            store_umi_quals: false,
+            store_cell_quals: false,
+            single_tag: None,
+            annotate_read_names: false,
+            extract_umis_from_read_names: false,
+            store_sample_barcode_qualities: false,
+            async_reader: false,
+        }
+    }
+
+    #[test]
+    fn cross_stage_extract_with_bam_source_rejected() {
+        // Rule 4: Stage::Extract + SourceSpec::Bam must be rejected.
+        let mut spec = empty_spec(vec![Stage::Extract]);
+        spec.source = SourceSpec::Bam(std::path::PathBuf::from("in.bam"));
+        spec.stage_opts.extract = Some(minimal_extract_opts());
+        let err = validate_cross_stage_constraints(&spec).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("requires SourceSpec::Fastqs"), "got: {msg}");
+    }
+
+    #[test]
+    fn cross_stage_extract_with_fastqs_source_accepted() {
+        // Rule 4: Stage::Extract + SourceSpec::Fastqs must be accepted.
+        use crate::read_structure::ReadStructure;
+        use std::str::FromStr;
+
+        let mut spec = empty_spec(vec![Stage::Extract]);
+        spec.source = SourceSpec::Fastqs {
+            paths: vec![std::path::PathBuf::from("r1.fq.gz"), std::path::PathBuf::from("r2.fq.gz")],
+            read_structures: vec![
+                ReadStructure::from_str("+T").unwrap(),
+                ReadStructure::from_str("+T").unwrap(),
+            ],
+        };
+        spec.stage_opts.extract = Some(minimal_extract_opts());
+        validate_cross_stage_constraints(&spec)
+            .expect("Stage::Extract + SourceSpec::Fastqs should be valid");
+    }
+
+    #[test]
+    fn opts_present_extract_with_options_passes() {
+        // Stage::Extract with its bag slot populated must pass the opts-present check.
+        use crate::read_structure::ReadStructure;
+        use std::str::FromStr;
+
+        let mut spec = empty_spec(vec![Stage::Extract]);
+        spec.source = SourceSpec::Fastqs {
+            paths: vec![std::path::PathBuf::from("r1.fq.gz")],
+            read_structures: vec![ReadStructure::from_str("+T").unwrap()],
+        };
+        spec.stage_opts.extract = Some(minimal_extract_opts());
+        validate_stage_opts_present(&spec)
+            .expect("Stage::Extract with options populated should pass");
+    }
+
+    // ── Rule 5: SinkSpec::{Fastq,FastqPaired} <-> Stage::Fastq biconditional ─
+
+    #[test]
+    fn cross_stage_fastq_paired_accepted_on_terminal_fastq() {
+        let mut spec = empty_spec(vec![Stage::Fastq]);
+        spec.sink = SinkSpec::FastqPaired {
+            out1: std::path::PathBuf::from("r1.fq.gz"),
+            out2: std::path::PathBuf::from("r2.fq.gz"),
+            out0: Some(std::path::PathBuf::from("other.fq.gz")),
+        };
+        validate_cross_stage_constraints(&spec)
+            .expect("FastqPaired + terminal Stage::Fastq must be valid");
+    }
+
+    #[test]
+    fn cross_stage_fastq_paired_rejected_on_non_fastq_terminal() {
+        // Sort -> Group (Group is terminal, not Fastq).
+        let mut spec = empty_spec(vec![Stage::Sort, Stage::Group]);
+        spec.sink = SinkSpec::FastqPaired {
+            out1: std::path::PathBuf::from("r1.fq"),
+            out2: std::path::PathBuf::from("r2.fq"),
+            out0: None,
+        };
+        let err = validate_cross_stage_constraints(&spec).unwrap_err();
+        assert!(err.to_string().contains("Stage::Fastq"), "got: {err}");
+    }
+
+    #[test]
+    fn cross_stage_fastq_terminal_rejected_on_non_fastq_sink() {
+        // The other direction of the Rule 5 biconditional: a Stage::Fastq
+        // terminal with a non-FASTQ sink (the default Bam sink) must be
+        // rejected, mirroring the FASTQ-sink/non-Fastq-terminal case above.
+        let spec = empty_spec(vec![Stage::Fastq]); // empty_spec defaults sink = Bam
+        assert!(matches!(spec.sink, SinkSpec::Bam(_)), "precondition: default sink is Bam");
+        let err = validate_cross_stage_constraints(&spec).unwrap_err();
+        assert!(err.to_string().contains("Stage::Fastq"), "got: {err}");
+    }
+}

--- a/src/lib/pipeline/mod.rs
+++ b/src/lib/pipeline/mod.rs
@@ -12,11 +12,11 @@
 //!   protocol, reorder buffers).
 //! - [`steps`]: the concrete `Step` implementations (decompress, boundaries,
 //!   parse, serialize, compress, write, …).
+//! - [`chains`]: declarative chain construction — `build_for`, `ChainBuilder`,
+//!   per-command step factories that assemble the steps into runnable pipelines.
 //!
-//! A `chains` module (declarative chain construction — `build_for`,
-//! `ChainBuilder`, per-command step factories) lands in a follow-up; until it
-//! does, nothing in `src/lib/commands` routes through this tree and every
-//! command still runs on `unified_pipeline`.
+//! Commands are rewired onto `chains` one at a time; until a given command is
+//! rewired it still runs on `unified_pipeline`.
 
 /// The typed-step execution engine, extracted into the `fgumi-pipeline-core`
 /// crate so its lightweight dependency graph (no `noodles`-bam / sort /
@@ -24,4 +24,5 @@
 /// `crate::pipeline::core::…` path resolves — which is what lets the ported
 /// step sources compile unmodified.
 pub use fgumi_pipeline_core as core;
+pub mod chains;
 pub mod steps;

--- a/src/lib/pipeline/steps/align_and_merge.rs
+++ b/src/lib/pipeline/steps/align_and_merge.rs
@@ -1,0 +1,2553 @@
+//! `AlignAndMergeStep` — typed `Step` that wraps an aligner
+//! subprocess and pairs aligner output with original unmapped tags.
+//!
+//! Supersedes a former hand-rolled orchestrator that drained aligner
+//! stdout to a tempfile and then re-opened the input BAM via
+//! `Zipper::execute`. This Step instead streams template-by-template
+//! with no tempfile bridge.
+//!
+//! ## Shape
+//!
+//! ```text
+//!  upstream (BamTemplateBatch)
+//!     │
+//!     ▼
+//!  ┌──────────────── AlignAndMergeStep ─────────────────┐
+//!  │  Owns:                                              │
+//!  │    • AlignerProcess (subprocess + stderr ring)      │
+//!  │    • stdin-writer thread (FASTQ → aligner stdin)    │
+//!  │    • stdout-reader thread (SAM/BAM parse only —     │
+//!  │      no merge; emits ZipperBatch for try_run)       │
+//!  │    • Three bounded channels (in_chan, token_chan,   │
+//!  │      out_chan) and a shared error slot              │
+//!  │                                                     │
+//!  │  Step::try_run (Serial; any worker can dispatch):   │
+//!  │    upstream → in_chan → (writer) → aligner stdin    │
+//!  │    aligner stdout → (reader) → out_chan ──┐         │
+//!  │                                            ▼         │
+//!  │                              merge_zipper_batch      │
+//!  │                              (merge_raw + bisulfite) │
+//!  │                                            │         │
+//!  │                                            ▼         │
+//!  │                                       downstream     │
+//!  └──────────────────────────────────────────────────────┘
+//! ```
+//!
+//! Why `Serial` instead of `Exclusive`: `Exclusive` pinned dispatch to
+//! one worker, which meant any other step's blocking work on that
+//! worker (e.g. a held-slot flush spin-retrying on a full downstream)
+//! could starve AAM and deadlock the pipeline.
+//! `Serial` lets any free worker dispatch AAM; the framework mutex
+//! preserves the "one dispatcher at a time" invariant that
+//! `in_tx`/`out_rx`/`held_*` require. See
+//! `docs/design/aam-bridge-refactor.md` for the full diagnosis.
+//!
+//! Why merge happens in `try_run`, not on the reader: the reader is
+//! the sole consumer of bwa's stdout, and `merge_raw` per template
+//! is CPU-heavy (especially with bisulfite restore). Doing the merge
+//! on the reader makes bwa stall on stdout flush when merge is the
+//! bottleneck. Emitting raw `ZipperBatch` (paired mapped + unmapped)
+//! and merging in `try_run` keeps the reader I/O-bound and lets
+//! whichever worker dispatches AAM amortize merge across the same
+//! `OUT_CHAN_DEPTH` of in-flight batches.
+//!
+//! ## [`BatchToken`] / [`ZipperBatch`] protocol (index-based pairing)
+//!
+//! Pairing of unmapped templates with their alignments is **structural
+//! by index, not queryname**. The writer thread keeps a per-batch
+//! template count and ships a `BatchToken { unmapped, n_templates,
+//! serial }` through `token_chan` to the reader thread. The reader
+//! pops one token at a time, reads exactly `n_templates` templates
+//! from aligner stdout, packages them into a `ZipperBatch { serial,
+//! mapped, unmapped }`, and sends that on `out_chan`. `try_run`
+//! pops `ZipperBatch`es and calls `merge_zipper_batch` (which runs
+//! `merge_raw` + optional bisulfite restore per template-pair) to
+//! produce the merged `BamTemplateBatch` pushed downstream.
+//!
+//! This relies on the aligner preserving input record order (bwa-mem
+//! and bwa-mem3 do this when `-K` chunk size is set, which our presets
+//! require). A per-template queryname-equality check — always on, not a
+//! debug assertion — rejects out-of-order aligner output with a loud
+//! error rather than silently mismerging tags onto the wrong reads.
+//!
+//! AAM further requires the aligner to emit **exactly one alignment
+//! group per input read**; the count guards in the reader error if it
+//! emits fewer or more. This is a deliberate narrowing of the sibling
+//! `ZipperMergeStep`'s contract, which tolerates missing mapped reads
+//! via its `exclude_missing_reads` flag: AAM targets order- and
+//! count-preserving aligners (bwa-mem/bwa-mem3) and treats a dropped or
+//! extra read as an error, not a silently-skipped template.
+//!
+//! ## Header propagation
+//!
+//! The reader thread's first action (before any record) is to parse
+//! the aligner's emitted SAM header, merge it with the
+//! construction-time partial header (dict-derived `@SQ` + unmapped
+//! `@HD`/`@CO`/`@RG`/`@PG` + fgumi's own `@PG`), and resolve the
+//! supplied [`HeaderHandle`]. The downstream `WriteBgzfFile`
+//! (constructed via `new_with_handle`) polls the handle and proceeds
+//! once it's resolved.
+//!
+//! ## Lifecycle
+//!
+//! - `new` spawns the subprocess + both daemon threads + sets up
+//!   channels.
+//! - `try_run` is dispatcher-driven, non-blocking, with two `HeldSlot`s
+//!   (`held_in` for upstream→`in_chan` backpressure, `held_out` for
+//!   merged-batch→downstream backpressure). It runs three phases across
+//!   re-dispatches: ingest (pump `ctx.input` → `in_tx` while merging the
+//!   aligner's output), close-stdin (once `ctx.input` is drained and
+//!   `held_in` is flushed, drop `in_tx` → aligner stdin EOF), and drain
+//!   (pump the aligner's tail through `out_rx` until the reader has exited
+//!   and the receiver is empty, then `finalize`). Returning
+//!   `StepOutcome::Finished` only at the end of the drain phase means the
+//!   final flush yields and is re-dispatched rather than blocking the worker.
+//! - `finalize` joins both daemons (which cannot block — the reader has
+//!   exited and the receiver is drained), waits the subprocess, and surfaces
+//!   the stderr ring on non-zero exit in order (aligner → reader → writer).
+//! - `Drop` is the resource-cleanup backstop on error paths — the clean
+//!   `finalize` is never reached when any step returns `Err` (the
+//!   framework signals teardown via `PipelineSignal::is_done`).
+//!
+//! ## Output formats
+//!
+//! The reader auto-detects BGZF by validating the aligner's leading
+//! bytes against the shared [`fgumi_bgzf::is_bgzf_header`] classifier:
+//! * BGZF → noodles BAM reader, zero-copy per-record via
+//!   [`fgumi_raw_bam::RawBamReader`].
+//! * Anything else → noodles SAM text reader, one
+//!   `RecordBuf → RawRecord` encode per record via
+//!   [`fgumi_raw_bam::encode_record_buf_to_raw`].
+//!
+//! BAM is the higher-throughput path because there's no encode
+//! cost; aligners that can emit BAM (e.g. via a `samtools view -bu -`
+//! pipe in the user's command) avoid the SAM encode entirely.
+
+use std::io::{self, BufReader, BufWriter, Read, Write};
+use std::process::ChildStdout;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{Receiver, Sender, SyncSender, TrySendError, channel, sync_channel};
+use std::thread::{self, JoinHandle};
+
+use noodles::sam::Header;
+use parking_lot::Mutex;
+
+use crate::aligner::AlignerProcess;
+use crate::commands::fastq::{FastqRecordBuffers, write_fastq_record};
+use crate::commands::zipper::merge_one_template;
+use crate::pipeline::core::header::HeaderHandle;
+use crate::pipeline::core::item::{HeapSize, Ordered};
+use crate::pipeline::core::{
+    BranchOrdering, HeldSlot, OrderedBytesSingle, QueueSpec, Step, StepCtx, StepKind, StepOutcome,
+    StepProfile, Unpushed,
+};
+use crate::pipeline::steps::types::BamTemplateBatch;
+use crate::reference::ReferenceReader;
+use crate::template::Template;
+use crate::umi::TagInfo;
+
+/// Number of aligner stderr lines retained for failure diagnostics.
+/// Same value the former hand-rolled orchestrator used.
+const ALIGNER_STDERR_RING_SIZE: usize = 50;
+
+/// Flag bits filtered from records written as FASTQ to the aligner.
+/// `0x900` = `SECONDARY | SUPPLEMENTARY`. Same rationale as the former
+/// hand-rolled orchestrator: if a previously-aligned BAM is passed by
+/// mistake, dropping these prevents duplicate FASTQ emissions for the
+/// same template.
+const FASTQ_WRITER_EXCLUDE_FLAGS: u16 =
+    fgumi_raw_bam::flags::SECONDARY | fgumi_raw_bam::flags::SUPPLEMENTARY;
+
+/// Bound for `in_chan` (dispatcher → writer thread). Two batches in
+/// flight match bwa's `kt_pipeline` `p_nt=2` double-buffer: one batch
+/// being aligned, one queued. See the design doc
+/// `align-and-merge-as-step.md` for the derivation from bwa-mem2's
+/// `fastmap.cpp`.
+///
+/// Note: the writer→reader **token** channel is intentionally
+/// unbounded (`std::sync::mpsc::channel()`), NOT bounded by this
+/// constant. See the comment at the `token_chan` construction site
+/// in [`AlignAndMergeStep::new`] for the deadlock rationale: bwa's
+/// `-K` flag lets it buffer many input batches before emitting any
+/// output, so the writer must be able to keep pushing tokens past
+/// the reader without blocking — otherwise the writer is stuck on
+/// `token_tx.send` and never closes bwa's stdin, and bwa never
+/// flushes. Backpressure on the writer-side flow is enforced
+/// naturally by the OS pipe buffer (~64 KiB on macOS) plus bwa's
+/// `-K`-bounded internal buffer, both of which throttle the
+/// FASTQ-write path well before the token channel ever fills up.
+const IN_CHAN_DEPTH: usize = 2;
+
+/// Bound for `out_chan` (reader thread → dispatcher). Two batches lets
+/// the reader stay one ahead while the dispatcher pumps the previous
+/// out to downstream; backpressure cascades back when downstream
+/// stalls.
+const OUT_CHAN_DEPTH: usize = 2;
+
+/// Estimated in-flight bytes per aligner-input base, used to derive the
+/// in-flight-unmapped byte budget from the aligner's `-K` chunk size.
+/// One base costs ~1 byte of sequence + ~1 byte of quality held in the
+/// unmapped `RawRecord`, plus read-name / tag overhead — 3 is a
+/// deliberately generous estimate so the budget never under-shoots the
+/// aligner's real buffering (under-shooting risks a writer stall).
+const IN_FLIGHT_BYTES_PER_BASE: u64 = 3;
+
+/// Multiplier over a single `-K` chunk for the in-flight budget. bwa's
+/// `kt_pipeline` double-buffers (`p_nt=2`: one chunk aligning, one
+/// queued), so the aligner can hold ~2 chunks before emitting; 4× adds
+/// slack for the FASTQ-write buffer and pipeline jitter so the writer
+/// never blocks before the aligner has a full chunk to emit (which
+/// would deadlock — see `InFlightGate`).
+const IN_FLIGHT_CHUNK_MULTIPLIER: u64 = 4;
+
+/// Floor for the in-flight-unmapped budget. Keeps the budget workable
+/// for small `-K` values (custom aligner commands, tests) where the
+/// `-K`-derived value would be tiny, and covers aligners whose internal
+/// buffering exceeds their nominal `-K`.
+const IN_FLIGHT_MIN_BUDGET: u64 = 512 * 1024 * 1024;
+
+/// Derive the in-flight-unmapped byte budget for AAM from the aligner's
+/// `-K` chunk size (bases per batch). The budget bounds the otherwise
+/// unbounded writer→reader token backlog: the writer blocks once the
+/// in-flight unmapped bytes reach this, so a fast-draining aligner can't
+/// accumulate the whole input's unmapped reads in RAM (issue #382).
+///
+/// Sized `≥` the aligner's real buffering so a **streaming** aligner
+/// (one that emits output after ≤ `-K` bases — every real aligner)
+/// always has a full chunk to emit before the writer blocks, so the
+/// block is transient, not a deadlock. A non-streaming aligner (one that
+/// reads all stdin before emitting) is out of contract: it would stall
+/// the writer here rather than OOM. For the default `-K` of 150M bases
+/// this is ~1.8 GiB.
+#[must_use]
+pub fn in_flight_budget_for_chunk_size(chunk_size_bases: u64) -> u64 {
+    chunk_size_bases
+        .saturating_mul(IN_FLIGHT_BYTES_PER_BASE)
+        .saturating_mul(IN_FLIGHT_CHUNK_MULTIPLIER)
+        .max(IN_FLIGHT_MIN_BUDGET)
+}
+
+/// Byte-budget gate bounding AAM's in-flight unmapped reads (the
+/// writer→reader token backlog). The writer [`acquire`](InFlightGate::acquire)s
+/// before feeding a batch to the aligner and the reader
+/// [`release`](InFlightGate::release)s when it consumes the matching
+/// token, so resident in-flight unmapped bytes stay near `budget`.
+///
+/// Deadlock-safety: the gate blocks the writer only while in-flight is at
+/// budget AND non-empty — a single oversized batch always passes when the
+/// gate is empty. Because the budget is sized `≥` a streaming aligner's
+/// `-K` buffering (see [`in_flight_budget_for_chunk_size`]), the aligner
+/// always has a full chunk to emit before the writer blocks, so the
+/// reader drains and the block lifts. If the reader exits (EOF or error),
+/// it latches `consumer_gone` so a blocked writer wakes and bails rather
+/// than hanging.
+struct InFlightGate {
+    budget: u64,
+    inner: std::sync::Mutex<GateInner>,
+    cond: std::sync::Condvar,
+}
+
+struct GateInner {
+    in_flight: u64,
+    consumer_gone: bool,
+}
+
+impl InFlightGate {
+    fn new(budget: u64) -> Self {
+        Self {
+            budget,
+            inner: std::sync::Mutex::new(GateInner { in_flight: 0, consumer_gone: false }),
+            cond: std::sync::Condvar::new(),
+        }
+    }
+
+    /// Reserve `n` in-flight bytes, blocking while the gate is full and
+    /// non-empty. Returns `false` if the consumer (reader) has gone — the
+    /// caller (writer) should then stop.
+    fn acquire(&self, n: u64) -> bool {
+        let mut g = self.inner.lock().expect("InFlightGate mutex poisoned");
+        // Block while non-empty AND this reservation would exceed budget.
+        // The `in_flight != 0` guard lets a single oversized batch through
+        // when the gate is empty (it can't be split, so holding it is
+        // unavoidable) — without it the writer would deadlock on a batch
+        // larger than the whole budget.
+        while !g.consumer_gone && g.in_flight != 0 && g.in_flight.saturating_add(n) > self.budget {
+            g = self.cond.wait(g).expect("InFlightGate mutex poisoned");
+        }
+        if g.consumer_gone {
+            return false;
+        }
+        g.in_flight = g.in_flight.saturating_add(n);
+        true
+    }
+
+    /// Release `n` in-flight bytes (reader consumed a token) and wake the
+    /// writer if it is blocked.
+    fn release(&self, n: u64) {
+        let mut g = self.inner.lock().expect("InFlightGate mutex poisoned");
+        g.in_flight = g.in_flight.saturating_sub(n);
+        drop(g);
+        self.cond.notify_all();
+    }
+
+    /// Latch that the consumer (reader) has exited, so a blocked writer
+    /// wakes and bails instead of hanging forever.
+    fn mark_consumer_gone(&self) {
+        let mut g = self.inner.lock().expect("InFlightGate mutex poisoned");
+        g.consumer_gone = true;
+        drop(g);
+        self.cond.notify_all();
+    }
+}
+
+/// RAII guard that latches consumer-gone on drop — on normal return, on an
+/// error return, AND on a panic unwinding out of `reader_loop`. Without the
+/// guard the panic path would skip `mark_consumer_gone`, leaving a writer
+/// parked in `gate.acquire` blocked forever and `Drop`'s `writer_thread.join()`
+/// hung with it.
+struct ConsumerGoneGuard<'a>(&'a InFlightGate);
+
+impl Drop for ConsumerGoneGuard<'_> {
+    fn drop(&mut self) {
+        self.0.mark_consumer_gone();
+    }
+}
+
+/// FASTQ-writer [`BufWriter`] capacity. 1 MiB matches the former
+/// hand-rolled orchestrator's choice: bigger than the OS pipe buffer
+/// (~64 KiB) so we amortize `write` syscalls, but not so large that we
+/// delay the aligner's first chunk perceptibly.
+const FASTQ_WRITER_BUF_BYTES: usize = 1 << 20;
+
+/// Stdout-side [`BufReader`] capacity for the aligner pipe. 64 KiB
+/// pairs with one OS pipe buffer's worth of pending bytes.
+const STDOUT_READER_BUF_BYTES: usize = 64 * 1024;
+
+/// Stable error-message fragment for the "aligner exited before
+/// emitting any bytes" branch in [`reader_loop_inner`]. Exposed so
+/// tests can assert on a token (not the full prose) that's
+/// guaranteed stable across rewordings of the user-facing message.
+pub(crate) const ERR_ALIGNER_EXITED_BEFORE_OUTPUT: &str = "exited before emitting any output";
+
+// ──────────────────────────────────────────────────────────────────────────
+// Configuration
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Immutable, Arc-friendly configuration shared by [`AlignAndMergeStep`].
+///
+/// One `Arc` clone of the inner is made per spawned thread; the cost is
+/// negligible compared to the data flowing through.
+#[derive(Clone)]
+pub struct AlignAndMergeConfig {
+    /// Tag-merge rules (remove / reverse / revcomp) plumbed to
+    /// `merge_raw`.
+    pub tag_info: Arc<TagInfo>,
+
+    /// Whether to skip TC (template-coordinate) tag handling. Mirrors
+    /// `ZipperMergeConfig::skip_tc_tags`.
+    pub skip_tc_tags: bool,
+
+    /// Optional reference reader used by
+    /// `restore_unconverted_bases_in_raw_template` (bisulfite path).
+    /// `None` for normal alignment.
+    pub reference: Option<Arc<ReferenceReader>>,
+
+    /// Partial output header built at construction time
+    /// (dict-derived `@SQ` + unmapped-derived
+    /// `@HD`/`@CO`/`@RG`/`@PG` + fgumi's own `@PG`). The reader
+    /// thread merges the aligner's emitted `@PG`/`@CO`/`@RG` lines
+    /// into this and resolves `header_handle`.
+    pub partial_output_header: Arc<Header>,
+
+    /// One-shot handle the reader thread resolves with the merged
+    /// header. The downstream `WriteBgzfFile` (constructed via
+    /// `new_with_handle`) polls this.
+    pub header_handle: HeaderHandle,
+
+    /// Counter for records emitted to downstream. Exposed back to the
+    /// caller after `Pipeline::run` returns so summary logging can
+    /// report a real throughput number.
+    pub records_emitted: Arc<AtomicU64>,
+
+    /// Byte limit for the **downstream** output queue
+    /// (`OrderedBytesSingle` `ByteBounded`) that AAM pushes merged
+    /// `BamTemplateBatch`es onto.
+    ///
+    /// AAM also has an *internal* `out_chan` (`SyncSender<ZipperBatch>`,
+    /// depth `OUT_CHAN_DEPTH = 2`) carrying the reader-to-`try_run`
+    /// hand-off. Because `ZipperBatch` carries both `mapped` and
+    /// `unmapped` halves (paired template Vecs), its per-item heap
+    /// is roughly **2×** the per-item heap of the old design's
+    /// `BamTemplateBatch` (which only carried merged templates).
+    /// Combined with `held_out` the worst-case in-flight footprint
+    /// is ≈ 3 × 2 × `batch_bytes`.
+    ///
+    /// For default 1000-template batches this is ~600 KB, negligible.
+    /// For production CODEC pipelines with multi-MB batches it can
+    /// approach ~1.5 GB additional in-flight; if memory is tight,
+    /// drop `OUT_CHAN_DEPTH` to 1 (one rebuild) — the reader
+    /// throughput cost is paid only when bwa stalls on stdout for
+    /// one batch worth of time, which is rare on production hardware.
+    /// This field gates the downstream queue, not the internal one.
+    pub output_byte_limit: u64,
+
+    /// Byte budget for AAM's **internal** in-flight unmapped reads (the
+    /// writer→reader token backlog). The writer blocks once in-flight
+    /// unmapped bytes reach this, bounding the otherwise-unbounded backlog
+    /// so a fast-draining aligner can't accumulate the whole input's
+    /// unmapped reads in RAM (issue #382). Derive it from the aligner's
+    /// `-K` chunk size via [`in_flight_budget_for_chunk_size`].
+    pub in_flight_unmapped_budget: u64,
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Internal types
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Metadata carried alongside an in-flight unmapped batch from the
+/// stdin-writer to the stdout-reader.
+///
+/// The writer pushes one `BatchToken` after writing all FASTQ records
+/// for an input batch. The reader pops one token, reads exactly
+/// `n_templates` templates from the aligner's stdout, and emits one
+/// `ZipperBatch { mapped, unmapped, serial }` for `try_run` to merge.
+struct BatchToken {
+    unmapped: BamTemplateBatch,
+    n_templates: usize,
+    /// Serial number assigned by the writer in push order. Carried
+    /// through into the `ZipperBatch` and ultimately the emitted
+    /// `BamTemplateBatch::batch_serial` so downstream's
+    /// `ByItemOrdinal` consumer sees a monotonic sequence.
+    serial: u64,
+}
+
+/// Reader-thread → `try_run` intermediate. Aligner-parsed but
+/// pre-merge templates paired with their original unmapped halves.
+/// Merging (`merge_raw` + optional bisulfite restore) happens later
+/// on whatever worker dispatches AAM; the reader stays I/O-bound.
+#[derive(Debug)]
+struct ZipperBatch {
+    serial: u64,
+    mapped: Vec<Template>,
+    unmapped: BamTemplateBatch,
+}
+
+impl HeapSize for ZipperBatch {
+    fn heap_size(&self) -> usize {
+        // Matches `BamTemplateBatch::total_bytes` semantics: sum of
+        // `Template::heap_size` only; no `Vec`-allocation overhead.
+        // `Template` carries only an inherent `heap_size` method (not
+        // a `HeapSize` trait impl) to keep `template.rs` framework-agnostic,
+        // so the sum is hand-rolled here.
+        let mapped_heap: usize = self.mapped.iter().map(Template::heap_size).sum();
+        mapped_heap + self.unmapped.heap_size()
+    }
+}
+
+impl Ordered for ZipperBatch {
+    fn ordinal(&self) -> u64 {
+        self.serial
+    }
+}
+
+/// Shared state visible to both threads and `try_run`. Used to
+/// surface a thread-local IO error to the dispatcher loop.
+///
+/// The error slot is set-once: the first thread to fail wins; later
+/// thread errors are dropped because they're likely cascading
+/// consequences of the first (e.g., closed pipe → writer error
+/// downstream of a crashed reader).
+struct SharedState {
+    error_slot: Mutex<Option<io::Error>>,
+}
+
+impl SharedState {
+    fn new() -> Self {
+        Self { error_slot: Mutex::new(None) }
+    }
+
+    /// Record an error if none has been recorded yet. First writer wins.
+    fn record_error(&self, err: io::Error) {
+        let mut guard = self.error_slot.lock();
+        if guard.is_none() {
+            *guard = Some(err);
+        }
+    }
+
+    /// Take any recorded error.
+    fn take_error(&self) -> Option<io::Error> {
+        self.error_slot.lock().take()
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Step
+// ──────────────────────────────────────────────────────────────────────────
+
+/// `Serial` Step that wraps an aligner subprocess + two internal
+/// threads + the inline `merge_raw` of tags from unmapped templates
+/// onto the aligned mapped templates.
+///
+/// See module doc for design rationale (including why `Serial`, not
+/// `Exclusive`).
+pub struct AlignAndMergeStep {
+    cfg: AlignAndMergeConfig,
+
+    /// Owned aligner subprocess. Taken out in `finalize` (or `Drop` on the
+    /// error path) for `wait()`.
+    aligner: Option<AlignerProcess>,
+
+    /// Sender side of `in_chan`. Dropped in `try_run`'s close-stdin phase to
+    /// signal EOF to the writer thread (which closes aligner stdin
+    /// in turn).
+    in_tx: Option<SyncSender<BamTemplateBatch>>,
+
+    /// Receiver side of `out_chan`. The reader thread sends raw
+    /// (pre-merge) `ZipperBatch`es here; `try_run` does the per-
+    /// template `merge_raw` + bisulfite restore, then pushes a
+    /// merged `BamTemplateBatch` to `ctx.outputs`.
+    out_rx: Option<Receiver<ZipperBatch>>,
+
+    writer_thread: Option<JoinHandle<io::Result<()>>>,
+    reader_thread: Option<JoinHandle<io::Result<()>>>,
+
+    shared: Arc<SharedState>,
+
+    /// Held slot for a batch that was popped from `ctx.input` but
+    /// couldn't be `try_send`'d to `in_chan` (writer thread is slow).
+    held_in: HeldSlot<BamTemplateBatch>,
+
+    /// Held slot for an `Unpushed<BamTemplateBatch>` we received from
+    /// the reader but couldn't `push` to `ctx.outputs` (downstream
+    /// backpressure).
+    held_out: HeldSlot<Unpushed<BamTemplateBatch>>,
+
+    name: &'static str,
+}
+
+impl AlignAndMergeStep {
+    /// Spawn the aligner subprocess + the two I/O threads and return
+    /// a ready-to-dispatch Step.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - the subprocess spawn fails,
+    /// - the aligner doesn't provide stdin/stdout pipes (should be
+    ///   impossible given `Stdio::piped()` is used by `AlignerProcess`),
+    /// - either I/O thread spawn fails.
+    pub fn new(cfg: AlignAndMergeConfig, aligner_command: &str) -> io::Result<Self> {
+        let mut aligner = AlignerProcess::spawn(aligner_command, ALIGNER_STDERR_RING_SIZE)
+            .map_err(|e| io::Error::other(format!("AlignAndMergeStep::new: spawn: {e:#}")))?;
+
+        let aligner_stdin = aligner
+            .take_stdin()
+            .ok_or_else(|| io::Error::other("aligner stdin pipe not available"))?;
+        let aligner_stdout = aligner
+            .take_stdout()
+            .ok_or_else(|| io::Error::other("aligner stdout pipe not available"))?;
+
+        let (in_tx, in_rx) = sync_channel::<BamTemplateBatch>(IN_CHAN_DEPTH);
+        // The `token_chan` itself stays unbounded: a bounded *channel*
+        // would deadlock the writer once full (writer blocks on
+        // `token_tx.send(...)`, never observes `in_rx` disconnection,
+        // never drops its BufWriter, the aligner never sees stdin EOF,
+        // never flushes). Instead the writer→reader unmapped backlog is
+        // bounded by *bytes* via `InFlightGate`: the writer reserves
+        // before feeding a batch and the reader releases when it consumes
+        // the token. The budget is sized ≥ the aligner's `-K` buffering,
+        // so a streaming aligner always emits before the writer blocks
+        // (transient block, not a deadlock); bwa's `-K`-bounded internal
+        // buffer + the OS pipe still provide the first line of throttling.
+        // This bound is what keeps a fast-draining (non-`-K`-throttling)
+        // aligner from accumulating the whole input's unmapped reads in
+        // RAM — issue #382.
+        let (token_tx, token_rx) = channel::<BatchToken>();
+        let (out_tx, out_rx) = sync_channel::<ZipperBatch>(OUT_CHAN_DEPTH);
+
+        let shared = Arc::new(SharedState::new());
+        let gate = Arc::new(InFlightGate::new(cfg.in_flight_unmapped_budget));
+
+        let writer_thread = {
+            let shared = Arc::clone(&shared);
+            let gate = Arc::clone(&gate);
+            thread::Builder::new()
+                .name("aam-fastq-writer".into())
+                .spawn(move || writer_loop(in_rx, token_tx, aligner_stdin, shared, &gate))
+                .map_err(|e| {
+                    io::Error::other(format!(
+                        "AlignAndMergeStep::new: failed to spawn writer thread: {e}"
+                    ))
+                })?
+        };
+
+        let reader_thread = {
+            let cfg = cfg.clone();
+            let shared = Arc::clone(&shared);
+            let gate = Arc::clone(&gate);
+            thread::Builder::new()
+                .name("aam-sam-reader".into())
+                .spawn(move || {
+                    // Latch consumer-gone on EVERY reader exit — normal return,
+                    // error, or a panic in `reader_loop` — via the RAII guard, so
+                    // a writer blocked in `gate.acquire` always wakes and bails
+                    // instead of hanging (and `Drop`'s `writer_thread.join()`
+                    // cannot deadlock on a panicked reader).
+                    let _consumer_gone = ConsumerGoneGuard(&gate);
+                    reader_loop(token_rx, out_tx, aligner_stdout, cfg, shared, &gate)
+                })
+                .map_err(|e| {
+                    io::Error::other(format!(
+                        "AlignAndMergeStep::new: failed to spawn reader thread: {e}"
+                    ))
+                })?
+        };
+
+        Ok(Self {
+            cfg,
+            aligner: Some(aligner),
+            in_tx: Some(in_tx),
+            out_rx: Some(out_rx),
+            writer_thread: Some(writer_thread),
+            reader_thread: Some(reader_thread),
+            shared,
+            held_in: HeldSlot::new(),
+            held_out: HeldSlot::new(),
+            name: "AlignAndMerge",
+        })
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Writer thread
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Drain `in_rx` to the aligner's stdin as interleaved FASTQ, pushing
+/// one [`BatchToken`] per batch to `token_tx` so the reader can pair
+/// alignments back by count.
+///
+/// Lifecycle:
+/// - When `in_rx` closes (sender dropped), flush + drop the
+///   [`BufWriter`] so the aligner sees stdin EOF. `token_tx` drops
+///   at the same time, signalling EOF to the reader after the last
+///   token is consumed.
+/// - On any IO error, record it in `shared.error_slot` and exit.
+///   Channels' drop closes them; reader / `try_run` notice via
+///   `Disconnected`.
+///
+/// The function intentionally owns its channel ends + `ChildStdin` so
+/// they all get dropped at return (closing the aligner's stdin pipe).
+#[allow(clippy::needless_pass_by_value)]
+fn writer_loop(
+    in_rx: Receiver<BamTemplateBatch>,
+    token_tx: Sender<BatchToken>,
+    aligner_stdin: std::process::ChildStdin,
+    shared: Arc<SharedState>,
+    gate: &InFlightGate,
+) -> io::Result<()> {
+    let mut writer = BufWriter::with_capacity(FASTQ_WRITER_BUF_BYTES, aligner_stdin);
+    let mut fastq_buffers = FastqRecordBuffers::with_capacity(512);
+    let mut next_serial: u64 = 0;
+
+    while let Ok(batch) = in_rx.recv() {
+        // Reserve this batch's unmapped bytes against the in-flight budget
+        // before feeding it to the aligner. Blocks (transiently) if the
+        // backlog is at budget; returns `false` only if the reader has
+        // exited, in which case we stop (the channel send below would also
+        // fail). Bounds the otherwise-unbounded token backlog (issue #382).
+        if !gate.acquire(batch.heap_size() as u64) {
+            return Ok(());
+        }
+        // Count only templates that contribute at least one record
+        // to the FASTQ stream. A template whose every record is
+        // filtered by `FASTQ_WRITER_EXCLUDE_FLAGS` produces zero
+        // aligner output; if we counted it, the reader would expect
+        // one more mapped template than the aligner emits and
+        // surface a misleading "aligner emitted fewer alignments"
+        // error. AAM's expected input is an unmapped BAM (from
+        // `fgumi extract`), which has no secondaries — a
+        // fully-filtered template here means the user passed a
+        // re-aligned BAM by mistake. Error out loudly with the
+        // queryname so the misconfiguration is obvious.
+        let mut n_templates = 0usize;
+        for template in batch.templates() {
+            let mut wrote_any = false;
+            for record in &template.records {
+                let flags = record.flags();
+                if (flags & FASTQ_WRITER_EXCLUDE_FLAGS) != 0 {
+                    continue;
+                }
+                if let Err(e) = write_fastq_record(
+                    &mut writer,
+                    record,
+                    flags,
+                    /* no_suffix */ true,
+                    &mut fastq_buffers,
+                    /* umi_header */ None,
+                ) {
+                    // Record + return the same full error message so
+                    // `finalize`'s join path and the shared
+                    // error_slot fallback path both see the same
+                    // text — no information loss either way. Same
+                    // pattern as the no-primary path below.
+                    let msg = format!(
+                        "align-and-merge writer: write_fastq_record for template '{name}': {e:#}",
+                        name = String::from_utf8_lossy(&template.name),
+                    );
+                    shared.record_error(io::Error::other(msg.clone()));
+                    return Err(io::Error::other(msg));
+                }
+                wrote_any = true;
+            }
+            if !wrote_any {
+                let msg = format!(
+                    "align-and-merge writer: template '{name}' has no primary records (all flagged \
+                     SECONDARY/SUPPLEMENTARY). align-and-merge expects unmapped BAM input — did \
+                     you pass a re-aligned BAM by mistake? Run `fgumi extract` first or pre-filter \
+                     the input.",
+                    name = String::from_utf8_lossy(&template.name),
+                );
+                shared.record_error(io::Error::other(msg.clone()));
+                return Err(io::Error::other(msg));
+            }
+            // KNOWN DIVERGENCE — resolve in the align-and-merge WIRING PR.
+            // This guard only rejects a template where EVERY record is filtered
+            // (no primary at all). A *partially* filtered template — e.g. a
+            // re-aligned BAM by mistake where one mate has a primary and the
+            // other is only SECONDARY/SUPPLEMENTARY — writes fewer FASTQ records
+            // than the unmapped template physically carries, and nothing
+            // downstream re-checks the per-template record count, so the reader
+            // pairs a short mapped template against the full unmapped one and
+            // merge_raw can mismerge. The queryname hard-check in the reader
+            // (see the pairing guard) already converts the common reorder case
+            // into a loud error, so this is a narrow residual edge — and it is
+            // unreachable on real input (`fgumi extract` output carries no
+            // secondaries). The correct fix compares *primaries written* against
+            // the unmapped template's expected mate count
+            // (`r1.is_some() + r2.is_some()`), NOT `records.len()` (which counts
+            // secondaries and would false-positive on the exact re-aligned-BAM
+            // shape the SECONDARY/SUPPLEMENTARY filter is designed to tolerate).
+            // Deferred so the wiring PR's byte-parity tests gate it.
+            n_templates += 1;
+        }
+
+        let token = BatchToken { unmapped: batch, n_templates, serial: next_serial };
+        next_serial = next_serial.wrapping_add(1);
+
+        // Send is bounded; block until the reader (or backpressure)
+        // makes room. If the reader has died, the channel disconnect
+        // surfaces here and we exit.
+        if token_tx.send(token).is_err() {
+            // Reader thread is gone — we cannot make progress.
+            // Don't record an error: the reader's own error (if any)
+            // is the root cause; we just shut down quietly.
+            return Ok(());
+        }
+    }
+
+    // in_rx closed → upstream is done. Flush + drop the writer to
+    // close the aligner's stdin → aligner flushes its output.
+    if let Err(e) = writer.flush() {
+        // Record and return the SAME detailed message so `finalize`'s join path
+        // and the error_slot fallback both see the actionable text (matching the
+        // write_fastq_record / no-primary paths above).
+        let msg = format!("align-and-merge writer: flush: {e}");
+        shared.record_error(io::Error::other(msg.clone()));
+        return Err(io::Error::other(msg));
+    }
+    drop(writer);
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Reader thread
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Parse the aligner's stdout, pair each emitted template with its
+/// corresponding unmapped via the token channel, and emit
+/// `ZipperBatch` to `out_tx`. Merging (`merge_raw` and any bisulfite
+/// restore) happens in `AlignAndMergeStep::try_run`, run by whatever
+/// worker the framework dispatches; the reader stays I/O-bound so
+/// bwa's stdout never stalls behind CPU-heavy merge work.
+///
+/// First action is to read the aligner's SAM/BAM header, merge with
+/// the partial header, and resolve `cfg.header_handle`. Once that
+/// resolves, the downstream writer can start.
+///
+/// Takes its channel ends + `ChildStdout` + config by value so they
+/// drop at return; the wrapping helper translates the `Result` into
+/// an error-slot + handle-poison action.
+#[allow(clippy::needless_pass_by_value)]
+fn reader_loop(
+    token_rx: Receiver<BatchToken>,
+    out_tx: SyncSender<ZipperBatch>,
+    aligner_stdout: ChildStdout,
+    cfg: AlignAndMergeConfig,
+    shared: Arc<SharedState>,
+    gate: &InFlightGate,
+) -> io::Result<()> {
+    let result = reader_loop_inner(token_rx, &out_tx, aligner_stdout, &cfg, gate);
+    match result {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            // Poison the HeaderHandle so the downstream writer's
+            // `try_get` resolves to Err instead of looping forever.
+            // It's harmless if the handle was already set (e.g.,
+            // error happened mid-record after header was emitted) —
+            // `poison` returns AlreadySetError, ignored.
+            let _ = cfg
+                .header_handle
+                .poison(io::Error::new(e.kind(), format!("align-and-merge reader: {e}")));
+            shared.record_error(io::Error::new(e.kind(), format!("align-and-merge reader: {e}")));
+            Err(e)
+        }
+    }
+}
+
+// Long but linear: the reader thread's body is a five-step
+// procedure (peek format → set up BAM reader → validate @SQ →
+// resolve HeaderHandle → process tokens) that fits naturally in
+// one function. Splitting it would require threading the BAM
+// reader through helper signatures whose generics are already
+// noisy enough (see `AlignerBamReader`).
+#[allow(clippy::needless_pass_by_value, clippy::too_many_lines)]
+fn reader_loop_inner(
+    token_rx: Receiver<BatchToken>,
+    out_tx: &SyncSender<ZipperBatch>,
+    aligner_stdout: ChildStdout,
+    cfg: &AlignAndMergeConfig,
+    gate: &InFlightGate,
+) -> io::Result<()> {
+    // 1. Peek 4 bytes to detect BGZF (BAM) vs SAM text. Returns the
+    //    peeked bytes prepended to a chained Read so we don't lose
+    //    the prefix.
+    let (is_bgzf, peek_filled, stdout) = peek_aligner_format(aligner_stdout)?;
+
+    if peek_filled == 0 {
+        // Aligner exited before emitting any output — usually an
+        // aligner crash or misconfiguration (wrong binary path,
+        // missing index files, segfault before reading FASTQ).
+        // Distinguished from "non-BGZF content" so the message
+        // doesn't misleadingly point at SAM/BAM format conversion.
+        let marker = ERR_ALIGNER_EXITED_BEFORE_OUTPUT;
+        return Err(io::Error::other(format!(
+            "AlignAndMergeStep: aligner {marker}. Likely causes: subprocess \
+             startup error (missing binary, missing index files), aligner \
+             argument error, or the aligner segfaulted before reading FASTQ. \
+             Check the aligner's stderr above for the specific failure."
+        )));
+    }
+
+    // 2. Set up the appropriate record source. BAM = BGZF →
+    //    noodles BAM reader → unwrap back into raw bytes reader.
+    //    SAM = text-mode noodles SAM reader. Both paths parse the
+    //    aligner-emitted header first; we feed it through the same
+    //    `@SQ` validation + merge + `HeaderHandle` resolution before
+    //    constructing the `TemplateStream` variant.
+    //
+    //    The noodles BAM reader does *not* read past the header
+    //    into the body, so `bam_reader.into_inner()` returns a BGZF
+    //    reader positioned at the first record. Same property
+    //    holds for the SAM reader.
+    let (mut template_stream, aligner_header) = if is_bgzf {
+        let buffered = BufReader::with_capacity(STDOUT_READER_BUF_BYTES, stdout);
+        let bgzf = noodles::bgzf::io::Reader::new(buffered);
+        let mut bam_reader = noodles::bam::io::Reader::from(bgzf);
+        let aligner_header = bam_reader
+            .read_header()
+            .map_err(|e| io::Error::other(format!("aligner BAM header: {e}")))?;
+        let bgzf = bam_reader.into_inner();
+        let stream =
+            TemplateStream::Bam(BamTemplateStream::new(fgumi_raw_bam::RawBamReader::new(bgzf)));
+        (stream, aligner_header)
+    } else {
+        let buffered = BufReader::with_capacity(STDOUT_READER_BUF_BYTES, stdout);
+        let mut sam_reader = noodles::sam::io::Reader::new(buffered);
+        let aligner_header = sam_reader
+            .read_header()
+            .map_err(|e| io::Error::other(format!("aligner SAM header: {e}")))?;
+        let header_arc = Arc::new(aligner_header.clone());
+        let stream = TemplateStream::Sam(SamTemplateStream::new(sam_reader, header_arc));
+        (stream, aligner_header)
+    };
+
+    // 3. Verify the aligner's `@SQ` table matches the partial
+    //    header's (which came from the reference dict). If they
+    //    don't, the aligner was built against a different FASTA
+    //    than the dict and the resulting BAM's `tid` integers
+    //    would silently point at the wrong contig. Catch it here
+    //    rather than emit a corrupt BAM.
+    validate_sq_consistency(&cfg.partial_output_header, &aligner_header)?;
+
+    // 4. Merge aligner header into the partial output header, then
+    //    resolve the HeaderHandle so the downstream writer can start.
+    //    `merge_aligner_header` is intentionally permissive: aligner
+    //    `@PG` / `@RG` / `@CO` lines are added; `@SQ` from the
+    //    aligner is discarded because the partial header already has
+    //    the dict-derived canonical reference list.
+    let merged = merge_aligner_header(&cfg.partial_output_header, &aligner_header);
+    // The handle should be unresolved at this point in production —
+    // AAM is the sole producer. A pre-set handle indicates either a
+    // test (where `from_header` was used) or a wiring bug. We log
+    // the latter case at warn level so it surfaces in CI / prod
+    // pipelines while letting tests proceed unchanged. The merged
+    // header is dropped in either case; the existing value wins.
+    if cfg.header_handle.set(merged).is_err() {
+        log::warn!(
+            "AlignAndMergeStep: HeaderHandle was already resolved before the aligner \
+             emitted its header — aligner @PG/@RG/@CO contributions will not appear \
+             in the output. This is expected in tests using HeaderHandle::from_header \
+             but indicates a wiring bug in production."
+        );
+    }
+
+    // 5. Process tokens. One token = one upstream batch. We read
+    //    exactly token.n_templates templates from the aligner output
+    //    for each token, via the `TemplateStream` iterator (which
+    //    encapsulates the scratch + peeked state).
+    while let Ok(token) = token_rx.recv() {
+        // The token's unmapped bytes have left the (bounded) token backlog;
+        // release them against the in-flight budget so a writer blocked in
+        // `gate.acquire` can resume. The bytes still live briefly in the
+        // `ZipperBatch` flowing through the depth-bounded `out_chan` +
+        // `held_out` + merge, which is separately bounded — so releasing
+        // here is what keeps the *unbounded* token backlog near budget.
+        gate.release(token.unmapped.heap_size() as u64);
+
+        if token.n_templates == 0 {
+            // Empty batch from upstream — write nothing FASTQ-side,
+            // so the aligner emits nothing for this token. Emit an
+            // empty `ZipperBatch` to keep ordinals contiguous so
+            // downstream `ByItemOrdinal` consumers don't stall.
+            // `GroupByQueryname` never emits empty batches in
+            // practice, but the framework's batch contract doesn't
+            // forbid them and emitting empty here is robust to
+            // future upstream changes.
+            let empty_unmapped = BamTemplateBatch::new(token.serial, Vec::new());
+            let zb =
+                ZipperBatch { serial: token.serial, mapped: Vec::new(), unmapped: empty_unmapped };
+            if out_tx.send(zb).is_err() {
+                return Ok(()); // downstream gone
+            }
+            continue;
+        }
+
+        let mut mapped_templates: Vec<Template> = Vec::with_capacity(token.n_templates);
+
+        for i in 0..token.n_templates {
+            let mapped = template_stream.next_template()?;
+
+            let mapped = mapped.ok_or_else(|| {
+                io::Error::other(format!(
+                    "align-and-merge reader: alignerstdout EOF after {emitted} of {expected} \
+                     templates in batch {serial} — aligner emitted fewer alignments \
+                     than input reads",
+                    emitted = i,
+                    expected = token.n_templates,
+                    serial = token.serial,
+                ))
+            })?;
+
+            // Verify the i-th aligner-emitted template really is the read we
+            // paired it with by position. Order preservation is an *external*
+            // contract (bwa-mem/bwa-mem3 with `-K` honor it), but
+            // `aligner_command` is a free-form user command, so a reordering
+            // aligner could keep the per-batch count while shuffling templates —
+            // silently merging one read's tags/UMI onto another's alignment.
+            // The compare is one byte-slice comparison per template (both names
+            // are already in hand), negligible against the per-record merge_raw
+            // it guards, so it stays on in release rather than as a debug_assert.
+            if token.unmapped.templates()[i].name != mapped.name {
+                return Err(io::Error::other(format!(
+                    "align-and-merge reader: queryname mismatch — unmapped[{i}]='{u}' but \
+                     mapped='{m}'; the aligner emitted templates out of input order (does the \
+                     aligner command preserve input order, e.g. bwa `-K`?)",
+                    u = String::from_utf8_lossy(&token.unmapped.templates()[i].name),
+                    m = String::from_utf8_lossy(&mapped.name),
+                )));
+            }
+
+            mapped_templates.push(mapped);
+        }
+
+        let zb = ZipperBatch {
+            serial: token.serial,
+            mapped: mapped_templates,
+            unmapped: token.unmapped,
+        };
+        if out_tx.send(zb).is_err() {
+            // Downstream gone — bail. The dispatcher will observe
+            // out_rx disconnected on its next try_run.
+            return Ok(());
+        }
+    }
+
+    // token_rx closed → writer is done. If TemplateStream has a
+    // peeked record still in flight, the aligner emitted at least
+    // one more template than the sum of n_templates across all
+    // tokens — fatal mismatch (input reads != output reads).
+    if template_stream.has_peeked() {
+        return Err(io::Error::other(
+            "align-and-merge reader: aligneremitted at least one more template than the sum of \
+             input batch sizes (residual record carried after final token)",
+        ));
+    }
+
+    // Probe for one more record past the final token. If the
+    // aligner emitted multiple extra templates this only detects
+    // the first; the count isn't useful for the error message, so
+    // we report "at least one" rather than a plural that would be
+    // wrong for exactly-one cases.
+    if template_stream.probe_trailing().map_err(|e| {
+        io::Error::other(format!("align-and-merge reader: probing trailing aligner output: {e}"))
+    })? {
+        return Err(io::Error::other(
+            "align-and-merge reader: aligneremitted at least one more record than the sum of \
+             input batch sizes (extra record at EOF)",
+        ));
+    }
+
+    Ok(())
+}
+
+/// Merge one `ZipperBatch` into a `BamTemplateBatch`. Per-template
+/// `merge_raw` plus optional bisulfite restore; folds record-count
+/// and heap-size accounting into the same single pass so the
+/// resulting `BamTemplateBatch` doesn't re-walk the templates to
+/// compute `total_bytes`.
+///
+/// **Single-threaded by construction.** This runs synchronously on
+/// whichever worker dispatches AAM (Serial); merge throughput is
+/// effectively single-core. If profiling reveals merge as a
+/// bottleneck (most likely on bisulfite workloads where
+/// `restore_unconverted_bases_in_raw_template` does meaningful
+/// per-record CPU), the right move is to extract a `Parallel`
+/// `MergeAligned` step that consumes `ZipperBatch` from a multi-
+/// consumer queue and emits `BamTemplateBatch`. The `ZipperBatch`
+/// intermediate is shaped for that promotion — no fixture/test
+/// refactor required at the call site. See
+/// `docs/design/aam-bridge-refactor.md` §8 (out-of-scope follow-ups).
+fn merge_zipper_batch(zb: ZipperBatch, cfg: &AlignAndMergeConfig) -> io::Result<BamTemplateBatch> {
+    let ZipperBatch { serial, mapped, unmapped } = zb;
+    // Release-safe guard (not a debug_assert): a violated length invariant would
+    // otherwise make the `zip` below silently truncate to the shorter side,
+    // dropping templates with no error. Fail loudly instead — mirroring
+    // `extract_batch`'s record-count guard. (A bare debug_assert would also
+    // shadow this Err path from CI's debug-build tests.)
+    if mapped.len() != unmapped.templates().len() {
+        return Err(io::Error::other(format!(
+            "align-and-merge: ZipperBatch invariant violated — {} mapped vs {} unmapped \
+             templates; refusing to zip mismatched halves",
+            mapped.len(),
+            unmapped.templates().len(),
+        )));
+    }
+
+    let mut merged: Vec<Template> = Vec::with_capacity(mapped.len());
+    let mut total_records: u64 = 0;
+    let mut total_bytes: usize = 0;
+    for (mut mapped_template, unmapped_template) in mapped.into_iter().zip(unmapped.templates()) {
+        merge_one_template(
+            unmapped_template,
+            &mut mapped_template,
+            &cfg.tag_info,
+            cfg.skip_tc_tags,
+            cfg.reference.as_deref(),
+            &cfg.partial_output_header,
+        )
+        .map_err(|e| io::Error::other(format!("align-and-merge: {e:#}")))?;
+
+        total_records += mapped_template.records.len() as u64;
+        total_bytes += mapped_template.heap_size();
+        merged.push(mapped_template);
+    }
+
+    cfg.records_emitted.fetch_add(total_records, Ordering::Relaxed);
+    Ok(BamTemplateBatch::from_parts(serial, merged, total_bytes))
+}
+
+/// Peek the leading bytes of `stdout` to classify the aligner's output
+/// format. Returns `(is_bgzf, peek_filled, chained_reader)` where:
+/// - `is_bgzf` is true iff the peeked prefix is a valid BGZF block
+///   header per the shared [`fgumi_bgzf::is_bgzf_header`] classifier,
+///   which validates the full header (magic + FEXTRA + the `BC`
+///   subfield), not just the 4 magic bytes — so a plain-gzip SAM stream
+///   is correctly NOT treated as BAM.
+/// - `peek_filled` is the number of bytes actually peeked
+///   (`0..=BGZF_HEADER_SIZE`). `0` means the aligner exited before
+///   producing any output, which the caller distinguishes from a
+///   "wrong format" condition for a clearer error message.
+/// - `chained_reader` re-emits the peeked bytes followed by the rest
+///   of the original stream — callers must drain the returned reader,
+///   not the original.
+///
+/// The return type is `Box<dyn Read + Send>` so the same boxed reader
+/// can feed both the BGZF (BAM) path and the SAM-text path without
+/// changing every downstream type signature.
+fn peek_aligner_format(mut stdout: ChildStdout) -> io::Result<(bool, usize, Box<dyn Read + Send>)> {
+    // Peek a full BGZF header's worth so the shared validator has enough bytes
+    // for a real verdict (a genuine BGZF header is exactly `BGZF_HEADER_SIZE`
+    // bytes). A shorter (or empty) prefix simply fails validation and falls to
+    // the SAM-text path; `peek_filled == 0` is handled specially upstream as
+    // "aligner exited before emitting any output".
+    let mut peek_buf = [0u8; fgumi_bgzf::BGZF_HEADER_SIZE];
+    let mut peek_filled = 0usize;
+    while peek_filled < peek_buf.len() {
+        match stdout.read(&mut peek_buf[peek_filled..]) {
+            Ok(0) => break, // aligner exited before filling the peek buffer
+            Ok(n) => peek_filled += n,
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+    let is_bgzf = fgumi_bgzf::is_bgzf_header(&peek_buf[..peek_filled]);
+    let prefix = std::io::Cursor::new(peek_buf[..peek_filled].to_vec());
+    let chained: Box<dyn Read + Send> = Box::new(prefix.chain(stdout));
+    Ok((is_bgzf, peek_filled, chained))
+}
+
+/// Concrete type of the BAM reader we use over the aligner's piped
+/// stdout. Defined to keep [`TemplateStream`]'s type signature
+/// manageable and to make the (single-threaded, pipe-friendly)
+/// BGZF stack explicit at this call site.
+type AlignerBamReader =
+    fgumi_raw_bam::RawBamReader<noodles::bgzf::io::Reader<BufReader<Box<dyn Read + Send>>>>;
+
+/// Concrete type of the SAM reader we use over the aligner's piped
+/// stdout when the peeked magic bytes show plain text (not BGZF).
+/// Same dyn-erasure boundary as `AlignerBamReader`.
+type AlignerSamReader = noodles::sam::io::Reader<BufReader<Box<dyn Read + Send>>>;
+
+/// Reads templates one at a time from the aligner's emitted output
+/// (BAM-on-pipe or SAM-text-on-pipe), groups records by queryname,
+/// and yields fully-assembled [`Template`]s.
+///
+/// Two variants for the two stdout formats the aligner can produce.
+/// They share the same `scratch` + `peeked` + `name_buf`
+/// state-machine shape — only the per-record read primitive differs:
+/// * BAM: `RawBamReader::read_record(&mut RawRecord)` — zero-copy
+///   into a reusable [`fgumi_raw_bam::RawRecord`] buffer.
+/// * SAM: `sam::io::Reader::read_record_buf(&Header, &mut RecordBuf)`
+///   followed by [`fgumi_raw_bam::encode_record_buf_to_raw`] to bring
+///   the record into the same `RawRecord` representation as BAM.
+///   The SAM path costs one `RecordBuf` → `RawRecord` encode per
+///   record (vs zero-copy on BAM); aligners emitting BAM are
+///   preferred for high-throughput workloads.
+///
+/// The prior caller-threaded `(scratch, peeked)` API is gone —
+/// centralising the state inside this enum makes the
+/// "forgot-to-thread-peeked-and-lost-a-record" footgun
+/// syntactically impossible.
+enum TemplateStream {
+    Bam(BamTemplateStream),
+    Sam(SamTemplateStream),
+}
+
+impl TemplateStream {
+    fn next_template(&mut self) -> io::Result<Option<Template>> {
+        match self {
+            Self::Bam(s) => s.next_template(),
+            Self::Sam(s) => s.next_template(),
+        }
+    }
+
+    /// `true` if the stream has a peeked record from a prior
+    /// `next_template` call — i.e., the aligner emitted at least
+    /// one record past the last consumed template boundary.
+    fn has_peeked(&self) -> bool {
+        match self {
+            Self::Bam(s) => s.peeked.is_some(),
+            Self::Sam(s) => s.peeked.is_some(),
+        }
+    }
+
+    /// Probe one more record from the underlying stream. Returns
+    /// `true` if a record was read (which counts as the aligner
+    /// having emitted extra records past the last token's
+    /// boundary). Caller is expected to have already checked
+    /// [`Self::has_peeked`]; this method does NOT take a peeked
+    /// record into account, only the underlying reader.
+    fn probe_trailing(&mut self) -> io::Result<bool> {
+        match self {
+            Self::Bam(s) => s.probe_trailing(),
+            Self::Sam(s) => s.probe_trailing(),
+        }
+    }
+}
+
+/// Group consecutive same-queryname records from `read` into one [`Template`].
+///
+/// Shared by [`BamTemplateStream`] and [`SamTemplateStream`]: only the
+/// per-record read primitive differs (zero-copy BAM read vs SAM decode+encode),
+/// so it is injected as the `read` closure. `peeked` carries the first record of
+/// the *next* template (read one past this template's boundary) across calls,
+/// and `name_buf` is a reusable queryname buffer. Returns `Ok(None)` at end of
+/// stream. Centralizing this here makes the "forgot to stash the peeked record
+/// and lost a template boundary" footgun impossible to reintroduce in only one
+/// of the two variants.
+fn assemble_next_template(
+    peeked: &mut Option<fgumi_raw_bam::RawRecord>,
+    name_buf: &mut Vec<u8>,
+    mut read: impl FnMut() -> io::Result<Option<fgumi_raw_bam::RawRecord>>,
+) -> io::Result<Option<Template>> {
+    let mut records: Vec<fgumi_raw_bam::RawRecord> = Vec::with_capacity(2);
+
+    if let Some(first) = peeked.take() {
+        records.push(first);
+    } else {
+        match read()? {
+            Some(r) => records.push(r),
+            None => return Ok(None),
+        }
+    }
+
+    name_buf.clear();
+    name_buf.extend_from_slice(records[0].read_name());
+
+    while let Some(r) = read()? {
+        if r.read_name() == name_buf.as_slice() {
+            records.push(r);
+        } else {
+            *peeked = Some(r);
+            break;
+        }
+    }
+
+    // Build the owned queryname only on the error path — the success path (every
+    // template but a malformed-record edge case) is the hot loop.
+    let template = Template::from_records(records).map_err(|e| {
+        io::Error::other(format!(
+            "Template::from_records for aligner-emitted queryname '{name}': {e}",
+            name = String::from_utf8_lossy(name_buf),
+        ))
+    })?;
+    Ok(Some(template))
+}
+
+struct BamTemplateStream {
+    reader: AlignerBamReader,
+    scratch: fgumi_raw_bam::RawRecord,
+    peeked: Option<fgumi_raw_bam::RawRecord>,
+    /// Reusable per-template name buffer. Re-cleared on each
+    /// `next_template` call; avoids ~one `Vec<u8>` allocation
+    /// per template (~40 bytes typical) on hot loops.
+    name_buf: Vec<u8>,
+}
+
+impl BamTemplateStream {
+    fn new(reader: AlignerBamReader) -> Self {
+        Self {
+            reader,
+            scratch: fgumi_raw_bam::RawRecord::new(),
+            peeked: None,
+            name_buf: Vec::with_capacity(64),
+        }
+    }
+
+    fn next_template(&mut self) -> io::Result<Option<Template>> {
+        // Disjoint field capture (Rust 2021+): the closure borrows
+        // `reader`/`scratch` while `peeked`/`name_buf` pass as sibling args, so
+        // there's no whole-`self` aliasing conflict. `scratch` is reused across
+        // reads, so we clone it out — a `RawRecord` free-list to avoid the clone
+        // is a deferred micro-opt (S5a1-007); at 10k–100k records/sec the clones
+        // are cheap.
+        assemble_next_template(&mut self.peeked, &mut self.name_buf, || {
+            let n = self.reader.read_record(&mut self.scratch)?;
+            Ok(if n == 0 { None } else { Some(self.scratch.clone()) })
+        })
+    }
+
+    fn probe_trailing(&mut self) -> io::Result<bool> {
+        let n = self.reader.read_record(&mut self.scratch)?;
+        Ok(n > 0)
+    }
+}
+
+struct SamTemplateStream {
+    reader: AlignerSamReader,
+    /// Aligner-emitted header; needed by
+    /// [`fgumi_raw_bam::encode_record_buf_to_raw`] per record.
+    /// Owned (not a reference) so the stream is self-contained and
+    /// the noodles SAM reader's `read_record_buf(&header, ...)` call
+    /// can borrow it freely on each iteration.
+    header: Arc<Header>,
+    /// Scratch [`RecordBuf`] reused across `read_record_buf` calls.
+    scratch: noodles::sam::alignment::RecordBuf,
+    /// First record of the next template, encoded to `RawRecord`.
+    /// Stashed when [`next_template`] reads past the current
+    /// template's last record.
+    peeked: Option<fgumi_raw_bam::RawRecord>,
+    name_buf: Vec<u8>,
+}
+
+impl SamTemplateStream {
+    fn new(reader: AlignerSamReader, header: Arc<Header>) -> Self {
+        Self {
+            reader,
+            header,
+            scratch: noodles::sam::alignment::RecordBuf::default(),
+            peeked: None,
+            name_buf: Vec::with_capacity(64),
+        }
+    }
+
+    /// Read one record-buf from the SAM stream and encode it into a
+    /// fresh `RawRecord`. Returns `Ok(None)` on EOF.
+    fn read_next_raw(&mut self) -> io::Result<Option<fgumi_raw_bam::RawRecord>> {
+        let n = self.reader.read_record_buf(&self.header, &mut self.scratch)?;
+        if n == 0 {
+            return Ok(None);
+        }
+        // RecordBuf → RawRecord. `encode_record_buf_to_raw` allocates
+        // a fresh output Vec per record (vs zero-copy on the BAM
+        // path). For SAM-emitting aligners this is the cost-of-doing
+        // business; aligners that can emit BAM avoid it entirely.
+        let raw = fgumi_raw_bam::encode_record_buf_to_raw(&self.scratch, &self.header)
+            .map_err(|e| io::Error::other(format!("encode_record_buf_to_raw: {e}")))?;
+        Ok(Some(raw))
+    }
+
+    fn next_template(&mut self) -> io::Result<Option<Template>> {
+        // Disjoint field capture (see BAM sibling): the closure borrows
+        // `reader`/`header`/`scratch` while `peeked`/`name_buf` pass as sibling
+        // args. The read primitive is inlined here rather than calling
+        // `read_next_raw` (which would borrow all of `self` and conflict with
+        // the `&mut self.peeked`/`&mut self.name_buf` args); `read_next_raw`
+        // remains as the primitive for `probe_trailing`.
+        assemble_next_template(&mut self.peeked, &mut self.name_buf, || {
+            let n = self.reader.read_record_buf(&self.header, &mut self.scratch)?;
+            if n == 0 {
+                Ok(None)
+            } else {
+                fgumi_raw_bam::encode_record_buf_to_raw(&self.scratch, &self.header)
+                    .map(Some)
+                    .map_err(|e| io::Error::other(format!("encode_record_buf_to_raw: {e}")))
+            }
+        })
+    }
+
+    fn probe_trailing(&mut self) -> io::Result<bool> {
+        Ok(self.read_next_raw()?.is_some())
+    }
+}
+
+/// Compare the aligner's emitted `@SQ` table to the partial output
+/// header's. The partial header's `@SQ` came from the reference dict
+/// at construction time; the aligner's `@SQ` comes from whatever
+/// FASTA the aligner was indexed against. If they don't match, the
+/// aligner's per-record `tid` integers index into a different
+/// `@SQ` ordering and the merged BAM would silently have corrupt
+/// reference IDs.
+///
+/// Comparison is name + length only (M5/UR/AS/SP are dict-specific
+/// fields the aligner doesn't propagate, so we don't require them).
+fn validate_sq_consistency(partial: &Header, aligner: &Header) -> io::Result<()> {
+    let partial_refs = partial.reference_sequences();
+    let aligner_refs = aligner.reference_sequences();
+
+    if partial_refs.len() != aligner_refs.len() {
+        return Err(io::Error::other(format!(
+            "align-and-merge: aligner @SQcount ({}) does not match reference dict @SQ count ({}). \
+             The aligner was indexed against a different FASTA than the supplied --ref. \
+             Re-index or fix the --ref path.",
+            aligner_refs.len(),
+            partial_refs.len(),
+        )));
+    }
+
+    for (idx, ((p_name, p_map), (a_name, a_map))) in
+        partial_refs.iter().zip(aligner_refs.iter()).enumerate()
+    {
+        if p_name != a_name {
+            return Err(io::Error::other(format!(
+                "align-and-merge: aligner @SQname mismatch at position {idx}: dict='{dict_name}' \
+                 aligner='{aln_name}'. The aligner was indexed against a different \
+                 FASTA than the supplied --ref.",
+                dict_name = String::from_utf8_lossy(p_name),
+                aln_name = String::from_utf8_lossy(a_name),
+            )));
+        }
+        if p_map.length() != a_map.length() {
+            return Err(io::Error::other(format!(
+                "align-and-merge: aligner @SQlength mismatch for '{name}': dict={dict_len} \
+                 aligner={aln_len}. The aligner was indexed against a different \
+                 FASTA than the supplied --ref.",
+                name = String::from_utf8_lossy(p_name),
+                dict_len = p_map.length(),
+                aln_len = a_map.length(),
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Merge aligner-emitted header lines into the partial output header.
+///
+/// The aligner contributes:
+/// - `@PG` lines (with bwa version, command line, etc.) — appended.
+///   On duplicate ID, the partial's existing PG wins (the aligner's
+///   PG with that ID is dropped). **Limitation:** this does not
+///   maintain the BAM spec's `@PG.PP` chain when the aligner adds
+///   its own PG to a chain that already has one with the same ID
+///   (rare in practice — bwa's PG ID is "bwa", which won't be in
+///   `fgumi extract`'s unmapped BAM output). Maintaining a proper
+///   PP chain requires constructing fresh IDs and threading the
+///   PP pointer; deferred to a follow-up commit if real-world data
+///   surfaces a collision.
+/// - `@RG` lines (if `-R` was passed to the aligner) — appended;
+///   partial's existing RG wins on duplicate ID.
+/// - `@CO` comment lines — concatenated (partial first, then
+///   aligner).
+///
+/// The aligner's `@SQ` lines are deliberately discarded:
+/// [`validate_sq_consistency`] runs first to ensure the two `@SQ`
+/// tables agree, after which the partial's (dict-derived) version
+/// is authoritative.
+fn merge_aligner_header(partial: &Header, aligner: &Header) -> Header {
+    use bstr::BString;
+
+    let mut builder = Header::builder();
+
+    if let Some(hd) = partial.header() {
+        builder = builder.set_header(hd.clone());
+    }
+
+    for (name, map) in partial.reference_sequences() {
+        builder = builder.add_reference_sequence(name.clone(), map.clone());
+    }
+
+    let mut rg_seen: std::collections::HashSet<BString> = std::collections::HashSet::new();
+    for (id, rg) in partial.read_groups() {
+        builder = builder.add_read_group(id.clone(), rg.clone());
+        rg_seen.insert(id.clone());
+    }
+    for (id, rg) in aligner.read_groups() {
+        if !rg_seen.contains(id) {
+            builder = builder.add_read_group(id.clone(), rg.clone());
+        }
+    }
+
+    let mut pg_seen: std::collections::HashSet<BString> = std::collections::HashSet::new();
+    for (id, pg) in partial.programs().as_ref() {
+        builder = builder.add_program(id.clone(), pg.clone());
+        pg_seen.insert(id.clone());
+    }
+    for (id, pg) in aligner.programs().as_ref() {
+        if !pg_seen.contains(id) {
+            builder = builder.add_program(id.clone(), pg.clone());
+        }
+    }
+
+    for c in partial.comments() {
+        builder = builder.add_comment(c.clone());
+    }
+    for c in aligner.comments() {
+        builder = builder.add_comment(c.clone());
+    }
+
+    builder.build()
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Step impl
+// ──────────────────────────────────────────────────────────────────────────
+
+impl Step for AlignAndMergeStep {
+    type Input = BamTemplateBatch;
+    type Outputs = OrderedBytesSingle<BamTemplateBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            // Serial — single-dispatcher-at-a-time is the real
+            // requirement (in_tx/out_rx/held_* are not Sync); the
+            // framework's mutex enforces it. `Exclusive` would pin
+            // dispatch to one worker, which lets any blocking call
+            // on that worker (e.g. another step's held-slot flush
+            // spin) starve AAM.
+            kind: StepKind::Serial,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.cfg.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // 1. Fast-fail on any async error from the threads.
+        if let Some(e) = self.shared.take_error() {
+            return Err(e);
+        }
+
+        // Already finalized (the threads were joined and `out_rx` taken on a
+        // prior pass). The shared `finished` latch normally stops other
+        // workers from re-dispatching a finished Serial step before this is
+        // reached, but guard defensively so a re-entry is an idempotent
+        // `Finished` rather than an `expect` panic.
+        if self.out_rx.is_none() {
+            return Ok(StepOutcome::Finished);
+        }
+
+        let mut did_work = false;
+        let outcome = |did_work: bool| {
+            if did_work { StepOutcome::Progress } else { StepOutcome::NoProgress }
+        };
+
+        // 2. Drain held output slot first. Backpressure cases below
+        //    return `NoProgress` (not `Contention`): `Contention` is
+        //    reserved by the framework (see `core/step.rs:10-12`) for
+        //    Serial-step mutex contention, not for full output
+        //    queues. Using the wrong variant skews dispatcher stats
+        //    and can change scheduling.
+        if let Some(unpushed) = self.held_out.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => did_work = true,
+                Err(again) => {
+                    self.held_out.put(again);
+                    return Ok(StepOutcome::NoProgress);
+                }
+            }
+        }
+
+        // 3. Pull `ZipperBatch`es from the reader, merge per-template,
+        //    push merged `BamTemplateBatch` to `ctx.outputs`. The loop exits
+        //    (without returning) on `Empty`/`Disconnected`. This is the
+        //    steady-state pump; it does NOT by itself guarantee `out_rx` is
+        //    empty at completion (the reader could buffer a final batch after
+        //    this loop's last `try_recv` saw `Empty`). The completion gate
+        //    below re-drains `out_rx` after observing `reader.is_finished()`
+        //    to close that window — see step 5.
+        {
+            let out_rx = self.out_rx.as_ref().expect("out_rx Some (checked above)");
+            // Loop exits on `Empty` (nothing right now) or `Disconnected`
+            // (reader done — if it errored, the slot is set and the next pass
+            // surfaces it). Either way the receiver is drained for this call.
+            while let Ok(zb) = out_rx.try_recv() {
+                let merged = merge_zipper_batch(zb, &self.cfg)?;
+                match ctx.outputs.push(merged) {
+                    Ok(()) => did_work = true,
+                    Err(unpushed) => {
+                        self.held_out.put(unpushed);
+                        return Ok(outcome(did_work));
+                    }
+                }
+            }
+        }
+
+        // 4. Ingest phase: while `in_tx` is open, feed the aligner. Held_out
+        //    has priority over held_in deliberately (see ZipperMergeStep
+        //    precedent): downstream backpressure must propagate upstream before
+        //    we accept more input, otherwise the internal in_chan grows
+        //    unbounded. The `in_tx` borrow is scoped to the feed so it ends
+        //    before 4c may `take()` it.
+        let mut close_stdin = false;
+        if let Some(in_tx) = self.in_tx.as_ref() {
+            let input_drained = ctx.input.is_drained();
+            // 4a. Drain held input slot.
+            if let Some(batch) = self.held_in.take() {
+                match in_tx.try_send(batch) {
+                    Ok(()) => did_work = true,
+                    Err(TrySendError::Full(b)) => {
+                        self.held_in.put(b);
+                        return Ok(outcome(did_work));
+                    }
+                    Err(TrySendError::Disconnected(_)) => {
+                        // Prefer the writer's own recorded error (the root cause)
+                        // over a generic disconnect message; the writer records
+                        // to `error_slot` before dropping its channel end, so a
+                        // disconnect here usually means it already failed for a
+                        // specific, actionable reason.
+                        return Err(self.shared.take_error().unwrap_or_else(|| {
+                            io::Error::other(
+                                "align-and-merge: writer thread is gone (channel disconnected)",
+                            )
+                        }));
+                    }
+                }
+            }
+            // 4b. Pump from ctx.input → in_chan until either side stalls.
+            loop {
+                let Some(batch) = ctx.input.pop() else {
+                    break;
+                };
+                match in_tx.try_send(batch) {
+                    Ok(()) => did_work = true,
+                    Err(TrySendError::Full(b)) => {
+                        self.held_in.put(b);
+                        return Ok(outcome(did_work));
+                    }
+                    Err(TrySendError::Disconnected(_)) => {
+                        // Prefer the writer's own recorded error (the root cause)
+                        // over a generic disconnect message; the writer records
+                        // to `error_slot` before dropping its channel end, so a
+                        // disconnect here usually means it already failed for a
+                        // specific, actionable reason.
+                        return Err(self.shared.take_error().unwrap_or_else(|| {
+                            io::Error::other(
+                                "align-and-merge: writer thread is gone (channel disconnected)",
+                            )
+                        }));
+                    }
+                }
+            }
+            // 4c-guard: ready to close once input is drained and `held_in` is
+            // flushed (closing earlier would lose the last input batch).
+            close_stdin = input_drained && !self.held_in.is_held();
+        }
+        if self.in_tx.is_some() {
+            // 4c. Close `in_tx` so the writer sees disconnect → aligner stdin
+            //     EOF → aligner flushes its remaining output. Re-dispatch then
+            //     enters the drain phase below to pump the aligner's tail.
+            if close_stdin {
+                drop(self.in_tx.take());
+                did_work = true;
+            }
+            return Ok(outcome(did_work));
+        }
+
+        // 5. Drain phase: `in_tx` is closed; the aligner is flushing its tail
+        //    through the reader. Reaching here means step 3 drained `out_rx`
+        //    empty this call. Complete only once the reader has also exited AND
+        //    nothing is held — then join the threads (which cannot block, since
+        //    the reader is finished and the receiver is drained), wait on the
+        //    subprocess, and surface errors.
+        let reader_finished = self.reader_thread.as_ref().is_none_or(JoinHandle::is_finished);
+        if !self.held_out.is_held() && reader_finished {
+            // The reader has exited, so it will send no more batches — but it
+            // may have buffered a final batch in `out_rx` in the window between
+            // step 3's last `try_recv` (which saw `Empty`) and `is_finished()`
+            // flipping true. A finished reader has dropped its `out_tx`, so
+            // drain `out_rx` to completion NOW (it yields any remaining batches
+            // then `Disconnected`) before joining — otherwise that final batch
+            // would be lost when `finalize` drops the receiver. If a merged
+            // batch can't be pushed, park it in `held_out` and re-dispatch.
+            {
+                let out_rx = self.out_rx.as_ref().expect("out_rx Some (checked above)");
+                while let Ok(zb) = out_rx.try_recv() {
+                    let merged = merge_zipper_batch(zb, &self.cfg)?;
+                    if let Err(unpushed) = ctx.outputs.push(merged) {
+                        self.held_out.put(unpushed);
+                        return Ok(StepOutcome::Progress);
+                    }
+                }
+            }
+            // out_rx fully drained, reader finished, held_out empty → done.
+            return self.finalize();
+        }
+        Ok(outcome(did_work))
+    }
+}
+
+impl AlignAndMergeStep {
+    /// Completion barrier, reached from `try_run` once the reader has exited,
+    /// `out_rx` is empty, and `held_out` is empty (so no aligner output can be
+    /// lost). Joins the writer + reader daemons, waits for the aligner
+    /// subprocess, and surfaces any error in the documented order
+    /// (aligner-exit → reader → writer → `error_slot` fallback). Returns
+    /// `StepOutcome::Finished`. The joins cannot deadlock here: the gate
+    /// guarantees the reader returned (so the bounded `out_chan` is closed) and
+    /// the writer has already seen `in_tx` disconnect.
+    fn finalize(&mut self) -> io::Result<StepOutcome> {
+        let writer_handle =
+            self.writer_thread.take().expect("writer_thread is Some until finalize");
+        let reader_handle =
+            self.reader_thread.take().expect("reader_thread is Some until finalize");
+        // Drop the receiver; the reader has already exited.
+        let _ = self.out_rx.take();
+
+        // Join threads. Both have exited by now — the writer when in_rx
+        // disconnected (we dropped in_tx), the reader when aligner stdout
+        // reached EOF (observed via `is_finished()` in the gate).
+        let writer_result = writer_handle.join();
+        let reader_result = reader_handle.join();
+
+        // Wait for the subprocess to exit. `AlignerProcess::wait` consumes it.
+        let aligner_result = self.aligner.take().expect("aligner is Some until finalize").wait();
+
+        // Surface errors. Order: aligner exit first because its stderr ring is
+        // the most actionable diagnostic in the common failure mode
+        // (aligner-crash). Reader / writer errors typically cascade from an
+        // aligner failure (broken pipes, mismatched template counts).
+        aligner_result
+            .map_err(|e| io::Error::other(format!("aligner subprocess failed: {e:#}")))?;
+
+        // Then reader: it observes aligner stdout, so its errors (header parse,
+        // mismatched template count, etc.) describe aligner output shape.
+        match reader_result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => return Err(e),
+            Err(_panic) => return Err(io::Error::other("align-and-merge reader thread panicked")),
+        }
+
+        // Writer last: its only failure mode (modulo pipe-broken from an
+        // aligner crash, already covered above) is a write_fastq_record bug.
+        match writer_result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => return Err(e),
+            Err(_panic) => return Err(io::Error::other("align-and-merge writer thread panicked")),
+        }
+
+        // Fallback: surface any error recorded in `shared.error_slot` that
+        // didn't come through a thread's `Result`. Both threads return Err
+        // when they record to the slot, so a non-empty slot here indicates a
+        // future bug — surface it loudly rather than swallow.
+        if let Some(e) = self.shared.take_error() {
+            return Err(e);
+        }
+
+        Ok(StepOutcome::Finished)
+    }
+}
+
+impl Drop for AlignAndMergeStep {
+    /// Best-effort resource cleanup for error paths that bypass the clean
+    /// `try_run` completion (`finalize`). The framework's `PipelineSignal`
+    /// records the first step error and other workers stop on their next loop
+    /// iteration; the step never reaches `finalize` when this happens, so the
+    /// threads/aligner are still live and must be torn down here.
+    ///
+    /// **This is also the cancel-response path.** When
+    /// `PipelineSignal::cancel` fires, workers exit at their next
+    /// loop iteration, `Pipeline::run` returns, the `AlignAndMergeStep`
+    /// `Arc` refcount hits zero, and `Drop` runs. `aligner.kill()`
+    /// here SIGKILLs bwa; its pipes close immediately so the reader
+    /// thread's stdout `read` unblocks within microseconds and the
+    /// daemon cascade completes. Total cancel latency is bounded by:
+    /// (one worker-loop iteration to observe `is_done`) + (longest
+    /// in-flight `try_run` wall — single-digit ms for AAM's merge
+    /// step) + (Drop+join, ≤ µs). Routing `is_done` through `try_run`
+    /// to kill earlier would shave ~ms but requires either a
+    /// framework change (`StepCtx` exposing `signal`) or threading
+    /// the signal through construction; not worth it for the
+    /// observable cancel response we ship today.
+    ///
+    /// Order is **disconnect-channels-then-kill-then-join** — the
+    /// opposite of the clean `finalize` path. Two distinct blocking points
+    /// have to be unblocked before we can join:
+    ///
+    /// * Reader blocked on `aligner_stdout.read(...)` → unblocked by
+    ///   killing the subprocess (closing its stdout fd).
+    /// * Reader blocked on `out_tx.send(...)` → unblocked by
+    ///   dropping `out_rx` (the receiver) so `send` returns
+    ///   `SendError`. This case arises when downstream stopped
+    ///   accepting batches before drain fired.
+    /// * Writer blocked on `in_rx.recv()` → unblocked by dropping
+    ///   `in_tx`.
+    /// * Writer blocked on `token_tx.send(...)` → unblocked by the
+    ///   reader exiting (drops its `token_rx`). The reader exiting
+    ///   is gated on the two cases above.
+    ///
+    /// Steps:
+    /// 1. Drop `in_tx` (unblocks writer's `recv`).
+    /// 2. Drop `out_rx` (unblocks reader's `send`).
+    /// 3. Kill + wait subprocess (unblocks reader's stdout `read`).
+    /// 4. Join both threads.
+    ///
+    /// All errors are silently ignored — we're already on a teardown
+    /// path with nowhere to surface them.
+    fn drop(&mut self) {
+        // Poison the header handle first. If the reader thread *panicked*
+        // before resolving the header (the panic unwinds past `reader_loop`'s
+        // `Err`-path poison, and the reader is a manual std::thread not covered
+        // by the framework's resume_unwind), the downstream WriteBgzfFile would
+        // otherwise block forever waiting on the handle. Poisoning here makes it
+        // fail with an error instead of hanging. Idempotent: if the header was
+        // already resolved on the normal path, `poison` returns `Err` (ignored).
+        let _ = self.cfg.header_handle.poison(io::Error::other(
+            "AlignAndMergeStep dropped before resolving the output header",
+        ));
+
+        drop(self.in_tx.take());
+        drop(self.out_rx.take());
+
+        if let Some(mut aligner) = self.aligner.take() {
+            // Bounded teardown: only issue the unbounded `wait()` once the child
+            // has actually been reaped. If `kill()` timed out (stuck child, e.g.
+            // uninterruptible I/O), calling `wait()` would block teardown
+            // forever — defeating the 1s kill deadline. In that case we skip
+            // `wait()` and let `AlignerProcess::Drop` (itself bounded) clean up.
+            if aligner.kill() {
+                let _ = aligner.wait();
+            }
+        }
+
+        if let Some(h) = self.writer_thread.take() {
+            let _ = h.join();
+        }
+        if let Some(h) = self.reader_thread.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_cfg() -> AlignAndMergeConfig {
+        AlignAndMergeConfig {
+            tag_info: Arc::new(TagInfo::new(vec![], vec![], vec![])),
+            skip_tc_tags: true,
+            reference: None,
+            partial_output_header: Arc::new(Header::default()),
+            header_handle: HeaderHandle::new(),
+            records_emitted: Arc::new(AtomicU64::new(0)),
+            output_byte_limit: 1024 * 1024,
+            in_flight_unmapped_budget: in_flight_budget_for_chunk_size(150_000_000),
+        }
+    }
+
+    #[test]
+    fn in_flight_budget_derivation() {
+        // Default -K (150M bases) → 4 × 150M × 3 = 1.8 GiB.
+        assert_eq!(in_flight_budget_for_chunk_size(150_000_000), 4 * 150_000_000 * 3);
+        // Small / zero -K floors at IN_FLIGHT_MIN_BUDGET.
+        assert_eq!(in_flight_budget_for_chunk_size(0), IN_FLIGHT_MIN_BUDGET);
+        assert_eq!(in_flight_budget_for_chunk_size(1_000_000), IN_FLIGHT_MIN_BUDGET);
+    }
+
+    #[test]
+    fn consumer_gone_latched_even_when_reader_scope_panics() {
+        // A panic unwinding out of the reader scope must still latch
+        // consumer-gone via `ConsumerGoneGuard`, so a writer parked in
+        // `acquire` bails (returns false) instead of blocking forever. Without
+        // the guard the panic would skip `mark_consumer_gone`, deadlocking the
+        // writer and the `writer_thread.join()` in `Drop`.
+        let gate = InFlightGate::new(1024);
+        assert!(gate.acquire(10), "acquire succeeds before the consumer is gone");
+
+        let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _consumer_gone = ConsumerGoneGuard(&gate);
+            panic!("simulated reader_loop panic");
+        }));
+        assert!(panicked.is_err(), "the panic must propagate out of the guarded scope");
+
+        // The guard's `Drop` latched consumer-gone during unwind, so a
+        // subsequent writer reservation bails instead of blocking.
+        assert!(!gate.acquire(10), "a writer must bail once the reader scope has panicked");
+    }
+
+    #[test]
+    fn in_flight_gate_oversized_single_batch_passes_when_empty() {
+        // A batch larger than the whole budget must still pass when the gate
+        // is empty — it can't be split, so holding it is unavoidable, and
+        // blocking would deadlock.
+        let gate = InFlightGate::new(100);
+        assert!(gate.acquire(1000), "oversized batch must pass when gate empty");
+    }
+
+    #[test]
+    fn in_flight_gate_blocks_until_release() {
+        use std::time::Duration;
+        let gate = Arc::new(InFlightGate::new(100));
+        assert!(gate.acquire(100), "first acquire fills the budget");
+
+        let g2 = Arc::clone(&gate);
+        let (tx, rx) = std::sync::mpsc::channel();
+        let h = std::thread::spawn(move || {
+            // in_flight is 100 (full, non-empty) → this blocks until release.
+            assert!(g2.acquire(50));
+            tx.send(()).unwrap();
+        });
+        // Still blocked.
+        assert!(
+            rx.recv_timeout(Duration::from_millis(150)).is_err(),
+            "second acquire must block while the gate is full"
+        );
+        gate.release(100);
+        rx.recv_timeout(Duration::from_secs(5)).expect("acquire must unblock after release");
+        h.join().unwrap();
+    }
+
+    #[test]
+    fn in_flight_gate_consumer_gone_unblocks_and_bails() {
+        use std::time::Duration;
+        let gate = Arc::new(InFlightGate::new(100));
+        assert!(gate.acquire(100), "fill the budget");
+
+        let g2 = Arc::clone(&gate);
+        let (tx, rx) = std::sync::mpsc::channel();
+        let h = std::thread::spawn(move || {
+            let ok = g2.acquire(50); // blocks (full) until consumer-gone
+            tx.send(ok).unwrap();
+        });
+        assert!(rx.recv_timeout(Duration::from_millis(150)).is_err(), "must be blocked");
+        gate.mark_consumer_gone();
+        let ok = rx.recv_timeout(Duration::from_secs(5)).expect("must wake on consumer-gone");
+        assert!(!ok, "acquire must return false once the consumer is gone");
+        h.join().unwrap();
+    }
+
+    /// `bash -c 'true'` is a stand-in for a subprocess that exits
+    /// cleanly. Lets us verify the spawn path doesn't panic and that
+    /// Drop tears down without leaking.
+    #[test]
+    fn spawn_with_trivial_command_does_not_panic() {
+        let cfg = make_test_cfg();
+        // The aligner exits before any FASTQ is written. The reader
+        // thread will fail to find BGZF magic at stdout EOF, which
+        // we expect — we just verify spawn + Drop.
+        // Spawn must succeed (the pipes are wired by `AlignerProcess`), and
+        // the returned step is dropped at end of scope, exercising the `Drop`
+        // teardown path. `true` exits immediately; the reader will later fail
+        // to find BGZF magic, which is fine — this test only covers spawn+Drop.
+        let step = AlignAndMergeStep::new(cfg, "true").expect("spawn true");
+        let _ = step;
+    }
+
+    #[test]
+    fn profile_advertises_serial_nonsticky_byordinal() {
+        // v2.2 refactor: AAM was `Exclusive`+`sticky` (which caused
+        // the worker-affinity hang); is now `Serial`+`!sticky` so any
+        // free worker can dispatch when an owner is stuck elsewhere.
+        // See docs/design/aam-bridge-refactor.md §0.
+        let cfg = make_test_cfg();
+        let step = AlignAndMergeStep::new(cfg, "cat").expect("spawn cat");
+        let p = step.profile();
+        assert_eq!(p.name, "AlignAndMerge");
+        assert_eq!(p.kind, StepKind::Serial);
+        assert!(!p.sticky, "post-v2.2: non-sticky so any free worker can dispatch");
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+        assert_eq!(p.output_queues.len(), 1);
+        // Don't strictly assert the exact QueueSpec variant to avoid
+        // brittle coupling to the framework's internal layout.
+    }
+
+    #[test]
+    fn drop_kills_long_running_subprocess() {
+        // Spawn a "sleep" subprocess; Drop should kill it within
+        // AlignerProcess::Drop's 1-second deadline.
+        let cfg = make_test_cfg();
+        let start = std::time::Instant::now();
+        {
+            let _step = AlignAndMergeStep::new(cfg, "sleep 60").expect("spawn sleep");
+        } // Drop runs here.
+        let elapsed = start.elapsed();
+        // AlignerProcess::kill waits up to 1s; thread joins should
+        // be near-instant once channels close. Generous bound.
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "Drop took {elapsed:?}; expected <5s — long-running subprocess not killed?"
+        );
+    }
+
+    #[test]
+    fn empty_stdout_poisons_header_handle() {
+        // When the subprocess emits nothing, the reader can't find BGZF
+        // magic, returns Err, and *poisons* the header handle rather than
+        // resolving it — so a downstream writer blocked on the handle fails
+        // instead of hanging. This test pins that poison behavior.
+        //
+        // (The happy path — handle resolved to Ok from a real header — is
+        // covered by `header_handle_resolves_to_ok_when_aligner_emits_valid_bam`
+        // / `..._emits_sam_text`; the more precise empty-stdout marker is
+        // pinned by `empty_stdout_surfaces_aligner_exited_before_emitting`.)
+        let cfg = make_test_cfg();
+        let handle = cfg.header_handle.clone();
+
+        // `true` exits immediately — no stdout. Reader sees empty
+        // stdout, peek finds 0 bytes, is_bgzf=false → Err →
+        // handle.poison.
+        let step = AlignAndMergeStep::new(cfg, "true").expect("spawn true");
+
+        // Drive the step a few times to let the reader thread run
+        // and propagate. The exact threading interleaving means we
+        // can't be deterministic — but we can give it a generous
+        // window.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while !handle.is_set() && std::time::Instant::now() < deadline {
+            thread::yield_now();
+            thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(handle.is_set(), "header handle was not resolved (set or poisoned) within 2s");
+        let result = handle.try_get().expect("set or poisoned");
+        // We expect Err (poisoned by reader's "requires BAM" error
+        // path when stdout is empty/non-BGZF).
+        assert!(result.is_err(), "expected handle to be poisoned on empty stdout");
+
+        // Subprocess + threads tear down at end-of-scope when
+        // `step` is dropped.
+        let _ = step;
+    }
+
+    /// Build a `RawRecord` for a single read. `flags` controls whether
+    /// the record is primary / secondary / supplementary. Used to
+    /// construct test fixtures for the writer-loop filter behavior.
+    fn make_record(qname: &[u8], flags: u16) -> fgumi_raw_bam::RawRecord {
+        let mut b = fgumi_raw_bam::SamBuilder::new();
+        b.read_name(qname).flags(flags).sequence(b"ACGT").qualities(b"IIII");
+        b.build()
+    }
+
+    /// Build a Template whose every record is filtered by
+    /// `FASTQ_WRITER_EXCLUDE_FLAGS`. AAM's writer should reject this
+    /// input loudly so the user sees the "expected unmapped input"
+    /// guidance rather than a misleading "aligner emitted fewer
+    /// alignments" downstream error.
+    fn make_all_secondary_template(qname: &[u8]) -> Template {
+        let rec1 = make_record(qname, fgumi_raw_bam::flags::SECONDARY);
+        let rec2 = make_record(qname, fgumi_raw_bam::flags::SUPPLEMENTARY);
+        Template::from_records(vec![rec1, rec2]).expect("template with secondary records")
+    }
+
+    /// Build a paired-end primary template (one R1 + one R2, both
+    /// primary alignments) — the shape `writer_loop` expects from a
+    /// realistic unmapped BAM (`fgumi extract` output).
+    fn make_paired_primary_template(qname: &[u8]) -> Template {
+        use fgumi_raw_bam::flags::{FIRST_SEGMENT, LAST_SEGMENT, PAIRED};
+        let r1 = make_record(qname, PAIRED | FIRST_SEGMENT);
+        let r2 = make_record(qname, PAIRED | LAST_SEGMENT);
+        Template::from_records(vec![r1, r2]).expect("paired primary template")
+    }
+
+    #[test]
+    fn writer_loop_errors_on_template_with_no_primary_records() {
+        use std::process::{Command, Stdio};
+        use std::sync::mpsc::sync_channel;
+
+        // `cat > /dev/null` consumes our FASTQ writes (if any) so we
+        // don't SIGPIPE. We expect zero FASTQ to actually be
+        // written before the writer errors out.
+        let mut cat = Command::new("cat")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn cat");
+        let cat_stdin = cat.stdin.take().expect("cat stdin");
+
+        let (in_tx, in_rx) = sync_channel::<BamTemplateBatch>(1);
+        // Unbounded token channel mirrors production (see comment at
+        // the `token_chan` construction site in `AlignAndMergeStep::new`).
+        let (token_tx, _token_rx) = channel::<BatchToken>();
+        let shared = Arc::new(SharedState::new());
+
+        let bad_template = make_all_secondary_template(b"secondary_only");
+        let batch = BamTemplateBatch::new(0, vec![bad_template]);
+        in_tx.send(batch).expect("send batch");
+        drop(in_tx);
+
+        // Non-engaging budget: this test has no reader to release the gate,
+        // so size it so the single batch never blocks (the gate's blocking
+        // behavior is covered by `in_flight_gate_*` unit tests).
+        let gate = InFlightGate::new(u64::MAX);
+        let result = writer_loop(in_rx, token_tx, cat_stdin, Arc::clone(&shared), &gate);
+
+        assert!(result.is_err(), "writer_loop should reject all-filtered template");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("no primary records") && msg.contains("secondary_only"),
+            "error should name the offending queryname: {msg}"
+        );
+
+        // Also surfaced into the shared error slot for try_run to
+        // observe on its next iteration.
+        let slot_err = shared.take_error().expect("error_slot populated");
+        assert!(slot_err.to_string().contains("no primary records"));
+
+        // `cat` self-exits once `writer_loop` drops its BufWriter
+        // (and the wrapped `ChildStdin`) at function return —
+        // closing the pipe makes `cat` see stdin EOF. The explicit
+        // kill+wait below is belt-and-braces in case `writer_loop`
+        // bailed before dropping (e.g. on an unexpected panic).
+        let _ = cat.kill();
+        let _ = cat.wait();
+    }
+
+    /// Regression for the AAM deadlock fixed in commit `069c265`.
+    ///
+    /// **Setup**: feed `writer_loop` more batches than the old
+    /// `IN_CHAN_DEPTH=2` token-channel bound would have allowed,
+    /// while keeping the reader side parked — `token_rx` is held
+    /// but never receives. With the old bounded `token_chan`, the
+    /// writer would block on its third `token_tx.send(...)` inside
+    /// the `while let Ok(batch) = in_rx.recv()` body and never
+    /// exit, causing `writer_loop` to hang here.
+    ///
+    /// **Invariant**: `token_chan` is unbounded; the writer must
+    /// drain `in_rx` regardless of whether anyone is recv'ing tokens.
+    /// The test runs `writer_loop` on a worker thread with a 30 s
+    /// join timeout — a regression that re-introduces the bound
+    /// shows up as a `join` timeout (test failure), not as silent
+    /// flakiness.
+    ///
+    /// `cat > /dev/null` plays the role of bwa: it absorbs the
+    /// FASTQ writes without emitting anything. With the unbounded
+    /// `token_chan` the writer pushes 16 tokens and then exits
+    /// cleanly when `in_tx` is dropped.
+    #[test]
+    fn writer_loop_does_not_deadlock_when_reader_does_not_drain_tokens() {
+        use std::process::{Command, Stdio};
+        use std::sync::mpsc::sync_channel;
+        use std::time::{Duration, Instant};
+
+        // `cat > /dev/null` consumes our FASTQ writes silently —
+        // standing in for an aligner that buffers stdin without
+        // emitting anything on stdout (the exact condition that
+        // triggered the production deadlock on bwa with
+        // `-K 150000000` and a small input).
+        let mut cat = Command::new("cat")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn cat");
+        let cat_stdin = cat.stdin.take().expect("cat stdin");
+
+        // Match production: in_chan small + bounded (mirrors
+        // `IN_CHAN_DEPTH = 2`); token channel unbounded.
+        // Pre-fix this would have deadlocked at batch 3; use 16 so a
+        // partial regression (e.g. someone bumping the bound to 8 or
+        // 16 without making it unbounded) is also caught.
+        let n_batches: usize = 16;
+        let (in_tx, in_rx) = sync_channel::<BamTemplateBatch>(2);
+        let (token_tx, token_rx) = channel::<BatchToken>();
+        let shared = Arc::new(SharedState::new());
+
+        // Drive the writer on a worker thread so the test can apply a
+        // join timeout — a deadlock surfaces as a timeout rather than
+        // hanging the test runner.
+        let shared_for_worker = Arc::clone(&shared);
+        // Non-engaging budget: this test deliberately never drains tokens, so
+        // size the in-flight gate so it can't block — the assertion under test
+        // is that `token_tx.send` (the unbounded channel) never blocks the
+        // writer, which the gate's byte bound must not change for in-flight
+        // below budget. The gate's blocking is covered by `in_flight_gate_*`.
+        let gate = Arc::new(InFlightGate::new(u64::MAX));
+        let gate_for_worker = Arc::clone(&gate);
+        let writer_handle = std::thread::Builder::new()
+            .name("writer-loop-deadlock-test".into())
+            .spawn(move || {
+                writer_loop(in_rx, token_tx, cat_stdin, shared_for_worker, &gate_for_worker)
+            })
+            .expect("spawn writer worker");
+
+        // Pump N batches of one paired template each from a separate
+        // producer thread. If the writer deadlocks on
+        // `token_tx.send` (the failure mode this test guards), the
+        // bounded `in_chan` (depth 2) will also fill up and block
+        // this producer — but the main test thread stays responsive
+        // and surfaces the timeout below. Pushing the sends in-line
+        // on the main thread would let the same `in_chan`-full
+        // condition wedge the test runner itself.
+        let producer_handle = std::thread::Builder::new()
+            .name("producer-deadlock-test".into())
+            .spawn(move || {
+                for i in 0..n_batches {
+                    let qname = format!("read_{i}").into_bytes();
+                    let template = make_paired_primary_template(&qname);
+                    let batch = BamTemplateBatch::new(i as u64, vec![template]);
+                    if in_tx.send(batch).is_err() {
+                        // writer dropped early — surface via join.
+                        return Err::<(), String>("in_rx closed before producer finished".into());
+                    }
+                }
+                // Closing `in_tx` flips `in_rx.recv()` to `Err` after
+                // the last buffered batch is consumed. The writer must
+                // observe that and exit; with the old bounded
+                // `token_chan`, the writer would be stuck on
+                // `token_tx.send` for batch 3+ and never get back to
+                // the `recv` site.
+                drop(in_tx);
+                Ok(())
+            })
+            .expect("spawn producer worker");
+
+        // Generous timeout: the test should complete in <1 s on a
+        // healthy system; 30 s leaves headroom for slow CI runners
+        // while still failing fast on a deadlock.
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            if writer_handle.is_finished() && producer_handle.is_finished() {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "writer_loop did not exit within 30s — likely a deadlock regression \
+                 (token_chan is bounded and reader isn't draining)"
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        producer_handle
+            .join()
+            .expect("producer thread did not panic")
+            .expect("producer did not finish");
+        let result = writer_handle.join().expect("writer thread did not panic");
+        result.expect("writer_loop returned Err — unexpected for valid input");
+
+        // All N tokens should have accumulated in the (unbounded)
+        // token channel — the writer pushed one token per batch
+        // without ever blocking.
+        let mut n_tokens = 0;
+        while token_rx.try_recv().is_ok() {
+            n_tokens += 1;
+        }
+        assert_eq!(
+            n_tokens, n_batches,
+            "expected {n_batches} tokens pushed into the unbounded channel"
+        );
+
+        // No error should have been recorded.
+        assert!(shared.take_error().is_none(), "writer_loop must not record an error");
+
+        let _ = cat.kill();
+        let _ = cat.wait();
+    }
+
+    fn make_sq_header(refs: &[(&str, usize)]) -> Header {
+        use noodles::sam::header::record::value::Map;
+        use noodles::sam::header::record::value::map::ReferenceSequence;
+        let mut b = Header::builder();
+        for (name, length) in refs {
+            let map: Map<ReferenceSequence> = Map::<ReferenceSequence>::new(
+                std::num::NonZeroUsize::new(*length).expect("nonzero ref length"),
+            );
+            b = b.add_reference_sequence(bstr::BString::from(*name), map);
+        }
+        b.build()
+    }
+
+    #[test]
+    fn validate_sq_consistency_accepts_matching_refs() {
+        let partial = make_sq_header(&[("chr1", 1000), ("chr2", 2000)]);
+        let aligner = make_sq_header(&[("chr1", 1000), ("chr2", 2000)]);
+        validate_sq_consistency(&partial, &aligner).expect("matching refs are ok");
+    }
+
+    #[test]
+    fn validate_sq_consistency_rejects_count_mismatch() {
+        let partial = make_sq_header(&[("chr1", 1000), ("chr2", 2000)]);
+        let aligner = make_sq_header(&[("chr1", 1000)]);
+        let err =
+            validate_sq_consistency(&partial, &aligner).expect_err("count mismatch must reject");
+        let msg = err.to_string();
+        assert!(msg.contains("@SQ count") && msg.contains("does not match"));
+    }
+
+    #[test]
+    fn validate_sq_consistency_rejects_length_mismatch() {
+        let partial = make_sq_header(&[("chr1", 1000)]);
+        let aligner = make_sq_header(&[("chr1", 999)]);
+        let err =
+            validate_sq_consistency(&partial, &aligner).expect_err("length mismatch must reject");
+        let msg = err.to_string();
+        assert!(msg.contains("length mismatch") && msg.contains("chr1"));
+    }
+
+    #[test]
+    fn validate_sq_consistency_rejects_name_mismatch() {
+        // Two refs so the position-index reporting can be exercised
+        // (round-1 had a format-args bug that put the dict name in
+        // the position slot; a single-ref test wouldn't have caught
+        // it).
+        let partial = make_sq_header(&[("chr1", 1000), ("chr2", 1000)]);
+        let aligner = make_sq_header(&[("chr1", 1000), ("chrZ", 1000)]);
+        let err =
+            validate_sq_consistency(&partial, &aligner).expect_err("name mismatch must reject");
+        let msg = err.to_string();
+        assert!(msg.contains("name mismatch"));
+        assert!(msg.contains("position 1"), "position index in message: {msg}");
+        assert!(msg.contains("dict='chr2'"), "dict name in message: {msg}");
+        assert!(msg.contains("aligner='chrZ'"), "aligner name in message: {msg}");
+    }
+
+    /// Build a minimal valid header-only BAM file at `path`. Used as
+    /// the output of a fake-aligner shell command so the reader can
+    /// exercise its real-BAM code path (header parse + `@SQ`
+    /// validation + handle resolve + EOF probe) without depending on
+    /// a real aligner.
+    fn write_minimal_header_only_bam(path: &std::path::Path) {
+        use fgumi_bgzf::{BGZF_EOF, InlineBgzfCompressor};
+        use std::fs::File;
+
+        let mut header_bytes = Vec::new();
+        fgumi_bam_io::write_bam_header(&mut header_bytes, &Header::default())
+            .expect("write_bam_header");
+        let mut hc = InlineBgzfCompressor::new(1);
+        hc.write_all(&header_bytes).expect("compress header");
+        hc.flush().expect("flush header");
+
+        let mut f = File::create(path).expect("create fixture");
+        hc.write_blocks_to(&mut f).expect("write compressed header blocks");
+        f.write_all(&BGZF_EOF).expect("write BGZF EOF");
+        f.flush().expect("flush fixture");
+    }
+
+    #[test]
+    fn header_handle_resolves_to_ok_when_aligner_emits_valid_bam() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let fixture = tmp.path().join("empty.bam");
+        write_minimal_header_only_bam(&fixture);
+
+        let cfg = make_test_cfg();
+        let handle = cfg.header_handle.clone();
+
+        // Fake-aligner: emit the pre-staged header-only BAM bytes
+        // and exit. The test never pushes FASTQ input, so the
+        // aligner doesn't need to consume stdin — `cat <file>`
+        // emits the file's bytes and exits when it's done. The
+        // writer thread sits in `in_rx.recv()` until the step is
+        // dropped at the end of the test.
+        let cmd = format!("cat {}", fixture.display());
+        let step = AlignAndMergeStep::new(cfg, &cmd).expect("spawn fake aligner");
+
+        // Wait up to 5s for the reader thread to parse the header
+        // and resolve the handle. The shell command takes a moment
+        // to start.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !handle.is_set() && std::time::Instant::now() < deadline {
+            thread::sleep(std::time::Duration::from_millis(20));
+        }
+        assert!(handle.is_set(), "handle not resolved within 5s");
+        let result = handle.try_get().expect("set");
+        assert!(result.is_ok(), "header should resolve to Ok, not poison: {:?}", result.err());
+
+        // Subprocess + threads tear down at end-of-scope when
+        // `step` is dropped.
+        let _ = step;
+    }
+
+    #[test]
+    fn empty_stdout_surfaces_aligner_exited_before_emitting() {
+        // Confirms the `peek_filled == 0` branch in
+        // `peek_aligner_format` produces the stable "exited before
+        // emitting" marker rather than going down the BAM or SAM
+        // reader paths (both of which would fail later with less
+        // actionable errors).
+        let cfg = make_test_cfg();
+        let handle = cfg.header_handle.clone();
+        let _step = AlignAndMergeStep::new(cfg, "true").expect("spawn true");
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while !handle.is_set() && std::time::Instant::now() < deadline {
+            thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(handle.is_set());
+        let err = handle.try_get().unwrap().expect_err("poisoned");
+        let msg = err.to_string();
+        assert!(
+            msg.contains(ERR_ALIGNER_EXITED_BEFORE_OUTPUT),
+            "expected zero-bytes error path, got: {msg}"
+        );
+    }
+
+    /// Build a minimal valid SAM-text fixture (header only) at `path`.
+    /// Used as the output of a fake-aligner shell command so the
+    /// reader can exercise the SAM-text code path through
+    /// `peek_aligner_format` → `SamTemplateStream`.
+    fn write_minimal_header_only_sam(path: &std::path::Path) {
+        use std::fs::File;
+        let mut f = File::create(path).expect("create sam fixture");
+        // Bare-minimum SAM header: one `@HD` line.
+        f.write_all(b"@HD\tVN:1.6\n").expect("write SAM header");
+        f.flush().expect("flush SAM fixture");
+    }
+
+    #[test]
+    fn header_handle_resolves_to_ok_when_aligner_emits_sam_text() {
+        // Companion to `..._when_aligner_emits_valid_bam` — same
+        // assertion but exercising the SAM-text branch through
+        // `peek_aligner_format` + `SamTemplateStream`.
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let fixture = tmp.path().join("empty.sam");
+        write_minimal_header_only_sam(&fixture);
+
+        let cfg = make_test_cfg();
+        let handle = cfg.header_handle.clone();
+
+        let cmd = format!("cat {}", fixture.display());
+        let _step = AlignAndMergeStep::new(cfg, &cmd).expect("spawn fake SAM aligner");
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !handle.is_set() && std::time::Instant::now() < deadline {
+            thread::sleep(std::time::Duration::from_millis(20));
+        }
+        assert!(handle.is_set(), "handle not resolved within 5s on SAM-text input");
+        let result = handle.try_get().expect("set");
+        assert!(result.is_ok(), "SAM-text header should resolve handle to Ok: {:?}", result.err(),);
+    }
+
+    /// `merge_aligner_header` must keep the *partial* header's `@PG` on a
+    /// duplicate ID (the aligner's PG with that ID is dropped, not merged)
+    /// while still appending aligner PGs whose IDs are unique to the
+    /// aligner. This pins the dedup behavior documented on the function.
+    #[test]
+    fn merge_aligner_header_keeps_partial_pg_on_duplicate_id() {
+        use bstr::BString;
+        use noodles::sam::header::record::value::Map;
+        use noodles::sam::header::record::value::map::Program;
+        use noodles::sam::header::record::value::map::program::tag as pg_tag;
+
+        // Helper: build a @PG map carrying a distinguishing PN field so we
+        // can tell the partial's PG apart from the aligner's.
+        let program_with_name = |name: &str| -> Map<Program> {
+            Map::<Program>::builder().insert(pg_tag::NAME, name).build().expect("valid @PG")
+        };
+
+        // Partial header: a "dup" PG (PN=partial) plus a partial-only PG.
+        let partial = Header::builder()
+            .add_program(BString::from("dup"), program_with_name("partial"))
+            .add_program(BString::from("onlypartial"), program_with_name("partial"))
+            .build();
+
+        // Aligner header: a "dup" PG (PN=aligner, must be dropped) plus a
+        // unique "bwa" PG (must be appended).
+        let aligner = Header::builder()
+            .add_program(BString::from("dup"), program_with_name("aligner"))
+            .add_program(BString::from("bwa"), program_with_name("aligner"))
+            .build();
+
+        let merged = merge_aligner_header(&partial, &aligner);
+        let programs = merged.programs();
+        let programs = programs.as_ref();
+
+        // Exactly three PGs survive: dup (partial's), onlypartial, bwa.
+        assert_eq!(programs.len(), 3, "expected dup + onlypartial + bwa");
+
+        // Read back the PN field for a given @PG ID.
+        let pn_of = |id: &str| -> Option<String> {
+            programs
+                .get(&BString::from(id))
+                .and_then(|pg| pg.other_fields().get(&pg_tag::NAME).map(ToString::to_string))
+        };
+
+        // The duplicate-ID PG is the PARTIAL's (PN=partial), not the
+        // aligner's — the aligner's same-ID PG was dropped.
+        assert_eq!(
+            pn_of("dup").as_deref(),
+            Some("partial"),
+            "duplicate @PG ID must retain the partial's PG, not the aligner's"
+        );
+        // The partial-only PG is preserved.
+        assert_eq!(pn_of("onlypartial").as_deref(), Some("partial"));
+        // The aligner-unique PG is appended.
+        assert_eq!(
+            pn_of("bwa").as_deref(),
+            Some("aligner"),
+            "aligner @PG with a non-duplicate ID must be appended"
+        );
+    }
+
+    /// Build a single-record `RawRecord` carrying one string tag.
+    fn make_record_with_string_tag(
+        qname: &[u8],
+        flags: u16,
+        tag: crate::sam::SamTag,
+        value: &[u8],
+    ) -> fgumi_raw_bam::RawRecord {
+        let mut b = fgumi_raw_bam::SamBuilder::new();
+        b.read_name(qname)
+            .flags(flags)
+            .sequence(b"ACGT")
+            .qualities(b"IIII")
+            .add_string_tag(tag, value);
+        b.build()
+    }
+
+    /// The shared queryname-grouping state machine (delegated to by both
+    /// `BamTemplateStream` and `SamTemplateStream`) must group consecutive
+    /// same-queryname records into one `Template` and stash the first record of
+    /// the *next* template across calls — the core reader contract that had no
+    /// record-level coverage. A mock `read` closure feeds canned records:
+    /// readA (R1+R2), then readB (single), then EOF.
+    #[test]
+    fn assemble_next_template_groups_consecutive_querynames() {
+        use fgumi_raw_bam::flags::{FIRST_SEGMENT, LAST_SEGMENT, PAIRED};
+        let recs = vec![
+            make_record(b"readA", PAIRED | FIRST_SEGMENT),
+            make_record(b"readA", PAIRED | LAST_SEGMENT),
+            make_record(b"readB", 0),
+        ];
+        let mut it = recs.into_iter();
+        let mut peeked: Option<fgumi_raw_bam::RawRecord> = None;
+        let mut name_buf: Vec<u8> = Vec::new();
+
+        let t1 = assemble_next_template(&mut peeked, &mut name_buf, || Ok(it.next()))
+            .expect("t1 ok")
+            .expect("t1 present");
+        assert_eq!(t1.name, b"readA");
+        assert_eq!(t1.read_count(), 2, "readA's R1+R2 group into one template");
+
+        let t2 = assemble_next_template(&mut peeked, &mut name_buf, || Ok(it.next()))
+            .expect("t2 ok")
+            .expect("t2 present");
+        assert_eq!(t2.name, b"readB");
+        assert_eq!(t2.read_count(), 1, "readB is a solo template");
+
+        assert!(
+            assemble_next_template(&mut peeked, &mut name_buf, || Ok(it.next()))
+                .expect("t3 ok")
+                .is_none(),
+            "stream is exhausted after the last template"
+        );
+    }
+
+    /// `merge_zipper_batch` transfers the unmapped half's tags onto the paired
+    /// mapped template, preserves the batch serial, and bumps `records_emitted`
+    /// by the emitted record count — the core merge contract, previously only
+    /// exercised through header-only fixtures.
+    #[test]
+    fn merge_zipper_batch_transfers_unmapped_tags_and_counts_records() {
+        let cfg = make_test_cfg();
+        // Unmapped half carries RX; the mapped half (aligner output) does not.
+        let unmapped_rec = make_record_with_string_tag(
+            b"readA",
+            fgumi_raw_bam::flags::UNMAPPED,
+            crate::sam::SamTag::RX,
+            b"ACGT",
+        );
+        let unmapped = Template::from_records(vec![unmapped_rec]).expect("unmapped template");
+        let mapped =
+            Template::from_records(vec![make_record(b"readA", 0)]).expect("mapped template");
+
+        let zb = ZipperBatch {
+            serial: 5,
+            mapped: vec![mapped],
+            unmapped: BamTemplateBatch::new(5, vec![unmapped]),
+        };
+        let out = merge_zipper_batch(zb, &cfg).expect("merge ok");
+
+        assert_eq!(out.ordinal(), 5, "batch serial is preserved through the merge");
+        assert_eq!(out.templates().len(), 1, "one merged template out");
+        assert_eq!(
+            cfg.records_emitted.load(Ordering::Relaxed),
+            1,
+            "records_emitted bumped by merged record count, not template count"
+        );
+        // The RX tag from the unmapped half must land on the merged mapped record.
+        let merged_rec = &out.templates()[0].records[0];
+        let aux = fgumi_raw_bam::fields::aux_data_slice(merged_rec);
+        assert_eq!(
+            fgumi_raw_bam::tags::find_string_tag(aux, crate::sam::SamTag::RX),
+            Some(&b"ACGT"[..]),
+            "the unmapped RX tag must transfer onto the correct mapped record"
+        );
+    }
+
+    /// A `ZipperBatch` whose mapped and unmapped halves differ in length is a
+    /// structural invariant violation: `merge_zipper_batch` must hard-error
+    /// (release-safe) rather than let `zip` silently truncate to the shorter
+    /// side and drop templates.
+    #[test]
+    fn merge_zipper_batch_errors_on_length_mismatch() {
+        let cfg = make_test_cfg();
+        let mapped = Template::from_records(vec![make_record(b"readA", 0)]).expect("mapped");
+        // One mapped template, zero unmapped -> lengths differ.
+        let zb = ZipperBatch {
+            serial: 0,
+            mapped: vec![mapped],
+            unmapped: BamTemplateBatch::new(0, Vec::new()),
+        };
+        let err =
+            merge_zipper_batch(zb, &cfg).expect_err("length mismatch must error, not truncate");
+        assert!(
+            err.to_string().contains("ZipperBatch invariant violated"),
+            "error must name the invariant: {err}"
+        );
+    }
+}

--- a/src/lib/pipeline/steps/align_and_merge.rs
+++ b/src/lib/pipeline/steps/align_and_merge.rs
@@ -51,7 +51,7 @@
 //! whichever worker dispatches AAM amortize merge across the same
 //! `OUT_CHAN_DEPTH` of in-flight batches.
 //!
-//! ## [`BatchToken`] / [`ZipperBatch`] protocol (index-based pairing)
+//! ## `BatchToken` / `ZipperBatch` protocol (index-based pairing)
 //!
 //! Pairing of unmapped templates with their alignments is **structural
 //! by index, not queryname**. The writer thread keeps a per-batch
@@ -244,8 +244,8 @@ pub fn in_flight_budget_for_chunk_size(chunk_size_bases: u64) -> u64 {
 /// than hanging.
 struct InFlightGate {
     budget: u64,
-    inner: std::sync::Mutex<GateInner>,
-    cond: std::sync::Condvar,
+    inner: Mutex<GateInner>,
+    cond: parking_lot::Condvar,
 }
 
 struct GateInner {
@@ -257,8 +257,8 @@ impl InFlightGate {
     fn new(budget: u64) -> Self {
         Self {
             budget,
-            inner: std::sync::Mutex::new(GateInner { in_flight: 0, consumer_gone: false }),
-            cond: std::sync::Condvar::new(),
+            inner: Mutex::new(GateInner { in_flight: 0, consumer_gone: false }),
+            cond: parking_lot::Condvar::new(),
         }
     }
 
@@ -266,14 +266,14 @@ impl InFlightGate {
     /// non-empty. Returns `false` if the consumer (reader) has gone — the
     /// caller (writer) should then stop.
     fn acquire(&self, n: u64) -> bool {
-        let mut g = self.inner.lock().expect("InFlightGate mutex poisoned");
+        let mut g = self.inner.lock();
         // Block while non-empty AND this reservation would exceed budget.
         // The `in_flight != 0` guard lets a single oversized batch through
         // when the gate is empty (it can't be split, so holding it is
         // unavoidable) — without it the writer would deadlock on a batch
         // larger than the whole budget.
         while !g.consumer_gone && g.in_flight != 0 && g.in_flight.saturating_add(n) > self.budget {
-            g = self.cond.wait(g).expect("InFlightGate mutex poisoned");
+            self.cond.wait(&mut g);
         }
         if g.consumer_gone {
             return false;
@@ -285,7 +285,7 @@ impl InFlightGate {
     /// Release `n` in-flight bytes (reader consumed a token) and wake the
     /// writer if it is blocked.
     fn release(&self, n: u64) {
-        let mut g = self.inner.lock().expect("InFlightGate mutex poisoned");
+        let mut g = self.inner.lock();
         g.in_flight = g.in_flight.saturating_sub(n);
         drop(g);
         self.cond.notify_all();
@@ -294,7 +294,7 @@ impl InFlightGate {
     /// Latch that the consumer (reader) has exited, so a blocked writer
     /// wakes and bails instead of hanging forever.
     fn mark_consumer_gone(&self) {
-        let mut g = self.inner.lock().expect("InFlightGate mutex poisoned");
+        let mut g = self.inner.lock();
         g.consumer_gone = true;
         drop(g);
         self.cond.notify_all();
@@ -624,7 +624,7 @@ impl AlignAndMergeStep {
 // ──────────────────────────────────────────────────────────────────────────
 
 /// Drain `in_rx` to the aligner's stdin as interleaved FASTQ, pushing
-/// one [`BatchToken`] per batch to `token_tx` so the reader can pair
+/// one `BatchToken` per batch to `token_tx` so the reader can pair
 /// alignments back by count.
 ///
 /// Lifecycle:
@@ -1272,10 +1272,10 @@ struct SamTemplateStream {
     /// the noodles SAM reader's `read_record_buf(&header, ...)` call
     /// can borrow it freely on each iteration.
     header: Arc<Header>,
-    /// Scratch [`RecordBuf`] reused across `read_record_buf` calls.
+    /// Scratch `RecordBuf` reused across `read_record_buf` calls.
     scratch: noodles::sam::alignment::RecordBuf,
     /// First record of the next template, encoded to `RawRecord`.
-    /// Stashed when [`next_template`] reads past the current
+    /// Stashed when `next_template` reads past the current
     /// template's last record.
     peeked: Option<fgumi_raw_bam::RawRecord>,
     name_buf: Vec<u8>,

--- a/src/lib/pipeline/steps/bgzf/decompress.rs
+++ b/src/lib/pipeline/steps/bgzf/decompress.rs
@@ -4,7 +4,7 @@
 
 use std::io;
 
-use fgumi_bgzf::reader::decompress_block_slice_into;
+use fgumi_bgzf::reader::decompress_block_slice_into_opts;
 use libdeflater::Decompressor;
 
 use crate::pipeline::core::Unpushed;
@@ -40,16 +40,32 @@ pub struct BgzfDecompress {
     output_scratch: Vec<u8>,
     held: HeldSlot<Unpushed<DecompressedBlock>>,
     output_byte_limit: u64,
+    /// Whether to verify each block's CRC32 against its footer. The BAM source
+    /// preamble threads the command's `--check-crc`/`--no-check-crc` policy (via
+    /// `BamIoOptions::effective_check_crc`) here so the chain reproduces the
+    /// non-chain path's CRC behavior; the decompressed-size check always runs.
+    verify_crc: bool,
 }
 
 impl BgzfDecompress {
+    /// Construct a decompressor that verifies CRC32 (the pre-existing default).
     #[must_use]
     pub fn new(output_byte_limit: u64) -> Self {
+        Self::new_with_crc(output_byte_limit, true)
+    }
+
+    /// Construct a decompressor with an explicit CRC-verification policy.
+    ///
+    /// The chain's BAM source preamble uses this to honor the command's
+    /// `--check-crc` / `--no-check-crc` policy, matching the non-chain path.
+    #[must_use]
+    pub fn new_with_crc(output_byte_limit: u64, verify_crc: bool) -> Self {
         Self {
             decompressor: Decompressor::new(),
             output_scratch: Vec::with_capacity(DECOMPRESS_SCRATCH_CAPACITY),
             held: HeldSlot::new(),
             output_byte_limit,
+            verify_crc,
         }
     }
 }
@@ -61,6 +77,7 @@ impl Clone for BgzfDecompress {
             output_scratch: Vec::with_capacity(DECOMPRESS_SCRATCH_CAPACITY),
             held: HeldSlot::new(),
             output_byte_limit: self.output_byte_limit,
+            verify_crc: self.verify_crc,
         }
     }
 }
@@ -111,10 +128,11 @@ impl Step for BgzfDecompress {
         // buffer goes into the emitted block; a fresh fixed-capacity
         // buffer takes its place). Single mimalloc size class keeps the
         // thread-local cache hot.
-        decompress_block_slice_into(
+        decompress_block_slice_into_opts(
             &block.bytes,
             &mut self.decompressor,
             &mut self.output_scratch,
+            self.verify_crc,
         )?;
         let bytes = std::mem::replace(
             &mut self.output_scratch,

--- a/src/lib/pipeline/steps/extract.rs
+++ b/src/lib/pipeline/steps/extract.rs
@@ -4,10 +4,10 @@
 //! [`BamTemplateBatch`] (N `Template`s) by:
 //!
 //! 1. Applying read structures to each `FastqRecord` in the template,
-//!    yielding a combined [`FastqSet`](crate::fastq::FastqSet).
-//! 2. Calling [`make_raw_records_from_fastq_set`] to produce
+//!    yielding a combined [`FastqSet`].
+//! 2. Calling `make_raw_records_from_fastq_set` to produce
 //!    `Vec<RawRecord>`.
-//! 3. Building a [`Template`](crate::template::Template) via
+//! 3. Building a [`Template`] via
 //!    [`Template::from_records`].
 //!
 //! The step is `Parallel` (closure-driven via [`ProcessOrdered`]) and
@@ -31,7 +31,7 @@ use crate::template::Template;
 ///
 /// Each input batch's `FastqTemplate`s are independently converted: read
 /// structures are applied, UMI/barcode tags are extracted via
-/// [`make_raw_records_from_fastq_set`], and the resulting `RawRecord`s are
+/// `make_raw_records_from_fastq_set`, and the resulting `RawRecord`s are
 /// assembled into `Template`s.
 ///
 /// The returned step preserves batch ordering (output ordinal ==
@@ -355,6 +355,35 @@ mod tests {
         let err = extract_batch(&read_structures, &opts, &emitted, &batch)
             .expect_err("record-count mismatch must return Err, not truncate");
         assert_eq!(err.kind(), io::ErrorKind::InvalidData, "mismatch must surface as InvalidData");
+        assert!(
+            err.to_string().contains("internal invariant violated"),
+            "error must be framed as an internal invariant: {err}"
+        );
+    }
+
+    #[test]
+    fn extract_batch_errors_on_record_surplus() {
+        // Mirror of the shortfall case: a template carrying MORE records than
+        // there are read structures. The guard rejects both directions, so a
+        // future rewrite to a one-sided check (`records.len() < structures.len()`)
+        // must fail here — the surplus direction is tested independently.
+        let read_structures = vec!["5T".parse::<ReadStructure>().unwrap(); 2];
+        let opts = default_extract_opts();
+        let emitted = AtomicU64::new(0);
+
+        let long_template = FastqTemplate {
+            name: b"read0".to_vec(),
+            records: vec![
+                fq_record("read0", "ACGTG"),
+                fq_record("read0", "ACGTG"),
+                fq_record("read0", "ACGTG"),
+            ],
+        };
+        let batch = FastqTemplateBatch::new(0, vec![long_template]);
+
+        let err = extract_batch(&read_structures, &opts, &emitted, &batch)
+            .expect_err("record-count surplus must return Err, not ignore the extra records");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData, "surplus must surface as InvalidData");
         assert!(
             err.to_string().contains("internal invariant violated"),
             "error must be framed as an internal invariant: {err}"

--- a/src/lib/pipeline/steps/extract.rs
+++ b/src/lib/pipeline/steps/extract.rs
@@ -1,0 +1,363 @@
+//! `ExtractStep` — parallel FASTQ-to-BAM conversion step.
+//!
+//! Transforms a [`FastqTemplateBatch`] (N `FastqTemplate`s) into a
+//! [`BamTemplateBatch`] (N `Template`s) by:
+//!
+//! 1. Applying read structures to each `FastqRecord` in the template,
+//!    yielding a combined [`FastqSet`](crate::fastq::FastqSet).
+//! 2. Calling [`make_raw_records_from_fastq_set`] to produce
+//!    `Vec<RawRecord>`.
+//! 3. Building a [`Template`](crate::template::Template) via
+//!    [`Template::from_records`].
+//!
+//! The step is `Parallel` (closure-driven via [`ProcessOrdered`]) and
+//! preserves batch ordering via `BamTemplateBatch::batch_serial`.
+
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::read_structure::ReadStructure;
+
+use crate::commands::extract::{ExtractOptions, make_raw_records_from_fastq_set};
+use crate::fastq::FastqSet;
+use crate::pipeline::steps::process::ProcessOrdered;
+use crate::pipeline::steps::source::zip_fastq::FastqTemplateBatch;
+use crate::pipeline::steps::types::BamTemplateBatch;
+use crate::template::Template;
+
+/// Build a `Parallel` step that converts [`FastqTemplateBatch`] into
+/// [`BamTemplateBatch`].
+///
+/// Each input batch's `FastqTemplate`s are independently converted: read
+/// structures are applied, UMI/barcode tags are extracted via
+/// [`make_raw_records_from_fastq_set`], and the resulting `RawRecord`s are
+/// assembled into `Template`s.
+///
+/// The returned step preserves batch ordering (output ordinal ==
+/// `batch_serial` from the input).
+///
+/// # Arguments
+///
+/// * `read_structures` — one per FASTQ input file, shared across workers.
+/// * `extract_opts` — tag-output and name-annotation options, shared across
+///   workers.
+/// * `records_emitted` — running counter incremented with the number of BAM
+///   records (reads) emitted per batch.
+/// * `output_byte_limit` — byte-bounded queue limit for the output branch.
+pub fn build_extract_step(
+    read_structures: Arc<Vec<ReadStructure>>,
+    extract_opts: Arc<ExtractOptions>,
+    records_emitted: Arc<AtomicU64>,
+    output_byte_limit: u64,
+) -> ProcessOrdered<
+    FastqTemplateBatch,
+    BamTemplateBatch,
+    impl Fn(FastqTemplateBatch) -> io::Result<BamTemplateBatch> + Send + Sync + 'static,
+> {
+    ProcessOrdered::new(
+        "ExtractStep",
+        output_byte_limit,
+        move |batch: FastqTemplateBatch| -> io::Result<BamTemplateBatch> {
+            extract_batch(&read_structures, &extract_opts, &records_emitted, &batch)
+        },
+    )
+}
+
+/// Convert one [`FastqTemplateBatch`] into a [`BamTemplateBatch`], applying read
+/// structures, extracting tags, and assembling `Template`s. This is the body of
+/// the [`build_extract_step`] closure, factored out so it can be unit-tested
+/// directly (the closure inside `ProcessOrdered` is otherwise unreachable).
+///
+/// `records_emitted` is incremented by the number of BAM records (reads)
+/// emitted — summed across templates, not the template count.
+///
+/// # Errors
+///
+/// Returns `io::ErrorKind::InvalidData` if a template's record count does not
+/// equal the read-structure count (an internal-invariant violation — see the
+/// per-template guard below), or if read-structure application / tag extraction
+/// / template assembly fails for any record.
+pub(crate) fn extract_batch(
+    read_structures: &[ReadStructure],
+    extract_opts: &ExtractOptions,
+    records_emitted: &AtomicU64,
+    batch: &FastqTemplateBatch,
+) -> io::Result<BamTemplateBatch> {
+    let serial = batch.batch_serial;
+    let mut templates = Vec::with_capacity(batch.templates.len());
+
+    for fq_template in &batch.templates {
+        // Convert each FastqRecord into a FastqSet via its read structure. The
+        // per-template record count must equal the read-structure count: this
+        // is an internal invariant enforced upstream (CLI parse validates
+        // `inputs.len() == read_structures.len()`, and the zipper rejects
+        // per-chunk stream desync), so a mismatch here indicates a pipeline
+        // logic regression, NOT malformed user input. Fail loud with a
+        // release-safe `Err` rather than letting the `.zip()` below silently
+        // truncate sequencing reads. This is deliberately NOT a `debug_assert!`:
+        // a debug-only assert both downgrades the abort to a panic AND shadows
+        // this branch from CI's debug-build tests, leaving the silent-truncation
+        // guard the comment warns about unexercised.
+        if fq_template.records.len() != read_structures.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "ExtractStep internal invariant violated in batch_serial {serial}: template \
+                     {:?} has {} record(s) but {} read structure(s) were provided; counts are \
+                     validated equal at CLI parse and enforced per-chunk by the zipper, so this \
+                     indicates a pipeline logic error, not malformed input",
+                    String::from_utf8_lossy(&fq_template.name),
+                    fq_template.records.len(),
+                    read_structures.len(),
+                ),
+            ));
+        }
+
+        let mut fastq_sets: Vec<FastqSet> = Vec::with_capacity(fq_template.records.len());
+        for (record, rs) in fq_template.records.iter().zip(read_structures.iter()) {
+            let fastq_set = FastqSet::from_record_with_structure(
+                record.name(),
+                record.sequence(),
+                record.quality(),
+                rs,
+                &[], // No skip reasons
+            )
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            fastq_sets.push(fastq_set);
+        }
+
+        let combined = FastqSet::combine_readsets(fastq_sets);
+
+        let raw_records = make_raw_records_from_fastq_set(&combined, extract_opts)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        let template = Template::from_records(raw_records)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        templates.push(template);
+    }
+
+    // Count emitted BAM records, not templates: each template carries one
+    // record per read (R1, R2, …), and the finalize hook reports "records
+    // emitted". Summing `templates.len()` would undercount on paired-end input.
+    let count: u64 = templates.iter().map(|t| t.read_count() as u64).sum();
+    records_emitted.fetch_add(count, Ordering::Relaxed);
+    Ok(BamTemplateBatch::new(serial, templates))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::extract::{ExtractOptions, QualityEncoding};
+    use crate::fastq::FastqSet;
+    use crate::sam::SamTag;
+    use fgumi_raw_bam::fields::RawRecordView;
+
+    /// Build a minimal `ExtractOptions` with standard quality encoding.
+    fn default_extract_opts() -> ExtractOptions {
+        ExtractOptions {
+            sample: "S1".to_string(),
+            library: "L1".to_string(),
+            platform: None,
+            platform_unit: None,
+            read_group_id: "A".to_string(),
+            comments: Vec::new(),
+            barcode: None,
+            platform_model: None,
+            sequencing_center: None,
+            predicted_insert_size: None,
+            description: None,
+            run_date: None,
+            quality_encoding: QualityEncoding::Standard,
+            store_umi_quals: false,
+            store_cell_quals: false,
+            single_tag: None,
+            annotate_read_names: false,
+            extract_umis_from_read_names: false,
+            store_sample_barcode_qualities: false,
+            async_reader: false,
+        }
+    }
+
+    #[test]
+    fn make_raw_records_single_end_template() {
+        // Construct a FastqSet for a single-end read with a +T read structure.
+        let rs = "10T".parse::<ReadStructure>().unwrap();
+        let fq_set =
+            FastqSet::from_record_with_structure(b"read1", b"ACGTACGTAC", b"IIIIIIIIII", &rs, &[])
+                .unwrap();
+
+        let opts = default_extract_opts();
+        let records = make_raw_records_from_fastq_set(&fq_set, &opts).unwrap();
+
+        assert_eq!(records.len(), 1, "single-end should produce one record");
+        let view = RawRecordView::new(&records[0]);
+        assert_eq!(view.read_name(), b"read1");
+        // Single-end: should NOT have PAIRED flag
+        assert_eq!(
+            view.flags() & fgumi_raw_bam::fields::flags::PAIRED,
+            0,
+            "single-end should not be paired"
+        );
+        // Should be UNMAPPED
+        assert_ne!(view.flags() & fgumi_raw_bam::fields::flags::UNMAPPED, 0, "should be unmapped");
+        // Verify the RG tag carries the read-group id value "A" (not just that
+        // the two bytes [R,G] appear somewhere in the aux blob).
+        let aux = fgumi_raw_bam::fields::aux_data_slice(&records[0]);
+        assert_eq!(
+            fgumi_raw_bam::tags::find_string_tag(aux, SamTag::RG),
+            Some(&b"A"[..]),
+            "RG must carry the read-group id 'A'"
+        );
+    }
+
+    #[test]
+    fn make_raw_records_paired_end_template() {
+        let rs = "5T".parse::<ReadStructure>().unwrap();
+        let fq_set1 =
+            FastqSet::from_record_with_structure(b"read1", b"ACGTG", b"IIIII", &rs, &[]).unwrap();
+        let fq_set2 =
+            FastqSet::from_record_with_structure(b"read1", b"TGCAA", b"IIIII", &rs, &[]).unwrap();
+
+        let combined = FastqSet::combine_readsets(vec![fq_set1, fq_set2]);
+        let opts = default_extract_opts();
+        let records = make_raw_records_from_fastq_set(&combined, &opts).unwrap();
+
+        assert_eq!(records.len(), 2, "paired-end should produce two records");
+
+        let v0 = RawRecordView::new(&records[0]);
+        let v1 = RawRecordView::new(&records[1]);
+
+        // Both should be PAIRED + UNMAPPED + MATE_UNMAPPED
+        for v in [&v0, &v1] {
+            assert_ne!(v.flags() & fgumi_raw_bam::fields::flags::PAIRED, 0);
+            assert_ne!(v.flags() & fgumi_raw_bam::fields::flags::UNMAPPED, 0);
+            assert_ne!(v.flags() & fgumi_raw_bam::fields::flags::MATE_UNMAPPED, 0);
+        }
+
+        // R1 = FIRST_SEGMENT, R2 = LAST_SEGMENT
+        assert_ne!(v0.flags() & fgumi_raw_bam::fields::flags::FIRST_SEGMENT, 0);
+        assert_ne!(v1.flags() & fgumi_raw_bam::fields::flags::LAST_SEGMENT, 0);
+    }
+
+    #[test]
+    fn make_raw_records_with_umi() {
+        // Read structure: 3M7T (3bp molecular barcode, 7bp template)
+        let rs = "3M7T".parse::<ReadStructure>().unwrap();
+        let fq_set =
+            FastqSet::from_record_with_structure(b"read1", b"AAACCCCCCC", b"IIIIIIIIII", &rs, &[])
+                .unwrap();
+
+        let opts = default_extract_opts();
+        let records = make_raw_records_from_fastq_set(&fq_set, &opts).unwrap();
+
+        assert_eq!(records.len(), 1);
+        // Verify the RX tag carries the 3bp UMI VALUE "AAA" (the leading 3M of
+        // the "3M7T" read structure), not merely that an RX tag is present.
+        let aux = fgumi_raw_bam::fields::aux_data_slice(&records[0]);
+        assert_eq!(
+            fgumi_raw_bam::tags::find_string_tag(aux, SamTag::RX),
+            Some(&b"AAA"[..]),
+            "RX must carry the UMI value 'AAA'"
+        );
+    }
+
+    #[test]
+    fn make_raw_records_builds_valid_template() {
+        // End-to-end: build RawRecords, then verify Template::from_records succeeds.
+        let rs = "5T".parse::<ReadStructure>().unwrap();
+        let fq_set1 =
+            FastqSet::from_record_with_structure(b"qname", b"ACGTG", b"IIIII", &rs, &[]).unwrap();
+        let fq_set2 =
+            FastqSet::from_record_with_structure(b"qname", b"TGCAA", b"IIIII", &rs, &[]).unwrap();
+
+        let combined = FastqSet::combine_readsets(vec![fq_set1, fq_set2]);
+        let opts = default_extract_opts();
+        let records = make_raw_records_from_fastq_set(&combined, &opts).unwrap();
+
+        let template = Template::from_records(records).unwrap();
+        assert_eq!(template.name, b"qname");
+        assert_eq!(template.read_count(), 2);
+        assert!(template.r1.is_some());
+        assert!(template.r2.is_some());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // S5a2-002: end-to-end coverage of the extract batch conversion, including
+    // the S5a2-001 record-count / read-structure mismatch hard-error.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    use crate::fastq_parse::FastqRecord;
+    use crate::grouper::FastqTemplate;
+    use crate::pipeline::core::item::Ordered;
+
+    /// Build a `FastqRecord` from a name/sequence (quality = all `I`).
+    fn fq_record(name: &str, seq: &str) -> FastqRecord {
+        let qual: String = std::iter::repeat_n('I', seq.len()).collect();
+        FastqRecord::from_slice(format!("@{name}\n{seq}\n+\n{qual}\n").as_bytes()).unwrap()
+    }
+
+    /// A paired-end `FastqTemplateBatch`: each template has two records (R1+R2).
+    fn paired_template_batch(batch_serial: u64, n_templates: usize) -> FastqTemplateBatch {
+        let templates = (0..n_templates)
+            .map(|i| FastqTemplate {
+                name: format!("read{i}").into_bytes(),
+                records: vec![
+                    fq_record(&format!("read{i}"), "ACGTG"),
+                    fq_record(&format!("read{i}"), "TGCAA"),
+                ],
+            })
+            .collect();
+        FastqTemplateBatch::new(batch_serial, templates)
+    }
+
+    /// `extract_batch` propagates the input `batch_serial` to the output and
+    /// bumps `records_emitted` by the number of BAM records (reads) emitted,
+    /// not the number of templates: 3 paired templates × 2 reads each = 6.
+    #[test]
+    fn extract_batch_propagates_serial_and_counts_records() {
+        let read_structures = vec!["5T".parse::<ReadStructure>().unwrap(); 2];
+        let opts = default_extract_opts();
+        let emitted = AtomicU64::new(0);
+
+        let batch = paired_template_batch(7, 3);
+        let out = extract_batch(&read_structures, &opts, &emitted, &batch).unwrap();
+
+        assert_eq!(out.ordinal(), 7, "output batch_serial must equal the input batch_serial");
+        assert_eq!(out.templates().len(), 3, "all templates converted");
+        let total_records: usize = out.templates().iter().map(Template::read_count).sum();
+        assert_eq!(total_records, 6, "3 paired templates yield 6 records");
+        assert_eq!(
+            emitted.load(Ordering::Relaxed),
+            6,
+            "records_emitted bumped by emitted record count, not template count"
+        );
+    }
+
+    /// A template whose record count differs from `read_structures.len()` is a
+    /// structural invariant violation: `extract_batch` must hard-error with
+    /// `InvalidData` rather than silently truncating reads via `zip`. (S5a2-001)
+    #[test]
+    fn extract_batch_errors_on_record_count_mismatch() {
+        // Two read structures but a template carrying only ONE record.
+        let read_structures = vec!["5T".parse::<ReadStructure>().unwrap(); 2];
+        let opts = default_extract_opts();
+        let emitted = AtomicU64::new(0);
+
+        let short_template =
+            FastqTemplate { name: b"read0".to_vec(), records: vec![fq_record("read0", "ACGTG")] };
+        let batch = FastqTemplateBatch::new(0, vec![short_template]);
+
+        // The mismatch must surface as a release-safe `Err(InvalidData)` in ALL
+        // build profiles (there is no `debug_assert` to panic first), so CI's
+        // debug build exercises exactly the silent-truncation guard the code
+        // comment warns about — not merely a debug-only panic.
+        let err = extract_batch(&read_structures, &opts, &emitted, &batch)
+            .expect_err("record-count mismatch must return Err, not truncate");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData, "mismatch must surface as InvalidData");
+        assert!(
+            err.to_string().contains("internal invariant violated"),
+            "error must be framed as an internal invariant: {err}"
+        );
+    }
+}

--- a/src/lib/pipeline/steps/mod.rs
+++ b/src/lib/pipeline/steps/mod.rs
@@ -18,24 +18,20 @@
 //! - `tuning.rs`                — per-chain byte/queue budgets
 //! - `types.rs`                 — flowing data types (`HeapSize` + `Ordered`)
 //!
-//! `extract.rs` and `align_and_merge` arrive in follow-up ports: `extract.rs`
-//! still needs `ExtractOptions` from the command-layer options refactor, and
-//! `align_and_merge` needs `crate::aligner`, neither of which has landed yet.
-//! (`correct/` had the same dependency on `CorrectOptions`; that arrived with
-//! the options projection, so it is ported here.)
+//! `extract.rs` and `align_and_merge.rs` land here with the chain builder
+//! (R2), which is their consumer: `extract.rs` needs `ExtractOptions` (ported
+//! alongside) and `align_and_merge.rs` needs `crate::aligner` (ported alongside).
 //!
-//! This module deliberately holds only what the chain builder actually
-//! constructs. Two steps that exist upstream are *not* ported here:
 //! `coalesce.rs` (a `CoalesceBytes` byte-batching step with no caller anywhere,
-//! upstream included) and `roundtrip.rs` (a whole-chain convenience whose only
-//! consumer is the `compare bam-roundtrip` command, so it travels with the
-//! command rewiring rather than with the steps).
+//! upstream included) is *not* ported — it would be dead code.
 
+pub mod align_and_merge;
 pub mod bgzf;
 pub mod boundaries;
 #[cfg(test)]
 mod chain_tests;
 pub mod correct;
+pub mod extract;
 pub mod group;
 pub mod parse;
 pub mod process;

--- a/src/lib/sam/mod.rs
+++ b/src/lib/sam/mod.rs
@@ -16,9 +16,10 @@ pub use fgumi_sam::SamTag;
 pub use fgumi_sam::{TC_TAG, TemplateCoordinateInfo};
 
 // Re-export top-level functions from fgumi-sam.
-// `is_sorted` stays public in fgumi-sam (published crate) but is no longer
-// re-exported here — nothing in the `fgumi` binary uses it directly, and
-// `check_sort` calls it internally within fgumi-sam.
+// `is_sorted` stays public in fgumi-sam (published crate) but is not
+// re-exported here — nothing in the `fgumi` binary uses it via `crate::sam`
+// (`commands::merge` calls `fgumi_sam::is_sorted` directly), and `check_sort`
+// calls it internally within fgumi-sam.
 pub use fgumi_sam::{
     buf_value_to_smallest_signed_int, check_sort, header_as_query_grouped, header_as_unsorted,
     is_query_grouped, is_template_coordinate_sorted, revcomp_buf_value, reverse_buf_value,

--- a/src/lib/umi/parallel_assigner.rs
+++ b/src/lib/umi/parallel_assigner.rs
@@ -44,6 +44,18 @@ impl MoleculeIdCounter {
         self.next.fetch_add(count, Ordering::SeqCst)
     }
 
+    /// Zero the block cursor so the next `rebase` restarts at id 0.
+    ///
+    /// Used by the parallel assigners' `UmiAssigner::reset` overrides: the
+    /// chain group/dedup loops reuse one assigner across position groups and
+    /// call `reset()` per group so each group emits local ids `0..k` (which the
+    /// downstream `distinct_mi_count` / `assign_mi_offsets` global rebase
+    /// depends on). Without this the cursor keeps advancing and successive
+    /// groups' ids are non-local, corrupting the MI numbering.
+    fn reset(&self) {
+        self.next.store(0, Ordering::SeqCst);
+    }
+
     /// Rebase locally-numbered (`0..k`) assignments onto a freshly reserved block.
     ///
     /// The block size is `max(local id) + 1` rather than `assignments.len()`,
@@ -583,6 +595,10 @@ impl ParallelIdentityAssigner {
 }
 
 impl UmiAssigner for ParallelIdentityAssigner {
+    fn reset(&self) {
+        self.counter.reset();
+    }
+
     fn assign(&self, raw_umis: &[Umi]) -> Vec<MoleculeId> {
         let mut assignments = self.assign_local(raw_umis);
         self.counter.rebase(&mut assignments);
@@ -710,6 +726,10 @@ impl ParallelEditAssigner {
 }
 
 impl UmiAssigner for ParallelEditAssigner {
+    fn reset(&self) {
+        self.counter.reset();
+    }
+
     fn assign(&self, raw_umis: &[Umi]) -> Vec<MoleculeId> {
         let mut assignments = self.assign_local(raw_umis);
         self.counter.rebase(&mut assignments);
@@ -878,6 +898,10 @@ impl ParallelAdjacencyAssigner {
 }
 
 impl UmiAssigner for ParallelAdjacencyAssigner {
+    fn reset(&self) {
+        self.counter.reset();
+    }
+
     fn assign(&self, raw_umis: &[Umi]) -> Vec<MoleculeId> {
         let mut assignments = self.assign_local(raw_umis);
         self.counter.rebase(&mut assignments);
@@ -1219,6 +1243,10 @@ impl ParallelPairedAssigner {
 }
 
 impl UmiAssigner for ParallelPairedAssigner {
+    fn reset(&self) {
+        self.counter.reset();
+    }
+
     fn assign(&self, raw_umis: &[Umi]) -> Vec<MoleculeId> {
         let mut assignments = self.assign_local(raw_umis);
         self.counter.rebase(&mut assignments);
@@ -1538,6 +1566,49 @@ mod tests {
         let umis: Vec<String> = vec!["ACGT".to_string()];
         let assignments = assigner.assign(&umis);
         assert_eq!(assignments.len(), 1);
+    }
+
+    // `reset()` must return a reused parallel assigner to its initial
+    // molecule-id numbering. The chain group/dedup loops reuse ONE assigner
+    // across position groups (the `--allow-unmapped` path builds a parallel
+    // `batch_assigner`) and call `reset()` per group, relying on each group
+    // emitting local ids `0..k` for `distinct_mi_count` / `assign_mi_offsets`.
+    // The trait's default `reset()` is a no-op, so a parallel assigner that
+    // holds a `MoleculeIdCounter` but forgets to override it would silently
+    // leave the counter accumulating and corrupt the per-group MI numbering.
+    // This pins that every parallel strategy resets its counter.
+    #[rstest]
+    #[case::identity(|| Box::new(ParallelIdentityAssigner::new(2)) as Box<dyn UmiAssigner>, &["AAAA", "AAAA", "CCCC"])]
+    #[case::edit(|| Box::new(ParallelEditAssigner::new(1, 2)) as Box<dyn UmiAssigner>, &["AAAA", "AAAT", "CCCC"])]
+    #[case::adjacency(
+        || Box::new(ParallelAdjacencyAssigner::new(1, 2)) as Box<dyn UmiAssigner>,
+        &["AAAA", "AAAT", "CCCC"]
+    )]
+    #[case::paired(
+        || Box::new(ParallelPairedAssigner::new(1, 2)) as Box<dyn UmiAssigner>,
+        &["ACT-ACT", "ACT-ACT", "TGA-TGA"]
+    )]
+    fn reset_restores_initial_molecule_numbering(
+        #[case] make: fn() -> Box<dyn UmiAssigner>,
+        #[case] umis: &[&str],
+    ) {
+        let assigner = make();
+        let umis: Vec<Umi> = umis.iter().map(|s| (*s).to_string()).collect();
+        let first = assigner.assign(&umis);
+        // Advance the block cursor with an extra batch (no reset here).
+        let _ = assigner.assign(&umis);
+        // Without reset, the reused assigner's ids drift past the first block —
+        // guards against a no-op `reset()` making the equality below pass
+        // trivially.
+        let reused = assigner.assign(&umis);
+        assert_ne!(reused, first, "reused parallel assign without reset must advance ids");
+        // reset() must restore the initial local numbering.
+        assigner.reset();
+        let after_reset = assigner.assign(&umis);
+        assert_eq!(
+            after_reset, first,
+            "reset() must restore local `0..k` molecule numbering for the parallel assigner"
+        );
     }
 
     // fgbio's GroupReadsByUmi throws on UMIs of differing length; every parallel

--- a/tests/integration/helpers/bam_generator.rs
+++ b/tests/integration/helpers/bam_generator.rs
@@ -265,6 +265,39 @@ pub fn create_umi_family(
     create_family_with_tags(&[(SamTag::RX, umi.as_bytes())], depth, base_name, sequence, quality)
 }
 
+/// Like [`create_umi_family`] but places every read at `pos` (1-based reference
+/// position) instead of the fixed default, so callers can build inputs that span
+/// many distinct positions — hence many position groups and, past the pipeline's
+/// template-batch size, multiple batches.
+pub fn create_umi_family_at_pos(
+    umi: &str,
+    depth: usize,
+    base_name: &str,
+    sequence: &str,
+    quality: u8,
+    pos: usize,
+) -> Vec<RawRecord> {
+    let seq = sequence.as_bytes();
+    let cigar_op = u32::try_from(seq.len()).expect("seq.len() fits u32") << 4; // M
+    let pos = i32::try_from(pos).expect("pos fits i32");
+    (0..depth)
+        .map(|i| {
+            let name = format!("{base_name}_{i}");
+            let mut b = SamBuilder::new();
+            b.read_name(name.as_bytes())
+                .ref_id(0)
+                .pos(pos)
+                .mapq(60)
+                .flags(0)
+                .cigar_ops(&[cigar_op])
+                .sequence(seq)
+                .qualities(&vec![quality; seq.len()]);
+            b.add_string_tag(SamTag::RX, umi.as_bytes());
+            b.build()
+        })
+        .collect()
+}
+
 /// Like [`create_umi_family`] but tags each read with an arbitrary `SamTag`
 /// (e.g. `SamTag::RX` for UMI mode or `SamTag::BC` for barcode mode).
 pub fn create_family_with_tag(
@@ -484,6 +517,16 @@ pub fn create_minimal_header(ref_name: &str, ref_len: usize) -> Header {
 /// Configured SAM Header with SO:coordinate sort order
 pub fn create_coordinate_sorted_header(ref_name: &str, ref_len: usize) -> Header {
     build_header_with_tags(ref_name, ref_len, &[(*b"SO", "coordinate")])
+}
+
+/// Creates a query-grouped (but not template-coordinate) SAM header:
+/// `SO:unsorted, GO:query`, without `SS:template-coordinate`.
+///
+/// `is_query_grouped` holds (GO:query) but `is_template_coordinate_sorted` does
+/// not (no `SS`), so `group` classifies this as `QueryGroupedUnmapped` and
+/// accepts it only under `--allow-unmapped`.
+pub fn create_query_grouped_header(ref_name: &str, ref_len: usize) -> Header {
+    build_header_with_tags(ref_name, ref_len, &[(*b"SO", "unsorted"), (*b"GO", "query")])
 }
 
 /// Creates a UMI family with intentional sequencing errors.

--- a/tests/integration/test_group_command.rs
+++ b/tests/integration/test_group_command.rs
@@ -9,12 +9,16 @@ use fgumi_lib::commands::group::GroupReadsByUmi;
 use fgumi_lib::metrics::UmiGroupingMetrics;
 use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
+use rstest::rstest;
 use std::fs;
 use std::path::PathBuf;
 use tempfile::TempDir;
 
 use crate::helpers::assertions::assert_bam_sorted;
-use crate::helpers::bam_generator::{create_minimal_header, create_umi_family, to_record_buf};
+use crate::helpers::bam_generator::{
+    create_minimal_header, create_query_grouped_header, create_umi_family,
+    create_umi_family_at_pos, to_record_buf,
+};
 
 /// Test that the group command properly writes metrics in the new format.
 #[test]
@@ -267,20 +271,21 @@ fn group_args<'a>(input: &'a str, output: &'a str, extra: &[&'a str]) -> Vec<&'a
 fn test_group_no_check_crc_accepts_corrupted_crc() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let input_bam = temp_dir.path().join("input.bam");
-    let output_bam = temp_dir.path().join("output.bam");
-
     create_multiblock_group_bam(&input_bam);
-    corrupt_last_block_crc(&input_bam);
+    // Baseline: group the intact file to pin the expected records.
+    let baseline = run_group_records(temp_dir.path(), "baseline", &input_bam, &[]);
+    assert!(!baseline.is_empty(), "baseline run must produce grouped records");
 
-    let cmd = GroupReadsByUmi::try_parse_from(group_args(
-        input_bam.to_str().unwrap(),
-        output_bam.to_str().unwrap(),
-        &["--no-check-crc"],
-    ))
-    .expect("failed to parse group args");
-    cmd.execute("fgumi group")
-        .expect("--no-check-crc must accept a corrupted BGZF CRC32 and complete");
-    assert!(output_bam.exists(), "Output BAM not created");
+    // Corrupt only the last block's CRC32 footer, then re-group with
+    // --no-check-crc: it must accept the file AND produce records identical to
+    // the intact run (a bit-flipped CRC footer leaves the payload intact, so a
+    // correct skip-CRC decode is byte-for-byte identical — not merely non-empty).
+    corrupt_last_block_crc(&input_bam);
+    let accepted = run_group_records(temp_dir.path(), "nocrc", &input_bam, &["--no-check-crc"]);
+    assert_eq!(
+        baseline, accepted,
+        "--no-check-crc must accept the corrupted CRC and yield records identical to the intact run",
+    );
 }
 
 /// Default (verify-on for file input) must reject the same corrupted CRC32.
@@ -326,4 +331,274 @@ fn test_group_check_crc_rejects_corrupted_crc() {
         cmd.execute("fgumi group").expect_err("--check-crc must reject a corrupted BGZF CRC32");
     let message = format!("{err:#}");
     assert!(message.to_uppercase().contains("CRC32"), "error should mention CRC32: {message}");
+}
+
+// ============================================================================
+// Chain-backed `--threads N` path: parity with the single-threaded fast path
+// (the `group` pilot rewire). The `--threads` path now runs on the declarative
+// chain builder; these tests pin the behaviors the single-threaded oracle
+// cannot see: the chain's CRC policy and its record-ordering acceptance, plus
+// cross-mode output parity.
+// ============================================================================
+
+/// Read the complete `RecordBuf` for every output record, in output order,
+/// asserting an `MI:Z` tag is present on each.
+///
+/// Positional `Vec` equality across two runs catches both re-ordering and any
+/// per-record difference (MI re-numbering, dropped/added records).
+fn read_group_records(path: &std::path::Path) -> Vec<noodles::sam::alignment::RecordBuf> {
+    use noodles::sam::alignment::record_buf::data::field::Value;
+    let mut reader = bam::io::Reader::new(fs::File::open(path).expect("open output bam"));
+    let header = reader.read_header().expect("read output header");
+    let mi = fgumi_lib::sam::SamTag::MI.to_noodles_tag();
+    reader
+        .record_bufs(&header)
+        .map(|r| {
+            let r = r.expect("read output record");
+            // Group must assign an MI:Z to every accepted output record; assert
+            // that invariant here, then return the COMPLETE record so the parity
+            // checks compare every BAM field, not only QNAME/flags/MI (a field
+            // that changed outside those three would otherwise slip through).
+            let qname = r.name().expect("output record has a name").to_string();
+            match r.data().get(&mi) {
+                Some(Value::String(_)) => {}
+                other => panic!("expected MI:Z string on output record {qname}, got {other:?}"),
+            }
+            r
+        })
+        .collect()
+}
+
+/// Run `group` on `input`, returning the output records. `extra` is appended to
+/// the base argv (e.g. `["--threads", "1"]`, `["--allow-unmapped"]`).
+fn run_group_records(
+    dir: &std::path::Path,
+    tag: &str,
+    input: &std::path::Path,
+    extra: &[&str],
+) -> Vec<noodles::sam::alignment::RecordBuf> {
+    let output = dir.join(format!("{tag}.bam"));
+    let cmd = GroupReadsByUmi::try_parse_from(group_args(
+        input.to_str().unwrap(),
+        output.to_str().unwrap(),
+        extra,
+    ))
+    .expect("failed to parse group args");
+    cmd.execute("fgumi group").unwrap_or_else(|e| panic!("group ({tag}) failed: {e:#}"));
+    read_group_records(&output)
+}
+
+/// The chain-backed `--threads N` path must honor the same CRC-verification
+/// policy as the single-threaded fast path — the plumbing that threads
+/// `effective_check_crc()` into the chain's BGZF decode. Before that plumbing
+/// the chain hardcoded verify-on, so `--no-check-crc --threads N` would have
+/// wrongly rejected a corrupted-CRC file. The single-threaded CRC tests above
+/// cannot see this path.
+#[rstest]
+#[case::no_check_crc_accepts(&["--no-check-crc"], true)]
+#[case::default_rejects(&[], false)]
+#[case::check_crc_rejects(&["--check-crc"], false)]
+fn test_group_threaded_crc_policy(#[case] extra: &[&str], #[case] expect_ok: bool) {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    create_multiblock_group_bam(&input_bam);
+    // Baseline: group the intact file through the same chain (--threads 1) so the
+    // accept case can assert record identity, not merely non-emptiness — a chain-path
+    // regression could silently drop the corrupted last block's records yet still
+    // write a non-empty file.
+    let baseline = expect_ok
+        .then(|| run_group_records(temp_dir.path(), "baseline", &input_bam, &["--threads", "1"]));
+    corrupt_last_block_crc(&input_bam);
+
+    let mut args = extra.to_vec();
+    args.extend_from_slice(&["--threads", "1"]);
+    let cmd = GroupReadsByUmi::try_parse_from(group_args(
+        input_bam.to_str().unwrap(),
+        output_bam.to_str().unwrap(),
+        &args,
+    ))
+    .expect("failed to parse group args");
+    let result = cmd.execute("fgumi group");
+
+    if expect_ok {
+        result.expect("--no-check-crc --threads must accept a corrupted BGZF CRC32 and complete");
+        let records = read_group_records(&output_bam);
+        assert_eq!(
+            baseline.expect("baseline is captured for the accept case"),
+            records,
+            "--no-check-crc --threads must accept the corrupted CRC and yield records \
+             identical to the intact run, not merely a non-empty file",
+        );
+    } else {
+        let err = result.expect_err("chain path must reject a corrupted BGZF CRC32");
+        let message = format!("{err:#}");
+        assert!(message.to_uppercase().contains("CRC32"), "error should mention CRC32: {message}");
+    }
+}
+
+/// The chain-backed `--threads 1` output must match the single-threaded fast
+/// path record-for-record on a normal template-coordinate input. This is the
+/// cross-mode parity oracle the within-mode determinism tests cannot provide.
+#[test]
+fn test_group_chain_matches_single_threaded() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    create_test_input_bam(&input_bam);
+
+    let single = run_group_records(temp_dir.path(), "single", &input_bam, &[]);
+    let chained = run_group_records(temp_dir.path(), "chained", &input_bam, &["--threads", "1"]);
+
+    assert!(
+        !single.is_empty(),
+        "sanity: expected grouped records so the parity check is not vacuous"
+    );
+    assert_eq!(
+        single, chained,
+        "chain (--threads 1) output must match the single-threaded fast path record-for-record",
+    );
+}
+
+/// A query-grouped (GO:query, not template-coordinate) input under
+/// `--allow-unmapped` must be accepted by the chain and produce output
+/// identical to the single-threaded path. The chain builder previously required
+/// `SO:queryname` and would have rejected this input; sharing the classifier
+/// (`require_group_input_ordering`) fixed that.
+#[test]
+fn test_group_allow_unmapped_query_grouped_chain_parity() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+
+    // Query-grouped (GO:query) input, not template-coordinate sorted.
+    let header = create_query_grouped_header("chr1", 10000);
+    let mut writer =
+        bam::io::Writer::new(fs::File::create(&input_bam).expect("Failed to create BAM file"));
+    writer.write_header(&header).expect("Failed to write header");
+    let family1 = create_umi_family("AAAAAAAA", 10, "family1", "ACGTACGT", 30);
+    let family2 = create_umi_family("CCCCCCCC", 5, "family2", "TGCATGCA", 30);
+    for record in family1.iter().chain(family2.iter()) {
+        writer
+            .write_alignment_record(&header, &to_record_buf(record))
+            .expect("Failed to write record");
+    }
+    writer.try_finish().expect("Failed to finish BAM");
+
+    let single = run_group_records(temp_dir.path(), "single", &input_bam, &["--allow-unmapped"]);
+    let chained = run_group_records(
+        temp_dir.path(),
+        "chained",
+        &input_bam,
+        &["--allow-unmapped", "--threads", "1"],
+    );
+
+    // This fixture/flag combo is content-pinned by no other test, so guard
+    // against a vacuous pass where both paths regressed to empty/all-dropped
+    // output: 10 + 5 input reads across two UMI families, all accepted.
+    assert_eq!(single.len(), 15, "expected all 15 query-grouped reads in the output");
+    assert_eq!(
+        single, chained,
+        "chain and single-threaded --allow-unmapped output must match on a query-grouped input",
+    );
+}
+
+/// The chain's finalize hook writes metrics via `write_metrics_for_chain`, a
+/// separate path from the single-threaded `write_all_metrics`. This pins that
+/// the two produce identical metrics files (grouping-metrics and the
+/// family-size histogram) on the same input, so the two orchestrations cannot
+/// drift on secondary output. Metrics files are deterministic TSV count tables
+/// with no embedded paths/timestamps, so a byte comparison is stable.
+#[test]
+fn test_group_metrics_files_match_across_modes() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    create_test_input_bam(&input_bam);
+
+    // Run `group` for one mode, returning (grouping-metrics, family-size-histogram) contents.
+    let run = |tag: &str, extra: &[&str]| -> (String, String) {
+        let output = temp_dir.path().join(format!("{tag}.bam"));
+        let grouping = temp_dir.path().join(format!("{tag}.grouping.txt"));
+        let famsize = temp_dir.path().join(format!("{tag}.famsize.txt"));
+        let mut args: Vec<&str> = vec![
+            "--grouping-metrics",
+            grouping.to_str().unwrap(),
+            "--family-size-histogram",
+            famsize.to_str().unwrap(),
+        ];
+        args.extend_from_slice(extra);
+        let cmd = GroupReadsByUmi::try_parse_from(group_args(
+            input_bam.to_str().unwrap(),
+            output.to_str().unwrap(),
+            &args,
+        ))
+        .expect("failed to parse group args");
+        cmd.execute("fgumi group").unwrap_or_else(|e| panic!("group ({tag}) failed: {e:#}"));
+        (
+            fs::read_to_string(&grouping).expect("read grouping metrics"),
+            fs::read_to_string(&famsize).expect("read family-size histogram"),
+        )
+    };
+
+    let single = run("single", &[]);
+    let chained = run("chained", &["--threads", "1"]);
+
+    // Pin a concrete value so the equality checks below cannot pass on two empty
+    // or degenerate files: create_test_input_bam has 30 accepted records, and
+    // `accepted_sam_records` is the first grouping-metrics column.
+    assert!(
+        single.0.lines().nth(1).is_some_and(|row| row.starts_with("30\t")),
+        "grouping-metrics should report 30 accepted records; got:\n{}",
+        single.0
+    );
+
+    assert_eq!(
+        single.0, chained.0,
+        "grouping-metrics file must be identical across single-threaded and chain modes",
+    );
+    assert_eq!(
+        single.1, chained.1,
+        "family-size histogram must be identical across single-threaded and chain modes",
+    );
+}
+
+/// Build a template-coordinate-sorted BAM with `n` single-read families at `n`
+/// distinct ascending positions, so the input spans `n` position groups and —
+/// for `n` past the pipeline's 500-template batch size — multiple batches.
+fn create_multi_batch_input_bam(path: &std::path::Path, n: usize) {
+    let header = create_minimal_header("chr1", 10_000_000);
+    let mut writer =
+        bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
+    writer.write_header(&header).expect("Failed to write header");
+    for i in 0..n {
+        for record in
+            &create_umi_family_at_pos("AAAAAAAA", 1, &format!("fam{i}"), "ACGTACGT", 30, i + 1)
+        {
+            writer
+                .write_alignment_record(&header, &to_record_buf(record))
+                .expect("Failed to write record");
+        }
+    }
+    writer.try_finish().expect("Failed to finish BAM");
+}
+
+/// The chain's multi-worker path (`--threads N>1`) reorders across batches and
+/// accumulates per-batch `MoleculeId` offsets — machinery the `--threads 1` parity
+/// tests do not exercise. Compare `--threads 4` output record-for-record against
+/// the single-threaded oracle on an input spanning many position groups and
+/// multiple pipeline batches (> the 500-template batch size).
+#[test]
+fn test_group_chain_threads4_matches_single_threaded_multi_batch() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    create_multi_batch_input_bam(&input_bam, 600);
+
+    let single = run_group_records(temp_dir.path(), "single", &input_bam, &[]);
+    let threads4 = run_group_records(temp_dir.path(), "threads4", &input_bam, &["--threads", "4"]);
+
+    // 600 positions × 1 read → 600 output records spanning multiple batches.
+    assert_eq!(single.len(), 600, "expected 600 grouped records (one per position group)");
+    assert_eq!(
+        single, threads4,
+        "chain (--threads 4) output must match the single-threaded oracle record-for-record across batches",
+    );
 }


### PR DESCRIPTION
Lands the **declarative chain-builder layer** on top of the typed-step pipeline foundation (#870), and wires the first live command onto it: `group --threads`. Stacked on #870 — base is `nh/pipeline-foundation` and will be retargeted to `main` (and rebased) once #870 merges.

The chain layer is the consumer of the framework #870 introduced: a `ChainSpec` is assembled by `build_for()` into a `BuiltPipeline` whose `.run()` drives a sequence of UMI-processing stages (source → steps → sink → finalize). This PR ports that layer and makes exactly **one** command reach it from a live CLI path (`group --threads N`); every other command builder is present but **dormant** (no live CLI path reaches it yet) and will be exercised — and behaviorally validated — by its own follow-up wiring PR. Treat the dormant builders' first-pass review as structural rather than behavioral.

## What's here (suggested reading order, oldest → newest)

1. **`8f04014c` — port the declarative chain-builder layer (dormant; group pilot wired).** The core infrastructure (`chains/{spec,stage,source_spec,sink_spec,build,build_helpers,finalize,validate,builder}.rs` + `chains/commands/*`), the two new pipeline steps (`align_and_merge`, `extract`), and the command/library adaptations that expose the helpers the chain consumes. Squashed from the R2 WIP history into a single green, clippy-clean commit. Structural — read for shape, not behavior.
2. **`ac5a8368` — share group input-ordering classification.** `Group::execute` and the chain's `add_group` had silently diverged on which input orders they accept (the chain was stricter, rejecting `GO:query`-grouped inputs the live path accepts) and on their diagnostics. Move `InputOrdering` + `classify_input_ordering` into `commands::common`, add `require_group_input_ordering` reproducing the live 3-state behavior verbatim, and route both orchestrations through it so they cannot drift. No behavior change to the live group path.
3. **`126afe8c` — thread CRC policy through the chain BAM source.** The chain's `BgzfDecompress` hardcoded CRC verification on, ignoring `--check-crc/--no-check-crc`; repointing `group` at it would have silently regressed `--no-check-crc`/stdin runs from skip-CRC to always-verify. Add a `verify_crc` field (`new()` keeps the verifying default; `new_with_crc()` takes an explicit policy), carry it on `ChainSpec.verify_crc` from `effective_check_crc()`. Inert for the SAM and FASTQ sources.
4. **`4c683be1` — repoint `group --threads` onto the chain builder (the pilot).** Replace `Group::execute`'s ~500-line hand-rolled unified-pipeline construction for the `--threads N` path with `ChainSpec::single_stage(Stage::Group) → build_for → run`, using the same shared helpers (`require_group_input_ordering`, `add_pg_record`, `write_metrics_for_chain`) as the single-threaded fast path, which is unchanged. The `--threads` branch runs before the reader is opened so the chain reads its source exactly once (pre-opening would consume stdin before the chain reopened it, breaking `stdin + --threads`).
5. **`b340d7b7` — green the docs and prune dead API surface.** Delete the 10 dead `build_*_chain` delegate functions (zero callers; `build_for` is the live dispatch) and the unused `pub use builder::ChainBuilder` re-export; drop the never-read `queue_memory` and `_header` parameters; demote `make_raw_records_from_fastq_set` to `pub(crate)`; repair every intra-doc link across the chains subtree and remove the blanket `broken_intra_doc_links` allow so `cargo ci-doc` is clean with no suppressions.

## Validation

The pilot (`4c683be1`) adds tests that pin behaviors the single-threaded oracle cannot see:

- **`test_group_chain_matches_single_threaded`** — `--threads 1` output is record-for-record identical to the single-threaded path.
- **`test_group_allow_unmapped_query_grouped_chain_parity`** — a `GO:query` (not `SO:queryname`) input under `--allow-unmapped` is accepted by the chain and matches the single-threaded output (would have been rejected before the shared classifier).
- **`test_group_threaded_crc_policy`** — `--no-check-crc` / `--check-crc` / default CRC policy is honored on the chain path, and the accept case asserts record identity against an intact-file baseline (not merely a non-empty output).

Beyond the suite (9,467 tests green), the `group` output was checked directly against the foundation binary at scale: single-threaded **and** `--threads 8`, adjacency + edit, on idt-cfdna (86K molecules), CODEC (2.34M) and kapa-umi (3.87M) — molecule groupings identical in every case (MI-invariant comparator). The branch also went through an adversarial multi-lens review and a scoped CodeRabbit-style pass before submission; all findings (assertion strength, a dead generic parameter, doc/visibility hygiene) were suggestion/nitpick level and are addressed in the commits above — no blocking or correctness findings.

## Deferred / follow-ups (not in this PR)

- **Chain-map perf seeding** — the fixed-seed ahash optimization for the chain's hot per-position-group maps depends on the `deterministic_state()` helper landed in #865 (already on `main`), which is not yet on this stacked base. It lands as a small follow-up perf PR once this base rebases onto `main`.
- **`sort --threads` rewire** — deferred; the arena sort engine has an open perf regression on that path.
- **Per-command wiring PRs** — the dormant builders (dedup, clip, codec, correct, duplex, simplex, filter, sort, zipper, align, extract, fastq) each get their own PR that makes them live and validates them behaviorally. Some carry KNOWN-DIVERGENCE notes (clip/extract/fastq) to resolve at wiring time.

## Merge gate

Same release gate as #870: the fgumi-benchmarks AWS run (fgbio equivalency + WES/WGS scale). This PR changes only the `group --threads` path's internal construction (proven record-identical) and adds dormant code; the release-time benchmark remains the correctness-at-scale gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: output changes apply to threaded `group`; parity tests, CRC propagation, and UMI-assignment reset tests pin the new output; unsafe changes: none, and no `CLAUDE.md` allowlist update is required; memory, queue-capacity, thread, and backpressure policy changes: none.

Fix: use `ChainSpec::build_for()` for declarative pipeline construction while preserving existing resource limits and CRC controls.

- Adds typed chain builders, validation, source/sink specifications, finalization hooks, and pipeline diagnostics.
- Rewires threaded `group` execution to the chain builder.
- Adds dormant chain support for extract, align, clip, filter, correct, dedup, consensus, FASTQ, zipper, and sort stages.
- Adds shared group input-order validation, including query-grouped input with `--allow-unmapped`.
- Propagates CRC policy through BGZF decompression.
- Adds reusable BAM framing, FASTQ extraction, zipper merging, aligner process management, and UMI assigner reset support.
- Adds tests for threaded group parity, ordering, metrics, CRC behavior, pipeline finalization, validation, and step behavior.
- Defers sort rewiring and chain-map performance work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->