### PR TITLE
feat(sort): restore --read-streams on the arena chain via a concurrent scatter reader

### DIFF
--- a/crates/fgumi-bam-io/src/lib.rs
+++ b/crates/fgumi-bam-io/src/lib.rs
@@ -23,6 +23,7 @@ pub mod progress;
 pub mod reader;
 pub mod reorder;
 pub mod sam_input;
+pub mod scatter_reader;
 pub mod writer;
 
 pub(crate) mod vendored;

--- a/crates/fgumi-bam-io/src/lib.rs
+++ b/crates/fgumi-bam-io/src/lib.rs
@@ -37,7 +37,7 @@ pub use paths::{is_stdin_path, is_stdout_path};
 pub use progress::ProgressTracker;
 pub use reader::{
     BamReaderAuto, BgzfReaderEnum, ChainedReader, FgumiBgzfReader, PipelineReaderOpts,
-    RawBamReaderAuto, TeeReader, create_bam_reader, create_bam_reader_for_pipeline,
+    RawBamReaderAuto, ReadStreams, TeeReader, create_bam_reader, create_bam_reader_for_pipeline,
     create_bam_reader_for_pipeline_with_opts, create_bam_reader_with_opts, create_raw_bam_reader,
     create_raw_bam_reader_from_stream_with_opts, create_raw_bam_reader_with_opts, make_bgzf_reader,
     open_normalized_input, read_header_and_replay, read_prefix,

--- a/crates/fgumi-bam-io/src/reader.rs
+++ b/crates/fgumi-bam-io/src/reader.rs
@@ -236,6 +236,49 @@ pub type BamReaderAuto = noodles::bam::io::Reader<BgzfReaderEnum>;
 /// Type alias for a raw BAM reader that supports both single and multi-threaded BGZF.
 pub type RawBamReaderAuto = RawBamReader<BgzfReaderEnum>;
 
+/// Read-stream policy for a seekable BAM/SAM source: how many concurrent
+/// positional reads to issue per fill window.
+///
+/// Ports the semantics of fgumi v0.7.0's `fgumi sort --read-streams` flag. The
+/// mechanism (concurrent positional reads that raise the device's read queue
+/// depth) lives in the `scatter_reader` module; on a slow, deep-queue device
+/// (e.g. EBS gp3) issuing several reads at once is markedly faster than the
+/// single outstanding read a plain reader issues.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ReadStreams {
+    /// Measure the device's single-stream throughput once, then pick a stream
+    /// count from it. The default.
+    #[default]
+    Auto,
+    /// Exactly this many concurrent streams; `1` is the plain sequential /
+    /// async-prefetch reader (no scatter).
+    Fixed(usize),
+}
+
+impl std::fmt::Display for ReadStreams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Auto => f.write_str("auto"),
+            Self::Fixed(n) => write!(f, "{n}"),
+        }
+    }
+}
+
+impl std::str::FromStr for ReadStreams {
+    type Err = String;
+
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
+        if text.eq_ignore_ascii_case("auto") {
+            return Ok(Self::Auto);
+        }
+        match text.parse::<usize>() {
+            Ok(0) => Err("--read-streams must be `auto` or at least 1".to_string()),
+            Ok(n) => Ok(Self::Fixed(n)),
+            Err(_) => Err(format!("expected `auto` or a positive number, got `{text}`")),
+        }
+    }
+}
+
 /// Options controlling how [`create_bam_reader_for_pipeline_with_opts`] opens
 /// and wraps its input file.
 #[derive(Debug, Clone, Copy)]
