### PR TITLE
refactor(retag): retire the legacy single-threaded path; the chain is the only path

### DIFF
--- a/src/lib/commands/common.rs
+++ b/src/lib/commands/common.rs
@@ -967,11 +967,11 @@ impl ThreadingMode {
 /// ```
 #[derive(Debug, Clone, Args)]
 pub struct ThreadingOptions {
-    /// Number of threads for the multi-threaded pipeline.
+    /// Number of worker threads for the processing pipeline.
     ///
-    /// If not specified, uses a single-threaded fast path optimized for
-    /// simple streaming. When specified (even with --threads 1), uses the
-    /// 7-step parallel pipeline with work-stealing scheduler.
+    /// If not specified, the command runs at a single worker. When specified
+    /// (even with --threads 1), it runs the multi-worker pipeline with a
+    /// work-stealing scheduler, capping total threads at N.
     #[arg(long = "threads")]
     pub threads: Option<usize>,
 }

--- a/src/lib/commands/retag.rs
+++ b/src/lib/commands/retag.rs
@@ -32,17 +32,14 @@ use std::sync::atomic::AtomicU64;
 
 use anyhow::{Result, bail, ensure};
 use clap::Parser;
-use fgumi_bam_io::{ProgressTracker, create_raw_bam_reader_with_opts, create_raw_bam_writer};
 use fgumi_raw_bam::{RawRecord, append_raw_tag, remove_tag};
-use log::{info, warn};
 use serde::{Deserialize, Serialize};
 
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, SchedulerOptions, ThreadingOptions,
-    add_pg_record, ensure_hd_record, reject_output_collisions,
+    reject_output_collisions,
 };
-use crate::logging::OperationTimer;
 use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::sam::SamTag;
 
