### PR TITLE
feat(simplex): route the simplex command onto the declarative chain builder

### DIFF
--- a/src/lib/commands/simplex.rs
+++ b/src/lib/commands/simplex.rs
@@ -377,10 +377,7 @@ impl SimplexOptions {
 
 impl Command for Simplex {
     fn execute(&self, command_line: &str) -> Result<()> {
-        // Start timing
-        let timer = OperationTimer::new("Calling simplex consensus");
-
-        // Validate inputs
+        // ---- reader-free pre-flight (runs on BOTH paths) ----
         self.io.validate()?;
         let mut outputs: Vec<(&Path, &str)> = vec![(self.io.output.as_path(), "--output")];
         if let Some(path) = &self.rejects_opts.rejects {
@@ -392,6 +389,26 @@ impl Command for Simplex {
         reject_output_collisions(&outputs)?;
 
         self.validate_read_bounds()?;
+
+        if self.reference.is_some() && self.methylation_mode.is_none() {
+            bail!("--ref requires --methylation-mode to be set");
+        }
+
+        // ---- --threads N on a consensus build: run on the declarative chain ----
+        // Dispatch BEFORE the timer/banner/reader below (execute_chain ->
+        // add_simplex builds its own). On a non-consensus build the chain
+        // machinery isn't compiled, so this block is absent and we fall through
+        // to the legacy threaded path.
+        #[cfg(feature = "consensus")]
+        if self.threading.threads.is_some() {
+            return self.execute_chain(command_line);
+        }
+
+        // ---- legacy tail (UNCHANGED): timer, banner, methylation resolve,
+        //      reader, Some(threads)->execute_threads_mode / None->single-
+        //      threaded fast path ----
+        // Start timing
+        let timer = OperationTimer::new("Calling simplex consensus");
 
         info!("Starting Simplex");
         info!("Input: {}", self.io.input.display());
@@ -411,9 +428,6 @@ impl Command for Simplex {
         // Enable rejects tracking if rejects file is specified
         let track_rejects = self.rejects_opts.is_enabled();
 
-        if self.reference.is_some() && self.methylation_mode.is_none() {
-            bail!("--ref requires --methylation-mode to be set");
-        }
         let methylation_mode =
             crate::commands::common::resolve_methylation_mode(self.methylation_mode);
 
@@ -665,6 +679,37 @@ impl Simplex {
     /// Returns an error if `min_reads` is 0, or if `max_reads` is below `min_reads`.
     fn validate_read_bounds(&self) -> Result<()> {
         self.to_simplex_options().validate_read_bounds()
+    }
+
+    /// Run the simplex stage on the declarative chain builder (the `--threads N`
+    /// path on a `consensus`-feature build).
+    ///
+    /// Replaces the hand-rolled unified-pipeline construction in `execute` for
+    /// the threaded case. The chain opens its own source, validates the
+    /// template-coordinate sort order, calls consensus, writes the output BAM,
+    /// and writes the rejects/stats via `SimplexFinalizeHook` — all through the
+    /// same shared helpers as the non-chain path, so the two orchestrations stay
+    /// in parity. The no-`--threads` path keeps its own single-threaded fast
+    /// path in `execute`, which is the in-process parity oracle for this one
+    /// (see `test_simplex_chain_matches_single_threaded`).
+    #[cfg(feature = "consensus")]
+    fn execute_chain(&self, command_line: &str) -> Result<()> {
+        use crate::pipeline::chains::{
+            ChainSpec, SingleStageContext, Stage, StageOptionsBag, build_for,
+        };
+        self.io.log_effective_check_crc();
+        let stage_opts =
+            StageOptionsBag { simplex: Some(self.to_simplex_options()), ..Default::default() };
+        let ctx = SingleStageContext {
+            io: &self.io,
+            threading: &self.threading,
+            compression: &self.compression,
+            scheduler: &self.scheduler_opts,
+            queue_memory: &self.queue_memory,
+            command_line,
+        };
+        let spec = ChainSpec::single_stage(Stage::Simplex, stage_opts, &ctx);
+        build_for(spec)?.run()
     }
 
     /// Execute using 7-step unified pipeline with --threads.

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -385,6 +385,16 @@ pub struct ChainBuilder<'a> {
     /// `add_source()` (SAM parse step uses it).
     header: Header,
 
+    /// The raw source header exactly as read from the input, **before** this
+    /// chain's `@PG` record is injected. Populated by `new()`. Used where a
+    /// stage must advertise the *unmodified* input header rather than the
+    /// chain's output header — specifically the consensus commands' `--rejects`
+    /// sink, whose records are raw-input records in input order (the PR #332
+    /// contract) and so must carry the input's `@PG`/`@RG`/`@HD` verbatim, to
+    /// match the single-threaded fast path (which opens the raw reader and
+    /// writes rejects with that header, un-augmented).
+    raw_source_header: Header,
+
     /// In-progress chain state. `None` before the first step (before
     /// `add_source` runs); `Some((producer, branch))` after. Updated
     /// by every `add_source` / `add_<stage>` / `add_sink` call.
@@ -545,12 +555,19 @@ impl<'a> ChainBuilder<'a> {
         // command's execute() does this before add_pg_record; ChainBuilder must
         // match the same order so @HD lands before @PG is appended.
         let raw_header = crate::commands::common::ensure_hd_record(raw_header)?;
+        // Retain the raw source header (post-`@HD`, pre-`@PG`) so stages that
+        // must advertise the unmodified input header (the consensus `--rejects`
+        // sink) can use it verbatim; see `raw_source_header`. This matches the
+        // legacy simplex/codec `execute()`, which likewise synthesizes `@HD`
+        // before writing rejects but never stamps `@PG` on the rejects header.
+        let raw_source_header = raw_header.clone();
         let header = crate::commands::common::add_pg_record(raw_header, &spec.command_line)?;
 
         Ok(Self {
             spec,
             tuning,
             header,
+            raw_source_header,
             current_tail: None,
             pipeline: PipelineBuilder::new(),
             finalize: Vec::new(),
@@ -3154,10 +3171,29 @@ impl<'a> ChainBuilder<'a> {
         // rejects, breaking the "same as standalone" contract.
         simplex.validate_read_bounds()?;
 
+        // Resolve source path for log messages and the sort-order guard below.
+        let input_path = self.resolve_log_input_path();
+
+        // Both legacy simplex paths call `check_consensus_sort_order` right
+        // after opening the reader; reproduce that guard here so a mis-sorted
+        // input is rejected instead of silently mis-grouped by `GroupByMi`
+        // (which has no out-of-order/duplicate detection of its own). Guard only
+        // when simplex consumes the raw source directly (the standalone
+        // `[Stage::Simplex]` chain): in a fused runall chain (e.g.
+        // group -> simplex) an upstream stage already orders/produces the records
+        // simplex groups, and `self.header` is the pre-upstream source header
+        // whose order simplex no longer depends on -- guarding it there would
+        // reject inputs the upstream stage (with its own guard) legitimately
+        // accepts.
+        if self.spec.stages.first() == Some(&Stage::Simplex) {
+            crate::commands::common::check_consensus_sort_order(
+                &self.header,
+                &input_path.display().to_string(),
+            )?;
+        }
+
         let tail = self.current_tail.expect("add_simplex called before add_source");
 
-        // Resolve source path for log messages only.
-        let input_path = self.resolve_log_input_path();
         let output_path = self.spec.sink.path().clone();
 
         let timer = OperationTimer::new("Calling simplex consensus");
@@ -3212,11 +3248,25 @@ impl<'a> ChainBuilder<'a> {
         // make_prefix_from_header returns "" which is the correct empty prefix.
         let read_name_prefix = simplex.read_group.prefix_or_from_header(&self.header);
 
-        // Capture the input header (raw-input RG/PG + @HD sort fields) BEFORE
-        // replacing self.header with the consensus output header. Per the PR
-        // #332 rejects contract, the rejects branch is written with this input
-        // header verbatim (rejects are raw-input records in input order).
-        let input_header = self.header.clone();
+        // The rejects branch is written with the raw-input header verbatim
+        // (raw-input RG/PG + @HD sort fields), per the PR #332 rejects contract:
+        // rejects are raw-input records in input order. Select that header
+        // stage-aware, mirroring the `check_consensus_sort_order` guard above:
+        // when simplex consumes the raw source directly (the standalone
+        // `[Stage::Simplex]` chain), it is `raw_source_header` (the header before
+        // this chain's `@PG` injection), so threaded rejects carry the same
+        // provenance as the single-threaded fast path — which writes rejects with
+        // the un-augmented input header. In a fused chain (e.g. `sort -> simplex`)
+        // an upstream stage rewrote `self.header`; the rejects must then advertise
+        // that stage-input header, not the original source — so use `self.header`,
+        // which is still the stage input here (`replace_header` below has not yet
+        // run). Reachable only once a multi-stage builder lands; single_stage
+        // chains always take the first arm today.
+        let input_header = if self.spec.stages.first() == Some(&Stage::Simplex) {
+            self.raw_source_header.clone()
+        } else {
+            self.header.clone()
+        };
 
         // Replace self.header with the consensus output header so add_sink()
         // uses the correct header for WriteBgzfFile.

--- a/tests/integration/test_simplex_command.rs
+++ b/tests/integration/test_simplex_command.rs
@@ -26,8 +26,10 @@ use tempfile::TempDir;
 
 use crate::helpers::assertions::{int_tag, string_tag};
 use crate::helpers::bam_generator::{
-    create_minimal_header, create_paired_umi_family, create_umi_family, to_record_buf,
+    create_coordinate_sorted_header, create_minimal_header, create_paired_umi_family,
+    create_umi_family, to_record_buf,
 };
+use crate::helpers::read_bam_output;
 
 /// Write grouped BAM file (reads grouped by MI tag).
 fn create_grouped_bam(path: &Path, families: Vec<(&str, Vec<fgumi_raw_bam::RawRecord>)>) {
@@ -873,4 +875,457 @@ fn test_simplex_indel_at_overlap_boundary_still_calls_a_consensus() {
             if is_r1 { "R1" } else { "R2" }
         );
     }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Chain-path (`--threads`) parity tests
+//
+// `simplex --threads N` routes through the declarative chain builder; the
+// no-`--threads` path keeps its own single-threaded fast path and is the
+// in-process parity oracle these tests diff against.
+//////////////////////////////////////////////////////////////////////////////
+
+/// Read a BAM's records back as decoded `RecordBuf`s, for record-for-record
+/// comparison (order-sensitive, catches drops/dupes/reorders that a bare count
+/// would miss), via the shared `read_bam_output` helper. (The full-header half
+/// of `read_bam_output` is used directly in the main parity test.)
+fn read_consensus_records(path: &Path) -> Vec<noodles::sam::alignment::RecordBuf> {
+    read_bam_output(path).1
+}
+
+/// Run `simplex` on `input` writing `output`, with `extra` args appended
+/// (e.g. `--threads`, `--min-reads`, output flags). Asserts the run succeeds.
+fn simplex_run(input: &Path, output: &Path, extra: &[&str]) {
+    let mut args =
+        vec!["simplex", "--input", input.to_str().unwrap(), "--output", output.to_str().unwrap()];
+    args.extend_from_slice(extra);
+    Simplex::try_parse_from(args)
+        .expect("failed to parse simplex args")
+        .execute("fgumi simplex")
+        .expect("simplex run failed");
+}
+
+/// A mix of single-end and paired-end MI families, several distinct MI groups
+/// each deep enough to survive `--min-reads 2` -- the default parity fixture
+/// for axes that don't need a more specialized shape.
+fn create_parity_families(count: usize) -> Vec<(String, Vec<fgumi_raw_bam::RawRecord>)> {
+    (0..count)
+        .map(|i| {
+            let mi = i.to_string();
+            let depth = 3 + (i % 3);
+            let family = if i % 2 == 0 {
+                create_umi_family("ACGT", depth, &format!("fam{i}"), "ACGTACGTAC", 30)
+            } else {
+                create_paired_umi_family(
+                    "TGCA",
+                    depth,
+                    &format!("fam{i}"),
+                    "ACGTACGTAC",
+                    "TTTTAAAAGG",
+                    30,
+                )
+            };
+            (mi, family)
+        })
+        .collect()
+}
+
+/// Writes [`create_parity_families`]-shaped families as the `(&str, Vec<RawRecord>)`
+/// pairs [`create_grouped_bam`] expects.
+fn write_parity_bam(path: &Path, families: &[(String, Vec<fgumi_raw_bam::RawRecord>)]) {
+    let refs: Vec<(&str, Vec<fgumi_raw_bam::RawRecord>)> =
+        families.iter().map(|(mi, records)| (mi.as_str(), records.clone())).collect();
+    create_grouped_bam(path, refs);
+}
+
+/// Axis 1 + 7: the chain (`--threads N`) path produces output records
+/// record-for-record identical to the non-chain (no-`--threads`) path, at both
+/// `--threads 1` (the minimal chain engine) and `--threads 4` (genuinely
+/// parallel, with enough distinct MI families to cross `GroupByMi` batch
+/// boundaries).
+#[rstest]
+#[case::threads_1(1)]
+#[case::threads_4(4)]
+fn test_simplex_chain_matches_single_threaded(#[case] threads: usize) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+
+    // 40 distinct MI families is enough to span multiple in-flight batches at
+    // `--threads 4` without slowing the test down.
+    let families = create_parity_families(40);
+    write_parity_bam(&input_bam, &families);
+
+    let oracle_out = temp_dir.path().join("oracle.bam");
+    simplex_run(&input_bam, &oracle_out, &["--min-reads", "2"]);
+
+    let chain_out = temp_dir.path().join("chain.bam");
+    let threads_str = threads.to_string();
+    simplex_run(&input_bam, &chain_out, &["--min-reads", "2", "--threads", &threads_str]);
+
+    let (oracle_header, expected) = read_bam_output(&oracle_out);
+    let (chain_header, actual) = read_bam_output(&chain_out);
+    assert!(!expected.is_empty(), "oracle output must be non-empty (guard against a vacuous pass)");
+    assert_eq!(
+        actual, expected,
+        "chain --threads {threads} output must match the non-chain path record-for-record"
+    );
+    // Whole-header parity (read_bam_output normalizes the @PG CL that differs by
+    // --threads): also catches a dropped @SQ/@RG/@HD/@CO.
+    assert_eq!(
+        chain_header, oracle_header,
+        "chain and non-chain output headers must match (with @PG CL normalized)"
+    );
+}
+
+/// The `--ref requires --methylation-mode` validation (relocated to run before
+/// the `--threads` chain dispatch) must reject on BOTH paths -- passing `--ref`
+/// without `--methylation-mode` errors regardless of `--threads`. The bail sits
+/// in the reader-free pre-flight, before the reference is opened, so a
+/// nonexistent `--ref` path still hits it.
+#[rstest]
+#[case::single_threaded(&[])]
+#[case::threaded(&["--threads", "2"])]
+fn test_simplex_rejects_ref_without_methylation_mode(#[case] extra: &[&str]) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let families = create_parity_families(4);
+    write_parity_bam(&input_bam, &families);
+    let out = temp_dir.path().join("out.bam");
+    let fake_ref = temp_dir.path().join("ref.fa");
+
+    let mut args = vec![
+        "simplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        out.to_str().unwrap(),
+        "--min-reads",
+        "1",
+        "--ref",
+        fake_ref.to_str().unwrap(),
+    ];
+    args.extend_from_slice(extra);
+    let err = Simplex::try_parse_from(args)
+        .expect("failed to parse simplex args")
+        .execute("fgumi simplex")
+        .expect_err("simplex must reject --ref without --methylation-mode");
+    assert!(
+        err.to_string().contains("--ref requires --methylation-mode"),
+        "unexpected error: {err:#}",
+    );
+}
+
+/// Axis 2: `--rejects` output from the chain path matches the non-chain path
+/// record-for-record, and is non-vacuous (the singleton family must actually be
+/// rejected on both paths). Also pins rejects **header** parity: the rejects
+/// BAM carries the raw input header verbatim on both paths (the PR #332
+/// contract), so the chain path must not leak its own `@PG` into rejects.
+#[test]
+fn test_simplex_chain_rejects_matches_single_threaded() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+
+    let mut families = create_parity_families(10);
+    // A singleton family that fails --min-reads 2 on both paths.
+    families
+        .push(("singleton".to_string(), create_umi_family("GATC", 1, "reject", "GGGGCCCCTT", 30)));
+    write_parity_bam(&input_bam, &families);
+
+    let oracle_out = temp_dir.path().join("oracle.bam");
+    let oracle_rejects = temp_dir.path().join("oracle.rejects.bam");
+    simplex_run(
+        &input_bam,
+        &oracle_out,
+        &["--min-reads", "2", "--rejects", oracle_rejects.to_str().unwrap()],
+    );
+
+    let chain_out = temp_dir.path().join("chain.bam");
+    let chain_rejects = temp_dir.path().join("chain.rejects.bam");
+    simplex_run(
+        &input_bam,
+        &chain_out,
+        &["--min-reads", "2", "--rejects", chain_rejects.to_str().unwrap(), "--threads", "4"],
+    );
+
+    let expected_out = read_consensus_records(&oracle_out);
+    let actual_out = read_consensus_records(&chain_out);
+    assert_eq!(actual_out, expected_out, "chain primary output must match the non-chain path");
+
+    let (oracle_rejects_header, expected_rejects) = read_bam_output(&oracle_rejects);
+    let (chain_rejects_header, actual_rejects) = read_bam_output(&chain_rejects);
+    assert!(
+        !expected_rejects.is_empty(),
+        "oracle rejects must be non-empty (guard against a vacuous pass)"
+    );
+    assert_eq!(
+        actual_rejects, expected_rejects,
+        "chain --rejects output must match the non-chain path record-for-record"
+    );
+
+    // Rejects-header provenance: rejects are raw-input records, so both paths
+    // must write them under the raw input header verbatim. `read_bam_output`
+    // normalizes the `@PG` CL, so the input header (which carries no fgumi `@PG`)
+    // must equal both rejects headers — a chain path that injected its own `@PG`
+    // into the rejects sink would fail this.
+    let (input_header, _) = read_bam_output(&input_bam);
+    assert_eq!(
+        chain_rejects_header, oracle_rejects_header,
+        "chain and non-chain rejects headers must match"
+    );
+    assert_eq!(
+        chain_rejects_header, input_header,
+        "rejects header must be the raw input header verbatim (no injected @PG)"
+    );
+}
+
+/// Axis 3: `--stats` output from the chain path is byte-identical to the
+/// non-chain path (recipe: byte-compare, not just field-by-field).
+#[test]
+fn test_simplex_chain_stats_matches_single_threaded() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+
+    let families = create_parity_families(20);
+    write_parity_bam(&input_bam, &families);
+
+    let oracle_out = temp_dir.path().join("oracle.bam");
+    let oracle_stats = temp_dir.path().join("oracle.stats.txt");
+    simplex_run(
+        &input_bam,
+        &oracle_out,
+        &["--min-reads", "2", "--stats", oracle_stats.to_str().unwrap()],
+    );
+
+    let chain_out = temp_dir.path().join("chain.bam");
+    let chain_stats = temp_dir.path().join("chain.stats.txt");
+    simplex_run(
+        &input_bam,
+        &chain_out,
+        &["--min-reads", "2", "--stats", chain_stats.to_str().unwrap(), "--threads", "4"],
+    );
+
+    let expected = fs::read(&oracle_stats).expect("read oracle stats");
+    let actual = fs::read(&chain_stats).expect("read chain stats");
+    assert!(!expected.is_empty(), "oracle stats must be non-empty (guard against a vacuous pass)");
+    assert_eq!(
+        actual, expected,
+        "chain --stats output must be byte-identical to the non-chain path"
+    );
+}
+
+/// Axis 4: methylation mode (`--methylation-mode em-seq` + `--ref`) output
+/// parity between the chain and non-chain paths. Builds a minimal grouped
+/// input with mapped, fully-methylated reads against a synthetic all-C
+/// reference, since no dedicated methylation test infra exists in this file.
+#[test]
+fn test_simplex_chain_methylation_matches_single_threaded() {
+    use fgumi_raw_bam::SamBuilder;
+    use fgumi_sam::builder::create_test_fasta;
+
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+
+    // An all-C reference so every read shows a fully-methylated (unconverted) signal.
+    let ref_seq = "C".repeat(200);
+    let ref_fasta = create_test_fasta(&[("chr1", &ref_seq)]).expect("build test fasta");
+
+    let header = create_minimal_header("chr1", 200);
+    let seq = "CCCCCCCCCC";
+    let cigar = u32::try_from(seq.len()).expect("fits u32") << 4;
+    let mut families = Vec::new();
+    for family_idx in 0..3 {
+        let records: Vec<fgumi_raw_bam::RawRecord> = (0..3)
+            .map(|read_idx| {
+                let mut b = SamBuilder::new();
+                b.read_name(format!("f{family_idx}_r{read_idx}").as_bytes())
+                    .ref_id(0)
+                    .pos(0)
+                    .mapq(60)
+                    .flags(0)
+                    .cigar_ops(&[cigar])
+                    .sequence(seq.as_bytes())
+                    .qualities(&vec![30u8; seq.len()])
+                    .add_string_tag(SamTag::RX, b"ACGT");
+                b.build()
+            })
+            .collect();
+        families.push((family_idx.to_string(), records));
+    }
+    let refs: Vec<(&str, Vec<fgumi_raw_bam::RawRecord>)> =
+        families.iter().map(|(mi, records)| (mi.as_str(), records.clone())).collect();
+    create_grouped_bam_with_header(&input_bam, &header, refs);
+
+    let methylation_args = &[
+        "--min-reads",
+        "2",
+        "--methylation-mode",
+        "em-seq",
+        "--ref",
+        ref_fasta.path().to_str().unwrap(),
+    ];
+
+    let oracle_out = temp_dir.path().join("oracle.bam");
+    simplex_run(&input_bam, &oracle_out, methylation_args);
+
+    let mut chain_args = methylation_args.to_vec();
+    chain_args.extend_from_slice(&["--threads", "4"]);
+    let chain_out = temp_dir.path().join("chain.bam");
+    simplex_run(&input_bam, &chain_out, &chain_args);
+
+    let expected = read_consensus_records(&oracle_out);
+    let actual = read_consensus_records(&chain_out);
+    assert!(!expected.is_empty(), "oracle output must be non-empty (guard against a vacuous pass)");
+    assert_eq!(
+        actual, expected,
+        "chain methylation-mode output must match the non-chain path record-for-record"
+    );
+
+    // Non-vacuity: the methylation tags this mode adds must actually be present.
+    let cu_tag = noodles::sam::alignment::record::data::field::Tag::from([b'c', b'u']);
+    assert!(
+        expected.iter().all(|r| r.data().get(&cu_tag).is_some()),
+        "methylation-mode consensus reads must carry the cu tag"
+    );
+}
+
+/// Axis 5: `--consensus-call-overlapping-bases false` output parity between the
+/// chain and non-chain paths. Uses the overlapping read-through fixture (real
+/// mate overlap), so this exercises the *disabled* overlap path -- the default
+/// (enabled) case is already covered by [`test_simplex_chain_matches_single_threaded`].
+#[test]
+fn test_simplex_chain_overlapping_disabled_matches_single_threaded() {
+    const DEPTH: usize = 3;
+
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    create_grouped_bam(&input_bam, vec![("1", indel_readthrough_family(DEPTH))]);
+
+    let args = &["--min-reads", "3", "--consensus-call-overlapping-bases", "false"];
+
+    let oracle_out = temp_dir.path().join("oracle.bam");
+    simplex_run(&input_bam, &oracle_out, args);
+
+    let mut chain_args = args.to_vec();
+    chain_args.extend_from_slice(&["--threads", "4"]);
+    let chain_out = temp_dir.path().join("chain.bam");
+    simplex_run(&input_bam, &chain_out, &chain_args);
+
+    let expected = read_consensus_records(&oracle_out);
+    let actual = read_consensus_records(&chain_out);
+    assert!(!expected.is_empty(), "oracle output must be non-empty (guard against a vacuous pass)");
+    assert_eq!(
+        actual, expected,
+        "chain --consensus-call-overlapping-bases false output must match the non-chain path"
+    );
+}
+
+/// Axis 6: `--allow-unmapped` output parity between the chain and non-chain
+/// paths, using a wholly-unmapped family (the case that most exercises the
+/// flag -- see `test_simplex_allow_unmapped_still_consenses_a_wholly_unmapped_family`).
+#[test]
+fn test_simplex_chain_allow_unmapped_matches_single_threaded() {
+    use fgumi_raw_bam::{SamBuilder, flags};
+
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+
+    let mut records = Vec::new();
+    for i in 0..3 {
+        for (segment, seq) in
+            [(flags::FIRST_SEGMENT, "ACGTACGTAC"), (flags::LAST_SEGMENT, "GGGGGGGGGG")]
+        {
+            let mut b = SamBuilder::new();
+            b.read_name(format!("unmapped_{i}").as_bytes())
+                .ref_id(-1)
+                .pos(-1)
+                .mapq(0)
+                .flags(flags::PAIRED | segment | flags::UNMAPPED | flags::MATE_UNMAPPED)
+                .mate_ref_id(-1)
+                .mate_pos(-1)
+                .sequence(seq.as_bytes())
+                .qualities(&vec![30u8; seq.len()])
+                .add_string_tag(SamTag::RX, b"ACGT");
+            records.push(b.build());
+        }
+    }
+    create_grouped_bam(&input_bam, vec![("1", records)]);
+
+    let args = &["--min-reads", "1", "--allow-unmapped"];
+
+    let oracle_out = temp_dir.path().join("oracle.bam");
+    simplex_run(&input_bam, &oracle_out, args);
+
+    let mut chain_args = args.to_vec();
+    chain_args.extend_from_slice(&["--threads", "4"]);
+    let chain_out = temp_dir.path().join("chain.bam");
+    simplex_run(&input_bam, &chain_out, &chain_args);
+
+    let expected = read_consensus_records(&oracle_out);
+    let actual = read_consensus_records(&chain_out);
+    assert!(!expected.is_empty(), "oracle output must be non-empty (guard against a vacuous pass)");
+    assert_eq!(
+        actual, expected,
+        "chain --allow-unmapped output must match the non-chain path record-for-record"
+    );
+}
+
+/// Axis 8 (proves Task 2A): a coordinate-sorted input is REJECTED on the chain
+/// (`--threads 4`) path with the same "not sorted correctly for consensus
+/// calling" error the non-chain path already raises. `add_simplex` has no
+/// out-of-order/duplicate detection of its own (`GroupByMi` doesn't either), so
+/// without the `check_consensus_sort_order` guard a mis-sorted input would be
+/// silently mis-grouped instead of rejected.
+#[test]
+fn test_simplex_chain_rejects_coordinate_sorted_input() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+
+    let header = create_coordinate_sorted_header("chr1", 10000);
+    let family = create_umi_family("ACGT", 3, "fam1", "ACGTACGTAC", 30);
+    create_grouped_bam_with_header(&input_bam, &header, vec![("1", family)]);
+
+    let output_bam = temp_dir.path().join("output.bam");
+
+    // Non-chain path (no --threads): must already reject.
+    let oracle_err = Simplex::try_parse_from([
+        "simplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--min-reads",
+        "2",
+    ])
+    .expect("failed to parse simplex args")
+    .execute("fgumi simplex")
+    .expect_err("non-chain path must reject coordinate-sorted input");
+    let oracle_message = format!("{oracle_err:#}");
+    assert!(
+        oracle_message.contains("not sorted correctly for consensus calling"),
+        "non-chain error should mention sort order: {oracle_message}"
+    );
+
+    // Chain path (--threads 4): must reject with the same message, proving the
+    // Task 2A `check_consensus_sort_order` guard in `add_simplex`.
+    let chain_out = temp_dir.path().join("chain_output.bam");
+    let chain_err = Simplex::try_parse_from([
+        "simplex",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        chain_out.to_str().unwrap(),
+        "--min-reads",
+        "2",
+        "--threads",
+        "4",
+    ])
+    .expect("failed to parse simplex args")
+    .execute("fgumi simplex")
+    .expect_err("chain path must reject coordinate-sorted input");
+    let chain_message = format!("{chain_err:#}");
+    assert!(
+        chain_message.contains("not sorted correctly for consensus calling"),
+        "chain error should mention sort order: {chain_message}"
+    );
+    assert!(!chain_out.exists(), "chain path must not create an output file on rejection");
 }


### PR DESCRIPTION
## What

Route `fgumi simplex` onto the declarative chain builder — R3.3, the first of the consensus trio.

`simplex --threads N` (on a `consensus`-feature build) now runs through `execute_chain` → `ChainSpec::single_stage(Stage::Simplex, …)` → `build_for(spec)?.run()`. The no-`--threads` single-threaded fast path is kept unchanged as an **in-process parity oracle** (legacy `execute_threads_mode` retained, removed in a follow-up).

## Feature-gating (the consensus-trio concern)

`commands::simplex` is gated `simplex`, but the chain machinery (`StageOptionsBag.simplex`, `add_simplex`) is gated `consensus`, and `simplex` does **not** imply `consensus`. So `execute_chain` and its dispatch are `#[cfg(feature = "consensus")]`-gated, and on a non-`consensus` build the dispatch is absent and execution **falls through to the legacy threaded path** (no regression, no bail). Verified: `cargo check -p fgumi --no-default-features --features simplex` compiles, alongside the default and `--all-features` builds.

## Correctness fix the cutover exposed (folded in)

- **`check_consensus_sort_order` guard in `add_simplex`.** Both legacy simplex paths call it right after opening the reader (it accepts template-coordinate/query-grouped input and rejects coordinate-sorted / plain-queryname / unsorted). `add_simplex` never did, and `GroupByMi` has no out-of-order detection — so `--threads N` would have **silently mis-grouped** a badly-sorted input into wrong consensus calls instead of rejecting it. Added the same guard (the one `builder.rs` edit). (`add_duplex`/`add_codec` almost certainly share this gap — noted for their cutovers.)

## Dispatch placement

The dispatch moves ahead of the timer/reader: the reader-free pre-flight (`io.validate`, output-collision check, `validate_read_bounds`, the `--ref`/`--methylation-mode` bail) runs first on both paths, then the consensus-gated `--threads` dispatch, then the unchanged legacy tail. An invalid run no longer prints the timer/banner before erroring — intentional, matching dedup's ordering.

## Tests

Chain-vs-oracle parity across plain, `--rejects`, `--stats` (byte-compare), methylation mode, overlapping-consensus (`--consensus-call-overlapping-bases false`, the disabled path), `--allow-unmapped`, a multi-batch case, and a coordinate-sorted rejection proving the new sort-order guard.

## Review

Spec Fable-reviewed against the code (the sort-order guard came from that review). A deep gauntlet review is running and any findings will be addressed before this is presented for merge.

## Verification

`cargo ci-fmt && cargo ci-lint && RUSTDOCFLAGS="-D warnings" cargo ci-doc && cargo ci-test` — all green (9768 tests); simplex suite 111 passing; the three feature-check legs (`--no-default-features --features simplex`, default, `--all-features`) all compile. No new `unsafe`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: threaded consensus simplex output changes, pinned by single-threaded parity and sort-order rejection tests; `unsafe`: none, with no `CLAUDE.md` allowlist update; memory bounds, queue capacity, and thread/backpressure policy: none.

Fix: Route consensus-feature threaded simplex execution through the declarative chain builder. Preserve the legacy fallback and add consensus sort-order validation to `add_simplex`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->