### PR TITLE
fix: restore chain-path diagnostic parity (dedup/group index-threshold banner, copy_umi serial inert-flag warnings, pair_fastq docstring)

### DIFF
--- a/src/lib/commands/copy_umi.rs
+++ b/src/lib/commands/copy_umi.rs
@@ -424,6 +424,17 @@ impl Command for CopyUmi {
         info!("Input: {}", self.io.input.display());
         info!("Output: {}", self.io.output.display());
 
+        // Without this, a scheduler/pipeline flag set here (e.g.
+        // `--deadlock-recover`) is silently ignored on the serial path with no
+        // diagnostic at all. This is NOT `common::warn_unwired_pipeline_flags`:
+        // that helper is chain-specific (its wording says "the chain engine ...",
+        // and it deliberately skips `--max-memory`/`--memory-reserve`/
+        // `--memory-per-thread` because the chain DOES honor them) — on this
+        // serial path there is no chain engine at all, so those queue-memory
+        // flags are inert here too and must be warned, with wording that is true
+        // for the single-threaded context.
+        self.warn_unwired_flags_on_serial_path();
+
         let totals = self.run_single_threaded(command_line)?;
         warn_and_log_copy_umi_summary(&totals);
         if let Some(path) = &self.metrics {
@@ -435,6 +446,51 @@ impl Command for CopyUmi {
 }
 
 impl CopyUmi {
+    /// Warn about scheduler/pipeline-queue flags that have no effect on THIS
+    /// serial (no-`--threads`) path.
+    ///
+    /// Deliberately NOT `common::warn_unwired_pipeline_flags`: that helper is
+    /// chain-specific -- its wording ("the chain engine ...", "the typed-step
+    /// pipeline") describes a running chain, and it deliberately skips
+    /// `--max-memory`/`--memory-reserve`/`--memory-per-thread` because the chain
+    /// DOES honor them (they seed `PipelineConfig::queue_memory_total`). On this
+    /// serial path there is no chain and no queue to budget, so reusing that
+    /// helper would both assert a false rationale and fail to warn about the
+    /// queue-memory flags, which are genuinely inert here. Each flag is warned
+    /// only when set away from its default, mirroring how the chain-path helper
+    /// gates its own warnings.
+    fn warn_unwired_flags_on_serial_path(&self) {
+        let requested_scheduler = self.scheduler_opts.strategy();
+        if requested_scheduler != crate::unified_pipeline::scheduler::SchedulerStrategy::default() {
+            warn!(
+                "--scheduler has no effect on the single-threaded path: the serial \
+                 read -> copy-umi -> write loop does not use a pluggable scheduler \
+                 strategy, so the requested strategy ({requested_scheduler:?}) is \
+                 ignored (run with --threads to use the pipeline)"
+            );
+        }
+        if self.scheduler_opts.deadlock_recover_enabled() {
+            warn!(
+                "--deadlock-recover has no effect on the single-threaded path: there \
+                 is no pipeline to deadlock-detect or recover on, only a serial \
+                 read -> copy-umi -> write loop (run with --threads to use the \
+                 pipeline)"
+            );
+        }
+        let default_queue_memory = QueueMemoryOptions::default();
+        if self.queue_memory.max_memory != default_queue_memory.max_memory
+            || self.queue_memory.memory_reserve != default_queue_memory.memory_reserve
+            || self.queue_memory.memory_per_thread != default_queue_memory.memory_per_thread
+        {
+            warn!(
+                "--max-memory/--memory-reserve/--memory-per-thread have no effect on \
+                 the single-threaded path: there are no pipeline queues to budget on \
+                 a serial read -> copy-umi -> write loop (run with --threads to use \
+                 the pipeline)"
+            );
+        }
+    }
+
     /// Serial no-`--threads` path: a read → copy-umi → write loop, and the
     /// in-process parity oracle for the chain path. Uses `pipeline_reader_opts()`
     /// so the CRC-check policy matches the chain, and `ensure_hd_record` +

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -3014,12 +3014,11 @@ impl<'a> ChainBuilder<'a> {
         if group.no_umi {
             info!("No-UMI mode: grouping by position only");
         }
-        if matches!(
+        crate::commands::common::log_index_threshold(
             group.effective_strategy,
-            crate::assigner::Strategy::Adjacency | crate::assigner::Strategy::Paired
-        ) {
-            info!("Index threshold: {}", group.index_threshold);
-        }
+            group.effective_edits,
+            group.index_threshold,
+        );
         if group.allow_unmapped {
             info!("Allow unmapped: enabled (unmapped templates will be grouped by UMI only)");
             warn!(
@@ -4766,9 +4765,11 @@ impl<'a> ChainBuilder<'a> {
         if dedup.no_umi {
             info!("No-UMI mode: deduplicating by position only");
         }
-        if matches!(effective_strategy, Strategy::Adjacency | Strategy::Paired) {
-            info!("Index threshold: {}", dedup.index_threshold);
-        }
+        crate::commands::common::log_index_threshold(
+            effective_strategy,
+            effective_edits,
+            dedup.index_threshold,
+        );
 
         warn_unwired_pipeline_flags(&self.spec.scheduler);
         let num_threads = self.spec.threading.num_threads();

--- a/src/lib/pipeline/steps/source/pair_fastq.rs
+++ b/src/lib/pipeline/steps/source/pair_fastq.rs
@@ -367,10 +367,16 @@ impl Step2 for PairRawFastq {
 /// records first (0 = R1/A, 1 = R2/B) and `chunk_serial` is the orphaned serial
 /// still holding only the other stream's chunk.
 ///
-/// Shared by both fail paths — the both-drained [`PairRawFastq::finalize_pairs`]
-/// desync report and the over-backpressure mid-stream fail-fast — so the two
-/// surface byte-for-byte identical diagnostics regardless of which path detects
-/// the mismatch.
+/// Shared by both of `PairRawFastq`'s fail paths — the both-drained
+/// [`PairRawFastq::finalize_pairs`] desync report and the over-backpressure
+/// mid-stream fail-fast — so those two sites surface byte-for-byte identical
+/// diagnostics within this step. That guarantee is scoped to this file: it does
+/// NOT extend to the other FASTQ-pairing implementations (the serial oracle in
+/// `grouper.rs`, the zip path in `zip_fastq.rs` / `parse_zip_fastq.rs`, and the
+/// unified-pipeline path in `unified_pipeline/fastq.rs`). Every path detects the
+/// same out-of-sync CONDITION — one stream's records running out before its
+/// mate's — but each words its own diagnostic independently, so the exact
+/// message text differs by path.
 fn out_of_sync_error(short_stream: usize, chunk_serial: u64) -> io::Error {
     // Name streams R1/R2 (1-based) and the short one as having "ended before" the
     // other, matching the serial oracle's wording so the operator learns which

--- a/tests/integration/helpers/cli.rs
+++ b/tests/integration/helpers/cli.rs
@@ -1,0 +1,34 @@
+//! Helpers for spawning the compiled `fgumi` binary and capturing its stderr.
+//!
+//! A handful of tests need to observe a real logged banner or warning line
+//! (not just a command's exit status or output BAM), which requires spawning
+//! the actual binary rather than calling `Command::execute()` in-process: the
+//! in-process log-capture harness (`fgumi_lib::commands::common::test_log_capture`)
+//! is `pub(crate)` inside `fgumi_lib` and unreachable from this external
+//! integration-test crate.
+
+use std::path::Path;
+
+/// Spawn `fgumi <subcommand> -i <input> -o <output> <extra_args>...` and
+/// return its captured stderr, asserting the run succeeded.
+///
+/// `RUST_LOG=info` is set so the run's `info!`/`warn!` banners reach stderr.
+pub fn run_and_capture_logs(
+    subcommand: &str,
+    input: &Path,
+    output: &Path,
+    extra_args: &[&str],
+) -> String {
+    let result = std::process::Command::new(env!("CARGO_BIN_EXE_fgumi"))
+        .env("RUST_LOG", "info")
+        .args([subcommand, "-i"])
+        .arg(input)
+        .arg("-o")
+        .arg(output)
+        .args(extra_args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn `fgumi {subcommand}`: {e}"));
+    let stderr = String::from_utf8_lossy(&result.stderr).into_owned();
+    assert!(result.status.success(), "fgumi {subcommand} failed:\n{stderr}");
+    stderr
+}

--- a/tests/integration/helpers/mod.rs
+++ b/tests/integration/helpers/mod.rs
@@ -9,9 +9,11 @@
 
 pub mod assertions;
 pub mod bam_generator;
+pub mod cli;
 
 pub use assertions::*;
 pub use bam_generator::*;
+pub use cli::*;
 
 /// Writes `contents` to `dir/name` and returns the path.
 ///

--- a/tests/integration/test_copy_umi_command.rs
+++ b/tests/integration/test_copy_umi_command.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, transcode_bam_to_sam, write_bam};
+use crate::helpers::cli::run_and_capture_logs;
 
 /// A minimal mapped record carrying the given read name (sequence/quals are fixed
 /// filler — `copy-umi` never touches them).
@@ -499,6 +500,77 @@ fn runs_on_multiple_threads() {
     assert_eq!(
         rows, want,
         "the parallel path must preserve every record's QNAME and its copied RX, in input order"
+    );
+}
+
+// ============================================================================
+// Unwired scheduler/pipeline flags must warn on BOTH the chain and serial paths
+// ============================================================================
+
+/// Unwired scheduler/pipeline-queue flags must warn on BOTH the `--threads N`
+/// chain path and the no-`--threads` serial path -- but with DIFFERENT wording,
+/// since the two paths are unwired for different reasons and the warning must
+/// stay true to whichever one is actually running:
+///
+/// * Chain path (`execute_chain` -> `add_copy_umi` ->
+///   `common::warn_unwired_pipeline_flags`): `--deadlock-recover`/`--scheduler`
+///   are inert because the typed-step engine has no pluggable scheduler and no
+///   deadlock-recovery mechanism to enable. `--max-memory` etc. are NOT warned
+///   here -- the chain DOES honor them (`PipelineConfig::queue_memory_total`).
+/// * Serial path (`CopyUmi::warn_unwired_flags_on_serial_path`): ALL THREE are
+///   inert, because there is no chain/pipeline at all on this path -- only a
+///   plain read -> copy-umi -> write loop with no scheduler, no deadlock
+///   detector, and no queues to budget.
+///
+/// `--max-memory`/`--scheduler` on the serial path is what regresses if
+/// `warn_unwired_flags_on_serial_path` is reverted to reusing
+/// `common::warn_unwired_pipeline_flags` (issue: that reuse asserted a false
+/// "chain engine" rationale on a path with no chain engine, AND silently
+/// skipped the queue-memory flags, which -- unlike on the chain path -- really
+/// are inert here).
+#[rstest]
+#[case::deadlock_recover_serial(
+    &["--deadlock-recover"],
+    &[],
+    "--deadlock-recover has no effect on the single-threaded path"
+)]
+#[case::deadlock_recover_threads(
+    &["--deadlock-recover"],
+    &["--threads", "1"],
+    "--deadlock-recover has no effect in the typed-step pipeline"
+)]
+#[case::scheduler_serial(
+    &["--scheduler", "fixed-priority"],
+    &[],
+    "--scheduler has no effect on the single-threaded path"
+)]
+#[case::scheduler_threads(
+    &["--scheduler", "fixed-priority"],
+    &["--threads", "1"],
+    "--scheduler has no effect in the typed-step pipeline"
+)]
+#[case::queue_memory_serial(
+    &["--max-memory", "100M"],
+    &[],
+    "--max-memory/--memory-reserve/--memory-per-thread have no effect on the \
+     single-threaded path"
+)]
+fn unwired_pipeline_flags_warn_with_path_appropriate_wording(
+    #[case] flag_args: &[&str],
+    #[case] thread_args: &[&str],
+    #[case] expected_substring: &str,
+) {
+    let dir = TempDir::new().unwrap();
+    let input = write_input(dir.path(), &[record_named("blah:AAAA")]);
+    let output = dir.path().join("out.bam");
+
+    let mut extra_args: Vec<&str> = flag_args.to_vec();
+    extra_args.extend_from_slice(thread_args);
+    let stderr = run_and_capture_logs("copy-umi", &input, &output, &extra_args);
+
+    assert!(
+        stderr.lines().any(|line| line.contains(expected_substring)),
+        "expected a line containing {expected_substring:?}; got:\n{stderr}"
     );
 }
 