@@ -145,7 +142,7 @@ impl FromStr for RetagOp {
 /// `dst_overwritten` counts `copy`/`move` records whose destination already held a
 /// value that was replaced (always `0` for `delete`).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct OpCounts {
+pub(crate) struct OpCounts {
     /// Records where the source tag was present and the operation was applied.
     pub records_applied: u64,
     /// Records (copy/move) where an existing destination value was overwritten.
@@ -188,21 +185,21 @@ fn copy_tag(record: &mut RawRecord, src: SamTag, dst: SamTag, counts: &mut OpCou
 /// Operations are pure per-record edits: `copy` adds `dst` and keeps `src`, `move`
 /// additionally drops `src`, and `delete` drops `src`. A record missing the source
 /// tag is left unchanged and counted in `src_missing`.
-pub fn apply_op(record: &mut RawRecord, op: &RetagOp, counts: &mut OpCounts) {
+pub(crate) fn apply_op(record: &mut RawRecord, op: RetagOp, counts: &mut OpCounts) {
     match op {
         RetagOp::Copy { src, dst } => {
-            copy_tag(record, *src, *dst, counts);
+            copy_tag(record, src, dst, counts);
         }
         RetagOp::Move { src, dst } => {
             // The parser rejects `src == dst`, so removing `src` never touches the
             // just-written `dst`.
-            if copy_tag(record, *src, *dst, counts) {
-                remove_tag(record.as_mut_vec(), *src);
+            if copy_tag(record, src, dst, counts) {
+                remove_tag(record.as_mut_vec(), src);
             }
         }
         RetagOp::Delete { src } => {
-            if record.tags().contains(*src) {
-                remove_tag(record.as_mut_vec(), *src);
+            if record.tags().contains(src) {
+                remove_tag(record.as_mut_vec(), src);
                 counts.records_applied += 1;
             } else {
                 counts.src_missing += 1;
@@ -343,10 +340,10 @@ pub struct Retag {
 
     /// Optional TSV file for per-operation metrics.
     ///
-    /// Works with `--threads`: the per-operation counts are summed across the
-    /// pipeline's worker threads, so the metrics are identical to a
-    /// single-threaded run. (This differs from `clip`, whose per-read metrics
-    /// are not summable and so are rejected under `--threads`.)
+    /// The per-operation counts are summed across the pipeline's worker threads,
+    /// so the metrics are identical regardless of `--threads`. (This differs from
+    /// `clip`, whose per-read metrics are not summable and so are rejected under
+    /// `--threads`.)
     #[arg(short = 'M', long = "metrics")]
     pub metrics: Option<PathBuf>,
 
@@ -354,16 +351,17 @@ pub struct Retag {
     #[command(flatten)]
     pub compression: CompressionOptions,
 
-    /// Threading options: `--threads N` routes through the declarative chain
-    /// builder (the typed-step pipeline) via `execute_chain`.
+    /// Threading options. retag always runs on the declarative chain builder (the
+    /// typed-step pipeline) via `execute_chain`; `--threads N` only sets the
+    /// worker count. Absent, the chain runs at a single worker.
     #[command(flatten)]
     pub threading: ThreadingOptions,
 
-    /// Scheduler and pipeline stats options (used only in `--threads` mode).
+    /// Scheduler and pipeline stats options.
     #[command(flatten)]
     pub scheduler_opts: SchedulerOptions,
 
-    /// Pipeline queue memory options (used only in `--threads` mode).
+    /// Pipeline queue memory options.
     #[command(flatten)]
     pub queue_memory: QueueMemoryOptions,
 }
@@ -401,51 +399,16 @@ impl Retag {
 }
 
 impl Retag {
-    /// Single-threaded fast path: a serial read → rewrite → write loop.
-    ///
-    /// Reached when `--threads` is absent. Opens its own record reader and
-    /// writer (both single-thread), synthesizes the `@HD`/`@PG` header, and
-    /// returns the record count plus the per-operation counts (positionally
-    /// indexed against `self.operations`) for shared summary/metrics reporting.
-    fn run_single_threaded(&self, command_line: &str) -> Result<(u64, Vec<OpCounts>)> {
-        let (mut reader, header) =
-            create_raw_bam_reader_with_opts(&self.io.input, 1, self.io.pipeline_reader_opts())?;
-        // Synthesize @HD VN:1.6 SO:unsorted when absent, then chain a @PG for provenance.
-        let header = ensure_hd_record(header)?;
-        let header = add_pg_record(header, command_line)?;
-
-        let mut writer =
-            create_raw_bam_writer(&self.io.output, &header, 1, self.compression.compression_level)?;
-
-        let mut counts = vec![OpCounts::default(); self.operations.len()];
-        let mut record_count: u64 = 0;
-        let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
-
-        let mut record = RawRecord::new();
-        while reader.read_record(&mut record)? != 0 {
-            for (op, op_counts) in self.operations.iter().zip(counts.iter_mut()) {
-                apply_op(&mut record, op, op_counts);
-            }
-            writer.write_raw_record(record.as_ref())?;
-            record_count += 1;
-            progress.log_if_needed(1);
-        }
-        progress.log_final();
-
-        // Flush before summarizing so any write error surfaces here, not silently on drop.
-        writer.finish()?;
-        Ok((record_count, counts))
-    }
-
-    /// Route `--threads N` onto the declarative chain builder
+    /// Run the retag on the declarative chain builder
     /// (`ChainSpec::single_stage(Stage::Retag, …)` → `build_for(spec)?.run()`).
     ///
-    /// The no-`--threads` `run_single_threaded` serial loop is the in-process
-    /// parity oracle; this path produces identical output records + `--metrics`
-    /// TSV. Diagnostics (the `Starting Retag` banner, the `OperationTimer`, and
-    /// the summary/warn/metrics finalize hooks) are emitted inside
+    /// The chain is the only execution path: `execute` always dispatches here,
+    /// with or without `--threads` (absent `--threads` runs the chain at a single
+    /// worker). All user-facing diagnostics — the `Starting Retag` banner, the
+    /// `OperationTimer`, the Input/Output/Operation lines, and the
+    /// summary/warn/metrics finalize hooks — are emitted inside
     /// `ChainBuilder::add_retag`, matching the `add_filter`/`add_dedup`
-    /// convention — so `execute_chain` itself only surfaces the CRC policy and
+    /// convention, so `execute_chain` itself only surfaces the CRC policy and
     /// runs the pipeline (mirrors `dedup`/`group` `execute_chain`).
     fn execute_chain(&self, command_line: &str) -> Result<()> {
         use crate::pipeline::chains::{
@@ -477,8 +440,7 @@ impl Retag {
 /// identical regardless of how the scheduler spread records across slots. Pulled
 /// out into a shared free function — used by the chain finalize hooks
 /// (`RetagFinalizeHook` and `RetagMetricsFinalizeHook`) to reduce the per-thread
-/// accumulator; the serial oracle builds its `Vec<OpCounts>` directly and does
-/// not call this — so the cross-slot merge is unit-testable with several
+/// accumulator — so the cross-slot merge is unit-testable with several
 /// deliberately-populated slots, rather than left to scheduler luck.
 pub(crate) fn sum_slot_counts(
     collected: &PerThreadAccumulator<Vec<OpCounts>>,
@@ -511,69 +473,20 @@ impl Command for Retag {
         // Reject it up front, resolving symlinks/`.`/`..` via canonicalize, before any
         // reader or writer opens (matching `merge`'s output-vs-input guard).
         self.reject_write_aliasing_input()?;
-        // Route on --threads BEFORE the CRC log / banner / timer. `--threads`
-        // dispatches to the chain builder, which emits its own banner + timer in
-        // `add_retag` and its own CRC log in `execute_chain`; running them here
-        // first would double-log and pre-consume stdin. The no-`--threads` serial
-        // path (the in-process parity oracle) keeps the CRC log, banner, and the
-        // metrics/summary tail below.
-        if self.threading.threads.is_some() {
-            return self.execute_chain(command_line);
-        }
-
-        // Surface the effective CRC-verification policy once, at run start, honoring
-        // the `--check-crc` doc's promise of a per-run `CRC verify:` line.
-        self.io.log_effective_check_crc();
-
-        let timer = OperationTimer::new("Rewriting tags");
-        info!("Starting Retag");
-        info!("Input: {}", self.io.input.display());
-        info!("Output: {}", self.io.output.display());
-        for op in &self.operations {
-            info!("Operation: {op}");
-        }
-
-        // No-`--threads` serial fast path: the in-process parity oracle.
-        let (record_count, counts) = self.run_single_threaded(command_line)?;
-
-        // Warn on operations that never matched — the usual sign of a mistyped source tag.
-        for (op, op_counts) in self.operations.iter().zip(&counts) {
-            if op_counts.records_applied == 0 {
-                warn!(
-                    "operation '{op}' matched zero records: no record carried the source tag '{}'",
-                    op.src()
-                );
-            }
-        }
-
-        if let Some(path) = &self.metrics {
-            let rows: Vec<RetagMetric> = self
-                .operations
-                .iter()
-                .zip(&counts)
-                .map(|(op, c)| RetagMetric::from_counts(*op, c))
-                .collect();
-            fgumi_metrics::write_metrics(path, &rows, "retag")?;
-            info!("Wrote metrics to: {}", path.display());
-        }
-
-        info!("=== Summary ===");
-        info!("Records processed: {record_count}");
-        for (op, op_counts) in self.operations.iter().zip(&counts) {
-            info!(
-                "{op}: applied={} overwritten={} missing={}",
-                op_counts.records_applied, op_counts.dst_overwritten, op_counts.src_missing
-            );
-        }
-
-        timer.log_completion(record_count);
-        Ok(())
+        // The declarative chain is the only execution path. It emits its own CRC
+        // log, `Starting Retag` banner + `OperationTimer`, and the
+        // summary/warn/metrics finalize hooks inside `ChainBuilder::add_retag`
+        // (running any of those here first would double-log and pre-consume
+        // stdin), so `execute` does only the pre-flight validation above and then
+        // dispatches. Absent `--threads` runs the chain at a single worker.
+        self.execute_chain(command_line)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use fgumi_bam_io::{create_raw_bam_reader_with_opts, create_raw_bam_writer};
     use fgumi_raw_bam::{RawTagsView, SamBuilder, aux_data_slice};
     use noodles::sam::Header;
     use rstest::rstest;
@@ -623,7 +536,7 @@ mod tests {
     /// Apply one op to a record starting from zeroed counts; return the counts.
     fn apply_one(record: &mut RawRecord, op: RetagOp) -> OpCounts {
         let mut counts = OpCounts::default();
-        apply_op(record, &op, &mut counts);
+        apply_op(record, op, &mut counts);
         counts
     }
 
@@ -676,7 +589,7 @@ mod tests {
     fn apply_all(record: &mut RawRecord, ops: &[RetagOp]) -> Vec<OpCounts> {
         let mut counts = vec![OpCounts::default(); ops.len()];
         for (op, c) in ops.iter().zip(counts.iter_mut()) {
-            apply_op(record, op, c);
+            apply_op(record, *op, c);
         }
         counts
     }
@@ -911,7 +824,7 @@ mod tests {
     }
 
     /// Build a `Retag` command with explicit operations and threading, for the
-    /// serial-vs-pipeline parity tests.
+    /// worker-count invariance tests (single worker vs multi-worker chain).
     fn retag_cmd_with(
         input: PathBuf,
         output: PathBuf,
@@ -960,7 +873,7 @@ mod tests {
         assert_eq!(records[0].tags().find_string(tag("RX")), Some(b"ACGT".as_ref()));
     }
 
-    // ── threaded pipeline: parity with the single-threaded path ──────────────
+    // ── worker-count invariance: output independent of --threads ─────────────
 
     /// A header with one `@SQ` (`chr1`), so the mapped records in
     /// [`build_varied_records`] carry a valid reference id.
@@ -993,18 +906,18 @@ mod tests {
         header
     }
 
-    /// Build 50 varied records spanning the record classes where a serial-vs-threaded
-    /// decode divergence could hide. Every record carries a distinct `RX`; read names
-    /// encode the input index (`r0000`..`r0049`) so order can be asserted after a
-    /// parallel run. `ZZ` is never present.
+    /// Build 50 varied records spanning the record classes where a
+    /// worker-count-dependent decode divergence could hide. Every record carries a
+    /// distinct `RX`; read names encode the input index (`r0000`..`r0049`) so order
+    /// can be asserted after a multi-worker run. `ZZ` is never present.
     ///
     /// - even `i` also carry `MI`;
     /// - every 5th record pre-carries `BX`, so `RX::copy::BX` overwrites it and the
-    ///   `dst_overwritten` counter is exercised (and its threaded aggregation checked);
+    ///   `dst_overwritten` counter is exercised (and its cross-worker aggregation checked);
     /// - every 3rd record is a mapped, paired read (real CIGAR, position, `MC`/`RG`
-    ///   tags, mate info) — some flagged secondary — so the threaded path's extra
-    ///   per-record decode work (CIGAR walk, aux/mate parsing) runs on real input,
-    ///   not just trivial unmapped primaries.
+    ///   tags, mate info) — some flagged secondary — so the per-record decode work
+    ///   (CIGAR walk, aux/mate parsing) runs on real input, not just trivial
+    ///   unmapped primaries.
     fn build_varied_records() -> Vec<RawRecord> {
         use fgumi_raw_bam::flags;
         (0..50u32)
@@ -1022,7 +935,7 @@ mod tests {
                 }
                 if i % 3 == 0 {
                     // Mapped, paired read: exercises the CIGAR walk + mate/aux parsing
-                    // the threaded decode performs but the serial loop skips.
+                    // the per-record decode performs on real input.
                     let mut f = flags::PAIRED;
                     if i % 6 == 0 {
                         f |= flags::SECONDARY;
@@ -1049,7 +962,7 @@ mod tests {
     #[rstest]
     #[case::threads_1(1)]
     #[case::threads_4(4)]
-    fn threaded_output_matches_single_threaded(#[case] threads: usize) {
+    fn output_is_independent_of_worker_count(#[case] threads: usize) {
         let dir = tempfile::TempDir::new().expect("temp dir");
         let input = dir.path().join("in.bam");
         write_bam_with_header(&input, &parity_header(), &build_varied_records());
@@ -1058,17 +971,18 @@ mod tests {
         // evens), delete a never-present tag.
         let ops = ["RX::copy::BX", "MI::move::CB", "ZZ::delete"];
 
-        let serial_out = dir.path().join("serial.bam");
-        let serial_tsv = dir.path().join("serial.tsv");
+        // No `--threads`: the chain at a single worker.
+        let single_worker_out = dir.path().join("single_worker.bam");
+        let single_worker_tsv = dir.path().join("single_worker.tsv");
         retag_cmd_with(
             input.clone(),
-            serial_out.clone(),
-            Some(serial_tsv.clone()),
+            single_worker_out.clone(),
+            Some(single_worker_tsv.clone()),
             &ops,
             ThreadingOptions::none(),
         )
         .execute("fgumi retag")
-        .expect("serial retag");
+        .expect("single-worker retag");
 
         let threaded_out = dir.path().join("threaded.bam");
         let threaded_tsv = dir.path().join("threaded.tsv");
@@ -1085,28 +999,32 @@ mod tests {
         // Decoded records are identical in order and content. (Compressed BAM bytes
         // may differ — the pipeline writer chunks BGZF blocks differently — so we
         // compare decoded records, not file bytes.)
-        let serial_recs = read_bam(&serial_out);
+        let single_worker_recs = read_bam(&single_worker_out);
         let threaded_recs = read_bam(&threaded_out);
-        assert_eq!(serial_recs.len(), threaded_recs.len(), "record count differs");
-        for (i, (a, b)) in serial_recs.iter().zip(&threaded_recs).enumerate() {
-            assert_eq!(a.as_ref(), b.as_ref(), "record {i} differs between modes");
+        assert_eq!(single_worker_recs.len(), threaded_recs.len(), "record count differs");
+        for (i, (a, b)) in single_worker_recs.iter().zip(&threaded_recs).enumerate() {
+            assert_eq!(a.as_ref(), b.as_ref(), "record {i} differs between worker counts");
         }
 
-        // The synthesized @HD and chained @PG header must also match between modes.
-        // Both runs pass the same command line, so the headers are byte-identical.
+        // The synthesized @HD and chained @PG header must also match across worker
+        // counts. Both runs pass the same command line, so the headers are byte-identical.
         assert_eq!(
-            read_bam_header(&serial_out),
+            read_bam_header(&single_worker_out),
             read_bam_header(&threaded_out),
-            "output header differs between modes"
+            "output header differs between worker counts"
         );
 
-        // Per-operation metrics TSV is byte-identical between modes (u64 counts sum
-        // commutatively, rows emitted in operation order).
-        let serial_metrics = std::fs::read_to_string(&serial_tsv).expect("serial tsv");
+        // Per-operation metrics TSV is byte-identical across worker counts (u64 counts
+        // sum commutatively, rows emitted in operation order).
+        let single_worker_metrics =
+            std::fs::read_to_string(&single_worker_tsv).expect("single-worker tsv");
         let threaded_metrics = std::fs::read_to_string(&threaded_tsv).expect("threaded tsv");
-        assert_eq!(serial_metrics, threaded_metrics, "metrics TSV differ between modes");
+        assert_eq!(
+            single_worker_metrics, threaded_metrics,
+            "metrics TSV differ between worker counts"
+        );
 
-        // Guard that the corpus actually exercises the counters whose threaded
+        // Guard that the corpus actually exercises the counters whose cross-worker
         // aggregation this test is here to check: `dst_overwritten > 0` (10 records
         // pre-carry BX) and the zero-match `delete` (drives the warning).
         let rx_row = threaded_metrics.lines().nth(1).expect("RX row");

--- a/src/lib/pipeline/chains/commands/retag.rs
+++ b/src/lib/pipeline/chains/commands/retag.rs
@@ -6,12 +6,12 @@
 //! grouping preamble, no rejects), so it mirrors filter's
 //! `build_filter_step_single_no_rejects` shape.
 //!
-//! The per-operation counters (`Vec<OpCounts>`, positionally indexed by op) and
-//! the row-building (`RetagMetric::from_counts`) are shared verbatim with the
-//! serial oracle in `commands::retag`, so the two paths' metrics rows cannot
-//! drift. `sum_slot_counts` reduces the chain's per-thread accumulator into that
-//! shared `Vec<OpCounts>` (the serial oracle has no per-thread slots, so it does
-//! not call it).
+//! The per-operation counters (`Vec<OpCounts>`, positionally indexed by op), the
+//! per-record apply engine (`apply_op`), and the row-building
+//! (`RetagMetric::from_counts`) all live in `commands::retag` and are reused
+//! verbatim here, so the metrics rows are defined in exactly one place.
+//! `sum_slot_counts` reduces the chain's per-thread accumulator into that shared
+//! `Vec<OpCounts>`.
 
 use std::io;
 use std::path::PathBuf;
@@ -35,10 +35,9 @@ use crate::pipeline::steps::types::{DecodedRecordBatch, DecompressedBlock};
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Always-run finalize hook: logs the `=== Summary ===` banner and completes the
-/// timer. Registered on the always-run `finalize` list, so — unlike the serial
-/// oracle, whose summary sits downstream of a fallible `?` — it reports even on a
-/// failed run; this is an accepted, intentional divergence (matches filter/dedup)
-/// and is not parity-tested.
+/// timer. Registered on the always-run `finalize` list (matching filter/dedup),
+/// so it reports even on a failed/partial run — the summary counts what was
+/// processed before the failure rather than being suppressed by an early `?`.
 ///
 /// `record_count` comes from the shared `progress` counter (the process step
 /// increments it once per record), NOT from summing `records_applied` across ops
@@ -72,9 +71,8 @@ impl FinalizeHook for RetagFinalizeHook {
 
 /// Success-only finalize hook: the warn-on-zero-match loop and the `--metrics`
 /// TSV write. Registered on `finalize_on_success` (not the always-run list) so a
-/// failed/partial run publishes neither the warning nor the TSV — matching the
-/// serial oracle, which only reaches its warn/metrics code after a fully
-/// successful run.
+/// failed/partial run publishes neither the warning nor the TSV — a zero-match
+/// warning or a metrics file are only meaningful once every record was processed.
 pub(crate) struct RetagMetricsFinalizeHook {
     pub(crate) accumulators: Arc<PerThreadAccumulator<Vec<OpCounts>>>,
     pub(crate) operations: Vec<RetagOp>,
@@ -87,7 +85,7 @@ impl FinalizeHook for RetagMetricsFinalizeHook {
         let counts = sum_slot_counts(&accumulators, operations.len());
 
         // Warn on operations that never matched — the usual sign of a mistyped
-        // source tag (verbatim message from the serial oracle's tail).
+        // source tag.
         for (op, op_counts) in operations.iter().zip(&counts) {
             if op_counts.records_applied == 0 {
                 warn!(
@@ -152,7 +150,7 @@ pub(crate) fn build_retag_process_step(
             for decoded in records {
                 let mut record = decoded.into_raw_bytes();
                 for (op, op_counts) in captures.operations.iter().zip(batch_counts.iter_mut()) {
-                    apply_op(&mut record, op, op_counts);
+                    apply_op(&mut record, *op, op_counts);
                 }
                 fgumi_raw_bam::write_framed_record(&mut bytes, record.as_ref())?;
             }

--- a/tests/integration/helpers/cutover.rs
+++ b/tests/integration/helpers/cutover.rs
@@ -1,0 +1,106 @@
+//! Shared helpers for command-cutover parity tests.
+//!
+//! A "cutover" test proves that routing a command through the declarative chain
+//! builder produces output byte-identical to the pre-cutover owned-engine
+//! baseline binary. Every such test needs the same three primitives: resolve the
+//! baseline binary from the environment, and compare two BAMs' decompressed
+//! record bytes with the necessarily-differing `@PG` line stripped. They live
+//! here so each per-command cutover test (`test_sort_cutover_parity.rs`,
+//! `test_retag_cutover_parity.rs`, and later ones) shares one copy.
+
+use std::path::{Path, PathBuf};
+
+/// Resolves the saved owned-engine baseline binary to compare a cutover against.
+///
+/// The baseline path comes solely from the `FGUMI_BASELINE_BIN` env var; when it
+/// is unset (or names a missing file) this returns `None` — "no baseline oracle
+/// available", never a passing result. Callers layer the baseline byte-parity
+/// check on top of an always-available oracle (e.g. `fgumi sort --verify`, or a
+/// self-consistency check); a missing baseline just drops the byte-parity half,
+/// it never skips the case outright. No hardcoded fallback: a baseline binary is
+/// host-specific and must never be a path committed into the repo.
+#[must_use]
+pub fn baseline_bin() -> Option<PathBuf> {
+    let path = PathBuf::from(std::env::var_os("FGUMI_BASELINE_BIN")?);
+    if path.is_file() {
+        return Some(path);
+    }
+    eprintln!(
+        "FGUMI_BASELINE_BIN={} does not name an existing file; baseline oracle unavailable",
+        path.display()
+    );
+    None
+}
+
+/// Removes every `@PG` line from a SAM header text blob.
+///
+/// Both a cutover build and the baseline binary stamp a single `@PG` line whose
+/// `VN` (git-describe version) and `CL` (command line, naming argv[0] — a
+/// different binary path for each side — and the per-run output path) necessarily
+/// differ between two independent invocations. Stripping the whole line (not just
+/// normalizing those two sub-fields) is simplest and correct because neither side
+/// emits more than one `@PG` record for these inputs (the test BAMs carry no
+/// pre-existing `@PG`).
+#[must_use]
+pub fn strip_pg_lines(text: &str) -> String {
+    // Empty in, empty out: `"".split('\n')` yields `[""]`, which the
+    // trailing-newline logic below would otherwise turn into `"\n"`.
+    if text.is_empty() {
+        return String::new();
+    }
+    let mut lines: Vec<&str> = text.split('\n').collect();
+    let had_trailing_newline = lines.last() == Some(&"");
+    if had_trailing_newline {
+        lines.pop();
+    }
+    lines.retain(|line| !line.starts_with("@PG"));
+    let mut out = lines.join("\n");
+    // Restore the trailing newline iff the source had one — never synthesize one
+    // the source lacked.
+    if had_trailing_newline {
+        out.push('\n');
+    }
+    out
+}
+
+/// Reads a BAM file's raw BGZF stream, decompresses it, strips the `@PG` line(s)
+/// from the embedded SAM header text, and returns the resulting bytes (new header
+/// + unmodified `n_ref`/reference-list/record bytes).
+///
+/// This compares the two writers' *decompressed* output rather than
+/// `RecordBuf`-parsed records or raw file bytes: BGZF block boundaries and
+/// compression levels differ between the two writers even when the logical
+/// content is identical, so raw file bytes never match; parsing into `RecordBuf`
+/// and re-encoding risks masking a real tag-order or binary-layout regression by
+/// normalizing it away. Operating directly on the decompressed BAM binary format
+/// keeps everything except the `@PG` line an exact, uninterpreted byte comparison.
+#[must_use]
+pub fn decompressed_records_without_pg(path: &Path) -> Vec<u8> {
+    let file = std::fs::File::open(path).unwrap_or_else(|e| panic!("open {}: {e}", path.display()));
+    let mut reader = noodles::bgzf::io::Reader::new(std::io::BufReader::new(file));
+    let mut raw = Vec::new();
+    std::io::Read::read_to_end(&mut reader, &mut raw)
+        .unwrap_or_else(|e| panic!("decompress BGZF stream for {}: {e}", path.display()));
+
+    assert!(
+        raw.len() >= 8 && &raw[0..4] == b"BAM\x01",
+        "{} does not decompress to a BAM binary stream (missing magic)",
+        path.display()
+    );
+    let l_text = i32::from_le_bytes(raw[4..8].try_into().expect("4 bytes"));
+    let l_text = usize::try_from(l_text).expect("l_text is non-negative");
+    let text_start = 8;
+    let text_end = text_start + l_text;
+    assert!(raw.len() >= text_end, "{} header text runs past end of stream", path.display());
+
+    let text = String::from_utf8_lossy(&raw[text_start..text_end]);
+    let stripped_text = strip_pg_lines(&text);
+
+    let mut out = Vec::with_capacity(raw.len());
+    out.extend_from_slice(b"BAM\x01");
+    let new_l_text = i32::try_from(stripped_text.len()).expect("stripped header text fits i32");
+    out.extend_from_slice(&new_l_text.to_le_bytes());
+    out.extend_from_slice(stripped_text.as_bytes());
+    out.extend_from_slice(&raw[text_end..]); // n_ref, reference list, and all records, untouched
+    out
+}

--- a/tests/integration/helpers/mod.rs
+++ b/tests/integration/helpers/mod.rs
@@ -11,12 +11,14 @@ pub mod aligner;
 pub mod assertions;
 pub mod bam_generator;
 pub mod cli;
+pub mod cutover;
 pub mod fastq;
 
 pub use aligner::*;
 pub use assertions::*;
 pub use bam_generator::*;
 pub use cli::*;
+pub use cutover::*;
 pub use fastq::*;
 
 /// Writes `contents` to `dir/name` and returns the path.

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -44,6 +44,7 @@ mod test_merge_command;
 mod test_pipeline_concurrency;
 mod test_pipeline_memory_backpressure;
 mod test_retag_command;
+mod test_retag_cutover_parity;
 mod test_review_command;
 mod test_runall_chain_transitions;
 mod test_runall_command;

--- a/tests/integration/test_retag_command.rs
+++ b/tests/integration/test_retag_command.rs
@@ -1,12 +1,12 @@
-//! End-to-end parity tests for the `retag` command's chain-builder cutover.
+//! End-to-end determinism tests for the `retag` command on the chain builder.
 //!
-//! `retag --threads N` routes through the declarative chain builder; the
-//! no-`--threads` serial `run_single_threaded` loop is the in-process parity
-//! oracle. These assert the two paths produce identical output records +
-//! normalized header and an identical `--metrics` TSV, across thread counts —
-//! including `--threads 1`, which dispatches to the chain at single-worker
-//! concurrency (a distinct code path from both the serial oracle and
-//! `--threads N`).
+//! retag always routes through the declarative chain builder (the legacy serial
+//! path is retired). These assert the output is independent of the worker count:
+//! a no-`--threads` run (the chain at a single worker) produces identical output
+//! records + normalized header and an identical `--metrics` TSV to a
+//! `--threads N` run. `--threads 1` is exercised explicitly as a distinct
+//! single-worker configuration. (Byte-parity against the pre-removal serial
+//! binary lives in `test_retag_cutover_parity.rs`.)
 
 use clap::Parser;
 use fgumi_lib::commands::command::Command;
@@ -64,8 +64,8 @@ fn mixed_input(dir: &Path, count: usize) -> PathBuf {
     write_input(dir, "in.bam", &records)
 }
 
-/// Parse + run `retag`. `threads = None` omits `--threads` (the serial oracle);
-/// `Some(n)` passes `--threads n` (the chain path).
+/// Parse + run `retag`. `threads = None` omits `--threads` (the chain at a
+/// single worker); `Some(n)` passes `--threads n`. Both take the chain.
 fn run_retag(
     input: &Path,
     output: &Path,
@@ -93,29 +93,32 @@ fn run_retag(
     cmd.execute("retag test")
 }
 
-// ── chain-vs-oracle record + header parity ─────────────────────────────────
+// ── worker-count invariance: record + header ───────────────────────────────
 
 #[rstest]
 #[case::threads_1(1)]
 #[case::threads_2(2)]
 #[case::threads_4(4)]
-fn retag_chain_matches_single_threaded(#[case] threads: usize) {
+fn output_matches_across_worker_counts(#[case] threads: usize) {
     let dir = TempDir::new().unwrap();
     let input = mixed_input(dir.path(), 40);
     // Fan RX out to BX and CB, then drop RX — exercises applied/overwritten/missing
     // across three positional ops.
     let ops = ["RX::copy::BX", "RX::copy::CB", "RX::delete"];
 
-    let oracle_out = dir.path().join("oracle.bam");
-    run_retag(&input, &oracle_out, None, &ops, None).expect("oracle run");
+    let single_worker_out = dir.path().join("single_worker.bam");
+    run_retag(&input, &single_worker_out, None, &ops, None).expect("single-worker run");
 
-    let chain_out = dir.path().join("chain.bam");
-    run_retag(&input, &chain_out, Some(threads), &ops, None).expect("chain run");
+    let multi_worker_out = dir.path().join("multi_worker.bam");
+    run_retag(&input, &multi_worker_out, Some(threads), &ops, None).expect("multi-worker run");
 
-    let oracle = read_bam_output(&oracle_out);
-    let chain = read_bam_output(&chain_out);
-    assert_eq!(oracle.1.len(), 40, "all records emitted");
-    assert_eq!(chain, oracle, "chain (--threads {threads}) must match the serial oracle");
+    let single_worker = read_bam_output(&single_worker_out);
+    let multi_worker = read_bam_output(&multi_worker_out);
+    assert_eq!(single_worker.1.len(), 40, "all records emitted");
+    assert_eq!(
+        multi_worker, single_worker,
+        "--threads {threads} output must match the single-worker run"
+    );
 }
 
 // ── --metrics TSV byte-parity ──────────────────────────────────────────────
@@ -124,29 +127,35 @@ fn retag_chain_matches_single_threaded(#[case] threads: usize) {
 #[case::threads_1(1)]
 #[case::threads_2(2)]
 #[case::threads_4(4)]
-fn retag_chain_metrics_match_single_threaded(#[case] threads: usize) {
+fn metrics_match_across_worker_counts(#[case] threads: usize) {
     let dir = TempDir::new().unwrap();
     let input = mixed_input(dir.path(), 40);
     let ops = ["RX::copy::BX", "RX::move::CB"];
 
-    let oracle_out = dir.path().join("oracle.bam");
-    let oracle_m = dir.path().join("oracle.tsv");
-    run_retag(&input, &oracle_out, None, &ops, Some(&oracle_m)).expect("oracle run");
+    let single_worker_out = dir.path().join("single_worker.bam");
+    let single_worker_m = dir.path().join("single_worker.tsv");
+    run_retag(&input, &single_worker_out, None, &ops, Some(&single_worker_m))
+        .expect("single-worker run");
 
-    let chain_out = dir.path().join("chain.bam");
-    let chain_m = dir.path().join("chain.tsv");
-    run_retag(&input, &chain_out, Some(threads), &ops, Some(&chain_m)).expect("chain run");
+    let multi_worker_out = dir.path().join("multi_worker.bam");
+    let multi_worker_m = dir.path().join("multi_worker.tsv");
+    run_retag(&input, &multi_worker_out, Some(threads), &ops, Some(&multi_worker_m))
+        .expect("multi-worker run");
 
-    let oracle_tsv = std::fs::read_to_string(&oracle_m).expect("read oracle tsv");
-    let chain_tsv = std::fs::read_to_string(&chain_m).expect("read chain tsv");
-    assert_eq!(chain_tsv, oracle_tsv, "--metrics TSV must be byte-identical across paths");
+    let single_worker_tsv =
+        std::fs::read_to_string(&single_worker_m).expect("read single-worker tsv");
+    let multi_worker_tsv = std::fs::read_to_string(&multi_worker_m).expect("read multi-worker tsv");
+    assert_eq!(
+        multi_worker_tsv, single_worker_tsv,
+        "--metrics TSV must be byte-identical across worker counts"
+    );
     // Non-vacuous: at least one op actually applied to some records.
     assert!(
-        oracle_tsv.lines().any(|l| {
+        single_worker_tsv.lines().any(|l| {
             let cols: Vec<&str> = l.split('\t').collect();
             cols.len() >= 3 && cols[2].parse::<u64>().map(|n| n > 0).unwrap_or(false)
         }),
-        "expected a non-zero records_applied somewhere in the metrics:\n{oracle_tsv}"
+        "expected a non-zero records_applied somewhere in the metrics:\n{single_worker_tsv}"
     );
 }
 
@@ -155,37 +164,55 @@ fn retag_chain_metrics_match_single_threaded(#[case] threads: usize) {
 #[rstest]
 #[case::threads_1(1)]
 #[case::threads_2(2)]
-fn retag_chain_zero_match_op_matches_oracle(#[case] threads: usize) {
+fn zero_match_op_consistent_across_worker_counts(#[case] threads: usize) {
     let dir = TempDir::new().unwrap();
     let input = mixed_input(dir.path(), 20);
-    // `ZZ` is present on no record, so this op matches zero records on both paths.
+    // `ZZ` is present on no record, so this op matches zero records at any worker count.
     let ops = ["ZZ::delete"];
 
-    let oracle_out = dir.path().join("oracle.bam");
-    let oracle_m = dir.path().join("oracle.tsv");
-    run_retag(&input, &oracle_out, None, &ops, Some(&oracle_m)).expect("oracle run");
+    let single_worker_out = dir.path().join("single_worker.bam");
+    let single_worker_m = dir.path().join("single_worker.tsv");
+    run_retag(&input, &single_worker_out, None, &ops, Some(&single_worker_m))
+        .expect("single-worker run");
 
-    let chain_out = dir.path().join("chain.bam");
-    let chain_m = dir.path().join("chain.tsv");
-    run_retag(&input, &chain_out, Some(threads), &ops, Some(&chain_m)).expect("chain run");
+    let multi_worker_out = dir.path().join("multi_worker.bam");
+    let multi_worker_m = dir.path().join("multi_worker.tsv");
+    run_retag(&input, &multi_worker_out, Some(threads), &ops, Some(&multi_worker_m))
+        .expect("multi-worker run");
 
-    let oracle_tsv = std::fs::read_to_string(&oracle_m).unwrap();
-    let chain_tsv = std::fs::read_to_string(&chain_m).unwrap();
-    assert_eq!(chain_tsv, oracle_tsv, "zero-match metrics must match across paths");
+    let single_worker_tsv = std::fs::read_to_string(&single_worker_m).unwrap();
+    let multi_worker_tsv = std::fs::read_to_string(&multi_worker_m).unwrap();
+    assert_eq!(
+        multi_worker_tsv, single_worker_tsv,
+        "zero-match metrics must match across worker counts"
+    );
     // The durable observable of the warn: records_applied == 0 for the op.
     // TSV columns: operation, kind, records_applied, dst_overwritten, src_missing.
-    let zz_row = oracle_tsv
+    let zz_row = single_worker_tsv
         .lines()
         .find(|l| l.starts_with("ZZ::delete\t"))
-        .unwrap_or_else(|| panic!("metrics should carry the ZZ::delete row:\n{oracle_tsv}"));
+        .unwrap_or_else(|| panic!("metrics should carry the ZZ::delete row:\n{single_worker_tsv}"));
     let fields: Vec<&str> = zz_row.split('\t').collect();
     assert_eq!(
         fields.get(2).copied(),
         Some("0"),
         "records_applied must be 0 for a zero-match op, got row: {zz_row}"
     );
-    // Output records are unchanged (no ZZ to delete), and the two BAMs agree.
-    assert_eq!(read_bam_output(&chain_out), read_bam_output(&oracle_out));
+    // A zero-match op changes no records, so both outputs must equal the INPUT
+    // record-for-record -- not merely each other. Identical corruption on both
+    // worker paths would satisfy a self-comparison but not this contract.
+    // (Headers legitimately differ by retag's own @PG line, so compare records.)
+    let (_, input_records) = read_bam_output(&input);
+    let (_, single_records) = read_bam_output(&single_worker_out);
+    let (_, multi_records) = read_bam_output(&multi_worker_out);
+    assert_eq!(
+        single_records, input_records,
+        "zero-match op must leave records unchanged (single worker)"
+    );
+    assert_eq!(
+        multi_records, input_records,
+        "zero-match op must leave records unchanged ({threads} workers)"
+    );
 }
 
 // ── empty input: zero-record parity (degenerate boundary for the hooks) ─────
@@ -193,54 +220,76 @@ fn retag_chain_zero_match_op_matches_oracle(#[case] threads: usize) {
 #[rstest]
 #[case::threads_1(1)]
 #[case::threads_4(4)]
-fn retag_chain_empty_input_matches_oracle(#[case] threads: usize) {
+fn empty_input_consistent_across_worker_counts(#[case] threads: usize) {
     let dir = TempDir::new().unwrap();
     // Header-only BAM: exercises the finalize hooks' zero-record path.
     let input = write_input(dir.path(), "empty.bam", &[]);
     let ops = ["RX::copy::BX", "ZZ::delete"];
 
-    let oracle_out = dir.path().join("oracle.bam");
-    let oracle_m = dir.path().join("oracle.tsv");
-    run_retag(&input, &oracle_out, None, &ops, Some(&oracle_m)).expect("oracle run");
+    let single_worker_out = dir.path().join("single_worker.bam");
+    let single_worker_m = dir.path().join("single_worker.tsv");
+    run_retag(&input, &single_worker_out, None, &ops, Some(&single_worker_m))
+        .expect("single-worker run");
 
-    let chain_out = dir.path().join("chain.bam");
-    let chain_m = dir.path().join("chain.tsv");
-    run_retag(&input, &chain_out, Some(threads), &ops, Some(&chain_m)).expect("chain run");
+    let multi_worker_out = dir.path().join("multi_worker.bam");
+    let multi_worker_m = dir.path().join("multi_worker.tsv");
+    run_retag(&input, &multi_worker_out, Some(threads), &ops, Some(&multi_worker_m))
+        .expect("multi-worker run");
 
-    // Header-only output, identical across paths.
-    assert_eq!(read_bam_output(&chain_out), read_bam_output(&oracle_out));
-    // Metrics TSVs byte-identical (all counts zero on both paths).
+    // Header-only output, identical across worker counts.
+    assert_eq!(read_bam_output(&multi_worker_out), read_bam_output(&single_worker_out));
+    // Metrics TSVs byte-identical (all counts zero at any worker count).
+    let single_worker_tsv = std::fs::read_to_string(&single_worker_m).unwrap();
     assert_eq!(
-        std::fs::read_to_string(&chain_m).unwrap(),
-        std::fs::read_to_string(&oracle_m).unwrap(),
-        "empty-input metrics must match across paths"
+        std::fs::read_to_string(&multi_worker_m).unwrap(),
+        single_worker_tsv,
+        "empty-input metrics must match across worker counts"
     );
+    // Empty input is the degenerate boundary: every op's counts must be exactly
+    // 0. Parity alone does not pin this -- both paths could agree on a non-zero
+    // count. TSV columns: operation, kind, records_applied, dst_overwritten,
+    // src_missing.
+    for op in ops {
+        let row = single_worker_tsv
+            .lines()
+            .find(|l| l.starts_with(&format!("{op}\t")))
+            .unwrap_or_else(|| panic!("metrics should carry the {op} row:\n{single_worker_tsv}"));
+        let fields: Vec<&str> = row.split('\t').collect();
+        assert_eq!(
+            (fields.get(2).copied(), fields.get(3).copied(), fields.get(4).copied()),
+            (Some("0"), Some("0"), Some("0")),
+            "empty-input op {op} must report records_applied/dst_overwritten/src_missing all 0, \
+             got row: {row}"
+        );
+    }
 }
 
 // ── multi-batch: enough records to cross pipeline batch boundaries ──────────
 
 #[test]
-fn retag_chain_multi_batch_matches_oracle() {
+fn multi_batch_consistent_across_worker_counts() {
     let dir = TempDir::new().unwrap();
     let input = mixed_input(dir.path(), 5_000);
     let ops = ["RX::copy::BX", "RX::delete"];
 
-    let oracle_out = dir.path().join("oracle.bam");
-    let oracle_m = dir.path().join("oracle.tsv");
-    run_retag(&input, &oracle_out, None, &ops, Some(&oracle_m)).expect("oracle run");
+    let single_worker_out = dir.path().join("single_worker.bam");
+    let single_worker_m = dir.path().join("single_worker.tsv");
+    run_retag(&input, &single_worker_out, None, &ops, Some(&single_worker_m))
+        .expect("single-worker run");
 
-    let chain_out = dir.path().join("chain.bam");
-    let chain_m = dir.path().join("chain.tsv");
-    run_retag(&input, &chain_out, Some(4), &ops, Some(&chain_m)).expect("chain run");
+    let multi_worker_out = dir.path().join("multi_worker.bam");
+    let multi_worker_m = dir.path().join("multi_worker.tsv");
+    run_retag(&input, &multi_worker_out, Some(4), &ops, Some(&multi_worker_m))
+        .expect("multi-worker run");
 
     assert_eq!(
-        read_bam_output(&chain_out),
-        read_bam_output(&oracle_out),
-        "multi-batch chain output must match the serial oracle"
+        read_bam_output(&multi_worker_out),
+        read_bam_output(&single_worker_out),
+        "multi-batch multi-worker output must match the single-worker run"
     );
     assert_eq!(
-        std::fs::read_to_string(&chain_m).unwrap(),
-        std::fs::read_to_string(&oracle_m).unwrap(),
-        "multi-batch summed metrics must match across paths"
+        std::fs::read_to_string(&multi_worker_m).unwrap(),
+        std::fs::read_to_string(&single_worker_m).unwrap(),
+        "multi-batch summed metrics must match across worker counts"
     );
 }

--- a/tests/integration/test_retag_cutover_parity.rs
+++ b/tests/integration/test_retag_cutover_parity.rs
@@ -1,0 +1,328 @@
+//! Parity gate for the `retag` command's single-threaded-path retirement (C4):
+//! `Retag::execute` no longer has a serial in-process loop reached when
+//! `--threads` is absent — it *always* routes through the declarative chain
+//! builder. This test proves that cutover lost nothing user-observable.
+//!
+//! Two independent things are checked here:
+//!
+//! 1. **The cutover actually happened** (`retag_no_threads_routes_through_chain`).
+//!    A no-`--threads` run now emits the chain-only `"Using pipeline with N
+//!    threads"` banner that `ChainBuilder::add_retag` logs and the retired serial
+//!    tail never did. This is the genuine RED/GREEN discriminator: before the
+//!    removal a no-`--threads` run took the serial path and printed no such line;
+//!    after it, the chain does.
+//!
+//! 2. **Output parity with the pre-removal serial path**
+//!    (`cutover_matches_baseline`). The current build's `retag` output — records
+//!    (byte-identical, modulo the `@PG` line) and the `--metrics` TSV — must match
+//!    the frozen owned-serial baseline binary. The baseline path comes from
+//!    `FGUMI_BASELINE_BIN`; when it is unset (or names a missing file) the case
+//!    degrades to a self-consistency oracle (expected tag rewrites, record
+//!    survival, and metrics content asserted directly) rather than skipping — the
+//!    exact fallback discipline of `test_sort_cutover_parity.rs`. Cases cover
+//!    multiple operations, an operation that matches zero records (pinning the
+//!    zero-match warning), and a run with `--metrics` (pinning the TSV).
+//!
+//! **Not a RED/GREEN gate for the parity half.** Because the removed serial loop
+//! and the chain were already output-equivalent, the baseline byte-parity check
+//! passes on both sides of the change — like the sort cutover it guards
+//! equivalence, it does not observe a regression the cutover introduces. The
+//! chain-banner check in (1) is the part that flips RED→GREEN across the removal.
+
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::Command;
+
+use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
+use rstest::rstest;
+use tempfile::TempDir;
+
+use crate::helpers::bam_generator::{create_minimal_header, write_bam};
+use crate::helpers::cutover::{baseline_bin, decompressed_records_without_pg};
+use crate::helpers::read_bam_output;
+use fgumi_lib::sam::SamTag;
+
+/// One mapped record: name, optional `RX`, optional pre-existing `BX` (to
+/// exercise `copy`/`move` overwrite), optional `MI`. Every third record is a
+/// mapped paired read (real CIGAR, mate info, `MC`/`RG`) so the chain's decode
+/// runs over non-trivial records, not just unmapped primaries — mirroring the
+/// varied corpus in the in-process retag parity unit tests.
+fn build_varied_records() -> Vec<RawRecord> {
+    (0..60u32)
+        .map(|i| {
+            let mut b = SamBuilder::new();
+            let name = format!("r{i:04}");
+            b.read_name(name.as_bytes());
+            // Record index 41 deliberately carries NO RX, so `RX::*` skips it
+            // (src_missing) — and no record ever carries `ZZ`, pinning the
+            // zero-match op path.
+            if i != 41 {
+                let rx = format!("ACGT{i:04}");
+                b.add_string_tag(SamTag::RX, rx.as_bytes());
+            }
+            if i % 2 == 0 {
+                b.add_string_tag(SamTag::MI, i.to_string().as_bytes());
+            }
+            if i % 5 == 0 {
+                b.add_string_tag("BX".parse::<SamTag>().expect("BX tag"), b"OLD");
+            }
+            let idx = i32::try_from(i).expect("record index fits i32");
+            if i % 3 == 0 {
+                let mut f = flags::PAIRED;
+                if i % 6 == 0 {
+                    f |= flags::SECONDARY;
+                }
+                b.ref_id(0)
+                    .pos(idx * 7 + 1)
+                    .mapq(60)
+                    .flags(f)
+                    .mate_ref_id(0)
+                    .mate_pos(idx * 7 + 50)
+                    .cigar_ops(&[8 << 4]) // 8M
+                    .sequence(b"ACGTACGT")
+                    .qualities(&[30u8; 8])
+                    .add_string_tag(SamTag::MC, b"8M")
+                    .add_string_tag(SamTag::RG, b"A");
+            } else {
+                b.flags(0).ref_id(0).pos(idx + 1).sequence(b"ACGT").qualities(&[30u8; 4]);
+            }
+            b.build()
+        })
+        .collect()
+}
+
+/// Writes the varied corpus to `dir/in.bam` and returns its path.
+fn write_varied_input(dir: &Path) -> std::path::PathBuf {
+    let input = dir.join("in.bam");
+    write_bam(&input, &create_minimal_header("chr1", 10_000), &build_varied_records());
+    input
+}
+
+/// The operations every parity case runs: fan `RX` out to `BX` (overwriting the
+/// pre-existing `BX` on every 5th record) and to `CB`, move `MI` to `XM`, then a
+/// `ZZ::delete` that matches zero records. Covers copy/move/delete, overwrite,
+/// `src_missing`, and the zero-match warn in one shot.
+const PARITY_OPS: &[&str] = &["RX::copy::BX", "RX::copy::CB", "MI::move::XM", "ZZ::delete"];
+
+/// Runs `<bin> retag -i <input> -o <output> [-M <metrics>] <ops...>` (no
+/// `--threads`, so the current build takes the post-cutover chain path and the
+/// baseline takes its serial path) with `RUST_LOG=info`, and returns the process
+/// output for stderr assertions.
+fn run_retag(
+    bin: &Path,
+    input: &Path,
+    output: &Path,
+    metrics: Option<&Path>,
+    ops: &[&str],
+) -> std::process::Output {
+    let mut cmd = Command::new(bin);
+    cmd.env("RUST_LOG", "info").args([
+        OsStr::new("retag"),
+        OsStr::new("-i"),
+        input.as_os_str(),
+        OsStr::new("-o"),
+        output.as_os_str(),
+    ]);
+    if let Some(m) = metrics {
+        cmd.args([OsStr::new("-M"), m.as_os_str()]);
+    }
+    cmd.args(ops.iter().map(OsStr::new));
+    cmd.output().unwrap_or_else(|e| panic!("failed to spawn `{}` retag: {e}", bin.display()))
+}
+
+/// A no-`--threads` run now routes through the declarative chain, which logs the
+/// `"Using pipeline with N threads"` banner from `ChainBuilder::add_retag`. The
+/// retired serial tail logged no such line, so this is the RED (pre-removal) →
+/// GREEN (post-removal) discriminator for the cutover.
+#[test]
+fn retag_no_threads_routes_through_chain() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = write_varied_input(dir.path());
+    let output = dir.path().join("out.bam");
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let out = run_retag(current_bin, &input, &output, None, PARITY_OPS);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "no-threads retag must succeed; stderr:\n{stderr}");
+    assert!(
+        stderr.contains("Using pipeline with 1 threads"),
+        "a no-`--threads` retag must route through the chain (which logs the pipeline banner); \
+         the serial path is retired. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Starting Retag"),
+        "the chain must still emit the `Starting Retag` banner; stderr:\n{stderr}"
+    );
+}
+
+/// Output parity of the post-cutover chain against the pre-removal serial
+/// baseline binary, across representative operation sets — plus the
+/// always-available self-consistency oracle when no baseline is set.
+///
+/// `#[case]` args: a label, the ops to run, and whether `--metrics` is written.
+#[rstest]
+#[case::multi_op_no_metrics(PARITY_OPS, false)]
+#[case::multi_op_with_metrics(PARITY_OPS, true)]
+#[case::zero_match_only(&["ZZ::delete"], true)]
+fn cutover_matches_baseline(#[case] ops: &[&str], #[case] with_metrics: bool) {
+    let dir = TempDir::new().expect("temp dir");
+    let input = write_varied_input(dir.path());
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let current_out = dir.path().join("current.bam");
+    let current_tsv = dir.path().join("current.tsv");
+    let current_metrics = with_metrics.then(|| current_tsv.clone());
+    let current = run_retag(current_bin, &input, &current_out, current_metrics.as_deref(), ops);
+    let current_stderr = String::from_utf8_lossy(&current.stderr);
+    assert!(current.status.success(), "current retag must succeed; stderr:\n{current_stderr}");
+
+    // A zero-match op must still warn on the chain (verbatim message from the
+    // retired serial tail). ZZ is present on no record in every case's ops.
+    if ops.contains(&"ZZ::delete") {
+        assert!(
+            current_stderr.contains(
+                "operation 'ZZ::delete' matched zero records: no record carried the source tag 'ZZ'"
+            ),
+            "the zero-match warning must survive the cutover; stderr:\n{current_stderr}"
+        );
+    }
+
+    if let Some(baseline) = baseline_bin() {
+        let baseline_out = dir.path().join("baseline.bam");
+        let baseline_tsv = dir.path().join("baseline.tsv");
+        let baseline_metrics = with_metrics.then(|| baseline_tsv.clone());
+        let base = run_retag(&baseline, &input, &baseline_out, baseline_metrics.as_deref(), ops);
+        assert!(
+            base.status.success(),
+            "baseline retag failed; stderr:\n{}",
+            String::from_utf8_lossy(&base.stderr)
+        );
+
+        assert_eq!(
+            decompressed_records_without_pg(&current_out),
+            decompressed_records_without_pg(&baseline_out),
+            "chain retag output diverges from the pre-removal serial baseline binary ({}) \
+             after stripping @PG — a real cutover parity bug, not something to relax",
+            baseline.display(),
+        );
+        if with_metrics {
+            assert_eq!(
+                std::fs::read_to_string(&current_tsv).expect("current tsv"),
+                std::fs::read_to_string(&baseline_tsv).expect("baseline tsv"),
+                "chain --metrics TSV diverges from the serial baseline binary"
+            );
+        }
+    } else {
+        eprintln!(
+            "SKIP baseline half of cutover_matches_baseline[{ops:?}]: FGUMI_BASELINE_BIN is \
+             unset or does not name an existing file — running self-consistency oracle instead"
+        );
+        assert_self_consistent(&current_out, current_metrics.as_deref(), ops);
+    }
+}
+
+/// Always-available oracle used when no baseline binary is set — it is the only
+/// retag header oracle that runs in plain CI (the pre-removal serial path was the
+/// old one). It asserts the chain output: (1) synthesizes `@HD VN:1.6 SO:unsorted`
+/// and stamps a retag `@PG` provenance record on the header; (2) keeps every input
+/// record; (3) applies exactly the tag rewrites `ops` prescribe (spot-checked on a
+/// known record for the standard op set); and (4) writes one `--metrics` row per
+/// op, in order, with the zero-match op reporting `records_applied == 0`. It does
+/// NOT recompute every count from the input — that full byte-parity check is the
+/// baseline-binary half of `cutover_matches_baseline`.
+fn assert_self_consistent(output: &Path, metrics: Option<&Path>, ops: &[&str]) {
+    assert_output_header(output);
+
+    let input_records = build_varied_records();
+    let (_, out_records) = read_bam_output(output);
+    assert_eq!(
+        out_records.len(),
+        input_records.len(),
+        "retag must keep every record (retag never adds or drops records)"
+    );
+
+    // For the standard multi-op set, spot-check the rewrites on a known record.
+    if ops == PARITY_OPS {
+        // Record 0 carries RX="ACGT0000", MI="0", and a pre-existing BX="OLD".
+        let r0 = &out_records[0];
+        assert_eq!(
+            tag_string(r0, "BX").as_deref(),
+            Some("ACGT0000"),
+            "RX::copy::BX must overwrite the pre-existing BX"
+        );
+        assert_eq!(tag_string(r0, "CB").as_deref(), Some("ACGT0000"), "RX::copy::CB must add CB");
+        assert_eq!(tag_string(r0, "XM").as_deref(), Some("0"), "MI::move::XM must add XM");
+        assert!(tag_string(r0, "MI").is_none(), "MI::move::XM must drop MI");
+        assert!(tag_string(r0, "ZZ").is_none(), "ZZ never present");
+    }
+
+    if let Some(path) = metrics {
+        let tsv = std::fs::read_to_string(path).expect("read metrics");
+        let lines: Vec<&str> = tsv.lines().collect();
+        assert_eq!(
+            lines[0], "operation\tkind\trecords_applied\tdst_overwritten\tsrc_missing",
+            "metrics header"
+        );
+        assert_eq!(lines.len(), ops.len() + 1, "one metrics row per operation");
+        // Every op named in the input appears as a row in order.
+        for (op, line) in ops.iter().zip(&lines[1..]) {
+            assert!(
+                line.starts_with(&format!("{op}\t")),
+                "metrics row order/label mismatch: {line} (expected {op})"
+            );
+        }
+        // The zero-match op reports records_applied == 0.
+        if let Some(zz) = lines.iter().find(|l| l.starts_with("ZZ::delete\t")) {
+            let fields: Vec<&str> = zz.split('\t').collect();
+            assert_eq!(fields.get(2).copied(), Some("0"), "ZZ::delete records_applied must be 0");
+        }
+    }
+}
+
+/// Asserts the chain output header carries the synthesized `@HD VN:1.6
+/// SO:unsorted` and a retag `@PG` provenance record.
+///
+/// Reads the header un-normalized (a fresh `noodles::bam` reader, NOT
+/// `read_bam_output`, which rewrites the `@PG` `CL` to `<normalized>`) so the
+/// `@PG` command line — which names `retag` — is still intact to assert on. When
+/// the serial path was removed this became the only retag test that pins @HD
+/// synthesis / @PG stamping in plain CI.
+fn assert_output_header(output: &Path) {
+    use noodles::sam::header::record::value::map::header::{Version, tag as header_tag};
+    use noodles::sam::header::record::value::map::program::tag as program_tag;
+
+    let mut reader = noodles::bam::io::reader::Builder
+        .build_from_path(output)
+        .unwrap_or_else(|e| panic!("open {}: {e}", output.display()));
+    let header = reader.read_header().expect("read output header");
+
+    let hd = header.header().expect("output BAM must carry a synthesized @HD line");
+    assert_eq!(hd.version(), Version::new(1, 6), "synthesized @HD VN must be 1.6");
+    assert_eq!(
+        hd.other_fields().get(&header_tag::SORT_ORDER).map(|v| v.to_vec()),
+        Some(b"unsorted".to_vec()),
+        "synthesized @HD SO must be 'unsorted'"
+    );
+
+    // The input carries no @PG, so any @PG present is the one retag stamped. Its
+    // CL names `retag`, which pins that this provenance record came from this run.
+    let stamped_retag_pg = header.programs().as_ref().values().any(|program| {
+        program
+            .other_fields()
+            .get(&program_tag::COMMAND_LINE)
+            .is_some_and(|cl| cl.windows(5).any(|w| w == b"retag"))
+    });
+    assert!(stamped_retag_pg, "output header must carry a retag @PG provenance record");
+}
+
+/// Reads a string aux tag (named by its two-char SAM tag) off a parsed
+/// `RecordBuf`, or `None` when the tag is absent or not a string value.
+fn tag_string(record: &noodles::sam::alignment::RecordBuf, tag: &str) -> Option<String> {
+    use noodles::sam::alignment::record::data::field::Tag;
+    use noodles::sam::alignment::record_buf::data::field::Value;
+    let sam_tag: SamTag = tag.parse().expect("valid two-char tag");
+    match record.data().get(&Tag::from(sam_tag))? {
+        Value::String(s) => Some(s.to_string()),
+        _ => None,
+    }
+}

--- a/tests/integration/test_sort_cutover_parity.rs
+++ b/tests/integration/test_sort_cutover_parity.rs
@@ -26,6 +26,7 @@ use rstest::rstest;
 use tempfile::TempDir;
 
 use crate::helpers::bam_generator::{create_minimal_header, write_bam};
+use crate::helpers::cutover::{baseline_bin, decompressed_records_without_pg};
 use crate::helpers::read_bam_output;
 
 /// `n` mapped, single-end records on one reference, placed at *descending*
@@ -107,28 +108,6 @@ fn sort_command_produces_coordinate_sorted_output_via_chain() {
 //
 // A failure here is a real cutover parity bug, not a test to relax.
 // ============================================================================
-
-/// Resolves the saved owned-engine baseline binary to compare against.
-///
-/// The baseline path comes solely from the `FGUMI_BASELINE_BIN` env var; when it
-/// is unset (or names a missing file) this returns `None` — "no baseline oracle
-/// available", never a passing result. Callers layer the baseline byte-parity
-/// check on top of the always-available order oracle (`fgumi sort --verify`) and,
-/// where it exists, a `samtools` cross-check; a missing baseline just drops the
-/// byte-parity half, it never skips the case outright.
-/// No hardcoded fallback: a baseline binary is host-specific and must never be a
-/// path committed into the repo.
-fn baseline_bin() -> Option<std::path::PathBuf> {
-    let path = std::path::PathBuf::from(std::env::var_os("FGUMI_BASELINE_BIN")?);
-    if path.is_file() {
-        return Some(path);
-    }
-    eprintln!(
-        "FGUMI_BASELINE_BIN={} does not name an existing file; baseline oracle unavailable",
-        path.display()
-    );
-    None
-}
 
 /// Whether `samtools` is on `PATH` and runnable.
 fn samtools_available() -> bool {
@@ -218,78 +197,6 @@ fn record_identities(bam_path: &Path) -> Vec<String> {
         .collect();
     identities.sort_unstable();
     identities
-}
-
-/// Removes every `@PG` line from a SAM header text blob.
-///
-/// Both the cutover build and the baseline binary stamp a single `@PG` line
-/// whose `VN` (git-describe version) and `CL` (command line, naming argv[0] --
-/// a different binary path for each side -- and the per-run output path)
-/// necessarily differ between two independent invocations. Stripping the whole
-/// line (not just normalizing those two sub-fields) is simplest and correct
-/// here because neither side emits more than one `@PG` record for this input
-/// (the test BAMs carry no pre-existing `@PG`).
-fn strip_pg_lines(text: &str) -> String {
-    // Empty in, empty out: `"".split('\n')` yields `[""]`, which the
-    // trailing-newline logic below would otherwise turn into `"\n"`.
-    if text.is_empty() {
-        return String::new();
-    }
-    let mut lines: Vec<&str> = text.split('\n').collect();
-    let had_trailing_newline = lines.last() == Some(&"");
-    if had_trailing_newline {
-        lines.pop();
-    }
-    lines.retain(|line| !line.starts_with("@PG"));
-    let mut out = lines.join("\n");
-    // Restore the trailing newline iff the source had one — never synthesize one
-    // the source lacked (the prior `!out.is_empty()` clause did exactly that).
-    if had_trailing_newline {
-        out.push('\n');
-    }
-    out
-}
-
-/// Reads a BAM file's raw BGZF stream, decompresses it, strips the `@PG`
-/// line(s) from the embedded SAM header text, and returns the resulting bytes
-/// (new header + unmodified `n_ref`/reference-list/record bytes).
-///
-/// This compares the two writers' *decompressed* output rather than
-/// `RecordBuf`-parsed records or raw file bytes: BGZF block boundaries and
-/// compression levels differ between the two writers even when the logical
-/// content is identical, so raw file bytes never match; parsing into
-/// `RecordBuf` and re-encoding risks masking a real tag-order or
-/// binary-layout regression by normalizing it away. Operating directly on the
-/// decompressed BAM binary format keeps everything except the `@PG` line an
-/// exact, uninterpreted byte comparison.
-fn decompressed_records_without_pg(path: &Path) -> Vec<u8> {
-    let file = std::fs::File::open(path).unwrap_or_else(|e| panic!("open {}: {e}", path.display()));
-    let mut reader = noodles::bgzf::io::Reader::new(std::io::BufReader::new(file));
-    let mut raw = Vec::new();
-    std::io::Read::read_to_end(&mut reader, &mut raw)
-        .unwrap_or_else(|e| panic!("decompress BGZF stream for {}: {e}", path.display()));
-
-    assert!(
-        raw.len() >= 8 && &raw[0..4] == b"BAM\x01",
-        "{} does not decompress to a BAM binary stream (missing magic)",
-        path.display()
-    );
-    let l_text = i32::from_le_bytes(raw[4..8].try_into().expect("4 bytes"));
-    let l_text = usize::try_from(l_text).expect("l_text is non-negative");
-    let text_start = 8;
-    let text_end = text_start + l_text;
-    assert!(raw.len() >= text_end, "{} header text runs past end of stream", path.display());
-
-    let text = String::from_utf8_lossy(&raw[text_start..text_end]);
-    let stripped_text = strip_pg_lines(&text);
-
-    let mut out = Vec::with_capacity(raw.len());
-    out.extend_from_slice(b"BAM\x01");
-    let new_l_text = i32::try_from(stripped_text.len()).expect("stripped header text fits i32");
-    out.extend_from_slice(&new_l_text.to_le_bytes());
-    out.extend_from_slice(stripped_text.as_bytes());
-    out.extend_from_slice(&raw[text_end..]); // n_ref, reference list, and all records, untouched
-    out
 }
 
 /// Builds a diverse SAM header for the four-order parity gate: three


### PR DESCRIPTION
## What

Retire the legacy single-threaded `fgumi retag` path so the declarative chain builder is the **only** execution path. `retag` was dual-mode — no `--threads` ran a serial in-process loop (`run_single_threaded`), `--threads N` ran the chain. `execute()` now keeps all its pre-flight validation and then always dispatches to the chain; the serial loop and its now-dead helpers are deleted.

Output is byte-identical (modulo the `@PG` line): the chain's `ClipTemplates`… correction — the chain's retag step and finalize hooks already produce the same records, `--metrics` TSV, banner/timer, and the zero-match warning.

## Parity analysis (done before deleting)

Every diagnostic the serial tail emitted is already produced by the chain (`ChainBuilder::add_retag` + `RetagFinalizeHook`/`RetagMetricsFinalizeHook`) — **nothing needed to be added**: the CRC-verify line, `Starting Retag` + Input/Output/Operation, the `OperationTimer`, the verbatim zero-match `warn!`, the success-only `--metrics` TSV, and the summary/record-count. The chain additionally emits threading/pipeline banners (additive) and, as already documented for filter/dedup, prints the summary even on a failed run.

## Tests

- `tests/integration/test_retag_cutover_parity.rs` — pins chain output == the pre-removal serial baseline via `FGUMI_BASELINE_BIN` (records byte-identical modulo `@PG`, plus the `--metrics` TSV), degrading to a self-consistency + header oracle (asserts synthesized `@HD VN:1.6 SO:unsorted` + a retag `@PG`) when the env var is unset — never skipping. Covers multiple operations, a zero-match op, and `--metrics`.
- Existing `test_retag_command.rs` determinism tests retained as worker-count-invariance checks.

## Incidental

- Reworded the shared `ThreadingOptions::threads` `--threads` help text to be command-agnostic (it no longer claims a universal "single-threaded fast path", which is no longer true once a command's serial loop is retired).
- Hoisted the cutover-parity helpers (`baseline_bin`, `strip_pg_lines`, `decompressed_records_without_pg`) into a shared `tests/integration/helpers/cutover.rs`; `test_sort_cutover_parity.rs` now uses them too (removing the duplication).

Full gate green (`cargo ci-test` 9957 passed / 31 skipped with `FGUMI_BASELINE_BIN` set proving cutover byte-parity, plus fmt/lint/doc and `--no-default-features`/`--all-features`). This is the first of the per-command R6-0 legacy-path retirements; no user-facing behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: `retag` BAM, tag, and metrics output changes; the declarative chain and parity tests pin the new output. Unsafe changes: none; `CLAUDE.md` allowlist unchanged. Threading policy changes; memory bounds and queue capacity: none.

- Removes the legacy serial `retag` path.
- Routes all `retag` runs through the declarative chain.
- Preserves pre-flight validation.
- Adds parity tests for BAM output, headers, metrics, zero-match operations, empty inputs, and multi-batch inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->