### PR TITLE
feat(retag): route the retag command onto the declarative chain builder

### DIFF
--- a/src/lib/commands/retag.rs
+++ b/src/lib/commands/retag.rs
@@ -25,34 +25,26 @@
 //! in `fgumi extract`.
 
 use std::fmt;
-use std::io;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 
 use anyhow::{Result, bail, ensure};
 use clap::Parser;
-use fgumi_bam_io::{
-    ProgressTracker, create_bam_reader_for_pipeline_with_opts, create_raw_bam_reader_with_opts,
-    create_raw_bam_writer,
-};
+use fgumi_bam_io::{ProgressTracker, create_raw_bam_reader_with_opts, create_raw_bam_writer};
 use fgumi_raw_bam::{RawRecord, append_raw_tag, remove_tag};
 use log::{info, warn};
-use noodles::sam::Header;
 use serde::{Deserialize, Serialize};
 
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
-    add_pg_record, build_pipeline_config, ensure_hd_record, reject_output_collisions,
-    serialize_raw_bam_records,
+    add_pg_record, ensure_hd_record, reject_output_collisions,
 };
-use crate::grouper::SingleRawRecordGrouper;
 use crate::logging::OperationTimer;
 use crate::per_thread_accumulator::PerThreadAccumulator;
-use crate::read_info::LibraryIndex;
 use crate::sam::SamTag;
