### PR TITLE
feat(clip): produce --metrics on the multi-threaded chain path

### DIFF
--- a/crates/fgumi-metrics/src/clip.rs
+++ b/crates/fgumi-metrics/src/clip.rs
@@ -307,6 +307,23 @@ impl ClippingMetricsCollection {
         }
     }
 
+    /// Merges another collection's raw `fragment`/`read_one`/`read_two` counters
+    /// into `self`.
+    ///
+    /// Deliberately does NOT touch `pair`/`all` — those are derived aggregates
+    /// that [`Self::finalize`] computes from the raw counters, so callers that
+    /// accumulate per-thread collections (e.g. the chain `--threads` clip path)
+    /// must merge every collection first and call `finalize` exactly once on the
+    /// merged total. That mirrors the single-threaded oracle's call sequence
+    /// (accumulate through the whole run, then finalize once at the end), so the
+    /// reported `pair`/`all` totals are identical regardless of how work was
+    /// sharded across threads.
+    pub fn merge(&mut self, other: &ClippingMetricsCollection) {
+        self.fragment.add(&other.fragment);
+        self.read_one.add(&other.read_one);
+        self.read_two.add(&other.read_two);
+    }
+
     /// Finalizes metrics by aggregating pair and all categories
     pub fn finalize(&mut self) {
         // Aggregate ReadOne and ReadTwo into Pair
@@ -322,6 +339,23 @@ impl ClippingMetricsCollection {
     #[must_use]
     pub fn all_metrics(&self) -> [&ClippingMetrics; 5] {
         [&self.fragment, &self.read_one, &self.read_two, &self.pair, &self.all]
+    }
+
+    /// Finalizes this collection (see [`Self::finalize`]) and writes the five-row
+    /// clipping-metrics TSV to `path`.
+    ///
+    /// Shared by the `clip` command's single-threaded oracle and the chain
+    /// `--threads` path's success-only finalize hook, so the
+    /// finalize → row-order → write sequence exists exactly once and the two
+    /// paths' metrics output cannot drift apart.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `path` cannot be created or written to.
+    pub fn finalize_and_write<P: AsRef<std::path::Path>>(&mut self, path: P) -> anyhow::Result<()> {
+        self.finalize();
+        let rows = self.all_metrics().map(Clone::clone);
+        crate::writer::write_metrics(path, &rows, "clipping")
     }
 }
 
@@ -526,6 +560,60 @@ mod tests {
     fn test_clipping_metrics_collection_default() {
         let collection = ClippingMetricsCollection::default();
         assert_eq!(collection.fragment.reads, 0);
+    }
+
+    #[test]
+    fn test_clipping_metrics_collection_merge() {
+        // Two "worker" collections, each with raw fragment/read_one/read_two
+        // counters populated but never finalized (mirrors per-thread accumulator
+        // slots mid-run).
+        let mut worker_a = ClippingMetricsCollection::new();
+        let mut worker_b = ClippingMetricsCollection::new();
+
+        let record = create_test_record("90M", false);
+        worker_a.read_one.update(&record, ClipCounts { five_prime: 10, ..ClipCounts::default() });
+        worker_a.fragment.update(&record, ClipCounts { prior: 2, ..ClipCounts::default() });
+
+        worker_b.read_one.update(&record, ClipCounts { three_prime: 4, ..ClipCounts::default() });
+        worker_b.read_two.update(&record, ClipCounts { overlapping: 6, ..ClipCounts::default() });
+
+        let mut merged = ClippingMetricsCollection::new();
+        merged.merge(&worker_a);
+        merged.merge(&worker_b);
+
+        // Raw per-category counters are summed across both workers.
+        assert_eq!(merged.fragment.reads, 1);
+        assert_eq!(merged.fragment.bases_clipped_pre, 2);
+        assert_eq!(merged.read_one.reads, 2);
+        assert_eq!(merged.read_one.bases_clipped_five_prime, 10);
+        assert_eq!(merged.read_one.bases_clipped_three_prime, 4);
+        assert_eq!(merged.read_two.reads, 1);
+        assert_eq!(merged.read_two.bases_clipped_overlapping, 6);
+
+        // pair/all are untouched by merge (still zero) until finalize runs once
+        // on the merged total.
+        assert_eq!(merged.pair.reads, 0);
+        assert_eq!(merged.all.reads, 0);
+
+        merged.finalize();
+        assert_eq!(merged.pair.reads, 3); // read_one (2) + read_two (1)
+        assert_eq!(merged.all.reads, 4); // fragment (1) + pair (3)
+
+        // Merging then finalizing once must equal updating a single collection
+        // directly with the same operations (the property the chain path relies
+        // on: cross-worker sharding cannot change the reported totals).
+        let mut direct = ClippingMetricsCollection::new();
+        direct.read_one.update(&record, ClipCounts { five_prime: 10, ..ClipCounts::default() });
+        direct.fragment.update(&record, ClipCounts { prior: 2, ..ClipCounts::default() });
+        direct.read_one.update(&record, ClipCounts { three_prime: 4, ..ClipCounts::default() });
+        direct.read_two.update(&record, ClipCounts { overlapping: 6, ..ClipCounts::default() });
+        direct.finalize();
+
+        assert_eq!(merged.fragment.reads, direct.fragment.reads);
+        assert_eq!(merged.read_one.reads, direct.read_one.reads);
+        assert_eq!(merged.read_two.reads, direct.read_two.reads);
+        assert_eq!(merged.pair.reads, direct.pair.reads);
+        assert_eq!(merged.all.reads, direct.all.reads);
     }
 
     #[test]

--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -8,7 +8,6 @@ use crate::alignment_tags::regenerate_alignment_tags_raw;
 use crate::clipper::{ClippingMode, RawRecordClipper};
 use crate::logging::OperationTimer;
 use crate::metrics::clip::{ClipCounts, ClippingMetricsCollection};
-use crate::metrics::writer::write_metrics as write_metrics_tsv;
 use crate::reference::ReferenceReader;
 use crate::sam::SamTag;
 use crate::template::{InsertSizeEnd, TemplateIterator, compute_insert_size_from_ends};
@@ -119,8 +118,8 @@ pub struct Clip {
     #[arg(short = 'a', long = "auto-clip-attributes", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub auto_clip_attributes: bool,
 
-    /// Output file for clipping metrics (only produced by the single-threaded path; cannot be
-    /// combined with --threads)
+    /// Output file for clipping metrics (produced on both the single-threaded and
+    /// --threads paths)
     #[arg(short = 'm', long = "metrics")]
     pub metrics: Option<PathBuf>,
 
@@ -202,8 +201,10 @@ impl ClipParams {
     ///
     /// This is the single shared implementation used by both the single-threaded and
     /// multi-threaded clip paths. When `metrics` is `Some`, per-read base-clip counts are
-    /// accumulated (single-threaded metrics output); the multi-threaded path passes `None` and
-    /// relies solely on the returned per-template flags.
+    /// accumulated into it. The single-threaded path always passes a collector when
+    /// `--metrics` is set; the multi-threaded path passes the calling worker's
+    /// `PerThreadAccumulator` slot when `--metrics` is set and `None` otherwise, relying
+    /// solely on the returned per-template flags for its atomic summary counters.
     ///
     /// Returns `(overlap_clipped, extend_clipped)`: whether overlap and/or mate-extension
     /// clipping removed any bases from the pair. A lone fragment returns `(false, false)`, as do
@@ -482,24 +483,12 @@ impl Command for Clip {
             anyhow::bail!("At least one clipping option is required");
         }
 
-        // --metrics is not produced in --threads mode; fail fast rather than
-        // silently dropping a user-requested output file. Reader-free, so it runs
-        // before the chain dispatch below (add_clip re-checks it, but failing here
-        // keeps the error identical whether or not the chain path is taken).
-        if self.threading.threads.is_some()
-            && let Some(path) = &self.metrics
-        {
-            anyhow::bail!(
-                "--metrics {} cannot be used with --threads: detailed clipping metrics \
-                     are only produced by the single-threaded path",
-                path.display()
-            );
-        }
-
         // --threads N: run the clip stage on the declarative chain builder. Dispatch
-        // here — after the reader-free pre-flight above (output collisions, input +
-        // reference existence, clipping-option and --metrics validation), which must
-        // run for both paths — but BEFORE the banner / timer / reader below.
+        // here — after the reader-free pre-flight above (output collisions, including
+        // --metrics; input + reference existence; clipping-option validation), which
+        // must run for both paths — but BEFORE the banner / timer / reader below.
+        // `--metrics` itself is no longer rejected under `--threads`: `add_clip`
+        // collects detailed metrics on the chain path too (see `execute_chain`).
         // execute_chain → add_clip re-emits the banner, timer, and threading log
         // lines, re-enforces require_query_grouped, and opens its own source, so
         // running them here too would double-log and pre-consume stdin. The
@@ -533,12 +522,15 @@ impl Clip {
     /// (`ChainSpec::single_stage(Stage::Clip, ...)` → `build_for(spec)?.run()`).
     ///
     /// `add_clip` opens its own source, re-emits the timer/banner/threading log
-    /// lines, reloads the reference, re-validates the clipping options and the
-    /// `--metrics`/`--threads` combination, and re-enforces `require_query_grouped`,
-    /// so none of those may run again here — only the CRC-verify status line, which
-    /// `add_clip` does not re-emit. The no-`--threads` path in `execute` keeps its
-    /// own single-threaded engine, which is the in-process parity oracle for this
-    /// one (see `test_clip_chain_matches_single_threaded`).
+    /// lines, reloads the reference, re-validates the clipping options, and
+    /// re-enforces `require_query_grouped`, so none of those may run again here —
+    /// only the CRC-verify status line, which `add_clip` does not re-emit. The
+    /// no-`--threads` path in `execute` keeps its own single-threaded engine,
+    /// which is the in-process parity oracle for this one (see
+    /// `test_clip_chain_matches_single_threaded`). `--metrics` is produced on both
+    /// paths: `add_clip` builds a per-thread `ClippingMetricsCollection`
+    /// accumulator when `self.metrics.is_some()` and reduces it in a
+    /// success-only finalize hook.
     fn execute_chain(&self, command_line: &str) -> Result<()> {
         use crate::pipeline::chains::{
             ChainSpec, SingleStageContext, Stage, StageOptionsBag, build_for,
@@ -653,15 +645,14 @@ impl Clip {
         info!("Templates with overlap clipping: {total_clipped_overlap}");
         info!("Templates with mate extension clipping: {total_clipped_mate_extension}");
 
-        // Write metrics if requested
+        // Write metrics if requested. `finalize_and_write` (shared with the chain
+        // `--threads` path's `ClipMetricsFinalizeHook`) aggregates pair/all and
+        // writes the TSV in one call, so the two paths' metrics output cannot drift.
         if let Some(metrics_path) = &self.metrics
             && let Some(mut metrics) = metrics_collection
         {
-            info!("Writing metrics to {}", metrics_path.display());
-            metrics.finalize();
-            let all_metrics = metrics.all_metrics().map(Clone::clone);
-            write_metrics_tsv(metrics_path, &all_metrics, "clipping")?;
-            info!("Metrics written successfully");
+            metrics.finalize_and_write(metrics_path)?;
+            info!("Wrote metrics to: {}", metrics_path.display());
         }
 
         // Flush and finish the writer

--- a/src/lib/per_thread_accumulator.rs
+++ b/src/lib/per_thread_accumulator.rs
@@ -164,4 +164,69 @@ mod tests {
         assert_eq!(slots.len(), 4);
         assert_eq!(slots.iter().map(|c| c.0).sum::<u64>(), 7);
     }
+
+    /// Regression guard for the clip `--metrics` chain path
+    /// (`ClipMetricsFinalizeHook`): a reduction bug that summed only a *subset*
+    /// of `PerThreadAccumulator` slots (e.g. an off-by-one `.take(n)`, or
+    /// iterating a stale slice) would silently drop a worker's contribution and
+    /// undercount the merged metrics. `parallel_threads_share_total_count`
+    /// above proves the *sum* is right; this test additionally proves the sum
+    /// is right *because multiple genuinely distinct slots were populated* —
+    /// directly inspecting slot occupancy via `slots()`, exactly as
+    /// `ClipMetricsFinalizeHook::finalize` does — not merely because the writes
+    /// happened to collapse into one slot that a buggy partial reduction would
+    /// still catch.
+    ///
+    /// Spawns `N_THREADS` real (never-before-used) OS threads via
+    /// `thread::scope`; each is assigned a fresh, sequential index by the
+    /// process-wide `SLOT_COUNTER` on its first `with_slot` call, so — modulo
+    /// any other test in this binary racing the same global counter, which
+    /// would if anything spread the indices further apart, not collapse them —
+    /// these threads land across more than one of the `N_THREADS` slots.
+    #[test]
+    fn parallel_threads_populate_and_merge_distinct_clip_metrics_slots() {
+        use crate::metrics::clip::{ClipCounts, ClippingMetricsCollection};
+        use fgumi_sam::builder::RecordBuilder;
+
+        const N_THREADS: usize = 8;
+        let acc: Arc<PerThreadAccumulator<ClippingMetricsCollection>> =
+            PerThreadAccumulator::new(N_THREADS);
+        let record = RecordBuilder::new().cigar("90M").build();
+
+        thread::scope(|s| {
+            for i in 0..N_THREADS {
+                let acc = Arc::clone(&acc);
+                let record = record.clone();
+                s.spawn(move || {
+                    acc.with_slot(|slot: &mut ClippingMetricsCollection| {
+                        slot.read_one.update(
+                            &record,
+                            ClipCounts { five_prime: i + 1, ..ClipCounts::default() },
+                        );
+                    });
+                });
+            }
+        });
+
+        // Slot occupancy: more than one PerThreadAccumulator slot actually
+        // received data, proving the concurrent threads landed in genuinely
+        // different slots rather than all serializing onto one.
+        let populated_slots = acc.slots().iter().filter(|m| m.lock().read_one.reads > 0).count();
+        assert!(
+            populated_slots > 1,
+            "expected more than one PerThreadAccumulator slot to be populated by \
+             {N_THREADS} concurrent OS threads, got {populated_slots}",
+        );
+
+        // Reducing every slot (mirrors ClipMetricsFinalizeHook::finalize: merge
+        // each slot, in order, into one collection) recovers the exact combined
+        // total. A reduction that skipped any slot would undercount both.
+        let mut merged = ClippingMetricsCollection::new();
+        for slot in acc.slots() {
+            merged.merge(&slot.lock());
+        }
+        let expected_five_prime: usize = (1..=N_THREADS).sum();
+        assert_eq!(merged.read_one.reads, N_THREADS);
+        assert_eq!(merged.read_one.bases_clipped_five_prime, expected_five_prime);
+    }
 }

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -4062,16 +4062,17 @@ impl<'a> ChainBuilder<'a> {
     /// query-grouped order it requires on input), matching `main`'s non-chain
     /// clip, which writes `&header` unchanged.
     ///
-    /// Registers a `ClipFinalizeHook` for metrics logging + timer.
-    /// The chain-level [`StageTimingFinalizeHook`] is registered by
-    /// [`Self::build`] (not here), so it captures the correct `Instant`.
+    /// Registers a `ClipFinalizeHook` for summary banner + timer, and — when
+    /// `--metrics` is set — a success-only `ClipMetricsFinalizeHook` that reduces
+    /// the per-thread detailed `ClippingMetricsCollection` accumulator and writes
+    /// the metrics TSV. The chain-level [`StageTimingFinalizeHook`] is registered
+    /// by [`Self::build`] (not here), so it captures the correct `Instant`.
     ///
     /// # Errors
     ///
     /// Returns errors if clip options are missing from the spec bag, if the
-    /// reference FASTA is absent, if no clipping operation is requested, if
-    /// `--metrics` is used with `--threads` mode, or if `position` is
-    /// `Intermediate` (not yet implemented).
+    /// reference FASTA is absent, if no clipping operation is requested, or if
+    /// `position` is `Intermediate` (not yet implemented).
     ///
     /// [`DecompressedBlock`]: crate::pipeline::steps::types::DecompressedBlock
     /// [`BamTemplateBatch`]: crate::pipeline::steps::types::BamTemplateBatch
@@ -4079,9 +4080,11 @@ impl<'a> ChainBuilder<'a> {
     fn add_clip(&mut self, position: StagePosition) -> Result<()> {
         use crate::commands::common::warn_unwired_pipeline_flags;
         use crate::logging::OperationTimer;
+        use crate::metrics::clip::ClippingMetricsCollection;
+        use crate::per_thread_accumulator::PerThreadAccumulator;
         use crate::pipeline::chains::commands::clip::{
-            ClipAtomicMetrics, ClipFinalizeHook, ClipProcessCaptures, build_clip_process_step,
-            build_clip_serialize_step,
+            ClipAtomicMetrics, ClipFinalizeHook, ClipMetricsFinalizeHook, ClipProcessCaptures,
+            build_clip_process_step, build_clip_serialize_step,
         };
         use crate::pipeline::steps::group::bam::GroupBam;
         use log::info;
@@ -4135,16 +4138,7 @@ impl<'a> ChainBuilder<'a> {
             bail!("At least one clipping option is required");
         }
 
-        // --metrics is not produced in --threads mode; fail fast rather than
-        // silently dropping a user-requested output file.
         let num_threads = self.spec.threading.num_threads();
-        if let Some(path) = &clip.metrics {
-            anyhow::bail!(
-                "--metrics {} cannot be used with --threads: detailed clipping metrics \
-                 are only produced by the single-threaded path",
-                path.display()
-            );
-        }
 
         // fgbio's ClipBam requires query-grouped input (a template's reads must be
         // adjacent). Both legacy clip paths enforce this — `execute_single_threaded`
@@ -4187,6 +4181,20 @@ impl<'a> ChainBuilder<'a> {
         let metrics = Arc::new(ClipAtomicMetrics::default());
         let progress_counter = Arc::new(std::sync::atomic::AtomicU64::new(0));
 
+        // Per-thread detailed `--metrics` accumulator, bundled with the metrics
+        // path in one `Option` — built only when `--metrics` is requested, one
+        // slot per worker thread, merged by `ClipMetricsFinalizeHook` (success-only)
+        // exactly like the single-threaded oracle's `ClippingMetricsCollection`.
+        // Bundling means the "accumulator and path are both Some or both None"
+        // invariant is structural (a single `Option`, not two kept in sync), so
+        // the finalize-hook registration below never needs to prove it via `.expect()`.
+        let metrics_target: Option<(
+            Arc<PerThreadAccumulator<ClippingMetricsCollection>>,
+            std::path::PathBuf,
+        )> = clip.metrics.clone().map(|path| {
+            (PerThreadAccumulator::<ClippingMetricsCollection>::new(num_threads.max(1)), path)
+        });
+
         // ── Step factories (see chains::commands::clip) ──────────────────
         let process_step = build_clip_process_step(
             self.tuning.per_step_byte_limit,
@@ -4198,6 +4206,7 @@ impl<'a> ChainBuilder<'a> {
                 reference: Arc::clone(&reference),
                 metrics: Arc::clone(&metrics),
                 progress: Arc::clone(&progress_counter),
+                metrics_accumulator: metrics_target.as_ref().map(|(acc, _)| Arc::clone(acc)),
             },
         );
         let serialize_step = build_clip_serialize_step(self.tuning.per_step_byte_limit);
@@ -4216,6 +4225,15 @@ impl<'a> ChainBuilder<'a> {
         // build() after all stages have been added — that way a single timer
         // covers the full pipeline run regardless of how many stages there are.
         self.finalize.push(Box::new(ClipFinalizeHook { metrics, progress_counter, timer }));
+
+        // Success-only: reduce the per-thread `--metrics` accumulator and write
+        // the TSV. A failed/partial run publishes no stale metrics file, matching
+        // the single-threaded oracle (which only reaches its metrics-write code
+        // after a fully successful pass over the input).
+        if let Some((accumulator, metrics_path)) = metrics_target {
+            self.finalize_on_success
+                .push(Box::new(ClipMetricsFinalizeHook { accumulator, metrics_path }));
+        }
 
         Ok(())
     }

--- a/src/lib/pipeline/chains/commands/clip.rs
+++ b/src/lib/pipeline/chains/commands/clip.rs
@@ -8,6 +8,7 @@
 //! step-factory functions used by `ChainBuilder::add_clip`.
 
 use std::io;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -15,7 +16,10 @@ use anyhow::Result;
 use log::info;
 
 use crate::clipper::RawRecordClipper;
+use crate::commands::clip::ClipParams;
 use crate::logging::OperationTimer;
+use crate::metrics::clip::ClippingMetricsCollection;
+use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::pipeline::chains::FinalizeHook;
 use crate::pipeline::steps::process::{ProcessOrdered, process_ordered};
 use crate::pipeline::steps::serialize::SerializeBamRecords;
@@ -85,6 +89,47 @@ impl FinalizeHook for ClipFinalizeHook {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// ClipMetricsFinalizeHook
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Success-only finalize hook: reduces the per-thread `--metrics` accumulator
+/// and writes the detailed clipping-metrics TSV. Registered on
+/// `finalize_on_success` (not the always-run `finalize` list) so a
+/// failed/partial run publishes no stale metrics file — matching the
+/// single-threaded oracle, which only reaches its metrics-write code after a
+/// fully successful pass over the input.
+///
+/// Reduction mirrors the single-threaded oracle's call sequence exactly: each
+/// worker's slot holds raw (unfinalized) `fragment`/`read_one`/`read_two`
+/// counters (see [`ClippingMetricsCollection::merge`]), which are summed
+/// across all slots into one collection and then finalized/written via
+/// [`ClippingMetricsCollection::finalize_and_write`] — the same helper the
+/// single-threaded oracle calls, so the two paths' metrics output cannot drift
+/// apart — with `finalize` running exactly once, after every slot is merged
+/// (the same order the oracle uses: accumulate, then finalize once at the
+/// end). That makes the `pair`/`all` aggregates the TSV reports byte-for-byte
+/// reproducible regardless of how work was sharded across threads.
+pub(crate) struct ClipMetricsFinalizeHook {
+    pub(crate) accumulator: Arc<PerThreadAccumulator<ClippingMetricsCollection>>,
+    pub(crate) metrics_path: PathBuf,
+}
+
+impl FinalizeHook for ClipMetricsFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let ClipMetricsFinalizeHook { accumulator, metrics_path } = *self;
+
+        let mut merged = ClippingMetricsCollection::new();
+        for slot in accumulator.slots() {
+            merged.merge(&slot.lock());
+        }
+        merged.finalize_and_write(&metrics_path)?;
+        info!("Wrote metrics to: {}", metrics_path.display());
+
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Step factories — extracted from build_clip_chain (T3a.5).
 //
 // Each factory receives its captured state as plain arguments and returns the
@@ -111,11 +156,16 @@ pub(crate) struct ClipProcessCaptures {
     pub(crate) auto_clip_attributes: bool,
     /// The per-template clip configuration, shared verbatim with the
     /// single-threaded `Clip::execute` path (its in-process parity oracle).
-    pub(crate) params: crate::commands::clip::ClipParams,
+    pub(crate) params: ClipParams,
     pub(crate) header: noodles::sam::Header,
     pub(crate) reference: Arc<ReferenceReader>,
     pub(crate) metrics: Arc<ClipAtomicMetrics>,
     pub(crate) progress: Arc<AtomicU64>,
+    /// Per-thread detailed `--metrics` accumulator. `None` when `--metrics` was
+    /// not requested, in which case the hot-path closure passes `None` into
+    /// `clip_template` and skips detailed collection entirely (the fast path is
+    /// unchanged from before this field existed).
+    pub(crate) metrics_accumulator: Option<Arc<PerThreadAccumulator<ClippingMetricsCollection>>>,
 }
 
 /// Build the `ClipTemplates` step: parallel, `ByItemOrdinal`. Operates in
@@ -137,8 +187,6 @@ pub(crate) fn build_clip_process_step(
         "ClipTemplates",
         limit_bytes,
         move |batch: BamTemplateBatch| -> io::Result<BamTemplateBatch> {
-            use crate::alignment_tags::regenerate_alignment_tags_raw;
-
             // Per-worker clipper: cheap to construct (no large state).
             let clipper = if cap.auto_clip_attributes {
                 RawRecordClipper::with_auto_clip(cap.clipping_mode, true)
@@ -147,48 +195,33 @@ pub(crate) fn build_clip_process_step(
             };
 
             let (batch_serial, mut templates) = batch.into_parts();
-            let mut local_templates: u64 = 0;
-            let mut local_overlap_clipped: u64 = 0;
-            let mut local_extend_clipped: u64 = 0;
-            let mut local_record_count: u64 = 0;
 
-            for template in &mut templates {
-                local_templates += 1;
-                // Mutate the template's records in place. The earlier
-                // version of this closure cloned `template.name` and
-                // re-allocated a fresh `Template` per template — that
-                // showed up as ~6% extra mimalloc CPU in profiling
-                // (mi_page_free_list_extend, mi_free) and pushed the
-                // new pipeline ~7% behind legacy at threads=4. Mutating
-                // in place keeps allocation count near-equal to legacy.
-                let records: &mut Vec<RawRecord> = &mut template.records;
-
-                // Delegate to the canonical per-template clip implementation —
-                // the exact code the single-threaded `Clip::execute` oracle runs
-                // (`ClipParams::clip_template`). It finds the primary pair by SAM
-                // flag (so secondary/supplementary reads are handled, not just
-                // records[0]/[1]), applies fixed clipping with "ensure at least N
-                // including existing clipping" semantics (not "clip N more"), and
-                // repairs mate info. The `--metrics` detailed collection is never
-                // produced under `--threads` (rejected up front), so pass `None`
-                // and use the returned per-template flags for the atomic counters.
-                let (overlap_clipped, extend_clipped) =
-                    cap.params.clip_template(records, &clipper, None).map_err(io::Error::other)?;
-                if overlap_clipped {
-                    local_overlap_clipped += 1;
-                }
-                if extend_clipped {
-                    local_extend_clipped += 1;
-                }
-
-                // Regenerate alignment tags for every record (matches the oracle).
-                for record in records.iter_mut() {
-                    regenerate_alignment_tags_raw(record.as_mut_vec(), &cap.header, &cap.reference)
-                        .map_err(io::Error::other)?;
-                }
-
-                local_record_count += records.len() as u64;
-            }
+            // When `--metrics` is requested, run the batch under this worker's
+            // `PerThreadAccumulator` slot so `clip_template` collects detailed
+            // per-read base-clip counts (exactly like the single-threaded oracle);
+            // otherwise pass `None` and stay on the fast, collection-free path.
+            let (local_templates, local_overlap_clipped, local_extend_clipped, local_record_count) =
+                if let Some(accumulator) = &cap.metrics_accumulator {
+                    accumulator.with_slot(|slot| {
+                        clip_templates_in_batch(
+                            &mut templates,
+                            &cap.params,
+                            &clipper,
+                            &cap.header,
+                            &cap.reference,
+                            Some(slot),
+                        )
+                    })?
+                } else {
+                    clip_templates_in_batch(
+                        &mut templates,
+                        &cap.params,
+                        &clipper,
+                        &cap.header,
+                        &cap.reference,
+                        None,
+                    )?
+                };
 
             // Aggregate metrics (relaxed atomics, lock-free).
             cap.metrics.total_templates.fetch_add(local_templates, Ordering::Relaxed);
@@ -206,6 +239,76 @@ pub(crate) fn build_clip_process_step(
             Ok(BamTemplateBatch::new(batch_serial, templates))
         },
     )
+}
+
+/// Clips every template in a batch in place, optionally accumulating detailed
+/// per-read base-clip counts into `metrics`.
+///
+/// Shared by both the `--metrics`-enabled and fast (`None`) call sites in
+/// [`build_clip_process_step`] so the per-template loop — clip, then
+/// regenerate alignment tags — exists exactly once. `metrics` is reborrowed
+/// on each iteration via `as_deref_mut` so the same `&mut ClippingMetricsCollection`
+/// (the calling worker's `PerThreadAccumulator` slot) accumulates across the
+/// whole batch.
+///
+/// Returns `(templates, overlap_clipped, extend_clipped, records)` counts for
+/// the batch, for the caller to fold into the chain's atomic summary counters
+/// and progress tracker.
+fn clip_templates_in_batch(
+    templates: &mut [crate::template::Template],
+    params: &ClipParams,
+    clipper: &RawRecordClipper,
+    header: &noodles::sam::Header,
+    reference: &ReferenceReader,
+    mut metrics: Option<&mut ClippingMetricsCollection>,
+) -> io::Result<(u64, u64, u64, u64)> {
+    use crate::alignment_tags::regenerate_alignment_tags_raw;
+
+    let mut local_templates: u64 = 0;
+    let mut local_overlap_clipped: u64 = 0;
+    let mut local_extend_clipped: u64 = 0;
+    let mut local_record_count: u64 = 0;
+
+    for template in templates.iter_mut() {
+        local_templates += 1;
+        // Mutate the template's records in place. The earlier
+        // version of this closure cloned `template.name` and
+        // re-allocated a fresh `Template` per template — that
+        // showed up as ~6% extra mimalloc CPU in profiling
+        // (mi_page_free_list_extend, mi_free) and pushed the
+        // new pipeline ~7% behind legacy at threads=4. Mutating
+        // in place keeps allocation count near-equal to legacy.
+        let records: &mut Vec<RawRecord> = &mut template.records;
+
+        // Delegate to the canonical per-template clip implementation — the exact
+        // code the single-threaded `Clip::execute` oracle runs
+        // (`ClipParams::clip_template`). It finds the primary pair by SAM flag (so
+        // secondary/supplementary reads are handled, not just records[0]/[1]),
+        // applies fixed clipping with "ensure at least N including existing
+        // clipping" semantics (not "clip N more"), and repairs mate info. When the
+        // caller passed a `--metrics` accumulator slot, detailed per-read base-clip
+        // counts are collected here too; otherwise `metrics` is `None` and only the
+        // returned per-template flags feed the atomic counters.
+        let (overlap_clipped, extend_clipped) = params
+            .clip_template(records, clipper, metrics.as_deref_mut())
+            .map_err(io::Error::other)?;
+        if overlap_clipped {
+            local_overlap_clipped += 1;
+        }
+        if extend_clipped {
+            local_extend_clipped += 1;
+        }
+
+        // Regenerate alignment tags for every record (matches the oracle).
+        for record in records.iter_mut() {
+            regenerate_alignment_tags_raw(record.as_mut_vec(), header, reference)
+                .map_err(io::Error::other)?;
+        }
+
+        local_record_count += records.len() as u64;
+    }
+
+    Ok((local_templates, local_overlap_clipped, local_extend_clipped, local_record_count))
 }
 
 /// Build the `SerializeBamRecords` step for clip: parallel, `ByItemOrdinal`.

--- a/tests/integration/test_clip_command.rs
+++ b/tests/integration/test_clip_command.rs
@@ -283,21 +283,354 @@ fn test_clip_rejects_coordinate_sorted_input(#[case] extra_args: &[&str]) {
     );
 }
 
-/// `--metrics` combined with `--threads` must fail fast: detailed clipping metrics are only
-/// produced by the single-threaded path, so accepting `--metrics` under `--threads` would
-/// silently drop a user-requested output file. This reader-free guard runs before the chain
-/// dispatch; pin it so a regression that dropped it would be caught rather than silently
-/// ignoring the flag.
-#[test]
-fn test_clip_rejects_metrics_with_threads() {
-    let temp_dir = TempDir::new().unwrap();
+/// Builds a query-grouped BAM covering the shapes `--metrics` must count correctly:
+/// a lone fragment, a plain overlapping pair (no pre-existing clipping), a pair with
+/// pre-existing SOFT clipping on R1, and a pair with pre-existing HARD clipping on R2.
+/// Every `ClipCounts` field the chain `--metrics` path can populate (`prior`,
+/// `five_prime`/`three_prime` fixed clipping, `overlapping`) ends up non-zero when run
+/// with `--clip-overlapping-reads --read-one-five-prime 1 --read-two-three-prime 1`.
+///
+/// The four-shape block is repeated `repeats` times (unique QNAME per repeat, same
+/// positions -- clip only ever compares records *within* one template, so distinct
+/// templates sharing coordinates is harmless) so callers can force the chain
+/// `--threads N` path across enough `GroupBam` batches to exercise real cross-worker
+/// `PerThreadAccumulator` sharding -- see
+/// `test_clip_metrics_match_across_threading_modes` for why that matters.
+fn build_clip_metrics_parity_bam(path: &Path, repeats: usize) {
+    let mut records: Vec<RawRecord> = Vec::new();
+    push_clip_metrics_parity_records(&mut records, repeats);
+    create_bam_from_records(path, &records);
+}
+
+/// Appends `repeats` copies of the four-shape block to `records`. Factored out of
+/// [`build_clip_metrics_parity_bam`] so `test_clip_metrics_not_written_on_chain_failure`
+/// can append a malformed template after a run of otherwise-valid ones, in the same
+/// query-grouped record stream.
+fn push_clip_metrics_parity_records(records: &mut Vec<RawRecord>, repeats: usize) {
+    for i in 0..repeats {
+        // A lone fragment (unpaired primary), no pre-existing clipping.
+        {
+            let mut b = SamBuilder::new();
+            b.read_name(format!("frag1_{i:05}").as_bytes())
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .flags(0)
+                .ref_id(0)
+                .pos(499)
+                .mapq(60)
+                .cigar_ops(&[8 << 4]); // 8M
+            records.push(b.build());
+        }
+
+        // A proper, overlapping pair with no pre-existing clipping.
+        {
+            let mut r1 = SamBuilder::new();
+            r1.read_name(format!("pair1_{i:05}").as_bytes())
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+                .ref_id(0)
+                .pos(99)
+                .mapq(60)
+                .cigar_ops(&[8 << 4]) // 8M
+                .mate_ref_id(0)
+                .mate_pos(103)
+                .template_length(12);
+            records.push(r1.build());
+
+            let mut r2 = SamBuilder::new();
+            r2.read_name(format!("pair1_{i:05}").as_bytes())
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+                .ref_id(0)
+                .pos(103)
+                .mapq(60)
+                .cigar_ops(&[8 << 4]) // 8M
+                .mate_ref_id(0)
+                .mate_pos(99)
+                .template_length(-12);
+            records.push(r2.build());
+        }
+
+        // A pair with pre-existing SOFT clipping on R1 (2S6M): non-zero `prior`
+        // base-clip count for read_one.
+        {
+            let mut r1 = SamBuilder::new();
+            r1.read_name(format!("pair2_{i:05}").as_bytes())
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+                .ref_id(0)
+                .pos(199)
+                .mapq(60)
+                .cigar_ops(&[(2 << 4) | 4, 6 << 4]) // 2S6M
+                .mate_ref_id(0)
+                .mate_pos(203)
+                .template_length(12);
+            records.push(r1.build());
+
+            let mut r2 = SamBuilder::new();
+            r2.read_name(format!("pair2_{i:05}").as_bytes())
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+                .ref_id(0)
+                .pos(203)
+                .mapq(60)
+                .cigar_ops(&[8 << 4]) // 8M
+                .mate_ref_id(0)
+                .mate_pos(199)
+                .template_length(-12);
+            records.push(r2.build());
+        }
+
+        // A pair with pre-existing HARD clipping on R2 (6M2H): non-zero `prior`
+        // base-clip count for read_two. Hard-clipped bases are absent from SEQ/QUAL,
+        // so R2's sequence is only 6 bases long.
+        {
+            let mut r1 = SamBuilder::new();
+            r1.read_name(format!("pair3_{i:05}").as_bytes())
+                .sequence(b"ACGTACGT")
+                .qualities(&[30; 8])
+                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+                .ref_id(0)
+                .pos(299)
+                .mapq(60)
+                .cigar_ops(&[8 << 4]) // 8M
+                .mate_ref_id(0)
+                .mate_pos(303)
+                .template_length(10);
+            records.push(r1.build());
+
+            let mut r2 = SamBuilder::new();
+            r2.read_name(format!("pair3_{i:05}").as_bytes())
+                .sequence(b"ACGTAC")
+                .qualities(&[30; 6])
+                .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+                .ref_id(0)
+                .pos(303)
+                .mapq(60)
+                .cigar_ops(&[6 << 4, (2 << 4) | 5]) // 6M2H
+                .mate_ref_id(0)
+                .mate_pos(299)
+                .template_length(-10);
+            records.push(r2.build());
+        }
+    }
+}
+
+/// Number of times the 4-shape block (`build_clip_metrics_parity_bam`) is repeated
+/// in `test_clip_metrics_match_across_threading_modes`'s fixture: `4 * REPEATS`
+/// templates total.
+///
+/// This must be large enough to force the chain `--threads N` path across *many*
+/// `GroupBam` batches, not just one -- `GroupBam` caps every emitted batch at
+/// `BamPipelineTuning::template_batch_size` (fixed at 500 templates regardless of
+/// `--threads`; see `crates/.../pipeline/steps/tuning.rs`), and each `ClipTemplates`
+/// worker call (one call per batch) runs `with_slot` on whichever `PerThreadAccumulator`
+/// slot its calling OS thread owns. A too-small fixture (one batch) would let every
+/// batch land on a single worker/slot even at `--threads 4`, so a
+/// `ClipMetricsFinalizeHook` bug that reduced only a subset of slots (e.g. summed only
+/// slot 0) would still merge correctly by accident and this test would not catch it --
+/// exactly the gap `parallel_threads_populate_and_merge_distinct_clip_metrics_slots`
+/// (`src/lib/per_thread_accumulator.rs`) closes deterministically at the
+/// `PerThreadAccumulator` level. Here, `4 * REPEATS = 8000` templates make `16`
+/// `GroupBam` batches (`8000 / 500`) available to the pipeline's pull-based `Parallel`
+/// worker scheduler (every idle worker thread can claim the next available batch --
+/// see `crates/fgumi-pipeline-core/src/runtime/pool.rs`'s "each worker has its own
+/// clone" note) -- 4x the `--threads 4` worker count, so multiple distinct worker
+/// threads claiming at least one batch each (and therefore populating multiple
+/// distinct accumulator slots) is the expected, reliably-reproduced outcome, not a
+/// lucky scheduling accident.
+const REPEATS: usize = 2000;
+
+/// `--metrics` on the chain `--threads N` path must now succeed (previously a hard
+/// error) and produce a metrics TSV that matches the single-threaded oracle exactly.
+///
+/// Detailed metrics are collected via a per-thread `ClippingMetricsCollection`
+/// accumulator (one slot per worker), reduced by summing raw `fragment`/`read_one`/
+/// `read_two` counters across slots and then calling `finalize()` once -- pure integer
+/// addition is commutative and associative, so the reduction is order-independent and
+/// the TSV is byte-identical to the oracle's regardless of thread count or how work was
+/// sharded. This is the load-bearing parity test for this feature.
+///
+/// The fixture is sized (`REPEATS`, see its doc comment) to force real cross-worker
+/// `PerThreadAccumulator` sharding at `--threads 2`/`4`, not just a single-slot
+/// accumulation -- so a reduction bug that dropped a worker's slot would change the
+/// merged totals and fail the byte-identity assertion below, rather than passing by
+/// accident because everything happened to land in one slot.
+#[rstest]
+#[case::threads_1(1)]
+#[case::threads_2(2)]
+#[case::threads_4(4)]
+fn test_clip_metrics_match_across_threading_modes(#[case] threads: usize) {
+    use fgumi_lib::metrics::{ClippingMetrics, ReadType};
+
+    let temp_dir = TempDir::new().expect("temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let ref_path = create_test_reference(temp_dir.path());
+    build_clip_metrics_parity_bam(&input_bam, REPEATS);
+
+    let oracle_out = temp_dir.path().join("oracle.bam");
+    let chain_out = temp_dir.path().join("chain.bam");
+    let oracle_metrics = temp_dir.path().join("oracle.metrics.txt");
+    let chain_metrics = temp_dir.path().join("chain.metrics.txt");
+
+    let opts =
+        ["--clip-overlapping-reads", "--read-one-five-prime", "1", "--read-two-three-prime", "1"];
+
+    // Oracle: no --threads (single-threaded engine, the parity reference).
+    {
+        let mut args = vec![
+            "clip",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            oracle_out.to_str().unwrap(),
+            "--ref",
+            ref_path.to_str().unwrap(),
+            "--metrics",
+            oracle_metrics.to_str().unwrap(),
+        ];
+        args.extend_from_slice(&opts);
+        Clip::try_parse_from(args)
+            .expect("parse oracle args")
+            .execute("fgumi clip")
+            .expect("oracle clip failed");
+    }
+
+    // Chain: --threads N with --metrics. Must succeed and write the metrics file.
+    {
+        let threads_arg = threads.to_string();
+        let mut args = vec![
+            "clip",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            chain_out.to_str().unwrap(),
+            "--ref",
+            ref_path.to_str().unwrap(),
+            "--metrics",
+            chain_metrics.to_str().unwrap(),
+            "--threads",
+            &threads_arg,
+        ];
+        args.extend_from_slice(&opts);
+        Clip::try_parse_from(args)
+            .expect("parse chain args")
+            .execute("fgumi clip")
+            .expect("chain clip with --metrics must now succeed under --threads");
+    }
+    assert!(chain_metrics.exists(), "chain --metrics file must be written");
+
+    // Non-vacuous: every ClipCounts field the fixture exercises (prior soft/hard
+    // clip, fixed 5'/3' clipping, overlap clipping) must show up as a real,
+    // non-zero count in the oracle -- not an all-zero table.
+    let oracle_rows =
+        fgumi_lib::metrics::read_metrics::<_, ClippingMetrics>(&oracle_metrics, "clipping")
+            .expect("parse oracle metrics");
+    let by_type = |t: ReadType| {
+        oracle_rows
+            .iter()
+            .find(|m| m.read_type == t)
+            .unwrap_or_else(|| panic!("missing {t:?} row in metrics TSV"))
+    };
+    assert_eq!(by_type(ReadType::Fragment).reads, REPEATS, "one fragment read per repeat");
+    assert!(
+        by_type(ReadType::ReadOne).bases_clipped_pre > 0,
+        "pair2's pre-existing R1 soft clip must count as `prior`"
+    );
+    assert!(
+        by_type(ReadType::ReadTwo).bases_clipped_pre > 0,
+        "pair3's pre-existing R2 hard clip must count as `prior`"
+    );
+    assert!(
+        by_type(ReadType::ReadOne).bases_clipped_five_prime > 0,
+        "--read-one-five-prime 1 must clip read one's 5' end"
+    );
+    assert!(
+        by_type(ReadType::ReadTwo).bases_clipped_three_prime > 0,
+        "--read-two-three-prime 1 must clip read two's 3' end"
+    );
+    assert!(
+        by_type(ReadType::Pair).bases_clipped_overlapping > 0,
+        "pair1's overlap must be clipped and rolled up into Pair"
+    );
+
+    // The chain (--threads N) metrics TSV must be byte-identical to the oracle's.
+    let oracle_content = fs::read_to_string(&oracle_metrics).expect("read oracle metrics");
+    let chain_content = fs::read_to_string(&chain_metrics).expect("read chain metrics");
+    assert_eq!(
+        oracle_content, chain_content,
+        "metrics TSV must be byte-identical between the oracle and chain (--threads {threads}) paths",
+    );
+}
+
+/// Builds a query-grouped BAM of `valid_repeats` copies of the four-shape parity
+/// block, followed by one malformed template: two primary (non-secondary,
+/// non-supplementary) first-of-pair reads sharing one QNAME. The chain's `GroupBam`
+/// step groups records into `Template`s via the shared grouper (`src/lib/template.rs`),
+/// which rejects that shape ("Multiple non-secondary, non-supplemental R1 records") --
+/// the same invariant `find_primary_pair_indices` in `commands::clip` also enforces,
+/// defensively, on the `RawRecord` path. Placed last, so grouping fails only after every
+/// valid template ahead of it has already been grouped into complete batches and handed
+/// to the downstream `ClipTemplates` workers -- `clip_templates_in_batch` commits each
+/// template's counts into its calling worker's live `PerThreadAccumulator` slot as it
+/// loops, not just at batch end, so by the time `GroupBam` hits the malformed record and
+/// fails the run, real (non-zero) metrics have very likely already been written into at
+/// least one slot.
+fn build_clip_metrics_failure_bam(path: &Path, valid_repeats: usize) {
+    let mut records: Vec<RawRecord> = Vec::new();
+    push_clip_metrics_parity_records(&mut records, valid_repeats);
+
+    for i in 0..2 {
+        let mut b = SamBuilder::new();
+        b.read_name(b"malformed1")
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+            .ref_id(0)
+            .pos(900 + i * 20)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]); // 8M
+        records.push(b.build());
+    }
+
+    create_bam_from_records(path, &records);
+}
+
+/// A failed/partial run must leave NO `--metrics` file on disk at all, not a
+/// partial/stale one -- on BOTH the single-threaded engine (`None`, no
+/// `--threads`) and the multi-threaded chain (`Some("4")`). The PR contract is
+/// that metrics are not written for a failed run on either path, and both share
+/// the finalization helper, so a single-threaded partial write would otherwise
+/// be unguarded.
+///
+/// On the chain path, `ClipMetricsFinalizeHook` is registered on
+/// `finalize_on_success` (`src/lib/pipeline/chains/builder.rs::add_clip`), which
+/// `drain_finalize` (`src/lib/pipeline/chains/finalize.rs`) runs only once
+/// `Pipeline::run` AND every always-run `finalize` hook have succeeded -- see
+/// `drain_finalize_skips_success_hooks_when_pipeline_fails` for the generic mechanism
+/// this test exercises end-to-end through the real `clip` command. The fixture
+/// (`build_clip_metrics_failure_bam`) forces a genuine mid-run pipeline failure via a
+/// malformed template appended after many valid ones, so real metrics accumulation
+/// happens in at least one `PerThreadAccumulator` slot before the failure -- proving the
+/// hook actually discards in-progress state rather than merely never having any to write.
+#[rstest]
+#[case::single_threaded(None)]
+#[case::threaded(Some("4"))]
+fn test_clip_metrics_not_written_on_chain_failure(#[case] threads: Option<&str>) {
+    let temp_dir = TempDir::new().expect("temp dir");
     let input_bam = temp_dir.path().join("input.bam");
     let output_bam = temp_dir.path().join("output.bam");
     let metrics_path = temp_dir.path().join("metrics.txt");
     let ref_path = create_test_reference(temp_dir.path());
-    build_clip_parity_bam(&input_bam, 8);
+    // REPEATS (many `GroupBam` batches' worth) valid templates ahead of the malformed
+    // one, so grouping fails only after real work has already reached `ClipTemplates`.
+    build_clip_metrics_failure_bam(&input_bam, REPEATS);
 
-    let cmd = Clip::try_parse_from([
+    let mut args: Vec<&str> = vec![
         "clip",
         "--input",
         input_bam.to_str().unwrap(),
@@ -306,17 +639,30 @@ fn test_clip_rejects_metrics_with_threads() {
         "--ref",
         ref_path.to_str().unwrap(),
         "--clip-overlapping-reads",
+        "--read-one-five-prime",
+        "1",
+        "--read-two-three-prime",
+        "1",
         "--metrics",
         metrics_path.to_str().unwrap(),
-        "--threads",
-        "2",
-    ])
-    .expect("failed to parse clip args");
+    ];
+    // `None` omits `--threads` entirely, exercising the single-threaded engine
+    // (the parity reference); `Some(n)` exercises the multi-threaded chain.
+    if let Some(t) = threads {
+        args.push("--threads");
+        args.push(t);
+    }
 
-    let err = cmd.execute("fgumi clip").expect_err("--metrics must be rejected under --threads");
+    let cmd = Clip::try_parse_from(args).expect("failed to parse clip args");
+
+    let err = cmd.execute("fgumi clip").expect_err("malformed template must fail the run");
     assert!(
-        err.to_string().contains("cannot be used with --threads"),
+        err.to_string().contains("Multiple non-secondary, non-supplemental R1"),
         "unexpected error message: {err}"
+    );
+    assert!(
+        !metrics_path.exists(),
+        "a failed chain run must not write a --metrics file, even a partial one"
     );
 }
 


### PR DESCRIPTION
## What

`fgumi clip --metrics` was a hard error when combined with `--threads` — the detailed clipping-metrics TSV was only produced by the single-threaded path. This produces the same metrics on the multi-threaded chain path, so `--metrics` and `--threads` now work together.

## Design

Follows the established retag/correct chain-metrics idioms:

- Each chain worker accumulates into a `PerThreadAccumulator<ClippingMetricsCollection>`, passed into the shared `ClipParams::clip_template` when `--metrics` is set (the `None` fast path is unchanged — no accumulator allocated).
- A **success-only** `ClipMetricsFinalizeHook` (registered on `finalize_on_success`, mirroring retag) sums every worker slot and writes the TSV, so a failed or partial run publishes no stale metrics.
- `ClippingMetricsCollection::merge` sums the raw `fragment`/`read_one`/`read_two` counters (all 15 `ClippingMetrics` fields, via `AddAssign`); `pair`/`all` are derived once in `finalize()` on the reduced total. Because the reduction is pure commutative/associative integer addition, the chain TSV is **byte-identical** to the single-threaded oracle.
- The finalize→derive→write sequence is a single shared `ClippingMetricsCollection::finalize_and_write` helper called by both the single-threaded path and the chain hook, so they can't drift.
- Both hard bails (`builder.rs`, `commands/clip.rs`) and the "single-threaded only" doc text are removed.

The single-threaded path's behavior and output are unchanged.

## Tests

- `test_clip_metrics_match_across_threading_modes` (rstest, threads 1/2/4): asserts a full-string TSV `assert_eq!` between each threaded run and the single-threaded oracle, over a fixture with fragments, plain overlapping pairs, and pairs with pre-existing soft/hard clips. The fixture is sized (8000 templates → 16 `GroupBam` batches vs 4 worker threads) so the threaded cases genuinely shard across multiple accumulator slots.
- `parallel_threads_populate_and_merge_distinct_clip_metrics_slots` (unit, `per_thread_accumulator.rs`): spawns 8 OS threads, asserts `populated_slots > 1` via `slots()`, and that the merged reduction recovers the exact combined total — deterministically closing the "merged only a subset of slots" gap the integration test can't observe directly.
- `test_clip_metrics_not_written_on_chain_failure`: forces a genuine mid-run `Pipeline::run` failure and asserts the `--metrics` file was never written (pins the success-only contract).

Full gate green: `cargo ci-test` 9958 passed / 31 skipped, plus `ci-fmt`/`ci-lint`/`ci-doc` and `--no-default-features`/`--all-features`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: `fgumi clip --metrics` changes TSV output, pinned by byte-identical single-threaded results and success-only finalization; `unsafe` changes are none, so the `CLAUDE.md` allowlist needs no update; memory bounds, queue capacity, and thread/backpressure policy changes are none.

- Adds threaded clipping metrics support.
- Merges per-thread metrics and writes them only after success.
- Reuses finalization logic across execution modes.
- Tests cross-thread merging, output equivalence, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->