### PR TITLE
[review-only] #870 split 2/2: pipeline tree + step ports

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,7 +14,14 @@ ci-publish-order = "run --package xtask -- check-publish-order"
 ci-doctest = "test --doc --workspace --features compare,simulate,profile-adjacency --locked"
 # Build the docs and fail on any rustdoc warning (e.g. broken intra-doc links).
 # RUSTDOCFLAGS="-D warnings" is set by the caller (CI job / pre-push).
-ci-doc = "doc --no-deps --workspace --features compare,simulate,profile-adjacency --locked"
+#
+# `--document-private-items` is load-bearing, not cosmetic. Without it rustdoc
+# only checks links on items it renders — i.e. public ones — so a broken link in
+# the doc comment of a private fn, a private field, or a `#[cfg(test)]` helper
+# passes silently. That is not hypothetical: several such links accumulated
+# undetected and had to be found by hand. The flag makes the docs job check every
+# doc comment in the workspace, which is what the job's name implies it does.
+ci-doc = "doc --no-deps --workspace --document-private-items --features compare,simulate,profile-adjacency --locked"
 # Run only the #[ignore]-d integration tests (the sort-correctness suites in
 # tests/integration/{test_sort_correctness,test_async_reader,test_sort_write_index}.rs).
 # They require the `samtools` binary on PATH — samtools builds the BAM fixtures,
@@ -34,7 +41,7 @@ ci-test-samtools = "nextest run --workspace --features compare,simulate,profile-
 # Run the concurrency stress tests (behind the `stress-tests` feature). Timing-
 # sensitive, so run on a nightly schedule (see .github/workflows/stress.yml) rather
 # than per-PR, where a flake would block unrelated changes.
-ci-test-stress = "nextest run --workspace --features compare,simulate,profile-adjacency,stress-tests --locked"
+ci-test-stress = "nextest run --workspace --features compare,simulate,profile-adjacency,stress-tests,fgumi-pipeline-io/stress-tests --locked"
 # Run tests with test-utils feature enabled (allows binary tests to use library test utilities)
 t = "test --features test-utils"
 # Generate and serve documentation locally (runs xtask then mdbook serve)

--- a/benches/pipeline_dispatch.rs
+++ b/benches/pipeline_dispatch.rs
@@ -1,0 +1,223 @@
+//! Dispatch-throughput benchmark for the typed-step pipeline runtime.
+//!
+//! This measures the runtime's *per-dispatch overhead*, not the work steps do:
+//! every step here is a near-no-op, so wall time is dominated by the scheduler
+//! loop, queue push/pop, and the reorder stage. That is exactly the path any
+//! change to the driver's inner loop lands on.
+//!
+//! It exists because the pipeline had no benchmark at all — no command on this
+//! branch drives it yet (the chain builders and command rewiring arrive later),
+//! so there was no way to tell whether a hot-path change cost anything.
+//!
+//! Read the numbers as *relative* only. Absolute throughput here is meaningless
+//! as a product metric (real steps decompress BGZF and parse records, which
+//! dwarfs dispatch); the point is A/B on the same host.
+
+use std::collections::VecDeque;
+use std::hint::black_box;
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use fgumi_pipeline_core::Unpushed;
+use fgumi_pipeline_core::builder::{Pipeline, PipelineConfig};
+use fgumi_pipeline_core::held::HeldSlot;
+use fgumi_pipeline_core::item::{HeapSize, Ordered};
+use fgumi_pipeline_core::outputs::OrderedBytesSingle;
+use fgumi_pipeline_core::queues::QueueSpec;
+use fgumi_pipeline_core::reorder::BranchOrdering;
+use fgumi_pipeline_core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+
+/// Per-edge byte budget. Large enough that the queues never bind — this
+/// benchmark measures dispatch cost, and backpressure stalls would swamp it
+/// with scheduling noise.
+const EDGE_LIMIT_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Items pushed through the chain per iteration.
+const N_ITEMS: u64 = 50_000;
+
+/// A minimal ordered item. `heap_size` is a small constant rather than 0 so the
+/// byte-bounded accounting does real work per item, as it would in production.
+#[derive(Clone, Copy)]
+struct Item {
+    ordinal: u64,
+}
+
+impl HeapSize for Item {
+    fn heap_size(&self) -> usize {
+        64
+    }
+}
+
+impl Ordered for Item {
+    fn ordinal(&self) -> u64 {
+        self.ordinal
+    }
+}
+
+/// Emits `n` items and finishes. `Exclusive` so it owns its cursor.
+struct CountingSource {
+    remaining: VecDeque<Item>,
+    held: HeldSlot<Unpushed<Item>>,
+}
+
+impl CountingSource {
+    fn new(n: u64) -> Self {
+        Self { remaining: (0..n).map(|ordinal| Item { ordinal }).collect(), held: HeldSlot::new() }
+    }
+}
+
+impl Step for CountingSource {
+    type Input = ();
+    type Outputs = OrderedBytesSingle<Item>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "BenchSource",
+            kind: StepKind::Exclusive,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: EDGE_LIMIT_BYTES }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        let Some(item) = self.remaining.pop_front() else {
+            return Ok(StepOutcome::Finished);
+        };
+        if let Err(unpushed) = ctx.outputs.push(item) {
+            self.held.put(unpushed);
+        }
+        Ok(StepOutcome::Progress)
+    }
+}
+
+/// A `Parallel` pass-through. Cloned per worker, so at `threads > 1` this is
+/// what puts several workers on the dispatch path at once.
+struct PassThrough {
+    held: HeldSlot<Unpushed<Item>>,
+}
+
+impl Step for PassThrough {
+    type Input = Item;
+    type Outputs = OrderedBytesSingle<Item>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "BenchPassThrough",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: EDGE_LIMIT_BYTES }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        let Some(item) = ctx.input.pop() else {
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        // A trivial amount of real work so the compiler cannot fold the step away.
+        let out = Item { ordinal: black_box(item).ordinal };
+        if let Err(unpushed) = ctx.outputs.push(out) {
+            self.held.put(unpushed);
+        }
+        Ok(StepOutcome::Progress)
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        Self { held: HeldSlot::new() }
+    }
+}
+
+/// Terminal sink; counts arrivals into a shared atomic so the run is verifiable.
+struct CountingSink {
+    seen: Arc<AtomicU64>,
+}
+
+impl Step for CountingSink {
+    type Input = Item;
+    type Outputs = ();
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "BenchSink",
+            kind: StepKind::Exclusive,
+            sticky: false,
+            output_queues: vec![],
+            branch_ordering: vec![],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        match ctx.input.pop() {
+            Some(item) => {
+                black_box(item);
+                self.seen.fetch_add(1, Ordering::Relaxed);
+                Ok(StepOutcome::Progress)
+            }
+            None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+            None => Ok(StepOutcome::NoProgress),
+        }
+    }
+}
+
+/// Run the chain once, asserting every item arrived.
+///
+/// The assert is not decoration: a timing harness reports a wall figure for a
+/// run that failed or short-circuited just as happily as for a correct one, and
+/// a chain that drops items would look like a speedup.
+fn run_chain(threads: usize) {
+    let seen = Arc::new(AtomicU64::new(0));
+    let sink_handle = Arc::clone(&seen);
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(CountingSource::new(N_ITEMS))
+        .chain(PassThrough { held: HeldSlot::new() })
+        .chain(CountingSink { seen: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("bench chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("bench chain runs");
+
+    assert_eq!(
+        seen.load(Ordering::Relaxed),
+        N_ITEMS,
+        "every item must reach the sink — a short run is an invalid measurement",
+    );
+}
+
+fn bench_dispatch(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pipeline_dispatch");
+    group.throughput(criterion::Throughput::Elements(N_ITEMS));
+    for threads in [1usize, 4, 8] {
+        group.bench_function(format!("threads_{threads}"), |b| {
+            b.iter(|| run_chain(threads));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_dispatch);
+criterion_main!(benches);

--- a/crates/fgumi-bam-io/Cargo.toml
+++ b/crates/fgumi-bam-io/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["bioinformatics", "bam", "sequencing", "ngs"]
 pedantic = { level = "deny", priority = -1 }
 
 [dependencies]
+ahash = { workspace = true }
 fgumi-raw-bam = { workspace = true, features = ["noodles"] }
 fgumi-bgzf = { workspace = true }
 noodles = { workspace = true, features = ["bam", "fasta", "sam", "bgzf", "core", "vcf"] }

--- a/crates/fgumi-bam-io/src/grouping.rs
+++ b/crates/fgumi-bam-io/src/grouping.rs
@@ -1,0 +1,1058 @@
+//! Shared grouping and decoded-record domain types.
+//!
+//! Used by both the group command path (`grouper`, `mi_group`,
+//! `commands::{group,dedup}` in the main crate) and the typed-step pipeline
+//! (`pipeline::steps::group`, `steps::parse::decode`).
+//!
+//! These are BAM-record domain types — pre-computed grouping keys, the
+//! decoded-record representation, the batching-weight and grouper traits.
+//! They live here in `fgumi-bam-io`, next to [`crate::MemoryEstimate`] and
+//! the [`fgumi_raw_bam`] raw-record helpers they operate on, rather than in
+//! the pipeline crate that merely consumes them.
+
+use std::io;
+use std::sync::Arc;
+
+use noodles::sam::alignment::record::data::field::Tag;
+
+use crate::library::LibraryIndex;
+use fgumi_raw_bam::{RawRecord, RawRecordView};
+
+pub use crate::mem_estimate::MemoryEstimate;
+
+// ============================================================================
+// GroupKey - Pre-computed grouping key for fast comparison in Group step
+// ============================================================================
+
+/// Pre-computed grouping key for fast comparison in Group step.
+///
+/// All fields are integers/hashes for O(1) comparison. This is computed during
+/// the parallel Decode step so the serial Group step only does integer comparisons.
+///
+/// For paired-end reads, positions are normalized so the lower position comes first.
+/// For single-end reads, the mate fields use `UNKNOWN_*` sentinel values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct GroupKey {
+    // Position info (normalized: lower position first)
+    /// Reference sequence index for position 1 (lower).
+    pub ref_id1: i32,
+    /// Unclipped 5' position for position 1.
+    pub pos1: i32,
+    /// Strand for position 1 (0=forward, 1=reverse).
+    pub strand1: u8,
+    /// Reference sequence index for position 2 (higher or mate).
+    pub ref_id2: i32,
+    /// Unclipped 5' position for position 2.
+    pub pos2: i32,
+    /// Strand for position 2.
+    pub strand2: u8,
+
+    // Grouping metadata
+    /// Library index (pre-computed from RG tag via header lookup).
+    pub library_idx: u16,
+    /// Hash of cell barcode (0 if none).
+    pub cell_hash: u64,
+
+    // For name-based grouping within position groups
+    /// Hash of QNAME for fast name comparison.
+    pub name_hash: u64,
+}
+
+impl GroupKey {
+    /// Sentinel value for unknown reference ID (unpaired reads).
+    pub const UNKNOWN_REF: i32 = i32::MAX;
+    /// Sentinel value for unknown position (unpaired reads).
+    pub const UNKNOWN_POS: i32 = i32::MAX;
+    /// Sentinel value for unknown strand (unpaired reads).
+    pub const UNKNOWN_STRAND: u8 = u8::MAX;
+
+    /// Create a `GroupKey` for a paired-end read with mate info.
+    ///
+    /// Positions are automatically normalized so the lower position comes first.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub fn paired(
+        ref_id: i32,
+        pos: i32,
+        strand: u8,
+        mate_ref_id: i32,
+        mate_pos: i32,
+        mate_strand: u8,
+        library_idx: u16,
+        cell_hash: u64,
+        name_hash: u64,
+    ) -> Self {
+        // Normalize: put lower position first (matching ReadInfo behavior)
+        let (ref_id1, pos1, strand1, ref_id2, pos2, strand2) =
+            if (ref_id, pos, strand) <= (mate_ref_id, mate_pos, mate_strand) {
+                (ref_id, pos, strand, mate_ref_id, mate_pos, mate_strand)
+            } else {
+                (mate_ref_id, mate_pos, mate_strand, ref_id, pos, strand)
+            };
+
+        Self { ref_id1, pos1, strand1, ref_id2, pos2, strand2, library_idx, cell_hash, name_hash }
+    }
+
+    /// Create a `GroupKey` for a single-end/unpaired read.
+    #[must_use]
+    pub fn single(
+        ref_id: i32,
+        pos: i32,
+        strand: u8,
+        library_idx: u16,
+        cell_hash: u64,
+        name_hash: u64,
+    ) -> Self {
+        Self {
+            ref_id1: ref_id,
+            pos1: pos,
+            strand1: strand,
+            ref_id2: Self::UNKNOWN_REF,
+            pos2: Self::UNKNOWN_POS,
+            strand2: Self::UNKNOWN_STRAND,
+            library_idx,
+            cell_hash,
+            name_hash,
+        }
+    }
+
+    /// Returns the position-only key for grouping by genomic position.
+    ///
+    /// This is used by `RecordPositionGrouper` to determine if records belong to
+    /// the same position group (ignoring name).
+    #[must_use]
+    pub fn position_key(&self) -> (i32, i32, u8, i32, i32, u8, u16, u64) {
+        (
+            self.ref_id1,
+            self.pos1,
+            self.strand1,
+            self.ref_id2,
+            self.pos2,
+            self.strand2,
+            self.library_idx,
+            self.cell_hash,
+        )
+    }
+
+    /// Whether this key carries a mate position, i.e. it was built by
+    /// [`Self::paired`] rather than [`Self::single`].
+    ///
+    /// `strand2` is set to [`Self::UNKNOWN_STRAND`] by the single-end
+    /// constructor, so it is the discriminator between the two shapes.
+    #[must_use]
+    pub fn has_mate_position(&self) -> bool {
+        self.strand2 != Self::UNKNOWN_STRAND
+    }
+}
+
+impl PartialOrd for GroupKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for GroupKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.position_key()
+            .cmp(&other.position_key())
+            .then_with(|| self.name_hash.cmp(&other.name_hash))
+    }
+}
+
+impl Default for GroupKey {
+    fn default() -> Self {
+        Self {
+            ref_id1: Self::UNKNOWN_REF,
+            pos1: Self::UNKNOWN_POS,
+            strand1: Self::UNKNOWN_STRAND,
+            ref_id2: Self::UNKNOWN_REF,
+            pos2: Self::UNKNOWN_POS,
+            strand2: Self::UNKNOWN_STRAND,
+            library_idx: 0,
+            cell_hash: 0,
+            name_hash: 0,
+        }
+    }
+}
+
+// ============================================================================
+// DecodedRecord - Record with pre-computed grouping key
+// ============================================================================
+
+/// A decoded BAM record with its pre-computed grouping key.
+///
+/// This is the output of the Decode step and input to the Group step.
+/// The key is computed during the parallel Decode step so that the
+/// serial Group step only needs to do fast integer comparisons.
+///
+/// # Cached-UMI invariant
+///
+/// `umi_value_offset` / `umi_value_len` cache the position of the UMI value
+/// *within* `data`. The invariant is: **the cache is only valid while `data` is
+/// unmodified.** Any mutation of `data` that could shift or overwrite the UMI
+/// value bytes invalidates the cache. To enforce this cheaply, the sole
+/// mutable-bytes accessor ([`Self::raw_bytes_mut`]) resets the cache to
+/// [`Self::UMI_OFFSET_UNCACHED`] on hand-out, so a `cached_umi()` read after a
+/// mutation falls back to a re-scan instead of slicing stale bytes.
+#[derive(Debug)]
+pub struct DecodedRecord {
+    /// Pre-computed grouping key.
+    pub key: GroupKey,
+    /// Raw BAM record bytes.
+    data: RawRecord,
+    /// Cached record-relative offset of the UMI tag's value bytes (i.e. the
+    /// first byte after the 2-byte tag header and the 1-byte type byte). The
+    /// slice `data[umi_value_offset..umi_value_offset + umi_value_len]` yields
+    /// the UMI bytes without the trailing NUL.
+    ///
+    /// Set to [`Self::UMI_OFFSET_UNCACHED`] when no UMI position was cached
+    /// during decode (UMI tag missing, not Z-typed, or caching disabled).
+    umi_value_offset: u32,
+    /// Cached UMI value length in bytes, paired with `umi_value_offset`.
+    umi_value_len: u16,
+}
+
+impl DecodedRecord {
+    /// Sentinel value for `umi_value_offset` indicating no cached UMI position.
+    /// Chosen as `u32::MAX` so it can never collide with a real BAM record
+    /// offset (BAM records are bounded well under 4 GiB).
+    pub const UMI_OFFSET_UNCACHED: u32 = u32::MAX;
+
+    /// Create a decoded record from raw bytes, skipping noodles decode.
+    ///
+    /// Accepts anything that converts `Into<RawRecord>` (e.g. a bare `Vec<u8>` or
+    /// an already-constructed `RawRecord`).
+    #[must_use]
+    pub fn from_raw_bytes(raw: impl Into<RawRecord>, key: GroupKey) -> Self {
+        Self {
+            key,
+            data: raw.into(),
+            umi_value_offset: Self::UMI_OFFSET_UNCACHED,
+            umi_value_len: 0,
+        }
+    }
+
+    /// Attach a cached UMI value position to this decoded record.
+    ///
+    /// `umi_value_offset` is the record-relative offset of the first UMI value
+    /// byte (after the tag header), and `umi_value_len` is the value length
+    /// (excluding any trailing NUL).
+    pub fn set_cached_umi(&mut self, umi_value_offset: u32, umi_value_len: u16) {
+        self.umi_value_offset = umi_value_offset;
+        self.umi_value_len = umi_value_len;
+    }
+
+    /// Returns the cached UMI bytes (without trailing NUL) if a position was
+    /// recorded during decode and still falls within the raw record bytes.
+    /// Returns `None` if no cache is set or the cached position is out of range.
+    #[must_use]
+    pub fn cached_umi(&self) -> Option<&[u8]> {
+        if self.umi_value_offset == Self::UMI_OFFSET_UNCACHED {
+            return None;
+        }
+        let start = self.umi_value_offset as usize;
+        let end = start.checked_add(self.umi_value_len as usize)?;
+        let value = self.data.as_ref().get(start..end)?;
+        // The cache only ever holds a Z-typed UMI value (NUL-free by the BAM
+        // spec; the trailing NUL is excluded by `set_cached_umi`). If a mutation
+        // shifted the record bytes such that this offset now lands on a different
+        // region, the slice would typically contain an interior NUL — a cheap,
+        // zero-release-cost canary for a stale cache that survived bounds checks.
+        debug_assert!(
+            !value.contains(&0),
+            "stale cached UMI: offset {start} sliced bytes containing an interior NUL \
+             (the record was likely mutated without invalidating the UMI cache)"
+        );
+        Some(value)
+    }
+
+    /// Returns the cached UMI offset ([`Self::UMI_OFFSET_UNCACHED`] when absent)
+    /// and length.
+    #[must_use]
+    pub fn cached_umi_position(&self) -> (u32, u16) {
+        (self.umi_value_offset, self.umi_value_len)
+    }
+
+    /// Returns the cached UMI `(offset, len)` position, or `None` when no
+    /// position was recorded during decode (the [`Self::UMI_OFFSET_UNCACHED`]
+    /// sentinel). Keeps the sentinel check at the owning layer so callers can
+    /// branch on a plain `Option` instead of comparing against the sentinel.
+    #[must_use]
+    pub fn cached_umi_position_opt(&self) -> Option<(u32, u16)> {
+        if self.umi_value_offset == Self::UMI_OFFSET_UNCACHED {
+            None
+        } else {
+            Some((self.umi_value_offset, self.umi_value_len))
+        }
+    }
+
+    /// Returns a reference to the raw bytes.
+    #[must_use]
+    pub fn raw_bytes(&self) -> &[u8] {
+        self.data.as_ref()
+    }
+
+    /// Immutable access to the underlying [`RawRecord`], for read-only
+    /// consumers (e.g. the FASTQ-encode step) that need the typed accessors
+    /// (`flags()`, sequence, qualities, tags) rather than the raw byte slice.
+    #[must_use]
+    pub fn record(&self) -> &RawRecord {
+        &self.data
+    }
+
+    /// Mutable access to the underlying [`RawRecord`]. Used by mid-chain
+    /// `Parallel` Process steps that need to mutate record bytes (e.g.,
+    /// MQ bumping, tag rewriting) without rebuilding the `DecodedRecord`
+    /// or invalidating its pre-computed `GroupKey`. Caller must not
+    /// change the record's identity (qname, library bytes, cell barcode)
+    /// — those feed `key`, which we don't recompute here.
+    ///
+    /// Handing out mutable bytes resets the cached UMI position to
+    /// [`Self::UMI_OFFSET_UNCACHED`] (see the type-level cached-UMI invariant):
+    /// a length-changing edit before the UMI tag could shift the value while
+    /// leaving the old offset in-bounds, so a later `cached_umi()` would slice
+    /// stale-but-valid bytes. Clearing forces a re-scan instead. This is a
+    /// single field store and the cache is only repopulated by the decode step.
+    pub fn raw_bytes_mut(&mut self) -> &mut RawRecord {
+        self.umi_value_offset = Self::UMI_OFFSET_UNCACHED;
+        self.umi_value_len = 0;
+        &mut self.data
+    }
+
+    /// Takes the [`RawRecord`] out.
+    #[must_use]
+    pub fn into_raw_bytes(self) -> RawRecord {
+        self.data
+    }
+}
+
+impl MemoryEstimate for DecodedRecord {
+    fn estimate_heap_size(&self) -> usize {
+        // RawRecord::capacity() returns the inner Vec<u8> capacity.
+        self.data.capacity()
+    }
+}
+// Vec<DecodedRecord>, Vec<RecordBuf>, Vec<u8>, RecordBuf, () — all provided
+// by the blanket/foreign impls in fgumi_bam_io::mem_estimate.
+
+// ============================================================================
+// GroupKeyConfig - Configuration for computing `GroupKey` during Decode
+// ============================================================================
+
+/// Configuration for computing `GroupKey` during the Decode step.
+///
+/// When this is provided to the pipeline, the Decode step will compute
+/// full `GroupKey` values for each record. This moves expensive computations
+/// (CIGAR parsing, tag extraction) from the serial Group step to the parallel
+/// Decode step.
+#[derive(Debug, Clone)]
+pub struct GroupKeyConfig {
+    /// Library index for fast RG → library lookup.
+    pub library_index: Arc<LibraryIndex>,
+    /// Tag used for cell barcode extraction. None skips cell extraction.
+    pub cell_tag: Option<Tag>,
+    /// When `true`, the Decode step computes only the read-name hash and
+    /// leaves the rest of the [`GroupKey`] at its default. Use for stages
+    /// that group by queryname (e.g. `correct`) and read only
+    /// [`GroupKey::name_hash`] — it skips the CIGAR 5′-position walk and the
+    /// aux-tag (RG/CB/MC) extraction pass entirely. See [`name_hash_key`].
+    pub name_hash_only: bool,
+    /// UMI tag (raw 2-byte form) whose value position should be cached on each
+    /// [`DecodedRecord`] during decode. `None` disables caching — downstream
+    /// code must fall back to scanning aux data. This is orthogonal to
+    /// `name_hash_only`: the UMI cache scan is gated solely on `umi_tag` being
+    /// set (in practice only the Group stage sets it).
+    pub umi_tag: Option<[u8; 2]>,
+}
+
+impl GroupKeyConfig {
+    /// Create a new `GroupKeyConfig` that computes the full position/cell key.
+    #[must_use]
+    pub fn new(library_index: LibraryIndex, cell_tag: Tag) -> Self {
+        Self {
+            library_index: Arc::new(library_index),
+            cell_tag: Some(cell_tag),
+            name_hash_only: false,
+            umi_tag: None,
+        }
+    }
+
+    /// Create a `GroupKeyConfig` without cell barcode extraction.
+    #[must_use]
+    pub fn new_raw_no_cell(library_index: LibraryIndex) -> Self {
+        Self {
+            library_index: Arc::new(library_index),
+            cell_tag: None,
+            name_hash_only: false,
+            umi_tag: None,
+        }
+    }
+
+    /// Create a `GroupKeyConfig` that computes only the read-name hash.
+    ///
+    /// For queryname-grouping stages (e.g. `correct`) whose grouper reads only
+    /// [`GroupKey::name_hash`]; skips the CIGAR position walk and the aux-tag
+    /// extraction pass. `library_index` is retained (unused for the key) so
+    /// the config shape is uniform across the pipeline.
+    #[must_use]
+    pub fn name_hash_only(library_index: LibraryIndex) -> Self {
+        Self {
+            library_index: Arc::new(library_index),
+            cell_tag: None,
+            name_hash_only: true,
+            umi_tag: None,
+        }
+    }
+
+    /// Enable UMI position caching for the given raw 2-byte UMI tag (e.g. `*b"RX"`).
+    ///
+    /// The Decode step will record the UMI value's record-relative position on
+    /// each [`DecodedRecord`] so downstream UMI lookups can slice it directly
+    /// via [`DecodedRecord::cached_umi`] without re-scanning aux data.
+    #[must_use]
+    pub fn with_umi_tag(mut self, umi_tag: [u8; 2]) -> Self {
+        self.umi_tag = Some(umi_tag);
+        self
+    }
+}
+
+impl Default for GroupKeyConfig {
+    fn default() -> Self {
+        Self {
+            library_index: Arc::new(LibraryIndex::default()),
+            cell_tag: Some(Tag::from([b'C', b'B'])), // Default cell barcode tag (CB)
+            name_hash_only: false,
+            umi_tag: None,
+        }
+    }
+}
+
+/// Hash a record's read name, mapping an empty name to `hash_name(None)` so the
+/// raw path matches the noodles path (which sees `None` for an empty name).
+///
+/// Shared by [`name_hash_key`] and [`compute_group_key_from_raw`]: both must
+/// produce the same hash for the same record, and a second copy of this block
+/// could drift out of parity silently.
+fn raw_name_hash(raw: &[u8]) -> u64 {
+    let name = fgumi_raw_bam::read_name(raw);
+    if name.is_empty() {
+        LibraryIndex::hash_name(None)
+    } else {
+        LibraryIndex::hash_name(Some(name))
+    }
+}
+
+/// Compute a [`GroupKey`] containing only the read-name hash, leaving all
+/// position/strand/library/cell fields at their default.
+///
+/// Reproduces exactly the `name_hash` that [`compute_group_key_from_raw`]
+/// computes (empty name → `hash_name(None)`), so a queryname grouper sees an
+/// identical hash. Skips the CIGAR 5′-position walk and the RG/CB/MC aux-tag
+/// extraction pass.
+///
+/// # Panics
+///
+/// Panics if `raw` is not a validated BAM record payload (same contract as
+/// [`compute_group_key_from_raw`]).
+#[must_use]
+pub fn name_hash_key(raw: &[u8]) -> GroupKey {
+    GroupKey { name_hash: raw_name_hash(raw), ..GroupKey::default() }
+}
+
+/// Compute a `GroupKey` directly from raw BAM bytes, matching `compute_group_key()` exactly.
+///
+/// Uses 1-based coordinate helpers to produce identical keys to the noodles path.
+///
+/// # Panics
+///
+/// Panics if `raw` is not a validated BAM record payload (as produced by the BAM
+/// reader / raw-record pipeline). Callers must not pass arbitrary external bytes;
+/// raw-field accessors will panic on malformed or truncated input.
+#[must_use]
+pub fn compute_group_key_from_raw(
+    raw: &[u8],
+    library_index: &LibraryIndex,
+    cell_tag: Option<noodles::sam::alignment::record::data::field::Tag>,
+) -> GroupKey {
+    // Extract name hash (match noodles path: empty name → None → hash 0)
+    let name_hash = raw_name_hash(raw);
+
+    // Check secondary/supplementary
+    let flg = RawRecordView::new(raw).flags();
+    let is_secondary = (flg & fgumi_raw_bam::flags::SECONDARY) != 0;
+    let is_supplementary = (flg & fgumi_raw_bam::flags::SUPPLEMENTARY) != 0;
+    if is_secondary || is_supplementary {
+        // A secondary/supplementary read cannot compute its own template
+        // coordinate (it lacks its own primary's position). When `fgumi zipper`
+        // has stamped the exact coordinate into `tc`, key on it so the read
+        // groups into the same position group as its primary — instead of an
+        // UNKNOWN position that relies on the read sorting adjacent to its
+        // primary. Library/cell are extracted the same way as primaries so the
+        // position key matches (they share their template's RG/CB).
+        let aux_data = fgumi_raw_bam::aux_data_slice(raw);
+        if let Some([tid1, pos1, neg1, tid2, pos2, neg2]) =
+            fgumi_raw_bam::read_tc_template_coordinate(aux_data)
+        {
+            let cell_tag_bytes = cell_tag.map_or([0u8; 2], |t| [t.as_ref()[0], t.as_ref()[1]]);
+            let aux_tags = fgumi_raw_bam::extract_aux_string_tags(aux_data, cell_tag_bytes, None);
+            let library_idx =
+                aux_tags.rg.map_or(0, |rg| library_index.get(LibraryIndex::hash_rg(rg)));
+            let cell_hash = aux_tags.cell.map_or(0, |cb| LibraryIndex::hash_cell_barcode(Some(cb)));
+            return GroupKey::paired(
+                tid1,
+                pos1,
+                u8::from(neg1 != 0),
+                tid2,
+                pos2,
+                u8::from(neg2 != 0),
+                library_idx,
+                cell_hash,
+                name_hash,
+            );
+        }
+        return GroupKey { name_hash, ..GroupKey::default() };
+    }
+
+    // Own position (1-based, matching noodles) — zero-allocation CIGAR iteration
+    let reverse = (flg & fgumi_raw_bam::flags::REVERSE) != 0;
+    let own_pos = fgumi_raw_bam::unclipped_5prime_from_raw_bam(raw);
+
+    // A mapped record with an empty or truncated CIGAR has no computable
+    // unclipped 5' position, so `unclipped_5prime_from_raw_bam` returns the
+    // `i32::MAX` sentinel. Fall back to the name-only key rather than letting the
+    // sentinel reach a position slot — otherwise distinct templates sharing
+    // ref/strand/library/cell would collide on `i32::MAX` (`position_key`
+    // excludes `name_hash`). Matches the secondary/supplementary fallback above.
+    if own_pos == i32::MAX {
+        return GroupKey { name_hash, ..GroupKey::default() };
+    }
+
+    let own_ref_id = fgumi_raw_bam::ref_id(raw);
+    let strand = u8::from(reverse);
+
+    // Single-pass aux tag extraction (RG, cell barcode, MC)
+    let aux_data = fgumi_raw_bam::aux_data_slice(raw);
+    let cell_tag_bytes = cell_tag.map_or([0u8; 2], |t| [t.as_ref()[0], t.as_ref()[1]]);
+    let aux_tags = fgumi_raw_bam::extract_aux_string_tags(aux_data, cell_tag_bytes, None);
+
+    let library_idx = if let Some(rg) = aux_tags.rg {
+        let rg_hash = LibraryIndex::hash_rg(rg);
+        library_index.get(rg_hash)
+    } else {
+        0
+    };
+
+    let cell_hash =
+        if let Some(cb) = aux_tags.cell { LibraryIndex::hash_cell_barcode(Some(cb)) } else { 0 };
+
+    // Check if paired
+    let is_paired = (flg & fgumi_raw_bam::flags::PAIRED) != 0;
+    if !is_paired {
+        return GroupKey::single(own_ref_id, own_pos, strand, library_idx, cell_hash, name_hash);
+    }
+
+    // Mate info — guard against MATE_UNMAPPED (matching noodles path)
+    let mate_unmapped = (flg & fgumi_raw_bam::flags::MATE_UNMAPPED) != 0;
+    let mate_reverse = (flg & fgumi_raw_bam::flags::MATE_REVERSE) != 0;
+    let mate_strand = u8::from(mate_reverse);
+    let raw_mate_ref_id = fgumi_raw_bam::mate_ref_id(raw);
+    let raw_mate_pos = fgumi_raw_bam::mate_pos(raw);
+
+    // Get mate unclipped 5' position via MC tag (skip if mate is unmapped)
+    let mate_pos_result = if mate_unmapped {
+        None
+    } else {
+        aux_tags
+            .mc
+            .map(|mc| fgumi_raw_bam::mate_unclipped_5prime_1based(raw_mate_pos, mate_reverse, mc))
+    };
+
+    match mate_pos_result {
+        Some(mp) => GroupKey::paired(
+            own_ref_id,
+            own_pos,
+            strand,
+            raw_mate_ref_id,
+            mp,
+            mate_strand,
+            library_idx,
+            cell_hash,
+            name_hash,
+        ),
+        None => {
+            // No MC tag — fall back to single-end behavior
+            GroupKey::single(own_ref_id, own_pos, strand, library_idx, cell_hash, name_hash)
+        }
+    }
+}
+
+/// Groups a stream of in-order [`DecodedRecord`]s into completed groups.
+///
+/// Implementors maintain partial groups across `add_records` calls and emit
+/// completed ones; `finish` flushes any trailing partial group at EOF. Used
+/// by the pipeline's Group step and the standalone grouping commands.
+pub trait Grouper: Send {
+    /// The type of group produced by this grouper.
+    type Group: Send;
+
+    /// Add decoded records to the grouper.
+    ///
+    /// Records are guaranteed to be in order (from template-coordinate sorted BAM).
+    /// The grouper maintains partial groups waiting for more records.
+    ///
+    /// Each `DecodedRecord` contains the record plus a pre-computed `GroupKey`
+    /// for fast comparison (position, name hash, library, etc.).
+    ///
+    /// Returns completed groups (may be empty if more records are needed).
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if grouping logic encounters invalid data.
+    fn add_records(&mut self, records: Vec<DecodedRecord>) -> io::Result<Vec<Self::Group>>;
+
+    /// Signal that no more input will arrive (EOF).
+    ///
+    /// Returns any remaining partial group.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if finalizing the grouper fails.
+    fn finish(&mut self) -> io::Result<Option<Self::Group>>;
+
+    /// Returns true if the grouper has a partial group.
+    fn has_pending(&self) -> bool;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fgumi_raw_bam::SamBuilder;
+    use fgumi_raw_bam::SamTag;
+    use fgumi_raw_bam::flags;
+
+    // ========================================================================
+    // compute_group_key_from_raw — primary (fully-populated) path
+    // ========================================================================
+
+    /// Read group `RG1` resolves to library `libA`; `RG2` to `libB`.
+    fn library_index_with_two_groups() -> LibraryIndex {
+        use noodles::sam::header::record::value::Map;
+        use noodles::sam::header::record::value::map::ReadGroup;
+        use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
+
+        let mut header = noodles::sam::Header::builder();
+        for (id, library) in [("RG1", "libA"), ("RG2", "libB")] {
+            let rg = Map::<ReadGroup>::builder()
+                .insert(rg_tag::LIBRARY, String::from(library))
+                .build()
+                .expect("read group builds");
+            header = header.add_read_group(bstr::BString::from(id), rg);
+        }
+        LibraryIndex::from_header(&header.build())
+    }
+
+    /// Build one mapped mate of a pair carrying `RG`, `CB` and `MC`.
+    fn paired_record_with_tags(
+        pos: i32,
+        mate_pos: i32,
+        reverse: bool,
+        mate_reverse: bool,
+    ) -> fgumi_raw_bam::RawRecord {
+        let mut flag = flags::PAIRED;
+        if reverse {
+            flag |= flags::REVERSE;
+        }
+        if mate_reverse {
+            flag |= flags::MATE_REVERSE;
+        }
+        let mut b = SamBuilder::new();
+        b.ref_id(0)
+            .pos(pos)
+            .flags(flag)
+            .mate_ref_id(0)
+            .mate_pos(mate_pos)
+            .read_name(b"pair_full")
+            .cigar_ops(&[cigar_m(50)])
+            .sequence(b"ACGT")
+            .qualities(&[30, 30, 30, 30])
+            .add_string_tag(SamTag::RG, b"RG1")
+            .add_string_tag(SamTag::CB, b"ACGTACGTA")
+            .add_string_tag(SamTag::MC, b"50M");
+        b.build()
+    }
+
+    /// The fully-populated branch: paired, mate mapped, `MC` present, `RG`
+    /// resolving through a non-default `LibraryIndex`, and a cell barcode read via
+    /// `cell_tag`. Every other test in this module lands on a fallback (secondary,
+    /// supplementary, or paired-without-`MC`) with `LibraryIndex::default()` and
+    /// `cell_tag: None`, so `library_idx`, `cell_hash` and the mate slot are
+    /// otherwise never exercised — and all three participate in key equality.
+    #[test]
+    fn paired_with_mc_populates_mate_library_and_cell_fields() {
+        let lib = library_index_with_two_groups();
+        let cb = noodles::sam::alignment::record::data::field::Tag::CELL_BARCODE_ID;
+
+        let rec = paired_record_with_tags(1000, 1200, false, true);
+        let key = compute_group_key_from_raw(rec.as_ref(), &lib, Some(cb));
+
+        // Mate slot is populated, not left at the single-end sentinels.
+        assert_ne!(key.ref_id2, GroupKey::UNKNOWN_REF, "MC must populate the mate slot");
+        assert_ne!(key.strand2, GroupKey::UNKNOWN_STRAND);
+
+        // Pin the mate coordinate: it must be the MC-derived unclipped 5' position,
+        // not the raw `mate_pos`. `!= UNKNOWN_POS` alone would accept a wrong
+        // CIGAR walk.
+        let expected_mate_pos = fgumi_raw_bam::mate_unclipped_5prime_1based(
+            fgumi_raw_bam::mate_pos(rec.as_ref()),
+            true,
+            b"50M",
+        );
+        assert_eq!(key.pos2, expected_mate_pos, "mate slot must hold the MC-derived position");
+
+        // RG resolved through the index — not the unknown bucket.
+        assert_eq!(key.library_idx, lib.get(LibraryIndex::hash_rg(b"RG1")));
+        assert_ne!(key.library_idx, 0, "RG1 must resolve to a real library");
+
+        // Cell barcode hashed because `cell_tag` named CB.
+        assert_eq!(key.cell_hash, LibraryIndex::hash_cell_barcode(Some(b"ACGTACGTA")));
+        assert_ne!(key.cell_hash, 0);
+
+        assert_eq!(key.name_hash, LibraryIndex::hash_name(Some(b"pair_full")));
+
+        // Own slot holds this record's own unclipped 5' position.
+        assert_eq!(key.pos1, fgumi_raw_bam::unclipped_5prime_from_raw_bam(rec.as_ref()));
+        assert_eq!(key.ref_id1, fgumi_raw_bam::ref_id(rec.as_ref()));
+    }
+
+    /// Both mates of the same template must normalize to one key — this is what
+    /// makes them group together. The mate sees own/mate swapped and the strands
+    /// exchanged.
+    #[test]
+    fn paired_with_mc_normalizes_both_mates_to_the_same_key() {
+        let lib = library_index_with_two_groups();
+        let cb = noodles::sam::alignment::record::data::field::Tag::CELL_BARCODE_ID;
+
+        let forward = paired_record_with_tags(1000, 1200, false, true);
+        let reverse = paired_record_with_tags(1200, 1000, true, false);
+
+        let key_forward = compute_group_key_from_raw(forward.as_ref(), &lib, Some(cb));
+        let key_reverse = compute_group_key_from_raw(reverse.as_ref(), &lib, Some(cb));
+
+        assert_eq!(key_forward, key_reverse, "both mates of a template must share one key");
+    }
+
+    /// A secondary/supplementary read cannot derive its own template coordinate,
+    /// so `fgumi zipper` stamps the primary's into the `tc` aux array. Keying on
+    /// it puts the read in the SAME position group as its primary; without it the
+    /// read falls back to a name-only key and relies on sorting adjacency.
+    #[test]
+    fn secondary_with_tc_tag_keys_on_the_stamped_template_coordinate() {
+        let lib = library_index_with_two_groups();
+
+        let mut b = SamBuilder::new();
+        b.ref_id(0)
+            .pos(5000)
+            .flags(flags::PAIRED | flags::SECONDARY)
+            .read_name(b"sec_with_tc")
+            .cigar_ops(&[cigar_m(50)])
+            .sequence(b"ACGT")
+            .qualities(&[30, 30, 30, 30])
+            .add_string_tag(SamTag::RG, b"RG1")
+            // tc = [tid1, pos1, neg1, tid2, pos2, neg2] — the primary's coordinate.
+            .add_array_i32(SamTag::TC, &[0, 1001, 0, 0, 1249, 1]);
+        let rec = b.build();
+
+        let key = compute_group_key_from_raw(rec.as_ref(), &lib, None);
+
+        // Both slots come from `tc`, NOT from this record's own pos (5000).
+        assert_eq!((key.ref_id1, key.pos1, key.strand1), (0, 1001, 0));
+        assert_eq!((key.ref_id2, key.pos2, key.strand2), (0, 1249, 1));
+        assert_ne!(key.pos1, 5001, "the record's own position must not be used");
+
+        // Library still resolves, so the key matches its primary's.
+        assert_eq!(key.library_idx, lib.get(LibraryIndex::hash_rg(b"RG1")));
+        assert_eq!(key.name_hash, LibraryIndex::hash_name(Some(b"sec_with_tc")));
+    }
+
+    /// Without a `tc` tag the secondary path still falls back to the name-only
+    /// key — including for a mapped record with an EMPTY cigar, where
+    /// `unclipped_5prime_from_raw_bam` returns `i32::MAX`. The fallback must not
+    /// leak that sentinel into a position slot.
+    #[test]
+    fn secondary_without_tc_falls_back_to_name_only_even_with_an_empty_cigar() {
+        let lib = library_index_with_two_groups();
+
+        let mut b = SamBuilder::new();
+        b.ref_id(0)
+            .pos(5000)
+            .flags(flags::SUPPLEMENTARY)
+            .read_name(b"sup_no_tc")
+            .cigar_ops(&[])
+            .sequence(b"ACGT")
+            .qualities(&[30, 30, 30, 30]);
+        let rec = b.build();
+
+        let key = compute_group_key_from_raw(rec.as_ref(), &lib, None);
+
+        assert_eq!(key, GroupKey { name_hash: key.name_hash, ..GroupKey::default() });
+        assert_eq!(key.name_hash, LibraryIndex::hash_name(Some(b"sup_no_tc")));
+        assert_eq!(key.pos1, GroupKey::default().pos1, "no i32::MAX sentinel may leak in");
+    }
+
+    /// The PRIMARY path has the same sentinel hazard: a mapped, unpaired primary
+    /// with an empty CIGAR has no computable unclipped 5' position, so it must
+    /// fall back to the name-only key too. Without the guard the `i32::MAX`
+    /// sentinel would reach `pos1` and merge distinct templates sharing
+    /// ref/strand/library/cell (`position_key` excludes `name_hash`).
+    #[test]
+    fn primary_with_empty_cigar_falls_back_to_name_only() {
+        let lib = library_index_with_two_groups();
+
+        // Default flags (0) => mapped, unpaired, primary.
+        let mut b = SamBuilder::new();
+        b.ref_id(0)
+            .pos(5000)
+            .read_name(b"primary_no_cigar")
+            .cigar_ops(&[])
+            .sequence(b"ACGT")
+            .qualities(&[30, 30, 30, 30]);
+        let rec = b.build();
+
+        let key = compute_group_key_from_raw(rec.as_ref(), &lib, None);
+
+        assert_eq!(key, GroupKey { name_hash: key.name_hash, ..GroupKey::default() });
+        assert_eq!(key.name_hash, LibraryIndex::hash_name(Some(b"primary_no_cigar")));
+        assert_eq!(key.pos1, GroupKey::default().pos1, "no i32::MAX sentinel may leak in");
+    }
+
+    /// `library_idx` is part of key equality: the same position read under a
+    /// different read group must NOT group with it.
+    #[test]
+    fn differing_library_splits_the_key() {
+        let lib = library_index_with_two_groups();
+
+        let mut b = SamBuilder::new();
+        b.ref_id(0)
+            .pos(1000)
+            .flags(flags::PAIRED)
+            .mate_ref_id(0)
+            .mate_pos(1200)
+            .read_name(b"pair_full")
+            .cigar_ops(&[cigar_m(50)])
+            .sequence(b"ACGT")
+            .qualities(&[30, 30, 30, 30])
+            .add_string_tag(SamTag::RG, b"RG2")
+            .add_string_tag(SamTag::MC, b"50M");
+        let other_library = b.build();
+
+        let key_a = compute_group_key_from_raw(
+            paired_record_with_tags(1000, 1200, false, true).as_ref(),
+            &lib,
+            None,
+        );
+        let key_b = compute_group_key_from_raw(other_library.as_ref(), &lib, None);
+
+        assert_ne!(key_a.library_idx, key_b.library_idx);
+        assert_ne!(key_a, key_b, "a different library must not group with the first");
+    }
+
+    /// CIGAR op `(len << 4) | op_code`; op 0 = `M`.
+    fn cigar_m(len: u32) -> u32 {
+        len << 4
+    }
+
+    // ========================================================================
+    // GroupKey::paired normalization
+    // ========================================================================
+
+    #[test]
+    fn paired_normalizes_swapped_own_and_mate_to_equal_keys() {
+        // Two reads of the same template: one sees (own=A, mate=B), the other
+        // sees (own=B, mate=A). After normalization both must yield the same
+        // GroupKey, so they group together.
+        let a = GroupKey::paired(0, 100, 0, 0, 200, 1, 7, 99, 42);
+        let b = GroupKey::paired(0, 200, 1, 0, 100, 0, 7, 99, 42);
+        assert_eq!(a, b, "swapped own/mate positions must normalize to equal keys");
+
+        // The lower (ref_id, pos, strand) tuple is placed in slot 1.
+        assert_eq!((a.ref_id1, a.pos1, a.strand1), (0, 100, 0));
+        assert_eq!((a.ref_id2, a.pos2, a.strand2), (0, 200, 1));
+    }
+
+    #[test]
+    fn paired_keys_order_by_normalized_position_then_name() {
+        // Position 1 < position 2 orders the keys; equal positions fall back to
+        // name_hash ordering.
+        let lower = GroupKey::paired(0, 100, 0, 0, 200, 0, 0, 0, 1);
+        let higher = GroupKey::paired(0, 150, 0, 0, 200, 0, 0, 0, 1);
+        assert!(lower < higher, "lower position-1 must sort first");
+
+        let same_pos_low_name = GroupKey::paired(0, 100, 0, 0, 200, 0, 0, 0, 1);
+        let same_pos_high_name = GroupKey::paired(0, 100, 0, 0, 200, 0, 0, 0, 2);
+        assert!(same_pos_low_name < same_pos_high_name, "equal positions must order by name_hash",);
+    }
+
+    // ========================================================================
+    // compute_group_key_from_raw: secondary / supplementary fallback
+    // ========================================================================
+
+    #[test]
+    fn secondary_and_supplementary_records_yield_name_hash_only_key() {
+        let lib = LibraryIndex::default();
+        let expected_name_hash = LibraryIndex::hash_name(Some(b"rec1"));
+
+        for flag in [flags::SECONDARY, flags::SUPPLEMENTARY] {
+            // Give the record a real mapped position so we can prove the
+            // position fields are *not* derived for secondary/supplementary.
+            let mut b = SamBuilder::new();
+            b.ref_id(0)
+                .pos(500)
+                .flags(flag)
+                .read_name(b"rec1")
+                .cigar_ops(&[cigar_m(50)])
+                .sequence(b"ACGT")
+                .qualities(&[30, 30, 30, 30]);
+            let rec = b.build();
+
+            let key = compute_group_key_from_raw(rec.as_ref(), &lib, None);
+
+            // Only the name hash is set; every position field stays at default.
+            assert_eq!(key, GroupKey { name_hash: expected_name_hash, ..GroupKey::default() });
+            assert_eq!(key.ref_id1, GroupKey::UNKNOWN_REF);
+            assert_eq!(key.pos1, GroupKey::UNKNOWN_POS);
+            assert_eq!(key.strand1, GroupKey::UNKNOWN_STRAND);
+        }
+    }
+
+    // ========================================================================
+    // compute_group_key_from_raw: paired record missing MC falls back to single
+    // ========================================================================
+
+    #[test]
+    fn paired_without_mc_tag_falls_back_to_single_semantics() {
+        let lib = LibraryIndex::default();
+
+        // Paired + mate mapped, but no MC tag: cannot compute the mate's
+        // unclipped 5' position, so the key must use single-end semantics
+        // (mate fields left at the UNKNOWN sentinels).
+        let mut b = SamBuilder::new();
+        b.ref_id(0)
+            .pos(1000)
+            .flags(flags::PAIRED)
+            .mate_ref_id(0)
+            .mate_pos(1200)
+            .read_name(b"pair_no_mc")
+            .cigar_ops(&[cigar_m(50)])
+            .sequence(b"ACGT")
+            .qualities(&[30, 30, 30, 30]);
+        let rec = b.build();
+
+        let key = compute_group_key_from_raw(rec.as_ref(), &lib, None);
+
+        // Mate fields fall back to the single-end sentinels.
+        assert_eq!(key.ref_id2, GroupKey::UNKNOWN_REF);
+        assert_eq!(key.pos2, GroupKey::UNKNOWN_POS);
+        assert_eq!(key.strand2, GroupKey::UNKNOWN_STRAND);
+
+        // The own position is still populated; the key matches the single-end
+        // key built from the same fields.
+        let expected = GroupKey::single(
+            key.ref_id1,
+            key.pos1,
+            key.strand1,
+            key.library_idx,
+            key.cell_hash,
+            LibraryIndex::hash_name(Some(b"pair_no_mc")),
+        );
+        assert_eq!(key, expected);
+    }
+
+    // ========================================================================
+    // name_hash_key parity with compute_group_key_from_raw
+    // ========================================================================
+
+    #[test]
+    fn name_hash_key_matches_compute_group_key_name_hash() {
+        let lib = LibraryIndex::default();
+
+        // A representative spread of records: mapped single-end, secondary,
+        // paired-without-MC, and an empty-named record (exercises the
+        // hash_name(None) branch shared by both functions).
+        let mut single = SamBuilder::new();
+        single
+            .ref_id(0)
+            .pos(10)
+            .read_name(b"alpha")
+            .cigar_ops(&[cigar_m(8)])
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8]);
+
+        let mut secondary = SamBuilder::new();
+        secondary.ref_id(0).pos(20).flags(flags::SECONDARY).read_name(b"beta");
+
+        let mut paired = SamBuilder::new();
+        paired
+            .ref_id(0)
+            .pos(30)
+            .flags(flags::PAIRED)
+            .mate_ref_id(0)
+            .mate_pos(60)
+            .read_name(b"gamma");
+
+        let mut empty_name = SamBuilder::new();
+        empty_name.ref_id(0).pos(40).read_name(b"");
+
+        for mut builder in [single, secondary, paired, empty_name] {
+            let rec = builder.build();
+            let raw = rec.as_ref();
+            assert_eq!(
+                name_hash_key(raw).name_hash,
+                compute_group_key_from_raw(raw, &lib, None).name_hash,
+                "name_hash parity mismatch",
+            );
+        }
+    }
+
+    // ========================================================================
+    // DecodedRecord cached-UMI invalidation (S6-002)
+    // ========================================================================
+
+    /// Build a `DecodedRecord` carrying an RX UMI tag with its value position
+    /// cached, exactly as the Decode step's `cache_umi_position` would.
+    fn decoded_with_cached_umi(umi: &[u8]) -> DecodedRecord {
+        use fgumi_raw_bam::SamTag;
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1").sequence(b"ACGT").qualities(&[30; 4]);
+        b.add_string_tag(SamTag::RX, umi);
+        let rec = b.build();
+        let bytes = rec.as_ref();
+        let aux_offset =
+            fgumi_raw_bam::aux_data_offset_from_record(bytes).expect("aux offset present");
+        let aux = &bytes[aux_offset..];
+        let (off_in_aux, len) =
+            fgumi_raw_bam::find_string_tag_position(aux, *SamTag::RX).expect("RX tag present");
+        let offset = u32::try_from(aux_offset).expect("aux offset fits u32") + off_in_aux;
+        let mut d = DecodedRecord::from_raw_bytes(rec, GroupKey::default());
+        d.set_cached_umi(offset, len);
+        d
+    }
+
+    #[test]
+    fn cached_umi_returns_value_then_raw_bytes_mut_invalidates() {
+        // The cache resolves to the UMI value up front; handing out mutable bytes
+        // must reset the cache to the sentinel so a later read re-scans rather
+        // than slicing stale-but-in-range bytes (see the cached-UMI invariant).
+        let mut decoded = decoded_with_cached_umi(b"ACGTACGT");
+        assert_eq!(decoded.cached_umi(), Some(b"ACGTACGT".as_ref()), "cache populated up front");
+        assert_ne!(decoded.cached_umi_position().0, DecodedRecord::UMI_OFFSET_UNCACHED);
+
+        let _ = decoded.raw_bytes_mut();
+
+        assert_eq!(
+            decoded.cached_umi_position().0,
+            DecodedRecord::UMI_OFFSET_UNCACHED,
+            "raw_bytes_mut resets the cache to the uncached sentinel",
+        );
+        assert!(decoded.cached_umi().is_none(), "cached_umi returns None after mutation");
+    }
+}

--- a/crates/fgumi-bam-io/src/lib.rs
+++ b/crates/fgumi-bam-io/src/lib.rs
@@ -12,7 +12,9 @@
 #![deny(unsafe_code)]
 
 pub mod format;
+pub mod grouping;
 pub mod header;
+pub mod library;
 pub mod mem_estimate;
 pub mod os_hints;
 pub mod paths;
@@ -26,6 +28,10 @@ pub mod writer;
 pub(crate) mod vendored;
 
 pub use format::{FORMAT_PREFIX_LEN, InputFormat, classify_input};
+pub use grouping::{
+    DecodedRecord, GroupKey, GroupKeyConfig, Grouper, compute_group_key_from_raw, name_hash_key,
+};
+pub use library::{LibraryIndex, LibraryLookup, build_library_lookup, unknown_library};
 pub use mem_estimate::MemoryEstimate;
 pub use paths::{is_stdin_path, is_stdout_path};
 pub use progress::ProgressTracker;

--- a/crates/fgumi-bam-io/src/library.rs
+++ b/crates/fgumi-bam-io/src/library.rs
@@ -1,0 +1,295 @@
+//! Library lookup tables built from SAM `@RG` headers.
+//!
+//! [`LibraryLookup`] maps read-group IDs to library-name strings;
+//! [`LibraryIndex`] is the hash-based hot-path variant returning numeric
+//! library indices (used by `grouping::compute_group_key_from_raw`).
+//!
+//! Relocated here from the main crate's `read_info` module so the grouping
+//! domain types (which depend on `LibraryIndex`) can live in this crate
+//! alongside [`fgumi_raw_bam::RawRecord`]-adjacent helpers and `MemoryEstimate`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use bstr::ByteSlice;
+use noodles::sam::header::Header;
+use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
+
+/// A lookup table mapping read group IDs to library names.
+///
+/// This is built from the SAM header's `@RG` lines and used to resolve the library
+/// name (`LB` field) from a record's `RG` tag. This matches fgbio's behavior where
+/// grouping uses the library name, not the read group ID.
+///
+/// Uses `Arc<str>` for library names to avoid cloning strings for every read.
+///
+/// # Note: `LibraryLookup` vs `LibraryIndex`
+///
+/// Both `LibraryLookup` and [`LibraryIndex`] exist for different use cases:
+/// - `LibraryLookup`: String-based lookup returning library names. Used where
+///   the actual library-name string is needed (e.g. the main crate's
+///   `ReadInfo::from`).
+/// - [`LibraryIndex`]: Hash-based lookup returning numeric indices. Used by
+///   [`compute_group_key_from_raw`](crate::compute_group_key_from_raw) in the
+///   hot path where only equality comparison matters, avoiding string
+///   allocations.
+pub type LibraryLookup = Arc<HashMap<String, Arc<str>>>;
+
+/// Shared "unknown" library string to avoid repeated allocations.
+static UNKNOWN_LIBRARY: std::sync::LazyLock<Arc<str>> =
+    std::sync::LazyLock::new(|| Arc::from("unknown"));
+
+/// Returns the shared "unknown" library name (`Arc<str>` of `"unknown"`),
+/// used as the fallback when a read group has no `LB` field.
+#[must_use]
+pub fn unknown_library() -> Arc<str> {
+    Arc::clone(&UNKNOWN_LIBRARY)
+}
+
+/// Builds a library lookup table from a SAM header.
+///
+/// Iterates through all `@RG` lines in the header and creates a mapping from
+/// read group ID to library name. If a read group has no `LB` field, it maps
+/// to "unknown" (matching fgbio's behavior).
+///
+/// # Arguments
+///
+/// * `header` - The SAM header containing `@RG` lines
+///
+/// # Returns
+///
+/// An `Arc<HashMap>` mapping read group IDs to library names
+#[must_use]
+pub fn build_library_lookup(header: &Header) -> LibraryLookup {
+    let mut lookup = HashMap::new();
+
+    for (id, rg) in header.read_groups() {
+        // Get the LB field from the read group's other_fields
+        let library: Arc<str> = rg
+            .other_fields()
+            .get(&rg_tag::LIBRARY)
+            .map_or_else(|| Arc::clone(&UNKNOWN_LIBRARY), |s| Arc::from(s.to_string()));
+        lookup.insert(id.to_string(), library);
+    }
+
+    Arc::new(lookup)
+}
+
+// ============================================================================
+// LibraryIndex - Fast RG to library index mapping for GroupKey computation
+// ============================================================================
+
+/// Fast lookup from `RG` tag value to library index.
+///
+/// This provides `O(1)` library lookup during Decode using string hashing,
+/// replacing the `O(n)` string comparison in the original `LibraryLookup`.
+#[derive(Debug, Clone)]
+pub struct LibraryIndex {
+    /// Map from `RG` string hash to library index.
+    lookup: ahash::AHashMap<u64, u16>,
+    /// Library names for each index (for output/debugging).
+    names: Vec<Arc<str>>,
+    /// Unknown library index (always 0).
+    unknown_idx: u16,
+}
+
+impl LibraryIndex {
+    /// Build a library index from a SAM header.
+    ///
+    /// Each unique library name gets a sequential index starting from 0.
+    /// Index 0 is reserved for "unknown" library.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the header contains more than 65,535 distinct libraries.
+    #[must_use]
+    pub fn from_header(header: &Header) -> Self {
+        let mut lookup = ahash::AHashMap::new();
+        let mut names = vec![Arc::clone(&UNKNOWN_LIBRARY)]; // Index 0 = unknown
+        let mut library_to_idx: ahash::AHashMap<Arc<str>, u16> = ahash::AHashMap::new();
+        library_to_idx.insert(Arc::clone(&UNKNOWN_LIBRARY), 0);
+
+        for (id, rg) in header.read_groups() {
+            // Get library name from LB field
+            let library: Arc<str> = rg
+                .other_fields()
+                .get(&rg_tag::LIBRARY)
+                .map_or_else(|| Arc::clone(&UNKNOWN_LIBRARY), |s| Arc::from(s.to_string()));
+
+            // Get or create library index
+            let lib_idx = *library_to_idx.entry(library.clone()).or_insert_with(|| {
+                let idx: u16 =
+                    names.len().try_into().expect("too many distinct libraries for u16 index");
+                names.push(library);
+                idx
+            });
+
+            // Hash the RG string and map to library index
+            let rg_hash = Self::hash_rg(id.as_bytes());
+            lookup.insert(rg_hash, lib_idx);
+        }
+
+        Self { lookup, names, unknown_idx: 0 }
+    }
+
+    /// Get the library index for a read group hash.
+    ///
+    /// Returns 0 (unknown) if the `RG` hash is not found.
+    #[must_use]
+    pub fn get(&self, rg_hash: u64) -> u16 {
+        *self.lookup.get(&rg_hash).unwrap_or(&self.unknown_idx)
+    }
+
+    /// Get the library name for an index.
+    #[must_use]
+    pub fn library_name(&self, idx: u16) -> &Arc<str> {
+        self.names.get(idx as usize).unwrap_or(&self.names[0])
+    }
+
+    /// Hash a byte slice using `AHash`. Returns 0 for `None`.
+    ///
+    /// This is the single hashing implementation used by all `hash_*` methods.
+    #[must_use]
+    pub fn hash_bytes(bytes: Option<&[u8]>) -> u64 {
+        use ahash::AHasher;
+        use std::hash::{Hash, Hasher};
+        match bytes {
+            Some(b) => {
+                let mut hasher = AHasher::default();
+                b.hash(&mut hasher);
+                hasher.finish()
+            }
+            None => 0,
+        }
+    }
+
+    /// Hash an `RG` tag value for lookup.
+    #[must_use]
+    pub fn hash_rg(rg_bytes: &[u8]) -> u64 {
+        Self::hash_bytes(Some(rg_bytes))
+    }
+
+    /// Hash a cell barcode for `GroupKey`.
+    #[must_use]
+    pub fn hash_cell_barcode(cell_bytes: Option<&[u8]>) -> u64 {
+        Self::hash_bytes(cell_bytes)
+    }
+
+    /// Hash a read name for `GroupKey`.
+    #[must_use]
+    pub fn hash_name(name_bytes: Option<&[u8]>) -> u64 {
+        Self::hash_bytes(name_bytes)
+    }
+}
+
+impl Default for LibraryIndex {
+    fn default() -> Self {
+        Self {
+            lookup: ahash::AHashMap::new(),
+            names: vec![Arc::clone(&UNKNOWN_LIBRARY)],
+            unknown_idx: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noodles::sam::header::record::value::Map;
+    use noodles::sam::header::record::value::map::ReadGroup;
+    use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
+
+    /// Header with three read groups: two sharing a library, one with no `LB`.
+    fn header_with_read_groups() -> Header {
+        let mut header = Header::builder();
+        // RG1 and RG3 deliberately share a library so the dedup path is exercised.
+        for (id, library) in [("RG1", "libA"), ("RG2", "libB"), ("RG3", "libA")] {
+            let rg = Map::<ReadGroup>::builder()
+                .insert(rg_tag::LIBRARY, String::from(library))
+                .build()
+                .expect("read group builds");
+            header = header.add_read_group(bstr::BString::from(id), rg);
+        }
+        // A fourth group with no LB at all, which must fall back to "unknown".
+        header = header.add_read_group(
+            bstr::BString::from("RG4"),
+            Map::<ReadGroup>::builder().build().expect("read group builds"),
+        );
+        header.build()
+    }
+
+    /// `library_idx` is the field `GroupKey` equality depends on, so read groups
+    /// sharing a library MUST collapse to one index and distinct libraries MUST
+    /// NOT — the first would merge unrelated UMI groups, the second would split
+    /// one group in half.
+    #[test]
+    fn from_header_assigns_one_index_per_distinct_library() {
+        let index = LibraryIndex::from_header(&header_with_read_groups());
+
+        let idx1 = index.get(LibraryIndex::hash_rg(b"RG1"));
+        let idx2 = index.get(LibraryIndex::hash_rg(b"RG2"));
+        let idx3 = index.get(LibraryIndex::hash_rg(b"RG3"));
+
+        assert_eq!(idx1, idx3, "read groups sharing a library share an index");
+        assert_ne!(idx1, idx2, "distinct libraries get distinct indices");
+        assert_ne!(idx1, 0, "a resolved library is never the unknown index");
+        assert_ne!(idx2, 0, "a resolved library is never the unknown index");
+
+        assert_eq!(index.library_name(idx1).as_ref(), "libA");
+        assert_eq!(index.library_name(idx2).as_ref(), "libB");
+    }
+
+    /// A read group with no `LB` maps to the shared "unknown" library at index 0,
+    /// which is also the miss value — so an absent `LB` and an absent read group
+    /// group together rather than each forming a singleton.
+    #[test]
+    fn from_header_maps_missing_library_and_unknown_read_group_to_index_zero() {
+        let index = LibraryIndex::from_header(&header_with_read_groups());
+
+        assert_eq!(index.get(LibraryIndex::hash_rg(b"RG4")), 0, "no LB field → unknown");
+        assert_eq!(index.get(LibraryIndex::hash_rg(b"ABSENT")), 0, "unseen RG → unknown");
+        assert_eq!(index.library_name(0).as_ref(), "unknown");
+    }
+
+    /// Out-of-range indices fall back to "unknown" rather than panicking.
+    #[test]
+    fn library_name_saturates_to_unknown_for_an_out_of_range_index() {
+        let index = LibraryIndex::from_header(&header_with_read_groups());
+        assert_eq!(index.library_name(u16::MAX).as_ref(), "unknown");
+    }
+
+    /// The string-keyed lookup carries the same LB resolution as the hashed one,
+    /// including the "unknown" fallback.
+    #[test]
+    fn build_library_lookup_maps_each_read_group_to_its_library() {
+        let lookup = build_library_lookup(&header_with_read_groups());
+
+        assert_eq!(lookup.len(), 4);
+        assert_eq!(lookup.get("RG1").expect("RG1 present").as_ref(), "libA");
+        assert_eq!(lookup.get("RG2").expect("RG2 present").as_ref(), "libB");
+        assert_eq!(lookup.get("RG3").expect("RG3 present").as_ref(), "libA");
+        assert_eq!(lookup.get("RG4").expect("RG4 present").as_ref(), "unknown");
+    }
+
+    /// An empty header yields an index that resolves everything to unknown.
+    #[test]
+    fn from_header_with_no_read_groups_resolves_everything_to_unknown() {
+        let index = LibraryIndex::from_header(&Header::default());
+        assert_eq!(index.get(LibraryIndex::hash_rg(b"RG1")), 0);
+        assert!(build_library_lookup(&Header::default()).is_empty());
+    }
+
+    /// `hash_bytes(None)` is the documented zero sentinel, and the typed wrappers
+    /// agree with it — `GroupKey`'s `cell_hash`/`name_hash` rely on that.
+    #[test]
+    fn hash_helpers_agree_and_treat_none_as_zero() {
+        assert_eq!(LibraryIndex::hash_bytes(None), 0);
+        assert_eq!(LibraryIndex::hash_cell_barcode(None), 0);
+        assert_eq!(LibraryIndex::hash_name(None), 0);
+        assert_eq!(
+            LibraryIndex::hash_name(Some(b"read1")),
+            LibraryIndex::hash_bytes(Some(b"read1"))
+        );
+        assert_ne!(LibraryIndex::hash_name(Some(b"read1")), 0);
+    }
+}

--- a/crates/fgumi-bam-io/src/prefetch_reader.rs
+++ b/crates/fgumi-bam-io/src/prefetch_reader.rs
@@ -205,7 +205,6 @@ impl PrefetchReader {
 
     /// Total bytes served to callers of [`Read::read`] so far.
     #[must_use]
-    #[allow(dead_code)]
     pub fn bytes_consumed(&self) -> u64 {
         self.bytes_consumed
     }
@@ -214,7 +213,6 @@ impl PrefetchReader {
     /// to deliver the next chunk. Useful as a prototype-phase signal for
     /// whether [`DEFAULT_PREFETCH_DEPTH`] is large enough.
     #[must_use]
-    #[allow(dead_code)]
     pub fn consumer_stalls(&self) -> u64 {
         self.consumer_stalls
     }

--- a/crates/fgumi-bam-io/src/reorder.rs
+++ b/crates/fgumi-bam-io/src/reorder.rs
@@ -48,7 +48,7 @@ pub struct ReorderBuffer<T> {
     /// Sparse buffer: index (seq - `next_seq`) maps to `Option<(T, usize)>` where
     /// usize is the pre-computed heap size (0 if not tracked).
     buffer: VecDeque<Option<(T, usize)>>,
-    /// Next sequence number to release (also the sequence number corresponding to buffer[0]).
+    /// Next sequence number to release (also the sequence number corresponding to `buffer[0]`).
     next_seq: u64,
     /// Number of items currently stored.
     count: usize,

--- a/crates/fgumi-consensus/src/codec_caller.rs
+++ b/crates/fgumi-consensus/src/codec_caller.rs
@@ -308,7 +308,7 @@ struct SingleStrandConsensus {
 
 /// Per-molecule duplex base tallies produced while building a duplex consensus.
 ///
-/// These are returned rather than folded straight into [`CodecStats`] so the caller can
+/// These are returned rather than folded straight into [`CodecConsensusStats`] so the caller can
 /// apply them only *after* the consensus record has been serialized. A molecule whose output
 /// fails to build — an over-long input-derived UMI makes `try_build_record` reject the read
 /// name — emits nothing, so its duplex bases must not be counted, exactly as

--- a/crates/fgumi-pipeline-core/src/liveness.rs
+++ b/crates/fgumi-pipeline-core/src/liveness.rs
@@ -1,0 +1,210 @@
+//! A cheap, always-on liveness signal for the deadlock monitor.
+//!
+//! # Why this exists separately from [`PipelineStats`](crate::runtime::stats::PipelineStats)
+//!
+//! The deadlock monitor needs to answer exactly one question: *has anything in
+//! the pipeline made progress since I last looked?* It compares one total
+//! against the previous total and cares about nothing else.
+//!
+//! It used to get that total from `PipelineStats`, which coupled the monitor to
+//! full instrumentation — and full instrumentation is deliberately not free.
+//! `dispatch_one_step` times each dispatch with `Instant::now()` (~20–50 ns on
+//! Apple Silicon, ~50–100 ns on `x86_64`) and gates that on `stats.is_some()`
+//! precisely to keep the uninstrumented path zero-cost. So the monitor could
+//! only be armed by paying a per-dispatch timing cost on every run, which is why
+//! it shipped disarmed by default and every wedge hung silently instead.
+//!
+//! This type breaks that coupling: liveness is a counter, profiling is a
+//! separate opt-in. The monitor can therefore run with no `PipelineStats`
+//! attached at all — a stats handle now only adds the per-step snapshot to the
+//! stall report, and its absence costs the diagnostic, not the detection.
+//!
+//! That removes the *cost* argument for shipping disarmed; it does not by
+//! itself arm anything. `PipelineConfig::default()` still sets
+//! `deadlock_timeout_secs: 0`, because an armed monitor additionally requires
+//! every output transport to be `ByteBounded` (see
+//! [`PipelineError::MonitorBlindTransport`](crate::signal::PipelineError)) and
+//! chains such as `Process2` use `CountBounded` today.
+//!
+//! Both of those are properties of the **scheduled** path. A run that fuses to
+//! a single thread returns before the transport check and before the monitor
+//! spawns, so it neither gains the monitor nor is rejected for a byte-blind
+//! edge; it is bounded by the fused path's own stall budget instead.
+//!
+//! # Why the counter is sharded
+//!
+//! A single shared `AtomicU64` bumped by every worker on every productive
+//! dispatch is a false-sharing hotspot: each increment is a read-modify-write on
+//! one cache line, so N workers ping-pong that line between cores and the cost
+//! grows with thread count — exactly the wrong shape, since more threads is when
+//! the monitor matters most.
+//!
+//! Each worker therefore owns a slot padded to its own cache line, so a bump is
+//! normally an uncontended increment on a line no other worker touches. (The one
+//! exception is a dedicated driver thread, which reuses `worker_slot` 0 and so
+//! shares slot 0 with pool worker 0; the bump is an atomic `fetch_add`, so a
+//! coincident increment is counted correctly rather than lost — it only costs the
+//! two threads a shared cache line, not accuracy.) The monitor sums
+//! the slots, which it does once per poll interval (seconds), so the read side's
+//! cost is irrelevant.
+//!
+//! The sum is not a synchronized snapshot — slots are read one at a time under
+//! `Relaxed`, so the total may mix values from slightly different instants. That
+//! is fine for the only question asked of it: a torn total still *changes* when
+//! any worker makes progress, and monotonicity per slot means it can never
+//! spuriously appear frozen while work is happening.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Cache-line padding. 128 rather than 64 because Apple Silicon and some `x86_64`
+/// prefetchers pair adjacent 64-byte lines, so a 64-byte stride can still share
+/// a coherence unit.
+const CACHE_LINE_BYTES: usize = 128;
+
+#[repr(align(128))]
+struct PaddedCounter(AtomicU64);
+
+const _: () = assert!(std::mem::size_of::<PaddedCounter>() == CACHE_LINE_BYTES);
+
+/// Per-worker progress counters, summed by the deadlock monitor.
+pub struct LivenessCounter {
+    slots: Box<[PaddedCounter]>,
+    /// `slots.len() - 1`, valid because the slot count is always a power of two.
+    /// The bump path masks with this instead of `%`: a runtime modulo is an
+    /// integer division (tens of cycles on both `aarch64` and `x86_64`) on a path
+    /// that runs once per productive dispatch, which measured as a double-digit
+    /// percentage of dispatch cost.
+    mask: usize,
+}
+
+impl LivenessCounter {
+    /// One slot per worker. `n_workers` must cover every index passed to
+    /// [`Self::bump`]; indices are taken modulo the slot count so an unexpected
+    /// worker id degrades to sharing a slot rather than panicking on the hot
+    /// path.
+    #[must_use]
+    pub fn new(n_workers: usize) -> Self {
+        // Round up to a power of two so the bump path can mask instead of
+        // dividing. The slack is a few unused cache lines — irrelevant next to
+        // removing a division from a per-dispatch path.
+        let n = n_workers.max(1).next_power_of_two();
+        Self { slots: (0..n).map(|_| PaddedCounter(AtomicU64::new(0))).collect(), mask: n - 1 }
+    }
+
+    /// Record one unit of progress for `worker`.
+    ///
+    /// `Relaxed` is sufficient: the value only has to change, and the monitor
+    /// re-reads it on a multi-second cadence, so no ordering relative to other
+    /// memory is required.
+    #[inline]
+    pub fn bump(&self, worker: usize) {
+        // Mask, not modulo — see `mask`. The slot count is a power of two, so
+        // this is exact for in-range ids and wraps harmlessly for anything else.
+        let slot = &self.slots[worker & self.mask];
+        slot.0.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Sum every worker's progress. Called once per monitor poll.
+    #[must_use]
+    pub fn total(&self) -> u64 {
+        self.slots.iter().map(|s| s.0.load(Ordering::Relaxed)).sum()
+    }
+
+    /// Number of slots. This is the requested worker count rounded up to a
+    /// power of two, not the requested count itself.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.slots.len()
+    }
+
+    /// Always false — `new` clamps to at least one slot. Present because clippy
+    /// requires it alongside `len`.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+}
+
+impl std::fmt::Debug for LivenessCounter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Hand-written rather than derived: the per-slot atomics are an
+        // implementation detail, and the only useful facts are how many slots
+        // there are and what they currently sum to.
+        f.debug_struct("LivenessCounter")
+            .field("slots", &self.slots.len())
+            .field("mask", &self.mask)
+            .field("total", &self.total())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn total_sums_every_slot() {
+        let counter = LivenessCounter::new(4);
+        counter.bump(0);
+        counter.bump(1);
+        counter.bump(1);
+        counter.bump(3);
+        assert_eq!(counter.total(), 4);
+    }
+
+    #[test]
+    fn an_out_of_range_worker_wraps_rather_than_panicking() {
+        // The hot path must never panic on an unexpected worker id; sharing a
+        // slot only costs contention, and the total stays correct.
+        let counter = LivenessCounter::new(2);
+        counter.bump(7);
+        assert_eq!(counter.total(), 1);
+    }
+
+    #[test]
+    fn a_single_worker_pipeline_still_gets_a_slot() {
+        let counter = LivenessCounter::new(0);
+        assert_eq!(counter.len(), 1, "the slot count is clamped to at least one");
+        counter.bump(0);
+        assert_eq!(counter.total(), 1);
+    }
+
+    /// Every increment must be observed — the point of the type is that a frozen
+    /// total means a frozen pipeline, so a lost bump would be a false wedge
+    /// report.
+    #[test]
+    fn concurrent_bumps_are_all_counted() {
+        const WORKERS: usize = 8;
+        const PER_WORKER: u64 = 10_000;
+
+        let counter = Arc::new(LivenessCounter::new(WORKERS));
+        let handles: Vec<_> = (0..WORKERS)
+            .map(|w| {
+                let counter = Arc::clone(&counter);
+                std::thread::spawn(move || {
+                    for _ in 0..PER_WORKER {
+                        counter.bump(w);
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("worker thread joins");
+        }
+        assert_eq!(counter.total(), WORKERS as u64 * PER_WORKER);
+    }
+
+    /// Each slot must sit on its own cache line — the whole reason for sharding.
+    #[test]
+    fn slots_are_cache_line_separated() {
+        let counter = LivenessCounter::new(4);
+        let a = std::ptr::from_ref(&counter.slots[0]) as usize;
+        let b = std::ptr::from_ref(&counter.slots[1]) as usize;
+        assert_eq!(
+            b - a,
+            CACHE_LINE_BYTES,
+            "adjacent slots must be a full cache line apart or they false-share",
+        );
+    }
+}

--- a/crates/fgumi-pipeline-io/Cargo.toml
+++ b/crates/fgumi-pipeline-io/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "fgumi-pipeline-io"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "BAM pipeline I/O types and steps for fgumi"
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+fgumi-bam-io = { workspace = true }
+fgumi-bgzf = { workspace = true }
+fgumi-pipeline-core = { workspace = true }
+fgumi-raw-bam = { workspace = true, features = ["noodles"] }
+fgumi-sort = { workspace = true }
+anyhow = "1.0.102"
+log = { workspace = true }
+noodles = { workspace = true, features = ["bam", "sam", "bgzf"] }
+parking_lot = "0.12"
+rayon = "1.10"
+tempfile = "3.4"
+
+[features]
+test-utils = []
+# Multi-minute soak / matrix / proptest suites. Off by default so PR CI stays
+# fast; run on the nightly schedule via `cargo ci-test-stress`, matching the
+# root crate's `stress-tests` convention.
+stress-tests = []
+
+[dev-dependencies]
+# fgumi-bam-io, fgumi-bgzf, and tempfile are omitted here: each is already a
+# normal dependency with identical configuration, which tests and benches
+# inherit, so a dev-dependency entry would be redundant.
+fgumi-raw-bam = { workspace = true, features = ["noodles", "test-utils"] }
+fgumi-sort = { workspace = true, features = ["test-utils"] }
+noodles = { workspace = true, features = ["bam", "sam"] }
+rstest = "0.26"
+proptest = "1.10"
+criterion = { version = "0.8", features = ["html_reports"] }
+
+[[bench]]
+name = "serial_ingest"
+harness = false

--- a/crates/fgumi-pipeline-io/benches/serial_ingest.rs
+++ b/crates/fgumi-pipeline-io/benches/serial_ingest.rs
@@ -1,0 +1,119 @@
+#![deny(unsafe_code)]
+
+//! Go/no-go microbenchmark for the parallel-inflate redesign (increment 3b.0).
+//!
+//! The redesign's whole wall-clock premise is that the *serial* Phase-1 ingest
+//! step gets cheaper per record by NOT copying each record's bytes: today's
+//! `SortBlockBuffer` does `BoundaryState::scan` → `CoordinateChunkSorter::push`,
+//! and `push` memcpys every record body into the sorter's own arena (~the
+//! 121 ns/rec the profile flagged). The redesign instead builds a lightweight
+//! `(key, offset, len)` ref over bytes already in a shared arena — no copy.
+//!
+//! This bench measures EXACTLY that per-record delta with today's public API —
+//! no new pipeline steps, no arena, no visibility changes:
+//!   * `scan_copy_push`  — scan + `CoordinateChunkSorter::push` (copies body)
+//!   * `scan_refbuild`   — scan + `extract_coordinate_key_inline` + `RecordRef::new` (no copy)
+//!
+//! It is a NECESSARY-condition gate, not the full wall proof: it shows whether
+//! removing the copy cuts serial per-record cost. If `scan_refbuild` is not
+//! materially faster than `scan_copy_push`, the redesign cannot beat legacy on
+//! wall and we stop before building the pipeline. If it is faster, the full wall
+//! win still has to be confirmed by the end-to-end gp3 measurement (the overlap
+//! the freeze-per-run model trades away is not captured here).
+//!
+//!     cargo bench -p fgumi-pipeline-io --bench serial_ingest
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use fgumi_pipeline_io::boundaries::BoundaryState;
+use fgumi_raw_bam::testutil::make_bam_bytes;
+use fgumi_sort::{RawExternalSorter, RecordRef, SortOrder, extract_coordinate_key_inline};
+use noodles::sam::Header;
+
+/// Build a decompressed-BAM-style buffer of `n` framed records: each record is
+/// `[block_size: u32 LE][body]`, exactly what `BoundaryState::scan` walks. Bodies
+/// are ~100 bp aligned reads at scattered positions on tid 0 (realistic per-record
+/// size; the sort would do real reordering work).
+fn synth_framed(n: usize) -> Vec<u8> {
+    let mut buf = Vec::new();
+    for i in 0..n {
+        let pos = (i as u64).wrapping_mul(2_654_435_761) % 5_000_000;
+        let name = format!("r{i:08}");
+        let body = make_bam_bytes(0, pos as i32, 0, name.as_bytes(), &[], 100, -1, -1, &[]);
+        let block_size = u32::try_from(body.len()).expect("record fits u32");
+        buf.extend_from_slice(&block_size.to_le_bytes());
+        buf.extend_from_slice(&body);
+    }
+    buf
+}
+
+fn bench_serial_ingest(c: &mut Criterion) {
+    const N: usize = 200_000;
+    let framed = synth_framed(N);
+    let n_ref = 1u32;
+
+    // Sanity: both paths see the same record count (so the throughput is over the
+    // same work). Computed once, untimed.
+    {
+        let mut bs = BoundaryState::new_no_header();
+        let (offsets, _range) = bs.scan(&framed).expect("scan");
+        assert_eq!(offsets.len().saturating_sub(1), N, "scan must yield N records");
+    }
+
+    let mut group = c.benchmark_group("serial_ingest");
+    group.throughput(Throughput::Elements(N as u64));
+    group.sample_size(20);
+
+    // OLD path: scan + CoordinateChunkSorter::push — `push` copies each body into
+    // the sorter's arena (plus key-extract + internal ref-push).
+    group.bench_function("scan_copy_push", |b| {
+        b.iter_batched(
+            || {
+                RawExternalSorter::new(SortOrder::Coordinate)
+                    .threads(1)
+                    .into_coordinate_chunk_sorter(&Header::default())
+                    .expect("build coordinate chunk sorter")
+            },
+            |mut sorter| {
+                let mut bs = BoundaryState::new_no_header();
+                let (offsets, range) = bs.scan(&framed).expect("scan");
+                let recs = bs.records_bytes(range);
+                for w in offsets.windows(2) {
+                    let body = &recs[w[0] + 4..w[1]];
+                    sorter.push(body).expect("push");
+                }
+                std::hint::black_box(&mut sorter);
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    // NEW path: scan + key-extract + ref-build — NO body copy. This is the
+    // per-record work the redesign's serial FindBoundariesAndSort step does.
+    group.bench_function("scan_refbuild", |b| {
+        b.iter_batched(
+            || Vec::<RecordRef>::with_capacity(N),
+            |mut refs| {
+                refs.clear();
+                let mut bs = BoundaryState::new_no_header();
+                let (offsets, range) = bs.scan(&framed).expect("scan");
+                let recs = bs.records_bytes(range);
+                for w in offsets.windows(2) {
+                    let body = &recs[w[0] + 4..w[1]];
+                    let key = extract_coordinate_key_inline(body, n_ref);
+                    // offset/len point at the body (prefix skipped) — the redesign's
+                    // arena ref representation; here the offset is illustrative.
+                    let offset = u64::try_from(w[0] + 4).expect("offset fits u64");
+                    let len = u32::try_from(w[1] - w[0] - 4).expect("len fits u32");
+                    refs.push(RecordRef::new(key, offset, len));
+                }
+                std::hint::black_box(&mut refs);
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_serial_ingest);
+criterion_main!(benches);

--- a/crates/fgumi-pipeline-io/src/boundaries.rs
+++ b/crates/fgumi-pipeline-io/src/boundaries.rs
@@ -1,0 +1,668 @@
+//! `BoundaryState` / `BoundaryBatch`: the BAM record-boundary state machine.
+//!
+//! Lives in `fgumi-pipeline-io` so both `FindBamBoundaries` (in the `fgumi`
+//! crate, via a re-export shim) and the fused `SortBuffer` ingest can share it.
+//!
+//! Scans decompressed BGZF block data for BAM record boundaries (header skip,
+//! cross-block record carryover, EOF validation) without decoding records.
+//! Driven by the `FindBamBoundaries` step (`super::bam`).
+//!
+//! Relocated from the legacy `bam.rs` (deleted in the issue #330 migration);
+//! the boundary-finding logic is reused verbatim so the new framework's
+//! boundary semantics match the legacy pipeline's exactly.
+
+use std::io;
+
+/// Upper bound on a single BAM record's `block_size`. The `block_size` prefix is
+/// read straight from the input bytes, so a corrupt or hostile value (e.g.
+/// `0xFFFF_FFFF`) would otherwise make the scanner buffer the whole unconsumed
+/// tail into `leftover` — up to ~4 GiB from a 4-byte corruption — and only fail
+/// at [`BoundaryState::finish`]. A record larger than this is corruption, not
+/// data; reject it at the point the prefix is read.
+const MAX_RECORD_BLOCK_SIZE: usize = 64 * 1024 * 1024;
+
+/// Output of `FindBoundaries` step: buffer + record offsets for parallel decoding.
+///
+/// This struct enables parallel BAM record decoding by pre-computing where
+/// each record starts in the decompressed data. The actual parsing/decoding
+/// can then be parallelized across multiple threads.
+#[derive(Debug, Clone)]
+pub struct BoundaryBatch {
+    /// The decompressed bytes (with leftover prepended, suffix removed).
+    pub buffer: Vec<u8>,
+    /// Byte offsets where each record starts (offsets into buffer).
+    /// Length = `num_records` + 1 (last entry is `buffer.len()` for easy slicing).
+    pub offsets: Vec<usize>,
+}
+
+/// State for the `FindBoundaries` step (sequential).
+///
+/// This state maintains leftover bytes from incomplete records that span
+/// across BGZF block boundaries. The boundary finding is very fast (~0.1μs
+/// per block) since it only reads 4-byte integers without decoding records.
+///
+/// Uses a reusable work buffer to minimize allocations on the hot path.
+pub struct BoundaryState {
+    /// Leftover bytes from previous block (incomplete record at end).
+    leftover: Vec<u8>,
+    /// Reusable working buffer to avoid per-call allocations.
+    work_buffer: Vec<u8>,
+    /// Whether the BAM header has been skipped.
+    header_skipped: bool,
+    /// Length of the previous call's `offsets` Vec, used to pre-size the next
+    /// one. Adjacent BGZF blocks hold near-identical record counts, so this
+    /// collapses the per-block push-regrowth (~8 reallocations) to ~1. The
+    /// returned `offsets` Vec is moved into `BoundaryBatch`, so it cannot be a
+    /// reused buffer; pre-sizing is the cheap, correctness-neutral alternative.
+    prev_offsets_len: usize,
+}
+
+/// Return the byte length of the BAM header at the start of `data`.
+///
+/// The BAM header consists of:
+/// - 4-byte magic (`BAM\x01`)
+/// - 4-byte `l_text` (little-endian u32)
+/// - `l_text` bytes of plain-text header
+/// - 4-byte `n_ref` (little-endian u32)
+/// - for each of the `n_ref` references: 4-byte `l_name` + `l_name` bytes of name + 4-byte `l_ref`
+///
+/// Returns:
+/// - `Ok(Some(offset))` — `offset` bytes consume the complete header; the first record starts there.
+/// - `Ok(None)` — `data` is too short to contain a complete header; more bytes are needed.
+/// - `Err(InvalidData)` — `data` does not begin with the BAM magic. This path skips a BAM header,
+///   so a wrong magic means the stream is not what the caller declared; fail closed rather than
+///   silently treating arbitrary bytes as headerless records. Genuinely headerless streams must use
+///   [`BoundaryState::new_no_header`], which never calls this.
+///
+/// # Errors
+///
+/// Returns `InvalidData` when `data` is long enough to check the magic but does not start with it.
+pub fn bam_header_len(data: &[u8]) -> io::Result<Option<usize>> {
+    // BAM header structure:
+    // - magic: 4 bytes ("BAM\1")
+    // - l_text: 4 bytes (header text length)
+    // - text: l_text bytes
+    // - n_ref: 4 bytes (number of references)
+    // - for each reference:
+    //   - l_name: 4 bytes
+    //   - name: l_name bytes
+    //   - l_ref: 4 bytes
+
+    if data.len() < 8 {
+        return Ok(None);
+    }
+
+    // Check magic. This function is only reached on the header-skipping path
+    // (`header_skipped == false`); a wrong magic there means the stream is not
+    // the BAM the caller declared, so fail closed instead of misinterpreting the
+    // bytes as headerless records.
+    if &data[0..4] != fgumi_raw_bam::BAM_MAGIC {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "invalid BAM magic"));
+    }
+
+    let l_text = u32::from_le_bytes([data[4], data[5], data[6], data[7]]) as usize;
+    let mut offset = 8 + l_text;
+
+    if data.len() < offset + 4 {
+        return Ok(None);
+    }
+
+    let n_ref =
+        u32::from_le_bytes([data[offset], data[offset + 1], data[offset + 2], data[offset + 3]])
+            as usize;
+    offset += 4;
+
+    // Parse each reference
+    for _ in 0..n_ref {
+        if data.len() < offset + 4 {
+            return Ok(None);
+        }
+        let l_name = u32::from_le_bytes([
+            data[offset],
+            data[offset + 1],
+            data[offset + 2],
+            data[offset + 3],
+        ]) as usize;
+        offset += 4 + l_name + 4; // l_name + name + l_ref
+
+        if data.len() < offset {
+            return Ok(None);
+        }
+    }
+
+    Ok(Some(offset))
+}
+
+impl BoundaryState {
+    /// Create a new boundary state.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            leftover: Vec::new(),
+            work_buffer: Vec::new(),
+            header_skipped: false,
+            prev_offsets_len: 0,
+        }
+    }
+
+    /// Create a new boundary state that doesn't skip the header.
+    /// Use this when the input stream is already positioned past the header.
+    #[must_use]
+    pub fn new_no_header() -> Self {
+        Self {
+            leftover: Vec::new(),
+            work_buffer: Vec::new(),
+            header_skipped: true,
+            prev_offsets_len: 0,
+        }
+    }
+
+    /// Find record boundaries in decompressed data.
+    ///
+    /// This is FAST (~0.1μs per block) because it only scans 4-byte integers
+    /// to find where records start - no actual record decoding is performed.
+    ///
+    /// # Arguments
+    ///
+    /// * `decompressed` - Decompressed bytes from one or more BGZF blocks
+    ///
+    /// # Returns
+    ///
+    /// A `BoundaryBatch` containing the complete records and their offsets.
+    /// Any incomplete record at the end is saved as leftover for the next call.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the BAM header is malformed.
+    ///
+    /// # Record-level validation
+    ///
+    /// This function does NOT validate individual record `block_size` values
+    /// against a malformed (but self-consistent) BAM stream. The per-record
+    /// cross-check below (offset delta vs. the stored prefix) is a
+    /// `debug_assertions`-only regression tripwire for this scanner's own
+    /// arithmetic — it re-reads the same `block_size` bytes the scan already
+    /// trusted, so it can only catch an internal bookkeeping bug, never input
+    /// corruption. Authoritative release-build validation of record structure
+    /// (out-of-bounds record end, trailing partial record) is performed
+    /// downstream by `parse_records` / `parse_record_ranges` on the same bytes,
+    /// which hard-error in all build modes. The `offsets` vector this returns
+    /// is not consumed in release builds (`FindBamBoundaries` forwards only
+    /// `buffer`), so promoting the cross-check to release would re-validate a
+    /// tautology at a per-record cost for no correctness benefit.
+    pub fn find_boundaries(&mut self, decompressed: &[u8]) -> io::Result<BoundaryBatch> {
+        let (offsets, range) = self.scan(decompressed)?;
+        // Owning copy of the complete records — for callers that need an owned
+        // buffer (`FindBamBoundaries`). The zero-copy ingest path
+        // ([`scan`](Self::scan) + [`records_bytes`](Self::records_bytes)) skips
+        // this allocation + copy entirely.
+        let buffer = self.work_buffer[range].to_vec();
+
+        // Debug-only regression tripwire (NOT input validation): cross-check
+        // each record's stored block_size prefix against the offset delta this
+        // scan just computed. Both derive from the same bytes with no
+        // intervening mutation, so this only catches an internal arithmetic /
+        // indexing bug in the scan above — a corrupt-but-self-consistent
+        // block_size passes trivially. Authoritative release validation lives
+        // in parse_records / parse_record_ranges downstream (see the
+        // `find_boundaries` doc comment).
+        #[cfg(debug_assertions)]
+        for i in 0..offsets.len().saturating_sub(1) {
+            let start = offsets[i];
+            let end = offsets[i + 1];
+            if end > start + 4 {
+                let stored = u32::from_le_bytes([
+                    buffer[start],
+                    buffer[start + 1],
+                    buffer[start + 2],
+                    buffer[start + 3],
+                ]) as usize;
+                let expected = end - start - 4;
+                debug_assert_eq!(
+                    stored, expected,
+                    "find_boundaries: block_size mismatch at record {i}: stored={stored}, expected={expected}"
+                );
+            }
+        }
+
+        Ok(BoundaryBatch { buffer, offsets })
+    }
+
+    /// Zero-copy core of [`find_boundaries`](Self::find_boundaries): combine
+    /// leftover + `decompressed` into the reusable `work_buffer`, skip the header
+    /// (first call), scan record boundaries, and stash the trailing partial
+    /// record as leftover — **without** copying the complete records out.
+    ///
+    /// Returns `(offsets, range)` where the complete records live in
+    /// `self.work_buffer[range]` (valid until the next `scan`/`find_boundaries`
+    /// call) and `offsets[i] .. offsets[i+1]` slices record `i` *relative to
+    /// `range.start`* (so record `i`'s bytes are
+    /// `records_bytes()[offsets[i] .. offsets[i+1]]`). The caller must consume
+    /// the records before the next call. A header-only / incomplete-header block
+    /// yields `(vec![0], 0..0)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the BAM header is malformed.
+    pub fn scan(
+        &mut self,
+        decompressed: &[u8],
+    ) -> io::Result<(Vec<usize>, std::ops::Range<usize>)> {
+        // Step 1: Combine leftover with new data into reusable work_buffer.
+        self.work_buffer.clear();
+        if !self.leftover.is_empty() {
+            self.work_buffer.append(&mut self.leftover);
+        }
+        self.work_buffer.extend_from_slice(decompressed);
+
+        // Step 2: Skip header if not already done.
+        let mut cursor = 0usize;
+        if !self.header_skipped {
+            let Some(header_size) = bam_header_len(&self.work_buffer)? else {
+                // Not enough data to parse header; save as leftover, empty range.
+                std::mem::swap(&mut self.leftover, &mut self.work_buffer);
+                return Ok((vec![0], 0..0));
+            };
+            cursor = header_size;
+            self.header_skipped = true;
+        }
+
+        // Step 3: Scan for record boundaries (FAST - just read integers).
+        let start_cursor = cursor;
+        let mut offsets = Vec::with_capacity(self.prev_offsets_len.max(1));
+        offsets.push(0usize);
+        while cursor + 4 <= self.work_buffer.len() {
+            let block_size = u32::from_le_bytes([
+                self.work_buffer[cursor],
+                self.work_buffer[cursor + 1],
+                self.work_buffer[cursor + 2],
+                self.work_buffer[cursor + 3],
+            ]) as usize;
+            if block_size > MAX_RECORD_BLOCK_SIZE {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "BAM record block_size {block_size} exceeds the maximum \
+                         {MAX_RECORD_BLOCK_SIZE} (corrupt or truncated input)"
+                    ),
+                ));
+            }
+            let record_end = cursor + 4 + block_size;
+            if record_end > self.work_buffer.len() {
+                break; // Incomplete record - becomes leftover.
+            }
+            cursor = record_end;
+            offsets.push(cursor - start_cursor);
+        }
+        self.prev_offsets_len = offsets.len();
+
+        // Step 4: Save trailing partial record as leftover (small — at most one
+        // record). The complete records stay in `work_buffer[start_cursor..cursor]`
+        // for the caller to read borrowed, with no copy.
+        self.leftover.clear();
+        self.leftover.extend_from_slice(&self.work_buffer[cursor..]);
+
+        Ok((offsets, start_cursor..cursor))
+    }
+
+    /// Borrow the complete records produced by the most recent [`scan`](Self::scan),
+    /// given the `range` it returned. Valid until the next `scan`/`find_boundaries`.
+    #[must_use]
+    pub fn records_bytes(&self, range: std::ops::Range<usize>) -> &[u8] {
+        &self.work_buffer[range]
+    }
+
+    /// Call at EOF to get any remaining leftover.
+    ///
+    /// This validates that any remaining bytes form complete records.
+    /// If there are incomplete bytes at EOF, an error is returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if there are incomplete BAM records at EOF.
+    pub fn finish(&mut self) -> io::Result<Option<BoundaryBatch>> {
+        if self.leftover.is_empty() {
+            return Ok(None);
+        }
+
+        // Try to parse remaining leftover
+        let mut offsets = vec![0usize];
+        let mut cursor = 0usize;
+
+        while cursor + 4 <= self.leftover.len() {
+            let block_size = u32::from_le_bytes([
+                self.leftover[cursor],
+                self.leftover[cursor + 1],
+                self.leftover[cursor + 2],
+                self.leftover[cursor + 3],
+            ]) as usize;
+
+            if block_size > MAX_RECORD_BLOCK_SIZE {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "BAM record block_size {block_size} exceeds the maximum \
+                         {MAX_RECORD_BLOCK_SIZE} (corrupt or truncated input)"
+                    ),
+                ));
+            }
+            let record_end = cursor + 4 + block_size;
+            if record_end > self.leftover.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    format!(
+                        "Incomplete BAM record at EOF: need {} bytes, have {}",
+                        record_end - cursor,
+                        self.leftover.len() - cursor
+                    ),
+                ));
+            }
+
+            cursor = record_end;
+            offsets.push(cursor);
+        }
+
+        // The loop only advances `cursor` by whole records. If it stops with
+        // bytes still unconsumed (`cursor < leftover.len()`), those 1-3 trailing
+        // bytes are too short to even hold a 4-byte block-size prefix — i.e. a
+        // truncated BAM record. Surface it as an error rather than dropping the
+        // bytes and masking corruption.
+        if cursor < self.leftover.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!(
+                    "Incomplete BAM record at EOF: {} trailing byte(s) cannot form a complete record",
+                    self.leftover.len() - cursor
+                ),
+            ));
+        }
+
+        Ok(Some(BoundaryBatch { buffer: std::mem::take(&mut self.leftover), offsets }))
+    }
+}
+
+impl Default for BoundaryState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    /// Build a BAM header: magic, `l_text` + text, `n_ref` + one entry per `(name, l_ref)`.
+    ///
+    /// Every test header is constructed here rather than committed as a fixture, so a
+    /// header's declared lengths and its actual bytes cannot drift apart.
+    fn header(text: &str, refs: &[(&str, u32)]) -> Vec<u8> {
+        let mut h = Vec::new();
+        h.extend_from_slice(fgumi_raw_bam::BAM_MAGIC);
+        h.extend_from_slice(&u32::try_from(text.len()).unwrap().to_le_bytes());
+        h.extend_from_slice(text.as_bytes());
+        h.extend_from_slice(&u32::try_from(refs.len()).unwrap().to_le_bytes());
+        for (name, l_ref) in refs {
+            // l_name counts the trailing NUL, matching the BAM spec.
+            let name_bytes = format!("{name}\0");
+            h.extend_from_slice(&u32::try_from(name_bytes.len()).unwrap().to_le_bytes());
+            h.extend_from_slice(name_bytes.as_bytes());
+            h.extend_from_slice(&l_ref.to_le_bytes());
+        }
+        h
+    }
+
+    /// Build one BAM record: a 4-byte little-endian `block_size` followed by
+    /// `payload_len` bytes of `fill`. The scanner only reads the length prefix, so
+    /// the payload just has to be the declared size and be identifiable.
+    fn record(payload_len: usize, fill: u8) -> Vec<u8> {
+        let mut r = u32::try_from(payload_len).unwrap().to_le_bytes().to_vec();
+        r.extend(std::iter::repeat_n(fill, payload_len));
+        r
+    }
+
+    /// The expected total on-disk size of a record with `payload_len` bytes.
+    fn record_len(payload_len: usize) -> usize {
+        payload_len + 4
+    }
+
+    // ---------------------------------------------------------------------
+    // bam_header_len
+    // ---------------------------------------------------------------------
+
+    /// What a `bam_header_len` case expects: a parsed length (or `None` for
+    /// "need more bytes"), or a hard `InvalidData` rejection.
+    #[derive(Debug, Clone, Copy)]
+    enum Expect {
+        Header(Option<usize>),
+        InvalidMagic,
+    }
+
+    #[rstest]
+    #[case::empty(vec![], Expect::Header(None))]
+    #[case::shorter_than_magic(b"BAM".to_vec(), Expect::Header(None))]
+    #[case::magic_only_no_room_for_n_ref(
+        // 8 bytes: magic + l_text=0. Needs offset+4 == 12 to read n_ref.
+        [&fgumi_raw_bam::BAM_MAGIC[..], &0u32.to_le_bytes()[..]].concat(),
+        Expect::Header(None)
+    )]
+    #[case::no_refs(header("", &[]), Expect::Header(Some(12)))]
+    #[case::with_header_text(header("@HD\tVN:1.6\n", &[]), Expect::Header(Some(12 + 11)))]
+    // 12 + (4 l_name + 3 name + 4 l_ref) == 23
+    #[case::one_ref(header("", &[("r1", 100)]), Expect::Header(Some(23)))]
+    #[case::two_refs(header("", &[("r1", 100), ("chr2", 200)]), Expect::Header(Some(23 + 4 + 5 + 4)))]
+    #[case::truncated_mid_ref_name(header("", &[("r1", 100)])[..20].to_vec(), Expect::Header(None))]
+    #[case::truncated_before_l_name(header("", &[("r1", 100)])[..14].to_vec(), Expect::Header(None))]
+    #[case::bad_magic(b"NOT\x01\x00\x00\x00\x00\x00\x00\x00\x00".to_vec(), Expect::InvalidMagic)]
+    fn bam_header_len_cases(#[case] data: Vec<u8>, #[case] expected: Expect) {
+        match expected {
+            Expect::Header(len) => assert_eq!(bam_header_len(&data).unwrap(), len),
+            Expect::InvalidMagic => {
+                let err = bam_header_len(&data).expect_err("expected an error");
+                assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Constructors
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn new_skips_the_header_and_new_no_header_does_not() {
+        let hdr = header("", &[]);
+        let rec = record(8, 0xAB);
+
+        // `new` consumes the header, so the first record starts after it.
+        let mut with_header = BoundaryState::new();
+        let (offsets, range) = with_header.scan(&[hdr.clone(), rec.clone()].concat()).unwrap();
+        assert_eq!(range, hdr.len()..hdr.len() + record_len(8));
+        assert_eq!(offsets, vec![0, record_len(8)]);
+        assert_eq!(with_header.records_bytes(range), rec.as_slice());
+
+        // `new_no_header` treats byte 0 as the first record.
+        let mut headerless = BoundaryState::new_no_header();
+        let (offsets, range) = headerless.scan(&rec).unwrap();
+        assert_eq!(range, 0..record_len(8));
+        assert_eq!(offsets, vec![0, record_len(8)]);
+    }
+
+    #[test]
+    fn default_matches_new_and_still_skips_the_header() {
+        let data = [header("", &[]), record(4, 0x11)].concat();
+        let mut from_default = BoundaryState::default();
+        let mut from_new = BoundaryState::new();
+        assert_eq!(from_default.scan(&data).unwrap(), from_new.scan(&data).unwrap());
+    }
+
+    // ---------------------------------------------------------------------
+    // scan
+    // ---------------------------------------------------------------------
+
+    #[rstest]
+    #[case::single(vec![8])]
+    #[case::several_same_size(vec![4, 4, 4])]
+    #[case::mixed_sizes(vec![1, 16, 3, 32])]
+    #[case::zero_length_payload(vec![0, 0])]
+    fn scan_finds_every_complete_record(#[case] payloads: Vec<usize>) {
+        let mut data = header("", &[]);
+        for (i, len) in payloads.iter().enumerate() {
+            data.extend(record(*len, u8::try_from(i).unwrap()));
+        }
+
+        let mut state = BoundaryState::new();
+        let (offsets, range) = state.scan(&data).unwrap();
+
+        // One offset per record plus the terminating end offset.
+        assert_eq!(offsets.len(), payloads.len() + 1);
+        let mut running = 0usize;
+        for (i, len) in payloads.iter().enumerate() {
+            assert_eq!(offsets[i], running, "record {i} start");
+            running += record_len(*len);
+        }
+        assert_eq!(*offsets.last().unwrap(), running);
+        assert_eq!(range.len(), running);
+        assert!(state.leftover.is_empty(), "no leftover when every record is complete");
+    }
+
+    #[test]
+    fn scan_holds_back_a_trailing_partial_record_as_leftover() {
+        let complete = record(8, 0x01);
+        let partial = &record(64, 0x02)[..10]; // declares 64 bytes, supplies 6
+        let data = [header("", &[]), complete.clone(), partial.to_vec()].concat();
+
+        let mut state = BoundaryState::new();
+        let (offsets, range) = state.scan(&data).unwrap();
+
+        // Only the complete record is emitted.
+        assert_eq!(offsets, vec![0, record_len(8)]);
+        assert_eq!(state.records_bytes(range), complete.as_slice());
+        assert_eq!(state.leftover, partial, "the partial record is carried forward verbatim");
+    }
+
+    #[test]
+    fn scan_reassembles_a_record_split_across_two_blocks() {
+        let rec = record(32, 0x7E);
+        let data = [header("", &[]), rec.clone()].concat();
+        let split = data.len() - 20; // cut mid-record
+
+        let mut state = BoundaryState::new();
+
+        // First block ends mid-record: nothing complete yet.
+        let (offsets, range) = state.scan(&data[..split]).unwrap();
+        assert_eq!(offsets, vec![0], "no complete record in the first block");
+        assert_eq!(range.len(), 0);
+        assert!(!state.leftover.is_empty());
+
+        // Second block completes it, and the bytes match the original record.
+        let (offsets, range) = state.scan(&data[split..]).unwrap();
+        assert_eq!(offsets, vec![0, record_len(32)]);
+        assert_eq!(state.records_bytes(range), rec.as_slice());
+        assert!(state.leftover.is_empty());
+    }
+
+    #[test]
+    fn scan_defers_when_the_header_itself_is_incomplete() {
+        let hdr = header("@HD\tVN:1.6\n", &[("r1", 100)]);
+        let mut state = BoundaryState::new();
+
+        // A prefix too short to hold the whole header yields an empty batch and
+        // stashes everything for the next call.
+        let (offsets, range) = state.scan(&hdr[..10]).unwrap();
+        assert_eq!(offsets, vec![0]);
+        assert_eq!(range, 0..0);
+        assert_eq!(state.leftover, hdr[..10]);
+        assert!(!state.header_skipped, "header must not be marked skipped yet");
+
+        // The rest of the header plus a record then parses normally.
+        let rec = record(8, 0x5A);
+        let (offsets, range) = state.scan(&[&hdr[10..], rec.as_slice()].concat()).unwrap();
+        assert!(state.header_skipped);
+        assert_eq!(offsets, vec![0, record_len(8)]);
+        assert_eq!(state.records_bytes(range), rec.as_slice());
+    }
+
+    #[test]
+    fn scan_propagates_a_bad_magic_as_invalid_data() {
+        let mut state = BoundaryState::new();
+        let err = state.scan(b"NOPE\x00\x00\x00\x00\x00\x00\x00\x00").expect_err("bad magic");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    // ---------------------------------------------------------------------
+    // find_boundaries (owned-buffer wrapper over scan)
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn find_boundaries_returns_the_same_bytes_scan_would_borrow() {
+        let recs = [record(8, 0x01), record(16, 0x02), record(2, 0x03)].concat();
+        let data = [header("", &[("r1", 10)]), recs.clone()].concat();
+
+        let mut owned = BoundaryState::new();
+        let batch = owned.find_boundaries(&data).unwrap();
+
+        let mut borrowed = BoundaryState::new();
+        let (offsets, range) = borrowed.scan(&data).unwrap();
+
+        assert_eq!(batch.offsets, offsets);
+        assert_eq!(batch.buffer, borrowed.records_bytes(range));
+        assert_eq!(batch.buffer, recs, "the owned copy is the record bytes, header excluded");
+
+        // Offsets slice the buffer into the original records.
+        for i in 0..batch.offsets.len() - 1 {
+            let rec = &batch.buffer[batch.offsets[i]..batch.offsets[i + 1]];
+            let declared = u32::from_le_bytes(rec[..4].try_into().unwrap()) as usize;
+            assert_eq!(declared, rec.len() - 4, "record {i} length prefix matches its slice");
+        }
+    }
+
+    #[test]
+    fn find_boundaries_on_a_header_only_block_yields_an_empty_batch() {
+        let mut state = BoundaryState::new();
+        let batch = state.find_boundaries(&header("", &[])).unwrap();
+        assert!(batch.buffer.is_empty());
+        assert_eq!(batch.offsets, vec![0]);
+    }
+
+    // ---------------------------------------------------------------------
+    // finish
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn finish_returns_none_when_nothing_is_pending() {
+        let mut state = BoundaryState::new_no_header();
+        assert!(state.finish().unwrap().is_none());
+
+        // Also none after a scan that consumed every record.
+        let (_, _) = state.scan(&record(4, 0x09)).unwrap();
+        assert!(state.finish().unwrap().is_none());
+    }
+
+    #[test]
+    fn finish_emits_leftover_that_forms_complete_records() {
+        // `scan` never leaves a *complete* record behind, so the pending buffer is
+        // seeded directly to exercise the success branch.
+        let mut state = BoundaryState::new_no_header();
+        state.leftover = [record(4, 0xA1), record(8, 0xA2)].concat();
+
+        let batch = state.finish().unwrap().expect("complete records must be emitted");
+        assert_eq!(batch.offsets, vec![0, record_len(4), record_len(4) + record_len(8)]);
+        assert_eq!(batch.buffer.len(), record_len(4) + record_len(8));
+        assert!(state.leftover.is_empty(), "finish takes the pending bytes");
+    }
+
+    #[rstest]
+    // Declares a 64-byte payload but only supplies part of it.
+    #[case::truncated_payload(record(64, 0x02)[..10].to_vec())]
+    // Fewer than 4 bytes cannot even hold a block-size prefix.
+    #[case::one_trailing_byte(vec![0x00])]
+    #[case::three_trailing_bytes(vec![0x00, 0x01, 0x02])]
+    // A whole record followed by an unusable tail.
+    #[case::complete_then_stray_bytes([record(4, 0x03), vec![0xFF, 0xFF]].concat())]
+    fn finish_rejects_incomplete_trailing_bytes(#[case] pending: Vec<u8>) {
+        let mut state = BoundaryState::new_no_header();
+        state.leftover = pending;
+        let err = state.finish().expect_err("truncated input must fail closed");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+}

--- a/crates/fgumi-pipeline-io/src/lib.rs
+++ b/crates/fgumi-pipeline-io/src/lib.rs
@@ -1,0 +1,30 @@
+#![deny(unsafe_code)]
+
+//! BAM-pipeline I/O layer for the fgumi typed-step pipeline.
+//!
+//! Provides the source, sink, and sort typed-step building blocks plus the
+//! record-batch and BGZF-block buffer types shared across the fgumi pipeline:
+//!
+//!   * [`source`] — BAM ingest steps ([`ReadBgzfBlocks`] and the
+//!     `read_bam*` helpers) that turn a reader into decompressed blocks.
+//!   * [`sink`] — BAM output steps ([`WriteBgzfFile`]).
+//!   * [`sort`] — in-pipeline sort steps ([`SortBuffer`], [`CompressSpill`],
+//!     [`SortSpillDecompress`], [`SortMerge`]).
+//!   * [`types`] — the record-batch / decompressed-block buffers
+//!     ([`RecordBatch`], [`DecompressedBlock`], [`BgzfBlock`], …) exchanged
+//!     between steps.
+
+pub mod boundaries;
+pub mod sink;
+pub mod sort;
+pub mod source;
+pub mod types;
+
+pub use fgumi_pipeline_core::HeaderHandle;
+pub use sink::write_bgzf::WriteBgzfFile;
+pub use sort::{CompressSpill, SortBuffer, SortMerge, SortSpillDecompress};
+pub use source::read_bam::{
+    DEFAULT_BLOCKS_PER_BATCH, ReadBgzfBlocks, read_bam, read_bam_auto, read_bam_from_reader,
+    read_bam_stdin,
+};
+pub use types::{BgzfBlock, DecompressedBlock, RecordBatch, RecordBatchBuilder};

--- a/crates/fgumi-pipeline-io/src/sink/mod.rs
+++ b/crates/fgumi-pipeline-io/src/sink/mod.rs
@@ -1,0 +1,2 @@
+pub mod write_bgzf;
+pub mod write_raw;

--- a/crates/fgumi-pipeline-io/src/sink/write_bgzf.rs
+++ b/crates/fgumi-pipeline-io/src/sink/write_bgzf.rs
@@ -1,0 +1,516 @@
+//! `WriteBgzfFile` sink step. `Serial + Affinity::Writer` by default, or
+//! `StepKind::Detached` (its own dedicated thread, off the pool) when built
+//! via [`WriteBgzfFile::with_detached`] — used only on the standalone-sort
+//! terminal (lever 2, legacy "N + 2"). Receives pre-compressed `BgzfBlock`s
+//! from `BgzfCompress` and writes them directly to disk.
+
+use std::fs::File;
+use std::io::{self, BufWriter, Write};
+use std::path::Path;
+
+use fgumi_bgzf::{BGZF_EOF, InlineBgzfCompressor};
+use noodles::sam::Header;
+use parking_lot::Mutex;
+
+use crate::types::BgzfBlock;
+use fgumi_pipeline_core::{
+    header::HeaderHandle,
+    step::{Affinity, DetachedGroup, Step, StepCtx, StepKind, StepOutcome, StepProfile},
+};
+
+/// `Serial + sticky` BAM sink (or `Detached` — see [`Self::with_detached`])
+/// that consumes pre-compressed `BgzfBlock`s.
+pub struct WriteBgzfFile {
+    state: Mutex<Option<WriterState>>,
+    name: &'static str,
+    /// When `Some`, advertise `StepKind::Detached` so the framework drives this
+    /// sink on its own dedicated driver thread (off the work-stealing pool) in the
+    /// given [`DetachedGroup`], instead of `Serial + Affinity::Writer`. The caller
+    /// (e.g. the sort chain) supplies the group via [`Self::with_detached`], so
+    /// this generic sink carries no chain-specific grouping. `None` (the default)
+    /// keeps the pool-scheduled writer that every other chain uses.
+    detached_group: Option<DetachedGroup>,
+}
+
+struct WriterState {
+    out: BufWriter<File>,
+    pending_header: Option<PendingHeader>,
+}
+
+/// Transform applied to the aligner's runtime-resolved header before it is
+/// written. Lets a post-`Align` stage (sort-order rewrite, consensus header,
+/// clip) re-apply its header change on top of the resolved header — which
+/// carries the aligner's runtime `@PG`/`@RG`/`@CO` — instead of discarding that
+/// provenance by writing a build-time header.
+pub type ResolvedHeaderTransform = Box<dyn Fn(Header) -> io::Result<Header> + Send + Sync>;
+
+struct PendingHeader {
+    handle: HeaderHandle,
+    compression_level: u32,
+    transform: Option<ResolvedHeaderTransform>,
+}
+
+impl WriteBgzfFile {
+    /// Open `path`, BGZF-compress and write the BAM header bytes, return
+    /// the sink ready to receive `BgzfBlock`s.
+    ///
+    /// # Errors
+    ///
+    /// Returns I/O errors from path open or header write.
+    pub fn new<P: AsRef<Path>>(
+        path: P,
+        header: &Header,
+        compression_level: u32,
+    ) -> io::Result<Self> {
+        let file = File::create(path.as_ref())?;
+        let mut out = BufWriter::with_capacity(256 * 1024, file);
+
+        let mut header_bytes = Vec::new();
+        fgumi_bam_io::write_bam_header(&mut header_bytes, header)
+            .map_err(|e| io::Error::other(format!("write_bam_header: {e}")))?;
+
+        let mut hc = InlineBgzfCompressor::new(compression_level);
+        hc.write_all(&header_bytes)?;
+        hc.flush()?;
+        hc.write_blocks_to(&mut out)?;
+
+        Ok(Self {
+            state: Mutex::new(Some(WriterState { out, pending_header: None })),
+            name: "WriteBgzfFile",
+            detached_group: None,
+        })
+    }
+
+    /// Run this sink on a dedicated `StepKind::Detached` driver thread (in the
+    /// given [`DetachedGroup`]) instead of as a pool-scheduled `Serial +
+    /// Affinity::Writer` step. Used ONLY on the standalone-sort terminal (lever 2):
+    /// it frees a pool worker for the compression-bound work, matching the legacy
+    /// sort's dedicated writer thread. The caller chooses the group so this generic
+    /// sink stays chain-agnostic. The `try_run` body and the bytes it writes are
+    /// unchanged — the driver pops blocks in the same (reorder-stage-ordered)
+    /// sequence — so the output BAM is byte-identical to the pool-scheduled writer.
+    /// Affinity is ignored for `Detached`.
+    #[must_use]
+    pub fn with_detached(mut self, group: DetachedGroup) -> Self {
+        self.detached_group = Some(group);
+        self
+    }
+
+    /// Open `path` and return the sink with the BAM header write
+    /// deferred until an upstream step resolves `handle`.
+    ///
+    /// `transform`, when `Some`, is applied to the resolved header before it is
+    /// written — see [`ResolvedHeaderTransform`] for why this exists; pass `None`
+    /// when the resolved header should be written unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns I/O errors from path open. Header-write errors are
+    /// surfaced from `try_run` once the handle resolves.
+    pub fn new_with_handle<P: AsRef<Path>>(
+        path: P,
+        handle: HeaderHandle,
+        compression_level: u32,
+        transform: Option<ResolvedHeaderTransform>,
+    ) -> io::Result<Self> {
+        let file = File::create(path.as_ref())?;
+        let out = BufWriter::with_capacity(256 * 1024, file);
+        Ok(Self {
+            state: Mutex::new(Some(WriterState {
+                out,
+                pending_header: Some(PendingHeader { handle, compression_level, transform }),
+            })),
+            name: "WriteBgzfFile",
+            detached_group: None,
+        })
+    }
+
+    fn try_write_pending_header(state: &mut WriterState) -> io::Result<bool> {
+        let Some(pending) = state.pending_header.as_ref() else {
+            return Ok(true);
+        };
+        let header_clone = match pending.handle.try_get() {
+            None => return Ok(false),
+            Some(Err(e)) => return Err(e),
+            Some(Ok(h)) => h.clone(),
+        };
+        let level = pending.compression_level;
+        // Re-apply the post-align header change (sort order / consensus / clip)
+        // on top of the aligner's runtime-resolved header so its @PG/@RG/@CO
+        // survive into the written header.
+        let header_clone = match &pending.transform {
+            Some(transform) => transform(header_clone)?,
+            None => header_clone,
+        };
+
+        let mut header_bytes = Vec::new();
+        fgumi_bam_io::write_bam_header(&mut header_bytes, &header_clone)
+            .map_err(|e| io::Error::other(format!("write_bam_header: {e}")))?;
+        let mut hc = InlineBgzfCompressor::new(level);
+        hc.write_all(&header_bytes)?;
+        hc.flush()?;
+        hc.write_blocks_to(&mut state.out)?;
+
+        state.pending_header = None;
+        Ok(true)
+    }
+}
+
+impl Step for WriteBgzfFile {
+    type Input = BgzfBlock;
+    type Outputs = ();
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            // Detached (own driver thread) when a group was set via
+            // `with_detached`; otherwise the default pool-scheduled Serial + sticky
+            // writer. `sticky` is irrelevant for Detached (it never enters a
+            // worker's worklist).
+            kind: if self.detached_group.is_some() { StepKind::Detached } else { StepKind::Serial },
+            sticky: true,
+            output_queues: vec![],
+            branch_ordering: vec![],
+        }
+    }
+
+    fn detached_group(&self) -> DetachedGroup {
+        // The caller-supplied group (the sort chain passes `SORT_IO_GROUP`);
+        // `PerStep` fallback is unreachable for a Serial (non-detached) writer
+        // since `detached_group()` is only consulted for `Detached` steps.
+        self.detached_group.unwrap_or(DetachedGroup::PerStep)
+    }
+
+    fn affinity(&self) -> Affinity {
+        // Ignored for `Detached` (no pool worker drives it); kept for the
+        // default Serial path where it pins the writer to the last worker.
+        Affinity::Writer
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        let mut guard = self.state.lock();
+        let Some(state) = guard.as_mut() else {
+            return Ok(StepOutcome::Finished);
+        };
+
+        let header_ready = Self::try_write_pending_header(state)?;
+        if header_ready && let Some(block) = ctx.input.pop() {
+            state.out.write_all(&block.bytes)?;
+            return Ok(StepOutcome::Progress);
+        }
+
+        if ctx.input.is_drained() {
+            if !header_ready {
+                return Err(io::Error::other(
+                    "WriteBgzfFile: input drained before HeaderHandle was resolved",
+                ));
+            }
+            state.out.write_all(&BGZF_EOF)?;
+            state.out.flush()?;
+            let _ = guard.take();
+            return Ok(StepOutcome::Finished);
+        }
+        Ok(StepOutcome::NoProgress)
+    }
+}
+
+impl Drop for WriteBgzfFile {
+    /// Cleanup-only drop. The BGZF EOF marker is written **exclusively** by the
+    /// drained-finish path in `try_run` (which then takes the state so this drop
+    /// is a no-op for a normally-finished sink). If state is still present here
+    /// the sink was dropped before that path ran — i.e. an aborted/partial
+    /// stream — so we deliberately do **not** append `BGZF_EOF`: stamping the
+    /// EOF marker onto a truncated BAM would make it look like a complete stream
+    /// and hide the truncation from downstream readers. We only flush whatever
+    /// bytes were already buffered so the on-disk file reflects what was written
+    /// (and stays detectably truncated). A still-pending header means nothing
+    /// valid was written, so leave the file empty.
+    fn drop(&mut self) {
+        let mut guard = self.state.lock();
+        if let Some(mut state) = guard.take() {
+            if state.pending_header.is_some() {
+                return;
+            }
+            let _ = state.out.flush();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_header() -> Header {
+        Header::default()
+    }
+
+    #[test]
+    fn profile_advertises_serial_writer_sink() {
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        let header = empty_header();
+        let step = WriteBgzfFile::new(&path, &header, 1).unwrap();
+        let profile = step.profile();
+        assert_eq!(profile.name, "WriteBgzfFile");
+        assert_eq!(profile.kind, StepKind::Serial);
+        assert!(profile.sticky);
+        assert_eq!(step.affinity(), Affinity::Writer);
+        assert_eq!(profile.output_queues.len(), 0);
+        assert_eq!(profile.branch_ordering.len(), 0);
+    }
+
+    /// L2.6: `with_detached()` flips the profile kind to `Detached` (its own
+    /// thread, off the pool) while leaving everything else — name, the
+    /// (now-irrelevant) sticky flag, the empty output edges — unchanged. The
+    /// default constructors stay `Serial`, so only the standalone-sort terminal
+    /// that opts in is affected.
+    #[test]
+    fn with_detached_advertises_detached_kind() {
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        let header = empty_header();
+        let step = WriteBgzfFile::new(&path, &header, 1)
+            .unwrap()
+            .with_detached(DetachedGroup::Shared("test-io"));
+        let profile = step.profile();
+        assert_eq!(profile.name, "WriteBgzfFile");
+        assert_eq!(profile.kind, StepKind::Detached);
+        assert_eq!(step.detached_group(), DetachedGroup::Shared("test-io"));
+        assert_eq!(profile.output_queues.len(), 0);
+    }
+
+    #[test]
+    fn header_only_round_trip() {
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        let header = empty_header();
+        let step = WriteBgzfFile::new(&path, &header, 1).unwrap();
+        let mut guard = step.state.lock();
+        let mut state = guard.take().expect("state present");
+        state.out.write_all(&BGZF_EOF).unwrap();
+        state.out.flush().unwrap();
+        drop(guard);
+
+        let bytes = std::fs::read(&path).unwrap();
+        assert!(bytes.len() >= 28, "BGZF EOF + header should be at least 28 bytes");
+        assert_eq!(&bytes[0..2], &[0x1f, 0x8b], "BGZF/gzip magic at start");
+        let tail = &bytes[bytes.len() - 28..];
+        assert_eq!(tail, &BGZF_EOF, "file ends with BGZF EOF marker");
+    }
+
+    /// Positive coverage for the drained-finish branch of `try_run`, driven
+    /// through a real 2-step pipeline (block source → sink): the sink must write
+    /// exactly one trailing `BGZF_EOF` and retire its state. The negative branch
+    /// (`drop_before_finish_does_not_append_eof_marker`) and the by-hand EOF
+    /// (`header_only_round_trip`) left this positive path — the one that decides
+    /// whether an output BAM is a valid, EOF-terminated stream — otherwise unpinned.
+    #[test]
+    fn try_run_drained_finish_writes_exactly_one_eof() {
+        use fgumi_pipeline_core::{
+            Unpushed,
+            builder::{Pipeline, PipelineConfig},
+            held::HeldSlot,
+            outputs::OrderedBytesSingle,
+            queues::QueueSpec,
+            reorder::BranchOrdering,
+        };
+
+        /// Exclusive source draining a `Vec<BgzfBlock>`, one block per `try_run`.
+        struct BlockSource {
+            blocks: Vec<BgzfBlock>,
+            held: HeldSlot<Unpushed<BgzfBlock>>,
+        }
+        impl Step for BlockSource {
+            type Input = ();
+            type Outputs = OrderedBytesSingle<BgzfBlock>;
+            fn profile(&self) -> StepProfile {
+                StepProfile {
+                    name: "BlockSource",
+                    kind: StepKind::Exclusive,
+                    sticky: true,
+                    output_queues: vec![QueueSpec::ByteBounded { limit_bytes: 1 << 20 }],
+                    branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+                }
+            }
+            fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+                if let Some(unpushed) = self.held.take()
+                    && let Err(again) = ctx.outputs.retry(unpushed)
+                {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Progress);
+                }
+                let Some(block) = self.blocks.pop() else {
+                    return Ok(StepOutcome::Finished);
+                };
+                if let Err(unpushed) = ctx.outputs.push(block) {
+                    self.held.put(unpushed);
+                }
+                Ok(StepOutcome::Progress)
+            }
+        }
+
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        let sink = WriteBgzfFile::new(&path, &empty_header(), 1).unwrap();
+
+        // Two payload blocks with dense ordinals (0, 1). `pop()` drains the tail
+        // first, so ordinal 0 is emitted before ordinal 1 for the `ByItemOrdinal`
+        // reorder stage. The bytes are arbitrary non-EOF markers.
+        let blocks = vec![
+            BgzfBlock { batch_serial: 1, bytes: vec![0xAB; 16], uncompressed_size: 0 },
+            BgzfBlock { batch_serial: 0, bytes: vec![0xCD; 16], uncompressed_size: 0 },
+        ];
+        let source = BlockSource { blocks, held: HeldSlot::new() };
+
+        let builder = Pipeline::builder();
+        builder.chain(source).chain(sink).into_sink_marker();
+        let pipeline = builder.build().expect("pipeline builds");
+        pipeline
+            .run(PipelineConfig { threads: 2, ..Default::default() })
+            .expect("pipeline runs to completion");
+
+        let bytes = std::fs::read(&path).unwrap();
+        assert!(bytes.len() >= 28, "header + payload + EOF present");
+        assert_eq!(
+            &bytes[bytes.len() - 28..],
+            &BGZF_EOF,
+            "the drained-finish path terminates the stream with a BGZF EOF marker"
+        );
+        // Exactly one trailing EOF: stripping it must not reveal a second, which
+        // is what a stray `Drop`-side append would produce.
+        let without_eof = &bytes[..bytes.len() - 28];
+        assert!(
+            without_eof.len() < 28 || without_eof[without_eof.len() - 28..] != BGZF_EOF,
+            "only the drained-finish path may append EOF; Drop must not add a second"
+        );
+        // Both payload blocks reached disk.
+        assert!(bytes.windows(16).any(|w| w == [0xAB; 16]), "first block written");
+        assert!(bytes.windows(16).any(|w| w == [0xCD; 16]), "second block written");
+    }
+
+    #[test]
+    fn new_with_handle_defers_header_until_resolved() {
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        let handle = HeaderHandle::new();
+        let step = WriteBgzfFile::new_with_handle(&path, handle.clone(), 1, None).unwrap();
+
+        let bytes_before = std::fs::read(&path).unwrap();
+        assert_eq!(bytes_before.len(), 0, "no bytes written until header resolves");
+
+        {
+            let mut guard = step.state.lock();
+            let state = guard.as_mut().expect("state present");
+            assert!(state.pending_header.is_some(), "handle still pending");
+            let wrote = WriteBgzfFile::try_write_pending_header(state).unwrap();
+            assert!(!wrote, "unresolved handle should yield without writing");
+            assert!(state.pending_header.is_some(), "still pending after no-op probe");
+        }
+        let bytes_mid = std::fs::read(&path).unwrap();
+        assert_eq!(bytes_mid.len(), 0, "still nothing on disk after no-op probe");
+
+        handle.set(empty_header()).expect("first set");
+        {
+            let mut guard = step.state.lock();
+            let state = guard.as_mut().expect("state present");
+            let wrote = WriteBgzfFile::try_write_pending_header(state).unwrap();
+            assert!(wrote, "resolved handle should write");
+            assert!(state.pending_header.is_none(), "pending slot cleared");
+            state.out.flush().unwrap();
+        }
+        let bytes_after = std::fs::read(&path).unwrap();
+        assert!(bytes_after.len() >= 2, "header BGZF block emitted");
+        assert_eq!(&bytes_after[0..2], &[0x1f, 0x8b], "BGZF/gzip magic at start");
+    }
+
+    #[test]
+    fn resolved_header_transform_runs_on_the_resolved_header() {
+        use std::sync::{Arc, Mutex as StdMutex};
+
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        let handle = HeaderHandle::new();
+
+        // Capture the header the transform is handed, to prove it is the
+        // runtime-resolved (aligner) header — not a build-time header.
+        let seen: Arc<StdMutex<Option<Header>>> = Arc::new(StdMutex::new(None));
+        let seen_for_closure = Arc::clone(&seen);
+        let transform: ResolvedHeaderTransform = Box::new(move |resolved: Header| {
+            *seen_for_closure.lock().unwrap() = Some(resolved.clone());
+            Ok(resolved)
+        });
+
+        let step =
+            WriteBgzfFile::new_with_handle(&path, handle.clone(), 1, Some(transform)).unwrap();
+
+        // Nothing is written (and the transform must not run) until the handle
+        // resolves.
+        {
+            let mut guard = step.state.lock();
+            let state = guard.as_mut().expect("state present");
+            assert!(!WriteBgzfFile::try_write_pending_header(state).unwrap());
+        }
+        assert!(seen.lock().unwrap().is_none(), "transform must not run before resolution");
+
+        // Resolve with a distinctive header standing in for the aligner's
+        // runtime-resolved header.
+        let resolved = Header::builder().add_comment("ALIGNER-PROVENANCE").build();
+        handle.set(resolved.clone()).expect("set");
+        {
+            let mut guard = step.state.lock();
+            let state = guard.as_mut().expect("state present");
+            assert!(WriteBgzfFile::try_write_pending_header(state).unwrap(), "resolved -> written");
+            state.out.flush().unwrap();
+        }
+
+        // The transform ran, and it received the resolved header — so a
+        // post-align stage's transform is applied on top of the aligner header.
+        assert_eq!(
+            seen.lock().unwrap().as_ref(),
+            Some(&resolved),
+            "transform must receive the resolved header, preserving aligner provenance",
+        );
+        assert!(std::fs::read(&path).unwrap().len() >= 2, "header block was written");
+    }
+
+    #[test]
+    fn new_with_handle_propagates_poison() {
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        let handle = HeaderHandle::new();
+        let step = WriteBgzfFile::new_with_handle(&path, handle.clone(), 1, None).unwrap();
+
+        handle.poison(io::Error::new(io::ErrorKind::BrokenPipe, "aligner died")).unwrap();
+        let mut guard = step.state.lock();
+        let state = guard.as_mut().expect("state present");
+        let err = WriteBgzfFile::try_write_pending_header(state).expect_err("poison");
+        assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+        assert_eq!(err.to_string(), "aligner died");
+    }
+
+    #[test]
+    fn drop_before_finish_does_not_append_eof_marker() {
+        // A sink dropped before the drained-finish path in `try_run` (e.g. a
+        // pipeline abort) must NOT append the BGZF EOF marker. Appending it
+        // would stamp a "complete stream" signature onto a truncated BAM,
+        // hiding the truncation from downstream readers. See the `Drop` doc.
+        let path = tempfile::NamedTempFile::new().unwrap();
+        let path_buf = path.path().to_path_buf();
+        let header = empty_header();
+        // `new` eagerly writes the header (pending_header is None), so the
+        // only thing standing between this state and a valid EOF marker is
+        // the `try_run` drained-finish path, which we never reach.
+        let step = WriteBgzfFile::new(&path_buf, &header, 1).unwrap();
+        drop(step);
+
+        let bytes = std::fs::read(&path_buf).unwrap();
+        assert!(bytes.len() >= 28, "header bytes should be on disk");
+        let tail = &bytes[bytes.len() - 28..];
+        assert_ne!(tail, &BGZF_EOF, "aborted output must not end with a valid BGZF EOF marker");
+    }
+
+    #[test]
+    fn drop_with_unresolved_handle_leaves_empty_file() {
+        let path = tempfile::NamedTempFile::new().unwrap();
+        let path_buf = path.path().to_path_buf();
+        let handle = HeaderHandle::new();
+        let step = WriteBgzfFile::new_with_handle(&path_buf, handle, 1, None).unwrap();
+        drop(step);
+
+        let bytes = std::fs::read(&path_buf).unwrap();
+        assert_eq!(bytes.len(), 0, "Drop with unresolved handle must skip EOF — see Drop doc");
+    }
+}

--- a/crates/fgumi-pipeline-io/src/sink/write_raw.rs
+++ b/crates/fgumi-pipeline-io/src/sink/write_raw.rs
@@ -1,0 +1,187 @@
+//! `WriteRawFile` sink step: writes a byte stream verbatim to a file or stdout,
+//! with **no** container header and **no** BGZF EOF marker.
+//!
+//! Unlike [`super::write_bgzf::WriteBgzfFile`] (which is BAM-specific — it emits
+//! a BAM header on open and a BGZF EOF on drain), this sink just concatenates
+//! the `bytes` of each block it receives. It backs FASTQ output: the chain's
+//! FASTQ-encode step produces `DecompressedBlock`s of FASTQ text, which either
+//! go straight here (plain output / stdout) or through `BgzfCompress` first
+//! (`.gz`/`.bgz` output, producing `BgzfBlock`s — still just bytes to write).
+//!
+//! `Serial + Affinity::Writer + sticky`, matching `WriteBgzfFile`: exactly one
+//! shared instance drains the (reorder-ordered) block stream to the sink.
+
+use std::fs::File;
+use std::io::{self, BufWriter, Write};
+use std::path::Path;
+
+use parking_lot::Mutex;
+
+use crate::types::{BgzfBlock, DecompressedBlock};
+use fgumi_pipeline_core::{
+    item::HeapSize,
+    step::{Affinity, Step, StepCtx, StepKind, StepOutcome, StepProfile},
+};
+
+/// A pipeline block whose payload is a run of bytes to write verbatim.
+pub trait RawBytesBlock: Send + HeapSize + 'static {
+    /// The bytes to write for this block.
+    fn bytes(&self) -> &[u8];
+}
+
+impl RawBytesBlock for DecompressedBlock {
+    fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+impl RawBytesBlock for BgzfBlock {
+    fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+/// `Serial + sticky` sink that writes each block's bytes verbatim to a file or
+/// stdout. Generic over the block type so it serves both the plain
+/// (`DecompressedBlock`) and BGZF-compressed (`BgzfBlock`) FASTQ tails.
+pub struct WriteRawFile<B> {
+    state: Mutex<Option<BufWriter<Box<dyn Write + Send>>>>,
+    /// Bytes appended once, after the last block, on a clean drain. Empty for
+    /// plain output; the 28-byte BGZF EOF marker for BGZF output so the `.gz`
+    /// stream is a complete, non-truncated BGZF file.
+    trailer: &'static [u8],
+    _marker: std::marker::PhantomData<fn(B)>,
+}
+
+impl<B> WriteRawFile<B> {
+    /// Open `path` for writing (`-` selects stdout), appending `trailer` once
+    /// after the final block on clean completion. No header is written.
+    ///
+    /// # Errors
+    ///
+    /// Returns I/O errors from opening the file.
+    pub fn new<P: AsRef<Path>>(path: P, trailer: &'static [u8]) -> io::Result<Self> {
+        let inner: Box<dyn Write + Send> = if path.as_ref().as_os_str() == "-" {
+            Box::new(io::stdout())
+        } else {
+            Box::new(File::create(path.as_ref())?)
+        };
+        Ok(Self {
+            state: Mutex::new(Some(BufWriter::with_capacity(256 * 1024, inner))),
+            trailer,
+            _marker: std::marker::PhantomData,
+        })
+    }
+}
+
+impl<B: RawBytesBlock> Step for WriteRawFile<B> {
+    type Input = B;
+    type Outputs = ();
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "WriteRawFile",
+            kind: StepKind::Serial,
+            sticky: true,
+            output_queues: vec![],
+            branch_ordering: vec![],
+        }
+    }
+
+    fn affinity(&self) -> Affinity {
+        Affinity::Writer
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        let mut guard = self.state.lock();
+        let Some(out) = guard.as_mut() else {
+            return Ok(StepOutcome::Finished);
+        };
+
+        if let Some(block) = ctx.input.pop() {
+            out.write_all(block.bytes())?;
+            return Ok(StepOutcome::Progress);
+        }
+
+        if ctx.input.is_drained() {
+            // Clean end-of-stream: append the trailer (e.g. the BGZF EOF marker)
+            // exactly once, then flush and retire the sink.
+            if !self.trailer.is_empty() {
+                out.write_all(self.trailer)?;
+            }
+            out.flush()?;
+            let _ = guard.take();
+            return Ok(StepOutcome::Finished);
+        }
+        Ok(StepOutcome::NoProgress)
+    }
+}
+
+impl<B> Drop for WriteRawFile<B> {
+    /// Cleanup-only drop: flush buffered bytes but deliberately do **not** write
+    /// `trailer`. The trailer (e.g. the BGZF EOF marker for `.gz` output) is
+    /// written exclusively by the drained-finish path in `try_run`, which then
+    /// takes the state so this drop is a no-op for a cleanly-finished sink. If
+    /// state is still present here the stream was aborted mid-way, and stamping
+    /// the BGZF EOF onto a truncated `.gz` would make it look complete and hide
+    /// the truncation from readers — so we withhold it, exactly as
+    /// `WriteBgzfFile::drop` does.
+    fn drop(&mut self) {
+        if let Some(mut out) = self.state.lock().take() {
+            let _ = out.flush();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_bytes_block_exposes_payload() {
+        let plain = DecompressedBlock { batch_serial: 0, bytes: b"ACGT".to_vec() };
+        assert_eq!(RawBytesBlock::bytes(&plain), b"ACGT");
+        let bgzf = BgzfBlock { batch_serial: 0, bytes: b"\x1f\x8b".to_vec(), uncompressed_size: 4 };
+        assert_eq!(RawBytesBlock::bytes(&bgzf), b"\x1f\x8b");
+    }
+
+    #[test]
+    fn profile_is_serial_writer_sink() {
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        let step = WriteRawFile::<DecompressedBlock>::new(&path, b"").unwrap();
+        let profile = step.profile();
+        assert_eq!(profile.name, "WriteRawFile");
+        assert_eq!(profile.kind, StepKind::Serial);
+        assert!(profile.sticky);
+        assert_eq!(step.affinity(), Affinity::Writer);
+    }
+
+    /// A sink dropped before the drained-finish path (an aborted stream) must
+    /// NOT append its trailer — stamping the BGZF EOF onto a truncated `.gz`
+    /// would hide the truncation. Mirrors
+    /// `WriteBgzfFile::drop_before_finish_does_not_append_eof_marker`.
+    #[test]
+    fn drop_before_finish_omits_trailer() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        let trailer = b"\x1f\x8bTRAILER";
+        let step = WriteRawFile::<BgzfBlock>::new(&path, trailer).unwrap();
+        // Write some payload bytes directly, then drop without draining (abort).
+        {
+            let mut guard = step.state.lock();
+            guard.as_mut().unwrap().write_all(b"PAYLOAD").unwrap();
+        }
+        drop(step);
+
+        let bytes = std::fs::read(&path).unwrap();
+        assert_eq!(bytes, b"PAYLOAD", "aborted stream must contain payload only, no trailer");
+        assert!(!bytes.ends_with(trailer), "aborted stream must not end with the trailer");
+    }
+
+    #[test]
+    fn dash_path_selects_stdout_without_error() {
+        // `-` must construct a stdout-backed sink without touching the filesystem.
+        let step = WriteRawFile::<DecompressedBlock>::new("-", b"").unwrap();
+        assert!(step.state.lock().is_some());
+    }
+}

--- a/crates/fgumi-pipeline-io/src/sort/arena_ingest.rs
+++ b/crates/fgumi-pipeline-io/src/sort/arena_ingest.rs
@@ -1,0 +1,2623 @@
+//! `ReadBlocks` serial arena-admit step, `InflateToArena` parallel step, and
+//! `FindBoundariesAndSort` serial step.
+//!
+//! `ReadBlocks`: serial step that consumes raw `BgzfBlock`s, uses an [`ArenaPool`]
+//! (capacity 1) to acquire/reuse arenas, reserves a fixed front region
+//! `[0, FRONT_REGION)` per run for the straddler carry (Task 2), reserves an
+//! uninit slot per block via `grow_uninit` at offsets `>= FRONT_REGION`, and
+//! seals a run when its cumulative uncompressed bytes reach `run_cap = memory_limit`.
+//! Sealed mid-stream runs emit [`ArenaBlock`]s with `seals_to_spill = true`;
+//! the final residual run emits with `seals_to_spill = false`.
+//! This is the second `unsafe` site in `fgumi-pipeline-io`; see CLAUDE.md
+//! §"Approved hot-path unsafe (parallel-inflate sort ingest, fgumi-pipeline-io)"
+//! for the full justification.
+//!
+//! `InflateToArena`: each worker decompresses one BGZF block directly into its
+//! disjoint arena slot via [`fgumi_bgzf::decompress_into_slice`].  This is the first
+//! `unsafe` site in `fgumi-pipeline-io`; see CLAUDE.md §"Approved hot-path
+//! unsafe (parallel-inflate sort ingest, fgumi-pipeline-io)" for the
+//! full justification and SAFETY invariant.
+//!
+//! `FindBoundariesAndSort`: serial step that scans a run's contiguous arena span
+//! directly (no copy), skips the BAM header via [`crate::boundaries::bam_header_len`],
+//! builds `(body_offset, block_size)` refs, sorts via
+//! [`fgumi_sort::coordinate_chunk_from_arena_refs`], and emits
+//! `SortChunkEvent::Residual` + `AllAnnounced`.  Single-run / no-spill scope;
+//! multi-run seal and straddler handling are 3b.4.
+//!
+//! Together these three steps form the BAM sort ingest front for the block-input
+//! path.  The chain builder's `add_sort` (`src/lib/pipeline/chains/builder.rs`)
+//! wires them as `ReadBlocks → InflateToArena → FindBoundariesAndSort` (feeding
+//! the Phase-1 spill/merge tail) when the sort source is raw BGZF blocks.
+
+use std::collections::VecDeque;
+use std::io;
+use std::sync::Arc;
+
+use fgumi_bgzf::{Decompressor, decompress_into_slice};
+use fgumi_sort::{
+    ArenaPool, InMemoryChunk, PooledSegmentedBuf, RawSortKey, RecordRef,
+    coordinate_chunk_from_refs, extract_coordinate_key_inline, queryname_chunk_from_arena_refs,
+};
+
+use crate::types::BgzfBlock;
+
+use fgumi_pipeline_core::held::HeldSlot;
+use fgumi_pipeline_core::item::{HeapSize, Ordered};
+use fgumi_pipeline_core::outputs::{OrderedBytesSingle, Single};
+use fgumi_pipeline_core::queues::QueueSpec;
+use fgumi_pipeline_core::reorder::BranchOrdering;
+use fgumi_pipeline_core::step::{DetachedGroup, Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use fgumi_pipeline_core::{HeldRetry, Unpushed};
+
+use crate::boundaries::bam_header_len;
+use crate::sort::protocol::{MemoryChunkErased, SortChunkEvent};
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/// Reserved front region at the start of every run's arena, in bytes.
+///
+/// Block 0 always lands at offset `FRONT_REGION`.  The region `[0, FRONT_REGION)`
+/// is left uninitialized by `ReadBlocks` and filled by `FindBoundariesAndSort`
+/// when it writes a carried straddler from the previous run (Task 2, 3b.4).
+/// Must be larger than any single BAM record; 8 MiB covers all realistic records.
+pub const FRONT_REGION: usize = 8 * 1024 * 1024;
+
+/// Maximum uncompressed size of a single BGZF block: the BGZF spec bounds an
+/// uncompressed block at 2^16 = 65536 bytes.  Used to cap a run's seal budget
+/// (`run_cap`) so the single-segment-per-run invariant
+/// `FRONT_REGION + Σ(block ISIZE) ≤ segment_size` holds with a true upper bound
+/// of margin (see `ReadBlocks::new`).  This must be `>=` any real block's ISIZE;
+/// 65536 is the exact spec maximum, so the headroom is a genuine bound rather
+/// than relying on the `< run_cap` cumulative check being off by one.
+const MAX_BGZF_BLOCK: usize = 1 << 16;
+
+/// Bytes ahead of the current scan cursor to software-prefetch in the
+/// `FindBoundariesAndSort` boundary+key scan.  Chosen from a microbench over a
+/// cold ~2.6 GiB arena (matching the ~220 B/record production density): 2 KiB
+/// gave the best speedup (~15%); ≤1 KiB was negligible (too little lead time),
+/// 4 KiB matched 2 KiB.  At ~220 B/record this is ~9 records of lead.
+const SCAN_PREFETCH_DISTANCE: usize = 2048;
+
+/// Max blocks `ReadBlocks` admits per `try_run` dispatch.
+///
+/// `ReadBlocks` runs on the coordination driver (`StepKind::Detached`), whose
+/// drain-first `round_robin_dispatch` restarts the whole downstream walk on every
+/// `Progress` (see `runtime::driver`): admitting one block per dispatch made this
+/// serial admit the input-side throughput bottleneck — the raw-block reader
+/// upstream backed up while the parallel `InflateToArena` pool workers starved
+/// (empty pops), leaving the pool short of full CPU occupancy. Admitting a bounded
+/// batch per dispatch amortises the per-dispatch queue/reorder overhead so the
+/// admit keeps the inflaters saturated, while the cap bounds how long the driver
+/// dwells on admit (fairness vs the group's other steps) and how far it runs
+/// ahead of the byte/count-bounded output queue (which backpressures early anyway).
+const ADMIT_BATCH: usize = 64;
+
+/// Software-prefetch (read, into L1, temporal) the cache line containing `byte`.
+/// The `FindBoundariesAndSort` scan walks the run's arena cold (it was written by
+/// the parallel `InflateToArena` workers long before this serial scan runs), so it
+/// is latency-bound on cache misses; prefetching [`SCAN_PREFETCH_DISTANCE`] ahead
+/// hides them.  `cfg`-gated to the supported architectures; a no-op elsewhere.
+///
+/// SAFETY note: this is the only place `fgumi-pipeline-io` uses an architecture
+/// intrinsic.  Both `prfm` (`aarch64`) and `_mm_prefetch` (`x86_64`) are
+/// *non-faulting hints* — they never read or write observable memory and never
+/// trap, even on an unmapped address.  `byte` is a live `&u8` (the caller
+/// bounds-checks the index), so the pointer is valid to name.  See CLAUDE.md
+/// §"Approved hot-path unsafe (parallel-inflate sort ingest, fgumi-pipeline-io)".
+#[inline]
+fn prefetch_read_l1(byte: &u8) {
+    let ptr: *const u8 = byte;
+    #[cfg(target_arch = "aarch64")]
+    #[allow(unsafe_code)]
+    // SAFETY: `prfm pldl1keep` is a non-faulting prefetch hint over a valid pointer.
+    unsafe {
+        core::arch::asm!(
+            "prfm pldl1keep, [{p}]",
+            p = in(reg) ptr,
+            options(nostack, readonly, preserves_flags),
+        );
+    }
+    #[cfg(target_arch = "x86_64")]
+    #[allow(unsafe_code)]
+    // SAFETY: `_mm_prefetch` is a non-faulting prefetch hint over a valid pointer.
+    unsafe {
+        core::arch::x86_64::_mm_prefetch::<{ core::arch::x86_64::_MM_HINT_T0 }>(ptr.cast());
+    }
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+    {
+        let _ = ptr; // no portable stable prefetch; hint is a no-op on other arches
+    }
+}
+
+// ============================================================================
+// ReadBlocks: serial arena-admit step
+// ============================================================================
+
+/// `Serial` step that consumes raw [`BgzfBlock`]s, acquires arenas from an
+/// [`ArenaPool`] (capacity 1), grows the whole arena segment to full capacity
+/// once at acquire (so block slots can be sliced by inflate workers without
+/// further `&mut` growth), reserves a front region `[0, FRONT_REGION)` per run,
+/// assigns each block a slot at an arithmetic offset (`FRONT_REGION` + prefix-sum
+/// of ISIZE), seals a run when cumulative uncompressed bytes reach `memory_limit`,
+/// and emits one [`ArenaBlock`] per block.
+///
+/// **Eager (streaming) emission.** Blocks are emitted *as they are read*, not
+/// buffered until the run seals: the `Arc<PooledSegmentedBuf>` is created at
+/// acquire and the slot offset is known immediately (from the block's ISIZE,
+/// without inflating), so an inflate worker can start on block 0 while
+/// `ReadBlocks` is still reading block 5000 — the Read‖Inflate overlap.  Exactly
+/// ONE block is withheld at a time (`last_block`): `is_last_of_run` and
+/// `seals_to_spill` are run-level facts known only when the run seals, so the
+/// most-recently-admitted block is held until either a successor in the same run
+/// arrives (confirming it is *not* last → emit it tagged `false`) or the run
+/// seals (it *is* last → stamp `is_last_of_run`/`seals_to_spill` and emit).  This
+/// single held block coincides with the deferred-seal block, so the two are one
+/// mechanism.
+///
+/// Mid-stream seals set `seals_to_spill = true`; the final (residual) run sets
+/// `seals_to_spill = false`.  Only the LAST block of a run carries a meaningful
+/// `is_last_of_run`/`seals_to_spill`; downstream (`FindBoundariesAndSort`) reads
+/// those fields only on the `is_last_of_run` block, so non-last blocks emit
+/// `is_last_of_run = false, seals_to_spill = false`.
+///
+/// With pool capacity 1, the next run's arena cannot be acquired until the
+/// prior run's [`Arc<PooledSegmentedBuf>`] drops (i.e. after `CompressSpill`
+/// consumes and releases it).  If acquisition fails, `try_run` returns
+/// `NoProgress` (backpressure) and retries on the next call.
+pub struct ReadBlocks {
+    /// Bounded pool (capacity 1) that owns arena storage and reuses it across runs.
+    pool: Arc<ArenaPool>,
+    /// Size of each arena segment (`FRONT_REGION + run_cap + MAX_BGZF_BLOCK`); the
+    /// whole segment is grown live once at acquire.
+    segment_size: usize,
+    /// `Arc`-shared arena for the current run, grown to full capacity at acquire so
+    /// blocks (and their inflate slots) can be handed out eagerly without further
+    /// `&mut` growth; `None` until the first block of the current run is admitted,
+    /// and again after the run seals (dropping this step's handle so the arena can
+    /// return to the pool once all emitted clones release it).
+    arena: Option<Arc<PooledSegmentedBuf>>,
+    /// Next slot offset within the current run's arena (set to `FRONT_REGION` on a
+    /// fresh run, then advanced by each block's ISIZE).
+    run_offset: u64,
+    /// The most-recently-admitted block of the current run, withheld from emission
+    /// until we learn whether another block joins this run, so `is_last_of_run` /
+    /// `seals_to_spill` (run-level facts known only at seal) can be stamped on it.
+    last_block: Option<ArenaBlock>,
+    /// A block popped from the input but not yet admitted because a deferred
+    /// seal fired first and the pool is momentarily exhausted (the just-sealed
+    /// run's arena has not returned yet).  Re-admitted on a later `try_run` once
+    /// the pool yields an arena.  Holding it here prevents losing the block.
+    deferred_block: Option<BgzfBlock>,
+    /// Emitted `ArenaBlock`s ready to push to the output queue.
+    emit: VecDeque<ArenaBlock>,
+    /// Held output slot for the backpressure retry path.
+    held: HeldSlot<Unpushed<ArenaBlock>>,
+    /// Monotonically-increasing ordinal assigned to each admitted block (across all runs).
+    next_ordinal: u64,
+    /// Current run sequence number.
+    run_seq: u32,
+    /// Cumulative uncompressed bytes in the current run (resets on each seal).
+    run_cumulative: usize,
+    /// Budget per run: seal when `run_cumulative >= run_cap`.
+    run_cap: usize,
+    /// Armed when the current run reached `run_cap`, but the seal is DEFERRED
+    /// until the next block arrives.  Deferring by one block guarantees that a
+    /// spill seal is only ever fired when at least one more block follows (so
+    /// the straddler carry from a spilled run always has a subsequent run to
+    /// complete it).  If the input drains while a seal is armed, the run is
+    /// sealed as the RESIDUAL instead (the final run's last record always
+    /// completes at EOF, so the carry is empty).  Without this, the budget seal
+    /// could fire on the very last input block, emitting a trailing *spill*
+    /// whose carry has no following run — surfacing as a spurious "truncated
+    /// BAM" error.
+    seal_pending: bool,
+    /// Set to `true` after the final run has been emitted.
+    finished: bool,
+    /// Byte limit for the output queue.
+    output_byte_limit: u64,
+}
+
+impl ReadBlocks {
+    /// Create a new `ReadBlocks` step.
+    ///
+    /// - `memory_limit`: bytes of record data a run holds before sealing — the
+    ///   FULL in-memory budget (`--max-memory × threads`, via
+    ///   `resolve_memory_budget`).  This is the SAME spill trigger legacy uses:
+    ///   the front spills to disk ONLY when the data exceeds this budget.  For
+    ///   data that fits the budget the result is exactly ONE in-memory run, ZERO
+    ///   disk spills, and one radix sort over the full budget — legacy's
+    ///   in-memory algorithm and footprint, but with the no-copy arena ingest.
+    /// - `output_byte_limit`: byte-bounds the output queue.
+    ///
+    /// The arena segment is sized so one full run always fits within ONE segment
+    /// (`FRONT_REGION` + the run budget + one deferred-seal tipping block), which
+    /// keeps the `FindBoundariesAndSort` contiguous-slice scan valid WITHOUT
+    /// capping the run below the budget.  (The earlier design fixed the segment at
+    /// 256 MiB and capped `run_cap` to fit it, which forced the front to spill
+    /// even when the data fit `--max-memory` — a wall-clock regression vs legacy.
+    /// Sizing the segment to the budget instead removes that forced spill.)
+    #[must_use]
+    pub fn new(memory_limit: usize, output_byte_limit: u64) -> Self {
+        // Seal a run only when its record data reaches the full budget (legacy's
+        // trigger); never cap below it.
+        let run_cap = memory_limit;
+        // One run = front region + up to `run_cap` of data + the single block that
+        // tips `run_cumulative` over `run_cap` (the deferred seal holds the NEXT
+        // block for the following run, so the current run overshoots by at most one
+        // block).  Sizing the segment to that upper bound guarantees a run is
+        // gap-free within one segment, so the scan's single `arena.slice(..)` over
+        // `[scan_start, run_end)` never spans a segment boundary.
+        let segment_size = FRONT_REGION + run_cap + MAX_BGZF_BLOCK;
+        let pool = ArenaPool::new(1, segment_size);
+        Self {
+            pool,
+            segment_size,
+            arena: None,
+            run_offset: 0,
+            last_block: None,
+            deferred_block: None,
+            emit: VecDeque::new(),
+            held: HeldSlot::new(),
+            next_ordinal: 0,
+            run_seq: 0,
+            run_cumulative: 0,
+            run_cap,
+            seal_pending: false,
+            finished: false,
+            output_byte_limit,
+        }
+    }
+
+    /// Ensure the current run's arena is acquired, grown to full capacity, and
+    /// `Arc`-shared, with `run_offset` reset to `FRONT_REGION`.
+    ///
+    /// Returns `true` if the arena is ready, `false` if the pool is exhausted
+    /// (backpressure: the previous run's chunk has not been consumed yet).
+    ///
+    /// # Side effects
+    ///
+    /// Acquires an arena from the pool, calls `reserve_full_capacity`, then grows
+    /// the ENTIRE segment to `segment_size` live bytes via a single `unsafe`
+    /// `grow_uninit` call (see the `// SAFETY:` comment inside), and wraps it in an
+    /// `Arc<PooledSegmentedBuf>`.  This `grow_uninit` is the second `unsafe` site in
+    /// `fgumi-pipeline-io`; see CLAUDE.md §"Approved hot-path unsafe (parallel-inflate
+    /// sort ingest, fgumi-pipeline-io)" — the `ReadBlocks::ensure_arena` grow-once
+    /// bullet — for the full justification.  Growing once, before sharing, is the
+    /// soundness keystone: every block's slot offset is then computed arithmetically
+    /// (`FRONT_REGION` + prefix-sum of ISIZE) so no further `&mut` growth is needed
+    /// while inflate workers hold disjoint `slice_mut` views.
+    fn ensure_arena(&mut self) -> bool {
+        if self.arena.is_some() {
+            return true;
+        }
+        let Some(mut arena) = self.pool.try_acquire() else {
+            return false;
+        };
+        arena.reserve_full_capacity();
+        // Grow the whole segment to `segment_size` live bytes in ONE call, here on
+        // the serial admit path BEFORE the arena is wrapped in an `Arc` or any slice
+        // is handed out — so no concurrent borrow can exist during the grow.
+        // SAFETY: sole writer, no live borrow (the `Arc` is created only after this
+        // returns).  `segment_size` is exactly the pool's segment size and the
+        // capacity `reserve_full_capacity` just guaranteed, so `grow_uninit` performs
+        // no realloc and the slot stays in one segment.  `u8` has no validity
+        // invariant; every live byte is written exactly once — block slots by their
+        // inflate worker, the `[0, FRONT_REGION)` carry region by `FindBoundariesAndSort`
+        // — before any read.  Bytes never read (the unused tail past a run's end, and
+        // the front region when there is no straddler) are never observed: `FBS` only
+        // ever slices `[scan_start, run_end)`.
+        #[allow(unsafe_code)]
+        let _all = unsafe { arena.grow_uninit(self.segment_size) };
+        // `ArenaPool::try_acquire` already returns the `PooledSegmentedBuf` wrapper
+        // (it wraps internally so a caller cannot orphan a pooled arena — the hang
+        // that motivated making `PooledSegmentedBuf::pooled` private), so the arena
+        // is wrapped by construction here and only needs sharing.
+        self.arena = Some(Arc::new(arena));
+        self.run_offset = FRONT_REGION as u64;
+        true
+    }
+
+    /// Admit one [`BgzfBlock`]: ensure the arena exists, assign the block an
+    /// arithmetic slot offset, and emit it eagerly (the PRIOR withheld block, now
+    /// confirmed to have a same-run successor, is pushed to the output queue; THIS
+    /// block becomes the new withheld `last_block`).
+    ///
+    /// Returns `Ok(())` on success, or `Err(b)` handing the block back if the pool
+    /// is exhausted (the arena could not be acquired) — so the caller never loses
+    /// the block.
+    ///
+    /// No `unsafe` here: the arena was grown to full capacity once by `ensure_arena`,
+    /// so the slot `(offset, len)` is already a live region of the shared arena;
+    /// the inflate worker writes it via `slice_mut`.
+    pub(crate) fn admit_block(&mut self, b: BgzfBlock) -> Result<(), BgzfBlock> {
+        if !self.ensure_arena() {
+            return Err(b);
+        }
+        let arena = self.arena.as_ref().expect("arena present after ensure_arena");
+
+        let len = b.uncompressed_size;
+        let offset = self.run_offset;
+        self.run_offset += u64::from(len);
+
+        let ordinal = self.next_ordinal;
+        self.next_ordinal += 1;
+        self.run_cumulative += len as usize;
+
+        // `is_last_of_run` / `seals_to_spill` are run-level facts known only at seal,
+        // so the just-admitted block is withheld as the tentative last block.  The
+        // PRIOR withheld block now has a same-run successor → it is NOT last → emit it.
+        let block = ArenaBlock {
+            arena: Arc::clone(arena),
+            ordinal,
+            offset,
+            len,
+            block: b.bytes,
+            is_last_of_run: false,
+            run_seq: self.run_seq,
+            seals_to_spill: false,
+        };
+        if let Some(prev) = self.last_block.replace(block) {
+            self.emit.push_back(prev);
+        }
+        Ok(())
+    }
+
+    /// Seal the current run: stamp the withheld `last_block` as the run's final
+    /// block (`is_last_of_run = true` plus the run's `seals_to_spill`), emit it,
+    /// drop this step's arena handle (so the arena can return to the pool once all
+    /// emitted clones release it), and advance `run_seq`.
+    ///
+    /// All non-last blocks of the run were already emitted eagerly by `admit_block`;
+    /// only the single withheld block remains.
+    ///
+    /// `seals_to_spill`: `true` for mid-stream seals (the run becomes a disk spill),
+    /// `false` for the final residual run.
+    ///
+    /// A `seal_run` call always follows at least one admit for the run, so
+    /// `last_block` is `Some`; the `try_run` EOF guard returns before sealing an
+    /// arena-less, blockless state.
+    fn seal_run(&mut self, seals_to_spill: bool) {
+        if let Some(mut last) = self.last_block.take() {
+            last.is_last_of_run = true;
+            last.seals_to_spill = seals_to_spill;
+            self.emit.push_back(last);
+        }
+        // Drop our handle to the sealed run's arena; the emitted blocks (and their
+        // downstream consumers) keep it alive until they release their `Arc` clones,
+        // at which point `PooledSegmentedBuf::drop` returns it to the capacity-1 pool.
+        self.arena = None;
+        self.run_seq += 1;
+        self.run_cumulative = 0;
+        self.run_offset = 0;
+    }
+
+    /// Test seam: admit blocks, then freeze the arena and drain all emitted
+    /// [`ArenaBlock`]s into a `Vec` for direct inspection, bypassing the pipeline
+    /// framework.  Uses `seals_to_spill = false` (residual) for the single flush.
+    #[cfg(test)]
+    pub(crate) fn seal_and_drain_for_test(&mut self) -> Vec<ArenaBlock> {
+        self.seal_run(false);
+        self.emit.drain(..).collect()
+    }
+}
+
+impl Step for ReadBlocks {
+    type Input = BgzfBlock;
+    type Outputs = OrderedBytesSingle<ArenaBlock>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ReadBlocks",
+            // Off-pool on the coordination driver (N+2): the serial arena-admit
+            // runs on a dedicated thread instead of stealing a pool worker slot
+            // from the parallel inflaters. Detached collapses the `ByItemOrdinal`
+            // output to `None` exactly as `Serial` did (transport-identical).
+            kind: StepKind::Detached,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn detached_group(&self) -> DetachedGroup {
+        DetachedGroup::Shared(crate::sort::SORT_COORD_GROUP)
+    }
+
+    // A single cohesive deferred-seal state machine: held-output retry, seal
+    // arming/execution, batched admit, and staged-emit drain are tightly coupled
+    // by `seal_pending` / `deferred_block` / `held` and are clearer read top to
+    // bottom than split across helpers that would each need the same state.
+    #[allow(clippy::too_many_lines)]
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // 1. Retry any held output first (backpressure path).
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        // 2. Drain any staged emitted ArenaBlocks before accepting new input.
+        if let Some(block) = self.emit.pop_front() {
+            match ctx.outputs.push(block) {
+                Ok(()) => return Ok(StepOutcome::Progress),
+                Err(unpushed) => {
+                    self.held.put(unpushed);
+                    return Ok(StepOutcome::Progress);
+                }
+            }
+        }
+
+        // 3. If finished and emit is empty, we are done.
+        if self.finished {
+            return Ok(StepOutcome::Finished);
+        }
+
+        // 4. Re-admit a block held over from a prior deferred seal, if any.  The
+        //    seal already fired; we just need an arena to land this block in.
+        if self.deferred_block.is_some() {
+            // Drain any still-staged emit blocks first so the pool can recycle.
+            if let Some(out) = self.emit.pop_front() {
+                match ctx.outputs.push(out) {
+                    Ok(()) => return Ok(StepOutcome::Progress),
+                    Err(unpushed) => {
+                        self.held.put(unpushed);
+                        return Ok(StepOutcome::Progress);
+                    }
+                }
+            }
+            // Acquire the arena BEFORE consuming the held block, so a pool
+            // exhaustion does not drop it.
+            if !self.ensure_arena() {
+                // Pool still exhausted (the just-sealed run's arena has not
+                // returned yet): keep holding the block and backpressure.
+                return Ok(StepOutcome::NoProgress);
+            }
+            let block = self.deferred_block.take().expect("deferred_block present");
+            match self.admit_block(block) {
+                Ok(()) => {}
+                Err(b) => {
+                    // ensure_arena just returned true, so admit cannot fail; restore
+                    // the block defensively rather than drop it.
+                    self.deferred_block = Some(b);
+                    debug_assert!(false, "admit_block must succeed after ensure_arena");
+                    return Ok(StepOutcome::NoProgress);
+                }
+            }
+            if self.run_cumulative >= self.run_cap {
+                self.seal_pending = true;
+            }
+            return Ok(StepOutcome::Progress);
+        }
+
+        // 5. Pop and admit BgzfBlocks — BATCHED (up to `ADMIT_BATCH`) to keep the
+        //    parallel inflaters fed.  See `ADMIT_BATCH`: one-per-dispatch made this
+        //    admit the input-side bottleneck under the coordination driver's
+        //    drain-first restart.  Only the clean admit path is batched; a seal
+        //    boundary and
+        //    output backpressure both break the batch and return, preserving the
+        //    exact single-dispatch semantics of the delicate deferred-seal state
+        //    machine (a seal is rare — ~one per spill).
+        let mut admitted_any = false;
+        for _ in 0..ADMIT_BATCH {
+            let Some(block) = ctx.input.pop() else { break };
+            // A seal is armed from a previous block hitting the budget.  The
+            // arrival of THIS block proves a following run exists, so it is safe
+            // to seal the previous run as a disk spill (its straddler carry will
+            // be completed by the run this block opens).  End the batch here: the
+            // just-sealed run's arena must be consumed before the next admit.
+            if self.seal_pending {
+                self.seal_run(true); // deferred mid-stream seal → spill
+                self.seal_pending = false;
+                // The just-sealed run's arena is held (as an Arc) in `emit` until
+                // it is pushed downstream and consumed, so the capacity-1 pool is
+                // momentarily empty.  Hold this block and re-admit it once the
+                // arena returns (step 4 on a later call).  Drain `emit` now.
+                self.deferred_block = Some(block);
+                if let Some(out) = self.emit.pop_front() {
+                    match ctx.outputs.push(out) {
+                        Ok(()) => return Ok(StepOutcome::Progress),
+                        Err(unpushed) => {
+                            self.held.put(unpushed);
+                            return Ok(StepOutcome::Progress);
+                        }
+                    }
+                }
+                return Ok(StepOutcome::Progress);
+            }
+            match self.admit_block(block) {
+                Ok(()) => {}
+                Err(b) => {
+                    // Pool exhausted on a fresh run's first block: hold the block and
+                    // backpressure until the prior run's chunk is consumed and its
+                    // arena returns.  (Mid-run admits never fail — the arena is
+                    // already acquired — so this is the cross-run boundary case.)
+                    // If we already admitted this batch, that IS progress.
+                    self.deferred_block = Some(b);
+                    return Ok(if admitted_any {
+                        StepOutcome::Progress
+                    } else {
+                        StepOutcome::NoProgress
+                    });
+                }
+            }
+            admitted_any = true;
+            // Check if we hit the run budget; arm the deferred seal.  The next
+            // loop iteration observes `seal_pending` and runs the seal path above.
+            if self.run_cumulative >= self.run_cap {
+                self.seal_pending = true;
+            }
+            // Drain staged emit eagerly within the batch so the inflaters see
+            // blocks promptly and `emit` stays bounded.  On output backpressure,
+            // hold and return — the batch ends; the rest is picked up next
+            // dispatch (step 1 retries the held item first).
+            while let Some(out) = self.emit.pop_front() {
+                match ctx.outputs.push(out) {
+                    Ok(()) => {}
+                    Err(unpushed) => {
+                        self.held.put(unpushed);
+                        return Ok(StepOutcome::Progress);
+                    }
+                }
+            }
+        }
+        if admitted_any {
+            return Ok(StepOutcome::Progress);
+        }
+
+        // 6. No input available.
+        if !ctx.input.is_drained() {
+            return Ok(StepOutcome::NoProgress);
+        }
+
+        // 7. Input fully drained: seal the final (residual) run.  A pending seal
+        //    is DOWNGRADED to a residual here — there is no following run to
+        //    complete a straddler carry, and the final run's last record always
+        //    completes at EOF, so the carry is empty.  `seal_run(false)` emits
+        //    the residual.
+        self.seal_pending = false;
+        // Only seal if a block is withheld; if no block is held and the arena is
+        // None, there was no data at all after the previous seal — i.e. truly
+        // empty input (no blocks ever admitted).  NOTE: the deferred-seal design
+        // guarantees the *final* run is always a residual (step 5 only seals a
+        // spill once a following block proves a next run exists; otherwise this
+        // step downgrades the pending seal to a residual), so this branch is NOT
+        // reached after any data — it is the empty-input case only.
+        if self.arena.is_none() && self.last_block.is_none() {
+            self.finished = true;
+            return Ok(StepOutcome::Finished);
+        }
+        self.seal_run(false); // final run → residual
+        self.finished = true;
+
+        if let Some(block) = self.emit.pop_front() {
+            match ctx.outputs.push(block) {
+                Ok(()) => return Ok(StepOutcome::Progress),
+                Err(unpushed) => {
+                    self.held.put(unpushed);
+                    return Ok(StepOutcome::Progress);
+                }
+            }
+        }
+
+        Ok(StepOutcome::Finished)
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        // Serial steps are never cloned by the framework; this is unreachable.
+        panic!("ReadBlocks is Serial — new_worker_copy should never be called")
+    }
+}
+
+// ============================================================================
+// Item types
+// ============================================================================
+
+/// Input to `InflateToArena`.
+///
+/// Carries a grown-but-uninit slot `(offset, len)` in `arena` plus the full
+/// raw BGZF `block` bytes to inflate into it.  The slot was reserved by
+/// `grow_uninit` on the serial admit path; it must be fully written by the
+/// inflate worker before any read.
+pub struct ArenaBlock {
+    /// The shared arena into which this block's bytes will be inflated.
+    pub arena: Arc<PooledSegmentedBuf>,
+    /// Global ordinal, used by `ByItemOrdinal` reordering so downstream steps
+    /// receive blocks in the original file order.
+    pub ordinal: u64,
+    /// Byte offset of this block's slot within the arena (returned by
+    /// `grow_uninit`).
+    pub offset: u64,
+    /// Uncompressed size (ISIZE from the BGZF footer == slot length).
+    pub len: u32,
+    /// Complete raw BGZF block bytes (header + deflate payload + footer).
+    pub block: Vec<u8>,
+    /// `true` if this is the last block of the current run (e.g. a BAM file
+    /// segment); used by downstream steps to detect run boundaries.
+    pub is_last_of_run: bool,
+    /// Run sequence number; increments with each new run.
+    pub run_seq: u32,
+    /// `true` if this run seals to a disk spill (mid-stream seal); `false` if
+    /// this is the final residual run (in-memory, not spilled).
+    pub seals_to_spill: bool,
+}
+
+impl HeapSize for ArenaBlock {
+    fn heap_size(&self) -> usize {
+        self.block.len()
+    }
+}
+
+impl Ordered for ArenaBlock {
+    fn ordinal(&self) -> u64 {
+        self.ordinal
+    }
+}
+
+/// Completion token emitted by `InflateToArena` after successfully inflating
+/// one block.  The decompressed bytes now live in `arena` at the byte range
+/// `offset..offset + len`.  The token carries no heap data of its own
+/// (`heap_size == 0`).
+pub struct InflatedBlock {
+    /// The arena holding the decompressed bytes.
+    pub arena: Arc<PooledSegmentedBuf>,
+    /// Global ordinal (same value as the originating `ArenaBlock`).
+    pub ordinal: u64,
+    /// Byte offset of the decompressed data within the arena.
+    pub offset: u64,
+    /// Byte length of the decompressed data.
+    pub len: u32,
+    /// Forwarded from `ArenaBlock`.
+    pub is_last_of_run: bool,
+    /// Forwarded from `ArenaBlock`.
+    pub run_seq: u32,
+    /// Forwarded from `ArenaBlock`: `true` if this run seals to a disk spill.
+    pub seals_to_spill: bool,
+}
+
+impl HeapSize for InflatedBlock {
+    fn heap_size(&self) -> usize {
+        0
+    }
+}
+
+impl Ordered for InflatedBlock {
+    fn ordinal(&self) -> u64 {
+        self.ordinal
+    }
+}
+
+// ============================================================================
+// Step
+// ============================================================================
+
+/// `Parallel + ByItemOrdinal` step that decompresses each `ArenaBlock`'s BGZF
+/// bytes directly into its pre-reserved arena slot.
+///
+/// Each parallel worker clone holds its own [`Decompressor`] (allocated via
+/// `new_worker_copy`) so there is no contention on the decompression state.
+pub struct InflateToArena {
+    decompressor: Decompressor,
+    held: HeldSlot<Unpushed<InflatedBlock>>,
+    output_byte_limit: u64,
+}
+
+impl InflateToArena {
+    /// Create a new `InflateToArena` step.
+    ///
+    /// `output_byte_limit` bounds the byte-counted output queue (tokens carry
+    /// `heap_size == 0`, so this mainly controls queue depth via the framework's
+    /// backpressure mechanism).
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self { decompressor: Decompressor::new(), held: HeldSlot::new(), output_byte_limit }
+    }
+
+    /// Decompress `item.block` into the arena slot `(item.offset, item.len)`,
+    /// returning an [`InflatedBlock`] completion token on success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `io::Error` if BGZF decompression fails or if the
+    /// decompressed length does not match `item.len`.
+    ///
+    /// # Safety (caller contract)
+    ///
+    /// See the `#[allow(unsafe_code)]` block inside — the caller must have
+    /// reserved the slot via `grow_uninit` before constructing the `ArenaBlock`.
+    // `pub(crate)` so the unit test below can call it directly without wiring up
+    // the full pipeline framework.
+    pub(crate) fn inflate_one(&mut self, item: ArenaBlock) -> io::Result<InflatedBlock> {
+        let ArenaBlock {
+            arena,
+            ordinal,
+            offset,
+            len,
+            block,
+            is_last_of_run,
+            run_seq,
+            seals_to_spill,
+        } = item;
+
+        // SAFETY: `(offset, len)` was reserved by `grow_uninit` on the serial
+        // ReadBlocks admit path before this `ArenaBlock` was enqueued, so the
+        // slot is live within the arena's allocated storage.  The ISIZE
+        // prefix-sum partitions the arena into non-overlapping slots, so this
+        // `&mut [u8]` aliases no other concurrent inflate worker's slice.
+        // `u8` has no validity invariant, so writing before reading is the only
+        // required contract — `decompress_into_slice` below fills every byte.
+        // `offset` is a u64 byte offset into the arena; on a 64-bit platform
+        // this always fits in usize — the arena itself cannot exceed
+        // `isize::MAX` bytes, which is the Rust allocation bound.
+        let offset_usize =
+            usize::try_from(offset).expect("arena offset must fit in usize on this platform");
+        let len_usize = len as usize; // u32 always fits in usize
+
+        #[allow(unsafe_code)]
+        let slot = unsafe { arena.slice_mut(offset_usize, len_usize) };
+
+        let n = decompress_into_slice(&block, &mut self.decompressor, slot)?;
+        debug_assert_eq!(n, len_usize, "decompressed length must match ISIZE");
+
+        Ok(InflatedBlock { arena, ordinal, offset, len, is_last_of_run, run_seq, seals_to_spill })
+    }
+}
+
+impl Step for InflateToArena {
+    type Input = ArenaBlock;
+    type Outputs = OrderedBytesSingle<InflatedBlock>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "InflateToArena",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // Retry any held output first (backpressure path — mirror BgzfDecompress).
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    // `Contention` keeps the worker alive for retry — `NoProgress`
+                    // would let the framework silently drop the held item if input
+                    // is also drained.
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(block) = ctx.input.pop() else {
+            // No input this call.  If upstream is fully drained the held slot was
+            // already flushed by the Contention preamble above, so every item has
+            // been processed.  For a Parallel step only the last clone to finish
+            // closes the shared output (gated by StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+
+        let inflated = self.inflate_one(block)?;
+
+        match ctx.outputs.push(inflated) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        Self::new(self.output_byte_limit)
+    }
+}
+
+// ============================================================================
+// Arena sort strategy (per-order key extraction + seal)
+// ============================================================================
+
+/// Per-sort-order policy for the arena-front [`FindBoundariesAndSort`] scan.
+///
+/// The strategy owns the accumulated per-record refs and knows how to (a) extract
+/// a record's sort key from its arena-resident body and (b) at run seal, sort
+/// those refs and wrap the shared arena into the correctly-typed
+/// [`MemoryChunkErased`] — with zero record-body copies. `FindBoundariesAndSort`
+/// is generic over this trait and monomorphised per order, so the per-record
+/// [`push_record`](Self::push_record) call inlines into the boundary scan hot
+/// loop with no dynamic dispatch.
+pub trait ArenaSortStrategy: Send + 'static {
+    /// Reserve capacity for approximately `est_records` refs at the start of a
+    /// run, so the incremental per-record pushes do not reallocate a multi-GB ref
+    /// buffer mid-run.
+    fn reserve_for_run(&mut self, est_records: usize);
+
+    /// Extract the sort key from `body` (the record's BAM body, `block_size`
+    /// prefix excluded) and accumulate a ref pointing at `(body_off, len)` in the
+    /// shared inflate arena. Called once per record on the boundary scan hot path.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the record is invalid for this order (e.g. a
+    /// template-coordinate dropped-lane violation). Coordinate never errors.
+    fn push_record(&mut self, body: &[u8], body_off: u64, len: u32) -> io::Result<()>;
+
+    /// Sort the refs accumulated for this run and wrap `arena` into the erased
+    /// chunk (zero record copies), resetting the accumulator for the next run.
+    fn seal(&mut self, arena: Arc<PooledSegmentedBuf>, sort_threads: usize) -> MemoryChunkErased;
+
+    /// A fresh, empty strategy carrying the same configuration — used to build a
+    /// worker copy of the step. `FindBoundariesAndSort` is `Serial`, so this only
+    /// ever constructs its single working instance.
+    #[must_use]
+    fn fresh(&self) -> Self
+    where
+        Self: Sized;
+}
+
+/// Coordinate-order strategy: extracts the fixed `u64` coordinate key inline and
+/// accumulates plain [`RecordRef`]s; seals to [`MemoryChunkErased::Coordinate`]
+/// via [`coordinate_chunk_from_refs`].
+pub struct CoordinateStrategy {
+    /// BAM header reference-sequence count, used by [`extract_coordinate_key_inline`].
+    n_ref: u32,
+    /// Coordinate-key refs accumulated across the current run's blocks. Filled
+    /// incrementally by the scan and consumed (via `mem::take`) at seal, leaving
+    /// an empty `Vec` for the next run.
+    refs: Vec<RecordRef>,
+}
+
+impl CoordinateStrategy {
+    /// Create a coordinate strategy for a header with `n_ref` reference sequences.
+    #[must_use]
+    pub fn new(n_ref: u32) -> Self {
+        Self { n_ref, refs: Vec::new() }
+    }
+}
+
+impl ArenaSortStrategy for CoordinateStrategy {
+    #[inline]
+    fn reserve_for_run(&mut self, est_records: usize) {
+        self.refs.reserve(est_records);
+    }
+
+    #[inline]
+    fn push_record(&mut self, body: &[u8], body_off: u64, len: u32) -> io::Result<()> {
+        let sort_key = extract_coordinate_key_inline(body, self.n_ref);
+        self.refs.push(RecordRef::new(sort_key, body_off, len));
+        Ok(())
+    }
+
+    fn seal(&mut self, arena: Arc<PooledSegmentedBuf>, sort_threads: usize) -> MemoryChunkErased {
+        let refs = std::mem::take(&mut self.refs);
+        MemoryChunkErased::Coordinate(coordinate_chunk_from_refs(arena, refs, sort_threads))
+    }
+
+    fn fresh(&self) -> Self {
+        Self::new(self.n_ref)
+    }
+}
+
+/// Template-coordinate strategy: wraps a [`fgumi_sort::TemplateArenaAccumulator`],
+/// which owns the library / cell-barcode / MI and `--key-types` narrowed-lane
+/// machinery the template key needs; accumulates arena-pointing refs and seals to
+/// [`MemoryChunkErased::TemplateCoordinate`] (an arena-backed
+/// `InMemoryChunk<TemplateKey>`), byte-identical to the owned `TemplateChunkSorter`.
+pub struct TemplateStrategy {
+    acc: fgumi_sort::TemplateArenaAccumulator,
+}
+
+impl TemplateStrategy {
+    /// Wrap a template accumulator (built from the header via
+    /// [`fgumi_sort::TemplateArenaAccumulator::from_header`]).
+    #[must_use]
+    pub fn new(acc: fgumi_sort::TemplateArenaAccumulator) -> Self {
+        Self { acc }
+    }
+}
+
+impl ArenaSortStrategy for TemplateStrategy {
+    #[inline]
+    fn reserve_for_run(&mut self, est_records: usize) {
+        self.acc.reserve(est_records);
+    }
+
+    #[inline]
+    fn push_record(&mut self, body: &[u8], body_off: u64, len: u32) -> io::Result<()> {
+        self.acc
+            .push(body, body_off, len)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("{e:#}")))
+    }
+
+    fn seal(&mut self, arena: Arc<PooledSegmentedBuf>, sort_threads: usize) -> MemoryChunkErased {
+        MemoryChunkErased::TemplateCoordinate(self.acc.seal(arena, sort_threads))
+    }
+
+    fn fresh(&self) -> Self {
+        Self { acc: self.acc.fresh() }
+    }
+}
+
+/// Queryname-order strategy (lexicographic or natural, selected by the key type
+/// `K` + `wrap`): extracts the embedded read-name key from each record and
+/// accumulates `(key, offset, len)` refs pointing into the shared arena; at seal
+/// it comparator-sorts the refs (variable-length names are not radix-able) into
+/// an arena-backed [`InMemoryChunk<K>`], wrapped into the matching erased variant.
+///
+/// The record bodies stay in the arena (zero-copy); only the small name bytes are
+/// owned by each key, exactly as the legacy queryname sort. Queryname's
+/// tie order is unspecified (the integration parity gate is name-order, not
+/// byte-identity), so one globally-sorted chunk per run is correct.
+pub struct QuerynameStrategy<K: RawSortKey> {
+    /// `(key, body_offset, len)` refs accumulated across the current run's blocks.
+    refs: Vec<(K, u64, u32)>,
+    /// Bounded rayon pool (sized to `sort_threads`) the per-run comparator sort
+    /// installs into, so the parallel sort does not oversubscribe the pipeline's
+    /// worker pool on a spill. Built once on the first seal, reused; `None` on a
+    /// fresh copy. Mirrors [`TemplateArenaAccumulator`](fgumi_sort::TemplateArenaAccumulator)'s pool.
+    sort_pool: Option<rayon::ThreadPool>,
+    /// Erases the sorted `InMemoryChunk<K>` into the correct `MemoryChunkErased`
+    /// arm (`QuerynameLex` for the lex key, `QuerynameNatural` for the natural
+    /// key). A `fn` pointer so [`fresh`](ArenaSortStrategy::fresh) can copy it.
+    wrap: fn(InMemoryChunk<K>) -> MemoryChunkErased,
+}
+
+impl<K: RawSortKey> QuerynameStrategy<K> {
+    /// Build a queryname strategy that erases its sealed chunk via `wrap`.
+    #[must_use]
+    pub fn new(wrap: fn(InMemoryChunk<K>) -> MemoryChunkErased) -> Self {
+        Self { refs: Vec::new(), sort_pool: None, wrap }
+    }
+
+    /// Test-only observation of the bounded sort pool's thread count, so a test
+    /// can assert the Phase-1 `sort_threads` value actually SIZED the worker pool
+    /// (the runtime effect), not merely that it was plumbed. `None` until the
+    /// first [`seal`](ArenaSortStrategy::seal) builds the pool.
+    #[cfg(test)]
+    pub(crate) fn sort_pool_threads(&self) -> Option<usize> {
+        self.sort_pool.as_ref().map(rayon::ThreadPool::current_num_threads)
+    }
+}
+
+impl<K: RawSortKey + 'static> ArenaSortStrategy for QuerynameStrategy<K> {
+    #[inline]
+    fn reserve_for_run(&mut self, est_records: usize) {
+        self.refs.reserve(est_records);
+    }
+
+    #[inline]
+    fn push_record(&mut self, body: &[u8], body_off: u64, len: u32) -> io::Result<()> {
+        // Queryname keys are EMBEDDED_IN_RECORD: the name lives in `body`, so the
+        // key is reconstructed straight from it (no SortContext needed).
+        self.refs.push((K::extract_from_record(body), body_off, len));
+        Ok(())
+    }
+
+    fn seal(&mut self, arena: Arc<PooledSegmentedBuf>, sort_threads: usize) -> MemoryChunkErased {
+        let refs = std::mem::take(&mut self.refs);
+        let pool = self.sort_pool.get_or_insert_with(|| {
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(sort_threads.max(1))
+                .thread_name(|i| format!("qname-sort-{i}"))
+                .build()
+                .expect("build bounded queryname-sort rayon pool")
+        });
+        let wrap = self.wrap;
+        pool.install(move || wrap(queryname_chunk_from_arena_refs(arena, refs)))
+    }
+
+    fn fresh(&self) -> Self {
+        Self::new(self.wrap)
+    }
+}
+
+// ============================================================================
+// FindBoundariesAndSort step
+// ============================================================================
+
+/// `Serial` step that scans each run's contiguous arena span directly (no copy),
+/// skips the BAM header on run 0 via [`bam_header_len`], accumulates one ref per
+/// record through the order's [`ArenaSortStrategy`], seals that into an arena-backed
+/// chunk (each strategy picks its own builder — see [`CoordinateStrategy::seal`]),
+/// and emits `SortChunkEvent::Spill` (for sealed mid-stream runs) or
+/// `SortChunkEvent::Residual` (for the final run), followed by
+/// `SortChunkEvent::AllAnnounced`.
+///
+/// **Straddler handling (3b.4 front-region carry):** A BAM record that spans the
+/// boundary between run k and run k+1 is handled as follows:
+/// - While scanning run k's span, the trailing partial record (a 4-byte
+///   `block_size` prefix whose body extends past the run's end) is detected when
+///   `cur + 4 <= span.len()` but `cur + 4 + bs > span.len()`.  Those partial bytes
+///   (`span[cur..]`) are copied into `self.carry`.
+/// - When the first block of run k+1 arrives (arena already frozen), the carry is
+///   written right-aligned into that arena's front region at
+///   `[FRONT_REGION - carry.len(), FRONT_REGION)` via `unsafe { arena.slice_mut(...) }`.
+///   The scan then starts at `FRONT_REGION - carry.len()` so that `carry ++ block-0-head`
+///   is physically contiguous, forming one complete record ref that is naturally
+///   record 0 after sorting.
+///
+/// **Parity invariant:** sealed mid-stream runs emit `Spill{seq: 0, 1, ...}`;
+/// exactly one final run emits `Residual`.  `AllAnnounced` carries
+/// `slot_count = spilled_run_count, memory_chunk_count = 1`.
+pub struct FindBoundariesAndSort<S: ArenaSortStrategy> {
+    /// Per-order key extraction + seal policy; owns the accumulated sort refs.
+    strategy: S,
+    /// Threads handed to the per-chunk coordinate sort (`coordinate_chunk_from_refs`);
+    /// `>1` enables the parallel radix on large chunks.  Matches the pipeline's
+    /// configured thread count.
+    sort_threads: usize,
+    output_byte_limit: u64,
+    /// Held slot for backpressure retry on emitting events.
+    held: HeldSlot<Unpushed<SortChunkEvent>>,
+    /// The shared arena that holds the current run's decompressed bytes (set on
+    /// the first block of each run, cleared after the run is scanned).
+    arena: Option<Arc<PooledSegmentedBuf>>,
+    /// Arena offset of the scan start for the current run.
+    ///
+    /// - Run 0 with empty carry: `FRONT_REGION + bam_header_len(...)`.
+    /// - Run k>0 with non-empty carry: `FRONT_REGION - carry.len()` (after
+    ///   writing carry into the front region).
+    /// - Run k>0 with empty carry (no straddler): `FRONT_REGION`.
+    scan_start: u64,
+    /// Arena offset one past the last byte of the current run span (updated with
+    /// each block).
+    run_end: u64,
+    /// Arena offset of the next un-parsed record's first byte within the current
+    /// run.  The incremental scan advances this as in-order blocks extend `run_end`,
+    /// parking it at the start of the first record that overruns the bytes inflated
+    /// so far; it resumes from here when the next block arrives.  At seal,
+    /// `[scan_cursor, run_end)` is exactly the trailing partial record (the straddler
+    /// carry for a spill, or empty for a clean residual).
+    scan_cursor: u64,
+    /// `true` once run 0's BAM header has been skipped.  Set `true` immediately for
+    /// runs `> 0` (no header).  Stays `false` on run 0 until enough blocks have been
+    /// inflated for [`bam_header_len`] to parse the full header — a many-reference
+    /// header can exceed a single 64 KiB block, so the skip may take several blocks.
+    header_skipped: bool,
+    /// Pending events staged after each run scan; drained in subsequent `try_run`
+    /// calls.  Holds `Spill`/`Residual` then `AllAnnounced` (only on the final run).
+    pending: VecDeque<SortChunkEvent>,
+    /// `true` once the final run has been scanned and `AllAnnounced` staged.
+    finalized: bool,
+    /// Trailing partial record bytes from the previous run (the carry buffer).
+    /// Non-empty when run k ended mid-record; written into run k+1's front region.
+    carry: Vec<u8>,
+    /// Sequence number for the next run's `Spill` event (monotonically increasing).
+    next_seq: u32,
+    /// Cumulative record count across all runs.
+    total_records: u64,
+    /// Number of runs that sealed to a disk spill (all runs except the final one).
+    spilled_run_count: u32,
+}
+
+impl<S: ArenaSortStrategy> FindBoundariesAndSort<S> {
+    /// Test-only borrow of the per-order strategy, so a test can observe
+    /// strategy-owned state (e.g. the bounded sort pool built at seal) after
+    /// driving the step — confirming the `sort_threads` handed to [`new`](Self::new)
+    /// is forwarded into `strategy.seal`.
+    #[cfg(test)]
+    pub(crate) fn strategy(&self) -> &S {
+        &self.strategy
+    }
+
+    /// Create a new `FindBoundariesAndSort` step over the given per-order
+    /// `strategy` (e.g. [`CoordinateStrategy`], which carries the header's
+    /// reference-sequence count for key extraction). `sort_threads` is the thread
+    /// count handed to the per-chunk sort (the pipeline's configured threads).
+    /// `output_byte_limit` byte-bounds the output queue.
+    #[must_use]
+    pub fn new(strategy: S, sort_threads: usize, output_byte_limit: u64) -> Self {
+        Self {
+            strategy,
+            sort_threads,
+            output_byte_limit,
+            held: HeldSlot::new(),
+            arena: None,
+            scan_start: 0,
+            run_end: 0,
+            scan_cursor: 0,
+            header_skipped: false,
+            pending: VecDeque::new(),
+            finalized: false,
+            carry: Vec::new(),
+            next_seq: 0,
+            total_records: 0,
+            spilled_run_count: 0,
+        }
+    }
+
+    /// Ingest one `InflatedBlock`, extending the current run's contiguous arena span
+    /// and then parsing every record made complete by it via
+    /// [`scan_available`](Self::scan_available) — so the scan overlaps the run's
+    /// still-inflating tail (Inflate‖Scan).  When the block is the last of a run
+    /// (`is_last_of_run`), the run is sealed: the trailing partial record (if any)
+    /// becomes the carry, the accumulated refs are sorted, and a `Spill` or
+    /// `Residual` event is staged in `self.pending`.  After the final run's
+    /// `Residual`, an `AllAnnounced` is also staged.
+    ///
+    /// On the first block of each run, the straddler carry from the previous run (if
+    /// any) is written right-aligned into the new arena's front region via an
+    /// `unsafe` `slice_mut` call (3rd `fgumi-pipeline-io` unsafe site — see
+    /// CLAUDE.md §"Approved hot-path unsafe (parallel-inflate sort ingest,
+    /// fgumi-pipeline-io)" for the full justification).
+    ///
+    /// # Errors
+    ///
+    /// Returns an `io::Error` if:
+    /// - The carry to write into the front region is longer than `FRONT_REGION`.
+    /// - A `block_size` value in the record stream overflows `u32`.
+    /// - At seal: run 0's header never fully arrived, the carry exceeds `FRONT_REGION`,
+    ///   or the final residual run ends mid-record (truncated BAM).
+    pub(crate) fn ingest_block(&mut self, block: &InflatedBlock) -> io::Result<()> {
+        let block_end = block.offset + u64::from(block.len);
+
+        if self.arena.is_none() {
+            // ----------------------------------------------------------------
+            // First block of this run.
+            // ----------------------------------------------------------------
+
+            // Straddler carry: write carry right-aligned into the front region.
+            let scan_start = if !self.carry.is_empty() {
+                let l = self.carry.len();
+                if l > FRONT_REGION {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "FindBoundariesAndSort: carry ({l} bytes) exceeds FRONT_REGION \
+                             ({FRONT_REGION}); record exceeds max straddler size — \
+                             raise --max-memory"
+                        ),
+                    ));
+                }
+                let write_offset = FRONT_REGION - l;
+                // SAFETY: `[FRONT_REGION - l, FRONT_REGION)` is the front region reserved
+                // by `ReadBlocks::ensure_arena` via `grow_uninit(FRONT_REGION)` before any
+                // block slot was allocated.  Soundness rests on DISJOINTNESS, not on
+                // ordering: this range lies strictly below `FRONT_REGION`, while every
+                // inflate block slot lies at or above `FRONT_REGION` (block 0 starts there
+                // by construction in ReadBlocks), so the `&mut [u8]` synthesized here
+                // aliases no slot an `InflateToArena` worker is concurrently writing — and
+                // run k+1's later blocks MAY still be inflating when this carry write runs
+                // (FBS is serial but does not wait for the whole run to inflate).  The
+                // arena's backing segment was frozen with `reserve_full_capacity` before
+                // being shared, so no `grow_uninit`/realloc can move these bytes underneath
+                // a live worker slice.  This write happens exactly once per straddler per
+                // run; `u8` has no validity invariant.
+                #[allow(unsafe_code)]
+                let dst = unsafe { block.arena.slice_mut(write_offset, l) };
+                dst.copy_from_slice(&self.carry);
+                self.carry.clear();
+                #[allow(clippy::cast_possible_truncation)]
+                let start = write_offset as u64;
+                start
+            } else if self.next_seq == 0 {
+                // Run 0: BAM header starts at block.offset (the first byte of the
+                // run's data).  In the real pipeline block.offset == FRONT_REGION
+                // (since ReadBlocks reserves the front region first), but in unit
+                // tests the arena may be laid out without the front region.
+                block.offset
+            } else {
+                // Non-first run, no carry: records start at FRONT_REGION.
+                #[allow(clippy::cast_possible_truncation)]
+                let start = FRONT_REGION as u64;
+                start
+            };
+
+            self.arena = Some(Arc::clone(&block.arena));
+            self.scan_start = scan_start;
+            self.scan_cursor = scan_start;
+            // Runs > 0 have no BAM header (it lives only at the very start of input);
+            // their first record is the straddler/`FRONT_REGION` data, so nothing to
+            // skip.  Run 0 must skip the header, which `scan_available` does once
+            // enough blocks have arrived.
+            self.header_skipped = self.next_seq != 0;
+            // Pre-size the ref buffer to the run's upper bound (the arena holds at
+            // most `segment_size` bytes of record data) so the incremental pushes do
+            // not trigger doubling reallocations of a multi-GB `Vec` mid-run.
+            let est = (block.arena.len() / 192).max(1024);
+            self.strategy.reserve_for_run(est);
+        } else {
+            debug_assert_eq!(
+                block.offset, self.run_end,
+                "FindBoundariesAndSort: non-contiguous arena block (expected offset {}, got {})",
+                self.run_end, block.offset
+            );
+        }
+        self.run_end = block_end;
+
+        // Parse every record made complete by the bytes inflated so far, overlapping
+        // the scan with the still-inflating tail of the run (Inflate‖Scan).
+        self.scan_available(&block.arena)?;
+
+        if block.is_last_of_run {
+            self.seal_run(block.seals_to_spill, block.run_seq)?;
+        }
+
+        Ok(())
+    }
+
+    /// Parse every record that is fully present in `[scan_cursor, run_end)`, pushing
+    /// a [`RecordRef`] (with its coordinate key extracted inline) for each, and park
+    /// `scan_cursor` at the first record that overruns the bytes inflated so far.
+    ///
+    /// Records are gap-free across block slots (the arena is one contiguous segment
+    /// with prefix-summed offsets), so the cursor walks straight through block
+    /// boundaries — a record that started in block k and continues into block k+1 is
+    /// simply parsed once k+1 has extended `run_end`.  A trailing partial record at
+    /// the *run* boundary is not handled here; it is left in `[scan_cursor, run_end)`
+    /// for `seal_run` to carry (spill) or reject (truncated residual).
+    ///
+    /// For run 0, the BAM header is skipped first; if the header is not yet fully
+    /// inflated (`bam_header_len` returns `None`), the scan returns and retries on the
+    /// next block.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `io::Error` on a `block_size` value that overflows `u32`.
+    fn scan_available(&mut self, arena: &PooledSegmentedBuf) -> io::Result<()> {
+        let scan_start = self.scan_start;
+        let scan_start_usize = usize::try_from(scan_start).expect("scan_start must fit in usize");
+        let run_end_usize = usize::try_from(self.run_end).expect("run_end must fit in usize");
+        let avail_len = run_end_usize.checked_sub(scan_start_usize).expect("run_end >= scan_start");
+
+        // Borrow the bytes inflated so far for this run directly from the arena — NO
+        // copy.  The whole run lives in one segment, so this single slice spans
+        // `[scan_start, run_end)` and is re-taken (cheaply) as `run_end` grows.
+        let span = arena.slice(scan_start_usize, avail_len);
+
+        // Run 0: skip the BAM header once it is fully present.  A many-reference
+        // header can exceed one BGZF block, so `None` means "wait for more blocks",
+        // NOT an error (the error is raised at seal if the header never completes).
+        if !self.header_skipped {
+            // `?` surfaces a wrong-magic stream as an error here; `Ok(None)` still
+            // means "header not fully inflated yet — wait for more blocks".
+            match bam_header_len(span)? {
+                Some(h) => {
+                    self.scan_cursor = scan_start + h as u64;
+                    self.header_skipped = true;
+                }
+                None => return Ok(()),
+            }
+        }
+
+        // Parse complete `[block_size(4)][body]` frames from the cursor, extracting
+        // the coordinate key inline (the body is already resident in `span`).
+        let mut cur = usize::try_from(self.scan_cursor - scan_start)
+            .expect("cursor offset within run fits in usize");
+        let mut run_records: u64 = 0;
+        loop {
+            if cur + 4 > span.len() {
+                // Not even a full 4-byte length prefix present yet — wait.
+                break;
+            }
+            let bs = u32::from_le_bytes([span[cur], span[cur + 1], span[cur + 2], span[cur + 3]])
+                as usize;
+            if cur + 4 + bs > span.len() {
+                // Record body not fully inflated yet — wait for the next block.
+                break;
+            }
+            // Software-prefetch a few records ahead to hide the cold-arena miss
+            // latency of this forward scan.
+            let pf = cur + SCAN_PREFETCH_DISTANCE;
+            if pf < span.len() {
+                prefetch_read_l1(&span[pf]);
+            }
+            #[allow(clippy::cast_possible_truncation)]
+            let body_arena_off = scan_start + cur as u64 + 4;
+            let bs_u32 = u32::try_from(bs).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("FindBoundariesAndSort: block_size {bs} overflows u32"),
+                )
+            })?;
+            self.strategy.push_record(&span[cur + 4..cur + 4 + bs], body_arena_off, bs_u32)?;
+            cur += 4 + bs;
+            run_records += 1;
+        }
+        self.scan_cursor = scan_start + cur as u64;
+        self.total_records += run_records;
+        Ok(())
+    }
+
+    /// Seal the current run: finalize the trailing carry, sort the refs accumulated
+    /// incrementally by [`scan_available`](Self::scan_available), and stage a `Spill`
+    /// or `Residual` event.
+    ///
+    /// By the time this is called, `scan_available` has already run for the run's last
+    /// block (in `ingest_block`), so every complete record is in `self.refs` and
+    /// `scan_cursor` is parked at the start of the trailing partial record (if any).
+    /// `[scan_cursor, run_end)` is therefore exactly that partial record:
+    /// - for a mid-stream (spill) seal it becomes the straddler carry for the next run;
+    /// - for the final (residual) seal it MUST be empty — a non-empty tail means the
+    ///   BAM ended mid-record (truncated/malformed), surfaced as a hard error.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `io::Error` if run 0's header never fully arrived, on a truncated
+    /// final record, or if the carry exceeds `FRONT_REGION`.
+    fn seal_run(&mut self, seals_to_spill: bool, run_seq: u32) -> io::Result<()> {
+        let arena = self.arena.take().expect("seal_run called with no arena");
+
+        // Run 0's header must have been skipped by now; if `scan_available` never
+        // managed it, the input is too short to contain a valid BAM header.
+        if !self.header_skipped {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "FindBoundariesAndSort: input too short to contain a valid BAM header",
+            ));
+        }
+
+        // The trailing partial record, if any, is `[scan_cursor, run_end)`.
+        let scan_cursor_usize =
+            usize::try_from(self.scan_cursor).expect("scan_cursor must fit in usize");
+        let run_end_usize = usize::try_from(self.run_end).expect("run_end must fit in usize");
+        let tail_len =
+            run_end_usize.checked_sub(scan_cursor_usize).expect("run_end >= scan_cursor");
+
+        if seals_to_spill {
+            // Mid-stream seal → the tail is the straddler carry for the next run.
+            if tail_len > 0 {
+                let tail = arena.slice(scan_cursor_usize, tail_len);
+                if tail_len > FRONT_REGION {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "FindBoundariesAndSort: carry ({tail_len} bytes) exceeds FRONT_REGION \
+                             ({FRONT_REGION}); record exceeds max straddler size — \
+                             raise --max-memory"
+                        ),
+                    ));
+                }
+                self.carry.extend_from_slice(tail);
+            }
+        } else if tail_len > 0 {
+            // Final (residual) run with a leftover tail → truncated/malformed BAM.
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "truncated BAM: final record incomplete at end of input",
+            ));
+        }
+
+        // Sort the refs accumulated across this run's blocks and wrap the arena into
+        // the erased chunk — no record copies (keys were extracted during the scan).
+        let chunk = self.strategy.seal(Arc::clone(&arena), self.sort_threads);
+
+        // Verify ReadBlocks and FindBoundariesAndSort are in lockstep on run
+        // sequencing.  A desync here indicates a bug in the pipeline wiring (e.g.
+        // ReadBlocks emitting the wrong seq on an is_last_of_run block).
+        debug_assert_eq!(
+            run_seq, self.next_seq,
+            "ReadBlocks run_seq desynced from FindBoundariesAndSort seq counter"
+        );
+
+        let seq = self.next_seq;
+        self.next_seq += 1;
+
+        if seals_to_spill {
+            // Mid-stream sealed run → disk spill.
+            debug_assert!(
+                !self.finalized,
+                "FindBoundariesAndSort: Spill emitted after finalization"
+            );
+            self.pending.push_back(SortChunkEvent::Spill {
+                seq,
+                chunk,
+                records_ingested_so_far: self.total_records,
+            });
+            self.spilled_run_count += 1;
+        } else {
+            // Final (residual) run.  A non-empty carry here means the BAM ends
+            // mid-record — the file is truncated or malformed.  We must surface
+            // this as a hard error in all build profiles: a debug_assert! would
+            // silently drop the partial record in release builds.
+            if !self.carry.is_empty() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "truncated BAM: final record incomplete at end of input",
+                ));
+            }
+            self.pending.push_back(SortChunkEvent::Residual {
+                chunk,
+                records_ingested_so_far: self.total_records,
+            });
+            self.pending.push_back(SortChunkEvent::AllAnnounced {
+                slot_count: self.spilled_run_count,
+                memory_chunk_count: 1,
+                total_records: self.total_records,
+            });
+            self.finalized = true;
+        }
+
+        // Reset per-run span tracking.  `self.refs` was emptied by `mem::take`; the
+        // next run's first block re-initializes `scan_cursor`/`header_skipped`.
+        self.scan_start = 0;
+        self.run_end = 0;
+        self.scan_cursor = 0;
+        self.header_skipped = false;
+
+        Ok(())
+    }
+
+    /// Called when input is fully drained and no `is_last_of_run` block was received
+    /// (empty pipeline — no arena was ingested at all).  Stages a well-formed
+    /// sentinel so downstream steps can complete.
+    ///
+    /// The "all runs sealed to spills, no residual" branch below is DEFENSIVE: the
+    /// `ReadBlocks` deferred-seal design guarantees the final run is always a
+    /// residual (it seals a spill only once a following block proves a next run
+    /// exists, and downgrades a pending seal to a residual at EOF), so for valid
+    /// input that branch is unreachable.  It is retained as a hard error on a
+    /// non-empty carry so a genuinely truncated BAM (or a future regression in the
+    /// seal logic) surfaces loudly instead of silently dropping a record.
+    ///
+    /// Returns `Some(first_event)` popped from `self.pending`, or `None` if no
+    /// arena was ingested.
+    pub(crate) fn finalize(&mut self) -> io::Result<Option<SortChunkEvent>> {
+        if self.finalized {
+            // Already handled by the last is_last_of_run block — nothing to do.
+            return Ok(self.pending.pop_front());
+        }
+        if self.arena.is_none() && self.next_seq == 0 {
+            // No arena was ever ingested (empty input).
+            return Ok(None);
+        }
+        if self.arena.is_none() && self.next_seq > 0 {
+            // DEFENSIVE / unreachable for valid input: the deferred-seal design
+            // always makes the final run a residual, so we should never finalize
+            // with spills-only-and-no-residual. If we somehow do, a non-empty carry
+            // means the BAM ends mid-record (truncated input or a seal-logic
+            // regression) — surface it as a hard error rather than drop a record.
+            if !self.carry.is_empty() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "truncated BAM: final record incomplete at end of input (no-residual path)",
+                ));
+            }
+            // Emit AllAnnounced with memory_chunk_count=0 so SortMerge completes.
+            self.pending.push_back(SortChunkEvent::AllAnnounced {
+                slot_count: self.spilled_run_count,
+                memory_chunk_count: 0,
+                total_records: self.total_records,
+            });
+            self.finalized = true;
+            return Ok(self.pending.pop_front());
+        }
+        // Edge case: arena present but no is_last_of_run seen — treat as residual.
+        if self.arena.is_some() {
+            self.seal_run(false, self.next_seq)?;
+        }
+        Ok(self.pending.pop_front())
+    }
+
+    fn flush_held(&mut self, ctx: &mut StepCtx<'_, Self>) -> bool {
+        // `true` once the slot is clear (was empty, or the held event flushed);
+        // `false` while it's still held under backpressure. Uses the canonical
+        // re-hold helper so the put-back-on-reject invariant lives in one place.
+        !matches!(ctx.outputs.retry_held(&mut self.held), HeldRetry::StillHeld)
+    }
+
+    fn emit_pending(&mut self, ctx: &mut StepCtx<'_, Self>) -> StepOutcome {
+        let Some(event) = self.pending.pop_front() else {
+            return StepOutcome::NoProgress;
+        };
+        match ctx.outputs.push(event) {
+            Ok(()) => StepOutcome::Progress,
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                StepOutcome::Progress
+            }
+        }
+    }
+}
+
+impl<S: ArenaSortStrategy> Step for FindBoundariesAndSort<S> {
+    type Input = InflatedBlock;
+    type Outputs = Single<SortChunkEvent>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "FindBoundariesAndSort",
+            // Off-pool on the coordination driver (N+2): the serial boundary scan
+            // + radix sort + seal/spill framing runs on the dedicated coordination
+            // thread, keeping the pool on pure parallel inflate/compress.
+            kind: StepKind::Detached,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::None],
+        }
+    }
+
+    fn detached_group(&self) -> DetachedGroup {
+        DetachedGroup::Shared(crate::sort::SORT_COORD_GROUP)
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // Retry any held output first (backpressure path).
+        if !self.flush_held(ctx) {
+            return Ok(StepOutcome::Contention);
+        }
+
+        // Drain any staged pending events before processing new input.
+        if !self.pending.is_empty() {
+            return Ok(self.emit_pending(ctx));
+        }
+
+        // If already finalized, drain pending or finish.
+        if self.finalized {
+            return Ok(StepOutcome::Finished);
+        }
+
+        // Try to pop and ingest one InflatedBlock.
+        if let Some(block) = ctx.input.pop() {
+            self.ingest_block(&block)?;
+            // If ingest_block sealed a run it may have staged events; drain them.
+            if !self.pending.is_empty() {
+                return Ok(self.emit_pending(ctx));
+            }
+            return Ok(StepOutcome::Progress);
+        }
+
+        // No input available.
+        if !ctx.input.is_drained() {
+            return Ok(StepOutcome::NoProgress);
+        }
+
+        // Input fully drained: finalize (handles empty-input edge case).
+        if let Some(first_event) = self.finalize()? {
+            match ctx.outputs.push(first_event) {
+                Ok(()) => {
+                    // The push landed, so `held` is empty: it is safe to drain the
+                    // next staged event this call (e.g. `AllAnnounced` after
+                    // `Residual`).  `emit_pending` will itself hold on a full queue.
+                    if !self.pending.is_empty() {
+                        return Ok(self.emit_pending(ctx));
+                    }
+                }
+                Err(unpushed) => {
+                    // The output queue is full: hold `first_event` and retry it on
+                    // the next `try_run` via `flush_held`.  Do NOT drain `pending`
+                    // here — pushing a later event now would place it ahead of the
+                    // still-held one, and a subsequent hold would clobber the held
+                    // event (silent loss).  Keep the one-event-per-call invariant
+                    // exactly like the normal path above.
+                    self.held.put(unpushed);
+                }
+            }
+            return Ok(StepOutcome::Progress);
+        }
+
+        // No arena was ingested (empty input).
+        Ok(StepOutcome::Finished)
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        Self::new(self.strategy.fresh(), self.sort_threads, self.output_byte_limit)
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fgumi_sort::{CoordinateChunkSorter, PooledSegmentedBuf, SegmentedBuf};
+    use std::sync::Arc;
+
+    // -----------------------------------------------------------------------
+    // Test helpers shared across ReadBlocks and InflateToArena tests.
+    // -----------------------------------------------------------------------
+
+    /// Build a single BGZF block containing `payload` using `InlineBgzfCompressor`
+    /// at compression level 0 (stored / uncompressed).
+    /// Returns the raw block bytes (header + deflate payload + footer).
+    fn make_test_bgzf_block(payload: &[u8]) -> Vec<u8> {
+        let mut compressor = fgumi_bgzf::writer::InlineBgzfCompressor::new(0);
+        compressor.write_all(payload).expect("compress payload");
+        compressor.flush().expect("flush compressor");
+        let mut blocks = compressor.take_blocks();
+        assert_eq!(blocks.len(), 1, "payload must fit in one BGZF block");
+        blocks.remove(0).data
+    }
+
+    /// Acquire a pooled arena for constructing block tokens in tests.
+    fn test_arena() -> Arc<PooledSegmentedBuf> {
+        let pool = ArenaPool::new(1, 1024);
+        Arc::new(pool.try_acquire().expect("a fresh pool always has one arena"))
+    }
+
+    // -----------------------------------------------------------------------
+    // Block token accounting (HeapSize / Ordered)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn arena_block_charges_only_its_compressed_bytes_to_the_heap() {
+        // The arena is shared via `Arc`, so it must NOT be counted per block —
+        // byte-bounded queues would otherwise over-charge by the arena size and
+        // stall the pipeline.
+        let block = ArenaBlock {
+            arena: test_arena(),
+            ordinal: 7,
+            offset: 64,
+            len: 128,
+            block: vec![0xAB; 40],
+            is_last_of_run: true,
+            run_seq: 2,
+            seals_to_spill: false,
+        };
+        assert_eq!(block.heap_size(), 40, "only the owned BGZF bytes are charged");
+        assert_eq!(block.ordinal(), 7, "ordinal drives ByItemOrdinal reordering");
+    }
+
+    #[test]
+    fn inflated_block_is_heap_free_because_its_bytes_live_in_the_arena() {
+        let token = InflatedBlock {
+            arena: test_arena(),
+            ordinal: 11,
+            offset: 0,
+            len: 256,
+            is_last_of_run: false,
+            run_seq: 1,
+            seals_to_spill: true,
+        };
+        assert_eq!(token.heap_size(), 0, "the token owns no bytes of its own");
+        assert_eq!(token.ordinal(), 11);
+    }
+
+    // -----------------------------------------------------------------------
+    // Step wiring
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn read_blocks_runs_off_pool_on_the_coordination_driver() {
+        let step = ReadBlocks::new(1 << 20, 4096);
+        let profile = step.profile();
+        assert_eq!(profile.name, "ReadBlocks");
+        // Detached keeps the serial arena-admit off a pool worker so it cannot
+        // steal a slot from the parallel inflaters.
+        assert_eq!(profile.kind, StepKind::Detached);
+        assert!(!profile.sticky);
+        assert_eq!(profile.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+        match profile.output_queues.as_slice() {
+            [QueueSpec::ByteBounded { limit_bytes }] => assert_eq!(*limit_bytes, 4096),
+            other => panic!("expected one byte-bounded queue, got {other:?}"),
+        }
+        assert_eq!(step.detached_group(), DetachedGroup::Shared(crate::sort::SORT_COORD_GROUP));
+    }
+
+    #[test]
+    fn inflate_to_arena_is_parallel_and_worker_copies_share_only_config() {
+        let step = InflateToArena::new(8192);
+        let profile = step.profile();
+        assert_eq!(profile.name, "InflateToArena");
+        assert_eq!(profile.kind, StepKind::Parallel, "inflation fans out across workers");
+        assert!(!profile.sticky);
+        assert_eq!(profile.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+
+        // Each worker gets an independent copy carrying the same queue bound.
+        let worker = step.new_worker_copy();
+        match worker.profile().output_queues.as_slice() {
+            [QueueSpec::ByteBounded { limit_bytes }] => assert_eq!(*limit_bytes, 8192),
+            other => panic!("expected one byte-bounded queue, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Sort strategies
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn coordinate_strategy_accumulates_refs_and_seal_drains_them() {
+        let mut strategy = CoordinateStrategy::new(4);
+        strategy.reserve_for_run(8);
+
+        // Two synthetic record bodies; only the leading tid/pos fields are read
+        // by the inline key extractor, so a minimal fixed-size body suffices.
+        let body = vec![0u8; 36];
+        strategy.push_record(&body, 0, 36).unwrap();
+        strategy.push_record(&body, 36, 36).unwrap();
+        assert_eq!(strategy.refs.len(), 2, "each pushed record yields one arena ref");
+
+        let chunk = strategy.seal(test_arena(), 1);
+        assert!(matches!(chunk, MemoryChunkErased::Coordinate(_)), "coordinate seal");
+        assert!(strategy.refs.is_empty(), "seal must drain the accumulator for the next run");
+    }
+
+    #[test]
+    fn coordinate_strategy_fresh_keeps_config_and_drops_accumulated_state() {
+        let mut strategy = CoordinateStrategy::new(9);
+        let body = vec![0u8; 36];
+        strategy.push_record(&body, 0, 36).unwrap();
+        assert!(!strategy.refs.is_empty());
+
+        let next = strategy.fresh();
+        assert_eq!(next.n_ref, 9, "reference count is configuration and is carried over");
+        assert!(next.refs.is_empty(), "a fresh strategy starts a new run with no refs");
+    }
+
+    /// Read the BGZF footer ISIZE field (last 4 bytes of the block), which is
+    /// the uncompressed size mod 2^32.  Returns the value as `usize`.
+    fn uncompressed_size_of(block: &[u8]) -> usize {
+        assert!(block.len() >= 4, "block too short to contain BGZF footer");
+        let n = block.len();
+        u32::from_le_bytes([block[n - 4], block[n - 3], block[n - 2], block[n - 1]]) as usize
+    }
+
+    /// Build a single BGZF block containing `payload` using `InlineBgzfCompressor`
+    /// at level 6, returning raw block bytes.  Used by `InflateToArena` tests.
+    fn compress_one_block(payload: &[u8]) -> Vec<u8> {
+        let mut compressor = fgumi_bgzf::writer::InlineBgzfCompressor::new(6);
+        compressor.write_all(payload).expect("compress payload");
+        compressor.flush().expect("flush compressor");
+        let mut blocks = compressor.take_blocks();
+        assert_eq!(blocks.len(), 1, "payload must fit in one BGZF block");
+        blocks.remove(0).data
+    }
+
+    // -----------------------------------------------------------------------
+    // ReadBlocks unit tests
+    // -----------------------------------------------------------------------
+
+    /// Two synthetic BGZF blocks are admitted; after freeze the emitted
+    /// `ArenaBlock`s must carry contiguous offsets starting at `FRONT_REGION`,
+    /// correct `len`/`ordinal` values, and share the same arena `Arc`.
+    #[allow(unsafe_code)]
+    #[test]
+    fn read_blocks_admits_grows_and_emits_arena_blocks() {
+        let blk0 = make_test_bgzf_block(b"first-block-decompressed-payload");
+        let blk1 = make_test_bgzf_block(b"second-block-payload-2");
+        let isz0 = uncompressed_size_of(&blk0);
+        let isz1 = uncompressed_size_of(&blk1);
+
+        // memory_limit larger than both blocks combined → single run
+        let mut step = ReadBlocks::new(64 * 1024 * 1024, 64 * 1024 * 1024);
+        assert!(
+            step.admit_block(BgzfBlock {
+                batch_serial: 0,
+                bytes: blk0.clone(),
+                uncompressed_size: u32::try_from(isz0).unwrap(),
+            })
+            .is_ok()
+        );
+        assert!(
+            step.admit_block(BgzfBlock {
+                batch_serial: 1,
+                bytes: blk1.clone(),
+                uncompressed_size: u32::try_from(isz1).unwrap(),
+            })
+            .is_ok()
+        );
+        let emitted: Vec<ArenaBlock> = step.seal_and_drain_for_test();
+
+        assert_eq!(emitted.len(), 2);
+        // Block 0 lands at FRONT_REGION (after the reserved front region).
+        assert_eq!(emitted[0].offset, FRONT_REGION as u64, "block 0 must start at FRONT_REGION");
+        // Block 1 is contiguous after block 0.
+        assert_eq!(
+            usize::try_from(emitted[1].offset).unwrap(),
+            FRONT_REGION + isz0,
+            "offsets must be contiguous after FRONT_REGION"
+        );
+        assert!(emitted[1].is_last_of_run, "last block must carry is_last_of_run=true");
+        assert!(!emitted[0].is_last_of_run, "first block must not carry is_last_of_run");
+        assert_eq!(emitted[0].len as usize, isz0);
+        assert_eq!(emitted[1].len as usize, isz1);
+        assert_eq!(emitted[0].ordinal, 0);
+        assert_eq!(emitted[1].ordinal, 1);
+        assert_eq!(emitted[0].run_seq, 0);
+        assert_eq!(emitted[1].run_seq, 0);
+        assert!(!emitted[0].seals_to_spill, "residual run must not seal to spill");
+        assert!(!emitted[1].seals_to_spill, "residual run must not seal to spill");
+        // All blocks share the same arena Arc.
+        assert!(Arc::ptr_eq(&emitted[0].arena, &emitted[1].arena));
+    }
+
+    /// Feed enough blocks to force TWO runs.
+    ///
+    /// Asserts:
+    /// - Run 0 blocks: `run_seq == 0`, offsets start at `FRONT_REGION`,
+    ///   last block has `is_last_of_run`, all have `seals_to_spill = true`.
+    /// - Run 1 blocks: `run_seq == 1`, offsets restart at `FRONT_REGION`
+    ///   (fresh/reused arena from the pool), `seals_to_spill = false`.
+    /// - Ordinals are monotonically increasing across both runs.
+    /// - Run 0 and run 1 arena `Arc`s differ (or are the same reused physical
+    ///   buffer returned via the pool after run 0's Arc drops).
+    #[allow(unsafe_code)]
+    #[allow(clippy::too_many_lines)] // exhaustive two-run state-machine assertions
+    #[test]
+    fn read_blocks_two_run_seal() {
+        // Make two blocks; each has isz bytes of uncompressed data.
+        let payload0 = b"run0-block0-payload".as_ref();
+        let payload1 = b"run0-block1-payload".as_ref();
+        let payload2 = b"run1-block0-payload".as_ref();
+        let payload3 = b"run1-block1-payload".as_ref();
+
+        let blk0 = make_test_bgzf_block(payload0);
+        let blk1 = make_test_bgzf_block(payload1);
+        let blk2 = make_test_bgzf_block(payload2);
+        let blk3 = make_test_bgzf_block(payload3);
+
+        let isz0 = uncompressed_size_of(&blk0);
+        let isz1 = uncompressed_size_of(&blk1);
+        let isz2 = uncompressed_size_of(&blk2);
+        let isz3 = uncompressed_size_of(&blk3);
+
+        // memory_limit set to force a seal after run 0 (blk0+blk1):
+        // use isz0+isz1 as the cap so that after admitting blk1, run_cumulative
+        // >= run_cap and a seal fires.  The arena segment is derived from this
+        // budget (FRONT_REGION + run_cap + one block), so all tiny test blocks
+        // still fit in one segment per run.
+        let run_cap = isz0 + isz1;
+        let mut step = ReadBlocks::new(run_cap, 64 * 1024 * 1024);
+
+        // Admit run 0 blocks.
+        assert!(
+            step.admit_block(BgzfBlock {
+                batch_serial: 0,
+                bytes: blk0.clone(),
+                uncompressed_size: u32::try_from(isz0).unwrap(),
+            })
+            .is_ok()
+        );
+        assert!(
+            step.admit_block(BgzfBlock {
+                batch_serial: 1,
+                bytes: blk1.clone(),
+                uncompressed_size: u32::try_from(isz1).unwrap(),
+            })
+            .is_ok()
+        );
+
+        // After run 0's blocks fill run_cap, seal run 0 explicitly and collect its
+        // blocks (simulating the seal that happens when run_cumulative >= run_cap).
+        // In the pipeline try_run, the seal fires after admit; here we do it manually
+        // via a dedicated seal so we can inspect both runs independently.
+        step.seal_run(true); // mid-stream → seals_to_spill = true
+
+        // Collect run 0 blocks.
+        let run0_blocks: Vec<ArenaBlock> = step.emit.drain(..).collect();
+        assert_eq!(run0_blocks.len(), 2, "run 0 must emit 2 blocks");
+
+        // Run 0 invariants.  Eager emission stamps `is_last_of_run` /
+        // `seals_to_spill` only on the run's LAST block (the withheld one); non-last
+        // blocks carry `false` (downstream reads these fields only on the last block).
+        for blk in &run0_blocks {
+            assert_eq!(blk.run_seq, 0, "run 0 blocks must have run_seq=0");
+        }
+        assert!(!run0_blocks[0].is_last_of_run, "run 0 block 0 must not be last_of_run");
+        assert!(run0_blocks[1].is_last_of_run, "run 0 block 1 must be last_of_run");
+        assert!(!run0_blocks[0].seals_to_spill, "non-last block carries seals_to_spill=false");
+        assert!(run0_blocks[1].seals_to_spill, "run 0 last block must seal to spill");
+        assert_eq!(
+            run0_blocks[0].offset, FRONT_REGION as u64,
+            "run 0 block 0 must start at FRONT_REGION"
+        );
+        assert_eq!(
+            usize::try_from(run0_blocks[1].offset).unwrap(),
+            FRONT_REGION + isz0,
+            "run 0 block 1 must be contiguous after block 0"
+        );
+        assert_eq!(run0_blocks[0].ordinal, 0, "global ordinal monotonic");
+        assert_eq!(run0_blocks[1].ordinal, 1, "global ordinal monotonic");
+
+        // Verify pool exhaustion: while run 0's Arc is still alive, admitting a new
+        // block must fail (pool capacity 1 → all arenas in flight).
+        {
+            let probe_blk = make_test_bgzf_block(b"pool-exhaustion-probe");
+            let probe_isz = uncompressed_size_of(&probe_blk);
+            let result = step.admit_block(BgzfBlock {
+                batch_serial: 99,
+                bytes: probe_blk,
+                uncompressed_size: u32::try_from(probe_isz).unwrap(),
+            });
+            assert!(result.is_err(), "pool must be exhausted while run 0 Arc is still in flight");
+            // A failed admit (ensure_arena returned false) must not leak state: the
+            // block is handed back in the Err, no block is withheld, arena stays None.
+            assert!(step.last_block.is_none(), "failed admit must not withhold a block");
+            assert!(step.arena.is_none(), "failed admit must leave arena as None");
+        }
+
+        // Drop run 0 blocks → their Arc<PooledSegmentedBuf> refcount falls to 0 →
+        // PooledSegmentedBuf::drop releases the arena back to the pool.
+        drop(run0_blocks);
+
+        // Now admit run 1 blocks — the pool has one free (reused) arena.
+        assert!(
+            step.admit_block(BgzfBlock {
+                batch_serial: 2,
+                bytes: blk2.clone(),
+                uncompressed_size: u32::try_from(isz2).unwrap(),
+            })
+            .is_ok(),
+            "run 1 admit must succeed after pool release"
+        );
+        assert!(
+            step.admit_block(BgzfBlock {
+                batch_serial: 3,
+                bytes: blk3.clone(),
+                uncompressed_size: u32::try_from(isz3).unwrap(),
+            })
+            .is_ok(),
+            "run 1 second admit must succeed"
+        );
+
+        // Seal run 1 as the residual.
+        step.seal_run(false);
+        let run1_blocks: Vec<ArenaBlock> = step.emit.drain(..).collect();
+        assert_eq!(run1_blocks.len(), 2, "run 1 must emit 2 blocks");
+
+        // Run 1 invariants.
+        for blk in &run1_blocks {
+            assert_eq!(blk.run_seq, 1, "run 1 blocks must have run_seq=1");
+            assert!(!blk.seals_to_spill, "run 1 (residual) blocks must have seals_to_spill=false");
+        }
+        assert!(!run1_blocks[0].is_last_of_run, "run 1 block 0 must not be last_of_run");
+        assert!(run1_blocks[1].is_last_of_run, "run 1 block 1 must be last_of_run");
+        // Run 1 offsets restart at FRONT_REGION (fresh/reused arena).
+        assert_eq!(
+            run1_blocks[0].offset, FRONT_REGION as u64,
+            "run 1 block 0 must restart at FRONT_REGION"
+        );
+        assert_eq!(
+            usize::try_from(run1_blocks[1].offset).unwrap(),
+            FRONT_REGION + isz2,
+            "run 1 block 1 must be contiguous after block 0"
+        );
+        // Ordinals are globally monotonic across runs.
+        assert_eq!(run1_blocks[0].ordinal, 2, "global ordinal monotonic across runs");
+        assert_eq!(run1_blocks[1].ordinal, 3, "global ordinal monotonic across runs");
+
+        // All run 1 blocks share the same arena Arc.
+        assert!(Arc::ptr_eq(&run1_blocks[0].arena, &run1_blocks[1].arena));
+
+        // Pool behavioral check: the run 1 arena was acquired after the pool round-
+        // tripped run 0's arena back.  Verify the underlying storage was reused
+        // (not a fresh allocation) by comparing the allocated_capacity of the run 1
+        // arena: the reused arena retains its segment allocations (reset_for_reuse
+        // keeps the Vec capacity), so its allocated_capacity is >= the derived
+        // segment size (FRONT_REGION + run_cap + one block, pre-reserved by
+        // reserve_full_capacity in ensure_arena).
+        let expected_segment_size = FRONT_REGION + run_cap + MAX_BGZF_BLOCK;
+        let run1_alloc_cap = run1_blocks[0].arena.allocated_capacity();
+        assert!(
+            run1_alloc_cap >= expected_segment_size,
+            "reused arena must retain its segment capacity (got {run1_alloc_cap}, expected >= {expected_segment_size})"
+        );
+    }
+
+    /// Build a minimal valid BAM record body (no `block_size` prefix) with the given
+    /// ref\_id/pos and a one-character read name `name`.  Returns the body bytes.
+    ///
+    /// Copied verbatim from `crates/fgumi-sort/src/ref_sort.rs`'s test module
+    /// (the `(i32, i32, u8)` version) so tests in this crate can construct
+    /// identical records without a cross-crate dependency on a `#[cfg(test)]`
+    /// helper.
+    fn coord_body(ref_id: i32, pos: i32, name: u8) -> Vec<u8> {
+        let mut b = Vec::new();
+        b.extend_from_slice(&ref_id.to_le_bytes());
+        b.extend_from_slice(&pos.to_le_bytes());
+        b.push(2); // l_read_name (incl NUL): "<name>\0"
+        b.push(0); // mapq
+        b.extend_from_slice(&0u16.to_le_bytes()); // bin
+        b.extend_from_slice(&0u16.to_le_bytes()); // n_cigar_op
+        b.extend_from_slice(&0u16.to_le_bytes()); // flag (forward)
+        b.extend_from_slice(&0u32.to_le_bytes()); // l_seq
+        b.extend_from_slice(&(-1i32).to_le_bytes()); // next_refID
+        b.extend_from_slice(&(-1i32).to_le_bytes()); // next_pos
+        b.extend_from_slice(&0i32.to_le_bytes()); // tlen
+        b.push(name); // read_name char
+        b.push(0); // read_name NUL terminator
+        b
+    }
+
+    /// Build a minimal BAM binary header parseable by `bam_header_len`.
+    ///
+    /// Layout: `magic(4) + l_text=0(4) + n_ref(4)` followed by `n_ref` entries of
+    /// `l_name=2(4) + "r\0"(2) + l_ref=100(4)`.
+    fn minimal_bam_header(n_ref: u32) -> Vec<u8> {
+        let mut h = Vec::new();
+        h.extend_from_slice(b"BAM\x01"); // magic
+        h.extend_from_slice(&0u32.to_le_bytes()); // l_text = 0
+        h.extend_from_slice(&n_ref.to_le_bytes()); // n_ref
+        for _ in 0..n_ref {
+            h.extend_from_slice(&2u32.to_le_bytes()); // l_name = 2
+            h.push(b'r');
+            h.push(0); // name "r\0"
+            h.extend_from_slice(&100u32.to_le_bytes()); // l_ref = 100
+        }
+        h
+    }
+
+    /// Oracle test: `FindBoundariesAndSort` emitted chunk must be byte-identical to
+    /// the copy-based `CoordinateChunkSorter` over the same record bodies.
+    #[allow(unsafe_code)]
+    #[test]
+    fn find_boundaries_and_sort_single_run_matches_oracle() {
+        let n_ref = 4u32;
+        // Records deliberately out of coordinate order; distinct names witness stability.
+        let recs = vec![
+            coord_body(2, 100, b'a'),
+            coord_body(0, 50, b'b'),
+            coord_body(2, 10, b'c'),
+            coord_body(0, 50, b'd'), // coordinate tie with b'b' → stable sort keeps b before d
+            coord_body(1, 999, b'e'),
+        ];
+
+        // Build an arena: [BAM header][[block_size][body]...] as one contiguous run.
+        let header = minimal_bam_header(n_ref);
+        let mut arena = SegmentedBuf::with_capacity(0, 1 << 20);
+        arena.reserve_full_capacity();
+
+        // SAFETY: every slot fully written before any read.
+        let h_off = unsafe { arena.grow_uninit(header.len()) };
+        unsafe { arena.slice_mut(h_off, header.len()) }.copy_from_slice(&header);
+        // h_off is usize; on 64-bit targets usize fits in u64.
+        #[allow(clippy::cast_possible_truncation)]
+        let run_start = h_off as u64;
+
+        for r in &recs {
+            let bs = u32::try_from(r.len()).unwrap();
+            let po = unsafe { arena.grow_uninit(4) };
+            unsafe { arena.slice_mut(po, 4) }.copy_from_slice(&bs.to_le_bytes());
+            let bo = unsafe { arena.grow_uninit(r.len()) };
+            unsafe { arena.slice_mut(bo, r.len()) }.copy_from_slice(r);
+        }
+        // arena.len() is usize; usize fits in u64 on 64-bit targets.
+        #[allow(clippy::cast_possible_truncation)]
+        let run_len = arena.len() as u64 - run_start;
+        let arena = Arc::new(PooledSegmentedBuf::unpooled(arena));
+
+        // Drive ingest_block + finalize directly (the test seam).
+        let mut step =
+            FindBoundariesAndSort::new(CoordinateStrategy::new(n_ref), 1, 64 * 1024 * 1024);
+        step.ingest_block(&InflatedBlock {
+            arena: Arc::clone(&arena),
+            ordinal: 0,
+            offset: run_start,
+            len: u32::try_from(run_len).unwrap(),
+            is_last_of_run: true,
+            run_seq: 0,
+            seals_to_spill: false,
+        })
+        .expect("ingest_block must succeed");
+        let ev = step.finalize().expect("finalize must succeed").expect("residual event");
+
+        let chunk_bytes: Vec<Vec<u8>> = match ev {
+            SortChunkEvent::Residual { chunk: MemoryChunkErased::Coordinate(c), .. } => {
+                (0..c.len()).map(|i| c.record_bytes(i).to_vec()).collect()
+            }
+            _ => panic!("expected Residual coordinate chunk, got something else"),
+        };
+
+        // Oracle: copy-based in-memory coordinate sort of the same record bodies.
+        let mut oracle = CoordinateChunkSorter::for_test(usize::MAX, n_ref);
+        for r in &recs {
+            let _ = oracle.push(r).unwrap();
+        }
+        let oc = oracle.take_sorted_chunk();
+        let oracle_bytes: Vec<Vec<u8>> =
+            (0..oc.len()).map(|i| oc.record_bytes(i).to_vec()).collect();
+
+        assert_eq!(
+            chunk_bytes, oracle_bytes,
+            "arena-scan single-run sort must be byte-identical to the copy-based sorter"
+        );
+    }
+
+    /// Two-run straddler test: a record that spans the boundary between run 0 and
+    /// run 1 must appear as record 0 of run 1's chunk with bytes equal to
+    /// `carry ++ head` (the full original record), and the merged union of both
+    /// runs (stable, lower-run first) must equal the oracle (`CoordinateChunkSorter`
+    /// over the same records in input order).
+    ///
+    /// Test layout:
+    /// - Run 0 arena (no `FRONT_REGION` prefix — built manually like the oracle test):
+    ///   `[header][rec0_prefix+body][rec1_prefix+body][straddler_prefix+partial_body]`
+    ///   The straddler record's `block_size` prefix PLUS the first few body bytes land
+    ///   in run 0; the rest of the body starts at `FRONT_REGION` in run 1's arena.
+    /// - Run 1 arena: `FRONT_REGION` uninit bytes reserved, then `straddler_tail +
+    ///   rec2_prefix + body`.
+    ///   `FindBoundariesAndSort` writes the carry into `[FRONT_REGION - L, FRONT_REGION)`,
+    ///   so `carry ++ straddler_tail` is contiguous and forms the complete record.
+    #[allow(unsafe_code)]
+    #[allow(clippy::too_many_lines)]
+    #[test]
+    fn find_boundaries_and_sort_two_run_straddler() {
+        let n_ref = 2u32;
+        let seg_size = 256 * 1024 * 1024usize;
+
+        // Records: rec0 + rec1 go into run 0 (complete); straddler goes across
+        // the boundary; rec2 goes into run 1 (complete).
+        let rec0 = coord_body(0, 10, b'a');
+        let rec1 = coord_body(1, 20, b'b');
+        let straddler = coord_body(0, 5, b'c'); // will be straddled across runs
+        let rec2 = coord_body(1, 5, b'd');
+
+        let all_recs = vec![&rec0, &rec1, &straddler, &rec2];
+
+        // -----------------------------------------------------------------------
+        // Build run 0 arena: [header][rec0][rec1][straddler_prefix+partial_body]
+        // We use the same manual layout as the oracle test (no FRONT_REGION prefix).
+        // -----------------------------------------------------------------------
+        let header = minimal_bam_header(n_ref);
+
+        let mut arena0 = SegmentedBuf::with_capacity(0, seg_size);
+        arena0.reserve_full_capacity();
+
+        // Write header.
+        let h_off = unsafe { arena0.grow_uninit(header.len()) };
+        unsafe { arena0.slice_mut(h_off, header.len()) }.copy_from_slice(&header);
+
+        // Write rec0 (prefix + body) — complete.
+        let bs0 = u32::try_from(rec0.len()).unwrap();
+        let po = unsafe { arena0.grow_uninit(4) };
+        unsafe { arena0.slice_mut(po, 4) }.copy_from_slice(&bs0.to_le_bytes());
+        let bo = unsafe { arena0.grow_uninit(rec0.len()) };
+        unsafe { arena0.slice_mut(bo, rec0.len()) }.copy_from_slice(&rec0);
+
+        // Write rec1 (prefix + body) — complete.
+        let bs1 = u32::try_from(rec1.len()).unwrap();
+        let po = unsafe { arena0.grow_uninit(4) };
+        unsafe { arena0.slice_mut(po, 4) }.copy_from_slice(&bs1.to_le_bytes());
+        let bo = unsafe { arena0.grow_uninit(rec1.len()) };
+        unsafe { arena0.slice_mut(bo, rec1.len()) }.copy_from_slice(&rec1);
+
+        // Write straddler prefix (4-byte block_size) + partial body.
+        // Split: put the 4-byte prefix + first 3 bytes of body in run 0.
+        let bs_str = u32::try_from(straddler.len()).unwrap();
+        let partial_len = 3usize; // bytes of straddler body in run 0
+        assert!(partial_len < straddler.len(), "partial_len must be < straddler body size");
+        let po = unsafe { arena0.grow_uninit(4) };
+        unsafe { arena0.slice_mut(po, 4) }.copy_from_slice(&bs_str.to_le_bytes());
+        let bp = unsafe { arena0.grow_uninit(partial_len) };
+        unsafe { arena0.slice_mut(bp, partial_len) }.copy_from_slice(&straddler[..partial_len]);
+
+        // run 0 span: from header offset (0) to end of arena.
+        let run0_start = h_off as u64;
+        let run0_end = arena0.len() as u64;
+        let run0_len = usize::try_from(run0_end - run0_start).unwrap();
+
+        let arena0 = Arc::new(PooledSegmentedBuf::unpooled(arena0));
+
+        // -----------------------------------------------------------------------
+        // Build run 1 arena: [FRONT_REGION uninit][straddler_tail][rec2 prefix+body]
+        // -----------------------------------------------------------------------
+        let mut arena1 = SegmentedBuf::with_capacity(0, seg_size);
+        arena1.reserve_full_capacity();
+
+        // Reserve the FRONT_REGION prefix (uninit — the carry will be written here
+        // by FindBoundariesAndSort).
+        let _front = unsafe { arena1.grow_uninit(FRONT_REGION) };
+        assert_eq!(arena1.len(), FRONT_REGION);
+
+        // Write straddler tail (remaining body bytes) at FRONT_REGION.
+        let tail_len = straddler.len() - partial_len;
+        let st_off = unsafe { arena1.grow_uninit(tail_len) };
+        assert_eq!(st_off, FRONT_REGION, "straddler tail must start at FRONT_REGION");
+        unsafe { arena1.slice_mut(st_off, tail_len) }.copy_from_slice(&straddler[partial_len..]);
+
+        // Write rec2 (prefix + body) — complete.
+        let bs2 = u32::try_from(rec2.len()).unwrap();
+        let po = unsafe { arena1.grow_uninit(4) };
+        unsafe { arena1.slice_mut(po, 4) }.copy_from_slice(&bs2.to_le_bytes());
+        let bo = unsafe { arena1.grow_uninit(rec2.len()) };
+        unsafe { arena1.slice_mut(bo, rec2.len()) }.copy_from_slice(&rec2);
+
+        // run 1 spans from FRONT_REGION (the inflate data, not the front region).
+        let run1_data_start = FRONT_REGION as u64;
+        let run1_data_end = arena1.len() as u64;
+        let run1_data_len = usize::try_from(run1_data_end - run1_data_start).unwrap();
+
+        let arena1 = Arc::new(PooledSegmentedBuf::unpooled(arena1));
+
+        // -----------------------------------------------------------------------
+        // Drive FindBoundariesAndSort across both runs.
+        // -----------------------------------------------------------------------
+        let mut fbs =
+            FindBoundariesAndSort::new(CoordinateStrategy::new(n_ref), 1, 64 * 1024 * 1024);
+
+        // Run 0: one block, is_last_of_run = true, seals_to_spill = true.
+        fbs.ingest_block(&InflatedBlock {
+            arena: Arc::clone(&arena0),
+            ordinal: 0,
+            offset: run0_start,
+            len: u32::try_from(run0_len).unwrap(),
+            is_last_of_run: true,
+            run_seq: 0,
+            seals_to_spill: true,
+        })
+        .expect("run 0 ingest must succeed");
+
+        // After run 0's last block, a Spill event must be staged.
+        assert_eq!(fbs.pending.len(), 1, "run 0 must stage exactly one Spill event");
+        let ev0 = fbs.pending.pop_front().unwrap();
+        let run0_chunk = match ev0 {
+            SortChunkEvent::Spill { seq, chunk: MemoryChunkErased::Coordinate(c), .. } => {
+                assert_eq!(seq, 0, "first Spill must have seq=0");
+                c
+            }
+            _ => panic!("expected Spill(Coordinate) for run 0, got something else"),
+        };
+
+        // Assert run 0's carry: 4 bytes (prefix) + partial_len body bytes.
+        let expected_carry_len = 4 + partial_len;
+        assert_eq!(
+            fbs.carry.len(),
+            expected_carry_len,
+            "carry after run 0 must be {expected_carry_len} bytes (prefix + partial body)"
+        );
+
+        // Run 0 chunk must NOT contain the straddler — only rec0 and rec1.
+        assert_eq!(
+            run0_chunk.len(),
+            2,
+            "run 0 chunk must have exactly 2 complete records (rec0, rec1)"
+        );
+
+        // Run 1: one block, is_last_of_run = true, seals_to_spill = false.
+        fbs.ingest_block(&InflatedBlock {
+            arena: Arc::clone(&arena1),
+            ordinal: 1,
+            offset: run1_data_start,
+            len: u32::try_from(run1_data_len).unwrap(),
+            is_last_of_run: true,
+            run_seq: 1,
+            seals_to_spill: false,
+        })
+        .expect("run 1 ingest must succeed");
+
+        // After run 1's last block, pending has Residual + AllAnnounced.
+        assert_eq!(fbs.pending.len(), 2, "run 1 must stage Residual + AllAnnounced");
+        assert!(fbs.carry.is_empty(), "carry must be empty after the final run");
+
+        let ev_residual = fbs.pending.pop_front().unwrap();
+        let SortChunkEvent::Residual { chunk: MemoryChunkErased::Coordinate(run1_chunk), .. } =
+            ev_residual
+        else {
+            panic!("expected Residual(Coordinate) for run 1, got something else")
+        };
+
+        let ev_announced = fbs.pending.pop_front().unwrap();
+        match ev_announced {
+            SortChunkEvent::AllAnnounced { slot_count, memory_chunk_count, total_records } => {
+                assert_eq!(slot_count, 1, "AllAnnounced: slot_count must be 1 (one spill)");
+                assert_eq!(memory_chunk_count, 1, "AllAnnounced: memory_chunk_count must be 1");
+                assert_eq!(total_records, 4, "AllAnnounced: total_records must be 4");
+            }
+            _ => panic!("expected AllAnnounced, got something else"),
+        }
+
+        // Run 1 chunk: straddler (record 0) + rec2 (record 1) — 2 records.
+        assert_eq!(run1_chunk.len(), 2, "run 1 chunk must have 2 records (straddler + rec2)");
+
+        // Assert straddler is record 0 of run 1's sorted chunk.
+        // The straddler has key (ref_id=0, pos=5) and rec2 has (ref_id=1, pos=5);
+        // coordinate sort orders by ref_id first, so straddler (ref_id=0) comes before
+        // rec2 (ref_id=1).
+        let straddler_bytes = run1_chunk.record_bytes(0).to_vec();
+        assert_eq!(
+            straddler_bytes, straddler,
+            "run 1 record 0 must be the straddler (carry ++ head = full original record)"
+        );
+        let rec2_bytes = run1_chunk.record_bytes(1).to_vec();
+        assert_eq!(rec2_bytes, rec2, "run 1 record 1 must be rec2");
+
+        // -----------------------------------------------------------------------
+        // Oracle check: stable merge of run0 + run1 by coordinate key, lower
+        // source index first (run0 < run1) must equal the oracle over all 4 records.
+        //
+        // Oracle sort order: (ref_id=0,pos=5)=straddler, (ref_id=0,pos=10)=rec0,
+        //   (ref_id=1,pos=5)=rec2, (ref_id=1,pos=20)=rec1.
+        //
+        // Merge gives: run0 records sorted = [rec0(0,10), rec1(1,20)];
+        //              run1 records sorted = [straddler(0,5), rec2(1,5)].
+        // Interleaved lower-run-first stable merge:
+        //   Compare run0[0]=(0,10) vs run1[0]=(0,5): run1 wins → straddler
+        //   Compare run0[0]=(0,10) vs run1[1]=(1,5): run0 wins → rec0
+        //   Compare run0[1]=(1,20) vs run1[1]=(1,5): run1 wins → rec2
+        //   run1 exhausted → run0[1] = rec1
+        // Merge result: [straddler, rec0, rec2, rec1]
+        // -----------------------------------------------------------------------
+        let mut oracle = CoordinateChunkSorter::for_test(usize::MAX, n_ref);
+        for r in &all_recs {
+            let _ = oracle.push(r).unwrap();
+        }
+        let oracle_chunk = oracle.take_sorted_chunk();
+        let oracle_bytes: Vec<Vec<u8>> =
+            (0..oracle_chunk.len()).map(|i| oracle_chunk.record_bytes(i).to_vec()).collect();
+        // Expected oracle order: [(0,5)=straddler, (0,10)=rec0, (1,5)=rec2, (1,20)=rec1]
+        assert_eq!(oracle_bytes[0], straddler, "oracle[0] must be straddler");
+        assert_eq!(oracle_bytes[1], rec0, "oracle[1] must be rec0");
+        assert_eq!(oracle_bytes[2], rec2, "oracle[2] must be rec2");
+        assert_eq!(oracle_bytes[3], rec1, "oracle[3] must be rec1");
+
+        // Collect sorted bytes from both run chunks (run0 first, then run1) via a
+        // manual stable merge that mirrors the merge engine's lower-source-index-first
+        // tie-break.
+        //
+        // run0 sorted: [rec0(0,10), rec1(1,20)]
+        // run1 sorted: [straddler(0,5), rec2(1,5)]
+        let run0_sorted: Vec<Vec<u8>> =
+            (0..run0_chunk.len()).map(|i| run0_chunk.record_bytes(i).to_vec()).collect();
+        let run1_sorted: Vec<Vec<u8>> =
+            (0..run1_chunk.len()).map(|i| run1_chunk.record_bytes(i).to_vec()).collect();
+
+        // Build a merged sequence via coordinate key comparison.
+        // We use the oracle order as the expected merged order (they must match).
+        let mut merged: Vec<Vec<u8>> = Vec::with_capacity(4);
+        let mut i0 = 0usize;
+        let mut i1 = 0usize;
+        while i0 < run0_sorted.len() || i1 < run1_sorted.len() {
+            if i0 >= run0_sorted.len() {
+                merged.push(run1_sorted[i1].clone());
+                i1 += 1;
+            } else if i1 >= run1_sorted.len() {
+                merged.push(run0_sorted[i0].clone());
+                i0 += 1;
+            } else {
+                // Extract coordinate key: ref_id (first i32) and pos (second i32).
+                let key0 = {
+                    let b = &run0_sorted[i0];
+                    let r = i32::from_le_bytes(b[0..4].try_into().unwrap());
+                    let p = i32::from_le_bytes(b[4..8].try_into().unwrap());
+                    (r, p)
+                };
+                let key1 = {
+                    let b = &run1_sorted[i1];
+                    let r = i32::from_le_bytes(b[0..4].try_into().unwrap());
+                    let p = i32::from_le_bytes(b[4..8].try_into().unwrap());
+                    (r, p)
+                };
+                // Stable: on tie, run0 (lower source index) wins.
+                if key1 < key0 {
+                    merged.push(run1_sorted[i1].clone());
+                    i1 += 1;
+                } else {
+                    merged.push(run0_sorted[i0].clone());
+                    i0 += 1;
+                }
+            }
+        }
+
+        assert_eq!(
+            merged, oracle_bytes,
+            "stable merge of run0 + run1 chunks must equal the oracle over all 4 records"
+        );
+    }
+
+    #[allow(unsafe_code)]
+    #[test]
+    fn inflate_writes_decompressed_bytes_into_the_slot() {
+        // Build a payload that is comfortably under one BGZF block (< 64 KiB).
+        let payload = b"PARALLEL-INFLATE-ARENA-TEST".repeat(50);
+        let block = compress_one_block(&payload);
+        let isize = u32::try_from(payload.len()).unwrap();
+
+        // Construct an arena with enough capacity for the payload, reserve it,
+        // then carve out an uninit slot for the inflate worker to fill.
+        let mut arena = SegmentedBuf::with_capacity(0, 1 << 20);
+        arena.reserve_full_capacity();
+        // SAFETY: slot is fully written by `inflate_one` below before any read.
+        let offset = unsafe { arena.grow_uninit(payload.len()) } as u64;
+        let arena = Arc::new(PooledSegmentedBuf::unpooled(arena));
+
+        let item = ArenaBlock {
+            arena: Arc::clone(&arena),
+            ordinal: 0,
+            offset,
+            len: isize,
+            block,
+            is_last_of_run: true,
+            run_seq: 0,
+            seals_to_spill: false,
+        };
+
+        let mut step = InflateToArena::new(64 * 1024 * 1024);
+        let inflated = step.inflate_one(item).expect("inflate must succeed");
+
+        assert_eq!(inflated.offset, offset, "offset must be forwarded unchanged");
+        assert_eq!(inflated.len, isize, "len must be forwarded unchanged");
+        assert!(!inflated.seals_to_spill, "seals_to_spill must be forwarded");
+        // Confirm the decompressed bytes are in the arena at the reserved slot.
+        assert_eq!(
+            arena.slice(
+                usize::try_from(offset).unwrap(),
+                isize as usize, // u32 always fits in usize
+            ),
+            &payload[..],
+            "arena slot must contain the original payload after inflate"
+        );
+    }
+
+    /// Regression coverage for the `FindBoundariesAndSort` `try_run`
+    /// finalize/drained-branch held-overwrite bug.
+    ///
+    /// The bug: on the drained path `try_run` did `push(first_event)` and then,
+    /// in the SAME call, unconditionally drained the rest of `pending` via
+    /// `emit_pending` WITHOUT re-checking `held`.  If the first push is rejected
+    /// (full output queue → `first_event` goes into `held`), the follow-on
+    /// `emit_pending` would push a LATER event (`AllAnnounced`) ahead of the
+    /// still-held `Residual` and then `held.put(...)` it — clobbering the held
+    /// `Residual` (`HeldSlot::put` asserts on a double-put, so it would panic /
+    /// lose the record).  The fix drains `pending` only when the first push
+    /// SUCCEEDED, preserving the one-event-per-call discipline of the normal path.
+    ///
+    /// This test pins the ordering contract `finalize()` hands `try_run`, which is
+    /// exactly what the one-event-per-call fix must emit in order: `Residual`
+    /// FIRST, then `AllAnnounced`, each staged exactly once.  If `finalize()`
+    /// staged them in the wrong order (or duplicated one), the held/retry path in
+    /// `try_run` could not emit a correct stream no matter how careful it is.
+    ///
+    /// Coverage limit: the held-overwrite lived inside `try_run`, which needs a
+    /// backpressuring `StepCtx` (an `OutputHandles<Single<_>>` whose queue rejects
+    /// the first push).  `OutputHandles::new` is `pub(crate)` to
+    /// `fgumi-pipeline-core`, so a rejecting output context cannot be built from
+    /// this crate without editing another crate; the full `try_run` held/retry path
+    /// is exercised end-to-end by the framework-driven tests in `sort/tests.rs`.
+    /// Here we assert the finalize-branch invariant as directly as the in-crate
+    /// seams (`finalize`, `pending`) allow.
+    #[allow(unsafe_code)]
+    #[test]
+    fn finalize_stages_residual_before_all_announced_each_once() {
+        let n_ref = 2u32;
+        // A complete run (header + two whole records, no trailing partial), so
+        // sealing it as a residual leaves an empty carry.
+        let recs = [coord_body(0, 10, b'a'), coord_body(1, 20, b'b')];
+        let header = minimal_bam_header(n_ref);
+        let mut arena = SegmentedBuf::with_capacity(0, 1 << 20);
+        arena.reserve_full_capacity();
+        // SAFETY: every slot fully written before any read.
+        let h_off = unsafe { arena.grow_uninit(header.len()) };
+        unsafe { arena.slice_mut(h_off, header.len()) }.copy_from_slice(&header);
+        #[allow(clippy::cast_possible_truncation)]
+        let run_start = h_off as u64;
+        for r in &recs {
+            let bs = u32::try_from(r.len()).unwrap();
+            let po = unsafe { arena.grow_uninit(4) };
+            unsafe { arena.slice_mut(po, 4) }.copy_from_slice(&bs.to_le_bytes());
+            let bo = unsafe { arena.grow_uninit(r.len()) };
+            unsafe { arena.slice_mut(bo, r.len()) }.copy_from_slice(r);
+        }
+        #[allow(clippy::cast_possible_truncation)]
+        let run_len = arena.len() as u64 - run_start;
+        let arena = Arc::new(PooledSegmentedBuf::unpooled(arena));
+
+        let mut step =
+            FindBoundariesAndSort::new(CoordinateStrategy::new(n_ref), 1, 64 * 1024 * 1024);
+        // Ingest the run WITHOUT `is_last_of_run`, so `ingest_block` does NOT seal:
+        // the seal (and the `Residual` + `AllAnnounced` staging) then happens in
+        // `finalize()` — the path `try_run`'s drained branch drives.
+        step.ingest_block(&InflatedBlock {
+            arena: Arc::clone(&arena),
+            ordinal: 0,
+            offset: run_start,
+            len: u32::try_from(run_len).unwrap(),
+            is_last_of_run: false,
+            run_seq: 0,
+            seals_to_spill: false,
+        })
+        .expect("ingest_block must succeed");
+        assert!(step.pending.is_empty(), "no events staged before finalize");
+
+        // finalize() returns the FIRST event (Residual) and leaves the remainder
+        // staged in `pending`.  This is the one-event-at-a-time hand-off that
+        // `try_run`'s drained branch must respect: emit `first_event`, and only
+        // drain `pending` if that push landed.
+        let first = step.finalize().expect("finalize must succeed").expect("first event present");
+        assert!(
+            matches!(first, SortChunkEvent::Residual { .. }),
+            "finalize must return Residual as the first event"
+        );
+        // Exactly one event remains staged, and it is AllAnnounced (never emitted
+        // ahead of the Residual).
+        assert_eq!(step.pending.len(), 1, "exactly one event remains staged after the Residual");
+        match step.pending.front().expect("AllAnnounced staged") {
+            SortChunkEvent::AllAnnounced { slot_count, memory_chunk_count, .. } => {
+                assert_eq!(*slot_count, 0, "no spills → slot_count 0");
+                assert_eq!(*memory_chunk_count, 1, "one in-memory residual chunk");
+            }
+            _ => panic!("second staged event must be AllAnnounced"),
+        }
+
+        // A subsequent finalize() (mirroring a later drained `try_run` after the
+        // Residual flushed) hands back AllAnnounced, then nothing — proving each
+        // event is produced exactly once and in order.
+        let second = step.finalize().expect("finalize must succeed").expect("AllAnnounced present");
+        assert!(
+            matches!(second, SortChunkEvent::AllAnnounced { .. }),
+            "second finalize must return AllAnnounced"
+        );
+        assert!(step.pending.is_empty(), "no further events staged");
+        assert!(
+            step.finalize().expect("finalize must succeed").is_none(),
+            "no more events after Residual + AllAnnounced"
+        );
+    }
+
+    /// Runtime proof that `--sort-threads` (Phase 1) controls the actual sort
+    /// worker count, not just that it parses.
+    ///
+    /// The chain builder resolves `--sort-threads` (falling back to `--threads`)
+    /// into `num_phase1_threads` and hands it to `FindBoundariesAndSort::new`,
+    /// which forwards it to `strategy.seal(arena, self.sort_threads)`. The
+    /// queryname strategy builds a bounded rayon pool sized to that value and runs
+    /// the per-run comparator sort inside it — so the pool's thread count IS the
+    /// effective Phase-1 concurrency. (The D1.1 regression handed the strategy the
+    /// raw global `--threads` instead, silently ignoring `--sort-threads`.)
+    ///
+    /// `ThreadPool::current_num_threads()` is the fixed pool size, so this is
+    /// deterministic — unlike counting how many workers a given input happens to
+    /// keep busy. Sort output is byte-identical across thread counts, so this pool
+    /// observation is the only way to assert the flag's runtime effect.
+    #[allow(unsafe_code)]
+    #[test]
+    fn phase1_sort_threads_sizes_the_queryname_worker_pool() {
+        use fgumi_sort::RawQuerynameLexKey;
+
+        for sort_threads in [1usize, 3] {
+            let n_ref = 2u32;
+            let recs = [coord_body(0, 10, b'a'), coord_body(1, 20, b'b')];
+            let header = minimal_bam_header(n_ref);
+            let mut arena = SegmentedBuf::with_capacity(0, 1 << 20);
+            arena.reserve_full_capacity();
+            // SAFETY: every slot fully written before any read.
+            let h_off = unsafe { arena.grow_uninit(header.len()) };
+            unsafe { arena.slice_mut(h_off, header.len()) }.copy_from_slice(&header);
+            #[allow(clippy::cast_possible_truncation)]
+            let run_start = h_off as u64;
+            for r in &recs {
+                let bs = u32::try_from(r.len()).unwrap();
+                let po = unsafe { arena.grow_uninit(4) };
+                unsafe { arena.slice_mut(po, 4) }.copy_from_slice(&bs.to_le_bytes());
+                let bo = unsafe { arena.grow_uninit(r.len()) };
+                unsafe { arena.slice_mut(bo, r.len()) }.copy_from_slice(r);
+            }
+            #[allow(clippy::cast_possible_truncation)]
+            let run_len = arena.len() as u64 - run_start;
+            let arena = Arc::new(PooledSegmentedBuf::unpooled(arena));
+
+            let mut step = FindBoundariesAndSort::new(
+                QuerynameStrategy::<RawQuerynameLexKey>::new(MemoryChunkErased::QuerynameLex),
+                sort_threads,
+                64 * 1024 * 1024,
+            );
+            assert_eq!(
+                step.strategy().sort_pool_threads(),
+                None,
+                "sort pool is not built until the first seal"
+            );
+            step.ingest_block(&InflatedBlock {
+                arena: Arc::clone(&arena),
+                ordinal: 0,
+                offset: run_start,
+                len: u32::try_from(run_len).unwrap(),
+                is_last_of_run: false,
+                run_seq: 0,
+                seals_to_spill: false,
+            })
+            .expect("ingest_block must succeed");
+            // finalize() seals the residual run, which builds + installs the
+            // bounded sort pool sized to `sort_threads`.
+            let _ = step.finalize().expect("finalize must succeed");
+            assert_eq!(
+                step.strategy().sort_pool_threads(),
+                Some(sort_threads),
+                "Phase-1 queryname sort pool must be sized to sort_threads={sort_threads} \
+                 (the value FindBoundariesAndSort was constructed with)"
+            );
+        }
+    }
+}

--- a/crates/fgumi-pipeline-io/src/sort/compress_spill.rs
+++ b/crates/fgumi-pipeline-io/src/sort/compress_spill.rs
@@ -1,0 +1,228 @@
+//! `CompressSpill` — the second step of the P6 Phase-1 split (`SortBuffer` →
+//! `CompressSpill` → `SortSpillDecompress` → `SortMerge`).
+//!
+//! `SortBuffer` (Serial) emits already-sorted chunks; `CompressSpill`
+//! (`Parallel`) compresses each spill chunk to disk **inline on its framework
+//! worker** (via [`fgumi_sort::write_sorted_chunk_inmem`], or the chunk's own
+//! `write_spill` for the template-arena variant, retiring the private
+//! `SortWorkerPool` compress path) and forwards the result as the existing
+//! [`SortPhase1Event`], so `SortSpillDecompress` / `SortMerge` are unchanged.
+//!
+//! # Why a `Parallel` step is safe here
+//!
+//! `SortMerge` collects setup events and gates on **counts** (`slot_count` /
+//! `memory_chunk_count` from `AllAnnounced`), not on event arrival order, so
+//! multiple `CompressSpill` workers may emit `SpillReady` / `MemoryChunk` events
+//! in any order. The one ordering-sensitive concern — the `LoserTree` tie-break
+//! for equal sort keys — is handled by stamping each spill slot's `file_id` with
+//! the chunk's **logical** spill index (`SortChunkEvent::Spill::seq`, assigned by
+//! `SortBuffer`), so the tie-break is independent of which worker writes first.
+
+use std::io;
+use std::path::Path;
+use std::sync::Arc;
+
+use fgumi_sort::{SpillCodec, TmpDirAllocator};
+use parking_lot::Mutex;
+use tempfile::TempDir;
+
+use crate::sort::protocol::{MemoryChunkErased, SortChunkEvent, SortPhase1Event};
+use fgumi_pipeline_core::{
+    HeldRetry, Unpushed,
+    held::HeldSlot,
+    outputs::Single,
+    queues::QueueSpec,
+    reorder::BranchOrdering,
+    step::{Step, StepCtx, StepKind, StepOutcome, StepProfile},
+};
+
+/// `Parallel` step that compresses sorted spill chunks to disk and forwards
+/// residual chunks, emitting [`SortPhase1Event`]s to `SortSpillDecompress`.
+///
+/// Not to be confused with the similarly-named
+/// [`SpillBlockCompress`](super::SpillBlockCompress): this `CompressSpill` is the
+/// **composite compress-and-write-to-disk** step of the coarser
+/// `SortBuffer → CompressSpill → SortSpillDecompress → SortMerge` chain, whereas
+/// `SpillBlockCompress` is the **pure block-compression** middle step of the finer
+/// `SpillGather → SpillBlockCompress → SpillWrite` split (where the disk write is a
+/// separate `SpillWrite` step).
+pub struct CompressSpill {
+    /// Shared temp-directory allocator (free-space-aware round-robin). Behind a
+    /// `Mutex` because the step is `Parallel`; the lock is held only for the
+    /// brief base-directory pick, never across the (expensive) compress+write.
+    alloc: Arc<Mutex<TmpDirAllocator>>,
+    /// Spill codec for chunk files (bgzf or zstd).
+    codec: SpillCodec,
+    /// Temp-file compression level (`0` = uncompressed bgzf; zstd level for zstd).
+    compression: u32,
+    /// At most one not-yet-pushable output event, parked on downstream
+    /// backpressure. This is the framework's standard backpressure idiom (there
+    /// is no peek-before-pop), identical to the sibling Parallel step
+    /// [`SortSpillDecompress`](super::SortSpillDecompress), and like it this one
+    /// held event sits **outside** `output_byte_limit`: total retained memory is
+    /// `queue_bytes + (≤1 event) × workers`. For a `SpillReady` the held event is
+    /// tiny (an `Arc<SortMergeSlot>` + path); only a `MemoryChunk` (residual)
+    /// holds records, and the residual must transit the pipeline occupying
+    /// ~`memory_limit` regardless of whether it sits in the queue or this slot, so
+    /// the held slot adds no peak beyond what the residual already costs.
+    held: HeldSlot<Unpushed<SortPhase1Event>>,
+    output_byte_limit: u64,
+    /// RAII temp-dir handles, shared across `Parallel` clones. Held for the
+    /// step's lifetime so spill files survive while being written; on the last
+    /// clone's drop (after the step finishes — i.e. every spill is written and
+    /// every slot has an open fd) the dirs are removed. `SortMerge` then reads
+    /// each slot via its already-open fd, matching the legacy `SortAndSpill`
+    /// unlink-after-emit lifetime (correct on the Unix targets). Empty in tests
+    /// that hold their own `TempDir`. Held purely for RAII (`Arc`-cloned to each
+    /// worker), never read for its value.
+    temp_dirs: Arc<Vec<TempDir>>,
+}
+
+impl CompressSpill {
+    /// Build a `CompressSpill` step.
+    ///
+    /// `alloc` names spill files across the configured temp dirs; `codec` /
+    /// `compression` select the on-disk spill format. `temp_dirs` holds the RAII
+    /// handles for those dirs alive for the step's lifetime. `output_byte_limit`
+    /// byte-bounds the forwarded-event output queue (its `MemoryChunk` variant
+    /// retains sorted records, so the queue must budget on bytes, not count).
+    #[must_use]
+    pub fn new(
+        alloc: Arc<Mutex<TmpDirAllocator>>,
+        codec: SpillCodec,
+        compression: u32,
+        output_byte_limit: u64,
+        temp_dirs: Arc<Vec<TempDir>>,
+    ) -> Self {
+        Self { alloc, codec, compression, held: HeldSlot::new(), output_byte_limit, temp_dirs }
+    }
+
+    fn flush_held(&mut self, ctx: &mut StepCtx<'_, Self>) -> bool {
+        // `true` once the slot is clear (was empty, or the held event flushed);
+        // `false` while it's still held under backpressure. Uses the canonical
+        // re-hold helper so the put-back-on-reject invariant lives in one place.
+        !matches!(ctx.outputs.retry_held(&mut self.held), HeldRetry::StillHeld)
+    }
+
+    /// Allocate a spill path for chunk `seq`. Names the file by the logical spill
+    /// index so the path is unique without a shared counter, then draws a base
+    /// directory from the shared allocator (the only locked section).
+    fn spill_path(&self, seq: u32) -> io::Result<std::path::PathBuf> {
+        let base = self.alloc.lock().next().map_err(|e| {
+            io::Error::other(format!("CompressSpill: temp-dir allocation failed: {e:#}"))
+        })?;
+        Ok(base.join(format!("chunk_{seq:04}.keyed")))
+    }
+
+    /// Compress one input event into the forwarded [`SortPhase1Event`]. The
+    /// `Spill` arm does the file write inline; the others are passthroughs. This
+    /// is `StepCtx`-free so it is unit-testable on synthetic chunks.
+    fn compress_event(&self, event: SortChunkEvent) -> io::Result<SortPhase1Event> {
+        match event {
+            SortChunkEvent::Spill { seq, chunk, records_ingested_so_far } => {
+                let path = self.spill_path(seq)?;
+                write_chunk(&chunk, &path, self.codec, self.compression)?;
+                let slot = fgumi_sort::open_spill_slot(&path, seq).map_err(|e| {
+                    io::Error::other(format!(
+                        "CompressSpill: failed to open spill slot {}: {e:#}",
+                        path.display()
+                    ))
+                })?;
+                Ok(SortPhase1Event::SpillReady { slot, path, records_ingested_so_far })
+            }
+            SortChunkEvent::Residual { chunk, records_ingested_so_far } => {
+                // Wrap in a fresh, uniquely-owned `Arc`: the chunk is only ever
+                // moved (never cloned) onward, so `SortMerge`'s `Arc::try_unwrap`
+                // invariant holds.
+                Ok(SortPhase1Event::MemoryChunk { chunk: Arc::new(chunk), records_ingested_so_far })
+            }
+            SortChunkEvent::AllAnnounced { slot_count, memory_chunk_count, total_records } => {
+                Ok(SortPhase1Event::AllAnnounced { slot_count, memory_chunk_count, total_records })
+            }
+        }
+    }
+}
+
+/// Dispatch a sorted [`MemoryChunkErased`] to [`fgumi_sort::write_sorted_chunk_inmem`]
+/// (or the chunk's own `write_spill`, for the template-arena variant) for the
+/// concrete key variant.
+fn write_chunk(
+    chunk: &MemoryChunkErased,
+    path: &Path,
+    codec: SpillCodec,
+    compression: u32,
+) -> io::Result<()> {
+    let result = match chunk {
+        MemoryChunkErased::Coordinate(c) => {
+            fgumi_sort::write_sorted_chunk_inmem(path, codec, compression, c)
+        }
+        MemoryChunkErased::QuerynameLex(c) => {
+            fgumi_sort::write_sorted_chunk_inmem(path, codec, compression, c)
+        }
+        MemoryChunkErased::QuerynameNatural(c) => {
+            fgumi_sort::write_sorted_chunk_inmem(path, codec, compression, c)
+        }
+        MemoryChunkErased::TemplateCoordinate(c) => c.write_spill(path, codec, compression),
+    };
+    result.map_err(|e| {
+        io::Error::other(format!("CompressSpill: chunk write to {} failed: {e:#}", path.display()))
+    })
+}
+
+impl Clone for CompressSpill {
+    fn clone(&self) -> Self {
+        Self {
+            alloc: Arc::clone(&self.alloc),
+            codec: self.codec,
+            compression: self.compression,
+            held: HeldSlot::new(),
+            output_byte_limit: self.output_byte_limit,
+            temp_dirs: Arc::clone(&self.temp_dirs),
+        }
+    }
+}
+
+impl Step for CompressSpill {
+    type Input = SortChunkEvent;
+    type Outputs = Single<SortPhase1Event>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "CompressSpill",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::None],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // 1. Drain held output first (at most one event is ever held, since we
+        //    only pop a new input after `flush_held` clears the slot).
+        if !self.flush_held(ctx) {
+            return Ok(StepOutcome::Contention);
+        }
+
+        // 2. Pop one input event, compress/forward it, hold on a full output.
+        if let Some(event) = ctx.input.pop() {
+            let forwarded = self.compress_event(event)?;
+            if let Err(unpushed) = ctx.outputs.push(forwarded) {
+                self.held.put(unpushed);
+            }
+            return Ok(StepOutcome::Progress);
+        }
+
+        // 3. No input available.
+        if ctx.input.is_drained() {
+            return Ok(StepOutcome::Finished);
+        }
+        Ok(StepOutcome::NoProgress)
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fgumi-pipeline-io/src/sort/compress_spill/tests.rs
+++ b/crates/fgumi-pipeline-io/src/sort/compress_spill/tests.rs
@@ -1,0 +1,325 @@
+//! Unit tests for `CompressSpill::compress_event` (the `StepCtx`-free core).
+//!
+//! These drive the per-event compression directly on synthetic sorted chunks,
+//! covering the three event arms: `Spill` (compress to disk, slot `file_id` =
+//! logical `seq`), `Residual` (pass through as a uniquely-owned `MemoryChunk`),
+//! and `AllAnnounced` (verbatim forward). The end-to-end chain parity vs the
+//! legacy oracle is exercised later, once `SortBuffer` + `add_sort` are wired
+//! (P6 increments 3–4).
+
+use super::*;
+
+use fgumi_raw_bam::RawRecord;
+use fgumi_sort::{RawCoordinateKey, TemplateKey};
+use rstest::rstest;
+use tempfile::TempDir;
+
+use crate::sort::protocol::MemoryChunkErased;
+
+/// Which easily-constructed sort-key variant a parameterized case exercises.
+/// (The two queryname variants are the same generic `write_sorted_chunk::<K>`
+/// dispatch; they get real coverage from the inc-4 chain parity test, where
+/// genuine queryname keys come from BAM data rather than fragile hand
+/// construction.)
+#[derive(Clone, Copy)]
+enum SpillVariant {
+    Coordinate,
+    Template,
+}
+
+type CoordRecords = Vec<(RawCoordinateKey, RawRecord)>;
+
+/// `n` coordinate records with distinct, sized payloads so the spill file has
+/// real content (and multiple zstd frames for large `n`).
+#[allow(clippy::cast_possible_truncation)] // payload byte is `% 251`, always fits u8
+fn coord_records(n: usize) -> CoordRecords {
+    (0..n)
+        .map(|i| {
+            // Distinct, ascending sort keys so the byte-identity checks exercise
+            // key serialization (not just record-byte order).
+            let key = RawCoordinateKey { sort_key: i as u64 };
+            (key, RawRecord::from(vec![(i % 251) as u8; 100 + i % 64]))
+        })
+        .collect()
+}
+
+/// Deterministic coordinate records keyed off `seq`, so a concurrently-written
+/// spill file can be checked against an independent reference write.
+#[allow(clippy::cast_possible_truncation)] // payload byte is `% 251`, always fits u8
+fn coord_records_for(seq: u32) -> CoordRecords {
+    let n = 40 + (seq as usize % 24);
+    (0..n)
+        .map(|i| {
+            let byte = (seq as usize + i) % 251;
+            // Distinct keys per (seq, i) so key serialization is exercised.
+            let key = RawCoordinateKey { sort_key: (u64::from(seq) << 32) | i as u64 };
+            (key, RawRecord::from(vec![byte as u8; 80 + i % 32]))
+        })
+        .collect()
+}
+
+/// Pack owned coordinate records into the zero-copy arena-backed
+/// [`InMemoryChunk`] the `Coordinate` protocol variant now carries. The spill
+/// file this produces must be byte-identical to a `write_sorted_chunk` of the
+/// same owned records (the tests assert exactly that).
+fn coord_chunk(records: CoordRecords) -> fgumi_sort::InMemoryChunk<RawCoordinateKey> {
+    fgumi_sort::InMemoryChunk::from_owned_records(
+        records.into_iter().map(|(k, r)| (k, r.into_inner())).collect(),
+    )
+}
+
+/// `n` template-coordinate records (the other easily-constructed key variant).
+#[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+fn template_records(n: usize) -> Vec<(TemplateKey, RawRecord)> {
+    (0..n)
+        .map(|i| {
+            let k = TemplateKey::new(
+                i as i32,
+                i as i32,
+                false,
+                i32::MAX,
+                i32::MAX,
+                false,
+                0,
+                0,
+                (0, false),
+                i as u64,
+                false,
+            );
+            (k, RawRecord::from(vec![(i % 251) as u8; 120 + i % 48]))
+        })
+        .collect()
+}
+
+/// Wrap owned template records into the arena-backed `InMemoryChunk<TemplateKey>`
+/// the `TemplateCoordinate` protocol variant now carries — the template analogue
+/// of [`coord_chunk`]. The spill file this produces must be byte-identical to a
+/// `write_sorted_chunk` of the same owned records (the test asserts exactly that).
+fn template_chunk(
+    records: Vec<(TemplateKey, RawRecord)>,
+) -> fgumi_sort::InMemoryChunk<TemplateKey> {
+    fgumi_sort::InMemoryChunk::from_owned_records(
+        records.into_iter().map(|(k, r)| (k, r.as_ref().to_vec())).collect(),
+    )
+}
+
+/// A `CompressSpill` over a single temp dir with an always-ample free-space
+/// probe (deterministic, no dependency on the host's real free space), plus the
+/// `TempDir` guard that must outlive the opened spill slots.
+fn make_step(codec: SpillCodec, compression: u32) -> (CompressSpill, TempDir) {
+    let dir = TempDir::new().expect("temp dir");
+    let alloc =
+        TmpDirAllocator::with_probe(vec![dir.path().to_path_buf()], Box::new(|_| Ok(u64::MAX)), 0)
+            .expect("allocator builds");
+    // The test holds `dir` alive itself, so the step's RAII set is empty.
+    let step = CompressSpill::new(
+        Arc::new(Mutex::new(alloc)),
+        codec,
+        compression,
+        8 * 1024 * 1024,
+        Arc::new(Vec::new()),
+    );
+    (step, dir)
+}
+
+/// A `Spill` event compresses the chunk to disk, opens a slot whose `file_id`
+/// equals the logical `seq` (not write order), and writes bytes byte-identical
+/// to a direct `write_sorted_chunk` of the same records — for every sort-key
+/// variant the dispatch handles.
+#[rstest]
+#[case::coordinate(SpillVariant::Coordinate, 5, 1234)]
+#[case::template(SpillVariant::Template, 2, 300)]
+fn spill_event_writes_chunk_with_seq_file_id_byte_identical(
+    #[case] variant: SpillVariant,
+    #[case] seq: u32,
+    #[case] records_ingested: u64,
+) {
+    let (step, dir) = make_step(SpillCodec::Zstd, 3);
+
+    // Write an independent reference from the same (deterministic) records, then
+    // move those records into the event chunk — borrow-then-move avoids cloning
+    // the chunk (`MemoryChunkErased` is deliberately not `Clone`).
+    let reference = dir.path().join("reference.keyed");
+    let chunk = match variant {
+        SpillVariant::Coordinate => {
+            let recs = coord_records(500);
+            fgumi_sort::write_sorted_chunk(&reference, SpillCodec::Zstd, 3, &recs).unwrap();
+            MemoryChunkErased::Coordinate(coord_chunk(recs))
+        }
+        SpillVariant::Template => {
+            let recs = template_records(300);
+            fgumi_sort::write_sorted_chunk(&reference, SpillCodec::Zstd, 3, &recs).unwrap();
+            MemoryChunkErased::TemplateCoordinate(fgumi_sort::TemplateMemChunk::K40(
+                template_chunk(recs),
+            ))
+        }
+    };
+
+    let event = SortChunkEvent::Spill { seq, chunk, records_ingested_so_far: records_ingested };
+    let forwarded = step.compress_event(event).expect("compress Spill event");
+
+    let SortPhase1Event::SpillReady { slot, path, records_ingested_so_far } = forwarded else {
+        panic!("Spill must forward as SpillReady");
+    };
+    assert_eq!(records_ingested_so_far, records_ingested, "records_ingested must be propagated");
+    assert_eq!(slot.file_id, seq, "slot file_id must equal the logical spill seq");
+    assert_eq!(slot.codec, SpillCodec::Zstd, "codec must be detected from the written magic");
+    assert!(path.exists(), "spill file must exist");
+    assert!(path.starts_with(dir.path()), "spill file must live under the allocated temp dir");
+    assert!(
+        path.file_name().unwrap().to_str().unwrap().contains(&format!("{seq:04}")),
+        "spill file should be named by its seq"
+    );
+
+    // Byte-identical to a direct write of the same records (the step must add no
+    // framing of its own — it delegates straight to write_sorted_chunk).
+    assert_eq!(
+        std::fs::read(&path).unwrap(),
+        std::fs::read(&reference).unwrap(),
+        "CompressSpill output must match write_sorted_chunk byte-for-byte"
+    );
+}
+
+/// Distinct `seq` values yield distinct slots/paths, so concurrent workers never
+/// collide and the merge can tie-break by `file_id`.
+#[test]
+fn distinct_seqs_yield_distinct_file_ids_and_paths() {
+    let (step, _dir) = make_step(SpillCodec::Bgzf, 1);
+    let mut paths = Vec::new();
+    for seq in [0u32, 1, 7, 42] {
+        let event = SortChunkEvent::Spill {
+            seq,
+            chunk: MemoryChunkErased::Coordinate(coord_chunk(coord_records(50))),
+            records_ingested_so_far: u64::from(seq),
+        };
+        let SortPhase1Event::SpillReady { slot, path, .. } =
+            step.compress_event(event).expect("compress")
+        else {
+            panic!("expected SpillReady");
+        };
+        assert_eq!(slot.file_id, seq);
+        paths.push(path);
+    }
+    let unique: std::collections::HashSet<_> = paths.iter().collect();
+    assert_eq!(unique.len(), paths.len(), "every spill path must be unique");
+}
+
+/// A `Residual` event passes through as a `MemoryChunk` wrapping a uniquely-owned
+/// `Arc` (the invariant `SortMerge`'s `Arc::try_unwrap` relies on).
+#[test]
+fn residual_event_passes_through_as_unique_memory_chunk() {
+    let (step, _dir) = make_step(SpillCodec::Zstd, 3);
+    let records = coord_records(120);
+
+    let event = SortChunkEvent::Residual {
+        chunk: MemoryChunkErased::Coordinate(coord_chunk(records)),
+        records_ingested_so_far: 99,
+    };
+    let forwarded = step.compress_event(event).expect("compress Residual event");
+
+    let SortPhase1Event::MemoryChunk { chunk, records_ingested_so_far } = forwarded else {
+        panic!("Residual must forward as MemoryChunk");
+    };
+    assert_eq!(records_ingested_so_far, 99);
+    let inner = Arc::try_unwrap(chunk).unwrap_or_else(|_| {
+        panic!("MemoryChunk Arc must be uniquely owned (SortMerge unwraps it)")
+    });
+    assert_eq!(inner.len(), 120, "residual chunk content must pass through intact");
+}
+
+/// `AllAnnounced` forwards verbatim — the counts `SortBuffer` computed are the
+/// completion target `SortMerge` keys off of.
+#[test]
+fn all_announced_passes_through_verbatim() {
+    let (step, _dir) = make_step(SpillCodec::Zstd, 3);
+    let event =
+        SortChunkEvent::AllAnnounced { slot_count: 4, memory_chunk_count: 1, total_records: 5000 };
+    let forwarded = step.compress_event(event).expect("compress AllAnnounced");
+    let SortPhase1Event::AllAnnounced { slot_count, memory_chunk_count, total_records } = forwarded
+    else {
+        panic!("AllAnnounced must forward as AllAnnounced");
+    };
+    assert_eq!((slot_count, memory_chunk_count, total_records), (4, 1, 5000));
+}
+
+/// Multiple cloned workers (the `new_worker_copy` fan-out) sharing one
+/// allocator can compress spill chunks concurrently: every file is unique,
+/// carries the right `file_id`, and is byte-identical to an independent
+/// reference write — i.e. the shared `Mutex<TmpDirAllocator>` is the only
+/// cross-worker state and it serializes cleanly.
+#[test]
+fn parallel_workers_share_allocator_without_collision() {
+    let (base, dir) = make_step(SpillCodec::Zstd, 3);
+    let total_seqs: u32 = 64;
+    let num_workers = 8;
+
+    // Each worker gets its own clone (fresh `held`), all sharing `base`'s
+    // allocator Arc — exactly how the framework materializes Parallel workers.
+    let results = std::thread::scope(|scope| {
+        let handles: Vec<_> = (0..num_workers)
+            .map(|w| {
+                let worker = base.clone();
+                scope.spawn(move || {
+                    let mut produced = Vec::new();
+                    let mut seq = w;
+                    while seq < total_seqs {
+                        let records = coord_records_for(seq);
+                        let event = SortChunkEvent::Spill {
+                            seq,
+                            chunk: MemoryChunkErased::Coordinate(coord_chunk(records)),
+                            records_ingested_so_far: u64::from(seq),
+                        };
+                        let SortPhase1Event::SpillReady { slot, path, .. } =
+                            worker.compress_event(event).expect("worker compress")
+                        else {
+                            panic!("expected SpillReady");
+                        };
+                        produced.push((seq, slot.file_id, path));
+                        seq += num_workers;
+                    }
+                    produced
+                })
+            })
+            .collect();
+        handles.into_iter().map(|h| h.join().expect("worker thread")).collect::<Vec<_>>()
+    });
+
+    let mut all: Vec<(u32, u32, std::path::PathBuf)> = results.into_iter().flatten().collect();
+    all.sort_by_key(|(seq, _, _)| *seq);
+
+    assert_eq!(all.len(), total_seqs as usize, "every seq must produce exactly one spill file");
+
+    let unique_paths: std::collections::HashSet<_> = all.iter().map(|(_, _, p)| p).collect();
+    assert_eq!(unique_paths.len(), all.len(), "no two workers may collide on a spill path");
+
+    for (seq, file_id, path) in &all {
+        assert_eq!(file_id, seq, "file_id must equal the logical seq, not write order");
+        // Independent reference write of this seq's deterministic records.
+        let reference = dir.path().join(format!("ref_{seq:04}.keyed"));
+        fgumi_sort::write_sorted_chunk(&reference, SpillCodec::Zstd, 3, &coord_records_for(*seq))
+            .unwrap();
+        assert_eq!(
+            std::fs::read(path).unwrap(),
+            std::fs::read(&reference).unwrap(),
+            "concurrently-written chunk {seq} must match its reference byte-for-byte"
+        );
+    }
+}
+
+/// An empty residual chunk is still a valid passthrough (zero-record fast path).
+#[test]
+fn empty_residual_passes_through() {
+    let (step, _dir) = make_step(SpillCodec::Zstd, 3);
+    let event = SortChunkEvent::Residual {
+        chunk: MemoryChunkErased::Coordinate(coord_chunk(Vec::new())),
+        records_ingested_so_far: 0,
+    };
+    let SortPhase1Event::MemoryChunk { chunk, .. } =
+        step.compress_event(event).expect("compress empty residual")
+    else {
+        panic!("expected MemoryChunk");
+    };
+    let inner =
+        Arc::try_unwrap(chunk).unwrap_or_else(|_| panic!("MemoryChunk Arc must be uniquely owned"));
+    assert!(inner.is_empty());
+}

--- a/crates/fgumi-pipeline-io/src/sort/merge.rs
+++ b/crates/fgumi-pipeline-io/src/sort/merge.rs
@@ -1,0 +1,1128 @@
+//! `SortMerge` — third step of the runall-sort three-step chain.
+
+use std::collections::HashMap;
+use std::io;
+use std::sync::Arc;
+
+use fgumi_sort::{
+    CbKey32, InMemoryChunk, MemorySources, MergeDriver, MergeDriverDyn, MergeStep,
+    QuerynameComparator, RawCoordinateKey, RawQuerynameKey, RawQuerynameLexKey, SortMergeSlot,
+    SortOrder, TemplateKey, TemplateKey24, TemplateMemChunk, TertKey32,
+};
+
+use crate::sort::protocol::{MemoryChunkErased, SortPhase2Event};
+use crate::types::{DecompressedBlock, RecordBatch, RecordBatchBuilder};
+use fgumi_pipeline_core::{
+    HeapSize, HeldRetry, Ordered, Unpushed,
+    held::HeldSlot,
+    outputs::OrderedBytesSingle,
+    queues::QueueSpec,
+    reorder::BranchOrdering,
+    step::{DetachedGroup, Step, StepCtx, StepKind, StepOutcome, StepProfile},
+};
+
+/// Default output batch size: 1024 records per emitted `RecordBatch`.
+pub const DEFAULT_TARGET_BATCH_COUNT: usize = 1024;
+
+/// Max output batches emitted per `try_run` invocation in `Merging`.
+const MAX_DRAIN_BATCHES_PER_LOCK: usize = 8;
+
+/// Initial reservation for an output-batch byte buffer, before any batch has
+/// been emitted to size the next one from. Kept modest on purpose: most batches
+/// fill on the record-count cap well below the output-queue byte budget, so
+/// reserving the full budget for every buffer chronically over-allocates (and
+/// inflates the byte-bounded queue's capacity-based accounting). Buffers grow
+/// on demand via `extend_from_slice`, so under-reserving only costs a few
+/// startup reallocations.
+const INITIAL_OUTPUT_BUFFER_BYTES: usize = 64 * 1024;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MergeOutput — the framing strategy the merge accumulates winners into.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The output-framing strategy `SortMerge` accumulates merged winner records
+/// into. The merge state machine, `LoserTree` driver, source ordering and
+/// tie-break are identical for every strategy; only the per-record framing and
+/// the emitted item type differ.
+///
+/// Two implementations exist:
+///
+/// - [`RecordBatchOutput`] (the default) — accumulates raw record bodies into a
+///   [`RecordBatch`] (flat backing buffer + per-record `(start, end)` ranges).
+///   This is the **intermediate** sort output, consumed by `DecodeFromRecords`
+///   downstream in a fused `--start-from sort` chain.
+/// - [`BlockOutput`] — frames each record as `[u32 LE block_size][body]`
+///   directly into a [`DecompressedBlock`], byte-for-byte identical to the
+///   `SerializeRecordBatch` step it replaces (lever 1). This is the
+///   **terminal** standalone-sort output, wired straight to `BgzfCompress`,
+///   folding the former `SortMerge → SerializeRecordBatch → BgzfCompress`
+///   triple into `SortMerge → BgzfCompress` (one fewer pool step, one fewer
+///   reorder stage, one fewer memcpy per record).
+pub trait MergeOutput: Send + 'static {
+    /// The emitted batch item type.
+    type Item: Send + HeapSize + Ordered + 'static;
+    /// The per-batch accumulator.
+    type Builder: MergeBatchBuilder<Item = Self::Item>;
+}
+
+/// A per-batch accumulator for a [`MergeOutput`] strategy. Mirrors the
+/// [`RecordBatchBuilder`] surface the merge loop already drives, so the merge
+/// state machine is strategy-agnostic.
+pub trait MergeBatchBuilder: Send + 'static {
+    /// The finalized batch item this builder produces.
+    type Item;
+
+    /// Create a builder for batch `batch_serial`, reserving `bytes_cap` bytes of
+    /// payload and room for `records_cap` records.
+    fn with_capacity(batch_serial: u64, bytes_cap: usize, records_cap: usize) -> Self;
+
+    /// Append one merged winner record's raw BAM body.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the record cannot be framed (e.g. a body whose
+    /// length does not fit the strategy's length prefix).
+    fn push_record_bytes(&mut self, body: &[u8]) -> io::Result<()>;
+
+    /// Number of records appended so far.
+    fn len(&self) -> usize;
+
+    /// `true` iff no records have been appended.
+    fn is_empty(&self) -> bool;
+
+    /// Total payload bytes accumulated so far (used to size the next buffer and
+    /// to enforce the per-batch byte cap).
+    fn total_bytes(&self) -> usize;
+
+    /// Finalize and produce the batch item, consuming the builder.
+    fn build(self) -> Self::Item;
+}
+
+/// Intermediate-sort output: raw record bodies into a [`RecordBatch`].
+pub struct RecordBatchOutput;
+
+impl MergeOutput for RecordBatchOutput {
+    type Item = RecordBatch;
+    type Builder = RecordBatchBuilder;
+}
+
+impl MergeBatchBuilder for RecordBatchBuilder {
+    type Item = RecordBatch;
+
+    fn with_capacity(batch_serial: u64, bytes_cap: usize, records_cap: usize) -> Self {
+        RecordBatchBuilder::with_capacity(batch_serial, bytes_cap, records_cap)
+    }
+
+    fn push_record_bytes(&mut self, body: &[u8]) -> io::Result<()> {
+        RecordBatchBuilder::push_record_bytes(self, body);
+        Ok(())
+    }
+
+    fn len(&self) -> usize {
+        RecordBatchBuilder::len(self)
+    }
+
+    fn is_empty(&self) -> bool {
+        RecordBatchBuilder::is_empty(self)
+    }
+
+    fn total_bytes(&self) -> usize {
+        RecordBatchBuilder::total_bytes(self)
+    }
+
+    fn build(self) -> RecordBatch {
+        RecordBatchBuilder::build(self)
+    }
+}
+
+/// Terminal standalone-sort output: each record framed as
+/// `[u32 LE block_size][body]` directly into a [`DecompressedBlock`], ready for
+/// `BgzfCompress`. This is byte-for-byte identical to the framing the former
+/// `SerializeRecordBatch` step produced (lever 1).
+pub struct BlockOutput;
+
+impl MergeOutput for BlockOutput {
+    type Item = DecompressedBlock;
+    type Builder = BlockBuilder;
+}
+
+/// Accumulates merged winner records as BAM on-disk framing
+/// (`[u32 LE block_size][body]` per record) into a single byte buffer that
+/// becomes a [`DecompressedBlock`]. This is the canonical BAM record layout;
+/// the `fgumi` crate's `serialize::frame_record_into` is the sibling
+/// implementation (a separate crate, so the two cannot share code) and the two
+/// MUST stay byte-for-byte in sync — each has a layout test pinning it.
+pub struct BlockBuilder {
+    batch_serial: u64,
+    bytes: Vec<u8>,
+    /// Record count — tracked separately because the framed byte buffer mixes
+    /// length prefixes with bodies, so it cannot be recovered from `bytes`.
+    records: usize,
+}
+
+impl MergeBatchBuilder for BlockBuilder {
+    type Item = DecompressedBlock;
+
+    fn with_capacity(batch_serial: u64, bytes_cap: usize, _records_cap: usize) -> Self {
+        // `_records_cap` sizes the `RecordBatch` ranges vector; the framed-block
+        // builder has no separate per-record allocation to reserve.
+        Self { batch_serial, bytes: Vec::with_capacity(bytes_cap), records: 0 }
+    }
+
+    fn push_record_bytes(&mut self, body: &[u8]) -> io::Result<()> {
+        // `[u32 LE block_size][body]`, byte-identical to
+        // `SerializeRecordBatch::frame_record_into`.
+        let block_size = u32::try_from(body.len()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("record exceeds u32 BAM block_size: {}", body.len()),
+            )
+        })?;
+        self.bytes.extend_from_slice(&block_size.to_le_bytes());
+        self.bytes.extend_from_slice(body);
+        self.records += 1;
+        Ok(())
+    }
+
+    fn len(&self) -> usize {
+        self.records
+    }
+
+    fn is_empty(&self) -> bool {
+        self.records == 0
+    }
+
+    fn total_bytes(&self) -> usize {
+        self.bytes.len()
+    }
+
+    fn build(self) -> DecompressedBlock {
+        DecompressedBlock { batch_serial: self.batch_serial, bytes: self.bytes }
+    }
+}
+
+/// Same-variant collector for template-coordinate residual chunks.
+///
+/// A single sort chooses its `--key-types` narrowed lane variant exactly once
+/// (globally, on the first record) and reuses it for every run, so all template
+/// chunks in one merge share one arm. The first push fixes the arm; subsequent
+/// pushes assert-match it (a variant change mid-sort is impossible by
+/// construction and would be a bug).
+#[derive(Default)]
+enum TemplateChunks {
+    /// No template chunks pushed yet — the variant is not yet known.
+    #[default]
+    Empty,
+    /// 24-byte core-only lane.
+    K24(Vec<InMemoryChunk<TemplateKey24>>),
+    /// 32-byte lane carrying `cb_hash`.
+    Cb32(Vec<InMemoryChunk<CbKey32>>),
+    /// 32-byte lane carrying the tertiary word.
+    Tert32(Vec<InMemoryChunk<TertKey32>>),
+    /// Full 40-byte key (all lanes) — the legacy owned path and full variant.
+    K40(Vec<InMemoryChunk<TemplateKey>>),
+}
+
+impl TemplateChunks {
+    /// Name the narrowed-lane variant for diagnostics.
+    fn variant_name(&self) -> &'static str {
+        match self {
+            Self::Empty => "empty",
+            Self::K24(_) => "K24",
+            Self::Cb32(_) => "Cb32",
+            Self::Tert32(_) => "Tert32",
+            Self::K40(_) => "K40",
+        }
+    }
+
+    /// Accumulate one template chunk, which must keep the lane variant fixed.
+    ///
+    /// The `--key-types` narrowed-lane variant is chosen once per sort and is
+    /// global to the run, so every template chunk reaching the merge must carry
+    /// the same one. A variant change means the phase-1 producer and the merge
+    /// consumer disagree about the key width, and merging on would compare keys
+    /// of different layouts and emit silently mis-ordered output.
+    ///
+    /// # Errors
+    ///
+    /// Returns `InvalidData` if `chunk`'s variant differs from the accumulated
+    /// one. This is the same fail-closed treatment the sibling protocol
+    /// violations get (`ensure_single_lane`, `build_driver`) rather than a
+    /// panic, so a corrupt stream aborts the sort with a diagnosable error.
+    fn push(&mut self, chunk: TemplateMemChunk) -> io::Result<()> {
+        /// Build the mismatch error, naming both variants.
+        fn mismatch(found: &str, have: &str) -> io::Error {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "SortMerge: template chunk variant changed mid-sort \
+                     (accumulated {have}, got {found}); the --key-types lane \
+                     variant is global to a sort and must not change"
+                ),
+            )
+        }
+        match chunk {
+            TemplateMemChunk::K24(c) => match self {
+                Self::Empty => *self = Self::K24(vec![c]),
+                Self::K24(v) => v.push(c),
+                other => return Err(mismatch("K24", other.variant_name())),
+            },
+            TemplateMemChunk::Cb32(c) => match self {
+                Self::Empty => *self = Self::Cb32(vec![c]),
+                Self::Cb32(v) => v.push(c),
+                other => return Err(mismatch("Cb32", other.variant_name())),
+            },
+            TemplateMemChunk::Tert32(c) => match self {
+                Self::Empty => *self = Self::Tert32(vec![c]),
+                Self::Tert32(v) => v.push(c),
+                other => return Err(mismatch("Tert32", other.variant_name())),
+            },
+            TemplateMemChunk::K40(c) => match self {
+                Self::Empty => *self = Self::K40(vec![c]),
+                Self::K40(v) => v.push(c),
+                other => return Err(mismatch("K40", other.variant_name())),
+            },
+        }
+        Ok(())
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Empty => 0,
+            Self::K24(v) => v.len(),
+            Self::Cb32(v) => v.len(),
+            Self::Tert32(v) => v.len(),
+            Self::K40(v) => v.len(),
+        }
+    }
+
+    /// Pop the sole chunk (caller guarantees exactly one) and re-erase it.
+    fn pop_single(self) -> TemplateMemChunk {
+        match self {
+            Self::K24(mut v) => TemplateMemChunk::K24(v.pop().expect("one chunk")),
+            Self::Cb32(mut v) => TemplateMemChunk::Cb32(v.pop().expect("one chunk")),
+            Self::Tert32(mut v) => TemplateMemChunk::Tert32(v.pop().expect("one chunk")),
+            Self::K40(mut v) => TemplateMemChunk::K40(v.pop().expect("one chunk")),
+            Self::Empty => unreachable!("pop_single called with no chunk"),
+        }
+    }
+}
+
+#[derive(Default)]
+struct MemoryChunksByKind {
+    coordinate: Vec<InMemoryChunk<RawCoordinateKey>>,
+    queryname_lex: Vec<InMemoryChunk<RawQuerynameLexKey>>,
+    queryname_natural: Vec<InMemoryChunk<RawQuerynameKey>>,
+    template_coordinate: TemplateChunks,
+}
+
+impl MemoryChunksByKind {
+    /// Accumulate one erased chunk into its per-order bucket.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the template lane-variant mismatch from
+    /// [`TemplateChunks::push`]; the other orders are infallible.
+    fn push(&mut self, chunk: MemoryChunkErased) -> io::Result<()> {
+        match chunk {
+            MemoryChunkErased::Coordinate(v) => self.coordinate.push(v),
+            MemoryChunkErased::QuerynameLex(v) => self.queryname_lex.push(v),
+            MemoryChunkErased::QuerynameNatural(v) => self.queryname_natural.push(v),
+            MemoryChunkErased::TemplateCoordinate(v) => {
+                return self.template_coordinate.push(v);
+            }
+        }
+        Ok(())
+    }
+
+    fn total_len(&self) -> usize {
+        self.coordinate.len()
+            + self.queryname_lex.len()
+            + self.queryname_natural.len()
+            + self.template_coordinate.len()
+    }
+
+    /// Fail closed if any lane other than the one `sort_order` selects holds a
+    /// chunk. `build_driver` (and the single-chunk fast path) consume only the
+    /// selected lane, so a chunk in another lane — a Phase-2 protocol violation
+    /// emitting the wrong `MemoryChunkErased` variant — would be silently dropped
+    /// even though `total_len()` counted it toward setup completion. Reject it
+    /// rather than merge a partial result.
+    fn ensure_single_lane(&self, sort_order: SortOrder) -> io::Result<()> {
+        let selected_len = match sort_order {
+            SortOrder::Coordinate => self.coordinate.len(),
+            SortOrder::Queryname(QuerynameComparator::Lexicographic) => self.queryname_lex.len(),
+            SortOrder::Queryname(QuerynameComparator::Natural) => self.queryname_natural.len(),
+            SortOrder::TemplateCoordinate => self.template_coordinate.len(),
+        };
+        let stray = self.total_len() - selected_len;
+        if stray > 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "SortMerge: {stray} residual memory chunk(s) in a lane not matching the \
+                     {sort_order:?} sort order — Phase-2 emitted a mismatched MemoryChunkErased \
+                     variant; failing closed rather than silently dropping records",
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Consume the single chunk held across all kinds, re-erased.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `total_len() != 1` (the single-source fast path's precondition).
+    fn into_single(mut self) -> MemoryChunkErased {
+        debug_assert_eq!(self.total_len(), 1, "into_single requires exactly one chunk");
+        if let Some(c) = self.coordinate.pop() {
+            MemoryChunkErased::Coordinate(c)
+        } else if let Some(c) = self.queryname_lex.pop() {
+            MemoryChunkErased::QuerynameLex(c)
+        } else if let Some(c) = self.queryname_natural.pop() {
+            MemoryChunkErased::QuerynameNatural(c)
+        } else if self.template_coordinate.len() == 1 {
+            MemoryChunkErased::TemplateCoordinate(
+                std::mem::take(&mut self.template_coordinate).pop_single(),
+            )
+        } else {
+            unreachable!("into_single called with no chunk")
+        }
+    }
+}
+
+fn build_driver(
+    sort_order: SortOrder,
+    slots: Vec<Arc<SortMergeSlot>>,
+    chunks: MemoryChunksByKind,
+    total_records: u64,
+) -> io::Result<Box<dyn MergeDriverDyn + Send>> {
+    Ok(match sort_order {
+        SortOrder::Coordinate => Box::new(MergeDriver::<RawCoordinateKey>::from_slots(
+            slots,
+            MemorySources::Shared(chunks.coordinate),
+            total_records,
+        )),
+        SortOrder::Queryname(QuerynameComparator::Lexicographic) => {
+            Box::new(MergeDriver::<RawQuerynameLexKey>::from_slots(
+                slots,
+                MemorySources::Shared(chunks.queryname_lex),
+                total_records,
+            ))
+        }
+        SortOrder::Queryname(QuerynameComparator::Natural) => {
+            Box::new(MergeDriver::<RawQuerynameKey>::from_slots(
+                slots,
+                MemorySources::Shared(chunks.queryname_natural),
+                total_records,
+            ))
+        }
+        SortOrder::TemplateCoordinate => match chunks.template_coordinate {
+            // `Empty` means no residual chunk identified the `--key-types` lane.
+            // For valid input this only happens with empty input (no spill files
+            // either) — Phase-1's deferred seal always emits a variant-tagged
+            // residual otherwise. So `Empty` WITH spill slots can only arise from
+            // the documented "defensive/unreachable" no-residual finalize branch
+            // (a seal-logic regression). Defaulting to `TemplateKey` (K40) there
+            // would decode narrow (K24/Cb32/Tert32) spill files at the wrong key
+            // width and silently corrupt output, so fail closed instead of
+            // guessing the width. With no slots, any K is safe (nothing to merge).
+            TemplateChunks::Empty => {
+                if !slots.is_empty() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "SortMerge: template-coordinate spill slots present but no residual \
+                         chunk to identify the key-types lane — refusing to guess the key \
+                         width (would mis-decode narrow spill files). This indicates a \
+                         Phase-1 seal-logic regression.",
+                    ));
+                }
+                Box::new(MergeDriver::<TemplateKey>::from_slots(
+                    slots,
+                    MemorySources::Shared(Vec::new()),
+                    total_records,
+                ))
+            }
+            TemplateChunks::K24(v) => Box::new(MergeDriver::<TemplateKey24>::from_slots(
+                slots,
+                MemorySources::Shared(v),
+                total_records,
+            )),
+            TemplateChunks::Cb32(v) => Box::new(MergeDriver::<CbKey32>::from_slots(
+                slots,
+                MemorySources::Shared(v),
+                total_records,
+            )),
+            TemplateChunks::Tert32(v) => Box::new(MergeDriver::<TertKey32>::from_slots(
+                slots,
+                MemorySources::Shared(v),
+                total_records,
+            )),
+            TemplateChunks::K40(v) => Box::new(MergeDriver::<TemplateKey>::from_slots(
+                slots,
+                MemorySources::Shared(v),
+                total_records,
+            )),
+        },
+    })
+}
+
+enum NextBatch<I> {
+    Batch(I),
+    Stalled(Option<I>),
+    Done(Option<I>, u64),
+}
+
+enum SortMergeState<B> {
+    WaitingForSetup {
+        slots: Vec<Arc<SortMergeSlot>>,
+        slot_index: HashMap<u32, usize>,
+        memory_chunks: MemoryChunksByKind,
+        total_records: u64,
+        expected_slot_count: Option<u32>,
+        expected_memory_chunk_count: Option<u32>,
+    },
+    Merging {
+        driver: Box<dyn MergeDriverDyn + Send>,
+        builder: B,
+        next_ordinal: u64,
+    },
+    /// Single-source fast path: 0 spill slots and exactly one in-memory chunk, so
+    /// the chunk is already globally sorted and no k-way merge is needed. Gather
+    /// its records in order straight into output blocks (the dominant in-memory
+    /// cost — a single-threaded k = 1 loser-tree walk — is pure overhead here).
+    FastPath {
+        chunk: MemoryChunkErased,
+        /// Index of the next record to gather.
+        cursor: usize,
+        /// Total record count (`chunk.len()`), cached to avoid re-dispatching.
+        total: usize,
+        builder: B,
+        next_ordinal: u64,
+    },
+    Done,
+}
+
+fn absorb_phase2_event(
+    event: SortPhase2Event,
+    slots: &mut Vec<Arc<SortMergeSlot>>,
+    slot_index: &mut HashMap<u32, usize>,
+    memory_chunks: &mut MemoryChunksByKind,
+    total_records: &mut u64,
+    expected_slot_count: &mut Option<u32>,
+    expected_memory_chunk_count: &mut Option<u32>,
+) -> io::Result<()> {
+    match event {
+        SortPhase2Event::SpillReady { slot, path: _, records_ingested_so_far } => {
+            if let std::collections::hash_map::Entry::Vacant(e) = slot_index.entry(slot.file_id) {
+                e.insert(slots.len());
+                slots.push(slot);
+            }
+            *total_records = (*total_records).max(records_ingested_so_far);
+        }
+        SortPhase2Event::MemoryChunk { chunk, records_ingested_so_far } => {
+            // The MemoryChunk `Arc` is created uniquely in the Phase-1 producer
+            // (`CompressSpill` / `SpillWrite`) and only ever *moved* (never cloned)
+            // through `SortSpillDecompress` to here, so
+            // it must be uniquely owned at this single consumer. Fail closed on a
+            // shared `Arc` rather than silently deep-cloning a potentially large
+            // record vector on the merge setup path.
+            let inner = Arc::try_unwrap(chunk).map_err(|_| {
+                io::Error::other(
+                    "SortMerge: MemoryChunk Arc unexpectedly shared at the merge consumer \
+                     (protocol invariant: memory chunks are moved, never cloned)",
+                )
+            })?;
+            memory_chunks.push(inner)?;
+            *total_records = (*total_records).max(records_ingested_so_far);
+        }
+        SortPhase2Event::AllAnnounced {
+            slot_count,
+            memory_chunk_count,
+            total_records: ar_total,
+        } => {
+            // The Phase-2 protocol emits exactly one `AllAnnounced` (the last event
+            // from the Phase-1 producer, `CompressSpill` / `SpillWrite`). A second
+            // one is a protocol violation; fail
+            // closed rather than overwrite the prior expectations and risk masking
+            // the bug behind a silently-different completion target.
+            if expected_slot_count.is_some() || expected_memory_chunk_count.is_some() {
+                return Err(io::Error::other(format!(
+                    "SortMerge: duplicate AllAnnounced — prior {expected_slot_count:?}/\
+                     {expected_memory_chunk_count:?}, new {slot_count}/{memory_chunk_count}; \
+                     the Phase-2 protocol emits exactly one AllAnnounced",
+                )));
+            }
+            *expected_slot_count = Some(slot_count);
+            *expected_memory_chunk_count = Some(memory_chunk_count);
+            *total_records = (*total_records).max(ar_total);
+        }
+    }
+    Ok(())
+}
+
+fn slot_set_complete(
+    slots_len: usize,
+    memory_chunks_total_len: usize,
+    expected_slot_count: Option<u32>,
+    expected_memory_chunk_count: Option<u32>,
+) -> bool {
+    matches!(
+        (expected_slot_count, expected_memory_chunk_count),
+        (Some(want_slots), Some(want_chunks))
+            if u32::try_from(slots_len).unwrap_or(u32::MAX) == want_slots
+                && u32::try_from(memory_chunks_total_len).unwrap_or(u32::MAX) == want_chunks
+    )
+}
+
+/// `Detached + ByItemOrdinal` terminal merge: the final of the three sort
+/// steps, producing the sorted output stream consumed by the sink.
+///
+/// Generic over the output-framing strategy `O` (see [`MergeOutput`]):
+/// [`RecordBatchOutput`] (the default) emits [`RecordBatch`] for a fused
+/// intermediate sort, and [`BlockOutput`] frames records directly into
+/// [`DecompressedBlock`]s for the standalone-sort terminal so the chain can
+/// wire `SortMerge → BgzfCompress` with no intervening serialize step
+/// (lever 1). The merge core — `LoserTree` driver, source ordering, tie-break,
+/// cooperative `try_run` body — is identical for both.
+pub struct SortMerge<O: MergeOutput = RecordBatchOutput> {
+    state: SortMergeState<O::Builder>,
+    held: HeldSlot<Unpushed<O::Item>>,
+    sort_order: SortOrder,
+    target_batch_count: usize,
+    output_byte_limit: u64,
+    /// Optional sink for the end-of-run sort summary, filled when the merge
+    /// reaches `Done`. The standalone-sort summary finalize hook reads it to
+    /// log records processed/written and the spill-chunk count.
+    stats_slot: Option<Arc<parking_lot::Mutex<Option<fgumi_sort::SortStats>>>>,
+    /// Total records ingested, captured at the merge transition (the summary's
+    /// "records processed").
+    processed: u64,
+    /// Number of spill files, captured at the merge transition (the summary's
+    /// "temporary chunks"). Zero for a fully in-memory sort.
+    chunk_count: usize,
+    /// INSTRUMENTATION (lever-2 merge-stall diagnosis; `RUST_LOG=info` at Done).
+    /// `SortMerge` runs on a single dedicated `Detached` thread (one instance,
+    /// never `new_worker_copy`'d), so plain `&mut self` counters are sound — no
+    /// atomics needed.
+    dbg: MergeDiag,
+}
+
+/// Lever-2 diagnostic counters: is the serial merge starved on decompress
+/// (`input-empty`/`stalls`) or blocked on the downstream writer
+/// (`output_full`), and how much does its worker spin (`contention`)?
+#[derive(Default, Clone, Copy)]
+struct MergeDiag {
+    /// Merge-loop passes that ended `Stalled` — the winning source's next block
+    /// was not yet decompressed (INPUT-STARVED: the lever-2 hypothesis).
+    stalls: u64,
+    /// `ctx.outputs.push` returned `Err` — downstream (compress/write) full
+    /// (OUTPUT-BACKPRESSURE).
+    output_full: u64,
+    /// `try_run` returned `Contention` — the merge worker had nothing to do this
+    /// dispatch and spun/yielded (pure under-utilization).
+    contention: u64,
+    /// `try_run` calls that delivered ≥1 batch (PROGRESS dispatches).
+    progress_dispatches: u64,
+}
+
+impl<O: MergeOutput> SortMerge<O> {
+    /// Build a `SortMerge` step with default batch size.
+    #[must_use]
+    pub fn new(sort_order: SortOrder, output_byte_limit: u64) -> Self {
+        Self::with_target_batch_count(sort_order, output_byte_limit, DEFAULT_TARGET_BATCH_COUNT)
+    }
+
+    /// Build a `SortMerge` step with a custom output batch size.
+    #[must_use]
+    pub fn with_target_batch_count(
+        sort_order: SortOrder,
+        output_byte_limit: u64,
+        target_batch_count: usize,
+    ) -> Self {
+        Self {
+            state: SortMergeState::WaitingForSetup {
+                slots: Vec::new(),
+                slot_index: HashMap::new(),
+                memory_chunks: MemoryChunksByKind::default(),
+                total_records: 0,
+                expected_slot_count: None,
+                expected_memory_chunk_count: None,
+            },
+            held: HeldSlot::new(),
+            sort_order,
+            target_batch_count: target_batch_count.max(1),
+            output_byte_limit,
+            stats_slot: None,
+            processed: 0,
+            chunk_count: 0,
+            dbg: MergeDiag::default(),
+        }
+    }
+
+    /// Attach a slot to receive the end-of-run [`fgumi_sort::SortStats`] when
+    /// the merge completes (records processed/written + spill-chunk count). Used
+    /// by the standalone-sort summary finalize hook; runall leaves it unset.
+    #[must_use]
+    pub fn with_stats_slot(
+        mut self,
+        slot: Arc<parking_lot::Mutex<Option<fgumi_sort::SortStats>>>,
+    ) -> Self {
+        self.stats_slot = Some(slot);
+        self
+    }
+
+    fn flush_held(&mut self, ctx: &mut StepCtx<'_, Self>) -> bool {
+        // `true` once the slot is clear (was empty, or the held event flushed);
+        // `false` while it's still held under backpressure. Uses the canonical
+        // re-hold helper so the put-back-on-reject invariant lives in one place.
+        !matches!(ctx.outputs.retry_held(&mut self.held), HeldRetry::StillHeld)
+    }
+
+    /// Drains every currently-available input event into the setup state and
+    /// returns the number absorbed. The drain is intentionally unbounded — the
+    /// upstream queue is byte-bounded, so memory is gated on the producer side.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self.state` is not `WaitingForSetup`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on a Phase-2 protocol violation (a duplicate
+    /// `AllAnnounced`, or a `MemoryChunk` whose `Arc` is unexpectedly shared).
+    fn absorb_events_into_setup(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<usize> {
+        let SortMergeState::WaitingForSetup {
+            slots,
+            slot_index,
+            memory_chunks,
+            total_records,
+            expected_slot_count,
+            expected_memory_chunk_count,
+        } = &mut self.state
+        else {
+            unreachable!("absorb_events_into_setup called outside WaitingForSetup state");
+        };
+        let mut absorbed = 0usize;
+        while let Some(event) = ctx.input.pop() {
+            absorb_phase2_event(
+                event,
+                slots,
+                slot_index,
+                memory_chunks,
+                total_records,
+                expected_slot_count,
+                expected_memory_chunk_count,
+            )?;
+            absorbed += 1;
+        }
+        Ok(absorbed)
+    }
+
+    fn is_ready_to_merge(&self) -> bool {
+        let SortMergeState::WaitingForSetup {
+            slots,
+            memory_chunks,
+            expected_slot_count,
+            expected_memory_chunk_count,
+            ..
+        } = &self.state
+        else {
+            return false;
+        };
+        slot_set_complete(
+            slots.len(),
+            memory_chunks.total_len(),
+            *expected_slot_count,
+            *expected_memory_chunk_count,
+        )
+    }
+
+    /// # Panics
+    ///
+    /// Panics if `self.state` is not `Merging`.
+    fn next_batch(&mut self) -> io::Result<NextBatch<O::Item>> {
+        let target = self.target_batch_count;
+        let byte_limit = self.output_byte_limit;
+        let bytes_cap = usize::try_from(byte_limit).unwrap_or(usize::MAX);
+        let SortMergeState::Merging { driver, builder, next_ordinal } = &mut self.state else {
+            unreachable!("next_batch called outside Merging state");
+        };
+
+        let buffer_floor = INITIAL_OUTPUT_BUFFER_BYTES.min(bytes_cap);
+        let flush = |builder: &mut O::Builder, next_ordinal: &mut u64| {
+            *next_ordinal += 1;
+            // Size the next buffer to the batch we just filled, clamped to
+            // `[buffer_floor, bytes_cap]`. Count-bound batches stay small; a
+            // byte-bound batch carries ~`bytes_cap` forward. This avoids
+            // reserving the full byte budget for every (typically count-bound)
+            // batch — see `INITIAL_OUTPUT_BUFFER_BYTES`.
+            let hint = builder.total_bytes().clamp(buffer_floor, bytes_cap);
+            let next_builder = O::Builder::with_capacity(*next_ordinal, hint, target);
+            std::mem::replace(builder, next_builder).build()
+        };
+        let flush_partial = |builder: &mut O::Builder, next_ordinal: &mut u64| {
+            if builder.is_empty() { None } else { Some(flush(builder, next_ordinal)) }
+        };
+
+        loop {
+            match driver
+                .try_step()
+                .map_err(|e| io::Error::other(format!("SortMerge: merge step failed: {e:#}")))?
+            {
+                MergeStep::Produced(bytes) => {
+                    builder.push_record_bytes(bytes)?;
+                    let count_full = builder.len() >= target;
+                    let bytes_full = (builder.total_bytes() as u64) >= byte_limit;
+                    if count_full || bytes_full {
+                        return Ok(NextBatch::Batch(flush(builder, next_ordinal)));
+                    }
+                }
+                MergeStep::Stalled => {
+                    return Ok(NextBatch::Stalled(flush_partial(builder, next_ordinal)));
+                }
+                MergeStep::Done => {
+                    return Ok(NextBatch::Done(
+                        flush_partial(builder, next_ordinal),
+                        driver.records_merged(),
+                    ));
+                }
+            }
+        }
+    }
+
+    /// # Panics
+    ///
+    /// Panics if `self.state` is not `Merging`.
+    fn emit_batches_cooperative(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        let mut delivered = 0usize;
+        loop {
+            match self.next_batch()? {
+                NextBatch::Batch(batch) => {
+                    if let Err(unpushed) = ctx.outputs.push(batch) {
+                        self.dbg.output_full += 1;
+                        self.held.put(unpushed);
+                        return Ok(StepOutcome::Progress);
+                    }
+                    delivered += 1;
+                    if delivered >= MAX_DRAIN_BATCHES_PER_LOCK {
+                        self.dbg.progress_dispatches += 1;
+                        return Ok(StepOutcome::Progress);
+                    }
+                }
+                NextBatch::Stalled(partial) => {
+                    // INPUT-STARVED: the driver couldn't advance because the
+                    // winning source's next block isn't decompressed yet.
+                    self.dbg.stalls += 1;
+                    if let Some(batch) = partial {
+                        if let Err(unpushed) = ctx.outputs.push(batch) {
+                            self.dbg.output_full += 1;
+                            self.held.put(unpushed);
+                            return Ok(StepOutcome::Progress);
+                        }
+                        delivered += 1;
+                    }
+                    return Ok(if delivered > 0 {
+                        self.dbg.progress_dispatches += 1;
+                        StepOutcome::Progress
+                    } else {
+                        // Pure under-utilization: this dispatch did nothing.
+                        self.dbg.contention += 1;
+                        StepOutcome::Contention
+                    });
+                }
+                NextBatch::Done(partial, merged) => {
+                    if let Some(batch) = partial {
+                        if let Err(unpushed) = ctx.outputs.push(batch) {
+                            self.dbg.output_full += 1;
+                            self.held.put(unpushed);
+                            return Ok(StepOutcome::Progress);
+                        }
+                        delivered += 1;
+                    }
+                    log::info!("Sort merge complete: {merged} records merged");
+                    // INSTRUMENTATION (lever-2): is the serial merge starved on
+                    // decompress (stalls/contention high) or blocked on the
+                    // writer (output_full high)? `stalls` counts merge-loop
+                    // passes that ended input-starved; `contention` counts
+                    // dispatches that produced nothing (pure idle spin);
+                    // `output_full` counts downstream-backpressure events.
+                    let d = self.dbg;
+                    log::info!(
+                        "Sort merge diag: stalls={} contention={} output_full={} \
+                         progress_dispatches={} ({} records, {} sources)",
+                        d.stalls,
+                        d.contention,
+                        d.output_full,
+                        d.progress_dispatches,
+                        merged,
+                        self.chunk_count,
+                    );
+                    if let Some(slot) = &self.stats_slot {
+                        *slot.lock() = Some(fgumi_sort::SortStats {
+                            total_records: self.processed,
+                            output_records: merged,
+                            runs_written: self.chunk_count,
+                        });
+                    }
+                    self.state = SortMergeState::Done;
+                    return Ok(if delivered > 0 {
+                        StepOutcome::Progress
+                    } else {
+                        StepOutcome::NoProgress
+                    });
+                }
+            }
+        }
+    }
+
+    /// Build the next output batch for the single-source fast path: gather records
+    /// from the sorted chunk into the builder until the count/byte cap, or `Done`
+    /// when the chunk is exhausted. Mirrors [`next_batch`](Self::next_batch)'s
+    /// framing and buffer-sizing exactly, so the output is byte-identical to a
+    /// (k = 1) loser-tree merge of the same chunk — only the record SOURCE differs
+    /// (a direct cursor instead of `driver.try_step()`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self.state` is not `FastPath`.
+    fn next_fast_batch(&mut self) -> io::Result<NextBatch<O::Item>> {
+        let target = self.target_batch_count;
+        let byte_limit = self.output_byte_limit;
+        let bytes_cap = usize::try_from(byte_limit).unwrap_or(usize::MAX);
+        let buffer_floor = INITIAL_OUTPUT_BUFFER_BYTES.min(bytes_cap);
+        let SortMergeState::FastPath { chunk, cursor, total, builder, next_ordinal } =
+            &mut self.state
+        else {
+            unreachable!("next_fast_batch called outside FastPath state");
+        };
+
+        let flush = |builder: &mut O::Builder, next_ordinal: &mut u64| {
+            *next_ordinal += 1;
+            let hint = builder.total_bytes().clamp(buffer_floor, bytes_cap);
+            let next_builder = O::Builder::with_capacity(*next_ordinal, hint, target);
+            std::mem::replace(builder, next_builder).build()
+        };
+        let flush_partial = |builder: &mut O::Builder, next_ordinal: &mut u64| {
+            if builder.is_empty() { None } else { Some(flush(builder, next_ordinal)) }
+        };
+
+        loop {
+            if *cursor >= *total {
+                return Ok(NextBatch::Done(flush_partial(builder, next_ordinal), *total as u64));
+            }
+            builder.push_record_bytes(chunk.record_bytes(*cursor))?;
+            *cursor += 1;
+            let count_full = builder.len() >= target;
+            let bytes_full = (builder.total_bytes() as u64) >= byte_limit;
+            if count_full || bytes_full {
+                return Ok(NextBatch::Batch(flush(builder, next_ordinal)));
+            }
+        }
+    }
+
+    /// Cooperative emit loop for the single-source fast path. Mirrors
+    /// [`emit_batches_cooperative`](Self::emit_batches_cooperative) but never
+    /// `Stalled` (every record is already in memory).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self.state` is not `FastPath`.
+    fn emit_fast_batches(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        let mut delivered = 0usize;
+        loop {
+            match self.next_fast_batch()? {
+                NextBatch::Batch(batch) => {
+                    if let Err(unpushed) = ctx.outputs.push(batch) {
+                        self.dbg.output_full += 1;
+                        self.held.put(unpushed);
+                        return Ok(StepOutcome::Progress);
+                    }
+                    delivered += 1;
+                    if delivered >= MAX_DRAIN_BATCHES_PER_LOCK {
+                        self.dbg.progress_dispatches += 1;
+                        return Ok(StepOutcome::Progress);
+                    }
+                }
+                NextBatch::Stalled(_) => unreachable!("FastPath never stalls (all in memory)"),
+                NextBatch::Done(partial, count) => {
+                    if let Some(batch) = partial {
+                        if let Err(unpushed) = ctx.outputs.push(batch) {
+                            self.dbg.output_full += 1;
+                            self.held.put(unpushed);
+                            return Ok(StepOutcome::Progress);
+                        }
+                        delivered += 1;
+                    }
+                    log::info!(
+                        "Sort in-memory fast path complete: {count} records (single source, \
+                         no merge)"
+                    );
+                    if let Some(slot) = &self.stats_slot {
+                        *slot.lock() = Some(fgumi_sort::SortStats {
+                            total_records: self.processed,
+                            output_records: count,
+                            runs_written: 0,
+                        });
+                    }
+                    self.state = SortMergeState::Done;
+                    return Ok(if delivered > 0 {
+                        StepOutcome::Progress
+                    } else {
+                        StepOutcome::NoProgress
+                    });
+                }
+            }
+        }
+    }
+
+    fn transition_to_merging(&mut self) -> io::Result<()> {
+        if !matches!(&self.state, SortMergeState::WaitingForSetup { .. }) {
+            return Ok(());
+        }
+        let SortMergeState::WaitingForSetup {
+            mut slots,
+            slot_index: _,
+            memory_chunks,
+            total_records,
+            expected_slot_count: _,
+            expected_memory_chunk_count: _,
+        } = std::mem::replace(&mut self.state, SortMergeState::Done)
+        else {
+            unreachable!("just matched WaitingForSetup")
+        };
+        // Fail closed before consuming only the selected lane (fast path or
+        // build_driver): a chunk stranded in a non-selected lane would otherwise
+        // be dropped silently.
+        memory_chunks.ensure_single_lane(self.sort_order)?;
+        slots.sort_by_key(|s| s.file_id);
+        // Capture summary inputs before `slots` is consumed by the driver:
+        // total records ingested and the spill-file count.
+        self.processed = total_records;
+        self.chunk_count = slots.len();
+        let bytes_cap_for_init = usize::try_from(self.output_byte_limit).unwrap_or(usize::MAX);
+        let initial_bytes_for_init = INITIAL_OUTPUT_BUFFER_BYTES.min(bytes_cap_for_init);
+        // FAST PATH: zero spill slots + exactly one in-memory chunk → the chunk is
+        // already globally sorted, so skip the (k = 1) loser-tree merge and gather
+        // it directly. This is the in-memory regime's dominant cost.
+        if slots.is_empty() && memory_chunks.total_len() == 1 {
+            let chunk = memory_chunks.into_single();
+            let total = chunk.len();
+            let builder =
+                O::Builder::with_capacity(0, initial_bytes_for_init, self.target_batch_count);
+            self.state =
+                SortMergeState::FastPath { chunk, cursor: 0, total, builder, next_ordinal: 0 };
+            return Ok(());
+        }
+        let driver = build_driver(self.sort_order, slots, memory_chunks, total_records)?;
+        let bytes_cap = usize::try_from(self.output_byte_limit).unwrap_or(usize::MAX);
+        // Seed the first buffer modestly; subsequent buffers are sized from the
+        // prior batch's actual byte length (see `next_batch`).
+        let initial_bytes = INITIAL_OUTPUT_BUFFER_BYTES.min(bytes_cap);
+        let builder = O::Builder::with_capacity(0, initial_bytes, self.target_batch_count);
+        self.state = SortMergeState::Merging { driver, builder, next_ordinal: 0 };
+        Ok(())
+    }
+}
+
+impl<O: MergeOutput> Step for SortMerge<O> {
+    type Input = SortPhase2Event;
+    type Outputs = OrderedBytesSingle<O::Item>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "SortMerge",
+            // The merge runs off the work-stealing pool, on the sort's shared
+            // COORDINATION driver thread (N+2) — the same thread that ran the
+            // phase-1 admit/sort/frame steps, which have Finished and left the
+            // driver's live set by the time the phase-2 merge runs, so the merge
+            // effectively gets a dedicated thread in phase 2 (mirrors main's main
+            // thread). Its cooperative `try_run` body is UNCHANGED —
+            // `run_detached_driver` drives it with the same `run_worker_loop` the
+            // pool uses (Park backoff), parking on `Contention`/`NoProgress`
+            // (winner-slot momentarily empty / output full) instead of the pool
+            // re-dispatching it. `Detached` collapses the declared `ByItemOrdinal`
+            // output to `None` exactly as `Serial` would (see
+            // `effective_branch_orderings`), so the output transport — a direct
+            // byte-bounded queue, no reorder stage — is byte-for-byte identical;
+            // the LoserTree core, source order (`slots.sort_by_key(file_id)` +
+            // residual last), and tie-break are untouched. SortMerge is only ever
+            // built by the sort chain's `add_sort`, so this is sort-chain-only.
+            kind: StepKind::Detached,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn detached_group(&self) -> DetachedGroup {
+        // Co-located with the phase-1 coordination steps on ONE driver thread —
+        // phase 1 and phase 2 are temporally disjoint, so this is the true N+2.
+        DetachedGroup::Shared(crate::sort::SORT_COORD_GROUP)
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if !self.flush_held(ctx) {
+            return Ok(StepOutcome::Contention);
+        }
+
+        if matches!(&self.state, SortMergeState::WaitingForSetup { .. }) {
+            // Drain the input queue unbounded: the setup absorb is cheap (it just
+            // moves `Arc`s/`Vec`s into the setup state) and the upstream queue is
+            // already byte-bounded, so backpressure belongs on the producer, not
+            // on a consumer-side drain cap. A cap here would cycle a full upstream
+            // queue through repeated partial drains and add producer contention.
+            let absorbed = self.absorb_events_into_setup(ctx)?;
+            if !self.is_ready_to_merge() {
+                if absorbed > 0 {
+                    return Ok(StepOutcome::Progress);
+                }
+                if !ctx.input.is_drained() {
+                    return Ok(StepOutcome::NoProgress);
+                }
+                // Input is drained but setup never completed. Fail closed for any
+                // setup that saw payload or a (mismatched) `AllAnnounced`, so an
+                // incomplete setup can never silently merge a partial result. The
+                // only legitimate drained-but-not-ready case is a wholly empty
+                // input (no slots, no chunks, no announcement), which merges to an
+                // empty output.
+                let SortMergeState::WaitingForSetup {
+                    slots,
+                    memory_chunks,
+                    expected_slot_count,
+                    expected_memory_chunk_count,
+                    ..
+                } = &self.state
+                else {
+                    unreachable!("state matched WaitingForSetup above");
+                };
+                let saw_payload = !slots.is_empty() || memory_chunks.total_len() > 0;
+                let saw_expectations =
+                    expected_slot_count.is_some() || expected_memory_chunk_count.is_some();
+                if saw_payload || saw_expectations {
+                    return Err(io::Error::other(format!(
+                        "SortMerge: setup incomplete at input drain \
+                         (slots={}, chunks={}, expected_slots={expected_slot_count:?}, \
+                         expected_chunks={expected_memory_chunk_count:?})",
+                        slots.len(),
+                        memory_chunks.total_len(),
+                    )));
+                }
+            }
+            self.transition_to_merging()?;
+        }
+
+        match &self.state {
+            SortMergeState::Merging { .. } => self.emit_batches_cooperative(ctx),
+            SortMergeState::FastPath { .. } => self.emit_fast_batches(ctx),
+            SortMergeState::Done => Ok(StepOutcome::Finished),
+            SortMergeState::WaitingForSetup { .. } => {
+                unreachable!("Phase 1 must have left state non-WaitingForSetup")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fgumi-pipeline-io/src/sort/merge/tests.rs
+++ b/crates/fgumi-pipeline-io/src/sort/merge/tests.rs
@@ -1,0 +1,97 @@
+// End-to-end merge behavior is covered by the integration tests in sort/tests.rs;
+// the unit tests here pin the memory-lane fail-closed guard.
+
+use super::*;
+
+/// A residual chunk stranded in a lane that does not match the sort order must
+/// fail closed: `build_driver` and the single-chunk fast path consume only the
+/// selected lane, so such a chunk would otherwise be dropped silently while
+/// `total_len()` still counted it toward setup completion.
+#[test]
+fn mismatched_memory_lane_fails_closed() {
+    let mut chunks = MemoryChunksByKind::default();
+    let chunk =
+        InMemoryChunk::from_owned_records(vec![(RawCoordinateKey { sort_key: 1 }, vec![9u8; 8])]);
+    chunks.push(MemoryChunkErased::Coordinate(chunk)).expect("coordinate lane never mismatches");
+
+    // The coordinate lane matches a Coordinate sort → accepted.
+    chunks.ensure_single_lane(SortOrder::Coordinate).expect("matching lane is accepted");
+
+    // The same chunk under a Queryname sort is a lane mismatch → fail closed.
+    let err = chunks
+        .ensure_single_lane(SortOrder::Queryname(QuerynameComparator::Natural))
+        .expect_err("stray coordinate chunk under a queryname sort must error");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+}
+
+/// Template-coordinate spill slots present but no residual chunk to identify the
+/// `--key-types` lane must fail closed: defaulting to K40 would mis-decode narrow
+/// (K24/Cb32/Tert32) spill files. Unreachable for valid input (Phase-1 always
+/// emits a variant-tagged residual), so this guards against a seal-logic
+/// regression. With no slots, the empty-input case is still accepted.
+#[test]
+fn empty_template_lane_with_spill_slots_fails_closed() {
+    let slot = Arc::new(SortMergeSlot::new(
+        0,
+        std::io::BufReader::new(tempfile::tempfile().unwrap()),
+        fgumi_sort::SpillCodec::Bgzf,
+    ));
+    // `Box<dyn MergeDriverDyn>` isn't `Debug`, so match rather than `expect_err`.
+    match build_driver(SortOrder::TemplateCoordinate, vec![slot], MemoryChunksByKind::default(), 1)
+    {
+        Err(e) => assert_eq!(e.kind(), std::io::ErrorKind::InvalidData),
+        Ok(_) => panic!("empty template lane with spill slots must fail closed"),
+    }
+
+    // No slots → empty input; any key width is safe (nothing to merge).
+    assert!(
+        build_driver(SortOrder::TemplateCoordinate, Vec::new(), MemoryChunksByKind::default(), 0)
+            .is_ok(),
+        "empty template lane with no slots is valid",
+    );
+}
+
+/// The `--key-types` narrowed-lane variant is chosen once per sort and is global
+/// to the run. A template chunk arriving with a different variant means phase 1
+/// and the merge disagree about the key width; merging on would compare keys of
+/// different layouts and emit silently mis-ordered output. It must fail closed,
+/// like the sibling `ensure_single_lane` / `build_driver` violations — not panic.
+#[test]
+fn template_variant_change_mid_sort_fails_closed() {
+    use fgumi_sort::{TemplateKey24, TemplateMemChunk, TertKey32};
+
+    let mut chunks = MemoryChunksByKind::default();
+
+    let k24 = InMemoryChunk::from_owned_records(vec![(TemplateKey24::default(), vec![1u8; 8])]);
+    chunks
+        .push(MemoryChunkErased::TemplateCoordinate(TemplateMemChunk::K24(k24)))
+        .expect("the first template chunk establishes the variant");
+
+    // A second chunk in a different lane width is the protocol violation.
+    let tert = InMemoryChunk::from_owned_records(vec![(TertKey32::default(), vec![2u8; 8])]);
+    let err = chunks
+        .push(MemoryChunkErased::TemplateCoordinate(TemplateMemChunk::Tert32(tert)))
+        .expect_err("a variant change must be rejected");
+
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    let msg = err.to_string();
+    assert!(msg.contains("variant changed mid-sort"), "unexpected message: {msg}");
+    // Both variants are named so the failure is diagnosable from the log alone.
+    assert!(msg.contains("K24"), "error names the accumulated variant: {msg}");
+    assert!(msg.contains("Tert32"), "error names the offending variant: {msg}");
+}
+
+/// Repeated chunks of the SAME variant are the normal path and must keep working.
+#[test]
+fn repeated_template_chunks_of_one_variant_accumulate() {
+    use fgumi_sort::{TemplateKey24, TemplateMemChunk};
+
+    let mut chunks = MemoryChunksByKind::default();
+    for i in 0..3u8 {
+        let c = InMemoryChunk::from_owned_records(vec![(TemplateKey24::default(), vec![i; 8])]);
+        chunks
+            .push(MemoryChunkErased::TemplateCoordinate(TemplateMemChunk::K24(c)))
+            .expect("same-variant chunks accumulate");
+    }
+    assert_eq!(chunks.total_len(), 3, "all three chunks are retained");
+}

--- a/crates/fgumi-pipeline-io/src/sort/mod.rs
+++ b/crates/fgumi-pipeline-io/src/sort/mod.rs
@@ -1,0 +1,41 @@
+//! Sort typed-steps for the unified pipeline.
+
+/// `DetachedGroup::Shared` label for the sort's **coordination** driver thread:
+/// the serial phase-1 coordination steps (`ReadBlocks` admit, `FindBoundariesAndSort`
+/// sort/seal, `SpillGather` framing) plus the phase-2 `SortMerge`. One dedicated
+/// thread runs all of them off the pool — the true N+2 model (mirrors main's
+/// single main thread). Phase 1 and phase 2 are temporally disjoint, so the
+/// coordination steps finish and leave the driver's live set before the merge
+/// runs, giving the merge a dedicated thread in phase 2.
+pub const SORT_COORD_GROUP: &str = "sort-coord";
+
+/// `DetachedGroup::Shared` label for the sort's **I/O writer** driver thread:
+/// `SpillWrite` (phase 1) and `WriteBgzfFile` (phase 2). Isolated from the
+/// coordination driver so a write flush never stalls coordination (main's reason
+/// for the second dedicated thread).
+pub const SORT_IO_GROUP: &str = "sort-io";
+
+pub mod arena_ingest;
+pub mod compress_spill;
+pub mod merge;
+pub mod protocol;
+pub mod sort_buffer;
+pub mod spill_block_compress;
+pub mod spill_decompress;
+pub mod spill_gather;
+pub mod spill_write;
+
+pub use arena_ingest::{
+    ArenaBlock, ArenaSortStrategy, CoordinateStrategy, FindBoundariesAndSort, InflateToArena,
+    InflatedBlock, QuerynameStrategy, ReadBlocks, TemplateStrategy,
+};
+pub use compress_spill::CompressSpill;
+pub use merge::{BlockOutput, MergeBatchBuilder, MergeOutput, RecordBatchOutput, SortMerge};
+pub use sort_buffer::SortBuffer;
+pub use spill_block_compress::SpillBlockCompress;
+pub use spill_decompress::{SortDecompressTuning, SortSpillDecompress};
+pub use spill_gather::SpillGather;
+pub use spill_write::SpillWrite;
+
+#[cfg(test)]
+pub mod tests;

--- a/crates/fgumi-pipeline-io/src/sort/protocol.rs
+++ b/crates/fgumi-pipeline-io/src/sort/protocol.rs
@@ -1,0 +1,477 @@
+//! Typed-event protocol between the three sort steps in the runall-sort
+//! fused chain.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use fgumi_sort::{
+    InMemoryChunk, RawCoordinateKey, RawQuerynameKey, RawQuerynameLexKey, SortMergeSlot,
+    TemplateMemChunk,
+};
+
+use fgumi_pipeline_core::item::HeapSize;
+
+/// Approximate fixed per-record index overhead of an arena-backed
+/// [`InMemoryChunk<K>`], in bytes, added once per record in
+/// [`MemoryChunkErased::approx_heap_bytes`] on top of the variable record payload
+/// (`InMemoryChunk::payload_bytes`).
+///
+/// This covers one `(K, offset, len)` index slot — the sort key `K` (largest
+/// variant: `TemplateKey`) plus the offset/len into the shared buffer — together
+/// with allocator-bucket slack the payload byte count does not capture. It is an
+/// intentionally conservative constant, not a `size_of` expression, so the queue
+/// accounting over-counts rather than under-counts memory.
+const PER_MEMORY_RECORD_OVERHEAD: usize = 354;
+
+/// In-memory sorted residual chunk produced by the Phase-1 sort head
+/// (`SortBuffer` or `FindBoundariesAndSort`), type-erased over the sort-key
+/// variant `K`.
+pub enum MemoryChunkErased {
+    /// Coordinate-sort residual. `K = RawCoordinateKey`. Zero-copy arena-backed
+    /// chunk (shares the sort buffer's `Arc<SegmentedBuf>`).
+    Coordinate(InMemoryChunk<RawCoordinateKey>),
+    /// Queryname-sort residual, lexicographic comparator. `K = RawQuerynameLexKey`.
+    /// Arena-backed like [`Coordinate`](Self::Coordinate): the record bodies live
+    /// in the chunk's shared buffer; the key owns its (small) name bytes.
+    QuerynameLex(InMemoryChunk<RawQuerynameLexKey>),
+    /// Queryname-sort residual, natural comparator. `K = RawQuerynameKey`.
+    QuerynameNatural(InMemoryChunk<RawQuerynameKey>),
+    /// Template-coordinate-sort residual, carried as a variant-tagged
+    /// [`TemplateMemChunk`] so the chosen `--key-types` narrow lane rides through
+    /// merge and spill like every other order's `K`. Zero-copy arena-backed chunk
+    /// (shares the sort buffer's `Arc<SegmentedBuf>`), like
+    /// [`Coordinate`](Self::Coordinate).
+    TemplateCoordinate(TemplateMemChunk),
+}
+
+impl MemoryChunkErased {
+    /// Number of records in this chunk.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Coordinate(v) => v.len(),
+            Self::QuerynameLex(v) => v.len(),
+            Self::QuerynameNatural(v) => v.len(),
+            Self::TemplateCoordinate(v) => v.len(),
+        }
+    }
+
+    /// `true` iff the chunk has zero records.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Borrow the `i`th record's raw BAM body bytes, in this chunk's sorted order.
+    ///
+    /// Zero-copy for every variant — each is arena-backed and slices its shared
+    /// `SegmentedBuf`. Used by `SortMerge`'s single-source fast path to gather a
+    /// fully-sorted in-memory chunk into output blocks without a (k = 1)
+    /// loser-tree merge.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `i >= self.len()`.
+    #[must_use]
+    pub fn record_bytes(&self, i: usize) -> &[u8] {
+        match self {
+            Self::Coordinate(v) => v.record_bytes(i),
+            Self::QuerynameLex(v) => v.record_bytes(i),
+            Self::QuerynameNatural(v) => v.record_bytes(i),
+            Self::TemplateCoordinate(v) => v.record_bytes(i),
+        }
+    }
+
+    /// Approximate heap footprint in bytes.
+    #[must_use]
+    pub fn approx_heap_bytes(&self) -> usize {
+        let (count, payload): (usize, usize) = match self {
+            Self::Coordinate(v) => (v.len(), v.payload_bytes()),
+            Self::QuerynameLex(v) => (v.len(), v.payload_bytes()),
+            Self::QuerynameNatural(v) => (v.len(), v.payload_bytes()),
+            Self::TemplateCoordinate(v) => (v.len(), v.payload_bytes()),
+        };
+        count * PER_MEMORY_RECORD_OVERHEAD + payload
+    }
+}
+
+/// Events from `SortBuffer` → `CompressSpill` (the P6 Phase-1 split).
+///
+/// `SortBuffer` (Serial) sorts each filled buffer and emits the sorted records
+/// as a chunk; `CompressSpill` (Parallel) then compresses spill chunks to disk
+/// or passes the in-memory residual through. The seam carries already-sorted
+/// `MemoryChunkErased`s, so it is byte-bounded by [`HeapSize`] just like the
+/// downstream `SortPhase1Event` queue.
+pub enum SortChunkEvent {
+    /// A sorted chunk to be compressed and written to disk by `CompressSpill`.
+    ///
+    /// `seq` is the chunk's logical spill index, assigned monotonically by
+    /// `SortBuffer`. `CompressSpill` uses it as the opened slot's `file_id` so
+    /// the merge tie-break order matches the legacy spill order regardless of
+    /// which Parallel worker writes the file.
+    Spill { seq: u32, chunk: MemoryChunkErased, records_ingested_so_far: u64 },
+    /// A sorted in-memory residual chunk to pass straight through as a
+    /// `SortPhase1Event::MemoryChunk` — no disk round-trip (the fast path).
+    Residual { chunk: MemoryChunkErased, records_ingested_so_far: u64 },
+    /// Terminal sentinel carrying the final counts (number of `Spill` chunks =
+    /// `slot_count`, number of `Residual` chunks = `memory_chunk_count`).
+    /// `CompressSpill` forwards it verbatim as `SortPhase1Event::AllAnnounced`.
+    AllAnnounced { slot_count: u32, memory_chunk_count: u32, total_records: u64 },
+}
+
+impl HeapSize for SortChunkEvent {
+    fn heap_size(&self) -> usize {
+        // Mirror `SortPhase1Event::heap_size`: a fixed per-event base so the
+        // byte-bounded transport queue cannot absorb an unbounded count of
+        // near-zero-cost control events (`AllAnnounced`).
+        let base = std::mem::size_of::<Self>();
+        match self {
+            Self::Spill { chunk, .. } | Self::Residual { chunk, .. } => {
+                base + chunk.approx_heap_bytes()
+            }
+            Self::AllAnnounced { .. } => base,
+        }
+    }
+}
+
+impl SortChunkEvent {
+    /// Running snapshot of records ingested at the moment this event was emitted.
+    #[must_use]
+    pub fn records_ingested_so_far(&self) -> u64 {
+        match self {
+            Self::Spill { records_ingested_so_far, .. }
+            | Self::Residual { records_ingested_so_far, .. } => *records_ingested_so_far,
+            Self::AllAnnounced { total_records, .. } => *total_records,
+        }
+    }
+}
+
+/// Events from `SpillGather` → `SpillBlockCompress` → `SpillWrite` (the
+/// block-parallel spill-write split that replaces the monolithic single-worker
+/// `CompressSpill`).
+///
+/// `SpillGather` (Serial) fans each `SortChunkEvent::Spill` chunk into
+/// record-aligned raw [`Block`](Self::Block)s and forwards `Residual` /
+/// `AllAnnounced`. `SpillBlockCompress` (Parallel) compresses each `Block`'s `bytes`
+/// in place. `SpillWrite` (Serial) demultiplexes blocks back to per-`file_id`
+/// spill files and emits the existing [`SortPhase1Event`].
+///
+/// **Ordinal contract:** `SpillGather` mints `ordinal` monotonically across
+/// **every** emitted item (every block of every file, plus the `Residual` /
+/// `AllAnnounced` passthroughs), so the stream is dense and gap-free for the
+/// framework's single-cursor `ByItemOrdinal` reorder. Because `SortBuffer`
+/// (Serial) emits `Spill` events one-at-a-time in `seq` order and
+/// `SpillGather` (Serial) drains them in order, each file's blocks are
+/// **contiguous** in the ordinal stream — so `SpillWrite` only ever has one
+/// spill file open at a time.
+pub enum SpillBlockEvent {
+    /// One raw (pre-compression) or compressed (post-`SpillBlockCompress`) block of a
+    /// spill file. `file_id` is the spill `seq` (the eventual slot `file_id`),
+    /// `is_last_in_file` marks the final block so `SpillWrite` can finalize the
+    /// file and emit `SpillReady`. `SpillWrite` (Serial) owns the path allocation,
+    /// so the block carries no path — only the `file_id` that names the file.
+    Block {
+        ordinal: u64,
+        file_id: u32,
+        is_last_in_file: bool,
+        records_ingested_so_far: u64,
+        bytes: Vec<u8>,
+    },
+    /// A sorted in-memory residual chunk, passed straight through to
+    /// `SortPhase1Event::MemoryChunk` (no disk round-trip).
+    Residual { ordinal: u64, chunk: MemoryChunkErased, records_ingested_so_far: u64 },
+    /// Terminal sentinel forwarded verbatim as `SortPhase1Event::AllAnnounced`.
+    AllAnnounced { ordinal: u64, slot_count: u32, memory_chunk_count: u32, total_records: u64 },
+}
+
+impl SpillBlockEvent {
+    /// The dense ordinal that drives `ByItemOrdinal` reordering into `SpillWrite`.
+    #[must_use]
+    pub fn ordinal(&self) -> u64 {
+        match self {
+            Self::Block { ordinal, .. }
+            | Self::Residual { ordinal, .. }
+            | Self::AllAnnounced { ordinal, .. } => *ordinal,
+        }
+    }
+}
+
+impl HeapSize for SpillBlockEvent {
+    fn heap_size(&self) -> usize {
+        // Fixed per-event base (so the byte-bounded queue can't absorb an
+        // unbounded count of near-empty control events) plus the variable
+        // payload: a block's bytes, or a residual chunk's records.
+        let base = std::mem::size_of::<Self>();
+        match self {
+            Self::Block { bytes, .. } => base + bytes.capacity(),
+            Self::Residual { chunk, .. } => base + chunk.approx_heap_bytes(),
+            Self::AllAnnounced { .. } => base,
+        }
+    }
+}
+
+impl fgumi_pipeline_core::item::Ordered for SpillBlockEvent {
+    fn ordinal(&self) -> u64 {
+        SpillBlockEvent::ordinal(self)
+    }
+}
+
+/// Events from the Phase-1 producers (`CompressSpill` / `SpillWrite`) →
+/// `SortSpillDecompress`.
+pub enum SortPhase1Event {
+    /// A spill chunk file has been closed and is ready for Phase 2 decompression.
+    SpillReady { slot: Arc<SortMergeSlot>, path: PathBuf, records_ingested_so_far: u64 },
+    /// A par-sorted residual in-memory chunk passed through by the Phase-1
+    /// producer (`CompressSpill` / `SpillWrite`) on its drained-completion path.
+    MemoryChunk { chunk: Arc<MemoryChunkErased>, records_ingested_so_far: u64 },
+    /// Sentinel emitted as the LAST event by the Phase-1 producer
+    /// (`CompressSpill` / `SpillWrite`) on its drained-completion path.
+    AllAnnounced { slot_count: u32, memory_chunk_count: u32, total_records: u64 },
+}
+
+/// Events from `SortSpillDecompress` → `SortMerge`.
+pub enum SortPhase2Event {
+    /// Forwarded `SortPhase1Event::SpillReady`.
+    SpillReady { slot: Arc<SortMergeSlot>, path: PathBuf, records_ingested_so_far: u64 },
+    /// Forwarded `SortPhase1Event::MemoryChunk`.
+    MemoryChunk { chunk: Arc<MemoryChunkErased>, records_ingested_so_far: u64 },
+    /// Forwarded `SortPhase1Event::AllAnnounced`.
+    AllAnnounced { slot_count: u32, memory_chunk_count: u32, total_records: u64 },
+}
+
+/// Generates the identical `HeapSize` impl and `records_ingested_so_far` accessor for a
+/// spill-phase event enum.
+///
+/// [`SortPhase1Event`] and [`SortPhase2Event`] are structurally identical (the Phase-2
+/// event is a verbatim forward of the Phase-1 event) but are kept as distinct types so
+/// the typed-step pipeline cannot wire a Phase-1 producer output straight into a
+/// Phase-2 (`SortMerge`) input. This macro removes the duplicated impl bodies without
+/// collapsing the two types.
+macro_rules! impl_spill_phase_event {
+    ($ty:ty) => {
+        impl HeapSize for $ty {
+            fn heap_size(&self) -> usize {
+                // Charge a fixed per-event base so the byte-bounded transport queues
+                // cannot accept an unbounded count of near-zero-cost control events
+                // (`SpillReady` with an empty path, `AllAnnounced`). Memory stays a
+                // function of configuration rather than event count.
+                let base = std::mem::size_of::<Self>();
+                match self {
+                    Self::SpillReady { path, .. } => base + path.as_os_str().len(),
+                    Self::MemoryChunk { chunk, .. } => base + chunk.approx_heap_bytes(),
+                    Self::AllAnnounced { .. } => base,
+                }
+            }
+        }
+
+        impl $ty {
+            /// Running snapshot of records ingested at the moment this event was emitted.
+            #[must_use]
+            pub fn records_ingested_so_far(&self) -> u64 {
+                match self {
+                    Self::SpillReady { records_ingested_so_far, .. }
+                    | Self::MemoryChunk { records_ingested_so_far, .. } => *records_ingested_so_far,
+                    Self::AllAnnounced { total_records, .. } => *total_records,
+                }
+            }
+        }
+    };
+}
+
+impl_spill_phase_event!(SortPhase1Event);
+impl_spill_phase_event!(SortPhase2Event);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build the arena-backed coordinate chunk the `Coordinate` variant carries,
+    /// from raw record payloads (keys are `default()`; irrelevant to these tests).
+    fn coord(payloads: Vec<Vec<u8>>) -> InMemoryChunk<RawCoordinateKey> {
+        InMemoryChunk::from_owned_records(
+            payloads.into_iter().map(|b| (RawCoordinateKey::default(), b)).collect(),
+        )
+    }
+
+    #[test]
+    fn memory_chunk_len_and_is_empty() {
+        let chunk: MemoryChunkErased = MemoryChunkErased::Coordinate(coord(Vec::new()));
+        assert_eq!(chunk.len(), 0);
+        assert!(chunk.is_empty());
+
+        let chunk = MemoryChunkErased::Coordinate(coord(vec![vec![0xAA; 16], vec![0xBB; 32]]));
+        assert_eq!(chunk.len(), 2);
+        assert!(!chunk.is_empty());
+    }
+
+    #[test]
+    fn memory_chunk_approx_heap_bytes_counts_overhead_plus_payload() {
+        let chunk = MemoryChunkErased::Coordinate(coord(vec![vec![0xAA; 100], vec![0xBB; 200]]));
+        assert_eq!(chunk.approx_heap_bytes(), 2 * PER_MEMORY_RECORD_OVERHEAD + 300);
+    }
+
+    #[test]
+    fn records_ingested_so_far_accessors() {
+        let dummy_path = std::path::PathBuf::from("/tmp/x");
+        let slot = Arc::new(SortMergeSlot::new(
+            0,
+            std::io::BufReader::new(tempfile::tempfile().unwrap()),
+            fgumi_sort::SpillCodec::Bgzf,
+        ));
+        let ev1 = SortPhase1Event::SpillReady {
+            slot: Arc::clone(&slot),
+            path: dummy_path.clone(),
+            records_ingested_so_far: 100,
+        };
+        assert_eq!(ev1.records_ingested_so_far(), 100);
+
+        let chunk = Arc::new(MemoryChunkErased::Coordinate(coord(Vec::new())));
+        let ev2 = SortPhase1Event::MemoryChunk {
+            chunk: Arc::clone(&chunk),
+            records_ingested_so_far: 250,
+        };
+        assert_eq!(ev2.records_ingested_so_far(), 250);
+
+        let ev3 =
+            SortPhase2Event::SpillReady { slot, path: dummy_path, records_ingested_so_far: 300 };
+        assert_eq!(ev3.records_ingested_so_far(), 300);
+
+        let ev4 = SortPhase2Event::MemoryChunk { chunk, records_ingested_so_far: 400 };
+        assert_eq!(ev4.records_ingested_so_far(), 400);
+
+        let ev5 = SortPhase1Event::AllAnnounced {
+            slot_count: 4,
+            memory_chunk_count: 1,
+            total_records: 500,
+        };
+        assert_eq!(ev5.records_ingested_so_far(), 500);
+        let ev6 = SortPhase2Event::AllAnnounced {
+            slot_count: 4,
+            memory_chunk_count: 1,
+            total_records: 600,
+        };
+        assert_eq!(ev6.records_ingested_so_far(), 600);
+    }
+
+    #[test]
+    fn sort_chunk_event_heap_size_and_accessors() {
+        let chunk = MemoryChunkErased::Coordinate(coord(vec![vec![0xAA; 100], vec![0xBB; 200]]));
+        let payload = chunk.approx_heap_bytes();
+
+        let spill = SortChunkEvent::Spill { seq: 3, chunk, records_ingested_so_far: 42 };
+        assert_eq!(spill.heap_size(), std::mem::size_of::<SortChunkEvent>() + payload);
+        assert_eq!(spill.records_ingested_so_far(), 42);
+
+        let residual = SortChunkEvent::Residual {
+            chunk: MemoryChunkErased::Coordinate(coord(Vec::new())),
+            records_ingested_so_far: 7,
+        };
+        assert_eq!(residual.records_ingested_so_far(), 7);
+
+        // Control events carry no heap payload but still cost a fixed base so the
+        // byte-bounded queue cannot accept an unbounded count of them.
+        let announced = SortChunkEvent::AllAnnounced {
+            slot_count: 4,
+            memory_chunk_count: 1,
+            total_records: 500,
+        };
+        assert_eq!(announced.heap_size(), std::mem::size_of::<SortChunkEvent>());
+        assert_eq!(announced.records_ingested_so_far(), 500);
+    }
+
+    #[test]
+    fn all_announced_heap_size_charges_base_cost() {
+        // Control events carry no heap payload but must still cost a fixed,
+        // non-zero amount so the byte-bounded queues cannot accept an unbounded
+        // count of them.
+        let ev1 = SortPhase1Event::AllAnnounced {
+            slot_count: 16,
+            memory_chunk_count: 4,
+            total_records: 1_000_000,
+        };
+        assert_eq!(ev1.heap_size(), std::mem::size_of::<SortPhase1Event>());
+        let ev2 = SortPhase2Event::AllAnnounced {
+            slot_count: 16,
+            memory_chunk_count: 4,
+            total_records: 1_000_000,
+        };
+        assert_eq!(ev2.heap_size(), std::mem::size_of::<SortPhase2Event>());
+    }
+
+    // ── SpillBlockEvent ─────────────────────────────────────────────────────
+
+    /// The `Ordered` impl delegates to the inherent `SpillBlockEvent::ordinal`.
+    /// If that inherent method is ever removed or renamed, the call silently
+    /// resolves to the trait method itself and recurses until the stack blows.
+    /// Asserting through the trait for every variant pins the delegation.
+    #[test]
+    fn spill_block_event_ordinal_delegates_for_every_variant() {
+        use fgumi_pipeline_core::item::Ordered;
+
+        let block = SpillBlockEvent::Block {
+            ordinal: 3,
+            file_id: 0,
+            is_last_in_file: false,
+            records_ingested_so_far: 0,
+            bytes: vec![0u8; 4],
+        };
+        let residual = SpillBlockEvent::Residual {
+            ordinal: 4,
+            chunk: MemoryChunkErased::Coordinate(coord(vec![vec![1u8; 8]])),
+            records_ingested_so_far: 1,
+        };
+        let announced = SpillBlockEvent::AllAnnounced {
+            ordinal: 5,
+            slot_count: 1,
+            memory_chunk_count: 1,
+            total_records: 1,
+        };
+
+        assert_eq!(<SpillBlockEvent as Ordered>::ordinal(&block), 3);
+        assert_eq!(<SpillBlockEvent as Ordered>::ordinal(&residual), 4);
+        assert_eq!(<SpillBlockEvent as Ordered>::ordinal(&announced), 5);
+    }
+
+    /// `heap_size` charges a fixed per-event base plus the variable payload. The
+    /// base is what stops a byte-bounded queue absorbing an unbounded number of
+    /// near-empty control events, so a `Block` must scale with its bytes while
+    /// `AllAnnounced` stays at the base.
+    #[test]
+    fn spill_block_event_heap_size_charges_base_plus_payload() {
+        let base = std::mem::size_of::<SpillBlockEvent>();
+
+        let announced = SpillBlockEvent::AllAnnounced {
+            ordinal: 0,
+            slot_count: 1,
+            memory_chunk_count: 0,
+            total_records: 0,
+        };
+        assert_eq!(announced.heap_size(), base, "a control event costs only the base");
+
+        let small = SpillBlockEvent::Block {
+            ordinal: 0,
+            file_id: 0,
+            is_last_in_file: false,
+            records_ingested_so_far: 0,
+            bytes: Vec::with_capacity(64),
+        };
+        let large = SpillBlockEvent::Block {
+            ordinal: 0,
+            file_id: 0,
+            is_last_in_file: false,
+            records_ingested_so_far: 0,
+            bytes: Vec::with_capacity(4096),
+        };
+        assert_eq!(small.heap_size(), base + 64, "a block charges its byte capacity");
+        assert_eq!(large.heap_size(), base + 4096);
+        assert!(large.heap_size() > small.heap_size(), "cost tracks payload size");
+
+        // A residual charges the chunk's records, so it too exceeds the base.
+        let residual = SpillBlockEvent::Residual {
+            ordinal: 0,
+            chunk: MemoryChunkErased::Coordinate(coord(vec![vec![7u8; 128]])),
+            records_ingested_so_far: 1,
+        };
+        assert!(residual.heap_size() > base, "a residual charges its retained records");
+    }
+}

--- a/crates/fgumi-pipeline-io/src/sort/sort_buffer.rs
+++ b/crates/fgumi-pipeline-io/src/sort/sort_buffer.rs
@@ -1,0 +1,667 @@
+//! `SortBuffer` — first step of the P6 Phase-1 split (`SortBuffer` →
+//! `CompressSpill` → `SortSpillDecompress` → `SortMerge`).
+//!
+//! `SortBuffer` (`Serial`) ingests `RecordBatch`es into an in-memory arena via
+//! the order-erased `ChunkSorter` (each variant drives the same per-order
+//! [`ArenaSortStrategy`] as the block-input `FindBoundariesAndSort` front),
+//! sorts each filled arena, and emits the sorted records as a [`SortChunkEvent`]
+//! — **without touching disk**. Mid-stream spill
+//! chunks (`Spill { seq, .. }`) and the final residual (`Residual`) flow to the
+//! `Parallel` `CompressSpill` step, which compresses + writes spills and passes
+//! the residual through. This replaces the monolithic `SortAndSpill`, which
+//! drove a private `SortWorkerPool` to compress inline.
+//!
+//! Spill chunks are emitted **as the buffer fills** (not accumulated to the
+//! end), and `try_run` drains the staged-events queue before popping the next
+//! input batch, so staged chunks never accumulate *across* batches. Within a
+//! single batch, `ingest_one_batch` seals one chunk each time the arena reaches
+//! `memory_limit`. In production this fires at most once per batch — each input
+//! `RecordBatch` is block-bounded (`ParseBamRecords` emits one batch per
+//! decompressed BGZF block, orders of magnitude below the 512 MB default
+//! `memory_limit`) — so peak memory stays at ~one spill chunk plus the live
+//! buffer. If `memory_limit` is configured far below the batch size (as some
+//! tests do to force spilling), a single batch may seal several chunks into
+//! `pending` in one `ingest_one_batch` call; this only raises transient peak
+//! memory — every sealed chunk is still emitted in order and no records are
+//! dropped.
+//!
+//! All four sort orders (coordinate, template-coordinate, queryname lex +
+//! natural) route through this step via the `ChunkSorter` order enum.
+
+use std::collections::VecDeque;
+use std::io;
+use std::sync::Arc;
+
+use anyhow::{Result, anyhow};
+use fgumi_bam_io::ProgressTracker;
+use fgumi_sort::{
+    PooledSegmentedBuf, QuerynameComparator, RawExternalSorter, RawQuerynameKey,
+    RawQuerynameLexKey, SegmentedBuf, SortOrder, TemplateArenaAccumulator,
+};
+use noodles::sam::Header;
+
+use crate::sort::protocol::{MemoryChunkErased, SortChunkEvent};
+use crate::sort::{ArenaSortStrategy, CoordinateStrategy, QuerynameStrategy, TemplateStrategy};
+use crate::types::RecordBatch;
+use fgumi_pipeline_core::{
+    HeldRetry, Unpushed,
+    held::HeldSlot,
+    outputs::Single,
+    queues::QueueSpec,
+    reorder::BranchOrdering,
+    step::{Affinity, Step, StepCtx, StepKind, StepOutcome, StepProfile},
+};
+
+/// Max staged events flushed to the output per `try_run` invocation.
+const MAX_EVENTS_PER_LOCK: usize = 8;
+
+/// Per-record memory overhead added to the arena byte count so the seal
+/// threshold accounts for the strategy's `(key, offset, len)` ref alongside the
+/// record body. Conservative; the exact value only shifts spill boundaries, not
+/// the merged output (coordinate/template are globally stable; queryname's tie
+/// order is unspecified).
+const PER_RECORD_REF_OVERHEAD: usize = 64;
+
+/// Record-input arena accumulator: copies each pushed record into a growing
+/// [`SegmentedBuf`] and drives an [`ArenaSortStrategy`] over the arena refs, so
+/// the record-input (SAM / fused) path uses the SAME per-order sort engine as the
+/// block-input arena front ([`FindBoundariesAndSort`](crate::sort::FindBoundariesAndSort)).
+/// At seal the filled arena is wrapped in an `Arc` and handed to the strategy (no
+/// further record copies), and a fresh arena starts the next run.
+struct ArenaAccum<S: ArenaSortStrategy> {
+    strategy: S,
+    arena: SegmentedBuf,
+    memory_limit: usize,
+    memory_used: usize,
+    total_records: u64,
+    sort_threads: usize,
+}
+
+impl<S: ArenaSortStrategy> ArenaAccum<S> {
+    fn new(strategy: S, memory_limit: usize, sort_threads: usize) -> Self {
+        Self {
+            strategy,
+            arena: SegmentedBuf::new(),
+            memory_limit,
+            memory_used: 0,
+            total_records: 0,
+            sort_threads,
+        }
+    }
+
+    /// Copy one record into the arena and accumulate its sort ref. Returns `true`
+    /// once the run's byte budget is reached.
+    #[allow(clippy::cast_possible_truncation)] // offset/len fit usize on all supported (64-bit) targets
+    fn push(&mut self, bam_bytes: &[u8]) -> Result<bool> {
+        let len =
+            u32::try_from(bam_bytes.len()).map_err(|_| anyhow!("record length exceeds u32"))?;
+        let offset = self.arena.extend_from_slice(bam_bytes) as u64;
+        let body = self.arena.slice(offset as usize, len as usize);
+        // The strategy reads `body` to extract the sort key and stores only
+        // `(key, offset, len)`; it does not retain `body`, so the arena may grow
+        // (and this slice's borrow end) freely afterwards.
+        self.strategy.push_record(body, offset, len).map_err(|e| anyhow!("{e:#}"))?;
+        self.memory_used += bam_bytes.len() + PER_RECORD_REF_OVERHEAD;
+        self.total_records += 1;
+        Ok(self.memory_used >= self.memory_limit)
+    }
+
+    /// Seal the current run: wrap the filled arena in an `Arc`, sort + materialize
+    /// via the strategy, and reset for the next run. Empty if nothing was pushed
+    /// since the last seal.
+    fn take_sorted_chunk(&mut self) -> MemoryChunkErased {
+        let arena = std::mem::replace(&mut self.arena, SegmentedBuf::new());
+        self.memory_used = 0;
+        let arc = Arc::new(PooledSegmentedBuf::unpooled(arena));
+        self.strategy.seal(arc, self.sort_threads)
+    }
+
+    fn total_records(&self) -> u64 {
+        self.total_records
+    }
+}
+
+/// Order-erased record-input arena sorter. Each variant pairs an [`ArenaAccum`]
+/// with the concrete [`ArenaSortStrategy`] for its order, so `SortBuffer` drives
+/// the same per-order sort engine as the block-input `FindBoundariesAndSort`.
+enum ChunkSorter {
+    Coordinate(ArenaAccum<CoordinateStrategy>),
+    Template(ArenaAccum<TemplateStrategy>),
+    QuerynameLex(ArenaAccum<QuerynameStrategy<RawQuerynameLexKey>>),
+    QuerynameNatural(ArenaAccum<QuerynameStrategy<RawQuerynameKey>>),
+}
+
+impl ChunkSorter {
+    /// Build the arena sorter matching `sorter.sort_order()`, provisioning each
+    /// order's strategy exactly as the block-input arena front does.
+    #[allow(clippy::needless_pass_by_value)] // by-value keeps the caller's move-in; only read here
+    fn from_sorter(sorter: RawExternalSorter, header: &Header) -> Result<Self> {
+        let memory_limit = sorter.memory_limit_bytes();
+        // Phase-1 count honors the `--sort-threads` override (falls back to
+        // `--threads`); `num_threads()` would drop the override silently.
+        let sort_threads = sorter.phase1_threads();
+        Ok(match sorter.sort_order() {
+            SortOrder::Coordinate => {
+                let n_ref = u32::try_from(header.reference_sequences().len())
+                    .map_err(|_| anyhow!("reference sequence count overflows u32"))?;
+                Self::Coordinate(ArenaAccum::new(
+                    CoordinateStrategy::new(n_ref),
+                    memory_limit,
+                    sort_threads,
+                ))
+            }
+            SortOrder::TemplateCoordinate => {
+                let acc = TemplateArenaAccumulator::from_header(
+                    header,
+                    sorter.cell_tag_value(),
+                    sorter.key_types_spec(),
+                );
+                Self::Template(ArenaAccum::new(
+                    TemplateStrategy::new(acc),
+                    memory_limit,
+                    sort_threads,
+                ))
+            }
+            SortOrder::Queryname(QuerynameComparator::Lexicographic) => {
+                Self::QuerynameLex(ArenaAccum::new(
+                    QuerynameStrategy::new(MemoryChunkErased::QuerynameLex),
+                    memory_limit,
+                    sort_threads,
+                ))
+            }
+            SortOrder::Queryname(QuerynameComparator::Natural) => {
+                Self::QuerynameNatural(ArenaAccum::new(
+                    QuerynameStrategy::new(MemoryChunkErased::QuerynameNatural),
+                    memory_limit,
+                    sort_threads,
+                ))
+            }
+        })
+    }
+
+    /// Push one record; `true` once the run hits the memory limit.
+    fn push(&mut self, bam_bytes: &[u8]) -> Result<bool> {
+        match self {
+            Self::Coordinate(s) => s.push(bam_bytes),
+            Self::Template(s) => s.push(bam_bytes),
+            Self::QuerynameLex(s) => s.push(bam_bytes),
+            Self::QuerynameNatural(s) => s.push(bam_bytes),
+        }
+    }
+
+    /// Seal + materialize the current run into one erased chunk (empty if nothing
+    /// was pushed), resetting for the next run.
+    fn take_sorted_chunk(&mut self) -> MemoryChunkErased {
+        match self {
+            Self::Coordinate(s) => s.take_sorted_chunk(),
+            Self::Template(s) => s.take_sorted_chunk(),
+            Self::QuerynameLex(s) => s.take_sorted_chunk(),
+            Self::QuerynameNatural(s) => s.take_sorted_chunk(),
+        }
+    }
+
+    /// Take the final residual as zero-or-one erased chunk. Every order seals one
+    /// globally-sorted chunk per run (coordinate/template are stable; queryname's
+    /// tie order is unspecified), so the residual is at most one chunk — the
+    /// legacy multi-chunk `par_chunks_mut` split is no longer needed.
+    ///
+    /// An empty residual is normally dropped. The one EXCEPTION is
+    /// template-coordinate when there were prior spills: the empty chunk still
+    /// carries the chosen `--key-types` narrow-lane variant, which is the only
+    /// signal `SortMerge`'s `build_driver` has to pick the spill files' key width.
+    /// Without it, a run whose records all spilled (empty final residual) would
+    /// leave the merge to default to the full 40-byte key and misread the
+    /// narrow-key spills. Coordinate and queryname have a fixed key type, so their
+    /// empty residual is dropped as before; with no spills there is nothing to
+    /// disambiguate, so the fast path (single non-empty chunk) is preserved.
+    fn take_residual_chunks(&mut self, had_spills: bool) -> Vec<MemoryChunkErased> {
+        residual_chunks_for(self.take_sorted_chunk(), had_spills)
+    }
+
+    fn total_records(&self) -> u64 {
+        match self {
+            Self::Coordinate(s) => s.total_records(),
+            Self::Template(s) => s.total_records(),
+            Self::QuerynameLex(s) => s.total_records(),
+            Self::QuerynameNatural(s) => s.total_records(),
+        }
+    }
+}
+
+/// Decide whether a run's final (residual) chunk is emitted.
+///
+/// Split out of `ChunkSorter::take_residual_chunks` so the rule can be tested
+/// without constructing a whole accumulator: the interesting behaviour is a pure
+/// function of the chunk and whether the run spilled.
+///
+/// An empty residual is normally dropped. The one EXCEPTION is
+/// template-coordinate when there were prior spills: the empty chunk is the only
+/// carrier of the chosen `--key-types` narrow-lane variant, which is the only
+/// signal `SortMerge`'s `build_driver` has to pick the spill files' key width.
+/// Dropping it leaves the merge defaulting to the full 40-byte key and misreading
+/// the narrow-key spills — wrong output, not a crash.
+fn residual_chunks_for(chunk: MemoryChunkErased, had_spills: bool) -> Vec<MemoryChunkErased> {
+    let keep_empty_for_variant =
+        had_spills && matches!(chunk, MemoryChunkErased::TemplateCoordinate(_));
+    if chunk.is_empty() && !keep_empty_for_variant { Vec::new() } else { vec![chunk] }
+}
+
+/// Push every record in `batch` into `sorter`, staging a sealed `Spill` chunk
+/// into `pending` (and bumping `next_seq`) each time the arena fills. Returns
+/// the number of records traversed and the first push failure, if any.
+///
+/// The sorter is BORROWED, so a failure cannot leave the caller's sorter slot
+/// empty — a state that would be indistinguishable from "finalized". The error
+/// is returned rather than propagated with `?` so the caller can record it and
+/// still account for the records it already consumed.
+///
+/// Ingest stops at the first failing record: the pushes that preceded it are
+/// retained (they are already in the arena), but continuing would ingest records
+/// *after* a rejected one and quietly sort a subset of the input.
+fn ingest_batch_records(
+    sorter: &mut ChunkSorter,
+    batch: &RecordBatch,
+    pending: &mut VecDeque<SortChunkEvent>,
+    next_seq: &mut u32,
+) -> (u64, Option<String>) {
+    let mut batch_records = 0u64;
+    for record in batch.iter_record_bytes() {
+        batch_records += 1;
+        let buffer_full = match sorter.push(record) {
+            Ok(full) => full,
+            Err(e) => return (batch_records, Some(format!("SortBuffer: push failed: {e:#}"))),
+        };
+        if buffer_full {
+            // Seal the filled arena and stage it. We keep draining the rest
+            // of the batch rather than stopping early — breaking here would
+            // strand the batch's remaining records. Staging multiple chunks
+            // per batch is correct (each is emitted in order downstream); in
+            // production a block-bounded `RecordBatch` is far below
+            // `memory_limit`, so this fires at most once per batch (see the
+            // module docs).
+            let chunk = sorter.take_sorted_chunk();
+            if !chunk.is_empty() {
+                pending.push_back(SortChunkEvent::Spill {
+                    seq: *next_seq,
+                    chunk,
+                    records_ingested_so_far: sorter.total_records(),
+                });
+                *next_seq += 1;
+            }
+        }
+    }
+    (batch_records, None)
+}
+
+/// `Serial` step that buffers, sorts, and emits sorted chunks for `CompressSpill`.
+pub struct SortBuffer {
+    /// In-memory buffering sorter. `Some` while ingesting; `None` after the
+    /// residual has been taken (finalized).
+    sorter: Option<ChunkSorter>,
+    /// Sorted chunks awaiting output (spill chunks during ingest; the residual +
+    /// `AllAnnounced` after finalize). Drained before the next batch is ingested.
+    pending: VecDeque<SortChunkEvent>,
+    /// Monotonic spill index. Each `Spill` event's `seq` (= the eventual slot
+    /// `file_id`) makes the merge tie-break order independent of which
+    /// `CompressSpill` worker writes the file. Also the final `slot_count`.
+    next_seq: u32,
+    /// First ingest failure, if any. Once set the step is poisoned and every
+    /// later `try_run` re-raises instead of ingesting or finalizing — a step
+    /// that failed must never go on to report `Finished`, which downstream
+    /// would read as a complete sort (see `try_run`). Holds the message rather
+    /// than the `io::Error` because `io::Error` is not `Clone`.
+    failed: Option<String>,
+    held: HeldSlot<Unpushed<SortChunkEvent>>,
+    output_byte_limit: u64,
+    affinity: Affinity,
+    /// Read+ingest progress, logged every 1M records (mirrors the legacy
+    /// "Read records" tracker) so the ingest rate over time is visible under
+    /// `RUST_LOG=info` — distinguishes a slow read path from a stalled one.
+    ingest_progress: ProgressTracker,
+}
+
+impl SortBuffer {
+    /// Build a `SortBuffer` from a configured `RawExternalSorter` (any of the
+    /// four sort orders) and the output `Header`.
+    ///
+    /// `output_byte_limit` byte-bounds the output event queue (its chunk-bearing
+    /// variants retain sorted records, so the queue budgets on bytes, not count).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the header's reference-sequence count does not fit in
+    /// a `u32` (the coordinate key's reference field). That conversion is the
+    /// only fallible step: the template path's `TemplateArenaAccumulator::from_header`
+    /// is infallible here.
+    pub fn from_sorter(
+        sorter: RawExternalSorter,
+        header: &Header,
+        output_byte_limit: u64,
+    ) -> Result<Self> {
+        let chunk_sorter = ChunkSorter::from_sorter(sorter, header)?;
+        Ok(Self {
+            sorter: Some(chunk_sorter),
+            pending: VecDeque::new(),
+            next_seq: 0,
+            failed: None,
+            held: HeldSlot::new(),
+            output_byte_limit,
+            affinity: Affinity::None,
+            ingest_progress: ProgressTracker::new("Sort ingest records").with_interval(1_000_000),
+        })
+    }
+
+    /// Override the affinity hint.
+    #[must_use]
+    pub fn with_affinity(mut self, affinity: Affinity) -> Self {
+        self.affinity = affinity;
+        self
+    }
+
+    /// Re-raise the first ingest failure once the step has been poisoned.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error naming the original failure if `failed` is set.
+    fn check_not_failed(&self) -> io::Result<()> {
+        match &self.failed {
+            None => Ok(()),
+            Some(message) => Err(io::Error::other(format!(
+                "SortBuffer: refusing to continue after an earlier failure: {message}"
+            ))),
+        }
+    }
+
+    fn flush_held(&mut self, ctx: &mut StepCtx<'_, Self>) -> bool {
+        // `true` once the slot is clear (was empty, or the held event flushed);
+        // `false` while it's still held under backpressure. Uses the canonical
+        // re-hold helper so the put-back-on-reject invariant lives in one place.
+        !matches!(ctx.outputs.retry_held(&mut self.held), HeldRetry::StillHeld)
+    }
+
+    /// Push up to `MAX_EVENTS_PER_LOCK` staged events to the output, parking the
+    /// first that can't be pushed in `held`. Caller guarantees `held` is empty.
+    fn emit_pending(&mut self, ctx: &mut StepCtx<'_, Self>) -> StepOutcome {
+        let mut emitted = 0usize;
+        while emitted < MAX_EVENTS_PER_LOCK {
+            let Some(event) = self.pending.pop_front() else { break };
+            if let Err(unpushed) = ctx.outputs.push(event) {
+                self.held.put(unpushed);
+                return StepOutcome::Progress;
+            }
+            emitted += 1;
+        }
+        if emitted > 0 { StepOutcome::Progress } else { StepOutcome::NoProgress }
+    }
+
+    /// Pop one input batch (if any) and push its records into the sorter, staging
+    /// a `Spill` chunk into `pending` whenever the buffer fills. Returns `true`
+    /// if a batch was consumed.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first `ChunkSorter::push` failure, after poisoning the step so
+    /// no later `try_run` can finalize (see the `failed` field).
+    ///
+    /// # Panics
+    ///
+    /// Panics if called after finalize (`self.sorter` is `None`).
+    fn ingest_one_batch(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<bool> {
+        let Some(batch) = ctx.input.pop() else {
+            return Ok(false);
+        };
+        // Borrow the sorter rather than taking it: an error path that left
+        // `self.sorter` as `None` would be indistinguishable from "finalized".
+        // `pending` / `next_seq` are passed alongside as disjoint borrows.
+        let sorter = self.sorter.as_mut().expect("ingest_one_batch after finalize");
+        let (batch_records, push_error) =
+            ingest_batch_records(sorter, &batch, &mut self.pending, &mut self.next_seq);
+        // Log ingest progress (every 1M records) so the read+ingest rate over
+        // wall time is visible — a steady rate means the read path is the cost;
+        // a bursty/stalling rate means downstream backpressure.
+        self.ingest_progress.log_if_needed(batch_records);
+        if let Some(message) = push_error {
+            self.failed = Some(message.clone());
+            return Err(io::Error::other(message));
+        }
+        Ok(true)
+    }
+
+    /// Take the residual chunk and enqueue it (if non-empty) followed by the
+    /// terminal `AllAnnounced`. Consumes the sorter (`self.sorter` becomes
+    /// `None`), freeing the buffer + rayon pool.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called twice (`self.sorter` already `None`).
+    fn finalize(&mut self) {
+        let mut sorter = self.sorter.take().expect("finalize called twice");
+        let total_records = sorter.total_records();
+        // `had_spills` keeps an EMPTY template-coordinate residual alive: it is
+        // the only carrier of the `--key-types` narrowed-lane variant, without
+        // which `SortMerge` falls back to the full 40-byte key and misreads the
+        // spills. See `take_residual_chunks` for the authoritative rule.
+        let residual_chunks = sorter.take_residual_chunks(self.next_seq > 0);
+        let memory_chunk_count =
+            u32::try_from(residual_chunks.len()).expect("residual chunk count fits u32");
+        for chunk in residual_chunks {
+            self.pending.push_back(SortChunkEvent::Residual {
+                chunk,
+                records_ingested_so_far: total_records,
+            });
+        }
+        self.pending.push_back(SortChunkEvent::AllAnnounced {
+            slot_count: self.next_seq,
+            memory_chunk_count,
+            total_records,
+        });
+        // `sorter` dropped here (releases the buffer + private rayon pool).
+    }
+}
+
+impl Step for SortBuffer {
+    type Input = RecordBatch;
+    type Outputs = Single<SortChunkEvent>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "SortBuffer",
+            kind: StepKind::Serial,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::None],
+        }
+    }
+
+    fn affinity(&self) -> Affinity {
+        self.affinity
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // Fail closed. Today both runtimes stop dispatching a step that returned
+        // `Err` (`record_error` marks the pipeline done), so this is unreachable
+        // — but a scheduler that re-dispatched instead would otherwise fall
+        // through to `finalize()` and publish a residual + `AllAnnounced` for a
+        // sort that never ingested the rest of its input: a truncated result
+        // that is structurally indistinguishable from a complete one.
+        self.check_not_failed()?;
+
+        if !self.flush_held(ctx) {
+            return Ok(StepOutcome::Contention);
+        }
+
+        // Drain staged events before ingesting more — keeps peak memory bounded
+        // to ~one spill chunk plus the live buffer.
+        if !self.pending.is_empty() {
+            return Ok(self.emit_pending(ctx));
+        }
+
+        if self.sorter.is_some() {
+            if self.ingest_one_batch(ctx)? {
+                // Emit anything the batch just staged.
+                if !self.pending.is_empty() {
+                    return Ok(self.emit_pending(ctx));
+                }
+                return Ok(StepOutcome::Progress);
+            }
+            // No batch available right now.
+            if !ctx.input.is_drained() {
+                return Ok(StepOutcome::NoProgress);
+            }
+            // Input fully drained — produce the residual + AllAnnounced.
+            self.finalize();
+            return Ok(self.emit_pending(ctx));
+        }
+
+        // Finalized and all events drained.
+        Ok(StepOutcome::Finished)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sort::tests::record_with_mi;
+    use crate::types::RecordBatchBuilder;
+    use fgumi_sort::{
+        InMemoryChunk, KeyTypesSpec, RawCoordinateKey, TemplateKey24, TemplateMemChunk,
+    };
+    use rstest::rstest;
+
+    fn coordinate(payloads: Vec<Vec<u8>>) -> MemoryChunkErased {
+        MemoryChunkErased::Coordinate(InMemoryChunk::from_owned_records(
+            payloads.into_iter().map(|b| (RawCoordinateKey::default(), b)).collect(),
+        ))
+    }
+
+    fn template(payloads: Vec<Vec<u8>>) -> MemoryChunkErased {
+        MemoryChunkErased::TemplateCoordinate(TemplateMemChunk::K24(
+            InMemoryChunk::from_owned_records(
+                payloads.into_iter().map(|b| (TemplateKey24::default(), b)).collect(),
+            ),
+        ))
+    }
+
+    /// The empty template-coordinate residual must survive `had_spills`, because
+    /// it is the only carrier of the narrowed-lane variant. Every other empty
+    /// residual is dropped, and every non-empty residual is kept.
+    #[rstest]
+    #[case::empty_coordinate_no_spills(coordinate(vec![]), false, 0)]
+    #[case::empty_coordinate_with_spills(coordinate(vec![]), true, 0)]
+    #[case::empty_template_no_spills(template(vec![]), false, 0)]
+    // The exception: kept purely to carry the key-width variant to the merge.
+    #[case::empty_template_with_spills(template(vec![]), true, 1)]
+    #[case::nonempty_coordinate_no_spills(coordinate(vec![vec![1u8; 8]]), false, 1)]
+    #[case::nonempty_coordinate_with_spills(coordinate(vec![vec![1u8; 8]]), true, 1)]
+    #[case::nonempty_template_no_spills(template(vec![vec![1u8; 8]]), false, 1)]
+    #[case::nonempty_template_with_spills(template(vec![vec![1u8; 8]]), true, 1)]
+    fn residual_chunk_emission_rule(
+        #[case] chunk: MemoryChunkErased,
+        #[case] had_spills: bool,
+        #[case] expected_len: usize,
+    ) {
+        assert_eq!(residual_chunks_for(chunk, had_spills).len(), expected_len);
+    }
+
+    // ── Ingest failure handling ─────────────────────────────────────────────
+
+    fn batch_of(records: &[Vec<u8>]) -> RecordBatch {
+        let total: usize = records.iter().map(Vec::len).sum();
+        let mut builder = RecordBatchBuilder::with_capacity(0, total, records.len());
+        for record in records {
+            builder.push_record_bytes(record);
+        }
+        builder.build()
+    }
+
+    /// Template-coordinate sorter with every optional lane dropped
+    /// (`--key-types none`), so the first record fixes the narrowed variant and
+    /// any later record whose MI differs is rejected — the one reachable
+    /// `ChunkSorter::push` failure.
+    fn template_sorter_dropping_mi(memory_limit: usize) -> ChunkSorter {
+        let sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+            .memory_limit(memory_limit)
+            .threads(1)
+            .key_types(KeyTypesSpec::None);
+        ChunkSorter::from_sorter(sorter, &Header::default()).expect("build template chunk sorter")
+    }
+
+    /// A push failure must stop ingest at the offending record and leave the
+    /// caller's sorter intact. `SortBuffer` distinguishes "ingesting" from
+    /// "finalized" solely by `sorter.is_some()`, so a failure that consumed the
+    /// sorter would let a later `try_run` report `Finished` — a truncated sort
+    /// that looks complete.
+    #[test]
+    fn ingest_batch_records_stops_at_the_failure_and_keeps_the_sorter() {
+        let mut sorter = template_sorter_dropping_mi(256 * 1024 * 1024);
+        let mut pending = VecDeque::new();
+        let mut next_seq = 0u32;
+        let records = vec![
+            record_with_mi(10, b"r1", 1),
+            record_with_mi(20, b"r2", 2), // differing MI — rejected
+            record_with_mi(30, b"r3", 1),
+        ];
+
+        let (traversed, error) =
+            ingest_batch_records(&mut sorter, &batch_of(&records), &mut pending, &mut next_seq);
+
+        let message = error.expect("a differing MI under --key-types none must be rejected");
+        assert!(message.starts_with("SortBuffer: push failed"), "unexpected message: {message}");
+        assert_eq!(traversed, 2, "ingest stops at the offending record, not after the batch");
+        assert_eq!(sorter.total_records(), 1, "only the accepted record reached the arena");
+        // Borrowed, never moved out: the sorter is still usable afterwards.
+        assert_eq!(sorter.take_sorted_chunk().len(), 1);
+        assert!(pending.is_empty());
+        assert_eq!(next_seq, 0);
+    }
+
+    /// The clean path: each time the arena reaches `memory_limit` the sealed
+    /// chunk is staged and `next_seq` advances. A 1-byte limit seals per record.
+    #[test]
+    fn ingest_batch_records_stages_a_spill_chunk_each_time_the_arena_fills() {
+        let mut sorter = template_sorter_dropping_mi(1);
+        let mut pending = VecDeque::new();
+        let mut next_seq = 0u32;
+        let records = vec![record_with_mi(10, b"r1", 1), record_with_mi(20, b"r2", 1)];
+
+        let (traversed, error) =
+            ingest_batch_records(&mut sorter, &batch_of(&records), &mut pending, &mut next_seq);
+
+        assert!(error.is_none(), "constant MI is not a dropped-lane violation");
+        assert_eq!(traversed, 2);
+        assert_eq!(pending.len(), 2, "one staged spill chunk per seal");
+        assert_eq!(next_seq, 2);
+    }
+
+    /// A poisoned step re-raises on every later `try_run` instead of falling
+    /// through to `finalize()`, and names the original failure so the re-raise
+    /// is not mistaken for a second, unrelated error.
+    #[rstest]
+    #[case::clean(None, None)]
+    #[case::poisoned(
+        Some("SortBuffer: push failed: dropped lane MI"),
+        Some(
+            "refusing to continue after an earlier failure: SortBuffer: push failed: dropped lane MI"
+        )
+    )]
+    fn check_not_failed_re_raises_the_original_failure(
+        #[case] failed: Option<&str>,
+        #[case] expected_message: Option<&str>,
+    ) {
+        let mut step = SortBuffer::from_sorter(
+            RawExternalSorter::new(SortOrder::Coordinate).memory_limit(1 << 20).threads(1),
+            &Header::default(),
+            1 << 20,
+        )
+        .expect("build SortBuffer");
+        step.failed = failed.map(str::to_string);
+
+        match expected_message {
+            None => step.check_not_failed().expect("a step that never failed continues"),
+            Some(expected) => {
+                let err = step.check_not_failed().expect_err("a poisoned step must re-raise");
+                assert!(err.to_string().contains(expected), "unexpected error: {err}");
+            }
+        }
+    }
+}

--- a/crates/fgumi-pipeline-io/src/sort/spill_block_compress.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_block_compress.rs
@@ -1,0 +1,152 @@
+//! `SpillBlockCompress` — middle step of the block-parallel spill-write split
+//! (`SpillGather` → `SpillBlockCompress` → `SpillWrite`).
+//!
+//! `SpillBlockCompress` (`Parallel + ByItemOrdinal`) compresses each raw
+//! [`SpillBlockEvent::Block`] from `SpillGather` into a self-contained
+//! compressed unit (framed BGZF block(s) for bgzf, or a `[u32 len][zstd frame]`
+//! for zstd) via the shared [`SpillBlockCompressor`] kernel, replacing the
+//! `bytes` in place. `Residual` and `AllAnnounced` pass straight through. The
+//! `ordinal` is preserved on every event, so the framework's `ByItemOrdinal`
+//! reorder hands `SpillWrite` a dense, in-order stream regardless of which worker
+//! compressed which block — exactly the output path's `BgzfCompress` idiom.
+//!
+//! Each `Parallel` worker holds its own [`SpillBlockCompressor`], built lazily on
+//! the first block (the zstd compressor's construction is fallible, so it is
+//! surfaced through `try_run`'s `io::Result` rather than the infallible
+//! `new_worker_copy`).
+
+use std::io;
+
+use fgumi_sort::{SpillBlockCompressor, SpillCodec};
+
+use crate::sort::protocol::SpillBlockEvent;
+use fgumi_pipeline_core::{
+    HeldRetry, Unpushed,
+    held::HeldSlot,
+    outputs::OrderedBytesSingle,
+    queues::QueueSpec,
+    reorder::BranchOrdering,
+    step::{Step, StepCtx, StepKind, StepOutcome, StepProfile},
+};
+
+/// `Parallel + ByItemOrdinal` block compressor for the spill-write split.
+///
+/// Not to be confused with the similarly-named
+/// [`CompressSpill`](super::CompressSpill): this `SpillBlockCompress` is the
+/// **pure block-compression** middle step of the finer
+/// `SpillGather → SpillBlockCompress → SpillWrite` split (the disk write is the
+/// separate `SpillWrite` step), whereas `CompressSpill` is the **composite
+/// compress-and-write-to-disk** step of the coarser
+/// `SortBuffer → CompressSpill → SortSpillDecompress → SortMerge` chain.
+pub struct SpillBlockCompress {
+    codec: SpillCodec,
+    compression: u32,
+    /// Per-worker compressor, built lazily on the first block. `None` until then
+    /// (and on fresh `new_worker_copy` clones).
+    compressor: Option<SpillBlockCompressor>,
+    held: HeldSlot<Unpushed<SpillBlockEvent>>,
+    output_byte_limit: u64,
+}
+
+impl SpillBlockCompress {
+    /// Build a `SpillBlockCompress` for `codec` at `compression`. `output_byte_limit`
+    /// byte-bounds the compressed-block output queue.
+    #[must_use]
+    pub fn new(codec: SpillCodec, compression: u32, output_byte_limit: u64) -> Self {
+        Self { codec, compression, compressor: None, held: HeldSlot::new(), output_byte_limit }
+    }
+
+    fn flush_held(&mut self, ctx: &mut StepCtx<'_, Self>) -> bool {
+        !matches!(ctx.outputs.retry_held(&mut self.held), HeldRetry::StillHeld)
+    }
+
+    /// Compress one event's payload (the `Block` arm) or pass it through. The
+    /// `ordinal` and routing fields are preserved. `StepCtx`-free for unit tests.
+    ///
+    /// # Errors
+    ///
+    /// Propagates compressor-init or compression errors.
+    fn compress_event(&mut self, event: SpillBlockEvent) -> io::Result<SpillBlockEvent> {
+        match event {
+            SpillBlockEvent::Block {
+                ordinal,
+                file_id,
+                is_last_in_file,
+                records_ingested_so_far,
+                bytes,
+            } => {
+                if self.compressor.is_none() {
+                    self.compressor =
+                        Some(SpillBlockCompressor::new(self.codec, self.compression)?);
+                }
+                let compressor = self.compressor.as_mut().expect("compressor built above");
+                let compressed = compressor.compress_block(&bytes)?;
+                Ok(SpillBlockEvent::Block {
+                    ordinal,
+                    file_id,
+                    is_last_in_file,
+                    records_ingested_so_far,
+                    bytes: compressed,
+                })
+            }
+            // Passthrough variants carry no compressible payload.
+            other @ (SpillBlockEvent::Residual { .. } | SpillBlockEvent::AllAnnounced { .. }) => {
+                Ok(other)
+            }
+        }
+    }
+}
+
+impl Clone for SpillBlockCompress {
+    fn clone(&self) -> Self {
+        // Fresh per-worker compressor + held slot; shared config copied.
+        Self {
+            codec: self.codec,
+            compression: self.compression,
+            compressor: None,
+            held: HeldSlot::new(),
+            output_byte_limit: self.output_byte_limit,
+        }
+    }
+}
+
+impl Step for SpillBlockCompress {
+    type Input = SpillBlockEvent;
+    type Outputs = OrderedBytesSingle<SpillBlockEvent>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "SpillBlockCompress",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if !self.flush_held(ctx) {
+            return Ok(StepOutcome::Contention);
+        }
+
+        if let Some(event) = ctx.input.pop() {
+            let forwarded = self.compress_event(event)?;
+            if let Err(unpushed) = ctx.outputs.push(forwarded) {
+                self.held.put(unpushed);
+            }
+            return Ok(StepOutcome::Progress);
+        }
+
+        if ctx.input.is_drained() {
+            return Ok(StepOutcome::Finished);
+        }
+        Ok(StepOutcome::NoProgress)
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fgumi-pipeline-io/src/sort/spill_block_compress/tests.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_block_compress/tests.rs
@@ -1,0 +1,186 @@
+//! Unit tests for `SpillBlockCompress::compress_event` (the `StepCtx`-free core).
+
+use super::*;
+use crate::sort::protocol::MemoryChunkErased;
+use fgumi_sort::{InMemoryChunk, RawCoordinateKey, SpillBlockDecompressor};
+use rstest::rstest;
+
+fn raw_block(
+    ordinal: u64,
+    file_id: u32,
+    is_last: bool,
+    records_ingested_so_far: u64,
+    bytes: Vec<u8>,
+) -> SpillBlockEvent {
+    SpillBlockEvent::Block {
+        ordinal,
+        file_id,
+        is_last_in_file: is_last,
+        records_ingested_so_far,
+        bytes,
+    }
+}
+
+#[rstest]
+#[case(SpillCodec::Zstd)]
+#[case(SpillCodec::Bgzf)]
+fn block_payload_is_compressed_and_routing_preserved(#[case] codec: SpillCodec) {
+    let mut step = SpillBlockCompress::new(codec, 1, 1 << 20);
+    let raw = vec![0xABu8; 4096];
+    let out = step.compress_event(raw_block(7, 2, true, 123, raw.clone())).unwrap();
+    let SpillBlockEvent::Block {
+        ordinal,
+        file_id,
+        is_last_in_file,
+        records_ingested_so_far,
+        bytes,
+    } = out
+    else {
+        panic!("expected Block");
+    };
+    assert_eq!(ordinal, 7, "ordinal must be preserved ({codec:?})");
+    assert_eq!(file_id, 2, "file_id must be preserved ({codec:?})");
+    assert!(is_last_in_file, "is_last must be preserved ({codec:?})");
+    assert_eq!(
+        records_ingested_so_far, 123,
+        "records_ingested_so_far must pass through compression unchanged ({codec:?})"
+    );
+    assert_ne!(bytes, raw, "payload must change (be compressed) ({codec:?})");
+    assert!(!bytes.is_empty(), "compressed payload non-empty ({codec:?})");
+
+    // Round-trip through the matching decoder (independent oracle): a compressor
+    // that silently corrupts still changes the bytes, so `assert_ne!` alone is
+    // too weak. `read_raw` parses the block framing (zstd length prefix / BGZF
+    // block) and `decompress_one` inverts the codec; the recovered payload must
+    // equal the exact input.
+    let mut dec = SpillBlockDecompressor::new();
+    let mut cursor = std::io::Cursor::new(&bytes[..]);
+    let frames = dec.read_raw(&mut cursor, codec, 64).unwrap();
+    let mut round = Vec::new();
+    for frame in &frames {
+        round.extend_from_slice(&dec.decompress_one(codec, frame).unwrap());
+    }
+    assert_eq!(round, raw, "compressed block must round-trip back to input ({codec:?})");
+}
+
+#[test]
+fn residual_and_announced_pass_through_unchanged() {
+    let mut step = SpillBlockCompress::new(SpillCodec::Zstd, 1, 1 << 20);
+
+    let chunk = MemoryChunkErased::Coordinate(InMemoryChunk::from_owned_records(vec![(
+        RawCoordinateKey { sort_key: 1 },
+        vec![9u8; 8],
+    )]));
+    let residual = SpillBlockEvent::Residual { ordinal: 5, chunk, records_ingested_so_far: 1 };
+    let out = step.compress_event(residual).unwrap();
+    let SpillBlockEvent::Residual { ordinal, records_ingested_so_far, .. } = out else {
+        panic!("expected Residual");
+    };
+    assert_eq!(ordinal, 5, "residual ordinal must pass through unchanged");
+    assert_eq!(
+        records_ingested_so_far, 1,
+        "residual records_ingested_so_far must pass through unchanged (not reset)"
+    );
+
+    let announced = SpillBlockEvent::AllAnnounced {
+        ordinal: 6,
+        slot_count: 2,
+        memory_chunk_count: 1,
+        total_records: 3,
+    };
+    let out = step.compress_event(announced).unwrap();
+    assert!(matches!(
+        out,
+        SpillBlockEvent::AllAnnounced {
+            ordinal: 6,
+            slot_count: 2,
+            memory_chunk_count: 1,
+            total_records: 3,
+        }
+    ));
+}
+
+#[test]
+fn clone_starts_with_fresh_lazy_compressor() {
+    let mut step = SpillBlockCompress::new(SpillCodec::Zstd, 1, 1 << 20);
+    // Force the original to build its compressor.
+    let _ = step.compress_event(raw_block(0, 0, true, 0, vec![1u8; 16])).unwrap();
+    assert!(step.compressor.is_some(), "original built its compressor");
+    let fresh = step.clone();
+    assert!(fresh.compressor.is_none(), "clone must start with no compressor");
+}
+
+#[test]
+fn new_worker_copy_is_independent_of_the_template() {
+    let mut template = SpillBlockCompress::new(SpillCodec::Bgzf, 3, 4096);
+    let _ = template.compress_event(raw_block(0, 0, true, 0, vec![2u8; 32])).unwrap();
+
+    let worker = template.new_worker_copy();
+    // Config is inherited...
+    assert_eq!(worker.codec, SpillCodec::Bgzf);
+    assert_eq!(worker.compression, 3);
+    assert_eq!(worker.output_byte_limit, 4096);
+    // ...but the compressor is per-worker, so workers cannot share codec state.
+    assert!(worker.compressor.is_none(), "each worker builds its own compressor lazily");
+}
+
+#[test]
+fn profile_advertises_parallel_byordinal_with_a_byte_bounded_queue() {
+    let step = SpillBlockCompress::new(SpillCodec::Zstd, 1, 8192);
+    let profile = step.profile();
+    assert_eq!(profile.name, "SpillBlockCompress");
+    // Parallel + ByItemOrdinal is what lets any worker compress any block while
+    // `SpillWrite` still receives a dense, in-order stream.
+    assert_eq!(profile.kind, StepKind::Parallel);
+    assert!(!profile.sticky);
+    assert_eq!(profile.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    match profile.output_queues.as_slice() {
+        [QueueSpec::ByteBounded { limit_bytes }] => assert_eq!(*limit_bytes, 8192),
+        other => panic!("expected a single byte-bounded queue, got {other:?}"),
+    }
+}
+
+#[rstest]
+#[case::zstd(SpillCodec::Zstd)]
+#[case::bgzf(SpillCodec::Bgzf)]
+fn an_empty_block_round_trips_to_empty(#[case] codec: SpillCodec) {
+    let mut step = SpillBlockCompress::new(codec, 1, 1 << 20);
+    let out = step.compress_event(raw_block(0, 0, true, 0, Vec::new())).unwrap();
+    let SpillBlockEvent::Block { bytes, .. } = out else { panic!("expected Block") };
+
+    let mut dec = SpillBlockDecompressor::new();
+    let mut cursor = std::io::Cursor::new(&bytes[..]);
+    let frames = dec.read_raw(&mut cursor, codec, 64).unwrap();
+    let mut round = Vec::new();
+    for frame in &frames {
+        round.extend_from_slice(&dec.decompress_one(codec, frame).unwrap());
+    }
+    assert!(round.is_empty(), "an empty block must decompress back to empty ({codec:?})");
+}
+
+#[rstest]
+#[case::zstd(SpillCodec::Zstd)]
+#[case::bgzf(SpillCodec::Bgzf)]
+fn consecutive_blocks_reuse_one_compressor_and_stay_independent(#[case] codec: SpillCodec) {
+    // The compressor is built once and reused across blocks; each block must still
+    // decode standalone, since `SpillWrite` may interleave files.
+    let mut step = SpillBlockCompress::new(codec, 1, 1 << 20);
+    let payloads = [vec![0x11u8; 512], vec![0x22u8; 1024], vec![0x33u8; 64]];
+
+    for (i, payload) in payloads.iter().enumerate() {
+        let out = step
+            .compress_event(raw_block(i as u64, 0, i == payloads.len() - 1, 0, payload.clone()))
+            .unwrap();
+        let SpillBlockEvent::Block { bytes, .. } = out else { panic!("expected Block") };
+
+        let mut dec = SpillBlockDecompressor::new();
+        let mut cursor = std::io::Cursor::new(&bytes[..]);
+        let frames = dec.read_raw(&mut cursor, codec, 64).unwrap();
+        let mut round = Vec::new();
+        for frame in &frames {
+            round.extend_from_slice(&dec.decompress_one(codec, frame).unwrap());
+        }
+        assert_eq!(&round, payload, "block {i} must decode standalone ({codec:?})");
+    }
+    assert!(step.compressor.is_some(), "the compressor is built once and retained");
+}

--- a/crates/fgumi-pipeline-io/src/sort/spill_decompress.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_decompress.rs
@@ -1,0 +1,565 @@
+//! `SortSpillDecompress` — Parallel typed step that reads spill chunk
+//! files, decompresses their blocks, and pushes the decompressed bytes
+//! into per-slot bounded queues on `SortMergeSlot`.
+//!
+//! # Two decompression granularities
+//!
+//! The step supports two strategies, selected by [`SortDecompressTuning`]:
+//!
+//! - **file-granularity (`file_granularity == true`, the fallback):** one worker
+//!   owns a file's decompression at a time. Under the per-slot reader lock it
+//!   reads AND decompresses up to `block_batch` blocks inline, in read order,
+//!   and pushes them to the slot's FIFO. No reorder buffer is needed — a plain
+//!   FIFO suffices because read-and-decompress is a single inline operation. This
+//!   is the proven path (see the `merge_slots` module header, "What used to live
+//!   here, and why it's gone (v4 vs v3.1)").
+//!
+//! - **block-parallel (`file_granularity == false`):** multiple workers
+//!   decompress different blocks of the SAME file concurrently. Each `try_run`
+//!   holds the reader lock only for the READ (sequence-tagging each raw block via
+//!   `SortMergeReader::next_seq`), releases it, then decompresses its own batch
+//!   OUTSIDE the lock and reassembles via the slot's `ReorderBuffer`. The read
+//!   and decompression of a given block still happen within a single `try_run`
+//!   of a single worker — the lock is merely released between them. Parallelism
+//!   comes from multiple workers each grabbing the lock briefly, reading their
+//!   own batch, and decompressing concurrently — NOT from splitting read and
+//!   decompress across dispatches (which would re-open the v3 Skip-wedge
+//!   deadlock).
+//!
+//! # HARD INVARIANT
+//!
+//! A spill block must be read AND decompressed within a single `try_run` by a
+//! single worker. Both paths uphold this.
+//!
+//! # Memory note
+//!
+//! `--max-memory` does NOT bound Phase-2 decompressed memory today: the FIFO is
+//! count-bounded (`PHASE2_DECOMP_CAP`). The block-parallel path's reorder window
+//! is the additional decompressed-memory surface a slow straggler could grow, so
+//! it is explicitly bounded per-slot by `window_budget` (derived from the step's
+//! `output_byte_limit`) via [`SortMergeSlot::bp_reorder_admits`].
+
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use fgumi_sort::{SortMergeSlot, SpillBlockDecompressor};
+use parking_lot::Mutex;
+
+use crate::sort::protocol::{SortPhase1Event, SortPhase2Event};
+use fgumi_pipeline_core::{
+    Unpushed,
+    held::HeldSlot,
+    outputs::Single,
+    queues::QueueSpec,
+    reorder::BranchOrdering,
+    step::{Step, StepCtx, StepKind, StepOutcome, StepProfile},
+};
+
+/// Default reorder-window byte budget substituted when the caller's
+/// `output_byte_limit` is `0`. Mirrors the legacy pipeline's `effective_limit`
+/// (`unified_pipeline`), which normalizes a `0` memory limit to a fixed cap
+/// rather than treating it as "unlimited": `SortMergeSlot::bp_reorder_admits`
+/// (via `ReorderBuffer::would_accept`) reads `window_budget == 0` as *no bound*,
+/// so passing a resolved-to-zero budget straight through would remove the only
+/// byte cap on decompressed stragglers. Matches
+/// `fgumi_pipeline_core::reorder::DEFAULT_REORDER_OVERFLOW_BYTES` (256 MiB).
+const DEFAULT_REORDER_WINDOW_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Tuning for the Phase-2 spill decompression granularity.
+///
+/// Threaded from `SortOptions` (`--sort::file-granularity` /
+/// `--sort::block-batch`) through `ChainBuilder::add_sort` into
+/// [`SortSpillDecompress::new`].
+#[derive(Debug, Clone, Copy)]
+pub struct SortDecompressTuning {
+    /// `false` (default) — block-level parallel: hold the reader lock only for
+    /// the READ (sequence-tagged), release, decompress OUTSIDE the lock; multiple
+    /// workers decompress one file's blocks concurrently, reassembled by a
+    /// `ReorderBuffer`. The hardened production default (loom + soak matrix).
+    ///
+    /// `true` — one worker owns a file's decompression at a time (inline under
+    /// the reader lock, in-order, plain FIFO): the older single-worker-per-file
+    /// fallback.
+    pub file_granularity: bool,
+    /// Number of raw blocks claimed per reader-lock acquisition (replaces the
+    /// formerly-hardcoded batch size). Default `4` (restores the original
+    /// `MAX_BATCH_PER_CALL`; a fleet decompress-throughput bench will pick the
+    /// final value). Must be `>= 1`; [`SortSpillDecompress::new`] clamps lower
+    /// values and the CLI rejects them.
+    pub block_batch: usize,
+}
+
+impl Default for SortDecompressTuning {
+    fn default() -> Self {
+        // Block-parallel is the production default: it cleared the hardening gate
+        // (loom over the real `SortMergeSlot` + the external-watchdog soak matrix
+        // + the reorder-window byte cap). `file_granularity = true` is the
+        // single-worker-per-file fallback. `block_batch` default is 4 (the
+        // original `MAX_BATCH_PER_CALL`); a fleet bench will tune it. Matches
+        // `SortOptions::default`.
+        Self { file_granularity: false, block_batch: 4 }
+    }
+}
+
+/// CAS-acquire one decompress permit. `max == None` ⇒ unbounded (always succeeds).
+///
+/// Returns the [`DecompressPermit`] on success so ownership of the slot is
+/// encoded in the type: the count is released exactly once, when the returned
+/// permit drops, and acquisition cannot be separated from release. `None` ⇒ the
+/// cap is full and no slot was taken.
+#[must_use]
+fn try_acquire(active: &Arc<AtomicUsize>, max: Option<usize>) -> Option<DecompressPermit> {
+    let Some(max) = max else {
+        active.fetch_add(1, Ordering::AcqRel);
+        return Some(DecompressPermit { active: Arc::clone(active) });
+    };
+    let max = max.max(1);
+    let mut cur = active.load(Ordering::Acquire);
+    loop {
+        if cur >= max {
+            return None;
+        }
+        match active.compare_exchange_weak(cur, cur + 1, Ordering::AcqRel, Ordering::Acquire) {
+            Ok(_) => return Some(DecompressPermit { active: Arc::clone(active) }),
+            Err(observed) => cur = observed,
+        }
+    }
+}
+
+/// RAII release of one decompress permit. Holds an OWNED `Arc` clone so it does
+/// not borrow `self` while `try_fill_some_slot(&mut self)` runs.
+struct DecompressPermit {
+    active: Arc<AtomicUsize>,
+}
+impl Drop for DecompressPermit {
+    fn drop(&mut self) {
+        self.active.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+struct RegisteredSpill {
+    slot: Arc<SortMergeSlot>,
+}
+
+/// Parallel step that reads + decompresses spill chunk files and
+/// pushes results into per-slot queues. Forwards `SortPhase1Event`s
+/// verbatim to `SortMerge`.
+pub struct SortSpillDecompress {
+    registry: Arc<Mutex<Vec<RegisteredSpill>>>,
+    block_dec: SpillBlockDecompressor,
+    held: HeldSlot<Unpushed<SortPhase2Event>>,
+    output_byte_limit: u64,
+    /// Shared admission counter: how many worker clones are currently inside the
+    /// decompress branch. Shared across all clones so the cap is global.
+    active: Arc<AtomicUsize>,
+    /// Maximum concurrent decompress workers. `None` ⇒ unbounded. Set from
+    /// `--merge-threads` (Phase-2 CPU control).
+    max_decompress: Option<usize>,
+    tuning: SortDecompressTuning,
+    /// Per-slot reorder-window byte budget for the block-parallel path. Derived
+    /// from `output_byte_limit` (one per-step byte budget per slot). Bounds the
+    /// reorder buffer so a slow straggler can't balloon decompressed memory.
+    window_budget: u64,
+}
+
+impl SortSpillDecompress {
+    /// Construct a fresh step with an empty registry.
+    ///
+    /// `output_byte_limit` byte-bounds the forwarded-event output queue.
+    /// The forwarded `SortPhase2Event::MemoryChunk` variant retains sorted
+    /// record chunks, so this queue must budget on bytes (`HeapSize`), not
+    /// event count, to keep retained memory a function of configuration.
+    ///
+    /// `tuning` selects the decompression granularity (see
+    /// [`SortDecompressTuning`]). The block-parallel path derives its per-slot
+    /// reorder-window budget from `output_byte_limit`.
+    #[must_use]
+    pub fn new(output_byte_limit: u64, tuning: SortDecompressTuning) -> Self {
+        // Clamp `block_batch` to >= 1. A value of 0 reads zero blocks per
+        // acquisition, which on the inline path declares a phantom EOF after
+        // reading nothing (silent record loss) and on the block-parallel path
+        // never sets `reader_eof`/`queue_eof` (the merge livelocks). 0 is
+        // nonsensical for a "blocks per read" knob, so we normalize rather than
+        // propagate it. This is the single construction chokepoint for the step,
+        // so it defends every entry point (CLI, runall, direct construction).
+        let tuning = SortDecompressTuning { block_batch: tuning.block_batch.max(1), ..tuning };
+        // Normalize a zero reorder-window budget to a sane default rather than
+        // propagating it: `bp_reorder_admits` treats `window_budget == 0` as
+        // "unlimited", so a resolved-to-zero budget (e.g. `--max-memory 0`) would
+        // silently remove the byte cap on decompressed stragglers. This mirrors
+        // the legacy `effective_limit` 0-normalization and is applied at the same
+        // construction chokepoint as the `block_batch` clamp, defending every
+        // entry point (CLI, runall, direct construction).
+        let window_budget =
+            if output_byte_limit == 0 { DEFAULT_REORDER_WINDOW_BYTES } else { output_byte_limit };
+        Self {
+            registry: Arc::new(Mutex::new(Vec::new())),
+            block_dec: SpillBlockDecompressor::new(),
+            held: HeldSlot::new(),
+            output_byte_limit,
+            active: Arc::new(AtomicUsize::new(0)),
+            max_decompress: None,
+            tuning,
+            window_budget,
+        }
+    }
+
+    /// Cap the number of concurrent spill-decompression workers (Phase-2 CPU
+    /// control via `--merge-threads`). `None` (default) leaves it unbounded.
+    #[must_use]
+    pub fn with_max_concurrency(mut self, max: Option<usize>) -> Self {
+        self.max_decompress = max;
+        self
+    }
+
+    fn flush_held(&mut self, ctx: &mut StepCtx<'_, Self>) -> bool {
+        let Some(unpushed) = self.held.take() else {
+            return true;
+        };
+        match ctx.outputs.retry(unpushed) {
+            Ok(()) => true,
+            Err(again) => {
+                self.held.put(again);
+                false
+            }
+        }
+    }
+
+    fn push_or_hold(&mut self, ctx: &mut StepCtx<'_, Self>, event: SortPhase2Event) -> bool {
+        match ctx.outputs.push(event) {
+            Ok(()) => true,
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                false
+            }
+        }
+    }
+
+    fn snapshot_registry(&self) -> Vec<Arc<SortMergeSlot>> {
+        let registry = self.registry.lock();
+        registry.iter().map(|e| Arc::clone(&e.slot)).collect()
+    }
+
+    /// Slot indices ordered by ascending FIFO block count (most-starved first) — the
+    /// emptiest-first refill forecaster (see the budget-refill design spec §4.1).
+    /// Snapshots each slot's [`SortMergeSlot::fifo_len`] once (O(N) brief locks), then
+    /// sorts the indices, so the per-slot lock is taken exactly once per dispatch — not
+    /// inside the sort comparator. For the typical spill count (tens) this is negligible
+    /// next to the decompression work; if N grows into the hundreds, profile (a relaxed
+    /// cached length on the slot is the fallback) before keeping it.
+    ///
+    /// Slots that have already signalled `queue_eof` are dropped before the FIFO
+    /// lengths are read. The registry is append-only, so a drained slot would
+    /// otherwise stay in the scan for the rest of the run — taking its FIFO lock
+    /// on every dispatch only to be rejected immediately by
+    /// `try_fill_inline_slot` / `try_fill_block_parallel_slot`. With many spill
+    /// files that drained tail dominates the scan. Filtering is scheduling-only:
+    /// an EOF slot can never make progress, so skipping it changes no output.
+    #[must_use]
+    pub(crate) fn emptiest_first_order(slots: &[Arc<SortMergeSlot>]) -> Vec<usize> {
+        use std::sync::atomic::Ordering;
+
+        let mut order: Vec<usize> =
+            (0..slots.len()).filter(|&i| !slots[i].queue_eof.load(Ordering::Acquire)).collect();
+        // `sort_by_cached_key`, not `sort_by_key`: the key takes the slot's FIFO
+        // lock, and `sort_by_key` would re-take it O(n log n) times. This way each
+        // surviving slot is locked exactly once, and EOF slots not at all.
+        order.sort_by_cached_key(|&i| slots[i].fifo_len());
+        order
+    }
+
+    fn try_fill_some_slot(&mut self) -> io::Result<bool> {
+        let slots = self.snapshot_registry();
+        // Refill the most-starved slot first so a free worker tops up the slot the merge
+        // will exhaust soonest, rather than the first in registry order. Scheduling-only:
+        // admission and the read-and-decompress-in-one-`try_run` invariant are unchanged,
+        // so this cannot affect output or wedge progress (a non-progressing slot returns
+        // `false` fast and the loop falls through to the next).
+        for i in Self::emptiest_first_order(&slots) {
+            let slot = &slots[i];
+            let progressed = if self.tuning.file_granularity {
+                self.try_fill_inline_slot(slot)?
+            } else {
+                self.try_fill_block_parallel_slot(slot)?
+            };
+            if progressed {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Inline (file-granularity) fill: read AND decompress up to `block_batch`
+    /// blocks under the reader lock, push them to the FIFO in read order. One
+    /// worker owns a slot at a time; no reorder buffer needed.
+    fn try_fill_inline_slot(&mut self, slot: &Arc<SortMergeSlot>) -> io::Result<bool> {
+        use std::sync::atomic::Ordering;
+
+        if slot.queue_eof.load(Ordering::Acquire) {
+            return Ok(false);
+        }
+
+        let mut reader_guard = match slot.reader.try_lock() {
+            Ok(guard) => guard,
+            // Contended (another worker owns the slot): a normal skip.
+            Err(std::sync::TryLockError::WouldBlock) => return Ok(false),
+            // Poisoned: a fill worker panicked mid-read. Fail the slot CLOSED so
+            // `SortMerge` surfaces the failure; swallowing it as a skip would
+            // leave `queue_eof` unset and spin `Contention` forever (deadlock).
+            Err(std::sync::TryLockError::Poisoned(_)) => {
+                Self::mark_slot_failed(slot);
+                return Err(io::Error::other(
+                    "spill reader mutex poisoned: a decompress fill worker panicked",
+                ));
+            }
+        };
+
+        let room = {
+            let dec = slot.decompressed.lock().expect("decompressed mutex poisoned");
+            fgumi_sort::PHASE2_DECOMP_CAP.saturating_sub(dec.len())
+        };
+        if room == 0 {
+            return Ok(false);
+        }
+        let want = room.min(self.tuning.block_batch);
+
+        let decompressed_batch =
+            match self.block_dec.read_blocks(&mut reader_guard.inner, slot.codec, want) {
+                Ok(b) => b,
+                Err(e) => {
+                    // Centralized in `mark_slot_failed` so failure semantics stay
+                    // in one place (see the block-parallel path's use of it).
+                    Self::mark_slot_failed(slot);
+                    drop(reader_guard);
+                    return Err(e);
+                }
+            };
+        let got = decompressed_batch.len();
+        let hit_eof = got < want;
+
+        if got == 0 {
+            {
+                let _g = slot.decompressed.lock().expect("decompressed mutex poisoned");
+                slot.queue_eof.store(true, Ordering::Release);
+            }
+            drop(reader_guard);
+            return Ok(true);
+        }
+
+        {
+            let mut dec = slot.decompressed.lock().expect("decompressed mutex poisoned");
+            for b in decompressed_batch {
+                dec.push_back(b);
+            }
+            if hit_eof {
+                slot.queue_eof.store(true, Ordering::Release);
+            }
+        }
+        drop(reader_guard);
+        Ok(true)
+    }
+
+    /// Block-parallel fill: under the reader lock read (only) up to `block_batch`
+    /// raw blocks, sequence-tag them, release the lock, decompress OUTSIDE the
+    /// lock, then reassemble via the slot's reorder buffer and drain in-order
+    /// blocks into the FIFO. Multiple workers run this concurrently on the same
+    /// slot.
+    fn try_fill_block_parallel_slot(&mut self, slot: &Arc<SortMergeSlot>) -> io::Result<bool> {
+        use std::sync::atomic::Ordering;
+
+        if slot.queue_eof.load(Ordering::Acquire) {
+            return Ok(false);
+        }
+
+        // Phase A: read a fresh batch if the reader is still live and the
+        // FIFO / reorder window admit more.
+        if !slot.reader_eof.load(Ordering::Acquire) {
+            let acquired = match slot.reader.try_lock() {
+                Ok(guard) => Some(guard),
+                // Contended: fall through to the drain-only phase below.
+                Err(std::sync::TryLockError::WouldBlock) => None,
+                // Poisoned: a fill worker panicked mid-read. Fail closed so
+                // `SortMerge` surfaces it instead of spinning forever.
+                Err(std::sync::TryLockError::Poisoned(_)) => {
+                    Self::mark_slot_failed(slot);
+                    return Err(io::Error::other(
+                        "spill reader mutex poisoned: a decompress fill worker panicked",
+                    ));
+                }
+            };
+            if let Some(mut reader_guard) = acquired {
+                // Re-check under the lock: another worker may have hit EOF.
+                if !slot.reader_eof.load(Ordering::Acquire) {
+                    let next_seq = reader_guard.next_seq;
+                    let fifo_room = slot.bp_fifo_room();
+                    let admit =
+                        fifo_room > 0 && slot.bp_reorder_admits(next_seq, self.window_budget);
+                    // NB: the reorder-window budget is checked once here (for
+                    // `next_seq`), then up to `want` (≤ `block_batch`) blocks are
+                    // inserted below without a per-block re-check. So the reorder
+                    // window can transiently exceed `window_budget` by up to
+                    // `block_batch - 1` blocks. This overshoot is bounded and by
+                    // design: `block_batch` is small (default 4) and configurable,
+                    // so worst-case resident bytes stay `O(window_budget +
+                    // block_batch × block_size)` — not the unbounded growth the
+                    // window guards against. Per-block admission is intentionally
+                    // avoided to keep the reader-lock hold short (read the whole
+                    // batch, release, decompress outside the lock).
+                    if admit {
+                        // Bound the read by FIFO room (as the inline path does):
+                        // reading `block_batch` when only `fifo_room < block_batch`
+                        // slots can drain would over-admit the surplus into the
+                        // reorder window. `want >= 1` since `fifo_room > 0`.
+                        let want = self.tuning.block_batch.min(fifo_room);
+                        let start_seq = reader_guard.next_seq;
+                        let raw = match self.block_dec.read_raw(
+                            &mut reader_guard.inner,
+                            slot.codec,
+                            want,
+                        ) {
+                            Ok(r) => r,
+                            Err(e) => {
+                                Self::mark_slot_failed(slot);
+                                drop(reader_guard);
+                                return Err(e);
+                            }
+                        };
+                        let got = raw.len();
+                        // EOF only when the reader returned fewer than we asked
+                        // for (`want`); a FIFO-limited short read is not EOF.
+                        let hit_eof = got < want;
+                        // Stamp the read range and account for it BEFORE releasing
+                        // the lock, so a concurrent worker observing EOF cannot
+                        // race ahead of this batch's in-flight accounting. The
+                        // publish order (reserve `in_flight` before setting
+                        // `reader_eof`) is the loom-verified protocol; it lives in
+                        // `SortMergeSlot::bp_commit_read` as the single source of
+                        // truth, so this call site and the loom model share it (see
+                        // that method's doc and fgumi-sort tests/loom_merge_slots.rs).
+                        reader_guard.next_seq += got as u64;
+                        slot.bp_commit_read(got, hit_eof);
+                        drop(reader_guard);
+
+                        // Decompress OUTSIDE the reader lock (still this try_run).
+                        let mut blocks = Vec::with_capacity(got);
+                        for raw_block in &raw {
+                            match self.block_dec.decompress_one(slot.codec, raw_block) {
+                                Ok(d) => blocks.push(d),
+                                Err(e) => {
+                                    Self::mark_slot_failed(slot);
+                                    return Err(e);
+                                }
+                            }
+                        }
+                        slot.bp_insert_drain_finalize(start_seq, blocks, got);
+                        return Ok(true);
+                    }
+                }
+            }
+        }
+
+        // Phase B: drain-only. Flush any now-in-order blocks the FIFO can accept
+        // (it may have freed up, or another worker delivered a straggler) and
+        // finalize EOF if fully delivered.
+        Ok(slot.bp_drain_and_finalize())
+    }
+
+    /// Mark a slot as failed (decompression / read error): set `decomp_error`
+    /// and `queue_eof` under the `decompressed` mutex so the consumer surfaces
+    /// the error in preference to a clean EOF.
+    fn mark_slot_failed(slot: &Arc<SortMergeSlot>) {
+        use std::sync::atomic::Ordering;
+        let _g = slot.decompressed.lock().expect("decompressed mutex poisoned");
+        slot.decomp_error.store(true, Ordering::Release);
+        slot.queue_eof.store(true, Ordering::Release);
+    }
+}
+
+impl Clone for SortSpillDecompress {
+    fn clone(&self) -> Self {
+        Self {
+            registry: Arc::clone(&self.registry),
+            block_dec: SpillBlockDecompressor::new(),
+            held: HeldSlot::new(),
+            output_byte_limit: self.output_byte_limit,
+            // Share the SAME counter so the cap is global across all worker clones.
+            active: Arc::clone(&self.active),
+            max_decompress: self.max_decompress,
+            tuning: self.tuning,
+            window_budget: self.window_budget,
+        }
+    }
+}
+
+impl Step for SortSpillDecompress {
+    type Input = SortPhase1Event;
+    type Outputs = Single<SortPhase2Event>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "SortSpillDecompress",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::None],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // 1. Drain held output first.
+        if !self.flush_held(ctx) {
+            return Ok(StepOutcome::Contention);
+        }
+
+        // 2. Pop one input event, register if SpillReady, forward all.
+        if let Some(event) = ctx.input.pop() {
+            let forwarded = match event {
+                SortPhase1Event::SpillReady { slot, path, records_ingested_so_far } => {
+                    self.registry.lock().push(RegisteredSpill { slot: Arc::clone(&slot) });
+                    SortPhase2Event::SpillReady { slot, path, records_ingested_so_far }
+                }
+                SortPhase1Event::MemoryChunk { chunk, records_ingested_so_far } => {
+                    SortPhase2Event::MemoryChunk { chunk, records_ingested_so_far }
+                }
+                SortPhase1Event::AllAnnounced { slot_count, memory_chunk_count, total_records } => {
+                    SortPhase2Event::AllAnnounced { slot_count, memory_chunk_count, total_records }
+                }
+            };
+            let _ = self.push_or_hold(ctx, forwarded);
+            return Ok(StepOutcome::Progress);
+        }
+
+        // 3. Greedy slot-fill, admission-controlled by --merge-threads.
+        // `_permit` stays live across the `try_fill_some_slot` call — let-chain
+        // bindings are in scope for the conditions that follow them — and drops at
+        // the end of this `if` whichever way the fill goes (and on the `?` early
+        // return), releasing the count.
+        if let Some(_permit) = try_acquire(&self.active, self.max_decompress)
+            && self.try_fill_some_slot()?
+        {
+            return Ok(StepOutcome::Progress);
+        }
+
+        // 4. No fill work.
+        let any_alive = self
+            .snapshot_registry()
+            .iter()
+            .any(|slot| !slot.queue_eof.load(std::sync::atomic::Ordering::Acquire));
+        if any_alive {
+            return Ok(StepOutcome::Contention);
+        }
+
+        if ctx.input.is_drained() {
+            return Ok(StepOutcome::Finished);
+        }
+        Ok(StepOutcome::NoProgress)
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fgumi-pipeline-io/src/sort/spill_decompress/tests.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_decompress/tests.rs
@@ -1,0 +1,205 @@
+use super::*;
+use std::io::BufReader;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use fgumi_sort::{SortMergeSlot, SpillCodec};
+
+/// A resolved-to-zero output budget must not disable the reorder-window byte cap:
+/// `bp_reorder_admits` treats `window_budget == 0` as unlimited, so `new()`
+/// substitutes the default cap (mirroring the legacy `effective_limit`
+/// 0-normalization). A nonzero budget passes through unchanged.
+#[test]
+fn zero_output_byte_limit_normalizes_reorder_window() {
+    let zero = SortSpillDecompress::new(0, SortDecompressTuning::default());
+    assert_eq!(zero.window_budget, DEFAULT_REORDER_WINDOW_BYTES);
+    assert_ne!(zero.window_budget, 0, "reorder window must stay bounded on a zero budget");
+
+    let nonzero = SortSpillDecompress::new(4 * 1024 * 1024, SortDecompressTuning::default());
+    assert_eq!(nonzero.window_budget, 4 * 1024 * 1024, "nonzero budget passes through unchanged");
+}
+
+#[test]
+fn admission_counter_caps_concurrency() {
+    let active = Arc::new(AtomicUsize::new(0));
+    let max = Some(2usize);
+    // Acquire up to the cap; hold the permits so the count accumulates.
+    let p1 = try_acquire(&active, max);
+    assert!(p1.is_some());
+    let p2 = try_acquire(&active, max);
+    assert!(p2.is_some());
+    assert!(try_acquire(&active, max).is_none()); // at cap
+    drop(p1); // releasing one permit frees a slot
+    assert!(try_acquire(&active, max).is_some()); // freed one slot
+    drop(p2);
+}
+
+#[test]
+fn admission_counter_unbounded_when_none() {
+    let active = Arc::new(AtomicUsize::new(0));
+    for _ in 0..1000 {
+        assert!(try_acquire(&active, None).is_some());
+    }
+}
+
+/// Under real thread contention, the shared counter never exceeds the cap and
+/// every acquired permit is released via `DecompressPermit::drop` (the counter
+/// returns to zero). Mirrors how `new_worker_copy` clones share one `active`.
+#[test]
+fn admission_counter_concurrent_never_exceeds_cap() {
+    use std::thread;
+
+    let active = Arc::new(AtomicUsize::new(0));
+    let cap = 3usize;
+    let handles: Vec<_> = (0..16)
+        .map(|_| {
+            let active = Arc::clone(&active);
+            thread::spawn(move || {
+                for _ in 0..5000 {
+                    // The returned permit IS the ownership token; its Drop at the
+                    // end of the block exercises the decrement.
+                    if let Some(_permit) = try_acquire(&active, Some(cap)) {
+                        // Occupancy observed while holding a permit can never
+                        // exceed the cap: `try_acquire` only increments past a
+                        // CAS that checks `cur < cap`, and the count only drops
+                        // otherwise.
+                        let occupancy = active.load(Ordering::Acquire);
+                        assert!(occupancy <= cap, "occupancy {occupancy} exceeded cap {cap}");
+                    }
+                }
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().expect("worker thread panicked");
+    }
+    assert_eq!(active.load(Ordering::Acquire), 0, "every permit must be released on drop");
+}
+
+// Most coverage for the decompress step lives in sort/tests.rs (the oracle parity
+// suite drives the whole chain). This unit test pins the emptiest-first refill
+// ordering in isolation.
+
+#[test]
+fn emptiest_first_order_sorts_by_fifo_len_ascending() {
+    let mk = |file_id: u32, nblocks: usize| {
+        let s = Arc::new(SortMergeSlot::new(
+            file_id,
+            BufReader::new(tempfile::tempfile().expect("tempfile")),
+            SpillCodec::Bgzf,
+        ));
+        for _ in 0..nblocks {
+            s.decompressed.lock().expect("decompressed lock").push_back(vec![0u8]);
+        }
+        s
+    };
+    // FIFO depths 5, 1, 3 ⇒ most-starved-first visit order is indices 1, 2, 0.
+    let slots = vec![mk(0, 5), mk(1, 1), mk(2, 3)];
+    assert_eq!(SortSpillDecompress::emptiest_first_order(&slots), vec![1, 2, 0]);
+}
+
+/// A poisoned `reader` mutex (a fill worker panicked while holding the lock)
+/// must fail the slot CLOSED — `try_fill_*_slot` returns `Err` and sets
+/// `decomp_error`/`queue_eof` — rather than being swallowed as `WouldBlock` and
+/// skipped forever. If it were skipped, `queue_eof` would never be set and
+/// `SortMerge` would spin on `Contention` and deadlock instead of surfacing the
+/// panic. Regression test for the poisoned-vs-would-block conflation.
+#[test]
+fn poisoned_reader_lock_fails_closed_rather_than_hanging() {
+    let make_poisoned_slot = || {
+        let slot = Arc::new(SortMergeSlot::new(
+            0,
+            BufReader::new(tempfile::tempfile().expect("tempfile")),
+            SpillCodec::Bgzf,
+        ));
+        let holder = Arc::clone(&slot);
+        // Panic while holding the reader lock; joining the panicked thread leaves
+        // the mutex poisoned (mirrors a fill worker dying mid-read).
+        let _ = std::thread::spawn(move || {
+            let _guard = holder.reader.lock().expect("acquire reader lock");
+            panic!("simulated fill-worker panic under the reader lock");
+        })
+        .join();
+        assert!(slot.reader.is_poisoned(), "precondition: reader mutex is poisoned");
+        slot
+    };
+
+    let mut dec = SortSpillDecompress::new(4 * 1024 * 1024, SortDecompressTuning::default());
+
+    // Inline path.
+    let inline_slot = make_poisoned_slot();
+    let inline = dec.try_fill_inline_slot(&inline_slot);
+    assert!(inline.is_err(), "inline path: poisoned reader must return Err, not Ok(false)");
+    assert!(inline_slot.decomp_error.load(Ordering::Acquire), "inline: decomp_error set");
+    assert!(inline_slot.queue_eof.load(Ordering::Acquire), "inline: queue_eof set");
+
+    // Block-parallel path.
+    let bp_slot = make_poisoned_slot();
+    let bp = dec.try_fill_block_parallel_slot(&bp_slot);
+    assert!(bp.is_err(), "block-parallel path: poisoned reader must return Err, not skip");
+    assert!(bp_slot.decomp_error.load(Ordering::Acquire), "bp: decomp_error set");
+    assert!(bp_slot.queue_eof.load(Ordering::Acquire), "bp: queue_eof set");
+}
+
+/// Slots that already signalled `queue_eof` are dropped from the refill scan.
+///
+/// The registry is append-only, so without this filter a drained slot stays in
+/// the scan for the rest of the run: every dispatch clones its `Arc`, takes its
+/// FIFO lock to sort, and is then rejected immediately by the `queue_eof` guard
+/// in `try_fill_*_slot`. With many spill files that drained tail dominates the
+/// scan. Filtering is scheduling-only — an EOF slot can never progress — so it
+/// changes no output.
+#[test]
+fn emptiest_first_order_skips_slots_that_reached_eof() {
+    use std::sync::atomic::Ordering;
+
+    let mk = |file_id: u32, nblocks: usize, eof: bool| {
+        let s = Arc::new(SortMergeSlot::new(
+            file_id,
+            BufReader::new(tempfile::tempfile().expect("tempfile")),
+            SpillCodec::Bgzf,
+        ));
+        for _ in 0..nblocks {
+            s.decompressed.lock().expect("decompressed lock").push_back(vec![0u8]);
+        }
+        if eof {
+            s.queue_eof.store(true, Ordering::Release);
+        }
+        s
+    };
+
+    // Slot 1 is the emptiest but has drained; it must not appear at all.
+    let slots = vec![mk(0, 5, false), mk(1, 0, true), mk(2, 3, false)];
+    assert_eq!(
+        SortSpillDecompress::emptiest_first_order(&slots),
+        vec![2, 0],
+        "drained slots are skipped; the rest stay most-starved-first"
+    );
+
+    // Every slot drained ⇒ nothing to scan.
+    let all_done = vec![mk(0, 0, true), mk(1, 0, true)];
+    assert!(
+        SortSpillDecompress::emptiest_first_order(&all_done).is_empty(),
+        "a fully drained registry yields an empty scan order"
+    );
+
+    // No slot drained ⇒ unchanged from the pre-filter behaviour.
+    let none_done = vec![mk(0, 5, false), mk(1, 1, false), mk(2, 3, false)];
+    assert_eq!(SortSpillDecompress::emptiest_first_order(&none_done), vec![1, 2, 0]);
+}
+
+/// The `block_batch` clamp is the sibling of the `window_budget` normalization
+/// already pinned by `zero_output_byte_limit_normalizes_reorder_window`. A
+/// `block_batch` of 0 would declare a phantom EOF after reading nothing on the
+/// inline path — silent record loss — so it is clamped to at least one block.
+#[test]
+fn zero_block_batch_is_clamped_to_one() {
+    let tuning = SortDecompressTuning { block_batch: 0, ..Default::default() };
+    let clamped = SortSpillDecompress::new(4 * 1024 * 1024, tuning);
+    assert_eq!(clamped.tuning.block_batch, 1, "a zero block_batch must be clamped, not honoured");
+
+    // A sane value passes through untouched.
+    let tuning = SortDecompressTuning { block_batch: 8, ..Default::default() };
+    let passthrough = SortSpillDecompress::new(4 * 1024 * 1024, tuning);
+    assert_eq!(passthrough.tuning.block_batch, 8, "a nonzero block_batch is honoured");
+}

--- a/crates/fgumi-pipeline-io/src/sort/spill_gather.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_gather.rs
@@ -1,0 +1,337 @@
+//! `SpillGather` — first step of the block-parallel spill-write split
+//! (`SpillGather` → `SpillBlockCompress` → `SpillWrite`), replacing the monolithic
+//! single-worker `CompressSpill`.
+//!
+//! `SpillGather` (`Serial`) consumes the [`SortChunkEvent`]s `SortBuffer`
+//! emits and fans each `Spill` chunk into record-aligned **raw** (uncompressed)
+//! [`SpillBlockEvent::Block`]s of ≤`BGZF_MAX_BLOCK_SIZE`, so the downstream
+//! `Parallel` `SpillBlockCompress` can compress them across the framework pool. The
+//! in-memory `Residual` and the terminal `AllAnnounced` pass straight through.
+//!
+//! # Ordinal minting
+//!
+//! The step mints `ordinal` monotonically across **every** emitted item — every
+//! block of every file plus the passthrough `Residual` / `AllAnnounced` — so the
+//! output stream is dense and gap-free. That is what lets the framework's
+//! single-cursor `ByItemOrdinal` reorder deliver the blocks to the `Serial`
+//! `SpillWrite` in order without any per-file ordering primitive. Because
+//! `SortBuffer` (Serial) emits `Spill` events one-at-a-time in `seq` order and
+//! this step (Serial) drains them in order, each file's blocks are contiguous in
+//! the ordinal stream.
+//!
+//! # Bounded memory (incremental framing)
+//!
+//! A spill chunk is large (≈ the per-thread sort budget). Framing it **all** into
+//! `pending` at once would duplicate the whole chunk in memory and then drain
+//! that copy slowly through the byte-bounded queue while `SortBuffer` races ahead
+//! filling the next multi-GB buffer — a ~2× peak-RSS blow-up. Instead the chunk
+//! is held in `active` and framed **incrementally**: each `try_run` frames at most
+//! `MAX_EVENTS_PER_LOCK` blocks into `pending`, drains them, and only frees the
+//! source chunk once its last record is framed. `pending` therefore holds ≤ a
+//! handful of 64 KiB blocks (~½ MiB) regardless of chunk size, and the chunk
+//! drains as fast as `SpillBlockCompress` consumes blocks.
+
+use std::collections::VecDeque;
+use std::io;
+
+use fgumi_bgzf::BGZF_MAX_BLOCK_SIZE;
+use fgumi_sort::frame_keyed_record_into;
+
+use crate::sort::protocol::{MemoryChunkErased, SortChunkEvent, SpillBlockEvent};
+use fgumi_pipeline_core::{
+    HeldRetry, Unpushed,
+    held::HeldSlot,
+    outputs::OrderedBytesSingle,
+    queues::QueueSpec,
+    reorder::BranchOrdering,
+    step::{DetachedGroup, Step, StepCtx, StepKind, StepOutcome, StepProfile},
+};
+
+/// Max staged events flushed to the output per `try_run` invocation. Matches
+/// `SortBuffer::MAX_EVENTS_PER_LOCK` so a single fanned chunk drains in bounded
+/// slices rather than holding the step lock for the whole spill.
+const MAX_EVENTS_PER_LOCK: usize = 8;
+
+/// Frame the `i`th record of a type-erased chunk into `out` in the spill layout
+/// `[key?][u32 LE len][record]`, dispatching over the sort-key variant.
+fn frame_record_at(chunk: &MemoryChunkErased, i: usize, out: &mut Vec<u8>) -> io::Result<()> {
+    match chunk {
+        MemoryChunkErased::Coordinate(c) => {
+            frame_keyed_record_into(out, c.key_at(i), c.record_bytes(i))
+        }
+        MemoryChunkErased::QuerynameLex(c) => {
+            frame_keyed_record_into(out, c.key_at(i), c.record_bytes(i))
+        }
+        MemoryChunkErased::QuerynameNatural(c) => {
+            frame_keyed_record_into(out, c.key_at(i), c.record_bytes(i))
+        }
+        MemoryChunkErased::TemplateCoordinate(c) => c.frame_record_into(i, out),
+    }
+}
+
+/// Frame records `[start..)` of `chunk` into a single block `out` of at most
+/// `block_size` bytes, returning the index of the next un-framed record (==
+/// `chunk.len()` when the chunk is exhausted).
+///
+/// A record is never split across blocks: a record that would push a **non-empty**
+/// block past `block_size` is left for the next block. The sole exception is a
+/// single record larger than `block_size`, which forms its own oversized block
+/// (BAM long reads can exceed 64 KiB; the codec re-blocks/​frames it safely,
+/// matching the streaming `SyncSpillWriter`, so this is not an error).
+fn frame_one_block(
+    chunk: &MemoryChunkErased,
+    start: usize,
+    block_size: usize,
+    out: &mut Vec<u8>,
+) -> io::Result<usize> {
+    let len = chunk.len();
+    let mut i = start;
+    while i < len {
+        let before = out.len();
+        frame_record_at(chunk, i, out)?;
+        if before != 0 && out.len() > block_size {
+            // This record overflowed a non-empty block — roll it back so it
+            // starts the next block, and finish this one.
+            out.truncate(before);
+            break;
+        }
+        i += 1;
+        if out.len() >= block_size {
+            // Block full (the record fit exactly, or was a lone oversized record
+            // framed into an empty block).
+            break;
+        }
+    }
+    Ok(i)
+}
+
+/// Frame an entire chunk into blocks (convenience for tests; production frames
+/// incrementally via [`SpillGather::produce_blocks`]). Returns one `Vec<u8>`
+/// per block; an empty chunk yields no blocks.
+#[cfg(test)]
+fn frame_chunk_into_blocks(
+    chunk: &MemoryChunkErased,
+    block_size: usize,
+) -> io::Result<Vec<Vec<u8>>> {
+    let mut blocks: Vec<Vec<u8>> = Vec::new();
+    let len = chunk.len();
+    let mut idx = 0;
+    while idx < len {
+        let mut block = Vec::with_capacity(block_size + 1024);
+        idx = frame_one_block(chunk, idx, block_size, &mut block)?;
+        if !block.is_empty() {
+            blocks.push(block);
+        }
+    }
+    Ok(blocks)
+}
+
+/// One spill chunk being framed incrementally into blocks across `try_run` calls.
+struct ActiveSpill {
+    /// The source sorted chunk, held until its last record is framed.
+    chunk: MemoryChunkErased,
+    /// Index of the next un-framed record.
+    next_idx: usize,
+    /// Logical spill index (the eventual slot `file_id`).
+    file_id: u32,
+    records_ingested_so_far: u64,
+}
+
+/// `Serial` step that fans sorted spill chunks into raw blocks for `SpillBlockCompress`.
+pub struct SpillGather {
+    /// The spill chunk currently being framed incrementally (`None` between
+    /// chunks). Holding it here — rather than materializing all its blocks into
+    /// `pending` — is what keeps peak memory bounded.
+    active: Option<ActiveSpill>,
+    /// Staged block / passthrough events awaiting output. Bounded to ≤
+    /// `MAX_EVENTS_PER_LOCK` blocks because framing only tops it up when it is
+    /// already drained.
+    pending: VecDeque<SpillBlockEvent>,
+    /// Monotonic ordinal minted across every emitted item (dense, gap-free).
+    next_ordinal: u64,
+    held: HeldSlot<Unpushed<SpillBlockEvent>>,
+    /// Raw-block size threshold (records are cut into blocks of ≤ this many bytes).
+    block_size: usize,
+    output_byte_limit: u64,
+}
+
+impl SpillGather {
+    /// Build a `SpillGather`. `output_byte_limit` byte-bounds the block-event
+    /// output queue (its `Block` / `Residual` variants retain bytes/records).
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self {
+            active: None,
+            pending: VecDeque::new(),
+            next_ordinal: 0,
+            held: HeldSlot::new(),
+            block_size: BGZF_MAX_BLOCK_SIZE,
+            output_byte_limit,
+        }
+    }
+
+    /// Take the next dense ordinal.
+    fn next_ordinal(&mut self) -> u64 {
+        let o = self.next_ordinal;
+        self.next_ordinal += 1;
+        o
+    }
+
+    /// `StepCtx`-free core: stage one input event. A `Spill` chunk is parked in
+    /// `active` for incremental framing (no blocks produced yet); `Residual` /
+    /// `AllAnnounced` are cheap and pushed straight to `pending`. Caller
+    /// guarantees `active` is `None` (the previous chunk fully framed).
+    fn stage_event(&mut self, event: SortChunkEvent) {
+        match event {
+            SortChunkEvent::Spill { seq, chunk, records_ingested_so_far } => {
+                // `SortBuffer` only emits `Spill` for a non-empty buffer; skip an
+                // (unexpected) empty chunk rather than open a zero-block file with
+                // no `is_last_in_file` terminator.
+                if chunk.is_empty() {
+                    return;
+                }
+                self.active =
+                    Some(ActiveSpill { chunk, next_idx: 0, file_id: seq, records_ingested_so_far });
+            }
+            SortChunkEvent::Residual { chunk, records_ingested_so_far } => {
+                let ordinal = self.next_ordinal();
+                self.pending.push_back(SpillBlockEvent::Residual {
+                    ordinal,
+                    chunk,
+                    records_ingested_so_far,
+                });
+            }
+            SortChunkEvent::AllAnnounced { slot_count, memory_chunk_count, total_records } => {
+                let ordinal = self.next_ordinal();
+                self.pending.push_back(SpillBlockEvent::AllAnnounced {
+                    ordinal,
+                    slot_count,
+                    memory_chunk_count,
+                    total_records,
+                });
+            }
+        }
+    }
+
+    /// Frame up to `MAX_EVENTS_PER_LOCK` blocks of the `active` chunk into
+    /// `pending`, minting dense ordinals and flagging the final block
+    /// `is_last_in_file`. Frees the chunk (`active = None`) once its last record
+    /// is framed. No-op when there is no active chunk.
+    ///
+    /// # Errors
+    ///
+    /// Propagates framing errors (e.g. a record too large for the `u32` length
+    /// prefix).
+    fn produce_blocks(&mut self) -> io::Result<()> {
+        let block_size = self.block_size;
+        while self.pending.len() < MAX_EVENTS_PER_LOCK {
+            // Frame one block, scoping the borrow of `active` so `next_ordinal`
+            // (a `&mut self` method) can run afterward.
+            let framed = {
+                let Some(active) = self.active.as_ref() else { return Ok(()) };
+                let len = active.chunk.len();
+                let mut bytes = Vec::with_capacity(block_size + 1024);
+                let next = frame_one_block(&active.chunk, active.next_idx, block_size, &mut bytes)?;
+                (bytes, next, next >= len, active.file_id, active.records_ingested_so_far)
+            };
+            let (bytes, next_idx, is_last, file_id, records_ingested_so_far) = framed;
+            let ordinal = self.next_ordinal();
+            self.pending.push_back(SpillBlockEvent::Block {
+                ordinal,
+                file_id,
+                is_last_in_file: is_last,
+                records_ingested_so_far,
+                bytes,
+            });
+            if is_last {
+                self.active = None;
+                return Ok(());
+            }
+            // Advance the cursor for the next block.
+            self.active.as_mut().expect("active present (not last)").next_idx = next_idx;
+        }
+        Ok(())
+    }
+
+    fn flush_held(&mut self, ctx: &mut StepCtx<'_, Self>) -> bool {
+        !matches!(ctx.outputs.retry_held(&mut self.held), HeldRetry::StillHeld)
+    }
+
+    /// Push up to `MAX_EVENTS_PER_LOCK` staged events, parking the first that
+    /// can't be pushed in `held`. Caller guarantees `held` is empty.
+    fn emit_pending(&mut self, ctx: &mut StepCtx<'_, Self>) -> StepOutcome {
+        let mut emitted = 0usize;
+        while emitted < MAX_EVENTS_PER_LOCK {
+            let Some(event) = self.pending.pop_front() else { break };
+            if let Err(unpushed) = ctx.outputs.push(event) {
+                self.held.put(unpushed);
+                return StepOutcome::Progress;
+            }
+            emitted += 1;
+        }
+        if emitted > 0 { StepOutcome::Progress } else { StepOutcome::NoProgress }
+    }
+}
+
+impl Step for SpillGather {
+    type Input = SortChunkEvent;
+    type Outputs = OrderedBytesSingle<SpillBlockEvent>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "SpillGather",
+            // Off-pool on the coordination driver (N+2): the serial spill framing
+            // + monotonic ordinal minting runs on the dedicated coordination
+            // thread instead of a pool worker, so it never starves the parallel
+            // spill compressors. Detached collapses `ByItemOrdinal` to `None`
+            // exactly as `Serial` did (transport-identical).
+            kind: StepKind::Detached,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn detached_group(&self) -> DetachedGroup {
+        DetachedGroup::Shared(crate::sort::SORT_COORD_GROUP)
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if !self.flush_held(ctx) {
+            return Ok(StepOutcome::Contention);
+        }
+
+        // Drain staged events before producing/ingesting more — bounds peak memory.
+        if !self.pending.is_empty() {
+            return Ok(self.emit_pending(ctx));
+        }
+
+        // Continue framing the active chunk (incrementally), if any.
+        if self.active.is_some() {
+            self.produce_blocks()?;
+            return Ok(self.emit_pending(ctx));
+        }
+
+        // No active chunk and nothing pending — ingest the next event.
+        if let Some(event) = ctx.input.pop() {
+            self.stage_event(event);
+            // Frame the first blocks of a freshly-parked chunk so we make progress.
+            if self.active.is_some() {
+                self.produce_blocks()?;
+            }
+            if !self.pending.is_empty() {
+                return Ok(self.emit_pending(ctx));
+            }
+            return Ok(StepOutcome::Progress);
+        }
+
+        // Drained: pending is empty and no chunk is mid-framing (checked above).
+        if ctx.input.is_drained() {
+            return Ok(StepOutcome::Finished);
+        }
+        Ok(StepOutcome::NoProgress)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fgumi-pipeline-io/src/sort/spill_gather/tests.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_gather/tests.rs
@@ -1,0 +1,323 @@
+//! Unit tests for `SpillGather`'s `StepCtx`-free core: chunk fan-out into raw
+//! blocks (`frame_chunk_into_blocks`) and event staging (`stage_event`).
+
+use super::*;
+use crate::sort::protocol::MemoryChunkErased;
+use fgumi_sort::{InMemoryChunk, RawCoordinateKey};
+use proptest::prelude::*;
+
+/// Build a coordinate chunk from raw payloads with distinct keys, so the framed
+/// blocks exercise key serialization (`RawCoordinateKey` is embedded, so no key
+/// prefix is written — but the chunk path is still the production one).
+fn coord_chunk(payloads: Vec<Vec<u8>>) -> MemoryChunkErased {
+    let recs = payloads
+        .into_iter()
+        .enumerate()
+        .map(|(i, b)| (RawCoordinateKey { sort_key: i as u64 }, b))
+        .collect();
+    MemoryChunkErased::Coordinate(InMemoryChunk::from_owned_records(recs))
+}
+
+/// Concatenate the framed-record bytes of all blocks (drops the per-block
+/// boundaries) — the decompressed-stream-equivalent the readers see.
+fn concat(blocks: &[Vec<u8>]) -> Vec<u8> {
+    blocks.iter().flat_map(|b| b.iter().copied()).collect()
+}
+
+/// Drive `SpillGather` over a sequence of input events exactly as `try_run`
+/// does — stage each event, then fully frame any active chunk (draining produced
+/// blocks) before staging the next — and return every emitted event in order.
+/// This preserves the dense-ordinal invariant (a chunk is fully framed, and its
+/// block ordinals minted, before the next event is staged).
+fn drive(step: &mut SpillGather, events: Vec<SortChunkEvent>) -> Vec<SpillBlockEvent> {
+    let mut out = Vec::new();
+    for event in events {
+        step.stage_event(event);
+        // Frame the active chunk to completion, collecting blocks as we go.
+        while step.active.is_some() {
+            step.produce_blocks().unwrap();
+            while let Some(ev) = step.pending.pop_front() {
+                out.push(ev);
+            }
+        }
+        // Drain any passthrough (Residual / AllAnnounced) events.
+        while let Some(ev) = step.pending.pop_front() {
+            out.push(ev);
+        }
+    }
+    out
+}
+
+#[test]
+fn frame_empty_chunk_yields_no_blocks() {
+    let chunk = coord_chunk(Vec::new());
+    let blocks = frame_chunk_into_blocks(&chunk, BGZF_MAX_BLOCK_SIZE).unwrap();
+    assert!(blocks.is_empty(), "empty chunk must yield zero blocks");
+}
+
+#[test]
+fn frame_cuts_blocks_at_threshold_without_splitting_records() {
+    // 10 records of 100 payload bytes each; embedded key adds only the 4-byte
+    // length prefix → 104 framed bytes/record. A 250-byte block threshold cuts
+    // *before* the record that would exceed 250, so each block holds 2 records
+    // (2×104=208 ≤ 250; a 3rd would be 312 > 250) → 5 blocks.
+    let chunk = coord_chunk((0u8..10).map(|i| vec![i; 100]).collect());
+    let blocks = frame_chunk_into_blocks(&chunk, 250).unwrap();
+    assert_eq!(blocks.len(), 5, "250-byte threshold must pack 2 records/block over 10 records");
+    // Every block stays within the threshold and holds a whole number of
+    // 104-byte records (no record split).
+    for b in &blocks {
+        assert!(b.len() <= 250, "block exceeded threshold: {} bytes", b.len());
+        assert_eq!(b.len() % 104, 0, "block boundary split a record: {} bytes", b.len());
+    }
+    // Reassembling the blocks reproduces a single 10-record stream.
+    assert_eq!(concat(&blocks).len(), 10 * 104);
+}
+
+proptest! {
+    /// The "no record split, ≤ threshold, exact reconstruction" packing invariant
+    /// of `frame_chunk_into_blocks` holds for arbitrary record sizes and
+    /// thresholds — far more of the space than the hand-picked cases above.
+    #[test]
+    fn frame_chunk_into_blocks_packing_invariant(
+        payloads in prop::collection::vec(prop::collection::vec(any::<u8>(), 0..40), 0..30),
+        threshold in 1usize..512,
+    ) {
+        let chunk = coord_chunk(payloads.clone());
+        let blocks = frame_chunk_into_blocks(&chunk, threshold).unwrap();
+
+        // Content is threshold-independent: block boundaries move, bytes do not.
+        // Compare against both the all-in-one framing and the one-record-per-block
+        // framing (threshold 1), pinning exact reconstruction of the framed stream.
+        let one_block = frame_chunk_into_blocks(&chunk, BGZF_MAX_BLOCK_SIZE).unwrap();
+        let per_record = frame_chunk_into_blocks(&chunk, 1).unwrap();
+        prop_assert_eq!(concat(&blocks), concat(&one_block));
+        prop_assert_eq!(concat(&blocks), concat(&per_record));
+
+        // Empty chunk → no blocks; any record (even a zero-length payload, which
+        // still frames its length prefix) → at least one, and never an empty one.
+        prop_assert_eq!(blocks.is_empty(), payloads.is_empty());
+        prop_assert!(blocks.iter().all(|b| !b.is_empty()), "no empty blocks");
+
+        // No record is split: a block may exceed `threshold` only when a single
+        // record is itself larger than it (the "cut before exceeding" rule can't
+        // shrink one record), so every block is bounded by
+        // `max(threshold, largest single framed record)`.
+        let max_record = per_record.iter().map(Vec::len).max().unwrap_or(0);
+        let bound = threshold.max(max_record);
+        for b in &blocks {
+            prop_assert!(b.len() <= bound, "block {} exceeds bound {bound}", b.len());
+        }
+    }
+}
+
+#[test]
+fn frame_one_block_when_under_threshold() {
+    let chunk = coord_chunk((0u8..5).map(|i| vec![i; 100]).collect());
+    let blocks = frame_chunk_into_blocks(&chunk, BGZF_MAX_BLOCK_SIZE).unwrap();
+    assert_eq!(blocks.len(), 1, "5 small records fit one block");
+    assert_eq!(blocks[0].len(), 5 * 104);
+}
+
+#[test]
+fn stage_spill_mints_dense_ordinals_and_marks_last_block() {
+    let mut step = SpillGather::new(1 << 20);
+    step.block_size = 250; // force several blocks
+    let chunk = coord_chunk((0u8..10).map(|i| vec![i; 100]).collect());
+    let events = drive(
+        &mut step,
+        vec![SortChunkEvent::Spill { seq: 3, chunk, records_ingested_so_far: 10 }],
+    );
+
+    assert!(events.len() > 1, "expected multiple block events");
+    // Ordinals are dense 0..n.
+    for (i, ev) in events.iter().enumerate() {
+        assert_eq!(ev.ordinal(), i as u64, "ordinal not dense at index {i}");
+    }
+    // Exactly the final block is flagged is_last_in_file; all carry file_id=3.
+    for (i, ev) in events.iter().enumerate() {
+        let SpillBlockEvent::Block { file_id, is_last_in_file, records_ingested_so_far, .. } = ev
+        else {
+            panic!("expected Block event");
+        };
+        assert_eq!(*file_id, 3);
+        assert_eq!(*records_ingested_so_far, 10);
+        assert_eq!(*is_last_in_file, i == events.len() - 1, "is_last wrong at {i}");
+    }
+    // The chunk was freed once fully framed.
+    assert!(step.active.is_none(), "active chunk must be cleared after framing");
+}
+
+#[test]
+fn produce_blocks_keeps_pending_bounded() {
+    // With many small records and a tiny block size, a single produce_blocks call
+    // must not materialize the whole chunk — it tops up at most
+    // MAX_EVENTS_PER_LOCK blocks.
+    let mut step = SpillGather::new(1 << 20);
+    step.block_size = 120; // ~1 record/block over 104-byte records
+    let chunk = coord_chunk((0u8..100).map(|i| vec![i; 100]).collect());
+    step.stage_event(SortChunkEvent::Spill { seq: 0, chunk, records_ingested_so_far: 100 });
+    step.produce_blocks().unwrap();
+    assert_eq!(step.pending.len(), 8, "one produce call tops up to MAX_EVENTS_PER_LOCK blocks");
+    assert!(step.active.is_some(), "chunk still mid-framing (not fully drained in one call)");
+}
+
+#[test]
+fn stage_residual_and_announced_pass_through_with_ordinals() {
+    let mut step = SpillGather::new(1 << 20);
+    // A spill (2 small records → 1 block, ordinal 0), then residual, then
+    // AllAnnounced — ordinals must stay dense across the variant boundary, with
+    // the spill's block ordinal minted *before* the later events (the chunk is
+    // fully framed before the next event is staged).
+    let events = drive(
+        &mut step,
+        vec![
+            SortChunkEvent::Spill {
+                seq: 0,
+                chunk: coord_chunk(vec![vec![1u8; 10], vec![2u8; 10]]),
+                records_ingested_so_far: 2,
+            },
+            SortChunkEvent::Residual {
+                chunk: coord_chunk(vec![vec![3u8; 10]]),
+                records_ingested_so_far: 3,
+            },
+            SortChunkEvent::AllAnnounced { slot_count: 1, memory_chunk_count: 1, total_records: 3 },
+        ],
+    );
+
+    let ords: Vec<u64> = events.iter().map(SpillBlockEvent::ordinal).collect();
+    assert_eq!(ords, vec![0, 1, 2], "ordinals must be dense across variants");
+
+    assert!(matches!(events[0], SpillBlockEvent::Block { is_last_in_file: true, .. }));
+    assert!(matches!(events[1], SpillBlockEvent::Residual { .. }));
+    assert!(matches!(
+        events[2],
+        SpillBlockEvent::AllAnnounced {
+            slot_count: 1,
+            memory_chunk_count: 1,
+            total_records: 3,
+            ..
+        }
+    ));
+}
+
+// ── Step wiring + ordinal minting ────────────────────────────────────────────
+
+#[test]
+fn profile_runs_off_pool_on_the_coordination_driver() {
+    let step = SpillGather::new(4096);
+    let profile = step.profile();
+    assert_eq!(profile.name, "SpillGather");
+    // Detached keeps the serial framing + ordinal minting off a pool worker, so
+    // it cannot starve the parallel spill compressors downstream.
+    assert_eq!(profile.kind, StepKind::Detached);
+    assert!(!profile.sticky);
+    assert_eq!(profile.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    match profile.output_queues.as_slice() {
+        [QueueSpec::ByteBounded { limit_bytes }] => assert_eq!(*limit_bytes, 4096),
+        other => panic!("expected one byte-bounded queue, got {other:?}"),
+    }
+    assert_eq!(step.detached_group(), DetachedGroup::Shared(crate::sort::SORT_COORD_GROUP));
+}
+
+#[test]
+fn ordinals_are_dense_and_monotonic_across_event_kinds() {
+    // Downstream `ByItemOrdinal` reordering depends on a gap-free sequence, and
+    // the counter is shared by every emitted event, not per-variant.
+    let mut step = SpillGather::new(1 << 20);
+
+    step.stage_event(SortChunkEvent::Residual {
+        chunk: coord_chunk(vec![vec![1u8; 8]]),
+        records_ingested_so_far: 1,
+    });
+    step.stage_event(SortChunkEvent::AllAnnounced {
+        slot_count: 1,
+        memory_chunk_count: 1,
+        total_records: 1,
+    });
+    step.stage_event(SortChunkEvent::Residual {
+        chunk: coord_chunk(vec![vec![2u8; 8]]),
+        records_ingested_so_far: 2,
+    });
+
+    let ordinals: Vec<u64> = step
+        .pending
+        .iter()
+        .map(|e| match e {
+            SpillBlockEvent::Block { ordinal, .. }
+            | SpillBlockEvent::Residual { ordinal, .. }
+            | SpillBlockEvent::AllAnnounced { ordinal, .. } => *ordinal,
+        })
+        .collect();
+    assert_eq!(ordinals, vec![0, 1, 2], "ordinals must be dense across variants");
+    assert_eq!(step.next_ordinal, 3);
+}
+
+#[test]
+fn an_empty_spill_chunk_is_skipped_rather_than_opening_a_file() {
+    // A zero-block file would never receive an `is_last_in_file` terminator, so
+    // `SpillWrite` would be left with a dangling open file forever.
+    let mut step = SpillGather::new(1 << 20);
+    step.stage_event(SortChunkEvent::Spill {
+        seq: 0,
+        chunk: coord_chunk(Vec::new()),
+        records_ingested_so_far: 0,
+    });
+    assert!(step.active.is_none(), "an empty chunk must not become the active spill");
+    assert!(step.pending.is_empty(), "and must emit nothing");
+    assert_eq!(step.next_ordinal, 0, "and must not consume an ordinal");
+}
+
+#[test]
+fn a_non_empty_spill_chunk_becomes_active_without_emitting_yet() {
+    let mut step = SpillGather::new(1 << 20);
+    step.stage_event(SortChunkEvent::Spill {
+        seq: 7,
+        chunk: coord_chunk(vec![vec![3u8; 32], vec![4u8; 32]]),
+        records_ingested_so_far: 2,
+    });
+    let active = step.active.as_ref().expect("chunk must be parked for incremental framing");
+    assert_eq!(active.file_id, 7, "file_id comes from the spill seq, not write order");
+    assert_eq!(active.next_idx, 0);
+    assert!(step.pending.is_empty(), "framing happens in produce_blocks, not stage_event");
+}
+
+/// The `TemplateCoordinate` variant is framed by a *different* function than the
+/// other three: `frame_record_at` routes it to `c.frame_record_into`, while
+/// `Coordinate` / `QuerynameLex` / `QuerynameNatural` share `frame_keyed_record_into`.
+/// Every other test here uses `coord_chunk`, so that branch never ran. A layout
+/// divergence produces spill files that `SortMerge` misreads — wrong output, not a
+/// crash — so the fourth variant needs its own framing coverage.
+#[test]
+fn template_coordinate_chunks_frame_through_their_own_path() {
+    use fgumi_sort::{TemplateKey24, TemplateMemChunk};
+
+    let payloads = [vec![0xA1u8; 24], vec![0xB2u8; 40], vec![0xC3u8; 8]];
+    let recs = payloads.iter().map(|b| (TemplateKey24::default(), b.clone())).collect::<Vec<_>>();
+    let chunk = MemoryChunkErased::TemplateCoordinate(TemplateMemChunk::K24(
+        InMemoryChunk::from_owned_records(recs),
+    ));
+
+    // Frame the whole chunk; every record must be emitted exactly once.
+    let mut blocks = Vec::new();
+    let mut next = 0usize;
+    while next < chunk.len() {
+        let mut out = Vec::new();
+        let advanced =
+            frame_one_block(&chunk, next, BGZF_MAX_BLOCK_SIZE, &mut out).expect("template framing");
+        assert!(advanced > next, "framing must make progress on every call");
+        next = advanced;
+        blocks.push(out);
+    }
+    assert_eq!(next, payloads.len(), "every template record is framed");
+
+    // Each payload appears in the framed stream, so the template layout carries
+    // the record bodies through unchanged.
+    let framed = concat(&blocks);
+    for (i, p) in payloads.iter().enumerate() {
+        assert!(
+            framed.windows(p.len()).any(|w| w == p.as_slice()),
+            "record {i}'s body must survive template framing"
+        );
+    }
+}

--- a/crates/fgumi-pipeline-io/src/sort/spill_write.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_write.rs
@@ -1,0 +1,292 @@
+//! `SpillWrite` — final step of the block-parallel spill-write split
+//! (`SpillGather` → `SpillBlockCompress` → `SpillWrite`).
+//!
+//! `SpillWrite` (`Serial + Affinity::Writer`) receives the compressed
+//! [`SpillBlockEvent`]s in dense `ordinal` order (the framework's `ByItemOrdinal`
+//! reorder feeds it like `WriteBgzfFile`), demultiplexes `Block`s back to
+//! per-`file_id` spill files, and emits the existing [`SortPhase1Event`] so
+//! `SortSpillDecompress` / `SortMerge` are unchanged.
+//!
+//! Because `SortBuffer` (Serial) emits spill chunks one-at-a-time in `seq` order,
+//! `SpillGather` (Serial) fans them in order, and the reorder preserves that
+//! order, each file's blocks arrive **contiguously** — so `SpillWrite` only ever
+//! holds **one** open spill file at a time (`current`). It opens the file on the
+//! first block (writing the codec magic), appends each compressed block, and on
+//! `is_last_in_file` writes the codec trailer, opens the merge slot, and emits
+//! `SpillReady`. This step owns the `TmpDirAllocator` (Serial ⇒ the pick is
+//! uncontended) and the RAII temp-dir handles, matching the retired
+//! `CompressSpill`'s lifetime contract.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, BufWriter, Write};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use fgumi_bam_io::ProgressTracker;
+use fgumi_sort::{SpillCodec, TmpDirAllocator, spill_magic, spill_trailer};
+use parking_lot::Mutex;
+use tempfile::TempDir;
+
+use crate::sort::protocol::{SortPhase1Event, SpillBlockEvent};
+use fgumi_pipeline_core::{
+    HeldRetry, Unpushed,
+    held::HeldSlot,
+    outputs::Single,
+    queues::QueueSpec,
+    reorder::BranchOrdering,
+    step::{Affinity, DetachedGroup, Step, StepCtx, StepKind, StepOutcome, StepProfile},
+};
+
+/// The one spill file currently being written (open from its first block until
+/// its `is_last_in_file` block).
+struct OpenSpill {
+    file_id: u32,
+    path: PathBuf,
+    writer: BufWriter<File>,
+}
+
+/// `Serial + Affinity::Writer` step that writes per-`file_id` spill files from
+/// the compressed block stream and emits `SortPhase1Event`s.
+pub struct SpillWrite {
+    /// Shared temp-directory allocator (free-space-aware round-robin). `Serial`,
+    /// so the lock is effectively uncontended (one writer worker).
+    alloc: Arc<Mutex<TmpDirAllocator>>,
+    /// Spill codec for chunk files (bgzf or zstd).
+    codec: SpillCodec,
+    /// The currently-open spill file, if any.
+    current: Option<OpenSpill>,
+    held: HeldSlot<Unpushed<SortPhase1Event>>,
+    output_byte_limit: u64,
+    /// Compressed spill bytes written, logged every 256 MiB under `RUST_LOG=info`
+    /// so the spill-write rate over wall time is visible alongside ingest.
+    spill_progress: ProgressTracker,
+    /// RAII temp-dir handles, held for the step's lifetime so spill files survive
+    /// while being read by `SortMerge`. Matches `CompressSpill`'s lifetime.
+    #[allow(dead_code)]
+    temp_dirs: Arc<Vec<TempDir>>,
+    /// When `true`, advertise `StepKind::Detached` so the framework drives this
+    /// writer on its own dedicated thread (off the pool) instead of as a
+    /// pool-scheduled `Serial + Affinity::Writer` step. Set only on the
+    /// standalone-sort spill path via [`Self::with_detached`] — the exact
+    /// Phase-1 analogue of Lever 2's detached terminal writer — so the single
+    /// serial write stream stops consuming a compute worker that could be
+    /// compressing. Every other chain leaves it `false`.
+    detached: bool,
+}
+
+impl SpillWrite {
+    /// Build a `SpillWrite`. `alloc` names spill files across the configured temp
+    /// dirs; `codec` selects the on-disk format; `temp_dirs` holds the RAII
+    /// handles alive for the step's lifetime. `output_byte_limit` byte-bounds the
+    /// forwarded-event output queue.
+    #[must_use]
+    pub fn new(
+        alloc: Arc<Mutex<TmpDirAllocator>>,
+        codec: SpillCodec,
+        output_byte_limit: u64,
+        temp_dirs: Arc<Vec<TempDir>>,
+    ) -> Self {
+        Self {
+            alloc,
+            codec,
+            current: None,
+            held: HeldSlot::new(),
+            output_byte_limit,
+            spill_progress: ProgressTracker::new("Spill bytes written")
+                .with_interval(256 * 1024 * 1024),
+            temp_dirs,
+            detached: false,
+        }
+    }
+
+    /// Run this spill writer on its own dedicated `StepKind::Detached` thread
+    /// instead of as a pool-scheduled `Serial + Affinity::Writer` step. Used
+    /// ONLY on the standalone-sort spill path (the Phase-1 analogue of Lever 2's
+    /// detached terminal writer): it frees a pool worker for the
+    /// compression-bound `SpillBlockCompress` work, matching feat-runall's dedicated
+    /// spill-I/O thread — but as a single persistent thread for the whole run,
+    /// not one per spill chunk.
+    ///
+    /// The `try_run` body and the bytes it writes are unchanged: the
+    /// dedicated-thread driver pops blocks in the same `ByItemOrdinal`
+    /// reorder-stage-ordered sequence, so each spill file's blocks still arrive
+    /// contiguously (the one-open-file-at-a-time invariant holds) and every
+    /// spill file is byte-identical to the pool-scheduled writer's output.
+    /// Affinity is ignored for `Detached`.
+    #[must_use]
+    pub fn with_detached(mut self) -> Self {
+        self.detached = true;
+        self
+    }
+
+    fn flush_held(&mut self, ctx: &mut StepCtx<'_, Self>) -> bool {
+        !matches!(ctx.outputs.retry_held(&mut self.held), HeldRetry::StillHeld)
+    }
+
+    /// Allocate a spill path for `file_id` (named by the logical spill index so
+    /// the merge tie-break is independent of write order) and create the file,
+    /// writing the codec magic prologue.
+    fn open_file(&self, file_id: u32) -> io::Result<OpenSpill> {
+        let base = self.alloc.lock().next().map_err(|e| {
+            io::Error::other(format!("SpillWrite: temp-dir allocation failed: {e:#}"))
+        })?;
+        let path = base.join(format!("chunk_{file_id:04}.keyed"));
+        // `create_new` fails closed on a duplicate/stale path: a reused `file_id`
+        // (or a leftover file) must surface as an error rather than truncate an
+        // existing spill and silently corrupt merge input.
+        let file = OpenOptions::new().write(true).create_new(true).open(&path)?;
+        let mut writer = BufWriter::with_capacity(256 * 1024, file);
+        writer.write_all(spill_magic(self.codec))?;
+        Ok(OpenSpill { file_id, path, writer })
+    }
+
+    /// Process one input event, performing any disk writes and returning the
+    /// `SortPhase1Event` to emit (a `Block` only emits on `is_last_in_file`).
+    /// `StepCtx`-free for unit testing.
+    ///
+    /// # Errors
+    ///
+    /// Propagates file-create / write / slot-open errors. Also errors if a block
+    /// arrives for a different `file_id` than the open file while one is open
+    /// without an intervening `is_last_in_file` — a framework-ordering invariant
+    /// violation that must fail loud rather than corrupt a spill.
+    fn process_event(&mut self, event: SpillBlockEvent) -> io::Result<Option<SortPhase1Event>> {
+        match event {
+            SpillBlockEvent::Block {
+                file_id,
+                is_last_in_file,
+                records_ingested_so_far,
+                bytes,
+                ..
+            } => {
+                // Open the file on its first block; otherwise the open file must
+                // match (blocks for one file are contiguous in the ordinal stream).
+                if self.current.is_none() {
+                    self.current = Some(self.open_file(file_id)?);
+                }
+                let open = self.current.as_mut().expect("open file set above");
+                if open.file_id != file_id {
+                    return Err(io::Error::other(format!(
+                        "SpillWrite: block for file_id {file_id} arrived while file_id {} \
+                         was still open (blocks must be contiguous per file)",
+                        open.file_id
+                    )));
+                }
+                open.writer.write_all(&bytes)?;
+                self.spill_progress.log_if_needed(bytes.len() as u64);
+
+                if is_last_in_file {
+                    let OpenSpill { file_id, path, mut writer } =
+                        self.current.take().expect("open file present");
+                    writer.write_all(spill_trailer(self.codec))?;
+                    writer.flush()?;
+                    drop(writer); // close the fd before opening the read slot
+                    let slot = fgumi_sort::open_spill_slot(&path, file_id).map_err(|e| {
+                        io::Error::other(format!(
+                            "SpillWrite: failed to open spill slot {}: {e:#}",
+                            path.display()
+                        ))
+                    })?;
+                    Ok(Some(SortPhase1Event::SpillReady { slot, path, records_ingested_so_far }))
+                } else {
+                    Ok(None)
+                }
+            }
+            SpillBlockEvent::Residual { chunk, records_ingested_so_far, .. } => {
+                self.ensure_no_open_file("residual")?;
+                // Wrap in a fresh, uniquely-owned `Arc`: the chunk is only ever
+                // moved (never cloned) onward, so `SortMerge`'s `Arc::try_unwrap`
+                // invariant holds.
+                Ok(Some(SortPhase1Event::MemoryChunk {
+                    chunk: Arc::new(chunk),
+                    records_ingested_so_far,
+                }))
+            }
+            SpillBlockEvent::AllAnnounced {
+                slot_count, memory_chunk_count, total_records, ..
+            } => {
+                self.ensure_no_open_file("AllAnnounced")?;
+                Ok(Some(SortPhase1Event::AllAnnounced {
+                    slot_count,
+                    memory_chunk_count,
+                    total_records,
+                }))
+            }
+        }
+    }
+
+    /// Error if a spill file is still open. A `Residual` / `AllAnnounced` event,
+    /// or end-of-stream, while `current` holds an unterminated file means a spill
+    /// lost its `is_last_in_file` block (a `SpillGather` framing bug) — failing
+    /// loud avoids dropping a spill or publishing `AllAnnounced` before its
+    /// `SpillReady`.
+    fn ensure_no_open_file(&self, at: &str) -> io::Result<()> {
+        if let Some(open) = &self.current {
+            return Err(io::Error::other(format!(
+                "SpillWrite: {at} arrived while spill file_id {} was still open \
+                 (missing is_last_in_file block)",
+                open.file_id
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl Step for SpillWrite {
+    type Input = SpillBlockEvent;
+    type Outputs = Single<SortPhase1Event>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "SpillWrite",
+            // Detached (own thread) on the standalone-sort spill path; otherwise
+            // the default pool-scheduled Serial + sticky writer. `sticky` is
+            // irrelevant for Detached (it never enters a worker's worklist).
+            kind: if self.detached { StepKind::Detached } else { StepKind::Serial },
+            sticky: true,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::None],
+        }
+    }
+
+    fn detached_group(&self) -> DetachedGroup {
+        // When detached (standalone-sort spill path), share the sort's I/O
+        // writer driver thread with the terminal `WriteBgzfFile` — phase-1 spill
+        // and phase-2 output writes are temporally disjoint (true N+2). Consulted
+        // only when the step is Detached.
+        DetachedGroup::Shared(crate::sort::SORT_IO_GROUP)
+    }
+
+    fn affinity(&self) -> Affinity {
+        // Ignored for `Detached` (no pool worker drives it); kept for the
+        // default Serial path where it pins the writer to the last worker.
+        Affinity::Writer
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if !self.flush_held(ctx) {
+            return Ok(StepOutcome::Contention);
+        }
+
+        if let Some(event) = ctx.input.pop() {
+            if let Some(out) = self.process_event(event)?
+                && let Err(unpushed) = ctx.outputs.push(out)
+            {
+                self.held.put(unpushed);
+            }
+            return Ok(StepOutcome::Progress);
+        }
+
+        if ctx.input.is_drained() {
+            // End-of-stream with a file still open means the final spill never
+            // got its `is_last_in_file` block — fail loud rather than leave a
+            // truncated, unterminated spill on disk.
+            self.ensure_no_open_file("input drained")?;
+            return Ok(StepOutcome::Finished);
+        }
+        Ok(StepOutcome::NoProgress)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/fgumi-pipeline-io/src/sort/spill_write/tests.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_write/tests.rs
@@ -1,0 +1,280 @@
+//! Unit tests for `SpillWrite::process_event` (the `StepCtx`-free core): per-file
+//! demux, codec magic/trailer bracketing, finalization on `is_last_in_file`, and
+//! event mapping. Byte-exact readback of the assembled file is gated end-to-end
+//! by the full-sort parity test (the production reader is crate-private to
+//! `fgumi-sort`).
+
+use super::*;
+use crate::sort::protocol::MemoryChunkErased;
+use fgumi_sort::{InMemoryChunk, RawCoordinateKey, SpillBlockCompressor};
+use rstest::rstest;
+use tempfile::TempDir;
+
+/// Build a `SpillWrite` writing into a fresh temp dir; returns it plus the dir
+/// (kept alive by the caller) so written files can be inspected.
+fn make_writer(codec: SpillCodec) -> (SpillWrite, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let alloc = TmpDirAllocator::new(vec![dir.path().to_path_buf()]).unwrap();
+    let writer = SpillWrite::new(Arc::new(Mutex::new(alloc)), codec, 1 << 20, Arc::new(Vec::new()));
+    (writer, dir)
+}
+
+/// Kernel-compress one raw block for `codec`, mirroring `SpillBlockCompress`.
+fn compress(codec: SpillCodec, raw: &[u8]) -> Vec<u8> {
+    SpillBlockCompressor::new(codec, 1).unwrap().compress_block(raw).unwrap()
+}
+
+fn block(codec: SpillCodec, file_id: u32, is_last: bool, raw: &[u8]) -> SpillBlockEvent {
+    SpillBlockEvent::Block {
+        ordinal: 0,
+        file_id,
+        is_last_in_file: is_last,
+        records_ingested_so_far: 42,
+        bytes: compress(codec, raw),
+    }
+}
+
+#[rstest]
+#[case(SpillCodec::Zstd)]
+#[case(SpillCodec::Bgzf)]
+fn non_last_block_opens_file_emits_nothing_last_block_emits_spill_ready(#[case] codec: SpillCodec) {
+    let (mut w, dir) = make_writer(codec);
+    // First (non-last) block: file opens, no event.
+    let out = w.process_event(block(codec, 5, false, &[1u8; 32])).unwrap();
+    assert!(out.is_none(), "non-last block emits no event ({codec:?})");
+    assert!(w.current.is_some(), "file must be open after first block ({codec:?})");
+
+    // Last block: trailer written, slot opened, SpillReady emitted.
+    let out = w.process_event(block(codec, 5, true, &[2u8; 32])).unwrap();
+    let Some(SortPhase1Event::SpillReady { slot, path, records_ingested_so_far }) = out else {
+        panic!("expected SpillReady ({codec:?})");
+    };
+    assert!(w.current.is_none(), "file closed after last block ({codec:?})");
+    assert_eq!(slot.file_id, 5, "slot file_id == logical seq ({codec:?})");
+    assert_eq!(records_ingested_so_far, 42);
+    assert!(path.exists(), "spill file exists ({codec:?})");
+    assert!(path.starts_with(dir.path()), "spill file under temp dir ({codec:?})");
+    assert_eq!(slot.codec, codec, "codec detected from written magic ({codec:?})");
+}
+
+#[test]
+fn distinct_file_ids_produce_distinct_files() {
+    let codec = SpillCodec::Zstd;
+    let (mut w, _dir) = make_writer(codec);
+    // File 0 (single block), then file 1 (single block) — contiguous per file.
+    let r0 = w.process_event(block(codec, 0, true, &[7u8; 16])).unwrap().unwrap();
+    let r1 = w.process_event(block(codec, 1, true, &[8u8; 16])).unwrap().unwrap();
+    let (
+        SortPhase1Event::SpillReady { path: p0, slot: s0, .. },
+        SortPhase1Event::SpillReady { path: p1, slot: s1, .. },
+    ) = (r0, r1)
+    else {
+        panic!("expected two SpillReady events");
+    };
+    assert_ne!(p0, p1, "distinct file_ids must yield distinct paths");
+    assert_eq!(s0.file_id, 0);
+    assert_eq!(s1.file_id, 1);
+}
+
+#[test]
+fn block_for_wrong_file_id_while_open_errors() {
+    let codec = SpillCodec::Zstd;
+    let (mut w, _dir) = make_writer(codec);
+    // Open file 0 with a non-last block, then feed a block for file 1 — a
+    // contiguity violation that must fail loud, not silently corrupt file 0.
+    w.process_event(block(codec, 0, false, &[1u8; 16])).unwrap();
+    // `SortPhase1Event` is not `Debug`, so match instead of `unwrap_err`.
+    match w.process_event(block(codec, 1, false, &[2u8; 16])) {
+        Err(err) => {
+            assert!(
+                err.to_string().contains("contiguous"),
+                "expected contiguity error, got: {err}"
+            );
+        }
+        Ok(_) => panic!("a block for a different open file_id must error"),
+    }
+}
+
+#[test]
+fn residual_while_file_open_errors() {
+    let codec = SpillCodec::Zstd;
+    let (mut w, _dir) = make_writer(codec);
+    // Open a file with a non-last block, then feed a Residual — a missing
+    // is_last_in_file terminator must fail loud, not drop the open spill.
+    w.process_event(block(codec, 0, false, &[1u8; 16])).unwrap();
+    let chunk = MemoryChunkErased::Coordinate(InMemoryChunk::from_owned_records(vec![(
+        RawCoordinateKey { sort_key: 1 },
+        vec![9u8; 8],
+    )]));
+    match w.process_event(SpillBlockEvent::Residual {
+        ordinal: 1,
+        chunk,
+        records_ingested_so_far: 1,
+    }) {
+        Err(err) => {
+            assert!(err.to_string().contains("still open"), "expected open-file error, got: {err}");
+        }
+        Ok(_) => panic!("residual while a spill file is open must error"),
+    }
+}
+
+#[test]
+fn default_is_serial_writer_and_with_detached_flips_to_detached() {
+    use fgumi_pipeline_core::step::{Affinity, Step, StepKind};
+    let (w, _dir) = make_writer(SpillCodec::Zstd);
+    // Default: pool-scheduled Serial + Affinity::Writer (pinned to worker N-1).
+    assert_eq!(w.profile().kind, StepKind::Serial, "default spill writer is Serial");
+    assert_eq!(w.affinity(), Affinity::Writer, "default spill writer pins to the writer worker");
+    // `with_detached()` flips only the advertised kind to Detached (own thread,
+    // off the pool); the write body — and hence the bytes it writes — is
+    // unchanged, so full-sort parity still covers the on-disk format.
+    let wd = w.with_detached();
+    assert_eq!(wd.profile().kind, StepKind::Detached, "with_detached flips kind to Detached");
+}
+
+#[test]
+fn residual_maps_to_memory_chunk_and_announced_passes_through() {
+    let codec = SpillCodec::Zstd;
+    let (mut w, _dir) = make_writer(codec);
+
+    let chunk = MemoryChunkErased::Coordinate(InMemoryChunk::from_owned_records(vec![(
+        RawCoordinateKey { sort_key: 1 },
+        vec![9u8; 8],
+    )]));
+    let out = w
+        .process_event(SpillBlockEvent::Residual { ordinal: 0, chunk, records_ingested_so_far: 3 })
+        .unwrap();
+    let Some(SortPhase1Event::MemoryChunk { chunk, records_ingested_so_far }) = out else {
+        panic!("expected MemoryChunk");
+    };
+    assert_eq!(records_ingested_so_far, 3);
+    assert_eq!(Arc::strong_count(&chunk), 1, "residual chunk wrapped in a fresh unique Arc");
+
+    let out = w
+        .process_event(SpillBlockEvent::AllAnnounced {
+            ordinal: 1,
+            slot_count: 4,
+            memory_chunk_count: 1,
+            total_records: 500,
+        })
+        .unwrap();
+    assert!(matches!(
+        out,
+        Some(SortPhase1Event::AllAnnounced {
+            slot_count: 4,
+            memory_chunk_count: 1,
+            total_records: 500,
+        })
+    ));
+}
+
+// ── Step wiring: profile / affinity / detached group ─────────────────────────
+
+#[test]
+fn profile_defaults_to_a_pool_scheduled_serial_writer() {
+    let (w, _dir) = make_writer(SpillCodec::Zstd);
+    let profile = w.profile();
+    assert_eq!(profile.name, "SpillWrite");
+    assert_eq!(profile.kind, StepKind::Serial, "default is the pool-scheduled writer");
+    assert!(profile.sticky);
+    assert_eq!(profile.branch_ordering, vec![BranchOrdering::None]);
+    match profile.output_queues.as_slice() {
+        [QueueSpec::ByteBounded { limit_bytes }] => assert_eq!(*limit_bytes, 1 << 20),
+        other => panic!("expected one byte-bounded queue, got {other:?}"),
+    }
+    // Affinity pins the pool-scheduled writer; ignored once detached.
+    assert_eq!(w.affinity(), Affinity::Writer);
+}
+
+#[test]
+fn with_detached_flips_only_the_step_kind() {
+    let (w, _dir) = make_writer(SpillCodec::Zstd);
+    let before = w.profile();
+    let detached = w.with_detached();
+    let after = detached.profile();
+
+    assert_eq!(before.kind, StepKind::Serial);
+    assert_eq!(after.kind, StepKind::Detached, "detached runs on its own thread");
+    // Everything else about the step is unchanged — the doc promises the
+    // `try_run` body and the bytes written are identical either way.
+    assert_eq!(after.name, before.name);
+    assert_eq!(after.sticky, before.sticky);
+    assert_eq!(after.branch_ordering, before.branch_ordering);
+    assert_eq!(detached.affinity(), Affinity::Writer);
+}
+
+#[test]
+fn detached_writer_shares_the_sort_io_group() {
+    // Phase-1 spill and phase-2 output writes are temporally disjoint, so both
+    // ride the same driver thread rather than each taking one.
+    let (w, _dir) = make_writer(SpillCodec::Zstd);
+    assert_eq!(w.detached_group(), DetachedGroup::Shared(crate::sort::SORT_IO_GROUP));
+    let (w2, _dir2) = make_writer(SpillCodec::Bgzf);
+    assert_eq!(
+        w2.with_detached().detached_group(),
+        DetachedGroup::Shared(crate::sort::SORT_IO_GROUP)
+    );
+}
+
+// ── Open-file bookkeeping ────────────────────────────────────────────────────
+
+#[test]
+fn ensure_no_open_file_passes_when_idle_and_fails_while_a_file_is_open() {
+    let (mut w, _dir) = make_writer(SpillCodec::Zstd);
+    w.ensure_no_open_file("Residual").expect("idle writer has no open file");
+
+    // Opening a file without its is_last block leaves it dangling.
+    let out = w.process_event(block(SpillCodec::Zstd, 3, false, &[7u8; 16])).unwrap();
+    assert!(out.is_none());
+    assert!(w.current.is_some());
+
+    let err = w.ensure_no_open_file("AllAnnounced").expect_err("dangling file must fail closed");
+    let msg = err.to_string();
+    assert!(msg.contains("AllAnnounced"), "error names the offending event: {msg}");
+    assert!(msg.contains("file_id 3"), "error names the open file: {msg}");
+}
+
+#[test]
+fn open_file_refuses_to_reuse_an_existing_path() {
+    let (w, dir) = make_writer(SpillCodec::Zstd);
+    // First open succeeds and creates the file on disk.
+    let opened = w.open_file(9).expect("first open succeeds");
+    drop(opened);
+    assert!(dir.path().join("chunk_0009.keyed").exists(), "spill file is created eagerly");
+
+    // A reused file_id must fail closed rather than truncate the existing file:
+    // silently overwriting a spill would drop records from the merge.
+    // `OpenSpill` is not `Debug`, so match instead of using `expect_err`.
+    match w.open_file(9) {
+        Ok(_) => panic!("reusing a file_id must fail"),
+        Err(e) => assert_eq!(e.kind(), io::ErrorKind::AlreadyExists),
+    }
+}
+
+/// `AllAnnounced` arriving while a spill file is still open must fail closed.
+///
+/// Without the guard, `AllAnnounced` reaches `SortMerge` before the matching
+/// `SpillReady`, so the merge starts against an undercounted slot set and
+/// silently drops a spill file's records.
+#[test]
+fn all_announced_while_a_file_is_open_fails_closed() {
+    let codec = SpillCodec::Zstd;
+    let (mut w, _dir) = make_writer(codec);
+    // Open file 0 and never terminate it with an is_last_in_file block.
+    w.process_event(block(codec, 0, false, &[1u8; 16])).unwrap();
+
+    match w.process_event(SpillBlockEvent::AllAnnounced {
+        ordinal: 1,
+        slot_count: 1,
+        memory_chunk_count: 0,
+        total_records: 1,
+    }) {
+        Err(err) => {
+            let msg = err.to_string();
+            assert!(msg.contains("AllAnnounced"), "error names the event: {msg}");
+            assert!(msg.contains("still open"), "error names the cause: {msg}");
+            assert!(msg.contains("file_id 0"), "error names the open file: {msg}");
+        }
+        Ok(_) => panic!("AllAnnounced while a spill file is open must error"),
+    }
+}

--- a/crates/fgumi-pipeline-io/src/sort/tests.rs
+++ b/crates/fgumi-pipeline-io/src/sort/tests.rs
@@ -1,0 +1,1930 @@
+//! Tests for the runall-sort chains.
+//!
+//! The record-input chain is `SortBuffer` → `CompressSpill` →
+//! `SortSpillDecompress` → `SortMerge`; the legacy `SortAndSpill` Phase-1 head
+//! it replaced was retired in P7. The block-input arena front (`ReadBlocks` →
+//! `InflateToArena` → `FindBoundariesAndSort`) is covered at the end of this
+//! module.
+//!
+//! `RawExternalSorter::sort` (driven here via [`sort_via_legacy`]) is retained
+//! as the parity oracle both chains are validated against.
+
+use std::io;
+use std::sync::Arc;
+
+use anyhow::Result;
+use fgumi_raw_bam::RawRecord;
+use fgumi_raw_bam::testutil::make_bam_bytes;
+use fgumi_sort::{QuerynameComparator, RawExternalSorter, SortOrder, SpillCodec};
+use noodles::sam::Header;
+use parking_lot::Mutex;
+use rstest::rstest;
+
+use super::*;
+use crate::sort::protocol::SortChunkEvent;
+use crate::types::RecordBatch;
+use fgumi_pipeline_core::{
+    Unpushed,
+    builder::{Pipeline, PipelineConfig},
+    held::HeldSlot,
+    outputs::OrderedBytesSingle,
+    queues::QueueSpec,
+    reorder::BranchOrdering,
+    step::{Step, StepCtx, StepKind, StepOutcome, StepProfile},
+};
+
+// ── In-memory source / sink test steps ──────────────────────────────────────
+
+/// `Exclusive` source that drains a `Vec<RecordBatch>` one batch per `try_run` call.
+struct VecSource {
+    batches: Vec<RecordBatch>,
+    held: HeldSlot<Unpushed<RecordBatch>>,
+    output_byte_limit: u64,
+}
+
+impl VecSource {
+    fn new(mut batches: Vec<RecordBatch>, output_byte_limit: u64) -> Self {
+        batches.reverse();
+        Self { batches, held: HeldSlot::new(), output_byte_limit }
+    }
+}
+
+impl Step for VecSource {
+    type Input = ();
+    type Outputs = OrderedBytesSingle<RecordBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "VecSource",
+            kind: StepKind::Exclusive,
+            sticky: true,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Progress);
+                }
+            }
+        }
+        let Some(batch) = self.batches.pop() else {
+            return Ok(StepOutcome::Finished);
+        };
+        match ctx.outputs.push(batch) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+}
+
+/// Sink that appends every received batch into a shared `Vec<RecordBatch>`.
+struct VecSink {
+    received: Arc<Mutex<Vec<RecordBatch>>>,
+    kind: StepKind,
+}
+
+impl Step for VecSink {
+    type Input = RecordBatch;
+    type Outputs = ();
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "VecSink",
+            kind: self.kind,
+            sticky: false,
+            output_queues: vec![],
+            branch_ordering: vec![],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        match ctx.input.pop() {
+            Some(batch) => {
+                self.received.lock().push(batch);
+                Ok(StepOutcome::Progress)
+            }
+            None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+            None => Ok(StepOutcome::NoProgress),
+        }
+    }
+}
+
+/// One sort's output as a flat list of raw BAM record-byte payloads, in output
+/// order. Both the streaming pipeline and the legacy oracle produce this shape.
+type RecordBytes = Vec<Vec<u8>>;
+
+// ── Synthetic-record helpers ────────────────────────────────────────────────
+
+fn synthesize_records(n: usize, seed: u64) -> (Header, Vec<RawRecord>) {
+    synthesize_sized_records(n, seed, 0)
+}
+
+fn pack_batches(records: &[RawRecord], batch_size: usize) -> Vec<RecordBatch> {
+    use crate::types::RecordBatchBuilder;
+    records
+        .chunks(batch_size)
+        .enumerate()
+        .map(|(i, chunk)| {
+            let total: usize = chunk.iter().map(RawRecord::len).sum();
+            let mut b = RecordBatchBuilder::with_capacity(i as u64, total, chunk.len());
+            for r in chunk {
+                b.push_record_bytes(r.as_ref());
+            }
+            b.build()
+        })
+        .collect()
+}
+
+fn drive_sort_pipeline(
+    sorter: RawExternalSorter,
+    header: &Header,
+    batches: Vec<RecordBatch>,
+    output_byte_limit: u64,
+    threads: usize,
+    sink_kind: StepKind,
+) -> Result<Vec<Vec<u8>>> {
+    drive_sort_pipeline_tuned(
+        sorter,
+        header,
+        batches,
+        output_byte_limit,
+        threads,
+        sink_kind,
+        SortDecompressTuning::default(),
+        SpillCodec::Zstd,
+    )
+}
+
+/// Drive the production sort chain (`VecSource` → `SortBuffer` →
+/// `CompressSpill` → `SortSpillDecompress` → `SortMerge` → `VecSink`). The
+/// legacy `SortAndSpill` Phase-1 head was retired in P7, so the Phase-2 tests
+/// (decompress-granularity, out-of-order, soak) run through the same production
+/// chain `fgumi sort` / `runall` build.
+#[allow(clippy::too_many_arguments)]
+fn drive_sort_pipeline_tuned(
+    sorter: RawExternalSorter,
+    header: &Header,
+    batches: Vec<RecordBatch>,
+    output_byte_limit: u64,
+    threads: usize,
+    sink_kind: StepKind,
+    decompress_tuning: SortDecompressTuning,
+    spill_codec: SpillCodec,
+) -> Result<Vec<Vec<u8>>> {
+    drive_sort_buffer_pipeline(
+        sorter,
+        header,
+        batches,
+        output_byte_limit,
+        threads,
+        sink_kind,
+        decompress_tuning,
+        spill_codec,
+    )
+}
+
+/// Drive the P6 four-step buffer chain
+/// (`VecSource` → `SortBuffer` → `CompressSpill` → `SortSpillDecompress` →
+/// `SortMerge` → `VecSink`) and collect the merged record bytes. Exercises
+/// every sort order `SortBuffer` supports (see
+/// `sort_buffer_chain_matches_legacy_all_orders`).
+#[allow(clippy::too_many_arguments)]
+fn drive_sort_buffer_pipeline(
+    sorter: RawExternalSorter,
+    header: &Header,
+    batches: Vec<RecordBatch>,
+    output_byte_limit: u64,
+    threads: usize,
+    sink_kind: StepKind,
+    decompress_tuning: SortDecompressTuning,
+    spill_codec: SpillCodec,
+) -> Result<Vec<Vec<u8>>> {
+    use fgumi_sort::TmpDirAllocator;
+
+    let received: Arc<Mutex<Vec<RecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sort_order = sorter.sort_order();
+
+    // Temp dir + allocator for CompressSpill, held alive by the step. The
+    // deterministic always-ample probe avoids any dependency on host free space.
+    let dir = tempfile::TempDir::new()?;
+    let alloc =
+        TmpDirAllocator::with_probe(vec![dir.path().to_path_buf()], Box::new(|_| Ok(u64::MAX)), 0)?;
+    let temp_dirs = Arc::new(vec![dir]);
+
+    let source = VecSource::new(batches, output_byte_limit);
+    let sort_buffer = SortBuffer::from_sorter(sorter, header, output_byte_limit)?;
+    // Codec/compression affect only intermediate spill bytes, not the final
+    // sorted records, so any codec yields output parity. The caller passes the
+    // codec so codec-specific tests (e.g. the BGZF block-parallel parity test)
+    // actually exercise their codec end-to-end.
+    let compress = CompressSpill::new(
+        Arc::new(Mutex::new(alloc)),
+        spill_codec,
+        3,
+        output_byte_limit,
+        temp_dirs,
+    );
+    let decompress = SortSpillDecompress::new(output_byte_limit, decompress_tuning);
+    let merge =
+        SortMerge::<RecordBatchOutput>::with_target_batch_count(sort_order, output_byte_limit, 256);
+    let sink = VecSink { received: Arc::clone(&received), kind: sink_kind };
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(source)
+        .chain(sort_buffer)
+        .chain(compress)
+        .chain(decompress)
+        .chain(merge)
+        .chain(sink)
+        .into_sink_marker();
+    let pipeline = builder.build()?;
+    pipeline.run(PipelineConfig { threads, ..Default::default() })?;
+
+    let collected = std::mem::take(&mut *received.lock());
+    let mut out = Vec::new();
+    for batch in collected {
+        for bytes in batch.iter_record_bytes() {
+            out.push(bytes.to_vec());
+        }
+    }
+    Ok(out)
+}
+
+/// Terminal-path sink: collects the [`DecompressedBlock`]s emitted by
+/// `SortMerge<BlockOutput>` (the framed-bytes terminal output, lever 1).
+struct BlockSink {
+    received: Arc<Mutex<Vec<crate::types::DecompressedBlock>>>,
+    kind: StepKind,
+}
+
+impl Step for BlockSink {
+    type Input = crate::types::DecompressedBlock;
+    type Outputs = ();
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "BlockSink",
+            kind: self.kind,
+            sticky: false,
+            output_queues: vec![],
+            branch_ordering: vec![],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        match ctx.input.pop() {
+            Some(block) => {
+                self.received.lock().push(block);
+                Ok(StepOutcome::Progress)
+            }
+            None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+            None => Ok(StepOutcome::NoProgress),
+        }
+    }
+}
+
+/// Parse a `[u32 LE block_size][body]`-framed byte buffer (the terminal-sort
+/// `BlockOutput` framing, identical to the former `SerializeRecordBatch`) into
+/// its record bodies. Mirrors what `BgzfDecompress → FindBamBoundaries` does
+/// downstream; kept local to the test so parity is checked against an
+/// independent re-implementation of the layout.
+fn unframe_block_records(bytes: &[u8]) -> Vec<Vec<u8>> {
+    let mut out = Vec::new();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let len = u32::from_le_bytes(bytes[i..i + 4].try_into().unwrap()) as usize;
+        i += 4;
+        out.push(bytes[i..i + len].to_vec());
+        i += len;
+    }
+    out
+}
+
+/// Drive the production sort chain with the **terminal** merge
+/// (`SortMerge<BlockOutput>` → `BlockSink`) and recover the merged record
+/// bodies by un-framing each `DecompressedBlock`. Used to prove the framed
+/// terminal output carries byte-identical records to the `RecordBatchOutput`
+/// path / legacy oracle (lever 1 parity gate).
+#[allow(clippy::too_many_arguments)]
+fn drive_sort_block_pipeline(
+    sorter: RawExternalSorter,
+    header: &Header,
+    batches: Vec<RecordBatch>,
+    output_byte_limit: u64,
+    threads: usize,
+    sink_kind: StepKind,
+    decompress_tuning: SortDecompressTuning,
+    spill_codec: SpillCodec,
+) -> Result<Vec<Vec<u8>>> {
+    use fgumi_sort::TmpDirAllocator;
+
+    let received: Arc<Mutex<Vec<crate::types::DecompressedBlock>>> =
+        Arc::new(Mutex::new(Vec::new()));
+    let sort_order = sorter.sort_order();
+
+    let dir = tempfile::TempDir::new()?;
+    let alloc =
+        TmpDirAllocator::with_probe(vec![dir.path().to_path_buf()], Box::new(|_| Ok(u64::MAX)), 0)?;
+    let temp_dirs = Arc::new(vec![dir]);
+
+    let source = VecSource::new(batches, output_byte_limit);
+    let sort_buffer = SortBuffer::from_sorter(sorter, header, output_byte_limit)?;
+    let compress = CompressSpill::new(
+        Arc::new(Mutex::new(alloc)),
+        spill_codec,
+        3,
+        output_byte_limit,
+        temp_dirs,
+    );
+    let decompress = SortSpillDecompress::new(output_byte_limit, decompress_tuning);
+    let merge =
+        SortMerge::<BlockOutput>::with_target_batch_count(sort_order, output_byte_limit, 256);
+    let sink = BlockSink { received: Arc::clone(&received), kind: sink_kind };
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(source)
+        .chain(sort_buffer)
+        .chain(compress)
+        .chain(decompress)
+        .chain(merge)
+        .chain(sink)
+        .into_sink_marker();
+    let pipeline = builder.build()?;
+    pipeline.run(PipelineConfig { threads, ..Default::default() })?;
+
+    let mut collected = std::mem::take(&mut *received.lock());
+    // `Detached` collapses ordering to None, so blocks arrive in merge-emit
+    // order on the single sink; sort by serial defensively in case a future
+    // change makes the sink parallel.
+    collected.sort_by_key(|b| b.batch_serial);
+    let mut out = Vec::new();
+    for block in &collected {
+        out.extend(unframe_block_records(&block.bytes));
+    }
+    Ok(out)
+}
+
+// ── Reference: RawExternalSorter::sort to bytes ─────────────────────────────
+
+fn sort_via_legacy(
+    sort_order: SortOrder,
+    header: &Header,
+    records: &[RawRecord],
+    memory_limit: usize,
+    threads: usize,
+) -> Result<Vec<Vec<u8>>> {
+    let tmp_in = tempfile::NamedTempFile::new()?;
+    {
+        let mut writer = fgumi_bam_io::create_raw_bam_writer(tmp_in.path(), header, 1, 1)?;
+        for r in records {
+            writer.write_raw_record(r.as_ref())?;
+        }
+        writer.finish()?;
+    }
+
+    let tmp_out = tempfile::NamedTempFile::new()?;
+    let sorter = RawExternalSorter::new(sort_order)
+        .memory_limit(memory_limit)
+        .threads(threads)
+        .output_compression(1)
+        .temp_compression(1);
+    sorter.sort(tmp_in.path(), tmp_out.path())?;
+
+    let (mut reader, _hdr) = fgumi_bam_io::create_raw_bam_reader_with_opts(
+        tmp_out.path(),
+        1,
+        fgumi_bam_io::PipelineReaderOpts::default(),
+    )?;
+    let mut record = RawRecord::default();
+    let mut out = Vec::new();
+    loop {
+        match reader.read_record(&mut record)? {
+            0 => break,
+            _ => out.push(record.as_ref().to_vec()),
+        }
+    }
+    Ok(out)
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+//
+// (The former `three_step_chain_{in_memory,multi_spill}_path_matches_legacy`
+// tests, which drove the retired `SortAndSpill` head, are subsumed by
+// `sort_buffer_chain_matches_legacy_all_orders` below — same orders, same
+// regimes, against the same `sort_via_legacy` oracle, but through the
+// production `SortBuffer` → `CompressSpill` chain.)
+
+// ── P6 buffer-chain parity (SortBuffer → CompressSpill → decompress → merge) ─
+
+/// The P6 four-step chain must produce byte-identical output to the legacy
+/// oracle for EVERY sort order, across the in-memory and multi-spill regimes at
+/// 2 and 4 threads. This is the inc-4/5 parity gate: it exercises `SortBuffer`'s
+/// streaming-spill emission, `CompressSpill`'s inline writes + slot opens
+/// (`file_id == seq`), and the single-residual fast path all the way through the
+/// real `SortSpillDecompress` + `SortMerge` — for coordinate, template, and both
+/// queryname comparators.
+#[rstest]
+#[case::coord_inmem_t2(SortOrder::Coordinate, 5_000, 256 * 1024 * 1024, 2)]
+#[case::coord_inmem_t4(SortOrder::Coordinate, 5_000, 256 * 1024 * 1024, 4)]
+#[case::coord_spill_t2(SortOrder::Coordinate, 20_000, 256 * 1024, 2)]
+#[case::coord_spill_t4(SortOrder::Coordinate, 20_000, 256 * 1024, 4)]
+#[case::template_inmem(SortOrder::TemplateCoordinate, 5_000, 256 * 1024 * 1024, 2)]
+#[case::template_spill(SortOrder::TemplateCoordinate, 20_000, 256 * 1024, 2)]
+#[case::template_spill_t4(SortOrder::TemplateCoordinate, 20_000, 256 * 1024, 4)]
+// Many-spill regime (~20+ spill runs at a 128 KiB buffer): exercises the deeper
+// per-slot FIFO (cap 32) and the emptiest-first refill order across many slots, where
+// the merge must still emit byte-identical output to the oracle.
+#[case::coord_manyspill_t4(SortOrder::Coordinate, 60_000, 128 * 1024, 4)]
+#[case::template_manyspill_t4(SortOrder::TemplateCoordinate, 60_000, 128 * 1024, 4)]
+#[case::qname_lex_inmem(SortOrder::Queryname(QuerynameComparator::Lexicographic), 5_000, 256 * 1024 * 1024, 2)]
+#[case::qname_lex_spill(SortOrder::Queryname(QuerynameComparator::Lexicographic), 20_000, 256 * 1024, 2)]
+#[case::qname_nat_inmem(SortOrder::Queryname(QuerynameComparator::Natural), 5_000, 256 * 1024 * 1024, 2)]
+#[case::qname_nat_spill(SortOrder::Queryname(QuerynameComparator::Natural), 20_000, 256 * 1024, 2)]
+fn sort_buffer_chain_matches_legacy_all_orders(
+    #[case] sort_order: SortOrder,
+    #[case] n: usize,
+    #[case] memory_limit: usize,
+    #[case] threads: usize,
+) {
+    let (header, records) = synthesize_records(n, 0x5A17_C0DE);
+    let sorter = RawExternalSorter::new(sort_order)
+        .memory_limit(memory_limit)
+        .threads(threads)
+        .output_compression(1)
+        .temp_compression(1);
+    let new_out = drive_sort_buffer_pipeline(
+        sorter,
+        &header,
+        pack_batches(&records, 256),
+        4 * 1024 * 1024,
+        // Run the pipeline with exactly the case's thread count — production
+        // sort uses `num_threads` workers (no `max(3)` floor), so the parity
+        // test must too.
+        threads,
+        StepKind::Exclusive,
+        SortDecompressTuning::default(),
+        SpillCodec::Zstd,
+    )
+    .expect("buffer pipeline drives to completion");
+
+    let legacy_out =
+        sort_via_legacy(sort_order, &header, &records, memory_limit, threads).expect("legacy");
+
+    assert_eq!(new_out.len(), legacy_out.len(), "{sort_order:?} record count mismatch");
+    if is_stable_for_equal_keys(sort_order) {
+        // Coordinate / template-coordinate use a stable radix sort: equal keys
+        // keep input order deterministically, so output is byte-for-byte equal.
+        for (i, (got, want)) in new_out.iter().zip(legacy_out.iter()).enumerate() {
+            assert_eq!(got, want, "{sort_order:?} record {i} bytes differ");
+        }
+    } else {
+        // Queryname uses an UNSTABLE comparator sort: the order of equal keys
+        // (same name + segment flags) is unspecified and differs between the
+        // parallel buffer chain and the `.sort()` oracle (and run-to-run). The
+        // sound parity claim is multiset equality — same records, possibly in a
+        // different equal-key order. Sortedness is covered by the production
+        // `queryname_*_sort_matrix` integration tests.
+        let mut got = new_out.clone();
+        let mut want = legacy_out.clone();
+        got.sort_unstable();
+        want.sort_unstable();
+        assert_eq!(got, want, "{sort_order:?} record multiset differs from the oracle");
+    }
+}
+
+/// Raw BAM record carrying `MI:i:<mi>` (aux tag bytes + `i` type + i32 LE).
+/// Shared with `sort_buffer`'s unit tests, which drive the same dropped-lane
+/// rejection directly against `ingest_batch_records`.
+pub(super) fn record_with_mi(pos: i32, name: &[u8], mi: i32) -> Vec<u8> {
+    let mut aux = vec![b'M', b'I', b'i'];
+    aux.extend_from_slice(&mi.to_le_bytes());
+    make_bam_bytes(0, pos, 0, name, &[], 40, -1, -1, &aux)
+}
+
+/// An ingest failure must fail the whole pipeline, never produce a partial sort.
+/// `SortBuffer` tracks "still ingesting" as `sorter.is_some()`, so a failure that
+/// left that slot empty would be indistinguishable from "finalized" and could
+/// surface as a clean `Finished` — a truncated result with a valid structure.
+/// Drives the one reachable `ChunkSorter::push` failure: under
+/// `--key-types none` the first record fixes the narrowed lane set, so a later
+/// record with a differing MI is rejected.
+#[test]
+fn sort_buffer_chain_fails_the_pipeline_on_a_dropped_lane_violation() {
+    use fgumi_sort::KeyTypesSpec;
+
+    let records: Vec<RawRecord> = (0..8i32)
+        .map(|i| {
+            // Record 0 fixes the variant with MI 1; record 4 violates it.
+            let mi = if i == 4 { 2 } else { 1 };
+            RawRecord::from(record_with_mi(100 - i, format!("rd_{i}").as_bytes(), mi))
+        })
+        .collect();
+
+    let sorter = RawExternalSorter::new(SortOrder::TemplateCoordinate)
+        .memory_limit(256 * 1024 * 1024)
+        .threads(1)
+        .key_types(KeyTypesSpec::None);
+    let err = drive_sort_buffer_pipeline(
+        sorter,
+        &Header::default(),
+        pack_batches(&records, 256),
+        4 * 1024 * 1024,
+        1,
+        StepKind::Exclusive,
+        SortDecompressTuning::default(),
+        SpillCodec::Zstd,
+    )
+    .expect_err("a dropped-lane violation must fail the pipeline, not truncate the sort");
+
+    let message = format!("{err:#}");
+    assert!(
+        message.contains("SortBuffer: push failed"),
+        "the ingest failure must reach the caller: {message}"
+    );
+}
+
+/// Regression guard for the `SortBuffer` peak-memory invariant: when a single
+/// input `RecordBatch` is larger than `memory_limit`, `ingest_one_batch` seals
+/// several chunks in one call (staging multiple `Spill` events into `pending`
+/// before `emit_pending` runs). That transiently exceeds the "~one spill chunk"
+/// production bound, but it MUST stay correct — every record emitted in sorted
+/// order, none stranded by the loop. Packs all records into ONE oversized batch
+/// against a small `memory_limit` (the case the 256-record-per-batch parity
+/// matrix never hits) and asserts byte-for-byte parity with the legacy oracle
+/// (coordinate is stable, so equal keys keep input order deterministically).
+#[test]
+fn sort_buffer_single_oversized_batch_seals_multiple_chunks_without_dropping() {
+    let sort_order = SortOrder::Coordinate;
+    let n = 20_000;
+    // Far below the single batch's byte size, so the one batch seals many chunks.
+    let memory_limit = 128 * 1024;
+    let threads = 2;
+    let (header, records) = synthesize_records(n, 0x0B16_BA7C);
+
+    // One batch holding every record — forces multiple seals per ingest call.
+    let batches = pack_batches(&records, records.len());
+    assert_eq!(batches.len(), 1, "test must drive a single oversized batch");
+
+    let sorter = RawExternalSorter::new(sort_order)
+        .memory_limit(memory_limit)
+        .threads(threads)
+        .output_compression(1)
+        .temp_compression(1);
+    let new_out = drive_sort_buffer_pipeline(
+        sorter,
+        &header,
+        batches,
+        4 * 1024 * 1024,
+        threads,
+        StepKind::Exclusive,
+        SortDecompressTuning::default(),
+        SpillCodec::Zstd,
+    )
+    .expect("buffer pipeline drives to completion");
+
+    let legacy_out =
+        sort_via_legacy(sort_order, &header, &records, memory_limit, threads).expect("legacy");
+
+    assert_eq!(new_out.len(), records.len(), "every record must survive — none dropped");
+    assert_eq!(new_out.len(), legacy_out.len(), "record count matches oracle");
+    for (i, (got, want)) in new_out.iter().zip(legacy_out.iter()).enumerate() {
+        assert_eq!(got, want, "record {i} bytes differ from oracle");
+    }
+}
+
+/// Lever 1 parity gate: the terminal `SortMerge<BlockOutput>` path (framed
+/// `DecompressedBlock`s, wired straight to `BgzfCompress`) must carry
+/// byte-identical records to the legacy oracle for every sort order, across the
+/// in-memory and spill regimes. The framed bytes are `[u32 LE len][body]` per
+/// record (identical to the removed `SerializeRecordBatch`); un-framing them
+/// recovers the same record bodies the `RecordBatchOutput` path emits. This is
+/// the gate proving the merge-side framing did not change the output bytes.
+#[rstest]
+#[case::coord_inmem(SortOrder::Coordinate, 5_000, 256 * 1024 * 1024, 2)]
+#[case::coord_spill(SortOrder::Coordinate, 20_000, 256 * 1024, 4)]
+#[case::template_inmem(SortOrder::TemplateCoordinate, 5_000, 256 * 1024 * 1024, 2)]
+#[case::template_spill(SortOrder::TemplateCoordinate, 20_000, 256 * 1024, 4)]
+#[case::qname_lex_spill(SortOrder::Queryname(QuerynameComparator::Lexicographic), 20_000, 256 * 1024, 2)]
+#[case::qname_nat_spill(SortOrder::Queryname(QuerynameComparator::Natural), 20_000, 256 * 1024, 2)]
+fn sort_merge_block_output_matches_legacy(
+    #[case] sort_order: SortOrder,
+    #[case] n: usize,
+    #[case] memory_limit: usize,
+    #[case] threads: usize,
+) {
+    let (header, records) = synthesize_records(n, 0x5A17_C0DE);
+    let make_sorter = || {
+        RawExternalSorter::new(sort_order)
+            .memory_limit(memory_limit)
+            .threads(threads)
+            .output_compression(1)
+            .temp_compression(1)
+    };
+
+    // Terminal framed-block path.
+    let block_out = drive_sort_block_pipeline(
+        make_sorter(),
+        &header,
+        pack_batches(&records, 256),
+        4 * 1024 * 1024,
+        threads,
+        StepKind::Exclusive,
+        SortDecompressTuning::default(),
+        SpillCodec::Zstd,
+    )
+    .expect("block pipeline drives to completion");
+
+    // Intermediate RecordBatch path — the framed bytes must un-frame to exactly
+    // the records this path emits (cross-check the two SortMerge framings agree).
+    let batch_out = drive_sort_buffer_pipeline(
+        make_sorter(),
+        &header,
+        pack_batches(&records, 256),
+        4 * 1024 * 1024,
+        threads,
+        StepKind::Exclusive,
+        SortDecompressTuning::default(),
+        SpillCodec::Zstd,
+    )
+    .expect("buffer pipeline drives to completion");
+
+    let legacy_out =
+        sort_via_legacy(sort_order, &header, &records, memory_limit, threads).expect("legacy");
+
+    assert_eq!(block_out.len(), legacy_out.len(), "{sort_order:?} record count vs legacy");
+    assert_eq!(block_out.len(), batch_out.len(), "{sort_order:?} record count vs RecordBatch path");
+
+    if is_stable_for_equal_keys(sort_order) {
+        // Stable orders: byte-for-byte identical output, in order.
+        for (i, (got, want)) in block_out.iter().zip(legacy_out.iter()).enumerate() {
+            assert_eq!(got, want, "{sort_order:?} record {i} (block path vs legacy) differs");
+        }
+        assert_eq!(block_out, batch_out, "{sort_order:?} block vs RecordBatch path bytes differ");
+    } else {
+        // Queryname's comparator sort is unstable on equal keys; assert multiset
+        // equality (same records, possibly different equal-key order).
+        let mut got = block_out.clone();
+        let mut want = legacy_out.clone();
+        got.sort_unstable();
+        want.sort_unstable();
+        assert_eq!(got, want, "{sort_order:?} block-path record multiset differs from oracle");
+
+        // The two framings must also agree with EACH OTHER. Without this the
+        // unstable branch only length-checks `batch_out`, so a framing divergence
+        // between `SortMerge<BlockOutput>` and `SortMerge<RecordBatchOutput>`
+        // that preserved record count would pass the queryname cases silently.
+        let mut batch_sorted = batch_out.clone();
+        batch_sorted.sort_unstable();
+        assert_eq!(
+            got, batch_sorted,
+            "{sort_order:?} block vs RecordBatch path record multiset differs"
+        );
+    }
+}
+
+/// `true` for sort orders whose sort is stable on equal keys (so byte-for-byte
+/// output parity is deterministic). Queryname's comparator sort is unstable.
+fn is_stable_for_equal_keys(order: SortOrder) -> bool {
+    matches!(order, SortOrder::Coordinate | SortOrder::TemplateCoordinate)
+}
+
+/// L2.6: a `StepKind::Detached` SINK — the `WriteBgzfFile` analogue, i.e. the
+/// detached-thread runtime driving a pure consumer — yields byte-identical
+/// merged output to the legacy oracle, exactly like the pool-scheduled sink.
+/// The chain's `SortMerge` is already `Detached`, so this drives the full chain
+/// through `pipeline.run` with TWO off-pool threads (merge + sink) over a
+/// multi-spill coordinate workload, pinning that `run_detached_driver` preserves
+/// the output bytes for both the producing (merge) and consuming (sink) roles.
+#[test]
+fn detached_sink_chain_matches_legacy_coordinate() {
+    let memory_limit = 64 * 1024; // small → forces many real spill files
+    let threads = 4;
+    let (header, records) = synthesize_records(20_000, 0xD17A_C4ED);
+    let sorter = RawExternalSorter::new(SortOrder::Coordinate)
+        .memory_limit(memory_limit)
+        .threads(threads)
+        .output_compression(1)
+        .temp_compression(1);
+    let detached_out = drive_sort_buffer_pipeline(
+        sorter,
+        &header,
+        pack_batches(&records, 256),
+        4 * 1024 * 1024,
+        threads,
+        StepKind::Detached,
+        SortDecompressTuning::default(),
+        SpillCodec::Zstd,
+    )
+    .expect("detached-sink buffer pipeline drives to completion");
+
+    let legacy_out =
+        sort_via_legacy(SortOrder::Coordinate, &header, &records, memory_limit, threads)
+            .expect("legacy");
+
+    assert_eq!(detached_out.len(), legacy_out.len(), "record count mismatch");
+    for (i, (got, want)) in detached_out.iter().zip(legacy_out.iter()).enumerate() {
+        assert_eq!(got, want, "detached-sink record {i} bytes differ from oracle");
+    }
+}
+
+/// The buffer chain must hold coordinate parity across BOTH decompress
+/// granularities × block batches, with a multi-spill workload that forces real
+/// spill files (so `CompressSpill`'s written chunks feed the block-parallel
+/// reorder path). Guards against any spill-format / slot-ordering drift between
+/// `CompressSpill` and the proven `SortSpillDecompress` reader.
+#[rstest]
+#[case::file_b1(true, 1)]
+#[case::file_b4(true, 4)]
+#[case::block_b1(false, 1)]
+#[case::block_b4(false, 4)]
+fn sort_buffer_chain_coordinate_matches_legacy_across_decompress_tunings(
+    #[case] file_granularity: bool,
+    #[case] block_batch: usize,
+) {
+    let (header, records) = synthesize_records(20_000, 0xBADD_CAFE);
+    let memory_limit = 256 * 1024;
+    let threads = 2;
+    let sorter = RawExternalSorter::new(SortOrder::Coordinate)
+        .memory_limit(memory_limit)
+        .threads(threads)
+        .output_compression(1)
+        .temp_compression(1);
+    let new_out = drive_sort_buffer_pipeline(
+        sorter,
+        &header,
+        pack_batches(&records, 256),
+        4 * 1024 * 1024,
+        // Exactly the case's thread count (see the sibling test): production
+        // runs the pipeline with `num_threads`, no `max(3)` floor.
+        threads,
+        StepKind::Exclusive,
+        SortDecompressTuning { file_granularity, block_batch },
+        SpillCodec::Zstd,
+    )
+    .expect("buffer pipeline drives to completion");
+
+    let legacy_out =
+        sort_via_legacy(SortOrder::Coordinate, &header, &records, memory_limit, threads)
+            .expect("legacy");
+
+    assert_eq!(new_out.len(), legacy_out.len(), "record count mismatch");
+    for (i, (got, want)) in new_out.iter().zip(legacy_out.iter()).enumerate() {
+        assert_eq!(got, want, "record {i} bytes differ");
+    }
+}
+
+/// Equal-key stability across spill boundaries — the output-identity-critical
+/// tie-break the single-residual design depends on. Every record shares one
+/// coordinate (tid 0, pos 0), so a stable sort must emit them in input order;
+/// the buffer chain must preserve that across multiple spill chunks (tie-broken
+/// by `file_id == seq`) and the residual. Pinned both directly (output == input
+/// order) and against the legacy oracle.
+#[test]
+fn sort_buffer_chain_preserves_equal_key_input_order_across_spills() {
+    let header = Header::default();
+    // All at tid 0, pos 0 → identical coordinate key; names encode input order.
+    // 6_000 records against a tiny memory limit forces several spill chunks.
+    let records: Vec<RawRecord> = (0..6_000u32)
+        .map(|i| {
+            let name = format!("r{i:06}");
+            RawRecord::from(make_bam_bytes(0, 0, 0, name.as_bytes(), &[], 80, -1, -1, &[]))
+        })
+        .collect();
+    let input_bytes: RecordBytes = records.iter().map(|r| r.as_ref().to_vec()).collect();
+    let memory_limit = 256 * 1024;
+
+    let sorter = RawExternalSorter::new(SortOrder::Coordinate)
+        .memory_limit(memory_limit)
+        .threads(2)
+        .output_compression(1)
+        .temp_compression(1);
+    let out = drive_sort_buffer_pipeline(
+        sorter,
+        &header,
+        pack_batches(&records, 256),
+        4 * 1024 * 1024,
+        2,
+        StepKind::Exclusive,
+        SortDecompressTuning::default(),
+        SpillCodec::Zstd,
+    )
+    .expect("buffer pipeline drives to completion");
+
+    assert_eq!(out.len(), input_bytes.len(), "record count mismatch");
+    assert_eq!(out, input_bytes, "equal-key records must preserve input order across spills");
+
+    let legacy =
+        sort_via_legacy(SortOrder::Coordinate, &header, &records, memory_limit, 2).expect("legacy");
+    assert_eq!(out, legacy, "equal-key order must also match the legacy oracle");
+}
+
+// ── Decompression-granularity parity (file-granularity × block-batch) ────────
+
+/// The streaming sort must produce byte-identical output for BOTH decompression
+/// granularities (`file_granularity ∈ {true, false}`) across `block_batch ∈
+/// {1, 4}`, validated against the legacy reference. The multi-spill workload
+/// forces real spill files so the block-parallel reorder path is exercised (the
+/// in-memory-only path never opens a slot reader).
+#[rstest]
+#[case::file_b1(true, 1)]
+#[case::file_b4(true, 4)]
+#[case::block_b1(false, 1)]
+#[case::block_b4(false, 4)]
+// block_batch == 0 is clamped to 1 in `SortSpillDecompress::new`. Without the
+// clamp, the inline path declares a phantom EOF after reading zero blocks
+// (silent record loss) and the block-parallel path livelocks (queue_eof never
+// finalizes). These cases assert the clamp holds: identical to legacy, no hang.
+#[case::file_b0(true, 0)]
+#[case::block_b0(false, 0)]
+fn three_step_chain_granularity_matrix_matches_legacy(
+    #[case] file_granularity: bool,
+    #[case] block_batch: usize,
+) {
+    let sort_order = SortOrder::Coordinate;
+    let threads = 4;
+    let (header, records) = synthesize_sized_records(30_000, 0x5EED_1234, 120);
+    // Small per-thread memory ⇒ many spill files ⇒ many slot blocks.
+    let memory_limit = 256 * 1024;
+
+    let sorter = RawExternalSorter::new(sort_order)
+        .memory_limit(memory_limit)
+        .threads(2)
+        .output_compression(1)
+        .temp_compression(1);
+    let new_out = drive_sort_pipeline_tuned(
+        sorter,
+        &header,
+        pack_batches(&records, 256),
+        4 * 1024 * 1024,
+        threads,
+        StepKind::Exclusive,
+        SortDecompressTuning { file_granularity, block_batch },
+        SpillCodec::Zstd,
+    )
+    .expect("pipeline drives to completion");
+
+    let legacy_out =
+        sort_via_legacy(sort_order, &header, &records, memory_limit, 2).expect("legacy");
+
+    assert_eq!(
+        new_out.len(),
+        legacy_out.len(),
+        "record count mismatch (file_granularity={file_granularity}, block_batch={block_batch})"
+    );
+    assert_eq!(
+        new_out, legacy_out,
+        "sorted bytes differ (file_granularity={file_granularity}, block_batch={block_batch})"
+    );
+}
+
+/// Block-parallel decompression over BGZF spill files (the non-default codec)
+/// must also match the legacy sorter — the matrix/soak/proptest exercise the
+/// default zstd spills, so this confirms the block-parallel reorder path is
+/// codec-agnostic. (Output records are codec-independent: the spill codec only
+/// affects temp files, not the sorted output.)
+#[test]
+fn block_parallel_bgzf_spill_matches_legacy() {
+    let sort_order = SortOrder::Coordinate;
+    let (header, records) = synthesize_sized_records(30_000, 0x5EED_BEEF, 120);
+    let memory_limit = 256 * 1024;
+    let sorter = RawExternalSorter::new(sort_order)
+        .memory_limit(memory_limit)
+        .threads(2)
+        .output_compression(1)
+        .temp_compression(1)
+        .spill_codec(fgumi_sort::SpillCodec::Bgzf);
+    let new_out = drive_sort_pipeline_tuned(
+        sorter,
+        &header,
+        pack_batches(&records, 256),
+        4 * 1024 * 1024,
+        8,
+        StepKind::Exclusive,
+        SortDecompressTuning { file_granularity: false, block_batch: 2 },
+        SpillCodec::Bgzf,
+    )
+    .expect("pipeline drives to completion");
+    let legacy_out =
+        sort_via_legacy(sort_order, &header, &records, memory_limit, 2).expect("legacy");
+    assert_eq!(new_out.len(), legacy_out.len(), "record count mismatch (bgzf block-parallel)");
+    assert_eq!(new_out, legacy_out, "sorted bytes differ (bgzf block-parallel)");
+}
+
+/// Block-parallel decompression completes out of order (workers decompress one
+/// file's blocks concurrently), yet the reassembled output must be byte-
+/// identical to the in-order (file-granularity) result. Property test over a
+/// range of record counts and `block_batch` sizes and a high pipeline-thread
+/// count (more concurrent decompressors ⇒ more out-of-order completion). A
+/// straggler worker hitting reader-EOF while another holds an in-flight block
+/// must not truncate the output (record count is asserted equal).
+#[cfg(test)]
+// Soak/matrix/proptest suites: multi-minute, so gated off the default test
+// target and run on the nightly `cargo ci-test-stress` job instead.
+#[cfg(feature = "stress-tests")]
+mod proptests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 24, ..ProptestConfig::default() })]
+
+        #[test]
+        fn block_parallel_matches_file_granularity(
+            n_records in 2_000usize..18_000,
+            block_batch in 1usize..=6,
+            seed in any::<u64>(),
+        ) {
+            let sort_order = SortOrder::Coordinate;
+            let (header, records) = synthesize_sized_records(n_records, seed, 100);
+            // Force spilling so slots (and the reorder path) are exercised.
+            let memory_limit = 256 * 1024;
+            let pipeline_threads = 6;
+
+            let make_sorter = || RawExternalSorter::new(sort_order)
+                .memory_limit(memory_limit)
+                .threads(2)
+                .output_compression(1)
+                .temp_compression(1);
+
+            let in_order = drive_sort_pipeline_tuned(
+                make_sorter(),
+                &header,
+                pack_batches(&records, 256),
+                4 * 1024 * 1024,
+                pipeline_threads,
+                StepKind::Exclusive,
+                SortDecompressTuning { file_granularity: true, block_batch },
+                SpillCodec::Zstd,
+            ).expect("file-granularity pipeline");
+
+            let out_of_order = drive_sort_pipeline_tuned(
+                make_sorter(),
+                &header,
+                pack_batches(&records, 256),
+                4 * 1024 * 1024,
+                pipeline_threads,
+                StepKind::Exclusive,
+                SortDecompressTuning { file_granularity: false, block_batch },
+                SpillCodec::Zstd,
+            ).expect("block-parallel pipeline");
+
+            prop_assert_eq!(out_of_order.len(), records.len(), "no truncation");
+            prop_assert_eq!(out_of_order, in_order, "block-parallel diverges from in-order");
+        }
+    }
+}
+
+#[cfg(feature = "stress-tests")]
+/// Maximum-contention soak for the block-parallel decompress path
+/// (`file_granularity == false`). Drives the path repeatedly under the most
+/// adversarial settings the knobs allow — many spill files, a tiny reorder
+/// window (so stragglers continuously hit `bp_reorder_admits` backpressure and
+/// the Phase-B drain-only path), `block_batch == 1` (maximum per-block churn and
+/// the most frequent `reader_eof`/`in_flight` transitions), and far more
+/// pipeline worker threads (12) than sorter threads (so many workers race to
+/// decompress one file's blocks concurrently and finalize out of order).
+///
+/// Each iteration uses a fresh random seed and is checked for *byte-identity*
+/// against the legacy `RawExternalSorter::sort` oracle — so a lost, duplicated,
+/// or reordered block (the truncation class the `reader_eof`/`in_flight`
+/// protocol guards against) fails the assertion. Each iteration runs under a
+/// per-iteration wall-clock watchdog (via `run_watchdogged_parity`): a livelock
+/// (e.g. `queue_eof` never finalizing) trips the timeout and fails the test
+/// instead of hanging CI.
+///
+/// This complements the loom model (exhaustive but tiny) and the proptest
+/// (random sizes, moderate threads) by hammering the REAL pipeline under
+/// sustained high contention for many iterations.
+#[test]
+fn block_parallel_high_contention_soak_matches_legacy() {
+    use std::time::Duration;
+
+    const ITERATIONS: usize = 40;
+    const RECORDS_PER_ITER: usize = 15_000;
+    const PIPELINE_THREADS: usize = 12;
+    const SORTER_THREADS: usize = 2;
+    // Tiny per-thread sort memory ⇒ many spill files ⇒ many slot readers.
+    const MEMORY_LIMIT: usize = 128 * 1024;
+    // Tiny output/reorder-window budget ⇒ the block-parallel reorder window is
+    // ~1 block, so `bp_reorder_admits` backpressures aggressively and workers
+    // are repeatedly forced through the Phase-B drain-only path.
+    const OUTPUT_BYTE_LIMIT: u64 = 64 * 1024;
+    const BLOCK_BATCH: usize = 1;
+    // Per-iteration watchdog: a livelock in any single iteration fails fast.
+    const WATCHDOG: Duration = Duration::from_secs(60);
+
+    let sort_order = SortOrder::Coordinate;
+    for iter in 0..ITERATIONS {
+        let seed = 0xA5A5_0000_u64 ^ (iter as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        let (header, records) = synthesize_sized_records(RECORDS_PER_ITER, seed, 110);
+        run_watchdogged_parity(
+            &format!("hc-soak-i{iter}"),
+            sort_order,
+            header,
+            records,
+            MEMORY_LIMIT,
+            SORTER_THREADS,
+            PIPELINE_THREADS,
+            OUTPUT_BYTE_LIMIT,
+            SortDecompressTuning { file_granularity: false, block_batch: BLOCK_BATCH },
+            WATCHDOG,
+        );
+    }
+}
+
+#[cfg(feature = "stress-tests")]
+/// Maximum-churn soak over the `SortBuffer` chain: a *tiny* memory limit seals a
+/// run after only a handful of records, so the chain cycles
+/// seal → compress → spill → decompress → merge as fast as it can while eight
+/// pipeline threads contend for the `Serial` steps. A wedge (a step parking
+/// while a downstream holds the chunk it is waiting on) trips the per-iteration
+/// watchdog and fails fast instead of hanging, and byte-parity against the
+/// legacy oracle proves nothing is lost, duplicated, or reordered under churn.
+///
+/// NOTE: this drives `drive_sort_pipeline_tuned` (the record-input `SortBuffer`
+/// chain), NOT the block-input arena front. The front's capacity-1 arena cycle —
+/// `ReadBlocks` acquire+admit and `FindBoundariesAndSort` seal+free on the
+/// coordination driver with `InflateToArena` on the pool in between — is covered
+/// by `arena_front_chain_seals_multiple_runs_without_losing_records`, which seals
+/// several runs through the real runtime and so exercises acquire/seal/free
+/// across runs. That test is not a *soak*: there is no watchdogged high-churn
+/// coverage of the arena front yet.
+#[test]
+fn sort_buffer_chain_tight_memory_soak_no_deadlock() {
+    use std::time::Duration;
+
+    const ITERATIONS: usize = 24;
+    const RECORDS_PER_ITER: usize = 12_000;
+    const PIPELINE_THREADS: usize = 8;
+    const SORTER_THREADS: usize = 4;
+    // Very tight sort memory ⇒ `SortBuffer` seals after only a handful of
+    // records ⇒ maximal seal/spill/merge churn across the pipeline threads.
+    const MEMORY_LIMIT: usize = 24 * 1024;
+    const OUTPUT_BYTE_LIMIT: u64 = 48 * 1024;
+    const WATCHDOG: Duration = Duration::from_secs(60);
+
+    for iter in 0..ITERATIONS {
+        let seed = 0xC0FF_EE00_u64 ^ (iter as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        let (header, records) = synthesize_sized_records(RECORDS_PER_ITER, seed, 130);
+        run_watchdogged_parity(
+            &format!("tight-memory-soak-i{iter}"),
+            SortOrder::Coordinate,
+            header,
+            records,
+            MEMORY_LIMIT,
+            SORTER_THREADS,
+            PIPELINE_THREADS,
+            OUTPUT_BYTE_LIMIT,
+            SortDecompressTuning { file_granularity: false, block_batch: 1 },
+            WATCHDOG,
+        );
+    }
+}
+
+/// Assert two record-byte streams are identical, reporting only the FIRST
+/// mismatch (index + lengths + 16-byte prefixes). A blanket `assert_eq!` on the
+/// two `Vec<Vec<u8>>` would dump tens of thousands of binary records into CI
+/// logs on divergence; this keeps a failure readable while still catching any
+/// lost / duplicated / reordered / corrupted record.
+fn assert_record_parity(label: &str, actual: &[Vec<u8>], expected: &[Vec<u8>]) {
+    if let Some((idx, (a, b))) = actual.iter().zip(expected).enumerate().find(|(_, (a, b))| a != b)
+    {
+        panic!(
+            "{label}: output diverges from legacy at record {idx}: \
+             actual_len={}, expected_len={}, actual_prefix={:?}, expected_prefix={:?}",
+            a.len(),
+            b.len(),
+            &a[..a.len().min(16)],
+            &b[..b.len().min(16)],
+        );
+    }
+    // No record differs within the common prefix; a length delta is the only
+    // remaining divergence (truncation or duplication).
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{label}: record count mismatch (truncation/duplication)"
+    );
+}
+
+/// Run one watchdog-guarded streaming sort and assert byte-identity against the
+/// legacy oracle. Owns `header`/`records` so the worker thread can take them.
+///
+/// Both the legacy oracle AND the streaming pipeline run *inside* the worker, so
+/// the `recv_timeout` watchdog covers both — a stall in either (the path under
+/// test or, defensively, the reference sorter) fails the test fast instead of
+/// hanging the test process. The merge sink is `Serial` (every watchdog'd parity
+/// caller drives the streaming three-step chain). Panics (failing the test) on
+/// divergence, pipeline/oracle error, watchdog timeout (livelock), or a worker
+/// panic — never hangs.
+#[allow(clippy::too_many_arguments)]
+fn run_watchdogged_parity(
+    label: &str,
+    sort_order: SortOrder,
+    header: Header,
+    records: Vec<RawRecord>,
+    memory_limit: usize,
+    sorter_threads: usize,
+    pipeline_threads: usize,
+    output_byte_limit: u64,
+    tuning: SortDecompressTuning,
+    watchdog: std::time::Duration,
+) {
+    use std::sync::mpsc;
+
+    let (tx, rx) = mpsc::channel();
+    let worker = std::thread::Builder::new()
+        .name(label.to_string())
+        .spawn(move || {
+            // (pipeline_out, legacy_out) — both computed under the watchdog.
+            let result = (|| -> Result<(RecordBytes, RecordBytes)> {
+                let legacy_out =
+                    sort_via_legacy(sort_order, &header, &records, memory_limit, sorter_threads)?;
+                let batches = pack_batches(&records, 256);
+                let sorter = RawExternalSorter::new(sort_order)
+                    .memory_limit(memory_limit)
+                    .threads(sorter_threads)
+                    .output_compression(1)
+                    .temp_compression(1);
+                let out = drive_sort_pipeline_tuned(
+                    sorter,
+                    &header,
+                    batches,
+                    output_byte_limit,
+                    pipeline_threads,
+                    StepKind::Serial,
+                    tuning,
+                    SpillCodec::Zstd,
+                )?;
+                Ok((out, legacy_out))
+            })();
+            let _ = tx.send(result);
+        })
+        .expect("spawn soak worker");
+
+    match rx.recv_timeout(watchdog) {
+        Ok(Ok((out, legacy_out))) => {
+            assert_record_parity(label, &out, &legacy_out);
+            worker.join().expect("soak worker panicked");
+        }
+        Ok(Err(e)) => panic!("{label}: pipeline/oracle errored: {e:#}"),
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            panic!("{label}: DEADLOCK/LIVELOCK — sort did not complete within {watchdog:?}")
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            panic!("{label}: soak worker dropped its sender (panicked?)")
+        }
+    }
+}
+
+#[cfg(feature = "stress-tests")]
+/// Spill-pressure regimes for the block-parallel soak matrix. Both force real
+/// spill files (so slot readers and the Phase-2 reorder path run); they differ
+/// in how the spilled data is shaped across files.
+#[derive(Clone, Copy, Debug)]
+enum SoakRegime {
+    /// Larger-than-budget workload: total spilled bytes vastly exceed the
+    /// in-memory sort budget, producing MANY small spill files (tens). This is
+    /// the mandatory larger-than-RAM run — the external merge over many slot
+    /// readers, with frequent cross-file `reader_eof`/`in_flight` transitions,
+    /// is the case the truncation protocol must survive.
+    ManySmallFiles,
+    /// A handful of LARGE spill files: the budget admits a big batch, so only a
+    /// few (but > 1) files spill, each with many blocks. Stresses long per-file
+    /// block runs and the per-slot reorder window rather than cross-file churn.
+    FewLargeFiles,
+}
+
+#[cfg(feature = "stress-tests")]
+struct SoakParams {
+    records: usize,
+    seq_len: usize,
+    memory_limit: usize,
+    output_byte_limit: u64,
+    block_batch: usize,
+}
+
+#[cfg(feature = "stress-tests")]
+impl SoakRegime {
+    /// Discriminant folded into the per-case seed so each regime sorts a
+    /// distinct record set.
+    fn seed_salt(self) -> u64 {
+        match self {
+            SoakRegime::ManySmallFiles => 0x1111_1111_1111_1111,
+            SoakRegime::FewLargeFiles => 0x2222_2222_2222_2222,
+        }
+    }
+
+    fn params(self) -> SoakParams {
+        match self {
+            // ~40k records ≈ 10 MB spilled into many (~100) small files at a
+            // 96 KiB budget, with a tiny reorder window and block_batch == 1
+            // (max per-block churn and the most `reader_eof`/`in_flight` events).
+            SoakRegime::ManySmallFiles => SoakParams {
+                records: 40_000,
+                seq_len: 150,
+                memory_limit: 96 * 1024,
+                output_byte_limit: 128 * 1024,
+                block_batch: 1,
+            },
+            // ~12k × 150B ≈ 1.8 MB spilled into ~4 large files at a 512 KiB
+            // budget, with a roomy window and block_batch == 4.
+            SoakRegime::FewLargeFiles => SoakParams {
+                records: 12_000,
+                seq_len: 150,
+                memory_limit: 512 * 1024,
+                output_byte_limit: 4 * 1024 * 1024,
+                block_batch: 4,
+            },
+        }
+    }
+}
+
+#[cfg(feature = "stress-tests")]
+/// External-watchdog soak MATRIX for the Phase-2 decompress path. Crosses
+/// pipeline-thread count × decompress granularity × spill regime, so both the
+/// block-parallel reorder/in-flight/EOF protocol and the file-granularity FIFO
+/// are hammered across {1, 2, 8} workers, {many small, few large} spill-file
+/// shapes, and both code paths. Each (case × iteration) runs under a wall-clock
+/// watchdog and is checked byte-for-byte against the legacy oracle, so a
+/// livelock fails fast and any lost / duplicated / reordered block is caught.
+///
+/// `rstest` generates the full cross product (3 × 2 × 2 = 12 cases); nextest runs
+/// them as independent parallel tests. The mandatory larger-than-budget run is
+/// `ManySmallFiles` (~100 spill files at a 96 KiB budget). This is the real P5
+/// hardening gate the OFF-default flip rests on; it complements the loom model
+/// (exhaustive but tiny), the proptest (random sizes), and the single-corner
+/// high-contention soak (12 threads, 1-block window).
+#[rstest]
+fn block_parallel_soak_matrix_matches_legacy(
+    #[values(1, 2, 8)] pipeline_threads: usize,
+    #[values(true, false)] file_granularity: bool,
+    #[values(SoakRegime::ManySmallFiles, SoakRegime::FewLargeFiles)] regime: SoakRegime,
+) {
+    use std::time::Duration;
+
+    const ITERATIONS: usize = 4;
+    const SORTER_THREADS: usize = 2;
+    const WATCHDOG: Duration = Duration::from_secs(120);
+
+    let sort_order = SortOrder::Coordinate;
+    let SoakParams { records, seq_len, memory_limit, output_byte_limit, block_batch } =
+        regime.params();
+
+    for iter in 0..ITERATIONS {
+        // Distinct seed per (regime, threads, granularity, iter).
+        let seed = 0x50A4_0000_u64
+            .wrapping_add((iter as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15))
+            .wrapping_add((pipeline_threads as u64) << 40)
+            .wrapping_add(u64::from(file_granularity) << 32)
+            ^ regime.seed_salt();
+        let (header, recs) = synthesize_sized_records(records, seed, seq_len);
+        let label = format!(
+            "soak-{regime:?}-t{pipeline_threads}-fg{file_granularity}-bb{block_batch}-i{iter}"
+        );
+        run_watchdogged_parity(
+            &label,
+            sort_order,
+            header,
+            recs,
+            memory_limit,
+            SORTER_THREADS,
+            pipeline_threads,
+            output_byte_limit,
+            SortDecompressTuning { file_granularity, block_batch },
+            WATCHDOG,
+        );
+    }
+}
+
+/// Number of reference sequences the synthetic header declares.
+const N_TEST_REFS: usize = 4;
+
+fn synthesize_sized_records(n: usize, seed: u64, seq_len: usize) -> (Header, Vec<RawRecord>) {
+    let mut state = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);
+    let mut next_u32 = || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        #[allow(clippy::cast_possible_truncation)]
+        let v = state as u32;
+        v
+    };
+
+    // Reference sequences must exist for the mapped records below to carry a
+    // meaningful coordinate key.
+    let header = {
+        use noodles::sam::header::record::value::Map;
+        use noodles::sam::header::record::value::map::ReferenceSequence;
+        use std::num::NonZeroUsize;
+        let len = NonZeroUsize::new(1_000_000).expect("nonzero");
+        let mut builder = Header::builder();
+        for i in 0..N_TEST_REFS {
+            builder = builder
+                .add_reference_sequence(format!("chr{i}"), Map::<ReferenceSequence>::new(len));
+        }
+        builder.build()
+    };
+    let mut records = Vec::with_capacity(n);
+    for i in 0..n {
+        let name = format!("rd_{}", next_u32() % 100_000);
+        let pos: i32 = (next_u32() % 1_000_000).cast_signed();
+        let is_paired = i % 2 == 0;
+        // Most records are MAPPED across a handful of references. With
+        // `tid = -1` everywhere, `extract_coordinate_key_inline` returns
+        // `RawCoordinateKey::unmapped()` (`u64::MAX`) for every record, `pos` is
+        // never read, and the coordinate cases degenerate into one equal-key
+        // bucket — they would pass even if the key comparison were broken. Every
+        // eighth record stays unmapped so the equal-key/tie path is still covered.
+        let unmapped = i % 8 == 0;
+        #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+        let tid: i32 = if unmapped { -1 } else { (i % N_TEST_REFS) as i32 };
+        let flags: u16 = if unmapped { 0x4 } else { 0 } | if is_paired { 0x1 | 0x8 } else { 0 };
+        let bytes = make_bam_bytes(tid, pos, flags, name.as_bytes(), &[], seq_len, -1, -1, &[]);
+        records.push(RawRecord::from(bytes));
+    }
+    (header, records)
+}
+
+#[rstest]
+#[case::t1(1)]
+#[case::t2(2)]
+#[case::t4(4)]
+#[case::t8(8)]
+fn three_step_chain_large_spill_completes(#[case] pipeline_threads: usize) {
+    use std::time::Duration;
+
+    let (header, records) = synthesize_sized_records(60_000, 0xBADD_CAFE, 200);
+    // Default decompress tuning (block-parallel, block_batch 4) under a
+    // per-case watchdog: the regression this pins is a deadlock at high
+    // pipeline-thread counts, so the watchdog converts a hang into a failure.
+    run_watchdogged_parity(
+        &format!("large-spill-t{pipeline_threads}"),
+        SortOrder::Coordinate,
+        header,
+        records,
+        1024 * 1024, // sort memory_limit
+        2,           // sorter_threads
+        pipeline_threads,
+        256 * 1024 * 1024, // output queue limit
+        SortDecompressTuning::default(),
+        Duration::from_secs(90),
+    );
+}
+
+#[test]
+fn three_step_chain_empty_input_drains_cleanly() {
+    let header = Header::default();
+    let sorter = RawExternalSorter::new(SortOrder::Coordinate).memory_limit(1024 * 1024);
+    let out = drive_sort_pipeline(sorter, &header, Vec::new(), 64 * 1024, 3, StepKind::Exclusive)
+        .expect("empty pipeline");
+    assert!(out.is_empty());
+}
+
+// ── SortMerge fail-closed regression tests ──────────────────────────────────
+
+/// `Exclusive` source that drains a `Vec<SortPhase2Event>` one event per
+/// `try_run`, feeding `SortMerge` directly. Used to drive the merge into a
+/// drained-but-incomplete-setup state without standing up the spill machinery.
+struct Phase2EventSource {
+    events: Vec<crate::sort::protocol::SortPhase2Event>,
+    held: HeldSlot<Unpushed<crate::sort::protocol::SortPhase2Event>>,
+    output_byte_limit: u64,
+}
+
+impl Phase2EventSource {
+    fn new(
+        mut events: Vec<crate::sort::protocol::SortPhase2Event>,
+        output_byte_limit: u64,
+    ) -> Self {
+        events.reverse();
+        Self { events, held: HeldSlot::new(), output_byte_limit }
+    }
+}
+
+impl Step for Phase2EventSource {
+    type Input = ();
+    type Outputs = fgumi_pipeline_core::outputs::Single<crate::sort::protocol::SortPhase2Event>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "Phase2EventSource",
+            kind: StepKind::Exclusive,
+            sticky: true,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::None],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Progress);
+                }
+            }
+        }
+        let Some(event) = self.events.pop() else {
+            return Ok(StepOutcome::Finished);
+        };
+        match ctx.outputs.push(event) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+}
+
+fn run_merge_over_events(
+    events: Vec<crate::sort::protocol::SortPhase2Event>,
+) -> Result<Vec<Vec<u8>>> {
+    // Delegates to `collect_merge_batches` so the merge chain is wired in exactly
+    // one place; this helper only flattens the batches into per-record bytes.
+    let batches = collect_merge_batches(events, 1 << 20, 256)?;
+    let mut out = Vec::new();
+    for batch in batches {
+        for bytes in batch.iter_record_bytes() {
+            out.push(bytes.to_vec());
+        }
+    }
+    Ok(out)
+}
+
+/// A wholly empty event stream (no payload, no `AllAnnounced`) is the one
+/// legitimate drained-but-not-ready case: it merges to an empty output.
+#[test]
+fn test_sort_merge_empty_input_merges_to_empty() {
+    let out = run_merge_over_events(Vec::new()).expect("empty merge should succeed");
+    assert!(out.is_empty(), "expected no records, got {}", out.len());
+}
+
+/// An `AllAnnounced` that promises a slot which never arrives leaves the setup
+/// incomplete when the input drains; `SortMerge` must fail closed rather than
+/// silently merge a partial result.
+#[test]
+fn test_sort_merge_fails_closed_on_incomplete_setup() {
+    let events = vec![crate::sort::protocol::SortPhase2Event::AllAnnounced {
+        slot_count: 1,
+        memory_chunk_count: 0,
+        total_records: 0,
+    }];
+    let err = run_merge_over_events(events).expect_err("incomplete setup must error");
+    let msg = err.to_string();
+    assert!(msg.contains("setup incomplete at input drain"), "unexpected error message: {msg}");
+}
+
+// ── SortMerge output-buffer sizing + duplicate-AllAnnounced regression ───────
+
+/// Drive `SortMerge` over `events` and return the *batches* it emits (not the
+/// flattened records), so tests can inspect per-batch buffer capacity.
+fn collect_merge_batches(
+    events: Vec<crate::sort::protocol::SortPhase2Event>,
+    output_byte_limit: u64,
+    target_batch_count: usize,
+) -> Result<Vec<RecordBatch>> {
+    let received: Arc<Mutex<Vec<RecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let source = Phase2EventSource::new(events, output_byte_limit);
+    let merge = SortMerge::<RecordBatchOutput>::with_target_batch_count(
+        SortOrder::Coordinate,
+        output_byte_limit,
+        target_batch_count,
+    );
+    let sink = VecSink { received: Arc::clone(&received), kind: StepKind::Serial };
+
+    let builder = Pipeline::builder();
+    builder.chain(source).chain(merge).chain(sink).into_sink_marker();
+    let pipeline = builder.build()?;
+    pipeline.run(PipelineConfig { threads: 1, ..Default::default() })?;
+
+    Ok(std::mem::take(&mut *received.lock()))
+}
+
+/// Wrap `records` as a single coordinate-sorted in-memory chunk event. All keys
+/// are `default()` (equal) — order does not matter for the buffer-sizing and
+/// duplicate-announcement assertions, only that the chunk merges cleanly.
+fn coordinate_memory_chunk_event(
+    records: Vec<RawRecord>,
+) -> crate::sort::protocol::SortPhase2Event {
+    use crate::sort::protocol::MemoryChunkErased;
+    let total = records.len() as u64;
+    let chunk = fgumi_sort::InMemoryChunk::from_owned_records(
+        records
+            .into_iter()
+            .map(|r| (fgumi_sort::RawCoordinateKey::default(), r.into_inner()))
+            .collect(),
+    );
+    crate::sort::protocol::SortPhase2Event::MemoryChunk {
+        chunk: Arc::new(MemoryChunkErased::Coordinate(chunk)),
+        records_ingested_so_far: total,
+    }
+}
+
+/// Count-bound output batches must not each reserve the full output-queue byte
+/// budget. Drive a many-small-record merge that emits several count-capped
+/// batches and assert their total resident capacity stays well under one byte
+/// budget — it would be ~`num_batches * byte_limit` if every buffer reserved
+/// the full budget (the pre-fix behavior).
+#[test]
+fn test_sort_merge_does_not_over_reserve_output_buffers() {
+    use fgumi_pipeline_core::item::HeapSize;
+
+    let (_header, records) = synthesize_records(600, 7);
+    let byte_limit: u64 = 1 << 20; // 1 MiB
+    let target = 256;
+    let events = vec![
+        coordinate_memory_chunk_event(records),
+        crate::sort::protocol::SortPhase2Event::AllAnnounced {
+            slot_count: 0,
+            memory_chunk_count: 1,
+            total_records: 600,
+        },
+    ];
+    let batches = collect_merge_batches(events, byte_limit, target).expect("merge should succeed");
+
+    let emitted: usize = batches.iter().map(|b| b.iter_record_bytes().count()).sum();
+    assert_eq!(emitted, 600, "all records must be emitted");
+    assert!(
+        batches.len() >= 2,
+        "workload must span multiple count-bound batches, got {}",
+        batches.len()
+    );
+    let total_heap: usize = batches.iter().map(HeapSize::heap_size).sum();
+    assert!(
+        (total_heap as u64) < byte_limit,
+        "output buffers over-reserved: {total_heap} bytes across {} batches \
+         (would exceed one byte budget if each reserved the full {byte_limit})",
+        batches.len(),
+    );
+}
+
+/// The Phase-2 protocol emits exactly one `AllAnnounced`. A second one is a
+/// protocol violation; `SortMerge` must fail closed rather than overwrite its
+/// completion expectations. The first announcement over-promises (2 chunks) so
+/// setup never completes and the duplicate is still absorbed in setup.
+#[test]
+fn test_sort_merge_fails_closed_on_duplicate_all_announced() {
+    let (_header, records) = synthesize_records(1, 1);
+    let byte_limit: u64 = 1 << 20;
+    let events = vec![
+        coordinate_memory_chunk_event(records),
+        crate::sort::protocol::SortPhase2Event::AllAnnounced {
+            slot_count: 0,
+            memory_chunk_count: 2,
+            total_records: 1,
+        },
+        crate::sort::protocol::SortPhase2Event::AllAnnounced {
+            slot_count: 0,
+            memory_chunk_count: 2,
+            total_records: 1,
+        },
+    ];
+    let err = collect_merge_batches(events, byte_limit, 256)
+        .expect_err("duplicate AllAnnounced must error");
+    let msg = err.to_string();
+    assert!(msg.contains("duplicate AllAnnounced"), "unexpected error: {msg}");
+}
+
+/// The `Arc::try_unwrap` guard in `absorb_phase2_event` has no coverage from the
+/// other tests: `coordinate_memory_chunk_event` always mints a fresh `Arc`, so
+/// only the success path runs. The protocol moves memory chunks rather than
+/// cloning them, so a shared `Arc` at the merge consumer means a producer kept a
+/// handle — deep-cloning the record vector instead would silently double memory.
+#[test]
+fn test_sort_merge_fails_closed_on_shared_memory_chunk_arc() {
+    use crate::sort::protocol::{MemoryChunkErased, SortPhase2Event};
+
+    let (_header, records) = synthesize_records(8, 3);
+    let chunk =
+        Arc::new(MemoryChunkErased::Coordinate(fgumi_sort::InMemoryChunk::from_owned_records(
+            records
+                .into_iter()
+                .map(|r| (fgumi_sort::RawCoordinateKey::default(), r.into_inner()))
+                .collect(),
+        )));
+
+    // Two events sharing ONE Arc — the violation. `Arc::strong_count` is 2 when
+    // the merge tries to take ownership of the first.
+    let events = vec![
+        SortPhase2Event::MemoryChunk { chunk: Arc::clone(&chunk), records_ingested_so_far: 8 },
+        SortPhase2Event::MemoryChunk { chunk, records_ingested_so_far: 8 },
+        SortPhase2Event::AllAnnounced { slot_count: 0, memory_chunk_count: 2, total_records: 8 },
+    ];
+
+    let err = run_merge_over_events(events).expect_err("a shared chunk Arc must fail closed");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Arc unexpectedly shared"),
+        "expected the shared-Arc guard message, got: {msg}"
+    );
+}
+
+/// The buffer-sizing logic is duplicated in `next_batch` (the k-way `Merging`
+/// path) and `next_fast_batch` (the single-chunk fast path).
+/// `test_sort_merge_does_not_over_reserve_output_buffers` has zero slots and one
+/// memory chunk, so it only ever exercises the fast path — a regression that
+/// reintroduced full-budget reservation in `next_batch` would pass it. Two
+/// memory chunks force `build_driver` and the real k-way merge.
+#[test]
+fn test_sort_merge_does_not_over_reserve_on_the_kway_path() {
+    use fgumi_pipeline_core::item::HeapSize;
+
+    let (_header, first) = synthesize_records(300, 7);
+    let (_header2, second) = synthesize_records(300, 11);
+    let byte_limit: u64 = 1 << 20; // 1 MiB
+    let target = 256;
+
+    let events = vec![
+        coordinate_memory_chunk_event(first),
+        coordinate_memory_chunk_event(second),
+        crate::sort::protocol::SortPhase2Event::AllAnnounced {
+            slot_count: 0,
+            memory_chunk_count: 2,
+            total_records: 600,
+        },
+    ];
+    let batches = collect_merge_batches(events, byte_limit, target).expect("merge should succeed");
+
+    let emitted: usize = batches.iter().map(|b| b.iter_record_bytes().count()).sum();
+    assert_eq!(emitted, 600, "all records from both chunks must be emitted");
+    assert!(
+        batches.len() >= 2,
+        "workload must span multiple count-bound batches, got {}",
+        batches.len()
+    );
+    let total_heap: usize = batches.iter().map(HeapSize::heap_size).sum();
+    assert!(
+        (total_heap as u64) < byte_limit,
+        "k-way output buffers over-reserved: {total_heap} bytes across {} batches",
+        batches.len(),
+    );
+}
+
+// ── Arena block-input front (ReadBlocks → InflateToArena → FindBoundariesAndSort) ──
+
+/// `Exclusive` source draining a `Vec<BgzfBlock>` one block per `try_run`.
+struct BgzfBlockSource {
+    blocks: Vec<crate::types::BgzfBlock>,
+    held: HeldSlot<Unpushed<crate::types::BgzfBlock>>,
+    output_byte_limit: u64,
+}
+
+impl BgzfBlockSource {
+    fn new(mut blocks: Vec<crate::types::BgzfBlock>, output_byte_limit: u64) -> Self {
+        blocks.reverse();
+        Self { blocks, held: HeldSlot::new(), output_byte_limit }
+    }
+}
+
+impl Step for BgzfBlockSource {
+    type Input = ();
+    type Outputs = OrderedBytesSingle<crate::types::BgzfBlock>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "BgzfBlockSource",
+            kind: StepKind::Exclusive,
+            sticky: true,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Progress);
+                }
+            }
+        }
+        let Some(block) = self.blocks.pop() else {
+            return Ok(StepOutcome::Finished);
+        };
+        match ctx.outputs.push(block) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+}
+
+/// What the arena front produced: one entry per emitted chunk (in emit order)
+/// plus the terminal `AllAnnounced` counts.
+#[derive(Default)]
+struct ArenaFrontOutput {
+    chunks: Vec<RecordBytes>,
+    slot_count: u32,
+    total_records: u64,
+}
+
+/// Sink that copies each chunk's record bodies out and DROPS the chunk in the
+/// same `try_run`. Retaining the chunks instead would pin their arena `Arc`:
+/// `ReadBlocks` owns a capacity-1 arena pool, so run *k+1* cannot start until
+/// run *k*'s chunk is released, and a hoarding sink wedges the pipeline.
+struct ChunkEventSink {
+    received: Arc<Mutex<ArenaFrontOutput>>,
+}
+
+impl Step for ChunkEventSink {
+    type Input = SortChunkEvent;
+    type Outputs = ();
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ChunkEventSink",
+            kind: StepKind::Serial,
+            sticky: false,
+            output_queues: vec![],
+            branch_ordering: vec![],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        match ctx.input.pop() {
+            Some(event) => {
+                let mut out = self.received.lock();
+                match event {
+                    SortChunkEvent::Spill { chunk, .. }
+                    | SortChunkEvent::Residual { chunk, .. } => {
+                        out.chunks.push(
+                            (0..chunk.len()).map(|i| chunk.record_bytes(i).to_vec()).collect(),
+                        );
+                    }
+                    SortChunkEvent::AllAnnounced { slot_count, total_records, .. } => {
+                        out.slot_count = slot_count;
+                        out.total_records = total_records;
+                    }
+                }
+                Ok(StepOutcome::Progress)
+            }
+            None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+            None => Ok(StepOutcome::NoProgress),
+        }
+    }
+}
+
+/// Minimal BAM binary header (`magic + l_text=0 + n_ref` + one entry per ref).
+/// Only `n_ref` matters to the front's `bam_header_len` scan and to the
+/// coordinate key, so the reference names/lengths are placeholders.
+fn minimal_binary_bam_header(n_ref: u32) -> Vec<u8> {
+    let mut header = Vec::new();
+    header.extend_from_slice(b"BAM\x01");
+    header.extend_from_slice(&0u32.to_le_bytes()); // l_text = 0
+    header.extend_from_slice(&n_ref.to_le_bytes());
+    for _ in 0..n_ref {
+        header.extend_from_slice(&2u32.to_le_bytes()); // l_name = 2
+        header.extend_from_slice(b"r\0");
+        header.extend_from_slice(&1_000_000u32.to_le_bytes()); // l_ref
+    }
+    header
+}
+
+/// Serialize `[binary header][[block_size][body]...]` and cut it into BGZF
+/// blocks of at most `payload_bytes` uncompressed each. Records straddle block
+/// boundaries by construction, which is what exercises the front's carry path.
+fn bgzf_blocks_for(
+    records: &[RawRecord],
+    n_ref: u32,
+    payload_bytes: usize,
+) -> Vec<crate::types::BgzfBlock> {
+    let mut stream = minimal_binary_bam_header(n_ref);
+    for record in records {
+        let bytes = record.as_ref();
+        let block_size = u32::try_from(bytes.len()).expect("record fits u32");
+        stream.extend_from_slice(&block_size.to_le_bytes());
+        stream.extend_from_slice(bytes);
+    }
+    stream
+        .chunks(payload_bytes)
+        .enumerate()
+        .map(|(i, payload)| {
+            let mut compressor = fgumi_bgzf::writer::InlineBgzfCompressor::new(1);
+            compressor.write_all(payload).expect("compress payload");
+            compressor.flush().expect("flush compressor");
+            let mut blocks = compressor.take_blocks();
+            assert_eq!(blocks.len(), 1, "payload must fit one BGZF block");
+            crate::types::BgzfBlock {
+                batch_serial: i as u64,
+                bytes: blocks.remove(0).data,
+                uncompressed_size: u32::try_from(payload.len()).expect("payload fits u32"),
+            }
+        })
+        .collect()
+}
+
+/// Drive `BgzfBlockSource → ReadBlocks → InflateToArena → FindBoundariesAndSort`
+/// and return every emitted chunk's record bodies, chunk by chunk, plus the
+/// terminal `AllAnnounced` counts.
+fn drive_arena_front(
+    blocks: Vec<crate::types::BgzfBlock>,
+    n_ref: u32,
+    memory_limit: usize,
+    output_byte_limit: u64,
+    threads: usize,
+) -> Result<ArenaFrontOutput> {
+    let received: Arc<Mutex<ArenaFrontOutput>> = Arc::new(Mutex::new(ArenaFrontOutput::default()));
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(BgzfBlockSource::new(blocks, output_byte_limit))
+        .chain(ReadBlocks::new(memory_limit, output_byte_limit))
+        .chain(InflateToArena::new(output_byte_limit))
+        .chain(FindBoundariesAndSort::new(CoordinateStrategy::new(n_ref), 1, output_byte_limit))
+        .chain(ChunkEventSink { received: Arc::clone(&received) })
+        .into_sink_marker();
+    let pipeline = builder.build()?;
+    pipeline.run(PipelineConfig { threads, ..Default::default() })?;
+
+    Ok(std::mem::take(&mut *received.lock()))
+}
+
+/// End-to-end parity for the block-input arena front, driven through the real
+/// runtime rather than by poking `ingest_block`/`finalize` directly. A
+/// `memory_limit` above the whole input yields exactly ONE run, so the single
+/// residual chunk must be byte-identical to the legacy oracle's coordinate sort.
+///
+/// `payload_bytes` varies where records fall relative to block boundaries: the
+/// small case guarantees records straddle blocks (the front's carry path), the
+/// large case puts the whole stream in one block.
+#[rstest]
+#[case::straddling_blocks(4096, 20)]
+#[case::one_block_per_run(60_000, 2)]
+fn arena_front_chain_single_run_matches_legacy_oracle(
+    #[case] payload_bytes: usize,
+    #[case] min_blocks: usize,
+) {
+    const N_RECORDS: usize = 2_000;
+    let (header, records) = synthesize_records(N_RECORDS, 0xA2E4_A100);
+    let n_ref = u32::try_from(header.reference_sequences().len()).expect("n_ref fits u32");
+
+    let blocks = bgzf_blocks_for(&records, n_ref, payload_bytes);
+    assert!(
+        blocks.len() >= min_blocks,
+        "expected at least {min_blocks} blocks at {payload_bytes} B/block, got {}",
+        blocks.len()
+    );
+
+    let out = drive_arena_front(blocks, n_ref, 256 * 1024 * 1024, 4 * 1024 * 1024, 4)
+        .expect("arena front drives to completion");
+
+    assert_eq!(out.slot_count, 0, "a budget-sized run never spills");
+    assert_eq!(out.total_records, N_RECORDS as u64);
+    assert_eq!(out.chunks.len(), 1, "one run ⇒ one residual chunk");
+
+    let legacy_out =
+        sort_via_legacy(SortOrder::Coordinate, &header, &records, 256 * 1024 * 1024, 1)
+            .expect("legacy oracle");
+    assert_eq!(out.chunks[0].len(), legacy_out.len(), "record count mismatch");
+    for (i, (got, want)) in out.chunks[0].iter().zip(legacy_out.iter()).enumerate() {
+        assert_eq!(got, want, "record {i} bytes differ from the oracle");
+    }
+}
+
+/// The same front under a `memory_limit` far below the input: `ReadBlocks` seals
+/// several runs, so the front emits `Spill` chunks ahead of the residual. Each
+/// run is independently sorted (the merge is a later stage), so the claim here
+/// is that every record survives exactly once and each chunk is itself sorted.
+#[test]
+fn arena_front_chain_seals_multiple_runs_without_losing_records() {
+    const N_RECORDS: usize = 4_000;
+    let (header, records) = synthesize_records(N_RECORDS, 0x5EA1_5EA1);
+    let n_ref = u32::try_from(header.reference_sequences().len()).expect("n_ref fits u32");
+
+    let out = drive_arena_front(
+        bgzf_blocks_for(&records, n_ref, 8192),
+        n_ref,
+        64 * 1024, // far below the input ⇒ several runs
+        4 * 1024 * 1024,
+        4,
+    )
+    .expect("arena front drives to completion");
+
+    assert!(out.chunks.len() > 1, "a tiny memory limit must seal several runs");
+    assert_eq!(out.slot_count as usize, out.chunks.len() - 1, "every run but the last spills");
+    assert_eq!(out.total_records, N_RECORDS as u64);
+
+    let mut got: Vec<Vec<u8>> = out.chunks.into_iter().flatten().collect();
+    let mut want: Vec<Vec<u8>> = records.iter().map(|r| r.as_ref().to_vec()).collect();
+    got.sort_unstable();
+    want.sort_unstable();
+    assert_eq!(got, want, "the sealed runs must carry every input record exactly once");
+}

--- a/crates/fgumi-pipeline-io/src/source/mod.rs
+++ b/crates/fgumi-pipeline-io/src/source/mod.rs
@@ -1,0 +1,1 @@
+pub mod read_bam;

--- a/crates/fgumi-pipeline-io/src/source/read_bam.rs
+++ b/crates/fgumi-pipeline-io/src/source/read_bam.rs
@@ -1,0 +1,454 @@
+//! `ReadBgzfBlocks` source step + `read_bam(path)` convenience helper.
+//!
+//! Reads raw BGZF blocks from a file (no decompression) and emits them as
+//! `BgzfBlock` items with monotonically increasing `batch_serial`. The
+//! header bytes are NOT skipped here — they pass through as part of the
+//! first block(s); `FindBamBoundaries` strips them downstream.
+
+use std::collections::VecDeque;
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+use fgumi_bam_io::PipelineReaderOpts;
+use fgumi_bgzf::reader::read_raw_blocks;
+use noodles::sam::Header;
+
+use crate::types::BgzfBlock;
+use fgumi_pipeline_core::{
+    Unpushed,
+    held::HeldSlot,
+    outputs::OrderedBytesSingle,
+    queues::QueueSpec,
+    reorder::BranchOrdering,
+    step::{Affinity, Step, StepCtx, StepKind, StepOutcome, StepProfile},
+};
+
+/// Legacy default blocks-per-batch.
+pub const DEFAULT_BLOCKS_PER_BATCH: usize = 16;
+
+/// `Serial + sticky` source step that reads raw BGZF blocks from a file.
+///
+/// The reader and the finished flag are plain owned fields, not `Arc`/atomics:
+/// this is a `Serial` step, so the runtime drives a single shared instance and
+/// never calls `new_worker_copy` on it (only `Parallel` steps are cloned per
+/// worker). There is no second owner to share them with.
+pub struct ReadBgzfBlocks {
+    reader: Option<Box<dyn io::Read + Send>>,
+    blocks_per_batch: usize,
+    next_serial: u64,
+    pending: VecDeque<BgzfBlock>,
+    held: HeldSlot<Unpushed<BgzfBlock>>,
+    output_byte_limit: u64,
+    finished: bool,
+}
+
+impl ReadBgzfBlocks {
+    #[must_use]
+    pub fn new(
+        reader: Box<dyn io::Read + Send>,
+        blocks_per_batch: usize,
+        output_byte_limit: u64,
+    ) -> Self {
+        Self {
+            reader: Some(reader),
+            blocks_per_batch: blocks_per_batch.max(1),
+            next_serial: 0,
+            pending: VecDeque::new(),
+            held: HeldSlot::new(),
+            output_byte_limit,
+            finished: false,
+        }
+    }
+}
+
+impl Step for ReadBgzfBlocks {
+    type Input = ();
+    type Outputs = OrderedBytesSingle<BgzfBlock>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ReadBgzfBlocks",
+            kind: StepKind::Serial,
+            sticky: true,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn affinity(&self) -> Affinity {
+        Affinity::Reader
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // 1. Drain the held slot first.
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        // 2. Drain pending blocks (one per call iteration).
+        if let Some(block) = self.pending.pop_front() {
+            match ctx.outputs.push(block) {
+                Ok(()) => return Ok(StepOutcome::Progress),
+                Err(unpushed) => {
+                    self.held.put(unpushed);
+                    return Ok(StepOutcome::Progress);
+                }
+            }
+        }
+
+        if self.finished {
+            return Ok(StepOutcome::Finished);
+        }
+
+        // 3. Read up to `blocks_per_batch` raw BGZF blocks. The reader is taken
+        // only at end of stream, so `None` here means `try_run` was called again
+        // after it already returned `Finished`.
+        let raw_blocks = {
+            let reader = self
+                .reader
+                .as_mut()
+                .expect("ReadBgzfBlocks: try_run called after the source reported Finished");
+            read_raw_blocks(reader.as_mut(), self.blocks_per_batch)?
+        };
+
+        if raw_blocks.is_empty() {
+            self.finished = true;
+            // Release the reader (and its 2 MiB BufReader) as soon as the stream
+            // is drained rather than holding it for the rest of the run.
+            self.reader = None;
+            return Ok(StepOutcome::Finished);
+        }
+
+        for raw in raw_blocks {
+            let serial = self.next_serial;
+            self.next_serial += 1;
+            self.pending.push_back(BgzfBlock {
+                batch_serial: serial,
+                uncompressed_size: u32::try_from(raw.uncompressed_size()).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "ReadBgzfBlocks: BGZF uncompressed_size out of range: {}",
+                            raw.uncompressed_size()
+                        ),
+                    )
+                })?,
+                bytes: raw.data,
+            });
+        }
+
+        if let Some(block) = self.pending.pop_front() {
+            match ctx.outputs.push(block) {
+                Ok(()) => Ok(StepOutcome::Progress),
+                Err(unpushed) => {
+                    self.held.put(unpushed);
+                    Ok(StepOutcome::Progress)
+                }
+            }
+        } else {
+            Ok(StepOutcome::NoProgress)
+        }
+    }
+}
+
+/// Build a [`ReadBgzfBlocks`] step from an already-prepared reader + header.
+#[must_use]
+pub fn read_bam_from_reader(
+    reader: Box<dyn io::Read + Send>,
+    header: Header,
+    blocks_per_batch: usize,
+    output_byte_limit: u64,
+) -> (ReadBgzfBlocks, Header) {
+    (ReadBgzfBlocks::new(reader, blocks_per_batch, output_byte_limit), header)
+}
+
+/// Convenience helper: open a BAM file, parse its header, return the
+/// `(step, header)` pair.
+///
+/// The file is deliberately opened twice: first via
+/// `create_raw_bam_reader_with_opts` to parse and return the `Header`, then
+/// re-opened with `File::open` and a fresh `BufReader` at offset 0 so the raw
+/// BGZF stream — including the header blocks — is emitted in full. Those header
+/// blocks are stripped downstream by `FindBamBoundaries`. Do not "optimize" this
+/// by reusing the first reader's position: skipping the header blocks corrupts
+/// the raw-block stream.
+///
+/// # Errors
+///
+/// Returns I/O errors from file open or BAM-header parse.
+pub fn read_bam<P: AsRef<Path>>(
+    path: P,
+    opts: PipelineReaderOpts,
+    blocks_per_batch: usize,
+    output_byte_limit: u64,
+) -> io::Result<(ReadBgzfBlocks, Header)> {
+    let path = path.as_ref();
+    let (_, header) = fgumi_bam_io::create_raw_bam_reader_with_opts(path, 1, opts)
+        .map_err(|e| io::Error::other(format!("create_raw_bam_reader_with_opts: {e}")))?;
+
+    let file = File::open(path)?;
+    // Honor `async_reader` for the reopened raw block stream too — not just the
+    // temporary header reader above — so a regular file prefetches like the
+    // stdin path (`read_bam_stdin`) does. `verify_crc` does not apply here:
+    // `ReadBgzfBlocks` forwards compressed bytes without decoding them.
+    let reader: Box<dyn io::Read + Send> = if opts.async_reader {
+        log::info!("async read enabled: spawning fgumi-prefetch thread for {}", path.display());
+        Box::new(fgumi_bam_io::prefetch_reader::PrefetchReader::from_file(file))
+    } else {
+        Box::new(io::BufReader::with_capacity(2 * 1024 * 1024, file))
+    };
+    Ok(read_bam_from_reader(reader, header, blocks_per_batch, output_byte_limit))
+}
+
+/// Stdin counterpart to [`read_bam`].
+///
+/// # Errors
+///
+/// Returns I/O errors from stdin read or BAM-header parse.
+pub fn read_bam_stdin(
+    opts: PipelineReaderOpts,
+    blocks_per_batch: usize,
+    output_byte_limit: u64,
+) -> io::Result<(ReadBgzfBlocks, Header)> {
+    let (reader, header) =
+        fgumi_bam_io::create_bam_reader_for_pipeline_with_opts(Path::new("-"), opts).map_err(
+            |e| io::Error::other(format!("create_bam_reader_for_pipeline_with_opts: {e}")),
+        )?;
+    Ok(read_bam_from_reader(reader, header, blocks_per_batch, output_byte_limit))
+}
+
+/// Path-aware dispatcher: routes to [`read_bam_stdin`] when `path` is a
+/// stdin sentinel (`-` or `/dev/stdin`) and to [`read_bam`] otherwise.
+///
+/// # Errors
+///
+/// Returns I/O errors from file open, stdin read, or BAM-header parse.
+pub fn read_bam_auto<P: AsRef<Path>>(
+    path: P,
+    opts: PipelineReaderOpts,
+    blocks_per_batch: usize,
+    output_byte_limit: u64,
+) -> io::Result<(ReadBgzfBlocks, Header)> {
+    if fgumi_bam_io::is_stdin_path(path.as_ref()) {
+        read_bam_stdin(opts, blocks_per_batch, output_byte_limit)
+    } else {
+        read_bam(path, opts, blocks_per_batch, output_byte_limit)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[test]
+    fn profile_advertises_serial_reader_byordinal() {
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        let header = noodles::sam::Header::default();
+        let writer = fgumi_bam_io::create_raw_bam_writer(&path, &header, 1, 1).unwrap();
+        writer.finish().unwrap();
+
+        let (step, _hdr) =
+            read_bam(&path, PipelineReaderOpts::default(), DEFAULT_BLOCKS_PER_BATCH, 1024 * 1024)
+                .unwrap();
+        let profile = step.profile();
+        assert_eq!(profile.name, "ReadBgzfBlocks");
+        assert_eq!(profile.kind, StepKind::Serial);
+        assert!(profile.sticky);
+        assert_eq!(step.affinity(), Affinity::Reader);
+        assert_eq!(profile.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+        assert!(matches!(profile.output_queues[0], QueueSpec::ByteBounded { .. }));
+    }
+
+    // ---------------------------------------------------------------------
+    // Driving the step through a real pipeline
+    // ---------------------------------------------------------------------
+
+    /// Sink that records every `BgzfBlock` the source emits, in arrival order.
+    struct BlockSink {
+        received: std::sync::Arc<parking_lot::Mutex<Vec<BgzfBlock>>>,
+    }
+
+    impl Step for BlockSink {
+        type Input = BgzfBlock;
+        type Outputs = ();
+
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "BlockSink",
+                kind: StepKind::Serial,
+                sticky: false,
+                output_queues: vec![],
+                branch_ordering: vec![],
+            }
+        }
+
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            match ctx.input.pop() {
+                Some(block) => {
+                    self.received.lock().push(block);
+                    Ok(StepOutcome::Progress)
+                }
+                None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+                None => Ok(StepOutcome::NoProgress),
+            }
+        }
+    }
+
+    /// Write `record_count` records to a temp BAM and return its `path` plus the
+    /// on-disk bytes.
+    fn temp_bam(record_count: usize) -> (tempfile::TempPath, Vec<u8>) {
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        let header = noodles::sam::Header::default();
+        let mut writer = fgumi_bam_io::create_raw_bam_writer(&path, &header, 1, 1).unwrap();
+        for i in 0..record_count {
+            let name = format!("q{i}");
+            let bytes = fgumi_raw_bam::testutil::make_bam_bytes(
+                0,
+                i32::try_from(i).unwrap(),
+                0,
+                name.as_bytes(),
+                &[],
+                10,
+                -1,
+                -1,
+                &[],
+            );
+            writer.write_raw_record(&bytes).unwrap();
+        }
+        writer.finish().unwrap();
+        let on_disk = std::fs::read(&path).unwrap();
+        (path, on_disk)
+    }
+
+    /// Run a `ReadBgzfBlocks -> BlockSink` pipeline and return the emitted blocks.
+    fn drive(path: &Path, blocks_per_batch: usize, threads: usize) -> Vec<BgzfBlock> {
+        let received = std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let (source, _hdr) =
+            read_bam(path, PipelineReaderOpts::default(), blocks_per_batch, 1024 * 1024).unwrap();
+        let sink = BlockSink { received: std::sync::Arc::clone(&received) };
+
+        let builder = fgumi_pipeline_core::builder::Pipeline::builder();
+        builder.chain(source).chain(sink).into_sink_marker();
+        let pipeline = builder.build().unwrap();
+        pipeline
+            .run(fgumi_pipeline_core::builder::PipelineConfig { threads, ..Default::default() })
+            .unwrap();
+
+        // Returned in ARRIVAL order, deliberately unsorted: the step declares
+        // `BranchOrdering::ByItemOrdinal`, so the sink must already see blocks in
+        // serial order. Sorting here would normalize out-of-order delivery and let
+        // an ordering regression pass.
+        std::mem::take(&mut *received.lock())
+    }
+
+    #[rstest]
+    #[case::single_block_batches(1)]
+    #[case::default_batching(DEFAULT_BLOCKS_PER_BATCH)]
+    #[case::larger_than_the_file(1024)]
+    fn try_run_emits_every_block_with_dense_serials(#[case] blocks_per_batch: usize) {
+        const BGZF_EOF_LEN: usize = 28;
+        let (path, on_disk) = temp_bam(64);
+        let blocks = drive(&path, blocks_per_batch, 1);
+
+        assert!(!blocks.is_empty(), "a non-empty BAM must yield at least one block");
+
+        // Serials are dense and start at zero.
+        for (i, block) in blocks.iter().enumerate() {
+            assert_eq!(block.batch_serial, i as u64, "serial {i} must be dense");
+            // `bytes` is the raw *compressed* block (this step does not inflate),
+            // so it is not the same length as `uncompressed_size`; only that the
+            // declared inflated size is populated is checkable here.
+            assert!(block.uncompressed_size > 0, "block {i} must declare an inflated size");
+            assert!(!block.bytes.is_empty(), "block {i} must carry its compressed bytes");
+        }
+
+        // Concatenating the payloads reproduces the file minus its BGZF EOF block,
+        // which is what `FindBamBoundaries` downstream expects to receive.
+        let concatenated: Vec<u8> = blocks.iter().flat_map(|b| b.bytes.clone()).collect();
+        assert_eq!(concatenated, on_disk[..on_disk.len() - BGZF_EOF_LEN]);
+    }
+
+    #[test]
+    fn try_run_emits_the_same_blocks_regardless_of_thread_count() {
+        let (path, _) = temp_bam(64);
+        let one = drive(&path, 4, 1);
+        let many = drive(&path, 4, 4);
+        assert_eq!(one.len(), many.len(), "block count must not depend on threads");
+        for (a, b) in one.iter().zip(many.iter()) {
+            assert_eq!(a.batch_serial, b.batch_serial);
+            assert_eq!(a.bytes, b.bytes);
+        }
+    }
+
+    #[test]
+    fn try_run_on_a_header_only_bam_still_emits_the_header_block() {
+        const BGZF_EOF_LEN: usize = 28;
+        let (path, on_disk) = temp_bam(0);
+        let blocks = drive(&path, DEFAULT_BLOCKS_PER_BATCH, 1);
+        let concatenated: Vec<u8> = blocks.iter().flat_map(|b| b.bytes.clone()).collect();
+        assert_eq!(concatenated, on_disk[..on_disk.len() - BGZF_EOF_LEN]);
+    }
+
+    // ---------------------------------------------------------------------
+    // Constructor + dispatch
+    // ---------------------------------------------------------------------
+
+    #[rstest]
+    #[case::zero_clamps_to_one(0, 1)]
+    #[case::one_stays_one(1, 1)]
+    #[case::larger_is_preserved(32, 32)]
+    fn new_clamps_blocks_per_batch_to_at_least_one(
+        #[case] requested: usize,
+        #[case] expected: usize,
+    ) {
+        let reader: Box<dyn io::Read + Send> = Box::new(io::Cursor::new(Vec::new()));
+        let step = ReadBgzfBlocks::new(reader, requested, 1024);
+        assert_eq!(step.blocks_per_batch, expected);
+    }
+
+    #[test]
+    fn read_bam_auto_routes_a_regular_path_to_the_file_reader() {
+        let (path, _) = temp_bam(4);
+        // `read_bam_auto` on a non-stdin path must behave exactly like `read_bam`:
+        // same header, and a step that reads the same file.
+        let (_, auto_hdr) =
+            read_bam_auto(&path, PipelineReaderOpts::default(), 4, 1024 * 1024).unwrap();
+        let (_, direct_hdr) =
+            read_bam(&path, PipelineReaderOpts::default(), 4, 1024 * 1024).unwrap();
+        assert_eq!(auto_hdr, direct_hdr);
+        assert!(!fgumi_bam_io::is_stdin_path(AsRef::<Path>::as_ref(&path)));
+    }
+
+    #[rstest]
+    #[case::dash("-")]
+    #[case::dev_stdin("/dev/stdin")]
+    fn stdin_sentinels_are_recognised(#[case] sentinel: &str) {
+        // Guards the branch condition in `read_bam_auto` without consuming the
+        // process's real stdin, which a test must not do.
+        assert!(fgumi_bam_io::is_stdin_path(Path::new(sentinel)));
+    }
+
+    #[test]
+    fn read_bam_errors_on_a_missing_file() {
+        // `ReadBgzfBlocks` is not `Debug`, so inspect the variant directly rather
+        // than via `expect_err`.
+        let result = read_bam(
+            Path::new("/nonexistent/definitely/not/here.bam"),
+            PipelineReaderOpts::default(),
+            4,
+            1024,
+        );
+        match result {
+            Ok(_) => panic!("a missing file must not open"),
+            Err(e) => assert!(!e.to_string().is_empty()),
+        }
+    }
+}

--- a/crates/fgumi-pipeline-io/src/types.rs
+++ b/crates/fgumi-pipeline-io/src/types.rs
@@ -1,0 +1,315 @@
+//! Concrete data types that flow through the BAM step library.
+//!
+//! Every flowing type carries an explicit `batch_serial: u64` field and
+//! impls both [`HeapSize`] (so byte-bounded queues can budget memory) and
+//! [`Ordered`] (so `BranchOrdering::ByItemOrdinal` reorder stages preserve
+//! global ordering across multi-step Parallel transforms).
+
+use fgumi_pipeline_core::{HeapSize, Ordered};
+use fgumi_raw_bam::RawRecord;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BgzfBlock — raw compressed BGZF block + read-order serial.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Raw compressed BGZF block + parsed metadata. Carries read-order serial.
+///
+/// Sentinel/EOF blocks have `bytes` containing the 28-byte BGZF EOF marker
+/// and `uncompressed_size = 0`.
+#[derive(Debug)]
+pub struct BgzfBlock {
+    /// Read-order serial. Set by `ReadBgzfBlocks` based on block read index.
+    pub batch_serial: u64,
+    pub bytes: Vec<u8>,
+    /// Decompressed size, parsed from the BGZF block header.
+    pub uncompressed_size: u32,
+}
+
+impl HeapSize for BgzfBlock {
+    fn heap_size(&self) -> usize {
+        // Byte-bounded queues budget on resident heap, so account for the full
+        // allocation (`capacity`), not just the populated prefix (`len`).
+        self.bytes.capacity()
+    }
+}
+
+impl Ordered for BgzfBlock {
+    fn ordinal(&self) -> u64 {
+        self.batch_serial
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DecompressedBlock — raw bytes from a BGZF decompression, record-aligned
+// or not.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Decompressed bytes from one or more BGZF blocks. Carries a serial for
+/// ordering purposes; record alignment is the consumer's responsibility.
+#[derive(Debug)]
+pub struct DecompressedBlock {
+    pub batch_serial: u64,
+    pub bytes: Vec<u8>,
+}
+
+impl HeapSize for DecompressedBlock {
+    fn heap_size(&self) -> usize {
+        // Account for the full allocation (`capacity`), not just `len` — see
+        // the `BgzfBlock` impl above.
+        self.bytes.capacity()
+    }
+}
+
+impl Ordered for DecompressedBlock {
+    fn ordinal(&self) -> u64 {
+        self.batch_serial
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RecordBatch — parsed BAM records grouped into a batch.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A batch of parsed BAM records, stored as a flat backing buffer + per-record
+/// `(start, end)` ranges.
+#[derive(Debug)]
+pub struct RecordBatch {
+    batch_serial: u64,
+    /// All record bodies concatenated, in batch order.
+    backing: Vec<u8>,
+    /// (start, end) byte ranges into `backing`, one per record.
+    ranges: Vec<(u32, u32)>,
+}
+
+impl RecordBatch {
+    /// Construct a batch from a pre-parsed backing buffer and `(start, end)` ranges.
+    ///
+    /// Each range must satisfy `start <= end <= backing.len()`; callers own that
+    /// invariant (the boundary scans that produce these ranges already validate
+    /// it). Violating it panics later in
+    /// [`iter_record_bytes`](Self::iter_record_bytes) when the range is sliced,
+    /// far from the site that produced it — the `debug_assert!` pins the failure
+    /// at the constructor boundary instead. Note that `total_bytes` reports
+    /// `backing.len()`, which differs from the sum of the record bodies if the
+    /// ranges do not cover the whole buffer.
+    #[must_use]
+    pub fn from_parsed(batch_serial: u64, backing: Vec<u8>, ranges: Vec<(u32, u32)>) -> Self {
+        debug_assert!(
+            ranges.iter().all(|&(s, e)| s <= e && e as usize <= backing.len()),
+            "RecordBatch::from_parsed: range outside backing buffer"
+        );
+        Self { batch_serial, backing, ranges }
+    }
+
+    /// Convenience constructor: serializes a slice of `RawRecord`s into the
+    /// flat representation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the concatenated record bodies exceed `u32::MAX` bytes.
+    #[must_use]
+    pub fn new(batch_serial: u64, records: &[RawRecord]) -> Self {
+        let total: usize = records.iter().map(RawRecord::len).sum();
+        let mut backing = Vec::with_capacity(total);
+        let mut ranges = Vec::with_capacity(records.len());
+        for rec in records {
+            let start = u32::try_from(backing.len()).expect("backing fits in u32");
+            backing.extend_from_slice(rec.as_ref());
+            let end = u32::try_from(backing.len()).expect("backing fits in u32");
+            ranges.push((start, end));
+        }
+        Self { batch_serial, backing, ranges }
+    }
+
+    /// Self-managed ordinal.
+    #[must_use]
+    pub fn batch_serial(&self) -> u64 {
+        self.batch_serial
+    }
+
+    /// Number of records in the batch.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.ranges.len()
+    }
+
+    /// `true` iff the batch contains zero records.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.ranges.is_empty()
+    }
+
+    /// Total bytes across all record bodies.
+    #[must_use]
+    pub fn total_bytes(&self) -> usize {
+        self.backing.len()
+    }
+
+    /// Iterate the record bodies as borrowed byte slices into the backing buffer.
+    pub fn iter_record_bytes(&self) -> impl Iterator<Item = &[u8]> + '_ {
+        let backing = &self.backing[..];
+        self.ranges.iter().map(move |&(s, e)| &backing[s as usize..e as usize])
+    }
+}
+
+/// Builder for emit-side `RecordBatch` construction.
+#[derive(Debug)]
+pub struct RecordBatchBuilder {
+    batch_serial: u64,
+    backing: Vec<u8>,
+    ranges: Vec<(u32, u32)>,
+}
+
+impl RecordBatchBuilder {
+    /// Build an empty builder with reserved capacity.
+    #[must_use]
+    pub fn with_capacity(batch_serial: u64, bytes_cap: usize, records_cap: usize) -> Self {
+        Self {
+            batch_serial,
+            backing: Vec::with_capacity(bytes_cap),
+            ranges: Vec::with_capacity(records_cap),
+        }
+    }
+
+    /// Append one record's body bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if accumulated bytes would exceed `u32::MAX`.
+    pub fn push_record_bytes(&mut self, bytes: &[u8]) {
+        let start = u32::try_from(self.backing.len()).expect("backing fits in u32");
+        self.backing.extend_from_slice(bytes);
+        let end = u32::try_from(self.backing.len()).expect("backing fits in u32");
+        self.ranges.push((start, end));
+    }
+
+    /// Number of records appended so far.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.ranges.len()
+    }
+
+    /// `true` iff no records have been appended.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.ranges.is_empty()
+    }
+
+    /// Total record bytes appended so far.
+    #[must_use]
+    pub fn total_bytes(&self) -> usize {
+        self.backing.len()
+    }
+
+    /// Finalize and produce the `RecordBatch`. Consumes the builder.
+    #[must_use]
+    pub fn build(self) -> RecordBatch {
+        RecordBatch { batch_serial: self.batch_serial, backing: self.backing, ranges: self.ranges }
+    }
+}
+
+impl HeapSize for RecordBatch {
+    fn heap_size(&self) -> usize {
+        // Account for the full allocation (`capacity`) of both buffers, not
+        // just their populated prefixes — see the `BgzfBlock` impl above.
+        self.backing.capacity() + self.ranges.capacity() * std::mem::size_of::<(u32, u32)>()
+    }
+}
+
+impl Ordered for RecordBatch {
+    fn ordinal(&self) -> u64 {
+        self.batch_serial
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bgzf_block_heap_size_matches_bytes_capacity() {
+        let b = BgzfBlock { batch_serial: 0, bytes: vec![0u8; 1024], uncompressed_size: 4096 };
+        assert_eq!(b.heap_size(), 1024);
+        assert_eq!(b.ordinal(), 0);
+    }
+
+    #[test]
+    fn decompressed_block_heap_size_matches_bytes_capacity() {
+        let b = DecompressedBlock { batch_serial: 7, bytes: vec![0u8; 4096] };
+        assert_eq!(b.heap_size(), 4096);
+        assert_eq!(b.ordinal(), 7);
+    }
+
+    #[test]
+    fn heap_size_counts_allocated_capacity_not_logical_len() {
+        // A buffer with spare capacity (e.g. after `with_capacity`) holds more
+        // resident heap than its `len` — byte-bounded queues must budget the
+        // full allocation or they undercount and bypass configured limits.
+        let mut bytes = Vec::with_capacity(8192);
+        bytes.extend_from_slice(&[0u8; 100]);
+        assert!(bytes.capacity() >= 8192 && bytes.len() == 100);
+        let cap = bytes.capacity();
+
+        let block = BgzfBlock { batch_serial: 0, bytes, uncompressed_size: 0 };
+        assert_eq!(block.heap_size(), cap);
+
+        let mut backing = Vec::with_capacity(4096);
+        backing.extend_from_slice(&[0u8; 10]);
+        let mut ranges = Vec::with_capacity(64);
+        ranges.push((0u32, 10u32));
+        let backing_cap = backing.capacity();
+        let ranges_cap = ranges.capacity();
+        let batch = RecordBatch::from_parsed(0, backing, ranges);
+        assert_eq!(batch.heap_size(), backing_cap + ranges_cap * std::mem::size_of::<(u32, u32)>());
+    }
+
+    #[test]
+    fn record_batch_total_bytes_sums_record_lengths() {
+        let r1: RawRecord = vec![0u8; 100].into();
+        let r2: RawRecord = vec![0u8; 200].into();
+        let batch = RecordBatch::new(3, &[r1, r2]);
+        assert_eq!(batch.len(), 2);
+        assert_eq!(batch.total_bytes(), 300);
+        // `Vec::with_capacity` may over-allocate, so assert against the actual
+        // allocated capacities rather than the requested sizes (see the sibling
+        // `heap_size_counts_allocated_capacity_not_logical_len` test).
+        assert_eq!(
+            batch.heap_size(),
+            batch.backing.capacity() + batch.ranges.capacity() * std::mem::size_of::<(u32, u32)>()
+        );
+        assert_eq!(batch.ordinal(), 3);
+    }
+
+    #[test]
+    fn record_batch_from_parsed_round_trips_ranges() {
+        let backing = b"AAABBBBCC".to_vec();
+        let ranges = vec![(0u32, 3u32), (3u32, 7u32), (7u32, 9u32)];
+        let batch = RecordBatch::from_parsed(11, backing, ranges);
+        let got: Vec<&[u8]> = batch.iter_record_bytes().collect();
+        assert_eq!(got, vec![&b"AAA"[..], &b"BBBB"[..], &b"CC"[..]]);
+        assert_eq!(batch.len(), 3);
+        assert_eq!(batch.total_bytes(), 9);
+        assert_eq!(batch.batch_serial(), 11);
+    }
+
+    #[test]
+    fn record_batch_builder_collects_records() {
+        let mut b = RecordBatchBuilder::with_capacity(0, 64, 4);
+        b.push_record_bytes(&[0u8; 50]);
+        b.push_record_bytes(&[0u8; 75]);
+        assert_eq!(b.len(), 2);
+        assert!(!b.is_empty());
+        assert_eq!(b.total_bytes(), 125);
+        let batch = b.build();
+        let got: Vec<usize> = batch.iter_record_bytes().map(<[u8]>::len).collect();
+        assert_eq!(got, vec![50, 75]);
+        // `heap_size` budgets allocated capacity (not logical length): the
+        // builder was seeded with a 64-byte backing buffer but 125 bytes were
+        // pushed, so `backing` reallocated and its capacity now exceeds 125.
+        assert_eq!(
+            batch.heap_size(),
+            batch.backing.capacity() + batch.ranges.capacity() * std::mem::size_of::<(u32, u32)>()
+        );
+        assert!(batch.heap_size() >= 125 + 2 * std::mem::size_of::<(u32, u32)>());
+    }
+}

--- a/crates/fgumi-raw-bam/src/lib.rs
+++ b/crates/fgumi-raw-bam/src/lib.rs
@@ -127,9 +127,10 @@ pub use tags::{
     array_tag_element_u16, array_tag_to_vec_u16, extract_aux_string_tags, extract_int_value,
     extract_template_aux_tags, find_array_tag, find_float_tag, find_int_tag, find_mc_tag_in_record,
     find_string_tag, find_string_tag_in_record, find_string_tag_position, find_tag_type,
-    find_uint8_tag, normalize_int_tag_to_smallest_signed, read_tc_template_coordinate, remove_tag,
-    reverse_array_tag_in_place, reverse_complement_string_tag_in_place,
-    reverse_string_tag_in_place, update_int_tag, update_string_tag,
+    find_two_string_tags_in_record, find_uint8_tag, normalize_int_tag_to_smallest_signed,
+    read_tc_template_coordinate, remove_tag, reverse_array_tag_in_place,
+    reverse_complement_string_tag_in_place, reverse_string_tag_in_place, update_int_tag,
+    update_string_tag,
 };
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/fgumi-raw-bam/src/tags.rs
+++ b/crates/fgumi-raw-bam/src/tags.rs
@@ -95,6 +95,73 @@ pub fn find_string_tag_in_record(bam: &[u8], tag: impl AsTagBytes) -> Option<&[u
     find_string_tag(aux, tag)
 }
 
+/// Find two string (Z-type) tags in a complete BAM record in a **single** aux-data
+/// walk, returning each value's bytes (without the NUL terminator) or `None` if that
+/// tag is absent or not Z-type.
+///
+/// Equivalent to calling [`find_string_tag_in_record`] twice, but it walks the aux
+/// block only once — relevant on hot paths that need both an MI tag and a cell-barcode
+/// tag per record. The returned slices borrow the record's aux data.
+#[inline]
+#[must_use]
+pub fn find_two_string_tags_in_record(
+    bam: &[u8],
+    first: impl AsTagBytes,
+    second: impl AsTagBytes,
+) -> (Option<&[u8]>, Option<&[u8]>) {
+    let first = u16::from_le_bytes(*first.as_tag_bytes());
+    let second = u16::from_le_bytes(*second.as_tag_bytes());
+    let aux = aux_data_slice(bam);
+
+    let mut first_done = false;
+    let mut second_done = false;
+    let mut first_val: Option<&[u8]> = None;
+    let mut second_val: Option<&[u8]> = None;
+    let mut p = 0;
+    while p + 3 <= aux.len() {
+        let entry_u16 = u16::from_le_bytes([aux[p], aux[p + 1]]);
+        let val_type = aux[p + 2];
+
+        // Each tag resolves on its FIRST matching entry, exactly as
+        // `find_string_tag_in_record` does (it returns the first tag match and
+        // yields a value only if that match is a NUL-terminated `Z` entry). A
+        // non-`Z` (or unterminated) first match resolves the tag to `None`; we
+        // must NOT skip it and pick up a later `Z` duplicate, or the two-tag
+        // walk would disagree with two single-tag lookups on malformed aux.
+        let matches_first = entry_u16 == first && !first_done;
+        let matches_second = entry_u16 == second && !second_done;
+        if matches_first || matches_second {
+            let value = if val_type == b'Z' {
+                let start = p + 3;
+                aux[start..].iter().position(|&b| b == 0).map(|len| &aux[start..start + len])
+            } else {
+                None
+            };
+            // Independent (not `else`) so a single entry resolves both slots
+            // when `first == second`, preserving the "call twice" contract.
+            if matches_first {
+                first_done = true;
+                first_val = value;
+            }
+            if matches_second {
+                second_done = true;
+                second_val = value;
+            }
+        }
+
+        // Stop once both tags have been resolved (each to a value or `None`).
+        if first_done && second_done {
+            break;
+        }
+
+        match tag_value_size(val_type, &aux[p + 3..]) {
+            Some(size) => p += 3 + size,
+            None => break,
+        }
+    }
+    (first_val, second_val)
+}
+
 /// Find the byte range `[start, end)` of an entire tag entry (tag+type+value) in aux data.
 ///
 /// Returns offsets relative to the start of `aux_data`.
@@ -4525,5 +4592,135 @@ mod tests {
         // so the destination value (NUL terminator included) round-trips.
         assert_eq!(find_string_tag(&record, SamTag::CB), Some(b"ACGT".as_ref()));
         assert_eq!(&record[8..], b"CBZACGT\0", "verbatim tag+type+value bytes");
+    }
+
+    #[test]
+    fn test_find_two_string_tags_both_present_either_order() {
+        // MI before CB.
+        let aux = b"MIZ7\x00CBZACGT\x00";
+        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
+        let (mi, cb) = find_two_string_tags_in_record(&rec, SamTag::MI, SamTag::CB);
+        assert_eq!(mi, Some(b"7".as_ref()));
+        assert_eq!(cb, Some(b"ACGT".as_ref()));
+
+        // CB before MI: result is independent of aux ordering and of arg order.
+        let aux = b"CBZACGT\x00MIZ7\x00";
+        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
+        let (mi, cb) = find_two_string_tags_in_record(&rec, SamTag::MI, SamTag::CB);
+        assert_eq!(mi, Some(b"7".as_ref()));
+        assert_eq!(cb, Some(b"ACGT".as_ref()));
+    }
+
+    #[test]
+    fn test_find_two_string_tags_agrees_with_single_lookups() {
+        // Interleave a non-Z tag to make the walk non-trivial.
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"NMC");
+        aux.push(3);
+        aux.extend_from_slice(b"MIZ42\x00");
+        aux.extend_from_slice(b"CBZTGCA\x00");
+        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, &aux);
+        let (mi, cb) = find_two_string_tags_in_record(&rec, SamTag::MI, SamTag::CB);
+        assert_eq!(mi, find_string_tag_in_record(&rec, SamTag::MI));
+        assert_eq!(cb, find_string_tag_in_record(&rec, SamTag::CB));
+    }
+
+    #[test]
+    fn test_find_two_string_tags_first_match_wins_on_malformed_dup() {
+        // A non-Z MI entry precedes a Z MI duplicate. `find_string_tag_in_record`
+        // resolves the FIRST MI match (non-Z → None) and never reaches the later
+        // Z duplicate; the two-tag walk must match that rather than skipping the
+        // non-Z entry and returning the later Z value.
+        let mut aux = Vec::new();
+        aux.extend_from_slice(b"MIC"); // MI, type 'C' (uint8) ...
+        aux.push(9); //                ... 1-byte value (non-Z → MI resolves None)
+        aux.extend_from_slice(b"MIZ77\x00"); // later Z duplicate — must be ignored
+        aux.extend_from_slice(b"CBZACGT\x00");
+        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, &aux);
+
+        let (mi, cb) = find_two_string_tags_in_record(&rec, SamTag::MI, SamTag::CB);
+        assert_eq!(mi, None, "first (non-Z) MI match resolves the tag to None");
+        assert_eq!(cb, Some(b"ACGT".as_ref()));
+        // Must agree with two independent single-tag lookups.
+        assert_eq!(mi, find_string_tag_in_record(&rec, SamTag::MI));
+        assert_eq!(cb, find_string_tag_in_record(&rec, SamTag::CB));
+    }
+
+    /// A `Z` entry with no terminating NUL, in the two shapes that behave
+    /// differently.
+    ///
+    /// The doc contract says a first match that is non-`Z` *or unterminated*
+    /// resolves the tag to `None`. Only the non-`Z` half was pinned, and the
+    /// unterminated half is subtler than it reads: the value scan looks for the
+    /// next NUL anywhere in the remaining aux block, not just within the entry.
+    /// So "unterminated" resolves to `None` only when there is no NUL left at
+    /// all — if a later entry supplies one, the value runs *through* that entry
+    /// and swallows it.
+    ///
+    /// Both shapes are pinned because they fail differently: the first stops the
+    /// walk via `tag_value_size` returning `None`, the second consumes the
+    /// remaining bytes as one oversized value. Either way the two-tag walk must
+    /// agree with two independent single-tag lookups, which is the contract that
+    /// makes `find_two_string_tags_in_record` a safe substitution for calling
+    /// `find_string_tag_in_record` twice.
+    #[rstest]
+    // No NUL anywhere after the tag: the value scan finds nothing, so MI is
+    // `None`, and the walk stops rather than advancing past a sizeless entry.
+    #[case::no_nul_anywhere(b"MIZ77".as_ref(), None, None)]
+    // A later entry supplies the NUL, so MI's value runs through `CBZACGT` and
+    // consumes it — CB is never seen as an entry of its own.
+    #[case::nul_supplied_by_a_later_entry(
+        b"MIZ77CBZACGT\x00".as_ref(),
+        Some(b"77CBZACGT".as_ref()),
+        None
+    )]
+    fn test_find_two_string_tags_unterminated_z_first_match(
+        #[case] aux: &[u8],
+        #[case] expected_mi: Option<&[u8]>,
+        #[case] expected_cb: Option<&[u8]>,
+    ) {
+        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
+
+        let (mi, cb) = find_two_string_tags_in_record(&rec, SamTag::MI, SamTag::CB);
+        assert_eq!(mi, expected_mi);
+        assert_eq!(cb, expected_cb);
+        // The parity contract: identical to two independent single-tag lookups.
+        assert_eq!(
+            mi,
+            find_string_tag_in_record(&rec, SamTag::MI),
+            "MI must match a single lookup"
+        );
+        assert_eq!(
+            cb,
+            find_string_tag_in_record(&rec, SamTag::CB),
+            "CB must match a single lookup"
+        );
+    }
+
+    #[test]
+    fn test_find_two_string_tags_same_tag_fills_both() {
+        // When the same tag is requested for both first and second, a single
+        // matching aux entry must populate both outputs (not just one).
+        let aux = b"MIZ7\x00CBZACGT\x00";
+        let rec = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, aux);
+        let (a, b) = find_two_string_tags_in_record(&rec, SamTag::MI, SamTag::MI);
+        assert_eq!(a, Some(b"7".as_ref()));
+        assert_eq!(b, Some(b"7".as_ref()));
+        // Both outputs must agree with an independent single-tag lookup, proving
+        // the same-tag case behaves like two separate `find_string_tag_in_record`
+        // calls (the contract the `mi_group.rs` production path relies on).
+        let mi = find_string_tag_in_record(&rec, SamTag::MI);
+        assert_eq!(a, mi, "first output must match an independent MI lookup");
+        assert_eq!(b, mi, "second output must match an independent MI lookup");
+
+        // Same-tag MISS path: when the (identical) requested tag is absent, both
+        // outputs must be None — the zero-match branch of the same-tag case,
+        // matching two independent single-tag lookups that each miss.
+        let rec_without_mi = make_bam_bytes(0, 0, 0, b"rea", &[], 0, -1, -1, b"CBZACGT\x00");
+        let (a_missing, b_missing) =
+            find_two_string_tags_in_record(&rec_without_mi, SamTag::MI, SamTag::MI);
+        assert_eq!(a_missing, None);
+        assert_eq!(b_missing, None);
+        assert_eq!(a_missing, find_string_tag_in_record(&rec_without_mi, SamTag::MI));
     }
 }

--- a/crates/fgumi-sort/src/memory_probe.rs
+++ b/crates/fgumi-sort/src/memory_probe.rs
@@ -78,7 +78,6 @@ mod platform_ffi {
     /// `mi_stats_print_out(None, null_mut())` uses mimalloc's internal synchronization,
     /// making it safe to call concurrently with allocation/deallocation on other threads.
     #[cfg(feature = "memory-debug")]
-    #[allow(dead_code)] // consumed by main fgumi's unified_pipeline via the crate-root re-export
     pub fn print_mi_stats() {
         // SAFETY: mimalloc synchronizes stats collection internally.
         unsafe {
@@ -488,7 +487,7 @@ impl MergeProbe {
     /// threshold.
     ///
     /// `pool_depths` is the `(raw_input, decompressed_input, buffer_pool)`
-    /// triple from [`SortWorkerPool::phase1_queue_depths`].
+    /// triple from [`crate::worker_pool::SortWorkerPool::phase1_queue_depths`].
     pub fn log_mid_with_depths(
         &mut self,
         pool_depths: (usize, usize, usize),

--- a/crates/fgumi-sort/src/tmp_dir_alloc.rs
+++ b/crates/fgumi-sort/src/tmp_dir_alloc.rs
@@ -135,7 +135,6 @@ impl TmpDirAllocator {
 
     /// Override the periodic recheck interval (primarily for testing).
     #[must_use]
-    #[allow(dead_code)]
     pub fn with_recheck_interval(mut self, interval: usize) -> Self {
         self.recheck_interval = interval.max(1);
         self
@@ -175,7 +174,6 @@ impl TmpDirAllocator {
     /// Drop a directory from rotation (e.g. after `ENOSPC` during a spill write).
     ///
     /// Matches by path equality. A no-op if the path isn't currently active.
-    #[allow(dead_code)]
     pub fn mark_full(&mut self, dir: &Path) {
         if let Some(pos) = self.active.iter().position(|d| d == dir) {
             self.active.remove(pos);

--- a/crates/fgumi-umi/src/assigner.rs
+++ b/crates/fgumi-umi/src/assigner.rs
@@ -565,7 +565,7 @@ pub const BOTTOM_STRAND_DUPLEX: &str = "/B";
 ///
 /// Determines how reads are grouped based on their UMI sequences. Each strategy makes
 /// different tradeoffs between speed, error tolerance, and grouping behavior.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum Strategy {
     /// Only reads with identical UMI sequences are grouped together

--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -242,7 +242,7 @@ impl ClipParams {
     /// the template — including secondary/supplementary alignments — before the primary pair is
     /// clipped, matching fgbio `ClipBam`'s `template.allReads.foreach(upgradeAllClipping)`
     /// (`ClipBam.scala:123`). Doing this template-wide pre-pass here (rather than per-primary
-    /// inside [`clip_pair`]/[`clip_fragment`]) is what lets supplementary reads' clipping be
+    /// inside `clip_pair`/`clip_fragment`) is what lets supplementary reads' clipping be
     /// upgraded too, and keeps both threading paths in lockstep since both go through this method.
     ///
     /// This is the single shared implementation used by both the single-threaded and

--- a/src/lib/commands/codec.rs
+++ b/src/lib/commands/codec.rs
@@ -309,6 +309,97 @@ pub struct Codec {
     pub queue_memory: QueueMemoryOptions,
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// CodecOptions — the stage's tuning knobs, projected out of the CLI struct
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Codec-stage tuning, independent of how the values were supplied.
+///
+/// See [`crate::commands::zipper::ZipperOptions`] for why this is a plain
+/// struct rather than a flattened `clap::Args`. Note that the consensus-calling
+/// knobs are held **flat** here even though [`Codec`] nests them behind
+/// `#[command(flatten)]` sub-structs: the chain builder wants one bag per stage,
+/// not a re-run of the CLI's grouping.
+#[derive(Debug, Clone)]
+pub struct CodecOptions {
+    /// Pre-UMI error rate (phred).
+    pub error_rate_pre_umi: u8,
+    /// Post-UMI error rate (phred).
+    pub error_rate_post_umi: u8,
+    /// Minimum input base quality.
+    pub min_input_base_quality: u8,
+    /// Emit per-base consensus tags.
+    pub output_per_base_tags: bool,
+    /// Trim consensus reads.
+    pub trim: bool,
+    /// Minimum consensus base quality.
+    pub min_consensus_base_quality: u8,
+    /// How to resolve a near-tie between the two most likely consensus bases.
+    pub tie_rule: fgumi_consensus::TieRule,
+    /// Minimum reads per consensus.
+    pub min_reads: usize,
+    /// Cap on reads per consensus.
+    pub max_reads: Option<usize>,
+    /// Minimum duplex overlap length.
+    pub min_duplex_length: usize,
+    /// Reproduce fgbio's legacy (pre-fgumi#761) overlap window for dovetailed
+    /// FR pairs. Off by default; see [`Codec::legacy_overlap_window`].
+    pub legacy_overlap_window: bool,
+    /// Quality cap for single-strand positions.
+    pub single_strand_qual: Option<u8>,
+    /// Quality cap for outer bases.
+    pub outer_bases_qual: Option<u8>,
+    /// How many bases count as outer.
+    pub outer_bases_length: usize,
+    /// Maximum duplex disagreement rate.
+    pub max_duplex_disagreement_rate: f64,
+    /// Maximum duplex disagreements.
+    pub max_duplex_disagreements: Option<usize>,
+    /// Let fully-unmapped primary templates through the pre-group filter.
+    ///
+    /// Carried as the whole flattened sub-struct, like `io` / `rejects_opts` /
+    /// `read_group`, rather than as a bare `bool`.
+    pub allow_unmapped: AllowUnmappedOptions,
+    /// Input/output paths and reader mode.
+    pub io: BamIoOptions,
+    /// Optional rejects output.
+    pub rejects_opts: RejectsOptions,
+    /// Optional stats output.
+    pub stats_opts: StatsOptions,
+    /// Read-group identity for emitted reads.
+    pub read_group: ReadGroupOptions,
+}
+
+impl Codec {
+    /// Project the parsed CLI flags into [`CodecOptions`].
+    #[must_use]
+    pub fn to_codec_options(&self) -> CodecOptions {
+        CodecOptions {
+            error_rate_pre_umi: self.consensus.error_rate_pre_umi,
+            error_rate_post_umi: self.consensus.error_rate_post_umi,
+            min_input_base_quality: self.consensus.min_input_base_quality,
+            output_per_base_tags: self.consensus.output_per_base_tags,
+            trim: self.consensus.trim,
+            min_consensus_base_quality: self.consensus.min_consensus_base_quality,
+            tie_rule: self.consensus.tie_rule.into(),
+            min_reads: self.min_reads,
+            max_reads: self.max_reads,
+            min_duplex_length: self.min_duplex_length,
+            legacy_overlap_window: self.legacy_overlap_window,
+            single_strand_qual: self.single_strand_qual,
+            outer_bases_qual: self.outer_bases_qual,
+            outer_bases_length: self.outer_bases_length,
+            max_duplex_disagreement_rate: self.max_duplex_disagreement_rate,
+            max_duplex_disagreements: self.max_duplex_disagreements,
+            allow_unmapped: self.allow_unmapped.clone(),
+            io: self.io.clone(),
+            rejects_opts: self.rejects_opts.clone(),
+            stats_opts: self.stats_opts.clone(),
+            read_group: self.read_group.clone(),
+        }
+    }
+}
+
 /// Decide how the single-thread codec loop should handle a typed
 /// [`CodecConsensusError`]: silently swallow recoverable duplex-disagreement
 /// rejects (so the loop continues) and surface any other variant as a fatal
@@ -889,6 +980,128 @@ impl Codec {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every tuning flag must survive the projection into [`CodecOptions`].
+    /// See the simplex counterpart for why this parses rather than constructs.
+    ///
+    /// Every value here is deliberately **non-default**, and every field of
+    /// `CodecOptions` is asserted. Both halves matter: an assertion that
+    /// compares a default against a default passes even when the projection
+    /// ignores the parsed field entirely, and a field left unasserted can be
+    /// dropped from the projection without any test noticing.
+    #[test]
+    fn to_codec_options_carries_every_tuning_flag() {
+        let cmd = Codec::try_parse_from([
+            "codec",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--error-rate-pre-umi",
+            "42",
+            "--error-rate-post-umi",
+            "37",
+            "--min-input-base-quality",
+            "16",
+            "--output-per-base-tags=false",
+            "--trim=true",
+            "--min-consensus-base-quality",
+            "23",
+            "--tie-rule",
+            "ulp-relative",
+            "--min-reads",
+            "4",
+            "--max-reads",
+            "88",
+            "--min-duplex-length",
+            "9",
+            "--legacy-overlap-window",
+            "--single-strand-qual",
+            "12",
+            "--outer-bases-qual",
+            "15",
+            "--outer-bases-length",
+            "7",
+            "--max-duplex-disagreement-rate",
+            "0.25",
+            "--max-duplex-disagreements",
+            "6",
+            "--rejects",
+            "rej.bam",
+            "--stats",
+            "stats.txt",
+            "--read-group-id",
+            "Z",
+            "--read-name-prefix",
+            "pfx",
+            "--allow-unmapped=true",
+        ])
+        .expect("parses");
+
+        let opts = cmd.to_codec_options();
+
+        assert_eq!(opts.error_rate_pre_umi, 42);
+        assert_eq!(opts.error_rate_post_umi, 37);
+        assert_eq!(opts.min_input_base_quality, 16);
+        assert!(!opts.output_per_base_tags, "an explicit false must not be lost");
+        assert!(opts.trim);
+        assert_eq!(opts.min_consensus_base_quality, 23);
+        assert_eq!(
+            opts.tie_rule,
+            fgumi_consensus::TieRule::UlpRelative,
+            "--tie-rule must reach the projection"
+        );
+        assert_eq!(opts.min_reads, 4);
+        assert_eq!(opts.max_reads, Some(88));
+        assert_eq!(opts.min_duplex_length, 9);
+        assert!(opts.legacy_overlap_window, "--legacy-overlap-window must reach the projection");
+        assert_eq!(opts.single_strand_qual, Some(12));
+        assert_eq!(opts.outer_bases_qual, Some(15));
+        assert_eq!(opts.outer_bases_length, 7);
+        assert!((opts.max_duplex_disagreement_rate - 0.25).abs() < f64::EPSILON);
+        assert_eq!(opts.max_duplex_disagreements, Some(6));
+        assert!(opts.allow_unmapped.enabled, "--allow-unmapped must reach the projection");
+        // The flattened sub-structs must come across whole, not field by field.
+        assert_eq!(opts.io.input, std::path::PathBuf::from("in.bam"));
+        assert_eq!(opts.io.output, std::path::PathBuf::from("out.bam"));
+        assert_eq!(opts.rejects_opts.rejects, Some(std::path::PathBuf::from("rej.bam")));
+        assert_eq!(opts.stats_opts.stats, Some(std::path::PathBuf::from("stats.txt")));
+        assert_eq!(opts.read_group.read_group_id, "Z");
+        assert_eq!(opts.read_group.read_name_prefix, Some("pfx".to_string()));
+    }
+
+    /// The projection must carry defaults faithfully too — a field hard-coded to
+    /// the value the non-default test happens to pass would slip through it.
+    #[test]
+    fn to_codec_options_carries_defaults() {
+        let cmd =
+            Codec::try_parse_from(["codec", "-i", "in.bam", "-o", "out.bam"]).expect("parses");
+
+        let opts = cmd.to_codec_options();
+
+        assert_eq!(opts.error_rate_pre_umi, 45);
+        assert_eq!(opts.error_rate_post_umi, 40);
+        assert_eq!(opts.min_input_base_quality, 10);
+        assert!(opts.output_per_base_tags);
+        assert!(!opts.trim);
+        assert_eq!(opts.min_consensus_base_quality, 2);
+        assert_eq!(opts.tie_rule, fgumi_consensus::TieRule::FgbioCompat);
+        assert_eq!(opts.min_reads, 1);
+        assert_eq!(opts.max_reads, None);
+        assert_eq!(opts.min_duplex_length, 1);
+        assert!(!opts.legacy_overlap_window, "the default must be preserved, not hard-coded true");
+        assert_eq!(opts.single_strand_qual, None);
+        assert_eq!(opts.outer_bases_qual, None);
+        assert_eq!(opts.outer_bases_length, 5);
+        assert!((opts.max_duplex_disagreement_rate - 1.0).abs() < f64::EPSILON);
+        assert_eq!(opts.max_duplex_disagreements, None);
+        assert!(!opts.allow_unmapped.enabled);
+        assert_eq!(opts.rejects_opts.rejects, None);
+        assert_eq!(opts.stats_opts.stats, None);
+        assert_eq!(opts.read_group.read_group_id, "A");
+        assert_eq!(opts.read_group.read_name_prefix, None);
+    }
+
     use noodles::sam::alignment::io::Write as AlignmentWrite;
     use rstest::rstest;
     use std::path::PathBuf;

--- a/src/lib/commands/compare/bams.rs
+++ b/src/lib/commands/compare/bams.rs
@@ -151,7 +151,7 @@ impl CommandPreset {
     ///   `clip` rewrites CIGAR/SEQ/QUAL in the clipped span and, as a consequence, regenerates
     ///   the alignment tags (`NM`/`UQ`/`MD`) and repairs mate-pair metadata — but neither ever
     ///   recomputes the depth-tag values. All five compare positionally under
-    ///   [`ContentPredicate::Exact`](super::engines::content::ContentPredicate::Exact):
+    ///   [`ContentPredicate::Exact`]:
     ///   because fgumi clamps the depth tags to fgbio's `Short` ceiling at the source, the
     ///   tags are bit-identical and an exact comparison is both sound and complete — no
     ///   consensus-specific predicate is needed. Since `Exact` holds every core SAM field
@@ -167,7 +167,7 @@ impl CommandPreset {
     ///   ([`super::engines::molecule_join::molecule_join_compare`]): molecules are matched by
     ///   an MI-invariant canonical id (no re-sort — both inputs must already be grouped),
     ///   and each matched pair is checked for record membership, content under
-    ///   [`ContentPredicate::ExactMinusMi`](super::engines::content::ContentPredicate::ExactMinusMi)
+    ///   [`ContentPredicate::ExactMinusMi`]
     ///   (everything except the MI tag), and duplex `/A`/`/B` strand-partition equivalence —
     ///   the predicate excludes MI precisely because the canonical-id matching, not the
     ///   content predicate, is what verifies MI equivalence.
@@ -196,7 +196,7 @@ impl CommandPreset {
     /// The [`ContentPredicate`] to use for this preset's content comparison. See
     /// [`Self::resolve`] for the full resolution table and rationale. Note that for `Group`
     /// (resolved mode `CompareMode::Grouping`), this value is *not* consulted by the
-    /// molecule-join engine — [`engines::molecule_join::molecule_join_compare`] hardcodes
+    /// molecule-join engine — [`super::engines::molecule_join::molecule_join_compare`] hardcodes
     /// [`ContentPredicate::ExactMinusMi`] internally and is not configurable via
     /// `--command`/`--mode`. `Group` never reaches `execute_content`, but this method is
     /// still live for it (its resolved value is exercised only by the
@@ -997,7 +997,7 @@ impl CompareBams {
     ///
     /// This is the sole `CompareMode::Grouping` path (and what `--command group` uses). Both
     /// inputs are cut into per-molecule runs and matched across the two files by an
-    /// MI-invariant canonical id (see [`molecule_join_compare`]) — no re-sort, so both inputs
+    /// MI-invariant canonical id (see [`super::engines::molecule_join::molecule_join_compare`]) — no re-sort, so both inputs
     /// must already be grouped (same-MI reads consecutive, as `fgumi group`/`fgbio group`
     /// output is). This makes the comparison inherently order-independent at the molecule
     /// level — `--ignore-order` is therefore a no-op under `--mode grouping`. Each matched
@@ -1009,7 +1009,7 @@ impl CompareBams {
     ///
     /// # Errors
     ///
-    /// Returns an error if either input cannot be read (see [`molecule_join_compare`]), or
+    /// Returns an error if either input cannot be read (see [`super::engines::molecule_join::molecule_join_compare`]), or
     /// [`super::CompareMismatch`] if the two BAMs are found to differ (non-zero exit via the
     /// `Command` trait).
     fn execute_grouping(&self, input1: OpenedInput, input2: OpenedInput) -> Result<u64> {

--- a/src/lib/commands/compare/engines/mod.rs
+++ b/src/lib/commands/compare/engines/mod.rs
@@ -1,7 +1,7 @@
 //! Comparison engines for `fgumi compare bams`.
 //!
 //! An "engine" pairs records from the two input streams (see
-//! [`positional`](self::positional), added alongside the positional-alignment work) and
+//! [`positional`], added alongside the positional-alignment work) and
 //! decides whether each pair is content-equal via a [`content::ContentPredicate`].
 //! Splitting pairing (positional) from equality (content) keeps the pairing logic honest:
 //! it can never quietly resync past a mismatch just because two *unrelated* records

--- a/src/lib/commands/compare/engines/positional.rs
+++ b/src/lib/commands/compare/engines/positional.rs
@@ -15,8 +15,8 @@
 //!   coincidence, not evidence of parity, so it must never be allowed to mask
 //!   the desync.
 //! - If the keys agree, the pair is compared under a
-//!   [`ContentPredicate`](super::content::ContentPredicate) via
-//!   [`content_diffs`](super::content::content_diffs).
+//!   [`ContentPredicate`] via
+//!   [`content_diffs`].
 //!
 //! A record-count mismatch (one file longer than the other) is reported as a
 //! presence difference, independent of and in addition to any key mismatch.
@@ -53,7 +53,7 @@ pub struct PositionalOutcome {
     /// pairing stopped at the first desync rather than attempting to resync.
     pub key_mismatch_at: Option<u64>,
     /// `true` if the two inputs' `@HD`/`@SQ`/`@RG` headers disagreed on a field
-    /// [`compare_headers`](super::header::compare_headers) considers significant (`@PG`/`@CO`
+    /// [`compare_headers`] considers significant (`@PG`/`@CO`
     /// are normalized and never contribute here).
     pub header_mismatch: bool,
     /// Human-readable diff strings (header, key mismatch, content diffs, and/or the
@@ -85,7 +85,7 @@ impl PositionalOutcome {
 /// always reflect the true totals even after pairing has stopped.
 ///
 /// Also compares the two inputs' headers via
-/// [`compare_headers`](super::header::compare_headers) (`@HD`/`@SQ`/`@RG`, normalizing away
+/// [`compare_headers`] (`@HD`/`@SQ`/`@RG`, normalizing away
 /// `@PG`/`@CO`); a significant divergence is folded into
 /// `PositionalOutcome::header_mismatch`/`PositionalOutcome::is_match` alongside the
 /// record-level findings.

--- a/src/lib/commands/compare/engines/sort_verify.rs
+++ b/src/lib/commands/compare/engines/sort_verify.rs
@@ -106,7 +106,7 @@ pub struct SortVerifyOutcome {
     /// compared (no resync), though both streams are still drained for accurate counts.
     pub presence_mismatch: bool,
     /// `true` if the two inputs' `@HD`/`@SQ`/`@RG` headers disagreed on a field
-    /// [`compare_headers`](super::header::compare_headers) considers significant (`@PG`/`@CO`
+    /// [`compare_headers`] considers significant (`@PG`/`@CO`
     /// are normalized and never contribute here). Note that `@HD` `SO`/`GO`/`SS` agreement is
     /// already implied by `detect_sort_order` succeeding on both inputs with a matching
     /// [`SortOrder`] (checked before this field is ever populated) *only when both writers use
@@ -1072,7 +1072,7 @@ where
 /// by maximal equal-core-sort-key run (see the module docs).
 ///
 /// Never re-sorts either input. Also compares the two inputs' headers via
-/// [`compare_headers`](super::header::compare_headers) (`@HD`/`@SQ`/`@RG`, normalizing away
+/// [`compare_headers`] (`@HD`/`@SQ`/`@RG`, normalizing away
 /// `@PG`/`@CO`); a significant divergence is folded into
 /// [`SortVerifyOutcome::header_mismatch`]/[`SortVerifyOutcome::is_match`] alongside the
 /// run-comparison findings. `max_diffs` caps the number of entries collected in

--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -335,8 +335,65 @@ pub struct CorrectUmis {
     pub queue_memory: QueueMemoryOptions,
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// CorrectOptions — the stage's tuning knobs, projected out of the CLI struct
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// CorrectUmis-stage tuning, independent of how the values were supplied.
+///
+/// See [`crate::commands::zipper::ZipperOptions`] for why this is a plain
+/// struct rather than a flattened `clap::Args`. Note that the rejects path is
+/// held **flat** here even though [`CorrectUmis`] nests it behind a
+/// `#[command(flatten)]` sub-struct: the chain builder wants one bag per stage,
+/// not a re-run of the CLI's grouping.
+#[derive(Debug, Clone)]
+pub struct CorrectOptions {
+    /// Optional metrics output.
+    pub metrics: Option<PathBuf>,
+    /// Which SAM tag is corrected: `RX`/`OX` for UMIs, `BC`/`ob` for barcodes.
+    pub target: Target,
+    /// Maximum mismatches when matching a UMI.
+    pub max_mismatches: usize,
+    /// Minimum distance to the runner-up UMI.
+    pub min_distance_diff: usize,
+    /// Expected UMI sequences.
+    pub umis: Vec<String>,
+    /// Files holding expected UMI sequences.
+    pub umi_files: Vec<PathBuf>,
+    /// Skip storing the original UMI.
+    pub dont_store_original_umis: bool,
+    /// UMI match cache size.
+    pub cache_size: usize,
+    /// Minimum corrected fraction before failing.
+    pub min_corrected: Option<f64>,
+    /// Also match the reverse complement.
+    pub revcomp: bool,
+    /// Optional rejects output path.
+    pub rejects_path: Option<PathBuf>,
+}
+
+impl CorrectUmis {
+    /// Project the parsed CLI flags into [`CorrectOptions`].
+    #[must_use]
+    pub fn to_correct_options(&self) -> CorrectOptions {
+        CorrectOptions {
+            metrics: self.metrics.clone(),
+            target: self.target,
+            max_mismatches: self.max_mismatches,
+            min_distance_diff: self.min_distance_diff,
+            umis: self.umis.clone(),
+            umi_files: self.umi_files.clone(),
+            dont_store_original_umis: self.dont_store_original_umis,
+            cache_size: self.cache_size,
+            min_corrected: self.min_corrected,
+            revcomp: self.revcomp,
+            rejects_path: self.rejects_opts.rejects.clone(),
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-enum RejectionReason {
+pub(crate) enum RejectionReason {
     WrongLength,
     Mismatched,
     #[default]
@@ -348,9 +405,9 @@ enum RejectionReason {
 /// This struct holds the result of correcting a UMI once for an entire template,
 /// which can then be applied to all records in that template.
 #[derive(Debug)]
-struct TemplateCorrection {
+pub(crate) struct TemplateCorrection {
     /// Whether the UMI matched successfully.
-    matched: bool,
+    pub(crate) matched: bool,
     /// The corrected UMI string (if matched).
     corrected_umi: Option<String>,
     /// The original UMI string.
@@ -360,9 +417,9 @@ struct TemplateCorrection {
     /// Whether there were actual mismatches (not just revcomp).
     has_mismatches: bool,
     /// Match details for metrics.
-    matches: Vec<UmiMatch>,
+    pub(crate) matches: Vec<UmiMatch>,
     /// Rejection reason if not matched.
-    rejection_reason: RejectionReason,
+    pub(crate) rejection_reason: RejectionReason,
 }
 
 // ============================================================================
@@ -400,17 +457,37 @@ impl MemoryEstimate for CorrectProcessedBatch {
 
 /// Metrics collected from UMI correction processing, aggregated post-pipeline.
 #[derive(Default)]
-struct CollectedCorrectMetrics {
+pub(crate) struct CollectedCorrectMetrics {
     /// Total templates processed.
-    templates_processed: u64,
+    pub(crate) templates_processed: u64,
     /// Records with missing UMI tag.
-    missing_umis: u64,
+    pub(crate) missing_umis: u64,
     /// Records with wrong UMI length.
-    wrong_length: u64,
+    pub(crate) wrong_length: u64,
     /// Records that didn't match any fixed UMI.
-    mismatched: u64,
+    pub(crate) mismatched: u64,
     /// Per-UMI match counts (for metrics file).
-    umi_matches: AHashMap<String, UmiCorrectionMetrics>,
+    pub(crate) umi_matches: AHashMap<String, UmiCorrectionMetrics>,
+}
+
+// Slot aggregation for the typed-step correction path
+// (`pipeline::steps::correct`). Per-UMI crediting is NOT re-derived here --
+// the step calls `CorrectUmis::credit_umi_metrics` directly, so both paths
+// share one definition of fgbio's per-segment accounting.
+impl CollectedCorrectMetrics {
+    /// Drain `other` into `self`, summing counts.
+    ///
+    /// Used to aggregate the per-thread accumulator slots once the pipeline has
+    /// drained. `other` is left empty.
+    pub(crate) fn merge_into(&mut self, other: &mut CollectedCorrectMetrics) {
+        self.templates_processed += std::mem::take(&mut other.templates_processed);
+        self.missing_umis += std::mem::take(&mut other.missing_umis);
+        self.wrong_length += std::mem::take(&mut other.wrong_length);
+        self.mismatched += std::mem::take(&mut other.mismatched);
+        for (umi, counts) in other.umi_matches.drain() {
+            merge_umi_counts(&mut self.umi_matches, umi, &counts);
+        }
+    }
 }
 
 impl Command for CorrectUmis {
@@ -640,7 +717,7 @@ impl CorrectUmis {
 
     /// Compute UMI correction for a template (called once per template).
     #[allow(clippy::too_many_arguments)]
-    fn compute_template_correction(
+    pub(crate) fn compute_template_correction(
         umi: &str,
         umi_length: usize,
         revcomp: bool,
@@ -745,7 +822,7 @@ impl CorrectUmis {
     ///
     /// `num_records` scales fgbio's per-record accounting to fgumi's
     /// per-template batching (both R1 and R2 of a template share one UMI).
-    fn credit_umi_metrics(
+    pub(crate) fn credit_umi_metrics(
         matches: &[UmiMatch],
         num_records: u64,
         unmatched_umi: &str,
@@ -783,7 +860,7 @@ impl CorrectUmis {
     /// - Records have different UMIs
     /// - Some records have UMIs and others don't
     /// - UMI tag has non-string type
-    fn extract_and_validate_template_umi_raw(
+    pub(crate) fn extract_and_validate_template_umi_raw(
         raw_records: &[RawRecord],
         umi_tag: [u8; 2],
     ) -> anyhow::Result<Option<String>> {
@@ -849,7 +926,7 @@ impl CorrectUmis {
     }
 
     /// Apply UMI correction to a raw BAM record.
-    fn apply_correction_to_raw(
+    pub(crate) fn apply_correction_to_raw(
         record: &mut RawRecord,
         correction: &TemplateCorrection,
         umi_tag: [u8; 2],
@@ -1701,6 +1778,99 @@ pub fn find_umi_pairs_within_distance(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every tuning flag must survive the projection into [`CorrectOptions`].
+    ///
+    /// Every value here is deliberately **non-default**, and every field of
+    /// `CorrectOptions` is asserted. Both halves matter: an assertion that
+    /// compares a default against a default passes even when the projection
+    /// ignores the parsed field entirely, and a field left unasserted can be
+    /// dropped from the projection without any test noticing.
+    ///
+    /// `rejects_path` is the one field that changes shape: it is read out of the
+    /// flattened `RejectsOptions`.
+    #[test]
+    fn to_correct_options_carries_every_tuning_flag() {
+        let cmd = CorrectUmis::try_parse_from([
+            "correct",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "-u",
+            "ACGT",
+            "-u",
+            "TTTT",
+            "-U",
+            "umis.txt",
+            "--target",
+            "barcode",
+            "--max-mismatches",
+            "5",
+            "--min-distance",
+            "3",
+            "--cache-size",
+            "4096",
+            "--min-corrected",
+            "0.75",
+            "--revcomp=true",
+            "--dont-store-original=true",
+            "--rejects",
+            "rej.bam",
+            "--metrics",
+            "m.txt",
+        ])
+        .expect("parses");
+
+        let opts = cmd.to_correct_options();
+
+        assert_eq!(opts.metrics, Some(std::path::PathBuf::from("m.txt")));
+        assert_eq!(opts.target, Target::Barcode, "--target must reach the projection");
+        assert_eq!(opts.max_mismatches, 5);
+        assert_eq!(opts.min_distance_diff, 3);
+        assert_eq!(opts.umis, vec!["ACGT".to_string(), "TTTT".to_string()]);
+        assert_eq!(opts.umi_files, vec![std::path::PathBuf::from("umis.txt")]);
+        assert!(opts.dont_store_original_umis);
+        assert_eq!(opts.cache_size, 4096);
+        assert_eq!(opts.min_corrected, Some(0.75));
+        assert!(opts.revcomp);
+        assert_eq!(
+            opts.rejects_path,
+            Some(std::path::PathBuf::from("rej.bam")),
+            "rejects_path must be read from the flattened RejectsOptions",
+        );
+    }
+
+    /// The projection must carry defaults faithfully too — a field hard-coded to
+    /// the value the non-default test happens to pass would slip through it.
+    #[test]
+    fn to_correct_options_carries_defaults() {
+        let cmd = CorrectUmis::try_parse_from([
+            "correct",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "-u",
+            "ACGT",
+            "--min-distance",
+            "1",
+        ])
+        .expect("parses");
+
+        let opts = cmd.to_correct_options();
+
+        assert_eq!(opts.metrics, None);
+        assert_eq!(opts.target, Target::Umi);
+        assert_eq!(opts.max_mismatches, 2);
+        assert!(opts.umi_files.is_empty());
+        assert!(!opts.dont_store_original_umis);
+        assert_eq!(opts.cache_size, 100_000);
+        assert_eq!(opts.min_corrected, None);
+        assert!(!opts.revcomp);
+        assert_eq!(opts.rejects_path, None);
+    }
+
     use noodles::sam;
     use noodles::sam::alignment::io::Write as SamWrite;
     use noodles::sam::alignment::record_buf::RecordBuf;

--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -306,8 +306,8 @@ struct LadderLibraryState {
     duplicate_templates: u64,
     /// Next cumulative `templates_seen` value that triggers a snapshot row.
     next_threshold: u64,
-    /// `templates_seen` at the last emitted row, used by [`Self::finish`] (via
-    /// [`DuplicationLadderRecorder::finish`]) to avoid a duplicate final row
+    /// `templates_seen` at the last emitted row, used by
+    /// [`DuplicationLadderRecorder::finish`] to avoid a duplicate final row
     /// when the true total already landed exactly on an interval crossing, and
     /// to size each snapshot's window (`templates_seen - last_emitted_at`).
     last_emitted_at: u64,

--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -238,6 +238,86 @@ pub struct Duplex {
     pub reference: Option<std::path::PathBuf>,
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// DuplexOptions — the stage's tuning knobs, projected out of the CLI struct
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Duplex-stage tuning, independent of how the values were supplied.
+///
+/// See [`crate::commands::zipper::ZipperOptions`] for why this is a plain
+/// struct rather than a flattened `clap::Args`. Note that the consensus-calling
+/// knobs are held **flat** here even though [`Duplex`] nests them behind
+/// `#[command(flatten)]` sub-structs: the chain builder wants one bag per stage,
+/// not a re-run of the CLI's grouping.
+#[derive(Debug, Clone)]
+pub struct DuplexOptions {
+    /// Pre-UMI error rate (phred).
+    pub error_rate_pre_umi: u8,
+    /// Post-UMI error rate (phred).
+    pub error_rate_post_umi: u8,
+    /// Minimum input base quality.
+    pub min_input_base_quality: u8,
+    /// Emit per-base consensus tags.
+    pub output_per_base_tags: bool,
+    /// Trim consensus reads.
+    pub trim: bool,
+    /// Minimum consensus base quality.
+    pub min_consensus_base_quality: u8,
+    /// How to resolve a near-tie between the two most likely consensus bases.
+    pub tie_rule: fgumi_consensus::TieRule,
+    /// Call overlapping bases jointly.
+    pub consensus_call_overlapping_bases: bool,
+    /// Minimum reads per consensus, per tier.
+    pub min_reads: Vec<usize>,
+    /// Cap on reads per strand.
+    pub max_reads_per_strand: Option<usize>,
+    /// Let fully-unmapped primary templates through the pre-group filter.
+    ///
+    /// Carried as the whole flattened sub-struct, like `io` / `rejects_opts` /
+    /// `read_group`, rather than as a bare `bool`.
+    pub allow_unmapped: AllowUnmappedOptions,
+    /// Input/output paths and reader mode.
+    pub io: BamIoOptions,
+    /// Optional rejects output.
+    pub rejects_opts: RejectsOptions,
+    /// Optional stats output.
+    pub stats_opts: StatsOptions,
+    /// Read-group identity for emitted reads.
+    pub read_group: ReadGroupOptions,
+    /// Resolved methylation calling mode (`Disabled` when the flag is unset).
+    pub methylation_mode: fgumi_consensus::MethylationMode,
+    /// Reference FASTA for methylation-aware modes.
+    pub reference: Option<std::path::PathBuf>,
+}
+
+impl Duplex {
+    /// Project the parsed CLI flags into [`DuplexOptions`].
+    #[must_use]
+    pub fn to_duplex_options(&self) -> DuplexOptions {
+        DuplexOptions {
+            error_rate_pre_umi: self.consensus.error_rate_pre_umi,
+            error_rate_post_umi: self.consensus.error_rate_post_umi,
+            min_input_base_quality: self.consensus.min_input_base_quality,
+            output_per_base_tags: self.consensus.output_per_base_tags,
+            trim: self.consensus.trim,
+            min_consensus_base_quality: self.consensus.min_consensus_base_quality,
+            tie_rule: self.consensus.tie_rule.into(),
+            consensus_call_overlapping_bases: self.overlapping.consensus_call_overlapping_bases,
+            min_reads: self.min_reads.clone(),
+            max_reads_per_strand: self.max_reads_per_strand,
+            allow_unmapped: self.allow_unmapped.clone(),
+            io: self.io.clone(),
+            rejects_opts: self.rejects_opts.clone(),
+            stats_opts: self.stats_opts.clone(),
+            read_group: self.read_group.clone(),
+            methylation_mode: crate::commands::common::resolve_methylation_mode(
+                self.methylation_mode,
+            ),
+            reference: self.reference.clone(),
+        }
+    }
+}
+
 impl Command for Duplex {
     /// Executes the duplex consensus calling pipeline.
     ///
@@ -980,6 +1060,110 @@ fn has_both_strands_raw(records: &[RawRecord]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every tuning flag must survive the projection into [`DuplexOptions`].
+    /// See the simplex counterpart for why this parses rather than constructs.
+    #[test]
+    fn to_duplex_options_carries_every_tuning_flag() {
+        let cmd = Duplex::try_parse_from([
+            "duplex",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--error-rate-pre-umi",
+            "41",
+            "--error-rate-post-umi",
+            "36",
+            "--min-input-base-quality",
+            "18",
+            "--output-per-base-tags=false",
+            "--trim=true",
+            "--min-consensus-base-quality",
+            "21",
+            "--tie-rule",
+            "ulp-relative",
+            "--consensus-call-overlapping-bases=false",
+            "--min-reads",
+            "3,2,1",
+            "--max-reads-per-strand",
+            "55",
+            "--rejects",
+            "rej.bam",
+            "--stats",
+            "stats.txt",
+            "--read-group-id",
+            "Z",
+            "--read-name-prefix",
+            "pfx",
+            "--methylation-mode",
+            "em-seq",
+            "--ref",
+            "ref.fa",
+            "--allow-unmapped=true",
+        ])
+        .expect("parses");
+
+        let opts = cmd.to_duplex_options();
+
+        assert_eq!(opts.error_rate_pre_umi, 41);
+        assert_eq!(opts.error_rate_post_umi, 36);
+        assert_eq!(opts.min_input_base_quality, 18);
+        assert!(!opts.output_per_base_tags, "an explicit false must not be lost");
+        assert!(opts.trim);
+        assert_eq!(opts.min_consensus_base_quality, 21);
+        assert_eq!(
+            opts.tie_rule,
+            fgumi_consensus::TieRule::UlpRelative,
+            "--tie-rule must reach the projection"
+        );
+        assert!(!opts.consensus_call_overlapping_bases);
+        assert_eq!(opts.min_reads, vec![3, 2, 1]);
+        assert_eq!(opts.max_reads_per_strand, Some(55));
+        assert!(opts.allow_unmapped.enabled, "--allow-unmapped must reach the projection");
+        assert_eq!(
+            opts.methylation_mode,
+            fgumi_consensus::MethylationMode::EmSeq,
+            "--methylation-mode must reach the projection",
+        );
+        assert_eq!(opts.reference, Some(std::path::PathBuf::from("ref.fa")));
+        // The flattened sub-structs must come across whole, not field by field.
+        assert_eq!(opts.io.input, std::path::PathBuf::from("in.bam"));
+        assert_eq!(opts.io.output, std::path::PathBuf::from("out.bam"));
+        assert_eq!(opts.rejects_opts.rejects, Some(std::path::PathBuf::from("rej.bam")));
+        assert_eq!(opts.stats_opts.stats, Some(std::path::PathBuf::from("stats.txt")));
+        assert_eq!(opts.read_group.read_group_id, "Z");
+        assert_eq!(opts.read_group.read_name_prefix, Some("pfx".to_string()));
+    }
+
+    /// The projection must carry defaults faithfully too — a field hard-coded to
+    /// the value the non-default test happens to pass would slip through it.
+    #[test]
+    fn to_duplex_options_carries_defaults() {
+        let cmd =
+            Duplex::try_parse_from(["duplex", "-i", "in.bam", "-o", "out.bam"]).expect("parses");
+
+        let opts = cmd.to_duplex_options();
+
+        assert_eq!(opts.error_rate_pre_umi, 45);
+        assert_eq!(opts.error_rate_post_umi, 40);
+        assert_eq!(opts.min_input_base_quality, 10);
+        assert!(opts.output_per_base_tags);
+        assert!(!opts.trim);
+        assert_eq!(opts.min_consensus_base_quality, 2);
+        assert_eq!(opts.tie_rule, fgumi_consensus::TieRule::FgbioCompat);
+        assert!(opts.consensus_call_overlapping_bases);
+        assert_eq!(opts.min_reads, vec![1]);
+        assert_eq!(opts.max_reads_per_strand, None);
+        assert!(!opts.allow_unmapped.enabled);
+        assert_eq!(opts.methylation_mode, fgumi_consensus::MethylationMode::Disabled);
+        assert_eq!(opts.reference, None);
+        assert_eq!(opts.rejects_opts.rejects, None);
+        assert_eq!(opts.stats_opts.stats, None);
+        assert_eq!(opts.read_group.read_group_id, "A");
+        assert_eq!(opts.read_group.read_name_prefix, None);
+    }
+
     use anyhow::Result;
     use fgumi_bam_io::{create_bam_reader, create_bam_writer};
     use fgumi_raw_bam::{

--- a/src/lib/commands/extract.rs
+++ b/src/lib/commands/extract.rs
@@ -916,7 +916,7 @@ impl Extract {
     /// <https://support.illumina.com/help/BaseSpace_OLH_009008/Content/Source/Informatics/BS/FileFormat_FASTQ-files_swBS.htm>.
     ///
     /// An old-style Casava (<1.8) `/1` / `/2` read-number suffix is stripped from
-    /// the returned name (see [`strip_read_suffix`](crate::fastq_parse::strip_read_suffix))
+    /// the returned name (see [`strip_read_suffix`])
     /// so both mates of a pair share an identical QNAME, matching fgbio's `FastqSource`.
     /// Stripping happens before UMI extraction so a read-number digit never leaks into the UMI.
     ///

--- a/src/lib/commands/filter.rs
+++ b/src/lib/commands/filter.rs
@@ -218,6 +218,80 @@ pub struct Filter {
     pub queue_memory: QueueMemoryOptions,
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// FilterOptions — the stage's tuning knobs, projected out of the CLI struct
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Filter-stage tuning, independent of how the values were supplied.
+///
+/// See [`crate::commands::zipper::ZipperOptions`] for why this is a plain
+/// struct rather than a flattened `clap::Args`: the chain builder only reads
+/// these values, so moving the fields off [`Filter`] would rewrite this module
+/// and its tests for no gain here.
+#[derive(Debug, Clone)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct FilterOptions {
+    /// Reference FASTA, required by methylation-aware filters.
+    pub reference: Option<PathBuf>,
+    /// Minimum reads supporting a consensus, per depth tier.
+    pub min_reads: Vec<usize>,
+    /// Maximum per-read error rate, per depth tier.
+    pub max_read_error_rate: Vec<f64>,
+    /// Maximum per-base error rate, per depth tier.
+    pub max_base_error_rate: Vec<f64>,
+    /// Minimum consensus base quality.
+    pub min_base_quality: Option<u8>,
+    /// Minimum mean base quality across the read.
+    pub min_mean_base_quality: Option<f64>,
+    /// Maximum fraction of no-called bases.
+    pub max_no_call_fraction: f64,
+    /// Reverse per-base tags on negative-strand reads.
+    pub reverse_per_base_tags: bool,
+    /// Filter whole templates rather than individual reads.
+    pub filter_by_template: bool,
+    /// Optional path for rejected records.
+    pub rejects: Option<PathBuf>,
+    /// Optional path for filter statistics.
+    pub stats: Option<PathBuf>,
+    /// Require both single-strand consensuses to agree.
+    pub require_single_strand_agreement: bool,
+    /// Minimum methylation depth, per tier.
+    pub min_methylation_depth: Vec<usize>,
+    /// Require both strands to agree on methylation.
+    pub require_strand_methylation_agreement: bool,
+    /// Minimum bisulfite conversion fraction.
+    pub min_conversion_fraction: Option<f64>,
+    /// Resolved methylation calling mode (`Disabled` when the flag is unset).
+    pub methylation_mode: fgumi_consensus::MethylationMode,
+}
+
+impl Filter {
+    /// Project the parsed CLI flags into [`FilterOptions`].
+    #[must_use]
+    pub fn to_filter_options(&self) -> FilterOptions {
+        FilterOptions {
+            reference: self.reference.clone(),
+            min_reads: self.min_reads.clone(),
+            max_read_error_rate: self.max_read_error_rate.clone(),
+            max_base_error_rate: self.max_base_error_rate.clone(),
+            min_base_quality: self.min_base_quality,
+            min_mean_base_quality: self.min_mean_base_quality,
+            max_no_call_fraction: self.max_no_call_fraction,
+            reverse_per_base_tags: self.reverse_per_base_tags,
+            filter_by_template: self.filter_by_template,
+            rejects: self.rejects.clone(),
+            stats: self.stats.clone(),
+            require_single_strand_agreement: self.require_single_strand_agreement,
+            min_methylation_depth: self.min_methylation_depth.clone(),
+            require_strand_methylation_agreement: self.require_strand_methylation_agreement,
+            min_conversion_fraction: self.min_conversion_fraction,
+            methylation_mode: crate::commands::common::resolve_methylation_mode(
+                self.methylation_mode,
+            ),
+        }
+    }
+}
+
 // ============================================================================
 // 7-Step Pipeline Types
 // ============================================================================
@@ -1188,6 +1262,104 @@ fn progress_heartbeat_total(before: u64, records: u64) -> Option<u64> {
 #[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
+
+    /// Every tuning flag must survive the projection into [`FilterOptions`].
+    ///
+    /// Driven through `try_parse_from` rather than a struct literal: a literal
+    /// would still compile if a flag were renamed or unwired, whereas parsing
+    /// pins the whole path from command line to option struct. Non-default
+    /// values throughout, so a field read from the wrong source fails rather
+    /// than coincidentally matching its default.
+    #[test]
+    fn to_filter_options_carries_every_tuning_flag() {
+        let cmd = Filter::try_parse_from([
+            "filter",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--ref",
+            "ref.fa",
+            "--min-reads",
+            "3,2,1",
+            "--max-read-error-rate",
+            "0.06,0.07",
+            "--max-base-error-rate",
+            "0.05",
+            "--min-base-quality",
+            "13",
+            "--min-mean-base-quality",
+            "22.5",
+            "--max-no-call-fraction",
+            "0.3",
+            "--reverse-per-base-tags=true",
+            "--filter-by-template=false",
+            "--rejects",
+            "rej.bam",
+            "--stats",
+            "stats.txt",
+            "--require-single-strand-agreement=true",
+            "--min-methylation-depth",
+            "4,5",
+            "--require-strand-methylation-agreement=true",
+            "--min-conversion-fraction",
+            "0.9",
+            "--methylation-mode",
+            "em-seq",
+        ])
+        .expect("parses");
+
+        let opts = cmd.to_filter_options();
+
+        assert_eq!(opts.reference, Some(std::path::PathBuf::from("ref.fa")));
+        assert_eq!(opts.min_reads, vec![3, 2, 1]);
+        assert_eq!(opts.max_base_error_rate, vec![0.05]);
+        assert_eq!(opts.min_base_quality, Some(13));
+        assert_eq!(opts.min_mean_base_quality, Some(22.5));
+        assert!((opts.max_no_call_fraction - 0.3).abs() < f64::EPSILON);
+        assert!(opts.reverse_per_base_tags);
+        assert!(!opts.filter_by_template, "an explicit false must not be lost");
+        assert_eq!(opts.rejects, Some(std::path::PathBuf::from("rej.bam")));
+        assert_eq!(opts.stats, Some(std::path::PathBuf::from("stats.txt")));
+        assert!(opts.require_single_strand_agreement);
+        assert_eq!(opts.min_methylation_depth, vec![4, 5]);
+        assert!(opts.require_strand_methylation_agreement);
+        assert_eq!(opts.min_conversion_fraction, Some(0.9));
+        assert_eq!(opts.max_read_error_rate, vec![0.06, 0.07]);
+        assert_eq!(
+            opts.methylation_mode,
+            fgumi_consensus::MethylationMode::EmSeq,
+            "--methylation-mode must reach the projection",
+        );
+    }
+
+    /// The projection must carry defaults faithfully too — a field hard-coded to
+    /// the value the non-default test happens to pass would slip through it.
+    #[test]
+    fn to_filter_options_carries_defaults() {
+        let cmd =
+            Filter::try_parse_from(["filter", "-i", "in.bam", "-o", "out.bam"]).expect("parses");
+
+        let opts = cmd.to_filter_options();
+
+        assert_eq!(opts.reference, None);
+        assert!(opts.min_reads.is_empty());
+        assert_eq!(opts.max_read_error_rate, vec![0.025]);
+        assert_eq!(opts.max_base_error_rate, vec![0.1]);
+        assert_eq!(opts.min_base_quality, None);
+        assert_eq!(opts.min_mean_base_quality, None);
+        assert!((opts.max_no_call_fraction - 0.2).abs() < f64::EPSILON);
+        assert!(!opts.reverse_per_base_tags);
+        assert!(opts.filter_by_template);
+        assert_eq!(opts.rejects, None);
+        assert_eq!(opts.stats, None);
+        assert!(!opts.require_single_strand_agreement);
+        assert!(opts.min_methylation_depth.is_empty());
+        assert!(!opts.require_strand_methylation_agreement);
+        assert_eq!(opts.min_conversion_fraction, None);
+        assert_eq!(opts.methylation_mode, fgumi_consensus::MethylationMode::Disabled);
+    }
+
     use crate::sam::SamTag;
     use fgumi_raw_bam::{RawRecord, SamBuilder as RawSamBuilder, aux_data_slice, flags};
     use noodles::sam::alignment::record_buf::RecordBuf;

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -721,6 +721,103 @@ pub struct GroupReadsByUmi {
     pub memory_report_interval: u64,
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// GroupOptions — the stage's tuning knobs, projected out of the CLI struct
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Group-stage tuning, independent of how the values were supplied.
+///
+/// See [`crate::commands::zipper::ZipperOptions`] for why this is a plain
+/// struct rather than a flattened `clap::Args`.
+///
+/// Two fields hold *resolved* values rather than raw flags, because grouping
+/// cannot be configured from the raw ones alone: `min_map_q` applies the
+/// default that [`GroupReadsByUmi`] would otherwise apply at run time, and
+/// `effective_strategy` / `effective_edits` carry the `--no-umi` and
+/// identity-implies-zero-edits rules. Both come from the same methods
+/// `execute` uses, so the command and the chain builder cannot drift apart.
+#[derive(Debug, Clone)]
+pub struct GroupOptions {
+    /// Minimum mapping quality for mapped reads, with the default applied.
+    pub min_map_q: u8,
+    /// Include non-PF reads.
+    pub include_non_pf_reads: bool,
+    /// Allow fully unmapped templates.
+    pub allow_unmapped: bool,
+    /// The strategy as requested on the command line.
+    pub strategy: Strategy,
+    /// The edit distance as requested on the command line.
+    pub edits: u32,
+    /// Minimum UMI length to accept.
+    pub min_umi_length: Option<usize>,
+    /// When to build the N-gram/BK-tree index instead of scanning linearly.
+    ///
+    /// This is [`fgumi_umi::IndexThreshold`] rather than a bare count: the
+    /// flag also accepts `always` / `never`, which a number cannot express.
+    pub index_threshold: IndexThreshold,
+    /// Skip UMI-based grouping entirely.
+    pub no_umi: bool,
+    /// Template-count floor for handing a position group to a parallel assigner.
+    pub parallel_group_min_templates: Option<ParallelMinTemplates>,
+    /// The strategy actually used, after applying `--no-umi`.
+    pub effective_strategy: Strategy,
+    /// The edit distance actually used, after applying `--no-umi` and the
+    /// identity-implies-zero rule.
+    pub effective_edits: u32,
+    /// Optional family-size histogram output.
+    pub family_size_histogram: Option<PathBuf>,
+    /// Optional grouping-metrics output.
+    pub grouping_metrics: Option<PathBuf>,
+    /// Optional output prefix for the full set of metrics files.
+    pub metrics_prefix: Option<PathBuf>,
+}
+
+impl GroupReadsByUmi {
+    /// The minimum mapping quality to apply, defaulting when the flag is absent.
+    #[must_use]
+    pub fn resolved_min_map_q(&self) -> u8 {
+        self.min_map_q.unwrap_or(1)
+    }
+
+    /// Resolve the strategy and edit distance grouping will actually use.
+    ///
+    /// `--no-umi` forces identity grouping, and identity grouping requires an
+    /// edit distance of zero; both rules live here so `execute` and the chain
+    /// builder cannot disagree about what was configured. The caller is
+    /// responsible for rejecting `--no-umi` with `--strategy paired` and for
+    /// logging the override — this method only computes.
+    #[must_use]
+    pub fn resolve_strategy_and_edits(&self) -> (Strategy, u32) {
+        if self.no_umi {
+            return (Strategy::Identity, 0);
+        }
+        let edits = if matches!(self.strategy, Strategy::Identity) { 0 } else { self.edits };
+        (self.strategy, edits)
+    }
+
+    /// Project the parsed CLI flags into [`GroupOptions`].
+    #[must_use]
+    pub fn to_group_options(&self) -> GroupOptions {
+        let (effective_strategy, effective_edits) = self.resolve_strategy_and_edits();
+        GroupOptions {
+            min_map_q: self.resolved_min_map_q(),
+            include_non_pf_reads: self.include_non_pf_reads,
+            allow_unmapped: self.allow_unmapped,
+            strategy: self.strategy,
+            edits: self.edits,
+            min_umi_length: self.min_umi_length,
+            index_threshold: self.index_threshold,
+            no_umi: self.no_umi,
+            parallel_group_min_templates: self.parallel_group_min_templates.clone(),
+            effective_strategy,
+            effective_edits,
+            family_size_histogram: self.family_size_histogram.clone(),
+            grouping_metrics: self.grouping_metrics.clone(),
+            metrics_prefix: self.metrics.clone(),
+        }
+    }
+}
+
 /// Build [`UmiGroupingMetrics`] from filter metrics and family size counts.
 ///
 /// Shared by both the pipeline and single-threaded execution paths.
@@ -802,23 +899,10 @@ impl Command for GroupReadsByUmi {
         }
 
         // Handle --no-umi mode: force identity strategy
-        let (effective_strategy, no_umi_edits_override) = if self.no_umi {
-            if !matches!(self.strategy, Strategy::Identity) {
-                info!("--no-umi mode: overriding strategy to identity");
-            }
-            (Strategy::Identity, true)
-        } else {
-            (self.strategy, false)
-        };
-
-        // Identity strategy requires edits=0, others use the configured value
-        // Also force edits=0 in no-umi mode
-        let effective_edits =
-            if no_umi_edits_override || matches!(effective_strategy, Strategy::Identity) {
-                0
-            } else {
-                self.edits
-            };
+        if self.no_umi && !matches!(self.strategy, Strategy::Identity) {
+            info!("--no-umi mode: overriding strategy to identity");
+        }
+        let (effective_strategy, effective_edits) = self.resolve_strategy_and_edits();
 
         // `--index-threshold always` asserts that indexing will happen; reject it when
         // the resolved strategy/edits can never index rather than ignoring the flag.
@@ -832,7 +916,7 @@ impl Command for GroupReadsByUmi {
         self.io.validate()?;
 
         // Set minimum mapping quality
-        let min_mapq: u8 = self.min_map_q.unwrap_or(1);
+        let min_mapq: u8 = self.resolved_min_map_q();
 
         // Initialize tracking infrastructure
         let timer = OperationTimer::new("Grouping reads by UMI");
@@ -1801,6 +1885,161 @@ fn with_extension(prefix: &Path, suffix: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The `--no-umi` and identity-implies-zero-edits rules, pinned as a table.
+    ///
+    /// These moved out of `execute` into [`GroupReadsByUmi::resolve_strategy_and_edits`]
+    /// so the command and the chain builder read them from one place; this is
+    /// the regression test for that move. Identity forces zero edits because a
+    /// non-zero edit distance would silently change which reads group together,
+    /// and `--no-umi` forces identity because there is no UMI to compare.
+    #[rstest]
+    #[case::adjacency_passes_through(Strategy::Adjacency, 2, false, Strategy::Adjacency, 2)]
+    #[case::edit_passes_through(Strategy::Edit, 3, false, Strategy::Edit, 3)]
+    #[case::paired_passes_through(Strategy::Paired, 1, false, Strategy::Paired, 1)]
+    #[case::identity_forces_zero_edits(Strategy::Identity, 2, false, Strategy::Identity, 0)]
+    #[case::no_umi_forces_identity_and_zero(Strategy::Adjacency, 2, true, Strategy::Identity, 0)]
+    #[case::no_umi_over_identity(Strategy::Identity, 0, true, Strategy::Identity, 0)]
+    fn resolve_strategy_and_edits_applies_the_no_umi_and_identity_rules(
+        #[case] strategy: Strategy,
+        #[case] edits: u32,
+        #[case] no_umi: bool,
+        #[case] expected_strategy: Strategy,
+        #[case] expected_edits: u32,
+    ) {
+        let mut cmd = GroupReadsByUmi::try_parse_from([
+            "group",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "-s",
+            "adjacency",
+        ])
+        .expect("parses");
+        cmd.strategy = strategy;
+        cmd.edits = edits;
+        cmd.no_umi = no_umi;
+
+        assert_eq!(cmd.resolve_strategy_and_edits(), (expected_strategy, expected_edits));
+    }
+
+    /// `--min-map-q` is optional on the command line but not optional for
+    /// grouping, so the projection applies the same default `execute` does.
+    #[rstest]
+    #[case::absent_defaults_to_one(None, 1)]
+    #[case::zero_is_honored_not_treated_as_absent(Some(0), 0)]
+    #[case::explicit_value(Some(30), 30)]
+    fn resolved_min_map_q_applies_the_default(#[case] flag: Option<u8>, #[case] expected: u8) {
+        let mut cmd = GroupReadsByUmi::try_parse_from([
+            "group",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "-s",
+            "adjacency",
+        ])
+        .expect("parses");
+        cmd.min_map_q = flag;
+
+        assert_eq!(cmd.resolved_min_map_q(), expected);
+    }
+
+    /// Every tuning flag must survive the projection into [`GroupOptions`].
+    ///
+    /// Parsed rather than constructed so a renamed or unwired flag fails here.
+    /// `metrics_prefix` is the one renamed field — it is fed by `--metrics` —
+    /// and `effective_*` are the resolved ones, so both are asserted explicitly.
+    #[test]
+    fn to_group_options_carries_every_tuning_flag() {
+        let cmd = GroupReadsByUmi::try_parse_from([
+            "group",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "-s",
+            "adjacency",
+            "-e",
+            "2",
+            "-m",
+            "30",
+            "--min-umi-length",
+            "8",
+            "--index-threshold",
+            "250",
+            "--family-size-histogram",
+            "fs.txt",
+            "--grouping-metrics",
+            "gm.txt",
+            "--metrics",
+            "prefix",
+            "--include-non-pf-reads=true",
+            "--allow-unmapped=true",
+            "--parallel-group-min-templates",
+            "500",
+        ])
+        .expect("parses");
+
+        let opts = cmd.to_group_options();
+
+        assert_eq!(opts.min_map_q, 30);
+        assert!(opts.include_non_pf_reads);
+        assert!(opts.allow_unmapped);
+        assert_eq!(opts.strategy, Strategy::Adjacency);
+        assert_eq!(opts.edits, 2);
+        assert_eq!(opts.min_umi_length, Some(8));
+        assert_eq!(opts.index_threshold, IndexThreshold::MinUmis(250));
+        assert_eq!(opts.parallel_group_min_templates, Some(ParallelMinTemplates::Fixed(500)));
+        assert!(!opts.no_umi);
+        assert_eq!(opts.family_size_histogram, Some(std::path::PathBuf::from("fs.txt")));
+        assert_eq!(opts.grouping_metrics, Some(std::path::PathBuf::from("gm.txt")));
+        assert_eq!(
+            opts.metrics_prefix,
+            Some(std::path::PathBuf::from("prefix")),
+            "metrics_prefix is fed by --metrics, not by a flag of its own",
+        );
+
+        // Not overridden here, so the resolved pair matches what was requested.
+        assert_eq!(opts.effective_strategy, Strategy::Adjacency);
+        assert_eq!(opts.effective_edits, 2);
+    }
+
+    /// The projection must carry defaults faithfully too — a field hard-coded to
+    /// the value the non-default test happens to pass would slip through it.
+    ///
+    /// `min_map_q` is the interesting one: the CLI holds `Option<u8>` and the
+    /// projection resolves the absent case to 1, so this pins the resolution
+    /// rather than the raw flag.
+    #[test]
+    fn to_group_options_carries_defaults() {
+        let cmd = GroupReadsByUmi::try_parse_from([
+            "group",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "-s",
+            "adjacency",
+        ])
+        .expect("parses");
+
+        let opts = cmd.to_group_options();
+
+        assert_eq!(opts.min_map_q, 1, "an absent --min-map-q resolves to 1");
+        assert!(!opts.include_non_pf_reads);
+        assert!(!opts.allow_unmapped);
+        assert_eq!(opts.edits, 1);
+        assert_eq!(opts.min_umi_length, None);
+        assert_eq!(opts.index_threshold, IndexThreshold::MinUmis(100));
+        assert_eq!(opts.parallel_group_min_templates, None);
+        assert!(!opts.no_umi);
+        assert_eq!(opts.family_size_histogram, None);
+        assert_eq!(opts.grouping_metrics, None);
+        assert_eq!(opts.metrics_prefix, None);
+    }
+
     use crate::assigner::{IdentityUmiAssigner, PairedUmiAssigner, Strategy};
     use crate::metrics::TemplateFilterReason;
     use bstr::BString;

--- a/src/lib/commands/review.rs
+++ b/src/lib/commands/review.rs
@@ -721,7 +721,7 @@ impl Review {
         None
     }
 
-    /// Extracts the leading numeric value from a typed VCF sample [`Value`] (used to
+    /// Extracts the leading numeric value from a typed VCF sample `Value` (used to
     /// read `AF`). Scalars convert directly; arrays take the first present element;
     /// strings parse their first comma-separated token (fgbio does `AF.toDouble`).
     fn value_as_f64(

--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -249,6 +249,86 @@ pub struct Simplex {
     pub reference: Option<std::path::PathBuf>,
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// SimplexOptions — the stage's tuning knobs, projected out of the CLI struct
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Simplex-stage tuning, independent of how the values were supplied.
+///
+/// See [`crate::commands::zipper::ZipperOptions`] for why this is a plain
+/// struct rather than a flattened `clap::Args`. Note that the consensus-calling
+/// knobs are held **flat** here even though [`Simplex`] nests them behind
+/// `#[command(flatten)]` sub-structs: the chain builder wants one bag per stage,
+/// not a re-run of the CLI's grouping.
+#[derive(Debug, Clone)]
+pub struct SimplexOptions {
+    /// Pre-UMI error rate (phred).
+    pub error_rate_pre_umi: u8,
+    /// Post-UMI error rate (phred).
+    pub error_rate_post_umi: u8,
+    /// Minimum input base quality.
+    pub min_input_base_quality: u8,
+    /// Emit per-base consensus tags.
+    pub output_per_base_tags: bool,
+    /// Trim consensus reads.
+    pub trim: bool,
+    /// Minimum consensus base quality.
+    pub min_consensus_base_quality: u8,
+    /// How to resolve a near-tie between the two most likely consensus bases.
+    pub tie_rule: fgumi_consensus::TieRule,
+    /// Call overlapping bases jointly.
+    pub consensus_call_overlapping_bases: bool,
+    /// Minimum reads per consensus.
+    pub min_reads: usize,
+    /// Cap on reads per consensus.
+    pub max_reads: Option<usize>,
+    /// Let fully-unmapped primary templates through the pre-group filter.
+    ///
+    /// Carried as the whole flattened sub-struct, like `io` / `rejects_opts` /
+    /// `read_group`, rather than as a bare `bool`.
+    pub allow_unmapped: AllowUnmappedOptions,
+    /// Input/output paths and reader mode.
+    pub io: BamIoOptions,
+    /// Optional rejects output.
+    pub rejects_opts: RejectsOptions,
+    /// Optional stats output.
+    pub stats_opts: StatsOptions,
+    /// Read-group identity for emitted reads.
+    pub read_group: ReadGroupOptions,
+    /// Resolved methylation calling mode (`Disabled` when the flag is unset).
+    pub methylation_mode: fgumi_consensus::MethylationMode,
+    /// Reference FASTA for methylation-aware modes.
+    pub reference: Option<std::path::PathBuf>,
+}
+
+impl Simplex {
+    /// Project the parsed CLI flags into [`SimplexOptions`].
+    #[must_use]
+    pub fn to_simplex_options(&self) -> SimplexOptions {
+        SimplexOptions {
+            error_rate_pre_umi: self.consensus.error_rate_pre_umi,
+            error_rate_post_umi: self.consensus.error_rate_post_umi,
+            min_input_base_quality: self.consensus.min_input_base_quality,
+            output_per_base_tags: self.consensus.output_per_base_tags,
+            trim: self.consensus.trim,
+            min_consensus_base_quality: self.consensus.min_consensus_base_quality,
+            tie_rule: self.consensus.tie_rule.into(),
+            consensus_call_overlapping_bases: self.overlapping.consensus_call_overlapping_bases,
+            min_reads: self.min_reads,
+            max_reads: self.max_reads,
+            allow_unmapped: self.allow_unmapped.clone(),
+            io: self.io.clone(),
+            rejects_opts: self.rejects_opts.clone(),
+            stats_opts: self.stats_opts.clone(),
+            read_group: self.read_group.clone(),
+            methylation_mode: crate::commands::common::resolve_methylation_mode(
+                self.methylation_mode,
+            ),
+            reference: self.reference.clone(),
+        }
+    }
+}
+
 impl Command for Simplex {
     fn execute(&self, command_line: &str) -> Result<()> {
         // Start timing
@@ -828,6 +908,122 @@ impl Simplex {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every tuning flag must survive the projection into [`SimplexOptions`].
+    ///
+    /// Driven through `try_parse_from` rather than a struct literal: a literal
+    /// would still compile if a flag were renamed or unwired, whereas parsing
+    /// pins the whole path from command line to option struct. Non-default
+    /// values throughout, so a field read from the wrong source fails rather
+    /// than coincidentally matching its default.
+    #[test]
+    fn to_simplex_options_carries_every_tuning_flag() {
+        let cmd = Simplex::try_parse_from([
+            "simplex",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--error-rate-pre-umi",
+            "40",
+            "--error-rate-post-umi",
+            "35",
+            "--min-input-base-quality",
+            "17",
+            "--output-per-base-tags=false",
+            "--trim=true",
+            "--min-consensus-base-quality",
+            "19",
+            "--tie-rule",
+            "ulp-relative",
+            "--consensus-call-overlapping-bases=false",
+            "--min-reads",
+            "3",
+            "--max-reads",
+            "77",
+            "--rejects",
+            "rej.bam",
+            "--stats",
+            "stats.txt",
+            "--read-group-id",
+            "Z",
+            "--read-name-prefix",
+            "pfx",
+            "--methylation-mode",
+            "em-seq",
+            "--ref",
+            "ref.fa",
+            "--allow-unmapped=true",
+        ])
+        .expect("parses");
+
+        let opts = cmd.to_simplex_options();
+
+        assert_eq!(opts.error_rate_pre_umi, 40);
+        assert_eq!(opts.error_rate_post_umi, 35);
+        assert_eq!(opts.min_input_base_quality, 17);
+        assert!(!opts.output_per_base_tags, "an explicit false must not be lost");
+        assert!(opts.trim);
+        assert_eq!(opts.min_consensus_base_quality, 19);
+        assert_eq!(
+            opts.tie_rule,
+            fgumi_consensus::TieRule::UlpRelative,
+            "--tie-rule must reach the projection"
+        );
+        assert!(!opts.consensus_call_overlapping_bases);
+        assert_eq!(opts.min_reads, 3);
+        assert_eq!(opts.max_reads, Some(77));
+        assert!(opts.allow_unmapped.enabled, "--allow-unmapped must reach the projection");
+        assert_eq!(opts.reference, Some(std::path::PathBuf::from("ref.fa")));
+        assert_eq!(
+            opts.methylation_mode,
+            fgumi_consensus::MethylationMode::EmSeq,
+            "--methylation-mode must reach the projection",
+        );
+        // The flattened sub-structs must come across whole, not field by field.
+        assert_eq!(opts.io.input, std::path::PathBuf::from("in.bam"));
+        assert_eq!(opts.io.output, std::path::PathBuf::from("out.bam"));
+        assert_eq!(opts.read_group.read_group_id, "Z");
+        assert_eq!(opts.read_group.read_name_prefix, Some("pfx".to_string()));
+        assert_eq!(opts.rejects_opts.rejects, Some(std::path::PathBuf::from("rej.bam")));
+        assert_eq!(opts.stats_opts.stats, Some(std::path::PathBuf::from("stats.txt")));
+    }
+
+    /// The projection must carry defaults faithfully too — a field hard-coded to
+    /// the value the non-default test happens to pass would slip through it.
+    #[test]
+    fn to_simplex_options_carries_defaults() {
+        let cmd = Simplex::try_parse_from([
+            "simplex",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--min-reads",
+            "1",
+        ])
+        .expect("parses");
+
+        let opts = cmd.to_simplex_options();
+
+        assert_eq!(opts.error_rate_pre_umi, 45);
+        assert_eq!(opts.error_rate_post_umi, 40);
+        assert_eq!(opts.min_input_base_quality, 10);
+        assert!(opts.output_per_base_tags);
+        assert!(!opts.trim);
+        assert_eq!(opts.min_consensus_base_quality, 2);
+        assert_eq!(opts.tie_rule, fgumi_consensus::TieRule::FgbioCompat);
+        assert!(opts.consensus_call_overlapping_bases);
+        assert_eq!(opts.max_reads, None);
+        assert!(!opts.allow_unmapped.enabled);
+        assert_eq!(opts.methylation_mode, fgumi_consensus::MethylationMode::Disabled);
+        assert_eq!(opts.reference, None);
+        assert_eq!(opts.rejects_opts.rejects, None);
+        assert_eq!(opts.stats_opts.stats, None);
+        assert_eq!(opts.read_group.read_group_id, "A");
+        assert_eq!(opts.read_group.read_name_prefix, None);
+    }
+
     use crate::metrics::consensus::ConsensusKvMetric;
     use noodles::sam::alignment::record::data::field::Tag;
     use noodles::sam::alignment::record_buf::RecordBuf;

--- a/src/lib/commands/simulate/common.rs
+++ b/src/lib/commands/simulate/common.rs
@@ -434,7 +434,7 @@ impl ReferenceGenome {
         Some(subseq.to_vec())
     }
 
-    /// Build a BAM [`Header`] with `@SQ` lines for every loaded contig.
+    /// Build a BAM `Header` with `@SQ` lines for every loaded contig.
     pub(super) fn build_bam_header(&self) -> noodles::sam::header::Header {
         use bstr::BString;
         use noodles::sam::header::Header;

--- a/src/lib/commands/zipper.rs
+++ b/src/lib/commands/zipper.rs
@@ -234,6 +234,62 @@ pub struct Zipper {
     pub restore_unconverted_bases: bool,
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// ZipperOptions — the stage's tuning knobs, projected out of the CLI struct
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Zipper-stage tuning, independent of how the values were supplied.
+///
+/// The chain builder needs these knobs without knowing where they came from:
+/// the standalone `fgumi zipper` command fills them from its own flags, and a
+/// fused pipeline fills them from its own. Holding them in a plain struct —
+/// rather than having the builder reach into [`Zipper`] — is what lets a chain
+/// be constructed with no CLI struct behind it at all.
+///
+/// This deliberately does **not** derive `clap::Args`. Flattening it into
+/// [`Zipper`] would move the fields off that struct and rewrite every
+/// `self.<field>` reference in this module and its tests, which buys the chain
+/// builder nothing — it only ever reads the values. That refactor belongs with
+/// the fused command that actually needs prefixed `--zipper::<flag>` flags, so
+/// the CLI surface here is untouched.
+#[derive(Debug, Clone)]
+pub struct ZipperOptions {
+    /// Tags to remove from mapped reads before copying unmapped tags.
+    pub tags_to_remove: Vec<String>,
+    /// Tags to reverse for reads mapped to the negative strand.
+    pub tags_to_reverse: Vec<String>,
+    /// Tags to reverse complement for reads mapped to the negative strand.
+    pub tags_to_revcomp: Vec<String>,
+    /// Buffer size for the template channel.
+    pub buffer: usize,
+    /// Accepted for backward compatibility; has no effect. Carried so the
+    /// projection stays total — see [`Zipper::bwa_chunk_size`].
+    pub bwa_chunk_size: u64,
+    /// Drop unmapped-BAM reads absent from the aligned BAM.
+    pub exclude_missing_reads: bool,
+    /// Skip adding `tc` tags to secondary/supplementary reads.
+    pub skip_tc_tags: bool,
+    /// Restore unconverted bases in EM-seq consensus reads.
+    pub restore_unconverted_bases: bool,
+}
+
+impl Zipper {
+    /// Project the parsed CLI flags into [`ZipperOptions`].
+    #[must_use]
+    pub fn to_zipper_options(&self) -> ZipperOptions {
+        ZipperOptions {
+            tags_to_remove: self.tags_to_remove.clone(),
+            tags_to_reverse: self.tags_to_reverse.clone(),
+            tags_to_revcomp: self.tags_to_revcomp.clone(),
+            buffer: self.buffer,
+            bwa_chunk_size: self.bwa_chunk_size,
+            exclude_missing_reads: self.exclude_missing_reads,
+            skip_tc_tags: self.skip_tc_tags,
+            restore_unconverted_bases: self.restore_unconverted_bases,
+        }
+    }
+}
+
 /// Builds the output BAM header from unmapped and mapped headers
 ///
 /// Merges information from both input headers:
@@ -3926,6 +3982,71 @@ mod tests {
     fn test_skip_tc_tags_parsing(#[case] args: &[&str], #[case] expected: bool) {
         let cmd = Zipper::try_parse_from(args).expect("failed to parse Zipper arguments");
         assert_eq!(cmd.skip_tc_tags, expected);
+    }
+
+    /// Every tuning flag must survive the projection into [`ZipperOptions`].
+    ///
+    /// Driven through `try_parse_from` rather than a struct literal on purpose:
+    /// a struct literal would still compile if a flag were renamed or unwired,
+    /// whereas parsing pins the whole path from command line to option struct.
+    /// Non-default values throughout, so a field copied from the wrong source —
+    /// or left at its default — fails rather than coincidentally matching.
+    #[test]
+    fn to_zipper_options_carries_every_tuning_flag() {
+        let cmd = Zipper::try_parse_from([
+            "zipper",
+            "-u",
+            "u.bam",
+            "-r",
+            "ref.fa",
+            "-o",
+            "out.bam",
+            "--tags-to-remove",
+            "RX,MI",
+            "--tags-to-reverse",
+            "QX",
+            "--tags-to-revcomp",
+            "OX,ZA",
+            "--buffer",
+            "1234",
+            "--bwa-chunk-size",
+            "4242",
+            "--exclude-missing-reads=true",
+            "--skip-tc-tags=true",
+            "--restore-unconverted-bases=true",
+        ])
+        .expect("failed to parse Zipper arguments");
+
+        let opts = cmd.to_zipper_options();
+
+        assert_eq!(opts.tags_to_remove, vec!["RX".to_string(), "MI".to_string()]);
+        assert_eq!(opts.tags_to_reverse, vec!["QX".to_string()]);
+        assert_eq!(opts.tags_to_revcomp, vec!["OX".to_string(), "ZA".to_string()]);
+        assert_eq!(opts.buffer, 1234);
+        assert_eq!(opts.bwa_chunk_size, 4242);
+        assert!(opts.exclude_missing_reads);
+        assert!(opts.skip_tc_tags);
+        assert!(opts.restore_unconverted_bases);
+    }
+
+    /// The projection must also carry defaults faithfully — a field hard-coded
+    /// to `true`/`0` would pass the all-non-default test above.
+    #[test]
+    fn to_zipper_options_carries_defaults() {
+        let cmd =
+            Zipper::try_parse_from(["zipper", "-u", "u.bam", "-r", "ref.fa", "-o", "out.bam"])
+                .expect("failed to parse Zipper arguments");
+
+        let opts = cmd.to_zipper_options();
+
+        assert!(opts.tags_to_remove.is_empty());
+        assert!(opts.tags_to_reverse.is_empty());
+        assert!(opts.tags_to_revcomp.is_empty());
+        assert_eq!(opts.buffer, 50_000);
+        assert_eq!(opts.bwa_chunk_size, 150_000_000);
+        assert!(!opts.exclude_missing_reads);
+        assert!(!opts.skip_tc_tags);
+        assert!(!opts.restore_unconverted_bases);
     }
 
     /// The rendered long help for `--skip-tc-tags`.

--- a/src/lib/fastq_parse.rs
+++ b/src/lib/fastq_parse.rs
@@ -171,6 +171,15 @@ impl MemoryEstimate for FastqRecord {
     }
 }
 
+/// The typed-step pipeline byte-bounds its queues on this. Delegates to
+/// [`MemoryEstimate::estimate_heap_size`] so the queue budget and the memory
+/// estimate are a single source of truth.
+impl crate::pipeline::core::item::HeapSize for FastqRecord {
+    fn heap_size(&self) -> usize {
+        MemoryEstimate::estimate_heap_size(self)
+    }
+}
+
 /// Result of parsing a FASTQ record.
 #[derive(Debug)]
 enum FastqParseResult {

--- a/src/lib/grouper.rs
+++ b/src/lib/grouper.rs
@@ -223,7 +223,7 @@ impl Grouper for TemplateGrouper {
         // records into the same template.
         for decoded in records {
             let name_hash = decoded.key.name_hash;
-            let raw = decoded.data;
+            let raw = decoded.into_raw_bytes();
             let read_name = fgumi_raw_bam::read_name(&raw);
             let same_template = match (self.current_name_hash, self.current_name.as_deref()) {
                 (Some(h), Some(name)) => h == name_hash && name == read_name,
@@ -430,7 +430,7 @@ impl RecordPositionGrouper {
     fn validate_mc_tag(decoded: &DecodedRecord) -> io::Result<()> {
         use fgumi_raw_bam::RawRecordView;
 
-        let raw = &decoded.data;
+        let raw = decoded.record();
         let flg = RawRecordView::new(raw).flags();
         let is_paired = (flg & fgumi_raw_bam::flags::PAIRED) != 0;
         let is_secondary = (flg & fgumi_raw_bam::flags::SECONDARY) != 0;
@@ -489,8 +489,8 @@ impl RecordPositionGrouper {
                     // Hash match is a fast pre-check; confirm QNAME bytes to guard
                     // against hash collisions merging unrelated templates.
                     last.key.name_hash == decoded.key.name_hash
-                        && fgumi_raw_bam::read_name(&last.data)
-                            == fgumi_raw_bam::read_name(&decoded.data)
+                        && fgumi_raw_bam::read_name(last.raw_bytes())
+                            == fgumi_raw_bam::read_name(decoded.raw_bytes())
                 }) =>
             {
                 // Different position but same template (name_hash + QNAME match with
@@ -601,7 +601,7 @@ fn group_by_name_and_build<T>(
         // borrow (and only copy it out when a new group starts) so records within
         // a group don't each allocate a QNAME `Vec` — the borrow must end before
         // `extract` consumes `decoded`.
-        let read_name = fgumi_raw_bam::read_name(&decoded.data);
+        let read_name = fgumi_raw_bam::read_name(decoded.raw_bytes());
         let same =
             current_name_hash == Some(name_hash) && current_name.as_deref() == Some(read_name);
         let new_name = if same { None } else { Some(read_name.to_vec()) };
@@ -666,6 +666,15 @@ impl MemoryEstimate for FastqTemplate {
         let records_heap: usize = self.records.iter().map(MemoryEstimate::estimate_heap_size).sum();
         let records_vec_overhead = self.records.capacity() * std::mem::size_of::<FastqRecord>();
         self.name.capacity() + records_heap + records_vec_overhead
+    }
+}
+
+/// The typed-step pipeline byte-bounds its queues on this. Delegates to
+/// [`MemoryEstimate::estimate_heap_size`] so the queue budget and the memory
+/// estimate are a single source of truth.
+impl crate::pipeline::core::item::HeapSize for FastqTemplate {
+    fn heap_size(&self) -> usize {
+        MemoryEstimate::estimate_heap_size(self)
     }
 }
 
@@ -1552,8 +1561,11 @@ mod tests {
             .finish()
             .expect("finish must succeed with a group key set")
             .expect("the buffered position must be emitted");
-        let names: Vec<Vec<u8>> =
-            group.records.iter().map(|r| fgumi_raw_bam::read_name(&r.data).to_vec()).collect();
+        let names: Vec<Vec<u8>> = group
+            .records
+            .iter()
+            .map(|r| fgumi_raw_bam::read_name(r.raw_bytes()).to_vec())
+            .collect();
         assert_eq!(
             names,
             vec![b"readA".to_vec(), b"readB".to_vec(), b"readC".to_vec()],

--- a/src/lib/mi_group.rs
+++ b/src/lib/mi_group.rs
@@ -107,6 +107,111 @@ type MiTransformFn = Box<dyn Fn(&[u8]) -> String + Send + Sync>;
 /// Type alias for raw-byte record filter function.
 type RecordFilterFn = Box<dyn Fn(&[u8]) -> bool + Send + Sync>;
 
+/// Borrowed MI tag transformation, shared by `MiGrouper` and `MiGroupIterator`
+/// (whose stored transforms differ only in `Send + Sync` bounds).
+pub(crate) type MiTransform<'a> = Option<&'a dyn Fn(&[u8]) -> String>;
+
+/// The grouping key for a run of consecutive records, stored as the raw
+/// comparison bytes so that boundary detection stays allocation-free on the
+/// common (no-transform) path: a record is compared against the current
+/// group by byte-equality of its tag value(s) rather than by building an
+/// owned `String` per record. The display label handed to `MiGroup` / the
+/// iterator output is materialized from these bytes only once per group.
+pub(crate) struct MiKey {
+    /// MI tag bytes, already transformed if a transform is configured.
+    mi: Vec<u8>,
+    /// Cell tag bytes, present (`Some`) only when cell-barcode grouping is
+    /// enabled. `Some(empty)` when the tag is configured but absent on the
+    /// record, mirroring the legacy `"MI\t"` composite key.
+    cell: Option<Vec<u8>>,
+}
+
+impl MiKey {
+    /// Locate the MI (and, when cell grouping is enabled, the cell) tag value(s)
+    /// for a record. When a cell tag is configured both are found in a **single**
+    /// aux-data walk; otherwise only the MI tag is looked up. Returns `None` when
+    /// the record has no MI tag (the record is then skipped). The boolean tracks
+    /// whether cell grouping is enabled so callers can distinguish a configured
+    /// cell tag that is absent on the record (`Some(b"")`) from no cell tag at all.
+    #[inline]
+    fn locate_values(
+        bam: &[u8],
+        tag: [u8; 2],
+        cell_tag: Option<[u8; 2]>,
+    ) -> Option<(&[u8], Option<&[u8]>)> {
+        match cell_tag {
+            Some(ct) => {
+                // Single aux-block walk for both the MI and the cell tag.
+                let (mi, cell) = fgumi_raw_bam::find_two_string_tags_in_record(bam, tag, ct);
+                Some((mi?, Some(cell.unwrap_or(b""))))
+            }
+            None => Some((fgumi_raw_bam::find_string_tag_in_record(bam, tag)?, None)),
+        }
+    }
+
+    /// Extract the grouping key from raw BAM bytes, allocating the owned key
+    /// bytes. Used when a new group begins. Returns `None` when the record has
+    /// no MI tag (the record is then skipped).
+    pub(crate) fn from_record(
+        bam: &[u8],
+        tag: [u8; 2],
+        cell_tag: Option<[u8; 2]>,
+        transform: MiTransform,
+    ) -> Option<Self> {
+        let (value, cell_value) = Self::locate_values(bam, tag, cell_tag)?;
+        let mi = match transform {
+            Some(transform) => transform(value).into_bytes(),
+            None => value.to_vec(),
+        };
+        let cell = cell_value.map(<[u8]>::to_vec);
+        Some(Self { mi, cell })
+    }
+
+    /// Test whether `bam` belongs to the same MI group as this key. Returns
+    /// `None` when the record has no MI tag (the record is then skipped).
+    /// Allocation-free on the no-transform path: the record's tag bytes are
+    /// compared against the stored key directly instead of building an owned key.
+    pub(crate) fn matches_record(
+        &self,
+        bam: &[u8],
+        tag: [u8; 2],
+        cell_tag: Option<[u8; 2]>,
+        transform: MiTransform,
+    ) -> Option<bool> {
+        let (value, cell_value) = Self::locate_values(bam, tag, cell_tag)?;
+        let mi_eq = match transform {
+            Some(transform) => transform(value).as_bytes() == self.mi.as_slice(),
+            None => value == self.mi.as_slice(),
+        };
+        let cell_eq = match (cell_value, &self.cell) {
+            (Some(have), Some(want)) => have == want.as_slice(),
+            // `cell_tag` is fixed for a grouper's lifetime, so the stored key's
+            // cell presence always matches the configuration; the mixed arms are
+            // unreachable.
+            (None, None) => true,
+            (Some(_), None) | (None, Some(_)) => {
+                debug_assert!(
+                    false,
+                    "cell-tag presence is fixed for the grouper's lifetime, so the stored key's \
+                     cell presence always matches the record's; this mixed arm is unreachable"
+                );
+                false
+            }
+        };
+        Some(mi_eq && cell_eq)
+    }
+
+    /// Build the display label. With a cell tag this is `"MI\tCELL"`,
+    /// matching the legacy composite key; otherwise it is just the MI value.
+    pub(crate) fn label(&self) -> String {
+        let mi = String::from_utf8_lossy(&self.mi);
+        match &self.cell {
+            Some(cell) => format!("{mi}\t{}", String::from_utf8_lossy(cell)),
+            None => mi.into_owned(),
+        }
+    }
+}
+
 /// A Grouper that groups raw-byte BAM records by MI tag.
 ///
 /// Records arrive as raw BAM bytes (see [`DecodedRecord::from_raw_bytes`]). MI tags are

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -142,6 +142,7 @@ pub mod logging;
 pub mod metrics;
 pub mod mi_group;
 pub mod per_thread_accumulator;
+pub mod pipeline;
 pub use fgumi_consensus::phred;
 pub mod read_info;
 pub mod read_structure;

--- a/src/lib/pipeline/mod.rs
+++ b/src/lib/pipeline/mod.rs
@@ -1,0 +1,27 @@
+//! The typed-step pipeline framework for `--threads N` mode.
+//!
+//! A pipeline is a chain of [`core::step::Step`]s, each declaring a
+//! [`core::step::StepKind`] (`Serial` / `Parallel` / `Exclusive`); the engine
+//! runs all `N` worker threads through a round-robin dispatch loop with
+//! `Affinity`-based pinning for I/O sources/sinks. This keeps `--threads N` a
+//! strict thread cap with no separate I/O thread pools.
+//!
+//! # Module structure
+//!
+//! - [`core`]: typed-step execution engine (worker loop, queues, drain
+//!   protocol, reorder buffers).
+//! - [`steps`]: the concrete `Step` implementations (decompress, boundaries,
+//!   parse, serialize, compress, write, …).
+//!
+//! A `chains` module (declarative chain construction — `build_for`,
+//! `ChainBuilder`, per-command step factories) lands in a follow-up; until it
+//! does, nothing in `src/lib/commands` routes through this tree and every
+//! command still runs on `unified_pipeline`.
+
+/// The typed-step execution engine, extracted into the `fgumi-pipeline-core`
+/// crate so its lightweight dependency graph (no `noodles`-bam / sort /
+/// consensus) compiles fast in isolation. Re-exported here so every
+/// `crate::pipeline::core::…` path resolves — which is what lets the ported
+/// step sources compile unmodified.
+pub use fgumi_pipeline_core as core;
+pub mod steps;

--- a/src/lib/pipeline/steps/bgzf/compress.rs
+++ b/src/lib/pipeline/steps/bgzf/compress.rs
@@ -1,0 +1,313 @@
+//! `BgzfCompress` mid-step. `Parallel + ByItemOrdinal`. Compresses each
+//! `DecompressedBlock` into one logical `BgzfBlock` whose `bytes` field
+//! contains the concatenation of however many physical 64-KiB BGZF blocks
+//! `libdeflater` produces internally.
+//!
+//! ## 1:1 input-to-output mapping (Phase 3 design)
+//!
+//! Each `try_run` consumes exactly one input and emits exactly one output
+//! with `batch_serial = input.batch_serial`. This preserves the
+//! consecutive-ordinal invariant required by the downstream
+//! `ReorderStage` without any sub-serial encoding.
+//!
+//! Internally, `InlineBgzfCompressor` may produce multiple physical BGZF
+//! blocks when the input exceeds `BGZF_MAX_BLOCK_SIZE = 64 KiB`. We
+//! concatenate those physical blocks into a single `BgzfBlock`'s bytes —
+//! a valid BGZF stream is just a concatenation of independent blocks, so
+//! the downstream writer can emit them verbatim.
+
+use std::io;
+
+use fgumi_bgzf::InlineBgzfCompressor;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::{BgzfBlock, DecompressedBlock};
+
+/// Per-worker BGZF compressed-output scratch capacity. The compressed
+/// output of `BgzfCompress` is the concatenation of physical 64 KiB BGZF
+/// blocks; a single batch typically produces 1-4 such blocks. Sized to
+/// the typical case so the same mimalloc size class is hit every call.
+/// Matches legacy `bam.rs:1561` `SERIALIZATION_BUFFER_CAPACITY` × 4.
+const COMPRESS_SCRATCH_CAPACITY: usize = 256 * 1024;
+
+/// `Parallel + ByItemOrdinal` BGZF compressor.
+pub struct BgzfCompress {
+    /// Per-worker compressor (each worker holds its own clone).
+    compressor: InlineBgzfCompressor,
+    compression_level: u32,
+    /// Per-worker output scratch buffer; `mem::replace`d on each emit so
+    /// the freshly-allocated replacement is always the same size class.
+    /// See `BgzfDecompress::output_scratch` for rationale.
+    output_scratch: Vec<u8>,
+    held: HeldSlot<Unpushed<BgzfBlock>>,
+    output_byte_limit: u64,
+}
+
+impl BgzfCompress {
+    #[must_use]
+    pub fn new(compression_level: u32, output_byte_limit: u64) -> Self {
+        Self {
+            compressor: InlineBgzfCompressor::new(compression_level),
+            compression_level,
+            output_scratch: Vec::with_capacity(COMPRESS_SCRATCH_CAPACITY),
+            held: HeldSlot::new(),
+            output_byte_limit,
+        }
+    }
+}
+
+impl Clone for BgzfCompress {
+    fn clone(&self) -> Self {
+        Self {
+            compressor: InlineBgzfCompressor::new(self.compression_level),
+            compression_level: self.compression_level,
+            output_scratch: Vec::with_capacity(COMPRESS_SCRATCH_CAPACITY),
+            held: HeldSlot::new(),
+            output_byte_limit: self.output_byte_limit,
+        }
+    }
+}
+
+impl BgzfCompress {
+    /// Drain the compressor's physical BGZF blocks and assemble the single
+    /// output `BgzfBlock` byte buffer.
+    ///
+    /// INVARIANT: each block's `serial` is `InlineBgzfCompressor`'s monotonic
+    /// per-worker counter; it has no relation to the pipeline-wide
+    /// `batch_serial`. We deliberately drop it (read only `child.data`) and
+    /// inherit the parent's `batch_serial` for the emitted `BgzfBlock`. Future
+    /// code must NOT propagate `child.serial` into the framework's ordinal stream.
+    ///
+    /// The output is the concatenation of the physical block bytes (a valid BGZF
+    /// stream is just independent blocks back to back). When there is exactly one
+    /// physical block — the common case, since a batch usually fits in one 64 KiB
+    /// block — its buffer is moved out directly (no scratch allocation and no
+    /// concatenating memcpy); this is byte-identical to concatenating a single
+    /// block. For the multi-block case the bytes are concatenated into the
+    /// per-worker scratch (then `mem::replace`d out so the replacement stays in a
+    /// fixed mimalloc size class), and each drained child buffer is handed back to
+    /// the compressor's pool so the next compression reuses it.
+    fn assemble_output_bytes(&mut self) -> Vec<u8> {
+        let mut children = self.compressor.take_blocks();
+        match children.len() {
+            // No physical blocks — reachable from the all-clean rejects path,
+            // where an empty `DecompressedBlock` produces no BGZF output. Return
+            // an empty `Vec` rather than `mem::replace`-ing out the scratch:
+            // after a prior multi-block batch the scratch retains a
+            // `COMPRESS_SCRATCH_CAPACITY` allocation, and handing that out as an
+            // "empty" output would inflate queue memory/backpressure on the
+            // ordinal-preserving fast path.
+            0 => Vec::new(),
+            1 => children.pop().expect("len == 1").data,
+            _ => {
+                for child in children {
+                    self.output_scratch.extend_from_slice(&child.data);
+                    self.compressor.recycle_buffer(child.data);
+                }
+                std::mem::replace(
+                    &mut self.output_scratch,
+                    Vec::with_capacity(COMPRESS_SCRATCH_CAPACITY),
+                )
+            }
+        }
+    }
+}
+
+impl Step for BgzfCompress {
+    type Input = DecompressedBlock;
+    type Outputs = OrderedBytesSingle<BgzfBlock>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "BgzfCompress",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(parent) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let DecompressedBlock { batch_serial, bytes } = parent;
+        let uncompressed_size = u32::try_from(bytes.len()).unwrap_or(u32::MAX);
+
+        // Compress and harvest physical BGZF blocks.
+        self.compressor.write_all(&bytes)?;
+        self.compressor.flush()?;
+        let bytes = self.assemble_output_bytes();
+
+        let out = BgzfBlock { batch_serial, bytes, uncompressed_size };
+        match ctx.outputs.push(out) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_advertises_parallel_byordinal() {
+        let s = BgzfCompress::new(1, 1024);
+        let p = s.profile();
+        assert_eq!(p.name, "BgzfCompress");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    #[test]
+    fn clone_constructs_fresh_compressor() {
+        let s = BgzfCompress::new(1, 1024);
+        let _cloned = s.clone();
+    }
+
+    #[test]
+    fn small_input_produces_single_concatenated_output() {
+        let mut s = BgzfCompress::new(1, 1024);
+        s.compressor.write_all(b"hello bgzf").unwrap();
+        s.compressor.flush().unwrap();
+        let blocks = s.compressor.take_blocks();
+        assert!(!blocks.is_empty(), "expected at least one BGZF block");
+        // Each block is a valid BGZF block (starts with gzip magic 0x1f 0x8b).
+        for b in &blocks {
+            assert_eq!(&b.data[..2], &[0x1f, 0x8b], "BGZF magic");
+        }
+    }
+
+    /// Reference assembly: the straightforward concatenation the move/recycle
+    /// fast path must reproduce byte-for-byte.
+    fn reference_concat(level: u32, input: &[u8]) -> Vec<u8> {
+        let mut c = InlineBgzfCompressor::new(level);
+        c.write_all(input).unwrap();
+        c.flush().unwrap();
+        let mut out = Vec::new();
+        for block in c.take_blocks() {
+            out.extend_from_slice(&block.data);
+        }
+        out
+    }
+
+    /// Drive `assemble_output_bytes` on a fresh step over `input`.
+    fn assemble(level: u32, input: &[u8]) -> Vec<u8> {
+        let mut s = BgzfCompress::new(level, 1024);
+        s.compressor.write_all(input).unwrap();
+        s.compressor.flush().unwrap();
+        s.assemble_output_bytes()
+    }
+
+    #[test]
+    fn single_block_fast_path_is_byte_identical() {
+        // Small input → one physical block → move fast path.
+        let input = b"the quick brown fox jumps over the lazy dog";
+        let mut s = BgzfCompress::new(1, 1024);
+        s.compressor.write_all(input).unwrap();
+        s.compressor.flush().unwrap();
+        assert_eq!(s.compressor.take_blocks().len(), 1, "input should fit one block");
+
+        let assembled = assemble(1, input);
+        assert_eq!(assembled, reference_concat(1, input));
+        assert_eq!(&assembled[..2], &[0x1f, 0x8b], "valid BGZF magic");
+    }
+
+    #[test]
+    fn multi_block_concat_path_is_byte_identical() {
+        // Input larger than one 64 KiB block forces the multi-block concat +
+        // recycle path; output must still match the plain concatenation.
+        let mut input = Vec::with_capacity(200 * 1024);
+        for i in 0..(200 * 1024u32) {
+            input.push((i % 251) as u8);
+        }
+        let mut s = BgzfCompress::new(1, 1024);
+        s.compressor.write_all(&input).unwrap();
+        s.compressor.flush().unwrap();
+        assert!(s.compressor.take_blocks().len() > 1, "input should span >1 block");
+
+        let assembled = assemble(1, &input);
+        assert_eq!(assembled, reference_concat(1, &input));
+    }
+
+    #[test]
+    fn recycle_buffer_repopulates_pool_for_reuse() {
+        // After the multi-block path recycles buffers, a subsequent compression
+        // reuses them, and output remains byte-identical to a fresh compressor.
+        let big: Vec<u8> = (0..(200 * 1024u32)).map(|i| (i % 251) as u8).collect();
+        let mut s = BgzfCompress::new(1, 1024);
+
+        s.compressor.write_all(&big).unwrap();
+        s.compressor.flush().unwrap();
+        let first = s.assemble_output_bytes();
+        assert_eq!(first, reference_concat(1, &big));
+
+        // Second block through the same (now pool-primed) compressor.
+        s.compressor.write_all(&big).unwrap();
+        s.compressor.flush().unwrap();
+        let second = s.assemble_output_bytes();
+        assert_eq!(second, reference_concat(1, &big), "recycled buffers must not corrupt output");
+    }
+
+    #[test]
+    fn empty_batch_returns_unallocated_vec() {
+        // An all-clean rejects batch produces no physical BGZF blocks. The
+        // assembled output must be a truly empty `Vec`, not the per-worker
+        // scratch — otherwise an "empty" output carries a retained
+        // `COMPRESS_SCRATCH_CAPACITY` allocation and inflates queue memory.
+        let mut s = BgzfCompress::new(1, 1024);
+
+        // Fresh compressor, nothing written → no blocks.
+        let fresh = s.assemble_output_bytes();
+        assert!(fresh.is_empty());
+        assert_eq!(fresh.capacity(), 0, "empty output must not carry a scratch allocation");
+
+        // After a real multi-block batch (which routes through the scratch and
+        // replaces it with a `COMPRESS_SCRATCH_CAPACITY` Vec), a following empty
+        // batch must still return an unallocated Vec.
+        let big: Vec<u8> = (0..(200 * 1024u32)).map(|i| (i % 251) as u8).collect();
+        s.compressor.write_all(&big).unwrap();
+        s.compressor.flush().unwrap();
+        let multi = s.assemble_output_bytes();
+        assert!(!multi.is_empty(), "multi-block batch should produce output");
+
+        let after = s.assemble_output_bytes(); // no new input → empty batch
+        assert!(after.is_empty());
+        assert_eq!(
+            after.capacity(),
+            0,
+            "empty batch after a multi-block batch must not retain scratch"
+        );
+    }
+}

--- a/src/lib/pipeline/steps/bgzf/decompress.rs
+++ b/src/lib/pipeline/steps/bgzf/decompress.rs
@@ -1,0 +1,159 @@
+//! `BgzfDecompress` mid-step. `Parallel + ByItemOrdinal`. Decompresses
+//! incoming `BgzfBlock`s into `DecompressedBlock`s using `libdeflater`'s
+//! decompressor (one per worker via `Clone`).
+
+use std::io;
+
+use fgumi_bgzf::reader::decompress_block_slice_into;
+use libdeflater::Decompressor;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::{BgzfBlock, DecompressedBlock};
+
+/// Per-worker decompression scratch capacity. Sized to the upper end
+/// of typical BGZF block decompressed sizes (256 KiB ≈ 4 blocks × 64 KiB).
+/// Mirrors legacy `pipeline/bam.rs:1560` `DECOMPRESSION_BUFFER_CAPACITY`.
+///
+/// Why a fixed size: when each `try_run` calls `Vec::with_capacity(N)` with
+/// a *variable* `N` (= `block.uncompressed_size`), every allocation hits a
+/// different mimalloc size class and defeats the thread-local cache. A
+/// fixed capacity always pulls from the same size class so the freed
+/// buffer that just left for downstream gets reused on the next call.
+const DECOMPRESS_SCRATCH_CAPACITY: usize = 256 * 1024;
+
+/// `Parallel + ByItemOrdinal` decompressor. Each worker holds its own
+/// `libdeflater::Decompressor` (`Clone` constructs a fresh one) and a
+/// fixed-capacity output scratch buffer that's emitted via `mem::replace`
+/// to avoid variable-size allocations on the hot path.
+pub struct BgzfDecompress {
+    decompressor: Decompressor,
+    /// Per-worker output scratch. `try_run` decompresses into this
+    /// buffer, then swaps it out with a fresh fixed-capacity Vec via
+    /// `mem::replace`. Keeps allocations on a single mimalloc size
+    /// class so the thread-local cache can recycle them. Mirrors legacy
+    /// `WorkerState::decompression_buffer`.
+    output_scratch: Vec<u8>,
+    held: HeldSlot<Unpushed<DecompressedBlock>>,
+    output_byte_limit: u64,
+}
+
+impl BgzfDecompress {
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self {
+            decompressor: Decompressor::new(),
+            output_scratch: Vec::with_capacity(DECOMPRESS_SCRATCH_CAPACITY),
+            held: HeldSlot::new(),
+            output_byte_limit,
+        }
+    }
+}
+
+impl Clone for BgzfDecompress {
+    fn clone(&self) -> Self {
+        Self {
+            decompressor: Decompressor::new(),
+            output_scratch: Vec::with_capacity(DECOMPRESS_SCRATCH_CAPACITY),
+            held: HeldSlot::new(),
+            output_byte_limit: self.output_byte_limit,
+        }
+    }
+}
+
+impl Step for BgzfDecompress {
+    type Input = BgzfBlock;
+    type Outputs = OrderedBytesSingle<DecompressedBlock>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "BgzfDecompress",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    // `Contention` (not `NoProgress`) keeps the worker
+                    // alive for retry — `NoProgress` would let the
+                    // framework mark this worker `Skip` if input is also
+                    // drained, silently dropping the held item.
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(block) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+
+        // Decompress into the per-worker scratch buffer. After the
+        // decompressor fills it, `mem::replace` swaps it out (the filled
+        // buffer goes into the emitted block; a fresh fixed-capacity
+        // buffer takes its place). Single mimalloc size class keeps the
+        // thread-local cache hot.
+        decompress_block_slice_into(
+            &block.bytes,
+            &mut self.decompressor,
+            &mut self.output_scratch,
+        )?;
+        let bytes = std::mem::replace(
+            &mut self.output_scratch,
+            Vec::with_capacity(DECOMPRESS_SCRATCH_CAPACITY),
+        );
+
+        let decompressed = DecompressedBlock { batch_serial: block.batch_serial, bytes };
+
+        match ctx.outputs.push(decompressed) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_advertises_parallel_byordinal() {
+        let s = BgzfDecompress::new(1024);
+        let p = s.profile();
+        assert_eq!(p.name, "BgzfDecompress");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    #[test]
+    fn clone_constructs_fresh_decompressor() {
+        let s = BgzfDecompress::new(1024);
+        let _cloned = s.clone();
+    }
+}

--- a/src/lib/pipeline/steps/bgzf/mod.rs
+++ b/src/lib/pipeline/steps/bgzf/mod.rs
@@ -1,0 +1,4 @@
+//! BGZF compress/decompress steps.
+
+pub mod compress;
+pub mod decompress;

--- a/src/lib/pipeline/steps/boundaries/bam.rs
+++ b/src/lib/pipeline/steps/boundaries/bam.rs
@@ -1,0 +1,177 @@
+//! `FindBamBoundaries` mid-step. `Serial + ByItemOrdinal`. Strips the BAM
+//! header (on first input) and finds record boundaries within decompressed
+//! BGZF block data, emitting `DecompressedBlock`s whose bytes contain only
+//! complete records (4-byte `block_size` prefix + record body, repeated).
+//!
+//! Wraps [`super::state::BoundaryState`] — the boundary-finding state
+//! machine handles header skipping, cross-block record carryover, and
+//! validation. Reusing it ensures the new framework's boundary semantics
+//! match the legacy pipeline's exactly.
+
+use std::io;
+
+use super::state::BoundaryState;
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::DecompressedBlock;
+
+/// Max inputs processed per `try_run` invocation. Amortizes the Serial
+/// mutex acquisition; matches legacy `bam.rs:2050+` (`MAX_BATCHES_PER_LOCK`).
+const MAX_BATCHES_PER_LOCK: usize = 8;
+
+/// `Serial + ByItemOrdinal` boundary finder. Holds `BoundaryState` (which
+/// owns the cross-block carryover buffer + header-skip flag).
+pub struct FindBamBoundaries {
+    state: BoundaryState,
+    /// Pending output batch when we found boundaries but the push was
+    /// rejected. Held across retries until pushed.
+    held: HeldSlot<Unpushed<DecompressedBlock>>,
+    /// Self-managed output ordinal. Incremented only when a new
+    /// `DecompressedBlock` is emitted. Using the input's `batch_serial`
+    /// directly would skip ordinals when the boundary state absorbs an
+    /// input without producing output (header bytes, mid-record carryover);
+    /// the downstream `ReorderStage` requires consecutive `0, 1, 2, …`.
+    next_output_serial: u64,
+    /// Set once the final-flush path has called the (non-idempotent)
+    /// `state.finish()`; guards against a second call across the multi-pass
+    /// completion drain.
+    finalized: bool,
+    output_byte_limit: u64,
+}
+
+impl FindBamBoundaries {
+    /// Construct expecting the first input batch to begin with the BAM
+    /// header (matches `BAM_MAGIC`). The header bytes are skipped on the
+    /// first call; subsequent calls just find record boundaries.
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self {
+            state: BoundaryState::new(),
+            held: HeldSlot::new(),
+            next_output_serial: 0,
+            finalized: false,
+            output_byte_limit,
+        }
+    }
+
+    /// Construct expecting the input stream to be already past the BAM
+    /// header. Useful for runall-spliced sub-pipelines.
+    #[must_use]
+    pub fn new_no_header(output_byte_limit: u64) -> Self {
+        Self {
+            state: BoundaryState::new_no_header(),
+            held: HeldSlot::new(),
+            next_output_serial: 0,
+            finalized: false,
+            output_byte_limit,
+        }
+    }
+}
+
+impl Step for FindBamBoundaries {
+    type Input = DecompressedBlock;
+    type Outputs = OrderedBytesSingle<DecompressedBlock>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "FindBamBoundaries",
+            kind: StepKind::Serial,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        // Process up to `MAX_BATCHES_PER_LOCK` inputs per `try_run` to
+        // amortize the Serial mutex acquisition. Each iteration pops one
+        // input, runs find_boundaries, and pushes at most one output —
+        // header-only or carryover-only inputs are fully absorbed and produce
+        // no output (the loop `continue`s, and `did_work` still records the
+        // consumed input as Progress). We stop early on push rejection (held
+        // the unpushed; subsequent iterations would contend on backpressure)
+        // or on input exhaustion.
+        let mut did_work = false;
+        for _ in 0..MAX_BATCHES_PER_LOCK {
+            let Some(block) = ctx.input.pop() else { break };
+            did_work = true;
+
+            let boundary_batch = self.state.find_boundaries(&block.bytes)?;
+            if boundary_batch.buffer.is_empty() {
+                // Input fully absorbed (header/leftover); try next input.
+                continue;
+            }
+
+            let serial = self.next_output_serial;
+            self.next_output_serial += 1;
+            let out = DecompressedBlock { batch_serial: serial, bytes: boundary_batch.buffer };
+            match ctx.outputs.push(out) {
+                Ok(()) => {}
+                Err(unpushed) => {
+                    self.held.put(unpushed);
+                    // Hold off on more inputs — the held item must clear
+                    // before we accept new work.
+                    return Ok(StepOutcome::Progress);
+                }
+            }
+        }
+
+        if did_work {
+            return Ok(StepOutcome::Progress);
+        }
+
+        // No input this call. If upstream is drained, flush the boundary
+        // state's final partial-record buffer once (guarded by `finalized` —
+        // `state.finish()` is not idempotent), emit it, and report `Finished`
+        // once nothing remains. `held` is empty here (step 1 returned
+        // `Contention` otherwise); a bounced final push is parked in `held`
+        // for the held-drain at the top of the next pass.
+        if ctx.input.is_drained() {
+            if !self.finalized {
+                self.finalized = true;
+                if let Some(boundary_batch) = self.state.finish()?
+                    && !boundary_batch.buffer.is_empty()
+                {
+                    let serial = self.next_output_serial;
+                    self.next_output_serial += 1;
+                    let out =
+                        DecompressedBlock { batch_serial: serial, bytes: boundary_batch.buffer };
+                    if let Err(unpushed) = ctx.outputs.push(out) {
+                        self.held.put(unpushed);
+                    }
+                    return Ok(StepOutcome::Progress);
+                }
+            }
+            return Ok(StepOutcome::Finished);
+        }
+        Ok(StepOutcome::NoProgress)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_advertises_serial_byordinal() {
+        let s = FindBamBoundaries::new(1024);
+        let p = s.profile();
+        assert_eq!(p.name, "FindBamBoundaries");
+        assert_eq!(p.kind, StepKind::Serial);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+}

--- a/src/lib/pipeline/steps/boundaries/mod.rs
+++ b/src/lib/pipeline/steps/boundaries/mod.rs
@@ -1,0 +1,4 @@
+//! Per-format boundary-finding steps.
+
+pub mod bam;
+pub mod state;

--- a/src/lib/pipeline/steps/boundaries/state.rs
+++ b/src/lib/pipeline/steps/boundaries/state.rs
@@ -1,0 +1,876 @@
+//! `BoundaryState` / `BoundaryBatch`: the BAM record-boundary state machine.
+//!
+//! Scans decompressed BGZF block data for BAM record boundaries (header skip,
+//! cross-block record carryover, EOF validation) without decoding records.
+//! Driven by the `FindBamBoundaries` step (`super::bam`).
+//!
+//! Relocated from the legacy `bam.rs` (deleted in the issue #330 migration);
+//! the boundary-finding logic is reused verbatim so the new framework's
+//! boundary semantics match the legacy pipeline's exactly.
+
+use std::io;
+
+/// Upper bound on bytes the scanner will carry forward waiting for one record
+/// (or the BAM header) to complete.
+///
+/// This is a **corruption backstop, not a biological limit**. The scanner is a
+/// push scanner: it is handed decompressed blocks and cannot ask for "the rest
+/// of this record" the way a pull reader (htslib's `bam_read1`) can, so a
+/// corrupt length field makes every block look like "not enough data yet" and
+/// the carry grows for the rest of the stream. That still terminates —
+/// [`BoundaryState::finish`] reports the shortfall at EOF — but only after
+/// buffering the remaining input, so a large corrupt file exhausts memory
+/// before it can print the diagnostic it was about to print.
+///
+/// The value sits in the gap between what BAM permits and what BAM files
+/// contain. `block_size` is a `u32`, so the format allows a ~4 GiB record, while
+/// the largest records seen in practice — ONT ultra-long reads carrying
+/// methylation tags — run a few MB. 256 MiB is roughly 25-50x above that and
+/// still bounds memory hard.
+///
+/// It is deliberately NOT tied to the pipeline's queue budget: byte-bounded
+/// queues always admit at least one item regardless of size, so a legitimate
+/// multi-MB record flows through a 4 MiB per-step budget, and bounding the carry
+/// there would reject valid BAMs.
+const MAX_CARRY_BYTES: usize = 256 * 1024 * 1024;
+
+/// Output of `FindBoundaries` step: buffer + record offsets for parallel decoding.
+///
+/// This struct enables parallel BAM record decoding by pre-computing where
+/// each record starts in the decompressed data. The actual parsing/decoding
+/// can then be parallelized across multiple threads.
+#[derive(Debug, Clone)]
+pub struct BoundaryBatch {
+    /// The decompressed bytes (with leftover prepended, suffix removed).
+    pub buffer: Vec<u8>,
+    /// Byte offsets where each record starts (offsets into buffer).
+    /// Length = `num_records` + 1 (last entry is `buffer.len()` for easy slicing).
+    pub offsets: Vec<usize>,
+}
+
+/// State for the `FindBoundaries` step (sequential).
+///
+/// This state maintains leftover bytes from incomplete records that span
+/// across BGZF block boundaries. The boundary finding is very fast (~0.1μs
+/// per block) since it only reads 4-byte integers without decoding records.
+///
+/// Uses a reusable work buffer to minimize allocations on the hot path.
+pub struct BoundaryState {
+    /// Leftover bytes from previous block (incomplete record at end).
+    leftover: Vec<u8>,
+    /// Reusable working buffer to avoid per-call allocations.
+    work_buffer: Vec<u8>,
+    /// Whether the BAM header has been skipped.
+    header_skipped: bool,
+    /// Length of the previous call's `offsets` Vec, used to pre-size the next
+    /// one. Adjacent BGZF blocks hold near-identical record counts, so this
+    /// collapses the per-block push-regrowth (~8 reallocations) to ~1. The
+    /// returned `offsets` Vec is moved into `BoundaryBatch`, so it cannot be a
+    /// reused buffer; pre-sizing is the cheap, correctness-neutral alternative.
+    prev_offsets_len: usize,
+}
+
+impl BoundaryState {
+    /// Create a new boundary state.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            leftover: Vec::new(),
+            work_buffer: Vec::new(),
+            header_skipped: false,
+            prev_offsets_len: 0,
+        }
+    }
+
+    /// Create a new boundary state that doesn't skip the header.
+    /// Use this when the input stream is already positioned past the header.
+    #[must_use]
+    pub fn new_no_header() -> Self {
+        Self {
+            leftover: Vec::new(),
+            work_buffer: Vec::new(),
+            header_skipped: true,
+            prev_offsets_len: 0,
+        }
+    }
+
+    /// Parse BAM header and return the number of bytes consumed.
+    ///
+    /// `Ok(None)` means more data is needed. `Err` means the header's own length
+    /// fields are corrupt — their sum overflows `usize`, so no amount of further
+    /// data could satisfy them.
+    ///
+    /// # Errors
+    ///
+    /// Returns `InvalidData` when `l_text` or a reference's `l_name` overflows
+    /// the running offset. Unreachable on 64-bit targets (both are `u32` widened
+    /// to `usize`); present because a length field taken from the stream must be
+    /// folded in with checked arithmetic rather than trusted to fit.
+    fn parse_header_size(data: &[u8]) -> io::Result<Option<usize>> {
+        // BAM header structure:
+        // - magic: 4 bytes ("BAM\1")
+        // - l_text: 4 bytes (header text length)
+        // - text: l_text bytes
+        // - n_ref: 4 bytes (number of references)
+        // - for each reference:
+        //   - l_name: 4 bytes
+        //   - name: l_name bytes
+        //   - l_ref: 4 bytes
+
+        if data.len() < 8 {
+            return Ok(None);
+        }
+
+        // Check magic
+        if &data[0..4] != fgumi_raw_bam::BAM_MAGIC {
+            // Not a valid BAM file, but let's not error here
+            // Just return 0 so records start immediately
+            return Ok(Some(0));
+        }
+
+        let l_text = u32::from_le_bytes([data[4], data[5], data[6], data[7]]) as usize;
+        let Some(mut offset) = 8usize.checked_add(l_text) else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "FindBamBoundaries: BAM header l_text={l_text} overflows the header offset"
+                ),
+            ));
+        };
+
+        if data.len() < offset + 4 {
+            return Ok(None);
+        }
+
+        let n_ref = u32::from_le_bytes([
+            data[offset],
+            data[offset + 1],
+            data[offset + 2],
+            data[offset + 3],
+        ]) as usize;
+        offset += 4;
+
+        // Parse each reference
+        for _ in 0..n_ref {
+            if data.len() < offset + 4 {
+                return Ok(None);
+            }
+            let l_name = u32::from_le_bytes([
+                data[offset],
+                data[offset + 1],
+                data[offset + 2],
+                data[offset + 3],
+            ]) as usize;
+            // l_name + name + l_ref, folded in with checked arithmetic for the
+            // same reason as `l_text` above.
+            let Some(next) = offset.checked_add(8).and_then(|o| o.checked_add(l_name)) else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "FindBamBoundaries: BAM header l_name={l_name} overflows \
+                         the header offset at {offset}"
+                    ),
+                ));
+            };
+            offset = next;
+
+            if data.len() < offset {
+                return Ok(None);
+            }
+        }
+
+        Ok(Some(offset))
+    }
+
+    /// Find record boundaries in decompressed data.
+    ///
+    /// This is FAST (~0.1μs per block) because it only scans 4-byte integers
+    /// to find where records start - no actual record decoding is performed.
+    ///
+    /// # Arguments
+    ///
+    /// * `decompressed` - Decompressed bytes from one or more BGZF blocks
+    ///
+    /// # Returns
+    ///
+    /// A `BoundaryBatch` containing the complete records and their offsets.
+    /// Any incomplete record at the end is saved as leftover for the next call.
+    ///
+    /// # Errors
+    ///
+    /// Returns `InvalidData` if the bytes carried forward waiting for the header
+    /// or for one record to complete exceed this module's `MAX_CARRY_BYTES`
+    /// corruption backstop. A well-formed stream always completes a record
+    /// within a bounded carry, so exceeding it means a length field is corrupt.
+    ///
+    /// # Record-level validation
+    ///
+    /// This function does NOT validate individual record `block_size` values
+    /// against a malformed (but self-consistent) BAM stream. The per-record
+    /// cross-check below (offset delta vs. the stored prefix) is a
+    /// `debug_assertions`-only regression tripwire for this scanner's own
+    /// arithmetic — it re-reads the same `block_size` bytes the scan already
+    /// trusted, so it can only catch an internal bookkeeping bug, never input
+    /// corruption. Authoritative release-build validation of record structure
+    /// (out-of-bounds record end, trailing partial record) is performed
+    /// downstream by `parse_records` / `parse_record_ranges` on the same bytes,
+    /// which hard-error in all build modes. The `offsets` vector this returns
+    /// is not consumed in release builds (`FindBamBoundaries` forwards only
+    /// `buffer`), so promoting the cross-check to release would re-validate a
+    /// tautology at a per-record cost for no correctness benefit.
+    pub fn find_boundaries(&mut self, decompressed: &[u8]) -> io::Result<BoundaryBatch> {
+        // Step 1: Combine leftover with new data into reusable work_buffer
+        // This avoids allocating a new Vec on every call
+        self.work_buffer.clear();
+        if !self.leftover.is_empty() {
+            self.work_buffer.append(&mut self.leftover);
+        }
+        self.work_buffer.extend_from_slice(decompressed);
+
+        // Step 2: Skip header if not already done
+        let mut cursor = 0usize;
+        if !self.header_skipped {
+            if let Some(header_size) = Self::parse_header_size(&self.work_buffer)? {
+                cursor = header_size;
+                self.header_skipped = true;
+            } else {
+                // Not enough data to parse header yet. Bound the carry: a corrupt
+                // `l_text` / `l_name` makes this branch unreachable-to-satisfy, so
+                // without the check every remaining block accumulates here.
+                if self.work_buffer.len() > MAX_CARRY_BYTES {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "FindBamBoundaries: BAM header still unresolved after {} byte(s) \
+                             (limit {MAX_CARRY_BYTES}); the header length fields are corrupt",
+                            self.work_buffer.len(),
+                        ),
+                    ));
+                }
+                // Save as leftover and return an empty batch.
+                std::mem::swap(&mut self.leftover, &mut self.work_buffer);
+                return Ok(BoundaryBatch { buffer: Vec::new(), offsets: vec![0] });
+            }
+        }
+
+        // Step 3: Scan for record boundaries (FAST - just read integers)
+        let start_cursor = cursor;
+        // Pre-size from the previous block's record count so the per-record
+        // pushes below don't trigger repeated Vec regrowth (adjacent blocks
+        // hold near-identical record counts). First offset is 0 (relative to
+        // the start of records).
+        let mut offsets = Vec::with_capacity(self.prev_offsets_len.max(1));
+        offsets.push(0usize);
+
+        while cursor + 4 <= self.work_buffer.len() {
+            let block_size = u32::from_le_bytes([
+                self.work_buffer[cursor],
+                self.work_buffer[cursor + 1],
+                self.work_buffer[cursor + 2],
+                self.work_buffer[cursor + 3],
+            ]) as usize;
+
+            // Checked: `block_size` comes from the stream. Unreachable on
+            // 64-bit, but the framing rule is checked-before-use.
+            let Some(record_end) = cursor.checked_add(4).and_then(|c| c.checked_add(block_size))
+            else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "FindBamBoundaries: record end overflows \
+                         (cursor={cursor}, block_size={block_size})"
+                    ),
+                ));
+            };
+            if record_end > self.work_buffer.len() {
+                break; // Incomplete record - becomes leftover
+            }
+
+            cursor = record_end;
+            // Offset is relative to start of records (after header)
+            offsets.push(cursor - start_cursor);
+        }
+
+        // Remember this block's offset count to pre-size the next call.
+        self.prev_offsets_len = offsets.len();
+
+        // Step 4: Save leftover for next block (reuse allocation)
+        // Split work_buffer: [0..start_cursor | start_cursor..cursor | cursor..]
+        //                     header (discard) | records (output)    | leftover
+        // Bound the carry before retaining it: a corrupt `block_size` keeps the
+        // scan breaking at the same record forever, so without this the leftover
+        // grows to the size of the remaining input. `finish` would still catch
+        // the shortfall at EOF, but only after the memory was already spent.
+        let carry_len = self.work_buffer.len() - cursor;
+        if carry_len > MAX_CARRY_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "FindBamBoundaries: incomplete BAM record has carried {carry_len} byte(s) \
+                     (limit {MAX_CARRY_BYTES}); its block_size prefix is corrupt",
+                ),
+            ));
+        }
+        self.leftover.clear();
+        self.leftover.extend_from_slice(&self.work_buffer[cursor..]);
+
+        // Extract the records buffer - this allocation is unavoidable as we return ownership
+        let buffer = self.work_buffer[start_cursor..cursor].to_vec();
+
+        // Debug-only regression tripwire (NOT input validation): cross-check
+        // each record's stored block_size prefix against the offset delta this
+        // scan just computed. Both derive from the same bytes with no
+        // intervening mutation, so this only catches an internal arithmetic /
+        // indexing bug in the scan above — a corrupt-but-self-consistent
+        // block_size passes trivially. Authoritative release validation lives
+        // in parse_records / parse_record_ranges downstream (see the
+        // `find_boundaries` doc comment).
+        #[cfg(debug_assertions)]
+        for i in 0..offsets.len().saturating_sub(1) {
+            let start = offsets[i];
+            let end = offsets[i + 1];
+            if end > start + 4 {
+                let stored = u32::from_le_bytes([
+                    buffer[start],
+                    buffer[start + 1],
+                    buffer[start + 2],
+                    buffer[start + 3],
+                ]) as usize;
+                let expected = end - start - 4;
+                debug_assert_eq!(
+                    stored, expected,
+                    "find_boundaries: block_size mismatch at record {i}: stored={stored}, expected={expected}"
+                );
+            }
+        }
+
+        Ok(BoundaryBatch { buffer, offsets })
+    }
+
+    /// Call at EOF to get any remaining leftover.
+    ///
+    /// This validates that any remaining bytes form complete records.
+    /// If there are incomplete bytes at EOF, an error is returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if there are incomplete BAM records at EOF.
+    pub fn finish(&mut self) -> io::Result<Option<BoundaryBatch>> {
+        if self.leftover.is_empty() {
+            return Ok(None);
+        }
+
+        // Try to parse remaining leftover
+        let mut offsets = vec![0usize];
+        let mut cursor = 0usize;
+
+        while cursor + 4 <= self.leftover.len() {
+            let block_size = u32::from_le_bytes([
+                self.leftover[cursor],
+                self.leftover[cursor + 1],
+                self.leftover[cursor + 2],
+                self.leftover[cursor + 3],
+            ]) as usize;
+
+            // Checked for the same reason as the scan loop above.
+            let Some(record_end) = cursor.checked_add(4).and_then(|c| c.checked_add(block_size))
+            else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "FindBamBoundaries: record end overflows at EOF \
+                         (cursor={cursor}, block_size={block_size})"
+                    ),
+                ));
+            };
+            if record_end > self.leftover.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    format!(
+                        "Incomplete BAM record at EOF: need {} bytes, have {}",
+                        record_end - cursor,
+                        self.leftover.len() - cursor
+                    ),
+                ));
+            }
+
+            cursor = record_end;
+            offsets.push(cursor);
+        }
+
+        // The loop only advances `cursor` by whole records. If it stops with
+        // bytes still unconsumed (`cursor < leftover.len()`), those 1-3 trailing
+        // bytes are too short to even hold a 4-byte block-size prefix — i.e. a
+        // truncated BAM record. Surface it as an error rather than dropping the
+        // bytes and masking corruption.
+        if cursor < self.leftover.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!(
+                    "Incomplete BAM record at EOF: {} trailing byte(s) cannot form a complete record",
+                    self.leftover.len() - cursor
+                ),
+            ));
+        }
+
+        Ok(Some(BoundaryBatch { buffer: std::mem::take(&mut self.leftover), offsets }))
+    }
+}
+
+impl Default for BoundaryState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    /// Frame `payload` as one BAM record: `block_size: u32 LE` + body. The
+    /// scanner never inspects the body, so an opaque payload is sufficient —
+    /// and keeps each case's record lengths readable in the table.
+    fn record(payload: &[u8]) -> Vec<u8> {
+        let mut framed = Vec::with_capacity(4 + payload.len());
+        framed.extend_from_slice(
+            &u32::try_from(payload.len()).expect("payload fits u32").to_le_bytes(),
+        );
+        framed.extend_from_slice(payload);
+        framed
+    }
+
+    /// A well-formed binary BAM header: magic, `l_text` + text, `n_ref`, then
+    /// `(l_name, name\0, l_ref)` per reference. This is exactly the prefix
+    /// `parse_header_size` walks, so building it honestly is what makes the
+    /// header-skip assertions meaningful.
+    fn bam_header(text: &str, refs: &[(&str, u32)]) -> Vec<u8> {
+        let mut header = Vec::new();
+        header.extend_from_slice(fgumi_raw_bam::BAM_MAGIC);
+        header.extend_from_slice(&u32::try_from(text.len()).expect("text fits u32").to_le_bytes());
+        header.extend_from_slice(text.as_bytes());
+        header.extend_from_slice(&u32::try_from(refs.len()).expect("n_ref fits u32").to_le_bytes());
+        for (name, ref_len) in refs {
+            let mut name_bytes = name.as_bytes().to_vec();
+            name_bytes.push(0); // names are NUL-terminated, and l_name counts the NUL
+            header.extend_from_slice(
+                &u32::try_from(name_bytes.len()).expect("l_name fits u32").to_le_bytes(),
+            );
+            header.extend_from_slice(&name_bytes);
+            header.extend_from_slice(&ref_len.to_le_bytes());
+        }
+        header
+    }
+
+    /// Concatenate framed records, as one decompressed block would hold them.
+    fn records(payloads: &[&[u8]]) -> Vec<u8> {
+        payloads.iter().flat_map(|p| record(p)).collect()
+    }
+
+    // ========================================================================
+    // Header skipping
+    // ========================================================================
+
+    /// The header must be consumed and excluded from the emitted buffer, with
+    /// only record bytes surviving. Parameterized over header shapes because
+    /// `parse_header_size`'s arithmetic differs per section: text length and
+    /// per-reference `(l_name, name, l_ref)` walking are separate loops, and a
+    /// bug in either would pass the other's case.
+    #[rstest]
+    #[case::no_text_no_refs("", &[])]
+    #[case::text_only("@HD\tVN:1.6\n", &[])]
+    #[case::one_ref("@HD\tVN:1.6\n", &[("chr1", 1000)])]
+    #[case::several_refs("@HD\tVN:1.6\n", &[("chr1", 1000), ("chr2", 2000), ("chrM", 16569)])]
+    #[case::empty_text_with_refs("", &[("chr1", 248_956_422)])]
+    fn find_boundaries_skips_the_header_and_emits_only_record_bytes(
+        #[case] text: &str,
+        #[case] refs: &[(&str, u32)],
+    ) {
+        let payloads: [&[u8]; 2] = [&[1u8; 8], &[2u8; 16]];
+        let mut block = bam_header(text, refs);
+        block.extend_from_slice(&records(&payloads));
+
+        let mut state = BoundaryState::new();
+        let batch = state.find_boundaries(&block).expect("well-formed block scans");
+
+        assert_eq!(
+            batch.buffer,
+            records(&payloads),
+            "header bytes must not reach the output buffer"
+        );
+        assert_eq!(batch.offsets, vec![0, 12, 32], "offsets are relative to the first record");
+    }
+
+    /// A `BoundaryState::new_no_header()` treats byte 0 as the first record —
+    /// this is the runall-spliced sub-pipeline case, where an upstream stage
+    /// already consumed the header.
+    #[test]
+    fn new_no_header_treats_the_first_byte_as_a_record_boundary() {
+        let payloads: [&[u8]; 2] = [&[7u8; 4], &[9u8; 4]];
+        let block = records(&payloads);
+
+        let mut state = BoundaryState::new_no_header();
+        let batch = state.find_boundaries(&block).expect("record-aligned block scans");
+
+        assert_eq!(batch.buffer, block, "every byte is a record byte when the header is skipped");
+        assert_eq!(batch.offsets, vec![0, 8, 16]);
+    }
+
+    /// `Default` must agree with `new()` — i.e. it expects a header. Asserted
+    /// behaviorally (the header is consumed) rather than by comparing private
+    /// fields, so the test survives a field-level refactor.
+    #[test]
+    fn default_expects_a_header_like_new() {
+        let payloads: [&[u8]; 1] = [&[1u8; 8]];
+        let mut block = bam_header("", &[]);
+        block.extend_from_slice(&records(&payloads));
+
+        let batch = BoundaryState::default().find_boundaries(&block).expect("scans");
+        assert_eq!(batch.buffer, records(&payloads));
+    }
+
+    /// A header split across blocks must be buffered, not mis-parsed: the first
+    /// call cannot determine the header size, so it emits an empty batch and
+    /// carries every byte forward. Parameterized over cut points that land in
+    /// each distinct section of `parse_header_size`'s walk, since each has its
+    /// own "need more data" early return.
+    #[rstest]
+    #[case::mid_magic(2)]
+    #[case::after_magic_before_l_text(4)]
+    #[case::mid_text(10)]
+    #[case::before_n_ref(15)]
+    #[case::mid_ref_name(24)]
+    fn a_header_split_across_blocks_is_buffered_until_complete(#[case] cut: usize) {
+        let payloads: [&[u8]; 1] = [&[3u8; 8]];
+        let header = bam_header("@HD\tVN:1.6\n", &[("chr1", 1000)]);
+        assert!(
+            cut < header.len(),
+            "cut must fall inside the header for this case to mean anything"
+        );
+        let mut full = header.clone();
+        full.extend_from_slice(&records(&payloads));
+
+        let mut state = BoundaryState::new();
+        let first = state.find_boundaries(&full[..cut]).expect("partial header is not an error");
+        assert!(first.buffer.is_empty(), "no records can be emitted before the header is parsed");
+        assert_eq!(first.offsets, vec![0]);
+
+        let second = state.find_boundaries(&full[cut..]).expect("rest of the header completes it");
+        assert_eq!(second.buffer, records(&payloads), "records resume once the header is consumed");
+        assert_eq!(second.offsets, vec![0, 12]);
+    }
+
+    /// Data that does not start with `BAM\1` is treated as record bytes from
+    /// offset 0 rather than erroring — the documented "not a valid BAM file,
+    /// but let's not error here" behavior. Worth pinning because it is
+    /// surprising: a caller who feeds the wrong stream gets garbage records,
+    /// not a diagnostic.
+    #[test]
+    fn a_non_bam_magic_prefix_is_scanned_as_records_from_offset_zero() {
+        let payloads: [&[u8]; 1] = [&[5u8; 8]];
+        let block = records(&payloads);
+        assert_ne!(&block[0..4], fgumi_raw_bam::BAM_MAGIC, "fixture must not look like a header");
+
+        let mut state = BoundaryState::new();
+        let batch = state.find_boundaries(&block).expect("scans");
+
+        assert_eq!(batch.buffer, block);
+        assert_eq!(batch.offsets, vec![0, 12]);
+    }
+
+    /// Fewer than 8 bytes cannot even hold magic + `l_text`, so the scanner
+    /// must ask for more data instead of reading past the end.
+    #[test]
+    fn fewer_than_eight_bytes_cannot_resolve_the_header() {
+        let mut state = BoundaryState::new();
+        let batch = state.find_boundaries(b"BAM\x01").expect("short input is not an error");
+        assert!(batch.buffer.is_empty());
+        assert_eq!(batch.offsets, vec![0]);
+    }
+
+    // ========================================================================
+    // Record scanning and cross-block carryover
+    // ========================================================================
+
+    /// The core carryover contract: a record straddling two blocks is held back
+    /// on the first call and emitted whole on the second, never split. The
+    /// concatenated output across both calls must equal the input records
+    /// exactly — that is the invariant downstream parsing depends on.
+    #[rstest]
+    #[case::split_mid_body(18)]
+    #[case::split_on_a_record_start(12)]
+    #[case::split_mid_length_prefix(14)]
+    #[case::split_one_byte_in(1)]
+    fn a_record_spanning_two_blocks_is_emitted_whole(#[case] cut: usize) {
+        let payloads: [&[u8]; 3] = [&[1u8; 8], &[2u8; 8], &[3u8; 8]];
+        let all = records(&payloads);
+        assert!(cut < all.len());
+
+        let mut state = BoundaryState::new_no_header();
+        let first = state.find_boundaries(&all[..cut]).expect("first half scans");
+        let second = state.find_boundaries(&all[cut..]).expect("second half scans");
+
+        let mut seen = first.buffer.clone();
+        seen.extend_from_slice(&second.buffer);
+        assert_eq!(seen, all, "no byte may be dropped or duplicated across the split");
+        assert!(state.finish().expect("nothing left over").is_none());
+    }
+
+    /// Offsets must always start at 0, end at `buffer.len()`, and step by each
+    /// record's framed size — this is the contract that lets a consumer slice
+    /// records with `offsets.windows(2)`.
+    #[test]
+    fn offsets_bracket_every_record_in_the_emitted_buffer() {
+        let payloads: [&[u8]; 3] = [&[1u8; 4], &[2u8; 20], &[3u8; 0]];
+        let block = records(&payloads);
+
+        let mut state = BoundaryState::new_no_header();
+        let batch = state.find_boundaries(&block).expect("scans");
+
+        assert_eq!(batch.offsets, vec![0, 8, 32, 36]);
+        assert_eq!(*batch.offsets.last().expect("non-empty"), batch.buffer.len());
+        for (i, window) in batch.offsets.windows(2).enumerate() {
+            let body = &batch.buffer[window[0] + 4..window[1]];
+            assert_eq!(body, payloads[i], "record {i} must round-trip through its offsets");
+        }
+    }
+
+    /// An empty block is a legal no-op: nothing to scan, nothing carried.
+    #[test]
+    fn an_empty_block_yields_an_empty_batch() {
+        let mut state = BoundaryState::new_no_header();
+        let batch = state.find_boundaries(&[]).expect("empty input is not an error");
+        assert!(batch.buffer.is_empty());
+        assert_eq!(batch.offsets, vec![0]);
+    }
+
+    /// Feeding many blocks in sequence must give the same records as feeding
+    /// one concatenated block. This is what exercises the `prev_offsets_len`
+    /// pre-sizing path across calls, and it is the property that actually
+    /// matters: block framing must not be observable in the output.
+    #[test]
+    fn streaming_many_blocks_matches_scanning_one_concatenated_block() {
+        let payloads: Vec<Vec<u8>> = (0..32u8).map(|i| vec![i; usize::from(i) + 1]).collect();
+        let refs: Vec<&[u8]> = payloads.iter().map(Vec::as_slice).collect();
+        let all = records(&refs);
+
+        let one_shot = {
+            let mut state = BoundaryState::new_no_header();
+            let batch = state.find_boundaries(&all).expect("scans");
+            assert!(state.finish().expect("nothing left over").is_none());
+            batch.buffer
+        };
+
+        let streamed = {
+            let mut state = BoundaryState::new_no_header();
+            let mut out = Vec::new();
+            for chunk in all.chunks(7) {
+                out.extend_from_slice(&state.find_boundaries(chunk).expect("scans").buffer);
+            }
+            assert!(state.finish().expect("nothing left over").is_none());
+            out
+        };
+
+        assert_eq!(streamed, one_shot, "block framing must not be observable downstream");
+        assert_eq!(one_shot, all);
+    }
+
+    // ========================================================================
+    // finish(): EOF validation
+    // ========================================================================
+
+    /// With no carryover there is nothing to flush.
+    #[test]
+    fn finish_returns_none_when_no_bytes_were_carried_over() {
+        let mut state = BoundaryState::new_no_header();
+        state.find_boundaries(&records(&[&[1u8; 8]])).expect("scans");
+        assert!(state.finish().expect("no leftover").is_none());
+    }
+
+    /// `finish` flushes carried-over bytes when they happen to form whole
+    /// records. That is narrower than it sounds, and the narrowness is the
+    /// point: `find_boundaries` consumes *every* complete record it can see, so
+    /// after a successful scan the carryover is by construction an INCOMPLETE
+    /// record — making `None` or an error the normal outcomes at EOF.
+    ///
+    /// The one reachable path to a flushed batch is a stream that ended before
+    /// the header could even be resolved (< 8 bytes, so `parse_header_size`
+    /// never ran) whose bytes nonetheless frame cleanly. Pinning it keeps the
+    /// flush path honest and documents why it is nearly dead code.
+    #[test]
+    fn finish_flushes_carried_over_bytes_that_form_whole_records() {
+        // Seven bytes: too short for magic + `l_text`, so the whole block is
+        // carried over unparsed — but a clean `block_size = 3` + 3-byte body.
+        let block = record(&[7u8; 3]);
+        assert_eq!(block.len(), 7);
+
+        let mut state = BoundaryState::new();
+        let batch = state.find_boundaries(&block).expect("short input is not an error");
+        assert!(batch.buffer.is_empty(), "the header was never resolved, so nothing is emitted");
+
+        let flushed =
+            state.finish().expect("carryover frames cleanly").expect("a batch is flushed");
+        assert_eq!(flushed.buffer, block);
+        assert_eq!(flushed.offsets, vec![0, 7]);
+    }
+
+    /// After a successful scan the carryover is always a partial record, so the
+    /// normal EOF outcome is `None` — the complete records were already emitted
+    /// by `find_boundaries` itself.
+    #[test]
+    fn finish_returns_none_after_a_scan_that_consumed_every_record() {
+        let payloads: [&[u8]; 2] = [&[1u8; 8], &[2u8; 8]];
+        let all = records(&payloads);
+
+        let mut state = BoundaryState::new_no_header();
+        let batch = state.find_boundaries(&all[..12]).expect("scans");
+        assert_eq!(batch.buffer, record(&[1u8; 8]), "the first record is emitted immediately");
+
+        assert!(
+            state.finish().expect("no carryover").is_none(),
+            "a scan that ended on a record boundary leaves nothing to flush"
+        );
+    }
+
+    /// A truncated record at EOF is corruption and must surface as
+    /// `UnexpectedEof` rather than silently dropping bytes. Two distinct
+    /// truncations reach two different error sites: a declared `block_size`
+    /// that outruns the buffer, and trailing bytes too short to even hold the
+    /// 4-byte length prefix.
+    #[rstest]
+    #[case::body_shorter_than_declared_block_size(&[0x20, 0, 0, 0, 1, 2, 3])]
+    #[case::three_trailing_bytes(&[1, 2, 3])]
+    #[case::one_trailing_byte(&[9])]
+    fn finish_rejects_an_incomplete_record_at_eof(#[case] tail: &[u8]) {
+        let mut block = record(&[1u8; 8]);
+        block.extend_from_slice(tail);
+
+        let mut state = BoundaryState::new_no_header();
+        let batch = state.find_boundaries(&block).expect("the complete record scans");
+        assert_eq!(batch.buffer, record(&[1u8; 8]));
+
+        let err = state.finish().expect_err("a truncated tail must not be dropped");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    /// `finish` takes the leftover, so a second call reports nothing remaining
+    /// rather than re-emitting the same bytes. `FindBamBoundaries` guards this
+    /// with its own `finalized` flag, but the state machine must not depend on
+    /// that guard for correctness of the buffer it returns.
+    #[test]
+    fn finish_does_not_re_emit_the_same_leftover_twice() {
+        // Same short-input setup as the flush test above — the only shape that
+        // leaves whole records parked in carryover.
+        let block = record(&[7u8; 3]);
+        let mut state = BoundaryState::new();
+        state.find_boundaries(&block).expect("short input buffers");
+
+        assert!(state.finish().expect("first flush").is_some());
+        assert!(state.finish().expect("second flush").is_none(), "leftover must be consumed once");
+    }
+
+    // ========================================================================
+    // Bounded carryover on corrupt framing
+    // ========================================================================
+
+    /// A corrupt `block_size` must be rejected once the carry passes
+    /// [`MAX_CARRY_BYTES`], rather than buffering the rest of the stream.
+    ///
+    /// Without the bound this terminates *correctly* — `finish` catches the
+    /// shortfall at EOF — but only after carrying every remaining byte, so peak
+    /// memory tracks input size and a large corrupt file OOMs before it can
+    /// print the diagnostic it was about to print.
+    #[test]
+    fn a_corrupt_block_size_is_rejected_once_the_carry_passes_the_bound() {
+        let mut state = BoundaryState::new_no_header();
+        // Declare a body far larger than any real record, and never supply it.
+        let mut first =
+            u32::try_from(MAX_CARRY_BYTES * 4).expect("fits u32").to_le_bytes().to_vec();
+        first.extend_from_slice(&[7u8; 64]);
+        state.find_boundaries(&first).expect("first block just starts the carry");
+
+        // Feed blocks until the bound trips. It must trip well before the
+        // declared size is reached.
+        let block = vec![9u8; 1024 * 1024];
+        let mut fed = first.len();
+        let err = loop {
+            match state.find_boundaries(&block) {
+                Ok(_) => {
+                    fed += block.len();
+                    assert!(
+                        fed <= MAX_CARRY_BYTES + block.len(),
+                        "carry ran past the bound without erroring ({fed} bytes fed)",
+                    );
+                }
+                Err(e) => break e,
+            }
+        };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// A header whose declared `l_text` never resolves must be bounded the same
+    /// way — it is the other path that carries the whole stream forward.
+    #[test]
+    fn a_header_that_never_resolves_is_rejected_once_the_carry_passes_the_bound() {
+        let mut header = fgumi_raw_bam::BAM_MAGIC.to_vec();
+        header.extend_from_slice(&u32::MAX.to_le_bytes()); // absurd l_text
+        let mut state = BoundaryState::new();
+        state.find_boundaries(&header).expect("first block just starts the carry");
+
+        let block = vec![0u8; 1024 * 1024];
+        let mut fed = header.len();
+        let err = loop {
+            match state.find_boundaries(&block) {
+                Ok(_) => {
+                    fed += block.len();
+                    assert!(
+                        fed <= MAX_CARRY_BYTES + block.len(),
+                        "header carry ran past the bound without erroring ({fed} bytes fed)",
+                    );
+                }
+                Err(e) => break e,
+            }
+        };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// The bound must not reject legitimately large records. An ONT ultra-long
+    /// read with methylation tags can reach a few MB, and such a record spans
+    /// many BGZF blocks — so it is carried across dozens of calls before it
+    /// completes. That is exactly the shape the bound must let through, which is
+    /// why it sits far above any real record rather than at the queue budget.
+    #[test]
+    fn a_multi_megabyte_record_spanning_many_blocks_is_still_accepted() {
+        const BODY: usize = 8 * 1024 * 1024; // ~8 MB — above any real BAM record
+        // Compile-time: if the bound is ever lowered under this fixture, the
+        // test must fail to build rather than silently stop proving anything.
+        const { assert!(BODY < MAX_CARRY_BYTES) };
+
+        let mut stream = u32::try_from(BODY).expect("fits u32").to_le_bytes().to_vec();
+        stream.extend_from_slice(&vec![3u8; BODY]);
+
+        let mut state = BoundaryState::new_no_header();
+        let mut emitted = Vec::new();
+        for chunk in stream.chunks(64 * 1024) {
+            emitted.extend_from_slice(
+                &state.find_boundaries(chunk).expect("a large but legal record must scan").buffer,
+            );
+        }
+        assert!(state.finish().expect("nothing left over").is_none());
+        assert_eq!(emitted, stream, "the whole record must survive the carry intact");
+    }
+
+    /// A header that never completes before EOF leaves the partial header in
+    /// `leftover`; `finish` then reports it as corruption rather than emitting
+    /// header bytes as if they were records.
+    #[test]
+    fn finish_reports_a_header_that_never_completed_as_corruption() {
+        let header = bam_header("@HD\tVN:1.6\n", &[("chr1", 1000)]);
+        let mut state = BoundaryState::new();
+        let batch = state.find_boundaries(&header[..12]).expect("partial header buffers");
+        assert!(batch.buffer.is_empty());
+
+        let err = state.finish().expect_err("a partial header is not a valid record stream");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+}

--- a/src/lib/pipeline/steps/chain_tests.rs
+++ b/src/lib/pipeline/steps/chain_tests.rs
@@ -1,0 +1,2202 @@
+//! Cross-step integration tests for the step subset in this port.
+//!
+//! Every step in `steps/` is a `try_run` state machine whose interesting
+//! behavior — held-item retry, drain detection, `Finished` reporting — only
+//! occurs when the framework drives it. Unit tests over a step's helpers
+//! therefore leave the step body itself unexercised, so these tests assemble
+//! real chains and run them through [`Pipeline::run`]:
+//!
+//! ```text
+//! ReplaySource → BgzfDecompress → FindBamBoundaries → DecodeRecords    → sink
+//! ReplaySource → BgzfDecompress → FindBamBoundaries → ParseBamRecords  → sink
+//! ReplaySource → BgzfDecompress → FindBamBoundaries → BgzfCompress     → sink
+//! ReplaySource → TemplatesToRecordBatch                                → sink
+//! ReplaySource → GroupByMi                                             → sink
+//! ReplaySource → Process2Ordered                          → sink A + sink B
+//! ```
+//!
+//! `ReplaySource` is a test-local source because the real `source/` steps
+//! are not part of this port; the block bytes it replays are built by the same
+//! BGZF compressor the production writer uses, so the decode path sees exactly
+//! what it would in production.
+//!
+//! Each chain runs at 1 and 4 threads. That is not redundancy: at 1 thread the
+//! `Parallel` steps have a single clone and drain trivially, while at 4 the
+//! last-worker barrier (only the final clone may close a shared output) is
+//! actually exercised. A drain bug that wedges the pipeline shows up as a
+//! hang in the 4-thread case only.
+//!
+//! The full production chain (through `GroupBam`, serialization, and the file
+//! sink) is covered by the integration tests that arrive with the remaining
+//! step subtrees.
+
+use std::collections::VecDeque;
+use std::io;
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+use std::sync::{Arc, Mutex};
+
+use fgumi_bam_io::GroupKeyConfig;
+use fgumi_raw_bam::{RawRecord, SamBuilder};
+use rstest::rstest;
+
+use crate::grouper::ProcessedPositionGroup;
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::builder::{Pipeline, PipelineConfig};
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::item::{HeapSize, Ordered};
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::bgzf::compress::BgzfCompress;
+use crate::pipeline::steps::bgzf::decompress::BgzfDecompress;
+use crate::pipeline::steps::boundaries::bam::FindBamBoundaries;
+use crate::pipeline::steps::group::position::BatchedProcessedPositionGroups;
+use crate::pipeline::steps::parse::bam::ParseBamRecords;
+use crate::pipeline::steps::parse::decode::{DecodeFromRecords, DecodeRecords};
+use crate::pipeline::steps::types::{BgzfBlock, DecodedRecordBatch, RecordBatch};
+use crate::template::Template;
+
+/// Per-edge byte budget. Deliberately small relative to the multi-record
+/// fixtures so the byte-bounded edges bind mid-run rather than swallowing the
+/// whole stream in one go. `the_edge_budget_binds_on_the_multi_record_fixtures`
+/// pins that this constant actually has teeth — a future edit that raised it
+/// past the fixture volume would silently turn every chain below into an
+/// unbounded-queue test.
+const EDGE_LIMIT_BYTES: u64 = 16 * 1024;
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+/// A minimal binary BAM header: magic, empty text, and `n_ref` references.
+/// This is the prefix `FindBamBoundaries` must consume and discard.
+fn minimal_binary_bam_header(n_ref: u32) -> Vec<u8> {
+    let mut header = Vec::new();
+    header.extend_from_slice(fgumi_raw_bam::BAM_MAGIC);
+    header.extend_from_slice(&0u32.to_le_bytes()); // l_text = 0
+    header.extend_from_slice(&n_ref.to_le_bytes());
+    for _ in 0..n_ref {
+        header.extend_from_slice(&2u32.to_le_bytes()); // l_name = 2 ("r" + NUL)
+        header.extend_from_slice(b"r\0");
+        header.extend_from_slice(&1_000_000u32.to_le_bytes()); // l_ref
+    }
+    header
+}
+
+/// `n` mapped, paired records with distinct read names and positions — enough
+/// field variety that a group key computed from them is not trivially constant.
+fn test_records(n: usize) -> Vec<RawRecord> {
+    (0..n)
+        .map(|i| {
+            let mut b = SamBuilder::new();
+            b.read_name(format!("read{i}").as_bytes())
+                .flags(fgumi_raw_bam::flags::PAIRED | fgumi_raw_bam::flags::FIRST_SEGMENT)
+                .ref_id(0)
+                .pos(i32::try_from(100 + i * 10).expect("pos fits i32"))
+                .cigar_ops(&[4u32 << 4]) // 4M
+                .sequence(b"ACGT")
+                .qualities(&[30u8; 4]);
+            b.build()
+        })
+        .collect()
+}
+
+/// Serialize a header + records into a BAM byte stream, then cut it into BGZF
+/// blocks of at most `payload_bytes` uncompressed bytes each.
+///
+/// Cutting at a fixed byte size (rather than on record boundaries) is the
+/// point: records land straddling block edges, which is exactly the carryover
+/// case `FindBamBoundaries` exists to handle.
+fn bgzf_blocks_for(records: &[RawRecord], payload_bytes: usize) -> Vec<BgzfBlock> {
+    let mut stream = minimal_binary_bam_header(1);
+    for record in records {
+        let bytes = record.as_ref();
+        let block_size = u32::try_from(bytes.len()).expect("record fits u32");
+        stream.extend_from_slice(&block_size.to_le_bytes());
+        stream.extend_from_slice(bytes);
+    }
+    stream
+        .chunks(payload_bytes)
+        .enumerate()
+        .map(|(i, payload)| {
+            let mut compressor = fgumi_bgzf::InlineBgzfCompressor::new(1);
+            compressor.write_all(payload).expect("compress payload");
+            compressor.flush().expect("flush compressor");
+            let mut blocks = compressor.take_blocks();
+            assert_eq!(blocks.len(), 1, "payload must fit one BGZF block");
+            BgzfBlock {
+                batch_serial: i as u64,
+                bytes: blocks.remove(0).data,
+                uncompressed_size: u32::try_from(payload.len()).expect("payload fits u32"),
+            }
+        })
+        .collect()
+}
+
+/// A four-record template for one queryname: primary R1 and R2 plus an R1
+/// supplementary and an R2 secondary.
+///
+/// The split alignments are the point — a flatten written against
+/// [`Template::r1`]/[`Template::r2`] would silently drop them, and every record
+/// here carries a distinct position, sequence, and length so any dropped,
+/// duplicated, or reordered record changes the emitted byte stream.
+fn split_alignment_template(qname: &[u8]) -> Template {
+    use fgumi_raw_bam::flags::{FIRST_SEGMENT, LAST_SEGMENT, PAIRED, SECONDARY, SUPPLEMENTARY};
+
+    let record = |flags: u16, pos: i32, seq: &[u8], quals: &[u8]| {
+        let mut b = SamBuilder::new();
+        b.read_name(qname)
+            .flags(flags)
+            .ref_id(0)
+            .pos(pos)
+            // (length << 4) | op, where op 0 is `M`.
+            .cigar_ops(&[u32::try_from(seq.len()).expect("seq length fits u32") << 4])
+            .sequence(seq)
+            .qualities(quals);
+        b.build()
+    };
+
+    Template::from_records(vec![
+        record(PAIRED | FIRST_SEGMENT, 100, b"ACGT", &[30u8; 4]),
+        record(PAIRED | LAST_SEGMENT, 200, b"TTGCA", &[31u8; 5]),
+        record(PAIRED | FIRST_SEGMENT | SUPPLEMENTARY, 300, b"GGGCCC", &[32u8; 6]),
+        record(PAIRED | LAST_SEGMENT | SECONDARY, 400, b"TATATATA", &[33u8; 8]),
+    ])
+    .expect("split-alignment template")
+}
+
+/// A minimal record carrying `MI:Z:<mi>` — the only field `GroupByMi` reads.
+fn mi_record(mi: &str) -> RawRecord {
+    let mut b = SamBuilder::new();
+    b.read_name(b"read")
+        .flags(0)
+        .sequence(b"ACGT")
+        .qualities(&[30u8; 4])
+        .add_string_tag(*crate::sam::SamTag::MI, mi.as_bytes());
+    b.build()
+}
+
+/// A minimal record with no `MI` tag at all — dropped by `GroupByMi` and
+/// counted against `skipped_no_mi`.
+fn record_without_mi() -> RawRecord {
+    let mut b = SamBuilder::new();
+    b.read_name(b"read").flags(0).sequence(b"ACGT").qualities(&[30u8; 4]);
+    b.build()
+}
+
+/// A minimal record carrying `MI:i:<value>` — an integer where a string is
+/// required, so it groups nothing and is counted against
+/// `skipped_non_string_mi`.
+fn record_with_integer_mi(value: i32) -> RawRecord {
+    let mut b = SamBuilder::new();
+    b.read_name(b"read")
+        .flags(0)
+        .sequence(b"ACGT")
+        .qualities(&[30u8; 4])
+        .add_int_tag(*crate::sam::SamTag::MI, value);
+    b.build()
+}
+
+/// Wrap raw records in a [`DecodedRecordBatch`]. The [`GroupKey`] is left at
+/// its default because `GroupByMi` re-reads the MI tag from the record bytes
+/// and never consults the pre-computed key.
+fn decoded_batch(batch_serial: u64, records: Vec<RawRecord>) -> DecodedRecordBatch {
+    DecodedRecordBatch::new(
+        batch_serial,
+        records
+            .into_iter()
+            .map(|raw| {
+                fgumi_bam_io::DecodedRecord::from_raw_bytes(raw, fgumi_bam_io::GroupKey::default())
+            })
+            .collect(),
+    )
+}
+
+// ============================================================================
+// Test-local source and sink steps
+// ============================================================================
+
+/// Replays pre-built items into the chain. `Exclusive` because it owns mutable
+/// cursor state and must not be cloned per worker.
+///
+/// Holds a rejected item and retries it on a later tick rather than dropping
+/// it — dropping would punch a hole in the ordinal sequence, which the
+/// downstream `ByItemOrdinal` reorder stages would then wait on forever.
+struct ReplaySource<T: Send + HeapSize + Ordered + 'static> {
+    items: VecDeque<T>,
+    held: HeldSlot<Unpushed<T>>,
+}
+
+impl<T: Send + HeapSize + Ordered + 'static> ReplaySource<T> {
+    fn new(items: Vec<T>) -> Self {
+        Self { items: items.into(), held: HeldSlot::new() }
+    }
+}
+
+impl<T: Send + HeapSize + Ordered + 'static> Step for ReplaySource<T> {
+    type Input = ();
+    type Outputs = OrderedBytesSingle<T>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ReplaySource",
+            kind: StepKind::Exclusive,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: EDGE_LIMIT_BYTES }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        let Some(item) = self.items.pop_front() else {
+            return Ok(StepOutcome::Finished);
+        };
+        if let Err(unpushed) = ctx.outputs.push(item) {
+            self.held.put(unpushed);
+        }
+        Ok(StepOutcome::Progress)
+    }
+}
+
+/// Terminal sink that accumulates every item it receives, in arrival order.
+/// `Exclusive` so arrival order is the chain's output order with no
+/// sink-side interleaving to reason about.
+struct CollectSink<T: Send + 'static> {
+    collected: Arc<Mutex<Vec<T>>>,
+}
+
+impl<T> Step for CollectSink<T>
+where
+    T: Send + HeapSize + 'static,
+{
+    type Input = T;
+    type Outputs = ();
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "CollectSink",
+            kind: StepKind::Exclusive,
+            sticky: false,
+            output_queues: vec![],
+            branch_ordering: vec![],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        match ctx.input.pop() {
+            Some(item) => {
+                self.collected.lock().expect("sink mutex not poisoned").push(item);
+                Ok(StepOutcome::Progress)
+            }
+            None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+            None => Ok(StepOutcome::NoProgress),
+        }
+    }
+}
+
+/// Like [`CollectSink`], but ignores its input for the first `remaining_stalls`
+/// calls.
+///
+/// Stalling the terminal step is what lets an upstream byte-bounded output
+/// queue actually fill up. With a sink that drains on every tick the queue
+/// returns to zero bytes between pushes, so `cur >= limit` never holds at push
+/// time and the producer's held-slot retry path is never taken — at one thread
+/// it is structurally unreachable, and at four it depends on scheduling. That
+/// makes a "this exercises backpressure" claim untrue exactly when the test
+/// looks like it passes.
+struct StallingCollectSink<T: Send + 'static> {
+    collected: Arc<Mutex<Vec<T>>>,
+    remaining_stalls: usize,
+}
+
+impl<T> Step for StallingCollectSink<T>
+where
+    T: Send + HeapSize + 'static,
+{
+    type Input = T;
+    type Outputs = ();
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "StallingCollectSink",
+            kind: StepKind::Exclusive,
+            sticky: false,
+            output_queues: vec![],
+            branch_ordering: vec![],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if self.remaining_stalls > 0 {
+            self.remaining_stalls -= 1;
+            return Ok(StepOutcome::NoProgress);
+        }
+        match ctx.input.pop() {
+            Some(item) => {
+                self.collected.lock().expect("sink mutex not poisoned").push(item);
+                Ok(StepOutcome::Progress)
+            }
+            None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+            None => Ok(StepOutcome::NoProgress),
+        }
+    }
+}
+
+// ============================================================================
+// Chains
+// ============================================================================
+
+/// `ReplaySource → BgzfDecompress → FindBamBoundaries → DecodeRecords`.
+///
+/// Every record in the input must arrive downstream exactly once, in order,
+/// with its bytes intact — across BGZF block boundaries, byte backpressure,
+/// and (at 4 threads) parallel decompress/decode workers.
+#[rstest]
+fn decode_chain_round_trips_every_record_in_order(
+    #[values(1, 4)] threads: usize,
+    #[values(1, 64, 500)] n_records: usize,
+) {
+    let records = test_records(n_records);
+    let blocks = bgzf_blocks_for(&records, 4096);
+    let collected: Arc<Mutex<Vec<DecodedRecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(blocks))
+        .chain(BgzfDecompress::new(EDGE_LIMIT_BYTES))
+        .chain(FindBamBoundaries::new(EDGE_LIMIT_BYTES))
+        .chain(DecodeRecords::new(GroupKeyConfig::default(), EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let batches = collected.lock().expect("mutex not poisoned");
+    let seen: Vec<&[u8]> = batches
+        .iter()
+        .flat_map(|batch| batch.records().iter().map(fgumi_bam_io::DecodedRecord::raw_bytes))
+        .collect();
+    let expected: Vec<&[u8]> = records.iter().map(AsRef::as_ref).collect();
+    assert_eq!(seen, expected, "records must survive the chain intact and in order");
+}
+
+/// Same chain but terminating in `ParseBamRecords`, the zero-alloc sibling of
+/// `DecodeRecords` that emits shared-buffer `RecordBatch`es instead of owned
+/// `DecodedRecord`s. It must yield the same records in the same order.
+#[rstest]
+fn parse_chain_round_trips_every_record_in_order(
+    #[values(1, 4)] threads: usize,
+    #[values(1, 64, 500)] n_records: usize,
+) {
+    let records = test_records(n_records);
+    let blocks = bgzf_blocks_for(&records, 4096);
+    let collected: Arc<Mutex<Vec<RecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(blocks))
+        .chain(BgzfDecompress::new(EDGE_LIMIT_BYTES))
+        .chain(FindBamBoundaries::new(EDGE_LIMIT_BYTES))
+        .chain(ParseBamRecords::new(EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let batches = collected.lock().expect("mutex not poisoned");
+    let seen: Vec<Vec<u8>> =
+        batches.iter().flat_map(|batch| batch.iter_record_bytes().map(<[u8]>::to_vec)).collect();
+    let expected: Vec<Vec<u8>> = records.iter().map(|r| r.as_ref().to_vec()).collect();
+    assert_eq!(seen, expected, "records must survive the parse chain intact and in order");
+}
+
+/// `… → FindBamBoundaries → BgzfCompress` re-compresses the record stream.
+/// Decompressing the sink's output must reproduce the record bytes exactly —
+/// proving the compress step preserves both content and batch ordering.
+#[rstest]
+fn compress_chain_output_decompresses_back_to_the_record_stream(#[values(1, 4)] threads: usize) {
+    let records = test_records(200);
+    let blocks = bgzf_blocks_for(&records, 4096);
+    let collected: Arc<Mutex<Vec<BgzfBlock>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(blocks))
+        .chain(BgzfDecompress::new(EDGE_LIMIT_BYTES))
+        .chain(FindBamBoundaries::new(EDGE_LIMIT_BYTES))
+        .chain(BgzfCompress::new(1, EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    // Concatenate the emitted BGZF blocks and inflate the whole stream.
+    let compressed: Vec<u8> = collected
+        .lock()
+        .expect("mutex not poisoned")
+        .iter()
+        .flat_map(|b| b.bytes.clone())
+        .collect();
+    // Read in bounded batches: `read_raw_blocks` pre-allocates `max_blocks`,
+    // so it must be given a sane cap rather than "everything".
+    let mut cursor = io::Cursor::new(compressed);
+    let mut decompressor = libdeflater::Decompressor::new();
+    let mut inflated = Vec::new();
+    loop {
+        let raw_blocks = fgumi_bgzf::reader::read_raw_blocks(&mut cursor, 64)
+            .expect("output is a valid BGZF stream");
+        if raw_blocks.is_empty() {
+            break;
+        }
+        for block in &raw_blocks {
+            inflated.extend_from_slice(
+                &fgumi_bgzf::reader::decompress_block(block, &mut decompressor)
+                    .expect("each emitted block inflates"),
+            );
+        }
+    }
+
+    // The compressed stream is the header-stripped record stream: framed
+    // `block_size` + body per record, in input order.
+    let mut expected = Vec::new();
+    for record in &records {
+        let bytes = record.as_ref();
+        expected.extend_from_slice(&u32::try_from(bytes.len()).expect("fits u32").to_le_bytes());
+        expected.extend_from_slice(bytes);
+    }
+    assert_eq!(inflated, expected, "compress must preserve the record stream byte-for-byte");
+}
+
+/// An input with a header but no records must still complete cleanly and
+/// produce nothing — the empty-BAM case, where every step sees drain before it
+/// ever sees an item.
+#[rstest]
+fn a_header_only_input_completes_with_no_records(#[values(1, 4)] threads: usize) {
+    let blocks = bgzf_blocks_for(&[], 4096);
+    let collected: Arc<Mutex<Vec<DecodedRecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(blocks))
+        .chain(BgzfDecompress::new(EDGE_LIMIT_BYTES))
+        .chain(FindBamBoundaries::new(EDGE_LIMIT_BYTES))
+        .chain(DecodeRecords::new(GroupKeyConfig::default(), EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let batches = collected.lock().expect("mutex not poisoned");
+    let total: usize = batches.iter().map(|b| b.records().len()).sum();
+    assert_eq!(total, 0, "a header-only BAM yields no records");
+}
+
+/// A single BGZF block holding the entire stream exercises the path where
+/// `FindBamBoundaries` never carries anything over — the whole header and every
+/// record arrive together in one input.
+#[rstest]
+fn a_single_block_input_needs_no_carryover(#[values(1, 4)] threads: usize) {
+    let records = test_records(50);
+    // One block big enough for the whole stream.
+    let blocks = bgzf_blocks_for(&records, 64 * 1024);
+    assert_eq!(blocks.len(), 1, "fixture must fit in a single BGZF block");
+
+    let collected: Arc<Mutex<Vec<DecodedRecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(blocks))
+        .chain(BgzfDecompress::new(EDGE_LIMIT_BYTES))
+        .chain(FindBamBoundaries::new(EDGE_LIMIT_BYTES))
+        .chain(DecodeRecords::new(GroupKeyConfig::default(), EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let batches = collected.lock().expect("mutex not poisoned");
+    let total: usize = batches.iter().map(|b| b.records().len()).sum();
+    assert_eq!(total, records.len());
+}
+
+/// `FindBamBoundaries::new_no_header` is the runall-spliced entry point: the
+/// stream is already past the header, so byte 0 is a record boundary. Feeding
+/// it a header-stripped stream must yield every record.
+#[rstest]
+fn the_no_header_boundary_variant_consumes_a_header_stripped_stream(
+    #[values(1, 4)] threads: usize,
+) {
+    let records = test_records(64);
+    // Build blocks over the record stream ONLY — no BAM header prefix.
+    let mut stream = Vec::new();
+    for record in &records {
+        let bytes = record.as_ref();
+        stream.extend_from_slice(&u32::try_from(bytes.len()).expect("fits u32").to_le_bytes());
+        stream.extend_from_slice(bytes);
+    }
+    let blocks: Vec<BgzfBlock> = stream
+        .chunks(1024)
+        .enumerate()
+        .map(|(i, payload)| {
+            let mut compressor = fgumi_bgzf::InlineBgzfCompressor::new(1);
+            compressor.write_all(payload).expect("compress");
+            compressor.flush().expect("flush");
+            let mut blocks = compressor.take_blocks();
+            assert_eq!(blocks.len(), 1);
+            BgzfBlock {
+                batch_serial: i as u64,
+                bytes: blocks.remove(0).data,
+                uncompressed_size: u32::try_from(payload.len()).expect("fits u32"),
+            }
+        })
+        .collect();
+
+    let collected: Arc<Mutex<Vec<DecodedRecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(blocks))
+        .chain(BgzfDecompress::new(EDGE_LIMIT_BYTES))
+        .chain(FindBamBoundaries::new_no_header(EDGE_LIMIT_BYTES))
+        .chain(DecodeRecords::new(GroupKeyConfig::default(), EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let batches = collected.lock().expect("mutex not poisoned");
+    let seen: Vec<&[u8]> = batches
+        .iter()
+        .flat_map(|batch| batch.records().iter().map(fgumi_bam_io::DecodedRecord::raw_bytes))
+        .collect();
+    let expected: Vec<&[u8]> = records.iter().map(AsRef::as_ref).collect();
+    assert_eq!(seen, expected, "no-header mode must treat byte 0 as a record boundary");
+}
+
+/// `… → ParseBamRecords → DecodeFromRecords` is the runall fusion shape: parse
+/// once into shared-buffer batches, then re-attach group keys downstream
+/// instead of re-serializing. It must yield the same records, in the same
+/// order, as the fused `DecodeRecords` chain above.
+#[rstest]
+fn decode_from_records_chain_matches_the_fused_decode_chain(#[values(1, 4)] threads: usize) {
+    let records = test_records(120);
+
+    let collect_via = |use_split: bool| -> Vec<Vec<u8>> {
+        let blocks = bgzf_blocks_for(&records, 4096);
+        let collected: Arc<Mutex<Vec<DecodedRecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_handle = Arc::clone(&collected);
+        let builder = Pipeline::builder();
+        let head = builder
+            .chain(ReplaySource::new(blocks))
+            .chain(BgzfDecompress::new(EDGE_LIMIT_BYTES))
+            .chain(FindBamBoundaries::new(EDGE_LIMIT_BYTES));
+        if use_split {
+            head.chain(ParseBamRecords::new(EDGE_LIMIT_BYTES))
+                .chain(DecodeFromRecords::new(GroupKeyConfig::default(), EDGE_LIMIT_BYTES))
+                .chain(CollectSink { collected: sink_handle })
+                .into_sink_marker();
+        } else {
+            head.chain(DecodeRecords::new(GroupKeyConfig::default(), EDGE_LIMIT_BYTES))
+                .chain(CollectSink { collected: sink_handle })
+                .into_sink_marker();
+        }
+        let pipeline = builder.build().expect("chain builds");
+        pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+        let batches = collected.lock().expect("mutex not poisoned");
+        batches
+            .iter()
+            .flat_map(|batch| batch.records().iter().map(|r| r.raw_bytes().to_vec()))
+            .collect()
+    };
+
+    let expected: Vec<Vec<u8>> = records.iter().map(|r| r.as_ref().to_vec()).collect();
+    assert_eq!(collect_via(false), expected, "fused decode chain must round-trip records");
+    assert_eq!(collect_via(true), expected, "split parse+decode chain must agree with it");
+}
+
+/// `ReplaySource → ParseSamChunk` covers the SAM ingest path, whose records
+/// converge on the same `DecodedRecordBatch` the BAM chain produces. Driving it
+/// through the framework (rather than calling `parse_sam_chunk_into_decoded`
+/// directly) is what exercises the step's drain and held-item handling.
+#[rstest]
+fn sam_chain_decodes_every_line_in_order(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::parse::sam::ParseSamChunk;
+    use crate::pipeline::steps::types::SamChunk;
+
+    const HEADER_TEXT: &str = "@HD\tVN:1.6\tSO:unsorted\n@SQ\tSN:chr1\tLN:100000\n";
+    let header = {
+        let mut reader = noodles::sam::io::Reader::new(HEADER_TEXT.as_bytes());
+        Arc::new(reader.read_header().expect("header parses"))
+    };
+
+    // One chunk per record keeps the ordinal stream long enough that the
+    // byte-bounded edge rejects pushes and the retry path is taken.
+    let n_records = 200usize;
+    let chunks: Vec<SamChunk> = (0..n_records)
+        .map(|i| {
+            let line = format!("read{i}\t0\tchr1\t{}\t60\t4M\t*\t0\t0\tACGT\tIIII\n", 100 + i);
+            let bytes = line.into_bytes();
+            let line_offsets = vec![0u32, u32::try_from(bytes.len()).expect("fits u32")];
+            SamChunk { batch_serial: i as u64, bytes, line_offsets }
+        })
+        .collect();
+
+    let key_config =
+        GroupKeyConfig::new_raw_no_cell(fgumi_bam_io::LibraryIndex::from_header(&header));
+    let collected: Arc<Mutex<Vec<DecodedRecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(chunks))
+        .chain(ParseSamChunk::new(Arc::clone(&header), key_config, EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let batches = collected.lock().expect("mutex not poisoned");
+    let names: Vec<Vec<u8>> = batches
+        .iter()
+        .flat_map(DecodedRecordBatch::records)
+        .map(|record| {
+            let body = record.raw_bytes();
+            let l_read_name = body[8] as usize;
+            body[32..32 + l_read_name - 1].to_vec()
+        })
+        .collect();
+    let expected: Vec<Vec<u8>> = (0..n_records).map(|i| format!("read{i}").into_bytes()).collect();
+    assert_eq!(names, expected, "SAM lines must decode in order, one record per line");
+}
+
+/// A stream that ends mid-record must fail the run, not silently drop the
+/// truncated tail. `FindBamBoundaries` carries the partial record forward, and
+/// at drain its EOF validation rejects it — so the error surfaces through
+/// `Pipeline::run` rather than showing up as quietly missing records.
+#[rstest]
+fn a_truncated_record_stream_fails_the_run(#[values(1, 4)] threads: usize) {
+    let records = test_records(32);
+    let mut stream = minimal_binary_bam_header(1);
+    for record in &records {
+        let bytes = record.as_ref();
+        stream.extend_from_slice(&u32::try_from(bytes.len()).expect("fits u32").to_le_bytes());
+        stream.extend_from_slice(bytes);
+    }
+    // Chop the final record in half — a `block_size` prefix promising bytes
+    // that never arrive.
+    stream.truncate(stream.len() - 20);
+
+    let blocks: Vec<BgzfBlock> = stream
+        .chunks(1024)
+        .enumerate()
+        .map(|(i, payload)| {
+            let mut compressor = fgumi_bgzf::InlineBgzfCompressor::new(1);
+            compressor.write_all(payload).expect("compress");
+            compressor.flush().expect("flush");
+            let mut blocks = compressor.take_blocks();
+            assert_eq!(blocks.len(), 1);
+            BgzfBlock {
+                batch_serial: i as u64,
+                bytes: blocks.remove(0).data,
+                uncompressed_size: u32::try_from(payload.len()).expect("fits u32"),
+            }
+        })
+        .collect();
+
+    let collected: Arc<Mutex<Vec<DecodedRecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(blocks))
+        .chain(BgzfDecompress::new(EDGE_LIMIT_BYTES))
+        .chain(FindBamBoundaries::new(EDGE_LIMIT_BYTES))
+        .chain(DecodeRecords::new(GroupKeyConfig::default(), EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: Arc::clone(&collected) })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+
+    let err = pipeline
+        .run(PipelineConfig { threads, ..Default::default() })
+        .expect_err("a truncated record stream must fail the run");
+    match err {
+        crate::pipeline::core::signal::PipelineError::Io { step, source } => {
+            assert_eq!(step, "FindBamBoundaries", "the boundary scanner owns EOF validation");
+            assert_eq!(source.kind(), io::ErrorKind::UnexpectedEof);
+        }
+        other => panic!("expected an I/O failure from the boundary step, got {other:?}"),
+    }
+}
+
+/// `ReplaySource → TemplatesToRecordBatch` is the AAM-fusion adapter: it turns
+/// the queryname-template view back into the flat-record view the sort ingest
+/// consumes. Driving it through `Pipeline::run` (rather than re-running its
+/// flattening loop in a unit test) is what exercises `try_run` itself — the
+/// held-slot retry, the drain path, and the last-clone `Finished` gate that a
+/// `Parallel` step only reaches under the framework.
+///
+/// Every record of every template must arrive downstream exactly once,
+/// byte-for-byte, in template order, in a batch carrying the input batch's
+/// serial — *including* the secondary and supplementary alignments.
+#[rstest]
+fn templates_to_records_flattens_every_record_including_split_alignments(
+    #[values(1, 4)] threads: usize,
+) {
+    use crate::pipeline::steps::templates_to_records::TemplatesToRecordBatch;
+    use crate::pipeline::steps::types::BamTemplateBatch;
+
+    const N_BATCHES: u64 = 200;
+    const TEMPLATES_PER_BATCH: usize = 2;
+    const RECORDS_PER_TEMPLATE: usize = 4;
+
+    // Record each template's records in `records` order — the order the step is
+    // contracted to emit. Reading that off the template rather than hard-coding
+    // r1/r2/supplementary/secondary keeps this a test of the flattening step,
+    // not of `Template::from_records`' internal layout.
+    let mut expected: Vec<Vec<u8>> = Vec::new();
+    let mut batches: Vec<BamTemplateBatch> = Vec::new();
+    for serial in 0..N_BATCHES {
+        let templates: Vec<Template> = (0..TEMPLATES_PER_BATCH)
+            .map(|t| split_alignment_template(format!("q{serial}_{t}").as_bytes()))
+            .collect();
+        for template in &templates {
+            expected.extend(template.records.iter().map(|r| r.as_ref().to_vec()));
+        }
+        batches.push(BamTemplateBatch::new(serial, templates));
+    }
+
+    // Same guard as `the_edge_budget_binds_on_the_multi_record_fixtures`: unless
+    // the fixture volume exceeds the per-edge budget the output queue never
+    // rejects a push, and the step's held-slot retry path — the whole reason for
+    // running this through the framework — goes unexercised.
+    let fixture_bytes: usize = batches.iter().map(BamTemplateBatch::total_bytes).sum();
+    assert!(
+        u64::try_from(fixture_bytes).expect("fixture volume fits u64") > EDGE_LIMIT_BYTES,
+        "fixture volume ({fixture_bytes} B) must exceed the per-edge budget \
+         ({EDGE_LIMIT_BYTES} B), else the held-slot retry path never runs",
+    );
+
+    let collected: Arc<Mutex<Vec<RecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(batches))
+        .chain(TemplatesToRecordBatch::new(EDGE_LIMIT_BYTES))
+        .chain(StallingCollectSink {
+            collected: sink_handle,
+            remaining_stalls: PROCESS_SINK_STALLS,
+        })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let emitted = collected.lock().expect("mutex not poisoned");
+
+    // One output batch per input batch, each carrying its input's serial, in
+    // ordinal order — the contract `BranchOrdering::ByItemOrdinal` consumers
+    // downstream depend on.
+    let serials: Vec<u64> = emitted.iter().map(RecordBatch::batch_serial).collect();
+    assert_eq!(
+        serials,
+        (0..N_BATCHES).collect::<Vec<u64>>(),
+        "each input batch must yield one output batch carrying its serial, in order",
+    );
+
+    // Batch boundaries are preserved 1:1 — the step neither splits an input
+    // batch across outputs nor coalesces several into one. Reported as the first
+    // offending batch rather than an `assert_eq!` over the whole vector, which
+    // would dump 200 elements to name a single bad one.
+    let expected_per_batch = TEMPLATES_PER_BATCH * RECORDS_PER_TEMPLATE;
+    if let Some((i, n)) =
+        emitted.iter().map(RecordBatch::len).enumerate().find(|&(_, n)| n != expected_per_batch)
+    {
+        panic!(
+            "output batch {i} holds {n} records, expected {expected_per_batch} — \
+             every output batch must hold exactly its input batch's records",
+        );
+    }
+
+    let seen: Vec<Vec<u8>> =
+        emitted.iter().flat_map(|batch| batch.iter_record_bytes().map(<[u8]>::to_vec)).collect();
+    assert_eq!(
+        seen.len(),
+        expected.len(),
+        "every record — primary, supplementary, and secondary — must be emitted exactly once",
+    );
+    // Likewise pinpointed: a whole-vector compare of ~1,600 records would print
+    // the entire fixture to report one differing byte.
+    if let Some((i, (got, want))) =
+        seen.iter().zip(&expected).enumerate().find(|(_, (got, want))| got != want)
+    {
+        panic!("record {i} was altered in flight: got {got:02x?}, expected {want:02x?}");
+    }
+}
+
+/// `ReplaySource → GroupByMi` drives the MI grouper through the framework.
+///
+/// Its unit tests all call `process_record` / `flush_current_group` directly,
+/// which leaves `try_run` — where the ordinals are minted, the held slot is
+/// retried, and drain is sequenced — entirely unexercised. Each of those fails
+/// by *silently truncating* output rather than erroring, so nothing downstream
+/// would notice:
+///
+/// * **Ordinal contiguity.** `GroupByMi` mints its own batch serials, and the
+///   `ByItemOrdinal` reorder stage releases only in contiguous order — a
+///   skipped or reused serial stalls it forever.
+/// * **Held-slot retry.** `output_byte_limit` is deliberately smaller than one
+///   emitted batch, and the sink stalls long enough for the queue to fill, so
+///   pushes bounce and `emit_batch` parks the batch in `held`. The retry must
+///   not mint a second ordinal for it. Both halves are needed: with a sink that
+///   drains every tick the queue empties between pushes and this path is never
+///   taken at all (verified by injecting a double-ordinal bug, which a
+///   non-stalling sink failed to catch at one thread).
+/// * **Drain sequencing.** The molecule count is not a multiple of the target
+///   batch count, so the run-in-progress must be flushed and emitted as a final
+///   partial batch *before* `Finished`.
+#[rstest]
+fn group_by_mi_emits_contiguous_batches_ending_in_a_partial(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::group::mi::{BatchedMiGroups, GroupByMi};
+
+    const N_MOLECULES: usize = 337;
+    const RECORDS_PER_MOLECULE: usize = 3;
+    const TARGET_BATCH_COUNT: usize = 10;
+    // Deliberately coprime with `RECORDS_PER_MOLECULE` so molecule runs straddle
+    // input-batch boundaries — the run-length state must survive across calls.
+    const RECORDS_PER_INPUT_BATCH: usize = 7;
+    // Smaller than one emitted batch, so the second push always bounces.
+    const OUTPUT_BYTE_LIMIT: u64 = 1024;
+    // Long enough for the grouper to emit and then bounce against a full queue,
+    // but no longer: each stall costs the driver a back-off interval, so a
+    // larger count buys nothing and adds seconds to the multi-threaded case.
+    // Calibrated by injecting the double-ordinal bug and finding the smallest
+    // count the single-threaded case still catches it at (16), then leaving a
+    // margin for scheduling variance. At 8 the bug slips through.
+    const SINK_STALLS: usize = 24;
+
+    assert_ne!(
+        N_MOLECULES % TARGET_BATCH_COUNT,
+        0,
+        "the fixture must leave a partial final batch, else the drain arm is untested",
+    );
+
+    let records: Vec<RawRecord> = (0..N_MOLECULES)
+        .flat_map(|m| (0..RECORDS_PER_MOLECULE).map(move |_| mi_record(&format!("mol{m}"))))
+        .collect();
+    let batches: Vec<DecodedRecordBatch> = records
+        .chunks(RECORDS_PER_INPUT_BATCH)
+        .enumerate()
+        .map(|(i, chunk)| decoded_batch(i as u64, chunk.to_vec()))
+        .collect();
+
+    let collected: Arc<Mutex<Vec<BatchedMiGroups>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(batches))
+        .chain(GroupByMi::with_target_batch_count(
+            *crate::sam::SamTag::MI,
+            OUTPUT_BYTE_LIMIT,
+            TARGET_BATCH_COUNT,
+        ))
+        .chain(StallingCollectSink { collected: sink_handle, remaining_stalls: SINK_STALLS })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let emitted = collected.lock().expect("mutex not poisoned");
+
+    // Several batches, or the contiguity claim below is vacuous.
+    assert!(
+        emitted.len() > 1,
+        "fixture must span several output batches, got {}; the ordinal contiguity and \
+         held-slot paths only run when more than one batch is emitted",
+        emitted.len(),
+    );
+
+    // The load-bearing assertion: serials are dense and start at zero. A held
+    // batch that minted a second ordinal on retry, or a dropped emit, shows up
+    // here as a gap or a duplicate.
+    let serials: Vec<u64> = emitted.iter().map(|b| b.batch_serial).collect();
+    assert_eq!(
+        serials,
+        (0..emitted.len() as u64).collect::<Vec<u64>>(),
+        "emitted batch serials must be contiguous from zero",
+    );
+
+    // No batch is emitted empty — an empty emit would burn an ordinal for
+    // nothing, which the drain arm's `!accumulator.is_empty()` guard prevents.
+    assert!(emitted.iter().all(|b| !b.groups.is_empty()), "no batch may be emitted empty");
+
+    // Every molecule arrives exactly once, in order, with all its records.
+    let groups: Vec<(String, usize)> =
+        emitted.iter().flat_map(|b| &b.groups).map(|g| (g.mi.clone(), g.records.len())).collect();
+    let expected: Vec<(String, usize)> =
+        (0..N_MOLECULES).map(|m| (format!("mol{m}"), RECORDS_PER_MOLECULE)).collect();
+    assert_eq!(
+        groups.len(),
+        expected.len(),
+        "every molecule must be emitted exactly once — a truncated tail means the drain \
+         arm dropped the final partial batch",
+    );
+    if let Some((i, (got, want))) =
+        groups.iter().zip(&expected).enumerate().find(|(_, (got, want))| got != want)
+    {
+        panic!("group {i} differs: got {got:?}, expected {want:?}");
+    }
+
+    // The batch cap: no emitted batch may exceed the target, even though one
+    // `add_records` call can complete more groups than that. Without this, a
+    // regression that let the accumulator grow past the cap before emitting
+    // would keep serials dense, keep every molecule present, and still leave a
+    // short final batch — passing every other assertion here.
+    if let Some((i, n)) =
+        emitted.iter().map(|b| b.groups.len()).enumerate().find(|&(_, n)| n > TARGET_BATCH_COUNT)
+    {
+        panic!("batch {i} holds {n} groups, above the {TARGET_BATCH_COUNT} cap");
+    }
+
+    // The last batch is the partial one the drain arm flushed.
+    let last = emitted.last().expect("at least one batch");
+    assert!(
+        last.groups.len() < TARGET_BATCH_COUNT,
+        "the final batch must be the short one emitted at drain, got {} groups",
+        last.groups.len(),
+    );
+}
+
+/// Records with no usable MI tag must be dropped without disturbing the
+/// grouping of the records around them, and the chain must still reach the
+/// drain arm — which is where the skipped-record warnings are reported.
+///
+/// The counters themselves are unit-tested; what only the framework reaches is
+/// `try_run`'s drain arm calling `report_skipped_records` and *still* returning
+/// `Finished`. A regression that returned early there would hang the chain
+/// rather than truncate it.
+#[rstest]
+fn group_by_mi_drops_untagged_records_and_still_completes(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::group::mi::{BatchedMiGroups, GroupByMi};
+
+    // Untagged and integer-MI records are interleaved *inside* a molecule run,
+    // so a regression that reset the run on a skip would split "mol0" in two.
+    let records = [
+        record_without_mi(),
+        mi_record("mol0"),
+        record_with_integer_mi(1),
+        mi_record("mol0"),
+        record_without_mi(),
+        mi_record("mol1"),
+        record_with_integer_mi(2),
+    ];
+    let batches: Vec<DecodedRecordBatch> = records
+        .chunks(2)
+        .enumerate()
+        .map(|(i, chunk)| decoded_batch(i as u64, chunk.to_vec()))
+        .collect();
+
+    let collected: Arc<Mutex<Vec<BatchedMiGroups>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(batches))
+        .chain(GroupByMi::new(*crate::sam::SamTag::MI, EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let emitted = collected.lock().expect("mutex not poisoned");
+    let groups: Vec<(String, usize)> =
+        emitted.iter().flat_map(|b| &b.groups).map(|g| (g.mi.clone(), g.records.len())).collect();
+    assert_eq!(
+        groups,
+        vec![("mol0".to_string(), 2), ("mol1".to_string(), 1)],
+        "untagged and wrong-typed records must be dropped without splitting the runs \
+         they sit inside",
+    );
+}
+
+/// A trivial ordered item: `ordinal` is its place in a branch's sequence,
+/// `value` identifies which input produced it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Numbered {
+    ordinal: u64,
+    value: u64,
+}
+
+/// A deliberately non-zero weight. `HeapSize`'s default returns 0, and a
+/// zero-weight item can never fill a `ByteBounded` queue — `current_bytes`
+/// stays at 0, every push is admitted, and the held-slot retry arms of every
+/// byte-bounded step below become unreachable. Giving the item a weight is what
+/// lets a small `limit_bytes` actually bind.
+impl HeapSize for Numbered {
+    fn heap_size(&self) -> usize {
+        128
+    }
+}
+
+impl Ordered for Numbered {
+    fn ordinal(&self) -> u64 {
+        self.ordinal
+    }
+}
+
+/// Returning `None` for a branch of a [`Process2Ordered`] must not stall the
+/// chain **when that branch mints its own dense, branch-local ordinals**.
+///
+/// This is the safe half of the contract documented on `Process2Output`. The
+/// unsafe half — a branch that propagates the *input's* ordinal and then omits
+/// an item — leaves a permanent hole, and the `ByItemOrdinal` reorder stage
+/// releases only in contiguous order, so it waits for an ordinal that will
+/// never arrive. That failure mode is a **hang**, which is precisely why it is
+/// not reproduced here: a test that builds the wedged configuration on purpose
+/// can only assert "still not finished after N seconds", which is slow, and
+/// proves a timeout rather than the contract. Asserting the safe direction
+/// positively pins the same rule without ever constructing the stall.
+///
+/// Note the test is still hang-*sensitive*, just not hang-*dependent*: if a
+/// regression made sparse output wedge this chain, the run would never return
+/// and nextest would kill it at its slow-test timeout. It fails either way —
+/// it just does not need the stall to pass.
+#[rstest]
+fn sparse_ordered_fan_out_completes_when_each_branch_mints_its_own_ordinals(
+    #[values(1, 4)] threads: usize,
+) {
+    use crate::pipeline::steps::process::{Process2Output, process2_ordered};
+
+    const N_INPUTS: u64 = 300;
+    // Every third input goes to B, the rest to A — so *both* branches see
+    // `None` for a substantial share of the inputs.
+    const B_EVERY: u64 = 3;
+
+    let inputs: Vec<Numbered> = (0..N_INPUTS).map(|i| Numbered { ordinal: i, value: i }).collect();
+
+    // Branch-local ordinal counters. Shared across worker clones (the closure is
+    // `Fn` behind an `Arc`), so at four threads the *assignment* of ordinals to
+    // values races — but the sequence each branch mints stays dense, which is
+    // the property the reorder stage actually requires.
+    let next_a = Arc::new(AtomicU64::new(0));
+    let next_b = Arc::new(AtomicU64::new(0));
+    let (mint_a, mint_b) = (Arc::clone(&next_a), Arc::clone(&next_b));
+
+    let collected_a: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let collected_b: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let (sink_a, sink_b) = (Arc::clone(&collected_a), Arc::clone(&collected_b));
+
+    let builder = Pipeline::builder();
+    let multi = builder
+        .chain(ReplaySource::new(inputs))
+        .chain(process2_ordered(
+            "SparseFanOut",
+            EDGE_LIMIT_BYTES,
+            EDGE_LIMIT_BYTES,
+            move |item: Numbered| {
+                if item.value.is_multiple_of(B_EVERY) {
+                    let ordinal = mint_b.fetch_add(1, AtomicOrdering::Relaxed);
+                    Ok(Process2Output::only_b(Numbered { ordinal, value: item.value }))
+                } else {
+                    let ordinal = mint_a.fetch_add(1, AtomicOrdering::Relaxed);
+                    Ok(Process2Output::only_a(Numbered { ordinal, value: item.value }))
+                }
+            },
+        ))
+        .into_multi();
+    multi.b0.chain(CollectSink { collected: sink_a }).into_sink_marker();
+    multi.b1.chain(CollectSink { collected: sink_b }).into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let branch_a = collected_a.lock().expect("mutex not poisoned");
+    let branch_b = collected_b.lock().expect("mutex not poisoned");
+
+    // Both branches must have skipped some inputs, or "sparse" is vacuous and
+    // this degenerates into an ordinary every-item fan-out test.
+    assert!(!branch_a.is_empty() && !branch_b.is_empty(), "both branches must receive items");
+    assert_eq!(
+        branch_a.len() as u64 + branch_b.len() as u64,
+        N_INPUTS,
+        "every input must reach exactly one branch",
+    );
+
+    // The load-bearing assertion: each branch released a dense sequence from
+    // zero, in order. A hole would have stalled the reorder stage instead.
+    for (name, branch) in [("a", &*branch_a), ("b", &*branch_b)] {
+        let ordinals: Vec<u64> = branch.iter().map(|n| n.ordinal).collect();
+        assert_eq!(
+            ordinals,
+            (0..branch.len() as u64).collect::<Vec<u64>>(),
+            "branch {name} must release a dense ordinal sequence from zero",
+        );
+    }
+
+    // Nothing was routed to the wrong branch, dropped, or duplicated. Sorted
+    // because ordinal assignment races across workers at four threads.
+    let mut values_a: Vec<u64> = branch_a.iter().map(|n| n.value).collect();
+    let mut values_b: Vec<u64> = branch_b.iter().map(|n| n.value).collect();
+    values_a.sort_unstable();
+    values_b.sort_unstable();
+    assert_eq!(
+        values_a,
+        (0..N_INPUTS).filter(|v| !v.is_multiple_of(B_EVERY)).collect::<Vec<u64>>()
+    );
+    assert_eq!(values_b, (0..N_INPUTS).filter(|v| v.is_multiple_of(B_EVERY)).collect::<Vec<u64>>());
+}
+
+/// A single-end primary record with the given queryname.
+fn single_end_record(qname: &[u8]) -> RawRecord {
+    let mut b = SamBuilder::new();
+    b.read_name(qname)
+        .flags(0)
+        .ref_id(0)
+        .pos(100)
+        .cigar_ops(&[4u32 << 4])
+        .sequence(b"ACGT")
+        .qualities(&[30u8; 4]);
+    b.build()
+}
+
+/// Wrap raw records in a [`DecodedRecordBatch`], pairing each with an explicit
+/// [`GroupKey`]. Position and queryname grouping both key off the pre-computed
+/// key rather than re-parsing the record, so the key is the fixture.
+fn decoded_batch_with_keys(
+    batch_serial: u64,
+    records: Vec<(RawRecord, fgumi_bam_io::GroupKey)>,
+) -> DecodedRecordBatch {
+    DecodedRecordBatch::new(
+        batch_serial,
+        records
+            .into_iter()
+            .map(|(raw, key)| fgumi_bam_io::DecodedRecord::from_raw_bytes(raw, key))
+            .collect(),
+    )
+}
+
+/// A single-end position key at `pos` — `strand2` stays `UNKNOWN_STRAND`, so
+/// `has_mate_position()` is false and the grouper's MC-tag validation (which
+/// only applies to *paired* primaries) is not triggered.
+fn position_key_at(pos: i32) -> fgumi_bam_io::GroupKey {
+    fgumi_bam_io::GroupKey { ref_id1: 0, pos1: pos, strand1: 0, ..Default::default() }
+}
+
+/// Hash a queryname the way the decode step would, so `GroupByQueryname`'s
+/// `name_hash` fast-path pre-check is exercised rather than short-circuited by
+/// a constant hash.
+///
+/// This routes through `LibraryIndex::hash_name`, the exact hasher
+/// `compute_group_key_from_raw` uses to fill `GroupKey::name_hash` on the decode
+/// path (an empty name maps to `hash_name(None)`), so a key built here is
+/// byte-for-byte comparable to one the grouper computes rather than merely
+/// self-consistent.
+fn name_hash_of(qname: &[u8]) -> u64 {
+    let name = if qname.is_empty() { None } else { Some(qname) };
+    fgumi_bam_io::LibraryIndex::hash_name(name)
+}
+
+/// Split a `DecompressedBlock` byte stream — framed `block_size` + body per
+/// record — back into record bodies, asserting the framing is well-formed.
+///
+/// The framing is half of what `SerializeGroups` produces, so parsing it back
+/// rather than comparing opaque bytes is what makes a truncated or
+/// wrongly-sized prefix fail loudly here instead of much further downstream.
+fn unframe_records(bytes: &[u8]) -> Vec<Vec<u8>> {
+    let mut out = Vec::new();
+    let mut pos = 0usize;
+    while pos < bytes.len() {
+        assert!(pos + 4 <= bytes.len(), "truncated block_size prefix at byte {pos}");
+        let len = u32::from_le_bytes(bytes[pos..pos + 4].try_into().expect("4 bytes")) as usize;
+        pos += 4;
+        assert!(pos + len <= bytes.len(), "block_size {len} at byte {pos} runs past the stream");
+        out.push(bytes[pos..pos + len].to_vec());
+        pos += len;
+    }
+    out
+}
+
+/// One `ProcessedPositionGroup` holding `n_templates` paired templates, each
+/// tagged with the molecule id `mi` (use [`MoleculeId::None`] for the
+/// pass-through path, which must emit the record bytes unchanged).
+fn processed_group(
+    qname_prefix: &str,
+    n_templates: usize,
+    mi: fgumi_umi::MoleculeId,
+) -> ProcessedPositionGroup {
+    let templates: Vec<Template> = (0..n_templates)
+        .map(|t| {
+            let mut template = split_alignment_template(format!("{qname_prefix}_{t}").as_bytes());
+            template.mi = mi;
+            template
+        })
+        .collect();
+    let input_record_count = templates.iter().map(|t| t.records.len() as u64).sum();
+    ProcessedPositionGroup {
+        templates,
+        family_sizes: ahash::AHashMap::new(),
+        filter_counts: fgumi_metrics::TemplateFilterCounts::default(),
+        input_record_count,
+        distinct_mi_count: u64::from(mi.id().is_some()),
+    }
+}
+
+/// `ReplaySource → SerializeGroups` covers `build_serialize_processed_groups_step`,
+/// which had no test at all.
+///
+/// The step does two things in one pass — rewrite the MI tag into each record's
+/// body, and frame each body with its BAM `block_size` prefix — and both are
+/// asserted here by parsing the emitted stream back apart.
+///
+/// The MI half matters beyond line coverage: `emit_templates_raw_with_mi` is
+/// deliberately shared with the single-threaded writer in `commands::group`
+/// precisely so the two cannot drift in MI-injection semantics. Nothing was
+/// pinning that shared behavior, so a change to it would have been invisible
+/// on both paths.
+///
+/// Both branches of the emit are exercised: templates with an assigned
+/// `MoleculeId` get `MI:Z:<id>` written into their records, while templates
+/// left at `MoleculeId::None` must pass through byte-for-byte untouched.
+///
+/// Note what the fixture pins about *which* records are emitted. The templates
+/// here carry four records each — primary R1 and R2 plus a supplementary and a
+/// secondary — and the step emits **only the two primaries**, because
+/// `emit_templates_raw_with_mi` iterates `[template.r1(), template.r2()]`. That
+/// matches its doc ("primary reads") and is asserted rather than worked around:
+/// it is a real output-shaping decision, and a change that started emitting
+/// split alignments would otherwise slip through silently.
+#[rstest]
+fn serialize_processed_groups_frames_every_record_and_injects_mi(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::serialize_processed::build_serialize_processed_groups_step;
+    use crate::pipeline::steps::types::DecompressedBlock;
+    use fgumi_umi::MoleculeId;
+
+    const N_BATCHES: u64 = 40;
+    const TEMPLATES_PER_GROUP: usize = 2;
+    // Records per template that the step *emits* (the two primaries). The
+    // fixture holds four; the progress counter instead totals every *input*
+    // record, which is why it has its own constant.
+    const EMITTED_PER_TEMPLATE: usize = 2;
+    const INPUT_RECORDS_PER_TEMPLATE: usize = 4;
+    // Two groups per batch: one MI-assigned, one left unassigned, so both emit
+    // branches run for every batch.
+    const GROUPS_PER_BATCH: usize = 2;
+
+    let mut expected: Vec<(Vec<u8>, Option<String>)> = Vec::new();
+    let mut batches: Vec<BatchedProcessedPositionGroups> = Vec::new();
+    for serial in 0..N_BATCHES {
+        let assigned = processed_group(
+            &format!("mi{serial}"),
+            TEMPLATES_PER_GROUP,
+            MoleculeId::Single(serial),
+        );
+        let untouched =
+            processed_group(&format!("raw{serial}"), TEMPLATES_PER_GROUP, MoleculeId::None);
+        for group in [&assigned, &untouched] {
+            for template in &group.templates {
+                let label = template.mi.id().map(|id| id.to_string());
+                // ONLY the primary R1/R2 — see the note on the test.
+                for raw in [template.r1(), template.r2()].into_iter().flatten() {
+                    expected.push((raw.to_vec(), label.clone()));
+                }
+            }
+        }
+        batches.push(BatchedProcessedPositionGroups::new(serial, vec![assigned, untouched]));
+    }
+
+    let collected: Arc<Mutex<Vec<DecompressedBlock>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let progress = Arc::new(AtomicU64::new(0));
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(batches))
+        .chain(build_serialize_processed_groups_step(
+            EDGE_LIMIT_BYTES,
+            *crate::sam::SamTag::MI,
+            Arc::clone(&progress),
+        ))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let emitted = collected.lock().expect("mutex not poisoned");
+
+    let serials: Vec<u64> = emitted.iter().map(|b| b.batch_serial).collect();
+    assert_eq!(
+        serials,
+        (0..N_BATCHES).collect::<Vec<u64>>(),
+        "each input batch must yield one block carrying its serial, in order",
+    );
+
+    // The progress counter is bumped with each batch's *input record* count.
+    let expected_records =
+        N_BATCHES * (GROUPS_PER_BATCH * TEMPLATES_PER_GROUP * INPUT_RECORDS_PER_TEMPLATE) as u64;
+    assert_eq!(
+        progress.load(AtomicOrdering::Relaxed),
+        expected_records,
+        "the shared progress counter must total every input record",
+    );
+
+    let bodies: Vec<Vec<u8>> =
+        emitted.iter().flat_map(|block| unframe_records(&block.bytes)).collect();
+    assert_eq!(
+        bodies.len(),
+        expected.len(),
+        "every primary record must be framed and emitted exactly once",
+    );
+    // Stated as its own arithmetic so the primaries-only contract is visible
+    // rather than implied by the length of `expected`.
+    assert_eq!(
+        bodies.len() as u64,
+        N_BATCHES * (GROUPS_PER_BATCH * TEMPLATES_PER_GROUP * EMITTED_PER_TEMPLATE) as u64,
+        "the step emits primaries only — supplementary and secondary records are excluded",
+    );
+    assert!(
+        bodies.iter().all(|b| {
+            let flags = u16::from_le_bytes([b[14], b[15]]);
+            flags & (fgumi_raw_bam::flags::SECONDARY | fgumi_raw_bam::flags::SUPPLEMENTARY) == 0
+        }),
+        "no emitted record may carry the secondary or supplementary flag",
+    );
+
+    for (i, (body, (original, want_mi))) in bodies.iter().zip(&expected).enumerate() {
+        let got_mi = fgumi_raw_bam::find_string_tag_in_record(body, *crate::sam::SamTag::MI)
+            .map(|v| String::from_utf8_lossy(v).into_owned());
+        assert_eq!(got_mi.as_deref(), want_mi.as_deref(), "record {i}: MI tag");
+        if want_mi.is_none() {
+            assert_eq!(
+                body, original,
+                "record {i}: an unassigned template must pass through byte-for-byte",
+            );
+        }
+    }
+}
+
+/// `ReplaySource → GroupByPosition` drives the position grouper through the
+/// framework. Like the MI grouper, its unit tests exercise helpers directly and
+/// leave `try_run`/`emit_batch` — the ordinal minting, the batch cap, and the
+/// `finish()`-once drain path — unrun.
+///
+/// Positions arrive in runs, so a group closes only when the position changes;
+/// the last run has no successor and can only be emitted by the drain arm
+/// calling the (non-idempotent) `grouper.finish()`, guarded by `finalized`.
+#[rstest]
+fn group_by_position_emits_contiguous_batches_ending_in_a_partial(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::group::position::{BatchedRawPositionGroups, GroupByPosition};
+
+    const N_POSITIONS: usize = 205;
+    const RECORDS_PER_POSITION: usize = 3;
+    const TARGET_BATCH_COUNT: usize = 8;
+    const RECORDS_PER_INPUT_BATCH: usize = 7;
+    const OUTPUT_BYTE_LIMIT: u64 = 1024;
+    const SINK_STALLS: usize = 24;
+
+    assert_ne!(
+        N_POSITIONS % TARGET_BATCH_COUNT,
+        0,
+        "the fixture must leave a partial final batch, else the drain arm is untested",
+    );
+
+    let records: Vec<(RawRecord, fgumi_bam_io::GroupKey)> = (0..N_POSITIONS)
+        .flat_map(|p| {
+            let key = position_key_at(i32::try_from(100 + p * 10).expect("pos fits i32"));
+            (0..RECORDS_PER_POSITION)
+                .map(move |r| (single_end_record(format!("p{p}_{r}").as_bytes()), key))
+        })
+        .collect();
+    let batches: Vec<DecodedRecordBatch> = records
+        .chunks(RECORDS_PER_INPUT_BATCH)
+        .enumerate()
+        .map(|(i, chunk)| decoded_batch_with_keys(i as u64, chunk.to_vec()))
+        .collect();
+
+    let collected: Arc<Mutex<Vec<BatchedRawPositionGroups>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(batches))
+        .chain(GroupByPosition::with_target_batch_count(OUTPUT_BYTE_LIMIT, TARGET_BATCH_COUNT))
+        .chain(StallingCollectSink { collected: sink_handle, remaining_stalls: SINK_STALLS })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let emitted = collected.lock().expect("mutex not poisoned");
+    assert!(emitted.len() > 1, "fixture must span several output batches");
+
+    let serials: Vec<u64> = emitted.iter().map(|b| b.batch_serial).collect();
+    assert_eq!(
+        serials,
+        (0..emitted.len() as u64).collect::<Vec<u64>>(),
+        "emitted batch serials must be contiguous from zero",
+    );
+    assert!(emitted.iter().all(|b| !b.groups.is_empty()), "no batch may be emitted empty");
+
+    // The batch cap: no emitted batch may exceed the target, even though one
+    // `add_records` call can complete more groups than that.
+    if let Some((i, n)) =
+        emitted.iter().map(|b| b.groups.len()).enumerate().find(|&(_, n)| n > TARGET_BATCH_COUNT)
+    {
+        panic!("batch {i} holds {n} groups, above the {TARGET_BATCH_COUNT} cap");
+    }
+
+    let sizes: Vec<usize> =
+        emitted.iter().flat_map(|b| &b.groups).map(|g| g.records.len()).collect();
+    assert_eq!(
+        sizes.len(),
+        N_POSITIONS,
+        "every position must be emitted exactly once — a short count means the drain arm \
+         dropped the final run that only `finish()` can close",
+    );
+    assert!(
+        sizes.iter().all(|&n| n == RECORDS_PER_POSITION),
+        "every position group must hold all of its records",
+    );
+}
+
+/// The default grouper drops secondary/supplementary records — they decode to
+/// an `UNKNOWN_REF` position key and have no position of their own — while
+/// `GroupByPosition::with_secondary_supplementary` keeps them, which is what
+/// `fgumi dedup` needs so the duplicate flag propagates across split
+/// alignments.
+///
+/// Run as one parameterized pair so the two constructors are compared on
+/// identical input; asserting only the inclusive case would not show that the
+/// default actually excludes.
+#[rstest]
+#[case::default_grouper_drops_them(false, 1)]
+#[case::with_secondary_supplementary_keeps_them(true, 2)]
+fn group_by_position_secondary_supplementary_policy(
+    #[case] include_secondary_supplementary: bool,
+    #[case] expected_groups: usize,
+) {
+    use crate::pipeline::steps::group::position::{BatchedRawPositionGroups, GroupByPosition};
+    use fgumi_bam_io::GroupKey;
+
+    // One positioned run, then a record carrying the UNKNOWN_REF key that a
+    // secondary/supplementary alignment decodes to.
+    let positioned = position_key_at(100);
+    let unknown = GroupKey::default(); // ref_id1 == UNKNOWN_REF
+    let records = vec![
+        (single_end_record(b"a"), positioned),
+        (single_end_record(b"b"), positioned),
+        (single_end_record(b"supp"), unknown),
+    ];
+
+    let collected: Arc<Mutex<Vec<BatchedRawPositionGroups>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let step = if include_secondary_supplementary {
+        GroupByPosition::with_secondary_supplementary(EDGE_LIMIT_BYTES)
+    } else {
+        GroupByPosition::new(EDGE_LIMIT_BYTES)
+    };
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(vec![decoded_batch_with_keys(0, records)]))
+        .chain(step)
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads: 1, ..Default::default() }).expect("chain runs");
+
+    let emitted = collected.lock().expect("mutex not poisoned");
+    let groups: Vec<usize> =
+        emitted.iter().flat_map(|b| &b.groups).map(|g| g.records.len()).collect();
+    assert_eq!(groups.len(), expected_groups, "position groups emitted: {groups:?}");
+    assert_eq!(groups[0], 2, "the positioned run always groups its two records");
+}
+
+/// `ReplaySource → GroupByQueryname` drives the queryname grouper through the
+/// framework, covering the same `try_run`/`emit_batch` surface: ordinal
+/// minting, the held-slot retry, and the drain arm that closes the final
+/// run-in-progress before reporting `Finished`.
+#[rstest]
+fn group_by_queryname_emits_contiguous_batches_ending_in_a_partial(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::group::queryname::GroupByQueryname;
+    use crate::pipeline::steps::types::BamTemplateBatch;
+    use fgumi_raw_bam::flags::{FIRST_SEGMENT, LAST_SEGMENT, PAIRED};
+
+    const N_TEMPLATES: usize = 203;
+    const TARGET_BATCH_COUNT: usize = 8;
+    const RECORDS_PER_INPUT_BATCH: usize = 5;
+    const OUTPUT_BYTE_LIMIT: u64 = 1024;
+    const SINK_STALLS: usize = 24;
+
+    assert_ne!(
+        N_TEMPLATES % TARGET_BATCH_COUNT,
+        0,
+        "the fixture must leave a partial final batch, else the drain arm is untested",
+    );
+
+    let paired = |qname: &[u8], flags: u16| {
+        let mut b = SamBuilder::new();
+        b.read_name(qname)
+            .flags(flags)
+            .ref_id(0)
+            .pos(100)
+            .cigar_ops(&[4u32 << 4])
+            .sequence(b"ACGT")
+            .qualities(&[30u8; 4]);
+        b.build()
+    };
+
+    let mut records: Vec<(RawRecord, fgumi_bam_io::GroupKey)> = Vec::new();
+    for t in 0..N_TEMPLATES {
+        let qname = format!("q{t:05}");
+        let key = fgumi_bam_io::GroupKey {
+            name_hash: name_hash_of(qname.as_bytes()),
+            ..Default::default()
+        };
+        records.push((paired(qname.as_bytes(), PAIRED | FIRST_SEGMENT), key));
+        records.push((paired(qname.as_bytes(), PAIRED | LAST_SEGMENT), key));
+    }
+    let batches: Vec<DecodedRecordBatch> = records
+        .chunks(RECORDS_PER_INPUT_BATCH)
+        .enumerate()
+        .map(|(i, chunk)| decoded_batch_with_keys(i as u64, chunk.to_vec()))
+        .collect();
+
+    let collected: Arc<Mutex<Vec<BamTemplateBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(batches))
+        .chain(GroupByQueryname::with_target_batch_count(OUTPUT_BYTE_LIMIT, TARGET_BATCH_COUNT))
+        .chain(StallingCollectSink { collected: sink_handle, remaining_stalls: SINK_STALLS })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let emitted = collected.lock().expect("mutex not poisoned");
+    assert!(emitted.len() > 1, "fixture must span several output batches");
+
+    let serials: Vec<u64> = emitted.iter().map(BamTemplateBatch::batch_serial).collect();
+    assert_eq!(
+        serials,
+        (0..emitted.len() as u64).collect::<Vec<u64>>(),
+        "emitted batch serials must be contiguous from zero",
+    );
+
+    // The batch cap: no emitted batch may exceed the target. Without this, a
+    // regression that let the accumulator grow past the cap before emitting
+    // would keep serials dense, keep every template present, and still leave a
+    // short final batch — passing every other assertion here.
+    if let Some((i, n)) = emitted
+        .iter()
+        .map(|b| b.templates().len())
+        .enumerate()
+        .find(|&(_, n)| n > TARGET_BATCH_COUNT)
+    {
+        panic!("batch {i} holds {n} templates, above the {TARGET_BATCH_COUNT} cap");
+    }
+
+    // Every queryname becomes exactly one template, in input order, holding
+    // both of its records.
+    let names: Vec<String> = emitted
+        .iter()
+        .flat_map(BamTemplateBatch::templates)
+        .map(|t| String::from_utf8_lossy(&t.name).into_owned())
+        .collect();
+    let expected: Vec<String> = (0..N_TEMPLATES).map(|t| format!("q{t:05}")).collect();
+    assert_eq!(
+        names.len(),
+        expected.len(),
+        "every queryname must yield one template — a short count means the drain arm \
+         dropped the run in progress",
+    );
+    if let Some((i, (got, want))) =
+        names.iter().zip(&expected).enumerate().find(|(_, (got, want))| got != want)
+    {
+        panic!("template {i} differs: got {got:?}, expected {want:?}");
+    }
+    assert!(
+        emitted.iter().flat_map(BamTemplateBatch::templates).all(|t| t.records.len() == 2),
+        "each template must hold both of its records",
+    );
+}
+
+/// Inputs for the closure-driven mid-step chains below.
+fn numbered_inputs(n: u64) -> Vec<Numbered> {
+    (0..n).map(|i| Numbered { ordinal: i, value: i }).collect()
+}
+
+/// Collect a sink's values, sorted — for the unordered (`BranchOrdering::None`)
+/// variants, where arrival order races across workers.
+fn sorted_values(sink: &Arc<Mutex<Vec<Numbered>>>) -> Vec<u64> {
+    let mut v: Vec<u64> =
+        sink.lock().expect("mutex not poisoned").iter().map(|n| n.value).collect();
+    v.sort_unstable();
+    v
+}
+
+const PROCESS_INPUTS: u64 = 200;
+
+/// Small enough that a handful of `Numbered` items exceed it, so the ordered
+/// mid-step chains below actually bounce a push and take their held-slot path.
+const PROCESS_EDGE_BYTES: u64 = 256;
+
+/// Ditto for the count-bounded variants.
+const PROCESS_EDGE_SLOTS: usize = 2;
+
+/// Ticks the terminal sink ignores before it starts draining, so the queue
+/// upstream of it fills. See [`StallingCollectSink`].
+const PROCESS_SINK_STALLS: usize = 64;
+
+/// The closure-driven mid-steps in `process.rs` are all the same state machine
+/// around a different output arity, and every one of their `try_run` bodies —
+/// held-slot retry, drain detection, `Finished` on the last clone — was
+/// reachable only through the framework. The unit tests in that module cover
+/// the `Process*Output` constructors and profiles, not the steps.
+///
+/// These chains exercise one variant each. They are deliberately small and
+/// uniform: the value being pinned is that each variant passes every input
+/// through exactly once and terminates, which is what a drain or held-slot
+/// regression breaks.
+#[rstest]
+fn process_chain_passes_every_item_through(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::process::process;
+
+    let collected: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(numbered_inputs(PROCESS_INPUTS)))
+        // `Process` is count-bounded and unordered; the doubling makes a
+        // pass-through implementation distinguishable from a real one.
+        .chain(process("Double", PROCESS_EDGE_SLOTS, |item: Numbered| {
+            Ok(Numbered { ordinal: item.ordinal, value: item.value * 2 })
+        }))
+        .chain(StallingCollectSink {
+            collected: sink_handle,
+            remaining_stalls: PROCESS_SINK_STALLS,
+        })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    assert_eq!(
+        sorted_values(&collected),
+        (0..PROCESS_INPUTS).map(|v| v * 2).collect::<Vec<u64>>(),
+        "every input must be transformed and emitted exactly once",
+    );
+}
+
+/// `ProcessOrdered` is the byte-bounded, `ByItemOrdinal` sibling of `Process`,
+/// so its output must arrive in input order rather than merely intact.
+#[rstest]
+fn process_ordered_chain_preserves_input_order(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::process::process_ordered;
+
+    let collected: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(numbered_inputs(PROCESS_INPUTS)))
+        .chain(process_ordered("DoubleOrdered", PROCESS_EDGE_BYTES, |item: Numbered| {
+            Ok(Numbered { ordinal: item.ordinal, value: item.value * 2 })
+        }))
+        .chain(StallingCollectSink {
+            collected: sink_handle,
+            remaining_stalls: PROCESS_SINK_STALLS,
+        })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let values: Vec<u64> =
+        collected.lock().expect("mutex not poisoned").iter().map(|n| n.value).collect();
+    assert_eq!(
+        values,
+        (0..PROCESS_INPUTS).map(|v| v * 2).collect::<Vec<u64>>(),
+        "an ordered branch must release in input order, not merely intact",
+    );
+}
+
+/// `ProcessWithWorkerState` lazily initializes one state value per worker and
+/// reuses it across items. The state here counts the items that worker handled,
+/// so the per-worker totals must sum to the input count however the framework
+/// distributes work.
+#[rstest]
+fn process_with_worker_state_chain_reuses_state_per_worker(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::process::process_with_worker_state;
+
+    let collected: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let inits = Arc::new(AtomicU64::new(0));
+    let init_counter = Arc::clone(&inits);
+    let handled = Arc::new(AtomicU64::new(0));
+    let handled_counter = Arc::clone(&handled);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(numbered_inputs(PROCESS_INPUTS)))
+        .chain(process_with_worker_state(
+            "CountPerWorker",
+            PROCESS_EDGE_BYTES,
+            move || {
+                init_counter.fetch_add(1, AtomicOrdering::Relaxed);
+                0u64 // per-worker item counter
+            },
+            move |seen: &mut u64, item: Numbered| {
+                *seen += 1;
+                handled_counter.fetch_add(1, AtomicOrdering::Relaxed);
+                Ok(Numbered { ordinal: item.ordinal, value: item.value })
+            },
+        ))
+        .chain(StallingCollectSink {
+            collected: sink_handle,
+            remaining_stalls: PROCESS_SINK_STALLS,
+        })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let values: Vec<u64> =
+        collected.lock().expect("mutex not poisoned").iter().map(|n| n.value).collect();
+    assert_eq!(values, (0..PROCESS_INPUTS).collect::<Vec<u64>>(), "ordered output, in order");
+    // State is created lazily per worker, so at most one per worker — never one
+    // per item, which is the regression this construction exists to avoid.
+    let inits = inits.load(AtomicOrdering::Relaxed);
+    assert!(
+        inits >= 1 && inits <= threads as u64,
+        "expected between 1 and {threads} state initializations, got {inits}",
+    );
+    // The per-worker counters must sum to the input count however the framework
+    // distributes work — the claim the doc comment makes, now pinned. Summing
+    // through the shared accumulator is what distinguishes "each item handled by
+    // some worker" from a drain regression that silently drops items.
+    assert_eq!(
+        handled.load(AtomicOrdering::Relaxed),
+        PROCESS_INPUTS,
+        "per-worker counters must total the input count",
+    );
+}
+
+/// `MiAssign` threads a single running counter through the closure so emitted
+/// molecule ids are globally consecutive. It is `Serial`, so the counter needs
+/// no synchronization — and the assertion is that the ids come out dense and
+/// in order regardless of thread count.
+#[rstest]
+fn mi_assign_chain_hands_out_consecutive_ids(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::process::mi_assign;
+
+    const IDS_PER_ITEM: u64 = 2;
+
+    let collected: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(numbered_inputs(PROCESS_INPUTS)))
+        .chain(mi_assign("AssignIds", PROCESS_EDGE_BYTES, |next_mi: &mut u64, item: Numbered| {
+            let base = *next_mi;
+            *next_mi += IDS_PER_ITEM;
+            Ok(Numbered { ordinal: item.ordinal, value: base })
+        }))
+        .chain(StallingCollectSink {
+            collected: sink_handle,
+            remaining_stalls: PROCESS_SINK_STALLS,
+        })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let values: Vec<u64> =
+        collected.lock().expect("mutex not poisoned").iter().map(|n| n.value).collect();
+    assert_eq!(
+        values,
+        (0..PROCESS_INPUTS).map(|i| i * IDS_PER_ITEM).collect::<Vec<u64>>(),
+        "each item must reserve its own block of ids, consecutively and in order",
+    );
+}
+
+/// `Process2` fans out to two *unordered* branches, each with its own held
+/// slot. Splitting on parity sends every input to exactly one branch, so a
+/// dropped held item shows up as a missing value on one side.
+#[rstest]
+fn process2_chain_splits_across_both_branches(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::process::{Process2Output, process2};
+
+    let collected_a: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let collected_b: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let (sink_a, sink_b) = (Arc::clone(&collected_a), Arc::clone(&collected_b));
+
+    let builder = Pipeline::builder();
+    let multi = builder
+        .chain(ReplaySource::new(numbered_inputs(PROCESS_INPUTS)))
+        .chain(process2("SplitParity", PROCESS_EDGE_SLOTS, PROCESS_EDGE_SLOTS, |item: Numbered| {
+            Ok(if item.value.is_multiple_of(2) {
+                Process2Output::only_a(item)
+            } else {
+                Process2Output::only_b(item)
+            })
+        }))
+        .into_multi();
+    multi
+        .b0
+        .chain(StallingCollectSink { collected: sink_a, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    multi
+        .b1
+        .chain(StallingCollectSink { collected: sink_b, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    assert_eq!(
+        sorted_values(&collected_a),
+        (0..PROCESS_INPUTS).filter(|v| v.is_multiple_of(2)).collect::<Vec<u64>>(),
+    );
+    assert_eq!(
+        sorted_values(&collected_b),
+        (0..PROCESS_INPUTS).filter(|v| !v.is_multiple_of(2)).collect::<Vec<u64>>(),
+    );
+}
+
+/// `Process2WithWorkerState` is the kept/rejects shape with per-worker scratch
+/// — `correct`'s cache lives here. Both branches are ordered, and both receive
+/// every item, so each must release a dense sequence.
+#[rstest]
+fn process2_with_worker_state_chain_feeds_both_ordered_branches(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::process::{Process2Output, process2_with_worker_state};
+
+    let collected_a: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let collected_b: Arc<Mutex<Vec<Numbered>>> = Arc::new(Mutex::new(Vec::new()));
+    let (sink_a, sink_b) = (Arc::clone(&collected_a), Arc::clone(&collected_b));
+
+    let builder = Pipeline::builder();
+    let multi = builder
+        .chain(ReplaySource::new(numbered_inputs(PROCESS_INPUTS)))
+        .chain(process2_with_worker_state(
+            "KeptAndRejects",
+            PROCESS_EDGE_BYTES,
+            PROCESS_EDGE_BYTES,
+            || 0u64,
+            |seen: &mut u64, item: Numbered| {
+                *seen += 1;
+                Ok(Process2Output::both(
+                    Numbered { ordinal: item.ordinal, value: item.value },
+                    Numbered { ordinal: item.ordinal, value: item.value * 10 },
+                ))
+            },
+        ))
+        .into_multi();
+    multi
+        .b0
+        .chain(StallingCollectSink { collected: sink_a, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    multi
+        .b1
+        .chain(StallingCollectSink { collected: sink_b, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let values_a: Vec<u64> =
+        collected_a.lock().expect("mutex not poisoned").iter().map(|n| n.value).collect();
+    let values_b: Vec<u64> =
+        collected_b.lock().expect("mutex not poisoned").iter().map(|n| n.value).collect();
+    assert_eq!(values_a, (0..PROCESS_INPUTS).collect::<Vec<u64>>(), "branch a, in order");
+    assert_eq!(
+        values_b,
+        (0..PROCESS_INPUTS).map(|v| v * 10).collect::<Vec<u64>>(),
+        "branch b, in order",
+    );
+}
+
+/// `Process3WithWorkerState` widens the same shape to three ordered branches —
+/// the FASTQ-encode fan-out (R1 / R2 / other).
+///
+/// This step had no test because it had no way to be *wired*: `OrderedBytesTuple3`
+/// carried queue and handle support but no `Chain::into_multi`, unlike its
+/// 2-branch sibling, and `append_step` exposes only branch 0. The step
+/// type-checked and built and was simply unreachable. `into_multi` for the
+/// 3-branch ordered shape is added alongside this test.
+#[rstest]
+fn process3_with_worker_state_chain_feeds_all_three_branches(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::process::{Process3Output, process3_with_worker_state};
+
+    let sinks: [Arc<Mutex<Vec<Numbered>>>; 3] =
+        std::array::from_fn(|_| Arc::new(Mutex::new(Vec::new())));
+    let [sink_a, sink_b, sink_c]: [Arc<Mutex<Vec<Numbered>>>; 3] =
+        std::array::from_fn(|i| Arc::clone(&sinks[i]));
+
+    let builder = Pipeline::builder();
+    let multi = builder
+        .chain(ReplaySource::new(numbered_inputs(PROCESS_INPUTS)))
+        .chain(process3_with_worker_state(
+            "FanOut3",
+            PROCESS_EDGE_BYTES,
+            PROCESS_EDGE_BYTES,
+            PROCESS_EDGE_BYTES,
+            || 0u64,
+            |seen: &mut u64, item: Numbered| {
+                *seen += 1;
+                Ok(Process3Output::both3(
+                    Numbered { ordinal: item.ordinal, value: item.value },
+                    Numbered { ordinal: item.ordinal, value: item.value * 10 },
+                    Numbered { ordinal: item.ordinal, value: item.value * 100 },
+                ))
+            },
+        ))
+        .into_multi();
+    multi
+        .b0
+        .chain(StallingCollectSink { collected: sink_a, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    multi
+        .b1
+        .chain(StallingCollectSink { collected: sink_b, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    multi
+        .b2
+        .chain(StallingCollectSink { collected: sink_c, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    for (branch, multiplier) in [(0usize, 1u64), (1, 10), (2, 100)] {
+        let values: Vec<u64> =
+            sinks[branch].lock().expect("mutex not poisoned").iter().map(|n| n.value).collect();
+        assert_eq!(
+            values,
+            (0..PROCESS_INPUTS).map(|v| v * multiplier).collect::<Vec<u64>>(),
+            "branch {branch} must release every item, in order",
+        );
+    }
+}
+
+/// `GroupBam` must emit the grouper's batches as formed, never merged.
+///
+/// [`TemplateGrouper::add_records`] already caps each returned batch at
+/// `template_batch_size` and keeps the remainder pending, so the only way to
+/// exceed the cap is for the step to `extend` those batches together — which is
+/// what it used to do, turning the configured size from a bound into a mere
+/// trigger (measured at 624x for a 40k-record input).
+///
+/// `RECORDS_PER_INPUT_BATCH` is deliberately several times `TARGET_BATCH_COUNT`
+/// so one `add_records` call completes several whole batches. That is the case
+/// the merge destroyed and the only one that distinguishes the two behaviors:
+/// feed it fewer templates per input than the target and both the fixed and the
+/// broken step emit one batch per input, and the test proves nothing.
+///
+/// This drives the step through `Pipeline::run` rather than calling the grouper
+/// directly, because the property belongs to `GroupBam`, not to
+/// `TemplateGrouper` — a grouper-level assertion passes even if the step
+/// reintroduces the merge.
+#[rstest]
+fn group_bam_emits_grouper_batches_without_merging_them(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::group::bam::GroupBam;
+    use crate::pipeline::steps::types::BamTemplateBatch;
+
+    const N_TEMPLATES: usize = 205;
+    const TARGET_BATCH_COUNT: usize = 8;
+    const RECORDS_PER_INPUT_BATCH: usize = 40;
+    const OUTPUT_BYTE_LIMIT: u64 = 1024;
+    const SINK_STALLS: usize = 24;
+
+    const _: () = assert!(
+        RECORDS_PER_INPUT_BATCH > TARGET_BATCH_COUNT,
+        "one input batch must complete more than one output batch or the merge is invisible",
+    );
+    assert_ne!(
+        N_TEMPLATES % TARGET_BATCH_COUNT,
+        0,
+        "the fixture must leave a partial final batch, else the drain arm is untested",
+    );
+
+    // One single-end record per queryname, so templates and records are 1:1 and
+    // a short count is unambiguous.
+    let records: Vec<(RawRecord, fgumi_bam_io::GroupKey)> = (0..N_TEMPLATES)
+        .map(|t| {
+            let qname = format!("t{t:04}");
+            let key = fgumi_bam_io::GroupKey {
+                name_hash: name_hash_of(qname.as_bytes()),
+                ..Default::default()
+            };
+            (single_end_record(qname.as_bytes()), key)
+        })
+        .collect();
+    let batches: Vec<DecodedRecordBatch> = records
+        .chunks(RECORDS_PER_INPUT_BATCH)
+        .enumerate()
+        .map(|(i, chunk)| decoded_batch_with_keys(i as u64, chunk.to_vec()))
+        .collect();
+
+    let collected: Arc<Mutex<Vec<BamTemplateBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(batches))
+        .chain(GroupBam::new(TARGET_BATCH_COUNT, OUTPUT_BYTE_LIMIT))
+        .chain(StallingCollectSink { collected: sink_handle, remaining_stalls: SINK_STALLS })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let emitted = collected.lock().expect("mutex not poisoned");
+    assert!(emitted.len() > 1, "fixture must span several output batches");
+
+    let serials: Vec<u64> = emitted.iter().map(Ordered::ordinal).collect();
+    assert_eq!(
+        serials,
+        (0..emitted.len() as u64).collect::<Vec<u64>>(),
+        "emitted batch serials must be contiguous from zero",
+    );
+    assert!(emitted.iter().all(|b| !b.templates().is_empty()), "no batch may be emitted empty");
+
+    // The cap, and the whole point of the test: with the merge in place the
+    // first batch of each input would hold `RECORDS_PER_INPUT_BATCH` templates.
+    if let Some((i, n)) = emitted
+        .iter()
+        .map(|b| b.templates().len())
+        .enumerate()
+        .find(|&(_, n)| n > TARGET_BATCH_COUNT)
+    {
+        panic!("batch {i} holds {n} templates, above the {TARGET_BATCH_COUNT} cap");
+    }
+
+    // Nothing was dropped on the way — a short count would mean the `Finished`
+    // gate closed the output while batches were still queued.
+    let total: usize = emitted.iter().map(|b| b.templates().len()).sum();
+    assert_eq!(
+        total, N_TEMPLATES,
+        "every template must be emitted exactly once; a short count means queued batches \
+         were lost when the step reported Finished",
+    );
+}
+
+/// A `None` on one of `Process3WithWorkerState`'s ordered branches must not
+/// stall the run, provided that branch mints its own dense ordinals.
+///
+/// The sibling test above feeds all three branches on every input, so it never
+/// exercises a gap. That matters because the step's named caller is the paired
+/// FASTQ encode fan-out (R1 / R2 / **other**), and the "other" branch is `None`
+/// for most inputs — the sparse case is the *normal* case in production, not an
+/// edge case. All three branches declare [`BranchOrdering::ByItemOrdinal`],
+/// whose `ReorderStage` releases only contiguously, so a branch that skipped an
+/// input while propagating the *input's* ordinal would leave a permanent hole
+/// and wait for it forever.
+///
+/// This pins the safe half of the rule documented on `Process2Output`: the
+/// sparse branch here numbers what it emits, so a skip simply means the next
+/// emitted item takes the next ordinal and the sequence stays dense. The
+/// failure it guards against is a hang, not a wrong answer, which is why the
+/// run completing at all is half the assertion.
+#[rstest]
+fn process3_tolerates_a_none_branch_that_mints_its_own_ordinals(#[values(1, 4)] threads: usize) {
+    use crate::pipeline::steps::process::{Process3Output, process3_with_worker_state};
+
+    // Only every fourth input reaches the third branch.
+    const C_EVERY: u64 = 4;
+
+    let sinks: [Arc<Mutex<Vec<Numbered>>>; 3] =
+        std::array::from_fn(|_| Arc::new(Mutex::new(Vec::new())));
+    let [sink_a, sink_b, sink_c]: [Arc<Mutex<Vec<Numbered>>>; 3] =
+        std::array::from_fn(|i| Arc::clone(&sinks[i]));
+
+    // Branch-local counter for the sparse branch. Shared across worker clones,
+    // so at four threads which *value* gets which ordinal races — but the
+    // sequence stays dense, which is the property the reorder stage requires.
+    let next_c = Arc::new(AtomicU64::new(0));
+    let mint_c = Arc::clone(&next_c);
+
+    let builder = Pipeline::builder();
+    let multi = builder
+        .chain(ReplaySource::new(numbered_inputs(PROCESS_INPUTS)))
+        .chain(process3_with_worker_state(
+            "SparseFanOut3",
+            PROCESS_EDGE_BYTES,
+            PROCESS_EDGE_BYTES,
+            PROCESS_EDGE_BYTES,
+            || 0u64,
+            move |seen: &mut u64, item: Numbered| {
+                *seen += 1;
+                // a and b take every input and propagate its ordinal, which
+                // stays dense because nothing is skipped on those branches.
+                let a = Numbered { ordinal: item.ordinal, value: item.value };
+                let b = Numbered { ordinal: item.ordinal, value: item.value * 10 };
+                let c = item.value.is_multiple_of(C_EVERY).then(|| Numbered {
+                    ordinal: mint_c.fetch_add(1, AtomicOrdering::Relaxed),
+                    value: item.value * 100,
+                });
+                Ok(Process3Output { a: Some(a), b: Some(b), c })
+            },
+        ))
+        .into_multi();
+    multi
+        .b0
+        .chain(StallingCollectSink { collected: sink_a, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    multi
+        .b1
+        .chain(StallingCollectSink { collected: sink_b, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    multi
+        .b2
+        .chain(StallingCollectSink { collected: sink_c, remaining_stalls: PROCESS_SINK_STALLS })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    // The dense branches are unaffected by the third one's gaps.
+    for (branch, multiplier) in [(0usize, 1u64), (1, 10)] {
+        let values: Vec<u64> =
+            sinks[branch].lock().expect("mutex not poisoned").iter().map(|n| n.value).collect();
+        assert_eq!(
+            values,
+            (0..PROCESS_INPUTS).map(|v| v * multiplier).collect::<Vec<u64>>(),
+            "dense branch {branch} must release every item, in order",
+        );
+    }
+
+    let branch_c = sinks[2].lock().expect("mutex not poisoned");
+    let expected_c: Vec<u64> =
+        (0..PROCESS_INPUTS).filter(|v| v.is_multiple_of(C_EVERY)).map(|v| v * 100).collect();
+
+    // Sparse, or the test degenerates into the all-branches case above.
+    assert!(
+        (branch_c.len() as u64) < PROCESS_INPUTS,
+        "the third branch must skip inputs or this proves nothing about gaps",
+    );
+    assert_eq!(branch_c.len(), expected_c.len(), "every routed item reached the sparse branch");
+
+    // The load-bearing assertion: the sparse branch released a dense sequence
+    // from zero. A hole would have stalled its reorder stage instead of
+    // producing short output.
+    let ordinals: Vec<u64> = branch_c.iter().map(|n| n.ordinal).collect();
+    assert_eq!(
+        ordinals,
+        (0..branch_c.len() as u64).collect::<Vec<u64>>(),
+        "the sparse branch must release a dense ordinal sequence from zero",
+    );
+
+    // Nothing was routed wrongly, dropped, or duplicated. Sorted because
+    // ordinal assignment races across workers at four threads.
+    let mut values_c: Vec<u64> = branch_c.iter().map(|n| n.value).collect();
+    values_c.sort_unstable();
+    assert_eq!(values_c, expected_c);
+}
+
+/// `EDGE_LIMIT_BYTES` must be small enough that the multi-record fixtures
+/// exceed it, or the byte-bounded edges never reject a push and every chain
+/// above silently degrades into an unbounded-queue test that proves nothing
+/// about backpressure or the steps' held-item retry paths.
+#[test]
+fn the_edge_budget_binds_on_the_multi_record_fixtures() {
+    let decompressed_bytes: usize = bgzf_blocks_for(&test_records(500), 4096)
+        .iter()
+        .map(|b| b.uncompressed_size as usize)
+        .sum();
+    assert!(
+        u64::try_from(decompressed_bytes).expect("fixture volume fits u64") > EDGE_LIMIT_BYTES,
+        "fixture volume ({decompressed_bytes} B) must exceed the per-edge budget \
+         ({EDGE_LIMIT_BYTES} B), else the byte-bounded edges never bind",
+    );
+}

--- a/src/lib/pipeline/steps/correct/mod.rs
+++ b/src/lib/pipeline/steps/correct/mod.rs
@@ -1,0 +1,299 @@
+//! `CorrectStep` — typed `Step` wrapping UMI correction.
+//!
+//! **Ported ahead of its caller.** Every item here is `pub(crate)` -- the
+//! config type names `CollectedCorrectMetrics`, which is `pub(crate)`, so this
+//! surface cannot be `pub` without leaking command internals. Until the
+//! command rewiring points `commands::correct` at this step, nothing outside
+//! the module's own tests constructs it, so the whole module is dead code to
+//! the compiler. The `allow` below is scoped to this module and should be
+//! deleted by the PR that adds the caller.
+//!
+//! Input:  `BamTemplateBatch` (from `GroupByQueryname`).
+//!
+//! Two factory functions cover the two `--rejects` cases:
+//!
+//! - `correct_step_with_rejects(cfg)` — `Step` with
+//!   `Outputs = OrderedBytesTuple2<BamTemplateBatch, DecompressedBlock>`.
+//!   `multi.b0` is the corrected templates (typed), `multi.b1` is the
+//!   pre-serialized rejects bytes. Used when `track_rejects = true`.
+//!
+//! - `correct_step_kept_only(cfg)` — `Step` with
+//!   `Outputs = OrderedBytesSingle<BamTemplateBatch>`. Single-output
+//!   variant when no rejects file is requested. The framework has no
+//!   public `DiscardSink`, and `Pipeline::build()` rejects an unwired
+//!   branch, so this is the only way to omit the rejects branch.
+//!
+//! Per-worker `LruCache<Vec<u8>, UmiMatch>` lives in the framework's
+//! `Process2WithWorkerState` (or `ProcessWithWorkerState`) lazy-init
+//! slot. Wrapped in `CorrectWorkerState` to satisfy the `S: HeapSize`
+//! bound (`LruCache` doesn't impl `HeapSize`; existing precedents like
+//! `ConsensusState` use the same `impl HeapSize for State {}` pattern).
+
+#![allow(dead_code)]
+
+use std::io;
+use std::num::NonZero;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use lru::LruCache;
+
+use crate::commands::correct::{
+    self, CollectedCorrectMetrics, CorrectOptions, EncodedUmiSet, RejectionReason, UmiMatch,
+};
+use crate::per_thread_accumulator::PerThreadAccumulator;
+use crate::pipeline::core::item::HeapSize;
+use crate::pipeline::core::outputs::{OrderedBytesSingle, OrderedBytesTuple2};
+use crate::pipeline::core::step::Step;
+use crate::pipeline::steps::process::{
+    Process2Output, process_with_worker_state, process2_with_worker_state,
+};
+use crate::pipeline::steps::types::{BamTemplateBatch, DecompressedBlock};
+use crate::template::Template;
+use fgumi_raw_bam::RawRecord;
+
+#[cfg(test)]
+mod tests;
+
+/// Per-worker scratch state for `CorrectStep`. Wraps `Option<LruCache>`
+/// in a newtype so we can `impl HeapSize` for it (the bound on
+/// `process2_with_worker_state`'s `S` type parameter). `LruCache` itself
+/// can't impl `HeapSize` (orphan rule). Reports `heap_size = 0` because
+/// the cache size is bounded by the user-set `cache_size` option, not
+/// dynamically grown — same convention as `ConsensusState` /
+/// `CodecState` / `DuplexState` in `commands::runall`.
+pub(crate) struct CorrectWorkerState {
+    cache: Option<LruCache<Vec<u8>, UmiMatch>>,
+}
+
+impl HeapSize for CorrectWorkerState {
+    fn heap_size(&self) -> usize {
+        0
+    }
+}
+
+/// Immutable configuration shared by `CorrectStep`. All `Arc`-wrapped
+/// fields are cheap to clone across workers; per-worker mutable state
+/// (the cache) lives in the framework's lazy-init slot, not here.
+///
+/// `pub(crate)` because the type references `CollectedCorrectMetrics`,
+/// which is `pub(crate)`; the new pipeline is wired entirely from
+/// `commands::correct::execute_new_pipeline`, so this never needs to
+/// cross the crate boundary.
+pub(crate) struct CorrectStepConfig {
+    pub(crate) encoded_umi_set: Arc<EncodedUmiSet>,
+    pub(crate) umi_length: usize,
+    pub(crate) umi_tag: [u8; 2],
+    /// Tag the pre-correction sequence is stashed in when original storage
+    /// is enabled. Derived from [`crate::commands::correct::Target::original_tag`]
+    /// by the caller, alongside `umi_tag`.
+    pub(crate) original_tag: [u8; 2],
+    pub(crate) opts: CorrectOptions,
+    pub(crate) metrics: Arc<PerThreadAccumulator<CollectedCorrectMetrics>>,
+    pub(crate) records_emitted: Arc<AtomicU64>,
+    pub(crate) output_byte_limit: u64,
+    pub(crate) unmatched_umi: String,
+}
+
+/// Build the 2-output `CorrectStep`. Used when `--rejects` is set; kept
+/// branch carries `BamTemplateBatch`, rejects branch carries
+/// pre-serialized BAM bytes inside a `DecompressedBlock`.
+pub(crate) fn correct_step_with_rejects(
+    cfg: CorrectStepConfig,
+) -> impl Step<Input = BamTemplateBatch, Outputs = OrderedBytesTuple2<BamTemplateBatch, DecompressedBlock>>
+{
+    let cfg = Arc::new(cfg);
+    let cfg_init = Arc::clone(&cfg);
+    let cfg_run = Arc::clone(&cfg);
+
+    let init = move || CorrectWorkerState {
+        cache: if cfg_init.opts.cache_size > 0 {
+            Some(LruCache::new(
+                NonZero::new(cfg_init.opts.cache_size).expect("cache_size > 0 checked above"),
+            ))
+        } else {
+            None
+        },
+    };
+
+    let body = move |state: &mut CorrectWorkerState,
+                     batch: BamTemplateBatch|
+          -> io::Result<Process2Output<BamTemplateBatch, DecompressedBlock>> {
+        let mut rejects_bytes: Vec<u8> = Vec::new();
+        let kept = run_batch(state, &cfg_run, batch, Some(&mut rejects_bytes))?;
+        // X5-001: an all-clean batch must still emit a (zero-byte) rejects block
+        // so the rejects branch's `ByItemOrdinal` reorder stage sees a dense
+        // serial sequence; pushing nothing (`only_a`) leaves a gap at this
+        // serial that wedges the rejects sink. An empty `Vec` does not allocate
+        // and produces no physical BGZF block, so the clean and rejecting cases
+        // are the same construction.
+        let batch_serial = kept.batch_serial();
+        Ok(Process2Output::both(kept, DecompressedBlock { batch_serial, bytes: rejects_bytes }))
+    };
+
+    process2_with_worker_state::<
+        BamTemplateBatch,
+        BamTemplateBatch,
+        DecompressedBlock,
+        CorrectWorkerState,
+        _,
+        _,
+    >("correct", cfg.output_byte_limit, cfg.output_byte_limit, init, body)
+}
+
+/// Build the 1-output (kept-only) `CorrectStep`. Used when `--rejects`
+/// is unset. The framework has no public `DiscardSink`, so the only way
+/// to omit the rejects branch is to omit it from the chain entirely via
+/// this single-output variant.
+pub(crate) fn correct_step_kept_only(
+    cfg: CorrectStepConfig,
+) -> impl Step<Input = BamTemplateBatch, Outputs = OrderedBytesSingle<BamTemplateBatch>> {
+    let cfg = Arc::new(cfg);
+    let cfg_init = Arc::clone(&cfg);
+    let cfg_run = Arc::clone(&cfg);
+
+    let init = move || CorrectWorkerState {
+        cache: if cfg_init.opts.cache_size > 0 {
+            Some(LruCache::new(
+                NonZero::new(cfg_init.opts.cache_size).expect("cache_size > 0 checked above"),
+            ))
+        } else {
+            None
+        },
+    };
+
+    let body =
+        move |state: &mut CorrectWorkerState,
+              batch: BamTemplateBatch|
+              -> io::Result<BamTemplateBatch> { run_batch(state, &cfg_run, batch, None) };
+
+    process_with_worker_state::<BamTemplateBatch, BamTemplateBatch, _, CorrectWorkerState, _>(
+        "correct",
+        cfg.output_byte_limit,
+        init,
+        body,
+    )
+}
+
+/// Per-batch correction body, shared by both output shapes.
+///
+/// `rejects` is `Some` only for the 2-output (`--rejects`) variant; the
+/// kept-only variant passes `None` and rejected records are simply dropped.
+/// One body rather than two so the metrics accounting below has a single
+/// definition -- it previously existed in two copies that could drift.
+///
+/// Metrics follow the legacy `execute` path exactly, which in turn follows
+/// fgbio (`CorrectUmis.scala`):
+///
+/// - `templates_processed` counts every template once, matching legacy's
+///   `templates_count = batch.len()`.
+/// - Per-UMI crediting is delegated to `CorrectUmis::credit_umi_metrics` and
+///   happens for every template that reached matching, *before* the
+///   keep/reject decision -- so a template rejected because one segment
+///   failed still credits its matched segments, and its unmatched segments
+///   credit the all-`N` bucket.
+/// - Missing-UMI and wrong-length templates credit **no** per-UMI bucket:
+///   fgbio counts them only in `missingUmisRecords` / wrong-length
+///   (`CorrectUmis.scala:199-202`), and `compute_template_correction`
+///   returns an empty `matches` for `WrongLength`.
+fn run_batch(
+    state: &mut CorrectWorkerState,
+    cfg: &Arc<CorrectStepConfig>,
+    batch: BamTemplateBatch,
+    mut rejects: Option<&mut Vec<u8>>,
+) -> io::Result<BamTemplateBatch> {
+    let (batch_serial, templates) = batch.into_parts();
+
+    let mut kept_templates: Vec<Template> = Vec::with_capacity(templates.len());
+    let mut local_metrics = CollectedCorrectMetrics::default();
+    let mut kept_record_count: u64 = 0;
+
+    for template in templates {
+        let mut records = template.into_records();
+        let num_records = records.len() as u64;
+
+        // Every template counts once, whatever its outcome.
+        local_metrics.templates_processed += 1;
+
+        let umi_opt =
+            correct::CorrectUmis::extract_and_validate_template_umi_raw(&records, cfg.umi_tag)
+                .map_err(io::Error::other)?;
+
+        let Some(umi) = umi_opt else {
+            // No per-UMI credit here: fgbio counts a missing-UMI read only in
+            // `missingUmisRecords`.
+            local_metrics.missing_umis += num_records;
+            if let Some(dst) = rejects.as_deref_mut() {
+                for rec in &records {
+                    append_framed_raw_record(dst, rec);
+                }
+            }
+            continue;
+        };
+
+        let correction = correct::CorrectUmis::compute_template_correction(
+            &umi,
+            cfg.umi_length,
+            cfg.opts.revcomp,
+            cfg.opts.max_mismatches,
+            cfg.opts.min_distance_diff,
+            &cfg.encoded_umi_set,
+            &mut state.cache,
+        );
+
+        // Credit segments before the keep/reject decision, matching legacy.
+        // `matches` is empty for `WrongLength`, so those credit nothing.
+        correct::CorrectUmis::credit_umi_metrics(
+            &correction.matches,
+            num_records,
+            &cfg.unmatched_umi,
+            &mut local_metrics.umi_matches,
+        );
+
+        if correction.matched {
+            for raw in &mut records {
+                correct::CorrectUmis::apply_correction_to_raw(
+                    raw,
+                    &correction,
+                    cfg.umi_tag,
+                    cfg.original_tag,
+                    cfg.opts.dont_store_original_umis,
+                );
+            }
+            let corrected = Template::from_records(records)
+                .map_err(|e| io::Error::other(format!("Template::from_records: {e}")))?;
+            kept_record_count += num_records;
+            kept_templates.push(corrected);
+        } else {
+            match correction.rejection_reason {
+                RejectionReason::WrongLength => local_metrics.wrong_length += num_records,
+                RejectionReason::Mismatched => local_metrics.mismatched += num_records,
+                RejectionReason::None => {}
+            }
+            if let Some(dst) = rejects.as_deref_mut() {
+                for rec in &records {
+                    append_framed_raw_record(dst, rec);
+                }
+            }
+        }
+    }
+
+    cfg.metrics.with_slot(|m| m.merge_into(&mut local_metrics));
+    cfg.records_emitted.fetch_add(kept_record_count, Ordering::Relaxed);
+
+    Ok(BamTemplateBatch::new(batch_serial, kept_templates))
+}
+
+/// Append one raw BAM record to `dst` using the standard BAM framing:
+/// 4-byte LE `block_size` followed by the record body. Matches the
+/// legacy rejects writer's framing (the `serialize_fn` body that frames
+/// kept records) and what `BgzfCompress` expects in a `DecompressedBlock`.
+fn append_framed_raw_record(dst: &mut Vec<u8>, rec: &RawRecord) {
+    // BAM record body size is u32-bounded per the spec; the underlying
+    // RawRecord buffer was sized to fit a single record, so the cast
+    // cannot truncate in practice. Matches the legacy serialize_fn cast.
+    #[allow(clippy::cast_possible_truncation)]
+    let block_size = rec.len() as u32;
+    dst.extend_from_slice(&block_size.to_le_bytes());
+    dst.extend_from_slice(rec);
+}

--- a/src/lib/pipeline/steps/correct/tests.rs
+++ b/src/lib/pipeline/steps/correct/tests.rs
@@ -1,0 +1,787 @@
+use std::collections::VecDeque;
+use std::sync::Mutex;
+
+use super::*;
+use crate::commands::correct::{CollectedCorrectMetrics, CorrectOptions, Target};
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::builder::{Pipeline, PipelineConfig};
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::item::Ordered;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::sam::SamTag;
+use crate::template::Template;
+use fgumi_raw_bam::SamBuilder;
+use rstest::rstest;
+
+/// `CorrectOptions` mirroring the CLI's documented defaults.
+///
+/// Spelled out rather than derived: a `Default` impl on `CorrectOptions` would
+/// hand back `max_mismatches: 0`, `min_distance_diff: 0` and `cache_size: 0`,
+/// none of which match the flags' `default_value`s, so it would be a trap for
+/// any non-test caller that reached for it.
+fn make_default_opts() -> CorrectOptions {
+    CorrectOptions {
+        metrics: None,
+        target: Target::Umi,
+        max_mismatches: 2,
+        min_distance_diff: 2,
+        umis: Vec::new(),
+        umi_files: Vec::new(),
+        dont_store_original_umis: false,
+        cache_size: 100_000,
+        min_corrected: None,
+        revcomp: false,
+        rejects_path: None,
+    }
+}
+
+fn make_default_cfg() -> CorrectStepConfig {
+    let opts = make_default_opts();
+    CorrectStepConfig {
+        encoded_umi_set: Arc::new(EncodedUmiSet::new(&["AAAA".to_string()])),
+        umi_length: 4,
+        umi_tag: opts.target.sequence_tag().into(),
+        original_tag: opts.target.original_tag().into(),
+        opts,
+        metrics: PerThreadAccumulator::new(1),
+        records_emitted: Arc::new(AtomicU64::new(0)),
+        output_byte_limit: 1024,
+        unmatched_umi: "NNNN".to_string(),
+    }
+}
+
+/// Both factories must present the same step identity and kind, and differ
+/// only in how many output queues they declare: the rejects variant fans out
+/// to two branches, the kept-only variant to one. Every queue is byte-bounded
+/// in both -- correction emits variable-size batches, so a count-bounded queue
+/// would not bound memory.
+#[rstest]
+#[case::with_rejects(correct_step_with_rejects(make_default_cfg()).profile(), 2)]
+#[case::kept_only(correct_step_kept_only(make_default_cfg()).profile(), 1)]
+fn correct_step_profile(#[case] profile: StepProfile, #[case] expected_output_queues: usize) {
+    assert_eq!(profile.name, "correct");
+    assert!(matches!(profile.kind, StepKind::Parallel));
+    assert_eq!(profile.output_queues.len(), expected_output_queues);
+    // Every output queue must be byte-bounded at exactly the config's
+    // `output_byte_limit`. Accepting any `ByteBounded` value would let a factory
+    // that ignored `output_byte_limit` (or wired a different bound) pass.
+    let expected_limit = make_default_cfg().output_byte_limit;
+    for q in &profile.output_queues {
+        let QueueSpec::ByteBounded { limit_bytes } = q else {
+            panic!("correct output queues must be byte-bounded");
+        };
+        assert_eq!(*limit_bytes, expected_limit, "queue byte bound must equal output_byte_limit");
+    }
+}
+
+// --- Batch-routing tests for `run_batch` (both output shapes) ---
+
+/// Mirror of the 2-output factory's body: run a batch collecting rejects and
+/// frame them exactly as the step does.
+///
+/// The step emits a `DecompressedBlock` unconditionally — an all-clean batch
+/// still yields a zero-byte block so the rejects branch's `ByItemOrdinal`
+/// reorder stage sees a dense serial sequence (X5-001). This helper does the
+/// same, so a test cannot assert a shape the step never produces.
+fn run_batch_collecting_rejects(
+    state: &mut CorrectWorkerState,
+    cfg: &Arc<CorrectStepConfig>,
+    batch: BamTemplateBatch,
+) -> (BamTemplateBatch, DecompressedBlock) {
+    let mut bytes: Vec<u8> = Vec::new();
+    let kept = run_batch(state, cfg, batch, Some(&mut bytes)).expect("run_batch with rejects");
+    let batch_serial = kept.batch_serial();
+    (kept, DecompressedBlock { batch_serial, bytes })
+}
+
+/// Build a fresh per-worker state matching how the step's `init` closure
+/// constructs it for the default (cache-enabled) `CorrectOptions`.
+fn make_state() -> CorrectWorkerState {
+    CorrectWorkerState {
+        cache: Some(LruCache::new(
+            NonZero::new(make_default_opts().cache_size).expect("default cache_size > 0"),
+        )),
+    }
+}
+
+/// Build a single-record (unpaired) template whose `RX` tag holds `umi`.
+///
+/// A 4-base sequence/quality keeps the record comfortably above the 32-byte
+/// minimum that `extract_and_validate_template_umi_raw` / `Template::from_records`
+/// require, and a distinct `qname` keeps each template independent.
+fn make_template_with_rx(qname: &[u8], umi: &str) -> Template {
+    let mut b = SamBuilder::new();
+    b.read_name(qname)
+        .flags(0) // unmapped, unpaired -> single-record template (R1)
+        .sequence(b"ACGT")
+        .qualities(b"IIII")
+        .add_string_tag(SamTag::RX, umi.as_bytes());
+    Template::from_records(vec![b.build()]).expect("single-record template")
+}
+
+/// Read the `RX` tag value back from the first record of a template.
+fn template_rx(template: &Template) -> String {
+    let rx = fgumi_raw_bam::find_string_tag_in_record(&template.records[0], SamTag::RX)
+        .expect("RX tag present on kept record");
+    String::from_utf8(rx.to_vec()).expect("RX is valid UTF-8")
+}
+
+/// Read an arbitrary string tag from the first record of a template, or `None`
+/// when the tag is absent — used to assert both presence and absence of the
+/// original-UMI tag (`OX`) after correction.
+fn template_tag(template: &Template, tag: SamTag) -> Option<String> {
+    fgumi_raw_bam::find_string_tag_in_record(&template.records[0], tag)
+        .map(|bytes| String::from_utf8(bytes.to_vec()).expect("tag is valid UTF-8"))
+}
+
+/// Read the `QNAME` (read name) back from the first record of a template. Used
+/// to pin *which* templates were routed to a branch by identity — the corrected
+/// `RX` collapses both kept templates to `AAAA`, so an RX-only check cannot tell
+/// the intended survivor from a regression that kept the wrong record.
+fn template_qname(template: &Template) -> String {
+    let name = fgumi_raw_bam::read_name(template.records[0].as_ref());
+    String::from_utf8(name.to_vec()).expect("qname is valid UTF-8")
+}
+
+/// Decode a BAM-framed reject block — `4-byte LE block_size` + record body,
+/// repeated — into the `RX` tag of each rejected record. This is an
+/// independent inverse of the production `append_framed_raw_record` writer, so
+/// a routing regression that serialized the wrong record can't pass a mere
+/// non-empty-bytes check.
+fn reject_block_rx_tags(bytes: &[u8]) -> Vec<String> {
+    let mut tags = Vec::new();
+    let mut offset = 0;
+    while offset < bytes.len() {
+        let block_size = u32::from_le_bytes(
+            bytes[offset..offset + 4].try_into().expect("4-byte block_size prefix"),
+        ) as usize;
+        offset += 4;
+        let body = &bytes[offset..offset + block_size];
+        let rx = fgumi_raw_bam::find_string_tag_in_record(body, SamTag::RX)
+            .expect("RX tag present on rejected record");
+        tags.push(String::from_utf8(rx.to_vec()).expect("RX is valid UTF-8"));
+        offset += block_size;
+    }
+    tags
+}
+
+/// With the default config (whitelist `["AAAA"]`, `max_mismatches = 2`):
+/// - `RX = "AAAA"` matches exactly -> KEPT, unchanged.
+/// - `RX = "AAAT"` is 1 mismatch from `AAAA` (<= 2) -> KEPT, corrected to `AAAA`.
+/// - `RX = "TTTT"` is 4 mismatches from `AAAA` (> 2) -> REJECTED.
+#[test]
+fn run_batch_with_rejects_splits_kept_and_rejected() {
+    let cfg = Arc::new(make_default_cfg());
+    let mut state = make_state();
+
+    let templates = vec![
+        make_template_with_rx(b"exact", "AAAA"),
+        make_template_with_rx(b"correctable", "AAAT"),
+        make_template_with_rx(b"offlist", "TTTT"),
+    ];
+    let batch = BamTemplateBatch::new(7, templates);
+
+    let (kept, rejects) = run_batch_collecting_rejects(&mut state, &cfg, batch);
+
+    // Kept branch keeps the on-whitelist + correctable templates only.
+    assert_eq!(kept.batch_serial(), 7);
+    assert_eq!(kept.templates().len(), 2, "exact + correctable kept");
+    let mut kept_umis: Vec<String> = kept.templates().iter().map(template_rx).collect();
+    kept_umis.sort();
+    // Both kept records carry the corrected/whitelisted UMI "AAAA".
+    assert_eq!(kept_umis, vec!["AAAA".to_string(), "AAAA".to_string()]);
+    // Pin kept *identity* by QNAME, not just the corrected RX: both kept
+    // templates normalize to "AAAA", so a regression that kept the wrong record
+    // (e.g. dropped `correctable` and kept `offlist` rewritten to AAAA) would
+    // still satisfy the RX check above.
+    let mut kept_qnames: Vec<String> = kept.templates().iter().map(template_qname).collect();
+    kept_qnames.sort();
+    assert_eq!(kept_qnames, vec!["correctable".to_string(), "exact".to_string()]);
+
+    // Rejects branch carries exactly the off-whitelist template. Decode the
+    // framed block and assert the rejected record's identity (its untouched
+    // `RX = "TTTT"`, 4 mismatches from the `AAAA` whitelist) — a non-empty
+    // bytes check alone would pass even if the wrong record were routed here.
+    assert_eq!(rejects.batch_serial, 7);
+    assert_eq!(
+        reject_block_rx_tags(&rejects.bytes),
+        vec!["TTTT".to_string()],
+        "only the off-whitelist TTTT record is routed to rejects, unchanged"
+    );
+
+    // records_emitted counts only the two kept single-record templates.
+    assert_eq!(cfg.records_emitted.load(Ordering::Relaxed), 2);
+
+    // Metrics: one rejected (mismatched) template, two kept.
+    let slot = &cfg.metrics.slots()[0];
+    let metrics = slot.lock();
+    assert_eq!(metrics.mismatched, 1, "one off-whitelist template rejected");
+}
+
+/// `run_batch` forwards `cfg.original_tag` and `cfg.opts.dont_store_original_umis`
+/// to `apply_correction_to_raw`, which stores the pre-correction UMI under the
+/// original tag (`OX` for `Target::Umi`) whenever a template is actually
+/// corrected — unless suppression is requested. Drive a corrected template
+/// (`AAAT` -> `AAAA`, one mismatch) through `run_batch` and assert the original
+/// `AAAT` lands under `OX` when storage is enabled and is absent when
+/// `dont_store_original_umis` is set. The corrected `RX` is `AAAA` either way.
+#[rstest]
+#[case::store_original(false, Some("AAAT"))]
+#[case::suppress_original(true, None)]
+fn run_batch_stores_or_suppresses_original_umi(
+    #[case] dont_store_original_umis: bool,
+    #[case] expected_ox: Option<&str>,
+) {
+    let mut cfg = make_default_cfg();
+    cfg.opts.dont_store_original_umis = dont_store_original_umis;
+    let cfg = Arc::new(cfg);
+    let mut state = make_state();
+
+    let batch = BamTemplateBatch::new(0, vec![make_template_with_rx(b"correctable", "AAAT")]);
+    let kept = run_batch(&mut state, &cfg, batch, None).expect("run_batch");
+
+    assert_eq!(kept.templates().len(), 1, "the correctable template is kept");
+    let template = &kept.templates()[0];
+    // The corrected UMI is written to RX regardless of original-UMI storage.
+    assert_eq!(template_rx(template), "AAAA", "RX is corrected to the whitelist UMI");
+    // The pre-correction UMI is stored under OX only when storage is enabled.
+    assert_eq!(
+        template_tag(template, SamTag::OX),
+        expected_ox.map(str::to_string),
+        "OX carries the original UMI iff dont_store_original_umis is false",
+    );
+}
+
+/// An all-on-whitelist batch produces no rejects (`None`) from the
+/// 2-output path, so the framework emits a zero-byte rejects block instead.
+/// This drives `run_batch` directly; its end-to-end companion,
+/// `correct_step_with_rejects_pipeline_emits_empty_rejects_for_clean_input`,
+/// proves the same invariant holds when the real pipeline drives the factory.
+#[test]
+fn run_batch_with_rejects_no_rejects_when_all_kept() {
+    let cfg = Arc::new(make_default_cfg());
+    let mut state = make_state();
+
+    let batch = BamTemplateBatch::new(3, vec![make_template_with_rx(b"exact", "AAAA")]);
+    let (kept, rejects) = run_batch_collecting_rejects(&mut state, &cfg, batch);
+
+    assert_eq!(kept.templates().len(), 1);
+    // X5-001: the block is still emitted, just empty — the rejects branch needs a
+    // dense serial sequence, so "no rejects" is a zero-byte block, not a gap.
+    assert_eq!(rejects.batch_serial, 3);
+    assert!(rejects.bytes.is_empty(), "no rejected records -> zero-byte rejects block");
+    assert_eq!(cfg.records_emitted.load(Ordering::Relaxed), 1);
+}
+
+/// Build a single-record template with **no** `RX` tag — the missing-UMI case.
+fn make_template_without_rx(qname: &[u8]) -> Template {
+    let mut b = SamBuilder::new();
+    b.read_name(qname).flags(0).sequence(b"ACGT").qualities(b"IIII");
+    Template::from_records(vec![b.build()]).expect("single-record template")
+}
+
+/// Total credited to one per-UMI bucket, or 0 when the bucket is absent.
+fn bucket_total(metrics: &CollectedCorrectMetrics, umi: &str) -> u64 {
+    metrics.umi_matches.get(umi).map_or(0, |m| m.total_matches)
+}
+
+/// Per-UMI crediting must match fgbio, which the legacy `execute` path
+/// implements via `CorrectUmis::credit_umi_metrics`. These are the three cases
+/// where a whole-template "unmatched" credit diverges from fgbio's per-segment
+/// accounting, so each is pinned independently.
+///
+/// - A **missing-UMI** template is counted only in `missing_umis`; fgbio never
+///   credits the all-`N` bucket for it (`CorrectUmis.scala:199-202`).
+/// - A **wrong-length** UMI never reaches matching, so it credits no bucket.
+/// - A **mismatched** template still credits its matched segments, and credits
+///   the all-`N` bucket only for the segments that actually failed. The
+///   `AAAA-TTTT` case is the discriminating one: the template is rejected on
+///   its second segment, yet the first still credits `AAAA`. Crediting the
+///   whole template to the all-`N` bucket would leave `AAAA` at zero.
+#[rstest]
+#[case::missing_umi_credits_no_bucket(None, 1, 0, 0, 0, 0)]
+#[case::wrong_length_credits_no_bucket(Some("AA"), 0, 1, 0, 0, 0)]
+#[case::offlist_credits_only_the_n_bucket(Some("TTTT"), 0, 0, 1, 0, 1)]
+#[case::partial_match_credits_both_segments(Some("AAAA-TTTT"), 0, 0, 1, 1, 1)]
+#[case::onlist_credits_its_own_bucket(Some("AAAA"), 0, 0, 0, 1, 0)]
+fn per_umi_crediting_matches_fgbio(
+    #[case] rx: Option<&str>,
+    #[case] expected_missing: u64,
+    #[case] expected_wrong_length: u64,
+    #[case] expected_mismatched: u64,
+    #[case] expected_aaaa_bucket: u64,
+    #[case] expected_n_bucket: u64,
+) {
+    let cfg = Arc::new(make_default_cfg());
+    let mut state = make_state();
+
+    let template = match rx {
+        Some(umi) => make_template_with_rx(b"t", umi),
+        None => make_template_without_rx(b"t"),
+    };
+    let batch = BamTemplateBatch::new(0, vec![template]);
+    let _kept = run_batch(&mut state, &cfg, batch, None).expect("run_batch");
+
+    let slot = &cfg.metrics.slots()[0];
+    let metrics = slot.lock();
+    assert_eq!(metrics.templates_processed, 1, "every template counts exactly once");
+    assert_eq!(metrics.missing_umis, expected_missing, "missing_umis");
+    assert_eq!(metrics.wrong_length, expected_wrong_length, "wrong_length");
+    assert_eq!(metrics.mismatched, expected_mismatched, "mismatched");
+    assert_eq!(bucket_total(&metrics, "AAAA"), expected_aaaa_bucket, "AAAA bucket");
+    assert_eq!(bucket_total(&metrics, "NNNN"), expected_n_bucket, "all-N bucket");
+}
+
+/// The kept-only path keeps exactly the same templates as the with-rejects
+/// path's kept branch, but silently DROPS rejected templates (there is no
+/// rejects branch to inspect).
+#[test]
+fn run_batch_kept_only_drops_rejected() {
+    let cfg = Arc::new(make_default_cfg());
+    let mut state = make_state();
+
+    let templates = vec![
+        make_template_with_rx(b"exact", "AAAA"),
+        make_template_with_rx(b"correctable", "AAAT"),
+        make_template_with_rx(b"offlist", "TTTT"),
+    ];
+    let batch = BamTemplateBatch::new(11, templates);
+
+    let kept = run_batch(&mut state, &cfg, batch, None).expect("run_batch kept-only");
+
+    // Only the AAAA + correctable templates survive; TTTT is dropped silently.
+    assert_eq!(kept.batch_serial(), 11);
+    assert_eq!(kept.templates().len(), 2, "TTTT dropped, no rejects branch");
+    let mut kept_umis: Vec<String> = kept.templates().iter().map(template_rx).collect();
+    kept_umis.sort();
+    assert_eq!(kept_umis, vec!["AAAA".to_string(), "AAAA".to_string()]);
+    // Pin kept identity by QNAME: the on-whitelist `exact` and the `correctable`
+    // template survive; `offlist` (TTTT) is the one dropped.
+    let mut kept_qnames: Vec<String> = kept.templates().iter().map(template_qname).collect();
+    kept_qnames.sort();
+    assert_eq!(kept_qnames, vec!["correctable".to_string(), "exact".to_string()]);
+
+    assert_eq!(cfg.records_emitted.load(Ordering::Relaxed), 2);
+
+    let slot = &cfg.metrics.slots()[0];
+    let metrics = slot.lock();
+    assert_eq!(metrics.mismatched, 1, "rejected template still counted in metrics");
+}
+
+/// Decode a BAM-framed reject block into the `QNAME` of each record. The
+/// missing-UMI case carries no `RX` to key on, so identity is pinned by read
+/// name instead -- an independent inverse of `append_framed_raw_record`.
+fn reject_block_qnames(bytes: &[u8]) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut offset = 0;
+    while offset < bytes.len() {
+        let block_size = u32::from_le_bytes(
+            bytes[offset..offset + 4].try_into().expect("4-byte block_size prefix"),
+        ) as usize;
+        offset += 4;
+        let body = &bytes[offset..offset + block_size];
+        let name = fgumi_raw_bam::read_name(body);
+        names.push(String::from_utf8(name.to_vec()).expect("qname is valid UTF-8"));
+        offset += block_size;
+    }
+    names
+}
+
+/// A template with no `RX` tag is a missing-UMI reject. On the 2-output
+/// (`--rejects`) path its record must be framed into the rejects block
+/// unchanged -- the `run_batch` branch a kept-only run never takes -- while it
+/// credits only `missing_umis` and no per-UMI bucket.
+#[test]
+fn run_batch_with_rejects_routes_missing_umi_to_rejects() {
+    let cfg = Arc::new(make_default_cfg());
+    let mut state = make_state();
+
+    let batch = BamTemplateBatch::new(
+        5,
+        vec![make_template_with_rx(b"kept", "AAAA"), make_template_without_rx(b"no_umi")],
+    );
+    let (kept, rejects) = run_batch_collecting_rejects(&mut state, &cfg, batch);
+
+    // Only the on-whitelist template survives; the missing-UMI one is rejected.
+    assert_eq!(kept.templates().len(), 1);
+    assert_eq!(template_qname(&kept.templates()[0]), "kept");
+
+    // The missing-UMI record reaches the rejects block, keyed by QNAME since it
+    // has no RX. A non-empty-bytes check alone would pass on the wrong record.
+    assert_eq!(rejects.batch_serial, 5);
+    assert_eq!(
+        reject_block_qnames(&rejects.bytes),
+        vec!["no_umi".to_string()],
+        "the missing-UMI record is framed into rejects unchanged",
+    );
+    assert_eq!(cfg.records_emitted.load(Ordering::Relaxed), 1, "only the kept record is emitted");
+
+    let slot = &cfg.metrics.slots()[0];
+    let metrics = slot.lock();
+    assert_eq!(metrics.missing_umis, 1, "the RX-less template credits missing_umis");
+    assert_eq!(metrics.mismatched, 0, "a missing UMI is not a mismatch");
+}
+
+// ============================================================================
+// End-to-end pipeline tests
+//
+// The batch-routing tests above call `run_batch` directly, which leaves the
+// factory functions' `init` (per-worker cache construction) and `body`
+// (the closure the framework invokes per batch) closures unexercised — they
+// only run when the framework drives the step. These tests assemble a real
+// `Pipeline` around each factory so those closures execute, at 1 and 4 threads
+// and with the cache both enabled and disabled (the `Some`/`None` arms of the
+// lazy-init closure).
+// ============================================================================
+
+/// Build a `CorrectStepConfig` with an explicit `cache_size`. `cache_size = 0`
+/// drives the factory's cache-disabled (`None`) init arm; any positive value
+/// drives the `Some(LruCache)` arm.
+fn make_cfg_with_cache(cache_size: usize) -> CorrectStepConfig {
+    let mut cfg = make_default_cfg();
+    cfg.opts.cache_size = cache_size;
+    cfg
+}
+
+/// The standard mixed batch used by the end-to-end tests: one on-whitelist
+/// template (kept, unchanged), one correctable (kept, rewritten to `AAAA`),
+/// one off-whitelist (rejected: mismatched), and one missing-UMI (rejected:
+/// missing). `serial` distinguishes the batches so a routing regression that
+/// dropped or duplicated a batch is visible.
+fn mixed_batch(serial: usize) -> BamTemplateBatch {
+    let templates = vec![
+        make_template_with_rx(b"exact", "AAAA"),
+        make_template_with_rx(b"correctable", "AAAT"),
+        make_template_with_rx(b"offlist", "TTTT"),
+        make_template_without_rx(b"no_umi"),
+    ];
+    BamTemplateBatch::new(serial as u64, templates)
+}
+
+/// An all-clean batch: two templates that both survive correction (`exact`
+/// stays `AAAA`, `correctable` is rewritten to `AAAA`). Nothing is rejected, so
+/// the factory's rejects branch must still emit one *empty* block for this
+/// serial to keep the `ByItemOrdinal` sequence dense (X5-001).
+fn clean_batch(serial: usize) -> BamTemplateBatch {
+    let templates = vec![
+        make_template_with_rx(b"exact", "AAAA"),
+        make_template_with_rx(b"correctable", "AAAT"),
+    ];
+    BamTemplateBatch::new(serial as u64, templates)
+}
+
+/// Test-local source that replays pre-built items into the chain. `Exclusive`
+/// so it owns its cursor and is never cloned per worker. Held-item retry keeps
+/// the ordinal sequence dense for the downstream `ByItemOrdinal` reorder.
+struct ReplaySource<T: Send + HeapSize + Ordered + 'static> {
+    items: VecDeque<T>,
+    held: HeldSlot<Unpushed<T>>,
+}
+
+impl<T: Send + HeapSize + Ordered + 'static> ReplaySource<T> {
+    fn new(items: Vec<T>) -> Self {
+        Self { items: items.into(), held: HeldSlot::new() }
+    }
+}
+
+impl<T: Send + HeapSize + Ordered + 'static> Step for ReplaySource<T> {
+    type Input = ();
+    type Outputs = OrderedBytesSingle<T>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ReplaySource",
+            kind: StepKind::Exclusive,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: 4096 }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        let Some(item) = self.items.pop_front() else {
+            return Ok(StepOutcome::Finished);
+        };
+        if let Err(unpushed) = ctx.outputs.push(item) {
+            self.held.put(unpushed);
+        }
+        Ok(StepOutcome::Progress)
+    }
+}
+
+/// Terminal sink that accumulates every item it receives. `Exclusive` so
+/// arrival is the chain's output order with no sink-side interleaving.
+struct CollectSink<T: Send + HeapSize + 'static> {
+    collected: Arc<Mutex<Vec<T>>>,
+}
+
+impl<T: Send + HeapSize + 'static> Step for CollectSink<T> {
+    type Input = T;
+    type Outputs = ();
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "CollectSink",
+            kind: StepKind::Exclusive,
+            sticky: false,
+            output_queues: vec![],
+            branch_ordering: vec![],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        match ctx.input.pop() {
+            Some(item) => {
+                self.collected.lock().expect("sink mutex not poisoned").push(item);
+                Ok(StepOutcome::Progress)
+            }
+            None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+            None => Ok(StepOutcome::NoProgress),
+        }
+    }
+}
+
+/// Sum a metric across every accumulator slot. Workers claim slots by thread
+/// index, so at >1 thread the counts can land in different slots.
+fn sum_metrics<F: Fn(&CollectedCorrectMetrics) -> u64>(
+    metrics: &PerThreadAccumulator<CollectedCorrectMetrics>,
+    field: F,
+) -> u64 {
+    metrics.slots().iter().map(|slot| field(&slot.lock())).sum()
+}
+
+/// Sort the kept QNAMEs collected from every kept batch.
+fn sorted_kept_qnames(batches: &Arc<Mutex<Vec<BamTemplateBatch>>>) -> Vec<String> {
+    let guard = batches.lock().expect("kept mutex not poisoned");
+    let mut names: Vec<String> =
+        guard.iter().flat_map(|b| b.templates().iter().map(template_qname)).collect();
+    names.sort();
+    names
+}
+
+/// The batch serials of every kept batch, in the order they arrived at the
+/// sink. Both output branches are `ByItemOrdinal`-ordered, so an intact run
+/// yields the dense sequence `0..n_batches`; a dropped-then-duplicated batch
+/// (which identical records would hide from a QNAME check) shows up here as a
+/// repeated or missing serial.
+fn kept_batch_serials(batches: &Arc<Mutex<Vec<BamTemplateBatch>>>) -> Vec<u64> {
+    batches
+        .lock()
+        .expect("kept mutex not poisoned")
+        .iter()
+        .map(BamTemplateBatch::batch_serial)
+        .collect()
+}
+
+/// The batch serials of every rejects block, in sink-arrival order. The factory
+/// emits exactly one block per input batch (empty when nothing was rejected),
+/// so these must also form the dense sequence `0..n_batches`.
+fn reject_block_serials(blocks: &Arc<Mutex<Vec<DecompressedBlock>>>) -> Vec<u64> {
+    blocks.lock().expect("rejects mutex not poisoned").iter().map(|b| b.batch_serial).collect()
+}
+
+/// The 2-output factory, driven through a real `Pipeline`, must split every
+/// batch into a kept branch (on-whitelist + correctable templates) and a
+/// rejects branch (framed off-whitelist + missing-UMI records), preserving the
+/// per-batch routing across `n_batches` batches and both thread counts. Running
+/// it end-to-end is what exercises the factory's `init` and `body` closures.
+#[rstest]
+fn correct_step_with_rejects_pipeline_splits_every_batch(
+    #[values(1, 4)] threads: usize,
+    #[values(0, 100_000)] cache_size: usize,
+) {
+    let n_batches: usize = 3;
+    let cfg = make_cfg_with_cache(cache_size);
+    let metrics = Arc::clone(&cfg.metrics);
+    let records_emitted = Arc::clone(&cfg.records_emitted);
+
+    let inputs: Vec<BamTemplateBatch> = (0..n_batches).map(mixed_batch).collect();
+    let kept: Arc<Mutex<Vec<BamTemplateBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let rejects: Arc<Mutex<Vec<DecompressedBlock>>> = Arc::new(Mutex::new(Vec::new()));
+    let (kept_sink, rejects_sink) = (Arc::clone(&kept), Arc::clone(&rejects));
+
+    let builder = Pipeline::builder();
+    let multi =
+        builder.chain(ReplaySource::new(inputs)).chain(correct_step_with_rejects(cfg)).into_multi();
+    multi.b0.chain(CollectSink { collected: kept_sink }).into_sink_marker();
+    multi.b1.chain(CollectSink { collected: rejects_sink }).into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    // Two templates kept per batch: the on-whitelist `exact` and `correctable`
+    // (sorted: all `correctable` then all `exact`).
+    let expected_kept: Vec<String> = std::iter::repeat_n("correctable".to_string(), n_batches)
+        .chain(std::iter::repeat_n("exact".to_string(), n_batches))
+        .collect();
+    assert_eq!(sorted_kept_qnames(&kept), expected_kept, "kept branch keeps exact + correctable");
+
+    // Rejects: the off-whitelist `offlist` and the missing-UMI `no_umi`, framed
+    // once per batch. Concatenating the framed blocks yields a self-delimiting
+    // sequence the decoder walks record by record.
+    let reject_bytes: Vec<u8> = rejects
+        .lock()
+        .expect("rejects mutex not poisoned")
+        .iter()
+        .flat_map(|block| block.bytes.clone())
+        .collect();
+    let mut reject_names = reject_block_qnames(&reject_bytes);
+    reject_names.sort();
+    // Sorted: all `no_umi` then all `offlist`.
+    let expected_rejects: Vec<String> = std::iter::repeat_n("no_umi".to_string(), n_batches)
+        .chain(std::iter::repeat_n("offlist".to_string(), n_batches))
+        .collect();
+    assert_eq!(reject_names, expected_rejects, "rejects branch frames offlist + missing per batch");
+
+    // Every input batch has identical records, so QNAME counts alone cannot
+    // distinguish a dropped batch that a duplicate silently replaced. Pin the
+    // per-batch identity by asserting both branches carry serials `0..n_batches`
+    // in output order.
+    let expected_serials: Vec<u64> = (0..n_batches as u64).collect();
+    assert_eq!(
+        kept_batch_serials(&kept),
+        expected_serials,
+        "kept branch carries a dense serial run"
+    );
+    assert_eq!(
+        reject_block_serials(&rejects),
+        expected_serials,
+        "rejects branch emits one block per input serial, densely",
+    );
+
+    let n_batches = n_batches as u64;
+    assert_eq!(
+        records_emitted.load(Ordering::Relaxed),
+        2 * n_batches,
+        "records_emitted counts the two kept single-record templates per batch",
+    );
+    assert_eq!(sum_metrics(&metrics, |m| m.mismatched), n_batches, "one mismatched per batch");
+    assert_eq!(sum_metrics(&metrics, |m| m.missing_umis), n_batches, "one missing-UMI per batch");
+    assert_eq!(
+        sum_metrics(&metrics, |m| m.templates_processed),
+        4 * n_batches,
+        "every template in every batch is counted once",
+    );
+}
+
+/// A fully clean input (every template kept) driven end-to-end through
+/// `correct_step_with_rejects`. The `run_batch_with_rejects_no_rejects_when_all_kept`
+/// unit test asserts the same X5-001 invariant against `run_batch` directly, but
+/// only the real pipeline exercises the factory body and the rejects branch's
+/// `ByItemOrdinal` reorder stage: a regression that omitted the second output
+/// (pushing `only_a`) would wedge that stage rather than fail an assert. This
+/// case proves the pipeline completes and emits exactly one *empty* rejects
+/// block per input serial.
+#[rstest]
+fn correct_step_with_rejects_pipeline_emits_empty_rejects_for_clean_input(
+    #[values(1, 4)] threads: usize,
+) {
+    let n_batches: usize = 3;
+    let cfg = make_default_cfg();
+    let records_emitted = Arc::clone(&cfg.records_emitted);
+
+    let inputs: Vec<BamTemplateBatch> = (0..n_batches).map(clean_batch).collect();
+    let kept: Arc<Mutex<Vec<BamTemplateBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let rejects: Arc<Mutex<Vec<DecompressedBlock>>> = Arc::new(Mutex::new(Vec::new()));
+    let (kept_sink, rejects_sink) = (Arc::clone(&kept), Arc::clone(&rejects));
+
+    let builder = Pipeline::builder();
+    let multi =
+        builder.chain(ReplaySource::new(inputs)).chain(correct_step_with_rejects(cfg)).into_multi();
+    multi.b0.chain(CollectSink { collected: kept_sink }).into_sink_marker();
+    multi.b1.chain(CollectSink { collected: rejects_sink }).into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    // Both templates in every batch survive, so all `2 * n_batches` records are emitted.
+    let expected_serials: Vec<u64> = (0..n_batches as u64).collect();
+    assert_eq!(
+        kept_batch_serials(&kept),
+        expected_serials,
+        "kept branch carries a dense serial run"
+    );
+    let kept_count: usize =
+        kept.lock().expect("kept mutex not poisoned").iter().map(|b| b.templates().len()).sum();
+    assert_eq!(kept_count, 2 * n_batches, "every clean template is kept");
+    assert_eq!(records_emitted.load(Ordering::Relaxed), 2 * n_batches as u64);
+
+    // The rejects branch emits exactly one block per input serial, each empty —
+    // the X5-001 invariant that keeps `ByItemOrdinal` dense on a clean input.
+    assert_eq!(
+        reject_block_serials(&rejects),
+        expected_serials,
+        "one rejects block per input serial, densely",
+    );
+    assert!(
+        rejects.lock().expect("rejects mutex not poisoned").iter().all(|b| b.bytes.is_empty()),
+        "a clean batch emits a zero-byte rejects block, not a gap",
+    );
+}
+
+/// The kept-only factory, driven through a real `Pipeline`, keeps the same
+/// templates as the 2-output path but drops the rejected ones silently — there
+/// is no rejects branch. Running it end-to-end exercises the kept-only
+/// factory's `init` and `body` closures.
+#[rstest]
+fn correct_step_kept_only_pipeline_keeps_survivors(
+    #[values(1, 4)] threads: usize,
+    #[values(0, 100_000)] cache_size: usize,
+) {
+    let n_batches: usize = 3;
+    let cfg = make_cfg_with_cache(cache_size);
+    let metrics = Arc::clone(&cfg.metrics);
+    let records_emitted = Arc::clone(&cfg.records_emitted);
+
+    let inputs: Vec<BamTemplateBatch> = (0..n_batches).map(mixed_batch).collect();
+    let kept: Arc<Mutex<Vec<BamTemplateBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let kept_sink = Arc::clone(&kept);
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReplaySource::new(inputs))
+        .chain(correct_step_kept_only(cfg))
+        .chain(CollectSink { collected: kept_sink })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let expected_kept: Vec<String> = std::iter::repeat_n("correctable".to_string(), n_batches)
+        .chain(std::iter::repeat_n("exact".to_string(), n_batches))
+        .collect();
+    assert_eq!(sorted_kept_qnames(&kept), expected_kept, "kept-only keeps exact + correctable");
+
+    let n_batches = n_batches as u64;
+    assert_eq!(
+        records_emitted.load(Ordering::Relaxed),
+        2 * n_batches,
+        "records_emitted counts the two kept templates per batch",
+    );
+    // Rejected templates are dropped but still counted in metrics.
+    assert_eq!(sum_metrics(&metrics, |m| m.mismatched), n_batches, "one mismatched per batch");
+    assert_eq!(sum_metrics(&metrics, |m| m.missing_umis), n_batches, "one missing-UMI per batch");
+}
+
+/// `CorrectWorkerState` deliberately reports `heap_size = 0`: the `LruCache` it
+/// wraps has no `HeapSize` impl, so its footprint is intentionally excluded from
+/// the pipeline's memory bound (documented on the `impl`). Pin that for both the
+/// cache-enabled and cache-disabled workers so a future switch to real
+/// accounting has to update this consciously.
+#[test]
+fn correct_worker_state_reports_zero_heap_size() {
+    assert_eq!(make_state().heap_size(), 0, "cache-enabled worker reports zero");
+    assert_eq!(
+        CorrectWorkerState { cache: None }.heap_size(),
+        0,
+        "cache-disabled worker reports zero",
+    );
+}

--- a/src/lib/pipeline/steps/group/bam.rs
+++ b/src/lib/pipeline/steps/group/bam.rs
@@ -1,0 +1,218 @@
+//! `GroupBam` mid-step. `Serial + ByItemOrdinal`. Wraps the legacy
+//! [`crate::grouper::TemplateGrouper`]: incoming `DecodedRecordBatch`es
+//! (records + pre-computed `GroupKey` from the parallel `DecodeRecords`
+//! step) are batched by QNAME into `Template`s and emitted as
+//! `BamTemplateBatch`es.
+//!
+//! Templates can span batch boundaries (a template may have records in
+//! consecutive `DecodedRecordBatch`es). The `Serial` mutex is held briefly
+//! per call and the per-record `GroupKey` work happens upstream in
+//! parallel — matches legacy's "Decode (parallel) → Group (serial)"
+//! split (`pipeline/bam.rs:329-403, 2269-2571`).
+//!
+//! Once the input is drained, `try_run` calls the grouper's `finish()` once
+//! (guarded by `finalized`) to flush any final partial template, emits whatever
+//! batches remain queued, and only then reports `Finished`.
+//!
+//! ## One emitted batch per formed batch
+//!
+//! [`TemplateGrouper::add_records`] already returns *correctly sized* batches —
+//! its `collect_batches` peels off exactly `batch_size` templates at a time and
+//! leaves the remainder pending — so this step must not flatten them back
+//! together. An earlier version did, `extend`ing every returned batch into one
+//! output, which turned `template_batch_size` from a bound into a mere trigger:
+//! the emitted batch was sized by however many templates one input batch
+//! happened to complete, measured at 624x the configured size for a 40k-record
+//! input. That also let a single item blow the output queue's byte budget wide
+//! open, since [`crate::pipeline::core::queues::ByteBoundedQueue`] admits any
+//! item once it is under budget (a strict `cur + size <= limit` would deadlock
+//! producers whose items legitimately exceed the limit).
+//!
+//! Batches the output queue has no room for are parked in `pending_batches` and
+//! re-offered on later calls, which is why `Finished` is gated on that queue
+//! being empty as well as on the input being drained.
+
+use std::collections::VecDeque;
+use std::io;
+
+use crate::grouper::TemplateGrouper;
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::{BamTemplateBatch, DecodedRecordBatch};
+use crate::template::Template;
+use fgumi_bam_io::Grouper;
+
+/// Max inputs processed per `try_run` invocation. Amortizes the `Serial`
+/// mutex acquisition; matches legacy `bam.rs:2497+` (`MAX_BATCHES_PER_LOCK`).
+const MAX_BATCHES_PER_LOCK: usize = 8;
+
+/// `Serial + ByItemOrdinal` template grouper. Holds a [`TemplateGrouper`]
+/// and consumes pre-decoded records from upstream `DecodeRecords`.
+pub struct GroupBam {
+    grouper: TemplateGrouper,
+    /// Self-managed output ordinal. Incremented only when a new
+    /// `BamTemplateBatch` is emitted. Templates may span several input
+    /// batches (a partial template with no `Grouper`-emitted output);
+    /// using the input's `batch_serial` would skip ordinals and deadlock
+    /// the downstream `ReorderStage`.
+    next_output_serial: u64,
+    /// Batches the grouper has already formed but the output queue has not yet
+    /// accepted, in emission order.
+    ///
+    /// Distinct from `held`, which parks the single batch whose push was
+    /// *rejected*: one `add_records` call can complete many batches, and only
+    /// one of them can be in flight at a time, so the rest queue here rather
+    /// than being merged into an oversized batch.
+    pending_batches: VecDeque<Vec<Template>>,
+    /// Pending output (when push is rejected).
+    held: HeldSlot<Unpushed<BamTemplateBatch>>,
+    /// Set once the final-flush path has called the (non-idempotent)
+    /// `grouper.finish()`; guards against a second call across the
+    /// multi-pass completion drain.
+    finalized: bool,
+    output_byte_limit: u64,
+    name: &'static str,
+}
+
+impl GroupBam {
+    /// Construct a `GroupBam` step.
+    ///
+    /// * `template_batch_size` — number of templates per emitted batch
+    ///   (passed through to `TemplateGrouper::new`).
+    /// * `output_byte_limit` — byte budget for the output queue.
+    #[must_use]
+    pub fn new(template_batch_size: usize, output_byte_limit: u64) -> Self {
+        Self {
+            grouper: TemplateGrouper::new(template_batch_size),
+            next_output_serial: 0,
+            pending_batches: VecDeque::new(),
+            held: HeldSlot::new(),
+            finalized: false,
+            output_byte_limit,
+            name: "GroupBam",
+        }
+    }
+}
+
+impl Step for GroupBam {
+    type Input = DecodedRecordBatch;
+    type Outputs = OrderedBytesSingle<BamTemplateBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Serial,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        // Flush batches formed by an earlier call before forming any more, so
+        // `pending_batches` drains rather than growing. If the output is still
+        // refusing, stop here — taking more input would only deepen the queue.
+        if self.emit_pending(ctx) {
+            return Ok(StepOutcome::Progress);
+        }
+
+        // Process up to `MAX_BATCHES_PER_LOCK` inputs per `try_run` to
+        // amortize the Serial mutex acquisition.
+        let mut did_work = false;
+        for _ in 0..MAX_BATCHES_PER_LOCK {
+            let Some(batch) = ctx.input.pop() else { break };
+            did_work = true;
+            let records = batch.into_records();
+
+            // Feed pre-decoded records into the wrapped grouper. The grouper
+            // returns zero or more completed `TemplateBatch`es (= `Vec<Template>`),
+            // each already capped at `template_batch_size`. Queue them as-is —
+            // merging them here would undo that cap.
+            self.pending_batches.extend(self.grouper.add_records(records)?);
+        }
+
+        if did_work {
+            self.emit_pending(ctx);
+            return Ok(StepOutcome::Progress);
+        }
+
+        // No input this call. If upstream is drained, flush the inner
+        // grouper's final partial template once (guarded by `finalized` —
+        // `grouper.finish()` is not idempotent), then drain whatever is still
+        // queued. `held` is empty here (step 1 returned `Contention`
+        // otherwise); a bounced push is parked in `held` for the held-drain at
+        // the top of the next pass.
+        if ctx.input.is_drained() {
+            if !self.finalized {
+                self.finalized = true;
+                if let Some(final_batch) = self.grouper.finish()?
+                    && !final_batch.is_empty()
+                {
+                    self.pending_batches.push_back(final_batch);
+                }
+            }
+            // `Finished` must wait for the queue to empty: reporting it while a
+            // batch is still queued closes the output with records unsent,
+            // which surfaces as short output far from here rather than as an
+            // error at the point of loss.
+            if !self.pending_batches.is_empty() {
+                self.emit_pending(ctx);
+                return Ok(StepOutcome::Progress);
+            }
+            return Ok(StepOutcome::Finished);
+        }
+        Ok(StepOutcome::NoProgress)
+    }
+}
+
+impl GroupBam {
+    /// Push queued batches until the output rejects one or the queue empties.
+    ///
+    /// Returns `true` if a push was rejected — the batch is parked in `held`
+    /// and the caller should yield rather than take on more work. Ordinals are
+    /// consumed in emission order, including for the rejected batch, because
+    /// `held` retries that same batch with the ordinal it was assigned; the
+    /// `ByItemOrdinal` reorder stage downstream releases only contiguously, so
+    /// a skipped or reused ordinal would stall it.
+    fn emit_pending(&mut self, ctx: &mut StepCtx<'_, Self>) -> bool {
+        while let Some(templates) = self.pending_batches.pop_front() {
+            let serial = self.next_output_serial;
+            self.next_output_serial += 1;
+            let out = BamTemplateBatch::new(serial, templates);
+            if let Err(unpushed) = ctx.outputs.push(out) {
+                self.held.put(unpushed);
+                return true;
+            }
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_advertises_serial_byordinal() {
+        let s = GroupBam::new(64, 1024);
+        let p = s.profile();
+        assert_eq!(p.name, "GroupBam");
+        assert_eq!(p.kind, StepKind::Serial);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+}

--- a/src/lib/pipeline/steps/group/mi.rs
+++ b/src/lib/pipeline/steps/group/mi.rs
@@ -1,0 +1,814 @@
+//! `GroupByMi` step for the new typed-step pipeline framework.
+//!
+//! Mirrors the legacy pipeline's MI-tag grouping (`fgumi simplex`,
+//! `fgumi duplex`): consumes `DecodedRecordBatch` items in input order,
+//! accumulates records by MI tag value via run-length grouping (assumes
+//! input is already sorted by MI, which is the contract upstream of
+//! consensus calling), and emits **batches** of completed `MiGroup`s as
+//! a single `BatchedMiGroups` per output ordinal.
+//!
+//! Design follows `GroupByPosition`: `Serial` + `ByItemOrdinal`, batched
+//! output to amortize downstream `Serial` mutex cost, held-slot retry
+//! pattern for backpressure.
+
+use std::io;
+
+use crate::mi_group::{MiGroup, MiKey, MiTransform};
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::item::{HeapSize, Ordered};
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::DecodedRecordBatch;
+use fgumi_bam_io::MemoryEstimate;
+
+/// Max input batches consumed per `try_run` invocation. Amortizes the
+/// Serial mutex acquisition; mirrors `GroupByPosition::MAX_BATCHES_PER_LOCK`.
+const MAX_BATCHES_PER_LOCK: usize = 8;
+
+/// Default target batch count. Mirrors legacy's per-batch group count
+/// for simplex (50 groups per `MiGroupBatch`).
+pub const DEFAULT_TARGET_BATCH_COUNT: usize = 50;
+
+/// Records retained for one MI key between long-run warnings.
+///
+/// `current_records` holds the whole run in progress and is not emitted until
+/// the key changes or input drains, so its size is set by the largest MI family
+/// in the input rather than by any configured limit: `MAX_BATCHES_PER_LOCK`
+/// bounds input consumed *per call*, `target_batch_count` counts *completed*
+/// groups, and the output queue's byte budget bounds what has been *pushed* —
+/// which this has not been. Legacy `MiGrouper` (`crate::mi_group`) retains the
+/// same way, so this is the ported behavior rather than a regression, but a
+/// pathological family can still exhaust memory with no diagnostic at all.
+///
+/// This does not bound anything; it makes the growth *visible* before the run
+/// dies, which is the cheap half of the fix and costs one comparison per record.
+///
+/// 100k is ~100x beyond any legitimate family — even deep amplicon data keeps a
+/// single UMI at a single position in the thousands — so it should never fire on
+/// real input, while still leaving roughly a 10x margin before the retained
+/// records amount to serious memory (100k records is tens of MB; 1M is hundreds).
+const LONG_RUN_WARN_INTERVAL: usize = 100_000;
+
+/// A batch of `MiGroup`s carrying its monotonic ordinal.
+#[derive(Debug)]
+pub struct BatchedMiGroups {
+    pub batch_serial: u64,
+    pub groups: Vec<MiGroup>,
+}
+
+impl BatchedMiGroups {
+    #[must_use]
+    pub fn new(batch_serial: u64, groups: Vec<MiGroup>) -> Self {
+        Self { batch_serial, groups }
+    }
+}
+
+impl HeapSize for BatchedMiGroups {
+    fn heap_size(&self) -> usize {
+        self.groups.iter().map(MemoryEstimate::estimate_heap_size).sum::<usize>()
+            + self.groups.capacity() * std::mem::size_of::<MiGroup>()
+    }
+}
+
+impl Ordered for BatchedMiGroups {
+    fn ordinal(&self) -> u64 {
+        self.batch_serial
+    }
+}
+
+/// Type alias for the optional MI-tag transform closure (mirrors
+/// `MiGrouper`'s `mi_transform`). When set, the closure is invoked
+/// with the raw MI tag bytes and produces a transformed key — used
+/// e.g. by `duplex` to strip `/A` and `/B` suffixes so both strands
+/// of a paired molecule group together.
+type MiTransformFn = Box<dyn Fn(&[u8]) -> String + Send + Sync>;
+
+/// Type alias for the optional record-filter closure (mirrors
+/// `MiGrouper`'s `record_filter`). When set, records that fail the
+/// filter are skipped without contributing to any MI group.
+type RecordFilterFn = Box<dyn Fn(&[u8]) -> bool + Send + Sync>;
+
+/// `Serial + ByItemOrdinal` MI-tag grouper. Records arriving in input
+/// order are partitioned into runs of consecutive same-MI records;
+/// each run becomes one [`MiGroup`]. Completed groups accumulate
+/// until the target batch size is reached, then emit as one
+/// [`BatchedMiGroups`].
+///
+/// State is held behind the framework's per-step mutex (the runtime
+/// stores a `Serial` step inside `Arc<Mutex<...>>` and acquires
+/// per-`try_run`). Held-slot retry pattern matches `GroupByPosition`:
+/// when an emit is rejected by downstream backpressure, the partial
+/// state stays buffered until the held slot drains.
+pub struct GroupByMi {
+    /// MI tag bytes to look up in each record's auxiliary data.
+    tag: [u8; 2],
+    /// Optional cell barcode tag. When set, the group key becomes
+    /// `MI\tCELL`, so reads from different cells with the same MI
+    /// tag are placed in separate groups (mirrors `MiGrouper`).
+    cell_tag: Option<[u8; 2]>,
+    /// Optional record filter (skip records that don't match).
+    record_filter: Option<RecordFilterFn>,
+    /// Optional MI-tag transformation. When set, the raw MI bytes are
+    /// piped through this closure before being used as the group key
+    /// (and stored on the emitted `MiGroup`). When unset, the raw MI
+    /// bytes are used as a UTF-8 lossy string.
+    mi_transform: Option<MiTransformFn>,
+    /// Run-length state: the grouping key currently being accumulated, stored as
+    /// raw comparison bytes so run-boundary detection stays allocation-free on
+    /// the common (no-transform) path. The owned display label is materialized
+    /// only once per group (at the group boundary) via [`MiKey::label`].
+    current_key: Option<MiKey>,
+    /// Run-length state: records accumulated for `current_key`.
+    current_records: Vec<fgumi_raw_bam::RawRecord>,
+    /// `current_records.len()` at which the next long-run warning fires, bumped
+    /// by [`LONG_RUN_WARN_INTERVAL`] each time and reset at every run boundary.
+    ///
+    /// A running threshold rather than `len % INTERVAL == 0`: this is checked
+    /// once per retained record, and a runtime modulo is an integer division on
+    /// that path, where this is a single predictable compare.
+    next_long_run_warn_at: usize,
+    /// Self-managed monotonic ordinal — each emitted *batch* gets the
+    /// next value. Required for `BranchOrdering::ByItemOrdinal`'s
+    /// `ReorderStage` to see contiguous serials.
+    next_ordinal: u64,
+    /// Accumulator: completed groups waiting to be packaged into a batch.
+    accumulator: Vec<MiGroup>,
+    /// Held output slot when downstream rejected the most recent push.
+    held: HeldSlot<Unpushed<BatchedMiGroups>>,
+    target_batch_count: usize,
+    output_byte_limit: u64,
+    /// Records dropped because they carry no MI tag at all. Expected in small
+    /// numbers (e.g. unmapped mates upstream filters missed); reported at
+    /// end-of-stream so a silent whole-input drop cannot go unnoticed.
+    skipped_no_mi: u64,
+    /// Records dropped because MI is present but **not** a `Z` (string) tag.
+    /// Almost always a malformed input rather than a legitimate skip: `fgumi
+    /// group` and fgbio both write MI as a string (it can carry a `/A`,`/B`
+    /// strand suffix), so an `MI:i:` integer silently matches nothing.
+    skipped_non_string_mi: u64,
+    name: &'static str,
+}
+
+impl GroupByMi {
+    /// Construct a `GroupByMi` step grouping by the given 2-byte tag
+    /// (typically `"MI"`).
+    #[must_use]
+    pub fn new(tag: [u8; 2], output_byte_limit: u64) -> Self {
+        Self::with_target_batch_count(tag, output_byte_limit, DEFAULT_TARGET_BATCH_COUNT)
+    }
+
+    /// Construct with a custom target batch count.
+    #[must_use]
+    pub fn with_target_batch_count(
+        tag: [u8; 2],
+        output_byte_limit: u64,
+        target_batch_count: usize,
+    ) -> Self {
+        Self {
+            tag,
+            cell_tag: None,
+            record_filter: None,
+            mi_transform: None,
+            current_key: None,
+            current_records: Vec::new(),
+            next_long_run_warn_at: LONG_RUN_WARN_INTERVAL,
+            next_ordinal: 0,
+            accumulator: Vec::with_capacity(target_batch_count),
+            held: HeldSlot::new(),
+            target_batch_count: target_batch_count.max(1),
+            output_byte_limit,
+            skipped_no_mi: 0,
+            skipped_non_string_mi: 0,
+            name: "GroupByMi",
+        }
+    }
+
+    /// Set an optional cell-barcode tag for composite grouping.
+    #[must_use]
+    pub fn with_cell_tag(mut self, cell_tag: Option<[u8; 2]>) -> Self {
+        self.cell_tag = cell_tag;
+        self
+    }
+
+    /// Install an optional record filter. Records that fail are dropped
+    /// before they contribute to any MI group. Mirrors
+    /// `MiGrouper::with_filter_and_transform`'s filter closure.
+    #[must_use]
+    pub fn with_record_filter<F>(mut self, filter: F) -> Self
+    where
+        F: Fn(&[u8]) -> bool + Send + Sync + 'static,
+    {
+        self.record_filter = Some(Box::new(filter));
+        self
+    }
+
+    /// Install an optional MI-tag transform closure. The raw MI tag
+    /// bytes are piped through this closure to produce the per-record
+    /// group key. Used by `duplex` to strip `/A`/`/B` suffixes so both
+    /// strands of a paired molecule end up in the same MI group.
+    #[must_use]
+    pub fn with_mi_transform<F>(mut self, transform: F) -> Self
+    where
+        F: Fn(&[u8]) -> String + Send + Sync + 'static,
+    {
+        self.mi_transform = Some(Box::new(transform));
+        self
+    }
+
+    /// Borrow the installed MI-transform closure (if any) as the
+    /// `Option<&dyn Fn>` shape [`MiKey`] expects.
+    #[inline]
+    fn transform(&self) -> MiTransform<'_> {
+        self.mi_transform.as_ref().map(|t| t.as_ref() as &dyn Fn(&[u8]) -> String)
+    }
+
+    /// Run the optional filter against a record's bytes; returns `true`
+    /// to keep, `false` to discard.
+    #[inline]
+    fn passes_filter(&self, bam: &[u8]) -> bool {
+        match &self.record_filter {
+            Some(filter) => filter(bam),
+            None => true,
+        }
+    }
+
+    /// Accumulate one raw record into the current MI run, opening a new run (and
+    /// flushing the previous one) at a group boundary. Run-boundary detection is
+    /// an allocation-free byte comparison against the stored key on the common
+    /// (no-transform) path; the owned key is built only when a new run begins.
+    /// Records that fail the optional filter, or that carry no MI tag, are
+    /// dropped (matching `MiGrouper`).
+    fn process_record(&mut self, raw: fgumi_raw_bam::RawRecord) {
+        // Optional filter (mirrors `MiGrouper::should_keep`).
+        if !self.passes_filter(raw.as_ref()) {
+            return;
+        }
+        let same_group = match &self.current_key {
+            Some(key) => {
+                // `None` means no usable MI tag on this record: count why, and skip.
+                let Some(matches) =
+                    key.matches_record(raw.as_ref(), self.tag, self.cell_tag, self.transform())
+                else {
+                    self.count_skipped_record(raw.as_ref());
+                    return;
+                };
+                matches
+            }
+            None => false,
+        };
+        if same_group {
+            self.current_records.push(raw);
+            self.warn_if_run_is_long();
+        } else {
+            // New run (or first record). Build the owned key once at the
+            // boundary; `from_record` returns `None` (skip) without an MI tag.
+            let Some(key) =
+                MiKey::from_record(raw.as_ref(), self.tag, self.cell_tag, self.transform())
+            else {
+                self.count_skipped_record(raw.as_ref());
+                return;
+            };
+            self.flush_current_group();
+            self.current_key = Some(key);
+            self.current_records.push(raw);
+            // A new run starts the ladder over, so a file with many large-but-
+            // legal families warns once per family that crosses the threshold
+            // rather than once and then never again.
+            self.next_long_run_warn_at = LONG_RUN_WARN_INTERVAL;
+        }
+    }
+
+    /// Warn every [`LONG_RUN_WARN_INTERVAL`] records retained for one MI key.
+    ///
+    /// Warning at each multiple rather than once keeps the signal proportional
+    /// to the problem: a run that keeps growing keeps saying so, and because the
+    /// gap between messages is a fixed number of records, the log cannot outpace
+    /// the growth it is reporting.
+    #[inline]
+    fn warn_if_run_is_long(&mut self) {
+        if self.current_records.len() < self.next_long_run_warn_at {
+            return;
+        }
+        let label = self.current_key.as_ref().map_or_else(|| "<none>".to_string(), MiKey::label);
+        log::warn!(
+            "MI group '{label}' has reached {} records held in memory, which is far beyond a \
+             typical family; this step holds a whole MI run before emitting it, so memory will \
+             keep growing until the MI tag changes. Check that the input is grouped and sorted \
+             by MI and that the MI tag is not constant across records.",
+            self.current_records.len(),
+        );
+        self.next_long_run_warn_at =
+            self.current_records.len().saturating_add(LONG_RUN_WARN_INTERVAL);
+    }
+
+    /// Classify a record that produced no usable MI key, so end-of-stream can tell
+    /// "no MI tag" apart from "MI present but the wrong type".
+    ///
+    /// Only runs on the skip path, so it costs nothing for records that group
+    /// normally.
+    #[inline]
+    fn count_skipped_record(&mut self, bam: &[u8]) {
+        let aux = fgumi_raw_bam::aux_data_slice(bam);
+        match fgumi_raw_bam::find_tag_type(aux, self.tag) {
+            // Present but not `Z`: the caller almost certainly meant this record
+            // to group, so it is tracked separately and warned about loudly.
+            Some(kind) if kind != b'Z' => self.skipped_non_string_mi += 1,
+            _ => self.skipped_no_mi += 1,
+        }
+    }
+
+    /// Report records dropped for want of a usable MI tag, once, at end-of-stream.
+    ///
+    /// A wrong-typed MI is warned about unconditionally: it means the input was
+    /// written with e.g. `MI:i:1` instead of `MI:Z:1`, which groups nothing and
+    /// otherwise surfaces only as an inexplicably empty output.
+    fn report_skipped_records(&self) {
+        if self.skipped_non_string_mi > 0 {
+            log::warn!(
+                "{}: dropped {} record(s) whose {} tag is present but not a string (Z) tag. \
+                 fgumi and fgbio write {} as a string because it may carry a /A or /B strand \
+                 suffix; an integer tag such as `MI:i:1` matches no group. Re-run `fgumi group` \
+                 on this input, or rewrite the tag as `MI:Z:`.",
+                self.name,
+                self.skipped_non_string_mi,
+                String::from_utf8_lossy(&self.tag),
+                String::from_utf8_lossy(&self.tag),
+            );
+        }
+        if self.skipped_no_mi > 0 {
+            log::warn!(
+                "{}: dropped {} record(s) carrying no {} tag.",
+                self.name,
+                self.skipped_no_mi,
+                String::from_utf8_lossy(&self.tag),
+            );
+        }
+    }
+
+    /// Flush the run-in-progress into the accumulator (if non-empty). The owned
+    /// display label is materialized here — once per group — from the stored key
+    /// bytes, rather than per record.
+    fn flush_current_group(&mut self) {
+        if let Some(key) = self.current_key.take()
+            && !self.current_records.is_empty()
+        {
+            let records = std::mem::take(&mut self.current_records);
+            self.accumulator.push(MiGroup::new(key.label(), records));
+        }
+    }
+
+    /// Take at most `target_batch_count` groups off the accumulator, leaving
+    /// any excess for the next batch.
+    ///
+    /// The last of the three grouping steps to get this cap; `GroupByPosition`
+    /// and `GroupByQueryname` have the identical method for the identical
+    /// reason. `process_record` appends per record and the `>=` checks run once
+    /// per input batch, so one `DecodedRecordBatch` that closes many MI runs
+    /// leaves the accumulator well past the target — handing it over wholesale
+    /// would size the emitted batch by the input rather than by
+    /// `target_batch_count`, defeating the threshold that exists to bound it.
+    /// The `>=` re-entry in `try_run` and the drained path both loop back here
+    /// until the accumulator falls below the target, so the excess is emitted
+    /// rather than delayed.
+    fn drain_one_batch(&mut self) -> Vec<MiGroup> {
+        let take = self.accumulator.len().min(self.target_batch_count);
+        self.accumulator.drain(..take).collect()
+    }
+
+    /// Package at most `target_batch_count` accumulated groups into a
+    /// `BatchedMiGroups` and emit. On rejection, hold; the next `try_run` will
+    /// retry via the held slot. Always returns `Progress` because we either
+    /// emitted or queued a batch for retry. Leftovers above the cap stay in the
+    /// accumulator, which is also what makes a rejected push safe.
+    fn emit_batch(&mut self, ctx: &mut StepCtx<'_, Self>) -> StepOutcome {
+        let serial = self.next_ordinal;
+        self.next_ordinal += 1;
+        let groups = self.drain_one_batch();
+        let out = BatchedMiGroups::new(serial, groups);
+        if let Err(unpushed) = ctx.outputs.push(out) {
+            self.held.put(unpushed);
+        }
+        StepOutcome::Progress
+    }
+}
+
+impl Step for GroupByMi {
+    type Input = DecodedRecordBatch;
+    type Outputs = OrderedBytesSingle<BatchedMiGroups>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Serial,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // 1. Drain held slot first.
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        // 2. If the accumulator is full enough, emit a batch first;
+        // hold off on more input until it lands.
+        if self.accumulator.len() >= self.target_batch_count {
+            return Ok(self.emit_batch(ctx));
+        }
+
+        // 3. Process up to `MAX_BATCHES_PER_LOCK` input batches per
+        // call to amortize the Serial mutex acquisition.
+        let mut did_work = false;
+        for _ in 0..MAX_BATCHES_PER_LOCK {
+            let Some(batch) = ctx.input.pop() else { break };
+            did_work = true;
+            let records = batch.into_records();
+            for decoded in records {
+                self.process_record(decoded.into_raw_bytes());
+            }
+            if self.accumulator.len() >= self.target_batch_count {
+                break;
+            }
+        }
+
+        if self.accumulator.len() >= self.target_batch_count {
+            return Ok(self.emit_batch(ctx));
+        }
+        if did_work {
+            return Ok(StepOutcome::Progress);
+        }
+
+        // 4. No input this call. If upstream is drained, close the
+        // in-progress MI run, emit the final partial batch, and report
+        // `Finished` once nothing remains. `held` is empty here (step 1
+        // returned `Contention` otherwise); a bounced `emit_batch` push is
+        // parked in `held` for step 1 to retry next pass.
+        if ctx.input.is_drained() {
+            self.flush_current_group();
+            if !self.accumulator.is_empty() {
+                return Ok(self.emit_batch(ctx));
+            }
+            self.report_skipped_records();
+            return Ok(StepOutcome::Finished);
+        }
+        Ok(StepOutcome::NoProgress)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fgumi_raw_bam::RawRecord;
+    use rstest::rstest;
+
+    /// Build a minimal unmapped raw BAM record carrying a single Z-type tag.
+    #[allow(clippy::cast_possible_truncation)]
+    fn raw_with_tag(tag: &str, value: &str) -> RawRecord {
+        raw_with_tags(&[(tag, value)])
+    }
+
+    /// An emitted batch must never exceed `target_batch_count`.
+    ///
+    /// `process_record` appends per record while the `>=` checks run once per
+    /// input batch, so a single `DecodedRecordBatch` that closes many MI runs
+    /// leaves the accumulator well past the target. Taking it wholesale would
+    /// size the emitted batch by the input rather than by the configured
+    /// threshold. Pins that the excess is preserved rather than dropped, and
+    /// that repeated draining converges — which is what makes the `>=` re-entry
+    /// in `try_run` and the drained-path loop terminate.
+    ///
+    /// The third of three: `GroupByPosition` and `GroupByQueryname` carry the
+    /// same test for the same guard.
+    #[test]
+    fn draining_caps_each_batch_and_preserves_the_excess() {
+        use crate::sam::SamTag;
+        const TARGET: usize = 64;
+        let mut step = GroupByMi::with_target_batch_count(*SamTag::MI, 1 << 20, TARGET);
+
+        // 150 completed groups, as one input batch closing many runs would leave.
+        step.accumulator = (0..150).map(|i| MiGroup::new(format!("mi{i}"), Vec::new())).collect();
+
+        let first = step.drain_one_batch();
+        assert_eq!(first.len(), TARGET, "a batch must never exceed the target");
+        assert_eq!(step.accumulator.len(), 86, "the excess stays queued, not dropped");
+
+        let second = step.drain_one_batch();
+        assert_eq!(second.len(), TARGET);
+        assert_eq!(step.accumulator.len(), 22);
+
+        // The tail comes out as a short final batch and the accumulator empties.
+        let third = step.drain_one_batch();
+        assert_eq!(third.len(), 22, "the remainder is emitted as a short batch");
+        assert!(step.accumulator.is_empty());
+        assert!(step.drain_one_batch().is_empty(), "draining an empty accumulator is a no-op");
+    }
+
+    /// The long-run warning re-arms at a fixed record interval and starts over
+    /// at each run boundary.
+    ///
+    /// Drives the threshold from a small seeded value rather than pushing
+    /// `LONG_RUN_WARN_INTERVAL` real records, so the arithmetic is pinned
+    /// without a 100k-record test. What matters is that the next threshold is
+    /// derived from the length *reached* (not the previous threshold), so the
+    /// ladder cannot fall behind a run that grows by more than one record
+    /// between checks, and that a new MI key resets it — otherwise a file of
+    /// many large families would warn once and then stay silent.
+    #[test]
+    fn the_long_run_warning_re_arms_and_resets_at_a_run_boundary() {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20);
+        assert_eq!(
+            step.next_long_run_warn_at, LONG_RUN_WARN_INTERVAL,
+            "a fresh step is armed at the interval",
+        );
+
+        // Open a run, then seed the threshold low enough to trip on the next
+        // record rather than materializing 100k of them.
+        step.process_record(raw_with_tag("MI", "fam"));
+        step.next_long_run_warn_at = 2;
+        step.process_record(raw_with_tag("MI", "fam"));
+        assert_eq!(step.current_records.len(), 2, "both records are retained in one run");
+        assert_eq!(
+            step.next_long_run_warn_at,
+            2 + LONG_RUN_WARN_INTERVAL,
+            "the next warning is a full interval past the length just reached",
+        );
+
+        // A different MI value starts a new run, which re-arms from scratch.
+        step.process_record(raw_with_tag("MI", "other"));
+        assert_eq!(
+            step.next_long_run_warn_at, LONG_RUN_WARN_INTERVAL,
+            "a run boundary resets the ladder so each family warns on its own merits",
+        );
+    }
+
+    /// Build a minimal unmapped raw BAM record carrying a single `i`-type
+    /// (signed 32-bit integer) tag, e.g. the malformed `MI:i:1` that groups
+    /// nothing because MI is defined as a string tag.
+    #[allow(clippy::cast_possible_truncation)]
+    fn raw_with_int_tag(tag: &str, value: i32) -> RawRecord {
+        let t = tag.as_bytes();
+        let mut aux: Vec<u8> = vec![t[0], t[1], b'i'];
+        aux.extend_from_slice(&value.to_le_bytes());
+        raw_with_aux(&aux)
+    }
+
+    /// Build a minimal unmapped raw BAM record carrying the given Z-type tags
+    /// in the supplied aux-block order.
+    #[allow(clippy::cast_possible_truncation)]
+    fn raw_with_tags(tags: &[(&str, &str)]) -> RawRecord {
+        let mut aux: Vec<u8> = Vec::new();
+        for (tag, value) in tags {
+            let t = tag.as_bytes();
+            aux.extend_from_slice(&[t[0], t[1], b'Z']);
+            aux.extend_from_slice(value.as_bytes());
+            aux.push(0);
+        }
+        raw_with_aux(&aux)
+    }
+
+    /// Wrap a pre-encoded aux block in a minimal unmapped raw BAM record.
+    #[allow(clippy::cast_possible_truncation)]
+    fn raw_with_aux(aux: &[u8]) -> RawRecord {
+        let name = b"read";
+        let l_read_name: u8 = (name.len() + 1) as u8;
+        let seq_len: u32 = 4;
+        let seq_bytes = seq_len.div_ceil(2) as usize;
+
+        let total = 32 + l_read_name as usize + seq_bytes + seq_len as usize + aux.len();
+        let mut buf = vec![0u8; total];
+        buf[0..4].copy_from_slice(&(-1i32).to_le_bytes());
+        buf[4..8].copy_from_slice(&(-1i32).to_le_bytes());
+        buf[8] = l_read_name;
+        buf[12..14].copy_from_slice(&0u16.to_le_bytes());
+        buf[16..20].copy_from_slice(&seq_len.to_le_bytes());
+        buf[20..24].copy_from_slice(&(-1i32).to_le_bytes());
+        buf[24..28].copy_from_slice(&(-1i32).to_le_bytes());
+        let name_start = 32;
+        buf[name_start..name_start + name.len()].copy_from_slice(name);
+        buf[name_start + name.len()] = 0;
+        let aux_start = 32 + l_read_name as usize + seq_bytes + seq_len as usize;
+        buf[aux_start..aux_start + aux.len()].copy_from_slice(aux);
+        RawRecord::from(buf)
+    }
+
+    /// Build a minimal unmapped raw BAM record carrying no aux tags.
+    #[allow(clippy::cast_possible_truncation)]
+    fn raw_without_tag() -> RawRecord {
+        raw_with_tags(&[])
+    }
+
+    /// Drive a sequence of records through [`GroupByMi::process_record`], close
+    /// the final run, and return `(label, record_count)` per completed group.
+    fn run_grouping(step: &mut GroupByMi, records: Vec<RawRecord>) -> Vec<(String, usize)> {
+        for raw in records {
+            step.process_record(raw);
+        }
+        step.flush_current_group();
+        step.accumulator.iter().map(|g| (g.mi.clone(), g.records.len())).collect()
+    }
+
+    /// Two MI values that are distinct raw bytes but render to the same
+    /// replacement character must stay in separate groups.
+    ///
+    /// This is the regression test for the `MiKey` change: the previous shape
+    /// ran `String::from_utf8_lossy` *before* comparing, so `\x80` and `\x81`
+    /// both became U+FFFD and the three records below collapsed into one group
+    /// of 3 — silently merging two distinct molecules. `MiKey` compares the raw
+    /// tag bytes and only converts lossily to build the display label.
+    ///
+    /// The labels are asserted to be *identical* on purpose. `MiGroup.mi` is a
+    /// diagnostic string, not an identity: nothing rekeys groups by it or writes
+    /// it back into a BAM, and treating it as unique is exactly the mistake the
+    /// old code made. The record counts are what carry the grouping claim.
+    #[test]
+    fn distinct_invalid_utf8_mi_values_stay_in_separate_groups() {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20);
+        let records = vec![
+            raw_with_aux(b"MIZ\x80\x00"),
+            raw_with_aux(b"MIZ\x80\x00"),
+            raw_with_aux(b"MIZ\x81\x00"),
+        ];
+
+        let groups = run_grouping(&mut step, records);
+
+        assert_eq!(groups.len(), 2, "distinct raw MI bytes must not merge: {groups:?}");
+        assert_eq!(groups[0].1, 2, "the two \\x80 records group together");
+        assert_eq!(groups[1].1, 1, "the \\x81 record is its own group");
+        assert_eq!(
+            groups[0].0, groups[1].0,
+            "both labels render to the same replacement character — the label is \
+             diagnostic, and the separation above is what proves the keys differ",
+        );
+    }
+
+    #[test]
+    fn single_mi_run_forms_one_group() {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20);
+        let records: Vec<RawRecord> = (0..1000).map(|_| raw_with_tag("MI", "7")).collect();
+        let groups = run_grouping(&mut step, records);
+        assert_eq!(groups, vec![("7".to_string(), 1000)]);
+    }
+
+    #[test]
+    fn distinct_mi_values_split_runs_and_label_once() {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20);
+        let records = vec![
+            raw_with_tag("MI", "1"),
+            raw_with_tag("MI", "1"),
+            raw_with_tag("MI", "2"),
+            raw_with_tag("MI", "1"), // non-adjacent: a fresh run, not merged
+        ];
+        let groups = run_grouping(&mut step, records);
+        assert_eq!(groups, vec![("1".to_string(), 2), ("2".to_string(), 1), ("1".to_string(), 1)]);
+    }
+
+    #[test]
+    fn records_without_mi_are_skipped() {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20);
+        let records = vec![
+            raw_without_tag(), // skipped, no current run yet
+            raw_with_tag("MI", "5"),
+            raw_without_tag(), // skipped, current run preserved
+            raw_with_tag("MI", "5"),
+        ];
+        let groups = run_grouping(&mut step, records);
+        assert_eq!(groups, vec![("5".to_string(), 2)]);
+    }
+
+    /// A dropped record must be *counted*, and a wrong-typed MI counted apart from
+    /// an absent one, so end-of-stream can warn instead of emitting a silently
+    /// empty output.
+    ///
+    /// The `MI:i:` case is the one that bites: fgumi and fgbio write MI as a `Z`
+    /// string (it may carry a `/A`,`/B` suffix), so an integer MI matches no group
+    /// and the whole input vanishes with no diagnostic.
+    #[rstest]
+    #[case::integer_mi_is_wrong_type(vec![raw_with_int_tag("MI", 1), raw_with_int_tag("MI", 1)], 0, 2)]
+    #[case::absent_mi(vec![raw_without_tag(), raw_without_tag()], 2, 0)]
+    #[case::mixed(vec![raw_without_tag(), raw_with_int_tag("MI", 3)], 1, 1)]
+    #[case::valid_string_mi_counts_nothing(vec![raw_with_tag("MI", "1"), raw_with_tag("MI", "1")], 0, 0)]
+    fn skipped_records_are_counted_by_reason(
+        #[case] records: Vec<RawRecord>,
+        #[case] expected_no_mi: u64,
+        #[case] expected_non_string_mi: u64,
+    ) {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20);
+        run_grouping(&mut step, records);
+
+        assert_eq!(step.skipped_no_mi, expected_no_mi, "records with no MI tag");
+        assert_eq!(
+            step.skipped_non_string_mi, expected_non_string_mi,
+            "records whose MI is present but not a Z tag",
+        );
+    }
+
+    /// An all-integer-MI input must produce zero groups — the regression that made
+    /// four simplex parity tests compare one empty BAM against another.
+    #[test]
+    fn integer_mi_groups_nothing() {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20);
+        let records = (0..8).map(|_| raw_with_int_tag("MI", 1)).collect();
+        assert!(run_grouping(&mut step, records).is_empty());
+    }
+
+    #[test]
+    fn cell_tag_composite_key_splits_and_labels() {
+        use crate::sam::SamTag;
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20).with_cell_tag(Some(*SamTag::CB));
+        // Same MI, different CB → distinct groups; aux order varies to exercise
+        // the single-pass dual-tag lookup regardless of tag ordering.
+        let records = vec![
+            raw_with_tags(&[("MI", "1"), ("CB", "ACGT")]),
+            raw_with_tags(&[("CB", "ACGT"), ("MI", "1")]),
+            raw_with_tags(&[("MI", "1"), ("CB", "TGCA")]),
+            raw_with_tags(&[("MI", "1"), ("CB", "TGCA")]),
+        ];
+        let groups = run_grouping(&mut step, records);
+        assert_eq!(groups, vec![("1\tACGT".to_string(), 2), ("1\tTGCA".to_string(), 2)]);
+    }
+
+    #[test]
+    fn missing_cell_tag_uses_empty_suffix() {
+        use crate::sam::SamTag;
+        // With a cell tag configured, a record that lacks `CB` keys on an empty
+        // cell suffix (`MI\t`), distinct from a record that carries `CB`. Guards
+        // against a future aux-lookup change silently merging or splitting MI
+        // groups when the configured cell tag is absent.
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20).with_cell_tag(Some(*SamTag::CB));
+        let records = vec![
+            raw_with_tag("MI", "1"),                       // no CB → "1\t"
+            raw_with_tag("MI", "1"),                       // no CB → "1\t"
+            raw_with_tags(&[("MI", "1"), ("CB", "ACGT")]), // → "1\tACGT"
+        ];
+        let groups = run_grouping(&mut step, records);
+        assert_eq!(groups, vec![("1\t".to_string(), 2), ("1\tACGT".to_string(), 1)]);
+    }
+
+    #[test]
+    fn mi_transform_groups_strands_together() {
+        use crate::sam::SamTag;
+        // Strip a trailing "/A" or "/B" so both strands of a molecule group.
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20).with_mi_transform(|mi: &[u8]| {
+            let s = String::from_utf8_lossy(mi);
+            s.split('/').next().unwrap_or("").to_string()
+        });
+        let records =
+            vec![raw_with_tag("MI", "1/A"), raw_with_tag("MI", "1/B"), raw_with_tag("MI", "2/A")];
+        let groups = run_grouping(&mut step, records);
+        // Label is the transformed key, materialized once per group.
+        assert_eq!(groups, vec![("1".to_string(), 2), ("2".to_string(), 1)]);
+    }
+
+    #[test]
+    fn record_filter_drops_records() {
+        use crate::sam::SamTag;
+        // Filter out any record whose MI tag value is "skip".
+        let mut step = GroupByMi::new(*SamTag::MI, 1 << 20).with_record_filter(|bam: &[u8]| {
+            fgumi_raw_bam::find_string_tag_in_record(bam, *SamTag::MI) != Some(b"skip")
+        });
+        let records = vec![
+            raw_with_tag("MI", "1"),
+            raw_with_tag("MI", "skip"), // dropped, run "1" preserved
+            raw_with_tag("MI", "1"),
+        ];
+        let groups = run_grouping(&mut step, records);
+        assert_eq!(groups, vec![("1".to_string(), 2)]);
+    }
+
+    #[test]
+    fn profile_advertises_serial_byordinal() {
+        use crate::sam::SamTag;
+        let s = GroupByMi::new(*SamTag::MI, 1024);
+        let p = s.profile();
+        assert_eq!(p.name, "GroupByMi");
+        assert_eq!(p.kind, StepKind::Serial);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    #[test]
+    fn batched_mi_groups_carries_ordinal() {
+        let groups = vec![MiGroup::new("0".to_string(), Vec::new())];
+        let wrapped = BatchedMiGroups::new(7, groups);
+        assert_eq!(wrapped.ordinal(), 7);
+        assert_eq!(wrapped.groups.len(), 1);
+    }
+}

--- a/src/lib/pipeline/steps/group/mod.rs
+++ b/src/lib/pipeline/steps/group/mod.rs
@@ -1,0 +1,6 @@
+//! Per-format grouping steps.
+
+pub mod bam;
+pub mod mi;
+pub mod position;
+pub mod queryname;

--- a/src/lib/pipeline/steps/group/position.rs
+++ b/src/lib/pipeline/steps/group/position.rs
@@ -1,0 +1,398 @@
+//! `GroupByPosition` step for the new typed-step pipeline framework.
+//!
+//! Mirrors the legacy pipeline's position-based grouping (`fgumi group`):
+//! consumes `DecodedRecordBatch` items in template-coordinate order,
+//! accumulates records by position via `RecordPositionGrouper`, and
+//! emits **batches** of completed `RawPositionGroup`s as a single
+//! `BatchedRawPositionGroups` per output ordinal.
+//!
+//! ## Why batched (not one-group-per-item)
+//!
+//! Legacy's chain operates on `Vec<P>` at every `Serial` step
+//! (`mi_assign`, `serialize`, ...) so each `Serial` step pays one mutex
+//! acquisition per *batch*, not per *group*. The new pipeline's
+//! initial implementation emitted one group per item; profile diff at
+//! 53M records showed `mi_assign`-style per-group serial bottlenecks
+//! collapsed CPU from 4 cores to ~1 effective core mid-run.
+//!
+//! Batching here matches legacy's data-flow shape: the `Group` step
+//! aggregates many small completions into one batch, every downstream
+//! `Serial` step amortizes its lock cost over the whole batch, and the
+//! `Parallel` `Process` / `Serialize` steps each get one fat unit of work
+//! per dispatch.
+//!
+//! ## Ordinal allocation
+//!
+//! Each emitted *batch* gets a fresh `batch_serial: u64` from a per-step
+//! monotonic counter. Ordinals form a contiguous `0, 1, 2, …` sequence
+//! so the downstream `ReorderStage` can release batches in
+//! input-record order — required for the `Serial` `MiAssign` step to
+//! produce deterministic MI numbering across runs (matches legacy
+//! `docs/design/deterministic-mi-numbering.md`).
+//!
+//! ## Batch sizing
+//!
+//! One threshold: `target_batch_count`, defaulting to 64 groups. Mirrors
+//! legacy's `template_batch_size: 500` adjusted for position-group granularity
+//! (one position group ≈ 5–10 templates on typical workloads). It is a hard cap
+//! on the emitted batch, not just a trigger — `emit_batch` drains at most that
+//! many groups, because `add_records` can complete more in one call than the
+//! target and the accumulator is only checked after extending.
+//!
+//! Byte-based sizing is deliberately *not* a second threshold here. An earlier
+//! revision of this doc described a `target_batch_bytes` derived from the
+//! producer's `output_byte_limit`, but no such field was ever implemented — the
+//! transport budget is enforced by the byte-bounded output queue itself, which
+//! rejects a push that would exceed it and parks the batch in `held`. Adding a
+//! second in-step threshold would duplicate that accounting rather than
+//! reinforce it.
+
+use std::io;
+
+use crate::grouper::{ProcessedPositionGroup, RawPositionGroup, RecordPositionGrouper};
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::item::{HeapSize, Ordered};
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::DecodedRecordBatch;
+use fgumi_bam_io::Grouper;
+use fgumi_bam_io::MemoryEstimate;
+
+/// Max input batches consumed per `try_run` invocation. Amortizes the
+/// `Serial` mutex acquisition; mirrors `GroupBam`'s `MAX_BATCHES_PER_LOCK`.
+const MAX_BATCHES_PER_LOCK: usize = 8;
+
+/// Default target batch count. Mirrors legacy's `template_batch_size: 500`
+/// adjusted for position-group granularity. Position grouping aggregates
+/// many records into one group; legacy's 500 templates per batch maps
+/// to roughly 50–100 position groups, but small caps reduce tail
+/// latency on busy loci. 64 is a balance: fewer mutex acquisitions
+/// downstream, but small enough that one busy-locus group dominating a
+/// batch isn't catastrophic.
+pub const DEFAULT_TARGET_BATCH_COUNT: usize = 64;
+
+/// A batch of `RawPositionGroup`s carrying its monotonic ordinal.
+/// Replaces the per-group `OrderedRawPositionGroup` emitted by earlier
+/// versions of `GroupByPosition`. Downstream `Process` / `MiAssign` /
+/// `Serialize` steps operate on the whole batch per dispatch, amortizing
+/// per-item costs the way legacy does on `Vec<P>`.
+#[derive(Debug)]
+pub struct BatchedRawPositionGroups {
+    pub batch_serial: u64,
+    pub groups: Vec<RawPositionGroup>,
+}
+
+impl BatchedRawPositionGroups {
+    #[must_use]
+    pub fn new(batch_serial: u64, groups: Vec<RawPositionGroup>) -> Self {
+        Self { batch_serial, groups }
+    }
+}
+
+impl HeapSize for BatchedRawPositionGroups {
+    fn heap_size(&self) -> usize {
+        self.groups.iter().map(MemoryEstimate::estimate_heap_size).sum::<usize>()
+            + self.groups.capacity() * std::mem::size_of::<RawPositionGroup>()
+    }
+}
+
+impl Ordered for BatchedRawPositionGroups {
+    fn ordinal(&self) -> u64 {
+        self.batch_serial
+    }
+}
+
+/// A batch of `ProcessedPositionGroup`s carrying its monotonic ordinal.
+/// Same shape as `BatchedRawPositionGroups`; the `process_step`
+/// transforms one into the other one-batch-at-a-time.
+#[derive(Debug)]
+pub struct BatchedProcessedPositionGroups {
+    pub batch_serial: u64,
+    pub groups: Vec<ProcessedPositionGroup>,
+}
+
+impl BatchedProcessedPositionGroups {
+    #[must_use]
+    pub fn new(batch_serial: u64, groups: Vec<ProcessedPositionGroup>) -> Self {
+        Self { batch_serial, groups }
+    }
+}
+
+impl HeapSize for BatchedProcessedPositionGroups {
+    fn heap_size(&self) -> usize {
+        self.groups.iter().map(MemoryEstimate::estimate_heap_size).sum::<usize>()
+            + self.groups.capacity() * std::mem::size_of::<ProcessedPositionGroup>()
+    }
+}
+
+impl Ordered for BatchedProcessedPositionGroups {
+    fn ordinal(&self) -> u64 {
+        self.batch_serial
+    }
+}
+
+/// `Serial + ByItemOrdinal` position grouper. Wraps a
+/// `RecordPositionGrouper` and emits batches of completed
+/// `RawPositionGroup`s.
+///
+/// State is held behind the framework's per-step mutex (the runtime
+/// stores a `Serial` step inside `Arc<Mutex<...>>` and acquires
+/// per-`try_run`); the inner `RecordPositionGrouper` mutates freely
+/// while the lock is held. Held-slot retry pattern matches `GroupBam`:
+/// when an emit is rejected by downstream backpressure, the partial
+/// state stays buffered until the held slot drains.
+pub struct GroupByPosition {
+    grouper: RecordPositionGrouper,
+    /// Self-managed monotonic ordinal — each emitted *batch* gets the
+    /// next value. Required for `BranchOrdering::ByItemOrdinal`'s
+    /// `ReorderStage` to see contiguous serials.
+    next_ordinal: u64,
+    /// Accumulator: completed groups produced by `add_records` waiting
+    /// to be packaged into a batch and pushed downstream. Drained when
+    /// it reaches `target_batch_count`, on the input-drained completion
+    /// path in `try_run`, or via the held-slot path when a prior push was
+    /// rejected.
+    accumulator: Vec<RawPositionGroup>,
+    /// Held output slot when downstream rejected the most recent push.
+    held: HeldSlot<Unpushed<BatchedRawPositionGroups>>,
+    /// Set once the final-flush path has called the (non-idempotent)
+    /// `grouper.finish()`; guards against a second call across the
+    /// multi-pass completion drain.
+    finalized: bool,
+    target_batch_count: usize,
+    output_byte_limit: u64,
+    name: &'static str,
+}
+
+impl GroupByPosition {
+    /// Construct a `GroupByPosition` step. `output_byte_limit` controls
+    /// the byte-bounded queue capacity for emitted batches; sized via
+    /// `BamPipelineTuning::per_step_byte_limit` in production.
+    /// Uses `DEFAULT_TARGET_BATCH_COUNT` for the per-batch group count.
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self::with_target_batch_count(output_byte_limit, DEFAULT_TARGET_BATCH_COUNT)
+    }
+
+    /// Construct with a custom target batch count.
+    #[must_use]
+    pub fn with_target_batch_count(output_byte_limit: u64, target_batch_count: usize) -> Self {
+        Self::with_grouper(RecordPositionGrouper::new(), output_byte_limit, target_batch_count)
+    }
+
+    /// Construct with `RecordPositionGrouper::with_secondary_supplementary()`
+    /// — used by `fgumi dedup`, which must place secondary/supplementary
+    /// records into the same position group as their adjacent primary so
+    /// the duplicate flag propagates uniformly across split alignments.
+    /// The standard `new` constructor uses the default grouper, which
+    /// excludes secondary/supplementary records by position (matching
+    /// `fgumi group` semantics).
+    #[must_use]
+    pub fn with_secondary_supplementary(output_byte_limit: u64) -> Self {
+        Self::with_grouper(
+            RecordPositionGrouper::with_secondary_supplementary(),
+            output_byte_limit,
+            DEFAULT_TARGET_BATCH_COUNT,
+        )
+    }
+
+    fn with_grouper(
+        grouper: RecordPositionGrouper,
+        output_byte_limit: u64,
+        target_batch_count: usize,
+    ) -> Self {
+        Self {
+            grouper,
+            next_ordinal: 0,
+            accumulator: Vec::with_capacity(target_batch_count),
+            held: HeldSlot::new(),
+            finalized: false,
+            target_batch_count: target_batch_count.max(1),
+            output_byte_limit,
+            name: "GroupByPosition",
+        }
+    }
+}
+
+impl Step for GroupByPosition {
+    type Input = DecodedRecordBatch;
+    type Outputs = OrderedBytesSingle<BatchedRawPositionGroups>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Serial,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // 1. Drain held slot first.
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        // 2. If the accumulator is full enough, emit a batch. Don't
+        // pull more input until the batch lands — keeps `accumulator`
+        // bounded to ~`target_batch_count` groups.
+        if self.accumulator.len() >= self.target_batch_count {
+            return Ok(self.emit_batch(ctx));
+        }
+
+        // 3. Process up to `MAX_BATCHES_PER_LOCK` input batches per
+        // call to amortize the Serial mutex acquisition. Stop early
+        // once the accumulator hits the target so memory stays
+        // bounded.
+        let mut did_work = false;
+        for _ in 0..MAX_BATCHES_PER_LOCK {
+            let Some(batch) = ctx.input.pop() else { break };
+            did_work = true;
+            let records = batch.into_records();
+            let groups = self.grouper.add_records(records)?;
+            self.accumulator.extend(groups);
+            if self.accumulator.len() >= self.target_batch_count {
+                break;
+            }
+        }
+
+        // 4. If we filled the accumulator, emit. Otherwise return
+        // Progress (we did work) or NoProgress (input was empty).
+        if self.accumulator.len() >= self.target_batch_count {
+            return Ok(self.emit_batch(ctx));
+        }
+        if did_work {
+            return Ok(StepOutcome::Progress);
+        }
+
+        // 5. No input this call. If upstream is drained, flush the inner
+        // grouper's final partial group once (guarded by `finalized` —
+        // `grouper.finish()` is not idempotent), emit any leftover groups as
+        // a final batch, and report `Finished` once nothing remains. `held` is
+        // empty here (step 1 returned `Contention` otherwise); `emit_batch`
+        // parks a bounced final push in `held` for step 1 to retry next pass.
+        if ctx.input.is_drained() {
+            if !self.finalized {
+                self.finalized = true;
+                if let Some(final_group) = self.grouper.finish()? {
+                    self.accumulator.push(final_group);
+                }
+            }
+            if !self.accumulator.is_empty() {
+                return Ok(self.emit_batch(ctx));
+            }
+            return Ok(StepOutcome::Finished);
+        }
+        Ok(StepOutcome::NoProgress)
+    }
+}
+
+impl GroupByPosition {
+    /// Take at most `target_batch_count` groups off the accumulator, leaving
+    /// any excess for the next batch.
+    ///
+    /// Split out from `emit_batch` so the cap is testable without standing up a
+    /// pipeline: `emit_batch` needs a `StepCtx`, and the property worth pinning
+    /// — that one oversized `add_records` result becomes several bounded batches
+    /// rather than one unbounded one — is entirely in this decision.
+    fn drain_one_batch(&mut self) -> Vec<RawPositionGroup> {
+        let take = self.accumulator.len().min(self.target_batch_count);
+        self.accumulator.drain(..take).collect()
+    }
+
+    /// Package at most `target_batch_count` accumulated groups into one batch.
+    ///
+    /// The cap is why this drains rather than taking the whole accumulator: a
+    /// single `add_records` call can complete more groups than the target — the
+    /// count is only checked *after* extending — so handing the accumulator over
+    /// wholesale would emit a batch of unbounded size, defeating the very
+    /// threshold that exists to bound it. Anything above the cap stays in the
+    /// accumulator, and the `>=` checks in `try_run` re-enter here until it
+    /// falls below the target.
+    ///
+    /// Leftovers are also what makes a rejected push safe: the bounced batch
+    /// parks in `held` while the groups that did not fit in it remain queued.
+    fn emit_batch(&mut self, ctx: &mut StepCtx<'_, Self>) -> StepOutcome {
+        let serial = self.next_ordinal;
+        self.next_ordinal += 1;
+        let groups = self.drain_one_batch();
+        let out = BatchedRawPositionGroups::new(serial, groups);
+        if let Err(unpushed) = ctx.outputs.push(out) {
+            self.held.put(unpushed);
+        }
+        StepOutcome::Progress
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_advertises_serial_byordinal() {
+        let s = GroupByPosition::new(1024);
+        let p = s.profile();
+        assert_eq!(p.name, "GroupByPosition");
+        assert_eq!(p.kind, StepKind::Serial);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    /// One `add_records` call can complete more groups than `target_batch_count`
+    /// — the count is only checked after extending the accumulator — so the cap
+    /// has to be applied when the batch is packaged, not when it is triggered.
+    ///
+    /// Without it, a burst of completions is emitted as a single unbounded
+    /// batch, which is exactly the memory bound `target_batch_count` exists to
+    /// provide. Pins that the excess is preserved rather than dropped, and that
+    /// repeated draining converges.
+    #[test]
+    fn draining_caps_each_batch_and_preserves_the_excess() {
+        const TARGET: usize = 64;
+        let mut step = GroupByPosition::with_target_batch_count(1 << 20, TARGET);
+
+        // 150 completed groups, as one oversized `add_records` result would leave.
+        step.accumulator = (0..150)
+            .map(|_| RawPositionGroup {
+                group_key: fgumi_bam_io::GroupKey::default(),
+                records: Vec::new(),
+            })
+            .collect();
+
+        let first = step.drain_one_batch();
+        assert_eq!(first.len(), TARGET, "a batch must never exceed the target");
+        assert_eq!(step.accumulator.len(), 86, "the excess stays queued, not dropped");
+
+        let second = step.drain_one_batch();
+        assert_eq!(second.len(), TARGET);
+        assert_eq!(step.accumulator.len(), 22);
+
+        // The tail comes out as a short final batch and the accumulator empties,
+        // so the repeated `>=` checks in `try_run` terminate.
+        let third = step.drain_one_batch();
+        assert_eq!(third.len(), 22, "the remainder is emitted as a short batch");
+        assert!(step.accumulator.is_empty());
+        assert!(step.drain_one_batch().is_empty(), "draining an empty accumulator is a no-op");
+    }
+
+    #[test]
+    fn batched_raw_groups_carries_ordinal() {
+        let groups = vec![RawPositionGroup {
+            group_key: fgumi_bam_io::GroupKey::default(),
+            records: Vec::new(),
+        }];
+        let wrapped = BatchedRawPositionGroups::new(42, groups);
+        assert_eq!(wrapped.ordinal(), 42);
+        assert_eq!(wrapped.groups.len(), 1);
+    }
+}

--- a/src/lib/pipeline/steps/group/queryname.rs
+++ b/src/lib/pipeline/steps/group/queryname.rs
@@ -1,0 +1,361 @@
+//! `GroupByQueryname` step for the new typed-step pipeline framework.
+//!
+//! Mirrors the legacy pipeline's queryname grouping (`fgumi filter
+//! --filter-by-template=true`, `fgumi sort --order queryname`):
+//! consumes `DecodedRecordBatch` items, run-length groups consecutive
+//! same-name records into `Template`s, and emits **batches** of
+//! completed templates as one `BamTemplateBatch` per output ordinal.
+//!
+//! Design follows `GroupByMi` and `GroupByPosition`: `Serial` +
+//! `ByItemOrdinal`, batched output to amortize downstream `Serial`
+//! mutex cost, held-slot retry pattern for backpressure.
+
+use std::io;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::{BamTemplateBatch, DecodedRecordBatch};
+use crate::template::Template;
+
+/// Max input batches consumed per `try_run` invocation. Amortizes the
+/// Serial mutex acquisition; mirrors `GroupByMi::MAX_BATCHES_PER_LOCK`.
+const MAX_BATCHES_PER_LOCK: usize = 8;
+
+/// Default target batch count. Mirrors legacy's
+/// `TemplateGrouper::new(1000)` (the production batch size in
+/// `Filter::execute_threads_mode_template`).
+pub const DEFAULT_TARGET_BATCH_COUNT: usize = 1000;
+
+/// `Serial + ByItemOrdinal` queryname grouper. Records arriving in
+/// queryname-grouped (or queryname-sorted) order are partitioned into
+/// runs of consecutive same-name records; each run becomes one
+/// [`Template`]. Completed templates accumulate until the target batch
+/// size is reached, then emit as one [`BamTemplateBatch`].
+///
+/// State is held behind the framework's per-step mutex (the runtime
+/// stores a `Serial` step inside `Arc<Mutex<...>>` and acquires
+/// per-`try_run`). Held-slot retry pattern matches `GroupByMi`:
+/// when an emit is rejected by downstream backpressure, the partial
+/// state stays buffered until the held slot drains.
+pub struct GroupByQueryname {
+    /// Run-length state: queryname currently being accumulated, kept in a
+    /// reusable buffer so each template boundary refills (`clear` +
+    /// `extend_from_slice`) rather than re-allocating a fresh `Vec`. Only
+    /// meaningful while a run is active (`current_name_hash.is_some()`).
+    current_name: Vec<u8>,
+    /// Run-length state: cached `name_hash` for fast pre-check. `Some` iff a
+    /// run is currently active; doubles as the run-active flag so the
+    /// `current_name` allocation survives across template boundaries.
+    current_name_hash: Option<u64>,
+    /// Run-length state: records accumulated for `current_name`.
+    current_records: Vec<fgumi_raw_bam::RawRecord>,
+    /// Self-managed monotonic ordinal — each emitted *batch* gets the
+    /// next value.
+    next_ordinal: u64,
+    /// Accumulator: completed templates waiting to be packaged.
+    accumulator: Vec<Template>,
+    /// Held output slot when downstream rejected the most recent push.
+    held: HeldSlot<Unpushed<BamTemplateBatch>>,
+    target_batch_count: usize,
+    output_byte_limit: u64,
+    name: &'static str,
+}
+
+impl GroupByQueryname {
+    /// Construct a `GroupByQueryname` step.
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self::with_target_batch_count(output_byte_limit, DEFAULT_TARGET_BATCH_COUNT)
+    }
+
+    /// Construct with a custom target batch count.
+    #[must_use]
+    pub fn with_target_batch_count(output_byte_limit: u64, target_batch_count: usize) -> Self {
+        Self {
+            current_name: Vec::new(),
+            current_name_hash: None,
+            current_records: Vec::new(),
+            next_ordinal: 0,
+            accumulator: Vec::with_capacity(target_batch_count),
+            held: HeldSlot::new(),
+            target_batch_count: target_batch_count.max(1),
+            output_byte_limit,
+            name: "GroupByQueryname",
+        }
+    }
+
+    /// Flush the run-in-progress into the accumulator (if non-empty). The
+    /// `current_name` buffer is retained (only the run-active flag is cleared)
+    /// so its allocation is reused by the next template boundary.
+    fn flush_current_template(&mut self) -> io::Result<()> {
+        if !self.current_records.is_empty() {
+            let records = std::mem::take(&mut self.current_records);
+            let template = Template::from_records(records)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            self.accumulator.push(template);
+            self.current_name_hash = None;
+        }
+        Ok(())
+    }
+
+    /// Accumulate one raw record into the current template run, opening a new
+    /// run (and flushing the previous one) at a queryname boundary. The cached
+    /// `name_hash` pre-check short-circuits most inequality before the byte
+    /// compare; the `current_name` buffer is reused across boundaries.
+    fn process_record(&mut self, raw: fgumi_raw_bam::RawRecord, name_hash: u64) -> io::Result<()> {
+        let read_name = fgumi_raw_bam::read_name(raw.as_ref());
+        // A run is active iff `current_name_hash` is `Some`.
+        let same_template = match self.current_name_hash {
+            Some(h) => h == name_hash && self.current_name == read_name,
+            None => false,
+        };
+        if same_template {
+            self.current_records.push(raw);
+        } else {
+            self.flush_current_template()?;
+            // Reuse the buffer: clear + refill rather than allocate.
+            self.current_name.clear();
+            self.current_name.extend_from_slice(read_name);
+            self.current_name_hash = Some(name_hash);
+            self.current_records.push(raw);
+        }
+        Ok(())
+    }
+
+    /// Take at most `target_batch_count` templates off the accumulator, leaving
+    /// any excess for the next batch.
+    ///
+    /// Mirrors `GroupByPosition::drain_one_batch`, and for the same reason: one
+    /// pass over an input batch can complete more templates than the target —
+    /// the count is only checked *after* extending — so handing the accumulator
+    /// over wholesale would emit a batch of unbounded size, defeating the very
+    /// threshold that exists to bound it. The `>=` checks in `try_run` re-enter
+    /// here until the accumulator falls below the target, and the drained path
+    /// does the same until it empties.
+    fn drain_one_batch(&mut self) -> Vec<Template> {
+        let take = self.accumulator.len().min(self.target_batch_count);
+        self.accumulator.drain(..take).collect()
+    }
+
+    /// Package at most `target_batch_count` accumulated templates into one
+    /// batch and emit. On rejection, hold; the next `try_run` will retry via the
+    /// held slot. Leftovers above the cap stay in the accumulator, which is also
+    /// what makes a rejected push safe.
+    fn emit_batch(&mut self, ctx: &mut StepCtx<'_, Self>) -> StepOutcome {
+        let serial = self.next_ordinal;
+        self.next_ordinal += 1;
+        let templates = self.drain_one_batch();
+        let out = BamTemplateBatch::new(serial, templates);
+        if let Err(unpushed) = ctx.outputs.push(out) {
+            self.held.put(unpushed);
+        }
+        StepOutcome::Progress
+    }
+}
+
+impl Step for GroupByQueryname {
+    type Input = DecodedRecordBatch;
+    type Outputs = OrderedBytesSingle<BamTemplateBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Serial,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // 1. Drain held slot first.
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        // 2. If the accumulator is full enough, emit a batch first.
+        if self.accumulator.len() >= self.target_batch_count {
+            return Ok(self.emit_batch(ctx));
+        }
+
+        // 3. Process up to `MAX_BATCHES_PER_LOCK` input batches per call.
+        let mut did_work = false;
+        for _ in 0..MAX_BATCHES_PER_LOCK {
+            let Some(batch) = ctx.input.pop() else { break };
+            did_work = true;
+            let records = batch.into_records();
+            for decoded in records {
+                let name_hash = decoded.key.name_hash;
+                let raw = decoded.into_raw_bytes();
+                self.process_record(raw, name_hash)?;
+            }
+            if self.accumulator.len() >= self.target_batch_count {
+                break;
+            }
+        }
+
+        if self.accumulator.len() >= self.target_batch_count {
+            return Ok(self.emit_batch(ctx));
+        }
+        if did_work {
+            return Ok(StepOutcome::Progress);
+        }
+
+        // 4. No input this call. If upstream is drained, close the
+        // run-in-progress, emit the final partial batch, and report
+        // `Finished` once nothing remains. `held` is empty here (step 1
+        // returned `Contention` otherwise); `emit_batch` parks a bounced
+        // final push in `held` for step 1 to retry next pass.
+        if ctx.input.is_drained() {
+            self.flush_current_template()?;
+            if !self.accumulator.is_empty() {
+                return Ok(self.emit_batch(ctx));
+            }
+            return Ok(StepOutcome::Finished);
+        }
+        Ok(StepOutcome::NoProgress)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::core::item::Ordered;
+    use fgumi_bam_io::library::LibraryIndex;
+    use fgumi_raw_bam::{RawRecord, SamBuilder as RawSamBuilder};
+
+    use fgumi_raw_bam::flags;
+
+    /// Build a minimal mapped raw record with the given read name and flags.
+    fn raw_named(name: &[u8], flag: u16) -> RawRecord {
+        let mut b = RawSamBuilder::new();
+        b.read_name(name).sequence(b"ACGT").qualities(&[30; 4]).flags(flag);
+        b.build()
+    }
+
+    /// An emitted batch must never exceed `target_batch_count`.
+    ///
+    /// One pass over an input batch can complete far more templates than the
+    /// target, so taking the whole accumulator would emit a single unbounded
+    /// batch — exactly the memory bound `target_batch_count` exists to provide.
+    /// Pins that the excess is preserved rather than dropped, and that repeated
+    /// draining converges, which is what makes the `>=` re-entry in `try_run`
+    /// and the drained-path loop terminate.
+    ///
+    /// Mirrors `GroupByPosition`'s `draining_caps_each_batch_and_preserves_the_excess`.
+    #[test]
+    fn draining_caps_each_batch_and_preserves_the_excess() {
+        const TARGET: usize = 64;
+        let mut step = GroupByQueryname::with_target_batch_count(1 << 20, TARGET);
+
+        // 150 completed templates, as one oversized grouping pass would leave.
+        step.accumulator = (0..150).map(|i| Template::new(format!("q{i}").into_bytes())).collect();
+
+        let first = step.drain_one_batch();
+        assert_eq!(first.len(), TARGET, "a batch must never exceed the target");
+        assert_eq!(step.accumulator.len(), 86, "the excess stays queued, not dropped");
+
+        let second = step.drain_one_batch();
+        assert_eq!(second.len(), TARGET);
+        assert_eq!(step.accumulator.len(), 22);
+
+        // The tail comes out as a short final batch and the accumulator empties.
+        let third = step.drain_one_batch();
+        assert_eq!(third.len(), 22, "the remainder is emitted as a short batch");
+        assert!(step.accumulator.is_empty());
+        assert!(step.drain_one_batch().is_empty(), "draining an empty accumulator is a no-op");
+    }
+
+    /// Drive each `(name, flag)` record through [`GroupByQueryname::process_record`],
+    /// close the final run, and return `(name, record_count)` per template in order.
+    fn run_grouping(
+        step: &mut GroupByQueryname,
+        records: &[(&[u8], u16)],
+    ) -> Vec<(Vec<u8>, usize)> {
+        for (name, flag) in records {
+            let raw = raw_named(name, *flag);
+            let name_hash = LibraryIndex::hash_name(Some(name));
+            step.process_record(raw, name_hash).expect("process_record");
+        }
+        step.flush_current_template().expect("flush");
+        step.accumulator.iter().map(|t| (t.name.clone(), t.records().len())).collect()
+    }
+
+    const R1: u16 = flags::PAIRED | flags::FIRST_SEGMENT;
+    const R2: u16 = flags::PAIRED | flags::LAST_SEGMENT;
+
+    #[test]
+    fn consecutive_same_name_forms_one_template() {
+        let mut step = GroupByQueryname::new(1 << 20);
+        let records: Vec<(&[u8], u16)> = vec![(b"read1", R1), (b"read1", R2)];
+        let groups = run_grouping(&mut step, &records);
+        assert_eq!(groups, vec![(b"read1".to_vec(), 2)]);
+    }
+
+    #[test]
+    fn distinct_and_nonadjacent_names_split_runs() {
+        let mut step = GroupByQueryname::new(1 << 20);
+        // read1 appears again non-adjacently → a fresh template, not merged.
+        let records: Vec<(&[u8], u16)> =
+            vec![(b"read1", R1), (b"read1", R2), (b"read2", R1), (b"read1", R1)];
+        let groups = run_grouping(&mut step, &records);
+        assert_eq!(
+            groups,
+            vec![(b"read1".to_vec(), 2), (b"read2".to_vec(), 1), (b"read1".to_vec(), 1)]
+        );
+    }
+
+    #[test]
+    fn buffer_reuse_across_boundaries_preserves_grouping() {
+        // Short-then-long-then-short name transitions exercise the reused
+        // `current_name` buffer (clear + refill); grouping must stay exact.
+        let mut step = GroupByQueryname::new(1 << 20);
+        let records: Vec<(&[u8], u16)> = vec![
+            (b"a", R1),
+            (b"a", R2),
+            (b"longer_name", R1),
+            (b"b", R1),
+            (b"b", R2),
+            (b"another_longer_name", R1),
+            (b"c", R1),
+        ];
+        let groups = run_grouping(&mut step, &records);
+        assert_eq!(
+            groups,
+            vec![
+                (b"a".to_vec(), 2),
+                (b"longer_name".to_vec(), 1),
+                (b"b".to_vec(), 2),
+                (b"another_longer_name".to_vec(), 1),
+                (b"c".to_vec(), 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn profile_advertises_serial_byordinal() {
+        let s = GroupByQueryname::new(1024);
+        let p = s.profile();
+        assert_eq!(p.name, "GroupByQueryname");
+        assert_eq!(p.kind, StepKind::Serial);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    #[test]
+    fn batched_templates_carries_ordinal() {
+        let templates = vec![];
+        let wrapped = BamTemplateBatch::new(11, templates);
+        assert_eq!(wrapped.ordinal(), 11);
+    }
+}

--- a/src/lib/pipeline/steps/mod.rs
+++ b/src/lib/pipeline/steps/mod.rs
@@ -1,0 +1,58 @@
+//! Typed `Step` library.
+//!
+//! Layout:
+//!
+//! - `bgzf/`                    — BGZF compress/decompress
+//! - `boundaries/`              — record-boundary discovery
+//! - `correct/`                 — UMI correction against a known-UMI set
+//! - `group/`                   — template grouping (BAM, position, queryname, MI)
+//! - `parse/`                   — record parsing
+//! - `process.rs`               — closure-driven mid-steps (`Process`,
+//!   `ProcessWithWorkerState`, `MiAssign`)
+//! - `serialize.rs`             — record serialization
+//! - `serialize_processed.rs`   — serialization for processed-template batches
+//! - `sink/`                    — write-side step implementations
+//! - `sort/`                    — sort-chain step re-exports
+//! - `source/`                  — read-side step implementations (BAM/SAM/FASTQ)
+//! - `templates_to_records.rs`  — flatten templates back into records
+//! - `tuning.rs`                — per-chain byte/queue budgets
+//! - `types.rs`                 — flowing data types (`HeapSize` + `Ordered`)
+//!
+//! `extract.rs` and `align_and_merge` arrive in follow-up ports: `extract.rs`
+//! still needs `ExtractOptions` from the command-layer options refactor, and
+//! `align_and_merge` needs `crate::aligner`, neither of which has landed yet.
+//! (`correct/` had the same dependency on `CorrectOptions`; that arrived with
+//! the options projection, so it is ported here.)
+//!
+//! This module deliberately holds only what the chain builder actually
+//! constructs. Two steps that exist upstream are *not* ported here:
+//! `coalesce.rs` (a `CoalesceBytes` byte-batching step with no caller anywhere,
+//! upstream included) and `roundtrip.rs` (a whole-chain convenience whose only
+//! consumer is the `compare bam-roundtrip` command, so it travels with the
+//! command rewiring rather than with the steps).
+
+pub mod bgzf;
+pub mod boundaries;
+#[cfg(test)]
+mod chain_tests;
+pub mod correct;
+pub mod group;
+pub mod parse;
+pub mod process;
+pub mod serialize;
+pub mod serialize_processed;
+pub mod sink;
+pub mod sort;
+pub mod source;
+pub mod templates_to_records;
+pub mod tuning;
+pub mod types;
+
+pub use tuning::BamPipelineTuning;
+pub use types::{
+    BamTemplateBatch, BgzfBlock, DecodedRecordBatch, DecompressedBlock, RecordBatch,
+    RecordBatchBuilder,
+};
+
+#[cfg(test)]
+mod tests;

--- a/src/lib/pipeline/steps/parse/bam.rs
+++ b/src/lib/pipeline/steps/parse/bam.rs
@@ -1,0 +1,439 @@
+//! `ParseBamRecords` mid-step. `Parallel + ByItemOrdinal`. Walks the
+//! record-aligned bytes from `FindBamBoundaries` and produces a
+//! `RecordBatch` that shares the input block's bytes (zero per-record
+//! allocation — the block's `Vec<u8>` is moved into the
+//! `RecordBatch`'s backing buffer, plus one `Vec<(u32, u32)>` of
+//! `(start, end)` ranges).
+
+use std::io;
+use std::sync::Arc;
+
+use fgumi_bam_io::ProgressTracker;
+use fgumi_raw_bam::RawRecord;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::{DecompressedBlock, RecordBatch};
+
+/// `Parallel + ByItemOrdinal` parser. Walks record-aligned bytes (one
+/// record = `block_size: u32 LE` + body) and emits a `RecordBatch`.
+///
+/// The bytes coming in MUST be record-aligned (post-`FindBamBoundaries`).
+/// If they aren't, parsing returns an error.
+pub struct ParseBamRecords {
+    held: HeldSlot<Unpushed<RecordBatch>>,
+    output_byte_limit: u64,
+    /// Records parsed across all Parallel workers (shared `Arc`), logged every
+    /// 1M under `RUST_LOG=info`. Compared against `SortBuffer`'s ingest rate,
+    /// this splits the read-supply (decode chain) cost from `SortBuffer.push`.
+    parse_progress: Arc<ProgressTracker>,
+}
+
+impl ParseBamRecords {
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self {
+            held: HeldSlot::new(),
+            output_byte_limit,
+            parse_progress: Arc::new(
+                ProgressTracker::new("Parse records").with_interval(1_000_000),
+            ),
+        }
+    }
+}
+
+impl Clone for ParseBamRecords {
+    fn clone(&self) -> Self {
+        // Share the parse counter across workers so the count is global.
+        Self {
+            held: HeldSlot::new(),
+            output_byte_limit: self.output_byte_limit,
+            parse_progress: Arc::clone(&self.parse_progress),
+        }
+    }
+}
+
+impl Step for ParseBamRecords {
+    type Input = DecompressedBlock;
+    type Outputs = OrderedBytesSingle<RecordBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ParseBamRecords",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    // Return `Contention` (not `NoProgress`) so the framework
+                    // doesn't observe drain on this worker while we still
+                    // have a held item to push — observing drain here
+                    // would mark the worker `Skip` and silently drop the
+                    // held item.
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(block) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let DecompressedBlock { batch_serial, bytes } = block;
+
+        // Zero per-record allocation: parse only the body byte ranges,
+        // then hand the block's `Vec<u8>` to the `RecordBatch` as the
+        // shared backing buffer. The ranges Vec is the only new
+        // allocation per batch (plus the move of `bytes` into the
+        // batch).
+        let ranges = parse_record_ranges(&bytes)?;
+        self.parse_progress.log_if_needed(ranges.len() as u64);
+        let batch = RecordBatch::from_parsed(batch_serial, bytes, ranges);
+
+        match ctx.outputs.push(batch) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+/// Smallest number of bytes a single framed BAM record can occupy: the 4-byte
+/// little-endian `block_size` prefix plus the 32-byte fixed-field header
+/// ([`fgumi_raw_bam::MIN_BAM_RECORD_LEN`]). Dividing a buffer length by this
+/// yields an upper bound on the records it can contain, which is what the two
+/// parsers below use to pre-size their output.
+const MIN_FRAMED_RECORD_LEN: usize = 4 + fgumi_raw_bam::MIN_BAM_RECORD_LEN;
+
+/// Walk record-aligned bytes and produce `(body_start, body_end)` ranges
+/// per record. Each record is preceded by a 4-byte little-endian
+/// `block_size` prefix; the body is `block_size` bytes that follow.
+/// Range values are byte offsets into the caller's buffer.
+///
+/// Used by [`ParseBamRecords`]'s zero-alloc path: the input block's
+/// `Vec<u8>` is moved into the output `RecordBatch` as a shared backing
+/// buffer, with these ranges identifying each record's body.
+///
+/// # Errors
+///
+/// Returns `Err` if a record runs past the buffer end or if there are
+/// trailing partial-record bytes.
+pub(crate) fn parse_record_ranges(bytes: &[u8]) -> io::Result<Vec<(u32, u32)>> {
+    // Pre-size from the smallest record a well-formed stream can hold (a 4-byte
+    // `block_size` prefix plus the 32-byte fixed header), so
+    // `len / MIN_FRAMED_RECORD_LEN` is an upper bound on the record count and
+    // the per-record pushes below never regrow.
+    //
+    // That bound over-reserves several times over for real records (60-200
+    // bytes), and this Vec is RETAINED: `RecordBatch::from_parsed` stores it
+    // verbatim and `RecordBatch::heap_size` bills `ranges.capacity()` against
+    // the pipeline's byte budget. Leaving the slack in place would inflate every
+    // batch's claim (~16% for a 64 KiB block of 150-byte records) and cut how
+    // many batches fit in flight. So the slack is released once at the end —
+    // see the `shrink_to_fit` below.
+    let mut ranges = Vec::with_capacity(bytes.len() / MIN_FRAMED_RECORD_LEN + 1);
+    let mut cursor = 0usize;
+    while cursor + 4 <= bytes.len() {
+        let block_size = u32::from_le_bytes([
+            bytes[cursor],
+            bytes[cursor + 1],
+            bytes[cursor + 2],
+            bytes[cursor + 3],
+        ]) as usize;
+        let body_start = cursor + 4;
+        // `block_size` is read straight out of the stream, so fold it in with
+        // checked arithmetic before it is compared against the buffer or used to
+        // slice. Unreachable on 64-bit (a `u32` widened to `usize` cannot
+        // overflow this sum), but the framing rule is that every length-derived
+        // range is checked before use, not that it happens to fit today.
+        let Some(record_end) = body_start.checked_add(block_size) else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "parse_record_ranges: record end overflows \
+                     (cursor={cursor}, block_size={block_size})"
+                ),
+            ));
+        };
+        if record_end > bytes.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "parse_record_ranges: record extends past buffer end \
+                     (cursor={cursor}, block_size={block_size}, buffer_len={})",
+                    bytes.len()
+                ),
+            ));
+        }
+        let start = u32::try_from(body_start).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("parse_record_ranges: body_start {body_start} exceeds u32::MAX"),
+            )
+        })?;
+        let end = u32::try_from(record_end).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("parse_record_ranges: body_end {record_end} exceeds u32::MAX"),
+            )
+        })?;
+        ranges.push((start, end));
+        cursor = record_end;
+    }
+    if cursor != bytes.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "parse_record_ranges: trailing partial record \
+                 (cursor={cursor}, buffer_len={})",
+                bytes.len()
+            ),
+        ));
+    }
+    // Return the table at exactly its populated size. This costs one copy of
+    // `len * 8` bytes, against the ~9 regrow-and-copy rounds the pre-size above
+    // avoided — and it keeps the batch's `heap_size` honest, so byte-bounded
+    // admission bills only memory that is actually needed.
+    ranges.shrink_to_fit();
+    Ok(ranges)
+}
+
+/// Walk record-aligned bytes and produce `Vec<RawRecord>` (one heap
+/// allocation per record, via `to_vec()`).
+///
+/// Used by:
+/// - the `SerializeBamRecords` round-trip and test paths;
+/// - the production [`DecodeRecords`](super::decode::DecodeRecords) step, whose
+///   downstream `DecodedRecord::from_raw_bytes` takes an **owned** `RawRecord`
+///   (it stores the bytes, unlike `ParseBamRecords` which only emits ranges into
+///   the shared block) — so the production decode path does allocate one `Vec`
+///   per record here. This is inherent to the owned-per-record `DecodedRecord`
+///   representation; sharing the block buffer across a batch's records (e.g.
+///   `Arc<[u8]>` + per-record range) is a `DecodedRecord` representation change
+///   deferred behind a benchmark.
+///
+/// The other production parser, the `ParseBamRecords` step, instead uses
+/// [`parse_record_ranges`] for its zero-alloc path.
+///
+/// # Errors
+///
+/// Returns `Err` if a record runs past the buffer end, or if the buffer ends
+/// with a trailing partial record (the final `block_size` does not consume the
+/// remaining bytes exactly). It does NOT enforce a per-record minimum body
+/// size, so a `block_size` below the BAM fixed-field minimum is accepted here
+/// and rejected (if at all) by later decode of the record body.
+pub(crate) fn parse_records(bytes: &[u8]) -> io::Result<Vec<RawRecord>> {
+    // Same upper-bound pre-size as `parse_record_ranges` — this sibling walks
+    // the identical framing and pushes once per record, so it has the identical
+    // regrowth cost.
+    //
+    // Deliberately NOT shrunk to fit, unlike that sibling. This `Vec` is
+    // consumed immediately by the caller (`DecodeRecords` maps it into
+    // `Vec<DecodedRecord>` and drops it), so its capacity never reaches a queued
+    // item and is never billed against the pipeline's byte budget. Paying a copy
+    // to shrink a Vec that is about to be dropped would be pure cost.
+    let mut records = Vec::with_capacity(bytes.len() / MIN_FRAMED_RECORD_LEN + 1);
+    let mut cursor = 0;
+    while cursor + 4 <= bytes.len() {
+        let block_size = u32::from_le_bytes([
+            bytes[cursor],
+            bytes[cursor + 1],
+            bytes[cursor + 2],
+            bytes[cursor + 3],
+        ]) as usize;
+        // Checked for the same reason as `parse_record_ranges` above.
+        let Some(record_end) = cursor.checked_add(4).and_then(|s| s.checked_add(block_size)) else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "parse_records: record end overflows \
+                     (cursor={cursor}, block_size={block_size})"
+                ),
+            ));
+        };
+        if record_end > bytes.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "parse_records: record extends past buffer end \
+                     (cursor={cursor}, block_size={block_size}, buffer_len={})",
+                    bytes.len()
+                ),
+            ));
+        }
+        let record: RawRecord = bytes[cursor + 4..record_end].to_vec().into();
+        records.push(record);
+        cursor = record_end;
+    }
+    if cursor != bytes.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "parse_records: trailing partial record \
+                 (cursor={cursor}, buffer_len={})",
+                bytes.len()
+            ),
+        ));
+    }
+    Ok(records)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[test]
+    fn profile_advertises_parallel_byordinal() {
+        let s = ParseBamRecords::new(1024);
+        let p = s.profile();
+        assert_eq!(p.name, "ParseBamRecords");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    /// Frame `payload` as one record: `block_size: u32 LE` + body.
+    fn framed(payload: &[u8]) -> Vec<u8> {
+        let mut out = u32::try_from(payload.len()).expect("fits u32").to_le_bytes().to_vec();
+        out.extend_from_slice(payload);
+        out
+    }
+
+    /// `parse_record_ranges` is the zero-alloc sibling of `parse_records`: it
+    /// must identify the same record bodies, expressed as offsets into the
+    /// caller's buffer rather than as copies.
+    #[test]
+    fn parse_record_ranges_brackets_each_record_body() {
+        let payloads: [&[u8]; 3] = [&[1u8; 8], &[2u8; 0], &[3u8; 20]];
+        let bytes: Vec<u8> = payloads.iter().flat_map(|p| framed(p)).collect();
+
+        let ranges = parse_record_ranges(&bytes).expect("record-aligned bytes parse");
+
+        assert_eq!(ranges, vec![(4, 12), (16, 16), (20, 40)]);
+        for (i, (start, end)) in ranges.iter().enumerate() {
+            assert_eq!(
+                &bytes[*start as usize..*end as usize],
+                payloads[i],
+                "range {i} must bracket exactly that record's body",
+            );
+        }
+    }
+
+    /// The returned table is retained inside `RecordBatch`, whose `heap_size`
+    /// bills `ranges.capacity()` against the pipeline's byte budget. So the
+    /// upper-bound pre-size must not survive into the returned Vec: excess
+    /// reserved slots would inflate every batch's claim and cut how many fit in
+    /// flight, for memory no record needs.
+    #[test]
+    fn parse_record_ranges_returns_a_table_with_no_excess_capacity() {
+        // Records well above the 36-byte minimum, so the pre-size over-reserves
+        // by several times and the slack is real rather than incidental.
+        let payloads: Vec<Vec<u8>> = (0..40).map(|_| vec![0u8; 160]).collect();
+        let refs: Vec<&[u8]> = payloads.iter().map(Vec::as_slice).collect();
+        let bytes: Vec<u8> = refs.iter().flat_map(|p| framed(p)).collect();
+
+        // Sanity: the pre-size really would over-reserve here.
+        let upper_bound = bytes.len() / MIN_FRAMED_RECORD_LEN + 1;
+        assert!(
+            upper_bound > payloads.len(),
+            "fixture must over-reserve for this test to mean anything \
+             ({upper_bound} <= {})",
+            payloads.len(),
+        );
+
+        let ranges = parse_record_ranges(&bytes).expect("parses");
+        assert_eq!(ranges.len(), payloads.len());
+        assert_eq!(
+            ranges.capacity(),
+            ranges.len(),
+            "the retained ranges table must carry no reserved slack — it is \
+             billed by RecordBatch::heap_size against the byte budget",
+        );
+    }
+
+    /// Empty input holds no records — a legal batch, not an error.
+    #[test]
+    fn parse_record_ranges_accepts_an_empty_buffer() {
+        assert!(parse_record_ranges(&[]).expect("empty is legal").is_empty());
+        assert!(parse_records(&[]).expect("empty is legal").is_empty());
+    }
+
+    /// Both parsers must reject malformed input rather than silently truncating
+    /// it — a record whose declared `block_size` runs past the buffer, and a
+    /// trailing fragment too short to frame. Silently dropping either would turn
+    /// stream corruption into missing records.
+    #[rstest]
+    #[case::block_size_overruns_the_buffer(&[0x40, 0, 0, 0, 1, 2, 3])]
+    #[case::trailing_bytes_cannot_frame_a_record(&[1, 2, 3])]
+    #[case::single_trailing_byte(&[9])]
+    fn both_parsers_reject_a_malformed_tail(#[case] tail: &[u8]) {
+        let mut bytes = framed(&[1u8; 8]);
+        bytes.extend_from_slice(tail);
+
+        let ranges_err = parse_record_ranges(&bytes).expect_err("must reject a malformed tail");
+        assert_eq!(ranges_err.kind(), io::ErrorKind::InvalidData);
+
+        let records_err = parse_records(&bytes).expect_err("must reject a malformed tail");
+        assert_eq!(records_err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// The two parsers must agree on where records are: same count, and the
+    /// bytes `parse_records` copies must equal the slices `parse_record_ranges`
+    /// points at. They feed different steps over the same stream, so a
+    /// disagreement would mean the two decode paths see different records.
+    #[test]
+    fn the_two_parsers_agree_on_record_boundaries() {
+        let payloads: Vec<Vec<u8>> = (0..16u8).map(|i| vec![i; usize::from(i) + 1]).collect();
+        let bytes: Vec<u8> = payloads.iter().flat_map(|p| framed(p)).collect();
+
+        let ranges = parse_record_ranges(&bytes).expect("parses");
+        let records = parse_records(&bytes).expect("parses");
+
+        assert_eq!(ranges.len(), records.len());
+        for (range, record) in ranges.iter().zip(&records) {
+            assert_eq!(&bytes[range.0 as usize..range.1 as usize], record.as_ref());
+        }
+    }
+
+    #[test]
+    fn parse_records_decodes_block_size_prefix() {
+        // Build two synthetic "records": [block_size=8, 8 bytes of payload], twice.
+        let mut bytes = Vec::new();
+        for &p in &[1u8, 2u8] {
+            let payload = vec![p; 8];
+            bytes.extend_from_slice(&u32::try_from(payload.len()).unwrap().to_le_bytes());
+            bytes.extend_from_slice(&payload);
+        }
+        let records = parse_records(&bytes).unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].len(), 8);
+        assert_eq!(records[1].len(), 8);
+        assert_eq!(records[0].as_ref(), &[1u8; 8]);
+        assert_eq!(records[1].as_ref(), &[2u8; 8]);
+    }
+}

--- a/src/lib/pipeline/steps/parse/decode.rs
+++ b/src/lib/pipeline/steps/parse/decode.rs
@@ -1,0 +1,648 @@
+//! `DecodeRecords` mid-step. `Parallel + ByItemOrdinal`. Takes a
+//! `DecompressedBlock` (record-aligned bytes from `FindBamBoundaries`),
+//! parses the records, and computes a `GroupKey` for each in a single
+//! pass — emits a `DecodedRecordBatch`.
+//!
+//! Mirrors the legacy pipeline's combined "Decode" step
+//! (`pipeline/bam.rs:329-403`, `try_step_decode`): parse +
+//! key extraction in one pass, parallelizable, so the downstream
+//! Serial `GroupBam` step only does fast hash-and-name comparisons
+//! under its mutex.
+//!
+//! ## Why parse + decode in one step (was two)
+//!
+//! An earlier shape split parse and decode into two `Parallel` steps
+//! (`ParseBamRecords` → `DecodeRecords`) under the assumption that
+//! some non-grouping callers would want the parse without the key
+//! extraction. In practice every grouping command (`clip`, `group`,
+//! `dedup`, `simplex`, `duplex`, `correct`, `filter`) does want the
+//! keys, so the split forced one extra `Sequenced<T>`-wrap +
+//! `ReorderStage` + queue traversal per batch with no payoff. Profiling
+//! at scale (twist-umi 16 M records, threads=8) showed ~16M extra
+//! atomic ops + ordinal allocations from the redundant edge —
+//! collapsing them halves the per-record framework dispatch on the
+//! upstream half of the chain.
+//!
+//! `ParseBamRecords` is still available as a standalone step for callers
+//! who genuinely don't need group keys (e.g., `roundtrip` no-op chains,
+//! integration tests that only mutate raw bytes).
+
+use std::io;
+use std::sync::Arc;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::parse::bam::parse_records;
+use crate::pipeline::steps::types::{DecodedRecordBatch, DecompressedBlock, RecordBatch};
+use fgumi_bam_io::{DecodedRecord, GroupKeyConfig, compute_group_key_from_raw, name_hash_key};
+
+/// Fail closed on a raw BAM record body too short for the unchecked field
+/// accessors used during group-key extraction.
+///
+/// The parse steps that feed this one ([`parse_records`] and the
+/// `RecordBatch` walked by [`DecodeFromRecords`]) accept any record whose
+/// `block_size` prefix is internally consistent — they do **not** enforce a
+/// per-record minimum body size (see `parse_records`' contract). Both
+/// [`name_hash_key`] and [`compute_group_key_from_raw`] then call
+/// `fgumi_raw_bam::read_name`, which reads `raw[8]` (`l_read_name`, including
+/// the trailing NUL) and slices `raw[32..32 + l_read_name - 1]` with **no**
+/// bounds check; the full-key path additionally reads the 32-byte fixed header
+/// (`flags`, `ref_id`, mate fields, …). A truncated or malformed record would
+/// therefore panic on out-of-bounds indexing. We reject it here with
+/// `InvalidData` before any key is computed so the pipeline surfaces a clean
+/// error instead of unwinding a worker thread.
+///
+/// ## Minimum-length reasoning
+///
+/// - `raw.len() >= MIN_BAM_RECORD_LEN` (32) covers every fixed-offset field,
+///   including the `raw[8]` read of `l_read_name` itself.
+/// - A `>= MIN_BAM_RECORD_LEN` check alone is **not** sufficient: with
+///   `l_read_name` as large as 255 the name slice
+///   `raw[32..32 + l_read_name - 1]` ends well past a 32-byte record. So when
+///   `l_read_name > 1` we additionally require
+///   `raw.len() >= 32 + l_read_name - 1` (the exclusive end of that slice).
+///   When `l_read_name <= 1`, `read_name` returns `&[]` without slicing, so the
+///   32-byte header is enough.
+fn validate_record_for_decode(raw: &[u8]) -> io::Result<()> {
+    if raw.len() < fgumi_raw_bam::MIN_BAM_RECORD_LEN {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "validate_record_for_decode: BAM record too short for group-key extraction \
+                 ({} byte(s) < {}-byte fixed header)",
+                raw.len(),
+                fgumi_raw_bam::MIN_BAM_RECORD_LEN,
+            ),
+        ));
+    }
+    // `raw[8]` is in bounds because `raw.len() >= MIN_BAM_RECORD_LEN` (>= 9).
+    // `read_name` only slices the name region when `l_read_name > 1`; that
+    // slice's exclusive end index is `32 + l_read_name - 1`, which must not run
+    // past the record end.
+    let l_read_name = raw[8] as usize;
+    if l_read_name > 1 {
+        // Derive from the same constant as the length guard above: both encode
+        // the identical layout fact (the fixed-field header is 32 bytes, and the
+        // read name starts immediately after it). A literal here would let the
+        // guard and the bound it protects drift apart if that constant moved.
+        let name_end = fgumi_raw_bam::MIN_BAM_RECORD_LEN + l_read_name - 1;
+        if name_end > raw.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "validate_record_for_decode: BAM record read-name region runs past record end \
+                     (l_read_name={l_read_name} needs {name_end} byte(s), record is {} byte(s))",
+                    raw.len(),
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Cache the UMI tag's value position on a `DecodedRecord` during decode.
+///
+/// Looks up `umi_tag` in the record's aux data and, when present and Z-typed,
+/// stores the record-relative offset of its value bytes (excluding the trailing
+/// NUL) via [`DecodedRecord::set_cached_umi`]. The UMI-assignment step can then
+/// slice the value through [`DecodedRecord::cached_umi`] instead of re-scanning
+/// aux data once per template. When the tag is absent or not Z-typed the cache
+/// is left in the `UMI_OFFSET_UNCACHED` state and downstream code falls back to
+/// scanning aux data. Issue #334.
+pub(crate) fn cache_umi_position(decoded: &mut DecodedRecord, umi_tag: [u8; 2]) {
+    let raw = decoded.raw_bytes();
+    let Some(aux_offset) = fgumi_raw_bam::aux_data_offset_from_record(raw) else {
+        return;
+    };
+    // `aux_data_offset_from_record` derives the offset from the record header
+    // (`n_cigar_op`, `l_seq`) without bounding it against `raw.len()`, so a
+    // framing-consistent but malformed record can produce `aux_offset > raw.len()`.
+    // Slice through `get` — matching the guard in `aux_data_slice` — rather than
+    // panicking on an out-of-range index.
+    let Some(aux) = raw.get(aux_offset..) else {
+        return;
+    };
+    let Some((value_off_in_aux, value_len)) = fgumi_raw_bam::find_string_tag_position(aux, umi_tag)
+    else {
+        return;
+    };
+    let Ok(aux_offset_u32) = u32::try_from(aux_offset) else {
+        return;
+    };
+    let Some(value_offset) = aux_offset_u32.checked_add(value_off_in_aux) else {
+        return;
+    };
+    decoded.set_cached_umi(value_offset, value_len);
+}
+
+/// `Parallel + ByItemOrdinal` parse + decode. `DecompressedBlock →
+/// DecodedRecordBatch`.
+pub struct DecodeRecords {
+    /// Shared across all worker clones — `GroupKeyConfig` holds an
+    /// `Arc<LibraryIndex>` internally, so cloning the config is cheap.
+    key_config: GroupKeyConfig,
+    held: HeldSlot<Unpushed<DecodedRecordBatch>>,
+    output_byte_limit: u64,
+}
+
+impl DecodeRecords {
+    #[must_use]
+    pub fn new(key_config: GroupKeyConfig, output_byte_limit: u64) -> Self {
+        Self { key_config, held: HeldSlot::new(), output_byte_limit }
+    }
+}
+
+impl Clone for DecodeRecords {
+    fn clone(&self) -> Self {
+        Self {
+            key_config: self.key_config.clone(),
+            held: HeldSlot::new(),
+            output_byte_limit: self.output_byte_limit,
+        }
+    }
+}
+
+impl Step for DecodeRecords {
+    type Input = DecompressedBlock;
+    type Outputs = OrderedBytesSingle<DecodedRecordBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "DecodeRecords",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(block) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let DecompressedBlock { batch_serial, bytes } = block;
+
+        // Single pass: parse the record-aligned bytes, then compute the
+        // group key per record. Both halves are parallelizable per record
+        // and don't share state, so the framework's `Parallel` kind covers
+        // the whole pass.
+        let records = parse_records(&bytes)?;
+        let library_index: &Arc<_> = &self.key_config.library_index;
+        let cell_tag = self.key_config.cell_tag;
+        let name_hash_only = self.key_config.name_hash_only;
+        let umi_tag = self.key_config.umi_tag;
+        let decoded: Vec<DecodedRecord> = records
+            .into_iter()
+            .map(|raw| -> io::Result<DecodedRecord> {
+                // Fail closed before the unchecked raw-field accessors run: a
+                // truncated/malformed body would otherwise panic in
+                // `read_name` (see `validate_record_for_decode`).
+                validate_record_for_decode(raw.as_ref())?;
+                // Queryname-grouping stages (e.g. correct) read only
+                // `key.name_hash`; skip the CIGAR position walk + aux-tag pass.
+                let key = if name_hash_only {
+                    name_hash_key(raw.as_ref())
+                } else {
+                    compute_group_key_from_raw(raw.as_ref(), library_index, cell_tag)
+                };
+                let mut decoded = DecodedRecord::from_raw_bytes(raw, key);
+                // Cache the UMI value position so the Group step's assignment
+                // pass can slice it without re-scanning aux data (#334).
+                if let Some(umi_tag) = umi_tag {
+                    cache_umi_position(&mut decoded, umi_tag);
+                }
+                Ok(decoded)
+            })
+            .collect::<io::Result<Vec<_>>>()?;
+
+        let out = DecodedRecordBatch::new(batch_serial, decoded);
+        match ctx.outputs.push(out) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+/// `Parallel + ByItemOrdinal` group-key extractor. `RecordBatch →
+/// DecodedRecordBatch`. Sibling of [`DecodeRecords`] that skips the
+/// parse phase — useful when an earlier step (e.g. the `Sort` typed
+/// step's output) already produced `RecordBatch`es and we need to
+/// re-attach group keys without re-serializing through framed bytes.
+///
+/// Used by the runall fusion path:
+///   `... → ParseBamRecords → Sort → DecodeFromRecords → GroupByPosition`
+/// instead of the (no-sort) shorter
+///   `... → DecodeRecords → GroupByPosition`.
+pub struct DecodeFromRecords {
+    key_config: GroupKeyConfig,
+    held: HeldSlot<Unpushed<DecodedRecordBatch>>,
+    output_byte_limit: u64,
+}
+
+impl DecodeFromRecords {
+    #[must_use]
+    pub fn new(key_config: GroupKeyConfig, output_byte_limit: u64) -> Self {
+        Self { key_config, held: HeldSlot::new(), output_byte_limit }
+    }
+}
+
+impl Clone for DecodeFromRecords {
+    fn clone(&self) -> Self {
+        Self {
+            key_config: self.key_config.clone(),
+            held: HeldSlot::new(),
+            output_byte_limit: self.output_byte_limit,
+        }
+    }
+}
+
+impl Step for DecodeFromRecords {
+    type Input = RecordBatch;
+    type Outputs = OrderedBytesSingle<DecodedRecordBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "DecodeFromRecords",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(batch) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let batch_serial = batch.batch_serial();
+
+        let library_index: &Arc<_> = &self.key_config.library_index;
+        let cell_tag = self.key_config.cell_tag;
+        let name_hash_only = self.key_config.name_hash_only;
+        let umi_tag = self.key_config.umi_tag;
+        // `DecodedRecord` owns its bytes (via `RawRecord`), so we materialize
+        // a heap-allocated copy here. The `RecordBatch`'s shared backing
+        // buffer is dropped once this batch is consumed.
+        let decoded: Vec<DecodedRecord> = batch
+            .iter_record_bytes()
+            .map(|bytes| -> io::Result<DecodedRecord> {
+                // Fail closed before the unchecked raw-field accessors run: a
+                // truncated/malformed body would otherwise panic in
+                // `read_name` (see `validate_record_for_decode`).
+                validate_record_for_decode(bytes)?;
+                // Mirror `DecodeRecords::try_run`: queryname-grouping stages
+                // (e.g. correct) read only `key.name_hash`, so skip the CIGAR
+                // position walk + aux-tag pass when `name_hash_only` is set.
+                let key = if name_hash_only {
+                    name_hash_key(bytes)
+                } else {
+                    compute_group_key_from_raw(bytes, library_index, cell_tag)
+                };
+                let mut decoded = DecodedRecord::from_raw_bytes(
+                    fgumi_raw_bam::RawRecord::from(bytes.to_vec()),
+                    key,
+                );
+                // Cache the UMI value position so the Group step's assignment
+                // pass can slice it without re-scanning aux data (#334).
+                if let Some(umi_tag) = umi_tag {
+                    cache_umi_position(&mut decoded, umi_tag);
+                }
+                Ok(decoded)
+            })
+            .collect::<io::Result<Vec<_>>>()?;
+
+        let out = DecodedRecordBatch::new(batch_serial, decoded);
+        match ctx.outputs.push(out) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_advertises_parallel_byordinal() {
+        let s = DecodeRecords::new(GroupKeyConfig::default(), 1024);
+        let p = s.profile();
+        assert_eq!(p.name, "DecodeRecords");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    #[test]
+    fn from_records_profile_advertises_parallel_byordinal() {
+        let s = DecodeFromRecords::new(GroupKeyConfig::default(), 1024);
+        let p = s.profile();
+        assert_eq!(p.name, "DecodeFromRecords");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    /// The `name_hash_only` decode path (used by queryname-grouping stages
+    /// like `correct`) must produce the *same* `name_hash` the full
+    /// `compute_group_key_from_raw` would, with every other `GroupKey` field
+    /// left at its default. This is what makes the optimization output-safe:
+    /// `GroupByQueryname` reads only `key.name_hash`.
+    #[test]
+    fn name_hash_only_key_matches_full_key_name_hash_and_zeros_rest() {
+        use fgumi_bam_io::{GroupKey, LibraryIndex};
+        use fgumi_raw_bam::SamBuilder;
+        use fgumi_raw_bam::flags::{PAIRED, SECONDARY, UNMAPPED};
+        use noodles::sam::alignment::record::data::field::Tag;
+
+        let lib = LibraryIndex::default();
+        let cb = Tag::from([b'C', b'B']);
+
+        let make = |name: &[u8], flags: u16, mapped: bool| -> fgumi_raw_bam::RawRecord {
+            let mut b = SamBuilder::new();
+            b.read_name(name).flags(flags).sequence(b"ACGT").qualities(b"IIII");
+            if mapped {
+                b.ref_id(0).pos(100).cigar_ops(&[4u32 << 4]); // 4M
+            }
+            b.build()
+        };
+
+        let records = [
+            make(b"q-mapped-paired", PAIRED, true),
+            make(b"q-unmapped", UNMAPPED, false),
+            make(b"q-secondary", SECONDARY, true),
+            make(b"q", 0, true), // short name
+        ];
+
+        for raw in &records {
+            let full = compute_group_key_from_raw(raw.as_ref(), &lib, Some(cb));
+            let name_only = name_hash_key(raw.as_ref());
+            assert_eq!(
+                name_only.name_hash, full.name_hash,
+                "name_hash_only must reproduce the full key's name_hash"
+            );
+            assert_eq!(
+                name_only,
+                GroupKey { name_hash: full.name_hash, ..GroupKey::default() },
+                "name_hash_only must leave all non-name fields at default"
+            );
+        }
+    }
+
+    // ========================================================================
+    // Fail-closed validation of undersized / malformed records
+    // ========================================================================
+
+    /// A record body shorter than the 32-byte BAM fixed header must be rejected
+    /// with `InvalidData` rather than panicking in the unchecked field
+    /// accessors. Mirrors the 8-byte records built by
+    /// `parse_records_decodes_block_size_prefix` in `bam.rs` — exactly the
+    /// shape `parse_records` accepts but the key extractors cannot decode.
+    #[test]
+    fn validate_record_for_decode_rejects_record_shorter_than_fixed_header() {
+        let too_short = [0u8; 8];
+        let err = validate_record_for_decode(&too_short).expect_err("must fail closed");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// A record long enough for the fixed header but whose declared
+    /// `l_read_name` runs past the record end must also be rejected. This is
+    /// the case a bare `len >= MIN_BAM_RECORD_LEN` check would miss: without
+    /// the read-name bound, `read_name` would slice `raw[32..32 + 50 - 1]` on a
+    /// 32-byte record and panic.
+    #[test]
+    fn validate_record_for_decode_rejects_truncated_read_name() {
+        let mut rec = [0u8; fgumi_raw_bam::MIN_BAM_RECORD_LEN];
+        rec[8] = 50; // l_read_name claims 49 name bytes + NUL, none of which exist
+        let err = validate_record_for_decode(&rec).expect_err("must fail closed");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// The boundary cases that must be accepted: a 32-byte record with an empty
+    /// name (`l_read_name <= 1`, where `read_name` never slices) and a real
+    /// well-formed record built by `SamBuilder`. Proves the guard does not
+    /// reject valid input.
+    #[test]
+    fn validate_record_for_decode_accepts_minimal_and_valid_records() {
+        use fgumi_raw_bam::SamBuilder;
+
+        // 32-byte record, l_read_name = 1 (just the NUL): read_name short-circuits.
+        let mut minimal = [0u8; fgumi_raw_bam::MIN_BAM_RECORD_LEN];
+        minimal[8] = 1;
+        validate_record_for_decode(&minimal).expect("minimal empty-name record is valid");
+
+        // A real record exercising read_name's slice path.
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1").sequence(b"ACGT").qualities(&[30u8; 4]);
+        let raw = b.build();
+        validate_record_for_decode(raw.as_ref()).expect("well-formed record is valid");
+    }
+
+    /// End-to-end fail-closed proof: the same undersized record fed through the
+    /// `DecodeRecords` map logic (the production `name_hash_only` and full-key
+    /// branches) yields an `io::Error`, not a panic. Reproduces the map +
+    /// `collect::<io::Result<Vec<_>>>()` shape used by `try_run`.
+    #[test]
+    fn decode_map_fails_closed_on_undersized_record_for_both_key_branches() {
+        use fgumi_bam_io::{GroupKey, LibraryIndex};
+        use noodles::sam::alignment::record::data::field::Tag;
+
+        let lib = LibraryIndex::default();
+        let cell_tag = Some(Tag::from([b'C', b'B']));
+        // Below the fixed-header minimum — would panic in `read_name` if it
+        // reached the key extractors.
+        let undersized: &[u8] = &[0u8; 8];
+
+        for name_hash_only in [true, false] {
+            let result: io::Result<Vec<GroupKey>> = [undersized]
+                .into_iter()
+                .map(|raw| -> io::Result<GroupKey> {
+                    validate_record_for_decode(raw)?;
+                    let key = if name_hash_only {
+                        name_hash_key(raw)
+                    } else {
+                        compute_group_key_from_raw(raw, &lib, cell_tag)
+                    };
+                    Ok(key)
+                })
+                .collect();
+            let err = result.expect_err("undersized record must fail closed");
+            assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        }
+    }
+
+    // ========================================================================
+    // UMI position caching during Decode (issue #334)
+    // ========================================================================
+
+    #[test]
+    fn cache_umi_position_records_value_offset_matching_fallback() {
+        use crate::sam::SamTag;
+        use fgumi_bam_io::GroupKey;
+        use fgumi_raw_bam::{SamBuilder, flags};
+
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGT")
+            .qualities(&[30u8; 4])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+        b.add_string_tag(SamTag::RX, b"ACGTACGT");
+        let raw = b.build();
+
+        let mut decoded = DecodedRecord::from_raw_bytes(raw, GroupKey::default());
+        cache_umi_position(&mut decoded, *SamTag::RX);
+
+        // The cached slice must equal the canonical find_string_tag answer.
+        let aux = fgumi_raw_bam::aux_data_slice(decoded.raw_bytes());
+        let expected = fgumi_raw_bam::find_string_tag(aux, *SamTag::RX).expect("RX present");
+        assert_eq!(decoded.cached_umi(), Some(expected));
+        assert_eq!(decoded.cached_umi().unwrap(), b"ACGTACGT");
+    }
+
+    #[test]
+    fn cache_umi_position_leaves_cache_unset_when_tag_missing() {
+        use crate::sam::SamTag;
+        use fgumi_bam_io::GroupKey;
+        use fgumi_raw_bam::{SamBuilder, flags};
+
+        // Record with no RX tag — caching must be a no-op.
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGT")
+            .qualities(&[30u8; 4])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+        let raw = b.build();
+
+        let mut decoded = DecodedRecord::from_raw_bytes(raw, GroupKey::default());
+        cache_umi_position(&mut decoded, *SamTag::RX);
+
+        assert!(decoded.cached_umi().is_none());
+        assert_eq!(decoded.cached_umi_position().0, DecodedRecord::UMI_OFFSET_UNCACHED);
+    }
+
+    /// A malformed record whose header inflates the derived aux offset past the
+    /// record end must leave the cache unset rather than panicking.
+    /// `aux_data_offset_from_record` derives the offset from `n_cigar_op` /
+    /// `l_seq` without bounding it against `raw.len()`, so the `raw.get(aux..)`
+    /// guard in `cache_umi_position` is the only thing between a
+    /// framing-consistent-but-corrupt record and an out-of-range slice panic.
+    /// The well-formed cache tests never take that branch.
+    #[test]
+    fn cache_umi_position_leaves_cache_unset_when_aux_offset_is_out_of_range() {
+        use crate::sam::SamTag;
+        use fgumi_bam_io::GroupKey;
+        use fgumi_raw_bam::{SamBuilder, flags};
+
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGT")
+            .qualities(&[30u8; 4])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+        b.add_string_tag(SamTag::RX, b"ACGTACGT");
+        let raw = b.build();
+
+        // Inflate n_cigar_op (u16 at bytes 12-13) to 0xFFFF so the derived aux
+        // offset (32 + l_read_name + n_cigar_op*4 + …) lands far past the record
+        // end, without changing the record's actual byte length.
+        let mut bytes = raw.as_ref().to_vec();
+        bytes[12] = 0xFF;
+        bytes[13] = 0xFF;
+        assert!(
+            fgumi_raw_bam::aux_data_offset_from_record(&bytes).unwrap() > bytes.len(),
+            "the corrupted header must derive an out-of-range aux offset",
+        );
+
+        let mut decoded = DecodedRecord::from_raw_bytes(bytes, GroupKey::default());
+        cache_umi_position(&mut decoded, *SamTag::RX); // must not panic
+
+        assert!(decoded.cached_umi().is_none());
+        assert_eq!(decoded.cached_umi_position().0, DecodedRecord::UMI_OFFSET_UNCACHED);
+    }
+
+    /// A tag present but not `Z`-typed must leave the cache unset rather than
+    /// caching a bogus offset/length into non-string bytes. `cache_umi_position`
+    /// relies on `find_string_tag_position` to reject the wrong type, and this
+    /// is a different rejection path from the tag being absent entirely — the
+    /// scan finds `RX`, then has to decline it on type.
+    #[test]
+    fn cache_umi_position_leaves_cache_unset_when_tag_is_not_z_typed() {
+        use crate::sam::SamTag;
+        use fgumi_bam_io::GroupKey;
+        use fgumi_raw_bam::{SamBuilder, flags};
+
+        let mut b = SamBuilder::new();
+        b.read_name(b"read1")
+            .sequence(b"ACGT")
+            .qualities(&[30u8; 4])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT);
+        // RX as an integer, not a Z string.
+        b.add_int_tag(SamTag::RX, 42);
+        let raw = b.build();
+
+        // Sanity: the tag really is present, so this exercises the type
+        // rejection and not the absent-tag path covered above.
+        let aux = fgumi_raw_bam::aux_data_slice(raw.as_ref());
+        assert!(
+            fgumi_raw_bam::find_string_tag(aux, *SamTag::RX).is_none(),
+            "an int-typed RX must not resolve as a string tag",
+        );
+
+        let mut decoded = DecodedRecord::from_raw_bytes(raw, GroupKey::default());
+        cache_umi_position(&mut decoded, *SamTag::RX);
+
+        assert!(decoded.cached_umi().is_none());
+        assert_eq!(decoded.cached_umi_position().0, DecodedRecord::UMI_OFFSET_UNCACHED);
+    }
+}

--- a/src/lib/pipeline/steps/parse/mod.rs
+++ b/src/lib/pipeline/steps/parse/mod.rs
@@ -1,0 +1,5 @@
+//! Per-format record-parsing steps.
+
+pub mod bam;
+pub mod decode;
+pub mod sam;

--- a/src/lib/pipeline/steps/parse/sam.rs
+++ b/src/lib/pipeline/steps/parse/sam.rs
@@ -1,0 +1,543 @@
+//! `ParseSamChunk` mid-step. `Parallel + ByItemOrdinal`. Consumes a
+//! `SamChunk` from the SAM source, parses each line via noodles' SAM
+//! reader, re-encodes the record into its BAM body bytes via
+//! `bam::io::Writer`, computes a `GroupKey`, and emits a
+//! `DecodedRecordBatch` — the same output type `DecodeRecords`
+//! produces for the BAM chain.
+//!
+//! Each chunk is independent (the upstream Read step splits at line
+//! boundaries, so records never cross chunks). Workers process
+//! different chunks concurrently — this is the parallel-parse phase
+//! that lets the SAM ingest path keep up with the multi-MB/s aligner
+//! output stream.
+
+use std::io;
+use std::sync::Arc;
+
+use noodles::bam;
+use noodles::sam;
+use noodles::sam::alignment::io::Write as _;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::{DecodedRecordBatch, SamChunk};
+use fgumi_bam_io::{DecodedRecord, GroupKeyConfig, compute_group_key_from_raw, name_hash_key};
+
+/// Parse every line in `chunk` and produce a `DecodedRecordBatch` carrying
+/// the chunk's batch serial. SAM lines are encoded into BAM record body
+/// bytes via `bam::io::Writer` (which writes `u32 LE block_size` +
+/// record body to its inner buffer); the 4-byte length prefix is
+/// stripped so the resulting `DecodedRecord` matches the shape produced
+/// by the BAM-side `DecodeRecords`.
+///
+/// # Errors
+///
+/// Returns I/O errors from SAM line parsing or BAM encoding.
+pub fn parse_sam_chunk_into_decoded(
+    chunk: SamChunk,
+    header: &sam::Header,
+    key_config: &GroupKeyConfig,
+) -> io::Result<DecodedRecordBatch> {
+    let SamChunk { batch_serial, bytes, line_offsets } = chunk;
+    let n_records = line_offsets.len().saturating_sub(1);
+    let mut decoded: Vec<DecodedRecord> = Vec::with_capacity(n_records);
+
+    let library_index = &key_config.library_index;
+    let cell_tag = key_config.cell_tag;
+    let name_hash_only = key_config.name_hash_only;
+
+    let mut sam_record = sam::Record::default();
+    let mut encoder = bam::io::Writer::from(Vec::<u8>::with_capacity(4096));
+
+    // Walk lines explicitly so we can skip empty ones (e.g. a trailing
+    // `\n\n` in the input shows up as a length-1 empty offset slot;
+    // feeding `\n` to noodles' `sam::io::Reader` errors with
+    // "unexpected EOL"). Each non-empty line is read with a fresh
+    // single-line reader so we don't have to coordinate state across
+    // skipped lines.
+    for i in 0..n_records {
+        let start = line_offsets[i] as usize;
+        let end = line_offsets[i + 1] as usize;
+        // Validate the range BEFORE any length arithmetic. `line_offsets` is
+        // caller-supplied (this function is `pub`), so a reversed or
+        // out-of-bounds pair must surface as `InvalidData` rather than panic on
+        // the slice below and unwind a pipeline worker. A `saturating_sub`
+        // length check does not cover this: `start = 100, end = 105` over a
+        // 12-byte buffer has span 5, sails past any length test, and then
+        // indexes out of bounds.
+        let Some(line) = bytes.get(start..end) else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "parse_sam_chunk_into_decoded: line {i} has an invalid offset range \
+                     ({start}..{end}) for a {}-byte chunk",
+                    bytes.len(),
+                ),
+            ));
+        };
+        // Length 1 means just the `\n`; length 0 would be an
+        // ill-formed offset (defensive — shouldn't happen with the
+        // current splitter, but skipping is the right behavior either way).
+        if line.len() <= 1 {
+            continue;
+        }
+        let mut sam_reader = sam::io::Reader::new(line);
+        let n = sam_reader.read_record(&mut sam_record)?;
+        if n == 0 {
+            continue;
+        }
+        encoder.get_mut().clear();
+        encoder.write_alignment_record(header, &sam_record)?;
+        // Copy the encoded body into a *right-sized* buffer, stripping the
+        // 4-byte little-endian `block_size` prefix `bam::io::Writer` prepends.
+        // The encoder's scratch buffer is retained and reused (it is cleared at
+        // the top of the next iteration), so it grows once to the largest record
+        // and never reallocates; only this right-sized `to_vec()` allocates per
+        // record.
+        //
+        // A record must NOT inherit the encoder's scratch capacity. A previous
+        // `mem::replace(encoder.get_mut(), Vec::with_capacity(cap.max(4096)))`
+        // handed every `DecodedRecord` a >=4 KiB buffer to hold a ~60-byte body
+        // — a ~20x per-record over-allocation. Because records are held in
+        // flight through the pipeline, that blew `zipper` (and any SAM-input
+        // pipeline) to tens of GiB on large inputs, while the BAM-input path
+        // stayed bounded (its records are right-sized). The single memcpy per
+        // record here is far cheaper than that blowup and matches the BAM path's
+        // right-sized records.
+        let body_bytes = encoder.get_ref()[4..].to_vec();
+        // Match the BAM decode path (`DecodeFromRecords`): under
+        // `name_hash_only` the key is the name hash alone, so SAM- and
+        // BAM-ingested records group identically.
+        let key = if name_hash_only {
+            name_hash_key(&body_bytes)
+        } else {
+            compute_group_key_from_raw(&body_bytes, library_index, cell_tag)
+        };
+        let mut record = DecodedRecord::from_raw_bytes(body_bytes, key);
+        // Parity with the BAM decode paths (`DecodeRecords` /
+        // `DecodeFromRecords`): cache the UMI value position so the Group step's
+        // assignment pass can slice it without re-scanning aux data (issue #334).
+        // Both paths converge on `DecodedRecordBatch`, so without this a
+        // SAM-ingested record would cost an extra aux scan per template that an
+        // otherwise identical BAM-ingested record does not.
+        if let Some(umi_tag) = key_config.umi_tag {
+            super::decode::cache_umi_position(&mut record, umi_tag);
+        }
+        decoded.push(record);
+    }
+
+    Ok(DecodedRecordBatch::new(batch_serial, decoded))
+}
+
+/// `Parallel + ByItemOrdinal` SAM parser. `SamChunk → DecodedRecordBatch`.
+/// Sibling of `parse::decode::DecodeRecords` for the SAM ingest path —
+/// converging at `DecodedRecordBatch` so every downstream step
+/// (`GroupBam`/`GroupByPosition`/`process_ordered`/…) is reused
+/// unchanged.
+pub struct ParseSamChunk {
+    /// Reference header. Shared across all worker clones — encoding
+    /// needs it for reference-sequence ID resolution. `Arc` so cloning
+    /// the step is cheap.
+    header: Arc<sam::Header>,
+    /// Group-key config (library index + cell tag). Shared via the
+    /// `Arc<LibraryIndex>` inside `GroupKeyConfig`.
+    key_config: GroupKeyConfig,
+    held: HeldSlot<Unpushed<DecodedRecordBatch>>,
+    output_byte_limit: u64,
+}
+
+impl ParseSamChunk {
+    #[must_use]
+    pub fn new(
+        header: Arc<sam::Header>,
+        key_config: GroupKeyConfig,
+        output_byte_limit: u64,
+    ) -> Self {
+        Self { header, key_config, held: HeldSlot::new(), output_byte_limit }
+    }
+}
+
+impl Clone for ParseSamChunk {
+    fn clone(&self) -> Self {
+        Self {
+            header: Arc::clone(&self.header),
+            key_config: self.key_config.clone(),
+            held: HeldSlot::new(),
+            output_byte_limit: self.output_byte_limit,
+        }
+    }
+}
+
+impl Step for ParseSamChunk {
+    type Input = SamChunk;
+    type Outputs = OrderedBytesSingle<DecodedRecordBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ParseSamChunk",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(chunk) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+
+        let batch = parse_sam_chunk_into_decoded(chunk, &self.header, &self.key_config)?;
+
+        match ctx.outputs.push(batch) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::steps::types::SamChunk;
+    use fgumi_bam_io::GroupKeyConfig;
+    use noodles::sam;
+    use rstest::rstest;
+
+    const SAM_TEXT: &str = "\
+@HD\tVN:1.6\tSO:unsorted\n\
+@SQ\tSN:chr1\tLN:1000\n\
+read1\t0\tchr1\t10\t60\t5M\t*\t0\t0\tACGTA\tIIIII\n\
+read2\t16\tchr1\t20\t60\t5M\t*\t0\t0\tTGCAT\t!!!!!\n";
+
+    fn parse_header(text: &str) -> sam::Header {
+        let mut reader = sam::io::Reader::new(text.as_bytes());
+        reader.read_header().expect("header parses")
+    }
+
+    fn key_config_for(header: &sam::Header) -> GroupKeyConfig {
+        let library_index = fgumi_bam_io::LibraryIndex::from_header(header);
+        GroupKeyConfig::new_raw_no_cell(library_index)
+    }
+
+    /// Build a `SamChunk` from the two record lines in `SAM_TEXT` (skipping
+    /// the header lines). This is what `ReadSamChunks` would emit downstream
+    /// of header consumption.
+    fn sam_chunk_from_records(serial: u64) -> SamChunk {
+        let records = "\
+read1\t0\tchr1\t10\t60\t5M\t*\t0\t0\tACGTA\tIIIII\n\
+read2\t16\tchr1\t20\t60\t5M\t*\t0\t0\tTGCAT\t!!!!!\n";
+        let bytes = records.as_bytes().to_vec();
+        // Two lines: offsets at [0, end_of_line_0, end_of_line_1].
+        let mut line_offsets = vec![0u32];
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'\n' {
+                line_offsets.push(u32::try_from(i + 1).unwrap());
+            }
+        }
+        SamChunk { batch_serial: serial, bytes, line_offsets }
+    }
+
+    #[test]
+    fn parse_sam_chunk_emits_one_decoded_record_per_input_line() {
+        let header = parse_header(SAM_TEXT);
+        let key_config = key_config_for(&header);
+        let chunk = sam_chunk_from_records(7);
+
+        let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
+        assert_eq!(batch.batch_serial(), 7, "serial propagated from input chunk");
+        assert_eq!(batch.records().len(), 2);
+    }
+
+    #[test]
+    fn parse_sam_chunk_records_are_right_sized_not_encoder_buffer() {
+        // Regression: each SAM record must own a *right-sized* buffer, not the
+        // shared >=4 KiB encoder scratch buffer. Handing every record the
+        // encoder's `Vec::with_capacity(>=4096)` (via `mem::replace`) made a
+        // ~60-byte record carry a 4 KiB allocation — a ~20x per-record blowup
+        // that drove pipeline-mode `zipper` to tens of GiB on large inputs
+        // (fast-path/BAM-input stayed bounded because those records are
+        // right-sized). The BAM decode path is the reference: its records'
+        // capacity tracks their length.
+        use fgumi_bam_io::MemoryEstimate;
+        let header = parse_header(SAM_TEXT);
+        let key_config = key_config_for(&header);
+        let chunk = sam_chunk_from_records(0);
+
+        let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
+        for rec in batch.records() {
+            let len = rec.raw_bytes().len();
+            let cap = rec.estimate_heap_size(); // RawRecord::capacity()
+            assert!(
+                cap <= len * 2 + 64,
+                "SAM-parsed record over-allocated: len={len} cap={cap} — each record \
+                 must own a right-sized buffer, not the shared >=4096 B encoder scratch",
+            );
+        }
+    }
+
+    #[test]
+    fn parse_sam_chunk_emits_records_with_correct_read_names() {
+        // Round-trip test: SAM text → BAM body bytes → decode names. Proves
+        // the encode step preserves identity (per SAM spec, BAM record body
+        // layout: refID/pos/l_read_name/.../read_name@offset 32).
+        let header = parse_header(SAM_TEXT);
+        let key_config = key_config_for(&header);
+        let chunk = sam_chunk_from_records(0);
+
+        let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
+
+        let mut names: Vec<Vec<u8>> = Vec::new();
+        for rec in batch.records() {
+            let body = rec.raw_bytes();
+            // BAM record body layout: bytes 0..32 are fixed fields;
+            // byte 8 is l_read_name (including NUL); read_name starts at
+            // byte 32 and is `l_read_name - 1` bytes (excluding NUL).
+            let l_read_name = body[8] as usize;
+            names.push(body[32..32 + l_read_name - 1].to_vec());
+        }
+        assert_eq!(names, vec![b"read1".to_vec(), b"read2".to_vec()]);
+    }
+
+    #[test]
+    fn parse_sam_chunk_skips_empty_lines() {
+        // A SAM file ending in `record\n\n` produces offsets that include an
+        // empty line slot. The parser must skip such empty offsets — feeding
+        // an empty line to noodles' SAM reader raises "unexpected EOL".
+        let header = parse_header(SAM_TEXT);
+        let key_config = key_config_for(&header);
+        // Construct a chunk with a real record followed by an empty line.
+        let records = b"read1\t0\tchr1\t10\t60\t5M\t*\t0\t0\tACGTA\tIIIII\n\n";
+        let bytes = records.to_vec();
+        let mut line_offsets = vec![0u32];
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'\n' {
+                line_offsets.push(u32::try_from(i + 1).unwrap());
+            }
+        }
+        // Three offsets => two "lines", second is empty (the `\n` after `\n`).
+        assert_eq!(line_offsets.len(), 3);
+        let chunk = SamChunk { batch_serial: 0, bytes, line_offsets };
+
+        let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
+        assert_eq!(batch.records().len(), 1, "empty line should be skipped, not parsed");
+    }
+
+    #[test]
+    fn parse_sam_chunk_with_empty_record_count_returns_empty_batch() {
+        let header = parse_header(SAM_TEXT);
+        let key_config = key_config_for(&header);
+        let chunk = SamChunk { batch_serial: 11, bytes: Vec::new(), line_offsets: Vec::new() };
+
+        let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
+        assert_eq!(batch.batch_serial(), 11);
+        assert!(batch.records().is_empty());
+    }
+
+    /// Full-field parity: BAM-encode a record via noodles + `DecodeRecords`
+    /// produces the same `DecodedRecord.raw_bytes()` as SAM-encode of the
+    /// equivalent text via `ParseSamChunk`. This is the strongest correctness
+    /// assertion for the SAM parse path — every BAM record field (flags,
+    /// refID, pos, MAPQ, CIGAR, sequence, quality, mate info, tags) must
+    /// round-trip identically.
+    #[test]
+    fn parse_sam_chunk_record_bytes_match_bam_decode_path() {
+        use fgumi_bam_io::DecodedRecord as _DecodedRecord;
+        use noodles::bam;
+        use noodles::sam::alignment::io::Write as _;
+
+        // Header with one ref + a read group.
+        let header_text = "\
+@HD\tVN:1.6\tSO:coordinate\n\
+@SQ\tSN:chr1\tLN:1000\n\
+@RG\tID:rg1\tSM:sample\n";
+        let header = parse_header(header_text);
+        let key_config = key_config_for(&header);
+
+        // Record with the full menagerie of fields: mapped, paired with mate,
+        // MAPQ 60, multi-op CIGAR (M/I/D/S/H), full sequence + qualities,
+        // and several optional tag types (Z string, i int, B array, A char).
+        // `RX` is a UMI tag the group-key extractor reads (relevant via
+        // GroupKeyConfig).
+        let sam_line = "rec1\t99\tchr1\t100\t60\t3M1I2M1D2S1H\t=\t200\t300\tACGTGCAC\tIIIIIIII\tRX:Z:ACGT\tNM:i:2\tBQ:Z:GGGGGGGG\tBI:B:S,10,20,30\n";
+
+        // ── BAM path: parse to noodles record, encode body bytes via the
+        // same encoder DecodeRecords would consume after BgzfDecompress +
+        // FindBamBoundaries.
+        let bam_body = {
+            let mut reader = noodles::sam::io::Reader::new(sam_line.as_bytes());
+            let mut rec = noodles::sam::Record::default();
+            reader.read_record(&mut rec).expect("sam parse");
+            let mut buf = bam::io::Writer::from(Vec::<u8>::new());
+            buf.write_alignment_record(&header, &rec).expect("encode");
+            // Strip the 4-byte block_size prefix.
+            buf.get_ref()[4..].to_vec()
+        };
+        let bam_decoded = _DecodedRecord::from_raw_bytes(
+            bam_body.clone(),
+            fgumi_bam_io::compute_group_key_from_raw(
+                &bam_body,
+                &key_config.library_index,
+                key_config.cell_tag,
+            ),
+        );
+
+        // ── SAM path: same line through ParseSamChunk.
+        let bytes = sam_line.as_bytes().to_vec();
+        let mut line_offsets = vec![0u32];
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'\n' {
+                line_offsets.push(u32::try_from(i + 1).unwrap());
+            }
+        }
+        let chunk = SamChunk { batch_serial: 0, bytes, line_offsets };
+        let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
+        assert_eq!(batch.records().len(), 1);
+        let sam_decoded = &batch.records()[0];
+
+        // Byte-identical raw record bytes (the SAM and BAM encoder paths
+        // both go through `bam::io::Writer::write_alignment_record`).
+        assert_eq!(
+            sam_decoded.raw_bytes(),
+            bam_decoded.raw_bytes(),
+            "SAM and BAM paths must produce byte-identical DecodedRecord.raw_bytes()",
+        );
+    }
+
+    /// Under `name_hash_only`, the SAM parse path must key records by the read
+    /// name hash alone — identical to the BAM `DecodeFromRecords` path — so
+    /// SAM- and BAM-ingested reads group together. Regression for the SAM path
+    /// previously ignoring `name_hash_only` and always computing the full
+    /// position/library key.
+    #[test]
+    fn parse_sam_chunk_honors_name_hash_only() {
+        let header = parse_header(SAM_TEXT);
+        let library_index = fgumi_bam_io::LibraryIndex::from_header(&header);
+        let key_config = GroupKeyConfig::name_hash_only(library_index);
+
+        let chunk = sam_chunk_from_records(0);
+        let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
+        assert_eq!(batch.records().len(), 2);
+
+        for rec in batch.records() {
+            let raw = rec.raw_bytes();
+            assert_eq!(
+                rec.key,
+                fgumi_bam_io::name_hash_key(raw),
+                "name_hash_only SAM key must be the name-hash key, not the full group key",
+            );
+            // The fixture reads are mapped (chr1:10 / chr1:20), so the full
+            // position/library key differs from the name-hash key — confirming
+            // the branch actually changed paths.
+            assert_ne!(
+                rec.key,
+                fgumi_bam_io::compute_group_key_from_raw(
+                    raw,
+                    &key_config.library_index,
+                    key_config.cell_tag,
+                ),
+                "name_hash_only key must differ from the full position/library key for a mapped read",
+            );
+        }
+    }
+
+    /// `line_offsets` is caller-supplied data, and `parse_sam_chunk_into_decoded`
+    /// is `pub`. A malformed table must produce `InvalidData`, never an
+    /// out-of-bounds slice panic that would unwind a pipeline worker.
+    ///
+    /// The `saturating_sub(start) <= 1` skip does not cover this: for
+    /// `start=100, end=105` over a 12-byte buffer the span is 5, so the old code
+    /// proceeded straight to `&bytes[100..105]` and panicked.
+    #[rstest]
+    #[case::start_and_end_past_the_buffer(100, 105)]
+    #[case::end_past_the_buffer(0, 999)]
+    #[case::reversed_range_with_a_wide_span(9, 2)]
+    fn parse_sam_chunk_rejects_a_malformed_line_offset_table(#[case] start: u32, #[case] end: u32) {
+        let header = parse_header(SAM_TEXT);
+        let key_config = key_config_for(&header);
+        let chunk = SamChunk {
+            batch_serial: 0,
+            bytes: b"read1\t0\t*\n".to_vec(),
+            line_offsets: vec![start, end],
+        };
+
+        let err = parse_sam_chunk_into_decoded(chunk, &header, &key_config)
+            .expect_err("a malformed offset table must be rejected, not sliced");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// The SAM path must cache the UMI value position exactly as the BAM paths
+    /// (`DecodeRecords` / `DecodeFromRecords`) do. Both converge on
+    /// `DecodedRecordBatch` for the same downstream Group step, so a SAM record
+    /// without the cache forces that step to re-scan aux data once per template
+    /// while a BAM record does not.
+    #[test]
+    fn parse_sam_chunk_caches_the_umi_position_like_the_bam_paths() {
+        use crate::sam::SamTag;
+
+        let header = parse_header(SAM_TEXT);
+        let library_index = fgumi_bam_io::LibraryIndex::from_header(&header);
+        let key_config = GroupKeyConfig::new_raw_no_cell(library_index).with_umi_tag(*SamTag::RX);
+
+        let line = "read1\t0\tchr1\t10\t60\t5M\t*\t0\t0\tACGTA\tIIIII\tRX:Z:ACGTACGT\n";
+        let bytes = line.as_bytes().to_vec();
+        let line_offsets = vec![0u32, u32::try_from(bytes.len()).expect("fits u32")];
+        let chunk = SamChunk { batch_serial: 0, bytes, line_offsets };
+
+        let batch = parse_sam_chunk_into_decoded(chunk, &header, &key_config).expect("parses");
+        assert_eq!(batch.records().len(), 1);
+        assert_eq!(
+            batch.records()[0].cached_umi(),
+            Some(&b"ACGTACGT"[..]),
+            "SAM-ingested records must carry the same UMI cache as BAM-ingested ones",
+        );
+    }
+
+    #[test]
+    fn parse_sam_chunk_step_profile_is_parallel_byordinal() {
+        let header = std::sync::Arc::new(parse_header(SAM_TEXT));
+        let key_config = key_config_for(&header);
+        let step = ParseSamChunk::new(header, key_config, 1024 * 1024);
+        let profile = step.profile();
+        assert_eq!(profile.name, "ParseSamChunk");
+        assert_eq!(profile.kind, crate::pipeline::core::step::StepKind::Parallel);
+        assert!(!profile.sticky);
+        assert_eq!(
+            profile.branch_ordering,
+            vec![crate::pipeline::core::reorder::BranchOrdering::ByItemOrdinal]
+        );
+        assert!(matches!(
+            profile.output_queues[0],
+            crate::pipeline::core::queues::QueueSpec::ByteBounded { .. }
+        ));
+    }
+}

--- a/src/lib/pipeline/steps/process.rs
+++ b/src/lib/pipeline/steps/process.rs
@@ -1,0 +1,1747 @@
+//! Closure-driven mid-steps: `Process`, `ProcessOrdered`,
+//! `ProcessWithWorkerState`, `MiAssign`.
+//!
+//! The four are colocated per Phase 0 design line 371:
+//! `process.rs # process(fn), process_with_worker_state(init, fn), mi_assign(fn)`.
+//!
+//! In addition to the single-output `Process*` family, this module also
+//! provides the 2-output fan-out variants `Process2`, `Process2Ordered`, and
+//! `Process2WithWorkerState` for the kept/rejects shape (e.g. `correct`'s
+//! `CorrectOutputs`).
+
+use std::io;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::item::{HeapSize, Ordered};
+use crate::pipeline::core::outputs::{OrderedBytesSingle, Single};
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Process<I, T, F> — Parallel, FIFO output (Single<T>).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Closure-driven `Parallel` mid-step with `Single<T>` output (FIFO by
+/// arrival). Use [`ProcessOrdered`] when consumers need order preserved.
+pub struct Process<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    f: Arc<F>,
+    held: HeldSlot<Unpushed<T>>,
+    name: &'static str,
+    capacity: usize,
+    _phantom: PhantomData<fn() -> I>,
+}
+
+impl<I, T, F> Process<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    pub fn new(name: &'static str, capacity: usize, f: F) -> Self {
+        Self { f: Arc::new(f), held: HeldSlot::new(), name, capacity, _phantom: PhantomData }
+    }
+}
+
+impl<I, T, F> Clone for Process<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            f: Arc::clone(&self.f),
+            held: HeldSlot::new(),
+            name: self.name,
+            capacity: self.capacity,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, T, F> Step for Process<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    type Input = I;
+    type Outputs = Single<T>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::CountBounded { capacity: self.capacity }],
+            branch_ordering: vec![BranchOrdering::None],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        let Some(item) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let out = (self.f)(item)?;
+        match ctx.outputs.push(out) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+/// Convenience constructor for [`Process`].
+pub fn process<I, T, F>(name: &'static str, capacity: usize, f: F) -> Process<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    Process::new(name, capacity, f)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ProcessOrdered<I, T, F> — Parallel, ByItemOrdinal output
+// (OrderedBytesSingle<T>). The canonical BAM-step shape.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Closure-driven `Parallel` mid-step with `OrderedBytesSingle<T>` output.
+/// Closure must produce `T: HeapSize + Ordered`; the framework's reorder
+/// stage uses `T::ordinal()` to preserve global ordering.
+///
+/// Phase 3's BAM steps that don't fit into a more specific type
+/// (`GroupBam`, `MiAssign`) compose via `ProcessOrdered` with a closure
+/// that copies the input batch's serial onto the output.
+pub struct ProcessOrdered<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    f: Arc<F>,
+    held: HeldSlot<Unpushed<T>>,
+    name: &'static str,
+    limit_bytes: u64,
+    _phantom: PhantomData<fn() -> I>,
+}
+
+impl<I, T, F> ProcessOrdered<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    pub fn new(name: &'static str, limit_bytes: u64, f: F) -> Self {
+        Self { f: Arc::new(f), held: HeldSlot::new(), name, limit_bytes, _phantom: PhantomData }
+    }
+}
+
+impl<I, T, F> Clone for ProcessOrdered<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            f: Arc::clone(&self.f),
+            held: HeldSlot::new(),
+            name: self.name,
+            limit_bytes: self.limit_bytes,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, T, F> Step for ProcessOrdered<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    type Input = I;
+    type Outputs = OrderedBytesSingle<T>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.limit_bytes }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        let Some(item) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let out = (self.f)(item)?;
+        match ctx.outputs.push(out) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+/// Convenience constructor for [`ProcessOrdered`].
+pub fn process_ordered<I, T, F>(
+    name: &'static str,
+    limit_bytes: u64,
+    f: F,
+) -> ProcessOrdered<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<T> + Send + Sync + 'static,
+{
+    ProcessOrdered::new(name, limit_bytes, f)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ProcessWithWorkerState<I, T, F, S, FInit> — Parallel + lazy per-worker
+// state. Used by consensus callers (simplex/duplex/codec) where each
+// worker reuses one caller across all batches.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `Parallel` + lazy per-worker state. The framework's `Clone` resets
+/// `state` to `None`; first `try_run` initializes via `init()`, subsequent
+/// calls reuse the stored `S` via `&mut`. Each worker owns its clone
+/// exclusively (`Parallel` kind), so no synchronization is needed.
+///
+/// **Implementation note** (deviates from Phase 0 design line 136 which
+/// proposed `OnceLock<S>`): `OnceLock` doesn't expose `&mut S`, but
+/// consensus callers need mutable access to internal scratch buffers.
+/// `Option<S>` + `get_or_insert_with` provides equivalent lazy-init
+/// semantics with the required `&mut` access. Race-free because `Parallel`
+/// workers each own their clone.
+pub struct ProcessWithWorkerState<I, T, F, S, FInit>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(&mut S, I) -> io::Result<T> + Send + Sync + 'static,
+    S: Send + HeapSize + 'static,
+    FInit: Fn() -> S + Send + Sync + 'static,
+{
+    f: Arc<F>,
+    init: Arc<FInit>,
+    /// Lazy per-worker state. `Clone` resets to `None`.
+    state: Option<S>,
+    held: HeldSlot<Unpushed<T>>,
+    name: &'static str,
+    limit_bytes: u64,
+    _phantom: PhantomData<fn() -> I>,
+}
+
+impl<I, T, F, S, FInit> ProcessWithWorkerState<I, T, F, S, FInit>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(&mut S, I) -> io::Result<T> + Send + Sync + 'static,
+    S: Send + HeapSize + 'static,
+    FInit: Fn() -> S + Send + Sync + 'static,
+{
+    pub fn new(name: &'static str, limit_bytes: u64, init: FInit, f: F) -> Self {
+        Self {
+            f: Arc::new(f),
+            init: Arc::new(init),
+            state: None,
+            held: HeldSlot::new(),
+            name,
+            limit_bytes,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, T, F, S, FInit> Clone for ProcessWithWorkerState<I, T, F, S, FInit>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(&mut S, I) -> io::Result<T> + Send + Sync + 'static,
+    S: Send + HeapSize + 'static,
+    FInit: Fn() -> S + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            f: Arc::clone(&self.f),
+            init: Arc::clone(&self.init),
+            state: None, // <-- per-worker fresh; lazy on first try_run
+            held: HeldSlot::new(),
+            name: self.name,
+            limit_bytes: self.limit_bytes,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, T, F, S, FInit> Step for ProcessWithWorkerState<I, T, F, S, FInit>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(&mut S, I) -> io::Result<T> + Send + Sync + 'static,
+    S: Send + HeapSize + 'static,
+    FInit: Fn() -> S + Send + Sync + 'static,
+{
+    type Input = I;
+    type Outputs = OrderedBytesSingle<T>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.limit_bytes }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        let Some(item) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let state = self.state.get_or_insert_with(|| (self.init)());
+        let out = (self.f)(state, item)?;
+        match ctx.outputs.push(out) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+/// Convenience constructor for [`ProcessWithWorkerState`].
+pub fn process_with_worker_state<I, T, F, S, FInit>(
+    name: &'static str,
+    limit_bytes: u64,
+    init: FInit,
+    f: F,
+) -> ProcessWithWorkerState<I, T, F, S, FInit>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(&mut S, I) -> io::Result<T> + Send + Sync + 'static,
+    S: Send + HeapSize + 'static,
+    FInit: Fn() -> S + Send + Sync + 'static,
+{
+    ProcessWithWorkerState::new(name, limit_bytes, init, f)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Process2WithWorkerState<I, A, B, S, Init, F> — Parallel + lazy per-worker
+// state + 2-output fan-out. Mirror of `ProcessWithWorkerState` widened to two
+// ordered + byte-bounded output branches. Used by `CorrectStep` (kept +
+// rejects) where each worker reuses one `LruCache` across all batches without
+// `thread_local!` debt at every 2-output worker-state call site.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `Parallel` + lazy per-worker state + 2-output fan-out. `Clone` resets
+/// `state` to `None`; first `try_run` initializes via `init()`; subsequent
+/// calls reuse the stored `S` via `&mut`. Each worker owns its clone
+/// exclusively (`Parallel` kind), so no synchronization is needed.
+///
+/// **Implementation note** (deviates from Phase 0 design line 136 which
+/// proposed `OnceLock<S>`): `OnceLock` doesn't expose `&mut S`, but
+/// consensus callers need mutable access to internal scratch buffers.
+/// `Option<S>` + `get_or_insert_with` provides equivalent lazy-init
+/// semantics with the required `&mut` access. Race-free because `Parallel`
+/// workers each own their clone. This applies to this variant for the same
+/// reasons as the 1-output sibling [`ProcessWithWorkerState`].
+pub struct Process2WithWorkerState<I, A, B, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    f: Arc<F>,
+    init: Arc<Init>,
+    state: Option<S>,
+    held_a: HeldSlot<Unpushed<A>>,
+    held_b: HeldSlot<Unpushed<B>>,
+    name: &'static str,
+    limit_bytes_a: u64,
+    limit_bytes_b: u64,
+    _phantom: PhantomData<fn() -> I>,
+}
+
+impl<I, A, B, S, Init, F> Process2WithWorkerState<I, A, B, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    pub fn new(
+        name: &'static str,
+        limit_bytes_a: u64,
+        limit_bytes_b: u64,
+        init: Init,
+        f: F,
+    ) -> Self {
+        Self {
+            f: Arc::new(f),
+            init: Arc::new(init),
+            state: None,
+            held_a: HeldSlot::new(),
+            held_b: HeldSlot::new(),
+            name,
+            limit_bytes_a,
+            limit_bytes_b,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, A, B, S, Init, F> Clone for Process2WithWorkerState<I, A, B, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            f: Arc::clone(&self.f),
+            init: Arc::clone(&self.init),
+            state: None, // per-worker fresh; lazy on first try_run
+            held_a: HeldSlot::new(),
+            held_b: HeldSlot::new(),
+            name: self.name,
+            limit_bytes_a: self.limit_bytes_a,
+            limit_bytes_b: self.limit_bytes_b,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, A, B, S, Init, F> Step for Process2WithWorkerState<I, A, B, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    type Input = I;
+    type Outputs = crate::pipeline::core::outputs::OrderedBytesTuple2<A, B>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![
+                QueueSpec::ByteBounded { limit_bytes: self.limit_bytes_a },
+                QueueSpec::ByteBounded { limit_bytes: self.limit_bytes_b },
+            ],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal, BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        let view = ctx.outputs.view();
+
+        if let Some(unpushed) = self.held_a.take() {
+            match view.a.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held_a.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        if let Some(unpushed) = self.held_b.take() {
+            match view.b.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held_b.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(item) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let state = self.state.get_or_insert_with(|| (self.init)());
+        let Process2Output { a, b } = (self.f)(state, item)?;
+
+        if let Some(av) = a
+            && let Err(unpushed) = view.a.push(av)
+        {
+            self.held_a.put(unpushed);
+        }
+        if let Some(bv) = b
+            && let Err(unpushed) = view.b.push(bv)
+        {
+            self.held_b.put(unpushed);
+        }
+        Ok(StepOutcome::Progress)
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+/// Convenience constructor for [`Process2WithWorkerState`].
+pub fn process2_with_worker_state<I, A, B, S, Init, F>(
+    name: &'static str,
+    limit_bytes_a: u64,
+    limit_bytes_b: u64,
+    init: Init,
+    f: F,
+) -> Process2WithWorkerState<I, A, B, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    Process2WithWorkerState::new(name, limit_bytes_a, limit_bytes_b, init, f)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Process3WithWorkerState<I, A, B, C, S, Init, F> — Parallel + lazy per-worker
+// state + 3-output fan-out. Mirror of `Process2WithWorkerState` widened to
+// three ordered + byte-bounded output branches. Used by the paired FASTQ
+// encode (R1 / R2 / other), where each worker reuses one scratch buffer set
+// across all batches. Each branch carries its own `HeldSlot` for independent
+// backpressure, exactly as the 2-output sibling.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Output of a [`Process3WithWorkerState`] closure: one optional value per
+/// output branch.
+///
+/// The rule for returning `None` on an ordered branch is the same one stated at
+/// length on [`Process2Output`], because both types feed the same `ReorderStage`
+/// contract: `None` is safe when the branch mints its own **dense, branch-local**
+/// ordinals, and unsafe when the branch propagates the *input's* ordinal, where
+/// the skip leaves a permanent hole that stalls the run. See [`Process2Output`]
+/// for why that stalls rather than merely dropping an item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Process3Output<A, B, C> {
+    pub a: Option<A>,
+    pub b: Option<B>,
+    pub c: Option<C>,
+}
+
+impl<A, B, C> Process3Output<A, B, C> {
+    #[must_use]
+    pub fn both3(a: A, b: B, c: C) -> Self {
+        Self { a: Some(a), b: Some(b), c: Some(c) }
+    }
+}
+
+/// `Parallel` + lazy per-worker state + 3-output fan-out. `Clone` resets
+/// `state` to `None`; first `try_run` initializes via `init()`; subsequent
+/// calls reuse the stored `S` via `&mut`. Each worker owns its clone
+/// exclusively (`Parallel` kind), so no synchronization is needed. Mirror of
+/// [`Process2WithWorkerState`] with a third branch.
+pub struct Process3WithWorkerState<I, A, B, C, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    C: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process3Output<A, B, C>> + Send + Sync + 'static,
+{
+    f: Arc<F>,
+    init: Arc<Init>,
+    state: Option<S>,
+    held_a: HeldSlot<Unpushed<A>>,
+    held_b: HeldSlot<Unpushed<B>>,
+    held_c: HeldSlot<Unpushed<C>>,
+    name: &'static str,
+    limit_bytes_a: u64,
+    limit_bytes_b: u64,
+    limit_bytes_c: u64,
+    _phantom: PhantomData<fn() -> I>,
+}
+
+impl<I, A, B, C, S, Init, F> Process3WithWorkerState<I, A, B, C, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    C: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process3Output<A, B, C>> + Send + Sync + 'static,
+{
+    pub fn new(
+        name: &'static str,
+        limit_bytes_a: u64,
+        limit_bytes_b: u64,
+        limit_bytes_c: u64,
+        init: Init,
+        f: F,
+    ) -> Self {
+        Self {
+            f: Arc::new(f),
+            init: Arc::new(init),
+            state: None,
+            held_a: HeldSlot::new(),
+            held_b: HeldSlot::new(),
+            held_c: HeldSlot::new(),
+            name,
+            limit_bytes_a,
+            limit_bytes_b,
+            limit_bytes_c,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, A, B, C, S, Init, F> Clone for Process3WithWorkerState<I, A, B, C, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    C: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process3Output<A, B, C>> + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            f: Arc::clone(&self.f),
+            init: Arc::clone(&self.init),
+            state: None, // per-worker fresh; lazy on first try_run
+            held_a: HeldSlot::new(),
+            held_b: HeldSlot::new(),
+            held_c: HeldSlot::new(),
+            name: self.name,
+            limit_bytes_a: self.limit_bytes_a,
+            limit_bytes_b: self.limit_bytes_b,
+            limit_bytes_c: self.limit_bytes_c,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, A, B, C, S, Init, F> Step for Process3WithWorkerState<I, A, B, C, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    C: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process3Output<A, B, C>> + Send + Sync + 'static,
+{
+    type Input = I;
+    type Outputs = crate::pipeline::core::outputs::OrderedBytesTuple3<A, B, C>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![
+                QueueSpec::ByteBounded { limit_bytes: self.limit_bytes_a },
+                QueueSpec::ByteBounded { limit_bytes: self.limit_bytes_b },
+                QueueSpec::ByteBounded { limit_bytes: self.limit_bytes_c },
+            ],
+            branch_ordering: vec![
+                BranchOrdering::ByItemOrdinal,
+                BranchOrdering::ByItemOrdinal,
+                BranchOrdering::ByItemOrdinal,
+            ],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        let view = ctx.outputs.view();
+
+        if let Some(unpushed) = self.held_a.take() {
+            match view.a.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held_a.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        if let Some(unpushed) = self.held_b.take() {
+            match view.b.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held_b.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        if let Some(unpushed) = self.held_c.take() {
+            match view.c.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held_c.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(item) = ctx.input.pop() else {
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let state = self.state.get_or_insert_with(|| (self.init)());
+        let Process3Output { a, b, c } = (self.f)(state, item)?;
+
+        if let Some(av) = a
+            && let Err(unpushed) = view.a.push(av)
+        {
+            self.held_a.put(unpushed);
+        }
+        if let Some(bv) = b
+            && let Err(unpushed) = view.b.push(bv)
+        {
+            self.held_b.put(unpushed);
+        }
+        if let Some(cv) = c
+            && let Err(unpushed) = view.c.push(cv)
+        {
+            self.held_c.put(unpushed);
+        }
+        Ok(StepOutcome::Progress)
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+/// Convenience constructor for [`Process3WithWorkerState`].
+#[allow(clippy::too_many_arguments)]
+pub fn process3_with_worker_state<I, A, B, C, S, Init, F>(
+    name: &'static str,
+    limit_bytes_a: u64,
+    limit_bytes_b: u64,
+    limit_bytes_c: u64,
+    init: Init,
+    f: F,
+) -> Process3WithWorkerState<I, A, B, C, S, Init, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    C: Send + HeapSize + Ordered + 'static,
+    S: Send + HeapSize + 'static,
+    Init: Fn() -> S + Send + Sync + 'static,
+    F: Fn(&mut S, I) -> io::Result<Process3Output<A, B, C>> + Send + Sync + 'static,
+{
+    Process3WithWorkerState::new(name, limit_bytes_a, limit_bytes_b, limit_bytes_c, init, f)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MiAssign<I, F> — Serial + monotonic MI counter. Used for deterministic
+// MoleculeId numbering across input batches.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `Serial` closure-driven step that maintains a monotonic MI counter.
+/// Used by `group` / `dedup` for deterministic `MoleculeId` numbering.
+/// The closure receives `(&mut next_mi, input)` and returns the transformed
+/// output (with MI tags applied to records).
+pub struct MiAssign<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(&mut u64, I) -> io::Result<T> + Send + Sync + 'static,
+{
+    f: Arc<F>,
+    next_mi: u64,
+    held: HeldSlot<Unpushed<T>>,
+    name: &'static str,
+    limit_bytes: u64,
+    _phantom: PhantomData<fn() -> I>,
+}
+
+impl<I, T, F> MiAssign<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(&mut u64, I) -> io::Result<T> + Send + Sync + 'static,
+{
+    pub fn new(name: &'static str, limit_bytes: u64, f: F) -> Self {
+        Self {
+            f: Arc::new(f),
+            next_mi: 0,
+            held: HeldSlot::new(),
+            name,
+            limit_bytes,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, T, F> Step for MiAssign<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(&mut u64, I) -> io::Result<T> + Send + Sync + 'static,
+{
+    type Input = I;
+    type Outputs = OrderedBytesSingle<T>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Serial,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.limit_bytes }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        let Some(item) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            //
+            // Unlike the `Parallel` steps above, this one is `Serial`: the
+            // driver keeps a single mutex-protected instance shared by every
+            // eligible worker and never calls `new_worker_copy`, so there are
+            // no sibling clones to wait for and no `StepDrainCounter` to
+            // coordinate. Whichever worker holds the lock when the input
+            // drains reports `Finished` once, and the shared `DrainGate`
+            // latches that so the others never re-run the step.
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let out = (self.f)(&mut self.next_mi, item)?;
+        match ctx.outputs.push(out) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+}
+
+/// Convenience constructor for [`MiAssign`].
+pub fn mi_assign<I, T, F>(name: &'static str, limit_bytes: u64, f: F) -> MiAssign<I, T, F>
+where
+    I: Send + HeapSize + 'static,
+    T: Send + HeapSize + Ordered + 'static,
+    F: Fn(&mut u64, I) -> io::Result<T> + Send + Sync + 'static,
+{
+    MiAssign::new(name, limit_bytes, f)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Process2<I, A, B, F> — Parallel, fan-out to two unordered output branches.
+// Used by `correct`/`filter`-style commands that emit a primary output plus
+// a rejects/secondary output. Both branches are `BranchOrdering::None` (FIFO
+// by arrival) so workers can race to push without ordinal coordination.
+//
+// Backpressure: each branch carries its own `HeldSlot`. If branch A pushes
+// fail, the rejected item is parked in `held_a` and the next `try_run`
+// drains it before popping new input. Branch B is independent. This means
+// a stuck consumer on one side won't drop items — but it also means a
+// permanently slow consumer will eventually block the step. The dispatch that
+// first parks an item still returns `Progress` (with the produced item(s)
+// buffered — up to one per branch, since a single dispatch can fill both
+// `held_a` and `held_b`); `Contention` is reported only on a *subsequent*
+// dispatch, by the held-drain preamble, when a still-held item cannot be
+// pushed. Each branch holds at most one item (one input is popped per call).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Output of a [`Process2`] closure: one optional value per output branch.
+/// Either branch may be `None` to indicate "no item produced for this
+/// branch this call" (filter / sparse fan-out).
+///
+/// # Returning `None` on an ordered branch
+///
+/// `None` is safe only when that branch mints its own **dense, branch-local**
+/// ordinals — i.e. the closure numbers what it emits, so skipping an input
+/// simply means the next emitted item takes the next ordinal.
+///
+/// It is **not** safe when the branch propagates the *input's* ordinal. Omitting
+/// an item then leaves a permanent hole in the sequence, and a branch wired with
+/// [`BranchOrdering::ByItemOrdinal`] has a `ReorderStage` that releases items
+/// only in contiguous order — so it waits forever for an ordinal no one will
+/// ever emit. That is a stall, not a dropped item: the run hangs rather than
+/// producing short output, which is why it is worth stating here rather than
+/// leaving to be discovered.
+///
+/// The same caveat applies to [`Process2Ordered`] and
+/// [`Process2WithWorkerState`], which share this output type.
+///
+/// [`BranchOrdering::ByItemOrdinal`]: crate::pipeline::core::reorder::BranchOrdering
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Process2Output<A, B> {
+    pub a: Option<A>,
+    pub b: Option<B>,
+}
+
+impl<A, B> Process2Output<A, B> {
+    #[must_use]
+    pub fn both(a: A, b: B) -> Self {
+        Self { a: Some(a), b: Some(b) }
+    }
+
+    #[must_use]
+    pub fn only_a(a: A) -> Self {
+        Self { a: Some(a), b: None }
+    }
+
+    #[must_use]
+    pub fn only_b(b: B) -> Self {
+        Self { a: None, b: Some(b) }
+    }
+
+    #[must_use]
+    pub fn none() -> Self {
+        Self { a: None, b: None }
+    }
+}
+
+/// Closure-driven `Parallel` mid-step that fans out to two unordered output
+/// branches `(A, B)`. The closure returns a [`Process2Output`] describing
+/// what to push to each branch.
+///
+/// Both output branches use `BranchOrdering::None`. If the consumer of either
+/// branch needs ordering, prefer composing single-output ordered steps
+/// instead — `Process2` is for the sparse-output / rejects-path shape.
+pub struct Process2<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + 'static,
+    B: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    f: Arc<F>,
+    held_a: HeldSlot<Unpushed<A>>,
+    held_b: HeldSlot<Unpushed<B>>,
+    name: &'static str,
+    capacity_a: usize,
+    capacity_b: usize,
+    _phantom: PhantomData<fn() -> I>,
+}
+
+impl<I, A, B, F> Process2<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + 'static,
+    B: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    pub fn new(name: &'static str, capacity_a: usize, capacity_b: usize, f: F) -> Self {
+        Self {
+            f: Arc::new(f),
+            held_a: HeldSlot::new(),
+            held_b: HeldSlot::new(),
+            name,
+            capacity_a,
+            capacity_b,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, A, B, F> Clone for Process2<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + 'static,
+    B: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            f: Arc::clone(&self.f),
+            held_a: HeldSlot::new(),
+            held_b: HeldSlot::new(),
+            name: self.name,
+            capacity_a: self.capacity_a,
+            capacity_b: self.capacity_b,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, A, B, F> Step for Process2<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + 'static,
+    B: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    type Input = I;
+    type Outputs = (A, B);
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![
+                QueueSpec::CountBounded { capacity: self.capacity_a },
+                QueueSpec::CountBounded { capacity: self.capacity_b },
+            ],
+            branch_ordering: vec![BranchOrdering::None, BranchOrdering::None],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        let view = ctx.outputs.view();
+
+        // Drain held items first. A branch that's still rejecting blocks
+        // forward progress on this worker until the consumer drains.
+        if let Some(unpushed) = self.held_a.take() {
+            match view.a.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held_a.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        if let Some(unpushed) = self.held_b.take() {
+            match view.b.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held_b.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(item) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let Process2Output { a, b } = (self.f)(item)?;
+
+        // Push each side. If either is rejected, hold and continue —
+        // we still made progress (consumed input + produced what we could).
+        if let Some(av) = a
+            && let Err(unpushed) = view.a.push(av)
+        {
+            self.held_a.put(unpushed);
+        }
+        if let Some(bv) = b
+            && let Err(unpushed) = view.b.push(bv)
+        {
+            self.held_b.put(unpushed);
+        }
+        Ok(StepOutcome::Progress)
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+/// Convenience constructor for [`Process2`].
+pub fn process2<I, A, B, F>(
+    name: &'static str,
+    capacity_a: usize,
+    capacity_b: usize,
+    f: F,
+) -> Process2<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + 'static,
+    B: Send + HeapSize + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    Process2::new(name, capacity_a, capacity_b, f)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Process2Ordered<I, A, B, F> — Parallel, fan-out to two ordered + byte-bounded
+// branches. Both branches use `BranchOrdering::ByItemOrdinal` so each output
+// stream is reorderable into input order downstream. Use this when both
+// outputs need to be BAM-sortable (e.g., `filter` emitting kept and rejected
+// records that each feed an ordered `BgzfCompress` + `WriteBgzfFile` chain).
+//
+// Backpressure semantics mirror `Process2`: per-branch `HeldSlot` parks the
+// rejected item and the next `try_run` retries before popping new input.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Closure-driven `Parallel` mid-step that fans out to two ordered output
+/// branches `(A, B)`, both `BranchOrdering::ByItemOrdinal`. The closure
+/// returns a [`Process2Output`] describing what to push to each branch.
+///
+/// Both `A` and `B` must implement [`Ordered`] + [`HeapSize`]: each
+/// branch's reorder stage uses `item.ordinal()` to release in input
+/// order and the byte-bounded queue uses `heap_size()` for admission
+/// control.
+pub struct Process2Ordered<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    f: Arc<F>,
+    held_a: HeldSlot<Unpushed<A>>,
+    held_b: HeldSlot<Unpushed<B>>,
+    name: &'static str,
+    limit_bytes_a: u64,
+    limit_bytes_b: u64,
+    _phantom: PhantomData<fn() -> I>,
+}
+
+impl<I, A, B, F> Process2Ordered<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    pub fn new(name: &'static str, limit_bytes_a: u64, limit_bytes_b: u64, f: F) -> Self {
+        Self {
+            f: Arc::new(f),
+            held_a: HeldSlot::new(),
+            held_b: HeldSlot::new(),
+            name,
+            limit_bytes_a,
+            limit_bytes_b,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, A, B, F> Clone for Process2Ordered<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            f: Arc::clone(&self.f),
+            held_a: HeldSlot::new(),
+            held_b: HeldSlot::new(),
+            name: self.name,
+            limit_bytes_a: self.limit_bytes_a,
+            limit_bytes_b: self.limit_bytes_b,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<I, A, B, F> Step for Process2Ordered<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    type Input = I;
+    type Outputs = crate::pipeline::core::outputs::OrderedBytesTuple2<A, B>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: self.name,
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![
+                QueueSpec::ByteBounded { limit_bytes: self.limit_bytes_a },
+                QueueSpec::ByteBounded { limit_bytes: self.limit_bytes_b },
+            ],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal, BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        let view = ctx.outputs.view();
+
+        if let Some(unpushed) = self.held_a.take() {
+            match view.a.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held_a.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+        if let Some(unpushed) = self.held_b.take() {
+            match view.b.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held_b.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(item) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+        let Process2Output { a, b } = (self.f)(item)?;
+
+        if let Some(av) = a
+            && let Err(unpushed) = view.a.push(av)
+        {
+            self.held_a.put(unpushed);
+        }
+        if let Some(bv) = b
+            && let Err(unpushed) = view.b.push(bv)
+        {
+            self.held_b.put(unpushed);
+        }
+        Ok(StepOutcome::Progress)
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+/// Convenience constructor for [`Process2Ordered`].
+pub fn process2_ordered<I, A, B, F>(
+    name: &'static str,
+    limit_bytes_a: u64,
+    limit_bytes_b: u64,
+    f: F,
+) -> Process2Ordered<I, A, B, F>
+where
+    I: Send + HeapSize + 'static,
+    A: Send + HeapSize + Ordered + 'static,
+    B: Send + HeapSize + Ordered + 'static,
+    F: Fn(I) -> io::Result<Process2Output<A, B>> + Send + Sync + 'static,
+{
+    Process2Ordered::new(name, limit_bytes_a, limit_bytes_b, f)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::core::{PipelineBuilder, PipelineConfig};
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicU32, Ordering as AtomicOrd};
+
+    /// Source emitting `remaining` items via a shared atomic counter; safe for
+    /// single- and multi-worker `Parallel` execution. (Relocated here with the
+    /// `process2` pipeline-run tests below: the `fgumi-pipeline-core` crate that
+    /// owns the builder can't depend on this `pipeline::steps` layer, so these
+    /// end-to-end `process2` tests live next to `process2` itself.)
+    #[derive(Clone)]
+    struct SharedCountingSource {
+        remaining: Arc<AtomicU32>,
+    }
+    impl Step for SharedCountingSource {
+        type Input = ();
+        type Outputs = Single<u32>;
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "SharedSource",
+                kind: StepKind::Parallel,
+                sticky: false,
+                output_queues: vec![QueueSpec::Unbounded],
+                branch_ordering: vec![BranchOrdering::None],
+            }
+        }
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> std::io::Result<StepOutcome> {
+            let n = self.remaining.load(AtomicOrd::Acquire);
+            if n == 0 {
+                return Ok(StepOutcome::Finished);
+            }
+            if self
+                .remaining
+                .compare_exchange(n, n - 1, AtomicOrd::AcqRel, AtomicOrd::Acquire)
+                .is_ok()
+            {
+                ctx.outputs.push(n).map_err(|_| {
+                    std::io::Error::other("Unbounded queue rejected push (impossible)")
+                })?;
+                Ok(StepOutcome::Progress)
+            } else {
+                Ok(StepOutcome::NoProgress)
+            }
+        }
+        fn new_worker_copy(&self) -> Self {
+            self.clone()
+        }
+    }
+
+    /// Sink that pops and collects the values it receives. Collecting the
+    /// actual values (rather than only a count) lets the fan-out tests assert
+    /// the exact multiset routed to each branch: a bug that drops, duplicates,
+    /// swaps, or misroutes values while preserving the per-branch count would
+    /// slip past a count-only assertion.
+    #[derive(Clone)]
+    struct ParallelCollectingSink {
+        received: Arc<Mutex<Vec<u32>>>,
+    }
+    impl Step for ParallelCollectingSink {
+        type Input = u32;
+        type Outputs = ();
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "ParallelSink",
+                kind: StepKind::Parallel,
+                sticky: false,
+                output_queues: vec![],
+                branch_ordering: vec![],
+            }
+        }
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> std::io::Result<StepOutcome> {
+            match ctx.input.pop() {
+                Some(v) => {
+                    self.received.lock().expect("sink mutex poisoned").push(v);
+                    Ok(StepOutcome::Progress)
+                }
+                None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+                None => Ok(StepOutcome::NoProgress),
+            }
+        }
+        fn new_worker_copy(&self) -> Self {
+            self.clone()
+        }
+    }
+
+    /// Sorted copy of a collecting sink's values, for multiset assertions
+    /// (workers pop concurrently, so arrival order is non-deterministic).
+    fn sorted_received(received: &Arc<Mutex<Vec<u32>>>) -> Vec<u32> {
+        let mut values = received.lock().expect("sink mutex poisoned").clone();
+        values.sort_unstable();
+        values
+    }
+
+    #[test]
+    fn pipeline_run_process2_fans_out_to_two_sinks() {
+        let remaining = Arc::new(AtomicU32::new(20));
+        let evens_received = Arc::new(Mutex::new(Vec::new()));
+        let odds_received = Arc::new(Mutex::new(Vec::new()));
+
+        // Process2 routes even items to branch A, odd items to branch B.
+        let split = process2::<u32, u32, u32, _>("EvenOddSplit", 32, 32, |x: u32| {
+            if x.is_multiple_of(2) {
+                Ok(Process2Output::only_a(x))
+            } else {
+                Ok(Process2Output::only_b(x))
+            }
+        });
+
+        let builder = PipelineBuilder::new();
+        let after_split =
+            builder.chain(SharedCountingSource { remaining: Arc::clone(&remaining) }).chain(split);
+        let multi = after_split.into_multi();
+        multi
+            .b0
+            .chain(ParallelCollectingSink { received: Arc::clone(&evens_received) })
+            .into_sink_marker();
+        multi
+            .b1
+            .chain(ParallelCollectingSink { received: Arc::clone(&odds_received) })
+            .into_sink_marker();
+
+        let pipeline = builder.build().unwrap();
+        let result = pipeline.run(PipelineConfig { threads: 4, ..Default::default() });
+        assert!(result.is_ok(), "run failed: {:?}", result.err());
+
+        // Source emits values [20, 19, ..., 1]. Assert the exact multiset each
+        // branch received, not just the count: evens = {2, 4, ..., 20}, odds =
+        // {1, 3, ..., 19}.
+        let expected_evens: Vec<u32> = (1..=10).map(|k| k * 2).collect();
+        let expected_odds: Vec<u32> = (0..10).map(|k| k * 2 + 1).collect();
+        assert_eq!(sorted_received(&evens_received), expected_evens, "evens values");
+        assert_eq!(sorted_received(&odds_received), expected_odds, "odds values");
+    }
+
+    #[test]
+    fn pipeline_run_process2_drops_branches_emit_none() {
+        let remaining = Arc::new(AtomicU32::new(15));
+        let kept = Arc::new(Mutex::new(Vec::new()));
+        let dropped = Arc::new(Mutex::new(Vec::new()));
+
+        // Keep multiples of 3 on branch A, route the rest to branch B, drop 1.
+        let filter = process2::<u32, u32, u32, _>("FilterStep", 16, 16, |x: u32| {
+            if x == 1 {
+                Ok(Process2Output::none())
+            } else if x.is_multiple_of(3) {
+                Ok(Process2Output::only_a(x))
+            } else {
+                Ok(Process2Output::only_b(x))
+            }
+        });
+
+        let builder = PipelineBuilder::new();
+        let after =
+            builder.chain(SharedCountingSource { remaining: Arc::clone(&remaining) }).chain(filter);
+        let multi = after.into_multi();
+        multi.b0.chain(ParallelCollectingSink { received: Arc::clone(&kept) }).into_sink_marker();
+        multi
+            .b1
+            .chain(ParallelCollectingSink { received: Arc::clone(&dropped) })
+            .into_sink_marker();
+
+        let pipeline = builder.build().unwrap();
+        let result = pipeline.run(PipelineConfig { threads: 4, ..Default::default() });
+        assert!(result.is_ok(), "run failed: {:?}", result.err());
+
+        // [15..1]: multiples of 3 kept = {3, 6, 9, 12, 15}; value 1 dropped; the
+        // other 9 on branch B. Assert the exact multiset per branch, not just
+        // the count, so a misroute that preserves counts can't slip through.
+        assert_eq!(sorted_received(&kept), vec![3, 6, 9, 12, 15], "kept values");
+        assert_eq!(
+            sorted_received(&dropped),
+            vec![2, 4, 5, 7, 8, 10, 11, 13, 14],
+            "other-branch values"
+        );
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct Item {
+        ord: u64,
+        v: u32,
+    }
+    impl HeapSize for Item {
+        fn heap_size(&self) -> usize {
+            std::mem::size_of::<Self>()
+        }
+    }
+    impl Ordered for Item {
+        fn ordinal(&self) -> u64 {
+            self.ord
+        }
+    }
+
+    #[test]
+    fn process_profile_is_parallel_fifo() {
+        let s: Process<u32, u32, _> = process("test", 4, |x: u32| Ok(x + 1));
+        let p = s.profile();
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::None]);
+    }
+
+    #[test]
+    fn process_ordered_profile_is_parallel_byitem() {
+        let s: ProcessOrdered<Item, Item, _> =
+            process_ordered("test", 1024, |x: Item| Ok(Item { ord: x.ord, v: x.v + 1 }));
+        let p = s.profile();
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    #[test]
+    fn process_with_worker_state_clone_resets_state() {
+        let s = process_with_worker_state::<Item, Item, _, u64, _>(
+            "stateful",
+            1024,
+            || 0u64, // init
+            |state, item| {
+                *state += 1;
+                Ok(Item { ord: item.ord, v: u32::try_from(*state).unwrap_or(0) })
+            },
+        );
+        let cloned = s.clone();
+        assert!(s.state.is_none());
+        assert!(cloned.state.is_none());
+    }
+
+    #[test]
+    fn process2_profile_is_parallel_two_unordered_branches() {
+        let s: Process2<u32, u32, String, _> =
+            process2("test2", 4, 4, |x: u32| Ok(Process2Output::both(x + 1, x.to_string())));
+        let p = s.profile();
+        assert_eq!(p.name, "test2");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert!(!p.sticky);
+        assert_eq!(p.output_queues.len(), 2);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::None, BranchOrdering::None]);
+    }
+
+    #[test]
+    fn process2_output_constructors() {
+        let both: Process2Output<u32, &str> = Process2Output::both(1, "a");
+        assert_eq!(both.a, Some(1));
+        assert_eq!(both.b, Some("a"));
+
+        let only_a: Process2Output<u32, &str> = Process2Output::only_a(2);
+        assert_eq!(only_a.a, Some(2));
+        assert_eq!(only_a.b, None);
+
+        let only_b: Process2Output<u32, &str> = Process2Output::only_b("b");
+        assert_eq!(only_b.a, None);
+        assert_eq!(only_b.b, Some("b"));
+
+        let none: Process2Output<u32, &str> = Process2Output::none();
+        assert_eq!(none.a, None);
+        assert_eq!(none.b, None);
+    }
+
+    #[test]
+    fn process2_with_worker_state_clone_resets_state() {
+        #[derive(Default)]
+        struct WS {
+            counter: u32,
+        }
+        impl HeapSize for WS {
+            fn heap_size(&self) -> usize {
+                0
+            }
+        }
+
+        let step = process2_with_worker_state::<Item, Item, Item, WS, _, _>(
+            "stateful2",
+            1024,
+            1024,
+            WS::default,
+            |state, item| {
+                state.counter += 1;
+                Ok(Process2Output::both(
+                    Item { ord: item.ord, v: state.counter },
+                    Item { ord: item.ord, v: state.counter },
+                ))
+            },
+        );
+        let cloned = step.clone();
+        assert!(step.state.is_none());
+        assert!(cloned.state.is_none());
+    }
+
+    #[test]
+    fn process2_with_worker_state_profile_is_parallel_byitem_two_branches() {
+        #[derive(Default)]
+        struct WS;
+        impl HeapSize for WS {
+            fn heap_size(&self) -> usize {
+                0
+            }
+        }
+
+        let step = process2_with_worker_state::<Item, Item, Item, WS, _, _>(
+            "stateful2-profile",
+            512,
+            1024,
+            WS::default,
+            |_state, item| Ok(Process2Output::both(item, Item { ord: 0, v: 0 })),
+        );
+        let profile = step.profile();
+        assert_eq!(profile.kind, StepKind::Parallel);
+        assert_eq!(profile.output_queues.len(), 2);
+        assert_eq!(
+            profile.output_queues,
+            vec![
+                QueueSpec::ByteBounded { limit_bytes: 512 },
+                QueueSpec::ByteBounded { limit_bytes: 1024 },
+            ]
+        );
+        assert_eq!(
+            profile.branch_ordering,
+            vec![BranchOrdering::ByItemOrdinal, BranchOrdering::ByItemOrdinal]
+        );
+    }
+
+    #[test]
+    fn process3_with_worker_state_clone_resets_state() {
+        #[derive(Default)]
+        struct WS {
+            counter: u32,
+        }
+        impl HeapSize for WS {
+            fn heap_size(&self) -> usize {
+                0
+            }
+        }
+
+        let step = process3_with_worker_state::<Item, Item, Item, Item, WS, _, _>(
+            "stateful3",
+            1024,
+            1024,
+            1024,
+            WS::default,
+            |state, item| {
+                state.counter += 1;
+                Ok(Process3Output::both3(
+                    Item { ord: item.ord, v: state.counter },
+                    Item { ord: item.ord, v: state.counter },
+                    Item { ord: item.ord, v: state.counter },
+                ))
+            },
+        );
+        let cloned = step.clone();
+        assert!(step.state.is_none());
+        assert!(cloned.state.is_none());
+    }
+
+    #[test]
+    fn process3_with_worker_state_profile_is_parallel_byitem_three_branches() {
+        #[derive(Default)]
+        struct WS;
+        impl HeapSize for WS {
+            fn heap_size(&self) -> usize {
+                0
+            }
+        }
+
+        let step = process3_with_worker_state::<Item, Item, Item, Item, WS, _, _>(
+            "stateful3-profile",
+            256,
+            512,
+            1024,
+            WS::default,
+            |_state, item| {
+                Ok(Process3Output::both3(item, Item { ord: 0, v: 0 }, Item { ord: 0, v: 0 }))
+            },
+        );
+        let profile = step.profile();
+        assert_eq!(profile.kind, StepKind::Parallel);
+        assert_eq!(profile.output_queues.len(), 3);
+        assert_eq!(
+            profile.output_queues,
+            vec![
+                QueueSpec::ByteBounded { limit_bytes: 256 },
+                QueueSpec::ByteBounded { limit_bytes: 512 },
+                QueueSpec::ByteBounded { limit_bytes: 1024 },
+            ]
+        );
+        assert_eq!(
+            profile.branch_ordering,
+            vec![
+                BranchOrdering::ByItemOrdinal,
+                BranchOrdering::ByItemOrdinal,
+                BranchOrdering::ByItemOrdinal,
+            ]
+        );
+    }
+
+    #[test]
+    fn mi_assign_profile_is_serial() {
+        let s: MiAssign<Item, Item, _> = mi_assign("mi", 1024, |next_mi, item: Item| {
+            let mi = *next_mi;
+            *next_mi += 1;
+            Ok(Item { ord: item.ord, v: u32::try_from(mi).unwrap_or(0) })
+        });
+        let p = s.profile();
+        assert_eq!(p.kind, StepKind::Serial);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+}

--- a/src/lib/pipeline/steps/serialize.rs
+++ b/src/lib/pipeline/steps/serialize.rs
@@ -1,0 +1,263 @@
+//! `SerializeBamRecords`: `Parallel + ByItemOrdinal` step that frames
+//! `RawRecord`s as on-disk BAM record framing (4-byte little-endian
+//! `block_size` prefix + record body) into a single
+//! `DecompressedBlock`, ready for `BgzfCompress`. Input is
+//! `BamTemplateBatch` (templates of records). Inverse of
+//! `ParseBamRecords + GroupBam`. Used by the group/consensus chains.
+//!
+//! Output `batch_serial` mirrors the input's.
+
+use std::io;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::{BamTemplateBatch, DecompressedBlock};
+
+/// Per-worker serialization scratch capacity. Sized to the typical
+/// 500-template batch (~ 256 B/record × ~2 records/template + framing).
+/// Mirrors legacy `bam.rs:1561` `SERIALIZATION_BUFFER_CAPACITY` (64 KiB)
+/// scaled up to match the new framework's larger batch sizes.
+const SERIALIZE_SCRATCH_CAPACITY: usize = 1024 * 1024;
+
+/// Append one BAM-framed record (4-byte little-endian `block_size` + body)
+/// into `scratch`. This is the canonical on-disk BAM record framing used by
+/// the output path; the terminal standalone-sort path inlines the identical
+/// layout in `SortMerge`'s `BlockBuilder` (`fgumi-pipeline-io`), which must
+/// stay byte-for-byte in sync with this helper.
+///
+/// # Errors
+///
+/// Returns `io::ErrorKind::InvalidData` if `body.len()` exceeds `u32::MAX` —
+/// unreachable in practice (BAM body size is u32-bounded and
+/// `tuning.per_step_byte_limit` is 4 MiB by default).
+fn frame_record_into(scratch: &mut Vec<u8>, body: &[u8]) -> io::Result<()> {
+    let block_size = u32::try_from(body.len()).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("record exceeds u32 BAM block_size: {}", body.len()),
+        )
+    })?;
+    scratch.extend_from_slice(&block_size.to_le_bytes());
+    scratch.extend_from_slice(body);
+    Ok(())
+}
+
+/// `Parallel + ByItemOrdinal` serializer. Templates → record-aligned bytes.
+pub struct SerializeBamRecords {
+    held: HeldSlot<Unpushed<DecompressedBlock>>,
+    output_byte_limit: u64,
+    /// Per-worker output scratch — see `BgzfDecompress::output_scratch`
+    /// for the `mem::replace` + fixed-size-class rationale.
+    output_scratch: Vec<u8>,
+}
+
+impl SerializeBamRecords {
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self {
+            held: HeldSlot::new(),
+            output_byte_limit,
+            output_scratch: Vec::with_capacity(SERIALIZE_SCRATCH_CAPACITY),
+        }
+    }
+}
+
+impl Clone for SerializeBamRecords {
+    fn clone(&self) -> Self {
+        Self {
+            held: HeldSlot::new(),
+            output_byte_limit: self.output_byte_limit,
+            output_scratch: Vec::with_capacity(SERIALIZE_SCRATCH_CAPACITY),
+        }
+    }
+}
+
+impl Step for SerializeBamRecords {
+    type Input = BamTemplateBatch;
+    type Outputs = OrderedBytesSingle<DecompressedBlock>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "SerializeBamRecords",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(batch) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+
+        // Serialize into the per-worker scratch buffer; `mem::replace` it
+        // out at the end. Same-size-class recycling via mimalloc's
+        // thread-local cache is the goal — see `BgzfDecompress` for the
+        // rationale. Per-record framing shared with `SerializeRecordBatch`
+        // via [`frame_record_into`].
+        for template in batch.templates() {
+            for record in &template.records {
+                frame_record_into(&mut self.output_scratch, record.as_ref())?;
+            }
+        }
+        let bytes = std::mem::replace(
+            &mut self.output_scratch,
+            Vec::with_capacity(SERIALIZE_SCRATCH_CAPACITY),
+        );
+
+        let out = DecompressedBlock { batch_serial: batch.batch_serial(), bytes };
+        match ctx.outputs.push(out) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::steps::parse::bam::parse_records;
+    use crate::template::Template;
+    use fgumi_raw_bam::RawRecord;
+    use rstest::rstest;
+
+    #[test]
+    fn profile_advertises_parallel_byordinal() {
+        let s = SerializeBamRecords::new(1024);
+        let p = s.profile();
+        assert_eq!(p.name, "SerializeBamRecords");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    /// Cross-crate parity: `frame_record_into` (this `Serialize` step) and
+    /// `fgumi-pipeline-io`'s `BlockBuilder` (the standalone-sort terminal path)
+    /// are separate, independently-maintained encoders of the same on-disk
+    /// `[u32 LE block_size][body]` BAM record framing. They MUST stay
+    /// byte-for-byte in sync; the cases below pin that so a future edit to either
+    /// can't silently diverge (the failure mode a written comment alone can't
+    /// catch). This helper asserts the parity for one `body`.
+    fn assert_framing_parity(body: &[u8]) {
+        use fgumi_pipeline_io::sort::merge::{BlockBuilder, MergeBatchBuilder};
+
+        let mut via_serialize = Vec::new();
+        frame_record_into(&mut via_serialize, body).expect("frame_record_into");
+
+        let mut builder = BlockBuilder::with_capacity(0, body.len() + 4, 1);
+        builder.push_record_bytes(body).expect("push_record_bytes");
+        let via_block_builder = builder.build().bytes;
+
+        assert_eq!(
+            via_serialize,
+            via_block_builder,
+            "framing diverged for a {}-byte body",
+            body.len()
+        );
+    }
+
+    #[rstest]
+    #[case::empty(&[])]
+    #[case::one_byte(b"x")]
+    #[case::short(b"a slightly longer record body")]
+    #[case::two_sixty(&[0u8; 260])]
+    fn framing_matches_pipeline_io_block_builder(#[case] body: &[u8]) {
+        assert_framing_parity(body);
+    }
+
+    /// Same parity check for a large (5000-byte) body — kept separate from the
+    /// `#[rstest]` cases above since a literal that size is awkward as a `#[case]`.
+    #[test]
+    fn framing_matches_pipeline_io_block_builder_large_body() {
+        assert_framing_parity(&vec![0xABu8; 5000]);
+    }
+
+    /// Build a minimal `RawRecord` whose bytes match what `parse_records`
+    /// would emit (a body of `len` arbitrary bytes; serialization
+    /// prepends the 4-byte `block_size`).
+    fn raw_of_len(len: usize, fill: u8) -> RawRecord {
+        vec![fill; len].into()
+    }
+
+    #[test]
+    fn serialize_then_parse_roundtrip() {
+        // Two templates, one record each. After serializing we expect
+        // [block_size=8, 8 bytes][block_size=12, 12 bytes].
+        let r1 = raw_of_len(8, 0xAA);
+        let r2 = raw_of_len(12, 0xBB);
+        let mut t1 = Template::new(b"q1".to_vec());
+        t1.records.push(r1.clone());
+        let mut t2 = Template::new(b"q2".to_vec());
+        t2.records.push(r2.clone());
+        let input = BamTemplateBatch::new(7, vec![t1, t2]);
+
+        // Drive the serializer manually (mirrors the closure path; the
+        // step trait integration is exercised by `tests.rs` via `run`).
+        let record_count: usize = input.templates().iter().map(|t| t.records.len()).sum();
+        let mut bytes = Vec::with_capacity(input.total_bytes() + 4 * record_count);
+        for template in input.templates() {
+            for record in &template.records {
+                // Frame through the production encoder rather than re-deriving
+                // the layout here: a local copy would keep this test green
+                // through a regression in `frame_record_into`, leaving it a
+                // round-trip against itself. The exact byte layout is pinned
+                // separately by `frame_record_into_writes_le_prefix_then_body`.
+                frame_record_into(&mut bytes, record.as_ref()).expect("frame_record_into");
+            }
+        }
+        let parsed = parse_records(&bytes).expect("parse");
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].as_ref(), r1.as_ref());
+        assert_eq!(parsed[1].as_ref(), r2.as_ref());
+    }
+
+    /// `frame_record_into` writes `[u32 LE block_size][body]` and is the
+    /// canonical layout the terminal-sort `BlockBuilder` must reproduce
+    /// byte-for-byte; verify the exact prefix + body layout here.
+    #[test]
+    fn frame_record_into_writes_le_prefix_then_body() {
+        let mut scratch = Vec::new();
+        frame_record_into(&mut scratch, &[0xAA; 8]).unwrap();
+        frame_record_into(&mut scratch, &[0xBB; 12]).unwrap();
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&8u32.to_le_bytes());
+        expected.extend_from_slice(&[0xAA; 8]);
+        expected.extend_from_slice(&12u32.to_le_bytes());
+        expected.extend_from_slice(&[0xBB; 12]);
+        assert_eq!(scratch, expected);
+        // Round-trips through the BAM record parser.
+        let parsed = parse_records(&scratch).expect("parse");
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].as_ref(), &[0xAA; 8]);
+        assert_eq!(parsed[1].as_ref(), &[0xBB; 12]);
+    }
+}

--- a/src/lib/pipeline/steps/serialize_processed.rs
+++ b/src/lib/pipeline/steps/serialize_processed.rs
@@ -1,0 +1,196 @@
+//! `build_serialize_processed_groups_step`: shared builder for the
+//! `BatchedProcessedPositionGroups → DecompressedBlock` serialize step.
+//!
+//! Standalone `fgumi group` and the runall `--stop-after group` fused
+//! chain (`execute_group_pipeline` in `commands::runall`) both end on
+//! the same shape: take an MI-id-assigned batch of position groups,
+//! rewrite the MI tag bytes into each record's body, frame each body
+//! with the BAM `block_size` prefix, and concatenate into a single
+//! `DecompressedBlock` ready for `BgzfCompress`.
+//!
+//! Doing MI-tag-injection + framing in ONE closure pass (rather than
+//! the three-step `BatchedProcessedPositionGroups → BatchedMiGroups →
+//! RecordBatch → DecompressedBlock` consensus-tap detour) eliminates
+//! two cross-step queue handoffs and two intermediate batch allocations
+//! per BAM block. Measured ~11–15 % wall-time recovery on `--stop-after
+//! group` benchmarks vs. the consensus-tap detour the runall path was
+//! using before this builder existed.
+//!
+//! `emit_templates_raw_with_mi` lives in this module because both this
+//! step AND the standalone single-threaded writer in `commands::group`
+//! call it — keeping it pub(crate) at the step-library layer means
+//! both callers can't drift in MI-injection semantics.
+
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use log::info;
+
+use crate::pipeline::steps::group::position::BatchedProcessedPositionGroups;
+use crate::pipeline::steps::process::{ProcessWithWorkerState, process_with_worker_state};
+use crate::pipeline::steps::types::DecompressedBlock;
+use crate::template::Template;
+
+/// Per-worker scratch state for the serialize step. `scratch` is the
+/// record-aligned tag-update buffer; `mi_buf` is the formatted MI
+/// string. Both are reused across batches for the same reason the
+/// legacy `try_step_serialize` reused
+/// `worker.core.{serialization_buffer, secondary_serialization_buffer}`.
+///
+/// Must be `pub` because [`build_serialize_processed_groups_step`]'s
+/// return type names it via `ProcessWithWorkerState<…, SerializeState, …>` —
+/// callers that bind the returned step to a `let` can't see a private
+/// type in the public signature.
+pub struct SerializeState {
+    scratch: Vec<u8>,
+    mi_buf: String,
+}
+
+impl crate::pipeline::core::item::HeapSize for SerializeState {}
+
+/// Construct the `SerializeGroups` step: consumes
+/// [`BatchedProcessedPositionGroups`], emits [`DecompressedBlock`].
+///
+/// The per-batch closure:
+///   * walks every `ProcessedPositionGroup.templates`,
+///   * calls `emit_templates_raw_with_mi` which writes the MI tag
+///     bytes into the per-record `scratch` and appends framed bytes
+///     into the batch's output `Vec<u8>`,
+///   * updates `progress_counter` with the input record count and
+///     logs a "Processed N records" line every million records.
+///
+/// The output `Vec<u8>` is sized at `total_records * 800` so a typical
+/// BAM record (~256 B body + ~4 B framing + tag-update headroom) hits
+/// zero `realloc`s mid-batch. Smaller starts (e.g. 64 KiB + grow)
+/// landed in the medium → large mimalloc size class boundary and
+/// regressed on CODEC 8M benches.
+///
+/// `assign_tag_bytes` is the 2-byte tag the MI string is written under
+/// (`MI` by default; user-overridable via `--assign-tag`).
+///
+/// `progress_counter` is shared across all worker copies — bump
+/// atomically with the batch's input record count.
+pub fn build_serialize_processed_groups_step(
+    per_step_byte_limit: u64,
+    assign_tag_bytes: [u8; 2],
+    progress_counter: Arc<AtomicU64>,
+) -> ProcessWithWorkerState<
+    BatchedProcessedPositionGroups,
+    DecompressedBlock,
+    impl Fn(&mut SerializeState, BatchedProcessedPositionGroups) -> io::Result<DecompressedBlock>
+    + Send
+    + Sync
+    + 'static,
+    SerializeState,
+    impl Fn() -> SerializeState + Send + Sync + 'static,
+> {
+    process_with_worker_state::<
+        BatchedProcessedPositionGroups,
+        DecompressedBlock,
+        _,
+        SerializeState,
+        _,
+    >(
+        "SerializeGroups",
+        per_step_byte_limit,
+        || SerializeState { scratch: Vec::with_capacity(512), mi_buf: String::with_capacity(16) },
+        move |state: &mut SerializeState,
+              item: BatchedProcessedPositionGroups|
+              -> io::Result<DecompressedBlock> {
+            let BatchedProcessedPositionGroups { batch_serial, groups } = item;
+            // Size by record count, not template count: a paired-end template
+            // holds ~2 records, so `templates.len()` under-sized the buffer ~2×
+            // and forced reallocs. `input_record_count` is the per-group record
+            // tally; summed once here for both the capacity hint and the
+            // progress counter below.
+            let total_input_records: u64 =
+                groups.iter().fold(0u64, |acc, g| acc.saturating_add(g.input_record_count));
+            // The `saturating_mul`/`unwrap_or(usize::MAX)` is purely overflow-
+            // defensive and unreachable for realistic record counts (a count
+            // approaching `usize::MAX / 800` is impossible for any BAM). It is a
+            // theoretical guard only: if it ever did saturate to `usize::MAX`,
+            // the `with_capacity(usize::MAX)` would itself abort — so the guard
+            // protects against the multiply wrapping, not against a real
+            // allocation of that size.
+            let mut output = Vec::with_capacity(
+                usize::try_from(total_input_records.saturating_mul(800)).unwrap_or(usize::MAX),
+            );
+            for processed in &groups {
+                emit_templates_raw_with_mi(
+                    &processed.templates,
+                    0, // already mi_assign'd upstream — base offset is 0
+                    assign_tag_bytes,
+                    &mut state.scratch,
+                    &mut state.mi_buf,
+                    |bytes| {
+                        output.extend_from_slice(bytes);
+                        Ok(())
+                    },
+                )?;
+            }
+
+            let prev = progress_counter.fetch_add(total_input_records, Ordering::Relaxed);
+            if (prev + total_input_records) / 1_000_000 > prev / 1_000_000 {
+                info!("Processed {} records", prev + total_input_records);
+            }
+
+            Ok(DecompressedBlock { batch_serial, bytes: output })
+        },
+    )
+}
+
+/// Emit raw-byte primary reads for a batch of templates with MI tags injected.
+///
+/// For each template, if `has_mi` then the raw bytes are copied into `scratch`,
+/// the MI tag is updated in place, and the result is emitted via `emit`; otherwise
+/// the raw bytes are emitted unchanged. Each emitted record is prefixed with a
+/// 4-byte little-endian `block_size`. `mi_buf` and `scratch` are reused across
+/// templates to amortize allocations.
+///
+/// Shared by the threaded-pipeline `SerializeGroups` step (this module's
+/// [`build_serialize_processed_groups_step`]) and the single-threaded writer
+/// in [`crate::commands::group`] so they can't drift in MI-injection
+/// semantics.
+pub(crate) fn emit_templates_raw_with_mi(
+    templates: &[Template],
+    base_mi: u64,
+    assign_tag_bytes: [u8; 2],
+    scratch: &mut Vec<u8>,
+    mi_buf: &mut String,
+    mut emit: impl FnMut(&[u8]) -> io::Result<()>,
+) -> io::Result<()> {
+    for template in templates {
+        let mi = template.mi;
+        let has_mi = mi.is_assigned();
+        if has_mi {
+            // write_with_offset clears the buffer before writing.
+            mi.write_with_offset(base_mi, mi_buf);
+        }
+        for raw in [template.r1(), template.r2()].into_iter().flatten() {
+            if has_mi {
+                scratch.clear();
+                scratch.extend_from_slice(raw);
+                fgumi_raw_bam::update_string_tag(scratch, assign_tag_bytes, mi_buf.as_bytes());
+                let block_size = u32::try_from(scratch.len()).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("BAM record too large ({} bytes)", scratch.len()),
+                    )
+                })?;
+                emit(&block_size.to_le_bytes())?;
+                emit(scratch)?;
+            } else {
+                let block_size = u32::try_from(raw.len()).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("BAM record too large ({} bytes)", raw.len()),
+                    )
+                })?;
+                emit(&block_size.to_le_bytes())?;
+                emit(raw)?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/lib/pipeline/steps/sink/mod.rs
+++ b/src/lib/pipeline/steps/sink/mod.rs
@@ -1,0 +1,4 @@
+//! Sink steps (BAM file writers, future FASTQ writers).
+
+pub mod write_bgzf;
+pub mod write_raw;

--- a/src/lib/pipeline/steps/sink/write_bgzf.rs
+++ b/src/lib/pipeline/steps/sink/write_bgzf.rs
@@ -1,0 +1,3 @@
+//! Re-export shim. The `WriteBgzfFile` sink step now lives in the
+//! `fgumi-pipeline-io` crate.
+pub use fgumi_pipeline_io::sink::write_bgzf::WriteBgzfFile;

--- a/src/lib/pipeline/steps/sink/write_raw.rs
+++ b/src/lib/pipeline/steps/sink/write_raw.rs
@@ -1,0 +1,3 @@
+//! Re-export shim. The `WriteRawFile` sink step lives in the
+//! `fgumi-pipeline-io` crate.
+pub use fgumi_pipeline_io::sink::write_raw::{RawBytesBlock, WriteRawFile};

--- a/src/lib/pipeline/steps/sort/mod.rs
+++ b/src/lib/pipeline/steps/sort/mod.rs
@@ -1,0 +1,29 @@
+//! Re-export shim. The sort typed-steps now live in the `fgumi-pipeline-io`
+//! crate (`fgumi_pipeline_io::sort`).
+pub use fgumi_pipeline_io::sort::{
+    BlockOutput, CompressSpill, MergeBatchBuilder, MergeOutput, RecordBatchOutput,
+    SORT_COORD_GROUP, SORT_IO_GROUP, SortBuffer, SortDecompressTuning, SortMerge,
+    SortSpillDecompress, SpillBlockCompress, SpillGather, SpillWrite, protocol,
+};
+
+pub mod compress_spill {
+    pub use fgumi_pipeline_io::sort::compress_spill::*;
+}
+pub mod sort_buffer {
+    pub use fgumi_pipeline_io::sort::sort_buffer::*;
+}
+pub mod merge {
+    pub use fgumi_pipeline_io::sort::merge::*;
+}
+pub mod spill_decompress {
+    pub use fgumi_pipeline_io::sort::spill_decompress::*;
+}
+pub mod spill_gather {
+    pub use fgumi_pipeline_io::sort::spill_gather::*;
+}
+pub mod spill_block_compress {
+    pub use fgumi_pipeline_io::sort::spill_block_compress::*;
+}
+pub mod spill_write {
+    pub use fgumi_pipeline_io::sort::spill_write::*;
+}

--- a/src/lib/pipeline/steps/source/chain_tests.rs
+++ b/src/lib/pipeline/steps/source/chain_tests.rs
@@ -1,0 +1,578 @@
+//! End-to-end tests for the read-side source chains.
+//!
+//! The source steps are `try_run` state machines wrapped around real readers,
+//! so their interesting behavior — round-robin stream rotation, chunk
+//! alignment to whole 4-line records, per-stream ordinal assignment, drain
+//! reporting, and held-item retry under backpressure — only happens when the
+//! framework drives them against an actual stream. These tests assemble the
+//! two production FASTQ topologies and the SAM topology and run them through
+//! `Pipeline::run`:
+//!
+//! ```text
+//! ReadFastqInputs (all streams)  → ParseFastqChunks → ZipFastqRecords → sink
+//! ReadFastqInputs (one per stream) ×2 → PairRawFastq → ParseAndZipFastq → sink
+//! ReadSamChunks → sink
+//! ```
+//!
+//! The two FASTQ chains are not redundant: the first is the N>=3 fallback
+//! (a single `Affinity::Reader` worker rotating across every stream), the
+//! second is the paired-end path (one reader per stream on disjoint workers,
+//! joined two-way). They assign ordinals by different rules, so a bug in
+//! either is invisible to the other. Both must recover the same templates in
+//! the same order from the same input.
+//!
+//! `pair_fastq` and `zip_fastq` carry their own targeted pipeline tests for
+//! backpressure and stream skew; these cover the plain read-through path those
+//! tests stub out with synthetic sources.
+
+use std::io::{self, BufRead};
+use std::sync::{Arc, Mutex};
+
+use rstest::rstest;
+
+use crate::pipeline::core::builder::{Pipeline, PipelineBuilder, PipelineConfig};
+use crate::pipeline::core::item::{HeapSize, Ordered};
+use crate::pipeline::core::step::{Affinity, Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::source::pair_fastq::PairRawFastq;
+use crate::pipeline::steps::source::parse_fastq::ParseFastqChunks;
+use crate::pipeline::steps::source::parse_zip_fastq::ParseAndZipFastq;
+use crate::pipeline::steps::source::read_fastq::{FastqOrdinalSequence, ReadFastqInputs};
+use crate::pipeline::steps::source::read_sam_chunks::ReadSamChunks;
+use crate::pipeline::steps::source::zip_fastq::{FastqTemplateBatch, ZipFastqRecords};
+use crate::pipeline::steps::types::SamChunk;
+
+/// Per-edge byte budget, deliberately small relative to the fixtures so the
+/// byte-bounded edges reject pushes mid-run and the sources' held-item retry
+/// paths run. `the_edge_budget_binds_on_the_fixture` pins that it has teeth.
+const EDGE_LIMIT_BYTES: u64 = 512;
+
+/// FASTQ records per emitted chunk. Small enough that the fixtures below span
+/// many chunks, so stream rotation and cross-chunk ordinal assignment are
+/// actually exercised rather than fitting in a single chunk.
+const BATCH_RECORD_COUNT: usize = 8;
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+/// `n` FASTQ records for stream `stream_idx`, named `read{i}` so both streams
+/// of a pair agree on the name (which is what `ZipFastqRecords` /
+/// `ParseAndZipFastq` join on) while their sequences differ.
+fn fastq_text(n: usize, stream_idx: usize) -> String {
+    use std::fmt::Write as _;
+    // One distinct base per stream, so a template that mixes streams (or drops
+    // one) is visible in the assertion rather than hidden behind identical
+    // sequences. Cycles past four streams, which no fixture here reaches.
+    let base = ['A', 'C', 'G', 'T'][stream_idx % 4];
+    let mut out = String::new();
+    for i in 0..n {
+        writeln!(out, "@read{i}\n{base}{base}{base}{base}\n+\nIIII").expect("write to String");
+    }
+    out
+}
+
+fn boxed_reader(text: String) -> Box<dyn BufRead + Send> {
+    Box::new(io::Cursor::new(text.into_bytes()))
+}
+
+/// SAM record lines (no header) for the `ReadSamChunks` fixture.
+fn sam_record_lines(n: usize) -> String {
+    let mut out = String::new();
+    for i in 0..n {
+        use std::fmt::Write as _;
+        let pos = 100 + i;
+        writeln!(out, "read{i}\t0\tchr1\t{pos}\t60\t4M\t*\t0\t0\tACGT\tIIII")
+            .expect("write to String");
+    }
+    out
+}
+
+// ============================================================================
+// Collecting sink
+// ============================================================================
+
+/// Terminal sink accumulating every item in arrival order. `Exclusive`, so
+/// arrival order is the chain's output order with no sink-side interleaving.
+struct CollectSink<T: Send + 'static> {
+    collected: Arc<Mutex<Vec<T>>>,
+}
+
+impl<T: Send + HeapSize + 'static> Step for CollectSink<T> {
+    type Input = T;
+    type Outputs = ();
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "CollectSink",
+            kind: StepKind::Exclusive,
+            sticky: false,
+            output_queues: vec![],
+            branch_ordering: vec![],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        match ctx.input.pop() {
+            Some(item) => {
+                self.collected.lock().expect("sink mutex not poisoned").push(item);
+                Ok(StepOutcome::Progress)
+            }
+            None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+            None => Ok(StepOutcome::NoProgress),
+        }
+    }
+}
+
+/// Flatten collected template batches into `(name, [seq per stream])`, in
+/// batch-serial order. Both FASTQ chains must produce the identical result,
+/// which is what makes them comparable.
+fn templates_in_order(batches: &[FastqTemplateBatch]) -> Vec<(Vec<u8>, Vec<Vec<u8>>)> {
+    // Assert arrival order rather than sorting into it. The chain declares
+    // `ByItemOrdinal` and terminates in an `Exclusive` sink, so batches must
+    // ALREADY arrive in ordinal order — that is the property the reorder stage
+    // exists to provide. Sorting here would silently repair a reorder
+    // regression and leave the comparison below still passing.
+    for pair in batches.windows(2) {
+        assert!(
+            pair[0].ordinal() < pair[1].ordinal(),
+            "batches arrived out of order: ordinal {} before {}",
+            pair[0].ordinal(),
+            pair[1].ordinal(),
+        );
+    }
+    batches
+        .iter()
+        .flat_map(|batch| {
+            batch.templates.iter().map(|t| {
+                (t.name.clone(), t.records.iter().map(|r| r.sequence().to_vec()).collect())
+            })
+        })
+        .collect()
+}
+
+/// The templates the fixtures must yield: `read0..read{n-1}`, each pairing an
+/// all-`A` R1 sequence with an all-`C` R2 sequence.
+fn expected_templates(n: usize, n_streams: usize) -> Vec<(Vec<u8>, Vec<Vec<u8>>)> {
+    (0..n)
+        .map(|i| {
+            let seqs = (0..n_streams)
+                .map(|s| {
+                    let base = [b'A', b'C', b'G', b'T'][s % 4];
+                    vec![base; 4]
+                })
+                .collect();
+            (format!("read{i}").into_bytes(), seqs)
+        })
+        .collect()
+}
+
+// ============================================================================
+// Chains
+// ============================================================================
+
+/// The N-stream fallback topology: one `Affinity::Reader` source rotating across
+/// every stream, then parallel parse, then the serial zip join.
+///
+/// Swept over `n_streams` including **3**, which is the case this topology
+/// exists for — `PairRawFastq` handles exactly two, so anything above that
+/// routes here. A 2-stream-only test would leave the rotation across a third
+/// stream, and its drain, entirely unexercised.
+#[rstest]
+fn round_robin_fastq_chain_recovers_every_template_in_order(
+    #[values(1, 4)] threads: usize,
+    #[values(1, 8, 100)] n_records: usize,
+    #[values(2, 3)] n_streams: usize,
+) {
+    let collected: Arc<Mutex<Vec<FastqTemplateBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+
+    let readers: Vec<Box<dyn BufRead + Send>> =
+        (0..n_streams).map(|s| boxed_reader(fastq_text(n_records, s))).collect();
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReadFastqInputs::new(readers, BATCH_RECORD_COUNT, EDGE_LIMIT_BYTES))
+        .chain(ParseFastqChunks::new(EDGE_LIMIT_BYTES))
+        .chain(ZipFastqRecords::new(n_streams, EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let batches = collected.lock().expect("mutex not poisoned");
+    let templates = templates_in_order(&batches);
+    assert_eq!(templates, expected_templates(n_records, n_streams));
+    // Every template must carry exactly one record per stream — a dropped or
+    // duplicated stream would otherwise be invisible if the sequences matched.
+    assert!(
+        templates.iter().all(|(_, seqs)| seqs.len() == n_streams),
+        "every template must hold one record per stream",
+    );
+}
+
+/// Mismatched FASTQ inputs must **fail**, not hang.
+///
+/// This is the regression test for the ordinal-density bug. The reader used to
+/// derive ordinals as `chunk_serial * n_streams_total + stream_idx`, giving each
+/// stream its own residue class. That is unique but only dense when every
+/// stream yields the same number of chunks — so a short R2 left a permanently
+/// unfilled ordinal, `BranchOrdering::ByItemOrdinal` stalled waiting for it, and
+/// the run hung.
+///
+/// The damage was not just the stall: it *masked the correct diagnostic*.
+/// `ZipFastqRecords` already detects this input and reports "FASTQ sources out
+/// of sync", but the stalled reorder stage meant those chunks never reached it.
+/// So the assertion here is the error, not merely "does not hang" — the fix is
+/// what lets the existing check fire.
+///
+/// Stream 0 must outlive stream 1 by at least two read cycles, since the gap
+/// only strands a later ordinal if one is minted *after* it.
+#[rstest]
+fn mismatched_stream_lengths_error_rather_than_hanging(#[values(1, 4)] threads: usize) {
+    let collected: Arc<Mutex<Vec<FastqTemplateBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+
+    // BATCH_RECORD_COUNT records per chunk per cycle: stream 0 runs for several
+    // cycles after stream 1 is exhausted.
+    let long_records = BATCH_RECORD_COUNT * 4;
+    let short_records = BATCH_RECORD_COUNT;
+    let readers: Vec<Box<dyn BufRead + Send>> =
+        vec![boxed_reader(fastq_text(long_records, 0)), boxed_reader(fastq_text(short_records, 1))];
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReadFastqInputs::new(readers, BATCH_RECORD_COUNT, EDGE_LIMIT_BYTES))
+        .chain(ParseFastqChunks::new(EDGE_LIMIT_BYTES))
+        .chain(ZipFastqRecords::new(2, EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+
+    let err = pipeline
+        .run(PipelineConfig { threads, ..Default::default() })
+        .expect_err("mismatched FASTQ stream lengths must fail the run");
+    let message = format!("{err}");
+    assert!(
+        message.contains("out of sync"),
+        "expected the zipper's out-of-sync diagnostic, got: {message}",
+    );
+}
+
+/// The paired-end topology: one reader per stream pinned to a distinct worker,
+/// joined two-way by `PairRawFastq`, then parsed and zipped in one step.
+///
+/// Needs >= 3 threads: R1 and R2 hold disjoint single-worker affinities and a
+/// third worker drives the join and sink.
+#[rstest]
+fn per_stream_paired_fastq_chain_recovers_every_template_in_order(
+    #[values(3, 5)] threads: usize,
+    #[values(1, 8, 100)] n_records: usize,
+) {
+    let collected: Arc<Mutex<Vec<FastqTemplateBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+
+    // One sequence, cloned into both readers — that shared counter is what
+    // keeps the combined ordinal stream gap-free.
+    let ordinals = FastqOrdinalSequence::new();
+    let r1 = ReadFastqInputs::new_single(
+        boxed_reader(fastq_text(n_records, 0)),
+        /* global_stream_idx */ 0,
+        ordinals.clone(),
+        Affinity::Worker(0),
+        BATCH_RECORD_COUNT,
+        EDGE_LIMIT_BYTES,
+    );
+    let r2 = ReadFastqInputs::new_single(
+        boxed_reader(fastq_text(n_records, 1)),
+        1,
+        ordinals,
+        Affinity::Worker(1),
+        BATCH_RECORD_COUNT,
+        EDGE_LIMIT_BYTES,
+    );
+
+    let builder = PipelineBuilder::new();
+    let r1_tail = builder.append_source(r1);
+    let r2_tail = builder.append_source(r2);
+    let paired = builder.append_step2(PairRawFastq::new(EDGE_LIMIT_BYTES), r1_tail, r2_tail);
+    let zipped = builder.append_step(ParseAndZipFastq::new(EDGE_LIMIT_BYTES), paired);
+    builder.append_step(CollectSink { collected: sink_handle }, zipped);
+
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let batches = collected.lock().expect("mutex not poisoned");
+    assert_eq!(templates_in_order(&batches), expected_templates(n_records, 2));
+}
+
+/// Both FASTQ topologies draw ordinals from one shared `FastqOrdinalSequence`;
+/// they differ only in *who mints* — the round-robin reader is the single
+/// instance minting for every stream, while the per-stream readers each hold a
+/// clone of the same sequence. Reading the same input through both must
+/// therefore recover byte-identical templates in the same order; a wiring
+/// mistake that gave one topology its own counter is invisible to that
+/// topology's own test, because a per-instance sequence still looks dense from
+/// inside a single reader.
+#[test]
+fn both_fastq_topologies_agree_on_the_same_input() {
+    const N: usize = 64;
+
+    let round_robin = {
+        let collected: Arc<Mutex<Vec<FastqTemplateBatch>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_handle = Arc::clone(&collected);
+        let builder = Pipeline::builder();
+        builder
+            .chain(ReadFastqInputs::new(
+                vec![boxed_reader(fastq_text(N, 0)), boxed_reader(fastq_text(N, 1))],
+                BATCH_RECORD_COUNT,
+                EDGE_LIMIT_BYTES,
+            ))
+            .chain(ParseFastqChunks::new(EDGE_LIMIT_BYTES))
+            .chain(ZipFastqRecords::new(2, EDGE_LIMIT_BYTES))
+            .chain(CollectSink { collected: sink_handle })
+            .into_sink_marker();
+        builder
+            .build()
+            .expect("builds")
+            .run(PipelineConfig { threads: 4, ..Default::default() })
+            .expect("runs");
+        let batches = collected.lock().expect("mutex not poisoned");
+        templates_in_order(&batches)
+    };
+
+    let per_stream = {
+        let collected: Arc<Mutex<Vec<FastqTemplateBatch>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_handle = Arc::clone(&collected);
+        let builder = PipelineBuilder::new();
+        let ordinals = FastqOrdinalSequence::new();
+        let a = builder.append_source(ReadFastqInputs::new_single(
+            boxed_reader(fastq_text(N, 0)),
+            0,
+            ordinals.clone(),
+            Affinity::Worker(0),
+            BATCH_RECORD_COUNT,
+            EDGE_LIMIT_BYTES,
+        ));
+        let b = builder.append_source(ReadFastqInputs::new_single(
+            boxed_reader(fastq_text(N, 1)),
+            1,
+            ordinals,
+            Affinity::Worker(1),
+            BATCH_RECORD_COUNT,
+            EDGE_LIMIT_BYTES,
+        ));
+        let paired = builder.append_step2(PairRawFastq::new(EDGE_LIMIT_BYTES), a, b);
+        let zipped = builder.append_step(ParseAndZipFastq::new(EDGE_LIMIT_BYTES), paired);
+        builder.append_step(CollectSink { collected: sink_handle }, zipped);
+        builder
+            .build()
+            .expect("builds")
+            .run(PipelineConfig { threads: 4, ..Default::default() })
+            .expect("runs");
+        let batches = collected.lock().expect("mutex not poisoned");
+        templates_in_order(&batches)
+    };
+
+    assert_eq!(round_robin, expected_templates(N, 2));
+    assert_eq!(
+        round_robin, per_stream,
+        "the round-robin and per-stream reader topologies must agree on identical input",
+    );
+}
+
+/// An empty FASTQ stream must drain cleanly and produce nothing — every step
+/// sees drain before it ever sees an item.
+#[rstest]
+fn an_empty_fastq_stream_completes_with_no_templates(#[values(1, 4)] threads: usize) {
+    let collected: Arc<Mutex<Vec<FastqTemplateBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReadFastqInputs::new(
+            vec![boxed_reader(String::new()), boxed_reader(String::new())],
+            BATCH_RECORD_COUNT,
+            EDGE_LIMIT_BYTES,
+        ))
+        .chain(ParseFastqChunks::new(EDGE_LIMIT_BYTES))
+        .chain(ZipFastqRecords::new(2, EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let batches = collected.lock().expect("mutex not poisoned");
+    let total: usize = batches.iter().map(|b| b.templates.len()).sum();
+    assert_eq!(total, 0);
+}
+
+/// `ReadSamChunks` must emit every record line exactly once, split on line
+/// boundaries, with a sentinel-form offset table per chunk. A tiny target chunk
+/// size forces many chunks so the split path runs repeatedly rather than
+/// emitting everything in one go.
+#[rstest]
+fn sam_chunk_source_emits_every_line_split_on_record_boundaries(
+    #[values(1, 4)] threads: usize,
+    #[values(1, 200)] n_records: usize,
+) {
+    let text = sam_record_lines(n_records);
+    let collected: Arc<Mutex<Vec<SamChunk>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReadSamChunks::new(
+            boxed_reader(text.clone()),
+            /* target_chunk_bytes */ 256,
+            EDGE_LIMIT_BYTES,
+        ))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    let pipeline = builder.build().expect("chain builds");
+    pipeline.run(PipelineConfig { threads, ..Default::default() }).expect("chain runs");
+
+    let chunks = collected.lock().expect("mutex not poisoned").drain(..).collect::<Vec<_>>();
+    // Same reasoning as `templates_in_order`: assert the arrival order the
+    // chain promises instead of sorting into it, so an out-of-order emission
+    // fails here rather than being repaired before the byte comparison.
+    for pair in chunks.windows(2) {
+        assert!(
+            pair[0].ordinal() < pair[1].ordinal(),
+            "chunks arrived out of order: ordinal {} before {}",
+            pair[0].ordinal(),
+            pair[1].ordinal(),
+        );
+    }
+
+    // Every chunk's offset table must be sentinel-form and describe complete
+    // lines; concatenating them must reproduce the input exactly.
+    let mut lines: Vec<String> = Vec::new();
+    let mut rebuilt = Vec::new();
+    for chunk in &chunks {
+        rebuilt.extend_from_slice(&chunk.bytes);
+        assert_eq!(
+            *chunk.line_offsets.last().expect("sentinel-form table is never empty") as usize,
+            chunk.bytes.len(),
+            "the final offset must be the sentinel end-of-chunk",
+        );
+        for w in chunk.line_offsets.windows(2) {
+            let line = &chunk.bytes[w[0] as usize..w[1] as usize];
+            assert_eq!(line.last(), Some(&b'\n'), "every emitted line must be complete");
+            lines.push(String::from_utf8(line.to_vec()).expect("utf8"));
+        }
+    }
+    assert_eq!(rebuilt, text.as_bytes(), "chunks must reproduce the input byte-for-byte");
+    assert_eq!(lines.len(), n_records, "one line per input record, no duplicates or drops");
+    assert_eq!(lines.concat(), text);
+}
+
+/// An empty SAM body drains cleanly with no chunks carrying records.
+#[test]
+fn an_empty_sam_stream_completes_with_no_records() {
+    let collected: Arc<Mutex<Vec<SamChunk>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_handle = Arc::clone(&collected);
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(ReadSamChunks::new(boxed_reader(String::new()), 256, EDGE_LIMIT_BYTES))
+        .chain(CollectSink { collected: sink_handle })
+        .into_sink_marker();
+    builder
+        .build()
+        .expect("chain builds")
+        .run(PipelineConfig { threads: 1, ..Default::default() })
+        .expect("chain runs");
+
+    let chunks = collected.lock().expect("mutex not poisoned");
+    let total: usize = chunks.iter().map(SamChunk::record_count).sum();
+    assert_eq!(total, 0);
+}
+
+/// `EDGE_LIMIT_BYTES` must be small enough that the multi-record fixtures
+/// exceed it, or the byte-bounded edges never reject a push and every chain
+/// above silently degrades into an unbounded-queue test.
+///
+/// This is a **necessary condition, not a proof of backpressure**: a fast
+/// -draining downstream can keep occupancy under the limit even when the whole
+/// fixture is far larger than one edge. The sibling test below closes the other
+/// half — that an edge at this budget really does reject these chunk sizes.
+#[test]
+fn the_edge_budget_binds_on_the_fixtures() {
+    let limit = usize::try_from(EDGE_LIMIT_BYTES).expect("budget fits usize");
+
+    // One FASTQ stream must not fit in a single edge, so the reader is forced
+    // to hold a rejected chunk and retry rather than emitting everything in one
+    // pass. One chunk must still fit, or the edge would wedge instead.
+    let stream_bytes = fastq_text(100, 0).len();
+    let chunk_bytes = fastq_text(BATCH_RECORD_COUNT, 0).len();
+    assert!(
+        stream_bytes > limit,
+        "one FASTQ stream ({stream_bytes} B) must exceed the per-edge budget \
+         ({limit} B), else the byte-bounded edges never bind and these chains \
+         prove nothing about backpressure",
+    );
+    assert!(
+        chunk_bytes < limit,
+        "a single chunk ({chunk_bytes} B) must still fit the budget ({limit} B), \
+         else the edge admits nothing and the pipeline wedges",
+    );
+
+    // Same for the SAM fixture.
+    let sam_bytes = sam_record_lines(200).len();
+    assert!(sam_bytes > limit, "SAM fixture ({sam_bytes} B) must exceed the budget ({limit} B)");
+}
+
+/// A byte-bounded edge at exactly `EDGE_LIMIT_BYTES`, fed the chunk sizes the
+/// FASTQ chains put on it, must reject before the fixture is exhausted — so the
+/// held-item retry path in `ReadFastqInputs` is genuinely reachable at this
+/// budget, not merely reachable in principle.
+///
+/// What this still does not assert is that a rejection occurred *during the
+/// chain runs above*. Observing that needs the per-edge reject counter, which
+/// `fgumi-pipeline-core` records (`EdgeMetrics::record_reject`) but keeps
+/// `pub(crate)`, so it is unreachable from here without widening that crate's
+/// API — out of scope for this PR. The chains cover the retry path indirectly:
+/// every record arrives, in order, across an edge this test shows must reject,
+/// which could not happen if held items were dropped or never retried. That is
+/// an inference from the end state, not a direct assertion, and it is recorded
+/// here so the gap is visible rather than assumed closed.
+#[test]
+fn the_byte_bounded_edge_rejects_at_the_test_budget() {
+    use crate::pipeline::core::queues::{ByteBoundedQueue, ItemQueue};
+    use crate::pipeline::steps::source::read_fastq::FastqRawChunk;
+
+    let queue = ByteBoundedQueue::<FastqRawChunk>::new(EDGE_LIMIT_BYTES);
+    let chunk_data = fastq_text(BATCH_RECORD_COUNT, 0).into_bytes();
+    let chunk_bytes = chunk_data.len();
+
+    // Push identical chunks until one is refused. The fixture spans many such
+    // chunks, so a queue that never rejects would loop past the whole stream.
+    let max_pushes = fastq_text(100, 0).len() / chunk_bytes + 1;
+    let mut accepted = 0usize;
+    let mut rejected = false;
+    for ordinal in 0..max_pushes {
+        let chunk = FastqRawChunk {
+            ordinal: ordinal as u64,
+            stream_idx: 0,
+            chunk_serial: ordinal as u64,
+            data: chunk_data.clone(),
+        };
+        if queue.try_push(chunk).is_err() {
+            rejected = true;
+            break;
+        }
+        accepted += 1;
+    }
+
+    assert!(
+        rejected,
+        "a {EDGE_LIMIT_BYTES}-byte edge admitted all {max_pushes} chunks of {chunk_bytes} B \
+         without rejecting; the byte budget is not binding and the chains above prove \
+         nothing about the held-item retry path",
+    );
+    assert!(
+        accepted >= 1,
+        "the edge must admit at least one chunk before rejecting, else the chains wedge \
+         instead of exercising backpressure",
+    );
+}

--- a/src/lib/pipeline/steps/source/mod.rs
+++ b/src/lib/pipeline/steps/source/mod.rs
@@ -1,0 +1,703 @@
+//! BAM, SAM, and FASTQ source steps.
+//!
+//! - `read_bam` / `read_sam_chunks` — open a BAM/SAM input and emit blocks
+//!   or line-aligned chunks.
+//! - `read_fastq` — read raw FASTQ bytes, cut on whole-record boundaries.
+//! - `parse_fastq` / `parse_zip_fastq` — parse those bytes into records.
+//! - `pair_fastq` / `zip_fastq` — join per-stream chunks into templates.
+
+#[cfg(test)]
+mod chain_tests;
+pub mod pair_fastq;
+pub mod parse_fastq;
+pub mod parse_zip_fastq;
+pub mod read_bam;
+pub mod read_fastq;
+pub mod read_sam_chunks;
+pub mod zip_fastq;
+
+use std::fs::File;
+use std::io::{self, BufRead, BufReader, Read};
+use std::path::Path;
+
+/// Wrap a `File::open` failure with the path while **preserving the original
+/// [`io::ErrorKind`]**.
+///
+/// `io::Error::other` would flatten every kind to [`io::ErrorKind::Other`], so a
+/// missing input would stop reporting as [`io::ErrorKind::NotFound`] and callers
+/// (and users) would lose the distinction between "no such file" and
+/// "permission denied".
+fn open_error(path: &std::path::Path, source: &io::Error) -> io::Error {
+    io::Error::new(source.kind(), format!("open {}: {source}", path.display()))
+}
+
+/// The BAM-opener counterpart to [`open_error`], preserving the underlying
+/// [`io::ErrorKind`] across an `anyhow::Error`.
+///
+/// `create_bam_reader_for_pipeline_with_opts` returns `anyhow::Error`, so
+/// `io::Error::other` on it would flatten `NotFound` to `Other` — exactly the
+/// loss `open_error` exists to prevent on the plain `File::open` paths, just one
+/// error type further away.
+///
+/// The `io::Error` is usually **not** the top of the chain: the opener adds
+/// `.with_context(..)`, so a top-level `downcast` would miss it. Walking
+/// `chain()` finds the first I/O error wherever it sits, and a non-I/O failure
+/// (a malformed header, say) still falls back to `Other`, which is accurate for
+/// it.
+fn open_bam_error(path: &std::path::Path, source: &anyhow::Error) -> io::Error {
+    let message = format!("open BAM {}: {source}", path.display());
+    match source.chain().find_map(|e| e.downcast_ref::<io::Error>()) {
+        Some(io_err) => io::Error::new(io_err.kind(), message),
+        None => io::Error::other(message),
+    }
+}
+
+/// Parse a whole-record-aligned FASTQ chunk into records, returning them with
+/// the summed `HeapSize` of the parsed records.
+///
+/// `data` must contain a whole number of 4-line FASTQ records, each terminated
+/// by `\n` (as produced by `read_fastq_raw_bytes_from_bufread`). Record
+/// boundaries are located with the SIMD lexer (`find_record_offsets`) — a single
+/// vectorized pass over the chunk rather than a per-byte scalar scan.
+///
+/// `step_name` appears in the truncation error so the two callers
+/// (`ParseFastqChunks` and `ParseAndZipFastq`) stay distinguishable in logs.
+///
+/// # Errors
+///
+/// Returns `InvalidData` when the chunk ends mid-record, i.e. the reader's
+/// whole-record alignment guarantee was violated upstream.
+pub(crate) fn parse_fastq_chunk(
+    data: &[u8],
+    step_name: &str,
+) -> io::Result<(Vec<crate::fastq_parse::FastqRecord>, usize)> {
+    use crate::pipeline::core::item::HeapSize as _;
+
+    // `find_record_offsets` returns `[0, end_1, .., end_n]` where `end_n` is one
+    // byte past the final *complete* record; trailing incomplete bytes are
+    // excluded. The reader guarantees whole-record-aligned chunks, so the last
+    // offset must equal `data.len()` — anything else is a truncated record.
+    let offsets = fgumi_simd_fastq::find_record_offsets(data);
+    let last = offsets.last().copied().unwrap_or(0);
+    if last != data.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "{step_name}: truncated FASTQ record ({} trailing bytes after the last \
+                 complete record)",
+                data.len() - last
+            ),
+        ));
+    }
+
+    let num_records = offsets.len().saturating_sub(1);
+    let mut records = Vec::with_capacity(num_records);
+    let mut total_bytes = 0usize;
+    for window in offsets.windows(2) {
+        let record = crate::fastq_parse::FastqRecord::from_slice(&data[window[0]..window[1]])?;
+        total_bytes += record.heap_size();
+        records.push(record);
+    }
+    Ok((records, total_bytes))
+}
+
+use fgumi_bam_io::{ChainedReader, InputFormat, TeeReader};
+use flate2::read::MultiGzDecoder;
+use noodles::bgzf::io::Reader as BgzfReader;
+use noodles::sam;
+
+/// Opaque, opened input source ready to feed into the typed-step pipeline.
+///
+/// The two variants encode the BAM vs. SAM choice. The BAM variant carries
+/// a `Box<dyn Read + Send>` whose first bytes are the BAM header (file
+/// seeked to byte 0 for on-disk inputs, or a `TeeReader`/`ChainedReader`
+/// replay for stdin) and the parsed header. The SAM variant carries the
+/// SAM reader already positioned past its header — record reads go
+/// straight into [`read_sam_chunks::ReadSamChunks`].
+///
+/// Each command's new-pipeline path opens its input via [`InputSource::open`]
+/// once, threads the [`sam::Header`] into upstream validation /
+/// `@PG`-mutation, then `match`es on the variant to build the appropriate
+/// chain preamble (3-step BAM vs. 2-step SAM).
+pub enum InputSource {
+    /// BAM input (BGZF-compressed). `reader` is positioned at byte 0 of
+    /// the BAM stream — the `read_bam::ReadBgzfBlocks` source emits the
+    /// header bytes as part of the first block(s); `FindBamBoundaries::new`
+    /// strips them downstream.
+    Bam { reader: Box<dyn Read + Send>, header: sam::Header },
+    /// SAM (text) input. `reader` has consumed the `@`-prefixed header
+    /// lines; subsequent `read_record` calls yield the first record.
+    /// Pair with `FindBamBoundaries::new_no_header` (the SAM source
+    /// emits record bodies directly, no header bytes to strip).
+    Sam { reader: sam::io::Reader<Box<dyn BufRead + Send>>, header: sam::Header },
+}
+
+impl InputSource {
+    /// Open `path` and detect the input shape.
+    ///
+    /// Detection: `is_stdin_path` chooses stdin vs file; then the file
+    /// extension (`.sam`/`.bam`/none) selects the reader, and anything without
+    /// one is classified by content through [`fgumi_bam_io::classify_input`].
+    ///
+    /// Content classification never reduces to a magic-byte test. A leading
+    /// `\x1f` says "gzip", not "BGZF", and plain gzip is a supported input on
+    /// every other fgumi path — so treating it as BAM would hand a single
+    /// deflate stream to a block reader that rejects it. Reopenable inputs get
+    /// this for free from `create_bam_reader_for_pipeline_with_opts`, which
+    /// normalizes; pipes are classified (and decompressed if needed) in
+    /// `open_stream_by_content`.
+    ///
+    /// # Errors
+    ///
+    /// Returns I/O errors from file open, stdin read, or header parse.
+    pub fn open<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        Self::open_with_opts(path, fgumi_bam_io::PipelineReaderOpts::default())
+    }
+
+    /// [`InputSource::open`] with a [`fgumi_bam_io::PipelineReaderOpts`].
+    ///
+    /// # Errors
+    ///
+    /// Returns I/O errors from file open, stdin read, or header parse.
+    pub fn open_with_opts<P: AsRef<Path>>(
+        path: P,
+        opts: fgumi_bam_io::PipelineReaderOpts,
+    ) -> io::Result<Self> {
+        let path = path.as_ref();
+        let is_stdin = fgumi_bam_io::is_stdin_path(path);
+
+        // Suffix hint: explicit `.sam` → SAM; `.bam` → BAM. Anything else is
+        // decided by content — including `.gz`, whose extension says only that
+        // it is compressed, not by what.
+        let extension = path.extension();
+        let suffix_says_sam = extension.is_some_and(|e| e.eq_ignore_ascii_case("sam"));
+        let suffix_is_bam = extension.is_some_and(|e| e.eq_ignore_ascii_case("bam"));
+
+        if is_stdin {
+            // The path is just `-`, so there is no suffix to consult and the
+            // content decides. `PipelineReaderOpts` is not threaded through here:
+            // there is no path to reopen, so there is no async-reader wiring.
+            let _ = opts;
+            open_stream_by_content(Box::new(io::stdin()))
+        } else if suffix_says_sam {
+            let file = File::open(path).map_err(|e| open_error(path, &e))?;
+            let buf: Box<dyn BufRead + Send> =
+                Box::new(BufReader::with_capacity(2 * 1024 * 1024, file));
+            open_sam_from_boxed_buf(buf)
+        } else if suffix_is_bam {
+            // BAM file: parse header via the existing helper, which
+            // handles the seek-to-0 + opt.async_reader wiring.
+            let (reader, header) =
+                fgumi_bam_io::create_bam_reader_for_pipeline_with_opts(path, opts)
+                    .map_err(|e| open_bam_error(path, &e))?;
+            Ok(InputSource::Bam { reader, header })
+        } else {
+            // No suffix hint: the content decides.
+            let file = File::open(path).map_err(|e| open_error(path, &e))?;
+            // Whether re-opening `path` can replay the bytes classification
+            // consumes. Only a regular file can: for a FIFO or a `/dev/fd/N`
+            // handed over by process substitution, reading those bytes drains
+            // them out of the pipe for good, and a second open yields the *rest*
+            // of the stream, not the start of it — silently losing the header.
+            //
+            // An `fstat` on an already-open descriptor essentially cannot fail, but
+            // `unwrap_or(false)` picks the safe direction if it somehow does: the
+            // in-stream path always yields correct bytes and merely forgoes the
+            // async-reader wiring, whereas a wrong "regular" answer corrupts input.
+            if !file.metadata().map(|m| m.is_file()).unwrap_or(false) {
+                // Non-regular: classify in-stream. Same trade-off the stdin branch
+                // makes — no async-reader wiring, because there is no reopenable path.
+                let _ = opts;
+                return open_stream_by_content(Box::new(file));
+            }
+
+            // Regular file: classify here, then choose between keeping the text
+            // in the SAM reader and handing the path to the normalizing helper.
+            let mut file = file;
+            let (prefix, format) = take_format_prefix(&mut file)?;
+            match format {
+                // SAM text stays SAM: `ReadSamChunks` parses it directly, and
+                // routing it through the helper would transcode it to BGZF and
+                // throw that away.
+                InputFormat::Text => {
+                    open_sam_from_boxed_buf(buffered(ChainedReader::new(prefix, file)))
+                }
+                // Compressed: re-open through the helper, which seeks to byte 0,
+                // preserves the async-reader wiring, and normalizes — so a plain
+                // gzip member is decompressed there rather than handed to a block
+                // reader that would reject it. The bytes consumed above are simply
+                // re-read; a regular file can always be replayed.
+                InputFormat::Bgzf | InputFormat::Gzip => {
+                    drop(file);
+                    let (reader, header) =
+                        fgumi_bam_io::create_bam_reader_for_pipeline_with_opts(path, opts)
+                            .map_err(|e| open_bam_error(path, &e))?;
+                    Ok(InputSource::Bam { reader, header })
+                }
+                InputFormat::Empty => Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    format!("input is empty: {} (expected BAM or SAM records)", path.display()),
+                )),
+            }
+        }
+    }
+
+    /// Borrow the parsed header. Common for both variants.
+    #[must_use]
+    pub fn header(&self) -> &sam::Header {
+        match self {
+            InputSource::Bam { header, .. } | InputSource::Sam { header, .. } => header,
+        }
+    }
+}
+
+/// Consume up to [`fgumi_bam_io::FORMAT_PREFIX_LEN`] bytes and classify them.
+///
+/// The bytes are returned rather than pushed back so the caller can replay them
+/// through a [`ChainedReader`]: these inputs are pipes, which cannot be rewound
+/// or reopened. Short reads are looped over, because one `read` on a pipe may
+/// return fewer bytes than are available and a short prefix classifies as
+/// [`fgumi_bam_io::InputFormat::Gzip`] regardless of what the stream really is
+/// — BGZF cannot be recognized from fewer than a full header.
+fn take_format_prefix<R: Read + ?Sized>(reader: &mut R) -> io::Result<(Vec<u8>, InputFormat)> {
+    let mut prefix = vec![0u8; fgumi_bam_io::FORMAT_PREFIX_LEN];
+    let mut filled = 0;
+    while filled < prefix.len() {
+        match reader.read(&mut prefix[filled..]) {
+            Ok(0) => break,
+            Ok(n) => filled += n,
+            // A signal can interrupt a `read` on a stream that is still
+            // perfectly readable. `read_exact` retries this kind rather than
+            // propagating it, and a hand-rolled fill loop has to do the same —
+            // otherwise a signal during startup fails the open outright.
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+    prefix.truncate(filled);
+    let format = fgumi_bam_io::classify_input(&prefix);
+    Ok((prefix, format))
+}
+
+/// Open a stream that cannot be reopened — stdin, a FIFO, a `/dev/fd/N` from
+/// process substitution — by classifying its content.
+///
+/// Regular files do not come through here: they go to
+/// `create_bam_reader_for_pipeline_with_opts`, which normalizes via
+/// `normalize_to_bgzf` and so already decompresses plain gzip and transcodes
+/// SAM. A pipe has no such second pass, so the classification and the gzip
+/// decompression have to happen here.
+///
+/// Classification is by content through the shared
+/// [`fgumi_bam_io::classify_input`], never by a hand-rolled magic-byte test: a
+/// bare `\x1f` check cannot tell BGZF from plain gzip, and answering "BGZF" for
+/// a plain-gzip member hands it to a block reader that rejects it — the
+/// misleading diagnosis that classifier exists to prevent.
+fn open_stream_by_content(reader: Box<dyn Read + Send>) -> io::Result<InputSource> {
+    let mut reader = reader;
+    let (prefix, format) = take_format_prefix(&mut reader)?;
+    match format {
+        InputFormat::Empty => Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "input stream is empty (expected BAM or SAM records)",
+        )),
+        InputFormat::Bgzf => {
+            open_bam_from_stdin_boxed_buf(buffered(ChainedReader::new(prefix, reader)))
+        }
+        InputFormat::Text => open_sam_from_boxed_buf(buffered(ChainedReader::new(prefix, reader))),
+        // Plain gzip: one deflate stream, so no block-parallel decode. Decompress
+        // at this boundary and classify what comes out, exactly as
+        // `normalize_to_bgzf` does for reopenable inputs.
+        InputFormat::Gzip => {
+            log::warn!(
+                "input stream is gzip-compressed rather than BGZF — decompressing it \
+                 single-threaded, so --threads will not speed up reading. Recompress \
+                 with `bgzip` for block-parallel decode."
+            );
+            let mut decoded: Box<dyn Read + Send> =
+                Box::new(MultiGzDecoder::new(ChainedReader::new(prefix, reader)));
+            let (inner_prefix, inner_format) = take_format_prefix(&mut *decoded)?;
+            match inner_format {
+                InputFormat::Bgzf => open_bam_from_stdin_boxed_buf(buffered(ChainedReader::new(
+                    inner_prefix,
+                    decoded,
+                ))),
+                InputFormat::Text => {
+                    open_sam_from_boxed_buf(buffered(ChainedReader::new(inner_prefix, decoded)))
+                }
+                InputFormat::Gzip => Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "input stream is gzip-compressed more than once; decompress it before \
+                     piping it in",
+                )),
+                InputFormat::Empty => Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "input stream decompresses to an empty gzip member",
+                )),
+            }
+        }
+    }
+}
+
+/// Box a reader as the buffered stream both openers take.
+fn buffered<R: Read + Send + 'static>(reader: R) -> Box<dyn BufRead + Send> {
+    Box::new(BufReader::with_capacity(2 * 1024 * 1024, reader))
+}
+
+/// Wrap an already-buffered stdin-shape BAM reader into a BAM
+/// `InputSource`. The BGZF reader's header-probe goes through a
+/// `TeeReader` so we can replay the consumed header bytes ahead of the
+/// remaining stdin stream via `ChainedReader`. File inputs take the
+/// re-open-at-byte-0 path via `create_bam_reader_for_pipeline_with_opts`
+/// and never reach this function.
+fn open_bam_from_stdin_boxed_buf(buf: Box<dyn BufRead + Send>) -> io::Result<InputSource> {
+    let tee = TeeReader::new(buf);
+    let bgzf = BgzfReader::new(tee);
+    let mut bam_reader = noodles::bam::io::Reader::from(bgzf);
+    let header = bam_reader
+        .read_header()
+        // Preserve the source kind: a truncated header arrives as
+        // `UnexpectedEof`, and flattening it to `Other` loses the one signal a
+        // caller can branch on. Same policy as `open_error`/`open_bam_error`.
+        .map_err(|e| io::Error::new(e.kind(), format!("read BAM header from stdin: {e}")))?;
+    let bgzf = bam_reader.into_inner();
+    let tee = bgzf.into_inner();
+    let (buffered, remaining) = tee.into_parts();
+    let chained: Box<dyn Read + Send> = Box::new(ChainedReader::new(buffered, remaining));
+    Ok(InputSource::Bam { reader: chained, header })
+}
+
+/// Wrap an already-buffered SAM-shape reader (file or stdin) into a SAM
+/// `InputSource`. Parses the header up front so subsequent record reads
+/// start at the first record line.
+fn open_sam_from_boxed_buf(buf: Box<dyn BufRead + Send>) -> io::Result<InputSource> {
+    let mut sam_reader = sam::io::Reader::new(buf);
+    let header = sam_reader.read_header().map_err(|e| {
+        // See the BAM header read above: keep the source `ErrorKind`.
+        io::Error::new(e.kind(), format!("read SAM header: {e}"))
+    })?;
+    Ok(InputSource::Sam { reader: sam_reader, header })
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+    use std::io::Write;
+
+    const SAM_TEXT: &str = "\
+@HD\tVN:1.6\tSO:unsorted\n\
+@SQ\tSN:chr1\tLN:1000\n\
+read1\t0\tchr1\t10\t60\t5M\t*\t0\t0\tACGTA\tIIIII\n";
+
+    #[test]
+    fn opens_bam_file_by_extension() {
+        let path = tempfile::NamedTempFile::with_suffix(".bam").unwrap().into_temp_path();
+        let header = noodles::sam::Header::default();
+        let writer = fgumi_bam_io::create_raw_bam_writer(&path, &header, 1, 1).unwrap();
+        writer.finish().unwrap();
+
+        let source = InputSource::open(&path).unwrap();
+        assert!(matches!(source, InputSource::Bam { .. }));
+    }
+
+    #[test]
+    fn opens_sam_file_by_extension() {
+        let path = tempfile::NamedTempFile::with_suffix(".sam").unwrap().into_temp_path();
+        std::fs::File::create(&path).unwrap().write_all(SAM_TEXT.as_bytes()).unwrap();
+
+        let source = InputSource::open(&path).unwrap();
+        let InputSource::Sam { header, .. } = source else {
+            panic!("expected SAM source");
+        };
+        assert_eq!(header.reference_sequences().len(), 1);
+    }
+
+    #[test]
+    fn falls_back_to_magic_byte_when_extension_missing() {
+        // SAM content, no `.sam` suffix.
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        std::fs::File::create(&path).unwrap().write_all(SAM_TEXT.as_bytes()).unwrap();
+
+        let source = InputSource::open(&path).unwrap();
+        assert!(matches!(source, InputSource::Sam { .. }));
+    }
+
+    /// Write a minimal single-reference BAM and return its path.
+    fn write_bam(suffix: &str) -> tempfile::TempPath {
+        let path = tempfile::NamedTempFile::with_suffix(suffix).unwrap().into_temp_path();
+        let header = noodles::sam::Header::builder()
+            .add_reference_sequence(
+                bstr::BString::from("chr1"),
+                noodles::sam::header::record::value::Map::<
+                    noodles::sam::header::record::value::map::ReferenceSequence,
+                >::new(std::num::NonZeroUsize::new(1000).unwrap()),
+            )
+            .build();
+        let writer = fgumi_bam_io::create_raw_bam_writer(&path, &header, 1, 1).unwrap();
+        writer.finish().unwrap();
+        path
+    }
+
+    /// The magic-byte fallback must resolve BGZF content to BAM, not just
+    /// resolve text content to SAM. Without this the suffix-less BAM branch —
+    /// which re-opens through the async-reader-aware helper — is never taken.
+    #[test]
+    fn falls_back_to_magic_byte_for_bam_without_extension() {
+        let path = write_bam("");
+        let source = InputSource::open(&path).unwrap();
+        assert!(matches!(source, InputSource::Bam { .. }));
+        assert_eq!(source.header().reference_sequences().len(), 1);
+    }
+
+    /// Serve `bytes` over a FIFO at a suffix-less path and open it.
+    ///
+    /// The FIFO is what makes the input non-reopenable, which is the branch
+    /// under test: a regular file would be handed to the normalizing helper
+    /// instead. Opening a FIFO for writing blocks until a reader opens it, so
+    /// the writer runs concurrently with the open.
+    #[cfg(unix)]
+    fn open_via_fifo(bytes: Vec<u8>, dir: &tempfile::TempDir) -> io::Result<InputSource> {
+        let fifo = dir.path().join("stream"); // deliberately no extension
+        let status = std::process::Command::new("mkfifo").arg(&fifo).status().expect("mkfifo runs");
+        assert!(status.success(), "mkfifo failed for {}", fifo.display());
+
+        let writer_path = fifo.clone();
+        let writer = std::thread::spawn(move || {
+            let mut f = std::fs::File::create(&writer_path).expect("open fifo for write");
+            let _ = f.write_all(&bytes); // the reader may reject before draining
+        });
+
+        let opened = InputSource::open(&fifo);
+        let _ = writer.join();
+        opened
+    }
+
+    /// Plain-gzip SAM over a pipe must be decompressed and read as SAM.
+    ///
+    /// A bare `\x1f` check calls this BGZF and hands it to the BAM block reader,
+    /// which fails with a header error on a stream that is perfectly readable —
+    /// the misleading diagnosis `classify_input` exists to prevent. Plain gzip is
+    /// a supported verdict on every other fgumi input path, so it must be one
+    /// here too.
+    #[cfg(unix)]
+    #[test]
+    fn suffix_less_plain_gzip_sam_over_a_pipe_is_read_as_sam() {
+        use flate2::write::GzEncoder;
+
+        let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        encoder.write_all(SAM_TEXT.as_bytes()).expect("gzip the SAM text");
+        let gzipped = encoder.finish().expect("finish gzip member");
+        assert_eq!(gzipped[0], 0x1f, "the fixture must start with the gzip magic byte");
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = open_via_fifo(gzipped, &dir).expect("gzipped SAM opens");
+
+        let InputSource::Sam { header, .. } = source else {
+            panic!("expected a SAM source; plain gzip must not be routed to the BAM reader");
+        };
+        assert_eq!(header.reference_sequences().len(), 1);
+    }
+
+    /// The error arms of `open_stream_by_content` and of the suffix-less regular
+    /// -file branch, which the happy-path tests above never reach.
+    ///
+    /// Each is a named diagnosis rather than a downstream parse failure, so the
+    /// message is what is asserted — a caller piping the wrong thing in should be
+    /// told what is wrong with it, not handed "invalid BGZF header".
+    #[cfg(unix)]
+    #[test]
+    fn an_empty_stream_is_named_as_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let Err(err) = open_via_fifo(Vec::new(), &dir) else {
+            panic!("an empty stream must be an error");
+        };
+
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        assert!(err.to_string().contains("empty"), "got: {err}");
+    }
+
+    /// gzip wrapped around gzip: the inner classification sees gzip again, which
+    /// no fgumi reader decodes. Named explicitly rather than left to fail as a
+    /// corrupt BAM header.
+    #[cfg(unix)]
+    #[test]
+    fn a_doubly_gzipped_stream_is_rejected_by_name() {
+        use flate2::write::GzEncoder;
+
+        let gzip_once = |bytes: &[u8]| {
+            let mut e = GzEncoder::new(Vec::new(), flate2::Compression::fast());
+            e.write_all(bytes).expect("gzip");
+            e.finish().expect("finish gzip member")
+        };
+        let doubled = gzip_once(&gzip_once(SAM_TEXT.as_bytes()));
+
+        let dir = tempfile::tempdir().unwrap();
+        let Err(err) = open_via_fifo(doubled, &dir) else {
+            panic!("a doubly-gzipped stream must be an error");
+        };
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("more than once"), "got: {err}");
+    }
+
+    /// A well-formed gzip member carrying nothing: the outer classification
+    /// succeeds and the *inner* one is `Empty`, a different branch from the
+    /// empty-stream case above.
+    #[cfg(unix)]
+    #[test]
+    fn a_gzip_member_that_decompresses_to_nothing_is_named() {
+        use flate2::write::GzEncoder;
+
+        let encoder = GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        let empty_member = encoder.finish().expect("finish an empty gzip member");
+        assert_eq!(empty_member[0], 0x1f, "still a well-formed gzip member");
+
+        let dir = tempfile::tempdir().unwrap();
+        let Err(err) = open_via_fifo(empty_member, &dir) else {
+            panic!("an empty gzip member must be an error");
+        };
+
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        assert!(err.to_string().contains("empty gzip member"), "got: {err}");
+    }
+
+    /// The regular-file branch has its own `Empty` arm, reached without any pipe.
+    #[test]
+    fn an_empty_suffix_less_file_is_named_as_empty() {
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        let Err(err) = InputSource::open(&path) else {
+            panic!("an empty file must be an error");
+        };
+
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        assert!(err.to_string().contains("input is empty"), "got: {err}");
+    }
+
+    /// The same path must still resolve gzipped *BAM* to BAM: the verdict comes
+    /// from what the member decompresses to, not from the outer wrapper.
+    #[cfg(unix)]
+    #[test]
+    fn suffix_less_plain_gzip_bam_over_a_pipe_is_read_as_bam() {
+        use flate2::write::GzEncoder;
+
+        let bam_bytes = std::fs::read(write_bam("")).unwrap();
+        let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        encoder.write_all(&bam_bytes).expect("gzip the BAM bytes");
+        let gzipped = encoder.finish().expect("finish gzip member");
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = open_via_fifo(gzipped, &dir).expect("gzipped BAM opens");
+
+        assert!(matches!(source, InputSource::Bam { .. }));
+        assert_eq!(source.header().reference_sequences().len(), 1);
+    }
+
+    /// A suffix-less BGZF input that is **not** a regular file must be read
+    /// through the buffer that already holds the peeked bytes. Re-opening the
+    /// path — which is what a regular file gets, to keep the async-reader
+    /// wiring — would hand back the stream *minus* the bytes `fill_buf` already
+    /// drained out of the pipe, so the BAM header would be gone. This is the
+    /// `<(...)` process-substitution and named-pipe case.
+    ///
+    /// A regression here manifests as a hang rather than an assertion failure:
+    /// the re-open blocks forever waiting for a second writer that never comes.
+    #[cfg(unix)]
+    #[test]
+    fn suffix_less_bam_from_a_fifo_keeps_the_peeked_bytes() {
+        let bam_bytes = std::fs::read(write_bam("")).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let fifo = dir.path().join("stream"); // deliberately no extension
+        let status = std::process::Command::new("mkfifo").arg(&fifo).status().expect("mkfifo runs");
+        assert!(status.success(), "mkfifo failed for {}", fifo.display());
+
+        // Opening a FIFO for writing blocks until a reader opens it, so the
+        // writer has to run concurrently with the `open` below. The payload is
+        // far under the pipe buffer, so the writer never blocks on a full pipe.
+        let writer_path = fifo.clone();
+        let writer = std::thread::spawn(move || {
+            let mut f = std::fs::File::create(&writer_path).expect("open fifo for write");
+            f.write_all(&bam_bytes).expect("write bam to fifo");
+        });
+
+        let source = InputSource::open(&fifo).expect("fifo opens as BAM");
+        assert!(matches!(source, InputSource::Bam { .. }));
+        assert_eq!(source.header().reference_sequences().len(), 1);
+
+        writer.join().expect("writer thread joins");
+    }
+
+    /// `header()` is the variant-agnostic accessor commands use before they
+    /// branch on the input shape, so it must resolve for both variants.
+    #[test]
+    fn header_accessor_resolves_for_both_variants() {
+        let sam_path = tempfile::NamedTempFile::with_suffix(".sam").unwrap().into_temp_path();
+        std::fs::File::create(&sam_path).unwrap().write_all(SAM_TEXT.as_bytes()).unwrap();
+        let sam = InputSource::open(&sam_path).unwrap();
+        assert!(matches!(sam, InputSource::Sam { .. }));
+        assert_eq!(sam.header().reference_sequences().len(), 1);
+
+        let bam = InputSource::open(write_bam(".bam")).unwrap();
+        assert!(matches!(bam, InputSource::Bam { .. }));
+        assert_eq!(bam.header().reference_sequences().len(), 1);
+    }
+
+    /// The stdin BAM path cannot re-open by path, so it tees the header-probe
+    /// bytes and replays them ahead of the remaining stream. Driving the helper
+    /// directly over an in-memory BAM covers that replay without needing a real
+    /// stdin: the parsed header must come back, and the returned reader must
+    /// still begin at byte 0 of the BAM stream (magic included) so the
+    /// downstream boundary step can strip the header itself.
+    #[test]
+    fn stdin_bam_path_replays_the_consumed_header_bytes() {
+        let bytes = std::fs::read(write_bam(".bam")).unwrap();
+        let buf: Box<dyn BufRead + Send> = Box::new(BufReader::new(io::Cursor::new(bytes.clone())));
+
+        let source = open_bam_from_stdin_boxed_buf(buf).unwrap();
+        let InputSource::Bam { mut reader, header } = source else {
+            panic!("expected BAM source");
+        };
+        assert_eq!(header.reference_sequences().len(), 1);
+
+        // The replayed stream must be byte-identical to the original file: the
+        // header probe consumed bytes that `ChainedReader` has to hand back.
+        let mut replayed = Vec::new();
+        reader.read_to_end(&mut replayed).unwrap();
+        assert_eq!(replayed, bytes, "the teed header bytes must be replayed intact");
+    }
+
+    /// A `.sam`-suffixed file whose header does not parse must surface an error
+    /// rather than yielding a source with an empty header.
+    #[test]
+    fn a_malformed_sam_header_is_an_error() {
+        let path = tempfile::NamedTempFile::with_suffix(".sam").unwrap().into_temp_path();
+        std::fs::File::create(&path).unwrap().write_all(b"@HD\tthis is not a valid tag\n").unwrap();
+        assert!(InputSource::open(&path).is_err());
+    }
+
+    /// Opening a path that does not exist must be an error, not a panic — and
+    /// must keep the original [`io::ErrorKind`] and name the path.
+    ///
+    /// `open_error` exists precisely so `io::Error::other` does not flatten
+    /// `NotFound` into `Other`, which would cost callers the distinction between
+    /// "no such file" and "permission denied". Asserting only `is_err()` would
+    /// let a regression back to `io::Error::other` pass unnoticed, so both
+    /// properties are pinned here. One case per branch that can fail to open: the
+    /// `.sam` and suffix-less branches go through `open_error`, and the `.bam`
+    /// branch through `open_bam_error`, which has to recover the kind from an
+    /// `anyhow::Error` chain rather than from an `io::Error` directly.
+    #[rstest]
+    #[case::sam_suffix("/nonexistent/fgumi-test-input.sam")]
+    #[case::bam_suffix("/nonexistent/fgumi-test-input.bam")]
+    #[case::suffix_less_path("/nonexistent/fgumi-test-input")]
+    fn a_missing_file_reports_not_found_with_its_path(#[case] path: &str) {
+        let Err(err) = InputSource::open(path) else {
+            panic!("opening {path} must be an error");
+        };
+
+        assert_eq!(err.kind(), io::ErrorKind::NotFound, "kind must survive the wrap: {err}");
+        assert!(err.to_string().contains(path), "the message must name the path; got: {err}");
+    }
+}

--- a/src/lib/pipeline/steps/source/pair_fastq.rs
+++ b/src/lib/pipeline/steps/source/pair_fastq.rs
@@ -1,0 +1,1017 @@
+//! `PairRawFastq` step: a cheap two-input chunk-level pairing step that joins
+//! the `FastqRawChunk` streams emitted by two concurrent per-stream
+//! [`ReadFastqInputs`] readers (R1 + R2) into a single
+//! [`PairedRawFastqBatch`] stream for the downstream `Parallel`
+//! [`ParseAndZipFastq`] step.
+//!
+//! `Serial` + `Affinity::None`. This step mirrors the legacy pipeline's
+//! `FindBoundaries` stage: it does the cheap chunk-level pairing serially
+//! (matching the R1 chunk and R2 chunk at the same `chunk_serial`) and assigns
+//! a fresh, globally-unique, monotonically-increasing `ordinal` to each emitted
+//! pair. The expensive per-record FASTQ parse and template build then run in
+//! parallel in [`ParseAndZipFastq`].
+//!
+//! [`ReadFastqInputs`]: super::read_fastq::ReadFastqInputs
+//! [`ParseAndZipFastq`]: super::parse_zip_fastq::ParseAndZipFastq
+//!
+//! ## Why serial ordinal assignment is load-bearing
+//!
+//! [`ParseAndZipFastq`] is `Parallel` + `ByItemOrdinal`, so the framework
+//! reorders its output by each item's `ordinal()`. For that reorder to be
+//! correct the ordinals MUST be globally unique and dense. Assigning them here,
+//! serially, from a single `next_ordinal` counter on this step guarantees both
+//! properties. (The per-`FastqRawChunk` ordinal from the readers is NOT reused
+//! — two readers each carry their own ordinal sequence; we mint a fresh one for
+//! the paired batch.)
+//!
+//! ## Completion
+//!
+//! `try_run` opportunistically buffers whichever branch has a chunk ready and
+//! emits a pair as soon as both streams' chunks for the lowest `chunk_serial`
+//! are present. Once **both** input branches are drained, `finalize_pairs`
+//! flushes the remaining complete pairs in `chunk_serial` order (one per call)
+//! and returns `StepOutcome::Finished`, bailing with an error if either stream
+//! ran short.
+
+use std::collections::BTreeMap;
+use std::io;
+
+use super::read_fastq::FastqRawChunk;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::item::{HeapSize, Ordered};
+use crate::pipeline::core::step::Affinity;
+use crate::pipeline::core::{
+    BranchOrdering, OrderedBytesSingle, QueueSpec, Step2, StepCtx2, StepKind, StepOutcome,
+    StepProfile, Unpushed,
+};
+
+/// Backpressure cap on the total bytes buffered across the two partial-pair
+/// slots. Mirrors `ZipFastqRecords::DEFAULT_PENDING_BACKPRESSURE_BYTES`.
+const DEFAULT_PENDING_BACKPRESSURE_BYTES: usize = 256 * 1024 * 1024;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PairedRawFastqBatch — the raw bytes of one R1 chunk + one R2 chunk that share
+// a chunk_serial, plus a freshly-minted globally-unique ordinal.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A matched pair of raw (decompressed, unparsed) FASTQ byte chunks — one from
+/// stream A (R1) and one from stream B (R2) — that share a `chunk_serial`.
+///
+/// `ordinal` is minted serially by [`PairRawFastq`] and is the key the
+/// framework uses to reorder the `Parallel` [`ParseAndZipFastq`] output.
+/// `chunk_serial` is carried through for diagnostics / desync messages only.
+///
+/// [`ParseAndZipFastq`]: super::parse_zip_fastq::ParseAndZipFastq
+pub struct PairedRawFastqBatch {
+    /// Globally-unique monotonic ordinal, minted by [`PairRawFastq`].
+    pub ordinal: u64,
+    /// The shared per-stream round-robin cycle serial (for desync diagnostics).
+    pub chunk_serial: u64,
+    /// Raw bytes of the stream-A (R1) chunk, whole-record-aligned.
+    pub data_a: Vec<u8>,
+    /// Raw bytes of the stream-B (R2) chunk, whole-record-aligned.
+    pub data_b: Vec<u8>,
+}
+
+impl HeapSize for PairedRawFastqBatch {
+    fn heap_size(&self) -> usize {
+        // Allocated capacity, not logical length. `try_emit_complete` moves the
+        // two `FastqRawChunk::data` buffers in verbatim, and those were built by
+        // `read_fastq_raw_bytes_from_bufread` with `Vec::with_capacity`, so
+        // capacity exceeds length on any short chunk (the final partial batch,
+        // or reads shorter than the per-record estimate). `FastqRawChunk::heap_size`
+        // and `pending_total_bytes` both account by capacity; measuring `len()`
+        // here would make the byte-bounded output queue under-count the memory it
+        // is holding.
+        self.data_a.capacity() + self.data_b.capacity()
+    }
+}
+
+impl Ordered for PairedRawFastqBatch {
+    fn ordinal(&self) -> u64 {
+        self.ordinal
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PairRawFastq — Serial two-input pairing step
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// `Serial` two-input chunk-level pairing step. Buffers the most recent
+/// unmatched chunk from each stream keyed by `chunk_serial`; once both streams
+/// have produced their chunk for the lowest pending `chunk_serial`, emits a
+/// [`PairedRawFastqBatch`] with a fresh `ordinal`.
+pub struct PairRawFastq {
+    /// Partial pairs keyed by `chunk_serial`. Each value is `(Option<a>,
+    /// Option<b>)`; a complete pair is emitted (and removed) as soon as both
+    /// slots are filled and it is the lowest pending serial.
+    pending: BTreeMap<u64, (Option<FastqRawChunk>, Option<FastqRawChunk>)>,
+    pending_total_bytes: usize,
+    pending_backpressure_bytes: usize,
+    /// Serial, monotonic ordinal assignment point for the downstream parallel
+    /// reorder. Incremented once per emitted pair.
+    next_ordinal: u64,
+    held: HeldSlot<Unpushed<PairedRawFastqBatch>>,
+    output_byte_limit: u64,
+}
+
+impl PairRawFastq {
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self {
+            pending: BTreeMap::new(),
+            pending_total_bytes: 0,
+            pending_backpressure_bytes: DEFAULT_PENDING_BACKPRESSURE_BYTES,
+            next_ordinal: 0,
+            held: HeldSlot::new(),
+            output_byte_limit,
+        }
+    }
+
+    /// Override the soft pending-backpressure limit (test-only).
+    ///
+    /// Production wires the default 256 MiB limit; tests shrink it to a few
+    /// bytes so a skewed-completion scenario can cross it with a handful of
+    /// small chunks rather than hundreds of megabytes of data.
+    #[cfg(test)]
+    fn with_backpressure_bytes(mut self, bytes: usize) -> Self {
+        self.pending_backpressure_bytes = bytes;
+        self
+    }
+
+    /// Buffer a chunk from stream A (slot 0) or stream B (slot 1).
+    ///
+    /// Each reader mints exactly one chunk per `(chunk_serial, stream)`, so a
+    /// target slot is always `None` here. The byte accounting (X5-004) depends
+    /// on that invariant: it adds `chunk.data.capacity()` to `pending_total_bytes`,
+    /// which feeds the catastrophic-desync guard and the backpressure decision.
+    /// A *hard* `assert!` enforces single-chunk-per-serial in release builds
+    /// too: overwriting an already-filled slot would silently change emitted
+    /// read identity (and drift the byte total), so a retry/replay/re-chunk
+    /// regression must fail fast rather than corrupt output.
+    fn buffer_chunk(&mut self, chunk: FastqRawChunk, is_a: bool) {
+        self.pending_total_bytes += chunk.data.capacity();
+        let entry = self.pending.entry(chunk.chunk_serial).or_insert((None, None));
+        let slot = if is_a { &mut entry.0 } else { &mut entry.1 };
+        assert!(
+            slot.is_none(),
+            "duplicate chunk for serial {} stream {}: single-chunk-per-serial invariant violated",
+            chunk.chunk_serial,
+            if is_a { "A" } else { "B" },
+        );
+        *slot = Some(chunk);
+    }
+
+    /// If the lowest pending `chunk_serial` has both stream slots filled, remove
+    /// it and produce a `PairedRawFastqBatch` with a fresh ordinal.
+    fn try_emit_complete(&mut self) -> Option<PairedRawFastqBatch> {
+        let lowest_serial = *self.pending.keys().next()?;
+        let entry = self.pending.get(&lowest_serial)?;
+        if entry.0.is_none() || entry.1.is_none() {
+            return None;
+        }
+
+        let (a, b) = self.pending.remove(&lowest_serial).unwrap();
+        let a = a.unwrap();
+        let b = b.unwrap();
+        self.pending_total_bytes =
+            self.pending_total_bytes.saturating_sub(a.data.capacity() + b.data.capacity());
+
+        let ordinal = self.next_ordinal;
+        self.next_ordinal += 1;
+        Some(PairedRawFastqBatch {
+            ordinal,
+            chunk_serial: lowest_serial,
+            data_a: a.data,
+            data_b: b.data,
+        })
+    }
+}
+
+/// Decide which input branches to pull this dispatch, given backpressure state.
+///
+/// Returns `(pull_a, pull_b)`. The pending-pair buffer must be byte-bounded, but
+/// bounding it by globally refusing to pull deadlocks: when one FASTQ stream
+/// races ahead, the buffer fills with its unmatched chunks, and the chunk needed
+/// to complete the lowest pending pair sits unpulled in the *behind* stream's
+/// queue. So under backpressure we still pull whichever stream is missing from
+/// the front (lowest pending) pair — the pull that lets the front pair emit and
+/// the buffer drain — and throttle only the stream that is already ahead.
+///
+/// - Not over the limit → pull both (normal streaming).
+/// - Over the limit, front pair missing a slot → pull only that (behind) stream.
+/// - Over the limit, front pair already complete (or no pending) → pull neither;
+///   the caller drains via `try_emit_complete` instead of accumulating more.
+fn pull_decision(
+    over_backpressure: bool,
+    front_missing_a: bool,
+    front_missing_b: bool,
+) -> (bool, bool) {
+    if !over_backpressure {
+        return (true, true);
+    }
+    (front_missing_a, front_missing_b)
+}
+
+impl Step2 for PairRawFastq {
+    type InputA = FastqRawChunk;
+    type InputB = FastqRawChunk;
+    type Outputs = OrderedBytesSingle<PairedRawFastqBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "PairRawFastq",
+            kind: StepKind::Serial,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            // FIFO (no reorder stage) is BOTH correct and required for
+            // throughput here. Each emitted `PairedRawFastqBatch` already
+            // carries a dense, globally-unique `ordinal` minted serially by
+            // this step, and the downstream `ParseAndZipFastq` is Parallel +
+            // `ByItemOrdinal`, so it re-establishes input order by that
+            // ordinal regardless of arrival order. Imposing `ByItemOrdinal`
+            // on THIS edge would insert a `ReorderStage` that releases items
+            // strictly one-at-a-time in ordinal order, serializing the
+            // Parallel consumer (its workers would contend on a single
+            // `next_serial` slot) and defeating the whole point of moving the
+            // parse + template build into a Parallel step. This mirrors the
+            // legacy `MergeFastqRawChunks` → `ParseFastqChunks` edge, which
+            // was FIFO for the same reason.
+            branch_ordering: vec![BranchOrdering::None],
+        }
+    }
+
+    fn affinity(&self) -> Affinity {
+        // Let any free worker drive the pairing; pinning it to a reader's
+        // worker would serialize read + pair on one thread.
+        Affinity::None
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx2<'_, Self>) -> io::Result<StepOutcome> {
+        // 1. Drain held output slot first.
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        // 2. Catastrophic-desync guard: one stream producing far more data
+        //    than its counterpart balloons the partial-pair buffer. With the
+        //    per-stream backpressure below this should never trip (the ahead
+        //    stream is throttled at 1x), but keep it as a safety net.
+        if self.pending_total_bytes > 2 * self.pending_backpressure_bytes {
+            return Err(io::Error::other(format!(
+                "PairRawFastq: catastrophic stream desync — pending buffer ({} bytes) \
+                 exceeds 2x backpressure limit ({} bytes). One FASTQ stream is producing \
+                 far more data than its counterpart.",
+                self.pending_total_bytes, self.pending_backpressure_bytes
+            )));
+        }
+
+        // 3. Drain available chunks and emit every pair we can in this dispatch.
+        //    Doing this in a loop (rather than one chunk per call) amortizes the
+        //    Serial mutex / dispatch overhead and keeps the downstream Parallel
+        //    `ParseAndZipFastq` workers fed.
+        //
+        //    Backpressure is PER-STREAM, not global: once the pending buffer is
+        //    over the limit we keep pulling whichever stream is missing from the
+        //    lowest pending pair (the pull that completes it and drains the
+        //    buffer) and throttle only the stream that is ahead. Globally
+        //    refusing to pull here deadlocks — the completing chunk sits unpulled
+        //    in the behind stream's full queue while the buffer never drains
+        //    (a fast aligner makes the front-end run fast enough to desync the
+        //    R1/R2 readers past the limit and trip this).
+        let mut pulled = false;
+        let mut emitted = false;
+        loop {
+            let over_backpressure = self.pending_total_bytes > self.pending_backpressure_bytes;
+            let (front_missing_a, front_missing_b) = match self.pending.values().next() {
+                Some((a, b)) => (a.is_none(), b.is_none()),
+                None => (false, false),
+            };
+            let (pull_a, pull_b) =
+                pull_decision(over_backpressure, front_missing_a, front_missing_b);
+
+            let mut pulled_this_iter = false;
+            if pull_a && let Some(chunk) = ctx.a.pop() {
+                self.buffer_chunk(chunk, /* is_a */ true);
+                pulled_this_iter = true;
+            }
+            if pull_b && let Some(chunk) = ctx.b.pop() {
+                self.buffer_chunk(chunk, /* is_a */ false);
+                pulled_this_iter = true;
+            }
+            pulled |= pulled_this_iter;
+
+            // Emit every complete pair currently at the front of the buffer.
+            while let Some(pair) = self.try_emit_complete() {
+                emitted = true;
+                if let Err(unpushed) = ctx.outputs.push(pair) {
+                    // Output queue is full: hold the rejected pair and yield so
+                    // the downstream consumer can drain it.
+                    self.held.put(unpushed);
+                    return Ok(StepOutcome::Progress);
+                }
+            }
+
+            // Stop when neither branch yielded a new chunk this iteration.
+            if !pulled_this_iter {
+                break;
+            }
+        }
+
+        if pulled || emitted {
+            return Ok(StepOutcome::Progress);
+        }
+
+        // Nothing pulled or emitted this call. When over backpressure, pulling
+        // of the surplus (ahead) stream has stopped, so if the front pending pair
+        // is missing a record from a stream that is already drained, that stream
+        // can never complete the pair AND the ahead stream can never drain —
+        // `finalize_pairs` (both-drained) is unreachable, and `pending_total_bytes`
+        // plateaus below the 2x catastrophic-desync abort so that guard never
+        // fires either. This is the unequal-record-count case (e.g. a truncated
+        // R1): fail fast instead of spinning `NoProgress` forever (a silent hang).
+        // Under normal backpressure both streams still drain and the richer
+        // `finalize_pairs` desync report handles the mismatch.
+        if self.pending_total_bytes > self.pending_backpressure_bytes
+            && let Some((&serial, (a_slot, b_slot))) = self.pending.iter().next()
+        {
+            let a_short = a_slot.is_none() && ctx.a.is_drained();
+            let b_short = b_slot.is_none() && ctx.b.is_drained();
+            if a_short || b_short {
+                // The stream whose front slot is missing is the one that ended
+                // early. Report through the shared helper so this mid-stream
+                // fail-fast names the short stream and orphaned serial exactly
+                // like the both-drained `finalize_pairs` path.
+                let short_stream = usize::from(!a_short);
+                return Err(out_of_sync_error(short_stream, serial));
+            }
+        }
+
+        // If both input branches are drained, the pairing is complete — flush
+        // remaining pairs and finish.
+        if ctx.a.is_drained() && ctx.b.is_drained() {
+            return self.finalize_pairs(ctx);
+        }
+        Ok(StepOutcome::NoProgress)
+    }
+}
+
+/// Build the canonical FASTQ out-of-sync error identifying the stream that ended
+/// early. `short_stream` is the 0-based index of the stream that ran out of
+/// records first (0 = R1/A, 1 = R2/B) and `chunk_serial` is the orphaned serial
+/// still holding only the other stream's chunk.
+///
+/// Shared by both fail paths — the both-drained [`PairRawFastq::finalize_pairs`]
+/// desync report and the over-backpressure mid-stream fail-fast — so the two
+/// surface byte-for-byte identical diagnostics regardless of which path detects
+/// the mismatch.
+fn out_of_sync_error(short_stream: usize, chunk_serial: u64) -> io::Error {
+    io::Error::other(format!(
+        "FASTQ sources out of sync: stream {short_stream} ended before chunk_serial \
+         {chunk_serial} while the other stream had more records"
+    ))
+}
+
+impl PairRawFastq {
+    /// Both input branches are drained: emit the next remaining complete pair
+    /// (in `chunk_serial` order), or report `Finished` once `pending` is empty.
+    /// Any serial holding only one stream's chunk means the two FASTQ streams
+    /// desynchronized (unequal record counts) — a fatal error. One pair per
+    /// call (re-dispatched); a bounced push is parked in `held` and retried by
+    /// `try_run`'s held-drain preamble next pass.
+    fn finalize_pairs(&mut self, ctx: &mut StepCtx2<'_, Self>) -> io::Result<StepOutcome> {
+        let Some(&lowest_serial) = self.pending.keys().next() else {
+            return Ok(StepOutcome::Finished);
+        };
+        let entry = self.pending.get(&lowest_serial).unwrap();
+        if entry.0.is_none() || entry.1.is_none() {
+            let short = usize::from(entry.0.is_some());
+            return Err(out_of_sync_error(short, lowest_serial));
+        }
+        let pair = self.try_emit_complete().expect("entry is complete");
+        if let Err(unpushed) = ctx.outputs.push(pair) {
+            self.held.put(unpushed);
+        }
+        Ok(StepOutcome::Progress)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chunk(stream_idx: usize, chunk_serial: u64, data: &[u8]) -> FastqRawChunk {
+        // The pairing reads only `chunk_serial` and `data`; ordinal/stream_idx
+        // are carried by the readers but irrelevant to the pair join. Derive a
+        // deterministic ordinal for clarity.
+        let ordinal = chunk_serial * 2 + stream_idx as u64;
+        FastqRawChunk { ordinal, stream_idx, chunk_serial, data: data.to_vec() }
+    }
+
+    #[test]
+    fn pull_decision_pulls_both_when_not_backpressured() {
+        assert_eq!(pull_decision(false, true, true), (true, true));
+        assert_eq!(pull_decision(false, false, false), (true, true));
+    }
+
+    #[test]
+    fn pull_decision_under_backpressure_pulls_only_the_behind_stream() {
+        // The deadlock fix: when over the limit and the front pair is missing
+        // B, we MUST still pull B (the behind stream) so the pair can complete
+        // and the buffer drain — never refuse the completing pull.
+        assert_eq!(pull_decision(true, false, true), (false, true), "missing B → pull B only");
+        assert_eq!(pull_decision(true, true, false), (true, false), "missing A → pull A only");
+    }
+
+    #[test]
+    fn pull_decision_under_backpressure_with_complete_front_pulls_neither() {
+        // Front pair is complete; draining (emit) is the way forward, not pulling
+        // more — so throttle both streams.
+        assert_eq!(pull_decision(true, false, false), (false, false));
+    }
+
+    #[test]
+    fn paired_batch_heap_size_and_ordinal() {
+        let batch = PairedRawFastqBatch {
+            ordinal: 9,
+            chunk_serial: 3,
+            data_a: vec![0u8; 10],
+            data_b: vec![0u8; 7],
+        };
+        assert_eq!(batch.heap_size(), 17);
+        assert_eq!(batch.ordinal(), 9);
+    }
+
+    /// `heap_size` must report the memory the batch actually holds, which for a
+    /// short chunk is the reader's over-allocated capacity rather than the byte
+    /// count. Built with explicit spare capacity so the two differ — a `vec![]`
+    /// of exact length cannot tell `len()` and `capacity()` apart.
+    #[test]
+    fn paired_batch_heap_size_counts_spare_capacity() {
+        let mut data_a = Vec::with_capacity(300);
+        data_a.extend_from_slice(&[0u8; 10]);
+        let mut data_b = Vec::with_capacity(300);
+        data_b.extend_from_slice(&[0u8; 7]);
+        let (cap_a, cap_b) = (data_a.capacity(), data_b.capacity());
+
+        let batch = PairedRawFastqBatch { ordinal: 0, chunk_serial: 0, data_a, data_b };
+
+        assert_eq!(batch.heap_size(), cap_a + cap_b);
+        assert!(
+            batch.heap_size() > 17,
+            "heap_size must exceed the 17 live bytes; got {}",
+            batch.heap_size()
+        );
+    }
+
+    #[test]
+    fn profile_advertises_serial_fifo() {
+        let step = PairRawFastq::new(1024);
+        let p = step.profile();
+        assert_eq!(p.name, "PairRawFastq");
+        assert_eq!(p.kind, StepKind::Serial);
+        assert!(!p.sticky);
+        assert_eq!(step.affinity(), Affinity::None);
+        // FIFO on this edge: the items carry a dense ordinal and the Parallel
+        // downstream reorders, so a reorder stage here would needlessly
+        // serialize the consumer.
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::None]);
+        assert!(matches!(p.output_queues[0], QueueSpec::ByteBounded { .. }));
+    }
+
+    /// X5-004: a duplicate chunk for an already-filled `(chunk_serial, stream)`
+    /// slot violates the single-chunk-per-serial invariant the byte accounting
+    /// depends on. The hard `assert!` in `buffer_chunk` must catch it in all
+    /// builds rather than letting `pending_total_bytes` silently drift.
+    #[test]
+    #[should_panic(expected = "single-chunk-per-serial invariant violated")]
+    fn buffer_chunk_rejects_duplicate_slot() {
+        let mut step = PairRawFastq::new(64 * 1024);
+        step.buffer_chunk(chunk(0, 0, b"raw_a0"), true);
+        // Second chunk for the same (serial 0, stream A) slot — must trip the guard.
+        step.buffer_chunk(chunk(0, 0, b"raw_a0_again"), true);
+    }
+
+    /// Buffering a-then-b for a serial completes the pair; out-of-order serial
+    /// arrival still emits in `chunk_serial` order with dense ordinals.
+    #[test]
+    fn pairs_in_chunk_serial_order_with_fresh_dense_ordinals() {
+        let mut step = PairRawFastq::new(64 * 1024 * 1024);
+
+        // Buffer serial 0 (A then B) and serial 1 (B then A) interleaved.
+        step.buffer_chunk(chunk(0, 0, b"raw_a0"), true);
+        assert!(step.try_emit_complete().is_none(), "serial 0 missing B");
+        step.buffer_chunk(chunk(1, 1, b"raw_b1"), false);
+        assert!(step.try_emit_complete().is_none(), "lowest serial 0 still missing B");
+        step.buffer_chunk(chunk(1, 0, b"raw_b0"), false);
+
+        // Now serial 0 is complete and is the lowest → emits first, ordinal 0.
+        let p0 = step.try_emit_complete().unwrap();
+        assert_eq!(p0.ordinal, 0);
+        assert_eq!(p0.chunk_serial, 0);
+        assert_eq!(p0.data_a, b"raw_a0");
+        assert_eq!(p0.data_b, b"raw_b0");
+
+        // serial 1 still missing A.
+        assert!(step.try_emit_complete().is_none());
+        step.buffer_chunk(chunk(0, 1, b"raw_a1"), true);
+        let p1 = step.try_emit_complete().unwrap();
+        assert_eq!(p1.ordinal, 1, "ordinals are dense and monotonic");
+        assert_eq!(p1.chunk_serial, 1);
+        assert_eq!(p1.data_a, b"raw_a1");
+        assert_eq!(p1.data_b, b"raw_b1");
+
+        assert_eq!(step.pending_total_bytes, 0);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // X3-003: drive the paired-FASTQ source through a REAL fused chain under
+    // back-pressure with skewed stream completion, on a watchdog thread.
+    //
+    // The in-module `pull_decision` tests above only check the decision
+    // predicate in isolation. This test exercises the actual `PairRawFastq`
+    // step inside a `Pipeline` with a tiny byte limit and one stream (R1)
+    // racing far ahead of the other (R2): R1 emits ALL its chunks before R2
+    // emits any. The partial-pair buffer crosses the limit while the front
+    // pair is missing R2; the deadlock fix must keep pulling R2 (the behind
+    // stream) so the front pair completes and the buffer drains. A regression
+    // that globally refuses to pull under back-pressure wedges the step, and
+    // the watchdog fires.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrd};
+
+    use crate::pipeline::core::{PipelineBuilder, PipelineConfig, Step, StepCtx};
+
+    /// Bytes per emitted raw chunk. Sized so that buffering a SINGLE unmatched
+    /// leader chunk already crosses the pairing step's soft byte limit — that
+    /// way the partial-pair buffer is over-limit with the front pair missing
+    /// its R2 slot, which is exactly the state where a "refuse all pulls under
+    /// back-pressure" regression deadlocks (it will not pull the available R2
+    /// chunk that would complete the front pair and drain the buffer).
+    const X3_CHUNK_BYTES: usize = 1024;
+    /// Number of chunk serials each stream emits.
+    const X3_N_SERIALS: u64 = 16;
+    /// Soft backpressure limit for the pairing step under test. Sized so a
+    /// single buffered unmatched chunk crosses the SOFT limit (1x) but stays
+    /// under the HARD desync limit (2x): `768 < 1024 (one chunk) < 1536`. This
+    /// puts the step in the over-soft-limit / front-pair-incomplete regime that
+    /// the deadlock fix targets, WITHOUT tripping the catastrophic-desync abort.
+    const X3_SOFT_LIMIT_BYTES: usize = 768;
+    /// Per-source output-queue byte limit. Small (a few chunks) so a
+    /// back-pressured pairing step leaves a source's output queue full and that
+    /// source cannot drain — the precondition for the deadlock to manifest (if
+    /// the streams always drained, `finalize_pairs` would flush everything even
+    /// under a refuse-to-pull regression, masking the bug).
+    const X3_SOURCE_QUEUE_BYTES: u64 = 4 * 1024;
+    /// R2 holds back until R1 has emitted this many chunks, so the front pair
+    /// (serial 0) is reliably buffered R1-first and over the limit with its R2
+    /// slot still missing. Kept minimal (just enough to order the front pair) so
+    /// it does not also stall the FIXED path, which over the limit pulls ONLY
+    /// the behind stream.
+    const X3_LAG_UNTIL: usize = 1;
+
+    /// Serial source emitting `FastqRawChunk`s for ONE stream, serials `0..N`,
+    /// at the given `stream_idx`. Mirrors the per-stream `ReadFastqInputs`
+    /// reader: one chunk per dispatch, each carrying a globally-unique ordinal.
+    ///
+    /// To force the skewed-completion regime the deadlock fix targets, the
+    /// stream is optionally gated on a shared "leader progress" counter: the
+    /// leader (R1) increments it on every emit, and the laggard (R2) refuses to
+    /// emit (`NoProgress`) until the leader has raced `lag_until` chunks ahead.
+    /// This piles the leader's unmatched chunks in `PairRawFastq`'s partial-pair
+    /// buffer past the byte limit while the front pair is still missing R2 —
+    /// exactly the state where a "refuse all pulls under back-pressure"
+    /// regression deadlocks (the completing R2 chunk is available but never
+    /// pulled).
+    struct OneStreamSource {
+        stream_idx: usize,
+        next_serial: u64,
+        n_serials: u64,
+        held: HeldSlot<Unpushed<FastqRawChunk>>,
+        output_byte_limit: u64,
+        /// Shared leader-progress counter (chunks the leader has emitted).
+        leader_progress: Arc<AtomicUsize>,
+        /// If `Some(n)`, this is the laggard: do not emit until the leader has
+        /// emitted at least `n` chunks. If `None`, this is the leader.
+        lag_until: Option<usize>,
+    }
+
+    impl OneStreamSource {
+        fn leader(
+            stream_idx: usize,
+            n_serials: u64,
+            output_byte_limit: u64,
+            leader_progress: Arc<AtomicUsize>,
+        ) -> Self {
+            Self {
+                stream_idx,
+                next_serial: 0,
+                n_serials,
+                held: HeldSlot::new(),
+                output_byte_limit,
+                leader_progress,
+                lag_until: None,
+            }
+        }
+
+        fn laggard(
+            stream_idx: usize,
+            n_serials: u64,
+            output_byte_limit: u64,
+            leader_progress: Arc<AtomicUsize>,
+            lag_until: usize,
+        ) -> Self {
+            Self {
+                stream_idx,
+                next_serial: 0,
+                n_serials,
+                held: HeldSlot::new(),
+                output_byte_limit,
+                leader_progress,
+                lag_until: Some(lag_until),
+            }
+        }
+    }
+
+    impl Step for OneStreamSource {
+        type Input = ();
+        type Outputs = OrderedBytesSingle<FastqRawChunk>;
+
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "OneStreamSource",
+                kind: StepKind::Serial,
+                sticky: false,
+                output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+                branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+            }
+        }
+
+        fn affinity(&self) -> Affinity {
+            // Distinct workers so R1 and R2 can race independently (mirrors the
+            // production per-stream reader affinities).
+            Affinity::Worker(self.stream_idx)
+        }
+
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            if let Some(unpushed) = self.held.take() {
+                match ctx.outputs.retry(unpushed) {
+                    Ok(()) => {}
+                    Err(again) => {
+                        self.held.put(again);
+                        return Ok(StepOutcome::Contention);
+                    }
+                }
+            }
+
+            if self.next_serial >= self.n_serials {
+                return Ok(StepOutcome::Finished);
+            }
+
+            // Laggard: stall until the leader has raced far enough ahead to
+            // pile its chunks past the byte limit with the front pair missing.
+            if let Some(lag_until) = self.lag_until
+                && self.leader_progress.load(AtomicOrd::Acquire) < lag_until
+            {
+                return Ok(StepOutcome::NoProgress);
+            }
+
+            let chunk_serial = self.next_serial;
+            self.next_serial += 1;
+
+            // Globally-unique ordinal across both streams (N == 2):
+            // serial*2 + stream_idx.
+            let ordinal = chunk_serial * 2 + self.stream_idx as u64;
+            let chunk = FastqRawChunk {
+                ordinal,
+                stream_idx: self.stream_idx,
+                chunk_serial,
+                data: vec![b'A'; X3_CHUNK_BYTES],
+            };
+            match ctx.outputs.push(chunk) {
+                Ok(()) => {
+                    if self.lag_until.is_none() {
+                        self.leader_progress.fetch_add(1, AtomicOrd::Release);
+                    }
+                    Ok(StepOutcome::Progress)
+                }
+                Err(unpushed) => {
+                    self.held.put(unpushed);
+                    if self.lag_until.is_none() {
+                        self.leader_progress.fetch_add(1, AtomicOrd::Release);
+                    }
+                    Ok(StepOutcome::Progress)
+                }
+            }
+        }
+    }
+
+    /// Serial sink that records each paired batch's `chunk_serial` in the order
+    /// it is popped. Declared `Serial` (not `Parallel`) so the recorded order is
+    /// exactly the emission order of the upstream `Serial` `PairRawFastq` step —
+    /// a `Parallel` sink would let multiple workers race on `pop()` and reorder
+    /// the observations, masking any ordering regression in the pairing step.
+    #[derive(Clone)]
+    struct PairSink {
+        seen_serials: Arc<Mutex<Vec<u64>>>,
+        count: Arc<AtomicUsize>,
+    }
+
+    impl Step for PairSink {
+        type Input = PairedRawFastqBatch;
+        type Outputs = ();
+
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "PairSink",
+                kind: StepKind::Serial,
+                sticky: false,
+                output_queues: vec![],
+                branch_ordering: vec![],
+            }
+        }
+
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            match ctx.input.pop() {
+                Some(batch) => {
+                    // Each emitted pair must carry equal-length R1/R2 data.
+                    assert_eq!(batch.data_a.len(), X3_CHUNK_BYTES);
+                    assert_eq!(batch.data_b.len(), X3_CHUNK_BYTES);
+                    self.seen_serials.lock().unwrap().push(batch.chunk_serial);
+                    self.count.fetch_add(1, AtomicOrd::Relaxed);
+                    Ok(StepOutcome::Progress)
+                }
+                None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+                None => Ok(StepOutcome::NoProgress),
+            }
+        }
+
+        fn new_worker_copy(&self) -> Self {
+            self.clone()
+        }
+    }
+
+    /// End-to-end: two per-stream sources (R1 races ahead, R2 lags) feed
+    /// `PairRawFastq` (tiny byte limit) which feeds a collecting sink. Driven on
+    /// a watchdog thread so the deadlock regression surfaces as a timeout. The
+    /// run must complete and emit every pair in `chunk_serial` order.
+    #[test]
+    fn pair_fastq_does_not_deadlock_under_backpressure_with_skewed_streams() {
+        use std::time::{Duration, Instant};
+
+        let seen = Arc::new(Mutex::new(Vec::<u64>::new()));
+        let count = Arc::new(AtomicUsize::new(0));
+
+        // R1 (leader) races ahead; R2 (laggard) stalls until R1 has emitted
+        // `X3_LAG_UNTIL` chunks, forcing the partial-pair buffer over the limit
+        // with the front pair missing R2.
+        let leader_progress = Arc::new(AtomicUsize::new(0));
+
+        let seen_for_thread = Arc::clone(&seen);
+        let count_for_thread = Arc::clone(&count);
+        let leader_for_thread = Arc::clone(&leader_progress);
+        let worker = std::thread::Builder::new()
+            .name("pair-fastq-x3-003".into())
+            .spawn(move || -> io::Result<()> {
+                let r1 = OneStreamSource::leader(
+                    0,
+                    X3_N_SERIALS,
+                    X3_SOURCE_QUEUE_BYTES,
+                    Arc::clone(&leader_for_thread),
+                );
+                let r2 = OneStreamSource::laggard(
+                    1,
+                    X3_N_SERIALS,
+                    X3_SOURCE_QUEUE_BYTES,
+                    leader_for_thread,
+                    X3_LAG_UNTIL,
+                );
+                let pair =
+                    PairRawFastq::new(64 * 1024).with_backpressure_bytes(X3_SOFT_LIMIT_BYTES);
+                let sink = PairSink { seen_serials: seen_for_thread, count: count_for_thread };
+
+                let builder = PipelineBuilder::new();
+                let r1_tail = builder.append_source(r1);
+                let r2_tail = builder.append_source(r2);
+                let pair_tail = builder.append_step2(pair, r1_tail, r2_tail);
+                builder.append_step(sink, pair_tail);
+
+                let pipeline = builder.build().map_err(io::Error::other)?;
+                // 3 workers: R1, R2, and a free worker for pairing/sink.
+                pipeline
+                    .run(PipelineConfig { threads: 3, ..Default::default() })
+                    .map_err(io::Error::other)
+            })
+            .expect("spawn pipeline worker");
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while !worker.is_finished() {
+            assert!(
+                Instant::now() < deadline,
+                "PairRawFastq pipeline did not finish within 30s — likely the X3-003 \
+                 refuse-to-pull-under-backpressure deadlock regression"
+            );
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        worker.join().expect("pipeline thread panicked").expect("pipeline run returned Err");
+
+        // Full output: one pair per serial, every serial present AND observed in
+        // ascending `chunk_serial` order. The Serial `PairSink` records in pop
+        // order, so we assert the observed vector directly (no sorting) — an
+        // out-of-order emission from `PairRawFastq` would now fail the test.
+        let serials = seen.lock().unwrap().clone();
+        assert_eq!(
+            serials.len(),
+            usize::try_from(X3_N_SERIALS).unwrap(),
+            "expected one emitted pair per serial, got {}",
+            serials.len()
+        );
+        let expected: Vec<u64> = (0..X3_N_SERIALS).collect();
+        assert_eq!(
+            serials, expected,
+            "every chunk_serial must be paired exactly once and emitted in order"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // S5a2-011: when the two FASTQ streams have UNEQUAL record counts, one
+    // stream's reader drains while the other still has a chunk for the lowest
+    // pending serial. `finalize_pairs` must abort with an "out of sync" error
+    // that names the stream index that ENDED EARLY (the missing one) — and it
+    // must do so symmetrically, whichever of the two streams is short. The
+    // `run_desync_harness` helper below drives both directions; the two tests
+    // assert the stream-1-short and stream-0-short cases respectively.
+    //
+    // Wiring mirrors the X3-003 harness above: two `OneStreamSource` leaders
+    // (no lag — we want clean end-of-stream desync at drain, not mid-stream
+    // backpressure), one feeding 3 serials and one feeding 2. Serial 2 buffers
+    // only the long stream's chunk; both readers then drain, `finalize_pairs`
+    // finds serial 2 holding one side present and the other missing, computes
+    // `short` from which side is absent, and reports "stream <short> ended
+    // before chunk_serial 2". The backpressure limit is kept generous so the
+    // catastrophic-desync hard-abort (2x) never fires first — the one-serial
+    // skew keeps the partial-pair buffer tiny.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// The long stream emits this many serials.
+    const DESYNC_LONG_SERIALS: u64 = 3;
+    /// The short stream emits this many serials (it ends one serial early).
+    const DESYNC_SHORT_SERIALS: u64 = 2;
+
+    /// Run the two-leader desync harness with `serials0` chunks on stream 0 and
+    /// `serials1` on stream 1, returning the pipeline run result. Whichever
+    /// stream is short drains first, leaving the lowest pending serial holding
+    /// only the long stream's chunk, so `finalize_pairs` must abort with an
+    /// "out of sync" error naming the SHORT (missing) stream index. Shared by
+    /// both desync tests so the stream-0-short and stream-1-short cases exercise
+    /// byte-for-byte the same wiring (only the lengths swap).
+    fn run_desync_harness(serials0: u64, serials1: u64) -> Result<(), String> {
+        run_desync_harness_with_backpressure(serials0, serials1, None)
+    }
+
+    fn run_desync_harness_with_backpressure(
+        serials0: u64,
+        serials1: u64,
+        backpressure_bytes: Option<usize>,
+    ) -> Result<(), String> {
+        use std::time::{Duration, Instant};
+
+        // Both sources are leaders with no lag gate; the shared counter is
+        // unused for ordering here but required by the constructor signature.
+        let unused_progress = Arc::new(AtomicUsize::new(0));
+
+        let progress_for_thread = Arc::clone(&unused_progress);
+        let worker = std::thread::Builder::new()
+            .name("pair-fastq-s5a2-011".into())
+            .spawn(move || -> Result<(), String> {
+                let stream0 = OneStreamSource::leader(
+                    0,
+                    serials0,
+                    X3_SOURCE_QUEUE_BYTES,
+                    Arc::clone(&progress_for_thread),
+                );
+                let stream1 = OneStreamSource::leader(
+                    1,
+                    serials1,
+                    X3_SOURCE_QUEUE_BYTES,
+                    progress_for_thread,
+                );
+                // Default (generous) backpressure lets the streams reach the
+                // end-of-stream `finalize_pairs` desync path; a small cap instead
+                // exercises the mid-stream fail-fast (surplus over 1x stops
+                // pulling before both branches drain).
+                let pair = match backpressure_bytes {
+                    Some(bytes) => PairRawFastq::new(64 * 1024).with_backpressure_bytes(bytes),
+                    None => PairRawFastq::new(64 * 1024),
+                };
+                let sink = PairSink {
+                    seen_serials: Arc::new(Mutex::new(Vec::new())),
+                    count: Arc::new(AtomicUsize::new(0)),
+                };
+
+                let builder = PipelineBuilder::new();
+                let tail0 = builder.append_source(stream0);
+                let tail1 = builder.append_source(stream1);
+                let pair_tail = builder.append_step2(pair, tail0, tail1);
+                builder.append_step(sink, pair_tail);
+
+                let pipeline = builder.build().map_err(|e| e.to_string())?;
+                pipeline
+                    .run(PipelineConfig { threads: 3, ..Default::default() })
+                    .map_err(|e| e.to_string())
+            })
+            .expect("spawn pipeline worker");
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while !worker.is_finished() {
+            assert!(
+                Instant::now() < deadline,
+                "PairRawFastq desync pipeline did not finish within 30s — likely a deadlock"
+            );
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        worker.join().expect("pipeline thread panicked")
+    }
+
+    #[test]
+    fn finalize_pairs_reports_desync_with_short_stream_index() {
+        // Stream 0 long (3 serials), stream 1 short (2): serial 2 buffers only
+        // stream 0's chunk, so `short = usize::from(entry.0.is_some()) = 1` and
+        // the error must name the MISSING (short) stream, index 1.
+        let result = run_desync_harness(DESYNC_LONG_SERIALS, DESYNC_SHORT_SERIALS);
+        let err = result.expect_err("unequal stream lengths must abort the pipeline run");
+        assert!(
+            err.contains("out of sync"),
+            "desync abort must report an out-of-sync error, got: {err}"
+        );
+        assert!(
+            err.contains("stream 1 ended before chunk_serial 2"),
+            "desync error must name the short stream (index 1) and the orphaned \
+             serial (2), got: {err}"
+        );
+    }
+
+    #[test]
+    fn finalize_pairs_reports_desync_when_stream_zero_is_short() {
+        // Mirror of the above with the lengths swapped: stream 0 short (2
+        // serials), stream 1 long (3). Serial 2 now buffers only stream 1's
+        // chunk, so the missing-stream index is 0 — guards the symmetric branch
+        // that a stream-1-only test would leave unexercised.
+        let result = run_desync_harness(DESYNC_SHORT_SERIALS, DESYNC_LONG_SERIALS);
+        let err = result.expect_err("unequal stream lengths must abort the pipeline run");
+        assert!(
+            err.contains("out of sync"),
+            "desync abort must report an out-of-sync error, got: {err}"
+        );
+        assert!(
+            err.contains("stream 0 ended before chunk_serial 2"),
+            "desync error must name the short stream (index 0) and the orphaned \
+             serial (2), got: {err}"
+        );
+    }
+
+    #[test]
+    fn truncated_stream_over_backpressure_fails_fast_instead_of_hanging() {
+        // Stream 0 (a) has 3 chunks (X3_CHUNK_BYTES each), stream 1 (b) has 1.
+        // With a small backpressure cap, after the first pair the surplus from
+        // stream 0 crosses 1x the cap, so per-stream backpressure STOPS pulling
+        // stream 0 — leaving its remaining chunks unpulled (so it never drains),
+        // and pending plateaus BELOW the 2x catastrophic-desync abort, which
+        // therefore never fires. The front pair is missing stream 1, which is
+        // drained. Pre-fix this spun `NoProgress` forever (the harness's 30s
+        // deadline would trip); the fix detects the unpairable record and fails
+        // fast. This also proves the run terminates (no hang).
+        let result = run_desync_harness_with_backpressure(3, 1, Some(X3_SOFT_LIMIT_BYTES));
+        let err = result.expect_err("truncated stream over backpressure must abort, not hang");
+        assert!(
+            err.contains("out of sync") && err.contains("stream 1 ended before chunk_serial 1"),
+            "backpressure fail-fast must reuse the shared out-of-sync error naming the \
+             short stream (index 1) and the orphaned serial (1), got: {err}"
+        );
+    }
+
+    #[test]
+    fn truncated_stream_zero_over_backpressure_fails_fast_instead_of_hanging() {
+        // Mirror of the above with the lengths swapped: stream 0 (a) has 1 chunk,
+        // stream 1 (b) has 3. Now the surplus is stream 1, and the front pair is
+        // missing stream 0, which is drained — so this drives the symmetric
+        // `a_slot.is_none() && ctx.a.is_drained()` branch that the stream-1-short
+        // test leaves unexercised. The abort must name the short stream (index 0).
+        let result = run_desync_harness_with_backpressure(1, 3, Some(X3_SOFT_LIMIT_BYTES));
+        let err = result.expect_err("truncated stream over backpressure must abort, not hang");
+        assert!(
+            err.contains("out of sync") && err.contains("stream 0 ended before chunk_serial 1"),
+            "backpressure fail-fast must reuse the shared out-of-sync error naming the \
+             short stream (index 0) and the orphaned serial (1), got: {err}"
+        );
+    }
+}

--- a/src/lib/pipeline/steps/source/parse_fastq.rs
+++ b/src/lib/pipeline/steps/source/parse_fastq.rs
@@ -1,0 +1,186 @@
+//! `ParseFastqChunks` mid-step. `Parallel + ByItemOrdinal`. Parses the raw,
+//! whole-record-aligned FASTQ bytes of a `FastqRawChunk` into a
+//! `FastqChunkBatch` of `FastqRecord`s.
+//!
+//! This step exists to lift the FASTQ-parse cost off the single
+//! `ReadFastqInputs` reader thread: `ReadFastqInputs` now only reads and
+//! gzip-decompresses bytes (serial, I/O-bound), and one `ParseFastqChunks`
+//! worker per pipeline thread parses the chunks concurrently. The framework
+//! reorders the parallel output by each chunk's globally-unique `ordinal`,
+//! which `ParseFastqChunks` faithfully propagates from input to output.
+
+use std::io;
+
+use crate::fastq_parse::FastqRecord;
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+
+use super::read_fastq::{FastqChunkBatch, FastqRawChunk};
+
+/// Parse a whole-record-aligned FASTQ chunk, returning the records and their
+/// summed heap size. Thin wrapper over [`super::parse_fastq_chunk`] that pins
+/// this step's name into the truncation error.
+///
+/// # Errors
+///
+/// Propagates the shared parser's `InvalidData` on a truncated chunk.
+fn parse_fastq_records(data: &[u8]) -> io::Result<(Vec<FastqRecord>, usize)> {
+    super::parse_fastq_chunk(data, "ParseFastqChunks")
+}
+
+/// `Parallel + ByItemOrdinal` FASTQ parser. Each worker is independent and
+/// stateless beyond the held slot — a `FastqRawChunk` in, a `FastqChunkBatch`
+/// out, with the globally-unique `ordinal` (and the `stream_idx` /
+/// `chunk_serial` join keys) preserved verbatim.
+pub struct ParseFastqChunks {
+    held: HeldSlot<Unpushed<FastqChunkBatch>>,
+    output_byte_limit: u64,
+}
+
+impl ParseFastqChunks {
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self { held: HeldSlot::new(), output_byte_limit }
+    }
+}
+
+impl Clone for ParseFastqChunks {
+    fn clone(&self) -> Self {
+        Self { held: HeldSlot::new(), output_byte_limit: self.output_byte_limit }
+    }
+}
+
+impl Step for ParseFastqChunks {
+    type Input = FastqRawChunk;
+    type Outputs = OrderedBytesSingle<FastqChunkBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ParseFastqChunks",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    // `Contention` (not `NoProgress`) keeps the worker alive
+                    // for retry — `NoProgress` would let the framework mark
+                    // this worker `Skip` if input is also drained, silently
+                    // dropping the held item.
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(chunk) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+
+        let (records, total_bytes) = parse_fastq_records(&chunk.data)?;
+        let batch = FastqChunkBatch::new(
+            chunk.ordinal,
+            chunk.stream_idx,
+            chunk.chunk_serial,
+            records,
+            total_bytes,
+        );
+
+        match ctx.outputs.push(batch) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::core::item::Ordered;
+
+    #[test]
+    fn profile_advertises_parallel_byordinal() {
+        let s = ParseFastqChunks::new(1024);
+        let p = s.profile();
+        assert_eq!(p.name, "ParseFastqChunks");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    #[test]
+    fn parse_fastq_records_parses_all_records() {
+        let data = b"@read1\nACGT\n+\nIIII\n@read2\nTGCA\n+\nJJJJ\n";
+        let (records, total_bytes) = parse_fastq_records(data).unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].name(), b"read1");
+        assert_eq!(records[0].sequence(), b"ACGT");
+        assert_eq!(records[1].name(), b"read2");
+        assert_eq!(records[1].sequence(), b"TGCA");
+        assert!(total_bytes > 0);
+    }
+
+    #[test]
+    fn parse_fastq_records_empty_input() {
+        let (records, total_bytes) = parse_fastq_records(b"").unwrap();
+        assert!(records.is_empty());
+        assert_eq!(total_bytes, 0);
+    }
+
+    #[test]
+    fn parse_fastq_records_truncated_errors() {
+        // Only 2 of 4 lines present.
+        let data = b"@read1\nACGT\n";
+        let err = parse_fastq_records(data).unwrap_err();
+        assert!(err.to_string().contains("truncated"), "got: {err}");
+    }
+
+    /// The core correctness gate: parsing a `FastqRawChunk` must preserve the
+    /// globally-unique `ordinal` and the `(stream_idx, chunk_serial)` join
+    /// keys verbatim on the produced `FastqChunkBatch`.
+    #[test]
+    fn parse_preserves_ordinal_stream_and_serial() {
+        let data = b"@read1\nACGT\n+\nIIII\n".to_vec();
+        let chunk = FastqRawChunk { ordinal: 17, stream_idx: 1, chunk_serial: 4, data };
+
+        let (records, total_bytes) = parse_fastq_records(&chunk.data).unwrap();
+        let batch = FastqChunkBatch::new(
+            chunk.ordinal,
+            chunk.stream_idx,
+            chunk.chunk_serial,
+            records,
+            total_bytes,
+        );
+
+        assert_eq!(batch.ordinal(), 17, "framework reorder key must be the unique ordinal");
+        assert_eq!(batch.stream_idx, 1);
+        assert_eq!(batch.chunk_serial, 4, "zip join key must be preserved");
+        assert_eq!(batch.records.len(), 1);
+        assert_eq!(batch.records[0].name(), b"read1");
+    }
+}

--- a/src/lib/pipeline/steps/source/parse_zip_fastq.rs
+++ b/src/lib/pipeline/steps/source/parse_zip_fastq.rs
@@ -1,0 +1,321 @@
+//! `ParseAndZipFastq` step: `Parallel + ByItemOrdinal`. Parses the raw,
+//! whole-record-aligned bytes of a [`PairedRawFastqBatch`] (one R1 chunk + one
+//! R2 chunk) into per-stream `FastqRecord`s and zips them record-by-record into
+//! a [`FastqTemplateBatch`].
+//!
+//! This step exists to lift BOTH the FASTQ parse and the template build off the
+//! serial source path and fan them across worker threads. It mirrors the legacy
+//! pipeline's `Decode` stage: the cheap chunk-level pairing already happened
+//! serially in [`PairRawFastq`] (which minted a globally-unique `ordinal`), and
+//! each worker here parses + zips one paired batch independently. The framework
+//! reorders the parallel output by each batch's `ordinal`, which this step
+//! propagates verbatim onto the emitted `FastqTemplateBatch`.
+//!
+//! [`PairRawFastq`]: super::pair_fastq::PairRawFastq
+//!
+//! Used only for the common paired-end (N == 2) case. The N == 1 and N >= 3
+//! paths keep the separate `ParseFastqChunks` → `ZipFastqRecords` structure.
+
+use std::io;
+
+use crate::fastq_parse::{FastqRecord, strip_read_suffix};
+use crate::grouper::FastqTemplate;
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+
+use super::pair_fastq::PairedRawFastqBatch;
+use super::zip_fastq::FastqTemplateBatch;
+
+/// Parse a whole-record-aligned FASTQ chunk into records. Thin wrapper over
+/// [`super::parse_fastq_chunk`] that pins this step's name into the truncation
+/// error and drops the byte total, which this step recomputes per template.
+///
+/// # Errors
+///
+/// Propagates the shared parser's `InvalidData` on a truncated chunk.
+fn parse_fastq_records(data: &[u8]) -> io::Result<Vec<FastqRecord>> {
+    super::parse_fastq_chunk(data, "ParseAndZipFastq").map(|(records, _)| records)
+}
+
+/// Zip the per-stream records of one paired batch into `FastqTemplate`s.
+///
+/// Record `i` from stream A and record `i` from stream B form one template; the
+/// names must match after [`strip_read_suffix`]. This mirrors the legacy
+/// `ZipFastqRecords::try_emit_complete` logic verbatim — including its error
+/// semantics — so output (and failure behavior) is byte-identical to the
+/// `ParseFastqChunks` → `ZipFastqRecords` path the N != 2 chains still use.
+///
+/// Strict, fgbio-consistent mismatch handling (see `FastqSource.zipped`): a
+/// record-count difference between the streams is an explicit "out of sync"
+/// error, and a read name that disagrees after suffix-stripping is a "read name
+/// mismatch" error. The count check is the same one `ZipFastqRecords` applies
+/// on the N>=3 path, so both paths report identically.
+fn zip_records(
+    records_a: Vec<FastqRecord>,
+    records_b: Vec<FastqRecord>,
+    chunk_serial: u64,
+) -> io::Result<Vec<FastqTemplate>> {
+    // Paired FASTQ is positionally parallel: every stream must contribute the
+    // same number of records for this chunk. Reject a mismatch explicitly
+    // rather than letting it surface as an incidental name mismatch from the
+    // back-pop below.
+    if records_a.len() != records_b.len() {
+        return Err(io::Error::other(format!(
+            "FASTQ sources out of sync at chunk_serial {chunk_serial}: \
+             stream 0 has {} records, stream 1 has {}",
+            records_a.len(),
+            records_b.len(),
+        )));
+    }
+
+    let n_records = records_a.len();
+    let mut streams: [Vec<FastqRecord>; 2] = [records_a, records_b];
+
+    // Pop from the back of each stream (avoids O(n^2) front removal) and
+    // reverse at the end to restore the original record order.
+    let mut reversed_templates = Vec::with_capacity(n_records);
+    for _ in 0..n_records {
+        let mut records = Vec::with_capacity(2);
+        let mut base_name: Option<Vec<u8>> = None;
+
+        for (stream_idx, stream) in streams.iter_mut().enumerate() {
+            // Unreachable after the equal-count check above; kept defensive.
+            let Some(record) = stream.pop() else {
+                return Err(io::Error::other(format!(
+                    "FASTQ sources out of sync: stream {stream_idx} ran short at \
+                     chunk_serial {chunk_serial}",
+                )));
+            };
+
+            let stripped = strip_read_suffix(record.name());
+            match &base_name {
+                None => base_name = Some(stripped.to_vec()),
+                Some(expected) => {
+                    if stripped != expected.as_slice() {
+                        // `InvalidData`, matching the same check in
+                        // `ZipFastqRecords::try_emit_complete`: a name mismatch is
+                        // malformed input, and the two paths must classify it the
+                        // same way or a caller matching on kind sees it only from
+                        // one of them.
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!(
+                                "FASTQ read name mismatch at chunk_serial {}: stream 0 has '{}', \
+                             stream {} has '{}'",
+                                chunk_serial,
+                                String::from_utf8_lossy(expected),
+                                stream_idx,
+                                String::from_utf8_lossy(stripped),
+                            ),
+                        ));
+                    }
+                }
+            }
+            records.push(record);
+        }
+
+        reversed_templates.push(FastqTemplate { name: base_name.unwrap(), records });
+    }
+
+    reversed_templates.reverse();
+    Ok(reversed_templates)
+}
+
+/// `Parallel + ByItemOrdinal` FASTQ parse-and-zip. Each worker is independent
+/// and stateless beyond the held slot — a `PairedRawFastqBatch` in, a
+/// `FastqTemplateBatch` out, with the globally-unique `ordinal` preserved
+/// verbatim as the output `batch_serial`.
+pub struct ParseAndZipFastq {
+    held: HeldSlot<Unpushed<FastqTemplateBatch>>,
+    output_byte_limit: u64,
+}
+
+impl ParseAndZipFastq {
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self { held: HeldSlot::new(), output_byte_limit }
+    }
+}
+
+impl Clone for ParseAndZipFastq {
+    fn clone(&self) -> Self {
+        Self { held: HeldSlot::new(), output_byte_limit: self.output_byte_limit }
+    }
+}
+
+impl Step for ParseAndZipFastq {
+    type Input = PairedRawFastqBatch;
+    type Outputs = OrderedBytesSingle<FastqTemplateBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ParseAndZipFastq",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    // `Contention` (not `NoProgress`) keeps the worker alive
+                    // for retry — `NoProgress` would let the framework mark
+                    // this worker `Skip` if input is also drained, silently
+                    // dropping the held item.
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(batch) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+
+        let records_a = parse_fastq_records(&batch.data_a)?;
+        let records_b = parse_fastq_records(&batch.data_b)?;
+        let templates = zip_records(records_a, records_b, batch.chunk_serial)?;
+        // Preserve the serially-minted ordinal so the framework reorder keeps
+        // the FASTQ records in input order.
+        let template_batch = FastqTemplateBatch::new(batch.ordinal, templates);
+
+        match ctx.outputs.push(template_batch) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::core::item::Ordered;
+
+    fn record_bytes(name: &str, seq: &str) -> Vec<u8> {
+        let qual: String = std::iter::repeat_n('I', seq.len()).collect();
+        format!("@{name}\n{seq}\n+\n{qual}\n").into_bytes()
+    }
+
+    #[test]
+    fn profile_advertises_parallel_byordinal() {
+        let s = ParseAndZipFastq::new(1024);
+        let p = s.profile();
+        assert_eq!(p.name, "ParseAndZipFastq");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    #[test]
+    fn parse_fastq_records_parses_all_records() {
+        let mut data = record_bytes("read1", "ACGT");
+        data.extend(record_bytes("read2", "TGCA"));
+        let records = parse_fastq_records(&data).unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].name(), b"read1");
+        assert_eq!(records[1].name(), b"read2");
+    }
+
+    #[test]
+    fn parse_fastq_records_truncated_errors() {
+        let data = b"@read1\nACGT\n";
+        let err = parse_fastq_records(data).unwrap_err();
+        assert!(err.to_string().contains("truncated"), "got: {err}");
+    }
+
+    /// The core zip correctness: record i from A and record i from B form one
+    /// template, the base read name (suffix-stripped) is preserved, and R1/R2
+    /// land in records[0]/records[1] in input order.
+    #[test]
+    fn zip_pairs_records_and_strips_suffixes() {
+        let mut data_a = record_bytes("read1/1", "ACGT");
+        data_a.extend(record_bytes("read2/1", "TGCA"));
+        let mut data_b = record_bytes("read1/2", "GGGG");
+        data_b.extend(record_bytes("read2/2", "CCCC"));
+
+        let recs_a = parse_fastq_records(&data_a).unwrap();
+        let recs_b = parse_fastq_records(&data_b).unwrap();
+        let templates = zip_records(recs_a, recs_b, 0).unwrap();
+
+        assert_eq!(templates.len(), 2);
+        assert_eq!(templates[0].name, b"read1");
+        assert_eq!(templates[0].records.len(), 2);
+        assert_eq!(templates[0].records[0].sequence(), b"ACGT");
+        assert_eq!(templates[0].records[1].sequence(), b"GGGG");
+        assert_eq!(templates[1].name, b"read2");
+        assert_eq!(templates[1].records[0].sequence(), b"TGCA");
+        assert_eq!(templates[1].records[1].sequence(), b"CCCC");
+    }
+
+    #[test]
+    fn zip_name_mismatch_errors() {
+        let recs_a = parse_fastq_records(&record_bytes("readA/1", "ACGT")).unwrap();
+        let recs_b = parse_fastq_records(&record_bytes("readB/2", "GGGG")).unwrap();
+        let err = zip_records(recs_a, recs_b, 0).unwrap_err();
+        assert!(err.to_string().contains("mismatch"), "expected mismatch error, got: {err}");
+    }
+
+    /// Unequal record counts are rejected by an explicit, strict count check
+    /// (fgbio-consistent) — distinct from a name mismatch. A has 2 records, B
+    /// has 1, so the streams are out of sync regardless of read names.
+    #[test]
+    fn zip_unequal_counts_errors() {
+        let mut data_a = record_bytes("read1/1", "ACGT");
+        data_a.extend(record_bytes("read2/1", "TGCA"));
+        let recs_a = parse_fastq_records(&data_a).unwrap();
+        let recs_b = parse_fastq_records(&record_bytes("read1/2", "GGGG")).unwrap();
+        let err = zip_records(recs_a, recs_b, 7).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("out of sync"), "expected count out-of-sync error, got: {msg}");
+        assert!(msg.contains("chunk_serial 7"), "should name the chunk_serial, got: {msg}");
+    }
+
+    /// A shorter than B is symmetric: the explicit count check rejects it the
+    /// same way, naming the differing counts rather than relying on back-pop
+    /// name misalignment.
+    #[test]
+    fn zip_a_shorter_than_b_errors() {
+        let recs_a = parse_fastq_records(&record_bytes("read1/1", "ACGT")).unwrap();
+        let mut data_b = record_bytes("read1/2", "GGGG");
+        data_b.extend(record_bytes("read2/2", "CCCC"));
+        let recs_b = parse_fastq_records(&data_b).unwrap();
+        let err = zip_records(recs_a, recs_b, 0).unwrap_err();
+        assert!(err.to_string().contains("out of sync"), "got: {err}");
+    }
+
+    /// The output `FastqTemplateBatch` must carry the input batch's ordinal as
+    /// its `batch_serial` so the framework reorder preserves input order.
+    #[test]
+    fn output_ordinal_is_input_ordinal() {
+        let data_a = record_bytes("r/1", "ACGT");
+        let data_b = record_bytes("r/2", "GGGG");
+        let recs_a = parse_fastq_records(&data_a).unwrap();
+        let recs_b = parse_fastq_records(&data_b).unwrap();
+        let templates = zip_records(recs_a, recs_b, 0).unwrap();
+        let batch = FastqTemplateBatch::new(42, templates);
+        assert_eq!(batch.ordinal(), 42);
+    }
+}

--- a/src/lib/pipeline/steps/source/read_bam.rs
+++ b/src/lib/pipeline/steps/source/read_bam.rs
@@ -1,0 +1,6 @@
+//! Re-export shim. The `ReadBgzfBlocks` source step and `read_bam*` helpers
+//! now live in the `fgumi-pipeline-io` crate.
+pub use fgumi_pipeline_io::source::read_bam::{
+    DEFAULT_BLOCKS_PER_BATCH, ReadBgzfBlocks, read_bam, read_bam_auto, read_bam_from_reader,
+    read_bam_stdin,
+};

--- a/src/lib/pipeline/steps/source/read_fastq.rs
+++ b/src/lib/pipeline/steps/source/read_fastq.rs
@@ -1,0 +1,756 @@
+//! `ReadFastqInputs` source step: reads (and gzip-decompresses) raw FASTQ
+//! bytes from one or more `BufRead` streams in round-robin order and emits
+//! `FastqRawChunk` items. Parsing into `FastqRecord`s is deferred to the
+//! downstream `Parallel` `ParseFastqChunks` step so the decode/parse work
+//! can fan out across worker threads rather than bottlenecking on the
+//! single reader thread.
+//!
+//! ## Per-stream vs. all-streams instantiation
+//!
+//! For the common paired-end case (R1 + R2) the gzip decompression is the
+//! bottleneck, and a single reader serializing both streams cannot keep up.
+//! The framework runs distinct `Serial` steps on distinct workers
+//! concurrently (a `Serial` step holds a per-step mutex, not a global one),
+//! so the fix is to instantiate **one reader per stream** and pair their
+//! outputs 2-way (see `PairRawFastq`). Each per-stream reader is built with
+//! [`ReadFastqInputs::new_single`], is pinned to its **own** worker
+//! (`Affinity::Worker(0)` for R1, `Affinity::Worker(1)` for R2), and draws its
+//! chunks' `ordinal` from a [`FastqOrdinalSequence`] **shared by every reader
+//! on the branch**. That sharing is required, not incidental: handing each
+//! reader its own sequence makes them all mint `0, 1, 2, …` and collide, which
+//! does not fail loudly — it silently interleaves records in the downstream
+//! reorder buffer.
+//!
+//! The distinct-worker pinning is load-bearing, not a tuning choice: a `Serial`
+//! source dispatched by more than one worker hits a `try_lock`-after-`Finished`
+//! race in the runtime's source-drain path, so concurrent per-stream readers
+//! must never use [`Affinity::None`]. See [`ReadFastqInputs::new_single`].
+//!
+//! The N≥3 fallback keeps the original single-reader, all-streams,
+//! round-robin model ([`ReadFastqInputs::new`], [`Affinity::Reader`]): a
+//! single worker-0-sticky thread drives all I/O reads, same as
+//! `ReadBgzfBlocks`.
+
+use std::collections::VecDeque;
+use std::io::{self, BufRead};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use parking_lot::Mutex;
+
+use crate::fastq_parse::FastqRecord;
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::item::{HeapSize, Ordered};
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Affinity, Step, StepCtx, StepKind, StepOutcome, StepProfile};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FastqRawChunk — one chunk of raw (decompressed, unparsed) FASTQ bytes from
+// a single stream.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The shared, monotonic ordinal sequence for FASTQ chunks.
+///
+/// Every chunk emitted by every [`ReadFastqInputs`] instance feeding one
+/// `ParseFastqChunks` branch draws its ordinal from a single counter, so the
+/// sequence is both **globally unique** and **gap-free**.
+///
+/// Density is the load-bearing half, and it is why this is a shared counter
+/// rather than a per-stream arithmetic partition. The earlier scheme assigned
+/// `chunk_serial * n_streams_total + stream_idx`, giving each stream its own
+/// residue class. That is unique, but it is only dense when every stream
+/// produces the *same number of chunks* — a property of the input data, not
+/// something a reader can enforce. Mismatched FASTQ inputs (R1 longer than R2,
+/// e.g. a truncated download) leave a permanently unfilled ordinal, and
+/// `BranchOrdering::ByItemOrdinal` releases only in contiguous order, so the
+/// reorder stage waits forever on an ordinal no reader will ever mint. The
+/// symptom is a hang, not an error — and it masks the *correct* diagnostic,
+/// because `ZipFastqRecords` already reports "FASTQ sources out of sync" once
+/// the chunks actually reach it.
+///
+/// A per-instance counter cannot replace this: under `new_single` each reader
+/// owns one stream and cannot know how many cycles the other streams will run,
+/// so it cannot know how many ordinals to mint. Density is a global property,
+/// so it needs a globally-shared counter. This mirrors `PairRawFastq`, which
+/// already mints its ordinals from one serial counter.
+///
+/// The cost is one uncontended `fetch_add` per *chunk* (hundreds of KB of
+/// FASTQ), which is far below the noise floor of decompressing that chunk.
+#[derive(Debug, Clone, Default)]
+pub struct FastqOrdinalSequence(Arc<AtomicU64>);
+
+impl FastqOrdinalSequence {
+    /// A fresh sequence starting at 0. Share one clone per reader instance
+    /// feeding the same downstream branch.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Take the next ordinal. `Relaxed` is sufficient: the value only has to be
+    /// unique and monotonic, and the reorder stage does its own ordering.
+    pub(crate) fn next(&self) -> u64 {
+        self.0.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+/// A chunk of decompressed, whole-record-aligned raw FASTQ bytes emitted by
+/// [`ReadFastqInputs`] and consumed by `ParseFastqChunks`.
+///
+/// `ordinal` is a globally-unique, monotonically-increasing counter assigned
+/// once per emitted chunk (regardless of stream). It is the key the framework
+/// uses to reorder the `Parallel` `ParseFastqChunks` output — `stream_idx` and
+/// `chunk_serial` are NOT globally unique (two streams emit chunks with the
+/// same `chunk_serial`), so they must not be used as a reorder key. The
+/// `(stream_idx, chunk_serial)` pair is preserved purely so `ZipFastqRecords`
+/// can re-join the per-stream chunks.
+pub struct FastqRawChunk {
+    /// Globally-unique monotonic ordinal, for the framework's reorder buffer.
+    pub ordinal: u64,
+    /// Index of the originating FASTQ stream (0-based).
+    pub stream_idx: usize,
+    /// Per-stream round-robin cycle serial, for the `ZipFastqRecords` join.
+    pub chunk_serial: u64,
+    /// Decompressed raw FASTQ bytes, aligned to whole records (4 lines each).
+    ///
+    /// Rebuild this chunk rather than mutating it in place: an in-place edit
+    /// that breaks whole-record (4-line) alignment desyncs downstream parsing.
+    pub data: Vec<u8>,
+}
+
+impl HeapSize for FastqRawChunk {
+    fn heap_size(&self) -> usize {
+        // Allocated capacity, not logical length: byte-bounded queues budget the
+        // memory actually held, and these buffers are read into with spare
+        // capacity. `PairFastqStreams` accounts for the same chunks and must use
+        // the same measure, or `pending_total_bytes` drifts against the queues.
+        self.data.capacity()
+    }
+}
+
+impl Ordered for FastqRawChunk {
+    fn ordinal(&self) -> u64 {
+        self.ordinal
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FastqChunkBatch — one chunk of parsed records from a single FASTQ stream.
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub struct FastqChunkBatch {
+    /// Globally-unique monotonic ordinal, propagated from the originating
+    /// [`FastqRawChunk`]. Used by the framework to reorder the output of the
+    /// `Parallel` `ParseFastqChunks` step. Distinct from `chunk_serial`,
+    /// which is only per-stream unique and is reused across streams.
+    pub ordinal: u64,
+    pub stream_idx: usize,
+    pub chunk_serial: u64,
+    pub records: Vec<FastqRecord>,
+    total_bytes: usize,
+}
+
+impl FastqChunkBatch {
+    #[must_use]
+    pub fn new(
+        ordinal: u64,
+        stream_idx: usize,
+        chunk_serial: u64,
+        records: Vec<FastqRecord>,
+        total_bytes: usize,
+    ) -> Self {
+        Self { ordinal, stream_idx, chunk_serial, records, total_bytes }
+    }
+}
+
+impl HeapSize for FastqChunkBatch {
+    fn heap_size(&self) -> usize {
+        self.total_bytes
+    }
+}
+
+impl Ordered for FastqChunkBatch {
+    fn ordinal(&self) -> u64 {
+        self.ordinal
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FASTQ reading helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Read up to `count` complete FASTQ records' worth of raw bytes from
+/// `reader` into a single `Vec<u8>`, returning the bytes plus the number of
+/// complete records read.
+///
+/// Each record is 4 lines (`@name`, sequence, `+`, quality); the bytes are
+/// always whole-record-aligned (the function never splits mid-record). A
+/// returned count of 0 with empty bytes signals EOF for the stream.
+///
+/// Decompression (when the underlying `BufRead` is a gzip decoder) happens
+/// here; FASTQ structure validation and `FastqRecord` parsing are deferred to
+/// `ParseFastqChunks`. The only structural check performed here is that each
+/// record begins with `@`, so the round-robin reader fails fast on a malformed
+/// stream rather than emitting garbage to the parse workers.
+fn read_fastq_raw_bytes_from_bufread(
+    reader: &mut dyn BufRead,
+    count: usize,
+) -> io::Result<(Vec<u8>, usize)> {
+    let mut data: Vec<u8> = Vec::with_capacity(count * 300);
+    let mut records_read = 0;
+
+    for _ in 0..count {
+        // Line 1: @name
+        let line_start = data.len();
+        let bytes_read = reader.read_until(b'\n', &mut data)?;
+        if bytes_read == 0 {
+            break;
+        }
+        if data[line_start] != b'@' {
+            // A lone newline (blank line between records) is a common
+            // hand-edit/corruption artifact; give it a clearer message than
+            // the raw "got '\n'" the generic branch would produce.
+            let message = if data[line_start] == b'\n' {
+                "Unexpected blank line in FASTQ stream (expected a record \
+                 starting with '@')"
+                    .to_string()
+            } else {
+                format!(
+                    "Expected FASTQ record to start with '@', got '{}'",
+                    data[line_start] as char
+                )
+            };
+            return Err(io::Error::new(io::ErrorKind::InvalidData, message));
+        }
+        if data.last() != Some(&b'\n') {
+            data.push(b'\n');
+        }
+
+        // Line 2: sequence
+        let bytes_read = reader.read_until(b'\n', &mut data)?;
+        if bytes_read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "Unexpected EOF reading FASTQ sequence line",
+            ));
+        }
+        if data.last() != Some(&b'\n') {
+            data.push(b'\n');
+        }
+
+        // Line 3: +
+        let bytes_read = reader.read_until(b'\n', &mut data)?;
+        if bytes_read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "Unexpected EOF reading FASTQ separator line",
+            ));
+        }
+        if data.last() != Some(&b'\n') {
+            data.push(b'\n');
+        }
+
+        // Line 4: quality
+        let bytes_read = reader.read_until(b'\n', &mut data)?;
+        if bytes_read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "Unexpected EOF reading FASTQ quality line",
+            ));
+        }
+        if data.last() != Some(&b'\n') {
+            data.push(b'\n');
+        }
+
+        records_read += 1;
+    }
+
+    Ok((data, records_read))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ReadFastqInputs — Serial+Reader source step
+// ─────────────────────────────────────────────────────────────────────────────
+
+type FastqReaders = Vec<Box<dyn BufRead + Send>>;
+
+pub struct ReadFastqInputs {
+    readers: Arc<Mutex<Option<FastqReaders>>>,
+    /// Number of streams this instance reads (the length of `readers`). For
+    /// `new_single` this is always 1; for `new` it is the total stream count.
+    n_streams: usize,
+    /// Global index of this instance's first (local) stream. The emitted
+    /// `FastqRawChunk::stream_idx` is `stream_idx_base + local_idx`, so a
+    /// per-stream reader for R2 reports `stream_idx = 1` even though its only
+    /// reader is at local index 0.
+    stream_idx_base: usize,
+    /// Shared ordinal source. Every reader feeding the same downstream branch
+    /// holds a clone, so the emitted ordinals are unique *and* gap-free even
+    /// when the streams differ in length. See [`FastqOrdinalSequence`].
+    ordinals: FastqOrdinalSequence,
+    /// Scheduling hint reported by `affinity()`. `Affinity::Worker(i)` for the
+    /// per-stream concurrent readers (each pinned to a distinct worker);
+    /// `Affinity::Reader` for the single all-streams fallback.
+    affinity: Affinity,
+    /// Whether the step advertises `sticky` in its profile. The all-streams
+    /// fallback is `sticky` (the legacy worker-0 burst-read model). The
+    /// per-stream concurrent readers are NOT sticky: a sticky reader would
+    /// monopolize its worker via the scheduler's sticky re-entry loop
+    /// (spinning on the reader while it makes Progress), starving the
+    /// `Parallel` `BgzfCompress` of that worker between read bursts and
+    /// regressing throughput at low `--threads`. Non-sticky lets the
+    /// affinity-pinned worker interleave compression work between reads.
+    sticky: bool,
+    batch_record_count: usize,
+    next_chunk_serial: u64,
+    pending: VecDeque<FastqRawChunk>,
+    held: HeldSlot<Unpushed<FastqRawChunk>>,
+    output_byte_limit: u64,
+    exhausted: Vec<bool>,
+    all_done: bool,
+}
+
+impl ReadFastqInputs {
+    /// All-streams reader: reads every stream in `readers` round-robin on a
+    /// single worker (`Affinity::Reader`). Used for the N≥3 fallback where
+    /// the per-stream concurrent model's coordination overhead is not worth
+    /// it. `stream_idx_base` is 0, so emitted chunks carry their natural
+    /// stream index. This is the only reader on its branch, so it owns a
+    /// private [`FastqOrdinalSequence`].
+    #[must_use]
+    pub fn new(
+        readers: Vec<Box<dyn BufRead + Send>>,
+        batch_record_count: usize,
+        output_byte_limit: u64,
+    ) -> Self {
+        Self::build(
+            readers,
+            0,
+            FastqOrdinalSequence::new(),
+            Affinity::Reader,
+            /* sticky */ true,
+            batch_record_count,
+            output_byte_limit,
+        )
+    }
+
+    /// Single-stream reader: reads exactly one stream so multiple instances
+    /// (e.g. one for R1, one for R2) can run concurrently on different
+    /// workers. `global_stream_idx` is this stream's index in the full
+    /// pipeline, carried on each chunk so `ZipFastqRecords` can re-join the
+    /// streams.
+    ///
+    /// `ordinals` must be the **same** [`FastqOrdinalSequence`] for every
+    /// reader feeding one downstream branch — that shared counter is what
+    /// makes the combined ordinal stream gap-free when the streams differ in
+    /// length. Handing each reader its own sequence would make them all mint
+    /// `0, 1, 2, …` and collide, which does not fail loudly: it silently
+    /// interleaves records in the reorder buffer.
+    ///
+    /// `affinity` pins this reader to a specific worker. Each per-stream
+    /// reader is given a **distinct** worker (e.g. `Affinity::Worker(0)` for
+    /// R1, `Affinity::Worker(1)` for R2) so the two gzip decoders run
+    /// concurrently AND no two workers ever contend the same source mutex.
+    /// The latter is load-bearing: a `Serial` source dispatched by more than
+    /// one worker hits a `try_lock`-after-`Finished` race in the runtime's
+    /// source-drain path, so concurrent readers must use disjoint
+    /// single-worker affinities, never `Affinity::None`.
+    ///
+    #[must_use]
+    pub fn new_single(
+        reader: Box<dyn BufRead + Send>,
+        global_stream_idx: usize,
+        ordinals: FastqOrdinalSequence,
+        affinity: Affinity,
+        batch_record_count: usize,
+        output_byte_limit: u64,
+    ) -> Self {
+        Self::build(
+            vec![reader],
+            global_stream_idx,
+            ordinals,
+            affinity,
+            /* sticky */ false,
+            batch_record_count,
+            output_byte_limit,
+        )
+    }
+
+    fn build(
+        readers: Vec<Box<dyn BufRead + Send>>,
+        stream_idx_base: usize,
+        ordinals: FastqOrdinalSequence,
+        affinity: Affinity,
+        sticky: bool,
+        batch_record_count: usize,
+        output_byte_limit: u64,
+    ) -> Self {
+        // No ordinal-collision guard is needed here any more. The previous
+        // scheme derived ordinals from `(stream_idx, n_streams_total)`, so a
+        // reader wired with an index outside the declared total silently minted
+        // another reader's ordinals, and an unconditional assert stood here to
+        // catch it. Drawing from one shared counter makes uniqueness structural
+        // instead of arithmetic, so there is nothing left to assert.
+        //
+        // Worth noting which half of the invariant that assert covered: it
+        // guarded *uniqueness* only. Nothing guarded *density*, which is the
+        // half that actually broke — and its failure mode was a silent hang
+        // rather than a panic. See [`FastqOrdinalSequence`].
+        let n_streams = readers.len();
+
+        Self {
+            readers: Arc::new(Mutex::new(Some(readers))),
+            n_streams,
+            stream_idx_base,
+            ordinals,
+            affinity,
+            sticky,
+            batch_record_count: batch_record_count.max(1),
+            next_chunk_serial: 0,
+            pending: VecDeque::new(),
+            held: HeldSlot::new(),
+            output_byte_limit,
+            exhausted: vec![false; n_streams],
+            all_done: false,
+        }
+    }
+}
+
+impl Step for ReadFastqInputs {
+    type Input = ();
+    type Outputs = OrderedBytesSingle<FastqRawChunk>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ReadFastqInputs",
+            kind: StepKind::Serial,
+            sticky: self.sticky,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn affinity(&self) -> Affinity {
+        self.affinity
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // 1. Drain held slot.
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        // 2. Drain pending batches.
+        if let Some(batch) = self.pending.pop_front() {
+            match ctx.outputs.push(batch) {
+                Ok(()) => return Ok(StepOutcome::Progress),
+                Err(unpushed) => {
+                    self.held.put(unpushed);
+                    return Ok(StepOutcome::Progress);
+                }
+            }
+        }
+
+        if self.all_done {
+            return Ok(StepOutcome::Finished);
+        }
+
+        // 3. Read one round-robin cycle: one chunk per stream at the current serial.
+        let chunk_serial = self.next_chunk_serial;
+        let mut any_read = false;
+
+        {
+            let mut guard = self.readers.lock();
+            let readers = guard.as_mut().expect("ReadFastqInputs: readers missing");
+            debug_assert_eq!(
+                readers.len(),
+                self.n_streams,
+                "reader count must match the declared stream count"
+            );
+
+            // Read one chunk from every non-exhausted stream this cycle. Each
+            // cycle reads all streams, so there is no rotation offset.
+            for (idx, reader) in readers.iter_mut().enumerate() {
+                if self.exhausted[idx] {
+                    continue;
+                }
+
+                let (data, records_read) =
+                    read_fastq_raw_bytes_from_bufread(reader.as_mut(), self.batch_record_count)?;
+
+                if records_read == 0 {
+                    self.exhausted[idx] = true;
+                    continue;
+                }
+
+                any_read = true;
+                // Global stream index (== local idx for the all-streams
+                // reader, which has stream_idx_base == 0).
+                let stream_idx = self.stream_idx_base + idx;
+                // Drawn per emitted chunk, so a stream that exhausts early
+                // leaves no hole in the sequence.
+                let ordinal = self.ordinals.next();
+                self.pending.push_back(FastqRawChunk { ordinal, stream_idx, chunk_serial, data });
+            }
+        }
+
+        // Advance to the next round-robin cycle.
+        self.next_chunk_serial += 1;
+
+        if !any_read {
+            self.all_done = true;
+            return Ok(StepOutcome::Finished);
+        }
+
+        // Emit one batch from the freshly-filled pending queue.
+        if let Some(batch) = self.pending.pop_front() {
+            match ctx.outputs.push(batch) {
+                Ok(()) => Ok(StepOutcome::Progress),
+                Err(unpushed) => {
+                    self.held.put(unpushed);
+                    Ok(StepOutcome::Progress)
+                }
+            }
+        } else {
+            Ok(StepOutcome::NoProgress)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+    use crate::pipeline::core::item::Ordered;
+
+    /// Every way `read_fastq_raw_bytes_from_bufread` can reject a malformed
+    /// record, one case per rejection. The reader exists to fail fast on
+    /// degenerate input, and without these the only covered paths were the happy
+    /// path, the count cap, and empty input — so a regression that reordered the
+    /// `read_until` / `bytes_read == 0` checks would still have passed.
+    ///
+    /// Note that the *first* line's `bytes_read == 0` is a clean `break` (end of
+    /// stream between records), not an error, so it is covered by the empty-input
+    /// test rather than here.
+    #[rstest]
+    #[case::eof_before_sequence(b"@read1\n".as_slice(), io::ErrorKind::UnexpectedEof, "sequence line")]
+    #[case::eof_before_separator(
+        b"@read1\nACGT\n".as_slice(),
+        io::ErrorKind::UnexpectedEof,
+        "separator line"
+    )]
+    #[case::eof_before_quality(
+        b"@read1\nACGT\n+\n".as_slice(),
+        io::ErrorKind::UnexpectedEof,
+        "quality line"
+    )]
+    #[case::blank_line_between_records(
+        b"\n@read1\nACGT\n+\nIIII\n".as_slice(),
+        io::ErrorKind::InvalidData,
+        "blank line"
+    )]
+    #[case::name_line_missing_at_sign(
+        b"read1\nACGT\n+\nIIII\n".as_slice(),
+        io::ErrorKind::InvalidData,
+        "start with '@'"
+    )]
+    fn read_fastq_raw_bytes_rejects_malformed_records(
+        #[case] input: &[u8],
+        #[case] expected_kind: io::ErrorKind,
+        #[case] expected_message_fragment: &str,
+    ) {
+        let mut reader = io::Cursor::new(input.to_vec());
+        let err = read_fastq_raw_bytes_from_bufread(&mut reader, 2)
+            .expect_err("malformed input must be rejected");
+
+        assert_eq!(err.kind(), expected_kind, "wrong error kind for: {err}");
+        assert!(
+            err.to_string().contains(expected_message_fragment),
+            "message {err:?} should mention {expected_message_fragment:?}",
+        );
+    }
+
+    /// A final quality line with no trailing newline is normalized rather than
+    /// rejected, so the emitted chunk stays 4-line aligned for the parser
+    /// downstream. This is the boundary case the `data.last() != Some(&b'\n')`
+    /// guards exist for, and it sits right next to the EOF rejections above.
+    #[test]
+    fn read_fastq_raw_bytes_appends_a_missing_final_newline() {
+        let mut reader = io::Cursor::new(b"@read1\nACGT\n+\nIIII".to_vec());
+
+        let (bytes, records_read) =
+            read_fastq_raw_bytes_from_bufread(&mut reader, 1).expect("record is complete");
+
+        assert_eq!(records_read, 1);
+        assert_eq!(bytes, b"@read1\nACGT\n+\nIIII\n");
+    }
+
+    #[test]
+    fn fastq_chunk_batch_heap_size_returns_total_bytes() {
+        // ordinal (7) and chunk_serial (5) are intentionally different to
+        // confirm `ordinal()` reports the unique ordinal, not chunk_serial.
+        let batch = FastqChunkBatch::new(7, 0, 5, vec![], 1234);
+        assert_eq!(batch.heap_size(), 1234);
+        assert_eq!(batch.ordinal(), 7);
+    }
+
+    #[test]
+    fn fastq_raw_chunk_heap_size_and_ordinal() {
+        let chunk =
+            FastqRawChunk { ordinal: 3, stream_idx: 1, chunk_serial: 0, data: vec![0u8; 42] };
+        assert_eq!(chunk.heap_size(), 42);
+        assert_eq!(chunk.ordinal(), 3);
+    }
+
+    /// `heap_size` must report allocation capacity, not live length: the reader
+    /// builds each chunk with `Vec::with_capacity(count * 300)`, so a short
+    /// chunk — the final partial batch, or reads under the per-record estimate —
+    /// holds materially more memory than it spans.
+    ///
+    /// The test above cannot pin that: `vec![0u8; 42]` has `capacity() == len()`,
+    /// so it passes for either measure and a regression to `len()` would stay
+    /// green while the byte-bounded queue under-counted what it holds. Mirrors
+    /// `pair_fastq::tests::paired_batch_heap_size_counts_spare_capacity`.
+    #[test]
+    fn fastq_raw_chunk_heap_size_counts_spare_capacity() {
+        let mut data = Vec::with_capacity(300);
+        data.extend_from_slice(&[0u8; 42]);
+        let capacity = data.capacity();
+
+        let chunk = FastqRawChunk { ordinal: 3, stream_idx: 1, chunk_serial: 0, data };
+
+        assert_eq!(chunk.heap_size(), capacity);
+        assert!(
+            chunk.heap_size() > 42,
+            "heap_size must exceed the 42 live bytes; got {}",
+            chunk.heap_size()
+        );
+    }
+
+    #[test]
+    fn profile_advertises_serial_reader_byordinal() {
+        let readers: Vec<Box<dyn BufRead + Send>> =
+            vec![Box::new(io::Cursor::new(Vec::<u8>::new()))];
+        let step = ReadFastqInputs::new(readers, 400, 1024 * 1024);
+        let profile = step.profile();
+        assert_eq!(profile.name, "ReadFastqInputs");
+        assert_eq!(profile.kind, StepKind::Serial);
+        assert!(profile.sticky);
+        assert_eq!(step.affinity(), Affinity::Reader);
+        assert_eq!(profile.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+        assert!(matches!(profile.output_queues[0], QueueSpec::ByteBounded { .. }));
+    }
+
+    /// The per-stream constructor keeps `global_stream_idx` purely as chunk
+    /// metadata for `ZipFastqRecords` to re-join on.
+    ///
+    /// This replaces a pair of tests that pinned an ordinal-collision guard
+    /// (`global_stream_idx` had to be `< n_streams_total`, else two readers
+    /// minted the same ordinal). Drawing ordinals from one shared sequence
+    /// makes that collision structurally impossible, so the guard and its
+    /// tests are gone rather than merely unused.
+    #[test]
+    fn new_single_records_its_global_stream_index() {
+        let reader: Box<dyn BufRead + Send> = Box::new(io::Cursor::new(Vec::<u8>::new()));
+        let step = ReadFastqInputs::new_single(
+            reader,
+            1,
+            FastqOrdinalSequence::new(),
+            Affinity::Worker(1),
+            400,
+            1024,
+        );
+        assert_eq!(step.stream_idx_base, 1);
+    }
+
+    #[test]
+    fn new_single_pins_to_requested_worker() {
+        // Per-stream readers pin to a distinct worker so the two gzip
+        // decoders run concurrently (R1 on worker 0, R2 on worker 1) without
+        // contending the same source mutex.
+        let reader: Box<dyn BufRead + Send> = Box::new(io::Cursor::new(Vec::<u8>::new()));
+        let step = ReadFastqInputs::new_single(
+            reader,
+            1,
+            FastqOrdinalSequence::new(),
+            Affinity::Worker(1),
+            400,
+            1024,
+        );
+        assert_eq!(step.affinity(), Affinity::Worker(1));
+        assert_eq!(step.stream_idx_base, 1);
+        assert_eq!(step.n_streams, 1);
+        // Per-stream readers are NOT sticky — a sticky reader would monopolize
+        // its worker and starve the parallel compressor.
+        assert!(!step.profile().sticky);
+    }
+
+    /// The shared sequence must be unique *and* gap-free across every reader
+    /// drawing from it — including when one stream exhausts long before
+    /// another, which is precisely the case the old strided formula could not
+    /// express.
+    ///
+    /// Density is the half that matters: `BranchOrdering::ByItemOrdinal`
+    /// releases only in contiguous order, so a hole stalls the reorder stage
+    /// forever rather than erroring.
+    #[test]
+    fn shared_ordinal_sequence_is_dense_across_readers() {
+        let seq = FastqOrdinalSequence::new();
+        // Two "readers" sharing one sequence, drawing at wildly different
+        // rates — stream 0 keeps going long after stream 1 stops.
+        let r1 = seq.clone();
+        let r2 = seq.clone();
+        let mut minted = Vec::new();
+        for cycle in 0..10u64 {
+            minted.push(r1.next());
+            if cycle < 3 {
+                minted.push(r2.next());
+            }
+        }
+
+        let expected: Vec<u64> = (0..minted.len() as u64).collect();
+        let mut sorted = minted.clone();
+        sorted.sort_unstable();
+        assert_eq!(
+            sorted, expected,
+            "ordinals must be unique and gap-free however unevenly the readers draw",
+        );
+    }
+
+    #[test]
+    fn read_fastq_raw_bytes_from_bufread_reads_whole_records() {
+        let data = b"@read1\nACGT\n+\nIIII\n@read2\nTGCA\n+\nJJJJ\n";
+        let mut reader = io::Cursor::new(data.to_vec());
+        let (bytes, records_read) = read_fastq_raw_bytes_from_bufread(&mut reader, 10).unwrap();
+        assert_eq!(records_read, 2);
+        // Raw bytes are returned verbatim (whole-record-aligned).
+        assert_eq!(bytes, data);
+    }
+
+    #[test]
+    fn read_fastq_raw_bytes_from_bufread_respects_count() {
+        let data = b"@read1\nACGT\n+\nIIII\n@read2\nTGCA\n+\nJJJJ\n";
+        let mut reader = io::Cursor::new(data.to_vec());
+        let (bytes, records_read) = read_fastq_raw_bytes_from_bufread(&mut reader, 1).unwrap();
+        assert_eq!(records_read, 1);
+        assert_eq!(bytes, b"@read1\nACGT\n+\nIIII\n");
+    }
+
+    #[test]
+    fn read_fastq_raw_bytes_from_bufread_empty_input() {
+        let mut reader = io::Cursor::new(Vec::<u8>::new());
+        let (bytes, records_read) = read_fastq_raw_bytes_from_bufread(&mut reader, 10).unwrap();
+        assert_eq!(records_read, 0);
+        assert!(bytes.is_empty());
+    }
+}

--- a/src/lib/pipeline/steps/source/read_sam_chunks.rs
+++ b/src/lib/pipeline/steps/source/read_sam_chunks.rs
@@ -1,0 +1,625 @@
+//! `ReadSamChunks` source step + supporting helpers.
+//!
+//! 2-step parallel-parse SAM ingest. See
+//! `docs/design/refactor/unified-chain-builder-architecture.md` (the
+//! "Source resolver (delivered in Phase 1)" diagram) for how this step
+//! fits into the per-command chain:
+//!
+//! ```text
+//! ReadSamChunks (Serial + Reader)
+//!     ↓ SamChunk { batch_serial, bytes, line_offsets }
+//! ParseSamChunk (Parallel)
+//!     ↓ DecodedRecordBatch
+//! ```
+//!
+//! The Read step does NOT parse records — it reads bytes, finds line
+//! boundaries with `memchr`, and emits a chunk plus its line-offset table.
+//! Per-line parsing happens in parallel downstream.
+
+use std::io::{self, BufRead};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use parking_lot::Mutex;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Affinity, Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::SamChunk;
+
+/// Target bytes per emitted [`SamChunk`]. Picked to match a typical L1 cache
+/// working set (256 KB) — each parallel parser worker chews through one
+/// chunk while the next one is in flight.
+pub const DEFAULT_SAM_CHUNK_BYTES: usize = 256 * 1024;
+
+/// Upper bound on the carryover buffer while still searching for the first
+/// newline. A single SAM alignment record — even a long-read record with a
+/// multi-megabase CIGAR/sequence — is realistically a few MB of text, so a
+/// 1 GiB ceiling is enormously generous. Exceeding it without ever seeing a
+/// `\n` means the input is not newline-delimited SAM (e.g. a truncated/binary
+/// stream); we surface an error rather than letting `leftover` grow until the
+/// process is OOM-killed.
+const MAX_RECORD_BYTES: usize = 1024 * 1024 * 1024;
+
+/// Mutable per-source state: the SAM byte reader, a small carryover buffer
+/// for the trailing partial line, and an EOF flag.
+///
+/// Read at the byte level — header parsing is the caller's job (typically
+/// via [`crate::pipeline::steps::source::InputSource::open`], which
+/// drives `noodles::sam::io::Reader::read_header` then hands the post-header
+/// reader's underlying buffered stream into [`ReadSamState::new`]).
+pub struct ReadSamState {
+    reader: Box<dyn BufRead + Send>,
+    /// Trailing partial line from the previous `read_next_chunk` call. The
+    /// next call prepends these bytes before scanning so records never get
+    /// split across chunks. Private (encapsulation); use `leftover_len`
+    /// and `leftover_bytes` for in-crate test assertions.
+    leftover: Vec<u8>,
+    eof: bool,
+    /// Ceiling on a single newline-free span before the input is rejected as
+    /// not newline-delimited. A field rather than a bare constant so tests can
+    /// drive the rejection path with a small cap instead of buffering a
+    /// gigabyte; production callers get [`MAX_RECORD_BYTES`] via `new`.
+    max_record_bytes: usize,
+}
+
+impl ReadSamState {
+    #[must_use]
+    pub fn new(reader: Box<dyn BufRead + Send>) -> Self {
+        Self { reader, leftover: Vec::new(), eof: false, max_record_bytes: MAX_RECORD_BYTES }
+    }
+
+    /// Construct with a custom newline-free span ceiling. Test-facing: it makes
+    /// the `InvalidData` rejection reachable without a gigabyte of input.
+    #[cfg(test)]
+    fn with_max_record_bytes(reader: Box<dyn BufRead + Send>, max_record_bytes: usize) -> Self {
+        Self { reader, leftover: Vec::new(), eof: false, max_record_bytes }
+    }
+
+    /// Read the next chunk: append fresh bytes to `leftover`, split at the
+    /// last newline, return the complete-records prefix plus its
+    /// sentinel-form offset table. The trailing partial line stays in
+    /// `self.leftover` for the next call.
+    ///
+    /// `target_bytes` is a **soft lower bound**: the loop reads at least
+    /// that many bytes AND waits for at least one newline before
+    /// splitting. This guarantees forward progress even when a single
+    /// SAM line exceeds `target_bytes` (otherwise an upper-bound loop
+    /// would stall — leftover would fill with bytes that contain no
+    /// newline and the splitter would emit empty chunks forever).
+    /// Practical implication: chunks may be larger than `target_bytes`
+    /// if a record spans several reads, but never smaller than one
+    /// complete record once data is available.
+    ///
+    /// Returns `Ok(None)` only when the reader has signalled EOF AND no
+    /// bytes remain in `leftover` — i.e. the stream is fully consumed.
+    /// If EOF is reached with leftover bytes present, a synthetic `\n`
+    /// is appended so the final partial line becomes a complete record
+    /// (SAM tools traditionally accept a missing trailing newline).
+    ///
+    /// # Panics (debug)
+    ///
+    /// Debug-asserts that `target_bytes <= u32::MAX`. Line offsets emitted
+    /// by `split_complete_lines` are stored as `u32`; the production
+    /// entry point [`ReadSamChunks::new`] also asserts this at
+    /// construction. Direct callers (e.g. unit tests) should respect
+    /// the same cap.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying reader's I/O error.
+    pub fn read_next_chunk(
+        &mut self,
+        target_bytes: usize,
+    ) -> io::Result<Option<(Vec<u8>, Vec<u32>)>> {
+        debug_assert!(
+            u32::try_from(target_bytes).is_ok(),
+            "target_bytes ({target_bytes}) exceeds u32::MAX; \
+             line offsets in the emitted chunk are stored as u32"
+        );
+        // Soft-lower-bound read loop: keep pulling from the reader until
+        // we have at least `target_bytes` AND at least one newline (so
+        // the splitter can emit a complete record). `read_until(b'\n', ...)`
+        // would force per-record I/O sync — we want larger reads to
+        // amortize syscalls, so we pull raw bytes via `fill_buf`/`consume`.
+        // Scan for the first newline incrementally. Re-running `memchr` over the
+        // whole of `leftover` on every iteration re-reads bytes already known to
+        // be newline-free, which is quadratic in the length of a newline-less
+        // span — exactly the input the ceiling below exists to reject, so the
+        // rejection path was the slowest one. `scanned` marks how far the search
+        // has already reached; everything before it is known newline-free.
+        let mut newline_at = memchr::memchr(b'\n', &self.leftover);
+        let mut scanned = if newline_at.is_some() { 0 } else { self.leftover.len() };
+
+        while !self.eof {
+            // Stop when we have enough bytes for the target AND at least
+            // one complete record sits in the buffer.
+            if self.leftover.len() >= target_bytes && newline_at.is_some() {
+                break;
+            }
+            let chunk = self.reader.fill_buf()?;
+            if chunk.is_empty() {
+                self.eof = true;
+                break;
+            }
+            let take = chunk.len();
+            self.leftover.extend_from_slice(&chunk[..take]);
+            self.reader.consume(take);
+
+            if newline_at.is_none() {
+                newline_at =
+                    memchr::memchr(b'\n', &self.leftover[scanned..]).map(|off| scanned + off);
+                if newline_at.is_none() {
+                    scanned = self.leftover.len();
+                }
+            }
+
+            // Guard against unbounded growth: if `leftover` exceeds the
+            // per-record ceiling while still containing no newline, the input
+            // is not newline-delimited SAM. Bail out instead of buffering the
+            // whole stream into memory. (Once a newline is present the loop
+            // breaks above, so this only fires on a genuinely newline-less span.)
+            if newline_at.is_none() && self.leftover.len() > self.max_record_bytes {
+                let max = self.max_record_bytes;
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "SAM record exceeds {max} bytes with no newline; \
+                         input does not appear to be newline-delimited SAM text"
+                    ),
+                ));
+            }
+        }
+
+        if self.leftover.is_empty() {
+            // Reader is fully drained and nothing was held over.
+            return Ok(None);
+        }
+
+        // At true EOF with leftover bytes: append a synthetic `\n` so the
+        // trailing partial line becomes a complete record. SAM tools
+        // traditionally accept files without a trailing newline.
+        if self.eof && !self.leftover.ends_with(b"\n") {
+            self.leftover.push(b'\n');
+        }
+
+        let (offsets, leftover_slice) = split_complete_lines(&self.leftover);
+        let split_at = self.leftover.len() - leftover_slice.len();
+        let new_leftover = self.leftover.split_off(split_at);
+        let bytes = std::mem::replace(&mut self.leftover, new_leftover);
+        Ok(Some((bytes, offsets)))
+    }
+
+    /// Test-only accessor: length of the carryover buffer holding the
+    /// trailing partial line. Mostly useful for asserting that a
+    /// mid-stream read held the right partial bytes.
+    #[cfg(test)]
+    fn leftover_len(&self) -> usize {
+        self.leftover.len()
+    }
+
+    /// Test-only accessor: bytes of the carryover buffer.
+    #[cfg(test)]
+    fn leftover_bytes(&self) -> &[u8] {
+        &self.leftover
+    }
+}
+
+/// `Serial + sticky + Affinity::Reader` SAM-chunk source. Reads SAM text
+/// bytes, splits at newline boundaries, and emits `SamChunk` items with
+/// inline line-offset tables. Per-line parsing is delegated to the
+/// downstream `Parallel` parser step.
+pub struct ReadSamChunks {
+    state: Arc<Mutex<Option<ReadSamState>>>,
+    next_serial: u64,
+    held: HeldSlot<Unpushed<SamChunk>>,
+    target_chunk_bytes: usize,
+    output_byte_limit: u64,
+    finished: Arc<AtomicBool>,
+}
+
+impl ReadSamChunks {
+    /// Build a SAM chunk source from a buffered reader positioned past the
+    /// SAM header (typically obtained via `InputSource::open`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `target_chunk_bytes` exceeds `u32::MAX` — line offsets
+    /// inside an emitted `SamChunk` are held as `u32`. In production all
+    /// callsites pass `DEFAULT_SAM_CHUNK_BYTES` (256 KB) so this is
+    /// unreachable; the assert exists to catch a configuration mistake
+    /// at construction rather than panicking deep in the read loop.
+    #[must_use]
+    pub fn new(
+        reader: Box<dyn BufRead + Send>,
+        target_chunk_bytes: usize,
+        output_byte_limit: u64,
+    ) -> Self {
+        assert!(
+            u32::try_from(target_chunk_bytes).is_ok(),
+            "target_chunk_bytes ({target_chunk_bytes}) exceeds u32::MAX; \
+             line offsets in SamChunk are stored as u32"
+        );
+        Self {
+            state: Arc::new(Mutex::new(Some(ReadSamState::new(reader)))),
+            next_serial: 0,
+            held: HeldSlot::new(),
+            target_chunk_bytes: target_chunk_bytes.max(1),
+            output_byte_limit,
+            finished: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+impl Step for ReadSamChunks {
+    type Input = ();
+    type Outputs = OrderedBytesSingle<SamChunk>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ReadSamChunks",
+            kind: StepKind::Serial,
+            sticky: true,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn affinity(&self) -> Affinity {
+        Affinity::Reader
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // 1. Drain the held slot first.
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        if self.finished.load(Ordering::Acquire) {
+            return Ok(StepOutcome::Finished);
+        }
+
+        // 3. Pull the next chunk from the reader.
+        let next = {
+            let mut guard = self.state.lock();
+            let state = guard.as_mut().expect("ReadSamChunks: state missing — was clone() called?");
+            state.read_next_chunk(self.target_chunk_bytes)?
+        };
+
+        let Some((bytes, line_offsets)) = next else {
+            self.finished.store(true, Ordering::Release);
+            return Ok(StepOutcome::Finished);
+        };
+
+        let serial = self.next_serial;
+        self.next_serial += 1;
+        let chunk = SamChunk { batch_serial: serial, bytes, line_offsets };
+        match ctx.outputs.push(chunk) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+}
+
+/// Split `data` into complete `\n`-terminated records.
+///
+/// Returns `(line_offsets, leftover)` where:
+///
+/// - `line_offsets` is the sentinel-form table — `N+1` entries describing
+///   `N` complete lines. Line `i` is `data[line_offsets[i]..line_offsets[i+1]]`.
+///   Each line's bytes include its trailing `\n`. Empty if `data` contains
+///   no complete line.
+/// - `leftover` is the trailing partial line (bytes after the last `\n`).
+///   Empty if `data` ends on a `\n` boundary. The caller carries this
+///   forward into the next read so records aren't split mid-line.
+///
+/// # Panics
+///
+/// Panics if `data.len()` exceeds `u32::MAX` (we hold offsets as `u32`
+/// because individual chunks are sized in the hundreds-of-KB range).
+#[must_use]
+pub fn split_complete_lines(data: &[u8]) -> (Vec<u32>, &[u8]) {
+    // Find the position just past the last newline. Everything up to that
+    // position is "complete lines"; the remainder is the partial-line
+    // leftover for the next read.
+    let Some(last_nl) = memchr::memrchr(b'\n', data) else {
+        return (Vec::new(), data);
+    };
+    let split = last_nl + 1; // include the trailing \n in the complete region
+    let (complete, leftover) = data.split_at(split);
+
+    // Walk newline positions to build the sentinel-form offset table.
+    let mut offsets: Vec<u32> = Vec::new();
+    offsets.push(0);
+    for nl in memchr::memchr_iter(b'\n', complete) {
+        offsets.push(u32::try_from(nl + 1).expect("chunk size fits in u32"));
+    }
+    (offsets, leftover)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufReader, Cursor};
+
+    fn reader_from(bytes: &[u8]) -> Box<dyn std::io::BufRead + Send> {
+        Box::new(BufReader::new(Cursor::new(bytes.to_vec())))
+    }
+
+    /// A `BufRead` that releases at most `piece` bytes per `fill_buf`.
+    ///
+    /// `BufReader<Cursor<_>>` hands the whole input over on the first
+    /// `fill_buf`, so every test built on `reader_from` leaves the read loop
+    /// after one iteration — with `scanned` still `0`. That makes the
+    /// incremental-scan arithmetic in `read_next_chunk` (which converts a
+    /// slice-relative newline index back to an absolute one) unreachable. This
+    /// reader forces the loop to append repeatedly and resume the search from
+    /// `scanned`.
+    struct Dribble {
+        data: Vec<u8>,
+        pos: usize,
+        piece: usize,
+    }
+
+    impl Dribble {
+        fn boxed(data: Vec<u8>, piece: usize) -> Box<dyn std::io::BufRead + Send> {
+            Box::new(Self { data, pos: 0, piece })
+        }
+    }
+
+    impl io::Read for Dribble {
+        fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+            let n = self.piece.min(out.len()).min(self.data.len() - self.pos);
+            out[..n].copy_from_slice(&self.data[self.pos..self.pos + n]);
+            self.pos += n;
+            Ok(n)
+        }
+    }
+
+    impl io::BufRead for Dribble {
+        fn fill_buf(&mut self) -> io::Result<&[u8]> {
+            let end = (self.pos + self.piece).min(self.data.len());
+            Ok(&self.data[self.pos..end])
+        }
+
+        fn consume(&mut self, amt: usize) {
+            self.pos = (self.pos + amt).min(self.data.len());
+        }
+    }
+
+    /// The newline search must resume at `scanned` and still report an
+    /// **absolute** offset. The first `\n` sits at byte 20, well past the 8-byte
+    /// piece size, so it is found on the third `fill_buf` in a slice that starts
+    /// at 16 — a sign error or a missing `scanned +` would place it at 4.
+    #[test]
+    fn read_next_chunk_resumes_the_newline_search_across_fill_buf_calls() {
+        let mut data = vec![b'A'; 20];
+        data.push(b'\n');
+        data.extend_from_slice(b"sec");
+
+        let mut state = ReadSamState::new(Dribble::boxed(data, 8));
+
+        let (bytes, offsets) =
+            state.read_next_chunk(4).expect("read succeeds").expect("a chunk is emitted");
+
+        // Three 8-byte pieces are pulled before the newline is seen, so the
+        // buffer holds 24 bytes; only the 21 through the newline are complete.
+        let mut expected = vec![b'A'; 20];
+        expected.push(b'\n');
+        assert_eq!(bytes, expected);
+        assert_eq!(offsets, vec![0, 21]);
+        assert_eq!(state.leftover_bytes(), b"sec");
+    }
+
+    /// The newline-free ceiling must also fire when bytes trickle in, since the
+    /// check runs inside the same loop the incremental scan advances.
+    #[test]
+    fn the_newline_free_cap_still_fires_on_small_pieces() {
+        const CAP: usize = 64;
+
+        let mut state =
+            ReadSamState::with_max_record_bytes(Dribble::boxed(vec![b'A'; CAP * 4], 7), CAP);
+
+        let err = state.read_next_chunk(16).expect_err("newline-free input is rejected");
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("no newline"), "got: {err}");
+    }
+
+    #[test]
+    fn split_complete_lines_empty_input_returns_empty_offsets_and_empty_leftover() {
+        let (offsets, leftover) = split_complete_lines(b"");
+        assert!(offsets.is_empty(), "expected no line offsets for empty input");
+        assert!(leftover.is_empty(), "expected no leftover for empty input");
+    }
+
+    #[test]
+    fn split_complete_lines_single_line_terminated_by_newline_no_leftover() {
+        // "abc\n" — one complete record, ends at newline. Sentinel-form
+        // offsets are [0, 4]: line 0 is bytes[0..4] = "abc\n".
+        let (offsets, leftover) = split_complete_lines(b"abc\n");
+        assert_eq!(offsets, vec![0, 4]);
+        assert!(leftover.is_empty(), "expected no leftover when input ends on \\n");
+    }
+
+    #[test]
+    fn split_complete_lines_multiple_lines_no_trailing_newline_leaves_partial_leftover() {
+        // "abc\nde\nf" — two complete lines ("abc\n", "de\n") and a partial
+        // line "f" carried over. Offsets [0, 4, 7] index into bytes[..7].
+        let input = b"abc\nde\nf";
+        let (offsets, leftover) = split_complete_lines(input);
+        assert_eq!(offsets, vec![0, 4, 7]);
+        assert_eq!(leftover, b"f");
+        // Verify the offsets actually slice out the lines.
+        assert_eq!(&input[offsets[0] as usize..offsets[1] as usize], b"abc\n");
+        assert_eq!(&input[offsets[1] as usize..offsets[2] as usize], b"de\n");
+    }
+
+    #[test]
+    fn split_complete_lines_only_partial_line_returns_empty_offsets() {
+        // "abc" — no newline at all. Nothing complete; everything is leftover.
+        let (offsets, leftover) = split_complete_lines(b"abc");
+        assert!(offsets.is_empty());
+        assert_eq!(leftover, b"abc");
+    }
+
+    #[test]
+    fn read_next_chunk_emits_complete_lines_and_holds_partial_as_leftover() {
+        // Soft-lower-bound semantics: with target=10 against a 16-byte
+        // cursor that delivers everything in one `fill_buf`, the loop
+        // reads it all (target satisfied + at least one `\n` present),
+        // splits at the last newline, and holds the trailing partial
+        // line "linX" as the carryover for the next call.
+        let mut state = ReadSamState::new(reader_from(b"line1\nline2\nlinX"));
+        let (bytes, offsets) =
+            state.read_next_chunk(10).expect("read ok").expect("at least one chunk");
+        assert_eq!(offsets, vec![0, 6, 12]);
+        assert_eq!(&bytes[0..6], b"line1\n");
+        assert_eq!(&bytes[6..12], b"line2\n");
+        assert_eq!(state.leftover_bytes(), b"linX");
+    }
+
+    #[test]
+    fn read_next_chunk_flushes_partial_line_at_eof_with_synthetic_newline() {
+        // Input without a trailing newline. A large target reads everything
+        // in one go, then EOF triggers the synthetic-`\n` flush so the
+        // final partial line becomes a complete record.
+        let mut state = ReadSamState::new(reader_from(b"only_one"));
+        let (bytes, offsets) =
+            state.read_next_chunk(1024).expect("read ok").expect("at least one chunk");
+        assert_eq!(offsets, vec![0, 9]);
+        assert_eq!(bytes, b"only_one\n");
+        assert_eq!(state.leftover_len(), 0, "EOF flush should drain leftover");
+    }
+
+    #[test]
+    fn read_next_chunk_returns_none_after_full_drain() {
+        // After EOF + flushed final record, the next call returns None.
+        let mut state = ReadSamState::new(reader_from(b"a\nb\n"));
+        let _first = state.read_next_chunk(1024).expect("read ok").expect("first chunk");
+        let second = state.read_next_chunk(1024).expect("read ok");
+        assert!(second.is_none(), "expected None on second call after drain");
+    }
+
+    #[test]
+    fn read_next_chunk_target_smaller_than_line_does_not_stall() {
+        // Regression test for the target-bytes-as-upper-bound stall: if
+        // `target_bytes` was smaller than the smallest line, the old
+        // upper-bound loop terminated with leftover holding partial
+        // bytes and no newline. Subsequent calls returned empty chunks
+        // forever (the exit condition was already satisfied).
+        //
+        // Fix treats `target_bytes` as a soft LOWER bound: read at least
+        // that many bytes AND wait for a newline before splitting.
+        //
+        // Input: two 5-byte records against a 4-byte target. First call
+        // must emit BOTH records (the Cursor delivers everything in one
+        // `fill_buf`, the second `\n` satisfies the lower bound). A
+        // follow-up call must return None — drained.
+        let mut state = ReadSamState::new(reader_from(b"hello\nworld\n"));
+        let (bytes, offsets) =
+            state.read_next_chunk(4).expect("read ok").expect("at least one chunk");
+        assert_eq!(bytes, b"hello\nworld\n", "must drain both complete records, not stall");
+        assert_eq!(offsets, vec![0, 6, 12], "two records: hello\\n at [0..6], world\\n at [6..12]");
+        assert_eq!(state.leftover_len(), 0, "leftover should be empty after draining");
+
+        // Second call: reader is drained, leftover empty → returns None.
+        let second = state.read_next_chunk(4).expect("read ok");
+        assert!(second.is_none(), "second call must return None — stream fully consumed");
+    }
+
+    #[test]
+    fn read_next_chunk_returns_none_for_empty_input() {
+        let mut state = ReadSamState::new(reader_from(b""));
+        let result = state.read_next_chunk(1024).expect("read ok");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn split_complete_lines_consecutive_newlines_yield_empty_lines() {
+        // "\n\n" — two empty records, both terminated. The parser should
+        // accept zero-length lines; SAM doesn't naturally produce them but
+        // the splitter shouldn't drop them either (drives the invariant
+        // that offsets.windows(2) cover every byte of `complete`).
+        let (offsets, leftover) = split_complete_lines(b"\n\n");
+        assert_eq!(offsets, vec![0, 1, 2]);
+        assert!(leftover.is_empty());
+    }
+
+    #[test]
+    fn read_sam_chunks_profile_advertises_serial_reader_byordinal() {
+        let step = ReadSamChunks::new(reader_from(b""), 64 * 1024, 1024 * 1024);
+        let profile = step.profile();
+        assert_eq!(profile.name, "ReadSamChunks");
+        assert_eq!(profile.kind, crate::pipeline::core::step::StepKind::Serial);
+        assert!(profile.sticky);
+        assert_eq!(step.affinity(), crate::pipeline::core::step::Affinity::Reader);
+        assert_eq!(
+            profile.branch_ordering,
+            vec![crate::pipeline::core::reorder::BranchOrdering::ByItemOrdinal]
+        );
+        assert!(matches!(
+            profile.output_queues[0],
+            crate::pipeline::core::queues::QueueSpec::ByteBounded { .. }
+        ));
+    }
+
+    /// A newline-free span past the ceiling must be rejected as `InvalidData`
+    /// rather than buffered. This is the path the cap exists for — a
+    /// non-newline-delimited input (a binary file handed to the SAM reader)
+    /// would otherwise pull the whole stream into `leftover`.
+    ///
+    /// Driven through a small cap so the rejection is reachable without
+    /// allocating the production-sized ceiling.
+    #[test]
+    fn a_newline_free_span_past_the_cap_is_rejected() {
+        const CAP: usize = 4 * 1024;
+        let input = vec![b'A'; CAP * 4]; // no newline anywhere
+        let mut state = ReadSamState::with_max_record_bytes(
+            Box::new(std::io::BufReader::new(std::io::Cursor::new(input))),
+            CAP,
+        );
+
+        let err = state
+            .read_next_chunk(1024)
+            .expect_err("a newline-free input must be rejected, not buffered");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("newline-delimited"),
+            "error should name the actual problem, got: {err}"
+        );
+    }
+
+    /// The cap must not fire on legitimate input whose records simply exceed the
+    /// soft target: a single long line under the ceiling still parses.
+    #[test]
+    fn a_long_but_terminated_line_under_the_cap_is_accepted() {
+        const CAP: usize = 4 * 1024;
+        let mut input = vec![b'A'; CAP / 2];
+        input.push(b'\n');
+        let expected = input.clone();
+        let mut state = ReadSamState::with_max_record_bytes(
+            Box::new(std::io::BufReader::new(std::io::Cursor::new(input))),
+            CAP,
+        );
+
+        let (bytes, offsets) = state
+            .read_next_chunk(64)
+            .expect("a terminated line under the cap must parse")
+            .expect("one complete record");
+        assert_eq!(bytes, expected);
+        assert_eq!(offsets, vec![0, u32::try_from(expected.len()).unwrap()]);
+    }
+}

--- a/src/lib/pipeline/steps/source/zip_fastq.rs
+++ b/src/lib/pipeline/steps/source/zip_fastq.rs
@@ -1,0 +1,1041 @@
+//! `ZipFastqRecords` step: joins per-stream `FastqChunkBatch` items into
+//! `FastqTemplateBatch` items by matching chunk serials across streams.
+//!
+//! `Serial` + `Affinity::None`. Receives round-robin chunks from
+//! `ReadFastqInputs` and buffers them in a `BTreeMap` keyed by
+//! `chunk_serial`. When all `n_streams` slots for the lowest serial are
+//! filled, the records are zipped into `FastqTemplate`s and emitted.
+
+use std::collections::BTreeMap;
+use std::io;
+
+use crate::fastq_parse::{FastqRecord, strip_read_suffix};
+use crate::grouper::FastqTemplate;
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::item::{HeapSize, Ordered};
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+
+use super::read_fastq::FastqChunkBatch;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FastqTemplateBatch
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub struct FastqTemplateBatch {
+    pub batch_serial: u64,
+    pub templates: Vec<FastqTemplate>,
+    total_bytes: usize,
+}
+
+impl FastqTemplateBatch {
+    #[must_use]
+    pub fn new(batch_serial: u64, templates: Vec<FastqTemplate>) -> Self {
+        let total_bytes: usize = templates.iter().map(HeapSize::heap_size).sum();
+        Self { batch_serial, templates, total_bytes }
+    }
+}
+
+impl HeapSize for FastqTemplateBatch {
+    fn heap_size(&self) -> usize {
+        self.total_bytes
+    }
+}
+
+impl Ordered for FastqTemplateBatch {
+    fn ordinal(&self) -> u64 {
+        self.batch_serial
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ZipFastqRecords — Serial step
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_PENDING_BACKPRESSURE_BYTES: usize = 256 * 1024 * 1024;
+
+/// Outcome of a full egress drain attempt ([`ZipFastqRecords::drain_complete`]).
+enum DrainStop {
+    /// The lowest serial is incomplete (or `pending` is empty): nothing more to
+    /// emit right now. `emitted` records whether at least one batch left.
+    Exhausted { emitted: bool },
+    /// A downstream push could not complete; the unpushed batch is now in
+    /// `self.held`. The caller must stop draining immediately (no further serial
+    /// may be emitted while the single held slot is occupied) and return
+    /// `Progress` — parking a complete serial in `held` is real forward progress,
+    /// and the held-slot retry preamble on the next dispatch flushes it before
+    /// any more work runs (see the `try_run` call site).
+    Held,
+}
+
+pub struct ZipFastqRecords {
+    n_streams: usize,
+    pending: BTreeMap<u64, Vec<Option<FastqChunkBatch>>>,
+    pending_total_bytes: usize,
+    pending_backpressure_bytes: usize,
+    held: HeldSlot<Unpushed<FastqTemplateBatch>>,
+    output_byte_limit: u64,
+    next_batch_serial: u64,
+    /// Whether the soft-limit warning has already fired for the current
+    /// over-limit episode. This step is `Serial` and the driver re-dispatches it
+    /// in a tight loop, so an unguarded warning emits one identical line per
+    /// dispatch for the whole time a legitimately-ahead stream stays over the
+    /// limit — the exact case the branch exists to admit. Cleared when the
+    /// buffer drops back under the limit, so each episode warns once.
+    over_soft_limit_warned: bool,
+}
+
+impl ZipFastqRecords {
+    /// Construct a zipper for `n_streams` FASTQ streams.
+    ///
+    /// # Preconditions
+    ///
+    /// `n_streams >= 1`. The count is wired from the FASTQ-input count, which
+    /// is always at least one, and `try_emit_complete` indexes
+    /// `stream_records[0]`, so a zero-stream configuration would panic on that
+    /// index. A `debug_assert!` makes an accidental zero-stream wiring fail
+    /// loudly in debug/test builds.
+    #[must_use]
+    pub fn new(n_streams: usize, output_byte_limit: u64) -> Self {
+        debug_assert!(n_streams >= 1, "ZipFastqRecords requires n_streams >= 1, got {n_streams}");
+        Self {
+            n_streams,
+            pending: BTreeMap::new(),
+            pending_total_bytes: 0,
+            pending_backpressure_bytes: DEFAULT_PENDING_BACKPRESSURE_BYTES,
+            held: HeldSlot::new(),
+            output_byte_limit,
+            next_batch_serial: 0,
+            over_soft_limit_warned: false,
+        }
+    }
+
+    /// Latch the over-soft-limit episode, returning `true` only on the dispatch
+    /// that *enters* it.
+    ///
+    /// The caller warns on `true`. Because this step is `Serial` and the driver
+    /// re-dispatches it in a tight loop, warning unconditionally would emit one
+    /// identical line per dispatch for as long as a legitimately-ahead stream
+    /// stays over the limit.
+    fn enter_over_soft_limit(&mut self) -> bool {
+        let first = !self.over_soft_limit_warned;
+        self.over_soft_limit_warned = true;
+        first
+    }
+
+    /// Clear the episode latch, so the next crossing warns again.
+    fn leave_over_soft_limit(&mut self) {
+        self.over_soft_limit_warned = false;
+    }
+
+    /// Override the soft pending-backpressure limit (test-only).
+    ///
+    /// Production wires the default 256 MiB limit; tests shrink it to a few KiB
+    /// so a lag-then-burst scenario can cross the soft/hard thresholds with a
+    /// handful of small records rather than hundreds of megabytes of data.
+    #[cfg(test)]
+    fn with_backpressure_bytes(mut self, bytes: usize) -> Self {
+        self.pending_backpressure_bytes = bytes;
+        self
+    }
+
+    /// Egress: emit every currently-complete consecutive lowest serial.
+    ///
+    /// Loops [`Self::try_emit_complete`] until it yields `None` (the lowest
+    /// serial is incomplete or `pending` is empty) or a downstream push fails.
+    /// On a failed push the unpushed batch is stashed in `self.held` and the
+    /// loop stops — the single held slot can hold only one item, so no further
+    /// serial may be emitted until it flushes on a later dispatch.
+    ///
+    /// Backpressure never gates this: draining is the only action that relieves
+    /// pending-byte pressure, so it must always run. Bounded: each successful
+    /// emit removes one key from `pending` (in `try_emit_complete`), so the loop
+    /// runs at most `pending.len()` times and strictly shrinks `pending`.
+    ///
+    /// Precondition: `self.held` is empty (the held-slot preamble in `try_run`
+    /// guarantees this by returning `Contention` on a failed retry).
+    fn drain_complete(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<DrainStop> {
+        debug_assert!(
+            !self.held.is_held(),
+            "drain_complete requires an empty held slot — the try_run preamble must clear it"
+        );
+        let mut emitted = false;
+        loop {
+            match self.try_emit_complete()? {
+                None => return Ok(DrainStop::Exhausted { emitted }),
+                Some(template_batch) => match ctx.outputs.push(template_batch) {
+                    Ok(()) => emitted = true,
+                    Err(unpushed) => {
+                        self.held.put(unpushed);
+                        return Ok(DrainStop::Held);
+                    }
+                },
+            }
+        }
+    }
+
+    fn try_emit_complete(&mut self) -> io::Result<Option<FastqTemplateBatch>> {
+        let Some(lowest_serial) = self.pending.keys().next().copied() else {
+            return Ok(None);
+        };
+
+        let slots = self.pending.get(&lowest_serial).unwrap();
+        let all_filled = slots.iter().all(Option::is_some);
+        if !all_filled {
+            return Ok(None);
+        }
+
+        let chunks: Vec<FastqChunkBatch> = self
+            .pending
+            .remove(&lowest_serial)
+            .unwrap()
+            .into_iter()
+            .map(|opt| opt.expect("every slot is filled — checked by `all_filled` above"))
+            .collect();
+
+        // Subtract using each batch's own `HeapSize`, which is the measure the
+        // byte-bounded queues budget and the same one the insert side adds. A
+        // hand-rolled sum over `records` would be a *second* measure of the same
+        // chunk: it happens to agree today because the records are moved through
+        // unchanged, but `FastqChunkBatch::new` takes `total_bytes` as a
+        // parameter rather than deriving it, so the two can diverge — and then
+        // `pending_total_bytes` would drift against the queue budget and the
+        // soft/hard thresholds would fire on a different measure than the queues
+        // enforce.
+        let chunk_bytes: usize = chunks.iter().map(HeapSize::heap_size).sum();
+        self.pending_total_bytes = self.pending_total_bytes.saturating_sub(chunk_bytes);
+
+        let mut stream_records: Vec<Vec<FastqRecord>> =
+            chunks.into_iter().map(|chunk| chunk.records).collect();
+
+        let n_records = stream_records[0].len();
+
+        // Paired/N-stream FASTQ is positionally parallel: every stream must
+        // contribute the same number of records for this chunk. Reject a
+        // mismatch explicitly (matches the N==2 ParseAndZipFastq path and
+        // fgbio's FastqSource.zipped "out of sync" check) rather than letting
+        // it surface as an incidental name mismatch from the back-pop below.
+        for (stream_idx, recs) in stream_records.iter().enumerate().skip(1) {
+            if recs.len() != n_records {
+                return Err(io::Error::other(format!(
+                    "FASTQ sources out of sync at chunk_serial {lowest_serial}: \
+                     stream 0 has {n_records} records, stream {stream_idx} has {}",
+                    recs.len(),
+                )));
+            }
+        }
+
+        // Zip across streams: record i from each stream forms one template.
+        // Drain from the back (via pop) to avoid O(n^2) from front removal;
+        // reverse in place afterwards.
+        let mut templates = Vec::with_capacity(n_records);
+        for _ in 0..n_records {
+            let mut records = Vec::with_capacity(self.n_streams);
+            let mut base_name: Option<Vec<u8>> = None;
+
+            for (stream_idx, stream) in stream_records.iter_mut().enumerate() {
+                // Unreachable after the equal-count check above; kept defensive.
+                let Some(record) = stream.pop() else {
+                    return Err(io::Error::other(format!(
+                        "FASTQ sources out of sync: stream {stream_idx} ran short at chunk_serial {lowest_serial}",
+                    )));
+                };
+
+                let stripped = strip_read_suffix(record.name());
+                match &base_name {
+                    None => {
+                        base_name = Some(stripped.to_vec());
+                    }
+                    Some(expected) => {
+                        if stripped != expected.as_slice() {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!(
+                                    "FASTQ read name mismatch at chunk_serial {}: stream 0 has '{}', stream {} has '{}'",
+                                    lowest_serial,
+                                    String::from_utf8_lossy(expected),
+                                    stream_idx,
+                                    String::from_utf8_lossy(stripped),
+                                ),
+                            ));
+                        }
+                    }
+                }
+                records.push(record);
+            }
+
+            templates.push(FastqTemplate { name: base_name.unwrap(), records });
+        }
+
+        // We popped from the back, so reverse to restore original order.
+        templates.reverse();
+
+        let serial = self.next_batch_serial;
+        self.next_batch_serial += 1;
+        Ok(Some(FastqTemplateBatch::new(serial, templates)))
+    }
+}
+
+impl Step for ZipFastqRecords {
+    type Input = FastqChunkBatch;
+    type Outputs = OrderedBytesSingle<FastqTemplateBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "ZipFastqRecords",
+            kind: StepKind::Serial,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        // ── (a) Held-slot retry preamble ────────────────────────────────────
+        // Single-occupancy: if the retry still can't push, re-hold and return
+        // Contention so control never reaches egress/ingress with a full slot.
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        // ── (b) Full egress drain — ALWAYS runs, before any backpressure gate.
+        // Draining the complete lowest serials is the ONLY action that relieves
+        // pending-byte pressure, so it must never be throttled (the previous
+        // code returned NoProgress/Err on backpressure *before* emitting, which
+        // wedged the step whenever the lowest serial was already complete but
+        // over the soft limit — see issue notes for S5a1-001).
+        match self.drain_complete(ctx)? {
+            // `Held` means a complete serial was removed from `pending` (bytes
+            // subtracted) and parked in the held slot for retry — that is real
+            // forward progress ("held one for later"), not mutex contention.
+            // Misreporting it as `Contention` on this liveness-critical
+            // backpressure path would understate progress to the driver.
+            DrainStop::Held => return Ok(StepOutcome::Progress),
+            DrainStop::Exhausted { emitted } => {
+                // If anything was emitted, report Progress now: pressure dropped
+                // and the next dispatch re-evaluates ingress against the new
+                // (lower) byte total. We deliberately do NOT also pop input this
+                // dispatch — that keeps the held-slot single-occupancy reasoning
+                // trivial and gives the driver a clean re-dispatch point.
+                if emitted {
+                    return Ok(StepOutcome::Progress);
+                }
+                // Nothing emitted ⇒ the lowest serial is incomplete (or pending
+                // is empty). Fall through to the desync check / ingress gate.
+            }
+        }
+
+        // Reaching here: `pending` is empty OR its lowest serial is incomplete,
+        // and the held slot is empty.
+
+        // ── (c) Hard desync abort — predicated on a genuinely-stuck serial ───
+        // Abort ONLY when the lowest serial is still incomplete after a full
+        // drain AND the buffer is over the hard limit. A complete lowest serial
+        // is drained in (b) before this check, so a non-empty `pending` here
+        // means the lowest serial is incomplete; if bytes are also over 2x, one
+        // stream is producing unboundedly more than its counterpart — a real
+        // desync. (The old predicate fired on bytes alone, false-aborting an
+        // in-sync but ahead stream whose lowest serial was emittable.)
+        let lowest_incomplete = !self.pending.is_empty();
+        if lowest_incomplete && self.pending_total_bytes > 2 * self.pending_backpressure_bytes {
+            let (&serial, _) = self.pending.iter().next().expect("pending non-empty");
+            return Err(io::Error::other(format!(
+                "ZipFastqRecords: catastrophic stream desync — lowest chunk_serial {serial} \
+                 is still incomplete while pending buffer ({} bytes) exceeds 2x backpressure \
+                 limit ({} bytes). One FASTQ stream is producing far more data than its \
+                 counterpart.",
+                self.pending_total_bytes, self.pending_backpressure_bytes
+            )));
+        }
+
+        // ── (c') Advisory soft limit — warn, never refuse ────────────────────
+        // Being over the soft limit does *not* throttle ingress, and cannot: the
+        // chunk that completes the lowest serial (and so lets egress drain) is
+        // itself still queued in `ctx.input`, so refusing input here would stall
+        // the very drain that relieves the pressure. That is the S5a1-001
+        // deadlock. The hard 2x abort above is therefore the sole bound on
+        // `pending`, and this arm only reports.
+        //
+        // An earlier revision also refused ingress when `pending` was empty, as a
+        // precautionary throttle. That branch could never run: `pending_total_bytes`
+        // moves only with `pending` — bytes are added on insert and the same sum
+        // is subtracted when the entry is removed — so an empty `pending` always
+        // means zero bytes, which is never over a positive limit. The assert below
+        // pins that invariant, so a future accounting change that breaks it is
+        // loud in debug builds rather than silently resurrecting dead code.
+        debug_assert!(
+            !self.pending.is_empty() || self.pending_total_bytes == 0,
+            "pending accounting desync: empty pending must imply zero bytes, got {}",
+            self.pending_total_bytes
+        );
+        if self.pending_total_bytes > self.pending_backpressure_bytes {
+            // Once per over-limit episode, not once per dispatch.
+            if self.enter_over_soft_limit() {
+                log::warn!(
+                    "ZipFastqRecords: pending buffer exceeds backpressure limit ({} > {}); lowest \
+                     serial incomplete, continuing ingress to complete it",
+                    self.pending_total_bytes,
+                    self.pending_backpressure_bytes
+                );
+            }
+        } else {
+            self.leave_over_soft_limit();
+        }
+
+        // ── (d) Ingress: pop one input chunk + insert, then drain again ──────
+        let Some(batch) = ctx.input.pop() else {
+            // No input this call. Egress already ran in (b) and emitted nothing,
+            // so the lowest serial is incomplete. If upstream is drained, this
+            // is the residual-completion / EOF path: every remaining entry must
+            // be complete (all streams ended cleanly) — a `None` slot means a
+            // stream ended early (out of sync).
+            if ctx.input.is_drained() {
+                if let Some((&serial, slots)) = self.pending.iter().next() {
+                    for (idx, slot) in slots.iter().enumerate() {
+                        if slot.is_none() {
+                            return Err(io::Error::other(format!(
+                                "FASTQ sources out of sync: stream {idx} ended before \
+                                 chunk_serial {serial} while other streams had more records",
+                            )));
+                        }
+                    }
+                    // All slots present but the full drain in (b) emitted
+                    // nothing: unreachable (a complete lowest entry always
+                    // emits). Fail loud — returning NoProgress here would hang
+                    // (input is drained, so the step is never re-fed).
+                    return Err(io::Error::other(format!(
+                        "ZipFastqRecords: chunk_serial {serial} has all streams present but \
+                         did not emit — internal invariant violated",
+                    )));
+                }
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+
+        let chunk_serial = batch.chunk_serial;
+        let stream_idx = batch.stream_idx;
+        // The batch's own `HeapSize`, matching the removal side and the measure
+        // the byte-bounded queues budget — see the note in `try_emit_complete`.
+        let batch_bytes: usize = batch.heap_size();
+
+        let n = self.n_streams;
+        let slots =
+            self.pending.entry(chunk_serial).or_insert_with(|| (0..n).map(|_| None).collect());
+        // `stream_idx` is set by the upstream splitter and is an invariant, not
+        // input — but indexing on a violated invariant would panic inside a
+        // worker. Fail closed with the step's own error path instead, keeping a
+        // `debug_assert!` so a violation is loud in development.
+        debug_assert!(stream_idx < n, "stream_idx {stream_idx} out of range for {n} streams");
+        let Some(slot) = slots.get_mut(stream_idx) else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("ZipFastqRecords: stream_idx {stream_idx} out of range for {n} streams"),
+            ));
+        };
+        *slot = Some(batch);
+        self.pending_total_bytes += batch_bytes;
+
+        // The new chunk may have completed the lowest serial. Run the full drain
+        // again so a completion is emitted immediately (one unified egress
+        // path). Held single-occupancy holds: the preamble guaranteed the slot
+        // empty and this drain only `put`s after a `take`-confirmed empty slot.
+        // Both drain outcomes are forward progress here — this dispatch consumed
+        // an input chunk, and `Held` additionally parked a freshly dequeued
+        // serial for retry — so report `Progress` either way (never `Contention`).
+        self.drain_complete(ctx)?;
+        Ok(StepOutcome::Progress)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fastq_parse::FastqRecord;
+    use crate::pipeline::core::item::Ordered;
+
+    fn make_record(name: &str, seq: &str) -> FastqRecord {
+        let qual: String = std::iter::repeat_n('I', seq.len()).collect();
+        let data = format!("@{name}\n{seq}\n+\n{qual}\n");
+        FastqRecord::from_slice(data.as_bytes()).unwrap()
+    }
+
+    fn make_chunk(
+        stream_idx: usize,
+        chunk_serial: u64,
+        records: Vec<FastqRecord>,
+    ) -> FastqChunkBatch {
+        let total_bytes: usize = records.iter().map(HeapSize::heap_size).sum();
+        // ZipFastqRecords joins by (stream_idx, chunk_serial) and does not read
+        // `ordinal`, so the per-chunk ordinal is irrelevant to the join. Derive
+        // a deterministic unique value for clarity.
+        let ordinal = chunk_serial * 8 + stream_idx as u64;
+        FastqChunkBatch::new(ordinal, stream_idx, chunk_serial, records, total_bytes)
+    }
+
+    #[test]
+    fn fastq_template_batch_heap_size_and_ordinal() {
+        let batch = FastqTemplateBatch::new(42, vec![]);
+        assert_eq!(batch.heap_size(), 0);
+        assert_eq!(batch.ordinal(), 42);
+    }
+
+    #[test]
+    fn test_zip_1_stream() {
+        let mut zip = ZipFastqRecords::new(1, 64 * 1024 * 1024);
+
+        let r1 = make_record("read1", "ACGT");
+        let r2 = make_record("read2", "TGCA");
+        let chunk = make_chunk(0, 0, vec![r1, r2]);
+
+        // Insert the chunk.
+        zip.pending.insert(0, vec![Some(chunk)]);
+
+        let batch = zip.try_emit_complete().unwrap().unwrap();
+        assert_eq!(batch.templates.len(), 2);
+        assert_eq!(batch.templates[0].name, b"read1");
+        assert_eq!(batch.templates[0].records.len(), 1);
+        assert_eq!(batch.templates[1].name, b"read2");
+        assert_eq!(batch.templates[1].records.len(), 1);
+        assert_eq!(batch.ordinal(), 0);
+    }
+
+    #[test]
+    fn test_zip_2_streams() {
+        let mut zip = ZipFastqRecords::new(2, 64 * 1024 * 1024);
+
+        let r1_s0 = make_record("read1/1", "ACGT");
+        let r2_s0 = make_record("read2/1", "TGCA");
+        let chunk_s0 = make_chunk(0, 0, vec![r1_s0, r2_s0]);
+
+        let r1_s1 = make_record("read1/2", "GGGG");
+        let r2_s1 = make_record("read2/2", "CCCC");
+        let chunk_s1 = make_chunk(1, 0, vec![r1_s1, r2_s1]);
+
+        zip.pending.insert(0, vec![Some(chunk_s0), Some(chunk_s1)]);
+
+        let batch = zip.try_emit_complete().unwrap().unwrap();
+        assert_eq!(batch.templates.len(), 2);
+        assert_eq!(batch.templates[0].name, b"read1");
+        assert_eq!(batch.templates[0].records.len(), 2);
+        assert_eq!(batch.templates[0].records[0].sequence(), b"ACGT");
+        assert_eq!(batch.templates[0].records[1].sequence(), b"GGGG");
+        assert_eq!(batch.templates[1].name, b"read2");
+        assert_eq!(batch.templates[1].records.len(), 2);
+    }
+
+    #[test]
+    fn test_zip_3_streams() {
+        let mut zip = ZipFastqRecords::new(3, 64 * 1024 * 1024);
+
+        let mk = |suffix: &str, seq: &str| make_record(&format!("read1{suffix}"), seq);
+        let chunk_s0 = make_chunk(0, 0, vec![mk("/1", "AAAA")]);
+        let chunk_s1 = make_chunk(1, 0, vec![mk("/2", "CCCC")]);
+        let chunk_s2 = make_chunk(2, 0, vec![mk("", "GGGG")]);
+
+        zip.pending.insert(0, vec![Some(chunk_s0), Some(chunk_s1), Some(chunk_s2)]);
+
+        let batch = zip.try_emit_complete().unwrap().unwrap();
+        assert_eq!(batch.templates.len(), 1);
+        assert_eq!(batch.templates[0].name, b"read1");
+        assert_eq!(batch.templates[0].records.len(), 3);
+    }
+
+    #[test]
+    fn test_zip_4_streams() {
+        let mut zip = ZipFastqRecords::new(4, 64 * 1024 * 1024);
+
+        let mk = |suffix: &str, seq: &str| make_record(&format!("readA{suffix}"), seq);
+        let chunk_s0 = make_chunk(0, 0, vec![mk("/1", "AAAA")]);
+        let chunk_s1 = make_chunk(1, 0, vec![mk("/2", "CCCC")]);
+        let chunk_s2 = make_chunk(2, 0, vec![mk("", "GGGG")]);
+        let chunk_s3 = make_chunk(3, 0, vec![mk("", "TTTT")]);
+
+        zip.pending.insert(0, vec![Some(chunk_s0), Some(chunk_s1), Some(chunk_s2), Some(chunk_s3)]);
+
+        let batch = zip.try_emit_complete().unwrap().unwrap();
+        assert_eq!(batch.templates.len(), 1);
+        assert_eq!(batch.templates[0].name, b"readA");
+        assert_eq!(batch.templates[0].records.len(), 4);
+    }
+
+    #[test]
+    fn test_zip_desync_bails() {
+        let mut zip = ZipFastqRecords::new(2, 64 * 1024 * 1024);
+
+        // Stream 0 has chunk_serial 0, stream 1 is missing.
+        let r1 = make_record("read1/1", "ACGT");
+        let chunk = make_chunk(0, 0, vec![r1]);
+        zip.pending.insert(0, vec![Some(chunk), None]);
+
+        // The drained-completion path in `try_run` walks `pending` and errors
+        // on a half-filled serial. Since we can't build a `StepCtx` here, test
+        // the pending state detection directly.
+        let slots = zip.pending.get(&0).unwrap();
+        let all_filled = slots.iter().all(Option::is_some);
+        assert!(!all_filled, "incomplete slot should be detected");
+
+        // Verify that try_emit_complete returns None for partial entries.
+        let result = zip.try_emit_complete().unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_zip_name_mismatch_errors() {
+        let mut zip = ZipFastqRecords::new(2, 64 * 1024 * 1024);
+
+        let r1_s0 = make_record("readA/1", "ACGT");
+        let r1_s1 = make_record("readB/2", "GGGG");
+        let chunk_s0 = make_chunk(0, 0, vec![r1_s0]);
+        let chunk_s1 = make_chunk(1, 0, vec![r1_s1]);
+
+        zip.pending.insert(0, vec![Some(chunk_s0), Some(chunk_s1)]);
+
+        let err = zip.try_emit_complete().unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("mismatch"), "expected name mismatch error, got: {msg}");
+    }
+
+    /// Within a complete chunk, unequal per-stream record counts are rejected
+    /// by the explicit strict count check (fgbio-consistent), not surfaced as a
+    /// name mismatch. Matches the `N==2` `ParseAndZipFastq` path.
+    #[test]
+    fn test_zip_unequal_counts_out_of_sync() {
+        let mut zip = ZipFastqRecords::new(2, 64 * 1024 * 1024);
+
+        // Same chunk_serial, both streams present, but stream 0 has 2 records
+        // and stream 1 has 1.
+        let s0 =
+            make_chunk(0, 0, vec![make_record("read1/1", "ACGT"), make_record("read2/1", "TT")]);
+        let s1 = make_chunk(1, 0, vec![make_record("read1/2", "GGGG")]);
+        zip.pending.insert(0, vec![Some(s0), Some(s1)]);
+
+        let err = zip.try_emit_complete().unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("out of sync"), "expected count out-of-sync error, got: {msg}");
+    }
+
+    #[test]
+    fn test_zip_multiple_serials_in_order() {
+        let mut zip = ZipFastqRecords::new(1, 64 * 1024 * 1024);
+
+        let chunk0 = make_chunk(0, 0, vec![make_record("read1", "AAAA")]);
+        let chunk1 = make_chunk(0, 1, vec![make_record("read2", "CCCC")]);
+
+        zip.pending.insert(0, vec![Some(chunk0)]);
+        zip.pending.insert(1, vec![Some(chunk1)]);
+
+        let batch0 = zip.try_emit_complete().unwrap().unwrap();
+        assert_eq!(batch0.ordinal(), 0);
+        assert_eq!(batch0.templates[0].name, b"read1");
+
+        let batch1 = zip.try_emit_complete().unwrap().unwrap();
+        assert_eq!(batch1.ordinal(), 1);
+        assert_eq!(batch1.templates[0].name, b"read2");
+    }
+
+    #[test]
+    fn profile_advertises_serial_byordinal() {
+        let step = ZipFastqRecords::new(2, 1024);
+        let p = step.profile();
+        assert_eq!(p.name, "ZipFastqRecords");
+        assert_eq!(p.kind, StepKind::Serial);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // S5a1-001 regression: lag-then-burst over the soft backpressure limit.
+    //
+    // The buggy code returned NoProgress/Err on backpressure *before* draining
+    // the (already-complete) lowest serial, so once `pending` crossed the soft
+    // limit with the lowest serial incomplete and input still queued, the step
+    // wedged forever (NoProgress on every re-dispatch, never popping the chunk
+    // that would complete the serial). The test below drives the REAL `try_run`
+    // through a `Pipeline` with a tiny soft limit and a lag-then-burst stream
+    // pattern; under the bug it deadlocks and the watchdog fires, under the fix
+    // it completes and emits every zipped template in order.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrd};
+
+    use crate::pipeline::core::step::Affinity;
+    use crate::pipeline::core::{PipelineBuilder, PipelineConfig};
+
+    /// `(batch_serial, template names)` recorded by the collecting sink.
+    type SeenBatches = Arc<Mutex<Vec<(u64, Vec<Vec<u8>>)>>>;
+
+    /// Bytes per FASTQ record this source emits. Sized so a small run of
+    /// records crosses the few-KiB soft limit the test sets on the zipper.
+    const TEST_RECORD_SEQ_LEN: usize = 200;
+    /// Number of chunk serials emitted per stream.
+    const TEST_N_SERIALS: u64 = 12;
+    /// Soft backpressure limit for the zipper under test. Sized so the lagging
+    /// streams (streams 0 and 1, `TEST_N_SERIALS` records each at
+    /// `TEST_RECORD_SEQ_LEN` bytes) cross the soft limit before the stream-2
+    /// burst arrives, yet stay UNDER the 2x hard-desync limit — the lag is a
+    /// legitimately-ahead in-sync stream, not a genuine desync, so the hard arm
+    /// must NOT fire. (~12 records/stream * 2 streams * ~280 B ≈ 6.7 KiB, which
+    /// is > soft (5 KiB) and < hard (10 KiB).)
+    const TEST_SOFT_LIMIT_BYTES: usize = 5 * 1024;
+
+    fn big_record(name: &str) -> FastqRecord {
+        let seq: String = std::iter::repeat_n('A', TEST_RECORD_SEQ_LEN).collect();
+        make_record(name, &seq)
+    }
+
+    /// Serial source that emits `FastqChunkBatch` items in a deliberately
+    /// skewed order: all of streams 0 and 1 (serials `0..N`) FIRST, then all of
+    /// stream 2 in a burst. The leading streams pile up incomplete lowest
+    /// serials in the zipper (stream 2's slot is missing) and push it over the
+    /// soft limit before the completing burst arrives.
+    struct LagThenBurstSource {
+        /// Emission plan: each entry is `(stream_idx, chunk_serial)`.
+        plan: Vec<(usize, u64)>,
+        next: usize,
+        ordinals: crate::pipeline::steps::source::read_fastq::FastqOrdinalSequence,
+        held: HeldSlot<Unpushed<FastqChunkBatch>>,
+        output_byte_limit: u64,
+    }
+
+    impl LagThenBurstSource {
+        fn new(n_serials: u64, n_streams_total: usize, output_byte_limit: u64) -> Self {
+            let mut plan = Vec::new();
+            // Streams 0..n-1 first (the "lag"): every serial of every leading
+            // stream before any of the final stream.
+            for stream_idx in 0..n_streams_total - 1 {
+                for serial in 0..n_serials {
+                    plan.push((stream_idx, serial));
+                }
+            }
+            // Final stream in a burst: a run of consecutive lowest serials
+            // becomes complete at once.
+            for serial in 0..n_serials {
+                plan.push((n_streams_total - 1, serial));
+            }
+            Self {
+                plan,
+                next: 0,
+                ordinals: crate::pipeline::steps::source::read_fastq::FastqOrdinalSequence::new(),
+                held: HeldSlot::new(),
+                output_byte_limit,
+            }
+        }
+
+        /// A plan in which only stream 0 ever emits, so the lowest serial can
+        /// never complete and `pending` grows without bound — a genuine desync,
+        /// as opposed to the in-sync-but-ahead lag the burst plan models.
+        fn with_only_the_first_stream(n_serials: u64, output_byte_limit: u64) -> Self {
+            let plan = (0..n_serials).map(|serial| (0usize, serial)).collect();
+            Self {
+                plan,
+                next: 0,
+                ordinals: crate::pipeline::steps::source::read_fastq::FastqOrdinalSequence::new(),
+                held: HeldSlot::new(),
+                output_byte_limit,
+            }
+        }
+
+        /// The same plan with the final stream stopped one serial short, so a
+        /// `pending` entry still has an empty slot when input drains — the
+        /// truncated-input shape the EOF-desync guard exists to diagnose.
+        fn with_final_stream_truncated(
+            n_serials: u64,
+            n_streams_total: usize,
+            output_byte_limit: u64,
+        ) -> Self {
+            let mut source = Self::new(n_serials, n_streams_total, output_byte_limit);
+            source.plan.pop().expect("plan is non-empty");
+            source
+        }
+    }
+
+    impl Step for LagThenBurstSource {
+        type Input = ();
+        type Outputs = OrderedBytesSingle<FastqChunkBatch>;
+
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "LagThenBurstSource",
+                kind: StepKind::Serial,
+                sticky: false,
+                output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+                branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+            }
+        }
+
+        fn affinity(&self) -> Affinity {
+            Affinity::Reader
+        }
+
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            if let Some(unpushed) = self.held.take() {
+                match ctx.outputs.retry(unpushed) {
+                    Ok(()) => {}
+                    Err(again) => {
+                        self.held.put(again);
+                        return Ok(StepOutcome::Contention);
+                    }
+                }
+            }
+
+            let Some(&(stream_idx, chunk_serial)) = self.plan.get(self.next) else {
+                return Ok(StepOutcome::Finished);
+            };
+            self.next += 1;
+
+            // Trailing non-digit so `strip_read_suffix` does not eat the serial
+            // (it strips a `_`/`/`/`.`/`:` + `1`/`2` pair-suffix).
+            let name = format!("read{chunk_serial}x");
+            let record = big_record(&name);
+            let total_bytes = record.heap_size();
+            // Draw from the same shared sequence production uses, so the
+            // harness cannot drift from what the reader emits. Ordinals follow
+            // emission order; the zipper keys on `chunk_serial`, so the skewed
+            // plan this source exists to produce is unaffected.
+            let ordinal = self.ordinals.next();
+            let chunk =
+                FastqChunkBatch::new(ordinal, stream_idx, chunk_serial, vec![record], total_bytes);
+
+            match ctx.outputs.push(chunk) {
+                Ok(()) => Ok(StepOutcome::Progress),
+                Err(unpushed) => {
+                    self.held.put(unpushed);
+                    Ok(StepOutcome::Progress)
+                }
+            }
+        }
+    }
+
+    /// Serial (single-consumer) sink that records, per emitted batch, its
+    /// `batch_serial` and the names of the templates it carries, so the test can
+    /// assert full drain and correct zipping/order. A `Serial` sink drains the
+    /// queue in FIFO order on one worker, so the recorded sequence is the true
+    /// emission order — letting the test assert ordering directly instead of
+    /// sorting (which would only prove set equality).
+    #[derive(Clone)]
+    struct CollectingSink {
+        seen: SeenBatches,
+        count: Arc<AtomicUsize>,
+    }
+
+    impl Step for CollectingSink {
+        type Input = FastqTemplateBatch;
+        type Outputs = ();
+
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "CollectingSink",
+                kind: StepKind::Serial,
+                sticky: false,
+                output_queues: vec![],
+                branch_ordering: vec![],
+            }
+        }
+
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            match ctx.input.pop() {
+                Some(batch) => {
+                    let names: Vec<Vec<u8>> =
+                        batch.templates.iter().map(|t| t.name.clone()).collect();
+                    self.seen.lock().unwrap().push((batch.batch_serial, names));
+                    self.count.fetch_add(1, AtomicOrd::Relaxed);
+                    Ok(StepOutcome::Progress)
+                }
+                None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+                None => Ok(StepOutcome::NoProgress),
+            }
+        }
+
+        fn new_worker_copy(&self) -> Self {
+            self.clone()
+        }
+    }
+
+    /// The soft-limit warning must fire once per over-limit *episode*, not once
+    /// per dispatch. The step is `Serial` and the driver re-dispatches it in a
+    /// tight loop, so an unlatched warning floods the log for the whole time an
+    /// ahead-but-in-sync stream sits over the limit — burying everything else.
+    #[test]
+    fn soft_limit_warning_latches_once_per_episode() {
+        let mut zip = ZipFastqRecords::new(1, 64 * 1024);
+
+        assert!(zip.enter_over_soft_limit(), "the dispatch that enters the episode must warn");
+        assert!(!zip.enter_over_soft_limit(), "a later dispatch in the same episode must not");
+        assert!(!zip.enter_over_soft_limit(), "nor any after that");
+
+        zip.leave_over_soft_limit();
+
+        assert!(zip.enter_over_soft_limit(), "a fresh episode must warn again");
+    }
+
+    /// Sized so a stream-0-only plan clears the 2x hard-desync ceiling with room
+    /// to spare: 12 serials * ~280 B/record is ~3.4 KB, well past 2 * 512 B.
+    /// Deliberately not `TEST_SOFT_LIMIT_BYTES` — that one is tuned so the
+    /// lag-then-burst case stays *under* the hard ceiling.
+    const TEST_HARD_ABORT_LIMIT_BYTES: usize = 512;
+
+    /// A genuinely desynced stream must abort, and this is the only bound on
+    /// `pending`.
+    ///
+    /// The soft limit deliberately does not refuse ingress — doing so deadlocks,
+    /// since the chunk that completes the lowest serial is itself still queued
+    /// upstream — so this 2x abort is what stops an unbounded buffer. Its
+    /// predicate is a conjunction (lowest serial still incomplete after a full
+    /// drain AND bytes past 2x), and a regression weakening either half, or
+    /// reverting to a bytes-only predicate, would leave the suite green while
+    /// removing the ceiling entirely.
+    ///
+    /// This pins the direction `zip_does_not_deadlock_on_lag_then_burst_over_soft_limit`
+    /// cannot: that test proves the abort does *not* fire for an ahead-but-in-sync
+    /// stream. Together they fix both sides of the predicate.
+    #[test]
+    fn zip_aborts_on_a_genuine_stream_desync() {
+        let n_streams = 2usize;
+        let seen = Arc::new(Mutex::new(Vec::<(u64, Vec<Vec<u8>>)>::new()));
+        let count = Arc::new(AtomicUsize::new(0));
+
+        // Only stream 0 emits, so serial 0 never completes and every chunk stays
+        // resident in `pending`.
+        let source = LagThenBurstSource::with_only_the_first_stream(TEST_N_SERIALS, 64 * 1024);
+        let zip = ZipFastqRecords::new(n_streams, 64 * 1024)
+            .with_backpressure_bytes(TEST_HARD_ABORT_LIMIT_BYTES);
+        let sink = CollectingSink { seen: Arc::clone(&seen), count: Arc::clone(&count) };
+
+        let builder = PipelineBuilder::new();
+        builder.chain(source).chain(zip).chain(sink).into_sink_marker();
+        let pipeline = builder.build().expect("chain builds");
+
+        let err = pipeline
+            .run(PipelineConfig { threads: 2, ..Default::default() })
+            .expect_err("a one-sided stream must abort rather than buffer without bound");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("catastrophic stream desync"),
+            "expected the hard 2x desync abort, got: {msg}"
+        );
+    }
+
+    /// A stream that ends before its counterparts must fail the run with a
+    /// diagnosable message rather than silently dropping the unmatched records.
+    ///
+    /// This is the guard that turns a truncated FASTQ input — one file cut short,
+    /// a partial download — into an error naming the stream and serial. It sits
+    /// on the input-drained path inside `try_run`, so it needs a real `Pipeline`
+    /// to reach: the `try_emit_complete` unit tests above cannot drive it.
+    #[test]
+    fn zip_reports_a_stream_that_ends_early() {
+        let n_streams = 2usize;
+        let seen = Arc::new(Mutex::new(Vec::<(u64, Vec<Vec<u8>>)>::new()));
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let source =
+            LagThenBurstSource::with_final_stream_truncated(TEST_N_SERIALS, n_streams, 64 * 1024);
+        let zip = ZipFastqRecords::new(n_streams, 64 * 1024);
+        let sink = CollectingSink { seen: Arc::clone(&seen), count: Arc::clone(&count) };
+
+        let builder = PipelineBuilder::new();
+        builder.chain(source).chain(zip).chain(sink).into_sink_marker();
+        let pipeline = builder.build().expect("chain builds");
+
+        let err = pipeline
+            .run(PipelineConfig { threads: 2, ..Default::default() })
+            .expect_err("a stream that ends early must fail the run");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ended before"),
+            "expected the EOF-desync diagnosis naming the stream and serial, got: {msg}"
+        );
+    }
+
+    /// Drive `ZipFastqRecords` through a real `Pipeline` under a lag-then-burst
+    /// stream pattern that crosses its (shrunk) soft backpressure limit, on a
+    /// watchdog thread so a deadlock regression surfaces as a timeout rather
+    /// than hanging the test runner.
+    ///
+    /// Pre-fix this deadlocks: the zipper crosses the soft limit while the
+    /// lowest serial is incomplete, returns `NoProgress` before draining/popping,
+    /// and never admits the completing burst → the watchdog fires. Post-fix the
+    /// advisory soft limit admits the completing chunks, egress fully drains,
+    /// and the run completes with every template zipped in order.
+    #[test]
+    fn zip_does_not_deadlock_on_lag_then_burst_over_soft_limit() {
+        use std::time::{Duration, Instant};
+
+        let n_streams = 3usize;
+        let seen = Arc::new(Mutex::new(Vec::<(u64, Vec<Vec<u8>>)>::new()));
+        let count = Arc::new(AtomicUsize::new(0));
+
+        let seen_for_thread = Arc::clone(&seen);
+        let count_for_thread = Arc::clone(&count);
+        let worker = std::thread::Builder::new()
+            .name("zip-lag-burst".into())
+            .spawn(move || -> io::Result<()> {
+                let source = LagThenBurstSource::new(TEST_N_SERIALS, n_streams, 64 * 1024);
+                let zip = ZipFastqRecords::new(n_streams, 64 * 1024)
+                    .with_backpressure_bytes(TEST_SOFT_LIMIT_BYTES);
+                let sink = CollectingSink { seen: seen_for_thread, count: count_for_thread };
+
+                let builder = PipelineBuilder::new();
+                builder.chain(source).chain(zip).chain(sink).into_sink_marker();
+                let pipeline = builder.build().map_err(io::Error::other)?;
+                // A modest thread count keeps the Serial zipper single-driven
+                // while letting the source/sink run on other workers.
+                pipeline
+                    .run(PipelineConfig { threads: 2, ..Default::default() })
+                    .map_err(io::Error::other)
+            })
+            .expect("spawn pipeline worker");
+
+        // Generous timeout: the run completes in well under a second on a
+        // healthy system; 30 s leaves headroom for slow CI while still failing
+        // fast on the deadlock regression.
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while !worker.is_finished() {
+            assert!(
+                Instant::now() < deadline,
+                "ZipFastqRecords pipeline did not finish within 30s — likely the S5a1-001 \
+                 backpressure-starves-egress deadlock regression"
+            );
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        worker.join().expect("pipeline thread panicked").expect("pipeline run returned Err");
+
+        // Full drain: one batch per serial, exactly TEST_N_SERIALS batches.
+        let seen = seen.lock().unwrap().clone();
+        assert_eq!(
+            seen.len(),
+            usize::try_from(TEST_N_SERIALS).unwrap(),
+            "expected one emitted batch per serial (full drain), got {}",
+            seen.len()
+        );
+
+        // Correctness + order: the single-consumer sink records the true emission
+        // order, so assert `batch_serial`s are contiguous 0..N directly (no sort)
+        // — proving `ZipFastqRecords` emits in order, not merely as a set. Each
+        // batch carries the single expected zipped template `read_<serial>`.
+        for (i, (serial, names)) in seen.iter().enumerate() {
+            assert_eq!(*serial, i as u64, "batch serials must be contiguous and in order");
+            assert_eq!(names.len(), 1, "each chunk carried exactly one record");
+            assert_eq!(
+                names[0],
+                format!("read{i}x").into_bytes(),
+                "template name must match the source record for serial {i}"
+            );
+        }
+    }
+}

--- a/src/lib/pipeline/steps/templates_to_records.rs
+++ b/src/lib/pipeline/steps/templates_to_records.rs
@@ -1,0 +1,196 @@
+//! `TemplatesToRecordBatch` adapter step.
+//!
+//! Bridges the queryname-template view (`BamTemplateBatch`,
+//! emitted by `AlignAndMergeStep` and `ZipperMergeStep`) to the
+//! flat-record view (`RecordBatch`, consumed by the sort ingest
+//! (`SortBuffer`), `DecodeRecords`, etc.). Flattens each `Template`'s records into
+//! a single `RecordBatch` carrying the input batch's serial
+//! ordinal, so `BranchOrdering::ByItemOrdinal` consumers downstream
+//! see a monotonic sequence.
+//!
+//! `Parallel + ByItemOrdinal` — the conversion is per-batch
+//! stateless, so the framework can clone this step across workers.
+//! Used to fuse AAM-fed runall pipelines (eliminating the
+//! tempfile bridge between AAM and the downstream sort).
+
+use std::io;
+
+use crate::pipeline::core::Unpushed;
+use crate::pipeline::core::held::HeldSlot;
+use crate::pipeline::core::outputs::OrderedBytesSingle;
+use crate::pipeline::core::queues::QueueSpec;
+use crate::pipeline::core::reorder::BranchOrdering;
+use crate::pipeline::core::step::{Step, StepCtx, StepKind, StepOutcome, StepProfile};
+use crate::pipeline::steps::types::{BamTemplateBatch, RecordBatch, RecordBatchBuilder};
+
+/// `Parallel + ByItemOrdinal` adapter step.
+///
+/// Each `try_run` pops one [`BamTemplateBatch`], appends every
+/// record from every contained template into a
+/// [`RecordBatchBuilder`], and emits the resulting [`RecordBatch`]
+/// downstream. Backpressure is handled via a [`HeldSlot`]
+/// preserving the input batch's serial ordinal.
+pub struct TemplatesToRecordBatch {
+    held: HeldSlot<Unpushed<RecordBatch>>,
+    output_byte_limit: u64,
+}
+
+impl TemplatesToRecordBatch {
+    #[must_use]
+    pub fn new(output_byte_limit: u64) -> Self {
+        Self { held: HeldSlot::new(), output_byte_limit }
+    }
+}
+
+impl Clone for TemplatesToRecordBatch {
+    fn clone(&self) -> Self {
+        Self { held: HeldSlot::new(), output_byte_limit: self.output_byte_limit }
+    }
+}
+
+impl Step for TemplatesToRecordBatch {
+    type Input = BamTemplateBatch;
+    type Outputs = OrderedBytesSingle<RecordBatch>;
+
+    fn profile(&self) -> StepProfile {
+        StepProfile {
+            name: "TemplatesToRecordBatch",
+            kind: StepKind::Parallel,
+            sticky: false,
+            output_queues: vec![QueueSpec::ByteBounded { limit_bytes: self.output_byte_limit }],
+            branch_ordering: vec![BranchOrdering::ByItemOrdinal],
+        }
+    }
+
+    fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+        if let Some(unpushed) = self.held.take() {
+            match ctx.outputs.retry(unpushed) {
+                Ok(()) => {}
+                Err(again) => {
+                    self.held.put(again);
+                    // `Contention` (not `NoProgress`) — see
+                    // `BgzfDecompress` for the rationale. Returning
+                    // `NoProgress` from a Parallel step on a held
+                    // slot risks the framework marking this worker
+                    // `Skip` if the upstream input is also drained,
+                    // silently dropping the held item.
+                    return Ok(StepOutcome::Contention);
+                }
+            }
+        }
+
+        let Some(batch) = ctx.input.pop() else {
+            // No input this call. If upstream is drained, every item has been
+            // processed (held output was flushed by the Contention preamble
+            // above) and this step will never push again — report Finished.
+            // For a Parallel step only the last clone to finish closes the
+            // shared output (gated by the StepDrainCounter in the driver).
+            if ctx.input.is_drained() {
+                return Ok(StepOutcome::Finished);
+            }
+            return Ok(StepOutcome::NoProgress);
+        };
+
+        let serial = batch.batch_serial();
+        // Pre-size the backing buffer from the exact sum of record
+        // body bytes. `batch.total_bytes()` over-estimates because
+        // `Template::heap_size` includes the queryname bytes, but
+        // those don't appear in the `RecordBatch.backing` (only the
+        // body bytes do). Computing the tight number once is cheap
+        // and keeps the builder's allocation in a single mimalloc
+        // size class.
+        let bytes_cap: usize = batch
+            .templates()
+            .iter()
+            .flat_map(|t| t.records.iter().map(fgumi_raw_bam::RawRecord::len))
+            .sum();
+        let records_cap: usize = batch.templates().iter().map(|t| t.records.len()).sum();
+        let mut builder = RecordBatchBuilder::with_capacity(serial, bytes_cap, records_cap);
+        let (_, templates) = batch.into_parts();
+        for template in templates {
+            for record in template.records {
+                builder.push_record_bytes(record.as_ref());
+            }
+        }
+        let rb = builder.build();
+
+        match ctx.outputs.push(rb) {
+            Ok(()) => Ok(StepOutcome::Progress),
+            Err(unpushed) => {
+                self.held.put(unpushed);
+                Ok(StepOutcome::Progress)
+            }
+        }
+    }
+
+    fn new_worker_copy(&self) -> Self {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::template::Template;
+    use fgumi_raw_bam::SamBuilder;
+
+    fn make_record(qname: &[u8], flags: u16) -> fgumi_raw_bam::RawRecord {
+        let mut b = SamBuilder::new();
+        b.read_name(qname).flags(flags).sequence(b"ACGT").qualities(b"IIII");
+        b.build()
+    }
+
+    /// Build a paired-end template: one R1 primary + one R2 primary
+    /// (the minimum that satisfies `Template::from_records`).
+    fn make_paired_template(qname: &[u8]) -> Template {
+        use fgumi_raw_bam::flags::{FIRST_SEGMENT, LAST_SEGMENT, PAIRED};
+        let r1 = make_record(qname, PAIRED | FIRST_SEGMENT);
+        let r2 = make_record(qname, PAIRED | LAST_SEGMENT);
+        Template::from_records(vec![r1, r2]).expect("paired template")
+    }
+
+    #[test]
+    fn profile_advertises_parallel_byordinal() {
+        let s = TemplatesToRecordBatch::new(1024);
+        let p = s.profile();
+        assert_eq!(p.name, "TemplatesToRecordBatch");
+        assert_eq!(p.kind, StepKind::Parallel);
+        assert!(!p.sticky);
+        assert_eq!(p.branch_ordering, vec![BranchOrdering::ByItemOrdinal]);
+    }
+
+    #[test]
+    fn clone_resets_held_slot() {
+        let mut s = TemplatesToRecordBatch::new(1024);
+        // We can't easily put a real Unpushed into held without a
+        // live framework, so just assert the clone has a fresh slot
+        // (no panic in HeldSlot::new(), which would fire if we
+        // accidentally cloned a held item).
+        let _ = s.held.take(); // empty
+        let cloned = s.clone();
+        assert!(!cloned.held.is_held());
+    }
+
+    /// Verify the flattening logic: 2 paired templates → 4 records,
+    /// preserving the input batch's serial ordinal.
+    #[test]
+    fn flatten_preserves_record_count_and_serial() {
+        let batch = BamTemplateBatch::new(
+            42,
+            vec![make_paired_template(b"q1"), make_paired_template(b"q2")],
+        );
+        let total_bytes = batch.total_bytes();
+        let serial = batch.batch_serial();
+        let records_cap: usize = batch.templates().iter().map(|t| t.records.len()).sum();
+        let mut builder = RecordBatchBuilder::with_capacity(serial, total_bytes, records_cap);
+        let (_, templates) = batch.into_parts();
+        for template in templates {
+            for record in template.records {
+                builder.push_record_bytes(record.as_ref());
+            }
+        }
+        let rb = builder.build();
+        assert_eq!(rb.batch_serial(), 42);
+        assert_eq!(rb.len(), 4, "4 records flattened from 2 paired templates");
+    }
+}

--- a/src/lib/pipeline/steps/tests.rs
+++ b/src/lib/pipeline/steps/tests.rs
@@ -1,0 +1,338 @@
+//! Phase 3 cross-step integration tests. The block-level chain:
+//!
+//! ```text
+//! ReadBgzfBlocks → BgzfDecompress → FindBamBoundaries → DecodeRecords
+//!     → GroupBam → SerializeBamRecords → BgzfCompress → WriteBgzfFile
+//! ```
+//!
+//! Drives the chain via `Pipeline::run` against a synthetic BAM, then
+//! reads back the output to verify record-count invariance and
+//! ordering. Threads-{1, 4} variants exercise the framework's drain
+//! protocol under both `Serial`-only and `Parallel` + `Serial` mixes.
+
+use crate::pipeline::core::builder::{Pipeline, PipelineConfig};
+use crate::pipeline::steps::bgzf::compress::BgzfCompress;
+use crate::pipeline::steps::bgzf::decompress::BgzfDecompress;
+use crate::pipeline::steps::boundaries::bam::FindBamBoundaries;
+use crate::pipeline::steps::group::bam::GroupBam;
+use crate::pipeline::steps::parse::decode::DecodeRecords;
+use crate::pipeline::steps::serialize::SerializeBamRecords;
+use crate::pipeline::steps::sink::write_bgzf::WriteBgzfFile;
+use crate::pipeline::steps::source::read_bam::{DEFAULT_BLOCKS_PER_BATCH, read_bam};
+use fgumi_bam_io::GroupKeyConfig;
+
+/// Build an in-memory BAM file with `n_records` synthetic records using
+/// fgumi-bam-io's writer. Returns the path (a `tempfile::TempPath`) so
+/// the file is cleaned up when dropped.
+fn build_test_bam(n_records: usize) -> tempfile::TempPath {
+    use fgumi_raw_bam::testutil::make_bam_bytes;
+    use noodles::sam::Header;
+
+    let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    let header = Header::default();
+    let mut writer = fgumi_bam_io::create_raw_bam_writer(&path, &header, 1, 1).unwrap();
+    for i in 0..n_records {
+        let name_str = format!("read_{i}");
+        let record_bytes = make_bam_bytes(
+            -1,  // tid (unmapped)
+            -1,  // pos
+            0x4, // flag (unmapped)
+            name_str.as_bytes(),
+            &[], // cigar_ops
+            0,   // seq_len
+            -1,  // mate_tid
+            -1,  // mate_pos
+            &[], // aux_data
+        );
+        writer.write_raw_record(&record_bytes).unwrap();
+    }
+    writer.finish().unwrap();
+    path
+}
+
+/// Read back a BAM file and return the count of records.
+fn count_records(path: &std::path::Path) -> usize {
+    use fgumi_bam_io::PipelineReaderOpts;
+    use fgumi_raw_bam::RawRecord;
+
+    let (mut reader, _hdr) =
+        fgumi_bam_io::create_raw_bam_reader_with_opts(path, 1, PipelineReaderOpts::default())
+            .unwrap();
+    let mut record = RawRecord::default();
+    let mut n = 0;
+    loop {
+        match reader.read_record(&mut record).unwrap() {
+            0 => break,
+            _ => n += 1,
+        }
+    }
+    n
+}
+
+/// Read every record's bytes into a `Vec<Vec<u8>>` in input order. Used
+/// for byte-level + ordering equivalence checks.
+fn collect_record_bytes(path: &std::path::Path) -> Vec<Vec<u8>> {
+    use fgumi_bam_io::PipelineReaderOpts;
+    use fgumi_raw_bam::RawRecord;
+
+    let (mut reader, _hdr) =
+        fgumi_bam_io::create_raw_bam_reader_with_opts(path, 1, PipelineReaderOpts::default())
+            .unwrap();
+    let mut record = RawRecord::default();
+    let mut all = Vec::new();
+    while reader.read_record(&mut record).unwrap() > 0 {
+        all.push(record.as_ref().to_vec());
+    }
+    all
+}
+
+/// Assert input and output have byte-identical records in input order.
+/// Catches reorderings, dropped records, and per-record mutations that a
+/// pure count check would miss.
+fn assert_records_round_trip_in_order(input: &std::path::Path, output: &std::path::Path) {
+    let in_recs = collect_record_bytes(input);
+    let out_recs = collect_record_bytes(output);
+    assert_eq!(
+        in_recs.len(),
+        out_recs.len(),
+        "record count mismatch: input={}, output={}",
+        in_recs.len(),
+        out_recs.len()
+    );
+    for (i, (a, b)) in in_recs.iter().zip(out_recs.iter()).enumerate() {
+        assert_eq!(a, b, "record {i}: input bytes != output bytes");
+    }
+}
+
+/// Wire the full block-level chain and return the built pipeline.
+///
+/// Shared by [`run_full_chain`] and the DAG-rendering test so there is exactly
+/// one description of the chain. Kept separate from running it because the two
+/// callers want different things from the same pipeline — one runs it, the other
+/// only renders `dag()` — and a second copy of the wiring would let the DAG
+/// assertion list drift from the chain it claims to describe.
+fn build_full_chain(input: &std::path::Path, output: &std::path::Path) -> Pipeline {
+    let opts = fgumi_bam_io::PipelineReaderOpts::default();
+    let (read_step, header) =
+        read_bam(input, opts, DEFAULT_BLOCKS_PER_BATCH, 4 * 1024 * 1024).unwrap();
+    let bytes_4mb: u64 = 4 * 1024 * 1024;
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(read_step)
+        .chain(BgzfDecompress::new(bytes_4mb))
+        .chain(FindBamBoundaries::new(bytes_4mb))
+        // DecodeRecords now does parse + group-key extraction in one pass
+        // (matches legacy bam.rs Decode step); the previous Parse → Decode
+        // split was unused outside tests.
+        .chain(DecodeRecords::new(GroupKeyConfig::default(), bytes_4mb))
+        .chain(GroupBam::new(64, bytes_4mb))
+        .chain(SerializeBamRecords::new(bytes_4mb))
+        .chain(BgzfCompress::new(1, bytes_4mb))
+        .chain(WriteBgzfFile::new(output, &header, 1).unwrap())
+        .into_sink_marker();
+    builder.build().unwrap()
+}
+
+/// Wire the full block-level chain end-to-end and run it.
+fn run_full_chain(input: &std::path::Path, output: &std::path::Path, threads: usize) {
+    build_full_chain(input, output).run(PipelineConfig { threads, ..Default::default() }).unwrap();
+}
+
+#[test]
+fn full_chain_threads_1() {
+    // The comment on `full_chain_threads_2` claims the chain works at
+    // `threads >= 1`, but every case in this file ran with 2 or 4 — so the
+    // claim was untested. One worker is the interesting case: the
+    // `Affinity::Reader` source and `Affinity::Writer` sink land on the *same*
+    // worker, so a drain or termination path that only makes progress when
+    // another worker can run the other end would deadlock here and nowhere
+    // else. Asserts the full ordered round-trip, not just completion.
+    let input = build_test_bam(50);
+    let output = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    run_full_chain(&input, &output, 1);
+    assert_records_round_trip_in_order(&input, &output);
+}
+
+#[test]
+fn full_chain_threads_2() {
+    // Source/sink are Serial+Affinity (Reader/Writer): worker 0 reads,
+    // worker 1 writes, all workers can do interior Parallel/Serial steps.
+    // The chain works at threads >= 1; this test exercises a small case.
+    let input = build_test_bam(50);
+    let output = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    run_full_chain(&input, &output, 2);
+    let bytes = std::fs::read(&output).unwrap();
+    assert!(bytes.len() >= 28, "output BAM must contain at least the BGZF EOF: {}", bytes.len());
+    assert_eq!(&bytes[0..2], &[0x1f, 0x8b], "BGZF/gzip magic");
+    assert_records_round_trip_in_order(&input, &output);
+}
+
+#[test]
+fn full_chain_threads_4() {
+    // Source/sink are Serial+Affinity (Reader on T0, Writer on TN-1);
+    // Boundaries/Group are Serial (any worker eligible). Decode/parse/
+    // serialize/compress are Parallel. With threads=4 every worker
+    // rotates through whatever has work.
+    let input = build_test_bam(200);
+    let output = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    run_full_chain(&input, &output, 4);
+    let bytes = std::fs::read(&output).unwrap();
+    assert!(bytes.len() >= 28);
+    assert_eq!(&bytes[0..2], &[0x1f, 0x8b]);
+    assert_records_round_trip_in_order(&input, &output);
+}
+
+#[test]
+fn full_chain_many_records_spans_many_bgzf_blocks() {
+    // 50_000 unmapped records → tens of BGZF blocks. Exercises the
+    // boundary state's cross-block carryover and the reorder stages
+    // under realistic block counts.
+    let input = build_test_bam(50_000);
+    let output = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    run_full_chain(&input, &output, 4);
+    assert_records_round_trip_in_order(&input, &output);
+}
+
+#[test]
+#[ignore = "big — run with --ignored or in CI"]
+fn full_chain_500k_records() {
+    let input = build_test_bam(500_000);
+    let output = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    run_full_chain(&input, &output, 4);
+    assert_eq!(count_records(&output), 500_000);
+}
+
+/// Build a BAM with mapped paired-end records (more realistic record
+/// sizes — sequence + cigar + tags). 100bp reads, 4bp cigar, RG tag.
+fn build_paired_test_bam(n_pairs: usize) -> tempfile::TempPath {
+    use fgumi_raw_bam::testutil::make_bam_bytes;
+    use noodles::sam::Header;
+
+    let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    let header = Header::default();
+    let mut writer = fgumi_bam_io::create_raw_bam_writer(&path, &header, 1, 1).unwrap();
+    // Flags: PAIRED | UNMAPPED | MATE_UNMAPPED + (FIRST_SEGMENT | LAST_SEGMENT).
+    let r1_flags: u16 = 1 | 4 | 8 | 64;
+    let r2_flags: u16 = 1 | 4 | 8 | 128;
+    for i in 0..n_pairs {
+        let name_str = format!("read_{i:08}");
+        let r1 = make_bam_bytes(-1, -1, r1_flags, name_str.as_bytes(), &[], 100, -1, -1, &[]);
+        writer.write_raw_record(&r1).unwrap();
+        let r2 = make_bam_bytes(-1, -1, r2_flags, name_str.as_bytes(), &[], 100, -1, -1, &[]);
+        writer.write_raw_record(&r2).unwrap();
+    }
+    writer.finish().unwrap();
+    path
+}
+
+#[test]
+fn full_chain_paired_records() {
+    // 10K pairs = 20K records, paired by name (GroupBam should produce
+    // one Template per pair).
+    let input = build_paired_test_bam(10_000);
+    let output = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    run_full_chain(&input, &output, 4);
+    assert_records_round_trip_in_order(&input, &output);
+}
+
+#[test]
+fn full_chain_empty_bam() {
+    // Header-only input; the chain should still produce a valid BAM with
+    // a header + EOF and zero records.
+    let input = build_test_bam(0);
+    let output = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+    run_full_chain(&input, &output, 2);
+    let bytes = std::fs::read(&output).unwrap();
+    assert!(bytes.len() >= 28);
+    assert_eq!(count_records(&output), 0);
+}
+
+#[test]
+fn full_chain_with_process_mutates_mq() {
+    // Plan Task 12 Step 4: insert a `Process` mid-step that bumps every
+    // record's MAPQ to a known value, run the chain end-to-end, and
+    // verify the output reflects the change. This is the regression test
+    // for the closure-driven `ProcessOrdered` family + the held-slot /
+    // drain contract under a non-trivial Parallel transform.
+    use crate::pipeline::steps::process::process_ordered;
+    use crate::pipeline::steps::types::DecodedRecordBatch;
+
+    let input = build_test_bam(2_000);
+    let output = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+
+    let opts = fgumi_bam_io::PipelineReaderOpts::default();
+    let (read_step, header) =
+        read_bam(&input, opts, DEFAULT_BLOCKS_PER_BATCH, 4 * 1024 * 1024).unwrap();
+    let bytes_4mb: u64 = 4 * 1024 * 1024;
+
+    let bump_mq = process_ordered::<DecodedRecordBatch, DecodedRecordBatch, _>(
+        "BumpMq",
+        bytes_4mb,
+        |batch: DecodedRecordBatch| {
+            // BAM record body byte 9 is `mapq` (raw layout: refID(4) +
+            // pos(4) + l_read_name(1) + mapq(1) + ...). Mutating mapq
+            // doesn't change the record's identity (qname / library /
+            // cell barcode), so the pre-computed GroupKey stays valid.
+            // Take ownership, edit in place, and rebuild via `new` so the
+            // cached `total_bytes` is recomputed for the edited records.
+            let serial = batch.batch_serial();
+            let mut records = batch.into_records();
+            for record in &mut records {
+                let buf = record.raw_bytes_mut().as_mut_vec();
+                if buf.len() > 9 {
+                    buf[9] = 42;
+                }
+            }
+            Ok(DecodedRecordBatch::new(serial, records))
+        },
+    );
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(read_step)
+        .chain(BgzfDecompress::new(bytes_4mb))
+        .chain(FindBamBoundaries::new(bytes_4mb))
+        .chain(DecodeRecords::new(GroupKeyConfig::default(), bytes_4mb))
+        .chain(bump_mq)
+        .chain(GroupBam::new(64, bytes_4mb))
+        .chain(SerializeBamRecords::new(bytes_4mb))
+        .chain(BgzfCompress::new(1, bytes_4mb))
+        .chain(WriteBgzfFile::new(&output, &header, 1).unwrap())
+        .into_sink_marker();
+    let pipeline = builder.build().unwrap();
+    pipeline.run(PipelineConfig { threads: 4, ..Default::default() }).unwrap();
+
+    // Every output record's mapq byte must be 42.
+    let recs = collect_record_bytes(&output);
+    assert_eq!(recs.len(), 2_000);
+    for (i, r) in recs.iter().enumerate() {
+        assert!(r.len() > 9, "record {i} too short");
+        assert_eq!(r[9], 42, "record {i} mapq not mutated by Process step");
+    }
+}
+
+#[test]
+fn pipeline_dag_renders_for_full_chain() {
+    let input = build_test_bam(0);
+    let output = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+
+    // The same helper `run_full_chain` uses, so the names asserted below cannot
+    // drift from the chain that actually runs.
+    let pipeline = build_full_chain(&input, &output);
+
+    let dag = pipeline.dag();
+    for name in [
+        "ReadBgzfBlocks",
+        "BgzfDecompress",
+        "FindBamBoundaries",
+        "DecodeRecords",
+        "GroupBam",
+        "SerializeBamRecords",
+        "BgzfCompress",
+        "WriteBgzfFile",
+    ] {
+        assert!(dag.contains(name), "DAG missing {name}: {dag}");
+    }
+    assert!(dag.contains("(sink)"), "DAG missing sink marker: {dag}");
+}

--- a/src/lib/pipeline/steps/tuning.rs
+++ b/src/lib/pipeline/steps/tuning.rs
@@ -1,0 +1,153 @@
+//! Per-thread auto-tuned defaults for the BAM step library, preserving the
+//! per-step batch-size and thread-count heuristics from the legacy
+//! `PipelineConfig::auto_tuned` (removed in the issue #330 migration).
+//!
+//! Centralizes the per-step batch sizes and thread-count heuristics so
+//! command builders don't have to know the magic numbers. Phase 4
+//! migrations should construct via `BamPipelineTuning::auto_tuned(threads)`
+//! and pass the resulting struct into each step's constructor.
+
+/// Per-thread auto-tuned defaults for the BAM step library.
+///
+/// Mirrors legacy `PipelineConfig::auto_tuned`: `blocks_per_read_batch`
+/// scales with thread count to reduce downstream queue-op pulse rate;
+/// `template_batch_size` defaults to 500 templates/batch (matches
+/// legacy's `target_templates_per_batch`).
+#[derive(Debug, Clone, Copy)]
+pub struct BamPipelineTuning {
+    /// Number of pipeline worker threads.
+    pub threads: usize,
+    /// BGZF blocks per `ReadBgzfBlocks` emission. Matches legacy's
+    /// `blocks_per_read_batch`: 16 (1-3 threads), 32 (4-7), 48 (8-15),
+    /// 64 (16+).
+    pub blocks_per_batch: usize,
+    /// Templates per `GroupBam` output batch. Legacy default: 500.
+    pub template_batch_size: usize,
+    /// Per-step output queue byte budget. 4 MiB per step is a reasonable
+    /// laptop-class default; large workloads should raise this via the
+    /// `--queue-memory` flag (see `PipelineConfig::queue_memory_total`).
+    pub per_step_byte_limit: u64,
+    /// BGZF compression level for output (1-12). Default: 1 for the
+    /// round-trip preset (fastest); production commands should use 6.
+    pub compression_level: u32,
+}
+
+impl BamPipelineTuning {
+    /// Auto-tuned defaults for `threads` worker threads, mirroring the legacy
+    /// `PipelineConfig::auto_tuned` (`unified_pipeline::base`). Deliberately not
+    /// an intra-doc link: that module is deleted once the commands migrate off
+    /// it, and a link would break again then.
+    #[must_use]
+    pub fn auto_tuned(threads: usize) -> Self {
+        let threads = threads.max(1);
+        let blocks_per_batch = match threads {
+            1..=3 => 16,
+            4..=7 => 32,
+            8..=15 => 48,
+            _ => 64,
+        };
+        Self {
+            threads,
+            blocks_per_batch,
+            template_batch_size: 500,
+            per_step_byte_limit: 4 * 1024 * 1024,
+            compression_level: 1,
+        }
+    }
+
+    /// Override the BGZF compression level (default 1 — fastest).
+    /// Production commands typically want 6.
+    #[must_use]
+    pub fn with_compression_level(mut self, level: u32) -> Self {
+        self.compression_level = level;
+        self
+    }
+
+    /// Override the per-step byte limit. Use this with the global memory
+    /// budget from the `--queue-memory` flag.
+    #[must_use]
+    pub fn with_per_step_byte_limit(mut self, bytes: u64) -> Self {
+        self.per_step_byte_limit = bytes;
+        self
+    }
+}
+
+impl Default for BamPipelineTuning {
+    fn default() -> Self {
+        Self::auto_tuned(4)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auto_tuned_matches_legacy_block_counts() {
+        assert_eq!(BamPipelineTuning::auto_tuned(1).blocks_per_batch, 16);
+        assert_eq!(BamPipelineTuning::auto_tuned(3).blocks_per_batch, 16);
+        assert_eq!(BamPipelineTuning::auto_tuned(4).blocks_per_batch, 32);
+        assert_eq!(BamPipelineTuning::auto_tuned(7).blocks_per_batch, 32);
+        assert_eq!(BamPipelineTuning::auto_tuned(8).blocks_per_batch, 48);
+        assert_eq!(BamPipelineTuning::auto_tuned(15).blocks_per_batch, 48);
+        assert_eq!(BamPipelineTuning::auto_tuned(16).blocks_per_batch, 64);
+        assert_eq!(BamPipelineTuning::auto_tuned(64).blocks_per_batch, 64);
+    }
+
+    #[test]
+    fn template_batch_size_matches_legacy_default() {
+        assert_eq!(BamPipelineTuning::auto_tuned(8).template_batch_size, 500);
+    }
+
+    #[test]
+    fn min_one_thread() {
+        assert_eq!(BamPipelineTuning::auto_tuned(0).threads, 1);
+    }
+
+    /// The defaults documented on the struct: 4 MiB per step and level 1 (the
+    /// round-trip preset). Commands override both, so a silent drift here would
+    /// change every chain that does not.
+    #[test]
+    fn auto_tuned_defaults_match_the_documented_budget_and_level() {
+        let tuning = BamPipelineTuning::auto_tuned(8);
+        assert_eq!(tuning.per_step_byte_limit, 4 * 1024 * 1024);
+        assert_eq!(tuning.compression_level, 1);
+    }
+
+    /// The builder-style overrides must change only their own field — a command
+    /// setting a production compression level must not also perturb the queue
+    /// budget, and vice versa.
+    #[test]
+    fn the_builder_overrides_change_only_their_own_field() {
+        let base = BamPipelineTuning::auto_tuned(8);
+
+        let leveled = base.with_compression_level(6);
+        assert_eq!(leveled.compression_level, 6);
+        assert_eq!(leveled.per_step_byte_limit, base.per_step_byte_limit);
+        assert_eq!(leveled.blocks_per_batch, base.blocks_per_batch);
+        assert_eq!(leveled.threads, base.threads);
+
+        let budgeted = base.with_per_step_byte_limit(64 * 1024);
+        assert_eq!(budgeted.per_step_byte_limit, 64 * 1024);
+        assert_eq!(budgeted.compression_level, base.compression_level);
+        assert_eq!(budgeted.blocks_per_batch, base.blocks_per_batch);
+
+        // Chaining applies both.
+        let both = base.with_compression_level(6).with_per_step_byte_limit(64 * 1024);
+        assert_eq!(both.compression_level, 6);
+        assert_eq!(both.per_step_byte_limit, 64 * 1024);
+    }
+
+    /// `Default` is documented as `auto_tuned(4)`; pin it so the default queue
+    /// budget cannot drift away from the 4-thread tuning without a test failing.
+    #[test]
+    fn default_is_the_four_thread_tuning() {
+        let default = BamPipelineTuning::default();
+        let explicit = BamPipelineTuning::auto_tuned(4);
+        assert_eq!(default.threads, explicit.threads);
+        assert_eq!(default.blocks_per_batch, explicit.blocks_per_batch);
+        assert_eq!(default.template_batch_size, explicit.template_batch_size);
+        assert_eq!(default.per_step_byte_limit, explicit.per_step_byte_limit);
+        assert_eq!(default.compression_level, explicit.compression_level);
+    }
+}

--- a/src/lib/pipeline/steps/types.rs
+++ b/src/lib/pipeline/steps/types.rs
@@ -1,0 +1,469 @@
+//! Concrete data types that flow through the BAM step library.
+//!
+//! Every flowing type carries an explicit `batch_serial: u64` field and
+//! impls both [`HeapSize`] (so byte-bounded queues can budget memory) and
+//! [`Ordered`] (so `BranchOrdering::ByItemOrdinal` reorder stages preserve
+//! global ordering across multi-step Parallel transforms).
+//!
+//! Serial propagation: every transform copies the input's `batch_serial`
+//! onto its output items when the mapping is 1:1. Steps that aggregate or
+//! split across input batches (`GroupBam`, `GroupByPosition`,
+//! `GroupByQueryname`) instead mint their own monotonic counter from 0, one
+//! value per emitted batch: `ByItemOrdinal` requires a *contiguous* sequence,
+//! and inheriting an input serial would skip ordinals and stall the
+//! downstream `ReorderStage`.
+//!
+//! `BamTemplateBatch` is named to disambiguate from
+//! `crate::template::TemplateBatch` (a legacy type alias for
+//! `Vec<Template>`); the new framework's batch carries metadata alongside
+//! the templates.
+
+use crate::pipeline::core::item::{HeapSize, Ordered};
+use crate::template::Template;
+use fgumi_bam_io::{DecodedRecord, MemoryEstimate};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Light flowing types (BgzfBlock, DecompressedBlock, RecordBatch,
+// RecordBatchBuilder) moved to the `fgumi-pipeline-io` crate. Re-export them so
+// `crate::pipeline::steps::types::*` paths keep resolving and there is ONE
+// canonical definition of each. The heavy types below (BamTemplateBatch,
+// DecodedRecordBatch, SamChunk) stay in the umbrella because they depend on
+// `crate::template::Template`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub use fgumi_pipeline_io::types::{BgzfBlock, DecompressedBlock, RecordBatch, RecordBatchBuilder};
+
+/// Bytes held by a `Vec`'s backing store, counted by **allocated capacity**.
+///
+/// The batch types below cache a `total_bytes` that feeds byte-bounded
+/// admission control, so it must describe the memory the queue is really
+/// holding. Summing only the elements' own heap misses the container itself: a
+/// 1,000-element `Vec<DecodedRecord>` is tens of KiB before a single record
+/// body is counted, and a `Vec` grown by repeated `push` typically carries up
+/// to 2x its logical length in reserved slots. Counting `capacity()` rather
+/// than `len()` is the same rule the per-record accounting already follows.
+///
+/// Takes the `Vec`'s `capacity()` rather than a borrow of the `Vec` itself, so
+/// the reserved-slot count is explicit at every call site and the helper cannot
+/// silently degrade to `len()` through a slice deref.
+fn container_bytes<T>(capacity: usize) -> usize {
+    capacity * std::mem::size_of::<T>()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DecodedRecordBatch — parsed records with pre-computed `GroupKey`s.
+// Output of the parallel `DecodeRecords` step; input to the serial
+// `GroupBam` step. Mirrors legacy's split where key computation runs in
+// the parallel Decode step (`pipeline/bam.rs:329-403`) so that
+// the serial Group step only does fast hash-and-name comparisons.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A batch of `DecodedRecord`s — raw record bytes paired with a
+/// pre-computed `GroupKey`. Carries `total_bytes` for O(1) `HeapSize`.
+///
+/// `total_bytes` is cached at construction (`new`) and sums each record's
+/// **allocated capacity** ([`MemoryEstimate::estimate_heap_size`]), not its
+/// logical `raw_bytes().len()`, plus the `Vec`'s own backing store (also by
+/// allocated capacity). This feeds the pipeline's byte-backpressure budget,
+/// which must track the true heap footprint: accounting by `len` under-counts
+/// an over-allocated record, and ignoring the container under-counts the
+/// reserved slots — either lets the pipeline buffer far past its budget.
+///
+/// The fields are **private** so the cached `total_bytes` can never drift out
+/// of sync with `records`: the only constructor is [`Self::new`] (which
+/// recomputes the cache), reads go through [`Self::records`] /
+/// [`Self::total_bytes`], and taking ownership of the records consumes the
+/// batch via [`Self::into_records`]. There is no way to mutate `records` in
+/// place, so byte-bounded admission control always sees the true footprint.
+#[derive(Debug)]
+pub struct DecodedRecordBatch {
+    batch_serial: u64,
+    records: Vec<DecodedRecord>,
+    total_bytes: usize,
+}
+
+impl DecodedRecordBatch {
+    #[must_use]
+    pub fn new(batch_serial: u64, records: Vec<DecodedRecord>) -> Self {
+        let total_bytes = records.iter().map(MemoryEstimate::estimate_heap_size).sum::<usize>()
+            + container_bytes::<DecodedRecord>(records.capacity());
+        Self { batch_serial, records, total_bytes }
+    }
+
+    /// The batch's ordering serial.
+    #[must_use]
+    pub fn batch_serial(&self) -> u64 {
+        self.batch_serial
+    }
+
+    /// Immutable view of the batch's decoded records.
+    #[must_use]
+    pub fn records(&self) -> &[DecodedRecord] {
+        &self.records
+    }
+
+    /// Cached heap footprint: each record's allocated capacity plus the
+    /// `Vec`'s own backing store.
+    #[must_use]
+    pub fn total_bytes(&self) -> usize {
+        self.total_bytes
+    }
+
+    /// Consume the batch and return ownership of its records. The cached
+    /// `total_bytes` is dropped with the batch, so callers move the records
+    /// out without any risk of leaving a stale byte count behind.
+    #[must_use]
+    pub fn into_records(self) -> Vec<DecodedRecord> {
+        self.records
+    }
+}
+
+impl HeapSize for DecodedRecordBatch {
+    fn heap_size(&self) -> usize {
+        self.total_bytes
+    }
+}
+
+impl Ordered for DecodedRecordBatch {
+    fn ordinal(&self) -> u64 {
+        self.batch_serial
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BamTemplateBatch — grouped templates carrying batch metadata.
+// Disambiguated from `crate::template::TemplateBatch` (= `Vec<Template>`).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A batch of templates (same-queryname record groups), with batch serial
+/// for ordering and `total_bytes` for memory accounting.
+///
+/// The fields are **private** so the cached `total_bytes` can never drift out
+/// of sync with `templates`: construct via [`Self::new`] (which recomputes the
+/// cache) or [`Self::from_parts`] (which trusts a caller that already summed
+/// `heap_size`), read through the accessors, and take ownership of the
+/// templates by consuming the batch via [`Self::into_parts`]. There is no way
+/// to mutate `templates` in place, so byte-bounded admission control always
+/// sees the true footprint.
+#[derive(Debug)]
+pub struct BamTemplateBatch {
+    batch_serial: u64,
+    templates: Vec<Template>,
+    total_bytes: usize,
+}
+
+impl BamTemplateBatch {
+    #[must_use]
+    pub fn new(batch_serial: u64, templates: Vec<Template>) -> Self {
+        let total_bytes = templates.iter().map(Template::heap_size).sum::<usize>()
+            + container_bytes::<Template>(templates.capacity());
+        Self { batch_serial, templates, total_bytes }
+    }
+
+    /// Construct from a pre-computed `total_bytes`, skipping the
+    /// per-template `heap_size` walk inside `new`. Use when the
+    /// caller already summed `heap_size` in a prior pass (e.g.,
+    /// the AAM merge loop, which folds heap accounting into the
+    /// same loop that builds the `Vec<Template>`).
+    #[must_use]
+    pub fn from_parts(batch_serial: u64, templates: Vec<Template>, total_bytes: usize) -> Self {
+        // The caller supplies the summed per-template heap; the container's
+        // reserved capacity is added here because the caller cannot know it.
+        let total_bytes = total_bytes + container_bytes::<Template>(templates.capacity());
+        Self { batch_serial, templates, total_bytes }
+    }
+
+    /// The batch's ordering serial.
+    #[must_use]
+    pub fn batch_serial(&self) -> u64 {
+        self.batch_serial
+    }
+
+    /// Immutable view of the batch's templates.
+    #[must_use]
+    pub fn templates(&self) -> &[Template] {
+        &self.templates
+    }
+
+    /// Cached heap footprint: summed `Template::heap_size` plus the `Vec`'s
+    /// own backing store.
+    #[must_use]
+    pub fn total_bytes(&self) -> usize {
+        self.total_bytes
+    }
+
+    /// Consume the batch and return its serial and templates. The cached
+    /// `total_bytes` is dropped with the batch, so callers move the templates
+    /// out (and re-wrap via [`Self::new`]) without risking a stale byte count.
+    #[must_use]
+    pub fn into_parts(self) -> (u64, Vec<Template>) {
+        (self.batch_serial, self.templates)
+    }
+}
+
+impl HeapSize for BamTemplateBatch {
+    fn heap_size(&self) -> usize {
+        self.total_bytes
+    }
+}
+
+impl Ordered for BamTemplateBatch {
+    fn ordinal(&self) -> u64 {
+        self.batch_serial
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SamChunk — a slab of SAM text bytes ending on a newline boundary, plus an
+// inline line-offset table. Emitted by `ReadSamChunks` (Serial+Reader) and
+// consumed by `ParseSamChunk` (Parallel). The parallel parser slices each
+// line via `bytes[offsets[i]..offsets[i+1]]` — no cross-chunk dependencies
+// because the Read step never splits a record across two chunks.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A chunk of SAM text plus its sentinel-form line-offset table.
+///
+/// `line_offsets` has `N+1` entries describing `N` complete records. Line
+/// `i` is `bytes[line_offsets[i] as usize..line_offsets[i+1] as usize]`
+/// and includes its trailing `\n`. The chunk always ends on a newline
+/// boundary (the Read step holds any trailing partial line as carryover).
+#[derive(Debug)]
+pub struct SamChunk {
+    pub batch_serial: u64,
+    pub bytes: Vec<u8>,
+    pub line_offsets: Vec<u32>,
+}
+
+impl SamChunk {
+    /// Number of complete records carried by this chunk.
+    #[must_use]
+    pub fn record_count(&self) -> usize {
+        self.line_offsets.len().saturating_sub(1)
+    }
+}
+
+impl HeapSize for SamChunk {
+    fn heap_size(&self) -> usize {
+        self.bytes.capacity() + container_bytes::<u32>(self.line_offsets.capacity())
+    }
+}
+
+impl Ordered for SamChunk {
+    fn ordinal(&self) -> u64 {
+        self.batch_serial
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Tests for the light types (BgzfBlock, DecompressedBlock, RecordBatch,
+    // RecordBatchBuilder) moved with those types to the `fgumi-pipeline-io`
+    // crate. Only the heavy-type tests remain below.
+
+    #[test]
+    fn template_batch_carries_serial() {
+        let batch = BamTemplateBatch::new(42, vec![]);
+        assert_eq!(batch.heap_size(), 0);
+        assert_eq!(batch.ordinal(), 42);
+    }
+
+    #[test]
+    fn decoded_record_batch_heap_size_counts_capacity_not_len() {
+        // `heap_size` feeds the pipeline's byte-backpressure budget, so it must
+        // report the records' true heap footprint (allocated capacity), not
+        // their logical length. Accounting by `len` under-counts an
+        // over-allocated record — exactly the failure mode where a SAM-parsed
+        // record with a 4 KiB buffer holding ~60 bytes fooled backpressure and
+        // let the pipeline buffer far past its memory budget.
+        use fgumi_bam_io::{GroupKey, MemoryEstimate};
+        let mut raw = Vec::with_capacity(4096);
+        raw.extend_from_slice(&[0u8; 64]); // len 64, capacity 4096
+        let rec = DecodedRecord::from_raw_bytes(raw, GroupKey::default());
+        let cap = rec.estimate_heap_size();
+        assert!(cap >= 4096, "sanity: over-allocated record capacity, got {cap}");
+        let batch = DecodedRecordBatch::new(0, vec![rec]);
+        let expected = cap + std::mem::size_of::<DecodedRecord>(); // one container slot
+        assert_eq!(
+            batch.heap_size(),
+            expected,
+            "heap_size must reflect allocated capacity ({cap}) plus the container, \
+             not logical len — else byte-backpressure under-counts real memory",
+        );
+    }
+
+    #[test]
+    fn decoded_record_batch_accessors_and_into_records_round_trip() {
+        // The fields are private; callers read via the accessors and take
+        // ownership by consuming the batch. `into_records` must hand back the
+        // exact records `new` was given, and `batch_serial` must round-trip.
+        use fgumi_bam_io::GroupKey;
+        let rec = DecodedRecord::from_raw_bytes(vec![7u8; 32], GroupKey::default());
+        let batch = DecodedRecordBatch::new(3, vec![rec]);
+        assert_eq!(batch.batch_serial(), 3);
+        assert_eq!(batch.records().len(), 1);
+        assert_eq!(batch.total_bytes(), batch.heap_size());
+        let records = batch.into_records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].raw_bytes().len(), 32);
+    }
+
+    #[test]
+    fn bam_template_batch_accessors_and_into_parts_round_trip() {
+        // Mirror of the DecodedRecordBatch contract: private fields, read via
+        // accessors, consume via `into_parts` to move the templates out and
+        // re-wrap through `new` (which recomputes the byte cache).
+        let t1 = crate::template::Template::new(b"read1".to_vec());
+        let expected_bytes = t1.heap_size() + std::mem::size_of::<crate::template::Template>();
+        let batch = BamTemplateBatch::new(9, vec![t1]);
+        assert_eq!(batch.batch_serial(), 9);
+        assert_eq!(batch.templates().len(), 1);
+        assert_eq!(batch.total_bytes(), expected_bytes);
+        let (serial, templates) = batch.into_parts();
+        assert_eq!(serial, 9);
+        // Re-wrapping the moved-out templates recomputes an identical cache.
+        let rewrapped = BamTemplateBatch::new(serial, templates);
+        assert_eq!(rewrapped.total_bytes(), expected_bytes);
+    }
+
+    #[test]
+    fn template_batch_new_total_bytes_sums_heap_sizes() {
+        // Template::new(name) → heap_size() == name.len() (no records).
+        // Two templates with distinct known names; no RawRecord builders needed.
+        let t1 = crate::template::Template::new(b"read1".to_vec()); // 5 bytes
+        let t2 = crate::template::Template::new(b"read_two".to_vec()); // 8 bytes
+        let expected =
+            t1.heap_size() + t2.heap_size() + 2 * std::mem::size_of::<crate::template::Template>(); // 13 + container
+        let batch = BamTemplateBatch::new(7, vec![t1, t2]);
+        assert_eq!(batch.total_bytes, expected);
+        assert_eq!(batch.heap_size(), expected); // HeapSize delegates to total_bytes
+        assert_eq!(batch.ordinal(), 7);
+    }
+
+    #[test]
+    fn template_batch_from_parts_trusts_caller_total_bytes() {
+        // from_parts must NOT re-walk the templates — it trusts the caller's
+        // summed `heap_size` (e.g. the AAM merge loop, which folds heap
+        // accounting into its own loop). It still adds the container term,
+        // which the caller has no way to know.
+        let batch = BamTemplateBatch::from_parts(99, vec![], 12345);
+        assert_eq!(batch.heap_size(), 12345, "an empty Vec has no container allocation");
+        assert_eq!(batch.ordinal(), 99);
+    }
+
+    // ========================================================================
+    // Container capacity in the byte budget
+    //
+    // `heap_size` feeds byte-bounded admission control, so it must report the
+    // batch's TRUE footprint. Each of these types owns a `Vec` whose backing
+    // store is real memory the queue is holding: a 1000-element
+    // `Vec<DecodedRecord>` is tens of KiB of container before a single record
+    // body is counted. Omitting it lets a full queue exceed its configured
+    // limit — the same class of under-count the per-record capacity accounting
+    // above already guards against.
+    // ========================================================================
+
+    /// Reserved-but-unused slots are allocated memory, so the batch's byte
+    /// count must grow with `capacity()`, not with `len()`.
+    #[test]
+    fn decoded_record_batch_counts_reserved_container_capacity() {
+        use fgumi_bam_io::GroupKey;
+        let record = || DecodedRecord::from_raw_bytes(vec![7u8; 32], GroupKey::default());
+
+        let tight = DecodedRecordBatch::new(0, vec![record()]);
+
+        let mut padded = Vec::with_capacity(256);
+        padded.push(record());
+        let padded = DecodedRecordBatch::new(0, padded);
+
+        assert!(
+            padded.heap_size() > tight.heap_size(),
+            "a batch holding 256 reserved slots must out-weigh a tight one \
+             ({} vs {})",
+            padded.heap_size(),
+            tight.heap_size(),
+        );
+        assert_eq!(
+            padded.heap_size() - tight.heap_size(),
+            (256 - 1) * std::mem::size_of::<DecodedRecord>(),
+            "the difference must be exactly the extra reserved slots",
+        );
+    }
+
+    /// Same contract for templates, through both constructors.
+    #[test]
+    fn template_batch_counts_reserved_container_capacity() {
+        let template = || crate::template::Template::new(b"read1".to_vec());
+
+        let mut padded = Vec::with_capacity(64);
+        padded.push(template());
+        let heap_only: usize = padded.iter().map(crate::template::Template::heap_size).sum();
+
+        let via_new = BamTemplateBatch::new(0, padded);
+        assert_eq!(
+            via_new.total_bytes(),
+            heap_only + 64 * std::mem::size_of::<crate::template::Template>(),
+            "new() must add the container's reserved capacity to the summed heap",
+        );
+
+        // `from_parts` receives the caller's summed heap and must add the same
+        // container term — otherwise the two constructors disagree on the
+        // footprint of identical batches.
+        let (_, templates) = via_new.into_parts();
+        let via_parts = BamTemplateBatch::from_parts(0, templates, heap_only);
+        assert_eq!(
+            via_parts.total_bytes(),
+            via_new_total_bytes_for_comparison(heap_only),
+            "from_parts must agree with new() on the same templates",
+        );
+    }
+
+    /// The expected `total_bytes` for the 64-slot fixture above, expressed once
+    /// so both constructors are compared against the same definition.
+    fn via_new_total_bytes_for_comparison(heap_only: usize) -> usize {
+        heap_only + 64 * std::mem::size_of::<crate::template::Template>()
+    }
+
+    /// A `SamChunk`'s `bytes` come from a reader buffer that routinely carries
+    /// spare capacity, so accounting by `len()` under-counts the slab the queue
+    /// is actually holding.
+    #[test]
+    fn sam_chunk_heap_size_counts_capacity_not_len() {
+        let mut bytes = Vec::with_capacity(8192);
+        bytes.extend_from_slice(&[0u8; 500]);
+        let mut line_offsets = Vec::with_capacity(64);
+        line_offsets.extend_from_slice(&[0u32; 10]);
+
+        let chunk = SamChunk { batch_serial: 1, bytes, line_offsets };
+        assert_eq!(
+            chunk.heap_size(),
+            8192 + 64 * std::mem::size_of::<u32>(),
+            "heap_size must report allocated capacity, not logical length",
+        );
+    }
+
+    #[test]
+    fn sam_chunk_record_count_is_offsets_minus_one() {
+        // Sentinel-form line_offsets: N+1 entries describe N records.
+        // `bytes` and `line_offsets` come from `split_complete_lines`.
+        let bytes = b"abc\nde\n".to_vec();
+        let line_offsets = vec![0u32, 4, 7];
+        let chunk = SamChunk { batch_serial: 5, bytes, line_offsets };
+        assert_eq!(chunk.record_count(), 2);
+    }
+
+    #[test]
+    fn sam_chunk_record_count_is_zero_for_empty_offsets() {
+        let chunk = SamChunk { batch_serial: 0, bytes: Vec::new(), line_offsets: Vec::new() };
+        assert_eq!(chunk.record_count(), 0);
+    }
+
+    #[test]
+    fn sam_chunk_heap_size_sums_bytes_and_offsets() {
+        let chunk =
+            SamChunk { batch_serial: 1, bytes: vec![0u8; 500], line_offsets: vec![0u32; 10] };
+        assert_eq!(chunk.heap_size(), 500 + 10 * std::mem::size_of::<u32>());
+        assert_eq!(chunk.ordinal(), 1);
+    }
+}

--- a/src/lib/read_info.rs
+++ b/src/lib/read_info.rs
@@ -11,184 +11,29 @@
 
 use anyhow::Result;
 use noodles::sam::alignment::record::data::field::Tag;
-use noodles::sam::header::Header;
-use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
 use std::cmp::Ordering;
-use std::collections::HashMap;
 use std::sync::Arc;
-
-use bstr::ByteSlice;
 
 use crate::sam::SamTag;
 use crate::template::Template;
 
-/// A lookup table mapping read group IDs to library names.
-///
-/// This is built from the SAM header's @RG lines and used to resolve the library
-/// name (LB field) from a record's RG tag. This matches fgbio's behavior where
-/// grouping uses the library name, not the read group ID.
-///
-/// Uses `Arc<str>` for library names to avoid cloning strings for every read.
-///
-/// # Note: `LibraryLookup` vs `LibraryIndex`
-///
-/// Both `LibraryLookup` and [`LibraryIndex`] exist for different use cases:
-/// - `LibraryLookup`: String-based lookup returning library names. Used by
-///   [`ReadInfo::from`] where the actual library name string is needed.
-/// - [`LibraryIndex`]: Hash-based lookup returning numeric indices. Used by
-///   `compute_group_key_from_raw` in the hot path where only equality comparison
-///   matters, avoiding string allocations.
-pub type LibraryLookup = Arc<HashMap<String, Arc<str>>>;
-
-/// Shared "unknown" library string to avoid repeated allocations.
-static UNKNOWN_LIBRARY: std::sync::LazyLock<Arc<str>> =
-    std::sync::LazyLock::new(|| Arc::from("unknown"));
-
-/// Builds a library lookup table from a SAM header.
-///
-/// Iterates through all @RG lines in the header and creates a mapping from
-/// read group ID to library name. If a read group has no LB field, it maps
-/// to "unknown" (matching fgbio's behavior).
-///
-/// # Arguments
-///
-/// * `header` - The SAM header containing @RG lines
-///
-/// # Returns
-///
-/// An `Arc<HashMap>` mapping read group IDs to library names
-#[must_use]
-pub fn build_library_lookup(header: &Header) -> LibraryLookup {
-    let mut lookup = HashMap::new();
-
-    for (id, rg) in header.read_groups() {
-        // Get the LB field from the read group's other_fields
-        let library: Arc<str> = rg
-            .other_fields()
-            .get(&rg_tag::LIBRARY)
-            .map_or_else(|| Arc::clone(&UNKNOWN_LIBRARY), |s| Arc::from(s.to_string()));
-        lookup.insert(id.to_string(), library);
-    }
-
-    Arc::new(lookup)
-}
+// `LibraryIndex`, `LibraryLookup`, and `build_library_lookup` are defined once,
+// in `fgumi-bam-io`, next to the `GroupKey` that stores a library index. They
+// were duplicated here alongside `DecodedRecord` / `GroupKey`, and stop being
+// separable for the same reason: a `GroupKeyConfig` built here has to be the
+// same type the ported steps consume. Re-exported so existing
+// `crate::read_info::LibraryIndex` paths keep resolving.
+//
+// `unknown_library()` is re-exported for the same reason one level down: the
+// index built by `build_library_lookup` reserves slot 0 for the crate's shared
+// "unknown" `Arc<str>`, so a second local `LazyLock<Arc<str>>` here would mean
+// two allocations for one logical value — the duplication this change exists to
+// remove, just of a value rather than a type.
+pub use fgumi_bam_io::{LibraryIndex, LibraryLookup, build_library_lookup, unknown_library};
 
 // ============================================================================
 // LibraryIndex - Fast RG to library index mapping for GroupKey computation
 // ============================================================================
-
-/// Fast lookup from RG tag value to library index.
-///
-/// This provides O(1) library lookup during Decode using string hashing,
-/// replacing the O(n) string comparison in the original `LibraryLookup`.
-#[derive(Debug, Clone)]
-pub struct LibraryIndex {
-    /// Map from RG string hash to library index.
-    lookup: ahash::AHashMap<u64, u16>,
-    /// Library names for each index (for output/debugging).
-    names: Vec<Arc<str>>,
-    /// Unknown library index (always 0).
-    unknown_idx: u16,
-}
-
-impl LibraryIndex {
-    /// Build a library index from a SAM header.
-    ///
-    /// Each unique library name gets a sequential index starting from 0.
-    /// Index 0 is reserved for "unknown" library.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the header contains more than 65,535 distinct libraries.
-    #[must_use]
-    pub fn from_header(header: &Header) -> Self {
-        let mut lookup = ahash::AHashMap::new();
-        let mut names = vec![Arc::clone(&UNKNOWN_LIBRARY)]; // Index 0 = unknown
-        let mut library_to_idx: ahash::AHashMap<Arc<str>, u16> = ahash::AHashMap::new();
-        library_to_idx.insert(Arc::clone(&UNKNOWN_LIBRARY), 0);
-
-        for (id, rg) in header.read_groups() {
-            // Get library name from LB field
-            let library: Arc<str> = rg
-                .other_fields()
-                .get(&rg_tag::LIBRARY)
-                .map_or_else(|| Arc::clone(&UNKNOWN_LIBRARY), |s| Arc::from(s.to_string()));
-
-            // Get or create library index
-            let lib_idx = *library_to_idx.entry(library.clone()).or_insert_with(|| {
-                let idx: u16 =
-                    names.len().try_into().expect("too many distinct libraries for u16 index");
-                names.push(library);
-                idx
-            });
-
-            // Hash the RG string and map to library index
-            let rg_hash = Self::hash_rg(id.as_bytes());
-            lookup.insert(rg_hash, lib_idx);
-        }
-
-        Self { lookup, names, unknown_idx: 0 }
-    }
-
-    /// Get the library index for a read group hash.
-    ///
-    /// Returns 0 (unknown) if the RG hash is not found.
-    #[must_use]
-    pub fn get(&self, rg_hash: u64) -> u16 {
-        *self.lookup.get(&rg_hash).unwrap_or(&self.unknown_idx)
-    }
-
-    /// Get the library name for an index.
-    #[must_use]
-    pub fn library_name(&self, idx: u16) -> &Arc<str> {
-        self.names.get(idx as usize).unwrap_or(&self.names[0])
-    }
-
-    /// Hash a byte slice using `AHash`. Returns 0 for `None`.
-    ///
-    /// This is the single hashing implementation used by all `hash_*` methods.
-    #[must_use]
-    pub fn hash_bytes(bytes: Option<&[u8]>) -> u64 {
-        use ahash::AHasher;
-        use std::hash::{Hash, Hasher};
-        match bytes {
-            Some(b) => {
-                let mut hasher = AHasher::default();
-                b.hash(&mut hasher);
-                hasher.finish()
-            }
-            None => 0,
-        }
-    }
-
-    /// Hash an RG tag value for lookup.
-    #[must_use]
-    pub fn hash_rg(rg_bytes: &[u8]) -> u64 {
-        Self::hash_bytes(Some(rg_bytes))
-    }
-
-    /// Hash a cell barcode for `GroupKey`.
-    #[must_use]
-    pub fn hash_cell_barcode(cell_bytes: Option<&[u8]>) -> u64 {
-        Self::hash_bytes(cell_bytes)
-    }
-
-    /// Hash a read name for `GroupKey`.
-    #[must_use]
-    pub fn hash_name(name_bytes: Option<&[u8]>) -> u64 {
-        Self::hash_bytes(name_bytes)
-    }
-}
-
-impl Default for LibraryIndex {
-    fn default() -> Self {
-        Self {
-            lookup: ahash::AHashMap::new(),
-            names: vec![Arc::clone(&UNKNOWN_LIBRARY)],
-            unknown_idx: 0,
-        }
-    }
-}
 
 /// Information about read positions needed for grouping and ordering.
 ///
@@ -423,9 +268,9 @@ impl ReadInfo {
         let library: Arc<str> =
             if let Some(TagValue::String(rg_bytes)) = record.tags().get(SamTag::RG.as_ref()) {
                 let rg_id = std::str::from_utf8(rg_bytes).unwrap_or("unknown");
-                library_lookup.get(rg_id).cloned().unwrap_or_else(|| Arc::clone(&UNKNOWN_LIBRARY))
+                library_lookup.get(rg_id).cloned().unwrap_or_else(unknown_library)
             } else {
-                Arc::clone(&UNKNOWN_LIBRARY)
+                unknown_library()
             };
 
         // Extract cell barcode using the raw tag bytes
@@ -550,6 +395,8 @@ fn get_unclipped_position_raw(record: &fgumi_raw_bam::RawRecord) -> Result<i32> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use noodles::sam::header::Header;
+    use rstest::rstest;
 
     #[test]
     fn test_read_info_ordering() {
@@ -664,6 +511,61 @@ mod tests {
         assert_eq!(lookup.get("RG1").map(AsRef::as_ref), Some("libA"));
         assert_eq!(lookup.get("RG2").map(AsRef::as_ref), Some("libB"));
         assert_eq!(lookup.get("RG3").map(AsRef::as_ref), Some("unknown"));
+    }
+
+    /// `ReadInfo::from` resolves the library through the header lookup, and
+    /// this pins all three outcomes of that resolution.
+    ///
+    /// The two fallbacks are the interesting half: an `RG` naming a read group
+    /// the header never declared, and a record with no `RG` at all, must both
+    /// land on the shared `unknown_library()` value rather than differing or
+    /// panicking. `unknown_library()` is the crate-shared `Arc<str>` this
+    /// change deduplicated — a second local copy would have compared equal by
+    /// value while allocating twice, so the pointer identity is asserted too.
+    #[rstest]
+    #[case::rg_present_in_header(Some("RG1"), "libA")]
+    #[case::rg_absent_from_header(Some("RG-not-in-header"), "unknown")]
+    #[case::no_rg_tag(None, "unknown")]
+    fn read_info_from_resolves_the_library(
+        #[case] rg: Option<&str>,
+        #[case] expected_library: &str,
+    ) {
+        use bstr::BString;
+        use fgumi_raw_bam::SamBuilder;
+        use noodles::sam::header::record::value::Map;
+        use noodles::sam::header::record::value::map::ReadGroup;
+        use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
+
+        let rg1 = Map::<ReadGroup>::builder()
+            .insert(rg_tag::LIBRARY, String::from("libA"))
+            .build()
+            .expect("read group builds");
+        let header = Header::builder().add_read_group(BString::from("RG1"), rg1).build();
+        let lookup = super::build_library_lookup(&header);
+
+        let mut b = SamBuilder::new();
+        b.read_name(b"q1")
+            .flags(0)
+            .ref_id(0)
+            .pos(100)
+            .cigar_ops(&[4u32 << 4])
+            .sequence(b"ACGT")
+            .qualities(&[30u8; 4]);
+        if let Some(rg) = rg {
+            b.add_string_tag(*SamTag::RG, rg.as_bytes());
+        }
+        let template = Template::from_records(vec![b.build()]).expect("template builds");
+
+        let info = ReadInfo::from(&template, Tag::CELL_BARCODE_ID, &lookup)
+            .expect("ReadInfo::from succeeds for a mapped single-end template");
+
+        assert_eq!(info.library.as_ref(), expected_library);
+        if expected_library == "unknown" {
+            assert!(
+                Arc::ptr_eq(&info.library, &unknown_library()),
+                "the fallback must reuse the crate-shared `unknown` Arc, not allocate a copy",
+            );
+        }
     }
 
     #[test]

--- a/src/lib/template.rs
+++ b/src/lib/template.rs
@@ -108,6 +108,23 @@ impl Template {
         }
     }
 
+    /// True allocated heap footprint in bytes: summed record **capacities** plus
+    /// the `Vec<RawRecord>` container overhead plus the queryname allocation.
+    /// Used by the pipeline framework's `BamTemplateBatch` for byte-bounded queue
+    /// budgeting, so the budget tracks real RSS. Accounting by logical `len()`
+    /// under-counts over-allocated record buffers and ignores container overhead,
+    /// which lets the pipeline buffer past its `--max-memory` budget and risk an
+    /// OOM (this mirrors `DecodedRecordBatch`, which already sizes by capacity).
+    /// `MemoryEstimate::estimate_heap_size` delegates here so the two never
+    /// diverge.
+    #[must_use]
+    pub fn heap_size(&self) -> usize {
+        let name_size = self.name.capacity();
+        let records_size = self.records.iter().map(RawRecord::capacity).sum::<usize>()
+            + self.records.capacity() * std::mem::size_of::<RawRecord>();
+        name_size + records_size
+    }
+
     /// Returns the primary R1 record if present.
     #[must_use]
     pub fn r1(&self) -> Option<&RawRecord> {
@@ -1035,14 +1052,10 @@ impl<R: std::io::Read> Iterator for TemplateIterator<R> {
 
 impl MemoryEstimate for Template {
     fn estimate_heap_size(&self) -> usize {
-        // name: Vec<u8>
-        let name_size = self.name.capacity();
-
-        // records: Vec<RawRecord>
-        let records_size = self.records.iter().map(RawRecord::capacity).sum::<usize>()
-            + self.records.capacity() * std::mem::size_of::<RawRecord>();
-
-        name_size + records_size
+        // Single source of truth: the pipeline byte-budget (`Template::heap_size`)
+        // and `MemoryEstimate` must agree, so both use the capacity-based
+        // footprint computed in `heap_size`.
+        self.heap_size()
     }
 }
 
@@ -1066,6 +1079,74 @@ mod tests {
     const FLAG_MATE_REVERSE: u16 = 0x20;
     const FLAG_UNMAPPED: u16 = 0x4;
     const FLAG_MATE_UNMAPPED: u16 = 0x8;
+    #[test]
+    fn heap_size_counts_capacity_and_matches_memory_estimate() {
+        // A queryname allocation with spare capacity: the byte budget must count
+        // the allocated capacity (real RSS), not the 5-byte logical length —
+        // otherwise the pipeline under-counts and can buffer past --max-memory.
+        let mut name = Vec::with_capacity(64);
+        name.extend_from_slice(b"read1");
+        let mut template = Template::new(name);
+
+        // Hold real records in a Vec with deliberately reserved spare capacity so
+        // BOTH record terms of `heap_size` are exercised — the per-record byte
+        // buffers (`RawRecord::capacity`) and the `Vec<RawRecord>` backing store
+        // (`records.capacity() * size_of::<RawRecord>()`). The empty-records case
+        // left both at zero, so a dropped record term would have gone unnoticed.
+        let mut records: Vec<RawRecord> = Vec::with_capacity(8);
+        let mut first = create_test_raw(b"read1", raw_flags::PAIRED | raw_flags::FIRST_SEGMENT);
+        // Force spare capacity on one record so the per-record term is genuinely
+        // capacity-based, not length-based: with `capacity() == len()` a
+        // regression from `RawRecord::capacity()` to `len()` would leave the
+        // total unchanged and slip through.
+        first.as_mut_vec().reserve(64);
+        records.push(first);
+        records.push(create_test_raw(b"read1", raw_flags::PAIRED | raw_flags::LAST_SEGMENT));
+        template.records = records;
+        assert!(
+            template.records.iter().any(|r| r.capacity() > r.len()),
+            "a record must carry spare capacity so the per-record term is capacity-based",
+        );
+
+        // heap_size (pipeline byte-budget) and estimate_heap_size (MemoryEstimate)
+        // are a single source of truth — they must never diverge.
+        assert_eq!(
+            template.heap_size(),
+            template.estimate_heap_size(),
+            "heap_size and estimate_heap_size must agree",
+        );
+
+        // Exact component total re-derived in the test (NOT via
+        // estimate_heap_size, which delegates to heap_size and is tautological).
+        // `heap_size` is exactly these three terms, so an exact equality catches a
+        // dropped record-buffer/Vec-backing term AND a capacity()→len() regression
+        // on the record buffers (which the spare capacity above makes observable).
+        let record_bytes = template.records.iter().map(RawRecord::capacity).sum::<usize>();
+        let vec_backing = template.records.capacity() * std::mem::size_of::<RawRecord>();
+        let expected_exact = template.name.capacity() + record_bytes + vec_backing;
+        assert_eq!(
+            template.heap_size(),
+            expected_exact,
+            "heap_size must equal queryname ({}) + record buffers ({record_bytes}) + \
+             Vec<RawRecord> backing ({vec_backing})",
+            template.name.capacity(),
+        );
+        // The record terms must be non-trivial: real byte buffers and the reserved
+        // spare Vec slots both contribute, not just the queryname.
+        assert!(record_bytes > 0, "records must carry real byte capacity");
+        assert!(vec_backing > 0, "Vec<RawRecord> backing store must be counted");
+        assert!(
+            template.records.capacity() >= 8,
+            "reserved spare Vec capacity must be retained ({} < 8)",
+            template.records.capacity(),
+        );
+        // And the footprint reflects the allocated queryname capacity (>= 64).
+        assert!(
+            template.heap_size() >= 64,
+            "heap_size must count allocated capacity, got {}",
+            template.heap_size(),
+        );
+    }
 
     /// Create a simple test raw record with given name and flags.
     fn create_test_raw(name: &[u8], flags: u16) -> RawRecord {

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -513,6 +513,16 @@ pub fn compute_group_key_from_raw(
     let reverse = (flg & fgumi_raw_bam::flags::REVERSE) != 0;
     let own_pos = fgumi_raw_bam::unclipped_5prime_from_raw_bam(raw);
 
+    // A mapped record with an empty or truncated CIGAR has no computable
+    // unclipped 5' position, so `unclipped_5prime_from_raw_bam` returns the
+    // `i32::MAX` sentinel. Fall back to the name-only key rather than letting the
+    // sentinel reach a position slot — otherwise distinct templates sharing
+    // ref/strand/library/cell would collide on `i32::MAX` (`position_key`
+    // excludes `name_hash`). Matches the secondary/supplementary fallback above.
+    if own_pos == i32::MAX {
+        return (GroupKey { name_hash, ..GroupKey::default() }, None);
+    }
+
     let own_ref_id = fgumi_raw_bam::ref_id(raw);
     let strand = u8::from(reverse);
 
@@ -1640,47 +1650,10 @@ impl QueueDepths {
 // Grouper Trait (for Step 5: Group)
 // ============================================================================
 
-/// Trait for command-specific record grouping logic.
-///
-/// The Grouper receives already-decoded BAM records and groups them according
-/// to command-specific rules. Since records are pre-decoded, grouping is very
-/// fast - just comparing record names, positions, or tags.
-///
-/// Different commands use different grouping strategies:
-/// - `group`: Groups by genomic position
-/// - `simplex/duplex/codec`: Groups by MI tag
-/// - `filter/clip/correct`: No grouping (each record is its own "group")
-pub trait Grouper: Send {
-    /// The type of group produced by this grouper.
-    type Group: Send;
-
-    /// Add decoded records to the grouper.
-    ///
-    /// Records are guaranteed to be in order (from template-coordinate sorted BAM).
-    /// The grouper maintains partial groups waiting for more records.
-    ///
-    /// Each `DecodedRecord` contains the record plus a pre-computed `GroupKey`
-    /// for fast comparison (position, name hash, library, etc.).
-    ///
-    /// Returns completed groups (may be empty if more records are needed).
-    ///
-    /// # Errors
-    ///
-    /// Returns an I/O error if grouping logic encounters invalid data.
-    fn add_records(&mut self, records: Vec<DecodedRecord>) -> io::Result<Vec<Self::Group>>;
-
-    /// Signal that no more input will arrive (EOF).
-    ///
-    /// Returns any remaining partial group.
-    ///
-    /// # Errors
-    ///
-    /// Returns an I/O error if finalizing the grouper fails.
-    fn finish(&mut self) -> io::Result<Option<Self::Group>>;
-
-    /// Returns true if the grouper has a partial group.
-    fn has_pending(&self) -> bool;
-}
+// The `Grouper` trait is defined once, in `fgumi-bam-io`, alongside the
+// `DecodedRecord` it consumes. Re-exported so existing
+// `crate::unified_pipeline::Grouper` paths keep resolving.
+pub use fgumi_bam_io::Grouper;
 
 /// State for the exclusive `Group` step.
 ///

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -89,10 +89,6 @@ pub use fgumi_bam_io::{ProgressTracker, RawBamWriter, ReorderBuffer};
 use super::deadlock::{DeadlockAction, DeadlockState, QueueSnapshot, check_deadlock_and_restore};
 
 use crate::bgzf_reader::{RawBgzfBlock, decompress_block_into_opts, read_raw_blocks};
-use crate::read_info::LibraryIndex;
-use crate::sam::SamTag;
-use fgumi_raw_bam::RawRecord;
-use noodles::sam::alignment::record::data::field::Tag;
 
 use super::scheduler::{BackpressureState, Scheduler, SchedulerStrategy, create_scheduler};
 
@@ -1500,328 +1496,32 @@ impl ActiveSteps {
 // GroupKey - Pre-computed grouping key for fast comparison in Group step
 // ============================================================================
 
-/// Pre-computed grouping key for fast comparison in Group step.
-///
-/// All fields are integers/hashes for O(1) comparison. This is computed during
-/// the parallel Decode step so the serial Group step only does integer comparisons.
-///
-/// For paired-end reads, positions are normalized so the lower position comes first.
-/// For single-end reads, the mate fields use `UNKNOWN_*` sentinel values.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct GroupKey {
-    // Position info (normalized: lower position first)
-    /// Reference sequence index for position 1 (lower).
-    pub ref_id1: i32,
-    /// Unclipped 5' position for position 1.
-    pub pos1: i32,
-    /// Strand for position 1 (0=forward, 1=reverse).
-    pub strand1: u8,
-    /// Reference sequence index for position 2 (higher or mate).
-    pub ref_id2: i32,
-    /// Unclipped 5' position for position 2.
-    pub pos2: i32,
-    /// Strand for position 2.
-    pub strand2: u8,
-
-    // Grouping metadata
-    /// Library index (pre-computed from RG tag via header lookup).
-    pub library_idx: u16,
-    /// Hash of cell barcode (0 if none).
-    pub cell_hash: u64,
-
-    // For name-based grouping within position groups
-    /// Hash of QNAME for fast name comparison.
-    pub name_hash: u64,
-}
-
-impl GroupKey {
-    /// Sentinel value for unknown reference ID (unpaired reads).
-    pub const UNKNOWN_REF: i32 = i32::MAX;
-    /// Sentinel value for unknown position (unpaired reads).
-    pub const UNKNOWN_POS: i32 = i32::MAX;
-    /// Sentinel value for unknown strand (unpaired reads).
-    pub const UNKNOWN_STRAND: u8 = u8::MAX;
-
-    /// Create a `GroupKey` for a paired-end read with mate info.
-    ///
-    /// Positions are automatically normalized so the lower position comes first.
-    ///
-    /// Both strands must be `0` (forward) or `1` (reverse). Every caller derives
-    /// them from a boolean — either a flag bit or a `!= 0` test on a `tc` field —
-    /// so `UNKNOWN_STRAND` can never reach `strand2` through this constructor.
-    /// [`GroupKey::has_mate_position`] depends on that, so the invariant is
-    /// asserted here rather than left to convention.
-    #[must_use]
-    #[allow(clippy::too_many_arguments)]
-    pub fn paired(
-        ref_id: i32,
-        pos: i32,
-        strand: u8,
-        mate_ref_id: i32,
-        mate_pos: i32,
-        mate_strand: u8,
-        library_idx: u16,
-        cell_hash: u64,
-        name_hash: u64,
-    ) -> Self {
-        debug_assert!(
-            strand <= 1 && mate_strand <= 1,
-            "GroupKey::paired requires boolean strands (got {strand}, {mate_strand}); \
-             UNKNOWN_STRAND in a paired key would break GroupKey::has_mate_position"
-        );
-
-        // Normalize: put lower position first (matching ReadInfo behavior)
-        let (ref_id1, pos1, strand1, ref_id2, pos2, strand2) =
-            if (ref_id, pos, strand) <= (mate_ref_id, mate_pos, mate_strand) {
-                (ref_id, pos, strand, mate_ref_id, mate_pos, mate_strand)
-            } else {
-                (mate_ref_id, mate_pos, mate_strand, ref_id, pos, strand)
-            };
-
-        Self { ref_id1, pos1, strand1, ref_id2, pos2, strand2, library_idx, cell_hash, name_hash }
-    }
-
-    /// Create a `GroupKey` for a single-end/unpaired read.
-    #[must_use]
-    pub fn single(
-        ref_id: i32,
-        pos: i32,
-        strand: u8,
-        library_idx: u16,
-        cell_hash: u64,
-        name_hash: u64,
-    ) -> Self {
-        Self {
-            ref_id1: ref_id,
-            pos1: pos,
-            strand1: strand,
-            ref_id2: Self::UNKNOWN_REF,
-            pos2: Self::UNKNOWN_POS,
-            strand2: Self::UNKNOWN_STRAND,
-            library_idx,
-            cell_hash,
-            name_hash,
-        }
-    }
-
-    /// Returns whether this key carries a resolved mate position.
-    ///
-    /// True for keys built by [`GroupKey::paired`], false for
-    /// [`GroupKey::single`] and [`GroupKey::default`].
-    ///
-    /// `strand2` is the discriminator because [`GroupKey::paired`] always
-    /// receives boolean strands (asserted there), so only the single-ended
-    /// constructors can produce [`GroupKey::UNKNOWN_STRAND`]. `ref_id2` and
-    /// `pos2` are weaker: `i32::MAX` is a legal-looking coordinate.
-    ///
-    /// Decode resolves the mate position from the `MC` tag, falling back to a
-    /// single-ended key when it is absent (see `compute_group_key_from_raw`).
-    /// `RecordPositionGrouper` therefore reads this instead of re-walking the
-    /// record's aux data.
-    #[must_use]
-    pub fn has_mate_position(&self) -> bool {
-        self.strand2 != Self::UNKNOWN_STRAND
-    }
-
-    /// Returns the position-only key for grouping by genomic position.
-    ///
-    /// This is used by `RecordPositionGrouper` to determine if records belong to
-    /// the same position group (ignoring name).
-    #[must_use]
-    pub fn position_key(&self) -> (i32, i32, u8, i32, i32, u8, u16, u64) {
-        (
-            self.ref_id1,
-            self.pos1,
-            self.strand1,
-            self.ref_id2,
-            self.pos2,
-            self.strand2,
-            self.library_idx,
-            self.cell_hash,
-        )
-    }
-}
-
-impl PartialOrd for GroupKey {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for GroupKey {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.position_key()
-            .cmp(&other.position_key())
-            .then_with(|| self.name_hash.cmp(&other.name_hash))
-    }
-}
-
-impl Default for GroupKey {
-    fn default() -> Self {
-        Self {
-            ref_id1: Self::UNKNOWN_REF,
-            pos1: Self::UNKNOWN_POS,
-            strand1: Self::UNKNOWN_STRAND,
-            ref_id2: Self::UNKNOWN_REF,
-            pos2: Self::UNKNOWN_POS,
-            strand2: Self::UNKNOWN_STRAND,
-            library_idx: 0,
-            cell_hash: 0,
-            name_hash: 0,
-        }
-    }
-}
-
 // ============================================================================
 // DecodedRecord - Record with pre-computed grouping key
 // ============================================================================
 
-/// A decoded BAM record with its pre-computed grouping key.
-///
-/// This is the output of the Decode step and input to the Group step.
-/// The key is computed during the parallel Decode step so that the
-/// serial Group step only needs to do fast integer comparisons.
-#[derive(Debug)]
-pub struct DecodedRecord {
-    /// Pre-computed grouping key.
-    pub key: GroupKey,
-    /// Raw BAM record bytes.
-    pub(crate) data: RawRecord,
-    /// Cached record-relative offset of the UMI tag's value bytes (i.e. the
-    /// first byte after the 2-byte tag header and the 1-byte type byte). The
-    /// slice `data[umi_value_offset..umi_value_offset + umi_value_len]` yields
-    /// the UMI bytes without the trailing NUL.
-    ///
-    /// Set to `Self::UMI_OFFSET_UNCACHED` when no UMI position was cached
-    /// during decode (UMI tag missing, not Z-typed, or caching disabled).
-    pub(crate) umi_value_offset: u32,
-    /// Cached UMI value length in bytes, paired with `umi_value_offset`.
-    pub(crate) umi_value_len: u16,
-}
+// `DecodedRecord` is defined once, in `fgumi-bam-io`, alongside the `GroupKey`
+// it carries and the `Grouper` trait that consumes it. It was duplicated here
+// while the ported step library only ever produced these records; the moment
+// ported steps started handing them to the umbrella groupers, the two copies
+// became two incompatible types with identical definitions. Re-exported so
+// every `crate::unified_pipeline::DecodedRecord` path keeps resolving.
+pub use fgumi_bam_io::DecodedRecord;
 
-impl DecodedRecord {
-    /// Sentinel value for `umi_value_offset` indicating no cached UMI position.
-    /// Chosen as `u32::MAX` so it can never collide with a real BAM record
-    /// offset (BAM records are bounded well under 4 GiB).
-    pub const UMI_OFFSET_UNCACHED: u32 = u32::MAX;
+// `GroupKey` and `GroupKeyConfig` are defined once, in `fgumi-bam-io`, next to
+// the `DecodedRecord` that carries them. They were duplicated here for the same
+// reason `DecodedRecord` was, and stopped being separable for the same reason:
+// a ported step handing a key to an umbrella grouper needs the two copies to be
+// one type. Re-exported so existing `crate::unified_pipeline::GroupKey` /
+// `GroupKeyConfig` paths keep resolving.
+pub use fgumi_bam_io::{GroupKey, GroupKeyConfig};
 
-    /// Create a decoded record from raw bytes, skipping noodles decode.
-    ///
-    /// Accepts anything that converts `Into<RawRecord>` (e.g. a bare `Vec<u8>` or
-    /// an already-constructed `RawRecord`).
-    #[must_use]
-    pub fn from_raw_bytes(raw: impl Into<RawRecord>, key: GroupKey) -> Self {
-        Self {
-            key,
-            data: raw.into(),
-            umi_value_offset: Self::UMI_OFFSET_UNCACHED,
-            umi_value_len: 0,
-        }
-    }
-
-    /// Attach a cached UMI value position to this decoded record.
-    ///
-    /// `umi_value_offset` is the record-relative offset of the first UMI value
-    /// byte (after the tag header), and `umi_value_len` is the value length
-    /// (excluding any trailing NUL).
-    pub fn set_cached_umi(&mut self, umi_value_offset: u32, umi_value_len: u16) {
-        self.umi_value_offset = umi_value_offset;
-        self.umi_value_len = umi_value_len;
-    }
-
-    /// Returns the cached UMI bytes (without trailing NUL) if a position was
-    /// recorded during decode and still falls within the raw record bytes.
-    /// Returns `None` if no cache is set or the cached position is out of range.
-    #[must_use]
-    pub fn cached_umi(&self) -> Option<&[u8]> {
-        if self.umi_value_offset == Self::UMI_OFFSET_UNCACHED {
-            return None;
-        }
-        let start = self.umi_value_offset as usize;
-        let end = start.checked_add(self.umi_value_len as usize)?;
-        self.data.as_ref().get(start..end)
-    }
-
-    /// Returns the cached UMI offset (`UMI_OFFSET_UNCACHED` when absent) and length.
-    #[must_use]
-    pub fn cached_umi_position(&self) -> (u32, u16) {
-        (self.umi_value_offset, self.umi_value_len)
-    }
-
-    /// Returns a reference to the raw bytes.
-    #[must_use]
-    pub fn raw_bytes(&self) -> &[u8] {
-        self.data.as_ref()
-    }
-
-    /// Takes the [`RawRecord`] out.
-    #[must_use]
-    pub fn into_raw_bytes(self) -> RawRecord {
-        self.data
-    }
-}
-
-impl MemoryEstimate for DecodedRecord {
-    fn estimate_heap_size(&self) -> usize {
-        // RawRecord::capacity() returns the inner Vec<u8> capacity.
-        self.data.capacity()
-    }
-}
 // Vec<DecodedRecord>, Vec<RecordBuf>, Vec<u8>, RecordBuf, () — all provided
 // by the blanket/foreign impls in fgumi_bam_io::mem_estimate.
 
 // ============================================================================
 // GroupKeyConfig - Configuration for computing `GroupKey` during Decode
 // ============================================================================
-
-/// Configuration for computing `GroupKey` during the Decode step.
-///
-/// When this is provided to the pipeline, the Decode step will compute
-/// full `GroupKey` values for each record. This moves expensive computations
-/// (CIGAR parsing, tag extraction) from the serial Group step to the parallel
-/// Decode step.
-#[derive(Debug, Clone)]
-pub struct GroupKeyConfig {
-    /// Library index for fast RG → library lookup.
-    pub library_index: Arc<LibraryIndex>,
-    /// Tag used for cell barcode extraction. None skips cell extraction.
-    pub cell_tag: Option<Tag>,
-    /// UMI tag (raw 2-byte form) whose value position should be cached on each
-    /// `DecodedRecord` during decode. None disables caching — downstream code
-    /// must fall back to scanning aux data.
-    pub umi_tag: Option<[u8; 2]>,
-}
-
-impl GroupKeyConfig {
-    /// Create a new `GroupKeyConfig`.
-    #[must_use]
-    pub fn new(library_index: LibraryIndex, cell_tag: Tag) -> Self {
-        Self { library_index: Arc::new(library_index), cell_tag: Some(cell_tag), umi_tag: None }
-    }
-
-    /// Create a `GroupKeyConfig` without cell barcode extraction.
-    #[must_use]
-    pub fn new_raw_no_cell(library_index: LibraryIndex) -> Self {
-        Self { library_index: Arc::new(library_index), cell_tag: None, umi_tag: None }
-    }
-
-    /// Enable UMI position caching for the given raw 2-byte UMI tag (e.g. `*b"RX"`).
-    #[must_use]
-    pub fn with_umi_tag(mut self, umi_tag: [u8; 2]) -> Self {
-        self.umi_tag = Some(umi_tag);
-        self
-    }
-}
-
-impl Default for GroupKeyConfig {
-    fn default() -> Self {
-        Self {
-            library_index: Arc::new(LibraryIndex::default()),
-            cell_tag: Some(Tag::from(SamTag::CB)), // Default cell barcode tag
-            umi_tag: None,
-        }
-    }
-}
 
 /// Decompressed data batch (output of Step 2, input to Step 3).
 #[derive(Default)]

--- a/src/lib/unified_pipeline/fastq.rs
+++ b/src/lib/unified_pipeline/fastq.rs
@@ -3682,7 +3682,7 @@ fn fastq_try_step_parse<R: BufRead + Send, P: Send + MemoryEstimate>(
 /// Create templates by zipping records from synchronized FASTQ streams.
 ///
 /// For single-end: each record becomes its own template.
-/// For paired-end: R1[i] and R2[i] are zipped into a single template.
+/// For paired-end: `R1[i]` and `R2[i]` are zipped into a single template.
 fn create_templates_from_streams(
     mut streams: Vec<FastqParsedStream>,
 ) -> io::Result<Vec<FastqTemplate>> {


### PR DESCRIPTION
**Do not merge.** Review-only split of #870 to fit CodeRabbit's 150-file limit; stacked on the split 1/2 PR. This PR is the second half (121 files, commits 8–22 of #870): `fgumi-pipeline-io`, the shared bam-io grouping/library-lookup, the typed-step pipeline tree, the read-side source steps (R1b), per-stage option projection, the grouping/mi and UMI-correction step ports, the crate-version sync, and the miri guard. Base is the split 1/2 branch so its diff shows only this half. Findings will be applied to #870 and this PR closed unmerged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: output changes are possible through new typed grouping, sorting, correction, and serialization steps, pinned by ordered events, legacy-compatible tuning, and integration tests; unsafe changes: none, and CLAUDE.md allowlist updates: none; memory bounds, queue capacities, and thread/backpressure policies: changed through byte-bounded queues, worker tuning, detached groups, and concurrency limits.

- Adds the `fgumi-pipeline-io` crate with BAM boundary scanning, BGZF/raw sinks, source readers, sorting, spill processing, decompression, merging, and shared pipeline types.
- Adds typed pipeline steps for BAM, SAM, and FASTQ input; parsing; grouping; UMI correction; serialization; BGZF processing; and sorting.
- Centralizes BAM library lookup, grouping keys, decoded records, MI extraction, and cached UMI handling.
- Adds per-stage option projections for codec, correction, duplex, filter, grouping, simplex, and zipper commands.
- Adds liveness monitoring and heap-size accounting.
- Adds extensive unit, property, integration, stress, and Miri-related coverage.
- Synchronizes crate configuration and documentation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->