-use crate::unified_pipeline::{GroupKeyConfig, Grouper, run_bam_pipeline_from_reader};
 
 /// A single tag-rewrite operation, parsed from one `SRC::op::DST` positional argument.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -236,7 +228,7 @@ pub struct RetagMetric {
 
 impl RetagMetric {
     /// Build a metrics row from an operation and its accumulated counts.
-    fn from_counts(op: RetagOp, counts: &OpCounts) -> Self {
+    pub(crate) fn from_counts(op: RetagOp, counts: &OpCounts) -> Self {
         Self {
             operation: op.to_string(),
             kind: op.kind().to_string(),
@@ -250,6 +242,55 @@ impl RetagMetric {
 impl fgumi_metrics::Metric for RetagMetric {
     fn metric_name() -> &'static str {
         "retag"
+    }
+}
+
+/// Projected options the chain builder needs for the retag stage.
+///
+/// A free-standing struct (mirrors filter/group) rather than `Some(self.clone())`,
+/// because `Retag` does not derive `Clone`. Compression/threading come from the
+/// [`crate::pipeline::chains::SingleStageContext`], so they are not carried here.
+#[derive(Debug, Clone)]
+pub struct RetagOptions {
+    /// Tag-rewrite operations, applied left-to-right per record.
+    pub operations: Vec<RetagOp>,
+    /// Optional per-operation metrics TSV.
+    pub metrics: Option<PathBuf>,
+}
+
+/// Shared per-run state for a retag chain, built by [`RetagOptions::setup_pipeline`].
+pub(crate) struct RetagPipelineSetup {
+    /// Per-thread per-operation counters, positionally indexed by operation.
+    pub(crate) collected_metrics: Arc<PerThreadAccumulator<Vec<OpCounts>>>,
+    /// Global processed-record counter — the finalize hook's `record_count`.
+    pub(crate) progress_counter: Arc<AtomicU64>,
+}
+
+/// Captures the retag chain process closure needs. retag's transform ignores the
+/// header, so — unlike filter's `process_captures` — this takes no header argument.
+pub(crate) struct RetagProcessCaptures {
+    /// The operations to apply per record, in order (shared, read-only).
+    pub(crate) operations: Arc<Vec<RetagOp>>,
+    /// Global processed-record counter, incremented once per record.
+    pub(crate) progress: Arc<AtomicU64>,
+}
+
+impl RetagOptions {
+    /// Build the shared per-thread accumulator + progress counter. Nothing here
+    /// is fallible (contrast filter, which loads a reference), so no `Result`.
+    pub(crate) fn setup_pipeline(&self, num_threads: usize) -> RetagPipelineSetup {
+        RetagPipelineSetup {
+            collected_metrics: PerThreadAccumulator::<Vec<OpCounts>>::new(num_threads),
+            progress_counter: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Build the process-closure captures from these options and the setup.
+    pub(crate) fn process_captures(&self, setup: &RetagPipelineSetup) -> RetagProcessCaptures {
+        RetagProcessCaptures {
+            operations: Arc::new(self.operations.clone()),
+            progress: Arc::clone(&setup.progress_counter),
+        }
     }
 }
 
@@ -313,7 +354,8 @@ pub struct Retag {
     #[command(flatten)]
     pub compression: CompressionOptions,
 
-    /// Threading options: `--threads N` routes through the unified pipeline.
+    /// Threading options: `--threads N` routes through the declarative chain
+    /// builder (the typed-step pipeline) via `execute_chain`.
     #[command(flatten)]
     pub threading: ThreadingOptions,
 
@@ -327,6 +369,12 @@ pub struct Retag {
 }
 
 impl Retag {
+    /// Project the clap fields into [`RetagOptions`] for the chain builder.
+    #[must_use]
+    pub fn to_retag_options(&self) -> RetagOptions {
+        RetagOptions { operations: self.operations.clone(), metrics: self.metrics.clone() }
+    }
+
     /// Reject a `--output`/`--metrics` path that resolves to the same file as
     /// `--input`, which would clobber the BAM being read.
     ///
@@ -389,91 +437,33 @@ impl Retag {
         Ok((record_count, counts))
     }
 
-    /// Multi-threaded path: route records through the unified 7-step pipeline.
+    /// Route `--threads N` onto the declarative chain builder
+    /// (`ChainSpec::single_stage(Stage::Retag, …)` → `build_for(spec)?.run()`).
     ///
-    /// retag is a pure per-record transform, so it uses [`SingleRawRecordGrouper`]
-    /// (one record per unit — no template batching) and applies the ops inside the
-    /// pipeline's `process_fn`. The pipeline preserves input order, so output order
-    /// matches the single-threaded path.
-    ///
-    /// Per-operation counts are accumulated into a [`PerThreadAccumulator`] and
-    /// summed after the pipeline drains. Because [`OpCounts`] fields are `u64` and
-    /// addition is commutative, the aggregated counts — and therefore the `--metrics`
-    /// TSV — are identical to the single-threaded path regardless of thread count.
-    /// This is a deliberate divergence from `clip`, which rejects `--metrics` with
-    /// `--threads` because its metrics are non-summable per-read collections; retag's
-    /// three summable counters aggregate cleanly, so `--metrics` stays available here.
-    fn run_threaded(&self, num_threads: usize, command_line: &str) -> Result<(u64, Vec<OpCounts>)> {
-        // The pipeline manages its own I/O lifecycle, so open the streaming reader
-        // (header pre-consumed) here rather than the serial record reader.
-        let (reader, header) = create_bam_reader_for_pipeline_with_opts(
-            &self.io.input,
-            self.io.pipeline_reader_opts(),
-        )?;
-        let header = ensure_hd_record(header)?;
-        let header = add_pg_record(header, command_line)?;
-
-        let mut pipeline_config = build_pipeline_config(
-            &self.scheduler_opts,
-            &self.compression,
-            &self.queue_memory,
-            &self.io,
-            num_threads,
-        )?;
-        // Raw-byte mode: hand the grouper RawRecord items and skip the per-record
-        // cell-barcode scan the default config would otherwise perform. retag never
-        // groups by key (one record per group), so the library index the key would
-        // carry is irrelevant — pass the default and skip the header scan, matching
-        // clip's raw-passthrough setup.
-        pipeline_config.group_key_config =
-            Some(GroupKeyConfig::new_raw_no_cell(LibraryIndex::default()));
-
-        let n_ops = self.operations.len();
-        let ops = self.operations.clone();
-        let collected = PerThreadAccumulator::<Vec<OpCounts>>::new(num_threads);
-        let collected_for_process = Arc::clone(&collected);
-
-        // One record per group: retag is a pure per-record transform, so no template
-        // batching is needed.
-        let grouper_fn = |_header: &Header| {
-            Box::new(SingleRawRecordGrouper::new()) as Box<dyn Grouper<Group = RawRecord> + Send>
+    /// The no-`--threads` `run_single_threaded` serial loop is the in-process
+    /// parity oracle; this path produces identical output records + `--metrics`
+    /// TSV. Diagnostics (the `Starting Retag` banner, the `OperationTimer`, and
+    /// the summary/warn/metrics finalize hooks) are emitted inside
+    /// `ChainBuilder::add_retag`, matching the `add_filter`/`add_dedup`
+    /// convention — so `execute_chain` itself only surfaces the CRC policy and
+    /// runs the pipeline (mirrors `dedup`/`group` `execute_chain`).
+    fn execute_chain(&self, command_line: &str) -> Result<()> {
+        use crate::pipeline::chains::{
+            ChainSpec, SingleStageContext, Stage, StageOptionsBag, build_for,
         };
-        // Apply every op to the record and merge the resulting counts into this
-        // worker's accumulator slot.
-        let process_fn = move |mut record: RawRecord| -> io::Result<RawRecord> {
-            collected_for_process.with_slot(|slot| {
-                // Lazily size the slot to the operation count on first use.
-                if slot.is_empty() {
-                    slot.resize(n_ops, OpCounts::default());
-                }
-                for (op, op_counts) in ops.iter().zip(slot.iter_mut()) {
-                    apply_op(&mut record, op, op_counts);
-                }
-            });
-            Ok(record)
+        self.io.log_effective_check_crc();
+        let stage_opts =
+            StageOptionsBag { retag: Some(self.to_retag_options()), ..Default::default() };
+        let ctx = SingleStageContext {
+            io: &self.io,
+            threading: &self.threading,
+            compression: &self.compression,
+            scheduler: &self.scheduler_opts,
+            queue_memory: &self.queue_memory,
+            command_line,
         };
-
-        // Serialize: write the rewritten record. The pipeline owns the
-        // "Processed records" heartbeat (its output stage logs it at each
-        // million-record boundary), so this closure must not log progress or it
-        // would double the heartbeat line.
-        let serialize_fn =
-            move |record: RawRecord, _header: &Header, output: &mut Vec<u8>| -> io::Result<u64> {
-                serialize_raw_bam_records(std::slice::from_ref(&record), output)
-            };
-
-        let record_count = run_bam_pipeline_from_reader(
-            pipeline_config,
-            reader,
-            header,
-            &self.io.output,
-            None, // reuse the input header for output
-            grouper_fn,
-            process_fn,
-            serialize_fn,
-        )?;
-
-        Ok((record_count, sum_slot_counts(&collected, n_ops)))
+        let spec = ChainSpec::single_stage(Stage::Retag, stage_opts, &ctx);
+        build_for(spec)?.run()
     }
 }
 
@@ -485,9 +475,15 @@ impl Retag {
 /// untouched slot is empty and contributes nothing (the `zip` stops early). The
 /// counters are `u64`, so the sum is exact and order-independent — the result is
 /// identical regardless of how the scheduler spread records across slots. Pulled
-/// out of [`Retag::run_threaded`] so the cross-slot merge is unit-testable with
-/// several deliberately-populated slots, rather than left to scheduler luck.
-fn sum_slot_counts(collected: &PerThreadAccumulator<Vec<OpCounts>>, n_ops: usize) -> Vec<OpCounts> {
+/// out into a shared free function — used by the chain finalize hooks
+/// (`RetagFinalizeHook` and `RetagMetricsFinalizeHook`) to reduce the per-thread
+/// accumulator; the serial oracle builds its `Vec<OpCounts>` directly and does
+/// not call this — so the cross-slot merge is unit-testable with several
+/// deliberately-populated slots, rather than left to scheduler luck.
+pub(crate) fn sum_slot_counts(
+    collected: &PerThreadAccumulator<Vec<OpCounts>>,
+    n_ops: usize,
+) -> Vec<OpCounts> {
     let mut counts = vec![OpCounts::default(); n_ops];
     for slot in collected.slots() {
         let slot = slot.lock();
@@ -515,9 +511,18 @@ impl Command for Retag {
         // Reject it up front, resolving symlinks/`.`/`..` via canonicalize, before any
         // reader or writer opens (matching `merge`'s output-vs-input guard).
         self.reject_write_aliasing_input()?;
+        // Route on --threads BEFORE the CRC log / banner / timer. `--threads`
+        // dispatches to the chain builder, which emits its own banner + timer in
+        // `add_retag` and its own CRC log in `execute_chain`; running them here
+        // first would double-log and pre-consume stdin. The no-`--threads` serial
+        // path (the in-process parity oracle) keeps the CRC log, banner, and the
+        // metrics/summary tail below.
+        if self.threading.threads.is_some() {
+            return self.execute_chain(command_line);
+        }
+
         // Surface the effective CRC-verification policy once, at run start, honoring
-        // the `--check-crc` doc's promise of a per-run `CRC verify:` line. Both modes
-        // take their policy from `pipeline_reader_opts()` / `build_pipeline_config`.
+        // the `--check-crc` doc's promise of a per-run `CRC verify:` line.
         self.io.log_effective_check_crc();
 
         let timer = OperationTimer::new("Rewriting tags");
@@ -528,12 +533,8 @@ impl Command for Retag {
             info!("Operation: {op}");
         }
 
-        // Route on --threads: absent → serial fast path; present → unified pipeline.
-        // Both return the record count and per-operation counts for shared reporting.
-        let (record_count, counts) = match self.threading.threads {
-            None => self.run_single_threaded(command_line)?,
-            Some(threads) => self.run_threaded(threads, command_line)?,
-        };
+        // No-`--threads` serial fast path: the in-process parity oracle.
+        let (record_count, counts) = self.run_single_threaded(command_line)?;
 
         // Warn on operations that never matched — the usual sign of a mistyped source tag.
         for (op, op_counts) in self.operations.iter().zip(&counts) {
@@ -574,10 +575,41 @@ impl Command for Retag {
 mod tests {
     use super::*;
     use fgumi_raw_bam::{RawTagsView, SamBuilder, aux_data_slice};
+    use noodles::sam::Header;
     use rstest::rstest;
 
     fn tag(s: &str) -> SamTag {
         s.parse().expect("valid tag")
+    }
+
+    // ── projector parity (to_retag_options) ────────────────────────────────
+
+    #[test]
+    fn to_retag_options_carries_every_tuning_flag() {
+        let cmd = Retag::try_parse_from([
+            "retag",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "-M",
+            "m.tsv",
+            "RX::copy::BX",
+            "BX::move::CB",
+        ])
+        .expect("parse");
+        let o = cmd.to_retag_options();
+        assert_eq!(o.operations, cmd.operations);
+        assert_eq!(o.metrics.as_deref(), Some(std::path::Path::new("m.tsv")));
+    }
+
+    #[test]
+    fn to_retag_options_carries_defaults() {
+        let cmd = Retag::try_parse_from(["retag", "-i", "in.bam", "-o", "out.bam", "RX::delete"])
+            .expect("parse");
+        let o = cmd.to_retag_options();
+        assert_eq!(o.operations, cmd.operations);
+        assert_eq!(o.metrics, None);
     }
 
     /// Read a tag's exact on-disk `(type_byte, value_bytes)`, for verbatim-copy assertions.

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -1081,7 +1081,18 @@ impl<'a> ChainBuilder<'a> {
     /// other first stages (group/dedup/consensus/clip) need the full
     /// position/cell key, so they fall through to [`Self::bam_group_key_config`].
     fn source_group_key_config(&self) -> fgumi_bam_io::GroupKeyConfig {
-        if matches!(self.spec.stages.first(), Some(Stage::Correct | Stage::Sort)) {
+        if matches!(self.spec.stages.first(), Some(Stage::Retag)) {
+            // Retag is a pure per-record transform that never reads the group key
+            // (the deleted run_threaded used `new_raw_no_cell` for the same reason),
+            // so it takes the cheap name-hash key and skips the per-record aux-tag
+            // scan + CIGAR walk `bam_group_key_config` would compute. Use a DEFAULT
+            // library index rather than `LibraryIndex::from_header`: `name_hash_only`
+            // ignores `library_index` entirely, and `from_header` panics on a header
+            // with >65,535 @RG libraries — a crash the serial oracle
+            // (`run_single_threaded`) never has, so routing Retag through the shared
+            // `from_header` arm would newly expose `--threads` to it.
+            fgumi_bam_io::GroupKeyConfig::name_hash_only(fgumi_bam_io::LibraryIndex::default())
+        } else if matches!(self.spec.stages.first(), Some(Stage::Correct | Stage::Sort)) {
             let library_index = fgumi_bam_io::LibraryIndex::from_header(&self.header);
             fgumi_bam_io::GroupKeyConfig::name_hash_only(library_index)
         } else {
@@ -1277,6 +1288,7 @@ impl<'a> ChainBuilder<'a> {
         match stage {
             Stage::Dedup => self.add_dedup(position),
             Stage::Filter => self.add_filter(position),
+            Stage::Retag => self.add_retag(position),
             Stage::Clip => self.add_clip(position),
             Stage::Sort => self.add_sort(position),
             Stage::Group => self.add_group(position),
@@ -4240,6 +4252,104 @@ impl<'a> ChainBuilder<'a> {
         self.finalize.push(Box::new(FilterFinalizeHook {
             accumulators,
             has_rejects: track_rejects,
+            timer,
+        }));
+
+        Ok(())
+    }
+
+    /// Retag-specific step: a single per-record `ProcessOrdered` transform.
+    ///
+    /// retag is a pure per-record tag rewriter (no grouping, no rejects), so this
+    /// mirrors `add_filter`'s `(false, false)` branch: consume the
+    /// `DecodedRecordBatch` tail, apply the ops, serialise every record. The
+    /// `OperationTimer` + `Starting Retag` banner are constructed here (matching
+    /// `add_filter`/`add_dedup` — the builder owns the banner, not the command's
+    /// `execute_chain`), and the timer is moved into `RetagFinalizeHook`. Two
+    /// finalize hooks are registered: a success-only `RetagMetricsFinalizeHook`
+    /// (warn-on-zero + `--metrics` TSV, so a failed run publishes neither) and an
+    /// always-run `RetagFinalizeHook` (summary banner + timer completion).
+    ///
+    /// # Errors
+    /// Returns an error if `position` is `Intermediate`, if the chain tail is not
+    /// a record stream, or if the retag options are missing from the bag.
+    fn add_retag(&mut self, position: StagePosition) -> Result<()> {
+        use crate::commands::common::warn_unwired_pipeline_flags;
+        use crate::logging::OperationTimer;
+        use crate::pipeline::chains::commands::retag::{
+            RetagFinalizeHook, RetagMetricsFinalizeHook, build_retag_process_step,
+        };
+        use crate::validation::validate_file_exists;
+        use fgumi_bam_io::is_stdin_path;
+        use log::info;
+
+        if position == StagePosition::Intermediate {
+            bail!(
+                "intermediate retag not implemented; retag is a standalone terminal transform \
+                 (no runall combination requires it as an intermediate stage)"
+            );
+        }
+
+        // retag consumes a record stream (DecodedRecordBatch), like filter/clip/dedup.
+        if self.chain_tail_kind != ChainTailKind::DecodedRecordBatch {
+            bail!(
+                "Stage::Retag requires a record-stream input (DecodedRecordBatch), but the chain \
+                 tail is {:?}; retag cannot follow a stage that emits grouped templates or \
+                 serialized bytes.",
+                self.chain_tail_kind
+            );
+        }
+
+        let retag = self
+            .spec
+            .stage_opts
+            .retag
+            .as_ref()
+            .ok_or_else(|| anyhow!("Stage::Retag options missing from StageOptionsBag"))?;
+
+        let tail = self.current_tail.expect("add_retag called before add_source");
+
+        let input_path = self.resolve_log_input_path();
+        if !is_stdin_path(&input_path) {
+            validate_file_exists(&input_path, "Input BAM")?;
+        }
+
+        let timer = OperationTimer::new("Rewriting tags");
+        let output_path = self.spec.sink.path().clone();
+        info!("Starting Retag");
+        info!("Input: {}", input_path.display());
+        info!("Output: {}", output_path.display());
+        for op in &retag.operations {
+            info!("Operation: {op}");
+        }
+
+        warn_unwired_pipeline_flags(&self.spec.scheduler);
+        let num_threads = self.spec.threading.num_threads();
+        info!("{}", self.spec.threading.log_message());
+        info!("Using pipeline with {num_threads} threads");
+
+        let setup = retag.setup_pipeline(num_threads);
+        let accumulators = Arc::clone(&setup.collected_metrics);
+
+        let captures = retag.process_captures(&setup);
+        let step = build_retag_process_step(
+            self.tuning.per_step_byte_limit,
+            captures,
+            Arc::clone(&accumulators),
+        );
+        self.current_tail = Some(self.pipeline.append_step(step, tail));
+
+        // Success-only: warn-on-zero + metrics TSV (a failed run publishes neither).
+        self.finalize_on_success.push(Box::new(RetagMetricsFinalizeHook {
+            accumulators: Arc::clone(&accumulators),
+            operations: retag.operations.clone(),
+            metrics: retag.metrics.clone(),
+        }));
+        // Always-run: summary banner + timer completion.
+        self.finalize.push(Box::new(RetagFinalizeHook {
+            accumulators,
+            operations: retag.operations.clone(),
+            progress: Arc::clone(&setup.progress_counter),
             timer,
         }));
 

--- a/src/lib/pipeline/chains/commands/mod.rs
+++ b/src/lib/pipeline/chains/commands/mod.rs
@@ -17,6 +17,7 @@ pub mod extract;
 pub mod fastq;
 pub mod filter;
 pub mod group;
+pub mod retag;
 #[cfg(feature = "consensus")]
 pub mod simplex;
 pub mod sort;

--- a/src/lib/pipeline/chains/commands/retag.rs
+++ b/src/lib/pipeline/chains/commands/retag.rs
@@ -1,0 +1,184 @@
+//! Chain builder support for `Stage::Retag`.
+//!
+//! Holds the retag-specific finalize hooks and the process-step factory that
+//! `ChainBuilder::add_retag` imports. retag
+//! is a pure per-record transform (`DecodedRecordBatch → DecompressedBlock`, no
+//! grouping preamble, no rejects), so it mirrors filter's
+//! `build_filter_step_single_no_rejects` shape.
+//!
+//! The per-operation counters (`Vec<OpCounts>`, positionally indexed by op) and
+//! the row-building (`RetagMetric::from_counts`) are shared verbatim with the
+//! serial oracle in `commands::retag`, so the two paths' metrics rows cannot
+//! drift. `sum_slot_counts` reduces the chain's per-thread accumulator into that
+//! shared `Vec<OpCounts>` (the serial oracle has no per-thread slots, so it does
+//! not call it).
+
+use std::io;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::Result;
+use log::{info, warn};
+
+use crate::commands::retag::{
+    OpCounts, RetagMetric, RetagOp, RetagProcessCaptures, apply_op, sum_slot_counts,
+};
+use crate::logging::OperationTimer;
+use crate::per_thread_accumulator::PerThreadAccumulator;
+use crate::pipeline::chains::FinalizeHook;
+use crate::pipeline::steps::process::{ProcessOrdered, process_ordered};
+use crate::pipeline::steps::types::{DecodedRecordBatch, DecompressedBlock};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Finalize hooks
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Always-run finalize hook: logs the `=== Summary ===` banner and completes the
+/// timer. Registered on the always-run `finalize` list, so — unlike the serial
+/// oracle, whose summary sits downstream of a fallible `?` — it reports even on a
+/// failed run; this is an accepted, intentional divergence (matches filter/dedup)
+/// and is not parity-tested.
+///
+/// `record_count` comes from the shared `progress` counter (the process step
+/// increments it once per record), NOT from summing `records_applied` across ops
+/// — that would undercount whenever an op's source tag is absent on some records.
+pub(crate) struct RetagFinalizeHook {
+    pub(crate) accumulators: Arc<PerThreadAccumulator<Vec<OpCounts>>>,
+    pub(crate) operations: Vec<RetagOp>,
+    pub(crate) progress: Arc<AtomicU64>,
+    pub(crate) timer: OperationTimer,
+}
+
+impl FinalizeHook for RetagFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let RetagFinalizeHook { accumulators, operations, progress, timer } = *self;
+        let record_count = progress.load(Ordering::Relaxed);
+        let counts = sum_slot_counts(&accumulators, operations.len());
+
+        info!("=== Summary ===");
+        info!("Records processed: {record_count}");
+        for (op, op_counts) in operations.iter().zip(&counts) {
+            info!(
+                "{op}: applied={} overwritten={} missing={}",
+                op_counts.records_applied, op_counts.dst_overwritten, op_counts.src_missing
+            );
+        }
+
+        timer.log_completion(record_count);
+        Ok(())
+    }
+}
+
+/// Success-only finalize hook: the warn-on-zero-match loop and the `--metrics`
+/// TSV write. Registered on `finalize_on_success` (not the always-run list) so a
+/// failed/partial run publishes neither the warning nor the TSV — matching the
+/// serial oracle, which only reaches its warn/metrics code after a fully
+/// successful run.
+pub(crate) struct RetagMetricsFinalizeHook {
+    pub(crate) accumulators: Arc<PerThreadAccumulator<Vec<OpCounts>>>,
+    pub(crate) operations: Vec<RetagOp>,
+    pub(crate) metrics: Option<PathBuf>,
+}
+
+impl FinalizeHook for RetagMetricsFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let RetagMetricsFinalizeHook { accumulators, operations, metrics } = *self;
+        let counts = sum_slot_counts(&accumulators, operations.len());
+
+        // Warn on operations that never matched — the usual sign of a mistyped
+        // source tag (verbatim message from the serial oracle's tail).
+        for (op, op_counts) in operations.iter().zip(&counts) {
+            if op_counts.records_applied == 0 {
+                warn!(
+                    "operation '{op}' matched zero records: no record carried the source tag '{}'",
+                    op.src()
+                );
+            }
+        }
+
+        if let Some(path) = &metrics {
+            let rows: Vec<RetagMetric> = operations
+                .iter()
+                .zip(&counts)
+                .map(|(op, c)| RetagMetric::from_counts(*op, c))
+                .collect();
+            fgumi_metrics::write_metrics(path, &rows, "retag")?;
+            info!("Wrote metrics to: {}", path.display());
+        }
+
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Process-step factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build the retag process step: `DecodedRecordBatch → DecompressedBlock`,
+/// parallel, `ByItemOrdinal` (input order preserved). Applies every op to each
+/// record via the shared `apply_op`, folding per-op counts into this worker's
+/// accumulator slot, then serialises every record (retag keeps all records — no
+/// rejects, no filtering).
+///
+/// Returns the concrete `ProcessOrdered` (not `impl Step`) — the closure type is
+/// opaque-return and cannot name itself, matching the filter/dedup factories.
+///
+/// `pub(crate)` — consumed only by `ChainBuilder::add_retag`.
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_retag_process_step(
+    limit_bytes: u64,
+    captures: RetagProcessCaptures,
+    accumulators: Arc<PerThreadAccumulator<Vec<OpCounts>>>,
+) -> ProcessOrdered<
+    DecodedRecordBatch,
+    DecompressedBlock,
+    impl Fn(DecodedRecordBatch) -> io::Result<DecompressedBlock> + Send + Sync + 'static,
+> {
+    let n_ops = captures.operations.len();
+    process_ordered::<DecodedRecordBatch, DecompressedBlock, _>(
+        "RetagProcess",
+        limit_bytes,
+        move |item: DecodedRecordBatch| -> io::Result<DecompressedBlock> {
+            let batch_serial = item.batch_serial();
+            let records = item.into_records();
+            let total_records = records.len() as u64;
+            let mut bytes: Vec<u8> = Vec::new();
+
+            // Accumulate per-op counts into a batch-local vector, then merge into
+            // the shared per-thread slot with a SINGLE lock at batch end (mirrors
+            // filter's `record_batch_metrics`), rather than locking per record.
+            let mut batch_counts = vec![OpCounts::default(); n_ops];
+            for decoded in records {
+                let mut record = decoded.into_raw_bytes();
+                for (op, op_counts) in captures.operations.iter().zip(batch_counts.iter_mut()) {
+                    apply_op(&mut record, op, op_counts);
+                }
+                fgumi_raw_bam::write_framed_record(&mut bytes, record.as_ref())?;
+            }
+            accumulators.with_slot(|slot: &mut Vec<OpCounts>| {
+                // Lazily size the slot to the operation count on first use
+                // (mirrors the pre-cutover run_threaded process closure).
+                if slot.is_empty() {
+                    slot.resize(n_ops, OpCounts::default());
+                }
+                for (agg, part) in slot.iter_mut().zip(batch_counts.iter()) {
+                    agg.records_applied += part.records_applied;
+                    agg.dst_overwritten += part.dst_overwritten;
+                    agg.src_missing += part.src_missing;
+                }
+            });
+
+            // Heartbeat + record-count source for RetagFinalizeHook. A shared
+            // `Arc<AtomicU64>` rather than `ProgressTracker`: it doubles as the
+            // aggregate record count the finalize hook reads at drain, and is
+            // trivially shared across the parallel workers.
+            let prev = captures.progress.fetch_add(total_records, Ordering::Relaxed);
+            if (prev + total_records) / 1_000_000 > prev / 1_000_000 {
+                info!("Processed {} records", prev + total_records);
+            }
+
+            Ok(DecompressedBlock { batch_serial, bytes })
+        },
+    )
+}

--- a/src/lib/pipeline/chains/options_bag.rs
+++ b/src/lib/pipeline/chains/options_bag.rs
@@ -17,6 +17,7 @@ pub use crate::commands::extract::ExtractOptions;
 pub use crate::commands::fastq::FastqOptions;
 pub use crate::commands::filter::FilterOptions;
 pub use crate::commands::group::GroupOptions;
+pub use crate::commands::retag::RetagOptions;
 #[cfg(feature = "consensus")]
 pub use crate::commands::simplex::SimplexOptions;
 pub use crate::commands::sort::SortOptions;
@@ -55,8 +56,8 @@ pub struct AlignOptions {
 /// that every stage in `spec.stages` has its matching options
 /// present before constructing any chain steps.
 ///
-/// Thirteen fields are wired: Correct, Zipper, Sort, Group, Duplex, Codec,
-/// Filter, Simplex, Align, Extract, and Fastq hold free-standing
+/// Fourteen fields are wired: Correct, Zipper, Sort, Group, Duplex, Codec,
+/// Filter, Retag, Simplex, Align, Extract, and Fastq hold free-standing
 /// `<Command>Options` structs, while Dedup and Clip hold the command struct
 /// directly (`MarkDuplicates` / `Clip`) — no separate `DedupOptions`/
 /// `ClipOptions` is extracted, because test code constructs those via
@@ -82,6 +83,9 @@ pub struct StageOptionsBag {
     pub filter: Option<FilterOptions>,
     /// Clip options. Holds `Clip` directly (same approach as Dedup/Filter).
     pub clip: Option<Clip>,
+    /// Retag options. Holds the free-standing `RetagOptions` struct (operations
+    /// + metrics path) — a pure per-record tag rewriter, un-feature-gated.
+    pub retag: Option<RetagOptions>,
     /// Simplex options. Holds the free-standing `SimplexOptions` struct
     /// (same approach as Duplex/Codec), so runall can re-expose the tuning
     /// knobs via `--simplex::*` through `MultiSimplexOptions`.

--- a/src/lib/pipeline/chains/stage.rs
+++ b/src/lib/pipeline/chains/stage.rs
@@ -26,6 +26,9 @@ pub enum Stage {
     Clip,
     Filter,
     Dedup,
+    /// Rewrite SAM aux tags (copy/move/delete) — a pure per-record transform,
+    /// standalone-only (like `Clip`/`Dedup`/`Downsample`).
+    Retag,
     Downsample,
     /// Terminal BAM → FASTQ encode (interleaved or paired split output).
     Fastq,
@@ -55,7 +58,7 @@ mod tests {
     /// enum rather than a hand-picked subset. A new variant that is not added
     /// here is still forced through the exhaustive `match`es in the
     /// `expected_*` helpers, which fail to compile until it is classified.
-    const ALL_STAGES: [Stage; 14] = [
+    const ALL_STAGES: [Stage; 15] = [
         Stage::Extract,
         Stage::Correct,
         Stage::Align,
@@ -68,6 +71,7 @@ mod tests {
         Stage::Clip,
         Stage::Filter,
         Stage::Dedup,
+        Stage::Retag,
         Stage::Downsample,
         Stage::Fastq,
     ];
@@ -87,6 +91,7 @@ mod tests {
             | Stage::Clip
             | Stage::Filter
             | Stage::Dedup
+            | Stage::Retag
             | Stage::Downsample
             | Stage::Fastq => false,
         }
@@ -107,6 +112,7 @@ mod tests {
             | Stage::Clip
             | Stage::Filter
             | Stage::Dedup
+            | Stage::Retag
             | Stage::Downsample
             | Stage::Fastq => false,
         }

--- a/src/lib/pipeline/chains/validate.rs
+++ b/src/lib/pipeline/chains/validate.rs
@@ -37,7 +37,15 @@ fn stage_ord(stage: Stage) -> usize {
         Stage::Zipper => 3,
         Stage::Sort => 4,
         Stage::Group => 5,
-        Stage::Clip | Stage::Dedup | Stage::Downsample => 6,
+        // Retag is a standalone-only per-record transform; it only ever appears
+        // as the sole stage of a `fgumi retag` chain, so its rank is nominal and
+        // it joins the post-group standalone bucket. `validate_stage_progression`
+        // rejects any multi-stage chain containing Retag outright, so this rank is
+        // never actually exercised against a neighbour — if a future fused chain
+        // ever pairs Retag with another stage, drop that standalone-only guard and
+        // revisit this rank (at 6 the non-decreasing rule would reject a trailing
+        // Sort/Group but accept a leading one).
+        Stage::Clip | Stage::Dedup | Stage::Retag | Stage::Downsample => 6,
         Stage::Simplex | Stage::Duplex | Stage::Codec => 7,
         Stage::Filter => 8,
         // Terminal BAM→FASTQ export. Only ever appears as the sole stage of a
@@ -50,6 +58,8 @@ fn stage_ord(stage: Stage) -> usize {
 ///
 /// Rules:
 /// - At least one stage (empty chain is meaningless).
+/// - `Stage::Retag` is standalone-only — it must be the sole stage of a chain
+///   (a multi-stage chain containing Retag is rejected).
 /// - Each adjacent pair must be non-decreasing in `stage_ord`.
 /// - At most one `Align` per chain (mutually exclusive with `Zipper`).
 /// - At most one `Zipper` per chain (mutually exclusive with `Align`).
@@ -67,6 +77,23 @@ pub fn validate_stage_progression(spec: &ChainSpec) -> Result<()> {
     let stages = &spec.stages;
     if stages.is_empty() {
         bail!("ChainSpec.stages is empty — a chain needs at least one stage");
+    }
+
+    // Retag is standalone-only: it is only ever the sole stage of a `fgumi retag`
+    // chain (routed via `ChainSpec::single_stage`). A multi-stage chain containing
+    // Retag is not a shape any command builds or that the retag step is tested for
+    // — and `[Sort, Retag]` in particular slips past the non-decreasing ord rule
+    // below (Sort ord 4 <= Retag ord 6), leaving an untested fused sort→retag path
+    // that terminal `add_retag` would happily consume. Reject it here, at the spec
+    // boundary, before progression validation succeeds. Checked ahead of the
+    // ordering loop so `[Retag, Sort]` gets this precise message rather than the
+    // generic "canonical pipeline order" one.
+    if stages.len() > 1 && stages.contains(&Stage::Retag) {
+        bail!(
+            "Stage::Retag is standalone-only: it must be the sole stage of a chain, \
+             but got a {}-stage chain containing Retag ({stages:?})",
+            stages.len(),
+        );
     }
 
     // Extract must be first when present.
@@ -173,6 +200,18 @@ pub fn validate_stage_opts_present(spec: &ChainSpec) -> Result<()> {
             Stage::Codec => bag.codec.is_some(),
             Stage::Dedup => bag.dedup.is_some(),
             Stage::Filter => bag.filter.is_some(),
+            // Retag requires its options AND at least one operation. The CLI
+            // enforces `>= 1` via clap (`required = true, num_args = 1..`), but a
+            // directly-constructed `ChainSpec` could pass
+            // `Some(RetagOptions { operations: vec![], .. })`, which would make
+            // Retag a no-op that rewrites nothing — silently defeating the
+            // required-operation contract. Reject the empty case here, at the
+            // spec-construction boundary, rather than let it build.
+            Stage::Retag => match bag.retag.as_ref() {
+                Some(retag) if !retag.operations.is_empty() => true,
+                Some(_) => bail!("Stage::Retag requires at least one operation"),
+                None => false,
+            },
             Stage::Clip => bag.clip.is_some(),
             #[cfg(feature = "consensus")]
             Stage::Simplex => bag.simplex.is_some(),
@@ -548,6 +587,34 @@ mod tests {
         assert!(err.to_string().contains("canonical pipeline order"));
     }
 
+    #[rstest]
+    #[case::sort_then_retag(vec![Stage::Sort, Stage::Retag])]
+    #[case::retag_then_sort(vec![Stage::Retag, Stage::Sort])]
+    #[case::group_then_retag(vec![Stage::Group, Stage::Retag])]
+    fn retag_multi_stage_rejected(#[case] stages: Vec<Stage>) {
+        // Retag is standalone-only (the sole stage of a `fgumi retag` chain). A
+        // multi-stage chain containing Retag — in either order — must be rejected
+        // at the spec boundary. `[Sort, Retag]` is the case the non-decreasing ord
+        // rule would otherwise accept (Sort ord 4 <= Retag ord 6), leaving an
+        // untested fused sort→retag path.
+        let err = validate_stage_progression(&empty_spec(stages)).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Retag"), "expected Retag in error, got: {msg}");
+        assert!(
+            msg.contains("standalone-only"),
+            "expected the standalone-only rejection, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn retag_single_stage_accepted() {
+        // The valid case: Retag as the sole stage of a chain must still pass
+        // progression — the standalone-only guard must not reject the shape the
+        // `fgumi retag` command actually builds.
+        validate_stage_progression(&empty_spec(vec![Stage::Retag]))
+            .expect("lone Stage::Retag must be a valid progression");
+    }
+
     #[test]
     fn align_and_zipper_mutually_exclusive() {
         let spec = empty_spec(vec![Stage::Align, Stage::Zipper]);
@@ -600,6 +667,34 @@ mod tests {
         let spec = empty_spec(vec![Stage::Correct]);
         let err = validate_stage_opts_present(&spec).unwrap_err();
         assert!(err.to_string().contains("Correct"));
+    }
+
+    #[test]
+    fn opts_present_retag_rejects_empty_operations() {
+        // The CLI enforces `>= 1` operation via clap, but a directly-constructed
+        // `ChainSpec` could pass empty operations, making Retag a silent no-op.
+        // `validate_stage_opts_present` must reject it at the spec boundary.
+        use crate::commands::retag::RetagOptions;
+        let mut spec = empty_spec(vec![Stage::Retag]);
+        spec.stage_opts.retag = Some(RetagOptions { operations: vec![], metrics: None });
+        let msg = validate_stage_opts_present(&spec).unwrap_err().to_string();
+        assert!(
+            msg.contains("at least one operation"),
+            "expected the empty-operations error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn opts_present_retag_accepts_populated_operations() {
+        use crate::commands::retag::{RetagOp, RetagOptions};
+        use crate::sam::SamTag;
+        let mut spec = empty_spec(vec![Stage::Retag]);
+        spec.stage_opts.retag = Some(RetagOptions {
+            operations: vec![RetagOp::Delete { src: SamTag::RX }],
+            metrics: None,
+        });
+        validate_stage_opts_present(&spec)
+            .expect("Retag with at least one operation must pass options-presence validation");
     }
 
     #[test]

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -43,6 +43,7 @@ mod test_input_source_matrix;
 mod test_merge_command;
 mod test_pipeline_concurrency;
 mod test_pipeline_memory_backpressure;
+mod test_retag_command;
 mod test_review_command;
 mod test_sam_input;
 #[cfg(feature = "simplex")]

--- a/tests/integration/test_retag_command.rs
+++ b/tests/integration/test_retag_command.rs
@@ -1,0 +1,246 @@
+//! End-to-end parity tests for the `retag` command's chain-builder cutover.
+//!
+//! `retag --threads N` routes through the declarative chain builder; the
+//! no-`--threads` serial `run_single_threaded` loop is the in-process parity
+//! oracle. These assert the two paths produce identical output records +
+//! normalized header and an identical `--metrics` TSV, across thread counts —
+//! including `--threads 1`, which dispatches to the chain at single-worker
+//! concurrency (a distinct code path from both the serial oracle and
+//! `--threads N`).
+
+use clap::Parser;
+use fgumi_lib::commands::command::Command;
+use fgumi_lib::commands::retag::Retag;
+use fgumi_lib::sam::SamTag;
+use fgumi_raw_bam::{RawRecord, SamBuilder};
+use rstest::rstest;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+use crate::helpers::bam_generator::{create_minimal_header, write_bam};
+use crate::helpers::read_bam_output;
+
+/// A minimal mapped record with the given name and optional RX/BX tags. Sequence
+/// and quals are fixed filler — retag only rewrites tags.
+fn rec(name: &str, rx: Option<&str>, bx: Option<&str>) -> RawRecord {
+    let mut b = SamBuilder::new();
+    b.read_name(name.as_bytes())
+        .sequence(b"ACGT")
+        .qualities(&[30; 4])
+        .flags(0)
+        .ref_id(0)
+        .pos(99)
+        .mapq(60)
+        .cigar_ops(&[4 << 4]);
+    if let Some(v) = rx {
+        b.add_string_tag(SamTag::RX, v.as_bytes());
+    }
+    if let Some(v) = bx {
+        b.add_string_tag("BX".parse::<SamTag>().unwrap(), v.as_bytes());
+    }
+    b.build()
+}
+
+/// Write `records` to a BAM in `dir/<name>` and return its path.
+fn write_input(dir: &Path, name: &str, records: &[RawRecord]) -> PathBuf {
+    let path = dir.join(name);
+    let header = create_minimal_header("chr1", 10_000);
+    write_bam(&path, &header, records);
+    path
+}
+
+/// A mixed input: records with RX, one with a pre-existing BX (to exercise
+/// overwrite), and one with no RX (to exercise `src_missing`).
+fn mixed_input(dir: &Path, count: usize) -> PathBuf {
+    let mut records = Vec::with_capacity(count);
+    for i in 0..count {
+        match i % 4 {
+            0 => records.push(rec(&format!("r{i}"), Some("ACGT"), None)),
+            1 => records.push(rec(&format!("r{i}"), Some("TTTT"), Some("OLD"))),
+            2 => records.push(rec(&format!("r{i}"), None, None)),
+            _ => records.push(rec(&format!("r{i}"), Some("GGCC"), None)),
+        }
+    }
+    write_input(dir, "in.bam", &records)
+}
+
+/// Parse + run `retag`. `threads = None` omits `--threads` (the serial oracle);
+/// `Some(n)` passes `--threads n` (the chain path).
+fn run_retag(
+    input: &Path,
+    output: &Path,
+    threads: Option<usize>,
+    ops: &[&str],
+    metrics: Option<&Path>,
+) -> anyhow::Result<()> {
+    let mut args: Vec<String> = vec![
+        "retag".into(),
+        "-i".into(),
+        input.display().to_string(),
+        "-o".into(),
+        output.display().to_string(),
+    ];
+    if let Some(t) = threads {
+        args.push("--threads".into());
+        args.push(t.to_string());
+    }
+    if let Some(m) = metrics {
+        args.push("-M".into());
+        args.push(m.display().to_string());
+    }
+    args.extend(ops.iter().map(|s| (*s).to_string()));
+    let cmd = Retag::try_parse_from(args).expect("failed to parse retag args");
+    cmd.execute("retag test")
+}
+
+// ── chain-vs-oracle record + header parity ─────────────────────────────────
+
+#[rstest]
+#[case::threads_1(1)]
+#[case::threads_2(2)]
+#[case::threads_4(4)]
+fn retag_chain_matches_single_threaded(#[case] threads: usize) {
+    let dir = TempDir::new().unwrap();
+    let input = mixed_input(dir.path(), 40);
+    // Fan RX out to BX and CB, then drop RX — exercises applied/overwritten/missing
+    // across three positional ops.
+    let ops = ["RX::copy::BX", "RX::copy::CB", "RX::delete"];
+
+    let oracle_out = dir.path().join("oracle.bam");
+    run_retag(&input, &oracle_out, None, &ops, None).expect("oracle run");
+
+    let chain_out = dir.path().join("chain.bam");
+    run_retag(&input, &chain_out, Some(threads), &ops, None).expect("chain run");
+
+    let oracle = read_bam_output(&oracle_out);
+    let chain = read_bam_output(&chain_out);
+    assert_eq!(oracle.1.len(), 40, "all records emitted");
+    assert_eq!(chain, oracle, "chain (--threads {threads}) must match the serial oracle");
+}
+
+// ── --metrics TSV byte-parity ──────────────────────────────────────────────
+
+#[rstest]
+#[case::threads_1(1)]
+#[case::threads_2(2)]
+#[case::threads_4(4)]
+fn retag_chain_metrics_match_single_threaded(#[case] threads: usize) {
+    let dir = TempDir::new().unwrap();
+    let input = mixed_input(dir.path(), 40);
+    let ops = ["RX::copy::BX", "RX::move::CB"];
+
+    let oracle_out = dir.path().join("oracle.bam");
+    let oracle_m = dir.path().join("oracle.tsv");
+    run_retag(&input, &oracle_out, None, &ops, Some(&oracle_m)).expect("oracle run");
+
+    let chain_out = dir.path().join("chain.bam");
+    let chain_m = dir.path().join("chain.tsv");
+    run_retag(&input, &chain_out, Some(threads), &ops, Some(&chain_m)).expect("chain run");
+
+    let oracle_tsv = std::fs::read_to_string(&oracle_m).expect("read oracle tsv");
+    let chain_tsv = std::fs::read_to_string(&chain_m).expect("read chain tsv");
+    assert_eq!(chain_tsv, oracle_tsv, "--metrics TSV must be byte-identical across paths");
+    // Non-vacuous: at least one op actually applied to some records.
+    assert!(
+        oracle_tsv.lines().any(|l| {
+            let cols: Vec<&str> = l.split('\t').collect();
+            cols.len() >= 3 && cols[2].parse::<u64>().map(|n| n > 0).unwrap_or(false)
+        }),
+        "expected a non-zero records_applied somewhere in the metrics:\n{oracle_tsv}"
+    );
+}
+
+// ── warn-on-zero-match: a never-matching op reports records_applied == 0 ────
+
+#[rstest]
+#[case::threads_1(1)]
+#[case::threads_2(2)]
+fn retag_chain_zero_match_op_matches_oracle(#[case] threads: usize) {
+    let dir = TempDir::new().unwrap();
+    let input = mixed_input(dir.path(), 20);
+    // `ZZ` is present on no record, so this op matches zero records on both paths.
+    let ops = ["ZZ::delete"];
+
+    let oracle_out = dir.path().join("oracle.bam");
+    let oracle_m = dir.path().join("oracle.tsv");
+    run_retag(&input, &oracle_out, None, &ops, Some(&oracle_m)).expect("oracle run");
+
+    let chain_out = dir.path().join("chain.bam");
+    let chain_m = dir.path().join("chain.tsv");
+    run_retag(&input, &chain_out, Some(threads), &ops, Some(&chain_m)).expect("chain run");
+
+    let oracle_tsv = std::fs::read_to_string(&oracle_m).unwrap();
+    let chain_tsv = std::fs::read_to_string(&chain_m).unwrap();
+    assert_eq!(chain_tsv, oracle_tsv, "zero-match metrics must match across paths");
+    // The durable observable of the warn: records_applied == 0 for the op.
+    // TSV columns: operation, kind, records_applied, dst_overwritten, src_missing.
+    let zz_row = oracle_tsv
+        .lines()
+        .find(|l| l.starts_with("ZZ::delete\t"))
+        .unwrap_or_else(|| panic!("metrics should carry the ZZ::delete row:\n{oracle_tsv}"));
+    let fields: Vec<&str> = zz_row.split('\t').collect();
+    assert_eq!(
+        fields.get(2).copied(),
+        Some("0"),
+        "records_applied must be 0 for a zero-match op, got row: {zz_row}"
+    );
+    // Output records are unchanged (no ZZ to delete), and the two BAMs agree.
+    assert_eq!(read_bam_output(&chain_out), read_bam_output(&oracle_out));
+}
+
+// ── empty input: zero-record parity (degenerate boundary for the hooks) ─────
+
+#[rstest]
+#[case::threads_1(1)]
+#[case::threads_4(4)]
+fn retag_chain_empty_input_matches_oracle(#[case] threads: usize) {
+    let dir = TempDir::new().unwrap();
+    // Header-only BAM: exercises the finalize hooks' zero-record path.
+    let input = write_input(dir.path(), "empty.bam", &[]);
+    let ops = ["RX::copy::BX", "ZZ::delete"];
+
+    let oracle_out = dir.path().join("oracle.bam");
+    let oracle_m = dir.path().join("oracle.tsv");
+    run_retag(&input, &oracle_out, None, &ops, Some(&oracle_m)).expect("oracle run");
+
+    let chain_out = dir.path().join("chain.bam");
+    let chain_m = dir.path().join("chain.tsv");
+    run_retag(&input, &chain_out, Some(threads), &ops, Some(&chain_m)).expect("chain run");
+
+    // Header-only output, identical across paths.
+    assert_eq!(read_bam_output(&chain_out), read_bam_output(&oracle_out));
+    // Metrics TSVs byte-identical (all counts zero on both paths).
+    assert_eq!(
+        std::fs::read_to_string(&chain_m).unwrap(),
+        std::fs::read_to_string(&oracle_m).unwrap(),
+        "empty-input metrics must match across paths"
+    );
+}
+
+// ── multi-batch: enough records to cross pipeline batch boundaries ──────────
+
+#[test]
+fn retag_chain_multi_batch_matches_oracle() {
+    let dir = TempDir::new().unwrap();
+    let input = mixed_input(dir.path(), 5_000);
+    let ops = ["RX::copy::BX", "RX::delete"];
+
+    let oracle_out = dir.path().join("oracle.bam");
+    let oracle_m = dir.path().join("oracle.tsv");
+    run_retag(&input, &oracle_out, None, &ops, Some(&oracle_m)).expect("oracle run");
+
+    let chain_out = dir.path().join("chain.bam");
+    let chain_m = dir.path().join("chain.tsv");
+    run_retag(&input, &chain_out, Some(4), &ops, Some(&chain_m)).expect("chain run");
+
+    assert_eq!(
+        read_bam_output(&chain_out),
+        read_bam_output(&oracle_out),
+        "multi-batch chain output must match the serial oracle"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&chain_m).unwrap(),
+        std::fs::read_to_string(&oracle_m).unwrap(),
+        "multi-batch summed metrics must match across paths"
+    );
+}


### PR DESCRIPTION
## What

Route `fgumi retag` onto the declarative chain builder — R3 follow-on. `retag --threads N` now runs through `execute_chain` → `ChainSpec::single_stage(Stage::Retag, …)` → `build_for(spec)?.run()`. The no-`--threads` `run_single_threaded` serial loop is kept unchanged as the **in-process parity oracle**; the old `run_threaded` / `run_bam_pipeline_from_reader` engine is removed in this PR.

Because retag had no dormant chain stage, this is a **2-part change**: (A) chains-core adds `Stage::Retag`, the `StageOptionsBag` slot, `ChainBuilder::add_retag`, the step module (`pipeline/chains/commands/retag.rs`), the finalize hooks, and every stage-enumerating-pass edit; (B) the cutover flips the `--threads` dispatch and makes the metrics/summary/warn tail oracle-only. retag is a pure per-record tag rewriter (`SingleRawRecordGrouper`, no rejects, no query-grouping guard, un-feature-gated), so it mirrors filter's single-no-rejects step shape.

## Design notes

- **Metrics parity via finalize hooks:** `RetagFinalizeHook` (always-run) logs the `=== Summary ===` + `timer.log_completion(record_count)`, reading `record_count` from a shared progress `AtomicU64` incremented once per record by the step (`OpCounts` has no total field); `RetagMetricsFinalizeHook` (success-only) does the warn-on-zero-match loop + writes the `--metrics` TSV. Reuses `apply_op` / `sum_slot_counts` / `RetagMetric::from_counts` (latter two made `pub(crate)`) so the oracle and chain metrics cannot drift.
- **Parity substrate:** decoded records + normalized header (`read_bam_output`) + the `--metrics` TSV — never raw BAM bytes (parallel vs serial BGZF framing differs at the same compression level).
- The `OperationTimer` + `Starting Retag` banner + threading logs are built inside `add_retag` (matching `add_filter`/`add_dedup`); `execute_chain` is `log_effective_check_crc` + build/run only, so the `--threads` path doesn't double-log.
- retag routes to the cheap `name_hash_only` group key with a **default** `LibraryIndex` (retag never reads the group key; a default index skips the per-record aux-tag scan + CIGAR walk and avoids the `>65,535`-library `LibraryIndex::from_header` panic the serial path doesn't have).

## Tests

Chain-vs-oracle parity across `--threads` 1/2/4 (records + normalized header), `--metrics` TSV byte-parity, zero-match op (asserts `records_applied == 0`), multi-op fan-out + chain-through, interleaved missing/empty-tag records, multi-batch cross-slot summation, **empty (0-record) input**, and the two `to_retag_options` projector tests.

## Review

`/code-review` (2 efficiency fixes folded in: cheap group-key routing; batch-local count merge with a single per-batch lock) and a deep multi-agent `/gauntlet` (8 raised → 1 refuted → 7 fixed: the `from_header` panic, doc-drift on `sum_slot_counts`/the `threading` field, empty-input coverage, and the zero-match assertion strength) both ran; every surviving finding is addressed.

## Verification

`cargo ci-fmt && cargo ci-lint && RUSTDOCFLAGS="-D warnings" cargo ci-doc && cargo ci-test` — all green (9791 tests). All three feature legs compile (`--no-default-features`, default, `--all-features`, all `--all-targets`). No new `unsafe`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: `retag` output changes in threaded mode, pinned by serial parity tests for records, normalized headers, and metrics; `unsafe` changes: none, and `CLAUDE.md` allowlist changes: none; memory bounds, queue capacity, and thread/backpressure policy changes: none.

Fix: Route threaded `retag` execution through the declarative chain builder while retaining the serial loop as the parity oracle.

- Add `Stage::Retag`, option projection, validation, and terminal chain-builder support.
- Add parallel record processing, metrics aggregation, summary logging, timing, and zero-match warnings.
- Remove the legacy threaded BAM pipeline.
- Add integration coverage for thread counts, metrics, empty and multi-batch inputs, missing tags, overwrites, and operation order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->