### PR TITLE
refactor(clip): retire the legacy single-threaded path; the chain is the only path

### DIFF
--- a/src/lib/commands/clip.rs
+++ b/src/lib/commands/clip.rs
@@ -4,20 +4,14 @@
 //! This is useful for variant calling to avoid double-counting evidence from
 //! overlapping portions of paired reads.
 
-use crate::alignment_tags::regenerate_alignment_tags_raw;
 use crate::clipper::{ClippingMode, RawRecordClipper};
-use crate::logging::OperationTimer;
 use crate::metrics::clip::{ClipCounts, ClippingMetricsCollection};
-use crate::reference::ReferenceReader;
 use crate::sam::SamTag;
-use crate::template::{InsertSizeEnd, TemplateIterator, compute_insert_size_from_ends};
+use crate::template::{InsertSizeEnd, compute_insert_size_from_ends};
 use crate::validation::validate_file_exists;
 use anyhow::Result;
 use clap::Parser;
-use fgumi_bam_io::ProgressTracker;
-use fgumi_bam_io::{create_raw_bam_reader_with_opts, create_raw_bam_writer};
 use fgumi_raw_bam::RawRecord;
-use log::info;
 use std::path::PathBuf;
 
 use super::command::Command;
@@ -118,8 +112,8 @@ pub struct Clip {
     #[arg(short = 'a', long = "auto-clip-attributes", value_name = "true|false", default_value = "false", num_args = 0..=1, default_missing_value = "true", action = clap::ArgAction::Set, value_parser = clap::builder::BoolishValueParser::new(), hide_possible_values = true)]
     pub auto_clip_attributes: bool,
 
-    /// Output file for clipping metrics (produced on both the single-threaded and
-    /// --threads paths)
+    /// Output file for clipping metrics (produced on the declarative chain, the
+    /// only execution path, regardless of `--threads`)
     #[arg(short = 'm', long = "metrics")]
     pub metrics: Option<PathBuf>,
 
@@ -146,11 +140,11 @@ pub struct Clip {
 
 /// Per-template clipping configuration, decoupled from `&Clip`.
 ///
-/// The single-threaded path holds a `&Clip` and could read these fields directly, but the
-/// multi-threaded pipeline's `process_fn` runs in a `move` closure that cannot borrow `&self`.
-/// Capturing this small `Copy` value lets both paths share the exact same per-template
-/// clipping logic (`clip_template`/`clip_pair`/`clip_fragment`) instead of maintaining two
-/// copies that can silently drift apart.
+/// The declarative chain's `process_fn` runs in a `move` closure that cannot borrow `&self`,
+/// so the per-template clipping decision is driven from this small `Copy` value rather than
+/// from `&Clip`. Capturing it lets the chain's worker closure share the exact same
+/// per-template clipping logic (`clip_template`/`clip_pair`/`clip_fragment`) that the unit
+/// tests exercise directly, instead of maintaining two copies that can silently drift apart.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ClipParams {
     /// Upgrade existing clipping to the configured mode before applying new clipping.
@@ -199,10 +193,9 @@ impl ClipParams {
     /// inside `clip_pair`/`clip_fragment`) is what lets supplementary reads' clipping be
     /// upgraded too, and keeps both threading paths in lockstep since both go through this method.
     ///
-    /// This is the single shared implementation used by both the single-threaded and
-    /// multi-threaded clip paths. When `metrics` is `Some`, per-read base-clip counts are
-    /// accumulated into it. The single-threaded path always passes a collector when
-    /// `--metrics` is set; the multi-threaded path passes the calling worker's
+    /// This is the single shared per-template implementation the chain's worker closure
+    /// runs (and the unit tests exercise directly). When `metrics` is `Some`, per-read
+    /// base-clip counts are accumulated into it: the chain passes the calling worker's
     /// `PerThreadAccumulator` slot when `--metrics` is set and `None` otherwise, relying
     /// solely on the returned per-template flags for its atomic summary counters.
     ///
@@ -454,7 +447,6 @@ impl ClipParams {
 }
 
 impl Command for Clip {
-    #[allow(clippy::too_many_lines)]
     fn execute(&self, command_line: &str) -> Result<()> {
         // Reject two outputs resolving to one destination before any writer opens.
         let mut outputs: Vec<(&std::path::Path, &str)> =
@@ -468,8 +460,9 @@ impl Command for Clip {
         self.io.validate()?;
         validate_file_exists(&self.reference, "Reference FASTA")?;
 
-        // Validate clipping parameters (reader-free; must run on both execution
-        // paths). At least one clipping option must be requested.
+        // Validate clipping parameters (reader-free). At least one clipping option
+        // must be requested. (`add_clip` re-checks this on the chain, but keeping it
+        // here reports the error before any reader/writer opens.)
         if self.upgrade_clipping
             || self.clip_overlapping_reads
             || self.clip_extending_past_mate
@@ -483,60 +476,38 @@ impl Command for Clip {
             anyhow::bail!("At least one clipping option is required");
         }
 
-        // --threads N: run the clip stage on the declarative chain builder. Dispatch
-        // here — after the reader-free pre-flight above (output collisions, including
-        // --metrics; input + reference existence; clipping-option validation), which
-        // must run for both paths — but BEFORE the banner / timer / reader below.
-        // `--metrics` itself is no longer rejected under `--threads`: `add_clip`
-        // collects detailed metrics on the chain path too (see `execute_chain`).
-        // execute_chain → add_clip re-emits the banner, timer, and threading log
-        // lines, re-enforces require_query_grouped, and opens its own source, so
-        // running them here too would double-log and pre-consume stdin. The
-        // no-`--threads` single-threaded path below stays the in-process parity oracle.
-        if self.threading.threads.is_some() {
-            return self.execute_chain(command_line);
-        }
-
-        // ---- legacy no-`--threads` oracle path (single-threaded engine) ----
-        info!("Clip");
-        info!("  Input: {}", self.io.input.display());
-        info!("  Output: {}", self.io.output.display());
-        info!("  Clipping mode: {}", self.clipping_mode);
-        info!("  Clip overlapping reads: {}", self.clip_overlapping_reads);
-        info!("  Clip extending past mate: {}", self.clip_extending_past_mate);
-        info!("  {}", self.threading.log_message());
-        // The single-threaded fast path (via create_raw_bam_reader_with_opts) honors
-        // --check-crc/--no-check-crc (#800).
-        self.io.log_effective_check_crc();
-
-        let timer = OperationTimer::new("Clipping reads");
-        let mode = self.clipping_mode;
-        let total_records = self.execute_single_threaded(mode, command_line)?;
-        timer.log_completion(total_records);
-        Ok(())
+        // The declarative chain is the only execution path. `execute` does the
+        // reader-free pre-flight above (output collisions, including --metrics;
+        // input + reference existence; clipping-option validation) and then always
+        // dispatches to the chain, with or without `--threads` (absent `--threads`
+        // runs the chain at a single worker). All user-facing diagnostics — the
+        // `Clip` banner + Input/Output/mode lines, the `OperationTimer`, the
+        // threading log lines, `require_query_grouped`, the summary counters, and
+        // the `--metrics` TSV — are emitted inside `ChainBuilder::add_clip` and its
+        // finalize hooks; running any of those here first would double-log and
+        // pre-consume stdin. `--metrics` is produced on the chain too (#915).
+        self.execute_chain(command_line)
     }
 }
 
 impl Clip {
-    /// Runs the `--threads N` path via the declarative chain builder
+    /// Runs the clip stage on the declarative chain builder
     /// (`ChainSpec::single_stage(Stage::Clip, ...)` → `build_for(spec)?.run()`).
     ///
-    /// `add_clip` opens its own source, re-emits the timer/banner/threading log
-    /// lines, reloads the reference, re-validates the clipping options, and
-    /// re-enforces `require_query_grouped`, so none of those may run again here —
-    /// only the CRC-verify status line, which `add_clip` does not re-emit. The
-    /// no-`--threads` path in `execute` keeps its own single-threaded engine,
-    /// which is the in-process parity oracle for this one (see
-    /// `test_clip_chain_matches_single_threaded`). `--metrics` is produced on both
-    /// paths: `add_clip` builds a per-thread `ClippingMetricsCollection`
-    /// accumulator when `self.metrics.is_some()` and reduces it in a
-    /// success-only finalize hook.
+    /// The chain is the only execution path: `execute` always dispatches here, with
+    /// or without `--threads` (absent `--threads` runs the chain at a single
+    /// worker). `add_clip` opens its own source, emits the timer/banner/threading
+    /// log lines, loads the reference, validates the clipping options, and enforces
+    /// `require_query_grouped`, so none of those run here — only the CRC-verify
+    /// status line, which `add_clip` does not emit. `--metrics` is produced by the
+    /// chain: `add_clip` builds a per-thread `ClippingMetricsCollection` accumulator
+    /// when `self.metrics.is_some()` and reduces it in a success-only finalize hook.
     fn execute_chain(&self, command_line: &str) -> Result<()> {
         use crate::pipeline::chains::{
             ChainSpec, SingleStageContext, Stage, StageOptionsBag, build_for,
         };
-        // add_clip re-emits the timer/banner/threading lines but NOT the
-        // CRC-verify status line.
+        // add_clip emits the timer/banner/threading lines but NOT the CRC-verify
+        // status line, so surface the effective CRC policy here.
         self.io.log_effective_check_crc();
         let stage_opts = StageOptionsBag { clip: Some(self.clone()), ..Default::default() };
         let ctx = SingleStageContext {
@@ -549,117 +520,6 @@ impl Clip {
         };
         let spec = ChainSpec::single_stage(Stage::Clip, stage_opts, &ctx);
         build_for(spec)?.run()
-    }
-
-    /// Execute single-threaded clipping.
-    #[allow(clippy::too_many_lines)]
-    fn execute_single_threaded(&self, mode: ClippingMode, command_line: &str) -> Result<u64> {
-        // Create clipper
-        let clipper = if self.auto_clip_attributes {
-            RawRecordClipper::with_auto_clip(mode, true)
-        } else {
-            RawRecordClipper::new(mode)
-        };
-
-        // Create metrics collection if metrics output requested
-        let mut metrics_collection =
-            self.metrics.as_ref().map(|_| ClippingMetricsCollection::new());
-
-        // Load reference (always required and tags are always regenerated to match Scala fgbio)
-        let reference_reader = ReferenceReader::new(&self.reference)?;
-
-        // Open input BAM. This fast path is only reached with no --threads, so
-        // reader_threads is 1 and the reader decodes through fgumi-bgzf, honoring
-        // --check-crc/--no-check-crc via pipeline_reader_opts (#800).
-        let reader_threads = self.threading.num_threads();
-        let (reader, header) = create_raw_bam_reader_with_opts(
-            &self.io.input,
-            reader_threads,
-            self.io.pipeline_reader_opts(),
-        )?;
-
-        // Synthesize @HD VN:1.6 SO:unsorted when the input lacks one (match fgbio).
-        let header = crate::commands::common::ensure_hd_record(header)?;
-        // CLIP3-05: require query-grouped input (fgbio Bams.requireQueryGrouped).
-        crate::commands::common::require_query_grouped(
-            &header,
-            &self.io.input.display().to_string(),
-        )?;
-
-        // Add @PG record with PP chaining to input's last program
-        let header = crate::commands::common::add_pg_record(header, command_line)?;
-
-        // Create output BAM writer with multi-threaded BGZF compression
-        let writer_threads = self.threading.num_threads();
-        let mut writer = create_raw_bam_writer(
-            &self.io.output,
-            &header,
-            writer_threads,
-            self.compression.compression_level,
-        )?;
-
-        // Process templates
-        info!("Processing templates...");
-
-        let mut total_records: usize = 0;
-        let mut total_clipped_overlap: u64 = 0;
-        let mut total_clipped_mate_extension: u64 = 0;
-        let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
-
-        // Shared per-template clip configuration (see `build_clip_process_step` in the chain
-        // builder for the parallel `--threads` use).
-        let params = ClipParams::from_clip(self);
-
-        // Single-threaded processing: iterate raw templates, clip in place
-        let template_iter = TemplateIterator::new(reader);
-
-        for template in template_iter {
-            let template = template?;
-            let mut records: Vec<RawRecord> = template.into_records();
-
-            let (overlap_clip, extend_clip) =
-                params.clip_template(&mut records, &clipper, metrics_collection.as_mut())?;
-            if overlap_clip {
-                total_clipped_overlap += 1;
-            }
-            if extend_clip {
-                total_clipped_mate_extension += 1;
-            }
-
-            // Regenerate alignment tags (always done to match Scala fgbio behavior)
-            for record in &mut records {
-                regenerate_alignment_tags_raw(record.as_mut_vec(), &header, &reference_reader)?;
-            }
-
-            // Count and write records
-            let batch_size = records.len();
-            total_records += batch_size;
-            for record in &records {
-                writer.write_raw_record(record.as_ref())?;
-            }
-            progress.log_if_needed(batch_size as u64);
-        }
-
-        progress.log_final();
-        info!("Total records processed: {total_records}");
-        info!("Templates with overlap clipping: {total_clipped_overlap}");
-        info!("Templates with mate extension clipping: {total_clipped_mate_extension}");
-
-        // Write metrics if requested. `finalize_and_write` (shared with the chain
-        // `--threads` path's `ClipMetricsFinalizeHook`) aggregates pair/all and
-        // writes the TSV in one call, so the two paths' metrics output cannot drift.
-        if let Some(metrics_path) = &self.metrics
-            && let Some(mut metrics) = metrics_collection
-        {
-            metrics.finalize_and_write(metrics_path)?;
-            info!("Wrote metrics to: {}", metrics_path.display());
-        }
-
-        // Flush and finish the writer
-        writer.finish()?;
-
-        info!("Done!");
-        Ok(total_records as u64)
     }
 }
 
@@ -2042,7 +1902,7 @@ mod tests {
     /// `clip5PrimeEndOfRead`/`clip3PrimeEndOfRead`. A read that already carries >= N
     /// bases of clipping at the requested end must not be clipped further.
     #[rstest]
-    #[case::single_threaded(ThreadingOptions::none())]
+    #[case::single_worker(ThreadingOptions::none())]
     #[case::multi_threaded(ThreadingOptions::new(2))]
     fn test_fixed_position_clip_counts_existing_clipping(
         #[case] threading: ThreadingOptions,
@@ -2122,10 +1982,10 @@ mod tests {
     /// CLIP3-01 (command level): overlap clipping must be strand-normalized end to end.
     /// A pair whose first-of-pair read is the reverse strand must yield the same
     /// per-strand output as the mirror pair whose first-of-pair read is the forward
-    /// strand — the `clip` command must not clip the wrong (outer) ends. Exercised in
-    /// both the single-threaded (`threads == 0`) and multi-threaded pipeline paths.
+    /// strand — the `clip` command must not clip the wrong (outer) ends. Exercised at
+    /// both a single worker (no `--threads`) and a multi-worker pipeline.
     #[rstest]
-    #[case::single_threaded(0)]
+    #[case::single_worker(0)]
     #[case::multi_threaded(4)]
     fn test_clip_overlap_negative_strand_first_matches_mirror(
         #[case] threads: usize,
@@ -2865,14 +2725,14 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("At least one clipping option"));
     }
 
-    /// Parameterized test for all threading modes.
+    /// Parameterized test for all threading modes (all run on the chain).
     ///
     /// Tests:
-    /// - `None`: Single-threaded fast path, no pipeline
-    /// - `Some(1)`: Pipeline with 1 thread
-    /// - `Some(2)`: Pipeline with 2 threads
+    /// - `None`: the chain at a single worker (no `--threads`)
+    /// - `Some(1)`: pipeline with 1 thread
+    /// - `Some(2)`: pipeline with 2 threads
     #[rstest]
-    #[case::fast_path(ThreadingOptions::none())]
+    #[case::single_worker(ThreadingOptions::none())]
     #[case::pipeline_1(ThreadingOptions::new(1))]
     #[case::pipeline_2(ThreadingOptions::new(2))]
     fn test_threading_modes(#[case] threading: ThreadingOptions) -> Result<()> {

--- a/src/lib/pipeline/chains/builder.rs
+++ b/src/lib/pipeline/chains/builder.rs
@@ -4157,11 +4157,10 @@ impl<'a> ChainBuilder<'a> {
         let num_threads = self.spec.threading.num_threads();
 
         // fgbio's ClipBam requires query-grouped input (a template's reads must be
-        // adjacent). Both legacy clip paths enforce this — `execute_single_threaded`
-        // (the parity oracle) and the pre-cutover `--threads` path, via
-        // `require_query_grouped` — so the chain `--threads` path must too; otherwise
-        // coordinate-sorted input that the legacy path rejected would be silently
-        // mis-clipped. Gated on Clip being the source stage: a future fused
+        // adjacent). The chain is clip's only execution path, so it must enforce this
+        // via `require_query_grouped`; otherwise coordinate-sorted input would be
+        // silently mis-clipped (mates scatter, so pair clip / overlap / mate-fix
+        // no-op). Gated on Clip being the source stage: a future fused
         // group→clip chain has an upstream stage that orders the records, so this
         // guard must not reject that. `ChainSpec` exposes only `single_stage` today,
         // so clip is always the source stage and the guard always fires.
@@ -4199,8 +4198,7 @@ impl<'a> ChainBuilder<'a> {
 
         // Per-thread detailed `--metrics` accumulator, bundled with the metrics
         // path in one `Option` — built only when `--metrics` is requested, one
-        // slot per worker thread, merged by `ClipMetricsFinalizeHook` (success-only)
-        // exactly like the single-threaded oracle's `ClippingMetricsCollection`.
+        // slot per worker thread, merged by `ClipMetricsFinalizeHook` (success-only).
         // Bundling means the "accumulator and path are both Some or both None"
         // invariant is structural (a single `Option`, not two kept in sync), so
         // the finalize-hook registration below never needs to prove it via `.expect()`.
@@ -4243,9 +4241,8 @@ impl<'a> ChainBuilder<'a> {
         self.finalize.push(Box::new(ClipFinalizeHook { metrics, progress_counter, timer }));
 
         // Success-only: reduce the per-thread `--metrics` accumulator and write
-        // the TSV. A failed/partial run publishes no stale metrics file, matching
-        // the single-threaded oracle (which only reaches its metrics-write code
-        // after a fully successful pass over the input).
+        // the TSV. A failed/partial run publishes no stale metrics file — a metrics
+        // TSV is only meaningful once every record was processed.
         if let Some((accumulator, metrics_path)) = metrics_target {
             self.finalize_on_success
                 .push(Box::new(ClipMetricsFinalizeHook { accumulator, metrics_path }));

--- a/src/lib/pipeline/chains/commands/clip.rs
+++ b/src/lib/pipeline/chains/commands/clip.rs
@@ -95,20 +95,17 @@ impl FinalizeHook for ClipFinalizeHook {
 /// Success-only finalize hook: reduces the per-thread `--metrics` accumulator
 /// and writes the detailed clipping-metrics TSV. Registered on
 /// `finalize_on_success` (not the always-run `finalize` list) so a
-/// failed/partial run publishes no stale metrics file — matching the
-/// single-threaded oracle, which only reaches its metrics-write code after a
-/// fully successful pass over the input.
+/// failed/partial run publishes no stale metrics file — a metrics TSV is only
+/// meaningful once every record was processed.
 ///
-/// Reduction mirrors the single-threaded oracle's call sequence exactly: each
-/// worker's slot holds raw (unfinalized) `fragment`/`read_one`/`read_two`
+/// Each worker's slot holds raw (unfinalized) `fragment`/`read_one`/`read_two`
 /// counters (see [`ClippingMetricsCollection::merge`]), which are summed
 /// across all slots into one collection and then finalized/written via
-/// [`ClippingMetricsCollection::finalize_and_write`] — the same helper the
-/// single-threaded oracle calls, so the two paths' metrics output cannot drift
-/// apart — with `finalize` running exactly once, after every slot is merged
-/// (the same order the oracle uses: accumulate, then finalize once at the
-/// end). That makes the `pair`/`all` aggregates the TSV reports byte-for-byte
-/// reproducible regardless of how work was sharded across threads.
+/// [`ClippingMetricsCollection::finalize_and_write`], with `finalize` running
+/// exactly once, after every slot is merged (accumulate, then finalize once at
+/// the end). Because the reduction is pure integer addition, that makes the
+/// `pair`/`all` aggregates the TSV reports byte-for-byte reproducible regardless
+/// of how work was sharded across threads.
 pub(crate) struct ClipMetricsFinalizeHook {
     pub(crate) accumulator: Arc<PerThreadAccumulator<ClippingMetricsCollection>>,
     pub(crate) metrics_path: PathBuf,
@@ -147,15 +144,13 @@ impl FinalizeHook for ClipMetricsFinalizeHook {
 /// `pub(crate)` — consumed only by `ChainBuilder::add_clip` and
 /// [`build_clip_process_step`].
 ///
-/// The clipping control flags are bundled into a single `params: ClipParams`,
-/// shared verbatim with the single-threaded oracle (`Clip::execute_single_threaded`);
+/// The clipping control flags are bundled into a single `params: ClipParams`;
 /// the hot-path closure delegates the whole per-template decision to
 /// `params.clip_template(...)` rather than branching on individual flags.
 pub(crate) struct ClipProcessCaptures {
     pub(crate) clipping_mode: crate::clipper::ClippingMode,
     pub(crate) auto_clip_attributes: bool,
-    /// The per-template clip configuration, shared verbatim with the
-    /// single-threaded `Clip::execute` path (its in-process parity oracle).
+    /// The per-template clip configuration built from the parsed `Clip` command.
     pub(crate) params: ClipParams,
     pub(crate) header: noodles::sam::Header,
     pub(crate) reference: Arc<ReferenceReader>,
@@ -198,8 +193,8 @@ pub(crate) fn build_clip_process_step(
 
             // When `--metrics` is requested, run the batch under this worker's
             // `PerThreadAccumulator` slot so `clip_template` collects detailed
-            // per-read base-clip counts (exactly like the single-threaded oracle);
-            // otherwise pass `None` and stay on the fast, collection-free path.
+            // per-read base-clip counts; otherwise pass `None` and stay on the
+            // fast, collection-free path.
             let (local_templates, local_overlap_clipped, local_extend_clipped, local_record_count) =
                 if let Some(accumulator) = &cap.metrics_accumulator {
                     accumulator.with_slot(|slot| {
@@ -280,8 +275,7 @@ fn clip_templates_in_batch(
         // in place keeps allocation count near-equal to legacy.
         let records: &mut Vec<RawRecord> = &mut template.records;
 
-        // Delegate to the canonical per-template clip implementation — the exact
-        // code the single-threaded `Clip::execute` oracle runs
+        // Delegate to the canonical per-template clip implementation
         // (`ClipParams::clip_template`). It finds the primary pair by SAM flag (so
         // secondary/supplementary reads are handled, not just records[0]/[1]),
         // applies fixed clipping with "ensure at least N including existing
@@ -299,7 +293,7 @@ fn clip_templates_in_batch(
             local_extend_clipped += 1;
         }
 
-        // Regenerate alignment tags for every record (matches the oracle).
+        // Regenerate alignment tags for every record (always done to match fgbio).
         for record in records.iter_mut() {
             regenerate_alignment_tags_raw(record.as_mut_vec(), header, reference)
                 .map_err(io::Error::other)?;

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -11,6 +11,7 @@ mod test_bam_pipeline;
 mod test_bgzf_eof;
 mod test_chain_bam_with_index;
 mod test_clip_command;
+mod test_clip_cutover_parity;
 #[cfg(feature = "codec")]
 mod test_codec_command;
 #[cfg(feature = "codec")]

--- a/tests/integration/test_clip_command.rs
+++ b/tests/integration/test_clip_command.rs
@@ -48,12 +48,11 @@ fn write_paired_bam_with_header(
 }
 
 // ============================================================================
-// --check-crc / --no-check-crc on the multi-threaded (`--threads N`) path (#800)
+// --check-crc / --no-check-crc on the chain (`--threads N`) path (#800)
 //
-// clip is the one command whose `--threads N` mode decodes its input through the
-// unified pipeline (not the single-threaded raw reader). These prove that path
-// honors the flag: `--no-check-crc` accepts a corrupted block, while the default
-// and `--check-crc` reject it.
+// clip always decodes its input through the unified pipeline (the chain is its
+// only execution path). These prove that path honors the flag: `--no-check-crc`
+// accepts a corrupted block, while the default and `--check-crc` reject it.
 // ============================================================================
 
 /// Flip a byte in the last BGZF block's CRC32 footer, so decoding that block
@@ -219,10 +218,11 @@ fn test_clip_threads_check_crc_rejects_corrupted_crc() {
 /// matching fgbio's `Bams.requireQueryGrouped`. On coordinate-sorted input mates
 /// scatter, so pair clip / overlap / mate-fix silently no-op — hard-fail instead.
 ///
-/// Exercised on both `Clip::execute` paths (the single-threaded fast path and the
-/// `--threads` pipeline) since the guard is wired into each.
+/// Exercised at both worker counts (no `--threads`, i.e. the chain at a single
+/// worker, and `--threads N`) since `require_query_grouped` fires on the chain
+/// regardless of worker count.
 #[rstest]
-#[case::single_threaded(&[])]
+#[case::single_worker(&[])]
 #[case::threaded(&["--threads", "2"])]
 fn test_clip_rejects_coordinate_sorted_input(#[case] extra_args: &[&str]) {
     let temp_dir = TempDir::new().unwrap();
@@ -445,15 +445,18 @@ fn push_clip_metrics_parity_records(records: &mut Vec<RawRecord>, repeats: usize
 /// lucky scheduling accident.
 const REPEATS: usize = 2000;
 
-/// `--metrics` on the chain `--threads N` path must now succeed (previously a hard
-/// error) and produce a metrics TSV that matches the single-threaded oracle exactly.
+/// The chain `--metrics` output must be independent of the worker count: a
+/// no-`--threads` run (the chain at a single worker) and `--threads N` runs must
+/// produce a byte-identical metrics TSV.
 ///
 /// Detailed metrics are collected via a per-thread `ClippingMetricsCollection`
 /// accumulator (one slot per worker), reduced by summing raw `fragment`/`read_one`/
 /// `read_two` counters across slots and then calling `finalize()` once -- pure integer
 /// addition is commutative and associative, so the reduction is order-independent and
-/// the TSV is byte-identical to the oracle's regardless of thread count or how work was
-/// sharded. This is the load-bearing parity test for this feature.
+/// the TSV is byte-identical regardless of thread count or how work was sharded. This
+/// is the load-bearing worker-count-independence test for `--metrics`. (Byte-parity
+/// against the pre-removal single-threaded binary lives in
+/// `test_clip_cutover_parity.rs`.)
 ///
 /// The fixture is sized (`REPEATS`, see its doc comment) to force real cross-worker
 /// `PerThreadAccumulator` sharding at `--threads 2`/`4`, not just a single-slot
@@ -480,7 +483,7 @@ fn test_clip_metrics_match_across_threading_modes(#[case] threads: usize) {
     let opts =
         ["--clip-overlapping-reads", "--read-one-five-prime", "1", "--read-two-three-prime", "1"];
 
-    // Oracle: no --threads (single-threaded engine, the parity reference).
+    // Reference: no --threads (the chain at a single worker).
     {
         let mut args = vec![
             "clip",
@@ -495,9 +498,9 @@ fn test_clip_metrics_match_across_threading_modes(#[case] threads: usize) {
         ];
         args.extend_from_slice(&opts);
         Clip::try_parse_from(args)
-            .expect("parse oracle args")
+            .expect("parse single-worker args")
             .execute("fgumi clip")
-            .expect("oracle clip failed");
+            .expect("single-worker clip failed");
     }
 
     // Chain: --threads N with --metrics. Must succeed and write the metrics file.
@@ -797,14 +800,15 @@ fn build_clip_parity_bam(path: &Path, count: usize) {
     create_paired_bam(path, pairs);
 }
 
-/// Chain-vs-oracle parity: the `--threads N` chain path
-/// (`ChainSpec::single_stage(Stage::Clip, ...)` → `build_for(spec)?.run()`) must
-/// produce the same records AND the same normalized header as the single-threaded
-/// oracle (`execute_single_threaded`). This is the load-bearing test for the R3
-/// clip cutover; `read_bam_output` normalizes only the `@PG` `CL` field, which
-/// legitimately differs by `--threads`, so a dropped `@SQ`/`@RG`/`@HD`/`@CO` line
-/// or any record divergence fails the test. Parameterized over thread counts to
-/// exercise single- and multi-worker scheduling.
+/// Worker-count independence: clip always runs on the declarative chain
+/// (`ChainSpec::single_stage(Stage::Clip, ...)` → `build_for(spec)?.run()`), so a
+/// no-`--threads` run (the chain at a single worker) and `--threads N` runs must
+/// produce the same records AND the same normalized header. `read_bam_output`
+/// normalizes only the `@PG` `CL` field, which legitimately differs by `--threads`,
+/// so a dropped `@SQ`/`@RG`/`@HD`/`@CO` line or any record divergence fails the
+/// test. Parameterized over thread counts to exercise single- and multi-worker
+/// scheduling. (Byte-parity against the pre-removal single-threaded binary lives in
+/// `test_clip_cutover_parity.rs`.)
 #[rstest]
 #[case::threads_1(1)]
 #[case::threads_2(2)]
@@ -821,7 +825,7 @@ fn test_clip_chain_matches_single_threaded(#[case] threads: usize) {
     let opts =
         ["--clip-overlapping-reads", "--read-one-five-prime", "1", "--read-two-three-prime", "1"];
 
-    // Oracle: no --threads (single-threaded engine).
+    // Reference: no --threads (the chain at a single worker).
     {
         let mut args = vec![
             "clip",
@@ -834,9 +838,9 @@ fn test_clip_chain_matches_single_threaded(#[case] threads: usize) {
         ];
         args.extend_from_slice(&opts);
         Clip::try_parse_from(args)
-            .expect("parse oracle args")
+            .expect("parse single-worker args")
             .execute("fgumi clip")
-            .expect("oracle clip failed");
+            .expect("single-worker clip failed");
     }
 
     // Chain: --threads N (declarative chain builder).
@@ -875,7 +879,7 @@ fn test_clip_chain_matches_single_threaded(#[case] threads: usize) {
 
     assert_eq!(
         oracle_records, chain_records,
-        "chain (--threads {threads}) output must match the single-threaded oracle record-for-record",
+        "chain (--threads {threads}) output must match the single-worker run record-for-record",
     );
     assert_eq!(
         oracle_header, chain_header,
@@ -889,11 +893,12 @@ fn test_clip_chain_matches_single_threaded(#[case] threads: usize) {
 /// fgbio's `Bams.requireQueryGrouped`. The `@HD` synthesis itself is still exercised
 /// end-to-end by `correct`/`review` (which have no query-grouped guard).
 ///
-/// Exercised on both `Clip::execute` paths (the single-threaded fast path and the
-/// `--threads` pipeline): both run `ensure_hd_record` before `require_query_grouped`,
-/// so header-less input is rejected the same way regardless of execution mode.
+/// Exercised at both worker counts (no `--threads`, i.e. the chain at a single
+/// worker, and `--threads N`): the chain runs `ensure_hd_record` before
+/// `require_query_grouped`, so header-less input is rejected the same way
+/// regardless of worker count.
 #[rstest]
-#[case::single_threaded(&[])]
+#[case::single_worker(&[])]
 #[case::threaded(&["--threads", "2"])]
 fn test_clip_rejects_headerless_input(#[case] extra_args: &[&str]) {
     let temp_dir = TempDir::new().unwrap();
@@ -1188,8 +1193,8 @@ fn read_with_cigar_mc(
 /// Runs `clip --upgrade-clipping` (Hard mode) over a template whose only clipped read is a
 /// supplementary alignment (`10S40M`), and asserts the supplementary's leading soft clip is
 /// upgraded to hard. fgbio `ClipBam` upgrades `template.allReads` (`ClipBam.scala:123`), not just
-/// the primary R1/R2, so the supplementary must be upgraded too. `threads` selects the
-/// single-threaded (`None`) vs `--threads` code path — the fix must hold on both.
+/// the primary R1/R2, so the supplementary must be upgraded too. `threads` selects a
+/// single worker (`None`) vs `--threads` — the fix must hold at both worker counts.
 fn run_supplementary_upgrade_case(threads: Option<&str>) {
     let temp_dir = TempDir::new().unwrap();
     let input_bam = temp_dir.path().join("input.bam");
@@ -1293,10 +1298,10 @@ fn run_supplementary_upgrade_case(threads: Option<&str>) {
     }
 }
 
-/// `--upgrade-clipping` upgrades a supplementary alignment's clipping on both the single-threaded
-/// (`None`) and `--threads` (`Some("2")`) code paths.
+/// `--upgrade-clipping` upgrades a supplementary alignment's clipping at both a single
+/// worker (`None`) and `--threads` (`Some("2")`).
 #[rstest]
-#[case::single_threaded(None)]
+#[case::single_worker(None)]
 #[case::threaded(Some("2"))]
 fn test_upgrade_clipping_upgrades_supplementary(#[case] threads: Option<&str>) {
     run_supplementary_upgrade_case(threads);
@@ -1602,11 +1607,11 @@ fn test_clip_command_threads_mode_supplementary_mate_repair() {
     assert_eq!(supp.mate_alignment_start(), r2.alignment_start());
 }
 
-/// The single-threaded (`execute_single_threaded`) and multi-threaded (`--threads`, via the chain
-/// builder's `build_clip_process_step`)
-/// paths share one per-template clipping implementation (`ClipParams::clip_template`), so clipping
-/// the same input under both must yield byte-identical output. This pins that invariant end-to-end:
-/// if the two paths ever diverge (e.g. a future edit touches only one), this comparison fails.
+/// Clip always runs on the declarative chain (via `build_clip_process_step` →
+/// `ClipParams::clip_template`), so its output must be independent of the worker count: a
+/// no-`--threads` run (the chain at a single worker) and a `--threads N` run must yield
+/// byte-identical output. This pins that invariant end-to-end: if the two configurations
+/// ever diverge (e.g. a future edit to the batching or reduction), this comparison fails.
 #[test]
 fn test_clip_command_single_and_multi_threaded_outputs_match() {
     let temp_dir = TempDir::new().unwrap();
@@ -1674,7 +1679,7 @@ fn test_clip_command_single_and_multi_threaded_outputs_match() {
     let multi_records = read_output_record_bufs(&multi_out);
     assert_eq!(
         single_records, multi_records,
-        "single-threaded and multi-threaded clip output must be identical"
+        "single-worker and multi-worker clip output must be identical"
     );
 
     // Independent oracle: the cross-mode equality above only proves the two paths agree — a
@@ -1807,9 +1812,7 @@ fn test_clip_command_lone_r2_primary_passed_through_unclipped() {
     let multi_records = read_output_record_bufs(&multi_out);
 
     // Both modes emit the single input record with no clipping applied (still 100M at 1-based 200).
-    for (label, records) in
-        [("single-threaded", &single_records), ("multi-threaded", &multi_records)]
-    {
+    for (label, records) in [("single-worker", &single_records), ("multi-worker", &multi_records)] {
         assert_eq!(records.len(), 1, "{label}: expected exactly one output record");
         assert_eq!(
             cigar_ops(&records[0]),
@@ -1849,7 +1852,7 @@ fn test_clip_command_lone_r2_primary_passed_through_unclipped() {
 /// mode is Hard, so Soft is forced explicitly here to match the unit test
 /// (`deletion_knock_on`) this test's expected CIGARs are hand-derived from.
 #[rstest]
-#[case::single_threaded(None)]
+#[case::single_worker(None)]
 #[case::threaded(Some("2"))]
 fn test_clip_command_past_mate_knock_on_regression(#[case] threads: Option<&str>) {
     let temp_dir = TempDir::new().unwrap();
@@ -1974,7 +1977,7 @@ fn test_clip_command_past_mate_knock_on_regression(#[case] threads: Option<&str>
 ///   soft-clipped bases to hard, leaving the other 20 still soft: r1 -> `20M20S60H`, r2
 ///   (symmetric, on its leading/low-coordinate side) -> `60H20S20M`.
 #[rstest]
-#[case::single_threaded(None)]
+#[case::single_worker(None)]
 #[case::threaded(Some("2"))]
 fn test_clip_command_past_mate_hard_mode_cigars(#[case] threads: Option<&str>) {
     let temp_dir = TempDir::new().unwrap();

--- a/tests/integration/test_clip_cutover_parity.rs
+++ b/tests/integration/test_clip_cutover_parity.rs
@@ -1,0 +1,626 @@
+//! Parity gate for the `clip` command's single-threaded-path retirement (C4):
+//! `Clip::execute` no longer has a serial in-process loop reached when `--threads`
+//! is absent — it *always* routes through the declarative chain builder.
+//!
+//! Two independent things are checked here:
+//!
+//! 1. **The cutover actually happened** (`clip_no_threads_routes_through_chain`).
+//!    A no-`--threads` run now emits the chain-only `"Using pipeline with N
+//!    threads"` banner that `ChainBuilder::add_clip` logs and the retired serial
+//!    tail never did. This is the genuine RED/GREEN discriminator: before the
+//!    removal a no-`--threads` run took the serial path and printed no such line;
+//!    after it, the chain does.
+//!
+//! 2. **Output equivalence** (`cutover_matches_baseline`), checked one of two ways:
+//!    - **CI default (no `FGUMI_BASELINE_BIN`): a self-consistency oracle.** The
+//!      chain's output is asserted directly — every record survives, the run
+//!      *introduces* clipping over the (deliberately pre-clipped) input, and the
+//!      `--metrics` counts are non-zero for the shapes exercised. This is what runs
+//!      in ordinary CI, so it must fail on a silently no-op'd clip on its own.
+//!    - **When `FGUMI_BASELINE_BIN` is set: an independent byte-parity check.** The
+//!      current build's `clip` output — records (byte-identical, modulo the `@PG`
+//!      line) and the `--metrics` TSV — must match the frozen pre-cutover baseline
+//!      binary run WITHOUT `--threads` (its serial engine). This is the stronger
+//!      check, but it runs only when the (host-specific, uncommitted) baseline
+//!      binary is provided; it never silently skips (the self-consistency oracle
+//!      always runs in its place) — the fallback discipline of
+//!      `test_sort_cutover_parity`.
+//!
+//! So this test proves the cutover lost nothing user-observable only to the strength
+//! of whichever half ran: the always-on self-consistency oracle in default CI, and
+//! the full byte-parity guarantee when a baseline binary is supplied.
+//!
+//! The corpus deliberately covers clip's historical known-divergence shapes in one
+//! query-grouped stream: a lone fragment, a plain overlapping FR pair, a pair with
+//! pre-existing SOFT clipping on R1, a pair with pre-existing HARD clipping on R2,
+//! and a template carrying a secondary + a supplementary alignment (passed through
+//! but with supplementary mate-info repaired, and clipping upgraded template-wide
+//! under `--upgrade-clipping`).
+//!
+//! **Not a RED/GREEN gate for the equivalence half.** Because the removed serial
+//! loop and the chain were already output-equivalent, both checks in (2) pass on
+//! both sides of the change — they guard equivalence, not a regression the cutover
+//! introduces. The chain-banner check in (1) is the part that flips RED→GREEN.
+
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::Command;
+
+use fgumi_raw_bam::{RawRecord, SamBuilder, flags};
+use rstest::rstest;
+use tempfile::TempDir;
+
+use crate::helpers::bam_generator::{create_minimal_header, create_test_reference, write_bam};
+use crate::helpers::read_bam_output;
+
+/// Resolves the saved pre-removal serial baseline binary to compare against.
+///
+/// The path comes solely from `FGUMI_BASELINE_BIN`; when unset (or naming a
+/// missing file) this returns `None` — "no baseline oracle available", never a
+/// silent pass. Callers layer the baseline byte-parity check on top of the
+/// always-available self-consistency oracle; a missing baseline drops only the
+/// byte-parity half, it never skips the case. No hardcoded fallback: a baseline
+/// binary is host-specific and must never be a path committed into the repo.
+fn baseline_bin() -> Option<std::path::PathBuf> {
+    let path = std::path::PathBuf::from(std::env::var_os("FGUMI_BASELINE_BIN")?);
+    if path.is_file() {
+        return Some(path);
+    }
+    eprintln!(
+        "FGUMI_BASELINE_BIN={} does not name an existing file; baseline oracle unavailable",
+        path.display()
+    );
+    None
+}
+
+/// Removes every `@PG` line from a SAM header text blob.
+///
+/// Both the current build and the baseline binary stamp a single `@PG` line whose
+/// `VN` (git-describe version) and `CL` (command line, naming argv[0] — a
+/// different binary path for each side — and the per-run output path) necessarily
+/// differ between two independent invocations. Stripping the whole line is correct
+/// here because neither side emits more than one `@PG` for these inputs (the test
+/// BAMs carry no pre-existing `@PG`).
+fn strip_pg_lines(text: &str) -> String {
+    if text.is_empty() {
+        return String::new();
+    }
+    let mut lines: Vec<&str> = text.split('\n').collect();
+    let had_trailing_newline = lines.last() == Some(&"");
+    if had_trailing_newline {
+        lines.pop();
+    }
+    lines.retain(|line| !line.starts_with("@PG"));
+    let mut out = lines.join("\n");
+    if had_trailing_newline {
+        out.push('\n');
+    }
+    out
+}
+
+/// Reads a BAM's raw BGZF stream, decompresses it, strips the `@PG` line(s) from
+/// the embedded SAM header text, and returns the resulting bytes (new header +
+/// unmodified `n_ref`/reference-list/record bytes).
+///
+/// Comparing the *decompressed* BAM binary — rather than `RecordBuf`-parsed
+/// records or raw file bytes — keeps everything except the `@PG` line an exact,
+/// uninterpreted byte comparison: BGZF block boundaries differ between the two
+/// writers even for identical logical content (so raw file bytes never match),
+/// while parsing into `RecordBuf` and re-encoding could mask a real tag-order or
+/// binary-layout regression by normalizing it away. clip rewrites SEQ/CIGAR and
+/// the NM/UQ/MD and mate tags, so that masking risk is exactly what must be
+/// avoided.
+fn decompressed_records_without_pg(path: &Path) -> Vec<u8> {
+    let file = std::fs::File::open(path).unwrap_or_else(|e| panic!("open {}: {e}", path.display()));
+    let mut reader = noodles::bgzf::io::Reader::new(std::io::BufReader::new(file));
+    let mut raw = Vec::new();
+    std::io::Read::read_to_end(&mut reader, &mut raw)
+        .unwrap_or_else(|e| panic!("decompress BGZF stream for {}: {e}", path.display()));
+
+    assert!(
+        raw.len() >= 8 && &raw[0..4] == b"BAM\x01",
+        "{} does not decompress to a BAM binary stream (missing magic)",
+        path.display()
+    );
+    let l_text = i32::from_le_bytes(raw[4..8].try_into().expect("4 bytes"));
+    let l_text = usize::try_from(l_text).expect("l_text is non-negative");
+    let text_start = 8;
+    let text_end = text_start + l_text;
+    assert!(raw.len() >= text_end, "{} header text runs past end of stream", path.display());
+
+    let text = String::from_utf8_lossy(&raw[text_start..text_end]);
+    let stripped_text = strip_pg_lines(&text);
+
+    let mut out = Vec::with_capacity(raw.len());
+    out.extend_from_slice(b"BAM\x01");
+    let new_l_text = i32::try_from(stripped_text.len()).expect("stripped header text fits i32");
+    out.extend_from_slice(&new_l_text.to_le_bytes());
+    out.extend_from_slice(stripped_text.as_bytes());
+    out.extend_from_slice(&raw[text_end..]); // n_ref, reference list, and all records, untouched
+    out
+}
+
+/// Number of records in one copy of the varied corpus block (see
+/// [`build_varied_records`]): a fragment (1) + three pairs (2 each) + a
+/// primary-pair-plus-secondary-plus-supplementary template (4) = 11.
+const RECORDS_PER_BLOCK: usize = 11;
+
+/// How many times the varied block is repeated. Byte parity is a pure
+/// record-for-record comparison, so spanning many `GroupBam` batches is not
+/// required here (worker-count independence is covered by
+/// `test_clip_command`); a handful of copies keeps the input small and fast.
+const BLOCKS: usize = 3;
+
+/// Appends one copy of the varied corpus block to `records`, tagged with `i` so
+/// every template QNAME is unique. All reads are 8 bases (`ACGTACGT`) so the
+/// reference tag regeneration is well-defined; positions are chosen so the FR
+/// pairs overlap (`--clip-overlapping-reads` does real work).
+///
+/// Shapes covered, in order (kept query-grouped: a template's reads are adjacent):
+/// 1. a lone fragment (unpaired primary) — the fragment branch;
+/// 2. a plain overlapping FR pair, no pre-existing clipping — overlap + fixed;
+/// 3. a pair with pre-existing SOFT clipping on R1 (`2S6M`) — the upgrade path;
+/// 4. a pair with pre-existing HARD clipping on R2 (`6M2H`);
+/// 5. a primary FR pair plus a supplementary R1 and a secondary R2 —
+///    secondary/supplementary passthrough and supplementary mate-info repair.
+#[allow(clippy::too_many_lines)] // a straight-line, per-shape record builder reads best in one place
+fn push_varied_block(records: &mut Vec<RawRecord>, i: usize) {
+    // 1. Lone fragment (unpaired primary).
+    {
+        let mut b = SamBuilder::new();
+        b.read_name(format!("frag_{i:05}").as_bytes())
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(0)
+            .ref_id(0)
+            .pos(499)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]); // 8M
+        records.push(b.build());
+    }
+
+    // 2. Plain overlapping FR pair, no pre-existing clipping.
+    {
+        let mut r1 = SamBuilder::new();
+        r1.read_name(format!("pair1_{i:05}").as_bytes())
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .ref_id(0)
+            .pos(99)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .mate_ref_id(0)
+            .mate_pos(103)
+            .template_length(12);
+        records.push(r1.build());
+
+        let mut r2 = SamBuilder::new();
+        r2.read_name(format!("pair1_{i:05}").as_bytes())
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .ref_id(0)
+            .pos(103)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .mate_ref_id(0)
+            .mate_pos(99)
+            .template_length(-12);
+        records.push(r2.build());
+    }
+
+    // 3. Pair with pre-existing SOFT clipping on R1 (2S6M).
+    {
+        let mut r1 = SamBuilder::new();
+        r1.read_name(format!("pair2_{i:05}").as_bytes())
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .ref_id(0)
+            .pos(199)
+            .mapq(60)
+            .cigar_ops(&[(2 << 4) | 4, 6 << 4]) // 2S6M
+            .mate_ref_id(0)
+            .mate_pos(203)
+            .template_length(12);
+        records.push(r1.build());
+
+        let mut r2 = SamBuilder::new();
+        r2.read_name(format!("pair2_{i:05}").as_bytes())
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .ref_id(0)
+            .pos(203)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .mate_ref_id(0)
+            .mate_pos(199)
+            .template_length(-12);
+        records.push(r2.build());
+    }
+
+    // 4. Pair with pre-existing HARD clipping on R2 (6M2H). Hard-clipped bases are
+    // absent from SEQ/QUAL, so R2's sequence is only 6 bases long.
+    {
+        let mut r1 = SamBuilder::new();
+        r1.read_name(format!("pair3_{i:05}").as_bytes())
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .ref_id(0)
+            .pos(299)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .mate_ref_id(0)
+            .mate_pos(303)
+            .template_length(10);
+        records.push(r1.build());
+
+        let mut r2 = SamBuilder::new();
+        r2.read_name(format!("pair3_{i:05}").as_bytes())
+            .sequence(b"ACGTAC")
+            .qualities(&[30; 6])
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .ref_id(0)
+            .pos(303)
+            .mapq(60)
+            .cigar_ops(&[6 << 4, (2 << 4) | 5]) // 6M2H
+            .mate_ref_id(0)
+            .mate_pos(299)
+            .template_length(-10);
+        records.push(r2.build());
+    }
+
+    // 5. A primary FR pair plus a supplementary R1 and a secondary R2. clip passes
+    // secondary/supplementary reads through unclipped but repairs supplementary
+    // mate info; with --upgrade-clipping it also upgrades clipping template-wide,
+    // including on the supplementary.
+    {
+        let mut r1 = SamBuilder::new();
+        r1.read_name(format!("supp_{i:05}").as_bytes())
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::FIRST_SEGMENT | flags::MATE_REVERSE)
+            .ref_id(0)
+            .pos(599)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .mate_ref_id(0)
+            .mate_pos(603)
+            .template_length(12);
+        records.push(r1.build());
+
+        let mut r2 = SamBuilder::new();
+        r2.read_name(format!("supp_{i:05}").as_bytes())
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::REVERSE)
+            .ref_id(0)
+            .pos(603)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]) // 8M
+            .mate_ref_id(0)
+            .mate_pos(599)
+            .template_length(-12);
+        records.push(r2.build());
+
+        // Supplementary R1 (a split alignment): carries a pre-existing soft clip so
+        // --upgrade-clipping has something to upgrade on a non-primary read.
+        let mut supp_r1 = SamBuilder::new();
+        supp_r1
+            .read_name(format!("supp_{i:05}").as_bytes())
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(
+                flags::PAIRED | flags::FIRST_SEGMENT | flags::SUPPLEMENTARY | flags::MATE_REVERSE,
+            )
+            .ref_id(0)
+            .pos(2999)
+            .mapq(60)
+            .cigar_ops(&[6 << 4, (2 << 4) | 4]) // 6M2S (soft clips consume 2 query bases)
+            .mate_ref_id(0)
+            .mate_pos(603);
+        records.push(supp_r1.build());
+
+        // Secondary R2.
+        let mut sec_r2 = SamBuilder::new();
+        sec_r2
+            .read_name(format!("supp_{i:05}").as_bytes())
+            .sequence(b"ACGTACGT")
+            .qualities(&[30; 8])
+            .flags(flags::PAIRED | flags::LAST_SEGMENT | flags::SECONDARY | flags::REVERSE)
+            .ref_id(0)
+            .pos(3999)
+            .mapq(60)
+            .cigar_ops(&[8 << 4]); // 8M
+        records.push(sec_r2.build());
+    }
+}
+
+/// Builds the varied query-grouped corpus and returns the records.
+fn build_varied_records() -> Vec<RawRecord> {
+    let mut records = Vec::with_capacity(RECORDS_PER_BLOCK * BLOCKS);
+    for i in 0..BLOCKS {
+        push_varied_block(&mut records, i);
+    }
+    assert_eq!(
+        records.len(),
+        RECORDS_PER_BLOCK * BLOCKS,
+        "corpus size must match RECORDS_PER_BLOCK"
+    );
+    records
+}
+
+/// Writes the varied corpus to `dir/in.bam` (query-grouped header) and returns
+/// its path.
+fn write_varied_input(dir: &Path) -> std::path::PathBuf {
+    let input = dir.join("in.bam");
+    write_bam(&input, &create_minimal_header("chr1", 10_000), &build_varied_records());
+    input
+}
+
+/// A representative clip option set that engages every clip shape in the corpus:
+/// overlap clipping on the FR pairs, fixed 5'/3' clipping, and the template-wide
+/// `--upgrade-clipping` pre-pass (upgrading the pre-existing soft clips to hard,
+/// including on the supplementary alignment). `--clip-bases-past-mate` exercises
+/// mate-extension clipping.
+const CLIP_OPS: &[&str] = &[
+    "--clip-overlapping-reads",
+    "--clip-bases-past-mate",
+    "--upgrade-clipping",
+    "--read-one-five-prime",
+    "1",
+    "--read-two-three-prime",
+    "1",
+];
+
+/// Runs `<bin> clip -i <input> -o <output> --reference <ref> [-m <metrics>]
+/// <ops...>` (no `--threads`, so the current build takes the post-cutover chain
+/// path and the baseline takes its serial path) with `RUST_LOG=info`, and returns
+/// the process output for stderr assertions.
+fn run_clip(
+    bin: &Path,
+    input: &Path,
+    output: &Path,
+    reference: &Path,
+    metrics: Option<&Path>,
+    ops: &[&str],
+) -> std::process::Output {
+    let mut cmd = Command::new(bin);
+    cmd.env("RUST_LOG", "info").args([
+        OsStr::new("clip"),
+        OsStr::new("-i"),
+        input.as_os_str(),
+        OsStr::new("-o"),
+        output.as_os_str(),
+        OsStr::new("--reference"),
+        reference.as_os_str(),
+    ]);
+    if let Some(m) = metrics {
+        cmd.args([OsStr::new("-m"), m.as_os_str()]);
+    }
+    cmd.args(ops.iter().map(OsStr::new));
+    cmd.output().unwrap_or_else(|e| panic!("failed to spawn `{}` clip: {e}", bin.display()))
+}
+
+/// A no-`--threads` run now routes through the declarative chain, which logs the
+/// `"Using pipeline with N threads"` banner from `ChainBuilder::add_clip`. The
+/// retired serial tail logged no such line, so this is the RED (pre-removal) →
+/// GREEN (post-removal) discriminator for the cutover.
+#[test]
+fn clip_no_threads_routes_through_chain() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = write_varied_input(dir.path());
+    let reference = create_test_reference(dir.path());
+    let output = dir.path().join("out.bam");
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let out = run_clip(current_bin, &input, &output, &reference, None, CLIP_OPS);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "no-threads clip must succeed; stderr:\n{stderr}");
+    assert!(
+        stderr.contains("Using pipeline with 1 threads"),
+        "a no-`--threads` clip must route through the chain (which logs the pipeline banner); \
+         the serial path is retired. stderr:\n{stderr}"
+    );
+    // Assert a banner line unique to clip's `add_clip` banner block — `"Clip"`
+    // alone also matches "Clipping reads" (the timer) and "Clip overlapping reads",
+    // so it would not discriminate the actual banner.
+    assert!(
+        stderr.contains("Clipping mode:"),
+        "the chain must still emit the clip banner (the `Clipping mode:` line); stderr:\n{stderr}"
+    );
+}
+
+/// Output parity of the post-cutover chain against the pre-removal serial baseline
+/// binary, plus the always-available self-consistency oracle when no baseline is
+/// set.
+///
+/// `#[case]` args: a label and whether `--metrics` is written. All cases run the
+/// full [`CLIP_OPS`] set over the varied corpus, so every known-divergence shape
+/// (fragment, pre-clipped pairs, secondary/supplementary, overlapping FR pairs) is
+/// exercised in each.
+#[rstest]
+#[case::no_metrics(false)]
+#[case::with_metrics(true)]
+fn cutover_matches_baseline(#[case] with_metrics: bool) {
+    let dir = TempDir::new().expect("temp dir");
+    let input = write_varied_input(dir.path());
+    let reference = create_test_reference(dir.path());
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let current_out = dir.path().join("current.bam");
+    let current_tsv = dir.path().join("current.tsv");
+    let current_metrics = with_metrics.then(|| current_tsv.clone());
+    let current = run_clip(
+        current_bin,
+        &input,
+        &current_out,
+        &reference,
+        current_metrics.as_deref(),
+        CLIP_OPS,
+    );
+    let current_stderr = String::from_utf8_lossy(&current.stderr);
+    assert!(current.status.success(), "current clip must succeed; stderr:\n{current_stderr}");
+
+    if let Some(baseline) = baseline_bin() {
+        let baseline_out = dir.path().join("baseline.bam");
+        let baseline_tsv = dir.path().join("baseline.tsv");
+        let baseline_metrics = with_metrics.then(|| baseline_tsv.clone());
+        let base = run_clip(
+            &baseline,
+            &input,
+            &baseline_out,
+            &reference,
+            baseline_metrics.as_deref(),
+            CLIP_OPS,
+        );
+        assert!(
+            base.status.success(),
+            "baseline clip failed; stderr:\n{}",
+            String::from_utf8_lossy(&base.stderr)
+        );
+
+        assert_eq!(
+            decompressed_records_without_pg(&current_out),
+            decompressed_records_without_pg(&baseline_out),
+            "chain clip output diverges from the pre-removal serial baseline binary ({}) \
+             after stripping @PG — a real cutover parity bug, not something to relax",
+            baseline.display(),
+        );
+        if with_metrics {
+            assert_eq!(
+                std::fs::read_to_string(&current_tsv).expect("current tsv"),
+                std::fs::read_to_string(&baseline_tsv).expect("baseline tsv"),
+                "chain --metrics TSV diverges from the serial baseline binary"
+            );
+        }
+    } else {
+        eprintln!(
+            "SKIP baseline half of cutover_matches_baseline[with_metrics={with_metrics}]: \
+             FGUMI_BASELINE_BIN is unset or does not name an existing file — running \
+             self-consistency oracle instead"
+        );
+        assert_self_consistent(&current_out, current_metrics.as_deref());
+    }
+}
+
+/// Sum of soft- + hard-clipped bases in a raw input record's CIGAR.
+fn clipped_bases_raw(record: &RawRecord) -> usize {
+    record
+        .cigar_ops_typed()
+        .filter(|op| {
+            matches!(
+                op.kind(),
+                fgumi_raw_bam::CigarKind::SoftClip | fgumi_raw_bam::CigarKind::HardClip
+            )
+        })
+        .map(|op| op.len() as usize)
+        .sum()
+}
+
+/// Sum of soft- + hard-clipped bases in a parsed output record's CIGAR.
+fn clipped_bases_record_buf(record: &noodles::sam::alignment::RecordBuf) -> usize {
+    use noodles::sam::alignment::record::cigar::op::Kind;
+    record
+        .cigar()
+        .as_ref()
+        .iter()
+        .filter(|op| matches!(op.kind(), Kind::SoftClip | Kind::HardClip))
+        .map(|op| op.len())
+        .sum()
+}
+
+/// Always-available oracle used when no baseline binary is set. It must fail on a
+/// silently no-op'd / passthrough clip on its own (it is the CI-default check).
+///
+/// The corpus is *deliberately pre-clipped* (soft/hard pre-clips on some pairs), so
+/// "an output CIGAR carries a clip op" would pass even on a passthrough — that is
+/// exactly the trap this avoids. Instead it proves THIS run introduced clipping:
+/// every record survives (clip never adds/drops records), the total clipped-base
+/// footprint of the output strictly exceeds the input's (`CLIP_OPS` adds overlap +
+/// fixed 5'/3' clipping), and a record that arrived unclipped (pair1's R1) leaves
+/// clipped. With `--metrics` it further asserts the recorded counts are non-zero for
+/// the shapes exercised (overlap, fixed 5'/3', and the pre-existing `prior`) — not
+/// merely that a Fragment row exists.
+fn assert_self_consistent(output: &Path, metrics: Option<&Path>) {
+    use fgumi_lib::metrics::{ClippingMetrics, ReadType};
+
+    let input_records = build_varied_records();
+    let (_, out_records) = read_bam_output(output);
+    assert_eq!(
+        out_records.len(),
+        input_records.len(),
+        "clip must keep every record (it never adds or drops records)"
+    );
+
+    // clip preserves the query-grouped input order and never substitutes a record, so the
+    // output must carry the same ordered (QNAME, flags) sequence as the input, position for
+    // position. The count and aggregate-clipping checks alone would still pass on a regression
+    // that reordered or replaced records while leaving the totals intact; pinning the ordered
+    // identity here closes that gap before the clipping assertions (which themselves rely on
+    // records lining up by index).
+    for (i, (input, output)) in input_records.iter().zip(out_records.iter()).enumerate() {
+        let output_name: &[u8] = output.name().expect("output record must have a QNAME").as_ref();
+        assert_eq!(
+            (input.read_name(), input.flags()),
+            (output_name, output.flags().bits()),
+            "record {i}: clip must preserve the ordered (QNAME, flags) sequence \
+             (a reordered or substituted record would slip past the count/aggregate checks)"
+        );
+    }
+
+    // clip preserves input order, so records line up by index. A real run must
+    // strictly increase the total clipped-base footprint; a passthrough leaves it
+    // equal and fails here. This is the check that makes the oracle non-vacuous.
+    let input_clipped: usize = input_records.iter().map(clipped_bases_raw).sum();
+    let output_clipped: usize = out_records.iter().map(clipped_bases_record_buf).sum();
+    assert!(
+        output_clipped > input_clipped,
+        "clip must introduce new clipping: output clipped bases ({output_clipped}) must exceed \
+         input ({input_clipped}); a no-op / passthrough clip would leave them equal"
+    );
+
+    // Pinpoint the overlapping pair: pair1's R1 (index 1) arrives as a plain 8M with
+    // no clipping, so after fixed 5' + overlap clipping it must carry clip ops. This
+    // catches a regression that clipped some records but silently skipped the FR pair.
+    assert_eq!(clipped_bases_raw(&input_records[1]), 0, "precondition: pair1 R1 starts unclipped");
+    assert!(
+        clipped_bases_record_buf(&out_records[1]) > 0,
+        "pair1 R1 must be clipped by --read-one-five-prime + --clip-overlapping-reads"
+    );
+
+    if let Some(path) = metrics {
+        let rows = fgumi_lib::metrics::read_metrics::<_, ClippingMetrics>(path, "clipping")
+            .expect("parse clipping metrics");
+        let by_type = |t: ReadType| {
+            rows.iter()
+                .find(|m| m.read_type == t)
+                .unwrap_or_else(|| panic!("metrics TSV must carry a {t:?} row"))
+        };
+        assert_eq!(by_type(ReadType::Fragment).reads, BLOCKS, "one fragment read per corpus block");
+        // A real run records non-zero clipping for the shapes CLIP_OPS exercises,
+        // not an all-zero table.
+        assert!(
+            by_type(ReadType::Pair).bases_clipped_overlapping > 0,
+            "overlap clipping must be recorded for the FR pairs (rolled up into Pair)"
+        );
+        assert!(
+            by_type(ReadType::ReadOne).bases_clipped_five_prime > 0
+                || by_type(ReadType::ReadTwo).bases_clipped_five_prime > 0,
+            "--read-one-five-prime must record 5' clipping"
+        );
+        assert!(
+            by_type(ReadType::ReadOne).bases_clipped_three_prime > 0
+                || by_type(ReadType::ReadTwo).bases_clipped_three_prime > 0,
+            "--read-two-three-prime must record 3' clipping"
+        );
+        assert!(
+            by_type(ReadType::ReadOne).bases_clipped_pre > 0
+                || by_type(ReadType::ReadTwo).bases_clipped_pre > 0,
+            "pre-existing soft/hard pre-clips must be recorded as `prior` (bases_clipped_pre)"
+        );
+    }
+}

--- a/tests/integration/test_streaming_input.rs
+++ b/tests/integration/test_streaming_input.rs
@@ -696,10 +696,10 @@ fn test_filter_reads_stdin_once(#[case] threads: &str) {
     });
 }
 
-/// clip has a single-threaded fast path (no `--threads`) plus the
-/// multi-threaded path; cover both.
+/// clip always runs on the chain: a no-`--threads` run is the chain at a single
+/// worker, and `--threads N` is the multi-worker pipeline; cover both.
 #[rstest]
-#[case::single_threaded(None)]
+#[case::single_worker(None)]
 #[case::multi_threaded(Some("2"))]
 fn test_clip_reads_stdin_once(#[case] threads: Option<&str>) {
     use crate::helpers::bam_generator::{create_paired_umi_family, create_test_reference};


### PR DESCRIPTION
## What

Retire the legacy single-threaded `fgumi clip` path so the declarative chain builder is the **only** execution path. `execute()` keeps its pre-flight validation and then always dispatches to the chain; `execute_single_threaded` and its now-dead imports are deleted.

Stacked on #915 (which put clip `--metrics` on the chain), so the metrics precondition is already satisfied. Output is byte-identical (modulo `@PG`).

## Parity analysis (done before deleting)

Every diagnostic the serial path emitted is already produced by the chain (`ChainBuilder::add_clip` + `ClipFinalizeHook`/`ClipMetricsFinalizeHook`): output records, the `--metrics` TSV, the `Clip` banner + Input/Output/mode lines, the `OperationTimer`, the `require_query_grouped` guard, the summary counters, and the CRC-verify line. Nothing needed adding.

## Tests

- `tests/integration/test_clip_cutover_parity.rs` — pins chain output == the pre-removal serial baseline via `FGUMI_BASELINE_BIN` (records byte-identical modulo `@PG`, plus the `--metrics` TSV) across fragment, overlapping FR pair, pre-existing soft-clip R1, pre-existing hard-clip R2, and secondary+supplementary. When `FGUMI_BASELINE_BIN` is unset (default CI), the self-consistency oracle proves **this run actually clipped** — it asserts the output's total clipped-base footprint strictly exceeds the input's (a passthrough leaves them equal → fails) and pins that a plain 8M R1 is left clipped by `--read-one-five-prime` + `--clip-overlapping-reads`; the `--metrics` fallback asserts non-zero counts for the exercised shapes.
- Existing determinism tests retained as worker-count-invariance checks.

Full gate green (`cargo ci-test` 9961 passed / 31 skipped with `FGUMI_BASELINE_BIN` set proving byte-parity, plus fmt/lint/doc and `--no-default-features`/`--all-features`). Part of the per-command R6-0 legacy-path retirements; no user-facing behavior change (no-`--threads` now runs the chain at a single worker).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: output changes because `clip` now always uses the declarative chain; parity tests and worker-count checks pin records and metrics; `unsafe` changes: none; `CLAUDE.md` allowlist update: none; memory bounds and queue capacity: none; no-`--threads` runs with one chain worker.

- Removed the legacy serial `clip` implementation.
- Preserved pre-flight validation and query-grouped input checks.
- Added parity coverage for records and metrics across clipping scenarios.
- Added chain-routing and worker-count coverage.
- Reported test gate: 9,961 passed and 31 skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->