### PR TITLE
fix(downsample): group by molecule by default, add --per-strand opt-out (#904)

### DIFF
--- a/src/lib/commands/downsample.rs
+++ b/src/lib/commands/downsample.rs
@@ -2,6 +2,8 @@
 //!
 //! This tool reads a BAM file that has been processed by fgumi group (or fgbio `GroupReadsByUmi`),
 //! uniformly samples UMI families based on the MI tag, and outputs kept reads directly to a BAM file.
+//! By default the two duplex strands of a molecule (`<base>/A` and `<base>/B`) are sampled as one
+//! family; `--per-strand` restores the legacy behavior of sampling each raw MI tag independently.
 //!
 //! Requires input BAM to be in template-coordinate order (from group).
 
@@ -24,6 +26,7 @@ use std::path::{Path, PathBuf};
 
 use crate::commands::command::Command;
 use crate::commands::common::{BamIoOptions, CompressionOptions, reject_output_collisions};
+use crate::umi::extract_mi_base;
 
 /// Downsample a BAM file by UMI family using streaming.
 ///
@@ -62,10 +65,20 @@ design, and differs from `DownsampleSam` in several deliberate ways:
 Because the sampling unit, decision function, and RNG all differ, output is intentionally not
 bit-identical to `DownsampleSam`; only a statistically-equivalent fraction of families is kept.
 
+DUPLEX DATA: the `paired` grouping strategy tags the two strands of a molecule `<base>/A` and
+`<base>/B`. By default downsample reduces each MI to its molecule base (the same last-`/`
+truncation `group` and `duplex` use) and samples whole molecules — both strands kept or dropped
+together — so duplex families survive at the intended fraction. Simplex MIs (no `/A`,`/B` suffix)
+are a no-op under this rule and unaffected. Pass `--per-strand` to instead sample each raw MI tag
+independently (legacy behavior); on duplex data this collapses duplex families, because a molecule
+then survives as a duplex only with probability fraction^2 — use it only when you deliberately want
+strand-level sampling.
+
 Example usage:
   fgumi downsample -i grouped.bam -o downsampled.bam -f 0.1 --seed 42
   fgumi downsample -i grouped.bam -o kept.bam -f 0.5 --rejects rejected.bam
   fgumi downsample -i grouped.bam -o kept.bam -f 0.1 --histogram-kept kept_hist.txt
+  fgumi downsample -i duplex.grouped.bam -o kept.bam -f 0.1 --per-strand   # legacy per-strand
 "#
 )]
 pub struct Downsample {
@@ -88,6 +101,20 @@ pub struct Downsample {
     /// Validate that MI tags appear in consecutive groups (error if seen non-consecutively)
     #[arg(long = "validate-mi-order", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub validate_mi_order: bool,
+
+    /// Sample by raw MI tag rather than by molecule, sampling each duplex strand independently.
+    ///
+    /// By default downsample groups by molecule: each MI is reduced to its molecule base
+    /// before grouping (the same last-`/` truncation `group`/`duplex` use), so the two
+    /// strands the `paired` (duplex) strategy tags `<base>/A` and `<base>/B` form ONE family
+    /// sharing a single keep/reject draw and are kept or dropped together. Simplex MIs (no
+    /// `/A`,`/B` suffix) have no `/` to strip and are unaffected either way. With this flag
+    /// each raw MI value is a separate family with its own draw — so a duplex molecule
+    /// survives as a duplex only if BOTH strand draws hit (probability `fraction`^2),
+    /// collapsing duplex families at low fractions. Use only when you deliberately want
+    /// strand-level sampling. Off by default.
+    #[arg(long = "per-strand", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
+    pub per_strand: bool,
 
     /// Output file for kept family size histogram
     #[arg(long = "histogram-kept")]
@@ -157,6 +184,13 @@ impl Command for Downsample {
         if self.validate_mi_order {
             info!("MI order validation: enabled");
         }
+        if self.per_strand {
+            info!(
+                "Sampling unit: strand (legacy per-MI sampling; duplex strands sampled independently)"
+            );
+        } else {
+            info!("Sampling unit: molecule (duplex strands /A,/B grouped and sampled together)");
+        }
         // downsample is single-threaded and reads through fgumi-bgzf's decoder
         // (`create_raw_bam_reader_with_opts` with threads=1), so it honors
         // --check-crc/--no-check-crc (#800).
@@ -212,7 +246,7 @@ impl Command for Downsample {
 
         info!("Processing reads...");
 
-        let mut family_iter = FamilyIterator::new(raw_record_iter(reader));
+        let mut family_iter = FamilyIterator::new(raw_record_iter(reader), self.per_strand);
 
         while let Some(family_result) = family_iter.next_family()? {
             let (mi, family) = family_result;
@@ -343,23 +377,30 @@ where
     I: Iterator<Item = Result<RawRecord>>,
 {
     records: std::iter::Peekable<I>,
+    /// When true (`--per-strand`), group by the raw MI tag (legacy). When false
+    /// (default), group by the molecule base MI so a duplex molecule's `<base>/A`
+    /// and `<base>/B` strands fall into one family. See `Downsample::per_strand`.
+    per_strand: bool,
 }
 
 impl<I> FamilyIterator<I>
 where
     I: Iterator<Item = Result<RawRecord>>,
 {
-    fn new(records: I) -> Self {
-        Self { records: records.peekable() }
+    fn new(records: I, per_strand: bool) -> Self {
+        Self { records: records.peekable(), per_strand }
     }
 
-    /// Get the next family of records sharing the same MI tag.
+    /// Get the next family of records sharing the same family key.
     ///
-    /// Returns `Ok(Some((mi_tag`, records))) for each family, or Ok(None) when exhausted.
+    /// The key is the molecule base MI (any trailing `/A`/`/B` duplex-strand suffix
+    /// stripped, so both strands of a molecule fall into one family), or — when
+    /// `per_strand` is set — the raw MI tag. Returns `Ok(Some((key, records)))` for
+    /// each family, or `Ok(None)` when exhausted.
     fn next_family(&mut self) -> Result<Option<(String, Vec<RawRecord>)>> {
-        // Peek at the first record to get the MI tag
-        let mi = match self.records.peek() {
-            Some(Ok(record)) => get_mi_tag(record)?,
+        // Peek at the first record to get the family key
+        let key = match self.records.peek() {
+            Some(Ok(record)) => family_key(record, self.per_strand)?,
             Some(Err(_)) => {
                 // Consume the error — next() is Some because peek() was Some(Err(_))
                 return Err(self.records.next().expect("peek() returned Some").unwrap_err());
@@ -367,16 +408,16 @@ where
             None => return Ok(None),
         };
 
-        // Collect all records with the same MI tag
+        // Collect all records with the same family key
         let mut family = Vec::new();
 
         while let Some(peek_result) = self.records.peek() {
             match peek_result {
                 Ok(record) => {
-                    // Compare the MI against the family key without allocating a
+                    // Compare the key against the family key without allocating a
                     // `String` per record — the family key was already materialized
                     // once above.
-                    if !mi_tag_equals(record, mi.as_bytes())? {
+                    if !family_key_equals(record, key.as_bytes(), self.per_strand)? {
                         break;
                     }
                     // Consume the record — next() is Some because peek() was Some
@@ -389,8 +430,56 @@ where
             }
         }
 
-        Ok(Some((mi, family)))
+        Ok(Some((key, family)))
     }
+}
+
+/// The family key for a record: its molecule base by default, or the raw MI tag
+/// when `per_strand` is set. The molecule base is computed by the canonical
+/// [`extract_mi_base`], which truncates at the last `/` exactly as `group`,
+/// `duplex`, and `duplex_metrics` do when collapsing strands to their source
+/// molecule — so grouping here matches the rest of the pipeline rather than a
+/// second, divergent strip rule.
+fn family_key(record: &RawRecord, per_strand: bool) -> Result<String> {
+    let mut mi = get_mi_tag(record)?;
+    if !per_strand {
+        // `mi` is already valid UTF-8, and `extract_mi_base` truncates at an ASCII
+        // '/' boundary, so truncating in place stays on a char boundary and reuses
+        // the existing allocation rather than round-tripping through a new String.
+        let base_len = extract_mi_base(&mi).len();
+        mi.truncate(base_len);
+    }
+    Ok(mi)
+}
+
+/// Whether a record's family key equals `target`, without allocating.
+///
+/// Mirrors [`family_key`]: compares its molecule base by default, or the raw MI
+/// tag when `per_strand` is set. Delegates to [`mi_tag_equals`] in the raw case;
+/// in the molecule case it reduces the record's MI to its base via the canonical
+/// [`extract_mi_base`] (the Z-typed path) and compares to `target`, which is
+/// itself already a base key.
+fn family_key_equals(record: &RawRecord, target: &[u8], per_strand: bool) -> Result<bool> {
+    if per_strand {
+        return mi_tag_equals(record, target);
+    }
+
+    let aux = aux_data_slice(record.as_ref());
+
+    if let Some(bytes) = find_string_tag(aux, SamTag::MI) {
+        let mi = std::str::from_utf8(bytes)
+            .map_err(|e| anyhow::anyhow!("MI tag is not valid UTF-8: {e}"))?;
+        return Ok(extract_mi_base(mi).as_bytes() == target);
+    }
+
+    if let Some(v) = find_int_tag(aux, SamTag::MI) {
+        // Integer MIs never carry a strand suffix, so the base equals the rendering.
+        return Ok(v.to_string().as_bytes() == target);
+    }
+
+    let name = String::from_utf8_lossy(read_name(record.as_ref())).into_owned();
+    let display_name = if name.is_empty() { "<unknown>".to_string() } else { name };
+    bail!("Read '{display_name}' is missing required MI tag")
 }
 
 /// Extract the MI tag value from a raw BAM record.
@@ -573,7 +662,7 @@ mod tests {
             Ok(create_test_record("r3", "100")),
         ];
 
-        let mut iter = FamilyIterator::new(records.into_iter());
+        let mut iter = FamilyIterator::new(records.into_iter(), false);
 
         let family1 =
             iter.next_family().expect("next_family should succeed").expect("expected a family");
@@ -595,7 +684,7 @@ mod tests {
             Ok(create_test_record("r6", "300")),
         ];
 
-        let mut iter = FamilyIterator::new(records.into_iter());
+        let mut iter = FamilyIterator::new(records.into_iter(), false);
 
         let family1 =
             iter.next_family().expect("next_family should succeed").expect("expected family 1");
@@ -619,7 +708,7 @@ mod tests {
     #[test]
     fn test_family_iterator_empty() {
         let records: Vec<Result<RawRecord>> = vec![];
-        let mut iter = FamilyIterator::new(records.into_iter());
+        let mut iter = FamilyIterator::new(records.into_iter(), false);
 
         let family = iter.next_family().expect("next_family should succeed");
         assert!(family.is_none());
@@ -655,6 +744,7 @@ mod tests {
             rejects: Some(PathBuf::from("rejects.bam")),
             seed: Some(42),
             validate_mi_order: true,
+            per_strand: true,
             histogram_kept: Some(PathBuf::from("kept.txt")),
             histogram_rejected: Some(PathBuf::from("rejected.txt")),
             compression: CompressionOptions { compression_level: 1 },
@@ -663,6 +753,7 @@ mod tests {
         assert_eq!(cmd.fraction, 0.1);
         assert_eq!(cmd.seed, Some(42));
         assert!(cmd.validate_mi_order);
+        assert!(cmd.per_strand);
         assert!(cmd.rejects.is_some());
         assert!(cmd.histogram_kept.is_some());
         assert!(cmd.histogram_rejected.is_some());
@@ -698,5 +789,107 @@ mod tests {
         // BTreeMap maintains sorted order
         let sizes: Vec<usize> = hist.keys().copied().collect();
         assert_eq!(sizes, vec![1, 3, 5]);
+    }
+
+    #[test]
+    fn test_family_key_respects_per_strand() {
+        let a = create_test_record("r", "7/A");
+        // Default (molecule) strips the strand suffix; --per-strand keeps the raw tag.
+        assert_eq!(family_key(&a, false).unwrap(), "7");
+        assert_eq!(family_key(&a, true).unwrap(), "7/A");
+
+        // An integer MI has no `/`, so both modes agree.
+        let i = create_test_record_int_mi("r", 7);
+        assert_eq!(family_key(&i, false).unwrap(), "7");
+        assert_eq!(family_key(&i, true).unwrap(), "7");
+    }
+
+    /// The default molecule key uses the canonical `extract_mi_base` rule (strip at
+    /// the last `/`), NOT a `/A`,`/B`-only strip: any final `/`-suffix is removed, and
+    /// a leading `/` (empty base) is preserved. Pinned deliberately so a future change
+    /// cannot silently narrow the rule to `/A`,`/B` and diverge downsample's grouping
+    /// from `group`/`duplex`, which collapse strands with this same canonical rule.
+    #[test]
+    fn test_family_key_default_strips_any_suffix_canonically() {
+        // A non-/A,/B suffix is still stripped (matches group/duplex, not narrowed).
+        assert_eq!(family_key(&create_test_record("r", "7/C"), false).unwrap(), "7");
+        // A leading '/' is an empty base and is preserved verbatim (extract_mi_base).
+        assert_eq!(family_key(&create_test_record("r", "/A"), false).unwrap(), "/A");
+    }
+
+    #[test]
+    fn test_family_key_equals_per_strand() {
+        let a = create_test_record("r", "7/A");
+        let b = create_test_record("r", "7/B");
+
+        // Default (molecule): both strands match the base key "7".
+        assert!(family_key_equals(&a, b"7", false).unwrap());
+        assert!(family_key_equals(&b, b"7", false).unwrap());
+        assert!(!family_key_equals(&a, b"8", false).unwrap());
+
+        // --per-strand: /A and /B are different families.
+        assert!(family_key_equals(&a, b"7/A", true).unwrap());
+        assert!(!family_key_equals(&b, b"7/A", true).unwrap());
+
+        // A missing MI is an error in both modes (mirrors get_mi_tag).
+        let none = create_test_record_no_mi("r");
+        assert!(family_key_equals(&none, b"7", false).is_err());
+        assert!(family_key_equals(&none, b"7", true).is_err());
+    }
+
+    /// `family_key_equals` must agree with `family_key` + compare, in BOTH modes and
+    /// across Z-typed and integer MIs — they are the two sides of the same grouping
+    /// decision and drift between them would split or merge families incorrectly.
+    #[test]
+    fn test_family_key_equals_matches_family_key() {
+        let records = [
+            create_test_record("r", "7/A"),
+            create_test_record("r", "7/B"),
+            create_test_record("r", "7"), // simplex MI, no suffix
+            create_test_record_int_mi("r", 7),
+        ];
+        for per_strand in [false, true] {
+            for rec in &records {
+                let key = family_key(rec, per_strand).unwrap();
+                assert!(
+                    family_key_equals(rec, key.as_bytes(), per_strand).unwrap(),
+                    "family_key_equals disagreed with family_key (per_strand={per_strand})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_family_iterator_duplex_strands_grouped_by_default_and_split_by_per_strand() {
+        // One molecule's two strands (7/A, 7/B), then a second molecule (8/A).
+        // Built fresh per iterator: Vec<Result<_, anyhow::Error>> is not Clone.
+        let records = || {
+            vec![
+                Ok(create_test_record("r1", "7/A")),
+                Ok(create_test_record("r2", "7/A")),
+                Ok(create_test_record("r3", "7/B")),
+                Ok(create_test_record("r4", "8/A")),
+            ]
+        };
+
+        // Default (per_strand = false): 7/A + 7/B collapse into ONE family keyed "7".
+        let mut iter = FamilyIterator::new(records().into_iter(), false);
+        let fam1 = iter.next_family().unwrap().expect("family 1");
+        assert_eq!(fam1.0, "7");
+        assert_eq!(fam1.1.len(), 3); // both strands of molecule 7
+        let fam2 = iter.next_family().unwrap().expect("family 2");
+        assert_eq!(fam2.0, "8");
+        assert_eq!(fam2.1.len(), 1);
+        assert!(iter.next_family().unwrap().is_none());
+
+        // --per-strand (true): 7/A and 7/B are separate families.
+        let mut iter = FamilyIterator::new(records().into_iter(), true);
+        let f1 = iter.next_family().unwrap().expect("family 7/A");
+        assert_eq!((f1.0.as_str(), f1.1.len()), ("7/A", 2));
+        let f2 = iter.next_family().unwrap().expect("family 7/B");
+        assert_eq!((f2.0.as_str(), f2.1.len()), ("7/B", 1));
+        let f3 = iter.next_family().unwrap().expect("family 8/A");
+        assert_eq!((f3.0.as_str(), f3.1.len()), ("8/A", 1));
+        assert!(iter.next_family().unwrap().is_none());
     }
 }

--- a/tests/integration/test_downsample_command.rs
+++ b/tests/integration/test_downsample_command.rs
@@ -12,6 +12,7 @@ use noodles::bam;
 use noodles::sam::alignment::io::Write as AlignmentWrite;
 use noodles::sam::alignment::record::data::field::Tag;
 use noodles::sam::alignment::record_buf::data::field::Value;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::PathBuf;
 use tempfile::TempDir;
@@ -459,6 +460,245 @@ fn test_downsample_keep_all() {
     // All records should be kept
     let output_records = read_bam_records(&output_bam);
     assert_eq!(output_records.len(), 15, "All 15 records should be kept with fraction=1.0");
+}
+
+/// Collect `(read_name, MI)` for every record in a BAM, in file order. Used to
+/// assert source-record IDENTITY (which named reads survived), not just counts.
+fn read_bam_name_mi_pairs(path: &PathBuf) -> Vec<(String, String)> {
+    read_bam_records(path)
+        .iter()
+        .map(|r| {
+            let name = r.name().map(ToString::to_string).unwrap_or_default();
+            let mi = match r.data().get(&MI_TAG) {
+                Some(Value::String(s)) => s.to_string(),
+                Some(_) => panic!("MI tag is not a string"),
+                None => panic!("record is missing its MI tag"),
+            };
+            (name, mi)
+        })
+        .collect()
+}
+
+/// The molecule base of an MI: everything before the last `/` (mirrors
+/// `extract_mi_base`), so `100/A` and `100/B` share the base `100`.
+fn mi_base(mi: &str) -> &str {
+    match mi.rfind('/') {
+        Some(i) if i > 0 => &mi[..i],
+        _ => mi,
+    }
+}
+
+/// End-to-end: by default (molecule grouping), the two duplex strands of a
+/// molecule are sampled as ONE family — kept or dropped together — so no
+/// surviving molecule base ever appears with only one of its strands. This holds
+/// for ANY seed, which is what makes the assertion robust: it is the atomicity
+/// guarantee, not a specific RNG outcome. The complementary `--per-strand`
+/// behavior (strands sampled independently) is covered by
+/// `test_downsample_per_strand_splits_duplex_strands` and the `FamilyIterator`
+/// unit tests.
+#[test]
+fn test_downsample_default_keeps_duplex_strands_together() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    // 12 duplex molecules, each with an /A strand (3 reads) and a /B strand
+    // (2 reads) laid out consecutively as group emits them, plus one simplex
+    // family with no strand suffix. Enough molecules that a fraction of 0.5
+    // keeps some and drops some, exercising the all-or-nothing path on both.
+    // create_grouped_bam names reads `read_{idx}` sequentially in family order,
+    // so molecule i owns read indices [i*5, i*5+5) — the exact set we assert
+    // survives as a unit below.
+    let mut families: Vec<(String, usize)> = Vec::new();
+    for i in 0..12 {
+        families.push((format!("{i}/A"), 3));
+        families.push((format!("{i}/B"), 2));
+    }
+    families.push(("999".to_string(), 4)); // simplex family, no suffix
+    let families_ref: Vec<(&str, usize)> =
+        families.iter().map(|(mi, n)| (mi.as_str(), *n)).collect();
+    create_grouped_bam(&input_bam, families_ref);
+
+    // No flag: molecule grouping is the default.
+    let cmd = Downsample::try_parse_from([
+        "downsample",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-o",
+        output_bam.to_str().unwrap(),
+        "-f",
+        "0.5",
+        "--seed",
+        "7",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse downsample args");
+    cmd.execute("fgumi downsample").expect("Downsample command failed");
+
+    // Group the surviving reads by molecule base: which named reads and which
+    // strand suffixes survived under each base.
+    let mut names_by_base: HashMap<String, HashSet<String>> = HashMap::new();
+    let mut strands_by_base: HashMap<String, HashSet<String>> = HashMap::new();
+    for (name, mi) in read_bam_name_mi_pairs(&output_bam) {
+        let base = mi_base(&mi).to_string();
+        let suffix = mi.strip_prefix(base.as_str()).unwrap_or("").to_string();
+        names_by_base.entry(base.clone()).or_default().insert(name);
+        strands_by_base.entry(base).or_default().insert(suffix);
+    }
+
+    // At least one duplex molecule survived and at least one was dropped, so the
+    // test actually exercises both branches (not a vacuous pass on an empty or
+    // full output).
+    let duplex_survivors = (0..12).filter(|i| names_by_base.contains_key(&i.to_string())).count();
+    assert!(duplex_survivors > 0, "expected some duplex molecules to survive at f=0.5");
+    assert!(duplex_survivors < 12, "expected some duplex molecules to be dropped at f=0.5");
+
+    // The core invariant, asserted by source-record IDENTITY (not just counts):
+    // every surviving duplex molecule kept BOTH strands and EXACTLY its own five
+    // reads (`read_{i*5}`..`read_{i*5+4}`: 3 from /A + 2 from /B). A molecule with
+    // only one strand — or with a read that belongs to a different molecule —
+    // would mean the strands were sampled independently or mis-grouped.
+    for i in 0..12 {
+        let base = i.to_string();
+        if let Some(names) = names_by_base.get(&base) {
+            let expected_names: HashSet<String> =
+                (i * 5..i * 5 + 5).map(|idx| format!("read_{idx}")).collect();
+            assert_eq!(
+                names, &expected_names,
+                "molecule {base} survived with reads {names:?}, expected exactly {expected_names:?}"
+            );
+            assert_eq!(
+                strands_by_base.get(&base),
+                Some(&HashSet::from(["/A".to_string(), "/B".to_string()])),
+                "molecule {base} survived without both /A and /B strands present"
+            );
+        }
+    }
+}
+
+/// By default at `f=1.0`, a simplex family (an MI with no `/A`/`/B` strand
+/// suffix) is preserved in full: exactly its own records survive, each still
+/// carrying its original MI. Deterministic complement to
+/// `keeps_duplex_strands_together`, which samples a mixed input at `f=0.5` where
+/// any single family's survival is not guaranteed. As per CLAUDE.md path
+/// instructions, which require coverage of simplex-record preservation by
+/// identity, not just its shape.
+#[test]
+fn test_downsample_default_preserves_simplex_family() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    // A single simplex family: MI `999`, four reads (read_0..read_3), no suffix.
+    create_grouped_bam(&input_bam, vec![("999", 4)]);
+
+    // No flag: molecule grouping is the default (a no-op for a simplex MI,
+    // which has no `/` to strip).
+    let cmd = Downsample::try_parse_from([
+        "downsample",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-o",
+        output_bam.to_str().unwrap(),
+        "-f",
+        "1.0",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse downsample args");
+    cmd.execute("fgumi downsample").expect("Downsample command failed");
+
+    // f=1.0 keeps everything: exactly the four input reads survive, each with MI
+    // `999`. Assert identity (which named reads), not just the count/MI shape.
+    let pairs = read_bam_name_mi_pairs(&output_bam);
+    let got: HashSet<(String, String)> = pairs.iter().cloned().collect();
+    let expected: HashSet<(String, String)> =
+        (0..4).map(|idx| (format!("read_{idx}"), "999".to_string())).collect();
+    assert_eq!(
+        got, expected,
+        "all four simplex reads (read_0..read_3) must be kept with MI 999 at f=1.0, got {pairs:?}"
+    );
+}
+
+/// With `--per-strand`, the legacy behavior is restored: a molecule's two strands
+/// are sampled INDEPENDENTLY, so a surviving molecule base may have only one of
+/// its strands. This is the opt-out inverse of the default atomicity invariant.
+/// Seed-pinned so the input is large enough that some molecule splits under
+/// independent draws (the whole reason `--per-strand` collapses duplex families).
+#[test]
+fn test_downsample_per_strand_splits_duplex_strands() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    // 12 duplex molecules laid out as group emits them (/A then /B per molecule).
+    let mut families: Vec<(String, usize)> = Vec::new();
+    for i in 0..12 {
+        families.push((format!("{i}/A"), 3));
+        families.push((format!("{i}/B"), 2));
+    }
+    let families_ref: Vec<(&str, usize)> =
+        families.iter().map(|(mi, n)| (mi.as_str(), *n)).collect();
+    create_grouped_bam(&input_bam, families_ref);
+
+    let cmd = Downsample::try_parse_from([
+        "downsample",
+        "-i",
+        input_bam.to_str().unwrap(),
+        "-o",
+        output_bam.to_str().unwrap(),
+        "-f",
+        "0.5",
+        "--seed",
+        "7",
+        "--per-strand",
+        "--compression-level",
+        "1",
+    ])
+    .expect("failed to parse downsample args");
+    cmd.execute("fgumi downsample").expect("Downsample command failed");
+
+    // Each raw MI (`i/A`, `i/B`) was its own family with its own draw. Collect the
+    // surviving read NAMES per raw MI, and the surviving strand suffixes per base.
+    // create_grouped_bam names reads `read_{idx}` sequentially in family order, so
+    // molecule i occupies [i*5, i*5+5): `i/A` = read_{i*5..i*5+3}, `i/B` = the next 2.
+    let mut names_by_raw_mi: HashMap<String, HashSet<String>> = HashMap::new();
+    let mut strands_by_base: HashMap<String, HashSet<String>> = HashMap::new();
+    for (name, mi) in read_bam_name_mi_pairs(&output_bam) {
+        let base = mi_base(&mi).to_string();
+        let suffix = mi.strip_prefix(base.as_str()).unwrap_or("").to_string();
+        names_by_raw_mi.entry(mi).or_default().insert(name);
+        strands_by_base.entry(base).or_default().insert(suffix);
+    }
+
+    // Per-strand keeps or drops each raw MI family ATOMICALLY (it is still a
+    // family-atomic sampler — only the family key differs). So every RETAINED raw
+    // MI must contain exactly its own source reads — all three of an `/A`, both of
+    // a `/B` — never a partial family. This is the raw-MI identity contract, the
+    // per-strand analogue of the by-molecule identity check.
+    for (mi, names) in &names_by_raw_mi {
+        let i: usize = mi_base(mi).parse().expect("base MI is an integer in this fixture");
+        let expected: HashSet<String> = if mi.ends_with("/A") {
+            (i * 5..i * 5 + 3).map(|idx| format!("read_{idx}")).collect()
+        } else {
+            (i * 5 + 3..i * 5 + 5).map(|idx| format!("read_{idx}")).collect()
+        };
+        assert_eq!(
+            names, &expected,
+            "raw MI {mi} survived with reads {names:?}, expected exactly its own family {expected:?}"
+        );
+    }
+
+    // The defining property of per-strand sampling: at least one molecule survived
+    // with only ONE of its two strands. (Under the default molecule grouping this
+    // can never happen — see keeps_duplex_strands_together.)
+    let split = strands_by_base.values().any(|strands| strands.len() == 1);
+    assert!(
+        split,
+        "expected at least one molecule to survive with a single strand under --per-strand, \
+         got {strands_by_base:?}"
+    );
 }
 
 /// Test error handling for invalid fractions. Each case writes to a


### PR DESCRIPTION
Fixes #904.

## Problem

`downsample` keeps or drops whole UMI families atomically, to model "fewer input molecules captured." For duplex data, the `paired` grouping strategy tags a molecule's two strands `<base>/A` and `<base>/B` as distinct MI values. So each strand gets an independent keep/reject draw, and a duplex molecule survives *as a duplex* only when both draws hit — probability `fraction²`. At low fractions duplex families collapse, and a duplex dataset downsampled with `downsample` is silently depleted of exactly the thing that makes it duplex.

## Fix

Group by the **molecule base** by default. Each MI is reduced to its base via the canonical `extract_mi_base` (the same last-`/` truncation `group`, `duplex`, and `duplex_metrics` already use to collapse strands to their source molecule), so both strands of a molecule form one family sharing a single keep/reject draw and are kept or dropped together. Duplex families then survive at the intended `fraction`.

This is a **no-op for simplex and integer MIs** (no `/` to strip), so the only outputs that change are the duplex ones that were previously wrong. Molecule-atomic is also the semantically correct sampling unit for a family-atomic downsampler, and it matches how the rest of the pipeline defines a molecule.

Add `--per-strand` (off by default) to opt back into the legacy behavior of sampling each raw MI tag independently — for deliberate strand-level sampling.

## Notes

- This **supersedes the earlier `--by-molecule` opt-in** from this same PR (never released). Making the correct behavior the default — rather than something a user must know to ask for — also removes the need for the previous duplex-suffix detection and the one-time "you're probably holding it wrong" warning, so the change is a net simplification: the detection predicate, the warning, and the mode-threading boolean are gone; grouping is always keyed on `extract_mi_base` unless `--per-strand` is set.
- Reuses the canonical `extract_mi_base` rather than a local strip, so downsample's grouping rule cannot drift from `group`/`duplex`. The canonical rule strips at the *last* `/` (any suffix), not only `/A`,`/B`; valid `paired` output only ever uses `<int>/A` and `<int>/B`, and simplex assigners emit bare integer MIs, so this is exactly right for grouped input and consistent with the rest of the pipeline.
- **Family-size histograms** (`--histogram-kept` / `--histogram-rejected`) now count both strands of a duplex molecule as one family, consistent with the sampling unit — a second observable output change beyond the BAM records themselves.

## Testing

- Unit tests: `FamilyIterator` collapses `N/A`+`N/B` into one family by default and splits them under `--per-strand`; `family_key`/`family_key_equals` parity across both modes and Z/integer MIs; a pin that the default key uses the canonical any-suffix strip (not a narrowed `/A`,`/B`-only strip) and preserves a leading-`/` empty base.
- Integration tests assert **source-record identity** (which named reads survived), not just counts or MI values:
  - `test_downsample_default_keeps_duplex_strands_together`: seed-independent atomicity invariant — every surviving molecule base keeps exactly its own five reads and both `/A` and `/B` strands, exercising both the kept and dropped branches at `f=0.5`.
  - `test_downsample_default_preserves_simplex_family`: deterministic `f=1.0` — exactly the four input reads survive, each retaining MI `999`.
  - `test_downsample_per_strand_splits_duplex_strands`: the opt-out inverse — under `--per-strand`, at least one molecule survives with only one of its two strands.
- `cargo nextest run -p fgumi` (46 downsample tests pass), `cargo ci-lint` (clippy `-D warnings`), and `cargo fmt --check` all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: `downsample` output changes because canonical `extract_mi_base` makes duplex strands share one decision; unsafe changes: none, and CLAUDE.md needs no update; memory, queue, and backpressure changes: none.

Adds molecule-level duplex sampling by default. Adds `--per-strand` for independent raw-MI sampling. Preserves simplex and integer-MI behavior.

Adds unit and integration tests for grouping keys, duplex atomicity, source-record identity, simplex preservation, and per-strand sampling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->