### PR TITLE
feat(clip): route the clip command onto the declarative chain builder

### DIFF
--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -6,43 +6,28 @@
 
 use crate::alignment_tags::regenerate_alignment_tags_raw;
 use crate::clipper::{ClippingMode, RawRecordClipper};
-use crate::grouper::TemplateGrouper;
 use crate::logging::OperationTimer;
 use crate::metrics::clip::{ClipCounts, ClippingMetricsCollection};
 use crate::metrics::writer::write_metrics as write_metrics_tsv;
-use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::reference::ReferenceReader;
 use crate::sam::SamTag;
-use crate::template::{
-    InsertSizeEnd, TemplateBatch, TemplateIterator, compute_insert_size_from_ends,
-};
-use crate::unified_pipeline::{
-    GroupKeyConfig, Grouper, MemoryEstimate, run_bam_pipeline_from_reader,
-};
+use crate::template::{InsertSizeEnd, TemplateIterator, compute_insert_size_from_ends};
 use crate::validation::validate_file_exists;
 use anyhow::Result;
 use clap::Parser;
 use fgumi_bam_io::ProgressTracker;
-use fgumi_bam_io::{
-    create_bam_reader_for_pipeline_with_opts, create_raw_bam_reader_with_opts,
-    create_raw_bam_writer,
-};
+use fgumi_bam_io::{create_raw_bam_reader_with_opts, create_raw_bam_writer};
 use fgumi_raw_bam::RawRecord;
 use log::info;
-use noodles::sam::Header;
-use std::io;
 use std::path::PathBuf;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::command::Command;
 use super::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
-    build_pipeline_config,
 };
 
 /// Clips reads in a BAM file to remove overlaps
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 #[command(
     name = "clip",
     about = "\x1b[38;5;173m[POST-CONSENSUS]\x1b[0m \x1b[36mClip overlapping reads in BAM files\x1b[0m",
