### PR TITLE
feat(runall): fused multi-stage `fgumi runall` command

### DIFF
--- a/src/lib/commands/duplex.rs
+++ b/src/lib/commands/duplex.rs
@@ -424,6 +424,34 @@ impl DuplexOptions {
             consensus_call_overlapping_bases: self.consensus_call_overlapping_bases,
         }
     }
+
+    /// Validate the numeric bounds fgbio's `CallDuplexConsensusReads` enforces:
+    /// both pre- and post-UMI Phred error rates strictly greater than zero, the
+    /// `--min-reads` ordering rule (each value no larger than the one before it),
+    /// and a `--max-reads-per-strand` of at least one. A rate of Q0 corresponds
+    /// to `P(error) = 1` (nonsensical as a prior) and a cap of 0 empties every
+    /// strand, so no molecule can produce a consensus (a silent empty BAM).
+    ///
+    /// Shared by `Duplex::validate` (the standalone CLI path) and the runall
+    /// duplex arm, so both reject the same degenerate configs from one guard.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if either error rate is 0, if `--min-reads` violates the
+    /// ordering rule, or if `--max-reads-per-strand` is `Some(0)`.
+    pub fn validate_numeric(&self) -> Result<()> {
+        if self.error_rate_pre_umi == 0 {
+            bail!("error-rate-pre-umi must be > 0");
+        }
+        if self.error_rate_post_umi == 0 {
+            bail!("error-rate-post-umi must be > 0");
+        }
+        DuplexConsensusCaller::validate_min_reads(&self.min_reads)?;
+        if self.max_reads_per_strand == Some(0) {
+            bail!("--max-reads-per-strand must be >= 1");
+        }
+        Ok(())
+    }
 }
 
 impl Command for Duplex {
@@ -812,12 +840,6 @@ impl Duplex {
     /// a prior and would corrupt the duplex consensus quality model, so fgbio
     /// rejects it (`CallDuplexConsensusReads.scala:131-132`).
     fn validate(&self) -> Result<()> {
-        if self.consensus.error_rate_pre_umi == 0 {
-            bail!("error-rate-pre-umi must be > 0");
-        }
-        if self.consensus.error_rate_post_umi == 0 {
-            bail!("error-rate-post-umi must be > 0");
-        }
         // `--min-reads` is deliberately not bounded below, matching fgbio, which validates
         // only the ordering -- each value no larger than the one before it
         // (`total >= XY >= YX`). A 0 in the per-strand slots is fgbio's single-strand mode
@@ -832,19 +854,18 @@ impl Duplex {
         // caller inside the pipeline's per-batch closure, i.e. after the output BAM has
         // been created, so relying on the constructor alone would turn an argument error
         // into a mid-run worker failure that leaves a partial output file behind.
-        DuplexConsensusCaller::validate_min_reads(&self.min_reads)?;
-
+        //
         // `--max-reads-per-strand 0` empties every strand, so no molecule can produce a
         // consensus. fgbio failed deep in consensus calling with a bare
         // `IllegalArgumentException` (fixed in fulcrumgenomics/fgbio#1166); fgumi was quieter
-        // still, exiting 0 having written an empty BAM. Only a lower bound is checked here,
+        // still, exiting 0 having written an empty BAM. Only a lower bound is checked,
         // matching fgbio: unlike `simplex` and `codec`, duplex cannot compare the cap against
         // `--min-reads` (a vector with its own ordering rule), and a cap below it is already
         // handled gracefully -- `consensus_call` returns no consensus rather than panicking.
-        if self.max_reads_per_strand == Some(0) {
-            bail!("--max-reads-per-strand must be >= 1");
-        }
-        Ok(())
+        //
+        // All of these numeric guards live on [`DuplexOptions::validate_numeric`] so the
+        // runall duplex arm reuses the exact same checks.
+        self.to_duplex_options().validate_numeric()
     }
 
     /// Whether a molecule seen on only one strand can still yield a consensus, i.e. whether

--- a/src/lib/commands/mod.rs
+++ b/src/lib/commands/mod.rs
@@ -73,6 +73,7 @@ pub mod group;
 pub mod merge;
 pub mod retag;
 pub mod review;
+pub mod runall;
 pub mod shared_metrics;
 #[cfg(feature = "simplex")]
 pub mod simplex;

--- a/src/lib/commands/runall.rs
+++ b/src/lib/commands/runall.rs
@@ -962,11 +962,10 @@ impl RunAll {
     /// requested, `None` otherwise (even if `--ref` was supplied — e.g. to
     /// feed an upstream align stage in the same chain).
     ///
-    /// Not yet called outside tests: the production call site (the
-    /// stage-options-bag builder) lands in a later task of this same PR-B
-    /// campaign.
+    /// Called by [`Self::build_stage_options_bag`] to populate the
+    /// `#[arg(skip)]` `reference` slot on the Simplex/Duplex consensus
+    /// options structs.
     #[must_use]
-    #[allow(dead_code)]
     pub(crate) fn consensus_reference(&self) -> Option<PathBuf> {
         if self.methylation_mode.is_some() { self.reference.clone() } else { None }
     }
@@ -1108,6 +1107,279 @@ impl RunAll {
     #[allow(dead_code)]
     pub(crate) fn derive_sink_spec(&self) -> Result<crate::pipeline::chains::SinkSpec> {
         Ok(crate::pipeline::chains::SinkSpec::Bam(self.output.clone()))
+    }
+
+    /// Build the [`StageOptionsBag`](crate::pipeline::chains::StageOptionsBag)
+    /// for the `ChainSpec` derived from the active stages in
+    /// [`Self::derive_stages`].
+    ///
+    /// Each active stage's options slot is populated; inactive slots remain
+    /// `None`. Fields annotated `#[arg(skip)]` on the per-stage options
+    /// structs are populated here using the same logic the existing
+    /// single-stage `execute_*_only` paths apply.
+    ///
+    /// # Option-population rules by stage
+    ///
+    /// * **Correct** — validates `MultiCorrectOptions`, then sets
+    ///   `rejects_path`:
+    ///   - Self-pair (`--stop-after correct`): honors the top-level
+    ///     `--rejects`, falling back to `--correct::rejects`.
+    ///   - Cross-stage (correct feeds AAM): `rejects_path` = `None` (the
+    ///     fused chain uses the kept-only correct step; UMI rejects are
+    ///     discarded — `RunAll::execute` emits a warning when `--rejects` is
+    ///     set on a chained correct run).
+    ///
+    /// * **Align** — constructs
+    ///   [`AlignOptions`](crate::pipeline::chains::options_bag::AlignOptions)
+    ///   from `--aligner::*` + `--aligner-bin` + `--ref`. Requires `--ref` to
+    ///   be set.
+    ///
+    /// * **Zipper** — validates `MultiZipperOptions`. No `#[arg(skip)]` fields.
+    ///
+    /// * **Sort** — validates `MultiSortOptions`, forces
+    ///   `order = TemplateCoordinate` (runall's sort step always feeds
+    ///   downstream group; coordinate order is not applicable), resolves
+    ///   `tmp_dirs` against `FGUMI_TMP_DIRS`, and — when sort is fused with
+    ///   another stage — overrides an explicit `--sort::max-memory auto` to
+    ///   the standalone 768 MiB default (auto-detection is not supported in a
+    ///   fused chain).
+    ///
+    /// * **Group** — validates `MultiGroupOptions`, then computes
+    ///   `effective_strategy` / `effective_edits` via
+    ///   [`crate::commands::group::GroupOptions::resolve_strategy_and_edits`]
+    ///   and clears the three histogram/metrics paths (anti-goal documented
+    ///   in the module-level doc).
+    ///
+    /// * **Simplex** / **Duplex** — validate the per-mode `Multi<X>`, then
+    ///   populate the cross-cutting `#[arg(skip)]` fields
+    ///   (`rejects_opts`/`stats_opts`/`read_group`/`methylation_mode`/
+    ///   `reference`) from `self`.
+    ///
+    /// * **Codec** — rejects `--methylation-mode` up front (codec has no
+    ///   methylation support), validates `MultiCodecOptions`, runs the
+    ///   inherent numeric-bounds `CodecOptions::validate`, then populates
+    ///   `rejects_opts`/`stats_opts`/`read_group`.
+    ///
+    /// * **Extract** — validates `MultiExtractRunallOptions`, runs the
+    ///   inherent `ExtractRunallOptions::validate` (the 2 macro-dropped
+    ///   conflicts), then the interleaved-vs-count check, template-count
+    ///   validation, non-empty-read-structure check, and
+    ///   `ExtractOptions::validate` (reserved-tag + store-umi-quals).
+    ///
+    /// * **Filter** — validates `MultiFilterOptions`. No cross-stage
+    ///   rewiring is needed: filter is always terminal in a runall chain.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if any per-stage `validate()` call fails (e.g. missing
+    /// required option like `--group::strategy` or `--correct::min-distance`),
+    /// if `Stage::Align` is present but `--ref` is absent, if
+    /// `--methylation-mode` is combined with `Stage::Codec`, or if `stages`
+    /// contains a stage `derive_stages` never emits for a runall chain (an
+    /// internal-error bail naming the unexpected stage).
+    ///
+    /// Not yet called outside tests: the production call site (`execute`)
+    /// lands in a later task of this same PR-B campaign.
+    #[allow(dead_code)]
+    pub(crate) fn build_stage_options_bag(
+        &self,
+        stages: &[crate::pipeline::chains::Stage],
+    ) -> Result<crate::pipeline::chains::StageOptionsBag> {
+        use crate::commands::common::MemoryLimit;
+        use crate::commands::sort::{SortOrderArg, TMP_DIRS_ENV, resolve_tmp_dirs};
+        use crate::pipeline::chains::options_bag::AlignOptions;
+        use crate::pipeline::chains::{Stage, StageOptionsBag};
+
+        let mut bag = StageOptionsBag::default();
+
+        for &stage in stages {
+            match stage {
+                Stage::Correct => {
+                    let mut opts = self.correct_opts.clone().validate()?;
+                    opts.rejects_path = if self.stop_after_stage() == RunAllStage::Correct {
+                        // self-pair: honor top-level --rejects, falling back to --correct::rejects.
+                        self.rejects_opts.rejects.clone().or(opts.rejects_path)
+                    } else {
+                        // fused kept-only correct discards UMI rejects (see execute() warn)
+                        None
+                    };
+                    bag.correct = Some(opts);
+                }
+
+                Stage::Align => {
+                    let reference = self.reference.clone().ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "--start-from align requires --ref (the aligner reference \
+                             FASTA with its index files alongside)"
+                        )
+                    })?;
+                    let aligner = self.aligner_opts.clone().validate()?;
+                    bag.aligner = Some(AlignOptions {
+                        aligner,
+                        reference,
+                        aligner_bin: self.aligner_bin.clone(),
+                    });
+                }
+
+                Stage::Zipper => {
+                    let opts = self.zipper_opts.clone().validate()?;
+                    bag.zipper = Some(opts);
+                }
+
+                Stage::Sort => {
+                    let mut sort_opts = self.sort_opts.clone().validate()?;
+                    // Runall's sort step always produces template-coordinate
+                    // output — the only order compatible with downstream Group.
+                    sort_opts.order = SortOrderArg::TemplateCoordinate;
+                    sort_opts.tmp_dirs = resolve_tmp_dirs(
+                        &sort_opts.tmp_dirs,
+                        std::env::var(TMP_DIRS_ENV).ok().as_deref(),
+                    );
+                    // --sort::max-memory=auto bails in any non-sole-[Sort] chain
+                    // (builder.rs:2560), so override auto -> the standalone
+                    // 768 MiB default when sort is fused with other stages.
+                    if stages != [Stage::Sort] && sort_opts.max_memory == MemoryLimit::Auto {
+                        log::warn!(
+                            "--sort::max-memory auto is not supported in a fused runall \
+                             chain; using 768M"
+                        );
+                        sort_opts.max_memory = MemoryLimit::Fixed(768 * 1024 * 1024);
+                    }
+                    bag.sort = Some(sort_opts);
+                }
+
+                Stage::Group => {
+                    let mut group_opts = self.group_opts.clone().validate()?;
+                    // Mirror GroupReadsByUmi::execute: compute
+                    // effective_strategy / effective_edits via the shared
+                    // helper, then null the per-position metrics outputs
+                    // (anti-goal documented in the module-level doc comment).
+                    let (effective_strategy, effective_edits) =
+                        group_opts.resolve_strategy_and_edits();
+                    group_opts.effective_strategy = effective_strategy;
+                    group_opts.effective_edits = effective_edits;
+                    group_opts.family_size_histogram = None;
+                    group_opts.grouping_metrics = None;
+                    group_opts.metrics_prefix = None;
+                    bag.group = Some(group_opts);
+                }
+
+                #[cfg(feature = "consensus")]
+                Stage::Simplex => {
+                    let mut opts = self.simplex_opts.clone().validate()?;
+                    opts.rejects_opts.clone_from(&self.rejects_opts);
+                    opts.stats_opts.clone_from(&self.stats_opts);
+                    opts.read_group.clone_from(&self.read_group);
+                    opts.methylation_mode =
+                        crate::commands::common::resolve_methylation_mode(self.methylation_mode);
+                    opts.reference = self.consensus_reference();
+                    bag.simplex = Some(opts);
+                }
+
+                #[cfg(feature = "consensus")]
+                Stage::Duplex => {
+                    let mut opts = self.duplex_opts.clone().validate()?;
+                    opts.rejects_opts.clone_from(&self.rejects_opts);
+                    opts.stats_opts.clone_from(&self.stats_opts);
+                    opts.read_group.clone_from(&self.read_group);
+                    opts.methylation_mode =
+                        crate::commands::common::resolve_methylation_mode(self.methylation_mode);
+                    opts.reference = self.consensus_reference();
+                    bag.duplex = Some(opts);
+                }
+
+                #[cfg(feature = "consensus")]
+                Stage::Codec => {
+                    // Codec does not support methylation calling — fail loud
+                    // rather than silently dropping the flag.
+                    if self.methylation_mode.is_some() {
+                        bail!(
+                            "--methylation-mode is not supported with codec consensus; \
+                             it is valid only for simplex/duplex"
+                        );
+                    }
+                    // Validate the `--codec::*` flags into CodecOptions, then
+                    // run the numeric/semantic checks (min-reads, qual
+                    // ceilings, disagreement-rate, …) that standalone `fgumi
+                    // codec` runs — otherwise runall would accept degenerate
+                    // configs the standalone command rejects.
+                    let mut opts = self.codec_opts.clone().validate()?;
+                    opts.validate()?;
+                    opts.rejects_opts.clone_from(&self.rejects_opts);
+                    opts.stats_opts.clone_from(&self.stats_opts);
+                    opts.read_group.clone_from(&self.read_group);
+                    bag.codec = Some(opts);
+                }
+
+                Stage::Extract => {
+                    use crate::commands::extract::validate_template_count;
+
+                    let opts = self.extract_opts.clone().validate()?; // -> ExtractRunallOptions
+                    opts.validate()?; // the 2 macro-dropped conflicts
+                    let rs = &opts.read_structures;
+                    if opts.interleaved {
+                        anyhow::ensure!(
+                            opts.inputs.len() == 1,
+                            "--extract::interleaved requires exactly one --extract::inputs; got {}",
+                            opts.inputs.len()
+                        );
+                        anyhow::ensure!(
+                            rs.len() == 2,
+                            "--extract::interleaved requires exactly two \
+                             --extract::read-structures; got {}",
+                            rs.len()
+                        );
+                    } else {
+                        anyhow::ensure!(
+                            opts.inputs.len() == rs.len(),
+                            "--extract::inputs and --extract::read-structures must have the \
+                             same count"
+                        );
+                    }
+                    validate_template_count(rs)?;
+                    for (i, r) in rs.iter().enumerate() {
+                        anyhow::ensure!(
+                            !r.segments().is_empty(),
+                            "Read structure {} is empty",
+                            i + 1
+                        );
+                    }
+                    let extract_options = opts.to_extract_options();
+                    extract_options.validate()?; // reserved-tag + store-umi-quals
+                    bag.extract = Some(extract_options);
+                }
+
+                Stage::Filter => {
+                    // The standalone filter chain builder reads `rejects` and
+                    // `stats` straight off the bag's FilterOptions, so
+                    // `--filter::rejects` / `--filter::stats` flow through
+                    // unchanged. No cross-stage rewiring is needed: filter is
+                    // always terminal in a runall chain.
+                    let filter_opts = self.filter_opts.clone().validate()?;
+                    bag.filter = Some(filter_opts);
+                }
+
+                // Stages runall never derives — a programming error if they appear.
+                Stage::Clip
+                | Stage::Dedup
+                | Stage::Downsample
+                | Stage::Fastq
+                | Stage::CopyUmi
+                | Stage::Retag => bail!(
+                    "internal error: build_stage_options_bag encountered unexpected \
+                     stage {stage:?} in a runall chain; this is a bug in derive_stages"
+                ),
+                // When built without the consensus feature, the
+                // Simplex/Duplex/Codec arms above are compiled out; keep the
+                // match exhaustive (mirrors validate.rs).
+                #[cfg(not(feature = "consensus"))]
+                Stage::Simplex | Stage::Duplex | Stage::Codec => {
+                    bail!("Stage {stage:?} requires building fgumi with the `consensus` feature")
+                }
+            }
+        }
+
+        Ok(bag)
     }
 }
 
@@ -1263,6 +1535,136 @@ mod derive_tests {
     #[case::simplex_adjacency_ok(RunAllMode::Simplex, Strategy::Adjacency, false)]
     fn strategy_for_mode(#[case] mode: RunAllMode, #[case] strat: Strategy, #[case] is_err: bool) {
         assert_eq!(validate_strategy_for_mode(mode, strat).is_err(), is_err);
+    }
+}
+
+#[cfg(test)]
+mod bag_tests {
+    use super::*;
+    use crate::assigner::Strategy;
+    use crate::commands::sort::SortOrderArg;
+    use crate::pipeline::chains::Stage;
+    use clap::Parser;
+
+    fn parse(args: &[&str]) -> RunAll {
+        RunAll::try_parse_from(std::iter::once("runall").chain(args.iter().copied())).unwrap()
+    }
+
+    #[test]
+    fn sort_order_is_forced_template_coordinate() {
+        let r = parse(&[
+            "--start-from",
+            "sort",
+            "--stop-after",
+            "group",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--group::strategy",
+            "adjacency",
+            "--sort::order",
+            "coordinate",
+        ]);
+        let bag = r.build_stage_options_bag(&[Stage::Sort, Stage::Group]).unwrap();
+        assert_eq!(bag.sort.unwrap().order, SortOrderArg::TemplateCoordinate);
+    }
+
+    #[test]
+    fn group_effective_strategy_resolved() {
+        let r = parse(&[
+            "--start-from",
+            "group",
+            "--stop-after",
+            "group",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--group::strategy",
+            "adjacency",
+            "--group::edits",
+            "1",
+        ]);
+        let bag = r.build_stage_options_bag(&[Stage::Group]).unwrap();
+        let g = bag.group.unwrap();
+        assert_eq!(g.effective_strategy, Strategy::Adjacency);
+        assert_eq!(g.effective_edits, 1);
+    }
+
+    #[test]
+    fn fused_sort_max_memory_auto_is_overridden_to_fixed() {
+        let r = parse(&[
+            "--start-from",
+            "sort",
+            "--stop-after",
+            "group",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--group::strategy",
+            "adjacency",
+            "--sort::max-memory",
+            "auto",
+        ]);
+        let bag = r.build_stage_options_bag(&[Stage::Sort, Stage::Group]).unwrap();
+        assert!(matches!(
+            bag.sort.unwrap().max_memory,
+            crate::commands::common::MemoryLimit::Fixed(_)
+        ));
+    }
+
+    #[cfg(feature = "consensus")]
+    #[test]
+    fn codec_rejects_methylation_mode() {
+        let r = parse(&[
+            "--start-from",
+            "group",
+            "--stop-after",
+            "consensus",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--group::strategy",
+            "adjacency",
+            "--consensus",
+            "codec",
+            "--codec::min-reads",
+            "1",
+            "--methylation-mode",
+            "em-seq",
+        ]);
+        let Err(err) = r.build_stage_options_bag(&[Stage::Codec]) else {
+            panic!("expected --methylation-mode + codec to be rejected");
+        };
+        let err = err.to_string();
+        assert!(err.contains("not supported with codec consensus"), "got: {err}");
+    }
+
+    #[cfg(not(feature = "consensus"))]
+    #[test]
+    fn consensus_stages_rejected_without_consensus_feature() {
+        let r = parse(&[
+            "--start-from",
+            "group",
+            "--stop-after",
+            "group",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--group::strategy",
+            "adjacency",
+        ]);
+        for stage in [Stage::Simplex, Stage::Duplex, Stage::Codec] {
+            let Err(err) = r.build_stage_options_bag(&[stage]) else {
+                panic!("expected {stage:?} to be rejected without the consensus feature");
+            };
+            let err = err.to_string();
+            assert!(err.contains("requires building fgumi with the `consensus` feature"));
+        }
     }
 }
 

--- a/src/lib/commands/runall.rs
+++ b/src/lib/commands/runall.rs
@@ -19,9 +19,10 @@ use anyhow::{Result, bail};
 use clap::Parser;
 
 use crate::assigner::Strategy;
+use crate::commands::command::Command;
 use crate::commands::common::{
-    CompressionOptions, QueueMemoryOptions, ReadGroupOptions, RejectsOptions, SchedulerOptions,
-    StatsOptions, ThreadingOptions,
+    BamIoOptions, CompressionOptions, QueueMemoryOptions, ReadGroupOptions, RejectsOptions,
+    SchedulerOptions, StatsOptions, ThreadingOptions,
 };
 
 /// Consensus mode selector for `runall`. Controls which consensus
@@ -291,11 +292,6 @@ impl std::fmt::Display for RunAllStage {
 ///
 /// Free function so the error-message Display formatting is unit-testable
 /// without constructing a full `RunAll`.
-///
-/// Not yet called outside tests: the `RunAll` struct and its
-/// `validate_strategy` wrapper land in a later task of this same PR-B
-/// campaign, at which point this has a production call site.
-#[allow(dead_code)]
 fn validate_strategy_for_mode(mode: RunAllMode, strategy: Strategy) -> Result<()> {
     match (mode, strategy) {
         (RunAllMode::Duplex, Strategy::Paired) => Ok(()),
@@ -915,10 +911,6 @@ impl RunAll {
     /// that actually reach consensus; `--stop-after sort`/`group`/`filter` are
     /// accepted stops that may not require it.
     ///
-    /// Not yet called outside tests: the production call site (the
-    /// stage-options-bag builder) lands in a later task of this same PR-B
-    /// campaign.
-    #[allow(dead_code)]
     pub(crate) fn require_consensus_mode(&self) -> Result<RunAllMode> {
         self.consensus_mode.ok_or_else(|| {
             anyhow::anyhow!(
@@ -942,11 +934,6 @@ impl RunAll {
     /// # Errors
     ///
     /// Returns `Err` if `--input` was not supplied.
-    ///
-    /// Not yet called outside tests: the production call sites (`execute`
-    /// and the stage-options-bag builder) land in a later task of this same
-    /// PR-B campaign.
-    #[allow(dead_code)]
     pub(crate) fn require_input(&self) -> Result<PathBuf> {
         self.input.clone().ok_or_else(|| {
             anyhow::anyhow!(
@@ -977,10 +964,6 @@ impl RunAll {
     /// # Errors
     ///
     /// Returns `Err` under the same conditions as [`validate_stages_for`].
-    ///
-    /// Not yet called outside tests: the production call site (`execute`)
-    /// lands in a later task of this same PR-B campaign.
-    #[allow(dead_code)]
     pub(crate) fn validate_stages(&self) -> Result<()> {
         validate_stages_for(self.start_from, self.stop_after_stage())
     }
@@ -992,10 +975,6 @@ impl RunAll {
     /// # Errors
     ///
     /// Returns `Err` under the same conditions as [`derive_stages_for`].
-    ///
-    /// Not yet called outside tests: the production call site (`execute`)
-    /// lands in a later task of this same PR-B campaign.
-    #[allow(dead_code)]
     pub(crate) fn derive_stages(&self) -> Result<Vec<crate::pipeline::chains::Stage>> {
         derive_stages_for(
             self.start_from,
@@ -1024,10 +1003,6 @@ impl RunAll {
     ///   `--extract::read-structures` of matching length.
     /// - `Zipper` start requires `--unmapped` and `--ref`; returns `Err` if
     ///   either is absent.
-    ///
-    /// Exercised directly by `source_tests` below; the production call site
-    /// (`execute`) lands in a later task of this same PR-B campaign.
-    #[allow(dead_code)]
     pub(crate) fn derive_source_spec(&self) -> Result<crate::pipeline::chains::SourceSpec> {
         use crate::pipeline::chains::SourceSpec;
         match self.start_from {
@@ -1101,12 +1076,71 @@ impl RunAll {
     ///
     /// Currently infallible; returns `Result` for API symmetry with the
     /// other `derive_*` helpers.
-    ///
-    /// Not yet called outside tests: the production call site (`execute`)
-    /// lands in a later task of this same PR-B campaign.
-    #[allow(dead_code)]
     pub(crate) fn derive_sink_spec(&self) -> Result<crate::pipeline::chains::SinkSpec> {
         Ok(crate::pipeline::chains::SinkSpec::Bam(self.output.clone()))
+    }
+
+    /// Validate the align-stage CLI surface without executing the chain.
+    /// Runs the same [`crate::aligner::AlignerOptions::resolve`] path the
+    /// eventual align step uses, so a misconfigured invocation fails before
+    /// any input is read AND produces the same error message users will see
+    /// at execute time.
+    ///
+    /// Called from [`Command::execute`] whenever the derived stage list
+    /// contains `Stage::Align`.
+    ///
+    /// # Errors
+    ///
+    /// - `--ref` not set (the aligner needs a reference path).
+    /// - `--methylation-mode` combined with an align-bearing chain (not yet
+    ///   supported; see the error message for the EM-seq workaround).
+    /// - No sequence-dictionary file (`.dict`) found next to `--ref`.
+    /// - `--aligner::preset` and `--aligner::command` both unset, or both
+    ///   set, or a preset-only flag paired with command mode, or preset-mode
+    ///   index files missing, or a command-mode template missing `{ref}`
+    ///   (delegated to [`crate::aligner::AlignerOptions::resolve`]).
+    pub(crate) fn validate_align_and_merge(&self) -> Result<()> {
+        let reference = self.reference.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "a runall chain that includes align requires --ref (the aligner \
+                 reference FASTA with its index files alongside)"
+            )
+        })?;
+        // `--methylation-mode` drives the *consensus* stage (which AAM never
+        // reaches alone) and would also conflict with the aligner's
+        // reference handling. Reject explicitly rather than silently ignore;
+        // methylation-aware AAM presets are a follow-up PR per the design doc.
+        if self.methylation_mode.is_some() {
+            bail!(
+                "--methylation-mode is not yet supported for runall chains that include \
+                 align. For EM-seq today, use `--aligner::command \"bwameth.py ...\"` (or \
+                 `bwa-mem3 --methylation-mode em-seq ...`) in command mode and apply \
+                 methylation downstream as a separate step."
+            );
+        }
+        // The downstream zipper-merge step needs a `.dict` file alongside
+        // the reference FASTA (used to populate the output BAM header).
+        // Validate up front so a missing `.dict` fails before the aligner
+        // runs — saves potentially hours of CPU.
+        if crate::reference::find_dict_path(reference).is_none() {
+            bail!(
+                "no sequence-dictionary file found next to --ref {} \
+                 (expected `<ref>.dict` or `<ref-without-extension>.dict`). \
+                 Generate one with `samtools dict {} -o <ref>.dict` before running \
+                 a runall chain that includes align.",
+                reference.display(),
+                reference.display(),
+            );
+        }
+        let top_threads = self.threading.num_threads();
+        // `resolve` consumes the options struct; we clone so the validator
+        // can be called multiple times if needed.
+        let _resolved = self.aligner_opts.clone().validate()?.resolve(
+            reference,
+            top_threads,
+            self.aligner_bin.as_deref(),
+        )?;
+        Ok(())
     }
 
     /// Build the [`StageOptionsBag`](crate::pipeline::chains::StageOptionsBag)
@@ -1177,10 +1211,6 @@ impl RunAll {
     /// `--methylation-mode` is combined with `Stage::Codec`, or if `stages`
     /// contains a stage `derive_stages` never emits for a runall chain (an
     /// internal-error bail naming the unexpected stage).
-    ///
-    /// Not yet called outside tests: the production call site (`execute`)
-    /// lands in a later task of this same PR-B campaign.
-    #[allow(dead_code)]
     pub(crate) fn build_stage_options_bag(
         &self,
         stages: &[crate::pipeline::chains::Stage],
@@ -1380,6 +1410,254 @@ impl RunAll {
         }
 
         Ok(bag)
+    }
+}
+
+impl Command for RunAll {
+    fn execute(&self, command_line: &str) -> Result<()> {
+        use crate::pipeline::chains::{ChainSpec, Stage};
+
+        let timer = crate::logging::OperationTimer::new(&format!(
+            "runall (--start-from {} --stop-after {})",
+            self.start_from,
+            self.stop_after_stage()
+        ));
+
+        // stdin is supported: the input flows into `SourceSpec::Bam`/`Fastqs`
+        // and is opened once via `InputSource::open` (BGZF/SAM auto-detected,
+        // stdin-aware). runall reads the source exactly once per run, so a
+        // streamed `-` works for every start stage.
+
+        self.validate_stages()?;
+
+        log::info!(
+            "Starting runall (--start-from {} --stop-after {})",
+            self.start_from,
+            self.stop_after_stage()
+        );
+        if let Some(input) = &self.input {
+            log::info!("Input: {}", input.display());
+        }
+        log::info!("Output: {}", self.output.display());
+
+        // Derive the ordered stage list for this (start_from, stop_after) pair.
+        let stages = self.derive_stages()?;
+
+        // `--ref` pairs with `--methylation-mode` for the consensus stages, but
+        // it is also legitimately consumed *without* methylation when the
+        // derived chain includes `Stage::Align` (the aligner reference) or
+        // starts at `zipper` (the FASTA + `.dict` for the output BAM header).
+        // For any other chain `--ref` is dead, so reject it without
+        // `--methylation-mode` rather than silently ignore it. Keyed on the
+        // derived chain — not the start stage — so a fused `extract`/`correct →
+        // … → align` run is exempted while a non-aligning chain (e.g.
+        // `correct → correct`) is not. This must run after `derive_stages()`.
+        let ref_is_consumed_without_methylation =
+            self.start_from == RunAllStage::Zipper || stages.contains(&Stage::Align);
+        if !ref_is_consumed_without_methylation
+            && self.reference.is_some()
+            && self.methylation_mode.is_none()
+        {
+            bail!("--ref requires --methylation-mode to be set");
+        }
+
+        // Symmetric guard for the *other* flag: in runall, `--methylation-mode`
+        // is wired only into the simplex/duplex consensus stages (see the
+        // `simplex_opts`/`duplex_opts` bag population in
+        // `build_stage_options_bag`; codec and align reject it with their own
+        // messages). On a chain that reaches no consensus stage (e.g.
+        // `group → group`, `correct → sort`) it is dead — silently ignored —
+        // so reject it rather than mislead. Align chains are exempt here:
+        // `validate_align_and_merge` (run just below for any chain containing
+        // `Stage::Align`) owns the align-specific EM-seq message, which is
+        // more actionable than this generic one.
+        let chain_reaches_consensus = stages.iter().any(|s| s.is_consensus());
+        let chain_includes_align = stages.contains(&Stage::Align);
+        // `--methylation-mode` on a simplex/duplex chain requires `--ref`: the
+        // consensus stage consumes the FASTA (via `consensus_reference()`), and
+        // the standalone contract (`--methylation-mode` doc, "requires --ref")
+        // demands it. Without this guard a non-align `group → simplex` run with
+        // `--methylation-mode` but no `--ref` slips through (the dead-consensus
+        // guard below does not fire because the chain *does* reach consensus),
+        // and `build_stage_options_bag()` then threads `methylation_mode =
+        // Some(...)` with `reference = None` into the stage — deferring the
+        // failure to a later, less actionable path. Codec is excluded (it
+        // rejects `--methylation-mode` outright below), and align chains are
+        // exempt (`validate_align_and_merge` owns the more specific message).
+        let chain_uses_methylation_capable_consensus =
+            stages.iter().any(|s| matches!(s, Stage::Simplex | Stage::Duplex));
+        if self.methylation_mode.is_some()
+            && chain_uses_methylation_capable_consensus
+            && !chain_includes_align
+            && self.reference.is_none()
+        {
+            bail!("--methylation-mode requires --ref to be set");
+        }
+        if self.methylation_mode.is_some() && !chain_reaches_consensus && !chain_includes_align {
+            bail!(
+                "--methylation-mode is only consumed by the consensus stage; \
+                 it is dead on a runall chain that stops before consensus"
+            );
+        }
+
+        // D12: log auto-inserted stages for extract-fed chains so users
+        // understand the chain expansion rules.
+        if self.start_from == RunAllStage::Extract {
+            if stages.contains(&Stage::Correct) {
+                log::info!(
+                    "Including Stage::Correct between Extract and downstream \
+                     (because --correct::umi-files or --correct::umis is set)"
+                );
+            }
+            if stages.contains(&Stage::Align) {
+                log::info!(
+                    "Including Stage::Align between Extract and downstream \
+                     (FASTQ source requires alignment)"
+                );
+            }
+            if stages.contains(&Stage::Sort) && self.start_from != RunAllStage::Sort {
+                log::info!(
+                    "Including Stage::Sort between Align and Group \
+                     (template-coordinate sort precedes Group)"
+                );
+            }
+        }
+
+        // Align-stage pre-flight: run `validate_align_and_merge` so that
+        // aligner option conflicts (preset vs command, missing --ref,
+        // --methylation-mode with AAM) are caught before the pipeline starts.
+        if stages.contains(&Stage::Align) {
+            self.validate_align_and_merge()?;
+        }
+
+        // Cross-stage validation: when Group feeds a consensus stage, the
+        // group strategy must be compatible with the consensus mode (e.g.
+        // duplex requires `--strategy paired`).
+        let has_group = stages.contains(&Stage::Group);
+        let has_consensus = stages.iter().any(|s| s.is_consensus());
+        if has_group && has_consensus {
+            let consensus_mode = self.require_consensus_mode()?;
+            let group_opts = self.group_opts.clone().validate()?;
+            validate_strategy_for_mode(consensus_mode, group_opts.strategy)?;
+            // Log group/consensus summary banner (mirrors old fused dispatcher).
+            log::info!("Strategy: {:?}, edits: {}", group_opts.strategy, group_opts.edits);
+        }
+
+        // Surface a warning if --rejects is set with --start-from
+        // extract/correct and a chained --stop-after. The fused chain uses
+        // the kept-only correct step (no UMI-rejects branch), so the rejects
+        // file collects only downstream rejects (post-consensus / etc.), not
+        // correct's UMI rejects. Users who need UMI rejects should stage a
+        // `fgumi correct --rejects` step separately.
+        if matches!(self.start_from, RunAllStage::Extract | RunAllStage::Correct)
+            && self.stop_after_stage() != RunAllStage::Correct
+            && self.rejects_opts.rejects.is_some()
+        {
+            log::warn!(
+                "--rejects with --start-from correct --stop-after {} discards correct's UMI rejects \
+                 (the fused chain has no UMI-rejects branch). The rejects file will collect only \
+                 downstream rejects. Use a separate `fgumi correct --rejects` step if you need \
+                 UMI rejects captured.",
+                self.stop_after_stage()
+            );
+        }
+
+        // Validate the input BAM exists, once every earlier guard (stage
+        // ordering, --ref/--methylation-mode, align pre-flight) has already
+        // passed — those checks are pure CLI-argument reasoning and should
+        // fail before we require any file to be present on disk.
+        // `--start-from extract` has no `--input` (FASTQ comes from
+        // `--extract::inputs`, validated in `derive_source_spec`), so this is
+        // conditional.
+        if let Some(input) = &self.input {
+            BamIoOptions::new(input, &self.output).validate()?;
+        }
+
+        // Construct the ChainSpec from the derived stages + spec-construction
+        // helpers. Build `source`/`sink`/`stage_opts` into locals FIRST — the
+        // bag borrows `stages`, so `stages` cannot be moved into the struct
+        // literal before that borrow is done with.
+        let verify_crc = match &self.input {
+            Some(p) => BamIoOptions::new(p, &self.output).effective_check_crc(),
+            // FASTQ source ignores verify_crc; value is inert.
+            None => true,
+        };
+        let source = self.derive_source_spec()?;
+        let sink = self.derive_sink_spec()?;
+        let stage_opts = self.build_stage_options_bag(&stages)?;
+
+        let spec = ChainSpec {
+            stages,
+            source,
+            sink,
+            stage_opts,
+            threading: self.threading.clone(),
+            compression: self.compression.clone(),
+            scheduler: self.scheduler_opts.clone(),
+            queue_memory: self.queue_memory.clone(),
+            async_reader: self.async_reader,
+            read_streams: fgumi_bam_io::ReadStreams::Fixed(1),
+            verify_crc,
+            command_line: command_line.to_string(),
+        };
+
+        crate::pipeline::chains::build_for(spec)?.run()?;
+
+        timer.log_completion(0);
+        log::info!("runall completed successfully");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod execute_tests {
+    use super::*;
+    use clap::Parser;
+
+    fn run(args: &[&str]) -> anyhow::Result<()> {
+        RunAll::try_parse_from(std::iter::once("runall").chain(args.iter().copied()))
+            .unwrap()
+            .execute("runall test")
+    }
+
+    #[test]
+    fn rejects_ref_without_methylation_on_nonalign_chain() {
+        let e = run(&[
+            "--start-from",
+            "group",
+            "--stop-after",
+            "group",
+            "-i",
+            "in.bam",
+            "-o",
+            "o.bam",
+            "--group::strategy",
+            "adjacency",
+            "--ref",
+            "ref.fa",
+        ])
+        .unwrap_err()
+        .to_string();
+        assert!(e.contains("--ref requires --methylation-mode"), "got: {e}");
+    }
+
+    #[test]
+    fn rejects_stop_after_align_at_clap_layer() {
+        // StopAfter has no `align` variant → clap rejects it before execute().
+        assert!(
+            RunAll::try_parse_from([
+                "runall",
+                "--start-from",
+                "align",
+                "--stop-after",
+                "align",
+                "-i",
+                "i.bam",
+                "-o",
+                "o.bam"
+            ])
+            .is_err()
+        );
     }
 }
 

--- a/src/lib/commands/runall.rs
+++ b/src/lib/commands/runall.rs
@@ -13,9 +13,16 @@
 //! excludes `align` because raw aligner output before the zipper-merge has
 //! lost every original tag).
 
+use std::path::PathBuf;
+
 use anyhow::{Result, bail};
+use clap::Parser;
 
 use crate::assigner::Strategy;
+use crate::commands::common::{
+    CompressionOptions, QueueMemoryOptions, ReadGroupOptions, RejectsOptions, SchedulerOptions,
+    StatsOptions, ThreadingOptions,
+};
 
 /// Consensus mode selector for `runall`. Controls which consensus
 /// caller runs after the fused group + MI-grouping stages.
@@ -315,9 +322,7 @@ fn validate_strategy_for_mode(mode: RunAllMode, strategy: Strategy) -> Result<()
 /// strategy/stage compatibility beyond what `validate_with`
 /// expresses) have a clear home.
 ///
-/// Not yet called outside tests: `RunAll::validate_stages` (a later task of
-/// this same PR-B campaign) is the production call site.
-#[allow(dead_code)]
+/// `RunAll::validate_stages` is the thin wrapper that calls this.
 fn validate_stages_for(start_from: RunAllStage, stop_after: RunAllStage) -> Result<()> {
     start_from.validate_with(stop_after)?;
     // `--stop-after align-and-merge` would mean "stop after the
@@ -392,9 +397,7 @@ fn validate_stages_for(start_from: RunAllStage, stop_after: RunAllStage) -> Resu
 /// if the Stage derivation reaches a branch that is a programming error (e.g.
 /// a non-consensus `stop` that makes it through all prior early-returns).
 ///
-/// Not yet called outside tests: `RunAll::derive_stages` (a later task of
-/// this same PR-B campaign) is the production call site.
-#[allow(dead_code)]
+/// `RunAll::derive_stages` is the thin wrapper that calls this.
 fn derive_stages_for(
     start_from: RunAllStage,
     stop_after: RunAllStage,
@@ -571,6 +574,608 @@ fn derive_stages_for(
     }
 
     Ok(stages)
+}
+
+/// Fused runall command. Stages are selected by `--start-from` and
+/// `--stop-after`; the accepted starts are
+/// `{Extract, Correct, AlignAndMerge, Zipper, Sort, Group, Consensus,
+/// Filter}` (the consensus algorithm is chosen by `--consensus`, not by a
+/// per-algorithm start value — `simplex`/`duplex`/`codec` are NOT accepted
+/// start values) and the accepted stops are
+/// `{Extract, Correct, Zipper, Sort, Group, Consensus, Filter}`
+/// (no `--stop-after align` — raw aligner output without zipper-merge
+/// would lose every original tag).
+#[derive(Debug, Parser)]
+#[command(
+    name = "runall",
+    about = "\x1b[38;5;166m[UTILITIES]\x1b[0m      \x1b[36mFused multi-stage pipeline (correct + align + zipper + sort + group + consensus, no intermediate BAM)\x1b[0m",
+    long_about = "\
+Fuses extract, UMI correction, alignment + zipper-merge, sort, group, and \
+consensus calling (optionally followed by filter) into a single in-memory \
+pipeline. Select the slice to run with `--start-from` and `--stop-after` (both \
+required); the stages run in the fixed order extract < correct < align < zipper \
+< sort < group < consensus < filter. Records flow directly between stages in \
+memory, so every intermediate BAM a sequential run would write is elided. The \
+record stream matches running the equivalent standalone commands in turn, as do \
+the `@HD` `SO`/`GO`/`SS` fields, the `@SQ` dictionary, and the `@RG` records. The \
+output is NOT byte-for-byte identical: the fused chain writes a single `@PG` \
+record while the staged run writes one `@PG` per command, and `@HD` `VN` and \
+`@CO` are not compared.
+
+`--start-from` declares the state of the input and selects the upstream work:
+
+* `extract` reads FASTQ via `--extract::inputs` / `--extract::read-structures` \
+  (no `--input`).
+* `correct` reads an unmapped BAM via `--input` and corrects UMIs against \
+  `--correct::umis` / `--correct::umi-files`.
+* `align` reads an unmapped BAM via `--input`, runs the aligner subprocess \
+  (`--aligner::preset` or `--aligner::command`) against `--ref`, and \
+  zipper-merges the result.
+* `zipper` reads a queryname-sorted mapped BAM via `--input` plus the matching \
+  unmapped BAM via `--unmapped` and the reference (`--ref` + `.dict`).
+* `sort` reads a raw unsorted aligned BAM via `--input`.
+* `group` reads a template-coordinate-sorted BAM via `--input`.
+* `consensus` reads a grouped (MI-tagged) BAM via `--input`.
+* `filter` reads a consensus BAM via `--input`.
+
+The consensus algorithm is chosen by `--consensus {simplex,duplex,codec}`, not \
+by a stage name; `--stop-after consensus` produces the same BAM as the matching \
+`fgumi {simplex,duplex,codec}` command. `--stop-after filter` fuses a \
+post-consensus `fgumi filter` pass (tunable via `--filter::*`) into the same \
+pipeline, so no intermediate consensus BAM is written. Tune any stage with its \
+prefixed flags: `--sort::max-memory`, `--group::strategy`, `--duplex::min-reads`, \
+and so on.
+
+`--stop-after align` is not allowed: raw aligner output before the zipper-merge \
+has lost every original tag, so the earliest stop after `--start-from align` is \
+`zipper`. The validator checks the requested stage range but cannot verify that \
+the on-disk input actually matches `--start-from` — make sure it does."
+)]
+pub struct RunAll {
+    /// Input BAM/SAM file. Optional because runall's input contract is
+    /// stage-dependent, unlike the standard single-required-BAM commands
+    /// that flatten `BamIoOptions`: `--start-from extract` reads FASTQ
+    /// from `--extract::inputs` (no `--input`); `--start-from zipper`
+    /// pairs `--input` (mapped) with `--unmapped`; the BAM-source start
+    /// stages (`correct`/`align`/`sort`/`group`/consensus) require
+    /// `--input`. Presence is validated per start-stage in
+    /// `RunAll::derive_source_spec`.
+    #[arg(short = 'i', long = "input")]
+    pub input: Option<PathBuf>,
+
+    /// Output BAM file.
+    #[arg(short = 'o', long = "output")]
+    pub output: PathBuf,
+
+    /// Wrap the input in a userspace async prefetch reader: a background
+    /// thread reads ahead so disk I/O overlaps decompression/compute.
+    /// Defaults to off.
+    #[arg(long = "async-reader", default_value_t = false, hide = true)]
+    pub async_reader: bool,
+
+    /// Optional output for rejected reads.
+    #[command(flatten)]
+    pub rejects_opts: RejectsOptions,
+
+    /// Optional output for statistics.
+    #[command(flatten)]
+    pub stats_opts: StatsOptions,
+
+    /// Read group and read name prefix options.
+    #[command(flatten)]
+    pub read_group: ReadGroupOptions,
+
+    /// Threading options.
+    #[command(flatten)]
+    pub threading: ThreadingOptions,
+
+    /// Compression options for output BAM.
+    #[command(flatten)]
+    pub compression: CompressionOptions,
+
+    /// Scheduler and pipeline statistics options.
+    #[command(flatten)]
+    pub scheduler_opts: SchedulerOptions,
+
+    /// Queue memory options.
+    #[command(flatten)]
+    pub queue_memory: QueueMemoryOptions,
+
+    /// Methylation-aware consensus calling mode (requires --ref).
+    #[arg(long = "methylation-mode", value_enum)]
+    pub methylation_mode: Option<crate::commands::common::MethylationModeArg>,
+
+    /// Path to the reference FASTA file. Required when `--methylation-mode`
+    /// is set (consensus stages), when `--start-from zipper` is used (zipper
+    /// requires the FASTA + `.dict` to build the output BAM header from the
+    /// reference dictionary), and whenever the derived stage chain includes
+    /// `Stage::Align` (the aligner reference) — not only `--start-from
+    /// align`, but also fused runs that reach align from an upstream start
+    /// (e.g. `--start-from extract`/`--start-from correct` with a
+    /// `--stop-after` past zipper). For those align-bearing upstream starts
+    /// the reference is consumed by the align stage and is accepted without
+    /// `--methylation-mode`.
+    #[arg(long = "ref")]
+    pub reference: Option<PathBuf>,
+
+    // ───────── extract-side options (used only when --start-from=extract) ─────────
+    /// Per-stage extract tuning, exposed as `--extract::inputs`,
+    /// `--extract::read-structures`, `--extract::sample`,
+    /// `--extract::library`, etc. via the `MultiExtractRunallOptions`
+    /// companion struct (generated by `#[multi_options]` on
+    /// `ExtractRunallOptions` in `commands::extract`).
+    /// Ignored when `--start-from` is not `extract`.
+    #[command(flatten)]
+    pub extract_opts: crate::commands::extract::MultiExtractRunallOptions,
+
+    // ───────── correct-side options (used only when --start-from <= correct) ─────────
+    /// Per-stage UMI-correction tuning, exposed as `--correct::umis`,
+    /// `--correct::umi-files`, `--correct::max-mismatches`,
+    /// `--correct::min-distance`, `--correct::revcomp`, etc. via the
+    /// `MultiCorrectOptions` companion struct (generated by
+    /// `#[multi_options]` on `CorrectOptions` in `commands::correct`).
+    /// `--correct::min-distance` is required when `--start-from
+    /// correct` is selected (no default); at least one of
+    /// `--correct::umis` / `--correct::umi-files` is required.
+    /// Ignored when `--start-from` is not `correct`.
+    #[command(flatten)]
+    pub correct_opts: crate::commands::correct::MultiCorrectOptions,
+
+    // ───────── aligner-side options (used whenever the chain includes Stage::Align) ─────────
+    /// Per-stage aligner tuning, exposed as `--aligner::preset`,
+    /// `--aligner::command`, `--aligner::threads`, `--aligner::chunk-size`
+    /// via the `MultiAlignerOptions` companion struct (generated by
+    /// `#[multi_options]` on `AlignerOptions` in `crate::aligner`).
+    /// Used whenever the derived stage chain includes `Stage::Align` — not
+    /// only on `--start-from=align`, but also on fused runs that reach align
+    /// from an upstream start (e.g. `--start-from extract` or
+    /// `--start-from correct` with a `--stop-after` past zipper). Ignored
+    /// only when the chain has no align stage.
+    #[command(flatten)]
+    pub aligner_opts: crate::aligner::MultiAlignerOptions,
+
+    /// Override path for the aligner binary (preset mode only). When
+    /// unset, the preset's binary (`bwa-mem3` / `bwa`) is found via
+    /// `which::which()` on `PATH`. Rejected with a clear error if
+    /// `--aligner::command` is used (command mode owns its own
+    /// binary). Used whenever the chain includes `Stage::Align` (see
+    /// `--aligner::*` above); ignored only when the chain has no align stage.
+    ///
+    /// Note: this flag is at the runall top level (`--aligner-bin`),
+    /// NOT inside the `--aligner::*` family. The `--aligner::*` flags
+    /// are mode-orthogonal tuning knobs (chunk-size, threads); the
+    /// binary identity is mode-shaped — command mode owns it inside
+    /// `--aligner::command "..."`, preset mode owns it here. Putting
+    /// the override in the `--aligner::*` family would suggest a
+    /// non-existent `--aligner::bin` symmetry.
+    #[arg(long = "aligner-bin")]
+    pub aligner_bin: Option<PathBuf>,
+
+    // ───────── zipper-side options (used only when --start-from=zipper) ─────────
+    /// Path to the unmapped BAM (required when `--start-from zipper`).
+    /// The standalone `fgumi zipper` reads this via `-u`/`--unmapped`;
+    /// runall surfaces it as a top-level flag because the
+    /// `BamIoOptions`-shared `--input` already names the mapped BAM.
+    /// Ignored when `--start-from` is not `zipper`.
+    #[arg(long = "unmapped")]
+    pub unmapped: Option<PathBuf>,
+
+    /// Per-stage zipper tuning, exposed as `--zipper::tags-to-remove`,
+    /// `--zipper::buffer`, `--zipper::skip-tc-tags`, etc. via the
+    /// `MultiZipperOptions` companion struct (generated by
+    /// `#[multi_options]` on `ZipperOptions` in `commands::zipper`).
+    /// Ignored when `--start-from` is not `zipper`.
+    #[command(flatten)]
+    pub zipper_opts: crate::commands::zipper::MultiZipperOptions,
+
+    // ───────── group-side options ─────────
+    /// Per-stage group tuning, exposed as `--group::strategy`,
+    /// `--group::edits`, `--group::min-map-q`, etc. via the
+    /// `MultiGroupOptions` companion struct (generated by
+    /// `#[multi_options]` on `GroupOptions` in `commands::group`).
+    /// `--group::strategy` is required when `--start-from {sort,group}`
+    /// is selected (no default).
+    #[command(flatten)]
+    pub group_opts: crate::commands::group::MultiGroupOptions,
+
+    // ───────── codec-specific options (used only when --consensus=codec) ─────────
+    /// Per-stage codec tuning, exposed as `--codec::min-duplex-length`,
+    /// `--codec::single-strand-qual`, `--codec::outer-bases-qual`,
+    /// `--codec::outer-bases-length`, `--codec::max-duplex-disagreements`,
+    /// `--codec::max-duplex-disagreement-rate`. Ignored when `--consensus`
+    /// is not `codec`.
+    ///
+    /// `--codec::allow-unmapped` is NOT exposed: PR A implemented spec
+    /// §12.2 option (b) (`CodecOptions` carries a skipped, always-disabled
+    /// `AllowUnmappedOptions`), so every runall codec stage runs with
+    /// `allow_unmapped: false` — a known, deferred capability gap versus
+    /// the standalone `fgumi codec` command.
+    #[cfg(feature = "consensus")]
+    #[command(flatten)]
+    pub codec_opts: crate::commands::codec::MultiCodecOptions,
+
+    // ───────── simplex-specific options (used only with --consensus simplex) ─────────
+    /// Per-stage simplex tuning, exposed as `--simplex::error-rate-pre-umi`,
+    /// `--simplex::min-reads`, `--simplex::max-reads`,
+    /// `--simplex::min-input-base-quality`, etc. via the
+    /// `MultiSimplexOptions` companion struct (generated by
+    /// `#[multi_options]` on `SimplexOptions` in `commands::simplex`).
+    /// `--simplex::min-reads` is required when `--consensus simplex` is
+    /// selected (no default). Ignored unless the chain reaches the
+    /// consensus stage with `--consensus simplex`.
+    ///
+    /// `--simplex::allow-unmapped` is NOT exposed: PR A implemented spec
+    /// §12.2 option (b) (`SimplexOptions` carries a skipped, always-disabled
+    /// `AllowUnmappedOptions`), so every runall simplex stage runs with
+    /// `allow_unmapped: false` — a known, deferred capability gap versus
+    /// the standalone `fgumi simplex` command.
+    #[cfg(feature = "consensus")]
+    #[command(flatten)]
+    pub simplex_opts: crate::commands::simplex::MultiSimplexOptions,
+
+    // ───────── duplex-specific options (used only with --consensus duplex) ─────────
+    /// Per-stage duplex tuning, exposed as `--duplex::error-rate-pre-umi`,
+    /// `--duplex::min-reads`, `--duplex::max-reads-per-strand`,
+    /// `--duplex::consensus-call-overlapping-bases`, etc. via the
+    /// `MultiDuplexOptions` companion struct. Ignored unless the chain
+    /// reaches the consensus stage with `--consensus duplex`.
+    ///
+    /// `--duplex::allow-unmapped` is NOT exposed: PR A implemented spec
+    /// §12.2 option (b) (`DuplexOptions` carries a skipped, always-disabled
+    /// `AllowUnmappedOptions`), so every runall duplex stage runs with
+    /// `allow_unmapped: false` — a known, deferred capability gap versus
+    /// the standalone `fgumi duplex` command.
+    #[cfg(feature = "consensus")]
+    #[command(flatten)]
+    pub duplex_opts: crate::commands::duplex::MultiDuplexOptions,
+
+    // ───────── pipeline stage control ─────────
+    /// Pipeline stage to start from: extract, correct, align, zipper, sort,
+    /// group, consensus, or filter (required, case-insensitive).
+    ///
+    /// Declares the state of the input and selects the upstream work
+    /// runall performs before the terminal `--stop-after` stage. See the
+    /// command description for what each start stage reads (FASTQ for
+    /// `extract`; `--input` plus, for `zipper`, `--unmapped`; a
+    /// template-coordinate-sorted BAM for `group`; a grouped MI-tagged
+    /// BAM for `consensus`; and so on).
+    ///
+    /// **Consensus-start chain:** `--start-from consensus` (with
+    /// `--consensus {simplex,duplex,codec}`) runs the standalone consensus
+    /// chain, which groups by the *existing* `MI` tag. It does NOT add a
+    /// position-grouping stage — doing so would double-group an
+    /// already-grouped input (see `derive_stages_for`'s
+    /// consensus-self-pair exception).
+    ///
+    /// Case-insensitive. Must satisfy `start_from.ord() <=
+    /// stop_after.ord()` (see [`RunAllStage::validate_with`]).
+    #[arg(long = "start-from", value_enum, ignore_case = true)]
+    pub start_from: RunAllStage,
+
+    /// Pipeline stage to stop after: extract, correct, zipper, sort, group,
+    /// consensus, or filter (required, case-insensitive).
+    ///
+    /// Determines the terminal stage of the chain. `--stop-after
+    /// consensus` writes the consensus BAM produced by the caller chosen
+    /// with `--consensus`; `--stop-after filter` fuses a post-consensus
+    /// filter pass into the same pipeline.
+    ///
+    /// `align` is intentionally not a valid stop: raw aligner output
+    /// before the zipper-merge has lost every original tag, so the
+    /// earliest stop after `--start-from align` is `zipper`. Must satisfy
+    /// `start_from.ord() <= stop_after.ord()` (`RunAllStage::validate_with`);
+    /// use `RunAll::stop_after_stage` to read this as a [`RunAllStage`].
+    #[arg(long = "stop-after", value_enum, ignore_case = true)]
+    pub stop_after: StopAfter,
+
+    /// Consensus algorithm to run at the consensus stage: `simplex`,
+    /// `duplex`, or `codec`. Required whenever the chain reaches the
+    /// consensus stage (`--stop-after consensus`, or `--start-from
+    /// consensus`); ignored otherwise. `duplex` requires
+    /// `--strategy paired`. Selects which standalone caller's output the
+    /// run reproduces (`fgumi simplex` / `duplex` / `codec`).
+    #[arg(long = "consensus", value_enum, ignore_case = true)]
+    pub consensus_mode: Option<RunAllMode>,
+
+    /// Per-stage sort tuning, exposed as `--sort::max-memory`,
+    /// `--sort::tmp-dir`, etc. Consumed only when `--start-from sort`
+    /// is selected; otherwise ignored. The full standalone option
+    /// set of `fgumi sort` is mirrored here via the
+    /// `#[multi_options]` macro — see `SortOptions` in
+    /// `commands::sort` for the field list.
+    #[command(flatten)]
+    pub sort_opts: crate::commands::sort::MultiSortOptions,
+
+    /// Per-stage filter tuning, exposed as `--filter::min-reads`,
+    /// `--filter::max-read-error-rate`, `--filter::ref`, … Used when the
+    /// chain reaches the filter stage (`--stop-after filter` or
+    /// `--start-from filter`); otherwise ignored. The full standalone
+    /// option set of `fgumi filter` is mirrored here via the
+    /// `#[multi_options]` macro — see `FilterOptions` in
+    /// `commands::filter` for the field list.
+    #[command(flatten)]
+    pub filter_opts: crate::commands::filter::MultiFilterOptions,
+}
+
+impl RunAll {
+    /// Returns `true` if the user passed enough `--correct::*` flags to
+    /// make Correct a load-bearing stage in an extract-fed chain.
+    /// Concretely: at least one of `--correct::umi-files` or
+    /// `--correct::umis` is non-empty. Used by `derive_stages` to
+    /// decide whether to splice Correct between Extract and Align.
+    #[must_use]
+    pub(crate) fn extract_chain_wants_correct(&self) -> bool {
+        !self.correct_opts.correct_umis.is_empty()
+            || !self.correct_opts.correct_umi_files.is_empty()
+    }
+
+    /// Returns the consensus algorithm for this run, from `--consensus`.
+    /// Errors (does not panic) if `--consensus` was omitted — it is required
+    /// whenever the chain reaches the consensus stage. Only called on chains
+    /// that actually reach consensus; `--stop-after sort`/`group`/`filter` are
+    /// accepted stops that may not require it.
+    ///
+    /// Not yet called outside tests: the production call site (the
+    /// stage-options-bag builder) lands in a later task of this same PR-B
+    /// campaign.
+    #[allow(dead_code)]
+    pub(crate) fn require_consensus_mode(&self) -> Result<RunAllMode> {
+        self.consensus_mode.ok_or_else(|| {
+            anyhow::anyhow!(
+                "--consensus <simplex|duplex|codec> is required when the chain \
+                 reaches the consensus stage"
+            )
+        })
+    }
+
+    /// Reads `--stop-after` as a [`RunAllStage`] (`StopAfter` converts via
+    /// [`From<StopAfter> for RunAllStage`]).
+    #[must_use]
+    pub(crate) fn stop_after_stage(&self) -> RunAllStage {
+        self.stop_after.into()
+    }
+
+    /// Returns `self.input`, or an actionable error naming `--start-from`
+    /// when it is absent. Used by every BAM-source `--start-from` stage
+    /// (`correct`/`align`/`zipper`(mapped)/`sort`/`group`/`consensus`/`filter`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if `--input` was not supplied.
+    ///
+    /// Not yet called outside tests: the production call sites (`execute`
+    /// and the stage-options-bag builder) land in a later task of this same
+    /// PR-B campaign.
+    #[allow(dead_code)]
+    pub(crate) fn require_input(&self) -> Result<PathBuf> {
+        self.input.clone().ok_or_else(|| {
+            anyhow::anyhow!(
+                "--input is required with --start-from {} (the input BAM)",
+                self.start_from
+            )
+        })
+    }
+
+    /// Returns the reference FASTA to thread into the consensus caller's
+    /// `#[arg(skip)]` `reference` slot, gated on `--methylation-mode` being
+    /// set: `Some(self.reference.clone())` when methylation mode is
+    /// requested, `None` otherwise (even if `--ref` was supplied — e.g. to
+    /// feed an upstream align stage in the same chain).
+    ///
+    /// Not yet called outside tests: the production call site (the
+    /// stage-options-bag builder) lands in a later task of this same PR-B
+    /// campaign.
+    #[must_use]
+    #[allow(dead_code)]
+    pub(crate) fn consensus_reference(&self) -> Option<PathBuf> {
+        if self.methylation_mode.is_some() { self.reference.clone() } else { None }
+    }
+
+    /// Validate the `--start-from` / `--stop-after` pair. Thin wrapper over
+    /// the free function [`validate_stages_for`] so the ordering rules stay
+    /// unit-testable without constructing a full `RunAll`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` under the same conditions as [`validate_stages_for`].
+    ///
+    /// Not yet called outside tests: the production call site (`execute`)
+    /// lands in a later task of this same PR-B campaign.
+    #[allow(dead_code)]
+    pub(crate) fn validate_stages(&self) -> Result<()> {
+        validate_stages_for(self.start_from, self.stop_after_stage())
+    }
+
+    /// Derive the ordered stage list for this run. Thin wrapper over the
+    /// free function [`derive_stages_for`] so the derivation rules stay
+    /// unit-testable without constructing a full `RunAll`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` under the same conditions as [`derive_stages_for`].
+    ///
+    /// Not yet called outside tests: the production call site (`execute`)
+    /// lands in a later task of this same PR-B campaign.
+    #[allow(dead_code)]
+    pub(crate) fn derive_stages(&self) -> Result<Vec<crate::pipeline::chains::Stage>> {
+        derive_stages_for(
+            self.start_from,
+            self.stop_after_stage(),
+            self.extract_chain_wants_correct(),
+            self.consensus_mode,
+        )
+    }
+
+    /// Build the [`SourceSpec`](crate::pipeline::chains::SourceSpec) for the
+    /// `ChainSpec` derived from `--start-from`.
+    ///
+    /// | `--start-from`     | `SourceSpec` variant                                              |
+    /// |--------------------|-------------------------------------------------------------------|
+    /// | `extract`          | `Fastqs`/`InterleavedFastq` from `--extract::inputs`              |
+    /// | `correct`          | `Bam(self.require_input()?)` — unmapped BAM feeding correct       |
+    /// | `align`            | `Bam(self.require_input()?)` — unmapped BAM feeding AAM           |
+    /// | `zipper`           | `PairedBams { unmapped, mapped: input, reference }`               |
+    /// | `sort` / `group` / consensus / `filter` | `Bam(self.require_input()?)` — aligned BAM |
+    ///
+    /// # Errors
+    ///
+    /// - `Extract` start with `--input` set is rejected (FASTQ paths come
+    ///   from `--extract::inputs`, not `-i`/`--input`).
+    /// - `Extract` start requires a non-empty `--extract::inputs` and
+    ///   `--extract::read-structures` of matching length.
+    /// - `Zipper` start requires `--unmapped` and `--ref`; returns `Err` if
+    ///   either is absent.
+    ///
+    /// Exercised directly by `source_tests` below; the production call site
+    /// (`execute`) lands in a later task of this same PR-B campaign.
+    #[allow(dead_code)]
+    pub(crate) fn derive_source_spec(&self) -> Result<crate::pipeline::chains::SourceSpec> {
+        use crate::pipeline::chains::SourceSpec;
+        match self.start_from {
+            RunAllStage::Extract => {
+                // When --start-from extract, FASTQ paths come from
+                // --extract::inputs, not from -i/--input.
+                if self.input.is_some() {
+                    bail!(
+                        "when --start-from extract, pass --extract::inputs instead of \
+                         -i/--input (--input is for BAM-source start-from values)"
+                    );
+                }
+                let opts = self.extract_opts.clone().validate()?;
+                anyhow::ensure!(
+                    !opts.inputs.is_empty(),
+                    "--extract::inputs is required when --start-from extract"
+                );
+                anyhow::ensure!(
+                    !opts.read_structures.is_empty(),
+                    "--extract::read-structures is required when --start-from extract"
+                );
+                anyhow::ensure!(
+                    opts.inputs.len() == opts.read_structures.len(),
+                    "--extract::inputs and --extract::read-structures must have the same count"
+                );
+                if opts.interleaved {
+                    let path = opts.inputs.first().cloned().ok_or_else(|| {
+                        anyhow::anyhow!("--extract::inputs is required when --start-from extract")
+                    })?;
+                    // Enforces exactly 2 read structures (the R1/R2 pair).
+                    SourceSpec::interleaved_fastq(path, opts.read_structures)
+                } else {
+                    // Enforces paths.len() == read_structures.len().
+                    SourceSpec::fastqs(opts.inputs, opts.read_structures)
+                }
+            }
+
+            RunAllStage::Correct
+            | RunAllStage::AlignAndMerge
+            | RunAllStage::Sort
+            | RunAllStage::Group
+            | RunAllStage::Consensus
+            | RunAllStage::Filter => Ok(SourceSpec::Bam(self.require_input()?)),
+
+            RunAllStage::Zipper => {
+                let unmapped = self.unmapped.clone().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "--unmapped is required with --start-from zipper (the second \
+                         input BAM, queryname-sorted, that carries the source tags)"
+                    )
+                })?;
+                let reference = self.reference.clone().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "--ref is required with --start-from zipper (the reference FASTA \
+                         with an accompanying `.dict` for the output BAM header)"
+                    )
+                })?;
+                Ok(SourceSpec::PairedBams { unmapped, mapped: self.require_input()?, reference })
+            }
+        }
+    }
+
+    /// Build the [`SinkSpec`](crate::pipeline::chains::SinkSpec) for the
+    /// `ChainSpec`. Runall always writes a plain BAM via `SinkSpec::Bam` —
+    /// `BamWithIndex` is never constructed here because runall's sort output
+    /// is either intermediate or a final template-coordinate BAM, neither of
+    /// which admits a valid BAI. Runall does not expose a
+    /// `--sort::write-index` flag.
+    ///
+    /// # Errors
+    ///
+    /// Currently infallible; returns `Result` for API symmetry with the
+    /// other `derive_*` helpers.
+    ///
+    /// Not yet called outside tests: the production call site (`execute`)
+    /// lands in a later task of this same PR-B campaign.
+    #[allow(dead_code)]
+    pub(crate) fn derive_sink_spec(&self) -> Result<crate::pipeline::chains::SinkSpec> {
+        Ok(crate::pipeline::chains::SinkSpec::Bam(self.output.clone()))
+    }
+}
+
+#[cfg(test)]
+mod source_tests {
+    use super::*;
+    use crate::pipeline::chains::SourceSpec;
+    use clap::Parser;
+
+    fn parse(args: &[&str]) -> RunAll {
+        RunAll::try_parse_from(std::iter::once("runall").chain(args.iter().copied())).unwrap()
+    }
+
+    #[test]
+    fn bam_start_uses_input() {
+        let r = parse(&[
+            "--start-from",
+            "group",
+            "--stop-after",
+            "group",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--group::strategy",
+            "adjacency",
+        ]);
+        assert!(matches!(r.derive_source_spec().unwrap(), SourceSpec::Bam(_)));
+    }
+
+    #[test]
+    fn extract_start_rejects_input() {
+        let r = parse(&[
+            "--start-from",
+            "extract",
+            "--stop-after",
+            "extract",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--extract::inputs",
+            "r1.fq",
+            "--extract::read-structures",
+            "+T",
+            "--extract::sample",
+            "s",
+            "--extract::library",
+            "l",
+        ]);
+        let err = r.derive_source_spec().unwrap_err().to_string();
+        assert!(err.contains("--extract::inputs instead of"), "got: {err}");
+    }
+
+    #[test]
+    fn zipper_start_requires_unmapped_and_ref() {
+        let r = parse(&[
+            "--start-from",
+            "zipper",
+            "--stop-after",
+            "zipper",
+            "-i",
+            "mapped.bam",
+            "-o",
+            "out.bam",
+        ]);
+        assert!(r.derive_source_spec().unwrap_err().to_string().contains("--unmapped is required"));
+    }
 }
 
 #[cfg(test)]

--- a/src/lib/commands/runall.rs
+++ b/src/lib/commands/runall.rs
@@ -1,0 +1,320 @@
+//! Fused multi-stage `runall` pipeline command.
+//!
+//! `runall` fuses a contiguous slice of the fgumi pipeline (extract, UMI
+//! correction, alignment + zipper-merge, sort, group, and consensus calling,
+//! optionally followed by filter) into a single in-memory chain, so every
+//! intermediate BAM a sequential run of the standalone commands would write
+//! is elided.
+//!
+//! This module currently defines the stage-selection vocabulary shared by the
+//! rest of the command: [`RunAllMode`] (which consensus algorithm to run),
+//! [`RunAllStage`] (the linear pipeline stage order used by `--start-from`),
+//! and [`StopAfter`] (the `--stop-after`-only subset of [`RunAllStage`], which
+//! excludes `align` because raw aligner output before the zipper-merge has
+//! lost every original tag).
+
+use anyhow::{Result, bail};
+
+/// Consensus mode selector for `runall`. Controls which consensus
+/// caller runs after the fused group + MI-grouping stages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, clap::ValueEnum)]
+pub enum RunAllMode {
+    /// Single-strand consensus via `VanillaUmiConsensusCaller`. Pair
+    /// with `--strategy adjacency` (or `identity`/`edit`).
+    Simplex,
+    /// CODEC duplex consensus via `CodecConsensusCaller`. Pair with
+    /// `--strategy adjacency` (or `identity`/`edit`).
+    Codec,
+    /// Two-strand duplex consensus via `DuplexConsensusCaller`. Requires
+    /// `--strategy paired` so MIs carry `/A`/`/B` suffixes.
+    Duplex,
+}
+
+impl std::fmt::Display for RunAllMode {
+    /// Lower-case the variant name so error messages match the CLI
+    /// flag values the user typed (`--consensus simplex`, not
+    /// `RunAllMode::Simplex`).
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::Simplex => "simplex",
+            Self::Codec => "codec",
+            Self::Duplex => "duplex",
+        };
+        f.write_str(name)
+    }
+}
+
+/// Pipeline stage marker for the `--start-from` / `--stop-after`
+/// runall stage flags. Stages are linearly ordered:
+/// `Extract < Correct < AlignAndMerge < Zipper < Sort < Group <
+/// Consensus < Filter` (see [`RunAllStage::ord`]).
+///
+/// **Stage semantics — "the input is positioned AT this stage's
+/// entry":**
+///
+/// * `Sort` — raw unsorted BAM, pre-sort. `--start-from sort`
+///   includes the sort step. `--stop-after sort` writes the
+///   sorted BAM and stops (apples-to-apples replacement for
+///   standalone `fgumi sort`).
+/// * `Group` — BAM is sorted by template-coordinate (output of
+///   `fgumi sort`). `--start-from group` skips the sort step.
+///   `--stop-after group` writes the grouped BAM (output of
+///   `fgumi group`) and stops.
+/// * `Consensus` — BAM is sorted and grouped (MI tags assigned,
+///   output of `fgumi group`). `--start-from consensus` skips sort
+///   and group. `--stop-after consensus` runs the consensus caller
+///   chosen by `--consensus {simplex,duplex,codec}` and writes the
+///   consensus BAM (output of `fgumi simplex`/`duplex`/`codec`). The
+///   algorithm is selected by `--consensus`, not by a stage variant.
+///
+/// `AlignAndMerge` is a valid `--start-from` but not a valid
+/// `--stop-after` (see [`StopAfter`]): raw aligner output before the
+/// zipper-merge has lost every original tag.
+///
+/// **Case-insensitive parsing**: `sort`, `Sort`, `SORT` all match
+/// because the `--start-from` / `--stop-after` flags use
+/// `#[arg(value_enum, ignore_case = true)]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, clap::ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+pub enum RunAllStage {
+    /// Extract UMIs from FASTQ files and produce an unmapped BAM.
+    /// `--start-from extract` accepts FASTQ files via
+    /// `--extract::inputs` and read structures via
+    /// `--extract::read-structures`. `--start-from extract --stop-after
+    /// extract` runs the extract-only chain and writes the unmapped BAM
+    /// (record-identical to standalone `fgumi extract`, with matching `@HD`
+    /// `SO`/`GO`/`SS`, `@SQ`, and `@RG`; runall's `@PG` provenance differs, and
+    /// `@HD` `VN` / `@CO` are not compared). Otherwise Extract feeds into
+    /// Correct (when `--correct::umi-files` is set) or Align.
+    Extract,
+    /// Correct UMIs in an unmapped BAM against a fixed whitelist of
+    /// expected sequences. `--start-from correct` accepts an
+    /// unmapped BAM via `--input` and requires at least one of
+    /// `--correct::umis` / `--correct::umi-files`. `--stop-after
+    /// correct` writes the corrected unmapped BAM and exits.
+    Correct,
+    /// Align an unmapped BAM with UMIs through an external aligner
+    /// subprocess (bwa-mem3 / bwa / user-supplied command), then merge
+    /// the resulting alignments with the original unmapped reads via
+    /// the zipper-merge logic — all streamed end-to-end. `--start-from
+    /// align` accepts an unmapped BAM via `--input` and requires
+    /// `--ref` (the aligner reference) plus one of
+    /// `--aligner::preset` or `--aligner::command`. Earliest stop
+    /// point reachable is `--stop-after zipper` (raw aligner output
+    /// without merge is not a supported stop point because it loses
+    /// every original tag).
+    ///
+    /// CLI value is `align` (short form for "align-and-merge" — the
+    /// stage does both, but the user-facing name is the verb).
+    #[clap(name = "align")]
+    AlignAndMerge,
+    /// Zip an unmapped BAM with an aligned BAM, transferring tags.
+    /// `--start-from zipper` accepts a queryname-sorted unmapped BAM
+    /// (via `--unmapped`) and a queryname-sorted mapped BAM (via
+    /// `--input`); `--stop-after zipper` writes the merged BAM.
+    /// Requires `--reference` (the same FASTA + `.dict` the standalone
+    /// `fgumi zipper` requires).
+    Zipper,
+    /// Raw unsorted BAM. Includes the sort step when used as
+    /// `--start-from sort`; writes sorted BAM and stops when used
+    /// as `--stop-after sort`.
+    Sort,
+    /// Sorted BAM (template-coordinate). Includes group + MI tag
+    /// assignment when used as `--start-from group`; writes
+    /// grouped BAM and stops when used as `--stop-after group`.
+    Group,
+    /// Consensus calling. The algorithm (simplex / duplex / CODEC) is
+    /// selected by `--consensus`, not by this stage. `--start-from
+    /// consensus` accepts a grouped (MI-tagged) BAM; `--stop-after
+    /// consensus` runs the chosen consensus caller and writes the
+    /// consensus BAM (record-identical to `fgumi simplex` / `duplex` / `codec`,
+    /// with matching `@HD` `SO`/`GO`/`SS`, `@SQ`, and `@RG`; runall's `@PG`
+    /// provenance differs, and `@HD` `VN` / `@CO` are not compared).
+    /// `--stop-after filter` fuses consensus → filter into one
+    /// in-memory pipeline (no intermediate consensus BAM).
+    Consensus,
+    /// Post-consensus filtering. `--start-from filter` accepts a
+    /// consensus BAM (output of `fgumi simplex`/`duplex`/`codec`) via
+    /// `--input`; `--stop-after filter` runs the filter stage and writes
+    /// the filtered BAM (record-identical to standalone `fgumi filter`, with
+    /// matching `@HD` `SO`/`GO`/`SS`, `@SQ`, and `@RG`; runall's `@PG`
+    /// provenance differs, and `@HD` `VN` / `@CO` are not compared).
+    /// Tunable via `--filter::*`. Filter is the last stage in the linear
+    /// order — no stage follows it. It runs either as the filter self-pair
+    /// (`--start-from filter --stop-after filter`, input = a consensus
+    /// BAM) or fused after an upstream consensus caller in the same
+    /// pipeline (`… → consensus → filter`), where the consensus output is
+    /// decoded in-memory and streamed straight into filter.
+    Filter,
+}
+
+/// The subset of [`RunAllStage`] values that are valid as `--stop-after`.
+///
+/// `align` (`AlignAndMerge`) is a valid `--start-from` but **not** a valid
+/// `--stop-after`: raw aligner output before the zipper-merge has lost
+/// every original tag (RX, QX, RG, …), so the earliest post-align stop
+/// point is `zipper`. Giving `--stop-after` its own value-enum makes
+/// `--help` list only the genuinely-valid stops and rejects
+/// `--stop-after align` at the clap parse layer with a clear
+/// "invalid value 'align'" error — instead of parsing it and failing
+/// later at runtime validation.
+///
+/// Convert to [`RunAllStage`] with `RunAllStage::from(stop)` /
+/// `stop.into()`; the two enums are kept in sync by
+/// `stop_after_values_are_runallstage_minus_align`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+pub enum StopAfter {
+    /// `--stop-after extract` — extract-only (FASTQ → unmapped BAM).
+    Extract,
+    /// `--stop-after correct` — write the corrected unmapped BAM.
+    Correct,
+    /// `--stop-after zipper` — merged-but-unsorted BAM (earliest
+    /// post-align stop).
+    Zipper,
+    /// `--stop-after sort` — template-coordinate sorted BAM.
+    Sort,
+    /// `--stop-after group` — grouped (MI-tagged) BAM.
+    Group,
+    /// `--stop-after consensus` — consensus BAM (algorithm chosen by
+    /// `--consensus`); same output as `fgumi simplex`/`duplex`/`codec`.
+    Consensus,
+    /// `--stop-after filter` — post-consensus filtered BAM (same output
+    /// as `fgumi filter`). Tunable via `--filter::*`.
+    Filter,
+}
+
+impl From<StopAfter> for RunAllStage {
+    fn from(stop: StopAfter) -> Self {
+        match stop {
+            StopAfter::Extract => Self::Extract,
+            StopAfter::Correct => Self::Correct,
+            StopAfter::Zipper => Self::Zipper,
+            StopAfter::Sort => Self::Sort,
+            StopAfter::Group => Self::Group,
+            StopAfter::Consensus => Self::Consensus,
+            StopAfter::Filter => Self::Filter,
+        }
+    }
+}
+
+impl RunAllStage {
+    /// Position in the linear stage order. `Extract = 0`,
+    /// `Correct = 1`, `AlignAndMerge = 2`, `Zipper = 3`, `Sort = 4`,
+    /// `Group = 5`, `Consensus = 6`, `Filter = 7`. Used to validate that
+    /// `start_from <= stop_after` and that the chain is buildable.
+    #[must_use]
+    pub fn ord(self) -> usize {
+        match self {
+            Self::Extract => 0,
+            Self::Correct => 1,
+            Self::AlignAndMerge => 2,
+            Self::Zipper => 3,
+            Self::Sort => 4,
+            Self::Group => 5,
+            Self::Consensus => 6,
+            Self::Filter => 7,
+        }
+    }
+
+    /// `true` if this stage is the consensus stage. Used by the Group
+    /// step-derivation exception (a consensus-start input is already
+    /// MI-tagged, so no explicit Group stage is added).
+    #[must_use]
+    pub fn is_consensus(self) -> bool {
+        matches!(self, Self::Consensus)
+    }
+
+    /// `true` if this stage is the extract stage.
+    #[must_use]
+    pub fn is_extract(self) -> bool {
+        matches!(self, Self::Extract)
+    }
+
+    /// Validate that `self` (as `--start-from`) and `stop_after` form
+    /// a buildable pipeline range.
+    ///
+    /// This is the sole ordinal-ordering check for the `--start-from` /
+    /// `--stop-after` pair: it enforces `self.ord() <= stop_after.ord()`,
+    /// i.e. that the pipeline does not start later than it stops.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if `self.ord() > stop_after.ord()`.
+    pub fn validate_with(self, stop_after: Self) -> Result<()> {
+        if self.ord() > stop_after.ord() {
+            bail!(
+                "--start-from {self} comes after --stop-after {stop_after}; \
+                 stop-after must be at or after start-from in the pipeline order \
+                 (extract < correct < align < zipper < sort < group < consensus < filter)"
+            );
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for RunAllStage {
+    /// Lower-case the variant name so error messages match the CLI
+    /// flag values the user typed (`--start-from sort`, not
+    /// `--start-from Sort`).
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            Self::Extract => "extract",
+            Self::Correct => "correct",
+            Self::AlignAndMerge => "align",
+            Self::Zipper => "zipper",
+            Self::Sort => "sort",
+            Self::Group => "group",
+            Self::Consensus => "consensus",
+            Self::Filter => "filter",
+        };
+        f.write_str(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runallstage_ord_is_linear() {
+        assert!(RunAllStage::Extract.ord() < RunAllStage::Correct.ord());
+        assert!(RunAllStage::Correct.ord() < RunAllStage::AlignAndMerge.ord());
+        assert!(RunAllStage::AlignAndMerge.ord() < RunAllStage::Zipper.ord());
+        assert!(RunAllStage::Zipper.ord() < RunAllStage::Sort.ord());
+        assert!(RunAllStage::Sort.ord() < RunAllStage::Group.ord());
+        assert!(RunAllStage::Group.ord() < RunAllStage::Consensus.ord());
+        assert!(RunAllStage::Consensus.ord() < RunAllStage::Filter.ord());
+    }
+
+    #[test]
+    fn stopafter_maps_to_runallstage_minus_align() {
+        // StopAfter has exactly RunAllStage minus AlignAndMerge; every StopAfter
+        // round-trips to a RunAllStage that is NOT AlignAndMerge.
+        for stop in [
+            StopAfter::Extract,
+            StopAfter::Correct,
+            StopAfter::Zipper,
+            StopAfter::Sort,
+            StopAfter::Group,
+            StopAfter::Consensus,
+            StopAfter::Filter,
+        ] {
+            let s: RunAllStage = stop.into();
+            assert_ne!(s, RunAllStage::AlignAndMerge);
+        }
+    }
+
+    #[test]
+    fn display_matches_cli_values() {
+        assert_eq!(RunAllStage::AlignAndMerge.to_string(), "align");
+        assert_eq!(RunAllStage::Consensus.to_string(), "consensus");
+        assert_eq!(RunAllMode::Simplex.to_string(), "simplex");
+    }
+
+    #[test]
+    fn validate_with_rejects_start_after_stop() {
+        assert!(RunAllStage::Group.validate_with(RunAllStage::Sort).is_err());
+        assert!(RunAllStage::Sort.validate_with(RunAllStage::Group).is_ok());
+    }
+}

--- a/src/lib/commands/runall.rs
+++ b/src/lib/commands/runall.rs
@@ -15,6 +15,8 @@
 
 use anyhow::{Result, bail};
 
+use crate::assigner::Strategy;
+
 /// Consensus mode selector for `runall`. Controls which consensus
 /// caller runs after the fused group + MI-grouping stages.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, clap::ValueEnum)]
@@ -269,6 +271,393 @@ impl std::fmt::Display for RunAllStage {
             Self::Filter => "filter",
         };
         f.write_str(name)
+    }
+}
+
+/// Validate that the `--strategy` chosen by the user is compatible
+/// with the terminal consensus mode derived from `--stop-after`.
+///
+/// `Duplex` requires `Strategy::Paired` (MIs need `/A`/`/B` suffixes);
+/// `Simplex` and `Codec` require any non-paired strategy. Error
+/// messages name `--stop-after` (Display, lowercase) so the user
+/// sees the flag they typed.
+///
+/// Free function so the error-message Display formatting is unit-testable
+/// without constructing a full `RunAll`.
+///
+/// Not yet called outside tests: the `RunAll` struct and its
+/// `validate_strategy` wrapper land in a later task of this same PR-B
+/// campaign, at which point this has a production call site.
+#[allow(dead_code)]
+fn validate_strategy_for_mode(mode: RunAllMode, strategy: Strategy) -> Result<()> {
+    match (mode, strategy) {
+        (RunAllMode::Duplex, Strategy::Paired) => Ok(()),
+        (RunAllMode::Duplex, _) => {
+            bail!("--consensus duplex requires --strategy paired (so MIs carry /A and /B suffixes)")
+        }
+        (RunAllMode::Simplex | RunAllMode::Codec, Strategy::Paired) => {
+            bail!("--consensus {mode} requires a non-paired strategy (identity/edit/adjacency)")
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Validate the `--start-from` / `--stop-after` pair against the
+/// structural (linear-ordering) rules. Delegates to
+/// [`RunAllStage::validate_with`]; consensus is no longer terminal-only
+/// (it fuses into `consensus → filter`), so only the ordinal order is
+/// enforced.
+///
+/// Historically this function also enforced "not yet implemented"
+/// gates while #33 tasks 4-9 incrementally wired each combination;
+/// those gates are all lifted now. The function is kept as the
+/// runall-side entry point so future validation rules (e.g.
+/// strategy/stage compatibility beyond what `validate_with`
+/// expresses) have a clear home.
+///
+/// Not yet called outside tests: `RunAll::validate_stages` (a later task of
+/// this same PR-B campaign) is the production call site.
+#[allow(dead_code)]
+fn validate_stages_for(start_from: RunAllStage, stop_after: RunAllStage) -> Result<()> {
+    start_from.validate_with(stop_after)?;
+    // `--stop-after align-and-merge` would mean "stop after the
+    // alignment but before zipper-merge". The design dropped that
+    // stop point because raw aligner output without the zipper-merge
+    // loses every original tag (RX, QX, RG, etc.) and isn't useful.
+    // Earliest stop point reachable from `--start-from align-and-merge`
+    // is `--stop-after zipper`. `validate_with`'s linear-order check
+    // would have let this combo through (ord 0 → ord 0 is structurally
+    // valid as a self-pair), so we reject it explicitly here.
+    if stop_after == RunAllStage::AlignAndMerge {
+        bail!(
+            "--stop-after align is not supported; raw aligner output \
+             without zipper-merge loses every original tag (RX, QX, RG, ...). \
+             Use `--stop-after zipper` for merged-but-unsorted output."
+        );
+    }
+    Ok(())
+}
+
+/// Derive the ordered [`Stage`](crate::pipeline::chains::Stage) list for a
+/// given `(start_from, stop_after)` pair.
+///
+/// Free function so the stage-derivation logic is unit-testable without
+/// constructing a full `RunAll` instance — same pattern as
+/// [`validate_stages_for`]. `RunAll::derive_stages` is the thin wrapper
+/// that reads `self` and calls this.
+///
+/// # Stage derivation rules
+///
+/// 1. **Correct**: included when `start_from == Correct`.
+///    When `stop_after > Correct`, the chain always chains through AAM
+///    (`Correct → Align` is the only supported downstream path; a corrected
+///    unmapped BAM must be aligned before it can be sorted or grouped).
+///
+/// 2. **Align**: included when `start_from <= AlignAndMerge` AND
+///    `stop_after >= Zipper`. `Stage::Align` encapsulates both the aligner
+///    subprocess AND the zipper-merge; there is no separate
+///    `--stop-after align` stop point (the validator rejects it).
+///    Included when:
+///    - `start_from == AlignAndMerge` (explicit AAM start), OR
+///    - `start_from == Correct` and `stop_after > Correct` (correct feeds
+///      into AAM as the mandatory next step).
+///
+/// 3. **Zipper**: included when `start_from == Zipper` (standalone zipper
+///    start). Mutually exclusive with `Stage::Align` — both produce a merged
+///    BAM from different source shapes.
+///
+/// 4. **Sort**: included when `start_from <= Sort` OR when `Align` /
+///    `Zipper` is in the chain AND `stop_after >= Sort`.
+///    **Sort-forcing rule**: `Stage::Align` and `Stage::Zipper` both emit
+///    queryname-sorted output. Downstream `Stage::Group` requires
+///    template-coordinate order — Sort is therefore mandatory between any
+///    Align/Zipper stage and Group, even when `--start-from` is not `sort`.
+///
+/// 5. **Group**: included when `stop_after >= Group` AND `start_from` is NOT
+///    a consensus stage. **Consensus-self-pair exception**: when
+///    `start_from.is_consensus()`, the input BAM is already MI-tagged. The
+///    standalone consensus chain builders handle MI-tag grouping internally
+///    via `GroupByMi` — adding an explicit `Stage::Group` here would
+///    double-group an already-grouped input. For all other start stages
+///    (correct, align, zipper, sort, group), the Group step is required to
+///    produce MI-tagged output before the consensus caller sees it.
+///
+/// 6. **Simplex / Duplex / Codec**: one of the three is appended when
+///    `stop_after` names that consensus stage (terminal, mutually exclusive).
+///
+/// # Errors
+///
+/// Returns `Err` for any `(start, stop)` pair that `validate_stages` would
+/// reject (should not be reached if `validate_stages` was called first), or
+/// if the Stage derivation reaches a branch that is a programming error (e.g.
+/// a non-consensus `stop` that makes it through all prior early-returns).
+///
+/// Not yet called outside tests: `RunAll::derive_stages` (a later task of
+/// this same PR-B campaign) is the production call site.
+#[allow(dead_code)]
+fn derive_stages_for(
+    start_from: RunAllStage,
+    stop_after: RunAllStage,
+    extract_wants_correct: bool,
+    consensus_mode: Option<RunAllMode>,
+) -> Result<Vec<crate::pipeline::chains::Stage>> {
+    use crate::pipeline::chains::Stage;
+
+    // `validate_stages` must have been called before this; the assert
+    // catches misuse in tests or future refactors.
+    debug_assert!(
+        start_from.ord() <= stop_after.ord() && stop_after != RunAllStage::AlignAndMerge,
+        "derive_stages_for called with invalid (start={start_from}, stop={stop_after}); \
+         validate_stages must run first"
+    );
+
+    let mut stages: Vec<Stage> = Vec::with_capacity(7);
+
+    // ── Step 0: Extract ──────────────────────────────────────────────────
+    // Included when the chain starts at Extract.
+    if start_from == RunAllStage::Extract {
+        stages.push(Stage::Extract);
+        // extract → extract: extract-only chain (FASTQ → unmapped BAM).
+        // The terminal Extract stage serialises and writes the unmapped
+        // BAM directly; there are no downstream stages.
+        if stop_after == RunAllStage::Extract {
+            return Ok(stages);
+        }
+    }
+
+    // Spec §6: an extract-start that stops at correct without a UMI source has
+    // no buildable chain (Correct would be skipped, and the ordinal fall-through
+    // would misreport "--consensus required"). Return the actionable error here
+    // so the pure fn is total over every (start, stop, wants_correct, mode).
+    if start_from == RunAllStage::Extract
+        && stop_after == RunAllStage::Correct
+        && !extract_wants_correct
+    {
+        bail!(
+            "--start-from extract --stop-after correct requires \
+             --correct::umi-files or --correct::umis"
+        );
+    }
+
+    // ── Filter self-pair ─────────────────────────────────────────────────
+    // `--start-from filter --stop-after filter`: input is a consensus BAM;
+    // run only the (terminal) filter stage. No group/consensus steps apply
+    // (the standalone filter chain handles its own queryname grouping when
+    // `--filter::filter-by-template` is set), so short-circuit here. The
+    // validator guarantees `start_from == Filter` implies
+    // `stop_after == Filter` (filter is the last stage in the linear order).
+    if start_from == RunAllStage::Filter {
+        stages.push(Stage::Filter);
+        return Ok(stages);
+    }
+
+    // ── Step 1: Correct ──────────────────────────────────────────────────
+    // Included when the chain starts at Correct. Also included when the
+    // chain starts at Extract AND the user supplied --correct::umi-files
+    // or --correct::umis (the extract_wants_correct flag).
+    // For a Correct self-pair there are no downstream stages; return early.
+    if start_from == RunAllStage::Correct
+        || (start_from == RunAllStage::Extract && extract_wants_correct)
+    {
+        stages.push(Stage::Correct);
+        if stop_after == RunAllStage::Correct {
+            return Ok(stages);
+        }
+        // `Correct → stop > Correct` always chains through AAM.
+        // Any stop beyond Correct (Zipper, Sort, Group, consensus)
+        // requires align-and-merge — a corrected unmapped BAM cannot
+        // be fed directly to Sort (no query-coordinate BAM).
+    }
+
+    // ── Step 2: Align (AAM = align + zipper-merge, fused) ────────────────
+    // `Stage::Align` covers both the aligner subprocess and the
+    // zipper-merge; there is no separate `--stop-after align` stop point.
+    // Included when:
+    //   (a) start_from == AlignAndMerge (explicit AAM start), OR
+    //   (b) start_from == Correct and stop_after > Correct (correct feeds
+    //       into AAM — see Step 1 above).
+    //   (c) start_from == Extract and stop_after > Correct (extract feeds
+    //       into Align, possibly through Correct first).
+    let includes_align = start_from == RunAllStage::AlignAndMerge
+        || (start_from == RunAllStage::Correct && stop_after != RunAllStage::Correct)
+        || (start_from == RunAllStage::Extract && stop_after.ord() > RunAllStage::Correct.ord());
+    if includes_align {
+        stages.push(Stage::Align);
+        // `--stop-after zipper` stops after the AAM step (which includes
+        // the zipper-merge internally). Return early.
+        if stop_after == RunAllStage::Zipper {
+            return Ok(stages);
+        }
+    }
+
+    // ── Step 3: Zipper (standalone zipper start) ─────────────────────────
+    // Mutually exclusive with `Stage::Align`. Included only when
+    // `start_from == Zipper` (the user supplies separate mapped + unmapped
+    // BAMs and the zipper-merge runs as the first step).
+    let includes_zipper = start_from == RunAllStage::Zipper;
+    if includes_zipper {
+        stages.push(Stage::Zipper);
+        if stop_after == RunAllStage::Zipper {
+            return Ok(stages);
+        }
+    }
+
+    // ── Step 4: Sort ──────────────────────────────────────────────────────
+    // Sort-forcing rule: Sort is ALWAYS included when Align or Zipper
+    // precede anything past Sort, because both produce queryname-sorted
+    // output and downstream Group requires template-coordinate order.
+    // Sort is also included when start_from == Sort (explicit sort start).
+    let sort_forced =
+        (includes_align || includes_zipper) && stop_after.ord() >= RunAllStage::Sort.ord();
+    let sort_explicit = start_from == RunAllStage::Sort;
+    if sort_forced || sort_explicit {
+        stages.push(Stage::Sort);
+    }
+    if stop_after == RunAllStage::Sort {
+        return Ok(stages);
+    }
+
+    // ── Step 5: Group ─────────────────────────────────────────────────────
+    // Included when stop_after >= Group AND start_from is NOT a consensus
+    // stage. The consensus-self-pair exception: when start_from is already
+    // a consensus stage (Simplex/Duplex/Codec), the input BAM is already
+    // MI-tagged. The standalone consensus chain builder (build_simplex_chain
+    // / build_duplex_chain / build_codec_chain) handles MI-tag grouping
+    // internally via GroupByMi — it does NOT run GroupByPosition /
+    // ProcessGroups / MiAssign. Adding an explicit Group stage here would
+    // double-group an already-grouped input.
+    //
+    // For `--start-from group --stop-after {consensus}` or any upstream
+    // start (sort, align, zipper, correct), Group IS required because the
+    // input is not yet MI-tagged.
+    let includes_group = !start_from.is_consensus()
+        && (start_from == RunAllStage::Group || stop_after.ord() >= RunAllStage::Group.ord());
+    if includes_group {
+        stages.push(Stage::Group);
+    }
+    if stop_after == RunAllStage::Group {
+        return Ok(stages);
+    }
+
+    // ── Step 6: Consensus ────────────────────────────────────────────────
+    // Reached when stop_after is Consensus or Filter (all earlier stops
+    // have returned, and the filter self-pair short-circuited above). The
+    // chain stage is chosen by the `--consensus` algorithm. When
+    // stop_after == Filter, consensus runs first, then Filter is appended
+    // below (consensus → filter chain).
+    debug_assert!(
+        matches!(stop_after, RunAllStage::Consensus | RunAllStage::Filter),
+        "derive_stages_for reached the consensus branch with unexpected \
+         stop stage {stop_after}; validate_stages must run first"
+    );
+    let mode = consensus_mode.ok_or_else(|| {
+        anyhow::anyhow!(
+            "--consensus <simplex|duplex|codec> is required when --stop-after \
+             reaches the consensus stage"
+        )
+    })?;
+    match mode {
+        RunAllMode::Simplex => stages.push(Stage::Simplex),
+        RunAllMode::Duplex => stages.push(Stage::Duplex),
+        RunAllMode::Codec => stages.push(Stage::Codec),
+    }
+
+    // ── Step 7: Filter (terminal) ────────────────────────────────────────
+    // Appended after the consensus caller when `--stop-after filter` chains
+    // consensus → filter. Filter is the last stage in the linear order, so
+    // no stage follows it.
+    if stop_after == RunAllStage::Filter {
+        stages.push(Stage::Filter);
+    }
+
+    Ok(stages)
+}
+
+#[cfg(test)]
+mod derive_tests {
+    use super::*;
+    use crate::assigner::Strategy;
+    use crate::pipeline::chains::Stage;
+    use RunAllStage::*;
+    use rstest::rstest;
+
+    #[rstest]
+    // ── self-pairs ──
+    #[case::extract_only(Extract, Extract, false, None, vec![Stage::Extract])]
+    #[case::correct_only(Correct, Correct, false, None, vec![Stage::Correct])]
+    #[case::sort_only(Sort, Sort, false, None, vec![Stage::Sort])]
+    #[case::group_only(Group, Group, false, None, vec![Stage::Group])]
+    #[case::filter_only(Filter, Filter, false, None, vec![Stage::Filter])]
+    // ── extract-fed fan-out ──
+    #[case::extract_to_group_no_umi(
+        Extract, Group, false, None,
+        vec![Stage::Extract, Stage::Align, Stage::Sort, Stage::Group])]
+    #[case::extract_to_group_with_umi(
+        Extract, Group, true, None,
+        vec![Stage::Extract, Stage::Correct, Stage::Align, Stage::Sort, Stage::Group])]
+    #[case::extract_to_zipper_allowed(
+        Extract, Zipper, false, None,
+        vec![Stage::Extract, Stage::Align])] // §6: ALLOW; align satisfies a zipper stop
+    #[case::extract_to_simplex(
+        Extract, Consensus, false, Some(RunAllMode::Simplex),
+        vec![Stage::Extract, Stage::Align, Stage::Sort, Stage::Group, Stage::Simplex])]
+    // ── correct-fed ──
+    #[case::correct_to_sort(
+        Correct, Sort, false, None,
+        vec![Stage::Correct, Stage::Align, Stage::Sort])]
+    // ── sort/group/consensus fed ──
+    #[case::sort_to_group(Sort, Group, false, None, vec![Stage::Sort, Stage::Group])]
+    #[case::sort_to_duplex(
+        Sort, Consensus, false, Some(RunAllMode::Duplex),
+        vec![Stage::Sort, Stage::Group, Stage::Duplex])]
+    #[case::group_to_codec(
+        Group, Consensus, false, Some(RunAllMode::Codec),
+        vec![Stage::Group, Stage::Codec])]
+    #[case::group_to_consensus_to_filter(
+        Group, Filter, false, Some(RunAllMode::Simplex),
+        vec![Stage::Group, Stage::Simplex, Stage::Filter])]
+    // ── consensus self-pair: NO Stage::Group (already MI-tagged) ──
+    #[case::consensus_self_pair(
+        Consensus, Consensus, false, Some(RunAllMode::Simplex),
+        vec![Stage::Simplex])]
+    // ── zipper start ──
+    #[case::zipper_to_sort(Zipper, Sort, false, None, vec![Stage::Zipper, Stage::Sort])]
+    fn derive_stages_matches_spec(
+        #[case] start: RunAllStage,
+        #[case] stop: RunAllStage,
+        #[case] wants_correct: bool,
+        #[case] mode: Option<RunAllMode>,
+        #[case] expected: Vec<Stage>,
+    ) {
+        let got = derive_stages_for(start, stop, wants_correct, mode).expect("derives");
+        assert_eq!(got, expected);
+    }
+
+    #[rstest]
+    #[case::extract_correct_no_umi(Extract, Correct, false, None)]
+    fn derive_stages_errors(
+        #[case] start: RunAllStage,
+        #[case] stop: RunAllStage,
+        #[case] wants_correct: bool,
+        #[case] mode: Option<RunAllMode>,
+    ) {
+        let err = derive_stages_for(start, stop, wants_correct, mode).unwrap_err().to_string();
+        assert!(err.contains("--correct::umi-files or --correct::umis"), "got: {err}");
+    }
+
+    #[rstest]
+    #[case::backwards(Group, Sort)]
+    fn validate_stages_rejects_backwards(#[case] start: RunAllStage, #[case] stop: RunAllStage) {
+        assert!(validate_stages_for(start, stop).is_err());
+    }
+
+    #[rstest]
+    #[case::duplex_needs_paired(RunAllMode::Duplex, Strategy::Adjacency, true)]
+    #[case::duplex_paired_ok(RunAllMode::Duplex, Strategy::Paired, false)]
+    #[case::simplex_paired_rejected(RunAllMode::Simplex, Strategy::Paired, true)]
+    #[case::simplex_adjacency_ok(RunAllMode::Simplex, Strategy::Adjacency, false)]
+    fn strategy_for_mode(#[case] mode: RunAllMode, #[case] strat: Strategy, #[case] is_err: bool) {
+        assert_eq!(validate_strategy_for_mode(mode, strat).is_err(), is_err);
     }
 }
 

