### PR TITLE
fix(dedup): consult the UMI-position cache by assigning UMI groups before clearing duplicate flags

### DIFF
--- a/src/lib/commands/dedup.rs
+++ b/src/lib/commands/dedup.rs
@@ -957,19 +957,31 @@ pub(crate) fn process_position_group(
         });
     }
 
-    // Clear existing duplicate flags before re-marking
-    let mut templates: Vec<Template> = filtered_templates
-        .into_iter()
-        .map(|mut t| {
-            for raw in t.records_mut().iter_mut() {
-                let flg = RawRecordView::new(raw.as_ref()).flags();
-                fgumi_raw_bam::set_flags(raw, flg & !DUPLICATE_FLAG);
-            }
-            t
-        })
-        .collect();
+    // Assign UMI groups before clearing duplicate flags, so this read runs while
+    // `cached_umi_position` (recorded during the parallel Decode step; see
+    // `GroupKeyConfig::with_umi_tag` and `Template::from_decoded_records`) is
+    // still valid. `assign_umi_groups` only reads record state (`cached_umi()`,
+    // and R1/R2 orientation for `get_pair_orientation`) and writes
+    // `Template::mi`; it never calls `records_mut()` or touches the BAM bytes.
+    let mut templates: Vec<Template> = filtered_templates;
     if let Err(e) = assign_umi_groups(&mut templates, assigner, raw_tag, min_umi_length, no_umi) {
         return Err(io::Error::new(io::ErrorKind::InvalidData, e));
+    }
+
+    // Clear existing duplicate flags before re-marking. This runs *after* UMI
+    // assignment above: nothing reads `cached_umi()` again below, so
+    // `records_mut()`'s blanket cache invalidation (needed for callers like
+    // `fix_mate_info` that rewrite aux tags) is harmless here, and
+    // `fgumi_raw_bam::set_flags` only ever writes the 2-byte FLAG field
+    // (`bam[14..16]`), never the aux block, so it cannot itself move RX. The
+    // two steps touch disjoint state (the duplicate flag bit vs. `Template::mi`
+    // plus read-only record access) and therefore commute, so this reorder is
+    // byte-identical to the previous ordering.
+    for t in &mut templates {
+        for raw in t.records_mut().iter_mut() {
+            let flg = RawRecordView::new(raw.as_ref()).flags();
+            fgumi_raw_bam::set_flags(raw, flg & !DUPLICATE_FLAG);
+        }
     }
 
     // Sort by molecule ID for grouping
