### PR TITLE
feat(extract): route the extract command onto the declarative chain builder

### DIFF
--- a/src/lib/commands/extract.rs
+++ b/src/lib/commands/extract.rs
@@ -26,18 +26,15 @@ use crate::fastq::FastqSet;
 use crate::fastq::ReadSetIterator;
 use crate::fastq_deinterleave::deinterleave;
 use crate::fastq_parse::strip_read_suffix;
-use crate::grouper::FastqTemplate;
 use crate::logging::OperationTimer;
 use crate::sam::SamTag;
-use crate::unified_pipeline::{
-    FastqPipelineConfig, MemoryEstimate, fastq_out_of_sync_error, run_fastq_pipeline,
-};
+use crate::unified_pipeline::fastq_out_of_sync_error;
 use crate::validation::validate_input_exists;
 use anyhow::{Context, Result, bail, ensure};
 use bstr::{BString, ByteSlice};
 use clap::Parser;
 use fgumi_bam_io::ProgressTracker;
-use fgumi_bam_io::{RawBamWriter, create_raw_bam_writer, open_output_writer};
+use fgumi_bam_io::{RawBamWriter, create_raw_bam_writer};
 use fgumi_raw_bam::UnmappedSamBuilder;
 use fgumi_raw_bam::fields::flags;
 use log::{debug, info};
@@ -66,28 +63,6 @@ use std::str::FromStr;
 
 const BUFFER_SIZE: usize = 1024 * 1024;
 const QUALITY_DETECTION_SAMPLE_SIZE: usize = 400;
-
-/// Output buffer for the parallel (`--threads N`) pipeline, which writes whole
-/// compressed BGZF blocks. Sized well above `BGZF_MAX_BLOCK_SIZE` so a block
-/// lands in the buffer instead of passing straight through it.
-const PIPELINE_OUTPUT_BUF_CAPACITY: usize = 256 * 1024;
-
-/// Pre-serialized batch of BAM records for the pipeline output type.
-///
-/// Contains raw BAM record bytes with `block_size` prefixes, ready for
-/// the compress step. Replaces `Vec<RecordBuf>` as the pipeline `P` type.
-struct ExtractedBatch {
-    /// BAM records with `block_size` prefixes, ready for compress step.
-    data: Vec<u8>,
-    /// Number of records in this batch.
-    num_records: u64,
-}
-
-impl MemoryEstimate for ExtractedBatch {
-    fn estimate_heap_size(&self) -> usize {
-        self.data.capacity()
-    }
-}
 
 /// Compression format detected from file header
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -701,15 +676,94 @@ pub struct Extract {
 }
 
 impl Extract {
-    /// CRC-verification policy for the `all_bgzf` pipeline path, which decodes
-    /// BGZF-file inputs itself (Step 2). That path never includes stdin — a
-    /// piped input takes the pre-opened-reader path — so every input there is a
-    /// file and the default is verify-on. `--no-check-crc` turns it off;
-    /// `--check-crc` and the default both verify. (The non-`all_bgzf` path
-    /// resolves per input path in [`open_fastq_reader`], honoring trusted-stdin.)
+    /// Project the parsed CLI struct into the per-stage [`ExtractOptions`] the
+    /// chain builder consumes (`StageOptionsBag::extract`).
+    ///
+    /// `quality_encoding` is a placeholder here (`QualityEncoding::Standard`):
+    /// the chain FASTQ source detects the real encoding while opening its readers
+    /// and overrides the field before the extract step runs (see
+    /// [`ExtractOptions::quality_encoding`]). Every other field maps directly
+    /// from the identically-named CLI flag; `platform` (CLI default `"illumina"`)
+    /// becomes `Some(..)` so `build_fastq_header` always emits `@RG PL:`, matching
+    /// `Self::create_header`. `clipping_attribute` is intentionally dropped — it
+    /// does not apply to FASTQ input (there is no existing clipping to adjust).
     #[must_use]
-    fn bgzf_input_verify_crc(&self) -> bool {
-        !self.no_check_crc
+    pub fn to_extract_options(&self) -> ExtractOptions {
+        ExtractOptions {
+            sample: self.sample.clone(),
+            library: self.library.clone(),
+            platform: Some(self.platform.clone()),
+            platform_unit: self.platform_unit.clone(),
+            read_group_id: self.read_group_id.clone(),
+            comments: self.comment.clone(),
+            barcode: self.barcode.clone(),
+            platform_model: self.platform_model.clone(),
+            sequencing_center: self.sequencing_center.clone(),
+            predicted_insert_size: self.predicted_insert_size,
+            description: self.description.clone(),
+            run_date: self.run_date.clone(),
+            quality_encoding: QualityEncoding::Standard,
+            store_umi_quals: self.store_umi_quals,
+            store_cell_quals: self.store_cell_quals,
+            single_tag: self.single_tag,
+            annotate_read_names: self.annotate_read_names,
+            extract_umis_from_read_names: self.extract_umis_from_read_names,
+            store_sample_barcode_qualities: self.store_sample_barcode_qualities,
+            async_reader: self.async_reader,
+            check_crc: self.check_crc,
+            no_check_crc: self.no_check_crc,
+        }
+    }
+
+    /// Run extract on the declarative chain builder (the `--threads` path).
+    ///
+    /// Hand-builds the [`ChainSpec`] (rather than using
+    /// [`ChainSpec::single_stage`], which is BAM-in/BAM-out): the source is a
+    /// FASTQ source — [`SourceSpec::InterleavedFastq`] for `--interleaved`, else
+    /// [`SourceSpec::Fastqs`] — and the sink is a BAM. The chain opens its own
+    /// readers and detects the quality encoding in `ChainBuilder::open_source`;
+    /// `read_streams`/`verify_crc` are BAM-reader knobs and inert here (the FASTQ
+    /// source carries its CRC policy in [`ExtractOptions`]). The no-`--threads`
+    /// serial loop in [`Command::execute`] is the in-process parity oracle.
+    ///
+    /// [`ChainSpec`]: crate::pipeline::chains::ChainSpec
+    /// [`ChainSpec::single_stage`]: crate::pipeline::chains::ChainSpec::single_stage
+    /// [`SourceSpec::Fastqs`]: crate::pipeline::chains::SourceSpec::Fastqs
+    /// [`SourceSpec::InterleavedFastq`]: crate::pipeline::chains::SourceSpec::InterleavedFastq
+    fn execute_chain(&self, command_line: &str) -> Result<()> {
+        use crate::pipeline::chains::{
+            ChainSpec, SinkSpec, SourceSpec, Stage, StageOptionsBag, build_for,
+        };
+
+        let read_structures = self.get_read_structures()?;
+        let source = if self.interleaved {
+            SourceSpec::interleaved_fastq(self.inputs[0].clone(), read_structures)?
+        } else {
+            SourceSpec::fastqs(self.inputs.clone(), read_structures)?
+        };
+
+        let stage_opts =
+            StageOptionsBag { extract: Some(self.to_extract_options()), ..Default::default() };
+
+        let spec = ChainSpec {
+            stages: vec![Stage::Extract],
+            source,
+            sink: SinkSpec::Bam(self.output.clone()),
+            stage_opts,
+            threading: self.threading.clone(),
+            compression: self.compression.clone(),
+            scheduler: self.scheduler_opts.clone(),
+            queue_memory: self.queue_memory.clone(),
+            async_reader: self.async_reader,
+            // Inert for a FASTQ source: `read_streams` is a seekable-BAM knob and
+            // `verify_crc` is the BAM BGZF-decode policy; the FASTQ source carries
+            // its own CRC policy in `ExtractOptions` (`check_crc`/`no_check_crc`).
+            read_streams: fgumi_bam_io::ReadStreams::Fixed(1),
+            verify_crc: false,
+            command_line: command_line.to_string(),
+        };
+
+        build_for(spec)?.run()
     }
 
     /// Get actual read structures (default to +T if none provided).
@@ -727,58 +781,6 @@ impl Extract {
             }
         }
         Ok(self.read_structures.clone())
-    }
-
-    /// Open every input FASTQ as a decompressed reader.
-    ///
-    /// `stdin_reader` is the already-opened stdin stream, if one of the inputs
-    /// is `-`. It is moved in rather than re-opened: stdin can be consumed only
-    /// once, and re-opening it yields an empty stream and a silently
-    /// record-less run. [`Self::validate`] guarantees stdin is the *sole* input
-    /// when present, so it is the whole reader list.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if a file input cannot be opened.
-    fn open_input_readers(
-        &self,
-        decomp_threads: usize,
-        stdin_reader: Option<Box<dyn BufRead + Send>>,
-    ) -> Result<Vec<Box<dyn BufRead + Send>>> {
-        // Interleaved: one physical source (stdin or the sole file), split into
-        // an R1 and an R2 reader. Validation guarantees exactly one input, so the
-        // stdin reader — when present — is that whole source. Decompression has
-        // already happened (stdin via the pre-opened reader, a file via
-        // `open_fastq_reader`), so the de-interleaver splits decompressed bytes.
-        if self.interleaved {
-            let source = match stdin_reader {
-                Some(reader) => reader,
-                None => open_fastq_reader(
-                    &self.inputs[0],
-                    decomp_threads,
-                    self.async_reader,
-                    self.check_crc,
-                    self.no_check_crc,
-                )?,
-            };
-            let (r1, r2) = deinterleave(source);
-            return Ok(vec![r1, r2]);
-        }
-        if let Some(reader) = stdin_reader {
-            return Ok(vec![reader]);
-        }
-        self.inputs
-            .iter()
-            .map(|path| {
-                open_fastq_reader(
-                    path,
-                    decomp_threads,
-                    self.async_reader,
-                    self.check_crc,
-                    self.no_check_crc,
-                )
-            })
-            .collect()
     }
 
     /// Validate inputs