--- a/tests/integration/test_dedup_command.rs
+++ b/tests/integration/test_dedup_command.rs
@@ -24,6 +24,7 @@ use tempfile::TempDir;
 
 use crate::helpers::assertions::assert_bam_sorted;
 use crate::helpers::bam_generator::{create_minimal_header, to_record_buf};
+use crate::helpers::cli::run_and_capture_logs;
 
 /// Create a template-coordinate sorted BAM with UMI-tagged reads.
 ///
@@ -1851,6 +1852,80 @@ fn test_dedup_accepts_index_threshold_never() {
     // One template is the primary; the other two pairs are marked duplicates.
     let duplicates = never.iter().filter(|(_, flags, _)| flags & flags::DUPLICATE != 0).count();
     assert_eq!(duplicates, 4, "two of the three pairs must be marked duplicate: {never:?}");
+}
+
+/// The chain (`--threads N`) dedup path's `Index threshold:` startup banner must
+/// be strategy/edits-aware, matching the non-chain path's
+/// `common::log_index_threshold` wording exactly (see
+/// `test_index_threshold_log_message` in `commands::common` for the full case
+/// table) -- not the flat `Index threshold: {dedup.index_threshold}` (the raw
+/// `--index-threshold` value, unfloored) the chain path used to emit whenever
+/// `matches!(effective_strategy, Strategy::Adjacency | Strategy::Paired)`.
+///
+/// `old_flat_regression_line` is `Some(line)` only when the OLD `matches!`-gated
+/// flat `info!` would actually have printed something distinguishable from the
+/// NEW correct output for that case's exact config -- i.e. a string that WOULD
+/// reappear if `add_dedup` regressed back to the flat banner. It is `None` for
+/// the `edit`-strategy cases: the old `matches!` guard excluded `Edit`
+/// unconditionally (regardless of `--edits`/`--index-threshold`), so old code
+/// printed no `Index threshold:` line at all there -- the positive assertion
+/// alone (expecting a line that old code never emitted) already catches a
+/// regression, and asserting the absence of some placeholder string would be
+/// vacuous (never true or false, since the string was never on the table).
+#[rstest]
+#[case::edit_off_its_indexing_edits_reports_not_used(
+    &["--threads", "1", "--strategy", "edit", "--edits", "2"],
+    "Index threshold: not used (edit indexes only at --edits 1)",
+    None
+)]
+#[case::adjacency_off_its_indexing_edits_reports_not_used(
+    &["--threads", "1", "--strategy", "adjacency", "--edits", "2"],
+    "Index threshold: not used (adjacency indexes only at --edits 1)",
+    // Old code: `matches!(Adjacency, Adjacency | Paired)` is true, so it printed
+    // the raw `--index-threshold` (default 100) verbatim -- misleadingly implying
+    // the index is consulted at 2 mismatches, when adjacency only ever indexes at
+    // exactly 1.
+    Some("Index threshold: 100")
+)]
+#[case::edit_at_one_mismatch_reports_the_edit_floored_value(
+    &["--threads", "1", "--strategy", "edit", "--edits", "1", "--index-threshold", "50"],
+    "Index threshold: 200 (edit)",
+    None
+)]
+#[case::adjacency_default_edits_one_reports_the_flag_verbatim(
+    // CLI defaults: --strategy adjacency --edits 1 --index-threshold 100.
+    &["--threads", "1"],
+    "Index threshold: 100",
+    // Old code prints the SAME text here: Adjacency/Paired at edits == 1 report
+    // the raw flag verbatim in both old and new code (this is the one branch FIX
+    // A left byte-identical to the old flat banner), so there is no distinct
+    // flat-regression string to guard against -- this case instead pins that the
+    // ordinary default path still reports the plain numeric threshold, unfloored
+    // and un-annotated.
+    None
+)]
+fn test_dedup_chain_index_threshold_banner_is_strategy_aware(
+    #[case] extra_args: &[&str],
+    #[case] expected_line: &str,
+    #[case] old_flat_regression_line: Option<&str>,
+) {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    create_sorted_bam(&input_bam, create_duplicate_group("banner", "ACGTACGT", 2, 100));
+
+    let stderr = run_and_capture_logs("dedup", &input_bam, &output_bam, extra_args);
+    assert!(
+        stderr.lines().any(|line| line.contains(expected_line)),
+        "expected a line containing {expected_line:?}; got:\n{stderr}"
+    );
+    if let Some(old_line) = old_flat_regression_line {
+        assert!(
+            !stderr.lines().any(|line| line.trim_end() == old_line),
+            "must not emit {old_line:?}, the pre-fix flat, strategy-unaware banner \
+             for this exact config; got:\n{stderr}"
+        );
+    }
 }
 
 /// Corrupt the CRC32 footer of the LAST non-EOF BGZF block in `path`, in place.

