### PR TITLE
feat(sort): thread --sort-stats diagnostics through the chain

### DIFF
--- a/crates/fgumi-pipeline-io/src/sort/merge.rs
+++ b/crates/fgumi-pipeline-io/src/sort/merge.rs
@@ -596,6 +596,11 @@ pub struct SortMerge<O: MergeOutput = RecordBatchOutput> {
     /// reaches `Done`. The standalone-sort summary finalize hook reads it to
     /// log records processed/written and the spill-chunk count.
     stats_slot: Option<Arc<parking_lot::Mutex<Option<fgumi_sort::SortStats>>>>,
+    /// Whether to log the `--sort-stats` merge-loop performance diagnostic
+    /// (`Sort merge diag: ...`: stalls/contention/backpressure counters). Off
+    /// by default -- it is instrumentation for performance investigations, not
+    /// something a normal run should show. See [`Self::with_sort_stats`].
+    sort_stats: bool,
     /// Total records ingested, captured at the merge transition (the summary's
     /// "records processed").
     processed: u64,
@@ -655,6 +660,7 @@ impl<O: MergeOutput> SortMerge<O> {
             target_batch_count: target_batch_count.max(1),
             output_byte_limit,
             stats_slot: None,
+            sort_stats: false,
             processed: 0,
             chunk_count: 0,
             dbg: MergeDiag::default(),
@@ -670,6 +676,14 @@ impl<O: MergeOutput> SortMerge<O> {
         slot: Arc<parking_lot::Mutex<Option<fgumi_sort::SortStats>>>,
     ) -> Self {
         self.stats_slot = Some(slot);
+        self
+    }
+
+    /// Enable or disable the `--sort-stats` merge-loop performance diagnostic
+    /// (`Sort merge diag: ...`). Off by default.
+    #[must_use]
+    pub fn with_sort_stats(mut self, enabled: bool) -> Self {
+        self.sort_stats = enabled;
         self
     }
 
@@ -848,17 +862,23 @@ impl<O: MergeOutput> SortMerge<O> {
                     // passes that ended input-starved; `contention` counts
                     // dispatches that produced nothing (pure idle spin);
                     // `output_full` counts downstream-backpressure events.
-                    let d = self.dbg;
-                    log::info!(
-                        "Sort merge diag: stalls={} contention={} output_full={} \
-                         progress_dispatches={} ({} records, {} sources)",
-                        d.stalls,
-                        d.contention,
-                        d.output_full,
-                        d.progress_dispatches,
-                        merged,
-                        self.chunk_count,
-                    );
+                    //
+                    // Gated on `--sort-stats` (`self.sort_stats`): this is
+                    // performance-investigation instrumentation, not something a
+                    // normal run should print.
+                    if self.sort_stats {
+                        let d = self.dbg;
+                        log::info!(
+                            "Sort merge diag: stalls={} contention={} output_full={} \
+                             progress_dispatches={} ({} records, {} sources)",
+                            d.stalls,
+                            d.contention,
+                            d.output_full,
+                            d.progress_dispatches,
+                            merged,
+                            self.chunk_count,
+                        );
+                    }
                     if let Some(slot) = &self.stats_slot {
                         *slot.lock() = Some(fgumi_sort::SortStats {
                             total_records: self.processed,
@@ -959,6 +979,20 @@ impl<O: MergeOutput> SortMerge<O> {
                         "Sort in-memory fast path complete: {count} records (single source, \
                          no merge)"
                     );
+                    // `--sort-stats` (`self.sort_stats`): the merge-loop diagnostic in
+                    // `emit_batches_cooperative` never runs on this path (there is no
+                    // k-way merge to diagnose -- the single already-sorted chunk is
+                    // gathered directly), so say so explicitly rather than staying
+                    // silent, which is indistinguishable from the flag being ignored.
+                    // Deliberately a different prefix from "Sort merge diag:" (the
+                    // k-way-merge counters emitted by `emit_batches_cooperative`) so
+                    // the two are never mistaken for one another in a log or a test.
+                    if self.sort_stats {
+                        log::info!(
+                            "Sort fast-path diag: in-memory fast path taken, no k-way merge \
+                             occurred"
+                        );
+                    }
                     if let Some(slot) = &self.stats_slot {
                         *slot.lock() = Some(fgumi_sort::SortStats {
                             total_records: self.processed,

--- a/docs/src/guide/performance-tuning.md
+++ b/docs/src/guide/performance-tuning.md
@@ -293,7 +293,7 @@ Prints detailed per-step timing, throughput, contention metrics, and per-thread 
 fgumi sort --sort-stats --input reads.bam --output sorted.bam
 ```
 
-`fgumi sort` has its own engine rather than the shared pipeline, so it carries a dedicated `--sort-stats` flag instead of `--pipeline-stats`. It prints the spill geometry, per-phase timing, the merge's floor (which of consumer serial CPU, worker capacity, or coordination limits the merge, and how much is recoverable), worker utilization, and park attribution — roughly a hundred lines. Off by default; it is instrumentation for performance work, read from a log with a `grep`.
+`fgumi sort` runs through the same shared `ChainBuilder` pipeline as every other command, but it carries a dedicated `--sort-stats` flag instead of `--pipeline-stats` for its own merge-loop diagnostic. Whenever the k-way merge runs -- any sort that spills, or a no-spill sort that still holds more than one in-memory chunk -- it prints a single `Sort merge diag: stalls=... contention=... output_full=... progress_dispatches=...` line reporting merge-loop stalls (waiting on decompress), contention (dispatches that produced nothing), and output backpressure. Only when the sort spills nothing *and* fits in a single in-memory chunk does no k-way merge run; there it instead prints one `Sort fast-path diag: ...` line noting the single-chunk in-memory fast path was taken. Off by default; it is instrumentation for performance work, read from a log with a `grep`.
 
 ### Scheduler Strategy
 

--- a/src/lib/commands/sort.rs
+++ b/src/lib/commands/sort.rs
@@ -434,12 +434,16 @@ pub struct Sort {
 
     /// Emit the sort's performance diagnostics.
     ///
-    /// Prints spill geometry, per-phase timing, the merge's floor (which of
-    /// consumer serial CPU, worker capacity, or coordination limits it, and how
-    /// much is recoverable), worker utilization, and park attribution -- roughly
-    /// a hundred lines. Off by default: it is instrumentation for performance
-    /// work, read from a log with a grep, and it buried the handful of lines a
-    /// normal run should show.
+    /// Whenever the k-way merge runs -- any sort that spills, or that keeps
+    /// more than one in-memory chunk -- prints the `SortMerge` merge-loop
+    /// diagnostic ("Sort merge diag: ..."): stalls (merge-loop passes that were
+    /// input-starved waiting on decompress), contention (dispatches that
+    /// produced nothing), and output-backpressure counts. Only when the sort
+    /// spills nothing *and* fits in a single in-memory chunk is there no merge
+    /// to diagnose -- there it instead prints a one-line note ("Sort fast-path
+    /// diag: ...") saying the single-chunk in-memory fast path was taken.
+    /// Off by default: it is instrumentation for performance work, read from a
+    /// log with a grep, and it is not something a normal run should show.
     #[arg(long = "sort-stats", default_value_t = false, hide = true)]
     pub sort_stats: bool,
 }
@@ -484,6 +488,8 @@ pub struct SortOptions {
     pub block_batch: usize,
     /// Spill at file rather than block granularity (chain engine; not a CLI flag).
     pub file_granularity: bool,
+    /// Emit the sort's performance diagnostics (`--sort-stats`).
+    pub sort_stats: bool,
 }
 
 impl Sort {
@@ -505,6 +511,7 @@ impl Sort {
             // Chain-engine defaults (see `SortOptions` docs) — not yet CLI flags.
             block_batch: 4,
             file_granularity: false,
+            sort_stats: self.sort_stats,
         }
     }
 
@@ -934,11 +941,9 @@ impl Sort {
             info!("Temp directories: {joined}");
         }
 
-        // `--read-streams` is now threaded end-to-end (into the chain's BAM
-        // source below); no warn shim. `--sort-stats` is still unthreaded.
-        if self.sort_stats {
-            warn!("--sort-stats is ignored by the sort chain (not yet threaded)");
-        }
+        // `--read-streams` and `--sort-stats` are threaded end-to-end (into the
+        // chain's BAM source and `SortMerge` respectively, below); no warn shim
+        // needed for either.
 
         // --- cutover: run via the chain instead of sorter.sort() ---
         // (`phase1_threads`/`phase2_threads` above are retained only to source the

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -2859,7 +2859,8 @@ impl<'a> ChainBuilder<'a> {
                 // produced, but emitted on the already-in-order `Detached` merge
                 // thread, dropping one pool step and one memcpy per record.
                 let mut merge =
-                    SortMerge::<BlockOutput>::new(sort_order, self.tuning.per_step_byte_limit);
+                    SortMerge::<BlockOutput>::new(sort_order, self.tuning.per_step_byte_limit)
+                        .with_sort_stats(sort.sort_stats);
                 if let Some(slot) = &sort_stats_slot {
                     merge = merge.with_stats_slot(Arc::clone(slot));
                 }
@@ -2900,11 +2901,14 @@ impl<'a> ChainBuilder<'a> {
                 // during this decode — otherwise group would re-scan aux per
                 // template and lose the #334/#343 optimization on the sort→group
                 // path. The intermediate sort is never standalone, so the stats
-                // slot is `None`; no `with_stats_slot` call is needed.
+                // slot is `None`; no `with_stats_slot` call is needed. The
+                // merge-loop diagnostic still honors `--sort-stats` like the
+                // terminal branch, for a fused pipeline that ever exposes it.
                 let merge = SortMerge::<RecordBatchOutput>::new(
                     sort_order,
                     self.tuning.per_step_byte_limit,
-                );
+                )
+                .with_sort_stats(sort.sort_stats);
                 let merge_tail = self.pipeline.append_step(merge, decompress_tail);
                 let group_key_config = self.bam_group_key_config();
                 let tail = self.pipeline.append_step(

--- a/src/lib/pipeline/chains/validate.rs
+++ b/src/lib/pipeline/chains/validate.rs
@@ -579,6 +579,7 @@ mod tests {
             max_temp_files: MaxTempFiles::Auto,
             block_batch: 4,
             file_granularity: false,
+            sort_stats: false,
         }
     }
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -55,6 +55,7 @@ mod test_simplex_pipeline;
 mod test_simulate_sort;
 mod test_sort_correctness;
 mod test_sort_cutover_parity;
+mod test_sort_stats_diagnostics;
 mod test_sort_thread_logging;
 mod test_sort_write_index;
 mod test_streaming_input;

--- a/tests/integration/test_chain_bam_with_index.rs
+++ b/tests/integration/test_chain_bam_with_index.rs
@@ -103,6 +103,7 @@ fn bam_with_index_produces_inline_sidecar_not_reread() {
         max_temp_files: MaxTempFiles::Auto,
         block_batch: 4,
         file_granularity: false,
+        sort_stats: false,
     };
 
     let spec = ChainSpec {
@@ -319,6 +320,7 @@ fn sort_options(max_memory: MemoryLimit, tmp_dirs: Vec<PathBuf>) -> SortOptions 
         max_temp_files: MaxTempFiles::Auto,
         block_batch: 4,
         file_granularity: false,
+        sort_stats: false,
     }
 }
 

--- a/tests/integration/test_sort_cutover_parity.rs
+++ b/tests/integration/test_sort_cutover_parity.rs
@@ -569,12 +569,14 @@ fn cutover_matches_baseline_and_samtools(
 // ============================================================================
 // Task 5: --write-index, edge cases, spill identity, env fallback, and guards
 //
-// Command-level coverage of the pieces the cutover changed or left inert:
-// the coordinate-only `--write-index` guard and its inline BAI content, the
+// Command-level coverage of the pieces the cutover changed: the
+// coordinate-only `--write-index` guard and its inline BAI content, the
 // empty/single/already-sorted edges, spill-vs-in-memory byte identity,
-// `FGUMI_TMP_DIRS` reaching the chain, and the `--threads 0` /
-// accept-but-inert-flag guards. A genuine failure here is a real cutover bug,
-// not a test to relax -- see the module-level correctness discipline note.
+// `FGUMI_TMP_DIRS` reaching the chain, the `--threads 0` rejection guard, and
+// `--sort-stats`/`--read-streams`, both now threaded into the chain and
+// active (neither is reported as ignored). A genuine failure here is a real
+// cutover bug, not a test to relax -- see the module-level correctness
+// discipline note.
 // ============================================================================
 
 /// `n` mapped, single-end records on one reference, placed at *ascending*
@@ -1134,13 +1136,12 @@ fn cutover_threads_zero_is_rejected() {
     }
 }
 
-/// `--sort-stats` is still inert on the chain (nothing downstream reads it), so
-/// it must be accept-but-inert with a visible notice. `--read-streams`, by
-/// contrast, is now threaded into the chain's BAM source (R7b), so it must NOT
-/// be reported as ignored. Either way the sort must still produce correct,
-/// coordinate-sorted output.
+/// `--sort-stats` and `--read-streams` are both threaded into the chain now
+/// (the former into `SortMerge`'s performance diagnostic, the latter into the
+/// chain's BAM source), so neither must be reported as ignored. Either way the
+/// sort must still produce correct, coordinate-sorted output.
 #[test]
-fn cutover_sort_stats_inert_read_streams_active() {
+fn cutover_sort_stats_and_read_streams_are_active() {
     let dir = TempDir::new().expect("create temp dir");
     let input_bam = dir.path().join("in.bam");
     let records = unsorted_records(200);
@@ -1149,9 +1150,9 @@ fn cutover_sort_stats_inert_read_streams_active() {
     let output_bam = dir.path().join("out.bam");
 
     // Run as a subprocess (with `RUST_LOG=info` pinned so the ambient environment
-    // cannot filter the notices out) so the test can assert on stderr: the ignored
-    // flags are `warn`-level and each must announce that it is inert, otherwise a
-    // silently-dropped flag would leave the user thinking it took effect.
+    // cannot filter the notices out) so the test can assert on stderr: both flags
+    // are threaded into the chain now, so neither must log a stale "ignored"
+    // notice, which would wrongly tell the user an active flag did nothing.
     let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
     let output = Command::new(current_bin)
         .env("RUST_LOG", "info")
@@ -1168,19 +1169,16 @@ fn cutover_sort_stats_inert_read_streams_active() {
             OsStr::new("4"),
         ])
         .output()
-        .expect("failed to spawn fgumi sort (inert flags)");
+        .expect("failed to spawn fgumi sort (--sort-stats/--read-streams)");
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        output.status.success(),
-        "--sort-stats (inert) and --read-streams (active) must not error:\n{stderr}"
-    );
+    assert!(output.status.success(), "--sort-stats and --read-streams must not error:\n{stderr}");
     assert!(
         !stderr.contains("--read-streams=4 is ignored"),
         "`--read-streams` is threaded now and must not be reported as ignored; stderr:\n{stderr}"
     );
     assert!(
-        stderr.contains("--sort-stats is ignored by the sort chain"),
-        "the ignored `--sort-stats` notice must be visible on stderr; stderr:\n{stderr}"
+        !stderr.contains("--sort-stats is ignored by the sort chain"),
+        "`--sort-stats` is threaded now and must not be reported as ignored; stderr:\n{stderr}"
     );
 
     let (_, out_records) = read_bam_output(&output_bam);

--- a/tests/integration/test_sort_stats_diagnostics.rs
+++ b/tests/integration/test_sort_stats_diagnostics.rs
@@ -1,0 +1,357 @@
+//! Integration tests for `fgumi sort --sort-stats`.
+//!
+//! `--sort-stats` is meant to gate the sort's performance diagnostics: on a
+//! spilling sort, `SortMerge`'s "Sort merge diag:" line (merge-loop stalls /
+//! contention / backpressure counters); on a sort that fits entirely in
+//! memory, the "Sort fast-path diag:" note (there is no k-way merge to
+//! diagnose there). Before this fix the chain-based `fgumi sort` ignored the
+//! flag entirely on the spilling path (the diag line was emitted
+//! unconditionally, and `--sort-stats` itself only produced a stale "is
+//! ignored by the sort chain" warning) and produced nothing at all on the
+//! fast path (the flag silently doing nothing there too). These tests pin
+//! both paths to something real.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Mutex, Once, OnceLock};
+
+use rstest::rstest;
+use tempfile::TempDir;
+
+use fgumi_lib::commands::common::{
+    CompressionOptions, MaxTempFiles, MemoryLimit, MemoryReserve, QueueMemoryOptions,
+    SchedulerOptions, ThreadingOptions,
+};
+use fgumi_lib::commands::group::GroupOptions;
+use fgumi_lib::commands::sort::{SortOptions, SortOrderArg};
+use fgumi_lib::pipeline::chains::{
+    ChainSpec, SinkSpec, SourceSpec, Stage, StageOptionsBag, build_for,
+};
+use fgumi_lib::sam::SamTag;
+
+use crate::helpers::assertions::{assert_bam_sorted, string_tag};
+use crate::helpers::bam_generator::{
+    create_minimal_header, create_umi_family, create_umi_family_at_pos, write_bam,
+};
+
+/// The stable substring pinning the `SortMerge` k-way-merge diagnostic line
+/// (`crates/fgumi-pipeline-io/src/sort/merge.rs`, `emit_batches_cooperative`).
+/// Only ever logged when a real merge ran (a spilling sort).
+const MERGE_DIAG_SUBSTRING: &str = "Sort merge diag:";
+
+/// The stable substring pinning the in-memory fast-path diagnostic note
+/// (`crates/fgumi-pipeline-io/src/sort/merge.rs`, `emit_fast_batches`). Only
+/// ever logged when the sort fit entirely in memory (no k-way merge ran).
+/// Deliberately a different prefix from [`MERGE_DIAG_SUBSTRING`] so the two
+/// are never mistaken for one another.
+const FAST_PATH_DIAG_SUBSTRING: &str = "Sort fast-path diag:";
+
+/// Shared buffer the capture logger appends every formatted `log` record to.
+/// A single global buffer (not thread-local) so a diagnostic emitted on a sort
+/// worker thread is still seen from the test thread.
+static CAPTURED_LOGS: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+
+/// A minimal `log::Log` that records each message into [`CAPTURED_LOGS`]. Used
+/// by the in-process chain tests below, which run `build_for(..).run()`
+/// directly and so cannot capture a subprocess's stderr the way the CLI tests
+/// do.
+struct CaptureLogger;
+
+impl log::Log for CaptureLogger {
+    fn enabled(&self, _: &log::Metadata<'_>) -> bool {
+        true
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        if let Some(buf) = CAPTURED_LOGS.get() {
+            buf.lock().expect("capture-log mutex poisoned").push(format!("{}", record.args()));
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+/// Installs [`CaptureLogger`] as the global logger (idempotent) and returns the
+/// shared buffer, cleared for the caller. `log::set_boxed_logger` succeeds only
+/// once per process; a later `Err` (already set) is fine because the buffer is
+/// the same. Nextest runs each test in its own process, so no other test in
+/// this binary competes for the global logger.
+fn capture_logs() -> &'static Mutex<Vec<String>> {
+    static INIT: Once = Once::new();
+    let buf = CAPTURED_LOGS.get_or_init(|| Mutex::new(Vec::new()));
+    INIT.call_once(|| {
+        let _ = log::set_boxed_logger(Box::new(CaptureLogger));
+        log::set_max_level(log::LevelFilter::Info);
+    });
+    buf.lock().expect("capture-log mutex poisoned").clear();
+    buf
+}
+
+/// Writes a BAM with `families` three-read UMI families, all at the same
+/// position.
+fn write_bam_fixture(path: &Path, families: usize) {
+    let header = create_minimal_header("chr1", 100_000);
+    let records: Vec<_> = (0..families)
+        .flat_map(|i| create_umi_family("ACGT", 3, &format!("fam_{i:06}"), "ACGTACGTAC", 35))
+        .collect();
+    write_bam(path, &header, &records);
+}
+
+/// Runs `fgumi sort` at info verbosity and returns its stderr.
+fn sort_and_capture_logs(families: usize, max_memory: &str, extra_args: &[&str]) -> String {
+    let tmp = TempDir::new().expect("tempdir");
+    let input: PathBuf = tmp.path().join("unsorted.bam");
+    write_bam_fixture(&input, families);
+    let output = tmp.path().join("sorted.bam");
+
+    let result = Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .env("RUST_LOG", "info")
+        .args(["sort", "-i"])
+        .arg(&input)
+        .arg("-o")
+        .arg(&output)
+        .args(["--order", "coordinate", "-m", max_memory])
+        .args(extra_args)
+        .output()
+        .expect("run fgumi sort");
+
+    let stderr = String::from_utf8_lossy(&result.stderr).into_owned();
+    assert!(result.status.success(), "fgumi sort failed:\n{stderr}");
+    stderr
+}
+
+/// Runs `fgumi sort` with a small `--max-memory` (forcing spills + a real
+/// k-way merge) and returns its stderr.
+///
+/// Sized so a small `--max-memory` forces multiple spill runs and therefore a
+/// real k-way merge (not the single-chunk fast path, which never logs the
+/// merge diagnostic at all): mirrors the fixture size
+/// `test_streaming_output::sort_streams_to_stdout`'s `spill_and_merge` case
+/// already validates as spilling (`test_streaming_output::the_spilling_fixture_spills`).
+fn sort_spilling(extra_args: &[&str]) -> String {
+    sort_and_capture_logs(20_000, "1M", extra_args)
+}
+
+/// Asserts the given stderr proves a real spill + k-way merge happened,
+/// independent of `--sort-stats`: the standalone-sort summary's "Spill runs:"
+/// line (`SortSummaryFinalizeHook`, unconditional) is only logged when
+/// `runs_written > 0`, which is exactly the condition (`!slots.is_empty()`)
+/// that rules out `SortMerge`'s single-chunk fast path. Guards the
+/// merge-diagnostic assertions below against a memory-accounting change
+/// silently making [`sort_spilling`]'s fixture fit in memory (which would
+/// make "the diagnostic is present" vacuously true only because the fast-path
+/// note happens to share no text with it, rather than because a real merge
+/// diagnostic fired).
+fn assert_really_spilled(stderr: &str) {
+    assert!(
+        stderr.contains("Spill runs:"),
+        "fixture did not spill (no k-way merge ran) -- the merge-diagnostic assertions in this \
+         test are vacuous without a real merge; stderr:\n{stderr}"
+    );
+}
+
+/// `--sort-stats` gates the `SortMerge` k-way-merge diagnostic line on a
+/// spilling sort: absent by default, present when passed.
+#[rstest]
+#[case::without_flag(&[], false)]
+#[case::with_flag(&["--sort-stats"], true)]
+fn sort_stats_gates_merge_diagnostics(#[case] extra_args: &[&str], #[case] expect_present: bool) {
+    let stderr = sort_spilling(extra_args);
+    assert_really_spilled(&stderr);
+
+    let present = stderr.contains(MERGE_DIAG_SUBSTRING);
+    assert_eq!(
+        present, expect_present,
+        "expected `{MERGE_DIAG_SUBSTRING}` presence={expect_present}, got:\n{stderr}"
+    );
+    // The flag must not resurrect the stale "ignored" warning.
+    assert!(
+        !stderr.contains("is ignored by the sort chain"),
+        "stale --sort-stats warning still present:\n{stderr}"
+    );
+}
+
+/// On a sort that fits entirely in memory (the single-chunk fast path, no
+/// k-way merge), `--sort-stats` gates the fast-path note: absent by default,
+/// present when the flag is passed. It must not be a silent no-op with the
+/// flag, and — the disabled case pins that the note is truly gated, not
+/// emitted unconditionally — it must stay silent without it. The merge
+/// diagnostic never appears on this path regardless of the flag, because no
+/// k-way merge runs.
+#[rstest]
+#[case::without_flag(&[], false)]
+#[case::with_flag(&["--sort-stats"], true)]
+fn sort_stats_gates_fast_path_note(#[case] extra_args: &[&str], #[case] expect_present: bool) {
+    // A handful of records under a large `--max-memory`: fits in one
+    // in-memory chunk, so `SortMerge` takes `FastPath` and never reaches
+    // `emit_batches_cooperative` (where `MERGE_DIAG_SUBSTRING` is logged).
+    let stderr = sort_and_capture_logs(4, "768M", extra_args);
+
+    assert!(
+        !stderr.contains("Spill runs:"),
+        "fixture unexpectedly spilled; this case must exercise the fast path:\n{stderr}"
+    );
+
+    let present = stderr.contains(FAST_PATH_DIAG_SUBSTRING);
+    assert_eq!(
+        present, expect_present,
+        "expected `{FAST_PATH_DIAG_SUBSTRING}` presence={expect_present} on a non-spilling sort, \
+         got:\n{stderr}"
+    );
+    // No k-way merge runs on the fast path, so the merge diagnostic must never
+    // appear regardless of the flag.
+    assert!(
+        !stderr.contains(MERGE_DIAG_SUBSTRING),
+        "the k-way-merge diagnostic must not appear when no merge ran:\n{stderr}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Coverage: the INTERMEDIATE `add_sort` branch's `.with_sort_stats(...)`
+// ─────────────────────────────────────────────────────────────────────────
+//
+// The tests above exercise `--sort-stats` only through the standalone
+// `fgumi sort` CLI, which always builds a `[Stage::Sort]`-terminal chain
+// (`Sort::to_chain_spec`, `src/lib/commands/sort.rs`). That leaves the
+// INTERMEDIATE branch of `add_sort` (`src/lib/pipeline/chains/builder.rs`,
+// the arm reached when `position != StagePosition::Terminal` — the fused
+// sort→group path) completely unexercised by any existing test: it is
+// `SortMerge<RecordBatchOutput>::new(..).with_sort_stats(sort.sort_stats)`,
+// followed by `DecodeFromRecords` and the `current_tail`/`chain_tail_kind`
+// bookkeeping for a non-terminal sort.
+//
+// No CLI command builds a multi-stage, `Stage::Sort`-non-terminal chain yet
+// (`runall` has not landed on this branch), but the chain builder itself has
+// no such restriction, and `ChainSpec`/`build_for` are a deliberate,
+// existing seam for exactly this: `validate.rs`'s Rule 6 comment notes "No
+// CLI builds this chain today ... this protects a directly-constructed
+// programmatic chain", and `test_chain_bam_with_index.rs` already
+// establishes the pattern of building a `ChainSpec` directly and running it
+// via `build_for(spec)?.run()` with no command-level driver involved. This
+// test follows that same pattern for `[Stage::Sort, Stage::Group]` — the
+// fused sort→group path the intermediate branch's own doc comment names.
+#[test]
+fn fused_sort_then_group_chain_exercises_intermediate_add_sort_branch() {
+    let dir = TempDir::new().expect("create temp dir");
+    let input_bam = dir.path().join("in.bam");
+    let output_bam = dir.path().join("out.bam");
+
+    // Three UMI families at distinct, deliberately out-of-order positions, so
+    // the intermediate sort has real reordering work to do before group sees
+    // template-coordinate-ordered input.
+    let header = create_minimal_header("chr1", 100_000);
+    let records: Vec<_> = create_umi_family_at_pos("AAAAAAAA", 3, "fam_a", "ACGTACGTAC", 35, 3_000)
+        .into_iter()
+        .chain(create_umi_family_at_pos("CCCCCCCC", 3, "fam_c", "ACGTACGTAC", 35, 1_000))
+        .chain(create_umi_family_at_pos("GGGGGGGG", 3, "fam_g", "ACGTACGTAC", 35, 2_000))
+        .collect();
+    write_bam(&input_bam, &header, &records);
+
+    // Capture the in-process chain's logs so we can prove `sort_stats: true`
+    // actually reaches `SortMerge::with_sort_stats` on the intermediate branch
+    // -- not just that the BAM came out sorted (which a regression dropping the
+    // flag before `with_sort_stats` would leave unchanged). This fixture is
+    // tiny and non-spilling, so the sort takes the single-chunk fast path and,
+    // with sort-stats enabled, emits the fast-path diagnostic note.
+    let logs = capture_logs();
+
+    let sort_options = SortOptions {
+        order: SortOrderArg::TemplateCoordinate,
+        key_types: None,
+        max_memory: MemoryLimit::Fixed(64 * 1024 * 1024),
+        memory_reserve: MemoryReserve::Auto,
+        memory_per_thread: true,
+        tmp_dirs: Vec::new(),
+        sort_threads: None,
+        merge_threads: None,
+        temp_compression: 1,
+        temp_codec: fgumi_sort::SpillCodec::default(),
+        max_temp_files: MaxTempFiles::Auto,
+        block_batch: 4,
+        file_granularity: false,
+        // The point of this test: exercise `with_sort_stats(true)` on the
+        // intermediate branch too, not just the flag being threaded through
+        // without effect.
+        sort_stats: true,
+    };
+
+    let spec = ChainSpec {
+        stages: vec![Stage::Sort, Stage::Group],
+        source: SourceSpec::Bam(input_bam.clone()),
+        sink: SinkSpec::Bam(output_bam.clone()),
+        stage_opts: StageOptionsBag {
+            sort: Some(sort_options),
+            group: Some(GroupOptions::default()),
+            ..Default::default()
+        },
+        threading: ThreadingOptions { threads: None },
+        compression: CompressionOptions::default(),
+        scheduler: SchedulerOptions::default(),
+        queue_memory: QueueMemoryOptions::default(),
+        async_reader: false,
+        read_streams: fgumi_bam_io::ReadStreams::Fixed(1),
+        verify_crc: true,
+        command_line: "fgumi <fused sort+group test>".to_string(),
+    };
+
+    build_for(spec)
+        .expect("build_for should accept a fused [Stage::Sort, Stage::Group] chain")
+        .run()
+        .expect("running the fused sort->group chain should succeed with --sort-stats enabled");
+
+    assert!(output_bam.exists(), "fused sort->group output BAM was not written");
+
+    // The intermediate sort ran with `sort_stats: true` on a non-spilling
+    // single-chunk fixture, so `SortMerge`'s fast-path note must have fired.
+    // This is the assertion that pins propagation through `with_sort_stats`:
+    // drop the flag before that call and this line fails while every BAM
+    // assertion below still passes.
+    let captured = logs.lock().expect("capture-log mutex poisoned");
+    assert!(
+        !captured.iter().any(|line| line.contains(MERGE_DIAG_SUBSTRING)),
+        "the k-way-merge diagnostic must not appear on the non-spilling fast path; logs:\n{}",
+        captured.join("\n")
+    );
+    assert!(
+        captured.iter().any(|line| line.contains(FAST_PATH_DIAG_SUBSTRING)),
+        "expected the fast-path note `{FAST_PATH_DIAG_SUBSTRING}` from the intermediate sort with \
+         `sort_stats: true`; logs:\n{}",
+        captured.join("\n")
+    );
+    drop(captured);
+
+    // `Group`'s own runtime precondition (`require_group_input_ordering`) only
+    // accepts template-coordinate-sorted input, so a correct, non-erroring
+    // output here proves the intermediate sort really ran (`position !=
+    // Terminal`) and its header transform + `SortMerge<RecordBatchOutput>` +
+    // `DecodeFromRecords` handoff to group all worked end to end -- not just
+    // that the call compiled.
+    assert_bam_sorted(&output_bam, "template-coordinate", Some("mi"));
+
+    let mut reader =
+        noodles::bam::io::Reader::new(std::fs::File::open(&output_bam).expect("open output BAM"));
+    reader.read_header().expect("read output BAM header");
+    let mi_values: Vec<String> =
+        reader.records().map(|r| string_tag(&r.expect("read output record"), SamTag::MI)).collect();
+    assert_eq!(mi_values.len(), 9, "expected all 9 input records in the fused output");
+
+    // Group MI values by their molecule id, stripping any trailing "/A" or
+    // "/B" strand suffix (fgumi's own convention for pairing both strands of
+    // a molecule under one id) so this assertion does not depend on whether
+    // that suffix applies to single-end reads.
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for mi in &mi_values {
+        let base = mi.split('/').next().unwrap_or(mi).to_string();
+        *counts.entry(base).or_insert(0) += 1;
+    }
+    assert_eq!(
+        counts.len(),
+        3,
+        "expected 3 distinct molecule groups (one per UMI family), got {counts:?}"
+    );
+    assert!(
+        counts.values().all(|&n| n == 3),
+        "expected each molecule group to have all 3 of its family's reads, got {counts:?}"
+    );
+}


### PR DESCRIPTION
## What

`fgumi sort` runs entirely on the declarative chain builder, but `--sort-stats` was inert on that path — it emitted `warn!("--sort-stats is ignored by the sort chain (not yet threaded)")` and produced no diagnostics. This threads the flag through so it actually works.

## Change

- `SortOptions` gains a `sort_stats: bool` field, projected from the CLI flag by `to_sort_options()`, and wired into `SortMerge::with_sort_stats(bool)` in **both** the terminal and intermediate `add_sort` chain branches (the intermediate branch matters for a fused `runall` sort).
- The `SortMerge` merge-loop diagnostic (`Sort merge diag: stalls=… contention=… output_full=…`) is now **gated behind `--sort-stats`**. Previously it was logged **unconditionally on every sort** — the opposite bug — so this also makes an always-on diagnostic opt-in, matching the `--sort-stats` policy established in #826.
- The single-source in-memory fast path (`emit_fast_batches`) now emits a short `Sort fast-path diag:` note under `--sort-stats`, so the flag is never a silent no-op even when the sort doesn't spill (no k-way merge to report).
- The stale `warn!` shim is deleted.

### Behavior change to call out

- `--sort-stats` now produces output (was inert).
- The `Sort merge diag:` line no longer prints on every sort — it now requires `--sort-stats`. A run that previously showed it unconditionally will need the flag.

## Scope note

This threads and gates the **existing** narrow `SortMerge` diagnostic; it does **not** restore the pre-cutover owned engine's richer (~100-line) per-phase diagnostics — that would be new instrumentation for a separate PR. The `--sort-stats` help text and the `docs/src/guide/performance-tuning.md` "Sort Statistics" section are rewritten to describe the current behavior accurately (one merge-diag line on spilling sorts; one fast-path note on in-memory sorts) and drop the now-false "own engine" claim.

## Tests

- New `tests/integration/test_sort_stats_diagnostics.rs`: a spilling case asserts the merge diag is absent without `--sort-stats` and present with it (guarded by an `assert_really_spilled` check so it can't pass vacuously if memory accounting changes), plus a small-input fast-path case pinning that the fast-path note appears (and the merge diag does not).
- Updated the pre-existing `test_sort_cutover_parity.rs` assertion that had pinned the old always-on/ignored behavior, and its stale comments.

Full gate green: `cargo ci-test` 9956 passed / 31 skipped, plus `ci-fmt`/`ci-lint`/`ci-doc` and `--no-default-features`/`--all-features`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: sort diagnostics change command output, pinned by integration tests; unsafe changes: none, and CLAUDE.md allowlist updates: none; memory, queue, and thread/backpressure policy changes: none.

- Propagates `--sort-stats` through terminal and intermediate sort chains.
- Gates merge diagnostics behind the flag.
- Adds a diagnostic for single-source in-memory sorts.
- Removes the stale ignored-option warning.
- Updates documentation and integration tests for spilling and fast-path cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->