@@ -1091,8 +1093,9 @@ impl Extract {
     /// `try_build_record` instead of panicking partway through writing the output BAM, and
     /// attach [`Self::read_name_too_long_context`] so the message names the offending read.
     ///
-    /// Shared by the single-threaded (`make_raw_records`) and threaded
-    /// (`make_raw_records_static`) paths, which are otherwise easy to let drift apart.
+    /// Used by the serial-oracle `make_raw_records` path; the chain path's
+    /// `make_raw_records_from_fastq_set` builds records through the same
+    /// `UnmappedSamBuilder` API, which the parity tests keep in step.
     fn build_template_record(
         builder: &mut UnmappedSamBuilder,
         name: &[u8],
@@ -1309,301 +1312,6 @@ impl Extract {
         progress.log_final();
         Ok(read_pair_count)
     }
-
-    /// Process records using the 7-step pipeline.
-    ///
-    /// Returns the number of records written.
-    fn process_with_pipeline(
-        &self,
-        header: &Header,
-        output: Box<dyn std::io::Write + Send>,
-        encoding: QualityEncoding,
-        read_structures: &[ReadStructure],
-        stdin_reader: Option<Box<dyn BufRead + Send>>,
-    ) -> Result<u64> {
-        // Detect if all inputs are BGZF. stdin is never "all BGZF" for this
-        // purpose: that path has the pipeline open the files itself, which stdin
-        // cannot support, so it must take the pre-opened-reader path below.
-        // Interleaved is likewise never "all BGZF": the single source must be
-        // read once and de-interleaved into two readers (in `open_input_readers`),
-        // which the pipeline consumes as decompressed streams — it cannot re-open
-        // and re-split the file itself.
-        let all_bgzf = !self.interleaved
-            && stdin_reader.is_none()
-            && self.inputs.iter().all(|p| {
-                detect_compression_format(p).map(|f| f == CompressionFormat::Bgzf).unwrap_or(false)
-            });
-
-        let num_threads = self.threading.threads.unwrap_or(1);
-
-        let mut config =
-            FastqPipelineConfig::new(num_threads, all_bgzf, self.compression.compression_level)
-                .with_stats(self.scheduler_opts.collect_stats())
-                .with_scheduler_strategy(self.scheduler_opts.strategy())
-                .with_deadlock_timeout(self.scheduler_opts.deadlock_timeout_secs())
-                .with_deadlock_recovery(self.scheduler_opts.deadlock_recover_enabled())
-                .with_async_reader(self.async_reader)
-                .with_verify_crc(self.bgzf_input_verify_crc());
-
-        // Calculate and apply queue memory limit
-        let queue_memory_limit_bytes = self.queue_memory.calculate_memory_limit(num_threads)?;
-        config.queue_memory_limit = queue_memory_limit_bytes;
-        self.queue_memory.log_memory_config(num_threads, queue_memory_limit_bytes);
-
-        // For Gzip/Plain: open decompressed readers upfront
-        // For BGZF: pass None, pipeline opens files directly
-        let decomp_threads = self.threading.num_threads().max(1);
-        let decompressed_readers: Option<Vec<Box<dyn BufRead + Send>>> = if all_bgzf {
-            None
-        } else {
-            Some(self.open_input_readers(decomp_threads, stdin_reader)?)
-        };
-
-        // Clone read_structures for the closure
-        let read_structures = read_structures.to_vec();
-
-        // Build config capturing all user options for the pipeline closure
-        let extract_config = ExtractConfig {
-            read_group_id: self.read_group_id.clone(),
-            store_umi_quals: self.store_umi_quals,
-            store_cell_quals: self.store_cell_quals,
-            single_tag: self.single_tag,
-            annotate_read_names: self.annotate_read_names,
-            extract_umis_from_read_names: self.extract_umis_from_read_names,
-            store_sample_barcode_qualities: self.store_sample_barcode_qualities,
-        };
-
-        let records_written = run_fastq_pipeline(
-            config,
-            &self.inputs,
-            decompressed_readers,
-            header,
-            output,
-            // process_fn: FastqTemplate → ExtractedBatch
-            move |template: FastqTemplate| -> std::io::Result<ExtractedBatch> {
-                // A template must carry one record per read structure; a short
-                // template would silently drop that read's segments below (see
-                // `validate_template_record_count`, issue #773).
-                validate_template_record_count(&template, read_structures.len())?;
-
-                // Validate read names match (synchronized mode defers this from Group step)
-                if template.records.len() >= 2 {
-                    let base_name = strip_read_suffix(template.records[0].name());
-                    for (i, record) in template.records.iter().enumerate().skip(1) {
-                        let other_base = strip_read_suffix(record.name());
-                        if base_name != other_base {
-                            return Err(std::io::Error::new(
-                                std::io::ErrorKind::InvalidData,
-                                format!(
-                                    "FASTQ files out of sync: R1 has '{}', R{} has '{}'",
-                                    String::from_utf8_lossy(base_name),
-                                    i + 1,
-                                    String::from_utf8_lossy(other_base),
-                                ),
-                            ));
-                        }
-                    }
-                }
-                // Convert each FastqRecord to a FastqSet using its read structure
-                let mut fastq_sets: Vec<FastqSet> = Vec::with_capacity(template.records.len());
-                for (record, rs) in template.records.iter().zip(read_structures.iter()) {
-                    let fastq_set = FastqSet::from_record_with_structure(
-                        record.name(),
-                        record.sequence(),
-                        record.quality(),
-                        rs,
-                        &[], // No skip reasons
-                    )
-                    .map_err(std::io::Error::other)?;
-                    fastq_sets.push(fastq_set);
-                }
-
-                // Combine all FastqSets into one
-                let combined = FastqSet::combine_readsets(fastq_sets);
-
-                // Build raw BAM records
-                // Render the whole `anyhow` chain (`{:#}`), not just the
-                // outermost context: the pipeline carries `io::Error`, so
-                // `to_string()` here would drop the underlying cause and leave
-                // the user with a context line and no reason for it.
-                let result = make_raw_records_static(&combined, encoding, &extract_config)
-                    .map_err(|e| {
-                        std::io::Error::new(std::io::ErrorKind::InvalidData, format!("{e:#}"))
-                    })?;
-
-                // Debug: Check if we produce fewer records than template has
-                if result.num_records as usize != template.records.len() {
-                    log::warn!(
-                        "Template with {} FASTQ records produced {} BAM records",
-                        template.records.len(),
-                        result.num_records
-                    );
-                }
-
-                Ok(result)
-            },
-            // serialize_fn: ExtractedBatch → copy pre-serialized bytes to buffer
-            |batch: ExtractedBatch, _header: &Header, buffer: &mut Vec<u8>| {
-                buffer.extend_from_slice(&batch.data);
-                Ok(batch.num_records)
-            },
-        )?;
-
-        info!("Wrote {records_written} records via 7-step pipeline");
-        Ok(records_written)
-    }
-}
-
-/// Cloneable config for the extract pipeline closure, capturing all user options
-/// needed by `make_raw_records_static` so they aren't hardcoded.
-#[derive(Clone)]
-#[allow(clippy::struct_excessive_bools)]
-struct ExtractConfig {
-    read_group_id: String,
-    store_umi_quals: bool,
-    store_cell_quals: bool,
-    single_tag: Option<SamTag>,
-    annotate_read_names: bool,
-    extract_umis_from_read_names: bool,
-    store_sample_barcode_qualities: bool,
-}
-
-/// Build raw BAM records from a `FastqSet` without requiring `&self`.
-/// Uses the provided `ExtractConfig` for all user-configurable options.
-fn make_raw_records_static(
-    read_set: &FastqSet,
-    encoding: QualityEncoding,
-    cfg: &ExtractConfig,
-) -> Result<ExtractedBatch> {
-    let templates: Vec<&FastqSegment> = read_set.template_segments().collect();
-
-    let read_name = String::from_utf8_lossy(&read_set.header);
-    ensure!(!templates.is_empty(), "No template segments found for read: {read_name}");
-
-    // Extract various barcode types as BString
-    let cell_barcode_bs = Extract::join_bytes_with_separator(
-        read_set.cell_barcode_segments().map(|s| s.seq.as_slice()),
-        b'-',
-    );
-    let cell_quals_bs = Extract::join_bytes_with_separator(
-        read_set.cell_barcode_segments().map(|s| s.quals.as_slice()),
-        b' ',
-    );
-    let sample_barcode_bs = Extract::join_bytes_with_separator(
-        read_set.sample_barcode_segments().map(|s| s.seq.as_slice()),
-        b'-',
-    );
-    let sample_quals_bs = Extract::join_bytes_with_separator(
-        read_set.sample_barcode_segments().map(|s| s.quals.as_slice()),
-        b' ',
-    );
-    let umi_bs = Extract::join_bytes_with_separator(
-        read_set.molecular_barcode_segments().map(|s| s.seq.as_slice()),
-        b'-',
-    );
-    let umi_qual_bs = Extract::join_bytes_with_separator(
-        read_set.molecular_barcode_segments().map(|s| s.quals.as_slice()),
-        b' ',
-    );
-
-    // Extract UMI from read name if requested
-    let (read_name_bytes, umi_from_name) =
-        Extract::extract_read_name_and_umi(&read_set.header, cfg.extract_umis_from_read_names)?;
-
-    // Prepare final UMI
-    let final_umi_bs: BString = match (umi_bs.is_empty(), &umi_from_name) {
-        (true, Some(from_name)) => BString::from(from_name.as_slice()),
-        (true, None) => BString::default(),
-        (false, Some(from_name)) => {
-            let mut combined = Vec::with_capacity(from_name.len() + 1 + umi_bs.len());
-            combined.extend_from_slice(from_name);
-            combined.push(b'-');
-            combined.extend_from_slice(umi_bs.as_bytes());
-            BString::from(combined)
-        }
-        (false, None) => umi_bs,
-    };
-
-    let num_templates = templates.len();
-    let mut builder = UnmappedSamBuilder::new();
-    let mut data = Vec::new();
-
-    for (index, template) in templates.iter().enumerate() {
-        // Compute flags for unmapped reads
-        let mut flag = flags::UNMAPPED;
-        if num_templates == 2 {
-            flag |= flags::PAIRED | flags::MATE_UNMAPPED;
-            if index == 0 {
-                flag |= flags::FIRST_SEGMENT;
-            } else {
-                flag |= flags::LAST_SEGMENT;
-            }
-        }
-
-        // Set read name (optionally with UMI annotation)
-        let annotated_name: Option<Vec<u8>> = if cfg.annotate_read_names && !final_umi_bs.is_empty()
-        {
-            let mut name = Vec::with_capacity(read_name_bytes.len() + 1 + final_umi_bs.len());
-            name.extend_from_slice(&read_name_bytes);
-            name.push(b'+');
-            name.extend_from_slice(final_umi_bs.as_bytes());
-            Some(name)
-        } else {
-            None
-        };
-        let final_read_name: &[u8] = annotated_name.as_deref().unwrap_or(&read_name_bytes);
-
-        Extract::build_template_record(
-            &mut builder,
-            final_read_name,
-            flag,
-            &template.seq,
-            &template.quals,
-            encoding,
-        )?;
-
-        // Append tags
-        // Read group
-        builder.append_string_tag(SamTag::RG, cfg.read_group_id.as_bytes());
-
-        // Cell barcode
-        if !cell_barcode_bs.is_empty() {
-            builder.append_string_tag(SamTag::CB, cell_barcode_bs.as_bytes());
-        }
-
-        if !cell_quals_bs.is_empty() && cfg.store_cell_quals {
-            builder.append_string_tag(SamTag::CY, cell_quals_bs.as_bytes());
-        }
-
-        // Sample barcode
-        if !sample_barcode_bs.is_empty() {
-            builder.append_string_tag(SamTag::BC, sample_barcode_bs.as_bytes());
-        }
-
-        if cfg.store_sample_barcode_qualities && !sample_quals_bs.is_empty() {
-            builder.append_string_tag(SamTag::QT, sample_quals_bs.as_bytes());
-        }
-
-        // UMI
-        if !final_umi_bs.is_empty() {
-            builder.append_string_tag(SamTag::RX, final_umi_bs.as_bytes());
-
-            // Single tag for all concatenated UMIs (if specified)
-            if let Some(st) = cfg.single_tag {
-                builder.append_string_tag(st, final_umi_bs.as_bytes());
-            }
-
-            // Only add UMI qualities if not extracted from read names
-            if umi_from_name.is_none() && !umi_qual_bs.is_empty() && cfg.store_umi_quals {
-                builder.append_string_tag(SamTag::QX, umi_qual_bs.as_bytes());
-            }
-        }
-
-        builder.write_with_block_size(&mut data);
-        builder.clear();
-    }
-
-    Ok(ExtractedBatch { data, num_records: num_templates as u64 })
 }
 
 /// Pool quality strings for encoding detection across the first
@@ -1691,136 +1399,176 @@ fn sample_detection_quals_from_stream(
     Ok((stats, replayed))
 }
 
+/// Open the decompressed FASTQ input readers for a run.
+///
+/// De-interleaves a single interleaved stream into an R1/R2 pair and consumes a
+/// pre-sampled stdin reader when present. Both the serial oracle and the chain
+/// reach it through [`detect_encoding_and_open_fastq_readers`] — the serial
+/// `Extract::execute` path directly, and the chain FASTQ source via
+/// `ChainBuilder::open_source` — so both open readers identically, the parity
+/// contract for the `--threads` cutover.
+fn open_fastq_input_readers(
+    inputs: &[PathBuf],
+    interleaved: bool,
+    decomp_threads: usize,
+    async_reader: bool,
+    check_crc: bool,
+    no_check_crc: bool,
+    stdin_reader: Option<Box<dyn BufRead + Send>>,
+) -> Result<Vec<Box<dyn BufRead + Send>>> {
+    // Interleaved: one physical source (stdin or the sole file), split into an R1
+    // and an R2 reader. Validation guarantees exactly one input, so the stdin
+    // reader — when present — is that whole source. A single physical stream gets
+    // the full `decomp_threads` BGZF-decode budget: the pipeline reads it on one
+    // worker and the de-interleaver splits one shared decoder, so per-stream
+    // decode threads are the only decode parallelism available here.
+    if interleaved {
+        let source = match stdin_reader {
+            Some(reader) => reader,
+            None => open_fastq_reader(
+                &inputs[0],
+                decomp_threads,
+                async_reader,
+                check_crc,
+                no_check_crc,
+            )?,
+        };
+        let (r1, r2) = deinterleave(source);
+        return Ok(vec![r1, r2]);
+    }
+    // stdin is a single stream, already opened with `decomp_threads` by the caller
+    // (the replay reader wraps that decoder), so its decode budget is fixed.
+    if let Some(reader) = stdin_reader {
+        return Ok(vec![reader]);
+    }
+    // Multiple file inputs: on the chain path the pipeline reads (and BGZF-decodes)
+    // the streams concurrently, one reader per typed-step worker, so each reader
+    // decodes single-threaded. Handing each file its own `decomp_threads` BGZF
+    // workers would spawn up to N×threads decode threads ON TOP OF the pipeline's
+    // own worker pool — over-subscription the pre-cutover chain deliberately
+    // avoided (it passed 1 here, "the pipeline framework provides the
+    // parallelism"). The serial oracle reaches this branch with `decomp_threads`
+    // == 1 (it is single-threaded), so hardcoding 1 leaves it unchanged; per-file
+    // BGZF-decode parallelism, if wanted, is a separate benchmarked change.
+    inputs
+        .iter()
+        .map(|path| open_fastq_reader(path, 1, async_reader, check_crc, no_check_crc))
+        .collect()
+}
+
+/// Detect the input FASTQ quality encoding and open the decompressed input
+/// readers in one pass, mirroring `Extract::execute`'s detection + reader-open
+/// exactly so the serial oracle and the `--threads` chain path see identical
+/// readers and encoding.
+///
+/// stdin is sampled once and its bytes replayed into the returned reader (there
+/// is no second open); file inputs are sampled through separate readers so the
+/// returned readers are fresh. The stdin sampling reader is opened with the run's
+/// decompression thread count (not a sampling one) because that same reader
+/// decompresses every record that follows.
+///
+/// # Errors
+///
+/// Returns an error if a reader cannot be opened, the FASTQ is malformed, or the
+/// encoding cannot be determined from the sampled qualities.
+pub(crate) fn detect_encoding_and_open_fastq_readers(
+    inputs: &[PathBuf],
+    interleaved: bool,
+    num_threads: usize,
+    async_reader: bool,
+    check_crc: bool,
+    no_check_crc: bool,
+) -> Result<(Vec<Box<dyn BufRead + Send>>, QualityEncoding)> {
+    let decomp_threads = num_threads.max(1);
+    let mut stdin_reader: Option<Box<dyn BufRead + Send>> = None;
+    let detection_stats = if let Some(stdin_input) = inputs.iter().find(|p| is_stdin_path(p)) {
+        let opened =
+            open_fastq_reader(stdin_input, decomp_threads, async_reader, check_crc, no_check_crc)?;
+        let (stats, replayed) = sample_detection_quals_from_stream(opened)?;
+        stdin_reader = Some(replayed);
+        stats
+    } else {
+        sample_detection_quals(inputs, check_crc, no_check_crc)?
+    };
+    let encoding = QualityEncoding::from_stats(&detection_stats)?;
+    let readers = open_fastq_input_readers(
+        inputs,
+        interleaved,
+        decomp_threads,
+        async_reader,
+        check_crc,
+        no_check_crc,
+        stdin_reader,
+    )?;
+    Ok((readers, encoding))
+}
+
 impl Command for Extract {
     fn execute(&self, command_line: &str) -> Result<()> {
         // Validate inputs
         self.validate()?;
 
+        // `--threads N` routes onto the declarative chain builder — the chain
+        // opens its own FASTQ readers and detects the quality encoding inside
+        // `ChainBuilder::open_source`. The no-`--threads` serial loop below is the
+        // in-process parity oracle. `--threads 1` takes the chain like any other
+        // `Some(n)`: the old dispatch was `is_parallel()`, which was already true
+        // for every `Threads(n)` including `Threads(1)`, so this
+        // `threads.is_some()` predicate is behaviorally identical — the cutover
+        // swaps the parallel *implementation* (the now-deleted legacy
+        // `process_with_pipeline`) for the chain builder, it does not change which
+        // `--threads` values run in parallel.
+        if self.threading.threads.is_some() {
+            return self.execute_chain(command_line);
+        }
+
         let timer = OperationTimer::new("Extracting UMIs");
         let read_structures = self.get_read_structures()?;
 
-        // Detect quality encoding from the pooled heads of ALL input FASTQs.
-        //
-        // For file inputs this opens a separate reader per input, so the main
-        // readers are untouched. stdin has no second open, so it is opened once
-        // here and the sampled bytes are replayed to the main pass; the reader
-        // below is that replaying stream, handed to whichever branch runs.
-        //
-        // It is opened with the *main pass's* decompression thread count, not a
-        // sampling one: this same reader decompresses every record that follows,
-        // so a hardcoded single thread would leave `--threads` unable to reach
-        // the BGZF decoder on the stdin path, where file inputs get the full
-        // count from [`Self::open_input_readers`].
-        let mut stdin_reader: Option<Box<dyn BufRead + Send>> = None;
-        let detection_stats =
-            if let Some(stdin_input) = self.inputs.iter().find(|p| is_stdin_path(p)) {
-                let decomp_threads = self.threading.num_threads().max(1);
-                let opened = open_fastq_reader(
-                    stdin_input,
-                    decomp_threads,
-                    self.async_reader,
-                    self.check_crc,
-                    self.no_check_crc,
-                )?;
-                let (stats, replayed) = sample_detection_quals_from_stream(opened)?;
-                stdin_reader = Some(replayed);
-                stats
-            } else {
-                sample_detection_quals(&self.inputs, self.check_crc, self.no_check_crc)?
-            };
-        let encoding = QualityEncoding::from_stats(&detection_stats)?;
+        // Serial oracle: detect the quality encoding and open the input readers
+        // in one pass — the same helper the chain FASTQ source uses, so both
+        // paths open identical readers (de-interleaving / stdin-replay included)
+        // and apply the same detected encoding.
+        let (fq_readers, encoding) = detect_encoding_and_open_fastq_readers(
+            &self.inputs,
+            self.interleaved,
+            self.threading.num_threads(),
+            self.async_reader,
+            self.check_crc,
+            self.no_check_crc,
+        )?;
 
         // Create header with @PG record
         let header = self.create_header(command_line)?;
 
-        let records_written = if self.threading.is_parallel() {
-            // Unified 7-step pipeline mode (--threads N was specified)
-            // Uses work-stealing for better CPU utilization with strict thread cap
-            // The 7-step pipeline handles its own BGZF compression internally
-            // `open_output_writer`, not `File::create`: the single-threaded
-            // branch below reaches stdout through `create_raw_bam_writer`, and
-            // which of the two runs is a function of `--threads`, which has
-            // nothing to do with where the output goes.
-            // 256 KiB, not the 8 KiB default: the pipeline hands this writer
-            // whole compressed BGZF blocks, which run up to 64 KiB and so would
-            // bypass the default buffer entirely, one `write` syscall apiece.
-            let output: Box<dyn std::io::Write + Send> =
-                Box::new(std::io::BufWriter::with_capacity(
-                    PIPELINE_OUTPUT_BUF_CAPACITY,
-                    open_output_writer(&self.output)?,
-                ));
+        let fq_sources: Vec<SimdFastqReader<Box<dyn BufRead + Send>>> = fq_readers
+            .into_iter()
+            .map(|fq| SimdFastqReader::with_capacity(fq, BUFFER_SIZE))
+            .collect();
 
-            self.process_with_pipeline(&header, output, encoding, &read_structures, stdin_reader)?
-        } else {
-            // Single-threaded mode: raw BAM writer
-            // Determine thread count for parallel BGZF decompression
-            let decomp_threads = self.threading.num_threads().max(1);
+        let mut fq_iterators: Vec<ReadSetIterator> = fq_sources
+            .into_iter()
+            .zip(read_structures.iter())
+            .map(|(source, rs)| ReadSetIterator::new(rs.clone(), source, Vec::new()))
+            .collect();
 
-            // Open input FASTQs with automatic BGZF detection
-            let fq_readers: Vec<Box<dyn BufRead + Send>> =
-                self.open_input_readers(decomp_threads, stdin_reader)?;
+        // Raw BAM writer (single-threaded oracle output).
+        let writer_threads = self.threading.num_threads();
+        let mut writer = create_raw_bam_writer(
+            &self.output,
+            &header,
+            writer_threads,
+            self.compression.compression_level,
+        )?;
 
-            let fq_sources: Vec<SimdFastqReader<Box<dyn BufRead + Send>>> = fq_readers
-                .into_iter()
-                .map(|fq| SimdFastqReader::with_capacity(fq, BUFFER_SIZE))
-                .collect();
+        let count = self.process_singlethreaded(&mut fq_iterators, &mut writer, encoding)?;
 
-            // Create iterators
-            let fq_iterators: Vec<ReadSetIterator> = fq_sources
-                .into_iter()
-                .zip(read_structures.iter())
-                .map(|(source, rs)| ReadSetIterator::new(rs.clone(), source, Vec::new()))
-                .collect();
+        // Flush and finish the writer so any write error surfaces here, not on drop.
+        writer.finish()?;
 
-            // Create output writer with multi-threaded BGZF
-            let writer_threads = self.threading.num_threads();
-            let mut writer = create_raw_bam_writer(
-                &self.output,
-                &header,
-                writer_threads,
-                self.compression.compression_level,
-            )?;
-
-            // Single-threaded processing: original simple loop (iterators are borrowed)
-            let mut fq_iterators = fq_iterators;
-            let count = self.process_singlethreaded(&mut fq_iterators, &mut writer, encoding)?;
-
-            // Flush and finish the writer
-            writer.finish()?;
-
-            count
-        };
-
-        timer.log_completion(records_written);
+        timer.log_completion(count);
         Ok(())
     }
-}
-
-/// Reject an assembled template that does not carry exactly one record per read
-/// structure.
-///
-/// `--inputs` and `--read-structures` are validated to be the same length, and
-/// the pipeline now rejects inputs of unequal record count, so a short template
-/// cannot normally be assembled. This enforces the invariant rather than logging
-/// it: the segment `zip` downstream stops at the shorter side, so a short
-/// template would silently drop that read's segments (issue #773).
-fn validate_template_record_count(
-    template: &FastqTemplate,
-    read_structure_count: usize,
-) -> std::io::Result<()> {
-    if template.records.len() != read_structure_count {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!(
-                "FASTQ sources out of sync: template '{}' has {} record(s) but {} \
-                 read structure(s) were given",
-                String::from_utf8_lossy(&template.name),
-                template.records.len(),
-                read_structure_count,
-            ),
-        ));
-    }
-    Ok(())
 }
 
 // ==== ported from feat-runall for the chain builder (R2) ====
