### PR TITLE
perf(pipeline): don't fuse single-thread chains that declare Detached steps

### DIFF
--- a/crates/fgumi-pipeline-core/src/builder.rs
+++ b/crates/fgumi-pipeline-core/src/builder.rs
@@ -3215,12 +3215,17 @@ mod tests {
         assert_received_every_ordinal_once(&sink, 0);
     }
 
-    /// L2.3 step 7: at `--threads 1` the fusible linear chain runs the Detached
-    /// step **inline** in the fused single-thread driver — no dedicated thread
-    /// is spawned (the fused path returns before `extract_detached_steps`), yet
-    /// the Detached step still drives to completion.
+    /// L2.3 step 7: a chain declaring a Detached step drives to completion at
+    /// `--threads 1` with every ordinal delivered exactly once. End-to-end this
+    /// asserts *correctness*, not which path ran: the fused and scheduled paths
+    /// produce identical output, so a run cannot distinguish them (that is the
+    /// whole reason detachment is safe to decline-fuse). The *policy* — that such
+    /// a chain does NOT fuse and takes the scheduled path — is pinned directly by
+    /// `runtime::fused::tests::should_not_fuse_a_chain_containing_a_detached_step`,
+    /// and the fused driver's *ability* to drive a Detached step inline by
+    /// `runtime::fused::tests::run_fused_drives_a_detached_step_inline`.
     #[test]