@@ -812,9 +855,41 @@ mod tests {
     use noodles::sam::header::record::value::{Map, map::ReferenceSequence};
     use rstest::rstest;
     use std::num::NonZeroUsize;
+    use std::str::FromStr;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tempfile::NamedTempFile;
+
+    #[rstest]
+    #[case::auto_lower("auto", ReadStreams::Auto)]
+    #[case::auto_mixed_case("Auto", ReadStreams::Auto)]
+    #[case::one("1", ReadStreams::Fixed(1))]
+    #[case::four("4", ReadStreams::Fixed(4))]
+    fn read_streams_from_str_accepts_valid(#[case] text: &str, #[case] expected: ReadStreams) {
+        assert_eq!(ReadStreams::from_str(text).expect("valid"), expected);
+    }
+
+    #[rstest]
+    #[case::zero("0")]
+    #[case::negative("-1")]
+    #[case::garbage("many")]
+    fn read_streams_from_str_rejects_invalid(#[case] text: &str) {
+        assert!(ReadStreams::from_str(text).is_err(), "'{text}' must be rejected");
+    }
+
+    #[rstest]
+    #[case::auto(ReadStreams::Auto, "auto")]
+    #[case::one(ReadStreams::Fixed(1), "1")]
+    #[case::four(ReadStreams::Fixed(4), "4")]
+    fn read_streams_display_round_trips(#[case] value: ReadStreams, #[case] expected: &str) {
+        assert_eq!(value.to_string(), expected);
+        assert_eq!(ReadStreams::from_str(expected).expect("round-trip"), value);
+    }
+
+    #[test]
+    fn read_streams_default_is_auto() {
+        assert_eq!(ReadStreams::default(), ReadStreams::Auto);
+    }
 
     fn create_test_header() -> Header {
         let mut builder = Header::builder();

--- a/crates/fgumi-bam-io/src/reader.rs
+++ b/crates/fgumi-bam-io/src/reader.rs
@@ -241,7 +241,7 @@ pub type RawBamReaderAuto = RawBamReader<BgzfReaderEnum>;
 ///
 /// Ports the semantics of fgumi v0.7.0's `fgumi sort --read-streams` flag. The
 /// mechanism (concurrent positional reads that raise the device's read queue
-/// depth) lives in the `scatter_reader` module; on a slow, deep-queue device
+/// depth) lives in [`crate::scatter_reader`]; on a slow, deep-queue device
 /// (e.g. EBS gp3) issuing several reads at once is markedly faster than the
 /// single outstanding read a plain reader issues.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]

--- a/crates/fgumi-bam-io/src/reader.rs
+++ b/crates/fgumi-bam-io/src/reader.rs
@@ -300,11 +300,23 @@ pub struct PipelineReaderOpts {
     /// `fgumi_lib`). Defaults to `true` (verify) — the safe, pre-existing
     /// behavior.
     pub verify_crc: bool,
+    /// Concurrent positional-read policy for seekable regular-file inputs.
+    ///
+    /// `Fixed(1)` (the default) is the plain sequential / async-prefetch reader
+    /// that every command except `fgumi sort` uses — only `sort` sets this from
+    /// its own `--read-streams` flag. A higher count (or `Auto`) selects the
+    /// [`crate::scatter_reader::ScatterReader`] for seekable files; non-seekable
+    /// inputs (stdin, pipes) fall back to the sequential/async reader regardless.
+    pub read_streams: ReadStreams,
 }
 
 impl Default for PipelineReaderOpts {
     fn default() -> Self {
-        Self { async_reader: false, verify_crc: true }
+        // NOTE: `Fixed(1)`, NOT `ReadStreams::default()` (which is `Auto`). Every
+        // non-sort command relies on `..Default::default()` keeping today's
+        // sequential/async behavior; defaulting to `Auto` here would silently
+        // turn on scatter-read probing for the whole codebase.
+        Self { async_reader: false, verify_crc: true, read_streams: ReadStreams::Fixed(1) }
     }
 }
 
@@ -455,19 +467,37 @@ fn open_normalized_with_opts(
         // failure is logged and ignored. On non-Linux targets this is a no-op.
         crate::os_hints::advise_sequential(&file);
 
-        if opts.async_reader {
-            log::info!(
-                "async {} enabled: spawning fgumi-prefetch thread for {}",
-                label,
-                path.display()
-            );
-            Box::new(crate::prefetch_reader::PrefetchReader::from_file(file))
-        } else {
-            Box::new(file)
-        }
+        build_file_reader(file, path, &opts, label)?
     };
 
     crate::sam_input::normalize_to_bgzf(opened, path)
+}
+
+/// Choose the reader for an open regular file: the concurrent
+/// [`crate::scatter_reader::ScatterReader`] when `--read-streams` asks for more
+/// than one stream and the file is seekable (Unix only), otherwise the plain
+/// sequential / async-prefetch reader. The scatter-vs-fallback decision (and its
+/// "requested but unavailable" warning) is shared with `read_bam`'s entry point
+/// via [`crate::scatter_reader::decide_reader`] so the two cannot drift.
+fn build_file_reader(
+    file: File,
+    path: &Path,
+    opts: &PipelineReaderOpts,
+    label: &str,
+) -> Result<Box<dyn Read + Send>> {
+    let file = match crate::scatter_reader::decide_reader(file, opts.read_streams, path, label)
+        .with_context(|| format!("open scatter reader for {}", path.display()))?
+    {
+        crate::scatter_reader::ScatterDecision::Scatter(scatter) => return Ok(scatter),
+        crate::scatter_reader::ScatterDecision::Fallback(file) => file,
+    };
+
+    Ok(if opts.async_reader {
+        log::info!("async {label} enabled: spawning fgumi-prefetch thread for {}", path.display());
+        Box::new(crate::prefetch_reader::PrefetchReader::from_file(file))
+    } else {
+        Box::new(file)
+    })
 }
 
 /// Open `path` as a BGZF byte stream, transcoding it if it is uncompressed SAM.
@@ -889,6 +919,16 @@ mod tests {
     #[test]
     fn read_streams_default_is_auto() {
         assert_eq!(ReadStreams::default(), ReadStreams::Auto);
+    }
+
+    #[test]
+    fn pipeline_reader_opts_default_read_streams_is_fixed_one() {
+        // Load-bearing: the `PipelineReaderOpts` Default deliberately overrides
+        // the `ReadStreams` enum default (`Auto`) with `Fixed(1)`, because every
+        // non-sort command builds its opts via `..Default::default()`. A refactor
+        // that let this fall back to `Auto` would silently enable scatter-read
+        // probing across the whole codebase, so pin it.
+        assert_eq!(PipelineReaderOpts::default().read_streams, ReadStreams::Fixed(1));
     }
 
     fn create_test_header() -> Header {

--- a/crates/fgumi-bam-io/src/scatter_reader.rs
+++ b/crates/fgumi-bam-io/src/scatter_reader.rs
@@ -1,0 +1,1013 @@
+//! Concurrent positional-read source that raises a device's read queue depth.
+//!
+//! On a slow, deep-queue device (EBS gp3 is the motivating case) a single
+//! outstanding `read()` leaves most of the device's bandwidth idle: gp3
+//! sustains ~358 MB/s at queue-depth-1 but ~1177 MB/s with four reads in
+//! flight. [`ScatterReader`] cuts each fill window into N byte-range slices,
+//! fetches them with independent concurrent positional reads
+//! (`pread`/[`std::os::unix::fs::FileExt::read_at`]), reassembles them **in file
+//! order**, and presents the result as an ordinary forward [`Read`] stream —
+//! so the downstream BGZF framer is untouched. This ports the mechanism of
+//! fgumi v0.7.0's `fgumi sort --read-streams` flag (PRs #838/#846) onto the
+//! current chain source.
+//!
+//! No `unsafe`: each slice is read into a `Vec<u8>` owned solely by the scoped
+//! thread that fills it (via [`std::thread::scope`]), and positional reads take
+//! `&self` (POSIX `pread(2)` touches no shared file offset), so concurrent
+//! reads on a shared `Arc<File>` need no synchronization.
+
+use std::io::{self, Read};
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Target aggregate throughput the [`ReadStreams::Auto`] stream count is chosen
+/// to clear (`ceil(target / measured)`), from PR #846 (b358928f). Set from what
+/// the consumer (decode + sort) can absorb, not the device — there is no point
+/// reading faster than the pipeline can process. Validated on the arena chain:
+/// a 38 GB coordinate sort on EBS gp3 (500 MB/s) ran ~14% faster at four streams
+/// than at one, and `Auto` resolved to four there, as designed.
+///
+/// [`ReadStreams::Auto`]: crate::ReadStreams::Auto
+pub(crate) const AUTO_TARGET_BYTES_PER_SEC: f64 = 1.2e9;
+
+/// Upper bound on the chosen stream count (b358928f / 9a80d7fe). Applies to both
+/// the `Auto` probe outcome and an explicit `Fixed(n)` (clamped in
+/// [`ScatterReader::from_parts`]).
+pub(crate) const MAX_STREAMS: usize = 8;
+
+/// Number of fills read at a single stream before `Auto` commits to a count.
+/// While probing, `active_streams` is 1, so each fill is a single positional
+/// read — the same queue depth `Fixed(1)` would use, and the throughput the
+/// probe is trying to measure. (It still travels `ScatterReader`'s own per-fill
+/// buffer path, not the bare-`File` path `Fixed(1)` takes, so it is cheap but
+/// not literally free.)
+pub(crate) const AUTO_PROBE_FILLS: usize = 8;
+
+/// Total bytes per fill window, split across the active stream count. Matches
+/// `PrefetchReader`'s chunk size.
+pub(crate) const DEFAULT_FILL_SIZE: usize = 4 * 1024 * 1024;
+
+/// Smallest slice a fill is split into. A window smaller than
+/// `active_streams * MIN_SLICE_SIZE` uses fewer, larger slices rather than many
+/// tiny reads whose per-read overhead would swamp the queue-depth win.
+pub(crate) const MIN_SLICE_SIZE: usize = 64 * 1024;
+
+use crate::ReadStreams;
+
+/// A byte-addressable source supporting concurrent positional reads.
+///
+/// Exists as a seam so [`ScatterReader`]'s reassembly / probe / fallback logic
+/// can be unit-tested against an in-memory or fault-injecting double without a
+/// real file.
+pub trait PositionalSource: Send + Sync {
+    /// Read starting at `offset` into `buf`, returning the number of bytes read
+    /// (may be short, as [`Read::read`]; `0` means EOF at `offset`).
+    ///
+    /// # Errors
+    /// Propagates any I/O error from the underlying source.
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize>;
+
+    /// Total length of the source in bytes.
+    ///
+    /// # Errors
+    /// Propagates any I/O error from querying the source's length.
+    fn byte_len(&self) -> io::Result<u64>;
+}
+
+#[cfg(unix)]
+impl PositionalSource for std::fs::File {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+        std::os::unix::fs::FileExt::read_at(self, buf, offset)
+    }
+
+    fn byte_len(&self) -> io::Result<u64> {
+        Ok(self.metadata()?.len())
+    }
+}
+
+/// Whether `file` supports the scatter reader's concurrent positional reads.
+///
+/// Regular files only: a FIFO or socket opened by path fails `pread(2)` with
+/// `ESPIPE`, so callers fall back to the sequential/async reader rather than
+/// fail the run over a performance optimization. A `metadata()` failure (e.g. a
+/// race with deletion) is treated as not-capable.
+#[cfg(unix)]
+#[must_use]
+pub fn is_scatter_capable(file: &std::fs::File) -> bool {
+    file.metadata().map(|m| m.is_file()).unwrap_or(false)
+}
+
+/// Non-Unix targets have no `read_at`; the scatter path is never selected.
+#[cfg(not(unix))]
+#[must_use]
+pub fn is_scatter_capable(_file: &std::fs::File) -> bool {
+    false
+}
+
+/// The reader [`decide_reader`] selected for an open regular `file`.
+///
+/// The scatter case is boxed as `dyn Read` rather than a concrete
+/// `ScatterReader<File>` so the type is well-formed on non-Unix targets too
+/// (where `File` is not a [`PositionalSource`] and the variant is never built).
+pub enum ScatterDecision {
+    /// The input is seekable and `--read-streams` asked for concurrency: read it
+    /// through this scatter reader (a boxed [`ScatterReader`]).
+    Scatter(Box<dyn Read + Send>),
+    /// Scatter did not apply (`Fixed(1)`, a non-seekable input, or a non-Unix
+    /// platform): the caller reads `file` with its own sequential/async reader.
+    Fallback(std::fs::File),
+}
+
+/// Decide how to read an open regular `file` under the `--read-streams` policy.
+///
+/// Centralizes the scatter-vs-sequential decision (and its warning) so the two
+/// production entry points — `open_normalized_with_opts` (the sort chain) and
+/// [`read_bam`](crate) — cannot drift. Returns [`ScatterDecision::Scatter`] when
+/// `read_streams` requests concurrency and `file` is a seekable regular file;
+/// otherwise [`ScatterDecision::Fallback`], handing `file` back for the caller's
+/// own sequential/async reader. Warns only when the user *explicitly* asked for
+/// `Fixed(n>1)` that cannot be honored — `Auto` is a best-effort default and
+/// falls back silently. `label` names the source in the scatter info log.
+///
+/// # Errors
+/// Returns an I/O error only if the seekable file's length cannot be read.
+pub fn decide_reader(
+    file: std::fs::File,
+    read_streams: ReadStreams,
+    path: &Path,
+    label: &str,
+) -> io::Result<ScatterDecision> {
+    // `Fixed(1)` is the plain reader: never scatter, never warn.
+    if read_streams == ReadStreams::Fixed(1) {
+        return Ok(ScatterDecision::Fallback(file));
+    }
+    #[cfg(unix)]
+    {
+        if is_scatter_capable(&file) {
+            log::info!("read-streams={read_streams}: scatter {label} on {}", path.display());
+            return Ok(ScatterDecision::Scatter(Box::new(ScatterReader::from_file(
+                file,
+                read_streams,
+            )?)));
+        }
+        warn_read_streams_unavailable(
+            read_streams,
+            &path.display().to_string(),
+            "is not a seekable regular file",
+        );
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = label;
+        warn_read_streams_unavailable(
+            read_streams,
+            &path.display().to_string(),
+            "is not supported on this platform",
+        );
+    }
+    Ok(ScatterDecision::Fallback(file))
+}
+
+/// Warn that `--read-streams` cannot be honored for `subject` (`reason` says
+/// why), but only when the user *explicitly* requested concurrency (`Fixed(n>1)`).
+/// `Auto` is the default and falls back silently; `Fixed(1)` never reaches here.
+/// Shared by [`decide_reader`] and the stdin paths so the wording is identical
+/// everywhere a non-seekable input drops the knob.
+pub fn warn_read_streams_unavailable(read_streams: ReadStreams, subject: &str, reason: &str) {
+    if let ReadStreams::Fixed(n) = read_streams
+        && n > 1
+    {
+        log::warn!(
+            "--read-streams={n} requested but {subject} {reason}; \
+             falling back to the sequential/async reader"
+        );
+    }
+}
+
+/// Pick a stream count from a measured single-stream throughput.
+///
+/// Pure and total: a non-positive measurement (which should not happen, but a
+/// probe over an empty file could report it) degrades to `1` rather than
+/// dividing by zero. The result is clamped to `[1, MAX_STREAMS]`.
+#[must_use]
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "n is clamped into (1.0, MAX_STREAMS as f64) before the cast, so \
+              the usize conversion is exact and non-negative"
+)]
+pub(crate) fn choose_stream_count(measured_bytes_per_sec: f64) -> usize {
+    if measured_bytes_per_sec <= 0.0 {
+        return 1;
+    }
+    let n = (AUTO_TARGET_BYTES_PER_SEC / measured_bytes_per_sec).ceil();
+    if n <= 1.0 {
+        1
+    } else if n >= MAX_STREAMS as f64 {
+        MAX_STREAMS
+    } else {
+        n as usize
+    }
+}
+
+/// Read exactly `buf.len()` bytes at `offset`, looping over short reads and
+/// retrying `Interrupted`. A `0`-byte read before the buffer is full means the
+/// source ended earlier than its reported length promised.
+fn read_at_exact<S: PositionalSource + ?Sized>(
+    source: &S,
+    buf: &mut [u8],
+    offset: u64,
+) -> io::Result<()> {
+    let mut filled = 0usize;
+    while filled < buf.len() {
+        match source.read_at(&mut buf[filled..], offset + filled as u64) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "scatter reader hit EOF before filling a slice",
+                ));
+            }
+            Ok(n) => filled += n,
+            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
+/// Split `[start, start + window)` into up to `max_slices` disjoint contiguous
+/// ranges, each at least `min_slice` bytes (except possibly the final one when
+/// `window` is not a multiple). Returns `(offset, len)` pairs in file order.
+fn slice_ranges(
+    start: u64,
+    window: usize,
+    max_slices: usize,
+    min_slice: usize,
+) -> Vec<(u64, usize)> {
+    debug_assert!(window > 0 && max_slices >= 1 && min_slice >= 1);
+    let by_min = window.div_ceil(min_slice).max(1);
+    let n = max_slices.min(by_min);
+    let base = window / n;
+    let rem = window % n;
+    let mut ranges = Vec::with_capacity(n);
+    let mut off = start;
+    for i in 0..n {
+        let len = base + usize::from(i < rem);
+        if len == 0 {
+            continue;
+        }
+        ranges.push((off, len));
+        off += len as u64;
+    }
+    ranges
+}
+
+/// A forward [`Read`] stream backed by concurrent positional reads.
+///
+/// See the module docs for the mechanism. Construct with [`Self::from_file`]
+/// (the production entry point); the crate-internal `new` / `with_params`
+/// constructors build one over any [`PositionalSource`] for tests.
+pub struct ScatterReader<S: PositionalSource + 'static> {
+    source: Arc<S>,
+    file_len: u64,
+    next_offset: u64,
+    /// Resolved stream count. Under `Auto` it starts at 1 and jumps once, after
+    /// [`AUTO_PROBE_FILLS`] probe fills.
+    active_streams: usize,
+    probing: bool,
+    probe_fills_done: usize,
+    probe_bytes: u64,
+    probe_elapsed: Duration,
+    /// The assembled current fill and how far it has been consumed.
+    current: Option<(Vec<u8>, usize)>,
+    /// An error observed while assembling a fill, surfaced only after the bytes
+    /// that were successfully read before it have been served.
+    pending_error: Option<io::Error>,
+    fill_size: usize,
+    min_slice_size: usize,
+    /// Test hook: when set, the `Auto` probe uses this throughput instead of the
+    /// wall-clock measurement, so probe-outcome tests are deterministic rather
+    /// than dependent on real timing under a loaded test runner. Always `None`
+    /// in production.
+    forced_throughput: Option<f64>,
+}
+
+impl<S: PositionalSource + 'static> ScatterReader<S> {
+    fn from_parts(
+        source: S,
+        file_len: u64,
+        read_streams: ReadStreams,
+        fill_size: usize,
+        min_slice_size: usize,
+    ) -> Self {
+        let (active_streams, probing) = match read_streams {
+            ReadStreams::Auto => (1, true),
+            // Clamp an explicit count to the same `[1, MAX_STREAMS]` ceiling the
+            // `Auto` path uses (`choose_stream_count`), so `--read-streams 1000`
+            // cannot spawn far more concurrent reads per fill than the heuristic
+            // ever would.
+            ReadStreams::Fixed(n) => (n.clamp(1, MAX_STREAMS), false),
+        };
+        Self {
+            source: Arc::new(source),
+            file_len,
+            next_offset: 0,
+            active_streams,
+            probing,
+            probe_fills_done: 0,
+            probe_bytes: 0,
+            probe_elapsed: Duration::ZERO,
+            current: None,
+            pending_error: None,
+            fill_size,
+            min_slice_size,
+            forced_throughput: None,
+        }
+    }
+
+    /// Construct from a generic source of known length. Not part of the crate's
+    /// public API — the production entry point is [`Self::from_file`], and tests
+    /// use `with_params` for custom fill/slice sizing.
+    #[must_use]
+    pub(crate) fn new(source: S, file_len: u64, read_streams: ReadStreams) -> Self {
+        Self::from_parts(source, file_len, read_streams, DEFAULT_FILL_SIZE, MIN_SLICE_SIZE)
+    }
+
+    /// Construct with explicit fill/slice sizing (used by tests to exercise
+    /// multi-fill / multi-slice behavior on small inputs).
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) fn with_params(
+        source: S,
+        file_len: u64,
+        read_streams: ReadStreams,
+        fill_size: usize,
+        min_slice_size: usize,
+    ) -> Self {
+        Self::from_parts(source, file_len, read_streams, fill_size.max(1), min_slice_size.max(1))
+    }
+
+    /// Currently-resolved stream count (for tests asserting the probe outcome).
+    #[cfg(test)]
+    pub(crate) fn active_streams(&self) -> usize {
+        self.active_streams
+    }
+
+    /// Force the `Auto` probe to resolve against a fixed throughput, making
+    /// probe-outcome tests deterministic (no wall-clock dependence).
+    #[cfg(test)]
+    pub(crate) fn force_probe_throughput(&mut self, bytes_per_sec: f64) {
+        self.forced_throughput = Some(bytes_per_sec);
+    }
+
+    /// Assemble the next fill window into `self.current`, recording any I/O
+    /// error in `self.pending_error` (after any bytes read before it). Never
+    /// returns an error itself: a fill that fails still serves whatever prefix
+    /// it read, then the stored error surfaces on the following `read`.
+    fn fill_next(&mut self) {
+        if self.next_offset >= self.file_len {
+            return;
+        }
+        let remaining = self.file_len - self.next_offset;
+        // `remaining` may exceed usize only on a 32-bit target with a file
+        // larger than 4 GiB; clamp to `fill_size` either way (a fill is never
+        // larger than `fill_size`), so the cast cannot truncate meaningfully.
+        let window = usize::try_from(remaining).unwrap_or(self.fill_size).min(self.fill_size);
+        let ranges =
+            slice_ranges(self.next_offset, window, self.active_streams, self.min_slice_size);
+
+        let start = if self.probing { Some(Instant::now()) } else { None };
+        let assembled: Result<Vec<u8>, (Vec<u8>, io::Error)> = if ranges.len() == 1 {
+            let (off, len) = ranges[0];
+            let mut buf = vec![0u8; len];
+            match read_at_exact(&*self.source, &mut buf, off) {
+                // A single-slice read has no successfully-read prefix to preserve.
+                Ok(()) => Ok(buf),
+                Err(e) => Err((Vec::new(), e)),
+            }
+        } else {
+            self.scatter_fill(&ranges)
+        };
+        if let Some(t) = start {
+            self.probe_bytes += window as u64;
+            self.probe_elapsed += t.elapsed();
+        }
+
+        match assembled {
+            Ok(buf) => {
+                self.current = Some((buf, 0));
+                self.next_offset += window as u64;
+            }
+            Err((prefix, err)) => {
+                // Serve whatever contiguous prefix was read, then surface the error.
+                self.next_offset += prefix.len() as u64;
+                if prefix.is_empty() {
+                    self.pending_error = Some(err);
+                } else {
+                    self.current = Some((prefix, 0));
+                    self.pending_error = Some(err);
+                }
+            }
+        }
+
+        if self.probing {
+            self.probe_fills_done += 1;
+            if self.probe_fills_done >= AUTO_PROBE_FILLS {
+                let secs = self.probe_elapsed.as_secs_f64();
+                // Precision loss is irrelevant: this is a throughput estimate
+                // over a few fills, fed straight into a ceil-and-cap.
+                #[allow(clippy::cast_precision_loss)]
+                let measured = if secs > 0.0 { self.probe_bytes as f64 / secs } else { 0.0 };
+                let throughput = self.forced_throughput.unwrap_or(measured);
+                self.active_streams = choose_stream_count(throughput);
+                self.probing = false;
+            }
+        }
+    }
+
+    /// Fetch every range concurrently (one scoped thread per range) and
+    /// reassemble in file order. On success returns the full window; on error
+    /// returns `(contiguous prefix successfully read, first error)`.
+    fn scatter_fill(&self, ranges: &[(u64, usize)]) -> Result<Vec<u8>, (Vec<u8>, io::Error)> {
+        let results: Vec<io::Result<Vec<u8>>> = std::thread::scope(|scope| {
+            let handles: Vec<_> = ranges
+                .iter()
+                .map(|&(off, len)| {
+                    let source = Arc::clone(&self.source);
+                    scope.spawn(move || {
+                        let mut buf = vec![0u8; len];
+                        read_at_exact(&*source, &mut buf, off)?;
+                        Ok(buf)
+                    })
+                })
+                .collect();
+            handles
+                .into_iter()
+                .map(|h| {
+                    h.join().unwrap_or_else(|_| {
+                        Err(io::Error::other("scatter reader slice thread panicked"))
+                    })
+                })
+                .collect()
+        });
+
+        // Concatenate slots in order until the first error. Slots are
+        // contiguous by construction, so the successes before the first failure
+        // form a valid forward prefix.
+        let mut assembled = Vec::new();
+        for result in results {
+            match result {
+                Ok(buf) => assembled.extend_from_slice(&buf),
+                Err(e) => return Err((assembled, e)),
+            }
+        }
+        Ok(assembled)
+    }
+}
+
+#[cfg(unix)]
+impl ScatterReader<std::fs::File> {
+    /// Construct from an open regular file (production entry point).
+    ///
+    /// # Errors
+    /// Returns an I/O error if the file's length cannot be read.
+    pub fn from_file(file: std::fs::File, read_streams: ReadStreams) -> io::Result<Self> {
+        let file_len = PositionalSource::byte_len(&file)?;
+        Ok(Self::new(file, file_len, read_streams))
+    }
+}
+
+impl<S: PositionalSource + 'static> Read for ScatterReader<S> {
+    fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+        if out.is_empty() {
+            return Ok(0);
+        }
+        loop {
+            if let Some((buf, pos)) = &mut self.current {
+                if *pos < buf.len() {
+                    let n = (buf.len() - *pos).min(out.len());
+                    out[..n].copy_from_slice(&buf[*pos..*pos + n]);
+                    *pos += n;
+                    return Ok(n);
+                }
+                self.current = None;
+            }
+            if let Some(err) = self.pending_error.take() {
+                return Err(err);
+            }
+            if self.next_offset >= self.file_len {
+                return Ok(0);
+            }
+            self.fill_next();
+            if self.current.is_none() && self.pending_error.is_none() {
+                return Ok(0);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "in-memory test doubles cast small, in-range offsets/lengths/bytes"
+)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use rstest::rstest;
+    use std::io::Write;
+    use std::thread::ThreadId;
+    use tempfile::NamedTempFile;
+
+    /// In-memory source of known bytes.
+    struct MemSource(Vec<u8>);
+
+    impl PositionalSource for MemSource {
+        fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+            let off = offset as usize;
+            if off >= self.0.len() {
+                return Ok(0);
+            }
+            let n = (self.0.len() - off).min(buf.len());
+            buf[..n].copy_from_slice(&self.0[off..off + n]);
+            Ok(n)
+        }
+        fn byte_len(&self) -> io::Result<u64> {
+            Ok(self.0.len() as u64)
+        }
+    }
+
+    /// A source that errors on any read whose range covers `fail_at`.
+    struct FaultySource {
+        data: Vec<u8>,
+        fail_at: u64,
+    }
+
+    impl PositionalSource for FaultySource {
+        fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+            let end = offset + buf.len() as u64;
+            if offset <= self.fail_at && self.fail_at < end {
+                return Err(io::Error::other("injected fault"));
+            }
+            let off = offset as usize;
+            if off >= self.data.len() {
+                return Ok(0);
+            }
+            let n = (self.data.len() - off).min(buf.len());
+            buf[..n].copy_from_slice(&self.data[off..off + n]);
+            Ok(n)
+        }
+        fn byte_len(&self) -> io::Result<u64> {
+            Ok(self.data.len() as u64)
+        }
+    }
+
+    /// A source that panics if read from any thread other than the constructing
+    /// one, and reports a controllable per-fill latency for the probe.
+    struct InstrumentedSource {
+        data: Vec<u8>,
+        owner: ThreadId,
+        per_read_sleep: Duration,
+    }
+
+    impl InstrumentedSource {
+        fn new(data: Vec<u8>, per_read_sleep: Duration) -> Self {
+            Self { data, owner: std::thread::current().id(), per_read_sleep }
+        }
+    }
+
+    impl PositionalSource for InstrumentedSource {
+        fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+            assert_eq!(
+                std::thread::current().id(),
+                self.owner,
+                "read issued off the owning thread",
+            );
+            if !self.per_read_sleep.is_zero() {
+                std::thread::sleep(self.per_read_sleep);
+            }
+            let off = offset as usize;
+            if off >= self.data.len() {
+                return Ok(0);
+            }
+            let n = (self.data.len() - off).min(buf.len());
+            buf[..n].copy_from_slice(&self.data[off..off + n]);
+            Ok(n)
+        }
+        fn byte_len(&self) -> io::Result<u64> {
+            Ok(self.data.len() as u64)
+        }
+    }
+
+    /// Thread-safe in-memory source with a controllable per-read latency (used
+    /// by the probe scale-up test, which legitimately fans out across threads).
+    struct TimedSource {
+        data: Vec<u8>,
+        per_read_sleep: Duration,
+    }
+
+    impl PositionalSource for TimedSource {
+        fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+            if !self.per_read_sleep.is_zero() {
+                std::thread::sleep(self.per_read_sleep);
+            }
+            let off = offset as usize;
+            if off >= self.data.len() {
+                return Ok(0);
+            }
+            let n = (self.data.len() - off).min(buf.len());
+            buf[..n].copy_from_slice(&self.data[off..off + n]);
+            Ok(n)
+        }
+        fn byte_len(&self) -> io::Result<u64> {
+            Ok(self.data.len() as u64)
+        }
+    }
+
+    /// A source whose reported `byte_len` overstates its backing data, so a read
+    /// that trusts the length hits EOF early — the truncation / delete-race case
+    /// that must fail closed rather than silently return a short clean stream.
+    struct ShortSource {
+        data: Vec<u8>,
+        claimed_len: u64,
+    }
+
+    impl PositionalSource for ShortSource {
+        fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+            let off = offset as usize;
+            if off >= self.data.len() {
+                return Ok(0);
+            }
+            let n = (self.data.len() - off).min(buf.len());
+            buf[..n].copy_from_slice(&self.data[off..off + n]);
+            Ok(n)
+        }
+        fn byte_len(&self) -> io::Result<u64> {
+            Ok(self.claimed_len)
+        }
+    }
+
+    /// Distinct-thread tracker shared between a [`ThreadTrackingSource`] and the
+    /// test, so the test can inspect it after the source has been moved into (and
+    /// dropped by) the reader.
+    type ThreadSet = Arc<std::sync::Mutex<std::collections::HashSet<ThreadId>>>;
+
+    /// Thread-safe source that records the distinct threads it was read from, so
+    /// a test can positively confirm the scatter path actually fanned reads out
+    /// across threads (rather than silently reading everything sequentially).
+    struct ThreadTrackingSource {
+        data: Vec<u8>,
+        threads: ThreadSet,
+    }
+
+    impl ThreadTrackingSource {
+        fn new(data: Vec<u8>) -> (Self, ThreadSet) {
+            let threads: ThreadSet =
+                Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
+            (Self { data, threads: Arc::clone(&threads) }, threads)
+        }
+    }
+
+    impl PositionalSource for ThreadTrackingSource {
+        fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+            self.threads.lock().expect("lock").insert(std::thread::current().id());
+            let off = offset as usize;
+            if off >= self.data.len() {
+                return Ok(0);
+            }
+            let n = (self.data.len() - off).min(buf.len());
+            buf[..n].copy_from_slice(&self.data[off..off + n]);
+            Ok(n)
+        }
+        fn byte_len(&self) -> io::Result<u64> {
+            Ok(self.data.len() as u64)
+        }
+    }
+
+    fn drain<S: PositionalSource + 'static>(mut r: ScatterReader<S>) -> io::Result<Vec<u8>> {
+        let mut out = Vec::new();
+        r.read_to_end(&mut out)?;
+        Ok(out)
+    }
+
+    // ---- choose_stream_count ----
+
+    #[rstest]
+    #[case::ebs_gp3_from_f13d1093(358_000_000.0, 4)]
+    #[case::instance_store_from_9a80d7fe(1_920_000_000.0, 1)]
+    #[case::just_under_target(1_500_000_000.0, 1)]
+    #[case::very_slow_device_caps_at_max(100_000_000.0, MAX_STREAMS)]
+    #[case::zero_is_defensive(0.0, 1)]
+    #[case::negative_is_defensive(-5.0, 1)]
+    fn choose_stream_count_matches_blueprint(#[case] measured: f64, #[case] expected: usize) {
+        assert_eq!(choose_stream_count(measured), expected);
+    }
+
+    #[rstest]
+    #[case::one(1, 1)]
+    #[case::within_ceiling(4, 4)]
+    #[case::at_ceiling(MAX_STREAMS, MAX_STREAMS)]
+    #[case::above_ceiling_clamps(1000, MAX_STREAMS)]
+    fn fixed_count_clamps_to_max_streams(#[case] requested: usize, #[case] expected: usize) {
+        // An explicit `--read-streams n` is bounded by the same ceiling the Auto
+        // heuristic uses; a huge value cannot spawn an unbounded fan-out per fill.
+        let reader = ScatterReader::with_params(
+            MemSource(vec![0u8; 8]),
+            8,
+            ReadStreams::Fixed(requested),
+            32,
+            4,
+        );
+        assert_eq!(reader.active_streams(), expected);
+    }
+
+    // ---- is_scatter_capable ----
+
+    #[cfg(unix)]
+    #[test]
+    fn regular_file_is_scatter_capable() {
+        let f = NamedTempFile::new().expect("temp");
+        assert!(is_scatter_capable(f.as_file()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn char_device_is_not_scatter_capable() {
+        let dev_null = std::fs::File::open("/dev/null").expect("open /dev/null");
+        assert!(!is_scatter_capable(&dev_null));
+    }
+
+    // ---- PositionalSource File impl ----
+
+    #[cfg(unix)]
+    #[test]
+    fn file_positional_source_reads_offsets() {
+        let mut f = NamedTempFile::new().expect("temp");
+        f.write_all(b"0123456789").expect("write");
+        f.flush().expect("flush");
+        let file = f.reopen().expect("reopen");
+        assert_eq!(PositionalSource::byte_len(&file).expect("len"), 10);
+        let mut buf = [0u8; 3];
+        let n = file.read_at(&mut buf, 4).expect("read_at");
+        assert_eq!(&buf[..n], b"456");
+    }
+
+    // ---- byte-identity (the load-bearing correctness gate) ----
+
+    proptest! {
+        #[test]
+        fn byte_identical_to_source(
+            data in proptest::collection::vec(any::<u8>(), 0..5000),
+            streams in prop::sample::select(vec![1usize, 2, 4, 8]),
+            fill in 1usize..64,
+            min_slice in 1usize..16,
+        ) {
+            let len = data.len() as u64;
+            let reader = ScatterReader::with_params(
+                MemSource(data.clone()),
+                len,
+                ReadStreams::Fixed(streams),
+                fill,
+                min_slice,
+            );
+            let out = drain(reader).expect("drain");
+            prop_assert_eq!(out, data);
+        }
+
+        #[test]
+        fn byte_identical_under_auto(
+            data in proptest::collection::vec(any::<u8>(), 0..5000),
+            fill in 1usize..64,
+            min_slice in 1usize..16,
+        ) {
+            let len = data.len() as u64;
+            let reader = ScatterReader::with_params(
+                MemSource(data.clone()),
+                len,
+                ReadStreams::Auto,
+                fill,
+                min_slice,
+            );
+            let out = drain(reader).expect("drain");
+            prop_assert_eq!(out, data);
+        }
+    }
+
+    // ---- EOF / short-file case table ----
+
+    #[rstest]
+    #[case::empty(0)]
+    #[case::one(1)]
+    #[case::just_under_fill(31)]
+    #[case::exactly_fill(32)]
+    #[case::just_over_fill(33)]
+    #[case::several_fills(32 * 3 + 17)]
+    fn round_trips_across_sizes_and_streams(
+        #[case] len: usize,
+        #[values(ReadStreams::Fixed(1), ReadStreams::Fixed(4), ReadStreams::Auto)]
+        streams: ReadStreams,
+    ) {
+        let data: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+        let mut reader =
+            ScatterReader::with_params(MemSource(data.clone()), len as u64, streams, 32, 4);
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).expect("read");
+        assert_eq!(out, data);
+        // A second read after EOF returns Ok(0) forever.
+        let mut extra = [0u8; 8];
+        assert_eq!(reader.read(&mut extra).expect("post-eof read"), 0);
+        assert_eq!(reader.read(&mut extra).expect("post-eof read"), 0);
+    }
+
+    // ---- error propagation ----
+
+    #[test]
+    fn serves_prefix_then_surfaces_error() {
+        // 200 bytes, fill 32, 4 streams: the first fill covers [0,32); put the
+        // fault at offset 40 so fill 1 succeeds and fill 2 ([32,64)) fails.
+        let data: Vec<u8> = (0..200).map(|i| (i % 251) as u8).collect();
+        let mut reader = ScatterReader::with_params(
+            FaultySource { data: data.clone(), fail_at: 40 },
+            200,
+            ReadStreams::Fixed(4),
+            32,
+            4,
+        );
+        let mut out = Vec::new();
+        let mut buf = [0u8; 16];
+        let mut err = None;
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => out.extend_from_slice(&buf[..n]),
+                Err(e) => {
+                    err = Some(e);
+                    break;
+                }
+            }
+        }
+        // Fill 1 ([0,32)) plus fill 2's contiguous prefix up to the failing
+        // slice ([32,40)) are delivered before the error surfaces; the slice
+        // covering offset 40 ([40,48)) is where it fails.
+        assert_eq!(out, data[..40]);
+        assert!(err.is_some(), "the injected fault must surface");
+    }
+
+    #[test]
+    fn single_slice_error_surfaces() {
+        // Fixed(1) always takes fill_next's single-slice branch (ranges.len() == 1).
+        // A fault in the first fill has no successfully-read prefix, so the error
+        // must surface on the first read with no bytes served.
+        let data: Vec<u8> = (0..200).map(|i| (i % 251) as u8).collect();
+        let mut reader = ScatterReader::with_params(
+            FaultySource { data, fail_at: 0 },
+            200,
+            ReadStreams::Fixed(1),
+            32,
+            4,
+        );
+        let mut buf = [0u8; 16];
+        let err = reader.read(&mut buf).expect_err("the single-slice fault must surface");
+        assert_eq!(err.to_string(), "injected fault");
+    }
+
+    #[test]
+    fn truncated_source_fails_closed_with_unexpected_eof() {
+        // A source that claims more bytes than it holds (truncation / delete race)
+        // must error, not silently feed a short-but-clean stream to the framer.
+        let data: Vec<u8> = (0..50).map(|i| (i % 251) as u8).collect();
+        let mut reader = ScatterReader::with_params(
+            ShortSource { data, claimed_len: 200 },
+            200,
+            ReadStreams::Fixed(1),
+            32,
+            4,
+        );
+        let mut out = Vec::new();
+        let err = reader.read_to_end(&mut out).expect_err("truncation must fail closed");
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    // ---- scatter positively engages under Fixed(n>1) ----
+
+    #[test]
+    fn fixed_four_fans_reads_across_multiple_threads() {
+        // The parity tests prove output is identical across stream counts, which by
+        // itself cannot distinguish "scatter engaged" from "flag silently ignored".
+        // This positively confirms Fixed(4) drives reads off the calling thread.
+        let len = 4096usize * 8;
+        let data: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+        let (source, threads) = ThreadTrackingSource::new(data.clone());
+        // A window (fill 4096) split 4 ways with min_slice 64 yields 4 slices → 4
+        // scoped threads per fill.
+        let reader =
+            ScatterReader::with_params(source, len as u64, ReadStreams::Fixed(4), 4096, 64);
+        let out = drain(reader).expect("drain");
+        assert_eq!(out, data, "scatter output must still be byte-identical");
+        let distinct = threads.lock().expect("lock").len();
+        assert!(distinct > 1, "Fixed(4) must fan reads across threads; saw {distinct} distinct");
+    }
+
+    // ---- Fixed(1) never spawns a thread ----
+
+    #[test]
+    fn fixed_one_never_leaves_the_calling_thread() {
+        let data: Vec<u8> = (0..500).map(|i| (i % 251) as u8).collect();
+        let reader = ScatterReader::with_params(
+            InstrumentedSource::new(data.clone(), Duration::ZERO),
+            500,
+            ReadStreams::Fixed(1),
+            32,
+            4,
+        );
+        // Would panic inside read_at if any read ran off the owning thread.
+        let out = drain(reader).expect("drain");
+        assert_eq!(out, data);
+    }
+
+    // ---- Auto probe transition ----
+
+    #[test]
+    fn auto_stays_at_one_until_the_probe_completes_then_scales() {
+        // Forced throughput removes wall-clock flakiness. 358 MB/s (the gp3
+        // measurement) resolves to 4 streams once the probe window elapses.
+        let fill = 4096usize;
+        let len = fill * (AUTO_PROBE_FILLS + 4);
+        let data: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+        // TimedSource is cross-thread safe (scaling up fans reads out); zero
+        // sleep since timing no longer matters.
+        let mut reader = ScatterReader::with_params(
+            TimedSource { data: data.clone(), per_read_sleep: Duration::ZERO },
+            len as u64,
+            ReadStreams::Auto,
+            fill,
+            64,
+        );
+        reader.force_probe_throughput(358_000_000.0);
+        assert_eq!(reader.active_streams(), 1, "must start at one stream");
+
+        let mut out = Vec::new();
+        let mut buf = [0u8; 1024];
+        loop {
+            let n = reader.read(&mut buf).expect("read");
+            if n == 0 {
+                break;
+            }
+            out.extend_from_slice(&buf[..n]);
+        }
+        assert_eq!(out, data, "output must be byte-identical regardless of probing");
+        assert_eq!(reader.active_streams(), 4, "358 MB/s must resolve to four streams");
+    }
+
+    #[test]
+    fn auto_stays_at_one_when_device_is_already_fast() {
+        // Forced 1.92 GB/s (the instance-store measurement) resolves to 1 stream,
+        // so the owner-checking source never sees an off-thread read.
+        let fill = 4096usize;
+        let len = fill * (AUTO_PROBE_FILLS + 2);
+        let data: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+        let mut reader = ScatterReader::with_params(
+            InstrumentedSource::new(data.clone(), Duration::ZERO),
+            len as u64,
+            ReadStreams::Auto,
+            fill,
+            64,
+        );
+        reader.force_probe_throughput(1_920_000_000.0);
+        // InstrumentedSource panics off-thread; if Auto wrongly scaled up on a
+        // fast device, the post-probe fills would spawn threads and panic.
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).expect("read");
+        assert_eq!(out, data);
+        assert_eq!(reader.active_streams(), 1, "a fast device stays at one stream");
+    }
+
+    // ---- slice_ranges cover the window exactly ----
+
+    #[rstest]
+    #[case::single(100, 1, 10)]
+    #[case::even_split(100, 4, 1)]
+    #[case::remainder(103, 4, 1)]
+    #[case::min_slice_limits_count(100, 8, 40)]
+    fn slice_ranges_cover_the_window(
+        #[case] window: usize,
+        #[case] max_slices: usize,
+        #[case] min_slice: usize,
+    ) {
+        let ranges = slice_ranges(1000, window, max_slices, min_slice);
+        assert!(!ranges.is_empty());
+        assert!(ranges.len() <= max_slices);
+        // Contiguous, starting at 1000, covering exactly `window` bytes.
+        let mut expected_off = 1000u64;
+        let mut total = 0usize;
+        for &(off, len) in &ranges {
+            assert_eq!(off, expected_off);
+            expected_off += len as u64;
+            total += len;
+        }
+        assert_eq!(total, window);
+    }
+}

