### PR TITLE
perf(sort): extend runs in the arena spill path (t16 parity)

### DIFF
--- a/crates/fgumi-pipeline-io/src/sort/protocol.rs
+++ b/crates/fgumi-pipeline-io/src/sort/protocol.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use fgumi_sort::{
-    InMemoryChunk, RawCoordinateKey, RawQuerynameKey, RawQuerynameLexKey, SortMergeSlot,
+    InMemoryChunk, RawCoordinateKey, RawQuerynameKey, RawQuerynameLexKey, RunBound, SortMergeSlot,
     TemplateMemChunk,
 };
 
@@ -79,6 +79,44 @@ impl MemoryChunkErased {
             Self::QuerynameLex(v) => v.record_bytes(i),
             Self::QuerynameNatural(v) => v.record_bytes(i),
             Self::TemplateCoordinate(v) => v.record_bytes(i),
+        }
+    }
+
+    /// The chunk's minimum sort key (`key_at(0)`) as an owned [`RunBound`], or
+    /// `None` if the chunk is empty. Records are pre-sorted at seal, so this is
+    /// `O(1)`. Used by the arena spill run-former to decide whether this chunk
+    /// extends the open run.
+    #[must_use]
+    pub fn min_bound(&self) -> Option<RunBound> {
+        match self {
+            Self::Coordinate(v) => (!v.is_empty()).then(|| RunBound::Coordinate(*v.key_at(0))),
+            Self::QuerynameLex(v) => {
+                (!v.is_empty()).then(|| RunBound::QuerynameLex(v.key_at(0).clone()))
+            }
+            Self::QuerynameNatural(v) => {
+                (!v.is_empty()).then(|| RunBound::QuerynameNatural(v.key_at(0).clone()))
+            }
+            Self::TemplateCoordinate(v) => v.min_bound(),
+        }
+    }
+
+    /// The chunk's maximum sort key (`key_at(len - 1)`) as an owned [`RunBound`],
+    /// or `None` if the chunk is empty. Records are pre-sorted at seal, so this
+    /// is `O(1)`. Used by the arena spill run-former to advance the open run's
+    /// upper bound after appending this chunk.
+    #[must_use]
+    pub fn max_bound(&self) -> Option<RunBound> {
+        match self {
+            Self::Coordinate(v) => {
+                v.len().checked_sub(1).map(|i| RunBound::Coordinate(*v.key_at(i)))
+            }
+            Self::QuerynameLex(v) => {
+                v.len().checked_sub(1).map(|i| RunBound::QuerynameLex(v.key_at(i).clone()))
+            }
+            Self::QuerynameNatural(v) => {
+                v.len().checked_sub(1).map(|i| RunBound::QuerynameNatural(v.key_at(i).clone()))
+            }
+            Self::TemplateCoordinate(v) => v.max_bound(),
         }
     }
 
@@ -291,6 +329,51 @@ mod tests {
         InMemoryChunk::from_owned_records(
             payloads.into_iter().map(|b| (RawCoordinateKey::default(), b)).collect(),
         )
+    }
+
+    /// Build a coordinate chunk whose keys carry the given packed `sort_key`s,
+    /// in the supplied (already-sorted) order, with dummy record bodies.
+    fn coord_keyed(keys: Vec<u64>) -> InMemoryChunk<RawCoordinateKey> {
+        InMemoryChunk::from_owned_records(
+            keys.into_iter().map(|k| (RawCoordinateKey { sort_key: k }, vec![0u8; 4])).collect(),
+        )
+    }
+
+    #[test]
+    fn coordinate_chunk_bounds_are_first_and_last_keys() {
+        let chunk = MemoryChunkErased::Coordinate(coord_keyed(vec![100, 200, 300]));
+        assert_eq!(
+            chunk.min_bound(),
+            Some(RunBound::Coordinate(RawCoordinateKey { sort_key: 100 }))
+        );
+        assert_eq!(
+            chunk.max_bound(),
+            Some(RunBound::Coordinate(RawCoordinateKey { sort_key: 300 }))
+        );
+    }
+
+    #[test]
+    fn empty_chunk_has_no_bounds() {
+        let chunk = MemoryChunkErased::Coordinate(coord(Vec::new()));
+        assert_eq!(chunk.min_bound(), None);
+        assert_eq!(chunk.max_bound(), None);
+    }
+
+    #[test]
+    fn queryname_chunk_bounds_clone_the_owned_keys() {
+        let chunk = MemoryChunkErased::QuerynameLex(InMemoryChunk::from_owned_records(vec![
+            (RawQuerynameLexKey::new(b"aaa".to_vec(), 0), vec![0u8; 4]),
+            (RawQuerynameLexKey::new(b"zzz".to_vec(), 0), vec![0u8; 4]),
+        ]));
+        let min = chunk.min_bound().unwrap();
+        let max = chunk.max_bound().unwrap();
+        assert_eq!(min, RunBound::QuerynameLex(RawQuerynameLexKey::new(b"aaa".to_vec(), 0)));
+        assert_eq!(max, RunBound::QuerynameLex(RawQuerynameLexKey::new(b"zzz".to_vec(), 0)));
+        // A contiguous next chunk starting at "zzz" or later extends the run.
+        assert!(max.precedes_or_equal(&RunBound::QuerynameLex(RawQuerynameLexKey::new(
+            b"zzz".to_vec(),
+            0
+        ))));
     }
 
     #[test]

--- a/crates/fgumi-pipeline-io/src/sort/spill_gather.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_gather.rs
@@ -8,6 +8,30 @@
 //! `Parallel` `SpillBlockCompress` can compress them across the framework pool. The
 //! in-memory `Residual` and the terminal `AllAnnounced` pass straight through.
 //!
+//! # Run extension (spill coalescing)
+//!
+//! `SpillGather` is also the arena's **run-former**, the coalescing counterpart of
+//! the owned engine's `RunFormer`. It sees spill chunks in seal order on a single
+//! `Detached` thread, so it can compare each incoming chunk's minimum key against
+//! the currently-open run's maximum key ([`RunBound::precedes_or_equal`]): when the
+//! chunk is contiguous with the run, its blocks reuse the run's `file_id`, so a
+//! whole run of contiguous chunks becomes **one physical spill file** (one merge
+//! source) instead of one file per chunk. On an already-sorted input every chunk
+//! is contiguous, so the N-way merge collapses to a trivial 1-way pass — matching
+//! the owned engine's headline behaviour. The read side is unchanged: a slot is
+//! still one file; there are simply fewer, longer files.
+//!
+//! Whether a run's final block is the *last block of its file* is only known once
+//! the next chunk arrives (does it extend?) — so the run's final framed block is
+//! **withheld** (`held_last_block`) and closed lazily: emitted with
+//! `is_last_in_file = false` and the run's `file_id` if the next chunk extends, or
+//! `true` if it does not (or on `Residual` / `AllAnnounced` / drain, which always
+//! close the open run). The withheld block's ordinal is minted **at emission**, so
+//! the ordinal stream stays dense for `ByItemOrdinal` (a minted-then-dropped
+//! ordinal would wedge the single-cursor reorder). `AllAnnounced.slot_count` is
+//! rewritten to the **run** count (`runs_written`), since that is how many
+//! `SpillReady`s the merge will see and gate on.
+//!
 //! # Ordinal minting
 //!
 //! The step mints `ordinal` monotonically across **every** emitted item — every
@@ -35,7 +59,7 @@ use std::collections::VecDeque;
 use std::io;
 
 use fgumi_bgzf::BGZF_MAX_BLOCK_SIZE;
