### PR TITLE
feat(copy-umi): add command to copy the read-name UMI into the RX tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Enable with: `cargo build --release --features <feature>`
 | `review` | Review consensus variants | `fgbio ReviewConsensusVariants` |
 | `downsample` | Downsample BAM by UMI family | N/A |
 | `retag` | Rewrite SAM tags (copy/move/delete) | N/A |
+| `copy-umi` | Copy the UMI from the read name into the RX tag | `fgbio CopyUmiFromReadName` |
 | `compare <cmd>` | Compare files (feature-gated) | N/A |
 | `simulate <cmd>` | Generate test data (feature-gated) | N/A |
 

--- a/src/lib/commands/copy_umi.rs
+++ b/src/lib/commands/copy_umi.rs
@@ -1,0 +1,410 @@
+//! `copy-umi` — copy the UMI embedded in a BAM read name into the `RX` tag.
+//!
+//! Ports fgbio's `CopyUmiFromReadName`: the UMI is the last field of the read
+//! name (split on `--field-delimiter`, default `:`), normalized to the canonical
+//! SAM form (dual UMIs `-`-joined, `r`-prefixed segments reverse-complemented by
+//! default), and written to the `RX` tag. It is a non-destructive, streaming
+//! BAM→BAM pass: alignments, `SEQ`, and other tags pass through untouched, and
+//! only the read name (optionally, with `--remove-umi`) and the `RX` tag change.
+//!
+//! Unlike `extract` (which parses FASTQ read names during unmapped-BAM creation
+//! and uses fgbio's strict ≥8-field rule), `copy-umi` uses fgbio
+//! `CopyUmiFromReadName`'s lenient rule: the UMI is simply the last delimited
+//! field, with no field-count requirement. The two commands share the
+//! normalization step (`crate::umi::read_name::normalize_read_name_umi`) but keep
+//! their own field-location logic.
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context, Result, bail, ensure};
+use clap::Parser;
+use log::{info, warn};
+use noodles::sam::Header;
+
+use crate::commands::command::Command;
+use crate::commands::common::{
+    BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
+    add_pg_record, build_pipeline_config, ensure_hd_record, reject_output_collisions,
+    serialize_raw_bam_records,
+};
+use crate::grouper::SingleRawRecordGrouper;
+use crate::logging::OperationTimer;
+use crate::per_thread_accumulator::PerThreadAccumulator;
+use crate::sam::SamTag;
+use crate::umi::read_name::normalize_read_name_umi;
+use crate::unified_pipeline::{Grouper, MemoryEstimate, run_bam_pipeline_from_reader};
+use fgumi_bam_io::create_bam_reader_for_pipeline_with_opts;
+use fgumi_raw_bam::{RawRecord, update_string_tag};
+
+/// Copy the UMI from a BAM read name into the RX tag.
+#[derive(Debug, Parser)]
+#[command(
+    name = "copy-umi",
+    about = "\x1b[38;5;166m[UTILITIES]\x1b[0m      \x1b[36mCopy the UMI from the read name into the RX tag\x1b[0m",
+    long_about = r#"
+Copy the UMI embedded in each read name into the RX SAM tag.
+
+Migrating from fgbio's CopyUmiFromReadName: for a BAM whose reads carry the UMI as
+the last field of the read name (e.g. the Illumina 8th field, or a UMI appended by
+an upstream tool), this copies that UMI into the RX tag so downstream fgumi tools
+(which read UMIs only from RX) can consume it.
+
+It is non-destructive and streams BAM in to BAM out: alignments, sequence, and all
+other tags pass through untouched. Only the RX tag is added and, with --remove-umi,
+the UMI is trimmed off the read name. This composes in a pipe, e.g. between
+`samtools fixmate` and `fgumi sort`.
+
+## UMI location
+
+The UMI is the last `--field-delimiter` (default `:`) field of the read name. There
+is no field-count requirement (fgbio CopyUmiFromReadName's lenient rule); a read
+name with fewer than two fields, or an empty last field, is an error.
+
+## UMI normalization
+
+The extracted UMI is normalized to the canonical SAM form, matching fgbio:
+- multiple UMIs in the field (delimited by `+`, fixed) are joined with `-`;
+- segments prefixed with `r` (marking reverse-complemented UMIs, e.g. from BCL
+  Convert) are reverse-complemented back to the forward strand by default; pass
+  --reverse-complement-r-umis false to instead strip the `r` and keep the stated
+  orientation (matching UMI-tools/fgpyo);
+- the result is upper-cased and rejected if it contains any character outside
+  `ACGTN-`; a field that normalizes to nothing (e.g. a bare `r`) is an error.
+
+An error on any record fails the run (fail-fast), naming the read name.
+
+## Performance
+
+The work is dominated by BGZF (de)compression, not the UMI copy itself, and
+output compression is the largest single cost. In a pipe to another tool, pass a
+low `--compression-level` (e.g. 1, or 0 for uncompressed BAM straight into
+`fgumi sort`) to roughly halve CPU; use `--threads` to parallelize.
+"#
+)]
+#[command(verbatim_doc_comment)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct CopyUmi {
+    /// Input/output BAM paths and reader options.
+    #[command(flatten)]
+    pub io: BamIoOptions,
+
+    /// Read-name field delimiter; the UMI is the last field. Must be ASCII.
+    #[arg(long = "field-delimiter", default_value_t = ':')]
+    pub field_delimiter: char,
+
+    /// Remove the UMI (and its delimiter) from the read name after copying it.
+    #[arg(long = "remove-umi", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
+    pub remove_umi: bool,
+
+    /// Reverse-complement `r`-prefixed UMI segments (fgbio default). Set to
+    /// `false` to strip the `r` marker without reverse-complementing, matching
+    /// UMI-tools/fgpyo.
+    #[arg(long = "reverse-complement-r-umis", value_name = "true|false", default_value = "true", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
+    pub reverse_complement_r_umis: bool,
+
+    /// Error if a record already carries an RX tag, instead of overwriting it.
+    #[arg(long = "fail-if-tag-present", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
+    pub fail_if_tag_present: bool,
+
+    /// Optional TSV file for run metrics.
+    #[arg(short = 'M', long = "metrics")]
+    pub metrics: Option<PathBuf>,
+
+    /// Threading options for the parallel pipeline.
+    #[command(flatten)]
+    pub threading: ThreadingOptions,
+
+    /// Compression options for the output BAM.
+    #[command(flatten)]
+    pub compression: CompressionOptions,
+
+    /// Scheduler and pipeline statistics options.
+    #[command(flatten)]
+    pub scheduler_opts: SchedulerOptions,
+
+    /// Queue memory options.
+    #[command(flatten)]
+    pub queue_memory: QueueMemoryOptions,
+}
+
+/// Per-record outcome flags, aggregated into [`CopyUmiCounts`] during serialize.
+#[derive(Debug, Clone, Copy, Default)]
+struct RecordOutcome {
+    /// An existing RX tag was overwritten with the newly extracted UMI.
+    overwrote_rx: bool,
+    /// The UMI was trimmed off the read name (`--remove-umi`).
+    trimmed_name: bool,
+}
+
+/// One record after processing, carried from the parallel process step to the
+/// serial serialize step.
+struct CopyUmiProcessed {
+    /// The record with RX written (and the name trimmed, if requested).
+    record: RawRecord,
+    /// What happened to this record, for metrics.
+    outcome: RecordOutcome,
+}
+
+impl MemoryEstimate for CopyUmiProcessed {
+    fn estimate_heap_size(&self) -> usize {
+        self.record.capacity()
+    }
+}
+
+/// Aggregated run counters, one instance per pipeline slot.
+#[derive(Debug, Clone, Default)]
+struct CopyUmiCounts {
+    /// Records processed (all successful; a failure aborts the run).
+    total_records: u64,
+    /// Records where an existing RX tag was overwritten.
+    rx_overwritten: u64,
+    /// Records whose read name had the UMI trimmed off.
+    names_trimmed: u64,
+}
+
+/// One metrics row summarizing the run, written to the optional `--metrics` TSV.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct CopyUmiMetric {
+    /// Total records processed.
+    pub total_records: u64,
+    /// Records where the RX tag was written (equals `total_records`).
+    pub rx_written: u64,
+    /// Records where a pre-existing RX tag was overwritten.
+    pub rx_overwritten: u64,
+    /// Records whose read name had the UMI trimmed off (`--remove-umi`).
+    pub names_trimmed: u64,
+}
+
+impl fgumi_metrics::Metric for CopyUmiMetric {
+    fn metric_name() -> &'static str {
+        "copy_umi"
+    }
+}
+
+/// Copy the read-name UMI into the RX tag of a single record, in place.
+///
+/// Locates the UMI as the last `field_delimiter` field of the read name,
+/// normalizes it via [`normalize_read_name_umi`], writes it to `RX` (overwriting
+/// or, with `fail_if_tag_present`, erroring on an existing tag), and optionally
+/// trims it off the read name.
+///
+/// # Errors
+/// Fails if the read name has no delimiter, has an empty last field, yields an
+/// invalid UMI, or already carries an RX tag when `fail_if_tag_present` is set.
+fn copy_umi_into_record(
+    record: &mut RawRecord,
+    field_delimiter: u8,
+    reverse_complement_prefixed: bool,
+    remove_umi: bool,
+    fail_if_tag_present: bool,
+) -> Result<RecordOutcome> {
+    // Locate + normalize the UMI while only borrowing the record immutably, then
+    // drop the borrow before mutating tags/name.
+    let (delim_idx, umi) = {
+        let name = record.read_name();
+        let Some(idx) = name.iter().rposition(|&b| b == field_delimiter) else {
+            bail!(
+                "read name '{}' has no '{}'-delimited UMI field",
+                String::from_utf8_lossy(name),
+                field_delimiter as char
+            );
+        };
+        let last = &name[idx + 1..];
+        // fgbio would write an empty RX here; we fail instead — an empty UMI only
+        // defers the failure to `group` (mixed UMI lengths) with a worse message.
+        if last.is_empty() {
+            bail!(
+                "read name '{}' has an empty UMI field after the final '{}'",
+                String::from_utf8_lossy(name),
+                field_delimiter as char
+            );
+        }
+        // `normalize_read_name_umi` rejects a field that normalizes to empty (e.g. a
+        // bare `r`), so an empty RX can never reach the output.
+        let umi =
+            normalize_read_name_umi(last, reverse_complement_prefixed).with_context(|| {
+                format!("extracting UMI from read name '{}'", String::from_utf8_lossy(name))
+            })?;
+        (idx, umi)
+    };
+
+    // Write RX, overwriting (or erroring on) a pre-existing tag. `update_string_tag`
+    // replaces an existing RX in place and appends the SAM-spec NUL itself; the
+    // `contains` probe is still needed for the overwrite counter and fail policy.
+    let overwrote_rx = record.tags().contains(SamTag::RX);
+    ensure!(
+        !(overwrote_rx && fail_if_tag_present),
+        "record '{}' already has an RX tag (drop --fail-if-tag-present to overwrite)",
+        String::from_utf8_lossy(record.read_name())
+    );
+    update_string_tag(record.as_mut_vec(), SamTag::RX, &umi);
+
+    // Trim the UMI (and its leading delimiter) off the read name, matching fgbio's
+    // `name.substring(0, lastIndexOf(delim))`.
+    let trimmed_name = if remove_umi {
+        // `delim_idx == 0` (a leading-delimiter name like `:ACGT`) would trim to an
+        // empty QNAME, which no downstream reader accepts; reject it instead.
+        ensure!(
+            delim_idx > 0,
+            "removing the UMI from read name '{}' would leave an empty read name",
+            String::from_utf8_lossy(record.read_name())
+        );
+        let new_name = record.read_name()[..delim_idx].to_vec();
+        record.set_read_name(&new_name);
+        true
+    } else {
+        false
+    };
+
+    Ok(RecordOutcome { overwrote_rx, trimmed_name })
+}
+
+impl CopyUmi {
+    /// Reject a write target that resolves to the same file as the input, which
+    /// would clobber the BAM being read (mirrors `retag`/`merge`).
+    fn reject_write_aliasing_input(&self) -> Result<()> {
+        let Ok(input_canon) = std::fs::canonicalize(&self.io.input) else {
+            return Ok(());
+        };
+        let write_targets = std::iter::once((self.io.output.as_path(), "--output"))
+            .chain(self.metrics.as_deref().map(|m| (m, "--metrics")));
+        for (path, flag) in write_targets {
+            if std::fs::canonicalize(path).is_ok_and(|canon| canon == input_canon) {
+                bail!(
+                    "{flag} '{}' is the same file as --input '{}'; choose a different path",
+                    path.display(),
+                    self.io.input.display()
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Command for CopyUmi {
+    fn execute(&self, command_line: &str) -> Result<()> {
+        self.io.validate()?;
+        let field_delimiter =
+            u8::try_from(self.field_delimiter).ok().filter(u8::is_ascii).with_context(|| {
+                format!(
+                    "--field-delimiter must be a single ASCII character, got '{}'",
+                    self.field_delimiter
+                )
+            })?;
+
+        // Reject two writers to one destination, and a write target aliasing input.
+        let mut outputs: Vec<(&Path, &str)> = vec![(self.io.output.as_path(), "--output")];
+        if let Some(path) = &self.metrics {
+            outputs.push((path.as_path(), "--metrics"));
+        }
+        reject_output_collisions(&outputs)?;
+        self.reject_write_aliasing_input()?;
+
+        let timer = OperationTimer::new("Copying UMIs from read names");
+        info!("Starting copy-umi");
+        info!("Input: {}", self.io.input.display());
+        info!("Output: {}", self.io.output.display());
+
+        let threads = self.threading.threads.unwrap_or(1);
+        let (reader, header) = create_bam_reader_for_pipeline_with_opts(
+            &self.io.input,
+            self.io.pipeline_reader_opts(),
+        )?;
+        let header = ensure_hd_record(header)?;
+        let header = add_pg_record(header, command_line)?;
+
+        let pipeline_config = build_pipeline_config(
+            &self.scheduler_opts,
+            &self.compression,
+            &self.queue_memory,
+            &self.io,
+            threads,
+        )?;
+
+        let counts = PerThreadAccumulator::<CopyUmiCounts>::new(threads);
+
+        let grouper_fn = move |_header: &Header| {
+            Box::new(SingleRawRecordGrouper::new()) as Box<dyn Grouper<Group = RawRecord> + Send>
+        };
+
+        // fgbio-style RC is the default; `--reverse-complement-r-umis false` switches
+        // to strip-only.
+        let reverse_complement_prefixed = self.reverse_complement_r_umis;
+        let remove_umi = self.remove_umi;
+        let fail_if_tag_present = self.fail_if_tag_present;
+        let process_fn = move |mut record: RawRecord| -> io::Result<CopyUmiProcessed> {
+            let outcome = copy_umi_into_record(
+                &mut record,
+                field_delimiter,
+                reverse_complement_prefixed,
+                remove_umi,
+                fail_if_tag_present,
+            )
+            .map_err(io::Error::other)?;
+            Ok(CopyUmiProcessed { record, outcome })
+        };
+
+        let counts_for_serialize = Arc::clone(&counts);
+        let serialize_fn = move |processed: CopyUmiProcessed,
+                                 _header: &Header,
+                                 output: &mut Vec<u8>|
+              -> io::Result<u64> {
+            counts_for_serialize.with_slot(|c| {
+                c.total_records += 1;
+                if processed.outcome.overwrote_rx {
+                    c.rx_overwritten += 1;
+                }
+                if processed.outcome.trimmed_name {
+                    c.names_trimmed += 1;
+                }
+            });
+            serialize_raw_bam_records(std::slice::from_ref(&processed.record), output)
+        };
+
+        run_bam_pipeline_from_reader(
+            pipeline_config,
+            reader,
+            header,
+            &self.io.output,
+            None,
+            grouper_fn,
+            process_fn,
+            serialize_fn,
+        )?;
+
+        // Aggregate per-slot counters.
+        let mut totals = CopyUmiCounts::default();
+        for slot in counts.slots() {
+            let c = slot.lock();
+            totals.total_records += c.total_records;
+            totals.rx_overwritten += c.rx_overwritten;
+            totals.names_trimmed += c.names_trimmed;
+        }
+
+        if totals.rx_overwritten > 0 {
+            warn!("overwrote a pre-existing RX tag on {} record(s)", totals.rx_overwritten);
+        }
+
+        if let Some(path) = &self.metrics {
+            let row = CopyUmiMetric {
+                total_records: totals.total_records,
+                rx_written: totals.total_records,
+                rx_overwritten: totals.rx_overwritten,
+                names_trimmed: totals.names_trimmed,
+            };
+            fgumi_metrics::write_metrics(path, std::slice::from_ref(&row), "copy_umi")?;
+            info!("Wrote metrics to: {}", path.display());
+        }
+
+        info!("=== Summary ===");
+        info!("Records processed: {}", totals.total_records);
+        info!("RX tags written: {}", totals.total_records);
+        info!("RX tags overwritten: {}", totals.rx_overwritten);
+        info!("Read names trimmed: {}", totals.names_trimmed);
+
+        timer.log_completion(totals.total_records);
+        Ok(())
+    }
+}

--- a/src/lib/commands/extract.rs
+++ b/src/lib/commands/extract.rs
@@ -37,7 +37,6 @@ use bstr::{BString, ByteSlice};
 use clap::Parser;
 use fgumi_bam_io::ProgressTracker;
 use fgumi_bam_io::{RawBamWriter, create_raw_bam_writer, open_output_writer};
-use fgumi_dna::dna::reverse_complement;
 use fgumi_raw_bam::UnmappedSamBuilder;
 use fgumi_raw_bam::fields::flags;
 use log::{debug, info};
@@ -71,14 +70,6 @@ const QUALITY_DETECTION_SAMPLE_SIZE: usize = 400;
 /// compressed BGZF blocks. Sized well above `BGZF_MAX_BLOCK_SIZE` so a block
 /// lands in the buffer instead of passing straight through it.
 const PIPELINE_OUTPUT_BUF_CAPACITY: usize = 256 * 1024;
-
-/// Prefix marking a read-name UMI segment that must be reverse-complemented,
-/// matching fgbio `Umis.RevcompPrefix` (`Umis.scala:33`).
-const REVCOMP_PREFIX: u8 = b'r';
-
-/// Delimiter separating dual UMIs in a read name, translated to `-` on extraction,
-/// matching fgbio's `umiDelimiter` default (`Umis.scala:88`).
-const UMI_DELIMITER: u8 = b'+';
 
 /// Pre-serialized batch of BAM records for the pipeline output type.
 ///
@@ -929,7 +920,7 @@ impl Extract {
     ///
     /// Names with fewer than 8 fields are treated as not containing a UMI and
     /// produce `None`. The extracted UMI is then normalized via
-    /// [`normalize_read_name_umi`](Self::normalize_read_name_umi) to match fgbio's
+    /// [`normalize_read_name_umi`](crate::umi::read_name::normalize_read_name_umi) to match fgbio's
     /// strict `Umis.extractUmisFromReadName` (reverse-complement `r`-prefixed
     /// segments, `+`→`-`, upper-case).
     ///
@@ -966,83 +957,13 @@ impl Extract {
             && let Some(last) = parts.last()
             && !last.is_empty()
         {
-            let umi = Self::normalize_read_name_umi(last).with_context(|| {
+            let umi = crate::umi::read_name::normalize_read_name_umi(last).with_context(|| {
                 format!("extracting UMI from read name '{}'", String::from_utf8_lossy(name_part))
             })?;
             return Ok((name_part.to_vec(), Some(umi)));
         }
 
         Ok((name_part.to_vec(), None))
-    }
-
-    /// Normalizes a UMI extracted from the last field of a read name, matching
-    /// fgbio's `Umis.extractUmisFromReadName` (strict mode, as called by
-    /// `FastqToBam`; `Umis.scala:85-126`).
-    ///
-    /// With `reverseComplementPrefixedUmis` defaulting to true, fgbio:
-    /// 1. reverse-complements any `r`-prefixed segment (EXT-04); when the UMI is
-    ///    `+`-delimited, only the `r`-prefixed segments are reverse-complemented,
-    /// 2. translates the `+` dual-UMI delimiter to `-`,
-    /// 3. upper-cases the result (EXT-03), and
-    /// 4. throws if any character is outside `ACGTN-` (EXT-01, strict mode).
-    ///
-    /// Reverse-complementing reuses [`fgumi_dna::dna::reverse_complement`], which
-    /// complements `ACGT`, maps RNA `U`→`A`, and preserves `N` — matching fgbio's
-    /// `Sequences.complement` over the bases a read-name UMI may contain. Any other
-    /// character is passed through and then rejected by the `ACGTN-` validation
-    /// below, mirroring fgbio's strict-mode rejection.
-    ///
-    /// # Errors
-    /// Returns an error if the normalized UMI contains a character outside `ACGTN-`,
-    /// mirroring fgbio's strict-mode `IllegalArgumentException`.
-    fn normalize_read_name_umi(raw: &[u8]) -> Result<Vec<u8>> {
-        // fgbio keys the transform on whether an 'r' appears anywhere and whether a
-        // '+' delimiter appears at an index > 0 (a leading '+' is not a delimiter).
-        let has_revcomp_prefix = raw.contains(&REVCOMP_PREFIX);
-        let has_delimiter = raw.iter().position(|&b| b == UMI_DELIMITER).is_some_and(|idx| idx > 0);
-
-        let transformed: Vec<u8> = match (has_revcomp_prefix, has_delimiter) {
-            // Reverse-complement each `r`-prefixed segment, join with '-'.
-            (true, true) => {
-                let mut out = Vec::with_capacity(raw.len());
-                for (i, segment) in raw.split(|&b| b == UMI_DELIMITER).enumerate() {
-                    if i > 0 {
-                        out.push(b'-');
-                    }
-                    match segment.split_first() {
-                        Some((&REVCOMP_PREFIX, rest)) => out.extend(reverse_complement(rest)),
-                        // `stripPrefix('r')` is a no-op when the segment is not
-                        // prefixed with 'r'; the segment is copied verbatim.
-                        _ => out.extend_from_slice(segment),
-                    }
-                }
-                out
-            }
-            // Single UMI: reverse-complement after stripping a leading 'r'.
-            (true, false) => {
-                let stripped = raw.strip_prefix(&[REVCOMP_PREFIX][..]).unwrap_or(raw);
-                reverse_complement(stripped)
-            }
-            // No revcomp: just translate the '+' delimiter to '-'.
-            (false, true) => {
-                raw.iter().map(|&b| if b == UMI_DELIMITER { b'-' } else { b }).collect()
-            }
-            (false, false) => raw.to_vec(),
-        };
-
-        // fgbio upper-cases the UMI after any reverse-complementing.
-        let umi: Vec<u8> = transformed.iter().map(u8::to_ascii_uppercase).collect();
-
-        // Strict mode: reject any character outside the SAM UMI alphabet.
-        if let Some(&bad) = umi.iter().find(|&&b| !is_valid_umi_char(b)) {
-            bail!(
-                "Invalid UMI '{}' extracted from read name (illegal character '{}')",
-                String::from_utf8_lossy(&umi),
-                bad as char,
-            );
-        }
-
-        Ok(umi)
     }
 
     /// Validates that all read names match across the read sets
@@ -1812,16 +1733,6 @@ impl Command for Extract {
         timer.log_completion(records_written);
         Ok(())
     }
-}
-
-/// Returns true if `b` is a valid SAM UMI character (`ACGTN-`), matching fgbio's
-/// `Umis.isValidUmiCharacter` (`Umis.scala:128-130`).
-///
-/// This is intentionally distinct from [`fgumi_umi::validate_umi`], which
-/// implements the more permissive `GroupReadsByUmi` counting rule (only rejects
-/// upper-case `N`); the read-name extraction path uses fgbio's strict alphabet.
-fn is_valid_umi_char(b: u8) -> bool {
-    matches!(b, b'A' | b'C' | b'G' | b'T' | b'N' | b'-')
 }
 
 /// Reject an assembled template that does not carry exactly one record per read

--- a/src/lib/commands/extract.rs
+++ b/src/lib/commands/extract.rs
@@ -957,9 +957,13 @@ impl Extract {
             && let Some(last) = parts.last()
             && !last.is_empty()
         {
-            let umi = crate::umi::read_name::normalize_read_name_umi(last).with_context(|| {
-                format!("extracting UMI from read name '{}'", String::from_utf8_lossy(name_part))
-            })?;
+            let umi =
+                crate::umi::read_name::normalize_read_name_umi(last, true).with_context(|| {
+                    format!(
+                        "extracting UMI from read name '{}'",
+                        String::from_utf8_lossy(name_part)
+                    )
+                })?;
             return Ok((name_part.to_vec(), Some(umi)));
         }
 
@@ -2982,6 +2986,15 @@ mod tests {
         let header = b"@q1:2:3:4:5:6:7:ACGT+CGTA".to_vec();
         let (_name, umi) = Extract::extract_read_name_and_umi(&header, true).unwrap();
         assert_eq!(umi, Some(b"ACGT-CGTA".to_vec()));
+    }
+
+    #[test]
+    fn test_extract_read_name_and_umi_rejects_field_that_normalizes_to_empty() {
+        // An 8-field name whose UMI field is a bare `r` normalizes to empty; the
+        // shared normalizer rejects it rather than emitting an empty RX.
+        let header = b"@q1:2:3:4:5:6:7:r".to_vec();
+        let err = Extract::extract_read_name_and_umi(&header, true).unwrap_err();
+        assert!(format!("{err:#}").contains("empty"), "got: {err:#}");
     }
 
     #[test]

--- a/src/lib/commands/mod.rs
+++ b/src/lib/commands/mod.rs
@@ -58,6 +58,7 @@ pub mod common;
 #[cfg(feature = "compare")]
 pub mod compare;
 pub mod consensus_runner;
+pub mod copy_umi;
 pub mod correct;
 pub mod dedup;
 pub mod downsample;

--- a/src/lib/umi/mod.rs
+++ b/src/lib/umi/mod.rs
@@ -14,3 +14,4 @@ pub use fgumi_umi::assigner::{
 };
 
 pub mod parallel_assigner;
+pub mod read_name;

--- a/src/lib/umi/read_name.rs
+++ b/src/lib/umi/read_name.rs
@@ -13,11 +13,11 @@ use fgumi_dna::dna::reverse_complement;
 
 /// Prefix marking a read-name UMI segment that must be reverse-complemented,
 /// matching fgbio `Umis.RevcompPrefix` (`Umis.scala:33`).
-pub(crate) const REVCOMP_PREFIX: u8 = b'r';
+const REVCOMP_PREFIX: u8 = b'r';
 
 /// Delimiter separating dual UMIs in a read name, translated to `-` on extraction,
 /// matching fgbio's `umiDelimiter` default (`Umis.scala:88`).
-pub(crate) const UMI_DELIMITER: u8 = b'+';
+const UMI_DELIMITER: u8 = b'+';
 
 /// Returns true if `b` is a valid SAM UMI character (`ACGTN-`), matching fgbio's
 /// `Umis.isValidUmiCharacter` (`Umis.scala:128-130`).
@@ -30,15 +30,21 @@ fn is_valid_umi_char(b: u8) -> bool {
 }
 
 /// Normalizes a UMI extracted from the last field of a read name, matching
-/// fgbio's `Umis.extractUmisFromReadName` (strict mode, as called by
-/// `FastqToBam`; `Umis.scala:85-126`).
+/// fgbio's `Umis.extractUmisFromReadName` (`Umis.scala:85-126`).
 ///
-/// With `reverseComplementPrefixedUmis` defaulting to true, fgbio:
+/// When `reverse_complement_prefixed` is true (fgbio's default, and `extract`'s
+/// only mode), fgbio:
 /// 1. reverse-complements any `r`-prefixed segment (EXT-04); when the UMI is
 ///    `+`-delimited, only the `r`-prefixed segments are reverse-complemented,
 /// 2. translates the `+` dual-UMI delimiter to `-`,
 /// 3. upper-cases the result (EXT-03), and
 /// 4. throws if any character is outside `ACGTN-` (EXT-01, strict mode).
+///
+/// When it is false (fgbio's `overrideReverseComplementUmis`, reached via
+/// `copy-umi --reverse-complement-r-umis false` and matching UMI-tools/fgpyo
+/// behavior), the `r` markers are instead *stripped* — every `r` is removed and
+/// the segment kept in its stated orientation — while the `+`→`-` translation,
+/// upper-casing, and validation are unchanged (`Umis.scala:114-115`).
 ///
 /// Reverse-complementing reuses [`fgumi_dna::dna::reverse_complement`], which
 /// complements `ACGT`, maps RNA `U`→`A`, and preserves `N` — matching fgbio's
@@ -49,41 +55,71 @@ fn is_valid_umi_char(b: u8) -> bool {
 /// # Errors
 /// Returns an error if the normalized UMI contains a character outside `ACGTN-`,
 /// mirroring fgbio's strict-mode `IllegalArgumentException`.
-pub(crate) fn normalize_read_name_umi(raw: &[u8]) -> Result<Vec<u8>> {
+pub(crate) fn normalize_read_name_umi(
+    raw: &[u8],
+    reverse_complement_prefixed: bool,
+) -> Result<Vec<u8>> {
     // fgbio keys the transform on whether an 'r' appears anywhere and whether a
     // '+' delimiter appears at an index > 0 (a leading '+' is not a delimiter).
     let has_revcomp_prefix = raw.contains(&REVCOMP_PREFIX);
     let has_delimiter = raw.iter().position(|&b| b == UMI_DELIMITER).is_some_and(|idx| idx > 0);
 
-    let transformed: Vec<u8> = match (has_revcomp_prefix, has_delimiter) {
-        // Reverse-complement each `r`-prefixed segment, join with '-'.
-        (true, true) => {
-            let mut out = Vec::with_capacity(raw.len());
-            for (i, segment) in raw.split(|&b| b == UMI_DELIMITER).enumerate() {
-                if i > 0 {
-                    out.push(b'-');
+    let transformed: Vec<u8> =
+        match (has_revcomp_prefix, has_delimiter, reverse_complement_prefixed) {
+            // Reverse-complement each `r`-prefixed segment, join with '-'.
+            (true, true, true) => {
+                // fgbio splits with JVM `String.split(Char)` (limit 0), which
+                // drops *trailing* empty segments but keeps internal ones. Rust's
+                // byte `split` keeps trailing empties, so `rAAAA+` would otherwise
+                // gain a spurious trailing `-` (`TTTT-` vs fgbio's `TTTT`). Trim
+                // the trailing empties to match, preserving internal empties.
+                let segments: Vec<&[u8]> = raw.split(|&b| b == UMI_DELIMITER).collect();
+                let keep = segments.iter().rposition(|s| !s.is_empty()).map_or(0, |i| i + 1);
+                let mut out = Vec::with_capacity(raw.len());
+                for (i, segment) in segments[..keep].iter().copied().enumerate() {
+                    if i > 0 {
+                        out.push(b'-');
+                    }
+                    match segment.split_first() {
+                        Some((&REVCOMP_PREFIX, rest)) => out.extend(reverse_complement(rest)),
+                        // `stripPrefix('r')` is a no-op when the segment is not
+                        // prefixed with 'r'; the segment is copied verbatim.
+                        _ => out.extend_from_slice(segment),
+                    }
                 }
-                match segment.split_first() {
-                    Some((&REVCOMP_PREFIX, rest)) => out.extend(reverse_complement(rest)),
-                    // `stripPrefix('r')` is a no-op when the segment is not
-                    // prefixed with 'r'; the segment is copied verbatim.
-                    _ => out.extend_from_slice(segment),
-                }
+                out
             }
-            out
-        }
-        // Single UMI: reverse-complement after stripping a leading 'r'.
-        (true, false) => {
-            let stripped = raw.strip_prefix(&[REVCOMP_PREFIX][..]).unwrap_or(raw);
-            reverse_complement(stripped)
-        }
-        // No revcomp: just translate the '+' delimiter to '-'.
-        (false, true) => raw.iter().map(|&b| if b == UMI_DELIMITER { b'-' } else { b }).collect(),
-        (false, false) => raw.to_vec(),
-    };
+            // Single UMI: reverse-complement after stripping a leading 'r'.
+            (true, false, true) => {
+                let stripped = raw.strip_prefix(&[REVCOMP_PREFIX][..]).unwrap_or(raw);
+                reverse_complement(stripped)
+            }
+            // Override (no revcomp), dual: remove every `r` marker, translate '+' to '-'.
+            // fgbio: `raw.replace("r","").replace(umiDelimiter, '-')`.
+            (true, true, false) => raw
+                .iter()
+                .filter(|&&b| b != REVCOMP_PREFIX)
+                .map(|&b| if b == UMI_DELIMITER { b'-' } else { b })
+                .collect(),
+            // Override (no revcomp), single: remove every `r` marker. fgbio: `raw.replace("r","")`.
+            (true, false, false) => raw.iter().copied().filter(|&b| b != REVCOMP_PREFIX).collect(),
+            // No `r` marker: just translate the '+' delimiter to '-'.
+            (false, true, _) => {
+                raw.iter().map(|&b| if b == UMI_DELIMITER { b'-' } else { b }).collect()
+            }
+            (false, false, _) => raw.to_vec(),
+        };
 
     // fgbio upper-cases the UMI after any reverse-complementing.
     let umi: Vec<u8> = transformed.iter().map(u8::to_ascii_uppercase).collect();
+
+    // A field that normalizes away to nothing (e.g. a bare `r`, stripped or
+    // reverse-complemented to empty) would pass the `ACGTN-` check vacuously and
+    // write an empty UMI, which only poisons downstream grouping. Reject it here
+    // so every caller (`extract`, `copy-umi`) inherits the guard.
+    if umi.is_empty() {
+        bail!("read-name UMI field normalizes to an empty UMI");
+    }
 
     // Strict mode: reject any character outside the SAM UMI alphabet.
     if let Some(&bad) = umi.iter().find(|&&b| !is_valid_umi_char(b)) {
@@ -102,6 +138,7 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
+    // Reverse-complement ON (fgbio default; `extract`'s mode).
     #[rstest]
     #[case::single(b"ACGT", b"ACGT")]
     #[case::lowercase_upcased(b"acgt", b"ACGT")]
@@ -112,9 +149,26 @@ mod tests {
     #[case::r_only_prefixed_segment(b"rAAAA+CCCC", b"TTTT-CCCC")]
     #[case::r_both_segments(b"rAAAA+rCCCC", b"TTTT-GGGG")]
     #[case::uracil_maps_to_a(b"rUACG", b"CGTA")]
-    #[case::trailing_plus(b"AAAA+", b"AAAA-")]
-    fn normalizes(#[case] raw: &[u8], #[case] expected: &[u8]) {
-        assert_eq!(normalize_read_name_umi(raw).unwrap(), expected);
+    #[case::trailing_plus_no_r(b"AAAA+", b"AAAA-")]
+    // JVM split (limit 0) drops trailing empties: `rAAAA+` -> ["rAAAA"] -> "TTTT",
+    // not "TTTT-". Internal empties are kept, so `rAAAA++CCCC` -> "TTTT--CCCC".
+    #[case::r_trailing_plus_dropped(b"rAAAA+", b"TTTT")]
+    #[case::r_double_trailing_plus(b"rAAAA++", b"TTTT")]
+    #[case::r_internal_empty_kept(b"rAAAA++CCCC", b"TTTT--CCCC")]
+    fn normalizes_revcomp(#[case] raw: &[u8], #[case] expected: &[u8]) {
+        assert_eq!(normalize_read_name_umi(raw, true).unwrap(), expected);
+    }
+
+    // Reverse-complement OFF (fgbio `overrideReverseComplementUmis`; UMI-tools/fgpyo):
+    // the `r` marker is stripped, not reverse-complemented.
+    #[rstest]
+    #[case::r_stripped_not_revcomped(b"rAAAA", b"AAAA")]
+    #[case::r_stripped_single_lowercase(b"racgt", b"ACGT")]
+    #[case::r_stripped_dual(b"rAAAA+CCCC", b"AAAA-CCCC")]
+    #[case::r_stripped_both_segments(b"rAAAA+rCCCC", b"AAAA-CCCC")]
+    #[case::no_r_unaffected(b"ACGT+CAGA", b"ACGT-CAGA")]
+    fn normalizes_strip_only(#[case] raw: &[u8], #[case] expected: &[u8]) {
+        assert_eq!(normalize_read_name_umi(raw, false).unwrap(), expected);
     }
 
     #[rstest]
@@ -122,7 +176,19 @@ mod tests {
     #[case::illegal_x(b"XYZ")]
     #[case::illegal_in_dual(b"ACGT+CCKC")]
     fn rejects_illegal_characters(#[case] raw: &[u8]) {
-        assert!(normalize_read_name_umi(raw).is_err());
+        assert!(normalize_read_name_umi(raw, true).is_err());
+        assert!(normalize_read_name_umi(raw, false).is_err());
+    }
+
+    // A field that normalizes away to nothing (a bare `r`, stripped/RC'd to empty)
+    // is rejected — an empty UMI would pass the `ACGTN-` check vacuously otherwise.
+    #[rstest]
+    #[case::bare_r(b"r")]
+    fn rejects_empty_after_normalization(#[case] raw: &[u8]) {
+        let rc_err = normalize_read_name_umi(raw, true).unwrap_err();
+        assert!(format!("{rc_err:#}").contains("empty"), "got: {rc_err:#}");
+        let strip_err = normalize_read_name_umi(raw, false).unwrap_err();
+        assert!(format!("{strip_err:#}").contains("empty"), "got: {strip_err:#}");
     }
 
     #[rstest]

--- a/src/lib/umi/read_name.rs
+++ b/src/lib/umi/read_name.rs
@@ -1,0 +1,138 @@
+//! Read-name UMI normalization shared across commands.
+//!
+//! Both `extract` (FASTQ read names) and `copy-umi` (BAM read names) take the raw
+//! UMI text from a read-name field and normalize it into the canonical `RX`-tag
+//! form. This module holds that normalization so the two commands stay in lock-step
+//! and byte-for-byte faithful to fgbio's `Umis.extractUmisFromReadName`
+//! (`Umis.scala:85-126`). Locating the raw UMI within the read name (which field,
+//! how strict about field count) is the caller's job and differs between commands;
+//! only the shared normalization lives here.
+
+use anyhow::{Result, bail};
+use fgumi_dna::dna::reverse_complement;
+
+/// Prefix marking a read-name UMI segment that must be reverse-complemented,
+/// matching fgbio `Umis.RevcompPrefix` (`Umis.scala:33`).
+pub(crate) const REVCOMP_PREFIX: u8 = b'r';
+
+/// Delimiter separating dual UMIs in a read name, translated to `-` on extraction,
+/// matching fgbio's `umiDelimiter` default (`Umis.scala:88`).
+pub(crate) const UMI_DELIMITER: u8 = b'+';
+
+/// Returns true if `b` is a valid SAM UMI character (`ACGTN-`), matching fgbio's
+/// `Umis.isValidUmiCharacter` (`Umis.scala:128-130`).
+///
+/// This is intentionally distinct from [`fgumi_umi::validate_umi`], which
+/// implements the more permissive `GroupReadsByUmi` counting rule (only rejects
+/// upper-case `N`); the read-name extraction path uses fgbio's strict alphabet.
+fn is_valid_umi_char(b: u8) -> bool {
+    matches!(b, b'A' | b'C' | b'G' | b'T' | b'N' | b'-')
+}
+
+/// Normalizes a UMI extracted from the last field of a read name, matching
+/// fgbio's `Umis.extractUmisFromReadName` (strict mode, as called by
+/// `FastqToBam`; `Umis.scala:85-126`).
+///
+/// With `reverseComplementPrefixedUmis` defaulting to true, fgbio:
+/// 1. reverse-complements any `r`-prefixed segment (EXT-04); when the UMI is
+///    `+`-delimited, only the `r`-prefixed segments are reverse-complemented,
+/// 2. translates the `+` dual-UMI delimiter to `-`,
+/// 3. upper-cases the result (EXT-03), and
+/// 4. throws if any character is outside `ACGTN-` (EXT-01, strict mode).
+///
+/// Reverse-complementing reuses [`fgumi_dna::dna::reverse_complement`], which
+/// complements `ACGT`, maps RNA `U`→`A`, and preserves `N` — matching fgbio's
+/// `Sequences.complement` over the bases a read-name UMI may contain. Any other
+/// character is passed through and then rejected by the `ACGTN-` validation
+/// below, mirroring fgbio's strict-mode rejection.
+///
+/// # Errors
+/// Returns an error if the normalized UMI contains a character outside `ACGTN-`,
+/// mirroring fgbio's strict-mode `IllegalArgumentException`.
+pub(crate) fn normalize_read_name_umi(raw: &[u8]) -> Result<Vec<u8>> {
+    // fgbio keys the transform on whether an 'r' appears anywhere and whether a
+    // '+' delimiter appears at an index > 0 (a leading '+' is not a delimiter).
+    let has_revcomp_prefix = raw.contains(&REVCOMP_PREFIX);
+    let has_delimiter = raw.iter().position(|&b| b == UMI_DELIMITER).is_some_and(|idx| idx > 0);
+
+    let transformed: Vec<u8> = match (has_revcomp_prefix, has_delimiter) {
+        // Reverse-complement each `r`-prefixed segment, join with '-'.
+        (true, true) => {
+            let mut out = Vec::with_capacity(raw.len());
+            for (i, segment) in raw.split(|&b| b == UMI_DELIMITER).enumerate() {
+                if i > 0 {
+                    out.push(b'-');
+                }
+                match segment.split_first() {
+                    Some((&REVCOMP_PREFIX, rest)) => out.extend(reverse_complement(rest)),
+                    // `stripPrefix('r')` is a no-op when the segment is not
+                    // prefixed with 'r'; the segment is copied verbatim.
+                    _ => out.extend_from_slice(segment),
+                }
+            }
+            out
+        }
+        // Single UMI: reverse-complement after stripping a leading 'r'.
+        (true, false) => {
+            let stripped = raw.strip_prefix(&[REVCOMP_PREFIX][..]).unwrap_or(raw);
+            reverse_complement(stripped)
+        }
+        // No revcomp: just translate the '+' delimiter to '-'.
+        (false, true) => raw.iter().map(|&b| if b == UMI_DELIMITER { b'-' } else { b }).collect(),
+        (false, false) => raw.to_vec(),
+    };
+
+    // fgbio upper-cases the UMI after any reverse-complementing.
+    let umi: Vec<u8> = transformed.iter().map(u8::to_ascii_uppercase).collect();
+
+    // Strict mode: reject any character outside the SAM UMI alphabet.
+    if let Some(&bad) = umi.iter().find(|&&b| !is_valid_umi_char(b)) {
+        bail!(
+            "Invalid UMI '{}' extracted from read name (illegal character '{}')",
+            String::from_utf8_lossy(&umi),
+            bad as char,
+        );
+    }
+
+    Ok(umi)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::single(b"ACGT", b"ACGT")]
+    #[case::lowercase_upcased(b"acgt", b"ACGT")]
+    #[case::plus_to_hyphen(b"ACGT+CAGA", b"ACGT-CAGA")]
+    #[case::already_hyphen(b"ACGT-CAGA", b"ACGT-CAGA")]
+    #[case::r_single_revcomped(b"rAAAA", b"TTTT")]
+    #[case::r_lowercase_revcomped(b"racgt", b"ACGT")]
+    #[case::r_only_prefixed_segment(b"rAAAA+CCCC", b"TTTT-CCCC")]
+    #[case::r_both_segments(b"rAAAA+rCCCC", b"TTTT-GGGG")]
+    #[case::uracil_maps_to_a(b"rUACG", b"CGTA")]
+    #[case::trailing_plus(b"AAAA+", b"AAAA-")]
+    fn normalizes(#[case] raw: &[u8], #[case] expected: &[u8]) {
+        assert_eq!(normalize_read_name_umi(raw).unwrap(), expected);
+    }
+
+    #[rstest]
+    #[case::illegal_k(b"CCKC")]
+    #[case::illegal_x(b"XYZ")]
+    #[case::illegal_in_dual(b"ACGT+CCKC")]
+    fn rejects_illegal_characters(#[case] raw: &[u8]) {
+        assert!(normalize_read_name_umi(raw).is_err());
+    }
+
+    #[rstest]
+    #[case::a_is_valid(b'A', true)]
+    #[case::n_is_valid(b'N', true)]
+    #[case::hyphen_is_valid(b'-', true)]
+    #[case::lowercase_invalid(b'a', false)]
+    #[case::plus_invalid(b'+', false)]
+    #[case::k_invalid(b'K', false)]
+    fn validates_umi_chars(#[case] b: u8, #[case] expected: bool) {
+        assert_eq!(is_valid_umi_char(b), expected);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use fgumi_lib::commands::command::Command;
 use fgumi_lib::commands::compare::Compare;
 #[cfg(feature = "compare")]
 use fgumi_lib::commands::compare::CompareMismatch;
+use fgumi_lib::commands::copy_umi::CopyUmi;
 use fgumi_lib::commands::correct::CorrectUmis;
 use fgumi_lib::commands::dedup::MarkDuplicates;
 use fgumi_lib::commands::downsample::Downsample;
@@ -146,12 +147,14 @@ enum Subcommand {
     #[command(display_order = 17)]
     Downsample(Downsample),
     #[command(display_order = 18)]
+    CopyUmi(CopyUmi),
+    #[command(display_order = 19)]
     Retag(Retag),
     #[cfg(feature = "compare")]
-    #[command(display_order = 19)]
+    #[command(display_order = 20)]
     Compare(Compare),
     #[cfg(feature = "simulate")]
-    #[command(display_order = 20)]
+    #[command(display_order = 21)]
     Simulate(Simulate),
 }
 
@@ -180,6 +183,7 @@ impl Subcommand {
             Self::SimplexMetrics(cmd) => cmd.execute(command_line),
             Self::Review(cmd) => cmd.execute(command_line),
             Self::Downsample(cmd) => cmd.execute(command_line),
+            Self::CopyUmi(cmd) => cmd.execute(command_line),
             Self::Retag(cmd) => cmd.execute(command_line),
             #[cfg(feature = "compare")]
             Self::Compare(cmd) => cmd.execute(command_line),

--- a/tests/integration/helpers/bam_generator.rs
+++ b/tests/integration/helpers/bam_generator.rs
@@ -238,6 +238,29 @@ pub fn to_record_buf(raw: &RawRecord) -> RecordBuf {
         .expect("raw_record_to_record_buf should succeed in test")
 }
 
+/// Records whose UMI lives in the last `:`-delimited field of the read name and
+/// which carry *no* `RX` tag — the input shape `copy-umi` consumes.
+///
+/// Two mapped reads at one position with Illumina-shaped names ending in a UMI
+/// field, so `copy-umi` writes a distinct `RX` per read (and an empty input
+/// yields a header-only file, keeping the output-depends-on-input axis honest).
+pub fn create_read_name_umi_records() -> Vec<RawRecord> {
+    ["inst:1:FC:1:1101:5:1:ACGT", "inst:1:FC:1:1101:5:2:TTGG"]
+        .iter()
+        .map(|name| {
+            let mut b = SamBuilder::new();
+            b.read_name(name.as_bytes())
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .ref_id(0)
+                .pos(100)
+                .mapq(60)
+                .cigar_ops(&[8 << 4]);
+            b.build()
+        })
+        .collect()
+}
+
 /// Creates a UMI family with specified parameters.
 ///
 /// All reads in the family are mapped to reference sequence 0 at position 100

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -21,6 +21,7 @@ mod test_compare_metrics_command;
 #[cfg(feature = "compare")]
 mod test_compare_mutation;
 mod test_consensus_downsampling;
+mod test_copy_umi_command;
 mod test_correct_command;
 mod test_dedup_command;
 mod test_downsample_command;

--- a/tests/integration/test_copy_umi_command.rs
+++ b/tests/integration/test_copy_umi_command.rs
@@ -115,9 +115,13 @@ fn copies_umi_to_rx(#[case] name: &str, #[case] expected_rx: &str) {
 // ============================================================================
 
 #[rstest]
-#[case::r_stripped_not_revcomped("blah:rAAAA", "AAAA")]
-#[case::r_stripped_dual("blah:rAAAA+CCCC", "AAAA-CCCC")]
-fn strip_only_does_not_reverse_complement(#[case] name: &str, #[case] expected_rx: &str) {
+#[case::r_stripped_not_revcomped("blah:rAAAA", "blah:rAAAA", "AAAA")]
+#[case::r_stripped_dual("blah:rAAAA+CCCC", "blah:rAAAA+CCCC", "AAAA-CCCC")]
+fn strip_only_does_not_reverse_complement(
+    #[case] name: &str,
+    #[case] expected_name: &str,
+    #[case] expected_rx: &str,
+) {
     let dir = TempDir::new().unwrap();
     let input = write_input(dir.path(), &[record_named(name)]);
     let output = dir.path().join("out.bam");
@@ -126,6 +130,7 @@ fn strip_only_does_not_reverse_complement(#[case] name: &str, #[case] expected_r
 
     let rows = read_name_and_rx(dir.path(), &output);
     assert_eq!(rows.len(), 1, "one input record must yield exactly one output record");
+    assert_eq!(rows[0].0, expected_name, "read name should be unchanged");
     assert_eq!(rows[0].1.as_deref(), Some(expected_rx));
 }
 
@@ -441,6 +446,7 @@ fn respects_non_default_field_delimiter() {
 
     let rows = read_name_and_rx(dir.path(), &output);
     assert_eq!(rows.len(), 1, "one input record must yield exactly one output record");
+    assert_eq!(rows[0].0, "a:b_c_ACGT", "read name should be unchanged");
     assert_eq!(rows[0].1.as_deref(), Some("ACGT"));
 }
 

--- a/tests/integration/test_copy_umi_command.rs
+++ b/tests/integration/test_copy_umi_command.rs
@@ -1,0 +1,490 @@
+//! End-to-end tests for the `copy-umi` command.
+//!
+//! These invoke `CopyUmi::execute()` in-process and validate that the UMI in the
+//! read name is copied to the `RX` tag with fgbio `CopyUmiFromReadName` parity:
+//! last-field location, `+`→`-` joining, `r`-prefix reverse-complementation (and
+//! its strip-only override), optional name trimming, tag overwrite/fail policy,
+//! and fail-fast on malformed names.
+
+use clap::Parser;
+use fgumi_lib::commands::command::Command;
+use fgumi_lib::commands::copy_umi::CopyUmi;
+use fgumi_raw_bam::{RawRecord, SamBuilder};
+use rstest::rstest;
+use std::collections::HashMap;
+use std::path::Path;
+use tempfile::TempDir;
+
+use crate::helpers::bam_generator::{create_minimal_header, transcode_bam_to_sam, write_bam};
+
+/// A minimal mapped record carrying the given read name (sequence/quals are fixed
+/// filler — `copy-umi` never touches them).
+fn record_named(name: &str) -> RawRecord {
+    let mut b = SamBuilder::new();
+    b.read_name(name.as_bytes())
+        .sequence(b"ACGT")
+        .qualities(&[30; 4])
+        .flags(0)
+        .ref_id(0)
+        .pos(99)
+        .mapq(60)
+        .cigar_ops(&[4 << 4]);
+    b.build()
+}
+
+/// As [`record_named`], but pre-populated with an `RX` tag to exercise the
+/// overwrite / fail-if-present policy.
+fn record_named_with_rx(name: &str, rx: &str) -> RawRecord {
+    let mut b = SamBuilder::new();
+    b.read_name(name.as_bytes())
+        .sequence(b"ACGT")
+        .qualities(&[30; 4])
+        .flags(0)
+        .ref_id(0)
+        .pos(99)
+        .mapq(60)
+        .cigar_ops(&[4 << 4])
+        .add_string_tag(fgumi_lib::sam::SamTag::RX, rx.as_bytes());
+    b.build()
+}
+
+/// Write `records` to a BAM in `dir` and return its path.
+fn write_input(dir: &Path, records: &[RawRecord]) -> std::path::PathBuf {
+    let path = dir.join("in.bam");
+    let header = create_minimal_header("chr1", 10_000);
+    write_bam(&path, &header, records);
+    path
+}
+
+/// Parse + run `copy-umi -i input -o output [extra...]`.
+fn run_copy_umi(input: &Path, output: &Path, extra: &[&str]) -> anyhow::Result<()> {
+    let mut args: Vec<String> = vec![
+        "copy-umi".into(),
+        "-i".into(),
+        input.display().to_string(),
+        "-o".into(),
+        output.display().to_string(),
+    ];
+    args.extend(extra.iter().map(|s| (*s).to_string()));
+    let cmd = CopyUmi::try_parse_from(args).expect("failed to parse copy-umi args");
+    cmd.execute("copy-umi test")
+}
+
+/// Read (`name`, `RX`) for every record in a BAM by transcoding to SAM text.
+fn read_name_and_rx(dir: &Path, bam: &Path) -> Vec<(String, Option<String>)> {
+    let sam = dir.join("out.sam");
+    transcode_bam_to_sam(bam, &sam);
+    std::fs::read_to_string(&sam)
+        .expect("read sam")
+        .lines()
+        .filter(|l| !l.starts_with('@'))
+        .map(|line| {
+            let fields: Vec<&str> = line.split('\t').collect();
+            let name = fields[0].to_string();
+            let rx = fields.iter().find_map(|f| f.strip_prefix("RX:Z:").map(str::to_string));
+            (name, rx)
+        })
+        .collect()
+}
+
+// ============================================================================
+// fgbio-parity: read name -> RX, reverse-complement ON (default)
+// ============================================================================
+
+#[rstest]
+#[case::single("inst:1:FC:1:1101:5:7:ACGT", "ACGT")]
+#[case::short_name("1:2:3:GGGG", "GGGG")]
+#[case::dual_plus_to_hyphen("blah:AAAA+CCCC", "AAAA-CCCC")]
+#[case::already_hyphen("blah:AAAA-CCCC", "AAAA-CCCC")]
+#[case::r_prefixed_revcomped("blah:rAAAA", "TTTT")]
+#[case::r_only_prefixed_segment("blah:rAAAA+CCCC", "TTTT-CCCC")]
+fn copies_umi_to_rx(#[case] name: &str, #[case] expected_rx: &str) {
+    let dir = TempDir::new().unwrap();
+    let input = write_input(dir.path(), &[record_named(name)]);
+    let output = dir.path().join("out.bam");
+    run_copy_umi(&input, &output, &[]).expect("copy-umi failed");
+
+    let rows = read_name_and_rx(dir.path(), &output);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].0, name, "read name should be unchanged without --remove-umi");
+    assert_eq!(rows[0].1.as_deref(), Some(expected_rx));
+}
+
+// ============================================================================
+// Reverse-complement OFF (strip-only): fgpyo / UMI-tools behavior
+// ============================================================================
+
+#[rstest]
+#[case::r_stripped_not_revcomped("blah:rAAAA", "AAAA")]
+#[case::r_stripped_dual("blah:rAAAA+CCCC", "AAAA-CCCC")]
+fn strip_only_does_not_reverse_complement(#[case] name: &str, #[case] expected_rx: &str) {
+    let dir = TempDir::new().unwrap();
+    let input = write_input(dir.path(), &[record_named(name)]);
+    let output = dir.path().join("out.bam");
+    run_copy_umi(&input, &output, &["--reverse-complement-r-umis", "false"])
+        .expect("copy-umi failed");
+
+    let rows = read_name_and_rx(dir.path(), &output);
+    assert_eq!(rows.len(), 1, "one input record must yield exactly one output record");
+    assert_eq!(rows[0].1.as_deref(), Some(expected_rx));
+}
+
+// ============================================================================
+// --remove-umi trims the UMI (and its delimiter) off the read name
+// ============================================================================
+
+#[test]
+fn remove_umi_trims_read_name() {
+    let dir = TempDir::new().unwrap();
+    let input = write_input(dir.path(), &[record_named("inst:1:FC:1:1101:5:7:ACGT+TTGG")]);
+    let output = dir.path().join("out.bam");
+    run_copy_umi(&input, &output, &["--remove-umi"]).expect("copy-umi failed");
+
+    let rows = read_name_and_rx(dir.path(), &output);
+    assert_eq!(rows.len(), 1, "one input record must yield exactly one output record");
+    assert_eq!(rows[0].0, "inst:1:FC:1:1101:5:7");
+    assert_eq!(rows[0].1.as_deref(), Some("ACGT-TTGG"));
+}
+
+// ============================================================================
+// Pre-existing RX: overwrite by default, error with --fail-if-tag-present
+// ============================================================================
+
+#[test]
+fn overwrites_existing_rx_by_default() {
+    let dir = TempDir::new().unwrap();
+    let input = write_input(dir.path(), &[record_named_with_rx("blah:ACGT", "STALEVAL")]);
+    let output = dir.path().join("out.bam");
+    run_copy_umi(&input, &output, &[]).expect("copy-umi failed");
+
+    let rows = read_name_and_rx(dir.path(), &output);
+    assert_eq!(rows.len(), 1, "one input record must yield exactly one output record");
+    assert_eq!(rows[0].1.as_deref(), Some("ACGT"), "stale RX should be replaced");
+}
+
+#[test]
+fn fail_if_tag_present_errors_on_existing_rx() {
+    let dir = TempDir::new().unwrap();
+    let input = write_input(dir.path(), &[record_named_with_rx("blah:ACGT", "STALEVAL")]);
+    let output = dir.path().join("out.bam");
+    let err = run_copy_umi(&input, &output, &["--fail-if-tag-present"])
+        .expect_err("should error when RX already present");
+    assert!(
+        format!("{err:#}").contains("already has an RX tag"),
+        "error should name the pre-existing RX tag, got: {err:#}"
+    );
+}
+
+// ============================================================================
+// Fail-fast on malformed read names — each error must name its actual cause,
+// so an unrelated failure cannot pass the test.
+// ============================================================================
+
+#[rstest]
+#[case::single_field("NAME", "no ':'-delimited UMI field")]
+#[case::empty_last_field("1:2:3:", "empty UMI field")]
+#[case::illegal_char("NAME:CCKC", "illegal character")]
+#[case::coordinate_not_a_umi("inst:1:FC:1:1101:5:7:10799", "illegal character")]
+#[case::empty_after_normalization("blah:r", "normalizes to an empty UMI")]
+fn errors_on_malformed_name(#[case] name: &str, #[case] expected_msg: &str) {
+    let dir = TempDir::new().unwrap();
+    let input = write_input(dir.path(), &[record_named(name)]);
+    let output = dir.path().join("out.bam");
+    let err =
+        run_copy_umi(&input, &output, &[]).expect_err(&format!("expected failure for '{name}'"));
+    assert!(
+        format!("{err:#}").contains(expected_msg),
+        "error for '{name}' should contain '{expected_msg}', got: {err:#}"
+    );
+}
+
+#[test]
+fn remove_umi_errors_when_it_would_empty_the_read_name() {
+    // A leading-delimiter name (`:ACGT`) has its UMI as the whole tail; trimming
+    // it would leave an empty QNAME, which must be rejected rather than written.
+    let dir = TempDir::new().unwrap();
+    let input = write_input(dir.path(), &[record_named(":ACGT")]);
+    let output = dir.path().join("out.bam");
+    let err = run_copy_umi(&input, &output, &["--remove-umi"])
+        .expect_err("should refuse to empty the read name");
+    assert!(
+        format!("{err:#}").contains("would leave an empty read name"),
+        "error should explain the empty-name refusal, got: {err:#}"
+    );
+}
+
+// ============================================================================
+// Idempotency: running twice (no trim) yields identical RX
+// ============================================================================
+
+#[test]
+fn idempotent_without_trim() {
+    let dir = TempDir::new().unwrap();
+    let input = write_input(dir.path(), &[record_named("blah:ACGT+TTGG")]);
+    let once = dir.path().join("once.bam");
+    let twice = dir.path().join("twice.bam");
+    run_copy_umi(&input, &once, &[]).expect("first pass");
+    run_copy_umi(&once, &twice, &[]).expect("second pass");
+
+    let a = read_name_and_rx(dir.path(), &once);
+    let dir2 = TempDir::new().unwrap();
+    let b = read_name_and_rx(dir2.path(), &twice);
+    assert_eq!(a.len(), 1, "first pass must yield exactly one output record");
+    assert_eq!(b.len(), 1, "second pass must yield exactly one output record");
+    assert_eq!(a, b, "copy-umi should be idempotent when the name still carries the UMI");
+}
+
+// ============================================================================
+// Metrics
+// ============================================================================
+
+/// Read the single metrics row as a `column -> value` map.
+fn read_metrics_row(path: &Path) -> HashMap<String, String> {
+    let text = std::fs::read_to_string(path).expect("read metrics");
+    let mut lines = text.lines();
+    let header: Vec<String> =
+        lines.next().expect("header line").split('\t').map(str::to_string).collect();
+    let values: Vec<String> =
+        lines.next().expect("value line").split('\t').map(str::to_string).collect();
+    assert_eq!(
+        header.len(),
+        values.len(),
+        "metrics header and value rows must have equal column counts"
+    );
+    assert!(lines.next().is_none(), "metrics file must contain exactly one data row");
+    header.into_iter().zip(values).collect()
+}
+
+#[test]
+fn writes_metrics_row() {
+    let dir = TempDir::new().unwrap();
+    let input = write_input(
+        dir.path(),
+        &[
+            record_named("blah:ACGT"),
+            record_named_with_rx("blah:CCGG", "STALE"),
+            record_named("blah:TTAA"),
+        ],
+    );
+    let output = dir.path().join("out.bam");
+    let metrics = dir.path().join("metrics.tsv");
+    run_copy_umi(&input, &output, &["-M", &metrics.display().to_string()])
+        .expect("copy-umi failed");
+
+    let row = read_metrics_row(&metrics);
+    assert_eq!(row["total_records"], "3");
+    assert_eq!(row["rx_written"], "3");
+    assert_eq!(row["rx_overwritten"], "1");
+    assert_eq!(row["names_trimmed"], "0");
+}
+
+#[test]
+fn metrics_count_trimmed_names_under_remove_umi() {
+    let dir = TempDir::new().unwrap();
+    let input = write_input(dir.path(), &[record_named("blah:ACGT"), record_named("blah:TTAA")]);
+    let output = dir.path().join("out.bam");
+    let metrics = dir.path().join("metrics.tsv");
+    run_copy_umi(&input, &output, &["--remove-umi", "-M", &metrics.display().to_string()])
+        .expect("copy-umi failed");
+
+    let row = read_metrics_row(&metrics);
+    assert_eq!(row["total_records"], "2");
+    assert_eq!(row["names_trimmed"], "2", "every record's name was trimmed");
+}
+
+// ============================================================================
+// Non-destructive contract: SEQ and unrelated tags survive; only RX changes
+// ============================================================================
+
+/// Every whitespace-split field of every non-header SAM line.
+fn read_sam_fields(dir: &Path, bam: &Path) -> Vec<Vec<String>> {
+    let sam = dir.join("fields.sam");
+    transcode_bam_to_sam(bam, &sam);
+    std::fs::read_to_string(&sam)
+        .expect("read sam")
+        .lines()
+        .filter(|l| !l.starts_with('@'))
+        .map(|line| line.split('\t').map(str::to_string).collect())
+        .collect()
+}
+
+#[test]
+fn preserves_sequence_and_unrelated_tags() {
+    // A record with a stale RX, an unrelated BX tag, and a known SEQ/POS.
+    let mut b = SamBuilder::new();
+    b.read_name(b"blah:ACGT")
+        .sequence(b"ACGTACGT")
+        .qualities(&[30; 8])
+        .flags(0)
+        .ref_id(0)
+        .pos(99)
+        .mapq(60)
+        .cigar_ops(&[8 << 4])
+        .add_string_tag(fgumi_lib::sam::SamTag::RX, b"STALE")
+        .add_string_tag(fgumi_lib::sam::SamTag::OX, b"KEEPME");
+    let dir = TempDir::new().unwrap();
+    let input = write_input(dir.path(), &[b.build()]);
+    let output = dir.path().join("out.bam");
+    run_copy_umi(&input, &output, &[]).expect("copy-umi failed");
+
+    // Exact-preservation oracle: transcode both input and output and compare the
+    // whole record. Only RX may change; everything else must be byte-for-byte equal.
+    let in_rows = read_sam_fields(dir.path(), &input);
+    let out_rows = read_sam_fields(dir.path(), &output);
+    assert_eq!(in_rows.len(), 1, "one input record must yield exactly one output record");
+    assert_eq!(out_rows.len(), 1, "one input record must yield exactly one output record");
+    let (in_rec, out_rec) = (&in_rows[0], &out_rows[0]);
+
+    // The 11 mandatory SAM fields (QNAME..QUAL) pass through untouched: QNAME,
+    // FLAG, RNAME, POS, MAPQ, CIGAR, RNEXT, PNEXT, TLEN, SEQ, QUAL.
+    assert_eq!(
+        in_rec[..11],
+        out_rec[..11],
+        "only RX may change; the 11 mandatory fields must be identical"
+    );
+
+    // The optional-tag multiset must match exactly once the expected RX rewrite is
+    // applied — catching any dropped, added, duplicated, or mutated tag, and a
+    // second RX. Sort both sides so tag order is not asserted.
+    let mut expected_tags: Vec<String> = in_rec[11..]
+        .iter()
+        .map(|t| if t.starts_with("RX:") { "RX:Z:ACGT".to_string() } else { t.clone() })
+        .collect();
+    expected_tags.sort();
+    let mut got_tags: Vec<String> = out_rec[11..].to_vec();
+    got_tags.sort();
+    assert_eq!(
+        got_tags, expected_tags,
+        "only RX:Z:STALE -> RX:Z:ACGT; every other tag preserved with no add/drop/dup"
+    );
+}
+
+// ============================================================================
+// Write-target guards: a write path that aliases the input is rejected
+// ============================================================================
+
+#[test]
+fn rejects_output_aliasing_input() {
+    let dir = TempDir::new().unwrap();
+    let input = write_input(dir.path(), &[record_named("blah:ACGT")]);
+    // Snapshot the whole input BAM so we can prove the rejection had no write
+    // side effect — an error message alone can be produced *after* a writer has
+    // already truncated the aliased file.
+    let before = std::fs::read(&input).expect("read input before");
+    // -o == -i would clobber the BAM being read; the guard must reject it.
+    let err = run_copy_umi(&input, &input, &[]).expect_err("should refuse to clobber the input");
+    assert!(
+        format!("{err:#}").contains("same file as --input"),
+        "error should name the input-aliasing conflict, got: {err:#}"
+    );
+    // The guard fires before any writer opens, so the input must be byte-for-byte
+    // intact — not truncated or partially rewritten.
+    let after = std::fs::read(&input).expect("read input after");
+    assert_eq!(after, before, "the input BAM must be untouched when the alias is rejected");
+}
+
+#[test]
+fn rejects_metrics_aliasing_input() {
+    // The metrics path is a second write target and gets the same clobber guard.
+    let dir = TempDir::new().unwrap();
+    let input = write_input(dir.path(), &[record_named("blah:ACGT")]);
+    let output = dir.path().join("out.bam");
+    let before = std::fs::read(&input).expect("read input before");
+    let err = run_copy_umi(&input, &output, &["-M", &input.display().to_string()])
+        .expect_err("should refuse to write metrics over the input");
+    assert!(
+        format!("{err:#}").contains("same file as --input"),
+        "error should name the input-aliasing conflict, got: {err:#}"
+    );
+    // Rejection happens before any writer opens: the input is untouched and no
+    // output BAM was created.
+    let after = std::fs::read(&input).expect("read input after");
+    assert_eq!(after, before, "the input BAM must be untouched when the metrics alias is rejected");
+    assert!(!output.exists(), "no output BAM should be created when the alias is rejected");
+}
+
+#[test]
+fn rejects_output_and_metrics_colliding() {
+    // Two write targets resolving to one path is rejected before any writer opens.
+    let dir = TempDir::new().unwrap();
+    let input = write_input(dir.path(), &[record_named("blah:ACGT")]);
+    let collide = dir.path().join("out.bam");
+    let before = std::fs::read(&input).expect("read input before");
+    let err = run_copy_umi(&input, &collide, &["-M", &collide.display().to_string()])
+        .expect_err("should refuse two writers to one path");
+    let msg = format!("{err:#}");
+    // The guard must fire specifically on the two-writers-one-path collision
+    // (naming both flags), not merely surface some unrelated parse/IO error.
+    assert!(
+        msg.contains("both write to") && msg.contains("--output") && msg.contains("--metrics"),
+        "error should name the --output/--metrics collision, got: {msg}"
+    );
+    // Rejection happens before either writer opens, so nothing was created and
+    // the input is untouched.
+    assert!(!collide.exists(), "no output should be written when the collision is rejected");
+    let after = std::fs::read(&input).expect("read input after");
+    assert_eq!(after, before, "the input BAM must be untouched when the collision is rejected");
+}
+
+// ============================================================================
+// --field-delimiter selects a non-default separator
+// ============================================================================
+
+#[test]
+fn respects_non_default_field_delimiter() {
+    // With `_` as the delimiter, the UMI is the last `_` field; the `:` in the
+    // name is ordinary content, not a delimiter.
+    let dir = TempDir::new().unwrap();
+    let input = write_input(dir.path(), &[record_named("a:b_c_ACGT")]);
+    let output = dir.path().join("out.bam");
+    run_copy_umi(&input, &output, &["--field-delimiter", "_"]).expect("copy-umi failed");
+
+    let rows = read_name_and_rx(dir.path(), &output);
+    assert_eq!(rows.len(), 1, "one input record must yield exactly one output record");
+    assert_eq!(rows[0].1.as_deref(), Some("ACGT"));
+}
+
+#[test]
+fn rejects_non_ascii_field_delimiter() {
+    // A single non-ASCII char parses as a `char` but is rejected at validation.
+    let dir = TempDir::new().unwrap();
+    let input = write_input(dir.path(), &[record_named("blah:ACGT")]);
+    let output = dir.path().join("out.bam");
+    let err = run_copy_umi(&input, &output, &["--field-delimiter", "€"])
+        .expect_err("non-ASCII delimiter must be rejected");
+    assert!(
+        format!("{err:#}").contains("single ASCII character"),
+        "error should explain the ASCII requirement, got: {err:#}"
+    );
+}
+
+// ============================================================================
+// The parallel pipeline path (--threads) produces the same result
+// ============================================================================
+
+#[test]
+fn runs_on_multiple_threads() {
+    let dir = TempDir::new().unwrap();
+    let names = ["blah:AAAA", "blah:CCCC", "blah:GGGG", "blah:TTTT"];
+    let input = write_input(dir.path(), &names.iter().map(|n| record_named(n)).collect::<Vec<_>>());
+    let output = dir.path().join("out.bam");
+    run_copy_umi(&input, &output, &["--threads", "4"]).expect("copy-umi failed");
+
+    // Compare the complete (QNAME, RX) rows in input order, not just the RX
+    // column: a threaded-path defect that reordered records or swapped read
+    // names while still emitting the expected RX set would pass an RX-only check.
+    let rows = read_name_and_rx(dir.path(), &output);
+    let want: Vec<(String, Option<String>)> = names
+        .iter()
+        .map(|n| {
+            // copy-umi copies the name's UMI into RX and leaves the name intact
+            // (no --remove-umi); `blah:<UMI>` → RX `<UMI>`.
+            let umi = n.strip_prefix("blah:").expect("test fixture name shape is blah:<UMI>");
+            ((*n).to_string(), Some(umi.to_string()))
+        })
+        .collect();
+    assert_eq!(
+        rows, want,
+        "the parallel path must preserve every record's QNAME and its copied RX, in input order"
+    );
+}

--- a/tests/integration/test_input_source_matrix.rs
+++ b/tests/integration/test_input_source_matrix.rs
@@ -39,8 +39,8 @@ use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{
     create_consensus_family, create_duplex_grouped_family, create_grouped_family,
-    create_minimal_header, create_single_strand_family, create_test_reference, create_umi_family,
-    transcode_bam_to_sam, write_bam,
+    create_minimal_header, create_read_name_umi_records, create_single_strand_family,
+    create_test_reference, create_umi_family, transcode_bam_to_sam, write_bam,
 };
 
 /// Whether a command is held to one of the properties [`CONTRACTS`] declares.
@@ -183,6 +183,13 @@ const CONTRACTS: &[IoContract] = &[
     },
     IoContract {
         command: "retag",
+        sam: Required,
+        stdin: Required,
+        stdout: Required,
+        output_depends_on_input: Required,
+    },
+    IoContract {
+        command: "copy-umi",
         sam: Required,
         stdin: Required,
         stdout: Required,
@@ -359,6 +366,8 @@ enum Shape {
     SimplexGrouped,
     /// Overlapping read pairs tagged `MI` + `MC`, the CODEC shape.
     Codec,
+    /// Reads with the UMI in the last `:`-field of the name and no `RX` tag.
+    ReadNameUmi,
 }
 
 /// The record shape `command` requires.
@@ -384,6 +393,9 @@ fn shape_for(command: &str) -> Shape {
         // CODEC gets duplex from a single overlapping pair rather than from two
         // strand-tagged templates, so it needs its own shape.
         "codec" => Shape::Codec,
+        // `copy-umi` reads the UMI from the read name and rejects names without
+        // one, so it needs names carrying a UMI field rather than tagged families.
+        "copy-umi" => Shape::ReadNameUmi,
         _ => Shape::Ungrouped,
     }
 }
@@ -429,6 +441,7 @@ fn write_fixture(dir: &Path, command: &str) -> Fixture {
                 [r1, r2]
             })
             .collect(),
+        Shape::ReadNameUmi => create_read_name_umi_records(),
     };
     write_bam(&bam, &header, &records);
 
@@ -525,6 +538,7 @@ fn invocation(command: &str) -> Option<Vec<&'static str>> {
             ]
         }
         "retag" => vec!["retag", "-i", "{input}", "-o", "{output}", "RX::copy::BX"],
+        "copy-umi" => vec!["copy-umi", "-i", "{input}", "-o", "{output}"],
         "duplex-metrics" => vec!["duplex-metrics", "-i", "{input}", "-o", "{output}"],
         "simplex-metrics" => vec!["simplex-metrics", "-i", "{input}", "-o", "{output}"],
         "downsample" => {


### PR DESCRIPTION
Closes #869.

Adds `fgumi copy-umi`, the port of fgbio's `CopyUmiFromReadName`: a non-destructive, streaming BAM→BAM command that copies the UMI embedded in each read name into the `RX` tag so downstream fgumi tools (which read UMIs only from `RX`) can consume it. This was the last remaining fgbio dependency for pipelines whose UMI arrives only in the read name (e.g. after `samtools fixmate`), and it composes in a pipe between alignment/fixmate and `fgumi sort`.

## What it does

- The UMI is the **last `--field-delimiter` (default `:`) field** of the read name, under fgbio's lenient last-field rule — no field-count requirement, unlike `extract`'s strict ≥8-field Illumina rule.
- It is normalized to the canonical SAM form via the shared normalizer: dual UMIs joined with `+` in the name become `-`-joined; `r`-prefixed segments are reverse-complemented back to the forward strand by default (`--reverse-complement-r-umis false` strips the marker instead, matching UMI-tools/fgpyo); the result is upper-cased and validated against `ACGTN-`.
- It runs on the unified BAM pipeline with `SingleRawRecordGrouper` (modeled on `filter`'s per-record path), so it honors `--threads` and the shared compression/scheduler/queue-memory options. It works on `RawRecord`, touching only the QNAME and the aux block, so alignments, `SEQ`, and unrelated tags pass through untouched.
- `--remove-umi` trims the UMI (and its delimiter) off the read name. `RX` is overwritten by default (`--fail-if-tag-present` errors instead), with an optional `-M` metrics report.
- Fail-fast on malformed names: too few fields, an empty last field, an invalid UMI, a field that normalizes to empty (e.g. a bare `r`), or a `--remove-umi` that would leave an empty read name.

## Design notes

- **Standalone command, not folded into `retag`.** `retag` is deliberately tag↔tag only ("never touches read names"); read-name handling stays out of it. `copy-umi` is the sanctioned home, mirroring fgbio's own split between `FastqToBam` (FASTQ) and `CopyUmiFromReadName` (BAM).
- **`RX` and the in-name `+` delimiter are hardcoded**, matching fgumi's opinionated tag vocabulary; `retag` handles alternate destination tags.
- **Empty/degenerate handling diverges from fgbio deliberately**: fgbio writes an empty `RX` for an empty field; `copy-umi` errors instead, since an empty `RX` only defers the failure to `group` (mixed UMI lengths) with a worse message.

## Suggested reading order

1. `refactor(umi): …` — a pure move lifting `normalize_read_name_umi` out of `extract` into `src/lib/umi/read_name.rs` as a shared free function, with no behavior change. Start here; it is small.
2. `feat(copy-umi): …` — the command itself, its tests, and the CLI/matrix wiring.

Note the parity fix called out in the second commit message: consolidating the normalizer also corrects a pre-existing fgbio-parity gap for an `r`-prefixed UMI field ending in a trailing `+` (e.g. `…:rACGT+`), which changes `extract`'s output for that narrow case toward fgbio parity (drops a spurious trailing `-`).

## Follow-up (separate PR)

A follow-up will bring `extract`'s FASTQ read-name path to the same lenient last-field parity, so the two commands share both the normalization and the field-location policy. The strict-vs-lenient default for `extract` (which affects `FastqToBam` parity) is the open decision to settle there.

## Testing

Full suite (`cargo ci-test`), `cargo ci-fmt`, `cargo ci-lint` (`-D warnings`), and the tag-literal check all pass. New coverage includes fgbio-parity vectors (RC on and strip-only, `+`→`-`, trailing/internal-empty split semantics), the non-destructive contract (SEQ/CIGAR/POS/QUAL and unrelated tags survive), `--field-delimiter`, `--threads`, overwrite/fail-if-present, metrics, write-target guards, and discriminating assertions on every error path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: outputs change for `RX`, read names, and `copy-umi` metrics, pinned by normalization, delimiter, overwrite, trimming, and metrics options; `unsafe`: none, and no `CLAUDE.md` allowlist update applies; memory/thread/backpressure policy: configurable queue memory, threading, and scheduler options are added.

Fix: Add `fgumi copy-umi` to extract normalized UMIs from BAM read names, write them to `RX`, and optionally trim read names.

- Add streaming, parallel BAM processing with overwrite protection and metrics.
- Share read-name UMI normalization with `extract`.
- Reject malformed or empty UMIs.
- Preserve alignment data and unrelated tags.
- Add CLI, README, I/O matrix, fixtures, and end-to-end tests.
- Enable migration from fgbio `CopyUmiFromReadName` before `fgumi sort`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->