### PR TITLE
docs: add NanoSeq (Duplex-Seq) pipeline guide

### DIFF
--- a/crates/xtask/src/generate_summary.rs
+++ b/crates/xtask/src/generate_summary.rs
@@ -71,6 +71,18 @@ pub fn generate(
         }
     }
 
+    // NanoSeq sub-group
+    let nanoseq = [("Pipeline Guide", "guide/nanoseq.md")];
+    let nanoseq_exists = nanoseq.iter().any(|(_, p)| docs_src.join(p).exists());
+    if nanoseq_exists {
+        md.push_str("- [NanoSeq (Duplex-Seq)]()\n");
+        for (title, path) in &nanoseq {
+            if docs_src.join(path).exists() {
+                let _ = writeln!(md, "  - [{title}]({path})");
+            }
+        }
+    }
+
     // Advanced Topics sub-group
     let advanced = [
         ("Best Practices", "guide/best-practices.md"),
@@ -181,4 +193,48 @@ pub fn generate(
 
     fs::write(docs_src.join("SUMMARY.md"), md)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Generate `SUMMARY.md` for a docs tree that either has or lacks the
+    /// `NanoSeq` guide page, and return the markdown it wrote.
+    fn summary_with_nanoseq(present: bool) -> String {
+        let tmp = TempDir::new().expect("failed to create temp dir");
+        let docs_src = tmp.path();
+        let guide_dir = docs_src.join("guide");
+        fs::create_dir_all(&guide_dir).expect("failed to create guide dir");
+        if present {
+            fs::write(guide_dir.join("nanoseq.md"), "# NanoSeq\n").expect("failed to write guide");
+        }
+        generate(docs_src, &[], &[]).expect("generate failed");
+        fs::read_to_string(docs_src.join("SUMMARY.md")).expect("failed to read SUMMARY.md")
+    }
+
+    #[test]
+    fn nanoseq_group_present_when_guide_exists() {
+        let md = summary_with_nanoseq(true);
+        assert!(md.contains("- [NanoSeq (Duplex-Seq)]()"), "missing NanoSeq group:\n{md}");
+        assert!(
+            md.contains("  - [Pipeline Guide](guide/nanoseq.md)"),
+            "missing NanoSeq guide link:\n{md}"
+        );
+    }
+
+    #[test]
+    fn nanoseq_group_absent_when_guide_missing() {
+        let md = summary_with_nanoseq(false);
+        assert!(
+            !md.contains("NanoSeq"),
+            "NanoSeq group should be omitted when guide is missing:\n{md}"
+        );
+        assert!(
+            !md.contains("guide/nanoseq.md"),
+            "NanoSeq link should be omitted when guide is missing:\n{md}"
+        );
+    }
 }

--- a/docs/src/guide/nanoseq.md
+++ b/docs/src/guide/nanoseq.md
@@ -1,0 +1,165 @@
+# NanoSeq (Duplex-Seq) Guide
+
+This guide describes how to process **NanoSeq** duplex sequencing data through fgumi's
+consensus pipeline. NanoSeq (and the closely related BotSeqS/Duplex-Seq protocols) tag both
+strands of each source molecule, so it fits fgumi's `paired` (duplex) grouping and `duplex`
+consensus calling without any NanoSeq-specific code — the only protocol-specific choice is the
+[read structure](read-structures.md).
+
+## Background
+
+NanoSeq is a whole-genome **duplex sequencing** protocol (Abascal et al., *Nature* 2021) designed
+to call somatic mutations at single-molecule accuracy. Unlike hybridization-capture UMI panels,
+where duplex recovery is rare, NanoSeq is engineered so that **most molecules are observed on both
+strands** — which is exactly the regime `fgumi duplex` exists for.
+
+Two design details matter for UMI processing:
+
+- **A short inline barcode.** Each read begins with a 3&nbsp;bp molecular barcode, followed by a
+  few constant bases from the protocol's restriction-based fragmentation that carry no molecular
+  information and are skipped.
+- **A read-barcode / mate-barcode pair.** The molecule's identity is the *pair* of the two reads'
+  3&nbsp;bp barcodes together with the fragment's genomic coordinates. The two physical strands of
+  one molecule are sequenced as separate templates whose barcode pairs are the **same two
+  barcodes in swapped order**.
+
+That swapped-pair structure is precisely what fgumi's `paired` grouping strategy canonicalizes: it
+combines the two reads' UMIs into one order-independent molecule key and assigns the two strands
+the `/A` and `/B` suffixes on the `MI` tag. No NanoSeq-aware logic is required — extracting the
+barcodes into the standard `RX` tag and grouping with `--strategy paired` reproduces NanoSeq's
+read-bundle model.
+
+## Read Structure
+
+NanoSeq's canonical extraction (the `cancerit/NanoSeq` `extract_tags.py -m 3 -s 4`) trims a
+3&nbsp;bp barcode and skips 4&nbsp;bp of constant sequence on **each** read. In fgumi read-structure
+terms that is:
+
+```text
+3M4S+T 3M4S+T
+```
+
+- `3M` — the 3&nbsp;bp molecular barcode (UMI), stored in `RX`.
+- `4S` — 4&nbsp;bp of restriction-site/constant sequence, skipped.
+- `+T` — the remaining bases are template (insert).
+
+Both reads use the same structure because both carry a barcode. After extraction each read's `RX`
+holds its own barcode plus its mate's, e.g. `RX:Z:GGG-GCA`; the opposite strand of the same
+molecule carries the swapped pair `RX:Z:GCA-GGG`.
+
+> If your NanoSeq library was prepared with a different barcode or skip length, adjust the `3M` /
+> `4S` counts to match; check the `extract_tags` parameters used for your data.
+
+## Pipeline
+
+The NanoSeq pipeline is the [standard duplex pipeline](best-practices.md) with the NanoSeq read
+structure at extraction. Alignment should be **genome-wide** (NanoSeq is WGS): the molecular key
+depends on true fragment coordinates, so mapping to a subset reference and letting off-target reads
+force-map would merge unrelated molecules.
+
+```text
+FASTQ → extract → fastq | aligner | zipper → sort → group → duplex → duplex-metrics
+```
+
+### Step 1: UMI Extraction
+
+```bash
+fgumi extract \
+    --inputs R1.fastq.gz R2.fastq.gz \
+    --output extracted.bam \
+    --read-structures "3M4S+T" "3M4S+T" \
+    --sample my_sample --library lib1
+```
+
+### Step 2: Alignment
+
+Convert back to FASTQ, align genome-wide, and merge the UMI tags back onto the aligned reads with
+`zipper`. `zipper` walks the extracted and aligned BAMs in lockstep, so the aligner must
+**preserve read names exactly and emit records in the same queryname grouping and order as the
+extracted BAM** — both inputs must carry the same set of read names in the same order, with
+same-named records consecutive. Aligning the interleaved FASTQ with `bwa mem -p` (below) satisfies
+this; use the same reference for `zipper --reference`.
+
+```bash
+samtools fastq extracted.bam \
+    | bwa mem -t 16 -p -K 150000000 -Y hg38.fa - \
+    | fgumi zipper \
+        --unmapped extracted.bam \
+        --reference hg38.fa \
+        --output mapped.bam \
+        --threads 16
+```
+
+### Step 3: Sort
+
+Group requires template-coordinate order:
+
+```bash
+fgumi sort --input mapped.bam --output sorted.bam --order template-coordinate --threads 16
+```
+
+### Step 4: UMI Grouping (paired / duplex)
+
+Use `--strategy paired` so the two strands of each molecule are grouped together and assigned
+`/A` and `/B`. Pass `--edits 0` for exact barcode matching: NanoSeq's 3&nbsp;bp-per-read barcodes
+give only 4096 possible pairs, so two distinct molecules that share a fragment's exact start/stop
+(a routine coordinate duplicate) can fall within the default `--edits 1` of each other and be
+merged. Canonical NanoSeq matches barcodes exactly — dropping a barcode-error read rather than
+risking a merge — which preserves single-molecule specificity:
+
+```bash
+fgumi group --input sorted.bam --output grouped.bam --strategy paired --edits 0 --threads 16
+```
+
+### Step 5: Duplex Consensus
+
+Call duplex consensus reads from the grouped BAM. See [Duplex Consensus
+Calling](duplex-consensus-calling.md) for the `--min-reads` semantics (one, two, or three values,
+high to low):
+
+```bash
+fgumi duplex --input grouped.bam --output consensus.bam --min-reads 1,1,0
+```
+
+`--min-reads 1,1,0` keeps every molecule (including single-strand ones); require `1,1,1` (or
+higher on each strand) if you want **only** true duplex molecules.
+
+### Step 6: QC Metrics
+
+```bash
+fgumi duplex-metrics --input grouped.bam --output my_sample
+```
+
+## Interpreting the Duplex Metrics
+
+`duplex-metrics` writes `<prefix>.duplex_yield_metrics.txt`, whose last row (100% of the data)
+summarizes duplex recovery. The families are counted at three levels of specificity:
+
+- **CS** — coordinate + strand (physical fragments, pre-UMI).
+- **SS** — single-strand tag families (coordinate + strand + UMI).
+- **DS** — double-strand families (coordinate + UMI, collapsing the two strands).
+
+The headline number is **`ds_fraction_duplexes`**: the fraction of double-strand families for which
+**both** strands were actually observed — i.e. the true duplex rate. For a healthy NanoSeq library
+this is high (a well-covered library commonly lands above 0.5); a value near zero means the data is
+effectively simplex and duplex calling will yield little. `ds_fraction_duplexes_ideal` is the
+asymptotic value at infinite sampling, so the gap between the two tells you how much duplex yield
+more sequencing would recover.
+
+The `<prefix>.duplex_family_sizes.txt` file breaks families down by `ab_size` / `ba_size` — the
+number of reads observed on each strand — which is the distribution the `duplex --min-reads`
+thresholds act on.
+
+## Notes
+
+- **Map genome-wide.** The molecule key is coordinate-anchored, so a subset reference distorts
+  grouping. To restrict analysis to a region, align to the whole genome first and *then* subset by
+  the aligned position, rather than aligning to a partial reference.
+- **`paired` is required for duplex.** Only `--strategy paired` resolves the `/A` and `/B` strands;
+  `adjacency`/`edit`/`identity` produce single-strand families and cannot feed `fgumi duplex`.
+- **No UMI correction step; match barcodes exactly (`--edits 0`).** NanoSeq barcodes are random
+  3-mers, not a fixed whitelist, so there is no `fgumi correct` step. Group with `--edits 0` rather
+  than the default `--edits 1`, which tolerates one mismatch across the *entire* 6&nbsp;bp
+  concatenated barcode pair (see [UMI Grouping](umi-grouping.md)) — enough that two unrelated
+  molecules at a coordinate-duplicate position can be merged. Exact matching instead drops a
+  barcode-error read from its family, the conservative failure mode NanoSeq's design assumes.


### PR DESCRIPTION
Adds a user-guide page documenting how to process **NanoSeq** (and the related BotSeqS/Duplex-Seq) data through fgumi.

## Why

NanoSeq is a whole-genome duplex sequencing protocol. It tags both strands of each molecule with a 3 bp inline barcode and identifies molecules by fragment coordinates plus the read/mate barcode pair. That model maps directly onto fgumi's existing `paired` grouping and `duplex` consensus — **no NanoSeq-specific code is needed**; the only protocol-specific choice is the read structure. The guide makes that explicit so users don't assume NanoSeq needs a separate tool.

## What the guide covers

- **Read structure `3M4S+T 3M4S+T`** — 3 bp barcode + 4 bp restriction-site skip, matching `cancerit/NanoSeq`'s `extract_tags -m 3 -s 4`.
- **The duplex mechanism** — each read's `RX` holds its own barcode plus its mate's (e.g. `GGG-GCA`); the opposite strand carries the swapped pair (`GCA-GGG`), which `--strategy paired` canonicalizes into one molecule with `/A` and `/B` strands.
- **End-to-end pipeline** — `extract` → align genome-wide → `zipper` → `sort` (template-coordinate) → `group --strategy paired` → `duplex` → `duplex-metrics`, with runnable commands.
- **Reading the metrics** — CS/SS/DS families and the `ds_fraction_duplexes` headline number.
- **Notes** — why genome-wide alignment matters (the key is coordinate-anchored), why `paired` is required, and why there is no `correct` step (random barcodes, not a fixed whitelist).

Registered in the generated `SUMMARY.md` as a protocol guide alongside Methylation (via `crates/xtask/src/generate_summary.rs`).

## Validation

- `cargo run -p xtask -- docs-build` succeeds; the page builds and the `linkcheck2` backend passes (all internal links resolve).
- The documented pipeline was run end-to-end on real NanoSeq data (Sanger Duplex-Seq, PRJEB71741): `extract 3M4S+T` + `group --strategy paired` + `duplex-metrics` produced a healthy duplex library (`ds_fraction_duplexes` ≈ 0.56), confirming the read structure and grouping described here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: command output changes (grouping, consensus, sort order, corrected UMIs, metrics): none; `unsafe` changes: none, with no `CLAUDE.md` allowlist update; memory, queue, and thread/backpressure policy changes: none. Fix: none required.

Adds a NanoSeq, BotSeqS, and Duplex-Seq guide. It covers read structure, paired barcodes, alignment, `paired` grouping, duplex consensus, metrics, and random-barcode handling.

Registers the guide in generated `SUMMARY.md`. Documentation builds, link checks, and an end-to-end NanoSeq test passed. The test produced `ds_fraction_duplexes` of approximately `0.56`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->