@@ -160,36 +145,6 @@ pub struct Clip {
 // Types for 7-step pipeline processing
 // ============================================================================
 
-/// Result from processing a batch of templates through clipping.
-struct ClipProcessedBatch {
-    /// Clipped records to write to output BAM.
-    clipped_records: Vec<RawRecord>,
-    /// Number of templates processed.
-    templates_count: u64,
-    /// Number of templates with overlap clipping applied.
-    overlap_clipped_count: u64,
-    /// Number of templates with mate extension clipping applied.
-    extend_clipped_count: u64,
-}
-
-impl MemoryEstimate for ClipProcessedBatch {
-    fn estimate_heap_size(&self) -> usize {
-        self.clipped_records.iter().map(MemoryEstimate::estimate_heap_size).sum::<usize>()
-            + self.clipped_records.capacity() * std::mem::size_of::<RawRecord>()
-    }
-}
-
-/// Metrics collected from clipping processing, aggregated post-pipeline.
-#[derive(Default)]
-struct CollectedClipMetrics {
-    /// Total templates processed.
-    total_templates: u64,
-    /// Templates with overlap clipping.
-    overlap_clipped: u64,
-    /// Templates with mate extension clipping.
-    extend_clipped: u64,
-}
-
 /// Per-template clipping configuration, decoupled from `&Clip`.
 ///
 /// The single-threaded path holds a `&Clip` and could read these fields directly, but the
@@ -198,7 +153,7 @@ struct CollectedClipMetrics {
 /// clipping logic (`clip_template`/`clip_pair`/`clip_fragment`) instead of maintaining two
 /// copies that can silently drift apart.
 #[derive(Debug, Clone, Copy)]
-struct ClipParams {
+pub(crate) struct ClipParams {
     /// Upgrade existing clipping to the configured mode before applying new clipping.
     upgrade_clipping: bool,
     /// Clip the overlapping bases of an FR read pair.
@@ -217,7 +172,7 @@ struct ClipParams {
 
 impl ClipParams {
     /// Builds the per-template clip configuration from the parsed `Clip` command.
-    fn from_clip(clip: &Clip) -> Self {
+    pub(crate) fn from_clip(clip: &Clip) -> Self {
         Self {
             upgrade_clipping: clip.upgrade_clipping,
             clip_overlapping_reads: clip.clip_overlapping_reads,
@@ -258,7 +213,7 @@ impl ClipParams {
     /// # Errors
     ///
     /// Returns an error if primary-pair detection or a clipping operation fails.
-    fn clip_template(
+    pub(crate) fn clip_template(
         &self,
         records: &mut [RawRecord],
         clipper: &RawRecordClipper,
@@ -512,22 +467,8 @@ impl Command for Clip {
         self.io.validate()?;
         validate_file_exists(&self.reference, "Reference FASTA")?;
 
-        info!("Clip");
-        info!("  Input: {}", self.io.input.display());
-        info!("  Output: {}", self.io.output.display());
-        info!("  Clipping mode: {}", self.clipping_mode);
-        info!("  Clip overlapping reads: {}", self.clip_overlapping_reads);
-        info!("  Clip extending past mate: {}", self.clip_extending_past_mate);
-        info!("  {}", self.threading.log_message());
-        // Both the single-threaded fast path (via create_raw_bam_reader_with_opts)
-        // and the multi-threaded pipeline honor --check-crc/--no-check-crc (#800).
-        self.io.log_effective_check_crc();
-
-        let timer = OperationTimer::new("Clipping reads");
-
-        let mode = self.clipping_mode;
-
-        // Validate clipping parameters
+        // Validate clipping parameters (reader-free; must run on both execution
+        // paths). At least one clipping option must be requested.
         if self.upgrade_clipping
             || self.clip_overlapping_reads
             || self.clip_extending_past_mate
@@ -542,7 +483,9 @@ impl Command for Clip {
         }
 
         // --metrics is not produced in --threads mode; fail fast rather than
-        // silently dropping a user-requested output file.
+        // silently dropping a user-requested output file. Reader-free, so it runs
+        // before the chain dispatch below (add_clip re-checks it, but failing here
+        // keeps the error identical whether or not the chain path is taken).
         if self.threading.threads.is_some()
             && let Some(path) = &self.metrics
         {
@@ -553,49 +496,69 @@ impl Command for Clip {
             );
         }
 
-        // ========================================================================
-        // CRITICAL: Check --threads mode BEFORE creating any file handles.
-        // The 7-step pipeline manages its own I/O and writer lifecycle, so we
-        // must not create a writer here if we're going to use the pipeline.
-        // Route: Some(threads) -> pipeline, None -> single-threaded fast path
-        // ========================================================================
-        let total_records = if let Some(threads) = self.threading.threads {
-            // Read header for the 7-step pipeline (supports stdin)
-            let (reader, header) = create_bam_reader_for_pipeline_with_opts(
-                &self.io.input,
-                self.io.pipeline_reader_opts(),
-            )?;
+        // --threads N: run the clip stage on the declarative chain builder. Dispatch
+        // here — after the reader-free pre-flight above (output collisions, input +
+        // reference existence, clipping-option and --metrics validation), which must
+        // run for both paths — but BEFORE the banner / timer / reader below.
+        // execute_chain → add_clip re-emits the banner, timer, and threading log
+        // lines, re-enforces require_query_grouped, and opens its own source, so
+        // running them here too would double-log and pre-consume stdin. The
+        // no-`--threads` single-threaded path below stays the in-process parity oracle.
+        if self.threading.threads.is_some() {
+            return self.execute_chain(command_line);
+        }
 
-            // Synthesize @HD VN:1.6 SO:unsorted when the input lacks one (match fgbio).
-            // Run before require_query_grouped so both execution modes guard the same
-            // normalized header (matching execute_single_threaded's ordering).
-            let header = crate::commands::common::ensure_hd_record(header)?;
+        // ---- legacy no-`--threads` oracle path (single-threaded engine) ----
+        info!("Clip");
+        info!("  Input: {}", self.io.input.display());
+        info!("  Output: {}", self.io.output.display());
+        info!("  Clipping mode: {}", self.clipping_mode);
+        info!("  Clip overlapping reads: {}", self.clip_overlapping_reads);
+        info!("  Clip extending past mate: {}", self.clip_extending_past_mate);
+        info!("  {}", self.threading.log_message());
+        // The single-threaded fast path (via create_raw_bam_reader_with_opts) honors
+        // --check-crc/--no-check-crc (#800).
+        self.io.log_effective_check_crc();
 
-            // CLIP3-05: fgbio's ClipBam calls Bams.requireQueryGrouped. Clipping is
-            // template-based (pair clip, overlap, past-mate, mate-fix), so coordinate-
-            // sorted input silently mis-groups mates. Guard the *input* header.
-            crate::commands::common::require_query_grouped(
-                &header,
-                &self.io.input.display().to_string(),
-            )?;
-
-            // Load reference (always required for clip)
-            let reference = Arc::new(ReferenceReader::new(&self.reference)?);
-
-            // Add @PG record with PP chaining to input's last program
-            let header = crate::commands::common::add_pg_record(header, command_line)?;
-
-            self.execute_threads_mode(reader, threads, header, reference)?
-        } else {
-            self.execute_single_threaded(mode, command_line)?
-        };
-
+        let timer = OperationTimer::new("Clipping reads");
+        let mode = self.clipping_mode;
+        let total_records = self.execute_single_threaded(mode, command_line)?;
         timer.log_completion(total_records);
         Ok(())
     }
 }
 
 impl Clip {
+    /// Runs the `--threads N` path via the declarative chain builder
+    /// (`ChainSpec::single_stage(Stage::Clip, ...)` → `build_for(spec)?.run()`).
+    ///
+    /// `add_clip` opens its own source, re-emits the timer/banner/threading log
+    /// lines, reloads the reference, re-validates the clipping options and the
+    /// `--metrics`/`--threads` combination, and re-enforces `require_query_grouped`,
+    /// so none of those may run again here — only the CRC-verify status line, which
+    /// `add_clip` does not re-emit. The no-`--threads` path in `execute` keeps its
+    /// own single-threaded engine, which is the in-process parity oracle for this
+    /// one (see `test_clip_chain_matches_single_threaded`).
+    fn execute_chain(&self, command_line: &str) -> Result<()> {
+        use crate::pipeline::chains::{
+            ChainSpec, SingleStageContext, Stage, StageOptionsBag, build_for,
+        };
+        // add_clip re-emits the timer/banner/threading lines but NOT the
+        // CRC-verify status line.
+        self.io.log_effective_check_crc();
+        let stage_opts = StageOptionsBag { clip: Some(self.clone()), ..Default::default() };
+        let ctx = SingleStageContext {
+            io: &self.io,
+            threading: &self.threading,
+            compression: &self.compression,
+            scheduler: &self.scheduler_opts,
+            queue_memory: &self.queue_memory,
+            command_line,
+        };
+        let spec = ChainSpec::single_stage(Stage::Clip, stage_opts, &ctx);
+        build_for(spec)?.run()
+    }
+
     /// Execute single-threaded clipping.
     #[allow(clippy::too_many_lines)]
     fn execute_single_threaded(&self, mode: ClippingMode, command_line: &str) -> Result<u64> {
@@ -651,7 +614,8 @@ impl Clip {
         let mut total_clipped_mate_extension: u64 = 0;
         let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
 
-        // Shared per-template clip configuration (see `execute_threads_mode` for the parallel use).
+        // Shared per-template clip configuration (see `build_clip_process_step` in the chain
+        // builder for the parallel `--threads` use).
         let params = ClipParams::from_clip(self);
 
         // Single-threaded processing: iterate raw templates, clip in place
@@ -705,165 +669,6 @@ impl Clip {
 
         info!("Done!");
         Ok(total_records as u64)
-    }
-
-    /// Execute using the 7-step unified pipeline with multi-threading.
-    ///
-    /// Uses `TemplateGrouper` to batch records by template (QNAME) for parallel processing.
-    #[allow(clippy::too_many_lines)]
-    fn execute_threads_mode(
-        &self,
-        reader: Box<dyn std::io::Read + Send>,
-        num_threads: usize,
-        header: Header,
-        reference: Arc<ReferenceReader>,
-    ) -> Result<u64> {
-        // Configure pipeline - clip is writer-heavy workload
-        let mut pipeline_config = build_pipeline_config(
-            &self.scheduler_opts,
-            &self.compression,
-            &self.queue_memory,
-            &self.io,
-            num_threads,
-        )?;
-        // Clip uses raw-byte mode so TemplateGrouper receives RawRecord items.
-        pipeline_config.group_key_config =
-            Some(GroupKeyConfig::new_raw_no_cell(crate::read_info::LibraryIndex::default()));
-
-        // Per-thread metrics accumulator: bounded memory, no unbounded queue.
-        let collected_metrics = PerThreadAccumulator::<CollectedClipMetrics>::new(num_threads);
-        let collected_for_serialize = Arc::clone(&collected_metrics);
-
-        // Configuration for closures
-        const BATCH_SIZE: usize = 1000;
-        let clipping_mode = self.clipping_mode;
-        let auto_clip_attributes = self.auto_clip_attributes;
-        // Shared per-template clip configuration (Copy), captured by the `process_fn` closure so
-        // it runs the exact same clipping logic as the single-threaded path.
-        let params = ClipParams::from_clip(self);
-        let reference_for_process = Arc::clone(&reference);
-        let header_for_process = header.clone();
-
-        // Progress tracking
-        let progress_counter = Arc::new(AtomicU64::new(0));
-        let progress_for_process = Arc::clone(&progress_counter);
-
-        // Grouper: batch records by template (QNAME)
-        let grouper_fn = move |_header: &Header| {
-            Box::new(TemplateGrouper::new(BATCH_SIZE))
-                as Box<dyn Grouper<Group = TemplateBatch> + Send>
-        };
-
-        // Process function: clip each template batch
-        let process_fn = move |batch: TemplateBatch| -> io::Result<ClipProcessedBatch> {
-            // Create per-worker clipper
-            let clipper = if auto_clip_attributes {
-                RawRecordClipper::with_auto_clip(clipping_mode, true)
-            } else {
-                RawRecordClipper::new(clipping_mode)
-            };
-
-            let mut clipped_records = Vec::new();
-            let mut templates_count = 0u64;
-            let mut overlap_clipped_count = 0u64;
-            let mut extend_clipped_count = 0u64;
-
-            for template in batch {
-                templates_count += 1;
-                let mut records: Vec<RawRecord> = template.into_records();
-
-                // Clip the primary R1/R2 (or a lone fragment) and repair mate info via the shared
-                // per-template logic (matches the single-threaded path exactly). This worker does
-                // not collect the detailed per-read metrics, so pass `None` and rely on the
-                // returned per-template flags for the overlap/extend counts.
-                let (overlap_clip, extend_clip) =
-                    params.clip_template(&mut records, &clipper, None).map_err(io::Error::other)?;
-                if overlap_clip {
-                    overlap_clipped_count += 1;
-                }
-                if extend_clip {
-                    extend_clipped_count += 1;
-                }
-
-                // Regenerate alignment tags (always done to match fgbio behavior)
-                for record in &mut records {
-                    regenerate_alignment_tags_raw(
-                        record.as_mut_vec(),
-                        &header_for_process,
-                        &reference_for_process,
-                    )
-                    .map_err(io::Error::other)?;
-                }
-
-                clipped_records.extend(records);
-            }
-
-            // Progress logging (count records, not templates)
-            let records_count = clipped_records.len() as u64;
-            let count = progress_for_process.fetch_add(records_count, Ordering::Relaxed);
-            if (count + records_count) / 1_000_000 > count / 1_000_000 {
-                info!("Processed {} records", count + records_count);
-            }
-
-            Ok(ClipProcessedBatch {
-                clipped_records,
-                templates_count,
-                overlap_clipped_count,
-                extend_clipped_count,
-            })
-        };
-
-        // Serialize function: write raw records directly into the output buffer
-        let serialize_fn = move |processed: ClipProcessedBatch,
-                                 _header: &Header,
-                                 output: &mut Vec<u8>|
-              -> io::Result<u64> {
-            // Merge per-batch counts into this worker's accumulator slot
-            collected_for_serialize.with_slot(|m| {
-                m.total_templates += processed.templates_count;
-                m.overlap_clipped += processed.overlap_clipped_count;
-                m.extend_clipped += processed.extend_clipped_count;
-            });
-
-            // Write raw records directly (4-byte block_size + bytes per record)
-            let count = processed.clipped_records.len() as u64;
-            fgumi_raw_bam::write_raw_records(output, &processed.clipped_records)?;
-            Ok(count)
-        };
-
-        // Run the 7-step pipeline
-        let records_written = run_bam_pipeline_from_reader(
-            pipeline_config,
-            reader,
-            header.clone(),
-            &self.io.output,
-            None, // Use input header for output
-            grouper_fn,
-            process_fn,
-            serialize_fn,
-        )?;
-
-        // ========== Post-pipeline: Aggregate metrics ==========
-        let mut total_templates = 0u64;
-        let mut total_overlap_clipped = 0u64;
-        let mut total_extend_clipped = 0u64;
-
-        for slot in collected_metrics.slots() {
-            let m = slot.lock();
-            total_templates += m.total_templates;
-            total_overlap_clipped += m.overlap_clipped;
-            total_extend_clipped += m.extend_clipped;
-        }
-
-        info!("Total templates processed: {total_templates}");
-        info!("Templates with overlap clipping: {total_overlap_clipped}");
-        info!("Templates with mate extension clipping: {total_extend_clipped}");
-
-        // `--metrics` with `--threads` is rejected in `execute()` before we ever
-        // reach this path, so no per-pipeline metrics file is written here.
-
-        info!("Done!");
-        Ok(records_written)
     }
 }
 
@@ -1138,40 +943,6 @@ fn clipped_bases_raw(record: &RawRecord) -> usize {
         })
         .map(|op| op.len() as usize)
         .sum()
-}
-
-// ==== ported from feat-runall for the chain builder (R2) ====
-/// Updates mate information tags (MC and MQ) for a read based on its mate.
-///
-/// After clipping operations, mate information tags need to be updated to reflect
-/// the new state of the mate read. This function updates:
-/// - MC tag: Mate CIGAR string
-/// - MQ tag: Mate mapping quality
-///
-/// These tags are standard SAM optional tags that store information about the mate
-/// to enable single-ended processing.
-///
-/// KNOWN DIVERGENCE — resolve in the clip WIRING PR: this is a NARROWER update
-/// than the canonical [`set_mate_info_raw`]. It updates only the MC/MQ tags and
-/// still does not update mate ref/pos/strand or TLEN; the clip wiring PR must
-/// delegate to `ClipParams::clip_template` / `set_mate_info_raw` and add
-/// byte-parity tests (same deferral as the Cluster-4 chain-clip divergence). The
-/// MC/MQ unmapped-mate divergence is closed here (see below) rather than
-/// deferred, so it cannot survive to the wiring PR.
-///
-/// # Arguments
-///
-/// * `record` - The record to update (mutable)
-/// * `mate` - The mate record to read information from
-pub(crate) fn update_mate_info_raw(record: &mut RawRecord, mate: &RawRecord) {
-    use fgumi_raw_bam::flags as rflags;
-    // An unmapped mate has no CIGAR and no meaningful MAPQ: remove MC/MQ rather
-    // than writing an empty `MC:Z:` and a stale MQ. Matches `set_mate_info_raw`.
-    if mate.flags() & rflags::UNMAPPED != 0 {
-        clear_mate_mq_mc_raw(record);
-        return;
-    }
-    set_mate_mq_mc_raw(record, mate.mapq(), &mate.cigar_to_string());
 }
 
 #[cfg(test)]
@@ -3162,29 +2933,6 @@ mod tests {
         assert_eq!(output_records.len(), 2, "Should have 2 records");
 
         Ok(())
-    }
-
-    #[test]
-    fn test_clip_processed_batch_memory_estimate() {
-        let record =
-            fgumi_raw_bam::SamBuilder::new().sequence(b"ACGT").qualities(&[30, 30, 30, 30]).build();
-        let mut records = Vec::with_capacity(10);
-        records.push(record);
-
-        let batch = ClipProcessedBatch {
-            clipped_records: records,
-            templates_count: 1,
-            overlap_clipped_count: 0,
-            extend_clipped_count: 0,
-        };
-
-        let estimate = batch.estimate_heap_size();
-        // Should include Vec overhead for capacity * size_of::<RawRecord>()
-        let vec_overhead = 10 * std::mem::size_of::<RawRecord>();
-        assert!(
-            estimate >= vec_overhead,
-            "estimate {estimate} should include Vec<RawRecord> overhead {vec_overhead}"
-        );
     }
 
     /// Helper to create a `Clip` struct with specified clipping parameters and

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -3942,6 +3942,22 @@ impl<'a> ChainBuilder<'a> {
             );
         }
 
+        // fgbio's ClipBam requires query-grouped input (a template's reads must be
+        // adjacent). Both legacy clip paths enforce this — `execute_single_threaded`
+        // (the parity oracle) and the pre-cutover `--threads` path, via
+        // `require_query_grouped` — so the chain `--threads` path must too; otherwise
+        // coordinate-sorted input that the legacy path rejected would be silently
+        // mis-clipped. Gated on Clip being the source stage: a future fused
+        // group→clip chain has an upstream stage that orders the records, so this
+        // guard must not reject that. `ChainSpec` exposes only `single_stage` today,
+        // so clip is always the source stage and the guard always fires.
+        if self.spec.stages.first() == Some(&Stage::Clip) {
+            crate::commands::common::require_query_grouped(
+                &self.header,
+                &input_path.display().to_string(),
+            )?;
+        }
+
         let timer = OperationTimer::new("Clipping reads");
 
         info!("Clip");
@@ -3973,13 +3989,7 @@ impl<'a> ChainBuilder<'a> {
             ClipProcessCaptures {
                 clipping_mode: clip.clipping_mode,
                 auto_clip_attributes: clip.auto_clip_attributes,
-                upgrade_clipping: clip.upgrade_clipping,
-                clip_overlapping_reads: clip.clip_overlapping_reads,
-                clip_extending_past_mate: clip.clip_extending_past_mate,
-                read_one_five_prime: clip.read_one_five_prime,
-                read_one_three_prime: clip.read_one_three_prime,
-                read_two_five_prime: clip.read_two_five_prime,
-                read_two_three_prime: clip.read_two_three_prime,
+                params: crate::commands::clip::ClipParams::from_clip(clip),
                 header: self.header.clone(),
                 reference: Arc::clone(&reference),
                 metrics: Arc::clone(&metrics),

--- a/src/lib/pipeline/chains/commands/clip.rs
+++ b/src/lib/pipeline/chains/commands/clip.rs
@@ -102,21 +102,16 @@ impl FinalizeHook for ClipFinalizeHook {
 /// `pub(crate)` — consumed only by `ChainBuilder::add_clip` and
 /// [`build_clip_process_step`].
 ///
-/// The five boolean fields reflect the five independent clipping control
-/// flags from the `Clip` command struct. Refactoring into a state-machine
-/// enum is not warranted here — each flag is checked individually in the
-/// hot-path closure.
-#[allow(clippy::struct_excessive_bools)]
+/// The clipping control flags are bundled into a single `params: ClipParams`,
+/// shared verbatim with the single-threaded oracle (`Clip::execute_single_threaded`);
+/// the hot-path closure delegates the whole per-template decision to
+/// `params.clip_template(...)` rather than branching on individual flags.
 pub(crate) struct ClipProcessCaptures {
     pub(crate) clipping_mode: crate::clipper::ClippingMode,
     pub(crate) auto_clip_attributes: bool,
-    pub(crate) upgrade_clipping: bool,
-    pub(crate) clip_overlapping_reads: bool,
-    pub(crate) clip_extending_past_mate: bool,
-    pub(crate) read_one_five_prime: usize,
-    pub(crate) read_one_three_prime: usize,
-    pub(crate) read_two_five_prime: usize,
-    pub(crate) read_two_three_prime: usize,
+    /// The per-template clip configuration, shared verbatim with the
+    /// single-threaded `Clip::execute` path (its in-process parity oracle).
+    pub(crate) params: crate::commands::clip::ClipParams,
     pub(crate) header: noodles::sam::Header,
     pub(crate) reference: Arc<ReferenceReader>,
     pub(crate) metrics: Arc<ClipAtomicMetrics>,
@@ -143,7 +138,6 @@ pub(crate) fn build_clip_process_step(
         limit_bytes,
         move |batch: BamTemplateBatch| -> io::Result<BamTemplateBatch> {
             use crate::alignment_tags::regenerate_alignment_tags_raw;
-            use crate::commands::clip::update_mate_info_raw;
 
             // Per-worker clipper: cheap to construct (no large state).
             let clipper = if cap.auto_clip_attributes {
@@ -169,86 +163,25 @@ pub(crate) fn build_clip_process_step(
                 // in place keeps allocation count near-equal to legacy.
                 let records: &mut Vec<RawRecord> = &mut template.records;
 
-                // KNOWN DIVERGENCE — MUST be resolved in the clip wiring PR
-                // (this chain path is dormant / has no callers today, so the
-                // divergence cannot yet reach output; the wiring PR must add
-                // byte-parity tests vs the standalone `clip`). This closure
-                // reimplements per-template clipping and has drifted from the
-                // canonical `ClipParams::clip_template` (src/lib/commands/clip.rs)
-                // in two ways:
-                //   1. It selects R1/R2 by POSITIONAL index (records[0]/[1]) and
-                //      does nothing for templates with >=3 records
-                //      (secondary/supplementary), whereas `clip_template` finds
-                //      the primary pair by SAM flag and upgrades all reads.
-                //   2. Fixed-position clipping calls `clip_*_end_of_alignment`
-                //      (clip N MORE aligned bases) where the canonical path calls
-                //      `clip_*_end_of_read_raw` (ensure at least N total clipped),
-                //      so this over-clips any read already carrying soft/hard clips.
-                // Fix: expose `ClipParams`/`clip_template` as `pub(crate)` and
-                // delegate to it here instead of reimplementing the loop.
-                if records.len() == 1 {
-                    let record = &mut records[0];
-                    if cap.upgrade_clipping {
-                        clipper.upgrade_all_clipping_raw(record).map_err(io::Error::other)?;
-                    }
-                    if cap.read_one_five_prime > 0 {
-                        clipper.clip_5_prime_end_of_alignment(record, cap.read_one_five_prime);
-                    }
-                    if cap.read_one_three_prime > 0 {
-                        clipper.clip_3_prime_end_of_alignment(record, cap.read_one_three_prime);
-                    }
-                } else if records.len() == 2 {
-                    let (r1_slice, r2_slice) = records.split_at_mut(1);
-                    let r1 = &mut r1_slice[0];
-                    let r2 = &mut r2_slice[0];
-
-                    if cap.upgrade_clipping {
-                        clipper.upgrade_all_clipping_raw(r1).map_err(io::Error::other)?;
-                        clipper.upgrade_all_clipping_raw(r2).map_err(io::Error::other)?;
-                    }
-
-                    let is_r1_first = r1.is_first_segment();
-                    let is_r2_last = r2.is_last_segment();
-
-                    if is_r1_first && cap.read_one_five_prime > 0 {
-                        clipper.clip_5_prime_end_of_alignment(r1, cap.read_one_five_prime);
-                    } else if !is_r1_first && cap.read_two_five_prime > 0 {
-                        clipper.clip_5_prime_end_of_alignment(r1, cap.read_two_five_prime);
-                    }
-                    if is_r1_first && cap.read_one_three_prime > 0 {
-                        clipper.clip_3_prime_end_of_alignment(r1, cap.read_one_three_prime);
-                    } else if !is_r1_first && cap.read_two_three_prime > 0 {
-                        clipper.clip_3_prime_end_of_alignment(r1, cap.read_two_three_prime);
-                    }
-                    if is_r2_last && cap.read_two_five_prime > 0 {
-                        clipper.clip_5_prime_end_of_alignment(r2, cap.read_two_five_prime);
-                    } else if !is_r2_last && cap.read_one_five_prime > 0 {
-                        clipper.clip_5_prime_end_of_alignment(r2, cap.read_one_five_prime);
-                    }
-                    if is_r2_last && cap.read_two_three_prime > 0 {
-                        clipper.clip_3_prime_end_of_alignment(r2, cap.read_two_three_prime);
-                    } else if !is_r2_last && cap.read_one_three_prime > 0 {
-                        clipper.clip_3_prime_end_of_alignment(r2, cap.read_one_three_prime);
-                    }
-
-                    if cap.clip_overlapping_reads {
-                        let (n1, n2) = clipper.clip_overlapping_reads(r1, r2);
-                        if n1 > 0 || n2 > 0 {
-                            local_overlap_clipped += 1;
-                        }
-                    }
-                    if cap.clip_extending_past_mate {
-                        let (n1, n2) = clipper.clip_extending_past_mate_ends(r1, r2);
-                        if n1 > 0 || n2 > 0 {
-                            local_extend_clipped += 1;
-                        }
-                    }
-
-                    update_mate_info_raw(r1, r2);
-                    update_mate_info_raw(r2, r1);
+                // Delegate to the canonical per-template clip implementation —
+                // the exact code the single-threaded `Clip::execute` oracle runs
+                // (`ClipParams::clip_template`). It finds the primary pair by SAM
+                // flag (so secondary/supplementary reads are handled, not just
+                // records[0]/[1]), applies fixed clipping with "ensure at least N
+                // including existing clipping" semantics (not "clip N more"), and
+                // repairs mate info. The `--metrics` detailed collection is never
+                // produced under `--threads` (rejected up front), so pass `None`
+                // and use the returned per-template flags for the atomic counters.
+                let (overlap_clipped, extend_clipped) =
+                    cap.params.clip_template(records, &clipper, None).map_err(io::Error::other)?;
+                if overlap_clipped {
+                    local_overlap_clipped += 1;
+                }
+                if extend_clipped {
+                    local_extend_clipped += 1;
                 }
 
-                // Regenerate alignment tags for every record.
+                // Regenerate alignment tags for every record (matches the oracle).
                 for record in records.iter_mut() {
                     regenerate_alignment_tags_raw(record.as_mut_vec(), &cap.header, &cap.reference)
                         .map_err(io::Error::other)?;

--- a/tests/integration/test_clip_command.rs
+++ b/tests/integration/test_clip_command.rs
@@ -283,6 +283,43 @@ fn test_clip_rejects_coordinate_sorted_input(#[case] extra_args: &[&str]) {
     );
 }
 
+/// `--metrics` combined with `--threads` must fail fast: detailed clipping metrics are only
+/// produced by the single-threaded path, so accepting `--metrics` under `--threads` would
+/// silently drop a user-requested output file. This reader-free guard runs before the chain
+/// dispatch; pin it so a regression that dropped it would be caught rather than silently
+/// ignoring the flag.
+#[test]
+fn test_clip_rejects_metrics_with_threads() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let metrics_path = temp_dir.path().join("metrics.txt");
+    let ref_path = create_test_reference(temp_dir.path());
+    build_clip_parity_bam(&input_bam, 8);
+
+    let cmd = Clip::try_parse_from([
+        "clip",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--ref",
+        ref_path.to_str().unwrap(),
+        "--clip-overlapping-reads",
+        "--metrics",
+        metrics_path.to_str().unwrap(),
+        "--threads",
+        "2",
+    ])
+    .expect("failed to parse clip args");
+
+    let err = cmd.execute("fgumi clip").expect_err("--metrics must be rejected under --threads");
+    assert!(
+        err.to_string().contains("cannot be used with --threads"),
+        "unexpected error message: {err}"
+    );
+}
+
 /// A header carrying only `@SQ` (no `@HD` line) -- mirrors header-less input.
 fn headerless_header(ref_name: &str, ref_len: usize) -> noodles::sam::Header {
     use noodles::sam::header::record::value::Map;
@@ -367,6 +404,137 @@ fn test_clip_command_basic() {
     let _header = reader.read_header().unwrap();
     let count = reader.records().count();
     assert_eq!(count, 2, "Should have both reads in output");
+}
+
+/// Build a query-grouped BAM of `count` overlapping paired templates. Each
+/// template is an 8M R1 at pos 99 and an 8M reverse R2 at pos 103 (mates overlap
+/// in [103,106]), so `--clip-overlapping-reads` plus fixed-end clipping both do
+/// real work. Read names are `tmpl{i}`, with R1/R2 kept adjacent (query-grouped),
+/// as clip requires.
+fn build_clip_parity_bam(path: &Path, count: usize) {
+    let pairs: Vec<(RawRecord, RawRecord)> = (0..count)
+        .map(|i| {
+            let name = format!("tmpl{i}");
+            let r1 = {
+                let mut b = SamBuilder::new();
+                b.read_name(name.as_bytes())
+                    .sequence(b"ACGTACGT")
+                    .qualities(&[30; 8])
+                    .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+                    .ref_id(0)
+                    .pos(99)
+                    .mapq(60)
+                    .cigar_ops(&[8 << 4]) // 8M
+                    .mate_ref_id(0)
+                    .mate_pos(103)
+                    .template_length(12);
+                b.build()
+            };
+            let r2 = {
+                let mut b = SamBuilder::new();
+                b.read_name(name.as_bytes())
+                    .sequence(b"ACGTACGT")
+                    .qualities(&[30; 8])
+                    .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+                    .ref_id(0)
+                    .pos(103)
+                    .mapq(60)
+                    .cigar_ops(&[8 << 4]) // 8M
+                    .mate_ref_id(0)
+                    .mate_pos(99)
+                    .template_length(-12);
+                b.build()
+            };
+            (r1, r2)
+        })
+        .collect();
+    create_paired_bam(path, pairs);
+}
+
+/// Chain-vs-oracle parity: the `--threads N` chain path
+/// (`ChainSpec::single_stage(Stage::Clip, ...)` → `build_for(spec)?.run()`) must
+/// produce the same records AND the same normalized header as the single-threaded
+/// oracle (`execute_single_threaded`). This is the load-bearing test for the R3
+/// clip cutover; `read_bam_output` normalizes only the `@PG` `CL` field, which
+/// legitimately differs by `--threads`, so a dropped `@SQ`/`@RG`/`@HD`/`@CO` line
+/// or any record divergence fails the test. Parameterized over thread counts to
+/// exercise single- and multi-worker scheduling.
+#[rstest]
+#[case::threads_1(1)]
+#[case::threads_2(2)]
+#[case::threads_4(4)]
+fn test_clip_chain_matches_single_threaded(#[case] threads: usize) {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let ref_path = create_test_reference(temp_dir.path());
+    build_clip_parity_bam(&input_bam, 8);
+
+    let oracle_out = temp_dir.path().join("oracle.bam");
+    let chain_out = temp_dir.path().join("chain.bam");
+
+    let opts =
+        ["--clip-overlapping-reads", "--read-one-five-prime", "1", "--read-two-three-prime", "1"];
+
+    // Oracle: no --threads (single-threaded engine).
+    {
+        let mut args = vec![
+            "clip",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            oracle_out.to_str().unwrap(),
+            "--ref",
+            ref_path.to_str().unwrap(),
+        ];
+        args.extend_from_slice(&opts);
+        Clip::try_parse_from(args)
+            .expect("parse oracle args")
+            .execute("fgumi clip")
+            .expect("oracle clip failed");
+    }
+
+    // Chain: --threads N (declarative chain builder).
+    {
+        let threads_arg = threads.to_string();
+        let mut args = vec![
+            "clip",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            chain_out.to_str().unwrap(),
+            "--ref",
+            ref_path.to_str().unwrap(),
+            "--threads",
+            &threads_arg,
+        ];
+        args.extend_from_slice(&opts);
+        Clip::try_parse_from(args)
+            .expect("parse chain args")
+            .execute("fgumi clip")
+            .expect("chain clip failed");
+    }
+
+    let (oracle_header, oracle_records) = crate::helpers::read_bam_output(&oracle_out);
+    let (chain_header, chain_records) = crate::helpers::read_bam_output(&chain_out);
+
+    // Non-vacuous guards: all 16 records (8 templates x 2) survive, and clipping
+    // actually ran -- at least one output CIGAR differs from the input's plain 8M
+    // (robust to soft/hard clipping mode). Without this a two-empty-output run
+    // would pass the equality check vacuously.
+    assert_eq!(oracle_records.len(), 16, "oracle should keep all 16 records");
+    assert!(
+        oracle_records.iter().any(|r| cigar_ops(r) != vec![(CigarKind::Match, 8)]),
+        "fixture must actually clip (expected an output CIGAR other than 8M)",
+    );
+
+    assert_eq!(
+        oracle_records, chain_records,
+        "chain (--threads {threads}) output must match the single-threaded oracle record-for-record",
+    );
+    assert_eq!(
+        oracle_header, chain_header,
+        "chain and oracle output headers must match (with @PG CL normalized)",
+    );
 }
 
 /// CLIP3-05: clip must reject header-less input. A header-less BAM synthesizes
@@ -788,7 +956,9 @@ fn test_upgrade_clipping_upgrades_supplementary(#[case] threads: Option<&str>) {
     run_supplementary_upgrade_case(threads);
 }
 
-/// `--threads` mode routes through `execute_threads_mode`; exercise the `(Some, Some)` primary-pair
+/// `--threads` mode routes through the declarative chain builder (`execute_chain` → `add_clip` →
+/// `build_clip_process_step`, which delegates to `ClipParams::clip_template`); exercise the
+/// `(Some, Some)` primary-pair
 /// branch with fixed R1/R2 clipping, overlap clipping, mate-extension clipping and clip upgrading
 /// all enabled. R1 (fwd, 150M) and R2 (rev, 100M) fully overlap, so overlap clipping engages.
 #[test]
@@ -963,7 +1133,8 @@ fn test_clip_command_threads_mode_secondary_only() {
 /// R1 — exercises the PR's headline fix end-to-end: after the primary pair is clipped,
 /// `fix_supplemental_mate_info` must repair the supplementary alignment's mate metadata to point
 /// at the *post-clip* primary R2. The `clip.rs` unit test covers the helper in isolation; this
-/// verifies the `execute_threads_mode` wiring (correct r1/r2 indices, and that the supplemental
+/// verifies the `--threads` chain-builder wiring (`execute_chain` → `build_clip_process_step`:
+/// correct r1/r2 indices, and that the supplemental
 /// mate snapshot is taken *after* the primary is clipped, not before). A wiring bug (wrong
 /// index, or records mutated out of order) would be invisible to every other test in this file.
 #[test]
@@ -1085,7 +1256,8 @@ fn test_clip_command_threads_mode_supplementary_mate_repair() {
     assert_eq!(supp.mate_alignment_start(), r2.alignment_start());
 }
 
-/// The single-threaded (`execute_single_threaded`) and multi-threaded (`execute_threads_mode`)
+/// The single-threaded (`execute_single_threaded`) and multi-threaded (`--threads`, via the chain
+/// builder's `build_clip_process_step`)
 /// paths share one per-template clipping implementation (`ClipParams::clip_template`), so clipping
 /// the same input under both must yield byte-identical output. This pins that invariant end-to-end:
 /// if the two paths ever diverge (e.g. a future edit touches only one), this comparison fails.


### PR DESCRIPTION
## What

Route `fgumi clip` onto the declarative chain builder — R3.x. This is the clip half of the command-cutover campaign (filter #892, correct #893, simplex #894, codec #895, duplex #896).

`clip --threads N` now runs through `execute_chain` → `ChainSpec::single_stage(Stage::Clip, …)` → `build_for(spec)?.run()`. The no-`--threads` single-threaded engine (`execute_single_threaded`) is kept unchanged as the **in-process parity oracle**. The old threaded engine (`execute_threads_mode`) is **removed in this PR**: once `--threads` dispatches to the chain it has no call site, and it was never the parity oracle, so it and its now-orphan helpers (`CollectedClipMetrics`, `ClipProcessedBatch` and its `MemoryEstimate` impl + unit test) are deleted here rather than carried dead into a follow-up.

`clip` is a core, non-feature-gated command, so the dispatch is unconditional. clip writes no rejects (only `--output` and single-threaded-only `--metrics`), so there is no rejects-header-provenance decision. The dispatch sits after the reader-free pre-flight (output-collision check, input + reference existence, the clipping-option validation, and the `--metrics`/`--threads` fail-fast) but before the banner / timer / reader, so `add_clip` — which re-emits those and opens its own source — does not double-log or pre-consume stdin.

## Two real defects the cutover exposed (fixed here)

- **`require_query_grouped` was missing on the chain path.** Both legacy clip paths enforce fgbio's `Bams.requireQueryGrouped`, but the dormant `add_clip` did not — so routing `--threads` onto the chain would silently mis-clip coordinate-sorted input the legacy path rejected. Added the guard in `add_clip`, gated on `Stage::Clip` being the source stage so a future fused `group→clip` chain (upstream stage orders the records) is not wrongly rejected. `ChainSpec` exposes only `single_stage` today, so the guard always fires. Pinned by the already-parameterized `test_clip_rejects_coordinate_sorted_input` / `test_clip_rejects_headerless_input`, whose `--threads` case now runs the chain.

- **The chain clip step over-clipped reads with existing clipping.** The dormant `build_clip_process_step` reimplemented per-template clipping and carried an explicit `KNOWN DIVERGENCE — MUST be resolved in the clip wiring PR` comment: it selected the primary pair by positional index (ignoring secondary/supplementary reads, and skipping templates with ≥3 records) and applied fixed clipping with "clip N more" (`clip_*_end_of_alignment`) instead of the canonical "ensure at least N including existing clipping" semantics — over-clipping any read already carrying soft/hard clips. This surfaced immediately: the existing unit test `test_fixed_position_clip_counts_existing_clipping::case_2_multi_threaded` expects `5S10M5S` (existing 5′ clip counted, 5 new 3′ bases) but the chain produced `8S7M5S`. Fixed by exposing `ClipParams`/`ClipParams::from_clip`/`ClipParams::clip_template` as `pub(crate)` and delegating the chain step to `cap.params.clip_template(records, &clipper, None)` — the exact code the oracle runs (its docstring already declares it "the single shared implementation used by both threading paths"). Parity is now by construction, not a parallel implementation. This let the now-dead `update_mate_info_raw` (itself carrying a "resolve in the clip wiring PR" note) be removed; `clip_template` repairs mate info via the canonical `set_mate_info_raw`. The `--metrics` detailed collection is never produced under `--threads`, so the chain passes `None` and drives its atomic `overlap_clipped`/`extend_clipped` counters off `clip_template`'s returned per-template flags.

## Tests

- `test_clip_chain_matches_single_threaded` (`#[case]` threads 1/2/4): chain vs. single-threaded oracle, full normalized-header + record parity via `read_bam_output`, with non-vacuous guards (all 16 records survive; at least one output CIGAR ≠ 8M, so clipping actually ran).
- `test_clip_rejects_metrics_with_threads`: pins the reader-free `--metrics` + `--threads` fast-fail (`expect_err`, message contains "cannot be used with --threads"), so a regression can't silently drop the user's requested metrics file.
- The pre-existing threaded tests now route through the chain and pass: coordinate / header-less rejection (the guard), primary-pair all-options, supplementary mate repair, secondary-only, fragment, past-mate, upgrade-supplementary, `--check-crc` handling, stdin-once, and `test_clip_command_single_and_multi_threaded_outputs_match`.
- The fixed `test_fixed_position_clip_counts_existing_clipping::case_2_multi_threaded`.

## Verification

`cargo ci-fmt && cargo ci-lint && RUSTDOCFLAGS="-D warnings" cargo ci-doc && cargo ci-test` — all green (9772 tests). The three feature legs compile (`--no-default-features`, default, `--all-features`, all `--all-targets`). No new `unsafe`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: output changes for `clip` threaded execution, pinned by single-threaded parity tests and shared `ClipParams::clip_template`; unsafe changes: none; memory, queue, and backpressure policy changes: none.

Threaded `clip` execution now uses the declarative chain builder. The single-threaded path remains the parity oracle. Reader-free validation runs before dispatch and rejects invalid query grouping, output collisions, clipping options, and `--metrics` with `--threads`.

The chain path reuses `ClipParams::clip_template`. This preserves existing clipping behavior, prevents over-clipping, and applies canonical mate repair. The obsolete threaded engine and helper code were removed.

Integration tests cover thread-count parity, normalized headers, clipping behavior, validation failures, and existing threaded scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->