### PR TITLE
feat(copy-umi): route the copy-umi command onto the declarative chain builder

### DIFF
--- a/src/lib/commands/copy_umi.rs
+++ b/src/lib/commands/copy_umi.rs
@@ -14,28 +14,24 @@
 //! normalization step (`crate::umi::read_name::normalize_read_name_umi`) but keep
 //! their own field-location logic.
 
-use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
 
 use anyhow::{Context, Result, bail, ensure};
 use clap::Parser;
 use log::{info, warn};
-use noodles::sam::Header;
 
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
-    add_pg_record, build_pipeline_config, ensure_hd_record, reject_output_collisions,
-    serialize_raw_bam_records,
+    add_pg_record, ensure_hd_record, reject_output_collisions,
 };
-use crate::grouper::SingleRawRecordGrouper;
 use crate::logging::OperationTimer;
 use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::sam::SamTag;
 use crate::umi::read_name::normalize_read_name_umi;
-use crate::unified_pipeline::{Grouper, MemoryEstimate, run_bam_pipeline_from_reader};
-use fgumi_bam_io::create_bam_reader_for_pipeline_with_opts;
+use fgumi_bam_io::{ProgressTracker, create_raw_bam_reader_with_opts, create_raw_bam_writer};
 use fgumi_raw_bam::{RawRecord, update_string_tag};
 
 /// Copy the UMI from a BAM read name into the RX tag.
@@ -129,39 +125,30 @@ pub struct CopyUmi {
     pub queue_memory: QueueMemoryOptions,
 }
 
-/// Per-record outcome flags, aggregated into [`CopyUmiCounts`] during serialize.
+/// Per-record outcome flags, aggregated into [`CollectedCopyUmiMetrics`].
+///
+/// `pub(crate)` so the chain step module can fold the outcome into its batch
+/// counters.
 #[derive(Debug, Clone, Copy, Default)]