--- a/tests/integration/test_group_command.rs
+++ b/tests/integration/test_group_command.rs
@@ -19,6 +19,7 @@ use crate::helpers::bam_generator::{
     create_minimal_header, create_query_grouped_header, create_umi_family,
     create_umi_family_at_pos, to_record_buf,
 };
+use crate::helpers::cli::run_and_capture_logs;
 use fgumi_lib::sam::SamTag;
 use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
 
@@ -459,6 +460,160 @@ fn test_group_chain_matches_single_threaded() {
     assert_eq!(
         single, chained,
         "chain (--threads 1) output must match the single-threaded fast path record-for-record",
+    );
+}
+
+/// Sibling of `dedup`'s `test_dedup_chain_index_threshold_banner_is_strategy_aware`:
+/// `group`'s non-chain path also reports the `Index threshold:` startup banner
+/// via the shared strategy/edits-aware `common::log_index_threshold` (see
+/// `group.rs`'s `execute`), so the chain path's banner must match it exactly --
+/// not the flat `Index threshold: {group.index_threshold}` (the raw
+/// `--index-threshold` value, unfloored) the chain path used to emit whenever
+/// `matches!(group.effective_strategy, Strategy::Adjacency | Strategy::Paired)`.
+///
+/// `old_flat_regression_line` is `Some(line)` only when the OLD `matches!`-gated
+/// flat `info!` would actually have printed something distinguishable from the
+/// NEW correct output for that case's exact config -- i.e. a string that WOULD
+/// reappear if `add_group` regressed back to the flat banner. It is `None` for
+/// the `edit`-strategy cases: the old `matches!` guard excluded `Edit`
+/// unconditionally (regardless of `--edits`/`--index-threshold`), so old code
+/// printed no `Index threshold:` line at all there -- the positive assertion
+/// alone (expecting a line that old code never emitted) already catches a
+/// regression, and asserting the absence of some placeholder string would be
+/// vacuous (never true or false, since the string was never on the table).
+#[rstest]
+#[case::edit_off_its_indexing_edits_reports_not_used(
+    &["--threads", "1", "--strategy", "edit", "--edits", "2"],
+    "Index threshold: not used (edit indexes only at --edits 1)",
+    None
+)]
+#[case::adjacency_off_its_indexing_edits_reports_not_used(
+    &["--threads", "1", "--strategy", "adjacency", "--edits", "2"],
+    "Index threshold: not used (adjacency indexes only at --edits 1)",
+    // Old code: `matches!(Adjacency, Adjacency | Paired)` is true, so it printed
+    // the raw `--index-threshold` (default 100) verbatim -- misleadingly implying
+    // the index is consulted at 2 mismatches, when adjacency only ever indexes at
+    // exactly 1.
+    Some("Index threshold: 100")
+)]
+#[case::edit_at_one_mismatch_reports_the_edit_floored_value(
+    &["--threads", "1", "--strategy", "edit", "--edits", "1", "--index-threshold", "50"],
+    "Index threshold: 200 (edit)",
+    None
+)]
+#[case::adjacency_default_edits_one_reports_the_flag_verbatim(
+    // `--strategy` is mandatory for `group` (no CLI default), so this pins
+    // adjacency at its own edits/index-threshold defaults (1 / 100) -- the most
+    // ordinary config, not covered by any `edit`-strategy case above.
+    &["--threads", "1", "--strategy", "adjacency"],
+    "Index threshold: 100",
+    // Old code prints the SAME text here: Adjacency/Paired at edits == 1 report
+    // the raw flag verbatim in both old and new code (this is the one branch FIX
+    // A left byte-identical to the old flat banner), so there is no distinct
+    // flat-regression string to guard against -- this case instead pins that the
+    // ordinary default path still reports the plain numeric threshold, unfloored
+    // and un-annotated.
+    None
+)]
+fn test_group_chain_index_threshold_banner_is_strategy_aware(
+    #[case] extra_args: &[&str],
+    #[case] expected_line: &str,
+    #[case] old_flat_regression_line: Option<&str>,
+) {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    create_test_input_bam(&input_bam);
+    let output_bam = temp_dir.path().join("output.bam");
+
+    let stderr = run_and_capture_logs("group", &input_bam, &output_bam, extra_args);
+    assert!(
+        stderr.lines().any(|line| line.contains(expected_line)),
+        "expected a line containing {expected_line:?}; got:\n{stderr}"
+    );
+    if let Some(old_line) = old_flat_regression_line {
+        assert!(
+            !stderr.lines().any(|line| line.trim_end() == old_line),
+            "must not emit {old_line:?}, the pre-fix flat, strategy-unaware banner \
+             for this exact config; got:\n{stderr}"
+        );
+    }
+}
+
+/// `Strategy::Paired` companion to
+/// `test_group_chain_index_threshold_banner_is_strategy_aware`. Paired grouping
+/// requires valid two-segment UMIs and proper paired-end templates, so it
+/// cannot share that test's single-end `create_test_input_bam` fixture and runs
+/// on its own paired-UMI input instead. Paired at the default `--edits 1`
+/// reports the raw `--index-threshold` verbatim in both old and new code (the
+/// one branch FIX A left byte-identical to the old flat banner), so — like the
+/// `adjacency_default_edits_one` case — there is no distinct flat-regression
+/// string to guard against; this case pins that the chain path still emits the
+/// `Index threshold:` startup banner for the paired strategy at all.
+#[test]
+fn test_group_chain_index_threshold_banner_paired_strategy() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+
+    // Paired-end templates with a valid two-segment (`-`-delimited) UMI so
+    // `--strategy paired` accepts them, and `MC` tags (mate CIGAR) so the
+    // position grouper accepts the paired reads (it requires `MC` on paired-end
+    // input). All pairs share one UMI at the same 5' positions, so they form one
+    // molecule group and the fixture is already template-coordinate ordered.
+    let header = create_minimal_header("chr1", 10000);
+    let paired = |name: &[u8]| -> Vec<RawRecord> {
+        let mut r1 = SamBuilder::new();
+        r1.read_name(name)
+            .ref_id(0)
+            .pos(199)
+            .mapq(60)
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .mate_ref_id(0)
+            .mate_pos(399)
+            .cigar_ops(&[8u32 << 4])
+            .sequence(b"ACGTACGT")
+            .qualities(&[30u8; 8])
+            .add_string_tag(SamTag::RX, b"AAAA-TTTT")
+            .add_string_tag(SamTag::MC, b"8M");
+        let mut r2 = SamBuilder::new();
+        r2.read_name(name)
+            .ref_id(0)
+            .pos(399)
+            .mapq(60)
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .mate_ref_id(0)
+            .mate_pos(199)
+            .cigar_ops(&[8u32 << 4])
+            .sequence(b"ACGTACGT")
+            .qualities(&[30u8; 8])
+            .add_string_tag(SamTag::RX, b"AAAA-TTTT")
+            .add_string_tag(SamTag::MC, b"8M");
+        vec![r1.build(), r2.build()]
+    };
+
+    let mut records = paired(b"paired_fam_0");
+    records.extend(paired(b"paired_fam_1"));
+    records.extend(paired(b"paired_fam_2"));
+
+    let mut writer =
+        bam::io::Writer::new(fs::File::create(&input_bam).expect("Failed to create BAM file"));
+    writer.write_header(&header).expect("Failed to write header");
+    for record in &records {
+        writer
+            .write_alignment_record(&header, &to_record_buf(record))
+            .expect("Failed to write record");
+    }
+    writer.try_finish().expect("Failed to finish BAM");
+
+    let stderr = run_and_capture_logs(
+        "group",
+        &input_bam,
+        &output_bam,
+        &["--threads", "1", "--strategy", "paired"],
+    );
+    assert!(
+        stderr.lines().any(|line| line.contains("Index threshold:")),
+        "expected the paired strategy to emit an `Index threshold:` startup banner; got:\n{stderr}"
     );
 }
 