@@ -1869,6 +1617,13 @@ pub struct ExtractOptions {
 
     // ── Extract behavior options ──
     /// Quality encoding of the input FASTQ files.
+    ///
+    /// On the chain path this is a placeholder at spec-construction time: the
+    /// FASTQ source detects the encoding while opening its readers (in
+    /// `ChainBuilder::open_source`) and overrides this field before the extract
+    /// step runs, so both the serial oracle and the chain apply the same
+    /// source-detected encoding. Tests that construct `ExtractOptions` directly
+    /// set the encoding they want to exercise.
     pub quality_encoding: QualityEncoding,
     /// Store UMI base qualities in the `QX` tag.
     pub store_umi_quals: bool,
@@ -1885,6 +1640,12 @@ pub struct ExtractOptions {
     pub store_sample_barcode_qualities: bool,
     /// Wrap FASTQ readers in a userspace async prefetch thread.
     pub async_reader: bool,
+    /// Force BGZF input CRC verification (`--check-crc`). Consumed when the chain
+    /// FASTQ source opens its readers, so `--check-crc`/`--no-check-crc` reach
+    /// `open_fastq_reader` on the `--threads` path exactly as on the serial path.
+    pub check_crc: bool,
+    /// Disable BGZF input CRC verification (`--no-check-crc`). See `check_crc`.
+    pub no_check_crc: bool,
 }
 
 /// Build raw BAM `RawRecord`s from a [`FastqSet`].
@@ -1894,13 +1655,17 @@ pub struct ExtractOptions {
 /// tags, and produces one `RawRecord` per template segment. The caller wraps
 /// the result in a [`crate::template::Template`] for the typed-step pipeline.
 ///
-/// KNOWN DUPLICATION — resolve in the extract WIRING PR: this is a third
-/// near-identical copy of the FASTQ→`RawRecord` per-read loop, alongside
-/// `Extract::make_raw_records` (writes to a `RawBamWriter`) and
-/// `make_raw_records_static` (builds an `ExtractedBatch`). The three differ only
-/// in output target, so tag-extraction/flag logic can drift between them. The
-/// extract wiring PR should unify them (sharing `Extract::create_header` and the
-/// per-read tag loop) once the chain extract path is live; dormant today.
+/// KNOWN DUPLICATION: this is the chain path's copy of the FASTQ→`RawRecord`
+/// per-read loop, near-identical to `Extract::make_raw_records` (the serial
+/// oracle's, which writes to a `RawBamWriter`). The two differ only in output
+/// target, so tag-extraction/flag logic can drift between them. The
+/// `chain_matches_serial_oracle*` integration tests guard against drift by
+/// comparing chain-vs-oracle output: the base case covers RX/RG, and
+/// `chain_matches_serial_oracle_barcode_and_annotate_tags` covers the
+/// CB/CY, BC/QT, QX, `--single-tag`, and `--annotate-read-names` branches.
+/// Unifying the two onto one shared per-read loop is a worthwhile follow-up.
+/// (The former third copy, `make_raw_records_static`, was deleted with the
+/// legacy threaded pipeline when extract cut over to the chain builder.)
 ///
 /// # Errors
 ///
@@ -3498,9 +3263,9 @@ mod tests {
         // suffixes must produce a single shared QNAME (no suffix) for both mates,
         // as required by the SAM spec. Guards the wiring from
         // `extract_read_name_and_umi` through to the written BAM QNAME in both the
-        // single-threaded (`make_raw_records`) and threaded
-        // (`make_raw_records_static` + `strip_read_suffix`) record-building
-        // paths.
+        // serial-oracle (`make_raw_records`) and the chain
+        // (`make_raw_records_from_fastq_set` + `strip_read_suffix`) record-building
+        // paths — this test is parameterized over threading to exercise both.
         let tmp = TempDir::new().expect("failed to create temp dir");
         let r1 = create_fastq(&tmp, "r1.fq", &[("SRR001.1/1", "AAAAAAAAAA", "==========")]);
         let r2 = create_fastq(&tmp, "r2.fq", &[("SRR001.1/2", "CCCCCCCCCC", "##########")]);
@@ -3555,8 +3320,9 @@ mod tests {
     /// Rust panic partway through writing the output BAM and leave a truncated
     /// file behind.
     ///
-    /// Both record-building paths are covered: `make_raw_records`
-    /// (single-threaded) and `make_raw_records_static` (threaded).
+    /// Both record-building paths are covered (the test is parameterized over
+    /// threading): `make_raw_records` (serial oracle) and
+    /// `make_raw_records_from_fastq_set` (chain, `--threads`).
     #[rstest]
     #[case::at_limit(254, true)]
     #[case::one_over(255, false)]
@@ -5211,8 +4977,8 @@ mod tests {
         Ok(())
     }
 
-    /// Verifies that the threaded pipeline path emits the same tags (RX, QX, RG) as the
-    /// single-threaded path, ensuring `make_raw_records_static` stays in sync with
+    /// Verifies that the chain (`--threads`) path emits the same tags (RX, QX, RG) as the
+    /// serial oracle, ensuring `make_raw_records_from_fastq_set` stays in sync with
     /// `make_raw_records`.
     #[rstest]
     #[case::fast_path(ThreadingOptions::none())]
@@ -5274,57 +5040,6 @@ mod tests {
         assert_eq!(rg.as_deref(), Some("RG1"), "RG tag should match read_group_id");
 
         Ok(())
-    }
-
-    /// Build a `FastqTemplate` carrying `record_count` records under a shared name.
-    fn template_with_record_count(name: &str, record_count: usize) -> FastqTemplate {
-        let records = (0..record_count)
-            .map(|_| {
-                crate::fastq_parse::FastqRecord::from_slice(
-                    format!("@{name}\nACGT\n+\nIIII\n").as_bytes(),
-                )
-                .expect("failed to parse synthetic FASTQ record")
-            })
-            .collect();
-        FastqTemplate { records, name: name.as_bytes().to_vec() }
-    }
-
-    /// A template with one record per read structure passes validation.
-    #[rstest]
-    #[case::single_end(1)]
-    #[case::paired_end(2)]
-    #[case::triple(3)]
-    fn test_validate_template_record_count_matched_is_accepted(#[case] count: usize) {
-        let template = template_with_record_count("read0", count);
-        validate_template_record_count(&template, count)
-            .expect("a template matching the read-structure count must be accepted");
-    }
-
-    /// A template whose record count differs from the read-structure count is
-    /// rejected, naming the template and both counts (issue #773).
-    #[rstest]
-    #[case::short(1, 2)]
-    #[case::surplus(3, 2)]
-    #[case::empty(0, 2)]
-    fn test_validate_template_record_count_mismatch_is_rejected(
-        #[case] record_count: usize,
-        #[case] read_structure_count: usize,
-    ) {
-        let template = template_with_record_count("read0", record_count);
-        let error = validate_template_record_count(&template, read_structure_count)
-            .expect_err("a template that disagrees with the read-structure count must be rejected");
-        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
-        let message = error.to_string();
-        assert!(message.contains("out of sync"), "unexpected message: {message}");
-        assert!(message.contains("read0"), "message must name the template: {message}");
-        assert!(
-            message.contains(&format!("{record_count} record(s)")),
-            "message must report the record count: {message}"
-        );
-        assert!(
-            message.contains(&format!("{read_structure_count} read structure(s)")),
-            "message must report the read-structure count: {message}"
-        );
     }
 
     /// Build an `Extract` for the interleaved-equivalence test, varying only the
@@ -5629,10 +5344,11 @@ mod tests {
     }
 
     /// A BGZF-compressed interleaved file must be decompressed exactly once and
-    /// then split — the `all_bgzf` fast path is force-disabled for interleaved
-    /// input, so the pipeline never re-opens and line-splits the raw compressed
+    /// then split: the chain opens the sole interleaved input once via
+    /// `open_fastq_reader` and `deinterleave` splits the *decompressed* bytes into
+    /// R1/R2, so BGZF is never decoded twice or line-split as raw compressed
     /// bytes. The BGZF and plaintext interleaved runs must produce the same
-    /// records, on both paths.
+    /// records, on both the serial and chain paths.
     #[rstest]
     #[case::single_threaded(ThreadingOptions::none())]
     #[case::multi_threaded(ThreadingOptions::new(2))]
@@ -5750,7 +5466,79 @@ mod tests {
             extract_umis_from_read_names: false,
             store_sample_barcode_qualities: false,
             async_reader: false,
+            check_crc: false,
+            no_check_crc: false,
         }
+    }
+
+    /// `Extract::to_extract_options` must project every CLI field onto the
+    /// matching `ExtractOptions` field so the chain path sees the same options
+    /// the serial oracle uses. `quality_encoding` is a placeholder (`Standard`)
+    /// because the chain FASTQ source overrides it with the detected encoding.
+    #[test]
+    fn to_extract_options_maps_all_fields() {
+        let extract = Extract {
+            inputs: vec![PathBuf::from("in.fq")],
+            output: PathBuf::from("out.bam"),
+            read_structures: vec![],
+            // Alternate true/false across the adjacent bool fields so an accidental
+            // field swap in `to_extract_options` (e.g. store_umi_quals <->
+            // store_cell_quals) flips an assertion below instead of passing
+            // silently. Bools can't be pairwise-distinct, so this catches the
+            // realistic adjacent copy-paste swap, not every possible pair.
+            store_umi_quals: true,
+            store_cell_quals: false,
+            store_sample_barcode_qualities: true,
+            extract_umis_from_read_names: false,
+            annotate_read_names: true,
+            single_tag: Some(SamTag::MI),
+            clipping_attribute: None,
+            read_group_id: "RGX".to_string(),
+            sample: "SAMP".to_string(),
+            library: "LIBR".to_string(),
+            barcode: Some("ACGT".to_string()),
+            platform: "ont".to_string(),
+            platform_unit: Some("PU1".to_string()),
+            platform_model: Some("PM1".to_string()),
+            sequencing_center: Some("CN1".to_string()),
+            predicted_insert_size: Some(300),
+            description: Some("desc".to_string()),
+            comment: vec!["c1".to_string(), "c2".to_string()],
+            run_date: Some("2020-01-01".to_string()),
+            threading: ThreadingOptions::new(4),
+            compression: CompressionOptions { compression_level: 1 },
+            scheduler_opts: SchedulerOptions::default(),
+            queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
+            check_crc: true,
+            no_check_crc: false,
+            interleaved: false,
+        };
+        let opts = extract.to_extract_options();
+        assert_eq!(opts.sample, "SAMP");
+        assert_eq!(opts.library, "LIBR");
+        // platform is Option in ExtractOptions but String on the CLI: always Some.
+        assert_eq!(opts.platform.as_deref(), Some("ont"));
+        assert_eq!(opts.platform_unit.as_deref(), Some("PU1"));
+        assert_eq!(opts.read_group_id, "RGX");
+        assert_eq!(opts.comments, vec!["c1".to_string(), "c2".to_string()]);
+        assert_eq!(opts.barcode.as_deref(), Some("ACGT"));
+        assert_eq!(opts.platform_model.as_deref(), Some("PM1"));
+        assert_eq!(opts.sequencing_center.as_deref(), Some("CN1"));
+        assert_eq!(opts.predicted_insert_size, Some(300));
+        assert_eq!(opts.description.as_deref(), Some("desc"));
+        assert_eq!(opts.run_date.as_deref(), Some("2020-01-01"));
+        // Placeholder — the chain source detects and overrides this.
+        assert_eq!(opts.quality_encoding, QualityEncoding::Standard);
+        assert!(opts.store_umi_quals);
+        assert!(!opts.store_cell_quals);
+        assert_eq!(opts.single_tag, Some(SamTag::MI));
+        assert!(opts.annotate_read_names);
+        assert!(!opts.extract_umis_from_read_names);
+        assert!(opts.store_sample_barcode_qualities);
+        assert!(!opts.async_reader);
+        assert!(opts.check_crc);
+        assert!(!opts.no_check_crc);
     }
 
     /// `ExtractOptions::validate` must reject a `--single-tag` that collides with

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -80,11 +80,27 @@ pub(crate) enum PendingSource {
         reference: std::path::PathBuf,
     },
 
-    /// `SourceSpec::Fastqs` — extract's input form.
-    /// `add_source` consumes this to build the FASTQ read preamble:
-    /// `ReadFastqInputs → ZipFastqRecords`. Read structures are read
-    /// from `self.spec.source` by `add_extract`, not carried here.
-    Fastq { paths: Vec<std::path::PathBuf> },
+    /// `SourceSpec::Fastqs` / `SourceSpec::InterleavedFastq` — extract's input
+    /// form. `open_source` opens the decompressed readers and detects the quality
+    /// encoding (so both live here, not in the path-only `SourceSpec`);
+    /// `add_source` consumes the readers to build the FASTQ read preamble
+    /// (`ReadFastqInputs → … → ZipFastqRecords`). Read structures are read from
+    /// `self.spec.source` by `add_extract`, not carried here.
+    Fastq {
+        /// Opened, decompressed FASTQ readers — one per stream (two for an
+        /// interleaved source, already de-interleaved).
+        readers: Vec<Box<dyn std::io::BufRead + Send>>,
+        /// Quality encoding detected from the input heads; applied by
+        /// `add_extract` (overrides the placeholder in `ExtractOptions`).
+        encoding: crate::commands::extract::QualityEncoding,
+        /// When `true`, force the drift-bounded round-robin read topology
+        /// (`ReadFastqInputs::new → ParseFastqChunks → ZipFastqRecords`) even for
+        /// two streams. Set for an interleaved source: its two halves share one
+        /// physical stream and the de-interleaver caps how far they may diverge,
+        /// so the N==2 `PairRawFastq` topology (which lets R1 outrun R2) can
+        /// overrun that cap.
+        force_round_robin: bool,
+    },
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -517,6 +533,13 @@ pub struct ChainBuilder<'a> {
     /// clip) keeps the pool-scheduled writer. `add_sink` reads this flag.
     /// Default `false`.
     detached_writer: bool,
+
+    /// Quality encoding detected by `open_source` for a FASTQ source, pulled out
+    /// of [`PendingSource::Fastq`] in `new()`. `add_extract` overrides the
+    /// placeholder `ExtractOptions::quality_encoding` with this so the chain
+    /// applies the same source-detected encoding the serial oracle does. `None`
+    /// for non-FASTQ sources.
+    fastq_encoding: Option<crate::commands::extract::QualityEncoding>,
 }
 
 impl<'a> ChainBuilder<'a> {
@@ -550,6 +573,13 @@ impl<'a> ChainBuilder<'a> {
         // the input itself) is gone: standalone sort now streams through the
         // normal source path, so `@PG` injection applies to it too.
         let (raw_header, pending_source) = Self::open_source(spec)?;
+        // A FASTQ source detects the input quality encoding while opening its
+        // readers; pull it out here so `add_extract` can override the placeholder
+        // in `ExtractOptions`. Non-FASTQ sources leave this `None`.
+        let fastq_encoding = match &pending_source {
+            Some(PendingSource::Fastq { encoding, .. }) => Some(*encoding),
+            _ => None,
+        };
         // Synthesize @HD VN:1.6 SO:unsorted when the input lacks one (match fgbio,
         // which never passes a header-less BAM straight through). Every legacy
         // command's execute() does this before add_pg_record; ChainBuilder must
@@ -585,6 +615,7 @@ impl<'a> ChainBuilder<'a> {
             // Pool-scheduled writer by default; add_sort opts the standalone
             // sort terminal into a Detached writer (lever 2).
             detached_writer: false,
+            fastq_encoding,
         })
     }
 
@@ -676,14 +707,45 @@ impl<'a> ChainBuilder<'a> {
                 ))
             }
             SourceSpec::Fastqs { paths, read_structures: _ } => {
-                let extract_opts = spec.stage_opts.extract.as_ref().ok_or_else(|| {
-                    anyhow!("Fastqs source requires extract options in StageOptionsBag")
-                })?;
-                let header =
-                    crate::pipeline::chains::commands::extract::build_fastq_header(extract_opts)?;
-                Ok((header, Some(PendingSource::Fastq { paths: paths.clone() })))
+                let (header, pending) = Self::open_fastq_source(spec, paths, false)?;
+                Ok((header, Some(pending)))
+            }
+            SourceSpec::InterleavedFastq { path, read_structures: _ } => {
+                let (header, pending) =
+                    Self::open_fastq_source(spec, std::slice::from_ref(path), true)?;
+                Ok((header, Some(pending)))
             }
         }