@@ -4007,5 +4019,119 @@ mod tests {
         // In no_umi mode, short UMIs should be accepted (min_umi_length is not checked)
         assert!(filter_template(&template, &config, &mut metrics));
         assert_eq!(metrics.accepted_templates(), 1);
+    }
+
+    // ========================================================================
+    // UMI-position-cache reorder pin (#334)
+    // ========================================================================
+
+    /// Builds one raw BAM record carrying a decoy `ZZ:Z:POISONXX` tag
+    /// immediately followed by the real `RX:Z:<umi>` tag, via
+    /// [`RawSamBuilder`] rather than hand-rolled record bytes: `ZZ` is one of
+    /// `xtask check-tag-literals`' allowlisted opaque test-fixture tags (it
+    /// carries no SAM-tag semantics of its own -- see that scanner's
+    /// `PAYLOAD_ALLOWLIST`), and `add_string_tag` appends aux tags in call
+    /// order, so calling it for `ZZ` before `RX` deterministically places the
+    /// decoy first without any manual offset arithmetic.
+    ///
+    /// Returns the record plus the record-relative byte offset of the decoy
+    /// tag's *value* bytes (found the same way production decode finds a
+    /// cached UMI position: [`fgumi_raw_bam::aux_data_offset_from_record`] +
+    /// [`fgumi_raw_bam::find_string_tag_position`]). The decoy sits before
+    /// `RX` at a layout fixed by `name`'s length, so two records built with
+    /// same-length names place it at the same offset — which is what lets the
+    /// test below poison both records' caches to one shared, identical,
+    /// WRONG position.
+    fn build_record_with_decoy_before_rx(name: &[u8], umi: &[u8]) -> (RawRecord, u32) {
+        let mut b = RawSamBuilder::new();
+        b.read_name(name)
+            .ref_id(0)
+            .pos(100)
+            .mapq(30)
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT)
+            .cigar_ops(&[encode_op(0, 4)])
+            .sequence(b"ACGT")
+            .add_string_tag(*b"ZZ", b"POISONXX")
+            .add_string_tag(*SamTag::RX, umi);
+        let raw = b.build();
+
+        let aux_offset = fgumi_raw_bam::aux_data_offset_from_record(raw.as_ref())
+            .expect("record has aux data past the fixed/name/cigar/seq/qual fields");
+        let aux = fgumi_raw_bam::aux_data_slice(raw.as_ref());
+        let (decoy_off_in_aux, decoy_len) = fgumi_raw_bam::find_string_tag_position(aux, *b"ZZ")
+            .expect("decoy ZZ tag must be present in aux data");
+        assert_eq!(decoy_len, 8, "decoy value POISONXX must be 8 bytes");
+        let decoy_value_offset =
+            u32::try_from(aux_offset + decoy_off_in_aux as usize).expect("offset fits in a u32");
+
+        (raw, decoy_value_offset)
+    }
+
+    /// Pins the reorder in `process_position_group` itself, not merely its
+    /// output. Two single-end templates share one position; their real `RX`
+    /// aux tags carry two DISTINCT UMIs (`AAAAAAAA`, `CCCCCCCC`), but each
+    /// record's `cached_umi_position` is deliberately poisoned (as a
+    /// wrong-offset cache mis-slice would poison it) to point at a decoy
+    /// region holding the SAME literal string (`POISONXX`) in both records.
+    ///
+    /// - Under the fixed ordering (`assign_umi_groups` before the
+    ///   duplicate-flag-clearing `records_mut()` preamble), the poisoned cache
+    ///   is still valid when `assign_umi_groups` reads it via
+    ///   `Template::cached_umi()`: both templates resolve to the identical
+    ///   decoy string, so `IdentityUmiAssigner` collapses them into ONE
+    ///   molecule.
+    /// - Under the pre-fix ordering (`records_mut()` before
+    ///   `assign_umi_groups`), `records_mut()` unconditionally clears
+    ///   `cached_umi_position`, so `assign_umi_groups` falls back to scanning
+    ///   aux data for the real `RX` tag and correctly finds the two DISTINCT
+    ///   UMI values, yielding TWO molecules.
+    ///
+    /// This test therefore fails under the pre-fix ordering and passes under
+    /// the fix: unlike an output-correctness check (which the aux-scan
+    /// fallback already satisfies on its own), it is a direct behavioral pin
+    /// on "the cache is actually consulted, not silently bypassed".
+    #[test]
+    fn test_assign_umi_groups_reads_the_cache_not_a_rescan_after_reorder() {
+        use crate::unified_pipeline::{DecodedRecord, GroupKey};
+
+        let (raw_a, decoy_offset_a) = build_record_with_decoy_before_rx(b"polyA1", b"AAAAAAAA");
+        let (raw_b, decoy_offset_b) = build_record_with_decoy_before_rx(b"polyA2", b"CCCCCCCC");
+        assert_eq!(
+            decoy_offset_a, decoy_offset_b,
+            "fixture invariant: the decoy value must sit at the same record-relative offset \
+             in both records so poisoning both caches to it is an apples-to-apples test"
+        );
+
+        let mut decoded_a = DecodedRecord::from_raw_bytes(raw_a, GroupKey::default());
+        decoded_a.set_cached_umi(decoy_offset_a, 8);
+        let mut decoded_b = DecodedRecord::from_raw_bytes(raw_b, GroupKey::default());
+        decoded_b.set_cached_umi(decoy_offset_b, 8);
+
+        let group = RawPositionGroup {
+            group_key: GroupKey::default(),
+            records: vec![decoded_a, decoded_b],
+        };
+
+        let filter_config = TemplateFilterConfig::default();
+        let assigner = IdentityUmiAssigner::new();
+        let processed = process_position_group(
+            group,
+            &filter_config,
+            &assigner,
+            SamTag::RX,
+            None,
+            false,
+            false,
+        )
+        .expect("process_position_group should succeed on this well-formed fixture");
+
+        assert_eq!(
+            processed.distinct_mi_count, 1,
+            "assign_umi_groups must read the still-valid UMI-position cache (poisoned to an \
+             identical decoy string on both templates) rather than falling back to an aux-data \
+             rescan of the real, distinct RX values -- got {} distinct molecule(s), which means \
+             the cache was NOT consulted at the point assign_umi_groups ran",
+            processed.distinct_mi_count
+        );
     }
 }

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -1113,16 +1113,44 @@ impl<'a> ChainBuilder<'a> {
         let cell_tag = Tag::from(SamTag::CB);
         let library_index = fgumi_bam_io::LibraryIndex::from_header(&self.header);
         let config = fgumi_bam_io::GroupKeyConfig::new(library_index, cell_tag);
-        // When a Group stage is in the chain, cache the UMI (RX) value position
-        // during decode so `fgumi group`'s per-template UMI-assignment lookup can
-        // slice it without re-scanning aux data (#334). Group's UMI tag is fixed
-        // to RX (see `add_group`'s `raw_tag`). Chains without a Group stage skip
-        // the cache to avoid the extra per-record aux scan.
-        if self.spec.stages.contains(&Stage::Group) {
+        // When a Group or Dedup stage is in the chain, cache the UMI (RX) value
+        // position during decode so the per-template UMI-assignment lookup
+        // (`fgumi group`'s and `fgumi dedup`'s) can slice it without re-scanning
+        // aux data (#334). Both stages' UMI tag is fixed to RX (see `add_group`'s
+        // and `add_dedup`'s `raw_tag`), and both consume the cache through the
+        // same `Template::cached_umi()` fallback path, so enabling it changes only
+        // how the RX position is found, never the grouping/dedup result. Chains
+        // with neither stage skip the cache to avoid the extra per-record aux
+        // scan. Extracted into `stages_want_umi_cache` so the gate is unit
+        // testable without constructing a full `ChainBuilder`.
+        //
+        // `--no-umi` additionally suppresses the cache even when Group/Dedup is
+        // present: no UMI grouping happens under `--no-umi` (both stages force
+        // identity/position-only grouping and never call `cached_umi()`), so the
+        // non-chain paths (`GroupReadsByUmi::execute`, `MarkDuplicates::execute`)
+        // deliberately skip `with_umi_tag` in that mode too. Without this the
+        // chain would pay a per-record decode-time RX aux-scan to populate a
+        // cache nothing ever reads under `--no-umi` — output-neutral, but a
+        // wasted-work regression the non-chain path doesn't have. `no_umi` is
+        // threaded in through `umi_cache_enabled` (rather than into
+        // `stages_want_umi_cache`, which stays a pure function of `stages` alone)
+        // since only this call site has `self.spec.stage_opts` in scope.
+        if umi_cache_enabled(&self.spec.stages, self.stage_no_umi()) {
             config.with_umi_tag(*SamTag::RX)
         } else {
             config
         }
+    }
+
+    /// Whether the chain's `Group` or `Dedup` stage options request `--no-umi`.
+    ///
+    /// Used only to gate the UMI-position cache in [`Self::bam_group_key_config`]
+    /// (see its doc comment); a chain has at most one of `Group`/`Dedup` in
+    /// practice (`Dedup` is currently always a standalone single-stage chain),
+    /// but checking both keeps this correct if that ever changes.
+    fn stage_no_umi(&self) -> bool {
+        self.spec.stage_opts.group.as_ref().is_some_and(|g| g.no_umi)
+            || self.spec.stage_opts.dedup.as_ref().is_some_and(|d| d.no_umi)
     }
 
     /// Group-key config for the **source preamble's** `DecodeRecords`.
@@ -4947,6 +4975,40 @@ fn sort_budget_threads(num_threads: usize, sort_threads: Option<usize>) -> usize
     crate::commands::common::sort_memory_budget_threads(num_threads, sort_threads)
 }
 
