### PR TITLE
feat(duplex): route the duplex command onto the declarative chain builder

### DIFF
--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -446,9 +446,6 @@ impl Command for Duplex {
     /// # Ok::<(), anyhow::Error>(())
     /// ```
     fn execute(&self, command_line: &str) -> Result<()> {
-        // Start timing
-        let timer = OperationTimer::new("Calling duplex consensus");
-
         // Validate the input exists (stdin paths are exempt — the reader
         // streams them in a single pass).
         self.io.validate()?;
@@ -463,6 +460,23 @@ impl Command for Duplex {
 
         // Validate consensus arguments (e.g. error rates must be > 0).
         self.validate()?;
+
+        // ---- --threads N on a consensus build: run on the declarative chain ----
+        // Dispatch here, after the reader-free pre-flight (io.validate /
+        // output-collision / validate — which must run on both paths) and BEFORE
+        // building the timer/reader below, because `execute_chain` -> `add_duplex`
+        // builds its own timer and reader. Placing the dispatch above the timer
+        // avoids logging the "Calling duplex consensus" start line twice on the
+        // threaded path. On a non-consensus build the chain machinery isn't
+        // compiled, so this block is absent and we fall through to legacy.
+        #[cfg(feature = "consensus")]
+        if self.threading.threads.is_some() {
+            return self.execute_chain(command_line);
+        }
+
+        // Start timing (legacy single-threaded path only; the chain path above
+        // builds its own timer).
+        let timer = OperationTimer::new("Calling duplex consensus");
 
         // Get threading configuration (duplex is worker-heavy with consensus calling)
         let reader_threads = self.threading.num_threads();
@@ -790,6 +804,37 @@ impl Duplex {
     /// raw `min_reads` slice rather than reading it off a constructed caller.
     fn allows_single_strand_consensus(&self) -> bool {
         DuplexConsensusCaller::allows_single_strand_consensus(&self.min_reads)
+    }
+
+    /// Run the duplex stage on the declarative chain builder (the `--threads N`
+    /// path on a `consensus`-feature build).
+    ///
+    /// Replaces the hand-rolled unified-pipeline construction in `execute` for
+    /// the threaded case. The chain opens its own source, validates the
+    /// template-coordinate sort order, calls consensus, writes the output BAM,
+    /// and writes the rejects/stats via `DuplexFinalizeHook` — all through the
+    /// same shared helpers as the non-chain path, so the two orchestrations stay
+    /// in parity. The no-`--threads` path keeps its own single-threaded fast
+    /// path in `execute`, which is the in-process parity oracle for this one
+    /// (see `test_duplex_chain_matches_single_threaded`).
+    #[cfg(feature = "consensus")]
+    fn execute_chain(&self, command_line: &str) -> Result<()> {
+        use crate::pipeline::chains::{
+            ChainSpec, SingleStageContext, Stage, StageOptionsBag, build_for,
+        };
+        self.io.log_effective_check_crc();
+        let stage_opts =
+            StageOptionsBag { duplex: Some(self.to_duplex_options()), ..Default::default() };
+        let ctx = SingleStageContext {
+            io: &self.io,
+            threading: &self.threading,
+            compression: &self.compression,
+            scheduler: &self.scheduler_opts,
+            queue_memory: &self.queue_memory,
+            command_line,
+        };
+        let spec = ChainSpec::single_stage(Stage::Duplex, stage_opts, &ctx);
+        build_for(spec)?.run()
     }
 
     /// Execute using 7-step unified pipeline with --threads.

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -3411,10 +3411,36 @@ impl<'a> ChainBuilder<'a> {
         // pipeline — instead of surfacing a clean error here before it is built.
         fgumi_consensus::DuplexConsensusCaller::validate_min_reads(&duplex.min_reads)?;
 
+        // Resolve source path for log messages and the sort-order guard below.
+        let input_path = self.resolve_log_input_path();
+
+        // Both legacy duplex paths call `check_consensus_sort_order` right
+        // after opening the reader; reproduce that guard here so a mis-sorted
+        // input is rejected instead of silently mis-grouped by `GroupByMi`
+        // (which has no out-of-order/duplicate detection of its own). Guard only
+        // when duplex consumes the raw source directly (the standalone
+        // `[Stage::Duplex]` chain): in a fused runall chain (e.g.
+        // group -> duplex) an upstream stage already orders/produces the records
+        // duplex groups, and `self.header` is the pre-upstream source header
+        // whose order duplex no longer depends on -- guarding it there would
+        // reject inputs the upstream stage (with its own guard) legitimately
+        // accepts.
+        //
+        // The false branch (duplex not the first stage) is not exercised by a
+        // test yet: `ChainSpec` only exposes `single_stage`, so no command can
+        // construct a fused `group -> duplex` chain through `build_for` today —
+        // that branch becomes reachable (and testable end to end) once the
+        // runall multi-stage builder lands. The guard is written conditionally
+        // now so that wiring does not have to revisit it.
+        if self.spec.stages.first() == Some(&Stage::Duplex) {
+            crate::commands::common::check_consensus_sort_order(
+                &self.header,
+                &input_path.display().to_string(),
+            )?;
+        }
+
         let tail = self.current_tail.expect("add_duplex called before add_source");
 
-        // Resolve source path for log messages only.
-        let input_path = self.resolve_log_input_path();
         let output_path = self.spec.sink.path().clone();
 
         let timer = OperationTimer::new("Calling duplex consensus");
@@ -3516,6 +3542,9 @@ impl<'a> ChainBuilder<'a> {
             max_reads_per_strand,
             error_rate_pre_umi,
             error_rate_post_umi,
+            // Resolved `--tie-rule`, converted exactly as both oracle paths do
+            // (`self.consensus.tie_rule.into()` in Duplex::execute).
+            tie_rule: consensus.tie_rule.into(),
             cell_tag,
             accumulators: accumulators_for_step,
             progress: progress_records,
@@ -3547,7 +3576,10 @@ impl<'a> ChainBuilder<'a> {
             // with the fused bridge above and standalone duplex.
             // MI transform: strip /A and /B so both strands group together.
             let mi_transform = |mi_bytes: &[u8]| -> String {
-                let mi_str = std::borrow::Cow::from(std::str::from_utf8(mi_bytes).unwrap_or(""));
+                // Match the oracle's `MiGroupIterator` transform: decode with
+                // `from_utf8_lossy` (not `from_utf8().unwrap_or("")`) so malformed
+                // MI bytes group identically on both paths.
+                let mi_str = String::from_utf8_lossy(mi_bytes);
                 extract_mi_base(&mi_str).to_string()
             };
             // `with_cell_tag` is defensive/redundant given MI uniqueness

--- a/src/lib/pipeline/chains/commands/duplex.rs
+++ b/src/lib/pipeline/chains/commands/duplex.rs
@@ -13,8 +13,9 @@
 //!
 //! This module supplies the chain-builder pieces for the duplex stage; the
 //! chain is constructed via `ChainBuilder` /
-//! [`crate::pipeline::chains::build::build_for`]. It is not yet wired as
-//! `Duplex::execute`'s live path.
+//! [`crate::pipeline::chains::build::build_for`]. `Duplex::execute` routes the
+//! `--threads N` path through this chain (via `execute_chain`), keeping the
+//! no-`--threads` in-process path as the parity oracle.
 
 use std::io;
 use std::sync::Arc;
@@ -76,6 +77,13 @@ pub(crate) struct CollectedDuplexMetrics {
 pub(crate) struct DuplexState {
     pub(crate) caller: DuplexConsensusCaller,
     pub(crate) overlapping: Option<OverlappingBasesConsensusCaller>,
+    /// Whether a molecule seen on only one strand can still yield a consensus
+    /// (`DuplexConsensusCaller::allows_single_strand_consensus(&min_reads)`),
+    /// i.e. fgbio's `-M 1 1 0` single-strand mode. Computed once at worker
+    /// init and read (never recomputed) by the overlapping-consensus gate in
+    /// [`run_duplex_consensus_batch`], mirroring the oracle's
+    /// `(single_strand_allowed || has_both_strands_raw(..))` condition.
+    pub(crate) single_strand_allowed: bool,
 }
 
 impl crate::pipeline::core::item::HeapSize for DuplexState {}
@@ -178,6 +186,9 @@ pub(crate) struct DuplexConsensusCaptures {
     pub(crate) max_reads_per_strand: Option<usize>,
     pub(crate) error_rate_pre_umi: u8,
     pub(crate) error_rate_post_umi: u8,
+    /// Resolved tie-breaking rule (`--tie-rule`). Threaded through so the chain
+    /// caller applies `.with_tie_rule(..)` exactly like both oracle paths.
+    pub(crate) tie_rule: fgumi_consensus::TieRule,
     pub(crate) cell_tag: noodles::sam::alignment::record::data::field::Tag,
     pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedDuplexMetrics>>,
     pub(crate) progress: Arc<AtomicU64>,
@@ -207,6 +218,7 @@ fn make_duplex_consensus_init(
     methylation_ref: MethylationRef,
     methylation_mode: fgumi_consensus::MethylationMode,
     overlapping_enabled: bool,
+    tie_rule: fgumi_consensus::TieRule,
 ) -> impl Fn() -> DuplexState + Send + Sync + 'static {
     move || {
         let mut caller = DuplexConsensusCaller::new(
@@ -222,7 +234,12 @@ fn make_duplex_consensus_init(
             error_rate_pre_umi,
             error_rate_post_umi,
         )
-        .expect("DuplexConsensusCaller::new failed during worker init");
+        .expect("DuplexConsensusCaller::new failed during worker init")
+        // Apply the resolved `--tie-rule`, matching both oracle paths
+        // (`with_tie_rule` in Duplex::execute's single-threaded and legacy
+        // threaded callers). `TieRule` is `Copy`, so the `Fn` closure re-applies
+        // it on every per-worker init.
+        .with_tie_rule(tie_rule);
         if let Some((ref reference, ref ref_names)) = methylation_ref {
             caller.set_reference(Arc::clone(reference), Arc::clone(ref_names), methylation_mode);
         }
@@ -234,7 +251,9 @@ fn make_duplex_consensus_init(
         } else {
             None
         };
-        DuplexState { caller, overlapping }
+        let single_strand_allowed =
+            DuplexConsensusCaller::allows_single_strand_consensus(&min_reads);
+        DuplexState { caller, overlapping, single_strand_allowed }
     }
 }
 
@@ -268,7 +287,8 @@ fn run_duplex_consensus_batch(
         total_input_records += group_reads.len() as u64;
 
         if let Some(ref mut oc) = state.overlapping
-            && crate::commands::duplex::has_both_strands_raw(&group_reads)
+            && (state.single_strand_allowed
+                || crate::commands::duplex::has_both_strands_raw(&group_reads))
         {
             oc.reset_stats();
             apply_overlapping_consensus(&mut group_reads, oc).map_err(|e| {
@@ -337,6 +357,7 @@ pub(crate) fn build_duplex_consensus_step_with_rejects(
         max_reads_per_strand,
         error_rate_pre_umi,
         error_rate_post_umi,
+        tie_rule,
         cell_tag,
         accumulators,
         progress,
@@ -357,6 +378,7 @@ pub(crate) fn build_duplex_consensus_step_with_rejects(
         methylation_ref,
         methylation_mode,
         overlapping_enabled,
+        tie_rule,
     );
     let body = move |state: &mut DuplexState,
                      item: BatchedMiGroups|
@@ -425,6 +447,7 @@ pub(crate) fn build_duplex_consensus_step_kept_only(
         max_reads_per_strand,
         error_rate_pre_umi,
         error_rate_post_umi,
+        tie_rule,
         cell_tag,
         accumulators,
         progress,
@@ -445,6 +468,7 @@ pub(crate) fn build_duplex_consensus_step_kept_only(
         methylation_ref,
         methylation_mode,
         overlapping_enabled,
+        tie_rule,
     );
     let body =
         move |state: &mut DuplexState, item: BatchedMiGroups| -> io::Result<DecompressedBlock> {

--- a/tests/integration/test_duplex_command.rs
+++ b/tests/integration/test_duplex_command.rs
@@ -18,7 +18,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
-use crate::helpers::bam_generator::{create_minimal_header, to_record_buf};
+use crate::helpers::bam_generator::{
+    create_coordinate_sorted_header, create_minimal_header, create_test_reference, to_record_buf,
+};
 
 /// Create a paired-end read pair for duplex consensus testing.
 ///
@@ -1876,4 +1878,551 @@ fn test_duplex_ignores_unmapped_end_when_mapped_reads_present() {
     // the AB and BA strands, so it does not expose the AB single-strand bases this test is about.
     // (The simplex counterpart can assert bases because it has only one strand.)
     assert_eq!(depth(r2, SamTag::AD), 2, "R2 must use only the two mapped AB reads");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Chain-vs-single-threaded parity tests (R3.6 duplex cutover)
+//
+// `Duplex::execute`'s no-`--threads` single-threaded fast path is the
+// in-process parity oracle. `--threads N` on a `consensus`-feature build now
+// runs on the declarative chain builder (`ChainBuilder::add_duplex`). These
+// tests pin record/header parity between the two paths across duplex's knobs,
+// including the Task 1A overlapping-consensus single-strand fix.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Run `duplex` with `extra` args appended to a base `-i/-o --min-reads
+/// --compression-level` invocation, returning the output header and records
+/// via [`crate::helpers::read_bam_output`] (which normalizes the `@PG` `CL`
+/// field so two runs against different temp paths compare equal).
+fn run_duplex_output(
+    input: &Path,
+    output: &Path,
+    min_reads: &str,
+    extra: &[&str],
+) -> (noodles::sam::Header, Vec<noodles::sam::alignment::RecordBuf>) {
+    let mut args = vec![
+        "duplex",
+        "--input",
+        input.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--min-reads",
+        min_reads,
+        "--compression-level",
+        "1",
+    ];
+    args.extend_from_slice(extra);
+    Duplex::try_parse_from(args)
+        .expect("failed to parse duplex args")
+        .execute("fgumi duplex")
+        .expect("Duplex command failed");
+    crate::helpers::read_bam_output(output)
+}
+
+/// Plain parity: full-header + record parity, chain `--threads 4` vs the
+/// single-threaded oracle. Input exercises AB/BA strand pairing (the
+/// strand-stripping preamble is the load-bearing duplex behavior).
+#[rstest]
+#[case::threads1("1")]
+#[case::threads2("2")]
+#[case::threads4("4")]
+fn test_duplex_chain_matches_single_threaded(#[case] threads: &str) {
+    // `--threads 1` is the dispatch-predicate boundary (`Some(1)` still routes to
+    // the chain, not the serial oracle), so it must be in the matrix alongside 2/4.
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    create_duplex_bam(&input_bam, vec![create_duplex_molecule("1", "ACGTACGT", 30, 100, 5)]);
+
+    let single = run_duplex_output(&input_bam, &temp_dir.path().join("single.bam"), "1", &[]);
+    let chain = run_duplex_output(
+        &input_bam,
+        &temp_dir.path().join("chain.bam"),
+        "1",
+        &["--threads", threads],
+    );
+
+    assert!(!single.1.is_empty(), "sanity: expected duplex consensus records");
+    assert_eq!(
+        single, chain,
+        "chain (--threads {threads}) output header+records must match the single-threaded oracle",
+    );
+}
+
+/// Build a single duplex molecule whose position 0 is a verified one-ULP
+/// near-tie: four Q37 observations reading `C,C,T,T` on each strand. At duplex's
+/// default error rates (45 pre-UMI / 40 post-UMI — the exact `ConsensusBaseBuilder`
+/// params the base-builder unit tests pin) the two bases' log-likelihoods differ
+/// by a single ULP of accumulation noise, so the two tie rules disagree there and
+/// nowhere else: `fgbio-compat` (the default) calls `T`, `ulp-relative` no-calls
+/// (`N`). All other positions are unanimous `A`, so they call identically under
+/// both rules. This is what makes the fixture *tie-sensitive* — the property the
+/// old `"ACGTACGT"` fixture lacked, which let a chain that dropped
+/// `.with_tie_rule(..)` still pass.
+fn create_tie_sensitive_molecule() -> Vec<(RawRecord, RawRecord)> {
+    // Two `C` and two `T` at position 0; the remaining positions agree.
+    let split_seqs = ["CAAAAAAA", "CAAAAAAA", "TAAAAAAA", "TAAAAAAA"];
+    let mut molecule = Vec::new();
+    for (i, seq) in split_seqs.iter().enumerate() {
+        molecule.push(create_duplex_read_pair(&format!("ab_{i}"), "1/A", seq, 37, 100, false));
+    }
+    for (i, seq) in split_seqs.iter().enumerate() {
+        molecule.push(create_duplex_read_pair(&format!("ba_{i}"), "1/B", seq, 37, 100, true));
+    }
+    molecule
+}
+
+/// `--tie-rule` parity (pins F1/F2): the chain path must apply the resolved
+/// `--tie-rule` to its `DuplexConsensusCaller` exactly like the oracle. A chain
+/// that dropped `.with_tie_rule(..)` (the original bug) would fall back to the
+/// default rule and diverge on any tie-sensitive call.
+///
+/// The fixture is a *verified* one-ULP near-tie (see
+/// [`create_tie_sensitive_molecule`]), so the two rules produce genuinely
+/// different consensus output — the test guards that with an explicit
+/// `default != ulp-relative` assertion, so it can never silently regress into
+/// the vacuous shape (identical output under both rules) that would let a
+/// dropped `.with_tie_rule(..)` pass unnoticed.
+#[test]
+fn test_duplex_chain_tie_rule_parity() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    create_duplex_bam(&input_bam, vec![create_tie_sensitive_molecule()]);
+
+    // Oracle (serial) under the default rule vs the opted-in ulp-relative rule.
+    let default_out = run_duplex_output(&input_bam, &temp_dir.path().join("default.bam"), "1", &[]);
+    let extra = ["--tie-rule", "ulp-relative"];
+    let single = run_duplex_output(&input_bam, &temp_dir.path().join("single.bam"), "1", &extra);
+
+    // The fixture must actually distinguish the two rules; otherwise the parity
+    // assertion below is vacuous and would pass even with the tie-rule dropped.
+    assert!(!single.1.is_empty(), "sanity: expected duplex consensus records");
+    assert_ne!(
+        default_out, single,
+        "fixture must be tie-sensitive: the default (fgbio-compat) and ulp-relative rules \
+         must produce different output, else this test cannot catch a dropped --tie-rule",
+    );
+
+    // Pin the known per-rule call at the tied position: default calls `T`,
+    // ulp-relative no-calls (`N`) — the base-builder-verified divergence.
+    let first_base = |out: &(noodles::sam::Header, Vec<noodles::sam::alignment::RecordBuf>)| {
+        let seq = out.1[0].sequence().as_ref();
+        seq[0]
+    };
+    assert_eq!(first_base(&default_out), b'T', "default (fgbio-compat) resolves the tie to T");
+    assert_eq!(first_base(&single), b'N', "ulp-relative no-calls the one-ULP tie");
+
+    // The chain path (--threads 4) under ulp-relative must match the oracle
+    // exactly. If `.with_tie_rule(..)` were dropped the chain would fall back to
+    // the default rule and call `T` where the oracle calls `N`, failing here.
+    let mut chain_extra = extra.to_vec();
+    chain_extra.extend_from_slice(&["--threads", "4"]);
+    let chain =
+        run_duplex_output(&input_bam, &temp_dir.path().join("chain.bam"), "1", &chain_extra);
+    assert_eq!(single, chain, "chain must honor --tie-rule ulp-relative identically to the oracle");
+}
+
+/// `--rejects` parity: record parity AND header parity (pins Task 2A — duplex
+/// intentionally keeps the `@PG` on rejects, unlike simplex/codec). Uses a
+/// family that fails `--min-reads` on both strands so rejects are non-empty.
+#[test]
+fn test_duplex_chain_rejects_parity() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    // depth=1 per strand; --min-reads 2 (-> [2,2,2]) requires >=2 templates
+    // per strand, so both strands fail and the whole group's raw records land
+    // in rejects.
+    create_duplex_bam(&input_bam, vec![create_duplex_molecule("1", "ACGTACGT", 30, 100, 1)]);
+
+    let run = |tag: &str, extra: &[&str]| {
+        let output = temp_dir.path().join(format!("{tag}-out.bam"));
+        let rejects = temp_dir.path().join(format!("{tag}-rej.bam"));
+        let mut args = vec![
+            "duplex",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            "--min-reads",
+            "2",
+            "--rejects",
+            rejects.to_str().unwrap(),
+            "--compression-level",
+            "1",
+        ];
+        args.extend_from_slice(extra);
+        Duplex::try_parse_from(args)
+            .expect("failed to parse duplex args")
+            .execute("fgumi duplex")
+            .expect("Duplex command failed");
+        (crate::helpers::read_bam_output(&output), crate::helpers::read_bam_output(&rejects))
+    };
+
+    let (single_out, single_rej) = run("single", &[]);
+    let (chain_out, chain_rej) = run("chain", &["--threads", "4"]);
+
+    assert!(single_out.1.is_empty(), "sanity: both strands fail --min-reads 2, no consensus");
+    assert!(!single_rej.1.is_empty(), "sanity: rejects must be non-vacuous");
+    assert_eq!(single_out, chain_out, "output header+records parity");
+    assert_eq!(
+        single_rej.0, chain_rej.0,
+        "rejects header parity (pins Task 2A: duplex keeps @PG on rejects)"
+    );
+    assert_eq!(single_rej.1, chain_rej.1, "rejects record parity");
+}
+
+/// `--stats` parity: byte-compare the duplex stats TSV between the two paths.
+#[test]
+fn test_duplex_chain_stats_parity() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    create_duplex_bam(&input_bam, vec![create_duplex_molecule("1", "ACGTACGT", 30, 100, 3)]);
+
+    let run = |tag: &str, extra: &[&str]| -> String {
+        let output = temp_dir.path().join(format!("{tag}-out.bam"));
+        let stats = temp_dir.path().join(format!("{tag}-stats.txt"));
+        let mut args = vec![
+            "duplex",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            "--min-reads",
+            "1",
+            "--stats",
+            stats.to_str().unwrap(),
+            "--compression-level",
+            "1",
+        ];
+        args.extend_from_slice(extra);
+        Duplex::try_parse_from(args)
+            .expect("failed to parse duplex args")
+            .execute("fgumi duplex")
+            .expect("Duplex command failed");
+        fs::read_to_string(&stats).expect("read stats")
+    };
+
+    let single = run("single", &[]);
+    let chain = run("chain", &["--threads", "4"]);
+
+    assert!(!single.trim().is_empty(), "sanity: stats file must be non-empty");
+    assert_eq!(single, chain, "duplex stats TSV must be byte-identical across the two paths");
+}
+
+/// `--stats` parity on an input that PRODUCES rejects (pins F6): the prior
+/// stats-parity test uses an all-kept input, so the reject/filter accounting
+/// columns are all zero and never compared. Here `--min-reads 2` on a depth-1
+/// molecule fails both strands, so the reject-count columns are non-zero and
+/// their chain-vs-oracle parity is actually exercised.
+#[test]
+fn test_duplex_chain_stats_parity_with_rejects() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    create_duplex_bam(&input_bam, vec![create_duplex_molecule("1", "ACGTACGT", 30, 100, 1)]);
+
+    let run = |tag: &str, extra: &[&str]| -> String {
+        let output = temp_dir.path().join(format!("{tag}-out.bam"));
+        let stats = temp_dir.path().join(format!("{tag}-stats.txt"));
+        let mut args = vec![
+            "duplex",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            "--min-reads",
+            "2",
+            "--stats",
+            stats.to_str().unwrap(),
+            "--compression-level",
+            "1",
+        ];
+        args.extend_from_slice(extra);
+        Duplex::try_parse_from(args)
+            .expect("failed to parse duplex args")
+            .execute("fgumi duplex")
+            .expect("Duplex command failed");
+        fs::read_to_string(&stats).expect("read stats")
+    };
+
+    let single = run("single", &[]);
+    let chain = run("chain", &["--threads", "4"]);
+
+    assert!(!single.trim().is_empty(), "sanity: stats file must be non-empty");
+    assert_eq!(
+        single, chain,
+        "duplex stats TSV (with non-zero reject columns) must be byte-identical across paths",
+    );
+}
+
+/// Methylation mode (`--methylation-mode em-seq` + `--ref`) parity.
+#[test]
+fn test_duplex_chain_methylation_mode_parity() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let ref_path = create_test_reference(temp_dir.path());
+    create_duplex_bam(&input_bam, vec![create_duplex_molecule("1", "ACGTACGT", 30, 100, 3)]);
+
+    let extra = ["--methylation-mode", "em-seq", "--ref", ref_path.to_str().unwrap()];
+    let single = run_duplex_output(&input_bam, &temp_dir.path().join("single.bam"), "1", &extra);
+    let mut chain_extra = extra.to_vec();
+    chain_extra.extend_from_slice(&["--threads", "4"]);
+    let chain =
+        run_duplex_output(&input_bam, &temp_dir.path().join("chain.bam"), "1", &chain_extra);
+
+    assert!(!single.1.is_empty(), "sanity: expected consensus records");
+    assert_eq!(single, chain, "methylation-mode output header+records must match across paths");
+}
+
+/// Overlapping-consensus disabled (`--consensus-call-overlapping-bases
+/// false`) parity, on the overlapping-mates fixture.
+#[test]
+fn test_duplex_chain_overlapping_disabled_parity() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    write_overlapping_single_strand_fixture(&input_bam);
+
+    let extra = ["--consensus-call-overlapping-bases", "false"];
+    let single =
+        run_duplex_output(&input_bam, &temp_dir.path().join("single.bam"), "1,1,0", &extra);
+    let mut chain_extra = extra.to_vec();
+    chain_extra.extend_from_slice(&["--threads", "4"]);
+    let chain =
+        run_duplex_output(&input_bam, &temp_dir.path().join("chain.bam"), "1,1,0", &chain_extra);
+
+    assert!(!single.1.is_empty(), "sanity: expected a single-strand consensus pair");
+    assert_eq!(single, chain, "overlapping-disabled output header+records must match across paths");
+}
+
+/// BLOCKING-bug regression pin (Task 1A). The chain path's overlapping-consensus
+/// gate must apply `single_strand_allowed || has_both_strands_raw(..)`, matching
+/// the oracle, rather than `has_both_strands_raw(..)` alone. `--min-reads 1,1,0`
+/// (single-strand mode) plus `--consensus-call-overlapping-bases true` on a
+/// single-strand-only molecule is the exact condition the buggy chain path
+/// skipped overlapping correction for. Before the Task 1A fix this fails at
+/// every `--threads` value below (the chain path emits the *uncorrected*
+/// single-strand consensus while the oracle emits the corrected one); after
+/// the fix both paths agree.
+#[rstest]
+#[case::threads_2("2")]
+#[case::threads_4("4")]
+fn test_duplex_chain_single_strand_overlapping_parity(#[case] threads: &str) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    write_overlapping_single_strand_fixture(&input_bam);
+
+    let extra = ["--consensus-call-overlapping-bases", "true"];
+    let oracle =
+        run_duplex_output(&input_bam, &temp_dir.path().join("oracle.bam"), "1,1,0", &extra);
+    let mut chain_extra = extra.to_vec();
+    chain_extra.extend_from_slice(&["--threads", threads]);
+    let chain =
+        run_duplex_output(&input_bam, &temp_dir.path().join("chain.bam"), "1,1,0", &chain_extra);
+
+    assert!(!oracle.1.is_empty(), "sanity: expected a single-strand consensus pair");
+    assert_eq!(
+        oracle, chain,
+        "chain (--threads {threads}) must match the oracle's overlapping-corrected \
+         single-strand consensus (Task 1A regression pin)",
+    );
+}
+
+/// A molecule seen on only one strand, with `--min-reads` requiring both
+/// strands (the default `1,1,1`), must be rejected identically by the chain
+/// and the single-threaded oracle: no consensus, and — with `--rejects` set —
+/// every raw record streamed to rejects.
+#[test]
+fn test_duplex_chain_only_one_strand_rejects_parity() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    create_duplex_bam(
+        &input_bam,
+        vec![create_single_strand_molecule("1", "ACGTACGT", 30, 100, 3, false)],
+    );
+
+    let run = |tag: &str, extra: &[&str]| {
+        let output = temp_dir.path().join(format!("{tag}-out.bam"));
+        let rejects = temp_dir.path().join(format!("{tag}-rej.bam"));
+        let mut args = vec![
+            "duplex",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            "--min-reads",
+            "1",
+            "--rejects",
+            rejects.to_str().unwrap(),
+            "--compression-level",
+            "1",
+        ];
+        args.extend_from_slice(extra);
+        Duplex::try_parse_from(args)
+            .expect("failed to parse duplex args")
+            .execute("fgumi duplex")
+            .expect("Duplex command failed");
+        (crate::helpers::read_bam_output(&output), crate::helpers::read_bam_output(&rejects))
+    };
+
+    let (single_out, single_rej) = run("single", &[]);
+    let (chain_out, chain_rej) = run("chain", &["--threads", "4"]);
+
+    assert!(
+        single_out.1.is_empty(),
+        "sanity: single-strand molecule rejected under default --min-reads"
+    );
+    assert_eq!(single_rej.1.len(), 6, "sanity: all 3 read pairs (6 records) must land in rejects");
+    assert_eq!(single_out, chain_out, "output header+records parity");
+    assert_eq!(single_rej, chain_rej, "rejects header+records parity");
+}
+
+/// A strand-count-mismatch molecule (4 `/A` pairs, 1 `/B` pair) proves the
+/// `/A`/`/B` strand-stripping MI transform (`extract_mi_base`) groups both
+/// strands into the same consensus identically on both paths.
+#[test]
+fn test_duplex_chain_strand_mismatch_parity() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let mut molecule = create_single_strand_molecule("1", "ACGTACGT", 30, 100, 4, false);
+    molecule.extend(create_single_strand_molecule("1", "ACGTACGT", 30, 100, 1, true));
+    create_duplex_bam(&input_bam, vec![molecule]);
+
+    let single = run_duplex_output(&input_bam, &temp_dir.path().join("single.bam"), "1", &[]);
+    let chain =
+        run_duplex_output(&input_bam, &temp_dir.path().join("chain.bam"), "1", &["--threads", "4"]);
+
+    assert!(!single.1.is_empty(), "sanity: 4 AB + 1 BA reads satisfy --min-reads 1,1,1");
+    assert_eq!(single, chain, "strand-mismatch output header+records must match across paths");
+}
+
+/// Enough distinct-MI molecules to force the chain path's `--threads 4` run
+/// across multiple pipeline batches (precedent:
+/// `test_group_command.rs::create_multi_batch_input_bam` +
+/// `test_group_chain_threads4_matches_single_threaded_multi_batch`).
+fn create_multi_batch_duplex_bam(path: &Path, n: usize) {
+    let molecules = (0..n)
+        .map(|i| {
+            let ref_start = 100 + i32::try_from(i).expect("n fits i32") * 200;
+            create_duplex_molecule(&i.to_string(), "ACGTACGT", 30, ref_start, 1)
+        })
+        .collect();
+    // The molecules span positions out to ~200*n, well past the 10 kb `chr1`
+    // that `create_duplex_bam`'s minimal header declares, which would place the
+    // mapped records off the end of the contig. Declare a contig large enough to
+    // hold every generated alignment — matching the sibling group precedent
+    // (`test_group_command.rs::create_multi_batch_input_bam`, LN 10_000_000).
+    let header = create_minimal_header("chr1", 10_000_000);
+    create_duplex_bam_with_header(path, &header, molecules);
+}
+
+/// `--threads 4` output must match the single-threaded oracle record-for-record
+/// across many pipeline batches, not just within a single one.
+#[test]
+fn test_duplex_chain_threads4_matches_single_threaded_multi_batch() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    create_multi_batch_duplex_bam(&input_bam, 600);
+
+    let single = run_duplex_output(&input_bam, &temp_dir.path().join("single.bam"), "1", &[]);
+    let chain =
+        run_duplex_output(&input_bam, &temp_dir.path().join("chain.bam"), "1", &["--threads", "4"]);
+
+    assert_eq!(single.1.len(), 1200, "600 molecules x (consensus R1 + R2) = 1200 records");
+    assert_eq!(
+        single, chain,
+        "chain (--threads 4) output must match the single-threaded oracle across batches",
+    );
+}
+
+/// Task 2's conditional sort-order guard: a coordinate-sorted (not
+/// template-coordinate) input must be rejected with the same message on both
+/// paths.
+#[test]
+fn test_duplex_chain_rejects_coordinate_sorted_input_same_as_oracle() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    let header = create_coordinate_sorted_header("chr1", 10000);
+    create_duplex_bam_with_header(
+        &input_bam,
+        &header,
+        vec![create_duplex_molecule("1", "ACGTACGT", 30, 100, 2)],
+    );
+
+    let run = |extra: &[&str]| -> String {
+        let mut args = vec![
+            "duplex",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output_bam.to_str().unwrap(),
+            "--min-reads",
+            "1",
+            "--compression-level",
+            "1",
+        ];
+        args.extend_from_slice(extra);
+        let error = Duplex::try_parse_from(args)
+            .expect("failed to parse duplex args")
+            .execute("fgumi duplex")
+            .expect_err("coordinate-sorted input must be rejected");
+        format!("{error:#}")
+    };
+
+    let single_msg = run(&[]);
+    let chain_msg = run(&["--threads", "4"]);
+
+    assert!(
+        single_msg.contains("not sorted correctly"),
+        "expected a sort-order error, got: {single_msg}"
+    );
+    assert_eq!(
+        single_msg, chain_msg,
+        "coordinate-sorted input must be rejected with the same message on both paths",
+    );
+}
+
+/// `--ref` without `--methylation-mode` must be rejected identically by both
+/// paths (mirrors the simplex #894 precedent).
+#[test]
+fn test_duplex_chain_ref_without_methylation_mode_rejected_same_as_oracle() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let ref_path = create_test_reference(temp_dir.path());
+
+    create_duplex_bam(&input_bam, vec![create_duplex_molecule("1", "ACGTACGT", 30, 100, 2)]);
+
+    let run = |extra: &[&str]| -> String {
+        let mut args = vec![
+            "duplex",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            output_bam.to_str().unwrap(),
+            "--min-reads",
+            "1",
+            "--compression-level",
+            "1",
+            "--ref",
+            ref_path.to_str().unwrap(),
+        ];
+        args.extend_from_slice(extra);
+        let error = Duplex::try_parse_from(args)
+            .expect("failed to parse duplex args")
+            .execute("fgumi duplex")
+            .expect_err("--ref without --methylation-mode must be rejected");
+        format!("{error:#}")
+    };
+
+    let single_msg = run(&[]);
+    let chain_msg = run(&["--threads", "4"]);
+
+    assert!(
+        single_msg.contains("--ref requires --methylation-mode"),
+        "expected the --ref/--methylation-mode error, got: {single_msg}"
+    );
+    assert_eq!(
+        single_msg, chain_msg,
+        "--ref without --methylation-mode must be rejected with the same message on both paths",
+    );
 }


### PR DESCRIPTION
## What

Route `fgumi duplex` onto the declarative chain builder — R3.6, the last of the consensus trio (simplex #894, codec #895, duplex).

`duplex --threads N` (on a `consensus`-feature build) now runs through `execute_chain` → `ChainSpec::single_stage(Stage::Duplex, …)` → `build_for(spec)?.run()`. The no-`--threads` single-threaded fast path is kept unchanged as the **in-process parity oracle** (legacy `execute_threads_mode` retained, removed in a follow-up A→B PR once parity is trusted).

## Feature-gating (the consensus-trio concern)

`commands::duplex` is gated `duplex`, but the chain machinery (`StageOptionsBag.duplex`, `add_duplex`) is gated by the umbrella `consensus` feature, and `duplex` does **not** imply `consensus`. So `execute_chain` and its dispatch are `#[cfg(feature = "consensus")]`-gated, and on a `--features duplex`-only build the dispatch is absent and execution **falls through to the legacy threaded path** (no regression, no bail). Verified across `--no-default-features`, default, `--all-features` (all `cargo check --workspace`) plus `cargo check -p fgumi --no-default-features --features duplex`.

## Correctness fix the cutover exposed (folded in)

- **Overlapping-consensus single-strand gate.** The dormant chain step (`run_duplex_consensus_batch`) gated overlapping-consensus correction on `has_both_strands_raw(...)` **alone**, but both legacy oracle paths gate on `(single_strand_allowed || has_both_strands_raw(...))`, where `single_strand_allowed = DuplexConsensusCaller::allows_single_strand_consensus(&min_reads)`. With single-strand mode enabled (3-value `--min-reads` ending in `0`, e.g. `1,1,0`) and `--consensus-call-overlapping-bases true`, a single-strand-only molecule was overlap-corrected by the oracle but **not** by the chain path — a real base/quality divergence that flipping the `--threads` branch would have surfaced. Fixed by computing `single_strand_allowed` once in the per-worker init and threading it (via `DuplexState`) into the gate, matching the oracle. Pinned by a fail-then-pass regression test parameterized over `--threads`.

## Duplex-specific behavior (matched to the oracle)

- **`/A`/`/B` MI strand-stripping** is applied on both the normal (`GroupByMi.with_mi_transform`) and fused (`templates_to_mi_step(.., true, ..)`) paths, matching legacy `MiGroupIterator::with_transform` (the transform governs the grouping key only; the per-record `MI` tag is preserved).
- **Rejects header keeps the chain `@PG`.** Unlike codec/simplex — whose legacy paths write rejects with the raw reader header — duplex's legacy single-threaded path applies `add_pg_record` **before** the rejects writer, so duplex rejects carry the `@PG`. `add_duplex` therefore correctly uses `self.header` (post-`@PG`), not `raw_source_header`; a rejects-header parity test pins that chain == oracle.
- **Conditional `check_consensus_sort_order` guard** in `add_duplex`, gated on `Stage::Duplex` being the source stage, so a future fused `group → duplex` chain (upstream stage orders records) is not wrongly rejected. That false branch is not reachable via `build_for` today (`ChainSpec` exposes only `single_stage`); a comment records that it becomes testable once the runall multi-stage builder lands.

## Tests

Chain-vs-oracle parity across plain (AB/BA pairing), `--rejects` (records + header), `--stats` (byte-compare), methylation mode, overlapping-disabled, the single-strand+overlapping regression case above, only-one-strand and strand-mismatch edge cases, multi-batch (hundreds of molecules to force batch boundaries), a coordinate-sorted rejection, and a `--ref`-without-`--methylation-mode` rejection.

## Review

Spec Fable-reviewed against the code before implementation — that review caught the overlapping-consensus gate bug above. A deep multi-agent gauntlet then reviewed the branch (4 raised → 0 refuted → 4 returned); addressed: the double timer-log / comment-mismatch on the `--threads` path (the dispatch now sits above the timer, which is created only for the legacy path — the gauntlet's own "move dispatch above the validations" suggestion was verified UNSOUND and not applied, as it would skip the output-collision/error-rate checks), a duplicated test-reference helper (replaced with the shared `create_test_reference`), and the guard-skip-branch coverage note above. The dead-`execute_threads_mode` observation is the accepted trio-wide trade-off (removed in the A→B follow-up).

## Verification

`cargo ci-fmt && cargo ci-lint && RUSTDOCFLAGS="-D warnings" cargo ci-doc && cargo ci-test` — all green (9772 tests). Feature legs compile. No new `unsafe`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Output risk: yes—duplex output changes, pinned by chain-versus-single-threaded parity tests; unsafe: none, and `CLAUDE.md` allowlist changes: none; memory bounds, queue capacity, and thread/backpressure policy: none.

The `--threads` duplex path now uses the declarative chain builder when `consensus` is enabled. Legacy threaded execution remains the fallback for duplex-only builds. The no-`--threads` path remains the parity oracle.

The change also:
- Fixes overlapping consensus for single-strand mode.
- Preserves rejects’ `@PG` header.
- Applies MI strand stripping consistently.
- Propagates the resolved tie rule through duplex workers.
- Validates consensus sort order only for standalone duplex stages.
- Adds parity tests for records, headers, rejects, statistics, methylation, strand handling, batching, sort validation, and invalid reference handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->