-    fn detached_collapses_inline_at_t1() {
+    fn detached_chain_at_t1_completes_with_every_ordinal_once() {
         let remaining = Arc::new(AtomicU32::new(30));
         let received = Arc::new(AtomicU32::new(0));
         let sink = ParallelCountingSink::new(&received);
@@ -3237,6 +3242,35 @@ mod tests {
         assert!(result.is_ok(), "run failed: {:?}", result.err());
         assert_eq!(received.load(AtomicOrd::Relaxed), 30);
         assert_received_every_ordinal_once(&sink, 30);
+    }
+
+    /// Executable form of the documented caveat on
+    /// `runtime::fused::should_fuse_single_thread`: a chain that declares a
+    /// Detached step AND two or more Exclusive steps no longer fuses at
+    /// `--threads 1`, so it reaches the scheduled path's `assign_exclusive_owners`
+    /// and fails with `NotEnoughThreads` (2 Exclusive > 1 thread) where the fused
+    /// path previously ran it inline. `StubSource` and `StubSinkU32` are both
+    /// `StepKind::Exclusive`; `DetachedPassThrough` is `StepKind::Detached`. No
+    /// production chain has this shape (sort chains have zero Exclusive steps);
+    /// this pins the caveat so it stays true.
+    #[test]
+    fn detached_chain_with_two_exclusive_steps_fails_not_enough_threads_at_t1() {
+        let builder = PipelineBuilder::new();
+        builder
+            .chain(StubSource)
+            .chain(DetachedPassThrough { held: None })
+            .chain(StubSinkU32)
+            .into_sink_marker();
+        let pipeline = builder.build().unwrap();
+
+        let result = pipeline.run(PipelineConfig { threads: 1, ..Default::default() });
+        assert!(
+            matches!(
+                result,
+                Err(crate::signal::PipelineError::NotEnoughThreads { required: 2, available: 1 })
+            ),
+            "expected NotEnoughThreads {{ required: 2, available: 1 }}, got {result:?}"
+        );
     }
 
     /// Sink whose worker loop panics the moment it pops an item — used to drive

--- a/crates/fgumi-pipeline-core/src/runtime/fused.rs
+++ b/crates/fgumi-pipeline-core/src/runtime/fused.rs
@@ -93,9 +93,43 @@ pub fn is_fusible_chain(steps: &[Box<dyn ErasedStep>], graph: &ChainGraph) -> bo
 /// and the `snapshot_with_edges` bottleneck verdict). An instrumented run
 /// (`InstrumentationLevel != Off`) must therefore NOT fuse, or its
 /// `--pipeline-stats` / `--pipeline-trace` output would silently omit all edge /
-/// occupancy data. When instrumentation is `Off` (the default), fusion is taken
-/// whenever the chain is single-thread and fusible (zero-overhead fast path
-/// preserved).
+/// occupancy data.
+///
+/// **Capability vs. policy.** [`is_fusible_chain`] answers whether the fused
+/// driver *can* drive a chain inline; this function decides whether it *should*.
+/// A chain that declares a [`StepKind::Detached`](crate::step::StepKind::Detached)
+/// step is fusible (the fused driver runs it inline correctly — pinned by
+/// `run_fused_drives_a_detached_step_inline`), but detachment exists to run that
+/// step on its own OS thread so its serial coordination / I/O overlaps the pool's
+/// (de)compression (the sort chain's "N+2" model). Fusing collapses that overlap
+/// onto the single driver thread — measured as a ~8-11% single-thread wall
+/// regression on `fgumi sort` (`mean_load` 96% fused vs ~111% scheduled). So a
+/// chain with any Detached step declines fusion and takes the scheduled path even
+/// single-threaded. That is not new territory: an instrumented single-thread run
+/// already takes exactly that path (1 pool worker + the detached driver threads),
+/// because `!instrumentation.is_on()` already declines fusion — this makes the
+/// default single-thread run match the instrumented one.
+///
+/// When instrumentation is `Off` (the default) and no Detached step is present,
+/// fusion is taken whenever the chain is single-thread and fusible (zero-overhead
+/// fast path preserved).
+///
+/// This keys off [`StepKind::Detached`](crate::step::StepKind::Detached) alone,
+/// so it applies to **any** chain that declares a Detached step, not only the
+/// sort chain: declaring a step Detached *is* the author's request for off-pool
+/// execution, so declining to fuse it away is the correct default. A future
+/// single-thread chain that declared Detached purely for isolation rather than
+/// overlap would pay the scheduled-path thread-spawn cost under this policy; that
+/// is an accepted trade — a per-chain fusion opt-in would be unwarranted
+/// complexity while every Detached chain in the tree wants the scheduled
+/// semantics.
+///
+/// Caveat: a (hypothetical) chain declaring a Detached step *and* two or more
+/// [`Exclusive`](crate::step::StepKind::Exclusive) steps would now reach
+/// `assign_exclusive_owners` at `--threads 1` and fail with
+/// `NotEnoughThreads` where fusion previously ran it. No production chain does
+/// this (the sort chain has zero Exclusive steps), and the scheduled semantics
+/// are the correct ones for such a chain regardless.
 #[must_use]
 pub fn should_fuse_single_thread(
     n_threads: usize,
@@ -103,7 +137,19 @@ pub fn should_fuse_single_thread(
     steps: &[Box<dyn ErasedStep>],
     graph: &ChainGraph,
 ) -> bool {
-    n_threads == 1 && !instrumentation.is_on() && is_fusible_chain(steps, graph)
+    n_threads == 1
+        && !instrumentation.is_on()
+        && !has_detached_step(steps)
+        && is_fusible_chain(steps, graph)
+}
+
+/// Whether any step in the chain declares
+/// [`StepKind::Detached`](crate::step::StepKind::Detached). Such a step was built
+/// to run on a dedicated off-pool thread; see
+/// [`should_fuse_single_thread`] for why its presence declines fusion.
+#[must_use]
+fn has_detached_step(steps: &[Box<dyn ErasedStep>]) -> bool {
+    steps.iter().any(|s| s.kind() == crate::step::StepKind::Detached)
 }
 
 /// Drive a fusible chain to completion on the calling thread, fused.
@@ -491,6 +537,58 @@ mod tests {
         (steps, graph)
     }
 
+    /// Mid step declaring `StepKind::Detached` — the shape a chain author uses
+    /// to ask for a dedicated off-pool OS thread (the sort chain's "N+2"
+    /// coordination/I/O steps do this). Behaviourally an identity relay; only
+    /// its `kind` distinguishes it from `AddHundred`.
+    #[derive(Clone)]
+    struct DetachedRelay;
+    impl Step for DetachedRelay {
+        type Input = u32;
+        type Outputs = Single<u32>;
+        fn profile(&self) -> StepProfile {
+            StepProfile {
+                name: "DetachedRelay",
+                kind: StepKind::Detached,
+                sticky: false,
+                output_queues: vec![QueueSpec::Unbounded],
+                branch_ordering: vec![BranchOrdering::None],
+            }
+        }
+        fn try_run(&mut self, ctx: &mut StepCtx<'_, Self>) -> io::Result<StepOutcome> {
+            match ctx.input.pop() {
+                Some(v) => {
+                    let _ = ctx.outputs.push(v);
+                    Ok(StepOutcome::Progress)
+                }
+                None if ctx.input.is_drained() => Ok(StepOutcome::Finished),
+                None => Ok(StepOutcome::NoProgress),
+            }
+        }
+    }
+
+    /// Build a linear `source → detached relay → sink` chain — structurally
+    /// fusible, but declaring a Detached step, so the *policy* declines to fuse
+    /// it (the overlap that detachment buys must not be collapsed onto one
+    /// thread).
+    fn detached_chain(
+        count: u32,
+        out: &Arc<Mutex<Vec<u32>>>,
+    ) -> (Vec<Box<dyn ErasedStep>>, ChainGraph) {
+        let mut graph = ChainGraph::new();
+        let s = graph.register_step("CountSource", 1);
+        let m = graph.register_step("DetachedRelay", 1);
+        let k = graph.register_step("CollectSink", 0);
+        graph.wire(s, BranchIdx(0), m);
+        graph.wire(m, BranchIdx(0), k);
+        let steps: Vec<Box<dyn ErasedStep>> = vec![
+            Box::new(TypedStep::new(CountSource { next: 0, count })),
+            Box::new(TypedStep::new(DetachedRelay)),
+            Box::new(TypedStep::new(CollectSink { out: Arc::clone(out) })),
+        ];
+        (steps, graph)
+    }
+
     #[test]
     fn is_fusible_detects_source_mid_sink() {
         let out = Arc::new(Mutex::new(Vec::new()));
@@ -625,6 +723,43 @@ mod tests {
         let (steps, graph) = linear_chain(4, &out);
         assert!(is_fusible_chain(&steps, &graph), "linear chain is fusible");
         assert_eq!(should_fuse_single_thread(n_threads, level, &steps, &graph), expected);
+    }
+
+    // A chain that declares a `Detached` step is *structurally* fusible, but the
+    // policy declines to fuse it: fusing collapses the dedicated off-pool thread
+    // the author asked for onto the single driver thread, discarding the
+    // read/(de)compress/write overlap detachment exists to provide (measured
+    // ~8-11% single-thread wall regression on `fgumi sort`). This is the only
+    // test that can distinguish the two paths — an end-to-end run cannot, because
+    // both the fused and scheduled paths produce identical correct output.
+    #[test]
+    fn should_not_fuse_a_chain_containing_a_detached_step() {
+        let out = Arc::new(Mutex::new(Vec::new()));
+        let (steps, graph) = detached_chain(4, &out);
+        // Still structurally fusible — the capability claim stays true (and is
+        // pinned by `run_fused_drives_a_detached_step_inline`).
+        assert!(is_fusible_chain(&steps, &graph), "a detached chain is still structurally fusible");
+        // ...but the policy declines, even single-thread and uninstrumented.
+        assert!(
+            !should_fuse_single_thread(1, InstrumentationLevel::Off, &steps, &graph),
+            "a chain with a Detached step must not fuse (overlap must be preserved)"
+        );
+    }
+
+    // Capability pin: `is_fusible_chain` staying `true` for a detached chain is
+    // only honest if the fused driver can in fact drive a Detached step inline to
+    // a correct result. This exercises that directly (bypassing the policy), so
+    // the "still structurally fusible" claim above is tested, not merely asserted
+    // in a doc comment. Mirrors the correctness that the former
+    // `detached_collapses_inline_at_t1` end-to-end test used to prove.
+    #[test]
+    fn run_fused_drives_a_detached_step_inline() {
+        let out = Arc::new(Mutex::new(Vec::new()));
+        let (steps, graph) = detached_chain(5, &out);
+        let signal = PipelineSignal::new();
+        run_fused_single_thread(steps, &graph, &signal, None, None, 0).expect("clean run");
+        // DetachedRelay is an identity relay, so the sink sees the source's 0..5.
+        assert_eq!(*out.lock().unwrap(), vec![0, 1, 2, 3, 4]);
     }
 
     #[test]

--- a/crates/fgumi-pipeline-io/src/sort/tests.rs
+++ b/crates/fgumi-pipeline-io/src/sort/tests.rs
@@ -535,13 +535,25 @@ fn sort_buffer_chain_fails_the_pipeline_on_a_dropped_lane_violation() {
         .memory_limit(256 * 1024 * 1024)
         .threads(1)
         .key_types(KeyTypesSpec::None);
+    // Serial sink (production's actual `WriteBgzfFile` kind), not the parity
+    // matrix's `Exclusive`: a sort chain declares a Detached step (the merge), so
+    // at `--threads 1` it no longer fuses (see
+    // `should_fuse_single_thread`/`has_detached_step`) and runs on the scheduled
+    // path. `VecSource` above is itself `StepKind::Exclusive`, so an `Exclusive`
+    // sink here would make TWO exclusive steps, and `assign_exclusive_owners`
+    // fails when `total_exclusive (2) > n_threads (1)` — before the ingest
+    // failure this test targets is even reached. A `Serial` sink leaves exactly
+    // one exclusive step (the source), which fits one thread, and also matches
+    // production's `WriteBgzfFile` kind — keeping the dropped-lane propagation
+    // assertion meaningful at one thread. (A *lone* Exclusive step is fine at
+    // `--threads 1`; only two or more exceed the budget — see `fused.rs`.)
     let err = drive_sort_buffer_pipeline(
         sorter,
         &Header::default(),
         pack_batches(&records, 256),
         4 * 1024 * 1024,
         1,
-        StepKind::Exclusive,
+        StepKind::Serial,
         SortDecompressTuning::default(),
         SpillCodec::Zstd,
     )


### PR DESCRIPTION
The sort-command cutover regressed `fgumi sort --threads 1` by ~8-11% wall: at one thread a fusible chain fuses onto the calling thread, which collapses the arena sort's Detached+Parallel overlap (the "N+2" model — a dedicated off-pool thread for serial coordination/I/O overlapping the pool's (de)compression) onto a single core. `should_fuse_single_thread` now declines fusion for any chain that declares a `StepKind::Detached` step (a policy gate, distinct from the structural `is_fusible_chain` capability), so such a chain takes the scheduled path even single-threaded — restoring the overlap. Fusion capability is unchanged (the fused driver can still run a Detached step inline; that's pinned by a test).

Validated: t1 non-spill −2.6%, spill +0.5% vs the owned engine (was +10.9%/+8.2%); `mean_load` 96%→111%.

Documented caveat (no production chain hits it, pinned by a test): a chain with a Detached step plus ≥2 Exclusive steps now fails `NotEnoughThreads` at `--threads 1` instead of fusing.

Stacked on #883.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: command output changes: none; `unsafe` changes: none; memory bounds, queue capacities, and thread/backpressure policy: single-thread scheduling changes for chains with `StepKind::Detached`, including `NotEnoughThreads` for some chains.

Fix: route single-thread chains with detached steps through the scheduled path to preserve overlap with pool decompression work.

- Keep structural fusion support and direct fused execution unchanged.
- Update tests for detached-step completion and ordinal delivery.
- Add coverage for detached plus two exclusive steps returning `PipelineError::NotEnoughThreads`.
- Align the dropped-lane failure test with production by using a `Serial` sink.
- Reported performance improved by 2.6% without spills and 0.5% with spills versus the owned engine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->