### PR TITLE
test: speed up the slow-test tail without weakening invariants

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,13 +1,2 @@
 [profile.default]
 slow-timeout = { period = "60s", terminate-after = 2 }
-
-# `read_ahead_under_a_stalled_writer_shrinks_with_the_queue_memory_budget` measures
-# each budget arm's read-ahead as the maximum over READ_AHEAD_REPS stalled-writer
-# runs (issue #809), so it spawns the stalled pipeline several times back to back,
-# each with its own settle wait. That is legitimately slow (~30s locally, and 2-3x
-# that under llvm-cov instrumentation plus CI's 2x CPU oversubscription), enough to
-# trip the default 120s (60s x 2) terminate-after. Give this one test a longer leash
-# rather than dropping reps and weakening the flake-suppression the maximum provides.
-[[profile.default.overrides]]
-filter = 'test(=test_pipeline_memory_backpressure::read_ahead_under_a_stalled_writer_shrinks_with_the_queue_memory_budget)'
-slow-timeout = { period = "60s", terminate-after = 4 }

--- a/crates/fgumi-consensus/src/base_builder.rs
+++ b/crates/fgumi-consensus/src/base_builder.rs
@@ -2357,9 +2357,14 @@ mod tests {
     /// `obs_qual` sweep their *entire* representable range (`0..=93`, not a sparse
     /// list), and `depth` densely covers `1..=60` — deliberately starting at `1`, not
     /// some higher floor, because the observed worst case (`base=G, post=Q35,
-    /// obs=Q56, depth=1`) is at the *shallowest* possible depth, plus a handful of
-    /// deeper spot-checks (up to `4000`) to retain the deep-depth coverage this test
-    /// has always had. `pre` is deliberately fixed at Q45 (not swept): `w`, `l`, and
+    /// obs=Q56, depth=1`) is at the *shallowest* possible depth. Deeper spot-checks
+    /// (up to `4000`) retain the deep-depth coverage this test has always had, but —
+    /// since running `add()` to depth 4000 for *every* `(post, obs_qual)` pair is what
+    /// dominated the runtime, and the gap's per-observation increment has a fixed sign
+    /// that cannot flip with depth — they run only on a coarse `DEEP_STRIDE` subset of
+    /// the `(post, obs_qual)` grid, which samples the deep regime broadly across the
+    /// whole space without re-confirming it tens of thousands of times. `pre` is
+    /// deliberately fixed at Q45 (not swept): `w`, `l`, and
     /// `gap` depend only on the post-UMI rate, observation quality, and depth, never
     /// on the pre-UMI rate, which enters only after this bound's scope (in the
     /// pre-UMI error combination step).
@@ -2394,6 +2399,20 @@ mod tests {
         /// allowance.
         const MAX_OBSERVED_RATIO_CEILING: f64 = 5.0;
 
+        // Deep depths [100..=4000] are visited only on a coarse stride of the
+        // `(post, obs_qual)` grid. Running `add()` up to depth 4000 for *every* one
+        // of the ~94×94 pairs is what made this test slow (tens of millions of
+        // accumulations), yet the worst case lives at the *shallowest* depths —
+        // which the dense `1..=60` sweep still covers for every pair — and the
+        // gap's per-observation increment has a fixed sign that cannot flip with
+        // more depth (see the doc comment), so deeper depths only re-confirm the
+        // same regime. Sampling them on a representative strided subset retains
+        // broad deep-depth coverage across the whole `(post, obs)` space at a small
+        // fraction of the cost, without moving the asserted bound or ceiling.
+        const DEEP_DEPTHS: [u32; 5] = [100, 400, 1000, 2000, 4000];
+        // Stride over the `(post, obs_qual)` grid for the deep-depth spot-checks.
+        const DEEP_STRIDE: u8 = 8;
+
         let idx = BASE_TO_INDEX[base as usize] as usize;
         let mut checked = 0u64;
         let mut max_observed_ratio = 0.0_f64;
@@ -2404,9 +2423,13 @@ mod tests {
                 let mut b = ConsensusBaseBuilder::new(45, post);
                 let mut current_depth = 0u32;
                 // Dense over the shallow depths where the worst case actually lives
-                // (do not start higher than 1), plus a handful of deep spot-checks to
-                // retain this test's historical deep-depth coverage.
-                for target_depth in (1u32..=60).chain([100, 400, 1000, 2000, 4000]) {
+                // (do not start higher than 1), plus the strided deep spot-checks.
+                let deep: &[u32] = if post % DEEP_STRIDE == 0 && obs_qual % DEEP_STRIDE == 0 {
+                    &DEEP_DEPTHS
+                } else {
+                    &[]
+                };
+                for target_depth in (1u32..=60).chain(deep.iter().copied()) {
                     for _ in current_depth..target_depth {
                         b.add(base, obs_qual);
                     }

--- a/crates/fgumi-pipeline-io/Cargo.toml
+++ b/crates/fgumi-pipeline-io/Cargo.toml
@@ -27,6 +27,15 @@ test-utils = []
 # root crate's `stress-tests` convention.
 stress-tests = []
 
+[lints.rust]
+# `coverage` is a config flag set only by `cargo llvm-cov` (the coverage CI job).
+# The `stress-tests` soak suites read it via `cfg!(coverage)` to collapse their
+# iteration counts to a minimal line-coverage pass there — the full race-hunting
+# soak still runs on the nightly `cargo ci-test-stress` job, which does not set
+# it. Declare the cfg so the unexpected-cfg lint stays quiet under the normal
+# `-D warnings` build (mirrors `fgumi-sort`'s `loom` registration).
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }
+
 [dev-dependencies]
 # fgumi-bam-io, fgumi-bgzf, and tempfile are omitted here: each is already a
 # normal dependency with identical configuration, which tests and benches

--- a/crates/fgumi-pipeline-io/src/sort/tests.rs
+++ b/crates/fgumi-pipeline-io/src/sort/tests.rs
@@ -985,6 +985,22 @@ mod proptests {
     }
 }
 
+/// Soak-iteration count, collapsed to a minimal pass under coverage
+/// instrumentation.
+///
+/// `cargo llvm-cov` (the coverage CI job) sets `cfg(coverage)`. Under it these
+/// soak tests run only to exercise the ~200 lines nothing else reaches, and a
+/// couple of iterations covers every one of them — so we drop to `min` there and
+/// skip the sustained repetition whose sole purpose is hunting rare races. The
+/// FULL soak (its actual race-hunting value) still runs on the nightly
+/// `cargo ci-test-stress` job, which does NOT set `cfg(coverage)`, so nothing is
+/// lost on the path where the soak matters; only the coverage job — which repeats
+/// the same covered lines dozens of times for no extra coverage — gets faster.
+#[cfg(feature = "stress-tests")]
+fn soak_iterations(full: usize, min: usize) -> usize {
+    if cfg!(coverage) { min } else { full }
+}
+
 #[cfg(feature = "stress-tests")]
 /// Maximum-contention soak for the block-parallel decompress path
 /// (`file_granularity == false`). Drives the path repeatedly under the most
@@ -1010,7 +1026,6 @@ mod proptests {
 fn block_parallel_high_contention_soak_matches_legacy() {
     use std::time::Duration;
 
-    const ITERATIONS: usize = 40;
     const RECORDS_PER_ITER: usize = 15_000;
     const PIPELINE_THREADS: usize = 12;
     const SORTER_THREADS: usize = 2;
@@ -1024,8 +1039,9 @@ fn block_parallel_high_contention_soak_matches_legacy() {
     // Per-iteration watchdog: a livelock in any single iteration fails fast.
     const WATCHDOG: Duration = Duration::from_secs(60);
 
+    let iterations = soak_iterations(40, 2);
     let sort_order = SortOrder::Coordinate;
-    for iter in 0..ITERATIONS {
+    for iter in 0..iterations {
         let seed = 0xA5A5_0000_u64 ^ (iter as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
         let (header, records) = synthesize_sized_records(RECORDS_PER_ITER, seed, 110);
         run_watchdogged_parity(
@@ -1064,7 +1080,6 @@ fn block_parallel_high_contention_soak_matches_legacy() {
 fn sort_buffer_chain_tight_memory_soak_no_deadlock() {
     use std::time::Duration;
 
-    const ITERATIONS: usize = 24;
     const RECORDS_PER_ITER: usize = 12_000;
     const PIPELINE_THREADS: usize = 8;
     const SORTER_THREADS: usize = 4;
@@ -1074,7 +1089,8 @@ fn sort_buffer_chain_tight_memory_soak_no_deadlock() {
     const OUTPUT_BYTE_LIMIT: u64 = 48 * 1024;
     const WATCHDOG: Duration = Duration::from_secs(60);
 
-    for iter in 0..ITERATIONS {
+    let iterations = soak_iterations(24, 2);
+    for iter in 0..iterations {
         let seed = 0xC0FF_EE00_u64 ^ (iter as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
         let (header, records) = synthesize_sized_records(RECORDS_PER_ITER, seed, 130);
         run_watchdogged_parity(
@@ -1274,15 +1290,15 @@ fn block_parallel_soak_matrix_matches_legacy(
 ) {
     use std::time::Duration;
 
-    const ITERATIONS: usize = 4;
     const SORTER_THREADS: usize = 2;
     const WATCHDOG: Duration = Duration::from_secs(120);
 
+    let iterations = soak_iterations(4, 1);
     let sort_order = SortOrder::Coordinate;
     let SoakParams { records, seq_len, memory_limit, output_byte_limit, block_batch } =
         regime.params();
 
-    for iter in 0..ITERATIONS {
+    for iter in 0..iterations {
         // Distinct seed per (regime, threads, granularity, iter).
         let seed = 0x50A4_0000_u64
             .wrapping_add((iter as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15))

--- a/src/lib/unified_pipeline/bam.rs
+++ b/src/lib/unified_pipeline/bam.rs
@@ -1087,6 +1087,14 @@ impl<G: Send, P: Send + MemoryEstimate> BamPipelineState<G, P> {
             return true;
         }
         let in_flight = self.queue_bytes_in_flight();
+        // Test-only observation hook (`None` in production — a single predictable
+        // branch). Publishing the in-flight total from the very check that gates
+        // the reader lets backpressure tests wait on the *actual* park condition
+        // (`in_flight >= limit`) instead of inferring it from wall-clock
+        // quiescence, which false-settles when the reader is descheduled (#809).
+        if let Some(probe) = &self.config.queue_bytes_probe {
+            probe.store(in_flight, Ordering::Relaxed);
+        }
         in_flight == 0 || in_flight < limit
     }
 

--- a/src/lib/unified_pipeline/base.rs
+++ b/src/lib/unified_pipeline/base.rs
@@ -2634,6 +2634,17 @@ pub struct PipelineConfig {
     /// `BamIoOptions::pipeline_reader_opts().verify_crc`), which defaults to
     /// verifying for file input and skipping for stdin input.
     pub verify_crc: bool,
+    /// Optional observation hook for the Read step's accounted in-flight bytes.
+    ///
+    /// When `Some`, every Read-admission check stores the current
+    /// `BamPipelineState::queue_bytes_in_flight` total into this atomic. It is
+    /// `None` in every production path (a single predictable branch, no store),
+    /// and exists only so backpressure tests can observe the *actual* gate
+    /// condition the reader parks on — `in_flight >= queue_memory_limit` — rather
+    /// than inferring it from wall-clock quiescence, which is subject to a
+    /// scheduler-noise false-settle (issue #809). It carries no pipeline
+    /// behaviour: nothing reads it back inside the pipeline.
+    pub queue_bytes_probe: Option<Arc<AtomicU64>>,
 }
 
 impl PipelineConfig {
@@ -2657,6 +2668,7 @@ impl PipelineConfig {
             deadlock_recover_enabled: false, // Detection only by default
             shared_stats: None,              // No shared stats by default
             verify_crc: true,                // Verify by default (safe baseline)
+            queue_bytes_probe: None,         // Test-only observation hook; off in production
         }
     }
 
@@ -2758,6 +2770,7 @@ impl PipelineConfig {
             deadlock_recover_enabled: false, // Detection only by default
             shared_stats: None,              // No shared stats by default
             verify_crc: true,                // Verify by default (safe baseline)
+            queue_bytes_probe: None,         // Test-only observation hook; off in production
         }
     }
 

--- a/tests/integration/test_group_determinism.rs
+++ b/tests/integration/test_group_determinism.rs
@@ -155,8 +155,12 @@ fn build_mixed_orientation_bam(path: &Path) {
     // Many position groups, each carrying templates from BOTH orientations.
     // Position-grouping is per-coordinate, so distinct positions form
     // independent subgroup AHashMaps in the assigner — each one a separate
-    // chance for iteration order to vary.
-    for group_idx in 0..40 {
+    // chance for iteration order to vary. The count is the detection knob: with
+    // 256 UMIs per orientation and `n_runs` fresh hash seeds, a couple of dozen
+    // independent position groups already make an unsorted-iteration regression
+    // overwhelmingly likely to surface, so 24 (down from 40) keeps the guard's
+    // sensitivity while cutting the per-run record count that dominates runtime.
+    for group_idx in 0..24 {
         let base_pos = 1_000 + group_idx * 1_000;
         for (u_idx, umi) in umis.iter().enumerate() {
             for is_rf in [false, true] {

--- a/tests/integration/test_pipeline_memory_backpressure.rs
+++ b/tests/integration/test_pipeline_memory_backpressure.rs
@@ -67,7 +67,16 @@ const TEST_BUDGET_BYTES: u64 = 2 * 1024 * 1024;
 /// gives the needed compressed margin for the least build cost; the pipeline is
 /// exercised with a pass-through grouper, so family structure is immaterial
 /// here.
-const FAMILIES: usize = 175_000;
+///
+/// Sized just above the [`MIN_INPUT_HEADROOM_BUDGETS`] floor rather than well
+/// over it: building and draining this fixture dominates every test's runtime
+/// (it is rebuilt per test process under nextest), so trimming the record count
+/// to the smallest size that still clears the floor with drift headroom is the
+/// biggest single speedup here. At this count the compressed input measures
+/// ~3.3 budgets — comfortably above the 3-budget floor while leaving ~1.8
+/// budgets unread past where the reader stops, so the margin assertions keep
+/// well over a full budget of BGZF block-size drift headroom (issue #789).
+const FAMILIES: usize = 143_000;
 const DEPTH: usize = 1;
 
 /// The compressed fixture must be at least this many `TEST_BUDGET_BYTES` in
@@ -79,7 +88,7 @@ const DEPTH: usize = 1;
 /// budget left unread on top of wherever the reader stops, so anything below
 /// three budgets has no slack for BGZF block-size drift (issue #789). The floor
 /// holds with room to spare at the current `FAMILIES`: the input measures
-/// ~4 budgets and the reader stops by ~1.5, leaving ~2.5 budgets unread on
+/// ~3.3 budgets and the reader stops by ~1.5, leaving ~1.8 budgets unread on
 /// every arm. [`shared_bam_bytes`] asserts this floor once at fixture
 /// construction so a future shrink of `FAMILIES` fails loudly for *every* test
 /// — not only the one that happens to re-check it — rather than silently
@@ -233,6 +242,11 @@ fn build_bam_bytes(header: &Header, num_families: usize, depth: usize) -> Vec<u8
 struct StalledRun {
     /// Input bytes the Read step has pulled so far.
     consumed: Arc<AtomicU64>,
+    /// The pipeline's live accounted in-flight-bytes total, published by the Read
+    /// step's own admission check (see `PipelineConfig::queue_bytes_probe`). The
+    /// reader is gated exactly when this reaches `queue_memory_limit`, so tests
+    /// wait on this rather than inferring the park from wall-clock quiescence.
+    in_flight: Arc<AtomicU64>,
     /// Set to release the writer.
     released: Arc<AtomicBool>,
     /// Output bytes accepted after release (record blocks only, no header).
@@ -256,6 +270,7 @@ fn spawn_stalled_pipeline(
     blocks_per_read_batch: Option<usize>,
 ) -> StalledRun {
     let consumed = Arc::new(AtomicU64::new(0));
+    let in_flight = Arc::new(AtomicU64::new(0));
     let released = Arc::new(AtomicBool::new(false));
     let sink = Arc::new(Mutex::new(Vec::new()));
 
@@ -275,6 +290,9 @@ fn spawn_stalled_pipeline(
         config.blocks_per_read_batch = blocks;
     }
     config.queue_memory_limit = queue_memory_limit;
+    // Publish the in-flight-bytes total from the Read admission check so the test
+    // can observe the gate directly (see `wait_until_gated`).
+    config.queue_bytes_probe = Some(Arc::clone(&in_flight));
     // A permanently stalled writer is exactly what the deadlock detector is
     // meant to flag, and flagging it would tear the pipeline down before the
     // assertion. Disable it so the test observes backpressure, not recovery.
@@ -302,57 +320,105 @@ fn spawn_stalled_pipeline(
         )
     });
 
-    StalledRun { consumed, released, sink, handle }
+    StalledRun { consumed, in_flight, released, sink, handle }
 }
 
 /// Outcome of waiting for the reader to stop pulling input.
 struct Consumption {
     /// Input bytes consumed when the wait ended.
     bytes: u64,
-    /// Whether consumption actually settled (or reached EOF), as opposed to the
-    /// wait timing out with the counter still moving. A timeout means the
-    /// caller's premise — that the reader had stopped — never held, so tests
-    /// assert on this to fail loudly rather than silently comparing a
-    /// still-moving figure.
+    /// Whether the reader actually parked at the byte gate (or reached EOF), as
+    /// opposed to the wait timing out with the reader still admitting input. A
+    /// timeout means the caller's premise — that the reader had stopped — never
+    /// held, so tests assert on this to fail loudly rather than silently
+    /// comparing a still-moving figure.
     settled: bool,
 }
 
-/// Wait until input consumption stops growing, or `timeout` elapses.
+/// Wait until the Read step is gated by the byte budget, or `timeout` elapses.
 ///
-/// Reports the number of input bytes consumed once the counter has held still
-/// across `STABLE_SAMPLES` consecutive samples, or as soon as the whole input
-/// has been read, with `settled: true`. Several samples rather than one guards
-/// against a loaded CI machine descheduling the reader briefly and looking like
-/// backpressure. If the deadline is reached with the counter still moving, it
-/// reports the last figure with `settled: false`.
-fn wait_for_consumption_to_settle(
+/// Observes the pipeline's *actual* park condition rather than inferring it from
+/// wall-clock quiescence. The Read step admits input only while accounted
+/// in-flight bytes stay under `queue_memory_limit`
+/// (`BamPipelineState::read_admission_allowed`); `in_flight` mirrors that total,
+/// published by the very check that gates the reader. Under a permanently
+/// stalled writer, once `in_flight` reaches the limit the reader parks and stays
+/// parked — a terminal state — so `consumed` at that point is the final
+/// read-ahead.
+///
+/// This is immune to the scheduler-noise false-settle that a "consumed stopped
+/// moving" heuristic suffers (issue #809): a reader descheduled mid-fill shows
+/// `in_flight` *below* the limit, so the wait correctly keeps going instead of
+/// declaring a partial read-ahead settled. That is what lets the read-ahead test
+/// take a single measurement per arm rather than a max over repeated samples.
+///
+/// The gate must *hold* across a short confirmation, because `queue_bytes_in_flight`
+/// can transiently read a counter high during a cross-queue handoff; a real gate
+/// under a stalled writer persists, a transient does not. Reaching EOF (the whole
+/// input consumed) also settles — that is the "gate did nothing" outcome the
+/// read-ahead test asserts against.
+///
+/// Only the byte-gate park (`in_flight >= limit`) or EOF settle this; a reader
+/// parked for any *other* reason (e.g. a Q1 slot-count bound reached with
+/// `in_flight < limit`) is deliberately not treated as settled, because these
+/// tests size the slot counts to swallow the whole input so the byte budget is
+/// the only bound that can engage (see [`spawn_stalled_pipeline`]). If a future
+/// change ever let a slot bound bind first, this returns `settled: false` at the
+/// `timeout` and the caller fails loudly with "reader never stopped" rather than
+/// silently measuring a slot-bounded stop — a truthful failure, not a wrong
+/// number.
+fn wait_until_gated(
     consumed: &AtomicU64,
+    in_flight: &AtomicU64,
+    limit: u64,
     input_len: u64,
     timeout: Duration,
 ) -> Consumption {
-    /// Consecutive unchanged samples required before calling it settled.
-    const STABLE_SAMPLES: u32 = 4;
+    /// Poll cadence. The Read step republishes `in_flight` on every admission
+    /// check (sub-millisecond while it is spinning on the gate), so a short poll
+    /// sees the transition promptly without busy-spinning.
+    const POLL: Duration = Duration::from_millis(2);
+    /// Once `in_flight` reaches the limit, require the reader to hold there — at
+    /// or above the limit, with `consumed` unmoving — for this long before
+    /// calling it parked. Under a stalled writer a real byte gate is a permanent
+    /// terminal state (nothing drains, so in-flight is constant and the reader
+    /// never reads again), so this passes on the first try and costs it only
+    /// once per arm. Its job is the *broken-gate* case: without a real gate the
+    /// reader keeps reading, and `in_flight` sails through the limit while
+    /// `consumed` is still climbing — a window long enough to outlast any
+    /// filling lull rejects that as not-yet-parked, so the reader is only sampled
+    /// where it truly stops (the budget-independent slot bound or EOF), which is
+    /// what lets the two arms' read-ahead gap collapse and fail the assertion.
+    const PARK_CONFIRM: Duration = Duration::from_millis(100);
 
     let deadline = Instant::now() + timeout;
-    let mut previous = u64::MAX;
-    let mut stable = 0u32;
-    while Instant::now() < deadline {
-        std::thread::sleep(Duration::from_millis(250));
-        let current = consumed.load(Ordering::Relaxed);
-        if current >= input_len {
-            return Consumption { bytes: current, settled: true };
+    loop {
+        let c = consumed.load(Ordering::Relaxed);
+        if c >= input_len {
+            // Reached EOF: the reader was never gated (e.g. a broken budget).
+            return Consumption { bytes: c, settled: true };
         }
-        if current == previous {
-            stable += 1;
-            if stable >= STABLE_SAMPLES {
-                return Consumption { bytes: current, settled: true };
+        // Bound *every* path by the deadline, not only the `in_flight < limit`
+        // one: a leaky gate that keeps trickling reads through while in-flight
+        // hovers at/above the limit would otherwise loop past `timeout` (only
+        // terminating at EOF). Checking here keeps the `timeout` contract honest
+        // regardless of which branch below runs.
+        if Instant::now() >= deadline {
+            return Consumption { bytes: c, settled: false };
+        }
+        if in_flight.load(Ordering::Relaxed) >= limit {
+            // Candidate gate — confirm the reader has actually parked here (in
+            // flight stays at/above the limit AND consumed does not advance),
+            // rejecting a transient counter-high mid-handoff or a brief lull
+            // while the reader is still filling toward its true stopping point.
+            std::thread::sleep(PARK_CONFIRM);
+            if in_flight.load(Ordering::Relaxed) >= limit && consumed.load(Ordering::Relaxed) == c {
+                return Consumption { bytes: c, settled: true };
             }
-        } else {
-            stable = 0;
+            continue;
         }
-        previous = current;
+        std::thread::sleep(POLL);
     }
-    Consumption { bytes: consumed.load(Ordering::Relaxed), settled: false }
 }
 
 /// Join a stalled pipeline within a deadline, returning the count of records it
@@ -404,10 +470,16 @@ fn stalled_writer_stops_the_reader_within_the_queue_memory_budget() {
     // `shared_bam_bytes`, so a `FAMILIES` shrink fails there before reaching here
     // (#789).
 
-    let StalledRun { consumed, released, handle, .. } =
+    let StalledRun { consumed, in_flight, released, handle, .. } =
         spawn_stalled_pipeline(header, bam_bytes.clone(), 4, TEST_BUDGET_BYTES, None);
 
-    let settled = wait_for_consumption_to_settle(&consumed, input_len, Duration::from_secs(30));
+    let settled = wait_until_gated(
+        &consumed,
+        &in_flight,
+        TEST_BUDGET_BYTES,
+        input_len,
+        Duration::from_secs(30),
+    );
     assert!(settled.settled, "reader never stopped under a stalled writer within the timeout");
     // Budget-relative, not a bare fraction of the input: the reader must leave at
     // least one whole queue memory budget's worth of input unread. A naive
@@ -458,19 +530,6 @@ fn read_ahead_under_a_stalled_writer_shrinks_with_the_queue_memory_budget() {
     /// Read batch small enough that read-ahead tracks the byte budget instead of
     /// the ~1 MiB production batch quantum.
     const FINE_READ_BLOCKS: usize = 4;
-    /// Reps per arm whose maximum read-ahead is taken as that arm's measurement.
-    ///
-    /// The budget-bounded stopping point is an *upper* bound the reader
-    /// approaches from below, and the only scheduler noise on it is one-sided and
-    /// downward: if the reader is starved of CPU for a full second mid-read,
-    /// [`wait_for_consumption_to_settle`] can call the arm settled at a partial
-    /// read-ahead — well short of where the budget would actually stop it. That
-    /// rare downward tail (observed on the generous arm) is what made a single
-    /// sample flap (issue #809). It never lifts an arm *above* its true ceiling,
-    /// so the maximum across a few reps recovers that ceiling and is immune to
-    /// the tail; three reps drive the odds of every rep tailing at once low
-    /// enough to be irrelevant while keeping the test cheap.
-    const READ_AHEAD_REPS: usize = 3;
 
     let (header, bam_bytes) = shared_bam_bytes();
     let input_len = bam_bytes.len() as u64;
@@ -483,12 +542,16 @@ fn read_ahead_under_a_stalled_writer_shrinks_with_the_queue_memory_budget() {
     let budget_difference = generous_budget - tight_budget;
 
     // Measure one arm's read-ahead: how far the reader runs before a stalled
-    // writer backs it up under `budget`. Returned as the settled input-bytes
-    // consumed, after asserting the arm actually settled short of EOF.
+    // writer backs it up under `budget`. A single measurement per arm suffices —
+    // `wait_until_gated` observes the reader parking at `in_flight >= budget`
+    // directly, so there is no scheduler-noise downward tail to average out with
+    // repeated samples (the max-over-reps this test carried for issue #809 was a
+    // workaround for a wall-clock quiescence heuristic that this signal replaces).
     let measure_read_ahead = |budget: u64| -> u64 {
-        let StalledRun { consumed, released, handle, .. } =
+        let StalledRun { consumed, in_flight, released, handle, .. } =
             spawn_stalled_pipeline(header, bam_bytes.clone(), 4, budget, Some(FINE_READ_BLOCKS));
-        let settled = wait_for_consumption_to_settle(&consumed, input_len, Duration::from_secs(30));
+        let settled =
+            wait_until_gated(&consumed, &in_flight, budget, input_len, Duration::from_secs(30));
         assert!(
             settled.settled,
             "reader never stopped under a {budget}-byte budget within the timeout"
@@ -503,14 +566,8 @@ fn read_ahead_under_a_stalled_writer_shrinks_with_the_queue_memory_budget() {
         settled.bytes
     };
 
-    // Take each arm's *maximum* read-ahead over a few reps, not a single sample:
-    // the measurement noise is a one-sided downward tail (see `READ_AHEAD_REPS`),
-    // so the max is the robust estimator of the arm's true budget-bounded ceiling.
-    let arm_read_ahead = |budget: u64| -> u64 {
-        (0..READ_AHEAD_REPS).map(|_| measure_read_ahead(budget)).max().expect("at least one rep")
-    };
-    let tight = arm_read_ahead(tight_budget);
-    let generous = arm_read_ahead(generous_budget);
+    let tight = measure_read_ahead(tight_budget);
+    let generous = measure_read_ahead(generous_budget);
 
     // A margin tied to the budget difference, not bare ordering: `tight < generous`
     // alone could be one stray block, and if a bound ignored the budget entirely
@@ -680,19 +737,25 @@ fn reader_resumes_and_completes_after_the_writer_recovers() {
     let expected_records = record_bufs(bam_bytes);
     assert_eq!(expected_records.len(), FAMILIES * DEPTH, "input should hold every generated read");
 
-    let StalledRun { consumed, released, sink, handle } =
+    let StalledRun { consumed, in_flight, released, sink, handle } =
         spawn_stalled_pipeline(header, bam_bytes.clone(), 4, TEST_BUDGET_BYTES, None);
 
-    let settled =
-        wait_for_consumption_to_settle(&consumed, bam_bytes.len() as u64, Duration::from_secs(30));
+    let input_len = bam_bytes.len() as u64;
+    let settled = wait_until_gated(
+        &consumed,
+        &in_flight,
+        TEST_BUDGET_BYTES,
+        input_len,
+        Duration::from_secs(30),
+    );
     assert!(settled.settled, "reader never stopped under a stalled writer within the timeout");
     released.store(true, Ordering::Release);
 
-    let written = join_pipeline_within(handle, &consumed, bam_bytes.len() as u64, JOIN_DEADLINE);
+    let written = join_pipeline_within(handle, &consumed, input_len, JOIN_DEADLINE);
     assert_eq!(written, expected_records.len() as u64, "every input record must reach the writer");
     assert_eq!(
         consumed.load(Ordering::Relaxed),
-        bam_bytes.len() as u64,
+        input_len,
         "the whole input must be consumed once the writer recovers"
     );
 

--- a/tests/integration/test_simulate_sort.rs
+++ b/tests/integration/test_simulate_sort.rs
@@ -120,7 +120,11 @@ fn simulate(
 #[case::mapped_reads("mapped-reads", 1_000, false)]
 #[case::grouped_reads_simplex("grouped-reads", 1_000, false)]
 #[case::grouped_reads_duplex("grouped-reads", 1_000, true)]
-#[case::grouped_reads_duplex_large("grouped-reads", 10_000, true)]
+// The "large" case exists only to drive a deeper spill/merge than the 1k cases:
+// at the 1M arm this still produces many spill files and a real k-way merge, but
+// 4k molecules reaches that regime far more cheaply than 10k (the sort-order
+// check does not get stronger with raw scale once several spill runs exist).
+#[case::grouped_reads_duplex_large("grouped-reads", 4_000, true)]
 fn simulate_output_is_template_coordinate_sorted(
     #[case] subcommand: &str,
     #[case] num_molecules: usize,
@@ -156,8 +160,11 @@ fn read_records(path: &Path) -> Vec<noodles::sam::alignment::RecordBuf> {
 /// generation order regardless of budget, so tie-breaking between equal sort
 /// keys cannot drift with the spill boundaries.
 #[rstest]
-#[case::mapped_reads("mapped-reads", 2_000, false)]
-#[case::grouped_reads_duplex("grouped-reads", 2_000, true)]
+// 1.5k molecules still forces the 1M arm to spill to disk and k-way merge while
+// the 768M arm stays fully in memory, so the two paths' outputs are compared
+// across the spill boundary — the property this test pins — for less work.
+#[case::mapped_reads("mapped-reads", 1_500, false)]
+#[case::grouped_reads_duplex("grouped-reads", 1_500, true)]
 fn simulate_output_is_identical_regardless_of_spilling(
     #[case] subcommand: &str,
     #[case] num_molecules: usize,


### PR DESCRIPTION
## What

Speeds up the slowest tests in the suite without weakening the invariants they protect (per the slow-test audit). Four independent clusters, one commit each; the whole `test_pipeline_memory_backpressure` module drops from ~78s to ~16s wall, the consensus error-bound cases from ~5s to ~0.3s each, and the sort soak block from ~143 CPU-s to seconds under coverage — with every guarantee intact.

## Cluster by cluster

**1. Backpressure read-ahead — observe the real gate instead of polling timing.** The read-ahead test measured where the reader parks by polling for wall-clock quiescence, a heuristic that false-settles when the reader is descheduled mid-fill — which is why #809 had to average each arm over `READ_AHEAD_REPS=3` samples, and why the flagship was the slowest test in the suite (~100s under coverage). This exposes the pipeline's actual gate condition: `PipelineConfig` gains an optional `queue_bytes_probe: Option<Arc<AtomicU64>>` (`None` in every production path — a single predictable branch, no behaviour change) that `read_admission_allowed` publishes the in-flight-bytes total into, and the test waits on `in_flight >= queue_memory_limit` directly. A descheduled reader shows in-flight *below* the limit, so the wait keeps going rather than declaring a partial read-ahead settled — immune to the #809 tail by construction, so each arm takes a single measurement (no reps). The shared fixture also shrinks 175k→143k families (still ~3.3 budgets, above the #789 drift-headroom floor that `shared_bam_bytes` asserts), and the now-obsolete per-test nextest slow-timeout override is dropped.

**2. Consensus ln-posterior error bound — stride the deep-depth sweep.** The test ran `add()` to depth 4000 for every one of ~94×94 `(post, obs)` pairs, though the worst case lives at depth 1 (on the always-run dense `1..=60` sweep). The deep spot-checks `[100..=4000]` now run only on a coarse stride of the grid; the gap's per-observation increment can't change sign with depth, so this re-confirms the deep regime broadly without repeating it thousands of times. Asserted bound and 5.0 ratio ceiling unchanged.

**3. Simulate-sort & group-determinism — shrink oversized fixtures.** Simulate's large case 10k→4k molecules and spill-parity cases 2k→1.5k (both still spill to disk and k-way merge). The determinism guard's mixed-orientation fixture 40→24 position groups, keeping `n_runs=6` and 256 UMIs — the unsorted-`AHashMap`-iteration bug is detected per position group across hash-seed-varying runs, so two dozen independent groups keep detection effectively certain. Assertions unchanged.

**4. Sort soak — collapse iterations under coverage only.** The soak tests (already `stress-tests`-gated, so coverage + nightly only) repeated their full iteration counts in the coverage job purely to line-cover ~200 lines. The count is now gated on `cfg(coverage)` (which `cargo llvm-cov` sets, registered like the existing `loom` cfg): the coverage job runs a minimal pass, and the full race-hunting soak still runs on the nightly `ci-test-stress` job, which does not set the cfg. No quarantine — the nightly soak is untouched.

## Verification

- Full suite green: `cargo ci-test` → 9524 passed; `cargo ci-fmt` and `cargo ci-lint` (incl. `--features stress-tests` and a `--cfg coverage` build) clean.
- Backpressure: both gate-break scenarios (gate always-admits; in-flight forced to zero) still make the read-ahead and stalled-writer tests **fail**; stress-tested 10/10 pass under CPU oversubscription with zero gap-flakes.
- Consensus: the documented worst case (`base=G post=Q35 obs=Q56 depth=1`) still lands on the dense shallow sweep, so the ratio ceiling stays meaningful.
- Soak `cfg(coverage)` path exercised: the full 14-case soak set passes under `--cfg coverage` in ~1s; the nightly (non-coverage) build still runs the full iteration counts.

## Notes / follow-ups

- `test_fastq_pipeline_memory_backpressure` is a sibling that still uses the wall-clock-quiescence helper. Giving `FastqPipelineConfig` the same probe and sharing one gate-observing helper is a natural follow-up (not done here to keep this change focused; the FASTQ test is unchanged from `main`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: command output changes: none; `unsafe` changes: none, and `CLAUDE.md` allowlist updates: none; memory bounds, queue capacity, and thread/backpressure policy changes: none.

- Speeds slow tests without changing assertions or protected invariants.
- Uses `queue_bytes_probe` for direct backpressure-gate detection instead of wall-clock polling.
- Strides deep consensus checks while retaining dense shallow coverage.
- Reduces sort, determinism, and simulation-sort fixtures while preserving spill, merge, and hash-order coverage.
- Reduces sort soak iterations only under coverage instrumentation. Nightly stress runs retain full iterations.
- Extends the stalled-writer test timeout to four 60-second periods.
- Verification reports 9,524 passing tests, clean formatting and lint checks, successful coverage builds, and stable backpressure stress tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->