-struct RecordOutcome {
+pub(crate) struct RecordOutcome {
     /// An existing RX tag was overwritten with the newly extracted UMI.
-    overwrote_rx: bool,
+    pub(crate) overwrote_rx: bool,
     /// The UMI was trimmed off the read name (`--remove-umi`).
-    trimmed_name: bool,
-}
-
-/// One record after processing, carried from the parallel process step to the
-/// serial serialize step.
-struct CopyUmiProcessed {
-    /// The record with RX written (and the name trimmed, if requested).
-    record: RawRecord,
-    /// What happened to this record, for metrics.
-    outcome: RecordOutcome,
-}
-
-impl MemoryEstimate for CopyUmiProcessed {
-    fn estimate_heap_size(&self) -> usize {
-        self.record.capacity()
-    }
+    pub(crate) trimmed_name: bool,
 }
 
 /// Aggregated run counters, one instance per pipeline slot.
+///
+/// Shared by the serial oracle and the chain finalize hooks, so the two paths
+/// reduce the same counters (`pub(crate)` fields for the chain step module).
 #[derive(Debug, Clone, Default)]
-struct CopyUmiCounts {
+pub(crate) struct CollectedCopyUmiMetrics {
     /// Records processed (all successful; a failure aborts the run).
-    total_records: u64,
+    pub(crate) total_records: u64,
     /// Records where an existing RX tag was overwritten.
-    rx_overwritten: u64,
+    pub(crate) rx_overwritten: u64,
     /// Records whose read name had the UMI trimmed off.
-    names_trimmed: u64,
+    pub(crate) names_trimmed: u64,
 }
 
 /// One metrics row summarizing the run, written to the optional `--metrics` TSV.
@@ -193,7 +180,7 @@ impl fgumi_metrics::Metric for CopyUmiMetric {
 /// # Errors
 /// Fails if the read name has no delimiter, has an empty last field, yields an
 /// invalid UMI, or already carries an RX tag when `fail_if_tag_present` is set.
-fn copy_umi_into_record(
+pub(crate) fn copy_umi_into_record(
     record: &mut RawRecord,
     field_delimiter: u8,
     reverse_complement_prefixed: bool,
@@ -283,16 +270,141 @@ impl CopyUmi {
     }
 }
 
+/// Validate that the read-name field delimiter is a single ASCII byte.
+///
+/// The sole delimiter validator, called by both `execute()`'s reader-free
+/// pre-flight and `CopyUmiOptions::process_captures` (so a chain built directly,
+/// bypassing `execute()`, still validates) — no divergence between the paths.
+pub(crate) fn validate_field_delimiter(c: char) -> Result<u8> {
+    u8::try_from(c)
+        .ok()
+        .filter(u8::is_ascii)
+        .with_context(|| format!("--field-delimiter must be a single ASCII character, got '{c}'"))
+}
+
+/// Write the single-row `--metrics` TSV from the reduced counters. Shared by the
+/// serial oracle and the chain's success-only metrics finalize hook so the two
+/// paths cannot drift.
+pub(crate) fn write_copy_umi_metrics(path: &Path, totals: &CollectedCopyUmiMetrics) -> Result<()> {
+    let row = CopyUmiMetric {
+        total_records: totals.total_records,
+        rx_written: totals.total_records,
+        rx_overwritten: totals.rx_overwritten,
+        names_trimmed: totals.names_trimmed,
+    };
+    fgumi_metrics::write_metrics(path, std::slice::from_ref(&row), "copy_umi")?;
+    info!("Wrote metrics to: {}", path.display());
+    Ok(())
+}
+
+/// Emit the overwrite warning (when any) and the `=== Summary ===` block. Shared
+/// by the serial oracle and the chain's summary finalize hook so the log content
+/// is byte-identical across the two paths.
+pub(crate) fn warn_and_log_copy_umi_summary(totals: &CollectedCopyUmiMetrics) {
+    if totals.rx_overwritten > 0 {
+        warn!("overwrote a pre-existing RX tag on {} record(s)", totals.rx_overwritten);
+    }
+    info!("=== Summary ===");
+    info!("Records processed: {}", totals.total_records);
+    info!("RX tags written: {}", totals.total_records);
+    info!("RX tags overwritten: {}", totals.rx_overwritten);
+    info!("Read names trimmed: {}", totals.names_trimmed);
+}
+
+/// Copy-umi tuning projected off the parsed CLI flags, independent of how they
+/// were supplied. Mirrors `FilterOptions`: the chain builder reads only these
+/// values, so they are projected into a plain struct rather than the bag holding
+/// the whole `CopyUmi` command.
+#[derive(Debug, Clone)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct CopyUmiOptions {
+    /// Read-name field delimiter (the UMI is the last field). Validated to a
+    /// single ASCII byte in `CopyUmiOptions::process_captures`.
+    pub field_delimiter: char,
+    /// Remove the UMI (and its delimiter) from the read name after copying it.
+    pub remove_umi: bool,
+    /// Reverse-complement `r`-prefixed UMI segments (fgbio default).
+    pub reverse_complement_r_umis: bool,
+    /// Error if a record already carries an RX tag, instead of overwriting it.
+    pub fail_if_tag_present: bool,
+    /// Optional TSV file for run metrics.
+    pub metrics: Option<PathBuf>,
+}
+
+impl CopyUmi {
+    /// Project the parsed CLI flags into [`CopyUmiOptions`].
+    #[must_use]
+    pub fn to_copy_umi_options(&self) -> CopyUmiOptions {
+        CopyUmiOptions {
+            field_delimiter: self.field_delimiter,
+            remove_umi: self.remove_umi,
+            reverse_complement_r_umis: self.reverse_complement_r_umis,
+            fail_if_tag_present: self.fail_if_tag_present,
+            metrics: self.metrics.clone(),
+        }
+    }
+}
+
+/// Shared state for a copy-umi chain run, built by
+/// [`CopyUmiOptions::setup_pipeline`].
+pub(crate) struct CopyUmiPipelineSetup {
+    /// Per-thread run counters, reduced by the finalize hooks.
+    pub(crate) collected_metrics: Arc<PerThreadAccumulator<CollectedCopyUmiMetrics>>,
+    /// Cross-thread processed-record counter driving the heartbeat.
+    pub(crate) progress_counter: Arc<AtomicU64>,
+}
+
+/// Captures the chain process closure needs, extracted from
+/// [`CopyUmiOptions`] and [`CopyUmiPipelineSetup`]. Copy-umi's transform ignores
+/// the header, so — unlike `FilterProcessCaptures` — this carries no header.
+pub(crate) struct CopyUmiProcessCaptures {
+    /// The validated single-byte read-name field delimiter.
+    pub(crate) field_delimiter: u8,
+    /// Reverse-complement `r`-prefixed UMI segments (fgbio default).
+    pub(crate) reverse_complement_prefixed: bool,
+    /// Trim the UMI off the read name after copying it.
+    pub(crate) remove_umi: bool,
+    /// Error on a pre-existing RX tag instead of overwriting.
+    pub(crate) fail_if_tag_present: bool,
+    /// Cross-thread processed-record counter for the heartbeat.
+    pub(crate) progress: Arc<AtomicU64>,
+}
+
+impl CopyUmiOptions {
+    /// Build the per-thread metrics accumulators and progress counter shared by
+    /// the chain builder's process step and finalize hooks. The
+    /// `BamPipelineConfig` is not built here — the chain builder derives it from
+    /// its `ChainSpec`.
+    pub(crate) fn setup_pipeline(&self, num_threads: usize) -> CopyUmiPipelineSetup {
+        CopyUmiPipelineSetup {
+            collected_metrics: PerThreadAccumulator::<CollectedCopyUmiMetrics>::new(num_threads),
+            progress_counter: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Build the process-closure captures. Validates the field delimiter here too
+    /// (not only in `execute()`'s pre-flight), so a chain built directly still
+    /// rejects a non-ASCII delimiter.
+    pub(crate) fn process_captures(
+        &self,
+        setup: &CopyUmiPipelineSetup,
+    ) -> Result<CopyUmiProcessCaptures> {
+        Ok(CopyUmiProcessCaptures {
+            field_delimiter: validate_field_delimiter(self.field_delimiter)?,
+            reverse_complement_prefixed: self.reverse_complement_r_umis,
+            remove_umi: self.remove_umi,
+            fail_if_tag_present: self.fail_if_tag_present,
+            progress: Arc::clone(&setup.progress_counter),
+        })
+    }
+}
+
 impl Command for CopyUmi {
     fn execute(&self, command_line: &str) -> Result<()> {
         self.io.validate()?;
-        let field_delimiter =
-            u8::try_from(self.field_delimiter).ok().filter(u8::is_ascii).with_context(|| {
-                format!(
-                    "--field-delimiter must be a single ASCII character, got '{}'",
-                    self.field_delimiter
-                )
-            })?;
+        // Fail fast on a non-ASCII delimiter before any reader opens; each path
+        // (serial oracle / chain) re-derives the validated byte itself.
+        validate_field_delimiter(self.field_delimiter)?;
 
         // Reject two writers to one destination, and a write target aliasing input.
         let mut outputs: Vec<(&Path, &str)> = vec![(self.io.output.as_path(), "--output")];
@@ -302,109 +414,108 @@ impl Command for CopyUmi {
         reject_output_collisions(&outputs)?;
         self.reject_write_aliasing_input()?;
 
+        if self.threading.threads.is_some() {
+            return self.execute_chain(command_line);
+        }
+
+        // No-`--threads` serial path: the in-process parity oracle.
         let timer = OperationTimer::new("Copying UMIs from read names");
         info!("Starting copy-umi");
         info!("Input: {}", self.io.input.display());
         info!("Output: {}", self.io.output.display());
 
-        let threads = self.threading.threads.unwrap_or(1);
-        let (reader, header) = create_bam_reader_for_pipeline_with_opts(
-            &self.io.input,
-            self.io.pipeline_reader_opts(),
-        )?;
+        let totals = self.run_single_threaded(command_line)?;
+        warn_and_log_copy_umi_summary(&totals);
+        if let Some(path) = &self.metrics {
+            write_copy_umi_metrics(path, &totals)?;
+        }
+        timer.log_completion(totals.total_records);
+        Ok(())
+    }
+}
+
+impl CopyUmi {
+    /// Serial no-`--threads` path: a read → copy-umi → write loop, and the
+    /// in-process parity oracle for the chain path. Uses `pipeline_reader_opts()`
+    /// so the CRC-check policy matches the chain, and `ensure_hd_record` +
+    /// `add_pg_record` so the header matches. A bad/empty UMI (or an existing RX
+    /// under `--fail-if-tag-present`) aborts the run via `?`, naming the read name.
+    ///
+    /// Parity: chain and oracle produce identical output on well-formed BAM, and
+    /// BOTH reject a framing-consistent-but-malformed record (`l_read_name` past
+    /// the record end) with a clean `InvalidData` error. This serial loop
+    /// validates each record via `validate_record_for_decode` before touching
+    /// read-name bytes, exactly as the chain path does through `DecodeRecords` —
+    /// without that guard the loop would panic in `read_name` on such a record,
+    /// a regression from the pre-cutover pipeline, which decoded and thus
+    /// validated.
+    fn run_single_threaded(&self, command_line: &str) -> Result<CollectedCopyUmiMetrics> {
+        let field_delimiter = validate_field_delimiter(self.field_delimiter)?;
+        let (mut reader, header) =
+            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
         let header = ensure_hd_record(header)?;
         let header = add_pg_record(header, command_line)?;
+        let mut writer =
+            create_raw_bam_writer(&self.io.output, &header, 1, self.compression.compression_level)?;
 
-        let pipeline_config = build_pipeline_config(
-            &self.scheduler_opts,
-            &self.compression,
-            &self.queue_memory,
-            &self.io,
-            threads,
-        )?;
-
-        let counts = PerThreadAccumulator::<CopyUmiCounts>::new(threads);
-
-        let grouper_fn = move |_header: &Header| {
-            Box::new(SingleRawRecordGrouper::new()) as Box<dyn Grouper<Group = RawRecord> + Send>
-        };
-
-        // fgbio-style RC is the default; `--reverse-complement-r-umis false` switches
-        // to strip-only.
-        let reverse_complement_prefixed = self.reverse_complement_r_umis;
-        let remove_umi = self.remove_umi;
-        let fail_if_tag_present = self.fail_if_tag_present;
-        let process_fn = move |mut record: RawRecord| -> io::Result<CopyUmiProcessed> {
+        let mut totals = CollectedCopyUmiMetrics::default();
+        let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
+        let mut record = RawRecord::new();
+        while reader.read_record(&mut record)? != 0 {
+            // Validate record framing (record length + l_read_name bound) before
+            // touching read-name bytes, exactly as the `--threads` chain path does
+            // via `DecodeRecords`. Without this, a framing-consistent-but-malformed
+            // record (l_read_name past the record end) would panic here in
+            // `read_name` instead of failing with a clean error — a regression from
+            // the pre-cutover pipeline, which validated. Both paths now reject a
+            // malformed record with the same InvalidData error.
+            crate::pipeline::steps::parse::decode::validate_record_for_decode(record.as_ref())?;
             let outcome = copy_umi_into_record(
                 &mut record,
                 field_delimiter,
-                reverse_complement_prefixed,
-                remove_umi,
-                fail_if_tag_present,
-            )
-            .map_err(io::Error::other)?;
-            Ok(CopyUmiProcessed { record, outcome })
+                self.reverse_complement_r_umis,
+                self.remove_umi,
+                self.fail_if_tag_present,
+            )?;
+            totals.total_records += 1;
+            if outcome.overwrote_rx {
+                totals.rx_overwritten += 1;
+            }
+            if outcome.trimmed_name {
+                totals.names_trimmed += 1;
+            }
+            writer.write_raw_record(record.as_ref())?;
+            progress.log_if_needed(1);
+        }
+        progress.log_final();
+        // Flush before returning so any write error surfaces here, not on drop.
+        writer.finish()?;
+        Ok(totals)
+    }
+
+    /// Run the copy-umi stage on the declarative chain builder (the `--threads N`
+    /// path). The no-`--threads` `CopyUmi::run_single_threaded` loop is the
+    /// in-process parity oracle. `add_copy_umi` re-emits the timer/banner/threading
+    /// logs and opens its own source, so — like dedup/group — this method only
+    /// builds and runs the chain. Copy-umi's `execute()` never emitted
+    /// `log_effective_check_crc`, so this does NOT call it either (adding it would
+    /// make the `--threads` path log a line the serial path never does).
+    fn execute_chain(&self, command_line: &str) -> Result<()> {
+        use crate::pipeline::chains::{
+            ChainSpec, SingleStageContext, Stage, StageOptionsBag, build_for,
         };
 
-        let counts_for_serialize = Arc::clone(&counts);
-        let serialize_fn = move |processed: CopyUmiProcessed,
-                                 _header: &Header,
-                                 output: &mut Vec<u8>|
-              -> io::Result<u64> {
-            counts_for_serialize.with_slot(|c| {
-                c.total_records += 1;
-                if processed.outcome.overwrote_rx {
-                    c.rx_overwritten += 1;
-                }
-                if processed.outcome.trimmed_name {
-                    c.names_trimmed += 1;
-                }
-            });
-            serialize_raw_bam_records(std::slice::from_ref(&processed.record), output)
+        let stage_opts =
+            StageOptionsBag { copy_umi: Some(self.to_copy_umi_options()), ..Default::default() };
+        let ctx = SingleStageContext {
+            io: &self.io,
+            threading: &self.threading,
+            compression: &self.compression,
+            scheduler: &self.scheduler_opts,
+            queue_memory: &self.queue_memory,
+            command_line,
         };
-
-        run_bam_pipeline_from_reader(
-            pipeline_config,
-            reader,
-            header,
-            &self.io.output,
-            None,
-            grouper_fn,
-            process_fn,
-            serialize_fn,
-        )?;
-
-        // Aggregate per-slot counters.
-        let mut totals = CopyUmiCounts::default();
-        for slot in counts.slots() {
-            let c = slot.lock();
-            totals.total_records += c.total_records;
-            totals.rx_overwritten += c.rx_overwritten;
-            totals.names_trimmed += c.names_trimmed;
-        }
-
-        if totals.rx_overwritten > 0 {
-            warn!("overwrote a pre-existing RX tag on {} record(s)", totals.rx_overwritten);
-        }
-
-        if let Some(path) = &self.metrics {
-            let row = CopyUmiMetric {
-                total_records: totals.total_records,
-                rx_written: totals.total_records,
-                rx_overwritten: totals.rx_overwritten,
-                names_trimmed: totals.names_trimmed,
-            };
-            fgumi_metrics::write_metrics(path, std::slice::from_ref(&row), "copy_umi")?;
-            info!("Wrote metrics to: {}", path.display());
-        }
-
-        info!("=== Summary ===");
-        info!("Records processed: {}", totals.total_records);
-        info!("RX tags written: {}", totals.total_records);
-        info!("RX tags overwritten: {}", totals.rx_overwritten);
-        info!("Read names trimmed: {}", totals.names_trimmed);
-
-        timer.log_completion(totals.total_records);
-        Ok(())
+        let spec = ChainSpec::single_stage(Stage::CopyUmi, stage_opts, &ctx);
+        build_for(spec)?.run()
     }
 }

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -1098,22 +1098,27 @@ impl<'a> ChainBuilder<'a> {
     /// other first stages (group/dedup/consensus/clip) need the full
     /// position/cell key, so they fall through to [`Self::bam_group_key_config`].
     fn source_group_key_config(&self) -> fgumi_bam_io::GroupKeyConfig {
-        if matches!(self.spec.stages.first(), Some(Stage::Retag)) {
-            // Retag is a pure per-record transform that never reads the group key
-            // (the deleted run_threaded used `new_raw_no_cell` for the same reason),
-            // so it takes the cheap name-hash key and skips the per-record aux-tag
-            // scan + CIGAR walk `bam_group_key_config` would compute. Use a DEFAULT
-            // library index rather than `LibraryIndex::from_header`: `name_hash_only`
-            // ignores `library_index` entirely, and `from_header` panics on a header
-            // with >65,535 @RG libraries — a crash the serial oracle
-            // (`run_single_threaded`) never has, so routing Retag through the shared
-            // `from_header` arm would newly expose `--threads` to it.
-            fgumi_bam_io::GroupKeyConfig::name_hash_only(fgumi_bam_io::LibraryIndex::default())
-        } else if matches!(self.spec.stages.first(), Some(Stage::Correct | Stage::Sort)) {
-            let library_index = fgumi_bam_io::LibraryIndex::from_header(&self.header);
-            fgumi_bam_io::GroupKeyConfig::name_hash_only(library_index)
-        } else {
-            self.bam_group_key_config()
+        match self.spec.stages.first() {
+            Some(Stage::Correct | Stage::Sort) => {
+                let library_index = fgumi_bam_io::LibraryIndex::from_header(&self.header);
+                fgumi_bam_io::GroupKeyConfig::name_hash_only(library_index)
+            }
+            Some(Stage::CopyUmi | Stage::Retag) => {
+                // copy-umi and retag are pure per-record transforms that never read
+                // the group key, like Sort, so they take the cheap name-hash key and
+                // skip the per-record CIGAR position walk + aux-tag scan
+                // `bam_group_key_config` would otherwise compute for every record and
+                // then discard. (The deleted `run_threaded` used `new_raw_no_cell`
+                // for the same reason.)
+                //
+                // Use a DEFAULT LibraryIndex, NOT `from_header`: `name_hash_only`
+                // never reads `library_index`, and `LibraryIndex::from_header`
+                // panics on a header with >65,535 @RG libraries — a crash the serial
+                // oracle (which builds no group key) never has, so routing these
+                // through the shared `from_header` arm would newly expose it.
+                fgumi_bam_io::GroupKeyConfig::name_hash_only(fgumi_bam_io::LibraryIndex::default())
+            }
+            _ => self.bam_group_key_config(),
         }
     }
 
@@ -1312,6 +1317,7 @@ impl<'a> ChainBuilder<'a> {
             Stage::Simplex => self.add_simplex(position),
             Stage::Duplex => self.add_duplex(position),
             Stage::Codec => self.add_codec(position),
+            Stage::CopyUmi => self.add_copy_umi(position),
             Stage::Correct => self.add_correct(position),
             Stage::Zipper => self.add_zipper(position),
             Stage::Align => self.add_align(position),
@@ -4153,6 +4159,99 @@ impl<'a> ChainBuilder<'a> {
         // build() after all stages have been added — that way a single timer
         // covers the full pipeline run regardless of how many stages there are.
         self.finalize.push(Box::new(ClipFinalizeHook { metrics, progress_counter, timer }));
+
+        Ok(())
+    }
+
+    /// Add the copy-umi stage (`Stage::CopyUmi`).
+    ///
+    /// A pure per-record transform that copies the read-name UMI into `RX`.
+    /// Mirrors filter's single-no-rejects shape (no template grouping, no
+    /// rejects, no sort-order guard). The header is `self.header` — already
+    /// `ensure_hd`'d + `add_pg`'d in `ChainBuilder::new` — and is not reassigned
+    /// (a pure transform leaves the header shape unchanged). The no-`--threads`
+    /// serial path in `CopyUmi::execute` is the in-process parity oracle.
+    fn add_copy_umi(&mut self, position: StagePosition) -> Result<()> {
+        use crate::commands::common::warn_unwired_pipeline_flags;
+        use crate::logging::OperationTimer;
+        use crate::pipeline::chains::commands::copy_umi::{
+            CopyUmiFinalizeHook, CopyUmiMetricsFinalizeHook, build_copy_umi_process_step,
+        };
+        use crate::validation::validate_file_exists;
+        use fgumi_bam_io::is_stdin_path;
+        use log::info;
+
+        if position == StagePosition::Intermediate {
+            bail!(
+                "intermediate copy-umi not implemented; copy-umi is a terminal, \
+                standalone per-record transform"
+            );
+        }
+
+        // Copy-umi consumes a record stream, so it needs a DecodedRecordBatch
+        // tail (same requirement as filter/clip). Reject any other upstream tail.
+        if self.chain_tail_kind != ChainTailKind::DecodedRecordBatch {
+            bail!(
+                "Stage::CopyUmi requires a record-stream input (DecodedRecordBatch), but the chain \
+                 tail is {:?}; copy-umi cannot follow a stage that emits grouped templates or \
+                 serialized bytes.",
+                self.chain_tail_kind
+            );
+        }
+
+        let copy_umi = self
+            .spec
+            .stage_opts
+            .copy_umi
+            .as_ref()
+            .ok_or_else(|| anyhow!("Stage::CopyUmi options missing from StageOptionsBag"))?;
+
+        let tail = self.current_tail.expect("add_copy_umi called before add_source");
+
+        let input_path = self.resolve_log_input_path();
+        if !is_stdin_path(&input_path) {
+            validate_file_exists(&input_path, "Input BAM")?;
+        }
+
+        let timer = OperationTimer::new("Copying UMIs from read names");
+        let output_path = self.spec.sink.path().clone();
+        info!("Starting copy-umi");
+        info!("Input: {}", input_path.display());
+        info!("Output: {}", output_path.display());
+
+        warn_unwired_pipeline_flags(&self.spec.scheduler);
+        let num_threads = self.spec.threading.num_threads();
+        info!("{}", self.spec.threading.log_message());
+        info!("Using pipeline with {num_threads} threads");
+
+        let setup = copy_umi.setup_pipeline(num_threads);
+        let accumulators = Arc::clone(&setup.collected_metrics);
+
+        let captures = copy_umi.process_captures(&setup)?;
+        let step = build_copy_umi_process_step(
+            self.tuning.per_step_byte_limit,
+            captures,
+            Arc::clone(&accumulators),
+        );
+        self.current_tail = Some(self.pipeline.append_step(step, tail));
+
+        // Register the finalize hooks — BOTH on `finalize_on_success` (not the
+        // always-run `finalize`): the serial oracle `?`-aborts before its summary
+        // on a fail-fast error, so an always-run summary hook would log a partial
+        // summary the serial path never logs. The chain-level
+        // StageTimingFinalizeHook is inserted at index 0 by `build()`.
+        //
+        // Order matters: the SUMMARY hook is registered BEFORE the metrics hook so
+        // it runs first, matching the serial path (`warn_and_log_copy_umi_summary`
+        // then `write_copy_umi_metrics`). This keeps log parity on a `--metrics`
+        // write failure — the summary + completion-timer are already logged on both
+        // paths before the failing write, rather than being swallowed on the chain.
+        self.finalize_on_success
+            .push(Box::new(CopyUmiFinalizeHook { accumulators: Arc::clone(&accumulators), timer }));
+        if let Some(metrics_path) = copy_umi.metrics.clone() {
+            self.finalize_on_success
+                .push(Box::new(CopyUmiMetricsFinalizeHook { accumulators, metrics_path }));
+        }
 
         Ok(())
     }

--- a/src/lib/pipeline/chains/commands/copy_umi.rs
+++ b/src/lib/pipeline/chains/commands/copy_umi.rs
@@ -1,0 +1,163 @@
+//! Chain builder support for `Stage::CopyUmi`.
+//!
+//! Holds the copy-umi-specific types and step factory the builder imports:
+//! `CopyUmiFinalizeHook`, `CopyUmiMetricsFinalizeHook`, and
+//! `build_copy_umi_process_step`. Copy-umi is a pure per-record transform
+//! (`DecodedRecordBatch → DecompressedBlock`, no template grouping, no rejects),
+//! so it mirrors filter's `build_filter_step_single_no_rejects` shape.
+
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use anyhow::Result;
+use log::info;
+
+use crate::commands::copy_umi::{
+    CollectedCopyUmiMetrics, CopyUmiProcessCaptures, copy_umi_into_record,
+    warn_and_log_copy_umi_summary, write_copy_umi_metrics,
+};
+use crate::logging::OperationTimer;
+use crate::per_thread_accumulator::PerThreadAccumulator;
+use crate::pipeline::chains::FinalizeHook;
+use crate::pipeline::steps::process::{ProcessOrdered, process_ordered};
+use crate::pipeline::steps::types::{DecodedRecordBatch, DecompressedBlock};
+
+/// Reduce the per-thread accumulators into a single set of totals. The pipeline
+/// is fully drained before any finalize hook runs, so every slot holds its final
+/// state.
+fn reduce(accumulators: &PerThreadAccumulator<CollectedCopyUmiMetrics>) -> CollectedCopyUmiMetrics {
+    let mut totals = CollectedCopyUmiMetrics::default();
+    for slot in accumulators.slots() {
+        let m = slot.lock();
+        totals.total_records += m.total_records;
+        totals.rx_overwritten += m.rx_overwritten;
+        totals.names_trimmed += m.names_trimmed;
+    }
+    totals
+}
+
+/// Success-only finalize hook: emits the overwrite warning + `=== Summary ===`
+/// block (via the shared [`warn_and_log_copy_umi_summary`]) and logs completion.
+///
+/// Registered on `finalize_on_success` (NOT the always-run `finalize`): the
+/// serial oracle `?`-returns on the first bad record and never reaches its
+/// summary, so an always-run summary would log a partial summary on a fail-fast
+/// abort the serial path never logs.
+pub(crate) struct CopyUmiFinalizeHook {
+    pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedCopyUmiMetrics>>,
+    pub(crate) timer: OperationTimer,
+}
+
+impl FinalizeHook for CopyUmiFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let CopyUmiFinalizeHook { accumulators, timer } = *self;
+        let totals = reduce(&accumulators);
+        warn_and_log_copy_umi_summary(&totals);
+        timer.log_completion(totals.total_records);
+        Ok(())
+    }
+}
+
+/// Success-only finalize hook that writes the `--metrics` TSV (via the shared
+/// [`write_copy_umi_metrics`]), so a failed/partial run never publishes counts.
+pub(crate) struct CopyUmiMetricsFinalizeHook {
+    pub(crate) accumulators: Arc<PerThreadAccumulator<CollectedCopyUmiMetrics>>,
+    pub(crate) metrics_path: std::path::PathBuf,
+}
+
+impl FinalizeHook for CopyUmiMetricsFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let CopyUmiMetricsFinalizeHook { accumulators, metrics_path } = *self;
+        let totals = reduce(&accumulators);
+        write_copy_umi_metrics(&metrics_path, &totals)
+    }
+}
+
+/// Emit the per-batch progress milestone and fold this batch's counts into the
+/// per-thread accumulator (mirrors filter's `record_batch_metrics`).
+fn record_batch_metrics(
+    captures: &CopyUmiProcessCaptures,
+    accumulators: &PerThreadAccumulator<CollectedCopyUmiMetrics>,
+    total_records: u64,
+    rx_overwritten: u64,
+    names_trimmed: u64,
+) {
+    // Cross-thread heartbeat: workers run this concurrently, so the milestone
+    // counter is a shared `AtomicU64` rather than `fgumi_bam_io::ProgressTracker`
+    // (which the single-threaded serial oracle uses but is not built for
+    // concurrent workers). The finalize hooks read the record total from the
+    // accumulator, not from this counter — it drives only the periodic log.
+    let prev = captures.progress.fetch_add(total_records, Ordering::Relaxed);
+    if (prev + total_records) / 1_000_000 > prev / 1_000_000 {
+        info!("Processed {} records", prev + total_records);
+    }
+    accumulators.with_slot(|m| {
+        m.total_records += total_records;
+        m.rx_overwritten += rx_overwritten;
+        m.names_trimmed += names_trimmed;
+    });
+}
+
+/// Build the copy-umi process step (`DecodedRecordBatch → DecompressedBlock`).
+///
+/// Parallel, `ByItemOrdinal`. Every record is kept (no filtering, no rejects);
+/// the read-name UMI is copied into `RX` in place. A bad/empty UMI (or an
+/// existing RX under `--fail-if-tag-present`) aborts the run via
+/// `map_err(io::Error::other)?`, matching the pre-cutover pipeline `process_fn`.
+///
+/// Returns the concrete `ProcessOrdered` (not `impl Step`), because the closure
+/// type embeds in opaque-return position and cannot name itself — the same
+/// pattern as the filter/dedup step factories.
+#[allow(clippy::type_complexity)]
+pub(crate) fn build_copy_umi_process_step(
+    limit_bytes: u64,
+    captures: CopyUmiProcessCaptures,
+    accumulators: Arc<PerThreadAccumulator<CollectedCopyUmiMetrics>>,
+) -> ProcessOrdered<
+    DecodedRecordBatch,
+    DecompressedBlock,
+    impl Fn(DecodedRecordBatch) -> io::Result<DecompressedBlock> + Send + Sync + 'static,
+> {
+    process_ordered::<DecodedRecordBatch, DecompressedBlock, _>(
+        "CopyUmiProcess",
+        limit_bytes,
+        move |item: DecodedRecordBatch| -> io::Result<DecompressedBlock> {
+            let batch_serial = item.batch_serial();
+            let records = item.into_records();
+            let total_records = records.len() as u64;
+            let mut bytes: Vec<u8> = Vec::new();
+            let mut rx_overwritten: u64 = 0;
+            let mut names_trimmed: u64 = 0;
+
+            for decoded in records {
+                let mut record = decoded.into_raw_bytes();
+                let outcome = copy_umi_into_record(
+                    &mut record,
+                    captures.field_delimiter,
+                    captures.reverse_complement_prefixed,
+                    captures.remove_umi,
+                    captures.fail_if_tag_present,
+                )
+                .map_err(io::Error::other)?;
+                if outcome.overwrote_rx {
+                    rx_overwritten += 1;
+                }
+                if outcome.trimmed_name {
+                    names_trimmed += 1;
+                }
+                fgumi_raw_bam::write_framed_record(&mut bytes, record.as_ref())?;
+            }
+
+            record_batch_metrics(
+                &captures,
+                &accumulators,
+                total_records,
+                rx_overwritten,
+                names_trimmed,
+            );
+
+            Ok(DecompressedBlock { batch_serial, bytes })
+        },
+    )
+}

--- a/src/lib/pipeline/chains/commands/mod.rs
+++ b/src/lib/pipeline/chains/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod align;
 pub mod clip;
 #[cfg(feature = "consensus")]
 pub mod codec;
+pub mod copy_umi;
 pub mod correct;
 pub mod dedup;
 #[cfg(feature = "consensus")]

--- a/src/lib/pipeline/chains/options_bag.rs
+++ b/src/lib/pipeline/chains/options_bag.rs
@@ -9,6 +9,7 @@ pub use crate::aligner::AlignerOptions;
 pub use crate::commands::clip::Clip;
 #[cfg(feature = "consensus")]
 pub use crate::commands::codec::CodecOptions;
+pub use crate::commands::copy_umi::CopyUmiOptions;
 pub use crate::commands::correct::CorrectOptions;
 pub use crate::commands::dedup::MarkDuplicates;
 #[cfg(feature = "consensus")]
@@ -56,16 +57,17 @@ pub struct AlignOptions {
 /// that every stage in `spec.stages` has its matching options
 /// present before constructing any chain steps.
 ///
-/// Fourteen fields are wired: Correct, Zipper, Sort, Group, Duplex, Codec,
-/// Filter, Retag, Simplex, Align, Extract, and Fastq hold free-standing
-/// `<Command>Options` structs, while Dedup and Clip hold the command struct
-/// directly (`MarkDuplicates` / `Clip`) — no separate `DedupOptions`/
-/// `ClipOptions` is extracted, because test code constructs those via
-/// `clap::Parser::parse_from` and extracting a sub-struct would destabilise
-/// that surface. The remaining stage (Downsample) has no slot yet; it is
-/// added incrementally in T2.19–T2.22.
+/// Fifteen fields are wired: `CopyUmi`, `Correct`, `Zipper`, `Sort`, `Group`,
+/// `Duplex`, `Codec`, `Filter`, `Retag`, `Simplex`, `Align`, `Extract`, and
+/// `Fastq` hold free-standing `<Command>Options` structs, while `Dedup` and
+/// `Clip` hold the command struct directly (`MarkDuplicates` / `Clip`) — no
+/// separate `DedupOptions`/`ClipOptions` is extracted, because test code
+/// constructs those via `clap::Parser::parse_from` and extracting a sub-struct
+/// would destabilise that surface. The remaining stage (`Downsample`) has no
+/// slot yet; it is added incrementally in T2.19–T2.22.
 #[derive(Default)]
 pub struct StageOptionsBag {
+    pub copy_umi: Option<CopyUmiOptions>,
     pub correct: Option<CorrectOptions>,
     pub zipper: Option<ZipperOptions>,
     pub sort: Option<SortOptions>,

--- a/src/lib/pipeline/chains/stage.rs
+++ b/src/lib/pipeline/chains/stage.rs
@@ -15,6 +15,7 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Stage {
     Extract,
+    CopyUmi,
     Correct,
     Align,
     Zipper,
@@ -58,8 +59,9 @@ mod tests {
     /// enum rather than a hand-picked subset. A new variant that is not added
     /// here is still forced through the exhaustive `match`es in the
     /// `expected_*` helpers, which fail to compile until it is classified.
-    const ALL_STAGES: [Stage; 15] = [
+    const ALL_STAGES: [Stage; 16] = [
         Stage::Extract,
+        Stage::CopyUmi,
         Stage::Correct,
         Stage::Align,
         Stage::Zipper,
@@ -83,6 +85,7 @@ mod tests {
         match stage {
             Stage::Simplex | Stage::Duplex | Stage::Codec => true,
             Stage::Extract
+            | Stage::CopyUmi
             | Stage::Correct
             | Stage::Align
             | Stage::Zipper
@@ -103,6 +106,7 @@ mod tests {
         match stage {
             Stage::Align | Stage::Zipper => true,
             Stage::Extract
+            | Stage::CopyUmi
             | Stage::Correct
             | Stage::Sort
             | Stage::Group

--- a/src/lib/pipeline/chains/validate.rs
+++ b/src/lib/pipeline/chains/validate.rs
@@ -18,15 +18,15 @@ use crate::pipeline::chains::{ChainSpec, Stage};
 /// they're mutually exclusive in a chain.
 ///
 /// Adjustments vs runall's ord:
-/// - Extract = 0 (input-producing, must precede everything)
-/// - Correct = 1 (was 0)
-/// - Align = 2 (was 1, was `AlignAndMerge`)
-/// - Zipper = 3 (was 2)
-/// - Sort = 4 (was 3)
-/// - Group = 5 (was 4)
-/// - Clip, Dedup, Downsample = 6 (post-group standalone-only)
-/// - Simplex, Duplex, Codec = 7 (terminal consensus, was 5)
-/// - Filter = 8 (post-consensus filtering; follows the consensus caller
+/// - `Extract` = 0 (input-producing, must precede everything)
+/// - `Correct` = 1 (was 0)
+/// - `Align` = 2 (was 1, was `AlignAndMerge`)
+/// - `Zipper` = 3 (was 2)
+/// - `Sort` = 4 (was 3)
+/// - `Group` = 5 (was 4)
+/// - `CopyUmi`, `Clip`, `Dedup`, `Downsample` = 6 (post-group standalone-only)
+/// - `Simplex`, `Duplex`, `Codec` = 7 (terminal consensus, was 5)
+/// - `Filter` = 8 (post-consensus filtering; follows the consensus caller
 ///   in a runall `consensus → filter` chain, so it sorts after the
 ///   consensus bucket)
 fn stage_ord(stage: Stage) -> usize {
@@ -37,15 +37,15 @@ fn stage_ord(stage: Stage) -> usize {
         Stage::Zipper => 3,
         Stage::Sort => 4,
         Stage::Group => 5,
-        // Retag is a standalone-only per-record transform; it only ever appears
-        // as the sole stage of a `fgumi retag` chain, so its rank is nominal and
-        // it joins the post-group standalone bucket. `validate_stage_progression`
-        // rejects any multi-stage chain containing Retag outright, so this rank is
-        // never actually exercised against a neighbour — if a future fused chain
-        // ever pairs Retag with another stage, drop that standalone-only guard and
-        // revisit this rank (at 6 the non-decreasing rule would reject a trailing
-        // Sort/Group but accept a leading one).
-        Stage::Clip | Stage::Dedup | Stage::Retag | Stage::Downsample => 6,
+        // `CopyUmi` and `Retag` are standalone-only per-record transforms that
+        // join the post-group standalone bucket; both ranks are nominal because
+        // `validate_stage_progression` rejects any multi-stage chain containing
+        // either one outright, so neither rank is ever exercised against a
+        // neighbour. (copy-umi semantically belongs BEFORE sort/group — it
+        // populates RX at the boundary — so a future fused `[CopyUmi, Sort]` /
+        // `[CopyUmi, Group]` chain would need CopyUmi < Sort(4)/Group(5); drop the
+        // standalone-only guard and revisit these ranks if such a chain is added.)
+        Stage::CopyUmi | Stage::Clip | Stage::Dedup | Stage::Retag | Stage::Downsample => 6,
         Stage::Simplex | Stage::Duplex | Stage::Codec => 7,
         Stage::Filter => 8,
         // Terminal BAM→FASTQ export. Only ever appears as the sole stage of a
@@ -58,8 +58,8 @@ fn stage_ord(stage: Stage) -> usize {
 ///
 /// Rules:
 /// - At least one stage (empty chain is meaningless).
-/// - `Stage::Retag` is standalone-only — it must be the sole stage of a chain
-///   (a multi-stage chain containing Retag is rejected).
+/// - `Stage::Retag` and `Stage::CopyUmi` are standalone-only — each must be the
+///   sole stage of a chain (a multi-stage chain containing either is rejected).
 /// - Each adjacent pair must be non-decreasing in `stage_ord`.
 /// - At most one `Align` per chain (mutually exclusive with `Zipper`).
 /// - At most one `Zipper` per chain (mutually exclusive with `Align`).
@@ -92,6 +92,21 @@ pub fn validate_stage_progression(spec: &ChainSpec) -> Result<()> {
         bail!(
             "Stage::Retag is standalone-only: it must be the sole stage of a chain, \
              but got a {}-stage chain containing Retag ({stages:?})",
+            stages.len(),
+        );
+    }
+
+    // CopyUmi is standalone-only for the same reason as Retag: it is only ever the
+    // sole stage of a `fgumi copy-umi` chain (routed via `ChainSpec::single_stage`).
+    // `[Sort, CopyUmi]` in particular slips past the non-decreasing ord rule below
+    // (Sort ord 4 <= CopyUmi ord 6), and `add_sort` (intermediate) leaves a
+    // `DecodedRecordBatch` that terminal `add_copy_umi` would happily consume —
+    // an untested fused sort→copy-umi path. Reject it here, ahead of the ordering
+    // loop, so `[CopyUmi, Sort]` gets this precise message too.
+    if stages.len() > 1 && stages.contains(&Stage::CopyUmi) {
+        bail!(
+            "Stage::CopyUmi is standalone-only: it must be the sole stage of a chain, \
+             but got a {}-stage chain containing CopyUmi ({stages:?})",
             stages.len(),
         );
     }
@@ -167,9 +182,9 @@ pub fn validate_stage_progression(spec: &ChainSpec) -> Result<()> {
 
 /// Reject specs where a referenced stage has no options in the bag.
 ///
-/// As of Phase 5 T5.3, thirteen stages have their options in the bag:
-/// Correct, Sort, Group, Zipper, Duplex, Codec, Dedup, Filter, Clip, Simplex,
-/// Align, Extract, and Fastq. The remaining stage (Downsample) adds its slot
+/// As of the copy-umi cutover, fourteen stages have their options in the bag:
+/// `Correct`, `Sort`, `Group`, `Zipper`, `Duplex`, `Codec`, `Dedup`, `Filter`, `Clip`,
+/// `Simplex`, `Align`, `Extract`, `Fastq`, and `CopyUmi`. The remaining stage (`Downsample`) adds its slot
 /// incrementally during its migration task (T2.19–T2.22). For now that stage
 /// skips the options-presence check — once its slot lands in the bag, add the
 /// check here.
@@ -190,6 +205,7 @@ pub fn validate_stage_opts_present(spec: &ChainSpec) -> Result<()> {
 
         // Check wired stages have their options present.
         let present = match stage {
+            Stage::CopyUmi => bag.copy_umi.is_some(),
             Stage::Correct => bag.correct.is_some(),
             Stage::Zipper => bag.zipper.is_some(),
             Stage::Sort => bag.sort.is_some(),
@@ -628,6 +644,25 @@ mod tests {
         let err = validate_stage_progression(&empty_spec(stages)).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("Retag"), "expected Retag in error, got: {msg}");
+        assert!(
+            msg.contains("standalone-only"),
+            "expected the standalone-only rejection, got: {msg}"
+        );
+    }
+
+    #[rstest]
+    #[case::sort_then_copy_umi(vec![Stage::Sort, Stage::CopyUmi])]
+    #[case::copy_umi_then_sort(vec![Stage::CopyUmi, Stage::Sort])]
+    #[case::group_then_copy_umi(vec![Stage::Group, Stage::CopyUmi])]
+    fn copy_umi_multi_stage_rejected(#[case] stages: Vec<Stage>) {
+        // CopyUmi is standalone-only (the sole stage of a `fgumi copy-umi` chain).
+        // A multi-stage chain containing CopyUmi — in either order — must be
+        // rejected at the spec boundary. `[Sort, CopyUmi]` is the case the
+        // non-decreasing ord rule would otherwise accept (Sort ord 4 <= CopyUmi
+        // ord 6), leaving an untested fused sort→copy-umi path.
+        let err = validate_stage_progression(&empty_spec(stages)).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("CopyUmi"), "expected CopyUmi in error, got: {msg}");
         assert!(
             msg.contains("standalone-only"),
             "expected the standalone-only rejection, got: {msg}"

--- a/src/lib/pipeline/steps/parse/decode.rs
+++ b/src/lib/pipeline/steps/parse/decode.rs
@@ -67,7 +67,7 @@ use fgumi_bam_io::{DecodedRecord, GroupKeyConfig, compute_group_key_from_raw, na
 ///   `raw.len() >= 32 + l_read_name - 1` (the exclusive end of that slice).
 ///   When `l_read_name <= 1`, `read_name` returns `&[]` without slicing, so the
 ///   32-byte header is enough.
-fn validate_record_for_decode(raw: &[u8]) -> io::Result<()> {
+pub(crate) fn validate_record_for_decode(raw: &[u8]) -> io::Result<()> {
     if raw.len() < fgumi_raw_bam::MIN_BAM_RECORD_LEN {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,

--- a/tests/integration/test_copy_umi_command.rs
+++ b/tests/integration/test_copy_umi_command.rs
@@ -167,13 +167,20 @@ fn overwrites_existing_rx_by_default() {
     assert_eq!(rows[0].1.as_deref(), Some("ACGT"), "stale RX should be replaced");
 }
 
-#[test]
-fn fail_if_tag_present_errors_on_existing_rx() {
+/// `--fail-if-tag-present` must abort on both the serial oracle and the
+/// `--threads` chain path — proving the flag is wired on the parallel path too,
+/// not just the serial one.
+#[rstest]
+#[case::serial(&[][..])]
+#[case::chain(&["--threads", "2"][..])]
+fn fail_if_tag_present_errors_on_existing_rx(#[case] thread_flags: &[&str]) {
     let dir = TempDir::new().unwrap();
     let input = write_input(dir.path(), &[record_named_with_rx("blah:ACGT", "STALEVAL")]);
     let output = dir.path().join("out.bam");
-    let err = run_copy_umi(&input, &output, &["--fail-if-tag-present"])
-        .expect_err("should error when RX already present");
+    let mut flags = vec!["--fail-if-tag-present"];
+    flags.extend_from_slice(thread_flags);
+    let err =
+        run_copy_umi(&input, &output, &flags).expect_err("should error when RX already present");
     assert!(
         format!("{err:#}").contains("already has an RX tag"),
         "error should name the pre-existing RX tag, got: {err:#}"
@@ -492,5 +499,391 @@ fn runs_on_multiple_threads() {
     assert_eq!(
         rows, want,
         "the parallel path must preserve every record's QNAME and its copied RX, in input order"
+    );
+}
+
+// ============================================================================
+// Chain-vs-oracle parity (the R3 cutover contract)
+//
+// The no-`--threads` serial path (`run_single_threaded`) is the in-process
+// oracle; `--threads N` routes through the chain builder. `--threads 1` is a
+// distinct chain-at-single-worker path from both, so the matrix includes it.
+// ============================================================================
+
+/// Build a copy-umi input of `n` records with `:`-delimited UMI read names.
+/// `n=500` crosses pipeline batch boundaries, exercising the cross-slot metrics
+/// reduction and the multi-batch ordering.
+fn build_parity_input(dir: &Path, n: usize) -> std::path::PathBuf {
+    let bases = [b'A', b'C', b'G', b'T'];
+    let records: Vec<RawRecord> = (0..n)
+        .map(|i| {
+            let umi: String = (0..8).map(|j| bases[(i + j) % 4] as char).collect();
+            record_named(&format!("inst:1:FC:1:1101:{i}:{i}:{umi}"))
+        })
+        .collect();
+    write_input(dir, &records)
+}
+
+#[rstest]
+#[case::t1(1)]
+#[case::t2(2)]
+#[case::t4(4)]
+fn chain_matches_single_threaded(#[case] threads: u8) {
+    let dir = TempDir::new().unwrap();
+    let input = build_parity_input(dir.path(), 500);
+
+    let oracle_out = dir.path().join("oracle.bam");
+    run_copy_umi(&input, &oracle_out, &[]).expect("serial oracle run");
+
+    let chain_out = dir.path().join("chain.bam");
+    run_copy_umi(&input, &chain_out, &["--threads", &threads.to_string()]).expect("chain run");
+
+    let (oracle_hdr, oracle_recs) = crate::helpers::read_bam_output(&oracle_out);
+    let (chain_hdr, chain_recs) = crate::helpers::read_bam_output(&chain_out);
+    assert_eq!(chain_hdr, oracle_hdr, "normalized header parity (threads={threads})");
+    assert_eq!(chain_recs, oracle_recs, "record parity (threads={threads})");
+    // Non-vacuous: every record survived and carries the copied RX.
+    assert_eq!(chain_recs.len(), 500, "all records emitted");
+}
+
+/// Every non-default, output-producing knob must be wired identically on the
+/// chain (`--threads`) path and the serial oracle. The default-flag parity test
+/// above exercises none of them, so a knob dropped or mis-wired on the parallel
+/// path would go unnoticed. The input carries `r`-prefixed and dual UMIs so both
+/// `--remove-umi` (name trim) and `--reverse-complement-r-umis false` (strip vs
+/// reverse-complement) change the output — if the chain dropped a flag, its
+/// records would diverge from the oracle's.
+/// The `expected` case column is the absolute `(read_name, RX)` the oracle must
+/// produce for each of the three input records under the case's flags. Pinning
+/// these fixed values — not just chain-vs-oracle parity — is what catches a bug
+/// present on *both* paths (e.g. a flag mis-parsed in shared code): parity alone
+/// would still pass. Verified against the command's observed output; note
+/// `--reverse-complement-r-umis false` still maps the `+` dual-UMI delimiter to
+/// `-` (it only disables the `r`-prefix reverse-complement), so the strip case
+/// yields `AAAA-CCCC`, not `AAAA+CCCC`.
+#[rstest]
+#[case::remove_umi(
+    &["--remove-umi"][..],
+    &[
+        ("inst:1:FC:1:1101:5:7", "TTTT-CCCC"),
+        ("inst:1:FC:1:1101:5:8", "CCCC"),
+        ("inst:1:FC:1:1101:5:9", "TTTT"),
+    ],
+)]
+#[case::strip_only(
+    &["--reverse-complement-r-umis", "false"][..],
+    &[
+        ("inst:1:FC:1:1101:5:7:rAAAA+CCCC", "AAAA-CCCC"),
+        ("inst:1:FC:1:1101:5:8:rGGGG", "GGGG"),
+        ("inst:1:FC:1:1101:5:9:TTTT", "TTTT"),
+    ],
+)]
+#[case::remove_and_strip(
+    &["--remove-umi", "--reverse-complement-r-umis", "false"][..],
+    &[
+        ("inst:1:FC:1:1101:5:7", "AAAA-CCCC"),
+        ("inst:1:FC:1:1101:5:8", "GGGG"),
+        ("inst:1:FC:1:1101:5:9", "TTTT"),
+    ],
+)]
+fn chain_matches_oracle_with_nondefault_options(
+    #[case] option_flags: &[&str],
+    #[case] expected: &[(&str, &str)],
+) {
+    let dir = TempDir::new().unwrap();
+    let records = [
+        record_named("inst:1:FC:1:1101:5:7:rAAAA+CCCC"),
+        record_named("inst:1:FC:1:1101:5:8:rGGGG"),
+        record_named("inst:1:FC:1:1101:5:9:TTTT"),
+    ];
+    let input = write_input(dir.path(), &records);
+
+    let oracle_out = dir.path().join("oracle.bam");
+    run_copy_umi(&input, &oracle_out, option_flags).expect("serial oracle run");
+
+    let mut chain_flags = option_flags.to_vec();
+    chain_flags.extend_from_slice(&["--threads", "4"]);
+    let chain_out = dir.path().join("chain.bam");
+    run_copy_umi(&input, &chain_out, &chain_flags).expect("chain run");
+
+    // Absolute anchor: the oracle must produce exactly these names+RX. A flag
+    // dropped in shared code would change these, even though chain==oracle held.
+    let oracle_name_rx = read_name_and_rx(dir.path(), &oracle_out);
+    let expected_name_rx: Vec<(String, Option<String>)> =
+        expected.iter().map(|(name, rx)| ((*name).to_string(), Some((*rx).to_string()))).collect();
+    assert_eq!(
+        oracle_name_rx, expected_name_rx,
+        "oracle (name, RX) must match the pinned expected values (flags={option_flags:?})",
+    );
+
+    let (oracle_hdr, oracle_recs) = crate::helpers::read_bam_output(&oracle_out);
+    let (chain_hdr, chain_recs) = crate::helpers::read_bam_output(&chain_out);
+    assert_eq!(chain_hdr, oracle_hdr, "normalized header parity (flags={option_flags:?})");
+    assert_eq!(chain_recs, oracle_recs, "record parity (flags={option_flags:?})");
+    assert_eq!(chain_recs.len(), 3, "all records emitted (flags={option_flags:?})");
+}
+
+/// `--metrics` TSV must be byte-identical between the serial oracle and the
+/// chain. `fgumi_metrics::write_metrics` embeds no timestamp, so a raw byte
+/// compare is stable.
+#[test]
+fn chain_metrics_match_single_threaded() {
+    let dir = TempDir::new().unwrap();
+    // Include a record with a pre-existing RX so `rx_overwritten` is non-zero.
+    let mut records: Vec<RawRecord> =
+        (0..50).map(|i| record_named(&format!("q:{i}:ACGT"))).collect();
+    records.push(record_named_with_rx("q:99:TTTT", "AAAA"));
+    let input = write_input(dir.path(), &records);
+
+    let oracle_out = dir.path().join("oracle.bam");
+    let oracle_metrics = dir.path().join("oracle.tsv");
+    run_copy_umi(&input, &oracle_out, &["-M", &oracle_metrics.display().to_string()])
+        .expect("serial run");
+
+    let chain_out = dir.path().join("chain.bam");
+    let chain_metrics = dir.path().join("chain.tsv");
+    run_copy_umi(
+        &input,
+        &chain_out,
+        &["--threads", "4", "-M", &chain_metrics.display().to_string()],
+    )
+    .expect("chain run");
+
+    let oracle_tsv = std::fs::read(&oracle_metrics).expect("read oracle metrics");
+    let chain_tsv = std::fs::read(&chain_metrics).expect("read chain metrics");
+    assert_eq!(chain_tsv, oracle_tsv, "the --metrics TSV must be byte-identical across paths");
+
+    // Absolute anchor: pin the metrics row to fixed expected counts, not just
+    // chain==oracle parity. 50 fresh names + 1 with a pre-existing RX = 51
+    // records; every record gets an RX (rx_written 51), the one carrying a stale
+    // RX is overwritten (rx_overwritten 1), and no `--remove-umi` means no name
+    // trims (names_trimmed 0). Shared miscounting would slip past a byte compare.
+    let row = read_metrics_row(&oracle_metrics);
+    assert_eq!(row.get("total_records").map(String::as_str), Some("51"), "row: {row:?}");
+    assert_eq!(row.get("rx_written").map(String::as_str), Some("51"), "row: {row:?}");
+    assert_eq!(row.get("rx_overwritten").map(String::as_str), Some("1"), "row: {row:?}");
+    assert_eq!(row.get("names_trimmed").map(String::as_str), Some("0"), "row: {row:?}");
+}
+
+/// Fail-fast under `--threads`: one record with an empty last field aborts the
+/// run, naming the read name. A single bad record keeps the surfaced
+/// error deterministic under the parallel pipeline.
+#[test]
+fn fail_fast_under_threads_single_bad_record() {
+    let dir = TempDir::new().unwrap();
+    let bad = "read-with-empty-umi:";
+    let input = write_input(dir.path(), &[record_named("q:1:ACGT"), record_named(bad)]);
+    let output = dir.path().join("out.bam");
+    let err = run_copy_umi(&input, &output, &["--threads", "2"])
+        .expect_err("empty UMI field must abort the --threads run");
+    let msg = format!("{err:#}");
+    assert!(msg.contains(bad), "chain error names the read name; got: {msg}");
+}
+
+/// Two-level fail-fast: an illegal-character UMI is a
+/// `with_context`-wrapped error. Both paths must abort naming the read name and
+/// the outer "extracting UMI from read name" context. The serial oracle also
+/// preserves the inner reason (full `anyhow` chain); the chain path's
+/// `reconstruct` flattens to Display-only, so the inner reason is not asserted on
+/// the chain path — this documents the framework flattening rather than asserting
+/// a parity that does not hold.
+#[test]
+fn two_level_fail_fast_names_read_name_on_both_paths() {
+    let dir = TempDir::new().unwrap();
+    let bad = "q:1:ZZZZ"; // Z is outside ACGTN-, so normalization fails.
+    let input = write_input(dir.path(), &[record_named(bad)]);
+
+    let serial_out = dir.path().join("serial.bam");
+    let serial_err = run_copy_umi(&input, &serial_out, &[])
+        .expect_err("illegal UMI char must abort the serial run");
+    let serial_msg = format!("{serial_err:#}");
+    assert!(serial_msg.contains(bad), "serial names the read name; got: {serial_msg}");
+    assert!(
+        serial_msg.contains("extracting UMI from read name"),
+        "serial carries the outer context; got: {serial_msg}"
+    );
+
+    let chain_out = dir.path().join("chain.bam");
+    let chain_err = run_copy_umi(&input, &chain_out, &["--threads", "2"])
+        .expect_err("illegal UMI char must abort the chain run");
+    let chain_msg = format!("{chain_err:#}");
+    assert!(chain_msg.contains(bad), "chain names the read name; got: {chain_msg}");
+    assert!(
+        chain_msg.contains("extracting UMI from read name"),
+        "chain carries the outer context; got: {chain_msg}"
+    );
+}
+
+/// Header-less input: both the chain and the serial oracle synthesize
+/// `@HD VN:1.6 SO:unsorted` and stay in header parity (`ChainBuilder::new`
+/// calls `ensure_hd_record`, so the chain path
+/// synthesizes @HD just like the oracle).
+#[test]
+fn chain_and_oracle_synthesize_hd_for_headerless_input() {
+    use noodles::sam::Header as SamHeader;
+    use noodles::sam::header::record::value::{Map, map::ReferenceSequence};
+    use std::num::NonZeroUsize;
+
+    let dir = TempDir::new().unwrap();
+    // A header with a reference sequence but NO @HD line.
+    let header = SamHeader::builder()
+        .add_reference_sequence(
+            bstr::BString::from("chr1"),
+            Map::<ReferenceSequence>::new(NonZeroUsize::new(10_000).unwrap()),
+        )
+        .build();
+    assert!(header.header().is_none(), "fixture must be header-less");
+    let input = dir.path().join("headerless.bam");
+    write_bam(&input, &header, &[record_named("q:1:ACGT")]);
+
+    let oracle_out = dir.path().join("oracle.bam");
+    run_copy_umi(&input, &oracle_out, &[]).expect("serial run");
+    let chain_out = dir.path().join("chain.bam");
+    run_copy_umi(&input, &chain_out, &["--threads", "2"]).expect("chain run");
+
+    let (oracle_hdr, _) = crate::helpers::read_bam_output(&oracle_out);
+    let (chain_hdr, _) = crate::helpers::read_bam_output(&chain_out);
+    assert!(oracle_hdr.header().is_some(), "serial synthesizes @HD");
+    assert!(chain_hdr.header().is_some(), "chain synthesizes @HD");
+    assert_eq!(chain_hdr, oracle_hdr, "header-less-input @HD parity");
+
+    // Absolute anchor: pin the exact synthesized @HD contract on BOTH paths, not
+    // just their equality — otherwise both could synthesize the same *wrong* @HD
+    // and pass. `ChainBuilder::new`/the oracle synthesize `@HD VN:1.6 SO:unsorted`.
+    let hd_line = |bam: &Path, tag: &str| -> String {
+        let sam = dir.path().join(format!("{tag}.sam"));
+        transcode_bam_to_sam(bam, &sam);
+        std::fs::read_to_string(&sam)
+            .expect("read sam")
+            .lines()
+            .find(|l| l.starts_with("@HD"))
+            .unwrap_or_else(|| panic!("{tag} output must carry an @HD line"))
+            .to_string()
+    };
+    for (tag, bam) in [("oracle", &oracle_out), ("chain", &chain_out)] {
+        let hd = hd_line(bam, tag);
+        assert!(hd.contains("VN:1.6"), "{tag} @HD must declare VN:1.6, got: {hd}");
+        assert!(hd.contains("SO:unsorted"), "{tag} @HD must declare SO:unsorted, got: {hd}");
+    }
+}
+
+// ============================================================================
+// CRC-policy parity: the serial oracle (no `--threads`) and the
+// chain (`--threads N`) derive `verify_crc` from independent sources — the
+// serial path from `self.io.pipeline_reader_opts()`, the chain from
+// `spec.verify_crc` — so pin them equal: both must honor `--check-crc` /
+// `--no-check-crc` identically (default verify-on for file input rejects a
+// corrupted block; `--no-check-crc` accepts it).
+// ============================================================================
+
+/// Flip a byte in the last BGZF block's CRC32 footer, so decoding that block
+/// fails only when CRC verification is on. The input must span >= 2 BGZF blocks
+/// so the corrupted block is not the header's block (which always verifies during
+/// the header parse). Mirrors the sibling command tests (clip/group/dedup/…).
+fn corrupt_last_block_crc(path: &Path) {
+    use fgumi_lib::bgzf_reader::{BGZF_FOOTER_SIZE, RawBgzfBlock, read_raw_blocks};
+    let mut bytes = std::fs::read(path).expect("read bam for corruption");
+    let mut cursor: &[u8] = &bytes;
+    let blocks = read_raw_blocks(&mut cursor, 100_000).expect("read bgzf blocks from test bam");
+    assert!(
+        blocks.len() >= 2,
+        "test input must span >= 2 BGZF blocks so the corrupted block isn't the header's; got {}",
+        blocks.len()
+    );
+    let offset: usize = blocks[..blocks.len() - 1].iter().map(RawBgzfBlock::len).sum();
+    let last = blocks.last().expect("checked len >= 2 above");
+    let crc_off = offset + last.len() - BGZF_FOOTER_SIZE;
+    bytes[crc_off] ^= 0x01;
+    std::fs::write(path, bytes).expect("write corrupted bam");
+}
+
+/// Both the serial oracle and the `--threads` chain must honor the CRC policy
+/// identically: the default (verify-on for file input) rejects a corrupted BGZF
+/// block, while `--no-check-crc` accepts it and completes.
+#[rstest]
+#[case::serial(&[][..])]
+#[case::chain(&["--threads", "4"][..])]
+fn crc_policy_parity_serial_and_chain(#[case] path_flags: &[&str]) {
+    let dir = TempDir::new().unwrap();
+    // 6000 records span several BGZF blocks, so the corrupted last block is a
+    // record block, not the header's.
+    let input = build_parity_input(dir.path(), 6000);
+    corrupt_last_block_crc(&input);
+
+    // Default policy: both paths reject the corrupted block.
+    let out_reject = dir.path().join("reject.bam");
+    assert!(
+        run_copy_umi(&input, &out_reject, path_flags).is_err(),
+        "default CRC policy must reject a corrupted block (flags={path_flags:?})"
+    );
+
+    // `--no-check-crc`: both paths accept the corrupted block and complete.
+    let out_accept = dir.path().join("accept.bam");
+    let mut accept_flags = path_flags.to_vec();
+    accept_flags.push("--no-check-crc");
+    run_copy_umi(&input, &out_accept, &accept_flags).unwrap_or_else(|e| {
+        panic!("--no-check-crc must accept a corrupted block (flags={path_flags:?}): {e}")
+    });
+    // Assert the accepted output is record-for-record identical to an
+    // *uncorrupted* run of the same input — a bare count (6000) would pass even
+    // if `--no-check-crc` silently dropped, duplicated, or reordered the
+    // corrupted block's records. Corrupting the CRC leaves the payload intact, so
+    // the two outputs must match exactly (order + content).
+    let (_hdr, recs) = crate::helpers::read_bam_output(&out_accept);
+    assert_eq!(
+        recs.len(),
+        6000,
+        "--no-check-crc must accept AND retain all records (flags={path_flags:?})"
+    );
+    let clean_dir = TempDir::new().unwrap();
+    let clean_input = build_parity_input(clean_dir.path(), 6000);
+    let clean_out = clean_dir.path().join("clean.bam");
+    run_copy_umi(&clean_input, &clean_out, path_flags).expect("uncorrupted reference run");
+    let (_clean_hdr, clean_recs) = crate::helpers::read_bam_output(&clean_out);
+    assert_eq!(
+        recs, clean_recs,
+        "--no-check-crc output must be record-for-record identical to the uncorrupted run \
+         (flags={path_flags:?})"
+    );
+}
+
+// ============================================================================
+// Malformed-record safety: a framing-consistent-but-malformed record (an
+// `l_read_name` that runs past the record end) must fail with a CLEAN error on
+// BOTH the serial oracle and the `--threads` chain — never panic. Before the
+// serial path revalidated framing, `copy_umi_into_record`'s `read_name()` slice
+// would panic (index out of bounds) on such a record, a regression from the
+// pre-cutover pipeline, which decoded (and thus validated) every record.
+// ============================================================================
+
+/// Write a one-record BAM whose record has a corrupted `l_read_name` (claims a
+/// 200-byte read name the short record cannot hold), via the RAW writer so the
+/// corruption survives (`write_bam` would re-normalize it through noodles).
+fn write_malformed_l_read_name_bam(dir: &Path) -> std::path::PathBuf {
+    let path = dir.join("malformed.bam");
+    let header = create_minimal_header("chr1", 10_000);
+    let mut record = record_named("inst:1:FC:1:1101:5:7:ACGT");
+    // Byte 8 of the record body is `l_read_name`; 200 runs far past this short
+    // record's end, so an unguarded `read_name()` would slice out of bounds.
+    record.as_mut_vec()[8] = 200;
+    let mut writer =
+        fgumi_bam_io::create_raw_bam_writer(&path, &header, 1, 6).expect("create raw BAM writer");
+    writer.write_raw_record(record.as_ref()).expect("write malformed record");
+    writer.finish().expect("finish malformed BAM");
+    path
+}
+
+#[rstest]
+#[case::serial(&[][..])]
+#[case::chain(&["--threads", "2"][..])]
+fn malformed_record_errors_cleanly_on_both_paths(#[case] thread_flags: &[&str]) {
+    let dir = TempDir::new().unwrap();
+    let input = write_malformed_l_read_name_bam(dir.path());
+    let output = dir.path().join("out.bam");
+    let err = run_copy_umi(&input, &output, thread_flags)
+        .expect_err("a malformed l_read_name record must error, not panic");
+    assert!(
+        format!("{err:#}").contains("read-name region runs past record end"),
+        "expected the clean framing error on both paths (flags={thread_flags:?}), got: {err:#}"
     );
 }


### PR DESCRIPTION
## What

Route `fgumi copy-umi` onto the declarative chain builder — R3 follow-on. `copy-umi --threads N` now runs through `execute_chain` → `ChainSpec::single_stage(Stage::CopyUmi, …)` → `build_for(spec)?.run()`. copy-umi was single-path before (it ran the pipeline even at `threads=1`), so this PR **adds a serial `run_single_threaded` no-`--threads` path as the in-process parity oracle**, and removes the old `run_bam_pipeline_from_reader` engine (+ `CopyUmiProcessed` + its `MemoryEstimate`).

**2-part change** (no dormant chain stage existed): (A) chains-core adds `Stage::CopyUmi`, the `StageOptionsBag` slot, `ChainBuilder::add_copy_umi`, the step module (`pipeline/chains/commands/copy_umi.rs`), the finalize hooks, and every stage-enumerating-pass edit; (B) the cutover adds the serial oracle, `execute_chain`, and the `--threads` dispatch flip. copy-umi is a pure per-record transform (`SingleRawRecordGrouper`, no rejects, un-feature-gated), mirroring filter's single-no-rejects shape.

## Design notes

- **Anti-drift sharing:** `validate_field_delimiter`, `copy_umi_into_record`, `write_copy_umi_metrics`, and `warn_and_log_copy_umi_summary` are each defined once and used by BOTH the serial oracle and the chain finalize hooks, so the two paths cannot drift.
- Both finalize hooks are **success-only** (a fail-fast abort logs no partial summary); the summary hook is registered *before* the metrics hook so a `--metrics` write failure doesn't swallow the summary — matching the serial path's summary-before-metrics order.
- `execute_chain` is build/run only — copy-umi's `execute()` never emitted `log_effective_check_crc`, so it stays off the `--threads` path (no double-log).
- Cheap group key via `name_hash_only` with a **default** `LibraryIndex` (copy-umi never reads the key; a default index skips the per-record aux-tag scan + CIGAR walk and avoids the `>65,535`-library `LibraryIndex::from_header` panic).
- **Robustness:** the serial path runs the same `validate_record_for_decode` framing check the chain does before touching read-name bytes, so a malformed (`l_read_name`-past-end) record returns a clean `InvalidData` error on BOTH paths — no panic.
- `@HD` synthesis parity holds because `ChainBuilder::new` calls `ensure_hd_record`, so headerless input gets `@HD` on both paths.
- **Fail-fast** (bad/empty UMI, or an existing `RX` under `--fail-if-tag-present`) aborts naming the read name; the chain wraps the error via `map_err(io::Error::other)`. Note: the chains framework's `PipelineError::reconstruct` flattens two-level errors on the `--threads` path (the inner reason is dropped) — a pre-existing framework limitation, not introduced here; the fail-fast test asserts the substrings that survive on both paths.

## Tests

Chain-vs-oracle parity across `--threads` 1/2/4 (records + normalized header), `--metrics` byte-parity, **non-default options on the chain path** (`--remove-umi` / `--reverse-complement-r-umis false` / `--fail-if-tag-present`, so a knob dropped on the parallel path is caught), dual-UMI + r-prefix normalization, fail-fast under `--threads`, leading-delimiter rejection, multi-batch, headerless `@HD` synthesis, **malformed-record clean-error on both paths**, and CRC-policy parity (corrupt last block: both reject under the default policy / accept with record-retention under `--no-check-crc`).

## Review

`/code-review` (group-key routing, doc-comment, the missing CRC-policy test, warn-flags convention) and a deep multi-agent `/gauntlet` (17 raised → 2 refuted → 15 fixed: the blocking serial-path malformed-record panic, the `from_header` panic, the metrics-failure log-parity divergence, the chain-path knob-coverage gap, and assorted test/doc cleanups) both ran; every surviving finding is addressed.

## Verification

`cargo ci-fmt && cargo ci-lint && RUSTDOCFLAGS="-D warnings" cargo ci-doc && cargo ci-test` — all green (9793 tests). All three feature legs compile (`--no-default-features`, default, `--all-features`, all `--all-targets`). No new `unsafe`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: `copy-umi` output changes, pinned by serial-versus-chain parity tests; no `unsafe` or CLAUDE.md allowlist changes; `--threads` now controls chain parallelism, but no memory-bound or queue-capacity change.

Routes threaded `copy-umi` execution through the declarative chain builder with `Stage::CopyUmi`. Keeps serial execution as a parity oracle.

Shares validation, record transformation, metrics, and summary logging across both paths. Removes the previous BAM pipeline engine and related accounting types.

Adds coverage for CRC policies, malformed records, header synthesis, fail-fast behavior, option propagation, metrics, multiple thread counts, and serial-versus-chain parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->