--- a/crates/fgumi-pipeline-io/src/source/read_bam.rs
+++ b/crates/fgumi-pipeline-io/src/source/read_bam.rs
@@ -195,17 +195,44 @@ pub fn read_bam<P: AsRef<Path>>(
         .map_err(|e| io::Error::other(format!("create_raw_bam_reader_with_opts: {e}")))?;
 
     let file = File::open(path)?;
-    // Honor `async_reader` for the reopened raw block stream too — not just the
-    // temporary header reader above — so a regular file prefetches like the
-    // stdin path (`read_bam_stdin`) does. `verify_crc` does not apply here:
-    // `ReadBgzfBlocks` forwards compressed bytes without decoding them.
-    let reader: Box<dyn io::Read + Send> = if opts.async_reader {
+    let reader = build_source_reader(file, path, &opts)?;
+    Ok(read_bam_from_reader(reader, header, blocks_per_batch, output_byte_limit))
+}
+
+/// The plain sequential / async-prefetch reader (`--read-streams 1` and every
+/// non-sort command). `verify_crc` does not apply here — `ReadBgzfBlocks`
+/// forwards compressed bytes without decoding them.
+fn sequential_or_async_reader(
+    file: File,
+    path: &Path,
+    async_reader: bool,
+) -> Box<dyn io::Read + Send> {
+    if async_reader {
         log::info!("async read enabled: spawning fgumi-prefetch thread for {}", path.display());
         Box::new(fgumi_bam_io::prefetch_reader::PrefetchReader::from_file(file))
     } else {
         Box::new(io::BufReader::with_capacity(2 * 1024 * 1024, file))
-    };
-    Ok(read_bam_from_reader(reader, header, blocks_per_batch, output_byte_limit))
+    }
+}
+
+/// Pick the reader for a regular-file source: the concurrent
+/// [`fgumi_bam_io::scatter_reader::ScatterReader`] when `--read-streams` asks
+/// for more than one stream and the file is seekable, otherwise the sequential
+/// / async reader. The scatter-vs-fallback decision (and its warning) is shared
+/// with the sort chain's reader via [`fgumi_bam_io::scatter_reader::decide_reader`]
+/// so the two copies cannot drift; only the fallback reader differs (a 2 MiB
+/// `BufReader` here vs a bare `File` there).
+fn build_source_reader(
+    file: File,
+    path: &Path,
+    opts: &PipelineReaderOpts,
+) -> io::Result<Box<dyn io::Read + Send>> {
+    match fgumi_bam_io::scatter_reader::decide_reader(file, opts.read_streams, path, "reader")? {
+        fgumi_bam_io::scatter_reader::ScatterDecision::Scatter(scatter) => Ok(scatter),
+        fgumi_bam_io::scatter_reader::ScatterDecision::Fallback(file) => {
+            Ok(sequential_or_async_reader(file, path, opts.async_reader))
+        }
+    }
 }
 
 /// Stdin counterpart to [`read_bam`].
