### PR TITLE
perf(filter): skip the discarded full group key on the chain filter/clip paths

### DIFF
--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -1127,39 +1127,46 @@ impl<'a> ChainBuilder<'a> {
 
     /// Group-key config for the **source preamble's** `DecodeRecords`.
     ///
-    /// A first stage that groups by queryname (correct's `GroupByQueryname`)
-    /// reads only `key.name_hash` and discards the rest of the `GroupKey`; a sort
-    /// first stage discards the `GroupKey` *entirely* (it computes its own sort
-    /// keys straight off the raw record bytes — see
-    /// `DecodedRecordBatchToRecordBatch`). Both therefore use
+    /// A first stage that groups by queryname (correct's `GroupByQueryname`;
+    /// filter's own `GroupByQueryname` in filter-by-template mode; clip's
+    /// `GroupBam`/`TemplateGrouper`) reads only `key.name_hash` and discards
+    /// the rest of the `GroupKey`; a sort first stage discards the `GroupKey`
+    /// *entirely* (it computes its own sort keys straight off the raw record
+    /// bytes — see `DecodedRecordBatchToRecordBatch`); copy-umi/retag/
+    /// single-record-mode filter are per-record transforms that never build
+    /// or consume a `GroupKey` at all. All of these therefore use
     /// [`fgumi_bam_io::GroupKeyConfig::name_hash_only`] — the cheapest config —
     /// skipping the CIGAR 5′-position walk and the RG/CB/MC aux-tag extraction
     /// pass entirely; for a SAM-first sort that pass runs once per record in
     /// `ParseSamChunk` and would otherwise be pure waste. This changes only the
-    /// discarded key, never the record bytes, so sort output is unchanged.
+    /// discarded key, never the record bytes, so output is unchanged.
     /// (The legacy single-threaded path uses `new_raw_no_cell`, which still
     /// pays the combined aux pass; name-hash-only is strictly less work.) All
-    /// other first stages (group/dedup/consensus/clip) need the full
-    /// position/cell key, so they fall through to [`Self::bam_group_key_config`].
+    /// other first stages (group/dedup/consensus) need the full position/cell
+    /// key, so they fall through to [`Self::bam_group_key_config`].
+    ///
+    /// Every arm below uses a DEFAULT `LibraryIndex`, never `from_header`:
+    /// `name_hash_only` never reads `library_index` (see `name_hash_key` in
+    /// `fgumi-bam-io`, and the `name_hash_only` branches in `DecodeRecords`
+    /// and `parse_sam_chunk_into_decoded`, which call it without touching
+    /// `library_index` at all), so resolving it from the header is pure waste
+    /// for these stages — and `LibraryIndex::from_header` panics on a header
+    /// with more than 65,535 distinct `@RG` libraries, a needless crash risk
+    /// this avoids. (Some of these stages' serial oracles independently build
+    /// a full-header group key of their own — e.g. filter-by-template's
+    /// `build_filter_pipeline_config` calls `LibraryIndex::from_header` — so
+    /// this isn't "a panic the oracle never has"; it is simply dead work this
+    /// arm has no reason to repeat.)
     fn source_group_key_config(&self) -> fgumi_bam_io::GroupKeyConfig {
         match self.spec.stages.first() {
-            Some(Stage::Correct | Stage::Sort) => {
-                let library_index = fgumi_bam_io::LibraryIndex::from_header(&self.header);
-                fgumi_bam_io::GroupKeyConfig::name_hash_only(library_index)
-            }
-            Some(Stage::CopyUmi | Stage::Retag) => {
-                // copy-umi and retag are pure per-record transforms that never read
-                // the group key, like Sort, so they take the cheap name-hash key and
-                // skip the per-record CIGAR position walk + aux-tag scan
-                // `bam_group_key_config` would otherwise compute for every record and
-                // then discard. (The deleted `run_threaded` used `new_raw_no_cell`
-                // for the same reason.)
-                //
-                // Use a DEFAULT LibraryIndex, NOT `from_header`: `name_hash_only`
-                // never reads `library_index`, and `LibraryIndex::from_header`
-                // panics on a header with >65,535 @RG libraries — a crash the serial
-                // oracle (which builds no group key) never has, so routing these
-                // through the shared `from_header` arm would newly expose it.
+            Some(
+                Stage::Correct
+                | Stage::Sort
+                | Stage::CopyUmi
+                | Stage::Retag
+                | Stage::Filter
+                | Stage::Clip,
+            ) => {
                 fgumi_bam_io::GroupKeyConfig::name_hash_only(fgumi_bam_io::LibraryIndex::default())
             }
             _ => self.bam_group_key_config(),
@@ -4900,7 +4907,115 @@ fn dict_not_found_error(reference: &std::path::Path) -> anyhow::Error {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_phase_threads, sort_budget_threads};
+    use super::*;
+
+    /// A `ChainSpec` with the given stages and every other field at its
+    /// simplest valid default. Mirrors `validate::tests::empty_spec` — kept as
+    /// a separate copy (not shared) since each module's tests exercise a
+    /// different pure function over `ChainSpec` and neither depends on the
+    /// other's test scaffolding.
+    fn empty_spec(stages: Vec<Stage>) -> ChainSpec {
+        use crate::commands::common::{
+            CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
+        };
+        use crate::pipeline::chains::{SinkSpec, StageOptionsBag};
+        use std::path::PathBuf;
+        ChainSpec {
+            stages,
+            source: SourceSpec::Bam(PathBuf::from("in.bam")),
+            sink: SinkSpec::Bam(PathBuf::from("out.bam")),
+            stage_opts: StageOptionsBag::default(),
+            threading: ThreadingOptions { threads: None },
+            compression: CompressionOptions::default(),
+            scheduler: SchedulerOptions::default(),
+            queue_memory: QueueMemoryOptions::default(),
+            async_reader: false,
+            read_streams: fgumi_bam_io::ReadStreams::Fixed(1),
+            verify_crc: true,
+            command_line: String::new(),
+        }
+    }
+
+    /// Construct a `ChainBuilder` directly (bypassing `ChainBuilder::new`'s
+    /// source-open I/O) so `source_group_key_config`'s pure stage-routing
+    /// logic can be unit-tested without a real BAM file on disk. Every field
+    /// gets the same placeholder `new()` would produce before `add_source`
+    /// runs; `source_group_key_config` only reads `spec.stages.first()`
+    /// (never `header`, for the `name_hash_only` arms), so the placeholder
+    /// header is inert for the cases this helper is used to test.
+    fn chain_builder_for_stages(spec: &ChainSpec) -> ChainBuilder<'_> {
+        ChainBuilder {
+            spec,
+            tuning: BamPipelineTuning::auto_tuned(1),
+            header: Header::default(),
+            raw_source_header: Header::default(),
+            current_tail: None,
+            pipeline: PipelineBuilder::new(),
+            finalize: Vec::new(),
+            finalize_on_success: Vec::new(),
+            progress_records: Arc::new(AtomicU64::new(0)),
+            pending_source: None,
+            paired_tail: None,
+            override_pipeline_threads: None,
+            use_drain_first_scheduler: false,
+            pending_header_handle: None,
+            pending_header_transform: None,
+            chain_tail_kind: ChainTailKind::DecodedRecordBatch,
+            detached_writer: false,
+            fastq_encoding: None,
+        }
+    }
+
+    /// `source_group_key_config` routes a chain-filter first stage to the
+    /// cheap `name_hash_only` config, like `Correct`/`Sort`/`CopyUmi`/`Retag`
+    /// — the chain filter grouper (`GroupByQueryname` in
+    /// `filter-by-template` mode, or nothing at all in single-record mode)
+    /// never reads the position/RG/CB portion of the `GroupKey`, so
+    /// computing it is pure waste (see `add_filter` /
+    /// `GroupByQueryname::process_record`, which reads only
+    /// `GroupKey::name_hash`).
+    #[test]
+    fn source_group_key_config_is_name_hash_only_for_filter_first_stage() {
+        let spec = empty_spec(vec![Stage::Filter]);
+        let builder = chain_builder_for_stages(&spec);
+        let config = builder.source_group_key_config();
+        assert!(
+            config.name_hash_only,
+            "Stage::Filter as the first stage must skip the discarded position/RG/CB key"
+        );
+    }
+
+    /// `source_group_key_config` routes a chain-clip first stage to the cheap
+    /// `name_hash_only` config too — clip's grouper (`GroupBam` /
+    /// `TemplateGrouper::add_records`) reads only `decoded.key.name_hash`
+    /// before discarding the rest of the key via `into_raw_bytes()`, exactly
+    /// like filter's `GroupByQueryname`, in every clipping mode (the
+    /// clipping-mode-specific logic runs downstream, on the grouped raw
+    /// `Template` records, never on the discarded `GroupKey`).
+    #[test]
+    fn source_group_key_config_is_name_hash_only_for_clip_first_stage() {
+        let spec = empty_spec(vec![Stage::Clip]);
+        let builder = chain_builder_for_stages(&spec);
+        let config = builder.source_group_key_config();
+        assert!(
+            config.name_hash_only,
+            "Stage::Clip as the first stage must skip the discarded position/RG/CB key"
+        );
+    }
+
+    /// Sanity check that the `Stage::Filter`/`Stage::Clip` additions to
+    /// `source_group_key_config` didn't broaden the match arm: a first stage
+    /// that genuinely needs the full key (e.g. `Group`) still gets it.
+    #[test]
+    fn source_group_key_config_is_full_for_group_first_stage() {
+        let spec = empty_spec(vec![Stage::Group]);
+        let builder = chain_builder_for_stages(&spec);
+        let config = builder.source_group_key_config();
+        assert!(
+            !config.name_hash_only,
+            "Stage::Group as the first stage must compute the full position/RG/CB key"
+        );
+    }
 
     /// Pin the per-phase thread resolution contract shared by the standalone and
     /// streaming sort branches in `add_sort`: each phase falls back to the base

--- a/tests/integration/test_clip_command.rs
+++ b/tests/integration/test_clip_command.rs
@@ -537,6 +537,192 @@ fn test_clip_chain_matches_single_threaded(#[case] threads: usize) {
     );
 }
 
+/// Header carrying two `@RG` lines with distinct `LB` values, for
+/// `test_clip_chain_matches_single_threaded_with_rg_and_cb_variation`. The
+/// `source_group_key_config` perf fix routes the chain clip path's first
+/// stage to a `name_hash_only` `GroupKeyConfig`, which never resolves a
+/// per-record library index or extracts the `CB` tag during decode — so the
+/// parity test needs a header/record set where that discarded information
+/// genuinely varies, not `build_clip_parity_bam`'s single-library, no-`CB`,
+/// single-position records.
+fn create_clip_header_with_read_groups(ref_name: &str, ref_len: usize) -> noodles::sam::Header {
+    use bstr::BString;
+    use noodles::sam::header::record::value::Map;
+    use noodles::sam::header::record::value::map::Map as HeaderRecordMap;
+    use noodles::sam::header::record::value::map::header::tag::Tag as HeaderTag;
+    use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
+    use noodles::sam::header::record::value::map::{
+        Header as HeaderRecord, ReadGroup, ReferenceSequence,
+    };
+    use std::num::NonZeroUsize;
+
+    let mut header_builder = HeaderRecordMap::<HeaderRecord>::builder();
+    for &(tag_bytes, value) in
+        &[(*b"SO", "unsorted"), (*b"GO", "query"), (*b"SS", "template-coordinate")]
+    {
+        let HeaderTag::Other(tag) = HeaderTag::from(tag_bytes) else { unreachable!() };
+        header_builder = header_builder.insert(tag, value);
+    }
+    let header_map = header_builder.build().expect("valid header map");
+
+    let reference_sequence = Map::<ReferenceSequence>::new(
+        NonZeroUsize::new(ref_len).expect("reference length must be non-zero"),
+    );
+
+    let rg_a = Map::<ReadGroup>::builder()
+        .insert(rg_tag::LIBRARY, String::from("libA"))
+        .build()
+        .expect("building read group RG1 should succeed");
+    let rg_b = Map::<ReadGroup>::builder()
+        .insert(rg_tag::LIBRARY, String::from("libB"))
+        .build()
+        .expect("building read group RG2 should succeed");
+
+    noodles::sam::Header::builder()
+        .set_header(header_map)
+        .add_reference_sequence(BString::from(ref_name), reference_sequence)
+        .add_read_group(BString::from("RG1"), rg_a)
+        .add_read_group(BString::from("RG2"), rg_b)
+        .build()
+}
+
+/// Like [`build_clip_parity_bam`], but each mate additionally carries an `RG`
+/// tag (alternating `RG1`/`RG2`, so both `@RG` lines in
+/// [`create_clip_header_with_read_groups`] are exercised), a `CB` tag that
+/// varies per template (`CB{i}`), and positions that advance per template
+/// (`99 + i*20` / `103 + i*20`, preserving the same overlap shape) rather than
+/// every template sharing one fixed position.
+fn build_clip_parity_bam_with_rg_and_cb(path: &Path, count: usize) {
+    let header = create_clip_header_with_read_groups("chr1", 10000);
+    let pairs: Vec<(RawRecord, RawRecord)> = (0..count)
+        .map(|i| {
+            let name = format!("tmpl{i}");
+            let offset = i32::try_from(i).expect("count fits in i32") * 20;
+            let pos1 = 99 + offset;
+            let pos2 = 103 + offset;
+            let rg_id: &[u8] = if i % 2 == 0 { b"RG1" } else { b"RG2" };
+            let cb = format!("CB{i}");
+            let r1 = {
+                let mut b = SamBuilder::new();
+                b.read_name(name.as_bytes())
+                    .sequence(b"ACGTACGT")
+                    .qualities(&[30; 8])
+                    .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+                    .ref_id(0)
+                    .pos(pos1)
+                    .mapq(60)
+                    .cigar_ops(&[8 << 4]) // 8M
+                    .mate_ref_id(0)
+                    .mate_pos(pos2)
+                    .template_length(12);
+                b.add_string_tag(SamTag::RG, rg_id).add_string_tag(SamTag::CB, cb.as_bytes());
+                b.build()
+            };
+            let r2 = {
+                let mut b = SamBuilder::new();
+                b.read_name(name.as_bytes())
+                    .sequence(b"ACGTACGT")
+                    .qualities(&[30; 8])
+                    .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+                    .ref_id(0)
+                    .pos(pos2)
+                    .mapq(60)
+                    .cigar_ops(&[8 << 4]) // 8M
+                    .mate_ref_id(0)
+                    .mate_pos(pos1)
+                    .template_length(-12);
+                b.add_string_tag(SamTag::RG, rg_id).add_string_tag(SamTag::CB, cb.as_bytes());
+                b.build()
+            };
+            (r1, r2)
+        })
+        .collect();
+    write_paired_bam_with_header(path, &header, pairs);
+}
+
+/// The chain (`--threads N`) path matches the non-chain oracle record-for-record
+/// even when the discarded position/RG/CB portion of the group key genuinely
+/// varies per record (distinct `@RG`/`LB` per template, a distinct `CB` per
+/// template, and positions that advance per template).
+/// `test_clip_chain_matches_single_threaded` already covers the thread-count
+/// matrix on RG/CB-free, single-position records; this test's unique
+/// contribution is exercising the exact fields `source_group_key_config`'s
+/// `name_hash_only` routing stops computing for the chain clip path,
+/// confirming the skip is genuinely invisible in the output.
+#[test]
+fn test_clip_chain_matches_single_threaded_with_rg_and_cb_variation() {
+    let temp_dir = TempDir::new().expect("temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let ref_path = create_test_reference(temp_dir.path());
+    build_clip_parity_bam_with_rg_and_cb(&input_bam, 8);
+
+    let oracle_out = temp_dir.path().join("oracle.bam");
+    let chain_out = temp_dir.path().join("chain.bam");
+
+    let opts =
+        ["--clip-overlapping-reads", "--read-one-five-prime", "1", "--read-two-three-prime", "1"];
+
+    // Oracle: no --threads (single-threaded engine).
+    {
+        let mut args = vec![
+            "clip",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            oracle_out.to_str().unwrap(),
+            "--ref",
+            ref_path.to_str().unwrap(),
+        ];
+        args.extend_from_slice(&opts);
+        Clip::try_parse_from(args)
+            .expect("parse oracle args")
+            .execute("fgumi clip")
+            .expect("oracle clip failed");
+    }
+
+    // Chain: --threads 4 (declarative chain builder).
+    {
+        let mut args = vec![
+            "clip",
+            "--input",
+            input_bam.to_str().unwrap(),
+            "--output",
+            chain_out.to_str().unwrap(),
+            "--ref",
+            ref_path.to_str().unwrap(),
+            "--threads",
+            "4",
+        ];
+        args.extend_from_slice(&opts);
+        Clip::try_parse_from(args)
+            .expect("parse chain args")
+            .execute("fgumi clip")
+            .expect("chain clip failed");
+    }
+
+    let (oracle_header, oracle_records) = crate::helpers::read_bam_output(&oracle_out);
+    let (chain_header, chain_records) = crate::helpers::read_bam_output(&chain_out);
+
+    // Non-vacuous guards: all 16 records (8 templates x 2) survive, and clipping
+    // actually ran, same as the RG/CB-free matrix test.
+    assert_eq!(oracle_records.len(), 16, "oracle should keep all 16 records with RG/CB variation");
+    assert!(
+        oracle_records.iter().any(|r| cigar_ops(r) != vec![(CigarKind::Match, 8)]),
+        "fixture must actually clip (expected an output CIGAR other than 8M)",
+    );
+
+    assert_eq!(
+        oracle_records, chain_records,
+        "chain output must match the single-threaded oracle record-for-record with RG/CB \
+         variation present, proving source_group_key_config's name_hash_only skip for \
+         Stage::Clip changes no output",
+    );
+    assert_eq!(
+        oracle_header, chain_header,
+        "chain and oracle output headers must match with RG/CB variation present",
+    );
+}
+
 /// CLIP3-05: clip must reject header-less input. A header-less BAM synthesizes
 /// `@HD VN:1.6 SO:unsorted` (via `ensure_hd_record`), which is neither queryname
 /// sorted nor query grouped, so `require_query_grouped` rejects it — matching

--- a/tests/integration/test_filter_command.rs
+++ b/tests/integration/test_filter_command.rs
@@ -681,6 +681,166 @@ fn test_filter_chain_matches_single_threaded(
     );
 }
 
+/// Header carrying two `@RG` lines with distinct `LB` values, for
+/// `test_filter_chain_matches_single_threaded_with_rg_and_cb_variation`. The
+/// `source_group_key_config` perf fix routes the chain filter path's first
+/// stage to a `name_hash_only` `GroupKeyConfig`, which never resolves a
+/// per-record library index or walks the CIGAR for position during decode —
+/// unlike the filter-by-template oracle's own decode config
+/// (`Filter::build_filter_pipeline_config`'s `new_raw_no_cell`), which
+/// resolves the library index and the position but, like `name_hash_only`,
+/// never extracts `CB` either way. So RG (library index) and position are the
+/// fields that genuinely differ between the two decode configs, and are what
+/// this parity test needs to vary to be non-vacuous; the `CB` variation below
+/// is incidental fixture realism, not a discriminating input — the oracle
+/// never reads `CB` regardless of this change, so it cannot expose a
+/// regression here.
+fn create_consensus_header_with_read_groups(
+    ref_name: &str,
+    ref_len: usize,
+) -> noodles::sam::Header {
+    use bstr::BString;
+    use noodles::sam::header::record::value::Map;
+    use noodles::sam::header::record::value::map::Map as HeaderRecordMap;
+    use noodles::sam::header::record::value::map::header::tag::Tag as HeaderTag;
+    use noodles::sam::header::record::value::map::read_group::tag as rg_tag;
+    use noodles::sam::header::record::value::map::{
+        Header as HeaderRecord, ReadGroup, ReferenceSequence,
+    };
+    use std::num::NonZeroUsize;
+
+    let mut header_builder = HeaderRecordMap::<HeaderRecord>::builder();
+    for &(tag_bytes, value) in
+        &[(*b"SO", "unsorted"), (*b"GO", "query"), (*b"SS", "template-coordinate")]
+    {
+        let HeaderTag::Other(tag) = HeaderTag::from(tag_bytes) else { unreachable!() };
+        header_builder = header_builder.insert(tag, value);
+    }
+    let header_map = header_builder.build().expect("valid header map");
+
+    let reference_sequence = Map::<ReferenceSequence>::new(
+        NonZeroUsize::new(ref_len).expect("reference length must be non-zero"),
+    );
+
+    let rg_a = Map::<ReadGroup>::builder()
+        .insert(rg_tag::LIBRARY, String::from("libA"))
+        .build()
+        .expect("building read group RG1 should succeed");
+    let rg_b = Map::<ReadGroup>::builder()
+        .insert(rg_tag::LIBRARY, String::from("libB"))
+        .build()
+        .expect("building read group RG2 should succeed");
+
+    noodles::sam::Header::builder()
+        .set_header(header_map)
+        .add_reference_sequence(BString::from(ref_name), reference_sequence)
+        .add_read_group(BString::from("RG1"), rg_a)
+        .add_read_group(BString::from("RG2"), rg_b)
+        .build()
+}
+
+/// Like [`build_mixed_depth_templates`], but each mate additionally carries an
+/// `RG` tag (alternating `RG1`/`RG2`, so both `@RG` lines in
+/// [`create_consensus_header_with_read_groups`] are exercised) and a `CB` tag
+/// that varies per template (`CB{i}`). Same mixed pass/fail depth pattern, so
+/// filtering still does non-trivial work.
+fn build_mixed_depth_templates_with_rg_and_cb(n: usize) -> Vec<RawRecord> {
+    let mut records = Vec::with_capacity(n * 2);
+    for i in 0..i32::try_from(n).expect("n fits in i32") {
+        let name = format!("t{i}");
+        let pos = 100 + i * 20;
+        let r2_depth: u16 = if i % 2 == 0 { 10 } else { 1 };
+        let rg_id: &[u8] = if i % 2 == 0 { b"RG1" } else { b"RG2" };
+        let cb = format!("CB{i}");
+
+        let mut r1 = RawSamBuilder::new();
+        r1.read_name(name.as_bytes())
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+            .ref_id(0)
+            .pos(pos)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .sequence(b"ACGTACGT")
+            .qualities(&[35; 8]);
+        r1.add_int_tag(SamTag::CD, 10).add_float_tag(SamTag::CE, 0.0_f32);
+        r1.add_array_u16(SamTag::CD_BASES, &[10; 8]).add_array_u16(SamTag::CE_BASES, &[0; 8]);
+        r1.add_string_tag(SamTag::RG, rg_id).add_string_tag(SamTag::CB, cb.as_bytes());
+        records.push(r1.build());
+
+        let mut r2 = RawSamBuilder::new();
+        r2.read_name(name.as_bytes())
+            .flags(flags::PAIRED | flags::LAST_SEGMENT)
+            .ref_id(0)
+            .pos(pos + 8)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .sequence(b"ACGTACGT")
+            .qualities(&[35; 8]);
+        r2.add_int_tag(SamTag::CD, i32::from(r2_depth)).add_float_tag(SamTag::CE, 0.0_f32);
+        r2.add_array_u16(SamTag::CD_BASES, &[r2_depth; 8]).add_array_u16(SamTag::CE_BASES, &[0; 8]);
+        r2.add_string_tag(SamTag::RG, rg_id).add_string_tag(SamTag::CB, cb.as_bytes());
+        records.push(r2.build());
+    }
+    records
+}
+
+/// The chain (`--threads N`) path matches the non-chain oracle record-for-record
+/// even when the discarded position/RG portion of the group key genuinely
+/// varies per record (distinct `@RG`/`LB` per template and distinct positions
+/// — the fields the oracle's decode config resolves but `name_hash_only`
+/// does not, per `create_consensus_header_with_read_groups`'s doc comment).
+/// `test_filter_chain_matches_single_threaded` already covers the
+/// `threads`/`filter_by_template` matrix on RG-free, single-position records;
+/// this test's unique contribution is exercising the exact fields
+/// `source_group_key_config`'s `name_hash_only` routing stops computing for
+/// the chain filter path, confirming the skip is genuinely invisible in the
+/// output. Records also carry a per-template `CB` tag for fixture realism,
+/// but it is not discriminating: the oracle's own decode config never
+/// extracts `CB` either, so `CB` variation cannot expose a regression here.
+#[test]
+fn test_filter_chain_matches_single_threaded_with_rg_and_cb_variation() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+    let ref_path = create_test_reference(temp_dir.path());
+    let header = create_consensus_header_with_read_groups("chr1", 10000);
+    create_consensus_bam_with_header(
+        &input_bam,
+        &header,
+        build_mixed_depth_templates_with_rg_and_cb(8),
+    );
+
+    let oracle_out = temp_dir.path().join("oracle.bam");
+    filter_run(&input_bam, &oracle_out, &ref_path, &["--filter-by-template", "true"]);
+
+    let chain_out = temp_dir.path().join("chain.bam");
+    filter_run(
+        &input_bam,
+        &chain_out,
+        &ref_path,
+        &["--filter-by-template", "true", "--threads", "4"],
+    );
+
+    let (oracle_header, expected) = crate::helpers::read_bam_output(&oracle_out);
+    let (chain_header, actual) = crate::helpers::read_bam_output(&chain_out);
+    // Non-vacuous: filter-by-template drops the 4 odd templates whole (keeps 8
+    // of 16), same as the RG/CB-free matrix test.
+    assert_eq!(
+        expected.len(),
+        8,
+        "oracle must keep exactly 8 of 16 records with RG/CB variation present"
+    );
+    assert_eq!(
+        actual, expected,
+        "chain output must match the non-chain path record-for-record with RG/CB variation \
+         present, proving source_group_key_config's name_hash_only skip for Stage::Filter \
+         changes no output"
+    );
+    assert_eq!(
+        chain_header, oracle_header,
+        "chain output header must match the non-chain path with RG/CB variation present"
+    );
+}
+
 /// The `--rejects` output BAM matches record-for-record between the chain and
 /// oracle paths, not just the kept output. Template mode over
 /// `build_mixed_depth_templates` rejects both mates of every odd-indexed


### PR DESCRIPTION
## What

Unify `ChainBuilder::source_group_key_config` so the chain **filter** and **clip** first stages take the cheapest `GroupKeyConfig::name_hash_only` key at Decode time, instead of falling through to the full position/cell key (`bam_group_key_config`).

The full key does a per-record CIGAR 5′-position walk plus an RG/CB/MC aux-tag extraction pass. Neither filter nor clip consumes that Decode-time key — each computes what it needs itself — so on the chain path that work was computed and then discarded for every record.

This only changes a *discarded* key, never record bytes, so output is byte-identical to baseline.

## Measured

Mac Studio (M3 Ultra, arm64), 8 threads, CPU-seconds via `/usr/bin/time -l`, 3 reps, byte-identical `samtools view | md5` verified against baseline:

- **filter** — 6.0M consensus reads, `-M 5 -r`, ~half rejected (discarded-key path genuinely exercised): baseline 24.10 → branch 23.82 CPU-s, **−1.2%** (wall −1.1%). All three branch reps sit below all three baseline reps.
- **clip** — 18.0M mapped reads, `--clip-overlapping-reads -r`: flat (−0.14%, within noise). The elision is real but dwarfed by clip's NM/UQ/MD regeneration and BGZF codec. Kept in scope because it still removes dead per-record work and shares the fix below.

The win is machine-agnostic work-elision; the absolute deltas are M3-Ultra/arm64-specific.

## Also fixes: a latent panic

Every arm now uses a **default** `LibraryIndex`, never `from_header`. `name_hash_only` never reads `library_index`, and `LibraryIndex::from_header` panics on a header with more than 65,535 distinct `@RG` libraries — so routing these stages through `from_header` was both pure waste and a needless crash risk.

## Tests

Added filter and clip parity tests asserting byte-identical output across threading modes / against the single-threaded oracle. Full gate green (`cargo ci-test`/`ci-fmt`/`ci-lint`/`ci-doc`, plus `--no-default-features` / `--all-features`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk: output remains byte-identical, pinned by filter and clip parity tests; no `unsafe` changes, so the `CLAUDE.md` allowlist is unchanged; no memory bound, queue capacity, or thread/backpressure policy changes.

- Uses `GroupKeyConfig::name_hash_only` for eligible chain stages.
- Avoids unnecessary CIGAR and auxiliary-tag processing.
- Removes `LibraryIndex::from_header` usage and its large-`@RG` panic risk.
- Adds filter and clip parity coverage with varied read groups, positions, and cell barcodes.
- Preserves existing sort, group routing, thread, and memory-budget coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->