--- a/src/lib/commands/runall.rs
+++ b/src/lib/commands/runall.rs
@@ -171,7 +171,7 @@ pub enum RunAllStage {
 ///
 /// Convert to [`RunAllStage`] with `RunAllStage::from(stop)` /
 /// `stop.into()`; the two enums are kept in sync by
-/// `stop_after_values_are_runallstage_minus_align`.
+/// `stopafter_maps_to_runallstage_minus_align`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 #[clap(rename_all = "kebab-case")]
 pub enum StopAfter {
@@ -233,12 +233,6 @@ impl RunAllStage {
     #[must_use]
     pub fn is_consensus(self) -> bool {
         matches!(self, Self::Consensus)
-    }
-
-    /// `true` if this stage is the extract stage.
-    #[must_use]
-    pub fn is_extract(self) -> bool {
-        matches!(self, Self::Extract)
     }
 
     /// Validate that `self` (as `--start-from`) and `stop_after` form
@@ -1024,18 +1018,32 @@ impl RunAll {
                     !opts.read_structures.is_empty(),
                     "--extract::read-structures is required when --start-from extract"
                 );
-                anyhow::ensure!(
-                    opts.inputs.len() == opts.read_structures.len(),
-                    "--extract::inputs and --extract::read-structures must have the same count"
-                );
+                // The equal-count check is only correct for the non-interleaved
+                // (one FASTQ per read structure) shape. Interleaved packs both
+                // reads of a pair into a single FASTQ, so it is 1 input + 2 read
+                // structures. Mirror `build_stage_options_bag`'s Extract arm and
+                // extract.rs so the two agree.
                 if opts.interleaved {
+                    anyhow::ensure!(
+                        opts.inputs.len() == 1,
+                        "--extract::interleaved requires exactly one --extract::inputs; got {}",
+                        opts.inputs.len()
+                    );
+                    anyhow::ensure!(
+                        opts.read_structures.len() == 2,
+                        "--extract::interleaved requires exactly two \
+                         --extract::read-structures; got {}",
+                        opts.read_structures.len()
+                    );
                     let path = opts.inputs.first().cloned().ok_or_else(|| {
                         anyhow::anyhow!("--extract::inputs is required when --start-from extract")
                     })?;
-                    // Enforces exactly 2 read structures (the R1/R2 pair).
                     SourceSpec::interleaved_fastq(path, opts.read_structures)
                 } else {
-                    // Enforces paths.len() == read_structures.len().
+                    anyhow::ensure!(
+                        opts.inputs.len() == opts.read_structures.len(),
+                        "--extract::inputs and --extract::read-structures must have the same count"
+                    );
                     SourceSpec::fastqs(opts.inputs, opts.read_structures)
                 }
             }
@@ -1176,7 +1184,11 @@ impl RunAll {
     ///   `tmp_dirs` against `FGUMI_TMP_DIRS`, and — when sort is fused with
     ///   another stage — overrides an explicit `--sort::max-memory auto` to
     ///   the standalone 768 MiB default (auto-detection is not supported in a
-    ///   fused chain).
+    ///   fused chain). Finally runs the inherent
+    ///   [`crate::commands::sort::SortOptions::validate_spill_settings`]
+    ///   cross-field check (rejects `--sort::temp-codec zstd` with
+    ///   `--sort::temp-compression 0`) before the chain builder wires the spill
+    ///   compressor.
     ///
     /// * **Group** — validates `MultiGroupOptions`, then computes
     ///   `effective_strategy` / `effective_edits` via
@@ -1239,8 +1251,8 @@ impl RunAll {
                 Stage::Align => {
                     let reference = self.reference.clone().ok_or_else(|| {
                         anyhow::anyhow!(
-                            "--start-from align requires --ref (the aligner reference \
-                             FASTA with its index files alongside)"
+                            "a runall chain that includes align requires --ref (the aligner \
+                             reference FASTA with its index files alongside)"
                         )
                     })?;
                     let aligner = self.aligner_opts.clone().validate()?;
@@ -1260,6 +1272,15 @@ impl RunAll {
                     let mut sort_opts = self.sort_opts.clone().validate()?;
                     // Runall's sort step always produces template-coordinate
                     // output — the only order compatible with downstream Group.
+                    // Warn before overriding a user-supplied order so the
+                    // override is not silent (mirrors the max-memory warn below).
+                    if sort_opts.order != SortOrderArg::TemplateCoordinate {
+                        log::warn!(
+                            "--sort::order {:?} is ignored; runall forces template-coordinate \
+                             sort order for its sort step",
+                            sort_opts.order
+                        );
+                    }
                     sort_opts.order = SortOrderArg::TemplateCoordinate;
                     sort_opts.tmp_dirs = resolve_tmp_dirs(
                         &sort_opts.tmp_dirs,
@@ -1267,14 +1288,25 @@ impl RunAll {
                     );
                     // --sort::max-memory=auto bails in any non-sole-[Sort] chain
                     // (builder.rs:2560), so override auto -> the standalone
-                    // 768 MiB default when sort is fused with other stages.
+                    // 768 MiB default when sort is fused with other stages. Use
+                    // the exact expression SortOptions::default() uses so the
+                    // value cannot diverge from the standalone default.
                     if stages != [Stage::Sort] && sort_opts.max_memory == MemoryLimit::Auto {
                         log::warn!(
                             "--sort::max-memory auto is not supported in a fused runall \
                              chain; using 768M"
                         );
-                        sort_opts.max_memory = MemoryLimit::Fixed(768 * 1024 * 1024);
+                        sort_opts.max_memory =
+                            crate::commands::common::parse_memory("768M").expect("valid default");
                     }
+                    // Inherent cross-field check (mirrors the Codec/Extract
+                    // branches below): reject `--sort::temp-codec zstd` paired
+                    // with `--sort::temp-compression 0` here, before the chain
+                    // builder wires `SpillBlockCompress`, rather than failing
+                    // lazily on the first spill. The macro-generated
+                    // `MultiSortOptions::validate` only converts staged-required
+                    // fields; it does not run this check.
+                    sort_opts.validate_spill_settings()?;
                     bag.sort = Some(sort_opts);
                 }
 
@@ -1288,6 +1320,28 @@ impl RunAll {
                         group_opts.resolve_strategy_and_edits();
                     group_opts.effective_strategy = effective_strategy;
                     group_opts.effective_edits = effective_edits;
+                    // `--index-threshold always` asserts indexing will happen;
+                    // reject it when the resolved strategy/edits can never index,
+                    // matching standalone `fgumi group` (group.rs
+                    // GroupReadsByUmi::validate) rather than silently ignoring it.
+                    crate::commands::common::validate_index_threshold(
+                        group_opts.index_threshold,
+                        effective_strategy,
+                        effective_edits,
+                    )?;
+                    // Forcing these to None is spec-mandated (runall does not
+                    // emit per-position group metrics in a fused run), but warn
+                    // so the dropped flags are not silent.
+                    if group_opts.family_size_histogram.is_some()
+                        || group_opts.grouping_metrics.is_some()
+                        || group_opts.metrics_prefix.is_some()
+                    {
+                        log::warn!(
+                            "--group::family-size-histogram / --group::grouping-metrics / \
+                             --group::metrics are ignored: runall does not emit per-position \
+                             group metrics in a fused run"
+                        );
+                    }
                     group_opts.family_size_histogram = None;
                     group_opts.grouping_metrics = None;
                     group_opts.metrics_prefix = None;
@@ -1309,6 +1363,12 @@ impl RunAll {
                 #[cfg(feature = "consensus")]
                 Stage::Duplex => {
                     let mut opts = self.duplex_opts.clone().validate()?;
+                    // `add_duplex` (builder.rs) does not validate numeric bounds
+                    // the way `add_simplex`/codec do, so run the same guards the
+                    // standalone `fgumi duplex` applies (DuplexOptions::validate_numeric,
+                    // extracted from duplex.rs Duplex::validate) — otherwise runall
+                    // accepts degenerate configs that yield a silent empty BAM.
+                    opts.validate_numeric()?;
                     opts.rejects_opts.clone_from(&self.rejects_opts);
                     opts.stats_opts.clone_from(&self.stats_opts);
                     opts.read_group.clone_from(&self.read_group);
@@ -1551,14 +1611,39 @@ impl Command for RunAll {
         // `fgumi correct --rejects` step separately.
         if matches!(self.start_from, RunAllStage::Extract | RunAllStage::Correct)
             && self.stop_after_stage() != RunAllStage::Correct
+            && stages.contains(&Stage::Correct)
             && self.rejects_opts.rejects.is_some()
         {
             log::warn!(
-                "--rejects with --start-from correct --stop-after {} discards correct's UMI rejects \
+                "--rejects with --start-from {} --stop-after {} discards correct's UMI rejects \
                  (the fused chain has no UMI-rejects branch). The rejects file will collect only \
                  downstream rejects. Use a separate `fgumi correct --rejects` step if you need \
                  UMI rejects captured.",
+                self.start_from,
                 self.stop_after_stage()
+            );
+        }
+
+        // A7: warn on top-level --stats / --rejects that the derived chain
+        // never consumes, so a silently-dead flag does not mislead. Top-level
+        // --stats is cloned only into consensus stages; top-level --rejects is
+        // wired only into a correct self-pair or a consensus stage. Filter reads
+        // its own --filter::stats / --filter::rejects, so point the user there.
+        // Use warn (not bail) — the run is still valid, just missing the output
+        // the user expected on the wrong flag.
+        if self.stats_opts.stats.is_some() && !chain_reaches_consensus {
+            log::warn!(
+                "--stats is consumed only by the consensus stage; it is dead on a runall chain \
+                 that reaches no consensus stage. Use --filter::stats to capture filter statistics."
+            );
+        }
+        if self.rejects_opts.rejects.is_some()
+            && !chain_reaches_consensus
+            && !stages.contains(&Stage::Correct)
+        {
+            log::warn!(
+                "--rejects is wired nowhere on this runall chain (it is consumed only by a correct \
+                 self-pair or a consensus stage). Use --filter::rejects to capture filter rejects."
             );
         }
 
@@ -1585,6 +1670,53 @@ impl Command for RunAll {
         let source = self.derive_source_spec()?;
         let sink = self.derive_sink_spec()?;
         let stage_opts = self.build_stage_options_bag(&stages)?;
+
+        // A1: reject an --output that collides with any rejects/stats path the
+        // derived chain will actually open as a *second* writer. Two writers on
+        // one file silently corrupt it (see `reject_output_collisions` in
+        // common.rs). Enumerate only the writer paths the bag actually wired —
+        // reading them off the populated `stage_opts` so the guard fires on the
+        // exact paths the chain will open. `--input`/`--unmapped` are read-only
+        // and exempt; stdin/`-`/`/dev/null` are handled inside the guard.
+        let mut write_targets: Vec<(&std::path::Path, &str)> =
+            vec![(self.output.as_path(), "--output")];
+        if let Some(rejects) = stage_opts.correct.as_ref().and_then(|c| c.rejects_path.as_ref()) {
+            write_targets.push((rejects.as_path(), "--rejects"));
+        }
+        #[cfg(feature = "consensus")]
+        {
+            // Only one consensus stage is ever wired, but enumerate all three
+            // uniformly; the absent bags contribute nothing.
+            for rejects in [
+                stage_opts.simplex.as_ref().and_then(|o| o.rejects_opts.rejects.as_ref()),
+                stage_opts.duplex.as_ref().and_then(|o| o.rejects_opts.rejects.as_ref()),
+                stage_opts.codec.as_ref().and_then(|o| o.rejects_opts.rejects.as_ref()),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                write_targets.push((rejects.as_path(), "--rejects"));
+            }
+            for stats in [
+                stage_opts.simplex.as_ref().and_then(|o| o.stats_opts.stats.as_ref()),
+                stage_opts.duplex.as_ref().and_then(|o| o.stats_opts.stats.as_ref()),
+                stage_opts.codec.as_ref().and_then(|o| o.stats_opts.stats.as_ref()),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                write_targets.push((stats.as_path(), "--stats"));
+            }
+        }
+        if let Some(filter) = stage_opts.filter.as_ref() {
+            if let Some(rejects) = filter.rejects.as_ref() {
+                write_targets.push((rejects.as_path(), "--filter::rejects"));
+            }
+            if let Some(stats) = filter.stats.as_ref() {
+                write_targets.push((stats.as_path(), "--filter::stats"));
+            }
+        }
+        crate::commands::common::reject_output_collisions(&write_targets)?;
 
         let spec = ChainSpec {
             stages,
@@ -1891,6 +2023,38 @@ mod bag_tests {
             bag.sort.unwrap().max_memory,
             crate::commands::common::MemoryLimit::Fixed(_)
         ));
+    }
+
+    #[test]
+    fn sort_rejects_zstd_with_zero_temp_compression() {
+        // The inherent `SortOptions::validate_spill_settings` cross-field check
+        // must run in the runall sort branch, rejecting the invalid zstd/level-0 pairing before
+        // the chain builder wires the spill compressor (rather than failing
+        // lazily on the first spill).
+        let r = parse(&[
+            "--start-from",
+            "sort",
+            "--stop-after",
+            "group",
+            "-i",
+            "in.bam",
+            "-o",
+            "out.bam",
+            "--group::strategy",
+            "adjacency",
+            "--sort::temp-codec",
+            "zstd",
+            "--sort::temp-compression",
+            "0",
+        ]);
+        let Err(err) = r.build_stage_options_bag(&[Stage::Sort, Stage::Group]) else {
+            panic!("expected --sort::temp-codec zstd + --sort::temp-compression 0 to be rejected");
+        };
+        let err = err.to_string();
+        assert!(
+            err.contains("--temp-compression 0 is only supported with --temp-codec bgzf"),
+            "got: {err}"
+        );
     }
 
     #[cfg(feature = "consensus")]

--- a/src/lib/commands/runall.rs
+++ b/src/lib/commands/runall.rs
@@ -2143,6 +2143,57 @@ mod tests {
         }
     }
 
+    /// The reverse of `stopafter_maps_to_runallstage_minus_align`: every
+    /// `RunAllStage` variant EXCEPT `AlignAndMerge` has a corresponding
+    /// `StopAfter` variant that round-trips back to it via `RunAllStage::from`.
+    ///
+    /// Enumerates all `RunAllStage` variants in a fixed array and maps each to
+    /// its `StopAfter` counterpart through an EXHAUSTIVE match (no wildcard
+    /// arm) — so if a new `RunAllStage` variant is ever added without also
+    /// adding a matching `StopAfter` variant (and updating this match), this
+    /// test fails to compile rather than silently passing.
+    #[test]
+    fn every_runallstage_except_align_has_a_stopafter() {
+        let variants = [
+            RunAllStage::Extract,
+            RunAllStage::Correct,
+            RunAllStage::AlignAndMerge,
+            RunAllStage::Zipper,
+            RunAllStage::Sort,
+            RunAllStage::Group,
+            RunAllStage::Consensus,
+            RunAllStage::Filter,
+        ];
+        for stage in variants {
+            let stop_after: Option<StopAfter> = match stage {
+                RunAllStage::Extract => Some(StopAfter::Extract),
+                RunAllStage::Correct => Some(StopAfter::Correct),
+                RunAllStage::AlignAndMerge => None,
+                RunAllStage::Zipper => Some(StopAfter::Zipper),
+                RunAllStage::Sort => Some(StopAfter::Sort),
+                RunAllStage::Group => Some(StopAfter::Group),
+                RunAllStage::Consensus => Some(StopAfter::Consensus),
+                RunAllStage::Filter => Some(StopAfter::Filter),
+            };
+            match stop_after {
+                Some(stop) => {
+                    assert_eq!(
+                        RunAllStage::from(stop),
+                        stage,
+                        "{stage} should round-trip through its StopAfter counterpart"
+                    );
+                }
+                None => {
+                    assert_eq!(
+                        stage,
+                        RunAllStage::AlignAndMerge,
+                        "only AlignAndMerge should have no StopAfter counterpart"
+                    );
+                }
+            }
+        }
+    }
+
     #[test]
     fn display_matches_cli_values() {
         assert_eq!(RunAllStage::AlignAndMerge.to_string(), "align");

--- a/src/lib/commands/runall.rs
+++ b/src/lib/commands/runall.rs
@@ -1681,7 +1681,16 @@ impl Command for RunAll {
         let mut write_targets: Vec<(&std::path::Path, &str)> =
             vec![(self.output.as_path(), "--output")];
         if let Some(rejects) = stage_opts.correct.as_ref().and_then(|c| c.rejects_path.as_ref()) {
-            write_targets.push((rejects.as_path(), "--rejects"));
+            // Name the flag that actually supplied this path: the correct
+            // self-pair prefers top-level `--rejects`, falling back to
+            // `--correct::rejects` (see the Stage::Correct arm), so the
+            // collision message points at the flag the user really typed.
+            let label = if self.rejects_opts.rejects.is_some() {
+                "--rejects"
+            } else {
+                "--correct::rejects"
+            };
+            write_targets.push((rejects.as_path(), label));
         }
         #[cfg(feature = "consensus")]
         {
@@ -2199,6 +2208,42 @@ mod tests {
         assert_eq!(RunAllStage::AlignAndMerge.to_string(), "align");
         assert_eq!(RunAllStage::Consensus.to_string(), "consensus");
         assert_eq!(RunAllMode::Simplex.to_string(), "simplex");
+    }
+
+    /// Drift guard: the hand-written `Display` impls must agree with the CLI
+    /// value names clap derives from `#[derive(ValueEnum)]` + the
+    /// `rename_all = "kebab-case"` / `#[clap(name = ...)]` attributes. Error
+    /// messages use `Display`, so a variant whose `Display` string diverged
+    /// from what the flag actually accepts would name a value the user cannot
+    /// type. This pins the two together for every variant.
+    #[test]
+    fn display_matches_clap_value_names() {
+        use clap::ValueEnum;
+        for stage in [
+            RunAllStage::Extract,
+            RunAllStage::Correct,
+            RunAllStage::AlignAndMerge,
+            RunAllStage::Zipper,
+            RunAllStage::Sort,
+            RunAllStage::Group,
+            RunAllStage::Consensus,
+            RunAllStage::Filter,
+        ] {
+            let clap_name = stage.to_possible_value().expect("stage is a real value-enum variant");
+            assert_eq!(
+                stage.to_string(),
+                clap_name.get_name(),
+                "RunAllStage::{stage:?} Display drifted from its clap value name"
+            );
+        }
+        for mode in [RunAllMode::Simplex, RunAllMode::Codec, RunAllMode::Duplex] {
+            let clap_name = mode.to_possible_value().expect("mode is a real value-enum variant");
+            assert_eq!(
+                mode.to_string(),
+                clap_name.get_name(),
+                "RunAllMode::{mode:?} Display drifted from its clap value name"
+            );
+        }
     }
 
     #[test]

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -1997,9 +1997,17 @@ impl<'a> ChainBuilder<'a> {
         info!("{}", self.spec.threading.log_message());
         info!("Using pipeline with {num_threads} threads");
 
-        // Wire GroupByQueryname before the correct step.
-        let tail =
-            self.pipeline.append_step(GroupByQueryname::new(self.tuning.per_step_byte_limit), tail);
+        // Wire GroupByQueryname before the correct step — but only when the upstream
+        // stage emits DecodedRecordBatch (the normal source-preamble path). When
+        // `chain_tail_kind == BamTemplateBatch`, an upstream stage (e.g. Extract) has
+        // already grouped records into templates, which is exactly the input the
+        // correct step consumes. Skip GroupByQueryname in that case to avoid a
+        // DecodedRecordBatch→BamTemplateBatch type mismatch (mirrors `add_align`).
+        let tail = if self.chain_tail_kind == ChainTailKind::BamTemplateBatch {
+            tail
+        } else {
+            self.pipeline.append_step(GroupByQueryname::new(self.tuning.per_step_byte_limit), tail)
+        };
 
         // Dispatch on rejects presence: either a 2-output or a 1-output step.
         let process_tail = if track_rejects {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ use fgumi_lib::commands::group::GroupReadsByUmi;
 use fgumi_lib::commands::merge::Merge;
 use fgumi_lib::commands::retag::Retag;
 use fgumi_lib::commands::review::Review;
+use fgumi_lib::commands::runall::RunAll;
 #[cfg(feature = "simplex")]
 use fgumi_lib::commands::simplex::Simplex;
 #[cfg(feature = "simplex")]
@@ -150,6 +151,8 @@ enum Subcommand {
     CopyUmi(CopyUmi),
     #[command(display_order = 19)]
     Retag(Retag),
+    #[command(name = "runall", display_order = 22)]
+    RunAll(RunAll),
     #[cfg(feature = "compare")]
     #[command(display_order = 20)]
     Compare(Compare),
@@ -185,6 +188,7 @@ impl Subcommand {
             Self::Downsample(cmd) => cmd.execute(command_line),
             Self::CopyUmi(cmd) => cmd.execute(command_line),
             Self::Retag(cmd) => cmd.execute(command_line),
+            Self::RunAll(cmd) => cmd.execute(command_line),
             #[cfg(feature = "compare")]
             Self::Compare(cmd) => cmd.execute(command_line),
             #[cfg(feature = "simulate")]

--- a/tests/integration/helpers/aligner.rs
+++ b/tests/integration/helpers/aligner.rs
@@ -1,0 +1,29 @@
+//! Real-aligner-subprocess helpers shared by the `runall` integration tests.
+//!
+//! `runall`'s Align-stage tests (`test_runall_command.rs`,
+//! `test_runall_chain_transitions.rs`) both run end to end only when a real
+//! aligner binary is on `PATH`, and validate the assembled spec/reject with a
+//! clear message otherwise; this guard used to be duplicated verbatim in both
+//! files.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+/// Returns the first real aligner binary found on `PATH` (`bwa-mem3`
+/// preferred, then classic `bwa`), or `None` if neither is installed.
+pub fn aligner_binary() -> Option<&'static str> {
+    ["bwa-mem3", "bwa"].into_iter().find(|bin| which::which(bin).is_ok())
+}
+
+/// Runs `<binary> index <reference>`, panicking on failure. Only called after
+/// the caller has confirmed `binary` is on `PATH` via [`aligner_binary`], so a
+/// failure here is a real setup regression, not a skip condition.
+pub fn build_aligner_index(reference: &Path, binary: &str) {
+    let status = Command::new(binary)
+        .args(["index", reference.to_str().expect("reference path is valid UTF-8")])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap_or_else(|e| panic!("failed to run `{binary} index`: {e}"));
+    assert!(status.success(), "`{binary} index` failed with status {status}");
+}

--- a/tests/integration/helpers/fastq.rs
+++ b/tests/integration/helpers/fastq.rs
@@ -1,0 +1,19 @@
+//! FASTQ-writing helpers shared by the `runall` integration tests.
+//!
+//! `runall`'s extract-fusion tests (`test_runall_command.rs`,
+//! `test_runall_chain_transitions.rs`) both need to stage small gzip-compressed
+//! FASTQ fixtures; this used to be duplicated verbatim in both files.
+
+use std::fs;
+use std::io::Write as _;
+use std::path::Path;
+
+/// Write a gzip-compressed FASTQ from `(name, seq, qual)` records.
+pub fn write_gzip_fastq(path: &Path, records: &[(&str, &str, &str)]) {
+    let file = fs::File::create(path).expect("create gzip fastq");
+    let mut encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+    for (name, seq, qual) in records {
+        writeln!(encoder, "@{name}\n{seq}\n+\n{qual}").expect("write fastq record");
+    }
+    encoder.finish().expect("finish gzip fastq");
+}

--- a/tests/integration/helpers/mod.rs
+++ b/tests/integration/helpers/mod.rs
@@ -7,13 +7,17 @@
 
 #![allow(dead_code, unused_imports)]
 
+pub mod aligner;
 pub mod assertions;
 pub mod bam_generator;
 pub mod cli;
+pub mod fastq;
 
+pub use aligner::*;
 pub use assertions::*;
 pub use bam_generator::*;
 pub use cli::*;
+pub use fastq::*;
 
 /// Writes `contents` to `dir/name` and returns the path.
 ///

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -45,6 +45,7 @@ mod test_pipeline_concurrency;
 mod test_pipeline_memory_backpressure;
 mod test_retag_command;
 mod test_review_command;
+mod test_runall_chain_transitions;
 mod test_sam_input;
 #[cfg(feature = "simplex")]
 mod test_simplex_command;

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -46,6 +46,7 @@ mod test_pipeline_memory_backpressure;
 mod test_retag_command;
 mod test_review_command;
 mod test_runall_chain_transitions;
+mod test_runall_command;
 mod test_sam_input;
 #[cfg(feature = "simplex")]
 mod test_simplex_command;

--- a/tests/integration/test_input_source_matrix.rs
+++ b/tests/integration/test_input_source_matrix.rs
@@ -195,6 +195,22 @@ const CONTRACTS: &[IoContract] = &[
         stdout: Required,
         output_depends_on_input: Required,
     },
+    IoContract {
+        command: "runall",
+        sam: NotApplicable(
+            "reads a BAM/FASTQ intermediate selected by `--start-from`; it never constructs a \
+             SAM source",
+        ),
+        stdin: NotApplicable(
+            "its input contract is stage-dependent (`--start-from` selects FASTQ, BAM, or \
+             paired BAM), so this harness's bare `-i`/`-o` invocation cannot exercise it",
+        ),
+        stdout: NotApplicable(
+            "requires `--start-from`/`--stop-after`, which this harness does not supply, so it \
+             is not invoked here",
+        ),
+        output_depends_on_input: NotApplicable("declares no axis this harness invokes"),
+    },
     #[cfg(feature = "duplex")]
     IoContract {
         command: "duplex-metrics",

--- a/tests/integration/test_runall_chain_transitions.rs
+++ b/tests/integration/test_runall_chain_transitions.rs
@@ -1,10 +1,7 @@
 //! In-process `build_for`+run tests for each multi-stage transition `runall`
 //! depends on. These validate the chain plumbing (type-erased hand-offs)
 //! BEFORE the CLI is wired, per spec §9.
-use std::fs;
-use std::io::Write as _;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
 
 use fgumi_lib::aligner::AlignerOptions;
 use fgumi_lib::assigner::Strategy;
@@ -41,6 +38,7 @@ use crate::helpers::bam_generator::{
     write_bam,
 };
 use crate::helpers::read_bam_output;
+use crate::helpers::{aligner_binary, build_aligner_index, write_gzip_fastq};
 
 /// Assembles a [`ChainSpec`] with the boilerplate fields every test below
 /// shares (threading/compression/scheduler/queue-memory defaults, a plain
@@ -68,16 +66,6 @@ fn base_chain_spec(
         verify_crc: false,
         command_line: "test".into(),
     }
-}
-
-/// Write a gzip-compressed FASTQ from `(name, seq, qual)` records.
-fn write_gzip_fastq(path: &Path, records: &[(&str, &str, &str)]) {
-    let file = fs::File::create(path).expect("create gzip fastq");
-    let mut encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
-    for (name, seq, qual) in records {
-        writeln!(encoder, "@{name}\n{seq}\n+\n{qual}").expect("write fastq record");
-    }
-    encoder.finish().expect("finish gzip fastq");
 }
 
 /// Build a small paired gzip FASTQ (`r1.fq.gz`, `r2.fq.gz`) with a 4 bp UMI on
@@ -167,7 +155,8 @@ fn extract_to_correct_chain_builds_and_runs() {
     };
 
     build_for(spec).expect("build").run().expect("run without panic");
-    assert!(fs::metadata(&out).unwrap().len() > 0, "corrected BAM is non-empty");
+    let (_, records) = read_bam_output(&out);
+    assert!(!records.is_empty(), "corrected BAM should have records");
 }
 
 // ─────────────────────────── Sort→Group, Group→consensus, Consensus→Filter ───────────────────────────
@@ -564,25 +553,6 @@ fn zipper_to_sort_chain_builds_and_runs() {
 // `validate_stage_opts_present` / `validate_cross_stage_constraints`), so the
 // transition's wiring is still exercised at the spec level everywhere.
 
-/// Returns the first real aligner binary found on `PATH` (`bwa-mem3`
-/// preferred, then classic `bwa`), or `None` if neither is installed.
-fn aligner_binary() -> Option<&'static str> {
-    ["bwa-mem3", "bwa"].into_iter().find(|bin| which::which(bin).is_ok())
-}
-
-/// Runs `<binary> index <reference>`, panicking on failure. Only called after
-/// the caller has confirmed `binary` is on `PATH` via [`aligner_binary`], so a
-/// failure here is a real setup regression, not a skip condition.
-fn build_aligner_index(reference: &Path, binary: &str) {
-    let status = Command::new(binary)
-        .args(["index", reference.to_str().expect("reference path is valid UTF-8")])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .unwrap_or_else(|e| panic!("failed to run `{binary} index`: {e}"));
-    assert!(status.success(), "`{binary} index` failed with status {status}");
-}
-
 /// Writes a single-end unmapped BAM: `n` reads, each carrying an `RX` UMI tag
 /// and a 12bp template sequence (`ACGTACGTACGT`) that is an exact substring of
 /// `create_test_reference`'s repeating `ACGTACGT` `chr1`, so a real aligner
@@ -656,7 +626,8 @@ fn extract_to_align_chain_builds_and_runs_or_validates() {
             bag,
         );
         build_for(spec).expect("build").run().expect("run");
-        assert!(fs::metadata(&out).unwrap().len() > 0, "aligned BAM is non-empty");
+        let (_, records) = read_bam_output(&out);
+        assert!(!records.is_empty(), "aligned BAM should have records");
     } else {
         eprintln!(
             "no bwa/bwa-mem3 on PATH: validating the Extract→Align spec instead of running it"
@@ -716,7 +687,8 @@ fn correct_to_align_chain_builds_and_runs_or_validates() {
             bag,
         );
         build_for(spec).expect("build").run().expect("run");
-        assert!(fs::metadata(&out).unwrap().len() > 0, "aligned BAM is non-empty");
+        let (_, records) = read_bam_output(&out);
+        assert!(!records.is_empty(), "aligned BAM should have records");
     } else {
         eprintln!(
             "no bwa/bwa-mem3 on PATH: validating the Correct→Align spec instead of running it"

--- a/tests/integration/test_runall_chain_transitions.rs
+++ b/tests/integration/test_runall_chain_transitions.rs
@@ -1,0 +1,116 @@
+//! In-process `build_for`+run tests for each multi-stage transition `runall`
+//! depends on. These validate the chain plumbing (type-erased hand-offs)
+//! BEFORE the CLI is wired, per spec §9.
+use std::fs;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use fgumi_lib::commands::common::{
+    CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
+};
+use fgumi_lib::commands::correct::CorrectOptions;
+use fgumi_lib::commands::extract::ExtractRunallOptions;
+use fgumi_lib::pipeline::chains::{
+    ChainSpec, SinkSpec, SourceSpec, Stage, StageOptionsBag, build_for,
+};
+use tempfile::TempDir;
+
+/// Write a gzip-compressed FASTQ from `(name, seq, qual)` records.
+fn write_gzip_fastq(path: &Path, records: &[(&str, &str, &str)]) {
+    let file = fs::File::create(path).expect("create gzip fastq");
+    let mut encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+    for (name, seq, qual) in records {
+        writeln!(encoder, "@{name}\n{seq}\n+\n{qual}").expect("write fastq record");
+    }
+    encoder.finish().expect("finish gzip fastq");
+}
+
+/// Build a small paired gzip FASTQ (`r1.fq.gz`, `r2.fq.gz`) with a 4 bp UMI on
+/// R1 only (read structures `4M+T` / `+T`) — 2 families x 3 read pairs each.
+/// The R1 UMI for each family is one of the correct-step's own whitelist
+/// entries (`ACGT`, `TGCA`), so every extracted record is an exact match and
+/// the correct step keeps it (a mismatched/ambiguous UMI would be dropped,
+/// which would make a non-empty-output assertion meaningless). Returns
+/// `(r1_path, r2_path)`.
+fn write_tiny_umi_fastqs(dir: &Path) -> (PathBuf, PathBuf) {
+    let r1 = dir.join("r1.fq.gz");
+    let r2 = dir.join("r2.fq.gz");
+    // (r1 umi (4bp, matches the correct-step whitelist), r1 template (12bp),
+    // r2 template (12bp)).
+    let families =
+        [("ACGT", "ACGTACGTACGT", "GGTTAACCGGTT"), ("TGCA", "TGCATGCATGCA", "CCAATTGGCCAA")];
+    let r1_qual = "I".repeat(4 + 12); // 4 (UMI) + 12 (template)
+    let r2_qual = "I".repeat(12);
+    let mut r1_owned: Vec<(String, String)> = Vec::new();
+    let mut r2_owned: Vec<(String, String)> = Vec::new();
+    for (fi, (umi, r1_tmpl, r2_tmpl)) in families.iter().enumerate() {
+        for i in 0..3 {
+            let name = format!("fam{fi}_{i}");
+            r1_owned.push((name.clone(), format!("{umi}{r1_tmpl}"))); // 4 + 12 = 16
+            r2_owned.push((name, (*r2_tmpl).to_string())); // 12
+        }
+    }
+    let r1_slices: Vec<(&str, &str, &str)> =
+        r1_owned.iter().map(|(n, s)| (n.as_str(), s.as_str(), r1_qual.as_str())).collect();
+    let r2_slices: Vec<(&str, &str, &str)> =
+        r2_owned.iter().map(|(n, s)| (n.as_str(), s.as_str(), r2_qual.as_str())).collect();
+    write_gzip_fastq(&r1, &r1_slices);
+    write_gzip_fastq(&r2, &r2_slices);
+    (r1, r2)
+}
+
+/// Extract→Correct is the one `runall` transition that is unwired at the
+/// chain-builder level: `add_correct` used to unconditionally prepend a
+/// `GroupByQueryname` step (input `DecodedRecordBatch`) onto whatever tail
+/// preceded it. Extract's output tail is `BamTemplateBatch`, so feeding an
+/// extract-fed chain into correct was a type-erased runtime panic, not a
+/// build-time error. This builds `[Stage::Extract, Stage::Correct]` directly
+/// (bypassing the not-yet-existing `RunAll` command) and asserts it runs to
+/// completion and produces a non-empty corrected unmapped BAM.
+#[test]
+fn extract_to_correct_chain_builds_and_runs() {
+    let tmp = TempDir::new().unwrap();
+    let (r1, r2) = write_tiny_umi_fastqs(tmp.path());
+    let out = tmp.path().join("corrected.bam");
+
+    let extract = ExtractRunallOptions {
+        inputs: vec![r1.clone(), r2.clone()],
+        read_structures: vec!["4M+T".parse().unwrap(), "+T".parse().unwrap()],
+        sample: "s1".into(),
+        library: "lib1".into(),
+        ..ExtractRunallOptions::default()
+    };
+    let correct = CorrectOptions {
+        umis: vec!["ACGT".into(), "TGCA".into()], // 4 bp whitelist, not 2 bp
+        min_distance_diff: 1,
+        ..CorrectOptions::default()
+    };
+
+    let bag = StageOptionsBag {
+        extract: Some(extract.to_extract_options()),
+        correct: Some(correct),
+        ..Default::default()
+    };
+
+    let spec = ChainSpec {
+        stages: vec![Stage::Extract, Stage::Correct],
+        source: SourceSpec::fastqs(
+            vec![r1, r2],
+            vec!["4M+T".parse().unwrap(), "+T".parse().unwrap()],
+        )
+        .unwrap(),
+        sink: SinkSpec::Bam(out.clone()),
+        stage_opts: bag,
+        threading: ThreadingOptions { threads: None },
+        compression: CompressionOptions::default(),
+        scheduler: SchedulerOptions::default(),
+        queue_memory: QueueMemoryOptions::default(),
+        async_reader: false,
+        read_streams: fgumi_bam_io::ReadStreams::Fixed(1),
+        verify_crc: false,
+        command_line: "test".into(),
+    };
+
+    build_for(spec).expect("build").run().expect("run without panic");
+    assert!(fs::metadata(&out).unwrap().len() > 0, "corrected BAM is non-empty");
+}

--- a/tests/integration/test_runall_chain_transitions.rs
+++ b/tests/integration/test_runall_chain_transitions.rs
@@ -4,16 +4,71 @@
 use std::fs;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
+use fgumi_lib::aligner::AlignerOptions;
+use fgumi_lib::assigner::Strategy;
+#[cfg(feature = "consensus")]
+use fgumi_lib::commands::codec::CodecOptions;
 use fgumi_lib::commands::common::{
     CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
 };
 use fgumi_lib::commands::correct::CorrectOptions;
+#[cfg(feature = "consensus")]
+use fgumi_lib::commands::duplex::DuplexOptions;
 use fgumi_lib::commands::extract::ExtractRunallOptions;
+use fgumi_lib::commands::filter::FilterOptions;
+use fgumi_lib::commands::group::GroupOptions;
+#[cfg(feature = "consensus")]
+use fgumi_lib::commands::simplex::SimplexOptions;
+use fgumi_lib::commands::sort::SortOptions;
+use fgumi_lib::commands::zipper::ZipperOptions;
+use fgumi_lib::pipeline::chains::options_bag::AlignOptions;
+use fgumi_lib::pipeline::chains::validate::{
+    validate_cross_stage_constraints, validate_stage_opts_present, validate_stage_progression,
+};
 use fgumi_lib::pipeline::chains::{
     ChainSpec, SinkSpec, SourceSpec, Stage, StageOptionsBag, build_for,
 };
+use fgumi_lib::sam::SamTag;
+use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 use tempfile::TempDir;
+
+#[cfg(feature = "consensus")]
+use crate::helpers::bam_generator::create_grouped_family;
+use crate::helpers::bam_generator::{
+    create_minimal_header, create_test_reference, create_umi_family, create_umi_family_at_pos,
+    write_bam,
+};
+use crate::helpers::read_bam_output;
+
+/// Assembles a [`ChainSpec`] with the boilerplate fields every test below
+/// shares (threading/compression/scheduler/queue-memory defaults, a plain
+/// sequential reader, no CRC verification, a nominal `@PG` command line) —
+/// mirrors the tail of `extract_to_correct_chain_builds_and_runs`'s literal,
+/// factored out so each transition test only spells out what varies:
+/// `stages`, `source`, `sink`, and `stage_opts`.
+fn base_chain_spec(
+    stages: Vec<Stage>,
+    source: SourceSpec,
+    sink: SinkSpec,
+    stage_opts: StageOptionsBag,
+) -> ChainSpec {
+    ChainSpec {
+        stages,
+        source,
+        sink,
+        stage_opts,
+        threading: ThreadingOptions { threads: None },
+        compression: CompressionOptions::default(),
+        scheduler: SchedulerOptions::default(),
+        queue_memory: QueueMemoryOptions::default(),
+        async_reader: false,
+        read_streams: fgumi_bam_io::ReadStreams::Fixed(1),
+        verify_crc: false,
+        command_line: "test".into(),
+    }
+}
 
 /// Write a gzip-compressed FASTQ from `(name, seq, qual)` records.
 fn write_gzip_fastq(path: &Path, records: &[(&str, &str, &str)]) {
@@ -113,4 +168,630 @@ fn extract_to_correct_chain_builds_and_runs() {
 
     build_for(spec).expect("build").run().expect("run without panic");
     assert!(fs::metadata(&out).unwrap().len() > 0, "corrected BAM is non-empty");
+}
+
+// ─────────────────────────── Sort→Group, Group→consensus, Consensus→Filter ───────────────────────────
+
+/// `Sort→Group`: an unsorted, mapped, `RX`-tagged BAM (two UMI families at two
+/// distinct positions, so sort has real work to do) sorted to
+/// template-coordinate order and grouped by UMI adjacency.
+#[test]
+fn sort_to_group_chain_builds_and_runs() {
+    let tmp = TempDir::new().unwrap();
+    let header = create_minimal_header("chr1", 10000);
+    let mut records = Vec::new();
+    records.extend(create_umi_family_at_pos("ACGT", 3, "famA", "ACGTACGTACGT", 30, 500));
+    records.extend(create_umi_family_at_pos("TGCA", 3, "famB", "ACGTACGTACGT", 30, 100));
+    let input = tmp.path().join("unsorted.bam");
+    write_bam(&input, &header, &records);
+
+    let out = tmp.path().join("grouped.bam");
+    let sort = SortOptions::default(); // order defaults to TemplateCoordinate
+    let mut group = GroupOptions { strategy: Strategy::Adjacency, ..GroupOptions::default() };
+    let (s, e) = group.resolve_strategy_and_edits();
+    group.effective_strategy = s;
+    group.effective_edits = e;
+
+    let bag = StageOptionsBag { sort: Some(sort), group: Some(group), ..Default::default() };
+    let spec = base_chain_spec(
+        vec![Stage::Sort, Stage::Group],
+        SourceSpec::Bam(input),
+        SinkSpec::Bam(out.clone()),
+        bag,
+    );
+    build_for(spec).expect("build").run().expect("run");
+    let (_, records) = read_bam_output(&out);
+    assert!(!records.is_empty(), "grouped BAM should have records");
+}
+
+/// `Group→Simplex`: a mapped, `RX`-tagged single-UMI family, grouped by
+/// identity (exact-match UMI) directly into a simplex consensus call.
+#[cfg(feature = "consensus")]
+#[test]
+fn group_to_simplex_chain_builds_and_runs() {
+    let tmp = TempDir::new().unwrap();
+    let header = create_minimal_header("chr1", 10000);
+    let records = create_umi_family("ACGT", 3, "fam", "ACGTACGTACGT", 30);
+    let input = tmp.path().join("input.bam");
+    write_bam(&input, &header, &records);
+
+    let out = tmp.path().join("simplex.bam");
+    let mut group = GroupOptions { strategy: Strategy::Identity, ..GroupOptions::default() };
+    let (s, e) = group.resolve_strategy_and_edits();
+    group.effective_strategy = s;
+    group.effective_edits = e;
+    let simplex = SimplexOptions { min_reads: 1, ..SimplexOptions::default() };
+
+    let bag = StageOptionsBag { group: Some(group), simplex: Some(simplex), ..Default::default() };
+    let spec = base_chain_spec(
+        vec![Stage::Group, Stage::Simplex],
+        SourceSpec::Bam(input),
+        SinkSpec::Bam(out.clone()),
+        bag,
+    );
+    build_for(spec).expect("build").run().expect("run");
+    let (_, records) = read_bam_output(&out);
+    assert!(!records.is_empty(), "simplex output should have records");
+}
+
+/// One paired-UMI (`AAA-TTT`/`TTT-AAA`) read pair for one duplex strand,
+/// oriented FR (top strand, `is_b_strand = false`) or RF (bottom strand,
+/// `is_b_strand = true`) — the shape `Strategy::Paired` grouping expects so it
+/// can assign both strands of one molecule the same base id with `/A`/`/B`
+/// suffixes. Mirrors `helpers::bam_generator::create_duplex_grouped_family`'s
+/// shape but adds `MC` tags: `RecordPositionGrouper` (the position-based UMI
+/// grouper `Group` wires for paired-end input) requires them.
+fn duplex_strand_pair(
+    name: &str,
+    umi: &str,
+    sequence: &str,
+    quality: u8,
+    ref_start: i32,
+    is_b_strand: bool,
+) -> (RawRecord, RawRecord) {
+    let seq = sequence.as_bytes();
+    let read_len = seq.len();
+    let cigar_op = u32::try_from(read_len).expect("read_len fits u32") << 4;
+    let mate_cigar = format!("{read_len}M");
+    let span = i32::try_from(read_len + 100).expect("template span fits i32");
+
+    // B strand is the same molecule read the other way round: R1 reverse at
+    // the far position, R2 forward at the near one.
+    let (r1_start, r2_start, r1_rev, r2_rev) = if is_b_strand {
+        (ref_start + 100, ref_start, true, false)
+    } else {
+        (ref_start, ref_start + 100, false, true)
+    };
+    let tlen = if is_b_strand { -span } else { span };
+
+    let build = |first: bool| {
+        let (pos, mate_pos, rev, mate_rev) = if first {
+            (r1_start, r2_start, r1_rev, r2_rev)
+        } else {
+            (r2_start, r1_start, r2_rev, r1_rev)
+        };
+        let segment = if first { flags::FIRST_SEGMENT } else { flags::LAST_SEGMENT };
+        let mut b = SamBuilder::new();
+        b.read_name(name.as_bytes())
+            .sequence(seq)
+            .qualities(&vec![quality; read_len])
+            .flags(
+                flags::PAIRED
+                    | segment
+                    | if rev { flags::REVERSE } else { 0 }
+                    | if mate_rev { flags::MATE_REVERSE } else { 0 },
+            )
+            .ref_id(0)
+            .pos(pos - 1)
+            .mapq(60)
+            .cigar_ops(&[cigar_op])
+            .mate_ref_id(0)
+            .mate_pos(mate_pos - 1)
+            .template_length(if first { tlen } else { -tlen })
+            .add_string_tag(SamTag::RX, umi.as_bytes())
+            .add_string_tag(SamTag::MC, mate_cigar.as_bytes());
+        b.build()
+    };
+
+    (build(true), build(false))
+}
+
+/// `depth` read pairs on each of the two duplex strands of one molecule.
+fn create_duplex_umi_family(
+    depth: usize,
+    sequence: &str,
+    quality: u8,
+    ref_start: i32,
+) -> Vec<RawRecord> {
+    let mut records = Vec::with_capacity(depth * 4);
+    for (umi, is_b_strand) in [("AAA-TTT", false), ("TTT-AAA", true)] {
+        for i in 0..depth {
+            let (r1, r2) = duplex_strand_pair(
+                &format!("{umi}_{i}"),
+                umi,
+                sequence,
+                quality,
+                ref_start,
+                is_b_strand,
+            );
+            records.push(r1);
+            records.push(r2);
+        }
+    }
+    records
+}
+
+/// `Group→Duplex`: a paired-UMI (`AAA-TTT`/`TTT-AAA`) two-strand molecule,
+/// grouped with `Strategy::Paired` (the strategy duplex consensus requires —
+/// see `validate_cross_stage_constraints` Rule 2) directly into a duplex call.
+#[cfg(feature = "consensus")]
+#[test]
+fn group_to_duplex_chain_builds_and_runs() {
+    let tmp = TempDir::new().unwrap();
+    let header = create_minimal_header("chr1", 10000);
+    let records = create_duplex_umi_family(2, "ACGTACGTACGT", 30, 500);
+    let input = tmp.path().join("input.bam");
+    write_bam(&input, &header, &records);
+
+    let out = tmp.path().join("duplex.bam");
+    let mut group = GroupOptions { strategy: Strategy::Paired, ..GroupOptions::default() };
+    let (s, e) = group.resolve_strategy_and_edits();
+    group.effective_strategy = s;
+    group.effective_edits = e;
+    let duplex = DuplexOptions::default(); // min_reads = [1]
+
+    let bag = StageOptionsBag { group: Some(group), duplex: Some(duplex), ..Default::default() };
+    let spec = base_chain_spec(
+        vec![Stage::Group, Stage::Duplex],
+        SourceSpec::Bam(input),
+        SinkSpec::Bam(out.clone()),
+        bag,
+    );
+    build_for(spec).expect("build").run().expect("run");
+    let (_, records) = read_bam_output(&out);
+    assert!(!records.is_empty(), "duplex output should have records");
+}
+
+/// One CODEC-shaped read pair for `Group→Codec`: R1 forward, R2 reverse,
+/// fully overlapping at the same position (mirrors real CODEC sequencing,
+/// where R1/R2 read opposite strands of the same short fragment), sharing an
+/// `RX` UMI so the upstream `Group` stage — not a pre-set `MI` — assigns the
+/// molecule id.
+fn create_codec_umi_pair(
+    name: &str,
+    seq: &[u8],
+    qual: &[u8],
+    ref_start: i32,
+    umi: &str,
+) -> (RawRecord, RawRecord) {
+    let len = seq.len();
+    let cigar_op = u32::try_from(len).expect("len fits u32") << 4;
+    let template_length = i32::try_from(len).expect("len fits i32");
+    let mate_cigar = format!("{len}M");
+
+    let mut b1 = SamBuilder::new();
+    b1.read_name(name.as_bytes())
+        .sequence(seq)
+        .qualities(qual)
+        .cigar_ops(&[cigar_op])
+        .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+        .ref_id(0)
+        .pos(ref_start)
+        .mapq(60)
+        .mate_ref_id(0)
+        .mate_pos(ref_start)
+        .template_length(template_length)
+        .add_string_tag(SamTag::RX, umi.as_bytes())
+        .add_string_tag(SamTag::MC, mate_cigar.as_bytes());
+
+    let mut b2 = SamBuilder::new();
+    b2.read_name(name.as_bytes())
+        .sequence(seq)
+        .qualities(qual)
+        .cigar_ops(&[cigar_op])
+        .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+        .ref_id(0)
+        .pos(ref_start)
+        .mapq(60)
+        .mate_ref_id(0)
+        .mate_pos(ref_start)
+        .template_length(-template_length)
+        .add_string_tag(SamTag::RX, umi.as_bytes())
+        .add_string_tag(SamTag::MC, mate_cigar.as_bytes());
+
+    (b1.build(), b2.build())
+}
+
+/// `Group→Codec`: two overlapping CODEC-shaped read pairs sharing one `RX`
+/// UMI, grouped by identity into a single molecule and CODEC-consensus-called.
+#[cfg(feature = "consensus")]
+#[test]
+fn group_to_codec_chain_builds_and_runs() {
+    let tmp = TempDir::new().unwrap();
+    let header = create_minimal_header("chr1", 10000);
+    let mut records = Vec::new();
+    for i in 0..2 {
+        let (r1, r2) =
+            create_codec_umi_pair(&format!("pair{i}"), b"ACGTACGTAC", &[30; 10], 500, "ACGT");
+        records.push(r1);
+        records.push(r2);
+    }
+    let input = tmp.path().join("input.bam");
+    write_bam(&input, &header, &records);
+
+    let out = tmp.path().join("codec.bam");
+    let mut group = GroupOptions::default(); // Strategy::Identity, edits 0
+    let (s, e) = group.resolve_strategy_and_edits();
+    group.effective_strategy = s;
+    group.effective_edits = e;
+    let codec = CodecOptions::default(); // min_reads = 1, min_duplex_length = 1
+
+    let bag = StageOptionsBag { group: Some(group), codec: Some(codec), ..Default::default() };
+    let spec = base_chain_spec(
+        vec![Stage::Group, Stage::Codec],
+        SourceSpec::Bam(input),
+        SinkSpec::Bam(out.clone()),
+        bag,
+    );
+    build_for(spec).expect("build").run().expect("run");
+    let (_, records) = read_bam_output(&out);
+    assert!(!records.is_empty(), "codec output should have records");
+}
+
+/// `Consensus→Filter`: a simplex consensus call immediately followed by
+/// `Filter` in the same chain — the `runall consensus → filter` shape that
+/// `validate_stage_progression` special-cases (a consensus stage may be
+/// followed by exactly one trailing `Filter`).
+#[cfg(feature = "consensus")]
+#[test]
+fn simplex_to_filter_chain_builds_and_runs() {
+    let tmp = TempDir::new().unwrap();
+    let header = create_minimal_header("chr1", 10000);
+    let records = create_grouped_family("ACGT", "1", 3, "fam", "ACGTACGTACGT", 30);
+    let input = tmp.path().join("grouped.bam");
+    write_bam(&input, &header, &records);
+
+    let out = tmp.path().join("filtered.bam");
+    let simplex = SimplexOptions { min_reads: 1, ..SimplexOptions::default() };
+    let filter = FilterOptions { min_reads: vec![1], ..FilterOptions::default() };
+
+    let bag =
+        StageOptionsBag { simplex: Some(simplex), filter: Some(filter), ..Default::default() };
+    let spec = base_chain_spec(
+        vec![Stage::Simplex, Stage::Filter],
+        SourceSpec::Bam(input),
+        SinkSpec::Bam(out.clone()),
+        bag,
+    );
+    build_for(spec).expect("build").run().expect("run");
+    let (_, records) = read_bam_output(&out);
+    assert!(!records.is_empty(), "filtered output should have records");
+}
+
+// ─────────────────────────────────── Zipper→Sort ───────────────────────────────────
+
+/// Matched (unmapped, mapped, reference) triple for the zipper stage: an
+/// unmapped BAM with `RX`/`QX` tags and a mapped BAM with the same read
+/// names aligned to `chr1`, both in the same (queryname-matching) order.
+/// Mirrors `feat-runall`'s `test_runall_parity.rs::zipper_fixture`.
+struct ZipperFixture {
+    unmapped: PathBuf,
+    mapped: PathBuf,
+    reference: PathBuf,
+}
+
+fn zipper_fixture(dir: &Path) -> ZipperFixture {
+    let unmapped_path = dir.join("zipper_unmapped.bam");
+    let mapped_path = dir.join("zipper_mapped.bam");
+    let reference = create_test_reference(dir);
+
+    let names = ["read1", "read2", "read3", "read4"];
+
+    let unmapped_records: Vec<RawRecord> = names
+        .iter()
+        .enumerate()
+        .map(|(i, name)| {
+            let mut b = SamBuilder::new();
+            b.read_name(name.as_bytes())
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .flags(flags::UNMAPPED)
+                .add_string_tag(SamTag::RX, format!("AACC{i}").as_bytes())
+                .add_string_tag(SamTag::QX, b"IIIIIIII");
+            b.build()
+        })
+        .collect();
+    write_bam(&unmapped_path, &noodles::sam::Header::default(), &unmapped_records);
+
+    let mapped_header = create_minimal_header("chr1", 10000);
+    let mapped_records: Vec<RawRecord> = names
+        .iter()
+        .enumerate()
+        .map(|(i, name)| {
+            let mut b = SamBuilder::new();
+            b.read_name(name.as_bytes())
+                .ref_id(0)
+                .pos(i32::try_from(100 + 50 * i).unwrap_or(0))
+                .mapq(60)
+                .flags(0)
+                .cigar_ops(&[8u32 << 4])
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8]);
+            b.build()
+        })
+        .collect();
+    write_bam(&mapped_path, &mapped_header, &mapped_records);
+
+    ZipperFixture { mapped: mapped_path, unmapped: unmapped_path, reference }
+}
+
+/// `Zipper→Sort`: zipper merges the matched mapped+unmapped BAMs into
+/// `BamTemplateBatch`es and sort (template-coordinate, the default) consumes
+/// them directly — no aligner subprocess involved, so this runs live
+/// unconditionally.
+#[test]
+fn zipper_to_sort_chain_builds_and_runs() {
+    let tmp = TempDir::new().unwrap();
+    let inputs = zipper_fixture(tmp.path());
+
+    let out = tmp.path().join("sorted.bam");
+    let zipper = ZipperOptions::default();
+    let sort = SortOptions::default(); // order defaults to TemplateCoordinate
+
+    let bag = StageOptionsBag { zipper: Some(zipper), sort: Some(sort), ..Default::default() };
+    let spec = base_chain_spec(
+        vec![Stage::Zipper, Stage::Sort],
+        SourceSpec::PairedBams {
+            unmapped: inputs.unmapped,
+            mapped: inputs.mapped,
+            reference: inputs.reference,
+        },
+        SinkSpec::Bam(out.clone()),
+        bag,
+    );
+    build_for(spec).expect("build").run().expect("run");
+    let (_, records) = read_bam_output(&out);
+    assert!(!records.is_empty(), "sorted zipper output should have records");
+}
+
+// ─────────────────────────── Align-stage transitions ───────────────────────────
+//
+// `Stage::Align` spawns a real aligner subprocess. These tests are gated by
+// `which::which()` (mirroring `feat-runall`'s `run_aam_parity_test` guard):
+// when a `bwa-mem3`/`bwa` binary is on `PATH`, the chain is built AND run
+// end-to-end against a tiny real reference; otherwise the assembled
+// `ChainSpec` is validated instead (`validate_stage_progression` /
+// `validate_stage_opts_present` / `validate_cross_stage_constraints`), so the
+// transition's wiring is still exercised at the spec level everywhere.
+
+/// Returns the first real aligner binary found on `PATH` (`bwa-mem3`
+/// preferred, then classic `bwa`), or `None` if neither is installed.
+fn aligner_binary() -> Option<&'static str> {
+    ["bwa-mem3", "bwa"].into_iter().find(|bin| which::which(bin).is_ok())
+}
+
+/// Runs `<binary> index <reference>`, panicking on failure. Only called after
+/// the caller has confirmed `binary` is on `PATH` via [`aligner_binary`], so a
+/// failure here is a real setup regression, not a skip condition.
+fn build_aligner_index(reference: &Path, binary: &str) {
+    let status = Command::new(binary)
+        .args(["index", reference.to_str().expect("reference path is valid UTF-8")])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap_or_else(|e| panic!("failed to run `{binary} index`: {e}"));
+    assert!(status.success(), "`{binary} index` failed with status {status}");
+}
+
+/// Writes a single-end unmapped BAM: `n` reads, each carrying an `RX` UMI tag
+/// and a 12bp template sequence (`ACGTACGTACGT`) that is an exact substring of
+/// `create_test_reference`'s repeating `ACGTACGT` `chr1`, so a real aligner
+/// maps them (even at low MAPQ, given the repeat). Used as the Align-stage
+/// "unmapped BAM" source/tail below.
+fn write_unmapped_umi_bam(path: &Path, umi: &str, n: usize) {
+    let header = noodles::sam::Header::default();
+    let records: Vec<RawRecord> = (0..n)
+        .map(|i| {
+            let mut b = SamBuilder::new();
+            b.read_name(format!("read{i}").as_bytes())
+                .sequence(b"ACGTACGTACGT")
+                .qualities(&[30; 12])
+                .flags(flags::UNMAPPED)
+                .add_string_tag(SamTag::RX, umi.as_bytes());
+            b.build()
+        })
+        .collect();
+    write_bam(path, &header, &records);
+}
+
+/// Asserts the three chain-spec validators all accept `spec` — the
+/// no-aligner-available fallback for the `Stage::Align` transition tests.
+fn assert_chain_spec_validates(spec: &ChainSpec) {
+    validate_stage_progression(spec).expect("stage progression should validate");
+    validate_stage_opts_present(spec).expect("stage options should validate");
+    validate_cross_stage_constraints(spec).expect("cross-stage constraints should validate");
+}
+
+/// `Extract→Align`: a single-end FASTQ (`4M+T`) extracted to an unmapped BAM
+/// and fed directly into Align (`add_align` skips `GroupByQueryname` when the
+/// upstream tail is already `BamTemplateBatch`).
+#[test]
+fn extract_to_align_chain_builds_and_runs_or_validates() {
+    let tmp = TempDir::new().unwrap();
+    let r1 = tmp.path().join("r1.fq.gz");
+    // 4bp UMI ("ACGT") + 12bp template exactly matching the test reference.
+    write_gzip_fastq(&r1, &[("read0", "ACGTACGTACGTACGT", "IIIIIIIIIIIIIIII")]);
+
+    let extract = ExtractRunallOptions {
+        inputs: vec![r1.clone()],
+        read_structures: vec!["4M+T".parse().unwrap()],
+        sample: "s1".into(),
+        library: "lib1".into(),
+        ..ExtractRunallOptions::default()
+    };
+    let source =
+        SourceSpec::fastqs(vec![r1], vec!["4M+T".parse().unwrap()]).expect("valid fastq source");
+    let out = tmp.path().join("aligned.bam");
+
+    if let Some(bin) = aligner_binary() {
+        let reference = create_test_reference(tmp.path());
+        build_aligner_index(&reference, bin);
+        let align = AlignOptions {
+            aligner: AlignerOptions {
+                command: Some(format!("{bin} mem {{ref}} /dev/stdin")),
+                ..AlignerOptions::default()
+            },
+            reference,
+            aligner_bin: None,
+        };
+        let bag = StageOptionsBag {
+            extract: Some(extract.to_extract_options()),
+            aligner: Some(align),
+            ..Default::default()
+        };
+        let spec = base_chain_spec(
+            vec![Stage::Extract, Stage::Align],
+            source,
+            SinkSpec::Bam(out.clone()),
+            bag,
+        );
+        build_for(spec).expect("build").run().expect("run");
+        assert!(fs::metadata(&out).unwrap().len() > 0, "aligned BAM is non-empty");
+    } else {
+        eprintln!(
+            "no bwa/bwa-mem3 on PATH: validating the Extract→Align spec instead of running it"
+        );
+        let align = AlignOptions {
+            aligner: AlignerOptions {
+                command: Some("bwa mem {ref} /dev/stdin".into()),
+                ..AlignerOptions::default()
+            },
+            reference: tmp.path().join("ref.fa"), // need not exist for spec validation
+            aligner_bin: None,
+        };
+        let bag = StageOptionsBag {
+            extract: Some(extract.to_extract_options()),
+            aligner: Some(align),
+            ..Default::default()
+        };
+        let spec =
+            base_chain_spec(vec![Stage::Extract, Stage::Align], source, SinkSpec::Bam(out), bag);
+        assert_chain_spec_validates(&spec);
+    }
+}
+
+/// `Correct→Align`: an unmapped BAM with an exact-whitelist-match `RX` tag,
+/// corrected, then fed directly into Align (same `BamTemplateBatch` hand-off
+/// as `Extract→Align`).
+#[test]
+fn correct_to_align_chain_builds_and_runs_or_validates() {
+    let tmp = TempDir::new().unwrap();
+    let unmapped = tmp.path().join("unmapped.bam");
+    write_unmapped_umi_bam(&unmapped, "ACGT", 3);
+
+    let correct = CorrectOptions {
+        umis: vec!["ACGT".into(), "TGCA".into()], // 4bp whitelist, not 2bp
+        min_distance_diff: 1,
+        ..CorrectOptions::default()
+    };
+    let out = tmp.path().join("aligned.bam");
+
+    if let Some(bin) = aligner_binary() {
+        let reference = create_test_reference(tmp.path());
+        build_aligner_index(&reference, bin);
+        let align = AlignOptions {
+            aligner: AlignerOptions {
+                command: Some(format!("{bin} mem {{ref}} /dev/stdin")),
+                ..AlignerOptions::default()
+            },
+            reference,
+            aligner_bin: None,
+        };
+        let bag =
+            StageOptionsBag { correct: Some(correct), aligner: Some(align), ..Default::default() };
+        let spec = base_chain_spec(
+            vec![Stage::Correct, Stage::Align],
+            SourceSpec::Bam(unmapped),
+            SinkSpec::Bam(out.clone()),
+            bag,
+        );
+        build_for(spec).expect("build").run().expect("run");
+        assert!(fs::metadata(&out).unwrap().len() > 0, "aligned BAM is non-empty");
+    } else {
+        eprintln!(
+            "no bwa/bwa-mem3 on PATH: validating the Correct→Align spec instead of running it"
+        );
+        let align = AlignOptions {
+            aligner: AlignerOptions {
+                command: Some("bwa mem {ref} /dev/stdin".into()),
+                ..AlignerOptions::default()
+            },
+            reference: tmp.path().join("ref.fa"),
+            aligner_bin: None,
+        };
+        let bag =
+            StageOptionsBag { correct: Some(correct), aligner: Some(align), ..Default::default() };
+        let spec = base_chain_spec(
+            vec![Stage::Correct, Stage::Align],
+            SourceSpec::Bam(unmapped),
+            SinkSpec::Bam(out),
+            bag,
+        );
+        assert_chain_spec_validates(&spec);
+    }
+}
+
+/// `Align→Sort`: Align is the FIRST stage (reads straight from
+/// `SourceSpec::Bam`, prepending `GroupByQueryname` itself since the upstream
+/// tail is not yet `BamTemplateBatch`), and Sort consumes Align's
+/// `BamTemplateBatch` output directly.
+#[test]
+fn align_to_sort_chain_builds_and_runs_or_validates() {
+    let tmp = TempDir::new().unwrap();
+    let unmapped = tmp.path().join("unmapped.bam");
+    write_unmapped_umi_bam(&unmapped, "ACGT", 3);
+
+    let sort = SortOptions::default(); // order defaults to TemplateCoordinate
+    let out = tmp.path().join("sorted.bam");
+
+    if let Some(bin) = aligner_binary() {
+        let reference = create_test_reference(tmp.path());
+        build_aligner_index(&reference, bin);
+        let align = AlignOptions {
+            aligner: AlignerOptions {
+                command: Some(format!("{bin} mem {{ref}} /dev/stdin")),
+                ..AlignerOptions::default()
+            },
+            reference,
+            aligner_bin: None,
+        };
+        let bag = StageOptionsBag { aligner: Some(align), sort: Some(sort), ..Default::default() };
+        let spec = base_chain_spec(
+            vec![Stage::Align, Stage::Sort],
+            SourceSpec::Bam(unmapped),
+            SinkSpec::Bam(out.clone()),
+            bag,
+        );
+        build_for(spec).expect("build").run().expect("run");
+        let (_, records) = read_bam_output(&out);
+        assert!(!records.is_empty(), "sorted, aligned output should have records");
+    } else {
+        eprintln!("no bwa/bwa-mem3 on PATH: validating the Align→Sort spec instead of running it");
+        let align = AlignOptions {
+            aligner: AlignerOptions {
+                command: Some("bwa mem {ref} /dev/stdin".into()),
+                ..AlignerOptions::default()
+            },
+            reference: tmp.path().join("ref.fa"),
+            aligner_bin: None,
+        };
+        let bag = StageOptionsBag { aligner: Some(align), sort: Some(sort), ..Default::default() };
+        let spec = base_chain_spec(
+            vec![Stage::Align, Stage::Sort],
+            SourceSpec::Bam(unmapped),
+            SinkSpec::Bam(out),
+            bag,
+        );
+        assert_chain_spec_validates(&spec);
+    }
 }

--- a/tests/integration/test_runall_command.rs
+++ b/tests/integration/test_runall_command.rs
@@ -1,0 +1,1435 @@
+//! End-to-end CLI parity + error-path tests for `fgumi runall`.
+//!
+//! `runall` fuses a contiguous slice of the pipeline into one in-memory chain
+//! and is spawned here as the real, built `fgumi` binary (never in-process),
+//! so these tests exercise the actual CLI surface a user invokes: argument
+//! parsing, per-stage `--<stage>::<flag>` wiring, and the fused execution
+//! path, end to end.
+//!
+//! This is a representative subset of the parity coverage the design doc
+//! calls for, not a full port of the (now-obsolete) `feat-runall` branch's
+//! 4030-line `test_runall_parity.rs` — see
+//! `docs/superpowers/specs/2026-09-04-runall-pr-b-command-design.md` for the
+//! full contract. It covers:
+//!
+//! * **Class A** self-pairs (`runall --start-from X --stop-after X` vs
+//!   standalone `fgumi X`): `sort`, `group`, and (consensus-gated) `simplex`.
+//! * **Class B** compositions (`runall` vs a staged standalone chain piped
+//!   through intermediate temp BAMs): `sort→group`, and (consensus-gated)
+//!   `sort→simplex`, `group→simplex`, `group→simplex→filter`.
+//! * The extract-fusion path (aligner-gated) and the now-dropped
+//!   `extract→zipper` "incompatible" guard (spec §6 rule 3).
+//! * Determinism, stdin-once, `--help`, and the CLI-level error-path
+//!   messages the design doc pins verbatim.
+//!
+//! Every parity test asserts BOTH record-stream equivalence AND header
+//! equivalence ignoring `@PG` (a fused runall chain writes one `@PG`; the
+//! staged standalone chain writes one per command) — a header-only
+//! regression (dropped `@SQ`/`@RG`, wrong `@HD` `SO`/`GO`/`SS`) would be
+//! invisible to a records-only comparison.
+
+use std::ffi::OsStr;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+use tempfile::TempDir;
+
+use crate::helpers::bam_generator::{
+    create_minimal_header, create_test_reference, create_umi_family_at_pos, write_bam,
+};
+use crate::helpers::read_bam_output;
+
+// ─────────────────────────── process + assertion helpers ───────────────────────────
+
+/// Spawns the real, built `fgumi` binary with `args` and captures its output.
+///
+/// Every test in this file drives `runall` (and the standalone commands it is
+/// compared against) as a subprocess — never in-process — so these tests pin
+/// the actual CLI surface (argument parsing included), not just the library
+/// API underneath it.
+fn fgumi<I, S>(args: I) -> Output
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    Command::new(env!("CARGO_BIN_EXE_fgumi")).args(args).output().expect("failed to spawn fgumi")
+}
+
+/// Runs `fgumi` with `args`, panicking with `context` and the captured
+/// stderr if it exits non-zero.
+fn run_ok<I, S>(args: I, context: &str) -> Output
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let output = fgumi(args);
+    assert!(
+        output.status.success(),
+        "{context} failed (status {:?}): stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+/// Runs `fgumi` with `args` and asserts it exits non-zero with `needle`
+/// somewhere in stderr.
+fn assert_rejected_with<I, S>(args: I, needle: &str, context: &str)
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let output = fgumi(args);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "{context}: expected failure but the command succeeded");
+    assert!(
+        stderr.contains(needle),
+        "{context}: expected stderr to contain {needle:?}, got:\n{stderr}"
+    );
+}
+
+fn p(path: &Path) -> &str {
+    path.to_str().expect("test path is valid UTF-8")
+}
+
+/// Record-stream equivalence: both BAMs are non-empty and their decoded
+/// record streams are identical.
+///
+/// Standalone-command `@PG` provenance is irrelevant to records, so no
+/// normalization is needed here (unlike the header comparison below).
+fn assert_bams_record_equivalent_nonempty(a: &Path, b: &Path) {
+    let (_, records_a) = read_bam_output(a);
+    let (_, records_b) = read_bam_output(b);
+    assert!(!records_a.is_empty(), "{} produced no records", a.display());
+    assert_eq!(
+        records_a,
+        records_b,
+        "record streams differ between {} and {}",
+        a.display(),
+        b.display()
+    );
+}
+
+/// Header equivalence ignoring `@PG` provenance (and `@HD` `VN` / `@CO`,
+/// which this deliberately does not inspect): compares `@HD` `SO`/`GO`/`SS`,
+/// the `@SQ` dictionary, and `@RG` records.
+///
+/// A fused `runall` chain writes a single `@PG` record while the equivalent
+/// staged standalone-command chain writes one per command (with different
+/// `ID`/`PN`/`CL` values), so a full-header `==` would fail even when the
+/// stage output is otherwise identical — hence the dedicated comparison
+/// here rather than reusing `crate::helpers::read_bam_output`'s header
+/// (which only normalizes `@PG` `CL`, not the `@PG` record count/identity).
+fn assert_bam_headers_equivalent_ignoring_pg(a: &Path, b: &Path) {
+    use noodles::sam::header::record::value::map::header::tag::{
+        GROUP_ORDER, SORT_ORDER, SUBSORT_ORDER,
+    };
+
+    fn read_header(path: &Path) -> noodles::sam::Header {
+        let mut reader = noodles::bam::io::Reader::new(std::io::BufReader::new(
+            std::fs::File::open(path).expect("open BAM for header comparison"),
+        ));
+        reader.read_header().expect("read BAM header")
+    }
+
+    type SortFields = (Option<Vec<u8>>, Option<Vec<u8>>, Option<Vec<u8>>);
+
+    fn sort_fields(header: &noodles::sam::Header) -> SortFields {
+        let Some(hd) = header.header() else { return (None, None, None) };
+        let other = hd.other_fields();
+        (
+            other.get(&SORT_ORDER).map(|v| v.to_vec()),
+            other.get(&GROUP_ORDER).map(|v| v.to_vec()),
+            other.get(&SUBSORT_ORDER).map(|v| v.to_vec()),
+        )
+    }
+
+    let header_a = read_header(a);
+    let header_b = read_header(b);
+
+    assert_eq!(
+        sort_fields(&header_a),
+        sort_fields(&header_b),
+        "@HD SO/GO/SS differ between {} and {}",
+        a.display(),
+        b.display()
+    );
+    assert_eq!(
+        header_a.reference_sequences(),
+        header_b.reference_sequences(),
+        "@SQ differs between {} and {}",
+        a.display(),
+        b.display()
+    );
+    assert_eq!(
+        header_a.read_groups(),
+        header_b.read_groups(),
+        "@RG differs between {} and {}",
+        a.display(),
+        b.display()
+    );
+}
+
+// ─────────────────────────────────── fixtures ───────────────────────────────────
+
+/// A small mapped, UMI-tagged BAM with three families at distinct positions,
+/// deliberately written out of template-coordinate order so `sort` has real
+/// work to do.
+fn unsorted_bam(dir: &Path) -> PathBuf {
+    let header = create_minimal_header("chr1", 10_000);
+    let mut records = Vec::new();
+    records.extend(create_umi_family_at_pos("ACGT", 3, "fam_a", "ACGTACGTACGT", 30, 800));
+    records.extend(create_umi_family_at_pos("TGCA", 3, "fam_b", "TGCATGCATGCA", 30, 200));
+    records.extend(create_umi_family_at_pos("GGCC", 3, "fam_c", "GGCCGGCCGGCC", 30, 500));
+    let path = dir.join("unsorted.bam");
+    write_bam(&path, &header, &records);
+    path
+}
+
+/// [`unsorted_bam`] piped through a real `fgumi sort` to seed tests that
+/// need an already-sorted (template-coordinate) input.
+fn sorted_bam(dir: &Path) -> PathBuf {
+    let unsorted = unsorted_bam(dir);
+    let sorted = dir.join("sorted.bam");
+    run_ok(["sort", "-i", p(&unsorted), "-o", p(&sorted)], "fixture setup: fgumi sort");
+    sorted
+}
+
+/// [`sorted_bam`] piped through a real `fgumi group` (`--edits 0`, given
+/// `strategy`) to seed tests that need an already-grouped (MI-tagged) input.
+fn grouped_bam(dir: &Path, strategy: &str, tag: &str) -> PathBuf {
+    let sorted = sorted_bam(dir);
+    let grouped = dir.join(format!("grouped_{tag}.bam"));
+    run_ok(
+        ["group", "-i", p(&sorted), "-o", p(&grouped), "--strategy", strategy, "--edits", "0"],
+        "fixture setup: fgumi group",
+    );
+    grouped
+}
+
+/// Writes a gzip-compressed FASTQ from `(name, seq, qual)` triples.
+fn write_gzip_fastq(path: &Path, records: &[(&str, &str, &str)]) {
+    let file = std::fs::File::create(path).expect("create gzip fastq");
+    let mut encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+    for (name, seq, qual) in records {
+        writeln!(encoder, "@{name}\n{seq}\n+\n{qual}").expect("write fastq record");
+    }
+    encoder.finish().expect("finish gzip fastq");
+}
+
+/// Returns the first real aligner binary found on `PATH` (`bwa-mem3`
+/// preferred, then classic `bwa`), or `None` if neither is installed.
+///
+/// Mirrors the guard `test_runall_chain_transitions.rs` uses for the
+/// chain-builder-level Align-stage tests: align-bearing CLI tests here run
+/// end-to-end only when a real aligner is available, and are skipped (with an
+/// `eprintln!`) otherwise — never failed.
+fn aligner_binary() -> Option<&'static str> {
+    ["bwa-mem3", "bwa"].into_iter().find(|bin| which::which(bin).is_ok())
+}
+
+/// Deterministic pseudo-random ACGT sequence (xorshift64), long enough that a
+/// short substring is very unlikely to recur elsewhere in it.
+///
+/// `create_test_reference`'s `ACGTACGT`-repeat sequence is periodic (period
+/// 8), so any substring drawn from it realigns ambiguously everywhere and
+/// gets MAPQ 0 — which `group`'s MAPQ filter (default `--min-map-q 1`) then
+/// rejects. A test that needs its aligned reads to actually survive `group`
+/// (not just `align`) needs a non-repetitive reference instead.
+fn pseudo_random_sequence(n: usize, seed: u64) -> String {
+    let bases = [b'A', b'C', b'G', b'T'];
+    let mut state = seed | 1;
+    (0..n)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            bases[usize::try_from(state % 4).expect("state % 4 fits usize")] as char
+        })
+        .collect()
+}
+
+/// Writes a FASTA + `.fai` + `.dict` for a `len`-bp single-contig (`chr1`)
+/// reference built from [`pseudo_random_sequence`], returning the FASTA path
+/// and the sequence itself (so callers can slice out a substring to use as a
+/// read that maps uniquely, unlike a substring of `create_test_reference`'s
+/// periodic sequence).
+fn write_unique_reference(dir: &Path, len: usize) -> (PathBuf, String) {
+    let sequence = pseudo_random_sequence(len, 0x5eed_1234_5678_9abc);
+    let ref_path = dir.join("unique_ref.fa");
+    let mut fasta = std::fs::File::create(&ref_path).expect("create unique reference fasta");
+    writeln!(fasta, ">chr1").expect("write fasta header");
+    writeln!(fasta, "{sequence}").expect("write fasta sequence");
+    drop(fasta);
+
+    std::fs::write(dir.join("unique_ref.fa.fai"), format!("chr1\t{len}\t6\t{len}\t{}\n", len + 1))
+        .expect("write fai");
+
+    let mut dict = std::fs::File::create(dir.join("unique_ref.dict")).expect("create dict");
+    writeln!(dict, "@HD\tVN:1.6\tSO:unsorted").expect("write dict @HD");
+    writeln!(dict, "@SQ\tSN:chr1\tLN:{len}").expect("write dict @SQ");
+
+    (ref_path, sequence)
+}
+
+/// Runs `<binary> index <reference>`, panicking on failure. Only called after
+/// [`aligner_binary`] has confirmed `binary` is on `PATH`.
+fn build_aligner_index(reference: &Path, binary: &str) {
+    let status = Command::new(binary)
+        .args(["index", p(reference)])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap_or_else(|e| panic!("failed to run `{binary} index`: {e}"));
+    assert!(status.success(), "`{binary} index` failed with status {status}");
+}
+
+fn reverse_complement(seq: &str) -> String {
+    seq.chars()
+        .rev()
+        .map(|c| match c {
+            'A' => 'T',
+            'C' => 'G',
+            'G' => 'C',
+            'T' => 'A',
+            other => other,
+        })
+        .collect()
+}
+
+/// Writes a paired gzip FASTQ pair encoding `molecules.len()` duplex
+/// molecules, each with BOTH strands present, over a `write_unique_reference`
+/// `sequence`.
+///
+/// For molecule `(p, r1_umi, r2_umi)`: strand A is a plain FR pair — R1 is
+/// the forward-strand `TEMPLATE_LEN`-bp anchor at `p` (paired UMI
+/// `r1_umi-r2_umi`), R2 is the anchor `SPAN` bp downstream, written as its
+/// reverse complement (so it aligns REVERSE there, standard paired-end FASTQ
+/// convention: the raw FASTQ read is the reverse complement of whatever the
+/// BAM's reference-forward-oriented `SEQ` field ends up holding). Strand B is
+/// the SAME molecule sequenced from the other end: its R1 is the reverse
+/// complement of the downstream anchor (so it aligns REVERSE there, at the
+/// position strand A's R2 occupied) and its R2 is the upstream anchor as-is
+/// (so it aligns FORWARD at strand A's R1 position), with the UMI order
+/// swapped (`r2_umi-r1_umi`). `--group::strategy paired` canonicalizes the
+/// swapped UMI order and matching swapped orientation into one molecule with
+/// `/A` and `/B` reads, matching the convention
+/// `bam_generator::create_duplex_grouped_family`'s `strand_reads` helper uses
+/// for pre-tagged fixtures — this builds the FASTQ-level equivalent from
+/// scratch so a real `extract` + aligner run derives the same shape.
+fn write_duplex_umi_fastq(
+    dir: &Path,
+    sequence: &str,
+    molecules: &[(usize, &str, &str)],
+) -> (PathBuf, PathBuf) {
+    const TEMPLATE_LEN: usize = 36;
+    const SPAN: usize = 150;
+    const DEPTH: usize = 2;
+
+    let r1 = dir.join("duplex_r1.fq.gz");
+    let r2 = dir.join("duplex_r2.fq.gz");
+    let qual = "I".repeat(4 + TEMPLATE_LEN);
+    let mut r1_records: Vec<(String, String)> = Vec::new();
+    let mut r2_records: Vec<(String, String)> = Vec::new();
+
+    for (mi, &(p, r1_umi, r2_umi)) in molecules.iter().enumerate() {
+        let anchor_near = &sequence[p..p + TEMPLATE_LEN];
+        let anchor_far = &sequence[p + SPAN..p + SPAN + TEMPLATE_LEN];
+        let anchor_far_rc = reverse_complement(anchor_far);
+
+        for i in 0..DEPTH {
+            // Strand A: R1 forward at the near anchor, R2 at the far anchor.
+            r1_records.push((format!("mol{mi}_A_{i}"), format!("{r1_umi}{anchor_near}")));
+            r2_records.push((format!("mol{mi}_A_{i}"), format!("{r2_umi}{anchor_far_rc}")));
+
+            // Strand B: the same molecule read from the other end, UMI order
+            // swapped, positions/orientations swapped.
+            r1_records.push((format!("mol{mi}_B_{i}"), format!("{r2_umi}{anchor_far_rc}")));
+            r2_records.push((format!("mol{mi}_B_{i}"), format!("{r1_umi}{anchor_near}")));
+        }
+    }
+
+    let r1_slices: Vec<(&str, &str, &str)> =
+        r1_records.iter().map(|(n, s)| (n.as_str(), s.as_str(), qual.as_str())).collect();
+    let r2_slices: Vec<(&str, &str, &str)> =
+        r2_records.iter().map(|(n, s)| (n.as_str(), s.as_str(), qual.as_str())).collect();
+    write_gzip_fastq(&r1, &r1_slices);
+    write_gzip_fastq(&r2, &r2_slices);
+    (r1, r2)
+}
+
+/// Converts a paired-end unmapped BAM into an interleaved FASTQ byte stream
+/// (R1, R2, R1, R2, ...), suitable for `bwa mem -p <ref> -`.
+///
+/// This is the staged oracle's hand-rolled stand-in for what `runall`'s fused
+/// `Stage::Align` does internally (stream `BamTemplateBatch` records to the
+/// aligner subprocess as FASTQ) — there is no standalone `fgumi align`
+/// command, so a staged comparison has to reconstruct this step itself
+/// rather than delegate to one.
+fn bam_to_interleaved_fastq(bam_path: &Path) -> Vec<u8> {
+    let mut reader = noodles::bam::io::Reader::new(std::io::BufReader::new(
+        std::fs::File::open(bam_path).expect("open BAM for FASTQ conversion"),
+    ));
+    let header = reader.read_header().expect("read BAM header");
+    let mut out = Vec::new();
+    for result in reader.record_bufs(&header) {
+        let record = result.expect("read BAM record");
+        let name = record.name().map(|n| n.to_vec()).unwrap_or_default();
+        let seq = record.sequence().as_ref().to_vec();
+        let quals: Vec<u8> = record.quality_scores().as_ref().iter().map(|q| q + 33).collect();
+        out.extend_from_slice(b"@");
+        out.extend_from_slice(&name);
+        out.push(b'\n');
+        out.extend_from_slice(&seq);
+        out.extend_from_slice(b"\n+\n");
+        out.extend_from_slice(&quals);
+        out.push(b'\n');
+    }
+    out
+}
+
+// ══════════════════════════ Class A: single-stage self-pairs ══════════════════════════
+
+#[test]
+fn sort_self_pair_matches_standalone_sort() {
+    let tmp = TempDir::new().unwrap();
+    let fixture = unsorted_bam(tmp.path());
+    let runall_out = tmp.path().join("runall.bam");
+    let staged_out = tmp.path().join("staged.bam");
+
+    run_ok(
+        [
+            "runall",
+            "--start-from",
+            "sort",
+            "--stop-after",
+            "sort",
+            "-i",
+            p(&fixture),
+            "-o",
+            p(&runall_out),
+        ],
+        "runall sort->sort",
+    );
+    run_ok(["sort", "-i", p(&fixture), "-o", p(&staged_out)], "standalone sort");
+
+    assert_bams_record_equivalent_nonempty(&runall_out, &staged_out);
+    assert_bam_headers_equivalent_ignoring_pg(&runall_out, &staged_out);
+}
+
+#[test]
+fn group_self_pair_matches_standalone_group() {
+    let tmp = TempDir::new().unwrap();
+    let fixture = sorted_bam(tmp.path());
+    let runall_out = tmp.path().join("runall.bam");
+    let staged_out = tmp.path().join("staged.bam");
+
+    run_ok(
+        [
+            "runall",
+            "--start-from",
+            "group",
+            "--stop-after",
+            "group",
+            "-i",
+            p(&fixture),
+            "-o",
+            p(&runall_out),
+            "--group::strategy",
+            "identity",
+            "--group::edits",
+            "0",
+        ],
+        "runall group->group",
+    );
+    run_ok(
+        [
+            "group",
+            "-i",
+            p(&fixture),
+            "-o",
+            p(&staged_out),
+            "--strategy",
+            "identity",
+            "--edits",
+            "0",
+        ],
+        "standalone group",
+    );
+
+    assert_bams_record_equivalent_nonempty(&runall_out, &staged_out);
+    assert_bam_headers_equivalent_ignoring_pg(&runall_out, &staged_out);
+}
+
+#[cfg(feature = "consensus")]
+#[test]
+fn simplex_self_pair_matches_standalone_simplex() {
+    let tmp = TempDir::new().unwrap();
+    let fixture = grouped_bam(tmp.path(), "identity", "simplex_self");
+    let runall_out = tmp.path().join("runall.bam");
+    let staged_out = tmp.path().join("staged.bam");
+
+    run_ok(
+        [
+            "runall",
+            "--start-from",
+            "consensus",
+            "--stop-after",
+            "consensus",
+            "--consensus",
+            "simplex",
+            "-i",
+            p(&fixture),
+            "-o",
+            p(&runall_out),
+            "--simplex::min-reads",
+            "1",
+        ],
+        "runall consensus(simplex)->consensus(simplex)",
+    );
+    run_ok(
+        ["simplex", "-i", p(&fixture), "-o", p(&staged_out), "--min-reads", "1"],
+        "standalone simplex",
+    );
+
+    assert_bams_record_equivalent_nonempty(&runall_out, &staged_out);
+    assert_bam_headers_equivalent_ignoring_pg(&runall_out, &staged_out);
+}
+
+// ══════════════════════════ Class B: multi-stage compositions ══════════════════════════
+
+#[test]
+fn sort_to_group_matches_staged_chain() {
+    let tmp = TempDir::new().unwrap();
+    let fixture = unsorted_bam(tmp.path());
+    let runall_out = tmp.path().join("runall.bam");
+    let staged_sorted = tmp.path().join("staged_sorted.bam");
+    let staged_out = tmp.path().join("staged.bam");
+
+    run_ok(
+        [
+            "runall",
+            "--start-from",
+            "sort",
+            "--stop-after",
+            "group",
+            "-i",
+            p(&fixture),
+            "-o",
+            p(&runall_out),
+            "--group::strategy",
+            "identity",
+            "--group::edits",
+            "0",
+        ],
+        "runall sort->group",
+    );
+
+    run_ok(["sort", "-i", p(&fixture), "-o", p(&staged_sorted)], "staged sort");
+    run_ok(
+        [
+            "group",
+            "-i",
+            p(&staged_sorted),
+            "-o",
+            p(&staged_out),
+            "--strategy",
+            "identity",
+            "--edits",
+            "0",
+        ],
+        "staged group",
+    );
+
+    assert_bams_record_equivalent_nonempty(&runall_out, &staged_out);
+    assert_bam_headers_equivalent_ignoring_pg(&runall_out, &staged_out);
+}
+
+#[cfg(feature = "consensus")]
+#[test]
+fn sort_to_simplex_matches_staged_chain() {
+    let tmp = TempDir::new().unwrap();
+    let fixture = unsorted_bam(tmp.path());
+    let runall_out = tmp.path().join("runall.bam");
+    let staged_sorted = tmp.path().join("staged_sorted.bam");
+    let staged_grouped = tmp.path().join("staged_grouped.bam");
+    let staged_out = tmp.path().join("staged.bam");
+
+    run_ok(
+        [
+            "runall",
+            "--start-from",
+            "sort",
+            "--stop-after",
+            "consensus",
+            "--consensus",
+            "simplex",
+            "-i",
+            p(&fixture),
+            "-o",
+            p(&runall_out),
+            "--group::strategy",
+            "identity",
+            "--group::edits",
+            "0",
+            "--simplex::min-reads",
+            "1",
+        ],
+        "runall sort->simplex",
+    );
+
+    run_ok(["sort", "-i", p(&fixture), "-o", p(&staged_sorted)], "staged sort");
+    run_ok(
+        [
+            "group",
+            "-i",
+            p(&staged_sorted),
+            "-o",
+            p(&staged_grouped),
+            "--strategy",
+            "identity",
+            "--edits",
+            "0",
+        ],
+        "staged group",
+    );
+    run_ok(
+        ["simplex", "-i", p(&staged_grouped), "-o", p(&staged_out), "--min-reads", "1"],
+        "staged simplex",
+    );
+
+    assert_bams_record_equivalent_nonempty(&runall_out, &staged_out);
+    assert_bam_headers_equivalent_ignoring_pg(&runall_out, &staged_out);
+}
+
+// `codec` requires FR-overlapping paired-end fragments (each duplex molecule's
+// two strands must overlap) — the single-end UMI-family fixtures used
+// elsewhere in this file don't satisfy that, so `--consensus simplex` covers
+// the "group -> consensus (one mode)" and "group -> consensus -> filter (one
+// mode)" compositions instead. `simplex_self_pair_matches_standalone_simplex`
+// above already covers the Class A self-pair; codec's own CLI wiring is still
+// exercised by `rejects_codec_with_methylation_mode` below.
+
+#[cfg(feature = "consensus")]
+#[test]
+fn group_to_simplex_matches_staged_chain() {
+    let tmp = TempDir::new().unwrap();
+    let fixture = sorted_bam(tmp.path());
+    let runall_out = tmp.path().join("runall.bam");
+    let staged_grouped = tmp.path().join("staged_grouped.bam");
+    let staged_out = tmp.path().join("staged.bam");
+
+    run_ok(
+        [
+            "runall",
+            "--start-from",
+            "group",
+            "--stop-after",
+            "consensus",
+            "--consensus",
+            "simplex",
+            "-i",
+            p(&fixture),
+            "-o",
+            p(&runall_out),
+            "--group::strategy",
+            "identity",
+            "--group::edits",
+            "0",
+            "--simplex::min-reads",
+            "1",
+        ],
+        "runall group->simplex",
+    );
+
+    run_ok(
+        [
+            "group",
+            "-i",
+            p(&fixture),
+            "-o",
+            p(&staged_grouped),
+            "--strategy",
+            "identity",
+            "--edits",
+            "0",
+        ],
+        "staged group",
+    );
+    run_ok(
+        ["simplex", "-i", p(&staged_grouped), "-o", p(&staged_out), "--min-reads", "1"],
+        "staged simplex",
+    );
+
+    assert_bams_record_equivalent_nonempty(&runall_out, &staged_out);
+    assert_bam_headers_equivalent_ignoring_pg(&runall_out, &staged_out);
+}
+
+#[cfg(feature = "consensus")]
+#[test]
+fn group_to_simplex_to_filter_matches_staged_chain() {
+    let tmp = TempDir::new().unwrap();
+    let fixture = sorted_bam(tmp.path());
+    let runall_out = tmp.path().join("runall.bam");
+    let staged_grouped = tmp.path().join("staged_grouped.bam");
+    let staged_simplex = tmp.path().join("staged_simplex.bam");
+    let staged_out = tmp.path().join("staged.bam");
+
+    run_ok(
+        [
+            "runall",
+            "--start-from",
+            "group",
+            "--stop-after",
+            "filter",
+            "--consensus",
+            "simplex",
+            "-i",
+            p(&fixture),
+            "-o",
+            p(&runall_out),
+            "--group::strategy",
+            "identity",
+            "--group::edits",
+            "0",
+            "--simplex::min-reads",
+            "1",
+            "--filter::min-reads",
+            "1",
+        ],
+        "runall group->simplex->filter",
+    );
+
+    run_ok(
+        [
+            "group",
+            "-i",
+            p(&fixture),
+            "-o",
+            p(&staged_grouped),
+            "--strategy",
+            "identity",
+            "--edits",
+            "0",
+        ],
+        "staged group",
+    );
+    run_ok(
+        ["simplex", "-i", p(&staged_grouped), "-o", p(&staged_simplex), "--min-reads", "1"],
+        "staged simplex",
+    );
+    run_ok(
+        ["filter", "-i", p(&staged_simplex), "-o", p(&staged_out), "--min-reads", "1"],
+        "staged filter",
+    );
+
+    assert_bams_record_equivalent_nonempty(&runall_out, &staged_out);
+    assert_bam_headers_equivalent_ignoring_pg(&runall_out, &staged_out);
+}
+
+// ══════════════════════════ Extract fusion + the dropped guard ══════════════════════════
+
+/// `extract→zipper` used to be rejected outright ("incompatible: zipper
+/// requires `PairedBams`, but extract produces `Fastqs`"). Spec §6 dropped that
+/// rule (extract now feeds Align, which is included whenever the chain
+/// reaches past `Correct`, so `extract→zipper` builds `[Extract, Align]` and
+/// is a normal align-bearing chain). This test pins the guard's absence
+/// regardless of whether a real aligner is on `PATH`: with one, the chain
+/// runs to completion; without one, it still gets past argument validation
+/// and fails later for an unrelated reason (the aligner subprocess not being
+/// spawnable) — the assertion that matters either way is that "incompatible"
+/// never appears.
+#[test]
+fn extract_to_zipper_guard_is_dropped() {
+    let tmp = TempDir::new().unwrap();
+    let r1 = tmp.path().join("r1.fq.gz");
+    write_gzip_fastq(&r1, &[("read0", "ACGTACGTACGTACGT", "IIIIIIIIIIIIIIII")]);
+    let out = tmp.path().join("out.bam");
+    let reference = create_test_reference(tmp.path());
+
+    let (aligner_cmd, have_real_aligner) = if let Some(bin) = aligner_binary() {
+        build_aligner_index(&reference, bin);
+        (format!("{bin} mem {{ref}} /dev/stdin"), true)
+    } else {
+        eprintln!(
+            "no bwa/bwa-mem3 on PATH: only checking the dropped guard's absence, not running \
+             extract->zipper end to end"
+        );
+        ("definitely-not-a-real-fgumi-test-aligner mem {ref} /dev/stdin".to_string(), false)
+    };
+
+    let output = fgumi([
+        "runall",
+        "--start-from",
+        "extract",
+        "--stop-after",
+        "zipper",
+        "--extract::inputs",
+        p(&r1),
+        "--extract::read-structures",
+        "4M+T",
+        "--extract::sample",
+        "s1",
+        "--extract::library",
+        "lib1",
+        "--ref",
+        p(&reference),
+        "--aligner::command",
+        &aligner_cmd,
+        "-o",
+        p(&out),
+    ]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("incompatible"),
+        "extract->zipper must not be rejected by the removed incompatibility guard: {stderr}"
+    );
+
+    if have_real_aligner {
+        assert!(
+            output.status.success(),
+            "extract->zipper should run to completion when a real aligner is available: {stderr}"
+        );
+        assert!(
+            std::fs::metadata(&out).map(|m| m.len() > 0).unwrap_or(false),
+            "expected a non-empty output BAM"
+        );
+    } else {
+        // With the bogus aligner, extract->zipper must still reach the Align
+        // stage and fail *there* -- running the non-existent aligner command --
+        // rather than pass on an unrelated validation error. Pin that failure
+        // boundary: a non-success status plus the bogus aligner's name surfaced
+        // from the retained subprocess stderr. Without this, the only assertion
+        // on the no-aligner path is the absence of "incompatible", which a
+        // spurious earlier error would also satisfy.
+        assert!(
+            !output.status.success(),
+            "extract->zipper with a bogus aligner must fail at the Align stage, not succeed: {stderr}"
+        );
+        assert!(
+            stderr.contains("definitely-not-a-real-fgumi-test-aligner"),
+            "expected the bogus aligner's name in the retained stderr, proving the Align stage ran \
+             it (not a spurious earlier failure): {stderr}"
+        );
+    }
+}
+
+/// `extract→group` (no UMI): FASTQ in, through the fused `Align` stage (real
+/// aligner subprocess + zipper-merge), `Sort`, and `Group` (`--no-umi`), all
+/// in one `runall` invocation. Gated on a real aligner being on `PATH`.
+///
+/// There is no standalone `align` command to build an external staged
+/// oracle from (that fusion — aligner subprocess + zipper-merge — is exactly
+/// what `Stage::Align` exists to elide), so unlike the Class A/B parity
+/// tests above this checks end-to-end success and header/record sanity
+/// rather than byte-for-byte parity against a staged chain.
+#[test]
+fn extract_to_group_no_umi_runs_end_to_end() {
+    let Some(bin) = aligner_binary() else {
+        eprintln!("no bwa/bwa-mem3 on PATH: skipping extract->group (no-UMI) fusion test");
+        return;
+    };
+    let tmp = TempDir::new().unwrap();
+    let (reference, sequence) = write_unique_reference(tmp.path(), 2000);
+    build_aligner_index(&reference, bin);
+    let r1 = tmp.path().join("r1.fq.gz");
+    // A 40bp substring of a 2000bp non-repetitive reference maps uniquely
+    // (high MAPQ), unlike a substring of `create_test_reference`'s periodic
+    // sequence — see `pseudo_random_sequence`'s doc comment. All three reads
+    // share the same 40bp window, so they land in one position group.
+    let read = &sequence[500..540];
+    let qual = "I".repeat(read.len());
+    write_gzip_fastq(
+        &r1,
+        &[("read0", read, &qual), ("read1", read, &qual), ("read2", read, &qual)],
+    );
+    let out = tmp.path().join("out.bam");
+    let aligner_cmd = format!("{bin} mem {{ref}} /dev/stdin");
+
+    run_ok(
+        [
+            "runall",
+            "--start-from",
+            "extract",
+            "--stop-after",
+            "group",
+            "--extract::inputs",
+            p(&r1),
+            "--extract::read-structures",
+            "+T",
+            "--extract::sample",
+            "s1",
+            "--extract::library",
+            "lib1",
+            "--ref",
+            p(&reference),
+            "--aligner::command",
+            &aligner_cmd,
+            "--group::strategy",
+            "identity",
+            "--group::no-umi",
+            "true",
+            "-o",
+            p(&out),
+        ],
+        "runall extract(no-umi)->group fused pipeline",
+    );
+
+    let (header, records) = read_bam_output(&out);
+    // The fixture is fully determined: three single-end reads share one 40bp
+    // window, so all three survive the fused chain and land in one position
+    // group. Assert the exact count and the MI tag Group is responsible for
+    // adding, not just non-emptiness.
+    assert_eq!(
+        records.len(),
+        3,
+        "all three input reads should survive the fused extract->group chain"
+    );
+    assert!(header.header().is_some(), "expected an @HD line in the fused output header");
+    let mi_tag = fgumi_lib::sam::SamTag::MI.to_noodles_tag();
+    for record in &records {
+        assert!(
+            record.data().get(&mi_tag).is_some(),
+            "group must assign an MI tag to every emitted record"
+        );
+    }
+}
+
+/// `extract→duplex` (with `--correct::umis`, splicing `Correct` between
+/// `Extract` and `Align`): the other extract-fusion path the design doc
+/// calls for, alongside `extract→group` above. Unlike `extract→group`, this
+/// needs a genuinely duplex-shaped input — both strands of each molecule
+/// present — for `--group::strategy paired` to assign `/A`/`/B` reads and
+/// for `duplex` to have real two-strand input to consensus-call, which
+/// [`write_duplex_umi_fastq`] builds. Aligner-gated like `extract→group`.
+///
+/// Unlike the other Class B/extract-fusion tests, the staged oracle here is
+/// built from EVERY individual stage as its own `fgumi` subprocess —
+/// `extract | correct | <real aligner> | zipper | sort | group | duplex` —
+/// because the brief specifically asks for that fully-staged comparison.
+/// There is no standalone `fgumi align` command (that fusion is exactly what
+/// `Stage::Align` exists to elide), so the "align" step here is a raw
+/// `bwa`/`bwa-mem3` subprocess reading [`bam_to_interleaved_fastq`]'s output,
+/// piped straight into `fgumi zipper`.
+#[cfg(feature = "consensus")]
+#[test]
+fn runall_extract_to_duplex_fusion_matches_staged() {
+    let Some(bin) = aligner_binary() else {
+        eprintln!("no bwa/bwa-mem3 on PATH: skipping extract->duplex fusion test");
+        return;
+    };
+    let tmp = TempDir::new().unwrap();
+    let (reference, sequence) = write_unique_reference(tmp.path(), 4000);
+    build_aligner_index(&reference, bin);
+
+    // Two duplex molecules (both strands present for each), 2 read-pairs per
+    // strand, at well-separated offsets in the 4000bp reference so neither
+    // molecule's anchors overlap the other's.
+    let molecules = [(500usize, "AAAA", "CCCC"), (2000usize, "GGGG", "TTTT")];
+    let (r1, r2) = write_duplex_umi_fastq(tmp.path(), &sequence, &molecules);
+    // `-p`: the fused Align stage interleaves paired-end reads into one
+    // stdin stream, so the aligner command must tell bwa to treat that
+    // stream as paired (interleaved) rather than single-end — unlike the
+    // single-end `extract_to_group_no_umi_runs_end_to_end` /
+    // `extract_to_zipper_guard_is_dropped` tests, which never hit this
+    // because they only ever feed one FASTQ file.
+    let aligner_cmd = format!("{bin} mem -p {{ref}} /dev/stdin");
+
+    // ── Fused: runall --start-from extract --stop-after consensus --consensus duplex. ──
+    let runall_out = tmp.path().join("runall.bam");
+    run_ok(
+        [
+            "runall",
+            "--start-from",
+            "extract",
+            "--stop-after",
+            "consensus",
+            "--consensus",
+            "duplex",
+            "--extract::inputs",
+            p(&r1),
+            p(&r2),
+            "--extract::read-structures",
+            "4M+T",
+            "4M+T",
+            "--extract::sample",
+            "s1",
+            "--extract::library",
+            "lib1",
+            "--correct::umis",
+            "AAAA",
+            "--correct::umis",
+            "CCCC",
+            "--correct::umis",
+            "GGGG",
+            "--correct::umis",
+            "TTTT",
+            "--correct::min-distance",
+            "1",
+            "--ref",
+            p(&reference),
+            "--aligner::command",
+            &aligner_cmd,
+            "--group::strategy",
+            "paired",
+            "--group::edits",
+            "0",
+            "-o",
+            p(&runall_out),
+        ],
+        "runall extract->duplex fusion",
+    );
+
+    let staged_out = run_staged_extract_to_duplex(tmp.path(), &r1, &r2, &reference, bin);
+
+    assert_bams_record_equivalent_nonempty(&runall_out, &staged_out);
+    assert_bam_headers_equivalent_ignoring_pg(&runall_out, &staged_out);
+}
+
+/// The fully-staged oracle for [`runall_extract_to_duplex_fusion_matches_staged`]:
+/// `extract | correct | <real aligner> | zipper | sort | group | duplex`, each
+/// its own `fgumi` subprocess (or, for the aligner step, a raw `bwa`/`bwa-mem3`
+/// subprocess — there is no standalone `fgumi align` command). Returns the
+/// final duplex-consensus BAM's path.
+fn run_staged_extract_to_duplex(
+    dir: &Path,
+    r1: &Path,
+    r2: &Path,
+    reference: &Path,
+    aligner_bin: &str,
+) -> PathBuf {
+    let extracted = dir.join("staged_extracted.bam");
+    run_ok(
+        [
+            "extract",
+            "--inputs",
+            p(r1),
+            p(r2),
+            "--read-structures",
+            "4M+T",
+            "4M+T",
+            "--sample",
+            "s1",
+            "--library",
+            "lib1",
+            "-o",
+            p(&extracted),
+        ],
+        "staged extract",
+    );
+
+    let corrected = dir.join("staged_corrected.bam");
+    run_ok(
+        [
+            "correct",
+            "-i",
+            p(&extracted),
+            "-o",
+            p(&corrected),
+            "--umis",
+            "AAAA",
+            "--umis",
+            "CCCC",
+            "--umis",
+            "GGGG",
+            "--umis",
+            "TTTT",
+            "--min-distance",
+            "1",
+        ],
+        "staged correct",
+    );
+
+    let interleaved = bam_to_interleaved_fastq(&corrected);
+    let mut aligner = Command::new(aligner_bin)
+        .args(["mem", "-p", p(reference), "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn staged aligner");
+    aligner
+        .stdin
+        .take()
+        .expect("aligner stdin was piped")
+        .write_all(&interleaved)
+        .expect("write interleaved FASTQ to aligner stdin");
+    let aligner_output = aligner.wait_with_output().expect("wait on staged aligner");
+    assert!(aligner_output.status.success(), "staged aligner run failed");
+    let mapped_sam = dir.join("staged_mapped.sam");
+    std::fs::write(&mapped_sam, &aligner_output.stdout).expect("write staged mapped SAM");
+
+    let zipped = dir.join("staged_zipped.bam");
+    run_ok(
+        [
+            "zipper",
+            "-i",
+            p(&mapped_sam),
+            "-u",
+            p(&corrected),
+            "--reference",
+            p(reference),
+            "-o",
+            p(&zipped),
+        ],
+        "staged zipper",
+    );
+
+    let staged_sorted = dir.join("staged_sorted.bam");
+    run_ok(["sort", "-i", p(&zipped), "-o", p(&staged_sorted)], "staged sort");
+
+    let staged_grouped = dir.join("staged_grouped.bam");
+    run_ok(
+        [
+            "group",
+            "-i",
+            p(&staged_sorted),
+            "-o",
+            p(&staged_grouped),
+            "--strategy",
+            "paired",
+            "--edits",
+            "0",
+        ],
+        "staged group",
+    );
+
+    let staged_out = dir.join("staged.bam");
+    run_ok(["duplex", "-i", p(&staged_grouped), "-o", p(&staged_out)], "staged duplex");
+    staged_out
+}
+
+// ══════════════════════════════════ determinism ══════════════════════════════════
+
+#[cfg(feature = "consensus")]
+#[test]
+fn runall_record_stream_is_deterministic() {
+    let tmp = TempDir::new().unwrap();
+    let fixture = sorted_bam(tmp.path());
+    let out1 = tmp.path().join("run1.bam");
+    let out2 = tmp.path().join("run2.bam");
+
+    for out in [&out1, &out2] {
+        run_ok(
+            [
+                "runall",
+                "--start-from",
+                "group",
+                "--stop-after",
+                "consensus",
+                "--consensus",
+                "simplex",
+                "-i",
+                p(&fixture),
+                "-o",
+                p(out),
+                "--group::strategy",
+                "identity",
+                "--group::edits",
+                "0",
+                "--simplex::min-reads",
+                "1",
+            ],
+            "runall determinism run",
+        );
+    }
+
+    let (_, records1) = read_bam_output(&out1);
+    let (_, records2) = read_bam_output(&out2);
+    assert!(!records1.is_empty(), "determinism fixture produced no records");
+    assert_eq!(
+        records1, records2,
+        "runall's record stream is not deterministic across repeated runs"
+    );
+}
+
+// ══════════════════════════════════ stdin-once ══════════════════════════════════
+
+/// `--input -` must be consumed exactly once: a double-read (or a read that
+/// starts partway through) would corrupt the BGZF stream and either fail
+/// outright or silently drop/duplicate records, which would show up here as
+/// a record-stream mismatch against the equivalent file-input run.
+#[test]
+fn runall_reads_bam_from_stdin_once() {
+    let tmp = TempDir::new().unwrap();
+    let fixture = unsorted_bam(tmp.path());
+    let file_out = tmp.path().join("from_file.bam");
+    let stdin_out = tmp.path().join("from_stdin.bam");
+
+    run_ok(
+        [
+            "runall",
+            "--start-from",
+            "sort",
+            "--stop-after",
+            "sort",
+            "-i",
+            p(&fixture),
+            "-o",
+            p(&file_out),
+        ],
+        "runall via file input",
+    );
+
+    let mut cat = Command::new("cat")
+        .arg(&fixture)
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn cat");
+    let cat_stdout = cat.stdout.take().expect("cat stdout was piped");
+    let status = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .args([
+            "runall",
+            "--start-from",
+            "sort",
+            "--stop-after",
+            "sort",
+            "-i",
+            "-",
+            "-o",
+            p(&stdin_out),
+        ])
+        .stdin(Stdio::from(cat_stdout))
+        .status()
+        .expect("failed to spawn runall with piped stdin");
+    let _ = cat.wait();
+    assert!(status.success(), "runall via stdin failed");
+
+    assert_bams_record_equivalent_nonempty(&file_out, &stdin_out);
+}
+
+// ══════════════════════════════════ --help smoke ══════════════════════════════════
+
+#[test]
+fn help_lists_key_flags() {
+    let output = fgumi(["runall", "--help"]);
+    assert!(output.status.success(), "`fgumi runall --help` should exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for needle in ["--start-from", "--stop-after", "--sort::max-memory", "--group::strategy"] {
+        assert!(stdout.contains(needle), "`runall --help` output is missing {needle:?}:\n{stdout}");
+    }
+}
+
+// ══════════════════════════════════ error paths ══════════════════════════════════
+
+#[test]
+fn rejects_backwards_group_to_sort() {
+    assert_rejected_with(
+        [
+            "runall",
+            "--start-from",
+            "group",
+            "--stop-after",
+            "sort",
+            "-i",
+            "nonexistent-input.bam",
+            "-o",
+            "out.bam",
+        ],
+        "comes after --stop-after sort",
+        "backwards group->sort",
+    );
+}
+
+/// `--stop-after align` is rejected at the clap parse layer (it is not a
+/// [`StopAfter`] value), before any runtime validation runs.
+#[test]
+fn rejects_stop_after_align_at_clap_level() {
+    let output = fgumi([
+        "runall",
+        "--start-from",
+        "align",
+        "--stop-after",
+        "align",
+        "-i",
+        "x",
+        "-o",
+        "out.bam",
+    ]);
+    assert!(!output.status.success(), "clap should reject --stop-after align");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid value 'align'"),
+        "expected clap's invalid-value error for --stop-after align, got:\n{stderr}"
+    );
+    // Pin the rejected argument: `--start-from align` is itself valid (it maps to
+    // `RunAllStage::AlignAndMerge`, clap name "align"), so the invalid-value error
+    // must name `--stop-after` -- otherwise the test could pass on a rejection of
+    // the wrong argument.
+    assert!(
+        stderr.contains("--stop-after"),
+        "the invalid-value error must name --stop-after (not --start-from, which accepts 'align'), \
+         got:\n{stderr}"
+    );
+}
+
+#[test]
+fn rejects_zipper_without_unmapped() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("mapped.bam");
+    write_bam(&input, &create_minimal_header("chr1", 1000), &[]);
+
+    assert_rejected_with(
+        [
+            "runall",
+            "--start-from",
+            "zipper",
+            "--stop-after",
+            "zipper",
+            "-i",
+            p(&input),
+            "-o",
+            "out.bam",
+        ],
+        "--unmapped is required with --start-from zipper",
+        "zipper without --unmapped",
+    );
+}
+
+#[test]
+fn rejects_extract_to_correct_without_umi_source() {
+    assert_rejected_with(
+        ["runall", "--start-from", "extract", "--stop-after", "correct", "-o", "out.bam"],
+        "--correct::umi-files or --correct::umis",
+        "extract->correct without a UMI source",
+    );
+}
+
+#[cfg(feature = "consensus")]
+#[test]
+fn rejects_codec_with_methylation_mode() {
+    let tmp = TempDir::new().unwrap();
+    let input = tmp.path().join("in.bam");
+    write_bam(&input, &create_minimal_header("chr1", 1000), &[]);
+
+    assert_rejected_with(
+        [
+            "runall",
+            "--start-from",
+            "group",
+            "--stop-after",
+            "consensus",
+            "--consensus",
+            "codec",
+            "--methylation-mode",
+            "em-seq",
+            "-i",
+            p(&input),
+            "-o",
+            "out.bam",
+            "--group::strategy",
+            "identity",
+        ],
+        "not supported with codec consensus",
+        "codec + --methylation-mode",
+    );
+}
+
+#[cfg(feature = "consensus")]
+#[test]
+fn rejects_duplex_without_paired_strategy() {
+    assert_rejected_with(
+        [
+            "runall",
+            "--start-from",
+            "group",
+            "--stop-after",
+            "consensus",
+            "--consensus",
+            "duplex",
+            "-i",
+            "nonexistent-input.bam",
+            "-o",
+            "out.bam",
+            "--group::strategy",
+            "identity",
+            "--duplex::min-reads",
+            "1",
+        ],
+        "--consensus duplex requires --strategy paired",
+        "duplex without --strategy paired",
+    );
+}
+
+#[test]
+fn rejects_ref_without_methylation_mode_on_non_align_chain() {
+    assert_rejected_with(
+        [
+            "runall",
+            "--start-from",
+            "sort",
+            "--stop-after",
+            "sort",
+            "-i",
+            "nonexistent-input.bam",
+            "-o",
+            "out.bam",
+            "--ref",
+            "/nonexistent/ref.fa",
+        ],
+        "--ref requires --methylation-mode to be set",
+        "--ref without --methylation-mode on a non-align chain",
+    );
+}
+
+/// Bonus coverage beyond the required error-path list: `correct→sort`
+/// always chains through the align stage (a corrected unmapped BAM has no
+/// query-coordinate BAM to sort directly), so it hits the align-stage
+/// `--ref` guard rather than the generic "`--ref` requires
+/// `--methylation-mode`" one above.
+#[test]
+fn rejects_correct_to_sort_without_ref() {
+    assert_rejected_with(
+        [
+            "runall",
+            "--start-from",
+            "correct",
+            "--stop-after",
+            "sort",
+            "-i",
+            "nonexistent-input.bam",
+            "-o",
+            "out.bam",
+            "--correct::umis",
+            "ACGT",
+            "--correct::min-distance",
+            "1",
+        ],
+        "a runall chain that includes align requires --ref",
+        "correct->sort without --ref",
+    );
+}
+
+/// Pins the deliberate, documented absence of `--simplex::allow-unmapped`
+/// (spec §12.2 option (b) — see the design doc): `runall` does not expose
+/// it, so clap rejects it as an unknown argument rather than silently
+/// accepting and ignoring it.
+#[cfg(feature = "consensus")]
+#[test]
+fn simplex_allow_unmapped_is_not_exposed() {
+    let output = fgumi([
+        "runall",
+        "--start-from",
+        "group",
+        "--stop-after",
+        "consensus",
+        "--consensus",
+        "simplex",
+        "--simplex::allow-unmapped",
+        "-i",
+        "nonexistent-input.bam",
+        "-o",
+        "out.bam",
+        "--group::strategy",
+        "identity",
+        "--simplex::min-reads",
+        "1",
+    ]);
+    assert!(!output.status.success(), "--simplex::allow-unmapped should be rejected by clap");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unexpected argument"),
+        "expected clap to reject --simplex::allow-unmapped as unknown, got:\n{stderr}"
+    );
+}

--- a/tests/integration/test_runall_command.rs
+++ b/tests/integration/test_runall_command.rs
@@ -39,6 +39,7 @@ use crate::helpers::bam_generator::{
     create_minimal_header, create_test_reference, create_umi_family_at_pos, write_bam,
 };
 use crate::helpers::read_bam_output;
+use crate::helpers::{aligner_binary, build_aligner_index, write_gzip_fastq};
 
 // ─────────────────────────── process + assertion helpers ───────────────────────────
 
@@ -208,27 +209,6 @@ fn grouped_bam(dir: &Path, strategy: &str, tag: &str) -> PathBuf {
     grouped
 }
 
-/// Writes a gzip-compressed FASTQ from `(name, seq, qual)` triples.
-fn write_gzip_fastq(path: &Path, records: &[(&str, &str, &str)]) {
-    let file = std::fs::File::create(path).expect("create gzip fastq");
-    let mut encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
-    for (name, seq, qual) in records {
-        writeln!(encoder, "@{name}\n{seq}\n+\n{qual}").expect("write fastq record");
-    }
-    encoder.finish().expect("finish gzip fastq");
-}
-
-/// Returns the first real aligner binary found on `PATH` (`bwa-mem3`
-/// preferred, then classic `bwa`), or `None` if neither is installed.
-///
-/// Mirrors the guard `test_runall_chain_transitions.rs` uses for the
-/// chain-builder-level Align-stage tests: align-bearing CLI tests here run
-/// end-to-end only when a real aligner is available, and are skipped (with an
-/// `eprintln!`) otherwise — never failed.
-fn aligner_binary() -> Option<&'static str> {
-    ["bwa-mem3", "bwa"].into_iter().find(|bin| which::which(bin).is_ok())
-}
-
 /// Deterministic pseudo-random ACGT sequence (xorshift64), long enough that a
 /// short substring is very unlikely to recur elsewhere in it.
 ///
@@ -273,31 +253,6 @@ fn write_unique_reference(dir: &Path, len: usize) -> (PathBuf, String) {
     (ref_path, sequence)
 }
 
-/// Runs `<binary> index <reference>`, panicking on failure. Only called after
-/// [`aligner_binary`] has confirmed `binary` is on `PATH`.
-fn build_aligner_index(reference: &Path, binary: &str) {
-    let status = Command::new(binary)
-        .args(["index", p(reference)])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .unwrap_or_else(|e| panic!("failed to run `{binary} index`: {e}"));
-    assert!(status.success(), "`{binary} index` failed with status {status}");
-}
-
-fn reverse_complement(seq: &str) -> String {
-    seq.chars()
-        .rev()
-        .map(|c| match c {
-            'A' => 'T',
-            'C' => 'G',
-            'G' => 'C',
-            'T' => 'A',
-            other => other,
-        })
-        .collect()
-}
-
 /// Writes a paired gzip FASTQ pair encoding `molecules.len()` duplex
 /// molecules, each with BOTH strands present, over a `write_unique_reference`
 /// `sequence`.
@@ -336,7 +291,7 @@ fn write_duplex_umi_fastq(
     for (mi, &(p, r1_umi, r2_umi)) in molecules.iter().enumerate() {
         let anchor_near = &sequence[p..p + TEMPLATE_LEN];
         let anchor_far = &sequence[p + SPAN..p + SPAN + TEMPLATE_LEN];
-        let anchor_far_rc = reverse_complement(anchor_far);
+        let anchor_far_rc = fgumi_dna::reverse_complement_str(anchor_far);
 
         for i in 0..DEPTH {
             // Strand A: R1 forward at the near anchor, R2 at the far anchor.
@@ -497,6 +452,67 @@ fn simplex_self_pair_matches_standalone_simplex() {
     assert_bam_headers_equivalent_ignoring_pg(&runall_out, &staged_out);
 }
 
+/// Spec §7: `--methylation-mode` (+ `--ref`) must actually reach the consensus
+/// stage's `#[arg(skip)]` `methylation_mode`/`reference` slots (wired via
+/// `resolve_methylation_mode`/`consensus_reference` in
+/// `build_stage_options_bag`), not just be accepted and silently dropped.
+/// Compares the fused `consensus(simplex)` self-pair against the standalone
+/// `fgumi simplex --methylation-mode em-seq --ref ...` oracle — record parity
+/// between the two proves the flags were threaded through identically,
+/// alongside `simplex_self_pair_matches_standalone_simplex` above proving the
+/// non-methylation self-pair.
+#[cfg(feature = "consensus")]
+#[test]
+fn simplex_self_pair_with_methylation_mode_matches_standalone() {
+    let tmp = TempDir::new().unwrap();
+    let fixture = grouped_bam(tmp.path(), "identity", "simplex_methylation");
+    let reference = create_test_reference(tmp.path());
+    let runall_out = tmp.path().join("runall.bam");
+    let staged_out = tmp.path().join("staged.bam");
+
+    run_ok(
+        [
+            "runall",
+            "--start-from",
+            "consensus",
+            "--stop-after",
+            "consensus",
+            "--consensus",
+            "simplex",
+            "-i",
+            p(&fixture),
+            "-o",
+            p(&runall_out),
+            "--simplex::min-reads",
+            "1",
+            "--methylation-mode",
+            "em-seq",
+            "--ref",
+            p(&reference),
+        ],
+        "runall consensus(simplex)+methylation-mode",
+    );
+    run_ok(
+        [
+            "simplex",
+            "-i",
+            p(&fixture),
+            "-o",
+            p(&staged_out),
+            "--min-reads",
+            "1",
+            "--methylation-mode",
+            "em-seq",
+            "--ref",
+            p(&reference),
+        ],
+        "standalone simplex+methylation-mode",
+    );
+
+    assert_bams_record_equivalent_nonempty(&runall_out, &staged_out);
+    assert_bam_headers_equivalent_ignoring_pg(&runall_out, &staged_out);
+}
+
 // ══════════════════════════ Class B: multi-stage compositions ══════════════════════════
 
 #[test]
@@ -603,13 +619,136 @@ fn sort_to_simplex_matches_staged_chain() {
     assert_bam_headers_equivalent_ignoring_pg(&runall_out, &staged_out);
 }
 
-// `codec` requires FR-overlapping paired-end fragments (each duplex molecule's
-// two strands must overlap) — the single-end UMI-family fixtures used
+// `codec` requires FR-overlapping paired-end fragments (each molecule's R1/R2
+// overlap at the same position) — the single-end UMI-family fixtures used
 // elsewhere in this file don't satisfy that, so `--consensus simplex` covers
 // the "group -> consensus (one mode)" and "group -> consensus -> filter (one
-// mode)" compositions instead. `simplex_self_pair_matches_standalone_simplex`
-// above already covers the Class A self-pair; codec's own CLI wiring is still
-// exercised by `rejects_codec_with_methylation_mode` below.
+// mode)" compositions below via those fixtures instead.
+// `group_to_codec_matches_staged_chain` below gives codec its own dedicated
+// FR-overlapping fixture and record/header parity test; codec's numeric-bounds
+// CLI wiring is additionally exercised by `rejects_codec_with_methylation_mode`.
+
+/// One CODEC-shaped read pair: R1 forward, R2 reverse, fully overlapping at
+/// the same position (mirrors real CODEC sequencing, where R1/R2 read
+/// opposite strands of the same short fragment), sharing an `RX` UMI so the
+/// `Group` stage — not a pre-set `MI` — assigns the molecule id. Mirrors
+/// `test_runall_chain_transitions.rs`'s `create_codec_umi_pair` (this file's
+/// own copy: the two integration-test binaries share fixtures only through
+/// the `helpers` module, and this one is specific to the CLI-parity shape
+/// here).
+fn create_codec_umi_pair(
+    name: &str,
+    seq: &[u8],
+    qual: &[u8],
+    ref_start: i32,
+    umi: &str,
+) -> (fgumi_raw_bam::RawRecord, fgumi_raw_bam::RawRecord) {
+    use fgumi_lib::sam::SamTag;
+    use fgumi_raw_bam::{SamBuilder, flags};
+
+    let len = seq.len();
+    let cigar_op = u32::try_from(len).expect("len fits u32") << 4;
+    let template_length = i32::try_from(len).expect("len fits i32");
+    let mate_cigar = format!("{len}M");
+
+    let mut b1 = SamBuilder::new();
+    b1.read_name(name.as_bytes())
+        .sequence(seq)
+        .qualities(qual)
+        .cigar_ops(&[cigar_op])
+        .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+        .ref_id(0)
+        .pos(ref_start)
+        .mapq(60)
+        .mate_ref_id(0)
+        .mate_pos(ref_start)
+        .template_length(template_length)
+        .add_string_tag(SamTag::RX, umi.as_bytes())
+        .add_string_tag(SamTag::MC, mate_cigar.as_bytes());
+
+    let mut b2 = SamBuilder::new();
+    b2.read_name(name.as_bytes())
+        .sequence(seq)
+        .qualities(qual)
+        .cigar_ops(&[cigar_op])
+        .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+        .ref_id(0)
+        .pos(ref_start)
+        .mapq(60)
+        .mate_ref_id(0)
+        .mate_pos(ref_start)
+        .template_length(-template_length)
+        .add_string_tag(SamTag::RX, umi.as_bytes())
+        .add_string_tag(SamTag::MC, mate_cigar.as_bytes());
+
+    (b1.build(), b2.build())
+}
+
+/// `Group→Codec` record/header parity: two overlapping CODEC-shaped read
+/// pairs sharing one `RX` UMI, grouped by identity, consensus-called by
+/// `runall --consensus codec` and compared against the staged standalone
+/// `fgumi group | fgumi codec` chain. codec (like simplex) requires a
+/// non-`Paired` group strategy (`validate_strategy_for_mode`), hence
+/// `--strategy identity` here rather than `paired`.
+#[cfg(feature = "consensus")]
+#[test]
+fn group_to_codec_matches_staged_chain() {
+    let tmp = TempDir::new().unwrap();
+    let header = create_minimal_header("chr1", 10_000);
+    let mut records = Vec::new();
+    for i in 0..2 {
+        let (r1, r2) =
+            create_codec_umi_pair(&format!("pair{i}"), b"ACGTACGTAC", &[30; 10], 500, "ACGT");
+        records.push(r1);
+        records.push(r2);
+    }
+    let input = tmp.path().join("codec_input.bam");
+    write_bam(&input, &header, &records);
+
+    let runall_out = tmp.path().join("runall.bam");
+    let staged_grouped = tmp.path().join("staged_grouped.bam");
+    let staged_out = tmp.path().join("staged.bam");
+
+    run_ok(
+        [
+            "runall",
+            "--start-from",
+            "group",
+            "--stop-after",
+            "consensus",
+            "--consensus",
+            "codec",
+            "-i",
+            p(&input),
+            "-o",
+            p(&runall_out),
+            "--group::strategy",
+            "identity",
+            "--group::edits",
+            "0",
+        ],
+        "runall group->codec",
+    );
+
+    run_ok(
+        [
+            "group",
+            "-i",
+            p(&input),
+            "-o",
+            p(&staged_grouped),
+            "--strategy",
+            "identity",
+            "--edits",
+            "0",
+        ],
+        "staged group",
+    );
+    run_ok(["codec", "-i", p(&staged_grouped), "-o", p(&staged_out)], "staged codec");
+
+    assert_bams_record_equivalent_nonempty(&runall_out, &staged_out);
+    assert_bam_headers_equivalent_ignoring_pg(&runall_out, &staged_out);
+}
 
 #[cfg(feature = "consensus")]
 #[test]
@@ -722,6 +861,316 @@ fn group_to_simplex_to_filter_matches_staged_chain() {
     run_ok(
         ["filter", "-i", p(&staged_simplex), "-o", p(&staged_out), "--min-reads", "1"],
         "staged filter",
+    );
+
+    assert_bams_record_equivalent_nonempty(&runall_out, &staged_out);
+    assert_bam_headers_equivalent_ignoring_pg(&runall_out, &staged_out);
+}
+
+// ══════════════════════════ Extract→Correct (no aligner) ══════════════════════════
+
+/// A small paired gzip FASTQ pair (`r1.fq.gz`, `r2.fq.gz`) with a 4 bp UMI on
+/// R1 only (read structures `4M+T` / `+T`) — 2 UMI families x 3 read pairs
+/// each. Both R1 UMIs (`ACGT`, `TGCA`) are exact entries in the correct
+/// step's own whitelist, so every extracted record is an exact match and
+/// `correct` keeps it (no UMI rejects), which is what makes the plain
+/// (non-`--rejects`) parity case below meaningful. Returns `(r1_path,
+/// r2_path)`.
+fn write_extract_correct_fastqs(dir: &Path) -> (PathBuf, PathBuf) {
+    let r1 = dir.join("ec_r1.fq.gz");
+    let r2 = dir.join("ec_r2.fq.gz");
+    let families =
+        [("ACGT", "ACGTACGTACGT", "GGTTAACCGGTT"), ("TGCA", "TGCATGCATGCA", "CCAATTGGCCAA")];
+    let r1_qual = "I".repeat(4 + 12);
+    let r2_qual = "I".repeat(12);
+    let mut r1_records: Vec<(String, String)> = Vec::new();
+    let mut r2_records: Vec<(String, String)> = Vec::new();
+    for (fi, (umi, r1_tmpl, r2_tmpl)) in families.iter().enumerate() {
+        for i in 0..3 {
+            let name = format!("fam{fi}_{i}");
+            r1_records.push((name.clone(), format!("{umi}{r1_tmpl}")));
+            r2_records.push((name, (*r2_tmpl).to_string()));
+        }
+    }
+    let r1_slices: Vec<(&str, &str, &str)> =
+        r1_records.iter().map(|(n, s)| (n.as_str(), s.as_str(), r1_qual.as_str())).collect();
+    let r2_slices: Vec<(&str, &str, &str)> =
+        r2_records.iter().map(|(n, s)| (n.as_str(), s.as_str(), r2_qual.as_str())).collect();
+    write_gzip_fastq(&r1, &r1_slices);
+    write_gzip_fastq(&r2, &r2_slices);
+    (r1, r2)
+}
+
+/// `runall --start-from extract --stop-after correct` vs the staged standalone
+/// `fgumi extract | fgumi correct` chain — no aligner involved, so this closes
+/// the "extract→correct builder change only verified by an aligner-gated
+/// test" gap (the extract→correct chain-builder wiring itself is exercised
+/// in-process by `test_runall_chain_transitions.rs`'s
+/// `extract_to_correct_chain_builds_and_runs`; this is the CLI-level parity
+/// counterpart).
+#[test]
+fn extract_to_correct_matches_staged_chain() {
+    let tmp = TempDir::new().unwrap();
+    let (r1, r2) = write_extract_correct_fastqs(tmp.path());
+    let runall_out = tmp.path().join("runall.bam");
+    let staged_extracted = tmp.path().join("staged_extracted.bam");
+    let staged_out = tmp.path().join("staged.bam");
+
+    run_ok(
+        [
+            "runall",
+            "--start-from",
+            "extract",
+            "--stop-after",
+            "correct",
+            "--extract::inputs",
+            p(&r1),
+            p(&r2),
+            "--extract::read-structures",
+            "4M+T",
+            "+T",
+            "--extract::sample",
+            "s1",
+            "--extract::library",
+            "lib1",
+            "--correct::umis",
+            "ACGT",
+            "--correct::umis",
+            "TGCA",
+            "--correct::min-distance",
+            "1",
+            "-o",
+            p(&runall_out),
+        ],
+        "runall extract->correct",
+    );
+
+    run_ok(
+        [
+            "extract",
+            "--inputs",
+            p(&r1),
+            p(&r2),
+            "--read-structures",
+            "4M+T",
+            "+T",
+            "--sample",
+            "s1",
+            "--library",
+            "lib1",
+            "-o",
+            p(&staged_extracted),
+        ],
+        "staged extract",
+    );
+    run_ok(
+        [
+            "correct",
+            "-i",
+            p(&staged_extracted),
+            "-o",
+            p(&staged_out),
+            "--umis",
+            "ACGT",
+            "--umis",
+            "TGCA",
+            "--min-distance",
+            "1",
+        ],
+        "staged correct",
+    );
+
+    assert_bams_record_equivalent_nonempty(&runall_out, &staged_out);
+    assert_bam_headers_equivalent_ignoring_pg(&runall_out, &staged_out);
+}
+
+/// Same extract→correct self-pair as above, but with a top-level `--rejects`
+/// — exercising the 2-output rejects branch off the `add_correct`
+/// `BamTemplateBatch` tail (`build_stage_options_bag`'s self-pair rule: honor
+/// top-level `--rejects`, falling back to `--correct::rejects`), previously
+/// untested. Every UMI in this fixture is an exact whitelist match (see
+/// [`write_extract_correct_fastqs`]), so no UMI is actually rejected — the
+/// rejects BAM is expected to be header-only (still non-empty as bytes: a
+/// BGZF header + EOF block) rather than record-bearing. What this test
+/// actually locks down is that (a) the run succeeds with `--rejects` wired
+/// through a self-pair correct stage fed by extract, (b) the rejects file is
+/// created, and (c) the kept output is unaffected by rejects tracking being
+/// enabled, by comparing it against the same staged oracle used above (run
+/// with its own `--rejects`).
+#[test]
+fn extract_to_correct_with_rejects_matches_staged_chain() {
+    let tmp = TempDir::new().unwrap();
+    let (r1, r2) = write_extract_correct_fastqs(tmp.path());
+    let runall_out = tmp.path().join("runall.bam");
+    let runall_rejects = tmp.path().join("runall_rejects.bam");
+    let staged_extracted = tmp.path().join("staged_extracted.bam");
+    let staged_out = tmp.path().join("staged.bam");
+    let staged_rejects = tmp.path().join("staged_rejects.bam");
+
+    run_ok(
+        [
+            "runall",
+            "--start-from",
+            "extract",
+            "--stop-after",
+            "correct",
+            "--extract::inputs",
+            p(&r1),
+            p(&r2),
+            "--extract::read-structures",
+            "4M+T",
+            "+T",
+            "--extract::sample",
+            "s1",
+            "--extract::library",
+            "lib1",
+            "--correct::umis",
+            "ACGT",
+            "--correct::umis",
+            "TGCA",
+            "--correct::min-distance",
+            "1",
+            "--rejects",
+            p(&runall_rejects),
+            "-o",
+            p(&runall_out),
+        ],
+        "runall extract->correct --rejects",
+    );
+    assert!(
+        std::fs::metadata(&runall_rejects).is_ok(),
+        "runall's --rejects file was not created: {}",
+        runall_rejects.display()
+    );
+    let (_, runall_rejects_records) = read_bam_output(&runall_rejects);
+    assert!(
+        runall_rejects_records.is_empty(),
+        "every UMI in this fixture is an exact whitelist match, so runall's rejects BAM must be \
+         header-only, got {} record(s)",
+        runall_rejects_records.len()
+    );
+
+    run_ok(
+        [
+            "extract",
+            "--inputs",
+            p(&r1),
+            p(&r2),
+            "--read-structures",
+            "4M+T",
+            "+T",
+            "--sample",
+            "s1",
+            "--library",
+            "lib1",
+            "-o",
+            p(&staged_extracted),
+        ],
+        "staged extract",
+    );
+    run_ok(
+        [
+            "correct",
+            "-i",
+            p(&staged_extracted),
+            "-o",
+            p(&staged_out),
+            "--umis",
+            "ACGT",
+            "--umis",
+            "TGCA",
+            "--min-distance",
+            "1",
+            "--rejects",
+            p(&staged_rejects),
+        ],
+        "staged correct --rejects",
+    );
+    assert!(
+        std::fs::metadata(&staged_rejects).is_ok(),
+        "staged --rejects file was not created: {}",
+        staged_rejects.display()
+    );
+    let (_, staged_rejects_records) = read_bam_output(&staged_rejects);
+    assert!(
+        staged_rejects_records.is_empty(),
+        "every UMI in this fixture is an exact whitelist match, so the staged rejects BAM must be \
+         header-only, got {} record(s)",
+        staged_rejects_records.len()
+    );
+
+    assert_bams_record_equivalent_nonempty(&runall_out, &staged_out);
+    assert_bam_headers_equivalent_ignoring_pg(&runall_out, &staged_out);
+}
+
+// ══════════════════════════ Extract→Extract (interleaved, no aligner) ══════════════════════════
+
+/// Validates A2 (`--extract::interleaved`'s interleaved-vs-count check):
+/// `runall --start-from extract --stop-after extract --extract::interleaved`
+/// vs standalone `fgumi extract --interleaved`. Before A2 this would have
+/// failed at the interleaved-vs-count check; it must pass now.
+#[test]
+fn extract_interleaved_matches_standalone_extract() {
+    let tmp = TempDir::new().unwrap();
+    let interleaved = tmp.path().join("interleaved.fq.gz");
+    // 3 read pairs, interleaved R1,R2,R1,R2,R1,R2: R1 = 4bp UMI + 8bp
+    // template (read structure `4M+T`), R2 = 8bp template only (`+T`).
+    let pairs = [
+        ("read0", "ACGTAAAACCCC", "GGGGTTTT"),
+        ("read1", "ACGTAAAACCCC", "GGGGTTTT"),
+        ("read2", "ACGTAAAACCCC", "GGGGTTTT"),
+    ];
+    let r1_qual = "I".repeat(12);
+    let r2_qual = "I".repeat(8);
+    let mut records: Vec<(&str, &str, &str)> = Vec::new();
+    for (name, r1_seq, r2_seq) in &pairs {
+        records.push((name, r1_seq, r1_qual.as_str()));
+        records.push((name, r2_seq, r2_qual.as_str()));
+    }
+    write_gzip_fastq(&interleaved, &records);
+
+    let runall_out = tmp.path().join("runall.bam");
+    let staged_out = tmp.path().join("staged.bam");
+
+    run_ok(
+        [
+            "runall",
+            "--start-from",
+            "extract",
+            "--stop-after",
+            "extract",
+            "--extract::interleaved",
+            "--extract::inputs",
+            p(&interleaved),
+            "--extract::read-structures",
+            "4M+T",
+            "+T",
+            "--extract::sample",
+            "s1",
+            "--extract::library",
+            "lib1",
+            "-o",
+            p(&runall_out),
+        ],
+        "runall extract(interleaved)->extract",
+    );
+    run_ok(
+        [
+            "extract",
+            "--interleaved",
+            "--inputs",
+            p(&interleaved),
+            "--read-structures",
+            "4M+T",
+            "+T",
+            "--sample",
+            "s1",
+            "--library",
+            "lib1",
+            "-o",
+            p(&staged_out),
+        ],
+        "standalone extract --interleaved",
     );
 
     assert_bams_record_equivalent_nonempty(&runall_out, &staged_out);
@@ -1323,6 +1772,32 @@ fn rejects_codec_with_methylation_mode() {
         ],
         "not supported with codec consensus",
         "codec + --methylation-mode",
+    );
+}
+
+/// Spec §7: `--consensus <simplex|duplex|codec>` is required whenever the
+/// derived chain reaches the consensus stage. `derive_stages_for` returns this
+/// error before the input BAM is ever opened (`nonexistent-input.bam` is never
+/// read), mirroring `rejects_duplex_without_paired_strategy` below.
+#[cfg(feature = "consensus")]
+#[test]
+fn rejects_missing_consensus_mode_when_chain_reaches_consensus() {
+    assert_rejected_with(
+        [
+            "runall",
+            "--start-from",
+            "group",
+            "--stop-after",
+            "consensus",
+            "-i",
+            "nonexistent-input.bam",
+            "-o",
+            "out.bam",
+            "--group::strategy",
+            "adjacency",
+        ],
+        "--consensus <simplex|duplex|codec> is required",
+        "group->consensus without --consensus",
     );
 }
 


### PR DESCRIPTION
Adds the net-new `fgumi runall` command: a fused multi-stage pipeline that chains a user-selected slice of `extract → correct → align → zipper → sort → group → consensus → filter` into **one** multi-stage `ChainSpec` on the declarative chain builder, so every intermediate BAM a sequential run would write is elided. The slice is selected with `--start-from <stage>` / `--stop-after <stage>` (both required), the consensus algorithm with `--consensus {simplex,duplex,codec}`, and each stage is tuned via its `--<stage>::<flag>` group — the `Multi<X>` companions delivered by PR A.

**Stacked on #907 (PR A).** This PR's base is `nh/r4-runall`; review/merge #907 first. Its own diff is just the runall command (PR A's option-struct conversions are its base).

## What it does

`runall` records flow directly between stages in memory. The output matches running the equivalent standalone commands in sequence — same record stream, same `@HD` `SO`/`GO`/`SS`, `@SQ` dictionary, and `@RG` records (the fused chain writes a single `@PG` vs one-per-command, and `@HD VN`/`@CO` are not compared). `--start-from` declares the input's state and selects the upstream work: FASTQ for `extract`; a BAM via `-i` (plus `--unmapped` for `zipper`); a template-coordinate-sorted BAM for `group`; a grouped MI-tagged BAM for `consensus`; etc.

## Structure (`src/lib/commands/runall.rs`)

- **Stage enums** `RunAllStage` / `StopAfter` / `RunAllMode` (`align` is a valid `--start-from` but not a `--stop-after` — raw pre-merge aligner output has lost every original tag).
- **Three pure, unit-tested functions** — `validate_stages_for`, `derive_stages_for` (the stage-selection algorithm), `validate_strategy_for_mode` — with an `rstest` matrix asserting the exact `Stage` list per `(start × stop × consensus × extract-wants-correct)`.
- **`RunAll` clap struct** flattening every `Multi<X>` companion; `derive_source_spec` / `derive_sink_spec`; `build_stage_options_bag` (cross-stage fan-out); `execute()` assembling the `ChainSpec` and calling `build_for(spec)?.run()`.
- Registered in `src/main.rs`; declares its I/O contract in the input-source-matrix test.

## The one shared-code change

`add_correct` (chain builder) previously prepended `GroupByQueryname` unconditionally, which type-erased into a runtime panic when Correct followed Extract (whose tail is already `BamTemplateBatch`). It now takes the same `chain_tail_kind == BamTemplateBatch` bypass `add_align` already has. Behavior is byte-identical for every existing caller (the non-`BamTemplateBatch` path is unchanged).

## Deliberate decisions (called out for review)

- `--start-from extract --stop-after zipper` is **allowed** (derives `[Extract, (Correct), Align]`; Align satisfies a zipper stop).
- Sort order is forced `TemplateCoordinate` (fused chains feed Group); an explicit non-default `--sort::order` is now **warned**, not silently overridden.
- Group per-position histograms are forced off (anti-goal for a fused run); passing `--group::*` metrics flags now **warns**.
- `--<consensus>::allow-unmapped` is not exposed (deferred); codec has no methylation support and rejects `--methylation-mode`.
- runall calls `reject_output_collisions` over its effective output/rejects/stats paths, matching every standalone command.

## Correctness

- **Pure-function matrix** + **per-transition `build_for`+run** tests (every multi-stage hand-off, aligner slices gated on an available binary).
- **CLI parity tests** compare `runall` to a genuinely staged run of the standalone commands (records + header-ignoring-`@PG`): Class A self-pairs, Class B compositions, extract→group / extract→duplex fusion, `--extract::interleaved`, all three consensus modes incl. codec, plus a `--rejects` branch case and error-path tests with exact stderr substrings.
- Full local gate green: `cargo ci-fmt`, `cargo ci-lint` (clippy pedantic `-D warnings`), `RUSTDOCFLAGS="-D warnings" cargo ci-doc`, **`cargo ci-test` (9994 passed / 31 skipped)**, and `cargo check` `--no-default-features` and `--all-features`.
- Pre-push review beyond CI: per-task + whole-branch review, CodeRabbit, and a multi-agent adversarial gauntlet — all sound findings fixed (most notably an output-collision guard gap and a broken `--extract::interleaved`, both now fixed and tested).

## Reading order

1. `src/lib/commands/runall.rs` — the enums and the three pure functions (the stage-selection contract).
2. The `build_stage_options_bag` fan-out and `execute()`.
3. `src/lib/pipeline/chains/builder.rs` — the `add_correct` bypass.
4. `tests/integration/test_runall_command.rs` — the parity + error-path suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: `runall` changes grouping, consensus, sort order, and corrected-UMI output; stage validation, derived `ChainSpec` options, parity, and deterministic-output tests pin the behavior. Unsafe: none; no `CLAUDE.md` allowlist update. Memory bounds, queue capacity, threads, and backpressure: none.

Fix: Adds `fgumi runall` with selectable pipeline boundaries, consensus modes, grouped stage options, validation, and in-memory execution.

- Registers the new CLI command.
- Shares duplex numeric validation across execution paths.
- Skips redundant grouping when `Extract` already emits `BamTemplateBatch`.
- Adds integration helpers and coverage for transitions, parity, rejects, stdin, interleaved FASTQ, aligners, validation, and consensus modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->