+/// Whether `stages` should have the Decode step cache the UMI (RX) value
+/// position (see [`ChainBuilder::bam_group_key_config`]).
+///
+/// `Group` and `Dedup` both key their per-template UMI-assignment lookup on a
+/// fixed RX tag and consume the cache through the same
+/// `Template::cached_umi()` fallback path (see `bam_group_key_config`'s doc
+/// comment for the full rationale), so both enable it. Extracted as a free
+/// function so the gate can be unit tested without constructing a full
+/// `ChainBuilder` (which requires an opened BAM/SAM/FASTQ source).
+///
+/// [`ChainBuilder::bam_group_key_config`]: ChainBuilder::bam_group_key_config
+fn stages_want_umi_cache(stages: &[Stage]) -> bool {
+    stages.iter().any(|s| matches!(s, Stage::Group | Stage::Dedup))
+}
+
+/// Whether the Decode step should actually cache the UMI (RX) value position,
+/// combining [`stages_want_umi_cache`] with the `--no-umi` override.
+///
+/// `--no-umi` forces identity/position-only grouping on both `Group` and
+/// `Dedup` (see their `no_umi` handling in `src/lib/commands/{group,dedup}.rs`),
+/// so neither ever calls `Template::cached_umi()` in that mode — the non-chain
+/// paths (`GroupReadsByUmi::execute`, `MarkDuplicates::execute`) already skip
+/// `GroupKeyConfig::with_umi_tag` under `--no-umi` for exactly this reason. This
+/// keeps `stages_want_umi_cache` a pure function of `stages` alone (so its
+/// existing tests need no `no_umi` parameter) while still gating the combined
+/// decision on it; `no_umi` is threaded in here, at
+/// [`ChainBuilder::bam_group_key_config`]'s call site, rather than folded into
+/// `stages_want_umi_cache` itself.
+///
+/// [`ChainBuilder::bam_group_key_config`]: ChainBuilder::bam_group_key_config
+fn umi_cache_enabled(stages: &[Stage], no_umi: bool) -> bool {
+    stages_want_umi_cache(stages) && !no_umi
+}
+
 /// Uniform "reference dictionary not found" error, shared by the zipper source
 /// open (`open_source`) and `add_align`, so both dict-resolution sites report
 /// the same actionable message (which paths were tried + the `samtools dict`
@@ -5074,6 +5136,106 @@ mod tests {
             !config.name_hash_only,
             "Stage::Group as the first stage must compute the full position/RG/CB key"
         );
+    }
+
+    /// `bam_group_key_config`'s UMI-position-cache gate (issue #334: dedup-only
+    /// chains left the cache gate inert, falling back to an aux-data rescan per
+    /// record). The cache must be enabled whenever `Group` or
+    /// `Dedup` is in the chain, and skipped otherwise. Exercised directly
+    /// against `stages_want_umi_cache` — the exact gate `bam_group_key_config`
+    /// calls — so this cannot drift from the production decision.
+    #[test]
+    fn stages_want_umi_cache_enables_for_group_and_dedup() {
+        use crate::pipeline::chains::Stage;
+
+        assert!(
+            stages_want_umi_cache(&[Stage::Group]),
+            "a Group-only chain must enable the UMI-position cache"
+        );
+        assert!(
+            stages_want_umi_cache(&[Stage::Dedup]),
+            "a Dedup-only chain must enable the UMI-position cache"
+        );
+        // [Sort, Dedup] is not a combination `validate_stage_progression` (and every
+        // real command's `ChainSpec`) ever produces: `Dedup` is currently always the
+        // sole stage of a standalone `fgumi dedup` chain (`ChainSpec::single_stage`),
+        // and `add_dedup` itself rejects an intermediate position. [Sort, Group] is
+        // the reachable multi-stage combination instead — `stage_ord(Sort) = 4 <=
+        // stage_ord(Group) = 5` passes `validate_stage_progression`, and `add_group`
+        // has no positional restriction — so it exercises the `.any()` finding its
+        // trigger stage past the first position on an input the validator actually
+        // permits.
+        assert!(
+            stages_want_umi_cache(&[Stage::Sort, Stage::Group]),
+            "Group anywhere in the chain must enable the UMI-position cache"
+        );
+        assert!(
+            !stages_want_umi_cache(&[Stage::Sort]),
+            "a chain with neither Group nor Dedup must skip the UMI-position cache"
+        );
+        assert!(
+            !stages_want_umi_cache(&[]),
+            "an empty stage list must skip the UMI-position cache"
+        );
+    }
+
+    /// `umi_cache_enabled` combines `stages_want_umi_cache` with the `--no-umi`
+    /// override (see its doc comment / `bam_group_key_config`'s doc comment for
+    /// the full rationale): `--no-umi` must suppress the cache even when `Group`
+    /// or `Dedup` is present, matching the non-chain paths
+    /// (`GroupReadsByUmi::execute`, `MarkDuplicates::execute`), which skip
+    /// `GroupKeyConfig::with_umi_tag` under `--no-umi` because neither ever
+    /// calls `Template::cached_umi()` in that mode.
+    #[test]
+    fn umi_cache_enabled_respects_no_umi_for_group_and_dedup() {
+        use crate::pipeline::chains::Stage;
+
+        assert!(
+            umi_cache_enabled(&[Stage::Group], false),
+            "Group without --no-umi must enable the UMI-position cache"
+        );
+        assert!(
+            !umi_cache_enabled(&[Stage::Group], true),
+            "Group with --no-umi must NOT enable the UMI-position cache"
+        );
+        assert!(
+            umi_cache_enabled(&[Stage::Dedup], false),
+            "Dedup without --no-umi must enable the UMI-position cache"
+        );
+        assert!(
+            !umi_cache_enabled(&[Stage::Dedup], true),
+            "Dedup with --no-umi must NOT enable the UMI-position cache"
+        );
+        assert!(
+            !umi_cache_enabled(&[Stage::Sort], true),
+            "a chain with neither Group nor Dedup must stay disabled regardless of --no-umi"
+        );
+    }
+
+    /// Direct wiring check for `bam_group_key_config`: a `Dedup` chain must
+    /// thread the `umi_cache_enabled` gate into the returned `GroupKeyConfig`,
+    /// so the config carries `umi_tag = Some(RX)` by default and `None` under
+    /// `--no-umi`. The sibling `stages_want_umi_cache`/`umi_cache_enabled` tests
+    /// prove the *gate*; this proves the gate is actually reflected in the
+    /// `GroupKeyConfig` the decode path consumes.
+    #[rstest::rstest]
+    #[case::dedup_with_umi(false, Some(*crate::sam::SamTag::RX))]
+    #[case::dedup_no_umi(true, None)]
+    fn bam_group_key_config_umi_tag_for_dedup(
+        #[case] no_umi: bool,
+        #[case] expected_umi_tag: Option<[u8; 2]>,
+    ) {
+        use clap::Parser;
+        let mut args = vec!["dedup", "--input", "in.bam", "--output", "out.bam"];
+        if no_umi {
+            args.push("--no-umi");
+        }
+        let dedup = crate::commands::dedup::MarkDuplicates::try_parse_from(args)
+            .expect("failed to parse dedup args");
+        let mut spec = empty_spec(vec![Stage::Dedup]);
+        spec.stage_opts.dedup = Some(dedup);
+        let builder = chain_builder_for_stages(&spec);
+        assert_eq!(builder.bam_group_key_config().umi_tag, expected_umi_tag);
     }
 
     /// Pin the per-phase thread resolution contract shared by the standalone and