-use fgumi_sort::frame_keyed_record_into;
+use fgumi_sort::{RunBound, frame_keyed_record_into};
 
 use crate::sort::protocol::{MemoryChunkErased, SortChunkEvent, SpillBlockEvent};
 use fgumi_pipeline_core::{
@@ -132,7 +156,18 @@ struct ActiveSpill {
     chunk: MemoryChunkErased,
     /// Index of the next un-framed record.
     next_idx: usize,
-    /// Logical spill index (the eventual slot `file_id`).
+    /// This chunk's run `file_id` — the open run's when the chunk extends it, or
+    /// the chunk's own spill `seq` when it starts a new run.
+    file_id: u32,
+    records_ingested_so_far: u64,
+}
+
+/// A run's most-recently-framed block, withheld until we know whether it is the
+/// last block *of its file*. Carries everything a [`SpillBlockEvent::Block`]
+/// needs except `is_last_in_file` (decided at flush) and `ordinal` (minted at
+/// flush, to keep the emitted stream dense).
+struct HeldBlock {
+    bytes: Vec<u8>,
     file_id: u32,
     records_ingested_so_far: u64,
 }
@@ -150,6 +185,18 @@ pub struct SpillGather {
     /// Monotonic ordinal minted across every emitted item (dense, gap-free).
     next_ordinal: u64,
     held: HeldSlot<Unpushed<SpillBlockEvent>>,
+    /// The currently-open run: its `file_id` and its maximum key so far. An
+    /// incoming chunk whose minimum key is `>=` this maximum *extends* the run
+    /// (reuses `file_id`); otherwise it starts a new run. `None` before the first
+    /// spill and after a `Residual` / `AllAnnounced` closes the run.
+    open_run: Option<(u32, RunBound)>,
+    /// The open run's final framed block, withheld pending the extend/close
+    /// decision of the next event (lazy run-close). At most one 64 KiB block.
+    held_last_block: Option<HeldBlock>,
+    /// Number of distinct runs (spill files) formed. Rewritten into
+    /// `AllAnnounced.slot_count`, since that is how many `SpillReady`s the merge
+    /// will receive and gate on.
+    runs_written: u32,
     /// Raw-block size threshold (records are cut into blocks of ≤ this many bytes).
     block_size: usize,
     output_byte_limit: u64,
@@ -165,6 +212,9 @@ impl SpillGather {
             pending: VecDeque::new(),
             next_ordinal: 0,
             held: HeldSlot::new(),
+            open_run: None,
+            held_last_block: None,
+            runs_written: 0,
             block_size: BGZF_MAX_BLOCK_SIZE,
             output_byte_limit,
         }
@@ -177,23 +227,62 @@ impl SpillGather {
         o
     }
 
-    /// `StepCtx`-free core: stage one input event. A `Spill` chunk is parked in
-    /// `active` for incremental framing (no blocks produced yet); `Residual` /
-    /// `AllAnnounced` are cheap and pushed straight to `pending`. Caller
+    /// Flush the withheld run-final block (if any) into `pending`, marking it
+    /// `is_last_in_file = is_last` and minting its ordinal now (at emission, so
+    /// the stream stays dense). No-op when nothing is held.
+    fn flush_held_block(&mut self, is_last: bool) {
+        let Some(hb) = self.held_last_block.take() else { return };
+        let ordinal = self.next_ordinal();
+        self.pending.push_back(SpillBlockEvent::Block {
+            ordinal,
+            file_id: hb.file_id,
+            is_last_in_file: is_last,
+            records_ingested_so_far: hb.records_ingested_so_far,
+            bytes: hb.bytes,
+        });
+    }
+
+    /// `StepCtx`-free core: stage one input event. A `Spill` chunk runs the
+    /// run-former (extend-or-close-and-open) and is parked in `active` for
+    /// incremental framing (no blocks produced yet). `Residual` / `AllAnnounced`
+    /// close the open run (flushing its withheld final block) and pass straight
+    /// through; `AllAnnounced.slot_count` is rewritten to the run count. Caller
     /// guarantees `active` is `None` (the previous chunk fully framed).
     fn stage_event(&mut self, event: SortChunkEvent) {
         match event {
             SortChunkEvent::Spill { seq, chunk, records_ingested_so_far } => {
                 // `SortBuffer` only emits `Spill` for a non-empty buffer; skip an
                 // (unexpected) empty chunk rather than open a zero-block file with
-                // no `is_last_in_file` terminator.
+                // no `is_last_in_file` terminator. An empty chunk is a pure no-op:
+                // it contributes no bounds and does NOT close the open run.
                 if chunk.is_empty() {
                     return;
                 }
+                let chunk_min = chunk.min_bound().expect("a non-empty chunk has a min bound");
+                let chunk_max = chunk.max_bound().expect("a non-empty chunk has a max bound");
+                // Extends the open run iff every record already in the run precedes
+                // or equals this chunk's first record.
+                let extends = match &self.open_run {
+                    Some((_, open_max)) => open_max.precedes_or_equal(&chunk_min),
+                    None => false,
+                };
+                // Close-or-continue the previous run's withheld final block: it is
+                // the last block of its file iff this chunk does NOT extend it.
+                self.flush_held_block(!extends);
+                let file_id = if extends {
+                    self.open_run.as_ref().expect("extends implies an open run").0
+                } else {
+                    self.runs_written += 1;
+                    seq
+                };
+                self.open_run = Some((file_id, chunk_max));
                 self.active =
-                    Some(ActiveSpill { chunk, next_idx: 0, file_id: seq, records_ingested_so_far });
+                    Some(ActiveSpill { chunk, next_idx: 0, file_id, records_ingested_so_far });
             }
             SortChunkEvent::Residual { chunk, records_ingested_so_far } => {
+                // A residual (in-memory, not spilled) ends any open spill run.
+                self.flush_held_block(true);
+                self.open_run = None;
                 let ordinal = self.next_ordinal();
                 self.pending.push_back(SpillBlockEvent::Residual {
                     ordinal,
@@ -201,11 +290,16 @@ impl SpillGather {
                     records_ingested_so_far,
                 });
             }
-            SortChunkEvent::AllAnnounced { slot_count, memory_chunk_count, total_records } => {
+            SortChunkEvent::AllAnnounced { memory_chunk_count, total_records, .. } => {
+                // Terminal: close the final run, then announce the RUN count as the
+                // slot count (the merge gates on `slots.len() == slot_count`, and
+                // with coalescing #SpillReady = #runs, not #chunks).
+                self.flush_held_block(true);
+                self.open_run = None;
                 let ordinal = self.next_ordinal();
                 self.pending.push_back(SpillBlockEvent::AllAnnounced {
                     ordinal,
-                    slot_count,
+                    slot_count: self.runs_written,
                     memory_chunk_count,
                     total_records,
                 });
@@ -213,10 +307,12 @@ impl SpillGather {
         }
     }
 
-    /// Frame up to `MAX_EVENTS_PER_LOCK` blocks of the `active` chunk into
-    /// `pending`, minting dense ordinals and flagging the final block
-    /// `is_last_in_file`. Frees the chunk (`active = None`) once its last record
-    /// is framed. No-op when there is no active chunk.
+    /// Frame up to `MAX_EVENTS_PER_LOCK` non-final blocks of the `active` chunk
+    /// into `pending`, minting dense ordinals. The chunk's **final** framed block
+    /// is not pushed: it is withheld into `held_last_block` (its `is_last_in_file`
+    /// is not yet known — it depends on whether the next chunk extends this run),
+    /// and the chunk is freed (`active = None`). No-op when there is no active
+    /// chunk.
     ///
     /// # Errors
     ///
@@ -235,18 +331,27 @@ impl SpillGather {
                 (bytes, next, next >= len, active.file_id, active.records_ingested_so_far)
             };
             let (bytes, next_idx, is_last, file_id, records_ingested_so_far) = framed;
+            if is_last {
+                // Withhold the run's final block: it is closed lazily once we know
+                // whether the next chunk extends this run (see `stage_event` /
+                // `flush_held_block`). The previous run's block was already flushed
+                // before this chunk was staged, so nothing is being overwritten.
+                debug_assert!(
+                    self.held_last_block.is_none(),
+                    "a prior held block must be flushed before withholding a new one"
+                );
+                self.held_last_block = Some(HeldBlock { bytes, file_id, records_ingested_so_far });
+                self.active = None;
+                return Ok(());
+            }
             let ordinal = self.next_ordinal();
             self.pending.push_back(SpillBlockEvent::Block {
                 ordinal,
                 file_id,
-                is_last_in_file: is_last,
+                is_last_in_file: false,
                 records_ingested_so_far,
                 bytes,
             });
-            if is_last {
-                self.active = None;
-                return Ok(());
-            }
             // Advance the cursor for the next block.
             self.active.as_mut().expect("active present (not last)").next_idx = next_idx;
         }
@@ -327,6 +432,18 @@ impl Step for SpillGather {
 
         // Drained: pending is empty and no chunk is mid-framing (checked above).
         if ctx.input.is_drained() {
+            // `AllAnnounced` (always the terminal event) closes the open run and
+            // flushes its withheld final block. A block still held at drain means
+            // that close never happened — a lost run terminator would leave
+            // `SpillWrite` with a dangling open file. Fail loudly rather than
+            // silently drop a run.
+            if self.held_last_block.is_some() {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "SpillGather drained with an unclosed run (a withheld spill block was \
+                     never flushed by AllAnnounced)",
+                ));
+            }
             return Ok(StepOutcome::Finished);
         }
         Ok(StepOutcome::NoProgress)

--- a/crates/fgumi-pipeline-io/src/sort/spill_gather.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_gather.rs
@@ -53,7 +53,10 @@
 //! `MAX_EVENTS_PER_LOCK` blocks into `pending`, drains them, and only frees the
 //! source chunk once its last record is framed. `pending` therefore holds ≤ a
 //! handful of 64 KiB blocks (~½ MiB) regardless of chunk size, and the chunk
-//! drains as fast as `SpillBlockCompress` consumes blocks.
+//! drains as fast as `SpillBlockCompress` consumes blocks. Run extension adds
+//! one more retained block — `held_last_block`, the withheld run-final block —
+//! which is O(1) (a single ~64 KiB block across a chunk boundary), not a
+//! per-chunk or per-run accumulation.
 
 use std::collections::VecDeque;
 use std::io;
@@ -192,8 +195,13 @@ pub struct SpillGather {
     /// spill and after a `Residual` / `AllAnnounced` closes the run.
     open_run: Option<(u32, RunBound)>,
     /// The open run's final framed block, withheld pending the extend/close
-    /// decision of the next event (lazy run-close). At most one 64 KiB block.
-    held_last_block: Option<HeldBlock>,
+    /// decision of the next event (lazy run-close). At most one ~64 KiB block
+    /// retained across a chunk boundary (O(1), not a per-chunk/-run accumulation).
+    /// Uses [`HeldSlot`] rather than a bare `Option` so `put` is a hard `assert!`:
+    /// overwriting a withheld block would silently drop a whole spill block (many
+    /// records), so an invariant break must fail loudly in release too, not only
+    /// under `debug_assert!`.
+    held_last_block: HeldSlot<HeldBlock>,
     /// Number of distinct runs (spill files) formed. Rewritten into
     /// `AllAnnounced.slot_count`, since that is how many `SpillReady`s the merge
     /// will receive and gate on.
@@ -220,7 +228,7 @@ impl SpillGather {
             next_ordinal: 0,
             held: HeldSlot::new(),
             open_run: None,
-            held_last_block: None,
+            held_last_block: HeldSlot::new(),
             runs_written: 0,
             chunks_spilled: 0,
             summary_logged: false,
@@ -237,17 +245,16 @@ impl SpillGather {
     }
 
     /// The owned-engine-style run-formation summary line, or `None` when nothing
-    /// spilled. Mirrors `fgumi_sort::external`'s `log_run_formation` so both sort
-    /// engines report run formation identically: every spilled chunk either
-    /// starts a run or extends one, so `extended = chunks_spilled - runs_written`.
+    /// spilled. Formats through the shared [`fgumi_sort::format_run_formation`] so
+    /// both sort engines report run formation with byte-identical wording (the
+    /// owned engine's `log_run_formation` calls the same function).
     fn run_formation_summary(&self) -> Option<String> {
         if self.chunks_spilled == 0 {
             return None;
         }
-        let extended = self.chunks_spilled.saturating_sub(self.runs_written);
-        Some(format!(
-            "Spill runs: {} from {} chunks ({extended} extended an existing run)",
-            self.runs_written, self.chunks_spilled
+        Some(fgumi_sort::format_run_formation(
+            self.runs_written as usize,
+            self.chunks_spilled as usize,
         ))
     }
 
@@ -360,12 +367,10 @@ impl SpillGather {
                 // Withhold the run's final block: it is closed lazily once we know
                 // whether the next chunk extends this run (see `stage_event` /
                 // `flush_held_block`). The previous run's block was already flushed
-                // before this chunk was staged, so nothing is being overwritten.
-                debug_assert!(
-                    self.held_last_block.is_none(),
-                    "a prior held block must be flushed before withholding a new one"
-                );
-                self.held_last_block = Some(HeldBlock { bytes, file_id, records_ingested_so_far });
+                // before this chunk was staged, so nothing is being overwritten —
+                // `HeldSlot::put` hard-asserts that invariant (overwriting would
+                // silently drop a whole spill block, i.e. lose records).
+                self.held_last_block.put(HeldBlock { bytes, file_id, records_ingested_so_far });
                 self.active = None;
                 return Ok(());
             }
@@ -462,7 +467,7 @@ impl Step for SpillGather {
             // that close never happened — a lost run terminator would leave
             // `SpillWrite` with a dangling open file. Fail loudly rather than
             // silently drop a run.
-            if self.held_last_block.is_some() {
+            if self.held_last_block.is_held() {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "SpillGather drained with an unclosed run (a withheld spill block was \

--- a/crates/fgumi-pipeline-io/src/sort/spill_gather.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_gather.rs
@@ -60,6 +60,7 @@ use std::io;
 
 use fgumi_bgzf::BGZF_MAX_BLOCK_SIZE;
 use fgumi_sort::{RunBound, frame_keyed_record_into};
+use log::info;
 
 use crate::sort::protocol::{MemoryChunkErased, SortChunkEvent, SpillBlockEvent};
 use fgumi_pipeline_core::{
@@ -197,6 +198,12 @@ pub struct SpillGather {
     /// `AllAnnounced.slot_count`, since that is how many `SpillReady`s the merge
     /// will receive and gate on.
     runs_written: u32,
+    /// Number of non-empty spill chunks seen. With `runs_written`, gives the
+    /// owned-style run-formation report (`extended = chunks_spilled - runs`).
+    chunks_spilled: u32,
+    /// Whether the run-formation summary has been logged (guards the single-shot
+    /// log at the drained `Finished` transition).
+    summary_logged: bool,
     /// Raw-block size threshold (records are cut into blocks of ≤ this many bytes).
     block_size: usize,
     output_byte_limit: u64,
@@ -215,6 +222,8 @@ impl SpillGather {
             open_run: None,
             held_last_block: None,
             runs_written: 0,
+            chunks_spilled: 0,
+            summary_logged: false,
             block_size: BGZF_MAX_BLOCK_SIZE,
             output_byte_limit,
         }
@@ -225,6 +234,21 @@ impl SpillGather {
         let o = self.next_ordinal;
         self.next_ordinal += 1;
         o
+    }
+
+    /// The owned-engine-style run-formation summary line, or `None` when nothing
+    /// spilled. Mirrors `fgumi_sort::external`'s `log_run_formation` so both sort
+    /// engines report run formation identically: every spilled chunk either
+    /// starts a run or extends one, so `extended = chunks_spilled - runs_written`.
+    fn run_formation_summary(&self) -> Option<String> {
+        if self.chunks_spilled == 0 {
+            return None;
+        }
+        let extended = self.chunks_spilled.saturating_sub(self.runs_written);
+        Some(format!(
+            "Spill runs: {} from {} chunks ({extended} extended an existing run)",
+            self.runs_written, self.chunks_spilled
+        ))
     }
 
     /// Flush the withheld run-final block (if any) into `pending`, marking it
@@ -258,6 +282,7 @@ impl SpillGather {
                 if chunk.is_empty() {
                     return;
                 }
+                self.chunks_spilled += 1;
                 let chunk_min = chunk.min_bound().expect("a non-empty chunk has a min bound");
                 let chunk_max = chunk.max_bound().expect("a non-empty chunk has a max bound");
                 // Extends the open run iff every record already in the run precedes
@@ -443,6 +468,15 @@ impl Step for SpillGather {
                     "SpillGather drained with an unclosed run (a withheld spill block was \
                      never flushed by AllAnnounced)",
                 ));
+            }
+            // Report run formation once, matching the owned engine's line so
+            // benchmark log parsing and cross-engine comparison see the same
+            // "Spill runs: R from C chunks (E extended…)" wording.
+            if !self.summary_logged {
+                self.summary_logged = true;
+                if let Some(line) = self.run_formation_summary() {
+                    info!("{line}");
+                }
             }
             return Ok(StepOutcome::Finished);
         }

--- a/crates/fgumi-pipeline-io/src/sort/spill_gather/tests.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_gather/tests.rs
@@ -500,6 +500,89 @@ fn a_residual_closes_the_open_run_before_a_later_spill() {
 }
 
 #[test]
+fn run_formation_summary_matches_the_owned_engine_wording() {
+    // Three contiguous chunks → one run, so 2 of the 3 chunks extended it. The
+    // line must read exactly like fgumi_sort::external::log_run_formation.
+    let mut step = SpillGather::new(1 << 20);
+    drive(
+        &mut step,
+        vec![
+            SortChunkEvent::Spill {
+                seq: 0,
+                chunk: coord_chunk_keyed(&[0, 1]),
+                records_ingested_so_far: 2,
+            },
+            SortChunkEvent::Spill {
+                seq: 1,
+                chunk: coord_chunk_keyed(&[2, 3]),
+                records_ingested_so_far: 4,
+            },
+            SortChunkEvent::Spill {
+                seq: 2,
+                chunk: coord_chunk_keyed(&[4, 5]),
+                records_ingested_so_far: 6,
+            },
+            SortChunkEvent::AllAnnounced { slot_count: 3, memory_chunk_count: 0, total_records: 6 },
+        ],
+    );
+    assert_eq!(step.chunks_spilled, 3);
+    assert_eq!(step.runs_written, 1);
+    assert_eq!(
+        step.run_formation_summary().as_deref(),
+        Some("Spill runs: 1 from 3 chunks (2 extended an existing run)"),
+    );
+}
+
+#[test]
+fn run_formation_summary_counts_each_run_when_nothing_coalesces() {
+    // Reverse-ordered chunks never extend: 3 chunks → 3 runs, 0 extended.
+    let mut step = SpillGather::new(1 << 20);
+    drive(
+        &mut step,
+        vec![
+            SortChunkEvent::Spill {
+                seq: 0,
+                chunk: coord_chunk_keyed(&[40, 50]),
+                records_ingested_so_far: 2,
+            },
+            SortChunkEvent::Spill {
+                seq: 1,
+                chunk: coord_chunk_keyed(&[20, 30]),
+                records_ingested_so_far: 4,
+            },
+            SortChunkEvent::Spill {
+                seq: 2,
+                chunk: coord_chunk_keyed(&[0, 10]),
+                records_ingested_so_far: 6,
+            },
+            SortChunkEvent::AllAnnounced { slot_count: 3, memory_chunk_count: 0, total_records: 6 },
+        ],
+    );
+    assert_eq!(step.chunks_spilled, 3);
+    assert_eq!(step.runs_written, 3);
+    assert_eq!(
+        step.run_formation_summary().as_deref(),
+        Some("Spill runs: 3 from 3 chunks (0 extended an existing run)"),
+    );
+}
+
+#[test]
+fn run_formation_summary_is_none_when_nothing_spilled() {
+    // A residual-only sort (no spills) reports no run-formation line, matching
+    // the owned engine (which only logs when it spilled).
+    let mut step = SpillGather::new(1 << 20);
+    drive(
+        &mut step,
+        vec![
+            SortChunkEvent::Residual { chunk: coord_chunk_keyed(&[1]), records_ingested_so_far: 1 },
+            SortChunkEvent::AllAnnounced { slot_count: 0, memory_chunk_count: 1, total_records: 1 },
+        ],
+    );
+    assert_eq!(step.chunks_spilled, 0);
+    assert_eq!(step.run_formation_summary(), None);
+}
+
+#[test]
 fn a_non_empty_spill_chunk_becomes_active_without_emitting_yet() {
     let mut step = SpillGather::new(1 << 20);
     step.stage_event(SortChunkEvent::Spill {

--- a/crates/fgumi-pipeline-io/src/sort/spill_gather/tests.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_gather/tests.rs
@@ -18,6 +18,26 @@ fn coord_chunk(payloads: Vec<Vec<u8>>) -> MemoryChunkErased {
     MemoryChunkErased::Coordinate(InMemoryChunk::from_owned_records(recs))
 }
 
+/// Build a coordinate chunk with explicit (already-sorted) `sort_key`s and dummy
+/// record bodies, so the run-former's min/max bounds are controllable. `keys`
+/// must be non-decreasing (chunks are pre-sorted at seal).
+fn coord_chunk_keyed(keys: &[u64]) -> MemoryChunkErased {
+    let recs = keys.iter().map(|&k| (RawCoordinateKey { sort_key: k }, vec![0u8; 8])).collect();
+    MemoryChunkErased::Coordinate(InMemoryChunk::from_owned_records(recs))
+}
+
+/// The `(file_id, is_last_in_file)` of every `Block` event, in order. Panics if a
+/// non-`Block` event is present, so callers separate spills from passthroughs.
+fn block_files(events: &[SpillBlockEvent]) -> Vec<(u32, bool)> {
+    events
+        .iter()
+        .map(|e| match e {
+            SpillBlockEvent::Block { file_id, is_last_in_file, .. } => (*file_id, *is_last_in_file),
+            _ => panic!("expected only Block events (a non-Block event was present)"),
+        })
+        .collect()
+}
+
 /// Concatenate the framed-record bytes of all blocks (drops the per-block
 /// boundaries) — the decompressed-stream-equivalent the readers see.
 fn concat(blocks: &[Vec<u8>]) -> Vec<u8> {
@@ -29,6 +49,10 @@ fn concat(blocks: &[Vec<u8>]) -> Vec<u8> {
 /// blocks) before staging the next — and return every emitted event in order.
 /// This preserves the dense-ordinal invariant (a chunk is fully framed, and its
 /// block ordinals minted, before the next event is staged).
+///
+/// After the last event, it closes the final run by flushing any withheld block
+/// with `is_last_in_file = true` — mirroring `try_run`'s drain path (in
+/// production `AllAnnounced` closes it; a `drive` without one relies on this).
 fn drive(step: &mut SpillGather, events: Vec<SortChunkEvent>) -> Vec<SpillBlockEvent> {
     let mut out = Vec::new();
     for event in events {
@@ -44,6 +68,11 @@ fn drive(step: &mut SpillGather, events: Vec<SortChunkEvent>) -> Vec<SpillBlockE
         while let Some(ev) = step.pending.pop_front() {
             out.push(ev);
         }
+    }
+    // Close the final run (no-op if a Residual/AllAnnounced already flushed it).
+    step.flush_held_block(true);
+    while let Some(ev) = step.pending.pop_front() {
+        out.push(ev);
     }
     out
 }
@@ -266,6 +295,208 @@ fn an_empty_spill_chunk_is_skipped_rather_than_opening_a_file() {
     assert!(step.active.is_none(), "an empty chunk must not become the active spill");
     assert!(step.pending.is_empty(), "and must emit nothing");
     assert_eq!(step.next_ordinal, 0, "and must not consume an ordinal");
+}
+
+// ── Run extension (spill coalescing) ─────────────────────────────────────────
+
+/// The `slot_count` an `AllAnnounced` event carries (its rewritten run count).
+/// Panics unless the last event is an `AllAnnounced`.
+fn announced_slot_count(events: &[SpillBlockEvent]) -> u32 {
+    match events.last().expect("at least one event") {
+        SpillBlockEvent::AllAnnounced { slot_count, .. } => *slot_count,
+        _ => panic!("last event must be AllAnnounced"),
+    }
+}
+
+/// Split the emitted stream into its `Block` events and the trailing
+/// `AllAnnounced` (asserting there are no other event kinds).
+fn blocks_and_announced(events: &[SpillBlockEvent]) -> (Vec<(u32, bool)>, u32) {
+    let (last, blocks) = events.split_last().expect("at least an AllAnnounced");
+    let slot_count = match last {
+        SpillBlockEvent::AllAnnounced { slot_count, .. } => *slot_count,
+        _ => panic!("last event must be AllAnnounced"),
+    };
+    (block_files(blocks), slot_count)
+}
+
+#[test]
+fn contiguous_chunks_coalesce_into_one_run() {
+    // Two chunks, the second starting strictly after the first ends → one run:
+    // both blocks share file_id 0, and only the final block closes the file.
+    let mut step = SpillGather::new(1 << 20);
+    let events = drive(
+        &mut step,
+        vec![
+            SortChunkEvent::Spill {
+                seq: 0,
+                chunk: coord_chunk_keyed(&[10, 20]),
+                records_ingested_so_far: 2,
+            },
+            SortChunkEvent::Spill {
+                seq: 1,
+                chunk: coord_chunk_keyed(&[30, 40]),
+                records_ingested_so_far: 4,
+            },
+            SortChunkEvent::AllAnnounced { slot_count: 2, memory_chunk_count: 0, total_records: 4 },
+        ],
+    );
+
+    let (blocks, slot_count) = blocks_and_announced(&events);
+    assert_eq!(blocks, vec![(0, false), (0, true)], "both blocks in one file, last closes it");
+    assert_eq!(slot_count, 1, "slot_count is the RUN count, not the chunk count");
+    assert_eq!(step.runs_written, 1);
+    // Ordinals stay dense across the withheld-block flush.
+    let ords: Vec<u64> = events.iter().map(SpillBlockEvent::ordinal).collect();
+    assert_eq!(ords, vec![0, 1, 2]);
+}
+
+#[test]
+fn exact_boundary_tie_extends_the_run_for_content_keys() {
+    // Coordinate keys are content-based: an exact boundary tie (20 == 20) still
+    // satisfies precedes-or-equal, so the chunks coalesce.
+    let mut step = SpillGather::new(1 << 20);
+    let events = drive(
+        &mut step,
+        vec![
+            SortChunkEvent::Spill {
+                seq: 0,
+                chunk: coord_chunk_keyed(&[10, 20]),
+                records_ingested_so_far: 2,
+            },
+            SortChunkEvent::Spill {
+                seq: 1,
+                chunk: coord_chunk_keyed(&[20, 30]),
+                records_ingested_so_far: 4,
+            },
+            SortChunkEvent::AllAnnounced { slot_count: 2, memory_chunk_count: 0, total_records: 4 },
+        ],
+    );
+    let (blocks, slot_count) = blocks_and_announced(&events);
+    assert_eq!(blocks, vec![(0, false), (0, true)]);
+    assert_eq!(slot_count, 1);
+}
+
+#[test]
+fn non_contiguous_chunk_starts_a_new_run() {
+    // The second chunk's min (20) falls inside the first run (…40), so it cannot
+    // extend it: two runs, each a self-contained file.
+    let mut step = SpillGather::new(1 << 20);
+    let events = drive(
+        &mut step,
+        vec![
+            SortChunkEvent::Spill {
+                seq: 0,
+                chunk: coord_chunk_keyed(&[10, 40]),
+                records_ingested_so_far: 2,
+            },
+            SortChunkEvent::Spill {
+                seq: 1,
+                chunk: coord_chunk_keyed(&[20, 30]),
+                records_ingested_so_far: 4,
+            },
+            SortChunkEvent::AllAnnounced { slot_count: 2, memory_chunk_count: 0, total_records: 4 },
+        ],
+    );
+    let (blocks, slot_count) = blocks_and_announced(&events);
+    assert_eq!(blocks, vec![(0, true), (1, true)], "each chunk closes its own file");
+    assert_eq!(slot_count, 2);
+    assert_eq!(step.runs_written, 2);
+}
+
+#[test]
+fn many_presorted_chunks_collapse_to_a_single_run() {
+    // The already-sorted-input case: every chunk is contiguous, so N chunks
+    // become one run — the whole point of run extension.
+    let mut step = SpillGather::new(1 << 20);
+    let events = drive(
+        &mut step,
+        vec![
+            SortChunkEvent::Spill {
+                seq: 0,
+                chunk: coord_chunk_keyed(&[0, 1]),
+                records_ingested_so_far: 2,
+            },
+            SortChunkEvent::Spill {
+                seq: 1,
+                chunk: coord_chunk_keyed(&[2, 3]),
+                records_ingested_so_far: 4,
+            },
+            SortChunkEvent::Spill {
+                seq: 2,
+                chunk: coord_chunk_keyed(&[4, 5]),
+                records_ingested_so_far: 6,
+            },
+            SortChunkEvent::AllAnnounced { slot_count: 3, memory_chunk_count: 0, total_records: 6 },
+        ],
+    );
+    let (blocks, slot_count) = blocks_and_announced(&events);
+    assert_eq!(blocks, vec![(0, false), (0, false), (0, true)], "one file, only the last closes");
+    assert_eq!(slot_count, 1);
+}
+
+#[test]
+fn an_empty_chunk_does_not_close_the_open_run() {
+    // An empty spill is a pure no-op — it neither closes the run nor breaks the
+    // contiguity of the chunks on either side of it.
+    let mut step = SpillGather::new(1 << 20);
+    let events = drive(
+        &mut step,
+        vec![
+            SortChunkEvent::Spill {
+                seq: 0,
+                chunk: coord_chunk_keyed(&[10, 20]),
+                records_ingested_so_far: 2,
+            },
+            SortChunkEvent::Spill {
+                seq: 1,
+                chunk: coord_chunk_keyed(&[]),
+                records_ingested_so_far: 2,
+            },
+            SortChunkEvent::Spill {
+                seq: 2,
+                chunk: coord_chunk_keyed(&[30, 40]),
+                records_ingested_so_far: 4,
+            },
+            SortChunkEvent::AllAnnounced { slot_count: 3, memory_chunk_count: 0, total_records: 4 },
+        ],
+    );
+    let (blocks, slot_count) = blocks_and_announced(&events);
+    assert_eq!(blocks, vec![(0, false), (0, true)], "the empty chunk contributes nothing");
+    assert_eq!(slot_count, 1, "still one run — the empty chunk did not split it");
+}
+
+#[test]
+fn a_residual_closes_the_open_run_before_a_later_spill() {
+    // A residual (in-memory tail) ends the spill run; a spill after it starts a
+    // fresh run even if its keys would otherwise have been contiguous.
+    let mut step = SpillGather::new(1 << 20);
+    let events = drive(
+        &mut step,
+        vec![
+            SortChunkEvent::Spill {
+                seq: 0,
+                chunk: coord_chunk_keyed(&[10, 20]),
+                records_ingested_so_far: 2,
+            },
+            SortChunkEvent::Residual {
+                chunk: coord_chunk_keyed(&[25]),
+                records_ingested_so_far: 3,
+            },
+            SortChunkEvent::Spill {
+                seq: 2,
+                chunk: coord_chunk_keyed(&[30, 40]),
+                records_ingested_so_far: 5,
+            },
+            SortChunkEvent::AllAnnounced { slot_count: 2, memory_chunk_count: 1, total_records: 5 },
+        ],
+    );
+    // Stream: Block(file0,last), Residual, Block(file2,last), AllAnnounced.
+    assert!(matches!(events[0], SpillBlockEvent::Block { file_id: 0, is_last_in_file: true, .. }));
+    assert!(matches!(events[1], SpillBlockEvent::Residual { .. }));
+    assert!(matches!(events[2], SpillBlockEvent::Block { file_id: 2, is_last_in_file: true, .. }));
+    assert_eq!(announced_slot_count(&events), 2, "two runs, split by the residual");
+    let ords: Vec<u64> = events.iter().map(SpillBlockEvent::ordinal).collect();
+    assert_eq!(ords, vec![0, 1, 2, 3], "ordinals dense across the residual boundary");
 }
 
 #[test]

--- a/crates/fgumi-pipeline-io/src/sort/spill_gather/tests.rs
+++ b/crates/fgumi-pipeline-io/src/sort/spill_gather/tests.rs
@@ -583,6 +583,42 @@ fn run_formation_summary_is_none_when_nothing_spilled() {
 }
 
 #[test]
+fn the_run_final_block_is_withheld_until_the_run_is_closed() {
+    // Frame a single spill chunk with no terminating event yet: its final block
+    // is withheld (the run is still open), which is exactly the state the drain
+    // guard fails closed on — `held_last_block.is_held()` at drain.
+    let mut step = SpillGather::new(1 << 20);
+    step.stage_event(SortChunkEvent::Spill {
+        seq: 0,
+        chunk: coord_chunk_keyed(&[10, 20]),
+        records_ingested_so_far: 2,
+    });
+    step.produce_blocks().unwrap();
+    assert!(step.active.is_none(), "the one-block chunk is fully framed");
+    assert!(step.pending.is_empty(), "the sole (run-final) block is withheld, not emitted");
+    assert!(
+        step.held_last_block.is_held(),
+        "a run-final block is withheld until close — a drain here would trip the guard"
+    );
+
+    // Closing the run (AllAnnounced) flushes the withheld block with is_last=true
+    // and leaves nothing held, so the drain guard is clear.
+    step.stage_event(SortChunkEvent::AllAnnounced {
+        slot_count: 1,
+        memory_chunk_count: 0,
+        total_records: 2,
+    });
+    assert!(!step.held_last_block.is_held(), "closing the run flushes the withheld block");
+    assert!(
+        matches!(
+            step.pending.front(),
+            Some(SpillBlockEvent::Block { is_last_in_file: true, file_id: 0, .. })
+        ),
+        "the flushed block closes its file"
+    );
+}
+
+#[test]
 fn a_non_empty_spill_chunk_becomes_active_without_emitting_yet() {
     let mut step = SpillGather::new(1 << 20);
     step.stage_event(SortChunkEvent::Spill {

--- a/crates/fgumi-pipeline-io/src/sort/tests.rs
+++ b/crates/fgumi-pipeline-io/src/sort/tests.rs
@@ -933,6 +933,201 @@ fn block_parallel_bgzf_spill_matches_legacy() {
     assert_eq!(new_out, legacy_out, "sorted bytes differ (bgzf block-parallel)");
 }
 
+// ── Production spill split + run extension (SpillGather run-former) ────────────
+//
+// `drive_sort_buffer_pipeline` above drives the retired monolithic `CompressSpill`
+// for legacy Phase-2 coverage. The tests below drive the PRODUCTION spill split
+// (`SortBuffer` → `SpillGather` → `SpillBlockCompress` → `SpillWrite` →
+// `SortSpillDecompress` → `SortMerge`) that `fgumi sort` actually builds, so they
+// exercise the run-forming `SpillGather` end-to-end: contiguous chunks coalesce
+// into one run, and the merge sees one slot per run.
+
+/// Drive the production spill split and return `(merged record bytes, run count)`.
+/// The run count is the `SortMerge` stats `runs_written`, which equals the number
+/// of spill files (`SpillReady`s) the merge saw — i.e. the number of runs the
+/// `SpillGather` run-former formed. Mirrors `ChainBuilder::add_sort`'s wiring.
+fn drive_spill_split_pipeline(
+    sorter: RawExternalSorter,
+    header: &Header,
+    batches: Vec<RecordBatch>,
+    output_byte_limit: u64,
+    threads: usize,
+) -> Result<(Vec<Vec<u8>>, usize)> {
+    use fgumi_sort::TmpDirAllocator;
+
+    let received: Arc<Mutex<Vec<RecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let stats_slot: Arc<Mutex<Option<fgumi_sort::SortStats>>> = Arc::new(Mutex::new(None));
+    let sort_order = sorter.sort_order();
+
+    let dir = tempfile::TempDir::new()?;
+    let alloc =
+        TmpDirAllocator::with_probe(vec![dir.path().to_path_buf()], Box::new(|_| Ok(u64::MAX)), 0)?;
+    let temp_dirs = Arc::new(vec![dir]);
+    let codec = SpillCodec::Zstd;
+
+    let source = VecSource::new(batches, output_byte_limit);
+    let sort_buffer = SortBuffer::from_sorter(sorter, header, output_byte_limit)?;
+    let gather = SpillGather::new(output_byte_limit);
+    let compress = SpillBlockCompress::new(codec, 3, output_byte_limit);
+    let write = SpillWrite::new(Arc::new(Mutex::new(alloc)), codec, output_byte_limit, temp_dirs);
+    let decompress = SortSpillDecompress::new(output_byte_limit, SortDecompressTuning::default());
+    let merge =
+        SortMerge::<RecordBatchOutput>::with_target_batch_count(sort_order, output_byte_limit, 256)
+            .with_stats_slot(Arc::clone(&stats_slot));
+    let sink = VecSink { received: Arc::clone(&received), kind: StepKind::Serial };
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(source)
+        .chain(sort_buffer)
+        .chain(gather)
+        .chain(compress)
+        .chain(write)
+        .chain(decompress)
+        .chain(merge)
+        .chain(sink)
+        .into_sink_marker();
+    let pipeline = builder.build()?;
+    pipeline.run(PipelineConfig { threads, ..Default::default() })?;
+
+    let collected = std::mem::take(&mut *received.lock());
+    let mut out = Vec::new();
+    for batch in collected {
+        for bytes in batch.iter_record_bytes() {
+            out.push(bytes.to_vec());
+        }
+    }
+    let runs = stats_slot.lock().take().expect("SortMerge published its stats").runs_written;
+    Ok((out, runs))
+}
+
+/// Records sorted into `order`, obtained by running them through the oracle and
+/// parsing its (byte-identical) sorted output back into `RawRecord`s. Feeding
+/// this back in is the already-sorted-input case the run-former must coalesce.
+fn presorted_records(order: SortOrder, header: &Header, records: &[RawRecord]) -> Vec<RawRecord> {
+    sort_via_legacy(order, header, records, 256 * 1024 * 1024, 1)
+        .expect("oracle sort")
+        .into_iter()
+        .map(RawRecord::from)
+        .collect()
+}
+
+/// An already-sorted input, re-sorted under a small memory budget through the
+/// production split, must coalesce every contiguous chunk into ONE run — and
+/// stay byte-identical to the oracle. This is the t16 fix's headline behaviour,
+/// exercised across all four sort orders via the shared `SpillGather` run-former.
+#[rstest]
+#[case::coordinate(SortOrder::Coordinate)]
+#[case::queryname_lex(SortOrder::Queryname(QuerynameComparator::Lexicographic))]
+#[case::queryname_natural(SortOrder::Queryname(QuerynameComparator::Natural))]
+#[case::template(SortOrder::TemplateCoordinate)]
+fn presorted_input_coalesces_to_one_run(#[case] order: SortOrder) {
+    let (header, records) = synthesize_sized_records(20_000, 0xC0FF_EE00, 40);
+    let sorted = presorted_records(order, &header, &records);
+
+    let sorter = RawExternalSorter::new(order)
+        .memory_limit(256 * 1024) // small ⇒ many contiguous chunks to coalesce
+        .threads(2)
+        .output_compression(1)
+        .temp_compression(1);
+    let (out, runs) =
+        drive_spill_split_pipeline(sorter, &header, pack_batches(&sorted, 256), 4 * 1024 * 1024, 4)
+            .expect("spill-split pipeline drives to completion");
+
+    let expected = sort_via_legacy(order, &header, &sorted, 256 * 1024 * 1024, 1).expect("oracle");
+    assert_eq!(out, expected, "{order:?}: coalesced output diverged from the oracle");
+    assert_eq!(
+        runs, 1,
+        "{order:?}: contiguous chunks must coalesce into a single run (SpillReady==#runs)"
+    );
+}
+
+/// A reverse-ordered input cannot coalesce: every chunk's minimum precedes the
+/// open run's maximum, so the run-former opens a fresh run per chunk. Output must
+/// still be byte-identical to the oracle — extension is a layout optimisation,
+/// never a reordering.
+#[test]
+fn reverse_ordered_input_forms_many_runs_but_stays_byte_parity() {
+    let order = SortOrder::Coordinate;
+    let (header, records) = synthesize_sized_records(20_000, 0xBEEF_0001, 40);
+    let mut reversed = presorted_records(order, &header, &records);
+    reversed.reverse();
+
+    let sorter = RawExternalSorter::new(order)
+        .memory_limit(256 * 1024)
+        .threads(2)
+        .output_compression(1)
+        .temp_compression(1);
+    let (out, runs) = drive_spill_split_pipeline(
+        sorter,
+        &header,
+        pack_batches(&reversed, 256),
+        4 * 1024 * 1024,
+        4,
+    )
+    .expect("spill-split pipeline drives to completion");
+
+    let expected =
+        sort_via_legacy(order, &header, &reversed, 256 * 1024 * 1024, 1).expect("oracle");
+    assert_eq!(out, expected, "reverse-ordered sort diverged from the oracle");
+    assert!(runs >= 2, "reverse-ordered chunks must not coalesce (got {runs} run(s))");
+}
+
+/// A fully shuffled input: the run-former coalesces the runs it can and opens new
+/// ones where it cannot, and the merged output must still match the oracle
+/// byte-for-byte. This is the partial-coalescing correctness case.
+#[rstest]
+#[case::coordinate(SortOrder::Coordinate)]
+#[case::queryname_natural(SortOrder::Queryname(QuerynameComparator::Natural))]
+#[case::template(SortOrder::TemplateCoordinate)]
+fn shuffled_input_matches_the_oracle_through_the_split(#[case] order: SortOrder) {
+    let (header, records) = synthesize_sized_records(20_000, 0x5EED_1234, 40);
+
+    let sorter = RawExternalSorter::new(order)
+        .memory_limit(256 * 1024)
+        .threads(2)
+        .output_compression(1)
+        .temp_compression(1);
+    let (out, _runs) = drive_spill_split_pipeline(
+        sorter,
+        &header,
+        pack_batches(&records, 256),
+        4 * 1024 * 1024,
+        4,
+    )
+    .expect("spill-split pipeline drives to completion");
+
+    let expected = sort_via_legacy(order, &header, &records, 256 * 1024 * 1024, 1).expect("oracle");
+    assert_eq!(out, expected, "{order:?}: shuffled-input sort diverged from the oracle");
+}
+
+/// An in-memory sort (memory budget above the whole input) never spills, so the
+/// run-former forms zero runs — the residual fast path stays intact under the
+/// production split.
+#[test]
+fn in_memory_input_forms_no_runs() {
+    let order = SortOrder::Coordinate;
+    let (header, records) = synthesize_sized_records(5_000, 0xA110_0C00, 40);
+
+    let sorter = RawExternalSorter::new(order)
+        .memory_limit(256 * 1024 * 1024) // above the whole input ⇒ no spill
+        .threads(2)
+        .output_compression(1)
+        .temp_compression(1);
+    let (out, runs) = drive_spill_split_pipeline(
+        sorter,
+        &header,
+        pack_batches(&records, 256),
+        4 * 1024 * 1024,
+        4,
+    )
+    .expect("spill-split pipeline drives to completion");
+
+    let expected = sort_via_legacy(order, &header, &records, 256 * 1024 * 1024, 1).expect("oracle");
+    assert_eq!(out, expected, "in-memory sort diverged from the oracle");
+    assert_eq!(runs, 0, "a budget-sized run never spills");
+}
+
 /// Block-parallel decompression completes out of order (workers decompress one
 /// file's blocks concurrently), yet the reassembled output must be byte-
 /// identical to the in-order (file-granularity) result. Property test over a
@@ -1956,4 +2151,101 @@ fn arena_front_chain_seals_multiple_runs_without_losing_records() {
     got.sort_unstable();
     want.sort_unstable();
     assert_eq!(got, want, "the sealed runs must carry every input record exactly once");
+}
+
+/// Drive the full BAM sort path — the benchmark path — end to end:
+/// `BgzfBlockSource → ReadBlocks → InflateToArena → FindBoundariesAndSort →
+/// SpillGather → SpillBlockCompress → SpillWrite → SortSpillDecompress →
+/// SortMerge`. Returns `(merged record bytes, run count)`. This is the head the
+/// 43 GB `1kg-wgs` benchmark actually uses (SAM/`SortBuffer` is the other head),
+/// so the run-former must coalesce here, not only on the `SortBuffer` path.
+fn drive_arena_split_pipeline(
+    blocks: Vec<crate::types::BgzfBlock>,
+    n_ref: u32,
+    memory_limit: usize,
+    output_byte_limit: u64,
+    threads: usize,
+) -> Result<(Vec<Vec<u8>>, usize)> {
+    use fgumi_sort::TmpDirAllocator;
+
+    let received: Arc<Mutex<Vec<RecordBatch>>> = Arc::new(Mutex::new(Vec::new()));
+    let stats_slot: Arc<Mutex<Option<fgumi_sort::SortStats>>> = Arc::new(Mutex::new(None));
+
+    let dir = tempfile::TempDir::new()?;
+    let alloc =
+        TmpDirAllocator::with_probe(vec![dir.path().to_path_buf()], Box::new(|_| Ok(u64::MAX)), 0)?;
+    let temp_dirs = Arc::new(vec![dir]);
+    let codec = SpillCodec::Zstd;
+
+    let merge = SortMerge::<RecordBatchOutput>::with_target_batch_count(
+        SortOrder::Coordinate,
+        output_byte_limit,
+        256,
+    )
+    .with_stats_slot(Arc::clone(&stats_slot));
+
+    let builder = Pipeline::builder();
+    builder
+        .chain(BgzfBlockSource::new(blocks, output_byte_limit))
+        .chain(ReadBlocks::new(memory_limit, output_byte_limit))
+        .chain(InflateToArena::new(output_byte_limit))
+        .chain(FindBoundariesAndSort::new(CoordinateStrategy::new(n_ref), 1, output_byte_limit))
+        .chain(SpillGather::new(output_byte_limit))
+        .chain(SpillBlockCompress::new(codec, 3, output_byte_limit))
+        .chain(SpillWrite::new(Arc::new(Mutex::new(alloc)), codec, output_byte_limit, temp_dirs))
+        .chain(SortSpillDecompress::new(output_byte_limit, SortDecompressTuning::default()))
+        .chain(merge)
+        .chain(VecSink { received: Arc::clone(&received), kind: StepKind::Serial })
+        .into_sink_marker();
+    let pipeline = builder.build()?;
+    pipeline.run(PipelineConfig { threads, ..Default::default() })?;
+
+    let collected = std::mem::take(&mut *received.lock());
+    let mut out = Vec::new();
+    for batch in collected {
+        for bytes in batch.iter_record_bytes() {
+            out.push(bytes.to_vec());
+        }
+    }
+    let runs = stats_slot.lock().take().expect("SortMerge published its stats").runs_written;
+    Ok((out, runs))
+}
+
+/// The benchmark case, in miniature: a pre-sorted BAM re-sorted through the full
+/// arena/BAM path under a small memory budget must coalesce every contiguous
+/// sealed run into ONE spill file, and stay byte-identical to the oracle. This is
+/// the `FindBoundariesAndSort` head (not `SortBuffer`), so it proves the
+/// run-former covers the path the 43 GB `1kg-wgs` sort exercises.
+#[test]
+fn presorted_bam_coalesces_to_one_run_through_the_arena_split() {
+    let (header, records) = synthesize_sized_records(8_000, 0xB00C_0001, 40);
+    let n_ref = u32::try_from(header.reference_sequences().len()).expect("n_ref fits u32");
+    let sorted = presorted_records(SortOrder::Coordinate, &header, &records);
+
+    // Small per-block payload ⇒ many BGZF blocks; small memory ⇒ ReadBlocks seals
+    // several contiguous runs the run-former must coalesce.
+    let blocks = bgzf_blocks_for(&sorted, n_ref, 4096);
+    let (out, runs) = drive_arena_split_pipeline(blocks, n_ref, 64 * 1024, 4 * 1024 * 1024, 4)
+        .expect("arena-split pipeline drives to completion");
+
+    let expected = sort_via_legacy(SortOrder::Coordinate, &header, &sorted, 256 * 1024 * 1024, 1)
+        .expect("oracle");
+    assert_eq!(out, expected, "arena/BAM-path coalesced output diverged from the oracle");
+    assert_eq!(runs, 1, "contiguous sealed runs must coalesce into a single run on the BAM path");
+}
+
+/// The same full BAM path on a shuffled input: partial coalescing, but the merged
+/// output must still match the oracle byte-for-byte.
+#[test]
+fn shuffled_bam_matches_the_oracle_through_the_arena_split() {
+    let (header, records) = synthesize_sized_records(8_000, 0xB00C_0002, 40);
+    let n_ref = u32::try_from(header.reference_sequences().len()).expect("n_ref fits u32");
+
+    let blocks = bgzf_blocks_for(&records, n_ref, 4096);
+    let (out, _runs) = drive_arena_split_pipeline(blocks, n_ref, 64 * 1024, 4 * 1024 * 1024, 4)
+        .expect("arena-split pipeline drives to completion");
+
+    let expected = sort_via_legacy(SortOrder::Coordinate, &header, &records, 256 * 1024 * 1024, 1)
+        .expect("oracle");
+    assert_eq!(out, expected, "arena/BAM-path shuffled output diverged from the oracle");
 }

--- a/crates/fgumi-pipeline-io/src/sort/tests.rs
+++ b/crates/fgumi-pipeline-io/src/sort/tests.rs
@@ -1078,6 +1078,7 @@ fn reverse_ordered_input_forms_many_runs_but_stays_byte_parity() {
 /// byte-for-byte. This is the partial-coalescing correctness case.
 #[rstest]
 #[case::coordinate(SortOrder::Coordinate)]
+#[case::queryname_lex(SortOrder::Queryname(QuerynameComparator::Lexicographic))]
 #[case::queryname_natural(SortOrder::Queryname(QuerynameComparator::Natural))]
 #[case::template(SortOrder::TemplateCoordinate)]
 fn shuffled_input_matches_the_oracle_through_the_split(#[case] order: SortOrder) {
@@ -1088,7 +1089,7 @@ fn shuffled_input_matches_the_oracle_through_the_split(#[case] order: SortOrder)
         .threads(2)
         .output_compression(1)
         .temp_compression(1);
-    let (out, _runs) = drive_spill_split_pipeline(
+    let (out, runs) = drive_spill_split_pipeline(
         sorter,
         &header,
         pack_batches(&records, 256),
@@ -1099,6 +1100,9 @@ fn shuffled_input_matches_the_oracle_through_the_split(#[case] order: SortOrder)
 
     let expected = sort_via_legacy(order, &header, &records, 256 * 1024 * 1024, 1).expect("oracle");
     assert_eq!(out, expected, "{order:?}: shuffled-input sort diverged from the oracle");
+    // Shuffled input under a tiny budget must open more than one run (partial
+    // coalescing: a new run wherever a chunk cannot extend the previous one).
+    assert!(runs >= 2, "{order:?}: shuffled input must form >=2 runs (got {runs})");
 }
 
 /// An in-memory sort (memory budget above the whole input) never spills, so the
@@ -1126,6 +1130,40 @@ fn in_memory_input_forms_no_runs() {
     let expected = sort_via_legacy(order, &header, &records, 256 * 1024 * 1024, 1).expect("oracle");
     assert_eq!(out, expected, "in-memory sort diverged from the oracle");
     assert_eq!(runs, 0, "a budget-sized run never spills");
+}
+
+/// The single-thread scheduled path the fusion-policy change (t1 fix) newly
+/// activates: at `threads == 1` this chain declares Detached steps (`SpillGather`
+/// and `SortMerge`), so it does NOT fuse and runs on the scheduled path (one pool
+/// worker plus the detached driver threads). Pin that path's spilling output
+/// against the oracle end-to-end through the production spill split — the
+/// buffer-chain parity matrix only covers threads 2/4, and its harness cannot
+/// take a `threads == 1` case (its `VecSource` + `VecSink` are both Exclusive).
+#[rstest]
+#[case::coordinate(SortOrder::Coordinate)]
+#[case::queryname_natural(SortOrder::Queryname(QuerynameComparator::Natural))]
+fn sorts_at_one_thread_through_the_scheduled_path(#[case] order: SortOrder) {
+    let (header, records) = synthesize_sized_records(8_000, 0x0057_0001, 40);
+
+    let sorter = RawExternalSorter::new(order)
+        .memory_limit(256 * 1024) // small ⇒ spills, exercising the merge at t1
+        .threads(1)
+        .output_compression(1)
+        .temp_compression(1);
+    let (out, runs) = drive_spill_split_pipeline(
+        sorter,
+        &header,
+        pack_batches(&records, 256),
+        4 * 1024 * 1024,
+        1,
+    )
+    .expect("spill-split pipeline drives to completion at one thread");
+
+    let expected = sort_via_legacy(order, &header, &records, 256 * 1024 * 1024, 1).expect("oracle");
+    assert_eq!(out, expected, "{order:?}: single-thread scheduled sort diverged from the oracle");
+    // The small budget must actually spill; otherwise this degrades to an
+    // in-memory sort and no longer exercises the merge path it names.
+    assert!(runs >= 1, "{order:?}: the small budget must spill (got {runs} run(s))");
 }
 
 /// Block-parallel decompression completes out of order (workers decompress one
@@ -2242,10 +2280,13 @@ fn shuffled_bam_matches_the_oracle_through_the_arena_split() {
     let n_ref = u32::try_from(header.reference_sequences().len()).expect("n_ref fits u32");
 
     let blocks = bgzf_blocks_for(&records, n_ref, 4096);
-    let (out, _runs) = drive_arena_split_pipeline(blocks, n_ref, 64 * 1024, 4 * 1024 * 1024, 4)
+    let (out, runs) = drive_arena_split_pipeline(blocks, n_ref, 64 * 1024, 4 * 1024 * 1024, 4)
         .expect("arena-split pipeline drives to completion");
 
     let expected = sort_via_legacy(SortOrder::Coordinate, &header, &records, 256 * 1024 * 1024, 1)
         .expect("oracle");
     assert_eq!(out, expected, "arena/BAM-path shuffled output diverged from the oracle");
+    // Shuffled BAM input under a tiny per-block budget must open more than one
+    // run (partial coalescing), otherwise the case no longer exercises it.
+    assert!(runs >= 2, "arena/BAM shuffled input must form >=2 runs (got {runs})");
 }

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -2068,10 +2068,7 @@ struct RunFormer<K> {
 /// have nothing to do with how ordered the input was -- which is the one thing
 /// this line exists to report.
 fn log_run_formation(chunks_spilled: usize, runs: usize) {
-    info!(
-        "Spill runs: {runs} from {chunks_spilled} chunks ({} extended an existing run)",
-        chunks_spilled.saturating_sub(runs)
-    );
+    info!("{}", crate::run_bound::format_run_formation(runs, chunks_spilled));
 }
 
 /// The smallest and largest keys in an already-sorted slice.

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -64,6 +64,9 @@ pub(crate) mod radix;
 pub(crate) mod read_ahead;
 pub(crate) mod reader;
 pub mod ref_sort;
+// Per-order run boundary key for the arena spill run-former (extend-vs-new-run
+// decision). Surfaced via the re-export below.
+pub(crate) mod run_bound;
 pub mod segmented_buf;
 pub mod template_arena;
 // Block-granular spill compression kernel for the block-parallel spill steps
@@ -247,6 +250,7 @@ pub use reader::{
 pub use ref_sort::{
     coordinate_chunk_from_arena_refs, coordinate_chunk_from_refs, queryname_chunk_from_arena_refs,
 };
+pub use run_bound::RunBound;
 pub use segmented_buf::SegmentedBuf;
 pub use spill_block::{SpillBlockCompressor, frame_keyed_record_into, spill_magic, spill_trailer};
 pub use spill_block_reader::SpillBlockDecompressor;

--- a/crates/fgumi-sort/src/lib.rs
+++ b/crates/fgumi-sort/src/lib.rs
@@ -250,7 +250,7 @@ pub use reader::{
 pub use ref_sort::{
     coordinate_chunk_from_arena_refs, coordinate_chunk_from_refs, queryname_chunk_from_arena_refs,
 };
-pub use run_bound::RunBound;
+pub use run_bound::{RunBound, format_run_formation};
 pub use segmented_buf::SegmentedBuf;
 pub use spill_block::{SpillBlockCompressor, frame_keyed_record_into, spill_magic, spill_trailer};
 pub use spill_block_reader::SpillBlockDecompressor;

--- a/crates/fgumi-sort/src/run_bound.rs
+++ b/crates/fgumi-sort/src/run_bound.rs
@@ -1,0 +1,164 @@
+//! Per-order run boundary key, used by the arena spill run-former to decide when
+//! a freshly-sealed sorted chunk *extends* the currently-open run.
+//!
+//! # Run extension
+//!
+//! The owned external sorter coalesces contiguous sorted spill chunks into a
+//! single run: when a new chunk's minimum key is `>=` the open run's maximum
+//! key, every record in the run precedes every record in the new chunk, so
+//! concatenating the new chunk's blocks after the run keeps the run globally
+//! sorted. On an already-sorted input, all chunks are contiguous and collapse to
+//! one run — a trivial final merge. The arena spill path reproduces this in
+//! `SpillGather`; [`RunBound`] is the owned, type-erased key it compares.
+//!
+//! # Why an owned enum
+//!
+//! Each sort order carries a different key type ([`RawCoordinateKey`],
+//! [`RawQuerynameLexKey`], [`RawQuerynameKey`], and the four narrowed template
+//! lanes). The run-former sees chunks type-erased through
+//! [`TemplateMemChunk`](crate::TemplateMemChunk) / `MemoryChunkErased`, so it
+//! needs one owned type that can hold whichever order's boundary key and compare
+//! two bounds of the *same* order. A bound outlives the chunk it came from (the
+//! open run's max is retained while later chunks are ingested and the source
+//! chunk is spilled and dropped), so it must own its key rather than borrow it.
+//!
+//! # Queryname tie-break is parity-safe
+//!
+//! Queryname keys ([`RawQuerynameKey`], [`RawQuerynameLexKey`]) carry an
+//! intra-chunk ingest `pos` as their final `cmp` tie-break. Within a chunk `pos`
+//! increases with ingest order, so the open run's max (`key_at(len-1)`, a large
+//! `pos`) never precedes-or-equals the next chunk's min (`key_at(0)`, `pos`
+//! reset near 0) on an exact name+flags tie — extension is conservatively
+//! declined. This is safe: `pos` is *not* serialized (the on-disk key is
+//! `[name_len][name][flags]`), so an extended run and a non-extended run produce
+//! byte-identical spill output. Coordinate and template keys are content-based
+//! (no `pos`), so their ties *do* extend — also byte-identical either way.
+
+use crate::inline::{CbKey32, TemplateKey, TemplateKey24, TertKey32};
+use crate::keys::{RawCoordinateKey, RawQuerynameKey, RawQuerynameLexKey};
+
+/// The minimum or maximum sort key of an in-memory sorted chunk, owned and
+/// type-erased over the sort order so the arena spill run-former can compare the
+/// open run's maximum against an incoming chunk's minimum.
+///
+/// One variant per concrete sort key: the three whole-record orders plus the
+/// four narrowed template-coordinate lanes. Two bounds are only ever compared
+/// when they come from the same sort run (hence the same variant); see
+/// [`precedes_or_equal`](Self::precedes_or_equal).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RunBound {
+    /// Coordinate order, `K = RawCoordinateKey`.
+    Coordinate(RawCoordinateKey),
+    /// Queryname order, lexicographic comparator, `K = RawQuerynameLexKey`.
+    QuerynameLex(RawQuerynameLexKey),
+    /// Queryname order, natural comparator, `K = RawQuerynameKey`.
+    QuerynameNatural(RawQuerynameKey),
+    /// Template-coordinate, 24-byte core-only lane.
+    TemplateK24(TemplateKey24),
+    /// Template-coordinate, 32-byte `cb_hash` lane.
+    TemplateCb32(CbKey32),
+    /// Template-coordinate, 32-byte tertiary lane.
+    TemplateTert32(TertKey32),
+    /// Template-coordinate, full 40-byte key (all lanes).
+    TemplateK40(TemplateKey),
+}
+
+impl RunBound {
+    /// True iff a chunk whose minimum bound is `next_min` extends the open run
+    /// whose maximum bound is `self` — i.e. `self <= next_min`, so the run stays
+    /// globally sorted when the incoming chunk's blocks are appended after it.
+    ///
+    /// Compares within a single sort order. Bounds of differing variants can
+    /// only arise from a programming error (a sort run is one order); such a
+    /// mismatch conservatively returns `false` (declines to extend) rather than
+    /// risk building an out-of-order run.
+    #[must_use]
+    pub fn precedes_or_equal(&self, next_min: &RunBound) -> bool {
+        match (self, next_min) {
+            (Self::Coordinate(a), Self::Coordinate(b)) => a <= b,
+            (Self::QuerynameLex(a), Self::QuerynameLex(b)) => a <= b,
+            (Self::QuerynameNatural(a), Self::QuerynameNatural(b)) => a <= b,
+            (Self::TemplateK24(a), Self::TemplateK24(b)) => a <= b,
+            (Self::TemplateCb32(a), Self::TemplateCb32(b)) => a <= b,
+            (Self::TemplateTert32(a), Self::TemplateTert32(b)) => a <= b,
+            (Self::TemplateK40(a), Self::TemplateK40(b)) => a <= b,
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::keys::RawSortKey;
+
+    /// Coordinate keys are content-based (no `pos` tie-break): an open run whose
+    /// max is `<=` an incoming chunk's min extends; a `>` boundary does not.
+    #[test]
+    fn coordinate_extends_when_max_precedes_or_equals_min() {
+        let nref = 100;
+        let lo = RunBound::Coordinate(RawCoordinateKey::new(1, 1000, false, nref));
+        let hi = RunBound::Coordinate(RawCoordinateKey::new(1, 2000, false, nref));
+
+        // open run max (lo) precedes incoming min (hi) → extend.
+        assert!(lo.precedes_or_equal(&hi));
+        // reverse order → do not extend.
+        assert!(!hi.precedes_or_equal(&lo));
+    }
+
+    /// An exact boundary tie on a content-based (coordinate) key *does* extend:
+    /// equal keys satisfy `<=`, and the spill bytes are identical either way.
+    #[test]
+    fn coordinate_exact_tie_extends() {
+        let k = RawCoordinateKey::new(3, 500, true, 100);
+        let a = RunBound::Coordinate(k);
+        let b = RunBound::Coordinate(k);
+        assert!(a.precedes_or_equal(&b));
+    }
+
+    /// Queryname keys carry `pos`, so an exact name+flags boundary tie does NOT
+    /// extend: the open run's max (`pos` large) is not `<=` the incoming min
+    /// (`pos` reset). Parity-safe because `pos` is not serialized. Uses the lex
+    /// comparator; the natural comparator shares the same `pos` tie-break.
+    #[test]
+    fn queryname_exact_name_tie_does_not_extend_due_to_pos() {
+        // Same name + flags, differing only in the intra-chunk ingest position:
+        // the open run's max record was ingested later (larger pos) than the
+        // incoming chunk's first record (pos reset near 0).
+        let mut open_max = RawQuerynameLexKey::new(b"readAAA".to_vec(), 0);
+        open_max.set_position(9);
+        let mut incoming_min = RawQuerynameLexKey::new(b"readAAA".to_vec(), 0);
+        incoming_min.set_position(0);
+
+        let open = RunBound::QuerynameLex(open_max);
+        let incoming = RunBound::QuerynameLex(incoming_min);
+        assert!(
+            !open.precedes_or_equal(&incoming),
+            "an exact name tie must NOT extend: pos makes max > min"
+        );
+    }
+
+    /// A strictly-smaller queryname name in the open run's max still extends
+    /// regardless of `pos` — the name comparison decides before `pos`.
+    #[test]
+    fn queryname_strictly_smaller_name_extends() {
+        let mut open_max = RawQuerynameLexKey::new(b"readAAA".to_vec(), 0);
+        open_max.set_position(9);
+        let mut incoming_min = RawQuerynameLexKey::new(b"readBBB".to_vec(), 0);
+        incoming_min.set_position(0);
+
+        let open = RunBound::QuerynameLex(open_max);
+        let incoming = RunBound::QuerynameLex(incoming_min);
+        assert!(open.precedes_or_equal(&incoming));
+    }
+
+    /// Mismatched variants can only arise from a bug; the compare declines to
+    /// extend rather than risk an out-of-order run.
+    #[test]
+    fn variant_mismatch_never_extends() {
+        let coord = RunBound::Coordinate(RawCoordinateKey::new(0, 0, false, 100));
+        let name = RunBound::QuerynameLex(RawQuerynameLexKey::new(b"r".to_vec(), 0));
+        assert!(!coord.precedes_or_equal(&name));
+        assert!(!name.precedes_or_equal(&coord));
+    }
+}

--- a/crates/fgumi-sort/src/run_bound.rs
+++ b/crates/fgumi-sort/src/run_bound.rs
@@ -22,17 +22,25 @@
 //! open run's max is retained while later chunks are ingested and the source
 //! chunk is spilled and dropped), so it must own its key rather than borrow it.
 //!
-//! # Queryname tie-break is parity-safe
+//! # Tie behaviour is parity-safe (all orders)
 //!
-//! Queryname keys ([`RawQuerynameKey`], [`RawQuerynameLexKey`]) carry an
-//! intra-chunk ingest `pos` as their final `cmp` tie-break. Within a chunk `pos`
-//! increases with ingest order, so the open run's max (`key_at(len-1)`, a large
-//! `pos`) never precedes-or-equals the next chunk's min (`key_at(0)`, `pos`
-//! reset near 0) on an exact name+flags tie — extension is conservatively
-//! declined. This is safe: `pos` is *not* serialized (the on-disk key is
-//! `[name_len][name][flags]`), so an extended run and a non-extended run produce
-//! byte-identical spill output. Coordinate and template keys are content-based
-//! (no `pos`), so their ties *do* extend — also byte-identical either way.
+//! An exact boundary tie (the open run's max key equals the incoming chunk's min
+//! key) *extends* the run in the arena path, for every order. That is safe
+//! whether a tie extends or splits, because equal-key records keep the same
+//! relative order either way: within one physical run they are concatenated in
+//! (chunk seal order, intra-chunk order); across two runs the merge combines the
+//! slots in the same (`file_id`, intra-chunk) order — the byte output is identical.
+//!
+//! Note the `pos` field on the queryname keys ([`RawQuerynameKey`],
+//! [`RawQuerynameLexKey`]) does **not** change this. `pos` is a per-chunk ingest
+//! index and is the keys' final `cmp` tie-break, but it is set (via
+//! [`RawSortKey::set_position`](crate::RawSortKey::set_position)) **only** in the
+//! owned engine's `RunFormer`, which never uses `RunBound`. The arena ingest that
+//! builds `RunBound` breaks equal-key ties by arena offset in the sort comparator
+//! and never calls `set_position`, so every arena queryname key carries `pos == 0`
+//! — an exact name+flags tie therefore compares `Equal` and the run extends. And
+//! even if `pos` did differ, it is not serialized (the on-disk key is
+//! `[name_len][name][flags]`), so extend-vs-split is byte-identical regardless.
 
 use crate::inline::{CbKey32, TemplateKey, TemplateKey24, TertKey32};
 use crate::keys::{RawCoordinateKey, RawQuerynameKey, RawQuerynameLexKey};
@@ -87,6 +95,21 @@ impl RunBound {
     }
 }
 
+/// The run-formation summary line both sort engines log, so the wording and the
+/// `extended = chunks_spilled - runs` arithmetic have a single source of truth:
+/// the owned engine's `log_run_formation` and the arena's
+/// `SpillGather::run_formation_summary` both format through this.
+///
+/// Every spilled chunk either starts a run or extends an existing one, so the
+/// number that extended is exactly `chunks_spilled - runs`.
+#[must_use]
+pub fn format_run_formation(runs: usize, chunks_spilled: usize) -> String {
+    format!(
+        "Spill runs: {runs} from {chunks_spilled} chunks ({} extended an existing run)",
+        chunks_spilled.saturating_sub(runs)
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -116,26 +139,40 @@ mod tests {
         assert!(a.precedes_or_equal(&b));
     }
 
-    /// Queryname keys carry `pos`, so an exact name+flags boundary tie does NOT
-    /// extend: the open run's max (`pos` large) is not `<=` the incoming min
-    /// (`pos` reset). Parity-safe because `pos` is not serialized. Uses the lex
-    /// comparator; the natural comparator shares the same `pos` tie-break.
+    /// The ARENA path never sets `pos` (it breaks ties by arena offset in the
+    /// sort comparator, not via `set_position`), so every arena queryname key has
+    /// `pos == 0`. An exact name+flags boundary tie therefore compares `Equal` and
+    /// the run EXTENDS — this is the real production behaviour, and it is
+    /// parity-safe (see the module docs: extend-vs-split is byte-identical).
     #[test]
-    fn queryname_exact_name_tie_does_not_extend_due_to_pos() {
-        // Same name + flags, differing only in the intra-chunk ingest position:
-        // the open run's max record was ingested later (larger pos) than the
-        // incoming chunk's first record (pos reset near 0).
-        let mut open_max = RawQuerynameLexKey::new(b"readAAA".to_vec(), 0);
-        open_max.set_position(9);
-        let mut incoming_min = RawQuerynameLexKey::new(b"readAAA".to_vec(), 0);
-        incoming_min.set_position(0);
+    fn queryname_exact_name_tie_with_default_pos_extends() {
+        // As built by the arena ingest: pos defaults to 0 on both sides.
+        let open_max = RawQuerynameLexKey::new(b"readAAA".to_vec(), 0);
+        let incoming_min = RawQuerynameLexKey::new(b"readAAA".to_vec(), 0);
+        assert_eq!(open_max.name(), incoming_min.name());
 
         let open = RunBound::QuerynameLex(open_max);
         let incoming = RunBound::QuerynameLex(incoming_min);
         assert!(
-            !open.precedes_or_equal(&incoming),
-            "an exact name tie must NOT extend: pos makes max > min"
+            open.precedes_or_equal(&incoming),
+            "with the default pos==0 the arena builds, an exact tie extends"
         );
+    }
+
+    /// `RunBound` compares the *full* key, so its comparator honours the `pos`
+    /// tie-break when the two keys carry different `pos` values. This pins the
+    /// comparator itself; note the differing-`pos` state does NOT arise in the
+    /// arena path (see `queryname_exact_name_tie_with_default_pos_extends`) — it
+    /// is only reachable through the owned engine's `set_position`.
+    #[test]
+    fn run_bound_queryname_compare_honours_pos_tiebreak() {
+        let mut later = RawQuerynameLexKey::new(b"readAAA".to_vec(), 0);
+        later.set_position(9);
+        let mut earlier = RawQuerynameLexKey::new(b"readAAA".to_vec(), 0);
+        earlier.set_position(0);
+
+        // Same name+flags; larger pos does not precede-or-equal the smaller pos.
+        assert!(!RunBound::QuerynameLex(later).precedes_or_equal(&RunBound::QuerynameLex(earlier)));
     }
 
     /// A strictly-smaller queryname name in the open run's max still extends

--- a/crates/fgumi-sort/src/template_arena.rs
+++ b/crates/fgumi-sort/src/template_arena.rs
@@ -30,6 +30,7 @@ use crate::inline::{
     TemplateRecordRef, TertKey32, parallel_radix_sort_template_refs, radix_sort_template_refs,
 };
 use crate::ref_sort::PARALLEL_SORT_THRESHOLD;
+use crate::run_bound::RunBound;
 use crate::{SpillCodec, frame_keyed_record_into, write_sorted_chunk_inmem};
 use fgumi_raw_bam::{RawRecordView, SamTag};
 
@@ -100,6 +101,36 @@ impl TemplateMemChunk {
     #[must_use]
     pub fn record_bytes(&self, i: usize) -> &[u8] {
         with_template_chunk!(self, c => c.record_bytes(i))
+    }
+
+    /// The chunk's minimum sort key (`key_at(0)`) as an owned [`RunBound`], or
+    /// `None` if the chunk is empty. The variant matches this chunk's narrowed
+    /// template lane. Records are pre-sorted, so this is `O(1)`.
+    #[must_use]
+    pub fn min_bound(&self) -> Option<RunBound> {
+        if self.is_empty() {
+            return None;
+        }
+        Some(match self {
+            TemplateMemChunk::K24(c) => RunBound::TemplateK24(*c.key_at(0)),
+            TemplateMemChunk::Cb32(c) => RunBound::TemplateCb32(*c.key_at(0)),
+            TemplateMemChunk::Tert32(c) => RunBound::TemplateTert32(*c.key_at(0)),
+            TemplateMemChunk::K40(c) => RunBound::TemplateK40(*c.key_at(0)),
+        })
+    }
+
+    /// The chunk's maximum sort key (`key_at(len - 1)`) as an owned [`RunBound`],
+    /// or `None` if the chunk is empty. The variant matches this chunk's
+    /// narrowed template lane. Records are pre-sorted, so this is `O(1)`.
+    #[must_use]
+    pub fn max_bound(&self) -> Option<RunBound> {
+        let last = self.len().checked_sub(1)?;
+        Some(match self {
+            TemplateMemChunk::K24(c) => RunBound::TemplateK24(*c.key_at(last)),
+            TemplateMemChunk::Cb32(c) => RunBound::TemplateCb32(*c.key_at(last)),
+            TemplateMemChunk::Tert32(c) => RunBound::TemplateTert32(*c.key_at(last)),
+            TemplateMemChunk::K40(c) => RunBound::TemplateK40(*c.key_at(last)),
+        })
     }
 
     /// Frame the `i`th record into `out` in the spill layout
@@ -451,5 +482,51 @@ impl TemplateArenaAccumulator {
             // Share the holder, not a new one: see the field's doc.
             sort_pool: Arc::clone(&self.sort_pool),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `TemplateKey24` with the given `primary` lane (the leading comparison
+    /// field); other lanes zeroed. Enough to order bounds in these tests.
+    fn k24(primary: u64) -> TemplateKey24 {
+        TemplateKey24 { primary, secondary: 0, name_hash_upper: 0 }
+    }
+
+    /// Build a K24 lane chunk from pre-sorted `(primary, body)` records (the seal
+    /// path always produces sorted chunks; `from_owned_records` preserves order).
+    fn k24_chunk(records: Vec<(u64, Vec<u8>)>) -> TemplateMemChunk {
+        TemplateMemChunk::K24(InMemoryChunk::from_owned_records(
+            records.into_iter().map(|(p, b)| (k24(p), b)).collect(),
+        ))
+    }
+
+    #[test]
+    fn empty_template_chunk_has_no_bounds() {
+        let chunk = k24_chunk(Vec::new());
+        assert_eq!(chunk.min_bound(), None);
+        assert_eq!(chunk.max_bound(), None);
+    }
+
+    #[test]
+    fn template_bounds_are_first_and_last_keys() {
+        let chunk = k24_chunk(vec![(10, vec![0xAA; 4]), (20, vec![0xBB; 4]), (30, vec![0xCC; 4])]);
+        assert_eq!(chunk.min_bound(), Some(RunBound::TemplateK24(k24(10))));
+        assert_eq!(chunk.max_bound(), Some(RunBound::TemplateK24(k24(30))));
+    }
+
+    #[test]
+    fn contiguous_template_chunks_extend_overlapping_do_not() {
+        let first = k24_chunk(vec![(10, vec![1; 4]), (20, vec![1; 4])]);
+        let contiguous = k24_chunk(vec![(20, vec![1; 4]), (30, vec![1; 4])]);
+        let overlapping = k24_chunk(vec![(15, vec![1; 4]), (25, vec![1; 4])]);
+
+        let open_max = first.max_bound().unwrap();
+        // second chunk's min (20) >= open run max (20) → extend (content tie).
+        assert!(open_max.precedes_or_equal(&contiguous.min_bound().unwrap()));
+        // overlapping chunk's min (15) < open run max (20) → new run.
+        assert!(!open_max.precedes_or_equal(&overlapping.min_bound().unwrap()));
     }
 }


### PR DESCRIPTION
The arena spill path wrote one file per sorted chunk, so an already-sorted input produced an N-way final merge — a +3.4% regression vs the owned engine at 16 threads (I/O-bound). `SpillGather` becomes the arena's run-former: it coalesces contiguous sorted chunks into one physical run (`file_id` = the run's first chunk's seq), matching the owned `RawExternalSorter`'s `RunFormer`, so a sorted input collapses to a single merge source.

A run's final block is withheld and closed lazily (extend vs. new run decided when the next chunk arrives, or on Residual/AllAnnounced/drain); ordinals are minted at emission to keep the reorder stream dense; `AllAnnounced.slot_count` is rewritten to the run count. The read side is unchanged.

Stacked on PR A. Validated: `cargo ci-test` green; EC2 on the 43 GB / 779.8M-record coordinate-sorted `1kg-wgs-HG00096.bam` (c8g.4xlarge, gp3 500 MB/s) — t16 +0.96% (was +3.4%), t8 −10.4%, t4 −17.8%, output byte-identical to the owned engine (md5 parity across all records).

Reviewed with a multi-agent gauntlet + a CodeRabbit-style pass; fixes in the final commit. Reading order: RunBound → SpillGather run-former → stats → tests → review hardening.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: output changes for sorted spill inputs, pinned by byte-identical parity and run-coalescing tests; `unsafe` changes: none; memory, queue, and thread/backpressure policy changes: none.

- Adds `RunBound` for type-safe comparison of supported sort-key variants.
- Adds minimum and maximum bounds to `MemoryChunkErased` and `TemplateMemChunk`.
- Coalesces contiguous spill chunks into physical runs in `SpillGather`.
- Assigns final-block ordinals at emission and reports formed runs through `AllAnnounced.slot_count`.
- Adds coverage for run boundaries, empty chunks, presorted and shuffled inputs, full BAM/arena paths, and output parity.
- Centralizes run-formation logging.
- Validation: `cargo ci-test` passes. T16 overhead improves from +3.4% to +0.96% versus the owned engine, with further improvements at t8 and t4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->