### PR TITLE
feat(group,dedup): add opt-in --verify for strict template-coordinate sort-order

### DIFF
--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -1246,6 +1246,20 @@ pub struct MarkDuplicates {
     #[arg(short = 'n', long = "include-non-pf-reads", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub include_non_pf_reads: bool,
 
+    /// Verify the input is in strict template-coordinate sort order.
+    ///
+    /// Off by default. Each record is checked against the exact ordering of
+    /// `fgumi sort --order template-coordinate` as it is read; the run aborts with
+    /// a non-zero exit on the first out-of-order record. This composes with
+    /// `--output` (a precondition gate, not a check-only mode): output is written
+    /// normally when the input is correctly ordered, and may be left partial if
+    /// the check fails mid-stream. The check is intentionally STRICTER than
+    /// deduplication requires (dedup only needs a template's mates adjacent by
+    /// position), which is why it is opt-in; for a standalone check with no output
+    /// use `fgumi sort --verify`.
+    #[arg(long = "verify", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
+    pub verify: bool,
+
     /// Emit templates with no mapped read (both mates unmapped) untouched instead of
     /// discarding them. Such templates carry no alignment coordinate and no duplicate
     /// signal; passing them through preserves a complete record set (like Picard
@@ -1503,10 +1517,18 @@ impl Command for MarkDuplicates {
             header,
             &self.io.output,
             None,
-            // Grouper factory - use with_secondary_supplementary to include all reads
-            move |_header: &Header| {
-                Box::new(RecordPositionGrouper::with_secondary_supplementary())
-                    as Box<dyn Grouper<Group = RawPositionGroup> + Send>
+            // Grouper factory - use with_secondary_supplementary to include all reads.
+            // With --verify, gate on strict template-coordinate order (the factory
+            // receives the header, which supplies library-ordinal mapping for keys).
+            {
+                let verify = self.verify;
+                move |header: &Header| {
+                    let mut grouper = RecordPositionGrouper::with_secondary_supplementary();
+                    if verify {
+                        grouper.enable_verify(header);
+                    }
+                    Box::new(grouper) as Box<dyn Grouper<Group = RawPositionGroup> + Send>
+                }
             },
             // Process function (parallel) — builds templates from raw records
             move |group: RawPositionGroup| -> io::Result<ProcessedDedupGroup> {

--- a/src/lib/commands/group.rs
+++ b/src/lib/commands/group.rs
@@ -487,6 +487,7 @@ because multiple pipeline workers can each spawn a --threads-sized pool concurre
 the live thread count higher still. See --parallel-group-min-templates for details.
 "#
 )]
+#[allow(clippy::struct_excessive_bools)] // CLI flags: each bool is a distinct user-facing option
 pub struct GroupReadsByUmi {
     /// Input and output BAM files
     #[command(flatten)]
@@ -515,6 +516,20 @@ pub struct GroupReadsByUmi {
     /// Include non-PF reads
     #[arg(short = 'n', long = "include-non-pf-reads", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub include_non_pf_reads: bool,
+
+    /// Verify the input is in strict template-coordinate sort order.
+    ///
+    /// Off by default. Each record is checked against the exact ordering of
+    /// `fgumi sort --order template-coordinate` as it is read; the run aborts with
+    /// a non-zero exit on the first out-of-order record. This composes with
+    /// `--output` (a precondition gate, not a check-only mode): output is written
+    /// normally when the input is correctly ordered, and may be left partial if
+    /// the check fails mid-stream. The check is intentionally STRICTER than
+    /// grouping requires (grouping only needs a template's mates adjacent by
+    /// position), which is why it is opt-in; for a standalone check with no output
+    /// use `fgumi sort --verify`.
+    #[arg(long = "verify", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
+    pub verify: bool,
 
     /// Allow fully unmapped templates (both reads unmapped). Input must be
     /// template-coordinate sorted (`fgumi sort --order template-coordinate`).
@@ -660,6 +675,7 @@ pub struct GroupReadsByUmi {
 /// identity-implies-zero-edits rules. Both come from the same methods
 /// `execute` uses, so the command and the chain builder cannot drift apart.
 #[derive(Debug, Clone)]
+#[allow(clippy::struct_excessive_bools)] // mirrors the CLI flags 1:1; each bool is a distinct option
 pub struct GroupOptions {
     /// Minimum mapping quality for mapped reads, with the default applied.
     pub min_map_q: u8,
@@ -693,6 +709,8 @@ pub struct GroupOptions {
     pub grouping_metrics: Option<PathBuf>,
     /// Optional output prefix for the full set of metrics files.
     pub metrics_prefix: Option<PathBuf>,
+    /// Verify the input is in strict template-coordinate sort order (`--verify`).
+    pub verify: bool,
 }
 
 impl Default for GroupOptions {
@@ -715,6 +733,7 @@ impl Default for GroupOptions {
             family_size_histogram: None,
             grouping_metrics: None,
             metrics_prefix: None,
+            verify: false,
         }
     }
 }
@@ -761,6 +780,7 @@ impl GroupReadsByUmi {
             family_size_histogram: self.family_size_histogram.clone(),
             grouping_metrics: self.grouping_metrics.clone(),
             metrics_prefix: self.metrics.clone(),
+            verify: self.verify,
         }
     }
 }
@@ -1051,8 +1071,12 @@ impl GroupReadsByUmi {
         // Build library index for GroupKey computation
         let library_index = LibraryIndex::from_header(header);
 
-        // Create RecordPositionGrouper (same grouper used in pipeline mode)
+        // Create RecordPositionGrouper (same grouper used in pipeline mode).
+        // With --verify, gate on strict template-coordinate order as records stream.
         let mut grouper = RecordPositionGrouper::new();
+        if self.verify {
+            grouper.enable_verify(header);
+        }
 
         // Metrics accumulators (no lock-free queue needed in single-threaded mode)
         let mut total_filter_counts = TemplateFilterCounts::new();
@@ -1515,6 +1539,7 @@ mod tests {
             "prefix",
             "--include-non-pf-reads=true",
             "--allow-unmapped=true",
+            "--verify=true",
             "--parallel-group-min-templates",
             "500",
         ])
@@ -1525,6 +1550,7 @@ mod tests {
         assert_eq!(opts.min_map_q, 30);
         assert!(opts.include_non_pf_reads);
         assert!(opts.allow_unmapped);
+        assert!(opts.verify);
         assert_eq!(opts.strategy, Strategy::Adjacency);
         assert_eq!(opts.edits, 2);
         assert_eq!(opts.min_umi_length, Some(8));
@@ -1568,6 +1594,7 @@ mod tests {
         assert_eq!(opts.min_map_q, 1, "an absent --min-map-q resolves to 1");
         assert!(!opts.include_non_pf_reads);
         assert!(!opts.allow_unmapped);
+        assert!(!opts.verify, "an absent --verify defaults to false");
         assert_eq!(opts.edits, 1);
         assert_eq!(opts.min_umi_length, None);
         assert_eq!(opts.index_threshold, IndexThreshold::MinUmis(100));
@@ -1776,6 +1803,7 @@ mod tests {
             metrics: None,
             min_map_q: None,
             include_non_pf_reads: false,
+            verify: false,
             strategy,
             edits,
             min_umi_length: None,

--- a/src/lib/grouper.rs
+++ b/src/lib/grouper.rs
@@ -6,6 +6,7 @@
 //! Note: BAM record parsing is handled by the Decode step in the pipeline.
 //! Groupers receive pre-decoded raw-byte records.
 
+use std::cmp::Ordering;
 use std::io;
 
 use noodles::sam::alignment::RecordBuf;
@@ -15,6 +16,7 @@ use crate::unified_pipeline::{BatchWeight, DecodedRecord, Grouper, MemoryEstimat
 use fgumi_metrics::TemplateFilterCounts;
 use fgumi_raw_bam;
 use fgumi_raw_bam::{RawRecord, raw_record_to_record_buf};
+use fgumi_sort::{LibraryLookup, TemplateKey, cb_hasher, extract_template_key_inline};
 
 // ============================================================================
 // BatchWeight Implementations
@@ -348,6 +350,92 @@ impl MemoryEstimate for RawPositionGroup {
     }
 }
 
+/// Inline, opt-in verifier that the records fed to a [`RecordPositionGrouper`]
+/// arrive in strict template-coordinate sort order.
+///
+/// This is the `--verify` gate for `fgumi group` and `fgumi dedup`. It reuses the
+/// **exact** template-coordinate key `fgumi sort --order template-coordinate`
+/// emits ([`extract_template_key_inline`]) and the same tolerant comparison
+/// `fgumi sort --verify` uses ([`TemplateKey::core_cmp`], which ignores the
+/// `name_hash`/`is_upper` tie-breaker so both fgumi- and samtools-sorted inputs
+/// pass). A record whose key sorts strictly before its predecessor is a
+/// violation and aborts the run.
+///
+/// It is deliberately **stricter than grouping requires**: grouping only needs a
+/// template's mates adjacent by position, whereas this asserts the whole file is
+/// in canonical sort order. That extra strictness is why the flag is opt-in.
+///
+/// Cell-barcode keying matches `fgumi sort --order template-coordinate`, which
+/// keys on the `CB` tag by default (see `parse_cell_tag` in `commands::sort`) —
+/// so `--verify` uses `Some(CB)` too. The `cb_hasher` is the same fixed-seed
+/// hasher the sorter uses ([`cb_hasher`]), so a recomputed `cb_hash` is
+/// bit-identical to what the sort produced for the same `CB` bytes; a record
+/// without a `CB` tag hashes to `0` on both sides. Keying with `None` here would
+/// force every `cb_hash` to `0` and spuriously reject a correctly-sorted
+/// pooled/single-cell input whose `CB` order disagrees with its library order.
+struct OrderVerifier {
+    /// Read-group -> library-ordinal lookup, built once from the BAM header.
+    lib_lookup: LibraryLookup,
+    /// Deterministic (fixed-seed) hasher for the cell-barcode lane, matching the
+    /// sorter's; constructed once and reused so key extraction is allocation-free
+    /// per record.
+    cb_hasher: ahash::RandomState,
+    /// Template-coordinate key of the previous record, or `None` before the first.
+    prev_key: Option<TemplateKey>,
+    /// Read name of the previous record, reused across calls (cleared + refilled,
+    /// so no per-record allocation) to name both records in a violation error.
+    prev_name: Vec<u8>,
+}
+
+impl OrderVerifier {
+    /// The cell-barcode tag `fgumi sort --order template-coordinate` keys on.
+    const CELL_TAG: fgumi_raw_bam::SamTag = fgumi_raw_bam::SamTag::CB;
+
+    /// Build a verifier from the input BAM header (for library-ordinal mapping).
+    fn from_header(header: &noodles::sam::Header) -> Self {
+        Self {
+            lib_lookup: LibraryLookup::from_header(header),
+            cb_hasher: cb_hasher(),
+            prev_key: None,
+            prev_name: Vec::new(),
+        }
+    }
+
+    /// Check `bam` (raw record bytes) against the previous record's key.
+    ///
+    /// # Errors
+    /// Returns [`io::ErrorKind::InvalidData`] naming both the offending read and
+    /// its predecessor when the record's template-coordinate key sorts strictly
+    /// before the previous record's.
+    fn check(&mut self, bam: &[u8]) -> io::Result<()> {
+        let key = extract_template_key_inline(
+            bam,
+            &self.lib_lookup,
+            Some(Self::CELL_TAG),
+            &self.cb_hasher,
+        );
+        let name = fgumi_raw_bam::RawRecordView::new(bam).read_name();
+        if let Some(prev) = self.prev_key.as_ref()
+            && key.core_cmp(prev) == Ordering::Less
+        {
+            let cur = String::from_utf8_lossy(name);
+            let previous = String::from_utf8_lossy(&self.prev_name);
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "--verify: input is not in template-coordinate sort order; record '{cur}' \
+                     sorts before the preceding record '{previous}'. Sort the input first, e.g. \
+                     `fgumi sort --order template-coordinate`, or drop --verify."
+                ),
+            ));
+        }
+        self.prev_key = Some(key);
+        self.prev_name.clear();
+        self.prev_name.extend_from_slice(name);
+        Ok(())
+    }
+}
+
 /// A lightweight position grouper that compares per-record [`GroupKey::position_key`]
 /// values to detect group boundaries.
 ///
@@ -389,6 +477,13 @@ pub struct RecordPositionGrouper {
     /// When false (default), they are filtered by their `SECONDARY`/`SUPPLEMENTARY`
     /// flags in [`Self::add_record`].
     include_secondary_supplementary: bool,
+    /// Opt-in strict template-coordinate sort-order gate (`--verify`).
+    ///
+    /// When `Some`, every record — including secondary/supplementary reads that
+    /// are otherwise skipped — is order-checked *before* the skip, so the check
+    /// matches the full `fgumi sort --order template-coordinate` output. `None`
+    /// (default) disables verification.
+    verifier: Option<OrderVerifier>,
 }
 
 impl RecordPositionGrouper {
@@ -402,6 +497,7 @@ impl RecordPositionGrouper {
             current_group_key: None,
             current_records: Vec::new(),
             include_secondary_supplementary: false,
+            verifier: None,
         }
     }
 
@@ -420,6 +516,22 @@ impl RecordPositionGrouper {
     #[must_use]
     pub fn with_secondary_supplementary() -> Self {
         Self { include_secondary_supplementary: true, ..Self::new() }
+    }
+
+    /// Enable strict template-coordinate sort-order verification (`--verify`).
+    ///
+    /// `header` supplies the read-group -> library-ordinal mapping used to build
+    /// the template-coordinate keys. Every subsequent record is checked, and
+    /// `process_record` aborts on the first record that sorts out of order.
+    ///
+    /// Orthogonal to secondary/supplementary inclusion: it composes with both
+    /// [`new`](Self::new) and [`with_secondary_supplementary`](Self::with_secondary_supplementary).
+    ///
+    /// The chain (`--threads N`) path reaches this through
+    /// [`GroupByPosition::verifying`](crate::pipeline::steps::group::position::GroupByPosition::verifying);
+    /// the non-chain paths call it directly on a `let mut` grouper.
+    pub fn enable_verify(&mut self, header: &noodles::sam::Header) {
+        self.verifier = Some(OrderVerifier::from_header(header));
     }
 
     /// Validate that a paired primary record has a resolved mate position.
@@ -480,6 +592,14 @@ impl RecordPositionGrouper {
 
     /// Process a single decoded record, potentially emitting a completed group.
     fn process_record(&mut self, decoded: DecodedRecord) -> io::Result<Option<RawPositionGroup>> {
+        // Strict sort-order verification (`--verify`), if enabled. Runs *before*
+        // the secondary/supplementary skip so every record — including the
+        // sec/supp reads that grouping otherwise drops — is order-checked,
+        // matching the full `fgumi sort --order template-coordinate` output.
+        if let Some(verifier) = self.verifier.as_mut() {
+            verifier.check(decoded.record())?;
+        }
+
         // Skip secondary and supplementary reads unless configured to include them
         // (dedup needs them in templates so its duplicate flag propagates across
         // split alignments). Filter by the record's own flags rather than by
@@ -1202,6 +1322,220 @@ mod tests {
         let mut b = RawSamBuilder::new();
         b.read_name(name).sequence(b"ACGT").qualities(&[30; 4]).flags(flag);
         DecodedRecord::from_raw_bytes(b.build(), key)
+    }
+
+    /// Helper: a mapped, forward, unpaired record at `(tid, pos0)` (0-based),
+    /// with a distinct read name/`name_hash` per `idx`. Used by the `--verify`
+    /// tests, whose template-coordinate order is driven purely by `(tid, pos0)`.
+    fn make_mapped_forward(tid: i32, pos0: i32, idx: usize) -> DecodedRecord {
+        use fgumi_raw_bam::testutil::encode_op;
+        let name = format!("read{idx}");
+        let mut b = RawSamBuilder::new();
+        b.read_name(name.as_bytes())
+            .sequence(b"ACGT")
+            .qualities(&[30; 4])
+            .flags(0) // unpaired, mapped, forward
+            .ref_id(tid)
+            .pos(pos0)
+            .cigar_ops(&[encode_op(0, 4)]);
+        let key = GroupKey::single(tid, pos0 + 1, 0, 0, 0, idx as u64 + 1);
+        DecodedRecord::from_raw_bytes(b.build(), key)
+    }
+
+    /// Helper: a mapped, forward SECONDARY record at `(tid, pos0)` with a resolved
+    /// real position in its raw bytes but an UNKNOWN `GroupKey` (as decode assigns
+    /// sec/supp), so grouping's skip fires on it. Used to prove `--verify` checks
+    /// order *before* the skip.
+    fn make_secondary_at(tid: i32, pos0: i32, idx: usize) -> DecodedRecord {
+        use fgumi_raw_bam::testutil::encode_op;
+        let name = format!("sec{idx}");
+        let mut b = RawSamBuilder::new();
+        b.read_name(name.as_bytes())
+            .sequence(b"ACGT")
+            .qualities(&[30; 4])
+            .flags(raw_flags::SECONDARY)
+            .ref_id(tid)
+            .pos(pos0)
+            .cigar_ops(&[encode_op(0, 4)]);
+        let key = GroupKey { name_hash: idx as u64 + 1, ..GroupKey::default() };
+        DecodedRecord::from_raw_bytes(b.build(), key)
+    }
+
+    /// Feed a sequence of `(tid, pos0)` records to a `--verify`-enabled grouper
+    /// and return the first ordering error, if any.
+    fn run_verify(positions: &[(i32, i32)], grouper: &mut RecordPositionGrouper) -> io::Result<()> {
+        for (idx, &(tid, pos0)) in positions.iter().enumerate() {
+            grouper.add_record(make_mapped_forward(tid, pos0, idx))?;
+        }
+        grouper.finish()?;
+        Ok(())
+    }
+
+    /// `--verify` accepts input in strict template-coordinate order (ties and
+    /// ascending positions across references) and rejects the first record that
+    /// sorts before its predecessor. Ordering is by `(tid, unclipped-5' pos)`.
+    #[rstest]
+    #[case::ascending_same_ref(&[(0, 100), (0, 200), (0, 300)], true)]
+    #[case::equal_positions_ok(&[(0, 100), (0, 100), (0, 100)], true)]
+    #[case::ascending_across_refs(&[(0, 500), (1, 100), (1, 200)], true)]
+    #[case::descending_same_ref(&[(0, 300), (0, 100)], false)]
+    #[case::descending_ref(&[(1, 100), (0, 100)], false)]
+    #[case::regression_after_run(&[(0, 100), (0, 200), (0, 150)], false)]
+    fn record_position_grouper_verify_order(
+        #[case] positions: &[(i32, i32)],
+        #[case] should_pass: bool,
+    ) {
+        let header = noodles::sam::Header::default();
+        let mut grouper = RecordPositionGrouper::new();
+        grouper.enable_verify(&header);
+        let result = run_verify(positions, &mut grouper);
+        assert_eq!(
+            result.is_ok(),
+            should_pass,
+            "verify result {result:?} did not match expected pass={should_pass}"
+        );
+        if let Err(e) = result {
+            assert_eq!(e.kind(), io::ErrorKind::InvalidData);
+            let msg = e.to_string();
+            assert!(
+                msg.contains("template-coordinate sort order"),
+                "error should name the ordering requirement, got: {msg}"
+            );
+        }
+    }
+
+    /// Without `--verify`, an out-of-order stream is grouped without error — the
+    /// verifier is the only thing that rejects it, proving the guard is what bites.
+    #[test]
+    fn record_position_grouper_without_verify_accepts_out_of_order() {
+        let mut grouper = RecordPositionGrouper::new();
+        run_verify(&[(0, 300), (0, 100)], &mut grouper)
+            .expect("no verifier: out-of-order input must not be rejected");
+    }
+
+    /// `--verify` composes with `with_secondary_supplementary`: in-order primaries
+    /// still pass with sec/supp inclusion enabled.
+    #[test]
+    fn record_position_grouper_verify_composes_with_secondary_supplementary() {
+        let header = noodles::sam::Header::default();
+        let mut grouper = RecordPositionGrouper::with_secondary_supplementary();
+        grouper.enable_verify(&header);
+        run_verify(&[(0, 100), (0, 200), (0, 300)], &mut grouper)
+            .expect("in-order input must pass verification with sec/supp inclusion");
+    }
+
+    /// An out-of-order secondary read is rejected by `--verify` in BOTH grouper
+    /// modes:
+    /// - `new()` (group): sec/supp are skipped, but verify runs BEFORE the skip, so
+    ///   the out-of-order secondary is still caught — pinning the check-before-skip
+    ///   placement (moving the check after the skip would let it through).
+    /// - `with_secondary_supplementary()` (dedup): sec/supp are included, and are
+    ///   order-checked like any record — this is the mode dedup always runs in
+    ///   production, so it must catch out-of-order sec/supp reads too.
+    #[rstest]
+    #[case::group_mode_skips_but_verify_checks_first(false)]
+    #[case::dedup_mode_includes_and_checks(true)]
+    fn record_position_grouper_verify_rejects_out_of_order_secondary(
+        #[case] include_secondary_supplementary: bool,
+    ) {
+        let header = noodles::sam::Header::default();
+        let mut grouper = if include_secondary_supplementary {
+            RecordPositionGrouper::with_secondary_supplementary()
+        } else {
+            RecordPositionGrouper::new()
+        };
+        grouper.enable_verify(&header);
+
+        grouper.add_record(make_mapped_forward(0, 299, 0)).expect("in-order primary is accepted");
+        // A SECONDARY read whose raw tid/pos (chr0:100) sorts before the primary
+        // (chr0:300).
+        let err = grouper
+            .add_record(make_secondary_at(0, 99, 1))
+            .expect_err("an out-of-order secondary read must be rejected under --verify");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("template-coordinate sort order"),
+            "error should name the ordering requirement, got: {err}"
+        );
+    }
+
+    /// Extract the template-coordinate key the verifier uses, for the property
+    /// tests' oracle. Keys on `CB` and uses the fixed-seed hasher, exactly as
+    /// [`OrderVerifier`] does.
+    fn oracle_key(
+        rec: &DecodedRecord,
+        lib: &LibraryLookup,
+        hasher: &ahash::RandomState,
+    ) -> TemplateKey {
+        extract_template_key_inline(rec.record(), lib, Some(fgumi_raw_bam::SamTag::CB), hasher)
+    }
+
+    proptest::proptest! {
+        /// Fuzz the verifier's fold over random `(tid, pos)` streams (arbitrary
+        /// orders, shuffles, and ties): `--verify` accepts a stream IFF it is
+        /// non-decreasing under the template-coordinate key (`core_cmp`) — i.e. it
+        /// rejects EVERY out-of-order arrangement, not just the hand-picked shapes
+        /// above. This exercises the control flow (prev-key tracking, checking
+        /// every adjacent pair, no per-position state reset, fail-fast on the first
+        /// violation) against the pure "is it sorted?" predicate. Key extraction
+        /// and `core_cmp` are themselves pinned in fgumi-sort's own suite; this
+        /// pins the verifier's fold, which is the code this change adds.
+        #[test]
+        fn verify_accepts_iff_key_nondecreasing(
+            seq in proptest::collection::vec((0i32..4, 0i32..500), 1..40)
+        ) {
+            let header = noodles::sam::Header::default();
+            let records: Vec<DecodedRecord> =
+                seq.iter().enumerate().map(|(i, &(tid, pos))| make_mapped_forward(tid, pos, i)).collect();
+
+            // Oracle: is the stream non-decreasing under the same key/comparison?
+            let lib = LibraryLookup::from_header(&header);
+            let hasher = cb_hasher();
+            let keys: Vec<TemplateKey> =
+                records.iter().map(|r| oracle_key(r, &lib, &hasher)).collect();
+            let expected_ok =
+                keys.windows(2).all(|w| w[0].core_cmp(&w[1]) != Ordering::Greater);
+
+            let mut grouper = RecordPositionGrouper::new();
+            grouper.enable_verify(&header);
+            let mut got_ok = true;
+            for r in records {
+                if grouper.add_record(r).is_err() {
+                    got_ok = false;
+                    break;
+                }
+            }
+            if got_ok {
+                grouper.finish().expect("finish after a fully-accepted stream must succeed");
+            }
+            proptest::prop_assert_eq!(got_ok, expected_ok);
+        }
+
+        /// Any random set of records, once sorted into template-coordinate key
+        /// order, is ALWAYS accepted — the verifier never rejects a genuinely
+        /// sorted stream, including runs of equal-key ties. The dual of the
+        /// property above: shuffle arbitrarily, sort by the key, and it must pass.
+        #[test]
+        fn verify_accepts_any_key_sorted_stream(
+            seq in proptest::collection::vec((0i32..4, 0i32..500), 1..40)
+        ) {
+            let header = noodles::sam::Header::default();
+            let lib = LibraryLookup::from_header(&header);
+            let hasher = cb_hasher();
+            let mut records: Vec<DecodedRecord> =
+                seq.iter().enumerate().map(|(i, &(tid, pos))| make_mapped_forward(tid, pos, i)).collect();
+            records.sort_by(|a, b| oracle_key(a, &lib, &hasher).core_cmp(&oracle_key(b, &lib, &hasher)));
+
+            let mut grouper = RecordPositionGrouper::new();
+            grouper.enable_verify(&header);
+            for r in records {
+                proptest::prop_assert!(
+                    grouper.add_record(r).is_ok(),
+                    "a key-sorted stream must never be rejected by --verify"
+                );
+            }
+            proptest::prop_assert!(grouper.finish().is_ok());
+        }
     }
 
     #[test]

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -3092,8 +3092,13 @@ impl<'a> ChainBuilder<'a> {
         let mi_assign_step = build_group_mi_assign_step(self.tuning.per_step_byte_limit);
 
         // Wire GroupByPosition → ProcessOrdered → MiAssign (always appended).
-        let tail =
-            self.pipeline.append_step(GroupByPosition::new(self.tuning.per_step_byte_limit), tail);
+        // With --verify, the position grouper strictly checks template-coordinate
+        // order as records stream through the serial step.
+        let mut group_by_position = GroupByPosition::new(self.tuning.per_step_byte_limit);
+        if group.verify {
+            group_by_position = group_by_position.verifying(&self.header);
+        }
+        let tail = self.pipeline.append_step(group_by_position, tail);
         let tail = self.pipeline.append_step(process_step, tail);
         let tail = self.pipeline.append_step(mi_assign_step, tail);
 
@@ -4825,11 +4830,15 @@ impl<'a> ChainBuilder<'a> {
             Arc::clone(&self.progress_records),
         );
 
-        // Wire the dedup-specific steps.
-        let tail = self.pipeline.append_step(
-            GroupByPosition::with_secondary_supplementary(self.tuning.per_step_byte_limit),
-            tail,
-        );
+        // Wire the dedup-specific steps. With --verify, the position grouper
+        // strictly checks template-coordinate order as records stream through the
+        // serial step.
+        let mut group_by_position =
+            GroupByPosition::with_secondary_supplementary(self.tuning.per_step_byte_limit);
+        if dedup.verify {
+            group_by_position = group_by_position.verifying(&self.header);
+        }
+        let tail = self.pipeline.append_step(group_by_position, tail);
         let tail = self.pipeline.append_step(process_step, tail);
         let tail = self.pipeline.append_step(mi_assign_step, tail);
         let tail = self.pipeline.append_step(serialize_step, tail);

--- a/src/lib/pipeline/steps/group/position.rs
+++ b/src/lib/pipeline/steps/group/position.rs
@@ -199,6 +199,16 @@ impl GroupByPosition {
         )
     }
 
+    /// Enable strict template-coordinate sort-order verification (`--verify`) on
+    /// the inner grouper. `header` supplies the read-group -> library-ordinal
+    /// mapping used to build the template-coordinate keys. Composes with either
+    /// constructor (`new` / `with_secondary_supplementary`).
+    #[must_use]
+    pub fn verifying(mut self, header: &noodles::sam::Header) -> Self {
+        self.grouper.enable_verify(header);
+        self
+    }
+
     fn with_grouper(
         grouper: RecordPositionGrouper,
         output_byte_limit: u64,

--- a/tests/integration/test_dedup_command.rs
+++ b/tests/integration/test_dedup_command.rs
@@ -2482,3 +2482,315 @@ fn test_dedup_marks_families_and_flags_tc_keyed_secondary_supplementary(#[case] 
         "the tc-keyed sec/supp read must be retained as {supp_primary}'s and marked duplicate"
     );
 }
+
+// ============================================================================
+// --verify (strict template-coordinate sort-order gate)
+// ============================================================================
+
+/// Build `count` paired-end duplicate templates with INTERNALLY CONSISTENT
+/// mate-strand flags: R1 forward with `MATE_REVERSE` set, R2 reverse with its
+/// mate forward. Unlike [`create_duplicate_group`], whose R1 omits
+/// `MATE_REVERSE`, this makes R1 and R2 resolve to the *same* template
+/// coordinate — a prerequisite for the strict `--verify` order check, which keys
+/// on the exact `fgumi sort --order template-coordinate` key. (An inconsistent
+/// pair splits into two different coordinates, which the strict check then reads
+/// as an out-of-order file.)
+fn create_consistent_pair_group(
+    base_name: &str,
+    umi: &str,
+    count: usize,
+    start: i32,
+) -> Vec<RawRecord> {
+    let mut records = Vec::new();
+    for i in 0..count {
+        let name = format!("{base_name}_{i}");
+        let r1 = {
+            let mut b = SamBuilder::new();
+            b.read_name(name.as_bytes())
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+                .ref_id(0)
+                .pos(start - 1)
+                .mapq(60)
+                .cigar_ops(&[8 << 4]) // 8M
+                .mate_ref_id(0)
+                .mate_pos(start + 99)
+                .template_length(108)
+                .add_string_tag(SamTag::RX, umi.as_bytes())
+                .add_string_tag(SamTag::MC, b"8M");
+            b.build()
+        };
+        let r2 = {
+            let mut b = SamBuilder::new();
+            b.read_name(name.as_bytes())
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+                .ref_id(0)
+                .pos(start + 99)
+                .mapq(60)
+                .cigar_ops(&[8 << 4]) // 8M
+                .mate_ref_id(0)
+                .mate_pos(start - 1)
+                .template_length(-108)
+                .add_string_tag(SamTag::RX, umi.as_bytes())
+                .add_string_tag(SamTag::MC, b"8M");
+            b.build()
+        };
+        records.push(r1);
+        records.push(r2);
+    }
+    records
+}
+
+/// Write `records` verbatim (NO sorting) under a header that advertises
+/// `SS:template-coordinate`. Unlike [`create_sorted_bam`], which shells out to
+/// `fgumi sort`, this preserves the caller's record order, so the header-level
+/// ordering check passes while the records can be genuinely out of order — the
+/// exact shape `--verify` exists to catch.
+fn write_bam_tc_header_unsorted(path: &Path, records: &[RawRecord]) {
+    let header = create_minimal_header("chr1", 10000);
+    let mut writer =
+        bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
+    writer.write_header(&header).expect("Failed to write header");
+    for record in records {
+        writer
+            .write_alignment_record(&header, &to_record_buf(record))
+            .expect("Failed to write record");
+    }
+    writer.try_finish().expect("Failed to finish BAM");
+}
+
+/// Run `dedup --verify` (plus `threads`), returning the raw execute result so a
+/// test can assert on either success or the ordering error.
+fn dedup_verify_result(input: &Path, output: &Path, threads: &[&str]) -> anyhow::Result<()> {
+    let mut args = vec![
+        "dedup",
+        "--input",
+        input.to_str().unwrap(),
+        "--output",
+        output.to_str().unwrap(),
+        "--verify",
+    ];
+    args.extend_from_slice(threads);
+    MarkDuplicates::try_parse_from(args).expect("failed to parse dedup args").execute("fgumi dedup")
+}
+
+/// `--verify` on a correctly template-coordinate-sorted input must succeed and
+/// produce output record-for-record identical to the same run without `--verify`
+/// — the flag is a precondition gate, not a mode, so it must not perturb the
+/// result (and `--output` is still written). Covers the non-chain path and the
+/// `--threads N` chain path.
+#[rstest]
+#[case::single_threaded(&[])]
+#[case::chain_threads2(&["--threads", "2"])]
+fn test_dedup_verify_accepts_sorted_input(#[case] threads: &[&str]) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    // Ascending start positions → correctly template-coordinate sorted.
+    let mut records = create_consistent_pair_group("dup1", "ACGTACGT", 3, 100);
+    records.extend(create_consistent_pair_group("dup2", "TGCATGCA", 2, 500));
+    create_sorted_bam(&input_bam, records);
+
+    let baseline_out = temp_dir.path().join("baseline.bam");
+    dedup_run(&input_bam, &baseline_out, threads);
+    let verified_out = temp_dir.path().join("verified.bam");
+    let mut extra = threads.to_vec();
+    extra.push("--verify");
+    dedup_run(&input_bam, &verified_out, &extra);
+
+    let baseline = read_deduped_records(&baseline_out);
+    assert_eq!(baseline.len(), 10, "sanity: all 10 reads present (duplicates marked, not removed)");
+    assert_eq!(
+        baseline,
+        read_deduped_records(&verified_out),
+        "--verify must not change dedup output on a correctly-sorted input",
+    );
+}
+
+/// `--verify` on an input that is out of template-coordinate order (despite a
+/// header that advertises it) must abort with a non-zero exit and an error that
+/// names the ordering requirement. The same input WITHOUT `--verify` is accepted
+/// — proving the gate is what rejects it. Covers the non-chain and `--threads N`
+/// chain paths.
+#[rstest]
+#[case::single_threaded(&[])]
+#[case::chain_threads2(&["--threads", "2"])]
+fn test_dedup_verify_rejects_out_of_order_input(#[case] threads: &[&str]) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    // Descending start positions → genuinely out of order under a TC-advertising
+    // header (the group at 500 is written before the group at 100). Written
+    // verbatim — NOT through `fgumi sort`, which would reorder it into order.
+    let mut records = create_consistent_pair_group("late", "ACGTACGT", 2, 500);
+    records.extend(create_consistent_pair_group("early", "TGCATGCA", 2, 100));
+    write_bam_tc_header_unsorted(&input_bam, &records);
+
+    // Without --verify the out-of-order input is accepted (no ordering guard).
+    let plain_out = temp_dir.path().join("plain.bam");
+    dedup_run(&input_bam, &plain_out, threads);
+    assert!(
+        !read_deduped_records(&plain_out).is_empty(),
+        "sanity: without --verify the input is deduplicated without error",
+    );
+
+    // With --verify it is rejected before completing.
+    let verified_out = temp_dir.path().join("verified.bam");
+    let err = dedup_verify_result(&input_bam, &verified_out, threads)
+        .expect_err("out-of-order input must be rejected under --verify");
+    let message = format!("{err:#}");
+    assert!(
+        message.contains("template-coordinate sort order"),
+        "error should name the ordering requirement, got: {message}",
+    );
+}
+
+/// dedup's chain verify path must accept a correctly-sorted input that spans many
+/// pipeline batches under multi-worker reordering — the sibling of group's
+/// `test_group_verify_accepts_sorted_multi_batch_chain`. Both commands wire the
+/// same serial `GroupByPosition` step, so the reorder-across-batches risk is
+/// identical; dedup additionally uses `with_secondary_supplementary`, so this also
+/// exercises verify on that grouper variant across batch boundaries.
+#[test]
+fn test_dedup_verify_accepts_sorted_multi_batch_chain() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    // 600 single-pair templates at distinct ascending positions → many position
+    // groups spanning multiple pipeline batches (both the position-group
+    // accumulator and the upstream decode batch).
+    let mut records = Vec::new();
+    for i in 0..600i32 {
+        records.extend(create_consistent_pair_group(&format!("t{i}"), "ACGTACGT", 1, 100 + i * 10));
+    }
+    create_sorted_bam(&input_bam, records);
+
+    let baseline_out = temp_dir.path().join("baseline.bam");
+    dedup_run(&input_bam, &baseline_out, &["--threads", "4"]);
+    let verified_out = temp_dir.path().join("verified.bam");
+    dedup_run(&input_bam, &verified_out, &["--threads", "4", "--verify"]);
+
+    let baseline = read_deduped_records(&baseline_out);
+    assert_eq!(
+        baseline.len(),
+        1200,
+        "600 pairs → 1200 reads present (duplicates marked, not removed)"
+    );
+    assert_eq!(
+        baseline,
+        read_deduped_records(&verified_out),
+        "--verify must accept a correctly-sorted input spanning many pipeline batches under \
+         multi-worker reordering, and must not change the output",
+    );
+}
+
+/// Build a single-end mapped read carrying `RG` and `CB` tags at `start`
+/// (1-based). Used to exercise the cell-barcode lane of the template-coordinate
+/// sort key, which `--verify` must key on to match `fgumi sort`'s default.
+fn single_end_rg_cb(name: &str, start: i32, rg_id: &str, cb: &str) -> RawRecord {
+    let mut b = SamBuilder::new();
+    b.read_name(name.as_bytes())
+        .sequence(b"ACGTACGT")
+        .qualities(&[30; 8])
+        .flags(0) // unpaired, mapped, forward
+        .ref_id(0)
+        .pos(start - 1)
+        .mapq(60)
+        .cigar_ops(&[8 << 4]) // 8M
+        .add_string_tag(SamTag::RX, b"ACGTACGT")
+        .add_string_tag(SamTag::RG, rg_id.as_bytes())
+        .add_string_tag(SamTag::CB, cb.as_bytes());
+    b.build()
+}
+
+/// Write `records` under `header`, then sort with `fgumi sort --order
+/// template-coordinate` using the DEFAULT `--key-types` (auto-detect, which
+/// INCLUDES the CB lane for CB-tagged input). Unlike [`create_sorted_bam`], which
+/// passes `--key-types mi` and drops the CB lane, this reproduces the exact order
+/// the command `--verify`'s help/error tells users to run.
+fn sort_default_keytypes(
+    temp_dir: &Path,
+    header: &noodles::sam::Header,
+    records: &[RawRecord],
+) -> std::path::PathBuf {
+    let unsorted = temp_dir.join("cb_unsorted.bam");
+    let mut writer =
+        bam::io::Writer::new(fs::File::create(&unsorted).expect("Failed to create BAM file"));
+    writer.write_header(header).expect("Failed to write header");
+    for r in records {
+        writer.write_alignment_record(header, &to_record_buf(r)).expect("Failed to write record");
+    }
+    writer.try_finish().expect("Failed to finish BAM");
+
+    let sorted = temp_dir.join("cb_sorted.bam");
+    let status = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "sort",
+            "-i",
+            unsorted.to_str().unwrap(),
+            "-o",
+            sorted.to_str().unwrap(),
+            "--order",
+            "template-coordinate",
+        ])
+        .status()
+        .expect("failed to spawn `fgumi sort` for CB test input");
+    assert!(status.success(), "failed to template-coordinate sort CB test input");
+    sorted
+}
+
+/// Regression for the CB-keying bug: `fgumi sort --order template-coordinate` keys
+/// on the `CB` tag by default (`parse_cell_tag`), and `cb_hash` outranks the
+/// library lane in `TemplateKey::core_cmp`. Two same-position reads whose `CB`
+/// order is the OPPOSITE of their library order are emitted by that sort in `CB`
+/// order; `--verify` must accept it because it keys on `CB` too. A CB-blind
+/// verifier (`cell_tag = None`) would see the library lane out of order and
+/// spuriously reject. `cb_hash(AAAAAAAA) < cb_hash(TTTTTTTT)` under fgumi's
+/// fixed-seed hasher, so pairing `CB=AAAAAAAA` with the higher library ordinal
+/// (`libB` = `RG2`) makes the CB-sorted order run library-descending — the exact
+/// shape that trips a `None` verifier. (Sorted via `fgumi sort` itself, so the
+/// input is genuinely what the recommended command produces, whatever the hash.)
+#[test]
+fn test_dedup_verify_accepts_cb_sorted_multi_library() {
+    let temp_dir = TempDir::new().unwrap();
+    let header = create_multi_library_header("chr1", 10000);
+    let records = [
+        single_end_rg_cb("readA", 501, "RG1", "TTTTTTTT"), // libA (ordinal 1), high cb_hash
+        single_end_rg_cb("readB", 501, "RG2", "AAAAAAAA"), // libB (ordinal 2), low cb_hash
+    ];
+    let sorted = sort_default_keytypes(temp_dir.path(), &header, &records);
+
+    let out = temp_dir.path().join("out.bam");
+    dedup_verify_result(&sorted, &out, &[])
+        .expect("--verify must accept the CB-sorted multi-library input `fgumi sort` produced");
+}
+
+/// A coordinate-ordered (mate-interleaved) paired file is a realistic mislabel:
+/// records physically in `SO:coordinate` order but under a header advertising
+/// `SS:template-coordinate`. That is NOT template-coordinate order — coordinate
+/// sort interleaves mates by each read's own leftmost position instead of
+/// grouping a template's two reads at their shared canonical coordinate — so
+/// `--verify` must reject it. (An *honestly*-labeled non-TC file, i.e. an
+/// `SO:coordinate`/`SO:queryname` header, is already rejected upstream by the
+/// header-ordering check before `--verify` runs; this exercises the record-order
+/// discontinuity that check cannot see.)
+#[test]
+fn test_dedup_verify_rejects_coordinate_ordered_input() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    // Two templates. Template-coordinate order keeps each mate pair adjacent
+    // (T1.R1,T1.R2,T2.R1,T2.R2); coordinate order interleaves them by leftmost
+    // position: R1@100, R1@150, R2@200, R2@250.
+    let t1 = create_consistent_pair_group("T1", "ACGTACGT", 1, 100); // [R1@100, R2@200]
+    let t2 = create_consistent_pair_group("T2", "TGCATGCA", 1, 150); // [R1@150, R2@250]
+    let coordinate_order = vec![t1[0].clone(), t2[0].clone(), t1[1].clone(), t2[1].clone()];
+    write_bam_tc_header_unsorted(&input_bam, &coordinate_order);
+
+    let out = temp_dir.path().join("out.bam");
+    let err = dedup_verify_result(&input_bam, &out, &[])
+        .expect_err("coordinate-ordered (mate-interleaved) input must be rejected under --verify");
+    assert!(
+        format!("{err:#}").contains("template-coordinate sort order"),
+        "error should name the ordering requirement, got: {err:#}",
+    );
+}

--- a/tests/integration/test_group_command.rs
+++ b/tests/integration/test_group_command.rs
@@ -654,6 +654,32 @@ fn create_supplementary_split_bam(path: &PathBuf) {
     writer.try_finish().expect("Failed to finish BAM");
 }
 
+// ============================================================================
+// --verify (strict template-coordinate sort-order gate)
+// ============================================================================
+
+/// Build a BAM whose header advertises template-coordinate order but whose
+/// records are written in the given position order. `create_minimal_header`
+/// stamps `SS:template-coordinate`, so a descending `positions` list passes the
+/// header-level ordering check while the records are genuinely out of order —
+/// exactly what `--verify` exists to catch.
+fn create_tc_bam_at_positions(path: &std::path::Path, positions: &[usize]) {
+    let header = create_minimal_header("chr1", 10_000_000);
+    let mut writer =
+        bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
+    writer.write_header(&header).expect("Failed to write header");
+    for (i, &pos) in positions.iter().enumerate() {
+        for record in
+            &create_umi_family_at_pos("AAAAAAAA", 1, &format!("fam{i}"), "ACGTACGT", 30, pos)
+        {
+            writer
+                .write_alignment_record(&header, &to_record_buf(record))
+                .expect("Failed to write record");
+        }
+    }
+    writer.try_finish().expect("Failed to finish BAM");
+}
+
 /// Build the paired-end analogue of [`create_supplementary_split_bam`]: two
 /// paired templates sharing one UMI at the same 5' positions (one molecule), with
 /// a `tc`-keyed supplementary interleaved between them. This mirrors real client
@@ -788,4 +814,103 @@ fn test_group_supplementary_does_not_inflate_molecule_count(
     // names its two templates `pair1`/`pair2` (R1 and R2 share the QNAME).
     let expected_qnames: &[&str] = if paired { &["pair1", "pair2"] } else { &["b1_0", "b2_0"] };
     assert_single_molecule_no_secondary(&records, expected_qnames);
+}
+
+/// Run `group --verify` (plus `threads`), returning the raw execute result so a
+/// test can assert on either success or the ordering error.
+fn group_verify_result(
+    dir: &std::path::Path,
+    input: &std::path::Path,
+    threads: &[&str],
+) -> anyhow::Result<()> {
+    let output = dir.join("verify_out.bam");
+    let mut extra = threads.to_vec();
+    extra.push("--verify");
+    let cmd = GroupReadsByUmi::try_parse_from(group_args(
+        input.to_str().unwrap(),
+        output.to_str().unwrap(),
+        &extra,
+    ))
+    .expect("failed to parse group args");
+    cmd.execute("fgumi group")
+}
+
+/// `--verify` on a correctly template-coordinate-sorted input must succeed and
+/// produce output byte-for-byte identical (record-for-record) to the same run
+/// without `--verify` — the flag is a precondition gate, not a mode, so it must
+/// not perturb the result. Covers both the single-threaded fast path and the
+/// `--threads N` chain path.
+#[rstest]
+#[case::single_threaded(&[])]
+#[case::chain_threads2(&["--threads", "2"])]
+fn test_group_verify_accepts_sorted_input(#[case] threads: &[&str]) {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    // Ascending positions → correctly template-coordinate sorted.
+    create_tc_bam_at_positions(&input_bam, &[100, 200, 300, 400, 500]);
+
+    let baseline = run_group_records(temp_dir.path(), "baseline", &input_bam, threads);
+    let mut extra = threads.to_vec();
+    extra.push("--verify");
+    let verified = run_group_records(temp_dir.path(), "verified", &input_bam, &extra);
+
+    assert_eq!(verified.len(), 5, "expected one grouped record per position group");
+    assert_eq!(
+        baseline, verified,
+        "--verify must not change the output on a correctly-sorted input (--output still written)",
+    );
+}
+
+/// `--verify` on an input that is out of template-coordinate order (despite a
+/// header that advertises it) must abort with a non-zero exit and an error that
+/// names the ordering requirement. The same input WITHOUT `--verify` is accepted
+/// — proving the gate is what rejects it, not some other validation. Covers both
+/// the single-threaded and `--threads N` chain paths.
+#[rstest]
+#[case::single_threaded(&[])]
+#[case::chain_threads2(&["--threads", "2"])]
+fn test_group_verify_rejects_out_of_order_input(#[case] threads: &[&str]) {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    // Descending positions → genuinely out of order under a TC-advertising header.
+    create_tc_bam_at_positions(&input_bam, &[500, 400, 300, 200, 100]);
+
+    // Without --verify the out-of-order input is accepted (no ordering guard).
+    let without = run_group_records(temp_dir.path(), "without_verify", &input_bam, threads);
+    assert!(!without.is_empty(), "sanity: without --verify the input is grouped without error");
+
+    // With --verify it is rejected before completing.
+    let err = group_verify_result(temp_dir.path(), &input_bam, threads)
+        .expect_err("out-of-order input must be rejected under --verify");
+    let message = format!("{err:#}");
+    assert!(
+        message.contains("template-coordinate sort order"),
+        "error should name the ordering requirement, got: {message}",
+    );
+}
+
+/// The verify-accepts cases above use a single-batch input. The real risk of
+/// `--verify` on the chain path is that records reach the *serial* grouper in
+/// genuine input order after multi-worker decode/reorder — a reorder regression
+/// that only bites past the pipeline's batch boundaries (both the position-group
+/// accumulator and the upstream decode batch) would make `--verify` spuriously
+/// reject correctly-sorted real inputs, and no other test would catch it. Run
+/// `--threads 4 --verify` over a 600-position input and require both that it
+/// succeeds and that its output equals the non-verify run.
+#[test]
+fn test_group_verify_accepts_sorted_multi_batch_chain() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    create_multi_batch_input_bam(&input_bam, 600);
+
+    let baseline = run_group_records(temp_dir.path(), "baseline", &input_bam, &["--threads", "4"]);
+    let verified =
+        run_group_records(temp_dir.path(), "verified", &input_bam, &["--threads", "4", "--verify"]);
+
+    assert_eq!(baseline.len(), 600, "expected 600 grouped records (one per position group)");
+    assert_eq!(
+        baseline, verified,
+        "--verify must accept a correctly-sorted input spanning many pipeline batches \
+         under multi-worker reordering, and must not change the output",
+    );
 }


