### PR TITLE
refactor(sort): delete the CLI's throwaway sorter construction

### DIFF
--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -27,9 +27,7 @@ use anyhow::{Result, bail};
 use bytesize::ByteSize;
 use clap::Parser;
 use fgumi_bam_io::is_stdout_path;
-use fgumi_sort::{
-    KeyTypesSpec, QuerynameComparator, RawExternalSorter, SortOrder, verify_sort_order,
-};
+use fgumi_sort::{KeyTypesSpec, QuerynameComparator, SortOrder, verify_sort_order};
 
 use log::{debug, info, warn};
 use std::path::{Path, PathBuf};
@@ -777,40 +775,6 @@ impl Sort {
         Ok(effective_memory.min(init))
     }
 
-    /// Construct the sorter from this command's options.
-    ///
-    /// Extracted from `execute` so the option-to-builder wiring is testable on
-    /// its own. That matters most for `--sort-threads` / `--merge-threads`:
-    /// they only affect scheduling, so an end-to-end run cannot distinguish a
-    /// correctly wired flag from one that was parsed and then dropped.
-    fn build_sorter(
-        &self,
-        effective_memory: usize,
-        command_line: &str,
-        soft_nofile: Option<u64>,
-    ) -> RawExternalSorter {
-        let mut sorter = RawExternalSorter::new(self.order.into())
-            .memory_limit(effective_memory)
-            .threads(self.threads)
-            .output_compression(self.compression.compression_level)
-            .temp_compression(self.temp_compression)
-            .spill_codec(self.temp_codec)
-            .write_index(self.write_index)
-            .read_streams(self.read_streams)
-            .sort_stats(self.sort_stats)
-            .pg_info(crate::version::VERSION.to_string(), command_line.to_string());
-
-        // Each per-phase override is optional and falls back to `--threads`.
-        if let Some(n) = self.sort_threads {
-            sorter = sorter.sort_threads(n);
-        }
-        if let Some(n) = self.merge_threads {
-            sorter = sorter.merge_threads(n);
-        }
-        sorter = sorter.max_temp_files(self.resolved_max_temp_files(soft_nofile));
-        sorter
-    }
-
     /// The spill-file consolidation limit this command will use.
     ///
     /// The engine's own default is a fixed, portable value; sizing it to the
@@ -985,8 +949,9 @@ impl Sort {
         }
 
         // --- cutover: run via the chain instead of sorter.sort() ---
-        // (self.build_sorter above is retained only to source the banner's thread/temp-file
-        //  numbers; the owned sorter is not executed. PR B removes the owned engine + banner-build.)
+        // (`phase1_threads`/`phase2_threads`/`resolved_max_temp_files` above are retained
+        //  only to source the banner's thread/temp-file numbers; the owned sorter is not
+        //  constructed or executed here. PR B removes the owned engine.)
         //
         // `output` is already bound at the top of this method (validated in `execute`),
         // and `resolved_tmp_dirs` was resolved above for the banner; hand both to the
@@ -1398,40 +1363,10 @@ mod tests {
         }
     }
 
-    /// The flags must actually reach the sorter. This cannot be checked through
-    /// an end-to-end run: the per-phase counts only affect scheduling, so a flag
-    /// that parsed and was then silently dropped produces byte-identical output
-    /// to one that was wired correctly. Assert the resolved per-phase counts on
-    /// the built sorter instead.
-    #[rstest]
-    #[case::defaults(None, None, 2, 2)]
-    #[case::narrow_sort(Some(1), Some(4), 1, 4)]
-    #[case::narrow_merge(Some(4), Some(1), 4, 1)]
-    #[case::sort_only(Some(3), None, 3, 2)]
-    #[case::merge_only(None, Some(3), 2, 3)]
-    fn test_build_sorter_wires_per_phase_threads(
-        #[case] sort_threads: Option<usize>,
-        #[case] merge_threads: Option<usize>,
-        #[case] expected_phase1: usize,
-        #[case] expected_phase2: usize,
-    ) {
-        let mut sort = make_sort(SortOrderArg::Coordinate);
-        sort.threads = 2;
-        sort.sort_threads = sort_threads;
-        sort.merge_threads = merge_threads;
-
-        let sorter =
-            sort.build_sorter(512 * 1024 * 1024, "fgumi sort (test)", fgumi_sort::soft_nofile());
-        assert_eq!(sorter.phase1_threads(), expected_phase1);
-        assert_eq!(sorter.phase2_threads(), expected_phase2);
-    }
-
     /// The sorter-free phase thread helpers `Sort::phase1_threads` /
     /// `Sort::phase2_threads` must match the engine's own formula, since
     /// they replace the CLI's only other caller of `RawExternalSorter`'s