@@ -218,6 +245,14 @@ pub fn read_bam_stdin(
     blocks_per_batch: usize,
     output_byte_limit: u64,
 ) -> io::Result<(ReadBgzfBlocks, Header)> {
+    // stdin is not seekable, so concurrent positional reads cannot apply. Don't
+    // fail the run over a perf knob — warn (only on an explicit `Fixed(n>1)`;
+    // the `Auto` default falls back silently) and read sequentially.
+    fgumi_bam_io::scatter_reader::warn_read_streams_unavailable(
+        opts.read_streams,
+        "stdin",
+        "is not a seekable regular file",
+    );
     let (reader, header) =
         fgumi_bam_io::create_bam_reader_for_pipeline_with_opts(Path::new("-"), opts).map_err(
             |e| io::Error::other(format!("create_bam_reader_for_pipeline_with_opts: {e}")),
@@ -331,9 +366,18 @@ mod tests {
 
     /// Run a `ReadBgzfBlocks -> BlockSink` pipeline and return the emitted blocks.
     fn drive(path: &Path, blocks_per_batch: usize, threads: usize) -> Vec<BgzfBlock> {
+        drive_with_opts(path, blocks_per_batch, threads, PipelineReaderOpts::default())
+    }
+
+    /// `drive` with explicit reader opts (used to exercise `--read-streams`).
+    fn drive_with_opts(
+        path: &Path,
+        blocks_per_batch: usize,
+        threads: usize,
+        opts: PipelineReaderOpts,
+    ) -> Vec<BgzfBlock> {
         let received = std::sync::Arc::new(parking_lot::Mutex::new(Vec::new()));
-        let (source, _hdr) =
-            read_bam(path, PipelineReaderOpts::default(), blocks_per_batch, 1024 * 1024).unwrap();
+        let (source, _hdr) = read_bam(path, opts, blocks_per_batch, 1024 * 1024).unwrap();
         let sink = BlockSink { received: std::sync::Arc::clone(&received) };
 
         let builder = fgumi_pipeline_core::builder::Pipeline::builder();
@@ -375,6 +419,26 @@ mod tests {
         // which is what `FindBamBoundaries` downstream expects to receive.
         let concatenated: Vec<u8> = blocks.iter().flat_map(|b| b.bytes.clone()).collect();
         assert_eq!(concatenated, on_disk[..on_disk.len() - BGZF_EOF_LEN]);
+    }
+
+    #[rstest]
+    #[case::sequential(fgumi_bam_io::ReadStreams::Fixed(1))]
+    #[case::four_streams(fgumi_bam_io::ReadStreams::Fixed(4))]
+    #[case::auto(fgumi_bam_io::ReadStreams::Auto)]
+    fn read_streams_emit_identical_blocks(#[case] read_streams: fgumi_bam_io::ReadStreams) {
+        // Routing a seekable file through the scatter reader (Fixed(4)/Auto)
+        // must yield byte-identical blocks to the plain sequential reader
+        // (Fixed(1)). 2000 records keep the file comfortably larger than the
+        // 64-record fixture while staying fast to build.
+        let (path, _) = temp_bam(2000);
+        let baseline = drive(&path, 4, 1);
+        let opts = PipelineReaderOpts { read_streams, ..PipelineReaderOpts::default() };
+        let actual = drive_with_opts(&path, 4, 1, opts);
+        assert_eq!(actual.len(), baseline.len(), "block count must not depend on read-streams");
+        for (a, b) in actual.iter().zip(baseline.iter()) {
+            assert_eq!(a.batch_serial, b.batch_serial);
+            assert_eq!(a.bytes, b.bytes, "block bytes must be identical across read-streams");
+        }
     }
 
     #[test]

--- a/crates/fgumi-sort/src/external.rs
+++ b/crates/fgumi-sort/src/external.rs
@@ -2142,42 +2142,10 @@ fn probe_stats(buf: &impl ProbeableBuffer) -> BufferProbeStats {
 
 /// Read-stream policy for the Phase-1 input reader.
 ///
-/// R10-sync compatibility shim: `main`'s `--read-streams` CLI (#838/#846) is carried on the
-/// arena engine so `commands/sort.rs` compiles and the flag keeps parsing; the arena reader
-/// does not yet honor it. Forward-porting the measured multi-stream reader onto the arena
-/// engine is tracked as R7b.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum ReadStreams {
-    /// Measure and grow. The default.
-    #[default]
-    Auto,
-    /// Exactly this many; `1` is the plain sequential reader.
-    Fixed(usize),
-}
-
-impl std::fmt::Display for ReadStreams {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Auto => f.write_str("auto"),
-            Self::Fixed(n) => write!(f, "{n}"),
-        }
-    }
-}
-
-impl std::str::FromStr for ReadStreams {
-    type Err = String;
-
-    fn from_str(text: &str) -> Result<Self, Self::Err> {
-        if text.eq_ignore_ascii_case("auto") {
-            return Ok(Self::Auto);
-        }
-        match text.parse::<usize>() {
-            Ok(0) => Err("--read-streams must be `auto` or at least 1".to_string()),
-            Ok(n) => Ok(Self::Fixed(n)),
-            Err(_) => Err(format!("expected `auto` or a positive number, got `{text}`")),
-        }
-    }
-}
+/// The canonical definition now lives in `fgumi-bam-io` (next to the reader that
+/// honors it); re-exported here so the `fgumi_sort::ReadStreams` path and the
+/// `commands/sort.rs` CLI arg keep resolving unchanged.
+pub use fgumi_bam_io::ReadStreams;
 
 /// Raw-bytes external sorter for BAM files.
 ///

--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -551,6 +551,9 @@ impl BamIoOptions {
         fgumi_bam_io::PipelineReaderOpts {
             async_reader: self.async_reader,
             verify_crc: self.effective_check_crc(),
+            // This helper serves non-sort command paths, which do not expose a
+            // read-stream knob; keep the plain sequential/async reader.
+            read_streams: fgumi_bam_io::ReadStreams::Fixed(1),
         }
     }
 

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -409,26 +409,28 @@ pub struct Sort {
     #[arg(long = "write-index", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub write_index: bool,
 
-    /// Concurrent streams to read the input BAM and the merge's spill files
-    /// with: `auto`, or a fixed count.
+    /// Concurrent positional reads to fetch the input BAM with: `auto`, or a
+    /// fixed count (`1` = the plain sequential reader).
     ///
     /// One blocking read keeps only about one read-ahead window outstanding at
     /// the device, which on network-attached storage is far below what it can
     /// serve -- and no buffer size fixes it, because a bigger single request is
     /// not more concurrency. How much that matters depends entirely on the
-    /// storage: on EBS gp3 four streams took a whole-genome sort 28% faster,
-    /// while on a direct-attached instance-store SSD one stream is already faster than four
-    /// are on gp3 and adding more costs 1.8%.
+    /// storage: on EBS gp3 a 38 GB coordinate sort ran ~14% faster at four
+    /// streams, while on a direct-attached instance-store SSD one stream is
+    /// already faster than four are on gp3 and adding more costs 1.8%.
     ///
-    /// `auto` therefore measures instead of guessing. It starts at one stream
-    /// -- exactly the pre-existing behaviour -- and doubles only while fills
-    /// are occupying most of the read span, which is the condition under which
-    /// concurrency has something to buy. It lands on four for gp3 and stays at
-    /// one for `NVMe` without being told which is which.
+    /// `auto` therefore measures instead of guessing. It reads the first several
+    /// fills at a single stream -- exactly the pre-existing behaviour -- then
+    /// commits once to a count of `ceil(target-throughput / measured)`, capped at
+    /// 8. It lands on four for gp3 and stays at one for `NVMe` without being told
+    /// which is which, and does not revisit the choice afterwards.
     ///
-    /// The streams are existing pool workers, not new threads, so this never
-    /// exceeds `--threads`. Ignored for stdin and other non-seekable inputs,
-    /// where positional reads do not exist.
+    /// Each active stream is served by a scoped OS thread spawned per fill window,
+    /// bounded by the chosen count (at most 8) -- this is independent of
+    /// `--threads`. Applies to the input BAM only, not the merge's spill files.
+    /// Ignored for stdin and other non-seekable inputs, where positional reads do
+    /// not exist.
     #[arg(long = "read-streams", default_value_t = fgumi_sort::ReadStreams::Auto)]
     pub read_streams: fgumi_sort::ReadStreams,
 
@@ -588,6 +590,10 @@ impl Sort {
             // budget scales by `--threads`; the sorter's by max(threads, sort_threads).
             queue_memory: self.queue_memory_options(),
             async_reader: false,
+            // Thread the sort command's --read-streams into the chain's BAM
+            // source: Auto probes the device and picks a concurrent-read count,
+            // Fixed(n) pins it, Fixed(1) is the plain sequential reader.
+            read_streams: self.read_streams,
             // The owned engine always verified CRC (incl. stdin); keep parity -- a future
             // PR can add --no-check-crc if opt-out is wanted. `effective_check_crc()` would
             // skip verification for stdin input (the file-vs-stdin default other commands
@@ -958,18 +964,8 @@ impl Sort {
             info!("Temp directories: {joined}");
         }
 
-        // The cutover chain does not yet thread the owned engine's `--read-streams`
-        // / `--sort-stats` knobs. Warn (not info) on a non-default value so the
-        // ignored behavior stays visible under a default `warn` log filter rather
-        // than being silently dropped. Restoring `--read-streams` end-to-end is
-        // tracked as follow-up R7b.
-        if !matches!(self.read_streams, fgumi_sort::ReadStreams::Auto) {
-            warn!(
-                "--read-streams={} is ignored by the sort chain (not yet threaded); \
-                 using the default read strategy",
-                self.read_streams
-            );
-        }
+        // `--read-streams` is now threaded end-to-end (into the chain's BAM
+        // source below); no warn shim. `--sort-stats` is still unthreaded.
         if self.sort_stats {
             warn!("--sort-stats is ignored by the sort chain (not yet threaded)");
         }
@@ -1379,6 +1375,9 @@ mod tests {
         assert_eq!(spec.threading.threads, Some(sort.threads));
         assert!(matches!(spec.source, SourceSpec::Bam(_)));
         assert!(spec.verify_crc);
+        // --read-streams reaches the chain's BAM source (defaulted to Auto here),
+        // proving the field is wired even without an explicit flag.
+        assert_eq!(spec.read_streams, sort.read_streams);
         match (write_index, &spec.sink) {
             (true, SinkSpec::BamWithIndex(_)) | (false, SinkSpec::Bam(_)) => {}
             (wi, other) => panic!("write_index={wi} produced the wrong sink: {other:?}"),

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -585,6 +585,7 @@ impl<'a> ChainBuilder<'a> {
                     path,
                     fgumi_bam_io::PipelineReaderOpts {
                         async_reader: spec.async_reader,
+                        read_streams: spec.read_streams,
                         ..Default::default()
                     },
                 )
@@ -610,6 +611,7 @@ impl<'a> ChainBuilder<'a> {
                     unmapped,
                     fgumi_bam_io::PipelineReaderOpts {
                         async_reader: spec.async_reader,
+                        read_streams: spec.read_streams,
                         ..Default::default()
                     },
                 )
@@ -627,6 +629,7 @@ impl<'a> ChainBuilder<'a> {
                     mapped,
                     fgumi_bam_io::PipelineReaderOpts {
                         async_reader: spec.async_reader,
+                        read_streams: spec.read_streams,
                         ..Default::default()
                     },
                 )

--- a/src/lib/pipeline/chains/spec.rs
+++ b/src/lib/pipeline/chains/spec.rs
@@ -4,6 +4,7 @@ use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
 };
 use crate::pipeline::chains::{SinkSpec, SourceSpec, Stage, StageOptionsBag};
+use fgumi_bam_io::ReadStreams;
 
 /// Declarative chain specification. Both standalone commands and
 /// `runall` construct one of these and pass it to
@@ -29,6 +30,12 @@ pub struct ChainSpec {
     /// When true, the BAM/SAM source is opened with a userspace async
     /// prefetch reader (`--async-reader`), overlapping disk I/O with compute.
     pub async_reader: bool,
+    /// Concurrent positional-read policy for a seekable file source. `Fixed(1)`
+    /// (the default every command but `sort` uses) is the plain
+    /// sequential/async reader; `sort` sets this from its `--read-streams` flag
+    /// to raise the device read queue depth (see
+    /// [`fgumi_bam_io::scatter_reader`]).
+    pub read_streams: ReadStreams,
     /// Whether the BAM source's BGZF decode verifies each block's CRC32. Set
     /// from the command's `--check-crc`/`--no-check-crc` policy (via
     /// [`crate::commands::common::BamIoOptions::effective_check_crc`]) so the
@@ -78,6 +85,9 @@ impl ChainSpec {
             scheduler: ctx.scheduler.clone(),
             queue_memory: ctx.queue_memory.clone(),
             async_reader: ctx.io.async_reader,
+            // Non-sort single-stage commands do not expose a read-stream knob;
+            // keep the plain sequential/async reader. Only sort sets this.
+            read_streams: ReadStreams::Fixed(1),
             verify_crc: ctx.io.effective_check_crc(),
             command_line: ctx.command_line.to_string(),
         }

--- a/src/lib/pipeline/chains/validate.rs
+++ b/src/lib/pipeline/chains/validate.rs
@@ -512,6 +512,7 @@ mod tests {
             scheduler: SchedulerOptions::default(),
             queue_memory: QueueMemoryOptions::default(),
             async_reader: false,
+            read_streams: fgumi_bam_io::ReadStreams::Fixed(1),
             verify_crc: true,
             command_line: String::new(),
         }

--- a/src/lib/pipeline/steps/source/mod.rs
+++ b/src/lib/pipeline/steps/source/mod.rs
@@ -181,8 +181,15 @@ impl InputSource {
         if is_stdin {
             // The path is just `-`, so there is no suffix to consult and the
             // content decides. `PipelineReaderOpts` is not threaded through here:
-            // there is no path to reopen, so there is no async-reader wiring.
-            let _ = opts;
+            // there is no path to reopen, so there is no async-reader wiring and
+            // no positional (scatter) reads. Warn if `--read-streams` explicitly
+            // asked for concurrency stdin can't provide (the `Auto` default falls
+            // back silently) so this path gives the same feedback as the others.
+            fgumi_bam_io::scatter_reader::warn_read_streams_unavailable(
+                opts.read_streams,
+                "stdin",
+                "is not a seekable regular file",
+            );
             open_stream_by_content(Box::new(io::stdin()))
         } else if suffix_is_bam {
             // BAM file: parse header via the existing helper, which
@@ -207,8 +214,14 @@ impl InputSource {
             // async-reader wiring, whereas a wrong "regular" answer corrupts input.
             if !file.metadata().map(|m| m.is_file()).unwrap_or(false) {
                 // Non-regular: classify in-stream. Same trade-off the stdin branch
-                // makes — no async-reader wiring, because there is no reopenable path.
-                let _ = opts;
+                // makes — no async-reader wiring and no positional reads, because
+                // there is no reopenable path. Warn on an explicit `--read-streams`
+                // the input can't honor (the `Auto` default stays silent).
+                fgumi_bam_io::scatter_reader::warn_read_streams_unavailable(
+                    opts.read_streams,
+                    &path.display().to_string(),
+                    "is not a seekable regular file",
+                );
                 return open_stream_by_content(Box::new(file));
             }
 

--- a/tests/integration/test_chain_bam_with_index.rs
+++ b/tests/integration/test_chain_bam_with_index.rs
@@ -115,6 +115,7 @@ fn bam_with_index_produces_inline_sidecar_not_reread() {
         scheduler: SchedulerOptions::default(),
         queue_memory: QueueMemoryOptions::default(),
         async_reader: false,
+        read_streams: fgumi_bam_io::ReadStreams::Fixed(1),
         verify_crc: true,
         command_line: "fgumi sort --write-index".to_string(),
     };
@@ -344,6 +345,7 @@ fn bam_with_index_spec(
         scheduler: SchedulerOptions::default(),
         queue_memory: QueueMemoryOptions::default(),
         async_reader: false,
+        read_streams: fgumi_bam_io::ReadStreams::Fixed(1),
         verify_crc: true,
         command_line: "fgumi sort --write-index".to_string(),
     }

--- a/tests/integration/test_sort_cutover_parity.rs
+++ b/tests/integration/test_sort_cutover_parity.rs
@@ -1134,14 +1134,13 @@ fn cutover_threads_zero_is_rejected() {
     }
 }
 
-/// `--sort-stats` and `--read-streams` are inert on the chain: neither field
-/// even exists on the chain-facing `SortOptions` struct (`to_sort_options`
-/// drops both), so nothing downstream reads them. Restoring
-/// `--read-streams`'s real behavior is tracked as R7b. Passing them must be
-/// accept-but-inert -- not a hard error -- and the sort must still produce
-/// correct, coordinate-sorted output.
+/// `--sort-stats` is still inert on the chain (nothing downstream reads it), so
+/// it must be accept-but-inert with a visible notice. `--read-streams`, by
+/// contrast, is now threaded into the chain's BAM source (R7b), so it must NOT
+/// be reported as ignored. Either way the sort must still produce correct,
+/// coordinate-sorted output.
 #[test]
-fn cutover_inert_flags_do_not_error() {
+fn cutover_sort_stats_inert_read_streams_active() {
     let dir = TempDir::new().expect("create temp dir");
     let input_bam = dir.path().join("in.bam");
     let records = unsorted_records(200);
@@ -1173,11 +1172,11 @@ fn cutover_inert_flags_do_not_error() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         output.status.success(),
-        "--sort-stats/--read-streams are accept-but-inert on the chain and must not error:\n{stderr}"
+        "--sort-stats (inert) and --read-streams (active) must not error:\n{stderr}"
     );
     assert!(
-        stderr.contains("--read-streams=4 is ignored by the sort chain"),
-        "the ignored `--read-streams` notice must be visible on stderr; stderr:\n{stderr}"
+        !stderr.contains("--read-streams=4 is ignored"),
+        "`--read-streams` is threaded now and must not be reported as ignored; stderr:\n{stderr}"
     );
     assert!(
         stderr.contains("--sort-stats is ignored by the sort chain"),
@@ -1199,6 +1198,55 @@ fn cutover_inert_flags_do_not_error() {
         keys.windows(2).all(|w| w[0] <= w[1]),
         "output is not coordinate-sorted with --sort-stats/--read-streams set: {keys:?}"
     );
+}
+
+/// The `--read-streams` count changes only *how* the input is read (disk queue
+/// depth), never *what* is read. Sorted output must be byte-identical across
+/// `1`, `4`, and `auto` — the load-bearing correctness gate for the concurrent
+/// scatter reader on the real sort command path. `-m 32K` forces the *sort* to
+/// spill through the external-merge path (it does not resize the reader's fill
+/// window, which is fixed at 4 MiB), so this exercises `--read-streams` end to
+/// end through spill+merge. The scatter reader's own multi-fill / multi-slice
+/// behaviour is covered directly by the unit proptests in `scatter_reader`.
+#[rstest]
+#[case::coordinate("coordinate")]
+#[case::queryname_natural("queryname-natural")]
+#[case::template_coordinate("template-coordinate")]
+fn cutover_read_streams_produce_identical_output(#[case] order: &str) {
+    let flag = order_flag(order);
+    let dir = TempDir::new().expect("create temp dir");
+    let input_bam = dir.path().join("in.bam");
+    let records = unsorted_records(4000);
+    write_bam(&input_bam, &create_minimal_header("chr1", 100_000_000), &records);
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let run = |streams: &str| -> Vec<u8> {
+        let out = dir.path().join(format!("out_{order}_{streams}.bam"));
+        let status = Command::new(current_bin)
+            .args([
+                OsStr::new("sort"),
+                OsStr::new("-i"),
+                input_bam.as_os_str(),
+                OsStr::new("-o"),
+                out.as_os_str(),
+                OsStr::new("--order"),
+                OsStr::new(flag),
+                OsStr::new("-m"),
+                OsStr::new("32K"),
+                OsStr::new("--read-streams"),
+                OsStr::new(streams),
+            ])
+            .status()
+            .expect("spawn fgumi sort");
+        assert!(status.success(), "sort --read-streams {streams} --order {flag} failed");
+        decompressed_records_without_pg(&out)
+    };
+
+    let one = run("1");
+    let four = run("4");
+    let auto = run("auto");
+    assert_eq!(one, four, "--read-streams 1 vs 4 must be byte-identical ({order})");
+    assert_eq!(one, auto, "--read-streams 1 vs auto must be byte-identical ({order})");
 }
 
 /// The owned engine always verified BGZF CRC32, including on stdin input


### PR DESCRIPTION
## What & why

PR #885's unified-engine cutover left `fgumi sort --read-streams` a dead `warn!` shim: the flag still parsed but the arena chain ignored it. This restores the mechanism of PRs #838/#846 — concurrent positional reads that raise the device's read queue depth — on the current chain source.

The win in #846 was **disk queue depth**, not decode: a single outstanding `read()` leaves most of a deep-queue device's bandwidth idle (EBS gp3 sustains ~358 MB/s at queue-depth-1 vs ~1177 MB/s with four reads in flight). The arena chain's BGZF decode is already parallel (`InflateToArena`) and a single `PrefetchReader` is still queue-depth-1, so only genuine N-way concurrent reads recover it.

## Mechanism

New `crates/fgumi-bam-io/src/scatter_reader.rs`: a `ScatterReader<S: PositionalSource>` that, per 4 MiB fill window, slices the byte range into N sub-ranges, fetches them with independent concurrent positional reads (`pread` / `FileExt::read_at`, which takes `&self` — no shared file offset), reassembles them **in file order**, and presents an ordinary forward `Read` stream, so the downstream BGZF framer is untouched.

- **No new `unsafe`.** Each slice reads into its own `Vec<u8>` owned by the scoped thread that fills it (`std::thread::scope`); `read_at` on `&self` needs no synchronization. `#![forbid(unsafe_code)]` is preserved and the module is Miri-clean.
- **`Auto` (the default)** reads the first `AUTO_PROBE_FILLS` at a single stream, then commits once to `ceil(1.2 GB/s ÷ measured)`, capped at `MAX_STREAMS = 8`. Device-adaptive: gp3 → 4, fast NVMe → 1. An explicit `Fixed(n)` is clamped to the same `[1, MAX_STREAMS]` ceiling.
- **`Fixed(1)` is the plain reader** — no threads, byte-identical to the old direct `File` read. `PipelineReaderOpts`/`ChainSpec` default to `Fixed(1)` for **every** command except `sort`, so scatter probing never turns on codebase-wide (pinned by a regression test).
- Scatter engages only for seekable regular files; stdin, pipes, and non-Unix fall back to the sequential/async reader, warning only when the user *explicitly* asked for `Fixed(n>1)` that can't be honored (`Auto` falls back silently).

## Correctness

Output is byte-identical across `--read-streams 1`/`4`/`auto` — the count changes only *how* the input is read, never *what*. Proven by:
- `scatter_reader` proptests `byte_identical_to_source` / `byte_identical_under_auto` (random data × stream counts × fill/slice sizes), a fail-closed `UnexpectedEof` test for truncation, error-prefix ordering, and a positive test that `Fixed(4)` actually fans reads across threads.
- The `cutover_read_streams_produce_identical_output` integration test (coordinate / queryname-natural / template-coordinate, forced spill), asserting byte-identical sorted output across 1/4/auto.
- Miri over the concurrency tests.

## Benchmark (EBS gp3, validated)

38.1 GB coordinate sort, `c8g.4xlarge`, gp3 300 GB / 3000 IOPS / **500 MB/s**, cold page cache, `-@16 -m256M`, 2 reps each:

| `--read-streams` | mean wall | vs baseline |
|---|---|---|
| 1 (baseline) | 207.6 s | — |
| 4 | 179.2 s | **−13.7%** |
| auto | 180.8 s | **−12.9%** (resolved to 4 streams, as designed) |

All six runs exit 0 and produced 254,093,850 records (== input); `samtools view` md5 is byte-identical across all three arms. The gain is smaller than #846's −28% on the old owned engine because the arena chain's parallel decode already shrank the ingest share — read-queue-depth recovers the remaining fraction.

## Note on the default

Because `--read-streams` defaults to `auto`, a plain `fgumi sort <regular-file>` now runs an 8-fill single-stream throughput probe and may then read with a few concurrent streams. Output is unchanged (byte-identical, per above); on a fast device the probe resolves to a single stream. This is the intended, measured behavior — the flag was always documented as `auto` by default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: Sort output remains byte-identical because `ScatterReader` reassembles reads in file order; `unsafe` changes: none; memory and concurrency policy: the reader adds up to eight per-window read threads with a fixed 4 MiB fill window, while downstream processing remains unchanged.

Fix: Route `--read-streams` through the BAM input path and use sequential fallback for unsupported inputs.

- Add `ReadStreams::{Auto, Fixed(usize)}` to the shared BAM reader API.
- Add `ScatterReader` for concurrent positional reads on seekable regular files.
- Preserve sequential behavior for non-sort commands and `Fixed(1)`.
- Clamp explicit and auto-selected concurrency to eight streams.
- Keep spill-file reads separate from input BAM reads.
- Warn when explicit stream concurrency cannot apply to stdin or non-regular inputs.
- Add unit, property, integration, and Miri coverage for byte identity, EOF, errors, and stream selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->