--- a/tests/integration/test_dedup_command.rs
+++ b/tests/integration/test_dedup_command.rs
@@ -40,7 +40,7 @@ fn create_sorted_bam(path: &Path, records: Vec<RawRecord>) {
 /// Create a group of paired-end reads at the same position with the same UMI
 /// (simulating PCR duplicates).
 fn create_duplicate_group(base_name: &str, umi: &str, count: usize, start: i32) -> Vec<RawRecord> {
-    create_duplicate_group_inner(base_name, umi, count, start, None, 60, 30)
+    create_duplicate_group_inner(base_name, umi, count, start, DuplicateGroupOptions::default())
 }
 
 /// A single paired-end template (R1 + R2) at `start` with UMI `umi`, every base
@@ -50,7 +50,13 @@ fn create_duplicate_group(base_name: &str, umi: &str, count: usize, start: i32) 
 /// which are marked duplicate) deterministic — the unique maximum wins, with no
 /// score tie whose resolution would depend on stream order.
 fn create_template_qual(name: &str, umi: &str, start: i32, base_qual: u8) -> Vec<RawRecord> {
-    create_duplicate_group_inner(name, umi, 1, start, None, 60, base_qual)
+    create_duplicate_group_inner(
+        name,
+        umi,
+        1,
+        start,
+        DuplicateGroupOptions { base_qual, ..Default::default() },
+    )
 }
 
 /// Like [`create_duplicate_group`] but with an explicit `mapq`, so a fixture can
@@ -63,24 +69,79 @@ fn create_duplicate_group_mapq(
     start: i32,
     mapq: u8,
 ) -> Vec<RawRecord> {
-    create_duplicate_group_inner(base_name, umi, count, start, None, mapq, 30)
+    create_duplicate_group_inner(
+        base_name,
+        umi,
+        count,
+        start,
+        DuplicateGroupOptions { mapq, ..Default::default() },
+    )
 }
 
-/// Shared implementation for [`create_duplicate_group`] and
-/// [`create_duplicate_group_with_rg`]: builds `count` paired-end duplicate
-/// templates, tagging each record with `RG:Z:{rg_id}` only when `rg_id` is
-/// `Some`. Keeping one implementation means the exact record shape the per-library
-/// and ladder tests derive their template counts from can never diverge between
-/// the RG and non-RG variants.
+/// Like [`create_duplicate_group`] but inserts `filler_tags` throwaway integer
+/// tags (`Z0`, `Z1`, ...) before the `RX` tag on every record, shifting the RX
+/// value's aux-data byte offset. `create_duplicate_group` always adds `RX`
+/// first, so its records all carry RX at aux offset 0 — too uniform to
+/// exercise the UMI-position cache (`ChainBuilder::bam_group_key_config`,
+/// issue #334), which caches whatever offset `RX` happens to land at during
+/// decode.
+fn create_duplicate_group_rx_offset(
+    base_name: &str,
+    umi: &str,
+    count: usize,
+    start: i32,
+    filler_tags: u8,
+) -> Vec<RawRecord> {
+    create_duplicate_group_inner(
+        base_name,
+        umi,
+        count,
+        start,
+        DuplicateGroupOptions { filler_tags, ..Default::default() },
+    )
+}
+
+/// Per-record knobs for [`create_duplicate_group_inner`], beyond the always-required
+/// name/UMI/count/start. Grouped into a struct (rather than four trailing positional
+/// `bool`/`u8` params) so call sites name only the field they vary and read as a
+/// spec, not a run of unlabeled literals like `(None, 60, 30, 0)`.
+#[derive(Debug, Clone, Copy)]
+struct DuplicateGroupOptions<'a> {
+    /// `RG:Z:<rg_id>` tag value; omitted from every record when `None`.
+    rg_id: Option<&'a str>,
+    /// Mapping quality for both mates.
+    mapq: u8,
+    /// Base quality for every base of both mates.
+    base_qual: u8,
+    /// Number of throwaway integer filler tags (`Z0`, `Z1`, ...) inserted
+    /// before `RX`, shifting its aux-data byte offset.
+    filler_tags: u8,
+}
+
+impl Default for DuplicateGroupOptions<'_> {
+    /// Matches [`create_duplicate_group`]'s plain case: no `RG`, MAPQ 60, base
+    /// quality 30, `RX` at aux offset 0 (no filler tags).
+    fn default() -> Self {
+        Self { rg_id: None, mapq: 60, base_qual: 30, filler_tags: 0 }
+    }
+}
+
+/// Shared implementation for [`create_duplicate_group`], [`create_duplicate_group_rx_offset`],
+/// and [`create_duplicate_group_with_rg`]: builds `count` paired-end duplicate
+/// templates, tagging each record with `RG:Z:{rg_id}` only when `opts.rg_id` is
+/// `Some` and inserting `opts.filler_tags` throwaway integer tags (`Z0`, `Z1`, ...)
+/// before `RX` to shift its aux-data offset. Keeping one implementation means
+/// the exact record shape the per-library and ladder tests derive their
+/// template counts from can never diverge between the RG, non-RG, and
+/// offset-varied variants.
 fn create_duplicate_group_inner(
     base_name: &str,
     umi: &str,
     count: usize,
     start: i32,
-    rg_id: Option<&str>,
-    mapq: u8,
-    base_qual: u8,
+    opts: DuplicateGroupOptions<'_>,
 ) -> Vec<RawRecord> {
+    let DuplicateGroupOptions { rg_id, mapq, base_qual, filler_tags } = opts;
     let mut records = Vec::new();
     for i in 0..count {
         let name = format!("{base_name}_{i}");
@@ -101,9 +162,11 @@ fn create_duplicate_group_inner(
                 .cigar_ops(&[8 << 4]) // 8M
                 .mate_ref_id(0)
                 .mate_pos(start + 99)
-                .template_length(108)
-                .add_string_tag(SamTag::RX, umi.as_bytes())
-                .add_string_tag(SamTag::MC, b"8M");
+                .template_length(108);
+            for f in 0..filler_tags {
+                b.add_int_tag([b'Z', b'0' + f], i32::from(f));
+            }
+            b.add_string_tag(SamTag::RX, umi.as_bytes()).add_string_tag(SamTag::MC, b"8M");
             if let Some(rg_id) = rg_id {
                 b.add_string_tag(SamTag::RG, rg_id.as_bytes());
             }
@@ -122,9 +185,11 @@ fn create_duplicate_group_inner(
                 .cigar_ops(&[8 << 4]) // 8M
                 .mate_ref_id(0)
                 .mate_pos(start - 1)
-                .template_length(-108)
-                .add_string_tag(SamTag::RX, umi.as_bytes())
-                .add_string_tag(SamTag::MC, b"8M");
+                .template_length(-108);
+            for f in 0..filler_tags {
+                b.add_int_tag([b'Z', b'0' + f], i32::from(f));
+            }
+            b.add_string_tag(SamTag::RX, umi.as_bytes()).add_string_tag(SamTag::MC, b"8M");
             if let Some(rg_id) = rg_id {
                 b.add_string_tag(SamTag::RG, rg_id.as_bytes());
             }
@@ -439,7 +504,13 @@ fn create_duplicate_group_with_rg(
     start: i32,
     rg_id: &str,
 ) -> Vec<RawRecord> {
-    create_duplicate_group_inner(base_name, umi, count, start, Some(rg_id), 60, 30)
+    create_duplicate_group_inner(
+        base_name,
+        umi,
+        count,
+        start,
+        DuplicateGroupOptions { rg_id: Some(rg_id), ..Default::default() },
+    )
 }
 
 /// Shared implementation for [`create_sorted_bam`]: writes `records` against the
@@ -2083,6 +2154,21 @@ fn dedup_run(input: &Path, output: &Path, extra: &[&str]) {
 /// identical to the non-chain (no-`--threads`) path. Run at both `--threads 1`
 /// (the minimal chain engine) and `--threads 4` (genuinely parallel) — dedup's
 /// output is deterministic, so both must equal the single oracle.
+///
+/// The fixture uses [`create_duplicate_group_rx_offset`] with a cycling filler
+/// count (0-3) so RX lands at a different aux-data offset from one group to the
+/// next, rather than always at offset 0. This is still a useful structural
+/// check (any divergence between the two engines shows up here), but it does
+/// NOT isolate the UMI-position cache: the non-chain oracle already enables
+/// the same cache unconditionally outside `--no-umi` mode (see
+/// `MarkDuplicates::execute`), so a wrong-offset mis-slice would corrupt both
+/// sides identically and this parity check would still pass; the fixture also
+/// gives every record in a group the SAME UMI under `--strategy identity`, so
+/// the UMI *value* never affects the result either. See
+/// [`test_dedup_umi_grouping_correct_with_varied_rx_aux_offsets`] for the
+/// hand-computed, cache-independent check this gap motivates -- and its doc
+/// comment for why no *end-to-end* dedup test can currently isolate the
+/// cache specifically.
 #[rstest]
 #[case::threads_1(&["--threads", "1"])]
 #[case::threads_4(&["--threads", "4"])]
@@ -2090,10 +2176,18 @@ fn test_dedup_chain_matches_single_threaded(#[case] thread_args: &[&str]) {
     let temp_dir = TempDir::new().unwrap();
     let input_bam = temp_dir.path().join("input.bam");
 
-    // Several distinct position groups so the chain sees multiple batches.
+    // Several distinct position groups so the chain sees multiple batches,
+    // with RX at a varied aux-data offset (0-3 filler tags) per group.
     let mut records = Vec::new();
     for i in 0..16 {
-        records.extend(create_duplicate_group(&format!("g{i}"), "ACGTACGT", 3, 100 + i * 200));
+        let filler_tags = u8::try_from(i % 4).expect("i % 4 is in 0..4, always fits in u8");
+        records.extend(create_duplicate_group_rx_offset(
+            &format!("g{i}"),
+            "ACGTACGT",
+            3,
+            100 + i * 200,
+            filler_tags,
+        ));
     }
     create_sorted_bam(&input_bam, records);
 
@@ -2111,6 +2205,178 @@ fn test_dedup_chain_matches_single_threaded(#[case] thread_args: &[&str]) {
     assert_eq!(
         actual, expected,
         "chain {thread_args:?} output must match the non-chain path record-for-record"
+    );
+}
+
+/// Cache-discriminating regression test for the UMI-position cache (#334).
+///
+/// [`test_dedup_chain_matches_single_threaded`] above compares chain vs
+/// non-chain output, but that comparison structurally cannot detect a cache
+/// mis-slice: both paths already enable the UMI-position cache (the
+/// non-chain path unconditionally, outside `--no-umi` mode), so a
+/// wrong-offset mis-slice corrupts both sides identically and the two would
+/// still agree; its fixture also gives every record in a group the same UMI
+/// under `--strategy identity`, so the UMI *value* never affects the result.
+/// This test fixes both gaps: it asserts against a CACHE-INDEPENDENT,
+/// hand-computed expectation (not "chain == non-chain"), and it varies the
+/// UMI *value* across records that share a position, with a varied number of
+/// filler tags before RX per record.
+///
+/// Five templates share one position: three carry UMI `AAAAAAAA` with 0, 1,
+/// and 2 filler tags before RX; two carry UMI `CCCCCCCC` with 0 and 3 filler
+/// tags before RX. `dedup` dedups each mate in its own
+/// position group rather than pairing R1 with R2 into one template first
+/// (see the doc comment on `count_template_pair_orphan` in
+/// `src/lib/commands/dedup.rs`), so this fixture yields TWO independent
+/// `assign_umi_groups` calls — one over the five R1 records, one over the
+/// five R2 records — confirmed empirically by dumping `(name, MI, duplicate)`
+/// for this exact fixture at `--threads 4`, `--threads 1`, and no `--threads`
+/// (all three agree). `IdentityUmiAssigner` (see
+/// `crates/fgumi-umi/src/assigner.rs`) mints exactly one molecule ID per
+/// distinct canonical UMI string among the UMIs given to one call, so EACH
+/// of the two independent calls collapses its three `AAAAAAAA` values and two
+/// `CCCCCCCC` values into 2 molecules — 4 molecules total, under
+/// `--strategy identity`, regardless of where RX sits in each record. This
+/// expectation is computed purely from the fixture's two distinct UMI
+/// strings and dedup's documented per-mate grouping; it holds independent of
+/// whatever engine or cache state produced it.
+///
+/// IMPORTANT — what this test does and does NOT prove: it pins dedup's
+/// output as correct on an RX-at-varied-aux-offsets fixture end-to-end,
+/// which is valuable regression coverage for exactly the input shape the
+/// `Stage::Dedup` cache-gate change touches. It does **not**,
+/// by itself, prove the UMI-position cache is what produced this result: the
+/// aux-tag rescan fallback in `assign_umi_groups_for_indices`
+/// (`src/lib/commands/dedup.rs`) is equally correct on this fixture, so an
+/// end-to-end output check like this one cannot distinguish "cache
+/// consulted" from "cache bypassed, rescanned aux data instead" — both paths
+/// agree on the right answer.
+///
+/// `process_position_group` now runs `assign_umi_groups` *before* the
+/// duplicate-flag-clearing preamble (previously it ran after), specifically
+/// so the still-valid `cached_umi_position` written during decode survives to
+/// this read instead of being cleared first by `Template::records_mut()`'s
+/// blanket cache invalidation. That reorder is pinned directly — not via an
+/// output-correctness fixture like this one, which cannot discriminate the
+/// two orderings — by
+/// `commands::dedup::tests::test_assign_umi_groups_reads_the_cache_not_a_rescan_after_reorder`
+/// in `src/lib/commands/dedup.rs`: it poisons the cached position on two
+/// templates to a shared decoy value distinct from their real (and mutually
+/// distinct) `RX` tags, so "cache consulted" and "cache bypassed" produce
+/// different molecule counts (1 vs. 2) rather than agreeing as they do here.
+#[test]
+fn test_dedup_umi_grouping_correct_with_varied_rx_aux_offsets() {
+    let temp_dir = TempDir::new().unwrap();
+    let input_bam = temp_dir.path().join("input.bam");
+
+    let mut records = Vec::new();
+    // Three "AAAAAAAA" templates, with 0, 1, 2 filler tags before RX.
+    for (i, filler_tags) in [0u8, 1, 2].into_iter().enumerate() {
+        records.extend(create_duplicate_group_rx_offset(
+            &format!("a{i}"),
+            "AAAAAAAA",
+            1,
+            500,
+            filler_tags,
+        ));
+    }
+    // Two "CCCCCCCC" templates, with 0, 3 filler tags before RX.
+    for (i, filler_tags) in [0u8, 3].into_iter().enumerate() {
+        records.extend(create_duplicate_group_rx_offset(
+            &format!("c{i}"),
+            "CCCCCCCC",
+            1,
+            500,
+            filler_tags,
+        ));
+    }
+    create_sorted_bam(&input_bam, records);
+
+    let output = temp_dir.path().join("output.bam");
+    dedup_run(&input_bam, &output, &["--strategy", "identity", "--threads", "4"]);
+
+    let deduped = read_deduped_records(&output);
+    assert_eq!(deduped.len(), 10, "5 templates x 2 records must all be present in output");
+
+    let mi_tag = Tag::from(SamTag::MI);
+    let mi_of = |r: &noodles::sam::alignment::RecordBuf| -> String {
+        r.data()
+            .get(&mi_tag)
+            .map(|value| match value {
+                Value::String(mi) => mi.to_string(),
+                other => panic!("MI must be a string tag, got {other:?}"),
+            })
+            .expect("every identity-strategy record must carry an MI tag")
+    };
+
+    // Partition the deduped records by (UMI class, mate side) and collect the MI
+    // value(s) each partition carries. A bare "distinct MI count" is too weak:
+    // incorrect grouping (e.g. an AAAAAAAA record mis-binned with a CCCCCCCC one)
+    // can still yield the expected number of labels. Assert the partitions directly
+    // -- every record in a partition must share ONE MI, and the two UMIs' MI sets
+    // must be disjoint (see the two assertions below).
+    let mut partition_mis: std::collections::BTreeMap<
+        (&str, bool),
+        std::collections::BTreeSet<String>,
+    > = std::collections::BTreeMap::new();
+    let mut partition_sizes: std::collections::BTreeMap<(&str, bool), usize> =
+        std::collections::BTreeMap::new();
+    for r in &deduped {
+        let name = r.name().expect("output record must be named").to_string();
+        let umi_class = if name.starts_with('a') {
+            "AAAAAAAA"
+        } else if name.starts_with('c') {
+            "CCCCCCCC"
+        } else {
+            panic!("unexpected read name {name:?}");
+        };
+        let key = (umi_class, r.flags().is_first_segment());
+        partition_mis.entry(key).or_default().insert(mi_of(r));
+        *partition_sizes.entry(key).or_default() += 1;
+    }
+
+    // Each (UMI class, mate side) partition must carry exactly one MI: the three
+    // AAAAAAAA records share one MI per mate, and the two CCCCCCCC records share
+    // another MI per mate.
+    for (key, mis) in &partition_mis {
+        assert_eq!(
+            mis.len(),
+            1,
+            "the {} {} records must all share one MI, got {mis:?}",
+            key.0,
+            if key.1 { "R1" } else { "R2" },
+        );
+    }
+
+    // Partition sizes: AAAAAAAA has 3 templates (3 records per mate side),
+    // CCCCCCCC has 2 (2 records per mate side).
+    assert_eq!(partition_sizes.get(&("AAAAAAAA", true)).copied(), Some(3));
+    assert_eq!(partition_sizes.get(&("AAAAAAAA", false)).copied(), Some(3));
+    assert_eq!(partition_sizes.get(&("CCCCCCCC", true)).copied(), Some(2));
+    assert_eq!(partition_sizes.get(&("CCCCCCCC", false)).copied(), Some(2));
+
+    // Distinct UMIs are distinct molecules: the MI(s) the AAAAAAAA records carry
+    // must be disjoint from the MI(s) the CCCCCCCC records carry, so no record of
+    // one UMI is grouped with the other. Assert cross-UMI disjointness rather than
+    // a fixed total MI count: the exact molecule-id integers -- and whether the two
+    // mate sides of one UMI happen to share an id -- are non-deterministic under
+    // `--threads` (the parallel assigner hands out molecule-id blocks in
+    // thread-completion order), so a "4 distinct MIs" count is flaky while the
+    // grouping contract this test exists to check is not.
+    let aaaa_mis: std::collections::BTreeSet<&String> = partition_mis
+        .iter()
+        .filter(|((umi_class, _), _)| *umi_class == "AAAAAAAA")
+        .flat_map(|(_, mis)| mis)
+        .collect();
+    let cccc_mis: std::collections::BTreeSet<&String> = partition_mis
+        .iter()
+        .filter(|((umi_class, _), _)| *umi_class == "CCCCCCCC")
+        .flat_map(|(_, mis)| mis)
+        .collect();
+    assert!(
+        aaaa_mis.is_disjoint(&cccc_mis),
+        "AAAAAAAA and CCCCCCCC records must not share any MI (distinct UMIs are distinct \
+         molecules); AAAAAAAA MIs = {aaaa_mis:?}, CCCCCCCC MIs = {cccc_mis:?}",
     );
 }
 
@@ -2547,63 +2813,6 @@ fn test_dedup_marks_families_and_flags_tc_keyed_secondary_supplementary(#[case] 
 // --verify (strict template-coordinate sort-order gate)
 // ============================================================================
 
-/// Build `count` paired-end duplicate templates with INTERNALLY CONSISTENT
-/// mate-strand flags: R1 forward with `MATE_REVERSE` set, R2 reverse with its
-/// mate forward. Unlike [`create_duplicate_group`], whose R1 omits
-/// `MATE_REVERSE`, this makes R1 and R2 resolve to the *same* template
-/// coordinate — a prerequisite for the strict `--verify` order check, which keys
-/// on the exact `fgumi sort --order template-coordinate` key. (An inconsistent
-/// pair splits into two different coordinates, which the strict check then reads
-/// as an out-of-order file.)
-fn create_consistent_pair_group(
-    base_name: &str,
-    umi: &str,
-    count: usize,
-    start: i32,
-) -> Vec<RawRecord> {
-    let mut records = Vec::new();
-    for i in 0..count {
-        let name = format!("{base_name}_{i}");
-        let r1 = {
-            let mut b = SamBuilder::new();
-            b.read_name(name.as_bytes())
-                .sequence(b"ACGTACGT")
-                .qualities(&[30; 8])
-                .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
-                .ref_id(0)
-                .pos(start - 1)
-                .mapq(60)
-                .cigar_ops(&[8 << 4]) // 8M
-                .mate_ref_id(0)
-                .mate_pos(start + 99)
-                .template_length(108)
-                .add_string_tag(SamTag::RX, umi.as_bytes())
-                .add_string_tag(SamTag::MC, b"8M");
-            b.build()
-        };
-        let r2 = {
-            let mut b = SamBuilder::new();
-            b.read_name(name.as_bytes())
-                .sequence(b"ACGTACGT")
-                .qualities(&[30; 8])
-                .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
-                .ref_id(0)
-                .pos(start + 99)
-                .mapq(60)
-                .cigar_ops(&[8 << 4]) // 8M
-                .mate_ref_id(0)
-                .mate_pos(start - 1)
-                .template_length(-108)
-                .add_string_tag(SamTag::RX, umi.as_bytes())
-                .add_string_tag(SamTag::MC, b"8M");
-            b.build()
-        };
-        records.push(r1);
-        records.push(r2);
-    }
-    records
-}
-
 /// Write `records` verbatim (NO sorting) under a header that advertises
 /// `SS:template-coordinate`. Unlike [`create_sorted_bam`], which shells out to
 /// `fgumi sort`, this preserves the caller's record order, so the header-level
@@ -2649,8 +2858,8 @@ fn test_dedup_verify_accepts_sorted_input(#[case] threads: &[&str]) {
     let temp_dir = TempDir::new().unwrap();
     let input_bam = temp_dir.path().join("input.bam");
     // Ascending start positions → correctly template-coordinate sorted.
-    let mut records = create_consistent_pair_group("dup1", "ACGTACGT", 3, 100);
-    records.extend(create_consistent_pair_group("dup2", "TGCATGCA", 2, 500));
+    let mut records = create_duplicate_group("dup1", "ACGTACGT", 3, 100);
+    records.extend(create_duplicate_group("dup2", "TGCATGCA", 2, 500));
     create_sorted_bam(&input_bam, records);
 
     let baseline_out = temp_dir.path().join("baseline.bam");
@@ -2683,8 +2892,8 @@ fn test_dedup_verify_rejects_out_of_order_input(#[case] threads: &[&str]) {
     // Descending start positions → genuinely out of order under a TC-advertising
     // header (the group at 500 is written before the group at 100). Written
     // verbatim — NOT through `fgumi sort`, which would reorder it into order.
-    let mut records = create_consistent_pair_group("late", "ACGTACGT", 2, 500);
-    records.extend(create_consistent_pair_group("early", "TGCATGCA", 2, 100));
+    let mut records = create_duplicate_group("late", "ACGTACGT", 2, 500);
+    records.extend(create_duplicate_group("early", "TGCATGCA", 2, 100));
     write_bam_tc_header_unsorted(&input_bam, &records);
 
     // Without --verify the out-of-order input is accepted (no ordering guard).
@@ -2721,7 +2930,7 @@ fn test_dedup_verify_accepts_sorted_multi_batch_chain() {
     // accumulator and the upstream decode batch).
     let mut records = Vec::new();
     for i in 0..600i32 {
-        records.extend(create_consistent_pair_group(&format!("t{i}"), "ACGTACGT", 1, 100 + i * 10));
+        records.extend(create_duplicate_group(&format!("t{i}"), "ACGTACGT", 1, 100 + i * 10));
     }
     create_sorted_bam(&input_bam, records);
 
@@ -2841,8 +3050,8 @@ fn test_dedup_verify_rejects_coordinate_ordered_input() {
     // Two templates. Template-coordinate order keeps each mate pair adjacent
     // (T1.R1,T1.R2,T2.R1,T2.R2); coordinate order interleaves them by leftmost
     // position: R1@100, R1@150, R2@200, R2@250.
-    let t1 = create_consistent_pair_group("T1", "ACGTACGT", 1, 100); // [R1@100, R2@200]
-    let t2 = create_consistent_pair_group("T2", "TGCATGCA", 1, 150); // [R1@150, R2@250]
+    let t1 = create_duplicate_group("T1", "ACGTACGT", 1, 100); // [R1@100, R2@200]
+    let t2 = create_duplicate_group("T2", "TGCATGCA", 1, 150); // [R1@150, R2@250]
     let coordinate_order = vec![t1[0].clone(), t2[0].clone(), t1[1].clone(), t2[1].clone()];
     write_bam_tc_header_unsorted(&input_bam, &coordinate_order);
 


### PR DESCRIPTION
## What

`process_position_group` ran the duplicate-flag-clearing preamble — which calls `Template::records_mut()`, unconditionally invalidating `cached_umi_position` — **before** `assign_umi_groups` read the cache via `Template::cached_umi()`. So the cache was always empty by the time it was consulted, and the `Stage::Group | Stage::Dedup` UMI-position-cache gate was **inert on the dedup path** (chain and legacy): dead infrastructure that never ran as designed.

Reorder `assign_umi_groups` to run first, then clear duplicate flags. The two steps touch disjoint state — `assign_umi_groups` only reads `cached_umi()`/`r1()`/`r2()` and writes `Template::mi`, while the flag-clear loop only writes the BAM FLAG field via `fgumi_raw_bam::set_flags` — so they commute and the output is **byte-identical** to the previous ordering. Fixes both the chain and legacy dedup paths, which both funnel through `process_position_group`.

## This is a correctness fix, not a perf optimization

Benchmarked on a Mac Studio (M3 Ultra, arm64, 8 threads, CPU-seconds via `/usr/bin/time -l`, 3 reps, byte-identical output): **within noise of baseline** (18.0M mapped reads, adjacency, umis/pos=4 — baseline 37.23 vs 37.17 CPU-s). It is deliberately framed as a fix rather than a `perf` change:

For dedup the position-group key is coordinate-based (the UMI is used only *within* a group for adjacency clustering), so the Decode step has no other reason to read the UMI. Consulting the cache therefore **relocates** the UMI `find_string_tag` scan into Decode rather than **eliminating** it — total work is unchanged. The value is that existing cache infrastructure now runs as designed instead of being silently inert, and the ordering inconsistency (a gate that did nothing) is removed.

## Tests

A cache-poison discriminating unit test (RX tag preceded by a decoy `ZZ:Z` tag at a varied aux offset) plus an end-to-end parity fixture, pinning byte-identical dedup output regardless of whether the cache is consulted or the aux-rescan fallback runs. Full gate green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: output changes only for affected deduplication grouping; cache-ordering tests and end-to-end parity tests pin the result. `unsafe` changes none, and the CLAUDE.md allowlist changes none. Memory bounds, queue capacity, and thread/backpressure policy changes none.

Reorders UMI assignment before duplicate-flag clearing so cached UMI positions remain available. Enables UMI-position caching for `Group` and `Dedup`, except with `--no-umi`. Adds unit and integration coverage for cache use, auxiliary-tag offsets, UMI partitioning, and output parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->