-    /// methods. This test uses the same case table as
-    /// `test_build_sorter_wires_per_phase_threads` to ensure both paths
-    /// produce the same results end to end.
+    /// methods.
     #[rstest]
     #[case::defaults(None, None, 2, 2)]
     #[case::narrow_sort(Some(1), Some(4), 1, 4)]
@@ -1478,39 +1413,6 @@ mod tests {
         sort.sort_threads = sort_threads;
 
         assert_eq!(sort.memory_budget_threads(), expected);
-    }
-
-    /// `memory_budget_threads` re-derives the sort-phase fallback that the engine
-    /// owns (the budget is needed before the sorter exists, so it cannot read
-    /// `phase1_threads` off it). Keep the two definitions in agreement.
-    ///
-    /// `expected_phase1` is spelled out per case rather than read back off the
-    /// sorter: asserting `threads.max(sorter.phase1_threads())` would re-apply the
-    /// implementation's own `max` and so could not detect an engine fallback that
-    /// resolves *below* `--threads`, which is the drift this test exists to catch.
-    ///
-    /// The two definitions intentionally diverge at `threads == 0`:
-    /// `memory_budget_threads` returns 0 so `resolve_memory_budget` can reject it,
-    /// while `phase1_threads` clamps to one worker. That case is covered by
-    /// `test_memory_budget_threads` and is excluded here.
-    #[rstest]
-    #[case::defaults(2, None, 2)]
-    #[case::sort_above_threads(1, Some(8), 8)]
-    #[case::sort_below_threads(32, Some(4), 4)]
-    #[case::zero_sort_override(4, Some(0), 1)]
-    fn test_memory_budget_threads_agrees_with_the_sorters_sort_phase(
-        #[case] threads: usize,
-        #[case] sort_threads: Option<usize>,
-        #[case] expected_phase1: usize,
-    ) {
-        let mut sort = make_sort(SortOrderArg::Coordinate);
-        sort.threads = threads;
-        sort.sort_threads = sort_threads;
-
-        let sorter =
-            sort.build_sorter(512 * 1024 * 1024, "fgumi sort (test)", fgumi_sort::soft_nofile());
-        assert_eq!(sorter.phase1_threads(), expected_phase1, "engine sort-phase fallback drifted");
-        assert_eq!(sort.memory_budget_threads(), threads.max(expected_phase1));
     }
 
     /// The `Max memory:` line names whichever flag supplied the multiplier.
@@ -1737,12 +1639,12 @@ mod tests {
         assert!(Sort::try_parse_from(args).is_err(), "--max-temp-files {value} must be rejected");
     }
 