### PR DESCRIPTION
## Summary

Adds an opt-in `--verify` flag to `fgumi group` and `fgumi dedup` that checks the input is in strict `fgumi sort --order template-coordinate` order and **fails fast** (non-zero exit) on the first out-of-order record, before writing a wrong result. Off by default.

`fgumi group`/`dedup` already assume template-coordinate input but only validate the header's sort tags (`SO`/`GO`/`SS`), not the actual record order — so a mislabeled or mangled file is silently mis-grouped. `--verify` closes that gap for callers who want a hard guarantee.

## Design

- **One insertion point.** The check runs inline, single-pass, at the top of `RecordPositionGrouper::process_record` — the serial chokepoint shared by all four paths (`group`/`dedup` × non-chain / `--threads N` chain). It runs *before* the secondary/supplementary skip, so the whole file's canonical order is checked, including sec/supp reads that grouping later drops.
- **Reuses the sort's own key.** It calls `fgumi_sort::extract_template_key_inline` and compares with `TemplateKey::core_cmp` (the same tolerant comparison `fgumi sort --verify` uses, which ignores the `name_hash` tie-break so both fgumi- and samtools-sorted inputs pass). It keys on the `CB` cell tag — matching what `fgumi sort --order template-coordinate` emits by default (`parse_cell_tag`), using the same fixed-seed hasher — so a correctly-sorted single-cell/multi-library input is not spuriously rejected.
- **Strict by design → opt-in.** The check is stricter than grouping/dedup strictly require (they only need a template's mates adjacent by position). That strictness is why it is opt-in, and the help text says so. For a standalone check-only pass, `fgumi sort --verify` already exists; here `--verify` is a precondition **gate** that composes with `--output`.

## Testing

- **Grouper unit tests:** in-order accept, out-of-order reject (including a mid-run regression), equal-position ties, cross-reference order, and out-of-order **secondary** reads rejected in both grouper modes (pinning that the check runs before the sec/supp skip).
- **Property tests (`proptest`, 256 cases each):** `--verify` accepts a random `(tid,pos)` stream **iff** it is non-decreasing under the template key, and any key-sorted stream is always accepted — fuzzing the fold over arbitrary orders, shuffles, and ties.
- **Integration tests (both commands, single-threaded and `--threads` chain):** `--verify` accepts a correctly-sorted input and leaves output identical to the non-verify run; rejects an out-of-order input with a clear error while the same input is accepted without `--verify`.
- **Multi-batch (600-position) chain acceptance** for both commands — guards cross-worker reorder across pipeline batch boundaries.
- **CB / multi-library regression:** an input `fgumi sort` orders by cell-barcode hash (overriding library order) is accepted by `--verify`; a CB-blind check would spuriously reject it.
- **Coordinate-mislabel:** a coordinate-ordered (mate-interleaved) file under a template-coordinate header is rejected.

## Notes

- Independent of #903 (the #901 secondary/supplementary molecule-count fix) and #908 (dedup fixture mate-flag corrections); this branch is off `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: output changes only when `--verify` rejects out-of-order input; `unsafe` changes are none, and no `CLAUDE.md` allowlist update applies; memory bounds, queue capacity, and thread/backpressure policy changes are none.

Fix: Use `--verify` with `fgumi group` or `fgumi dedup` to fail fast on input that is not in strict template-coordinate order. Verification is disabled by default.

- Reuses the `fgumi sort --order template-coordinate` key and comparison logic.
- Checks records before secondary and supplementary reads are skipped.
- Applies to single-threaded, threaded-chain, and multi-batch processing.
- Uses the `CB` tag and fixed-seed hash for ordering.
- Covers sorted input, out-of-order input, ties, references, secondary reads, multi-library data, threaded execution, and misleading headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->