### PR TITLE
refactor(correct): retire the legacy single-threaded path; the chain is the only path

### DIFF
--- a/src/lib/commands/correct.rs
+++ b/src/lib/commands/correct.rs
@@ -5,11 +5,13 @@
 //! observed UMIs to match the expected set based on mismatch tolerance and minimum
 //! distance requirements.
 //!
-//! When `--rejects` is set, the threaded pipeline routes rejected records through
-//! the unified pipeline's first-class secondary output (see
-//! [`crate::unified_pipeline::run_bam_pipeline_from_reader_with_secondary`]).
-//! Rejects land in batch-input order rather than mutex-acquisition order, and the
-//! rejects BAM inherits the input header. The pattern matches `commands::filter`.
+//! Execution always runs on the declarative chain builder (via
+//! `ChainBuilder::add_correct`); `--threads` only sets the worker count, and
+//! absent it the chain runs at a single worker.
+//! When `--rejects` is set, the chain routes rejected records through its
+//! first-class secondary output branch so rejects land in batch-input order and
+//! the rejects BAM inherits the input header. The pattern matches
+//! `commands::filter`.
 //!
 //! By default (`--target umi`) the tool reads and writes the `RX` UMI tag and
 //! stores the pre-correction value in `OX`. With `--target barcode` it instead
@@ -59,41 +61,22 @@
 
 use crate::bitenc::BitEnc;
 use crate::dna::reverse_complement_str;
-use crate::grouper::TemplateGrouper;
-use crate::logging::OperationTimer;
 use crate::metrics::correct::UmiCorrectionMetrics;
-use crate::per_thread_accumulator::PerThreadAccumulator;
 use crate::sam::SamTag;
-use crate::template::TemplateBatch;
-use crate::unified_pipeline::{
-    Grouper, MemoryEstimate, run_bam_pipeline_from_reader,
-    run_bam_pipeline_from_reader_with_secondary,
-};
 use ahash::AHashMap;
 use anyhow::{Result, bail};
 use clap::Parser;
-use fgumi_bam_io::ProgressTracker;
-use fgumi_bam_io::{
-    BamWriter, PipelineReaderOpts, create_bam_reader_for_pipeline_with_opts, create_bam_writer,
-    create_optional_bam_writer, create_raw_bam_reader_from_stream_with_opts,
-};
 use fgumi_raw_bam;
 use fgumi_raw_bam::RawRecord;
-use log::{error, info, warn};
+use log::{info, warn};
 use lru::LruCache;
-use noodles::sam::Header;
-use noodles::sam::alignment::record::data::field::Tag;
-use std::io;
-use std::num::NonZero;
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::commands::command::Command;
 use crate::commands::common::{
     BamIoOptions, CompressionOptions, QueueMemoryOptions, RejectsOptions, SchedulerOptions,
-    ThreadingOptions, build_pipeline_config, reject_output_collisions, serialize_raw_bam_records,
+    ThreadingOptions, reject_output_collisions,
 };
 
 /// Which SAM tag `correct` operates on.
@@ -580,39 +563,6 @@ pub(crate) struct TemplateCorrection {
     pub(crate) rejection_reason: RejectionReason,
 }
 
-// ============================================================================
-// 7-Step Pipeline Types
-// ============================================================================
-
-/// Result from processing a batch of templates through UMI correction.
-struct CorrectProcessedBatch {
-    /// Raw-byte kept records.
-    kept_raw_records: Vec<RawRecord>,
-    /// Raw-byte rejected records, in batch-input order. Empty unless the
-    /// pipeline was configured with a `--rejects` output.
-    rejected_records: Vec<Vec<u8>>,
-    /// Number of templates processed.
-    templates_count: u64,
-    /// Number of missing UMI records.
-    missing_umis: u64,
-    /// Number of wrong length UMI records.
-    wrong_length: u64,
-    /// Number of mismatched UMI records.
-    mismatched: u64,
-    /// Per-UMI match counts for metrics.
-    umi_matches: AHashMap<String, UmiCorrectionMetrics>,
-}
-
-impl MemoryEstimate for CorrectProcessedBatch {
-    fn estimate_heap_size(&self) -> usize {
-        let raw_size: usize = self.kept_raw_records.iter().map(RawRecord::capacity).sum();
-        let raw_vec_overhead = self.kept_raw_records.capacity() * std::mem::size_of::<RawRecord>();
-        let rej_size: usize = self.rejected_records.iter().map(Vec::capacity).sum();
-        let rej_vec_overhead = self.rejected_records.capacity() * std::mem::size_of::<Vec<u8>>();
-        raw_size + raw_vec_overhead + rej_size + rej_vec_overhead
-    }
-}
-
 /// Metrics collected from UMI correction processing, aggregated post-pipeline.
 #[derive(Default)]
 pub(crate) struct CollectedCorrectMetrics {
@@ -716,52 +666,15 @@ impl Command for CorrectUmis {
         }
         reject_output_collisions(&outputs)?;
 
-        // --threads N: run the correct stage on the declarative chain builder. Dispatch
-        // here — after the reader-free pre-flight above, but BEFORE the timer / UMI-set
-        // load / distance check / reader below. execute_chain → add_correct re-emits the
-        // timer, banner, UMI-set load, distance check, and threading logs and opens its
-        // own source, so running them here too would double-log and pre-consume stdin.
-        // The no-`--threads` single-threaded path below stays the in-process parity oracle.
-        if self.threading.threads.is_some() {
-            return self.execute_chain(command_line);
-        }
-
-        // ---- legacy no-threads oracle path (everything below stays as-is) ----
-        let timer = OperationTimer::new("Correcting UMIs");
-
-        // Load UMI sequences
-        let (umi_sequences, umi_length) = self.load_umi_sequences()?;
-        // Create encoded UMI set for fast comparison
-        let encoded_umi_set = EncodedUmiSet::new(&umi_sequences);
-
-        // Warn about UMIs that are too close together
-        self.check_umi_distances(&umi_sequences);
-
-        self.io.log_effective_check_crc();
-
-        // Open input using streaming-capable reader for pipeline use
-        let reader_opts = self.io.pipeline_reader_opts();
-        let (reader, header) =
-            create_bam_reader_for_pipeline_with_opts(&self.io.input, reader_opts)?;
-
-        // Synthesize @HD VN:1.6 SO:unsorted when the input lacks one (match fgbio,
-        // which never passes a header-less BAM straight through).
-        let header = crate::commands::common::ensure_hd_record(header)?;
-
-        // Add @PG record with PP chaining to input's last program
-        let header = crate::commands::common::add_pg_record(header, command_line)?;
-
-        let total_records = self.execute_single_thread_mode(
-            reader,
-            reader_opts.verify_crc,
-            header,
-            encoded_umi_set,
-            umi_length,
-            self.rejects_opts.rejects.is_some(),
-        )?;
-
-        timer.log_completion(total_records);
-        Ok(())
+        // The declarative chain builder is the only execution path. `execute`
+        // does the reader-free pre-flight above and then always dispatches:
+        // `execute_chain` → `add_correct` opens its own source and emits the
+        // timer, `Starting correct` banner, UMI-set load, distance check,
+        // threading logs, summary/warn banners, the `--metrics` TSV, and the
+        // `--min-corrected` gate. Running any of those here first would
+        // double-log and pre-consume stdin. Absent `--threads`, the chain runs
+        // at a single worker.
+        self.execute_chain(command_line)
     }
 }
 
@@ -789,32 +702,6 @@ impl CorrectUmis {
             bail!("--min-corrected must be between 0 and 1.");
         }
         Ok(())
-    }
-
-    /// Loads UMI sequences from command line and files.
-    ///
-    /// Combines UMIs from both `umis` and `umi_files`, converts them to uppercase,
-    /// and validates that all UMIs are the same length.
-    ///
-    /// # Returns
-    ///
-    /// A tuple of `(umi_sequences, umi_length)`.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - No UMIs are provided
-    /// - UMI files cannot be read
-    /// - UMIs have different lengths
-    pub(crate) fn load_umi_sequences(&self) -> Result<(Vec<String>, usize)> {
-        self.to_correct_options().load_umi_sequences()
-    }
-
-    /// Checks distances between UMI pairs and warns about ambiguities.
-    ///
-    /// Delegates to [`CorrectOptions::check_umi_distances`].
-    pub(crate) fn check_umi_distances(&self, umi_sequences: &[String]) {
-        self.to_correct_options().check_umi_distances(umi_sequences);
     }
 
     /// Compute UMI correction for a template (called once per template).
@@ -1059,23 +946,15 @@ impl CorrectUmis {
         }
     }
 
-    pub(crate) fn finalize_metrics(
-        &self,
-        umi_metrics: &mut AHashMap<String, UmiCorrectionMetrics>,
-        unmatched_umi: &str,
-    ) -> Result<()> {
-        self.to_correct_options().finalize_metrics(umi_metrics, unmatched_umi)
-    }
-
-    /// Runs the `--threads N` path via the declarative chain builder
+    /// Runs the correct stage via the declarative chain builder
     /// (`ChainSpec::single_stage(Stage::Correct, ...)` → `build_for(spec)?.run()`).
     ///
     /// `add_correct` opens its own source, re-emits the timer/banner/threading
     /// log lines, reloads the UMI set, and re-runs the distance check, so none
     /// of those may run again here — only the CRC-verify status line, which
