### PR TITLE
fix(group): filter secondary/supplementary reads by flag, not UNKNOWN_REF

### DIFF
--- a/src/lib/grouper.rs
+++ b/src/lib/grouper.rs
@@ -368,10 +368,14 @@ impl MemoryEstimate for RawPositionGroup {
 /// [`DecodedRecord`]s with keys from some other source is likewise not
 /// validated; both in-tree producers go through `compute_group_key_from_raw`.
 ///
-/// By default, secondary/supplementary reads are skipped (they have UNKNOWN
-/// position keys). Use [`with_secondary_supplementary`](Self::with_secondary_supplementary)
-/// to include them — they are coalesced by `name_hash` into the group of their
-/// adjacent primary read (requires template-coordinate sorted input).
+/// By default, secondary/supplementary reads are skipped — filtered by their
+/// `SECONDARY`/`SUPPLEMENTARY` flags (not by position key: a `tc` tag on
+/// template-coordinate input gives them a *resolved* key, so the key alone no
+/// longer identifies them — see [`Self::add_record`]). Use
+/// [`with_secondary_supplementary`](Self::with_secondary_supplementary) to
+/// include them — they are then coalesced into their template's group by QNAME
+/// adjacency to the preceding accumulated record (requires template-coordinate
+/// sorted input so each template's reads are contiguous).
 pub struct RecordPositionGrouper {
     /// Current position key being accumulated (tuple for fast comparison).
     current_position_key: Option<PositionKeyTuple>,
@@ -380,9 +384,10 @@ pub struct RecordPositionGrouper {
     /// Records at the current position.
     current_records: Vec<DecodedRecord>,
     /// Whether to include secondary and supplementary reads in groups.
-    /// When true, secondary/supplementary reads (which have UNKNOWN position keys)
-    /// are kept and coalesced by `name_hash` into the group of their primary read.
-    /// When false (default), they are skipped.
+    /// When true, secondary/supplementary reads are kept and coalesced into their
+    /// template's group by QNAME adjacency to the preceding accumulated record.
+    /// When false (default), they are filtered by their `SECONDARY`/`SUPPLEMENTARY`
+    /// flags in [`Self::add_record`].
     include_secondary_supplementary: bool,
 }
 
@@ -402,8 +407,16 @@ impl RecordPositionGrouper {
 
     /// Create a record-level position grouper that includes secondary/supplementary reads.
     ///
-    /// Secondary/supplementary reads have UNKNOWN position keys and are coalesced
-    /// by `name_hash` into the group of their adjacent primary read.
+    /// Secondary/supplementary reads may carry a name-only key or, on
+    /// template-coordinate input carrying a `tc` tag, a resolved position key.
+    /// Either way they are coalesced into their template's group by QNAME match
+    /// against the preceding accumulated record — coalescing is driven by that
+    /// stream adjacency, independent of whether the key is resolved. A
+    /// secondary/supplementary read that is not stream-adjacent to a same-template
+    /// record would start its own group, so this relies on template-coordinate
+    /// ordering keeping each template's reads contiguous. Used by `fgumi dedup`,
+    /// which must retain these reads so its duplicate flag propagates across split
+    /// alignments.
     #[must_use]
     pub fn with_secondary_supplementary() -> Self {
         Self { include_secondary_supplementary: true, ..Self::new() }
@@ -467,10 +480,23 @@ impl RecordPositionGrouper {
 
     /// Process a single decoded record, potentially emitting a completed group.
     fn process_record(&mut self, decoded: DecodedRecord) -> io::Result<Option<RawPositionGroup>> {
-        // Skip secondary and supplementary reads (they have UNKNOWN ref_id1)
-        // unless configured to include them (for dedup, which needs them in templates).
-        if decoded.key.ref_id1 == GroupKey::UNKNOWN_REF && !self.include_secondary_supplementary {
-            return Ok(None);
+        // Skip secondary and supplementary reads unless configured to include them
+        // (dedup needs them in templates so its duplicate flag propagates across
+        // split alignments). Filter by the record's own flags rather than by
+        // `ref_id1 == UNKNOWN_REF`: a `tc` tag (stamped by `fgumi zipper` for
+        // template-coordinate ordering) gives a secondary/supplementary read a
+        // *resolved* position key, so `UNKNOWN_REF` no longer identifies it. Left
+        // unfiltered, such a record enters position grouping and — when its key
+        // differs from a neighboring group's — breaks the streaming grouper's
+        // contiguity assumption, splitting one molecule across groups and inflating
+        // the reported molecule count (issue #901). The `UNKNOWN_REF` skip is
+        // retained for records that resolve to a name-only key for other reasons.
+        if !self.include_secondary_supplementary {
+            let record = decoded.record();
+            let is_secondary_or_supplementary = record.is_secondary() || record.is_supplementary();
+            if is_secondary_or_supplementary || decoded.key.ref_id1 == GroupKey::UNKNOWN_REF {
+                return Ok(None);
+            }
         }
 
         // Validate the mate position resolved during decode (i.e. the MC tag was usable)
@@ -1167,6 +1193,17 @@ mod tests {
         DecodedRecord::from_raw_bytes(b.build(), key)
     }
 
+    /// Helper: create a secondary/supplementary `DecodedRecord` carrying a
+    /// *resolved* position key (real `ref_id1`), as `tc`-tag keying produces for
+    /// template-coordinate input. `flag` selects SECONDARY or SUPPLEMENTARY, and
+    /// `name` sets the read name (its match against a preceding record's name
+    /// drives the dedup-mode QNAME coalescing path).
+    fn make_sec_supp_decoded(flag: u16, name: &[u8], key: GroupKey) -> DecodedRecord {
+        let mut b = RawSamBuilder::new();
+        b.read_name(name).sequence(b"ACGT").qualities(&[30; 4]).flags(flag);
+        DecodedRecord::from_raw_bytes(b.build(), key)
+    }
+
     #[test]
     fn test_record_position_grouper_empty() {
         let mut grouper = RecordPositionGrouper::new();
@@ -1256,6 +1293,117 @@ mod tests {
         let final_group =
             grouper.finish().expect("finish should succeed").expect("should emit final group");
         assert_eq!(final_group.records.len(), 1); // Only primary kept
+    }
+
+    /// Regression test for issue #901: a secondary/supplementary read that carries
+    /// a `tc` tag (stamped by `fgumi zipper` / `fgumi sort` for template-coordinate
+    /// ordering) receives a *resolved* position key — a real `ref_id1`, not the
+    /// `UNKNOWN_REF` the grouper's original skip keyed off. If such a record is not
+    /// filtered it enters position grouping, and when its key differs from a
+    /// neighboring group's it breaks the streaming grouper's contiguity assumption,
+    /// splitting one molecule's reads across two position groups (inflating the
+    /// reported molecule count). It must be dropped by its flags regardless of its
+    /// key, matching fgbio and the documented `fgumi group` behavior.
+    #[rstest]
+    #[case::secondary(raw_flags::SECONDARY)]
+    #[case::supplementary(raw_flags::SUPPLEMENTARY)]
+    fn test_record_position_grouper_skips_tc_keyed_secondary_supplementary(
+        #[case] flag: u16,
+        // The sec/supp read must be dropped by its flags whether its resolved
+        // position key DIFFERS from the primaries' (500 — left unfiltered it would
+        // split the group by breaking stream contiguity) or MATCHES them (100 —
+        // left unfiltered it would instead merge in and inflate the group's record
+        // count). Both must yield the same clean result, so a future skip that is
+        // conditional on the key (e.g. only when it differs) is caught here.
+        #[values(500, 100)] sec_supp_pos: i32,
+    ) {
+        let mut grouper = RecordPositionGrouper::new();
+
+        // Two primary reads at the same position (one molecule's worth of reads),
+        // with a tc-keyed sec/supp read placed between them in the stream. The
+        // distinct name hashes keep the sec/supp read off the unmapped-mate
+        // name-match path so this exercises the flag-based filter specifically.
+        let key_primary1 = GroupKey::single(0, 100, 0, 0, 0, 11111);
+        let key_primary2 = GroupKey::single(0, 100, 0, 0, 0, 22222);
+        let sec_supp_key = GroupKey::single(0, sec_supp_pos, 0, 0, 0, 99999); // real ref_id1
+
+        let primary1 = make_decoded(key_primary1, false, false, None);
+        let sec_supp = make_sec_supp_decoded(flag, b"read2", sec_supp_key);
+        let primary2 = make_decoded(key_primary2, false, false, None);
+
+        let mut groups = grouper
+            .add_records(vec![primary1, sec_supp, primary2])
+            .expect("add_records should succeed");
+        if let Some(final_group) = grouper.finish().expect("finish should succeed") {
+            groups.push(final_group);
+        }
+
+        // Both primaries stay in a single position group; the sec/supp read is
+        // dropped entirely — it neither forms its own group, splits the primaries
+        // across two groups, nor merges into their group.
+        assert_eq!(
+            groups.len(),
+            1,
+            "a filtered secondary/supplementary read must not split the primaries across groups"
+        );
+        assert_eq!(
+            groups[0].records.len(),
+            2,
+            "both primaries must remain in one group, with the sec/supp read excluded"
+        );
+        for group in &groups {
+            for rec in &group.records {
+                let record = rec.record();
+                assert!(
+                    !record.is_secondary() && !record.is_supplementary(),
+                    "no secondary/supplementary record should appear in a group"
+                );
+            }
+        }
+    }
+
+    /// The dedup path (`with_secondary_supplementary`) must do the opposite of the
+    /// `group` path: it *retains* secondary/supplementary reads, coalescing them
+    /// into their template's group so the duplicate flag propagates across split
+    /// alignments. This pins that retention contract for a tc-keyed (resolved-key)
+    /// sec/supp read, so a future change that hoists the flag filter above the
+    /// `!include_secondary_supplementary` guard — silently dropping them for dedup
+    /// — fails here rather than passing an `is_ok()`-only assertion.
+    #[rstest]
+    #[case::secondary(raw_flags::SECONDARY)]
+    #[case::supplementary(raw_flags::SUPPLEMENTARY)]
+    fn test_record_position_grouper_dedup_mode_retains_tc_keyed_secondary_supplementary(
+        #[case] flag: u16,
+    ) {
+        let mut grouper = RecordPositionGrouper::with_secondary_supplementary();
+
+        // Primary then a same-QNAME sec/supp read carrying a *resolved* key that
+        // differs from the primary's position. Coalescing is by QNAME adjacency to
+        // the preceding record, so both must share read name and name_hash.
+        let name_hash = 42424;
+        let primary_key = GroupKey::single(0, 100, 0, 0, 0, name_hash);
+        let sec_supp_key = GroupKey::single(0, 500, 0, 0, 0, name_hash); // resolved, != primary
+
+        let primary = make_decoded(primary_key, false, false, None); // read name "read1"
+        let sec_supp = make_sec_supp_decoded(flag, b"read1", sec_supp_key);
+
+        let mut groups =
+            grouper.add_records(vec![primary, sec_supp]).expect("add_records should succeed");
+        if let Some(final_group) = grouper.finish().expect("finish should succeed") {
+            groups.push(final_group);
+        }
+
+        // The sec/supp read is retained in the primary's group (not dropped, not
+        // split into its own group).
+        assert_eq!(groups.len(), 1, "the sec/supp read must coalesce into the primary's group");
+        assert_eq!(groups[0].records.len(), 2, "dedup mode must retain the sec/supp read");
+        assert!(
+            groups[0].records.iter().any(|rec| {
+                let record = rec.record();
+                record.is_secondary() || record.is_supplementary()
+            }),
+            "the retained record must be the secondary/supplementary read"
+        );
     }
 
     #[test]

--- a/tests/integration/test_dedup_command.rs
+++ b/tests/integration/test_dedup_command.rs
@@ -39,7 +39,17 @@ fn create_sorted_bam(path: &Path, records: Vec<RawRecord>) {
 /// Create a group of paired-end reads at the same position with the same UMI
 /// (simulating PCR duplicates).
 fn create_duplicate_group(base_name: &str, umi: &str, count: usize, start: i32) -> Vec<RawRecord> {
-    create_duplicate_group_inner(base_name, umi, count, start, None, 60)
+    create_duplicate_group_inner(base_name, umi, count, start, None, 60, 30)
+}
+
+/// A single paired-end template (R1 + R2) at `start` with UMI `umi`, every base
+/// at quality `base_qual`. `dedup` scores a template by the sum of its primary
+/// reads' base qualities, so building several same-coordinate/same-UMI templates
+/// with *distinct* `base_qual`s makes which one wins the representative slot (and
+/// which are marked duplicate) deterministic — the unique maximum wins, with no
+/// score tie whose resolution would depend on stream order.
+fn create_template_qual(name: &str, umi: &str, start: i32, base_qual: u8) -> Vec<RawRecord> {
+    create_duplicate_group_inner(name, umi, 1, start, None, 60, base_qual)
 }
 
 /// Like [`create_duplicate_group`] but with an explicit `mapq`, so a fixture can
@@ -52,7 +62,7 @@ fn create_duplicate_group_mapq(
     start: i32,
     mapq: u8,
 ) -> Vec<RawRecord> {
-    create_duplicate_group_inner(base_name, umi, count, start, None, mapq)
+    create_duplicate_group_inner(base_name, umi, count, start, None, mapq, 30)
 }
 
 /// Shared implementation for [`create_duplicate_group`] and
@@ -68,6 +78,7 @@ fn create_duplicate_group_inner(
     start: i32,
     rg_id: Option<&str>,
     mapq: u8,
+    base_qual: u8,
 ) -> Vec<RawRecord> {
     let mut records = Vec::new();
     for i in 0..count {
@@ -77,7 +88,7 @@ fn create_duplicate_group_inner(
             let mut b = SamBuilder::new();
             b.read_name(name.as_bytes())
                 .sequence(b"ACGTACGT")
-                .qualities(&[30; 8])
+                .qualities(&[base_qual; 8])
                 .flags(flags::PAIRED | flags::FIRST_SEGMENT)
                 .ref_id(0)
                 .pos(start - 1)
@@ -98,7 +109,7 @@ fn create_duplicate_group_inner(
             let mut b = SamBuilder::new();
             b.read_name(name.as_bytes())
                 .sequence(b"ACGTACGT")
-                .qualities(&[30; 8])
+                .qualities(&[base_qual; 8])
                 .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
                 .ref_id(0)
                 .pos(start + 99)
@@ -404,7 +415,7 @@ fn create_duplicate_group_with_rg(
     start: i32,
     rg_id: &str,
 ) -> Vec<RawRecord> {
-    create_duplicate_group_inner(base_name, umi, count, start, Some(rg_id), 60)
+    create_duplicate_group_inner(base_name, umi, count, start, Some(rg_id), 60, 30)
 }
 
 /// Shared implementation for [`create_sorted_bam`]: writes `records` against the
@@ -2303,5 +2314,171 @@ fn test_dedup_threaded_duplication_ladder_parity() {
         read_deduped_records(&oracle_out),
         read_deduped_records(&chain_out),
         "output records diverged between the chain and non-chain paths"
+    );
+}
+
+/// Complement to the `group` #901 regression, on a fixture that exercises the
+/// full PCR-duplicate marking contract rather than mere retention. `dedup` must:
+///
+/// 1. Mark the correct read in each duplicate family: the representative (highest
+///    base-quality template) is kept unflagged and every other template in the
+///    family gets the `PCR/optical duplicate` flag (`0x400`).
+/// 2. *Retain* a `tc`-keyed secondary/supplementary read (the opposite of `group`,
+///    which filters it) and propagate its primary's duplicate status onto it —
+///    guarding against a regression that hoists the secondary/supplementary filter
+///    above the `include_secondary_supplementary` guard, or that marks primaries
+///    but skips the coalesced non-primary record.
+///
+/// The fixture is 10 paired templates across four independent duplicate families
+/// (distinct coordinate + UMI, so they never cross-contaminate) of sizes 1, 4, 3,
+/// and 2. Within each family every template gets a *distinct* base quality, so the
+/// representative is the unique maximum — deterministic, with no score tie whose
+/// resolution would depend on stream order. Every one of the 20 primary reads is
+/// asserted to carry exactly the flag its family membership dictates. The flagged
+/// alignment is attached to a marked duplicate (`famD_dup`), so its output flag
+/// pins the propagation this test's ancestor could not: the single-template
+/// fixture it replaced never marked any record duplicate.
+#[rstest]
+#[case::secondary(flags::SECONDARY)]
+#[case::supplementary(flags::SUPPLEMENTARY)]
+fn test_dedup_marks_families_and_flags_tc_keyed_secondary_supplementary(#[case] extra_flag: u16) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    // Four duplicate families at distinct coordinates and UMIs, of sizes 1/4/3/2.
+    // Each entry is (UMI, start position, templates), where a template is a
+    // (QNAME base, base quality) pair — `create_template_qual` builds one template
+    // per pair, named `{base}_0`. Within a family the unique top quality (40) is the
+    // representative and the rest (35/30/25) are marked duplicate.
+    #[expect(clippy::type_complexity, reason = "an inline fixture table of duplicate families")]
+    let families: [(&str, i32, &[(&str, u8)]); 4] = [
+        // Family A: a lone template — a singleton is never a duplicate.
+        ("AAAAAAAA", 100, &[("famA_rep", 40)]),
+        // Family B: 4 templates -> 1 kept + 3 marked.
+        (
+            "CCCCCCCC",
+            500,
+            &[("famB_rep", 40), ("famB_dup0", 35), ("famB_dup1", 30), ("famB_dup2", 25)],
+        ),
+        // Family C: 3 templates -> 1 kept + 2 marked.
+        ("GGGGGGGG", 900, &[("famC_rep", 40), ("famC_dup0", 35), ("famC_dup1", 30)]),
+        // Family D: 2 templates -> 1 kept + 1 marked. This is the highest
+        // coordinate, so family D's reads sort last; the flagged alignment below
+        // (own position 5000, past every primary) sorts to the very end and
+        // coalesces — by QNAME adjacency — onto whichever family-D primary sorts
+        // last. `famD_dup` is named so it sorts after `famD_rep` (the
+        // template-coordinate tie-break below the shared coordinate is `name_hash`,
+        // not lexicographic), making the marked duplicate the trailing record. If
+        // that ordering ever changes, the flagged read coalesces onto the wrong
+        // primary (or is dropped) and the assertions below fail loudly.
+        ("TTTTTTTT", 1300, &[("famD_rep", 40), ("famD_dup", 35)]),
+    ];
+
+    // Names that must be kept (representatives) vs. marked duplicate, derived from
+    // the family table so the expectation and the fixture cannot drift.
+    let mut expected_kept: Vec<String> = Vec::new();
+    let mut expected_duplicate: Vec<String> = Vec::new();
+    let mut records = Vec::new();
+    for (umi, start, templates) in families {
+        // Representative = the unique maximum base quality in the family.
+        let rep_qual = templates.iter().map(|&(_, q)| q).max().expect("family is non-empty");
+        for &(name, qual) in templates {
+            records.extend(create_template_qual(name, umi, start, qual));
+            let read_name = format!("{name}_0");
+            if qual == rep_qual {
+                expected_kept.push(read_name);
+            } else {
+                expected_duplicate.push(read_name);
+            }
+        }
+    }
+
+    // A `tc`-keyed secondary/supplementary alignment of `famD_dup` (a marked
+    // duplicate). Its `tc` tag carries family D's template coordinate — R1 fwd
+    // unclipped-5' = 1300, R2 rev unclipped-5' = 1407 -> [0,1300,0,0,1407,1] — the
+    // resolved key dedup uses to place it in family D's molecule. dedup coalesces
+    // it into `famD_dup`'s template, where it must inherit that template's
+    // duplicate flag.
+    let supp_primary = "famD_dup_0";
+    let mut supp = SamBuilder::new();
+    supp.read_name(supp_primary.as_bytes())
+        .sequence(b"ACGTACGT")
+        .qualities(&[30; 8])
+        .flags(flags::PAIRED | flags::FIRST_SEGMENT | extra_flag)
+        .ref_id(0)
+        .pos(5000)
+        .mapq(60)
+        .cigar_ops(&[8u32 << 4])
+        .mate_ref_id(0)
+        .mate_pos(1399)
+        .add_string_tag(SamTag::RX, b"TTTTTTTT")
+        .add_string_tag(SamTag::MC, b"8M")
+        .add_array_i32(SamTag::TC, &[0, 1300, 0, 0, 1407, 1]);
+    records.push(supp.build());
+
+    create_sorted_bam(&input_bam, records);
+    let cmd = MarkDuplicates::try_parse_from([
+        "dedup",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--strategy",
+        "identity",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse dedup args");
+    cmd.execute("fgumi dedup").expect("dedup should succeed");
+
+    // Collect the full output: primary reads keyed by QNAME -> the duplicate flag on
+    // each of that template's records (R1 and R2 must agree), plus the retained
+    // secondary/supplementary alignment.
+    let mut reader = bam::io::Reader::new(fs::File::open(&output_bam).unwrap());
+    let header = reader.read_header().unwrap();
+    let mut primary_flags: std::collections::HashMap<String, Vec<bool>> =
+        std::collections::HashMap::new();
+    let mut secondary_supplementary: Vec<(String, bool)> = Vec::new();
+    let mut total = 0usize;
+    for record in reader.record_bufs(&header) {
+        let record = record.expect("read dedup output record");
+        let flag = record.flags();
+        let name = record.name().map(ToString::to_string).expect("output record has a name");
+        total += 1;
+        if flag.is_secondary() || flag.is_supplementary() {
+            secondary_supplementary.push((name, flag.is_duplicate()));
+        } else {
+            primary_flags.entry(name).or_default().push(flag.is_duplicate());
+        }
+    }
+
+    // 10 templates * 2 mates + 1 flagged alignment, nothing removed (mark mode).
+    assert_eq!(total, 21, "mark mode retains all 20 primary reads plus the flagged alignment");
+    assert_eq!(primary_flags.len(), 10, "every one of the 10 templates must be present by QNAME");
+
+    // Every primary template carries exactly the flag its family membership dictates,
+    // on BOTH mates — checked read-by-read, not merely by count.
+    for name in &expected_kept {
+        assert_eq!(
+            primary_flags.get(name).map(Vec::as_slice),
+            Some([false, false].as_slice()),
+            "representative {name} must keep both mates unflagged"
+        );
+    }
+    for name in &expected_duplicate {
+        assert_eq!(
+            primary_flags.get(name).map(Vec::as_slice),
+            Some([true, true].as_slice()),
+            "duplicate {name} must have the PCR-duplicate flag on both mates"
+        );
+    }
+
+    // The flagged alignment is retained, belongs to its `famD_dup` primary, and
+    // inherits that primary's duplicate flag — the propagation this test pins.
+    assert_eq!(
+        secondary_supplementary,
+        vec![(supp_primary.to_string(), true)],
+        "the tc-keyed sec/supp read must be retained as {supp_primary}'s and marked duplicate"
     );
 }

--- a/tests/integration/test_group_command.rs
+++ b/tests/integration/test_group_command.rs
@@ -19,6 +19,8 @@ use crate::helpers::bam_generator::{
     create_minimal_header, create_query_grouped_header, create_umi_family,
     create_umi_family_at_pos, to_record_buf,
 };
+use fgumi_lib::sam::SamTag;
+use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 
 /// Test that the group command properly writes metrics in the new format.
 #[test]
@@ -601,4 +603,189 @@ fn test_group_chain_threads4_matches_single_threaded_multi_batch() {
         single, threads4,
         "chain (--threads 4) output must match the single-threaded oracle record-for-record across batches",
     );
+}
+
+/// End-to-end regression for issue #901: a secondary/supplementary read carrying
+/// a `tc` tag (stamped by `fgumi zipper` for template-coordinate ordering) is
+/// documented as filtered from grouping, so it must not change the molecule
+/// count. Before the fix, such a read received a resolved position key and, being
+/// interleaved between two same-UMI reads of one molecule, split that molecule
+/// across position groups — inflating the reported molecule count and diverging
+/// from fgbio. This pins the reported symptom (distinct MI count), not just the
+/// internal position-group shape the unit tests cover.
+///
+/// Records are written in a deliberately split-inducing order (the tc-keyed
+/// supplementary sits between the two primaries); `group` trusts the declared
+/// template-coordinate order and does not re-sort, so this reproduces the
+/// interleaving that real template-coordinate sort can produce.
+fn create_supplementary_split_bam(path: &PathBuf) {
+    let header = create_minimal_header("chr1", 20000);
+    let mut writer =
+        bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
+    writer.write_header(&header).expect("Failed to write header");
+
+    // Two single-read "molecules" sharing one UMI at the same position — one
+    // molecule that must group together.
+    let mut records = Vec::new();
+    records.extend(create_umi_family_at_pos("AAAAAAAA", 1, "b1", "ACGTACGT", 30, 200));
+
+    // A supplementary read carrying the same UMI and a `tc` tag whose resolved
+    // template coordinate (pos 1) differs from the primaries' (pos 200).
+    let mut supp = SamBuilder::new();
+    supp.read_name(b"supp")
+        .ref_id(0)
+        .pos(4999)
+        .mapq(60)
+        .flags(flags::SUPPLEMENTARY)
+        .cigar_ops(&[8u32 << 4]) // 8M
+        .sequence(b"ACGTACGT")
+        .qualities(&[30u8; 8]);
+    supp.add_string_tag(SamTag::RX, b"AAAAAAAA");
+    supp.add_array_i32(SamTag::TC, &[0, 1, 0, 0, 1, 0]);
+    records.push(supp.build());
+
+    records.extend(create_umi_family_at_pos("AAAAAAAA", 1, "b2", "ACGTACGT", 30, 200));
+
+    for record in &records {
+        writer
+            .write_alignment_record(&header, &to_record_buf(record))
+            .expect("Failed to write record");
+    }
+    writer.try_finish().expect("Failed to finish BAM");
+}
+
+/// Build the paired-end analogue of [`create_supplementary_split_bam`]: two
+/// paired templates sharing one UMI at the same 5' positions (one molecule), with
+/// a `tc`-keyed supplementary interleaved between them. This mirrors real client
+/// data, where the reads are paired and carry `MC` tags.
+fn create_paired_supplementary_split_bam(path: &PathBuf) {
+    let header = create_minimal_header("chr1", 20000);
+    let mut writer =
+        bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
+    writer.write_header(&header).expect("Failed to write header");
+
+    // One paired template (R1 fwd @200, R2 rev @400) with MC tags, sharing a UMI.
+    let paired = |name: &[u8]| -> Vec<RawRecord> {
+        let mut r1 = SamBuilder::new();
+        r1.read_name(name)
+            .ref_id(0)
+            .pos(199)
+            .mapq(60)
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .mate_ref_id(0)
+            .mate_pos(399)
+            .cigar_ops(&[8u32 << 4])
+            .sequence(b"ACGTACGT")
+            .qualities(&[30u8; 8])
+            .add_string_tag(SamTag::RX, b"AAAAAAAA")
+            .add_string_tag(SamTag::MC, b"8M");
+        let mut r2 = SamBuilder::new();
+        r2.read_name(name)
+            .ref_id(0)
+            .pos(399)
+            .mapq(60)
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .mate_ref_id(0)
+            .mate_pos(199)
+            .cigar_ops(&[8u32 << 4])
+            .sequence(b"ACGTACGT")
+            .qualities(&[30u8; 8])
+            .add_string_tag(SamTag::RX, b"AAAAAAAA")
+            .add_string_tag(SamTag::MC, b"8M");
+        vec![r1.build(), r2.build()]
+    };
+
+    // A supplementary carrying the same UMI and a `tc` tag whose resolved
+    // template coordinate differs from the primaries', written between the two
+    // templates so it would break contiguity if not filtered.
+    let mut supp = SamBuilder::new();
+    supp.read_name(b"supp")
+        .ref_id(0)
+        .pos(4999)
+        .mapq(60)
+        .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::SUPPLEMENTARY)
+        .mate_ref_id(0)
+        .mate_pos(399)
+        .cigar_ops(&[8u32 << 4])
+        .sequence(b"ACGTACGT")
+        .qualities(&[30u8; 8])
+        .add_string_tag(SamTag::RX, b"AAAAAAAA")
+        .add_array_i32(SamTag::TC, &[0, 1, 0, 0, 1, 0]);
+
+    let mut records = paired(b"pair1");
+    records.push(supp.build());
+    records.extend(paired(b"pair2"));
+
+    for record in &records {
+        writer
+            .write_alignment_record(&header, &to_record_buf(record))
+            .expect("Failed to write record");
+    }
+    writer.try_finish().expect("Failed to finish BAM");
+}
+
+/// Shared oracle for the #901 regression: grouped output must contain exactly one
+/// molecule (one distinct MI) and no secondary/supplementary records.
+fn assert_single_molecule_no_secondary(
+    records: &[noodles::sam::alignment::RecordBuf],
+    expected_qnames: &[&str],
+) {
+    use noodles::sam::alignment::record_buf::data::field::Value;
+    let mi = SamTag::MI.to_noodles_tag();
+    let distinct_mi: std::collections::BTreeSet<String> = records
+        .iter()
+        .filter_map(|r| match r.data().get(&mi) {
+            Some(Value::String(s)) => Some(s.to_string()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        distinct_mi.len(),
+        1,
+        "the tc-keyed supplementary must not split the single molecule (got MIs {distinct_mi:?})"
+    );
+    // Assert record identity, not just the count: a regression that dropped one
+    // of the two primaries would still leave a single MI and no flagged record,
+    // so pin the exact set of output QNAMEs.
+    let output_qnames: std::collections::BTreeSet<String> =
+        records.iter().filter_map(|r| r.name().map(ToString::to_string)).collect();
+    let expected: std::collections::BTreeSet<String> =
+        expected_qnames.iter().map(|s| (*s).to_string()).collect();
+    assert_eq!(
+        output_qnames, expected,
+        "both primaries must survive: expected QNAMEs {expected:?}, got {output_qnames:?}"
+    );
+    for r in records {
+        let flag = r.flags();
+        assert!(
+            !flag.is_secondary() && !flag.is_supplementary(),
+            "no secondary/supplementary record should appear in grouped output"
+        );
+    }
+}
+
+/// Regression for issue #901 across both the single-threaded fast path and the
+/// `--threads N` chain path, for single-end and paired input. A `tc`-keyed
+/// supplementary interleaved between two same-UMI reads of one molecule must not
+/// split it or appear in the output, on every path.
+#[rstest]
+#[case::single_end(false)]
+#[case::paired(true)]
+fn test_group_supplementary_does_not_inflate_molecule_count(
+    #[case] paired: bool,
+    #[values(&[] as &[&str], &["--threads", "2"])] extra: &[&str],
+) {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    if paired {
+        create_paired_supplementary_split_bam(&input_bam);
+    } else {
+        create_supplementary_split_bam(&input_bam);
+    }
+
+    let records = run_group_records(temp_dir.path(), "supp_split", &input_bam, extra);
+    // Single-end input names its two primaries `b1_0`/`b2_0`; the paired input
+    // names its two templates `pair1`/`pair2` (R1 and R2 share the QNAME).
+    let expected_qnames: &[&str] = if paired { &["pair1", "pair2"] } else { &["b1_0", "b2_0"] };
+    assert_single_molecule_no_secondary(&records, expected_qnames);
 }


### PR DESCRIPTION
## Summary
Fixes #901: `fgumi group` over-counts molecules when supplementary/secondary alignments are present in the recommended `fgumi sort` (template-coordinate) → `group` workflow, diverging from `fgbio GroupReadsByUmi`.

## Root cause
`RecordPositionGrouper::process_record` skipped secondary/supplementary reads only when `key.ref_id1 == GroupKey::UNKNOWN_REF` — using "UNKNOWN key" as a *proxy* for "is secondary/supplementary."

#529 ("fix(sort,dedup): place secondary/supplementary reads at their exact template coordinate via tc") then taught the shared `compute_group_key_from_raw` to build a **resolved** position key from the `tc` tag (stamped by `fgumi zipper`) for secondary/supplementary reads — deliberately, so `sort` and `dedup` place them at their primary pair's exact coordinate. But `group` shares that decode path, so its `UNKNOWN_REF` proxy silently stopped matching: `tc`-keyed secondary/supplementary reads now have a real `ref_id1`, bypass the skip, and enter the single-position streaming grouper. When such a read's key falls between a neighboring position group's records, it breaks the grouper's contiguity assumption and splits one molecule across two position groups, inflating the distinct-`MI` count. fgbio filters these reads by flag before sorting, so it never sees them — hence the divergence.

This was a side effect of #529 on `group`; `group` always intended to filter these reads (its docs: "Records are filtered out if flagged as either secondary or supplementary"), while `sort`/`dedup` intentionally keep and place them.

## Affected versions
Introduced by #529 (merged 2026-07-15). Affects **v0.5.0, v0.6.0, and v0.7.0** (current); v0.4.0 and earlier are unaffected. Reported against v0.7.0.

## Fix
Filter secondary/supplementary reads by their `SECONDARY`/`SUPPLEMENTARY` flags (matching fgbio's `filterNot(r => r.secondary || r.supplementary)` and the command's documented behavior). The flag check is OR-ed with the retained `UNKNOWN_REF` skip, so the change is strictly additive: unmapped-mate name-hash coalescing and the `dedup` `with_secondary_supplementary` path (which must retain these reads, per #529) are unchanged — the fix is gated on `!include_secondary_supplementary`, which is `false` only for dedup.

## Tests
- **Unit (grouper):** `tc`-keyed sec/supp reads with both a differing and a matching position key are dropped in group mode (secondary and supplementary); plus the dedup-mode (`with_secondary_supplementary`) retention contract.
- **Integration (group):** a `tc`-keyed supplementary interleaved between two same-UMI reads yields one molecule and no sec/supp in output — across **single-end and paired** input and both the **single-threaded and `--threads` chain** paths (verified to fail without the fix).
- **Integration (dedup):** a `tc`-keyed secondary/supplementary read is **retained** and emitted at its primary's template coordinate, confirming the fix does not touch dedup's opposite contract.
- Full suite (4374 tests) green.

Closes #901


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: changes `group` and `dedup` output, pinned by SAM `SECONDARY`/`SUPPLEMENTARY` flags and `tc`-resolved keys; `unsafe`: none; memory, queue, and threading policy: none.

Fix: `group` now excludes secondary and supplementary records, while `dedup` retains them.

Regression tests cover single-end, paired-end, single-threaded, threaded, and `tc`-resolved records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->