-    /// The flag reaches the sorter: an explicit limit passes through untouched;
-    /// `auto` derives one from the descriptor budget it is handed. The budget is
-    /// supplied rather than read from the host, so the expected derived value is
-    /// a fixed number instead of one that depends on the machine the test runs
-    /// on — and it is deliberately *not* the engine's own default, which stays a
-    /// fixed portable value now that the derivation lives in the command.
+    /// An explicit limit passes through untouched; `auto` derives one from the
+    /// descriptor budget it is handed. The budget is supplied rather than read
+    /// from the host, so the expected derived value is a fixed number instead of
+    /// one that depends on the machine the test runs on — and it is deliberately
+    /// *not* the engine's own default, which stays a fixed portable value now
+    /// that the derivation lives in the command.
     #[rstest]
     #[case::set(MaxTempFiles::Fixed(256), Some(1024), 256)]
     #[case::auto_derives_from_the_budget(MaxTempFiles::Auto, Some(1024), 992)]
@@ -1751,16 +1653,14 @@ mod tests {
         None,
         fgumi_sort::FALLBACK_MAX_TEMP_FILES
     )]
-    fn test_build_sorter_wires_max_temp_files(
+    fn test_resolved_max_temp_files(
         #[case] max_temp_files: MaxTempFiles,
         #[case] soft_nofile: Option<u64>,
         #[case] expected: usize,
     ) {
         let mut sort = make_sort(SortOrderArg::Coordinate);
         sort.max_temp_files = max_temp_files;
-
-        let sorter = sort.build_sorter(512 * 1024 * 1024, "fgumi sort (test)", soft_nofile);
-        assert_eq!(sorter.temp_file_limit(), expected);
+        assert_eq!(sort.resolved_max_temp_files(soft_nofile), expected);
     }
 
     /// The accessor test above only proves the flag reaches the builder. This
@@ -1805,8 +1705,9 @@ mod tests {
         let input = dir.path().join("in.bam");
         builder.write_bam(&input).expect("write bam");
 
-        // 1 KiB memory forces spilling; `build_sorter` is the exact option ->
-        // builder path `execute` uses, so this exercises the real wiring.
+        // 1 KiB memory forces spilling; this mirrors the order/memory/threads/
+        // max-temp-files fields the command's owned-engine wiring used to set,
+        // so it exercises the same consolidation behavior.
         let run = |max_temp_files: MaxTempFiles, out: PathBuf| {
             let mut sort = make_sort(SortOrderArg::Coordinate);
             sort.input = input.clone();
@@ -1814,7 +1715,10 @@ mod tests {
             sort.threads = 1;
             sort.max_temp_files = max_temp_files;
 
-            let sorter = sort.build_sorter(1024, "fgumi sort (test)", fgumi_sort::soft_nofile());
+            let sorter = fgumi_sort::RawExternalSorter::new(sort.order.into())
+                .memory_limit(1024)
+                .threads(1)
+                .max_temp_files(sort.resolved_max_temp_files(fgumi_sort::soft_nofile()));
             let stats = sorter.sort(&input, &out).expect("sort should succeed");
 
             let mut reader =

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -738,21 +738,20 @@ impl Sort {
 
     /// Effective Phase-1 (accumulate/sort/spill) worker count.
     ///
-    /// Mirrors `RawExternalSorter::phase1_threads` in
-    /// `fgumi-sort/src/external.rs` exactly. Duplicated rather than shared:
-    /// the engine's own version is used only internally by
-    /// `SortBuffer::from_sorter` after this method replaces the CLI's only
-    /// other caller, so there is no third call site to justify a cross-crate
-    /// export. Kept honest by `test_phase_threads_match_sorters_formula`
+    /// Delegates to `pipeline::chains::builder::resolve_phase_threads`, the
+    /// same intra-crate resolver the chain uses to size the streaming sorter
+    /// in `add_sort` — so the banner reports exactly the per-phase counts the
+    /// chain will actually run with, rather than a separately maintained copy
+    /// of the formula. Kept honest by `test_phase_threads_match_sorters_formula`
     /// (values) and `test_phase_threads_match_engine` (direct parity with
     /// the engine's formula) here.
     fn phase1_threads(&self) -> usize {
-        self.sort_threads.unwrap_or(self.threads).max(1)
+        crate::pipeline::chains::builder::resolve_phase_threads(self.sort_threads, self.threads)
     }
 
     /// Effective Phase-2 (merge/write) worker count. See `phase1_threads`.
     fn phase2_threads(&self) -> usize {
-        self.merge_threads.unwrap_or(self.threads).max(1)
+        crate::pipeline::chains::builder::resolve_phase_threads(self.merge_threads, self.threads)
     }
 
     /// The spill-file consolidation limit this command will use.
@@ -1428,6 +1427,27 @@ mod tests {
         assert_eq!(sort.memory_budget_threads(), expected);
     }
 
+    /// `memory_budget_threads` sizes the sort buffer for at least as many workers
+    /// as the sort phase runs. Guards that relationship (with `phase1_threads` now
+    /// delegating to the chain's resolver) so the two cannot silently diverge for
+    /// threads >= 1; at threads == 0 they intentionally differ (budget is 0).
+    #[rstest]
+    #[case::defaults(1, None)]
+    #[case::threads_only(4, None)]
+    #[case::sort_above_threads(1, Some(8))]
+    #[case::sort_below_threads(32, Some(4))]
+    #[case::sort_equals_threads(4, Some(4))]
+    #[case::zero_sort_override(4, Some(0))]
+    fn test_memory_budget_covers_phase1(
+        #[case] threads: usize,
+        #[case] sort_threads: Option<usize>,
+    ) {
+        let mut sort = make_sort(SortOrderArg::Coordinate);
+        sort.threads = threads;
+        sort.sort_threads = sort_threads;
+        assert_eq!(sort.memory_budget_threads(), sort.threads.max(sort.phase1_threads()));
+    }
+
     /// The `Max memory:` line names whichever flag supplied the multiplier.
     ///
     /// `--threads` is the floor, so it stays the attributed source whenever it
@@ -1686,9 +1706,6 @@ mod tests {
         // so it exercises the same consolidation behavior.
         let run = |max_temp_files: MaxTempFiles, out: PathBuf| {
             let mut sort = make_sort(SortOrderArg::Coordinate);
-            sort.input = input.clone();
-            sort.output = Some(out.clone());
-            sort.threads = 1;
             sort.max_temp_files = max_temp_files;
 
             let sorter = fgumi_sort::RawExternalSorter::new(sort.order.into())

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -744,7 +744,8 @@ impl Sort {
     /// `SortBuffer::from_sorter` after this method replaces the CLI's only
     /// other caller, so there is no third call site to justify a cross-crate
     /// export. Kept honest by `test_phase_threads_match_sorters_formula`
-    /// here and the engine's own equivalent unit tests in `fgumi-sort`.
+    /// (values) and `test_phase_threads_match_engine` (direct parity with
+    /// the engine's formula) here.
     fn phase1_threads(&self) -> usize {
         self.sort_threads.unwrap_or(self.threads).max(1)
     }
@@ -891,17 +892,17 @@ impl Sort {
                 info!("Max memory: {} (fixed)", ByteSize(effective_memory as u64));
             }
         }
-        // Read the counts off the sorter rather than off `--threads`, which is
-        // only where `--sort-threads`/`--merge-threads` default from: logging the
-        // flag alone reports 1 thread for a run that was asked for more.
+        // Report the effective per-phase thread counts (not the raw --threads,
+        // which is only where --sort-threads/--merge-threads default from):
+        // logging the flag alone reports 1 thread for a run that asked for more.
         info!(
             "Threads: {}",
             fgumi_sort::format_thread_counts(self.phase1_threads(), self.phase2_threads())
         );
         info!("Temp compression level: {}", self.temp_compression);
-        // Read off the sorter, like the thread counts above: it is the number
-        // the engine will actually consolidate at, so it cannot drift from what
-        // this line reports.
+        // The resolved max-temp-files the sort will actually consolidate at,
+        // sourced the same way as the thread counts above so the banner cannot
+        // drift from the value handed to the sort.
         let max_temp_files = self.resolved_max_temp_files(soft_nofile);
         info!("{}", max_temp_files_log_line(self.max_temp_files, max_temp_files, soft_nofile));
         if let Some(warning) = fd_budget_warning(self.max_temp_files, max_temp_files, soft_nofile) {
@@ -1365,6 +1366,39 @@ mod tests {
 
         assert_eq!(sort.phase1_threads(), expected_phase1);
         assert_eq!(sort.phase2_threads(), expected_phase2);
+    }
+
+    /// The CLI's `phase1_threads`/`phase2_threads` are hand-copied from
+    /// `RawExternalSorter`'s formula. Pin them against the engine directly so
+    /// the two copies cannot drift silently (both would otherwise stay green
+    /// against their own tables).
+    #[rstest]
+    #[case::defaults(2, None, None)]
+    #[case::narrow_sort(2, Some(1), Some(4))]
+    #[case::narrow_merge(2, Some(4), Some(1))]
+    #[case::sort_only(2, Some(3), None)]
+    #[case::merge_only(2, None, Some(3))]
+    #[case::zero_sort_override_clamps(4, Some(0), None)]
+    #[case::zero_merge_override_clamps(4, None, Some(0))]
+    fn test_phase_threads_match_engine(
+        #[case] threads: usize,
+        #[case] sort_threads: Option<usize>,
+        #[case] merge_threads: Option<usize>,
+    ) {
+        let mut sort = make_sort(SortOrderArg::Coordinate);
+        sort.threads = threads;
+        sort.sort_threads = sort_threads;
+        sort.merge_threads = merge_threads;
+
+        let mut engine = fgumi_sort::RawExternalSorter::new(sort.order.into()).threads(threads);
+        if let Some(n) = sort_threads {
+            engine = engine.sort_threads(n);
+        }
+        if let Some(n) = merge_threads {
+            engine = engine.merge_threads(n);
+        }
+        assert_eq!(sort.phase1_threads(), engine.phase1_threads());
+        assert_eq!(sort.phase2_threads(), engine.phase2_threads());
     }
 
     /// The per-thread budget sizes the buffer the sort phase fills, so it follows

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -754,27 +754,6 @@ impl Sort {
         self.merge_threads.unwrap_or(self.threads).max(1)
     }
 
-    /// Initial buffer pre-allocation for `--max-memory auto`, in bytes.
-    ///
-    /// Capped at 768 MiB per budget thread (matching the samtools default) so an
-    /// `auto` budget on a large host doesn't allocate the whole budget upfront;
-    /// the buffer still grows on demand up to `effective_memory`. Scales by
-    /// [`memory_budget_threads`](Self::memory_budget_threads) for the same reason
-    /// the budget does — the sort phase is what fills the buffer.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the per-thread product overflows `usize`.
-    // used by the owned-engine oracle path; PR B removes
-    #[allow(dead_code)]
-    fn auto_initial_capacity(&self, effective_memory: usize) -> Result<usize> {
-        let init = 768_usize
-            .checked_mul(1024 * 1024)
-            .and_then(|b| b.checked_mul(self.memory_budget_threads()))
-            .ok_or_else(|| anyhow::anyhow!("initial auto buffer size overflowed"))?;
-        Ok(effective_memory.min(init))
-    }
-
     /// The spill-file consolidation limit this command will use.
     ///
     /// The engine's own default is a fixed, portable value; sizing it to the
@@ -1468,43 +1447,6 @@ mod tests {
         .expect("budget should resolve");
 
         assert_eq!(resolved, expected_bytes);
-    }
-
-    /// `--max-memory auto` pre-allocates 768 MiB per budget thread, so it follows
-    /// `--sort-threads` upward exactly as the budget does, and never exceeds the
-    /// resolved budget.
-    #[rstest]
-    #[case::sort_above_threads(1, Some(8), usize::MAX, 8 * 768 * 1024 * 1024)]
-    #[case::sort_below_threads(4, Some(2), usize::MAX, 4 * 768 * 1024 * 1024)]
-    #[case::threads_only(2, None, usize::MAX, 2 * 768 * 1024 * 1024)]
-    #[case::capped_by_effective_memory(8, Some(16), 1024, 1024)]
-    fn test_auto_initial_capacity(
-        #[case] threads: usize,
-        #[case] sort_threads: Option<usize>,
-        #[case] effective_memory: usize,
-        #[case] expected: usize,
-    ) {
-        let mut sort = make_sort(SortOrderArg::Coordinate);
-        sort.threads = threads;
-        sort.sort_threads = sort_threads;
-
-        assert_eq!(
-            sort.auto_initial_capacity(effective_memory).expect("capacity should resolve"),
-            expected
-        );
-    }
-
-    /// The per-thread product is checked, not wrapped.
-    #[test]
-    fn test_auto_initial_capacity_rejects_overflow() {
-        let mut sort = make_sort(SortOrderArg::Coordinate);
-        sort.threads = usize::MAX;
-
-        let err = sort.auto_initial_capacity(usize::MAX).expect_err("should overflow");
-        assert!(
-            err.to_string().contains("initial auto buffer size overflowed"),
-            "unexpected error: {err}"
-        );
     }
 
     /// `--max-temp-files` parses onto the struct and defaults to `auto`, which

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -922,10 +922,6 @@ impl Sort {
         // different limits if `RLIMIT_NOFILE` changes mid-run.
         let soft_nofile = fgumi_sort::soft_nofile();
 
-        // Built before the config log so the log can report the sorter's own
-        // effective per-phase thread counts.
-        let sorter = self.build_sorter(effective_memory, command_line, soft_nofile);
-
         debug!("Starting Sort");
         info!("Input: {}", self.input.display());
         info!("Output: {}", output.display());
@@ -963,7 +959,7 @@ impl Sort {
         // Read off the sorter, like the thread counts above: it is the number
         // the engine will actually consolidate at, so it cannot drift from what
         // this line reports.
-        let max_temp_files = sorter.temp_file_limit();
+        let max_temp_files = self.resolved_max_temp_files(soft_nofile);
         info!("{}", max_temp_files_log_line(self.max_temp_files, max_temp_files, soft_nofile));
         if let Some(warning) = fd_budget_warning(self.max_temp_files, max_temp_files, soft_nofile) {
             warn!("{warning}");

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -738,6 +738,28 @@ impl Sort {
         }
     }
 
+    /// Effective Phase-1 (accumulate/sort/spill) worker count.
+    ///
+    /// Mirrors `RawExternalSorter::phase1_threads` in
+    /// `fgumi-sort/src/external.rs` exactly. Duplicated rather than shared:
+    /// the engine's own version is used only internally by
+    /// `SortBuffer::from_sorter` after this method replaces the CLI's only
+    /// other caller, so there is no third call site to justify a cross-crate
+    /// export. Kept honest by `test_phase_threads_match_sorters_formula`
+    /// here and the engine's own equivalent unit tests in `fgumi-sort`.
+    // Used by the startup banner; will be wired in Task 2
+    #[allow(dead_code)]
+    fn phase1_threads(&self) -> usize {
+        self.sort_threads.unwrap_or(self.threads).max(1)
+    }
+
+    /// Effective Phase-2 (merge/write) worker count. See `phase1_threads`.
+    // Used by the startup banner; will be wired in Task 2
+    #[allow(dead_code)]
+    fn phase2_threads(&self) -> usize {
+        self.merge_threads.unwrap_or(self.threads).max(1)
+    }
+
     /// Initial buffer pre-allocation for `--max-memory auto`, in bytes.
     ///
     /// Capped at 768 MiB per budget thread (matching the samtools default) so an
@@ -1410,6 +1432,33 @@ mod tests {
             sort.build_sorter(512 * 1024 * 1024, "fgumi sort (test)", fgumi_sort::soft_nofile());
         assert_eq!(sorter.phase1_threads(), expected_phase1);
         assert_eq!(sorter.phase2_threads(), expected_phase2);
+    }
+
+    /// The sorter-free phase thread helpers `Sort::phase1_threads` /
+    /// `Sort::phase2_threads` must match the engine's own formula, since
+    /// they replace the CLI's only other caller of `RawExternalSorter`'s
+    /// methods. This test uses the same case table as
+    /// `test_build_sorter_wires_per_phase_threads` to ensure both paths
+    /// produce the same results end to end.
+    #[rstest]
+    #[case::defaults(None, None, 2, 2)]
+    #[case::narrow_sort(Some(1), Some(4), 1, 4)]
+    #[case::narrow_merge(Some(4), Some(1), 4, 1)]
+    #[case::sort_only(Some(3), None, 3, 2)]
+    #[case::merge_only(None, Some(3), 2, 3)]
+    fn test_phase_threads_match_sorters_formula(
+        #[case] sort_threads: Option<usize>,
+        #[case] merge_threads: Option<usize>,
+        #[case] expected_phase1: usize,
+        #[case] expected_phase2: usize,
+    ) {
+        let mut sort = make_sort(SortOrderArg::Coordinate);
+        sort.threads = 2;
+        sort.sort_threads = sort_threads;
+        sort.merge_threads = merge_threads;
+
+        assert_eq!(sort.phase1_threads(), expected_phase1);
+        assert_eq!(sort.phase2_threads(), expected_phase2);
     }
 
     /// The per-thread budget sizes the buffer the sort phase fills, so it follows

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -747,15 +747,11 @@ impl Sort {
     /// other caller, so there is no third call site to justify a cross-crate
     /// export. Kept honest by `test_phase_threads_match_sorters_formula`
     /// here and the engine's own equivalent unit tests in `fgumi-sort`.
-    // Used by the startup banner; will be wired in Task 2
-    #[allow(dead_code)]
     fn phase1_threads(&self) -> usize {
         self.sort_threads.unwrap_or(self.threads).max(1)
     }
 
     /// Effective Phase-2 (merge/write) worker count. See `phase1_threads`.
-    // Used by the startup banner; will be wired in Task 2
-    #[allow(dead_code)]
     fn phase2_threads(&self) -> usize {
         self.merge_threads.unwrap_or(self.threads).max(1)
     }
@@ -961,7 +957,7 @@ impl Sort {
         // flag alone reports 1 thread for a run that was asked for more.
         info!(
             "Threads: {}",
-            fgumi_sort::format_thread_counts(sorter.phase1_threads(), sorter.phase2_threads())
+            fgumi_sort::format_thread_counts(self.phase1_threads(), self.phase2_threads())
         );
         info!("Temp compression level: {}", self.temp_compression);
         // Read off the sorter, like the thread counts above: it is the number

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -2523,8 +2523,8 @@ impl<'a> ChainBuilder<'a> {
 
             // Thread `--max-temp-files` through: `Auto` resolves against the host
             // `RLIMIT_NOFILE` (one snapshot), matching the standalone
-            // `Sort::build_sorter`. Without this the chain used the engine's
-            // portable fallback and silently ignored the CLI value.
+            // `Sort::resolved_max_temp_files`. Without this the chain used the
+            // engine's portable fallback and silently ignored the CLI value.
             let resolved_max_temp_files = match sort.max_temp_files {
                 crate::commands::common::MaxTempFiles::Auto => {
                     fgumi_sort::temp_file_limit_from_nofile(fgumi_sort::soft_nofile())
@@ -4441,7 +4441,10 @@ impl<'a> ChainBuilder<'a> {
 /// never disables a phase. This is the single source of truth for both the
 /// sole-stage (`SortStepCaptures`) and streaming (`RawExternalSorter`) sort
 /// paths in `add_sort`.
-fn resolve_phase_threads(override_threads: Option<usize>, num_sorter_threads: usize) -> usize {
+pub(crate) fn resolve_phase_threads(
+    override_threads: Option<usize>,
+    num_sorter_threads: usize,
+) -> usize {
     override_threads.unwrap_or(num_sorter_threads).max(1)
 }
 


### PR DESCRIPTION
## What

Removes the CLI-side throwaway sorter construction from `fgumi sort`. Since #885 routed the sort command onto the declarative arena chain, `execute_sort` no longer runs the owned engine — but it still built a full `RawExternalSorter` via a private `Sort::build_sorter` helper purely to read three numbers off it for the startup banner (Phase-1/Phase-2 thread counts and the max-temp-files limit). This deletes that dead construction and sources those numbers directly from the command's own options.

Concretely, in `src/lib/commands/sort.rs`:

- **Adds** `Sort::phase1_threads()` / `Sort::phase2_threads()` — small helpers that resolve the effective per-phase thread counts without constructing a sorter. They are deliberate, exact mirrors of `RawExternalSorter::phase1_threads()` / `phase2_threads()` (a two-line `sort_threads.unwrap_or(threads).max(1)` formula); duplicating rather than exporting a cross-crate function is intentional, because after this change the engine's own methods have only one internal caller (`SortBuffer::from_sorter`). The duplication is pinned against drift by a new `test_phase_threads_match_engine`, which constructs a `RawExternalSorter` directly and asserts the two implementations agree across representative inputs (including the zero-override clamp).
- **Sources** the max-temp-files banner line from `self.resolved_max_temp_files(soft_nofile)` directly — an exact identity, since `build_sorter` set the sorter's limit via that same call and the banner read it back.
- **Deletes** `Sort::build_sorter` and the already-`#[allow(dead_code)]` `Sort::auto_initial_capacity` helper, plus the tests that only existed to exercise them.

## What is NOT changed

`RawExternalSorter` / `SortWorkerPool` remain live production code — used by `fgumi merge`, `fgumi simulate`, and the arena chain's own per-chunk in-memory sort (`SortBuffer::from_sorter`). `crates/fgumi-sort` is untouched. This PR only removes the CLI's throwaway *construction* of a sorter for banner values, not the engine itself.

## Correctness

The startup banner text is unchanged: the new helpers reproduce the exact numbers the throwaway sorter reported (`test_sort_thread_logging` pins the literal banner line, and passes byte-identically). Output is unchanged: the `fgumi sort` cutover parity suite (`test_sort_cutover_parity`) is untouched and still passes byte-for-byte against the saved pre-cutover baseline binary across all four sort orders (coordinate, queryname, queryname-natural, template-coordinate), plus the spill/consolidation record-identity and stdin/CRC/write-index cases.

Test coverage is preserved: the deleted wiring/agreement tests were redundant with retained ones (`test_memory_budget_threads` keeps its full formula table; the new `test_phase_threads_match_engine` and the renamed `test_resolved_max_temp_files` assert the same properties without constructing a throwaway sorter), and the `--max-temp-files` consolidation-record-identity test was rewritten to build the engine directly rather than via the deleted helper.

No new `unsafe`. Full gate green (fmt, clippy `-D warnings -W pedantic`, doc `-D warnings`, test suite).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: command output changes: none; existing chain sorting and parity tests pin output. `unsafe` changes: none; CLAUDE.md allowlist unchanged. Memory bounds, queue capacity, and thread/backpressure policy changes: none; helpers mirror existing engine formulas.

Fix: Removed the CLI-only `RawExternalSorter` construction from `fgumi sort`.

- Added sorter-free phase-thread and max-temp-file resolution helpers.
- Updated banner values to use command options.
- Removed obsolete `Sort::build_sorter` and `Sort::auto_initial_capacity`.
- Added tests for engine parity, consolidation, banner values, and record identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->