+    }
+
+    /// Open the decompressed FASTQ readers and detect the input quality encoding
+    /// for a `Fastqs` / `InterleavedFastq` source, then build the unmapped-BAM
+    /// header. Shared by both FASTQ arms of [`Self::open_source`].
+    ///
+    /// The chain opens its own readers here (the conformant "chain owns its
+    /// source" shape) through the same helper the serial oracle uses, so both see
+    /// identical readers and encoding. `interleaved` de-interleaves the sole input
+    /// into the R1/R2 pair and selects the drift-bounded round-robin read topology
+    /// (carried downstream as `PendingSource::Fastq::force_round_robin`).
+    fn open_fastq_source(
+        spec: &ChainSpec,
+        inputs: &[std::path::PathBuf],
+        interleaved: bool,
+    ) -> Result<(Header, PendingSource)> {
+        let extract_opts =
+            spec.stage_opts.extract.as_ref().ok_or_else(|| {
+                anyhow!("a FASTQ source requires extract options in StageOptionsBag")
+            })?;
+        let (readers, encoding) = crate::commands::extract::detect_encoding_and_open_fastq_readers(
+            inputs,
+            interleaved,
+            spec.threading.num_threads(),
+            extract_opts.async_reader,
+            extract_opts.check_crc,
+            extract_opts.no_check_crc,
+        )?;
+        let header = crate::pipeline::chains::commands::extract::build_fastq_header(extract_opts)?;
+        Ok((header, PendingSource::Fastq { readers, encoding, force_round_robin: interleaved }))
     }
 
     /// Add the input source step(s) to the pipeline.