### PR DESCRIPTION
## What

Restores three diagnostics the chain path dropped or got wrong versus the legacy path. All changes are log/doc-only — no record output changes. This is groundwork for retiring the legacy single-threaded paths (once removed, the chain path is the only path, so its diagnostics must match first).

## Changes

- **dedup + group index-threshold banner** (`src/lib/pipeline/chains/builder.rs`): both chain banners logged a flat `Index threshold: {value}`, which is wrong for `--strategy edit` (logs a meaningless value) and misleading for `adjacency --edits 2`. They now call the shared strategy/edits-aware `common::log_index_threshold(...)` the legacy paths use, so all four combinations agree. Both dedup and group were fixed (group's legacy path uses the same helper — sibling parity).
- **copy_umi serial-path inert-flag warning** (`src/lib/commands/copy_umi.rs`): the no-`--threads` serial path silently ignored `--scheduler`, `--deadlock-recover`, and the `--max-memory`/`--memory-reserve`/`--memory-per-thread` queue-memory flags. It now warns for each (when set to a non-default) with wording accurate to the serial context ("has no effect on the single-threaded path; run with --threads to use the pipeline"). This is a copy_umi-local helper — the shared `common::warn_unwired_pipeline_flags` (which describes the chain engine and is correct for its chain callers) is left untouched.
- **pair_fastq docstring** (`src/lib/pipeline/steps/source/pair_fastq.rs`): the `out_of_sync_error` docstring falsely claimed all detection paths "surface byte-for-byte identical diagnostics." Reworded to state accurately that the same out-of-sync condition is detected on every path but the wording differs; the byte-identical claim is scoped to this file's two call sites. Doc-only.

## Tests

Subprocess-level (spawn the real `fgumi` binary, assert on captured stderr — the in-process log-capture harness isn't reachable from the integration-test crate), via a new shared `helpers/cli.rs::run_and_capture_logs` (dedups three near-identical spawn helpers):
- dedup + group index-threshold banner: strategy/edits-aware cases including the default `adjacency --edits 1` verbatim-value branch. The negative guards assert absence of the exact flat-banner string the pre-fix code would have emitted for each case's config (not a vacuous never-matching literal), so a regression to the flat banner fails the test.
- copy_umi inert-flag warnings on the serial path: `--deadlock-recover` (serial + chain, distinct wording each), `--scheduler`, and `--max-memory`.

Full gate green: `cargo ci-test` 9965 passed / 31 skipped, plus `ci-fmt`/`ci-lint`/`ci-doc` and `--no-default-features`/`--all-features`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: grouping, consensus, sort order, corrected UMIs, and metrics output are unchanged; diagnostic changes are pinned by shared strategy-aware logging and integration tests; unsafe changes are none and CLAUDE.md updates are not applicable; memory, queue capacity, and thread/backpressure policy changes are none.

Fix: Restore diagnostic parity across chain and legacy paths.

- Add serial `copy_umi` warnings for inert scheduler, deadlock-recovery, and queue-memory options.
- Use shared index-threshold logging for deduplication and grouping.
- Correct the `pair_fastq` `out_of_sync_error` documentation.
- Add subprocess integration tests and shared CLI log-capture helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->