### PR TITLE
fix(correct): write --metrics only when processing completes (fgbio parity on --min-corrected failure)

### DIFF
--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -1901,9 +1901,16 @@ impl<'a> ChainBuilder<'a> {
     /// `self.header` is the input header (correct preserves input order and does
     /// not replace `self.header` with a consensus header), so it is used as-is.
     ///
-    /// Registers a [`CorrectFinalizeHook`] for: per-thread accumulator reduce →
-    /// `finalize_metrics` → summary + warn banners → `--min-corrected` ratio
-    /// gate (bail!) → `timer.log_completion`.
+    /// Registers two finalize hooks. Always-run: [`CorrectFinalizeHook`]
+    /// (per-thread counter reduce → summary → warn banners →
+    /// `timer.log_completion`). Success-only: [`CorrectMetricsFinalizeHook`],
+    /// which writes the `--metrics` TSV FIRST and then, only when
+    /// `--min-corrected` was given, enforces the ratio gate. That ordering
+    /// matches fgbio: `CorrectUmis` writes its metrics before checking the
+    /// `--min-corrected` ratio, so a ratio-below-floor failure is not treated
+    /// as a processing failure and still leaves the metrics file in place. A
+    /// genuine pipeline processing failure skips `finalize_on_success`
+    /// entirely, withholding the metrics write (and thus the gate never runs).
     /// The chain-level [`StageTimingFinalizeHook`] is registered by
     /// [`Self::build`] (not here), so it captures the correct `Instant`.
     ///
@@ -1915,13 +1922,16 @@ impl<'a> ChainBuilder<'a> {
     /// [`EncodedUmiSet`]: crate::commands::correct::EncodedUmiSet
     /// [`DecompressedBlock`]: crate::pipeline::steps::types::DecompressedBlock
     /// [`CorrectFinalizeHook`]: crate::pipeline::chains::commands::correct::CorrectFinalizeHook
+    /// [`CorrectMetricsFinalizeHook`]: crate::pipeline::chains::commands::correct::CorrectMetricsFinalizeHook
     #[allow(clippy::too_many_lines)]
     fn add_correct(&mut self, position: StagePosition) -> Result<()> {
         use crate::commands::common::warn_unwired_pipeline_flags;
         use crate::commands::correct::{CollectedCorrectMetrics, EncodedUmiSet};
         use crate::logging::OperationTimer;
         use crate::per_thread_accumulator::PerThreadAccumulator;
-        use crate::pipeline::chains::commands::correct::CorrectFinalizeHook;
+        use crate::pipeline::chains::commands::correct::{
+            CorrectFinalizeHook, CorrectMetricsFinalizeHook,
+        };
         use crate::pipeline::steps::correct::{
             CorrectStepConfig, correct_step_kept_only, correct_step_with_rejects,
         };
@@ -2067,19 +2077,28 @@ impl<'a> ChainBuilder<'a> {
             self.chain_tail_kind = ChainTailKind::BamTemplateBatch;
         }
 
-        // Register the correct finalize hook.
+        // Register the correct finalize hooks.
         // The chain-level StageTimingFinalizeHook is inserted at index 0 by
         // build() after all stages have been added — that way a single timer
         // covers the full pipeline run regardless of how many stages there are.
-        self.finalize.push(Box::new(CorrectFinalizeHook {
-            metrics,
-            records_emitted,
+
+        // Success-only: writes the --metrics TSV, THEN (only when
+        // --min-corrected was given) enforces the ratio gate -- in that exact
+        // order, within one hook. This matches fgbio: a ratio-below-floor
+        // failure is not a processing failure, so the metrics file must
+        // already be on disk by the time the gate can error. Skipped
+        // entirely on a genuine pipeline failure, since finalize_on_success
+        // does not run at all in that case.
+        self.finalize_on_success.push(Box::new(CorrectMetricsFinalizeHook {
+            metrics: Arc::clone(&metrics),
+            records_emitted: Arc::clone(&records_emitted),
             encoded_umi_set,
             unmatched_umi,
-            min_corrected: correct_opts.min_corrected,
             correct: correct_opts.clone(),
-            timer,
         }));
+        // Always-run: summary + warn banners + timer completion. No longer
+        // includes the --min-corrected gate (see above).
+        self.finalize.push(Box::new(CorrectFinalizeHook { metrics, records_emitted, timer }));
 
         Ok(())
     }

--- a/src/lib/pipeline/chains/commands/correct.rs
+++ b/src/lib/pipeline/chains/commands/correct.rs
@@ -4,7 +4,22 @@
 //! Phase 3 (T3a.11) lifts that logic into
 //! [`crate::pipeline::chains::builder::ChainBuilder`]; this module
 //! now holds the correct-specific types and step factories that the builder
-//! imports: `CorrectFinalizeHook` used by `ChainBuilder::add_correct`.
+//! imports: `CorrectFinalizeHook` (always-run: summary/banner) and
+//! `CorrectMetricsFinalizeHook` (success-only: `--metrics` TSV write, THEN the
+//! `--min-corrected` ratio gate), both used by `ChainBuilder::add_correct`.
+//!
+//! ## fgbio parity: metrics vs. the `--min-corrected` gate
+//!
+//! fgbio's `CorrectUmis` writes the metrics file once processing completes,
+//! *before* it checks the `--min-corrected` ratio — so a ratio-below-floor
+//! failure is not treated as a processing failure and still leaves the
+//! metrics (and other output) files in place. Only a genuine processing error
+//! (I/O, malformed input) withholds them. `CorrectMetricsFinalizeHook`
+//! reproduces that ordering directly: it writes the `--metrics` TSV first,
+//! then (only when `--min-corrected` was given) runs the ratio gate — both
+//! within the same success-only hook, so the write always happens before the
+//! gate can error. A genuine pipeline processing failure skips the whole
+//! `finalize_on_success` list, withholding both.
 //!
 //! ## Four chain shapes
 //!
@@ -34,53 +49,133 @@ use crate::metrics::correct::UmiCorrectionMetrics;
 use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::pipeline::chains::FinalizeHook;
 
-/// Post-pipeline finalize hook for correct. Reduces per-thread metrics,
-/// writes the optional metrics TSV, logs the summary and the
-/// missing/wrong-length-UMI error banner, enforces the `--min-corrected`
-/// ratio gate, and calls `timer.log_completion`.
+/// Aggregated per-thread totals shared by [`CorrectFinalizeHook`]'s summary
+/// and [`CorrectMetricsFinalizeHook`]'s `--min-corrected` gate. Extracted into
+/// one struct + reducer ([`sum_correct_counts`]) so the two call sites read
+/// the exact same counters and cannot silently diverge if the set of
+/// rejection reasons on [`CollectedCorrectMetrics`] ever changes.
+#[derive(Default)]
+pub(crate) struct CorrectCounts {
+    pub(crate) templates: u64,
+    pub(crate) missing: u64,
+    pub(crate) wrong_length: u64,
+    pub(crate) mismatched: u64,
+}
+
+impl CorrectCounts {
+    /// Total rejected records: every rejection-reason counter summed.
+    pub(crate) fn rejected(&self) -> u64 {
+        self.missing + self.wrong_length + self.mismatched
+    }
+}
+
+/// Sum the plain per-thread counters (everything except `umi_matches`) across
+/// every `PerThreadAccumulator` slot. Reads only `Copy` fields, so this is
+/// non-destructive and safe to call from more than one finalize hook sharing
+/// the same accumulator.
+pub(crate) fn sum_correct_counts(
+    metrics: &PerThreadAccumulator<CollectedCorrectMetrics>,
+) -> CorrectCounts {
+    let mut counts = CorrectCounts::default();
+    for slot in metrics.slots() {
+        let m = slot.lock();
+        counts.templates += m.templates_processed;
+        counts.missing += m.missing_umis;
+        counts.wrong_length += m.wrong_length;
+        counts.mismatched += m.mismatched;
+    }
+    counts
+}
+
+/// Post-pipeline finalize hook for correct. Reduces per-thread counters (via
+/// [`sum_correct_counts`]), logs the summary and the missing/wrong-length-UMI
+/// error banner, and calls `timer.log_completion`.
 ///
-/// Mirrors the body of `CorrectUmis::finalize_correct_run`, extracted here so
-/// `BuiltPipeline::run` can call it after `Pipeline::run` returns.
+/// Registered on the **always-run** `finalize` list, so the summary/banner are
+/// reported even after a pipeline processing failure. The `--metrics` TSV
+/// write and the `--min-corrected` ratio gate live on the success-only
+/// [`CorrectMetricsFinalizeHook`] instead — see the module-level fgbio-parity
+/// note for why the gate is success-gated rather than living here. Shares the
+/// `metrics` accumulator with that hook via `Arc`; only the per-counter
+/// totals (not `umi_matches`) are read here, non-destructively, so both hooks
+/// can independently read the same accumulator.
 ///
 /// `pub(crate)` so `ChainBuilder` can construct and register it in
 /// `add_correct`.
 pub(crate) struct CorrectFinalizeHook {
     pub(crate) metrics: Arc<PerThreadAccumulator<CollectedCorrectMetrics>>,
     pub(crate) records_emitted: Arc<AtomicU64>,
-    pub(crate) encoded_umi_set: Arc<EncodedUmiSet>,
-    pub(crate) unmatched_umi: String,
-    /// `--min-corrected` gate value (if set).
-    pub(crate) min_corrected: Option<f64>,
-    /// Used by `finalize_metrics` to compute and write the metrics TSV.
-    pub(crate) correct: CorrectOptions,
     pub(crate) timer: OperationTimer,
 }
 
 impl FinalizeHook for CorrectFinalizeHook {
     fn finalize(self: Box<Self>) -> Result<()> {
-        let CorrectFinalizeHook {
+        let CorrectFinalizeHook { metrics, records_emitted, timer } = *self;
+
+        let counts = sum_correct_counts(&metrics);
+
+        // Log summary.
+        let records_written = records_emitted.load(Ordering::Relaxed);
+        let rejected = counts.rejected();
+        let total_records = records_written + rejected;
+        info!("Read {total_records}; kept {records_written} and rejected {rejected}");
+        info!("Total templates processed: {}", counts.templates);
+
+        // fgbio logs this summary at error level (CorrectUmis.scala:275-280).
+        if counts.missing > 0 || counts.wrong_length > 0 {
+            error!("###################################################################");
+            error!("# {} were missing UMI attributes in the BAM file!", counts.missing);
+            error!(
+                "# {} had unexpected UMIs of differing lengths in the BAM file!",
+                counts.wrong_length
+            );
+            error!("###################################################################");
+        }
+
+        timer.log_completion(records_written);
+
+        Ok(())
+    }
+}
+
+/// Success-only finalize hook that writes the `--metrics` TSV and then, only
+/// when `--min-corrected` was given, enforces the ratio gate. Registered on
+/// `finalize_on_success` (not the always-run `finalize`), so a genuine
+/// pipeline processing failure withholds both — but, per fgbio parity, a
+/// `--min-corrected` ratio failure does NOT withhold the metrics write: the
+/// TSV is written first, inside this same hook, before the gate can error
+/// (see the module-level fgbio-parity note). Owns the sole read of the shared
+/// `metrics` accumulator's `umi_matches` map, so it drains it (moves out);
+/// the ratio gate instead calls [`sum_correct_counts`], the same reducer
+/// [`CorrectFinalizeHook`] uses for its summary.
+pub(crate) struct CorrectMetricsFinalizeHook {
+    pub(crate) metrics: Arc<PerThreadAccumulator<CollectedCorrectMetrics>>,
+    pub(crate) records_emitted: Arc<AtomicU64>,
+    pub(crate) encoded_umi_set: Arc<EncodedUmiSet>,
+    pub(crate) unmatched_umi: String,
+    /// Used by `finalize_metrics` to compute and write the metrics TSV, and
+    /// to read the `--min-corrected` gate value (if any).
+    pub(crate) correct: CorrectOptions,
+}
+
+impl FinalizeHook for CorrectMetricsFinalizeHook {
+    fn finalize(self: Box<Self>) -> Result<()> {
+        let CorrectMetricsFinalizeHook {
             metrics,
             records_emitted,
             encoded_umi_set,
             unmatched_umi,
-            min_corrected,
             correct,
-            timer,
         } = *self;
 
-        // Drain all PerThreadAccumulator slots into per-counter totals +
-        // a single AHashMap that finalize_metrics consumes.
-        let mut total_templates = 0u64;
-        let mut total_missing = 0u64;
-        let mut total_wrong_length = 0u64;
-        let mut total_mismatched = 0u64;
+        // Drain every PerThreadAccumulator slot's `umi_matches` into a single
+        // AHashMap that `finalize_metrics` consumes. This hook is the sole
+        // consumer of `umi_matches` (`CorrectFinalizeHook` only reads the
+        // plain counters via `sum_correct_counts`), so draining (move, not
+        // clone) is safe here.
         let mut merged_umi_matches: AHashMap<String, UmiCorrectionMetrics> = AHashMap::new();
         for slot in metrics.slots() {
             let mut m = slot.lock();
-            total_templates += m.templates_processed;
-            total_missing += m.missing_umis;
-            total_wrong_length += m.wrong_length;
-            total_mismatched += m.mismatched;
             for (umi, counts) in m.umi_matches.drain() {
                 merge_umi_counts(&mut merged_umi_matches, umi, &counts);
             }
@@ -92,31 +187,19 @@ impl FinalizeHook for CorrectFinalizeHook {
                 .entry(umi.clone())
                 .or_insert_with(|| UmiCorrectionMetrics::new(umi.clone()));
         }
+        // Write the metrics TSV BEFORE the ratio gate below, so a
+        // --min-corrected failure still leaves it on disk (fgbio parity).
         correct.finalize_metrics(&mut merged_umi_matches, &unmatched_umi)?;
 
-        // Log summary.
-        let records_written = records_emitted.load(Ordering::Relaxed);
-        let rejected = total_missing + total_wrong_length + total_mismatched;
-        let total_records = records_written + rejected;
-        info!("Read {total_records}; kept {records_written} and rejected {rejected}");
-        info!("Total templates processed: {total_templates}");
-
-        // fgbio logs this summary at error level (CorrectUmis.scala:275-280).
-        if total_missing > 0 || total_wrong_length > 0 {
-            error!("###################################################################");
-            error!("# {total_missing} were missing UMI attributes in the BAM file!");
-            error!(
-                "# {total_wrong_length} had unexpected UMIs of differing lengths in the BAM file!"
-            );
-            error!("###################################################################");
-        }
-
-        // Check minimum correction ratio.
-        if let Some(min) = min_corrected {
+        // Enforce the --min-corrected ratio gate, if requested. Uses the same
+        // `sum_correct_counts` reducer as CorrectFinalizeHook's summary, so
+        // the two can't diverge on which counters count as "rejected".
+        if let Some(min) = correct.min_corrected {
+            let counts = sum_correct_counts(&metrics);
+            let records_written = records_emitted.load(Ordering::Relaxed);
+            let total_records = records_written + counts.rejected();
             check_min_corrected(records_written, total_records, min)?;
         }
-
-        timer.log_completion(records_written);
 
         Ok(())
     }
@@ -192,7 +275,6 @@ mod tests {
     // `crate::commands::common::test_log_capture`) so this test does not
     // install a competing process-global logger under plain `cargo t`.
     use crate::commands::common::test_log_capture::{capture_logs, captured_with_level};
-    use crate::commands::correct::Target;
     use rstest::rstest;
 
     /// Content needles identifying the missing/wrong-length-UMI banner lines,
@@ -246,22 +328,6 @@ mod tests {
         let hook = CorrectFinalizeHook {
             metrics,
             records_emitted: Arc::new(AtomicU64::new(5)),
-            encoded_umi_set: Arc::new(EncodedUmiSet::new(&["AAA".to_string(), "CCC".to_string()])),
-            unmatched_umi: "NNN".to_string(),
-            min_corrected: None,
-            correct: CorrectOptions {
-                metrics: None,
-                target: Target::Umi,
-                max_mismatches: 1,
-                min_distance_diff: 1,
-                umis: vec!["AAA".to_string(), "CCC".to_string()],
-                umi_files: vec![],
-                dont_store_original_umis: false,
-                cache_size: 10,
-                min_corrected: None,
-                revcomp: false,
-                rejects_path: None,
-            },
             timer: OperationTimer::new("Correct"),
         };
 

--- a/tests/integration/test_correct_command.rs
+++ b/tests/integration/test_correct_command.rs
@@ -986,6 +986,194 @@ fn test_correct_chain_rejects_empty_input_with_min_corrected() {
     assert!(err.to_string().contains("No reads were processed"), "unexpected error: {err:#}");
 }
 
+/// Regression: a chain (`--threads`) `correct` run that fails the
+/// `--min-corrected` gate on EMPTY input (the `total_records == 0` branch of
+/// `check_min_corrected`) must still WRITE the `--metrics` TSV. fgbio writes
+/// its metrics once processing completes, before checking the
+/// `--min-corrected` ratio, so a ratio-below-floor failure is not treated as
+/// a processing failure and still leaves the metrics file in place -- only a
+/// genuine pipeline processing error (I/O, malformed input) should withhold
+/// it. The command must still exit non-zero. See
+/// `test_correct_chain_writes_metrics_on_min_corrected_ratio_failure` for the
+/// companion case where real records ARE processed and the ratio itself (not
+/// the empty-input guard) is what fails.
+#[test]
+fn test_correct_chain_writes_metrics_on_min_corrected_failure_empty_input() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let whitelist = temp_dir.path().join("whitelist.txt");
+    let metrics_path = temp_dir.path().join("metrics.tsv");
+
+    // Header-only BAM: no records at all, so the --min-corrected gate always
+    // bails (0 / 0 cannot meet a positive minimum), even though processing
+    // itself completes without error.
+    create_umi_bam(&input_bam, vec![]);
+    create_whitelist(&whitelist, &["ACGTACGT"]);
+
+    let cmd = CorrectUmis::try_parse_from([
+        "correct",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        temp_dir.path().join("chain.bam").to_str().unwrap(),
+        "--umi-files",
+        whitelist.to_str().unwrap(),
+        "--max-mismatches",
+        "1",
+        "--min-distance",
+        "1",
+        "--min-corrected",
+        "0.5",
+        "--metrics",
+        metrics_path.to_str().unwrap(),
+        "--compression-level",
+        "1",
+        "--threads",
+        "4",
+    ])
+    .expect("parse correct args");
+    let err = cmd
+        .execute("fgumi correct")
+        .expect_err("chain path must reject empty input under a positive --min-corrected");
+    assert!(err.to_string().contains("No reads were processed"), "unexpected error: {err:#}");
+
+    // Strengthen beyond exists(): the file must actually parse, and must
+    // carry a row for every UMI (including the unmatched bucket) -- a
+    // truncated or empty file would fail this, not just a missing one.
+    let parsed = fgumi_lib::metrics::UmiCorrectionMetrics::read_metrics(&metrics_path)
+        .expect("metrics TSV must be parseable");
+    assert_eq!(
+        parsed.len(),
+        2,
+        "expected one row for the whitelisted UMI and one for the unmatched bucket: {parsed:?}"
+    );
+    assert!(
+        parsed.iter().any(|m| m.umi == "ACGTACGT"),
+        "expected a row for the whitelisted UMI: {parsed:?}"
+    );
+    // The unmatched bucket's UMI is `"N".repeat(umi_length)` (correct.rs), which
+    // is `NNNNNNNN` for the 8bp whitelist UMI. Assert it by identity so a TSV
+    // carrying some other second key cannot satisfy the row-count check above.
+    assert!(
+        parsed.iter().any(|m| m.umi == "NNNNNNNN"),
+        "expected a row for the unmatched UMI bucket: {parsed:?}"
+    );
+}
+
+/// Regression: a chain (`--threads`) `correct` run that fails the
+/// `--min-corrected` gate because the ACHIEVED ratio is below the floor --
+/// with real records processed, exercising `check_min_corrected`'s ratio
+/// branch (`total_records > 0`), not the empty-input branch covered by
+/// `test_correct_chain_writes_metrics_on_min_corrected_failure_empty_input`
+/// -- must still WRITE the `--metrics` TSV, for the same fgbio-parity reason.
+#[test]
+fn test_correct_chain_writes_metrics_on_min_corrected_ratio_failure() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let whitelist = temp_dir.path().join("whitelist.txt");
+    let metrics_path = temp_dir.path().join("metrics.tsv");
+
+    // 3 correctable reads (kept) + 2 reads with a UMI at edit distance 8 from
+    // the whitelist (uncorrectable at --max-mismatches 1, so rejected) gives
+    // a real, non-empty run with kept/total = 3/5 = 0.6 -- below a 0.9 floor,
+    // so the RATIO branch fails, not the "no reads processed" branch.
+    let correctable = create_umi_family("ACGTACGT", 3, "exact", "AAAAGGGG", 30);
+    let uncorrectable = create_umi_family("TTTTTTTT", 2, "far", "AAAAGGGG", 30);
+    create_umi_bam(&input_bam, vec![correctable, uncorrectable]);
+    create_whitelist(&whitelist, &["ACGTACGT"]);
+
+    let cmd = CorrectUmis::try_parse_from([
+        "correct",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        temp_dir.path().join("chain.bam").to_str().unwrap(),
+        "--umi-files",
+        whitelist.to_str().unwrap(),
+        "--max-mismatches",
+        "1",
+        "--min-distance",
+        "1",
+        "--min-corrected",
+        "0.9",
+        "--metrics",
+        metrics_path.to_str().unwrap(),
+        "--compression-level",
+        "1",
+        "--threads",
+        "4",
+    ])
+    .expect("parse correct args");
+    let err = cmd
+        .execute("fgumi correct")
+        .expect_err("chain path must reject a kept/total ratio below --min-corrected");
+    let message = err.to_string();
+    assert!(
+        message.contains("Final ratio of reads kept / total was"),
+        "expected the ratio-branch error (not the empty-input branch): {message}"
+    );
+    assert!(
+        !message.contains("No reads were processed"),
+        "this run processed real records; the empty-input branch must not fire: {message}"
+    );
+
+    // Strengthen beyond exists(): parse the file and confirm the whitelisted
+    // UMI's row reflects the 3 kept records, not a truncated/empty write.
+    let parsed = fgumi_lib::metrics::UmiCorrectionMetrics::read_metrics(&metrics_path)
+        .expect("metrics TSV must be parseable");
+    assert!(!parsed.is_empty(), "metrics TSV must have at least one row: {parsed:?}");
+    let whitelisted = parsed
+        .iter()
+        .find(|m| m.umi == "ACGTACGT")
+        .unwrap_or_else(|| panic!("expected a row for the whitelisted UMI: {parsed:?}"));
+    assert_eq!(
+        whitelisted.total_matches, 3,
+        "the whitelisted UMI's row must reflect all 3 kept records: {parsed:?}"
+    );
+}
+
+/// Regression: a chain (`--threads`) `correct` run that fails mid-pipeline
+/// (a genuine `Pipeline::run` error, not just a finalize-hook gate) must not
+/// leave a `--metrics` TSV behind either -- mirrors the clip/retag pattern of
+/// gating the metrics write on `finalize_on_success`, which is skipped
+/// entirely whenever the pipeline run itself errors.
+#[test]
+fn test_correct_chain_no_metrics_on_pipeline_failure() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let input_bam = temp_dir.path().join("input.bam");
+    let output_bam = temp_dir.path().join("output.bam");
+    let metrics_path = temp_dir.path().join("metrics.tsv");
+
+    create_multiblock_umi_bam(&input_bam, "ACGTACGT");
+    corrupt_last_block_crc(&input_bam);
+
+    let cmd = CorrectUmis::try_parse_from([
+        "correct",
+        "--input",
+        input_bam.to_str().unwrap(),
+        "--output",
+        output_bam.to_str().unwrap(),
+        "--umis",
+        "ACGTACGT",
+        "--max-mismatches",
+        "1",
+        "--min-distance",
+        "1",
+        "--metrics",
+        metrics_path.to_str().unwrap(),
+        "--compression-level",
+        "1",
+        "--threads",
+        "4",
+    ])
+    .expect("parse correct args");
+    let err =
+        cmd.execute("fgumi correct").expect_err("chain path must reject corrupted BGZF CRC32");
+    let message = format!("{err:#}");
+    assert!(message.to_uppercase().contains("CRC32"), "error should mention CRC32: {message}");
+    assert!(!metrics_path.exists(), "metrics TSV must not be written on a failed chain run");
+}
+
 /// Write a header-less UMI-tagged BAM (no `@HD`) -- the shape
 /// `ChainBuilder::new`'s `ensure_hd_record` call (Task 2B) must synthesize
 /// `@HD` for. Mirrors `write_headerless_consensus_bam` in


### PR DESCRIPTION
## What

On the chain `correct` path, the metrics finalize hook was on the **always-run** list, so a run that failed with a genuine pipeline processing error still left a `--metrics` TSV on disk. This moves the metrics write to a success-only hook — but preserves fgbio's exact contract for the `--min-corrected` gate.

## The fgbio contract this preserves

fgbio writes the metrics file once processing completes, *before* checking the `--min-corrected` ratio — a ratio below the floor is a failure, but **all files (including metrics) are still written**. So the correct behavior is:

- **Pipeline processing error** (I/O, malformed input): no metrics written (the run didn't complete).
- **`--min-corrected` ratio failure** (run completed, ratio below floor): metrics **are** written, then the command errors — the metrics are exactly the diagnostic that explains *why* the ratio was low.

## How

A single success-only `CorrectMetricsFinalizeHook` (registered on `finalize_on_success`) writes the `--metrics` TSV **first**, then — only when `--min-corrected` was given — runs `check_min_corrected`. The `--min-corrected` gate is removed from the always-run `CorrectFinalizeHook` (which keeps the counter reduce, summary, #912's error-level missing/wrong-length banner, and the timer). On a pipeline error, `finalize_on_success` is skipped entirely, so neither the metrics write nor the gate runs. This is the two-hook shape retag/filter already use.

A shared `sum_correct_counts` reducer (over `CorrectCounts`) is used by both the summary hook and the metrics hook's ratio gate, so the two can't diverge on what counts as "rejected."

## Tests

- `test_correct_chain_writes_metrics_on_min_corrected_ratio_failure` — real records with kept/total = 3/5 = 0.6 against a 0.9 floor: asserts the command errors with the **ratio-branch** message AND the `--metrics` TSV is written (parsed back with `UmiCorrectionMetrics::read_metrics` and asserted on content, not just existence).
- `test_correct_chain_writes_metrics_on_min_corrected_failure_empty_input` — the empty-input (0/0) branch, same "metrics still written" contract.
- `test_correct_chain_no_metrics_on_pipeline_failure` — CRC-corruption forces a genuine pipeline error → no metrics file.

Full gate green (`cargo ci-test` 9958 passed / 31 skipped, plus fmt/lint/doc and `--no-default-features`/`--all-features`).

Stacked on #912.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: metrics output changes, pinned by regression tests; grouping, consensus, sort order, and corrected UMI output changes none; unsafe changes none; memory, queue, and thread/backpressure changes none.

Metrics write after successful pipeline processing and before `--min-corrected` validation. Processing failures skip metrics. Shared count reduction supports summary and ratio validation. Tests cover empty input, low corrected ratios, and corrupted BGZF input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->