@@ -871,7 +933,7 @@ impl<'a> ChainBuilder<'a> {
                 self.current_tail = Some(unmapped_tail);
                 self.paired_tail = Some(mapped_tail);
             }
-            PendingSource::Fastq { paths } => {
+            PendingSource::Fastq { readers, encoding: _, force_round_robin } => {
                 use crate::pipeline::core::step::Affinity;
                 use crate::pipeline::steps::source::pair_fastq::PairRawFastq;
                 use crate::pipeline::steps::source::parse_fastq::ParseFastqChunks;
@@ -881,37 +943,13 @@ impl<'a> ChainBuilder<'a> {
                 };
                 use crate::pipeline::steps::source::zip_fastq::ZipFastqRecords;
 
-                // Open one BufRead reader per FASTQ path. Extract's
-                // `open_fastq_reader` handles BGZF / gzip / plain
-                // detection and optional async prefetch wrapping.
-                let extract_opts = self.spec.stage_opts.extract.as_ref().ok_or_else(|| {
-                    anyhow!("Fastq source requires extract options in StageOptionsBag")
-                })?;
-                let async_reader = extract_opts.async_reader;
-                // CRC-verification policy: `ExtractOptions` (the projection) does
-                // not yet carry the `--check-crc` / `--no-check-crc` flags — that
-                // wiring lands when `Extract::execute` builds the projection at the
-                // extract rewire. Until the chain is the live extract caller, use
-                // the default policy (verify a file, trust stdin), which
-                // `open_fastq_reader` selects when both flags are false.
-                let check_crc = false;
-                let no_check_crc = false;
-                // FASTQ decompression threads: for BGZF inputs the reader
-                // can multi-thread; for gzip/plain it is single-threaded
-                // regardless.  Pass 1 here — the pipeline framework
-                // provides the parallelism via typed steps.
-                let mut readers: Vec<Box<dyn std::io::BufRead + Send>> = paths
-                    .iter()
-                    .map(|p| {
-                        crate::commands::extract::open_fastq_reader(
-                            p,
-                            1,
-                            async_reader,
-                            check_crc,
-                            no_check_crc,
-                        )
-                    })
-                    .collect::<Result<Vec<_>>>()?;
+                // Readers were opened by `open_source` — one per stream, or the
+                // de-interleaved R1/R2 pair for an interleaved source — using the
+                // run's thread count and CRC policy, with BGZF/gzip/plain
+                // detection and optional async prefetch already applied. Consume
+                // them directly; the detected quality encoding is applied by
+                // `add_extract` via `self.fastq_encoding`.
+                let mut readers = readers;
 
                 let n_streams = readers.len();
                 // batch_record_count — same default as the legacy pipeline.
@@ -952,8 +990,8 @@ impl<'a> ChainBuilder<'a> {
                 // worker index is clamped to `num_threads - 1` so a low
                 // `--threads` count can never request a non-existent worker
                 // (which would deadlock).
-                let tail = match n_streams {
-                    1 => {
+                let tail = match (n_streams, force_round_robin) {
+                    (1, _) => {
                         let only = readers.pop().expect("n_streams == 1");
                         let read_step = ReadFastqInputs::new_single(
                             only,
@@ -968,7 +1006,7 @@ impl<'a> ChainBuilder<'a> {
                             self.pipeline.append_step(ParseFastqChunks::new(byte_limit), tail);
                         self.pipeline.append_step(ZipFastqRecords::new(1, byte_limit), parse_tail)
                     }
-                    2 => {
+                    (2, false) => {
                         // Two concurrent single-stream readers (R1, R2) →
                         // PairRawFastq (Step2) → ParseAndZipFastq.
                         let r2_in = readers.pop().expect("n_streams == 2");
@@ -1013,8 +1051,13 @@ impl<'a> ChainBuilder<'a> {
                         self.pipeline.append_step(ParseAndZipFastq::new(byte_limit), pair_tail)
                     }
                     _ => {
-                        // N >= 3 fallback: single all-streams round-robin
-                        // reader (Affinity::Reader), serial decompress.
+                        // Round-robin fallback (N >= 3, or the two-stream
+                        // interleaved case where `force_round_robin` is set): one
+                        // all-streams reader (Affinity::Reader), serial decompress.
+                        // Reading one chunk per stream per cycle bounds how far the
+                        // streams diverge to `batch_records`, which the interleaved
+                        // de-interleaver's lockstep cap requires (the N==2
+                        // `PairRawFastq` path would let R1 outrun R2 past it).
                         let read_step = ReadFastqInputs::new(readers, batch_records, byte_limit);
                         let tail = self.pipeline.append_source(read_step);
                         let parse_tail =
@@ -1049,6 +1092,7 @@ impl<'a> ChainBuilder<'a> {
             SourceSpec::Bam(p) | SourceSpec::Sam(p) => p.clone(),
             SourceSpec::PairedBams { mapped, .. } => mapped.clone(),
             SourceSpec::Fastqs { paths, .. } => paths.first().cloned().unwrap_or_default(),
+            SourceSpec::InterleavedFastq { path, .. } => path.clone(),
         }
     }
 
@@ -1766,8 +1810,11 @@ impl<'a> ChainBuilder<'a> {
         let timer = OperationTimer::new("Extracting UMIs");
 
         let read_structures = match &self.spec.source {
-            SourceSpec::Fastqs { read_structures, .. } => Arc::new(read_structures.clone()),
-            other => bail!("add_extract requires SourceSpec::Fastqs, got {other:?}"),
+            SourceSpec::Fastqs { read_structures, .. }
+            | SourceSpec::InterleavedFastq { read_structures, .. } => {
+                Arc::new(read_structures.clone())
+            }
+            other => bail!("add_extract requires a FASTQ source, got {other:?}"),
         };
 
         // Enforce the same read-structure guard the standalone `Extract` command
@@ -1782,9 +1829,19 @@ impl<'a> ChainBuilder<'a> {
 
         let records_emitted = Arc::new(AtomicU64::new(0));
 
+        // Apply the source-detected quality encoding over the placeholder in the
+        // projected options: `open_source` detected it while opening the FASTQ
+        // readers and stashed it in `self.fastq_encoding`, so the chain applies
+        // the same encoding the serial oracle does. `None` only for a
+        // (non-existent) non-FASTQ extract source, where the placeholder stands.
+        let mut extract_opts = extract_opts.clone();
+        if let Some(encoding) = self.fastq_encoding {
+            extract_opts.quality_encoding = encoding;
+        }
+
         let step = build_extract_step(
             read_structures,
-            Arc::new(extract_opts.clone()),
+            Arc::new(extract_opts),
             Arc::clone(&records_emitted),
             self.tuning.per_step_byte_limit,
         );

--- a/src/lib/pipeline/chains/commands/extract.rs
+++ b/src/lib/pipeline/chains/commands/extract.rs
@@ -167,6 +167,8 @@ mod tests {
             extract_umis_from_read_names: false,
             store_sample_barcode_qualities: false,
             async_reader: false,
+            check_crc: false,
+            no_check_crc: false,
         }
     }
 

--- a/src/lib/pipeline/chains/source_spec.rs
+++ b/src/lib/pipeline/chains/source_spec.rs
@@ -29,6 +29,18 @@ pub enum SourceSpec {
     /// re-checks it for any spec that was constructed directly.
     Fastqs { paths: Vec<PathBuf>, read_structures: Vec<ReadStructure> },
 
+    /// A single interleaved FASTQ stream (`R1, R2, R1, R2, …`, or `-` for
+    /// stdin) that the chain de-interleaves into two logical reads. Used by
+    /// `fgumi extract --interleaved`.
+    ///
+    /// Distinct from [`SourceSpec::Fastqs`] because interleaved input is one
+    /// physical `path` carrying **two** `read_structures` — the R1/R2 pair —
+    /// which would violate the `Fastqs` "one read structure per path"
+    /// invariant. Build this via [`SourceSpec::interleaved_fastq`] (which
+    /// enforces exactly two read structures); [`SourceSpec::validate`]
+    /// re-checks it.
+    InterleavedFastq { path: PathBuf, read_structures: Vec<ReadStructure> },
+
     /// SAM text file (or `-` for stdin). Standalone-only — runall does
     /// not accept SAM input (it always reads from a BAM intermediate).
     Sam(PathBuf),
@@ -53,25 +65,54 @@ impl SourceSpec {
         Ok(spec)
     }
 
+    /// Constructs a [`SourceSpec::InterleavedFastq`] source, enforcing that
+    /// the single interleaved `path` carries exactly two read structures
+    /// (the R1/R2 pair the stream de-interleaves into).
+    ///
+    /// Prefer this over an `InterleavedFastq { .. }` struct literal so a
+    /// wrong read-structure count fails here rather than downstream.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `read_structures.len() != 2`.
+    pub fn interleaved_fastq(path: PathBuf, read_structures: Vec<ReadStructure>) -> Result<Self> {
+        let spec = Self::InterleavedFastq { path, read_structures };
+        spec.validate()?;
+        Ok(spec)
+    }
+
     /// Re-checks structural invariants that the variant types cannot
-    /// encode. Currently this validates that a [`SourceSpec::Fastqs`]
-    /// source has one read structure per path. Call this when accepting a
-    /// `SourceSpec` that may have been built via a struct literal rather
-    /// than [`SourceSpec::fastqs`].
+    /// encode: a [`SourceSpec::Fastqs`] source has one read structure per
+    /// path, and a [`SourceSpec::InterleavedFastq`] source has exactly two.
+    /// Call this when accepting a `SourceSpec` that may have been built via a
+    /// struct literal rather than [`SourceSpec::fastqs`] /
+    /// [`SourceSpec::interleaved_fastq`].
     ///
     /// # Errors
     ///
     /// Returns an error if a `Fastqs` source has diverging `paths` and
-    /// `read_structures` lengths.
+    /// `read_structures` lengths, or an `InterleavedFastq` source does not
+    /// carry exactly two read structures.
     pub fn validate(&self) -> Result<()> {
-        if let Self::Fastqs { paths, read_structures } = self {
-            ensure!(
-                paths.len() == read_structures.len(),
-                "FASTQ source is mis-sized: {} path(s) but {} read structure(s); \
-                 each path needs exactly one read structure",
-                paths.len(),
-                read_structures.len(),
-            );
+        match self {
+            Self::Fastqs { paths, read_structures } => {
+                ensure!(
+                    paths.len() == read_structures.len(),
+                    "FASTQ source is mis-sized: {} path(s) but {} read structure(s); \
+                     each path needs exactly one read structure",
+                    paths.len(),
+                    read_structures.len(),
+                );
+            }
+            Self::InterleavedFastq { read_structures, .. } => {
+                ensure!(
+                    read_structures.len() == 2,
+                    "interleaved FASTQ source needs exactly two read structures \
+                     (R1/R2); got {}",
+                    read_structures.len(),
+                );
+            }
+            Self::Bam(_) | Self::PairedBams { .. } | Self::Sam(_) => {}
         }
         Ok(())
     }
@@ -82,7 +123,10 @@ impl SourceSpec {
     #[must_use]
     pub fn is_runall_compatible(&self) -> bool {
         match self {
-            Self::Bam(_) | Self::PairedBams { .. } | Self::Fastqs { .. } => true,
+            Self::Bam(_)
+            | Self::PairedBams { .. }
+            | Self::Fastqs { .. }
+            | Self::InterleavedFastq { .. } => true,
             Self::Sam(_) => false,
         }
     }
@@ -138,5 +182,37 @@ mod tests {
     fn validate_is_ok_for_non_fastq_sources() {
         assert!(SourceSpec::Bam(PathBuf::from("a.bam")).validate().is_ok());
         assert!(SourceSpec::Sam(PathBuf::from("a.sam")).validate().is_ok());
+    }
+
+    #[test]
+    fn interleaved_constructor_accepts_exactly_two_read_structures() {
+        let spec = SourceSpec::interleaved_fastq(
+            PathBuf::from("interleaved.fq"),
+            vec![read_structure(), read_structure()],
+        )
+        .expect("two read structures should construct");
+        assert!(spec.validate().is_ok());
+        assert!(spec.is_runall_compatible());
+    }
+
+    #[rstest::rstest]
+    #[case::one(1)]
+    #[case::three(3)]
+    fn interleaved_constructor_rejects_non_two_read_structures(#[case] n: usize) {
+        let err = SourceSpec::interleaved_fastq(
+            PathBuf::from("interleaved.fq"),
+            std::iter::repeat_with(read_structure).take(n).collect(),
+        )
+        .expect_err("only two read structures are valid");
+        assert!(err.to_string().contains("exactly two read structures"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_catches_mismatched_interleaved_struct_literal() {
+        let spec = SourceSpec::InterleavedFastq {
+            path: PathBuf::from("interleaved.fq"),
+            read_structures: vec![read_structure()],
+        };
+        assert!(spec.validate().is_err());
     }
 }

--- a/src/lib/pipeline/chains/validate.rs
+++ b/src/lib/pipeline/chains/validate.rs
@@ -431,13 +431,15 @@ pub fn validate_cross_stage_constraints(spec: &ChainSpec) -> Result<()> {
         )?;
     }
 
-    // Rule 4: `Stage::Extract` requires a `SourceSpec::Fastqs` source.
-    // Extract reads directly from FASTQ files; feeding it a BAM, SAM, or
-    // paired-BAM source is a programmer error that would be caught late
-    // (at chain-build time) without this guard. Catching it here at
-    // spec-validation time gives a clearer error message.
-    if spec.stages.contains(&Stage::Extract) && !matches!(spec.source, SourceSpec::Fastqs { .. }) {
-        bail!("Stage::Extract requires SourceSpec::Fastqs; got {:?}", spec.source);
+    // Rule 4: `Stage::Extract` requires a FASTQ source — `SourceSpec::Fastqs`
+    // or `SourceSpec::InterleavedFastq`. Extract reads directly from FASTQ;
+    // feeding it a BAM, SAM, or paired-BAM source is a programmer error that
+    // would be caught late (at chain-build time) without this guard. Catching it
+    // here at spec-validation time gives a clearer error message.
+    if spec.stages.contains(&Stage::Extract)
+        && !matches!(spec.source, SourceSpec::Fastqs { .. } | SourceSpec::InterleavedFastq { .. })
+    {
+        bail!("Stage::Extract requires a FASTQ source; got {:?}", spec.source);
     }
 
     // Rule 5: the FASTQ sink and `Stage::Fastq` must go together. A `Fastq`
@@ -1051,7 +1053,7 @@ mod tests {
         validate_cross_stage_constraints(&spec).expect("standalone duplex skips paired check");
     }
 
-    // ── Rule 4: Stage::Extract requires SourceSpec::Fastqs ──────────────────
+    // ── Rule 4: Stage::Extract requires a FASTQ source ──────────────────────
 
     /// Helper: a minimal `ExtractOptions` suitable for tests.
     fn minimal_extract_opts() -> crate::commands::extract::ExtractOptions {
@@ -1077,6 +1079,8 @@ mod tests {
             extract_umis_from_read_names: false,
             store_sample_barcode_qualities: false,
             async_reader: false,
+            check_crc: false,
+            no_check_crc: false,
         }
     }
 
@@ -1088,7 +1092,7 @@ mod tests {
         spec.stage_opts.extract = Some(minimal_extract_opts());
         let err = validate_cross_stage_constraints(&spec).unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("requires SourceSpec::Fastqs"), "got: {msg}");
+        assert!(msg.contains("requires a FASTQ source"), "got: {msg}");
     }
 
     #[test]

--- a/src/lib/pipeline/steps/extract.rs
+++ b/src/lib/pipeline/steps/extract.rs
@@ -130,7 +130,14 @@ pub(crate) fn extract_batch(
         let combined = FastqSet::combine_readsets(fastq_sets);
 
         let raw_records = make_raw_records_from_fastq_set(&combined, extract_opts)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            // Render the full anyhow context chain into the io::Error string (the
+            // alternate `{:#}` form: "context: cause"). A bare
+            // `io::Error::new(_, e)` Displays only the top context, dropping the
+            // root cause — e.g. it would keep "could not write the record for read
+            // …" but lose the "read name too long" underneath, so the chain path's
+            // error would diverge from the serial oracle's. Preserving the chain
+            // keeps the two paths' messages in parity.
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("{e:#}")))?;
 
         let template = Template::from_records(raw_records)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
@@ -176,6 +183,8 @@ mod tests {
             extract_umis_from_read_names: false,
             store_sample_barcode_qualities: false,
             async_reader: false,
+            check_crc: false,
+            no_check_crc: false,
         }
     }
 

--- a/src/lib/pipeline/steps/source/pair_fastq.rs
+++ b/src/lib/pipeline/steps/source/pair_fastq.rs
@@ -372,8 +372,13 @@ impl Step2 for PairRawFastq {
 /// surface byte-for-byte identical diagnostics regardless of which path detects
 /// the mismatch.
 fn out_of_sync_error(short_stream: usize, chunk_serial: u64) -> io::Error {
+    // Name streams R1/R2 (1-based) and the short one as having "ended before" the
+    // other, matching the serial oracle's wording so the operator learns which
+    // FASTQ ran out (issue #773). `short_stream` is 0-based (0 = R1, 1 = R2).
+    let ended = short_stream + 1;
+    let other = if short_stream == 0 { 2 } else { 1 };
     io::Error::other(format!(
-        "FASTQ sources out of sync: stream {short_stream} ended before chunk_serial \
+        "FASTQ sources out of sync: R{ended} ended before R{other} at chunk_serial \
          {chunk_serial} while the other stream had more records"
     ))
 }
@@ -954,8 +959,8 @@ mod tests {
             "desync abort must report an out-of-sync error, got: {err}"
         );
         assert!(
-            err.contains("stream 1 ended before chunk_serial 2"),
-            "desync error must name the short stream (index 1) and the orphaned \
+            err.contains("R2 ended before R1 at chunk_serial 2"),
+            "desync error must name the short stream (R2) and the orphaned \
              serial (2), got: {err}"
         );
     }
@@ -973,8 +978,8 @@ mod tests {
             "desync abort must report an out-of-sync error, got: {err}"
         );
         assert!(
-            err.contains("stream 0 ended before chunk_serial 2"),
-            "desync error must name the short stream (index 0) and the orphaned \
+            err.contains("R1 ended before R2 at chunk_serial 2"),
+            "desync error must name the short stream (R1) and the orphaned \
              serial (2), got: {err}"
         );
     }
@@ -993,9 +998,9 @@ mod tests {
         let result = run_desync_harness_with_backpressure(3, 1, Some(X3_SOFT_LIMIT_BYTES));
         let err = result.expect_err("truncated stream over backpressure must abort, not hang");
         assert!(
-            err.contains("out of sync") && err.contains("stream 1 ended before chunk_serial 1"),
+            err.contains("out of sync") && err.contains("R2 ended before R1 at chunk_serial 1"),
             "backpressure fail-fast must reuse the shared out-of-sync error naming the \
-             short stream (index 1) and the orphaned serial (1), got: {err}"
+             short stream (R2) and the orphaned serial (1), got: {err}"
         );
     }
 
@@ -1009,9 +1014,9 @@ mod tests {
         let result = run_desync_harness_with_backpressure(1, 3, Some(X3_SOFT_LIMIT_BYTES));
         let err = result.expect_err("truncated stream over backpressure must abort, not hang");
         assert!(
-            err.contains("out of sync") && err.contains("stream 0 ended before chunk_serial 1"),
+            err.contains("out of sync") && err.contains("R1 ended before R2 at chunk_serial 1"),
             "backpressure fail-fast must reuse the shared out-of-sync error naming the \
-             short stream (index 0) and the orphaned serial (1), got: {err}"
+             short stream (R1) and the orphaned serial (1), got: {err}"
         );
     }
 }

--- a/src/lib/pipeline/steps/source/parse_zip_fastq.rs
+++ b/src/lib/pipeline/steps/source/parse_zip_fastq.rs
@@ -64,9 +64,14 @@ fn zip_records(
     // rather than letting it surface as an incidental name mismatch from the
     // back-pop below.
     if records_a.len() != records_b.len() {
+        // Name streams R1/R2 (1-based) and the shorter one as having "ended
+        // before" the other, matching the serial oracle's wording so the operator
+        // learns which FASTQ ran out (issue #773). `records_a` is R1, `records_b`
+        // is R2. `ZipFastqRecords` (the N>=3 path) reports the same shape.
+        let (ended, before) = if records_a.len() < records_b.len() { (1, 2) } else { (2, 1) };
         return Err(io::Error::other(format!(
-            "FASTQ sources out of sync at chunk_serial {chunk_serial}: \
-             stream 0 has {} records, stream 1 has {}",
+            "FASTQ sources out of sync at chunk_serial {chunk_serial}: R{ended} ended before \
+             R{before} (R1 has {} record(s), R2 has {} in this chunk)",
             records_a.len(),
             records_b.len(),
         )));

--- a/src/lib/pipeline/steps/source/zip_fastq.rs
+++ b/src/lib/pipeline/steps/source/zip_fastq.rs
@@ -221,9 +221,18 @@ impl ZipFastqRecords {
         // it surface as an incidental name mismatch from the back-pop below.
         for (stream_idx, recs) in stream_records.iter().enumerate().skip(1) {
             if recs.len() != n_records {
+                // Name streams R1/R2/… (1-based) and the shorter one as having
+                // "ended before" the other, matching the serial oracle and the
+                // N==2 `ParseAndZipFastq` path so the operator learns which FASTQ
+                // ran out (issue #773).
+                let (ended, before) =
+                    if recs.len() < n_records { (stream_idx, 0) } else { (0, stream_idx) };
                 return Err(io::Error::other(format!(
-                    "FASTQ sources out of sync at chunk_serial {lowest_serial}: \
-                     stream 0 has {n_records} records, stream {stream_idx} has {}",
+                    "FASTQ sources out of sync at chunk_serial {lowest_serial}: R{} ended before \
+                     R{} (R1 has {n_records} record(s), R{} has {} in this chunk)",
+                    ended + 1,
+                    before + 1,
+                    stream_idx + 1,
                     recs.len(),
                 )));
             }
@@ -403,9 +412,17 @@ impl Step for ZipFastqRecords {
                 if let Some((&serial, slots)) = self.pending.iter().next() {
                     for (idx, slot) in slots.iter().enumerate() {
                         if slot.is_none() {
+                            // `idx` (0-based) ended early; name a stream that still
+                            // had a record here as the "before" reference. R1/R2/…
+                            // (1-based) matches the serial oracle and the N==2 path.
+                            let before = slots.iter().position(Option::is_some).map_or_else(
+                                || "the other stream".to_string(),
+                                |o| format!("R{}", o + 1),
+                            );
                             return Err(io::Error::other(format!(
-                                "FASTQ sources out of sync: stream {idx} ended before \
+                                "FASTQ sources out of sync: R{} ended before {before} at \
                                  chunk_serial {serial} while other streams had more records",
+                                idx + 1,
                             )));
                         }
                     }
@@ -623,6 +640,27 @@ mod tests {
         let err = zip.try_emit_complete().unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("out of sync"), "expected count out-of-sync error, got: {msg}");
+        // stream 0 (R1) has 2 records, stream 1 (R2) has 1 → R2 ran short. Assert
+        // the directional wording so a flipped `ended`/`before` mapping is caught.
+        assert!(msg.contains("R2 ended before R1"), "expected directional wording, got: {msg}");
+    }
+
+    /// The reverse of `test_zip_unequal_counts_out_of_sync`: stream 0 (R1) has
+    /// fewer records than stream 1 (R2), so the directional wording must name R1
+    /// as the short stream. Exercises the other branch of the `ended`/`before`
+    /// selection so a flipped mapping cannot pass on both directions.
+    #[test]
+    fn test_zip_unequal_counts_out_of_sync_reversed() {
+        let mut zip = ZipFastqRecords::new(2, 64 * 1024 * 1024);
+        let s0 = make_chunk(0, 0, vec![make_record("read1/1", "ACGT")]);
+        let s1 =
+            make_chunk(1, 0, vec![make_record("read1/2", "GGGG"), make_record("read2/2", "TT")]);
+        zip.pending.insert(0, vec![Some(s0), Some(s1)]);
+
+        let err = zip.try_emit_complete().unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("out of sync"), "expected count out-of-sync error, got: {msg}");
+        assert!(msg.contains("R1 ended before R2"), "expected directional wording, got: {msg}");
     }
 
     #[test]
@@ -956,9 +994,12 @@ mod tests {
             .expect_err("a stream that ends early must fail the run");
 
         let msg = err.to_string();
+        // The final stream (R2, with n_streams == 2) is the one truncated, so it
+        // ends before R1. Assert the directional wording, not just "ended before",
+        // so an inverted stream-index mapping is caught.
         assert!(
-            msg.contains("ended before"),
-            "expected the EOF-desync diagnosis naming the stream and serial, got: {msg}"
+            msg.contains("R2 ended before R1"),
+            "expected the EOF-desync diagnosis naming R2 as the short stream, got: {msg}"
         );
     }
 

--- a/tests/integration/test_extract_command.rs
+++ b/tests/integration/test_extract_command.rs
@@ -608,6 +608,177 @@ fn test_parallel_parse_output_equivalence_across_threads() {
     }
 }
 
+/// The chain (`--threads`) output must equal the serial oracle (no `--threads`)
+/// on decoded records AND normalized header, with `--threads 1` explicitly
+/// covered. `--threads 1` already ran a parallel path before this change (the
+/// now-deleted legacy `process_with_pipeline`, since the old `is_parallel()`
+/// dispatch was true for every `Threads(n)`); the cutover moves it onto the chain
+/// builder. The earlier across-threads equivalence test only compares the chain
+/// against itself at different `--threads` values, so this is the test that pins
+/// the chain against the serial oracle.
+///
+/// Fixed-value anchors (record count, each mate's template sequence, the combined
+/// `RX`, and the `RG`) are pinned in addition to chain==oracle, so a regression
+/// in the shared record-building code is caught even when both paths still agree
+/// with each other.
+#[rstest]
+#[case::threads_one(1)]
+#[case::threads_four(4)]
+fn chain_matches_serial_oracle(#[case] threads: usize) {
+    use fgumi_lib::sam::SamTag;
+    use noodles::sam::alignment::record::data::field::Tag;
+    use noodles::sam::alignment::record_buf::data::field::Value;
+
+    let tmp = TempDir::new().unwrap();
+    // 5M+T over a 10 bp read: a 5 bp UMI then a 5 bp template. One paired template.
+    let r1 = create_plain_fastq(&tmp, "r1.fq", &[("pair0", "AAAAACCCCC", "IIIIIIIIII")]);
+    let r2 = create_plain_fastq(&tmp, "r2.fq", &[("pair0", "GGGGGTTTTT", "IIIIIIIIII")]);
+
+    let run = |threads: Option<usize>, out: &Path| {
+        let mut args: Vec<String> = vec![
+            "extract".into(),
+            "--inputs".into(),
+            r1.to_str().unwrap().into(),
+            r2.to_str().unwrap().into(),
+            "--output".into(),
+            out.to_str().unwrap().into(),
+            "--read-structures".into(),
+            "5M+T".into(),
+            "5M+T".into(),
+            "--sample".into(),
+            "psample".into(),
+            "--library".into(),
+            "plib".into(),
+            "--compression-level".into(),
+            "1".into(),
+        ];
+        if let Some(t) = threads {
+            args.push("--threads".into());
+            args.push(t.to_string());
+        }
+        Extract::try_parse_from(args)
+            .expect("failed to parse extract args")
+            .execute("fgumi extract")
+            .expect("extract failed");
+    };
+
+    let oracle_out = tmp.path().join("oracle.bam");
+    let chain_out = tmp.path().join(format!("chain_t{threads}.bam"));
+    run(None, &oracle_out); // serial oracle (no --threads)
+    run(Some(threads), &chain_out); // chain (--threads N, incl. N == 1)
+
+    let (oracle_hdr, oracle_recs) = crate::helpers::read_bam_output(&oracle_out);
+    let (chain_hdr, chain_recs) = crate::helpers::read_bam_output(&chain_out);
+    assert_eq!(chain_hdr, oracle_hdr, "normalized header parity (threads={threads})");
+    assert_eq!(chain_recs, oracle_recs, "record parity (threads={threads})");
+
+    // Fixed-value anchors on the oracle output (which the chain now equals): one
+    // record per mate, the template halves after the 5 bp UMI, the combined
+    // R1-R2 UMI in RX, and the default read group on every record.
+    assert_eq!(oracle_recs.len(), 2, "one BAM record per mate");
+    assert_eq!(oracle_recs[0].sequence().as_ref(), b"CCCCC", "R1 template after 5M UMI");
+    assert_eq!(oracle_recs[1].sequence().as_ref(), b"TTTTT", "R2 template after 5M UMI");
+    let string_tag = |rec: &RecordBuf, tag: SamTag| -> Vec<u8> {
+        match rec.data().get(&Tag::from(tag)) {
+            Some(Value::String(s)) => s.to_vec(),
+            other => panic!("expected a string {tag:?} tag, got {other:?}"),
+        }
+    };
+    for rec in &oracle_recs {
+        assert_eq!(string_tag(rec, SamTag::RX), b"AAAAA-GGGGG", "combined R1-R2 UMI in RX");
+        assert_eq!(string_tag(rec, SamTag::RG), b"A", "default read group id");
+    }
+}
+
+/// Chain-vs-oracle parity across the barcode / single-tag / annotate branches of
+/// the record builder. `chain_matches_serial_oracle` covers only RX/RG, and every
+/// threading-parameterized tag test pins `store_cell_quals` / `single_tag` /
+/// `annotate_read_names` / `store_sample_barcode_qualities` off, so nothing else
+/// exercises those branches on the chain path — yet the chain
+/// (`make_raw_records_from_fastq_set`) and the serial oracle (`make_raw_records`)
+/// are two independent copies of that tag-append block. A single-end `2C2B2M+T`
+/// read with every tag flag on drives CB/CY, BC/QT, RX/QX, the `--single-tag`
+/// copy, and `--annotate-read-names`; the chain must match the serial oracle
+/// byte-for-byte, and the emitted tag values are pinned so a shared-code
+/// regression is caught even when the two paths still agree.
+#[rstest]
+#[case::threads_one(1)]
+#[case::threads_four(4)]
+fn chain_matches_serial_oracle_barcode_and_annotate_tags(#[case] threads: usize) {
+    use fgumi_lib::sam::SamTag;
+    use noodles::sam::alignment::record::data::field::Tag;
+    use noodles::sam::alignment::record_buf::data::field::Value;
+
+    let tmp = TempDir::new().unwrap();
+    // 3C 3B 3M then template over a 13 bp read "AAACCCGGGTTTT": cell=AAA,
+    // sample=CCC, umi=GGG, template=TTTT. (3 bp segments, so the pinned barcode/UMI
+    // payloads are not 2-char tag-shaped literals the tag-literal lint would flag.)
+    let input = create_plain_fastq(&tmp, "r1.fq", &[("readX", "AAACCCGGGTTTT", "IIIIIIIIIIIII")]);
+
+    let run = |threads: Option<usize>, out: &Path| {
+        let mut args: Vec<String> = vec![
+            "extract".into(),
+            "--inputs".into(),
+            input.to_str().unwrap().into(),
+            "--output".into(),
+            out.to_str().unwrap().into(),
+            "--read-structures".into(),
+            "3C3B3M+T".into(),
+            "--sample".into(),
+            "s".into(),
+            "--library".into(),
+            "l".into(),
+            "--store-umi-quals".into(),
+            "--store-cell-quals".into(),
+            "--store-sample-barcode-qualities".into(),
+            "--annotate-read-names".into(),
+            "--single-tag".into(),
+            "MI".into(),
+            "--compression-level".into(),
+            "1".into(),
+        ];
+        if let Some(t) = threads {
+            args.push("--threads".into());
+            args.push(t.to_string());
+        }
+        Extract::try_parse_from(args)
+            .expect("failed to parse extract args")
+            .execute("fgumi extract")
+            .expect("extract failed");
+    };
+
+    let oracle_out = tmp.path().join("oracle.bam");
+    let chain_out = tmp.path().join(format!("chain_t{threads}.bam"));
+    run(None, &oracle_out);
+    run(Some(threads), &chain_out);
+
+    let (oracle_hdr, oracle_recs) = crate::helpers::read_bam_output(&oracle_out);
+    let (chain_hdr, chain_recs) = crate::helpers::read_bam_output(&chain_out);
+    assert_eq!(chain_hdr, oracle_hdr, "header parity (threads={threads})");
+    assert_eq!(chain_recs, oracle_recs, "record parity (threads={threads})");
+
+    assert_eq!(oracle_recs.len(), 1, "one record for the single-end read");
+    let rec = &oracle_recs[0];
+    let string_tag = |rec: &RecordBuf, tag: SamTag| -> Vec<u8> {
+        match rec.data().get(&Tag::from(tag)) {
+            Some(Value::String(s)) => s.to_vec(),
+            other => panic!("expected a string {tag:?} tag, got {other:?}"),
+        }
+    };
+    assert_eq!(rec.sequence().as_ref(), b"TTTT", "template after 3C3B3M");
+    assert_eq!(string_tag(rec, SamTag::CB), b"AAA", "cell barcode");
+    assert_eq!(string_tag(rec, SamTag::BC), b"CCC", "sample barcode");
+    assert_eq!(string_tag(rec, SamTag::RX), b"GGG", "UMI");
+    assert_eq!(string_tag(rec, SamTag::MI), b"GGG", "--single-tag copy of the UMI");
+    // The store_* flags are on, so the quality tags must be present.
+    assert!(rec.data().get(&Tag::from(SamTag::CY)).is_some(), "cell-barcode quals (CY)");
+    assert!(rec.data().get(&Tag::from(SamTag::QT)).is_some(), "sample-barcode quals (QT)");
+    assert!(rec.data().get(&Tag::from(SamTag::QX)).is_some(), "UMI quals (QX)");
+    // --annotate-read-names appends `+<UMI>` to the read name.
+    let name: &[u8] = rec.name().expect("read name must be present").as_ref();
+    assert_eq!(name, &b"readX+GGG"[..], "annotated read name");
+}
+
 /// Test that running the same input multiple times produces identical output.
 ///
 /// This verifies determinism of the parallel parse pipeline.


### PR DESCRIPTION
Routes `fgumi extract --threads N` onto the declarative chain builder (Pattern A), the last of the R3 command cutovers. The no-`--threads` serial loop (`process_singlethreaded`) stays as the in-process parity oracle; the legacy `process_with_pipeline` typed-step pipeline is deleted.

The dispatch predicate changes from `is_parallel()` to `threads.is_some()`. For `Option<usize>` threads these are equivalent — the old `is_parallel()` was already true for every `Threads(n)`, `--threads 1` included — so this swaps the parallel *implementation* for the chain builder; it does not change which `--threads` values run in parallel.

## Full input parity

Extract is the only cutover whose source is FASTQ rather than BAM, and it supports three input shapes the legacy `--threads` path all parallelized: multiple files, `--interleaved` (one physical stream de-interleaved into R1/R2), and stdin. All three still parallelize, and the chain path is held byte-for-byte identical to the serial oracle:

- **The chain opens its own FASTQ readers and detects the quality encoding** inside `ChainBuilder::open_source`, through the same `detect_encoding_and_open_fastq_readers` helper the serial oracle uses. Both paths therefore open identical readers (de-interleaving and stdin sample-and-replay included) and apply the same detected encoding by construction — no reader is injected through the (Debug/Clone) `SourceSpec`.
- **`SourceSpec::InterleavedFastq`** is a new variant rather than an overload of `Fastqs`: interleaved input is one path carrying two read structures, which violates `Fastqs`' one-structure-per-path invariant (`PairedBams` is the precedent for a structurally distinct source). Its two de-interleaved halves run through the drift-bounded round-robin read topology (`ReadFastqInputs::new → ParseFastqChunks → ZipFastqRecords`), **not** the N==2 `PairRawFastq` path — the latter lets R1 outrun R2, which can overrun the de-interleaver's ~1M-record lockstep cap.
- **`PendingSource::Fastq`** now carries the opened readers, the detected encoding, and a `force_round_robin` flag; `add_extract` applies the detected encoding over the projected `ExtractOptions`.
- **`--check-crc`/`--no-check-crc`** are wired through `ExtractOptions`. Multi-file readers decode single-threaded (the pipeline parallelizes across streams); only a single physical stream (stdin/interleaved) takes the per-stream decode-thread budget, avoiding N×threads BGZF-decode over-subscription.

## Error-message parity

The chain's FASTQ out-of-sync errors are now directional ("R2 ended before R1"), matching the serial oracle so the operator learns which file ran short (the shared FASTQ steps `pair_fastq`, `parse_zip_fastq`, and `zip_fastq` all report the same shape). The extract step also preserves the full anyhow context chain when it converts to `io::Error`, so a "read name too long" root cause survives instead of being flattened to the top context.

## Deletions

`process_with_pipeline`, `make_raw_records_static`, `ExtractConfig`, `ExtractedBatch`, and `validate_template_record_count` are removed — the chain's `extract_batch` enforces the same one-record-per-read-structure invariant (issue #773), and the serial oracle never used that function. This drops extract's `unified_pipeline` imports to a single still-referenced symbol (`fastq_out_of_sync_error`).

## Suggested reading order

1. `src/lib/commands/extract.rs` — `to_extract_options`, `execute_chain`, the `execute()` dispatch, and the shared `detect_encoding_and_open_fastq_readers` / `open_fastq_input_readers` helpers (the deletions are the bulk of the diff here).
2. `src/lib/pipeline/chains/source_spec.rs` — the `InterleavedFastq` variant + constructor.
3. `src/lib/pipeline/chains/builder.rs` — `open_source` (`open_fastq_source` helper), `PendingSource::Fastq`, the `add_source` topology routing, and `add_extract`'s encoding override.
4. The `steps/source/*` error-message changes and the tests.

## Testing

Chain-vs-serial-oracle parity tests with fixed-value anchors — one for the RX/RG path and one covering the CB/CY, BC/QT, QX, `--single-tag`, and `--annotate-read-names` branches — plus `--threads 1` coverage and directional out-of-sync assertions on the shared steps. The existing multithreaded-equivalence, interleaved-equivalence, mismatched-pair, and read-name-limit tests now exercise the chain path. Full local gate green (fmt, clippy `-D warnings`, doc, `--no-default-features`/`--all-features`, and the complete test suite).

## Deferred follow-ups

- The legacy FASTQ pipeline driver (`run_fastq_pipeline` / `FastqPipelineConfig` and `test_fastq_pipeline_memory_backpressure.rs`) is now dead but lives in `src/lib/unified_pipeline/`, whose removal is a separate planned phase — left for that cleanup rather than a piecemeal deletion here.
- Per-file BGZF decode parallelism vs the legacy all-BGZF pipeline-internal decode is a perf question to benchmark, not a correctness one; this PR is gated on byte-parity like the prior sibling cutovers.
- Relocating `QualityEncoding` + the FASTQ-open helpers out of `commands::extract` into a shared source module would tidy the pipeline→commands dependency, but follows the pre-existing pattern and is better done as its own sweep.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: output changes are intended to remain pinned by serial parity tests; unsafe changes: none; memory, queue, and thread/backpressure policy changes: interleaved inputs force round-robin processing.

Fix: route explicit `--threads` extraction through the declarative chain while retaining serial processing as the parity oracle.

- Add `SourceSpec::InterleavedFastq` with validation and runall support.
- Share FASTQ reader setup, quality detection, stdin replay, compression, and CRC handling.
- Preserve complete extraction error context.
- Improve directional R1/R2 and stream EOF diagnostics.
- Remove the legacy pipeline extraction implementation and unused types.
- Add integration coverage for threaded output parity, interleaved and mismatched inputs, read-name limits, CRC behavior, quality detection, and extraction option branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->