-    /// `add_correct` does not re-emit. The no-`--threads` path in `execute`
-    /// keeps its own single-threaded engine, which is the in-process parity
-    /// oracle for this one (see `test_correct_chain_matches_single_threaded`).
+    /// `add_correct` does not re-emit. The chain is the only execution path:
+    /// `execute` always dispatches here, with or without `--threads` (absent
+    /// `--threads` runs the chain at a single worker).
     fn execute_chain(&self, command_line: &str) -> Result<()> {
         use crate::pipeline::chains::{
             ChainSpec, SingleStageContext, Stage, StageOptionsBag, build_for,
@@ -1095,564 +974,6 @@ impl CorrectUmis {
         };
         let spec = ChainSpec::single_stage(Stage::Correct, stage_opts, &ctx);
         build_for(spec)?.run()
-    }
-
-    /// Execute using the 7-step unified pipeline.
-    ///
-    /// This method uses the template-based grouper to process records in batches,
-    /// with parallel decompression, processing, and compression.
-    ///
-    /// Retained as the parity oracle's twin until the follow-up PR removes the
-    /// legacy engine (mirrors sort PR A→B). `execute()` no longer calls this —
-    /// the `--threads` path now dispatches to `execute_chain` before the reader
-    /// opens — so it has no call site and would otherwise trip `cargo ci-lint`
-    /// as dead code.
-    #[allow(clippy::too_many_lines)]
-    #[allow(dead_code)]
-    fn execute_threads_mode(
-        &self,
-        num_threads: usize,
-        reader: Box<dyn std::io::Read + Send>,
-        header: Header,
-        encoded_umi_set: Arc<EncodedUmiSet>,
-        umi_length: usize,
-        track_rejects: bool,
-    ) -> Result<u64> {
-        // Configure pipeline - correct is ReaderHeavy (70% in decompression)
-        let mut pipeline_config = build_pipeline_config(
-            &self.scheduler_opts,
-            &self.compression,
-            &self.queue_memory,
-            &self.io,
-            num_threads,
-        )?;
-
-        // Enable raw-byte mode (correct uses TemplateGrouper, no cell tag needed)
-        {
-            use crate::read_info::LibraryIndex;
-            use crate::unified_pipeline::GroupKeyConfig;
-
-            let library_index = LibraryIndex::from_header(&header);
-            pipeline_config.group_key_config = Some(GroupKeyConfig::new_raw_no_cell(library_index));
-        }
-
-        // Per-thread metrics accumulator: bounded memory, no unbounded queue.
-        let collected_metrics = PerThreadAccumulator::<CollectedCorrectMetrics>::new(num_threads);
-        let collected_for_serialize = Arc::clone(&collected_metrics);
-
-        // Rejects (`--rejects`) flow through the unified pipeline's first-class
-        // secondary output (see `run_bam_pipeline_from_reader_with_secondary` in
-        // `unified_pipeline/bam.rs`). `process_fn` collects rejected raw bytes
-        // into `CorrectProcessedBatch::rejected_records`; the pipeline's
-        // `secondary_serialize_fn` writes them in batch-input order. This
-        // matches the pattern used by `commands/filter.rs`.
-
-        // Configuration for closures
-        const BATCH_SIZE: usize = 1000; // Templates per batch
-        let max_mismatches = self.max_mismatches;
-        let min_distance_diff = self.min_distance_diff;
-        let umi_tag = Tag::from(self.target.sequence_tag());
-        let original_tag_sam = self.target.original_tag();
-        let revcomp = self.revcomp;
-        let cache_size = self.cache_size;
-        let dont_store_original_umis = self.dont_store_original_umis;
-
-        // Progress tracking
-        let progress_counter = Arc::new(AtomicU64::new(0));
-        let progress_for_process = Arc::clone(&progress_counter);
-
-        // Unmatched UMI string for rejected reads (matches fgbio behavior)
-        let unmatched_umi = "N".repeat(umi_length);
-        let unmatched_umi_for_process = unmatched_umi.clone();
-
-        // Clone the UMI set for post-aggregation use (before closure moves original)
-        let encoded_umi_set_for_metrics = Arc::clone(&encoded_umi_set);
-
-        // Grouper: batch templates by QNAME
-        let grouper_fn = move |_header: &Header| {
-            Box::new(TemplateGrouper::new(BATCH_SIZE))
-                as Box<dyn Grouper<Group = TemplateBatch> + Send>
-        };
-
-        // Process function: correct UMIs in each template batch
-        let process_fn = move |batch: TemplateBatch| -> io::Result<CorrectProcessedBatch> {
-            // Per-thread LRU cache for UMI matching
-            thread_local! {
-                static CACHE: std::cell::RefCell<Option<LruCache<Vec<u8>, UmiMatch>>> = const { std::cell::RefCell::new(None) };
-            }
-
-            CACHE.with(|cache_cell| {
-                let mut cache_ref = cache_cell.borrow_mut();
-                if cache_ref.is_none() && cache_size > 0 {
-                    *cache_ref = Some(LruCache::new(
-                        NonZero::new(cache_size).expect("cache_size > 0 checked above"),
-                    ));
-                }
-
-                let mut kept_raw_records: Vec<RawRecord> = Vec::new();
-                // Rejected records are collected per-batch and drained by the
-                // unified pipeline's secondary serializer; empty unless
-                // `track_rejects` is true.
-                let mut rejected_records: Vec<Vec<u8>> = Vec::new();
-                let mut missing_umis = 0u64;
-                let mut wrong_length = 0u64;
-                let mut mismatched = 0u64;
-                let mut umi_matches_map: AHashMap<String, UmiCorrectionMetrics> =
-                    AHashMap::with_hasher(crate::hashing::deterministic_state());
-                let templates_count = batch.len() as u64;
-                // Count ALL input records for progress tracking (not just kept/rejected)
-                let mut total_input_records = 0u64;
-                let umi_tag_bytes: [u8; 2] = [umi_tag.as_ref()[0], umi_tag.as_ref()[1]];
-                let original_tag_bytes: [u8; 2] =
-                    [original_tag_sam.as_ref()[0], original_tag_sam.as_ref()[1]];
-
-                for template in batch {
-                    // Count input records BEFORE processing
-                    total_input_records += template.read_count() as u64;
-
-                    {
-                        let raw_records: Vec<RawRecord> = template.into_records();
-                        let umi_opt = Self::extract_and_validate_template_umi_raw(
-                            &raw_records,
-                            umi_tag_bytes,
-                        )
-                        .map_err(io::Error::other)?;
-
-                        match umi_opt {
-                            None => {
-                                // fgbio counts a missing-UMI read only in
-                                // `missingUmisRecords` and never credits the all-`N`
-                                // metric bucket (CorrectUmis.scala:199-202).
-                                let num_records = raw_records.len() as u64;
-                                missing_umis += num_records;
-                                if track_rejects {
-                                    // Move out of `raw_records` (consumed here) to
-                                    // avoid a per-record clone+memcpy on the rejects
-                                    // hot path.
-                                    for raw in raw_records {
-                                        rejected_records.push(raw.into_inner());
-                                    }
-                                }
-                            }
-                            Some(umi) => {
-                                let correction = Self::compute_template_correction(
-                                    &umi,
-                                    umi_length,
-                                    revcomp,
-                                    max_mismatches,
-                                    min_distance_diff,
-                                    &encoded_umi_set,
-                                    &mut cache_ref,
-                                );
-                                let num_records = raw_records.len() as u64;
-
-                                // Credit per-segment metrics for every correct-length
-                                // template before the keep/reject decision, matching
-                                // fgbio (CorrectUmis.scala:218-232): a mismatched
-                                // template still credits its matched segments and the
-                                // all-`N` bucket for its unmatched segments.
-                                Self::credit_umi_metrics(
-                                    &correction.matches,
-                                    num_records,
-                                    &unmatched_umi_for_process,
-                                    &mut umi_matches_map,
-                                );
-
-                                if correction.matched {
-                                    for mut raw in raw_records {
-                                        Self::apply_correction_to_raw(
-                                            &mut raw,
-                                            &correction,
-                                            umi_tag_bytes,
-                                            original_tag_bytes,
-                                            dont_store_original_umis,
-                                        );
-                                        kept_raw_records.push(raw);
-                                    }
-                                } else {
-                                    match correction.rejection_reason {
-                                        RejectionReason::WrongLength => {
-                                            wrong_length += num_records;
-                                        }
-                                        RejectionReason::Mismatched => {
-                                            mismatched += num_records;
-                                        }
-                                        RejectionReason::None => {}
-                                    }
-                                    if track_rejects {
-                                        // Move out of `raw_records` (consumed
-                                        // here) to avoid a per-record clone.
-                                        for raw in raw_records {
-                                            rejected_records.push(raw.into_inner());
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // Progress logging (count ALL input records, not just output)
-                let count = progress_for_process.fetch_add(total_input_records, Ordering::Relaxed);
-                if (count + total_input_records) / 1_000_000 > count / 1_000_000 {
-                    info!("Processed {} records", count + total_input_records);
-                }
-
-                Ok(CorrectProcessedBatch {
-                    kept_raw_records,
-                    rejected_records,
-                    templates_count,
-                    missing_umis,
-                    wrong_length,
-                    mismatched,
-                    umi_matches: umi_matches_map,
-                })
-            })
-        };
-
-        // Serialize function: convert kept records to bytes and collect metrics.
-        // Rejects are drained by `secondary_serialize_fn` separately.
-        let serialize_fn = move |mut processed: CorrectProcessedBatch,
-                                 _header: &Header,
-                                 output: &mut Vec<u8>|
-              -> io::Result<u64> {
-            let umi_matches = std::mem::take(&mut processed.umi_matches);
-            collected_for_serialize.with_slot(|m| {
-                m.templates_processed += processed.templates_count;
-                m.missing_umis += processed.missing_umis;
-                m.wrong_length += processed.wrong_length;
-                m.mismatched += processed.mismatched;
-                for (umi, counts) in umi_matches {
-                    merge_umi_counts(&mut m.umi_matches, umi, &counts);
-                }
-            });
-
-            // Return KEPT record count (not input count, to avoid double-counting).
-            serialize_raw_bam_records(&processed.kept_raw_records, output)
-        };
-
-        // Secondary serialize: drains the per-batch rejected_records into the
-        // pipeline's secondary output buffer. The pipeline reorders by batch
-        // serial, so rejects land in input order and the secondary writer is
-        // finalized automatically inside the pipeline.
-        let secondary_serialize_fn =
-            |batch: &CorrectProcessedBatch, buf: &mut Vec<u8>| -> io::Result<u64> {
-                serialize_raw_bam_records(&batch.rejected_records, buf)
-            };
-
-        // Run the 7-step pipeline with the already-opened reader (supports streaming).
-        // When `--rejects` is set, route rejects through the unified pipeline's
-        // first-class secondary output so they land in input/batch-serial order.
-        let records_written = if let Some(rejects_path) = self.rejects_opts.rejects.as_ref() {
-            run_bam_pipeline_from_reader_with_secondary(
-                pipeline_config,
-                reader,
-                header,
-                &self.io.output,
-                None, // primary uses input header
-                rejects_path,
-                None, // secondary uses resolved primary header (== input header for correct)
-                grouper_fn,
-                process_fn,
-                serialize_fn,
-                secondary_serialize_fn,
-            )?
-        } else {
-            run_bam_pipeline_from_reader(
-                pipeline_config,
-                reader,
-                header,
-                &self.io.output,
-                None, // Use input header for output
-                grouper_fn,
-                process_fn,
-                serialize_fn,
-            )?
-        };
-
-        // ========== Post-pipeline: Aggregate metrics ==========
-        let mut total_templates = 0u64;
-        let mut total_missing = 0u64;
-        let mut total_wrong_length = 0u64;
-        let mut total_mismatched = 0u64;
-        let mut merged_umi_matches: AHashMap<String, UmiCorrectionMetrics> = AHashMap::new();
-
-        for slot in collected_metrics.slots() {
-            let mut m = slot.lock();
-            total_templates += m.templates_processed;
-            total_missing += m.missing_umis;
-            total_wrong_length += m.wrong_length;
-            total_mismatched += m.mismatched;
-
-            for (umi, counts) in m.umi_matches.drain() {
-                merge_umi_counts(&mut merged_umi_matches, umi, &counts);
-            }
-        }
-
-        // Ensure ALL UMI rows are present (even with zero counts) - matches fgbio behavior
-        for umi in encoded_umi_set_for_metrics.strings.iter().chain(std::iter::once(&unmatched_umi))
-        {
-            merged_umi_matches
-                .entry(umi.clone())
-                .or_insert_with(|| UmiCorrectionMetrics::new(umi.clone()));
-        }
-
-        // Finalize and write metrics if requested
-        self.finalize_metrics(&mut merged_umi_matches, &unmatched_umi)?;
-
-        // Log summary (records_written = kept records only)
-        let rejected = total_missing + total_wrong_length + total_mismatched;
-        let total_records = records_written + rejected;
-        info!("Read {total_records}; kept {records_written} and rejected {rejected}");
-        info!("Total templates processed: {total_templates}");
-
-        if total_missing > 0 || total_wrong_length > 0 {
-            // fgbio logs this summary at error level (CorrectUmis.scala:275-280).
-            error!("###################################################################");
-            if total_missing > 0 {
-                error!("# {total_missing} were missing UMI attributes in the BAM file!");
-            }
-            if total_wrong_length > 0 {
-                error!(
-                    "# {total_wrong_length} had unexpected UMIs of differing lengths in the BAM file!"
-                );
-            }
-            error!("###################################################################");
-        }
-
-        // Check minimum correction ratio
-        if let Some(min) = self.min_corrected {
-            check_min_corrected(records_written, total_records, min)?;
-        }
-
-        Ok(total_records)
-    }
-
-    /// Execute using single-threaded mode with template-level UMI correction.
-    ///
-    /// This method runs entirely on the main thread with no pipeline overhead.
-    /// It reads raw BAM records and groups them by QNAME, applying UMI correction
-    /// once per template, then applies the correction to all records in the template.
-    #[allow(clippy::too_many_lines)]
-    fn execute_single_thread_mode(
-        &self,
-        reader: Box<dyn std::io::Read + Send>,
-        verify_crc: bool,
-        header: Header,
-        encoded_umi_set: EncodedUmiSet,
-        umi_length: usize,
-        track_rejects: bool,
-    ) -> Result<u64> {
-        info!("Using single-threaded mode with template-level UMI correction");
-
-        // Reuse the already-opened reader (required for stdin: re-opening a pipe
-        // double-consumes it). Decode through fgumi-bgzf so `--no-check-crc`
-        // takes effect on this fast path too (#800); the re-parsed header is
-        // discarded because `header` already carries the synthesized @HD/@PG.
-        let reader_opts = PipelineReaderOpts { verify_crc, ..PipelineReaderOpts::default() };
-        let (mut bam_reader, _skipped_header) =
-            create_raw_bam_reader_from_stream_with_opts(reader, reader_opts)?;
-
-        // Open output writer (single-threaded)
-        let mut writer =
-            create_bam_writer(&self.io.output, &header, 1, self.compression.compression_level)?;
-        let mut reject_writer = create_optional_bam_writer(
-            self.rejects_opts.rejects.as_ref(),
-            &header,
-            1,
-            self.compression.compression_level,
-        )?;
-
-        // LRU cache (single thread, no thread_local needed)
-        let mut cache: Option<LruCache<Vec<u8>, UmiMatch>> = if self.cache_size > 0 {
-            Some(LruCache::new(
-                NonZero::new(self.cache_size).expect("cache_size > 0 checked above"),
-            ))
-        } else {
-            None
-        };
-
-        // Initialize metrics
-        let unmatched_umi = "N".repeat(umi_length);
-        let umi_sequences = encoded_umi_set.strings.clone();
-        let mut umi_metrics: AHashMap<String, UmiCorrectionMetrics> = umi_sequences
-            .iter()
-            .chain(std::iter::once(&unmatched_umi))
-            .map(|umi| (umi.clone(), UmiCorrectionMetrics::new(umi.clone())))
-            .collect();
-
-        // Counters
-        let mut total_records = 0u64;
-        let mut total_templates = 0u64;
-        let mut missing_umis = 0u64;
-        let mut wrong_length = 0u64;
-        let mut mismatched = 0u64;
-        let progress = ProgressTracker::new("Processed records").with_interval(1_000_000);
-
-        let umi_tag_bytes: [u8; 2] = self.target.sequence_tag().into();
-        let original_tag_bytes: [u8; 2] = self.target.original_tag().into();
-        let max_mismatches = self.max_mismatches;
-        let min_distance_diff = self.min_distance_diff;
-        let revcomp = self.revcomp;
-        let dont_store_original_umis = self.dont_store_original_umis;
-
-        // Helper to write a raw BAM record to a noodles BamWriter
-        #[allow(clippy::cast_possible_truncation)]
-        fn write_raw(writer: &mut BamWriter, raw: &[u8]) -> Result<()> {
-            use std::io::Write;
-            let block_size = raw.len() as u32;
-            writer.get_mut().write_all(&block_size.to_le_bytes())?;
-            writer.get_mut().write_all(raw)?;
-            Ok(())
-        }
-
-        // Read raw records and group by QNAME
-        let mut record = RawRecord::new();
-        let mut current_template: Vec<RawRecord> = Vec::new();
-        let mut current_name: Option<Vec<u8>> = None;
-
-        loop {
-            let bytes_read = bam_reader.read_record(&mut record)?;
-            let eof = bytes_read == 0;
-
-            // Determine if we need to flush the current template
-            let flush = if eof {
-                !current_template.is_empty()
-            } else {
-                let name = fgumi_raw_bam::read_name(record.as_ref());
-                current_name.as_deref().is_some_and(|cn| cn != name)
-            };
-
-            if flush {
-                let mut raw_records = std::mem::take(&mut current_template);
-
-                #[allow(clippy::cast_possible_truncation)]
-                let num_records = raw_records.len() as u64;
-                total_records += num_records;
-                total_templates += 1;
-
-                // Template-level UMI correction
-                let umi_opt = CorrectUmis::extract_and_validate_template_umi_raw(
-                    &raw_records,
-                    umi_tag_bytes,
-                )?;
-
-                match umi_opt {
-                    None => {
-                        // fgbio counts a missing-UMI read only in
-                        // `missingUmisRecords` and never credits the all-`N`
-                        // metric bucket (CorrectUmis.scala:199-202).
-                        missing_umis += num_records;
-
-                        if track_rejects && let Some(rw) = reject_writer.as_mut() {
-                            for raw in raw_records.drain(..) {
-                                write_raw(rw, &raw)?;
-                            }
-                        }
-                    }
-                    Some(umi) => {
-                        // Correct UMI once for the template
-                        let correction = CorrectUmis::compute_template_correction(
-                            &umi,
-                            umi_length,
-                            revcomp,
-                            max_mismatches,
-                            min_distance_diff,
-                            &encoded_umi_set,
-                            &mut cache,
-                        );
-
-                        // Credit per-segment metrics for every correct-length
-                        // template before the keep/reject decision, matching fgbio
-                        // (CorrectUmis.scala:218-232): a mismatched template still
-                        // credits its matched segments and the all-`N` bucket for its
-                        // unmatched segments.
-                        CorrectUmis::credit_umi_metrics(
-                            &correction.matches,
-                            num_records,
-                            &unmatched_umi,
-                            &mut umi_metrics,
-                        );
-
-                        if correction.matched {
-                            // Apply correction to all records in template and write
-                            for mut raw in raw_records.drain(..) {
-                                CorrectUmis::apply_correction_to_raw(
-                                    &mut raw,
-                                    &correction,
-                                    umi_tag_bytes,
-                                    original_tag_bytes,
-                                    dont_store_original_umis,
-                                );
-                                write_raw(&mut writer, &raw)?;
-                            }
-                        } else {
-                            // Rejection - update counters based on reason
-                            match correction.rejection_reason {
-                                RejectionReason::WrongLength => wrong_length += num_records,
-                                RejectionReason::Mismatched => mismatched += num_records,
-                                RejectionReason::None => {}
-                            }
-
-                            if track_rejects && let Some(rw) = reject_writer.as_mut() {
-                                for raw in raw_records.drain(..) {
-                                    write_raw(rw, &raw)?;
-                                }
-                            }
-                        }
-                    }
-                }
-
-                progress.log_if_needed(num_records);
-            }
-
-            if eof {
-                break;
-            }
-
-            // Accumulate current record — move the reader's buffer instead of copying.
-            current_name = Some(fgumi_raw_bam::read_name(record.as_ref()).to_vec());
-            let taken = std::mem::take(&mut record);
-            current_template.push(taken);
-        }
-
-        progress.log_final();
-
-        // Finish writers
-        writer.into_inner().finish()?;
-        if let Some(rw) = reject_writer {
-            rw.into_inner().finish()?;
-        }
-
-        // Finalize and write metrics
-        self.finalize_metrics(&mut umi_metrics, &unmatched_umi)?;
-
-        // Log summary
-        let rejected = missing_umis + wrong_length + mismatched;
-        let kept = total_records - rejected;
-        info!("Read {total_records}; kept {kept} and rejected {rejected}");
-        info!("Total templates processed: {total_templates}");
-
-        if missing_umis > 0 || wrong_length > 0 {
-            // fgbio logs this summary at error level (CorrectUmis.scala:275-280).
-            error!("###################################################################");
-            if missing_umis > 0 {
-                error!("# {missing_umis} were missing UMI attributes in the BAM file!");
-            }
-            if wrong_length > 0 {
-                error!(
-                    "# {wrong_length} had unexpected UMIs of differing lengths in the BAM file!"
-                );
-            }
-            error!("###################################################################");
-        }
-
-        // Check minimum correction ratio
-        if let Some(min) = self.min_corrected {
-            check_min_corrected(kept, total_records, min)?;
-        }
-
-        Ok(total_records)
     }
 }
 
@@ -2053,6 +1374,7 @@ mod tests {
 
     use noodles::sam;
     use noodles::sam::alignment::io::Write as SamWrite;
+    use noodles::sam::alignment::record::data::field::Tag;
     use noodles::sam::alignment::record_buf::RecordBuf;
     use rstest::rstest;
     use std::{io::Write as IoWrite, path::Path};
@@ -3269,63 +2591,6 @@ mod tests {
         Ok(())
     }
 
-    /// Sibling regression test covering the second legacy site,
-    /// `execute_threads_mode`. This method has no live call site any more
-    /// (`execute()` routes `--threads` to `execute_chain` and no-`--threads` to
-    /// `execute_single_thread_mode`; see its `#[allow(dead_code)]` doc comment),
-    /// but it still carried the same NaN-bypass bug and is retained pending a
-    /// follow-up removal, so it is exercised directly here rather than through
-    /// `CorrectUmis::execute`.
-    #[test]
-    fn test_min_corrected_errors_on_empty_input_threads_mode() -> Result<()> {
-        let input = create_test_bam(vec![])?;
-        let paths = TestPaths::new()?;
-
-        let corrector = CorrectUmis {
-            io: BamIoOptions {
-                input: input.path().to_path_buf(),
-                output: paths.output.clone(),
-                async_reader: false,
-                check_crc: false,
-                no_check_crc: false,
-            },
-            rejects_opts: RejectsOptions::default(),
-            metrics: None,
-            target: Target::Umi,
-            max_mismatches: 1,
-            min_distance_diff: 2,
-            umis: vec!["AAAAAA".to_string()],
-            umi_files: vec![],
-            dont_store_original_umis: false,
-            cache_size: 100_000,
-            min_corrected: Some(0.5),
-            revcomp: false,
-            threading: ThreadingOptions::none(),
-            compression: CompressionOptions { compression_level: 1 },
-            scheduler_opts: SchedulerOptions::default(),
-            queue_memory: QueueMemoryOptions::default(),
-        };
-
-        let (umi_sequences, umi_length) = corrector.load_umi_sequences()?;
-        let encoded_umi_set = Arc::new(EncodedUmiSet::new(&umi_sequences));
-
-        let reader_opts = corrector.io.pipeline_reader_opts();
-        let (reader, header) =
-            create_bam_reader_for_pipeline_with_opts(&corrector.io.input, reader_opts)?;
-        let header = crate::commands::common::ensure_hd_record(header)?;
-
-        let result =
-            corrector.execute_threads_mode(1, reader, header, encoded_umi_set, umi_length, false);
-
-        let err = result.expect_err("--min-corrected must error on empty input, not silently pass");
-        assert!(
-            err.to_string().contains("No reads were processed"),
-            "error should explain empty input (chain-path parity), got: {err}"
-        );
-
-        Ok(())
-    }
-
     /// End-to-end regression test for the LIVE `--threads N` (chain) path:
     /// empty input under a positive `--min-corrected` must error, exactly
     /// like the legacy no-`--threads` path covered above. The chain path
@@ -3972,9 +3237,9 @@ mod tests {
     #[test]
     fn test_metrics_unmatched_row_with_multithreaded() -> Result<()> {
         // Test that unmatched UMI row is correct with multi-threaded processing.
-        // On a chain build (`--threads`), `execute()` now routes through
-        // `execute_chain` -> the declarative chain builder, so this exercises the
-        // chain path's metrics accounting (not the legacy `execute_threads_mode`).
+        // `execute()` always routes through `execute_chain` -> the declarative
+        // chain builder, so this exercises the chain path's metrics accounting at
+        // a multi-worker (`--threads`) configuration.
         let mut records: Vec<(&str, Option<&str>)> = Vec::new();
 
         // Create a mix of correctable and uncorrectable reads
@@ -4383,14 +3648,15 @@ mod tests {
         assert_eq!(umi, Some(b"AAAAAA".as_ref()));
     }
 
-    /// Characterization test for the single-thread mode (`execute_single_thread_mode`).
+    /// Characterization test for a no-`--threads` correct run (the chain at a
+    /// single worker, now the only path).
     ///
-    /// Exercises the streaming path triggered by `threads: None` with paired-end reads,
+    /// Exercises the `threads: None` invocation with paired-end reads,
     /// verifying that UMI correction produces the expected output:
     /// - Template 1 ("t1"): UMI "AAAAAG" (1 mismatch from "AAAAAA") is corrected, OX tag set
     /// - Template 2 ("t2"): UMI "CCCCCC" (exact match) is unchanged, no OX tag
     #[test]
-    fn test_single_thread_mode_produces_correct_output() -> Result<()> {
+    fn test_no_threads_produces_correct_output() -> Result<()> {
         use fgumi_raw_bam::{
             SamBuilder as RawSamBuilder, flags, raw_record_to_record_buf, testutil::encode_op,
         };
@@ -4596,61 +3862,6 @@ mod tests {
         // OX tag should NOT be present (dont_store_original_umis = true)
         let ox = fgumi_raw_bam::find_string_tag_in_record(&raw, SamTag::OX);
         assert!(ox.is_none());
-    }
-
-    /// Verifies `CorrectProcessedBatch::estimate_heap_size` accounts for both
-    /// `kept_raw_records` (consensus path) and `rejected_records` (secondary
-    /// rejects path), plus the outer-vec capacity overhead for each. The
-    /// non-empty-rejects case in particular guards against a regression where
-    /// the buffered rejects branch added by the secondary-output migration is
-    /// dropped from the estimate (which would mis-throttle the pipeline).
-    #[rstest]
-    #[case::empty_rejects(vec![1024], vec![])]
-    #[case::non_empty_rejects(vec![64, 128], vec![256, 512])]
-    fn test_correct_processed_batch_memory_estimate(
-        #[case] kept_capacities: Vec<usize>,
-        #[case] rej_capacities: Vec<usize>,
-    ) {
-        let kept_raw_records: Vec<RawRecord> =
-            kept_capacities.iter().map(|&cap| RawRecord::with_capacity(cap)).collect();
-        let kept_outer_capacity = kept_raw_records.capacity();
-        // RawRecord::with_capacity / Vec::with_capacity(n) only guarantee AT
-        // LEAST n; the allocator may round up. Read the observed capacities
-        // back so the expected value matches what was actually allocated
-        // under any allocator.
-        let kept_inner_total: usize = kept_raw_records.iter().map(RawRecord::capacity).sum();
-
-        let rejected_records: Vec<Vec<u8>> = rej_capacities
-            .iter()
-            .map(|&cap| {
-                let mut v = Vec::with_capacity(cap);
-                v.extend_from_slice(&[1u8; 8]);
-                v
-            })
-            .collect();
-        let rej_outer_capacity = rejected_records.capacity();
-        let rej_inner_total: usize = rejected_records.iter().map(Vec::capacity).sum();
-
-        let batch = CorrectProcessedBatch {
-            kept_raw_records,
-            rejected_records,
-            templates_count: 0,
-            missing_umis: 0,
-            wrong_length: 0,
-            mismatched: 0,
-            umi_matches: AHashMap::new(),
-        };
-
-        let expected = kept_inner_total
-            + kept_outer_capacity * std::mem::size_of::<RawRecord>()
-            + rej_inner_total
-            + rej_outer_capacity * std::mem::size_of::<Vec<u8>>();
-        assert_eq!(
-            batch.estimate_heap_size(),
-            expected,
-            "estimate should account for kept-record capacities, rejects inner capacities, \
-             and both outer-vec overheads",
-        );
     }
 
     #[rstest]

--- a/src/lib/pipeline/chains/commands/correct.rs
+++ b/src/lib/pipeline/chains/commands/correct.rs
@@ -122,13 +122,20 @@ impl FinalizeHook for CorrectFinalizeHook {
         info!("Total templates processed: {}", counts.templates);
 
         // fgbio logs this summary at error level (CorrectUmis.scala:275-280).
+        // Each detail line is individually guarded so a run with only one of the
+        // two problem counters nonzero does not print a spurious `# 0 ...` line
+        // (the retired serial path and fgbio both guard each line separately).
         if counts.missing > 0 || counts.wrong_length > 0 {
             error!("###################################################################");
-            error!("# {} were missing UMI attributes in the BAM file!", counts.missing);
-            error!(
-                "# {} had unexpected UMIs of differing lengths in the BAM file!",
-                counts.wrong_length
-            );
+            if counts.missing > 0 {
+                error!("# {} were missing UMI attributes in the BAM file!", counts.missing);
+            }
+            if counts.wrong_length > 0 {
+                error!(
+                    "# {} had unexpected UMIs of differing lengths in the BAM file!",
+                    counts.wrong_length
+                );
+            }
             error!("###################################################################");
         }
 
@@ -272,9 +279,12 @@ mod tests {
     ///   emits the banner unconditionally would still pass the positive case
     ///   alone.
     ///
-    /// Whenever a banner is expected, both message needles must be present
-    /// (the guard emits both lines together), not merely one -- requiring only
-    /// one would let a dropped message line slip through.
+    /// Each detail line is guarded on its own counter in production (correct.rs:
+    /// `if counts.missing > 0` / `if counts.wrong_length > 0`), so a
+    /// single-trigger case emits only its one line. Assert each line's presence
+    /// against its own counter -- not against `expect_banner` -- so a dropped
+    /// line is still caught without demanding the other line the guard correctly
+    /// suppressed.
     #[rstest]
     #[case::missing_and_wrong_length_present(2, 1, true)]
     #[case::missing_only(2, 0, true)]
@@ -303,38 +313,40 @@ mod tests {
         Box::new(hook).finalize().expect("finalize must succeed");
 
         let logs = captured_with_level();
-        // The banner emits both message lines together whenever it fires, so
-        // locate each independently and require both when a banner is expected
-        // (requiring only one would let a dropped line pass).
+        // Each detail line is guarded on its own counter, so locate each
+        // independently and check its presence against that counter.
         let missing_line = logs.iter().find(|(_, msg)| msg.contains(MISSING_UMI_NEEDLE));
         let wrong_length_line = logs.iter().find(|(_, msg)| msg.contains(WRONG_LENGTH_NEEDLE));
 
-        if expect_banner {
-            // `assert!` + `unwrap` rather than `unwrap_or_else(|| panic!(..))`: the
-            // never-taken closure of the latter is an uncovered region on the
-            // (always-passing) happy path, whereas an `assert!`'s panic branch
-            // folds onto its covered line. Same rigor -- both lines must be present.
-            assert!(
-                missing_line.is_some(),
-                "expected the missing-UMI banner line ({MISSING_UMI_NEEDLE:?}); got: {logs:?}"
-            );
-            assert!(
-                wrong_length_line.is_some(),
-                "expected the wrong-length-UMI banner line ({WRONG_LENGTH_NEEDLE:?}); got: {logs:?}"
-            );
-            for (level, msg) in [missing_line.unwrap(), wrong_length_line.unwrap()] {
-                assert_eq!(
-                    *level,
-                    log::Level::Error,
-                    "banner line {msg:?} logged at {level:?}; fgbio parity requires error level \
-                    (CorrectUmis.scala:275-280)"
-                );
-            }
-        } else {
-            assert!(
-                missing_line.is_none() && wrong_length_line.is_none(),
-                "expected no missing/wrong-length-UMI banner when neither counter is nonzero \
-                (the guard must suppress it); got: {logs:?}"
+        // Presence of each line tracks its own counter (not `expect_banner`):
+        // the missing line iff `missing_umis > 0`, the wrong-length line iff
+        // `wrong_length > 0`. `expect_banner` is the disjunction of the two.
+        assert_eq!(
+            missing_line.is_some(),
+            missing_umis > 0,
+            "missing-UMI banner line ({MISSING_UMI_NEEDLE:?}) presence must match \
+             missing_umis > 0 ({missing_umis}); got: {logs:?}"
+        );
+        assert_eq!(
+            wrong_length_line.is_some(),
+            wrong_length > 0,
+            "wrong-length-UMI banner line ({WRONG_LENGTH_NEEDLE:?}) presence must match \
+             wrong_length > 0 ({wrong_length}); got: {logs:?}"
+        );
+        assert_eq!(
+            missing_line.is_some() || wrong_length_line.is_some(),
+            expect_banner,
+            "a banner must fire iff either counter is nonzero; got: {logs:?}"
+        );
+        // Every line that IS present must be at error level -- the regression
+        // guard against the chain path silently downgrading the banner to
+        // `warn!` (fgbio parity, CorrectUmis.scala:275-280).
+        for (level, msg) in [missing_line, wrong_length_line].into_iter().flatten() {
+            assert_eq!(
+                *level,
+                log::Level::Error,
+                "banner line {msg:?} logged at {level:?}; fgbio parity requires error level \
+                (CorrectUmis.scala:275-280)"
             );
         }
     }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -24,6 +24,7 @@ mod test_compare_mutation;
 mod test_consensus_downsampling;
 mod test_copy_umi_command;
 mod test_correct_command;
+mod test_correct_cutover_parity;
 mod test_dedup_command;
 mod test_downsample_command;
 #[cfg(feature = "duplex")]

--- a/tests/integration/test_correct_command.rs
+++ b/tests/integration/test_correct_command.rs
@@ -26,7 +26,7 @@ use crate::helpers::bam_generator::{
 use crate::helpers::read_bam_output;
 
 /// Write a BAM with UMI-tagged reads.
-fn create_umi_bam(path: &PathBuf, families: Vec<Vec<RawRecord>>) {
+pub(crate) fn create_umi_bam(path: &PathBuf, families: Vec<Vec<RawRecord>>) {
     let header = create_minimal_header("chr1", 10000);
     let mut writer =
         bam::io::Writer::new(fs::File::create(path).expect("Failed to create BAM file"));
@@ -317,8 +317,8 @@ fn test_correct_command_rejects_streaming_threaded_integrity() {
 /// that drops/duplicates records — fails rather than passing an aggregate
 /// count. `seq_tag`/`original_tag` come from the case table (literal tags),
 /// not from `Target::sequence_tag()`, so the oracle does not derive its
-/// expectations from the code under test. Both the single-thread (`None`) and
-/// multi-threaded (`Some(2)`) pipeline paths are covered per target.
+/// expectations from the code under test. Both the single-worker (`None`) and
+/// multi-worker (`Some(2)`) chain paths are covered per target.
 #[rstest]
 #[case::umi_serial(Target::Umi, SamTag::RX, SamTag::OX, None)]
 #[case::umi_threaded(Target::Umi, SamTag::RX, SamTag::OX, Some(2))]
@@ -507,7 +507,7 @@ fn correct_barcode_leaves_umi_tags_untouched() {
 }
 
 // ============================================================================
-// --check-crc / --no-check-crc on the single-threaded fast path (#800)
+// --check-crc / --no-check-crc on correct's reader (#800)
 // ============================================================================
 
 /// Flip a byte in the last BGZF block's CRC32 footer, so decoding that block
@@ -539,8 +539,8 @@ fn create_multiblock_umi_bam(path: &PathBuf, umi: &str) {
     create_umi_bam(path, vec![create_umi_family(umi, 3000, "read", "ACGTACGT", 30)]);
 }
 
-/// Build correct's argv for the single-threaded fast path (no `--threads`),
-/// appending any extra flags (e.g. `--no-check-crc`).
+/// Build correct's argv for a no-`--threads` run (the chain at a single
+/// worker), appending any extra flags (e.g. `--no-check-crc`).
 fn correct_args<'a>(input: &'a str, output: &'a str, extra: &[&'a str]) -> Vec<&'a str> {
     let mut args = vec![
         "correct",
@@ -561,7 +561,7 @@ fn correct_args<'a>(input: &'a str, output: &'a str, extra: &[&'a str]) -> Vec<&
     args
 }
 
-/// `--no-check-crc` must let correct's single-threaded reader accept a corrupted
+/// `--no-check-crc` must let correct's reader accept a corrupted
 /// BGZF CRC32: it decodes through fgumi-bgzf, honoring the flag (#800). Against
 /// the noodles reader this path used before, this could not pass.
 #[test]
@@ -630,7 +630,7 @@ fn test_correct_check_crc_rejects_corrupted_crc() {
 }
 
 // ============================================================================
-// Chain (`--threads N`) vs single-threaded oracle parity (R3.2 cutover)
+// Worker-count-invariance parity (R3.2 cutover)
 // ============================================================================
 
 /// Read the complete `RecordBuf` for every output record, in output order, via
@@ -674,16 +674,16 @@ fn run_correct(
     cmd.execute("fgumi correct").unwrap_or_else(|e| panic!("correct ({tag}) failed: {e:#}"));
 }
 
-/// `--threads N` (chain) vs no-`--threads` (single-thread oracle) on a
-/// non-vacuous fixture: one exact-match family (kept as-is), one correctable
-/// (1-mismatch) family (corrected), and one uncorrectable (far) family
-/// (dropped from the main output, since no `--rejects` is given). Exercises
-/// the keep/rewrite/reject paths together so the parity check cannot pass on
-/// a trivial pass-through.
+/// Worker-count invariance: a multi-worker (`--threads N`) run must produce the
+/// same output as a single-worker (no-`--threads`) run on a non-vacuous fixture:
+/// one exact-match family (kept as-is), one correctable (1-mismatch) family
+/// (corrected), and one uncorrectable (far) family (dropped from the main
+/// output, since no `--rejects` is given). Exercises the keep/rewrite/reject
+/// paths together so the parity check cannot pass on a trivial pass-through.
 #[rstest]
 #[case::threads1(1)]
 #[case::threads4(4)]
-fn test_correct_chain_matches_single_threaded(#[case] threads: usize) {
+fn correct_output_matches_across_worker_counts(#[case] threads: usize) {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let input_bam = temp_dir.path().join("input.bam");
     let whitelist = temp_dir.path().join("whitelist.txt");
@@ -694,9 +694,15 @@ fn test_correct_chain_matches_single_threaded(#[case] threads: usize) {
     create_umi_bam(&input_bam, vec![exact, corr, far]);
     create_whitelist(&whitelist, &["ACGTACGT"]);
 
-    let oracle_out = temp_dir.path().join("oracle.bam");
+    let single_worker_out = temp_dir.path().join("single_worker.bam");
     let chain_out = temp_dir.path().join("chain.bam");
-    run_correct(&input_bam, &oracle_out, &whitelist, &["--min-distance", "1"], "oracle");
+    run_correct(
+        &input_bam,
+        &single_worker_out,
+        &whitelist,
+        &["--min-distance", "1"],
+        "single-worker",
+    );
     let threads_arg = threads.to_string();
     run_correct(
         &input_bam,
@@ -711,27 +717,31 @@ fn test_correct_chain_matches_single_threaded(#[case] threads: usize) {
     // from the code under test, so the parity check below cannot pass
     // vacuously on two empty/degenerate outputs.
     let expected_kept = 5;
-    let (oracle_header, oracle_records) = read_bam_output(&oracle_out);
+    let (single_worker_header, single_worker_records) = read_bam_output(&single_worker_out);
     let (chain_header, chain_records) = read_bam_output(&chain_out);
-    assert_eq!(oracle_records.len(), expected_kept, "oracle output should keep exactly 5 records");
     assert_eq!(
-        oracle_records, chain_records,
-        "chain (--threads {threads}) output must match the single-threaded oracle record-for-record",
+        single_worker_records.len(),
+        expected_kept,
+        "single-worker output should keep exactly 5 records"
+    );
+    assert_eq!(
+        single_worker_records, chain_records,
+        "multi-worker (--threads {threads}) output must match the single-worker run record-for-record",
     );
     // Whole-header parity (read_bam_output normalizes the @PG CL, which
     // legitimately differs by --threads): also catches a dropped @SQ/@RG/@HD/@CO.
     assert_eq!(
-        oracle_header, chain_header,
-        "chain and oracle output headers must match (with @PG CL normalized)",
+        single_worker_header, chain_header,
+        "multi-worker and single-worker output headers must match (with @PG CL normalized)",
     );
 }
 
-/// The `--rejects` output must also match record-for-record between the
-/// chain and oracle paths -- rejects flow through the chain's own
-/// `correct_step_with_rejects` branch, a code path the main-output-only
-/// parity test above does not exercise.
+/// The `--rejects` output must also match record-for-record across worker
+/// counts -- rejects flow through the chain's own `correct_step_with_rejects`
+/// branch, a code path the main-output-only parity test above does not
+/// exercise.
 #[test]
-fn test_correct_chain_matches_single_threaded_rejects() {
+fn correct_output_matches_across_worker_counts_rejects() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let input_bam = temp_dir.path().join("input.bam");
     let whitelist = temp_dir.path().join("whitelist.txt");
@@ -741,17 +751,17 @@ fn test_correct_chain_matches_single_threaded_rejects() {
     create_umi_bam(&input_bam, vec![exact, far]);
     create_whitelist(&whitelist, &["ACGTACGT"]);
 
-    let oracle_out = temp_dir.path().join("oracle.bam");
-    let oracle_rejects = temp_dir.path().join("oracle.rejects.bam");
+    let single_worker_out = temp_dir.path().join("single_worker.bam");
+    let single_worker_rejects = temp_dir.path().join("single_worker.rejects.bam");
     let chain_out = temp_dir.path().join("chain.bam");
     let chain_rejects = temp_dir.path().join("chain.rejects.bam");
 
     run_correct(
         &input_bam,
-        &oracle_out,
+        &single_worker_out,
         &whitelist,
-        &["--min-distance", "1", "--rejects", oracle_rejects.to_str().unwrap()],
-        "oracle",
+        &["--min-distance", "1", "--rejects", single_worker_rejects.to_str().unwrap()],
+        "single-worker",
     );
     run_correct(
         &input_bam,
@@ -761,27 +771,31 @@ fn test_correct_chain_matches_single_threaded_rejects() {
         "chain",
     );
 
-    let oracle_rejects_records = read_correct_records(&oracle_rejects);
-    assert!(!oracle_rejects_records.is_empty(), "oracle rejects must be non-empty");
-    assert_eq!(oracle_rejects_records.len(), 4, "the far family (4 reads) is entirely rejected");
+    let single_worker_rejects_records = read_correct_records(&single_worker_rejects);
+    assert!(!single_worker_rejects_records.is_empty(), "single-worker rejects must be non-empty");
     assert_eq!(
-        oracle_rejects_records,
-        read_correct_records(&chain_rejects),
-        "chain (--threads 4) rejects output must match the oracle record-for-record",
+        single_worker_rejects_records.len(),
+        4,
+        "the far family (4 reads) is entirely rejected"
     );
     assert_eq!(
-        read_correct_records(&oracle_out),
+        single_worker_rejects_records,
+        read_correct_records(&chain_rejects),
+        "multi-worker (--threads 4) rejects output must match the single-worker run record-for-record",
+    );
+    assert_eq!(
+        read_correct_records(&single_worker_out),
         read_correct_records(&chain_out),
-        "main output must also match between chain and oracle",
+        "main output must also match across worker counts",
     );
 }
 
-/// Byte-compares the `--metrics` TSV between the chain and oracle paths.
-/// Metrics counting runs through a per-thread accumulator on the chain path
-/// vs. a single accumulator on the oracle, even though both eventually call
-/// the same `UmiCorrectionMetrics::write_metrics` writer -- so this axis is
-/// load-bearing: it is the one test that would catch a per-thread counting
-/// divergence that a record-parity check alone would miss.
+/// Byte-compares the `--metrics` TSV across worker counts.
+/// Metrics counting runs through a per-thread accumulator on the multi-worker
+/// run vs. a single accumulator on the single-worker run, even though both
+/// eventually call the same `UmiCorrectionMetrics::write_metrics` writer -- so
+/// this axis is load-bearing: it is the one test that would catch a per-thread
+/// counting divergence that a record-parity check alone would miss.
 #[test]
 fn test_correct_metrics_files_match_across_modes() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
@@ -793,14 +807,14 @@ fn test_correct_metrics_files_match_across_modes() {
     create_umi_bam(&input_bam, vec![exact, corr]);
     create_whitelist(&whitelist, &["ACGTACGT"]);
 
-    let oracle_metrics = temp_dir.path().join("oracle.metrics.tsv");
+    let single_worker_metrics = temp_dir.path().join("single_worker.metrics.tsv");
     let chain_metrics = temp_dir.path().join("chain.metrics.tsv");
     run_correct(
         &input_bam,
-        &temp_dir.path().join("oracle.bam"),
+        &temp_dir.path().join("single_worker.bam"),
         &whitelist,
-        &["--min-distance", "1", "--metrics", oracle_metrics.to_str().unwrap()],
-        "oracle",
+        &["--min-distance", "1", "--metrics", single_worker_metrics.to_str().unwrap()],
+        "single-worker",
     );
     run_correct(
         &input_bam,
@@ -812,16 +826,20 @@ fn test_correct_metrics_files_match_across_modes() {
 
     // Non-vacuous: the corrected family's one-mismatch match must show up as
     // a real, non-zero count -- not an all-zero table.
-    let parsed = fgumi_lib::metrics::UmiCorrectionMetrics::read_metrics(&oracle_metrics)
-        .expect("parse oracle metrics");
+    let parsed = fgumi_lib::metrics::UmiCorrectionMetrics::read_metrics(&single_worker_metrics)
+        .expect("parse single-worker metrics");
     assert!(
         parsed.iter().any(|m| m.one_mismatch_matches > 0),
         "metrics must record a non-zero one-mismatch match count: {parsed:?}",
     );
 
-    let oracle_content = fs::read_to_string(&oracle_metrics).expect("read oracle metrics");
+    let single_worker_content =
+        fs::read_to_string(&single_worker_metrics).expect("read single-worker metrics");
     let chain_content = fs::read_to_string(&chain_metrics).expect("read chain metrics");
-    assert_eq!(oracle_content, chain_content, "metrics TSV must be byte-identical across modes");
+    assert_eq!(
+        single_worker_content, chain_content,
+        "metrics TSV must be byte-identical across worker counts"
+    );
 }
 
 /// Build a **paired** template: two mates (R1/R2) sharing query name `name`,
@@ -860,9 +878,9 @@ fn create_paired_umi_template(name: &str, umi: &str, pos: i32) -> Vec<RawRecord>
 /// (exercising the carry-over) and comfortably exceeds `GroupByQueryname`'s
 /// default template-batch size (exercising the output-emit boundary). A
 /// single-record-per-name fixture exercises neither. Compare `--threads 4`
-/// against the oracle record-for-record.
+/// against the single-worker run record-for-record.
 #[test]
-fn test_correct_chain_matches_single_threaded_multi_batch() {
+fn correct_output_matches_across_worker_counts_multi_batch() {
     const N: usize = 1200;
 
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
@@ -881,9 +899,15 @@ fn test_correct_chain_matches_single_threaded_multi_batch() {
     create_umi_bam(&input_bam, families);
     create_whitelist(&whitelist, &["ACGTACGT"]);
 
-    let oracle_out = temp_dir.path().join("oracle.bam");
+    let single_worker_out = temp_dir.path().join("single_worker.bam");
     let chain_out = temp_dir.path().join("chain.bam");
-    run_correct(&input_bam, &oracle_out, &whitelist, &["--min-distance", "1"], "oracle");
+    run_correct(
+        &input_bam,
+        &single_worker_out,
+        &whitelist,
+        &["--min-distance", "1"],
+        "single-worker",
+    );
     run_correct(
         &input_bam,
         &chain_out,
@@ -892,17 +916,17 @@ fn test_correct_chain_matches_single_threaded_multi_batch() {
         "chain",
     );
 
-    let oracle_records = read_correct_records(&oracle_out);
+    let single_worker_records = read_correct_records(&single_worker_out);
     assert_eq!(
-        oracle_records.len(),
+        single_worker_records.len(),
         N * 2,
         "all {} records ({N} paired templates) should be kept",
         N * 2
     );
     assert_eq!(
-        oracle_records,
+        single_worker_records,
         read_correct_records(&chain_out),
-        "chain (--threads 4) output must match the single-threaded oracle record-for-record across batches",
+        "multi-worker (--threads 4) output must match the single-worker run record-for-record across batches",
     );
 }
 
@@ -913,7 +937,7 @@ fn test_correct_chain_matches_single_threaded_multi_batch() {
 /// unguarded `- 1` subtraction" safety analysis backing the relaxation was
 /// wrong.
 #[test]
-fn test_correct_chain_matches_single_threaded_min_distance_zero() {
+fn correct_output_matches_across_worker_counts_min_distance_zero() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     let input_bam = temp_dir.path().join("input.bam");
     let whitelist = temp_dir.path().join("whitelist.txt");
@@ -923,9 +947,15 @@ fn test_correct_chain_matches_single_threaded_min_distance_zero() {
     create_umi_bam(&input_bam, vec![exact, corr]);
     create_whitelist(&whitelist, &["ACGTACGT"]);
 
-    let oracle_out = temp_dir.path().join("oracle.bam");
+    let single_worker_out = temp_dir.path().join("single_worker.bam");
     let chain_out = temp_dir.path().join("chain.bam");
-    run_correct(&input_bam, &oracle_out, &whitelist, &["--min-distance", "0"], "oracle");
+    run_correct(
+        &input_bam,
+        &single_worker_out,
+        &whitelist,
+        &["--min-distance", "0"],
+        "single-worker",
+    );
     run_correct(
         &input_bam,
         &chain_out,
@@ -934,22 +964,26 @@ fn test_correct_chain_matches_single_threaded_min_distance_zero() {
         "chain",
     );
 
-    let oracle_records = read_correct_records(&oracle_out);
-    assert_eq!(oracle_records.len(), 5, "both families should be kept under --min-distance 0");
+    let single_worker_records = read_correct_records(&single_worker_out);
     assert_eq!(
-        oracle_records,
+        single_worker_records.len(),
+        5,
+        "both families should be kept under --min-distance 0"
+    );
+    assert_eq!(
+        single_worker_records,
         read_correct_records(&chain_out),
-        "--min-distance 0 output must match between the chain and single-threaded oracle",
+        "--min-distance 0 output must match across worker counts",
     );
 }
 
-/// The chain (`--threads`) path rejects empty input under a positive
-/// `--min-corrected`, where the legacy single-threaded oracle silently passes
-/// (its `0 / 0 = NaN` kept-ratio compares false against the floor -- a latent
-/// bug). This is an intentional correctness improvement of the chain path, not
-/// a regression: an empty run cannot meet a positive minimum, so the chain's
-/// explicit error is the right behavior. Pin it so it is not lost; the legacy
-/// engine's NaN-pass is left to the follow-up PR that removes that engine.
+/// `correct` rejects empty input under a positive `--min-corrected`. The
+/// retired legacy single-threaded engine used to silently pass this case (its
+/// `0 / 0 = NaN` kept-ratio compared false against the floor -- a latent bug);
+/// removing that engine in this cutover eliminated the NaN-pass, so the chain's
+/// explicit error is now the only behavior. This is an intentional correctness
+/// fix, not a regression: an empty run cannot meet a positive minimum, so the
+/// error is right. Pin it so it is not lost.
 #[test]
 fn test_correct_chain_rejects_empty_input_with_min_corrected() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
@@ -1204,10 +1238,10 @@ fn write_headerless_umi_bam(path: &std::path::Path) {
 }
 
 /// `@HD` synthesis parity (proves Task 2B): correct enforces no
-/// query-grouped guard, so header-less input flows through to completion on
-/// both paths. Before the `ChainBuilder::new` fix, the chain path would have
-/// emitted a header without `@HD` while the oracle synthesized one -- a real
-/// output-byte divergence.
+/// query-grouped guard, so header-less input flows through to completion at any
+/// worker count. Before the `ChainBuilder::new` fix, the multi-worker path
+/// would have emitted a header without `@HD` while the single-worker run
+/// synthesized one -- a real output-byte divergence.
 #[rstest]
 #[case::threads1(1)]
 #[case::threads4(4)]
@@ -1218,9 +1252,15 @@ fn test_correct_chain_synthesizes_hd_for_headerless_input(#[case] threads: usize
     write_headerless_umi_bam(&input_bam);
     create_whitelist(&whitelist, &["ACGTACGT"]);
 
-    let oracle_out = temp_dir.path().join("oracle.bam");
+    let single_worker_out = temp_dir.path().join("single_worker.bam");
     let chain_out = temp_dir.path().join("chain.bam");
-    run_correct(&input_bam, &oracle_out, &whitelist, &["--min-distance", "1"], "oracle");
+    run_correct(
+        &input_bam,
+        &single_worker_out,
+        &whitelist,
+        &["--min-distance", "1"],
+        "single-worker",
+    );
     let threads_arg = threads.to_string();
     run_correct(
         &input_bam,
@@ -1230,11 +1270,11 @@ fn test_correct_chain_synthesizes_hd_for_headerless_input(#[case] threads: usize
         "chain",
     );
 
-    let (oracle_header, _) = read_bam_output(&oracle_out);
+    let (single_worker_header, _) = read_bam_output(&single_worker_out);
     let (chain_header, _) = read_bam_output(&chain_out);
     assert!(
-        oracle_header.header().is_some(),
-        "oracle output must synthesize @HD for headerless input",
+        single_worker_header.header().is_some(),
+        "single-worker output must synthesize @HD for headerless input",
     );
     assert!(
         chain_header.header().is_some(),
@@ -1242,7 +1282,7 @@ fn test_correct_chain_synthesizes_hd_for_headerless_input(#[case] threads: usize
     );
     assert_eq!(
         chain_header.header(),
-        oracle_header.header(),
-        "chain (--threads {threads}) must synthesize the same @HD as the oracle for headerless input",
+        single_worker_header.header(),
+        "multi-worker (--threads {threads}) must synthesize the same @HD as the single-worker run for headerless input",
     );
 }

--- a/tests/integration/test_correct_cutover_parity.rs
+++ b/tests/integration/test_correct_cutover_parity.rs
@@ -1,0 +1,688 @@
+//! Parity gate for the `correct` command's legacy-path retirement (C4):
+//! `CorrectUmis::execute` no longer has a no-`--threads` serial engine
+//! (`execute_single_thread_mode`) or a `#[allow(dead_code)]`
+//! `execute_threads_mode` — it *always* routes through the declarative chain
+//! builder. This test proves that cutover lost nothing user-observable.
+//!
+//! Two independent things are checked here:
+//!
+//! 1. **The cutover actually happened** (`correct_no_threads_routes_through_chain`).
+//!    A no-`--threads` run now emits the chain-only `"Using pipeline with N
+//!    threads"` banner that `ChainBuilder::add_correct` logs and the retired
+//!    serial engine never did. This is the genuine RED/GREEN discriminator:
+//!    before the removal a no-`--threads` run took the serial path and printed no
+//!    such line; after it, the chain does.
+//!
+//! 2. **Output parity with the pre-removal serial path**
+//!    (`cutover_matches_baseline`, `cutover_rejects_matches_baseline`,
+//!    `cutover_min_corrected_failure_writes_metrics`). The current build's
+//!    `correct` output — records (byte-identical, modulo the `@PG` line), the
+//!    `--rejects` secondary BAM, and the `--metrics` TSV — must match the frozen
+//!    serial baseline binary run with no `--threads` (its legacy single-threaded
+//!    engine). The baseline path comes from `FGUMI_BASELINE_BIN`; when it is unset
+//!    (or names a missing file) the case degrades to a self-consistency oracle
+//!    rather than skipping — the exact fallback discipline of
+//!    `test_sort_cutover_parity.rs`.
+//!
+//! The `--min-corrected`-failure case pins the fgbio-parity behavior the cutover
+//! must preserve: a kept ratio below `--min-corrected` fails the run, but the
+//! `--metrics` TSV is still written (fgbio CorrectUmis.scala:152 — "a ratio
+//! below --min-corrected will cause a failure but all files will still be
+//! written"). The retired legacy path wrote metrics before its ratio bail; the
+//! chain matches it (metrics on a success-only hook, the gate on a later
+//! success-only hook), and this test proves both the current build and the
+//! baseline's legacy path error *and* leave identical metrics behind.
+//!
+//! **Not a RED/GREEN gate for the parity half.** Because the removed serial
+//! engine and the chain were already output-equivalent, the baseline byte-parity
+//! check passes on both sides of the change — like the sort/retag cutovers it
+//! guards equivalence, it does not observe a regression the cutover introduces.
+//! The chain-banner check in (1) is the part that flips RED→GREEN.
+
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::Command;
+
+use rstest::rstest;
+use tempfile::TempDir;
+
+use crate::helpers::bam_generator::create_umi_family;
+use crate::helpers::read_bam_output;
+use crate::test_correct_command::create_umi_bam;
+
+/// The fixed UMI set every case corrects against.
+const WHITELIST: &[&str] = &["AAAAAAAA", "CCCCCCCC", "GGGGGGGG"];
+
+/// Resolves the saved pre-removal serial baseline binary to compare against.
+///
+/// The path comes solely from `FGUMI_BASELINE_BIN`; when unset (or naming a
+/// missing file) this returns `None` — "no baseline oracle available", never a
+/// silent pass. Callers layer the baseline byte-parity check on top of the
+/// always-available self-consistency oracle; a missing baseline drops only the
+/// byte-parity half, it never skips the case. No hardcoded fallback: a baseline
+/// binary is host-specific and must never be a path committed into the repo.
+fn baseline_bin() -> Option<std::path::PathBuf> {
+    let path = std::path::PathBuf::from(std::env::var_os("FGUMI_BASELINE_BIN")?);
+    if path.is_file() {
+        return Some(path);
+    }
+    eprintln!(
+        "FGUMI_BASELINE_BIN={} does not name an existing file; baseline oracle unavailable",
+        path.display()
+    );
+    None
+}
+
+/// Removes the single expected `@PG` line from a SAM header text blob, first
+/// asserting that exactly one is present.
+///
+/// Both the current build and the baseline binary stamp a single `@PG` line
+/// whose `VN` (git-describe version) and `CL` (command line, naming argv[0] — a
+/// different binary path for each side — and the per-run output path) necessarily
+/// differ between two independent invocations. Stripping that line is what lets
+/// the rest of the header and record bytes compare exactly.
+///
+/// The cardinality assertion is load-bearing: this helper is applied to each side
+/// independently before the two are compared, so a chain output that *dropped* its
+/// `@PG` (0 lines) or *duplicated* it (2+ lines) would, if we blindly stripped all
+/// `@PG` lines, still compare equal to a well-formed baseline — masking exactly the
+/// program-header regression the parity gate exists to catch. Asserting `== 1`
+/// pins the "one `@PG` per side" contract the byte comparison relies on (the test
+/// BAMs carry no pre-existing `@PG`, so one stamped record is the only correct
+/// count).
+fn strip_pg_lines(text: &str) -> String {
+    if text.is_empty() {
+        return String::new();
+    }
+    let mut lines: Vec<&str> = text.split('\n').collect();
+    let had_trailing_newline = lines.last() == Some(&"");
+    if had_trailing_newline {
+        lines.pop();
+    }
+    let pg_count = lines.iter().filter(|line| line.starts_with("@PG")).count();
+    assert_eq!(
+        pg_count, 1,
+        "expected exactly one @PG header line before stripping, found {pg_count}: a dropped \
+         (0) or duplicated (2+) @PG record would otherwise compare equal to the baseline and \
+         hide a program-header regression"
+    );
+    lines.retain(|line| !line.starts_with("@PG"));
+    let mut out = lines.join("\n");
+    if had_trailing_newline {
+        out.push('\n');
+    }
+    out
+}
+
+/// Reads a BAM's raw BGZF stream, decompresses it, strips the `@PG` line(s) from
+/// the embedded SAM header text, and returns the resulting bytes (new header +
+/// unmodified `n_ref`/reference-list/record bytes).
+///
+/// Comparing the *decompressed* BAM binary — rather than `RecordBuf`-parsed
+/// records or raw file bytes — keeps everything except the `@PG` line an exact,
+/// uninterpreted byte comparison: BGZF block boundaries differ between the two
+/// writers even for identical logical content (so raw file bytes never match),
+/// while parsing into `RecordBuf` and re-encoding could mask a real tag-order or
+/// binary-layout regression by normalizing it away. correct rewrites UMI/OX tag
+/// bytes in place, so that masking risk is exactly what must be avoided.
+fn decompressed_records_without_pg(path: &Path) -> Vec<u8> {
+    let file = std::fs::File::open(path).unwrap_or_else(|e| panic!("open {}: {e}", path.display()));
+    let mut reader = noodles::bgzf::io::Reader::new(std::io::BufReader::new(file));
+    let mut raw = Vec::new();
+    std::io::Read::read_to_end(&mut reader, &mut raw)
+        .unwrap_or_else(|e| panic!("decompress BGZF stream for {}: {e}", path.display()));
+
+    assert!(
+        raw.len() >= 8 && &raw[0..4] == b"BAM\x01",
+        "{} does not decompress to a BAM binary stream (missing magic)",
+        path.display()
+    );
+    let l_text = i32::from_le_bytes(raw[4..8].try_into().expect("4 bytes"));
+    let l_text = usize::try_from(l_text).expect("l_text is non-negative");
+    let text_start = 8;
+    let text_end = text_start + l_text;
+    assert!(raw.len() >= text_end, "{} header text runs past end of stream", path.display());
+
+    let text = String::from_utf8_lossy(&raw[text_start..text_end]);
+    let stripped_text = strip_pg_lines(&text);
+
+    let mut out = Vec::with_capacity(raw.len());
+    out.extend_from_slice(b"BAM\x01");
+    let new_l_text = i32::try_from(stripped_text.len()).expect("stripped header text fits i32");
+    out.extend_from_slice(&new_l_text.to_le_bytes());
+    out.extend_from_slice(stripped_text.as_bytes());
+    out.extend_from_slice(&raw[text_end..]); // n_ref, reference list, and all records, untouched
+    out
+}
+
+/// Writes a varied UMI-tagged corpus to `dir/in.bam` and returns its path.
+///
+/// Each family carries a distinct query-name prefix (so template grouping keeps
+/// input order) and one of four RX shapes, exercising the exact-match,
+/// single-mismatch-correction, and no-match-reject branches the chain must
+/// reproduce (it does not cover the missing-UMI or wrong-length buckets — every
+/// record here carries a well-formed 8-base RX):
+/// - `AAAAAAAA` — exact match (kept, no OX rewrite)
+/// - `AAAAAAAT` — 1 mismatch from `AAAAAAAA` (corrected, OX stashed)
+/// - `CCCCCCCC` — exact match to a different whitelist UMI (kept)
+/// - `TTTTTTTT` — matches nothing within `--max-mismatches 2` (rejected)
+fn write_varied_input(dir: &Path) -> std::path::PathBuf {
+    let input = dir.join("in.bam");
+    let families = vec![
+        create_umi_family("AAAAAAAA", 3, "exact_a", "ACGTACGT", 30),
+        create_umi_family("AAAAAAAT", 2, "corr_a", "ACGTACGT", 30),
+        create_umi_family("CCCCCCCC", 3, "exact_c", "ACGTACGT", 30),
+        create_umi_family("TTTTTTTT", 2, "reject_t", "ACGTACGT", 30),
+        create_umi_family("GGGGGGGG", 1, "exact_g", "ACGTACGT", 30),
+    ];
+    create_umi_bam(&input, families);
+    input
+}
+
+/// Runs `<bin> correct` (no `--threads`, so the current build takes the
+/// post-cutover chain path and the baseline takes its legacy serial path) with
+/// `RUST_LOG=info`, and returns the process output for stderr/exit assertions.
+fn run_correct(
+    bin: &Path,
+    input: &Path,
+    output: &Path,
+    metrics: Option<&Path>,
+    min_corrected: Option<&str>,
+    rejects: Option<&Path>,
+) -> std::process::Output {
+    let mut cmd = Command::new(bin);
+    cmd.env("RUST_LOG", "info").args([
+        OsStr::new("correct"),
+        OsStr::new("-i"),
+        input.as_os_str(),
+        OsStr::new("-o"),
+        output.as_os_str(),
+        OsStr::new("--max-mismatches"),
+        OsStr::new("2"),
+        OsStr::new("--min-distance"),
+        OsStr::new("1"),
+        OsStr::new("--compression-level"),
+        OsStr::new("1"),
+    ]);
+    for umi in WHITELIST {
+        cmd.args([OsStr::new("--umis"), OsStr::new(umi)]);
+    }
+    if let Some(m) = metrics {
+        cmd.args([OsStr::new("-M"), m.as_os_str()]);
+    }
+    if let Some(min) = min_corrected {
+        cmd.args([OsStr::new("--min-corrected"), OsStr::new(min)]);
+    }
+    if let Some(r) = rejects {
+        cmd.args([OsStr::new("--rejects"), r.as_os_str()]);
+    }
+    cmd.output().unwrap_or_else(|e| panic!("failed to spawn `{}` correct: {e}", bin.display()))
+}
+
+/// A no-`--threads` run now routes through the declarative chain, which logs the
+/// `"Using pipeline with N threads"` banner from `ChainBuilder::add_correct`.
+/// The retired serial engine logged no such line, so this is the RED
+/// (pre-removal) → GREEN (post-removal) discriminator for the cutover.
+#[test]
+fn correct_no_threads_routes_through_chain() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = write_varied_input(dir.path());
+    let output = dir.path().join("out.bam");
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let out = run_correct(current_bin, &input, &output, None, None, None);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "no-threads correct must succeed; stderr:\n{stderr}");
+    assert!(
+        stderr.contains("Using pipeline with 1 threads"),
+        "a no-`--threads` correct must route through the chain (which logs the pipeline banner); \
+         the serial engine is retired. stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Starting correct"),
+        "the chain must still emit the `Starting correct` banner; stderr:\n{stderr}"
+    );
+}
+
+/// Output parity of the post-cutover chain against the pre-removal serial
+/// baseline binary (run with no `--threads`, i.e. its legacy engine), with and
+/// without `--metrics` — plus the always-available self-consistency oracle when
+/// no baseline is set.
+#[rstest]
+#[case::no_metrics(false)]
+#[case::with_metrics(true)]
+fn cutover_matches_baseline(#[case] with_metrics: bool) {
+    let dir = TempDir::new().expect("temp dir");
+    let input = write_varied_input(dir.path());
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let current_out = dir.path().join("current.bam");
+    let current_tsv = dir.path().join("current.tsv");
+    let current_metrics = with_metrics.then(|| current_tsv.clone());
+    let current =
+        run_correct(current_bin, &input, &current_out, current_metrics.as_deref(), None, None);
+    let current_stderr = String::from_utf8_lossy(&current.stderr);
+    assert!(current.status.success(), "current correct must succeed; stderr:\n{current_stderr}");
+
+    if let Some(baseline) = baseline_bin() {
+        let baseline_out = dir.path().join("baseline.bam");
+        let baseline_tsv = dir.path().join("baseline.tsv");
+        let baseline_metrics = with_metrics.then(|| baseline_tsv.clone());
+        let base =
+            run_correct(&baseline, &input, &baseline_out, baseline_metrics.as_deref(), None, None);
+        assert!(
+            base.status.success(),
+            "baseline correct failed; stderr:\n{}",
+            String::from_utf8_lossy(&base.stderr)
+        );
+
+        assert_eq!(
+            decompressed_records_without_pg(&current_out),
+            decompressed_records_without_pg(&baseline_out),
+            "chain correct output diverges from the pre-removal serial baseline binary ({}) \
+             after stripping @PG — a real cutover parity bug, not something to relax",
+            baseline.display(),
+        );
+        if with_metrics {
+            assert_eq!(
+                std::fs::read_to_string(&current_tsv).expect("current tsv"),
+                std::fs::read_to_string(&baseline_tsv).expect("baseline tsv"),
+                "chain --metrics TSV diverges from the serial baseline binary"
+            );
+        }
+    } else {
+        eprintln!(
+            "SKIP baseline half of cutover_matches_baseline[with_metrics={with_metrics}]: \
+             FGUMI_BASELINE_BIN is unset or does not name an existing file — running \
+             self-consistency oracle instead"
+        );
+        assert_self_consistent(&current_out, current_metrics.as_deref());
+    }
+}
+
+/// Output parity of the post-cutover chain's `--rejects` secondary output against
+/// the pre-removal serial baseline binary. `correct` streams every uncorrectable
+/// record to `--rejects`; the cutover moved that secondary output onto the unified
+/// pipeline, so the rejects BAM — records and header (modulo `@PG`) — must still
+/// match the retired serial path byte-for-byte. `run_correct` could not pass a
+/// rejects path before, so the other baseline cases never compared it. When no
+/// baseline is set this degrades to a self-consistency oracle asserting the
+/// rejects' exact identity and header against the fixture, never a skip — the same
+/// discipline as `cutover_matches_baseline`.
+#[test]
+fn cutover_rejects_matches_baseline() {
+    let dir = TempDir::new().expect("temp dir");
+    let input = write_varied_input(dir.path());
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let current_out = dir.path().join("current.bam");
+    let current_rejects = dir.path().join("current.rejects.bam");
+    let current =
+        run_correct(current_bin, &input, &current_out, None, None, Some(&current_rejects));
+    let current_stderr = String::from_utf8_lossy(&current.stderr);
+    assert!(current.status.success(), "current correct must succeed; stderr:\n{current_stderr}");
+    assert!(
+        current_rejects.exists(),
+        "the --rejects secondary BAM must be written; stderr:\n{current_stderr}"
+    );
+
+    if let Some(baseline) = baseline_bin() {
+        let baseline_out = dir.path().join("baseline.bam");
+        let baseline_rejects = dir.path().join("baseline.rejects.bam");
+        let base =
+            run_correct(&baseline, &input, &baseline_out, None, None, Some(&baseline_rejects));
+        assert!(
+            base.status.success(),
+            "baseline correct failed; stderr:\n{}",
+            String::from_utf8_lossy(&base.stderr)
+        );
+
+        assert_eq!(
+            decompressed_records_without_pg(&current_rejects),
+            decompressed_records_without_pg(&baseline_rejects),
+            "chain --rejects output diverges from the pre-removal serial baseline binary ({}) \
+             after stripping @PG — a real cutover parity bug in the secondary output",
+            baseline.display(),
+        );
+    } else {
+        eprintln!(
+            "SKIP baseline half of cutover_rejects_matches_baseline: FGUMI_BASELINE_BIN is unset \
+             or does not name an existing file — running self-consistency oracle instead"
+        );
+        assert_rejects_self_consistent(&current_rejects, &input);
+    }
+}
+
+/// fgbio parity across the cutover: a kept ratio below `--min-corrected` fails
+/// the run *and* still leaves the `--metrics` TSV behind (CorrectUmis.scala:152).
+/// The retired legacy path wrote metrics before its ratio bail; the current
+/// chain must match, and — when a baseline is available — the baseline's legacy
+/// path must error the same way and produce a byte-identical metrics TSV.
+#[test]
+fn cutover_min_corrected_failure_writes_metrics() {
+    let dir = TempDir::new().expect("temp dir");
+    // Every read is `TTTTTTTT`, which matches nothing in WHITELIST within
+    // `--max-mismatches 2`: kept/total = 0, below the 0.5 floor.
+    let input = dir.path().join("all_reject.bam");
+    create_umi_bam(&input, vec![create_umi_family("TTTTTTTT", 6, "reject", "ACGTACGT", 30)]);
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let current_out = dir.path().join("current.bam");
+    let current_tsv = dir.path().join("current.tsv");
+    let current =
+        run_correct(current_bin, &input, &current_out, Some(&current_tsv), Some("0.5"), None);
+    let current_stderr = String::from_utf8_lossy(&current.stderr);
+    assert!(
+        !current.status.success(),
+        "correct must fail when the kept ratio is below --min-corrected; stderr:\n{current_stderr}"
+    );
+    assert!(
+        current_stderr.contains("Final ratio of reads kept"),
+        "the --min-corrected failure message must survive the cutover; stderr:\n{current_stderr}"
+    );
+    assert!(
+        current_tsv.exists(),
+        "the --metrics TSV must be written even on a --min-corrected failure (fgbio parity); \
+         stderr:\n{current_stderr}"
+    );
+    assert!(
+        current_out.exists(),
+        "the primary BAM must still be written on a --min-corrected failure; a missing or \
+         truncated primary output is a chain regression the metrics-only check would miss; \
+         stderr:\n{current_stderr}"
+    );
+
+    if let Some(baseline) = baseline_bin() {
+        let baseline_out = dir.path().join("baseline.bam");
+        let baseline_tsv = dir.path().join("baseline.tsv");
+        let base =
+            run_correct(&baseline, &input, &baseline_out, Some(&baseline_tsv), Some("0.5"), None);
+        assert!(
+            !base.status.success(),
+            "baseline correct must also fail the --min-corrected gate; stderr:\n{}",
+            String::from_utf8_lossy(&base.stderr)
+        );
+        assert!(
+            baseline_tsv.exists(),
+            "the baseline's legacy path must also leave a --metrics TSV behind on the failure"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&current_tsv).expect("current tsv"),
+            std::fs::read_to_string(&baseline_tsv).expect("baseline tsv"),
+            "chain --metrics TSV on a --min-corrected failure diverges from the serial baseline",
+        );
+        assert_eq!(
+            decompressed_records_without_pg(&current_out),
+            decompressed_records_without_pg(&baseline_out),
+            "chain primary BAM on a --min-corrected failure diverges from the serial baseline \
+             (records + header modulo @PG)",
+        );
+    } else {
+        eprintln!(
+            "SKIP baseline half of cutover_min_corrected_failure_writes_metrics: \
+             FGUMI_BASELINE_BIN is unset or does not name an existing file"
+        );
+        // Parse the TSV and assert the actual counts, not just a line count: all
+        // 6 reads are TTTTTTTT (no match), so every whitelist UMI records zero
+        // matches and the unmatched all-N bucket takes all 6. A numerically wrong
+        // but structurally valid file fails here.
+        let parsed = fgumi_lib::metrics::UmiCorrectionMetrics::read_metrics(&current_tsv)
+            .expect("parse metrics TSV");
+        let by_umi: std::collections::HashMap<&str, &fgumi_lib::metrics::UmiCorrectionMetrics> =
+            parsed.iter().map(|m| (m.umi.as_str(), m)).collect();
+        for umi in WHITELIST {
+            let m = by_umi.get(umi).unwrap_or_else(|| {
+                panic!("metrics TSV must include a row for whitelist UMI {umi}")
+            });
+            assert_eq!(m.total_matches, 0, "no read matches {umi}, so total_matches must be 0");
+        }
+        let unmatched =
+            by_umi.get("NNNNNNNN").expect("metrics TSV must include the unmatched all-N row");
+        assert_eq!(
+            unmatched.total_matches, 6,
+            "all 6 unmatched reads must credit the all-N bucket"
+        );
+        assert_eq!(
+            parsed.iter().map(|m| m.total_matches).sum::<u64>(),
+            6,
+            "total matches across all rows must equal the 6 input reads"
+        );
+
+        // The primary BAM is the enforced oracle in CI. Every input read is
+        // `TTTTTTTT` (rejected, and no `--rejects` here), so the failure-path
+        // primary output must be a valid, readable BAM carrying zero kept
+        // records — its header preserving the input's reference sequences. A
+        // truncated file, a header regression, or leaked reject records fail here.
+        let (input_header, _) = read_bam_output(&input);
+        let (out_header, kept) = read_bam_output(&current_out);
+        assert!(
+            kept.is_empty(),
+            "every input read is rejected, so the --min-corrected failure primary BAM must \
+             contain zero kept records; got {}",
+            kept.len()
+        );
+        assert_eq!(
+            out_header.reference_sequences(),
+            input_header.reference_sequences(),
+            "the failure-path primary BAM header must preserve the input reference sequences"
+        );
+    }
+}
+
+/// Behavior change the cutover intentionally makes (a bug fix, not a
+/// regression): a no-`--threads` run over EMPTY input under a positive
+/// `--min-corrected` now ERRORS. The retired legacy serial engine silently
+/// passed this case (its `0 / 0 = NaN` kept-ratio compared false against the
+/// floor and exited 0); the chain — now the only path — treats "no reads
+/// processed" as a failure, which is correct since an empty run can never meet a
+/// positive minimum. When a baseline is available this is a genuine RED/GREEN
+/// discriminator: the frozen pre-removal binary (legacy engine) SUCCEEDS on the
+/// same input while the current build fails.
+#[test]
+fn cutover_empty_input_min_corrected_now_errors() {
+    let dir = TempDir::new().expect("temp dir");
+    // Header-only BAM: no records at all.
+    let input = dir.path().join("empty.bam");
+    create_umi_bam(&input, vec![]);
+
+    let current_bin = Path::new(env!("CARGO_BIN_EXE_fgumi"));
+    let current_out = dir.path().join("current.bam");
+    let current = run_correct(current_bin, &input, &current_out, None, Some("0.5"), None);
+    let current_stderr = String::from_utf8_lossy(&current.stderr);
+    assert!(
+        !current.status.success(),
+        "the cutover makes a no-`--threads` empty-input --min-corrected run error \
+         (was a legacy silent pass); stderr:\n{current_stderr}"
+    );
+    assert!(
+        current_stderr.contains("No reads were processed"),
+        "the empty-input failure must name the empty-run guard; stderr:\n{current_stderr}"
+    );
+
+    if let Some(baseline) = baseline_bin() {
+        let baseline_out = dir.path().join("baseline.bam");
+        let base = run_correct(&baseline, &input, &baseline_out, None, Some("0.5"), None);
+        assert!(
+            base.status.success(),
+            "the frozen pre-removal baseline (legacy serial engine) silently passed empty input \
+             under --min-corrected; this asymmetry is exactly the bug the cutover fixes. \
+             stderr:\n{}",
+            String::from_utf8_lossy(&base.stderr)
+        );
+    }
+}
+
+/// Always-available oracle used when no baseline binary is set: the chain's
+/// output must keep only records whose UMI is (or corrects to) a whitelist UMI,
+/// rewrite the one 1-mismatch family's RX to its exact expected whitelist entry
+/// (stashing the pre-correction UMI in `OX`), leave exact matches untouched, and
+/// (with `--metrics`) carry a well-formed TSV whose per-UMI `total_matches` match
+/// the fixture. Asserting the exact corrected values — not just "some whitelist
+/// UMI" and a presence check — is what makes this catch a real correction
+/// regression (e.g. a near-match corrected to the wrong entry, or a miscount).
+fn assert_self_consistent(output: &Path, metrics: Option<&Path>) {
+    use std::collections::HashMap;
+
+    use noodles::sam::alignment::record::data::field::Tag;
+    use noodles::sam::alignment::record_buf::data::field::Value;
+
+    use fgumi_lib::sam::SamTag;
+
+    let (_, records) = read_bam_output(output);
+    // Kept families: exact_a(3) + corr_a(2) + exact_c(3) + exact_g(1) = 9; the
+    // reject_t(2) family matches nothing and is dropped (no --rejects here).
+    assert_eq!(records.len(), 9, "only correctable/exact records are kept");
+
+    let tag_of =
+        |name: &str| -> Tag { Tag::from(name.parse::<SamTag>().expect("valid two-char tag")) };
+    let rx_string = |r: &noodles::sam::alignment::RecordBuf, name: &str| -> Option<String> {
+        match r.data().get(&tag_of(name))? {
+            Value::String(s) => Some(s.to_string()),
+            _ => None,
+        }
+    };
+
+    // Tally the post-correction RX distribution and, for every corrected record
+    // (OX present), the exact original -> corrected mapping.
+    let mut rx_counts: HashMap<String, usize> = HashMap::new();
+    let mut correction_pairs: Vec<(String, String)> = Vec::new();
+    for r in &records {
+        let rx = rx_string(r, "RX").expect("kept record must carry RX");
+        assert!(
+            WHITELIST.contains(&rx.as_str()),
+            "kept record RX {rx} must be a whitelist UMI after correction"
+        );
+        if let Some(ox) = rx_string(r, "OX") {
+            correction_pairs.push((ox, rx.clone()));
+        }
+        *rx_counts.entry(rx).or_default() += 1;
+    }
+
+    // The 1-mismatch corr_a family (original RX AAAAAAAT) must correct to exactly
+    // AAAAAAAA — not merely to "a whitelist UMI". Both of its records carry OX.
+    assert_eq!(
+        correction_pairs,
+        vec![
+            ("AAAAAAAT".to_string(), "AAAAAAAA".to_string()),
+            ("AAAAAAAT".to_string(), "AAAAAAAA".to_string()),
+        ],
+        "the two corrected records must map original AAAAAAAT -> corrected AAAAAAAA"
+    );
+
+    // Exact per-UMI kept counts: exact_a(3) + corr_a(2, corrected to AAAAAAAA) = 5;
+    // exact_c = 3; exact_g = 1. A miscount or a mis-corrected near-match fails here.
+    let expected_rx: HashMap<String, usize> =
+        [("AAAAAAAA".to_string(), 5), ("CCCCCCCC".to_string(), 3), ("GGGGGGGG".to_string(), 1)]
+            .into_iter()
+            .collect();
+    assert_eq!(rx_counts, expected_rx, "post-correction RX distribution must match the fixture");
+
+    if let Some(path) = metrics {
+        let parsed = fgumi_lib::metrics::UmiCorrectionMetrics::read_metrics(path)
+            .expect("parse metrics TSV");
+        let by_umi: HashMap<&str, &fgumi_lib::metrics::UmiCorrectionMetrics> =
+            parsed.iter().map(|m| (m.umi.as_str(), m)).collect();
+        // Each whitelist UMI has a row; total_matches equals the kept-count for
+        // that UMI (AAAAAAAA credits both the exact and the corrected family).
+        for (umi, expected) in [("AAAAAAAA", 5u64), ("CCCCCCCC", 3), ("GGGGGGGG", 1)] {
+            let m = by_umi.get(umi).unwrap_or_else(|| {
+                panic!("metrics TSV must include a row for whitelist UMI {umi}")
+            });
+            assert_eq!(m.total_matches, expected, "total_matches for {umi}");
+        }
+        // The single 1-mismatch correction is recorded against AAAAAAAA.
+        assert_eq!(
+            by_umi["AAAAAAAA"].one_mismatch_matches, 2,
+            "AAAAAAAA must record the two 1-mismatch corrections"
+        );
+        // The two uncorrectable `reject_t` reads credit the unmatched all-N
+        // bucket; a regression that drops or mis-buckets them (and so silently
+        // shrinks the metrics) fails here.
+        let unmatched =
+            by_umi.get("NNNNNNNN").expect("metrics TSV must include the unmatched all-N row");
+        assert_eq!(
+            unmatched.total_matches, 2,
+            "the two uncorrectable reject_t reads must credit the unmatched all-N bucket"
+        );
+    }
+}
+
+/// Always-available oracle for the `--rejects` secondary output when no baseline
+/// binary is set: only the one no-match family (`TTTTTTTT`/`reject_t`, 2 records)
+/// in `write_varied_input` is uncorrectable within `--max-mismatches 2` of the
+/// whitelist, so the rejects BAM must carry exactly those two records — each
+/// keeping its original `RX` (`TTTTTTTT`) with no `OX` rewrite, because a reject is
+/// passed through untouched and never corrected — and its header's sort-order
+/// fields must match the input verbatim (rejects inherit the input header).
+fn assert_rejects_self_consistent(rejects: &Path, input: &Path) {
+    use noodles::sam::alignment::record::data::field::Tag;
+    use noodles::sam::alignment::record_buf::data::field::Value;
+
+    use fgumi_lib::sam::SamTag;
+
+    let (_, records) = read_bam_output(rejects);
+    // reject_t(2) is the only family that matches nothing within --max-mismatches
+    // 2 of the whitelist; every other family is kept or corrected.
+    assert_eq!(records.len(), 2, "only the uncorrectable reject_t family is rejected");
+
+    let tag_of =
+        |name: &str| -> Tag { Tag::from(name.parse::<SamTag>().expect("valid two-char tag")) };
+    let rx_string = |r: &noodles::sam::alignment::RecordBuf, name: &str| -> Option<String> {
+        match r.data().get(&tag_of(name))? {
+            Value::String(s) => Some(s.to_string()),
+            _ => None,
+        }
+    };
+
+    // Assert the exact emitted order, not a sorted set: rejects stream in
+    // batch-input order, which is deterministic for a no-`--threads` run, so this
+    // fallback catches a reject record-order regression the same way the byte-
+    // parity baseline path does.
+    let names: Vec<String> = records
+        .iter()
+        .map(|r| r.name().expect("reject record must carry a read name").to_string())
+        .collect();
+    assert_eq!(
+        names,
+        vec!["reject_t_0".to_string(), "reject_t_1".to_string()],
+        "the rejects BAM must contain exactly the two uncorrectable reject_t records, in input order"
+    );
+
+    for r in &records {
+        assert_eq!(
+            rx_string(r, "RX").as_deref(),
+            Some("TTTTTTTT"),
+            "a rejected record keeps its original RX untouched"
+        );
+        assert!(
+            rx_string(r, "OX").is_none(),
+            "a rejected record is never corrected, so it carries no OX"
+        );
+    }
+
+    crate::helpers::assertions::assert_rejects_header_matches_input(rejects, input);
+}
+
+/// `strip_pg_lines` removes the one expected `@PG` line and leaves every other
+/// header line — and the trailing-newline shape — untouched.
+#[rstest]
+#[case::trailing_newline(
+    "@HD\tVN:1.6\n@PG\tID:fgumi\tCL:fgumi correct\n@CO\tnote\n",
+    "@HD\tVN:1.6\n@CO\tnote\n"
+)]
+#[case::no_trailing_newline("@HD\tVN:1.6\n@PG\tID:fgumi\tCL:fgumi correct", "@HD\tVN:1.6")]
+#[case::empty_stays_empty("", "")]
+fn strip_pg_lines_removes_the_single_pg(#[case] input: &str, #[case] expected: &str) {
+    assert_eq!(strip_pg_lines(input), expected);
+}
+
+/// The cardinality assertion fires when a side is missing its `@PG` (a dropped
+/// program-header record) or carries more than one (a duplicated one) — the exact
+/// regressions blindly stripping all `@PG` lines would hide.
+#[rstest]
+#[case::zero_pg("@HD\tVN:1.6\n@CO\tnote\n")]
+#[case::two_pg("@HD\tVN:1.6\n@PG\tID:a\n@PG\tID:b\n")]
+#[should_panic(expected = "expected exactly one @PG header line")]
+fn strip_pg_lines_asserts_pg_cardinality(#[case] input: &str) {
+    let _ = strip_pg_lines(input);
+}


### PR DESCRIPTION
## What

Retire the legacy single-threaded `fgumi correct` execution so the declarative chain builder is the **only** path. `correct` had TWO legacy engines — the no-`--threads` serial `execute_single_thread_mode` and the `#[allow(dead_code)]` `execute_threads_mode`. `execute()` keeps its reader-free pre-flight (validate, reject_output_collisions) and then always dispatches to the chain. Deleted both engines plus the legacy-only `CorrectProcessedBatch` (+ its `MemoryEstimate`), the three dead `CorrectUmis` wrapper methods (`load_umi_sequences`/`check_umi_distances`/`finalize_metrics`), and now-dead imports (−777 lines).

Stacked on #921 (the correct `--metrics` fgbio-parity fix), which already made the chain correct-path fgbio-correct. Output is byte-identical (modulo `@PG`).

## Parity analysis (done before deleting)

Every diagnostic the serial engine emitted is already produced by the chain (`add_correct` + finalize hooks): CRC line, `Starting correct` banner, `OperationTimer`, `Loaded N UMI sequences`, the ambiguous-pair distance warning, summary/record-count, the missing/wrong-length error banner, the `--metrics` TSV, and the `--min-corrected` gate. Nothing needed adding — **except** one banner correctness fix the cutover surfaces (below).

## Banner fix (the cutover makes the chain banner the sole banner)

The chain's missing/wrong-length error banner printed *both* detail lines whenever *either* counter was nonzero — emitting a spurious `# 0 were missing…` / `# 0 had unexpected…` line that neither the retired serial engine nor fgbio ever printed. Each detail line is now individually guarded (`if counts.missing > 0` / `if counts.wrong_length > 0`). This is the only chain-hook change (17 lines).

## Two behavior points, both correct-by-design

- **Empty input + `--min-corrected`:** the retired no-`--threads` serial engine silently *passed* (`NaN < min` is false); the chain errors, matching fgbio. New test `cutover_empty_input_min_corrected_now_errors` pins it (and, with a baseline binary, asserts the frozen legacy binary *succeeds* on the same input — a RED/GREEN discriminator documenting the fix).
- **`--min-corrected` ratio failure** still writes the `--metrics` TSV (fgbio parity, from #921) — withheld only on a genuine pipeline processing error.

## Tests

`tests/integration/test_correct_cutover_parity.rs` pins chain == pre-removal serial baseline via `FGUMI_BASELINE_BIN` (records byte-identical modulo `@PG`, plus the `--metrics` TSV) for a normal run and a `--min-corrected` failure. The self-consistency oracle (default CI) asserts the exact corrected UMI values (`AAAAAAAT`→`AAAAAAAA`, the full post-correction RX distribution, per-UMI `total_matches`), not just counts.

Full gate green (`cargo ci-test` 9961 passed / 31 skipped with `FGUMI_BASELINE_BIN` set, plus fmt/lint/doc and `--no-default-features`/`--all-features`). Part of the per-command R6-0 legacy-path retirements; no user-facing behavior change beyond the two correct-by-design points above (no-`--threads` now runs the chain at a single worker).

**Supersedes #919** (which fixes the legacy `--min-corrected` NaN bypass): this PR deletes that legacy path entirely. If #919 lands first, this rebases cleanly; if this lands first, #919 can be closed as moot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk: `correct` output changes are pinned by serial-baseline and parity tests; `unsafe` changes: none, with no CLAUDE.md allowlist update; no memory-bound, queue-capacity, or backpressure changes, but no `--threads` now uses one chain worker.

- Routes all `correct` executions through the declarative chain.
- Removes both legacy execution engines and related code.
- Preserves validation and output-collision checks.
- Adds parity tests for records, corrected UMIs, rejects, metrics, headers, and `--min-corrected` failures.
- Makes empty input with `--min-corrected` fail as in fgbio.
- Omits zero-count UMI detail lines while retaining the error banner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->